### PR TITLE
CA-71325: Bond.create should update PIF.other_config

### DIFF
--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -256,6 +256,20 @@ let add_defaults requirements properties =
 			else (requirement.name, requirement.default_value)::acc)
 		properties requirements
 
+(* Temporary measure for compatibility with current interface-reconfigure.
+ * Remove once interface-reconfigure has been updated to recognise bond.mode and bond.properties. *)
+let refresh_pif_other_config ~__context ~self =
+	let master = Db.Bond.get_master ~__context ~self in
+	let mode = Db.Bond.get_mode ~__context ~self in
+	let properties = Db.Bond.get_properties ~__context ~self in
+
+	Db.PIF.remove_from_other_config ~__context ~self:master ~key:"bond-mode";
+	Db.PIF.remove_from_other_config ~__context ~self:master ~key:"bond-hashing-algorithm";
+
+	Db.PIF.add_to_other_config ~__context ~self:master ~key:"bond-mode" ~value:(Record_util.bond_mode_to_string mode);
+	if List.mem_assoc "hashing_algorithm" properties then
+		Db.PIF.add_to_other_config ~__context ~self:master ~key:"bond-hashing-algorithm" ~value:(List.assoc "hashing_algorithm" properties)
+
 let create ~__context ~network ~members ~mAC ~mode ~properties =
 	let host = Db.PIF.get_host ~__context ~self:(List.hd members) in
 	Xapi_pif.assert_no_other_local_pifs ~__context ~host ~network;
@@ -356,8 +370,8 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
 		copy_configuration ~__context primary_slave master;
 
 		(* Temporary measure for compatibility with current interface-reconfigure.
-		 * Remove once interface-reconfigure has been updated to recognise bond.mode. *)
-		Db.PIF.add_to_other_config ~__context ~self:master ~key:"bond-mode" ~value:(Record_util.bond_mode_to_string mode);
+		 * Remove once interface-reconfigure has been updated to recognise bond.mode and bond.properties. *)
+		refresh_pif_other_config ~__context ~self:bond;
 
 		begin match management_pif with
 		| Some management_pif ->
@@ -456,20 +470,6 @@ let destroy ~__context ~self =
 		List.iter (fun slave -> Db.PIF.set_bond_slave_of ~__context ~self:slave ~value:(Ref.null)) members;
 		TaskHelper.set_progress ~__context 1.0
 	)
-
-(* Temporary measure for compatibility with current interface-reconfigure.
- * Remove once interface-reconfigure has been updated to recognise bond.mode and bond.properties. *)
-let refresh_pif_other_config ~__context ~self =
-	let master = Db.Bond.get_master ~__context ~self in
-	let mode = Db.Bond.get_mode ~__context ~self in
-	let properties = Db.Bond.get_properties ~__context ~self in
-
-	Db.PIF.remove_from_other_config ~__context ~self:master ~key:"bond-mode";
-	Db.PIF.remove_from_other_config ~__context ~self:master ~key:"bond-hashing-algorithm";
-
-	Db.PIF.add_to_other_config ~__context ~self:master ~key:"bond-mode" ~value:(Record_util.bond_mode_to_string mode);
-	if List.mem_assoc "hashing_algorithm" properties then
-		Db.PIF.add_to_other_config ~__context ~self:master ~key:"bond-hashing-algorithm" ~value:(List.assoc "hashing_algorithm" properties)
 
 let set_mode ~__context ~self ~value =
 	Db.Bond.set_mode ~__context ~self ~value;


### PR DESCRIPTION
This change causes Bond.create to update the other_config of the bond's
master PIF with the bond mode and hashing algorithm, whereas previously
PIF.other_config was only updated with the bond mode.
