### PR TITLE
[HFX-1158] CA-129089: Disable global login via slave hosts

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1237,7 +1237,7 @@ let session_login  = call ~flags:[]
   [{param_type=String; param_name="uname"; param_doc="Username for login."; param_release=rio_release; param_default=None};
    {param_type=String; param_name="pwd"; param_doc="Password for login."; param_release=rio_release; param_default=None};
    {param_type=String; param_name="version"; param_doc="Client API version."; param_release=miami_release; param_default=Some (VString "1.1")}]
-  ~errs:[Api_errors.session_authentication_failed]
+  ~errs:[Api_errors.session_authentication_failed; Api_errors.host_is_slave]
   ~secret:true
   ~allowed_roles:_R_ALL (*any static role can try to create a user session*)
   ()

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -365,7 +365,10 @@ let login_with_password ~__context ~uname ~pwd ~version = wipe_params_after_fn [
 			~auth_user_sid:"" ~auth_user_name:uname ~rbac_permissions:[]
 	end 
 	else
-	let login_as_local_superuser auth_type = 
+	let () =
+		if Pool_role.is_slave() then
+			raise (Api_errors.Server_error (Api_errors.host_is_slave, [Pool_role.get_master_address()])) in
+	let login_as_local_superuser auth_type =
 		if (auth_type <> "") && (uname <> local_superuser)
 		then (* makes local superuser = root only*)
 		     failwith ("Local superuser must be "^local_superuser)


### PR DESCRIPTION
Signed-off-by: Zheng Li dev@zheng.li

Conflicts:
    ocaml/idl/datamodel.ml

Signed-off-by: Akshay akshay.ramani@citrix.com
