### PR TITLE
xenserver/EA-1110/CI-18/timeout-value-tweaks

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -590,14 +590,14 @@ let master_connection_retry_timeout = ref (-1.)
 
 let master_connection_default_timeout = ref 10.
 
-let qemu_dm_ready_timeout = ref 1200.
+let qemu_dm_ready_timeout = ref 300.
 
 (* seconds per balancing check *)
 let squeezed_balance_check_interval = ref 10.
 
 (* Time we allow for the hotplug scripts to run before we assume something bad
    has happened and abort *)
-let hotplug_timeout = ref 1200.
+let hotplug_timeout = ref 300.
 
 let pif_reconfigure_ip_timeout = ref 300.
 
@@ -607,7 +607,7 @@ let pool_db_sync_interval = ref 300.
 let pool_data_sync_interval = ref 86400.
 
 let domain_shutdown_ack_timeout = ref 10.
-let domain_shutdown_total_timeout = ref 3600.
+let domain_shutdown_total_timeout = ref 720.
 
 (* The actual reboot delay will be a random value between base and base + extra *)
 let emergency_reboot_delay_base = ref 60.
@@ -634,7 +634,7 @@ let update_all_subjects_interval = ref 900. (* every 15 minutes *)
    reach its current memory target. *)
 let wait_memory_target_timeout = ref 256.
 
-let snapshot_with_quiesce_timeout = ref 300.
+let snapshot_with_quiesce_timeout = ref 600.
 
 (* Interval between host heartbeats *)
 let host_heartbeat_interval = ref 30.

--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -380,7 +380,7 @@ let destroy ?(preserve_xs_vm=false) ~xc ~xs domid =
 	      warn "Xenctrl.domain_getinfo %d threw unexpected error: %s -- assuming domain nolonger exists" domid (Printexc.to_string e);
 	      raise e in
 	let start = Unix.gettimeofday () in
-	let timeout = 30. in
+	let timeout = 60. in
 	while still_exists () && (Unix.gettimeofday () -. start < timeout) do
 	  Thread.delay 5.
 	done;

--- a/ocaml/xenops/watch.ml
+++ b/ocaml/xenops/watch.ml
@@ -39,7 +39,7 @@ type 'a t = { paths: path list;
 let map f x = { x with evaluate = fun ~xs -> result_map f (x.evaluate ~xs) }
   
 (** Block waiting for a result *)
-let wait_for ~xs ?(timeout=60. *. 20.) (x: 'a t) =
+let wait_for ~xs ?(timeout=300.) (x: 'a t) =
   let result = ref None in
 
   (*let start_time = Unix.gettimeofday () in


### PR DESCRIPTION
In principle, we'd like to set the timeouts to a little bit longer than the ordinary limit (just in case of stress),  but should definitely shorter than user's patience --- otherwise they would see the operations are hung and start to kill them anyway, or even worst, to kill or reboot the VMs or hosts out of panic. This is much worse than we setting and sticking to our own limit, failing quick and aborting the operation ourselves.

Signed-off-by: Zheng Li zheng.li@eu.citrix.com
