### PR TITLE
CA-74709: Translate bond mode "lacp" to "802.3ad" on linux bridge

### DIFF
--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -695,6 +695,11 @@ module Bridge = struct
 		| Openvswitch ->
 			ignore (Ovs.set_bond_properties name params)
 		| Bridge ->
+			let params =
+				if List.mem_assoc "mode" params && List.assoc "mode" params = "lacp" then
+					List.replace_assoc "mode" "802.3ad" params
+				else params
+			in
 			Interface.bring_down () ~name;
 			Sysfs.set_bond_properties name params;
 			Interface.bring_up () ~name


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
