### PR TITLE
xe host-evacuate accepts all host selectors (minor)

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2018,11 +2018,11 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
     };
    "host-evacuate",
     {
-      reqd=["uuid"];
+      reqd=[];
       optn=[];
       help="Migrate all VMs off a host.";
       implementation=No_fd Cli_operations.host_evacuate;
-      flags=[];
+      flags=[Host_selectors];
     };   
    "host-get-vms-which-prevent-evacuation",
     {

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2823,9 +2823,10 @@ let host_all_editions printer rpc session_id params =
 	printer (Cli_printer.PList editions)
 
 let host_evacuate printer rpc session_id params =
-	let uuid = List.assoc "uuid" params in
-	let host = Client.Host.get_by_uuid rpc session_id uuid in
-	ignore (Client.Host.evacuate rpc session_id host)
+	ignore (do_host_op rpc session_id ~multiple:false
+		(fun _ host ->
+			Client.Host.evacuate rpc session_id (host.getref ()))
+		params [])
 
 let host_get_vms_which_prevent_evacuation printer rpc session_id params =
 	let uuid = List.assoc "uuid" params in


### PR DESCRIPTION
Not sure if this is something we want to do, but we got a feature request for it on xen-api. This pull request allows you to evacuate a host based on name-label, but doesn't allow multiple-host selection. This is the same functionality as host-disable and host-reboot (though I think they allow multiple host selection).
