### PR TITLE
[CA-61336] Prevent redo_log from skipping non-consecutive deltas.

### DIFF
--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -206,7 +206,7 @@ let length_size = 16
    Set to true if we prefer consistency over completeness/up-to-dateness.
    Set to false if we are happy to (attempt to) apply a record which comes after a missing record.
    In practise, this should never happen since whenever a writedelta fails, we attempt a writedb. *)
-let stop_at_missing_record = true
+let stop_at_missing_record = false
 
 let get_latest_response_time block_time =
   let now = Unix.gettimeofday() in


### PR DESCRIPTION
The database behaviour has been changed so that all database changes,
not just those which would cause a redo_log write, increase the
generation count. This change means that when reading a database, the
redo_log no longer expects database deltas to be consecutive.

This is a quick fix for beta3 - for RC1 the redo_log should be changed
to expect deltas with a monotonically increasing generation count.
