### PR TITLE
CA-147161: Discard messages after logging to remote host

### DIFF
--- a/scripts/xe-syslog-reconfigure
+++ b/scripts/xe-syslog-reconfigure
@@ -36,7 +36,7 @@ fi
 
 sed -e '/^\*\.\*.*[@~]/ d' $conf_file >/etc/syslog.$$
 if [ $remote -eq 1 ]; then
-  echo "*.* @$host" >>/etc/syslog.$$
+  echo -e "*.* @$host\n*.* ~" >>/etc/syslog.$$
 else
   echo "*.* ~" >>/etc/syslog.$$
 fi


### PR DESCRIPTION
Make rsyslog discard messages after they have been logged locally and
sent to a remote host to prevent the default rules from picking them up.

Signed-off-by: Ross Lagerwall ross.lagerwall@citrix.com
