### PR TITLE
CA-148243: Getting rid of bad assertion failure after VM starts

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1842,6 +1842,12 @@ let sync __context queue_name x =
 	let dbg = Context.string_of_task __context in
 	x |> wait_for_task queue_name dbg |> success_task queue_name (update_debug_info __context) dbg
 
+let check_power_state ~__context ~self ~expected =
+	let found = Db.VM.get_power_state ~__context ~self in
+	if expected <> found then begin
+		let f = xenops_of_xenapi_power_state in
+		raise (Bad_power_state(f found, f expected)) end
+
 let pause ~__context ~self =
 	let queue_name = queue_of_vm ~__context ~self in
 	transform_xenops_exn ~__context queue_name
@@ -1852,10 +1858,7 @@ let pause ~__context ~self =
 			let module Client = (val make_client queue_name : XENOPS) in
 			Client.VM.pause dbg id |> sync_with_task __context queue_name;
 			Events_from_xenopsd.wait queue_name dbg id ();
-			let ps = Db.VM.get_power_state ~__context ~self in
-			if ps <> `Paused then begin
-				let f = xenops_of_xenapi_power_state in
-				raise (Bad_power_state(f ps, f `Paused)) end
+			check_power_state ~__context ~self ~expected:`Paused
 		)
 
 let unpause ~__context ~self =
@@ -1868,10 +1871,7 @@ let unpause ~__context ~self =
 			let module Client = (val make_client queue_name : XENOPS) in
 			Client.VM.unpause dbg id |> sync_with_task __context queue_name;
 			Events_from_xenopsd.wait queue_name dbg id ();
-			let ps = Db.VM.get_power_state ~__context ~self in
-			if ps <> `Running then begin
-				let f = xenops_of_xenapi_power_state in
-				raise (Bad_power_state(f ps, f `Running)) end
+			check_power_state ~__context ~self ~expected:`Running
 		)
 
 let set_xenstore_data ~__context ~self xsdata =
@@ -2012,11 +2012,7 @@ let start ~__context ~self paused =
 				raise e
 		);
 	(* XXX: if the guest crashed or shutdown immediately then it may be offline now *)
-	let ps = Db.VM.get_power_state ~__context ~self in
-	let expected_ps = if paused then `Paused else `Running in 
-	if ps <> expected_ps then begin
-		let f = xenops_of_xenapi_power_state in
-		raise (Bad_power_state(f ps, f expected_ps)) end
+	check_power_state ~__context ~self ~expected:(if paused then `Paused else `Running)
 
 let start ~__context ~self paused =
 	let queue_name = queue_of_vm ~__context ~self in
@@ -2046,10 +2042,7 @@ let reboot ~__context ~self timeout =
 			let module Client = (val make_client queue_name : XENOPS) in
 			Client.VM.reboot dbg id timeout |> sync_with_task __context queue_name;
 			Events_from_xenopsd.wait queue_name dbg id ();
-			let ps = Db.VM.get_power_state ~__context ~self in
-			if ps <> `Running then begin
-				let f = xenops_of_xenapi_power_state in
-				raise (Bad_power_state(f ps, f `Running)) end
+			check_power_state ~__context ~self ~expected:`Running
 		)
 
 let shutdown ~__context ~self timeout =
@@ -2064,10 +2057,7 @@ let shutdown ~__context ~self timeout =
 			let module Client = (val make_client queue_name : XENOPS) in
 			Client.VM.shutdown dbg id timeout |> sync_with_task __context queue_name;
 			Events_from_xenopsd.wait queue_name dbg id ();
-			let ps = Db.VM.get_power_state ~__context ~self in
-			if ps <> `Halted then begin
-				let f = xenops_of_xenapi_power_state in
-				raise (Bad_power_state(f ps, f `Halted)) end;
+			check_power_state ~__context ~self ~expected:`Halted;
 			(* force_state_reset called from the xenopsd event loop above *)
 			assert (Db.VM.get_resident_on ~__context ~self = Ref.null);
 			List.iter
@@ -2105,10 +2095,7 @@ let suspend ~__context ~self =
 						info "xenops: VM.suspend %s to %s" id (disk |> rpc_of_disk |> Jsonrpc.to_string);
 						Client.VM.suspend dbg id disk |> sync_with_task __context queue_name;
 						Events_from_xenopsd.wait queue_name dbg id ();
-						let ps = Db.VM.get_power_state ~__context ~self in
-						if ps <> `Suspended then begin
-							let f = xenops_of_xenapi_power_state in
-							raise (Bad_power_state(f ps, f `Suspended)) end;
+						check_power_state ~__context ~self ~expected:`Suspended;
 						assert (Db.VM.get_resident_on ~__context ~self = Ref.null);
 					with e ->
 						error "Caught exception suspending VM: %s" (string_of_exn e);
@@ -2164,11 +2151,7 @@ let resume ~__context ~self ~start_paused ~force =
 				(fun rpc session_id ->
 					XenAPI.VDI.destroy rpc session_id vdi
 				);
-			let ps = Db.VM.get_power_state ~__context ~self in
-			let expected_ps = if start_paused then `Paused else `Running in 
-			if ps <> expected_ps then begin
-				let f = xenops_of_xenapi_power_state in
-				raise (Bad_power_state(f ps, f expected_ps)) end
+			check_power_state ~__context ~self ~expected:(if start_paused then `Paused else `Running)
 		)
 
 let s3suspend ~__context ~self =


### PR DESCRIPTION
After VM starts, if it is not in paused or running state, then an
ungraceful assertion failure is raised.
This patch raises the failure in a readable format.

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
