### PR TITLE
CA-88290: SXM shouldn't attach RO disks as RW when mirroring

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -275,7 +275,7 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 					location,vdi,"none"
 				else begin
 					let newdp = Printf.sprintf "mirror_%s" dp in
-					ignore(SMAPI.VDI.attach ~dbg ~dp:newdp ~sr ~vdi:location ~read_write:true);
+					ignore(SMAPI.VDI.attach ~dbg ~dp:newdp ~sr ~vdi:location ~read_write:do_mirror);
 					SMAPI.VDI.activate ~dbg ~dp:newdp ~sr ~vdi:location;
 					new_dps := newdp :: !new_dps;
 


### PR DESCRIPTION
This is also true for snapshot VDIs. We now only attach RW if the VDI is going to be mirrored.

NOTE: This pull request only fixes the smaller issue of allowing RO VDIs, but not the larger issue of deciding what to do when a VDI is attached to multiple VMs. I think we should pull this commit now and worry about the bigger issue later.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
