### PR TITLE
Bump omake job count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ export VARDIR ETCDIR OPTDIR PLUGINDIR HOOKSDIR INVENTORY VARPATCHDIR LIBEXECDIR 
 
 .PHONY: all
 all: version ocaml/fhs.ml
-	omake phase1
-	omake phase2
-	omake phase3
+	omake -j 8 phase1
+	omake -j 8 phase2
+	omake -j 8 phase3
 
 .PHONY: phase3
 phase3:


### PR DESCRIPTION
Set omake -j 8 in the main Makefile. Cut down my total build time from 4:00 to 2:30.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
