### PR TITLE
CA-139501 VM hard_shutdown & hard_reboot must wait for nothing else.

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -107,8 +107,8 @@ let is_allowed_concurrently ~(op:API.vm_operations) ~current_ops =
 		  [`migrate_send],          `metadata_export;
 		  [`migrate_send],          `clean_shutdown;
 		  [`migrate_send],          `clean_reboot;
-        	  [`migrate_send],          `start;
-        	  [`migrate_send],          `start_on;
+		  [`migrate_send],          `start;
+		  [`migrate_send],          `start_on;
 		] in
 	let state_machine () = 
 		let current_state = List.map snd current_ops in


### PR DESCRIPTION
CA-139501 VM hard_shutdown & hard_reboot must wait for nothing else.

We were already allowing hard_reboot concurrent with a clean_reboot
already in progress, and the same for hard/clean shutdown, but
clean_(shutdown|reboot) would block hard_(reboot|shutdown).

Now the is_allowed_concurrently function allows hard_shutdown
concurrent with anything except itself, and allows hard_reboot
concurrent with anything but itself or hard_shutdown.
