### PR TITLE
[CA-56359] Mark ignore_foreign_key fields as persistent.

### DIFF
--- a/ocaml/idl/datamodel_schema.ml
+++ b/ocaml/idl/datamodel_schema.ml
@@ -33,7 +33,7 @@ let of_datamodel () =
 		{
 			Column.name = Escaping.escape_id f.Datamodel_types.full_name;
 			(* NB we always regenerate one-to-many Set(Ref _) fields *)
-			persistent = f.Datamodel_types.field_persist && (is_many_to_many f || not issetref);
+			persistent = f.Datamodel_types.field_persist && (is_many_to_many f || not issetref || f.Datamodel_types.field_ignore_foreign_key);
 			empty = Datamodel_values.gen_empty_db_val f.Datamodel_types.ty;
 			(* NB Set(Ref _) fields aren't allowed to have a default value specified so we hardcode one here *)
 			default = 


### PR DESCRIPTION
When first populating its in-memory database, for each one-to-many
relationship xapi clears the field which is a set of references (i.e.
at the "one" end of the relationship) and regenerates these fields from
the "many" end of the relationship.

In the case of the role-subject relationship this fails, as there is no
Role.subject field with which to repopulate the Subject.roles field.

This change means that xapi no longer empties fields which are reference
sets if the field has ignore_foreign_key=true.
