### PR TITLE
Remove a modprobe warning in new systems.

### DIFF
--- a/scripts/xe-switch-network-backend
+++ b/scripts/xe-switch-network-backend
@@ -49,7 +49,7 @@ for i in /etc/sysconfig/network-scripts/ifcfg-* ; do
 done
 
 
-BLACKLIST=/etc/modprobe.d/blacklist-bridge
+BLACKLIST=/etc/modprobe.d/blacklist-bridge.conf
 if [ "$new" = "openvswitch" ] ; then
 	# Add blacklist of bridge module so it can't be loaded.
 	echo "install bridge /bin/true" > $BLACKLIST


### PR DESCRIPTION
New modprobe give a warning if configuration files do not end with .conf.
Add .conf to /etc/modprobe.d/blacklist-bridge in order to avoid this
warning.

Signed-off-by: Frediano Ziglio frediano.ziglio@citrix.com
