### PR TITLE
[HFX-1037] CA-113392: Fix PBD password-secret lifecycle

### DIFF
--- a/ocaml/xapi/create_storage.ml
+++ b/ocaml/xapi/create_storage.ml
@@ -64,17 +64,8 @@ let maybe_create_pbd rpc session_id sr device_config me =
 			else pbds
 	in
 	if List.length pbds = 0 (* If there's no PBD, create it *)
-		then
-			let dev_cfg = Server_helpers.exec_with_new_task
-				~session_id
-				"duplicate secrets"
-				(fun ctxt -> Xapi_secret.duplicate_passwds ctxt device_config)
-			in
-			Client.PBD.create ~rpc ~session_id ~host:me ~sR:sr 
-				~device_config:dev_cfg ~other_config:[]
-		else
-			List.hd pbds (* Otherwise, return the current one *)
-
+	then Client.PBD.create ~rpc ~session_id ~host:me ~sR:sr ~device_config ~other_config:[]
+	else List.hd pbds (* Otherwise, return the current one *)
 
 let create_storage (me: API.ref_host) rpc session_id __context : unit =
   let create_pbds_for_shared_srs () =

--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -30,9 +30,11 @@ let create_common ~__context ~host ~sR ~device_config ~currently_attached ~other
 		; Ref.string_of host
 		; Ref.string_of (List.find (fun pbd -> Db.PBD.get_host ~__context ~self:pbd = host) pbds)
 		]));
+	(* Make sure each PBD has a unique secret in the database *)
+	let dev_cfg = Xapi_secret.duplicate_passwds ~__context device_config in
 	let ref = Ref.make() in
 	let uuid = Uuid.to_string (Uuid.make_uuid()) in
-	Db.PBD.create ~__context ~ref ~uuid ~host ~sR ~device_config ~currently_attached ~other_config:[];
+	Db.PBD.create ~__context ~ref ~uuid ~host ~sR ~device_config:dev_cfg ~currently_attached ~other_config:[];
 	ref
 
 let create ~__context ~host ~sR ~device_config ~other_config = create_common ~__context ~host ~sR ~device_config ~currently_attached:false ~other_config

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -336,11 +336,7 @@ let create  ~__context ~host ~device_config ~(physical_size:int64) ~name_label ~
 	let pbds =
 		if shared then
 			let create_on_host host =
-				let dev_cfg = if Helpers.is_pool_master ~__context ~host
-					then device_config
-					else Xapi_secret.duplicate_passwds ~__context device_config
-				in
-				Xapi_pbd.create ~__context ~sR:sr_ref ~device_config:dev_cfg ~host ~other_config:[]
+				Xapi_pbd.create ~__context ~sR:sr_ref ~device_config ~host ~other_config:[]
 			in
 			List.map create_on_host (Db.Host.get_all ~__context)
 		else


### PR DESCRIPTION
When creating an SR, if there are any secrets in the device-config then they
are duplicated and a unique one is used for each PBD creation.

However, XenCenter's "Repair SR" feature creates new PBDs directly, copying the
device-config field from existing ones. This bypasses the secret-duplication
which is in the SR-create code path.

This patch pushes the secret-duplication logic down to the PBD creation which
solves the XenCenter issue pending a revised design of the secret datamodel.
Also the master is no-longer special cased for the same reason. This has the
added benefit of making secret creation/destruction entirely symmetrical: the
secrets created with PBDs are destroyed when the PBD is destroyed and the
secrets created manually must be destroyed manually.

XenCenter should now be updated to tidy up after itself: if it chooses to
create secrets around passwords used in SR creation, then they should be
destroyed in a finally block after the SR creation is complete. This is safe
since all PBDs will have duplicated the secret.

Note this patch applies (as the previous semantics did) to any key in device
config ending in '_secret'. The ones used by the SM backends are
'password_secret' and 'chappassword_secret'.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
