### PR TITLE
CA-70692: Add other-config key to disable VLAN replication

### DIFF
--- a/ocaml/xapi/sync_networking.ml
+++ b/ocaml/xapi/sync_networking.ml
@@ -147,9 +147,13 @@ let copy_bonds_from_master ~__context () =
 (** Copy VLANs from master *)
 (* This is now executed fully on the master, once asked by the slave when the slave's Xapi starts up *)
 let copy_vlans_from_master ~__context () =
-	debug "Resynchronising VLANs";
 	let host = !Xapi_globs.localhost_ref in
-	Helpers.call_api_functions ~__context (fun rpc session_id -> Client.Host.sync_vlans ~rpc ~session_id ~host)
+	let oc = Db.Host.get_other_config ~__context ~self:host in
+	if not (List.mem_assoc Xapi_globs.sync_vlans oc &&
+		List.assoc Xapi_globs.sync_vlans oc = Xapi_globs.sync_switch_off) then begin
+		debug "Resynchronising VLANs";
+		Helpers.call_api_functions ~__context (fun rpc session_id -> Client.Host.sync_vlans ~rpc ~session_id ~host)
+	end
 
 (** Copy tunnels from master *)
 let copy_tunnels_from_master ~__context () =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -339,6 +339,9 @@ let sync_gpus = "sync_gpus"
 (* create_storage *)
 let sync_create_pbds = "sync_create_pbds"
 
+(* sync VLANs on slave with master *)
+let sync_vlans = "sync_vlans"
+
 (* Set on the Pool.other_config to signal that the pool is currently in a mixed-mode
    rolling upgrade state. *)
 let rolling_upgrade_in_progress = "rolling_upgrade_in_progress"


### PR DESCRIPTION
Setting host.other-config:sync_vlans=nosync will disable VLAN
syncing in the particular slave.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
