### PR TITLE
Re-add xapi API methods related to cooperativeness.

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -937,6 +937,10 @@ let vm_record rpc session_id vm =
 				~get:(fun () -> default nid (may (fun m -> string_of_bool m.API.vM_guest_metrics_live) (xgm ()) )) ();
 			make_field ~name:"guest-metrics-last-updated"
 				~get:(fun () -> default nid (may (fun m -> Date.to_string m.API.vM_guest_metrics_last_updated) (xgm ()) )) ();
+			make_field ~name:"cooperative"
+				(* NB this can receive VM_IS_SNAPSHOT *)
+				~get:(fun () -> string_of_bool (try Client.VM.get_cooperative rpc session_id vm with _ -> true))
+				~expensive:true ~deprecated:true ();
 			make_field ~name:"protection-policy"
 				~get:(fun () -> get_uuid_from_ref (x ()).API.vM_protection_policy)
 				~set:(fun x -> if x="" then Client.VM.set_protection_policy rpc session_id vm Ref.null else Client.VM.set_protection_policy rpc session_id vm (Client.VMPP.get_by_uuid rpc session_id x)) ();

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1744,6 +1744,18 @@ let vm_wait_memory_target_live = call
 		Ref _vm, "self", "The VM";
 	] ()
 
+let vm_get_cooperative = call
+	~name:"get_cooperative"
+	~in_product_since:rel_midnight_ride
+	~internal_deprecated_since:rel_tampa
+	~doc:"Return true if the VM is currently 'co-operative' i.e. is expected to reach a balloon target and actually has done"
+	~params:[
+		Ref _vm, "self", "The VM";
+	]
+	~result:(Bool, "true if the VM is currently 'co-operative'; false otherwise")
+	~allowed_roles:_R_READ_ONLY
+	()
+
 let vm_query_services = call
 	~name:"query_services"
 	~in_product_since:rel_tampa
@@ -2485,6 +2497,28 @@ let host_evacuate = call
   ~params:[Ref _host, "host", "The host to evacuate"]
   ~allowed_roles:_R_POOL_OP
   ()
+
+let host_get_uncooperative_resident_VMs = call
+	~in_product_since:rel_midnight_ride
+	~internal_deprecated_since:rel_tampa
+	~name:"get_uncooperative_resident_VMs"
+	~doc:"Return a set of VMs which are not co-operating with the host's memory control system"
+	~params:[Ref _host, "self", "The host to query"]
+	~result:((Set(Ref _vm)), "VMs which are not co-operating")
+	~allowed_roles:_R_READ_ONLY
+	()
+
+let host_get_uncooperative_domains = call
+	~in_product_since:rel_midnight_ride
+	~internal_deprecated_since:rel_tampa
+	~name:"get_uncooperative_domains"
+	~doc:"Return the set of domain uuids which are not co-operating with the host's memory control system"
+	~params:[Ref _host, "self", "The host to query"]
+	~result:((Set(String)), "UUIDs of domains which are not co-operating")
+	~pool_internal:true
+	~hide_from_docs:true
+	~allowed_roles:_R_LOCAL_ROOT_ONLY
+	()
 
 let host_retrieve_wlb_evacuate_recommendations = call
   ~name:"retrieve_wlb_evacuate_recommendations"
@@ -4071,6 +4105,8 @@ let host =
 		 host_forget_data_source_archives;
 		 host_assert_can_evacuate;
 		 host_get_vms_which_prevent_evacuation;
+		 host_get_uncooperative_resident_VMs;
+		 host_get_uncooperative_domains;
 		 host_evacuate;
 		 host_signal_networking_change;
 		 host_notify;
@@ -6480,7 +6516,7 @@ let vm_power_state =
 			    "Running", "Running";
 				"Suspended", "VM state has been saved to disk and it is nolonger running. Note that disks remain in-use while the VM is suspended."])
 
-let vm_operations = 
+let vm_operations =
   Enum ("vm_operations",
 	List.map operation_enum
 	  [ vm_snapshot; vm_clone; vm_copy; vm_create_template; vm_revert; vm_checkpoint; vm_snapshot_with_quiesce;
@@ -6538,6 +6574,7 @@ let vm =
 		vm_set_memory_limits;
 		vm_set_memory_target_live;
 		vm_wait_memory_target_live;
+		vm_get_cooperative;
 		vm_set_HVM_shadow_multiplier;
 		vm_set_shadow_multiplier_live;
 		vm_set_VCPUs_max;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1746,6 +1746,11 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					forward_vm_op ~local_fn ~__context ~vm:self
 						(fun session_id rpc -> Client.VM.wait_memory_target_live rpc session_id self))
 
+		(* Dummy implementation for a deprecated API method. *)
+		let get_cooperative ~__context ~self =
+			info "VM.get_cooperative: VM = '%s'" (vm_uuid ~__context self);
+			Local.VM.get_cooperative ~__context ~self
+
 		let set_HVM_shadow_multiplier ~__context ~self ~value =
 			info "VM.set_HVM_shadow_multiplier: self = %s; multiplier = %f"
 				(vm_uuid ~__context self) value;
@@ -2043,6 +2048,16 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			info "Host.emergency_ha_disable";
 			Local.Host.emergency_ha_disable ~__context
 
+		(* Dummy implementation for a deprecated API method. *)
+		let get_uncooperative_resident_VMs ~__context ~self =
+			info "Host.get_uncooperative_resident_VMs host=%s" (Ref.string_of self);
+			Local.Host.get_uncooperative_resident_VMs ~__context ~self
+
+		(* Dummy implementation for a deprecated API method. *)
+		let get_uncooperative_domains ~__context ~self =
+			info "Host.get_uncooperative_domains host=%s" (Ref.string_of self);
+			Local.Host.get_uncooperative_domains ~__context ~self
+
 		let management_reconfigure ~__context ~pif =
 			info "Host.management_reconfigure: management PIF = '%s'" (pif_uuid ~__context pif);
 			(* The management interface on the slave may change during this operation, so expect connection loss.
@@ -2059,7 +2074,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			info "Host.management_disable";
 			Local.Host.management_disable ~__context
 
-		let get_management_interface ~__context ~host = 
+		let get_management_interface ~__context ~host =
 			info "Host.get_management_interface: host = '%s'" (host_uuid ~__context host);
 			Local.Host.get_management_interface ~__context ~host
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -939,6 +939,12 @@ let disable_binary_storage ~__context ~host =
   Db.Host.remove_from_other_config ~__context ~self:host ~key:Xapi_globs.host_no_local_storage;
   Db.Host.add_to_other_config ~__context ~self:host ~key:Xapi_globs.host_no_local_storage ~value:"true"
 
+(* Dummy implementation for a deprecated API method. *)
+let get_uncooperative_resident_VMs ~__context ~self = []
+
+(* Dummy implementation for a deprecated API method. *)
+let get_uncooperative_domains ~__context ~self = []
+
 let certificate_install ~__context ~host ~name ~cert =
   Certificates.host_install true name cert
 

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -168,6 +168,8 @@ val enable_binary_storage :
   __context:Context.t -> host:[ `host ] Ref.t -> unit
 val disable_binary_storage :
   __context:Context.t -> host:[ `host ] Ref.t -> unit
+val get_uncooperative_resident_VMs : __context:Context.t -> self:[`host] Ref.t -> API.ref_VM_set
+val get_uncooperative_domains : __context:Context.t -> self:[`host] Ref.t -> string list
 val certificate_install :
   __context:'a -> host:'b -> name:string -> cert:string -> unit
 val certificate_uninstall : __context:'a -> host:'b -> name:string -> unit

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -648,6 +648,9 @@ let wait_memory_target_live ~__context ~self =
 	in
 	wait 0
 
+(* Dummy implementation for a deprecated API method. *)
+let get_cooperative ~__context ~self = true
+
 let set_HVM_shadow_multiplier ~__context ~self ~value =
 	set_HVM_shadow_multiplier ~__context ~self ~value
 

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -178,6 +178,7 @@ val set_memory_dynamic_range :
 val set_memory_target_live :
   __context:'a -> self:API.ref_VM -> target:'b -> unit
 val wait_memory_target_live : __context:Context.t -> self:API.ref_VM -> unit
+val get_cooperative : __context:Context.t -> self:[ `VM ] Ref.t -> bool
 val set_HVM_shadow_multiplier :
   __context:Context.t -> self:[ `VM ] Ref.t -> value:float -> unit
 val set_shadow_multiplier_live :

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -76,7 +76,7 @@ let allowed_power_states ~__context ~vmr ~(op:API.vm_operations) =
 	| `hard_shutdown
 	                                -> [`Paused; `Suspended; `Running]
 	| `assert_operation_valid
-	| `metadata_export 
+	| `metadata_export
 	| `power_state_reset
 	| `revert
 	| `reverting


### PR DESCRIPTION
This is done in order to prevent breaking compatibility. The implementations
are dummy, and are marked as such. The API methods are marked as deprecated.

Signed-off-by: Rok Strniša rok.strnisa@citrix.com

p.s.: The API methods were removed in xen-org/xen-api@81e3f66308304e0f490a85417a5c5da746b16179.
