### PR TITLE
xe console should not be hidden command

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1060,7 +1060,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
      optn=[];
      help="Attach to a particular console.";
      implementation=With_fd Cli_operations.console;
-     flags=[Hidden; Vm_selectors];
+     flags=[Vm_selectors];
    };
 
    "vm-query-services",


### PR DESCRIPTION
I think it's time to make the console command a non-hidden command. Thoughts?

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
