### PR TITLE
CA-143838: let network configure all physical and bond interfaces on sta...

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -28,7 +28,11 @@ let local_m = Mutex.create ()
 let with_local_lock f = Mutex.execute local_m f
 
 let is_dom0_interface pif_r =
-  pif_r.API.pIF_ip_configuration_mode <> `None || pif_r.API.pIF_ipv6_configuration_mode <> `None
+	pif_r.API.pIF_ip_configuration_mode <> `None
+	|| pif_r.API.pIF_ipv6_configuration_mode <> `None
+	|| pif_r.API.pIF_physical = true
+	|| pif_r.API.pIF_bond_master_of <> []
+
 
 let determine_mtu pif_rc net_rc =
 	let mtu = Int64.to_int net_rc.API.network_MTU in


### PR DESCRIPTION
...rtup

If a VLAN is used for storage and is configured to use jumbo frames (MTU =
9000), then XS does not immediately enable jumbo frames on the interface at
boot time. Specifically, if HA is enabled, the HA daemon is unable to access
the storage device, and blocks the host's startup process for a long time.

Networkd can be told to bring up interfaces and bridges at boot time, which is
before xapi is started, and before anything else may need the network. This is
done by marking the interface/bridge as "persistent". Currently, all
interfaces/bridges with an IP address in dom0 are made persistent. This
includes VLAN bridges, but not the interface that the VLAN is based on, which
is what caused the bug.

To simplify, this patch makes all physical and bond interfaces/bridge
persistent, besides all other interface/bridges that have an IP address.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
