### PR TITLE
CA-57530: host-evacuate filters hosts incorrectly by product version

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -232,8 +232,8 @@ let compute_evacuation_plan_no_wlb ~__context ~host =
 	then
 		begin
 			List.iter (fun (vm, _) ->
-				Hashtbl.add plans vm (Error (Api_errors.host_not_enough_free_memory, [ Ref.string_of vm ])))
-				all_user_vms;
+				Hashtbl.add plans vm (Error (Api_errors.no_hosts_available, [ Ref.string_of vm ])))
+				all_user_vms ;
 			plans
 		end
 	else


### PR DESCRIPTION
After inspecting CA-55221, which happened to be unrelated to host-evacuate, I found some areas where host-evacuate could be improved. This set of patches makes host-evacuate correct in light of PR-1007 (rolling pool upgrade), cleans up logging a bit, and logs a more sensible error message in the event that no hosts are available for evacuation due to version mismatches.
