### PR TITLE
CA-75710: check for more recent PV tools isos on-demand, rather than rel...

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -41,7 +41,9 @@ let api_version_vendor = "XenSource"
 let api_version_vendor_implementation = []
 
 (* version of latest tools ISO in filesystem *)
-let tools_version = ref (-1, -1, -1, -1)
+let tools_version_none = (-1, -1, -1, -1)
+
+let tools_version = ref tools_version_none
 
 (* client min/max version range *)
 let xencenter_min_verstring = "1.10"

--- a/ocaml/xapi/xapi_pv_driver_version.ml
+++ b/ocaml/xapi/xapi_pv_driver_version.ml
@@ -60,7 +60,7 @@ let string_of_vsn2 (maj, min) = string_of_vsn [maj; min]
    with the master's SR scanning thread. Called from the startup code only *)
 let get_latest_tools_vsn () = 
   let all = Sys.readdir Xapi_globs.tools_sr_dir in
-  let none = (-1, -1, -1, -1) in
+  let none = Xapi_globs.tools_version_none in
   let vsn_of_filename f = 
     try
       let prefix = "xs-tools-" and suffix = ".iso" in
@@ -128,6 +128,8 @@ let compare_vsn_with_product_vsn ?(relaxed=false) (pv_maj, pv_min, pv_mic) (prod
    returns 1 if the PV drivers are a newer verrsion than the tools version on this host *)
 let compare_vsn_with_tools_iso ?(relaxed=false) pv_vsn =
 	(* XXX: consolidate with create_templates code and the function above *)
+	if !Xapi_globs.tools_version = Xapi_globs.tools_version_none then get_latest_tools_vsn ();
+
 	if relaxed then
 		let pv_maj, pv_min, _, _ = pv_vsn in
 		let tools_maj, tools_min, _, _  = !Xapi_globs.tools_version in


### PR DESCRIPTION
...ying on the startup sequence

Unfortunately the startup-sequence was populating the cached version _after_ all the running VMs were checked to see if they had up-to-date drivers.

Signed-off-by: David Scott dave.scott@eu.citrix.com
