### PR TITLE
CA-151605: Fix race in host_dead_hook

### DIFF
--- a/ocaml/xapi/xapi_hooks.ml
+++ b/ocaml/xapi/xapi_hooks.ml
@@ -108,11 +108,13 @@ let host_pre_declare_dead ~__context ~host ~reason =
 
 (* Called when host died -- !! hook code in here to abort outstanding forwarded ops *)
 let internal_host_dead_hook __context host =
-	(* reverse lookup host from metrics id; don't have backedge here... *)
-	let tasks = Db.Task.get_all ~__context in
 	info "Running host dead hook for %s" (Ref.string_of host);
+	(* reverse lookup host from metrics id; don't have backedge here... *)
 	let forwarded_tasks =
-		List.filter (fun t -> Db.Task.get_forwarded_to ~__context ~self:t = host) tasks in
+		let open Db_filter_types in
+		Db.Task.get_refs_where ~__context
+			~expr:(Eq (Field "forwarded_to", Literal (Ref.string_of host)))
+	in
 	List.iter
 		(fun task ->
 			let resources = Locking_helpers.Thread_state.get_acquired_resources_by_task task in


### PR DESCRIPTION
If any tasks are destroyed or GCed after getting the list of tasks but
before finding the host to which they were forwarded, the
host_post_declare_dead hook script will not actually be called.
