### PR TITLE
CA-71111: Fix pool.eject for slave with bonded management PIF

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -788,9 +788,8 @@ let eject ~__context ~host =
 			(* assumes that the management interface is either physical or a bond *)
 			if pif.API.pIF_bond_master_of <> [] then
 				let bond = List.hd pif.API.pIF_bond_master_of in
-				let slaves = Db.Bond.get_slaves ~__context ~self:bond in
-				let first_slave = List.hd slaves in
-				Db.PIF.get_device ~__context ~self:first_slave
+				let primary_slave = Db.Bond.get_primary_slave ~__context ~self:bond in
+				Db.PIF.get_device ~__context ~self:primary_slave
 			else
 				pif.API.pIF_device
 		in


### PR DESCRIPTION
When ejecting a host with a bonded management PIF from a pool,
the primary bond slave should become the management interface.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
