### PR TITLE
CP-4465 contribution: reduce logging of low-value messages

### DIFF
--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -373,7 +373,7 @@ let login_with_password ~__context ~uname ~pwd ~version ~originator = wipe_param
 		     failwith ("Local superuser must be "^local_superuser)
 		else begin
 			do_local_auth uname pwd;
-			debug "Successful local authentication user %s from %s" uname (Context.get_origin __context);
+			debug "Success: local auth, user %s from %s" uname (Context.get_origin __context);
 			login_no_password_common ~__context ~uname:(Some uname) ~originator ~host:(Helpers.get_localhost ~__context) 
 				~pool:false ~is_local_superuser:true ~subject:(Ref.null) ~auth_user_sid:"" ~auth_user_name:uname
 				~rbac_permissions:[]


### PR DESCRIPTION
- log less in block_device_io.action_writedelta
- shorten a common log line in xapi_session.ml

Signed-off-by: Thomas Sanders thomas.sanders@citrix.com
