### PR TITLE
CA-67761: ommit the DEVICE=xxx line when executing batch script

### DIFF
--- a/scripts/with-vdi
+++ b/scripts/with-vdi
@@ -20,15 +20,15 @@ if [ -z "$(xe vdi-list params=uuid uuid=${VDI})" ]; then
 fi
 
 COMMAND=$2
-if [ -z "$COMMAND" ]; then
-  COMMAND=/bin/sh
-elif ! which "$COMMAND" > /dev/null ; then
-  echo Failed to find command: ${COMMAND}
-  usage
-  exit 1
-else
-  shift 1
-  COMMAND=$*
+if [ -n "$COMMAND" ]; then
+  if ! which "$COMMAND" > /dev/null ; then
+    echo Failed to find command: ${COMMAND}
+    usage
+    exit 1
+  else
+    shift 1
+    COMMAND=$*
+  fi
 fi
 
 . /etc/xensource-inventory
@@ -42,7 +42,10 @@ VBD=`xe vbd-create vm-uuid=${CONTROL_DOMAIN_UUID} vdi-uuid=${VDI} device=autodet
 xe vbd-plug uuid=${VBD}
 DEVICE=`xe vbd-param-get uuid=${VBD} param-name=device`
 export DEVICE
-echo DEVICE=${DEVICE}
+if [ -z "$COMMAND" ]; then
+  echo DEVICE=${DEVICE}
+  COMMAND=/bin/sh
+fi
 ${COMMAND}
 RC=$?
 xe vbd-unplug uuid=${VBD} timeout=15


### PR DESCRIPTION
... for the benefit of some not-so-robust XenRT testcases. The information will still get printed out when we use the interactive shell mode.

Signed-off-by: Zheng Li zheng.li@eu.citrix.com
