### PR TITLE
[Dodger] CA-122467: Fix for setting the right value of memory_actual after vm is ...

### DIFF
--- a/ocaml/xapi/monitor_dbcalls.ml
+++ b/ocaml/xapi/monitor_dbcalls.ml
@@ -165,6 +165,7 @@ let pifs_and_memory_update_fn xc =
 			if (Db.VM.get_resident_on ~__context ~self:vm =
 				Helpers.get_localhost ~__context)
 			then Db.VM_metrics.set_memory_actual ~__context ~self:vmm ~value:memory
+			else clear_cache_for_vm uuid
 		) vm_memory_changes;
 		Monitor_master.update_pifs ~__context host pif_changes;
 		let localhost = Helpers.get_localhost ~__context in


### PR DESCRIPTION
...started

There is a race condition between vm_start and monitor thread.
The monitor thread runs every 5s and updates the memory changes of the
VMs if any. It does that only if the VM's resident_on value is set to
localhost.
Currently, the memory changes are being seen by monitor thread while
VM is starting but since the start operation has'nt yet set the
resident_on, the monitor thread doesn't do anything.
However, the in-memory cache of monitor thread already has the vm_memory
changes for that VM. This needs to be removed, so that monitor thread
updates it next time when the resident_on value of the VM is set by
start operation.
Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
