### PR TITLE
CA-80468: Incomplete prechecks for cross pool migrations

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -500,6 +500,10 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 		let force = try bool_of_string (List.assoc "force" options) with _ -> false in
 		if (not force) && live then Xapi_vm_helpers.assert_vm_is_compatible ~__context ~vm ~host
 	| `cross_pool remote_rpc ->
+		(* Check that the VM has no more than one snapshot *)
+		let (snapshots_vbds, nb_snapshots) = get_snapshots_vbds ~__context ~vm in
+		if nb_snapshots > 1 then
+			raise (Api_errors.Server_error(Api_errors.vm_has_too_many_snapshots, []));
 		(* Ignore vdi_map for now since we won't be doing any mirroring. *)
 		inter_pool_metadata_transfer ~__context ~remote_rpc ~session_id ~remote_address ~vm ~vdi_map:[] ~dry_run:true ~live
 


### PR DESCRIPTION
VM migrate assertion should raise error for cross pool migrations if the VM has more than one snapshots.

Signed-off-by: Rabin Karki rabin.karki@citrix.com
