### PR TITLE
CA-80579: An HVM without PV drivers can be shutdown/suspend again.

### DIFF
--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -302,9 +302,11 @@ let shutdown_wait_for_ack (t: Xenops_task.t) ?(timeout=60.) ~xc ~xs domid req =
 	let di = Xenctrl.domain_getinfo xc domid in
 	let uuid = get_uuid ~xc domid in
 	if di.Xenctrl.hvm_guest then begin
-		if Xenctrl.hvm_check_pvdriver xc domid
-		then debug "VM = %s; domid = %d; HVM guest with PV drivers: not expecting any acknowledgement" (Uuid.to_string uuid) domid
-		else Xenctrl.domain_shutdown xc domid (shutdown_to_xc_shutdown req)
+		if not (Xenctrl.hvm_check_pvdriver xc domid)
+		then begin
+			debug "VM = %s; domid = %d; HVM guest without PV drivers: not expecting any acknowledgement" (Uuid.to_string uuid) domid;
+			Xenctrl.domain_shutdown xc domid (shutdown_to_xc_shutdown req)
+		end
 	end else begin
 		debug "VM = %s; domid = %d; Waiting for PV domain to acknowledge shutdown request" (Uuid.to_string uuid) domid;
 		let path = control_shutdown ~xs domid in


### PR DESCRIPTION
Not supported, but used by CloudStack.

Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
