### PR TITLE
CA-94406: VDI reset only on epoch begin (merge request is CA-94998)

### DIFF
--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -210,6 +210,18 @@ let vdi_compose dconf driver sr vdi1 vdi2 =
 	let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi2 dconf "vdi_compose" [ Ref.string_of vdi1] in
 	Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
 
+let vdi_epoch_begin dconf driver sr vdi =
+	debug "vdi_epoch_begin" driver (sprintf "sr=%s vdi=%s"
+		(Ref.string_of sr) (Ref.string_of vdi));
+	let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_epoch_begin" [] in
+	Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+
+let vdi_epoch_end dconf driver sr vdi =
+	debug "vdi_epoch_end" driver (sprintf "sr=%s vdi=%s"
+		(Ref.string_of sr) (Ref.string_of vdi));
+	let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_epoch_end" [] in
+	Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+
 let session_has_internal_sr_access ~__context ~sr = 
   let session_id = Context.get_session_id __context in
   (* XXX: need to move this somewhere else eventually *)

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -240,7 +240,14 @@ module SMAPIv1 = struct
 		let vdi_read_write = Hashtbl.create 10
 		let vdi_read_write_m = Mutex.create ()
 
-		let epoch_begin context ~dbg ~sr ~vdi = ()
+		let epoch_begin context ~dbg ~sr ~vdi =
+			try
+				for_vdi ~dbg ~sr ~vdi "VDI.epoch_begin"
+					(fun device_config _type sr self ->
+						Sm.vdi_epoch_begin device_config _type sr self)
+			with
+				| Api_errors.Server_error(code, params) ->
+						raise (Backend_error(code, params))
 
 		let attach context ~dbg ~dp ~sr ~vdi ~read_write =
 			try
@@ -307,7 +314,14 @@ module SMAPIv1 = struct
 			with Api_errors.Server_error(code, params) ->
 				raise (Backend_error(code, params))
 
-		let epoch_end context ~dbg ~sr ~vdi = ()
+		let epoch_end context ~dbg ~sr ~vdi =
+			try
+				for_vdi ~dbg ~sr ~vdi "VDI.epoch_end"
+					(fun device_config _type sr self ->
+						Sm.vdi_epoch_end device_config _type sr self)
+			with
+				| Api_errors.Server_error(code, params) ->
+						raise (Backend_error(code, params))
 
         let require_uuid vdi_info =
             match vdi_info.Smint.vdi_info_uuid with

--- a/ocaml/xenops/xenops_server.ml
+++ b/ocaml/xenops/xenops_server.ml
@@ -742,9 +742,10 @@ let rec atomics_of_operation = function
 			VM_build id;
 		] @ (List.map (fun vbd -> VBD_set_active (vbd.Vbd.id, true))
 			(VBD_DB.vbds id)
-		) @	(List.concat (List.map (fun vbd -> Opt.default [] (Opt.map (fun x -> [ VBD_epoch_begin (vbd.Vbd.id, x) ]) vbd.Vbd.backend))
-			(VBD_DB.vbds id)
-		)) @ (List.map (fun vbd -> VBD_plug vbd.Vbd.id)
+		) @	(List.concat (List.map (fun vbd -> Opt.default [] (Opt.map
+			(fun x -> [ VBD_epoch_begin (vbd.Vbd.id, x) ]) vbd.Vbd.backend))
+			(VBD_DB.vbds id |> vbd_plug_order))
+		) @ (List.map (fun vbd -> VBD_plug vbd.Vbd.id)
 			(VBD_DB.vbds id |> vbd_plug_order)
 		) @ (List.map (fun vif -> VIF_set_active (vif.Vif.id, true))
 			(VIF_DB.vifs id)
@@ -773,6 +774,9 @@ let rec atomics_of_operation = function
 			VM_destroy_device_model id;
 		] @ (List.map (fun vbd -> VBD_unplug (vbd.Vbd.id, true))
 			(VBD_DB.vbds id |> vbd_unplug_order)
+		) @	(List.concat (List.map (fun vbd -> Opt.default [] (Opt.map
+			(fun x -> [ VBD_epoch_end (vbd.Vbd.id, x) ]) vbd.Vbd.backend))
+			(VBD_DB.vbds id |> vbd_unplug_order))
 		) @ (List.map (fun vif -> VIF_unplug (vif.Vif.id, true))
 			(VIF_DB.vifs id)
 		) @ (List.map (fun pci -> PCI_unplug pci.Pci.id)


### PR DESCRIPTION
This resolves a bug where VDIs were reset after migration, because the act of
plugging a VBD will reset the VDI. A corresponding change in the storage
managers moves the reset_leaf call (which resets VDIs) to the SR command
"vdi_epoch_begin", which was recently added to Xapi's SMAPIv2.

This commit just adds the plumbing necessary to call epoch_begin and epoch_end
on VDIs in the storage layer. The corresponding commit in sm.hg adds those
commands to the storage layer, and also moves the reset_leaf call into
vdi_epoch_begin.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
