### PR TITLE
Let's not expose POST /servvices/SM in the SDK for now.

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7531,7 +7531,7 @@ let rbac_http_permission_prefix = "http/"
 *)
 let http_actions = [
   ("get_services", (Get, Constants.services_uri, true, [], _R_READ_ONLY, []));
-  ("post_services", (Post, Constants.services_uri, true, [], _R_POOL_ADMIN, []));
+  ("post_services", (Post, Constants.services_uri, false, [], _R_POOL_ADMIN, []));
   ("post_remote_db_access", (Post, Constants.remote_db_access_uri, false, [], _R_POOL_ADMIN, []));
   ("post_remote_db_access_v2", (Post, Constants.remote_db_access_uri_v2, false, [], _R_POOL_ADMIN, []));
   ("connect_migrate", (Connect, Constants.migrate_uri, false, [], _R_VM_POWER_ADMIN, []));


### PR DESCRIPTION
The bindings generator can't cope with POST yet.

Signed-off-by: David Scott dave.scott@eu.citrix.com
