### PR TITLE
CA-133768 Bump xapi version number to 2.3 for xs64bit changes

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -41,7 +41,7 @@ let xapi_user_agent = "xapi/"^(string_of_int version_major)^"."^(string_of_int v
 (* Normally xencenter_min_verstring and xencenter_max_verstring below should be set to the same value,
  * but there are exceptions: please consult the XenCenter maintainers if in doubt. *)
 let api_version_major = 2L
-let api_version_minor = 2L
+let api_version_minor = 3L
 let api_version_string =
   Printf.sprintf "%Ld.%Ld" api_version_major api_version_minor
 let api_version_vendor = "XenSource"
@@ -64,8 +64,8 @@ let tools_version = ref tools_version_none
  *
  * Please consult the XenCenter maintainers before changing these numbers, because a corresponding change
  * will need to be made in XenCenter *)
-let xencenter_min_verstring = "2.0"
-let xencenter_max_verstring = "2.2"
+let xencenter_min_verstring = "2.3"
+let xencenter_max_verstring = "2.3"
 
 (* linux pack vsn key in host.software_version (used for a pool join restriction *)
 let linux_pack_vsn_key = "xs:linux"


### PR DESCRIPTION
Note that after this change, it will be required to use a recent xs64bit XenCenter to connect to the server.
