### PR TITLE
CA-96211: Fix return value of system.isAlive.

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -307,7 +307,7 @@ let gen_module api : O.Module.t =
 			" ])";
 			"| func -> ";
 			"  if (try Scanf.sscanf func \"system.isAlive:%s\" (fun _ -> true) with _ -> false)";
-			"  then Rpc.success (Rpc.Bool true)";
+			"  then Rpc.success (List.hd __params)";
 			"  else begin";
 			"    if (try Scanf.sscanf func \"unknown-message-%s\" (fun _ -> false) with _ -> true)";
 			"    then " ^ (debug "Unknown rpc \"%s\"" [ "__call" ]);


### PR DESCRIPTION
This was causing pooling not to work, as all connections failed
the 'is_reusable' test in xen-api-libs/http_svr/xmlrpc_client.ml (!)

Resolves: CA-96211
Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
