### PR TITLE
[HFX-954] Fix backport: Use correct interface for Xapi_alert

### DIFF
--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -465,7 +465,9 @@ let restart_auto_run_vms ~__context live_set n =
 						if not (List.exists (fun x -> x=h) shutting_down) then begin
 							let obj_uuid = Db.Host.get_uuid ~__context ~self:h in
 							let host_name = Db.Host.get_name_label ~__context ~self:h in
-							Xapi_alert.add ~msg:Api_messages.ha_host_failed ~cls:`Host ~obj_uuid
+							Xapi_alert.add ~name:Api_messages.ha_host_failed
+								~priority:Api_messages.ha_host_failed_priority
+								~cls:`Host ~obj_uuid
 								~body:(Printf.sprintf "Server '%s' has failed" host_name);
 						end;
 						(* Call external host failed hook (allows a third-party to use power-fencing if desired) *)


### PR DESCRIPTION
Fixes error introduced by 4ba168e which was a backported fix from trunk which
uses a different signature for Xapi_alert.add.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
