### PR TITLE
To ensure backwards compatability, continue to use deprecated linux-speci

### DIFF
--- a/ocaml/xenops/device_number.ml
+++ b/ocaml/xenops/device_number.ml
@@ -139,7 +139,7 @@ let to_disk_number = function
 	| Ide(disk, _) -> disk
 
 let of_disk_number hvm n = 
-	if hvm && (n < 4)
+	if hvm && (n < 16)
 	then Ide(n, 0)
 	else Xen(n, 0)
 


### PR DESCRIPTION
WARNING: this has had insufficient devtest, I need to complete before merging!

To ensure backwards compatability, continue to use deprecated linux-specific encodings for the first 16 disks of HVM guests.

Ideally we would comply with the non-deprecated parts of the vbd-interface.txt in xen-4.1. However we have been using the linux-specific IDE encodings (hde..hdp) up until now; we will preserve this behaviour.

Note that the exact presentation to the guest depends on the behaviour of the PV drivers and the OS. In the case of Windows, the primary means of identifying disks is actually the volume label so even if devices got permuted on the IDE/xen bus it wouldn't matter.

Signed-off-by: David Scott dave.scott@eu.citrix.com
