### PR TITLE
Use cmdliner for command-line parsing and manpage generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ ocaml/xapi/quicktest_encodings_module.ml
 ocaml/xapi/quicktestbin
 ocaml/xapi/stresstest
 ocaml/xapi/xapi
+ocaml/xapi/xapi.1
 ocaml/xe-cli/rt/geneva/cli_test
 ocaml/xe-cli/rt/geneva/sm_stress
 ocaml/xe-cli/rt/gtclient

--- a/OMakefile
+++ b/OMakefile
@@ -154,6 +154,7 @@ JAVA_PHASE3_TARGETS = $(if $(COMPILE_JAVA), $(JAVA_PHASE3))
 # Phase 3 targets divided into two depending on whether we're building the Xen stuff or not:
 OCAML_PHASE3_XEN = \
 	ocaml/xapi/xapi \
+	ocaml/xapi/xapi.1 \
 	ocaml/xapi/quicktestbin \
 	ocaml/xapi/storage_impl_test \
 	ocaml/license/v6d

--- a/configure
+++ b/configure
@@ -36,6 +36,7 @@ let xhadir = dir "xhadir" "/opt/xensource/xha" "XHADIR" "HA daemon"
 let bindir = dir "bindir" "/opt/xensource/bin" "BINDIR" "binaries"
 let sbindir = dir "sbindir" "/opt/xensource/bin" "BINDIR" "system binaries"
 let udevdir = dir "udevdir" "/etc/udev" "UDEVDIR" "udev scripts"
+let mandir = dir "mandir" "/usr/share/man" "MANDIR" "man pages"
 
 let info =
   let doc = "Configures a package" in
@@ -47,8 +48,8 @@ let output_file filename lines =
   List.iter (output_string oc) lines;
   close_out oc
 
-let configure disable_tests varpatchdir etcdir optdir plugindir hooksdir inventory xapiconf libexecdir scriptsdir sharedir webdir xhadir bindir sbindir udevdir =
-  Printf.printf "Configuring with the following params:\n\tdisable_tests=%b\n\tvarpatchdir=%s\n\tetcdir=%s\n\toptdir=%s\n\tplugindir=%s\n\thooksdir=%s\n\tinventory=%s\n\txapiconf=%s\n\tlibexecdir=%s\n\tscriptsdir=%s\n\tsharedir=%s\n\twebdir=%s\n\txhadir=%s\n\tbindir=%s\n\tsbindir=%s\n\tudevdir=%s\n\n" disable_tests varpatchdir etcdir optdir plugindir hooksdir inventory xapiconf libexecdir scriptsdir sharedir webdir xhadir bindir sbindir udevdir;
+let configure disable_tests varpatchdir etcdir optdir plugindir hooksdir inventory xapiconf libexecdir scriptsdir sharedir webdir xhadir bindir sbindir udevdir mandir =
+  Printf.printf "Configuring with the following params:\n\tdisable_tests=%b\n\tvarpatchdir=%s\n\tetcdir=%s\n\toptdir=%s\n\tplugindir=%s\n\thooksdir=%s\n\tinventory=%s\n\txapiconf=%s\n\tlibexecdir=%s\n\tscriptsdir=%s\n\tsharedir=%s\n\twebdir=%s\n\txhadir=%s\n\tbindir=%s\n\tsbindir=%s\n\tudevdir=%s\n\tmandir=%s\n\n" disable_tests varpatchdir etcdir optdir plugindir hooksdir inventory xapiconf libexecdir scriptsdir sharedir webdir xhadir bindir sbindir udevdir mandir;
 
   (* Write config.mk *)
   let lines = 
@@ -69,7 +70,8 @@ let configure disable_tests varpatchdir etcdir optdir plugindir hooksdir invento
       Printf.sprintf "XHADIR=%s" xhadir;
       Printf.sprintf "BINDIR=%s" bindir;
       Printf.sprintf "SBINDIR=%s" sbindir;
-      Printf.sprintf "UDEVDIR=%s" udevdir
+      Printf.sprintf "UDEVDIR=%s" udevdir;
+      Printf.sprintf "MANDIR=%s" mandir;
     ] in
   output_file config_mk lines;
 
@@ -93,7 +95,7 @@ let configure disable_tests varpatchdir etcdir optdir plugindir hooksdir invento
   in
   output_file fhs_ml fhs_lines
 
-let configure_t = Term.(pure configure $ disable_tests $ varpatchdir $ etcdir $ optdir $ plugindir $ hooksdir $ inventory $ xapiconf $ libexecdir $ scriptsdir $ sharedir $ webdir $ xhadir $ bindir $ sbindir $ udevdir )
+let configure_t = Term.(pure configure $ disable_tests $ varpatchdir $ etcdir $ optdir $ plugindir $ hooksdir $ inventory $ xapiconf $ libexecdir $ scriptsdir $ sharedir $ webdir $ xhadir $ bindir $ sbindir $ udevdir $ mandir)
 
 let () = 
   match 

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -273,6 +273,9 @@ XAPI_MODULES = $(COMMON) \
 OCamlProgram(xapi, xapi_main $(XAPI_MODULES))
 OCamlDocProgram(xapi, xapi_main $(XAPI_MODULES))
 
+xapi.1: xapi
+	./xapi --help=groff > xapi.1
+
 OCamlLibrary(xapi, xapi $(XAPI_MODULES))
 
 OCamlProgram(bootloader, bootloader bootloader_test)
@@ -291,6 +294,8 @@ install:
 	$(IPROG) quicktest $(DESTDIR)$(OPTDIR)/debug
 	cp -f quicktestbin $(DESTDIR)$(OPTDIR)/debug
 	mkdir -p $(DESTDIR)$(LIBEXECDIR)
+	mkdir -p $(DESTDIR)$(MANDIR)/man1
+	cp -f xapi.1 $(DESTDIR)$(MANDIR)/man1/xapi.1
 
 .PHONY: clean
 clean:

--- a/scripts/init.d-xapi
+++ b/scripts/init.d-xapi
@@ -59,13 +59,13 @@ start() {
 	if [ -e ${XAPI_BOOT_TIME_INFO_UPDATED} ]; then
 	    # clear out qemu coredumps/chroot dirs on system boot:
 	    rm -rf /var/xen/qemu/*
-	    "@BINDIR@/xapi" -daemon true ${xapiflags} \
-		-writereadyfile ${XAPI_STARTUP_COOKIE} -writeinitcomplete ${XAPI_INIT_COMPLETE_COOKIE} -onsystemboot
+	    "@BINDIR@/xapi" --daemon true ${xapiflags} \
+		--writereadyfile ${XAPI_STARTUP_COOKIE} --writeinitcomplete ${XAPI_INIT_COMPLETE_COOKIE} --onsystemboot
 		RETVAL=$?
 	    rm -f ${XAPI_BOOT_TIME_INFO_UPDATED}
 	else
-	    "@BINDIR@/xapi" -daemon true ${xapiflags} \
-		-writereadyfile ${XAPI_STARTUP_COOKIE} -writeinitcomplete ${XAPI_INIT_COMPLETE_COOKIE}
+	    "@BINDIR@/xapi" --daemon true ${xapiflags} \
+		--writereadyfile ${XAPI_STARTUP_COOKIE} --writeinitcomplete ${XAPI_INIT_COMPLETE_COOKIE}
 		RETVAL=$?
 	fi
 


### PR DESCRIPTION
Note this is a backwards-incompatible change to the command-line arguments.
Where an argument was previously '-foo' it will now be '--foo'. Where an
argument was a flag '-flag' it is now '--flag true'.

Signed-off-by: David Scott <dave.scott@citrix.com>