### PR TITLE
Improve ovs logging

### DIFF
--- a/scripts/InterfaceReconfigureVswitch.py
+++ b/scripts/InterfaceReconfigureVswitch.py
@@ -721,7 +721,7 @@ class DatapathVswitch(Datapath):
 
 def vswitchCfgQuery(action_args):
     cmd = ['%s/usr/bin/ovs-vsctl' % root_prefix(),
-        '--timeout=5', '-vANY:console:emer'] + action_args
+        '--timeout=5', '-vANY:console:off'] + action_args
     output = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()
     if len(output) == 0 or output[0] == None:
         output = ""


### PR DESCRIPTION
OVS 1.2 added a log level called "off" that
is a better way to turn off logging, so we now use that in
interface-reconfigure.  It's a good idea to apply this, then, after
you update to OVS 1.2 or later.  There are no ill effects if you
don't, except that fatal errors (which wouldn't normally occur) will
be printed on the console as well as logged.

Signed-off-by: Ben Pfaff blp@nicira.com
Acked-by: Rob Hoes rob.hoes@citrix.com
