### PR TITLE
CP-8639: Enable core dumps

### DIFF
--- a/scripts/init.d-genptoken
+++ b/scripts/init.d-genptoken
@@ -7,6 +7,9 @@
 
 . /etc/init.d/functions
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
     if [ ! -f @ETCDIR@/ptoken ]; then
         echo -n $"Creating pool secret (this may take some time)"

--- a/scripts/init.d-management-interface
+++ b/scripts/init.d-management-interface
@@ -13,6 +13,9 @@ export INTERFACE_RECONFIGURE="@LIBEXECDIR@/interface-reconfigure"
 [ -r ${XENSOURCE_INVENTORY} ] || exit 0
 . ${XENSOURCE_INVENTORY}
 
+# Enable core dumping
+ulimit -c unlimited
+
 bring_up_mgmt_if() {
     [ -n "${MANAGEMENT_INTERFACE}" ] || return 0
     action $"Bringing up management interface ${MANAGEMENT_INTERFACE}: " \

--- a/scripts/init.d-networkd
+++ b/scripts/init.d-networkd
@@ -21,6 +21,9 @@ PID_FILE="/var/run/xcp-networkd.pid"
 # lock file
 SUBSYS_FILE="/var/lock/subsys/xcp-networkd"
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
 	echo -n $"Starting the XCP networking daemon: "
 	

--- a/scripts/init.d-perfmon
+++ b/scripts/init.d-perfmon
@@ -18,6 +18,9 @@ if [ -f /etc/sysconfig/perfmon ]; then
   . /etc/sysconfig/perfmon
 fi
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
 	echo -n $"Starting perfmon: "
 

--- a/scripts/init.d-rrdd
+++ b/scripts/init.d-rrdd
@@ -24,6 +24,9 @@ PID_FILE="/var/run/${NAME}.pid"
 # lock file
 SUBSYS_FILE="/var/lock/subsys/${NAME}"
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
 	echo -n $"Starting ${FULL_NAME}: "
 

--- a/scripts/init.d-sdkinit
+++ b/scripts/init.d-sdkinit
@@ -8,6 +8,9 @@
 
 . /etc/init.d/functions
 
+# Enable core dumping
+ulimit -c unlimited
+
 case "$1" in
     start)
 	# This is a run-once script!

--- a/scripts/init.d-v6d
+++ b/scripts/init.d-v6d
@@ -21,6 +21,9 @@ PID_FILE="/var/run/v6d.pid"
 # lock file
 SUBSYS_FILE="/var/lock/subsys/v6d"
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
 	echo -n $"Starting the v6 licensing daemon: "
 	

--- a/scripts/init.d-xapi-domains
+++ b/scripts/init.d-xapi-domains
@@ -21,6 +21,9 @@ if [ "x${INSTALLATION_UUID}" = "x" ] ; then
     exit 1
 fi
 
+# Enable core dumping
+ulimit -c unlimited
+
 case "$1" in
     start)
         # Need this to be present so that we get run on shutdown.

--- a/scripts/init.d-xenservices
+++ b/scripts/init.d-xenservices
@@ -13,6 +13,9 @@
 # Source function library.
 . /etc/init.d/functions
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
     # If this domain hasn't got sufficient privileges then assume it is a domU
     # and start the hypercall simulator


### PR DESCRIPTION
Update the daemon init scripts in xen-api to enable coredumps.   There are a few init scripts defined in other repositories; these also need to be updated.
