### PR TITLE
CA-68641: Add missing hashing-algorithm key to InterfaceReconfigure.py

### DIFF
--- a/scripts/InterfaceReconfigure.py
+++ b/scripts/InterfaceReconfigure.py
@@ -283,7 +283,7 @@ _ETHTOOL_OTHERCONFIG_ATTRS = ['ethtool-%s' % x for x in 'autoneg', 'speed', 'dup
 
 _PIF_OTHERCONFIG_ATTRS = [ 'domain', 'peerdns', 'defaultroute', 'mtu', 'static-routes' ] + \
                         [ 'bond-%s' % x for x in 'mode', 'miimon', 'downdelay', 'updelay', 'use_carrier' ] + \
-			[ 'vlan-bug-workaround' ] + \
+                        [ 'vlan-bug-workaround', 'hashing-algorithm' ] + \
                         _ETHTOOL_OTHERCONFIG_ATTRS
 
 _PIF_ATTRS = { 'uuid': (_str_to_xml,_str_from_xml),


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
