### PR TITLE
CA-135189: Remove restricted device_config on upgrade

### DIFF
--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -447,6 +447,17 @@ let set_vgpu_types = {
 			vgpus;
 }
 
+let remove_restricted_pbd_keys = {
+	description = "Removing restricted legacy PBD.device_config keys";
+	version = (fun x -> x < creedence);
+	fn = fun ~__context ->
+		List.iter (fun self ->
+			let dc = Db.PBD.get_device_config ~__context ~self in
+			let dc' = List.filter (fun (k, _) -> k <> "SRmaster") dc in
+			Db.PBD.set_device_config ~__context ~self ~value:dc'
+		) (Db.PBD.get_all ~__context)
+}
+
 let rules = [
 	upgrade_alert_priority;
 	update_mail_min_priority;
@@ -466,6 +477,7 @@ let rules = [
 	set_vgpu_types;
 	remove_wlb;
 	add_default_pif_properties;
+	remove_restricted_pbd_keys;
 ]
 
 (* Maybe upgrade most recent db *)


### PR DESCRIPTION
The SRmaster key is restricted for internal use only. There are precautions
taken against creating PBDs with such a key in the device config now but we
should purge the database of any such keys created before these measures were
in place.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
