### PR TITLE
CA-108913: Initialise parameters on the stack.

### DIFF
--- a/ocaml/xenguest/xenguest_stubs.c
+++ b/ocaml/xenguest/xenguest_stubs.c
@@ -401,8 +401,8 @@ CAMLprim value stub_xc_linux_build_native(value xc_handle, value domid,
     CAMLxparam1(console_evtchn);
     CAMLlocal1(result);
 
-    unsigned long store_mfn;
-    unsigned long console_mfn;
+    unsigned long store_mfn = 0;
+    unsigned long console_mfn = 0;
     int r;
     struct xc_dom_image *dom;
     char c_protocol[64];
@@ -764,7 +764,7 @@ CAMLprim value stub_xc_domain_restore(value handle, value fd, value domid,
     CAMLparam5(handle, fd, domid, store_evtchn, console_evtchn);
     CAMLxparam2(hvm, no_incr_generationid);
     CAMLlocal1(result);
-    unsigned long store_mfn, console_mfn;
+    unsigned long store_mfn = 0, console_mfn = 0;
     domid_t c_store_domid, c_console_domid;
 
 #ifdef XENGUEST_4_2


### PR DESCRIPTION
These four values are passed by pointer into libxc, and are only filled in if
relevent.  The bindings then convert the uninitialised variable into an
integer and pass it to xenops, which writes it to xenstore.

xenconsoled sees the write and, if the junk value looks like a valid guest
gfn, maps it and starts the console connect protocol by writing into it.

This causes HVM domain corruption if the junk value happens to be in the range
1 to max_pages.

Signed-off-by: Andrew Cooper andrew.cooper3@citrix.com
