### PR TITLE
[DR] Allow storage sessions to set VDI.metadata_of_pool

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4924,6 +4924,17 @@ let vdi_set_snapshot_time = call
 	~allowed_roles:_R_VM_ADMIN
 	()
 
+let vdi_set_metadata_of_pool = call
+	~name:"set_metadata_of_pool"
+	~in_oss_since:None
+	~in_product_since:rel_boston
+	~params:[Ref _vdi, "self", "The VDI to modify";
+		Ref _pool, "value", "The pool whose metadata is contained by this VDI"]
+	~flags:[`Session]
+	~doc:"Records the pool whose metadata is contained by this VDI."
+	~allowed_roles:_R_VM_ADMIN
+	()
+
 (** An API call for debugging and testing only *)
 let vdi_generate_config = call
    ~name:"generate_config"
@@ -5038,6 +5049,7 @@ let vdi =
 		 vdi_set_is_a_snapshot;
 		 vdi_set_snapshot_of;
 		 vdi_set_snapshot_time;
+		 vdi_set_metadata_of_pool;
 		 vdi_set_name_label;
 		 vdi_set_name_description;
 		 vdi_generate_config;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2906,6 +2906,11 @@ end
 			Sm.assert_session_has_internal_sr_access ~__context ~sr;
 			Local.VDI.set_snapshot_time ~__context ~self ~value
 
+		let set_metadata_of_pool ~__context ~self ~value =
+			let sr = Db.VDI.get_SR ~__context ~self in
+			Sm.assert_session_has_internal_sr_access ~__context ~sr;
+			Local.VDI.set_metadata_of_pool ~__context ~self ~value
+
 		let set_name_label ~__context ~self ~value =
 			info "VDI.set_name_label: VDI = '%s' name-label = '%s'"
 				(vdi_uuid ~__context self) value;

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -543,6 +543,9 @@ let set_snapshot_of ~__context ~self ~value =
 let set_snapshot_time ~__context ~self ~value =
 	Db.VDI.set_snapshot_time ~__context ~self ~value
 
+let set_metadata_of_pool ~__context ~self ~value =
+	Db.VDI.set_metadata_of_pool ~__context ~self ~value
+
 let set_on_boot ~__context ~self ~value =
 	let sr = Db.VDI.get_SR ~__context ~self in
 	let ty = Db.SR.get_type ~__context ~self:sr in


### PR DESCRIPTION
This is required so that the storage backend can update
VDI.metadata_of_pool after it introduces new VDIs.
