### PR TITLE
Remove the correct xenstore key when PCI unplugging.

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -1376,7 +1376,7 @@ let plug (task: Xenops_task.t) ~xc ~xs (domain, bus, dev, func) domid =
 
 let unplug (task: Xenops_task.t) ~xc ~xs (domain, bus, dev, func) domid =
 	try
-		let current = list ~xc ~xs domid in
+		let current = read_pcidir ~xc ~xs domid in
 
 		let pci = to_string (domain, bus, dev, func) in
 		let idx = fst (List.find (fun x -> snd x = (domain, bus, dev, func)) current) in


### PR DESCRIPTION
We were always attempting to remove dev-0 instead of dev-n. This
led to multiple attempts to e.g. deassign_device for all but the
first passed through device. It also led to a cancelled shutdown
attempting to unplug everything again without any exception handler,
leading to an infinite loop.
