### PR TITLE
Report out-of-space, not patch-invalid

### DIFF
--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -242,18 +242,19 @@ exception CannotUploadPatchToSlave
 (* Experiments showed that we need about twice the amount of free
    space on the filesystem as the size of the patch, which is where
    the multiplier comes from. *)
-let assert_space_available ?(multiplier=2L) required =
+let assert_space_available ?(multiplier=2L) patch_size =
 	let open Unixext in
 	ignore (Unixext.mkdir_safe patch_dir 0o755);
 	let stat = statvfs patch_dir in
 	let free_bytes =
 		(* block size times free blocks *)
 		Int64.mul stat.f_frsize stat.f_bavail in
-	if (Int64.mul multiplier required) > free_bytes
+	let really_required = Int64.mul multiplier patch_size in
+	if really_required > free_bytes
 	then
 		begin
 			warn "Not enough space on filesystem to upload patch. Required %Ld, \
-			but only %Ld available" required free_bytes;
+			but only %Ld available" really_required free_bytes;
 			raise (Api_errors.Server_error (Api_errors.out_of_space, [patch_dir]))
 		end
 


### PR DESCRIPTION
If there isn't enough space on the filesystem to upload a patch (which can take
2-3 times the size of the patch, because of multiple copies and gpg signature
checking), we should fail with an Out_of_space exception. Before, if the gpg
check failed because there wasn't enough space to write the unsigned cleartext,
we would erroneously report patch_invalid. Now we check that there is enough
free space to signature check the patch (we make a guess of 2 \* size of the
patch), and catch Unix.ENOSPC exceptions and handle them accordingly.
