### PR TITLE
[CA-61117] Disallow conversion of appliance VMs to templates.

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1078,7 +1078,7 @@ let _ =
 		~doc:"The disaster recovery task could not be cleanly destroyed." ();
 
 	error Api_errors.vm_is_part_of_an_appliance ["vm"; "appliance"]
-		~doc:"The VM cannot be recovered on its own as it is part of a VM appliance." ();
+		~doc:"This operation is not allowed as the VM is part of an appliance." ();
 
 	error Api_errors.vm_to_import_is_not_newer_version ["vm"; "existing_version"; "version_to_import"]
 		~doc:"The VM cannot be imported unforced because it is either the same version or an older version of an existing VM." ()

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -87,6 +87,10 @@ let validate_basic_parameters ~__context ~self ~snapshot:x =
 let set_actions_after_crash ~__context ~self ~value = 
 	Db.VM.set_actions_after_crash ~__context ~self ~value
 let set_is_a_template ~__context ~self ~value =
+	let appliance = Db.VM.get_appliance ~__context ~self in
+	if Db.is_valid_ref __context appliance then
+		raise (Api_errors.Server_error(Api_errors.vm_is_part_of_an_appliance,
+			[(Ref.string_of self); (Ref.string_of appliance)]));
 	(* We define a 'set_is_a_template false' as 'install time' *)
 	info "VM.set_is_a_template('%b')" value;
 	let m = Db.VM.get_metrics ~__context ~self in


### PR DESCRIPTION
Since we do not allow templates to be added to appliances, for
consistency we should not allow VMs to be converted into templates while
they are in an appliance.
