### PR TITLE
Update to use new Tar, Tar_unix interface from ocaml-tar 0.2.1

### DIFF
--- a/ocaml/test/OMakefile
+++ b/ocaml/test/OMakefile
@@ -1,5 +1,6 @@
 OCAMLPACKS = oUnit sexpr xcp xmlm stunnel xml-light2 http-svr uuid netdev \
-             tapctl xenctrl xenctrlext xenstore-compat cpuid pciutil oclock gzip sha1 xcp.network xcp.rrd xcp.storage xcp.xen xcp.memory
+             tapctl xenctrl xenctrlext xenstore-compat cpuid pciutil oclock gzip sha1 xcp.network xcp.rrd xcp.storage xcp.xen xcp.memory \
+             tar tar.unix
 
 OCAMLINCLUDES = \
 	../database \

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -1,4 +1,4 @@
-OCAMLPACKS    = oclock xml-light2 cdrom pciutil sexpr xcp stunnel http-svr xen-utils netdev tapctl rpclib nbd.unix xenstore-compat xenctrl uuid gzip vhdlib sha1 xcp.network xcp.rrd xcp.storage xcp.xen xcp.memory
+OCAMLPACKS    = oclock xml-light2 cdrom pciutil sexpr xcp stunnel http-svr xen-utils netdev tapctl rpclib nbd.unix xenstore-compat xenctrl uuid gzip vhdlib sha1 xcp.network xcp.rrd xcp.storage xcp.xen xcp.memory tar tar.unix
 
 OCAML_LIBS    = ../fhs ../util/version ../util/vm_memory_constraints ../util/sanitycheck ../util/stats \
 	../idl/ocaml_backend/common ../idl/ocaml_backend/client ../idl/ocaml_backend/server ../util/ocamltest

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -3097,8 +3097,8 @@ let vm_import fd printer rpc session_id params =
 									let writer (response, sock) =
 										try
 											(* First add the metadata file *)
-											let hdr = Tar.Header.make Xva.xml_filename (Int64.of_int (String.length buffer)) in
-											Tar.write_block hdr (fun ofd -> Tar.write_string ofd buffer) sock;
+											let hdr = Tar_unix.Header.make Xva.xml_filename (Int64.of_int (String.length buffer)) in
+											Tar_unix.write_block hdr (fun ofd -> Unixext.really_write_string ofd buffer) sock;
 											List.iter
 												(fun vdi ->
 													let counter = ref 0 in
@@ -3126,8 +3126,8 @@ let vm_import fd printer rpc session_id params =
 																		| Blob (Chunk x) -> x
 																		| _ -> failwith "Thin CLI protocol error"
 																	in
-																	let hdr = Tar.Header.make chunk (Int64.of_int32 length) in
-																	Tar.write_block hdr
+																	let hdr = Tar_unix.Header.make chunk (Int64.of_int32 length) in
+																	Tar_unix.write_block hdr
 																		(fun ofd ->
 																			let limit = Int64.of_int32 length in
 																			let total_bytes = Unixext.copy_file ~limit fd ofd in
@@ -3142,7 +3142,7 @@ let vm_import fd printer rpc session_id params =
 															| m ->
 																	debug "Protocol failure: unexpected: %s" (string_of_message m)
 													done) disks;
-											Tar.write_end sock;
+											Tar_unix.write_end sock;
 											true
 										with e ->
 											debug "vm_import caught %s while writing data" (Printexc.to_string e);

--- a/ocaml/xapi/export.ml
+++ b/ocaml/xapi/export.ml
@@ -358,8 +358,8 @@ let export_metadata ~__context ~with_snapshot_metadata ~preserve_power_state ~in
 				(string_of_bool preserve_power_state) end;
 
 	let _, ova_xml = vm_metadata ~with_snapshot_metadata ~preserve_power_state ~include_vhd_parents ~__context ~vms in
-	let hdr = Tar.Header.make Xva.xml_filename (Bigbuffer.length ova_xml) in
-	Tar.write_block hdr (fun s -> Tar.write_bigbuffer s ova_xml) s
+	let hdr = Tar_unix.Header.make Xva.xml_filename (Bigbuffer.length ova_xml) in
+	Tar_unix.write_block hdr (fun s -> Bigbuffer.to_fct ova_xml (fun frag -> Unixext.really_write_string s frag)) s
 
 let export refresh_session __context rpc session_id s vm_ref preserve_power_state =
   info "VM.export: VM = %s; preserve_power_state = '%s'"
@@ -370,8 +370,8 @@ let export refresh_session __context rpc session_id s vm_ref preserve_power_stat
 
   debug "Outputting ova.xml";
 
-  let hdr = Tar.Header.make Xva.xml_filename (Bigbuffer.length ova_xml) in
-  Tar.write_block hdr (fun s -> Tar.write_bigbuffer s ova_xml) s;
+  let hdr = Tar_unix.Header.make Xva.xml_filename (Bigbuffer.length ova_xml) in
+  Tar_unix.write_block hdr (fun s -> Bigbuffer.to_fct ova_xml (fun frag -> Unixext.really_write_string s frag)) s;
 
   (* Only stream the disks that are in the table AND which are not CDROMs (ie whose VBD.type <> CD
      and whose SR.content_type <> "iso" *)
@@ -389,7 +389,7 @@ let export refresh_session __context rpc session_id s vm_ref preserve_power_stat
 
   (* We no longer write the end-of-tar checksum table, preferring the inline ones instead *)
 
-  Tar.write_end s;
+  Tar_unix.write_end s;
   debug "export VM = %s completed successfully" (Ref.string_of vm_ref)
 
 open Http
@@ -480,7 +480,7 @@ let metadata_handler (req: Request.t) s _ =
                 (fun () -> export_metadata ~with_snapshot_metadata:export_snapshots ~preserve_power_state:true ~include_vhd_parents ~__context ~vms:vm_refs s)
  				(fun () ->
  					 List.iter (fun vm -> unlock_vm ~__context ~vm ~task_id) vm_refs;
- 					 Tar.write_end s);
+ 					 Tar_unix.write_end s);
 		)
 
 let handler (req: Request.t) s _ =

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1156,14 +1156,14 @@ let handle_all __context config rpc session_id (xs: obj list) =
 (** Read the next file in the archive as xml *)
 let read_xml hdr fd =
 	let xml_string = Bigbuffer.make () in
-	really_read_bigbuffer fd xml_string hdr.Tar.Header.file_size;
+	really_read_bigbuffer fd xml_string hdr.Tar_unix.Header.file_size;
 	Xml.parse_bigbuffer xml_string
 
 let assert_filename_is hdr =
 	let expected = Xva.xml_filename in
-	let actual = hdr.Tar.Header.file_name in
+	let actual = hdr.Tar_unix.Header.file_name in
 	if expected <> actual then begin
-		let hex = Tar.Header.to_hex in
+		let hex = Tar_unix.Header.to_hex in
 		error "import expects the next file in the stream to be [%s]; got [%s]"
 			(hex expected) (hex actual);
 		raise (IFailure (Unexpected_file(expected, actual)))
@@ -1174,19 +1174,19 @@ let assert_filename_is hdr =
     the lot through gzip and try again *)
 let with_open_archive fd ?length f =
 	(* Read the first header's worth into a buffer *)
-	let buffer = String.make Tar.Header.length ' ' in
+	let buffer = Cstruct.create Tar_unix.Header.length in
 	let retry_with_gzip = ref true in
 	try
-		really_read fd buffer 0 Tar.Header.length;
+		Tar_unix.really_read fd buffer;
 
 		(* we assume the first block is not all zeroes *)
-		let hdr = Opt.unbox (Tar.Header.unmarshal buffer) in
+		let hdr = Opt.unbox (Tar_unix.Header.unmarshal buffer) in
 		assert_filename_is hdr;
 
 		(* successfully opened uncompressed stream *)
 		retry_with_gzip := false;
 		let xml = read_xml hdr fd in
-		Tar.Archive.skip fd (Tar.Header.compute_zero_padding_length hdr);
+		Tar_unix.Archive.skip fd (Tar_unix.Header.compute_zero_padding_length hdr);
 		f xml fd
 	with e ->
 		if not(!retry_with_gzip) then raise e;
@@ -1198,19 +1198,19 @@ let with_open_archive fd ?length f =
 				(* Write the initial buffer *)
 				Unix.set_close_on_exec compressed_in;
 				debug "Writing initial buffer";
-				let (_: int) = Unix.write compressed_in buffer 0 Tar.Header.length in
+				Tar_unix.really_write compressed_in buffer;
 				let limit = (Opt.map
-					(fun x -> Int64.sub x (Int64.of_int Tar.Header.length)) length) in
+					(fun x -> Int64.sub x (Int64.of_int Tar_unix.Header.length)) length) in
 				let n = Unixext.copy_file ?limit fd compressed_in in
-				debug "Written a total of %d + %Ld bytes" Tar.Header.length n;
+				debug "Written a total of %d + %Ld bytes" Tar_unix.Header.length n;
 			) in
 		finally
 			(fun () ->
-				let hdr = Tar.Header.get_next_header pipe_out in
+				let hdr = Tar_unix.Header.get_next_header pipe_out in
 				assert_filename_is hdr;
 
 				let xml = read_xml hdr pipe_out in
-				Tar.Archive.skip pipe_out (Tar.Header.compute_zero_padding_length hdr);
+				Tar_unix.Archive.skip pipe_out (Tar_unix.Header.compute_zero_padding_length hdr);
 				f xml pipe_out)
 			(fun () ->
 				debug "Closing pipes";
@@ -1266,7 +1266,7 @@ let metadata_handler (req: Request.t) s _ =
 				(fun metadata s ->
 					debug "Got XML";
 					(* Skip trailing two zero blocks *)
-					Tar.Archive.skip s (Tar.Header.length * 2);
+					Tar_unix.Archive.skip s (Tar_unix.Header.length * 2);
 
 					let header = header_of_xmlrpc metadata in
 					assert_compatable ~__context header.version;
@@ -1433,7 +1433,7 @@ let handler (req: Request.t) s _ =
 															(* against the table here. Nb. Rio GA-Miami B2 exports get their checksums checked twice! *)
 															if header.version.export_vsn < 2 then
 																begin
-																	let xml = Tar.Archive.with_next_file s (fun s hdr -> read_xml hdr s) in
+																	let xml = Tar_unix.Archive.with_next_file s (fun s hdr -> read_xml hdr s) in
 																	let expected_checksums = checksum_table_of_xmlrpc xml in
 																	if not(compare_checksums checksum_table expected_checksums) then begin
 																		error "Some data checksums were incorrect: VM may be corrupt";
@@ -1476,7 +1476,7 @@ let handler (req: Request.t) s _ =
 										error "Cannot import guest with currently attached disks which cannot be found";
 										raise (Api_errors.Server_error (Api_errors.import_error_attached_disks_not_found, []))
 									| Unexpected_file (expected, actual) ->
-										let hex = Tar.Header.to_hex in
+										let hex = Tar_unix.Header.to_hex in
 										error "Invalid XVA file: import expects the next file in the stream to be \"%s\" [%s]; got \"%s\" [%s]"
 										expected (hex expected) actual (hex actual);
 										raise (Api_errors.Server_error (Api_errors.import_error_unexpected_file, [expected; actual]))

--- a/ocaml/xva/OMakefile
+++ b/ocaml/xva/OMakefile
@@ -1,4 +1,4 @@
-OCAMLPACKS = stdext xml-light2 xcp
+OCAMLPACKS = stdext tar tar.unix xml-light2 xcp
 
 .PHONY: clean
 clean:

--- a/ocaml/xva/xva.ml
+++ b/ocaml/xva/xva.ml
@@ -229,13 +229,13 @@ let send path fd =
   let is_dir path = let stat = Unix.stat path in stat.Unix.st_kind = Unix.S_DIR in
   let add path (* actual path *) filename (* for tar header *) = 
     debug "Attempting to add %s (%s)\n" path filename;
-    let hdr = Tar.Header.of_file path in
-    let hdr = { hdr with Tar.Header.file_name = filename } in
-    debug "file_size = %Ld\n" (hdr.Tar.Header.file_size); 
-    Tar.write_block hdr 
+    let hdr = Tar_unix.Header.of_file path in
+    let hdr = { hdr with Tar_unix.Header.file_name = filename } in
+    debug "file_size = %Ld\n" (hdr.Tar_unix.Header.file_size); 
+    Tar_unix.write_block hdr 
       (fun ofd ->
 	 let ifd = Unix.openfile path [Unix.O_RDONLY] 0o644 in
-	 Pervasiveext.finally (fun () -> Tar.Archive.copy_n ifd ofd hdr.Tar.Header.file_size)
+	 Pervasiveext.finally (fun () -> Tar_unix.Archive.copy_n ifd ofd hdr.Tar_unix.Header.file_size)
 	   (fun () -> Unix.close ifd)) fd in
 
   let add_disk path = 
@@ -250,5 +250,5 @@ let send path fd =
   let disks = List.filter (fun x -> not(String.startswith "." x) && is_dir x) disks in
   List.iter add_disk disks;
 
-  Tar.write_end fd
+  Tar_unix.write_end fd
   


### PR DESCRIPTION
This must be merged in combination with: [xapi-project/stdext#3] and [xapi-project/xen-api-libs-specs#20]

The new ocaml-tar library separates the modules into:

   Tar: for pure OCaml definitions
   Tar_unix: for impure Unix I/O
   Tar_lwt: for impure Lwt I/O

So mostly we have to replace Tar. with Tar_unix. and adjust the
OCAMLPACKS.

Most of this code concerns VM import/export. There is an alternative
implementation which is much more efficient inside recent releases
of vhd-tool, so we should switch to that soon.
