### PR TITLE
CA-71710: The file udhcpd_skel is in vardir, not etcdir

### DIFF
--- a/ocaml/xapi/xapi_udhcpd.ml
+++ b/ocaml/xapi/xapi_udhcpd.ml
@@ -26,7 +26,7 @@ let ip_begin_key = "ip_begin"
 let ip_end_key = "ip_end"
 
 let udhcpd_conf = Filename.concat Fhs.vardir "udhcpd.conf"
-let udhcpd_skel = Filename.concat Fhs.etcdir "udhcpd.skel"
+let udhcpd_skel = Filename.concat Fhs.vardir "udhcpd.skel"
 let leases_db = Filename.concat Fhs.vardir "dhcp-leases.db"
 let pidfile = "/var/run/udhcpd.pid"
 


### PR DESCRIPTION
This was a typo in the large FHS patch a few weeks ago.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
