### PR TITLE
Move metadata VDI handling code into message_forwarding

### DIFF
--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -159,7 +159,8 @@ let scan_finished sr =
        Hashtbl.remove scans_in_progress sr)
 
 (* Perform a single scan of an SR in a background thread. Limit to one thread per SR *)
-let scan_one ~__context sr = 
+(* If a callback is supplied, call it once the scan is complete. *)
+let scan_one ~__context ?callback sr =
 	if i_should_scan_sr sr
 	then 
 		ignore(Thread.create
@@ -177,7 +178,8 @@ let scan_one ~__context sr =
 								error "Caught exception attempting an SR.scan: %s" (ExnHelper.string_of_exn e)
 						)
 						(fun () -> 
-							scan_finished sr)
+							scan_finished sr;
+							Opt.iter (fun f -> f ()) callback)
 					)) ())
 
 let get_all_plugged_srs ~__context =

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -544,23 +544,7 @@ let set_snapshot_time ~__context ~self ~value =
 	Db.VDI.set_snapshot_time ~__context ~self ~value
 
 let set_metadata_of_pool ~__context ~self ~value =
-	Db.VDI.set_metadata_of_pool ~__context ~self ~value;
-	(* If storage has introduced a metadata VDI record, we need to deal with it accordingly. *)
-	let pool = Helpers.get_pool ~__context in
-	let vdi_uuid = Db.VDI.get_uuid ~__context ~self in
-	if value = pool then begin
-		(* Restart database replication if the VDI was created by this pool. *)
-		try
-			Xapi_vdi_helpers.enable_database_replication ~__context ~vdi:self;
-			debug "Re-enabled database replication to VDI %s" vdi_uuid
-		with e ->
-			debug "Could not re-enable database replication to VDI %s - caught %s"
-				vdi_uuid (Printexc.to_string e)
-	end else if value <> Ref.null then begin
-		(* Cache the pool UUID and database generation count if the VDI was created by foreign pool. *)
-		debug "Adding VDI %s to foreign database VDI cache" vdi_uuid;
-		Xapi_dr.add_vdis_to_cache ~__context ~vdis:[self]
-	end
+	Db.VDI.set_metadata_of_pool ~__context ~self ~value
 
 let set_on_boot ~__context ~self ~value =
 	let sr = Db.VDI.get_SR ~__context ~self in


### PR DESCRIPTION
When a PBD is plugged for a new SR, it has not yet been scanned so
VDIs aren't present in the database - because of this, the code for
handling metadata VDIs is now passed as a callback into Xapi_sr.scan_one
so that it runs after the scan is complete.
