### PR TITLE
CA-95053: VM.start must check if a host has enough memory.

### DIFF
--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -581,7 +581,7 @@ let vm_can_run_on_host __context vm snapshot host =
 		let host_metrics = Db.Host.get_metrics ~__context ~self:host in
 		Db.Host_metrics.get_live ~__context ~self:host_metrics in
 	let host_can_run_vm () =
-		assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_memory_check:false ();
+		assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_memory_check:true ();
 		true in
 	try host_has_proper_version () && host_enabled () && host_live () && host_can_run_vm ()
 	with _ -> false


### PR DESCRIPTION
Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
