### PR TITLE
CA-84688: log changes ("drift") between a monotonic clock source and UTC

### DIFF
--- a/ocaml/rrdd/OMakefile
+++ b/ocaml/rrdd/OMakefile
@@ -9,7 +9,7 @@ OCAMLINCLUDES = \
 	$(ROOT)/ocaml/xenops \
 	interface
 # ocaml/xapi only needed for xapi_fist : should move xapi_first to libs
-OCAMLPACKS = xml-light2 stunnel http-svr xenctrl xenctrlext xenstore
+OCAMLPACKS = oclock xml-light2 stunnel http-svr xenctrl xenctrlext xenstore
 OCAML_LIBS = $(ROOT)/ocaml/fhs ../idl/ocaml_backend/xapi_client
 # ../xenops/xenops_client
 

--- a/ocaml/rrdd/rrdd_stats.ml
+++ b/ocaml/rrdd/rrdd_stats.ml
@@ -129,9 +129,15 @@ let string_of_process_memory_info (x: process_memory_info) =
 		"size: %d KiB; rss: %d KiB; data: %d KiB; stack: %d KiB"
 		x.size x.rss x.data x.stack
 
+(* Log the initial offset between our monotonic clock and UTC *)
+let initial_offset =
+	Unix.gettimeofday () -. (Int64.to_float (Oclock.gettime Oclock.monotonic) /. 1e9)
+
 let print_system_stats () =
 	let mi = string_of_meminfo (meminfo ()) in
-	debug "system stats: %s" mi
+	debug "system stats: %s" mi;
+	let current_offset = Unix.gettimeofday () -. (Int64.to_float (Oclock.gettime Oclock.monotonic) /. 1e9) in
+	debug "Clock drift: %.0f" (current_offset -. initial_offset)
 
 (* Obtains process IDs for the specified program.
  * This should probably be moved into xen-api-libs. *)

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -1,4 +1,4 @@
-OCAMLPACKS    = xml-light2 cdrom pciutil sexpr log stunnel http-svr rss xen-utils netdev tapctl vhd rpc-light nbd
+OCAMLPACKS    = oclock xml-light2 cdrom pciutil sexpr log stunnel http-svr rss xen-utils netdev tapctl vhd rpc-light nbd
 OCAML_LIBS    = ../fhs ../util/version ../util/vm_memory_constraints ../util/sanitycheck ../util/stats \
 	../idl/ocaml_backend/common ../idl/ocaml_backend/client ../idl/ocaml_backend/server ../util/ocamltest
 OCAMLINCLUDES = ../idl ../idl/ocaml_backend \


### PR DESCRIPTION
This highlights when problems are being caused by the system clock being manipulated.

Signed-off-by: David Scott dave.scott@eu.citrix.com

Tested by:
1. observing that drift is zero after a xapi start
2. setting the clock forward with "date -u -s"
3. observing a non-zero drift is recorded
4. quicktest passes
