### PR TITLE
Do not try deleting the old xenguest log file.

### DIFF
--- a/ocaml/xenops/xenguestHelper.ml
+++ b/ocaml/xenops/xenguestHelper.ml
@@ -44,7 +44,6 @@ let connect path domid (args: string list) (fds: (string * Unix.file_descr) list
 	let using_xiu = Xenctrl.is_fake () in
 
 	let last_log_file = Printf.sprintf "/tmp/xenguest.%d.log" domid in
-	(try Unix.unlink last_log_file with _ -> ());
 
 	let slave_to_server_w_uuid = Uuid.to_string (Uuid.make_uuid ()) in
 	let server_to_slave_r_uuid = Uuid.to_string (Uuid.make_uuid ()) in


### PR DESCRIPTION
The only time where this will succeed is when performing localhost
migrations.  This action is a deliberate choice on behalf of the user,
suggesting that they are also likely to want the log files.

Specifically, in the case of a localhost migrate, the logs for the transmit
half of the migrate are deleted.

Signed-off-by: Andrew Cooper andrew.cooper3@citrix.com
