### PR TITLE
CA-114333: Allow Linux HVM guests to use >4 devices.

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -466,7 +466,7 @@ let release (task: Xenops_task.t) ~xs (x: device) =
 	 * to unplug as well as the backend. CA-13506 *)
 	if x.frontend.domid = 0 then Hotplug.wait_for_frontend_unplug task ~xs x
 
-let free_device ~xs bus_type domid =
+let free_device ~xs hvm domid =
 	let disks = List.map
 		(fun x -> x.frontend.devid
 		|> Device_number.of_xenstore_key
@@ -474,6 +474,8 @@ let free_device ~xs bus_type domid =
 		|> (fun (_, disk, _) -> disk))
 		(Device_common.list_frontends ~xs domid) in
 	let next = List.fold_left max 0 disks + 1 in
+	let open Device_number in
+        let bus_type = if (hvm && next < 4) then Ide else Xen in	
 	bus_type, next, 0
 
 type t = {
@@ -496,7 +498,7 @@ let add_async ~xs ~hvm x domid =
 	let device_number = match x.device_number with
 		| Some x -> x
 		| None ->
-			make (free_device ~xs (if hvm then Ide else Xen) domid) in
+			make (free_device ~xs hvm domid) in
 	let devid = to_xenstore_key device_number in
 	let device = 
 	  let backend = { domid = x.backend_domid; kind = Vbd; devid = devid } 


### PR DESCRIPTION
Windows PV drivers don't check the guest device name, but the Linux kernel does
With devices > 4, Linux expects them to be in xvdN format, so this patch ensures
that all devices are treated as Linux devices

Signed-off-by: Bob Ball bob.ball@citrix.com
