### PR TITLE
CA-70699: expose CDROMs to PV guests with device-type=cdrom rather than ...

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -16,17 +16,20 @@ case "$1" in
 add)
         params=$(xenstore-read "${XENBUS_PATH}/params")
         frontend="/local/domain/${DOMID}/device/${TYPE}/${DEVID}"
-        type=$(xenstore-read "${frontend}/device-type")
-        syslog "${XENBUS_PATH}: add type=${type} params=\"${params}\""
+        syslog "${XENBUS_PATH}: add params=\"${params}\""
         # We don't have PV drivers for CDROM devices, so we prevent blkback
         # from opening the physical-device
-        if [ "${type}" != "cdrom" ]; then
+		xenstore-exists "${XENBUS_PATH}/no-physical-device"
+        if [ $? -ne 0 ]; then
           physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
           syslog "${XENBUS_PATH}: physical-device=${physical_device}"
           xenstore-exists "${XENBUS_PATH}/physical-device"
           if [ $? -eq 1 ]; then
+			syslog "${XENBUS_PATH}: writing physical-device=${physical-device}"
             xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
           fi
+        else
+          syslog "${XENBUS_PATH}: not writing physical-device because no-physical-device is present"
         fi
         xenstore-write "${HOTPLUG}/hotplug" "online"
         xenstore-write "${HOTPLUG_STATUS}" "connected"


### PR DESCRIPTION
...disk.

This information is used by the guest to (eg) decide whether to recognise
partitions within the disk. Note we don't support PV CDROMs in the sense of
media sense/ eject/ insert.

Note that we must special-case HVM guests CDROMs because
1. we must prevent blkback from opening the physical-device, since this
   would cause a subsequent qemu eject, vdi_deactivate to block
2. qemu expects the CDROM configuration to be in xenstore, as a PV
   disk configuration

Signed-off-by: David Scott dave.scott@eu.citrix.com
