### PR TITLE
CA-75701: more work on host randomization of VDI.copy

### DIFF
--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -182,10 +182,10 @@ let check_sr_availability ~__context sr =
   let localhost = Helpers.get_localhost ~__context in
   check_sr_availability_host ~__context sr localhost
     
-let find_host_for_sr ~__context sr =
+let find_host_for_sr ~__context ?(prefer_slaves=false) sr =
   let choose_fn ~host = 
-    Xapi_vm_helpers.assert_can_see_specified_SRs ~__context ~reqd_srs:[sr] ~host in
-    Xapi_vm_helpers.choose_host ~__context ~choose_fn ()
+	  Xapi_vm_helpers.assert_can_see_specified_SRs ~__context ~reqd_srs:[sr] ~host in
+  Xapi_vm_helpers.choose_host ~__context ~choose_fn ~prefer_slaves ()
 
 let check_vm_host_SRs ~__context vm host =
   try 

--- a/ocaml/xapi/sm_fs_ops.ml
+++ b/ocaml/xapi/sm_fs_ops.ml
@@ -55,10 +55,10 @@ let with_block_attached_devices (__context: Context.t) rpc (session_id: API.ref_
 	loop [] vdis
 
 (** Return a URL suitable for passing to the sparse_dd process *)
-let import_vdi_url ~__context rpc session_id vdi =
+let import_vdi_url ~__context ?(prefer_slaves=false) rpc session_id vdi =
 	(* Find a suitable host for the SR containing the VDI *)
 	let sr = Db.VDI.get_SR ~__context ~self:vdi in
-	let host = Importexport.find_host_for_sr ~__context sr in
+	let host = Importexport.find_host_for_sr ~__context ~prefer_slaves sr in
 	let address = Db.Host.get_address ~__context ~self:host in
 	Printf.sprintf "https://%s%s?vdi=%s&session_id=%s" address Constants.import_raw_vdi_uri (Ref.string_of vdi) (Ref.string_of session_id)
 
@@ -214,7 +214,7 @@ let copy_vdi ~__context vdi_src vdi_dst =
 							Sparse_dd_wrapper.dd ~__context sparse device_src device_dst size
 						)
 					else
-						let remote_uri = import_vdi_url ~__context rpc session_id vdi_dst in
+						let remote_uri = import_vdi_url ~__context ~prefer_slaves:true rpc session_id vdi_dst in
 						debug "remote_uri = %s" remote_uri;
 						Sparse_dd_wrapper.dd ~__context sparse device_src remote_uri size
 				)

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -180,7 +180,8 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
 	in
 	let need_write = record.Db_actions.vBD_mode = `RW in
 	(* Read-only access doesn't require VDI to be marked sharable *)
-	if not(vdi_record.Db_actions.vDI_sharable) && (not is_system_domain) && someones_got_rw_access
+	if not(vdi_record.Db_actions.vDI_sharable) && (not is_system_domain)
+		&& (someones_got_rw_access || need_write && vbds_to_check <> [])
 	then set_errors Api_errors.vdi_in_use [ Ref.string_of vdi ] [ `attach; `insert; `plug ];
 	if need_write && vdi_record.Db_actions.vDI_read_only 
 	then set_errors Api_errors.vdi_readonly [ Ref.string_of vdi ] [ `attach; `insert; `plug ]

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -539,11 +539,18 @@ function [choose_fn] can be applied without raising an exception. Raises
 argument is present, then this function additionally prints a debug message
 that includes the names of the given VM and the subset of all hosts that
 satisfy the given function [choose_fn]. *)
-let choose_host ~__context ?vm ~choose_fn () =
+let choose_host ~__context ?vm ~choose_fn ?(prefer_slaves=false) () =
 	let choices = possible_hosts ~__context ?vm ~choose_fn () in
-	if List.length choices = 0
-	then raise (Api_errors.Server_error (Api_errors.no_hosts_available, []));
-	List.nth choices (Random.int (List.length choices))
+	match choices with
+	| [] -> raise (Api_errors.Server_error (Api_errors.no_hosts_available, []))
+	| [h] -> h
+	| _ ->
+		let choices =
+			if prefer_slaves then
+				let master = Db.Pool.get_master ~__context ~self:(Helpers.get_pool ~__context) in
+				List.filter ((<>) master) choices
+			else choices in
+		List.nth choices (Random.int (List.length choices))
 
 (** Returns the subset of all hosts on which the given [vm] can boot. This
 function also prints a debug message identifying the given [vm] and hosts. *)


### PR DESCRIPTION
Some previous work already went in a few month back. With the requst of backporting it to Oxford (CA-75701), we did a little more:
- Provide option to avoid master workload
- Fix a long term VDI race condition bug

This patch is to sync trunk's implementation with the one in CA-75701 (to become oxford hotfix).

Signed-off-by: Zheng Li zheng.li@eu.citrix.com
