### PR TITLE
CLEARWATER-LCM: XOP-375 - vif-locking=disabled allowed when vswitch controller active

### DIFF
--- a/ocaml/xapi/xapi_network.ml
+++ b/ocaml/xapi/xapi_network.ml
@@ -187,10 +187,6 @@ let create_new_blob ~__context ~network ~name ~mime_type ~public =
 	blob
 
 let set_default_locking_mode ~__context ~network ~value =
-	if (value = `disabled) then begin
-		(* Don't allow locking of a network if a vswitch controller is present. *)
-		Helpers.assert_vswitch_controller_not_active ~__context
-	end;
 	(* Get all VIFs which are attached and associated with this network. *)
 	let open Db_filter_types in
 	match Db.VIF.get_records_where ~__context

--- a/ocaml/xapi/xapi_vif.ml
+++ b/ocaml/xapi/xapi_vif.ml
@@ -72,7 +72,7 @@ let set_locking_mode ~__context ~self ~value =
 			Db.Network.get_default_locking_mode ~__context ~self:network
 		| other -> other
 	in
-	if effective_locking_mode <> `unlocked then
+	if effective_locking_mode = `locked then
 		Helpers.assert_vswitch_controller_not_active ~__context;
 	change_locking_config ~__context ~self
 		~licence_check:(effective_locking_mode = `locked)


### PR DESCRIPTION
Don't pull until we decide we need a hotfix.
