### PR TITLE
CA-79538: Disallow setting number of VCPUs to zero

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1348,7 +1348,7 @@ let transform_xenops_exn ~__context f =
 		| Does_not_exist(thing, id) -> internal "Object with type %s and id %s does not exist in xenopsd" thing id
 		| Unimplemented(fn) -> reraise Api_errors.not_implemented [ fn ]
 		| Domain_not_built -> internal "domain has not been built"
-		| Maximum_vcpus n -> internal "the maximum number of vcpus configured for this VM is currently: %d" n
+		| Invalid_vcpus n -> internal "the maximum number of vcpus configured for this VM is currently: %d" n
 		| Bad_power_state(found, expected) ->
 			let f x = x |> (fun x -> Some x) |> xenapi_of_xenops_power_state |> Record_util.power_state_to_string in
 			let found = f found and expected = f expected in
@@ -1472,7 +1472,7 @@ let set_vcpus ~__context ~self n =
 					Db.VM_metrics.set_VCPUs_number ~__context ~self:metrics ~value:n;
 				Event.wait dbg ();
 			with
-				| Maximum_vcpus n ->
+				| Invalid_vcpus n ->
 					raise (Api_errors.Server_error(Api_errors.invalid_value, [
 						"VCPU values must satisfy: 0 < VCPUs ≤ VCPUs_max";
 						string_of_int n

--- a/ocaml/xenops/xenops_interface.ml
+++ b/ocaml/xenops/xenops_interface.ml
@@ -27,7 +27,7 @@ exception Already_exists of (string * string)
 exception Does_not_exist of (string * string)
 exception Unimplemented of string
 exception Domain_not_built
-exception Maximum_vcpus of int
+exception Invalid_vcpus of int
 exception Bad_power_state of (power_state * power_state)
 exception Failed_to_acknowledge_shutdown_request
 exception Failed_to_shutdown of (string * float)

--- a/ocaml/xenops/xenops_server.ml
+++ b/ocaml/xenops/xenops_server.ml
@@ -917,8 +917,8 @@ let perform_atomic ~progress_callback ?subtask (op: atomic) (t: Xenops_task.t) :
 		| VM_set_vcpus (id, n) ->
 			debug "VM.set_vcpus (%s, %d)" id n;
 			let vm_t = VM_DB.read_exn id in
-			if n > vm_t.Vm.vcpu_max
-			then raise (Maximum_vcpus vm_t.Vm.vcpu_max);
+			if n <= 0 || n > vm_t.Vm.vcpu_max
+			then raise (Invalid_vcpus vm_t.Vm.vcpu_max);
 			B.VM.set_vcpus t (VM_DB.read_exn id) n
 		| VM_set_shadow_multiplier (id, m) ->
 			debug "VM.set_shadow_multiplier (%s, %.2f)" id m;


### PR DESCRIPTION
- Rename the `Maximum_vcpus` exception to `Invalid_vcpus` to better reflect meaning
- Extend the `fail_max_vcpus_task` unit test to `fail_invalid_vcpus_task`
  NOTE: The test was failing before this change and is still failing
