### PR TITLE
Add a flag (Pool.other_config:force_loopback_vbd) which will trigger the 

### DIFF
--- a/ocaml/xapi/events.ml
+++ b/ocaml/xapi/events.ml
@@ -220,6 +220,8 @@ module Resync = struct
       let domid = Int64.to_int (Db.VM.get_domid ~__context ~self:vm) in
 	  let driver_vm = System_domains.storage_driver_domain_of_vbd ~__context ~vbd in
 	  let is_loopback = driver_vm = vm in
+	  let force_loopback_vbd = Helpers.force_loopback_vbd ~__context in
+
 	  let is_attached = Db.VBD.get_currently_attached ~__context ~self:vbd in
       debug "VM %s (domid: %d) Resync.vbd %s" (Ref.string_of vm) domid (Ref.string_of vbd);
       assert_not_on_xal_thread ();
@@ -234,7 +236,7 @@ module Resync = struct
 		  then debug "VM is suspended: leaving currently-attached as-is"
 		  else Db.VBD.set_currently_attached ~__context ~self:vbd ~value:online in
 
-	  if is_loopback then begin
+	  if is_loopback && not force_loopback_vbd then begin
 		  let online = Storage_access.is_attached ~__context ~vbd ~domid in
 		  if is_attached = online then begin
 			  debug "VBD %s currently_attached field is in sync with storage layer" (Ref.string_of vbd)

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -891,3 +891,9 @@ let short_string_of_ref x =
   let x' = Ref.string_of x in
   String.sub x' (String.length "OpaqueRef:") 8
 
+let force_loopback_vbd ~__context =
+	(* Workaround assumption in SMRT: if a global flag is set, force use
+	   of loopback VBDs. *)
+	let pool = get_pool ~__context in
+	let other_config = Db.Pool.get_other_config ~__context ~self:pool in
+	List.mem_assoc "force_loopback_vbd" other_config

--- a/ocaml/xapi/vbdops.ml
+++ b/ocaml/xapi/vbdops.ml
@@ -71,6 +71,8 @@ let create_vbd ~__context ~xs ~hvm ~protocol domid self =
 
 	let vdi = Db.VBD.get_VDI ~__context ~self in
 
+	let force_loopback_vbd = Helpers.force_loopback_vbd ~__context in
+
 	if empty then begin
 		if hvm then begin
 			let (_: Device_common.device) = Device.Vbd.add ~xs ~hvm ~mode ~phystype:Device.Vbd.File ~params:""
@@ -78,7 +80,7 @@ let create_vbd ~__context ~xs ~hvm ~protocol domid self =
 			Db.VBD.set_device ~__context ~self ~value:(Device_number.to_linux_device device_number);
 			Db.VBD.set_currently_attached ~__context ~self ~value:true;			
 		end else info "domid: %d PV guests don't support the concept of an empty CD; skipping device" domid
-	end else if System_domains.storage_driver_domain_of_vbd ~__context ~vbd:self = Db.VBD.get_VM ~__context ~self then begin
+	end else if System_domains.storage_driver_domain_of_vbd ~__context ~vbd:self = Db.VBD.get_VM ~__context ~self && not force_loopback_vbd then begin
 		debug "VBD.plug of loopback VBD '%s'" (Ref.string_of self);
 		Storage_access.attach_and_activate ~__context ~vbd:self ~domid ~hvm
 			(fun params ->

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -83,12 +83,13 @@ let dynamic_destroy ?(do_safety_check=true) ~__context ~vbd (force: bool) token 
 		raise (Api_errors.Server_error (Api_errors.device_already_detached,[Ref.string_of vbd]));
 	let vm = Db.VBD.get_VM ~__context ~self:vbd in
 	let hvm = Helpers.has_booted_hvm ~__context ~self:vm in
+	let force_loopback_vbd = Helpers.force_loopback_vbd ~__context in
 	(* 'empty' VBDs are represented to PV VMs as nothing since the
 	   PV block protocol doesn't support empty devices *)
 	if not hvm && Db.VBD.get_empty ~__context ~self:vbd then begin
 	  debug "VBD.unplug of empty VBD '%s' from VM '%s'" (Db.VBD.get_uuid ~__context ~self:vbd) (Db.VM.get_uuid ~__context ~self:vm);
 	  Db.VBD.set_currently_attached ~__context ~self:vbd ~value:false
-	end else if System_domains.storage_driver_domain_of_vbd ~__context ~vbd = vm then begin
+	end else if System_domains.storage_driver_domain_of_vbd ~__context ~vbd = vm && not force_loopback_vbd then begin
 		debug "VBD.unplug of loopback VBD '%s'" (Ref.string_of vbd);
 		let domid = Int64.to_int (Db.VM.get_domid ~__context ~self:vm) in
 		Storage_access.deactivate_and_detach ~__context ~vbd ~domid ~unplug_frontends:true;


### PR DESCRIPTION
Add a flag (Pool.other_config:force_loopback_vbd) which will trigger the formation of redundant dom0 block attaches.

This is a temporary measure until the SMRT test can be fixed.

Signed-off-by: David Scott dave.scott@eu.citrix.com
