### PR TITLE
Fix the marshalling of the event.from API call

### DIFF
--- a/ocaml/idl/datamodel_values.ml
+++ b/ocaml/idl/datamodel_values.ml
@@ -54,6 +54,7 @@ let to_ocaml_string v =
 		| Rpc.Null -> "Rpc.Null"
 		| Rpc.String s -> sprintf "Rpc.String \"%s\"" s
 		| Rpc.Int i -> sprintf "Rpc.Int %LdL" i
+		| Rpc.Int32 i -> sprintf "Rpc.Int32 %ldl" i
 		| Rpc.Float f -> sprintf "Rpc.Float %f" f
 		| Rpc.Bool b -> sprintf "Rpc.Bool %b" b
 		| Rpc.Dict d -> sprintf "Rpc.Dict [%s]" (String.concat ";" (List.map (fun (n,v) -> sprintf "(\"%s\",%s)" n (aux v)) d))

--- a/ocaml/idl/ocaml_backend/event_types.ml
+++ b/ocaml/idl/ocaml_backend/event_types.ml
@@ -58,6 +58,19 @@ type event_from = {
 	token: token;
 } with rpc
 
+let rec rpc_of_event_from e =
+    Rpc.Dict
+		[ ("events",
+           (Rpc.Enum (List.map rpc_of_event e.events)));
+          ("valid_ref_counts",
+           (let dict =
+				List.map
+					(fun (key, count) ->
+						(key, (Rpc.Int32 count)))
+					e.valid_ref_counts
+			in Rpc.Dict dict));
+          ("token", (rpc_of_token e.token)) ]
+
 (** Return result of an events.from call *)
 
 open Printf

--- a/ocaml/xenops-cli/xn.ml
+++ b/ocaml/xenops-cli/xn.ml
@@ -428,6 +428,7 @@ let pp x =
 		aux "" xs in
 	let rec to_t = function
 		| Int x -> [ Line (Printf.sprintf "%Ld" x) ]
+		| Int32 x -> [ Line (Printf.sprintf "%ld" x) ]
 		| Bool x -> [ Line (Printf.sprintf "%b" x) ]
 		| Float x -> [ Line (Printf.sprintf "%g" x) ]
 		| String x -> [ Line x ]


### PR DESCRIPTION
This used to marshal valid_ref_counts with i4 tagged xml, unlike
any other use of XMLRPC in xapi (more or less). This got changed
with the rpc-light switch, and this commit changes it back for
backwards compatibility.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
