### PR TITLE
[CA-57775] [BLOCKER] Repairs function "Helpers.host_versions_not_decreasing" so that it performs the correct comparison.

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -285,12 +285,8 @@ let host_has_highest_version_in_pool : __context:Context.t -> host:API.ref_host 
 		and max_version = max_version_in_pool ~__context in
 		(compare_int_lists host_version max_version) >= 0
 
-let host_versions_not_decreasing :
-		__context:Context.t -> host_from:API.ref_host -> host_to:API.ref_host -> bool =
-	fun ~__context ~host_from ~host_to ->
-		let from_version = version_of ~__context host_from
-		and to_version = version_of ~__context host_to in
-		(compare_int_lists from_version to_version) > 0
+let host_versions_not_decreasing ~__context ~host_from ~host_to =
+	compare_host_product_versions ~__context host_from host_to <= 0
 
 (* Assertion functions which raise an exception if certain invariants
    are broken during an upgrade. *)
@@ -307,7 +303,7 @@ let assert_host_has_highest_version_in_pool : __context:Context.t -> host:API.re
 let assert_host_versions_not_decreasing :
 		__context:Context.t -> host_from:API.ref_host -> host_to:API.ref_host -> unit =
 	fun ~__context ~host_from ~host_to ->
-		if host_versions_not_decreasing ~__context ~host_from ~host_to then
+		if not (host_versions_not_decreasing ~__context ~host_from ~host_to) then
 			raise (Api_errors.Server_error (Api_errors.not_supported_during_upgrade, []))
 
 (** Fetch the configuration the VM was booted with *)


### PR DESCRIPTION
[CA-57775] [BLOCKER] Repairs function "Helpers.host_versions_not_decreasing" so that it performs the correct comparison: (host_from <= host_to) rather than (host_from > host_to).

This change should fix pool rolling upgrade, which relies on Host.evacuate. (It's not currently possible to use Host.evacuate on a slave, during a pool rolling upgrade.)

I've tested the change with the following steps:
- Create a pool of three hosts from the previous release version.
- Install multiple VMs and start them on a slave.
- Upgrade the master to trunk.
- Check that VM.migrate works from slave to slave (it does).
- Check that VM.migrate works from slave to master (it does).
- Check that VM.migrate does not work from master to slave (it doesn't).
- Check that Host.get_vms_which_prevent_evacuation, when applied to a slave, returns with the empty set (it does).
- Check that Host.evacuate works when applied to a slave (it does).

Signed-off-by: Jonathan Knowles jonathan.knowles@eu.citrix.com
Acked-by: Mike McClurg mike.mcclurg@citrix.com
