### PR TITLE
CA-85940: use the creation time measured with a monotonic clock to judge...

### DIFF
--- a/ocaml/xenops/OMakefile
+++ b/ocaml/xenops/OMakefile
@@ -8,7 +8,7 @@ OCAML_LINK_FLAGS+= $(XEN_OCAML_LINK_FLAGS) # $(XENLIGHT_LINK_FLAGS)
 
 CFLAGS          += $(XEN_CFLAGS)
 
-OCAMLPACKS     = xml-light2 sexpr stunnel http-svr netdev rpc-light threads xenctrl xenstore xenctrlext xenstoreext stdext log cdrom netdev oUnit # xenlight
+OCAMLPACKS     = oclock xml-light2 sexpr stunnel http-svr netdev rpc-light threads xenctrl xenstore xenctrlext xenstoreext stdext log cdrom netdev oUnit # xenlight
 OCAMLFLAGS    += -thread
 
 UseCamlp4(rpc-light.syntax, device_number xenops_utils xenops_server xenops_server_simulator xenops_migrate xenops_server_xen updates xenops_server_plugin domain device device_common xenops_hooks task_server)

--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -177,6 +177,7 @@ let make ~xc ~xs vm_info uuid =
 		let rwperm = Xenbus_utils.rwperm_for_guest domid in
 		debug "VM = %s; creating xenstored tree: %s" (Uuid.to_string uuid) dom_path;
 
+		let create_time = Oclock.gettime Oclock.monotonic in
 		Xs.transaction xs (fun t ->
 			(* Clear any existing rubbish in xenstored *)
 			t.Xst.rm dom_path;
@@ -194,6 +195,7 @@ let make ~xc ~xs vm_info uuid =
 				];
 			end;
 			t.Xst.write (Printf.sprintf "%s/domains/%d" vm_path domid) dom_path;
+			t.Xst.write (Printf.sprintf "%s/domains/%d/create-time" vm_path domid) (Int64.to_string create_time);
 
 			t.Xst.rm vss_path;
 			t.Xst.mkdir vss_path;


### PR DESCRIPTION
... which domain is "newer" for a given UUID

The previous metric (whether a VM had clocked up CPU time or not)
would be confused if neither domain had started.

Signed-off-by: David Scott dave.scott@eu.citrix.com

Tested by:
1. manually starting, stopping VMs, checking the times look sensible
2. verifying by eye that domain 0 has a sensible value
3. quicktest: in particular this does localhost live migrates which stresses this code. I grepped the log to verify that it was always sorting the list into the correct order.
