### PR TITLE
CA-115138: Don't block PBD.create during SR.scan

### DIFF
--- a/ocaml/test/OMakefile
+++ b/ocaml/test/OMakefile
@@ -8,6 +8,7 @@ OCAMLINCLUDES = \
 	../idl \
 	../idl/ocaml_backend \
 	../autogen \
+	../client_records \
 
 OCAML_LIBS = \
 	../fhs \
@@ -30,6 +31,7 @@ OCAML_OBJS = \
 	test_pool_db_backup \
 	test_xapi_db_upgrade \
 	test_vdi_allowed_operations \
+	test_sr_operations \
 	test_pool_license \
 	test_platformdata \
 	test_sm_features \

--- a/ocaml/test/suite.ml
+++ b/ocaml/test/suite.ml
@@ -22,6 +22,7 @@ let base_suite =
 			Test_pool_db_backup.test;
 			Test_xapi_db_upgrade.test;
 			Test_vdi_allowed_operations.test;
+			Test_sr_operations.test;
 			Test_pool_license.test;
 			Test_platformdata.test;
 			Test_sm_features.test;

--- a/ocaml/test/test_sr_operations.ml
+++ b/ocaml/test/test_sr_operations.ml
@@ -1,0 +1,81 @@
+(*
+ * Copyright (C) 2006-2014 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open OUnit
+open Test_common
+
+let (|>) a f = f a
+
+let all_pairs (l : 'a list) (l' : 'b list) : ('a * 'b) list =
+	List.rev_map (fun x -> List.rev_map (fun y -> (x, y)) l' ) l |> List.flatten
+
+(* Helpers for testing Xapi_sr_operations *)
+
+let cmp a b = match a, b with
+	| Some aa, Some bb -> aa = bb
+	| None, None -> true
+	| _ -> false
+
+let printer = function Some a -> a | None -> "None (No exception expected)"
+let msg ~cur_ops ~op ~pbd =
+	let open Record_util in
+	Printf.sprintf "Attempting operation %s, on an SR %s PBD, while operations [ %s ] in progress did not behave as expected:"
+		(sr_operation_to_string op)
+		(match pbd with Some true -> "with an attached" | Some false -> "with a detached" | None -> "without a")
+		(cur_ops |> List.map sr_operation_to_string |> String.concat "; ")
+
+let run_assert_exn ~__context ~cur_ops ~op ~pbd expected_exn =
+	let sr_ref = make_sr ~__context ~current_operations:(List.map (fun op -> ("", op)) cur_ops) () in
+	let _ = match pbd with
+		| Some currently_attached -> ignore (make_pbd ~__context ~sR:sr_ref ~currently_attached ())
+		| None -> ()
+	in
+	let r = try
+		Xapi_sr_operations.assert_operation_valid ~__context ~self:sr_ref ~op;
+		None
+	with Api_errors.Server_error (e, _) -> Some e
+	in
+	assert_equal ~cmp ~msg:(msg ~cur_ops ~op ~pbd) ~printer expected_exn r
+
+let test_permissible () =
+	let __context = Mock.make_context_with_new_db "Mock context" in
+	let open Api_errors in
+	[
+		([], `destroy, Some false, None); (* Can destroy SR with unplugged PBD *)
+		([], `forget, Some false, None); (* Can forget SR with unplugged PBD *)
+		([], `forget, None, None); (* Can forget SR with no PBD *)
+		([`scan], `pbd_create, Some true, None); (* Currently the only parallelisable operation *)
+		([`scan], `pbd_destroy, Some true, Some other_operation_in_progress);
+	]
+	|> List.iter (fun (cur_ops, op, pbd, expected_exn) ->
+		run_assert_exn ~__context ~cur_ops ~op ~pbd expected_exn)
+
+let test_not_permitted () =
+	let __context = Mock.make_context_with_new_db "Mock context" in
+	let open Api_errors in
+	[
+		([], `destroy, Some true, Some sr_has_pbd); (* Cannot destroy SR if PBD plugged *)
+		([], `destroy, None, Some sr_no_pbds); (* Cannot destroy SR with no PBD *)
+		([], `forget, Some true, Some sr_has_pbd); (* Cannot forget SR if PBD plugged *)
+		(* TODO: Cannot destroy SR with managed VDI *)
+	]
+	|> List.iter (fun (cur_ops, op, pbd, expected_exn) ->
+		run_assert_exn ~__context ~cur_ops ~op ~pbd expected_exn)
+
+let test =
+	"test_sr_operations" >:::
+		[
+			"test_permissible" >:: test_permissible;
+			"test_not_permitted" >:: test_not_permitted;
+		]


### PR DESCRIPTION
The PBD.create and PBD.destroy operations are now 'SR operations' however, we
do not want a long running scan to hold the lock at the exclusion of
a PBD.create.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
