### PR TITLE
CA-108189: Prevent timeouts when collecting bugtools

### DIFF
--- a/scripts/bugtool-plugin/xenopsd.xml
+++ b/scripts/bugtool-plugin/xenopsd.xml
@@ -1,1 +1,1 @@
-<capability pii="maybe" max_size="1638400" max_time="60" mime="text/plain" checked="true"/>
+<capability pii="maybe" max_size="1638400" max_time="600" mime="text/plain" checked="true"/>


### PR DESCRIPTION
Prevent timeouts when collecting bugtools by increasing the timeout for
the xenopsd bugtool plugin from 60 seconds to 600 seconds.  Since it
took about 200 seconds for 460 VMs, 600 seconds should be enough for
very large hosts.

Signed-off-by: Ross Lagerwall ross.lagerwall@citrix.com
