### PR TITLE
Don't record RRDs for the "ovs-system" interface

### DIFF
--- a/ocaml/network/network_monitor_thread.ml
+++ b/ocaml/network/network_monitor_thread.ml
@@ -116,7 +116,8 @@ let rec monitor dbg () =
 				if not(String.startswith "dummy" name) &&
 					not(String.startswith "xenbr" name) &&
 					not(String.startswith "xapi" name) &&
-					not(String.startswith "eth" name && String.contains name '.')
+					not(String.startswith "eth" name && String.contains name '.') &&
+					name <> "ovs-system"
 				then devs := (name,eth_stat) :: (!devs)
 			)
 		in


### PR DESCRIPTION
This started appearing in the recent single-datapath OVSes, but does not really
add anything useful.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
