### PR TITLE
CA-145355: Make xcp-rrdd report all stats exposed by tapdisk3

### DIFF
--- a/ocaml/rrdd/rrdd_main.ml
+++ b/ocaml/rrdd/rrdd_main.ml
@@ -476,6 +476,11 @@ let update_vbds doms =
 						else 0L in
 					let rd_avg_usecs = max b_rd_avg_usecs s.rd_avg_usecs in
 					let wr_avg_usecs = max b_wr_avg_usecs s.wr_avg_usecs in
+					(* Retain old behaviour as handling sysfs becomes important only
+					 * when CAR-133 is in place. CAR-133 attempts to plug raw VDI's
+					 * directly from LVs to blkback. *)
+					let inflight = Int64.add (Int64.sub b.st_rd_req b.st_rd_cnt) (Int64.sub b.st_wr_req b.st_wr_cnt) in
+					let iowait = Int64.to_float (Int64.div (Int64.add b.st_rd_cnt b.st_wr_cnt) (Int64.add b.st_rd_sum_usecs b.st_wr_sum_usecs))  /. 1000. in
 					let newacc =
 						try
 							let uuid = uuid_of_domid doms domid in
@@ -495,6 +500,30 @@ let update_vbds doms =
 								~description:("Write latency for device '" ^ device_name ^ "' in microseconds")
 								~value:(Rrd.VT_Int64 wr_avg_usecs) ~ty:Rrd.Gauge ~min:0.0
 								~default:false ~units:"μs" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_inflight")
+								~description:("Number of I/O requests currently in flight")
+								~value:(Rrd.VT_Int64 inflight) ~ty:Rrd.Gauge ~min:0.0 ~default:true
+								~units:"requests" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iowait")
+								~description:("Total I/O wait time (all requests) per second")
+								~value:(Rrd.VT_Float iowait) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"s/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_read")
+								~description:("Read requests per second")
+								~value:(Rrd.VT_Int64 b.st_rd_cnt) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_write")
+								~description:("Write requests per second")
+								~value:(Rrd.VT_Int64 b.st_wr_cnt) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_total")
+								~description:("I/O Requests per second")
+								~value:(Rrd.VT_Int64 (Int64.add b.st_rd_cnt b.st_wr_cnt))
+								~ty:Rrd.Derive ~min:1.0 ~default:true ~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_io_throughput_total")
+								~description:("All " ^ device_name ^ " I/O")
+								~value:(Rrd.VT_Int64 (Int64.add rd_bytes wr_bytes)) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
 							acc
 						with _ -> acc
 					in
@@ -510,6 +539,9 @@ let update_vbds doms =
 						if b.st_wr_cnt > 0L then
 							Int64.div b.st_wr_sum_usecs b.st_wr_cnt
 						else 0L in
+					(* Create variables to hold new statistics *)
+					let inflight = Int64.add (Int64.sub b.st_rd_req b.st_rd_cnt) (Int64.sub b.st_wr_req b.st_wr_cnt) in
+					let iowait = Int64.to_float (Int64.div (Int64.add b.st_rd_cnt b.st_wr_cnt) (Int64.add b.st_rd_sum_usecs b.st_wr_sum_usecs))  /. 1000. in
 					let newacc =
 						try
 							let uuid = uuid_of_domid doms domid in
@@ -529,6 +561,30 @@ let update_vbds doms =
 								~description:("Write latency for device '" ^ device_name ^ "' in microseconds")
 								~value:(Rrd.VT_Int64 wr_avg_usecs) ~ty:Rrd.Gauge ~min:0.0
 								~default:false ~units:"μs" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_inflight")
+								~description:("Number of I/O requests currently in flight")
+								~value:(Rrd.VT_Int64 inflight) ~ty:Rrd.Gauge ~min:0.0 ~default:true
+								~units:"requests" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iowait")
+								~description:("Total I/O wait time (all requests) per second")
+								~value:(Rrd.VT_Float iowait) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"s/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_read")
+								~description:("Read requests per second")
+								~value:(Rrd.VT_Int64 b.st_rd_cnt) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_write")
+								~description:("Write requests per second")
+								~value:(Rrd.VT_Int64 b.st_wr_cnt) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_total")
+								~description:("I/O Requests per second")
+								~value:(Rrd.VT_Int64 (Int64.add b.st_rd_cnt b.st_wr_cnt))
+								~ty:Rrd.Derive ~min:1.0 ~default:true ~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_io_throughput_total")
+								~description:("All " ^ device_name ^ " I/O")
+								~value:(Rrd.VT_Int64 (Int64.add rd_bytes wr_bytes)) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
 							acc
 						with _ -> acc
 					in


### PR DESCRIPTION
Prior to XS6.5, a VM's metrics were supplied by xcp-rrdd,
xcp-rrd-iostat, etc... Originally, these metrics were created by reading
counters from `sysfs`. With tapdisk3, we read the statistics exposed
under '/dev/shm' to create these datasources.
The newly exposed counters are:
- vbd_<X>_iowait
- vbd_<X>_inflight
- vbd_<X>_iops_read
- vbd_<X>_iops_write
- vbd_<X>_iops_total
- vbd_<X>_io_throughput_total

Metrics like vbd_<X>_io_throughput_read and vbd_<X>_io_throughput_write
are redundant.

Signed-off-by: Siddharth Vinothkumar siddharth.vinothkumar@citrix.com
