### PR TITLE
Remove compiler warning in odoc_json.ml that broke "make doc"

### DIFF
--- a/ocaml/doc/odoc_json.ml
+++ b/ocaml/doc/odoc_json.ml
@@ -91,7 +91,6 @@ let remove_asterisks str =
 				phase := false;
 				Buffer.add_char res str.[i]
 			end
-		| _ -> failwith "something went wrong!"
 	done;
 	Buffer.contents res
 


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
