### PR TITLE
CA-116551: Remove the extra log files created by xenguest

### DIFF
--- a/ocaml/xenops/xenguestHelper.ml
+++ b/ocaml/xenops/xenguestHelper.ml
@@ -53,9 +53,7 @@ let connect path domid (args: string list) (fds: (string * Unix.file_descr) list
 	let server_to_slave_r, server_to_slave_w = Unix.pipe () in
 
 	let args = [ "-controloutfd"; slave_to_server_w_uuid;
-		     "-controlinfd"; server_to_slave_r_uuid;
-		     "-debuglog";
-		     last_log_file
+		     "-controlinfd"; server_to_slave_r_uuid
 	] @ (if using_xiu then [ "-fake" ] else []) @ args in
 	let pid = Forkhelpers.safe_close_and_exec None None None 
 	  ([ slave_to_server_w_uuid, slave_to_server_w;


### PR DESCRIPTION
The C xenguest will write that log if given a "-debuglog /path/to/log" argument. By omitting the argument we prevent a file being created for each domain on the host under /tmp.

Signed-off-by: Akshay akshay.ramani@citrix.com
