### PR TITLE
Serialise unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test:
 	@echo @
 #	Pipe ugly bash output to /dev/null
 	@echo @ xapi unit test suite
-	@./ocaml/test/suite -verbose true
+	@./ocaml/test/suite -verbose true -shards 1
 	@echo
 	@echo @ HA binpack test
 	@./ocaml/xapi/binpack


### PR DESCRIPTION
There seems to be a race in OUnit. Serialising the tests adds less than
a second to the run time, which I think we can live with for now.
