### PR TITLE
CA-77015: Ignore storage errors in Xenops.VM.destroy, as we used to do.

### DIFF
--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -682,7 +682,11 @@ module VM = struct
 		end;
 		Domain.destroy task ~preserve_xs_vm:false ~xc ~xs domid;
 		(* Detach any remaining disks *)
-		List.iter (fun vbd -> Storage.deactivate_and_detach task (Storage.id_of domid vbd.Vbd.id)) vbds
+		List.iter (fun vbd -> 
+			try 
+				Storage.deactivate_and_detach task (Storage.id_of domid vbd.Vbd.id)
+			with e ->
+		        warn "Ignoring exception in VM.detroy: %s" (Printexc.to_string e)) vbds
 	) Oldest
 
 	let pause = on_domain (fun xc xs _ _ di ->


### PR DESCRIPTION
Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
