### PR TITLE
CA-86833: Cannot delete VM if RRD daemon is not running in DOM0

### DIFF
--- a/ocaml/rrdd/interface/rrdd_interface.ml
+++ b/ocaml/rrdd/interface/rrdd_interface.ml
@@ -31,7 +31,7 @@ external has_vm_rrd : vm_uuid:string -> bool = ""
 
 external push_rrd : vm_uuid:string -> domid:int -> is_on_localhost:bool ->
 	unit -> unit = ""
-external remove_rrd : uuid:string -> unit = ""
+external remove_rrd : uuid:string -> unit -> unit = ""
 external migrate_rrd : ?session_id:string -> remote_address:string ->
 	vm_uuid:string -> host_uuid:string -> unit -> unit = ""
 external send_host_rrd_to_master : unit -> unit = ""

--- a/ocaml/rrdd/rrdd_server.ml
+++ b/ocaml/rrdd/rrdd_server.ml
@@ -306,7 +306,7 @@ let push_rrd _ ~(vm_uuid : string) ~(domid : int) ~(is_on_localhost : bool) ()
 	with _ -> ()
 
 (** Remove an RRD from the local filesystem, if it exists. *)
-let remove_rrd _ ~(uuid : string) : unit =
+let remove_rrd _ ~(uuid : string) () : unit =
 	let path = Xapi_globs.xapi_rrd_location ^ "/" ^ uuid in
 	let gz_path = path ^ ".gz" in
 	(try Unix.unlink path with _ -> ());

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -437,7 +437,7 @@ let destroy  ~__context ~self =
 		(fun child -> try Db.VM.set_parent ~__context ~self:child ~value:parent with _ -> ())
 		(Db.VM.get_children ~__context ~self);
 
-	Rrdd.remove_rrd ~uuid:(Db.VM.get_uuid ~__context ~self);
+	log_and_ignore_exn (Rrdd.remove_rrd ~uuid:(Db.VM.get_uuid ~__context ~self));
 	destroy ~__context ~self
 
 (* Note: we don't need to call lock_vm around clone or copy. The lock_vm just takes the local


### PR DESCRIPTION
This patch puts a try-catch-log wrapper around the relevant call from xapi
to xcp-rrdd.

Signed-off-by: Rok Strniša rok.strnisa@citrix.com
