### PR TITLE
CA-61491: The VM resume could not be performed on this host, because it has a different (incompatible) product version to the pool's master.

### DIFF
--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -355,8 +355,6 @@ let assert_can_boot_here_common
 		~__context ~self ~host ~snapshot do_memory_check =
 	(* Check to see if the VM is obviously malformed *)
 	validate_basic_parameters ~__context ~self ~snapshot;
-	(* Check if host's product version is compatible with master's. *)
-	Helpers.assert_product_version_is_same_on_master ~__context ~host ~self;
 	(* Check host is live *)
 	assert_host_is_live ~__context ~host;
 	(* Check host is enabled *)


### PR DESCRIPTION
Revert the patch for CA-59780 ([pull request 228](https://github.com/xen-org/xen-api/pull/228)), since it disallows migration from a non-upgraded slave to another, an operation required by the XenRT test that corresponds to this ticket.

Signed-off-by: Rok Strnisa rok.strnisa@citrix.com
