### PR TITLE
CA-56727: "xe host-get-system-status" blocks forever waiting for the task

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -3610,9 +3610,10 @@ let host_get_system_status fd printer rpc session_id params =
 			let prefix = uri_of_someone rpc session_id someone in
 			
 			let url =
-				Printf.sprintf "%s%s?session_id=%s&entries=%s&output=%s"
+				Printf.sprintf "%s%s?session_id=%s&entries=%s&output=%s&task_id=%s"
 					prefix Constants.system_status_uri
-					(Ref.string_of session_id) entries output in
+					(Ref.string_of session_id) entries output
+					(Ref.string_of task_id) in
 			HttpGet (filename, url) in
 		track_http_operation fd rpc session_id doit "system-status download"
 	in


### PR DESCRIPTION
CA-56727: "xe host-get-system-status" blocks forever waiting for the task to complete.

This was because the task_id=... parameter accidentally got removed from the HTTP URI. This patch adds this back.

Signed-off-by: David Scott dave.scott@eu.citrix.com
