### PR TITLE
CA-50822: add VM post destroy hook

### DIFF
--- a/ocaml/xapi/xapi_hooks.ml
+++ b/ocaml/xapi/xapi_hooks.ml
@@ -18,6 +18,7 @@ open D
 let scriptname__vm_pre_destroy  = "vm-pre-shutdown"
 let scriptname__vm_pre_migrate  = "vm-pre-migrate"
 let scriptname__vm_pre_start    = "vm-pre-start"
+let scriptname__vm_post_destroy  = "vm-post-destroy"
 
 (* VM Script hook reason codes *)
 let reason__clean_shutdown = "clean-shutdown"
@@ -94,6 +95,8 @@ let vm_pre_migrate ~__context ~reason ~vm =
   execute_vm_hook ~__context ~script_name:scriptname__vm_pre_migrate ~reason ~vm
 let vm_pre_start ~__context ~reason ~vm =
   execute_vm_hook ~__context ~script_name:scriptname__vm_pre_start ~reason ~vm
+let vm_post_destroy ~__context ~reason ~vm =
+  execute_vm_hook ~__context ~script_name:scriptname__vm_post_destroy ~reason ~vm
 
 let host_pre_declare_dead ~__context ~host ~reason = 
   execute_host_hook ~__context ~script_name:scriptname__host_pre_declare_dead ~reason ~host

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -408,6 +408,7 @@ module Reboot = struct
 	 Xapi_hooks.vm_pre_destroy ~__context ~reason:(if clean then Xapi_hooks.reason__clean_reboot else Xapi_hooks.reason__hard_reboot) ~vm;
 	 debug "Destroying domain...";
          with_xc_and_xs (fun xc xs -> Vmops.destroy ~__context ~xc ~xs ~self:vm ~clear_currently_attached:false domid `Running);
+         Xapi_hooks.vm_post_destroy ~__context ~reason:(if clean then Xapi_hooks.reason__clean_reboot else Xapi_hooks.reason__hard_reboot) ~vm;
 	 
 	 (* At this point the domain has been destroyed but the VM is still marked as Running.
 	    If any error occurs then we must remember to clean everything up... *)
@@ -530,6 +531,8 @@ module Shutdown = struct
 			   Xapi_hooks.vm_pre_destroy ~__context ~reason:(if clean then Xapi_hooks.reason__clean_shutdown else Xapi_hooks.reason__hard_shutdown) ~vm;
 			   debug "%s: phase 2/2: destroying old domain (domid %d)" api_call_name domid;
  		       Vmops.destroy ~__context ~xc ~xs ~self:vm domid `Halted;
+		       Xapi_hooks.vm_post_destroy ~__context ~reason:(if clean then Xapi_hooks.reason__clean_shutdown else Xapi_hooks.reason__hard_shutdown) ~vm;
+
 		       (* Force an update of the stats - this will cause the rrds to be synced back to the master *)
 		       Monitor.do_monitor __context xc
 		  )
@@ -745,7 +748,8 @@ let suspend  ~__context ~vm =
 						debug "suspend phase 4/4: destroying the domain";
 						Vmops.destroy ~clear_currently_attached:false
 							~__context ~xc ~xs ~self:vm domid `Suspended;
-
+						Xapi_hooks.vm_post_destroy ~__context
+		                                        ~reason:Xapi_hooks.reason__suspend ~vm;
 				)
 			)
 		) ()


### PR DESCRIPTION
This can be used to perform additional cleanup when domains are destroyed (VM reboots, migrations etc)
