### PR TITLE
CP-4480: Remove check for PV drivers from migrate

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -136,8 +136,7 @@ let check_drivers ~__context ~vmr ~vmgmr ~op ~ref =
 	else None
 
 let need_pv_drivers_check ~__context ~vmr ~power_state ~op =
-	let op_list = [ `suspend; `checkpoint; `pool_migrate; `migrate_send
-	              ; `clean_shutdown; `clean_reboot; `changing_VCPUs_live ] in
+	let op_list = [ `clean_shutdown; `clean_reboot; `changing_VCPUs_live ] in
 	power_state = `Running
 	&& Helpers.has_booted_hvm_of_record ~__context vmr
 	&& List.mem op op_list


### PR DESCRIPTION
If the PV drivers haven't loaded, we shutdown the domain immediately.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
