### PR TITLE
[SANIBEL] Fix memory utilisation reporting (migration race condition)

### DIFF
--- a/ocaml/xapi/monitor_rrds.ml
+++ b/ocaml/xapi/monitor_rrds.ml
@@ -696,7 +696,9 @@ let update_rrds ~__context timestamp dss uuids pifs rebooting_vms paused_vms =
 			  cur_mem <> old_mem
 			with _ -> true end in
 		  if changed then
-			dirty_memory := StringSet.add vm_uuid !dirty_memory;
+			let vm_ref = Db.VM.get_by_uuid ~__context ~uuid:vm_uuid in
+			if (Db.VM.get_resident_on ~__context ~self:vm_ref = Helpers.get_localhost ~__context)
+			then dirty_memory := StringSet.add vm_uuid !dirty_memory;
 		  
 		  (* Now update the rras/dss *)
 			Rrd.ds_update_named rrd timestamp (domid <> rrdi.domid)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1227,6 +1227,14 @@ let maximise_memory ~__context ~self ~total ~approximate =
 let atomic_set_resident_on ~__context ~vm ~host = assert false
 let update_snapshot_metadata ~__context ~vm ~snapshot_of ~snapshot_time = assert false
 
+let mark_vm_metrics_as_dirty ~__context ~vm =
+	let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
+	let open Rrd_shared in
+	Threadext.Mutex.execute mutex (fun () ->
+		dirty_memory := StringSet.add vm_uuid !dirty_memory;
+		Condition.broadcast condition
+	)
+
 let create_new_blob ~__context ~vm ~name ~mime_type =
   let blob = Xapi_blob.create ~__context ~mime_type in
   Db.VM.add_to_blobs ~__context ~self:vm ~key:name ~value:blob;

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -249,6 +249,7 @@ val update_snapshot_metadata :
 val create_new_blob :
   __context:Context.t ->
   vm:[ `VM ] Ref.t -> name:string -> mime_type:string -> [ `blob ] Ref.t
+val mark_vm_metrics_as_dirty : __context:Context.t -> vm:API.ref_VM -> unit
 
 (** {2 Experimental support for S3 suspend/ resume} *)
 

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -493,6 +493,8 @@ let receiver ~__context ~localhost is_localhost_migration fd vm xc xs memory_req
   Helpers.call_api_functions ~__context
     (fun rpc session_id -> Client.VM.atomic_set_resident_on rpc session_id vm localhost);
 
+  Xapi_vm.mark_vm_metrics_as_dirty ~__context ~vm;
+
   (* MTC: Normal XenMotion migration does not change the VM's power state *)
   Mtc.update_vm_state_if_necessary ~__context ~vm;
 


### PR DESCRIPTION
Fixes a race condition in pool migration whereby the memory-actual field may be incorrectly set to a spuriously low value and never updated.

The change is described in commit f0f94eb.

This has been tested by adding a delay on the sender side of the migration prior to the destruction of the domain and the spoofing of a memory value on the sender side triggered by a FIST file.

It is likely this will also need fixing on trunk which will not just be a simple forward-port due to the `rrdd` and `xenopsd` disaggregation.
