### PR TITLE
Event.next: improve performance

### DIFF
--- a/ocaml/database/db_action_helper.ml
+++ b/ocaml/database/db_action_helper.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2006-2009 Citrix Systems Inc.
+ * Copyright (C) 2006-2014 Citrix Systems Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -12,21 +12,18 @@
  * GNU Lesser General Public License for more details.
  *)
 
-(* General DB utils *)
+(* This callback is used in the events.next implementation *)
 
-let __callback : ((?snapshot: Rpc.t -> string -> string -> string -> unit) option ref) = ref None
+type snapshot_fn = unit -> Rpc.t option
+
+type callback = ?snapshot_fn:snapshot_fn -> string -> string -> string -> unit
+
+let __callback : callback option ref = ref None
+
 let events_register f = __callback := Some f
 let events_unregister () = __callback := None
     
-let events_notify ?(snapshot) ty op ref =
+let events_notify ?snapshot_fn ty op ref =
   match !__callback with
     | None -> ()
-    | Some f -> f ?snapshot ty op ref
-	 (* 
-exception Db_set_or_map_parse_fail of string
-  
-let parse_sexpr s : SExpr.t list =
-  match SExpr_TS.of_string s with
-    | SExpr.Node xs -> xs
-    | _ -> raise (Db_set_or_map_parse_fail s)
-*)
+    | Some f -> f ?snapshot_fn ty op ref

--- a/ocaml/database/eventgen.ml
+++ b/ocaml/database/eventgen.ml
@@ -58,26 +58,20 @@ let _ =
 
 let follow_references (obj_name:string) = Hashtbl.find obj_references_table obj_name
 
-(** Compute a set of modify events but skip any for objects which were missing
-    (must have been dangling references) *)
-let events_of_other_tbl_refs other_tbl_refs = 
-  List.concat 
-    (List.map (fun (tbl, fld, x) -> 
-		 try [ tbl, fld, x () ]
-		 with _ -> 
-		   (* Probably means the reference was dangling *)
-		   warn "skipping event for dangling reference %s: %s" tbl fld;
-		   []) other_tbl_refs)
-
 open Db_cache_types
 open Db_action_helper
 
-let database_callback event db = 
-	let context = Context.make "eventgen" in
+let database_callback event db =
+        (* Take a database snapshot. We don't need to worry about other
+           threads racing with us and deleting data we need. *)
+        let database = Db_ref.in_memory (ref (ref db)) in
+        let __context = Context.make ~database "eventgen" in
 
 	let other_tbl_refs tblname = follow_references tblname in
 	let other_tbl_refs_for_this_field tblname fldname =
-		List.filter (fun (_,fld) -> fld=fldname) (other_tbl_refs tblname) in	
+                other_tbl_refs tblname
+            |>  List.filter (fun (_, fld) -> fld=fldname)
+            |>  List.map fst in
 
 	let is_valid_ref = function
                 | Schema.Value.String r ->
@@ -92,63 +86,37 @@ let database_callback event db =
 	match event with
 		| RefreshRow (tblname, objref) ->
 			(* Generate event *)
-			let snapshot = find_get_record tblname ~__context:context ~self:objref in
-			let record = snapshot() in
-			begin match record with
-				| None ->
-					error "Failed to send MOD event for %s %s" tblname objref;
-					Printf.printf "Failed to send MOD event for %s %s\n%!" tblname objref;
-				| Some record ->
-					events_notify ~snapshot:record tblname "mod" objref;
-			end
+			let snapshot_fn = find_get_record tblname ~__context ~self:objref in
+			events_notify ~snapshot_fn tblname "mod" objref;
 		| WriteField (tblname, objref, fldname, oldval, newval) ->
 			let events_old_val = 
 				if is_valid_ref oldval then 
                                         let oldval = Schema.Value.Unsafe_cast.string oldval in
-					events_of_other_tbl_refs
-						(List.map (fun (tbl,fld) ->
-							(tbl, oldval, find_get_record tbl ~__context:context ~self:oldval)) (other_tbl_refs_for_this_field tblname fldname)) 
+					List.map (fun tbl ->
+                                                let snapshot_fn = find_get_record tbl ~__context ~self:oldval in
+                                                tbl, oldval, snapshot_fn)
+                                                (other_tbl_refs_for_this_field tblname fldname) 
 				else [] in
 			let events_new_val =
 				if is_valid_ref newval then
                                         let newval = Schema.Value.Unsafe_cast.string newval in
-					events_of_other_tbl_refs
-						(List.map (fun (tbl,fld) ->
-							(tbl, newval, find_get_record tbl ~__context:context ~self:newval)) (other_tbl_refs_for_this_field tblname fldname)) 
+					List.map (fun tbl ->
+                                                let snapshot_fn = find_get_record tbl ~__context ~self:newval in
+                                                tbl, newval, snapshot_fn)
+                                                (other_tbl_refs_for_this_field tblname fldname)
 				else [] 
 			in
-			(* Generate event *)
-			let snapshot = find_get_record tblname ~__context:context ~self:objref in
-			let record = snapshot() in
-			List.iter (function 
-				| tbl, ref, None ->
-					error "Failed to send MOD event for %s %s" tbl ref;
-					Printf.printf "Failed to send MOD event for %s %s\n%!" tbl ref;
-				| tbl, ref, Some s ->
-					events_notify ~snapshot:s tbl "mod" ref
+			List.iter (fun (tbl, ref, snapshot_fn) ->
+				events_notify ~snapshot_fn tbl "mod" ref
 			) events_old_val;
-			begin match record with
-				| None ->
-					error "Failed to send MOD event for %s %s" tblname objref;
-					Printf.printf "Failed to send MOD event for %s %s\n%!" tblname objref;
-				| Some record ->
-					events_notify ~snapshot:record tblname "mod" objref;
-			end;
-			List.iter (function 
-				| tbl, ref, None ->
-					error "Failed to send MOD event for %s %s" tbl ref;
-					Printf.printf "Failed to send MOD event for %s %s\n%!" tbl ref;
-				| tbl, ref, Some s -> 
-					events_notify ~snapshot:s tbl "mod" ref
+			let snapshot_fn = find_get_record tblname ~__context ~self:objref in
+			events_notify ~snapshot_fn tblname "mod" objref;
+			List.iter (fun (tbl, ref, snapshot_fn) ->
+				events_notify ~snapshot_fn tbl "mod" ref
 			) events_new_val;
 		| PreDelete(tblname, objref) ->
-			begin match find_get_record tblname ~__context:context ~self:objref () with
-				| None ->
-					error "Failed to generate DEL event for %s %s" tblname objref;
-					(*				Printf.printf "Failed to generate DEL event for %s %s\n%!" tblname objref; *)
-				| Some snapshot ->
-					events_notify ~snapshot tblname "del" objref
-			end
+                        let snapshot_fn = find_get_record tblname ~__context ~self:objref in
+			events_notify ~snapshot_fn tblname "del" objref
 		| Delete(tblname, objref, kv) ->
 			let other_tbl_refs = follow_references tblname in
 			let other_tbl_refs =
@@ -156,41 +124,27 @@ let database_callback event db =
 					let fld_value = List.assoc fld kv in
 					if is_valid_ref fld_value then begin
                                                 let fld_value = Schema.Value.Unsafe_cast.string fld_value in
-					        (remote_tbl, fld_value, find_get_record remote_tbl ~__context:context ~self:fld_value) :: accu 
+                                                let snapshot_fn = find_get_record remote_tbl ~__context ~self:fld_value in
+					        (remote_tbl, fld_value, snapshot_fn) :: accu 
                                         end else accu) 
 					[] other_tbl_refs in
-			let other_tbl_ref_events = events_of_other_tbl_refs other_tbl_refs in
-			List.iter (function
-				| tbl, ref, None ->
-					error "Failed to generate MOD event on %s %s" tbl ref;
-(*					Printf.printf "Failed to generate MOD event on %s %s\n%!" tbl ref; *)
-				| tbl, ref, Some s -> 
-					events_notify ~snapshot:s tbl "mod" ref
-			) other_tbl_ref_events
+			List.iter (fun (tbl, ref, snapshot_fn) ->
+				events_notify ~snapshot_fn tbl "mod" ref
+			) other_tbl_refs
 
 		| Create (tblname, new_objref, kv) ->
-			let snapshot = find_get_record tblname ~__context:context ~self:new_objref in
 			let other_tbl_refs = follow_references tblname in
 			let other_tbl_refs =
 				List.fold_left (fun accu (tbl,fld) ->
 					let fld_value = List.assoc fld kv in
                                         if is_valid_ref fld_value then begin
                                                 let fld_value = Schema.Value.Unsafe_cast.string fld_value in
-					         (tbl, fld_value, find_get_record tbl ~__context:context ~self:fld_value) :: accu
+                                                let snapshot_fn = find_get_record tbl ~__context ~self:fld_value in
+                                                (tbl, fld_value, snapshot_fn) :: accu
                                         end else accu) 
 					[] other_tbl_refs in
-			let other_tbl_events = events_of_other_tbl_refs other_tbl_refs in
-			begin match snapshot() with
-				| None ->
-					error "Failed to generate ADD event for %s %s" tblname new_objref;
-					(*				Printf.printf "Failed to generate ADD event for %s %s\n%!" tblname new_objref; *)
-				| Some snapshot ->
-					events_notify ~snapshot tblname "add" new_objref;
-			end;
-			List.iter (function
-				| tbl, ref, None ->
-					error "Failed to generate MOD event for %s %s" tbl ref;
-					(* 				Printf.printf "Failed to generate MOD event for %s %s\n%!" tbl ref;*)
-				| tbl, ref, Some s ->
-					events_notify ~snapshot:s tbl "mod" ref
-			) other_tbl_events
+			let snapshot_fn = find_get_record tblname ~__context ~self:new_objref in
+			events_notify ~snapshot_fn tblname "add" new_objref;
+			List.iter (fun (tbl, ref, snapshot_fn) ->
+				events_notify ~snapshot_fn tbl "mod" ref
+			) other_tbl_refs

--- a/ocaml/idl/ocaml_backend/event_helper.ml
+++ b/ocaml/idl/ocaml_backend/event_helper.ml
@@ -48,7 +48,7 @@ let maybe f x =
 		| None -> None
 			
 let record_of_event ev =
-	let rpc = ev.Event_types.snapshot in
+    let rpc = ev.Event_types.snapshot_fn () in
     match ev.Event_types.ty with
 		| "session" ->          Session (Ref.of_string ev.Event_types.reference, maybe (API.session_t_of_rpc) rpc)
 		| "task" ->             Task (Ref.of_string ev.Event_types.reference, maybe (API.task_t_of_rpc) rpc)

--- a/ocaml/idl/ocaml_backend/event_types.ml
+++ b/ocaml/idl/ocaml_backend/event_types.ml
@@ -18,35 +18,54 @@ type op = API.event_operation
 let rpc_of_op = API.rpc_of_event_operation
 let op_of_rpc = API.event_operation_of_rpc
 
+module Wire_protocol = struct
+        (* This module exists to marshal/unmarshal the wire protocol events *)
+
+        type event = {
+                id: string;
+                ts: string;
+                ty: string;
+                op: op;
+                reference: string;
+                snapshot: Rpc.t option;
+        } with rpc
+
+        let ev_struct_remap = [
+                "id","id";
+                "ts","timestamp";
+                "ty","class";
+                "op","operation";
+                "reference","ref";
+                "snapshot","snapshot"
+        ]
+
+        let remap map str = match str with 
+        | Rpc.Dict d -> Rpc.Dict (List.map (fun (k,v) -> (List.assoc k map, v)) d)
+        | _ -> str
+
+        let rpc_of_event ev =
+                remap ev_struct_remap (rpc_of_event ev)
+
+        let event_of_rpc rpc =
+                event_of_rpc (remap (List.map (fun (k,v) -> (v,k)) ev_struct_remap) rpc)
+end
+
 type event = {
-	id: string;
-	ts: string;
-	ty: string;
-	op: op;
-	reference: string;
-	snapshot: Rpc.t option;
-} with rpc
+        id: string;
+        ts: string;
+        ty: string;
+        op: op;
+        reference: string;
+        snapshot_fn: unit -> (Rpc.t option);
+}
+(* The event type we use internally. Note the snapshot is kept as a thunk. *)
 
-let ev_struct_remap = [
-	"id","id";
-	"ts","timestamp";
-	"ty","class";
-	"op","operation";
-	"reference","ref";
-	"snapshot","snapshot"
-]
-
-let remap map str =
-	match str with 
-		| Rpc.Dict d ->
-			Rpc.Dict (List.map (fun (k,v) -> (List.assoc k map, v)) d)
-		| _ -> str
-
-let rpc_of_event ev =
-	remap ev_struct_remap (rpc_of_event ev)
-
-let event_of_rpc rpc =
-	event_of_rpc (remap (List.map (fun (k,v) -> (v,k)) ev_struct_remap) rpc)
+let rpc_of_event { id; ts; ty; op; reference; snapshot_fn } =
+        let snapshot = snapshot_fn () in
+        Wire_protocol.(rpc_of_event { id; ts; ty; op; reference; snapshot })
+let event_of_rpc rpc = match Wire_protocol.event_of_rpc rpc with
+        | { Wire_protocol.id; ts; ty; op; reference; snapshot } ->
+                { id; ts; ty; op; reference; snapshot_fn = fun () -> snapshot }
 
 type events = event list with rpc
 
@@ -81,9 +100,4 @@ let op_of_string x = match String.lowercase x with
   | "add" -> `add | "mod" -> `_mod | "del" -> `del
   | x -> failwith (sprintf "Unknown operation type: %s" x)
 
-let string_of_event ev = sprintf "%s %s %s %s %s" ev.id ev.ty (string_of_op ev.op) ev.reference
-  (if ev.snapshot = None then "(no snapshot)" else "OK")
-
-
-
-		
+let string_of_event ev = Jsonrpc.to_string (rpc_of_event ev)

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1686,7 +1686,7 @@ let event_wait_gen rpc session_id classname record_matches =
 								let record = List.map (fun r -> (r.name,fun () -> safe_get_field r)) tbl in
 								if record_matches record then raise Finished
 							in
-							List.iter doevent (List.filter (fun e -> e.Event_types.snapshot <> None) events)
+							List.iter doevent (List.filter (fun e -> e.Event_types.snapshot_fn () <> None) events)
 						with Api_errors.Server_error(code, _) when code = Api_errors.events_lost ->
 							debug "Got EVENTS_LOST; reregistering";
 							Client.Event.unregister ~rpc ~session_id ~classes;

--- a/ocaml/xapi/xapi_event.mli
+++ b/ocaml/xapi/xapi_event.mli
@@ -32,7 +32,7 @@ val inject: __context:Context.t -> _class:string -> _ref:string -> string
 
 (** {2} Internal interfaces with the other parts of xapi. *)
 
-val event_add: ?snapshot:Rpc.t -> string -> string -> string -> unit
+val event_add: ?snapshot_fn:(unit -> Rpc.t option) -> string -> string -> string -> unit
 
 val register_hooks: unit -> unit
 

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -358,8 +358,8 @@ let write ~__context ~_ref ~message =
 		   hasn't been written, we may want to also emit a del even, for
 		   consistency (since the reference for the message will never be
 		   valid again. *)
-		let rpc = API.rpc_of_message_t message in
-		Xapi_event.event_add ~snapshot:rpc "message" "add" (Ref.string_of _ref);
+		let snapshot_fn () = Some (API.rpc_of_message_t message) in
+		Xapi_event.event_add ~snapshot_fn "message" "add" (Ref.string_of _ref);
 		let (_: bool) = (!queue_push) message.API.message_name (message_to_string (_ref,message)) in
 		(*Xapi_event.event_add ~snapshot:xml "message" "del" (Ref.string_of _ref);*)
 
@@ -429,7 +429,7 @@ let destroy_real __context basefilename =
   List.iter (fun (dir,newpath) ->
 	Unixext.unlink_safe newpath) symlinks;
   Unixext.unlink_safe filename;
-  let rpc = API.rpc_of_message_t message in
+  let snapshot_fn () = Some (API.rpc_of_message_t message) in
 
   let gen = ref 0L in
 
@@ -449,7 +449,7 @@ let destroy_real __context basefilename =
 				ndeleted := 512)
 	  );
   cache_remove _ref;
-  Xapi_event.event_add ~snapshot:rpc "message" "del" (Ref.string_of _ref)
+  Xapi_event.event_add ~snapshot_fn "message" "del" (Ref.string_of _ref)
 
 let destroy ~__context ~self =
   (* Find the original message so we know where the symlinks will be *)


### PR DESCRIPTION
We
- only generate snapshots if the user calls 'next' (previously we did it on every database write, irrespective of event system used, irrespective even of class -- even sessions were being snapshotted)
- capture database references in the queue, where each reference shares most of the data with other database references.

This is a generalisation of the idea of storing a list of database deltas, with the observation that the heap usage churn between two databases is about the same size as the delta would be since the non-shared heap blocks *is* the delta (kinda)

This request includes a (disabled, but easy to re-activate) micro benchmark.

Outstanding issues: (discussed this with @jonludlam this morning)
- [ ] in the case of xenstore_data, there currently won't be any sharing of the xenstore_data field itself, because each one appears as a fresh set of strings. Is this a problem?
- [ ] since there is no sharing in 'event.next', the output code be too large. We should limit the amount of XMLRPC we're prepared to buffer and force the client to make multiple calls