### PR TITLE
CA-61495 - Add concept of a "read only" redo_log.

### DIFF
--- a/ocaml/database/redo_log.mli
+++ b/ocaml/database/redo_log.mli
@@ -29,6 +29,7 @@ val redo_log_sm_config : (string * string) list
 (** {redo_log data type} *)
 type redo_log = {
 	marker: string;
+	read_only: bool;
 	enabled: bool ref;
 	device: block_device option ref;
 	currently_accessible: bool ref;
@@ -63,16 +64,13 @@ val switch : redo_log -> string -> unit
 (** Start using the VDI with the given reason as redo-log, discarding the current one. *)
 
 (** {Keeping track of existing redo_log instances} *)
-val create: unit -> redo_log
+val create: read_only:bool -> redo_log
 (* Create a redo log instance and add it to the set. *)
 
 val delete: redo_log -> unit
 (* Shutdown a redo_log instance and remove it from the set. *)
 
 (** {Finding active redo_log instances} *)
-val active_redo_logs_exist : unit -> bool
-(* Return true if any redo_logs are active. *)
-
 val with_active_redo_logs : (redo_log -> unit) -> unit
 (* Apply the supplied function to all active redo_logs. *)
 

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -30,7 +30,7 @@ open Client
 open Threadext
 
 (* Create a redo_log instance to use for HA. *)
-let ha_redo_log = Redo_log.create ()
+let ha_redo_log = Redo_log.create ~read_only:false
 
 (*********************************************************************************************)
 (* Interface with the low-level HA subsystem                                                 *)

--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -113,7 +113,7 @@ let enable_database_replication ~__context ~get_vdi_callback =
 				vbd)
 			in
 			(* Enable redo_log and point it at the new device *)
-			let log = Redo_log.create () in
+			let log = Redo_log.create ~read_only:false in
 			let device = Db.VBD.get_device ~__context ~self:vbd in
 			try
 				Redo_log.enable_block log ("/dev/" ^ device);
@@ -162,7 +162,7 @@ let database_open_mutex = Mutex.create ()
 (* Extract a database from a VDI. *)
 let database_ref_of_vdi ~__context ~vdi =
 	let database_ref_of_device device =
-		let log = Redo_log.create () in
+		let log = Redo_log.create ~read_only:true in
 		debug "Enabling redo_log with device reason [%s]" device;
 		Redo_log.enable_block log device;
 		let db = Database.make (Datamodel_schema.of_datamodel ()) in


### PR DESCRIPTION
Database deltas should only be written the HA redo_log and the
persistent DR redo_logs - if a redo_log has been created temporarily to
open a database (e.g. for DR) then the database callback should ignore
it.
