### PR TITLE
CP-9795: Improve comparison of hostname against localhost

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -156,7 +156,9 @@ let on_dom0_networking_change ~__context =
 		debug "Changing Host.hostname in database to: %s" new_hostname;
 		Db.Host.set_hostname ~__context ~self:localhost ~value:new_hostname
 	end;
-	if Db.Host.get_name_label ~__context ~self:localhost = "localhost.localdomain" then
+	if List.mem
+	  (Db.Host.get_name_label ~__context ~self:localhost)
+	  ["localhost"; "localhost.localdomain"] then
 		Db.Host.set_name_label ~__context ~self:localhost ~value:new_hostname;
 	begin match Helpers.get_management_ip_addr ~__context with
 		| Some ip ->


### PR DESCRIPTION
On RHEL-based systems prior to 7, the output of hostname with no
hostname setup is "localhost.localdomain".  On RHEL 7-based systems and
Debian-based systems, the output of hostname is "localhost".  Compare
the name label against either of these values for resilience.

Signed-off-by: Ross Lagerwall ross.lagerwall@citrix.com
