### PR TITLE
Revert "CA-143836: Fix up snapshot_of links after reverting to snapshot"

### DIFF
--- a/ocaml/client_records/record_util.ml
+++ b/ocaml/client_records/record_util.ml
@@ -105,8 +105,6 @@ let vdi_operation_to_string = function
   | `update -> "update"
   | `generate_config -> "generate_config"
   | `blocked -> "blocked"
-  | `revert -> "revert"
-  | `reverting -> "reverting"
 
 let sr_operation_to_string = function
   | `scan -> "scan"
@@ -123,7 +121,6 @@ let sr_operation_to_string = function
   | `vdi_snapshot -> "VDI.snapshot"
   | `pbd_create -> "PBD.create"
   | `pbd_destroy -> "PBD.destroy"
-  | `vdi_revert -> "VDI.revert"
 
 let vbd_operation_to_string = function
   | `attach -> "attach"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2971,29 +2971,6 @@ let vdi_clone = call
   ~allowed_roles:_R_VM_ADMIN
   ()
 
-let vdi_revert = call
-	~name:"revert"
-	~in_oss_since:None
-	~in_product_since:rel_creedence
-	~versioned_params:[{
-		param_type=Ref _vdi;
-		param_name="snapshot";
-		param_doc="The snapshot to which we want to revert";
-		param_release=creedence_release;
-		param_default=None
-	};
-	{
-		param_type=Map (String, String);
-		param_name="driver_params";
-		param_doc="Optional parameters that are passed through to the backend driver in order to specify storage-type-specific clone options";
-		param_release=creedence_release;
-		param_default=Some (VMap []);
-	}]
-	~doc:"Clone a new VDI from the specified snapshot; mark all snapshots in the tree of snapshots of this new VDI; delete the original VDI these snapshots were pointing at; return the new VDI."
-	~result:(Ref _vdi, "The ID of the newly created VDI.")
-	~allowed_roles:_R_VM_POWER_ADMIN
-	()
-
 let vdi_resize = call
   ~name:"resize"
   ~in_product_since:rel_rio
@@ -5188,8 +5165,7 @@ let storage_operations =
 	  "vdi_clone", "Cloneing a VDI"; 
 	  "vdi_snapshot", "Snapshotting a VDI";
 	  "pbd_create", "Creating a PBD for this SR";
-	  "pbd_destroy", "Destroying one of this SR's PBDs";
-	  "vdi_revert", "Reverting a VDI to a clone of this snapshot"; ])
+	  "pbd_destroy", "Destroying one of this SR's PBDs"; ])
 
 let sr_set_virtual_allocation = call
    ~name:"set_virtual_allocation"
@@ -5468,8 +5444,6 @@ let vdi_operations =
 	  "force_unlock", "Forcibly unlocking the VDI";
 	  "generate_config", "Generating static configuration";
 	  "blocked", "Operations on this VDI are temporarily blocked";
-	  "revert", "Reverting a VDI to a clone of this snapshot";
-	  "reverting", "Reverting this VDI to a clone of one of its snapshots";
 	])
 
 let vdi_set_missing = call
@@ -5680,11 +5654,7 @@ let vdi =
       ~gen_events:true
       ~doccomments:[]
       ~messages_default_allowed_roles:_R_VM_ADMIN
-      ~messages:[
-		 vdi_snapshot;
-		 vdi_clone;
-		 vdi_revert;
-		 vdi_resize;
+      ~messages:[vdi_snapshot; vdi_clone; vdi_resize; 
 		 vdi_resize_online;
 		 vdi_introduce; vdi_pool_introduce;
 		 vdi_db_introduce; vdi_db_forget;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3317,21 +3317,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					forward_vdi_op ~local_fn ~__context ~self:vdi
 						(fun session_id rpc -> Client.VDI.clone rpc session_id vdi driver_params))
 
-		let revert ~__context ~snapshot ~driver_params =
-			info "VDI.revert: snapshot = '%s'" (vdi_uuid ~__context snapshot);
-			let vdi = Db.VDI.get_snapshot_of ~__context ~self:snapshot in
-			let local_fn = Local.VDI.revert ~snapshot ~driver_params in
-			let sR = Db.VDI.get_SR ~__context ~self:snapshot in
-			with_sr_andor_vdi ~__context
-				~sr:(sR, `vdi_revert) ~vdi:(snapshot, `revert) ~doc:"VDI.revert"
-				(fun () ->
-					with_sr_andor_vdi ~__context
-						~vdi:(vdi, `reverting) ~doc:"VDI.reverting"
-						(fun () ->
-							forward_vdi_op ~local_fn ~__context ~self:snapshot
-								(fun session_id rpc ->
-									Client.VDI.revert rpc session_id snapshot driver_params)))
-
 		let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
 			info "VDI.copy: VDI = '%s'; SR = '%s'; base_vdi = '%s'; into_vdi = '%s'" (vdi_uuid ~__context vdi) (sr_uuid ~__context sr) (vdi_uuid ~__context base_vdi) (vdi_uuid ~__context into_vdi);
 			let local_fn = Local.VDI.copy ~vdi ~sr ~base_vdi ~into_vdi in

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -493,23 +493,6 @@ module SMAPIv1 = struct
 					raise (Vdi_does_not_exist vdi)
 				| Sm.MasterOnly -> redirect sr
 
-		let revert context ~dbg ~sr ~snapshot_info =
-			Server_helpers.exec_with_new_task "VDI.revert" ~subtask_of:(Ref.of_string dbg)
-				(fun __context ->
-					(* Clone the snapshot. *)
-					let new_vdi_info = clone context ~dbg ~sr ~vdi_info:snapshot_info in
-					(* Update snapshot links. *)
-					let vdi_ref = Db.VDI.get_by_uuid ~__context ~uuid:snapshot_info.snapshot_of in
-					let new_vdi_ref = Db.VDI.get_by_uuid ~__context ~uuid:new_vdi_info.vdi in
-					let snapshot_refs = Db.VDI.get_snapshots ~__context ~self:vdi_ref in
-					List.iter
-						(fun snapshot_ref -> Db.VDI.set_snapshot_of ~__context ~self:snapshot_ref ~value:new_vdi_ref)
-						snapshot_refs;
-					(* Destroy the original VDI. *)
-					destroy context ~dbg ~sr ~vdi:snapshot_info.snapshot_of;
-					(* Return the new VDI. *)
-					new_vdi_info)
-
 		let stat context ~dbg ~sr ~vdi =
 			try
 				Server_helpers.exec_with_new_task "VDI.stat" ~subtask_of:(Ref.of_string dbg)

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -498,13 +498,6 @@ module Wrapper = functor(Impl: Server_impl) -> struct
                         )
                 )
 
-		let revert context ~dbg ~sr ~snapshot_info =
-			info "VDI.revert dbg:%s sr:%s snapshot:%s"
-				dbg sr
-				(string_of_vdi_info snapshot_info);
-			with_vdi sr snapshot_info.snapshot_of
-				(fun () -> Impl.VDI.revert context ~dbg ~sr ~snapshot_info)
-
 		let stat context ~dbg ~sr ~vdi =
 			info "VDI.stat dbg:%s sr:%s vdi:%s" dbg sr vdi;
 			Impl.VDI.stat context ~dbg ~sr ~vdi

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -86,8 +86,6 @@ module Debug_print_impl = struct
                     end
                 )
 
-		let revert context ~dbg ~sr ~snapshot_info = assert false
-
 		let epoch_begin context ~dbg ~sr ~vdi = ()
 
 		let stat context ~dbg ~sr ~vdi = assert false

--- a/ocaml/xapi/storage_interface.ml
+++ b/ocaml/xapi/storage_interface.ml
@@ -268,14 +268,6 @@ module VDI = struct
     (** [destroy task sr vdi] removes [vdi] from [sr] *)
     external destroy : dbg:debug_info -> sr:sr -> vdi:vdi -> unit = ""
 
-	(** [revert task sr vdi_info snapshot_info] creates a new VDI which is a clone
-	    of [snapshot_info] in [sr]. [vdi_info] will be destroyed, and all its
-	    snapshots will be marked as [snapshot_of] the new VDI. *)
-	external revert : dbg:debug_info
-		-> sr:sr
-		-> snapshot_info:vdi_info
-		-> vdi_info = ""
-
 	(** [stat dbg sr vdi] returns information about VDI [vdi] in SR [sr] *)
 	external stat : dbg:debug_info -> sr:sr -> vdi:vdi -> vdi_info = ""
 

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -186,9 +186,6 @@ module Mux = struct
 		let destroy context ~dbg ~sr ~vdi =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.destroy ~dbg ~sr ~vdi
-		let revert context ~dbg ~sr ~snapshot_info =
-			let module C = Client(struct let rpc = of_sr sr end) in
-			C.VDI.revert ~dbg ~sr ~snapshot_info
 		let stat context ~dbg ~sr ~vdi =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.stat ~dbg ~sr ~vdi

--- a/ocaml/xapi/storage_proxy.ml
+++ b/ocaml/xapi/storage_proxy.ml
@@ -60,7 +60,6 @@ module Proxy = functor(RPC: RPC) -> struct
 		let snapshot _ = Client.VDI.snapshot
 		let clone _ = Client.VDI.clone
 		let destroy _ = Client.VDI.destroy
-		let revert _ = Client.VDI.revert
 		let stat _ = Client.VDI.stat
 		let set_persistent _ = Client.VDI.set_persistent
 		let get_by_name _ = Client.VDI.get_by_name

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -36,7 +36,7 @@ open Record_util
 
 let all_ops : API.storage_operations_set = 
   [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy; `vdi_resize; `vdi_clone; `vdi_snapshot;
-    `vdi_introduce; `update; `pbd_create; `pbd_destroy; `vdi_revert ]
+    `vdi_introduce; `update; `pbd_create; `pbd_destroy ]
 
 let sm_cap_table = 
   [ `vdi_create, Smint.Vdi_create;


### PR DESCRIPTION
Reverts xapi-project/xen-api#1935
because it introduced a new bug CA-147786.

Signed-off-by: Thomas Sanders thomas.sanders@citrix.com
