### PR TITLE
SCTX-1585: Update allowed operations for upgrade

### DIFF
--- a/ocaml/client_records/record_util.ml
+++ b/ocaml/client_records/record_util.ml
@@ -66,6 +66,7 @@ let vm_operation_table =
     `awaiting_memory_live, "awaiting_memory_live";
     `changing_shadow_memory_live, "changing_shadow_memory_live";
     `pool_migrate, "pool_migrate";
+    `migrate_send, "migrate_send";
     `power_state_reset, "power_state_reset";
     `csvm, "csvm";
   ]
@@ -118,6 +119,8 @@ let sr_operation_to_string = function
   | `vdi_resize -> "VDI.resize"
   | `vdi_clone -> "VDI.clone"
   | `vdi_snapshot -> "VDI.snapshot"
+  | `pbd_create -> "PBD.create"
+  | `pbd_destroy -> "PBD.destroy"
 
 let vbd_operation_to_string = function
   | `attach -> "attach"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4581,7 +4581,9 @@ let storage_operations =
 	  "vdi_destroy", "Destroying a VDI";
 	  "vdi_resize", "Resizing a VDI"; 
 	  "vdi_clone", "Cloneing a VDI"; 
-	  "vdi_snapshot", "Snapshotting a VDI" ])
+	  "vdi_snapshot", "Snapshotting a VDI";
+	  "pbd_create", "Creating a PBD for this SR";
+	  "pbd_destroy", "Destroying one of this SR's PBDs";])
 
 let sr_set_virtual_allocation = call
    ~name:"set_virtual_allocation"
@@ -6120,7 +6122,8 @@ let vm_operations =
 	    "export", "exporting a VM to a network stream";
 	    "metadata_export", "exporting VM metadata to a network stream";
 	    "reverting", "Reverting the VM to a previous snapshotted state";
-	    "destroy", "refers to the act of uninstalling the VM"; ]
+	    "destroy", "refers to the act of uninstalling the VM";
+	    "migrate_send", "Added for forwards compatibility with XS6.1 and greater";]
        )
 
 (** VM (or 'guest') configuration: *)

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -27,6 +27,10 @@ let allowed_power_states ~(op:API.vm_operations) =
 	let all_power_states =
 		[`Halted; `Paused; `Suspended; `Running] in
 	match op with
+	(* migrate_send is only here for forwards compatibility; if a master host has
+	 * equal version installed then no VMs in the pool will have the migrate_send
+	 * operation available. *)
+	| `migrate_send                 -> []
 	(* a VM.import is done on file and not on VMs, so there is not power-state there! *)
 	| `import
 	                                -> []


### PR DESCRIPTION
For forward compatability, the datamodel on the host being upgraded needs to
know about these extra enums.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
