### PR TITLE
Several updates

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2799,7 +2799,6 @@ let vdi_pool_migrate = call
   ~in_product_since:rel_tampa
   ~params:[ Ref _vdi, "vdi", "The VDI to migrate"
     ; Ref _sr, "sr", "The destination SR"
-    ; Ref _network, "network", "The network through which migration traffic should be sent."
     ; Map (String, String), "options", "Other parameters" ]
   ~doc:"Migrate a VDI, which may be attached to a running guest, to a different SR. The destination SR must be visible to the guest."
   ~allowed_roles:_R_VM_POWER_ADMIN

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1728,7 +1728,7 @@ there are two or more empty CD devices, please use the command 'vbd-insert' and 
    "vdi-pool-migrate",
     {
       reqd=["uuid"; "sr-uuid"];
-      optn=["network-uuid"];
+		optn=[];
       help="Migrate a VDI to a specified SR, while the VDI is attached to a running guest.";
       implementation=No_fd Cli_operations.vdi_pool_migrate;
       flags=[];

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3209,9 +3209,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			with Not_found ->
 				SR.forward_sr_multiple_op ~local_fn ~__context ~srs:[src_sr] ~prefer_slaves:true op
 
-		let pool_migrate ~__context ~vdi ~sr ~network ~options =
-			info "VDI.pool_migrate: VDI = '%s'; SR = '%s'; network = '%s'"
-				(vdi_uuid ~__context vdi) (sr_uuid ~__context sr) (network_uuid ~__context network);
+		let pool_migrate ~__context ~vdi ~sr ~options =
+			info "VDI.pool_migrate: VDI = '%s'; SR = '%s'"
+				(vdi_uuid ~__context vdi) (sr_uuid ~__context sr);
 			let vbds = Db.VBD.get_records_where ~__context
 				~expr:(Db_filter_types.Eq(Db_filter_types.Field "VDI", Db_filter_types.Literal (Ref.string_of vdi))) in
 			let vbds = List.filter (fun (_,vbd) -> vbd.API.vBD_currently_attached) vbds in
@@ -3223,9 +3223,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let host = vmr.API.vM_resident_on in
 			(* hackity hack *)
 			let options = ("__internal__vm",Ref.string_of vm) :: (List.remove_assoc "__internal__vm" options) in
-			let local_fn = Local.VDI.pool_migrate ~vdi ~sr ~network ~options in
+			let local_fn = Local.VDI.pool_migrate ~vdi ~sr ~options in
 			do_op_on ~local_fn ~__context ~host 
-				(fun session_id rpc -> Client.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr ~network ~options)
+				(fun session_id rpc -> Client.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr ~options)
 
 
 		let resize ~__context ~vdi ~size =

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -529,10 +529,20 @@ let copy ~__context ~vdi ~sr =
       (fun rpc session_id -> Client.VDI.destroy rpc session_id dst);
       raise e
 
-let pool_migrate ~__context ~vdi ~sr ~network ~options =
+let pool_migrate ~__context ~vdi ~sr ~options =
 	let localhost = Helpers.get_localhost ~__context in
 	(* inserted by message_forwarding *)
 	let vm = Ref.of_string (List.assoc "__internal__vm" options) in
+
+	(* Need a network for the VM migrate *)
+	let management_if =
+		Xapi_inventory.lookup Xapi_inventory._management_interface in
+	let open Db_filter_types in
+	let networks = Db.Network.get_records_where ~__context ~expr:(Eq (Field "bridge", Literal management_if)) in
+	let network = match networks with
+		| (net,_)::_ -> net
+		| _ -> raise (Api_errors.Server_error(Api_errors.host_has_no_management_ip, []))
+	in
 	Helpers.call_api_functions ~__context (fun rpc session_id -> 
 		let token = Client.Host.migrate_receive ~rpc ~session_id ~host:localhost ~network ~options in
 		Client.VM.migrate_send rpc session_id vm token true [ vdi, sr ] [] [])


### PR DESCRIPTION
Use management interface rather than HIMN for migration
Actually use the specified network for the data transfer
Remove the network parameter from the VDI.pool_migrate API call
  (it doesn't make any sense)

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
