### PR TITLE
CA-81053: make xapissl block when the host has no IP

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -34,7 +34,9 @@ let update_mh_info interface =
 	()
 
 let restart_stunnel () =
-	ignore(Forkhelpers.execute_command_get_output "/sbin/service" [ "xapissl"; "restart" ])
+	let (_ : Thread.t) = Thread.create (fun () ->
+		Forkhelpers.execute_command_get_output "/sbin/service" [ "xapissl"; "restart" ]) () in
+	()
 
 let stop () =
 	debug "Shutting down the old management interface (if any)";

--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -34,8 +34,15 @@ mgmt_ip() {
     if [ -n "${MANAGEMENT_INTERFACE}" ] &&
         [ "${MANAGEMENT_INTERFACE}" != "lo" ];
     then
-        /sbin/ifconfig ${MANAGEMENT_INTERFACE} | \
-            sed -ne 's/.*inet addr:\([^ ]*\).*/\1/p'
+        while [ true ]; do
+            IP=`/sbin/ifconfig ${MANAGEMENT_INTERFACE} | sed -ne 's/.*inet addr:\([^ ]*\).*/\1/p'`
+            if [ -n "$IP" ]; then
+                echo "$IP"
+                return
+            else
+                sleep 1
+            fi
+        done
     fi
 }
 


### PR DESCRIPTION
At the same time, xapi should not wait for it.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
