### PR TITLE
CA-98090: (XOP-206) Block SXM when VM cannot match any bridge names on destination. 

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -118,7 +118,7 @@ let openvswitch_not_active = "OPENVSWITCH_NOT_ACTIVE"
 let transport_pif_not_configured = "TRANSPORT_PIF_NOT_CONFIGURED"
 let is_tunnel_access_pif = "IS_TUNNEL_ACCESS_PIF"
 let pif_tunnel_still_exists = "PIF_TUNNEL_STILL_EXISTS"
-
+let bridge_not_available = "BRIDGE_NOT_AVAILABLE"
 let vlan_tag_invalid = "VLAN_TAG_INVALID"
 let vm_bad_power_state = "VM_BAD_POWER_STATE"
 let vm_is_template = "VM_IS_TEMPLATE"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -523,7 +523,8 @@ let _ =
     ~doc:"You tried to create a VLAN or tunnel on top of a tunnel access PIF - use the underlying transport PIF instead." ();
   error Api_errors.pif_tunnel_still_exists ["PIF"]
     ~doc:"Operation cannot proceed while a tunnel exists on this interface." ();
-
+	error Api_errors.bridge_not_available [ "bridge" ]
+    ~doc:"Could not find bridge required by VM." ();
   (* VM specific errors *)
   error Api_errors.vm_is_protected [ "vm" ]
     ~doc:"This operation cannot be performed because the specified VM is protected by xHA" ();


### PR DESCRIPTION
I think we just need to revert this patch to resolve the issue raised by XOP-206.
We now intend to block SXM when VM cannot match any bridge names on the destination. 

Revert "CA-84673: Metadata import should create a network if it can't find one"

This reverts commit 99f82b7cecb961f9bf0da966a38e67bae618653b.
