### PR TITLE
CA-69134: ignore spurious failures caused by interleaving parallel "remov

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -381,6 +381,7 @@ let make_remote host path =
 let bind ~__context ~pbd =
     (* Start the VM if necessary, record its uuid *)
     let driver = System_domains.storage_driver_domain_of_pbd ~__context ~pbd in
+	System_domains.record_pbd_storage_driver_domain ~__context ~pbd ~domain:driver;
     if Db.VM.get_power_state ~__context ~self:driver = `Halted then begin
         info "PBD %s driver domain %s is offline: starting" (Ref.string_of pbd) (Ref.string_of driver);
         Helpers.call_api_functions ~__context

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -64,6 +64,12 @@ let vm_set_storage_driver_domain ~__context ~self ~value =
 			Db.VM.add_to_other_config ~__context ~self ~key:storage_driver_domain_key ~value
 		) ()
 
+let record_pbd_storage_driver_domain ~__context ~pbd ~domain =
+	set_is_system_domain ~__context ~self:domain ~value:"true";
+	pbd_set_storage_driver_domain ~__context ~self:pbd ~value:(Ref.string_of domain);
+	vm_set_storage_driver_domain ~__context ~self:domain ~value:(Ref.string_of pbd)
+
+
 let pbd_of_vm ~__context ~vm =
 	let other_config = Db.VM.get_other_config ~__context ~self:vm in
 	if List.mem_assoc storage_driver_domain_key other_config
@@ -83,13 +89,6 @@ let storage_driver_domain_of_pbd ~__context ~pbd =
 			with _ ->
 				failwith (Printf.sprintf "PBD %s has invalid %s key" (Ref.string_of pbd) storage_driver_domain_key)
 	end else dom0
-
-let storage_driver_domain_of_pbd ~__context ~pbd =
-	let domain = storage_driver_domain_of_pbd ~__context ~pbd in
-	set_is_system_domain ~__context ~self:domain ~value:"true";
-	pbd_set_storage_driver_domain ~__context ~self:pbd ~value:(Ref.string_of domain);
-	vm_set_storage_driver_domain ~__context ~self:domain ~value:(Ref.string_of pbd);
-	domain
 
 let storage_driver_domain_of_vbd ~__context ~vbd =
 	let dom0 = Helpers.get_domain_zero ~__context in

--- a/ocaml/xapi/system_domains.mli
+++ b/ocaml/xapi/system_domains.mli
@@ -29,6 +29,10 @@ val storage_driver_domain_of_pbd: __context:Context.t -> pbd:API.ref_PBD -> API.
     the storage backends for [vbd] on this host *)
 val storage_driver_domain_of_vbd: __context:Context.t -> vbd:API.ref_VBD -> API.ref_VM
 
+(** [record_pbd_storage_driver_domain __context pbd domain] persists [domain]
+    as the driver domain for [pbd]. *)
+val record_pbd_storage_driver_domain: __context:Context.t -> pbd:API.ref_PBD -> domain:API.ref_VM -> unit
+
 (** [pbd_of_vm __context vm] returns (Some pbd) if [vm] is a driver domain
 	for [pbd] and None otherwise. *)
 val pbd_of_vm: __context:Context.t -> vm:API.ref_VM -> API.ref_PBD option


### PR DESCRIPTION
CA-69134: ignore spurious failures caused by interleaving parallel "remove_from_other_config" and "add_to_other_config"

xapi tracks where its storage drivers live (always in domain 0). The code which sets the other_config keys can run in parallel; it's safe to ignore the MAP_DUPLICATE_KEY exception because the key/value will have been set by a parallel operation to the same value.

Signed-off-by: David Scott dave.scott@eu.citrix.com
