### PR TITLE
CA-104869: Generation-id value incorrect when prepended with leading zer...

### DIFF
--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -786,7 +786,7 @@ let consider_generic_bios_strings ~__context ~vm =
 (* Windows VM Generation ID *)
 
 let fresh_genid () =
-	Printf.sprintf "%019Ld:%019Ld" (* 19 is max digits of Int64 *)
+	Printf.sprintf "%Ld:%Ld" (* 19 is max digits of Int64 *)
 		(Random.int64 Int64.max_int)
 		(Random.int64 Int64.max_int)
 


### PR DESCRIPTION
...os. 

Signed-off-by: Akshay Ramani akshay.ramani@citrix.com
