### PR TITLE
Allow alternative implementations of the device-model and domain builder...

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -35,7 +35,7 @@ let xenapi_of_xenops_power_state = function
 (* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)
 let filtered_platform_flags = ["acpi"; "apic"; "nx"; "pae"; "viridian";
                                "acpi_s3";"acpi_s4"; "mmio_size_mib"; "revision"; "device_id";
-                               "tsc_mode"]
+                               "tsc_mode"; "device-model"; "xenguest" ]
 
 let xenops_vdi_locator_of_strings sr_uuid vdi_location =
 	Printf.sprintf "%s/%s" sr_uuid vdi_location

--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -540,7 +540,7 @@ let build_post ~xc ~xs ~vcpus ~static_max_mib ~target_mib domid
 
 (** build a linux type of domain *)
 let build_linux (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~kernel ~cmdline ~ramdisk
-		~vcpus domid =
+		~vcpus xenguest_path domid =
 	let uuid = get_uuid ~xc domid in
 	assert_file_is_readable kernel;
 	maybe assert_file_is_readable ramdisk;
@@ -570,7 +570,7 @@ let build_linux (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~kerne
 	let store_port, console_port = build_pre ~xc ~xs
 		~xen_max_mib ~shadow_mib ~required_host_free_mib ~vcpus domid in
 
-	let line = XenguestHelper.with_connection task domid
+	let line = XenguestHelper.with_connection task xenguest_path domid
 	  [
 	    "-mode"; "linux_build";
 	    "-domid"; string_of_int domid;
@@ -611,7 +611,7 @@ let build_linux (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~kerne
 
 (** build hvm type of domain *)
 let build_hvm (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~shadow_multiplier ~vcpus
-              ~kernel ~timeoffset ~video_mib domid =
+              ~kernel ~timeoffset ~video_mib xenguest_path domid =
 	let uuid = get_uuid ~xc domid in
 	assert_file_is_readable kernel;
 
@@ -637,7 +637,7 @@ let build_hvm (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~shadow_
 	let store_port, console_port = build_pre ~xc ~xs
 		~xen_max_mib ~shadow_mib ~required_host_free_mib ~vcpus domid in
 
-	let line = XenguestHelper.with_connection task domid
+	let line = XenguestHelper.with_connection task xenguest_path domid
 	  [
 	    "-mode"; "hvm_build";
 	    "-domid"; string_of_int domid;
@@ -695,22 +695,22 @@ let build_hvm (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~shadow_
 
 	Arch_HVM
 
-let build (task: Xenops_task.t) ~xc ~xs info timeoffset domid =
+let build (task: Xenops_task.t) ~xc ~xs info timeoffset xenguest_path domid =
 	match info.priv with
 	| BuildHVM hvminfo ->
 		build_hvm task ~xc ~xs ~static_max_kib:info.memory_max ~target_kib:info.memory_target
 		          ~shadow_multiplier:hvminfo.shadow_multiplier ~vcpus:info.vcpus
-		          ~kernel:info.kernel ~timeoffset ~video_mib:hvminfo.video_mib domid
+		          ~kernel:info.kernel ~timeoffset ~video_mib:hvminfo.video_mib xenguest_path domid
 	| BuildPV pvinfo   ->
 		build_linux task ~xc ~xs ~static_max_kib:info.memory_max ~target_kib:info.memory_target
 		            ~kernel:info.kernel ~cmdline:pvinfo.cmdline ~ramdisk:pvinfo.ramdisk
-		            ~vcpus:info.vcpus domid
+		            ~vcpus:info.vcpus xenguest_path domid
 
 (* restore a domain from a file descriptor. it read first the signature
  * to be we are not trying to restore from random data.
  * the linux_restore process is in charge to allocate memory as it's needed
  *)
-let restore_common (task: Xenops_task.t) ~xc ~xs ~hvm ~store_port ~console_port ~vcpus ~extras domid fd =
+let restore_common (task: Xenops_task.t) ~xc ~xs ~hvm ~store_port ~console_port ~vcpus ~extras xenguest_path domid fd =
 	let uuid = get_uuid ~xc domid in
 	let read_signature = Io.read fd (String.length save_signature) in
 	if read_signature <> save_signature then begin
@@ -720,7 +720,7 @@ let restore_common (task: Xenops_task.t) ~xc ~xs ~hvm ~store_port ~console_port 
 	Unix.clear_close_on_exec fd;
 	let fd_uuid = Uuid.to_string (Uuid.make_uuid ()) in
 
-	let line = XenguestHelper.with_connection task domid
+	let line = XenguestHelper.with_connection task xenguest_path domid
 	  ([
 	    "-mode"; if hvm then "hvm_restore" else "restore";
 	    "-domid"; string_of_int domid;
@@ -768,7 +768,7 @@ let resume (task: Xenops_task.t) ~xc ~xs ~hvm ~cooperative ~qemu_domid domid =
 	resume_post ~xc	~xs domid;
 	if hvm then Device.Dm.resume task ~xs ~qemu_domid domid
 
-let pv_restore (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~vcpus domid fd =
+let pv_restore (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~vcpus xenguest_path domid fd =
 
 	(* Convert memory configuration values into the correct units. *)
 	let static_max_mib = Memory.mib_of_kib_used static_max_kib in
@@ -792,7 +792,7 @@ let pv_restore (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~vcpus 
 
 	let store_mfn, console_mfn = restore_common task ~xc ~xs ~hvm:false
 	                                            ~store_port ~console_port
-	                                            ~vcpus ~extras:[] domid fd in
+	                                            ~vcpus ~extras:[] xenguest_path domid fd in
 	let local_stuff = [
 		"serial/0/limit",    string_of_int 65536;
 		"console/port",     string_of_int console_port;
@@ -802,7 +802,7 @@ let pv_restore (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~vcpus 
 	build_post ~xc ~xs ~vcpus ~target_mib ~static_max_mib
 		domid store_mfn store_port local_stuff vm_stuff
 
-let hvm_restore (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~shadow_multiplier ~vcpus  ~timeoffset domid fd =
+let hvm_restore (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~shadow_multiplier ~vcpus  ~timeoffset xenguest_path domid fd =
 
 	(* Convert memory configuration values into the correct units. *)
 	let static_max_mib = Memory.mib_of_kib_used static_max_kib in
@@ -824,7 +824,7 @@ let hvm_restore (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~shado
 
 	let store_mfn, console_mfn = restore_common task ~xc ~xs ~hvm:true
 	                                            ~store_port ~console_port
-	                                            ~vcpus ~extras:[] domid fd in
+	                                            ~vcpus ~extras:[] xenguest_path domid fd in
 	let local_stuff = [
 		"serial/0/limit",    string_of_int 65536;
 (*
@@ -839,7 +839,7 @@ let hvm_restore (task: Xenops_task.t) ~xc ~xs ~static_max_kib ~target_kib ~shado
 	build_post ~xc ~xs ~vcpus ~target_mib ~static_max_mib
 		domid store_mfn store_port local_stuff vm_stuff
 
-let restore (task: Xenops_task.t) ~xc ~xs info timeoffset domid fd =
+let restore (task: Xenops_task.t) ~xc ~xs info timeoffset xenguest_path domid fd =
 	let restore_fct = match info.priv with
 	| BuildHVM hvminfo ->
 		hvm_restore task ~shadow_multiplier:hvminfo.shadow_multiplier
@@ -849,7 +849,7 @@ let restore (task: Xenops_task.t) ~xc ~xs info timeoffset domid fd =
 		in
 	restore_fct ~xc ~xs
 	            ~static_max_kib:info.memory_max ~target_kib:info.memory_target ~vcpus:info.vcpus
-	            domid fd
+	            xenguest_path domid fd
 
 type suspend_flag = Live | Debug
 
@@ -857,7 +857,7 @@ type suspend_flag = Live | Debug
  * and is in charge to suspend the domain when called. the whole domain
  * context is saved to fd
  *)
-let suspend (task: Xenops_task.t) ~xc ~xs ~hvm domid fd flags ?(progress_callback = fun _ -> ()) ~qemu_domid do_suspend_callback =
+let suspend (task: Xenops_task.t) ~xc ~xs ~hvm xenguest_path domid fd flags ?(progress_callback = fun _ -> ()) ~qemu_domid do_suspend_callback =
 	let uuid = get_uuid ~xc domid in
 	debug "VM = %s; domid = %d; suspend live = %b" (Uuid.to_string uuid) domid (List.mem Live flags);
 	Io.write fd save_signature;
@@ -877,7 +877,7 @@ let suspend (task: Xenops_task.t) ~xc ~xs ~hvm domid fd flags ?(progress_callbac
 		"-fork"; "true";
 	] @ (List.concat flags') in
 
-	XenguestHelper.with_connection task domid xenguestargs [ fd_uuid, fd ]
+	XenguestHelper.with_connection task xenguest_path domid xenguestargs [ fd_uuid, fd ]
 		(fun cnx ->
 		debug "VM = %s; domid = %d; waiting for xenguest to call suspend callback" (Uuid.to_string uuid) domid;
 

--- a/ocaml/xenops/domain.mli
+++ b/ocaml/xenops/domain.mli
@@ -120,25 +120,25 @@ val get_action_request: xs:Xenstore.Xs.xsh -> domid -> string option
 (** Builds a linux guest in a fresh domain created with 'make' *)
 val build_linux: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> static_max_kib:Int64.t
               -> target_kib:Int64.t -> kernel:string -> cmdline:string
-              -> ramdisk:string option -> vcpus:int -> domid
+              -> ramdisk:string option -> vcpus:int -> string -> domid
               -> domarch
 
 (** build an hvm domain in a fresh domain created with 'make' *)
 val build_hvm: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> static_max_kib:Int64.t
             -> target_kib:Int64.t -> shadow_multiplier:float
             -> vcpus:int -> kernel:string
-            -> timeoffset:string -> video_mib:int -> domid
+            -> timeoffset:string -> video_mib:int -> string -> domid
             -> domarch
 
 (** Restore a domain using the info provided *)
-val build: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> build_info -> string -> domid -> domarch
+val build: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> build_info -> string -> string -> domid -> domarch
 
 (** resume a domain either cooperative or not *)
 val resume: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> hvm: bool -> cooperative: bool -> qemu_domid:int -> domid -> unit
 
 (** restore a PV domain into a fresh domain created with 'make' *)
 val pv_restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> static_max_kib:Int64.t 
-          -> target_kib:Int64.t -> vcpus:int -> domid -> Unix.file_descr
+          -> target_kib:Int64.t -> vcpus:int -> string -> domid -> Unix.file_descr
           -> unit
 
 (** restore an HVM domain from the file descriptor into a fresh domain created
@@ -146,16 +146,16 @@ val pv_restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.
 val hvm_restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> static_max_kib:Int64.t
              -> target_kib:Int64.t -> shadow_multiplier:float
              -> vcpus:int -> timeoffset:string
-             -> domid -> Unix.file_descr
+             -> string -> domid -> Unix.file_descr
              -> unit
 
 (** Restore a domain using the info provided *)
-val restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> build_info -> string -> domid -> Unix.file_descr -> unit
+val restore: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> build_info -> string -> string -> domid -> Unix.file_descr -> unit
 
 type suspend_flag = Live | Debug
 
 (** suspend a domain into the file descriptor *)
-val suspend: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> hvm: bool -> domid
+val suspend: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> hvm: bool -> string -> domid
           -> Unix.file_descr -> suspend_flag list
           -> ?progress_callback: (float -> unit)
 		  -> qemu_domid: int

--- a/ocaml/xenops/stubdom.ml
+++ b/ocaml/xenops/stubdom.ml
@@ -41,7 +41,7 @@ let create ~xc ~xs domid =
     Domain.set_machine_address_size ~xc stubdom_domid (Some 32);
 	stubdom_domid
 
-let build (task: Xenops_task.t) ~xc ~xs info domid stubdom_domid =
+let build (task: Xenops_task.t) ~xc ~xs info xenguest domid stubdom_domid =
     (* Now build it as a PV domain *)
     let (_: Domain.domarch) = Domain.build task ~xc ~xs {
         Domain.memory_max=memory_kib;
@@ -49,7 +49,7 @@ let build (task: Xenops_task.t) ~xc ~xs info domid stubdom_domid =
         Domain.kernel="/usr/lib/xen/boot/ioemu-stubdom.gz";
         Domain.vcpus=1;
         Domain.priv=Domain.BuildPV {Domain.cmdline=""; Domain.ramdisk=None};
-    } "" stubdom_domid in
+    } "" xenguest stubdom_domid in
 
     (* Point the stub domain at the guest *)
     debug "jjd27: pointing stubdom %d to guest %d" stubdom_domid domid;

--- a/ocaml/xenops/stubdom.mli
+++ b/ocaml/xenops/stubdom.mli
@@ -16,4 +16,4 @@ val memory_kib: int64
 
 val create: xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Xenctrl.domid
 
-val build: Xenops_task.Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> Device.Dm.info -> Xenctrl.domid -> Xenctrl.domid -> unit
+val build: Xenops_task.Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> Device.Dm.info -> string -> Xenctrl.domid -> Xenctrl.domid -> unit

--- a/ocaml/xenops/xenguestHelper.ml
+++ b/ocaml/xenops/xenguestHelper.ml
@@ -18,9 +18,6 @@ open Xenops_task
 module D = Debug.Debugger(struct let name = "xenguesthelper" end)
 open D
 
-(** Installed path of the xenguest helper *)
-let path = Filename.concat Fhs.libexecdir "xenguest"
-
 (** Where to place the last xenguesthelper debug log (just in case) *)
 let last_log_file = "/tmp/xenguesthelper-log"
 
@@ -39,7 +36,7 @@ type t = in_channel * out_channel * Unix.file_descr * Unix.file_descr * Forkhelp
 
 (** Fork and run a xenguest helper with particular args, leaving 'fds' open 
     (in addition to internal control I/O fds) *)
-let connect domid (args: string list) (fds: (string * Unix.file_descr) list) : t =
+let connect path domid (args: string list) (fds: (string * Unix.file_descr) list) : t =
 	debug "connect: args = [ %s ]" (String.concat " " args);
 	(* Need to send commands and receive responses from the
 	   slave process *)
@@ -82,8 +79,8 @@ let disconnect (_, _, r, w, pid) =
 	(try Unix.kill (Forkhelpers.getpid pid) Sys.sigterm with _ -> ());
 	ignore(Forkhelpers.waitpid pid)
 
-let with_connection (task: Xenops_task.t) domid (args: string list) (fds: (string * Unix.file_descr) list) f =
-	let t = connect domid args fds in
+let with_connection (task: Xenops_task.t) path domid (args: string list) (fds: (string * Unix.file_descr) list) f =
+	let t = connect path domid args fds in
 	let cancelled = ref false in
 	let cancel_cb () =
 		let _, _, _, _, pid = t in

--- a/ocaml/xenops/xenops.ml
+++ b/ocaml/xenops/xenops.ml
@@ -71,14 +71,16 @@ let create_domain ~xc ~xs ~hvm =
 	let domid = Domain.make ~xc ~xs info uuid in
 	printf "%u\n" domid
 
+let default_xenguest = "/opt/xensource/libexec/xenguest"
+
 let build_domain ~xc ~xs ~kernel ?(ramdisk=None) ~cmdline ~domid ~vcpus ~static_max_kib ~target_kib =
 	let (_: Domain.domarch) = Domain.build_linux task xc xs static_max_kib target_kib
-	                                             kernel cmdline ramdisk vcpus domid in
+	                                             kernel cmdline ramdisk vcpus default_xenguest domid in
 	printf "built domain: %u\n" domid
 
 let build_hvm ~xc ~xs ~kernel ~domid ~vcpus ~static_max_kib ~target_kib =
 	let (_: Domain.domarch) = Domain.build_hvm task xc xs static_max_kib target_kib 1.
-	                                           vcpus kernel "" 4 domid in
+	                                           vcpus kernel "" 4 default_xenguest domid in
 	printf "built hvm domain: %u\n" domid
 
 let clean_shutdown_domain ~xal ~domid ~reason ~sync =
@@ -108,7 +110,7 @@ let suspend_domain ~xc ~xs ~domid ~file =
 		in
 	let hvm = is_hvm ~xc domid in
 	let fd = Unix.openfile file [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_EXCL ] 0o600 in
-	Domain.suspend task ~xc ~xs ~hvm ~qemu_domid:0 domid fd [] suspendfct;
+	Domain.suspend task ~xc ~xs ~hvm ~qemu_domid:0 default_xenguest domid fd [] suspendfct;
 	Unix.close fd
 
 let suspend_domain_and_resume ~xc ~xs ~domid ~file ~cooperative =
@@ -121,7 +123,7 @@ let suspend_domain_and_destroy ~xc ~xs ~domid ~file =
 
 let restore_domain ~xc ~xs ~domid ~vcpus ~static_max_kib ~target_kib ~file =
 	let fd = Unix.openfile file [ Unix.O_RDONLY ] 0o400 in
-	Domain.pv_restore task ~xc ~xs domid ~static_max_kib ~target_kib ~vcpus fd;
+	Domain.pv_restore task ~xc ~xs default_xenguest domid ~static_max_kib ~target_kib ~vcpus fd;
 	Unix.close fd
 
 let balloon_domain ~xs ~domid ~mem_mib =

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -27,7 +27,11 @@ open Xenops_task
 module D = Debug.Debugger(struct let name = service_name end)
 open D
 
-let _qemu_dm = "/opt/xensource/libexec/qemu-dm-wrapper"
+let _alternatives = "/opt/xensource/alternatives"
+let _qemu_dm_default = Filename.concat Fhs.libexecdir "qemu-dm-wrapper"
+let _xenguest_default = Filename.concat Fhs.libexecdir "xenguest"
+let _device_model = "device-model"
+let _xenguest = "xenguest"
 let _tune2fs = "/sbin/tune2fs"
 let _mkfs = "/sbin/mkfs"
 let _mount = "/bin/mount"
@@ -37,6 +41,25 @@ let _ionice = "/usr/bin/ionice"
 let run cmd args =
 	debug "%s %s" cmd (String.concat " " args);
 	fst(Forkhelpers.execute_command_get_output cmd args)
+
+let choose_alternative kind default platformdata =
+	debug "looking for %s in [ %s ]" kind (String.concat "; " (List.map (fun (k, v) -> k ^ " : " ^v) platformdata));
+	if List.mem_assoc kind platformdata then begin
+		let x = List.assoc kind platformdata in
+		let path = Printf.sprintf "%s/%s/%s" _alternatives kind x in
+		try
+			Unix.access path [ Unix.X_OK ];
+			path
+		with _ ->
+			error "Invalid platform:%s=%s (check execute permissions of %s)" kind x path;
+			default
+	end else default
+
+(* We allow qemu-dm to be overriden via a platform flag *)
+let choose_qemu_dm = choose_alternative _device_model _qemu_dm_default
+
+(* We allow xenguest to be overriden via a platform flag *)
+let choose_xenguest = choose_alternative _xenguest _xenguest_default
 
 type qemu_frontend =
 	| Name of string (* block device path or bridge name *)
@@ -988,7 +1011,7 @@ module VM = struct
 								} in
 								((make_build_info b.Bootloader.kernel_path builder_spec_info), "")
 							) in
-			let arch = Domain.build task ~xc ~xs build_info timeoffset domid in
+			let arch = Domain.build task ~xc ~xs build_info timeoffset (choose_xenguest vm.Vm.platformdata) domid in
 			Int64.(
 				let min = to_int (div vm.Vm.memory_dynamic_min 1024L)
 				and max = to_int (div vm.Vm.memory_dynamic_max 1024L) in
@@ -1040,22 +1063,26 @@ module VM = struct
 
 	let create_device_model_exn vbds vifs saved_state xc xs task vm di =
 		let vmextra = DB.read_exn vm.Vm.id in
+		let qemu_dm = choose_qemu_dm vm.Vm.platformdata in
+		let xenguest = choose_xenguest vm.Vm.platformdata in
+		debug "chosen qemu_dm = %s" qemu_dm;
+		debug "chosen xenguest = %s" xenguest;
 		Opt.iter (fun info ->
 			match vm.Vm.ty with
 				| Vm.HVM { Vm.qemu_stubdom = true } ->
 					if saved_state then failwith "Cannot resume with stubdom yet";
 					Opt.iter
 						(fun stubdom_domid ->
-							Stubdom.build task ~xc ~xs info di.domid stubdom_domid;
-							Device.Dm.start_vnconly task ~xs ~dmpath:_qemu_dm info stubdom_domid
+							Stubdom.build task ~xc ~xs info xenguest di.domid stubdom_domid;
+							Device.Dm.start_vnconly task ~xs ~dmpath:qemu_dm info stubdom_domid
 						) (get_stubdom ~xs di.domid);
 				| Vm.HVM { Vm.qemu_stubdom = false } ->
 					(if saved_state then Device.Dm.restore else Device.Dm.start)
-						task ~xs ~dmpath:_qemu_dm info di.domid
+						task ~xs ~dmpath:qemu_dm info di.domid
 				| Vm.PV _ ->
 					Device.Vfb.add ~xc ~xs di.domid;
 					Device.Vkbd.add ~xc ~xs di.domid;
-					Device.Dm.start_vnconly task ~xs ~dmpath:_qemu_dm info di.domid
+					Device.Dm.start_vnconly task ~xs ~dmpath:qemu_dm info di.domid
 		) (create_device_model_config vbds vifs vmextra);
 		match vm.Vm.ty with
 			| Vm.PV { vncterm = true; vncterm_ip = ip } -> Device.PV_Vnc.start ~xs ?ip di.domid
@@ -1177,7 +1204,7 @@ module VM = struct
 
 				with_data ~xc ~xs task data true
 					(fun fd ->
-						Domain.suspend task ~xc ~xs ~hvm ~progress_callback ~qemu_domid domid fd flags'
+						Domain.suspend task ~xc ~xs ~hvm ~progress_callback ~qemu_domid (choose_xenguest vm.Vm.platformdata) domid fd flags'
 							(fun () ->
 								if not(request_shutdown task vm Suspend 30.)
 								then raise (Failed_to_acknowledge_shutdown_request);
@@ -1240,7 +1267,7 @@ module VM = struct
 					try
 						with_data ~xc ~xs task data false
 							(fun fd ->
-								Domain.restore task ~xc ~xs (* XXX progress_callback *) build_info timeoffset domid fd
+								Domain.restore task ~xc ~xs (* XXX progress_callback *) build_info timeoffset (choose_xenguest vm.Vm.platformdata) domid fd
 							);
 					with e ->
 						error "VM %s: restore failed: %s" vm.Vm.id (Printexc.to_string e);


### PR DESCRIPTION
... (aka xenguest)

To use an alternative device model, first put a new executable in

  /opt/xensource/alternatives/device-model/name

and then set VM.platform:device-model=name

To use an alternative xenguest, first put a new executable in

  /opt/xensource/alternatives/xenguest/name

and then set VM.platform:xenguest=name

Signed-off-by: David Scott dave.scott@eu.citrix.com
