### PR TITLE
CA-147820: don't run hotplug add if params is missing

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -15,6 +15,10 @@ syslog ()
 case "$1" in
 add)
         params=$(xenstore-read "${XENBUS_PATH}/params")
+        if [ $? -ne 0 ]; then
+            syslog "${XENBUS_PATH}: failed to read params (may be missing?)"
+            exit 1
+        fi
         frontend="/local/domain/${DOMID}/device/${TYPE}/${DEVID}"
         syslog "${XENBUS_PATH}: add params=\"${params}\""
         # We don't have PV drivers for CDROM devices, so we prevent blkback


### PR DESCRIPTION
This patch checks the return value of "xenstore-read" when it reads
"backend/vbd/domid/devid/params" while processing an "add" event. This
ensures that we won't write garbage to XenStore, which otherwise
confuses everyone.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
