### PR TITLE
Change some info level logging to debug.

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -220,7 +220,7 @@ let operation (obj: obj) (x: message) =
 			else 
 				[
 					Printf.sprintf "%s \"%s\";"
-					(if may_be_side_effecting x then "ApiLogSideEffect.info" else "ApiLogRead.info")
+					(if may_be_side_effecting x then "ApiLogSideEffect.debug" else "ApiLogRead.debug")
 					wire_name
 				] in
 

--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -315,8 +315,8 @@ let from ~__context ~classes ~token ~timeout =
 			(fun acc table ->
 				 Db_cache_types.Table.fold_over_recent sub.last_generation
 					 (fun ctime mtime dtime objref (creates,mods,deletes,last) ->
-						  info "last_generation=%Ld cur_id=%Ld" sub.last_generation sub.cur_id;
-						  info "ctime: %Ld mtime:%Ld dtime:%Ld objref:%s" ctime mtime dtime objref;
+						  debug "last_generation=%Ld cur_id=%Ld" sub.last_generation sub.cur_id;
+						  debug "ctime: %Ld mtime:%Ld dtime:%Ld objref:%s" ctime mtime dtime objref;
 						  let last = max last (max mtime dtime) in (* mtime guaranteed to always be larger than ctime *)
 						  if dtime > 0L then begin
 							  if ctime > sub.last_generation then


### PR DESCRIPTION
Since xapi now logs via syslog, all logging of info level or higher
gets echoed to /var/log/messages. This patch changes some very common
log messages to debug level.
