### PR TITLE
[Lull/HFX-1161]CA-129192: restore metadata for all SR

### DIFF
--- a/scripts/restore-sr-metadata.py
+++ b/scripts/restore-sr-metadata.py
@@ -41,7 +41,7 @@ def main(argv):
         if o == "-u":
             sruuid = a
 
-    if infile == None or sruuid == None:
+    if infile == None:
         usage()
 
     try:
@@ -63,7 +63,7 @@ def main(argv):
             print >> sys.stderr, "Error parsing SR tag"
             continue
         # only set attributes on the selected SR passed in on cmd line
-        if uuid == sruuid:
+        if sruuid is None or sruuid == "all" or sruuid == uuid:
             try:
                 srref = session.xenapi.SR.get_by_uuid(uuid)
                 print "Setting SR (%s):" % uuid
@@ -93,7 +93,6 @@ def main(argv):
                 except:
                     print >> sys.stderr, "Error setting VDI data for: %s (%s)" % (vdi_uuid, name_label)
                     continue
-            sys.exit(0)
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/scripts/xe-restore-metadata
+++ b/scripts/xe-restore-metadata
@@ -297,7 +297,12 @@ for meta in *.vmmeta; do
 done
 
 smmeta_file=${mnt}/metadata/${chosen_metadata_dir}/SRMETA.xml
-cmd="@LIBEXECDIR@/restore-sr-metadata.py -u ${sr_uuid} -f ${smmeta_file}"
+if [ "$restore_mode" == "all" ]; then
+   cmd="@LIBEXECDIR@/restore-sr-metadata.py -f ${smmeta_file}"
+else
+   cmd="@LIBEXECDIR@/restore-sr-metadata.py -u ${sr_uuid} -f ${smmeta_file}"
+fi
+
 if [ -e ${smmeta_file} ]; then
     if [ ${dry_run} -gt 0 ]; then
         echo ${cmd}


### PR DESCRIPTION
CA-129192/SCTX-1728: revise restore-sr-metadata.py so that it could restore
metadata for all SR with command line:
   ./restore-sr-metadata.py -f <input file> -u all
or just omit the sr-uuid:
   ./restore-sr-metadata.py -f <input file>

xe-restore-metadata is modified accordingly.

Signed-off-by: Kaifeng Zhu kaifeng.zhu@citrix.com
