### PR TITLE
CA-73099: revert CA-14804: we nolonger delete the xenstore error node on...

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -162,8 +162,8 @@ let clean_shutdown ~xs (x: device) =
 
 	let on_error error =
 	    debug "Device.Generic.shutdown_common: read an error: %s" error;
-	    (* CA-14804: Delete the error node contents *)
-	    safe_rm ~xs (error_path_of_device ~xs x);
+	    (* After CA-14804 we deleted the error node *)
+		(* After CA-73099 we stopped doing that *)
 	    raise (Device_error (x, error)) in
 
 	request_closure ~xs x;
@@ -393,8 +393,8 @@ let shutdown_request_clean_shutdown ~xs (x: device) =
                work.) This also clears any stale error nodes. *)
 			Generic.rm_device_state ~xs x
 		| `Failed, error ->
-			(* CA-14804: Delete the error node contents *)
-			Generic.safe_rm ~xs (error_path_of_device ~xs x);
+			(* After CA-14804 we would delete the error node *)
+			(* After CA-73099 we stopped doing that *)
 			debug "Device.Vbd.shutdown_common: read an error: %s" error;
 			raise (Device_error (x, error))
 


### PR DESCRIPTION
... device unplug failure

We now let multiple VBD.unplugs fail. When the guest finally lets the disk go, it will be handled asynchronously.

Signed-off-by: David Scott dave.scott@eu.citrix.com
