### PR TITLE
CA-58362: Host is not getting upgraded while performing Automatic upgrade

### DIFF
--- a/scripts/examples/python/XenAPIPlugin.py
+++ b/scripts/examples/python/XenAPIPlugin.py
@@ -37,7 +37,7 @@ def dispatch(fn_table):
             # SystemExit should not be caught, as it is handled elsewhere in the plugin system.
             raise
         except Exception, e:
-            print failure_message(['XENAPI_PLUGIN_EXCEPTION',
+            print failure_message(['XENAPI_PLUGIN_FAILURE',
                                    methodname, e.__class__.__name__, str(e)])
     else:
         print failure_message(['UNKNOWN_XENAPI_PLUGIN_FUNCTION', methodname])


### PR DESCRIPTION
CA-58362: Host is not getting upgraded while performing Automatic upgrade through Rolling Pool Upgrade wizard

At the moment, XAPI plugins are throwing non-standardised exceptions, all of
which are caught by the XAPI plugin manager, which throws a single kind of
exception.

When a XAPI plugin threw a non-"SystemExit" exception, `XenAPIPlugin.py` would
rpcdump an exception message with error string `XENAPI_PLUGIN_EXCEPTION`;
however, this string is not a standard error string --- it appears that this
was a typo, since the string should have been `XENAPI_PLUGIN_FAILURE`. This
commit fixes this.

It appears that with a wrong error string rcpdump-ed, XenCenter would ignore
it altogether, making it seem that everything went ok.

A potential future improvement would be to modify XAPI plugins to throw
standardised errors, which would then be propagaded outside XAPI plugin
manager.

Signed-off-by: Rok Strnisa rok.strnisa@citrix.com
