### PR TITLE
Ensure that "internal" API fields are hidden from the HTML API docs

### DIFF
--- a/ocaml/doc/apidoc.js
+++ b/ocaml/doc/apidoc.js
@@ -219,6 +219,7 @@ function class_doc()
 		}, [], contents);
 	fields = map(function(f){return f[1];}, fields);
 	
+	fields = filter(function(f){return f.internal_only == false;}, fields);
 	fields.sort(function(a, b){return compare(a.full_name.join('_').toLowerCase(), b.full_name.join('_').toLowerCase());});
 	messages = clsdoc.messages;
 	messages = filter(function(m){return m.msg_hide_from_docs == false;}, messages);

--- a/ocaml/doc/jsapi.ml
+++ b/ocaml/doc/jsapi.ml
@@ -57,6 +57,7 @@ let _ =
 				) [] contents
 			in
 			let fields = flatten_contents obj.contents in
+			let fields = List.filter (fun f -> not f.internal_only) fields in
 			let field_changes : changes_t = List.fold_left (fun l f -> l @ (changes_for_field f)) [] fields in
 			
 			"{'cls': '" ^ obj.name ^ "', 'obj_changes': " ^ Jsonrpc.to_string (rpc_of_changes_t obj_changes) ^ ", 'field_changes': " ^ Jsonrpc.to_string (rpc_of_changes_t field_changes) ^ ", 'msg_changes': " ^ Jsonrpc.to_string (rpc_of_changes_t msg_changes) ^ "}"


### PR DESCRIPTION
Internal fields can only be seen and used by xapi, and are invisible to XenAPI clients. Therefore, they should not be visible in the API docs.
