### PR TITLE
CA-81330: If we need to add default flows to an ovs port, ensure we got a MAC

### DIFF
--- a/ocaml/network/network_interface.ml
+++ b/ocaml/network/network_interface.ml
@@ -92,7 +92,7 @@ type interface_config_t = {
 type port_config_t = {
 	interfaces: iface list;
 	bond_properties: (string * string) list;
-	mac: string;
+	bond_mac: string option;
 }
 type bridge_config_t = {
 	ports: (port * port_config_t) list;
@@ -132,7 +132,7 @@ let default_bridge = {
 let default_port = {
 	interfaces = [];
 	bond_properties = [];
-	mac = "";
+	bond_mac = None;
 }
 
 (** {2 Configuration manipulation} *)
@@ -211,7 +211,7 @@ module Bridge = struct
 	external is_persistent : debug_info -> name:bridge -> bool = ""
 	external set_persistent : debug_info -> name:bridge -> value:bool -> unit = ""
 	external get_vlan : debug_info -> name:bridge -> (bridge * int) option = ""
-	external add_port : debug_info -> ?mac:string -> bridge:bridge -> name:port -> interfaces:iface list ->
+	external add_port : debug_info -> ?bond_mac:string -> bridge:bridge -> name:port -> interfaces:iface list ->
 		?bond_properties:(string * string) list -> unit -> unit = ""
 	external remove_port : debug_info -> bridge:bridge -> name:port -> unit = ""
 	external get_interfaces : debug_info -> name:bridge -> iface list = ""

--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -627,7 +627,7 @@ module Bridge = struct
 			| Bridge -> ()
 		) ()
 
-	let add_port _ dbg ?(mac="") ~bridge ~name ~interfaces ?(bond_properties=[]) () =
+	let add_port _ dbg ?bond_mac ~bridge ~name ~interfaces ?(bond_properties=[]) () =
 		Debug.with_thread_associated dbg (fun () ->
 			let config = get_config bridge in
 			let ports =
@@ -636,26 +636,32 @@ module Bridge = struct
 				else
 					config.ports
 			in
-			let ports = (name, {interfaces; mac; bond_properties}) :: ports in
+			let ports = (name, {interfaces; bond_mac; bond_properties}) :: ports in
 			update_config bridge {config with ports};
 			debug "Adding port %s to bridge %s with interfaces %s%s" name bridge
 				(String.concat ", " interfaces)
-				(if mac <> "" then " and MAC " ^ mac else "");
+				(match bond_mac with Some mac -> " and MAC " ^ mac | None -> "");
 			match !kind with
 			| Openvswitch ->
 				if List.length interfaces = 1 then begin
 					List.iter (fun name -> Interface.bring_up () dbg ~name) interfaces;
 					ignore (Ovs.create_port (List.hd interfaces) bridge)
 				end else begin
-					ignore (Ovs.create_bond name interfaces bridge mac bond_properties);
+					if bond_mac = None then
+						warn "No MAC address specified for the bond";
+					ignore (Ovs.create_bond ?mac:bond_mac name interfaces bridge bond_properties);
 					List.iter (fun name -> Interface.bring_up () dbg ~name) interfaces
 				end;
 				if List.mem bridge !add_default then begin
-					let mac' = if mac = "" then try Ip.get_mac name with _ -> "" else mac in
-					if mac' <> "" then begin
-						add_default_flows () dbg bridge mac' interfaces;
+					let mac = match bond_mac with
+						| None -> (try Some (Ip.get_mac name) with _ -> None)
+						| Some mac -> Some mac
+					in
+					match mac with
+					| Some mac ->
+						add_default_flows () dbg bridge mac interfaces;
 						add_default := List.filter ((<>) bridge) !add_default
-					end else
+					| None ->
 						warn "Could not add default flows for port %s on bridge %s because no MAC address was specified"
 							name bridge
 				end
@@ -666,7 +672,10 @@ module Bridge = struct
 				end else begin
 					if not (List.mem name (Sysfs.bridge_to_interfaces bridge)) then begin
 						Linux_bonding.add_bond_master name;
-						if mac <> "" then Ip.set_mac name mac;
+						begin match bond_mac with
+							| Some mac -> Ip.set_mac name mac
+							| None -> warn "No MAC address specified for the bond"
+						end;
 						List.iter (fun name -> Interface.bring_down () dbg ~name) interfaces;
 						List.iter (Linux_bonding.add_bond_slave name) interfaces;
 						let bond_properties =
@@ -763,8 +772,8 @@ module Bridge = struct
 			List.iter (function (bridge_name, ({ports; vlan; bridge_mac; other_config; _} as c)) ->
 				update_config bridge_name c;
 				create () dbg ?vlan ?mac:bridge_mac ~other_config ~name:bridge_name ();
-				List.iter (fun (port_name, {interfaces; bond_properties; mac}) ->
-					add_port () dbg ~mac ~bridge:bridge_name ~name:port_name ~interfaces ~bond_properties ()
+				List.iter (fun (port_name, {interfaces; bond_properties; bond_mac}) ->
+					add_port () dbg ?bond_mac ~bridge:bridge_name ~name:port_name ~interfaces ~bond_properties ()
 				) ports
 			) config
 		) ()

--- a/ocaml/network/network_utils.ml
+++ b/ocaml/network/network_utils.ml
@@ -718,10 +718,14 @@ module Ovs = struct
 		) properties in
 		mode_args @ extra_args @ other_args
 
-	let create_bond name interfaces bridge mac properties =
+	let create_bond ?mac name interfaces bridge properties =
 		let args = make_bond_properties name properties in
+		let mac_args = match mac with
+			| None -> []
+			| Some mac -> ["--"; "set"; "port"; name; "MAC=\"" ^ (String.escaped mac) ^ "\""]
+		in
 		vsctl ~log:true (["--"; "--may-exist"; "add-bond"; bridge; name] @ interfaces @
-			["--"; "set"; "port"; name; "MAC=\"" ^ (String.escaped mac) ^ "\""] @ args)
+			mac_args @ args)
 
 	let get_fail_mode bridge =
 		vsctl ["get-fail-mode"; bridge]

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -154,7 +154,7 @@ let create_bond ~__context bond mtu =
 	in
 
 	let ports = [port, {interfaces=(List.map (fun (device, _) -> device) slave_devices_and_bridges);
-		bond_properties=props; mac}] in
+		bond_properties=props; bond_mac=Some mac}] in
 	cleanup,
 	[master_net_rc.API.network_bridge, {default_bridge with ports; bridge_mac=(Some mac); other_config;
 		persistent_b}],


### PR DESCRIPTION
Default flows need to be added to an ovs instance whenever the fail mode
changes from standalone to secure. If we don't do that, the DVS controller
won't have access to the vswitch anymore.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
