### PR TITLE
CP-3638: Remove now redundant code from various source files in rrdd and...

### DIFF
--- a/ocaml/rrdd/interface/rrdd_interface.ml
+++ b/ocaml/rrdd/interface/rrdd_interface.ml
@@ -71,11 +71,7 @@ module HA = struct
 end
 
 module Deprecated = struct
-	external get_full_update_avg_rra_idx : unit -> int = ""
-	external get_full_update_last_rra_idx : unit -> int = ""
 	(* Could change timescale to sum type, e.g. Slow | Fast.*)
 	external load_rrd : uuid:string -> domid:int -> is_host:bool ->
 		timescale:int -> unit -> unit = ""
-	(* external get_host_rrd : unit -> rrd_info option = "" *)
-	external get_host_stats : unit -> unit = ""
 end


### PR DESCRIPTION
... xapi.

Signed-off-by: Rok Strniša rok.strnisa@citrix.com

REVIEW BEFORE MERGING!

This patch removes code that is no longer required due to `rrdd` split from `xapi`. It is not fixing any bug, so there is no rush to merge it. The changes should be reviewed by JonL and/or Jerome (preferably both).

Please verify also that RRDs for the host and its VMs are correctly created at boot/`xapi` restart. At the moment, RRD for the host is re-loaded at each `xapi` start --- this is most likely correct, since the RRD might have to come from a different host, and it can only do so through HTTP transfer, which works only after `xapi` is up on all relevant hosts. The methods for this are currently still in the `Deprecated` submodule, but if this is normal functionality then they should be moved to its super-module. RRD lifecycle should also be verified for VM RRDs.
