### PR TITLE
Fix event.next after EVENTS_LOST

### DIFF
--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -138,7 +138,7 @@ module Next = struct
 				then !queue, []
 				else
 					(* Reverse-sort by ID and preserve the first 'max_stored_events' *)
-					List.chop max_stored_events (List.sort (fun a b -> compare b.id a.id) !queue) in
+					List.chop max_stored_events (List.sort (fun a b -> compare (Int64.of_string b.id) (Int64.of_string a.id)) !queue) in
 			queue := to_keep;
 			(* Remember the highest ID of the list of events to drop *)
 			if to_drop <> [] then


### PR DESCRIPTION
When recording the id of the latest dropped event, we need to sort the list of
ids as integers. Unfortunately in the forward port of the events.from patch from
clearwater-lcm-sp1 I accidentally sorted the list of ids as strings.

```
#100 < 50;;
- : bool = false

# "100" < "50";;
- : bool = true
```

This corrupts the stored id, resulting in multiple EVENTS_LOST where only one
is expected.

Signed-off-by: David Scott dave.scott@eu.citrix.com
