### PR TITLE
Add a websockets console proxy to xapi

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7483,6 +7483,8 @@ let http_actions = [
   ("get_export_metadata", (Get, Constants.export_metadata_uri, true, [String_query_arg "uuid"], _R_VM_ADMIN, []));
   ("connect_console", (Connect, Constants.console_uri, false, [], _R_VM_OP, 
     [("host_console", _R_POOL_ADMIN)])); (* only _R_POOL_ADMIN can access the host/Dom0 console *)
+  ("connect_console_ws", (Get, Constants.console_uri, false, [], _R_VM_OP, 
+    [("host_console_ws", _R_POOL_ADMIN)])); (* only _R_POOL_ADMIN can access the host/Dom0 console *)
   ("get_root", (Get, "/", false, [], _R_READ_ONLY, []));
   ("post_cli", (Post, Constants.cli_uri, false, [], _R_READ_ONLY, []));
   ("get_host_backup", (Get, Constants.host_backup_uri, true, [], _R_POOL_ADMIN, []));

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -668,6 +668,7 @@ let common_http_handlers = [
   ("get_export", (Http_svr.FdIO Export.handler));
   ("get_export_metadata", (Http_svr.FdIO Export.metadata_handler));
   ("connect_console", Http_svr.FdIO (Console.handler Console.real_proxy));
+  ("connect_console_ws", Http_svr.FdIO (Console.handler Console.ws_proxy));
   ("get_root", Http_svr.BufIO (Fileserver.send_file "/" (Xapi_globs.base_path ^ "/www")));
   ("post_cli", (Http_svr.BufIO Xapi_cli.handler));
   ("get_host_backup", (Http_svr.FdIO Xapi_host_backup.host_backup_handler));


### PR DESCRIPTION
The actual proxying is done by another process, wsproxy, available
at http://github.com/jonludlam/wsproxy

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
