### PR TITLE
CA-52663/SCTX-581 -- vncscreenshot now takes screenshots of blank screens

### DIFF
--- a/ocaml/xapi/xapi_vncsnapshot.ml
+++ b/ocaml/xapi/xapi_vncsnapshot.ml
@@ -35,7 +35,7 @@ let vncsnapshot_handler (req: request) s =
 	      let vnc_port = Int64.to_int (Db.Console.get_port ~__context ~self:console) in
 	      
 	    let pid = safe_close_and_exec None None None [] vncsnapshot 
-	      [ "-quiet"; "-encodings"; "\"raw\"";
+	      [ "-quiet"; "-allowblank" ; "-encodings"; "\"raw\"";
 		Printf.sprintf "%s:%d" "127.0.0.1" (vnc_port-5900); tmp ] in
 	    waitpid_fail_if_bad_exit pid;
 	    Http_svr.response_file ~mime_content_type:None s tmp


### PR DESCRIPTION
... instead of waiting for a non-blank screen. This seems the opposite of what we want, but there have been reports of people repeatedly taking thousands of screenshots, all of which block while waiting for a non-blank screen, causing the host to run out of memory from all the blocked processes.
