### PR TITLE
CA-117817 Add CentOS 6.4 gpg checksum to allowed list

### DIFF
--- a/ocaml/gpg/gpg.ml
+++ b/ocaml/gpg/gpg.ml
@@ -28,6 +28,7 @@ let gpg_pub_keyring = gpg_homedir ^ "pubring.gpg"
 let allowed_gpg_checksum =
 	[ "be00ee82bffad791edfba477508d5d84"; (* centos52 version *)
 	  "a267af68c53f5d998b982235bbccb01e"; (* centos53/54 version *)
+	  "da75ecb57ff12b2573f44466d36f395e"; (* centos64 version *) 
 	  "f52886b87126c06d419f408e32268b4e"; (* 64 bit product version *)
 	  "aa27ac0b0ebfd1278bf2386c343053db"; (* debian developer version *)
 	  "044d1327ea42400ac590195e0ec1e7e6"; ]


### PR DESCRIPTION
This adds the checksum for the CentOS 6.4 version of gpg to the allowed list in gpg.ml, allowing patches to be applied.
