### PR TITLE
Fix scripts/setup-vif-rules to work with VLAN-tagged networks

### DIFF
--- a/scripts/setup-vif-rules
+++ b/scripts/setup-vif-rules
@@ -232,6 +232,10 @@ def create_vswitch_rules(bridge_name, port, config):
 def get_bridge_name_vswitch(vif_name):
     '''return bridge vif belong to'''
     (rc, stdout, stderr) = doexec([vsctl, "iface-to-br",  vif_name ])
+    temp_bridge_name = stdout.readline().strip() 
+    '''get bridge parent, in case we were given a fake bridge device'''
+    '''will return same name if it is already a real bridge'''
+    (rc, stdout, stderr) = doexec([vsctl, "br-to-parent", temp_bridge_name ])
     return stdout.readline().strip()
 
 def handle_vswitch(vif_type, domid, devid, action):


### PR DESCRIPTION
VLAN-tagged networks/ports are connected to a "fake bridge" device.
Most ovs-\* commands will not work with a fake bridge
device, so this function needs to return the true parent bridge
device name, not the fake bridge.  Otherwise, subsequent calls
in this script to configure port locking via ovs-ofctl will
(silently) fail, and port locking will not activate.
