### PR TITLE
CA-63225: the qemu-dm-wrapper still needs to write its pid to xenstore, s

### DIFF
--- a/scripts/qemu-dm-wrapper
+++ b/scripts/qemu-dm-wrapper
@@ -94,6 +94,8 @@ def main(argv):
 	core_dump_limit = enable_core_dumps()
 	print "core dump limit: %d" % core_dump_limit
 
+	write_dm_pid(domid, os.getpid())
+
 	os.dup2(1, 2)
 	os.execve(qemu_dm, qemu_args, qemu_env)
 


### PR DESCRIPTION
CA-63225: the qemu-dm-wrapper still needs to write its pid to xenstore, so xapi can clean it up later

Signed-off-by: David Scott dave.scott@eu.citrix.com
