### PR TITLE
CA-110585: Setting snapshot_time for VDI before passing it to SM during

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -475,6 +475,7 @@ module SMAPIv1 = struct
 						in
 						Db.VDI.set_name_label ~__context ~self ~value:vdi_info.name_label;
 						Db.VDI.set_name_description ~__context ~self ~value:vdi_info.name_description;
+						Db.VDI.set_snapshot_time ~__context ~self ~value:(Date.of_string vdi_info.snapshot_time);
 						Db.VDI.remove_from_other_config ~__context ~self ~key:"content_id";
 						Db.VDI.add_to_other_config ~__context ~self ~key:"content_id" ~value:content_id;
 						debug "copying sm-config";

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -424,6 +424,7 @@ let snapshot_and_clone call_f ~__context ~vdi ~driver_params =
 			  name_label = a.Db_actions.vDI_name_label;
 			  name_description = a.Db_actions.vDI_name_description;
 			  sm_config = driver_params;
+			  snapshot_time = Date.to_string (Date.of_float (Unix.gettimeofday ()));
 	  } in
 	  let sr' = Db.SR.get_uuid ~__context ~self:sR in
 	  (* We don't use transform_storage_exn because of the clone/copy fallback below *)
@@ -460,7 +461,6 @@ let snapshot ~__context ~vdi ~driver_params =
 	(* Record the fact this is a snapshot *)
 	Db.VDI.set_is_a_snapshot ~__context ~self:newvdi ~value:true;
 	Db.VDI.set_snapshot_of ~__context ~self:newvdi ~value:vdi;
-	Db.VDI.set_snapshot_time ~__context ~self:newvdi ~value:(Date.of_float (Unix.gettimeofday ()));
 
 	update_allowed_operations ~__context ~self:newvdi;
 	newvdi


### PR DESCRIPTION
VDI.snapshot

Issue:The vdi snapshot time was being set after SM returned from
creating vdi.

Fix: The snapshot_time is now set before it being passed to SM.

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
