### PR TITLE
CA-137238: Revert "CA-90424: Does not migrate VDI if it is already migrating."

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3343,8 +3343,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			info "VDI.pool_migrate: VDI = '%s'; SR = '%s'; VM = '%s'"
 			    (vdi_uuid ~__context vdi) (sr_uuid ~__context sr) (vm_uuid ~__context vm);
 
-			Xapi_vm_lifecycle.assert_operation_valid ~__context ~self:vm ~op:`migrate_send;
-
 			VM.with_vm_operation ~__context ~self:vm ~doc:"VDI.pool_migrate" ~op:`migrate_send
 			    (fun () ->
 			        let host = Db.VM.get_resident_on ~__context ~self:vm in


### PR DESCRIPTION
The added assert meant that we couldn't make use of the queuing
functionality of VM.with_vm_operation. After the change which this
commit reverts, if one of a VM's disks was undergoing a VDI.pool_migrate
then attempting to VDI.pool_migrate another of the VM's disks would fail
immediately with OTHER_OPERATION_IN_PROGRESS.

After reverting this commit, the second VDI.pool_migrate gets queued up
behind the first.

This reverts commit 8598ea5b2dcda479a0c01ee081a3f7f999091087.
