### PR TITLE
Wire up cancellation and progress to the correct task in VDI.pool_migrate

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -570,7 +570,10 @@ let pool_migrate ~__context ~vdi ~sr ~options =
 	in
 	Helpers.call_api_functions ~__context (fun rpc session_id -> 
 		let token = Client.Host.migrate_receive ~rpc ~session_id ~host:localhost ~network ~options in
-		Client.VM.migrate_send rpc session_id vm token true [ vdi, sr ] [] []) ;
+		let task = Client.Async.VM.migrate_send rpc session_id vm token true [ vdi, sr ] [] [] in
+		
+		ignore(Xapi_vm_clone.wait_for_subtask ~progress_minmax:(0.0,1.0) ~__context task)
+	) ;
 	Db.VBD.get_VDI ~__context ~self:vbd
 
 let force_unlock ~__context ~vdi = 

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -27,7 +27,7 @@ let delete_disks rpc session_id disks =
 				   else debug "Not destroying CD VDI: %s" (Ref.string_of vdi)
 			  ) disks
 
-let wait_for_clone ?progress_minmax ~__context task =
+let wait_for_subtask ?progress_minmax ~__context task =
 	Helpers.call_api_functions ~__context (fun rpc session ->
 	let refresh_session = Xapi_session.consider_touching_session rpc session in
 	let main_task = Context.get_task_id __context in
@@ -91,9 +91,14 @@ let wait_for_clone ?progress_minmax ~__context task =
 	done;
 	debug "Finished listening for events relating to tasks %s and %s" (Ref.string_of task) (Ref.string_of main_task);
 
-	let result = Db_actions.DB_Action.Task.get_result ~__context ~self:task in
-	let vdiref = API.From.ref_VDI "" (Xml.parse_string result) in
-	vdiref)
+	Db_actions.DB_Action.Task.get_result ~__context ~self:task)
+
+
+let wait_for_clone ?progress_minmax ~__context task =
+	let result = wait_for_subtask ?progress_minmax ~__context task in
+	let result = Xml.parse_string result in
+	let vdiref = API.From.ref_VDI "" result in
+	vdiref
 
 (* Clone code is parameterised over this so it can be shared with copy *)
 type disk_op_t =


### PR DESCRIPTION
Progress/cancellation was previously tied to the subtask

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
