### PR TITLE
Update .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,7 @@ ocaml/xenops/squeezed
 ocaml/xenops/squeezed_client
 ocaml/xenops-cli/xenopstest
 ocaml/xenops-cli/xn
+ocaml/xenops-cli/xn_cfg_parser.ml
 ocaml/xenops/xenopsd
 
 noarch.spec


### PR DESCRIPTION
After the switch to OCaml 4.00.1 in the chroot environment.  
File: "ocaml/xenops-cli/xn_cfg_parser.ml" is modified even though its untouched. 
