### PR TITLE
[CA-56683] Update VDI.metadata_latest without the redo_log lock held.

### DIFF
--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -49,13 +49,12 @@ let metadata_replication_monitor ~__context =
 				(* Set each VDI's metadata_latest according to whether its redo_log is currently accessible. *)
 				Hashtbl.iter
 					(fun vdi (_, log) ->
-						Mutex.execute log.Redo_log.currently_accessible_mutex
-							(fun () ->
-								let accessible = !(log.Redo_log.currently_accessible) in
-								try
-									Db.VDI.set_metadata_latest ~__context ~self:vdi ~value:accessible
-								with e -> () (* Should only get here if the VDI ref stored in the hashtbl is invalid. *)
-							)
+						let accessible = Mutex.execute log.Redo_log.currently_accessible_mutex
+							(fun () -> !(log.Redo_log.currently_accessible))
+						in
+						try
+							Db.VDI.set_metadata_latest ~__context ~self:vdi ~value:accessible
+						with e -> () (* Should only get here if the VDI ref stored in the hashtbl is invalid. *)
 					)
 					metadata_replication
 			);


### PR DESCRIPTION
This is a temporary fix so that the issue is resolved for MS4 - a better
way of keeping VDI.metadata_latest updated will have to wait until after
MS4.
