### PR TITLE
CA-95645: fix Python 2.6 type error comparing DateTime

### DIFF
--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -72,7 +72,8 @@ class Failure(Exception):
                      for i in range(len(self.details))])
 
 
-_RECONNECT_AND_RETRY = (lambda _ : ())
+# Just a "constant" that we use to decide whether to retry the RPC
+_RECONNECT_AND_RETRY = object()
 
 class UDSHTTPConnection(httplib.HTTPConnection):
     """HTTPConnection subclass to allow HTTP over Unix domain sockets. """
@@ -136,7 +137,7 @@ class Session(xmlrpclib.ServerProxy):
             while retry_count < 3:
                 full_params = (self._session,) + params
                 result = _parse_result(getattr(self, methodname)(*full_params))
-                if result == _RECONNECT_AND_RETRY:
+                if result is _RECONNECT_AND_RETRY:
                     retry_count += 1
                     if self.last_login_method:
                         self._login(self.last_login_method,
@@ -151,7 +152,7 @@ class Session(xmlrpclib.ServerProxy):
 
     def _login(self, method, params):
         result = _parse_result(getattr(self, 'session.%s' % method)(*params))
-        if result == _RECONNECT_AND_RETRY:
+        if result is _RECONNECT_AND_RETRY:
             raise xmlrpclib.Fault(
                 500, 'Received SESSION_INVALID when logging in')
         self._session = result


### PR DESCRIPTION
We compare the result of an rpc call with a constant called
_RECONNECT_AND_RETRY (which was just set to an anonymous function) to decide if
we need to retry the rpc call. When the result is a DateTime object, and we're
using python 2.6+, this comparison (using ==) throws an exception.

The fix is to use the 'is' operator instead of '==', so that we're testing
object equality, and not structural equality. We also set the
_RECONNECT_AND_RETRY constant to object(), which is more sensible than (lambda
_ : ()).

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
