### PR TITLE
CA-58406: Do not update MAC addresses of non-physical PIFs

### DIFF
--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -44,11 +44,12 @@ let refresh_internal ~__context ~self =
 				end)
 			(Opt.of_exception (fun () -> get_value device)) in
 
-	maybe_update_database "MAC"
-		(Db.PIF.get_MAC)
-		(Db.PIF.set_MAC)
-		(Netdev.get_address)
-		(id);
+	if Db.PIF.get_physical ~__context ~self then
+		maybe_update_database "MAC"
+			(Db.PIF.get_MAC)
+			(Db.PIF.set_MAC)
+			(Netdev.get_address)
+			(id);
 	maybe_update_database "MTU"
 		(Db.PIF.get_MTU)
 		(Db.PIF.set_MTU)


### PR DESCRIPTION
MAC addresses of PIFs are synchronised with dom0 when xapi starts
to allow NICs to be replaced. Currently, xapi updates _all_ PIFs,
include bond and VLAN PIFs, which are not actual NICs. The MACs of
these non-physical NICs should not be updated. Especially in the
case of bond PIFs, as when the user creates a NIC bond, they are free
to choose any MAC they want, even if there is no NIC with a corresponding
MAC address in the system.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
