### PR TITLE
CA-152387: Add m2crypto dependency to xapi-core

### DIFF
--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -20,7 +20,7 @@ XCP toolstack.
 %package core
 Summary: The xapi toolstack
 Group: System/Hypervisor
-Requires: busybox
+Requires: busybox m2crypto
 
 %description core
 This package contains the xapi toolstack.


### PR DESCRIPTION
This is needed by the iLO plugin. It used to be pulled in as a
dependency of yum, but that's no longer the case.
