### PR TITLE
CA-54145: xapi doesn't store passed in name_label for VDI snapshot.

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -332,12 +332,8 @@ let snapshot ~__context ~vdi ~driver_params =
 	let newvdi = Db.VDI.get_by_uuid ~__context ~uuid in
 
 	(* Copy across the metadata which we control *)
-	Db.VDI.set_name_label ~__context ~self:newvdi ~value:a.Db_actions.vDI_name_label;
-	Db.VDI.set_name_description ~__context ~self:newvdi ~value:a.Db_actions.vDI_name_description;
-	Db.VDI.set_type ~__context ~self:newvdi ~value:a.Db_actions.vDI_type;
 	Db.VDI.set_sharable ~__context ~self:newvdi ~value:a.Db_actions.vDI_sharable;
 	Db.VDI.set_other_config ~__context ~self:newvdi ~value:a.Db_actions.vDI_other_config;
-	Db.VDI.set_xenstore_data ~__context ~self:newvdi ~value:a.Db_actions.vDI_xenstore_data;
 	Db.VDI.set_on_boot ~__context ~self:newvdi ~value:a.Db_actions.vDI_on_boot;
 	Db.VDI.set_allow_caching ~__context ~self:newvdi ~value:a.Db_actions.vDI_allow_caching;
 
@@ -347,9 +343,6 @@ let snapshot ~__context ~vdi ~driver_params =
 	  (try Db.VDI.remove_from_other_config ~__context ~self:newvdi ~key:Xapi_globs.snapshot_time with _ -> ());
 	  Db.VDI.add_to_other_config ~__context ~self:newvdi ~key:Xapi_globs.snapshot_of ~value:a.Db_actions.vDI_uuid;
 	  Db.VDI.add_to_other_config ~__context ~self:newvdi ~key:Xapi_globs.snapshot_time ~value:(Date.to_string (Date.of_float (Unix.gettimeofday ())));*)
-	Db.VDI.set_is_a_snapshot ~__context ~self:newvdi ~value:true;
-	Db.VDI.set_snapshot_of ~__context ~self:newvdi ~value:(Db.VDI.get_by_uuid ~__context ~uuid:a.Db_actions.vDI_uuid);
-	Db.VDI.set_snapshot_time ~__context ~self:newvdi ~value:(Date.of_float (Unix.gettimeofday ()));
 
 	update_allowed_operations ~__context ~self:newvdi;
 	update ~__context ~vdi:newvdi;


### PR DESCRIPTION
The first commit is a whitespace change only. Here's the proof:

```
git checkout 629317c9f59e1e39b878f40f6ff5a2cfb427705a
~/myrepos/xen-api$ camlp4 -parser o -printer o -no_comments ocaml/xapi/xapi_vdi.ml | md5sum
3e06ccd9461aecfd0c19daf8645a564c  -
git checkout f5a8c5edbc05608d0b44834e63b5d394bf72f39a
~/myrepos/xen-api$ camlp4 -parser o -printer o -no_comments ocaml/xapi/xapi_vdi.ml | md5sum
3e06ccd9461aecfd0c19daf8645a564c  -
```

The second commit removes the lines that set the metadata of fields now owned by the storage backend --- `xapi` does not own these fields any more and should therefore not be setting them. See [PR-1223](http://tinyurl.com/638alc2) for details.

Note that this does not close the corresponding ticket (CA-54145) yet, since we still need to confirm with the storage team that appending .snap to the name_label is actually desired.

Signed-off-by: Rok Strnisa rok.strnisa@citrix.com
