### PR TITLE
CA-68584: Fix bond.create bug that may occur when moving a VIF

### DIFF
--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -70,6 +70,8 @@ let get_local_vifs ~__context host networks =
 		let resident_on = Db.VM.get_resident_on ~__context ~self:vm in
 		if resident_on = host then
 			true
+		else if resident_on <> Ref.null then
+			false
 		else begin
 			let hosts = Xapi_vm.get_possible_hosts ~__context ~vm in
 			(List.mem host hosts && List.length hosts = 1) || (List.length hosts = 0)


### PR DESCRIPTION
It turns out that if a VM is running, Xapi_vm.get_possible_hosts
may not include the host the VM is running on.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
