### PR TITLE
CA-62072: fix the handling of the internal management interface DHCP server

### DIFF
--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -6,7 +6,7 @@ OCAMLINCLUDES = ../idl ../idl/ocaml_backend \
 	../xenops ../xva ../util \
 	../auth ../license ../client_records ../rfb ../gpg
 
-UseCamlp4(rpc-light.syntax, features rrd monitor_fake monitor_fake_common vdi_automaton storage_impl)
+UseCamlp4(rpc-light.syntax, features rrd monitor_fake monitor_fake_common vdi_automaton storage_impl xapi_udhcpd)
 UseCamlp4(rpc-light.idl, storage_interface)
 
 CFLAGS += -std=gnu99 -Wall -Werror -I$(shell ocamlc -where)

--- a/ocaml/xapi/vmops.ml
+++ b/ocaml/xapi/vmops.ml
@@ -459,17 +459,7 @@ let destroy_domain ?(preserve_xs_vm=false) ?(clear_currently_attached=true)  ~__
 				(fun () ->
 					Xapi_vbd.clean_up_on_domain_destroy vbd (* effect is to unblock threads, not actually unpause *)
 				) ();
-		) all_vbds;
-
-	(* Remove any static lease we might have *)
-	let all_vifs = Db.VM.get_VIFs ~__context ~self in
-	List.iter
-		(fun vif ->
-			Helpers.log_exn_continue (Printf.sprintf "Vmops.destroy_domain: attempting to remove DHCP lease for VIF: %s" (Ref.string_of vif))
-				(fun () ->
-					Xapi_udhcpd.maybe_remove_lease ~__context vif
-				) ()
-		) all_vifs
+		) all_vbds
 
 (* Destroy a VM's domain and all runtime state (domid etc).
    If release_devices is true, unlock all VDIs and clear device_status_flags.

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -800,6 +800,7 @@ let server_init() =
     "XAPI SERVER STARTING", [], print_server_starting_message;
     "Parsing inventory file", [], Xapi_inventory.read_inventory;
     "Initialising local database", [], init_local_database;
+	"Loading DHCP leases", [], Xapi_udhcpd.init;
     "Reading pool secret", [], Helpers.get_pool_secret;
     "Logging xapi version info", [], Xapi_config.dump_config;
     "Checking control domain", [], check_control_domain;

--- a/ocaml/xapi/xapi_udhcpd.mli
+++ b/ocaml/xapi/xapi_udhcpd.mli
@@ -3,10 +3,9 @@
    management network then configure a DHCP lease via udhcpd *)
 val maybe_add_lease: __context:Context.t -> API.ref_VIF -> unit
 
-(* [maybe_remove_lease __context vif]: if [vif] is on the Host internal
-   management network then remove the assigned DHCP lease *)
-val maybe_remove_lease: __context:Context.t -> API.ref_VIF -> unit
-
 (* [get_ip __context vif]: if [vif] is on the Host internal management
    network then return the assigned IP *)
 val get_ip: __context:Context.t -> API.ref_VIF -> (int * int * int * int) option
+
+(* [init ()]: load in the saved leases database from disk, if there is one *)
+val init: unit -> unit


### PR DESCRIPTION
With these patches the leases aren't forgotten over a xapi restart (!) and the leases are treated as permanently associated with VIFs, so there is no scope for confusion over VM.suspend/VM.resume etc.
