### PR TITLE
CP-3712: Set default rebalance-interval for balance-slb bonds to 30 minu...

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -138,7 +138,8 @@ let create_bond ~__context bond mtu =
 				"downdelay", "200";
 				"updelay", "31000";
 				"use_carrier", "1";
-				"hashing-algorithm", hashing_algorithm
+				"hashing-algorithm", hashing_algorithm;
+				"rebalance-interval", "1800000";
 			] in
 			let overrides = List.filter_map (fun (k, v) ->
 				if String.startswith "bond-" k then


### PR DESCRIPTION
...tes

This would alleviate problems in (non-stacked) physical switches, due to rapid
movement of MAC addresses between links.

We do this only on ovs, because the linux bond mode does not support
changing the rebalance-interval (it is fixed at 10s).

It is (still) possible to override this by setting
PIF.other_config:bond-rebalance-interval (in ms), followed by a PIF.plug.

Tested in both the ovs and Linux bridge mode by creating and destroying
a bond, and inspecting the rebalance interval in the ovs case (ovs-vsctl
list port).

Signed-off-by: Rob Hoes rob.hoes@citrix.com
