### PR TITLE
Update xapi following Http_svr interface change: "empty" is now a functio

### DIFF
--- a/ocaml/license/v6daemon.ml
+++ b/ocaml/license/v6daemon.ml
@@ -36,7 +36,7 @@ let xmlrpc_handler process req bio =
 	let str = Xmlrpc.string_of_response result in
 	Http_svr.response_str req s str
 
-let server = Http_svr.Server.empty
+let server = Http_svr.Server.empty ()
 
 let daemon_init post_daemonize_hook process =
 	post_daemonize_hook ();

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -597,7 +597,7 @@ let initialise () =
 
 module Local_domain_socket = struct
 	(** Code to create a standalone process listening on a Unix domain socket. *)
-	let server = Http_svr.Server.empty
+	let server = Http_svr.Server.empty ()
 
 	let socket = ref None
 

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -222,7 +222,7 @@ let with_context ?(dummy=false) label (req: Request.t) (s: Unix.file_descr) f =
 
 (* Other exceptions are dealt with by the Http_svr module's exception handler *)
 
-let server = Http_svr.Server.empty
+let server = Http_svr.Server.empty ()
 	  
 let http_request = Http.Request.make ~user_agent:Xapi_globs.xapi_user_agent
 


### PR DESCRIPTION
Update xapi following Http_svr interface change: "empty" is now a function from unit -> t

Signed-off-by: David Scott dave.scott@eu.citrix.com
