### PR TITLE
Support both GPU PCI bus address formats

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -1268,7 +1268,9 @@ let unbind_from_nvidia devstr =
 			(* Work around due to PCI ID formatting inconsistency. *)
 			let devstr2 = String.copy devstr in
 			devstr2.[7] <- '.';
-			if String.has_substr gpu_info devstr2
+			if false
+				|| (String.has_substr gpu_info devstr2)
+				|| (String.has_substr gpu_info devstr)
 			then gpu_path
 			else find_gpu rest
 	in


### PR DESCRIPTION
The NVIDIA procfs file currently uses the format:

xxxx:xx.xx.x

But everywhere else (lspci, sysfs, xapi/xenopsd) uses the format:

xxxx:xx:xx.x

This change means that the NVIDIA unbind code understands both formats,
in case the procfs file changes in future to use the format used
elsewhere.
