### PR TITLE
CA-154341: Disallow Resume when a Checkpoint is ongoing

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -405,8 +405,9 @@ let update_allowed_operations ~__context ~self =
 		Xapi_vm_appliance_lifecycle.update_allowed_operations ~__context ~self:appliance
 
 (** Called on new VMs (clones, imports) and on server start to manually refresh
-    the power state, allowed_operations field etc *)
-let force_state_reset ~__context ~self ~value:state =
+    the power state, allowed_operations field etc.  Current-operations won't be
+    cleaned *)
+let force_state_reset_keep_current_operations ~__context ~self ~value:state =
 	if state = `Halted then begin
 		(* mark all devices as disconnected *)
 		List.iter 
@@ -451,9 +452,15 @@ let force_state_reset ~__context ~self ~value:state =
 	end;
 
 	Db.VM.set_power_state ~__context ~self ~value:state;
-	if (Db.VM.get_current_operations ~__context ~self)<>[] then
-		Db.VM.set_current_operations ~__context ~self ~value:[];
 	update_allowed_operations ~__context ~self
+
+(** Called on new VMs (clones, imports) and on server start to manually refresh
+    the power state, allowed_operations field etc.  Clean current-operations
+    as well *)
+let force_state_reset ~__context ~self ~value:state =
+	if (Db.VM.get_current_operations ~__context ~self) <> [] then
+		Db.VM.set_current_operations ~__context ~self ~value:[];
+	force_state_reset_keep_current_operations ~__context ~self ~value:state
 
 (** Someone is cancelling a task so remove it from the current_operations *)
 let cancel_task ~__context ~self ~task_id = 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -953,8 +953,9 @@ let update_vm ~__context id =
 							let power_state = xenapi_of_xenops_power_state (Opt.map (fun x -> (snd x).power_state) info) in
 							debug "xenopsd event: Updating VM %s power_state <- %s" id (Record_util.power_state_to_string power_state);
 							(* This will mark VBDs, VIFs as detached and clear resident_on
-							   if the VM has permenantly shutdown. *)
-							Xapi_vm_lifecycle.force_state_reset ~__context ~self ~value:power_state;
+							   if the VM has permanently shutdown.  current-operations
+							   should not be reset as there maybe a checkpoint is ongoing*)
+							Xapi_vm_lifecycle.force_state_reset_keep_current_operations ~__context ~self ~value:power_state;
 
 							if power_state = `Suspended || power_state = `Halted then begin
 								Xapi_network.detach_for_vm ~__context ~host:localhost ~vm:self;


### PR DESCRIPTION
The Resume operation sould be blocked when a checkpoint is ongoing,
otherwise two domains may coexist for a single VM.  In existent
implement the current-operations field of a VM were cleaned upon
the finish of the suspension, which is a part of a checkpoint task,
makes Resume become an allowed operation.

Signed-off-by: Kaifeng Zhu <kaifeng.zhu@citrix.com>