### PR TITLE
CA-137722: Determining gateway and dns appropriately.

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -348,7 +348,8 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
 
 		Network.transform_networkd_exn pif (fun () ->
 			let persistent = is_dom0_interface rc in
-			let gateway_if, dns_if = Helpers.determine_gateway_and_dns_ifs ~__context ~management_interface:pif () in
+			let gateway_if, dns_if = Helpers.determine_gateway_and_dns_ifs ~__context
+			 ?management_interface:(if management_interface then Some pif else None) () in
 			Opt.iter (fun (_, name) -> Net.set_gateway_interface dbg ~name) gateway_if;
 			Opt.iter (fun (_, name) -> Net.set_dns_interface dbg ~name) dns_if;
 


### PR DESCRIPTION
If bring_pif_up is called for management interface then passing
that pif to determine_gateway_and_dns_ifs function else passing None.

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
