### PR TITLE
Add domain_sethandle to .gitignore (trivial)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,4 +211,4 @@ ocaml/fhs.*
 /ocaml/sm-cli/smtest
 /ocaml/xenops/cancel_utils_test
 ocaml/xapi/storage_impl_test
-
+ocaml/xenops/domain_sethandle


### PR DESCRIPTION
We were missing the domain_sethandle binary from gitignore.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
