### PR TITLE
CA-56613

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -62,7 +62,7 @@ let get_chunks fd =
 		match unmarshal fd with
 			| Blob (Chunk len) ->
 				debug "Reading a chunk of %ld bytes" len;
-				let data = really_read fd (Int32.to_int len) in
+				let data = Unixext.really_read_string fd (Int32.to_int len) in
 				Buffer.add_string buffer data;
 				f()
 			| Blob End ->

--- a/ocaml/xapi/cli_util.ml
+++ b/ocaml/xapi/cli_util.ml
@@ -181,7 +181,7 @@ let user_says_yes fd =
   let response = match unmarshal fd with
     | Blob (Chunk len) ->
 	debug "Reading a chunk of %ld bytes" len;
-	really_read fd (Int32.to_int len)
+	Unixext.really_read_string fd (Int32.to_int len)
     | _ -> failwith "Protocol error"
   in
   begin match unmarshal fd with


### PR DESCRIPTION
This fix tries to address the disk-out-of-space issue as in CA-56613. It doesn't try to to smart things like log rotation or disk cleanup (which , I believe is up to the user to do, unless we could come up with some clever automatic solution), but simply makes best effort to gave a reasonable response back to xe CLI. API user (e.g. XenCenter) should be more careful with the possibility of getting HTTP500 when some server faults happen and propagate the errors (which is not the case for now).

The merge request of the same name in xapi-libs repo should get pulled together with this one.
