### PR TITLE
Fix trivial shell warning

### DIFF
--- a/scripts/with-vdi
+++ b/scripts/with-vdi
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function usage()
+function usage
 {
   echo
   echo Usage:


### PR DESCRIPTION
scripts/with-vdi defined a function in a syntax that gave a warning when called
with 'sh -n'.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
