### PR TITLE
CA-89798: Fix a problem with Bonds status on a slave.

### DIFF
--- a/ocaml/network/network_monitor_thread.ml
+++ b/ocaml/network/network_monitor_thread.ml
@@ -24,13 +24,6 @@ open D
 
 (** Table for bonds status. *)
 let bonds_status : (string, (int * int)) Hashtbl.t = Hashtbl.create 10
-let bonds_status_update : (string * int) list ref = ref []
-let bonds_status_update_m = Mutex.create ()
-
-let add_bond_status bond links_up =
-	Mutex.execute bonds_status_update_m (fun _ ->
-		bonds_status_update := !bonds_status_update @ [(bond,links_up)]
-	)
 
 let xapi_rpc =
 	let open Xmlrpc_client in


### PR DESCRIPTION
The main problem with in the call of local_logout instead of logout on the master, which raised an exception.

I tested on a pool of 2 hosts, with a bond having 1 disconnected NIC on the slave. It was enough to trigger the bug.
