### PR TITLE
[BOSTON] Fix data races in HA when slaves return in the pool.

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -975,8 +975,8 @@ let server_init() =
 	debug "Waiting forever for the management interface to gain an IP address";
 	let ip = wait_for_management_ip_address () in
 	debug "Management interface got IP address: %s; attempting to re-plug any unplugged PBDs" ip;
-	Helpers.call_api_functions ~__context (fun rpc session_id -> 
-	       Create_storage.plug_unplugged_pbds __context rpc session_id)
+	Helpers.call_api_functions ~__context (fun rpc session_id ->
+		Create_storage.plug_unplugged_pbds __context)
       )
       in
 

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -521,7 +521,7 @@ module Monitor = struct
 				let now = Unix.gettimeofday () in
 				let plan_too_old = now -. !last_plan_time > Xapi_globs.ha_monitor_plan_timer in
 				if plan_too_old || !plan_out_of_date then begin
-					let changed = Xapi_ha_vm_failover.update_pool_status ~__context in
+					let changed = Xapi_ha_vm_failover.update_pool_status ~__context ~live_set:liveset_refs () in
 
 					(* Extremely bad: something managed to break our careful plan *)
 					if changed && not !plan_out_of_date then error "Overcommit protection failed to prevent a change which invalidated our failover plan";
@@ -1461,7 +1461,7 @@ let enable __context heartbeat_srs configuration =
 		(* Update the Pool's planning configuration (ha_overcommitted, ha_plan_exists_for) *)
 		(* Start by assuming there is no ha_plan_for: this can be revised upwards later *)
 		Db.Pool.set_ha_plan_exists_for ~__context ~self:pool ~value:0L;
-		let (_: bool) = Xapi_ha_vm_failover.update_pool_status ~__context in
+		let (_: bool) = Xapi_ha_vm_failover.update_pool_status ~__context () in
 
 		let generation = Uuid.string_of_uuid (Uuid.make_uuid ()) in
 

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -430,53 +430,53 @@ let restart_auto_run_vms ~__context live_set n =
 	   an accurate way to determine 'failed' VMs but it will suffice for our 'best-effort' 
 	   category. *)
 	let reset_vms = ref [] in
-	List.iter
-		(fun h ->
-			if not (List.mem h live_set) then
-				begin
-					let hostname = Db.Host.get_hostname ~__context ~self:h in
-					debug "Setting host %s to dead" hostname;
-					(* Sample this before calling any hook scripts *)
-					let resident_on_vms = Db.Host.get_resident_VMs ~__context ~self:h in
-					reset_vms := resident_on_vms @ !reset_vms;
-
-					(* ensure live=false *)
-					begin
-						try
-							let h_metrics = Db.Host.get_metrics ~__context ~self:h in
-							let current = Db.Host_metrics.get_live ~__context ~self:h_metrics in
-							if current then begin
-								(* Fire off a ha_host_failed message if the host hasn't just shut itself down *)
-								let shutting_down = Threadext.Mutex.execute Xapi_globs.hosts_which_are_shutting_down_m (fun () -> !Xapi_globs.hosts_which_are_shutting_down) in
-								if not (List.exists (fun x -> x=h) shutting_down) then begin
-									let obj_uuid = Db.Host.get_uuid ~__context ~self:h in
-									let host_name = Db.Host.get_name_label ~__context ~self:h in
-									Xapi_alert.add ~name:Api_messages.ha_host_failed ~priority:Api_messages.ha_host_failed_priority ~cls:`Host ~obj_uuid
-										~body:(Printf.sprintf "Server '%s' has failed" host_name);
-								end;
-								(* Call external host failed hook (allows a third-party to use power-fencing if desired) *)
-								Xapi_hooks.host_pre_declare_dead ~__context ~host:h ~reason:Xapi_hooks.reason__fenced;
-								Db.Host_metrics.set_live ~__context ~self:h_metrics ~value:false; (* since slave is fenced, it will not set this to true again itself *)
-								Xapi_host_helpers.update_allowed_operations ~__context ~self:h;
-								Xapi_hooks.host_post_declare_dead ~__context ~host:h ~reason:Xapi_hooks.reason__fenced;
-							end
-						with _ -> 
-							(* if exn assume h_metrics doesn't exist, then "live" is defined to be false implicitly, so do nothing *)
-							()
-					end;
-					debug "Setting all VMs running or paused on %s to Halted" hostname;
-					(* ensure all vms resident_on this host running or paused have their powerstates reset *)
-
-					List.iter
-						(fun vm ->
-							let vm_powerstate = Db.VM.get_power_state ~__context ~self:vm in
-							if (vm_powerstate=`Running || vm_powerstate=`Paused) then
-								Xapi_vm_lifecycle.force_state_reset ~__context ~self:vm ~value:`Halted
-						)
-						resident_on_vms
-				end
-		)
-		hosts;
+	let dead_hosts = ref [] in 
+	List.iter (fun h ->
+		if not (List.mem h live_set) then begin
+	  		let hostname = Db.Host.get_hostname ~__context ~self:h in
+			debug "Setting host %s to dead" hostname;
+			(* Sample this before calling any hook scripts *)
+			let resident_on_vms = List.filter
+				(fun vm -> not (Db.VM.get_is_control_domain ~__context ~self:vm)) 
+				(Db.Host.get_resident_VMs ~__context ~self:h) in
+			reset_vms := resident_on_vms @ !reset_vms;
+			
+			(* ensure live=false *)
+			begin
+				try
+					let h_metrics = Db.Host.get_metrics ~__context ~self:h in
+					let current = Db.Host_metrics.get_live ~__context ~self:h_metrics in
+					if current then begin
+						(* Fire off a ha_host_failed message if the host hasn't just shut itself down *)
+						let shutting_down = Threadext.Mutex.execute Xapi_globs.hosts_which_are_shutting_down_m (fun () -> !Xapi_globs.hosts_which_are_shutting_down) in
+						if not (List.exists (fun x -> x=h) shutting_down) then begin
+							let obj_uuid = Db.Host.get_uuid ~__context ~self:h in
+							let host_name = Db.Host.get_name_label ~__context ~self:h in
+							Xapi_alert.add ~name:Api_messages.ha_host_failed ~priority:Api_messages.ha_host_failed_priority ~cls:`Host ~obj_uuid
+								~body:(Printf.sprintf "Server '%s' has failed" host_name);
+						end;
+						(* Call external host failed hook (allows a third-party to use power-fencing if desired) *)
+						Xapi_hooks.host_pre_declare_dead ~__context ~host:h ~reason:Xapi_hooks.reason__fenced;
+						Db.Host_metrics.set_live ~__context ~self:h_metrics ~value:false; (* since slave is fenced, it will not set this to true again itself *)
+						Xapi_host_helpers.update_allowed_operations ~__context ~self:h;
+						dead_hosts := h :: !dead_hosts;
+					end
+				with _ -> 
+					() (* if exn assume h_metrics doesn't exist, then "live" is defined to be false implicitly, so do nothing *)
+			end
+		end) hosts;
+	  
+	debug "Setting all VMs running or paused to Halted";
+	(* ensure all vms resident_on this host running or paused have their powerstates reset *)
+	List.iter (fun vm ->
+		let vm_powerstate = Db.VM.get_power_state ~__context ~self:vm in
+		if (vm_powerstate=`Running || vm_powerstate=`Paused) then
+			Xapi_vm_lifecycle.force_state_reset ~__context ~self:vm ~value:`Halted)
+	  !reset_vms;
+	(* host_post_declare_dead may take a long time if the SR is locked *)
+	dead_hosts := List.rev !dead_hosts;
+	List.iter (fun h -> Xapi_hooks.host_post_declare_dead ~__context ~host:h ~reason:Xapi_hooks.reason__fenced)
+	  !dead_hosts;
 
 	(* If something has changed then we'd better refresh the pool status *)
 	if !reset_vms <> [] then ignore(update_pool_status ~__context);

--- a/ocaml/xapi/xapi_ha_vm_failover.mli
+++ b/ocaml/xapi/xapi_ha_vm_failover.mli
@@ -42,13 +42,13 @@ type configuration_change = {
 val no_configuration_change : configuration_change
 
 (** Update the Pool.ha_* fields with the current planning status *)
-val update_pool_status : __context:Context.t -> bool
+val update_pool_status : __context:Context.t -> ?live_set:API.ref_host list -> unit -> bool
 
 (** Consider all possible failures of 'n' hosts *)
-val plan_for_n_failures : __context:Context.t -> all_protected_vms:((API.ref_VM * API.vM_t) list) -> ?change:configuration_change -> int -> result
+val plan_for_n_failures : __context:Context.t -> all_protected_vms:((API.ref_VM * API.vM_t) list) -> ?live_set:API.ref_host list -> ?change:configuration_change -> int -> result
 
 (** Compute the maximum plan size we can currently find *)
-val compute_max_host_failures_to_tolerate : __context:Context.t -> ?protected_vms:((API.ref_VM * API.vM_t) list) -> unit -> int64
+val compute_max_host_failures_to_tolerate : __context:Context.t -> ?live_set:API.ref_host list -> ?protected_vms:((API.ref_VM * API.vM_t) list) -> unit -> int64
 
 (** HA admission control functions: aim is to block operations which would make us become overcommitted: *)  
 val assert_vm_placement_preserves_ha_plan : __context:Context.t -> ?leaving:(API.ref_host * (API.ref_VM * API.vM_t)) list -> ?arriving:(API.ref_host * (API.ref_VM * API.vM_t)) list -> unit -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -948,9 +948,12 @@ let hello ~__context ~host_uuid ~host_address =
 	   host VMs it will mark itself as enabled again. *)
 	info "Host.enabled: setting host %s (%s) to disabled" (Ref.string_of host_ref) (Db.Host.get_hostname ~__context ~self:host_ref);
 	Db.Host.set_enabled ~__context ~self:host_ref ~value:false;
-	debug "Host_metrics.live: setting host %s (%s) to alive" (Ref.string_of host_ref) (Db.Host.get_hostname ~__context ~self:host_ref);
-	let metrics = Db.Host.get_metrics ~__context ~self:host_ref in
-	Db.Host_metrics.set_live ~__context ~self:metrics ~value:true;
+	let pool = Helpers.get_pool ~__context in
+	if not (Db.Pool.get_ha_enabled ~__context ~self:pool) then begin
+		debug "Host_metrics.live: setting host %s (%s) to alive" (Ref.string_of host_ref) (Db.Host.get_hostname ~__context ~self:host_ref);
+		let metrics = Db.Host.get_metrics ~__context ~self:host_ref in
+		Db.Host_metrics.set_live ~__context ~self:metrics ~value:true;
+	end;
 	(* Cancel tasks on behalf of slave *)
 	debug "Hello message from slave OK: cancelling tasks on behalf of slave";
 	Cancel_tasks.cancel_tasks_on_host ~__context ~host_opt:(Some host_ref);

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1165,7 +1165,7 @@ let set_ha_host_failures_to_tolerate ~__context ~self ~value =
   if Db.Pool.get_ha_plan_exists_for ~__context ~self:pool > 0L
   then Xapi_ha_vm_failover.assert_nfailures_change_preserves_ha_plan ~__context (Int64.to_int value);
   Db.Pool.set_ha_host_failures_to_tolerate ~__context ~self ~value;
-  let (_: bool) = Xapi_ha_vm_failover.update_pool_status ~__context in ()
+	let (_: bool) = Xapi_ha_vm_failover.update_pool_status ~__context () in ()
 
 let ha_schedule_plan_recomputation ~__context = 
   Xapi_ha.Monitor.plan_out_of_date := true

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -90,7 +90,7 @@ let set_ha_restart_priority ~__context ~self ~value =
 			Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context self;
 			let pool = Helpers.get_pool ~__context in
 			if Db.Pool.get_ha_enabled ~__context ~self:pool then
-				let (_: bool) = Xapi_ha_vm_failover.update_pool_status ~__context in ()
+				let (_: bool) = Xapi_ha_vm_failover.update_pool_status ~__context () in ()
 		end;
 
 	if current <> value then begin


### PR DESCRIPTION
Backport of https://github.com/xapi-project/xen-api/pull/1387 for Boston-lcm.

In HA, during the recovery process of failed hosts, there were data races due to the conflicts between the liveness information of a returning host and its live status as determined by the xha daemon.
These commits are fixing all the problems found when Xapi_hooks.host_post_declare_dead, which is called on every dead hosts, took few minutes to complete, leaving a large window to the dead hosts to come back in the pool.