### PR TITLE
Add the ability for xapi to generate fake data for the RRDs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ srpm: xapi.spec
 	rm -f $(RPM_SOURCESDIR)/xapi-version.patch
 	(cd $(REPO); diff -u /dev/null ocaml/util/version.ml > $(RPM_SOURCESDIR)/xapi-version.patch) || true
 	cp -f xapi.spec $(RPM_SPECSDIR)/
-	chown root.root $(RPM_SPECSDIR)/xapi.spec
+	chown root.root $(RPM_SPECSDIR)/xapi.spec || true
 	$(RPMBUILD) -bs --nodeps $(RPM_SPECSDIR)/xapi.spec
 
 

--- a/OMakefile
+++ b/OMakefile
@@ -115,6 +115,7 @@ OCAML_PHASE3_XEN = \
 	ocaml/xapi/fakeguestagent \
 	ocaml/xapi/quicktestbin \
 	ocaml/xapi/sparse_dd \
+	ocaml/xapi/monitor_fake_plugin \
 	ocaml/license/v6d \
 	ocaml/license/v6d-reopen-logs
 

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -6,7 +6,7 @@ OCAMLINCLUDES = ../idl ../idl/ocaml_backend \
 	../xenops ../xva ../util \
 	../auth ../license ../client_records ../rfb ../gpg
 
-UseCamlp4(rpc-light.syntax, features)
+UseCamlp4(rpc-light.syntax, features rrd monitor_fake monitor_fake_common)
 
 CFLAGS += -std=gnu99 -Wall -Werror -I$(shell ocamlc -where)
 
@@ -34,6 +34,7 @@ OCAMLPACKS = $(XEN_OCAMLPACKS) $(OCAMLPACKS)
 OCamlProgram(http_test, http_test)
 OCamlProgram(sparse_dd, sparse_dd sparse_encoding)
 OCamlProgram(show_bat, show_bat)
+OCamlProgram(monitor_fake_plugin, monitor_fake_plugin monitor_fake_common rrd)
 
 COMMON = \
 	xapi_templates \
@@ -165,6 +166,8 @@ XAPI_MODULES = $(COMMON) \
 	rrd_shared \
 	monitor_dbcalls \
 	monitor_rrds \
+	monitor_fake \
+	monitor_fake_common \
 	monitor \
 	rrd \
 	api_server \
@@ -272,6 +275,8 @@ install:
 	$(IPROG) rrddump $(DEBUGDIST)
 	mkdir -p $(DESTDIR)/opt/xensource/libexec
 	$(IPROG) sparse_dd $(DESTDIR)/opt/xensource/libexec
+	mkdir -p $(DESTDIR)/etc/xapi.d/plugins
+	$(IPROG) monitor_fake_plugin $(DESTDIR)/etc/xapi.d/plugins
 
 .PHONY: sdk-install
 sdk-install: install

--- a/ocaml/xapi/monitor.ml
+++ b/ocaml/xapi/monitor.ml
@@ -539,8 +539,8 @@ let read_all_dom0_stats __context =
       Xapi_guest_agent.sync_cache domids;
       Helpers.remove_other_keys memory_targets domids;
       Helpers.remove_other_keys uncooperative_domains domids;
-
-      (List.concat [
+      
+      let real_stats = List.concat [
 	handle_exn "ha_stats" (fun () -> Xapi_ha_stats.all ()) [];
 	handle_exn "read_mem_metrics" (fun ()->read_mem_metrics xc) [];
         vcpus;
@@ -549,9 +549,11 @@ let read_all_dom0_stats __context =
 	handle_exn "update_pcpus" (fun ()->update_pcpus xc) [];
 	handle_exn "update_vbds" (fun ()->update_vbds domains) [];
 	handle_exn "update_loadavg" (fun ()-> [ update_loadavg () ]) [];
-	handle_exn "update_memory" (fun ()->update_memory __context xc domains) []],uuids,pifs,timestamp,my_rebooting_vms, my_paused_domain_uuids)
-    )
-  )
+	handle_exn "update_memory" (fun ()->update_memory __context xc domains) []] in
+      let fake_stats = Monitor_fake.get_fake_stats uuids in
+      let all_stats = Monitor_fake.combine_stats real_stats fake_stats in
+      (all_stats,uuids,pifs,timestamp,my_rebooting_vms, my_paused_domain_uuids)
+  ))
 
   
 let do_monitor __context xc =

--- a/ocaml/xapi/monitor_fake.ml
+++ b/ocaml/xapi/monitor_fake.ml
@@ -1,0 +1,32 @@
+open Listext
+open Ds
+open Rrd_shared 
+
+open Monitor_fake_common
+
+module D=Debug.Debugger(struct let name="monitor_fake" end)
+open D
+
+let collect_fake_stats uuids =
+  List.filter_map (fun uuid ->
+    try 
+      let fname = Printf.sprintf "%s/%s.fakestats" fake_dir uuid in
+      let file = Unixext.string_of_file fname in
+	  let ds_list = fake_ds_list_of_rpc (Jsonrpc.of_string file) in
+	  debug "Got %d fake data source(s) for VM=%s" (List.length ds_list) uuid;
+      Some (List.map (fun fake_ds ->
+	  	  (VM uuid, ds_make ~name:fake_ds.f_name ~description:"" ~value:(Rrd.VT_Float fake_ds.f_val) ~ty:fake_ds.f_ty ~default:true ()))
+               (fake_ds_list_of_rpc (Jsonrpc.of_string file)))
+    with _ -> None) uuids
+
+let get_fake_stats uuids =
+  let fake_dir_exists = try
+      let st = Unix.stat fake_dir in
+      st.Unix.st_kind = Unix.S_DIR
+    with _ -> false in
+  if fake_dir_exists then List.concat (collect_fake_stats uuids) else []
+
+let combine_stats real fake =
+  (* Remove all of the real DSs that are shadowed by fake dss *)
+  let real2 = List.fold_left (fun acc (fake_ds_x, fake_ds_ds) -> List.filter (fun (x,ds) -> x=fake_ds_x && ds.ds_name <> fake_ds_ds.ds_name) acc) real fake in
+  real2 @ fake

--- a/ocaml/xapi/monitor_fake_common.ml
+++ b/ocaml/xapi/monitor_fake_common.ml
@@ -1,0 +1,14 @@
+open Listext
+open Ds
+open Rrd_shared 
+
+type fake_ds = {
+   f_name : string;
+   f_ty : Rrd.ds_type;
+   f_val : float;
+} with rpc
+
+type fake_ds_list = fake_ds list with rpc
+
+let fake_dir = "/var/xapi/fake_data"
+

--- a/ocaml/xapi/monitor_fake_plugin.ml
+++ b/ocaml/xapi/monitor_fake_plugin.ml
@@ -1,0 +1,63 @@
+open Monitor_fake_common
+
+exception UnknownRpc
+
+
+let add_fake_ds uuid ds_name ds_type value =
+	let value = float_of_string value in
+	let ty = match ds_type with 
+		| "absolute" -> Rrd.Absolute
+		| "gauge" -> Rrd.Gauge
+		| "derive" -> Rrd.Derive
+		| _ -> failwith "Unknown ds type"
+	in
+	Unixext.mkdir_rec fake_dir 0o755;
+	let fname = Printf.sprintf "%s/%s.fakestats" fake_dir uuid in
+	let orig_dss = 
+		try
+			fake_ds_list_of_rpc (Jsonrpc.of_string (Unixext.string_of_file fname))
+		with _ -> [] 
+	in
+	let new_ds = { f_name=ds_name; f_ty=ty; f_val=value } in
+	let new_dss = new_ds::(List.filter (fun ds -> ds.f_name <> ds_name) orig_dss) in
+	Unixext.write_string_to_file fname (Jsonrpc.to_string (rpc_of_fake_ds_list new_dss))
+
+
+
+let _ =
+	try 
+		let oc = open_out "/tmp/foo" in
+		Printf.fprintf oc "%s" Sys.argv.(1);
+		let call = Xmlrpc.call_of_string Sys.argv.(1) in
+		let host = Rpc.string_of_rpc (List.hd call.Rpc.params) in
+		let oc = open_out "/tmp/foo2" in
+		Printf.fprintf oc "%s" host;
+		let args = match (List.hd (List.tl call.Rpc.params)) with
+			| Rpc.Dict args ->
+				args
+			| _ -> 
+				failwith "Can't parse args"
+		in
+		let oc = open_out "/tmp/foo3" in
+		List.iter (fun (a,b) -> Printf.fprintf oc "%s: %s" a (Rpc.string_of_rpc b)) args;
+		let contents = 
+			match call.Rpc.name with
+				| "add_fake_ds" -> 					
+					let uuid = Rpc.string_of_rpc (List.assoc "uuid" args) in
+					let ds_name = Rpc.string_of_rpc (List.assoc "ds_name" args) in
+					let ds_type = Rpc.string_of_rpc (List.assoc "ds_type" args) in
+					let value = Rpc.string_of_rpc (List.assoc "value" args) in
+					add_fake_ds uuid ds_name ds_type value;
+					Rpc.rpc_of_string "OK"
+				| _ -> 
+					raise UnknownRpc
+		in
+		Printf.printf "%s" (Xmlrpc.string_of_response {Rpc.success=true; contents=contents});
+		exit 0
+	with
+		| UnknownRpc ->
+			Printf.printf "%s" (Xmlrpc.string_of_response {Rpc.success=false; contents=Rpc.rpc_of_string "Unknown RPC"});
+			exit 1
+		| _ ->
+			Printf.printf "%s" (Xmlrpc.string_of_response {Rpc.success=false; contents=Rpc.rpc_of_string "Internal error"});
+			exit 1

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -369,6 +369,7 @@ rm -rf $RPM_BUILD_ROOT
 /opt/xensource/debug/quicktestbin
 /opt/xensource/debug/watch_test
 /cli-rt/*
+/etc/xapi.d/plugins/monitor_fake_plugin
 
 %files client-devel
 %defattr(-,root,root,-)


### PR DESCRIPTION
Add the ability for xapi to generate fake data for the RRDs. Useful when xapi is running in a VM.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
