### PR TITLE
CA-93613: Balance_memory raises an exception if squeezed is stopped

### DIFF
--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -450,9 +450,9 @@ module Mem = struct
 		()
 
 	(** After an event which frees memory (eg a domain destruction), perform a one-off memory rebalance *)
-	let balance_memory dbg =
+	let balance_memory dbg = Opt.default () (wrap (fun () ->
 		debug "rebalance_memory";
-		Client.balance_memory dbg
+		Client.balance_memory dbg))
 
 end
 


### PR DESCRIPTION
Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
