### PR TITLE
[xs64bit] CP-9457: Read VBD kthread-pid from right path

### DIFF
--- a/ocaml/xenops/device_common.ml
+++ b/ocaml/xenops/device_common.ml
@@ -95,10 +95,7 @@ let disconnect_path_of_device ~xs (x: device) =
 
 (** Where linux blkback writes its thread id. NB this won't work in a driver domain *)
 let kthread_pid_path_of_device ~xs (x: device) =
-	sprintf "%s/device/%s/%d/kthread-pid"
-		(xs.Xs.getdomainpath x.backend.domid)
-		(string_of_kind x.backend.kind)
-		x.frontend.devid
+	sprintf "%s/kthread-pid" (backend_path_of_device ~xs x)
 
 (** Location of the backend error path *)
 let backend_error_path_of_device ~xs (x : device) =


### PR DESCRIPTION
Before we were reading from:

```
/local/domain/0/backend/<vbd|vbd3>/<devid>
```

When we should also include the domid of the frontend:

```
/local/domain/0/backend/<vbd|vbd3>/<domid>/<devid>
```

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
