### PR TITLE
CA-100704: Fix xenguest

### DIFF
--- a/ocaml/xenguest/xenguest_main.ml
+++ b/ocaml/xenguest/xenguest_main.ml
@@ -42,7 +42,7 @@ let close_all_fds_except (fds: Unix.file_descr list) =
 (* Code to log internal debug messages ***************************************)
 let debug_fd = ref None
 let openlog filename =
-  debug_fd := Some (Unix.openfile filename [ Unix.O_CREAT; Unix.O_APPEND ] 0o644)
+  debug_fd := Some (Unix.openfile filename [ Unix.O_CREAT; Unix.O_APPEND; Unix.O_RDWR ] 0o644)
 let log_writer prefix (x: string) = match !debug_fd with
   | Some fd ->
       let x = prefix ^ x ^ "\n" in


### PR DESCRIPTION
From http://ocamlunix.forge.ocamlcore.org/ocamlunix.html

The flag list must contain exactly one of the following flags:
O_RDONLY    Open in read-only mode.
O_WRONLY    Open in write-only mode.
O_RDWR      Open in read and write mode.

So I've added exactly one of those flags!

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
