### PR TITLE
CA-105789: Ensure the bridge has the correct MAC on first boot

### DIFF
--- a/ocaml/network/OMakefile
+++ b/ocaml/network/OMakefile
@@ -20,7 +20,7 @@ OCamlLibraryClib(network_utils, network_utils, link_stubs)
 OCamlProgram($(NETWORKD), $(NETWORKD_FILES))
 OCamlDocProgram($(NETWORKD), $(NETWORKD_FILES))
 OCamlProgram($(NETWORK_TEST), ../fhs network_test network_interface)
-OCamlProgram($(NETWORKD_DB), network_interface network_config networkd_db)
+OCamlProgram($(NETWORKD_DB), network_interface network_config network_utils networkd_db)
 
 .PHONY: install
 install:

--- a/ocaml/network/network_config.ml
+++ b/ocaml/network/network_config.ml
@@ -35,6 +35,7 @@ let read_management_conf () =
 		Util_inventory.reread_inventory ();
 		let bridge_name = Util_inventory.lookup Util_inventory._management_interface in
 		debug "Management bridge in inventory file: %s" bridge_name;
+		let mac = Network_utils.Ip.get_mac device in
 		let ipv4_conf, ipv4_gateway, dns =
 			match List.assoc "MODE" args with
 			| "static" ->
@@ -63,6 +64,7 @@ let read_management_conf () =
 		let phy_interface = {default_interface with persistent_i = true} in
 		let bridge_interface = {default_interface with ipv4_conf; ipv4_gateway; persistent_i = true} in
 		let bridge = {default_bridge with
+			bridge_mac = Some mac;
 			ports = [device, {default_port with interfaces = [device]}];
 			persistent_b = true
 		} in


### PR DESCRIPTION
Also, Use the interface name, not the bridge name when looking up MAC,
which is for firstboot and for when xe-reset-networking has been
executed.

Cherry pick of commits from xcp-networkd.git:
5b97592aaff07760693a416d100c253ebe456987
e23a6c1c71bf0a1c994ff546db3db6dc47640dc7

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
