### PR TITLE
 CA-105903: VBD surprise-remove flag is now ignored

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1606,7 +1606,7 @@ there are two or more empty CD devices, please use the command 'vbd-insert' and 
     {
       reqd=["uuid"];
       optn=["timeout"; "force"];
-      help="Attempt to detach the VBD while the VM is in the running state. If the optional argument 'timeout=N' is given then the command will wait for up to 'N' seconds for the unplug to complete. If the optional argument 'force' is given and the device supports surprise removal then it will be immediately unplugged.";
+      help="Attempt to detach the VBD while the VM is in the running state. If the optional argument 'timeout=N' is given then the command will wait for up to 'N' seconds for the unplug to complete. If the optional argument 'force' is given then it will be immediately unplugged.";
       implementation=No_fd Cli_operations.vbd_unplug;
       flags=[];
     };

--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -127,8 +127,12 @@ let rm_device_state ~xs (x: device) =
 	safe_rm ~xs (backend_error_path_of_device ~xs x);
 	safe_rm ~xs (Filename.dirname (error_path_of_device ~xs x))
 
+
+(* The surprise-remove flag is now ignored: a vbd-unplug --force will
+	 unplug regardless of surprise-remove. Leave this code here for now,
+	 to warn the user in the logs. *)
 let can_surprise_remove ~xs (x: device) =
-  (* "(info key in xenstore) && 2" tells us whether a vbd can be surprised removed *)
+				(* "(info key in xenstore) && 2" tells us whether a vbd can be surprised removed *)
         let key = backend_path_of_device ~xs x ^ "/info" in
 	try
 	  let info = Int64.of_string (xs.Xs.read key) in

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -1743,7 +1743,9 @@ module VBD = struct
 					Opt.iter
 						(fun device ->
 							if force && (not (Device.can_surprise_remove ~xs device))
-							then debug "VM = %s; VBD = %s; Device is not surprise-removable" vm (id_of vbd); (* happens on normal shutdown too *)
+							then debug
+								"VM = %s; VBD = %s; Device is not surprise-removable (ignoring and removing anyway)"
+								vm (id_of vbd); (* this happens on normal shutdown too *)
 							(* Case (1): success; Case (2): success; Case (3): an exception is thrown *)
 							Xenops_task.with_subtask task (Printf.sprintf "Vbd.clean_shutdown %s" (id_of vbd))
 								(fun () -> (if force then Device.hard_shutdown else Device.clean_shutdown) task ~xs device);


### PR DESCRIPTION
This is just acknowledging the changes that were introduced in Tampa, and not a
change in behaviour since Tampa.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
