### PR TITLE
import_raw_vdi: Pass Content-Length to vhd-tool

### DIFF
--- a/ocaml/xapi/import_raw_vdi.ml
+++ b/ocaml/xapi/import_raw_vdi.ml
@@ -59,8 +59,8 @@ let localhost_handler rpc session_id vdi (req: Request.t) (s: Unix.file_descr) =
 										content_type ] in
 									Http_svr.headers s headers;
 									if chunked
-									then Vhd_tool_wrapper.receive (Vhd_tool_wrapper.update_task_progress __context) "raw" "chunked" s path "" prezeroed
-									else Vhd_tool_wrapper.receive (Vhd_tool_wrapper.update_task_progress __context) (Importexport.Format.to_string format) "none" s path "" prezeroed
+									then Vhd_tool_wrapper.receive (Vhd_tool_wrapper.update_task_progress __context) "raw" "chunked" s None path "" prezeroed
+									else Vhd_tool_wrapper.receive (Vhd_tool_wrapper.update_task_progress __context) (Importexport.Format.to_string format) "none" s req.Request.content_length path "" prezeroed
 								);
 						TaskHelper.complete ~__context None;
 				with e ->

--- a/ocaml/xapi/vhd_tool_wrapper.ml
+++ b/ocaml/xapi/vhd_tool_wrapper.ml
@@ -62,7 +62,7 @@ let run_vhd_tool progress_cb args s s' path =
     | Failure(out, e) -> error "vhd-tool output: %s" out; raise e
   ) (fun () -> close pipe_read; close pipe_write)
 
-let receive progress_cb format protocol (s: Unix.file_descr) (path: string) (prefix: string) (prezeroed: bool) =
+let receive progress_cb format protocol (s: Unix.file_descr) (length: int64 option) (path: string) (prefix: string) (prezeroed: bool) =
   let s' = Uuidm.to_string (Uuidm.create `V4) in
   let args = [ "serve";
                "--source-format"; format;
@@ -74,7 +74,11 @@ let receive progress_cb format protocol (s: Unix.file_descr) (path: string) (pre
                "--progress";
                "--machine";
                "--direct";
-             ] @ (if prezeroed then [ "--prezeroed" ] else []) in
+             ] @
+             (match length with
+              | Some x -> [ "--destination-size"; Int64.to_string x ]
+              | None -> []) @
+             (if prezeroed then [ "--prezeroed" ] else []) in
   run_vhd_tool progress_cb args s s' path
 
 open Fun


### PR DESCRIPTION
This passes the `Content-Length` header to `vhd-tool serve` when using raw non-chunked imports. This way clients don't need to manually pad out the HTTP PUT with zeros, to fill it up to the next 2MB boundary.

Compiled and tested. No changes to `vhd-tool` required (so far -- see below).

Two issues/queries:
- I'm using the `--destination-size` parameter for `vhd-tool` to determine how much it should read from the source, which sounds counterintuitive. On the other hand, if it's intended behaviour that `vhd-tool` always expects to read as much as the size of the destination allows (which is how this 2MB rounding issue arose in the first place), then I can see how it could make some sense. Despite that, should we rename the argument?
- I haven't added explicit error handling for the case when `Content-Length` exceeds the allocated size of the VHD. In this case vhd-tool currently raises a VDI_IO_ERROR. Should we check for this up-front? If so, should the check go in xapi or vhd-tool?
