### PR TITLE
SMAPIv1: support backtrace reporting via XenAPI-style errors

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -60,11 +60,13 @@ let progress_bar printer task_record =
 let wait_with_progress_bar printer rpc session_id task =
 	Cli_util.track (progress_bar printer) rpc session_id task;
 	Cli_printer.PStderr "\n" |> printer;
-	Cli_util.result_from_task rpc session_id task
+	let (_: string) = Cli_util.result_from_task rpc session_id task in
+	()
 
 let wait printer rpc session_id task =
 	Cli_util.track (fun _ -> ()) rpc session_id task;
-	Cli_util.result_from_task rpc session_id task
+	let (_: string) = Cli_util.result_from_task rpc session_id task in
+	()
 
 let waiter printer rpc session_id params task =
 	finally

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -207,7 +207,8 @@ let exec_xmlrpc ?context ?(needs_session=true) (driver: string) (call: call) =
     let response = match methodResponse xml with
     | XMLRPC.Fault(code, reason) -> `Error (code, reason, None)
     | XMLRPC.Failure ("SR_BACKEND_FAILURE_WITH_BACKTRACE", backtrace :: code :: reason :: []) ->
-        let backtrace = Backtrace.Interop.of_json (Filename.basename call.cmd) backtrace in
+        let name = Filename.basename driver ^ " @ " ^ (Helper_hostname.get_hostname ()) in
+        let backtrace = Backtrace.Interop.of_json name backtrace in
         `Error (Int32.of_string code, reason, Some backtrace)
     | XMLRPC.Failure (code, params) -> `XenAPI(code, params)
     | XMLRPC.Success [ result ] -> `Ok result

--- a/ocaml/xapi/smint.ml
+++ b/ocaml/xapi/smint.ml
@@ -157,8 +157,6 @@ exception Command_failed of (int * string * string (*stdout*) * string (*stderr*
 exception Command_killed of (int * string * string (*stdout*) * string (*stderr*))
 exception Missing_field of string
 
-exception Not_implemented_in_backend (* Raised by clone at least *)
-
 exception Sr_not_empty
 exception Vdi_in_use
 exception Device_in_use

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -155,9 +155,6 @@ module SMAPIv1 = struct
 							try
 								Sm.sr_create (subtask_of, device_config) _type sr physical_size
 							with
-								| Smint.Not_implemented_in_backend ->
-									error "SR.create failed SR:%s Not_implemented_in_backend" (Ref.string_of sr);
-									raise (Storage_interface.Backend_error(Api_errors.sr_operation_not_supported, [ Ref.string_of sr ]))
 								| Api_errors.Server_error(code, params) ->
 									raise (Backend_error(code, params))
 								| e ->
@@ -220,8 +217,6 @@ module SMAPIv1 = struct
 							try
 								Sm.sr_delete device_config _type sr
 							with
-								| Smint.Not_implemented_in_backend ->
-									raise (Storage_interface.Backend_error(Api_errors.sr_operation_not_supported, [ Ref.string_of sr ]))
 								| Api_errors.Server_error(code, params) ->
 									raise (Backend_error(code, params))
 								| e ->
@@ -244,8 +239,6 @@ module SMAPIv1 = struct
 								let free_space = Int64.sub r.API.sR_physical_size r.API.sR_physical_utilisation in
 								{ total_space; free_space }
 							with
-								| Smint.Not_implemented_in_backend ->
-									raise (Storage_interface.Backend_error(Api_errors.sr_operation_not_supported, [ Ref.string_of sr ]))
 								| Api_errors.Server_error(code, params) ->
 									error "SR.scan failed SR:%s code=%s params=[%s]" (Ref.string_of sr) code (String.concat "; " params);
 									raise (Backend_error(code, params))
@@ -269,8 +262,6 @@ module SMAPIv1 = struct
 								let vdis = Db.VDI.get_records_where ~__context ~expr:(Eq(Field "SR", Literal (Ref.string_of sr))) |> List.map snd in
 								List.map (vdi_info_of_vdi_rec __context) vdis
 							with
-								| Smint.Not_implemented_in_backend ->
-									raise (Storage_interface.Backend_error(Api_errors.sr_operation_not_supported, [ Ref.string_of sr ]))
 								| Api_errors.Server_error(code, params) ->
 									error "SR.scan failed SR:%s code=%s params=[%s]" (Ref.string_of sr) code (String.concat "; " params);
 									raise (Backend_error(code, params))
@@ -497,8 +488,6 @@ module SMAPIv1 = struct
             with 
 				| Api_errors.Server_error(code, params) ->
 					raise (Backend_error(code, params))
-				| Smint.Not_implemented_in_backend ->
-					raise (Unimplemented call_name)
 				| Sm.MasterOnly -> redirect sr
 
 
@@ -519,8 +508,6 @@ module SMAPIv1 = struct
             with
                                 | Api_errors.Server_error(code, params) ->
                                         raise (Backend_error(code, params))
-                                | Smint.Not_implemented_in_backend ->
-                                        raise (Unimplemented "VDI.resize")
                                 | Sm.MasterOnly -> redirect sr
 
         let destroy context ~dbg ~sr ~vdi =
@@ -662,8 +649,6 @@ module SMAPIv1 = struct
 							)
 					)
             with
-				| Smint.Not_implemented_in_backend ->
-					raise (Unimplemented "VDI.compose")
 				| Api_errors.Server_error(code, params) ->
 					raise (Backend_error(code, params))
 				| No_VDI ->


### PR DESCRIPTION
This is an implementation of http://xapi-project.github.io/features/backtraces.html

This must be merged after: https://github.com/xapi-project/backtrace/pull/4

For reference here is an SM patch which consumes this interface: https://github.com/djs55/sm/tree/smapiv1-backtraces