### PR TITLE
CA-67536: Remove unplug_force from vif_operations

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4813,7 +4813,6 @@ let vif_operations =
 	[ "attach", "Attempting to attach this VIF to a VM";
 	  "plug", "Attempting to hotplug this VIF";
 	  "unplug", "Attempting to hot unplug this VIF";
-	  "unplug_force", "Attempting to forcibly unplug this VIF";
 	])
 
 let vif_locking_mode =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2618,7 +2618,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					forward_vif_op ~local_fn ~__context ~self (fun session_id rpc -> Client.VIF.plug rpc session_id self))
 
 		let unplug_common ~__context  ~self ~force =
-			let op = if force then `unplug_force else `unplug in
+			let op = `unplug in
 			let name = "VIF." ^ (Record_util.vif_operation_to_string op) in
 			info "%s: VIF = '%s'" name (vif_uuid ~__context self);
 			let local_fn, remote_fn =


### PR DESCRIPTION
The unplug_force operation was recently added to the vif_operations enum.
However, this causes problems during rolling pool upgrade, while the
master has been upgraded, but some of the slaves have not. Operations
such as Db.VIF.get_record on running VMs were be broken by this, which broke
live migrations between un-upgraded hosts.

After this patch, the "unplug" operation is used for both "unplug" as well
as "unplug_force" in VIF.allowed_operations, which is fine, since they are
always allowed at the same time.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
