### PR TITLE
[CP-2258] Allow VDI.set_snapshot_time to be called from SM.

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4874,6 +4874,17 @@ let vdi_set_snapshot_of = call
 	~allowed_roles:_R_VM_ADMIN
 	()
 
+let vdi_set_snapshot_time = call
+	~name:"set_snapshot_time"
+	~in_oss_since:None
+	~in_product_since:rel_boston
+	~params:[Ref _vdi, "self", "The VDI to modify";
+		DateTime, "value", "The snapshot time of this VDI."]
+	~flags:[`Session]
+	~doc:"Sets the snapshot time of this VDI."
+	~allowed_roles:_R_VM_ADMIN
+	()
+
 (** An API call for debugging and testing only *)
 let vdi_generate_config = call
    ~name:"generate_config"
@@ -4987,6 +4998,7 @@ let vdi =
 		 vdi_set_physical_utilisation;
 		 vdi_set_is_a_snapshot;
 		 vdi_set_snapshot_of;
+		 vdi_set_snapshot_time;
 		 vdi_set_name_label;
 		 vdi_set_name_description;
 		 vdi_generate_config;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2904,6 +2904,11 @@ end
 			Sm.assert_session_has_internal_sr_access ~__context ~sr;
 			Local.VDI.set_snapshot_of ~__context ~self ~value
 
+		let set_snapshot_time ~__context ~self ~value =
+			let sr = Db.VDI.get_SR ~__context ~self in
+			Sm.assert_session_has_internal_sr_access ~__context ~sr;
+			Local.VDI.set_snapshot_time ~__context ~self ~value
+
     let set_name_label ~__context ~self ~value =
 	    info "VDI.set_name_label: VDI = '%s' name-label = '%s'"
 		    (vdi_uuid ~__context self) value;

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -544,6 +544,9 @@ let set_is_a_snapshot ~__context ~self ~value =
 let set_snapshot_of ~__context ~self ~value =
 	Db.VDI.set_snapshot_of ~__context ~self ~value
 
+let set_snapshot_time ~__context ~self ~value =
+	Db.VDI.set_snapshot_time ~__context ~self ~value
+
 let set_on_boot ~__context ~self ~value =
 	let sr = Db.VDI.get_SR ~__context ~self in
 	let ty = Db.SR.get_type ~__context ~self:sr in


### PR DESCRIPTION
This got missed before - SM needs to be able to set snapshot time in XAPI during SR.scan, if XAPI is missing the VDI.
