### PR TITLE
CA-63739: Fix console handling after reboot/migrate/vncterm crash; add "x

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1046,6 +1046,15 @@ let rec cmdtable_data : (string*cmd_spec) list =
       flags=[Standard;Vm_selectors];
    };
 
+   "console",
+   {
+     reqd=[];
+     optn=[];
+     help="Attach to a particular console.";
+	 implementation= With_fd Cli_operations.console;
+	 flags=[Hidden; Vm_selectors];
+   };
+
    "vm-start",
    {
      reqd=[];

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -80,7 +80,7 @@ let refresh_console_urls ~__context =
 	    let vm = Db.Console.get_VM ~__context ~self:console in
 	    let host = Db.VM.get_resident_on ~__context ~self:vm in
 	    let address = Db.Host.get_address ~__context ~self:host in
-	    let url_should_be = Printf.sprintf "https://%s%s?ref=%s" address Constants.console_uri (Ref.string_of vm) in
+	    let url_should_be = Printf.sprintf "https://%s%s?ref=%s" address Constants.console_uri (Ref.string_of console) in
 	    Db.Console.set_location ~__context ~self:console ~value:url_should_be
 	 ) ()
     ) (Db.Console.get_all ~__context)

--- a/ocaml/xapi/events.ml
+++ b/ocaml/xapi/events.ml
@@ -449,6 +449,9 @@ let callback_devices ctx domid dev_event =
 	 (fun __context -> 
 	    try
 	      match dev_event with
+			  | Xal.Console(ty, port) ->
+				  let vm = vm_of_domid ~__context domid in
+				  Vmops.update_console ~__context ty port vm
 	      | Xal.HotplugChanged (devid, oldextra, newextra) ->  
 		  begin 
 	            let vm = vm_of_domid ~__context domid in

--- a/ocaml/xenops/device.mli
+++ b/ocaml/xenops/device.mli
@@ -114,9 +114,11 @@ sig
 	exception Failed_to_start
 	val save : xs:Xs.xsh -> Xc.domid -> unit
 	val get_statefile : xs:Xs.xsh -> Xc.domid -> string option
-	val start : ?statefile:string -> xs:Xs.xsh -> Xc.domid -> int
+	val start : ?statefile:string -> xs:Xs.xsh -> Xc.domid -> unit
+	val stop : xs:Xs.xsh -> Xc.domid -> unit
 
-	val vnc_port_path : Xc.domid -> string
+	val get_vnc_port : xs:Xs.xsh -> Xc.domid -> int option
+	val get_tc_port : xs:Xs.xsh -> Xc.domid -> int option
 end
 
 module PCI :
@@ -197,16 +199,18 @@ sig
 	val write_logfile_to_log : int -> unit
 	val unlink_logfile : int -> unit
 
-	val vnc_port_path : Xc.domid -> string
+	val get_vnc_port : xs:Xs.xsh -> Xc.domid -> int option
+	val get_tc_port : xs:Xs.xsh -> Xc.domid -> int option
 
 	val signal : xs:Xs.xsh -> domid:Xc.domid -> ?wait_for:string -> ?param:string
 	          -> string -> unit
 
-	val start : xs:Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xc.domid -> int
-	val restore : xs:Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xc.domid -> int
+	val start : xs:Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xc.domid -> unit
+	val restore : xs:Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xc.domid -> unit
 	val suspend : xs:Xs.xsh -> Xc.domid -> unit
 	val resume : xs:Xs.xsh -> Xc.domid -> unit
 	val stop : xs:Xs.xsh -> Xc.domid -> unit
 end
 
-val vnc_port_path: xc:Xc.handle -> xs:Xs.xsh -> Xc.domid -> string
+val get_vnc_port : xs:Xs.xsh -> Xc.domid -> int option
+val get_tc_port : xs:Xs.xsh -> Xc.domid -> int option

--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -309,6 +309,8 @@ let destroy ?(preserve_xs_vm=false) ~xc ~xs domid =
 
 	log_exn_continue "Error stoping device-model, already dead ?"
 	                 (fun () -> Device.Dm.stop ~xs domid) ();
+	log_exn_continue "Error stoping vncterm, already dead ?"
+	                 (fun () -> Device.PV_Vnc.stop ~xs domid) ();
 
 	(* Forcibly shutdown every backend *)
 	List.iter 

--- a/ocaml/xenops/xal.mli
+++ b/ocaml/xenops/xal.mli
@@ -36,6 +36,10 @@ exception Domain_not_dead of domid
 exception Device_not_monitored
 exception Timeout
 
+type console_type =
+	| Text
+	| VNC
+
 type dev_event =
 	| DevEject of string
 	| DevThread of string * int
@@ -45,6 +49,7 @@ type dev_event =
 	| HotplugChanged of string * string option * string option
 	| ChangeUncooperative of bool
 	| PciChanged of string
+	| Console of console_type * int
 
 (* type dev_state = Connecting | Connected | Closing | Closed *)
 

--- a/ocaml/xenops/xenops.ml
+++ b/ocaml/xenops/xenops.ml
@@ -783,8 +783,7 @@ let _ = try
 	| "add_dm" ->
 		assert_domid ();
 		with_xs (fun xs ->
-			let vnc_port = add_dm ~xs ~domid ~static_max_kib ~vcpus ~boot in
-			Printf.printf "%d\n" vnc_port
+			add_dm ~xs ~domid ~static_max_kib ~vcpus ~boot
 		)
 	| "balloon" ->
 		assert_domid ();

--- a/scripts/vncterm-wrapper
+++ b/scripts/vncterm-wrapper
@@ -39,7 +39,7 @@ else
 fi
 
 echo vncterm-wrapper:
-xenstore-write -s /local/domain/$DOMID/console/vncterm-pid $$
+xenstore-write -s /local/domain/$DOMID/vncterm-pid $$
 if [ -z "${XIU}" ]; then
 	exec /usr/lib/xen/bin/vncterm $VNCTERM_LISTEN $VNCVIEWER $* > /dev/null 2>&1
 else


### PR DESCRIPTION
CA-63739: Fix console handling after reboot/migrate/vncterm crash; add "xe console vm=..." for debugging

Previously if a client is watching the vncterm console of a VM while it reboots, then
a fresh console is created for the new domain but the old console lingers
while a connection remains open to it. This causes the user to see a "freeze"
and us to leak a vncterm and a proxy thread in xapi.

Now when the domain is destroyed xapi will kill the vncterm process group,
causing the client to disconnect and then reconnect to the real console
later, when it appears.

Previously When vncterm crashes, the local VNC port becomes free. A new vncterm or
qemu may then bind to the port. Two users may then accidentally get the same
console.

Now before opening a proxy to a particular local console port, we check that
the pid of vncterm or qemu is still valid, and reject the call with a 404
if not.

To help debugging it is nolonger necessary to port forward to vncterm at all.
Instead one may use 'xe' as follows:

$ xe console vm=<vm name or uuid>

The escape character is Control + ]

Note this only works with newer versions of the linux CLI and won't work
at all with the windows CLI. It remains a 'Hidden' command for now.

To make it easier to support CLI extensions in future the CLI protocol
version check has been loosened: now only the major versions need to match,
not the minor versions (oops).

Furthermore if one wants to experiment with PVFB, one only has to write:

$ xe vm-param-set uuid=... platform:pvfb=true

Signed-off-by: David Scott dave.scott@eu.citrix.com
