### PR TITLE
CA-121351:PR-1675: Confusing error message shown when trying to start a VM on a pool where the required vGPU cannot be allocated

### DIFF
--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -643,7 +643,11 @@ let choose_host_for_vm_no_wlb ~__context ~vm ~snapshot =
 				Xapi_gpu_group.get_remaining_capacity_internal ~__context
 					~self:gpu_group ~vgpu_type
 			with
-			| Either.Left e -> raise e
+			| Either.Left e -> 
+				raise (Api_errors.Server_error (Api_errors.vm_requires_vgpu, [
+						Ref.string_of vm;
+						Ref.string_of gpu_group;
+						Ref.string_of vgpu_type;]))
 			| Either.Right _ -> ();
 			let host_lists =
 				group_hosts_by_best_pgpu_in_group ~__context gpu_group vgpu_type in


### PR DESCRIPTION
In vm_start, when required VGPU cannot be allocated, the error message will show detail reason of why this problem happen, but for user it is hard to understand the situation because they just start a VM and the error message they can understand is just the VM cannot start because of VGPU cannot allocated.
This change is to catch all VGPU detail error message and translate it to vm cannot start error.
