### PR TITLE
Give message to error when VGPU_type import fails

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -960,8 +960,9 @@ module VGPUType : HandlerTools = struct
 		match choose_one compatible_types with
 		| Some (vgpu_type, _) -> Found_VGPU_type vgpu_type
 		| None ->
-			let msg = ""
-			in
+			let msg = Printf.sprintf "Unable to find equivalent VGPU_type '%s'"
+				vgpu_type_record.API.vGPU_type_model_name in
+			error "%s" msg;
 			Found_no_VGPU_type (Failure msg)
 
 	let handle_dry_run __context config rpc session_id state x precheck_result =


### PR DESCRIPTION
This was raising an error with an empty string. Now it follows the same pattern
as the error paths for importing other types (see GPU group import).

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
