### PR TITLE
CP-2257: fix use of uninitialised variable error.

### DIFF
--- a/ocaml/xenguest/xenguest_stubs.c
+++ b/ocaml/xenguest/xenguest_stubs.c
@@ -132,7 +132,7 @@ static uint64_t
 xenstore_get(int domid, const char *fmt, ...)
 {
 	char *s;
-	uint64_t value;
+	uint64_t value = 0;
 	va_list ap;
 
 	va_start(ap, fmt);


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@eu.citrix.com
