### PR TITLE
[xenopsd] wire-up VM.platform:pvfb=true (i.e. PVFB for PV guests)

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -162,14 +162,16 @@ let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
 			) initrd in
 			PV {
 				boot = Direct { kernel = k; cmdline = ka; ramdisk = initrd };
-				framebuffer = false;
+				framebuffer = bool vm.API.vM_platform false "pvfb";
+				framebuffer_ip = Some "0.0.0.0"; (* None PR-1255 *)
 				vncterm = true;
 				vncterm_ip = Some "0.0.0.0" (*None PR-1255*);
 			}
 		| Helpers.IndirectPV { Helpers.bootloader = b; extra_args = e; legacy_args = l; pv_bootloader_args = p; vdis = vdis } ->
 			PV {
 				boot = Indirect { bootloader = b; extra_args = e; legacy_args = l; bootloader_args = p; devices = List.filter_map (fun x -> disk_of_vdi ~__context ~self:x) vdis };
-				framebuffer = false;
+				framebuffer = bool vm.API.vM_platform false "pvfb";
+				framebuffer_ip = Some "0.0.0.0"; (* None PR-1255 *)
 				vncterm = true;
 				vncterm_ip = Some "0.0.0.0" (*None PR-1255*);
 			}
@@ -1112,7 +1114,7 @@ let manage_dom0 dbg =
 			bios_strings = [];
 			ty = PV {
 				boot = Direct { kernel = ""; cmdline = ""; ramdisk = None };
-				framebuffer = false; vncterm = false; vncterm_ip = None 
+				framebuffer = false; framebuffer_ip = None; vncterm = false; vncterm_ip = None 
 			};
 			suppress_spurious_page_faults = false;
 			machine_address_size = None;

--- a/ocaml/xenops-cli/test.ml
+++ b/ocaml/xenops-cli/test.ml
@@ -153,6 +153,7 @@ let create_vm id =
 	let open Vm in
 	let _ = PV {
 		framebuffer = false;
+		framebuffer_ip = Some "0.0.0.0";
 		vncterm = true;
 		vncterm_ip = None;
 		Vm.boot = Indirect {

--- a/ocaml/xenops-cli/xn.ml
+++ b/ocaml/xenops-cli/xn.ml
@@ -287,6 +287,7 @@ let add filename =
 			let builder_info = match pv with
 				| true -> PV {
 					framebuffer = false;
+					framebuffer_ip = Some "0.0.0.0";
 					vncterm = true;
 					vncterm_ip = Some "0.0.0.0";
 					boot =

--- a/ocaml/xenops/xenops_interface.ml
+++ b/ocaml/xenops/xenops_interface.ml
@@ -118,6 +118,7 @@ module Vm = struct
 	type pv_info = {
 		boot: pv_boot;
 		framebuffer: bool;
+		framebuffer_ip: string option;
 		vncterm: bool;
 		vncterm_ip: string option;
 	}

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -815,7 +815,9 @@ module VM = struct
 			) vifs in
 			match ty with
 				| PV { framebuffer = false } -> None
-				| PV { framebuffer = true } ->
+				| PV { framebuffer = true; framebuffer_ip=Some vnc_ip } ->
+					Some (make ~hvm:false ~vnc_ip ())
+				| PV { framebuffer = true; framebuffer_ip=None } ->
 					Some (make ~hvm:false ())
 				| HVM hvm_info ->
 					let disks = List.filter_map (fun vbd ->
@@ -941,9 +943,13 @@ module VM = struct
 							Stubdom.build task ~xc ~xs info di.Xenctrl.domid stubdom_domid;
 							Device.Dm.start_vnconly task ~xs ~dmpath:_qemu_dm info stubdom_domid
 						) (get_stubdom ~xs di.Xenctrl.domid);
-				| _ ->
+				| Vm.HVM { Vm.qemu_stubdom = false } ->
 					(if saved_state then Device.Dm.restore else Device.Dm.start)
 						task ~xs ~dmpath:_qemu_dm info di.Xenctrl.domid
+				| Vm.PV _ ->
+					Device.Vfb.add ~xc ~xs di.Xenctrl.domid;
+					Device.Vkbd.add ~xc ~xs di.Xenctrl.domid;
+					Device.Dm.start_vnconly task ~xs ~dmpath:_qemu_dm info di.Xenctrl.domid
 		) (vmextra |> create_device_model_config);
 		match vm.Vm.ty with
 			| Vm.PV { vncterm = true; vncterm_ip = ip } -> Device.PV_Vnc.start ~xs ?ip di.Xenctrl.domid


### PR DESCRIPTION
This went missing during the xenopsd migration (it was in xapi before)

Signed-off-by: David Scott dave.scott@eu.citrix.com
