### PR TITLE
CA-100000: Don't use lexicographic sort when sorting events

### DIFF
--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -155,7 +155,7 @@ let event_add ?snapshot ty op reference  =
 		let to_keep, to_drop = if too_many <= 0 then !queue, []
 		  else
 		    (* Reverse-sort by ID and preserve the first 'max_stored_events' *)
-		    List.chop max_stored_events (List.sort (fun a b -> compare b.id a.id) !queue) in
+		    List.chop max_stored_events (List.sort (fun a b -> compare (Int64.of_string b.id) (Int64.of_string a.id)) !queue) in
 		queue := to_keep;
 		(* Remember the highest ID of the list of events to drop *)
 		if to_drop <> [] then


### PR DESCRIPTION
Bug introduced during rpc-light integration. The type of 'id' was
changed from an int to a string, and the type checker used to fix
the code. Unfortunately there was a sort function using the
polymorphic 'compare' function. The compare thus changed from an
integer comparison to a lexicographic compare on the string
representation of the integer. The observable result in this case
was that e.g. event '1000' was 'older' than event '999' and was
GCd. Elsewhere, the correct integer comparison was being made and
this caused the event.next to raise 'EVENTS_LOST'.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
