### PR TITLE
Fix XenAPI.py on python2.7

### DIFF
--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -97,6 +97,7 @@ class UDSHTTP(httplib.HTTP):
 
 class UDSTransport(xmlrpclib.Transport):
     def __init__(self, use_datetime=0):
+        xmlrpclib.Transport.__init__(self, use_datetime)
         self._use_datetime = use_datetime
         self._extra_headers=[]
     def add_extra_header(self, key, value):


### PR DESCRIPTION
This fix was made by Mike Mcclurg here:

https://bugs.launchpad.net/xcp/+bug/917913

I tested it on Ubuntu raring and XenServer release 6.2.50-74022c
