### PR TITLE
CA-66512: Properly set SO_REUSEADDR when (re)starting HIMN XenAPI server

### DIFF
--- a/ocaml/xapi/xapi_network_real.ml
+++ b/ocaml/xapi/xapi_network_real.ml
@@ -85,8 +85,8 @@ let http_proxy master_ip ip =
 				server := None;
 				let handler = { Server_io.name = "http_proxy"; body = tcp_connection } in
 				let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-				Unix.bind sock sockaddr;
 				Unix.setsockopt sock Unix.SO_REUSEADDR true;
+				Unix.bind sock sockaddr;
 				Unixext.set_tcp_nodelay sock true;
 				Unix.listen sock 5;
 				let s = Server_io.server handler sock in


### PR DESCRIPTION
When rebooting the VM soon after the VM talked to xapi using wget, the
HIMN XenAPI server stopped working. The reason was as follows.

The wget command sets up a TCP connection with xapi, which is closed after
the command is done. However, the TCP socket on the xapi side does not go
away immediately, but stays in a state called TIME_WAIT for a while (a
minute or so). When the VM starts up again, xapi opens a new HIMN socket,
which fails because there was already a socket on the same address/port.
Setting the SO_REUSEADDR option on the socket gets rid of the problem,
because it allows new sockets for the same (local) address/port. This
option was actually set in the code, but apparently too late in the sequence
(after the "bind" operation).

Signed-off-by: Rob Hoes rob.hoes@citrix.com
