### PR TITLE
Add passthrough to supported_vgpu_types when appropriate

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -486,6 +486,8 @@ let vgpu_pci_key = "vgpu_pci_id"
 let vgpu_config_key = "vgpu_config"
 let vgpu_extra_args_key = "vgpu_extra_args"
 
+let igd_passthru_vendor_whitelist : string list ref = ref []
+
 let dev_zero = "/dev/zero"
 
 let wlb_timeout = "wlb_timeout"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -240,10 +240,6 @@ let foreign_metadata_db = Filename.concat Fhs.vardir "foreign.db"
 
 let migration_failure_test_key = "migration_wings_fall_off" (* set in other-config to simulate migration failures *)
 
-(* A comma-separated list of extra xenstore paths to watch in the migration code during
-   the disk flushing *)
-let migration_extra_paths_key = "migration_extra_paths"
-
 (* After this we start to delete completed tasks (never pending ones) *)
 let max_tasks = 200
 

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -110,5 +110,3 @@ let get_host_pcis pci_db =
 	link_related_pcis [] pcis
 
 let is_hidden_from_dom0 pci = true
-
-let is_igd_whitelisted pci = true

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -108,3 +108,7 @@ let get_host_pcis pci_db =
 			link_related_pcis (pci :: ac) tl
 	in
 	link_related_pcis [] pcis
+
+let is_hidden_from_dom0 pci = true
+
+let is_igd_whitelisted pci = true

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -56,9 +56,10 @@ let update_gpus ~__context ~host =
 	let rec find_or_create cur = function
 		| [] -> cur
 		| pci :: remaining_pcis ->
-			let pci_id = Db.PCI.get_pci_id ~__context ~self:pci in
 			let supported_VGPU_types =
+				let pci_id =  Db.PCI.get_pci_id ~__context ~self:pci in
 				if system_display_device = (Some pci_id)
+				&& not (Xapi_pci_helpers.(is_hidden_from_dom0 pci && is_igd_whitelisted pci))
 				then []
 				else Xapi_vgpu_type.find_or_create_supported_types ~__context ~pci_db pci
 			in

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -56,10 +56,14 @@ let update_gpus ~__context ~host =
 	let rec find_or_create cur = function
 		| [] -> cur
 		| pci :: remaining_pcis ->
+			let igd_is_whitelisted pci =
+				let vendor_id = Db.PCI.get_vendor_id ~__context ~self:pci in
+				List.mem vendor_id !Xapi_globs.igd_passthru_vendor_whitelist
+			in
 			let supported_VGPU_types =
-				let pci_id =  Db.PCI.get_pci_id ~__context ~self:pci in
-				if system_display_device = (Some pci_id)
-				&& not (Xapi_pci_helpers.(is_hidden_from_dom0 pci && is_igd_whitelisted pci))
+				let pci_addr =  Db.PCI.get_pci_id ~__context ~self:pci in
+				if system_display_device = (Some pci_addr)
+				&& not (Xapi_pci_helpers.is_hidden_from_dom0 pci && igd_is_whitelisted pci)
 				then []
 				else Xapi_vgpu_type.find_or_create_supported_types ~__context ~pci_db pci
 			in

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -2,3 +2,4 @@
 
 use-xenopsd = true
 disable-logging-for = http db_write redo_log api_readonly
+igd-passthru-vendor-whitelist = 8086


### PR DESCRIPTION
Backport of https://github.com/xapi-project/xen-api/pull/2087 and https://github.com/xapi-project/xen-api/pull/2091 for creedence-igd-passthru.