### PR TITLE
CA-46110 Tab completion on xe-switch-network-backend

### DIFF
--- a/scripts/OMakefile
+++ b/scripts/OMakefile
@@ -125,6 +125,9 @@ install:
 	mkdir -p $(DESTDIR)$(HOOKSDIR)/host-post-declare-dead
 	$(IPROG) 10resetvdis $(DESTDIR)$(HOOKSDIR)/host-post-declare-dead
 	$(IPROG) pci-info $(DESTDIR)$(LIBEXECDIR)
+	mkdir -p $(DESTDIR)/etc/bash_completion.d
+	$(IPROG) xe-switch-network-backend-bash-completion $(DESTDIR)/etc/bash_completion.d/xe-switch-network-backend
+	$(IPROG) xe-switch-network-backend $(DESTDIR)$(BINDIR)
 
 sdk-install: install
 	mkdir -p $(SDK)

--- a/scripts/xe-switch-network-backend
+++ b/scripts/xe-switch-network-backend
@@ -1,0 +1,72 @@
+#!/bin/sh
+#########################################################################
+# Script to switch between Linux Bridge network stack and OpenvSwitch
+# 
+# Usage:
+#   xe-switch-network-backend  <option>
+#
+# where <option> is either:
+#   bridge      - Linux standard Bridge network stack
+#   openvswitch - OpenvSwitch stack
+#
+#########################################################################
+
+set -e
+
+if [ $# -ne 1 ] ; then
+	echo "Need bridge or openvswitch..."
+	exit 1
+fi
+
+source /etc/xensource-inventory
+
+new=$1
+case $new in
+    bridge) ;;
+    vswitch|openvswitch) ;;
+    *)
+	echo "Mode must be \"bridge\" or \"vswitch\""
+	exit 1
+esac
+
+if [ X"$new" = Xvswitch ] ; then
+    new="openvswitch"
+fi
+
+curr=$(cat /etc/xensource/network.conf)
+if [ X"$curr" = Xvswitch ] ; then
+    new="openvswitch"
+fi
+
+
+echo "Cleaning up old ifcfg files"
+for i in /etc/sysconfig/network-scripts/ifcfg-* ; do
+	if [ "$i" = "/etc/sysconfig/network-scripts/ifcfg-lo" ] ; then
+		continue
+	fi
+	echo " Remove... $(basename $i)"
+	rm $i
+done
+
+
+BLACKLIST=/etc/modprobe.d/blacklist-bridge
+if [ "$new" = "openvswitch" ] ; then
+	# Add blacklist of bridge module so it can't be loaded.
+	echo "install bridge /bin/true" > $BLACKLIST
+elif [ -e $BLACKLIST ] ; then
+	# Remove blacklist of bridge.
+	rm $BLACKLIST
+fi
+
+if [ "$new" = "openvswitch" ] ; then
+	echo "Enabling openvswitch daemon"
+	chkconfig --add openvswitch
+else
+	echo "Disabling openvswitch daemon"
+	chkconfig --del openvswitch
+fi
+
+echo "Configure system for $new networking"
+echo $new > /etc/xensource/network.conf
+
+echo "You *MUST* now reboot your system" 1>&2

--- a/scripts/xe-switch-network-backend-bash-completion
+++ b/scripts/xe-switch-network-backend-bash-completion
@@ -1,0 +1,16 @@
+#xe-switch-network-backend tab completion
+
+_xe-switch-network-backend() 
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="bridge openvswitch"
+
+    if [[ ${cur} == * ]] ; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+}
+complete -F _xe-switch-network-backend xe-switch-network-backend

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -219,6 +219,8 @@ rm -rf $RPM_BUILD_ROOT
 @OPTDIR@/bin/xe-set-iscsi-iqn
 @OPTDIR@/bin/xe-toolstack-restart
 @OPTDIR@/bin/xe-xentrace
+@OPTDIR@/bin/xe-switch-network-backend
+/etc/bash_completion.d/xe-switch-network-backend
 @OPTDIR@/bin/xsh
 /etc/xensource/bugtool/xapi.xml
 /etc/xensource/bugtool/xapi/stuff.xml


### PR DESCRIPTION
Moved xe-switch-network-backend from dom0.hg/overlay.dom0/opt/xensource/bin/xe-switch-network-backend to xen-api/scripts/xe-switch-network-backend. Added xe-switch-network-backend tab completion (CA-46110) to xen-api/scripts/xe-switch-network-backend-bash-completion. Updated scripts/OMake & xapi.spec.in file to accommodate changes.
- The script will still need to be removed from the dom0.hg but the build did not break. *
