### PR TITLE
[xs64bit] CA-74222 : Allow the Bond.create to carry on even if the MTU size is invalid , however log the error.

### DIFF
--- a/ocaml/network/network_utils.ml
+++ b/ocaml/network/network_utils.ml
@@ -181,7 +181,10 @@ module Ip = struct
 		ignore (call ~log:true ("link" :: "set" :: dev :: args))
 
 	let link_set_mtu dev mtu =
+	 try
 		ignore (link_set dev ["mtu"; string_of_int mtu])
+   with exn -> error "MTU size is not supported %s" (string_of_int mtu);
+							 ()
 
 	let link_set_up dev =
 		ignore (link_set dev ["up"])


### PR DESCRIPTION
Backport of #1049.
