### PR TITLE
CA-84354: SXM fails when VM has snapshot

### DIFF
--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -626,7 +626,7 @@ let copy ~task ~dbg ~sr ~vdi ~dp ~url ~dest =
 						Remote.VDI.clone ~dbg ~sr:dest ~vdi_info:vdi
 				| None ->
 						debug "Creating a blank remote VDI";
-						Remote.VDI.create ~dbg ~sr:dest ~vdi_info:local_vdi in
+						Remote.VDI.create ~dbg ~sr:dest ~vdi_info:{ local_vdi with sm_config = [] }  in
 			let remote_copy = copy' ~task ~dbg ~sr ~vdi ~url ~dest ~dest_vdi:remote_base.vdi |> vdi_info in
 			let snapshot = Remote.VDI.snapshot ~dbg ~sr:dest ~vdi_info:remote_copy in
 			Remote.VDI.destroy ~dbg ~sr:dest ~vdi:remote_copy.vdi;


### PR DESCRIPTION
We weren't clearing the vdi_info.sm_config map when we created a new VDI on the
remote host for the snapshot VDI. The sm_config map still had the
host_OpaqueRef:... field, which caused blktap2.py to think that the VDI was
already attached and activated, when in fact it wasn't. We now clear the
sm_config map (although it is unclear whether clearing it is better than just
filtering the host_OpaqueRef key).

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
