### PR TITLE
Enable -bin-annot compiler flag

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -26,7 +26,7 @@ OCAMLDEP_MODULES_ENABLED = false
 
 USE_OCAMLFIND = true
 
-OCAMLFLAGS = -g -dtypes -thread -warn-error +a-4-6-9-27-28-29
+OCAMLFLAGS = -g -dtypes -bin-annot -thread -warn-error +a-4-6-9-27-28-29
 
 # c compiling stuff
 OCAMLCFLAGS += -g


### PR DESCRIPTION
This enables binary annotation for use with tools such as ocamlspotter.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
