### PR TITLE
CA-154346: scripts: Fix compatibility with Python 2.7

### DIFF
--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -99,6 +99,7 @@ class UDSTransport(xmlrpclib.Transport):
     def __init__(self, use_datetime=0):
         self._use_datetime = use_datetime
         self._extra_headers=[]
+        self._connection = (None, None)
     def add_extra_header(self, key, value):
         self._extra_headers += [ (key,value) ]
     def make_connection(self, host):


### PR DESCRIPTION
Pyython 2.7 requires the Transport instance to have a _connection tuple.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>