### PR TITLE
[CA-55593] Fix deadlock on broken HA storage.

### DIFF
--- a/ocaml/database/backend_xml.ml
+++ b/ocaml/database/backend_xml.ml
@@ -54,7 +54,7 @@ let flush dbconn db =
 	let time = Unix.gettimeofday() in
 
 	let do_flush_xml db filename =
-		Redo_log.flush_db_to_redo_log db;
+		Redo_log.flush_db_to_all_active_redo_logs db;
 		Unixext.atomic_write_to_file filename 0o0644
 			(fun fd ->
 				if not dbconn.Parse_db_conf.compress

--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -295,7 +295,7 @@ let load connections default_schema =
 		
 let sync conns db =
     (* Flush the in-memory cache to the redo-log *)
-    Redo_log.flush_db_to_redo_log db;
+    Redo_log.flush_db_to_all_active_redo_logs db;
 	(* and then to the filesystem *)
 	List.iter (fun c -> Db_connections.flush c db) conns
 		

--- a/ocaml/database/redo_log.mli
+++ b/ocaml/database/redo_log.mli
@@ -114,7 +114,10 @@ val empty : redo_log -> unit
 (** Invalidate the block device. This means that subsequent attempts to read from the block device will not find anything.
     This function is best-effort only and does not raise any exceptions in the case of error. *)
 
-val flush_db_to_redo_log: Db_cache_types.Database.t -> unit
+val flush_db_to_redo_log: Db_cache_types.Database.t -> redo_log -> unit
+(** Immediately write the given database to the given redo_log instance *)
+
+val flush_db_to_all_active_redo_logs: Db_cache_types.Database.t -> unit
 (** Immediately write the given database to all active redo logs *)
 
 val database_callback: Db_cache_types.update -> Db_cache_types.Database.t -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -839,7 +839,7 @@ let sync_database ~__context =
     (fun () ->
        (* If HA is enabled I'll first try to flush to the LUN *)
        let pool = Helpers.get_pool ~__context in
-       let flushed_to_vdi = Db.Pool.get_ha_enabled ~__context ~self:pool && (Xha_metadata_vdi.flush_database ~__context) in
+       let flushed_to_vdi = Db.Pool.get_ha_enabled ~__context ~self:pool && (Xha_metadata_vdi.flush_database ~__context Xapi_ha.ha_redo_log) in
        if flushed_to_vdi
        then debug "flushed database to metadata VDI: assuming this is sufficient."
        else begin

--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -113,7 +113,7 @@ let enable_database_replication ~__context ~vdi =
 			try
 				Redo_log.enable_block log ("/dev/" ^ device);
 				Redo_log.startup log;
-				Redo_log.flush_db_to_redo_log (Db_ref.get_database (Db_backend.make ()));
+				Redo_log.flush_db_to_redo_log (Db_ref.get_database (Db_backend.make ())) log;
 				Hashtbl.add metadata_replication vdi (vbd, log);
 				let vbd_uuid = Db.VBD.get_uuid ~__context ~self:vbd in
 				Db.VDI.set_metadata_latest ~__context ~self:vdi ~value:true;

--- a/ocaml/xapi/xha_metadata_vdi.ml
+++ b/ocaml/xapi/xha_metadata_vdi.ml
@@ -66,8 +66,8 @@ let deactivate_and_detach_existing ~__context =
 open Pervasiveext
 
 (** Attempt to flush the database to the metadata VDI *)
-let flush_database ~__context = 
+let flush_database ~__context log = 
   try
-    Redo_log.flush_db_to_redo_log (Db_ref.get_database (Db_backend.make ()));
+    Redo_log.flush_db_to_redo_log (Db_ref.get_database (Db_backend.make ())) log;
     true
   with _ -> false


### PR DESCRIPTION
Before this fix, Redo_log.database_callback would call Redo_log.flush_db_to_all_active_redo_logs when it needed to flush to a reconnected block device - the only problem being that both these functions called with_active_redo_logs which requires a mutex. This change fixes the issue, and I've also taken the opportunity to make the redo_log interface a bit more descriptive.
