### PR TITLE
CA-103748: Swap heartbeat and delay in heartbeat thread

### DIFF
--- a/ocaml/xapi/db_gc.ml
+++ b/ocaml/xapi/db_gc.ml
@@ -538,8 +538,8 @@ let start_heartbeat_thread() =
 						(fun rpc session_id ->
 							while(true) do
 								try
-									Thread.delay !Xapi_globs.host_heartbeat_interval;
-									send_one_heartbeat ~__context rpc session_id
+									send_one_heartbeat ~__context rpc session_id;
+									Thread.delay !Xapi_globs.host_heartbeat_interval
 								with
 								| (Api_errors.Server_error (x,y)) as e ->
 									if x=Api_errors.session_invalid


### PR DESCRIPTION
If a pool.hello takes over five minutes (which it can do if a lot of
slaves in a large pool are rebooted at once) the master's GC thread will
have declared the slave dead again by the time the pool.hello returns.

The heartbeat thread will signal to the master that the slave is in fact
still alive but only after waiting for the heartbeat delay (which by
default is 30 seconds long).

This means that there is a 30 second window where the startup sequence
is continuing but the slave is seen as dead on the master, and if the
slave tries to plug its PBDs in this window it will receive a
HOST_OFFLINE exception (i.e. the master is telling the slave that it
thinks the slave is offline).

This change means that the first heartbeat is sent _before_ the delay
period, closing this window to the time taken to make a few database
calls.
