### PR TITLE
CA-87277: Allow migration of a VM with one snapshot which has multiple VBDs.

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -456,6 +456,7 @@ let suspend_vdi_replacement_is_not_identical = "SUSPEND_VDI_REPLACEMENT_IS_NOT_I
 
 let vdi_needs_vm_for_migrate = "VDI_NEEDS_VM_FOR_MIGRATE"
 let vm_has_too_many_snapshots = "VM_HAS_TOO_MANY_SNAPSHOTS"
+let vm_has_checkpoint = "VM_HAS_CHECKPOINT"
 
 let mirror_failed = "MIRROR_FAILED"
 let too_many_storage_migrates = "TOO_MANY_STORAGE_MIGRATES"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -786,6 +786,8 @@ let _ =
     ~doc:"An error occurred during the migration process." ();
   error Api_errors.vm_has_too_many_snapshots [ "vm" ]
     ~doc:"You attempted to migrate a VM with more than one snapshot." ();
+  error Api_errors.vm_has_checkpoint [ "vm" ]
+    ~doc:"You attempted to migrate a VM which has a checkpoint." ();
   error Api_errors.vdi_needs_vm_for_migrate [ "vdi" ]
     ~doc:"You attempted to migrate a VDI which is not attached to a runnning VM." ();
   error Api_errors.mirror_failed [ "vdi" ]


### PR DESCRIPTION
Previously we were using the total number of VBDs connnected to all
snapshots to determine whether we could migrate a VM - now we just use
the number of snapshots.
