### PR TITLE
Add skeleton implementations to the SR modules

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -143,6 +143,7 @@ module SMAPIv1 = struct
 	end
 
 	module SR = struct
+		include Storage_skeleton.SR
 		let create context ~dbg ~sr ~device_config ~physical_size =
 			Server_helpers.exec_with_new_task "SR.create" ~subtask_of:(Ref.of_string dbg)
 				(fun __context ->

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -666,6 +666,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
 	end
 
 	module SR = struct
+		include Storage_skeleton.SR
 		let locks : (string, unit) Storage_locks.t = Storage_locks.make ()
 		let with_sr sr f = Storage_locks.with_instance_lock locks sr f
 

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -181,6 +181,7 @@ module Debug_print_impl = struct
 	end
 		
 	module SR = struct
+		include Storage_skeleton.SR
 		let list context ~dbg = assert false
 		let scan context ~dbg ~sr = assert false
 		let create context ~dbg ~sr ~device_config ~physical_size = assert false

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -148,6 +148,7 @@ module Mux = struct
 			
 	end
 	module SR = struct
+		include Storage_skeleton.SR
 		let create context ~dbg ~sr ~device_config ~physical_size =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.SR.create ~dbg ~sr ~device_config ~physical_size

--- a/ocaml/xapi/storage_proxy.ml
+++ b/ocaml/xapi/storage_proxy.ml
@@ -38,6 +38,7 @@ module Proxy = functor(RPC: RPC) -> struct
 		let stat_vdi _ = Client.DP.stat_vdi
 	end
 	module SR = struct
+		include Storage_skeleton.SR
 		let create _ = Client.SR.create
 		let attach _ = Client.SR.attach
 		let detach _ = Client.SR.detach


### PR DESCRIPTION
This allows the addition of extra calls without breaking the
compilation of xapi.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
