### PR TITLE
CA-63313: xapi's logrotate configuration requests a rotation if the file 

### DIFF
--- a/scripts/xapi-logrotate
+++ b/scripts/xapi-logrotate
@@ -1,5 +1,6 @@
 /var/log/xensource.log {
     missingok
+	size 16M
     sharedscripts
     postrotate
 	/opt/xensource/bin/xe log-reopen 2> /dev/null || true


### PR DESCRIPTION
CA-63313: xapi's logrotate configuration requests a rotation if the file exceeds 16M

Note that xapi calls out to logrotate when it believes it has written 16M of new stuff: see "logrot_*" in ocaml/xapi/xapi_globs.ml

Signed-off-by: David Scott dave.scott@eu.citrix.com
