### PR TITLE
CA-100511: Don't fail SXM when guests are shutdown during migration

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -465,7 +465,8 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 						Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid;
 						Xapi_xenops.Events_from_xenopsd.wait dbg vm_uuid ())
 			with
-				| Xenops_interface.Does_not_exist ("VM",_) ->
+				| Xenops_interface.Does_not_exist ("VM",_)
+				| Xenops_interface.Does_not_exist ("extra",_) ->
 					()	
 		end;
 


### PR DESCRIPTION
If, during the VDI copy to the remote, the guest is shutdown then, when it
comes to moving the domain, Xenops will complain that the domain doesn't exist.
We had already desinged to handle this case but the exception catch needed to
be broadened to match the new "extra" TypedTable used for the VM metadata.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
