### PR TITLE
CA-97023: Preserve VM settings (Optimized for Citrix XenApp)

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1047,7 +1047,8 @@ let update_vm ~__context id =
 							Opt.iter
 								(fun (_, state) ->
 									debug "xenopsd event: Updating VM %s shadow_multiplier <- %.2f" id state.shadow_multiplier_target;
-									Db.VM.set_HVM_shadow_multiplier ~__context ~self ~value:state.shadow_multiplier_target
+									if state.power_state <> Halted then
+										Db.VM.set_HVM_shadow_multiplier ~__context ~self ~value:state.shadow_multiplier_target
 								) info
 						with e ->
 							error "Caught %s: while updating VM %s HVM_shadow_multiplier" (Printexc.to_string e) id


### PR DESCRIPTION
When a VM is optimized for Citrix XenApp, the field HVM_shadow_multiplier = 4.

When this VM is shutdown, the field HVM_shadow_multiplier is reverted back to its default value which it obtains from the hatled_vm record. 

This patch prevents the xapi DB from updating the field HVM_shadow_multiplier on shutdown. 
