### PR TITLE
Remove event.from from the audit log.

### DIFF
--- a/ocaml/idl/ocaml_backend/rbac_audit.ml
+++ b/ocaml/idl/ocaml_backend/rbac_audit.ml
@@ -424,6 +424,7 @@ let has_to_audit action =
 				"session.logout"; (* rbac_audit calls, because after logout *)
 				                  (* the session is destroyed and no audit is possible*)
 				"event.next"; (* this action is just spam in the audit log*)
+				"event.from"; (* spam *)
 				"http/get_rrd_updates"; (* spam *)
 				"http/post_remote_db_access"; (* spam *)
 				"host.tickle_heartbeat"; (* spam *)


### PR DESCRIPTION
This removes a lot of spam since XenCenter calls it all the time.
