### PR TITLE
Don't drop CDROM drives over a migrate with a storage backend exposing VDI_ACTIVATE

### DIFF
--- a/ocaml/xapi/vmops.ml
+++ b/ocaml/xapi/vmops.ml
@@ -658,10 +658,23 @@ let create_vfb_vkbd ~xc ~xs protocol domid =
   Device.Vfb.add ~xc ~xs ~hvm:false ~protocol domid;
   Device.Vkbd.add ~xc ~xs ~hvm:false ~protocol domid
 
+(* get CD VBDs required to resume *)
+let get_required_CD_VBDs ~__context ~vm =
+  List.filter (fun self -> (Db.VBD.get_currently_attached ~__context ~self) 
+      && (Db.VBD.get_type ~__context ~self = `CD))
+    (Db.VM.get_VBDs ~__context ~self:vm)
+   
+(* get non-CD VBDs required to resume *)
+let get_required_nonCD_VBDs ~__context ~vm =
+  List.filter (fun self -> (Db.VBD.get_currently_attached ~__context ~self) 
+      && (Db.VBD.get_type ~__context ~self <> `CD))
+    (Db.VM.get_VBDs ~__context ~self:vm)
+   
 (* get VBDs required to resume *)
 let get_VBDs_required_on_resume ~__context ~vm =
   List.filter (fun self -> Db.VBD.get_currently_attached ~__context ~self)
     (Db.VM.get_VBDs ~__context ~self:vm)
+  
 (* get real VDIs required to resume -- i.e. the things we have to attach and maybe activate *)
 let get_VDIs_required_on_resume ~__context ~vm =
   let needed_vbds = get_VBDs_required_on_resume ~__context ~vm in
@@ -670,10 +683,24 @@ let get_VDIs_required_on_resume ~__context ~vm =
       (List.filter (fun self -> not (Db.VBD.get_empty ~__context ~self)) needed_vbds) in
   needed_vdis
 
+(* restore CD drives. This needs to happen earlier in the restore sequence. 
+ * See CA-17925
+ *)
+let _restore_CD_devices ~__context ~xc ~xs ~self at_boot_time fd domid vifs =
+  	let hvm = Helpers.will_boot_hvm ~__context ~self in
+	let protocol = Helpers.device_protocol_of_string (Db.VM.get_domarch ~__context ~self) in
+    let needed_vbds = get_required_CD_VBDs ~__context ~vm:self in
+	let string_of_vbd_list vbds = String.concat "; " 
+	  (List.map (fun vbd -> string_of_vbd ~__context ~vbd) vbds) in
+    debug "CD VBDs: [ %s ]" (string_of_vbd_list needed_vbds);
+
+  	(* If any VBDs cannot be attached, let the exn propagate *)
+	List.iter (fun self -> create_vbd ~__context ~xs ~hvm ~protocol domid self) needed_vbds
+  
 (* restore the devices, but not the domain; the vdis must all be attached/activated by the
    time this function is executed
 *)
-let _restore_devices ~__context ~xc ~xs ~self at_boot_time fd domid vifs =
+let _restore_devices ~__context ~xc ~xs ~self at_boot_time fd domid vifs includeCDs =
 	let hvm = Helpers.will_boot_hvm ~__context ~self in
 	(* CA-25297: domarch is r/o and not currently stored in the LBR *)
 	let protocol = Helpers.device_protocol_of_string (Db.VM.get_domarch ~__context ~self) in
@@ -682,7 +709,9 @@ let _restore_devices ~__context ~xc ~xs ~self at_boot_time fd domid vifs =
 	  (List.map (fun vbd -> string_of_vbd ~__context ~vbd) vbds) in
 
 	(* We /must/ be able to re-attach all the VBDs the guest had when it suspended. *)
-	let needed_vbds = get_VBDs_required_on_resume ~__context ~vm:self in
+	let needed_vbds = 
+      if includeCDs then get_VBDs_required_on_resume ~__context ~vm:self 
+      else get_required_nonCD_VBDs ~__context ~vm:self in
 	debug "To restore this domain we need VBDs: [ %s ]" (string_of_vbd_list needed_vbds);
 	
 	(* If any VBDs cannot be attached, let the exn propagate *)
@@ -788,7 +817,7 @@ let restore ~__context ~xc ~xs ~self start_paused =
 		     (fun () ->
 			try
 			  let vifs = Vm_config.vifs_of_vm ~__context ~vm:self domid in
-			  _restore_devices ~__context ~xc ~xs ~self snapshot fd domid vifs;
+			  _restore_devices ~__context ~xc ~xs ~self snapshot fd domid vifs true;
 			  _restore_domain ~__context ~xc ~xs ~self snapshot fd ?vnc_statefile domid vifs;
 
 			with exn ->

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -426,11 +426,14 @@ let receiver ~__context ~localhost is_localhost_migration fd vm xc xs memory_req
   (try
      if not delay_device_create_until_after_activate then
        begin
-	 debug "Receiver 5. Calling Vmops._restore_devices (domid = %d)" domid;
-	 Vmops._restore_devices ~__context ~xc ~xs ~self:vm snapshot fd domid needed_vifs
+	 debug "Receiver 5. Calling Vmops._restore_devices (domid = %d) for CD and non-CD devices" domid;
+	 Vmops._restore_devices ~__context ~xc ~xs ~self:vm snapshot fd domid needed_vifs true
        end
      else
-       debug "Note: receiver _not_ calling _restore_devices yet, because at least one SR has activate capability -- we will call _restore_devices after activate instead";
+       begin
+     debug "Receiver 5. Calling Vmops._restore_CD_devices (domid = %d). We will restore non-CD devices after calling activate." domid;
+	 Vmops._restore_CD_devices ~__context ~xc ~xs ~self:vm snapshot fd domid needed_vifs
+       end;
      if want_failure __context vm 4 then begin
        debug "Simulating failure just before restore";
        failwith "Simulating failure just before restore (eg out of memory, couldn't attach disk)";
@@ -485,8 +488,8 @@ let receiver ~__context ~localhost is_localhost_migration fd vm xc xs memory_req
      
      if delay_device_create_until_after_activate then
        begin
-	 debug "Receiver 7a1. Calling Vmops._restore_devices (domid = %d) [doing this now because we call after activate]" domid;
-	 Vmops._restore_devices ~__context ~xc ~xs ~self:vm snapshot fd domid needed_vifs
+	 debug "Receiver 7a1. Calling Vmops._restore_devices (domid = %d) for non-CD devices [doing this now because we call after activate]" domid;
+	 Vmops._restore_devices ~__context ~xc ~xs ~self:vm snapshot fd domid needed_vifs false
        end;
    with e ->
      error "Caught exception during activate: %s" (ExnHelper.string_of_exn e);


### PR DESCRIPTION
If any storage backend exports VDI_ACTIVATE then we delay creating device trees in xenstore until the last minute. This means that qemu starts up without needed CDROM information, causing the CDROM to disappear from the guest.

We need to completely rethink this. However this patch fixes the immediate problem.

(Sorry about the whitespace -- it's in-keeping with the surrounding code but not great overall. Given this code needs a complete rewrite I'm not worried about it)
