### PR TITLE
Fix windows serial debugging: the key was other_config:hvm_serial, not p...

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -140,7 +140,7 @@ let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
 					Cirrus
 			end;
 			acpi = bool vm.API.vM_platform true "acpi";
-			serial = Some (string vm.API.vM_platform "pty" "hvm_serial");
+			serial = Some (string vm.API.vM_other_config "pty" "hvm_serial");
 			keymap = Some (string vm.API.vM_platform "en-us" "keymap");
 			vnc_ip = Some "0.0.0.0" (*None PR-1255*);
 			pci_emulations = pci_emulations;


### PR DESCRIPTION
...latform:hvm_serial

Although platform:hvm_serial makes more sense than other_config.

Signed-off-by: David Scott dave.scott@eu.citrix.com
