### PR TITLE
CA-107700 - Default to turning USB emulation on in xenopsd

### DIFF
--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -997,11 +997,11 @@ module VM = struct
 					) vbds in
 					let usb_enabled =
 						try (List.assoc "usb" vm.Vm.platformdata) = "true"
-						with Not_found -> false
+						with Not_found -> true
 					in
 					let usb_tablet_enabled =
 						try (List.assoc "usb_tablet" vm.Vm.platformdata) = "true"
-						with Not_found -> false
+						with Not_found -> true
 					in
 					let usb =
 						match usb_enabled, usb_tablet_enabled with


### PR DESCRIPTION
xapi already defaults to turning this on, but during rolling-pool
upgrade the platform data gets passed directly from the sending to the
receiving xenopsd without xapi adding its usual defaults.

Therefore xenopsd also needs to default to turning this on, to match
previous releases.
