### PR TITLE
CA-58613: Fix Bond.create when CHINs are in use.

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -111,9 +111,7 @@ let bring_pif_down ~__context (pif: API.ref_PIF) =
 	with_local_lock (fun () ->
 		(* Check that the PIF is not in-use *)
 		let uuid = Db.PIF.get_uuid ~__context ~self:pif in
-		let network = Db.PIF.get_network ~__context ~self:pif in
-		Xapi_network_attach_helpers.assert_network_has_no_vifs_in_use_on_me ~__context ~host:(Helpers.get_localhost ~__context) ~network;
-		Xapi_network_attach_helpers.assert_pif_disallow_unplug_not_set ~__context pif;
+
 		if Db.PIF.get_currently_attached ~__context ~self:pif = true then begin
 			debug "PIF %s has currently_attached set to true; bringing down now" uuid;
 			reconfigure_pif ~__context pif [ "down" ];

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -123,8 +123,6 @@ let move_tunnel ~__context host new_transport_PIF old_tunnel =
 	let old_access_PIF = Db.Tunnel.get_access_PIF ~__context ~self:old_tunnel in
 	let network = Db.PIF.get_network ~__context ~self:old_access_PIF in
 	let plugged = Db.PIF.get_currently_attached ~__context ~self:old_access_PIF in
-	if plugged then
-		Nm.bring_pif_down ~__context old_access_PIF;
 
 	(* Create new tunnel object and access PIF *)
 	let new_tunnel, new_access_PIF =
@@ -133,7 +131,8 @@ let move_tunnel ~__context host new_transport_PIF old_tunnel =
 
 	(* Destroy old VLAN and VLAN-master objects *)
 	debug "Destroying old tunnel %s" (Ref.string_of old_tunnel);
-	Xapi_tunnel.destroy ~__context ~self:old_tunnel;
+	Db.Tunnel.destroy ~__context ~self:old_tunnel;
+	Db.PIF.destroy ~__context ~self:old_access_PIF;
 
 	(* Plug again if plugged before the move *)
 	if plugged then begin

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -563,6 +563,10 @@ let rec unplug ~__context ~self =
 	if Db.Host.get_enabled ~__context ~self:host
 	then abort_if_network_attached_to_protected_vms ~__context ~self;
 
+	let network = Db.PIF.get_network ~__context ~self in
+	Xapi_network_attach_helpers.assert_network_has_no_vifs_in_use_on_me ~__context ~host:(Helpers.get_localhost ~__context) ~network;
+	Xapi_network_attach_helpers.assert_pif_disallow_unplug_not_set ~__context self;
+
 	let tunnel = Db.PIF.get_tunnel_transport_PIF_of ~__context ~self in
 	if tunnel <> []
 	then begin

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -79,7 +79,7 @@ let destroy ~__context ~self =
 		let network = Db.PIF.get_network ~__context ~self:untagged_PIF in
 		let bridge = Db.Network.get_bridge ~__context ~self:network in
 
-		Nm.bring_pif_down ~__context untagged_PIF;
+		Xapi_pif.unplug ~__context ~self:untagged_PIF;
 
 		Xapi_network.detach bridge;
 


### PR DESCRIPTION
Creating a bond was tripping over an assert in Nm.bring_pif_down. We move to the convention that the outermost functions (ie PIF.unplug -> Xapi_pif.unplug) are responsible for running the asserts, which the inner functions (Nm.bring_pif_down) "just do it".

Signed-off-by: David Scott dave.scott@eu.citrix.com
Signed-off-by: Rob Hoes rob.hoes@eu.citrix.com
