### PR TITLE
CA-74343: Fix HA on VLANs

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -829,7 +829,8 @@ let get_pif_underneath_vlan ~__context vlan_pif_ref =
  * network can run on (and be migrated to) any (enabled) host in the pool. *)
 let is_network_properly_shared ~__context ~self =
 	let pifs = Db.Network.get_PIFs ~__context ~self in
-	let non_slave_pifs = List.filter (fun pif -> Db.PIF.get_bond_slave_of ~__context ~self:pif = Ref.null) pifs in
+	let non_slave_pifs = List.filter (fun pif ->
+		not (Db.is_valid_ref __context (Db.PIF.get_bond_slave_of ~__context ~self:pif))) pifs in
 	let hosts_with_pif = List.setify (List.map (fun pif -> Db.PIF.get_host ~__context ~self:pif) non_slave_pifs) in
 	let all_hosts = Db.Host.get_all ~__context in
 	let enabled_hosts = List.filter (fun host -> Db.Host.get_enabled ~__context ~self:host) all_hosts in


### PR DESCRIPTION
The recent change to not automatically plug VLANs on host boot (for
scalability reasons), led the HA code to believe that VMs on VLANs
were not agile, even if they were.

It turns out that the agility check for networking is too strict.
Currently, xapi only considers a VM agile if all its networks
1. have PIFs on all enabled hosts, AND
2. have all those PIFs attached/plugged.

This is too strict, because a PIF can always be plugged, unless it is
a bond slave, and xapi automatically plugs a PIF when it is needed by a
VM.

Therefore, the agility check was changed to require that a VM's networks
1. have PIFs on all enabled hosts, AND
2. none of those PIFs are bond slaves.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
