### PR TITLE
[block]: remove physical-device workaround following linux-2.6.32.pq.hg ...

### DIFF
--- a/ocaml/xapi/monitor.ml
+++ b/ocaml/xapi/monitor.ml
@@ -35,6 +35,7 @@
 open Threadext
 open Stringext
 open Listext
+open Fun
 open Printf
 open Vmopshelpers
 open Monitor_types
@@ -365,7 +366,8 @@ let update_vbds doms =
       else
 	Scanf.sscanf vbd "vbd-%d-%d" (fun id devid -> (id, devid))
     in
-    let device_name = Device.Vbd.device_name devid in
+	let open Device_number in
+	let device_name = devid |> of_xenstore_key |> to_linux_device in
     let vbd_name = Printf.sprintf "vbd_%s" device_name in
     (* If blktap fails to cleanup then we might find a backend domid which doesn't
        correspond to an active domain uuid. Skip these for now. *)

--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -282,55 +282,6 @@ let shutdown_mode_of_device ~xs (x: device) =
 	then ShutdownRequest
 	else Classic
 
-let blkback_needs_physical_device_in_transaction ~xs (x: device) =
-	read_feature_flag ~xs x "feature-blkback-needs-physical-device-in-transaction"
-
-let major_number_table = [| 3; 22; 33; 34; 56; 57; 88; 89; 90; 91 |]
-
-(** Given a string device name, return the major and minor number *)
-let device_major_minor name =
-	(* This is the same algorithm xend uses: *)
-	let a = int_of_char 'a' in
-	(* Interpret as 'sda1', 'hda' etc *)
-	try
-		let number chars =
-			if chars = [] then
-				0
-			else
-			int_of_string (String.implode chars) in
-		match String.explode name with
-		| 's' :: 'd' :: ('a'..'p' as letter) :: rest ->
-			8, 16 * (int_of_char letter - a) + (number rest)
-		| 'x' :: 'v' :: 'd' :: ('a'..'p' as letter) :: rest ->
-			202, 16 * (int_of_char letter - a) + (number rest)
-		| 'h' :: 'd' :: ('a'..'t' as letter) :: rest ->
-			let n = int_of_char letter - a in
-			major_number_table.(n / 2), 64 * (n mod 2) + (number rest)
-		| _ ->
-			raise (Device_unrecognized name)
-	with _ ->
-		let file = if Filename.is_relative name then "/dev/" ^ name else name in
-		Statdev.get_major_minor file
-
-(** Given a major and minor number, return a device name *)
-let major_minor_to_device (major, minor) =
-	let a = int_of_char 'a' in
-	let number x = if x = 0 then "" else string_of_int x in
-	match major with
-	| 8 -> Printf.sprintf "sd%c%s" (char_of_int (minor / 16 + a)) (number (minor mod 16))
-	| 202 -> Printf.sprintf "xvd%c%s" (char_of_int (minor / 16 + a)) (number (minor mod 16))
-	| x ->
-	    (* Find the index of x in the table *)
-	    let n = snd(Array.fold_left (fun (idx, result) n -> idx + 1, if x = n then idx else result) (0, -1) major_number_table) in
-	    if n = -1 then failwith (Printf.sprintf "Couldn't determine device name for (%d, %d)" major minor)
-	    else
-	      let plus_one, minor = if minor >= 64 then 1, minor - 64 else 0, minor in
-	      Printf.sprintf "hd%c%s" (char_of_int (n * 2 + plus_one + a)) (number minor)
-
-let device_name number =
-	let major, minor = number / 256, number mod 256 in
-	major_minor_to_device (major, minor)
-
 type mode = ReadOnly | ReadWrite
 
 let string_of_mode = function
@@ -380,10 +331,6 @@ let devty_of_string = function
 	| "cdrom" -> CDROM
 	| "disk"  -> Disk
 	| _       -> invalid_arg "devty_of_string"
-
-let string_of_major_minor file =
-	let major, minor = device_major_minor file in
-	sprintf "%x:%x" major minor
 
 let kind_of_physty physty =
 	match physty with
@@ -538,17 +485,9 @@ let add ~xs ~hvm ~mode ~device_number ~phystype ~params ~dev_type ~unpluggable
 		"mode", string_of_mode mode;
 		"params", params;
 	];
-	if blkback_needs_physical_device_in_transaction ~xs device then
-		Hashtbl.add back_tbl "physical-device" (string_of_major_minor params);
 
 	if protocol <> Protocol_Native then
 		Hashtbl.add front_tbl "protocol" (string_of_protocol protocol);
-
-	if hvm && dev_type = CDROM then
-	  (* CA-50383: Don't place physical-device in the HVM CDROM
- 	     case, to prevent blkback from pinning the device node. A
- 	     Vbd.media_eject will only make qemu close it again. *)
-	  Hashtbl.remove back_tbl "physical-device";
 
 	let back = Hashtbl.to_list back_tbl in
 	let front = Hashtbl.to_list front_tbl in

--- a/ocaml/xenops/device.mli
+++ b/ocaml/xenops/device.mli
@@ -43,10 +43,6 @@ sig
 	val string_of_devty : devty -> string
 	val devty_of_string : string -> devty
 
-	val device_name : int -> string
-	val device_major_minor : string -> int * int
-	val major_minor_to_device : int * int -> string
-
 	val add : xs:Xenstore.Xs.xsh -> hvm:bool -> mode:mode
 	       -> device_number:Device_number.t
 	       -> phystype:physty -> params:string

--- a/ocaml/xenops/xenops.ml
+++ b/ocaml/xenops/xenops.ml
@@ -420,14 +420,6 @@ let affinity_get ~xc ~domid ~vcpu =
 	Array.iteri (fun i b -> s.[i] <- if b then '1' else '0') cpumap;
 	printf "%s\n" s
 
-let self_test () =
-    let device_tests = [ "sda2"; "sda"; "xvdd"; "xvda1"; "hde4"; "hdf" ] in
-    let numbers = List.map Device.Vbd.device_major_minor device_tests in
-    let names = List.map Device.Vbd.major_minor_to_device numbers in
-    List.iter (fun (a, ((major, minor), b)) ->
-        if a <> b then failwith (Printf.sprintf "%s -> (%d, %d) -> %s" a major minor b))
-        (List.combine device_tests (List.combine numbers names))
-
 let cmd_alias cmd =
 	match cmd with
 	| "init"                    -> "create_domain"
@@ -871,8 +863,6 @@ let _ = try
 		with_xc (fun xc -> print_pcpus_info ~xc);
 	| "capabilities" ->
 		with_xc (fun xc -> print_endline (Xenctrl.version_capabilities xc))
-    | "test" ->
-        self_test ()
     | "help" ->
         raise (usage (try Some (List.hd otherargs) with _ -> None) allcommands)
     | s ->

--- a/scripts/init.d-xapi
+++ b/scripts/init.d-xapi
@@ -34,9 +34,6 @@ start() {
     # This init.d script is only used on the XCP 'appliance' so we assume
     # we have the shutdown-request ability in the dom0 kernel
     xenstore-write /local/domain/0/control/feature-shutdown-request 1
-    # we also know the dom0 kernel has a bug where it needs the physical-device
-    # key to be created in the same transaction as the params key.
-	xenstore-write /local/domain/0/control/feature-blkback-needs-physical-device-in-transaction 1
 
 	# clear out any old xapi coredumps
 	rm -rf /var/xapi/debug


### PR DESCRIPTION
...c/s 547:e58106c4ba08

We can now rely on the linux udev script writing the physical-device key, needed only by the linux (dom0 or domU) kernel.

In all cases (XCP dom0, linux 3.x dom0, driver domain), xapi will only write the "params" key.

Signed-off-by: David Scott dave.scott@eu.citrix.com
