### PR TITLE
CA-113612: Uncomment hvm_check_pvdriver in Domain.shutdown_wait_for_ack

### DIFF
--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -307,7 +307,7 @@ let shutdown ~xc ~xs domid req =
 let shutdown_wait_for_ack (t: Xenops_task.t) ?(timeout=60.) ~xc ~xs domid req =
 	let di = Xenctrl.domain_getinfo xc domid in
 	let uuid = get_uuid ~xc domid in
-	if (di.Xenctrl.hvm_guest) (* not (Xenctrl.hvm_check_pvdriver xc domid)) *) then begin
+	if di.Xenctrl.hvm_guest && not (Xenctrl.hvm_check_pvdriver xc domid) then begin
 		debug "VM = %s; domid = %d; HVM guest without PV drivers: not expecting any acknowledgement" (Uuid.to_string uuid) domid;
 		Xenctrl.domain_shutdown xc domid (shutdown_to_xc_shutdown req)
 	end else begin


### PR DESCRIPTION
The last two changes in this function (e8a7d8229c426a573bf461a0667993ed7644b28e
and 939cd11ecfa56daafc2daa1c3c81b1a2b97b0ffa) seem to have accidentally
commented-out an essential check.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
