### PR TITLE
Add passthrough to supported_vgpu_types when appropriate

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -883,7 +883,7 @@ let other_options = [
       with e ->
         D.error "Unable to parse disable-logging-for=%s (expected space-separated list)" x
     ), (fun () -> "<default>"), (* no API to query the current list *)
-    "comma-separated list of modules to suppress logging from";
+    "space-separated list of modules to suppress logging from";
 
   "xenopsd-queues", Arg.String (fun x -> xenopsd_queues := String.split ',' x),
     (fun () -> String.concat "," !xenopsd_queues), "list of xenopsd instances to manage";

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -231,10 +231,6 @@ let foreign_metadata_db = Filename.concat "/var/lib/xcp" "foreign.db"
 
 let migration_failure_test_key = "migration_wings_fall_off" (* set in other-config to simulate migration failures *)
 
-(* A comma-separated list of extra xenstore paths to watch in the migration code during
-   the disk flushing *)
-let migration_extra_paths_key = "migration_extra_paths"
-
 (* After this we start to delete completed tasks (never pending ones) *)
 let max_tasks = 200
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -781,6 +781,8 @@ let static_vdis_dir = ref "/etc/xensource/static-vdis"
 
 let logging_disabled_for = ref []
 
+let igd_passthru_vendor_whitelist = ref []
+
 type xapi_globs_spec_ty = | Float of float ref | Int of int ref
 
 let xapi_globs_spec =
@@ -897,6 +899,13 @@ let other_options = [
 
   "xenopsd-default", Arg.Set_string default_xenopsd,
     (fun () -> !default_xenopsd), "default xenopsd to use";
+
+  gen_list_option "igd-passthru-vendor-whitelist"
+    "list of PCI vendor IDs for integrated graphics passthrough (space-separated)"
+    (fun s ->
+      D.debug "Whitelisting PCI vendor %s for passthrough" s;
+      Scanf.sscanf s "%4Lx" (fun _ -> s)) (* Scanf verifies format *)
+    (fun s -> s) igd_passthru_vendor_whitelist
 ] 
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -779,7 +779,7 @@ let gpg_homedir = ref "/opt/xensource/gpg"
 
 let static_vdis_dir = ref "/etc/xensource/static-vdis"
 
-let logging_disabled_for = ref []
+let disable_logging_for= ref []
 
 let igd_passthru_vendor_whitelist = ref []
 
@@ -891,8 +891,7 @@ let other_options = [
 
   gen_list_option "disable-logging-for"
     "space-separated list of modules to suppress logging from"
-    (fun s -> D.debug "Disabling logging for: %s" s; Debug.disable s; s)
-    (fun s -> s) logging_disabled_for;
+    (fun s -> s) (fun s -> s) disable_logging_for;
 
   "xenopsd-queues", Arg.String (fun x -> xenopsd_queues := String.split ',' x),
     (fun () -> String.concat "," !xenopsd_queues), "list of xenopsd instances to manage";

--- a/ocaml/xapi/xapi_main.ml
+++ b/ocaml/xapi/xapi_main.ml
@@ -23,6 +23,12 @@ let _ =
 	init_args(); (* need to read args to find out whether to daemonize or not *)
 	Xcp_service.maybe_daemonize ();
 
+  (* Disable logging for the module requested in the config *)
+  List.iter (fun m ->
+    D.debug "Disabling logging for: %s" m;
+    Debug.disable m
+  ) !Xapi_globs.disable_logging_for;
+
   Unixext.pidfile_write "/var/run/xapi.pid";
 
   (* chdir to /var/lib/xcp/debug so that's where xapi coredumps go 

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -117,5 +117,3 @@ let get_host_pcis pci_db =
 	link_related_pcis [] pcis
 
 let is_hidden_from_dom0 pci = true
-
-let is_igd_whitelisted pci = true

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -115,3 +115,7 @@ let get_host_pcis pci_db =
 			link_related_pcis (pci :: ac) tl
 	in
 	link_related_pcis [] pcis
+
+let is_hidden_from_dom0 pci = true
+
+let is_igd_whitelisted pci = true

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -56,9 +56,10 @@ let update_gpus ~__context ~host =
 	let rec find_or_create cur = function
 		| [] -> cur
 		| pci :: remaining_pcis ->
-			let pci_id = Db.PCI.get_pci_id ~__context ~self:pci in
 			let supported_VGPU_types =
+				let pci_id =  Db.PCI.get_pci_id ~__context ~self:pci in
 				if system_display_device = (Some pci_id)
+				&& not (Xapi_pci_helpers.(is_hidden_from_dom0 pci && is_igd_whitelisted pci))
 				then []
 				else Xapi_vgpu_type.find_or_create_supported_types ~__context ~pci_db pci
 			in

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -56,10 +56,14 @@ let update_gpus ~__context ~host =
 	let rec find_or_create cur = function
 		| [] -> cur
 		| pci :: remaining_pcis ->
+			let igd_is_whitelisted pci =
+				let vendor_id = Db.PCI.get_subsystem_vendor_id ~__context ~self:pci in
+				List.mem vendor_id !Xapi_globs.igd_passthru_vendor_whitelist
+			in
 			let supported_VGPU_types =
-				let pci_id =  Db.PCI.get_pci_id ~__context ~self:pci in
-				if system_display_device = (Some pci_id)
-				&& not (Xapi_pci_helpers.(is_hidden_from_dom0 pci && is_igd_whitelisted pci))
+				let pci_addr =  Db.PCI.get_pci_id ~__context ~self:pci in
+				if system_display_device = (Some pci_addr)
+				&& not (Xapi_pci_helpers.is_hidden_from_dom0 pci && igd_is_whitelisted pci)
 				then []
 				else Xapi_vgpu_type.find_or_create_supported_types ~__context ~pci_db pci
 			in

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -57,6 +57,9 @@ disable-logging-for = http db_write redo_log api_readonly
 # The default xenopsd to use for VMs, unless a per-VM override is specified
 # xenopsd-default = org.xen.xcp.xenops.xenlight
 
+# List of PCI vendor IDs for which to enable integrated GPU passthrough
+igd-passthru-vendor-whitelist = 8086
+
 # Paths to utilities: ############################################
 
 search-path = @LIBEXECDIR@:@BINDIR@


### PR DESCRIPTION
This is the work for CP-10795. It has stubbed out the functionality for checking that a PCI device has been hidden from dom0 since that will be delivered in a separate pull request.