### PR TITLE
CA-75018: A VM should not start if ha-host-failures-to-tolerate is too

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -200,8 +200,10 @@ let start ~__context ~vm ~start_paused ~force =
 			Vgpuops.create_vgpus ~__context (vm, vmr) (Helpers.will_boot_hvm ~__context ~self:vm);
 
 			if vmr.API.vM_ha_restart_priority = Constants.ha_restart
-			then Db.VM.set_ha_always_run ~__context ~self:vm ~value:true;
-
+			then begin
+				Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm;
+				Db.VM.set_ha_always_run ~__context ~self:vm ~value:true
+			end;
 			Xapi_xenops.start ~__context ~self:vm start_paused
 		)
 


### PR DESCRIPTION
high.

Backport of the pull-request for CA-57613 that is already merged.

Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
