### PR TITLE
CA-88290: VDI.attach for SXM mirroring should be read only.

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -281,7 +281,7 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 					location,vdi,"none"
 				else begin
 					let newdp = Printf.sprintf "mirror_%s" dp in
-					ignore(SMAPI.VDI.attach ~dbg ~dp:newdp ~sr ~vdi:location ~read_write:true);
+					ignore(SMAPI.VDI.attach ~dbg ~dp:newdp ~sr ~vdi:location ~read_write:false);
 					SMAPI.VDI.activate ~dbg ~dp:newdp ~sr ~vdi:location;
 					new_dps := newdp :: !new_dps;
 


### PR DESCRIPTION
This allows us to attach RO discs for mirroring - attaching them RW will
fail.

Even if the disk is already attached RW, we only need a RO attach for
mirroring.
