### PR TITLE
[HA] Use ha_always_run to keep track of last known VM power state.

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -695,13 +695,13 @@ let rec bisect f lower upper =
     else bisect f lower mid
 
 (* All non best-effort VMs which are running should be kept running at all costs *)
-let vm_should_always_run power_state restart_priority =
-  power_state = `Running && restart_priority = Constants.ha_restart
+let vm_should_always_run always_run restart_priority =
+  always_run && restart_priority = Constants.ha_restart
 
 (* Returns true if the specified VM is "protected" (non best-effort) by xHA *)
 let is_xha_protected ~__context ~self =
-  vm_should_always_run (Db.VM.get_power_state ~__context ~self) (Db.VM.get_ha_restart_priority ~__context ~self)
-let is_xha_protected_r record = vm_should_always_run record.API.vM_power_state record.API.vM_ha_restart_priority
+  vm_should_always_run (Db.VM.get_ha_always_run ~__context ~self) (Db.VM.get_ha_restart_priority ~__context ~self)
+let is_xha_protected_r record = vm_should_always_run record.API.vM_ha_always_run record.API.vM_ha_restart_priority
 
 open Listext
 

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -19,7 +19,7 @@ open D
 (* Return a list of (ref, record) pairs for all VMs which are marked as always_run *)
 let all_protected_vms ~__context = 
    let vms = Db.VM.get_all_records ~__context in
-   List.filter (fun (_, vm_rec) -> Helpers.vm_should_always_run vm_rec.API.vM_power_state vm_rec.API.vM_ha_restart_priority) vms 
+   List.filter (fun (_, vm_rec) -> Helpers.vm_should_always_run vm_rec.API.vM_ha_always_run vm_rec.API.vM_ha_restart_priority) vms 
 
 (* Comparison function which can be used to sort a list of VM ref, record by order *)
 let by_order (vm_ref1,vm_rec1) (vm_ref2,vm_rec2) =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -245,7 +245,7 @@ let compute_evacuation_plan_no_wlb ~__context ~host =
   let pool = Helpers.get_pool ~__context in
   let protected_vms, unprotected_vms = 
     if Db.Pool.get_ha_enabled ~__context ~self:pool
-    then List.partition (fun (vm, record) -> Helpers.vm_should_always_run record.API.vM_power_state record.API.vM_ha_restart_priority) all_user_vms
+    then List.partition (fun (vm, record) -> Helpers.vm_should_always_run record.API.vM_ha_always_run record.API.vM_ha_restart_priority) all_user_vms
     else all_user_vms, [] in
   List.iter (fun (vm, _) -> Hashtbl.replace plans vm (Error (Api_errors.host_not_enough_free_memory, [ Ref.string_of vm ]))) unprotected_vms;
   let migratable_vms, unmigratable_vms = List.partition (fun (vm, record) ->

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1089,7 +1089,7 @@ let ha_compute_hypothetical_max_host_failures_to_tolerate ~__context ~configurat
 	       if not(List.mem pri Constants.ha_valid_restart_priorities)
 	       then raise (Api_errors.Server_error(Api_errors.invalid_value, [ "ha_restart_priority"; pri ]))) configuration;
 
-  let protected_vms = List.map fst (List.filter (fun (vm, priority) -> Helpers.vm_should_always_run `Running priority) configuration) in
+  let protected_vms = List.map fst (List.filter (fun (vm, priority) -> Helpers.vm_should_always_run true priority) configuration) in
   let protected_vms = List.map (fun vm -> vm, Db.VM.get_record ~__context ~self:vm) protected_vms in
   Xapi_ha_vm_failover.compute_max_host_failures_to_tolerate ~__context ~protected_vms ()
 


### PR DESCRIPTION
The field ha_always_run is now used internally to keep track of whether
a VM is running, in case of host failure. The field is not settable via
the API.
