### PR TITLE
CA-133718: Fix HIMN login_with_password

### DIFF
--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -122,9 +122,16 @@ let callback1 is_json req fd body xml =
   (* if we're a master or slave and whether the call came in on the unix domain socket or the tcp socket *)
   (* If we're a slave, and the call is from the unix domain socket or from the HIMN, and the call *isn't* *)
   (* in the whitelist, then forward *)
-  if !Xapi_globs.slave_emergency_mode && (not (List.mem call emergency_call_list)) 
+
+  let whitelisted = List.mem call whitelist in
+  let emergency_call = List.mem call emergency_call_list in
+  let is_slave = not (Pool_role.is_master ()) in
+
+  if !Xapi_globs.slave_emergency_mode && (not emergency_call)
   then raise !Xapi_globs.emergency_mode_error;
-  if ((not (Pool_role.is_master ())) && (Context.is_unix_socket fd || is_himn_req req) && (not (List.mem call whitelist)))
+  if is_slave && 
+    ((Context.is_unix_socket fd && not whitelisted) ||
+     (is_himn_req req && not emergency_call))
   then
     forward req body xml
   else


### PR DESCRIPTION
HIMN had been relying on login_with_password working on the slave
as it was erroneously not being forwarded. When xapi was changed
to disallow logins on slaves, this broke. This changeset causes
login_with_password to be forwarded to the master, which should
fix the issue.
