### PR TITLE
Revert "Ca 137813: Temporarily enable core dumps for v6d"

### DIFF
--- a/scripts/init.d-v6d
+++ b/scripts/init.d-v6d
@@ -21,9 +21,6 @@ PID_FILE="/var/run/v6d.pid"
 # lock file
 SUBSYS_FILE="/var/lock/subsys/v6d"
 
-# Enable core dumping
-ulimit -c unlimited
-
 start() {
 	echo -n $"Starting the v6 licensing daemon: "
 	


### PR DESCRIPTION
Reverts xapi-project/xen-api#1802.   Not reproducible.
