### PR TITLE
Kronos: xapi -help: Citrix XenServer API server -> XenAPI server

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -249,7 +249,7 @@ let init_args() =
 	       "-dummydata", Arg.Set debug_dummy_data, "populate with dummy data for demo/debugging purposes";
 	       "-version", Arg.Unit show_version, "show version of the binary"
 	     ] (fun x -> printf "Warning, ignoring unknown argument: %s" x)
-    "Citrix XenServer API server"
+    "XenAPI server"
 
 let wait_to_die() =
   (* don't call Thread.join cos this interacts strangely with OCAML runtime and stops


### PR DESCRIPTION
xapi -help now has a more generic message. I think that this message works well for XenServer as well as XCP, so we don't need to worry about branding. Here is the full text of xapi -help:

[root@dt26 ~]# ./xapi.help -help
XenAPI server
  -daemon run as a daemon in the background
  -config set config file to use
  -logconfig set log config file to use
  -writereadyfile touch specified file when xapi is ready to accept requests
  -writeinitcomplete touch specified file when xapi init process is complete
  -nowatchdog turn watchdog off, avoiding initial fork
  -setdom0mem (ignored)
  -dom0memgradient (ignored)
  -dom0memintercept (ignored)
  -onsystemboot indicates that this server start is the first since the host rebooted
  -noevents turn event thread off for debugging -leaves crashed guests undestroyed
  -dummydata populate with dummy data for demo/debugging purposes
  -version show version of the binary
  -help  Display this list of options
  --help  Display this list of options
