### PR TITLE
Fix GPU-passthrough platform key for xenopsd

### DIFF
--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -149,6 +149,6 @@ let create_vgpus ~__context (vm, vm_r) hvm =
 
 let list_pcis_for_passthrough ~__context ~vm =
 	try
-		let value = List.assoc Xapi_globs.vgpu_pci_key (Db.VM.get_other_config ~__context ~self:vm) in
+		let value = List.assoc Xapi_globs.vgpu_pci (Db.VM.get_other_config ~__context ~self:vm) in
 		List.map Pciops.of_string (String.split ',' value)
 	with _ -> []


### PR DESCRIPTION
s/vgpu_pci_id/vgpu_pci in VM.platform when using full GPU-passthrough
(PCI-passthrough). The former is used for vGPU, the latter for full GPU.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
