### PR TITLE
Storage interface updates

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -447,3 +447,4 @@ let vdi_needs_vm_for_migrate = "VDI_NEEDS_VM_FOR_MIGRATE"
 let vm_has_too_many_snapshots = "VM_HAS_TOO_MANY_SNAPSHOTS"
 
 let mirror_failed = "MIRROR_FAILED"
+let too_many_storage_migrates = "TOO_MANY_STORAGE_MIGRATES"


### PR DESCRIPTION
Fix migrate when VM has shutdown, and restrict the number of concurrent migrates to 3
