### PR TITLE
[xapi] We shouldn't call "Unix.sleep" in a multithreaded program

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -896,7 +896,7 @@ let import_convert ~__context ~_type ~username ~password ~sr ~remote_config =
 		(match jobInstance.state with
 			| Created
 			| Queued
-			| Running -> Unix.sleep 1; loop call vpx_ip
+			| Running -> Thread.delay 1.; loop call vpx_ip
 			| Completed
 			| Aborted
 			| UserAborted -> ()) in


### PR DESCRIPTION
This will cause the whole process (ie all the threads) to sleep.
We should use "Thread.delay" instead.

Signed-off-by: David Scott dave.scott@eu.citrix.com
