### PR TITLE
CA-152343: Start SMAPIv1 proxies later in the startup sequence

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -799,7 +799,6 @@ let server_init() =
     "Initialising random number generator", [], random_setup;
     "Running startup check", [], startup_check;
     "Registering SMAPIv1 plugins", [Startup.OnlyMaster], Sm.register;
-    "Starting SMAPIv1 proxies", [], Storage_access.start_smapiv1_servers;
 	"Initialising SM state", [], Storage_impl.initialise;
 	"Starting SM internal event service", [], Storage_task.Updates.Scheduler.start;
 	"Starting SM service", [], Storage_access.start;
@@ -884,6 +883,7 @@ let server_init() =
 
     Server_helpers.exec_with_new_task "server_init" ~task_in_database:true (fun __context -> 
     Startup.run ~__context [
+      "Starting SMAPIv1 proxies", [], Storage_access.start_smapiv1_servers;
       "Checking emergency network reset", [], check_network_reset;
       "Upgrade bonds to Boston", [Startup.NoExnRaising], Sync_networking.fix_bonds ~__context;
       "Synchronising bonds on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_bonds_from_master ~__context;


### PR DESCRIPTION
On a slave this requires making a DB call to the master to find out
which SM objects exist, so this needs to be done after starting HA (if
applicable) and setting up the database connection to the master.
