### PR TITLE
Fix logic at the conclusion of Xenguest for domain creation and migration

### DIFF
--- a/ocaml/xenops/xenguestHelper.ml
+++ b/ocaml/xenops/xenguestHelper.ml
@@ -75,8 +75,6 @@ let connect path domid (args: string list) (fds: (string * Unix.file_descr) list
 let disconnect (_, _, r, w, pid) =
 	Unix.close r;
 	Unix.close w;
-	(* just in case *)
-	(try Unix.kill (Forkhelpers.getpid pid) Sys.sigterm with _ -> ());
 	ignore(Forkhelpers.waitpid pid)
 
 let with_connection (task: Xenops_task.t) path domid (args: string list) (fds: (string * Unix.file_descr) list) f =


### PR DESCRIPTION
Fix logic at the conclusion of Xenguest for domain creation and migration.

As part of the control protocol, Xenguest is expected to write the string

   "result: <xenstore mfn> <console mfn>\n"

to the a pipe back into xenops.  forkexecutioner has already executed a
waitpid() on the xenguest process, waiting for it to exit.

Unfortunately, as soon as xenops receives the result string, it decides to
SIGTERM the xenguest process.

This begins a race condition.  If xenguest finishes executing and exits
cleanly (which it will do, given the result string) in a timely fashion, fe
will record success and the domain creation/migration will be all good.

If however xenguest gets killed with the SIGTERM before it has exited cleanly
(such as actually having valgrind wrapped around xenguest, and the recipient
of the SIGTERM), fe will record a failure at which point xenops will clean up
the domain, despite it having actually been created/migrated successfully.

This could likely explain some spurious failures seen in high-load situation
but not reliably enough to investigate.

Signed-off-by: Andrew Cooper andrew.cooper3@citrix.com
