### PR TITLE
CLEARWATER: CA-89023: Fix PV tools OS type detection.

### DIFF
--- a/ocaml/xapi/xapi_pv_driver_version.ml
+++ b/ocaml/xapi/xapi_pv_driver_version.ml
@@ -19,7 +19,7 @@ open Printf
 module D=Debug.Debugger(struct let name="xapi" end)
 open D
 
-(* A comparision function suitable for passing to List.sort and Array.sort.
+(* A comparison function suitable for passing to List.sort and Array.sort.
    Sorts into oldest first *)
 let compare_vsn =
 	List.fold_left2 (fun r x y -> if r <> 0 then r else compare x y) 0


### PR DESCRIPTION
Using the /drivers/xenvbd xenstore key to flag that a guest is Windows
is problematic, since:
1. This key goes away after suspend/resume or migrate, so cannot be relied upon to mark PV tools as out of date after a rolling pool upgrade.
2. This key isn't written at all by the Tampa PV drivers.

Instead, we now check that /data/os_distro equals "windows" - this value is
hardcoded in the windows guest agent.
