### PR TITLE
CP-9795: Use ip tool instead of ifconfig

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -36,7 +36,7 @@ mgmt_ip() {
         [ "${MANAGEMENT_INTERFACE}" != "lo" ];
     then
         while [ true ]; do
-            IP=`/sbin/ifconfig ${MANAGEMENT_INTERFACE} | sed -ne 's/.*inet addr:\([^ ]*\).*/\1/p'`
+            IP=`/sbin/ip address show dev ${MANAGEMENT_INTERFACE} | sed -ne 's/.*inet \([^ /]*\).*/\1/p'`
             if [ -n "$IP" ]; then
                 echo "$IP"
                 return


### PR DESCRIPTION
The output of ifconfig varies by version so rather parse the output
of the ip tool.

Signed-off-by: Ross Lagerwall ross.lagerwall@citrix.com
