### PR TITLE
Kronos: Give the xe bash completion script a better name than cli

### DIFF
--- a/ocaml/xe-cli/OMakefile
+++ b/ocaml/xe-cli/OMakefile
@@ -99,7 +99,7 @@ install:
 	mkdir -p $(DESTDIR)/usr/bin
 	ln -sf $(BIN_DIR)/xe $(DESTDIR)/usr/bin/xe
 	mkdir -p $(DESTDIR)/etc/bash_completion.d
-	$(IPROG) bash-completion $(DESTDIR)/etc/bash_completion.d/cli
+	$(IPROG) bash-completion $(DESTDIR)/etc/bash_completion.d/xe
 	mkdir -p $(DEBUGDIST)
 
 .PHONY: sdk-install

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -1,4 +1,4 @@
-# Copy this file to /etc/bash_completion.d/cli
+# Copy this file to /etc/bash_completion.d/xe
 # Make sure that cli is on your path, too!
 
 MAGIC_SQUOTE="jsufbtghejhw"

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -278,7 +278,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 @BASE_PATH@/bin/xe
 /usr/bin/xe
-/etc/bash_completion.d/cli
+/etc/bash_completion.d/xe
 
 %files squeezed
 %defattr(-,root,root,-)


### PR DESCRIPTION
I don't think that the Debian folks will be very happy about us naming our xe bash completion script /etc/bash_completion.d/cli, so I renamed the file to /etc/bash_completion.d/xe and removed the execute permissions.

This should be perfectly safe for a merge to trunk, but it's not critical and can wait if necessary.
