### PR TITLE
CA-51141: apply cpuid policy when resuming VM

### DIFF
--- a/ocaml/xapi/vmops.ml
+++ b/ocaml/xapi/vmops.ml
@@ -972,6 +972,7 @@ let resume ~__context ~xc ~xs ~vm =
 	Xapi_xenops_errors.handle_xenops_error (fun () ->
 		(* TTT: check if the domain is really cooperative *)
 		Domain.resume ~xs ~xc ~hvm ~cooperative:true domid;
+		Domain.cpuid_apply ~xc ~hvm domid;
 		Domain.unpause ~xc domid) 
 
 (** Starts up a VM, leaving it in the paused state *)


### PR DESCRIPTION
According to George Dunlap, this might resolve the RHEL 4.x resume panic problem.

Signed-off-by: Zheng Li zheng.li@eu.citrix.com
