### PR TITLE
CA-92156: Revert commit 1c13665b2305d4a73be7422d1765a3ef3e27e09a

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -668,28 +668,13 @@ let cancel_tasks ~__context ~ops ~all_tasks_in_db (* all tasks in database *) ~t
     Currently this just means "CD" but might change in future? *)
 let is_removable ~__context ~vbd = Db.VBD.get_type ~__context ~self:vbd = `CD
 
-let is_tools_sr_cache = ref []
-let is_tools_sr_cache_m = Mutex.create ()
-
 (** Returns true if this SR is the XenSource Tools SR *)
 let is_tools_sr ~__context ~sr =
-	try
-		Mutex.execute is_tools_sr_cache_m
-			(fun () -> List.assoc sr !is_tools_sr_cache)
-	with Not_found _ ->
-		let other_config = Db.SR.get_other_config ~__context ~self:sr in
-		(* Miami GA *)
-		let result =
-			List.mem_assoc Xapi_globs.tools_sr_tag other_config
-			(* Miami beta2 and earlier: *)
-			|| (List.mem_assoc Xapi_globs.xensource_internal other_config)
-		in
-		Mutex.execute is_tools_sr_cache_m
-			(fun () ->
-				let cache = !is_tools_sr_cache in
-				if not (List.mem_assoc sr cache) then
-					is_tools_sr_cache := (sr, result) :: !is_tools_sr_cache);
-		result
+  let other_config = Db.SR.get_other_config ~__context ~self:sr in
+  (* Miami GA *)
+  List.mem_assoc Xapi_globs.tools_sr_tag other_config
+    (* Miami beta2 and earlier: *)
+  || (List.mem_assoc Xapi_globs.xensource_internal other_config)
 
 (** Return true if the MAC is in the right format XX:XX:XX:XX:XX:XX *)
 let is_valid_MAC mac =


### PR DESCRIPTION
Caching is_tools_sr broke pool join - presumably because it cached
the result when the tools SR was there but didn't have the other-config
key marking it as such - the pool join subsequently failed due to
xapi thinking the slave-to-be had a shared SR.

The failure only seems to happen on first boot - any toolstack restart
flushes the cache and it gets repopulated correctly, making this quite
hard to test.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
