### PR TITLE
CA-68721: make sure we "listen" before we "accept" on the host internal m

### DIFF
--- a/ocaml/xapi/xapi_network_real.ml
+++ b/ocaml/xapi/xapi_network_real.ml
@@ -86,6 +86,8 @@ let http_proxy master_ip ip =
 				let handler = { Server_io.name = "http_proxy"; body = tcp_connection } in
 				let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
 				Unix.bind sock sockaddr;
+				Unix.setsockopt sock Unix.SO_REUSEADDR true;
+				Unixext.set_tcp_nodelay sock true;
 				Unix.listen sock 5;
 				let s = Server_io.server handler sock in
 				server := Some s


### PR DESCRIPTION
CA-68721: make sure we "listen" before we "accept" on the host internal management network socket.

Signed-off-by: David Scott dave.scott@eu.citrix.com
