### PR TITLE
Remove hardcoded '64' (or '63') when dealing with physical CPUs

### DIFF
--- a/ocaml/xapi/vmops.ml
+++ b/ocaml/xapi/vmops.ml
@@ -320,12 +320,15 @@ let general_domain_create_check ~__context ~vm ~snapshot =
 let vcpu_configuration snapshot = 
   let vcpus = Int64.to_int snapshot.API.vM_VCPUs_max in
 
+  let pcpus = with_xc (fun xc -> (Xc.physinfo xc).Xc.max_nr_cpus) in
+  debug "xen reports max %d pCPUs" pcpus;
+
   (* vcpu <-> pcpu affinity settings are stored here: *)
   let mask = try Some (List.assoc "mask" snapshot.API.vM_VCPUs_params) with _ -> None in
   (* convert the mask into a bitmap, one bit per pCPU *)
   let bitmap string = 
     let cpus = List.map int_of_string (String.split ',' string) in
-    let cpus = List.filter (fun x -> x >= 0 && x <= 63) cpus in
+    let cpus = List.filter (fun x -> x >= 0 && x < pcpus) cpus in
     let bits = List.map (Int64.shift_left 1L) cpus in
     List.fold_left Int64.logor 0L bits in
   let bitmap = try Opt.map bitmap mask with _ -> warn "Failed to parse vCPU mask"; None in

--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -843,12 +843,12 @@ let vcpu_affinity_set ~xc domid vcpu cpumap =
 	Xc.vcpu_affinity_set xc domid vcpu !bitmap
 
 let vcpu_affinity_get ~xc domid vcpu =
+	let pcpus = (Xc.physinfo xc).Xc.max_nr_cpus in
+	(* NB we ignore bits corresponding to pCPUs which we don't have *)
 	let bitmap = Xc.vcpu_affinity_get xc domid vcpu in
-	let cpumap = Array.make 64 false in
 	let bit_isset bitmap n =
 		(Int64.logand bitmap (Int64.shift_left 1L n)) > 0L in
-	(* set bit in the array that are set in the bitmap *)
-	for i = 0 to 63 do cpumap.(i) <- bit_isset bitmap i done;
+	let cpumap = Array.of_list (List.map (bit_isset bitmap) (List.range 0 pcpus)) in
 	cpumap
 
 let get_uuid ~xc domid =


### PR DESCRIPTION
This is necessary but not sufficient to support setting affinity to more than 64 host pCPUs. We also need to revamp our xc bindings, using the upstream libxc, to get an interface which doesn't have a limit of 64 imposed by the function parameter types (int64s as bitmaps)
