### PR TITLE
CA-120529: Wait for receiver in X-host VDI.copy

### DIFF
--- a/ocaml/xapi/sm_fs_ops.ml
+++ b/ocaml/xapi/sm_fs_ops.ml
@@ -220,7 +220,15 @@ try
 			Sparse_dd_wrapper.dd ~__context sparse device_src remote_uri size;
 			let finished () =
 				match Db.Task.get_status ~__context ~self:task_id with
-				| `success | `failure | `cancelled -> true
+				| `success -> true
+				| `failure | `cancelled ->
+					begin match Db.Task.get_error_info ~__context ~self:task_id with
+					| [] -> (* This should never happen *)
+						failwith("Copy of VDI to remote failed with unspecified error!")
+					| code :: params ->
+						debug "Copy of VDI to remote failed: %s [ %s ]" code (String.concat "; " params);
+						raise (Api_errors.Server_error(code, params))
+					end
 				| _ -> false in
 			while not (finished ()) do
 				Thread.delay 0.5


### PR DESCRIPTION
The sender was completing the VDI.copy operation after it had sent the last of
the data. This meant that any subsequent operations on the new VDI could fail
with VDI_IN_USE because the datapath on the receiver had yet to be destroyed.

Now we forward the task to the receiving host and wait for it to set it as
complete.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
