### PR TITLE
CLEARWATER: CA-106580: suppress debug-level log messages in block_device_io

### DIFF
--- a/ocaml/database/block_device_io.ml
+++ b/ocaml/database/block_device_io.ml
@@ -90,7 +90,8 @@
 
 open Pervasiveext
 
-module R = Debug.Debugger(struct let name = "block_device_io" end)
+let name = "block_device_io"
+module R = Debug.Debugger(struct let name = name end)
 
 let magic = "redo-log--------" (* 16 bytes *)
 
@@ -118,7 +119,9 @@ exception EndOfDeltas
 exception NotEnoughSpace
 
 (* Make informational output go to the syslog *)
-let initialise_logging () = Debug.set_facility Syslog.Local5
+let initialise_logging () =
+	Debug.set_facility Syslog.Local5;
+	Debug.disable ~level:Syslog.Debug name
 
 (* --------------------------------------------- *)
 (* Functions to deal with layout of block device *)


### PR DESCRIPTION
Duplicate of #1247 for clearwater.
