### PR TITLE
CP-10125: Pass -gfx_passthru flag down to qemu

### DIFF
--- a/ocaml/test/test_xenopsd_metadata.ml
+++ b/ocaml/test/test_xenopsd_metadata.ml
@@ -42,7 +42,7 @@ let run_builder_of_vm __context =
 	let vms = Db.VM.get_by_name_label ~__context ~label:test_vm_name in
 	let vm = List.nth vms 0 in
 	let vm_record = Db.VM.get_record ~__context ~self:vm in
-	Xapi_xenops.builder_of_vm ~__context ~vm:vm_record "0" false
+	Xapi_xenops.builder_of_vm ~__context (vm, vm_record) "0" false
 
 (* Test the behaviour of the "hvm_serial" other_config/platform key. *)
 module HVMSerial = Generic.Make(Generic.EncapsulateState(struct

--- a/ocaml/test/test_xenopsd_metadata.ml
+++ b/ocaml/test/test_xenopsd_metadata.ml
@@ -127,6 +127,7 @@ module VideoMode = Generic.Make(Generic.EncapsulateState(struct
 			| Vm.Cirrus -> "Cirrus"
 			| Vm.Standard_VGA -> "Standard_VGA"
 			| Vm.Vgpu -> "Vgpu"
+			| Vm.IGD_passthrough -> "IGD_passthrough"
 	end
 
 	module State = XapiDb

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -192,3 +192,18 @@ let unhide_pci ~__context pci =
 	Mutex.execute m (fun () ->
 		_unhide_pci ~__context pci
 	)
+
+(** Return the id of a PCI device *)
+let id_of (id, (domain, bus, dev, fn)) = id
+
+(** Return the domain of a PCI device *)
+let domain_of (id, (domain, bus, dev, fn)) = domain
+
+(** Return the bus of a PCI device *)
+let bus_of (id, (domain, bus, dev, fn)) = bus
+
+(** Return the device of a PCI device *)
+let dev_of (id, (domain, bus, dev, fn)) = dev
+
+(** Return the function of a PCI device *)
+let fn_of (id, (domain, bus, dev, fn)) = fn

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -54,3 +54,18 @@ val hide_pci: __context:Context.t -> [ `PCI ] Ref.t -> unit
 
 (** Unhide a PCI device from the dom0 kernel. (Takes affect after next boot.) *)
 val unhide_pci: __context:Context.t -> [ `PCI ] Ref.t -> unit
+
+(** Return the id of a PCI device *)
+val id_of: (int * (int * int * int * int)) -> int
+
+(** Return the domain of a PCI device *)
+val domain_of: (int * (int * int * int * int)) -> int
+
+(** Return the bus of a PCI device *)
+val bus_of: (int * (int * int * int * int)) -> int
+
+(** Return the device of a PCI device *)
+val dev_of: (int * (int * int * int * int)) -> int
+
+(** Return the function of a PCI device *)
+val fn_of: (int * (int * int * int * int)) -> int

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -117,3 +117,8 @@ let get_host_pcis pci_db =
 	link_related_pcis [] pcis
 
 let is_hidden_from_dom0 pci = true
+
+let igd_is_whitelisted ~__context pci =
+	let vendor_id = Db.PCI.get_vendor_id ~__context ~self:pci in
+	List.mem vendor_id !Xapi_globs.igd_passthru_vendor_whitelist
+

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -56,14 +56,10 @@ let update_gpus ~__context ~host =
 	let rec find_or_create cur = function
 		| [] -> cur
 		| pci :: remaining_pcis ->
-			let igd_is_whitelisted pci =
-				let vendor_id = Db.PCI.get_vendor_id ~__context ~self:pci in
-				List.mem vendor_id !Xapi_globs.igd_passthru_vendor_whitelist
-			in
 			let supported_VGPU_types =
 				let pci_addr =  Db.PCI.get_pci_id ~__context ~self:pci in
 				if system_display_device = (Some pci_addr)
-				&& not (Xapi_pci_helpers.is_hidden_from_dom0 pci && igd_is_whitelisted pci)
+				&& not Xapi_pci_helpers.(is_hidden_from_dom0 pci && igd_is_whitelisted ~__context pci)
 				then []
 				else Xapi_vgpu_type.find_or_create_supported_types ~__context ~pci_db pci
 			in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -282,7 +282,7 @@ let is_boot_file_whitelisted filename =
 		(* avoid ..-style attacks and other weird things *)
 	&&(safe_str filename)
 
-let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
+let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough =
 	let open Vm in
 
 	let video_mode =
@@ -644,7 +644,7 @@ module MD = struct
 			xsdata = vm.API.vM_xenstore_data;
 			platformdata = platformdata;
 			bios_strings = vm.API.vM_bios_strings;
-			ty = builder_of_vm ~__context ~vm timeoffset pci_passthrough;
+			ty = builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough;
 			suppress_spurious_page_faults = (try List.assoc "suppress-spurious-page-faults" vm.API.vM_other_config = "true" with _ -> false);
 			machine_address_size = (try Some(int_of_string (List.assoc "machine-address-size" vm.API.vM_other_config)) with _ -> None);
 			memory_static_max = vm.API.vM_memory_static_max;

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -297,8 +297,6 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough =
 		List.exists (Xapi_pci_helpers.igd_is_whitelisted ~__context) pci_refs
 	in 
 
-        let igd_is_on_bus_zero (_, (_, bus, _, _)) = bus = 0 in
-
 	let video_mode =
 		(* If the vgpu keys are present for this VM, this overrides
 		 * the value of platform:vgpu. *)
@@ -306,7 +304,7 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough =
 			&& (List.mem_assoc Platform.vgpu_config vm.API.vM_platform)
 		then Vgpu
 		else if List.exists 
-			(fun x -> igd_is_on_bus_zero x && igd_is_whitelisted x) 
+			(fun pci -> Pciops.bus_of pci = 0 && igd_is_whitelisted pci) 
 			(Vgpuops.list_pcis_for_passthrough ~__context ~vm:vmref) 
 		then IGD_passthrough
 		else

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -291,12 +291,10 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough =
 		let open Db_filter_types in
 		let target_pci_id = 
 			Printf.sprintf "%04x:%02x:%02x.%01x" domain bus dev fn in
-		match Db.PCI.get_refs_where ~__context
+		let pci_refs = Db.PCI.get_refs_where ~__context
                 	~expr:(And (Eq (Field "host", Literal (Ref.string_of localhost)),
-				(Eq (Field "pci_id", Literal target_pci_id)))) with
-		| pci_ref :: _ -> 
-			Xapi_pci_helpers.igd_is_whitelisted ~__context pci_ref
-		| _ -> false
+				(Eq (Field "pci_id", Literal target_pci_id)))) in
+		List.exists (Xapi_pci_helpers.igd_is_whitelisted ~__context) pci_refs
 	in 
 
         let igd_is_on_bus_zero (_, (_, bus, _, _)) = bus = 0 in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -288,8 +288,7 @@ let builder_of_vm ~__context ~vm timeoffset pci_passthrough =
 	let video_mode =
 		(* If the vgpu keys are present for this VM, this overrides
 		 * the value of platform:vgpu. *)
-		if true
-			&& (List.mem_assoc Platform.vgpu_pci_id vm.API.vM_platform)
+		if (List.mem_assoc Platform.vgpu_pci_id vm.API.vM_platform)
 			&& (List.mem_assoc Platform.vgpu_config vm.API.vM_platform)
 		then Vgpu
 		else


### PR DESCRIPTION
Ensure that qemu is started with the -gfx_passthru flag when an
appropriate integrated GPU is available.   The logic is explained in
the following design document:

   http://xapi-project.github.io/features/futures/integrated-gpu-passthrough.html