### PR TITLE
CA-82051: Removing "Cancel" from the PBD.plug/unplug task's allowed_operations

### DIFF
--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -106,6 +106,7 @@ let check_sharing_constraint ~__context ~self =
 module C = Storage_interface.Client(struct let rpc = Storage_access.rpc end)
 
 let plug ~__context ~self =
+	TaskHelper.set_not_cancellable ~__context;
 	(* It's possible to end up with a PBD being plugged after "unbind" is
 	   called if SR.create races with a PBD.plug (see Storage_access.create_sr)
 	   Since "bind" is idempotent it is safe to always call it. *)
@@ -130,6 +131,7 @@ let plug ~__context ~self =
 			end
 
 let unplug ~__context ~self =
+	TaskHelper.set_not_cancellable ~__context;
 	let currently_attached = Db.PBD.get_currently_attached ~__context ~self in
 	if currently_attached then
 		begin


### PR DESCRIPTION
Cancel button flickrs between enabled/disabled state and doesn't do anything when pressed during SR reattach operation in XenCenter. Making PBD.plug/unplug tasks not cancellable.

Signed-off-by: Rabin Karki rabin.karki@citrix.com
