### PR TITLE
CLEARWATER CA-95669: VNCTerm to listen on just 127.0.0.1

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -268,7 +268,7 @@ let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
 				framebuffer = bool vm.API.vM_platform false "pvfb";
 				framebuffer_ip = Some "0.0.0.0"; (* None PR-1255 *)
 				vncterm = true;
-				vncterm_ip = Some "0.0.0.0" (*None PR-1255*);
+				vncterm_ip = None (*None PR-1255*);
 			}
 		| Helpers.IndirectPV { Helpers.bootloader = b; extra_args = e; legacy_args = l; pv_bootloader_args = p; vdis = vdis } ->
 			PV {

--- a/scripts/vncterm-wrapper
+++ b/scripts/vncterm-wrapper
@@ -15,9 +15,6 @@
 DOMID=$1
 shift 1
 
-#For security reasons, we only listen on locahost by default
-export VNCTERM_LISTEN="-v 127.0.0.1:1"
-
 # 64MiB core dumps
 ulimit -c 67108864
 


### PR DESCRIPTION
Signed-off-by: Siddharth Vinothkumar siddharth.vinothkumar@citrix.com
(cherry picked from commit 4b289363c546aa02c44929815fed5968ae9c8c71)

This pull-request is a clone of https://github.com/xen-org/xen-api/pull/1042
