### PR TITLE
CA-112572: networkd: protect IP watcher thread with an exception handler

### DIFF
--- a/ocaml/network/network_monitor_thread.ml
+++ b/ocaml/network/network_monitor_thread.ml
@@ -259,7 +259,6 @@ let ip_watcher () =
 	);
 	Unix.close writeme;
 	let in_channel = Unix.in_channel_of_descr readme in
-	debug "Started IP watcher thread";
 	let rec loop () =
 		let line = input_line in_channel in
 		(* Do not send events for link-local IPv6 addresses *)
@@ -272,7 +271,13 @@ let ip_watcher () =
 		end;
 		loop ()
 	in
-	loop ()
+	while true do
+		try
+			info "(Re)started IP watcher thread";
+			loop ()
+		with e ->
+			warn "Error in IP watcher: %s\n%s" (Printexc.to_string e) (Printexc.get_backtrace ())
+	done
 
 let start () =
 	let dbg = "monitor_thread" in


### PR DESCRIPTION
This needs to go in the xcp-networkd repo as well.
