### PR TITLE
Revert "Remove a modprobe warning in new systems."

### DIFF
--- a/scripts/xe-switch-network-backend
+++ b/scripts/xe-switch-network-backend
@@ -49,7 +49,7 @@ for i in /etc/sysconfig/network-scripts/ifcfg-* ; do
 done
 
 
-BLACKLIST=/etc/modprobe.d/blacklist-bridge.conf
+BLACKLIST=/etc/modprobe.d/blacklist-bridge
 if [ "$new" = "openvswitch" ] ; then
 	# Add blacklist of bridge module so it can't be loaded.
 	echo "install bridge /bin/true" > $BLACKLIST


### PR DESCRIPTION
This breaks switching to the bridge networking backend - this
change means /etc/modprobe.d/blacklist-bridge is not deleted when
switching to bridge, so after the host reboots it can't load the
ethernet bridging kernel module and networking is totally broken.

This reverts commit 37eee6eff0ce3fb4a0185e6f4aa03094c0668844.
