### PR TITLE
CP-2634: remove the experimental tag from OEL 6.0 templates

### DIFF
--- a/ocaml/xapi/create_templates.ml
+++ b/ocaml/xapi/create_templates.ml
@@ -544,8 +544,8 @@ let create_all_templates rpc session_id =
 		rhel6x_template "Red Hat Enterprise Linux 6.0"   X32 [    ];
 		rhel6x_template "Red Hat Enterprise Linux 6.0"   X64 [    ];
 
-		rhel6x_template "Oracle Enterprise Linux 6.0" X32 ~is_experimental:true [    ];
-		rhel6x_template "Oracle Enterprise Linux 6.0" X64 ~is_experimental:true [    ];
+		rhel6x_template "Oracle Enterprise Linux 6.0" X32 [    ];
+		rhel6x_template "Oracle Enterprise Linux 6.0" X64 [    ];
 
 		sles_9_template    "SUSE Linux Enterprise Server 9 SP4"  X32 [    ];
 		sles10sp1_template "SUSE Linux Enterprise Server 10 SP1" X32 [    ];


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@eu.citrix.com
