### PR TITLE
CA-110585: Passing correct snapshot_time during VDI.snapshot

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -448,6 +448,7 @@ module SMAPIv1 = struct
 						in
 						Db.VDI.set_name_label ~__context ~self ~value:vdi_info.name_label;
 						Db.VDI.set_name_description ~__context ~self ~value:vdi_info.name_description;
+						Db.VDI.set_snapshot_time ~__context ~self ~value:(Date.of_string vdi_info.snapshot_time);
 						Db.VDI.remove_from_other_config ~__context ~self ~key:"content_id";
 						Db.VDI.add_to_other_config ~__context ~self ~key:"content_id" ~value:content_id;
 						debug "copying sm-config";

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -423,6 +423,7 @@ let snapshot_and_clone call_f ~__context ~vdi ~driver_params =
 			  name_label = a.Db_actions.vDI_name_label;
 			  name_description = a.Db_actions.vDI_name_description;
 			  sm_config = driver_params;
+			  snapshot_time = Date.to_string (Date.of_float (Unix.gettimeofday ()));
 	  } in
 	  let sr' = Db.SR.get_uuid ~__context ~self:sR in
 	  (* We don't use transform_storage_exn because of the clone/copy fallback below *)
@@ -459,7 +460,6 @@ let snapshot ~__context ~vdi ~driver_params =
 	(* Record the fact this is a snapshot *)
 	Db.VDI.set_is_a_snapshot ~__context ~self:newvdi ~value:true;
 	Db.VDI.set_snapshot_of ~__context ~self:newvdi ~value:vdi;
-	Db.VDI.set_snapshot_time ~__context ~self:newvdi ~value:(Date.of_float (Unix.gettimeofday ()));
 
 	update_allowed_operations ~__context ~self:newvdi;
 	newvdi


### PR DESCRIPTION
Issue: for_vdi calls find_vdi which in turn refers to xapi db to find out about vdi. At that point, the xapi db is not updated with the vdi info. This leads to snapshot time being set to Date.never (1970-01-01). This then gets passed to SM.

Fix: Adding an optional parameter vdi_info. This, if present, takes info from vdi_info directly and doesnt peek xapi db for snapshot time. 

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
