### PR TITLE
CP-6172: Don't specify VBD backend-kind by default

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -175,7 +175,6 @@ let vhd_parent = "vhd-parent" (* set in VDIs backed by VHDs *)
 
 let owner_key = "owner" (* set in VBD other-config to indicate that clients can delete the attached VDI on VM uninstall if they want.. *)
 let vbd_backend_key = "backend-kind" (* set in VBD other-config *)
-let vbd_backend_default = "blktap2"
 
 let using_vdi_locking_key = "using-vdi-locking" (* set in Pool other-config to indicate that we should use storage-level (eg VHD) locking *)
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -350,11 +350,13 @@ module MD = struct
 				warn "Unknown VBD QoS type: %s (try 'ionice')" x;
 				None in
 
-		let backend_kind_of_vbd vbd =
+		let backend_kind_keys_of_vbd vbd =
 			let oc = vbd.API.vBD_other_config in
 			let k = Xapi_globs.vbd_backend_key in
-			let v = try List.assoc k oc with _ -> Xapi_globs.vbd_backend_default in
-			(k, v)
+			try
+				let v = List.assoc k oc in
+				[(k, v)]
+			with Not_found -> []
 		in
 
 		{
@@ -364,7 +366,7 @@ module MD = struct
 			backend = disk_of_vdi ~__context ~self:vbd.API.vBD_VDI;
 			ty = if vbd.API.vBD_type = `Disk then Disk else CDROM;
 			unpluggable = vbd.API.vBD_unpluggable;
-			extra_backend_keys = [ backend_kind_of_vbd vbd ];
+			extra_backend_keys = backend_kind_keys_of_vbd vbd;
 			extra_private_keys = [];
 			qos = qos ty;
 		}


### PR DESCRIPTION
Rather than defaulting this value (meaning we have to keep parity with
xenopsd), leave the default to be determined by xenopsd itself by not
specifying a backend-kind.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
