### PR TITLE
CA-58398: new slave should reuse chipset_info from its pre-pool host reco

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3516,6 +3516,7 @@ let host_create_params =
     {param_type=String; param_name="edition"; param_doc="XenServer edition"; param_release=midnight_ride_release; param_default=Some(VString "")};
     {param_type=Map(String,String); param_name="license_server"; param_doc="Contact information of the license server"; param_release=midnight_ride_release; param_default=Some(VMap [VString "address", VString "localhost"; VString "port", VString "27000"])};
     {param_type=Ref _sr; param_name="local_cache_sr"; param_doc="The SR that is used as a local cache"; param_release=cowley_release; param_default=(Some (VRef (Ref.string_of Ref.null)))};
+    {param_type=Map(String,String); param_name="chipset_info"; param_doc="Information about chipset features"; param_release=boston_release; param_default=Some(VMap [])};
   ]
 
 let host_create = call

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -48,7 +48,7 @@ let create_localhost ~__context info =
 	~hostname:info.hostname ~address:ip 
 	~external_auth_type:"" ~external_auth_service_name:"" ~external_auth_configuration:[] 
 	~license_params:[] ~edition:"free" ~license_server:["address", "localhost"; "port", "27000"]
-	~local_cache_sr:Ref.null
+	~local_cache_sr:Ref.null ~chipset_info:[]
     in ()		
 
 (* TODO cat /proc/stat for btime ? *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -571,7 +571,7 @@ let is_host_alive ~__context ~host =
 	false
   end
 
-let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr =
+let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info =
 
   let make_new_metrics_object ref =
 	Db.Host_metrics.create ~__context ~ref
@@ -595,7 +595,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
 	~capabilities:[]
 	~cpu_configuration:[]   (* !!! FIXME hard coding *)
 	~cpu_info:[]
-	~chipset_info:[]
+	~chipset_info
 	~memory_overhead:0L
 	~sched_policy:"credit"  (* !!! FIXME hard coding *)
 	~supported_bootloaders:(List.map fst Xapi_globs.supported_bootloaders)

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -86,6 +86,7 @@ val create :
   edition:string ->
   license_server:(string * string) list ->
   local_cache_sr:[ `SR ] Ref.t ->
+  chipset_info:(string * string) list ->
   [ `host ] Ref.t
 val destroy : __context:Context.t -> self:API.ref_host -> unit
 val ha_disable_failover_decisions : __context:'a -> host:'b -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -337,6 +337,7 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
 				 * we need an alternative way of preserving the value of the local_cache_sr field, so it's
 				 * been added to the constructor. *)
 				~local_cache_sr
+        ~chipset_info:host.API.host_chipset_info
 			in
 
 			(* Copy other-config into newly created host record: *)

--- a/ocaml/xapi/xapi_test_common.ml
+++ b/ocaml/xapi/xapi_test_common.ml
@@ -65,9 +65,9 @@ let make_vm ~__context ?(name_label="name_label") ?(name_description="descriptio
 let make_host ~__context ?(uuid=Uuid.string_of_uuid (Uuid.make_uuid ())) ?(name_label="host")
 		?(name_description="description") ?(hostname="localhost") ?(address="127.0.0.1")
 		?(external_auth_type="") ?(external_auth_service_name="") ?(external_auth_configuration=[])
-		?(license_params=[]) ?(edition="free") ?(license_server=[]) ?(local_cache_sr=Ref.null) () = 
+		?(license_params=[]) ?(edition="free") ?(license_server=[]) ?(local_cache_sr=Ref.null) ?(chipset_info=[]) () = 
 
-	Xapi_host.create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr
+	Xapi_host.create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info
 
 let make_pif ~__context ~network ~host ?(device="eth0") ?(mAC="C0:FF:EE:C0:FF:EE") ?(mTU=1500L)
 		?(vLAN=(-1L)) ?(physical=true) ?(ip_configuration_mode=`None) ?(iP="") ?(netmask="")


### PR DESCRIPTION
CA-58398: new slave should reuse chipset_info from its pre-pool host record

Signed-off-by: Marcus Granado marcus.granado@citrix.com
