### PR TITLE
HFX-1236: Pick CA-114333: Allow Linux HVM guests to use >4 devices to clearwater-sp1-lcm

### DIFF
--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -464,7 +464,7 @@ let release (task: Xenops_task.t) ~xs (x: device) =
 	 * to unplug as well as the backend. CA-13506 *)
 	if x.frontend.domid = 0 then Hotplug.wait_for_frontend_unplug task ~xs x
 
-let free_device ~xs bus_type domid =
+let free_device ~xs hvm domid =
 	let disks = List.map
 		(fun x -> x.frontend.devid
 		|> Device_number.of_xenstore_key
@@ -472,6 +472,8 @@ let free_device ~xs bus_type domid =
 		|> (fun (_, disk, _) -> disk))
 		(Device_common.list_frontends ~xs domid) in
 	let next = List.fold_left max 0 disks + 1 in
+	let open Device_number in
+        let bus_type = if (hvm && next < 4) then Ide else Xen in	
 	bus_type, next, 0
 
 type t = {
@@ -494,7 +496,7 @@ let add_async ~xs ~hvm x domid =
 	let device_number = match x.device_number with
 		| Some x -> x
 		| None ->
-			make (free_device ~xs (if hvm then Ide else Xen) domid) in
+			make (free_device ~xs hvm domid) in
 	let devid = to_xenstore_key device_number in
 	let device = 
 	  let backend = { domid = x.backend_domid; kind = Vbd; devid = devid } 

--- a/ocaml/xenops/device_number.ml
+++ b/ocaml/xenops/device_number.ml
@@ -151,7 +151,7 @@ let to_disk_number = function
 	| Ide, disk, _ -> disk
 
 let of_disk_number hvm n = 
-	if hvm && (n < 16)
+	if hvm && (n < 4)
 	then Ide, n, 0
 	else Xen, n, 0
 


### PR DESCRIPTION
Windows PV drivers don't check the guest device name, but the Linux kernel does
With devices > 4, Linux expects them to be in xvdN format, so this patch ensures
that all devices are treated as Linux devices

Signed-off-by: Bob Ball bob.ball@citrix.com
