### PR TITLE
CA-137766: Add GC stats reporting

### DIFF
--- a/ocaml/xapi/xapi_stats.ml
+++ b/ocaml/xapi/xapi_stats.ml
@@ -52,6 +52,54 @@ let generate_master_stats ~__context =
 	in
 	[session_count_ds; task_count_ds]
 
+let gc_debug = ref true
+let previous_oldness = ref 0
+let previous_free_words = ref 0
+let previous_live_words = ref 0
+
+let generate_gc_stats () =
+	let gcstat =
+		if !gc_debug then (
+			if !previous_oldness > 5 then (
+				let stat = Gc.stat () in
+				previous_free_words := stat.Gc.free_words;
+				previous_live_words := stat.Gc.live_words;
+				previous_oldness := 0;
+				stat
+			) else (
+				incr previous_oldness;
+				{(Gc.quick_stat ()) with
+					Gc.free_words = !previous_free_words;
+					Gc.live_words = !previous_live_words;}
+			)
+		) else Gc.quick_stat ()
+	in
+	let xapigrad_kib =
+		(gcstat.Gc.minor_words +. gcstat.Gc.major_words -. gcstat.Gc.promoted_words)
+		/. 256.
+	in
+	let xapitotal_kib = Int64.of_int (gcstat.Gc.heap_words / 256) in
+	let xapiactualfree_kib = Int64.of_int (gcstat.Gc.free_words / 256) in
+	let xapiactuallive_kib = Int64.of_int (gcstat.Gc.live_words / 256) in
+	[
+		(Rrd.Host, Ds.ds_make ~name:"xapi_memory_usage_kib" ~units:"KiB"
+			~description:"Total memory allocated used by xapi daemon"
+			~value:(Rrd.VT_Int64 xapitotal_kib) ~ty:Rrd.Gauge ~min:0.0
+			~default:true ());
+		(Rrd.Host, Ds.ds_make ~name:"xapi_free_memory_kib" ~units:"KiB"
+			~description:"Free memory available to the xapi daemon"
+			~value:(Rrd.VT_Int64 xapiactualfree_kib) ~ty:Rrd.Gauge ~min:0.0
+			~default:true ());
+		(Rrd.Host, Ds.ds_make ~name:"xapi_live_memory_kib" ~units:"KiB"
+			~description:"Live memory used by xapi daemon"
+			~value:(Rrd.VT_Int64 xapiactuallive_kib) ~ty:Rrd.Gauge ~min:0.0
+			~default:true ());
+		(Rrd.Host, Ds.ds_make ~name:"xapi_allocation_kib" ~units:"KiB"
+			~description:"Memory allocation done by the xapi daemon"
+			~value:(Rrd.VT_Float xapigrad_kib) ~ty:Rrd.Derive ~min:0.0
+			~default:true ());
+	]
+
 let generate_other_stats () =
 	let open_fds =
 		Utils.list_directory_entries_unsafe "/proc/self/fd"
@@ -78,11 +126,12 @@ let generate_stats ~__context ~master =
 		then generate_master_stats ~__context
 		else []
 	in
+	let gc_stats = generate_gc_stats () in
 	let other_stats = generate_other_stats () in
 	List.fold_left
 		(fun acc stats -> List.rev_append acc stats)
 		[]
-		[master_only_stats; other_stats]
+		[master_only_stats; gc_stats; other_stats]
 
 let reporter_cache : Reporter.t option ref = ref None
 let reporter_m = Mutex.create ()


### PR DESCRIPTION
rrdd was erronously reporting its own GC stats as xapi's - this code is
adapted from the code removed from rrdd.
