### PR TITLE
Add a new host parameter: guest_VCPUs_params.

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -1129,6 +1129,10 @@ let host_record rpc session_id host =
 				~get_set:(fun () -> (x ()).API.host_tags)
 				~add_to_set:(fun tag -> Client.Host.add_tags rpc session_id host tag)
 				~remove_from_set:(fun tag -> Client.Host.remove_tags rpc session_id host tag) ();
+			make_field ~name:"guest_VCPUs_params" ~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.host_guest_VCPUs_params) 
+				~get_map:(fun () -> (x ()).API.host_guest_VCPUs_params) 
+				~add_to_map:(fun k v -> Client.Host.add_to_guest_VCPUs_params rpc session_id host k v)
+				~remove_from_map:(fun k -> Client.Host.remove_from_guest_VCPUs_params rpc session_id host k) ();
 		]}
 
 let vdi_record rpc session_id vdi =

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4218,6 +4218,7 @@ let host =
 		"chipset_info" "Information about chipset features";
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pci)) "PCIs" "List of PCI devices in the host";
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pgpu)) "PGPUs" "List of physical GPUs in the host";
+	field ~qualifier:RW ~in_product_since:rel_tampa ~default_value:(Some (VMap [])) ~ty:(Map (String, String)) "guest_VCPUs_params" "VCPUs params to apply to all resident guests";
  ])
 	()
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -609,6 +609,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
 	~power_on_mode:""
 	~power_on_config:[]
 	~local_cache_sr
+	~guest_VCPUs_params:[]
   ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.of_float (Unix.gettimeofday ()));

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -360,6 +360,21 @@ module MD = struct
 						(fun x -> List.map int_of_string (String.split ',' x))
 						(String.split ';' (List.assoc "mask" vm.API.vM_VCPUs_params))
 				with _ -> [] in
+			let localhost = Helpers.get_localhost ~__context in
+			let host_guest_VCPUs_params = Db.Host.get_guest_VCPUs_params ~__context ~self:localhost in
+			let host_cpu_mask =
+				try 
+					List.map int_of_string (String.split ',' (List.assoc "mask" host_guest_VCPUs_params))
+				with _ -> [] in
+			let affinity = 
+				match affinity,host_cpu_mask with 
+					| [],[] -> []
+					| [],h -> [h]
+					| v,[] -> v
+					| affinity,mask -> 
+						List.map
+							(fun vcpu_affinity ->
+								List.filter (fun x -> List.mem x mask) vcpu_affinity) affinity in
 			let priority =
 				try
 					let weight = List.assoc "weight" vm.API.vM_VCPUs_params in


### PR DESCRIPTION
It has a similar function to that defined on guests, but it is per
host. It is also limited only to be used for defining masks, and
not on a per-vcpu basis (i.e., it defines which pcpus are available
for use by a VM at all). The VM and host masks are effectively
anded together to get the final mask.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
