### PR TITLE
TALLAHASSEE: CA-102855: Gateway PIF was not set properly when creating bond while management disabled

### DIFF
--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -36,7 +36,7 @@ let choose_bond_device_name ~__context ~host =
 		else name in
 	choose 0
 
-let copy_configuration ~__context from_pif to_pif =
+let move_configuration ~__context from_pif to_pif =
 	debug "Moving IP configuration from PIF %s to PIF %s" (Db.PIF.get_uuid ~__context ~self:from_pif)
 		(Db.PIF.get_uuid ~__context ~self:to_pif);
 	let mode =	Db.PIF.get_ip_configuration_mode ~__context ~self:from_pif in
@@ -48,7 +48,12 @@ let copy_configuration ~__context from_pif to_pif =
 	Db.PIF.set_IP ~__context ~self:to_pif ~value:ip;
 	Db.PIF.set_netmask ~__context ~self:to_pif ~value:netmask;
 	Db.PIF.set_gateway ~__context ~self:to_pif ~value:gateway;
-	Db.PIF.set_DNS ~__context ~self:to_pif ~value:dns
+	Db.PIF.set_DNS ~__context ~self:to_pif ~value:dns;
+	Db.PIF.set_ip_configuration_mode ~__context ~self:from_pif ~value:`None;
+	Db.PIF.set_IP ~__context ~self:from_pif ~value:"";
+	Db.PIF.set_netmask ~__context ~self:from_pif ~value:"";
+	Db.PIF.set_gateway ~__context ~self:from_pif ~value:"";
+	Db.PIF.set_DNS ~__context ~self:from_pif ~value:""
 
 (* Determine local VIFs: candidates for moving to the bond.
  * Local VIFs are those VIFs on the given networks that belong to VMs that
@@ -380,7 +385,7 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
 		List.iter (fun slave -> Db.PIF.set_bond_slave_of ~__context ~self:slave ~value:bond) members;
 
 		(* Copy the IP configuration of the primary member to the master *)
-		copy_configuration ~__context primary_slave master;
+		move_configuration ~__context primary_slave master;
 
 		begin match management_pif with
 		| Some management_pif ->
@@ -409,16 +414,15 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
 		List.iter (Xapi_vif.move ~__context ~network) local_vifs;
 		TaskHelper.set_progress ~__context 0.8;
 
-		(* Set disallow_unplug on the master, if one of the slaves had disallow_unplug = true (see above) *)
-		if disallow_unplug then
+		(* Set disallow_unplug on the master, if one of the slaves had disallow_unplug = true (see above),
+		 * and reset disallow_unplug of members. *)
+		if disallow_unplug then begin
+			debug "Setting disallow_unplug on master, and clearing slaves";
 			Db.PIF.set_disallow_unplug ~__context ~self:master ~value:true;
-
-		(* Reset IP configuration and disallow_unplug of members *)
-		debug "Resetting IP config and disallow_unplug on slaves";
-		List.iter (fun pif ->
-			Db.PIF.set_ip_configuration_mode ~__context ~self:pif ~value:`None;
-			Db.PIF.set_disallow_unplug ~__context ~self:pif ~value:false)
-			members;
+			List.iter (fun pif ->
+				Db.PIF.set_disallow_unplug ~__context ~self:pif ~value:false)
+				members
+		end;
 		TaskHelper.set_progress ~__context 1.0;
 	);
 	(* return a ref to the new Bond object *)
@@ -444,7 +448,7 @@ let destroy ~__context ~self =
 		then raise (Api_errors.Server_error(Api_errors.ha_cannot_change_bond_status_of_mgmt_iface, []));
 
 		(* Copy IP configuration from master to primary member *)
-		copy_configuration ~__context master primary_slave;
+		move_configuration ~__context master primary_slave;
 
 		if Db.PIF.get_management ~__context ~self:master = true then begin
 			(* The master is the management interface: move management to first slave *)
@@ -473,8 +477,10 @@ let destroy ~__context ~self =
 		List.iter (move_tunnel ~__context host primary_slave) local_tunnels;
 		TaskHelper.set_progress ~__context 0.8;
 
-		if Db.PIF.get_disallow_unplug ~__context ~self:master = true then
-			Db.PIF.set_disallow_unplug ~__context ~self:primary_slave ~value:true;
+		if Db.PIF.get_disallow_unplug ~__context ~self:master = true then begin
+			debug "Setting disallow_unplug on primary slave";
+			Db.PIF.set_disallow_unplug ~__context ~self:primary_slave ~value:true
+		end;
 
 		(* Destroy the Bond and master PIF *)
 		Db.Bond.destroy ~__context ~self;


### PR DESCRIPTION
This is fixed by ensuring that, during a bond create or destroy, when the IP config is
move from bond slave to master or vice versa, only one of the PIFs has IP config.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
