### PR TITLE
CA-94159: Restarting XAPI creates a new RFB console record for Dom0

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -125,19 +125,22 @@ and ensure_domain_zero_record ~__context (host_info: host_info): [`VM] Ref.t =
 	domain_zero_ref
 
 and ensure_domain_zero_console_record ~__context ~domain_zero_ref : unit =
-	match Db.VM.get_consoles ~__context ~self: domain_zero_ref with
-		| [] ->
-			(* if there are no consoles then make one *)
-			create_domain_zero_console_record ~__context ~domain_zero_ref
-		| [console_ref] ->
-			(* if there's a single reference but it's invalid, make a new one: *)
-			if not (Db.is_valid_ref __context console_ref) then
-				create_domain_zero_console_record ~__context ~domain_zero_ref
-		| _ ->
-			(* if there's more than one console then something strange is *)
-			(* going on; make a new one                                   *)
-			create_domain_zero_console_record ~__context ~domain_zero_ref
+	let dom0_consoles =  Db.VM.get_consoles ~__context ~self: domain_zero_ref in
+	let console_records_rfb = List.filter (fun x -> Db.Console.get_protocol ~__context ~self:x <> `vt100) dom0_consoles in 
+	let console_records_vt100 = List.filter (fun x -> Db.Console.get_protocol ~__context ~self:x <> `rfb) dom0_consoles in
 
+match List.length console_records_rfb, List.length console_records_vt100 with
+		| 0, 0 ->
+			(* if there are no consoles then make one *)
+			debug "No console records found, creating new console records";
+			create_domain_zero_console_record ~__context ~domain_zero_ref ~console_records_rfb ~console_records_vt100;
+		| 1, 1 ->
+      debug "Two different consoles found";
+		| _ ->
+			(* if there are more than two consoles then something strange is going on*)
+			debug "Multiple console records found";
+			create_domain_zero_console_record ~__context ~domain_zero_ref ~console_records_rfb ~console_records_vt100;
+                                                                                                               
 and ensure_domain_zero_guest_metrics_record ~__context ~domain_zero_ref (host_info: host_info) : unit =
 	if not (Db.is_valid_ref __context (Db.VM.get_metrics ~__context ~self:domain_zero_ref)) then
 	begin
@@ -198,30 +201,47 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info: host_info)
 	;
 	Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref
 
-and create_domain_zero_console_record ~__context ~domain_zero_ref : unit =
-	debug "Domain 0 record does not have associated console record. Creating now";
-	(* first delete any old dom0 console records that may be kicking around: *)
-	let this_dom0s_consoles = Db.Console.get_refs_where ~__context ~expr: (Eq(Field "_ref", Literal (Ref.string_of domain_zero_ref))) in
-	List.iter (fun console -> debug "Deleted old dom0 console record"; Db.Console.destroy ~__context ~self: console) this_dom0s_consoles;
-	(* now make a new console record for dom0 *)
+and create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref ~console_proto =
+	debug "Creating a new console record";
 	let console_ref = Ref.make () in
 	let address = Db.Host.get_address ~__context ~self: (Helpers.get_localhost ~__context) in
 	let location = Printf.sprintf "https://%s%s?ref=%s" address Constants.console_uri (Ref.string_of domain_zero_ref) in
 	Db.Console.create ~__context ~ref: console_ref
-		~uuid: (Uuid.to_string (Uuid.make_uuid ()))
-		~protocol:`rfb
-		~location
-		~vM: domain_zero_ref
-		~other_config:[]
-		~port: (Int64.of_int Xapi_globs.host_console_vncport)
+				~uuid: (Uuid.to_string (Uuid.make_uuid ()))
+				~protocol: console_proto
+				~location
+				~vM: domain_zero_ref
+				~other_config:[]
+				~port: (Int64.of_int Xapi_globs.host_console_vncport)                         
 
+and create_domain_zero_console_record ~__context ~domain_zero_ref ~console_records_rfb ~console_records_vt100 =
+	debug "Creating new dom0 console records";
+
+  if List.length console_records_rfb = 0 then create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref ~console_proto: `rfb ;
+  if List.length console_records_vt100 = 0 then create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref ~console_proto: `vt100 ;
+	
+	if List.length console_records_rfb > 1 then
+		begin
+			debug "Destroy all RFB consoles";
+			List.iter (fun console -> Db.Console.destroy ~__context ~self: console ) console_records_rfb ;
+			debug "Create a new RFB console";
+	 	  create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref ~console_proto: `rfb ;
+		end;
+  if List.length console_records_vt100 > 1 then
+		begin
+			debug "Destroy all VT100 consoles";
+			List.iter (fun console -> Db.Console.destroy ~__context ~self: console ) console_records_vt100 ;
+			debug "Creating new VT100 console record";
+			create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref ~console_proto: `vt100 ;
+		end
+                                                      
 and create_domain_zero_guest_metrics_record ~__context ~domain_zero_metrics_ref ~memory_constraints ~vcpus : unit =
 	let rec mkints = function
 		| 0 -> []
 		| n -> (mkints (n - 1) @ [n]) in
 	Db.VM_metrics.create ~__context ~ref: domain_zero_metrics_ref ~uuid: (Uuid.to_string (Uuid.make_uuid ()))
 		~memory_actual: memory_constraints.target
-		~vCPUs_utilisation: (List.map (fun x -> Int64.of_int x, 0.) (mkints vcpus))
+	  ~vCPUs_utilisation: (List.map (fun x -> Int64.of_int x, 0.) (mkints vcpus))
 		~vCPUs_number: (Int64.of_int vcpus)
 		~vCPUs_CPU:[]
 		~vCPUs_params:[]


### PR DESCRIPTION
Issue-
Restarting XAPI creates a new RFB console record for Dom0

Solution-
Check for two valid dom0 console objects(one each of VT100 and RFB)
In the case of multiple rfb dom0 consoles, destroy all dom0 rfb consoles and create a new dom0 rfb console
