### PR TITLE
CP-10787: functions for (un)hiding PCI devices from dom0 kernel.

### DIFF
--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -45,3 +45,12 @@ val to_string: (int * (int * int * int * int)) -> string
 
 (** Return the PCI device as a tuple *)
 val of_string: string -> (int * (int * int * int * int))
+
+(** Check whether a PCI device will be hidden from the dom0 kernel on boot. *)
+val is_pci_hidden: __context:Context.t -> [ `PCI ] Ref.t -> bool
+
+(** Hide a PCI device from the dom0 kernel. (Takes affect after next boot.) *)
+val hide_pci: __context:Context.t -> [ `PCI ] Ref.t -> unit
+
+(** Unhide a PCI device from the dom0 kernel. (Takes affect after next boot.) *)
+val unhide_pci: __context:Context.t -> [ `PCI ] Ref.t -> unit


### PR DESCRIPTION
pciops now has functions hide_pci, unhide_pci, is_pci_hidden

Signed-off-by: Thomas Sanders <thomas.sanders@citrix.com>