### PR TITLE
CP-4273: add Hotfix_apply to keys_of_features map

### DIFF
--- a/ocaml/xapi/features.ml
+++ b/ocaml/xapi/features.ml
@@ -72,6 +72,7 @@ let keys_of_features =
 		DR, ("restrict_dr", Negative, "DR");
 		VIF_locking, ("restrict_vif_locking", Negative, "VIFLock");
 		Storage_motion, ("restrict_storage_xen_motion", Negative, "SXM");
+		Hotfix_apply, ("restrict_hotfix_apply", Negative, "HFX");
 	]
 
 let string_of_feature f =


### PR DESCRIPTION
This feature flag was missing from the feature-flat-to-string map, and so wasn't shown in the host-license-view.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
