### PR TITLE
Fix to xe-edit-bootloader

### DIFF
--- a/scripts/xe-edit-bootloader
+++ b/scripts/xe-edit-bootloader
@@ -37,7 +37,7 @@ while getopts "hu:n:p:f:" opt ; do
     h) usage ;;
     u) vm_uuid=${OPTARG} ;;
     n) vm_name="${OPTARG}" ;;
-    p) device_number=${OPTARG} ;;
+    p) device_number=p${OPTARG} ;;
     f) default_file_list="${OPTARG}" ;;
     *) echo "Invalid option"; usage ;;
     esac


### PR DESCRIPTION
Old XCP use /dev/xvd\* devices when done vbd-plug to dom0.
xe-edit-bootloader adds parition number to it:

-p 0 -> /dev/xvda0, -p 1 -> /dev/xvda1, etc.

New SM backend scheme use kpartx to get partitions from devices like this:

/dev/sm/backend/b9b15e78-c79b-f9b7-4238-d36be14b8075/a5711219-c54f-4d14-ad1e-a0ac36d16232p1
/dev/sm/backend/b9b15e78-c79b-f9b7-4238-d36be14b8075/a5711219-c54f-4d14-ad1e-a0ac36d16232p2

This fix replace old dev+part_num scheme with new: dev+'p'+part_num scheme.

Note: Partition numbers are shifting (was: 0,1,2,3,4,5...; become: 1,2,3,4,5,6...)
