### PR TITLE
 CA-100489: xenopsd: ignore errors in PCI.unplug when VM does not exist

### DIFF
--- a/ocaml/xenops/xenops_server.ml
+++ b/ocaml/xenops/xenops_server.ml
@@ -978,8 +978,10 @@ let perform_atomic ~progress_callback ?subtask (op: atomic) (t: Xenops_task.t) :
 			PCI_DB.signal id
 		| PCI_unplug id ->
 			debug "PCI.unplug %s" (PCI_DB.string_of_id id);
-			B.PCI.unplug t (PCI_DB.vm_of id) (PCI_DB.read_exn id);
-			PCI_DB.signal id
+			finally
+				(fun () ->
+					B.PCI.unplug t (PCI_DB.vm_of id) (PCI_DB.read_exn id);
+				) (fun () -> PCI_DB.signal id)
 		| VM_set_xsdata (id, xsdata) ->
 			debug "VM.set_xsdata (%s, [ %s ])" id (String.concat "; " (List.map (fun (k, v) -> k ^ ": " ^ v) xsdata));
 			B.VM.set_xsdata t (VM_DB.read_exn id) xsdata

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -1509,15 +1509,20 @@ module PCI = struct
 
 	let unplug task vm pci =
 		let device = pci.domain, pci.bus, pci.dev, pci.fn in
-		on_frontend
-			(fun xc xs frontend_domid hvm ->
-				try
-					if hvm
-					then Device.PCI.unplug task ~xc ~xs device frontend_domid
-					else error "VM = %s; PCI.unplug for PV guests is unsupported" vm
-				with Not_found ->
-					debug "VM = %s; PCI.unplug %s.%s caught Not_found: assuming device is unplugged already" vm (fst pci.id) (snd pci.id)
-			) Oldest vm
+		try
+			on_frontend
+				(fun xc xs frontend_domid hvm ->
+					try
+						if hvm
+						then Device.PCI.unplug task ~xc ~xs device frontend_domid
+						else error "VM = %s; PCI.unplug for PV guests is unsupported" vm
+					with Not_found ->
+						debug "VM = %s; PCI.unplug %s.%s caught Not_found: assuming device is unplugged already" vm (fst pci.id) (snd pci.id)
+				) Oldest vm
+		with
+		| (Does_not_exist(_,_)) ->
+			debug "VM = %s; PCI = %s; Ignoring missing domain" vm (id_of pci)
+
 end
 
 let set_active_device path active =


### PR DESCRIPTION
This makes it consistent with VIF.unplug and VBD.unplug, and prevents xenopsd
from spinning in VM.shutdown with PCI devices present.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
