### PR TITLE
CA-61743: block VBD.set_mode when the VM isn't halted

### DIFF
--- a/ocaml/client_records/record_util.ml
+++ b/ocaml/client_records/record_util.ml
@@ -289,6 +289,10 @@ let string_to_vbd_mode s =
 		| "rw" -> `RW
 		| _ -> raise (Record_failure ("Expected 'RO' or 'RW', got "^s))
 
+let vbd_mode_to_string = function
+	| `RO -> "ro"
+	| `RW -> "rw"
+
 let string_to_vbd_type s =
 	match String.lowercase s with
 		| "cd" -> `CD

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5157,7 +5157,7 @@ let vbd =
        field ~qualifier:DynamicRO "device" "device seen by the guest e.g. hda1";
        field "userdevice" "user-friendly device name e.g. 0,1,2,etc.";
        field ~ty:Bool "bootable" "true if this VBD is bootable";
-       field ~ty:vbd_mode "mode" "the mode the VBD should be mounted with";
+       field ~effect:true ~ty:vbd_mode "mode" "the mode the VBD should be mounted with";
        field ~ty:vbd_type "type" "how the VBD will appear to the guest (e.g. disk or CD)";
        field ~in_oss_since:None ~in_product_since:rel_miami ~ty:Bool ~default_value:(Some (VBool true))
 	 "unpluggable" "true if this VBD will support hot-unplug";

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3173,6 +3173,10 @@ end
       (* NB must always execute this on the master because of the autodetect_mutex *)
       Local.VBD.create ~__context ~vM ~vDI ~userdevice ~bootable ~mode ~_type ~unpluggable ~empty ~other_config ~qos_algorithm_type ~qos_algorithm_params
 
+	let set_mode ~__context ~self ~value =
+		info "VBD.set_mode: VBD = '%s'; value = %s" (vbd_uuid ~__context self) (Record_util.vbd_mode_to_string value);
+		Local.VBD.set_mode ~__context ~self ~value
+
     let destroy ~__context ~self =
       info "VBD.destroy: VBD = '%s'" (vbd_uuid ~__context self);
       Local.VBD.destroy ~__context ~self

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -98,6 +98,13 @@ let dynamic_destroy ?(do_safety_check=true) ~__context ~vbd (force: bool) token 
 	  with_xs (fun xs -> destroy_vbd ~do_safety_check ~__context ~xs domid vbd force)
 	end
 
+let set_mode ~__context ~self ~value =
+	let vm = Db.VBD.get_VM ~__context ~self in
+	let power_state = Db.VM.get_power_state ~__context ~self:vm in
+	if power_state <> `Halted
+	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [Ref.string_of vm; Record_util.power_to_string `Halted; Record_util.power_to_string power_state]));
+	Db.VBD.set_mode ~__context ~self ~value
+
 let plug ~__context ~self =
   let r = Db.VBD.get_record_internal ~__context ~self in
   let vm = r.Db_actions.vBD_VM in


### PR DESCRIPTION
This was never supposed to be possible, hence the block.

Signed-off-by: David Scott dave.scott@eu.citrix.com
