### PR TITLE
CA-83260: Raise API error when attaching RO disk VBD to HVM guest

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -192,6 +192,8 @@ let vdi_readonly = "VDI_READONLY"
 let vdi_is_a_physical_device = "VDI_IS_A_PHYSICAL_DEVICE"
 let vdi_is_not_iso = "VDI_IS_NOT_ISO"
 let vbd_cds_must_be_readonly = "VBD_CDS_MUST_BE_READONLY"
+(* CA-83260 *)
+let disk_vbd_must_be_readwrite_for_hvm = "DISK_VBD_MUST_BE_READWRITE_FOR_HVM"
 let host_cd_drive_empty = "HOST_CD_DRIVE_EMPTY"
 let vdi_not_available = "VDI_NOT_AVAILABLE"
 let vdi_location_missing = "VDI_LOCATION_MISSING"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -545,6 +545,9 @@ let _ =
     ~doc:"This VM has locked the DVD drive tray, so the disk cannot be ejected" ();
   error Api_errors.vbd_cds_must_be_readonly [ ]
     ~doc:"Read/write CDs are not supported" ();
+  (* CA-83260 *)
+  error Api_errors.disk_vbd_must_be_readwrite_for_hvm ["vbd"]
+    ~doc:"All VBDs of type 'disk' must be read/write for HVM guests" ();
   error Api_errors.vm_hvm_required ["vm"]
     ~doc:"HVM is required for this operation" ();
   error Api_errors.vm_no_vcpus ["vm"]


### PR DESCRIPTION
Tested by:
- Try attaching a VDI with a mode=RO VBD to a PV guest. Should succeed.
- Try attaching a VDI with a mode=RO VBD to an HVM guest that has PV drivers. Should fail with the appropriate API error.
- Try attaching a VDI with a mode=RW VBD to an HVM guest that has PV drivers. Should succeed.

Note that this pull request introduces a new API error. Therefore this patch should not be merged to a branch into which XenCenter has not has this error internationalised.
