### PR TITLE
Revert fix for CA-101238

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -385,12 +385,7 @@ let create ~__context
 	let other_config =
 		if not (List.mem_assoc Xapi_globs.mac_seed other_config)
 		then (Xapi_globs.mac_seed, gen_mac_seed ()) :: other_config
-		else begin
-			let  pool= Helpers.get_pool ~__context in
-			let current_mac_seed = (List.assoc Xapi_globs.mac_seed other_config) in
-			Xapi_pool.assert_mac_seeds_available ~__context ~self:pool ~seeds:[current_mac_seed];
-			other_config
-		end
+		else other_config
 	in
 	create ~__context
 		~name_label


### PR DESCRIPTION
The duplicate MAC seed check breaks cross-pool migration of VMs with
snapshots, since snapshots will usually have the same MAC seed as the VM
they belong to.
