### PR TITLE
Update xiu C code for GCC 4.5

### DIFF
--- a/ocaml/xiu/marshall.h
+++ b/ocaml/xiu/marshall.h
@@ -31,7 +31,8 @@ static int marshall_command(int handle, const char *fmt, ...)
 
 	if (ret > 255)
 		return -1;
-	write(handle, buf, ret);
+	if(write(handle, buf, ret) < ret)
+		return -1;
 	return 0;
 }
 

--- a/ocaml/xiu/xenctrl_xiu.c
+++ b/ocaml/xiu/xenctrl_xiu.c
@@ -46,7 +46,7 @@ static xc_osdep_handle xiu_privcmd_open(xc_interface *xch)
  	return XC_OSDEP_OPEN_ERROR;
     }
 
-    snprintf(remote.sun_path, 256, "%s-xc", s);
+    snprintf(remote.sun_path, sizeof(remote.sun_path), "%s-xc", s);
     remote.sun_family = AF_UNIX;
     len = strlen(remote.sun_path) + sizeof(remote.sun_family);
 
@@ -468,7 +468,7 @@ static xc_osdep_handle xiu_evtchn_open(xc_evtchn *xce)
  	ERROR(xce, "XIU not found. Set $XIU");
  	return XC_OSDEP_OPEN_ERROR;
     }
-	snprintf(remote.sun_path, 256, "%s-ev", s);
+	snprintf(remote.sun_path, sizeof(remote.sun_path), "%s-ev", s);
 	remote.sun_family = AF_UNIX;
 	len = strlen(remote.sun_path) + sizeof(remote.sun_family);
 


### PR DESCRIPTION
This is in support of our porting Xapi to Ubuntu/Debian. GCC 4.5 is more strict than 4.1, and some warnings have turned to errors. Also, we had included a magic number which apparently changed recently, and now we use sizeof instead of guessing.

This can definitely wait until after the beta is built.
