### PR TITLE
CA-79334: set_VCPUs_at_startup should be allowed when the VM is running

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1640,9 +1640,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 		let set_VCPUs_at_startup ~__context ~self ~value =
 			info "VM.set_VCPUs_at_startup: self = %s; value = %Ld"
 				(vm_uuid ~__context self) value;
-			with_vm_operation ~__context ~self ~doc:"VM.set_VCPUs_at_startup"
-				~op:`changing_VCPUs
-				(fun () -> Local.VM.set_VCPUs_at_startup ~__context ~self ~value)
+			Local.VM.set_VCPUs_at_startup ~__context ~self ~value
 
 		let compute_memory_overhead ~__context ~vm =
 			info "VM.compute_memory_overhead: vm = '%s'"

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -560,9 +560,6 @@ let set_VCPUs_max ~__context ~self ~value =
 
 (** Sets the number of startup VCPUs for a {b Halted} guest. *)
 let set_VCPUs_at_startup ~__context ~self ~value =
-	if Db.VM.get_power_state ~__context ~self <> `Halted
-	then failwith "assertion_failed: set_VCPUs_at_startup should only be \
-		called when the VM is Halted";
 	let vcpus_max = Db.VM.get_VCPUs_max ~__context ~self in
 	if value < 1L || value > vcpus_max then invalid_value
 		"VCPU values must satisfy: 0 < VCPUs_at_startup ≤ VCPUs_max"


### PR DESCRIPTION
Signed-off-by: Thomas Gazagnaire thomas.gazagnaire@ocamlpro.com
