### PR TITLE
Revert "CA-108916: add call to V6rpc.get_current_edition API"

### DIFF
--- a/ocaml/license/fakev6.ml
+++ b/ocaml/license/fakev6.ml
@@ -36,7 +36,3 @@ let get_version dbg =
 	Debug.with_thread_associated dbg (fun () -> "") ()
 
 let reopen_logs () = true
-
-let get_current_edition dbg additional =
-	Debug.with_thread_associated dbg (fun () ->
-		Edition.(to_string Free, to_features Free, [])) ()

--- a/ocaml/license/fakev6.mli
+++ b/ocaml/license/fakev6.mli
@@ -28,6 +28,3 @@ val get_version : string -> string
 (** Close and re-open the log file *)
 val reopen_logs : unit -> bool
 
-(** Call the [get_current_edition] function on the v6d *)
-val get_current_edition : string -> (string * string) list ->
-	string * Features.feature list * (string * string) list

--- a/ocaml/license/v6client.ml
+++ b/ocaml/license/v6client.ml
@@ -27,7 +27,7 @@ let v6rpc call =
 	let open Xmlrpc_client in
 	XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"v6d" ~transport:(Unix socket) ~http:(xmlrpc ~version:"1.0" "/") call
 
-let construct_additional ~__context additional =
+let rec apply_edition ~__context edition additional =
 	(* Get localhost's current license state. *)
 	let host = Helpers.get_localhost ~__context in
 	let license_server = Db.Host.get_license_server ~__context ~self:host in
@@ -40,13 +40,9 @@ let construct_additional ~__context additional =
 	let socket_count = List.assoc "socket_count" cpu_info in
 	let current_license_params =
 		List.replace_assoc "sockets" socket_count current_license_params in
+	(* Construct the RPC params to be sent to v6d *)
 	let additional = ("current_edition", current_edition) ::
 		license_server @ current_license_params @ additional in
-	additional
-
-let rec apply_edition ~__context edition additional =
-	(* Construct the RPC params to be sent to v6d *)
-	let additional = construct_additional ~__context additional in
 	let params = [ Rpc.rpc_of_string (Context.string_of_task __context)
 				 ; V6rpc.rpc_of_apply_edition_in
 					 { V6rpc.edition_in = edition
@@ -102,27 +98,3 @@ let get_version dbg =
 	with _ ->
 		raise (Api_errors.Server_error (Api_errors.v6d_failure, []))
 
-let get_current_edition ~__context additional =
-	try
-		let additional = construct_additional ~__context additional in
-		let params = [ Rpc.rpc_of_string (Context.string_of_task __context)
-		             ; V6rpc.rpc_of_get_current_edition_in additional ] in
-
-		let call = Rpc.call "get_current_edition" params in
-		let response = try v6rpc call with _ -> raise V6DaemonFailure in
-
-		debug "response: %s" (Rpc.to_string response.Rpc.contents);
-
-		if response.Rpc.success then
-			(* We reuse apply_edition_out for this RPC call *)
-			let r = V6rpc.apply_edition_out_of_rpc response.Rpc.contents in
-			r.V6rpc.edition_out, r.V6rpc.features_out, r.V6rpc.additional_out
-		else
-			let e = V6errors.error_of_rpc response.Rpc.contents in
-			match e with
-			| s, _ when s = V6errors.v6d_failure ->
-				raise V6DaemonFailure
-			| name, args ->
-				raise (Api_errors.Server_error (name, args))
-	with _ ->
-		raise (Api_errors.Server_error (Api_errors.v6d_failure, []))

--- a/ocaml/license/v6client.mli
+++ b/ocaml/license/v6client.mli
@@ -27,6 +27,3 @@ val get_editions : string -> (string * string * string * int) list
 (** Call the [get_version] function on the v6d *)
 val get_version : string -> string
 
-(** Call the [get_current_edition] function on the v6d *)
-val get_current_edition : __context:Context.t -> (string * string) list ->
-	string * Features.feature list * (string * string) list

--- a/ocaml/license/v6rpc.ml
+++ b/ocaml/license/v6rpc.ml
@@ -31,15 +31,9 @@ type get_editions_out = {
 	editions: names list;
 } with rpc
 
-type get_current_edition_in = (string * string) list with rpc
-
 module type V6api = sig
-	(* dbg_str -> edition -> additional_params ->
-		 edition * enabled_features * additional_params *)
+	(* dbg_str -> edition -> additional_params -> enabled_features, additional_params *)
 	val apply_edition : string -> string -> (string * string) list ->
-		string * Features.feature list * (string * string) list
-	(* dbg_str -> edition * enabled_features * additional_params *)
-	val get_current_edition : string -> (string * string) list ->
 		string * Features.feature list * (string * string) list
 	(* dbg_str -> list of editions (name, marketing name, short name) *)
 	val get_editions : string -> (string * string * string * int) list
@@ -66,24 +60,6 @@ module V6process = functor(V: V6api) -> struct
 				let response = rpc_of_apply_edition_out
 					{edition_out = edition; features_out = features; additional_out = additional_params} in 
 				Rpc.success response
-
-			| "get_current_edition" ->
-				let dbg_rpc, arg_rpc = match call.Rpc.params with
-					| [a;b] -> (a,b)
-					| _ ->
-						debug "Error in get_current_edition rpc" ;
-						raise (V6errors.Error ("unmarshalling_error", [])) in
-				let arg = get_current_edition_in_of_rpc arg_rpc in
-				let dbg = Rpc.string_of_rpc dbg_rpc in
-				let edition, features, additional_params =
-					V.get_current_edition dbg arg in
-				(* We reuse rpc_of_apply_edition_out for this RPC call *)
-				let response = rpc_of_apply_edition_out
-					{edition_out = edition;
-					 features_out = features;
-					 additional_out = additional_params} in
-				Rpc.success response
-
 			| "get_editions" ->
 				let dbg_rpc = match call.Rpc.params with
 					| [a] -> a

--- a/ocaml/license/v6rpc.mli
+++ b/ocaml/license/v6rpc.mli
@@ -17,12 +17,8 @@
 (** The RPC interface of the licensing daemon *)
 module type V6api =
 	sig
-		(*  dbg_str -> edition -> additional_params ->
-				edition * enabled_features * additional_params *)
+		(*  dbg_str -> edition -> additional_params -> enabled_features, additional_params *)
 		val apply_edition : string -> string -> (string * string) list ->
-			string * Features.feature list * (string * string) list
-		(* dbg_str -> edition * enabled_features * additional_params *)
-		val get_current_edition : string -> (string * string) list ->
 			string * Features.feature list * (string * string) list
 		(* dbg_str -> list of editions *)
 		val get_editions : string -> (string * string * string * int) list
@@ -30,7 +26,7 @@ module type V6api =
 		val get_version : string -> string
 		(* () -> version *)
 		val reopen_logs : unit -> bool
-	end
+	end  
 
 (** RPC handler module *)
 module V6process : functor (V : V6api) ->
@@ -85,12 +81,3 @@ val get_editions_out_of_rpc : Rpc.t -> get_editions_out
 (** Convert {!get_editions_out} structure into RPC *)
 val rpc_of_get_editions_out : get_editions_out -> Rpc.t
 
-
-(** Definition of [get_current_edition] RPC *)
-type get_current_edition_in = (string * string) list
-
-(** Convert RPC into {!get_current_edition_in} structure *)
-val get_current_edition_in_of_rpc : Rpc.t -> get_current_edition_in
-
-(** Convert {!get_current_edition_in} structure into RPC *)
-val rpc_of_get_current_edition_in : get_current_edition_in -> Rpc.t

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1148,22 +1148,12 @@ let set_license_params ~__context ~self ~value =
 	Db.Host.set_license_params ~__context ~self ~value;
 	Pool_features.update_pool_features ~__context
 
-let apply_edition_internal	~__context ~host ~edition ~additional =
-	let db_update_license edition features additional =
-		Db.Host.set_edition ~__context ~self:host ~value:edition;
-		copy_license_to_db ~__context ~host ~features ~additional in
-	try
-		let edition, features, additional =
-			V6client.apply_edition ~__context edition additional in
-		db_update_license edition features additional
-	with e ->
-		(* If we catch an exception, retrieve what v6d thinks are the
-		   current license parameters and rethrow the exception. *)
-		let new_edition, features, additional =
-			V6client.get_current_edition ~__context additional in
-		warn "v6d: couldn't apply '%s' edition; new edition is '%s'" edition new_edition ;
-		db_update_license new_edition features additional ;
-		raise e
+let apply_edition_internal  ~__context ~host ~edition ~additional =
+	let edition', features, additional =
+		V6client.apply_edition ~__context edition additional
+	in
+	Db.Host.set_edition ~__context ~self:host ~value:edition';
+	copy_license_to_db ~__context ~host ~features ~additional
 
 let apply_edition ~__context ~host ~edition ~force =
 	(* if HA is enabled do not allow the edition to be changed *)


### PR DESCRIPTION
This reverts commit 04f4d921c9d657f928fb4768abc390095b1418cc.
CA-113278: This commit was causing many testcases to fail. Reverting the commit for now till we figure out a better way to fix the original problem.

Signed-off-by: Akshay akshay.ramani@citrix.com
