### PR TITLE
CA-76523: on spontaneous VM shutdown, do not reset ha_always_run

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -228,6 +228,7 @@ let hard_reboot ~__context ~vm =
 		)
 
 let hard_shutdown ~__context ~vm =
+	Db.VM.set_ha_always_run ~__context ~self:vm ~value:false;
     if Db.VM.get_power_state ~__context ~self:vm = `Suspended then begin
 		debug "hard_shutdown: destroying any suspend VDI";
 		let vdi = Db.VM.get_suspend_VDI ~__context ~self:vm in
@@ -249,6 +250,7 @@ let clean_reboot ~__context ~vm =
 		)
 
 let clean_shutdown ~__context ~vm =
+	Db.VM.set_ha_always_run ~__context ~self:vm ~value:false;
 	Xapi_xenops.shutdown ~__context ~self:vm (Some 1200.0)
 
 (***************************************************************************************)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -739,7 +739,6 @@ let update_vm ~__context id =
 						debug "xenopsd event: Updating VM %s power_state <- %s" id (Record_util.power_state_to_string power_state);
 						if power_state = `Suspended || power_state = `Halted then begin
 							detach_networks ~__context ~self;
-							Db.VM.set_ha_always_run ~__context ~self ~value:false;
 							Storage_access.reset ~__context ~vm:self;
 						end;
 						if power_state = `Halted


### PR DESCRIPTION
The convention is that VM.ha_always_run should be reset when an API
call is received (the API call overrides the current policy) but
an internal VM shutdown is treated as a VM failure, and HA restarts it.

Signed-off-by: David Scott dave.scott@eu.citrix.com
