### PR TITLE
Remove the runstate_entry_time data source from monitor.ml.

### DIFF
--- a/ocaml/xapi/monitor.ml
+++ b/ocaml/xapi/monitor.ml
@@ -110,7 +110,6 @@ let update_vcpus xc doms =
     let dss = 
       try
 	let ri = Xenctrlext.domain_get_runstate_info xc domid in 
-	(VM uuid, ds_make ~name:"runstate_entry_time" ~value:(Rrd.VT_Float ((Int64.to_float ri.Xenctrlext.state_entry_time) /. 1.0e9)) ~description:"" ~ty:Rrd.Derive ~default:false ~min:0.0 ())::
 	  (VM uuid, ds_make ~name:"runstate_fullrun" ~value:(Rrd.VT_Float ((Int64.to_float ri.Xenctrlext.time0) /. 1.0e9)) ~description:"Fraction of time that all VCPUs are running" ~ty:Rrd.Derive ~default:false ~min:0.0 ())::
 	  (VM uuid, ds_make ~name:"runstate_full_contention" ~value:(Rrd.VT_Float ((Int64.to_float ri.Xenctrlext.time1) /. 1.0e9)) ~description:"Fraction of time that all VCPUs are runnable (i.e., waiting for CPU)" ~ty:Rrd.Derive ~default:false ~min:0.0 ())::
 	  (VM uuid, ds_make ~name:"runstate_concurrency_hazard" ~value:(Rrd.VT_Float ((Int64.to_float ri.Xenctrlext.time2) /. 1.0e9)) ~description:"Fraction of time that some VCPUs are running and some are runnable" ~ty:Rrd.Derive ~default:false ~min:0.0 ())::


### PR DESCRIPTION
It is a temporary information used for counting the time spent in
different VCPU states.

Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
