### PR TITLE
CA-156264: Starting SMAPIv1 proxies on master just after SMAPIv1 plugins...

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -799,6 +799,7 @@ let server_init() =
     "Initialising random number generator", [], random_setup;
     "Running startup check", [], startup_check;
     "Registering SMAPIv1 plugins", [Startup.OnlyMaster], Sm.register;
+    "Starting SMAPIv1 proxies", [Startup.OnlyMaster], Storage_access.start_smapiv1_servers;
 	"Initialising SM state", [], Storage_impl.initialise;
 	"Starting SM internal event service", [], Storage_task.Updates.Scheduler.start;
 	"Starting SM service", [], Storage_access.start;
@@ -883,7 +884,7 @@ let server_init() =
 
     Server_helpers.exec_with_new_task "server_init" ~task_in_database:true (fun __context -> 
     Startup.run ~__context [
-      "Starting SMAPIv1 proxies", [], Storage_access.start_smapiv1_servers;
+      "Starting SMAPIv1 proxies", [Startup.OnlySlave], Storage_access.start_smapiv1_servers;
       "Checking emergency network reset", [], check_network_reset;
       "Upgrade bonds to Boston", [Startup.NoExnRaising], Sync_networking.fix_bonds ~__context;
       "Synchronising bonds on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_bonds_from_master ~__context;


### PR DESCRIPTION
... are registered
Changes done in https://github.com/xapi-project/xen-api/commit/1e86722b292386b73c2123d4c3de516ca9ca394b
causes delay in Starting SMAPIv1 proxies. In this delay gap if "sr-create" is being called via firstboot scripts
it throws error as mentioned in CA-156264.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>