### PR TITLE
CA-74222:All the Bond.create to carry on without failing when created with an unsupported MTU value, however log the error

### DIFF
--- a/ocaml/network/network_utils.ml
+++ b/ocaml/network/network_utils.ml
@@ -181,7 +181,10 @@ module Ip = struct
 		ignore (call ~log:true ("link" :: "set" :: dev :: args))
 
 	let link_set_mtu dev mtu =
+	 try
 		ignore (link_set dev ["mtu"; string_of_int mtu])
+   with exn -> error "MTU size is not supported %s" (string_of_int mtu);
+							 ()
 
 	let link_set_up dev =
 		ignore (link_set dev ["up"])


### PR DESCRIPTION
All the Bond.create to carry on and create a bond object and ignore the exception raised for an unsupported MTU value. However log the error in the xensource.log
