### PR TITLE
CA-107247: HVM guests don't require the latest PV drivers for vbd-plug and vif-plug. 

### DIFF
--- a/ocaml/xapi/xapi_pv_driver_version.ml
+++ b/ocaml/xapi/xapi_pv_driver_version.ml
@@ -189,11 +189,8 @@ let of_guest_metrics gmr =
 				gmr.Db_actions.vM_guest_metrics_PV_drivers_version
 		| None -> Unknown
 
-(** Returns an API error option if the PV drivers are missing or not the most recent version *)
+(** Returns an API error option if the PV drivers are missing *)
 let make_error_opt version vm self =
 	match version with
 		| Unknown -> Some(Api_errors.vm_missing_pv_drivers, [ Ref.string_of vm ])
-		| (Linux(major, minor, micro, _) | Windows(major, minor, micro, _)) as x ->
-			if is_up_to_date x
-			then None
-			else Some(Api_errors.vm_old_pv_drivers, [ Ref.string_of vm; string_of_int major; string_of_int minor; string_of_int micro])
+		| (Linux(major, minor, micro, _) | Windows(major, minor, micro, _)) -> None

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -117,7 +117,7 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
 	  let bad_ops' = if power_state = `Paused then bad_ops else `pause :: `unpause :: bad_ops in
       set_errors Api_errors.vm_bad_power_state [ Ref.string_of vm; expected; actual ] bad_ops');
 
-  (* HVM guests only support plug/unplug IF they have recent PV drivers *)
+  (* HVM guests only support plug/unplug IF they have PV drivers *)
   (* They can only eject/insert CDs not plug/unplug *)
   let vm_gm = Db.VM.get_guest_metrics ~__context ~self:vm in
   let vm_gmr = try Some (Db.VM_guest_metrics.get_record_internal ~__context ~self:vm_gm) with _ -> None in  

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -67,7 +67,7 @@ let valid_operations ~__context record _ref' : table =
       let expected = Record_util.power_to_string `Running in
       set_errors Api_errors.vm_bad_power_state [ Ref.string_of vm; expected; actual ] [ `plug; `unplug ]);
 
-  (* HVM guests only support plug/unplug IF they have recent PV drivers *)
+  (* HVM guests only support plug/unplug IF they have PV drivers *)
   let vm_gm = Db.VM.get_guest_metrics ~__context ~self:vm in
   let vm_gmr = try Some (Db.VM_guest_metrics.get_record_internal ~__context ~self:vm_gm) with _ -> None in
   if power_state = `Running && Helpers.has_booted_hvm ~__context ~self:vm


### PR DESCRIPTION
This is critical for CloudStack as many of the HVM guests may not have the latest PV Drivers installed. 

Signed-off-by: Siddharth Vinothkumar siddharth.vinothkumar@citrix.com
