### PR TITLE
CA-78139 - Make reading the inventory threadsafe.

### DIFF
--- a/ocaml/util/util_inventory.ml
+++ b/ocaml/util/util_inventory.ml
@@ -95,14 +95,15 @@ let reread_inventory () = Mutex.execute inventory_m (fun () ->
 exception Missing_inventory_key of string
 
 let lookup ?default key =
-	(if not (!loaded_inventory) then read_inventory());
-	if (Hashtbl.mem inventory key)
-	then
-		Hashtbl.find inventory key
-	else
-		match default with
-			| None   -> raise (Missing_inventory_key key)
-			| Some v -> v
+	Mutex.execute inventory_m (fun () ->
+		(if not (!loaded_inventory) then read_inventory_contents ());
+		if (Hashtbl.mem inventory key)
+		then
+			Hashtbl.find inventory key
+		else
+			match default with
+				| None   -> raise (Missing_inventory_key key)
+				| Some v -> v)
 
 let flush_to_disk_locked () =
 	let h = Hashtbl.fold (fun k v acc -> (k, v) :: acc) inventory [] in


### PR DESCRIPTION
If something (e.g. bringing up the management interface) is updating the
inventory, it's not safe to read from the hashtable.

This intermittently breaks the creation of the local SR at first boot,
since the sr-create command logs in to localhost which requires looking
up the installation uuid from the inventory.
