### PR TITLE
CA-86263: Revert patch for CA-85191.

### DIFF
--- a/ocaml/xenops/cancel_utils.ml
+++ b/ocaml/xenops/cancel_utils.ml
@@ -55,10 +55,9 @@ let cancel ~xs key =
 		xs.Xs.rm path
 	end
 
-let on_shutdown ~xs domid devices =
+let on_shutdown ~xs domid =
 	let path = domain_shutdown_path_of ~xs (Domain domid) in
-	let paths = List.map (fun d -> domain_shutdown_path_of ~xs (Device d)) devices in
-	List.iter (fun p -> xs.Xs.write p "") (path :: paths)
+	xs.Xs.write path ""
 
 let with_path ~xs key f =
 	let path = cancel_path_of ~xs key in

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -2089,8 +2089,7 @@ let watch_xenstore () =
 				(* Anyone blocked on a domain/device operation which won't happen because the domain
 				   just shutdown should be cancelled here. *)
 				debug "Cancelling watches for: domid %d" domid;
-				let devices = try IntMap.find domid !watches with Not_found -> [] in
-				Cancel_utils.on_shutdown ~xs domid devices in
+				Cancel_utils.on_shutdown ~xs domid in
 
 			let add_device_watch xs device =
 				let open Device_common in


### PR DESCRIPTION
The patch that's been reverted cancelled outstanding watches for devices
associated with a domain when the domain was destroyed. However, the watches
are for dom0 events which should not be dependent on the state of the
domU. In the case where the original problem was identified, the domU had
crashed and been left paused, leaving the devices up. The watches waiting
for the backends to go away timed out, which is actually not unreasonable
given that the backends still existed at that point.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
