### PR TITLE
CA-30417: More relevant error message should be thrown while migrating Dom 0 through CLI.

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2290,7 +2290,7 @@ let vm_migrate printer rpc session_id params =
 	if not (List.mem_assoc "host" params) then failwith "No destination host specified";
 	let host = (get_host_by_name_or_id rpc session_id (List.assoc "host" params)).getref () in
 	let options = List.map_assoc_with_key (string_of_bool +++ bool_of_string) (List.restrict_with_default "false" ["live"; "encrypt"] params) in
-	ignore(do_vm_op printer rpc session_id (fun vm -> Client.VM.pool_migrate rpc session_id (vm.getref ()) host options)
+	ignore(do_vm_op ~include_control_vms:true printer rpc session_id (fun vm -> Client.VM.pool_migrate rpc session_id (vm.getref ()) host options)
 		params ["host"; "host-uuid"; "host-name"; "live"; "encrypt"])
 
 let vm_disk_list_aux vm is_cd_list printer rpc session_id params =


### PR DESCRIPTION
Now when we try to migrate a control domain from the command line, we get a meaningful error message.
