### PR TITLE
Tell the frontend driver about the MTU

### DIFF
--- a/scripts/vif
+++ b/scripts/vif
@@ -62,6 +62,7 @@ handle_mtu()
     if [ $? -eq 0 -a -n "${mtu}" ]; then
         logger -t scripts-vif "Setting ${dev} MTU ${mtu}"
         ${IP} link set "${dev}" mtu ${mtu} || logger -t scripts-vif "Failed to ip link set ${dev} mtu ${mtu}. Error code $?"
+        xenstore-write "/local/domain/${DOMID}/device/vif/${DEVID}/mtu" "${mtu}"
     fi
 }
 


### PR DESCRIPTION
This patch simply introduces a key into the frontend driver area so it knows what MTU the backend vif has been given, hence it can reflect it through to the frontend stack.
