### PR TITLE
[SCTX-1849] CA-130748: Bumping down the xencenter max version to 2.1

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -52,7 +52,7 @@ let tools_version = ref tools_version_none
 
 (* client min/max version range *)
 let xencenter_min_verstring = "2.0"
-let xencenter_max_verstring = "2.2"
+let xencenter_max_verstring = "2.1"
 
 (* linux pack vsn key in host.software_version (used for a pool join restriction *)
 let linux_pack_vsn_key = "xs:linux"


### PR DESCRIPTION
Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
