### PR TITLE
CA-58318: Reduce RHEL template max-memory to Red Hat-limited 8GiB

### DIFF
--- a/ocaml/xapi/create_templates.ml
+++ b/ocaml/xapi/create_templates.ml
@@ -442,7 +442,7 @@ let oracle_template name architecture ?(is_experimental=false) flags =
 
 let rhel6x_template name architecture ?(is_experimental=false) flags =
 	let maximum_supported_memory_gib = match architecture with
-		| X32 -> 16
+		| X32 -> 8
 		| X64 -> 32
 		| X64_sol | X64_debianlike -> assert false
 	in


### PR DESCRIPTION
Red Hat set CONFIG_XEN_MAX_DOMAIN_MEMORY=8 in their kernel config, so that's the max we can support for them as well.

I don't believe this needs to make it into beta2, but the risk for this patch is nil so it shouldn't matter either way.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
