### PR TITLE
SMAPI: use the SR uuid to identify SRs in the SMAPI (rather than the xap...

### DIFF
--- a/ocaml/xapi/vbdops.ml
+++ b/ocaml/xapi/vbdops.ml
@@ -95,7 +95,7 @@ let create_vbd ~__context ~xs ~hvm ~protocol domid self =
 		let phystype = Device.Vbd.physty_of_string (Sm.sr_content_type ~__context ~sr) in
 		Storage_access.attach_and_activate ~__context ~vbd:self ~domid ~hvm
 			(fun params ->
-				let backend_domid = Storage_mux.domid_of_sr (Ref.string_of sr) in
+				let backend_domid = Storage_mux.domid_of_sr (Db.SR.get_uuid ~__context ~self:sr) in
 				try
 					(* The backend can put useful stuff in here on vdi_attach *)
 					let extra_backend_keys = List.map (fun (k, v) -> "sm-data/" ^ k, v) (Db.VDI.get_xenstore_data ~__context ~self:vdi) in

--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -113,7 +113,7 @@ let plug ~__context ~self =
 				let task = Ref.string_of (Context.get_task_id __context) in
 				let device_config = Db.PBD.get_device_config ~__context ~self in
 				Storage_access.expect_unit (fun () -> ())
-					(Storage_interface.Client.SR.attach Storage_access.rpc task (Ref.string_of sr) device_config);
+					(Storage_interface.Client.SR.attach Storage_access.rpc task (Db.SR.get_uuid ~__context ~self:sr) device_config);
 				Db.PBD.set_currently_attached ~__context ~self ~value:true;
 			end
 
@@ -164,7 +164,7 @@ let unplug ~__context ~self =
 			end;
 			let task = Ref.string_of (Context.get_task_id __context) in
 			Storage_access.expect_unit (fun () -> ())
-				(Storage_interface.Client.SR.detach Storage_access.rpc task (Ref.string_of sr));
+				(Storage_interface.Client.SR.detach Storage_access.rpc task (Db.SR.get_uuid ~__context ~self:sr));
             Storage_access.unbind ~__context ~pbd:self;
 			Db.PBD.set_currently_attached ~__context ~self ~value:false
 		end

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -521,7 +521,7 @@ let scan ~__context ~sr =
     let open Storage_interface in
 
 	let sr' = Ref.string_of sr in
-	match Client.SR.scan rpc ~task:(Ref.string_of task) ~sr:sr' with
+	match Client.SR.scan rpc ~task:(Ref.string_of task) ~sr:(Db.SR.get_uuid ~__context ~self:sr) with
 		| Success (Vdis vs) ->
 			let db_vdis = Db.VDI.get_records_where ~__context ~expr:(Eq(Field "SR", Literal sr')) in
 			update_vdis ~__context ~sr:sr db_vdis vs;

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -235,7 +235,7 @@ let create ~__context ~name_label ~name_description
             if virtual_size < vi.virtual_size
             then info "sr:%s vdi:%s requested virtual size %Ld < actual virtual size %Ld" (Ref.string_of sR) vi.vdi virtual_size vi.virtual_size;
             newvdi ~__context ~sr:sR vi
-        ) (Client.VDI.create rpc ~task:(Ref.string_of task) ~sr:(Ref.string_of sR)
+        ) (Client.VDI.create rpc ~task:(Ref.string_of task) ~sr:(Db.SR.get_uuid ~__context ~self:sR)
 			~vdi_info ~params:sm_config)
 
 (* Make the database record only *)
@@ -388,7 +388,7 @@ let destroy ~__context ~self =
           let open Storage_interface in
           let task = Context.get_task_id __context in
           expect_unit (fun () -> ())
-              (Client.VDI.destroy rpc ~task:(Ref.string_of task) ~sr:(Ref.string_of sr) ~vdi:location);
+              (Client.VDI.destroy rpc ~task:(Ref.string_of task) ~sr:(Db.SR.get_uuid ~__context ~self:sr) ~vdi:location);
 
 	(* destroy all the VBDs now rather than wait for the GC thread. This helps
 	   prevent transient glitches but doesn't totally prevent races. *)

--- a/ocaml/xapi/xen_helpers.ml
+++ b/ocaml/xapi/xen_helpers.ml
@@ -34,7 +34,7 @@ let device_of_vbd ~__context ~self =
         else
             let vdi = Db.VBD.get_VDI ~__context ~self in
             let sr = Db.VDI.get_SR ~__context ~self:vdi in
-			Storage_mux.domid_of_sr (Ref.string_of sr) in
+			Storage_mux.domid_of_sr (Db.SR.get_uuid ~__context ~self:sr) in
   let vm = Db.VBD.get_VM ~__context ~self in
   let domid = Int64.to_int (Db.VM.get_domid ~__context ~self:vm) in
   let hvm = 


### PR DESCRIPTION
...i reference). This allows other clients to speak SMAPI more easily.

Signed-off-by: David Scott dave.scott@eu.citrix.com
