### PR TITLE
CA-86568: Kill only the vncterm parent process

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -913,7 +913,7 @@ let stop ~xs domid =
 	match pid ~xs domid with
 		| Some pid ->
 			best_effort "killing vncterm"
-				(fun () -> Unix.kill (-pid) Sys.sigterm);
+				(fun () -> Unix.kill pid Sys.sigterm);
 			best_effort "removing vncterm-pid from xenstore"
 				(fun () -> xs.Xs.rm (vnc_pid_path domid))
 		| None -> ()


### PR DESCRIPTION
Do not kill the process group.

vncterm will now catch SIGTERM, pass it on to its child process,
wait for it to exit, clean up, and finally exit itself.
