### PR TITLE
CA-135187: Filter out restricted device_config keys

### DIFF
--- a/ocaml/xapi/create_storage.ml
+++ b/ocaml/xapi/create_storage.ml
@@ -79,8 +79,10 @@ let create_storage (me: API.ref_host) rpc session_id __context : unit =
     let maybe_create_pbd_for_shared_sr s =
       let mpbd,mpbd_rec = List.find (fun (_,pbdr)->pbdr.API.pBD_SR = s) master_pbds in
       let master_devconf = mpbd_rec.API.pBD_device_config in
-       maybe_create_pbd rpc session_id s master_devconf me (* copy device config from master *) in
-      List.iter (fun s -> try ignore (maybe_create_pbd_for_shared_sr s) with _ -> ()) shared_sr_refs
+      let my_devconf = List.remove_assoc "SRmaster" master_devconf in (* this should never be used *)
+      maybe_create_pbd rpc session_id s my_devconf me
+    in
+    List.iter (fun s -> try ignore (maybe_create_pbd_for_shared_sr s) with _ -> ()) shared_sr_refs
   in
 
   let other_config = 


### PR DESCRIPTION
A commit fixing SCTX-1616 now causes PBD create to throw an error if given
a device_config with the SRmaster key in (internal use only).

However, if this happened to exist from a time when this was not forbidden then
pool join will fail since the slave uses the device_config from the master's
PBD record which might contain this key.

This commit filters this key out in the pool join code-path.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
