### PR TITLE
CA-59029: When calling sr_delete, the SM backends expect the SR to be attached and PBD.currently_attached=true

### DIFF
--- a/ocaml/xapi/storage_access.mli
+++ b/ocaml/xapi/storage_access.mli
@@ -71,3 +71,6 @@ val diagnostics: __context:Context.t -> string
 
 (** [dp_destroy __context dp allow_leak] attempts to cleanup and detach a given DP *)
 val dp_destroy: __context:Context.t -> string -> bool -> unit
+
+(** [destroy_sr __context sr] attempts to cleanup and destroy a given SR *)
+val destroy_sr: __context:Context.t -> sr:API.ref_SR -> unit

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -115,7 +115,7 @@ module Debug_print_impl = struct
 		let attach context ~task ~sr =
 			info "SR.attach sr:%s" sr;
 			Success Unit
-		let detach context ~task ~sr =
+		let fail_if_anything_leaked () = 
 			Mutex.execute VDI.m
 				(fun () ->
 					Hashtbl.iter
@@ -128,8 +128,14 @@ module Debug_print_impl = struct
 							error "leaked activate: %s" k;
 							inc_errors ();
 						) VDI.activated
-				);
+				)
+		let detach context ~task ~sr =
 			info "SR.detach sr:%s" sr;
+			fail_if_anything_leaked ();
+			Success Unit
+		let destroy context ~task ~sr =
+			info "SR.destroy sr:%s" sr;
+			fail_if_anything_leaked (); 
 			Success Unit
 	end
 

--- a/ocaml/xapi/storage_interface.ml
+++ b/ocaml/xapi/storage_interface.ml
@@ -95,6 +95,11 @@ module SR = struct
 		or VDI.deactivate. *)
     external detach : task:task -> sr:sr -> result = ""
 
+	(** [destroy sr]: destroys (i.e. makes unattachable and unprobeable) the [sr],
+		first detaching and/or deactivating any active VDIs. This may fail with 
+		Sr_not_attached, or any error from VDI.detach or VDI.deactivate. *)
+	external destroy : task:task -> sr:sr -> result = ""
+
 	(** [list task] returns the list of currently attached SRs *)
 	external list: task:task -> sr list = ""
 end


### PR DESCRIPTION
CA-59029: When calling sr_delete, the SM backends expect the SR to be attached _and_ the PBD.currently_attached=true

In the storage interface, add SR.destroy and make it act the same way as SR.detach, except calling the underlying destroy function instead of the attach function. This means that it will also try to clean up any attached/activated VDIs before continuing.

It's not ideal that PBD.currently_attached=true because it's possible for other API calls to come in and touch the storage that we're about to delete.

Signed-off-by: David Scott dave.scott@eu.citrix.com
