### PR TITLE
Use correct names for configurable options

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -785,7 +785,7 @@ let xapi_globs_spec =
 
 let options_of_xapi_globs_spec = 
   List.map (fun (name,ty) -> 
-    "name", (match ty with Float x -> Arg.Set_float x | Int x -> Arg.Set_int x),
+    name, (match ty with Float x -> Arg.Set_float x | Int x -> Arg.Set_int x),
     (fun () -> match ty with Float x -> string_of_float !x | Int x -> string_of_int !x),
     (Printf.sprintf "Set the value of '%s'" name)) xapi_globs_spec
 


### PR DESCRIPTION
All the configurable options were using the same string in the config file
("name") which was confusing Xcp_service.

This patch gives the correct name for use in the config file

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
