### PR TITLE
[xs64bit] SCTX-1616: Ensure PBD.device_config:SRmaster never exists

### DIFF
--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -22,6 +22,12 @@ open Db_filter_types
 module D=Debug.Debugger(struct let name="xapi_pbd" end)
 open D
 
+let assert_no_srmaster_key dev_cfg =
+	let k = "SRmaster" in
+	if List.mem_assoc k dev_cfg
+	then raise (Api_errors.Server_error (Api_errors.value_not_supported,
+		[k; List.assoc k dev_cfg; "This key is for internal use only"]))
+
 let create_common ~__context ~host ~sR ~device_config ~currently_attached ~other_config =
 	let pbds = Db.SR.get_PBDs ~__context ~self:sR in
 	if List.exists (fun pbd -> Db.PBD.get_host ~__context ~self:pbd = host) pbds 
@@ -30,6 +36,8 @@ let create_common ~__context ~host ~sR ~device_config ~currently_attached ~other
 		; Ref.string_of host
 		; Ref.string_of (List.find (fun pbd -> Db.PBD.get_host ~__context ~self:pbd = host) pbds)
 		]));
+	(* This field should never be present in the record itself *)
+	assert_no_srmaster_key device_config;
 	(* Make sure each PBD has a unique secret in the database *)
 	let dev_cfg = Xapi_secret.duplicate_passwds ~__context device_config in
 	let ref = Ref.make() in
@@ -196,4 +204,5 @@ let destroy ~__context ~self =
 
 let set_device_config ~__context ~self ~value = 
   (* Only allowed from the SM plugin *)
+  assert_no_srmaster_key value;
   Db.PBD.set_device_config ~__context ~self ~value


### PR DESCRIPTION
This should never be part of the PBD record. Instead it is computed before each
SM call in (the internal function) Sm.__get_my_devconf_for_sr before being
passed to the SM driver. Having this field in the device config will mean that
the wrong value could be passed to the SM.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
