### PR TITLE
CA-106034: update device_watches when domain appears/disappears

### DIFF
--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -2180,12 +2180,14 @@ module Actions = struct
 
 	let device_watches = ref IntMap.empty
 
-	let domain_appeared xc xs domid = ()
+	let domain_appeared xc xs domid =
+		device_watches := IntMap.add domid [] !device_watches
 
 	let domain_disappeared xc xs domid =
 		List.iter (fun d ->
 			List.iter (Xenstore_watch.unwatch ~xs) (watches_of_device d)
 		) (try IntMap.find domid !device_watches with Not_found -> []);
+		device_watches := IntMap.remove domid !device_watches;
 
 		(* Anyone blocked on a domain/device operation which won't happen because the domain
 		   just shutdown should be cancelled here. *)
@@ -2211,6 +2213,8 @@ module Actions = struct
 		let look_for_different_devices domid =
 			if not(Xenstore_watch.IntSet.mem domid watches)
 			then debug "Ignoring frontend device watch on unmanaged domain: %d" domid
+			else if not(IntMap.mem domid !device_watches)
+			then warn "Xenstore watch fired, but no entry for domid %d in device watches list" domid
 			else begin
 				let devices = IntMap.find domid !device_watches in
 				let devices' = Device_common.list_frontends ~xs domid in


### PR DESCRIPTION
When a domain appears, we need to initialise the entry in device_watches for
that domid. When a domain disappears, we need to remove the entry in
device_watches for that domid.

This was overlooked in the refactoring of CA-102259 -- the old semantics of
add_domU_watches and remove_domU_watches was not preserved as the watches map
was split into a set of domain watches and a map of device_watches.

Acked-by: Jonathan Davies Jonathan.Davies@eu.citrix.com
Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
