### PR TITLE
Add a new diagnostic command: "xenops list_devices" which is driver-domai

### DIFF
--- a/ocaml/xenops/device_common.ml
+++ b/ocaml/xenops/device_common.ml
@@ -119,53 +119,94 @@ let device_of_backend (backend: endpoint) (domu: Xc.domid) =
 		   devid = backend.devid } in
   { backend = backend; frontend = frontend }
 
+let parse_kind k =
+	try
+		Some (kind_of_string k)
+	with Unknown_device_type _ -> None
+
+let parse_int i = 
+	try
+		Some (int_of_string i)
+	with _ -> None
+
+let parse_frontend_link x =
+	match String.split '/' x with
+		| [ ""; "local"; "domain"; domid; "device"; kind; devid ] ->
+			begin
+				match parse_int domid, parse_kind kind, parse_int devid with
+					| Some domid, Some kind, Some devid ->
+						Some { domid = domid; kind = kind; devid = devid }
+					| _, _, _ -> None
+			end
+		| _ -> None
+
+let parse_backend_link x = 
+	match String.split '/' x with
+		| [ ""; "local"; "domain"; domid; "backend"; kind; _; devid ] ->
+			begin
+				match parse_int domid, parse_kind kind, parse_int devid with
+					| Some domid, Some kind, Some devid ->
+						Some { domid = domid; kind = kind; devid = devid }
+					| _, _, _ -> None
+			end
+		| _ -> None
+
+let readdir ~xs d = try xs.Xs.directory d with Xb.Noent -> []
+let to_list ys = List.concat (List.map Opt.to_list ys)
+let list_kinds ~xs dir = to_list (List.map parse_kind (readdir ~xs dir))
+
+(* NB: we only read data from the frontend directory. Therefore this gives
+   the "frontend's point of view". *)
+let list_frontends ~xs domid = 
+	let frontend_dir = xs.Xs.getdomainpath domid ^ "/device" in
+	let kinds = list_kinds ~xs frontend_dir in
+	List.concat (List.map
+		(fun k ->
+			let dir = sprintf "%s/%s" frontend_dir (string_of_kind k) in
+			let devids = to_list (List.map parse_int (readdir ~xs dir)) in
+			to_list (List.map
+				(fun devid ->
+					(* domain [domid] believes it has a frontend for
+					   device [devid] *)
+					let frontend = { domid = domid; kind = k; devid = devid } in
+					let be = xs.Xs.read (sprintf "%s/%d/backend" dir devid) in
+					Opt.map (fun b -> { backend = b; frontend = frontend })
+						(parse_backend_link be)
+				) devids)
+		) kinds)
+
+(* NB: we only read data from the backend directory. Therefore this gives
+   the "backend's point of view". *)
+let list_backends ~xs domid =
+	let backend_dir = xs.Xs.getdomainpath domid ^ "/backend" in
+	let kinds = list_kinds ~xs backend_dir in
+
+	List.concat (List.map
+		(fun k ->
+			let dir = sprintf "%s/%s" backend_dir (string_of_kind k) in
+			let domids = to_list (List.map parse_int (readdir ~xs dir)) in
+			List.concat (List.map
+				(fun frontend_domid ->
+					let dir = sprintf "%s/%s/%d" backend_dir (string_of_kind k) frontend_domid in
+					let devids = to_list (List.map parse_int (readdir ~xs dir)) in
+					to_list (List.map
+						(fun devid ->
+							(* domain [domid] believes it has a backend for
+							   [frontend_domid] of type [k] with devid [devid] *)
+							let backend = { domid = domid; kind = k; devid = devid } in
+							let fe = xs.Xs.read (sprintf "%s/%d/frontend" dir devid) in
+							Opt.map (fun f -> { backend = backend; frontend = f })
+								(parse_frontend_link fe)
+						) devids)
+				) domids)
+		) kinds)
+
 (** Return a list of devices connecting two domains. Ignore those whose kind 
     we don't recognise *)
 let list_devices_between ~xs driver_domid user_domid = 
-  let backend_dir = xs.Xs.getdomainpath driver_domid ^ "/backend" in
-  let kinds = try xs.Xs.directory backend_dir with Xb.Noent -> [] in
-  let kinds = List.concat 
-    (List.map 
-       (fun k -> 
-	try [ kind_of_string k ]
-	with Unknown_device_type _ ->
-	  debug "Ignoring unknown backend device type: %s" k;
-	  []) kinds) in
-  List.concat
-    (List.map 
-       (fun k ->
-	  let dir = sprintf "%s/%s/%d" backend_dir (string_of_kind k) user_domid in
-	  let devids = try xs.Xs.directory dir with _ -> [] in
-	  List.concat
-	    (List.map 
-	       (fun devid ->
-		  try
-		    let backend = { domid = driver_domid; kind = k; devid = int_of_string devid } in
-		    (* Ignore if we fail to parse the frontend link *)
-		    let fe = xs.Xs.read (dir ^ "/" ^ devid ^ "/frontend") in
-		    let devid = int_of_string devid in
-		    match String.split '/' fe with
-		    | [ ""; "local"; "domain"; domid'; "device"; k'; devid' ] ->
-			let domid' = int_of_string domid'
-			and k' = kind_of_string k' 
-			and devid' = int_of_string devid' in
-			if domid' <> user_domid then begin
-			  debug "Malformed frontend link %s: domid should be %d" fe user_domid;
-			  []
-			end else if devid' <> devid then begin
-			  debug "Malformed frontend link %s: devid should be %d" fe devid;
-			  []
-			end else begin
-			  let frontend = { domid = user_domid; kind = k'; devid = devid' } in
-			  [ { frontend = frontend; backend = backend } ]
-			end
-		    | _ -> 
-			debug "Malformed frontend link %s" fe;
-			[]
-		  with _ -> []) devids)
-       ) kinds
-    )
-
+	List.filter
+		(fun d -> d.frontend.domid = user_domid) 
+		(list_backends ~xs driver_domid)
   
 
 let print_device domid kind devid =

--- a/ocaml/xenops/device_common.mli
+++ b/ocaml/xenops/device_common.mli
@@ -51,6 +51,16 @@ val string_of_device : device -> string
 val string_of_kind : kind -> string
 val kind_of_string : string -> kind
 
+(** [list_backends xs domid] returns a list of devices where there is a
+	backend in [domid]. This function only reads data stored in the backend
+    directory.*)
+val list_backends : xs:Xs.xsh -> Xc.domid -> device list
+
+(** [list_frontends xs domid] returns a list of devices where there is a
+	frontend in [domid]. This function only reads data stored in the frontend
+    directory.*)
+val list_frontends : xs:Xs.xsh -> Xc.domid -> device list
+
 (** Return a list of devices connecting two domains. Ignore those whose kind 
     we don't recognise *)
 val list_devices_between : xs:Xs.xsh -> Xc.domid -> Xc.domid -> device list

--- a/ocaml/xenops/xenops.ml
+++ b/ocaml/xenops/xenops.ml
@@ -148,6 +148,11 @@ let domain_get_uuid ~xc ~domid =
 	with _ ->
 		()
 
+let print_table (rows: string list list) =
+	let widths = Table.compute_col_widths rows in
+	let sll = List.map (List.map2 Table.right widths) rows in
+	List.iter (fun line -> print_endline (String.concat " | " line)) sll
+
 let list_domains ~xc ~verbose =
 	let header () =
 		if verbose then
@@ -186,45 +191,92 @@ let list_domains ~xc ~verbose =
 			[ domid; state; cpu_time; handle ]
 		in
 
-	let print (rows: string list list) =
-		let widths = Table.compute_col_widths rows in
-		let sll = List.map (List.map2 Table.right widths) rows in
-		List.iter (fun line -> print_endline (String.concat " | " line)) sll
-		in
-
 	let l = Xc.domain_getinfolist xc 0 in
 	let header = header () in
 	let infos = List.map sl_of_domaininfo l in
-	print (header :: infos)
+	print_table (header :: infos)
 
-let list_devices ~xs ~domid = 
-	(* Assume all drivers are in domain 0 *)
-	let all = list_devices_between ~xs 0 domid in
-	let string_of_state path = 
-	  try
-	    Xenbus.to_string_desc (Xenbus.of_string (xs.Xs.read (sprintf "%s/state" path)))
-	  with _ -> "gone" in
-	List.iter (fun device ->
-		     let fe = frontend_path_of_device ~xs device
-		     and be = backend_path_of_device ~xs device in
-		     let bdev = try xs.Xs.read (sprintf "%s/dev" be) with _ -> "" in
-		     printf "%s[%d] is %s to dom(%d) ty(%s) devid(%d %s) state(%s)\n"
-		       (string_of_kind device.frontend.kind) 
-		       device.frontend.devid 
-		       (string_of_state fe)
-		       device.backend.domid
-		       (string_of_kind device.backend.kind)
-		       device.backend.devid
-		       bdev 
-		       (string_of_state be)
-		  ) all
+(*
+   backend                  frontend
+   ---------------------------------------------------------------
+   domain domstate ty devid state -> domain domstate ty devid state
 
-let add_vbd ~xs ~hvm ~domid ~device_number ~phystype ~physpath ~dev_type ~mode ~backend_domid =
+   where domstate = R | S | D | ?
+   state = 1 | 2 | 3 | 4 | 5 | 6 | ?          
+*)
+
+type device_stat = {
+	device: device;
+	backend_proto: string;   (* blk or net *)
+	backend_device: string;  (* physical device eg. fd:2 *)
+	backend_state: string;   (* 1...6 *)
+	frontend_type: string;   (* cdrom or hd *)
+	frontend_device: string; (* linux device name *)
+	frontend_state: string;  (* 1..6 *)
+}
+let device_state_to_sl ds =
+	let int = string_of_int in
+	[ int ds.device.backend.domid; ds.backend_proto; ds.backend_device; ds.backend_state; "->"; ds.frontend_state; ds.frontend_type; ds.frontend_device; int ds.device.frontend.domid; ]
+
+let stat ~xs d =
+	let frontend_state = try xs.Xs.read (sprintf "%s/state" (frontend_path_of_device ~xs d)) with Xb.Noent -> "??" in
+	let backend_state = try xs.Xs.read (sprintf "%s/state" (backend_path_of_device ~xs d)) with Xb.Noent -> "??" in
+	(* The params string can be very long, truncate to a more reasonable width *)
+	let truncate params =
+		let limit = 10 in
+		let dots = "..." in
+		let len = String.length params in
+		if len <= limit
+		then params
+		else
+			let take = limit - (String.length dots) in
+			dots ^ (String.sub params (len - take) take) in
+	let backend_proto = match d.backend.kind with
+		| Vbd | Tap -> "blk"
+		| Vif -> "net"
+		| x -> string_of_kind x in
+	let frontend_type = match d.frontend.kind with
+		| Vbd | Tap ->
+			let be = frontend_path_of_device ~xs d in
+			(try if xs.Xs.read (sprintf "%s/device-type" be) = "cdrom" then "cdrom" else "disk" with _ -> "??")
+		| x -> string_of_kind x in
+	let backend_device = match d.backend.kind with
+		| Vbd | Tap ->
+			let be = backend_path_of_device ~xs d in
+			(try xs.Xs.read (sprintf "%s/physical-device" be)
+			with Xb.Noent ->
+				(try truncate (xs.Xs.read (sprintf "%s/params" be))
+				with Xb.Noent -> "??"))
+		| Vif -> "-"
+		| _ -> string_of_int d.backend.devid in
+	let frontend_device = match d.frontend.kind with
+		| Vbd | Tap -> Device_number.to_linux_device (Device_number.of_xenstore_key d.frontend.devid)
+		| _ -> string_of_int d.frontend.devid in
+	{ device = d; frontend_state = frontend_state; backend_state = backend_state; frontend_device = frontend_device; frontend_type = frontend_type; backend_proto = backend_proto; backend_device = backend_device }
+
+let list_devices ~xc ~xs =
+	let header = [ "be"; "proto"; "dev"; "state"; "->"; "state"; "kind"; "dev"; "fe" ] in
+	let of_device (d: device) : string list =
+		device_state_to_sl (stat ~xs d) in
+	let l = Xc.domain_getinfolist xc 0 in
+	let domids = List.map (fun x -> x.Xc.domid) l in
+	let devices =
+		Listext.List.setify (
+			List.concat (
+				List.map
+					(fun domid ->
+						list_backends ~xs domid @ (list_frontends ~xs domid)
+				) domids
+			)
+		) in
+	let infos = List.map of_device devices in
+	print_table (header :: infos)
+
+let add_vbd ~xs ~hvm ~domid ~device_number ~phystype ~physpath ~backend_domid ~dev_type ~mode=
 	let phystype = Device.Vbd.physty_of_string phystype in
 	let dev_type = Device.Vbd.devty_of_string dev_type in
-
 	Device.Vbd.add ~xs ~hvm ~mode:(Device.Vbd.mode_of_string mode)
-	               ~phystype ~physpath ~device_number ~dev_type ~backend_domid domid
+	               ~device_number ~phystype ~physpath ~backend_domid ~dev_type domid
 
 let find_device ~xs (frontend: endpoint) (backend: endpoint) = 
   let all = list_devices_between ~xs backend.domid frontend.domid in
@@ -284,7 +336,7 @@ let list_pci ~xc ~xs ~domid =
 		  ) pcidevs
 
 let add_dm ~xs ~domid ~static_max_kib ~vcpus ~boot =
-	let dmpath = Xapi_globs.base_path ^ "/libexec/qemu-dm-wrapper" in
+    let dmpath = Xapi_globs.base_path ^ "/libexec/qemu-dm-wrapper" in
 	let info = {
  	  Device.Dm.memory = static_max_kib;
  	  Device.Dm.boot = boot;
@@ -367,12 +419,12 @@ let affinity_get ~xc ~domid ~vcpu =
 	printf "%s\n" s
 
 let self_test () =
-	let device_tests = [ "sda2"; "sda"; "xvdd"; "xvda1"; "hde4"; "hdf" ] in
-	let numbers = List.map Device.Vbd.device_major_minor device_tests in
-	let names = List.map Device.Vbd.major_minor_to_device numbers in
-	List.iter (fun (a, ((major, minor), b)) ->
-		     if a <> b then failwith (Printf.sprintf "%s -> (%d, %d) -> %s" a major minor b))
-	  (List.combine device_tests (List.combine numbers names))
+    let device_tests = [ "sda2"; "sda"; "xvdd"; "xvda1"; "hde4"; "hdf" ] in
+    let numbers = List.map Device.Vbd.device_major_minor device_tests in
+    let names = List.map Device.Vbd.major_minor_to_device numbers in
+    List.iter (fun (a, ((major, minor), b)) ->
+        if a <> b then failwith (Printf.sprintf "%s -> (%d, %d) -> %s" a major minor b))
+        (List.combine device_tests (List.combine numbers names))
 
 let cmd_alias cmd =
 	match cmd with
@@ -393,23 +445,24 @@ let cmd_alias cmd =
 	| "getuuid_domain"          -> "dom-uuid"
 	| _                         -> cmd
 
-let usage subcmd allcommands =
-	let usage_all () =
-		let l = List.map (fun (cmd, _) -> "\t" ^ cmd) allcommands in
-		sprintf "%s\n" (String.concat "\n" ("usage:" :: l)) in
-	(* Unfortunately we can not reuse Arg.usage since it always output to stdout *)
-	let usage_sub c =
-		let spec = List.assoc c allcommands in
-		let l = List.map (fun (opt, _, doc) -> sprintf "  %s %s" opt doc) spec in
-		sprintf "%s\n" (String.concat "\n" (c :: l)) in
-	match subcmd with
-	| None -> Arg.Help (usage_all ())
-	| Some c ->
-		try Arg.Help (usage_sub c)
-		with Not_found ->
-			Arg.Bad (sprintf "Unknown subcommand: %s\n%s" c (usage_all ()))
 
-let do_cmd_parsing subcmd init_pos=
+let usage subcmd allcommands =
+    let usage_all () =
+        let l = List.map (fun (cmd, _) -> "\t" ^ cmd) allcommands in
+        sprintf "%s\n" (String.concat "\n" ("usage:" :: l)) in
+    (* Unfortunately we can not reuse Arg.usage since it always output to stdout *)
+    let usage_sub c =
+        let spec = List.assoc c allcommands in
+        let l = List.map (fun (opt, _, doc) -> sprintf "  %s %s" opt doc) spec in
+        sprintf "%s\n" (String.concat "\n" (c :: l)) in
+    match subcmd with
+		| None -> Arg.Help (usage_all ())
+		| Some c ->
+            try Arg.Help (usage_sub c)
+            with Not_found ->
+                Arg.Bad (sprintf "Unknown subcommand: %s\n%s" c (usage_all ()))
+
+let do_cmd_parsing subcmd init_pos =
 	let domid = ref (-1)
 	and backend_domid = ref (0)
 	and hvm = ref false
@@ -457,17 +510,17 @@ let do_cmd_parsing subcmd init_pos=
 	let set_int64 r s =
 		try r := Int64.of_string s
 		with _ -> eprintf "cannot parse %s at integer\n" s
-	in
-
+		in
 	let set_netty s =
 		match String.split ':' s with
 		| "DriverDomain" :: []    -> netty := Netman.DriverDomain
 		| "bridge" :: bname :: [] -> netty := Netman.Bridge bname
 		| _                       -> eprintf "not a valid network type: %s\n" s
-	in
+		in
 
 	let common = [
-		"-debug", Arg.Unit (fun () -> Logs.set_default Log.Debug [ "stderr" ]), "enable debugging";
+		"-debug", Arg.Unit (fun () -> Logs.set_default Log.Debug [ "stderr" ]),
+			  "enable debugging";
 		"-domid", Arg.Set_int domid, "Domain ID to be built";
 	]
 	and setmaxmem_args = [
@@ -497,7 +550,7 @@ let do_cmd_parsing subcmd init_pos=
 	and vbd_args = [
 		"-mode", Arg.Set_string mode, "Vbd Mode";
 		"-phystype", Arg.Set_string phystype, "Vbd set physical type (file|phy)";
-		"-physpath", Arg.Set_string physpath, "Vbd set physical path";
+        "-physpath", Arg.Set_string physpath, "Vbd set physical path";
 		"-device-number", Arg.String (fun x -> device_number := (Device_number.of_string false x)), "Vbd set device_number";
 		"-devtype", Arg.Set_string dev_type, "Vbd dev type";
 	]
@@ -576,7 +629,7 @@ let do_cmd_parsing subcmd init_pos=
 		("affinity_set"   , common @ affinity_args @ affinity_set_args);
 		("affinity_get"   , common @ affinity_args);
 		("list_domains"   , list_args);
-		("list_devices"   , common);
+		("list_devices"   , []);
 		("add_vbd"        , common @ vbd_args @ backend_args);
 		("del_vbd"        , common @ vbd_args @ backend_args);
 		("add_vif"        , common @ vif_args @ backend_args);
@@ -608,44 +661,42 @@ let do_cmd_parsing subcmd init_pos=
 		("pcpuinfo"       , []);
 		("help"           , []);
 	] in
-
-	let () =
-		let () =
-			match usage (Some subcmd) allcommands with
-			| Arg.Help _ -> () | e -> raise e in
-		let spec = List.assoc subcmd allcommands in
-		Arg.current := init_pos;
-		Arg.parse_argv Sys.argv spec
-			(fun x ->
-				if x.[0] = '-' then
-					eprintf "Warning, ignoring unknown argument: %s\n" x
-				else
-					otherargs := x :: !otherargs
-			) subcmd in
-	!domid, !backend_domid, !hvm, !vcpus, !vcpu, !kernel,
-	!ramdisk, !cmdline, Int64.of_int !mem_max_kib, Int64.of_int !mem_mib,
-	!pae, !apic, !acpi, !nx, !viridian, !verbose, !file,
-	!mode, !phystype, !physpath, !device_number, !dev_type, !devid, !mac, !pci,
-	!reason, !sysrq, !script, !sync, !netty, !weight, !cap, !bitmap, !cooperative,
-	!boot, !ioport_start, !ioport_end, !iomem_start, !iomem_end, !irq,
-	!slot, !timeout, List.rev !otherargs, allcommands
+       let () =
+               let () =
+                       match usage (Some subcmd) allcommands with
+                       | Arg.Help _ -> () | e -> raise e in
+               let spec = List.assoc subcmd allcommands in
+               Arg.current := init_pos;
+               Arg.parse_argv Sys.argv spec
+                       (fun x ->
+                               if x.[0] = '-' then
+                                       eprintf "Warning, ignoring unknown argument: %s\n" x
+                               else
+                                       otherargs := x :: !otherargs
+                       ) subcmd in
+		!domid, !backend_domid, !hvm, !vcpus, !vcpu, !kernel,
+		!ramdisk, !cmdline, Int64.of_int !mem_max_kib, Int64.of_int !mem_mib,
+		!pae, !apic, !acpi, !nx, !viridian, !verbose, !file,
+		!mode, !phystype, !physpath, !device_number, !dev_type, !devid, !mac, !pci,
+		!reason, !sysrq, !script, !sync, !netty, !weight, !cap, !bitmap, !cooperative,
+		!boot, !ioport_start, !ioport_end, !iomem_start, !iomem_end, !irq,
+		!slot, !timeout, List.rev !otherargs, allcommands
 
 let _ = try
 
-	let subcmd, init_pos =
-		let cmd = Filename.basename Sys.argv.(0) in
-		if cmd <> "xenops" then cmd, 0
-		else if Array.length Sys.argv > 1 then Sys.argv.(1), 1
-		else "help", 0 in
+    let subcmd, init_pos =
+        let cmd = Filename.basename Sys.argv.(0) in
+        if cmd <> "xenops" then cmd, 0
+        else if Array.length Sys.argv > 1 then Sys.argv.(1), 1
+        else "help", 0 in
 
-	let subcmd = cmd_alias subcmd in
-
+    let subcmd = cmd_alias subcmd in
 	let domid, backend_domid, hvm, vcpus, vcpu, kernel, ramdisk, cmdline,
-		max_kib, mem_mib, pae, apic, acpi, nx, viridian, verbose, file, mode,
-		phystype, physpath, device_number, dev_type, devid, mac, pci, reason, sysrq,
-		script, sync, netty, weight, cap, bitmap, cooperative,
-		boot, ioport_start, ioport_end, iomem_start, iomem_end, irq,
-		slot, timeout, otherargs, allcommands = do_cmd_parsing subcmd init_pos in
+               max_kib, mem_mib, pae, apic, acpi, nx, viridian, verbose, file, mode,
+               phystype, physpath, device_number, dev_type, devid, mac, pci, reason, sysrq,
+               script, sync, netty, weight, cap, bitmap, cooperative,
+               boot, ioport_start, ioport_end, iomem_start, iomem_end, irq,
+               slot, timeout, otherargs, allcommands = do_cmd_parsing subcmd init_pos in
 
 	let is_domain_hvm xc domid = (Xc.domain_getinfo xc domid).Xc.hvm_guest in
 
@@ -712,8 +763,7 @@ let _ = try
 	| "list_domains" ->
 		with_xc (fun xc -> list_domains ~xc ~verbose)
 	| "list_devices" ->
-		assert_domid ();
-		with_xs (fun xs -> list_devices ~xs ~domid)
+		with_xc_and_xs (fun xc xs -> list_devices ~xc ~xs)
 	| "sched_domain" ->
 		assert_domid ();
 		with_xc (fun xc -> sched_domain ~xc ~domid ~weight ~cap)
@@ -819,13 +869,12 @@ let _ = try
 		with_xc (fun xc -> print_pcpus_info ~xc);
 	| "capabilities" ->
 		with_xc (fun xc -> print_endline (Xc.version_capabilities xc))
-	| "test" ->
-		self_test ()
-	| "help" ->
-		raise (usage (try Some (List.hd otherargs) with _ -> None) allcommands)
-	| s ->
-		raise (usage (Some s) allcommands)
+    | "test" ->
+        self_test ()
+    | "help" ->
+        raise (usage (try Some (List.hd otherargs) with _ -> None) allcommands)
+    | s ->
+        raise (usage (Some s) allcommands)
 with
 | Arg.Help msg -> printf "%s\n" msg; exit 0
 | Arg.Bad msg -> eprintf "%s\n" msg; exit 1
-


### PR DESCRIPTION
Add a new diagnostic command: "xenops list_devices" which is driver-domain aware.

This code was originally developed as part of the storage driver domain work.

Signed-off-by: David Scott dave.scott@eu.citrix.com
