### PR TITLE
Fix clean targets for OMakefiles

### DIFF
--- a/ocaml/auth/OMakefile
+++ b/ocaml/auth/OMakefile
@@ -13,7 +13,7 @@ section
 
 .PHONY: clean
 clean:
-	rm -rf $(CLEAN_OBJS) *.aux *.log *.fig
+	rm -rf $(CLEAN_OBJS) *.aux *.log *.fig testauthx
 
 .PHONY: install
 install:

--- a/ocaml/client_records/OMakefile
+++ b/ocaml/client_records/OMakefile
@@ -1,2 +1,5 @@
 OCAMLINCLUDES += ../autogen ../idl ../idl/ocaml_backend ../database
 
+.PHONY: clean
+clean:
+	rm -f *.cmi *.cmx *.o

--- a/ocaml/console/OMakefile
+++ b/ocaml/console/OMakefile
@@ -3,4 +3,4 @@ OCAMLPACKS += unix
 OCamlProgram(console, client)
 
 clean:
-	rm -f $(CLEAN_OBJS)
+	rm -f $(CLEAN_OBJS) console

--- a/ocaml/database/OMakefile
+++ b/ocaml/database/OMakefile
@@ -42,4 +42,5 @@ sdk-install: install
 .PHONY: clean
 clean:
 	rm -f *.cmo *.cmi *.cmx *.o *.cmx *.cma *.cmxa xenEnterpriseAPI* gen gen.opt *.omc *.annot db_filter_parse.ml db_filter_parse.mli db_filter_lex.ml
+	rm -f block_device_io unit_test_marshall block_device_io.opt unit_test_marshall.opt
 

--- a/ocaml/db_process/OMakefile
+++ b/ocaml/db_process/OMakefile
@@ -15,4 +15,4 @@ sdk-install: install
 
 .PHONY: clean
 clean:
-	rm -rf $(CLEAN_OBJS) *.aux *.log *.fig xapi
+	rm -rf $(CLEAN_OBJS) *.aux *.log *.fig xapi xapi-db-process

--- a/ocaml/events/OMakefile
+++ b/ocaml/events/OMakefile
@@ -6,7 +6,7 @@ OCamlProgram(event_listen, event_listen)
 
 .PHONY: clean
 clean:
-	rm -f $(CLEAN_OBJS)
+	rm -f $(CLEAN_OBJS) event_listen
 
 .PHONY: install
 install:

--- a/ocaml/graph/OMakefile
+++ b/ocaml/graph/OMakefile
@@ -6,7 +6,7 @@ OCamlProgram(graph, graph ../idl/datamodel ../idl/datamodel_utils ../idl/dm_api)
 
 .PHONY: clean
 clean:
-	rm -f $(CLEAN_OBJS)
+	rm -f $(CLEAN_OBJS) graph
 
 .PHONY: install
 install:

--- a/ocaml/idl/OMakefile
+++ b/ocaml/idl/OMakefile
@@ -117,6 +117,7 @@ clean:
 	rm -rf *datamodel.tex datamodel-dtd.xml datamodel-coversheet.tex
 	rm -rf /tmp/docs
 	rm -rf $(SDKWWW)/docs/html
+	rm -f html_build js_backend/main
 
 sdk-README.txt : sdk-README.html
 	lynx -dump sdk-README.html > sdk-README.txt

--- a/ocaml/lvhdrt/OMakefile
+++ b/ocaml/lvhdrt/OMakefile
@@ -7,7 +7,7 @@ OCamlProgram(lvhdrt, lvhdrt lvhdrt_exceptions utils globs fists tc_8670 tc_8682 
 .PHONY: clean
 
 clean:
-	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o
+	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o lvhdrt
 
 .PHONY: install
 install:

--- a/ocaml/mpathalert/OMakefile
+++ b/ocaml/mpathalert/OMakefile
@@ -8,7 +8,7 @@ OCamlDocProgram(mpathalert, mpathalert)
 .PHONY: clean
 
 clean:
-	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o
+	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o mpathalert
 
 .PHONY: install
 install:

--- a/ocaml/multipathrt/OMakefile
+++ b/ocaml/multipathrt/OMakefile
@@ -11,7 +11,7 @@ OCamlProgram(multipathrt, \
 .PHONY: clean
 
 clean:
-	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o
+	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o multipathrt
 
 .PHONY: install
 install:

--- a/ocaml/perftest/OMakefile
+++ b/ocaml/perftest/OMakefile
@@ -16,7 +16,7 @@ section
 .PHONY: clean
 
 clean:
-	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o
+	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o histogram cumulative_time perftest
 
 .PHONY: install
 install:

--- a/ocaml/rfb/OMakefile
+++ b/ocaml/rfb/OMakefile
@@ -2,5 +2,5 @@ OCamlProgram(rfb_randomtest, rfb rfb_randomtest rfb_randomtest_main)
 
 .PHONY: clean
 clean:
-	rm -f $(CLEAN_OBJS)
+	rm -f $(CLEAN_OBJS) rfb_randomtest
 

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -303,3 +303,5 @@ sdk-install: install
 clean:
 	rm -rf $(CLEAN_OBJS) *.aux *.log *.fig xapi
 	rm -f config_constants.ml
+	rm -f binpack xapi_unit_test sparse_dd fakeguestagent monitor_fake_plugin rrddump quicktestbin
+

--- a/ocaml/xe-cli/OMakefile
+++ b/ocaml/xe-cli/OMakefile
@@ -89,6 +89,11 @@ section
 .PHONY: clean
 clean:
 	rm -f $(CLEAN_OBJS)
+	rm -f ./xe
+	rm -f ./rt/gtclient
+	rm -f ./rt/xgetip
+	rm -f ./rt/gtserver_linux
+	rm -f ./rt/test_host
 
 .SUBDIRS: rt
 

--- a/ocaml/xe-cli/rt/geneva/OMakefile
+++ b/ocaml/xe-cli/rt/geneva/OMakefile
@@ -9,7 +9,8 @@ OCamlProgram(sm_stress, sm_stress cli_utils utils)
 
 .PHONY: clean
 clean:
-	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt cli_test sm_stress
+	rm -f *.o *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt cli_test sm_stress
+	rm -f $(DIST)/cli-regress-geneva/cli_test $(DIST)/cli-regress-geneva/sm_stress
 
 .PHONY: install
 install:

--- a/ocaml/xsh/OMakefile
+++ b/ocaml/xsh/OMakefile
@@ -14,4 +14,4 @@ install:
 	cp -f xsh $(BIN_PATH)
 
 clean:
-	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o
+	rm -f *.cmi *.cmx *.cmo *.a *.cma *.cmxa *.run *.opt *.annot *.o xsh

--- a/ocaml/xstest/OMakefile
+++ b/ocaml/xstest/OMakefile
@@ -7,4 +7,4 @@ OCamlProgram(xscheckperms, perms common)
 
 .PHONY: clean
 clean:
-	rm -rf $(CLEAN_OBJS) *.aux *.log *.fig xapi
+	rm -rf $(CLEAN_OBJS) *.aux *.log *.fig xapi xstest xsbench xscheckperms


### PR DESCRIPTION
We weren't properly cleaning up after builds, which was breaking debuild (Debian package builder). This patch adds new clean targets to our OMakefiles.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
