### PR TITLE
 	Revert the rebalance-interval changes to networkd of f03a307

### DIFF
--- a/ocaml/network/network_utils.ml
+++ b/ocaml/network/network_utils.ml
@@ -717,9 +717,9 @@ module Ovs = struct
 			else
 				[]
 		in
-		let extra_args = List.flatten (List.map get_prop (["updelay", "bond_updelay"; "downdelay", "bond_downdelay";
-			"miimon", "other-config:bond-miimon-interval"; "use_carrier", "other-config:bond-detect-mode";]
-			@ (if (List.mem_assoc "mode" properties) && (List.assoc "mode" properties = "lacp") then [] else ["rebalance-interval", "other-config:bond-rebalance-interval"]))) in
+		let extra_args = List.flatten (List.map get_prop ["updelay", "bond_updelay"; "downdelay", "bond_downdelay";
+			"miimon", "other-config:bond-miimon-interval"; "use_carrier", "other-config:bond-detect-mode";
+			"rebalance-interval", "other-config:bond-rebalance-interval"]) in
 		let other_args = List.filter_map (fun (k, v) ->
 			if List.mem k known_props then None
 			else Some (Printf.sprintf "other-config:\"%s\"=\"%s\"" (String.escaped ("bond-" ^ k)) (String.escaped v))


### PR DESCRIPTION
The policies for which values are set in the network layer should be in xapi. Networkd should
just do do what xapi says.

After this change, the default rebalance-intervals are unchanged: for balance-slb bonds it is 30min,
while for LACP bonds, the value is unset and the default from the ovs is used (10s). However, the
change makes it possible for the user to override the rebalance-interval using the other-config key,
even in the LACP case (for whatever reason).

Signed-off-by: Rob Hoes rob.hoes@citrix.com
