### PR TITLE
CA-103062: Fix for preventing vm pause during SXM

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1660,10 +1660,10 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
 		let migrate_send ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 			info "VM.migrate_send: VM = '%s'" (vm_uuid ~__context vm);
-			Local.VM.assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options;
 			let local_fn = Local.VM.migrate_send ~vm ~dest ~live ~vdi_map ~vif_map ~options in
 			with_vm_operation ~__context ~self:vm ~doc:"VM.migrate_send" ~op:`migrate_send
 				(fun () ->
+					Local.VM.assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options;
 					forward_vm_op ~local_fn ~__context ~vm
 						(fun session_id rpc -> Client.VM.migrate_send rpc session_id vm dest live vdi_map vif_map options)
 				)


### PR DESCRIPTION
Issue: The vm is able to pause during SXM. This is happening because when we trigger an SXM, it first calls assert_can_migrate which is not a blocking operation. After it completes, then migrate_send, a blocking operation, is called and added to current_operations. When we trigger vm pause shortly after SXM has started, it is able to interfere the assert_can_migrate operation and does not migrate_send operate.

Fix : assert_can_migrate needs to be grouped with migrate_send operation inside with_vm_operation so that while SXM is in operation, vm pause should not interfere after assert_can_migrate completes or in between. I think fix is safe because it is not interfering with any other operation except SXM. Also the order of operations i.e asser_can_migrate followed by migrate_send remains same. With the fix , this order has become uninterruptible which I think is good. 

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
