### PR TITLE
CA-94735: Check host liveness with oclock instead of gettimeofday

### DIFF
--- a/ocaml/xapi/db_gc.ml
+++ b/ocaml/xapi/db_gc.ml
@@ -186,7 +186,7 @@ let check_host_liveness ~__context =
 	(* Use whichever value is the most recent to determine host liveness *)
 	let host_time = max old_heartbeat_time new_heartbeat_time in
 
-	let now = Unix.gettimeofday () in
+	let now = Int64.to_float (Oclock.gettime Oclock.monotonic) /. 1e9 in
 	(* we can now compare 'host_time' with 'now' *) 
 
 	if now -. host_time < !Xapi_globs.host_assumed_dead_interval then begin
@@ -439,7 +439,7 @@ let tickle_heartbeat ~__context host stuff =
 				if use_host_heartbeat_for_liveness
 				then Xapi_host_helpers.mark_host_as_dead ~__context ~host ~reason
 			end else begin
-				let now = Unix.gettimeofday () in
+				let now = Int64.to_float (Oclock.gettime Oclock.monotonic) /. 1e9 in
 				Hashtbl.replace host_heartbeat_table host now;
 				(* compute the clock skew for later analysis *)
 				if List.mem_assoc _time stuff then begin

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -519,7 +519,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
 	~guest_VCPUs_params:[]
   ;
   (* If the host we're creating is us, make sure its set to live *)
-  Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.of_float (Unix.gettimeofday ()));
+  Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.of_float (Int64.to_float (Oclock.gettime Oclock.monotonic) /. 1e9));
   Db.Host_metrics.set_live ~__context ~self:metrics ~value:(uuid=(Helpers.get_localhost_uuid ()));
   host
 

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -143,7 +143,7 @@ let update_host_metrics ~__context ~host ~memory_total ~memory_free =
       (fun () -> List.mem host !Xapi_globs.hosts_which_are_shutting_down) in
   let should_set_live = not ha_enabled && not shutting_down in
 
-  let last_updated = Date.of_float (Unix.gettimeofday ()) in
+  let last_updated = Date.of_float (Int64.to_float (Oclock.gettime Oclock.monotonic) /. 1e9) in
   let m = Db.Host.get_metrics ~__context ~self:host in
   (* Every host should always have a Host_metrics object *)
   if Db.is_valid_ref __context m then begin


### PR DESCRIPTION
Untested.

Signed-off-by: Jerome Maloberti jerome.maloberti@citrix.com
