### PR TITLE
Reset the state of networkd on pool.eject

### DIFF
--- a/ocaml/network/network_interface.ml
+++ b/ocaml/network/network_interface.ml
@@ -26,6 +26,7 @@ type ipv4 = None4 | DHCP4 of dhcp_options list | Static4 of (Unix.inet_addr * in
 type ipv6 = None6 | DHCP6 of dhcp_options list | Autoconf6 | Static6 of (Unix.inet_addr * int) list
 
 external reopen_logs: unit -> bool = ""
+external reset_state: unit -> unit = ""
 
 module Interface = struct
 	external get_all : unit -> iface list = ""

--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -66,8 +66,8 @@ and config_t = {
 	dns_interface: iface option;
 } with rpc
 
-let config : config_t ref = ref {interface_config = []; bridge_config = [];
-	gateway_interface = None; dns_interface = None}
+let empty_config = {interface_config = []; bridge_config = []; gateway_interface = None; dns_interface = None}
+let config : config_t ref = ref empty_config
 
 let read_management_conf () =
 	let management_conf = Unixext.string_of_file (Xapi_globs.first_boot_dir ^ "data/management.conf") in
@@ -175,6 +175,9 @@ let reopen_logs _ () =
 		debug "Logfiles reopened";
 		true
 	with _ -> false
+
+let reset_state _ () =
+	config := read_management_conf ()
 
 module Interface = struct
 	let default = {

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -18,6 +18,8 @@ open Threadext
 open Stringext
 open Listext
 
+module Net = (val (Network.get_client ()) : Network.CLIENT)
+
 module L = Debug.Debugger(struct let name="license" end)
 module D=Debug.Debugger(struct let name="xapi" end)
 open D
@@ -853,6 +855,7 @@ let eject ~__context ~host =
 
 		write_first_boot_management_interface_configuration_file ();
 
+		Net.reset_state ();
 		Xapi_inventory.update Xapi_inventory._current_interfaces "";
 
 		debug "Pool.eject: deleting Host record (the point of no return)";


### PR DESCRIPTION
Ejecting a host from a pool brings it back to a state resembling
a fresh installation. This requires us to clear the state of networkd.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
