### PR TITLE
[Lull/HFX-1255]SCTX-1649: Set SO_KEEPALIVE on server sockets

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -75,6 +75,7 @@ pid = ${SSLPIDFILE}
 socket = r:TCP_NODELAY=1
 socket = a:TCP_NODELAY=1
 socket = l:TCP_NODELAY=1
+socket = a:SO_KEEPALIVE=1
 compression = zlib
 
 [xapi]


### PR DESCRIPTION
This ensures that a TCP connection is cleaned up on the server, when
the connection is closed on the client without the server knowing (for
example, if a FIN packet is not sent or went missing).

This does not affect idle connections, or long-running
XenAPI calls.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
