### PR TITLE
EA-1110/CI-18: reduce stunnel TIMEOUTclose setting for mis-behaved clients

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -71,7 +71,7 @@ accept = ${MGMT_IP}:443
 connect = 80
 cert = ${PEMFILE}
 ciphers = !SSLv2:RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA
-TIMEOUTclose = 5
+TIMEOUTclose = 0
 EOF
 
     fi


### PR DESCRIPTION
The fix was for CA-59191, written by Jonathan Davies.

The TIMEOUTclose was introduced to cope with mis-behaved SSL client such as MS IE etc (python XMLRPC/SSL seems to have similar issue) in that they do not send out close_notify before dropping the the connection. In such case, stunnel will do a polling of TIMEOUTclose before timing out the connection. That's the 5 seconds we observed here (The python client probably does some shutdown and then wait for close sort of thing, hence the delay, I don't have the time to verify). There are pitfalls however .... more in the ticket comments.

Signed-off-by: Jonathan Davies jonathan.davies@citrix.com
Acked-by: Zheng Li zheng.li@eu.citrix.com
