### PR TITLE
SCTX-1817: Check host memory before executing vdi-pool-migrate

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3345,10 +3345,13 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			Xapi_vm_lifecycle.assert_operation_valid ~__context ~self:vm ~op:`migrate_send;
 
 			VM.with_vm_operation ~__context ~self:vm ~doc:"VDI.pool_migrate" ~op:`migrate_send
-			    (fun () ->
-			        let host = Db.VM.get_resident_on ~__context ~self:vm in
-			        do_op_on ~local_fn ~__context ~host
-			            (fun session_id rpc -> Client.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr ~options))
+					(fun () ->
+							let snapshot = Helpers.get_boot_record ~__context ~self:vm in
+							let host = Db.VM.get_resident_on ~__context ~self:vm in
+							VM.reserve_memory_for_vm ~__context ~vm:vm ~host ~snapshot ~host_op:`vm_migrate
+								(fun () ->
+									do_op_on ~local_fn ~__context ~host
+									(fun session_id rpc -> Client.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr ~options)))
 
 		let resize ~__context ~vdi ~size =
 			info "VDI.resize: VDI = '%s'; size = %Ld" (vdi_uuid ~__context vdi) size;


### PR DESCRIPTION
Currently XAPI does not account for the VM memory while performing a VDI.pool_migrate. However we need to account for the VM memory as at one point during the VDI.pool_migrate a domain will exist twice thus needing 2x VM memory to be free on the host. This is not obvious will performing the VDI.pool_migrate. 

This fix ensures that a VDI.pool_migrate will not begin unless there is sufficient memory on the host. 
Signed-off-by: Akshay akshay.ramani@citrix.com
