### PR TITLE
CA-98393/SCTX-1190: Prevent xal exception if console/vnc-port is missing.

### DIFF
--- a/ocaml/xenops/xal.ml
+++ b/ocaml/xenops/xal.ml
@@ -470,8 +470,11 @@ let other_watch xs w v =
 		let xsds = read_state w in
 		Some (int_of_string domid, Frontend xsds, ty, devid)
 	| "" :: "local" :: "domain" :: domid :: "console" :: [ "vnc-port" ] ->
-		let port = int_of_string (xs.Xs.read w) in
-		Some (int_of_string domid, ConsolePort(VNC, port), "", "")
+		begin try
+			let port = int_of_string (xs.Xs.read w) in
+			Some (int_of_string domid, ConsolePort(VNC, port), "", "")
+		with _ -> None
+		end
 	| "" :: "local" :: "domain" :: domid :: "console" :: [ "tc-port" ] ->
 		let port = int_of_string (xs.Xs.read w) in
 		Some (int_of_string domid, ConsolePort(Text, port), "", "")


### PR DESCRIPTION
BOSTON-LCM.

Which can happen if disable_pv_vnc=true is specified in other-config.
This commit fixes the problem related to CA-90566.

Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
