### PR TITLE
[HFX-918] CA-73960: avoid allocating debug console for HVM

### DIFF
--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -594,8 +594,10 @@ let build_hvm ~xc ~xs ~static_max_kib ~target_kib ~shadow_multiplier ~vcpus
 
 	let local_stuff = [
 		"serial/0/limit",    string_of_int 65536;
+(*
 		"console/port",      string_of_int console_port;
 		"console/ring-ref",  sprintf "%nu" console_mfn;
+*)
 	] in
 (*
 	let store_mfn =
@@ -736,8 +738,10 @@ let hvm_restore ~xc ~xs ~static_max_kib ~target_kib ~shadow_multiplier ~vcpus  ~
 	                                            ~vcpus ~extras:[] domid fd in
 	let local_stuff = [
 		"serial/0/limit",    string_of_int 65536;
+(*
 		"console/port",     string_of_int console_port;
 		"console/ring-ref", sprintf "%nu" console_mfn;
+*)
 	] in
 	let vm_stuff = [
 		"rtc/timeoffset",    timeoffset;


### PR DESCRIPTION
This will save one event channel per HVM guest in Dom0, since we don't currently make use of it anyway.

Signed-off-by: Marcus Granado marcus.granado@citrix.com
