### PR TITLE
CA-80656: Remove some very common debug lines.

### DIFF
--- a/ocaml/database/db_remote_cache_access_v1.ml
+++ b/ocaml/database/db_remote_cache_access_v1.ml
@@ -33,7 +33,6 @@ module DBCacheRemoteListener = struct
 		(* update_lengths xml resp; *)
 		(* let s = Xml.to_string_fmt resp  in *)
 		(* debug "Resp [Len = %d]: %s" (String.length s) s; *)
-		debug "Call succeeded";
 		resp
 			
 	let failure exn_name xml =
@@ -44,7 +43,6 @@ module DBCacheRemoteListener = struct
 					[XMLRPC.To.string exn_name;
 					xml]] in
 		(* update_lengths xml resp; *)
-		debug "Call failed";
 		resp
 			
 	module DBCache : Db_interface.DB_ACCESS = Db_cache_impl
@@ -63,7 +61,6 @@ module DBCacheRemoteListener = struct
 				| _ -> raise DBCacheListenerInvalidMessageReceived in
 		let t = Db_backend.make () in
 		try
-			debug "Received [total=%d rx=%d tx=%d] %s" !calls_processed !total_recv_len !total_transmit_len fn_name;
 			match fn_name with
 					"get_table_from_ref" ->
 						let s = unmarshall_get_table_from_ref_args args in

--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -315,8 +315,6 @@ let from ~__context ~classes ~token ~timeout =
 			(fun acc table ->
 				 Db_cache_types.Table.fold_over_recent sub.last_generation
 					 (fun ctime mtime dtime objref (creates,mods,deletes,last) ->
-						  debug "last_generation=%Ld cur_id=%Ld" sub.last_generation sub.cur_id;
-						  debug "ctime: %Ld mtime:%Ld dtime:%Ld objref:%s" ctime mtime dtime objref;
 						  let last = max last (max mtime dtime) in (* mtime guaranteed to always be larger than ctime *)
 						  if dtime > 0L then begin
 							  if ctime > sub.last_generation then
@@ -337,8 +335,6 @@ let from ~__context ~classes ~token ~timeout =
 		if List.length creates = 0 && List.length mods = 0 && List.length deletes = 0 && List.length messages = 0 && Unix.gettimeofday () < sub.timeout
 		then
 			(
-				debug "Waiting more: timeout=%f now=%f" sub.timeout (Unix.gettimeofday ());
-				
 				sub.last_generation <- last; (* Cur_id was bumped, but nothing relevent fell out of the db. Therefore the *)
 				sub.last_timestamp <- timestamp;
 				sub.cur_id <- last; (* last id the client got is equivalent to the current one *)

--- a/ocaml/xapi/xapi_periodic_scheduler.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler.ml
@@ -31,7 +31,6 @@ let (queue : (t Ipq.t)) = Ipq.create 50
 let lock = Mutex.create ()
 
 let add_to_queue ?(signal=true) name ty start newfunc =
-  debug "Adding function %s to queue, start=%f, type=%s" name start (match ty with OneShot -> "OneShot" | Periodic x -> Printf.sprintf "Periodic(%f)" x);
   Mutex.execute lock (fun () ->
     Ipq.add queue { Ipq.ev={ func=newfunc; ty=ty; name=name}; Ipq.time=((Unix.gettimeofday ()) +. start) });
   if signal then Delay.signal delay
@@ -39,7 +38,6 @@ let add_to_queue ?(signal=true) name ty start newfunc =
 let remove_from_queue name =
 	let index = Ipq.find_p queue (fun {name=n} -> name = n) in
 	if index > -1 then begin
-		debug "Removing function %s from queue" name;
 		Ipq.remove queue index
 	end
   
@@ -62,7 +60,7 @@ let loop () =
 		| OneShot -> ()
 		| Periodic timer -> add_to_queue ~signal:false todo.name todo.ty timer todo.func
 	    end else begin
-	      debug "Sleeping until next event (%f seconds)" (next.Ipq.time -. now +. 0.001);
+	      (* Sleep until next event. *)
 	      ignore(Delay.wait delay (next.Ipq.time -. now +. 0.001))
 	    end
 	  end


### PR DESCRIPTION
When rebooting a VM on a slave from XenCenter, this reduces the amount
of logging on the master from ~3500 lines to ~500 (!)
