### PR TITLE
CA-89978: Fix restoration of database from temporary restore file.

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -67,6 +67,9 @@ let populate_db backend =
 		then [ Parse_db_conf.make Xapi_globs.db_temporary_restore_path ]
 		else output_connections
 	in
+	debug "Attempting to populate database from one of these locations: [%s]"
+		(String.concat "; "
+			(List.map (fun conn -> conn.Parse_db_conf.path) input_connections));
 	Db_cache_impl.make backend input_connections schema;
 	Db_cache_impl.sync output_connections (Db_ref.get_database backend);
 	(* Delete the temporary restore file so that we don't revert to it again at next startup. *)


### PR DESCRIPTION
- Delete the temporary restore file after using it to populate the
  database - if we don't do this then xapi will use the restore file
  again the next time it starts up.
- Perform the initial database flush to the global list of database
  connections in all cases; don't flush to the restore database file
  if it's being used.
