### PR TITLE
CA-54153: Parse the WLB response ResultCode before trying to parse rest of the response content

### DIFF
--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -354,7 +354,6 @@ let perform_wlb_request ?auth ?url ?enable_log ~meth ~params
         with          
         | Xml_parse_failure error -> "0" (* If it failed trying to get ResultCode, assume the call was successful *)
         in
-        debug "Code: %s Call: %s" code meth;
         if code <> "0" then
           (* Call failed, get error message and raise internal error *)
           let message =


### PR DESCRIPTION
Currently xapi ignores error codes sent by wlb until it runs into some problems. Then it thinks "maybe call to wlb didn't succeed in the first place," gets the error code/message and raises exception. 
This change will fix that process, i.e. xapi will parse error code and continue only if error code is 0 (i.e. call succeeded).

Signed-off-by: Rabin Karki rabin.karki@citrix.com
