### PR TITLE
CLEARWATER-SP1-LCM: CA-114498: Linux bonding: set properties (e.g. mode) before adding slave...

### DIFF
--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -634,18 +634,18 @@ module Bridge = struct
 				end else begin
 					if not (List.mem name (Sysfs.bridge_to_interfaces bridge)) then begin
 						Linux_bonding.add_bond_master name;
-						begin match bond_mac with
-							| Some mac -> Ip.set_mac name mac
-							| None -> warn "No MAC address specified for the bond"
-						end;
-						List.iter (fun name -> Interface.bring_down () dbg ~name) interfaces;
-						List.iter (Linux_bonding.add_bond_slave name) interfaces;
 						let bond_properties =
 							if List.mem_assoc "mode" bond_properties && List.assoc "mode" bond_properties = "lacp" then
 								List.replace_assoc "mode" "802.3ad" bond_properties
 							else bond_properties
 						in
-						Linux_bonding.set_bond_properties name bond_properties
+						Linux_bonding.set_bond_properties name bond_properties;
+						begin match bond_mac with
+							| Some mac -> Ip.set_mac name mac
+							| None -> warn "No MAC address specified for the bond"
+						end;
+						List.iter (fun name -> Interface.bring_down () dbg ~name) interfaces;
+						List.iter (Linux_bonding.add_bond_slave name) interfaces
 					end;
 					Interface.bring_up () dbg ~name;
 					ignore (Brctl.create_port bridge name)


### PR DESCRIPTION
Backport from creedence to clearwater-sp1-lcm.

DO NOT MERGE YET!
