### PR TITLE
CA-113402: Attempt to reset PCI device by writing to device PCI file. If that fails, fallback to the old method.

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -1190,6 +1190,7 @@ let write_string_to_file file s =
 let do_flr device =
 	debug "Doing FLR on pci device: %s" device;
 	let doflr = "/sys/bus/pci/drivers/pciback/do_flr" in
+	let device_reset_file = Printf.sprintf "/sys/bus/pci/devices/%s/reset" device in
 	let script = Filename.concat Fhs.libexecdir "pci-flr" in
 	let callscript s devstr =
 		if Sys.file_exists script then begin
@@ -1198,7 +1199,12 @@ let do_flr device =
 		end
 	in
 	callscript "flr-pre" device;
-	( try write_string_to_file doflr device with _ -> (); );
+	(
+		if Sys.file_exists device_reset_file then
+			try write_string_to_file device_reset_file "1" with _ -> ()
+		else
+			try write_string_to_file doflr device with _ -> ()
+	);
 	callscript "flr-post" device
 
 let bind pcidevs =


### PR DESCRIPTION
This is a Blocker issue raised by RIng0. This is blocking their EA work.
