### PR TITLE
CA-89974: Live migrate fails on IPv6-preferring hosts

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -741,13 +741,6 @@ let is_valid_MAC mac =
     let validchar c = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') in
     List.length l = 6 && (List.fold_left (fun acc s -> acc && String.length s = 2 && validchar s.[0] && validchar s.[1]) true l)
 
-(** Returns Some Unix.PF_INET or Some Unix.PF_INET6 if passed a valid IP address, otherwise returns None. *)
-let validate_ip_address str =
-	try
-		let addr = Unix.inet_addr_of_string str in
-		Some (Unix.domain_of_sockaddr (Unix.ADDR_INET (addr, 1)))
-	with _ -> None
-
 (** Returns true if the supplied IP address looks like one of mine *)
 let this_is_my_address ~__context address =
   let dbg = Context.string_of_task __context in

--- a/ocaml/xapi/xapi_vif.ml
+++ b/ocaml/xapi/xapi_vif.ml
@@ -79,7 +79,7 @@ let set_locking_mode ~__context ~self ~value =
 		(fun () -> Db.VIF.set_locking_mode ~__context ~self ~value)
 
 let assert_ip_address_is domain field_name addr =
-	match Helpers.validate_ip_address addr with
+	match Unixext.domain_of_addr addr with
 	| Some x when x = domain -> ()
 	| _ -> raise (Api_errors.Server_error (Api_errors.invalid_value, [field_name; addr]))
 

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -70,7 +70,7 @@ let get_ip_from_url url =
 let pool_migrate ~__context ~vm ~host ~options =
 	let dbg = Context.string_of_task __context in
 	let session_id = Ref.string_of (Context.get_session_id __context) in
-	let ip = Db.Host.get_address ~__context ~self:host in
+	let ip = Http.Url.maybe_wrap_IPv6_literal (Db.Host.get_address ~__context ~self:host) in
 	let xenops_url = Printf.sprintf "http://%s/services/xenops?session_id=%s" ip session_id in
 	let open Xenops_client in
 	let vm' = Db.VM.get_uuid ~__context ~self:vm in


### PR DESCRIPTION
Make HTTP client embed IPv6 literal addresses correctly in URLs. A
related commit to xen-api-libs makes the HTTP server understand such URLs.

This commit removes 'Helpers.validate_ip_address' from
xapi/helpers.ml. The related commit to xen-api-libs adds it to
stdext/unixext.ml, renaming it to 'domain_of_addr'.
