### PR TITLE
CA-113235: Don't call init.d scripts directly

### DIFF
--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -28,7 +28,7 @@ let config : config_t ref = ref empty_config
 
 let legacy_management_interface_start () =
 	try
-		ignore (call_script "/etc/init.d/management-interface" ["start"]);
+		ignore (call_script "/sbin/service" ["management-interface"; "start"]);
 		debug "Upgrade: brought up interfaces using the old script. Xapi will sync up soon."
 	with e ->
 		debug "Error while configuring the management interface using the old script: %s\n%s"

--- a/ocaml/xapi/static_vdis.ml
+++ b/ocaml/xapi/static_vdis.ml
@@ -85,8 +85,8 @@ let gc () =
 (** If we just rebooted and failed to attach our static VDIs then this can be called to reattempt the attach:
 	this is necessary for HA to start. *)
 let reattempt_on_boot_attach () =
-	let script = "/etc/init.d/attach-static-vdis" in
+	let script = "attach-static-vdis" in
 	try
-		ignore(Helpers.call_script script [ "start" ])
+		ignore(Helpers.call_script "/sbin/service" [ script; "start" ])
 	with e ->
 		warn "Attempt to reattach static VDIs via '%s start' failed: %s" script (ExnHelper.string_of_exn e)


### PR DESCRIPTION
Some daemons are launched invoking /etc/init.d scripts directly. This
could be a problem in environment with upstart which wants to know the
status of these services. For this reason it's better to use the {service}
command to notify upstart.

Signed-off-by: Euan Harris euan.harris@citrix.com
