### PR TITLE
CA-108916: Revert to free when apply_edition fails

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1149,11 +1149,19 @@ let set_license_params ~__context ~self ~value =
 	Pool_features.update_pool_features ~__context
 
 let apply_edition_internal  ~__context ~host ~edition ~additional =
-	let edition', features, additional =
-		V6client.apply_edition ~__context edition additional
-	in
-	Db.Host.set_edition ~__context ~self:host ~value:edition';
-	copy_license_to_db ~__context ~host ~features ~additional
+	let db_update_license edition features additional =
+		Db.Host.set_edition ~__context ~self:host ~value:edition;
+		copy_license_to_db ~__context ~host ~features ~additional in
+	try
+		let edition', features, additional =
+			V6client.apply_edition ~__context edition additional in
+		db_update_license edition' features additional
+	with e ->
+		(* If we catch an exception, retry with free edition and rethrow *)
+		let edition', features, additional =
+			V6client.apply_edition ~__context "free" additional in
+		db_update_license edition' features additional ;
+		raise e
 
 let apply_edition ~__context ~host ~edition ~force =
 	(* if HA is enabled do not allow the edition to be changed *)


### PR DESCRIPTION
Previously, when applying a new edition failed (for instance, if an incorrect
license server address is used), xapi will continue to operate under the old
edition's license parameters, even though v6d had released the license back to
the license server. This was a design decsion made on-purpose in order to give
the user the benefit of the doubt.

Since it is now less dangerous for a host to lose a license due to a fat-finger
mistake like this, we'd like to remove this functionality and instead revert to
the free edition when V6client.apply_edition returns an exception. We now
reapply the free edition, and then rethrow the original exception.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
