### PR TITLE
CP-2190 for PR-1221: host alerts for memory-use and sr-throughput

### DIFF
--- a/scripts/perfmon
+++ b/scripts/perfmon
@@ -654,7 +654,7 @@ class HOSTMonitor(ObjectMonitor):
        * alarm_auto_inhibit_period: num seconds this alarm disabled after an alarm is sent (default '3600')
        * consolidation_fn: how to combine variables from rrd_updates into one value
          (default is 'average' for 'cpu_usage' & 'sum' for everything else)
-       * rrd_regex matches the names of variables from (xe host-data-sources-list uuid=$hostuuid) used to compute value
+       * rrd_regex matches the names of variables from (xe host-data-source-list uuid=$hostuuid) used to compute value
          (only has defaults for "cpu_usage", "network_usage", "memory_total_kib" and "sr_io_throughput_total_xxxxxxxx")
     """
     def __init__(self, *args):


### PR DESCRIPTION
For now the per-sr throughput alert is configured with a name of the form `sr_io_throughput_total_[0-9a-f]{8}` where the hex at the end is the start of the SR uuid.

Alternatively we could have a simple name like `sr_io_throughput_total` and add a new sub-node to the config variable, something like
`<subsidiary_identifier value="8e41ab3f" />`
