### PR TITLE
CP-10532: Block VMs migration to host which does not support its virtual hardware platform

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -880,6 +880,8 @@ let vm_record rpc session_id vm =
 				~get:(fun () -> Int64.to_string (x ()).API.vM_version) ();
 			make_field ~name:"generation-id"
 				~get:(fun () -> (x ()).API.vM_generation_id) ();
+			make_field ~name:"virt-hw-vn"
+				~get:(fun () -> Int64.to_string (x ()).API.vM_virt_hw_vn) ();
 		]}
 
 let host_crashdump_record rpc session_id host = 
@@ -1048,6 +1050,9 @@ let host_record rpc session_id host =
 				~get_map:(fun () -> (x ()).API.host_guest_VCPUs_params) 
 				~add_to_map:(fun k v -> Client.Host.add_to_guest_VCPUs_params rpc session_id host k v)
 				~remove_from_map:(fun k -> Client.Host.remove_from_guest_VCPUs_params rpc session_id host k) ();
+			make_field ~name:"virt_hw_vns" 
+				~get:(fun () -> String.concat "; " (List.map Int64.to_string (x ()).API.host_virt_hw_vns)) 
+				~get_set:(fun () -> List.map Int64.to_string (x ()).API.host_virt_hw_vns) ();
 		]}
 
 let vdi_record rpc session_id vdi =

--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -38,6 +38,7 @@ let change_password_rejected = "CHANGE_PASSWORD_REJECTED"
 let user_is_not_local_superuser = "USER_IS_NOT_LOCAL_SUPERUSER"
 let cannot_contact_host = "CANNOT_CONTACT_HOST"
 let not_supported_during_upgrade = "NOT_SUPPORTED_DURING_UPGRADE"
+let hardware_platform_version_6_5_SP1_required= "HARDWARE_PLATFORM_VERSION_6_5_SP1_REQUIRED"
 
 let handle_invalid = "HANDLE_INVALID"
 let uuid_invalid = "UUID_INVALID"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3827,6 +3827,7 @@ let host_create_params =
     {param_type=Map(String,String); param_name="license_server"; param_doc="Contact information of the license server"; param_release=midnight_ride_release; param_default=Some(VMap [VString "address", VString "localhost"; VString "port", VString "27000"])};
     {param_type=Ref _sr; param_name="local_cache_sr"; param_doc="The SR that is used as a local cache"; param_release=cowley_release; param_default=(Some (VRef (Ref.string_of Ref.null)))};
     {param_type=Map(String,String); param_name="chipset_info"; param_doc="Information about chipset features"; param_release=boston_release; param_default=Some(VMap [])};
+    {param_type=(Set(Int)); param_name="virt_hw_vns"; param_doc="Information about Virtual Hardware Platform Version"; param_release=creedence_release; param_default=Some(VSet [])};
   ]
 
 let host_create = call
@@ -4358,6 +4359,7 @@ let host =
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pci)) "PCIs" "List of PCI devices in the host";
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pgpu)) "PGPUs" "List of physical GPUs in the host";
 	field ~qualifier:RW ~in_product_since:rel_tampa ~default_value:(Some (VMap [])) ~ty:(Map (String, String)) "guest_VCPUs_params" "VCPUs params to apply to all resident guests";
+	field ~qualifier:DynamicRO ~in_product_since:rel_creedence ~default_value:(Some (VSet [])) ~ty:(Set (Int)) "virt_hw_vns" "The virtual hardware versions have";
  ])
 	()
 
@@ -6883,6 +6885,7 @@ let vm =
 	field ~writer_roles:_R_VM_ADMIN ~qualifier:RW ~in_product_since:rel_boston ~default_value:(Some (VRef (Ref.string_of Ref.null))) ~ty:(Ref _sr) "suspend_SR" "The SR on which a suspend image is stored";
 	field ~qualifier:StaticRO ~in_product_since:rel_boston ~default_value:(Some (VInt 0L)) ~ty:Int "version" "The number of times this VM has been recovered";
 	field ~qualifier:StaticRO ~in_product_since:rel_clearwater ~default_value:(Some (VString "0:0")) ~ty:(String) "generation_id" "Generation ID of the VM";
+	field ~writer_roles:_R_VM_ADMIN ~qualifier:StaticRO ~in_product_since:rel_creedence ~default_value:(Some (VInt 0L)) ~ty:Int "virt_hw_vn" "The host virtual hardware version the VM can running on";
       ])
 	()
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6885,7 +6885,7 @@ let vm =
 	field ~writer_roles:_R_VM_ADMIN ~qualifier:RW ~in_product_since:rel_boston ~default_value:(Some (VRef (Ref.string_of Ref.null))) ~ty:(Ref _sr) "suspend_SR" "The SR on which a suspend image is stored";
 	field ~qualifier:StaticRO ~in_product_since:rel_boston ~default_value:(Some (VInt 0L)) ~ty:Int "version" "The number of times this VM has been recovered";
 	field ~qualifier:StaticRO ~in_product_since:rel_clearwater ~default_value:(Some (VString "0:0")) ~ty:(String) "generation_id" "Generation ID of the VM";
-	field ~writer_roles:_R_VM_ADMIN ~qualifier:StaticRO ~in_product_since:rel_creedence ~default_value:(Some (VInt 0L)) ~ty:Int "virt_hw_vn" "The host virtual hardware version the VM can running on";
+	field ~writer_roles:_R_VM_ADMIN ~qualifier:RW ~in_product_since:rel_creedence ~default_value:(Some (VInt 0L)) ~ty:Int "virt_hw_vn" "The host virtual hardware version the VM can run on";
       ])
 	()
 

--- a/ocaml/test/test_common.ml
+++ b/ocaml/test/test_common.ml
@@ -77,7 +77,7 @@ let make_vm ~__context ?(name_label="name_label") ?(name_description="descriptio
 		?(other_config=[]) ?(xenstore_data=[]) ?(recommendations="") ?(ha_always_run=false)
 		?(ha_restart_priority="") ?(tags=[]) ?(blocked_operations=[]) ?(protection_policy=Ref.null)
 		?(is_snapshot_from_vmpp=false) ?(appliance=Ref.null) ?(start_delay=0L)
-		?(shutdown_delay=0L) ?(order=0L) ?(suspend_SR=Ref.null) ?(version=0L) ?(generation_id="0:0") () =
+		?(shutdown_delay=0L) ?(order=0L) ?(suspend_SR=Ref.null) ?(version=0L) ?(generation_id="0:0") ?(virt_hw_vn=0L) () =
 	Xapi_vm.create ~__context ~name_label ~name_description ~user_version ~is_a_template
 		~affinity ~memory_target ~memory_static_max ~memory_dynamic_max ~memory_dynamic_min
         ~memory_static_min ~vCPUs_params ~vCPUs_max ~vCPUs_at_startup ~actions_after_shutdown 
@@ -86,14 +86,14 @@ let make_vm ~__context ?(name_label="name_label") ?(name_description="descriptio
 		~hVM_shadow_multiplier ~platform ~pCI_bus ~other_config ~xenstore_data ~recommendations
 		~ha_always_run ~ha_restart_priority ~tags ~blocked_operations ~protection_policy
 		~is_snapshot_from_vmpp ~appliance ~start_delay ~shutdown_delay ~order ~suspend_SR
-		~version ~generation_id
+		~version ~generation_id ~virt_hw_vn
 
 let make_host ~__context ?(uuid=make_uuid ()) ?(name_label="host")
 		?(name_description="description") ?(hostname="localhost") ?(address="127.0.0.1")
 		?(external_auth_type="") ?(external_auth_service_name="") ?(external_auth_configuration=[])
-		?(license_params=[]) ?(edition="free") ?(license_server=[]) ?(local_cache_sr=Ref.null) ?(chipset_info=[]) () = 
+		?(license_params=[]) ?(edition="free") ?(license_server=[]) ?(local_cache_sr=Ref.null) ?(chipset_info=[]) ?(virt_hw_vns=[]) () = 
 
-	Xapi_host.create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info
+	Xapi_host.create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info ~virt_hw_vns
 
 let make_pif ~__context ~network ~host ?(device="eth0") ?(mAC="C0:FF:EE:C0:FF:EE") ?(mTU=1500L)
 		?(vLAN=(-1L)) ?(physical=true) ?(ip_configuration_mode=`None) ?(iP="") ?(netmask="")

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1552,7 +1552,8 @@ let vm_create printer rpc session_id params =
 		~order:0L
 		~suspend_SR:Ref.null
 		~version:0L
-		~generation_id:"" in
+		~generation_id:""
+		~virt_hw_vn:0L in
 	let uuid=Client.VM.get_uuid rpc session_id vm in
 	printer (Cli_printer.PList [uuid])
 

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -193,7 +193,8 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info: host_info)
 		~order:0L
 		~suspend_SR:Ref.null
 		~version:0L
-		~generation_id:"";
+		~generation_id:""
+		~virt_hw_vn:0L;
 	Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref
 
 and create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref ~dom0_console_protocol =

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -49,7 +49,7 @@ let create_localhost ~__context info =
 	~hostname:info.hostname ~address:ip 
 	~external_auth_type:"" ~external_auth_service_name:"" ~external_auth_configuration:[] 
 	~license_params:[] ~edition:"free" ~license_server:["address", "localhost"; "port", "27000"]
-	~local_cache_sr:Ref.null ~chipset_info:[]
+	~local_cache_sr:Ref.null ~chipset_info:[] ~virt_hw_vns:Xapi_globs.host_virt_hw_vns
     in ()		
 
 (* TODO cat /proc/stat for btime ? *)
@@ -98,7 +98,6 @@ let refresh_localhost_info ~__context info =
 
     Db.Host.remove_from_other_config ~__context ~self:host ~key:agent_start_key;
     Db.Host.add_to_other_config ~__context ~self:host ~key:agent_start_key ~value:agent_start_time;
-
     (* Register whether we have local storage or not *)
 
     if not (Helpers.local_storage_exists ()) then begin

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -92,6 +92,7 @@ let refresh_localhost_info ~__context info =
 
     Db.Host.remove_from_other_config ~__context ~self:host ~key:boot_time_key;
     Db.Host.add_to_other_config ~__context ~self:host ~key:boot_time_key ~value:boot_time_value;
+    Db.Host.set_virt_hw_vns ~__context ~self:host ~value:Xapi_globs.host_virt_hw_vns;
 
     let agent_start_key = "agent_start_time" in 
     let agent_start_time = string_of_float (Unix.time ()) in

--- a/ocaml/xapi/import_xva.ml
+++ b/ocaml/xapi/import_xva.ml
@@ -90,6 +90,7 @@ let make __context rpc session_id srid (vms, vdis) =
 				~suspend_SR:Ref.null
 				~version:0L
 				~generation_id:""
+				~virt_hw_vn:0L
 			      in
 
                  TaskHelper.operate_on_db_task ~__context

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1639,6 +1639,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					~host_from:(Helpers.LocalObject source_host)
 					~host_to:(Helpers.LocalObject host);
 			end;
+			
+			Xapi_vm_helpers.assert_virt_hw_support
+				~__context
+				~vm:(vm)
+				~host_to:(Helpers.LocalObject host);
+
 			let local_fn = Local.VM.pool_migrate ~vm ~host ~options in
 
 			(* Check that the VM is compatible with the host it is being migrated to. *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -836,5 +836,8 @@ let read_external_config () =
 		D.info "Read global variables successfully from %s" xapi_globs_conf
 	end
 
+(* This parameter means current hardware support Windows PV tool auto upgrade by create a specific PCI device *)
+let win_auto_update_support = 1L
+
 (* This set is used as an indicator to show the hardware virtual platform the current host have *)
-let host_virt_hw_vns = []
+let host_virt_hw_vns = [win_auto_update_support]

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -836,3 +836,5 @@ let read_external_config () =
 		D.info "Read global variables successfully from %s" xapi_globs_conf
 	end
 
+(* This set is used as an indicator to show the hardware virtual platform the current host have *)
+let host_virt_hw_vns = []

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -606,7 +606,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
 	~power_on_config:[]
 	~local_cache_sr
 	~guest_VCPUs_params:[]
-	~virt_hw_vns:[]
+	~virt_hw_vns:Xapi_globs.host_virt_hw_vns
   ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.of_float (Unix.gettimeofday ()));

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -565,7 +565,7 @@ let is_host_alive ~__context ~host =
 	false
   end
 
-let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info =
+let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info ~virt_hw_vns =
 
   let make_new_metrics_object ref =
 	Db.Host_metrics.create ~__context ~ref
@@ -606,6 +606,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
 	~power_on_config:[]
 	~local_cache_sr
 	~guest_VCPUs_params:[]
+	~virt_hw_vns:[]
   ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.of_float (Unix.gettimeofday ()));

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -87,6 +87,7 @@ val create :
   license_server:(string * string) list ->
   local_cache_sr:[ `SR ] Ref.t ->
   chipset_info:(string * string) list ->
+  virt_hw_vns:(int64) list ->
   [ `host ] Ref.t
 val destroy : __context:Context.t -> self:API.ref_host -> unit
 val declare_dead : __context:Context.t -> host:API.ref_host -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -415,7 +415,8 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
 				 * we need an alternative way of preserving the value of the local_cache_sr field, so it's
 				 * been added to the constructor. *)
 				~local_cache_sr
-        ~chipset_info:host.API.host_chipset_info
+        		~chipset_info:host.API.host_chipset_info
+        		~virt_hw_vns:host.API.host_virt_hw_vns
 			in
 
 			(* Copy other-config into newly created host record: *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -194,7 +194,6 @@ let set_xenstore_data ~__context ~self ~value =
 let start ~__context ~vm ~start_paused ~force =
 	let vmr = Db.VM.get_record ~__context ~self:vm in
 	Vgpuops.create_vgpus ~__context (vm, vmr) (Helpers.will_boot_hvm ~__context ~self:vm);
-
 	if vmr.API.vM_ha_restart_priority = Constants.ha_restart
 	then Db.VM.set_ha_always_run ~__context ~self:vm ~value:true;
 
@@ -392,6 +391,7 @@ let create ~__context
 		~suspend_SR
 		~version
 		~generation_id
+		~virt_hw_vn
 		: API.ref_VM =
 	let gen_mac_seed () = Uuid.to_string (Uuid.make_uuid ()) in
 	(* Add random mac_seed if there isn't one specified already *)
@@ -443,6 +443,7 @@ let create ~__context
 		~suspend_SR
 		~version
 		~generation_id
+		~virt_hw_vn
 
 let destroy  ~__context ~self =
 	let parent = Db.VM.get_parent ~__context ~self in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -204,6 +204,8 @@ let start ~__context ~vm ~start_paused ~force =
 	Db.VM.set_guest_metrics ~__context ~self:vm ~value:Ref.null;
 	(try Db.VM_guest_metrics.destroy ~__context ~self:vm_gm with _ -> ());
 
+	Db.VM.set_virt_hw_vn ~__context ~self:vm ~value:(get_vm_virt_hw_vn ~vm_record:vmr);
+
 	(* If the VM has any vGPUs, gpumon must remain stopped until the
 	 * VM has started. *)
 	match vmr.API.vM_VGPUs with

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -150,7 +150,8 @@ val create :
   order:int64 ->
   suspend_SR:[ `SR ] Ref.t ->
   version:int64 ->
-  generation_id:string
+  generation_id:string ->
+  virt_hw_vn:int64
 -> API.ref_VM
 val destroy : __context:Context.t -> self:[ `VM ] Ref.t -> unit
 val clone :

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -330,6 +330,7 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
 		~suspend_SR:Ref.null
 		~version:0L
 		~generation_id
+		~virt_hw_vn:0L
 	;
 
 	(* update the VM's parent field in case of snapshot. Note this must be done after "ref"

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -1041,3 +1041,11 @@ let assert_virt_hw_support ~__context ~vm ~host_to =
 		if not (List.mem vm_virt_hw_vn host_virt_hw_vns) then
 			raise (Api_errors.Server_error (Api_errors.hardware_platform_version_6_5_SP1_required, []))
 	end
+
+let get_vm_virt_hw_vn ~vm_record =
+	let pcipv_enabled =
+		try
+			bool_of_string (List.assoc Xapi_globs.pci_pv_key_name vm_record.API.vM_platform)
+		with _ ->
+			Xapi_globs.default_pci_pv_key_value	in
+	if pcipv_enabled then Xapi_globs.win_auto_update_support else 0L


### PR DESCRIPTION
This pull request include two commits:
1. Add virtual hardware platform infrastructure in XenServer Host. VM migration will be blocked if virtual hardware platform not support.
With this infrastructure, we can add virtual hardware platform information in other feature.
2. Set XenServer virtual hardware platform to 1 as default. Also set virtual hardware platform to VM as 1 if VM enable PCI device for Windows auto update
Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>