### PR TITLE
API docs: update API version number to 2.3 on PDF

### DIFF
--- a/ocaml/idl/xenenterpriseapi-coversheet.tex
+++ b/ocaml/idl/xenenterpriseapi-coversheet.tex
@@ -17,7 +17,7 @@
 \newcommand{\releasestatement}{}
 
 %% Document revision
-\newcommand{\revstring}{API Revision 2.0}
+\newcommand{\revstring}{API Revision 2.3}
 
 %% Document authors
 \newcommand{\docauthors}{


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
