### PR TITLE
CA-116281: restart syslog service instead of reload

### DIFF
--- a/scripts/xe-syslog-reconfigure
+++ b/scripts/xe-syslog-reconfigure
@@ -35,4 +35,4 @@ if [ $remote -eq 1 ]; then
 fi
 
 [ -s /etc/syslog.$$ ] && mv -f /etc/syslog.$$ $conf_file
-service $service reload
+service $service restart


### PR DESCRIPTION
rsyslog does not support reload, host-syslog-reconfigure
is not working at present.

Signed-off-by: Simon Rowe simon.rowe@eu.citrix.com
