### PR TITLE
Add the default value of 'pass-through-pif-carrier' to xapi.conf

### DIFF
--- a/ocaml/xapi/monitor_master.ml
+++ b/ocaml/xapi/monitor_master.ml
@@ -30,11 +30,11 @@ let update_configuration_from_master () =
 		let new_use_min_max = (List.mem_assoc Xapi_globs.create_min_max_in_new_VM_RRDs oc) &&
 			(List.assoc Xapi_globs.create_min_max_in_new_VM_RRDs oc = "true") in
 		log_and_ignore_exn (Rrdd.update_use_min_max ~value:new_use_min_max);
-		let carrier = (List.mem_assoc Xapi_globs.pass_through_pif_carrier oc) &&
-			(List.assoc Xapi_globs.pass_through_pif_carrier oc = "true") in
-		if !Xapi_xenops.pass_through_pif_carrier <> carrier
+		let carrier = (List.mem_assoc Xapi_globs.pass_through_pif_carrier_key oc) &&
+			(List.assoc Xapi_globs.pass_through_pif_carrier_key oc = "true") in
+		if !Xapi_globs.pass_through_pif_carrier <> carrier
 		then debug "Updating pass_through_pif_carrier: New value=%b" carrier;
-		Xapi_xenops.pass_through_pif_carrier := carrier
+		Xapi_globs.pass_through_pif_carrier := carrier
 	)
 
 let set_vm_metrics ~__context ~vm ~memory ~cpus =
@@ -217,7 +217,7 @@ let update_pifs ~__context host pifs =
 			let pcibuspath = pif_stats.pif_pci_bus_path in
 
 			(* 1. Update corresponding VIF carrier flags *)
-			if !Xapi_xenops.pass_through_pif_carrier then begin
+			if !Xapi_globs.pass_through_pif_carrier then begin
 				try
 					(* Go from physical interface -> bridge -> vif devices.
 					 * Do this for the physical network and any VLANs/tunnels on top of it. *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -465,7 +465,10 @@ let host_no_local_storage = "no_local_storage"
 let create_min_max_in_new_VM_RRDs = "create_min_max_in_new_VM_RRDs"
 
 (* Pool.other_config key to enable pass-through of PIF carrier *)
-let pass_through_pif_carrier = "pass_through_pif_carrier"
+let pass_through_pif_carrier_key = "pass_through_pif_carrier"
+
+(* Don't pass through PIF carrier information by default *)
+let pass_through_pif_carrier = ref false
 
 (* Remember the specific PCI devices needed for GPU passthrough *)
 let vgpu_pci = "vgpu_pci"
@@ -907,7 +910,10 @@ let other_options = [
     (fun s ->
       D.debug "Whitelisting PCI vendor %s for passthrough" s;
       Scanf.sscanf s "%4Lx" (fun _ -> s)) (* Scanf verifies format *)
-    (fun s -> s) igd_passthru_vendor_whitelist
+    (fun s -> s) igd_passthru_vendor_whitelist;
+
+  "pass-through-pif-carrier", Arg.Set pass_through_pif_carrier,
+    (fun () -> string_of_bool !pass_through_pif_carrier), "reflect physical interface carrier information to VMs by default";
 ] 
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -389,8 +389,6 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough =
 				vncterm_ip = None (*None PR-1255*);
 			}
 
-let pass_through_pif_carrier = ref false
-
 module MD = struct
 	(** Convert between xapi DB records and xenopsd records *)
 
@@ -499,7 +497,7 @@ module MD = struct
 			| `unlocked, _ -> Vif.Unlocked
 			| `disabled, _ -> Vif.Disabled in
 		let carrier =
-			if !pass_through_pif_carrier then
+			if !Xapi_globs.pass_through_pif_carrier then
 				(* We need to reflect the carrier of the local PIF on the network (if any) *)
 				let host = Helpers.get_localhost ~__context in
 				let pifs = Xapi_network_attach_helpers.get_local_pifs ~__context ~network:vif.API.vIF_network ~host in

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -190,6 +190,10 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # the master to re-establish before concluding that it's broken and failing
 # pif_reconfigure_ip_timeout = 300
 
+# true if we want to pass network interface carrier information
+# to guests
+# pass-through-pif-carrier = false
+
 # time between invocations of the pool database sync; every interval
 # the pool database will be backed up to one host
 # pool_db_sync_interval = 300


### PR DESCRIPTION
This allows admins to configure a system default when the package
is installed, without relying on the infrequently-polled
Pool.other_config override mechanism.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>