### PR TITLE
CP-4277: Allow unsigned patches to be installable

### DIFF
--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -127,3 +127,6 @@ let storage_motion_keep_vdi () = fistpoint "storage_motion_keep_vdi"
 let allow_test_patches () = fistpoint "allow_test_patches"
 
 let delay_xenopsd_event_threads () = fistpoint "delay_xenopsd_event_threads"
+
+let allowed_unsigned_patches () = fistpoint_read "allowed_unsigned_patches"
+

--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -55,6 +55,23 @@ let oem_patch_keys = [
 	"NEJDMzFFN0Q3M0EwRjdBNzY3QzM3NEMyQTk3NjkwNTYzMERBQTkxNA=="; (* pub=30DAA914 public key *)
 ]
 
+let check_unsigned_patch_fist path =
+	match Xapi_fist.allowed_unsigned_patches () with
+	| None -> false
+	| Some fist ->
+		let sha1 =
+			Sha1sum.sha1sum (fun checksum_fd ->
+				let (_: int64) = Unixext.with_file path [ Unix.O_RDONLY ] 0 (fun fd ->
+					Unixext.copy_file fd checksum_fd
+				) in
+				()
+			)
+		in
+		debug "Patch Sha1sum: %s" sha1;
+		let fist_sha1s = String.split_f String.isspace fist in
+		debug "FIST allowed_unsigned_patches: %s" fist;
+		List.mem sha1 fist_sha1s
+
 let extract_patch path =
   let run_path = path ^ ".run" in
   try
@@ -86,9 +103,21 @@ let extract_patch path =
           )
       );
     run_path
-  with e -> 
-    Unixext.unlink_safe run_path;
-    raise e
+  with e ->
+    if check_unsigned_patch_fist path then begin
+      debug "Patch not signed, but still letting it through";
+      Unixext.with_file run_path [ Unix.O_WRONLY; Unix.O_CREAT ] 0o755
+        (fun fd ->
+          Unixext.with_file path [ Unix.O_RDONLY ] 0
+            (fun fd' ->
+              let (_: int64) = Unixext.copy_file fd' fd in
+              run_path
+            )
+        )
+    end else begin
+      Unixext.unlink_safe run_path;
+      raise e
+    end
 
 
 


### PR DESCRIPTION
This is controlled by the presence of the hotfix file's sha1sum
in the FIST-point "allowed_unsigned_patches".

Signed-off-by: Rob Hoes rob.hoes@citrix.com
