### PR TITLE
CA-84345: WLB unable to add pool when pool master uses IPv6 address.

### DIFF
--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -449,9 +449,15 @@ let init_wlb ~__context ~wlb_url ~wlb_username ~wlb_password ~xenserver_username
 		(generate_safe_param "Password" xenserver_password)
 		(pool_uuid_param ~__context)
 		(generate_safe_param "UserName" xenserver_username)
-		(generate_safe_param "XenServerUrl" 
-			(sprintf "http://%s:80/" 
-				(Db.Host.get_address ~__context ~self:master)))) 
+		(generate_safe_param "XenServerUrl"
+			(let master_address = Db.Host.get_address ~__context ~self:master
+			in
+			if (String.contains master_address ':') && not (String.contains master_address '[')
+			then
+				(*This is an ipv6 address and doesn't have [], put [] around the address so that WLB can properly parse the url*)
+				sprintf "http://[%s]:80/" master_address
+			else
+				sprintf "http://%s:80/" master_address)))
 	in
 	let handle_response inner_xml =
 		(*A succesful result has an ID inside the addxenserverresult *)


### PR DESCRIPTION
This could be done at WLB side but the code to do that is ugly once we add http:// and :80 around the address. 
Also if there is a function already that detects whether the address is ipv6 or not, please let me know. I'll replace the String.contains functions with that.
