### PR TITLE
CP-10954: Use "feature-ts2" as RDP feature indicator and update api minor version

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -41,7 +41,7 @@ let xapi_user_agent = "xapi/"^(string_of_int version_major)^"."^(string_of_int v
 (* Normally xencenter_min_verstring and xencenter_max_verstring below should be set to the same value,
  * but there are exceptions: please consult the XenCenter maintainers if in doubt. *)
 let api_version_major = 2L
-let api_version_minor = 3L
+let api_version_minor = 4L
 let api_version_string =
   Printf.sprintf "%Ld.%Ld" api_version_major api_version_minor
 let api_version_vendor = "XenSource"

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -699,16 +699,19 @@ let set_memory_dynamic_range ~__context ~self ~min ~max =
 let request_rdp ~__context ~vm ~enabled =
 	let vm_gm = Db.VM.get_guest_metrics ~__context ~self:vm in
 	let vm_gmr = try Some (Db.VM_guest_metrics.get_record_internal ~__context ~self:vm_gm) with _ -> None in  
-	let is_feature_ts_on =
+	let is_feature_ts2_on =
 		match vm_gmr with
 			| None -> false
 			| Some vm_gmr ->
 				let other = vm_gmr.Db_actions.vM_guest_metrics_other in
 				try
-					List.assoc "feature-ts" other = "1"
+					match List.assoc "feature-ts2" other with
+					    | ""
+					    | "0" -> false
+					    | _ -> true
 				with Not_found -> false
 	in
-	if is_feature_ts_on
+	if is_feature_ts2_on
 	then
 		Xapi_xenops.request_rdp ~__context ~self:vm enabled
 	else raise Not_found


### PR DESCRIPTION
This pull requst is to implement the RDP feature design update.
It contains 2 commits. One is to increase the API version so that XenCenter could distinguish the Xapi version and know if it supports RDP feature. Another one is to use "feature-ts2" as RDP feature indicator so Xapi could understand if the Windows Guest Agent supports the new RDP feature.