### PR TITLE
CA-61130: Remove unnecessary redo_log calls.

### DIFF
--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -117,8 +117,6 @@ let enable_database_replication ~__context ~get_vdi_callback =
 			let device = Db.VBD.get_device ~__context ~self:vbd in
 			try
 				Redo_log.enable_block log ("/dev/" ^ device);
-				Redo_log.startup log;
-				Redo_log.flush_db_to_redo_log (Db_ref.get_database (Db_backend.make ())) log;
 				Hashtbl.add metadata_replication vdi (vbd, log);
 				let vbd_uuid = Db.VBD.get_uuid ~__context ~self:vbd in
 				Db.VDI.set_metadata_latest ~__context ~self:vdi ~value:true;


### PR DESCRIPTION
Redo_log.startup and Redo_log.flush_db_to_redo_log are unnecessary as
the new redo_log is already enabled so will be started up by the
database engine as soon as a database write occurs.

It is also dangerous to call them here, as the database engine can
request that all enabled redo_logs carry out a database flush at any
time - if this happens while a log is creating a block_device_io
process, we may end up with two processes, one of which the redo_log
will have lost track of.

This change means that the startup of the redo_log will be handled by
the database engine, so should not happen in two threads at once.
