### PR TITLE
CP-10236: Expose RDP status to VM guest metrics

### DIFF
--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -125,11 +125,15 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
     | Some xsval -> [ mapkey, xsval ]
     | None -> []) kvpairs) in
 
+  let ts = match lookup "data/ts" with
+  	| Some value -> ["data-ts",value]
+  	| None -> [] in
+  	
   let pv_drivers_version = to_map pv_drivers_version
   and os_version = to_map os_version
   and device_id = to_map device_id
   and networks = to_map (networks "attr" list)
-  and other = to_map (other all_control)
+  and other = List.append (to_map (other all_control)) ts
   and memory = to_map memory
   and last_updated = Unix.gettimeofday () in
 

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -2185,6 +2185,7 @@ module Actions = struct
 	let interesting_paths_for_domain domid uuid =
 		let open Printf in [
 			sprintf "/local/domain/%d/data/updated" domid;
+			sprintf "/local/domain/%d/data/ts" domid;
 			sprintf "/local/domain/%d/memory/target" domid;
 			sprintf "/local/domain/%d/memory/uncooperative" domid;
 			sprintf "/local/domain/%d/console/vnc-port" domid;


### PR DESCRIPTION
Add data/ts to VM_guest_metrics so XenCenter can detect guest VM RDP status.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>