### PR TITLE
CA-53577: Fix 'xe vm-install' of snapshots

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1971,7 +1971,7 @@ let vm_install_real printer rpc session_id template name description params =
 
 	let sr_ref =
 		if Client.VM.get_is_a_snapshot rpc session_id template then
-			if true
+			if false
 				|| (List.mem_assoc "sr-name-label" params
 				|| List.mem_assoc "sr-uuid" params) then
 				failwith "Do not use the sr-name-label or sr-uuid argument when installing from a snapshot. By default, it will install each new disk on the same SR as the corresponding snapshot disks."


### PR DESCRIPTION
An earlier "fix whitespace" patch introduced a semantic change (ie this bug)
