### PR TITLE
CA-79682: When looking up a SR/VDI, tolerate VDI.locations containing '/...

### DIFF
--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -173,7 +173,7 @@ module Mux = struct
            SR/VDI -- for a particular SR and VDI
            content_id -- for a particular content *)
         let open Stringext in
-        match List.filter (fun x -> x <> "") (String.split '/' name) with
+        match List.filter (fun x -> x <> "") (String.split ~limit:2 '/' name) with
             | [ sr; name ] ->
                 let module C = Client(struct let rpc = of_sr sr end) in
                 C.VDI.get_by_name ~dbg ~sr ~name


### PR DESCRIPTION
...'

Signed-off-by: David Scott dave.scott@eu.citrix.com
