### PR TITLE
Revert "CA-109035: Remove the correct xenstore key when PCI unplugging."

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -1376,7 +1376,7 @@ let plug (task: Xenops_task.t) ~xc ~xs (domain, bus, dev, func) domid =
 
 let unplug (task: Xenops_task.t) ~xc ~xs (domain, bus, dev, func) domid =
 	try
-		let current = read_pcidir ~xc ~xs domid in
+		let current = list ~xc ~xs domid in
 
 		let pci = to_string (domain, bus, dev, func) in
 		let idx = fst (List.find (fun x -> snd x = (domain, bus, dev, func)) current) in


### PR DESCRIPTION
This reverts commit 1fd7e5aad5a2f272cc0ed0b39f5a1969bfb3e9f4.

Removing this patch for the tech preview since it hasn't been QA'd yet.
