### PR TITLE
CA-140545: wrapper should exit after launching vncterm

### DIFF
--- a/scripts/vncterm-wrapper
+++ b/scripts/vncterm-wrapper
@@ -19,9 +19,10 @@ shift 1
 ulimit -c 67108864
 
 echo vncterm-wrapper:
-xenstore-write -s /local/domain/$DOMID/vncterm-pid $$
 if [ -z "${XIU}" ]; then
-	exec /usr/lib64/xen/bin/vncterm $* > /dev/null 2>&1
+	/usr/lib64/xen/bin/vncterm $* > /dev/null 2>&1 &
+	xenstore-write -s /local/domain/$DOMID/vncterm-pid $!
 else
-	exec xenstore-write -s /local/domain/$DOMID/console/vnc-port 0
+	xenstore-write -s /local/domain/$DOMID/console/vnc-port 0
+	xenstore-write -s /local/domain/$DOMID/vncterm-pid $$
 fi


### PR DESCRIPTION
To avoid an instance of fe hanging around for each vncterm we launch,
fork vncterm and exit rather than calling exec.

This means that the script has to write the child pid ($!) rather than
its own pid ($$) to xenstore.

This commit also removes the exec of xenstore-write in the xiu branch,
since it should return straight away.
