### PR TITLE
CA-145257: Set the right month for host_crashdump.

### DIFF
--- a/ocaml/xapi/xapi_host_crashdump.ml
+++ b/ocaml/xapi/xapi_host_crashdump.ml
@@ -86,11 +86,10 @@ let resynchronise ~__context ~host =
 			| size :: _ -> Int64.of_string size
 			| _ -> (-1L) in
 		let timestamp =
+			let open Unix in
 			try Scanf.sscanf filename "%04d%02d%02d-%02d%02d%02d-UTC"
-				(fun tm_year tm_mon tm_mday tm_hour tm_min tm_sec ->
-					fst (Unix.mktime
-						{ Unix.tm_year=tm_year-1900; tm_mon; tm_mday;
-						  tm_hour; tm_min; tm_sec; tm_wday=0; tm_yday=0; tm_isdst=false }))
+				(fun year mon tm_mday tm_hour tm_min tm_sec ->
+					fst ( mktime {tm_year=year-1900; tm_mon=mon-1; tm_mday; tm_hour; tm_min; tm_sec; tm_wday=0; tm_yday=0; tm_isdst=false}))
 			with _ ->
 				(Unix.stat (Filename.concat crash_dir filename)).Unix.st_ctime in
 		let timestamp = Date.of_float timestamp in


### PR DESCRIPTION
Date.of_float increments tm_mon by 1.So, we need to pass tm_mon value
decremented by 1.

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
