### PR TITLE
CA-73099: revert CA-14804: we nolonger delete the xenstore error node on device unplug failure

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -358,8 +358,8 @@ let clean_shutdown ~xs (x: device) =
 	       work.) This also clears any stale error nodes. *)
 	    Generic.rm_device_state ~xs x
 	| `Failed, error ->
-	    (* CA-14804: Delete the error node contents *)
-	    Generic.safe_rm ~xs (error_path_of_device ~xs x);
+			(* After CA-14804 we deleted the error node *)
+			(* After CA-73099 we stopped doing that *)
 	    debug "Device.Vbd.shutdown_common: read an error: %s" error;
 	    raise (Device_error (x, error))
 


### PR DESCRIPTION
For HFX-252.

We now let multiple VBD.unplugs fail. When the guest finally lets the
disk go, it will be handled asynchronously.

Copied from xen-api/master
commit:77fca7c4e74a4a0634163097ff0542d5fd7a27f7
