### PR TITLE
CA-54145: xapi doesn't store passed in name_label for VDI snapshot.

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -332,7 +332,6 @@ let snapshot ~__context ~vdi ~driver_params =
 	let newvdi = Db.VDI.get_by_uuid ~__context ~uuid in
 
 	(* Copy across the metadata which we control *)
-	Db.VDI.set_name_label ~__context ~self:newvdi ~value:a.Db_actions.vDI_name_label;
 	Db.VDI.set_name_description ~__context ~self:newvdi ~value:a.Db_actions.vDI_name_description;
 	Db.VDI.set_type ~__context ~self:newvdi ~value:a.Db_actions.vDI_type;
 	Db.VDI.set_sharable ~__context ~self:newvdi ~value:a.Db_actions.vDI_sharable;


### PR DESCRIPTION
The first commit is a whitespace change only. Here's the proof:

```
git checkout 629317c9f59e1e39b878f40f6ff5a2cfb427705a
~/myrepos/xen-api$ camlp4 -parser o -printer o -no_comments ocaml/xapi/xapi_vdi.ml | md5sum
3e06ccd9461aecfd0c19daf8645a564c  -
git checkout f5a8c5edbc05608d0b44834e63b5d394bf72f39a
~/myrepos/xen-api$ camlp4 -parser o -printer o -no_comments ocaml/xapi/xapi_vdi.ml | md5sum
3e06ccd9461aecfd0c19daf8645a564c  -
```

The second commit removes the line that sets the `name_label` metadata --- `xapi` does not own the `name_label` and should therefore not be setting it.

Note that this does not close the corresponding ticket (CA-54145) yet, since we still need to confirm with the storage team that appending `.snap` to the `name_label` is actually desired.

Signed-off-by: Rok Strnisa rok.strnisa@citrix.com
