### PR TITLE
CA-62028: perform an FLR in the PCI hot unplug path, for further defence 

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -1175,6 +1175,8 @@ let unplug ~xc ~xs (domain, bus, dev, func) domid =
 	| x ->
 		failwith (Printf.sprintf "Waiting for state=pci-removed; got state=%s" x)
 	in
+	(* CA-62028: tell the device to stop whatever it's doing *)
+	do_flr pci;
 	Xc.domain_deassign_device xc domid (domain, bus, dev, func)
 
 end


### PR DESCRIPTION
CA-62028: perform an FLR in the PCI hot unplug path, for further defence in depth.

We should always FLR a device after removing it from a VM. We are doing this in the domain destruction path but not in the hot unplug path, used by suspend and migrate.

Signed-off-by: David Scott dave.scott@eu.citrix.com
