### PR TITLE
[CA-141792] wrap task.destroy with approriate exception handler

### DIFF
--- a/scripts/examples/python/shutdown.py
+++ b/scripts/examples/python/shutdown.py
@@ -109,7 +109,12 @@ def host_evacuate(session, host):
                         print "Failed to cancel task: %s" % t,
                         sys.stdout.flush()
     finally:
-        session.xenapi.task.destroy(task)
+        try:
+            session.xenapi.task.destroy(task)
+        except Exception, e:
+            # db gc thread in xapi may delete task from tasks table
+            print "\n Task %s has been destroyed" % task
+            sys.stdout.flush()
         return rc
 
 def parallel_clean_shutdown(session, vms):
@@ -149,7 +154,12 @@ def parallel_clean_shutdown(session, vms):
 
     finally:
         for (task,_,_) in tasks:
-            session.xenapi.task.destroy(task)
+            try:
+                session.xenapi.task.destroy(task)
+            except Exception, e:
+                # db gc thread in xapi may delete task from tasks table
+                print "\n Task %s has been destroyed" % task
+                sys.stdout.flush()
         return rc
 
 def serial_hard_shutdown(session, vms):


### PR DESCRIPTION
  db gc thread might delete task from tasks table, we should
  ignore the Not_found exception
