### PR TITLE
Update XenAPI.py for Python 2.7 (still 2.4 compatible)

### DIFF
--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -48,6 +48,7 @@ import gettext
 import xmlrpclib
 import httplib
 import socket
+import sys
 
 translation = gettext.translation('xen-xm', fallback = True)
 
@@ -85,17 +86,22 @@ class UDSHTTP(httplib.HTTP):
 
 class UDSTransport(xmlrpclib.Transport):
     def __init__(self, use_datetime=0):
+        xmlrpclib.Transport.__init__(self, use_datetime)
         self._use_datetime = use_datetime
         self._extra_headers=[]
     def add_extra_header(self, key, value):
         self._extra_headers += [ (key,value) ]
     def make_connection(self, host):
-        return UDSHTTP(host)
+        # Python 2.4 compatibility
+        if sys.version_info[0] <= 2 and sys.version_info[1] < 6:
+            return UDSHTTP(host)
+        else:
+            return UDSHTTPConnection(host)
     def send_request(self, connection, handler, request_body):
         connection.putrequest("POST", handler)
         for key, value in self._extra_headers:
             connection.putheader(key, value)
-        
+
 class Session(xmlrpclib.ServerProxy):
     """A server proxy and session manager for communicating with xapi using
     the Xen-API.


### PR DESCRIPTION
This is for Ubuntu dom0, and is pretty low-risk.
