### PR TITLE
CA-72709: Fix logic in netmask_to_prefixlen

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -64,7 +64,8 @@ let netmask_to_prefixlen netmask =
 			else
 				l
 		in
-		List.fold_left length 0 [a; b; c; d]
+		let masks = List.map ((-) 255) [a; b; c; d] in
+		32 - (List.fold_left length 0 masks)
 	)
 
 let determine_mtu ~__context pif_rc =


### PR DESCRIPTION
This bug caused the wrong netmask to be set for static
IP configuration, in some cases.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
