### PR TITLE
CA-77236: networkd: fix parsing of empty DNS and DOMAIN from firstboot data

### DIFF
--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -88,12 +88,12 @@ let read_management_conf () =
 				else None
 			in
 			let nameservers =
-				if List.mem_assoc "DNS" args then
+				if List.mem_assoc "DNS" args && List.assoc "DNS" args <> "" then
 					List.map Unix.inet_addr_of_string (String.split ',' (List.assoc "DNS" args))
 				else []
 			in
 			let domains =
-				if List.mem_assoc "DOMAIN" args then
+				if List.mem_assoc "DOMAIN" args && List.assoc "DOMAIN" args <> "" then
 					String.split ' ' (List.assoc "DOMAIN" args)
 				else []
 			in


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
