### PR TITLE
CA-84333: New XenServer installation has crash dump files. xapi mistakes sacrificial files as crashdumps

### DIFF
--- a/ocaml/xapi/xapi_host_crashdump.ml
+++ b/ocaml/xapi/xapi_host_crashdump.ml
@@ -55,7 +55,12 @@ let resynchronise ~__context ~host =
 		(fun self ->
 			Db.Host_crashdump.get_filename ~__context ~self) all_refs in
 
-	let real_filenames = try Array.to_list (Sys.readdir crash_dir) with _ -> [] in
+	let real_filenames = 
+		List.filter (fun filename ->
+			let stat = Unix.stat (Filename.concat crash_dir filename) in
+			stat.Unix.st_kind = Unix.S_DIR (*only directories are marked as crashdumps*)
+		)
+		(try Array.to_list (Sys.readdir crash_dir) with _ -> []) in
 	let gone_away = set_difference db_filenames real_filenames
 	and arrived = set_difference real_filenames db_filenames in
 


### PR DESCRIPTION
Detecting only directories as crashdumps. 
This also makes detection consistent with the crashdump deletion, as only directories are deleted from /var/crash dir.
