### PR TITLE
CA-136972: Read raw stats from blktap3

### DIFF
--- a/ocaml/rrdd/OMakefile
+++ b/ocaml/rrdd/OMakefile
@@ -15,6 +15,9 @@ OCAML_LIBS = $(ROOT)/ocaml/fhs ../idl/ocaml_backend/xapi_client ../xenops/xensto
 
 UseCamlp4(rpc-light.syntax, rrdd_server)
 
+OCAML_CLIBS = blktap3_stats_stubs
+StaticCLibrary(blktap3_stats_stubs, blktap3_stats_stubs)
+
 RRDD = xcp-rrdd
 RRDD_FILES = \
 	../pool_role_shared \

--- a/ocaml/rrdd/blktap3_stats_stubs.c
+++ b/ocaml/rrdd/blktap3_stats_stubs.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <errno.h>
+#include <blktap/blktap3.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/unixsupport.h>
+
+
+CAMLprim value stub_get_blktap3_stats(value filename)
+{
+	
+	CAMLparam1(filename);
+	CAMLlocal1(stats);
+
+	FILE *c_fd;
+	struct blkback_stats c_stats;
+
+	c_fd = fopen(String_val(filename), "rb");
+
+	if (!c_fd) uerror("fopen", Nothing);
+	if (fread(&c_stats, sizeof(struct blkback_stats), 1, c_fd) < 1) uerror("fread", Nothing);
+	
+	stats = caml_alloc_tuple(6);
+
+	Store_field(stats, 0, caml_copy_int64((int64) c_stats.st_rd_req));
+	Store_field(stats, 1, caml_copy_int64((int64) c_stats.st_rd_cnt));
+	Store_field(stats, 2, caml_copy_int64((int64) c_stats.st_rd_sum_usecs));
+	Store_field(stats, 3, caml_copy_int64((int64) c_stats.st_wr_req));
+	Store_field(stats, 4, caml_copy_int64((int64) c_stats.st_wr_cnt));
+	Store_field(stats, 5, caml_copy_int64((int64) c_stats.st_wr_sum_usecs));
+
+	CAMLreturn(stats);
+
+}


### PR DESCRIPTION
This is a revised version of #1883 by @siddharthv. Things worth noting:
- The only change by this pull req (compared with @siddharthv's original) is making use of OCaml/C binding, whereas the algorithm in the original pull req is untouched. 
- A successful compilation will depend on Thanos' pull req xapi-project/blktap#97 being merged first (given if  the compiler.h issue previously reported being fixed)
- I've verified that the code can generate data stream successfully, though the correctness of these figures has to depend on the validity of data sources (blktap3) and the original import algorithm, which is not in the the scope of this work. 
- Also, the original pull req is only about devX_read, devX_write, devX_read_latency, devX_write_latency. I'm not sure about the status of other data sources such as devX_iops_read/write/total etc.
- Currently the binding returns 6 fields of the original struct as a tuple. Suppose if we need more fields later on, it's better to read out all the fields and convert them to a OCaml record type instead.
