### PR TITLE
Add VBD.other_config:backend-kind for blktap3

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -174,6 +174,8 @@ let host_console_vncport = 5900 (* guaranteed by the startup scripts *)
 let vhd_parent = "vhd-parent" (* set in VDIs backed by VHDs *)
 
 let owner_key = "owner" (* set in VBD other-config to indicate that clients can delete the attached VDI on VM uninstall if they want.. *)
+let vbd_backend_key = "backend-kind" (* set in VBD other-config *)
+let vbd_backend_default = "blktap2"
 
 let using_vdi_locking_key = "using-vdi-locking" (* set in Pool other-config to indicate that we should use storage-level (eg VHD) locking *)
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -350,6 +350,13 @@ module MD = struct
 				warn "Unknown VBD QoS type: %s (try 'ionice')" x;
 				None in
 
+		let backend_kind_of_vbd vbd =
+			let oc = vbd.API.vBD_other_config in
+			let k = Xapi_globs.vbd_backend_key in
+			let v = try List.assoc k oc with _ -> Xapi_globs.vbd_backend_default in
+			(k, v)
+		in
+
 		{
 			id = (vm.API.vM_uuid, Device_number.to_linux_device device_number);
 			position = Some device_number;
@@ -357,7 +364,7 @@ module MD = struct
 			backend = disk_of_vdi ~__context ~self:vbd.API.vBD_VDI;
 			ty = if vbd.API.vBD_type = `Disk then Disk else CDROM;
 			unpluggable = vbd.API.vBD_unpluggable;
-			extra_backend_keys = [];
+			extra_backend_keys = [ backend_kind_of_vbd vbd ];
 			extra_private_keys = [];
 			qos = qos ty;
 		}


### PR DESCRIPTION
Note: this change is co-dependent on a change in xenopsd.

Blktap3 and kernel blkback need to co-exist and, since kernel blkback watches
keys in the /local/domain/0/vbd/ tree, the paths for blktap3 need to be moved.

A new key has been added to the other_config field of the VBD record which is
passed through to xenopsd to determine where to place the VBD's XenStore
entries.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
