### PR TITLE
CA-103101: Create a background process from restart_agent to restart the entire toolstack.

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -343,8 +343,9 @@ let evacuate ~__context ~host =
 
 let restart_agent ~__context ~host =
 	let cmd = Filename.concat Fhs.bindir "xe-toolstack-restart" in
-	let pid = Forkhelpers.safe_close_and_exec None None None [] cmd ["-daemon"] in
-	debug "Created process with pid: %d to perform xe-toolstack-restart" (Forkhelpers.getpid pid);
+	let syslog_stdout = Forkhelpers.Syslog_WithKey ("Host.restart_agent") in
+	let pid = Forkhelpers.safe_close_and_exec None None None [] ~syslog_stdout cmd [] in
+	debug "Created process with pid: %d to perform xe-toolstack-restart" (Forkhelpers.getpid pid)
 
 let shutdown_agent ~__context =
   debug "Host.restart_agent: Host agent will shutdown in 1s!!!!";

--- a/scripts/xe-toolstack-restart
+++ b/scripts/xe-toolstack-restart
@@ -11,11 +11,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
 #
+FILENAME=`basename $0`
 LOCKFILE='/dev/shm/xe_toolstack_restart.lock'
 
 (
 flock -x -n 200
-if [ "$?" != 0 ]; then echo "Exiting: cannot lock $LOCKFILE. Is an instance $0 running already?"; exit 1; fi
+if [ "$?" != 0 ]; then echo "Exiting: cannot lock $LOCKFILE. Is an instance of $0 running already?"; exit 1; fi
+echo "Executing $FILENAME"
 
 POOLCONF=`cat @ETCDIR@/pool.conf`
 


### PR DESCRIPTION
This patch was created to make Host.restart_agent restart the whole of Toolstack.

Signed-off-by: Siddharth Vinothkumar siddharth.vinothkumar@citrix.com
