### PR TITLE
CA-146595: Improve parsing of VM platform flags

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -218,11 +218,17 @@ let backend_of_network net =
 		Network.Local net.API.network_bridge (* PR-1255 *)
 
 let find f map default feature =
-	try f (List.assoc feature map)
-	with _ -> default
+	try
+		let v = List.assoc feature map in
+		try f v
+		with e ->
+			warn "Failed to parse %s as value for %s: %s; Using default value."
+				v feature (Printexc.to_string e);
+			default
+	with Not_found -> default
 let string = find (fun x -> x)
 let int = find int_of_string
-let bool = find bool_of_string
+let bool = find (function "1" -> true | "0" -> false | x -> bool_of_string x)
 
 let rtc_timeoffset_of_vm ~__context (vm, vm_t) vbds =
 	let timeoffset = string vm_t.API.vM_platform "0" Platform.timeoffset in


### PR DESCRIPTION
We need to be able to use 0 and 1 in (at least) the case of the acpi key.
Before this patch, using 0 and 1 would have both been converted to true when
passed to Xenopsd and therefore wrong arguments could be passed to Qemu when
trying to disable this feature.

This patch makes the 'bool' function a little more lenient on its input rather
than using OCaml's stock bool_of_string. It also introduces a warning message
if the value has been specified incorrectly.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
