### PR TITLE
[CA-57401] Allow pool admin to recover VMs.

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1267,10 +1267,7 @@ let assert_can_be_recovered ~__context ~self ~session_to =
 	Xapi_vm_helpers.assert_can_be_recovered ~__context ~self ~session_to
 
 let recover ~__context ~self ~session_to ~force =
-	Server_helpers.exec_with_new_task ~session_id:session_to "Checking pool license allows DR"
-		(fun __context_to ->
-			if (not (Pool_features.is_enabled ~__context:__context_to Features.DR)) then
-				raise (Api_errors.Server_error(Api_errors.license_restriction, [])));
+	Xapi_dr.assert_session_allows_dr ~session_id:session_to ~action:"VM.recover";
 	(* Check the VM SRs are available. *)
 	assert_can_be_recovered ~__context ~self ~session_to;
 	(* Attempt to recover the VM. *)

--- a/ocaml/xapi/xapi_vm_appliance.ml
+++ b/ocaml/xapi/xapi_vm_appliance.ml
@@ -171,10 +171,7 @@ let assert_can_be_recovered ~__context ~self ~session_to =
 		vms
 
 let recover ~__context ~self ~session_to ~force =
-	Server_helpers.exec_with_new_task ~session_id:session_to "Checking pool license allows DR"
-		(fun __context_to ->
-			if (not (Pool_features.is_enabled ~__context:__context_to Features.DR)) then
-				raise (Api_errors.Server_error(Api_errors.license_restriction, [])));
+	Xapi_dr.assert_session_allows_dr ~session_id:session_to ~action:"VM_appliance.recover";
 	assert_can_be_recovered ~__context ~self ~session_to;
 	let vms = Db.VM_appliance.get_VMs ~__context ~self in
 	let recovered_vms = Xapi_dr.recover_vms ~__context ~vms ~session_to ~force in


### PR DESCRIPTION
Add the function Xapi_dr.assert_session_allows_dr

VM.recover and VM_appliance.recover take two session as arguments - the
first session only requires read-only permissions as it will typically
be a session returned from VDI.open_database.

The second session must have permissions of at least pool-operator level
- to assert this we check that the session has permission to call
  VDI.open_database.

Previously xapi would check that the session had the pool-operator
permission, however pool-admin sessions do not have this permission so
would fail the assertion.
