### PR TITLE
CA-107107: enable backtraces in xenopsd 

### DIFF
--- a/scripts/init.d-xenopsd
+++ b/scripts/init.d-xenopsd
@@ -43,6 +43,9 @@ start() {
 		fi
 	fi
 	
+	# Enable backtraces
+	export OCAMLRUNPARAM="b"
+
 	${BIN} -daemon -config /etc/xenopsd.conf >/dev/null 2>&1 </dev/null
 
 	MAX_RETRIES=30


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
