### PR TITLE
Add flag to enable/disable the VNC console with vGPU

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -468,6 +468,7 @@ let vgpu_vga_key = "vga"
 let vgpu_vga_value = "vgpu"
 let vgpu_pci_key = "vgpu_pci_id"
 let vgpu_config_key = "vgpu_config"
+let vgpu_vnc_enabled_key = "vgpu_vnc_enabled"
 
 let dev_zero = "/dev/zero"
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -53,6 +53,7 @@ module Platform = struct
 	let vga = Xapi_globs.vgpu_vga_key
 	let vgpu_pci_id = Xapi_globs.vgpu_pci_key
 	let vgpu_config = Xapi_globs.vgpu_config_key
+	let vgpu_vnc_enabled = Xapi_globs.vgpu_vnc_enabled_key
 
 	(* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)
 	let filtered_flags = [
@@ -75,6 +76,7 @@ module Platform = struct
 		vga;
 		vgpu_pci_id;
 		vgpu_config;
+		vgpu_vnc_enabled;
 	]
 
 	(* Other keys we might want to write to the platform map. *)

--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -1558,6 +1558,12 @@ type disp_opt =
 type media = Disk | Cdrom
 let string_of_media = function Disk -> "disk" | Cdrom -> "cdrom"
 
+type vgpu_t = {
+	pci_id: string;
+	config: string;
+	vnc_enabled: bool;
+}
+
 type info = {
 	memory: int64;
 	boot: string;
@@ -1572,7 +1578,7 @@ type info = {
 	disp: disp_opt;
 	pci_emulations: string list;
 	pci_passthrough: bool;
-	vgpu: (string * string) option;
+	vgpu: vgpu_t option;
 
 	(* Xenclient extras *)
 	xenclient_enabled : bool;
@@ -1754,11 +1760,13 @@ let vnconly_cmdline ~info ?(extras=[]) domid =
 
 let vgpu_args_of_info info domid =
 	match info.vgpu with
-		| Some (pci_id, config) ->
-			[ "--domain=" ^ (string_of_int domid);
-			  "--vcpus=" ^ (string_of_int info.vcpus);
-			  "--gpu=" ^ pci_id;
-			  "--config=" ^ config
+		| Some vgpu ->
+			[
+				"--domain=" ^ (string_of_int domid);
+				"--vcpus=" ^ (string_of_int info.vcpus);
+				"--gpu=" ^ vgpu.pci_id;
+				"--config=" ^ vgpu.config
+					^ ",disable_vnc=" ^ (if vgpu.vnc_enabled then "0" else "1");
 			]
 		| None -> []
 

--- a/ocaml/xenops/device.mli
+++ b/ocaml/xenops/device.mli
@@ -186,6 +186,13 @@ sig
 
 	type media = Disk | Cdrom
 
+	type vgpu_t = {
+		pci_id: string; (* The PCI device on which the vGPU will run. *)
+		config: string; (* Path to the vGPU config file. *)
+		vnc_enabled: bool; (* Flag to enable framebuffer copying to VNC console. *)
+	}
+
+
 	type info = {
 		memory: int64;
 		boot: string;
@@ -200,7 +207,7 @@ sig
 		disp: disp_opt;
 		pci_emulations: string list;
 		pci_passthrough: bool;
-		vgpu: (string * string) option;
+		vgpu: vgpu_t option;
 
 		(* Xenclient extras *)
 		xenclient_enabled: bool;

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -947,11 +947,20 @@ module VM = struct
 						let vgpu =
 							try
 								let vgpu_pci = List.assoc Xapi_globs.vgpu_pci_key vm.Vm.platformdata
-								and vgpu_config = List.assoc Xapi_globs.vgpu_config_key vm.Vm.platformdata in
-								debug "VGPU config: %s -> %s; %s -> %s"
+								and vgpu_config = List.assoc Xapi_globs.vgpu_config_key vm.Vm.platformdata
+								and vgpu_vnc_enabled =
+									try bool_of_string (List.assoc Xapi_globs.vgpu_vnc_enabled_key vm.Vm.platformdata)
+									with _ -> true
+								in
+								debug "VGPU config: %s -> %s; %s -> %s; %s -> %b"
 									Xapi_globs.vgpu_pci_key vgpu_pci
-									Xapi_globs.vgpu_config_key vgpu_config;
-								Some (vgpu_pci, vgpu_config)
+									Xapi_globs.vgpu_config_key vgpu_config
+									Xapi_globs.vgpu_vnc_enabled_key vgpu_vnc_enabled;
+								Some {
+									Device.Dm.pci_id = vgpu_pci;
+									config = vgpu_config;
+									vnc_enabled = vgpu_vnc_enabled
+								}
 							with Not_found -> failwith "Missing vGPU config in platform data" in
 						Device.Dm.Vgpu, vgpu
 				in


### PR DESCRIPTION
Setting VM.platform:vgpu_vnc_enabled to "true" or "false" will enable or
disable copying of the vGPU's framebuffer to the VNC console. The
setting will default to enabled if the platform key is not present.
