### PR TITLE
Add platform options for HVM display adapter and videoram.

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -1342,7 +1342,7 @@ type info = {
 	power_mgmt : int option;
 	oem_features : int option;
 	inject_sci : int option;
-	videoram : int;
+	video_mib : int;
 
 	extras: (string * string option) list;
 }
@@ -1409,7 +1409,7 @@ let xenclient_specific ~xs info domid =
       | Some device -> [ "-soundhw"; device ]
   in
 
-  ["-videoram"; string_of_int info.videoram;
+  ["-videoram"; string_of_int info.video_mib;
    "-M"; (if info.hvm then "xenfv" else "xenpv")] 
   @ sound_options
    

--- a/ocaml/xenops/device.mli
+++ b/ocaml/xenops/device.mli
@@ -191,7 +191,7 @@ sig
 		power_mgmt: int option;
 		oem_features: int option;
 		inject_sci: int option;
-		videoram: int;
+		video_mib: int;
 	       
 		extras: (string * string option) list;
 	}

--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -36,6 +36,7 @@ type create_info = {
 type build_hvm_info = {
 	shadow_multiplier: float;
 	timeoffset: string;
+	video_mib: int;
 }
 
 type build_pv_info = {
@@ -472,10 +473,11 @@ let build_linux ~xc ~xs ~static_max_kib ~target_kib ~kernel ~cmdline ~ramdisk
 	assert (target_mib <= static_max_mib);
 
 	(* Adapt memory configuration values for Xen and the domain builder. *)
+	let video_mib = 0 in
 	let build_max_mib =
-		Memory.Linux.build_max_mib static_max_mib in
+		Memory.Linux.build_max_mib static_max_mib video_mib in
 	let build_start_mib =
-		Memory.Linux.build_start_mib target_mib in
+		Memory.Linux.build_start_mib target_mib video_mib in
 	let xen_max_mib =
 		Memory.Linux.xen_max_mib static_max_mib in
 	let shadow_multiplier =
@@ -530,7 +532,7 @@ let build_linux ~xc ~xs ~static_max_kib ~target_kib ~kernel ~cmdline ~ramdisk
 
 (** build hvm type of domain *)
 let build_hvm ~xc ~xs ~static_max_kib ~target_kib ~shadow_multiplier ~vcpus
-              ~kernel ~timeoffset domid =
+              ~kernel ~timeoffset ~video_mib domid =
 	assert_file_is_readable kernel;
 
 	(* Convert memory configuration values into the correct units. *)
@@ -542,9 +544,9 @@ let build_hvm ~xc ~xs ~static_max_kib ~target_kib ~shadow_multiplier ~vcpus
 
 	(* Adapt memory configuration values for Xen and the domain builder. *)
 	let build_max_mib =
-		Memory.HVM.build_max_mib static_max_mib in
+		Memory.HVM.build_max_mib static_max_mib video_mib in
 	let build_start_mib =
-		Memory.HVM.build_start_mib target_mib in
+		Memory.HVM.build_start_mib target_mib video_mib in
 	let xen_max_mib =
 		Memory.HVM.xen_max_mib static_max_mib in
 	let shadow_mib =
@@ -616,7 +618,7 @@ let build ~xc ~xs info domid =
 	| BuildHVM hvminfo ->
 		build_hvm ~xc ~xs ~static_max_kib:info.memory_max ~target_kib:info.memory_target
 		          ~shadow_multiplier:hvminfo.shadow_multiplier ~vcpus:info.vcpus
-		          ~kernel:info.kernel ~timeoffset:hvminfo.timeoffset domid
+		          ~kernel:info.kernel ~timeoffset:hvminfo.timeoffset ~video_mib:hvminfo.video_mib domid
 	| BuildPV pvinfo   ->
 		build_linux ~xc ~xs ~static_max_kib:info.memory_max ~target_kib:info.memory_target
 		            ~kernel:info.kernel ~cmdline:pvinfo.cmdline ~ramdisk:pvinfo.ramdisk

--- a/ocaml/xenops/domain.mli
+++ b/ocaml/xenops/domain.mli
@@ -38,6 +38,7 @@ type create_info = {
 type build_hvm_info = {
 	shadow_multiplier: float;
 	timeoffset: string;
+	video_mib: int;
 }
 
 type build_pv_info = {
@@ -115,7 +116,7 @@ val build_linux: xc: Xc.handle -> xs: Xs.xsh -> static_max_kib:Int64.t
 val build_hvm: xc: Xc.handle -> xs: Xs.xsh -> static_max_kib:Int64.t
             -> target_kib:Int64.t -> shadow_multiplier:float
             -> vcpus:int -> kernel:string
-            -> timeoffset:string -> domid
+            -> timeoffset:string -> video_mib:int -> domid
             -> domarch
 
 (** Restore a domain using the info provided *)

--- a/ocaml/xenops/memory.ml
+++ b/ocaml/xenops/memory.ml
@@ -127,28 +127,25 @@ let get_total_memory_bytes ~xc =
 (* === Domain memory breakdown: HVM guests ================================== *)
 
 module type MEMORY_MODEL_DATA = sig
-	val video_mib : int64
 	val extra_internal_mib : int64
 	val extra_external_mib : int64
 end
 
 module HVM_memory_model_data : MEMORY_MODEL_DATA = struct
-	let video_mib = 4L
 	let extra_internal_mib = 1L
 	let extra_external_mib = 1L
 end
 
 module Linux_memory_model_data : MEMORY_MODEL_DATA = struct
-	let video_mib = 0L
 	let extra_internal_mib = 0L
 	let extra_external_mib = 1L
 end
 
 module Memory_model (D : MEMORY_MODEL_DATA) = struct
 
-	let build_max_mib static_max_mib = static_max_mib --- D.video_mib
+	let build_max_mib static_max_mib video_mib = static_max_mib --- (Int64.of_int video_mib)
 
-	let build_start_mib target_mib = target_mib --- D.video_mib
+	let build_start_mib target_mib video_mib = target_mib --- (Int64.of_int video_mib)
 
 	let xen_max_offset_mib = D.extra_internal_mib
 

--- a/ocaml/xenops/xenops.ml
+++ b/ocaml/xenops/xenops.ml
@@ -72,7 +72,7 @@ let build_domain ~xc ~xs ~kernel ?(ramdisk=None) ~cmdline ~domid ~vcpus ~static_
 
 let build_hvm ~xc ~xs ~kernel ~domid ~vcpus ~static_max_kib ~target_kib =
 	let (_: Domain.domarch) = Domain.build_hvm xc xs static_max_kib target_kib 1.
-	                                           vcpus kernel "0" domid in
+	                                           vcpus kernel "0" 4 domid in
 	printf "built hvm domain: %u\n" domid
 
 let clean_shutdown_domain ~xal ~domid ~reason ~sync =
@@ -355,7 +355,7 @@ let add_dm ~xs ~domid ~static_max_kib ~vcpus ~boot =
 	  Device.Dm.power_mgmt=None;
 	  Device.Dm.oem_features=None;
 	  Device.Dm.inject_sci=None;
-	  Device.Dm.videoram=0;
+	  Device.Dm.video_mib=0;
 
  	  Device.Dm.extras = []
  	} in


### PR DESCRIPTION
$ xe vm-param-set uuid=... platform:vga=std
$ xe vm-param-set uuid=... platform:videoram=16

will configure the guest to have 16 MiB of video memory, using a stdvga interface.

NB the defaults are unchanged: cirrus and 4 MiB

Signed-off-by: David Scott dave.scott@eu.citrix.com
