### PR TITLE
CA-108508: Add a script to re-enable the RRDD plugin data sources

### DIFF
--- a/scripts/OMakefile
+++ b/scripts/OMakefile
@@ -89,6 +89,7 @@ install:
 	$(IPROG) xe-xentrace $(DESTDIR)$(BINDIR)
 	$(IPROG) xe-edit-bootloader $(DESTDIR)$(BINDIR)
 	$(IPROG) xe-get-network-backend $(DESTDIR)$(BINDIR)
+	$(IPROG) xe-enable-all-plugin-metrics $(DESTDIR)$(BINDIR)
 	$(IPROG) static-vdis $(DESTDIR)$(BINDIR)
 	$(IPROG) with-vdi $(DESTDIR)$(OPTDIR)/debug
 	$(IPROG) pool.conf $(DESTDIR)$(ETCDIR)

--- a/scripts/xe-enable-all-plugin-metrics
+++ b/scripts/xe-enable-all-plugin-metrics
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+##############################################################################
+# script to enable automatic recording of all metrics coming from
+# RRDD plugins
+# 
+# Note that this will cause a large number of data sources to be recorded
+# both for VMs and for the host, which may cause delays and/or large amounts
+# of network traffic when XenCenter is displaying performance graphs.
+# 
+##############################################################################
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Need to specify true or false"
+fi
+
+if [ ! -e /etc/xcp-rrdd.conf ]; then
+    echo "Missing xcp-rrdd config file: expecting it in /etc/xcp-rrdd.conf"
+    exit 1
+fi
+
+enable=$1
+case $enable in
+    true|false) ;;
+    *)
+	echo "Argument 1 must be either 'true' or 'false'"
+        exit 1
+esac
+
+# Remove the line specifying this from the config file:
+
+grep -v "^plugin-default" /etc/xcp-rrdd.conf > /tmp/xcp-rrdd.conf
+mv /etc/xcp-rrdd.conf /etc/xcp-rrdd.conf.old
+cp /tmp/xcp-rrdd.conf /etc/xcp-rrdd.conf
+echo "plugin-default = $enable" >> /etc/xcp-rrdd.conf
+
+case $enable in
+    true)
+	echo "Enabling all metrics delivered by plugins"
+	;;
+    false)
+	echo "Disabling any new metrics delivered by plugins"
+	;;
+esac
+
+echo
+
+# We do a toolstack restart at this point to ensure the RRDs are
+# written to disk (by xapi shutting down!)
+xe-toolstack-restart
+
+ 
+case $enable in
+    false)
+	echo
+	echo "Note that anything that was already being recorded"
+	echo "will continue to be recorded. If you wish to stop"
+	echo "this the data source archives must be explicitly"
+	echo "forgotten."
+	;;
+esac
+
+

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -214,6 +214,7 @@ rm -rf $RPM_BUILD_ROOT
 @OPTDIR@/bin/xe-toolstack-restart
 @OPTDIR@/bin/xe-xentrace
 @OPTDIR@/bin/xe-switch-network-backend
+@OPTDIR@/bin/xe-enable-all-plugin-metrics
 /etc/bash_completion.d/xe-switch-network-backend
 @OPTDIR@/bin/xsh
 /etc/xensource/bugtool/xapi.xml


### PR DESCRIPTION
Script is 'xe-enable-all-plugin-metrics', which takes a single
argument 'true' or 'false'. This script will restart the toolstack.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
