### PR TITLE
Update Host.name_label if it is localhost.localdomain

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -127,6 +127,8 @@ let on_dom0_networking_change ~__context =
 		debug "Changing Host.hostname in database to: %s" new_hostname;
 		Db.Host.set_hostname ~__context ~self:localhost ~value:new_hostname
 	end;
+	if Db.Host.get_name_label ~__context ~self:localhost = "localhost.localdomain" then
+		Db.Host.set_name_label ~__context ~self:localhost ~value:new_hostname;
 	begin match Helpers.get_management_ip_addr ~__context with
 		| Some ip ->
 			if Db.Host.get_address ~__context ~self:localhost <> ip then begin


### PR DESCRIPTION
The Host.name_label field is set to be the hostname when xapi
first starts and the Host record is created. If the hostname has
not yet been set at that point, for example due to a slow DHCP
response, you may end up with a "localhost.localdomain" name_label.
This became more likely since the init script of the network daemon
no longer waits for the DHCP reply.

This patch changes the Host.name_label of a host when the hostname
changes, and the name_label currently is "localhost.localdomain".

Signed-off-by: Rob Hoes rob.hoes@citrix.com
