### PR TITLE
Remove the VM.set_suspend_SR redundant definitions

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1955,16 +1955,6 @@ let vm_set_protection_policy = call
   ~allowed_roles:_R_POOL_OP
   ()
 
-let vm_set_suspend_SR = call
-  ~name:"set_suspend_SR"
-  ~in_oss_since:None
-  ~in_product_since:rel_boston
-  ~doc:"Set the SR to use when suspending this VM"
-  ~params:[Ref _vm, "vm", "The VM to modify";
-    Ref _sr, "sr", "The SR to use when suspending this VM"]
-  ~allowed_roles:_R_POOL_OP
-  ()
-
 (* ------------------------------------------------------------------------------------------------------------
    Host Management
    ------------------------------------------------------------------------------------------------------------ *)
@@ -5889,7 +5879,6 @@ let vm =
 		vm_retrieve_wlb_recommendations;
 		vm_copy_bios_strings;
     vm_set_protection_policy;
-		vm_set_suspend_SR;
 		]
       ~contents:
       ([ uid _vm;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1748,10 +1748,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 		info "VM.set_protection_policy: self = '%s'; " (vm_uuid ~__context self);
 		Local.VM.set_protection_policy ~__context ~self ~value
 
-	let set_suspend_SR ~__context ~vm ~sr =
-		info "VM.set_suspend_SR: VM = '%s'; SR ='%s'" (vm_uuid ~__context vm) (sr_uuid ~__context sr);
-		Local.VM.set_suspend_SR ~__context ~vm ~sr
-
   end
 
   module VM_metrics = struct

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1234,6 +1234,3 @@ let set_protection_policy ~__context ~self ~value =
     (if (value <> Ref.null) then Xapi_vmpp.assert_licensed ~__context);
     Db.VM.set_protection_policy ~__context ~self ~value
   )
-
-let set_suspend_SR ~__context ~vm ~sr =
-	Db.VM.set_suspend_SR ~__context ~self:vm ~value:sr

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -266,4 +266,3 @@ val copy_bios_strings :
  *  had already been set. *)
 
 val set_protection_policy : __context:Context.t -> self:API.ref_VM -> value:API.ref_VMPP -> unit
-val set_suspend_SR : __context:Context.t -> vm:API.ref_VM -> sr:API.ref_SR -> unit


### PR DESCRIPTION
The set_suspend_SR stuff is autogenerated - we don't need to explicitly write it. Doing so doesn't harm the ocaml, but it does break the java bindings!
