### PR TITLE
SCTX-1473 [HFX-1077]: Unable to start VM by VM_REQUIRES_GPU. Multiple PCI consumed

### DIFF
--- a/ocaml/xapi/vmops.ml
+++ b/ocaml/xapi/vmops.ml
@@ -949,7 +949,7 @@ let resume ~__context ~xc ~xs ~vm =
 		Domain.unpause ~xc domid) 
 
 (** Starts up a VM, leaving it in the paused state *)
-let start_paused ?(progress_cb = fun _ -> ()) ~pcidevs ~__context ~vm ~snapshot =
+let start_paused ?(progress_cb = fun _ -> ()) ?(is_reboot = false) ~pcidevs ~__context ~vm ~snapshot =
 	(* Ensure no old consoles survive *)
 	destroy_consoles ~__context ~vM:vm;
 
@@ -1059,7 +1059,7 @@ let start_paused ?(progress_cb = fun _ -> ()) ~pcidevs ~__context ~vm ~snapshot 
 								let vifs = Vm_config.vifs_of_vm ~__context ~vm domid in
 								create_vifs ~__context ~xs vifs;
 								progress_cb 0.70;
-								let pcis = Vgpuops.create_vgpus ~__context ~vm domid hvm in
+								let pcis = if is_reboot then [] else Vgpuops.create_vgpus ~__context ~vm domid hvm in
 								(* WORKAROUND FOR CA-55754: temporarily disable msitranslate when GPU is passed through. *)
 								(* other-config:msitranslate can be used the override the default *)
 								let msitranslate =

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -231,7 +231,7 @@ let start ~__context ~vm ~start_paused:paused ~force =
 
 						debug "start: bringing up domain in the paused state";
 						Vmops.start_paused
-							~progress_cb:(TaskHelper.set_progress ~__context) ~pcidevs:None ~__context ~vm ~snapshot;
+							~progress_cb:(TaskHelper.set_progress ~__context) ~is_reboot:false ~pcidevs:None ~__context ~vm ~snapshot;
 						delete_guest_metrics ~__context ~self:vm;
 
 						let localhost = Helpers.get_localhost ~__context in
@@ -427,7 +427,7 @@ module Reboot = struct
 	 begin
 	   try
              Vmops.start_paused
-               ~progress_cb:(fun x -> TaskHelper.set_progress ~__context (0.50 +. x /. 2.))
+               ~progress_cb:(fun x -> TaskHelper.set_progress ~__context (0.50 +. x /. 2.)) ~is_reboot:true
 				 ~pcidevs:(Some pcidevs)
                ~__context ~vm ~snapshot:new_snapshot;
 	   with e ->


### PR DESCRIPTION
by a single VM.
The GPU code in the start_paused function selects a GPU to be passed
through during a VM start. This does not take into account the fact that
xapi has already taken care of the PCI devices attached to the VM before
reboot.
Hence during a VM reboot the VM will get assigned a different PCI device
other than the one it was holding prior to the reboot.
Signed-off-by: Akshay akshay.ramani@citrix.com
