### PR TITLE
CA-80695: Remove setting of MTU in vif frontend area as Boston windows PV...

### DIFF
--- a/scripts/vif
+++ b/scripts/vif
@@ -64,7 +64,6 @@ handle_mtu()
     if [ $? -eq 0 -a -n "${mtu}" ]; then
         logger -t scripts-vif "Setting ${dev} MTU ${mtu}"
         ${IP} link set "${dev}" mtu ${mtu} || logger -t scripts-vif "Failed to ip link set ${dev} mtu ${mtu}. Error code $?"
-        xenstore-write "/local/domain/${DOMID}/device/vif/${DEVID}/mtu" "${mtu}"
     fi
 }
 


### PR DESCRIPTION
... drivers interpret it as maximum frame size.

The drivers will use their default in the absence of ths key, which is an _MTU_ of 1500 rather than a frame size.
