### PR TITLE
CA-75708: Remove the 16MB limit on DB RPC responses.

### DIFF
--- a/ocaml/database/db_interface.ml
+++ b/ocaml/database/db_interface.ml
@@ -12,6 +12,10 @@
  * GNU Lesser General Public License for more details.
  *)
 
+type response =
+	| String of string
+	| Bigbuf of Bigbuffer.t
+
 (** A generic RPC interface *)
 module type RPC = sig 
 	
@@ -19,7 +23,7 @@ module type RPC = sig
 	val initialise : unit -> unit
 		
 	(** [rpc request] transmits [request] and receives a response *)
-	val rpc : string -> string
+	val rpc : string -> response
 end
 
 (** dictionary of regular fields x dictionary of associated set_ref values *)

--- a/ocaml/database/db_rpc_client_v1.ml
+++ b/ocaml/database/db_rpc_client_v1.ml
@@ -49,7 +49,10 @@ module Make = functor(RPC: Db_interface.RPC) -> struct
 	let do_remote_call marshall_args unmarshall_resp fn_name args =
 		let xml = marshall_args args in
 		let xml = XMLRPC.To.array [XMLRPC.To.string fn_name; XMLRPC.To.string "" (* unused *); xml] in
-		let resp = Xml.parse_string (RPC.rpc (Xml.to_string xml)) in
+		let resp = match RPC.rpc (Xml.to_string xml) with
+		| Db_interface.String s -> Xml.parse_string s
+		| Db_interface.Bigbuf b -> Xml.parse_bigbuffer b
+		in
 		match XMLRPC.From.array (fun x->x) resp with
 				[status_xml; resp_xml] ->
 					let status = XMLRPC.From.string status_xml in

--- a/ocaml/database/db_rpc_client_v2.ml
+++ b/ocaml/database/db_rpc_client_v2.ml
@@ -19,7 +19,10 @@ open Db_exn
 
 module Make = functor(RPC: Db_interface.RPC) -> struct
 	let initialise = RPC.initialise
-	let rpc x = Jsonrpc.of_string (RPC.rpc (Jsonrpc.to_string x))
+	let rpc x =
+		match RPC.rpc (Jsonrpc.to_string x) with
+		| Db_interface.String s -> Jsonrpc.of_string s
+		| Db_interface.Bigbuf b -> raise (Failure "Response too large - cannot convert bigbuffer to json!")
 
 	let process (x: Request.t) = 
 		let y : Response.t = Response.t_of_rpc (rpc (Request.rpc_of_t x)) in


### PR DESCRIPTION
Check the content length of responses to requests made by the database
RPC client; if the content length is greater than the maximum string
length then read the response into a Bigbuffer instead.
