### PR TITLE
CA-74209: fix incorrect trimming in Xmlrpc_sexpr module

### DIFF
--- a/ocaml/auth/extauth_plugin_ADlikewise.ml
+++ b/ocaml/auth/extauth_plugin_ADlikewise.ml
@@ -28,9 +28,6 @@ struct
  *
 *)
 
-(* removes white spaces in the beginning and the end of a string *)
-let trim = Xmlrpc_sexpr.trim 
-
 (** has_substr str sub returns true if sub is a substring of str. Simple, naive, slow. *)
 let has_substr str sub =
   if String.length sub > String.length str then false else

--- a/ocaml/xapi/xmlrpc_sexpr.ml
+++ b/ocaml/xapi/xmlrpc_sexpr.ml
@@ -18,15 +18,8 @@
 open Xml
 open XMLRPC
 open SExpr
+open Stringext
 
-
-let rec trim str =
-	let len=String.length str in
-	if len=0 then str
-	else match (str.[0],str.[len-1]) with
-		| ((' '|'\t'|'\n'),_) -> trim (String.sub str 1 (len-1))
-		| (_,(' '|'\t'|'\n')) -> trim (String.sub str 0 (len-2))
-		| _ -> str
 
 (** Accepts an xml-rpc tree of type xml.xml
     with contents <tag> [child1] [child2] ... [childn] </tag>
@@ -50,7 +43,7 @@ let xmlrpc_to_sexpr (root:xml) =
 	let rec visit (h:int) (xml_lt:xml list) = match (h, xml_lt) with
 		| h, [] -> []
 		| h, (PCData text)::_ ->
-		let text = trim text in
+		let text = String.strip String.isspace text in
 		SExpr.String text::[] 	 
 
 		(* empty <value>s have default value '' *)
@@ -79,7 +72,7 @@ let xmlrpc_to_sexpr (root:xml) =
 
 		(* any other element *)
 		| h,((Element (tag, _, children))::siblings) -> 
-			let tag = trim tag in
+			let tag = String.strip String.isspace tag in
 			let mytag = (SExpr.String tag) in
 			let (mychildren:SExpr.t list) = visit (h+1) children in
 			let anode = (SExpr.Node (mytag::mychildren)) in


### PR DESCRIPTION
The trim function cuts off 1 byte too many in case of a whitespace
character at the end of the string due to an incorrect use of String.sub.

Rather than fixing the trim function, we remove it and use a similar
function from Stringext instead.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
