### PR TITLE
CP-4460: substitute trunk-specific elements with the clearwater equivale...

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -241,7 +241,7 @@ let operation (obj: obj) (x: message) =
 			if not (List.exists (fun (l, _, _) -> l = DT.Removed) x.DT.msg_lifecycle) then
 				(comments @ unmarshall_code @ session_check_exp @ rbac_check_begin @ gen_body () @ rbac_check_end)
 			else
-				(comments @ ["let session_id = ref_session_of_rpc session_id_rpc in"] @ session_check_exp @ ["response_of_failure Api_errors.message_removed []"]) in
+				(comments @ List.filter (Stringext.String.startswith "let session_id") unmarshall_code @ session_check_exp @ ["Server_helpers.message_removed_failure"]) in
 		String.concat "\n            " ("" :: all_list) in
 
 	name_pattern_match ^ "\n"

--- a/ocaml/idl/ocaml_backend/server_helpers.ml
+++ b/ocaml/idl/ocaml_backend/server_helpers.ml
@@ -55,6 +55,9 @@ let parameter_count_mismatch_failure func expected received =
   XMLRPC.Failure (Api_errors.message_parameter_count_mismatch,
                   [func; expected; received])
 
+let message_removed_failure =
+  XMLRPC.Failure (Api_errors.message_removed, [])
+
 (* Execute fn f in specified __context, marshalling result with "marshaller".
    If has_task is set then __context has a real task in it that has to be completed. *)
 let exec ?marshaller ?f_forward ~__context f =


### PR DESCRIPTION
...nts

Unfortunately the original pull request duplicated from trunk contains some trunk specific elements which are non-exist in clearwater. This changeset should fix it.

Signed-off-by: Zheng Li zheng.li@eu.citrix.com
