### PR TITLE
Move /xapi/* -> /xenops/* in XenStore

### DIFF
--- a/ocaml/xenops/device_common.ml
+++ b/ocaml/xenops/device_common.ml
@@ -167,7 +167,7 @@ let to_list ys = List.concat (List.map Opt.to_list ys)
 let list_kinds ~xs dir = to_list (List.map parse_kind (readdir ~xs dir))
 
 let list_devices ~xs domid =
-	let path = Printf.sprintf "/xapi/%d/private" domid in
+	let path = Printf.sprintf "/xenops/%d/private" domid in
 	let kinds = list_kinds ~xs path in
 	List.concat (List.map
 		(fun k ->

--- a/ocaml/xenops/hotplug.ml
+++ b/ocaml/xenops/hotplug.ml
@@ -51,9 +51,9 @@ exception Hotplug_error of string
 (* We store some transient data elsewhere in xenstore to avoid it getting
    deleted by accident when a domain shuts down. We should always zap this
    tree on boot. *)
-let private_path = "/xapi"
+let private_path = "/xenops"
 
-(* The private data path is only used by xapi and ignored by frontend and backend *)
+(* The private data path is only used by xenops and ignored by frontend and backend *)
 let get_private_path domid = sprintf "%s/%d" private_path domid
 
 let get_private_data_path_of_device (x: device) = 


### PR DESCRIPTION
It's really xenops that's using these paths so it makes sense that these paths
be under that name.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
