### PR TITLE
CA-60507: explicitly block pool.join when there is no management interfac

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -604,7 +604,7 @@ let _ =
   error Api_errors.host_its_own_slave []
     ~doc:"The host is its own slave. Please use pool-emergency-transition-to-master or pool-emergency-reset-master." ();
   error Api_errors.host_still_booting []
-    ~doc:"The host is still booting." ();
+    ~doc:"The host toolstack is still initialising. Please wait." ();
   error Api_errors.host_has_no_management_ip []
     ~doc:"The host failed to acquire an IP address on its management interface and therefore cannot contact the master." ();
   error Api_errors.host_name_invalid [ "reason" ]


### PR DESCRIPTION
CA-60507: explicitly block pool.join when there is no management interface PIF

If we allow pool.join under these circumstances then pool.eject fails to work properly. As a side-effect of this, due to the firstboot ordering, it won't be possible to join a pool before your storage is setup.

Signed-off-by: David Scott dave.scott@eu.citrix.com
