### PR TITLE
CA-92550: Update xenstore permissions on /vm/<uuid> tree to reflect the new domain ID when a domain is rebooted or migrated to localhost.

### DIFF
--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -23,6 +23,7 @@ open Cancel_utils
 open Xenops_helpers
 open Device_common
 open Xenops_task
+open Xenops_utils
 
 module D = Debug.Debugger(struct let name = "xenops" end)
 open D
@@ -186,7 +187,9 @@ let make ~xc ~xs vm_info uuid =
 
 			(* The /vm path needs to be shared over a localhost migrate *)
 			let vm_exists = try ignore(t.Xst.read vm_path); true with _ -> false in
-			if not vm_exists then begin
+			if vm_exists then 
+				xenstore_iter t (fun d -> t.Xst.setperms d roperm) vm_path
+			else begin
 				t.Xst.mkdir vm_path;
 				t.Xst.setperms vm_path roperm;
 				t.Xst.writev vm_path [

--- a/ocaml/xenops/xenops_utils.ml
+++ b/ocaml/xenops/xenops_utils.ml
@@ -18,6 +18,7 @@ open Pervasiveext
 open Threadext
 open Fun
 open Xenops_interface
+open Xenstore
 
 module D = Debug.Debugger(struct let name = service_name end)
 open D
@@ -30,6 +31,14 @@ end
 
 let all = List.fold_left (&&) true
 let any = List.fold_left (||) false
+
+(* Recursively iterate over a directory and all its children, calling fn for each *)
+let rec xenstore_iter t fn path =
+       fn path;
+       match t.Xst.directory path with
+       | [] -> ()
+       | names -> List.iter (fun n -> if n <> "" then xenstore_iter t fn (path ^ "/" ^ n)) names
+
 
 let dropnone x = List.filter_map (fun x -> x) x
 


### PR DESCRIPTION
For want of a better place to put it, I've added 'xenops/utils.ml' to hold a new utility function that recurses over a subtree in Xenstore.   This should be moved to somewhere more suitable. 
