### PR TITLE
CA-86869: Don't list snapshots when listing custom templates.

### DIFF
--- a/scripts/print-custom-templates
+++ b/scripts/print-custom-templates
@@ -18,7 +18,7 @@ def main(argv):
         session = XenAPI.xapi_local()
         session.xenapi.login_with_password("", "")
 
-        templates = session.xenapi.VM.get_all_records_where('field "is_a_template" = "true"' )
+        templates = session.xenapi.VM.get_all_records_where('field "is_a_template" = "true" and field "is_a_snapshot" = "false"' )
     except:
         print >> sys.stderr, "Error retrieving template list"
         sys.exit(1)


### PR DESCRIPTION
print-custom-templates is used by xe-backup-metadata so that it can then
backup metadata of all custom templates. xapi explicitly blocks exporting
the metadata of snapshots, so there's no reason for
print-custom-templates to include snapshots.

Signed-off-by: John Else john.else@citrix.com
