### PR TITLE
CP-9795: Remove use of deprecated a4wide package

### DIFF
--- a/doc/futures/main.tex
+++ b/doc/futures/main.tex
@@ -2,7 +2,14 @@
 
 \documentclass[a4paper]{article}
 
-\usepackage{a4wide}
+\usepackage{geometry}
+\usepackage{layout}
+\geometry{
+  left=2.0cm,
+  right=2.5cm,
+  top=3.5cm,
+  bottom=3cm
+}
 \usepackage{graphicx}
 \usepackage{longtable}
 \usepackage{fancyhdr}
@@ -12,10 +19,6 @@
 \newcommand{\eqdef}{\stackrel{def}{=}}
 \newcommand{\Fig}[1]{Figure~\ref{#1}}
 
-\setlength\topskip{0cm}
-\setlength\topmargin{0cm}
-\setlength\oddsidemargin{0cm}
-\setlength\evensidemargin{0cm}
 %\setlength\parindent{0pt}
 
 \input{globals}

--- a/doc/squeezed/main.tex
+++ b/doc/squeezed/main.tex
@@ -2,7 +2,14 @@
 
 \documentclass{article}
 
-\usepackage{a4wide}
+\usepackage{geometry}
+\usepackage{layout}
+\geometry{
+  left=2.0cm,
+  right=2.5cm,
+  top=3.5cm,
+  bottom=3cm
+}
 \usepackage{graphics}
 \usepackage{longtable}
 \usepackage{fancyhdr}
@@ -10,10 +17,6 @@
 
 \newcommand{\eqdef}{\stackrel{def}{=}}
 
-\setlength\topskip{0cm}
-\setlength\topmargin{0cm}
-\setlength\oddsidemargin{0cm}
-\setlength\evensidemargin{0cm}
 %\setlength\parindent{0pt}
 
 \input{globals}

--- a/ocaml/idl/latex_backend.ml
+++ b/ocaml/idl/latex_backend.ml
@@ -167,15 +167,18 @@ let of_content x closed =
     
 (*
   let header = [ "\\documentclass[8pt]{article}"; 
-  "\\usepackage{a4wide}";
+  "\\usepackage{geometry}";
+  "\\usepackage{layout}";
+  "\\geometry{";
+  "\left=2.0cm,";
+  "\right=2.5cm,";
+  "\top=3.5cm,";
+  "\bottom=3cm";
+  "}";
   "\\usepackage{graphics}";
   "\\usepackage{longtable}";
 (* "\\usepackage[a3paper,pdftex]{geometry}"; *)
   "\\usepackage{fancyhdr}";
-  "\\setlength\\topskip{0cm}";
-  "\\setlength\\topmargin{0cm}";
-  "\\setlength\\oddsidemargin{0cm}";
-  "\\setlength\\evensidemargin{0cm}";
   "\\setlength\\parindent{0pt}";
   "\\begin{document}" ]
   let footer = [ "\\end{document}" ]

--- a/ocaml/idl/xenapi.tex
+++ b/ocaml/idl/xenapi.tex
@@ -8,15 +8,18 @@
 
 \documentclass{report}
 
-\usepackage{a4wide}
+\usepackage{geometry}
+\usepackage{layout}
+\geometry{
+  left=2.0cm,
+  right=2.5cm,
+  top=3.5cm,
+  bottom=3cm
+}
 \usepackage{graphics}
 \usepackage{longtable}
 \usepackage{fancyhdr}
 
-\setlength\topskip{0cm}
-\setlength\topmargin{0cm}
-\setlength\oddsidemargin{0cm}
-\setlength\evensidemargin{0cm}
 \setlength\parindent{0pt}
 
 %% Parameters for coversheet:

--- a/ocaml/idl/xenenterpriseapi.tex
+++ b/ocaml/idl/xenenterpriseapi.tex
@@ -8,16 +8,19 @@
 
 \documentclass{report}
 
-\usepackage{a4wide}
+\usepackage{geometry}
+\usepackage{layout}
+\geometry{
+  left=2.0cm,
+  right=2.5cm,
+  top=3.5cm,
+  bottom=3cm
+}
 \usepackage{graphics}
 \usepackage{longtable}
 \usepackage{fancyhdr}
 \pagestyle{fancy}
 
-\setlength\topskip{0cm}
-\setlength\topmargin{0cm}
-\setlength\oddsidemargin{0cm}
-\setlength\evensidemargin{0cm}
 \setlength\parindent{0pt}
 
 %% Parameters for coversheet:


### PR DESCRIPTION
Replace use of the deprecated a4wide package with the geometry package
with equivalent settings.  The a4wide package is not available on some
systems.

Signed-off-by: Ross Lagerwall ross.lagerwall@citrix.com
