### PR TITLE
Improve bond create and destroy while VMs are running

### DIFF
--- a/scripts/vif
+++ b/scripts/vif
@@ -174,8 +174,13 @@ esac
 
 case ${TYPE} in
     vif)
-        DOMID=`echo ${XENBUS_PATH} | cut -f 3 -d '/'`
-        DEVID=`echo ${XENBUS_PATH} | cut -f 4 -d '/'`
+        if [ -z ${XENBUS_PATH} ]; then
+            DOMID=$3
+            DEVID=$4
+        else
+            DOMID=`echo ${XENBUS_PATH} | cut -f 3 -d '/'`
+            DEVID=`echo ${XENBUS_PATH} | cut -f 4 -d '/'`
+        fi
         dev=vif${DOMID}.${DEVID}
         ;;
     tap)
@@ -229,4 +234,9 @@ remove)
     logger -t scripts-vif "${dev} has been removed"
     remove_from_bridge
     ;;
+
+move)
+    if [ "${TYPE}" = "vif" ] ;then
+        add_to_bridge
+    fi
 esac


### PR DESCRIPTION
Change VIF move function to move a dom0 vif device from one bridge to another

This function now no longer uses hot-unplug+plug, and should therefore
work for all guests. Some packet loss may occur during the move, but
for the current use cases (bond create/destroy) that is acceptable.

The patch adds a "move" option to the vif script, and adds to optional
parameters to the script for the domid and devid.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
