### PR TITLE
CA-115915: Network backend is not a VIF thing.

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -433,7 +433,6 @@ module MD = struct
 			extra_private_keys = [
                                 "vif-uuid", vif.API.vIF_uuid;
 				"network-uuid", net.API.network_uuid;
-                                "network-backend", Network_interface.string_of_kind (Net.Bridge.get_kind dbg ());
                         ]
 		}
 


### PR DESCRIPTION
Note that this requires a xenopsd with with appropriate
changes in. (use CA-ticket to find the commit)

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
