### PR TITLE
Remove calls to xenlight.

### DIFF
--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -19,9 +19,9 @@ XENLIGHT_LINK_FLAGS=-cclib -luuid
 # (the same holds for OCaml packages)
 XEN_OCAML_LIBS = ../xenops/xenops ../auth/pam
 XEN_OCAMLINCLUDES =
-XEN_OCAMLPACKS = xenctrl xenctrlext xenstore cpuid xenlight
+XEN_OCAMLPACKS = xenctrl xenctrlext xenstore cpuid # xenlight
 OCAML_CLIBS = $(XEN_OCAML_CLIBS) $(OCAML_CLIBS)
-OCAML_LINK_FLAGS = $(XEN_OCAML_LINK_FLAGS) $(OCAML_LINK_FLAGS) $(XENLIGHT_LINK_FLAGS)
+OCAML_LINK_FLAGS = $(XEN_OCAML_LINK_FLAGS) $(OCAML_LINK_FLAGS) # $(XENLIGHT_LINK_FLAGS)
 CFLAGS = $(XEN_CFLAGS) $(CFLAGS)
 OCAMLINCLUDES = $(XEN_OCAMLINCLUDES) $(OCAMLINCLUDES)
 # xc.cma depends on uuid.cma

--- a/ocaml/xenops/OMakefile
+++ b/ocaml/xenops/OMakefile
@@ -4,11 +4,11 @@ OCAML_CLIBS     += $(XEN_OCAML_CLIBS)
 # XXX: these should all be specified in the ocamlfind META file:
 XENLIGHT_LINK_FLAGS= -cclib -luuid
 #XENLIGHT_LINK_FLAGS= -cclib -lxlutil -cclib -luuid -cclib -lblktapctl -cclib -lutil -cclib -lxenlight -cclib -lxenstore
-OCAML_LINK_FLAGS+= $(XEN_OCAML_LINK_FLAGS) $(XENLIGHT_LINK_FLAGS)
+OCAML_LINK_FLAGS+= $(XEN_OCAML_LINK_FLAGS) # $(XENLIGHT_LINK_FLAGS)
 
 CFLAGS          += $(XEN_CFLAGS)
 
-OCAMLPACKS     = threads xenctrl xenctrlext xenstore stdext log cdrom netdev xenlight
+OCAMLPACKS     = threads xenctrl xenctrlext xenstore stdext log cdrom netdev # xenlight
 OCAMLFLAGS    += -thread
 
 LIBFILES = table xenops_helpers xenbus_utils balloon xenguestHelper domain hotplug device io statdev xal netman memory watch device_common squeeze squeeze_xen squeezed_rpc squeezed_state squeezed_rpc device_number stubdom

--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -947,6 +947,7 @@ let add_noexn ~xc ~xs ~hvm ~msitranslate ~pci_power_mgmt ?(flrscript=None) pcide
 	Generic.add_device ~xs device (others @ xsdevs @ backendlist) frontendlist [];
 	()
 
+(* comment out while we sort out libxenlight
 let pci_info_of ~msitranslate ~pci_power_mgmt = function
     | domain, bus, dev, func ->
         {
@@ -966,6 +967,7 @@ let pci_info_of ~msitranslate ~pci_power_mgmt = function
             msitranslate = msitranslate = 1;
             power_mgmt = pci_power_mgmt = 1;
         }
+*)
 
 
 (* XXX: this will crash because of the logging policy within the
@@ -992,6 +994,7 @@ let release_libxl ~msitranslate ~pci_power_mgmt pcidevs domid =
 				raise e
 		) pcidevs
 *)
+
 (* XXX: we don't want to use the 'xl' command here because the "interface"
    isn't considered as stable as the C API *)
 let xl_pci cmd ?(msitranslate=0) ?(pci_power_mgmt=0) pcidevs domid =


### PR DESCRIPTION
Just disable all calls to xenlight for now, so we can get a building Frontier branch.  We can re-enable them when we get xenlight building properly again.

Signed-off-by: George Dunlap george.dunlap@eu.citrix.com
