### PR TITLE
CA-145878: make the hotfix signing key configurable

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -848,7 +848,17 @@ let xenopsd_queues = ref ([
 
 let default_xenopsd = ref "org.xen.xcp.xenops.xenlight"
 
+(* Fingerprint of default patch key *)
+let citrix_patch_key = "NERDNTUzMDMwRUMwNDFFNDI4N0M4OEVCRUFEMzlGOTJEOEE5REUyNg=="
+(* Used only for testing hotfixes *)
+let test_patch_key = "RjgyNjVCRURDMzcxMjgzNkQ1NkJENjJERDQ2MDlGOUVDQzBBQkZENQ=="
+
+let trusted_patch_key = ref citrix_patch_key
+
 let other_options = [
+  "hotfix-fingerprint", Arg.Set_string trusted_patch_key,
+    (fun () -> !trusted_patch_key), "Fingerprint of the key used for signed hotfixes";
+
   "logconfig", Arg.Set_string log_config_file, 
     (fun () -> !log_config_file), "Log config file to use";
 

--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -47,15 +47,6 @@ let rm = "/bin/rm"
 (* Host patches are directories are placed here: *)
 let patch_dir = "/var/patch"
 
-let xensource_patch_key = "NERDNTUzMDMwRUMwNDFFNDI4N0M4OEVCRUFEMzlGOTJEOEE5REUyNg=="
-let test_patch_key = "RjgyNjVCRURDMzcxMjgzNkQ1NkJENjJERDQ2MDlGOUVDQzBBQkZENQ=="
-
-let oem_patch_keys = [
-	xensource_patch_key; (* normal public key *)
-	"NDExQUZBNzQwMDJFMDg1QjM3RDZGRkY1QTY1OTlCNDdENDBFMUY4Qw=="; (* pub=D40E1F8C public key *)
-	"NEJDMzFFN0Q3M0EwRjdBNzY3QzM3NEMyQTk3NjkwNTYzMERBQTkxNA=="; (* pub=30DAA914 public key *)
-]
-
 let check_unsigned_patch_fist path =
 	match Xapi_fist.allowed_unsigned_patches () with
 	| None -> false
@@ -85,7 +76,7 @@ let extract_patch path =
 		  let enc = Base64.encode f in
 		  let acceptable_keys = 
 			  if Xapi_fist.allow_test_patches () then
-				  [ xensource_patch_key; test_patch_key ] else [ xensource_patch_key ]
+				  [ !Xapi_globs.trusted_patch_key; Xapi_globs.test_patch_key ] else [ !Xapi_globs.trusted_patch_key ]
 		  in
 		  if not (List.mem enc acceptable_keys)
 		  then 

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -157,6 +157,9 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # Passed as --homedir to gpg commands
 # gpg-homedir = @OPTDIR@/gpg
 
+# The fingerprint of the key to expect a hotfix is signed by
+# hotfix-fingerprint = <printable fingerprint>
+
 # Optional directory for configuring static VDIs
 # static-vdis-root = @ETCDIR@/static-vdis
 


### PR DESCRIPTION
The xapi.conf file can override the hotfix signing key fingerprint
by:

  hotfix-fingerprint=<fingerprint>

This extends the FIST-point activated hotfix testing key mechanism
that we already have.

Signed-off-by: David Scott dave.scott@eu.citrix.com
