### PR TITLE
CA-149017: If videoram is unspecified, use a default value of 8MiB

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -309,7 +309,7 @@ let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
 			timeoffset = timeoffset;
 			video_mib = begin
 				(* For vGPU, make sure videoram is at least 16MiB. *)
-				let requested_videoram = int vm.API.vM_platform 4 "videoram" in
+				let requested_videoram = int vm.API.vM_platform 8 "videoram" in
 				if video_mode = Vgpu
 				then max requested_videoram 16
 				else requested_videoram


### PR DESCRIPTION
4MiB is an illegal value for Cirrus graphics (the legacy default) and
libxl will simply refuse to start the VM.

Signed-off-by: David Scott dave.scott@citrix.com
