### PR TITLE
CA-68648: Copy operation should not be allowed for HA VDIs

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3198,6 +3198,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
 		let copy ~__context ~vdi ~sr =
 			info "VDI.copy: VDI = '%s'; SR = '%s'" (vdi_uuid ~__context vdi) (sr_uuid ~__context sr);
+			Xapi_vdi.assert_operation_valid ~__context ~self:vdi ~op:`copy;
 			let local_fn = Local.VDI.copy ~vdi ~sr in
 			let src_sr = Db.VDI.get_SR ~__context ~self:vdi in
 			(* No need to lock the VDI because the VBD.plug will do that for us *)

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -115,6 +115,10 @@ let check_operation_error ~__context ha_enabled record _ref' op =
 			Some (Api_errors.vdi_is_sharable, [ _ref ])
 	  | `snapshot when reset_on_boot ->
 		    Some (Api_errors.vdi_on_boot_mode_incompatable_with_operation, [])
+	  | `copy ->
+	  if List.mem record.Db_actions.vDI_type [ `ha_statefile; `redo_log ]
+	  then Some (Api_errors.operation_not_allowed, ["VDI containing HA statefile or redo log cannot be copied (check the VDI's allowed operations)."])
+	  else None
       | _ -> None
     )
 


### PR DESCRIPTION
Removing copy from allowed_operations and blocking the copy operation for HA VDIs.
