### PR TITLE
CA-58213: make pif-reconfigure-ip handle stunnels better

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -73,12 +73,10 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
 
 			reconfigure_pif ~__context pif args;
 
-			if management_interface then begin
-				warn "About to kill cached stunnels and the master database connection";
-				(* The master_connection would otherwise try to take a broken stunnel from the cache *)
-				Stunnel_cache.flush (); 
-				Master_connection.force_connection_reset ()
-			end;
+			warn "About to kill cached stunnels and the master database connection";
+			(* The master_connection would otherwise try to take a broken stunnel from the cache *)
+			Stunnel_cache.flush ();
+			Master_connection.force_connection_reset ();
 
 			Db.PIF.set_currently_attached ~__context ~self:pif ~value:true;
 			if Db.PIF.get_management ~__context ~self:pif then begin


### PR DESCRIPTION
pif-reconfigure-ip now flushes stunnels and resets the master
connection for all interfaces, not just management interfaces.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
Acked-by: Jonathan Knowles jonathan.knowles@eu.citrix.com
Acked-by: Dave Scott dave.scott@eu.citrix.com
