### PR TITLE
CA-74937: Reset master (remote DB) connection for any dom0 IP address change

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -376,11 +376,15 @@ let determine_static_routes net_rc =
 let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
 	with_local_lock (fun () ->
 		let rc = Db.PIF.get_record ~__context ~self:pif in
+		let net_rc = Db.Network.get_record ~__context ~self:rc.API.pIF_network in
+		let bridge = net_rc.API.network_bridge in
 
 		(* Call networkd even if currently_attached is false, just to update its state *)
 		debug "PIF %s has currently_attached set to %s%s; bringing up now" rc.API.pIF_uuid
 			(string_of_bool rc.API.pIF_currently_attached)
 			(if management_interface then " and this is to be the new management interface" else "");
+
+		let old_ip = try Net.Interface.get_ipv4_addr ~name:bridge with _ -> [] in
 
 		(* If the PIF is a bond master, the bond slaves will now go down *)
 		(* Interface-reconfigure in bridge mode requires us to set currently_attached to false here *)
@@ -393,8 +397,6 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
 
 		if !use_networkd then
 			begin try
-				let net_rc = Db.Network.get_record ~__context ~self:rc.API.pIF_network in
-				let bridge = net_rc.API.network_bridge in
 				let persistent = is_dom0_interface rc in
 
 				(* Setup network infrastructure *)
@@ -455,10 +457,17 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
 			reconfigure_pif ~__context pif args
 		end;
 
-		if rc.API.pIF_currently_attached = false || management_interface then begin
+		let new_ip = try Net.Interface.get_ipv4_addr ~name:bridge with _ -> [] in
+		if new_ip <> old_ip then begin
+			warn "An IP address of dom0 was changed";
 			warn "About to kill idle client stunnels";
 			(* The master_connection would otherwise try to take a broken stunnel from the cache *)
 			Stunnel_cache.flush ();
+			warn "About to forcibly reset the master connection";
+			Master_connection.force_connection_reset ()
+		end;
+
+		if rc.API.pIF_currently_attached = false || management_interface then begin
 			if management_interface then begin
 				warn "About to kill active client stunnels";
 				let stunnels =
@@ -467,8 +476,6 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
 					List.filter (function Locking_helpers.Process("stunnel", _) -> true | _ -> false) all in
 				debug "Of which %d are stunnels" (List.length stunnels);
 				List.iter Locking_helpers.kill_resource stunnels;
-				warn "About to forcibly reset the master connection";
-				Master_connection.force_connection_reset ();
 			end;
 
 			Db.PIF.set_currently_attached ~__context ~self:pif ~value:true;


### PR DESCRIPTION
This prevents the master connection from getting "stuck" when:
1. A slave has two NICs, with management on eth0.
2. An IP address is put on eth1, and management is moved to it.
3. The IP address of eth0 is removed.

After step 1, the slave has a master connection with as local (socket)
address the IP of eth0. After step 2, the master connection is reset, but
it may still get the same local address (eth0's IP), since there are now
two routes to the master, and it is up to dom0's kernel to pick one.
After step 3, however, this routes breaks, but the master connection was
not reset. This patch causes the connection to be reset in this case as well.

In the "stuck" state, DB calls may still arrive at the master (and other slave
operations may still work), but the master would send replies to the old IP,
which would never arrive. I believe the slave would eventually realise this
and reset the connection, but only after a very long timeout. I think that
the situation is different when the master goes offline, because the MAC layer
would cause the TCP connection to break immediately, after which the slave
automatically resets the master connection, and keeps trying until the master
is back.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
