### PR TITLE
CA-119115: Use a portable 'timeout' parameter for dhclient.

### DIFF
--- a/scripts/interface-reconfigure
+++ b/scripts/interface-reconfigure
@@ -201,7 +201,10 @@ def ifup(netdev):
         raise Error("ifup: device %s exists but ifcfg-%s does not" % (netdev,netdev))
     d = os.getenv("DHCLIENTARGS","")
     if os.path.exists("/etc/firstboot.d/data/firstboot_in_progress"):
-        os.putenv("DHCLIENTARGS", d + " -T 240 " )
+        f = open('/tmp/default_dhclient.conf', 'w')
+        f.write('timeout 240;\n')
+        f.close()
+        os.putenv("DHCLIENTARGS", d + " -cf /tmp/default_dhclient.conf " )
     run_command(["/sbin/ifup", netdev])
     os.putenv("DHCLIENTARGS", d )
 


### PR DESCRIPTION
In Centos 5.7, dhclient takes -T <timeout> as an argument (see manpage).
This is a RHEL extension.

In Centos 6.4 dhclient, -T is for 'temoporary ipv6 address'.

Due to this incompatibility, upgrade from Sanibel to EA-1173exp branch
fails due to dhcp failure.

Signed-off-by: Joby Poriyath joby.poriyath@citrix.com
