### PR TITLE
CP-2081: add vm-pre-reboot hook which is called when a VM reboots, after 

### DIFF
--- a/ocaml/xapi/xapi_hooks.ml
+++ b/ocaml/xapi/xapi_hooks.ml
@@ -18,6 +18,7 @@ open D
 let scriptname__vm_pre_destroy  = "vm-pre-shutdown"
 let scriptname__vm_pre_migrate  = "vm-pre-migrate"
 let scriptname__vm_pre_start    = "vm-pre-start"
+let scriptname__vm_pre_reboot   = "vm-pre-reboot"
 let scriptname__vm_post_destroy  = "vm-post-destroy"
 
 (* VM Script hook reason codes *)
@@ -95,6 +96,8 @@ let vm_pre_migrate ~__context ~reason ~vm =
   execute_vm_hook ~__context ~script_name:scriptname__vm_pre_migrate ~reason ~vm
 let vm_pre_start ~__context ~reason ~vm =
   execute_vm_hook ~__context ~script_name:scriptname__vm_pre_start ~reason ~vm
+let vm_pre_reboot ~__context ~reason ~vm =
+  execute_vm_hook ~__context ~script_name:scriptname__vm_pre_reboot ~reason ~vm
 let vm_post_destroy ~__context ~reason ~vm =
   execute_vm_hook ~__context ~script_name:scriptname__vm_post_destroy ~reason ~vm
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -418,6 +418,9 @@ module Reboot = struct
 	 debug "Setting boot record";
 	 Helpers.set_boot_record ~__context ~self:vm new_snapshot;
 
+	 (* Invoke pre-reboot hook *)
+	 Xapi_hooks.vm_pre_reboot ~__context ~reason:Xapi_hooks.reason__none ~vm;
+
          debug "%s phase 2/3: starting new domain" api_call_name;
 	 begin
 	   try


### PR DESCRIPTION
CP-2081: add vm-pre-reboot hook which is called when a VM reboots, after the old domain is destroyed but before the new one is created.

This hook is called on for both internally-initiated and externally-initiated reboots.

Signed-off-by: David Scott dave.scott@eu.citrix.com
