### PR TITLE
CA-112324: Check destination SR's connectivity during VM migration.

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -385,6 +385,7 @@ let xenapi_missing_plugin = "XENAPI_MISSING_PLUGIN"
 let xenapi_plugin_failure = "XENAPI_PLUGIN_FAILURE"
 
 let sr_attached = "SR_ATTACHED"
+let sr_not_attached = "SR_NOT_ATTACHED"
 
 let domain_builder_error = "DOMAIN_BUILDER_ERROR"
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -847,6 +847,8 @@ let _ =
 
 
   (* Storage errors *)
+  error Api_errors.sr_not_attached ["sr"]
+    ~doc:"The SR is not attached." ();
   error Api_errors.sr_attach_failed ["sr"]
     ~doc:"Attaching this SR failed." ();
   error Api_errors.sr_backend_failure ["status"; "stdout"; "stderr"]

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -412,10 +412,15 @@ let start' ~task ~dbg ~sr ~vdi ~dp ~url ~dest =
 		Local.VDI.destroy ~dbg ~sr ~vdi:snapshot.vdi;
 
 		Some (Mirror_id id)
-	with e ->
-		error "Caught %s: performing cleanup actions" (Printexc.to_string e);
-		perform_cleanup_actions !on_fail;
-		raise e
+	with
+		| Sr_not_attached(sr_uuid) ->
+			error " Caught exception %s:%s. Performing cleanup." Api_errors.sr_not_attached sr_uuid;
+			perform_cleanup_actions !on_fail;
+			raise (Api_errors.Server_error(Api_errors.sr_not_attached,[sr_uuid]))
+		| e ->
+			error "Caught %s: performing cleanup actions" (Printexc.to_string e);
+			perform_cleanup_actions !on_fail;
+			raise e
 
 
 (* XXX: PR-1255: copy the xenopsd 'raise Exception' pattern *)


### PR DESCRIPTION
Issue: During VM migration if the destination SR is not attached , then the migration fails with a bad error message with an ungraceful view

Fix: Defined an error message in api_errors.ml namely "sr_not_attached". Catching the exception in storage_migrate.ml before mirroring starts and displaying it in a graceful manner.

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
