### PR TITLE
CA-143836: Fix up snapshot_of links after reverting to snapshot

### DIFF
--- a/ocaml/client_records/record_util.ml
+++ b/ocaml/client_records/record_util.ml
@@ -106,6 +106,7 @@ let vdi_operation_to_string = function
   | `generate_config -> "generate_config"
   | `blocked -> "blocked"
   | `revert -> "revert"
+  | `reverting -> "reverting"
 
 let sr_operation_to_string = function
   | `scan -> "scan"

--- a/ocaml/client_records/record_util.ml
+++ b/ocaml/client_records/record_util.ml
@@ -105,6 +105,7 @@ let vdi_operation_to_string = function
   | `update -> "update"
   | `generate_config -> "generate_config"
   | `blocked -> "blocked"
+  | `revert -> "revert"
 
 let sr_operation_to_string = function
   | `scan -> "scan"
@@ -121,6 +122,7 @@ let sr_operation_to_string = function
   | `vdi_snapshot -> "VDI.snapshot"
   | `pbd_create -> "PBD.create"
   | `pbd_destroy -> "PBD.destroy"
+  | `vdi_revert -> "VDI.revert"
 
 let vbd_operation_to_string = function
   | `attach -> "attach"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5479,6 +5479,7 @@ let vdi_operations =
 	  "generate_config", "Generating static configuration";
 	  "blocked", "Operations on this VDI are temporarily blocked";
 	  "revert", "Reverting a VDI to a clone of this snapshot";
+	  "reverting", "Reverting this VDI to a clone of one of its snapshots";
 	])
 
 let vdi_set_missing = call

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2981,6 +2981,29 @@ let vdi_clone = call
   ~allowed_roles:_R_VM_ADMIN
   ()
 
+let vdi_revert = call
+	~name:"revert"
+	~in_oss_since:None
+	~in_product_since:rel_creedence
+	~versioned_params:[{
+		param_type=Ref _vdi;
+		param_name="snapshot";
+		param_doc="The snapshot to which we want to revert";
+		param_release=creedence_release;
+		param_default=None
+	};
+	{
+		param_type=Map (String, String);
+		param_name="driver_params";
+		param_doc="Optional parameters that are passed through to the backend driver in order to specify storage-type-specific clone options";
+		param_release=creedence_release;
+		param_default=Some (VMap []);
+	}]
+	~doc:"Clone a new VDI from the specified snapshot; mark all snapshots in the tree of snapshots of this new VDI; delete the original VDI these snapshots were pointing at; return the new VDI."
+	~result:(Ref _vdi, "The ID of the newly created VDI.")
+	~allowed_roles:_R_VM_POWER_ADMIN
+	()
+
 let vdi_resize = call
   ~name:"resize"
   ~in_product_since:rel_rio
@@ -5175,7 +5198,8 @@ let storage_operations =
 	  "vdi_clone", "Cloneing a VDI"; 
 	  "vdi_snapshot", "Snapshotting a VDI";
 	  "pbd_create", "Creating a PBD for this SR";
-	  "pbd_destroy", "Destroying one of this SR's PBDs"; ])
+	  "pbd_destroy", "Destroying one of this SR's PBDs";
+	  "vdi_revert", "Reverting a VDI to a clone of this snapshot"; ])
 
 let sr_set_virtual_allocation = call
    ~name:"set_virtual_allocation"
@@ -5454,6 +5478,7 @@ let vdi_operations =
 	  "force_unlock", "Forcibly unlocking the VDI";
 	  "generate_config", "Generating static configuration";
 	  "blocked", "Operations on this VDI are temporarily blocked";
+	  "revert", "Reverting a VDI to a clone of this snapshot";
 	])
 
 let vdi_set_missing = call
@@ -5664,7 +5689,11 @@ let vdi =
       ~gen_events:true
       ~doccomments:[]
       ~messages_default_allowed_roles:_R_VM_ADMIN
-      ~messages:[vdi_snapshot; vdi_clone; vdi_resize; 
+      ~messages:[
+		 vdi_snapshot;
+		 vdi_clone;
+		 vdi_revert;
+		 vdi_resize;
 		 vdi_resize_online;
 		 vdi_introduce; vdi_pool_introduce;
 		 vdi_db_introduce; vdi_db_forget;

--- a/ocaml/test/test_vdi_allowed_operations.ml
+++ b/ocaml/test/test_vdi_allowed_operations.ml
@@ -17,7 +17,7 @@ open Test_common
 
 (* Helpers for testing Xapi_vdi.check_operation_error *)
 
-let setup_test ~__context vbd_fun =
+let setup_test ~__context ~vdi_fun =
 	let sr_ref = make_sr ~__context () in
 	let sr_uuid = Db.SR.get_uuid ~__context ~self:sr_ref in
 	(* Register the SR with a dummy processor which has a sensible
@@ -52,7 +52,7 @@ let setup_test ~__context vbd_fun =
 	let (_: API.ref_PBD) = make_pbd ~__context ~sR:sr_ref () in
 	let vdi_ref = make_vdi ~__context ~sR:sr_ref () in
 	let vdi_record = Db.VDI.get_record_internal ~__context ~self:vdi_ref in
-	vbd_fun vdi_ref;
+	vdi_fun vdi_ref;
 	vdi_ref, vdi_record
 
 let my_cmp a b = match a,b with
@@ -65,8 +65,8 @@ let string_of_api_exn_opt = function
 	| Some (code, args) ->
 		Printf.sprintf "Some (%s, [%s])" code (String.concat "; " args)
 
-let run_assert_equal_with_vdi ~__context ?(cmp = my_cmp) ?(ha_enabled=false) vbd_list op exc =
-	let vdi_ref, vdi_record = setup_test ~__context vbd_list in
+let run_assert_equal_with_vdi ~__context ?(cmp = my_cmp) ?(ha_enabled=false) ~vdi_fun op exc =
+	let vdi_ref, vdi_record = setup_test ~__context ~vdi_fun in
 	assert_equal
 		~cmp
 		~printer:string_of_api_exn_opt
@@ -78,33 +78,33 @@ let test_ca98944 () =
 	let __context = Mock.make_context_with_new_db "Mock context" in
 	(* Should raise vdi_in_use *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			make_vbd ~vDI:vdi_ref ~__context
 				~reserved:true ~currently_attached:false ~current_operations:["", `attach] ())
 		`update (Some (Api_errors.vdi_in_use, []));
 
 	(* Should raise vdi_in_use *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			make_vbd ~vDI:vdi_ref
 				~__context ~reserved:false ~currently_attached:true ~current_operations:["", `attach] ())
 		`update (Some (Api_errors.vdi_in_use, []));
 
 	(* Should raise vdi_in_use *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref -> make_vbd ~vDI:vdi_ref
+		~vdi_fun:(fun vdi_ref -> make_vbd ~vDI:vdi_ref
 			~__context ~reserved:true ~currently_attached:true ~current_operations:["", `attach] ())
 		`update (Some (Api_errors.vdi_in_use, []));
 
 	(* Should raise other_operation_in_progress *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref -> make_vbd ~vDI:vdi_ref
+		~vdi_fun:(fun vdi_ref -> make_vbd ~vDI:vdi_ref
 			~__context ~reserved:false ~currently_attached:false ~current_operations:["", `attach] ())
 		`update (Some (Api_errors.other_operation_in_progress, []));
 
 	(* Should pass *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref -> make_vbd ~vDI:vdi_ref
+		~vdi_fun:(fun vdi_ref -> make_vbd ~vDI:vdi_ref
 			~__context ~reserved:false ~currently_attached:false ~current_operations:[] ())
 		`forget None
 
@@ -114,24 +114,24 @@ let test_ca101669 () =
 
 	(* Attempting to copy a RW-attached VDI should fail with VDI_IN_USE. *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RW ())
 		`copy (Some (Api_errors.vdi_in_use, []));
 
 	(* Attempting to copy a RO-attached VDI should pass. *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RO ())
 		`copy None;
 
 	(* Attempting to copy an unattached VDI should pass. *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref -> ())
+		~vdi_fun:(fun vdi_ref -> ())
 		`copy None;
 
 	(* Attempting to copy RW- and RO-attached VDIs should fail with VDI_IN_USE. *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			let (_: API.ref_VBD) = make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RW () in
 			make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RO ())
 		`copy (Some (Api_errors.vdi_in_use, []))
@@ -141,7 +141,7 @@ let test_ca125187 () =
 
 	(* A VDI being copied can be copied again concurrently. *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			let (_: API.ref_VBD) = make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RO () in
 			Db.VDI.set_current_operations ~__context
 				~self:vdi_ref
@@ -151,7 +151,7 @@ let test_ca125187 () =
 	(* A VBD can be plugged to a VDI which is being copied. This is required as
 	 * the VBD is plugged after the VDI is marked with the copy operation. *)
 	let _, _ = setup_test ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			let vm_ref = make_vm ~__context () in
 			Db.VM.set_is_control_domain ~__context ~self:vm_ref ~value:true;
 			Db.VM.set_power_state ~__context ~self:vm_ref ~value:`Running;
@@ -178,7 +178,7 @@ let test_ca126097 () =
 
 	(* Attempting to clone a VDI being copied should fail with VDI_IN_USE. *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			let (_: API.ref_VBD) = make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RO () in
 			Db.VDI.set_current_operations ~__context
 				~self:vdi_ref
@@ -187,7 +187,7 @@ let test_ca126097 () =
 
 	(* Attempting to snapshot a VDI being copied should be allowed. *)
 	run_assert_equal_with_vdi ~__context
-		(fun vdi_ref ->
+		~vdi_fun:(fun vdi_ref ->
 			let (_: API.ref_VBD) = make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RO () in
 			Db.VDI.set_current_operations ~__context
 				~self:vdi_ref

--- a/ocaml/test/test_vdi_allowed_operations.ml
+++ b/ocaml/test/test_vdi_allowed_operations.ml
@@ -51,8 +51,8 @@ let setup_test ~__context ~vdi_fun =
 		});
 	let (_: API.ref_PBD) = make_pbd ~__context ~sR:sr_ref () in
 	let vdi_ref = make_vdi ~__context ~sR:sr_ref () in
-	let vdi_record = Db.VDI.get_record_internal ~__context ~self:vdi_ref in
 	vdi_fun vdi_ref;
+	let vdi_record = Db.VDI.get_record_internal ~__context ~self:vdi_ref in
 	vdi_ref, vdi_record
 
 let my_cmp a b = match a,b with

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3316,6 +3316,17 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					forward_vdi_op ~local_fn ~__context ~self:vdi
 						(fun session_id rpc -> Client.VDI.clone rpc session_id vdi driver_params))
 
+		let revert ~__context ~snapshot ~driver_params =
+			info "VDI.revert: snapshot = '%s'" (vdi_uuid ~__context snapshot);
+			let local_fn = Local.VDI.revert ~snapshot ~driver_params in
+			let sR = Db.VDI.get_SR ~__context ~self:snapshot in
+			with_sr_andor_vdi ~__context
+				~sr:(sR, `vdi_revert) ~vdi:(snapshot, `revert) ~doc:"VDI.revert"
+				(fun () ->
+					forward_vdi_op ~local_fn ~__context ~self:snapshot
+						(fun session_id rpc ->
+							Client.VDI.revert rpc session_id snapshot driver_params))
+
 		let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
 			info "VDI.copy: VDI = '%s'; SR = '%s'; base_vdi = '%s'; into_vdi = '%s'" (vdi_uuid ~__context vdi) (sr_uuid ~__context sr) (vdi_uuid ~__context base_vdi) (vdi_uuid ~__context into_vdi);
 			let local_fn = Local.VDI.copy ~vdi ~sr ~base_vdi ~into_vdi in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3318,14 +3318,18 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
 		let revert ~__context ~snapshot ~driver_params =
 			info "VDI.revert: snapshot = '%s'" (vdi_uuid ~__context snapshot);
+			let vdi = Db.VDI.get_snapshot_of ~__context ~self:snapshot in
 			let local_fn = Local.VDI.revert ~snapshot ~driver_params in
 			let sR = Db.VDI.get_SR ~__context ~self:snapshot in
 			with_sr_andor_vdi ~__context
 				~sr:(sR, `vdi_revert) ~vdi:(snapshot, `revert) ~doc:"VDI.revert"
 				(fun () ->
-					forward_vdi_op ~local_fn ~__context ~self:snapshot
-						(fun session_id rpc ->
-							Client.VDI.revert rpc session_id snapshot driver_params))
+					with_sr_andor_vdi ~__context
+						~vdi:(vdi, `reverting) ~doc:"VDI.reverting"
+						(fun () ->
+							forward_vdi_op ~local_fn ~__context ~self:snapshot
+								(fun session_id rpc ->
+									Client.VDI.revert rpc session_id snapshot driver_params)))
 
 		let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
 			info "VDI.copy: VDI = '%s'; SR = '%s'; base_vdi = '%s'; into_vdi = '%s'" (vdi_uuid ~__context vdi) (sr_uuid ~__context sr) (vdi_uuid ~__context base_vdi) (vdi_uuid ~__context into_vdi);

--- a/ocaml/xapi/quicktest_storage.ml
+++ b/ocaml/xapi/quicktest_storage.ml
@@ -407,6 +407,46 @@ in
     success test
   end
 
+(** After reverting a VDI to one of its snapshots, all snapshots should be
+    marked as snapshot_of the new VDI. *)
+let vdi_revert_test caps session_id sr vdi =
+	if (List.mem vdi_clone caps) && (List.mem vdi_delete caps) then begin
+		let test = make_test "VDI.revert should keep snapshot links up to date" 2 in
+		start test;
+		(* Clone the original VDI, since we're going to destroy the working VDI. *)
+		let cloned =
+			Client.VDI.clone ~rpc:!rpc ~session_id ~vdi ~driver_params:[] in
+		(* Create two snapshots. *)
+		let snap1 =
+			Client.VDI.snapshot ~rpc:!rpc ~session_id ~vdi:cloned ~driver_params:[] in
+		let snap2 =
+			Client.VDI.snapshot ~rpc:!rpc ~session_id ~vdi:cloned ~driver_params:[] in
+		(* Revert to the second snapshot. *)
+		let reverted =
+			Client.VDI.revert ~rpc:!rpc ~session_id ~snapshot:snap2 ~driver_params:[]
+		in
+		(* Check the snapshots' snapshot_of fields. *)
+		let snap1_snapshot_of =
+			Client.VDI.get_snapshot_of ~rpc:!rpc ~session_id ~self:snap1 in
+		let snap2_snapshot_of =
+			Client.VDI.get_snapshot_of ~rpc:!rpc ~session_id ~self:snap2 in
+		finally
+			(fun () ->
+				if snap1_snapshot_of <> reverted then begin
+					failed test "snap1 was not marked as a snapshot of the new VDI";
+					failwith "vdi_revert"
+				end;
+				if snap2_snapshot_of <> reverted then begin
+					failed test "snap2 was not marked as a snapshot of the new VDI";
+					failwith "vdi_revert"
+				end)
+			(fun () ->
+				List.iter
+					(fun vdi -> Client.VDI.destroy ~rpc:!rpc ~session_id ~self:vdi)
+					[snap1; snap2; reverted]);
+		success test
+	end
+
 
 
 (** Basic support for parsing the SR probe result *)
@@ -577,6 +617,7 @@ let foreach_sr session_id sr =
       with_arbitrary_vdi caps session_id sr vdi_resize_test;
       with_arbitrary_vdi caps session_id sr vdi_update_test;
       with_arbitrary_vdi caps session_id sr vdi_generate_config_test;
+      with_arbitrary_vdi caps session_id sr vdi_revert_test;
   | _ ->
       failed test "Multiple plugins with the same type detected"
 

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -505,6 +505,13 @@ module Wrapper = functor(Impl: Server_impl) -> struct
                         )
                 )
 
+		let revert context ~dbg ~sr ~snapshot_info =
+			info "VDI.revert dbg:%s sr:%s snapshot:%s"
+				dbg sr
+				(string_of_vdi_info snapshot_info);
+			with_vdi sr snapshot_info.snapshot_of
+				(fun () -> Impl.VDI.revert context ~dbg ~sr ~snapshot_info)
+
 		let stat context ~dbg ~sr ~vdi =
 			info "VDI.stat dbg:%s sr:%s vdi:%s" dbg sr vdi;
 			Impl.VDI.stat context ~dbg ~sr ~vdi

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -86,6 +86,8 @@ module Debug_print_impl = struct
                     end
                 )
 
+		let revert context ~dbg ~sr ~snapshot_info = assert false
+
 		let epoch_begin context ~dbg ~sr ~vdi = ()
 
 		let stat context ~dbg ~sr ~vdi = assert false

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -193,6 +193,9 @@ module Mux = struct
 		let destroy context ~dbg ~sr ~vdi =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.destroy ~dbg ~sr ~vdi
+		let revert context ~dbg ~sr ~snapshot_info =
+			let module C = Client(struct let rpc = of_sr sr end) in
+			C.VDI.revert ~dbg ~sr ~snapshot_info
 		let stat context ~dbg ~sr ~vdi =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.stat ~dbg ~sr ~vdi

--- a/ocaml/xapi/storage_proxy.ml
+++ b/ocaml/xapi/storage_proxy.ml
@@ -62,6 +62,7 @@ module Proxy = functor(RPC: RPC) -> struct
 		let snapshot _ = Client.VDI.snapshot
 		let clone _ = Client.VDI.clone
 		let destroy _ = Client.VDI.destroy
+		let revert _ = Client.VDI.revert
 		let resize _ = Client.VDI.resize
 		let stat _ = Client.VDI.stat
 		let set_persistent _ = Client.VDI.set_persistent

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -36,7 +36,7 @@ open Record_util
 
 let all_ops : API.storage_operations_set = 
   [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy; `vdi_resize; `vdi_clone; `vdi_snapshot;
-    `vdi_introduce; `update; `pbd_create; `pbd_destroy ]
+    `vdi_introduce; `update; `pbd_create; `pbd_destroy; `vdi_revert ]
 
 let sm_cap_table = 
   [ `vdi_create, Smint.Vdi_create;

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -177,6 +177,16 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
 					if not Smint.(has_capability Vdi_clone sm_features)
 					then Some (Api_errors.sr_operation_not_supported, [Ref.string_of sr])
 					else None
+				| `revert -> begin
+					match
+						record.Db_actions.vDI_is_a_snapshot,
+						Smint.(has_capability Vdi_clone sm_features)
+					with
+					| true, true -> None
+					| _, false ->
+						Some (Api_errors.sr_operation_not_supported, [Ref.string_of sr])
+					| false, true -> Some (Api_errors.only_revert_snapshot, [])
+				end
 				| _ -> None
 			)
 

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -570,6 +570,16 @@ let clone ~__context ~vdi ~driver_params =
        raise e)
 		)
 
+let revert ~__context ~snapshot ~driver_params =
+	let new_vdi = Storage_access.transform_storage_exn
+		(fun () ->
+			let module C = Storage_interface.Client(struct let rpc = Storage_access.rpc end) in
+			snapshot_and_clone
+				(fun ~dbg ~sr ~vdi_info -> C.VDI.revert ~dbg ~sr ~snapshot_info:vdi_info)
+				~__context ~vdi:snapshot ~driver_params)
+	in
+	update_allowed_operations ~__context ~self:new_vdi;
+	new_vdi
 
 let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
 	Xapi_vdi_helpers.assert_managed ~__context ~vdi;

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -130,7 +130,7 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
 					if ha_enabled && List.mem record.Db_actions.vDI_type [ `ha_statefile; `redo_log ]
 					then Some (Api_errors.ha_is_enabled, [])
 					else None
-				| `destroy ->
+				| `destroy | `reverting ->
 					if sr_type = "udev"
 					then Some (Api_errors.vdi_is_a_physical_device, [_ref])
 					else

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -94,9 +94,10 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
 
 			(* If the VBD is currently_attached then some operations can still be performed ie:
 			   VDI.clone (if the VM is suspended we have to have the 'allow_clone_suspended_vm'' flag)
-			   VDI.snapshot; VDI.resize_online; 'blocked' (CP-831) *)
+			   VDI.snapshot; VDI.resize_online; 'blocked' (CP-831)
+			   VDI.revert is allowed as checkpoints have currently_attached VBDs. *)
 			let operation_can_be_performed_live = match op with
-			| `snapshot | `resize_online | `blocked | `clone -> true
+			| `snapshot | `resize_online | `blocked | `clone | `revert -> true
 			| _ -> false in
 
 			let operation_can_be_performed_with_ro_attach =

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -428,6 +428,11 @@ let snapshot_and_clone call_f ~__context ~vdi ~driver_params =
 			  name_label = a.Db_actions.vDI_name_label;
 			  name_description = a.Db_actions.vDI_name_description;
 			  sm_config = driver_params;
+				is_a_snapshot = a.Db_actions.vDI_is_a_snapshot;
+				snapshot_of =
+					if Db.is_valid_ref __context a.Db_actions.vDI_snapshot_of
+					then Db.VDI.get_uuid ~__context ~self:a.Db_actions.vDI_snapshot_of
+					else "";
 			  snapshot_time = Date.to_string (Date.of_float (Unix.gettimeofday ()));
 	  } in
 	  let sr' = Db.SR.get_uuid ~__context ~self:sR in

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -105,6 +105,7 @@ type disk_op_t =
 	| Disk_op_copy of API.ref_SR option
 	| Disk_op_snapshot
 	| Disk_op_checkpoint
+	| Disk_op_revert
 
 let clone_single_vdi ?(progress) rpc session_id disk_op ~__context vdi driver_params = 
 	let task = 
@@ -118,6 +119,8 @@ let clone_single_vdi ?(progress) rpc session_id disk_op ~__context vdi driver_pa
 			Client.Async.VDI.copy rpc session_id vdi other_sr Ref.null Ref.null
 		| Disk_op_snapshot | Disk_op_checkpoint ->
 			Client.Async.VDI.snapshot rpc session_id vdi driver_params
+		| Disk_op_revert ->
+			Client.Async.VDI.revert rpc session_id vdi driver_params
 	in
 	(* This particular clone takes overall progress from startprogress to endprogress *)
 	let progress_minmax = may 
@@ -191,6 +194,7 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
 		| Disk_op_copy _-> `copy
 		| Disk_op_snapshot -> `snapshot
 		| Disk_op_checkpoint -> `checkpoint
+		| Disk_op_revert -> `reverting
 	in
 	(* replace VM mac seed on clone *)
 	let rec replace_seed l =
@@ -251,7 +255,7 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
 	let parent =
 		match disk_op with
 		(* CA-52668: clone or copy result in new top-level VMs *)
-		| Disk_op_clone | Disk_op_copy _-> Ref.null
+		| Disk_op_clone | Disk_op_copy _ | Disk_op_revert -> Ref.null
 		| Disk_op_snapshot | Disk_op_checkpoint -> all.Db_actions.vM_parent in
 
 	(* We always reset an existing generation ID on VM.clone *)
@@ -335,7 +339,7 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
 	(* update the VM's parent field in case of snapshot. Note this must be done after "ref"
 	   has been created, so that its "children" field can be updated by the database layer *)
 	begin match disk_op with
-		| Disk_op_clone | Disk_op_copy _-> ()
+		| Disk_op_clone | Disk_op_copy _ | Disk_op_revert -> ()
 		| Disk_op_snapshot | Disk_op_checkpoint -> Db.VM.set_parent ~__context ~self:vm ~value:ref
 	end;
 

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -282,14 +282,16 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 	(* clone all the disks of the snapshot *)
 	Helpers.call_api_functions ~__context (fun rpc session_id ->
 
-		debug "Cleaning up the old VBDs and VDIs to have more free space";
+		debug "Cleaning up the old VBDs and suspend VDI (if any) to have more free space";
 		List.iter (safe_destroy_vbd ~__context ~rpc ~session_id) vm_VBDs;
-		List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) (vm_suspend_VDI :: vm_VDIs);
+		safe_destroy_vdi ~__context ~rpc ~session_id vm_suspend_VDI;
 		TaskHelper.set_progress ~__context 0.2;
 
 		debug "Cloning the snapshoted disks";
 		let driver_params = Xapi_vm_clone.make_driver_params () in
-		let cloned_disks = Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone ~__context snap_vbds driver_params in
+		let cloned_disks = Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_revert ~__context snap_vbds driver_params in
+		debug "Cleaning up any VDIs not destroyed by the reversions";
+		List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vm_VDIs;
 		TaskHelper.set_progress ~__context 0.5;
 
 		debug "Cloning the suspend VDI if needed";


### PR DESCRIPTION
SXM uses the snapshot_of field to decide where to migrate snapshot disks, as they should be copied to the same SR as the disk of which they are a snapshot. Reverting a VM to a snapshot does not update snapshot VDIs to point to the new leaf VDIs, meaning SXM can no longer decide where snapshot disks should be migrated.

To fix this without explicitly setting VDI.snapshot_of (an SMAPI-owned field) in xapi, we introduce a new SMAPI call: VDI.revert. This takes a snapshot as an argument, and proceeds to:

* Clone the snapshot
* Update all snapshots in the tree to be snapshot_of this newly cloned VDI.
* Destroy the original VDI from which the snapshot had been taken.

VM.revert then makes use of VDI.revert when reverting all of a VM's disks.

Tested by:

* Manually creating a snapshot of a VM with 2 disks, reverting to the snapshot, then SXM'ing.
* As above, but with a checkpoint.
* Running quicktest.
* Running a couple of snapshot/checkpoint rollback sequences.
* Running a couple of SXM sequences (test cases which try to SXM a reverted VM are still failing, but I believe this is now due to a testcase bug).