### PR TITLE
Remove the hardcoded disabling of ballooning for dom0

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -605,10 +605,6 @@ let pool_has_different_host_platform_versions ~__context =
 	let is_different_to_me platform_version = platform_version <> Version.platform_version in
 	List.fold_left (||) false (List.map is_different_to_me platform_versions)
 
-(** Indicates whether ballooning is enabled for the given virtual machine. *)
-let ballooning_enabled_for_vm ~__context vm_record =
-	not vm_record.API.vM_is_control_domain
-
 let get_vm_metrics ~__context ~self =
     let metrics = Db.VM.get_metrics ~__context ~self in
     if metrics = Ref.null

--- a/ocaml/xapi/memory_check.ml
+++ b/ocaml/xapi/memory_check.ml
@@ -56,13 +56,11 @@ type accounting_policy =
 		(** use dynamic_min: liberal: assumes that guests always co-operate. *)
 
 (** Common logic of vm_compute_start_memory and vm_compute_used_memory *)
-let choose_memory_required ~policy ~ballooning_enabled ~memory_dynamic_min ~memory_dynamic_max ~memory_static_max =
-	match (ballooning_enabled, policy) with
-		| (true, Dynamic_min) -> memory_dynamic_min
-		| (true, Dynamic_max) -> memory_dynamic_max
-		| (false, Dynamic_min)
-		| (false, Dynamic_max)
-		| (_, Static_max) -> memory_static_max
+let choose_memory_required ~policy ~memory_dynamic_min ~memory_dynamic_max ~memory_static_max =
+	match policy with
+		| Dynamic_min -> memory_dynamic_min
+		| Dynamic_max -> memory_dynamic_max
+		| Static_max -> memory_static_max
 
 (** Calculates the amount of memory required in both 'normal' and 'shadow'
 memory, to start a VM. If the given VM is a PV guest and if memory ballooning
@@ -77,7 +75,6 @@ let vm_compute_start_memory ~__context ?(policy=Dynamic_min) vm_record =
 	else
 		let memory_required = choose_memory_required
 			~policy: policy
-			~ballooning_enabled: (Helpers.ballooning_enabled_for_vm ~__context vm_record)
 			~memory_dynamic_min: vm_record.API.vM_memory_dynamic_min
 			~memory_dynamic_max: vm_record.API.vM_memory_dynamic_max
 			~memory_static_max:  vm_record.API.vM_memory_static_max in
@@ -95,7 +92,6 @@ let vm_compute_used_memory ~__context policy vm_ref =
 
 	let memory_required = choose_memory_required
 		~policy: policy
-		~ballooning_enabled: (Helpers.ballooning_enabled_for_vm ~__context vm_boot_record)
 		~memory_dynamic_min: vm_main_record.API.vM_memory_dynamic_min
 		(* ToDo: Is vm_main_record or vm_boot_record the right thing for dynamic_max? *)
 		~memory_dynamic_max: vm_main_record.API.vM_memory_dynamic_max 


### PR DESCRIPTION
To express "don't balloon me", set the dynamic-min and dynamic-max
to the same values.

Signed-off-by: David Scott dave.scott@eu.citrix.com
