### PR TITLE
CA-61702: block HA enable if the pool is in a partially-upgraded state

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1072,7 +1072,9 @@ let slave_network_report ~__context ~phydevs ~dev_to_mac ~dev_to_mtu ~slave_host
 (* Let's only process one enable/disable at a time. I would have used an allowed_operation for this but
    it would involve a datamodel change and it's too late for Orlando. *)
 let enable_disable_m = Mutex.create ()
-let enable_ha ~__context ~heartbeat_srs ~configuration = Mutex.execute enable_disable_m (fun () -> Xapi_ha.enable __context heartbeat_srs configuration)
+let enable_ha ~__context ~heartbeat_srs ~configuration = 
+	Helpers.assert_rolling_upgrade_not_in_progress ~__context;
+	Mutex.execute enable_disable_m (fun () -> Xapi_ha.enable __context heartbeat_srs configuration)
 let disable_ha ~__context = Mutex.execute enable_disable_m (fun () -> Xapi_ha.disable __context)
 
 let ha_prevent_restarts_for ~__context ~seconds = Xapi_ha.ha_prevent_restarts_for __context seconds


### PR DESCRIPTION
HA is unlikely to work reliably unless all the software has matching versions.

Signed-off-by: David Scott dave.scott@eu.citrix.com
