### PR TITLE
CA-98753: Correct ha_restart_priority for VMs imported on post-6.0.0

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -346,6 +346,11 @@ module VM : HandlerTools = struct
 			in
 			(* Clear the appliance field - in the case of DR we will reconstruct the appliance separately. *)
 			let vm_record = {vm_record with API.vM_appliance = Ref.null} in
+			(* Correct ha-restart-priority for pre boston imports*)
+			let vm_record = match vm_record.API.vM_ha_restart_priority with
+					"0"|"1"|"2"|"3" as order -> { vm_record with API.vM_ha_restart_priority = "restart"; API.vM_order = Int64.of_string (order) }
+					| _ -> vm_record;
+			in
 
 			let vm = log_reraise
 				("failed to create VM with name-label " ^ vm_record.API.vM_name_label)


### PR DESCRIPTION
When VMs were exported from pre-6.0.0 hosts, they could have ha_restart_priority set to 0,1,2,3 . When these VMs are imported on post-6.0.0 hosts and HA is enabled, they error out. 

This patch aims to correct this field during import hence preventing any error while HA is enabled. 
