### PR TITLE
Revert "CA-143944: Allow suspend when PV drivers are present (as before)...

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -123,6 +123,15 @@ let is_allowed_concurrently ~(op:API.vm_operations) ~current_ops =
 	in
 	aux long_copies || aux snapshot || aux boot_record || state_machine ()
 
+(** Special handling is required for RedHat version 3 *)
+let is_rhel3 = function
+	| Some gmr ->
+		let version = gmr.Db_actions.vM_guest_metrics_os_version in
+		assoc_opt "distro" version = Some "rhel"
+		&& assoc_opt "major" version = Some "3"
+	| None ->
+		false
+
 (** True iff the vm guest metrics "other" field includes (feature, "1")
 	as a key-value pair. *)
 let has_feature ~vmgmr ~feature =
@@ -134,15 +143,10 @@ let has_feature ~vmgmr ~feature =
 				List.assoc feature other = "1"
 			with Not_found -> false
 
-(** Return an error iff vmr is an HVM guest and lacks a needed feature.
- *  Note: it turned out that the Windows guest agent does not write "feature-suspend"
- *  on resume (only on startup), so we cannot rely just on that flag. We therefore
- *  add a cause that enables all features when PV drivers are present using the
- *  old-style check. *)
+(** Return an error iff vmr is an HVM guest and lacks a needed feature *)
 let check_op_for_feature ~__context ~vmr ~vmgmr ~power_state ~op ~ref =
 	if power_state <> `Running ||
-		not (Helpers.has_booted_hvm_of_record ~__context vmr) ||
-		has_pv_drivers (of_guest_metrics vmgmr) (* Full PV drivers imply all features *)
+		not (Helpers.has_booted_hvm_of_record ~__context vmr)
 	then None (* PV guests offer support implicitly *)
 	else
 		let some_err e =


### PR DESCRIPTION
Reverts xapi-project/xen-api#1895
(Undoing all of the recent HVM-Linux changes in xen-api)
