### PR TITLE
CA-85032: disallow non-empty vif-maps in intra-pool (storage) migrations

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -545,7 +545,10 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 
 	match migration_type with
 	| `intra_pool host ->
-		if (not force) && live then Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host ()
+		if (not force) && live then Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host ();
+		if vif_map <> [] then
+			raise (Api_errors.Server_error(Api_errors.not_implemented, [
+				"VIF mapping is not supported for intra-pool migration"]))
 	| `cross_pool remote_rpc ->
 		(* Check that the VM has no more than one snapshot *)
 		let (snapshots_vbds, nb_snapshots) = get_snapshots_vbds ~__context ~vm in


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
