### PR TITLE
CA-85224: ensure qemu watch "cancel paths" are unique per qemu instance

### DIFF
--- a/ocaml/xenops/cancel_utils.ml
+++ b/ocaml/xenops/cancel_utils.ml
@@ -26,26 +26,38 @@ open D
 type key =
 	| Device of device
 	| Domain of int
+	| Qemu of int * int
 	| TestPath of string
 
 let string_of = function
 	| Device device -> Printf.sprintf "device %s" (Device_common.string_of_device device)
 	| Domain domid -> Printf.sprintf "domid %d" domid
+	| Qemu (backend, frontend) -> Printf.sprintf "qemu backend = %d; frontend = %d" backend frontend
 	| TestPath x -> x
 
 let cancel_path_of ~xs = function
-	| Device device -> backend_path_of_device ~xs device ^ "/tools/xenops/cancel"
-	| Domain domid -> Printf.sprintf "%s/tools/xenops/cancel" (xs.Xs.getdomainpath domid)
+	| Device device ->
+		(* Device operations can be cancelled separately *)
+		backend_path_of_device ~xs device ^ "/tools/xenops/cancel"
+	| Domain domid ->
+		Printf.sprintf "%s/tools/xenops/cancel" (xs.Xs.getdomainpath domid)
+	| Qemu (backend, frontend) ->
+		(* Domain and qemu watches are considered to be domain-global *)
+		Printf.sprintf "%s/cancel" (Device_common.device_model_path ~qemu_domid:backend frontend)
 	| TestPath x -> x
 
 let domain_shutdown_path_of ~xs = function
 	| Device device -> frontend_path_of_device ~xs device ^ "/tools/xenops/shutdown"
 	| Domain domid -> Printf.sprintf "%s/tools/xenops/shutdown" (xs.Xs.getdomainpath domid)
+	| Qemu (backend, _) ->
+		(* We only need to cancel when the backend domain shuts down. It will
+		   break suspend if we cancel when the frontend shuts down. *)
+		Printf.sprintf "%s/tools/xenops/shutdown" (xs.Xs.getdomainpath backend)
 	| TestPath x -> x
 
 let watches_of ~xs key = [
 	Watch.key_to_disappear (cancel_path_of ~xs key);
-	Watch.value_to_become (domain_shutdown_path_of ~xs key) "";
+	Watch.value_to_become (domain_shutdown_path_of ~xs key) ""
 ]
 
 let cancel ~xs key =
@@ -57,7 +69,14 @@ let cancel ~xs key =
 
 let on_shutdown ~xs domid =
 	let path = domain_shutdown_path_of ~xs (Domain domid) in
-	xs.Xs.write path ""
+	(* Only write if the guest domain still exists *)
+	Xs.transaction xs
+		(fun t ->
+			let exists = try ignore(t.Xst.read (xs.Xs.getdomainpath domid)); true with _ -> false in
+			if exists
+			then t.Xst.write path ""
+			else info "Not cancelling watches associated with domid: %d- domain nolonger exists" domid
+		)
 
 let with_path ~xs key f =
 	let path = cancel_path_of ~xs key in

--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -1580,9 +1580,6 @@ type info = {
 }
 
 
-(* Where qemu writes its state and is signalled *)
-let device_model_path ~qemu_domid domid = sprintf "/local/domain/%d/device-model/%d" qemu_domid domid
-
 let get_vnc_port ~xs domid =
 	if not (Qemu.is_running ~xs domid)
 	then None
@@ -1642,7 +1639,7 @@ let signal (task: Xenops_task.t) ~xs ~qemu_domid ~domid ?wait_for ?param cmd =
                 * way too long for our software to recover successfully.
                 * Talk to Citrix about this
                 *)
-		let cancel = Domain qemu_domid in
+		let cancel = Qemu (qemu_domid, domid) in
 		let (_: bool) = cancellable_watch cancel [ Watch.value_to_become pw state ] [] task ~xs ~timeout:30. () in
 		()
 	| None -> ()
@@ -1773,7 +1770,7 @@ let __start (task: Xenops_task.t) ~xs ~dmpath ?(timeout = !Xapi_globs.qemu_dm_re
 	begin
 		let finished = ref false in
 		let watch = Watch.value_to_appear dm_ready |> Watch.map (fun _ -> ()) in
-		let cancel = Domain domid in
+		let cancel = Qemu (qemu_domid, domid) in
 		let start = Unix.gettimeofday () in
 		while Unix.gettimeofday () -. start < timeout && not !finished do
 			Xenops_task.check_cancelling task;

--- a/ocaml/xenops/device_common.ml
+++ b/ocaml/xenops/device_common.ml
@@ -241,3 +241,6 @@ let protocol_of_string = function
 let qemu_save_path : (_, _, _) format = "/var/lib/xen/qemu-save.%d"
 let qemu_restore_path : (_, _, _) format = "/var/lib/xen/qemu-resume.%d"
 
+(* Where qemu writes its state and is signalled *)
+let device_model_path ~qemu_domid domid = sprintf "/local/domain/%d/device-model/%d" qemu_domid domid
+

--- a/ocaml/xenops/device_common.mli
+++ b/ocaml/xenops/device_common.mli
@@ -76,3 +76,6 @@ val protocol_of_string : string -> protocol
 
 val qemu_save_path: (int -> 'a, 'b, 'a) format
 val qemu_restore_path: (int -> 'a, 'b, 'a) format
+
+(** Directory in xenstore where qemu writes its state *)
+val device_model_path: qemu_domid:int -> int -> string


### PR DESCRIPTION
Rather than determining the path based solely on the domain containing
the qemu, use both the qemu domain and the guest domain id.

This avoids two concurrent suspend/resumes from cancelling each other
by accident (!)

Signed-off-by: David Scott dave.scott@eu.citrix.com

Tested by:
1. win7 suspend/resume/migrate/shutdown/start
2. cancelling a win7 resume -- the cancel did wake the guest up
3. quicktest
