### PR TITLE
CP-5593: Implement PGPU.set_GPU_group

### DIFF
--- a/ocaml/xapi/xapi_gpu_group.ml
+++ b/ocaml/xapi/xapi_gpu_group.ml
@@ -41,8 +41,9 @@ let destroy ~__context ~self =
 	Db.GPU_group.destroy ~__context ~self
 
 let find_or_create ~__context pgpu =
-	let pci = Db.PCI.get_record_internal ~__context ~self:(Db.PGPU.get_PCI ~__context ~self:pgpu) in
-	let gpu_type = pci.Db_actions.pCI_vendor_id ^ "/" ^ pci.Db_actions.pCI_device_id in
+	let pci = Db.PGPU.get_PCI ~__context ~self:pgpu in
+	let pci_rec = Db.PCI.get_record_internal ~__context ~self:pci in
+	let gpu_type = Xapi_pci.get_device_id ~__context ~self:pci in
 	try
 		List.find (fun rf->
 			let rc = Db.GPU_group.get_record_internal ~__context ~self:rf in
@@ -50,7 +51,7 @@ let find_or_create ~__context pgpu =
 		)
 		(Db.GPU_group.get_all ~__context)
 	with Not_found ->
-		let name_label = "Group of " ^ pci.Db_actions.pCI_vendor_name ^ " " ^ pci.Db_actions.pCI_device_name ^ " GPUs" in
+		let name_label = "Group of " ^ pci_rec.Db_actions.pCI_vendor_name ^ " " ^ pci_rec.Db_actions.pCI_device_name ^ " GPUs" in
 		let group = create ~__context ~name_label ~name_description:"" ~other_config:[] in
 		Db.GPU_group.set_GPU_types ~__context ~self:group ~value:[gpu_type];
 		group

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -61,6 +61,10 @@ let read_pcis () =
 let get_pcis_by_class pcis cls =
 	List.filter (fun pci -> pci.class_id = find_class_id cls) pcis
 
+let get_device_id ~__context ~self =
+	let pci = Db.PCI.get_record_internal ~__context ~self in
+	pci.Db_actions.pCI_vendor_id ^ "/" ^ pci.Db_actions.pCI_device_id
+
 let create ~__context ~class_id ~class_name ~vendor_id ~vendor_name ~device_id
 		~device_name ~host ~pci_id ~functions ~dependencies ~other_config =
 	let p = Ref.make () in

--- a/ocaml/xapi/xapi_pci.mli
+++ b/ocaml/xapi/xapi_pci.mli
@@ -20,5 +20,8 @@ type pci_class = Display_controller | Network_controller
 (** Get the PCI class ID for a given class. *)
 val find_class_id : pci_class -> string
 
+(** Get the device ID for a PCI **)
+val get_device_id : __context:Context.t -> self:API.ref_PCI -> string
+
 (** Synchronise the PCI objects in the database with the actual devices in the host. *)
 val update_pcis : __context:Context.t -> host:API.ref_host -> unit

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -15,6 +15,7 @@ module D=Debug.Debugger(struct let name="xapi" end)
 open D
 
 open Listext
+open Threadext
 
 let create ~__context ~pCI ~gPU_group ~host ~other_config =
 	let pgpu = Ref.make () in
@@ -48,4 +49,36 @@ let update_gpus ~__context ~host =
 	let obsolete_pgpus = List.set_difference existing_pgpus current_pgpus in
 	List.iter (fun (self, _) -> Db.PGPU.destroy ~__context ~self) obsolete_pgpus
 
-let set_GPU_group ~__context ~self ~value = failwith "not implemented"
+let gpu_group_m = Mutex.create ()
+let set_GPU_group ~__context ~self ~value =
+	Mutex.execute gpu_group_m (fun () ->
+		let pci = Db.PGPU.get_PCI ~__context ~self in
+
+		(* Precondition: PGPU not currently in use by a VM *)
+		if Db.PCI.get_attached_VMs ~__context ~self:pci <> []
+		then failwith "PGPU currently in use";
+
+		(* Precondition: Moving PGPU from current group can't orphan VGPU *)
+		let src_g = Db.PGPU.get_GPU_group ~__context ~self in
+		let pgpu_is_singleton =
+			(List.length (Db.GPU_group.get_PGPUs ~__context ~self:src_g) = 1)
+		and pgpu_has_vgpus =
+			((Db.GPU_group.get_VGPUs ~__context ~self:src_g) <> []) in
+		if (pgpu_is_singleton && pgpu_has_vgpus)
+		then failwith "Moving this PGPU would leave VGPUs without a PGPU";
+
+		let check_compatibility gpu_type group_types =
+			match group_types with
+			| [] -> true, [gpu_type]
+			| _ -> List.mem gpu_type group_types, group_types in
+
+		let gpu_type = Xapi_pci.get_device_id ~__context ~self:pci
+		and group_types = Db.GPU_group.get_GPU_types ~__context ~self:value in
+		match check_compatibility gpu_type group_types with
+		| true, new_types ->
+			Db.PGPU.set_GPU_group ~__context ~self ~value;
+			(* Group inherits the device type *)
+			Db.GPU_group.set_GPU_types ~__context ~self:value ~value:new_types
+		| false, _ ->
+			failwith "PGPU type not compatible with destination group"
+	)


### PR DESCRIPTION
Now able to set  the GPU group for a PGPU. The new group is checked for
compatability and will have it's GPU type updated to the incoming PGPU if it is
an empty group. The group from with the PGPU is departing is also checked in
case it's left in an unusable state w.r.t. any VGPUs that may or may not be
attached to running VMs.

The code used to get the identifier string from a PCI device has been factored
out from the GPU_group and into the PCI module for reuse in the PGPU module.
