### PR TITLE
Add generated symlinks to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,9 @@ ocaml/idl/ocaml_backend/META
 ocaml/xapi/rrddump
 ocaml/xapi/sparse_dd
 ocaml/xapi/xapi_unit_test
+ocaml/license/v6d
+ocaml/license/v6d-reopen-logs
+ocaml/ptoken/genptoken
+ocaml/xenops/memory_breakdown
+ocaml/xenops/squeezed
+ocaml/xenops/squeezed_client


### PR DESCRIPTION
We've got a few makefile-generated symlinks to .opt binaries that haven't yet been added to .gitignore. I'm adding them now so that 'git status' shows a clean branch even if these symlinks are there.
