### PR TITLE
CA-104674: Don't add genid to VMs that don't need one

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1546,7 +1546,7 @@ let vm_create printer rpc session_id params =
 		~order:0L
 		~suspend_SR:Ref.null
 		~version:0L
-		~generation_id:(Xapi_vm_helpers.fresh_genid ()) in
+		~generation_id:"" in
 	let uuid=Client.VM.get_uuid rpc session_id vm in
 	printer (Cli_printer.PList [uuid])
 

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -194,7 +194,7 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info: host_info)
 		~order:0L
 		~suspend_SR:Ref.null
 		~version:0L
-		~generation_id:(Xapi_vm_helpers.fresh_genid ());
+		~generation_id:"";
 	Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref
 
 and create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref ~dom0_console_protocol =

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -326,7 +326,8 @@ module VM : HandlerTools = struct
 				if (is_live config) || vm_record.API.vM_is_a_template
 				then vm_record
 				else {
-					vm_record with API.vM_generation_id = Xapi_vm_helpers.fresh_genid ()
+					vm_record with API.vM_generation_id = Xapi_vm_helpers.fresh_genid
+						~current_genid:vm_record.API.vM_generation_id ()
 				}
 			in
 

--- a/ocaml/xapi/import_xva.ml
+++ b/ocaml/xapi/import_xva.ml
@@ -89,7 +89,7 @@ let make __context rpc session_id srid (vms, vdis) =
 				~order:0L
 				~suspend_SR:Ref.null
 				~version:0L
-				~generation_id:(Xapi_vm_helpers.fresh_genid ())
+				~generation_id:""
 			      in
 
                  TaskHelper.operate_on_db_task ~__context

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -254,8 +254,9 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
 		| Disk_op_clone | Disk_op_copy _-> Ref.null
 		| Disk_op_snapshot | Disk_op_checkpoint -> all.Db_actions.vM_parent in
 
-	(* We always reset the generation ID on VM.clone *)
-	let generation_id = Xapi_vm_helpers.fresh_genid () in
+	(* We always reset an existing generation ID on VM.clone *)
+	let generation_id = Xapi_vm_helpers.fresh_genid
+		~current_genid:all.Db_actions.vM_generation_id () in
 
 	(* create a new VM *)
 	Db.VM.create ~__context 

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -791,14 +791,16 @@ let consider_generic_bios_strings ~__context ~vm =
 
 (* Windows VM Generation ID *)
 
-let fresh_genid () =
-	Printf.sprintf "%Ld:%Ld"
-		(Random.int64 Int64.max_int)
-		(Random.int64 Int64.max_int)
+let fresh_genid ?(current_genid="0:0") () =
+	if current_genid = "" then "" else
+		Printf.sprintf "%Ld:%Ld"
+			(Random.int64 Int64.max_int)
+			(Random.int64 Int64.max_int)
 
 let vm_fresh_genid ~__context ~self =
-	let genid = fresh_genid ()
+	let current_genid = Db.VM.get_generation_id ~__context ~self in
+	let new_genid = fresh_genid ~current_genid ()
 	and uuid = Db.VM.get_uuid ~__context ~self in
-	debug "Refreshing GenID for VM %s to %s" uuid genid;
-	Db.VM.set_generation_id ~__context ~self ~value:genid ;
-	genid
+	debug "Refreshing GenID for VM %s to %s" uuid new_genid;
+	Db.VM.set_generation_id ~__context ~self ~value:new_genid ;
+	new_genid


### PR DESCRIPTION
VM.clone was erroneously adding a fresh generation ID to template VMs which
weren't set with "O:O". We now check for blank generation IDs and preserve
them.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
