### PR TITLE
CP-9798: Depend on net-tools for ifconfig

### DIFF
--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -63,7 +63,7 @@ XCP toolstack.
 %package core
 Summary: The xapi toolstack
 Group: System/Hypervisor
-Requires: busybox m2crypto
+Requires: busybox m2crypto net-tools
 
 %description core
 This package contains the xapi toolstack.
@@ -78,6 +78,7 @@ The command-line interface for controlling XCP hosts.
 %package tests
 Summary: Toolstack test programs
 Group: System/Hypervisor
+Requires: net-tools
 
 %description tests
 This package contains a series of simple regression tests.


### PR DESCRIPTION
net-tools is not pulled in by default on CentOS 7, so depend on it.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>