### PR TITLE
CA-56957: fix bond/vlan/tunnel syncing on slave startup

### DIFF
--- a/ocaml/xapi/sync_networking.mli
+++ b/ocaml/xapi/sync_networking.mli
@@ -15,4 +15,6 @@
  * @group Main Loop and Start-up
  *)
 
-val sync_slave_with_master : __context:Context.t -> unit -> unit
+val copy_bonds_from_master : __context:Context.t -> unit -> unit
+val copy_vlans_from_master : __context:Context.t -> unit -> unit
+val copy_tunnels_from_master : __context:Context.t -> unit -> unit

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -875,7 +875,9 @@ let server_init() =
  
     Startup.run ~__context [
       "Checking emergency network reset", [], check_network_reset;
-      "Synchronising bonds/VLANs on slave with master", [], Sync_networking.sync_slave_with_master ~__context;
+      "Synchronising bonds on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_bonds_from_master ~__context;
+      "Synchronising VLANs on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_vlans_from_master ~__context;
+      "Synchronising tunnels on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_tunnels_from_master ~__context;
       "Initialise monitor configuration", [], Monitor_rrds.update_configuration_from_master;
       "Initialising licensing", [], handle_licensing;
       "control domain memory", [ Startup.OnThread ], control_domain_memory;


### PR DESCRIPTION
Wrapped bond, vlan and tunnel sync functions in separate startup
tasks to be more robust against connection loss due to the management
reconfiguration that may now happen as a result of bond.create calls.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
