### PR TITLE
Make sure we remove the vif-map key before setting it.

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -329,6 +329,7 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 			(device,bridge)) vif_map in
 
 		List.iter (fun (vif,network) ->
+			Db.VIF.remove_from_other_config ~__context ~self:vif ~key:Constants.storage_migrate_vif_map_key;
 			Db.VIF.add_to_other_config ~__context ~self:vif ~key:Constants.storage_migrate_vif_map_key ~value:(Ref.string_of network)) vif_map;
 
 		(* Wait for delay fist to disappear *)


### PR DESCRIPTION
This fixes a bug where migrating a VM with a VIF would fail on the second attempt

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
