### PR TITLE
Report out-of-space, not patch-invalid

### DIFF
--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -257,10 +257,10 @@ let assert_space_available ?(multiplier=2L) required =
 		Int64.mul stat.f_frsize stat.f_bavail in
 	if (Int64.mul multiplier required) > free_bytes
 	then
-    begin
-      warn "Not enough space on filesystem to upload patch. Required %Ld, \
-            but only %Ld available" required free_bytes;
-      raise (Api_errors.Server_error (Api_errors.out_of_space, [patch_dir]))
+		begin
+			warn "Not enough space on filesystem to upload patch. Required %Ld, \
+			but only %Ld available" required free_bytes;
+			raise (Api_errors.Server_error (Api_errors.out_of_space, [patch_dir]))
 		end
 
 let pool_patch_upload_handler (req: Request.t) s _ =


### PR DESCRIPTION
If there isn't enough space on the filesystem to upload a patch (which can take
2-3 times the size of the patch, because of multiple copies and gpg signature
checking), we should fail with an Out_of_space exception. Before, if the gpg
check failed because there wasn't enough space to write the unsigned cleartext,
we would erroneously report patch_invalid. Now we check that there is enough
free space to signature check the patch (we make a guess of 2 \* size of the
patch), and catch Unix.ENOSPC exceptions and handle them accordingly.

CA-124008

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
