### PR TITLE
CA-86513 : Hide the  'include-snapshots' parameter for the xe vm-export 

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1293,7 +1293,7 @@ there are two or more empty CD devices, please use the command 'vbd-insert' and 
    "vm-export",
     {
       reqd=["filename"];
-      optn=["preserve-power-state"; "compress"; "include-snapshots"];
+      optn=["preserve-power-state"; "compress"];
       help="Export a VM to <filename>.";
       implementation=With_fd Cli_operations.vm_export;
       flags=[Standard; Vm_selectors];


### PR DESCRIPTION
CA-86513 : Remove the 'include-snapshots' parameter for the xe vm-export command in the command line.
