### PR TITLE
BOSTON-LCM: CA-79715: Allow API XMLRPC client to handle responses larger than 16MB.

### DIFF
--- a/ocaml/idl/ocaml_backend/xmlrpcclient.ml
+++ b/ocaml/idl/ocaml_backend/xmlrpcclient.ml
@@ -270,8 +270,9 @@ module Protocol = functor(F: FORMAT) -> struct
 	let read_response r s =
 		try
 			match r.Http.Response.content_length with
-				| Some l -> F.response_of_string (Unixext.really_read_string s (Int64.to_int l))
-				| None -> F.response_of_file_descr s
+				| Some l when (Int64.to_int l) <= Sys.max_string_length ->
+					F.response_of_string (Unixext.really_read_string s (Int64.to_int l))
+				| Some _ | None -> F.response_of_file_descr s
 		with
 			| Unix.Unix_error(Unix.ECONNRESET, _, _) -> raise Connection_reset
 


### PR DESCRIPTION
This is very similar to CA-75708, which was the same fix for the
database RPC client. Maybe in the long run we should look at whether
the two can share more code than they do at present.
