### PR TITLE
XOP-49: Make sure we synchronise SR.local_cache_enabled with Host.local_cache_sr

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -542,6 +542,7 @@ let update_env __context sync_keys =
 	  try
 		  let cache_sr = Db.Host.get_local_cache_sr ~__context ~self:(Helpers.get_localhost ~__context) in
 		  let cache_sr_uuid = Db.SR.get_uuid ~__context ~self:cache_sr in
+		  Db.SR.set_local_cache_enabled ~__context ~self:cache_sr ~value:true;
 		  Monitor.set_cache_sr cache_sr_uuid
 	  with _ -> Monitor.unset_cache_sr () 
   end;


### PR DESCRIPTION
XOP-49: Make sure we synchronise SR.local_cache_enabled with Host.local_cache_sr

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
