### PR TITLE
CA-101571: Allow the vcpu params weight and cap value to be set independently

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -506,11 +506,21 @@ module MD = struct
 							(fun vcpu_affinity ->
 								List.filter (fun x -> List.mem x mask) vcpu_affinity) affinity in
 			let priority =
-				try
-					let weight = List.assoc "weight" vm.API.vM_VCPUs_params in
-					let cap = List.assoc "cap" vm.API.vM_VCPUs_params in
-					Some (int_of_string weight, int_of_string cap)
-				with _ -> None in
+				let weight =
+					let default=256 in
+					try
+						let weight = List.assoc "weight" vm.API.vM_VCPUs_params in
+						int_of_string weight
+					with e -> error "%s" (Printexc.to_string e);
+										debug "Could not parse weight value. Setting it to default value %d." default; default in
+				let cap =
+					let default=0 in
+					try
+						let cap = List.assoc "cap" vm.API.vM_VCPUs_params in
+						int_of_string cap
+					with e -> error "%s" (Printexc.to_string e);
+										debug "Could not parse cap value. Setting it to default value %d." default; default in
+				Some ( weight , cap ) in
 			{ priority = priority; affinity = affinity } in
 
 		let platformdata =


### PR DESCRIPTION
Issue: If only one of the weight and cpu is set, then a Not_found error is raised and a None is returned because of which the param set is not propagated further.

Fix: Two separate try with blocks have been put for weight and cap each which when not set returns its respective default value.

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
