### PR TITLE
CA-153127: Enable master connection watchdog

### DIFF
--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -141,8 +141,8 @@ let do_db_xml_rpc_persistent_with_reopen ~host ~path (req: string) : Db_interfac
 	  None -> raise Goto_handler
 	| (Some stunnel_proc) ->
 	    let fd = stunnel_proc.Stunnel.fd in
-		with_http request
-			(fun (response, _) ->
+	    with_timestamp (fun () ->
+	        with_http request (fun (response, _) ->
 				(* XML responses must have a content-length because we cannot use the Xml.parse_in
 				   in_channel function: the input channel will buffer an arbitrary amount of stuff
 				   and we'll be out of sync with the next request. *)
@@ -150,17 +150,17 @@ let do_db_xml_rpc_persistent_with_reopen ~host ~path (req: string) : Db_interfac
 					| None -> raise Content_length_required
 					| Some l -> begin
 						if (Int64.to_int l) <= Sys.max_string_length then
-							with_timestamp (fun () -> Db_interface.String (Unixext.really_read_string fd (Int64.to_int l)))
+							Db_interface.String (Unixext.really_read_string fd (Int64.to_int l))
 						else
-							with_timestamp (fun () ->
-								let buf = Bigbuffer.make () in
-								Unixext.really_read_bigbuffer fd buf l;
-								Db_interface.Bigbuf buf)
+							let buf = Bigbuffer.make () in
+							Unixext.really_read_bigbuffer fd buf l;
+							Db_interface.Bigbuf buf
 					end
 				in
 				write_ok := true;
 				result := res (* yippeee! return and exit from while loop *)
 			) fd
+        )
       with
       | Http_svr.Client_requested_size_over_limit ->
 	error "Content length larger than known limit (%d)." Xapi_globs.http_limit_max_rpc_size;

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -876,6 +876,9 @@ let server_init() =
           (* Grab the management IP address (wait forever for it if necessary) *)
           let ip = wait_for_management_ip_address ~__context in
 
+          debug "Start master_connection watchdog";
+          ignore (Master_connection.start_master_connection_watchdog ());
+
           debug "Attempting to communicate with master";
           (* Try to say hello to the pool *)
           begin match attempt_pool_hello ip with


### PR DESCRIPTION
The master connection watchdog did not take effect as
a) Only the processing time of the HTTP response was treated as the lasting time to compare with the timeout value;
b) The watchdog thread was not started.

So extend the scope of with_timestamp and start the watchdog thread in slave before attempting to communicate with pool master.