### PR TITLE
CA-136972: Read raw stats from blktap3

### DIFF
--- a/ocaml/rrdd/OMakefile
+++ b/ocaml/rrdd/OMakefile
@@ -15,6 +15,9 @@ OCAML_LIBS = $(ROOT)/ocaml/fhs ../idl/ocaml_backend/xapi_client ../xenops/xensto
 
 UseCamlp4(rpc-light.syntax, rrdd_server)
 
+OCAML_CLIBS = blktap3_stats_stubs
+StaticCLibrary(blktap3_stats_stubs, blktap3_stats_stubs)
+
 RRDD = xcp-rrdd
 RRDD_FILES = \
 	../pool_role_shared \
@@ -38,6 +41,7 @@ RRDD_FILES = \
 	rrdd_server \
 	rrdd_monitor \
 	rrdd_stats \
+	blktap3_stats\
 	rrdd_main
 RRDD_TEST = rrdd_test
 RRDD_TEST_FILES = \

--- a/ocaml/rrdd/blktap3_stats.ml
+++ b/ocaml/rrdd/blktap3_stats.ml
@@ -1,0 +1,39 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(*
+ * This module extracts the external declaration to make things easier
+ * for a library which might be used elsewhere.
+*)
+
+(** Define an equivalent blktap3 statistics record *)
+type blktap3_stats = {
+	st_ds_req : int64;
+	st_f_req  : int64;
+	st_oo_req : int64;
+	st_rd_req : int64;
+	st_rd_cnt : int64;
+	st_rd_sect: int64;
+	st_rd_sum_usecs : int64;
+	st_rd_max_usecs : int64;
+	st_wr_req : int64;
+	st_wr_cnt : int64;
+	st_wr_sect: int64;
+	st_wr_sum_usecs : int64;
+	st_wr_max_usecs : int64;
+}
+
+(** Obtain a blktap3 statistics record using the stubs *)
+external get_blktap3_stats:
+	filename:string -> blktap3_stats = "stub_get_blktap3_stats"

--- a/ocaml/rrdd/blktap3_stats.mli
+++ b/ocaml/rrdd/blktap3_stats.mli
@@ -1,0 +1,51 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+(**
+ * This module defines an equivalent blktap3 stats record and the
+ * associated API method.
+ *)
+
+(** Attributes associated with the blktap3 stats struct *)
+type blktap3_stats = {
+	(** BLKIF_OP_DISCARD, not currently supported in blktap3, zero always *)
+	st_ds_req : int64;
+	(** BLKIF_OP_FLUSH_DISKCACHE, not currently supported in blktap3, zero always*)
+	st_f_req  : int64;
+	(** Increased each time we fail to allocate memory for a internal 
+	 * request descriptor in response to a ring request. *)
+	st_oo_req : int64;
+	(** Received BLKIF_OP_READ requests. *)
+	st_rd_req : int64;
+	(** Completed BLKIF_OP_READ requests. *)
+	st_rd_cnt : int64;
+	(** Read sectors, after we've forwarded the request to actual storage. *)
+	st_rd_sect: int64;
+	(** Sum of the request response time of all BLKIF_OP_READ *)
+	st_rd_sum_usecs : int64;
+	(** Absolute maximum BLKIF_OP_READ response time *)
+	st_rd_max_usecs : int64;
+	(** Received BLKIF_OP_WRITE requests. *)
+	st_wr_req : int64;
+	(** Completed BLKIF_OP_WRITE requests. *)
+	st_wr_cnt : int64;
+	(** Write sectors, after we've forwarded the request to actual storage. *)
+	st_wr_sect: int64;
+	(** Sum of the request response time of all BLKIF_OP_WRITE *)
+	st_wr_sum_usecs : int64;
+	(** Absolute maximum BLKIF_OP_WRITE response time *)
+	st_wr_max_usecs : int64;
+}
+
+(** Get a blktap3 statistics record *)
+val get_blktap3_stats: filename:string -> blktap3_stats

--- a/ocaml/rrdd/blktap3_stats_stubs.c
+++ b/ocaml/rrdd/blktap3_stats_stubs.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2006-2009 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ */
+
+/*
+  This stubs file retrieves the blkback statistics struct created by
+  blktap3 under '/dev/shm/<vbd3-domid-devid>/statistics' *)
+*/
+
+#include <stdio.h>
+#include <errno.h>
+#include <blktap/blktap3.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/unixsupport.h>
+
+
+CAMLprim value stub_get_blktap3_stats(value filename)
+{
+	
+	CAMLparam1(filename);
+	CAMLlocal1(stats);
+
+	FILE *c_fd;
+	struct blkback_stats c_stats;
+
+	c_fd = fopen(String_val(filename), "rb");
+
+	if (!c_fd) uerror("fopen", Nothing);
+	if (fread(&c_stats, sizeof(struct blkback_stats), 1, c_fd) < 1) uerror("fread", Nothing);
+	
+	stats = caml_alloc_tuple(13);
+
+	Store_field(stats, 0, caml_copy_int64((int64) c_stats.st_ds_req));
+	Store_field(stats, 1, caml_copy_int64((int64) c_stats.st_f_req));
+	Store_field(stats, 2, caml_copy_int64((int64) c_stats.st_oo_req));
+	Store_field(stats, 3, caml_copy_int64((int64) c_stats.st_rd_req));
+	Store_field(stats, 4, caml_copy_int64((int64) c_stats.st_rd_cnt));
+	Store_field(stats, 5, caml_copy_int64((int64) c_stats.st_rd_sect));
+	Store_field(stats, 6, caml_copy_int64((int64) c_stats.st_rd_sum_usecs));
+	Store_field(stats, 7, caml_copy_int64((int64) c_stats.st_rd_max_usecs));
+	Store_field(stats, 8, caml_copy_int64((int64) c_stats.st_wr_req));
+	Store_field(stats, 9, caml_copy_int64((int64) c_stats.st_wr_cnt));
+	Store_field(stats, 10, caml_copy_int64((int64) c_stats.st_wr_sect));
+	Store_field(stats, 11, caml_copy_int64((int64) c_stats.st_wr_sum_usecs));
+	Store_field(stats, 12, caml_copy_int64((int64) c_stats.st_wr_max_usecs));
+
+	fclose(c_fd);
+
+	CAMLreturn(stats);
+
+}

--- a/ocaml/rrdd/rrdd_main.ml
+++ b/ocaml/rrdd/rrdd_main.ml
@@ -394,39 +394,6 @@ let update_vbds doms =
 			!vals
 		with _ -> !vals
 	in
-	(* With blktap3, the IO statistics are maintained in a file 'statistics'
-	 * under the directory '/dev/shm/vbd3-<pid>-<minor>/'
-	 * The file contains the following information:
-	 * ds_req, f_req, oo_req, rd_req, rd_sect, wr_req, wr_sect
-	 * read requests: %Ld, avg usecs: %Ld, max usecs: %Ld
-	 * write requests: %Ld, avg usecs: %Ld, max usecs: %Ld *)
-
-	(* This method reads the first line from the 'statistics' file *)
-	let read_shm_stats_line line =
-		try
-			Scanf.sscanf line "%Ld %Ld %Ld %Ld %Ld %Ld %Ld"
-				(fun a b c d e f g -> (a, b, c, d, e, f, g))
-		with _ -> (0L, 0L, 0L, 0L, 0L, 0L, 0L)
-	in
-	(* This method obtains the latency metrics from the 'statistics' file *)
-	let get_latency_metrics line rdwr =
-		match rdwr with
-		| `Read ->
-			Scanf.sscanf line "read requests: %Ld, avg usecs: %Ld, max usecs: %Ld"
-				(fun a b c -> (a, b, c))
-		| `Write ->
-			Scanf.sscanf line "write requests: %Ld, avg usecs: %Ld, max usecs: %Ld"
-				(fun a b c -> (a, b, c))
-	in
-	let parse_shm_stats file_contents =
-		match file_contents with
-		| [shm_stats; read_latency_stats; write_latency_stats] ->
-				let _,_,_, shm_rd_req,_,shm_wr_req,_ = read_shm_stats_line shm_stats in
-				let _, shm_rd_avg_usecs, _ = get_latency_metrics read_latency_stats `Read in
-				let _, shm_wr_avg_usecs, _ = get_latency_metrics write_latency_stats `Write in
-				Some(shm_rd_req, shm_wr_req, shm_rd_avg_usecs, shm_wr_avg_usecs)
-		| _ -> None
-	in
 	let shm_devices_dir = "/dev/shm" in
 	let sysfs_devices_dir = "/sys/devices/" in
 	(* Method to read stats from sysfs *)
@@ -444,15 +411,28 @@ let update_vbds doms =
 				let wr_file = statdir ^ "wr_sect" in
 				let rd_usecs_file = statdir ^ "rd_usecs" in
 				let wr_usecs_file = statdir ^ "wr_usecs" in
-				let rd_reqs = read_int_file rd_file in
-				let wr_reqs = read_int_file wr_file in
+				let rd_sect = read_int_file rd_file in
+				let wr_sect = read_int_file wr_file in
 				let _, rd_avg_usecs, _ = read_usecs_file rd_usecs_file in
 				let _, wr_avg_usecs, _ = read_usecs_file wr_usecs_file in
-				Some(rd_reqs, wr_reqs, rd_avg_usecs, wr_avg_usecs)
+				Some(rd_sect, wr_sect, rd_avg_usecs, wr_avg_usecs)
 			end
 		else
 			None
 	in
+	let read_raw_blktap3_stats vbd =
+		try
+			let open Blktap3_stats in
+			let stat_file = Printf.sprintf "%s/%s/statistics" shm_devices_dir vbd in
+			(* Retrieve blktap3 statistics record *)
+			let stat_rec = get_blktap3_stats stat_file in
+			let rd_avg_usecs =
+				if stat_rec.st_rd_cnt > 0L then Int64.div stat_rec.st_rd_sum_usecs stat_rec.st_rd_cnt else 0L in
+			let wr_avg_usecs =
+				if stat_rec.st_wr_cnt > 0L then Int64.div stat_rec.st_wr_sum_usecs stat_rec.st_wr_cnt else 0L in
+			Some(stat_rec.st_rd_sect, stat_rec.st_wr_sect, rd_avg_usecs, wr_avg_usecs)
+		with _ ->
+			None in
 	let shm_dirs = Array.to_list (Sys.readdir shm_devices_dir) in
 	let shm_vbds =
 		List.filter
@@ -466,13 +446,11 @@ let update_vbds doms =
 		let istap = String.startswith "tap-" vbd in
 		let isvbd3 = String.startswith "vbd3-" vbd in
 		let avg64 a b = Int64.div (Int64.add a b) 2L in
-		let stat_file = Printf.sprintf "%s/%s/statistics" shm_devices_dir vbd in
-		let stats = Unixext.read_lines stat_file in
 		(* Produce IO RRDs when demanded *)
-		let generate_rrds acc rd_reqs wr_reqs rd_avg_usecs wr_avg_usecs =
+		let generate_rrds acc rd_sect wr_sect rd_avg_usecs wr_avg_usecs =
 			let blksize = 512L in
-			let rd_bytes = Int64.mul rd_reqs blksize in
-			let wr_bytes = Int64.mul wr_reqs blksize in
+			let rd_bytes = Int64.mul rd_sect blksize in
+			let wr_bytes = Int64.mul wr_sect blksize in
 			let domid, devid =
 				if istap then Scanf.sscanf vbd "tap-%d-%d" (fun id devid -> (id, devid))
 				else if isvbd3 then Scanf.sscanf vbd "vbd3-%d-%d" (fun id devid -> (id, devid))
@@ -507,23 +485,23 @@ let update_vbds doms =
 				in
 				newacc
 		in
-		match parse_shm_stats stats, read_all_sysfs_stats vbd with
+		match read_raw_blktap3_stats vbd, read_all_sysfs_stats vbd with
 		| Some(a, b, c, d), Some(p, q, r, s) ->
-				let (shm_rd_reqs, shm_wr_reqs, shm_rd_avg_usecs, shm_wr_avg_usecs) = (a, b, c, d) in
-				let (rd_reqs, wr_reqs, rd_avg_usecs, wr_avg_usecs) = (p, q, r, s) in
-				(* Take max for usecs *)
-				let rd_avg_usecs = max rd_avg_usecs shm_rd_avg_usecs in
-				let wr_avg_usecs = max wr_avg_usecs shm_wr_avg_usecs in
-				(* Average out the read/write requests *)
-				let rd_reqs = avg64 rd_reqs shm_rd_reqs in
-				let wr_reqs = avg64 wr_reqs shm_wr_reqs in
-				generate_rrds acc rd_reqs wr_reqs rd_avg_usecs wr_avg_usecs;
+			let (shm_rd_sect, shm_wr_sect, shm_rd_avg_usecs, shm_wr_avg_usecs) = (a, b, c, d) in
+			let (rd_sect, wr_sect, rd_avg_usecs, wr_avg_usecs) = (p, q, r, s) in
+			(* Take max for usecs *)
+			let rd_avg_usecs = max rd_avg_usecs shm_rd_avg_usecs in
+			let wr_avg_usecs = max wr_avg_usecs shm_wr_avg_usecs in
+			(* Average out the read/write requests *)
+			let rd_sect = avg64 rd_sect shm_rd_sect in
+			let wr_sect = avg64 wr_sect shm_wr_sect in
+			generate_rrds acc rd_sect wr_sect rd_avg_usecs wr_avg_usecs;
 		| Some(a, b, c, d), None ->
-				let (shm_rd_reqs, shm_wr_reqs, shm_rd_avg_usecs, shm_wr_avg_usecs) = (a, b, c, d) in
-				generate_rrds acc shm_rd_reqs shm_wr_reqs shm_rd_avg_usecs shm_wr_avg_usecs
+			let (shm_rd_sect, shm_wr_sect, shm_rd_avg_usecs, shm_wr_avg_usecs) = (a, b, c, d) in
+			generate_rrds acc shm_rd_sect shm_wr_sect shm_rd_avg_usecs shm_wr_avg_usecs;
 		| None, Some(p, q, r, s) ->
-				let (rd_reqs, wr_reqs, rd_avg_usecs, wr_avg_usecs) = (p, q, r, s) in
-				generate_rrds acc rd_reqs wr_reqs rd_avg_usecs wr_avg_usecs
+			let (rd_sect, wr_sect, rd_avg_usecs, wr_avg_usecs) = (p, q, r, s) in
+			generate_rrds acc rd_sect wr_sect rd_avg_usecs wr_avg_usecs
 		| None, None -> acc
 	) [] vbds
 


### PR DESCRIPTION
With blktap3, the blkback stats structure is maintained on a shared page
This patch fetches the required counters to create the datasources.

Signed-off-by: Siddharth Vinothkumar siddharth.vinothkumar@citrix.com
Revised-by: Zheng Li zheng.li3@citrix.com
