### PR TITLE
[CA-56093] Make SR/VDI metadata change persistence best-effort.

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2779,20 +2779,15 @@ end
     let set_shared ~__context ~sr ~value =
 	    Local.SR.set_shared ~__context ~sr ~value
 
-    let set_name_label ~__context ~sr ~value =
-	    info "SR.set_name_label: SR = '%s' name-label = '%s'"
-		    (sr_uuid ~__context sr) value;
-	    let local_fn = Local.SR.set_name_label ~sr ~value in
-	    forward_sr_op ~local_fn ~__context ~self:sr
-		    (fun session_id rpc -> Client.SR.set_name_label ~rpc ~session_id ~sr ~value)
+		let set_name_label ~__context ~sr ~value =
+			info "SR.set_name_label: SR = '%s' name-label = '%s'"
+				(sr_uuid ~__context sr) value;
+			Local.SR.set_name_label ~__context ~sr ~value
 
-    let set_name_description ~__context ~sr ~value =
-	    info "SR.set_name_description: SR = '%s' name-description = '%s'"
-		    (sr_uuid ~__context sr) value;
-	    let local_fn = Local.SR.set_name_description ~sr ~value in
-	    forward_sr_op ~local_fn ~__context ~self:sr
-		    (fun session_id rpc ->
-			    Client.SR.set_name_description ~rpc ~session_id ~sr ~value)
+		let set_name_description ~__context ~sr ~value =
+			info "SR.set_name_description: SR = '%s' name-description = '%s'"
+				(sr_uuid ~__context sr) value;
+			Local.SR.set_name_description ~__context ~sr ~value
 
     let assert_can_host_ha_statefile ~__context ~sr = 
       info "SR.assert_can_host_ha_statefile: SR = '%s'" (sr_uuid ~__context sr);
@@ -2909,20 +2904,15 @@ end
 			Sm.assert_session_has_internal_sr_access ~__context ~sr;
 			Local.VDI.set_snapshot_time ~__context ~self ~value
 
-    let set_name_label ~__context ~self ~value =
-	    info "VDI.set_name_label: VDI = '%s' name-label = '%s'"
-		    (vdi_uuid ~__context self) value;
-	    let local_fn = Local.VDI.set_name_label ~self ~value in
-	    forward_vdi_op ~local_fn ~__context ~self
-		    (fun session_id rpc -> Client.VDI.set_name_label ~rpc ~session_id ~self ~value)
+		let set_name_label ~__context ~self ~value =
+			info "VDI.set_name_label: VDI = '%s' name-label = '%s'"
+				(vdi_uuid ~__context self) value;
+			Local.VDI.set_name_label ~__context ~self ~value
 
-    let set_name_description ~__context ~self ~value =
-	    info "VDI.set_name_description: VDI = '%s' name-description = '%s'"
-		    (vdi_uuid ~__context self) value;
-	    let local_fn = Local.VDI.set_name_description ~self ~value in
-	    forward_vdi_op ~local_fn ~__context ~self
-		    (fun session_id rpc ->
-			    Client.VDI.set_name_description ~rpc ~session_id ~self ~value)
+		let set_name_description ~__context ~self ~value =
+			info "VDI.set_name_description: VDI = '%s' name-description = '%s'"
+				(vdi_uuid ~__context self) value;
+			Local.VDI.set_name_description ~__context ~self ~value
 
 	let ensure_vdi_not_on_running_vm ~__context ~self =
 		let vbds = Db.VDI.get_VBDs ~__context ~self in

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -419,13 +419,22 @@ let set_shared ~__context ~sr ~value =
       Db.SR.set_shared ~__context ~self:sr ~value
     end
 
+(* set_name_label and set_name_description attempt to persist the change to the storage backend. *)
+(* If the SR is detached this will fail, but this is OK since the SR will persist metadata on sr_attach. *)
+let try_update_sr ~__context ~sr =
+	try
+		Helpers.call_api_functions ~__context
+			(fun rpc session_id -> Client.SR.update ~rpc ~session_id ~sr)
+	with e ->
+		debug "Could not persist change to SR - caught %s" (Printexc.to_string e)
+
 let set_name_label ~__context ~sr ~value =
 	Db.SR.set_name_label ~__context ~self:sr ~value;
-	update ~__context ~sr
+	try_update_sr ~__context ~sr
 
 let set_name_description ~__context ~sr ~value =
 	Db.SR.set_name_description ~__context ~self:sr ~value;
-	update ~__context ~sr
+	try_update_sr ~__context ~sr
 
 let set_virtual_allocation ~__context ~self ~value = 
   Db.SR.set_virtual_allocation ~__context ~self ~value

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -565,13 +565,22 @@ let set_on_boot ~__context ~self ~value =
 let set_allow_caching ~__context ~self ~value =
 	Db.VDI.set_allow_caching ~__context ~self ~value
 
+(* set_name_label and set_name_description attempt to persist the change to the storage backend. *)
+(* If the SR is detached this will fail, but this is OK since the SR will persist metadata on sr_attach. *)
+let try_update_vdi ~__context ~self =
+	try
+		Helpers.call_api_functions ~__context
+			(fun rpc session_id -> Client.VDI.update ~rpc ~session_id ~vdi:self)
+	with e ->
+		debug "Could not persist change to SR - caught %s" (Printexc.to_string e)
+
 let set_name_label ~__context ~self ~value =
 	Db.VDI.set_name_label ~__context ~self ~value;
-	update ~__context ~vdi:self
+	try_update_vdi ~__context ~self
 
 let set_name_description ~__context ~self ~value =
 	Db.VDI.set_name_description ~__context ~self ~value;
-	update ~__context ~vdi:self
+	try_update_vdi ~__context ~self
 
 let checksum ~__context ~self =
 	let do_checksum f = Digest.to_hex (Digest.file f) in


### PR DESCRIPTION
[SR|VDI].set_name_[label|description] no longer fail if the contained
call to [SR|VDI] update fails (usually caused by the SR being detached).

This means that if metadata changes occur while an SR is detached, XAPI
and the SR will persist inconsistent metadata - as a result of this, the
storage backend will be changed to update
[SR|VDI].name_[label|description] on sr_attach.
