### PR TITLE
CA-87552: add "Network.other_config:assume_network_is_shared=true" to ov...

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -157,6 +157,10 @@ let is_guest_installer_network = "is_guest_installer_network"
 
 let is_host_internal_management_network = "is_host_internal_management_network"
 
+(* Used to override the check which blocks VM start or migration if a VIF is on an internal
+   network which is pinned to a particular host. *)
+let assume_network_is_shared = "assume_network_is_shared"
+
 let auto_scan = "auto-scan" (* if set in SR.other_config, scan the SR in the background *)
 let auto_scan_interval = "auto-scan-interval" (* maybe set in Host.other_config *)
 


### PR DESCRIPTION
...erride internal network checks

Normally we block VM.start, migrate etc if a VIF is on an "internal"
network which is already in use on another host. In the longer term we
should just tunnel, but in the short term we allow clients to specify
whether they want to allow the operations instead, per Network.

Signed-off-by: David Scott dave.scott@eu.citrix.com

Tested by:
1. installing two VMs both using an internal network without the flag, starting both on the same host and attempting to migrate one to a new host -- it failed as expected (default behaviour is unchanged)
2. setting the flag on the network and retrying the migration -- it worked as expected (new behaviour)
