### PR TITLE
CA-67728: merge request for resolving CA-66403, for HFX-225

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -272,9 +272,9 @@ let compute_evacuation_plan_no_wlb ~__context ~host =
 								Db.VM_guest_metrics.get_record_internal
 									~__context ~self:vm_record.API.vM_guest_metrics)) in
 					let pv_drivers_error =
-						if Helpers.has_booted_hvm ~__context ~self:vm
-						then None
-						else
+						if not (Helpers.has_booted_hvm ~__context ~self:vm)
+						then None       (* PV guests don't need driver check *)
+						else            (* HVM guest do *)
 							if Xapi_pv_driver_version.is_ok_for_migrate pv_driver_version
 							then None
 							else Some Api_errors.vm_missing_pv_drivers in


### PR DESCRIPTION
An incorrect patch (sha 42914ac) caused host_evacuate to check the PV drivers
for PV guests, but not for HVM guests. This causes a rolling pool upgrade to
fail when it tries to migrate HVM guests which don't have PV drivers installed.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
