### PR TITLE
CA-139894: Fix waiting for VM.remove

### DIFF
--- a/ocaml/xenops/xenops_task.ml
+++ b/ocaml/xenops/xenops_task.ml
@@ -15,7 +15,7 @@ let event_wait local_updates task ?from timeout p =
 			let _, deltas, next_id = Updates.get (Printf.sprintf "event_wait task %s" task.Xenops_task.id)
 				~with_cancel:(Xenops_task.with_cancel task) event_id (Some (remaining |> ceil |> int_of_float)) local_updates in
 			let success = List.fold_left (fun acc d -> acc || (p d)) false deltas in
-			let finished = success || deltas = [] in
+			let finished = success in
 			if not finished
 			then
 				let elapsed = Unix.gettimeofday () -. start in


### PR DESCRIPTION
Due to a change in semantics of UPDATES.get, task_wait would
occasionally not wait.

This also adds back in error handling into the VM.remove path.

This is a backport of commit 3eb967b7a62ceaa7257b2a7a8b1ee0c0170ca418
from xenopsd.git

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
