### PR TITLE
CA-52804: xapi reports Gpg.InvalidSignature for believed-good test hotfixes

### DIFF
--- a/ocaml/gpg/gpg.ml
+++ b/ocaml/gpg/gpg.ml
@@ -27,7 +27,7 @@ let gpg_homedir = "/opt/xensource/gpg/"
 let gpg_pub_keyring = gpg_homedir^"pubring.gpg"
 let allowed_gpg_checksum =
 	[ "be00ee82bffad791edfba477508d5d84"; (* centos52 version *)
-	  "08690c3d1a43d920a1b278cb57ed97ba"; (* centos53/54 version *)
+	  "a267af68c53f5d998b982235bbccb01e"; (* centos53/54 version *)
 	  "f52886b87126c06d419f408e32268b4e"; (* 64 bit product version *)
 	  "aa27ac0b0ebfd1278bf2386c343053db"; (* debian developer version *)
 	  "044d1327ea42400ac590195e0ec1e7e6"; ]


### PR DESCRIPTION
We forgot to update the /usr/bin/gpg checksum in ocaml/gpg/gpg.ml after the recent CentOS upgrade. This should go into trunk today to avoid any more failing tests.

I'm going to open a new ticket for us to move the GPG code into xapi-libs. This way v6 and xapi (for hotfixes) can reference a single bit of code, and we won't have to fix this twice again next time we upgrade gpg. (For the unaware, Rob had to fix this separately in v6d last week, since we have md5sums in two places now.)
