### PR TITLE
Don't save/restore terminal state unless we're actually changing it: this

### DIFF
--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -259,8 +259,6 @@ exception Stunnel_exit of int * Unix.process_status
 exception Unexpected_msg of message
 exception Server_internal_error
 
-let attr = ref None
-
 let handle_unmarshal_failure ex ifd = match ex with
 	| Unmarshal_failure (e, s) ->
 		let s = s ^ Unixext.try_read_string ifd in
@@ -271,10 +269,6 @@ let handle_unmarshal_failure ex ifd = match ex with
 	| e -> raise e
 
 let main_loop ifd ofd =
-  (* Save the terminal state to restore it at exit *)
-  (attr := try Some (Unix.tcgetattr Unix.stdin) with _ -> None);
-  at_exit (fun () ->
-             match !attr with Some a -> Unix.tcsetattr Unix.stdin Unix.TCSANOW a | None -> ());
   (* Intially exchange version information *)
   let major', minor' =
 	  try unmarshal_protocol ifd with


### PR DESCRIPTION
Don't save/restore terminal state unless we're actually changing it: this avoids wierd interactions with non-terminals (e.g. piping via less)

Originally this code was added to fix CA-6701, where a subprocess was fiddling with our terminal. We are now more careful when calling subprocesses so I don't think we need this workaround any more.

Signed-off-by: David Scott dave.scott@eu.citrix.com
