### PR TITLE
CLEARWATER-SP1-LCM: CA-141103: Do not set GRO on Linux VLAN devices

### DIFF
--- a/ocaml/network/network_interface.ml
+++ b/ocaml/network/network_interface.ml
@@ -119,7 +119,7 @@ let default_interface = {
 	dns = [], [];
 	mtu = 1500;
 	ethtool_settings = [];
-	ethtool_offload = ["gro", "off"; "lro", "off"];
+	ethtool_offload = [];
 	persistent_i = false;
 }
 let default_bridge = {


### PR DESCRIPTION
...at all. This involves removing the defaults from xcp-networkd.
The GRO settings for VLANs are inherited from the underlying physical
or bond interface.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
