### PR TITLE
CP-6649 Rename /etc/modprobe.d/blacklist-bridge to /etc/modprobe.d/black...

### DIFF
--- a/scripts/xe-switch-network-backend
+++ b/scripts/xe-switch-network-backend
@@ -49,7 +49,7 @@ for i in /etc/sysconfig/network-scripts/ifcfg-* ; do
 done
 
 
-BLACKLIST=/etc/modprobe.d/blacklist-bridge
+BLACKLIST=/etc/modprobe.d/blacklist-bridge.conf
 if [ "$new" = "openvswitch" ] ; then
 	# Add blacklist of bridge module so it can't be loaded.
 	echo "install bridge /bin/true" > $BLACKLIST


### PR DESCRIPTION
...list-bridge.conf

Newer versions of udev warn about modprobe.d files without .conf suffix, and future versions may stop loading them entirely
