### PR TITLE
Relax xencenter_min_verstring

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -51,7 +51,7 @@ let tools_version_none = (-1, -1, -1, -1)
 let tools_version = ref tools_version_none
 
 (* client min/max version range *)
-let xencenter_min_verstring = "2.1"
+let xencenter_min_verstring = "2.0"
 let xencenter_max_verstring = "2.1"
 
 (* linux pack vsn key in host.software_version (used for a pool join restriction *)


### PR DESCRIPTION
Blocking XenCenter 2.0 means that Clearwater XenCenter will fail to
reconnect to a server after installing the vGPU hotfix.
