### PR TITLE
CP-3657: Update alert priorities

### DIFF
--- a/ocaml/idl/api_messages.ml
+++ b/ocaml/idl/api_messages.ml
@@ -11,93 +11,94 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+
+(*
+Priority Name                  Description
+-------- --------------------- -----------------------------------------------------------------------------
+1        Data-loss imminent    Take action now or your data may be permanently lost (e.g. corrupted)
+2        Service-loss imminent Take action now or some service(s) may fail (e.g. host / VM crash)
+3        Service degraded      Take action now or some service may suffer (e.g. NIC bond degraded without HA)
+4        Service recovered     Notice that something just improved (e.g. NIC bond repaired)
+5        Informational         More day-to-day stuff (e.g. VM started, suspended, shutdown, rebooted etc)
+*)
+
 let msgList = ref []
 
-let addMessage x =
-	let _ = msgList := x::!msgList in
-	x
+let addMsg name priority =
+    let msg = (name, priority) in
+    let _ = msgList := msg :: !msgList in
+    msg
 
-let license_does_not_support_pooling = addMessage "LICENSE_DOES_NOT_SUPPORT_POOLING"
-(* Fired by license-check.py *)
-let license_expires_soon = addMessage "LICENSE_EXPIRES_SOON"
+let license_does_not_support_pooling = addMsg "LICENSE_DOES_NOT_SUPPORT_POOLING" 2L (* Unused? *)
+let license_expires_soon = addMsg "LICENSE_EXPIRES_SOON" 2L (* Used by license-check.py, which may be unused? *)
 
-let ha_statefile_lost = addMessage "HA_STATEFILE_LOST"
-let ha_statefile_lost_priority = 10L
+let ha_statefile_lost = addMsg "HA_STATEFILE_LOST" 2L
 
-let ha_heartbeat_approaching_timeout = addMessage "HA_HEARTBEAT_APPROACHING_TIMEOUT"
-let ha_statefile_approaching_timeout = addMessage "HA_STATEFILE_APPROACHING_TIMEOUT"
-let ha_xapi_healthcheck_approaching_timeout = addMessage "HA_XAPI_HEALTHCHECK_APPROACHING_TIMEOUT"
+let ha_heartbeat_approaching_timeout = addMsg "HA_HEARTBEAT_APPROACHING_TIMEOUT" 5L
+let ha_statefile_approaching_timeout = addMsg "HA_STATEFILE_APPROACHING_TIMEOUT" 5L
+let ha_xapi_healthcheck_approaching_timeout = addMsg "HA_XAPI_HEALTHCHECK_APPROACHING_TIMEOUT" 5L (* Previously missing from table *)
 
-let ha_network_bonding_error = addMessage "HA_NETWORK_BONDING_ERROR"
-let ha_network_bonding_error_priority = 10L
+let ha_network_bonding_error = addMsg "HA_NETWORK_BONDING_ERROR" 3L
 
-let ha_pool_overcommitted = addMessage "HA_POOL_OVERCOMMITTED"
-let ha_pool_overcommitted_priority = 1L (* GUI maximizes ntol, which means this is often subsumed by DROP_IN_PLAN_EXISTS_FOR; hence low priority *)
+let ha_pool_overcommitted = addMsg "HA_POOL_OVERCOMMITTED" 3L (* GUI maximizes ntol, which means this is often subsumed by DROP_IN_PLAN_EXISTS_FOR; hence low priority *)
 
-let ha_pool_drop_in_plan_exists_for = addMessage "HA_POOL_DROP_IN_PLAN_EXISTS_FOR"
-let ha_protected_vm_restart_failed = addMessage "HA_PROTECTED_VM_RESTART_FAILED"
+let ha_pool_drop_in_plan_exists_for = addMsg "HA_POOL_DROP_IN_PLAN_EXISTS_FOR" 3L
+let ha_protected_vm_restart_failed = addMsg "HA_PROTECTED_VM_RESTART_FAILED" 2L
 
-let ha_host_failed = addMessage "HA_HOST_FAILED"
-let ha_host_failed_priority = 10L
+let ha_host_failed = addMsg "HA_HOST_FAILED" 3L
 
-let ha_host_was_fenced = addMessage "HA_HOST_WAS_FENCED"
+let ha_host_was_fenced = addMsg "HA_HOST_WAS_FENCED" 4L
 
-let redo_log_healthy = addMessage "METADATA_LUN_HEALTHY"
-let redo_log_broken = addMessage "METADATA_LUN_BROKEN"
+let redo_log_healthy = addMsg "METADATA_LUN_HEALTHY" 4L
+let redo_log_broken = addMsg "METADATA_LUN_BROKEN" 3L
 
-let ip_configured_pif_can_unplug = addMessage "IP_CONFIGURED_PIF_CAN_UNPLUG"
+let ip_configured_pif_can_unplug = addMsg "IP_CONFIGURED_PIF_CAN_UNPLUG" 3L
 
-let vif_qos_failed = addMessage "VIF_QOS_FAILED"
-let vbd_qos_failed = addMessage "VBD_QOS_FAILED"
-let vcpu_qos_failed = addMessage "VCPU_QOS_FAILED"
+let vif_qos_failed = addMsg "VIF_QOS_FAILED" 3L (* Only used by idl/datamodel.ml *)
+let vbd_qos_failed = addMsg "VBD_QOS_FAILED" 3L (* Only used by idl/datamodel.ml *)
+let vcpu_qos_failed = addMsg "VCPU_QOS_FAILED" 3L (* Only used by idl/datamodel.ml *)
 
-let vm_started = addMessage "VM_STARTED"
-let vm_shutdown = addMessage "VM_SHUTDOWN"
-let vm_rebooted = addMessage "VM_REBOOTED"
-let vm_suspended = addMessage "VM_SUSPENDED"
-let vm_resumed = addMessage "VM_RESUMED"
-let vm_crashed = addMessage "VM_CRASHED"
-let vm_cloned = addMessage "VM_CLONED"
-let host_sync_data_failed = addMessage "HOST_SYNC_DATA_FAILED" (* Kept for backward compatibility. *)
-let host_clock_skew_detected = addMessage "HOST_CLOCK_SKEW_DETECTED"
-let host_clock_skew_detected_priority = 10L
-let host_clock_went_backwards = addMessage "HOST_CLOCK_WENT_BACKWARDS"
-let host_clock_went_backwards_priority = 10L
+let vm_started = addMsg "VM_STARTED" 5L (* Previously missing from table *)
+let vm_shutdown = addMsg "VM_SHUTDOWN" 3L (* Previously missing from table *)
+let vm_rebooted = addMsg "VM_REBOOTED" 3L (* Previously missing from table *)
+let vm_suspended = addMsg "VM_SUSPENDED" 5L (* Previously missing from table *)
+let vm_resumed = addMsg "VM_RESUMED" 5L (* Previously missing from table *)
+let vm_crashed = addMsg "VM_CRASHED" 3L (* Previously missing from table; unused? *)
+let vm_cloned = addMsg "VM_CLONED" 5L (* Prviously missing from table *)
 
-let pool_master_transition = addMessage "POOL_MASTER_TRANSITION"
+let host_clock_skew_detected = addMsg "HOST_CLOCK_SKEW_DETECTED" 3L
+let host_clock_went_backwards = addMsg "HOST_CLOCK_WENT_BACKWARDS" 1L (* Unused? *)
 
-let pbd_plug_failed_on_server_start = addMessage "PBD_PLUG_FAILED_ON_SERVER_START"
+let pool_master_transition = addMsg "POOL_MASTER_TRANSITION" 4L
 
-let alarm = addMessage "ALARM"
+let pbd_plug_failed_on_server_start = addMsg "PBD_PLUG_FAILED_ON_SERVER_START" 3L
 
-let wlb_failed = addMessage "WLB_CONSULTATION_FAILED"
-let wlb_optimization_alert = addMessage "WLB_OPTIMIZATION_ALERT"
+let alarm = addMsg "ALARM" 1L (* Previously missing from table; unused? *)
 
-let auth_external_init_failed = addMessage "EXTAUTH_INIT_IN_HOST_FAILED"
-let auth_external_pool_non_homogeneous = addMessage "EXTAUTH_IN_POOL_IS_NON_HOMOGENEOUS"
+let wlb_failed = addMsg "WLB_CONSULTATION_FAILED" 3L
 
-let multipath_periodic_alert = addMessage "MULTIPATH_PERIODIC_ALERT"
+let auth_external_init_failed = addMsg "EXTAUTH_INIT_IN_HOST_FAILED" 2L
+let auth_external_pool_non_homogeneous = addMsg "EXTAUTH_IN_POOL_IS_NON_HOMOGENEOUS" 2L
 
-let v6_server_up = addMessage "LICENSE_SERVER_CONNECTED"
-let v6_server_down = addMessage "LICENSE_SERVER_UNAVAILABLE"
-let v6_license_expired = addMessage "LICENSE_EXPIRED"
-let v6_grace_license = addMessage "GRACE_LICENSE"
-let v6_rejected = addMessage "LICENSE_NOT_AVAILABLE"
-let v6_comm_error = addMessage "LICENSE_SERVER_UNREACHABLE"
+let multipath_periodic_alert = addMsg "MULTIPATH_PERIODIC_ALERT" 3L
+
+let v6_grace_license = addMsg "GRACE_LICENSE" 3L
+let v6_rejected = addMsg "LICENSE_NOT_AVAILABLE" 2L
+let v6_comm_error = addMsg "LICENSE_SERVER_UNREACHABLE" 2L
 
 (* VMPP message types *)
-let vmpp_backup_lock_failed = addMessage "VMPP_SNAPSHOT_LOCK_FAILED" (*'The snapshot phase is already executing for this protection policy. Please try again later'*)
-let vmpp_backup_succeeded = addMessage "VMPP_SNAPSHOT_SUCCEEDED" (*'Successfully performed the snapshot phase of the protection policy'*)
-let vmpp_archive_lock_failed = addMessage "VMPP_ARCHIVE_LOCK_FAILED" (*'The archive sub-policy is already executing for some protection policy in the pool.Please try again later'*)
-let vmpp_archive_failed_0 = addMessage "VMPP_ARCHIVE_FAILED_0" (*'The archive phase failed for this protection policy'*)
-let vmpp_archive_suceeded = addMessage "VMPP_ARCHIVE_SUCCEEDED" (*'Successfully performed the archive phase of the protection policy'*)
-let vmpp_archive_target_mount_failed = addMessage "VMPP_ARCHIVE_TARGET_MOUNT_FAILED" (*'Failed to mount the archive target. Please check the archive target configuration settings'*)
-let vmpp_archive_target_unmount_failed = addMessage "VMPP_ARCHIVE_TARGET_UNMOUNT_FAILED" (*'Failed to unmount the archive target. Please make sure than the local directory was mounted successfully and has no open handles'*)
-let vmpp_license_error = addMessage "VMPP_LICENSE_ERROR" (*'This operation is not allowed under your license.  Please contact your support representative'*)
-let vmpp_xapi_logon_failure = addMessage "VMPP_XAPI_LOGON_FAILURE" (*'Could not login to API session.'*)
-let vmpp_backup_missed_event = addMessage "VMPP_SNAPSHOT_MISSED_EVENT" (*'A scheduled snapshot event was missed due to another on-going scheduled snapshot run. This is unexpected behaviour, please re-configure your snapshot sub-policy',*)
-let vmpp_archive_missed_event = addMessage "VMPP_ARCHIVE_MISSED_EVENT" (*'A scheduled archive event was missed due to another on-going scheduled archive run. This is unexpected behaviour, please re-configure your archive sub-policy'*)
-let vmpp_backup_failed = addMessage "VMPP_SNAPSHOT_FAILED" (*'The snapshot phase of the protection policy failed.'*)
-let vmpp_snapshot_archive_already_exists = addMessage "VMPP_SNAPSHOT_ARCHIVE_ALREADY_EXISTS" (*'Failed to archive the snapshot, it has already been archived on the specified target'*)
+let vmpp_snapshot_lock_failed = addMsg "VMPP_SNAPSHOT_LOCK_FAILED" 3L (*'The snapshot phase is already executing for this protection policy. Please try again later'*)
+let vmpp_snapshot_succeeded = addMsg "VMPP_SNAPSHOT_SUCCEEDED" 5L (*'Successfully performed the snapshot phase of the protection policy'*)
+let vmpp_snapshot_failed = addMsg "VMPP_SNAPSHOT_FAILED" 3L (*'The snapshot phase of the protection policy failed.'*)
+let vmpp_archive_lock_failed = addMsg "VMPP_ARCHIVE_LOCK_FAILED" 3L (*'The archive sub-policy is already executing for some protection policy in the pool.Please try again later'*)
+let vmpp_archive_failed_0 = addMsg "VMPP_ARCHIVE_FAILED_0" 3L (*'The archive phase failed for this protection policy'*)
+let vmpp_archive_suceeded = addMsg "VMPP_ARCHIVE_SUCCEEDED" 5L (*'Successfully performed the archive phase of the protection policy'*)
+let vmpp_archive_target_mount_failed = addMsg "VMPP_ARCHIVE_TARGET_MOUNT_FAILED" 3L (*'Failed to mount the archive target. Please check the archive target configuration settings'*)
+let vmpp_archive_target_unmount_failed = addMsg "VMPP_ARCHIVE_TARGET_UNMOUNT_FAILED" 3L (*'Failed to unmount the archive target. Please make sure than the local directory was mounted successfully and has no open handles'*)
+let vmpp_license_error = addMsg "VMPP_LICENSE_ERROR" 3L (*'This operation is not allowed under your license.  Please contact your support representative'*)
+let vmpp_xapi_logon_failure = addMsg "VMPP_XAPI_LOGON_FAILURE" 3L (*'Could not login to API session.'*)
+let vmpp_snapshot_missed_event = addMsg "VMPP_SNAPSHOT_MISSED_EVENT" 3L (*'A scheduled snapshot event was missed due to another on-going scheduled snapshot run. This is unexpected behaviour, please re-configure your snapshot sub-policy',*)
+let vmpp_archive_missed_event = addMsg "VMPP_ARCHIVE_MISSED_EVENT" 3L (*'A scheduled archive event was missed due to another on-going scheduled archive run. This is unexpected behaviour, please re-configure your archive sub-policy'*)
+let vmpp_snapshot_archive_already_exists = addMsg "VMPP_SNAPSHOT_ARCHIVE_ALREADY_EXISTS" 3L (*'Failed to archive the snapshot, it has already been archived on the specified target'*)
 
-let bond_status_changed = addMessage "BOND_STATUS_CHANGED" (* A link in a bond went down or came back up *)
+let bond_status_changed = addMsg "BOND_STATUS_CHANGED" 3L (* A link in a bond went down or came back up *) (* Previously missing from table *)

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1135,18 +1135,18 @@ let _ =
 
 
 let _ =
-  message Api_messages.ha_pool_overcommitted ~doc:"Pool has become overcommitted: it can nolonger guarantee to restart protected VMs if the configured number of hosts fail." ();
-  message Api_messages.ha_statefile_lost ~doc:"Host lost access to HA storage heartbeat" ();
-  message Api_messages.ha_heartbeat_approaching_timeout ~doc:"HA network heartbeat almost timed-out" ();
-  message Api_messages.ha_statefile_approaching_timeout ~doc:"HA storage heartbeat almost timed-out" ();
-  message Api_messages.ha_xapi_healthcheck_approaching_timeout ~doc:"HA xapi healthcheck almost timed-out" ();
-  message Api_messages.ha_network_bonding_error ~doc:"HA network heartbeat interface bonding error" ();
-  message Api_messages.vif_qos_failed ~doc:"Applying QoS to VIF failed." ();
-  message Api_messages.vbd_qos_failed ~doc:"Applying QoS to VBD failed." ();
-  message Api_messages.vcpu_qos_failed ~doc:"Applying QoS to VCPU failed." ();
-  message Api_messages.pool_master_transition ~doc:"Host has become the new Pool master." ();
-  message Api_messages.pbd_plug_failed_on_server_start ~doc:"Host failed to attach one or more Storage Repositories." ();
-  ()
+    message (fst Api_messages.ha_pool_overcommitted) ~doc:"Pool has become overcommitted: it can no longer guarantee to restart protected VMs if the configured number of hosts fail." ();
+    message (fst Api_messages.ha_statefile_lost) ~doc:"Host lost access to HA storage heartbeat" ();
+    message (fst Api_messages.ha_heartbeat_approaching_timeout) ~doc:"HA network heartbeat almost timed-out" ();
+    message (fst Api_messages.ha_statefile_approaching_timeout) ~doc:"HA storage heartbeat almost timed-out" ();
+    message (fst Api_messages.ha_xapi_healthcheck_approaching_timeout) ~doc:"HA xapi healthcheck almost timed-out" ();
+    message (fst Api_messages.ha_network_bonding_error) ~doc:"HA network heartbeat interface bonding error" ();
+    message (fst Api_messages.vif_qos_failed) ~doc:"Applying QoS to VIF failed." ();
+    message (fst Api_messages.vbd_qos_failed) ~doc:"Applying QoS to VBD failed." ();
+    message (fst Api_messages.vcpu_qos_failed) ~doc:"Applying QoS to VCPU failed." ();
+    message (fst Api_messages.pool_master_transition) ~doc:"Host has become the new Pool master." ();
+    message (fst Api_messages.pbd_plug_failed_on_server_start) ~doc:"Host failed to attach one or more Storage Repositories." ();
+    ()
 
 (* ------------------------------------------------------------------------------------------------------------
    Session Management

--- a/ocaml/mpathalert/mpathalert.ml
+++ b/ocaml/mpathalert/mpathalert.ml
@@ -267,7 +267,8 @@ let sender rpc session (delay, msg, queue) =
 			end);
 
 		if Buffer.length msg <> 0 then begin
-			let (_:API.ref_message) = Client.Message.create rpc session Api_messages.multipath_periodic_alert 5L `Pool pool_uuid (Buffer.contents msg) in
+			let (name, priority) = Api_messages.multipath_periodic_alert in
+			let (_:API.ref_message) = Client.Message.create rpc session name priority `Pool pool_uuid (Buffer.contents msg) in
 			remember_broken_history state_of_the_world;
 			Buffer.clear msg;
 		end;

--- a/ocaml/multipathrt/alert_utils.ml
+++ b/ocaml/multipathrt/alert_utils.ml
@@ -147,7 +147,7 @@ let wait_for_alert rpc session ?(delay=180.0) check_message f =
       raise (Multipathrt_exceptions.Test_error (Printf.sprintf "received unexpected exception: %s" (Printexc.to_string e)))
 
 let wait_for_alert_saying_all_is_well rpc session scsi_id max_paths =
-  wait_for_alert rpc session (fun msg -> msg.API.message_name = Api_messages.multipath_periodic_alert) (fun msg ->
+  wait_for_alert rpc session (fun msg -> msg.API.message_name = fst Api_messages.multipath_periodic_alert) (fun msg ->
     (* Check there's no unhealthy entry for this path *)
     let body = parse_alert_body msg.API.message_body in
     begin
@@ -169,7 +169,7 @@ let wait_for_alert_saying_all_is_well rpc session scsi_id max_paths =
   )
 
 let wait_for_alert_saying_we_flapped rpc session scsi_id max_paths =
-  wait_for_alert rpc session (fun msg -> msg.API.message_name = Api_messages.multipath_periodic_alert) (fun msg ->
+  wait_for_alert rpc session (fun msg -> msg.API.message_name = fst Api_messages.multipath_periodic_alert) (fun msg ->
     (* Check there's no unhealthy entry for this path *)
     let body = parse_alert_body msg.API.message_body in
     begin
@@ -195,7 +195,7 @@ let wait_for_alert_saying_we_flapped rpc session scsi_id max_paths =
 
 let wait_for_alert_saying_path_is_unhealthy rpc session scsi_id max_paths =
   wait_for_alert rpc session (fun msg ->
-    msg.API.message_name = Api_messages.multipath_periodic_alert && begin
+    msg.API.message_name = fst Api_messages.multipath_periodic_alert && begin
       let body = parse_alert_body msg.API.message_body in
       let unhealthy_entries = get_entries_concerning_scsiid body.unhealthy scsi_id in
       match unhealthy_entries with

--- a/ocaml/network/network_monitor_thread.ml
+++ b/ocaml/network/network_monitor_thread.ml
@@ -47,9 +47,9 @@ let send_bond_change_alert dev interfaces message =
 			let obj_uuid = Util_inventory.lookup Util_inventory._installation_uuid in
 			let body = Printf.sprintf	"The status of the %s bond %s" ifaces message in
 			try
+				let (name, priority) = Api_messages.bond_status_changed in
 				let (_: 'a Ref.t) = XenAPI.Message.create ~rpc:xapi_rpc ~session_id
-					~name:Api_messages.bond_status_changed ~priority:1L ~cls:`Host
-					~obj_uuid ~body in ()
+					~name ~priority ~cls:`Host ~obj_uuid ~body in ()
 			with _ ->
 				warn "Exception sending a bond-status-change alert."
 		)

--- a/ocaml/xapi/create_storage.ml
+++ b/ocaml/xapi/create_storage.ml
@@ -110,7 +110,7 @@ let create_storage (me: API.ref_host) rpc session_id __context : unit =
   let all_pbds_ok = plug_all_pbds __context rpc session_id in
   if not(all_pbds_ok) then begin
     let obj_uuid = Helpers.get_localhost_uuid () in
-    Xapi_alert.add ~name:Api_messages.pbd_plug_failed_on_server_start ~priority:1L ~cls:`Host ~obj_uuid ~body:"";
+    Xapi_alert.add ~msg:Api_messages.pbd_plug_failed_on_server_start ~cls:`Host ~obj_uuid ~body:"";
   end;
   Xapi_host_helpers.consider_enabling_host ~__context
       

--- a/ocaml/xapi/db_gc.ml
+++ b/ocaml/xapi/db_gc.ml
@@ -149,7 +149,7 @@ let detect_clock_skew ~__context host skew =
     let host_name_label = Db.Host.get_name_label ~__context ~self:host in
     let pool = Helpers.get_pool ~__context in
     let pool_name_label = Db.Pool.get_name_label ~__context ~self:pool in
-    Xapi_alert.add ~name:Api_messages.host_clock_skew_detected ~priority:Api_messages.host_clock_skew_detected_priority ~cls:`Host ~obj_uuid
+    Xapi_alert.add ~msg:Api_messages.host_clock_skew_detected ~cls:`Host ~obj_uuid
       ~body:(Printf.sprintf "The clock on server '%s' may not be synchronized with the other servers in pool '%s'. This could lead to errors when performing VM lifecycle operations, and will also affect the times recorded against archived performance data gathered from this server." host_name_label pool_name_label)
   end;
   (* If we are under half the max skew then re-arm the message sender *)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1193,11 +1193,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					(Db.Host.get_name_label ~__context ~self:host)
 					(Db.Host.get_uuid ~__context ~self:host)
 			in
+			let (name, priority) = Api_messages.vm_started in
 			(try ignore
 				(Xapi_message.create
 					~__context
-					~name:Api_messages.vm_started
-					~priority:1L
+					~name
+					~priority
 					~cls:`VM
 					~obj_uuid:uuid
 					~body:message_body)
@@ -1243,11 +1244,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					(Db.VM.get_name_label ~__context ~self:vm)
 					(Db.Host.get_name_label ~__context ~self:host)
 					(Db.Host.get_uuid ~__context ~self:host) in
+			let (name, priority) = Api_messages.vm_started in
 			(try ignore
 				(Xapi_message.create
 					~__context
-					~name:Api_messages.vm_started
-					~priority:1L
+					~name
+					~priority
 					~cls:`VM
 					~obj_uuid:(Db.VM.get_uuid ~__context ~self:vm)
 					~body:message_body)
@@ -1291,8 +1293,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				Printf.sprintf "VM '%s' shutdown"
 					(Db.VM.get_name_label ~__context ~self:vm)
 			in
-			(try ignore(Xapi_message.create ~__context ~name:Api_messages.vm_shutdown
-				~priority:1L ~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
+			let (name, priority) = Api_messages.vm_shutdown in
+			(try ignore(Xapi_message.create ~__context ~name ~priority
+				~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
 			update_vbd_operations ~__context ~vm;
 			update_vif_operations ~__context ~vm
 
@@ -1316,8 +1319,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				Printf.sprintf "VM '%s' rebooted cleanly"
 					(Db.VM.get_name_label ~__context ~self:vm)
 			in
-			(try ignore(Xapi_message.create ~__context ~name:Api_messages.vm_rebooted
-				~priority:1L ~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
+			let (name, priority) = Api_messages.vm_rebooted in
+			(try ignore(Xapi_message.create ~__context ~name ~priority
+				~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
 			update_vbd_operations ~__context ~vm;
 			update_vif_operations ~__context ~vm
 
@@ -1364,8 +1368,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				Printf.sprintf "VM '%s' shutdown forcibly"
 					(Db.VM.get_name_label ~__context ~self:vm)
 			in
-			(try ignore(Xapi_message.create ~__context ~name:Api_messages.vm_shutdown
-				~priority:1L ~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
+			let (name, priority) = Api_messages.vm_shutdown in
+			(try ignore(Xapi_message.create ~__context ~name ~priority
+				~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
 			update_vbd_operations ~__context ~vm;
 			update_vif_operations ~__context ~vm
 
@@ -1387,8 +1392,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				Printf.sprintf "VM '%s' rebooted forcibly"
 					(Db.VM.get_name_label ~__context ~self:vm)
 			in
-			(try ignore(Xapi_message.create ~__context ~name:Api_messages.vm_rebooted
-				~priority:1L ~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
+			let (name, priority) = Api_messages.vm_rebooted in
+			(try ignore(Xapi_message.create ~__context ~name ~priority
+				~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
 			update_vbd_operations ~__context ~vm;
 			update_vif_operations ~__context ~vm
 
@@ -1419,8 +1425,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				Printf.sprintf "VM '%s' suspended"
 					(Db.VM.get_name_label ~__context ~self:vm)
 			in
-			(try ignore(Xapi_message.create ~__context ~name:Api_messages.vm_suspended
-				~priority:1L ~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
+			let (name, priority) = Api_messages.vm_suspended in
+			(try ignore(Xapi_message.create ~__context ~name ~priority
+				~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
 			update_vbd_operations ~__context ~vm;
 			update_vif_operations ~__context ~vm
 
@@ -1479,8 +1486,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					(Db.VM.get_name_label ~__context ~self:vm)
 					(Db.VM.get_uuid ~__context ~self:result)
 			in
-			(try ignore(Xapi_message.create ~__context ~name:Api_messages.vm_cloned
-				~priority:1L ~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
+			let (name, priority) = Api_messages.vm_cloned in
+			(try ignore(Xapi_message.create ~__context ~name ~priority
+				~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
 			result
 
 		(* Like start.. resume on any suitable host *)
@@ -1509,8 +1517,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					(Db.Host.get_name_label ~__context ~self:host)
 					(Db.Host.get_uuid ~__context ~self:host)
 			in
-			(try ignore(Xapi_message.create ~__context ~name:Api_messages.vm_resumed
-				~priority:1L ~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
+			let (name, priority) = Api_messages.vm_resumed in
+			(try ignore(Xapi_message.create ~__context ~name ~priority
+				~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
 			Rrdd_proxy.push_rrd ~__context ~vm_uuid:(Db.VM.get_uuid ~__context ~self:vm)
 
 		let resume_on ~__context ~vm ~host ~start_paused ~force =
@@ -1540,8 +1549,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					(Db.Host.get_name_label ~__context ~self:host)
 					(Db.Host.get_uuid ~__context ~self:host)
 			in
-			(try ignore(Xapi_message.create ~__context ~name:Api_messages.vm_resumed
-				~priority:1L ~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
+			let (name, priority) = Api_messages.vm_resumed in
+			(try ignore(Xapi_message.create ~__context ~name ~priority
+				~cls:`VM ~obj_uuid:uuid ~body:message_body) with _ -> ());
 			Rrdd_proxy.push_rrd ~__context ~vm_uuid:(Db.VM.get_uuid ~__context ~self:vm)
 
 		let pool_migrate_complete ~__context ~vm ~host =

--- a/ocaml/xapi/redo_log_alert.ml
+++ b/ocaml/xapi/redo_log_alert.ml
@@ -16,17 +16,17 @@ open Threadext
 module R = Debug.Debugger(struct let name = "redo_log" end)
 open R
 
-let raise_system_alert news body =
+let raise_system_alert (name, priority) body =
 	(* This code may block indefinitely while attempting to look up the pool UUID and send the alert, so do it in a separate thread *)
 	ignore (Thread.create (fun () ->
-		debug "Processing redo log event: %s" news;
+		debug "Processing redo log event: %s" name;
 		let __context = Context.make "context" in
 		let pool = Helpers.get_pool ~__context in
 		let obj_uuid = Db.Pool.get_uuid ~__context ~self:pool in
 		let other_config = Db.Pool.get_other_config ~__context ~self:pool in
 		if List.mem_assoc Xapi_globs.redo_log_alert_key other_config && (List.assoc Xapi_globs.redo_log_alert_key other_config = "true") then begin
 			debug "Raising alert for pool UUID %s" obj_uuid;
-			(try ignore (Xapi_message.create ~__context ~name:news ~priority:1L ~cls:`Pool ~obj_uuid ~body) with _ -> ());
+			(try ignore (Xapi_message.create ~__context ~name ~priority ~cls:`Pool ~obj_uuid ~body) with _ -> ());
 			debug "Alert raised"
 		end else debug "Not raising alert because Pool.other_config:%s <> true" Xapi_globs.redo_log_alert_key;
   ) ())

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -738,8 +738,8 @@ let server_init() =
           (* CP-729: alert to notify client if internal event hook ext_auth.on_xapi_initialize fails *)
           ignore (Helpers.call_api_functions ~__context (fun rpc session_id ->
             (* we need to create the alert on the *master* so that XenCenter will be able to pick it up *)
-            Client.Client.Message.create ~rpc ~session_id ~name:Api_messages.auth_external_init_failed 
-              ~priority:1L ~cls:`Host ~obj_uuid ~body:(
+            let (name, priority) = Api_messages.auth_external_init_failed in
+            Client.Client.Message.create ~rpc ~session_id ~name ~priority ~cls:`Host ~obj_uuid ~body:(
                 "host_external_auth_type="^auth_type^
                 ", host_external_auth_service_name="^service_name^
                 ", error="^ (match !last_error with None -> "timeout" | Some e ->

--- a/ocaml/xapi/xapi_alert.ml
+++ b/ocaml/xapi/xapi_alert.ml
@@ -39,8 +39,8 @@ end
 let alert_queue_push = (Thread_queue.make ~name:"API messages" ~max_q_length:100 Alert.process).Thread_queue.push_fn
 
 (** Function which guarantees not to block and creates the message on a 'best-effort' basis *)
-let add ~name ~priority ~cls ~obj_uuid ~body = 
-  let sent = 
+let add ~msg:(name, priority) ~cls ~obj_uuid ~body = 
+  let sent =
     if Pool_role.is_master () then begin
       Server_helpers.exec_with_new_task "Sending an alert" ~task_in_database:false 
 	(fun __context ->    

--- a/ocaml/xapi/xapi_alert.mli
+++ b/ocaml/xapi/xapi_alert.mli
@@ -15,7 +15,7 @@
 (** Creates an alert/message and guarantees not to block. If called on the master it will use the
     internal Xapi_message.create function. If called on a slave it will enqueue the alert and 
     leave it for processing by a background thread. *)
-val add : name:string -> priority:int64 -> cls:API.cls -> obj_uuid:string -> body:string -> unit
+val add : msg:(string * int64) -> cls:API.cls -> obj_uuid:string -> body:string -> unit
 
 (** Calls the given function whenever values change *)
 val edge_trigger : ('a -> 'a -> unit) -> 'a -> unit

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -322,7 +322,7 @@ let mark_pool_as_overcommitted ~__context =
   if planned_for <> max_failures then begin
     Db.Pool.set_ha_plan_exists_for ~__context ~self:pool ~value:(min to_tolerate max_failures);
     if max_failures < planned_for
-    then Xapi_alert.add ~name:Api_messages.ha_pool_drop_in_plan_exists_for ~priority:1L ~cls:`Pool ~obj_uuid:(Db.Pool.get_uuid ~__context ~self:pool) ~body:(Int64.to_string max_failures);
+    then Xapi_alert.add ~msg:Api_messages.ha_pool_drop_in_plan_exists_for ~cls:`Pool ~obj_uuid:(Db.Pool.get_uuid ~__context ~self:pool) ~body:(Int64.to_string max_failures);
   end;
     
   if not overcommitted then begin
@@ -333,8 +333,8 @@ let mark_pool_as_overcommitted ~__context =
     let pool_name_label = Db.Pool.get_name_label ~__context ~self:pool in
     (* Note -- it's OK to look up stuff in the database when generating the alert text, because this code runs on the master; therefore there is no
        danger of blocking for db.* calls to return *)
-    let (_: 'a Ref.t) = Xapi_message.create ~__context ~name:Api_messages.ha_pool_overcommitted 
-      ~priority:Api_messages.ha_pool_overcommitted_priority ~cls:`Pool ~obj_uuid
+    let (name, priority) = Api_messages.ha_pool_overcommitted in
+    let (_: 'a Ref.t) = Xapi_message.create ~__context ~name ~priority ~cls:`Pool ~obj_uuid
       ~body:(Printf.sprintf "The failover tolerance for pool '%s' has dropped and the initially specified number of host failures to tolerate can no longer be guaranteed"
 	       pool_name_label) in
     ();
@@ -451,7 +451,7 @@ let restart_auto_run_vms ~__context live_set n =
 								if not (List.exists (fun x -> x=h) shutting_down) then begin
 									let obj_uuid = Db.Host.get_uuid ~__context ~self:h in
 									let host_name = Db.Host.get_name_label ~__context ~self:h in
-									Xapi_alert.add ~name:Api_messages.ha_host_failed ~priority:Api_messages.ha_host_failed_priority ~cls:`Host ~obj_uuid
+									Xapi_alert.add ~msg:Api_messages.ha_host_failed ~cls:`Host ~obj_uuid
 										~body:(Printf.sprintf "Server '%s' has failed" host_name);
 								end;
 								(* Call external host failed hook (allows a third-party to use power-fencing if desired) *)
@@ -528,7 +528,7 @@ let restart_auto_run_vms ~__context live_set n =
 		if not(Hashtbl.mem restart_failed vm) then begin
 			Hashtbl.replace restart_failed vm ();
 			let obj_uuid = Db.VM.get_uuid ~__context ~self:vm in
-			Xapi_alert.add ~name:Api_messages.ha_protected_vm_restart_failed ~priority:1L ~cls:`VM ~obj_uuid ~body:""
+			Xapi_alert.add ~msg:Api_messages.ha_protected_vm_restart_failed ~cls:`VM ~obj_uuid ~body:""
 		end in
 
 	(* execute the plan *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -391,7 +391,8 @@ let compute_evacuation_plan ~__context ~host =
 			(Db.Host.get_name_label ~__context ~self:host)
 			(Db.Pool.get_uuid ~__context ~self:(Helpers.get_pool ~__context))
 		  in
-		  ignore(Xapi_message.create ~__context ~name:Api_messages.wlb_failed ~priority:3L ~cls:`Host ~obj_uuid:uuid ~body:message_body)
+		  let (name, priority) = Api_messages.wlb_failed in
+		  ignore(Xapi_message.create ~__context ~name ~priority ~cls:`Host ~obj_uuid:uuid ~body:message_body)
 		with _ -> ());
 	  compute_evacuation_plan_no_wlb ~__context ~host
 	| _ ->
@@ -999,9 +1000,10 @@ let detect_nonhomogeneous_external_auth_in_host ~__context ~host =
 				master_external_auth_type master_external_auth_service_name;
 			(* raise alert about this non-homogeneous slave in the pool *)
 			let host_uuid = host_rec.API.host_uuid in
+			let (name, priority) = Api_messages.auth_external_pool_non_homogeneous in
 			ignore(
-				Client.Client.Message.create ~rpc ~session_id ~name:Api_messages.auth_external_pool_non_homogeneous
-				~priority:1L ~cls:`Host ~obj_uuid:host_uuid ~body:(
+				Client.Client.Message.create ~rpc ~session_id ~name ~priority
+				~cls:`Host ~obj_uuid:host_uuid ~body:(
 					"host_external_auth_type="^host_external_auth_type^
 					", host_external_auth_service_name="^host_external_auth_service_name^
 					", master_external_auth_type="^master_external_auth_type^

--- a/ocaml/xapi/xapi_host_crashdump.ml
+++ b/ocaml/xapi/xapi_host_crashdump.ml
@@ -72,7 +72,7 @@ let resynchronise ~__context ~host =
 		with _ -> false (* on first boot no-pool=>exn, but on first boot HA is never enabled *) in
 	begin
 		if ha_is_enabled && (arrived = []) && not was_shutdown_cleanly && !Xapi_globs.on_system_boot
-		then Xapi_alert.add ~name:Api_messages.ha_host_was_fenced ~priority:1L ~cls:`Host ~obj_uuid:(Db.Host.get_uuid ~__context ~self:host) ~body:""
+		then Xapi_alert.add ~msg:Api_messages.ha_host_was_fenced ~cls:`Host ~obj_uuid:(Db.Host.get_uuid ~__context ~self:host) ~body:""
 	end;
 
 	let table = List.combine db_filenames all_refs in

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1161,7 +1161,7 @@ let ha_compute_max_host_failures_to_tolerate ~__context =
     if current_plan_for <> n then begin
       Db.Pool.set_ha_plan_exists_for ~__context ~self:pool ~value:(min n' n);
       if n < current_plan_for
-      then Xapi_alert.add ~name:Api_messages.ha_pool_drop_in_plan_exists_for ~priority:1L ~cls:`Pool ~obj_uuid:(Db.Pool.get_uuid ~__context ~self:pool) ~body:(Int64.to_string n);
+      then Xapi_alert.add ~msg:Api_messages.ha_pool_drop_in_plan_exists_for ~cls:`Pool ~obj_uuid:(Db.Pool.get_uuid ~__context ~self:pool) ~body:(Int64.to_string n);
     end;
   end;
   n

--- a/ocaml/xapi/xapi_pool_transition.ml
+++ b/ocaml/xapi/xapi_pool_transition.ml
@@ -170,5 +170,6 @@ let consider_sending_alert __context () =
   if (try bool_of_string (Localdb.get Constants.this_node_just_became_master) with _ -> false)
   then 
     let obj_uuid = Helpers.get_localhost_uuid () in
-    let (_: 'a Ref.t) = Xapi_message.create ~__context ~name:Api_messages.pool_master_transition ~priority:1L ~cls:`Host ~obj_uuid ~body:"" in 
+    let (name, priority) = Api_messages.pool_master_transition in
+    let (_: 'a Ref.t) = Xapi_message.create ~__context ~name ~priority ~cls:`Host ~obj_uuid ~body:"" in 
     Localdb.put Constants.this_node_just_became_master (string_of_bool false)

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -656,8 +656,8 @@ let choose_host_for_vm ~__context ~vm ~snapshot =
 							(Db.Pool.get_uuid ~__context
 								~self:(Helpers.get_pool ~__context))
 					in
-					ignore (Xapi_message.create ~__context
-						~name:Api_messages.wlb_failed ~priority:3L
+					let (name, priority) = Api_messages.wlb_failed in
+					ignore (Xapi_message.create ~__context ~name ~priority
 						~cls:`VM ~obj_uuid:uuid ~body:message_body)
 				with _ -> ()
 			end;

--- a/ocaml/xapi/xapi_vmpp.ml
+++ b/ocaml/xapi/xapi_vmpp.ml
@@ -71,18 +71,11 @@ let create_alert ~__context ~vmpp ~name ~priority ~body ~data =
 		^(Xml.to_string (Xml.PCData body))
     ^"</email><data>"^value^"</data></message>"
   in
-  let successful = priority < 5L in
-  if successful
-  then ( (* alert indicates a vmpp success *)
-		add_to_recent_alerts ~__context ~vmpp ~value;
-  )
-  else ( (* alert indicates a vmpp failure *)
-    add_to_recent_alerts ~__context ~vmpp ~value;
-    let cls = `VMPP in
-    let obj_uuid = Db.VMPP.get_uuid ~__context ~self:vmpp in
-    let (_: API.ref_message) = Xapi_message.create ~__context ~name ~priority ~cls ~obj_uuid ~body:msg in
-    ()
-  )
+  add_to_recent_alerts ~__context ~vmpp ~value;
+  let cls = `VMPP in
+  let obj_uuid = Db.VMPP.get_uuid ~__context ~self:vmpp in
+  let (_: API.ref_message) = Xapi_message.create ~__context ~name ~priority ~cls ~obj_uuid ~body:msg in
+  ()
 
 let unzip b64zdata = (* todo: remove i/o, make this more efficient *)
   try

--- a/scripts/license-check.py
+++ b/scripts/license-check.py
@@ -55,7 +55,7 @@ def main():
         timeleft=expiry-currenttime
         if (timeleft < 24.0 * 3600.0 * 30.0 and timeleft > 0):
             localhost=get_localhost()
-            doexec(["xe","message-create","host-uuid=%s" % localhost, "name=%s" % expiry_message_name, "priority=10", "body=Your license will expire in %.0f days" % (timeleft / (24.0 * 3600.0))])
+            doexec(["xe","message-create","host-uuid=%s" % localhost, "name=%s" % expiry_message_name, "priority=2", "body=Your license will expire in %.0f days" % (timeleft / (24.0 * 3600.0))])
     return 0
 
 if __name__ == '__main__':

--- a/scripts/mail-alarm
+++ b/scripts/mail-alarm
@@ -414,15 +414,15 @@ class XapiMessage:
 
 def main():
     other_config = get_pool_other_config()
-    if other_config.has_key('mail-min-priority'):
-        min_priority = int(other_config['mail-min-priority'])
+    if other_config.has_key('mail-max-priority'):
+        max_priority = int(other_config['mail-max-priority'])
     else:
-        min_priority = 5
+        max_priority = 4
 
     msg = XapiMessage(sys.argv[1])
 
-    # We only mail messages with level min_priority or higher
-    if msg.get_priority() < min_priority:
+    # We only mail messages with priority lower than or equal to max_priority
+    if msg.get_priority() > max_priority:
         return 0
 
     if msg.get_cls() == "VMPP":


### PR DESCRIPTION
- Reversed the meaning of mail-min-priority config key, and renamed it
  mail-max-priority.
- Removed priority checking from Xapi_vmpp.
- Updated priority checking in mail-alarm.
