### PR TITLE
CA-68356: xe-backup-metadata should ignore snapshots

### DIFF
--- a/scripts/link-vms-by-sr.py
+++ b/scripts/link-vms-by-sr.py
@@ -52,6 +52,9 @@ def main(argv):
         # Ignore dom0
         if vmrec['is_control_domain']:
             continue
+        # Ignore snapshots
+        if vmrec['is_a_snapshot']:
+            continue
 
         # for each VM, figure out the set of SRs it uses
         for vbd in vmrec['VBDs']:


### PR DESCRIPTION
Snapshots of VMs are handled automatically when ex/importing a VM.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
