### PR TITLE
TAMPA HFX-30: CA-95669: VNC/VNCTerm should listen on localhost only (127.0.0.1)

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -150,7 +150,7 @@ let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
 			acpi = bool vm.API.vM_platform true "acpi";
 			serial = Some (string vm.API.vM_other_config "pty" "hvm_serial");
 			keymap = Some (string vm.API.vM_platform "en-us" "keymap");
-			vnc_ip = Some "0.0.0.0" (*None PR-1255*);
+			vnc_ip = None (*None PR-1255*);
 			pci_emulations = pci_emulations;
 			pci_passthrough = pci_passthrough;
 			boot_order = string vm.API.vM_HVM_boot_params "cd" "order";
@@ -171,7 +171,7 @@ let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
 			PV {
 				boot = Direct { kernel = k; cmdline = ka; ramdisk = initrd };
 				framebuffer = bool vm.API.vM_platform false "pvfb";
-				framebuffer_ip = Some "0.0.0.0"; (* None PR-1255 *)
+				framebuffer_ip = None; (* None PR-1255 *)
 				vncterm = true;
 				vncterm_ip = None (*None PR-1255*);
 			}
@@ -179,9 +179,9 @@ let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
 			PV {
 				boot = Indirect { bootloader = b; extra_args = e; legacy_args = l; bootloader_args = p; devices = List.filter_map (fun x -> disk_of_vdi ~__context ~self:x) vdis };
 				framebuffer = bool vm.API.vM_platform false "pvfb";
-				framebuffer_ip = Some "0.0.0.0"; (* None PR-1255 *)
+				framebuffer_ip = None; (* None PR-1255 *)
 				vncterm = true;
-				vncterm_ip = Some "0.0.0.0" (*None PR-1255*);
+				vncterm_ip = None (*None PR-1255*);
 			}
 
 let pass_through_pif_carrier = ref false

--- a/ocaml/xenops-cli/test.ml
+++ b/ocaml/xenops-cli/test.ml
@@ -152,7 +152,7 @@ let create_vm id =
 	let open Vm in
 	let _ = PV {
 		framebuffer = false;
-		framebuffer_ip = Some "0.0.0.0";
+		framebuffer_ip = None;
 		vncterm = true;
 		vncterm_ip = None;
 		Vm.boot = Indirect {

--- a/ocaml/xenops-cli/xn.ml
+++ b/ocaml/xenops-cli/xn.ml
@@ -287,9 +287,9 @@ let add filename =
 			let builder_info = match pv with
 				| true -> PV {
 					framebuffer = false;
-					framebuffer_ip = Some "0.0.0.0";
+					framebuffer_ip = None;
 					vncterm = true;
-					vncterm_ip = Some "0.0.0.0";
+					vncterm_ip = None;
 					boot =
 						if mem _bootloader then Indirect {
 							bootloader = find _bootloader |> string;
@@ -318,7 +318,7 @@ let add filename =
 					acpi = true;
 					serial = None;
 					keymap = None;
-					vnc_ip = Some "0.0.0.0";
+					vnc_ip = None;
 					pci_emulations = [];
 					pci_passthrough = false;
 					boot_order = if mem _boot then find _boot |> string else "cd";


### PR DESCRIPTION
(The commit from Feb/March 2013 didn't fix this.)

This only fixes the problem for guest domains, not for dom0.

The dom0 vncterm is run from /etc/inittab so we shall need to
change the repository that adds the relevant line to that file.

Signed-off-by: Thomas Sanders thomas.sanders@citrix.com
(cherry picked from commit 484e4bfca5c6154e6a3b3722d937d34a805cadbc)
