### PR TITLE
CA-124008: Report out-of-space, not patch-invalid

### DIFF
--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -207,7 +207,11 @@ let read_in_and_check_patch length s path =
     
     let run_path = extract_patch path in
     Unixext.unlink_safe run_path
-  with exn ->
+  with
+    | Unix.Unix_error (errno, _, _) when errno = Unix.ENOSPC ->
+       warn "Not enough space on filesystem to upload patch.";
+       raise (Api_errors.Server_error (Api_errors.out_of_space, [patch_dir]))
+    | exn ->
     debug "Caught exception while checking signature: %s" (ExnHelper.string_of_exn exn);
     Unixext.unlink_safe path;
     raise (Api_errors.Server_error(Api_errors.invalid_patch, []))
@@ -235,6 +239,20 @@ let create_patch_record ~__context ?path patch_info =
 
 exception CannotUploadPatchToSlave
 
+let assert_space_available required =
+	let open Unixext in
+	let stat = statvfs patch_dir in
+	let free_bytes =
+		(* block size times free blocks *)
+		Int64.mul stat.f_frsize stat.f_bavail in
+	if required > free_bytes
+	then
+    begin
+      warn "Not enough space on filesystem to upload patch. Required %Ld, \
+            but only %Ld available" required free_bytes;
+      raise (Api_errors.Server_error (Api_errors.out_of_space, [patch_dir]))
+		end
+
 let pool_patch_upload_handler (req: Request.t) s _ =
   debug "Patch Upload Handler - Entered...";
 
@@ -256,7 +274,16 @@ let pool_patch_upload_handler (req: Request.t) s _ =
         debug "Patch Upload Handler - Sending headers...";
 
         Http_svr.headers s (Http.http_200_ok ());
-        
+
+        (match req.Request.content_length with
+         | None -> ()
+         | Some size ->
+            (* Later in the process we'll require more than 2 * size,
+               but this will get us past the gpg signature
+               checking until we can catch Unix.ENOSPC. *)
+            let required = Int64.mul 2L size in
+            assert_space_available required);
+
         read_in_and_check_patch req.Request.content_length s new_path;
 	
         try


### PR DESCRIPTION
Requested by HFX-1226. Merge Thomas's fix from master branch
(https://github.com/xapi-project/xen-api/pull/1678)

If there isn't enough space on the filesystem to upload a patch (which can take
2-3 times the size of the patch, because of multiple copies and gpg signature
checking), we should fail with an Out_of_space exception. Before, if the gpg
check failed because there wasn't enough space to write the unsigned cleartext,
we would erroneously report patch_invalid. Now we check that there is enough
free space to signature check the patch (we make a guess of 2 \* size of the
patch), and catch Unix.ENOSPC exceptions and handle them accordingly.
