### PR TITLE
CA-54553: if the SM backend fails to emit valid XML, package this up as a

### DIFF
--- a/scripts/log.conf
+++ b/scripts/log.conf
@@ -16,7 +16,7 @@ debug;server_io;nil
 debug;server_helpers;nil
 #debug;taskhelper;nil
 #debug;dummytaskhelper;nil
-debug;sm_exec;nil
+#debug;sm_exec;nil
 debug;stunnel;nil
 debug;stunnel_cache;nil
 debug;remote_requests;nil


### PR DESCRIPTION
CA-54553: if the SM backend fails to emit valid XML, package this up as an SR_BACKEND_FAILURE

Previously this was a non-descript Xml.Error(_)

Signed-off-by: David Scott dave.scott@eu.citrix.com
