### PR TITLE
CA-84345: WLB is unable to add pool when pool master uses IPv6 address.

### DIFF
--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -450,8 +450,13 @@ let init_wlb ~__context ~wlb_url ~wlb_username ~wlb_password ~xenserver_username
 		(pool_uuid_param ~__context)
 		(generate_safe_param "UserName" xenserver_username)
 		(generate_safe_param "XenServerUrl" 
-			(sprintf "http://%s:80/" 
-				(Db.Host.get_address ~__context ~self:master)))) 
+			(let address_type = Record_util.primary_address_type_of_string (Xapi_inventory.lookup Xapi_inventory._management_address_type ~default:"ipv4") in
+			let master_address = Db.Host.get_address ~__context ~self:master in
+			if address_type = `IPv4 then
+				sprintf "http://%s:80/" master_address
+			else
+				(*This is an ipv6 address, put [] around the address so that WLB can properly parse the url*)
+				sprintf "http://[%s]:80/" master_address)))
 	in
 	let handle_response inner_xml =
 		(*A succesful result has an ID inside the addxenserverresult *)


### PR DESCRIPTION
Using function suggested by Rob in https://github.com/xen-org/xen-api/pull/702 to find out whether the host is in IPv4 or in IPv6 mode.
