### PR TITLE
NIC-379-xenserver-Pull-slave-MTU-from-bond-record

### DIFF
--- a/scripts/InterfaceReconfigureVswitch.py
+++ b/scripts/InterfaceReconfigureVswitch.py
@@ -598,6 +598,12 @@ class DatapathVswitch(Datapath):
         # when they are added, and a network device that is down
         # always reports "no carrier".
         physical_devices = datapath_get_physical_pifs(self._dp)
+
+        if pif_is_bond(self._dp):
+            brec = db().get_pif_record(self._dp)
+            bond_mtu = mtu_setting(brec['network'], "PIF", brec['other_config'])
+        else:
+            bond_mtu = None
         
         for p in physical_devices:
             prec = db().get_pif_record(p)
@@ -605,7 +611,10 @@ class DatapathVswitch(Datapath):
 
             dev = pif_netdev_name(p)
 
-            mtu = mtu_setting(prec['network'], "PIF", oc)
+            if bond_mtu:
+                mtu = bond_mtu
+            else:
+                mtu = mtu_setting(prec['network'], "PIF", oc)
 
             netdev_up(dev, mtu)
 


### PR DESCRIPTION
commit 903b35164e00e5c5a859fc87aa3547517fc45377
Author: Ethan Jackson ethan@nicira.com
Date:   Thu May 19 15:52:54 2011 -0700

```
xenserver: Pull slave MTU from bond record.

The MTU of the fake bond interface and the slaves participating in
a bond should all agree.  The correct long term solution to this
problem is to remove the fake bond interface altogether.  Until
that's possible, we simply set the MTU of the slaves.

Signed-off-by: Ethan Jackson <ethan@nicira.com>
```
