### PR TITLE
CA-101788: increase xenconsoled default number of fds in xenservices fro...

### DIFF
--- a/scripts/init.d-xenservices
+++ b/scripts/init.d-xenservices
@@ -36,7 +36,10 @@ start() {
     [ -e /var/lib/xenstored/tdb ] && mv -f /var/lib/xenstored/tdb /var/lib/xenstored/tdb.bak
     "@BINDIR@/xenstored" ${XENSTORED_ARG}
 
+	OLD_ULIMIT_N=$(ulimit -n)
+	ulimit -n 4096
 	/usr/sbin/xenconsoled
+	ulimit -n $OLD_ULIMIT_N
 	[ -d /var/log/blktap ] || mkdir /var/log/blktap
 	
 	# Delete rubbish from xapi's private tree in xenstore, once per boot (not once per


### PR DESCRIPTION
...m 1024 to 4096

xenconsoled is currently started in xenservices using the default ulimit -n
value 1024. This aligns well with the limit of 1024 fds that the xenconsoled
select() can handle. Each vm console will tipically use 3 fds (4 if logging
is enabled), limiting the number of consoles in dom0 to a couple of hundred.

The new upstream xenconsoled uses poll() instead of select() and can handle

> 1024 fds, as long as its ulimit -n value is properly set up in xenservices.
> Increasing this value to 4096 will allow us to have 1000 vm consoles in dom0,
> which is more aligned to other values.

Signed-off-by: Marcus Granado marcus.granado@citrix.com
