### PR TITLE
CA-87492: Add migrate_send to need_pv_drivers_check

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -136,7 +136,8 @@ let check_drivers ~__context ~vmr ~vmgmr ~op ~ref =
 	else None
 
 let need_pv_drivers_check ~__context ~vmr ~power_state ~op =
-	let op_list = [ `suspend; `checkpoint; `pool_migrate; `clean_shutdown; `clean_reboot; `changing_VCPUs_live ] in
+	let op_list = [ `suspend; `checkpoint; `pool_migrate; `migrate_send
+	              ; `clean_shutdown; `clean_reboot; `changing_VCPUs_live ] in
 	power_state = `Running
 	&& Helpers.has_booted_hvm_of_record ~__context vmr
 	&& List.mem op op_list


### PR DESCRIPTION
We didn't check for PV drivers for HVM guests, so we could migrate_send a guest
when we wouldn't have been able to pool_migrate it. We now do the same
allowed-operations checks for both migrate_send and pool_migrate.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
