### PR TITLE
CA-84673: Metadata import should create a network if it can't find one

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -620,43 +620,33 @@ end
 module Net : HandlerTools = struct
 	type precheck_t =
 		| Found_net of API.ref_network
-		| Found_no_net of exn
 		| Create of API.network_t
 	
 	let precheck __context config rpc session_id state x =
 		let net_record = API.From.network_t "" x.snapshot in
 		let possibilities = Client.Network.get_by_name_label rpc session_id net_record.API.network_name_label in
-		match possibilities, config.import_type with
-		| [], Metadata_import _ ->
+		match possibilities with
+		| [] ->
 			begin
 				(* Lookup by bridge name as fallback *)
 				let expr = "field \"bridge\"=\"" ^ net_record.API.network_bridge ^ "\"" in
 				let nets = Client.Network.get_all_records_where rpc session_id expr in
 				match nets with
-				| [] ->
-					(* In vm_metadata_only_mode the network must exist *)
-					let msg =
-						Printf.sprintf "Unable to find Network with name_label = '%s' nor bridge = '%s'"
-						net_record.API.network_name_label net_record.API.network_bridge
-					in
-					error "%s" msg;
-					Found_no_net (Failure msg)
+				| [] -> Create net_record
 				| (net, _) :: _ -> Found_net net
 			end
-		| [], Full_import _ -> Create net_record
-		| (n::ns), _ -> Found_net n
+		| (n::ns) -> Found_net n
 
 	let handle_dry_run __context config rpc session_id state x precheck_result =
 		match precheck_result with
 		| Found_net net -> state.table <- (x.cls, x.id, Ref.string_of net) :: state.table
-		| Found_no_net e -> raise e
 		| Create _ ->
 			let dummy_net = Ref.make () in
 			state.table <- (x.cls, x.id, Ref.string_of dummy_net) :: state.table
 
 	let handle __context config rpc session_id state x precheck_result =
 		match precheck_result with
-		| Found_net _ | Found_no_net _ ->
+		| Found_net _ ->
 			handle_dry_run __context config rpc session_id state x precheck_result
 		| Create net_record ->
 			let net =


### PR DESCRIPTION
This already happens for "normal" VM imports. There is no good reason
why a metadata import should fail if it cannot find a network, rather than
creating an internal network.

This will prevent issues during, e.g., cross pool migration, where metadata
export+import is used to migrate VM metadata to the remote pool.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
