### PR TITLE
CA-64782: Catch an HTTP exception that was leaking

### DIFF
--- a/ocaml/idl/ocaml_backend/xmlrpcclient.ml
+++ b/ocaml/idl/ocaml_backend/xmlrpcclient.ml
@@ -31,8 +31,9 @@ let connect ?session_id ?task_id ?subtask_of path =
 	Http.Request.make ~user_agent ~version:"1.0" ~keep_alive:true ~cookie ?subtask_of
 		Http.Connect path
 
-let xmlrpc ?version ?keep_alive ?cookie ?length ?subtask_of ?body path = 
-	Http.Request.make ~user_agent ?version ?keep_alive ?cookie ?length ?subtask_of ?body
+let xmlrpc ?version ?keep_alive ?task_id ?cookie ?length ?subtask_of ?body path =
+	let headers = Opt.map (fun x -> [ Http.Hdr.task_id, x ]) task_id in
+	Http.Request.make ~user_agent ?version ?keep_alive ?cookie ?headers ?length ?subtask_of ?body
 		Http.Post path
 
 (** Thrown when ECONNRESET is caught which suggests the remote crashed or restarted *)

--- a/ocaml/idl/ocaml_backend/xmlrpcclient.mli
+++ b/ocaml/idl/ocaml_backend/xmlrpcclient.mli
@@ -50,7 +50,7 @@ val with_transport : transport -> (Unix.file_descr -> 'a) -> 'a
 val with_http : Http.Request.t -> (Http.Response.t * Unix.file_descr -> 'a) -> Unix.file_descr -> 'a
 
 (** Returns an HTTP.Request.t representing an XMLRPC request *)
-val xmlrpc: ?version:string -> ?keep_alive:bool -> ?cookie:(string*string) list -> ?length:int64 -> ?subtask_of:string -> ?body:string -> string -> Http.Request.t
+val xmlrpc: ?version:string -> ?keep_alive:bool -> ?task_id:string -> ?cookie:(string*string) list -> ?length:int64 -> ?subtask_of:string -> ?body:string -> string -> Http.Request.t
 
 (** Returns an HTTP.Request.t representing an HTTP CONNECT *)
 val connect: ?session_id:string -> ?task_id:string -> ?subtask_of:string -> string -> Http.Request.t


### PR DESCRIPTION
Further, make sure a task forwarded to a slave gets the task_id passed along (again)

Signed-off-by: Rob Hoes rob.hoes@citrix.com
Signed-off-by: Dave Scott dave.scott@eu.citrix.com
