### PR TITLE
CA-76603: Get PIF MTU from bridge, not interface

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -490,7 +490,7 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
 
 			(* sync MTU *)
 			(try
-				let mtu = Int64.of_string (Netdev.get_mtu rc.API.pIF_device) in
+				let mtu = Int64.of_string (Netdev.get_mtu bridge) in
 				Db.PIF.set_MTU ~__context ~self:pif ~value:mtu
 			with _ ->
 				debug "could not update MTU field on PIF %s" rc.API.pIF_uuid


### PR DESCRIPTION
This is because there is not always an interface, e.g. in the
case of bonds on ovs.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
