### PR TITLE
CA-86764: SXM intra-pool shouldn't move unmapped VDIs

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -594,7 +594,7 @@ let pool_migrate ~__context ~vdi ~sr ~options =
 	Helpers.call_api_functions ~__context (fun rpc session_id -> 
 		let token = Client.Host.migrate_receive ~rpc ~session_id ~host:localhost ~network ~options in
 		let task = Client.Async.VM.migrate_send rpc session_id vm token true [ vdi, sr ] [] [] in
-		
+
 		ignore(Xapi_vm_clone.wait_for_subtask ~progress_minmax:(0.0,1.0) ~__context task)
 	) ;
 	Db.VBD.get_VDI ~__context ~self:vbd


### PR DESCRIPTION
On intra-pool SXM migrate, we shouldn't move unmapped VDIs, but should instead
leave them on their current SR. This was causing strange behavior on
VDI.pool_migrate, which would attempt to move single VDIs, but would find the
other VM's VDI(s) moving as well.

We should consider blocking a cross-pool migrate_send if the VDI map isn't
fully specified, instead of guessing and sending VDIs to the default SR. We'll
leave that for another commit.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
