### PR TITLE
Revert "Update to the Xen-4.2 interface (deactived by #ifdefs)"

### DIFF
--- a/ocaml/xenguest/xenguest.ml
+++ b/ocaml/xenguest/xenguest.ml
@@ -39,7 +39,7 @@ external domain_resume_slow : handle -> domid -> unit
 
 (** restore a domain *)
 external domain_restore : handle -> Unix.file_descr -> domid
-                       -> int -> int -> int -> int -> bool -> bool
+                       -> int -> int -> bool
                        -> nativeint * nativeint
        = "stub_xc_domain_restore_bytecode" "stub_xc_domain_restore"
 

--- a/ocaml/xenguest/xenguest_main.ml
+++ b/ocaml/xenguest/xenguest_main.ml
@@ -253,11 +253,11 @@ let domain_save_real fd domid x y flags hvm =
 		""
 	)
 
-let domain_restore_real fd domid store_port store_domid console_port console_domid hvm no_incr_generationid =
+let domain_restore_real fd domid store_port console_port hvm =
 	with_xenguest (fun xc ->
 		let store_mfn, console_mfn =
-		Xenguest.domain_restore xc fd domid store_port store_domid
-					console_port console_domid hvm no_incr_generationid in
+		Xenguest.domain_restore xc fd domid store_port
+					console_port hvm in
 		String.concat " "  [ Nativeint.to_string store_mfn;
 				     Nativeint.to_string console_mfn ]
 	)
@@ -266,14 +266,14 @@ let domain_restore_real fd domid store_port store_domid console_port console_dom
 let linux_build_fake domid mem_max_mib mem_start_mib image ramdisk cmdline features flags store_port console_port = "10 10 x86-32"
 let hvm_build_fake domid mem_max_mib mem_start_mib image store_port console_port = "2901 2901"
 let domain_save_fake fd domid x y flags hvm = Unix.sleep 1; ignore (suspend_callback domid); ""
-let domain_restore_fake fd domid store_port store_domid console_port console_domid hvm no_incr_generationid = "10 10"
+let domain_restore_fake fd domid store_port console_port hvm = "10 10"
 
 (** operation vector *)
 type ops = {
 	linux_build: int -> int -> int -> string -> string option -> string -> string -> int -> int -> int -> string;
 	hvm_build: int -> int -> int -> string -> int -> int -> string;
 	domain_save: Unix.file_descr -> int -> int -> int -> Xenguest.suspend_flags list -> bool -> string;
-	domain_restore: Unix.file_descr -> int -> int -> int -> int -> int -> bool -> bool -> string;
+	domain_restore: Unix.file_descr -> int -> int -> int -> bool -> string;
 }
 
 (* main *)
@@ -376,16 +376,13 @@ let _ =
 	      | Some "restore" ->
 		  debug "restore mode selected";
 		  let hvm = if !mode = (Some "hvm_restore") then true else false in
-		  require [ "domid"; "fd"; "store_port"; "store_domid"; "console_port"; "console_domid" ];
+		  require [ "domid"; "fd"; "store_port"; "console_port"; ];
 		  let fd = file_descr_of_int (int_of_string (get_param "fd"))
 		  and domid = int_of_string (get_param "domid")
 		  and store_port = int_of_string (get_param "store_port")
-		  and store_domid = int_of_string (get_param "store_domid")
-		  and console_port = int_of_string (get_param "console_port")
-		  and console_domid = int_of_string (get_param "console_domid")
-		  and no_incr_generationid = bool_of_string (get_param "no_incr_generationid") in
+		  and console_port = int_of_string (get_param "console_port") in
 
-		  with_logging (fun () -> ops.domain_restore fd domid store_port store_domid console_port console_domid hvm no_incr_generationid)
+		  with_logging (fun () -> ops.domain_restore fd domid store_port console_port hvm)
 	      | Some "linux_build" ->
 		  debug "linux_build mode selected";
 		  require [ "domid"; "mem_max_mib"; "mem_start_mib"; "image"; "ramdisk"; "cmdline"; "features"; "flags";

--- a/ocaml/xenguest/xenguest_stubs.c
+++ b/ocaml/xenguest/xenguest_stubs.c
@@ -85,38 +85,6 @@ static int pasprintf(char **buf, const char *fmt, ...)
     return ret;
 }
 
-static int
-xenstore_putsv(int domid, const char *val, const char *fmt, va_list ap)
-{
-  char *path = NULL;
-  struct xs_handle *xsh = NULL;
-  int n, m, rc;
-  char key[1024];
-
-  rc = 1;
-  bzero(key, sizeof(key));
-  xsh = xs_daemon_open();
-  if (xsh == NULL)
-	goto out;
-
-  path = xs_get_domain_path(xsh, domid);
-  if (path == NULL)
-	goto out;
-
-  n = snprintf(key, sizeof(key), "%s/", path);
-  if (n < 0)
-	goto out;
-  m = vsnprintf(key + n, sizeof(key) - n, fmt, ap);
-  if (m < 0)
-	goto out;
-
-  rc = xs_write(xsh, XBT_NULL, key, val, strlen(val));
-  out:
-  xs_daemon_close(xsh);
-  free(path);
-  return rc;
-}
-
 static char *
 xenstore_getsv(int domid, const char *fmt, va_list ap)
 {
@@ -136,7 +104,7 @@ xenstore_getsv(int domid, const char *fmt, va_list ap)
     if (path == NULL)
         goto out;
 
-	n = snprintf(key, sizeof(key), "%s/", path);
+	n = snprintf(key, sizeof(key), "%s/platform/", path);
 	if (n < 0)
 	  goto out;
 	m = vsnprintf(key + n, sizeof(key) - n, fmt, ap);
@@ -148,18 +116,6 @@ xenstore_getsv(int domid, const char *fmt, va_list ap)
     xs_daemon_close(xsh);
     free(path);
     return s;
-}
-
-static int
-xenstore_puts(int domid, const char *val, const char *fmt, ...)
-{
-  int rc;
-  va_list ap;
-
-  va_start(ap, fmt);
-  rc = xenstore_putsv(domid, val, fmt, ap);
-  va_end(ap);
-  return rc;
 }
 
 static char *
@@ -198,24 +154,24 @@ static void
 get_flags(struct flags *f, int domid) 
 {
   int n;
-  f->vcpus    = xenstore_get(domid, "platform/vcpu/number");
+  f->vcpus    = xenstore_get(domid, "vcpu/number");
   f->vcpu_affinity = (const char**)(malloc(sizeof(char*) * f->vcpus));
 
   for (n = 0; n < f->vcpus; n++) {
-	f->vcpu_affinity[n] = xenstore_gets(domid, "platform/vcpu/%d/affinity", n);
+	f->vcpu_affinity[n] = xenstore_gets(domid, "vcpu/%d/affinity", n);
   }
-  f->vcpus_current = xenstore_get(domid, "platform/vcpu/current");
-  f->vcpu_weight = xenstore_get(domid, "platform/vcpu/weight");
-  f->vcpu_cap = xenstore_get(domid, "platform/vcpu/cap");
-  f->nx       = xenstore_get(domid, "platform/nx");
-  f->viridian = xenstore_get(domid, "platform/viridian");
-  f->apic     = xenstore_get(domid, "platform/apic");
-  f->acpi     = xenstore_get(domid, "platform/acpi");
-  f->pae      = xenstore_get(domid, "platform/pae");
-  f->acpi_s4  = xenstore_get(domid, "platform/acpi_s4");
-  f->acpi_s3  = xenstore_get(domid, "platform/acpi_s3");
-  f->mmio_size_mib = xenstore_get(domid, "platform/mmio_size_mib");
-  f->tsc_mode = xenstore_get(domid, "platform/tsc_mode");
+  f->vcpus_current = xenstore_get(domid, "vcpu/current");
+  f->vcpu_weight = xenstore_get(domid, "vcpu/weight");
+  f->vcpu_cap = xenstore_get(domid, "vcpu/cap");
+  f->nx       = xenstore_get(domid, "nx");
+  f->viridian = xenstore_get(domid, "viridian");
+  f->apic     = xenstore_get(domid, "apic");
+  f->acpi     = xenstore_get(domid, "acpi");
+  f->pae      = xenstore_get(domid, "pae");
+  f->acpi_s4  = xenstore_get(domid, "acpi_s4");
+  f->acpi_s3  = xenstore_get(domid, "acpi_s3");
+  f->mmio_size_mib = xenstore_get(domid, "mmio_size_mib");
+  f->tsc_mode = xenstore_get(domid, "tsc_mode");
 
   openlog("xenguest",LOG_NDELAY,LOG_DAEMON);
   syslog(LOG_INFO|LOG_DAEMON,"Determined the following parameters from xenstore:");
@@ -542,11 +498,9 @@ int switch_qemu_logdirty(int domid, unsigned enable, void *data)
 
 static struct save_callbacks save_callbacks = {
 	.suspend = dispatch_suspend,
-	.switch_qemu_logdirty = switch_qemu_logdirty,
+  .postcopy = switch_qemu_logdirty,
         .checkpoint = NULL,
 };
-
-#define GENERATION_ID_ADDRESS "hvmloader/generation-id-address"
 
 CAMLprim value stub_xc_domain_save(value handle, value fd, value domid,
                                    value max_iters, value max_factors,
@@ -559,25 +513,19 @@ CAMLprim value stub_xc_domain_save(value handle, value fd, value domid,
 	uint32_t c_flags;
   uint32_t c_domid;
 	int r;
-	unsigned long generation_id_addr;
 
 	c_flags = caml_convert_flag_list(flags, suspend_flag_list);
   c_domid = _D(domid);
 
 	memset(&callbacks, 0, sizeof(callbacks));
-	callbacks.data = (void*) c_domid;
+  callbacks.data = c_domid;
 	callbacks.suspend = dispatch_suspend;
 	callbacks.switch_qemu_logdirty = switch_qemu_logdirty;
 
 	caml_enter_blocking_section();
-	generation_id_addr = xenstore_get(c_domid, GENERATION_ID_ADDRESS);
 	r = xc_domain_save(_H(handle), Int_val(fd), c_domid,
 	                   Int_val(max_iters), Int_val(max_factors),
-	                   c_flags, &callbacks, Bool_val(hvm)
-#ifdef XENGUEST_4_2
-					   ,generation_id_addr
-#endif
-					   );
+	                   c_flags, &callbacks, Bool_val(hvm));
 	caml_leave_blocking_section();
 	if (r)
 		failwith_oss_xc(_H(handle), "xc_domain_save");
@@ -607,28 +555,21 @@ CAMLprim value stub_xc_domain_resume_slow(value handle, value domid)
 
 
 CAMLprim value stub_xc_domain_restore(value handle, value fd, value domid,
-                                      value store_evtchn, value store_domid,
-									  value console_evtchn, value console_domid,
-                                      value hvm, value no_incr_generationid)
+                                      value store_evtchn, value console_evtchn,
+                                      value hvm)
 {
 	CAMLparam5(handle, fd, domid, store_evtchn, console_evtchn);
 	CAMLxparam1(hvm);
 	CAMLlocal1(result);
 	unsigned long store_mfn, console_mfn;
-	domid_t c_store_domid, c_console_domid;
-	unsigned long c_vm_generationid_addr;
-	char c_vm_generationid_addr_s[32];
 	unsigned int c_store_evtchn, c_console_evtchn;
 	int r;
-	size_t size, written;
 
 	struct flags f;
 	get_flags(&f,_D(domid));
 
 	c_store_evtchn = Int_val(store_evtchn);
-	c_store_domid = Int_val(store_domid);
 	c_console_evtchn = Int_val(console_evtchn);
-	c_console_domid = Int_val(console_domid);
 
 #ifdef HVM_PARAM_VIRIDIAN
 	xc_set_hvm_param(_H(handle), _D(domid), HVM_PARAM_VIRIDIAN, f.viridian);	
@@ -636,34 +577,10 @@ CAMLprim value stub_xc_domain_restore(value handle, value fd, value domid,
 	configure_vcpus(_H(handle), _D(domid), f);
 
 	caml_enter_blocking_section();
-
 	r = xc_domain_restore(_H(handle), Int_val(fd), _D(domid),
 	                      c_store_evtchn, &store_mfn,
-#ifdef XENGUEST_4_2
-						  c_store_domid,
-#endif
 	                      c_console_evtchn, &console_mfn,
-#ifdef XENGUEST_4_2
-						  c_console_domid,
-#endif
-						  Bool_val(hvm), f.pae, 0 /*superpages*/
-#ifdef XENGUEST_4_2
-						  ,
-						  Bool_val(no_incr_generationid),
-						  &c_vm_generationid_addr,
-						  NULL /* restore_callbacks */
-#endif
-						  );
-	if (!r) {
-	  size = sizeof(c_vm_generationid_addr_s) - 1; /* guarantee a NULL remains on the end */
-	  written = snprintf(c_vm_generationid_addr_s, size, "0x%lx", c_vm_generationid_addr);
-	  if (written < size)
-		r = xenstore_puts(_D(domid), c_vm_generationid_addr_s, GENERATION_ID_ADDRESS);
-	  else {
-		syslog(LOG_ERR|LOG_DAEMON,"Failed to write %s (%d >= %d)", GENERATION_ID_ADDRESS, written, size);
-		r = 1;
-	  }
-	}
+			      Bool_val(hvm), f.pae, 0 /*superpages*/);
 	caml_leave_blocking_section();
 	if (r)
 		failwith_oss_xc(_H(handle), "xc_domain_restore");
@@ -671,14 +588,14 @@ CAMLprim value stub_xc_domain_restore(value handle, value fd, value domid,
 	result = caml_alloc_tuple(2);
 	Store_field(result, 0, caml_copy_nativeint(store_mfn));
 	Store_field(result, 1, caml_copy_nativeint(console_mfn));
+
 	CAMLreturn(result);
 }
 
 CAMLprim value stub_xc_domain_restore_bytecode(value * argv, int argn)
 {
 	return stub_xc_domain_restore(argv[0], argv[1], argv[2], argv[3],
-	                              argv[4], argv[5], argv[6], argv[7],
-								  argv[8]);
+	                              argv[4], argv[5]);
 }
 
 CAMLprim value stub_xc_domain_dumpcore(value handle, value domid, value file)

--- a/ocaml/xenops/domain.mli
+++ b/ocaml/xenops/domain.mli
@@ -136,7 +136,6 @@ val build: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xs
 (** resume a domain either cooperative or not *)
 val resume: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> hvm: bool -> cooperative: bool -> qemu_domid:int -> domid -> unit
 
-(*
 (** restore a PV domain into a fresh domain created with 'make' *)
 val pv_restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> static_max_kib:Int64.t 
           -> target_kib:Int64.t -> vcpus:int -> domid -> Unix.file_descr
@@ -149,10 +148,9 @@ val hvm_restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore
              -> vcpus:int -> timeoffset:string
              -> domid -> Unix.file_descr
              -> unit
-*)
 
 (** Restore a domain using the info provided *)
-val restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> store_domid:int -> console_domid:int -> no_incr_generationid:bool -> build_info -> string -> domid -> Unix.file_descr -> unit
+val restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> build_info -> string -> domid -> Unix.file_descr -> unit
 
 type suspend_flag = Live | Debug
 

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -1236,14 +1236,11 @@ module VM = struct
 								Some x -> (match x with HVM hvm_info -> hvm_info.timeoffset | _ -> "")
 							| _ -> "" in
 						({ x with Domain.memory_target = initial_target }, timeoffset) in
-				let store_domid = 0 in
-				let console_domid = 0 in
-				let no_incr_generationid = false in
 				begin
 					try
 						with_data ~xc ~xs task data false
 							(fun fd ->
-								Domain.restore task ~xc ~xs ~store_domid ~console_domid ~no_incr_generationid (* XXX progress_callback *) build_info timeoffset domid fd
+								Domain.restore task ~xc ~xs (* XXX progress_callback *) build_info timeoffset domid fd
 							);
 					with e ->
 						error "VM %s: restore failed: %s" vm.Vm.id (Printexc.to_string e);


### PR DESCRIPTION
This reverts commit 24527607f99d27e3a8eed025c42c2315282dbf69.

The original patch broke VM.resume.

Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
