### PR TITLE
Revert "Fix XenAPI.py on python2.7"

### DIFF
--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -97,7 +97,6 @@ class UDSHTTP(httplib.HTTP):
 
 class UDSTransport(xmlrpclib.Transport):
     def __init__(self, use_datetime=0):
-        xmlrpclib.Transport.__init__(self, use_datetime)
         self._use_datetime = use_datetime
         self._extra_headers=[]
     def add_extra_header(self, key, value):


### PR DESCRIPTION
Unfortunately python2.4 doesn't work with this fix.

This reverts commit 7cd259574198123e9152db4a483bae54eed15c95.
