### PR TITLE
Don't hardcode stunnel filepath

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -14,6 +14,7 @@
 PEMFILE="/etc/xensource/xapi-ssl.pem"
 SSLPIDFILE="/var/run/xapissl.pid"
 SSLCONFFILE="/var/xapi/xapi-ssl.conf"
+STUNNEL=$(which stunnel)
 
 mgmt_ip() {
     . /etc/xensource-inventory
@@ -88,7 +89,7 @@ start() {
 	if test -z "$NEWSTUNNEL"
 	then
 		writeconffile
-		daemon nice -n -3 /usr/sbin/stunnel ${SSLCONFFILE}
+		daemon nice -n -3 ${STUNNEL} ${SSLCONFFILE}
 	else
 		daemon nice -n -3 /usr/sbin/stunnelng -m server -p ${SSLPIDFILE} -c ${PEMFILE} -s :443 -d 127.0.0.1:80
 	fi


### PR DESCRIPTION
Debian systems place stunnel in /usr/bin, but we had been assuming that it was
in /usr/sbin. Now we check `which stunnel` before calling it.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
