### PR TITLE
CA-138930: Xapi should not call domain_set_memmap_limit for HVM

### DIFF
--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -496,8 +496,12 @@ let build_pre ~xc ~xs ~vcpus ~xen_max_mib ~shadow_mib ~required_host_free_mib do
 	) vpt_align;
 	debug "VM = %s; domid = %d; domain_max_vcpus %d" (Uuid.to_string uuid) domid vcpus;
 	Xenctrl.domain_max_vcpus xc domid vcpus;
-	debug "VM = %s; domid = %d; domain_set_memmap_limit %Ld MiB" (Uuid.to_string uuid) domid xen_max_mib;
-	Xenctrl.domain_set_memmap_limit xc domid (Memory.kib_of_mib xen_max_mib);
+	let di = Xenctrl.domain_getinfo xc domid in
+	if not (di.Xenctrl.Domain_info.hvm_guest) then
+		begin
+			debug "VM = %s; domid = %d; domain_set_memmap_limit %Ld MiB" (Uuid.to_string uuid) domid xen_max_mib;
+			Xenctrl.domain_set_memmap_limit xc domid (Memory.kib_of_mib xen_max_mib);
+		end;
 	debug "VM = %s; domid = %d; shadow_allocation_set %d MiB" (Uuid.to_string uuid) domid shadow_mib;
 	Xenctrl.shadow_allocation_set xc domid shadow_mib;
 


### PR DESCRIPTION
domains.

Since Xen 4.2 the hypercall behind xc_domain_set_memmap_limit() is not
permitted for HVM domains. Xapi should only call this for PV domains.

Signed-off-by: Akshay akshay.ramani@citrix.com
