### PR TITLE
(CLW-LCM) Report out-of-space, not patch-invalid

### DIFF
--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -244,6 +244,7 @@ exception CannotUploadPatchToSlave
    the multiplier comes from. *)
 let assert_space_available ?(multiplier=2L) required =
 	let open Unixext in
+	ignore (mkdir_safe patch_dir 0o755);
 	let stat = statvfs patch_dir in
 	let free_bytes =
 		(* block size times free blocks *)


### PR DESCRIPTION
If there isn't enough space on the filesystem to upload a patch (which can take
2-3 times the size of the patch, because of multiple copies and gpg signature
checking), we should fail with an Out_of_space exception. Before, if the gpg
check failed because there wasn't enough space to write the unsigned cleartext,
we would erroneously report patch_invalid. Now we check that there is enough
free space to signature check the patch (we make a guess of 2 \* size of the
patch), and catch Unix.ENOSPC exceptions and handle them accordingly.

CA-124008

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
