### PR TITLE
CA-140252: Hack for legacy PV tools evtchn alignment

### DIFF
--- a/ocaml/xenops/domain.ml
+++ b/ocaml/xenops/domain.ml
@@ -456,6 +456,8 @@ let get_action_request ~xs domid =
 
 (** create store and console channels *)
 let create_channels ~xc uuid domid =
+	if !Xenops_utils.ca_140252_workaround
+	then ignore_int (Xenctrl.evtchn_alloc_unbound xc domid 0);
 	let store = Xenctrl.evtchn_alloc_unbound xc domid 0 in
 	let console = Xenctrl.evtchn_alloc_unbound xc domid 0 in
 	debug "VM = %s; domid = %d; store evtchn = %d; console evtchn = %d" (Uuid.to_string uuid) domid store console;

--- a/ocaml/xenops/xenops_utils.ml
+++ b/ocaml/xenops/xenops_utils.ml
@@ -26,6 +26,7 @@ open D
 (* shared place for config option *)
 let default_vbd_backend_kind = ref "vbd"
 let vgpu_path = ref "/usr/lib/xen/bin/vgpu"
+let ca_140252_workaround = ref false
 
 module Unix = struct
 	include Unix

--- a/ocaml/xenops/xenopsd.ml
+++ b/ocaml/xenops/xenopsd.ml
@@ -55,6 +55,7 @@ let config_spec = [
 	"default-vbd-backend-kind", Config.Set_string Xenops_utils.default_vbd_backend_kind;
 	"database-path", Config.Set_string Xenops_utils.root;
 	"vgpu-path", Config.Set_string Xenops_utils.vgpu_path;
+	"ca-140252-workaround", Config.Set_bool Xenops_utils.ca_140252_workaround;
 ]
 
 let read_config_file () =
@@ -76,7 +77,8 @@ let dump_config_file () : unit =
 	debug "worker-pool-size = %d" !worker_pool_size;
 	debug "default-vbd-backend-kind = %s" !default_vbd_backend_kind;
 	debug "database-path = %s" !Xenops_utils.root;
-	debug "vgpu-path = %s" !Xenops_utils.vgpu_path
+	debug "vgpu-path = %s" !Xenops_utils.vgpu_path;
+	debug "ca-140252-workaround = %b" !Xenops_utils.ca_140252_workaround
 
 let socket : Http_svr.socket option ref = ref None
 let server = Http_svr.Server.empty (Xenops_server.make_context ())

--- a/scripts/xenopsd.conf
+++ b/scripts/xenopsd.conf
@@ -23,3 +23,6 @@ default-vbd-backend-kind=vbd3
 
 # path to the vgpu display emulator
 vgpu-path=/usr/lib64/xen/bin/vgpu
+
+# workaround for ca-140252: evtchn misalignment workaround for legacy PV tools
+ca-140252-workaround=true


### PR DESCRIPTION
Since the new ioreq server in Xen, one of its event channels is now allocated
on-demand rather than eagerly at start-of-day. Therefore, when the toolstack
comes to allocate event channels for Xenstore and the console, they are
shuffled down by one.

This is fine for HVM guests with modern PV tools since they re-read this
information upon each resume. However, legacy PV tools do not and rely on these
to be the same across suspend/resume.

This patch adds an explicit workaround to realign the event channels as they
were on previous versions by having Xenopsd allocating another channel before
the two it needs. As this is done with evtchn_allocate_unbound and the guest
will not bind it, it should not affect event channel scalability in dom0.

The workaround has been made explicit and a configuration option in Xenopsd so
that we can only carry it until such a time that we no longer support HVM
guests using these legacy PV tools, at which point it can be removed.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
