### PR TITLE
Replace hard-coded mail-alarm sender with a user-setable value.

### DIFF
--- a/scripts/mail-alarm
+++ b/scripts/mail-alarm
@@ -396,7 +396,7 @@ def main():
         return 1
 
     if not sender:
-        sender = "noreply@%s" % getfqdn.encode('utf-8')
+        sender = "noreply@%s" % getfqdn().encode('utf-8')
 
     # Replace macros in config file using search_replace list
     for s,r in search_replace:


### PR DESCRIPTION
Without this patch, email from the pool are sent from
noreply@${FSQN}. Some organisations setup their email so as to only
allow emails from  whitelist of addresses, so are unable to get mail
alerts.

This patch lets the administrator run:
xe pool-param-set other-config:mail-sender=${SENDER}
to choose an whitelisted address.
