### PR TITLE
CA-41262: In VDI.create and "xe vdi-create" allow the setting of the tags

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1639,7 +1639,7 @@ there are two or more empty CD devices, please use the command 'vbd-insert' and 
    "vdi-create",
     {
       reqd=["sr-uuid";"name-label";"type";"virtual-size"];
-      optn=["sm-config:";"sharable"];
+      optn=["sm-config:";"sharable"; "tags:"];
       help="Create a VDI. Type is 'system' 'user' 'suspend' or 'crashdump'.";
       implementation=No_fd Cli_operations.vdi_create;
       flags=[];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -54,7 +54,7 @@ let read_map_params name params =
 	let len = String.length name + 1 in (* include ':' *)
 	let filter_params = List.filter (fun (p,_) -> (String.startswith name p) && (String.length p > len)) params in
 	List.map (fun (k,v) -> String.sub k len (String.length k - len),v) filter_params
-
+let read_set_params name params = List.map fst (read_map_params name params)
 
 let get_chunks fd =
 	let buffer = Buffer.create 10240 in
@@ -1048,9 +1048,10 @@ let vdi_create printer rpc session_id params =
 	let ty = vdi_type_of_string str_type in
 	let sharable = get_bool_param params "sharable" in
 	let sm_config=read_map_params "sm-config" params in
+	let tags=read_set_params "tags" params in
 
 	let vdi = Client.VDI.create ~rpc ~session_id ~name_label ~name_description:"" ~sR ~virtual_size ~_type:ty
-		~sharable ~read_only:false ~xenstore_data:[] ~other_config:[] ~sm_config ~tags:[] in
+		~sharable ~read_only:false ~xenstore_data:[] ~other_config:[] ~sm_config ~tags in
 	let vdi_uuid = Client.VDI.get_uuid rpc session_id vdi in
 	printer (Cli_printer.PList [vdi_uuid])
 

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -216,6 +216,7 @@ let create ~__context ~name_label ~name_description
 
 	(* Set the fields which belong to the higher-level API: *)
 	Db.VDI.set_other_config ~__context ~self:ref ~value:other_config;
+	Db.VDI.set_tags ~__context ~self:ref ~value:tags;
 	Db.VDI.set_xenstore_data ~__context ~self:ref ~value:xenstore_data;
 	Db.VDI.set_sharable ~__context ~self:ref ~value:sharable;
 	Db.VDI.set_type ~__context ~self:ref ~value:_type;


### PR DESCRIPTION
CA-41262: In VDI.create and "xe vdi-create" allow the setting of the tags field.

Signed-off-by: David Scott dave.scott@eu.citrix.com
