### PR TITLE
Further improve rrdd robustness

### DIFF
--- a/ocaml/rrdd/rrdd_http_handler.ml
+++ b/ocaml/rrdd/rrdd_http_handler.ml
@@ -1,6 +1,7 @@
 module D = Debug.Debugger(struct let name="rrdd_http_handler" end)
 open D
 
+open Hashtblext
 open Threadext
 open Rrdd_shared
 
@@ -51,11 +52,11 @@ let get_host_stats ?(json = false) ~(start : int64) ~(interval : int64)
 		~(cfopt : Rrd.cf_type option) ~(is_host : bool) ?(uuid : string option) () =
 	Mutex.execute mutex (fun () ->
 		let prefixandrrds =
-			let vmsandrrds = Hashtbl.fold (fun k v acc -> (k, v)::acc) vm_rrds [] in
+			let vmsandrrds = Hashtbl.to_list vm_rrds in
 			let vmsandrrds =
-			match uuid with
-			| None -> vmsandrrds
-			| Some uuid -> List.filter (fun (k, v) -> k = uuid) vmsandrrds
+				match uuid with
+				| None -> vmsandrrds
+				| Some uuid -> List.filter (fun (k, _) -> k = uuid) vmsandrrds
 			in
 			let vm_rrds = List.map (fun (k, v) -> "vm:" ^ k ^ ":", v.rrd) vmsandrrds in
 			if is_host then match !host_rrd with None -> vm_rrds | Some rrdi ->

--- a/ocaml/rrdd/rrdd_shared.ml
+++ b/ocaml/rrdd/rrdd_shared.ml
@@ -108,15 +108,14 @@ let send_rrd ?(session_id : string option) ~(address : string)
 		Http.Request.make ~user_agent:Xapi_globs.xapi_user_agent
 			~query ~cookie Http.Put Constants.put_rrd_uri in
 	let open Xmlrpc_client in
-	let transport = SSL(SSL.make ~use_stunnel_cache:true (), address, !Xapi_globs.https_port) in
+	let transport = SSL(SSL.make (), address, !Xapi_globs.https_port) in
 	with_transport transport (
 		with_http request (fun (response, fd) ->
 			try Rrd.to_fd rrd fd
-			with e ->
-				(*debug "Caught exception: %s" (ExnHelper.string_of_exn e);*)
-				log_backtrace ()
+			with e -> log_backtrace ()
 		)
-	)
+	);
+	debug "Sending RRD complete."
 
 let archive_rrd ?(save_stats_locally = Pool_role_shared.is_master ()) ~uuid
 		~rrd () =


### PR DESCRIPTION
Stunnel caching can trigger a sigpipe interrupt, which can kill the parent
process. This patch disables stunnel caching for rrdd, and makes it resistant
to sigpipe interrupts (in the same way as xapi is already).

Signed-off-by: Rok Strniša rok.strnisa@citrix.com
