### PR TITLE
Oliver/HFX-909:CA-105003: Handle exceptions in get_shadow_allocation.

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1023,7 +1023,7 @@ let update_vm ~__context id =
 							Opt.iter
 								(fun (_, state) ->
 									debug "xenopsd event: Updating VM %s shadow_multiplier <- %.2f" id state.shadow_multiplier_target;
-									if state.power_state <> Halted then
+									if state.power_state <> Halted && state.shadow_multiplier_target >= 0.0 then
 										Db.VM.set_HVM_shadow_multiplier ~__context ~self ~value:state.shadow_multiplier_target
 								) info
 						with e ->

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -1364,12 +1364,23 @@ module VM = struct
 						let shadow_multiplier_target =
 							if not di.hvm_guest
 							then 1.
-							else
-								let static_max_mib = Memory.mib_of_bytes_used vm.Vm.memory_static_max in
-								let default_shadow_mib = Memory.HVM.shadow_mib static_max_mib vm.Vm.vcpu_max 1. in
-								let actual_shadow_mib =
-									Int64.of_int (Xenctrl.shadow_allocation_get xc di.domid) in
-								(Int64.to_float actual_shadow_mib) /. (Int64.to_float default_shadow_mib) in
+							else begin
+							  try 
+							    let static_max_mib = Memory.mib_of_bytes_used vm.Vm.memory_static_max in
+							    let default_shadow_mib = Memory.HVM.shadow_mib static_max_mib vm.Vm.vcpu_max 1. in
+							    let actual_shadow_mib_int = Xenctrl.shadow_allocation_get xc di.domid in
+							    let actual_shadow_mib = Int64.of_int actual_shadow_mib_int in
+							    let result = (Int64.to_float actual_shadow_mib) /. (Int64.to_float default_shadow_mib) in
+							    (* CA-104562: Work around probable bug in bindings *)
+							    if result > 1000.0 then begin
+							      warn "CA-104562: Got value '%d' from shadow_allocation_get" actual_shadow_mib_int;
+							      -1.0 
+							    end else result
+							  with e -> 
+							    warn "Caught exception in getting shadow allocation: %s" (Printexc.to_string e);
+							    -1.0
+							end
+						in	     
 						{
 							Vm.power_state = if di.paused then Paused else Running;
 							domids = [ di.domid ];


### PR DESCRIPTION
This fails when the VM has no VCPUs, which has been observed in
the wild. Also contains a workaround for CA-104562 by preventing
bizarrely large values being set.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
