### PR TITLE
XOP-261: Revert.

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -323,7 +323,7 @@ let bring_up_management_if ~__context () =
 			(Xapi_inventory.lookup Xapi_inventory._management_address_type) in
 		if management_if = "" then begin
 			debug "No management interface defined (management is disabled)";
-			Xapi_mgmt_iface.start_localhost_interface ~__context
+			Xapi_mgmt_iface.start_localhost_interface ~__context ()
 		end else begin
 			Xapi_mgmt_iface.run ~__context management_if management_address_type;
 			match Helpers.get_management_ip_addr ~__context with

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -798,7 +798,7 @@ let management_disable ~__context =
 
   Xapi_mgmt_iface.shutdown ();
   Xapi_mgmt_iface.maybe_start_himn ~__context ();
-  Xapi_mgmt_iface.start_localhost_interface ~__context;
+  Xapi_mgmt_iface.start_localhost_interface ~__context ();
 
   (* Make sure all my PIFs are marked appropriately *)
   Xapi_pif.update_management_flags ~__context ~host:(Helpers.get_localhost ~__context)

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -25,8 +25,7 @@ let himn_addr = ref None
 (* Stores a key into the table in Http_srv which identifies the server thread bound
 	 to the management IP. *)
 let management_interface_server = ref []
-let specific_addresses_only = ref false
-let localhost_server_started = ref false
+let himn_only = ref false
 let management_m = Mutex.create ()
 
 let update_mh_info_script = Filename.concat Fhs.libexecdir "update-mh-info"
@@ -43,9 +42,7 @@ let restart_stunnel () =
 let stop () =
 	debug "Shutting down the old management interface (if any)";
 	List.iter (fun i -> Http_svr.stop i) !management_interface_server;	
-	management_interface_server := [];
-	localhost_server_started := false;
-	himn_addr := None
+	management_interface_server := []
 
 (* Even though xapi listens on all IP addresses, there is still an interface appointed as
  * _the_ management interface. Slaves in a pool use the IP address of this interface to connect
@@ -56,7 +53,6 @@ let start ~__context ?addr () =
 		match addr with
 			| None ->
 					begin
-						specific_addresses_only := false;
 						try (* Is it IPv6 ? *)
 							let addr = Unix.inet6_addr_any in
 							addr, Xapi_http.bind (Unix.ADDR_INET(addr, Xapi_globs.http_port))
@@ -66,7 +62,7 @@ let start ~__context ?addr () =
 					end
 			| Some ip ->
 					debug "Starting new server (listening on HIMN only: %s)" ip;
-					specific_addresses_only := true;
+					himn_only := true;
 					let addr = Unix.inet_addr_of_string ip in
 					addr, Xapi_http.bind (Unix.ADDR_INET(addr, Xapi_globs.http_port))
 	in
@@ -94,10 +90,18 @@ let change interface primary_address_type =
 let run ~__context interface primary_address_type =
 	Mutex.execute management_m (fun () ->
 		change interface primary_address_type;
-		if !specific_addresses_only then
-			stop ();
+		stop ();
 		if !management_interface_server = [] then
 			start ~__context ()
+	)
+
+let rebind ~__context =
+	Mutex.execute management_m (fun () ->
+		if !management_interface_server <> [] then
+		begin
+			stop ();
+			start ~__context ();
+		end;
 	)
 
 let shutdown () =
@@ -110,20 +114,15 @@ let shutdown () =
 
 let maybe_start_himn ~__context ?addr () =
 	Mutex.execute management_m (fun () ->
-		match !himn_addr with
-		| Some a -> warn "There is already a server started on HIMN address %s: new address %s !"
-			a (match addr with None -> "None" | Some b -> b)
-		| None -> Opt.iter (fun addr ->
-			himn_addr := Some addr;
-			start ~__context ~addr ()) addr
+		Opt.iter (fun addr -> himn_addr := Some addr) addr;
+		if !management_interface_server = [] then
+			Opt.iter (fun addr -> start ~__context ~addr ()) !himn_addr
 	)
 
 let start_localhost_interface ~__context =
-	if not (!localhost_server_started) then
-		Mutex.execute management_m (fun () ->
-			start ~__context ~addr:"127.0.0.1" ();
-			localhost_server_started := true
-		)
+	Mutex.execute management_m (fun () ->
+	  start ~__context ~addr:"127.0.0.1"
+	)
 
 let management_ip_mutex = Mutex.create ()
 let management_ip_cond = Condition.create ()

--- a/ocaml/xapi/xapi_mgmt_iface.mli
+++ b/ocaml/xapi/xapi_mgmt_iface.mli
@@ -29,6 +29,9 @@ val on_dom0_networking_change : __context:Context.t -> unit
  *  update the inventory file with the given interface (used for management traffic). *)
 val run : __context:Context.t -> string -> [< `IPv4 | `IPv6 ] -> unit
 
+(** Re-bind the management interface to respond to changes (e.g. adding IPv6 address) *)
+val rebind : __context:Context.t -> unit
+
 (** Stop the server thread listening on the management interface *)
 val shutdown : unit -> unit
 
@@ -36,5 +39,5 @@ val shutdown : unit -> unit
 val maybe_start_himn : __context:Context.t -> ?addr:string -> unit -> unit
 
 (** Start a server thread on 127.0.0.1 *)
-val start_localhost_interface : __context:Context.t -> unit
+val start_localhost_interface : __context:Context.t -> unit -> unit
 

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -550,6 +550,8 @@ let reconfigure_ipv6 ~__context ~self ~mode ~iPv6 ~gateway ~dNS =
 		raise (Api_errors.Server_error
 			(Api_errors.pif_is_management_iface, [ Ref.string_of self ]));
 
+	let old_mode = Db.PIF.get_ipv6_configuration_mode ~__context ~self in
+
 	(* Set the values in the DB *)
 	Db.PIF.set_ipv6_configuration_mode ~__context ~self ~value:mode;
 	Db.PIF.set_ipv6_gateway ~__context ~self ~value:gateway;
@@ -567,7 +569,12 @@ let reconfigure_ipv6 ~__context ~self ~mode ~iPv6 ~gateway ~dNS =
 			 * we are not getting a host-signal-networking-change callback. *)
 			Helpers.update_pif_address ~__context ~self
 	end;
-	Monitor_dbcalls.clear_cache_for_pif ~pif_name:(Db.PIF.get_device ~__context ~self)
+	Monitor_dbcalls.clear_cache_for_pif ~pif_name:(Db.PIF.get_device ~__context ~self);
+	if ((old_mode == `None && mode <> `None) || (old_mode <> `None && mode == `None)) then
+	begin
+		debug "IPv6 mode has changed - updating management interface";
+		Xapi_mgmt_iface.rebind ~__context;
+	end
 
 let reconfigure_ip ~__context ~self ~mode ~iP ~netmask ~gateway ~dNS =
 	assert_no_protection_enabled ~__context ~self;


### PR DESCRIPTION
XOP-261: Reinstate the server on 127.0.0.1 when no management
    interface is defined

```
XOP-261/CA-96936: Remove Xapi_mgmt_iface.rebind
Since the management interface is listening in IPv6 automatically if
available.

XAPI-261/CA-96936: Make himn_only more general
To also manage the case of a localhost server.

XOP-261/CA-96936: Prevent multiple starts of localhost server

XOP-261/CA-96936: Issue a warning in case of multiple starts of HIMN server
```

Reverted since it broke TC-16120.

Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
