### PR TITLE
Remove suspend, checkpoint, and pool_migrate from VM.allowed_operations if PCI device is passed through

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -723,9 +723,6 @@ let suspend  ~__context ~vm =
 	(fun () ->
 		Locking_helpers.with_lock vm
 		(fun token () ->
-			(* We don't support suspend/resume while PCI devices have been passed through (yet). *)
-			if Db.VM.get_attached_PCIs ~__context ~self:vm <> [] then
-				raise (Api_errors.Server_error(Api_errors.vm_has_pci_attached, [Ref.string_of vm]));
 			Stats.time_this "VM suspend"
 			(fun () ->
 				let domid = Helpers.domid_of_vm ~__context ~self:vm in
@@ -955,9 +952,6 @@ let revert ~__context ~snapshot =
 let checkpoint ~__context ~vm ~new_name =
 	if not (Pool_features.is_enabled ~__context Features.Checkpoint) then
 		raise (Api_errors.Server_error(Api_errors.license_restriction, []))
-	(* We don't support VM checkpointing while PCI devices have been passed through (yet). *)
-	else if Db.VM.get_attached_PCIs ~__context ~self:vm <> [] then
-		raise (Api_errors.Server_error(Api_errors.vm_has_pci_attached, [Ref.string_of vm]))
 	else begin
 		Local_work_queue.wait_in_line Local_work_queue.long_running_queue
 			(Printf.sprintf "VM.checkpoint %s" (Context.string_of_task __context))

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -202,6 +202,12 @@ let report_concurrent_operations_error ~current_ops ~ref_str =
 	in
 	Some (Api_errors.other_operation_in_progress,["VM." ^ current_ops_str; ref_str])
 
+(* Suspending, checkpointing and live-migrating are not (yet) allowed if a PCI device is passed through *)
+let check_pci ~op ~ref_str =
+	match op with
+	|`suspend | `checkpoint | `pool_migrate -> Some (Api_errors.vm_has_pci_attached, [ref_str])
+	| _ -> None
+
 (** Take an internal VM record and a proposed operation, return true if the operation
     would be acceptable *)
 let check_operation_error ~__context ~vmr ~vmgmr ~ref ~clone_suspended_vm_enabled vdis_reset_and_caching ~op =
@@ -313,7 +319,13 @@ let check_operation_error ~__context ~vmr ~vmgmr ~ref ~clone_suspended_vm_enable
 			else None
 
 		else None) in
-	
+
+	(* If a PCI device is passed-through, check if the operation is allowed *)
+	let current_error = check current_error (fun () ->
+		if vmr.Db_actions.vM_attached_PCIs <> []
+		then check_pci ~op ~ref_str
+		else None) in
+
 	current_error
 
 let maybe_get_guest_metrics ~__context ~ref =

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -721,9 +721,6 @@ let pool_migrate ~__context ~vm ~host ~options =
 	let force = try bool_of_string (List.assoc "force" options) with _ -> false in
 	if not force then
 		Xapi_vm_helpers.assert_vm_is_compatible ~__context ~vm ~host;
-	(* We don't support VM migration while PCI devices have been passed through (yet). *)
-	if Db.VM.get_attached_PCIs ~__context ~self:vm <> [] then
-		raise (Api_errors.Server_error(Api_errors.vm_has_pci_attached, [Ref.string_of vm]));
 	Local_work_queue.wait_in_line Local_work_queue.long_running_queue 
 	  (Printf.sprintf "VM.pool_migrate %s" (Context.string_of_task __context))
 	  (fun () ->


### PR DESCRIPTION
XenCenter uses this information to "grey out" certain options, and it potentially useful for WLB as well.

Furthermore, the exceptions for this case in Xapi_vm and Xapi_vm_migrate are now redundant and could be removed (Message_forwarding already does the checks).
