### PR TITLE
CA-92842: revert change of timeout when squeezing domains

### DIFF
--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -413,7 +413,7 @@ module Mem = struct
 	let retry f =
 		let start = Unix.gettimeofday () in
 		let interval = 10. in
-		let timeout = 0. in
+		let timeout = 60. in
 		let rec loop () =
 			try
 				f ()


### PR DESCRIPTION
Introduced probably accidentally in c/s c533d1ec

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
