### PR TITLE
CA-56857: Don't call the host_{pre,post}_declare_dead scripts unless we'r

### DIFF
--- a/ocaml/xapi/db_gc.ml
+++ b/ocaml/xapi/db_gc.ml
@@ -194,10 +194,8 @@ let check_host_liveness ~__context =
 	end else begin
 	  if live then begin
 	    debug "Assuming host is offline since the heartbeat/metrics haven't been updated for %.2f seconds; setting live to false" (now -. host_time);
-	    Xapi_hooks.host_pre_declare_dead ~__context ~host ~reason:Xapi_hooks.reason__assume_failed;
 	    Db.Host_metrics.set_live ~__context ~self:hmetric ~value:false;
-	    Xapi_host_helpers.update_allowed_operations ~__context ~self:host;
-	    Xapi_hooks.host_post_declare_dead ~__context ~host ~reason:Xapi_hooks.reason__assume_failed;
+	    Xapi_host_helpers.update_allowed_operations ~__context ~self:host
 	  end
 	end;
 	(* Check for clock skew *)


### PR DESCRIPTION
CA-56857: Don't call the host_{pre,post}_declare_dead scripts unless we're absolutely sure that the host really is dead (ie, not unless we're in HA mode)

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
