### PR TITLE
Fix JSON issues in odoc_json

### DIFF
--- a/ocaml/doc/odoc_json.ml
+++ b/ocaml/doc/odoc_json.ml
@@ -166,7 +166,7 @@ let rec json_to_string n = function
 | Object l -> (endl n) ^ "{ " ^ (String.concat ("," ^ (endl (n+1))) (List.map (fun (s, j) -> "\"" ^ s ^ "\": " ^ (json_to_string (n+2) j)) l)) ^ " }"
 | Array l -> "[ " ^ (String.concat ", " (List.map (fun j -> (json_to_string n j)) l)) ^ " ]"
 | String s -> "\"" ^ (escape_json s) ^ "\""
-| Number n -> string_of_float n
+| Number n -> Printf.sprintf "%.4f" n
 | True -> "true"
 | False -> "false"
 | Empty -> "\"\""


### PR DESCRIPTION
- Minor cleanup to prevent an exhaustiveness warning
- Fix the output to not be "2." with ocaml-3.12.0 and "2.0000" instead, to pass JSON validation (or else jQuery cannot parse it).
