### PR TITLE
CP-4460: Add some nonconvential WLB "API" back to datamodel

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -267,6 +267,25 @@ let pool_joining_host_must_have_physical_managment_nic = "POOL_JOINING_HOST_MUST
 let pool_joining_external_auth_mismatch = "POOL_JOINING_EXTERNAL_AUTH_MISMATCH"
 let pool_joining_host_must_have_same_product_version = "POOL_JOINING_HOST_MUST_HAVE_SAME_PRODUCT_VERSION"
 
+(* workload balancing, deprecated since Clearwater *)
+let wlb_not_initialized = "WLB_NOT_INITIALIZED"
+let wlb_disabled = "WLB_DISABLED"
+let wlb_connection_refused = "WLB_CONNECTION_REFUSED"
+let wlb_unknown_host = "WLB_UNKNOWN_HOST"
+let wlb_timeout = "WLB_TIMEOUT"
+let wlb_authentication_failed = "WLB_AUTHENTICATION_FAILED"
+let wlb_malformed_request = "WLB_MALFORMED_REQUEST"
+let wlb_malformed_response = "WLB_MALFORMED_RESPONSE"
+let wlb_xenserver_connection_refused = "WLB_XENSERVER_CONNECTION_REFUSED"
+let wlb_xenserver_unknown_host = "WLB_XENSERVER_UNKNOWN_HOST"
+let wlb_xenserver_timeout = "WLB_XENSERVER_TIMEOUT"
+let wlb_xenserver_authentication_failed = "WLB_XENSERVER_AUTHENTICATION_FAILED"
+let wlb_xenserver_malformed_response = "WLB_XENSERVER_MALFORMED_RESPONSE"
+let wlb_internal_error = "WLB_INTERNAL_ERROR"
+let wlb_url_invalid = "WLB_URL_INVALID"
+let wlb_connection_reset = "WLB_CONNECTION_RESET"
+
+
 let sr_not_shared = "SR_NOT_SHARED"
 
 let default_sr_not_found = "DEFAULT_SR_NOT_FOUND"

--- a/ocaml/idl/constants.ml
+++ b/ocaml/idl/constants.ml
@@ -55,6 +55,8 @@ let blob_uri = "/blob"                                (* ocaml/xapi/xapi_blob.ml
 let remotecmd_uri = "/remotecmd"                      (* ocaml/xapi/xapi_remotecmd.ml *)
 let message_rss_feed = "/rss"                         (* ocaml/xapi/xapi_message.ml *)
 let message_put_uri = "/messages"                     (* ocaml/xapi/xapi_message.ml *)
+let wlb_report_uri = "/wlb_report"                    (* deprecated since Clearwater *)
+let wlb_diagnostics_uri = "/wlb_diagnostics"          (* deprecated since Clearwater *)
 let audit_log_uri = "/audit_log"                      (* ocaml/xapi/audit.ml *)
 
 let use_compression = "use_compression"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -754,6 +754,41 @@ let _ =
   error Api_errors.rbac_permission_denied ["permission";"message"]
     ~doc: "RBAC permission denied." ();
 
+  (* wlb errors, deprecated since clearwater *)
+  error Api_errors.wlb_not_initialized []
+    ~doc:"No WLB connection is configured." ();
+  error Api_errors.wlb_disabled []
+    ~doc:"This pool has wlb-enabled set to false." ();
+  error Api_errors.wlb_connection_refused []
+    ~doc:"The WLB server refused a connection to XenServer." ();
+  error Api_errors.wlb_unknown_host []
+    ~doc:"The configured WLB server name failed to resolve in DNS." ();
+  error Api_errors.wlb_timeout ["configured_timeout"]
+    ~doc:"The communication with the WLB server timed out." ();
+  error Api_errors.wlb_authentication_failed []
+    ~doc:"The WLB server rejected our configured authentication details." ();
+  error Api_errors.wlb_malformed_request []
+    ~doc:"The WLB server rejected XenServer's request as malformed." ();
+  error Api_errors.wlb_malformed_response ["method"; "reason"; "response"]
+    ~doc:"The WLB server said something that XenServer wasn't expecting or didn't understand.  The method called on the WLB server, a diagnostic reason, and the response from WLB are returned." ();
+  error Api_errors.wlb_xenserver_connection_refused []
+    ~doc:"The WLB server reported that XenServer refused it a connection (even though we're connecting perfectly fine in the other direction)." ();
+  error Api_errors.wlb_xenserver_unknown_host []
+    ~doc:"The WLB server reported that its configured server name for this XenServer instance failed to resolve in DNS." ();
+  error Api_errors.wlb_xenserver_timeout []
+    ~doc:"The WLB server reported that communication with XenServer timed out." ();
+  error Api_errors.wlb_xenserver_authentication_failed []
+    ~doc:"The WLB server reported that XenServer rejected its configured authentication details." ();
+  error Api_errors.wlb_xenserver_malformed_response []
+    ~doc:"The WLB server reported that XenServer said something to it that WLB wasn't expecting or didn't understand." ();
+  error Api_errors.wlb_internal_error []
+    ~doc:"The WLB server reported an internal error." ();
+  error Api_errors.wlb_connection_reset []
+    ~doc:"The connection to the WLB server was reset." ();
+  error Api_errors.wlb_url_invalid ["url"]
+    ~doc:"The WLB URL is invalid. Ensure it is in format: <ipaddress>:<port>.  The configured/given URL is returned." ();
+
+
   (* Api_errors specific to running VMs on multiple hosts *)
   error Api_errors.vm_unsafe_boot ["vm"]
     ~doc:"You attempted an operation on a VM that was judged to be unsafe by the server. This can happen if the VM would run on a CPU that has a potentially incompatible set of feature flags to those the VM requires. If you want to override this warning then use the 'force' option." ();
@@ -7961,6 +7996,8 @@ let http_actions = [
   ("put_messages", (Put, Constants.message_put_uri, false, [], _R_VM_POWER_ADMIN, []));
   ("connect_remotecmd", (Connect, Constants.remotecmd_uri, false, [], _R_POOL_ADMIN, []));
   ("post_remote_stats", (Post, Constants.remote_stats_uri, false, [], _R_POOL_ADMIN, []));  (* deprecated *)
+  ("get_wlb_report", (Get, Constants.wlb_report_uri, true, [String_query_arg "report"; Varargs_query_arg], _R_READ_ONLY, [])); (* deprecated since Clearwater *)
+  ("get_wlb_diagnostics", (Get, Constants.wlb_diagnostics_uri, true, [], _R_READ_ONLY, [])); (* deprecated since Clearwater *)
   ("get_audit_log", (Get, Constants.audit_log_uri, true, [], _R_READ_ONLY, []));
 
   (* XMLRPC callback *)


### PR DESCRIPTION
There are not standard API messages, but web services and errors. They don't have a concept of API "lifecycle" like the standard ones, so we can't simply mark them as "deprecated" or "removed" and take advantage of the logic in our code autogeneration engine.

Instead of removing them, we have to keep the stubs around for the following reasons:
- SDK auto generates some binding parts out of them (as well)
- And, XenCenter will compile with a single version of API bindings and use it talk with different versions of XenServer (hence those binding stubs have to be a superset of all the historic versions we currently support).

Signed-off-by: Zheng Li zheng.li@eu.citrix.com
