### PR TITLE
CP-6271: Set default mode for XSM checks to use UUIDs

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -23,7 +23,7 @@ module D = Debug.Debugger(struct let name="xapi_globs" end)
 let use_xenopsd = ref false
 
 (* set this to true to enable XSM to out-of-pool SRs with matching UUID *)
-let relax_xsm_sr_check = ref false
+let relax_xsm_sr_check = ref true
 
 (* xapi process returns this code on exit when it wants to be restarted *)
 let restart_return_code = 123


### PR DESCRIPTION
After this change the code at xapi_vm_migrate.ml:362 will
check if the VDI exists (by UUID) in the destination SR.
If it does, a mirror will not be performed as the VDI already exists.

The original behaviour can be used by setting the value to false in xapi.conf

Signed-off-by: Bob Ball bob.ball@citrix.com
