### PR TITLE
CA-108916: add call to V6rpc.get_current_edition API

### DIFF
--- a/ocaml/license/fakev6.ml
+++ b/ocaml/license/fakev6.ml
@@ -36,3 +36,7 @@ let get_version dbg =
 	Debug.with_thread_associated dbg (fun () -> "") ()
 
 let reopen_logs () = true
+
+let get_current_edition dbg additional =
+	Debug.with_thread_associated dbg (fun () ->
+		Edition.(to_string Free, to_features Free, [])) ()

--- a/ocaml/license/fakev6.mli
+++ b/ocaml/license/fakev6.mli
@@ -28,3 +28,6 @@ val get_version : string -> string
 (** Close and re-open the log file *)
 val reopen_logs : unit -> bool
 
+(** Call the [get_current_edition] function on the v6d *)
+val get_current_edition : string -> (string * string) list ->
+	string * Features.feature list * (string * string) list

--- a/ocaml/license/v6client.mli
+++ b/ocaml/license/v6client.mli
@@ -27,3 +27,6 @@ val get_editions : string -> (string * string * string * int) list
 (** Call the [get_version] function on the v6d *)
 val get_version : string -> string
 
+(** Call the [get_current_edition] function on the v6d *)
+val get_current_edition : __context:Context.t -> (string * string) list ->
+	string * Features.feature list * (string * string) list

--- a/ocaml/license/v6rpc.mli
+++ b/ocaml/license/v6rpc.mli
@@ -17,8 +17,12 @@
 (** The RPC interface of the licensing daemon *)
 module type V6api =
 	sig
-		(*  dbg_str -> edition -> additional_params -> enabled_features, additional_params *)
+		(*  dbg_str -> edition -> additional_params ->
+				edition * enabled_features * additional_params *)
 		val apply_edition : string -> string -> (string * string) list ->
+			string * Features.feature list * (string * string) list
+		(* dbg_str -> edition * enabled_features * additional_params *)
+		val get_current_edition : string -> (string * string) list ->
 			string * Features.feature list * (string * string) list
 		(* dbg_str -> list of editions *)
 		val get_editions : string -> (string * string * string * int) list
@@ -26,7 +30,7 @@ module type V6api =
 		val get_version : string -> string
 		(* () -> version *)
 		val reopen_logs : unit -> bool
-	end  
+	end
 
 (** RPC handler module *)
 module V6process : functor (V : V6api) ->
@@ -81,3 +85,12 @@ val get_editions_out_of_rpc : Rpc.t -> get_editions_out
 (** Convert {!get_editions_out} structure into RPC *)
 val rpc_of_get_editions_out : get_editions_out -> Rpc.t
 
+
+(** Definition of [get_current_edition] RPC *)
+type get_current_edition_in = (string * string) list
+
+(** Convert RPC into {!get_current_edition_in} structure *)
+val get_current_edition_in_of_rpc : Rpc.t -> get_current_edition_in
+
+(** Convert {!get_current_edition_in} structure into RPC *)
+val rpc_of_get_current_edition_in : get_current_edition_in -> Rpc.t

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1161,12 +1161,22 @@ let set_license_params ~__context ~self ~value =
 	Db.Host.set_license_params ~__context ~self ~value;
 	Pool_features.update_pool_features ~__context
 
-let apply_edition_internal  ~__context ~host ~edition ~additional =
-	let edition', features, additional =
-		V6client.apply_edition ~__context edition additional
-	in
-	Db.Host.set_edition ~__context ~self:host ~value:edition';
-	copy_license_to_db ~__context ~host ~features ~additional
+let apply_edition_internal	~__context ~host ~edition ~additional =
+	let db_update_license edition features additional =
+		Db.Host.set_edition ~__context ~self:host ~value:edition;
+		copy_license_to_db ~__context ~host ~features ~additional in
+	try
+		let edition, features, additional =
+			V6client.apply_edition ~__context edition additional in
+		db_update_license edition features additional
+	with e ->
+		(* If we catch an exception, retrieve what v6d thinks are the
+		   current license parameters and rethrow the exception. *)
+		let new_edition, features, additional =
+			V6client.get_current_edition ~__context additional in
+		warn "v6d: couldn't apply '%s' edition; new edition is '%s'" edition new_edition ;
+		db_update_license new_edition features additional ;
+		raise e
 
 let apply_edition ~__context ~host ~edition ~force =
 	(* if HA is enabled do not allow the edition to be changed *)


### PR DESCRIPTION
We add this API so that when v6d returns a failure on apply_edition, xapi is able to find out the correct edition to set itself to. This fixes a "bug" (design decision, really) where 1) v6d holds a valid license, 2) xapi apply_edition with bad license-server url, 3) v6d release license, and fails to check out new license, 4) xapi remains at the current licensed edition, but v6d doesn't hold the license for that edition.

NB: this must be pulled in conjunction with the hg/trunk-ring3/v6.git/ca108916-get-current-edition branch.
