### PR TITLE
Refactor Pciops

### DIFF
--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -91,7 +91,7 @@ let pcidev_of_pci ~__context pci =
 let sort_pcidevs devs =
 	let ids = List.sort compare (Listext.List.setify (List.map fst devs)) in
 	List.flatten (List.map (fun id ->
-		List.map snd (List.filter (fun (x, _) -> x = id) devs)
+		List.filter (fun (x, _) -> x = id) devs
 	) ids)
 
 let of_string dev =

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -90,9 +90,9 @@ let pcidev_of_pci ~__context pci =
    multiple PCI buses anyway. We reinterpret the 'n' to be a hotplug ordering *)
 let sort_pcidevs devs =
 	let ids = List.sort compare (Listext.List.setify (List.map fst devs)) in
-	List.map (fun id ->
+	List.flatten (List.map (fun id ->
 		List.map snd (List.filter (fun (x, _) -> x = id) devs)
-	) ids
+	) ids)
 
 let of_string dev =
 	Scanf.sscanf dev slash_bdf_scan_fmt (fun id a b c d -> (id, (a, b, c, d)))

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -91,7 +91,7 @@ let pcidev_of_pci ~__context pci =
 let sort_pcidevs devs =
 	let ids = List.sort compare (Listext.List.setify (List.map fst devs)) in
 	List.map (fun id ->
-		id, (List.map snd (List.filter (fun (x, _) -> x = id) devs))
+		List.map snd (List.filter (fun (x, _) -> x = id) devs)
 	) ids
 
 let of_string dev =

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -74,12 +74,10 @@ let unassign_all_for_vm ~__context vm =
 	List.iter (fun self -> Db.PCI.remove_attached_VMs ~__context ~self ~value:vm) pcis
 
 (* http://wiki.xen.org/wiki/Bus:Device.Function_%28BDF%29_Notation *)
-(* It might be possible to refactor this but attempts so far have failed. *)
-let bdf_fmt            = format_of_string    "%04x:%02x:%02x.%01x"
-let slash_bdf_scan_fmt = format_of_string "%d/%04x:%02x:%02x.%01x"
-let slash_bdf_prnt_fmt = format_of_string "%d/%04x:%02x:%02x.%01x"
-let bdf_paren_prnt_fmt = format_of_string   "(%04x:%02x:%02x.%01x)"
-let bdf_paren_scan_fmt = format_of_string   "(%04x:%02x:%02x.%01x)"
+(* http://stackoverflow.com/questions/25025091/ocaml-formatters-and-value-restriction *)
+let bdf_fmt : ('a, 'b, 'c, 'd, 'e, 'f) format6       = "%04x:%02x:%02x.%01x"
+let slash_bdf_fmt : ('a, 'b, 'c, 'd, 'e, 'f) format6 = "%d/%04x:%02x:%02x.%01x"
+let bdf_paren_fmt : ('a, 'b, 'c, 'd, 'e, 'f) format6 = "(%04x:%02x:%02x.%01x)"
 
 let pcidev_of_pci ~__context pci =
 	let bdf_str = Db.PCI.get_pci_id ~__context ~self:pci in
@@ -95,10 +93,10 @@ let sort_pcidevs devs =
 	) ids)
 
 let of_string dev =
-	Scanf.sscanf dev slash_bdf_scan_fmt (fun id a b c d -> (id, (a, b, c, d)))
+	Scanf.sscanf dev slash_bdf_fmt (fun id a b c d -> (id, (a, b, c, d)))
 
 let to_string (id, (a, b, c, d)) =
-	Printf.sprintf slash_bdf_prnt_fmt id a b c d
+	Printf.sprintf slash_bdf_fmt id a b c d
 
 let other_pcidevs_of_vm ~__context other_config =
 	let devs =
@@ -135,7 +133,7 @@ let get_hidden_pcidevs () =
 			| "" -> devs
 			| _ -> (
 				let dev = Scanf.sscanf
-					raw bdf_paren_scan_fmt (fun a b c d -> (a, b, c, d)) in
+					raw bdf_paren_fmt (fun a b c d -> (a, b, c, d)) in
 				read_dev (dev::devs) (String.sub_to_end raw paren_len)
 			)
 	in
@@ -154,7 +152,7 @@ let is_pci_hidden ~__context pci =
 let _hide_pci ~__context pci =
 	if not (is_pci_hidden ~__context pci) then (
 		let paren_of (a, b, c, d) = (
-			Printf.sprintf bdf_paren_prnt_fmt a b c d
+			Printf.sprintf bdf_paren_fmt a b c d
 		) in
 		let p = pcidev_of_pci ~__context pci in
 		let devs = p::(get_hidden_pcidevs ()) in

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -34,7 +34,7 @@ val unassign_all_for_vm : __context:Context.t -> [ `VM ] Ref.t -> unit
 val pcidev_of_pci: __context:Context.t -> API.ref_PCI -> (int * int * int * int)
 
 (** Return a list of PCIdevs in plug order *)
-val sort_pcidevs: ('a * 'b) list -> 'b list list
+val sort_pcidevs: ('a * 'b) list -> 'b list
 
 (** Return the PCI devices that are specified in the VM.other_config:pci field. *)
 val other_pcidevs_of_vm :

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -34,7 +34,7 @@ val unassign_all_for_vm : __context:Context.t -> [ `VM ] Ref.t -> unit
 val pcidev_of_pci: __context:Context.t -> API.ref_PCI -> (int * int * int * int)
 
 (** Return a list of PCIdevs in plug order *)
-val sort_pcidevs: ('a * 'b) list -> ('a * 'b list) list
+val sort_pcidevs: ('a * 'b) list -> 'b list list
 
 (** Return the PCI devices that are specified in the VM.other_config:pci field. *)
 val other_pcidevs_of_vm :

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -34,7 +34,7 @@ val unassign_all_for_vm : __context:Context.t -> [ `VM ] Ref.t -> unit
 val pcidev_of_pci: __context:Context.t -> API.ref_PCI -> (int * int * int * int)
 
 (** Return a list of PCIdevs in plug order *)
-val sort_pcidevs: ('a * 'b) list -> 'b list
+val sort_pcidevs: (int * (int * int * int * int)) list -> (int * (int * int * int * int)) list
 
 (** Return the PCI devices that are specified in the VM.other_config:pci field. *)
 val other_pcidevs_of_vm :

--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -98,7 +98,7 @@ let add_pcis_to_vm ~__context vm passthru_vgpus =
 		(List.map (fun pci -> Db.PCI.get_dependencies ~__context ~self:pci) pcis)) in
 	let devs : (int * int * int * int) list = List.sort compare (List.map (Pciops.pcidev_of_pci ~__context) (pcis @ dependent_pcis)) in
 	(* Add a hotplug ordering (see pcidevs_of_pci) *)
-	let devs : ((int * (int * int * int * int))) list = List.rev (snd (List.fold_left (fun (i, acc) pci -> i + 1, (i, pci) :: acc) (0, []) devs)) in
+	let devs : ((int * (int * int * int * int))) list = List.mapi (fun i pci -> i, pci) devs in
 	(* Update VM other_config for PCI passthrough *)
 	(try Db.VM.remove_from_other_config ~__context ~self:vm ~key:Xapi_globs.vgpu_pci with _ -> ());
 	let value = String.concat "," (List.map Pciops.to_string devs) in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -532,12 +532,12 @@ module MD = struct
 
 	let pcis_of_vm ~__context (vmref, vm) =
 		let vgpu_pcidevs = Vgpuops.list_pcis_for_passthrough ~__context ~vm:vmref in
-		let devs = List.flatten (List.map (fun (_, dev) -> dev) (Pciops.sort_pcidevs vgpu_pcidevs)) in
+		let devs = List.flatten (Pciops.sort_pcidevs vgpu_pcidevs) in
 
 		(* The 'unmanaged' PCI devices are in the other_config key: *)
 		let other_pcidevs = Pciops.other_pcidevs_of_vm ~__context vm.API.vM_other_config in
 
-		let unmanaged = List.flatten (List.map (fun (_, dev) -> dev) (Pciops.sort_pcidevs other_pcidevs)) in
+		let unmanaged = List.flatten (Pciops.sort_pcidevs other_pcidevs) in
 
 		let devs = devs @ unmanaged in
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -532,12 +532,11 @@ module MD = struct
 
 	let pcis_of_vm ~__context (vmref, vm) =
 		let vgpu_pcidevs = Vgpuops.list_pcis_for_passthrough ~__context ~vm:vmref in
-		let devs = List.flatten (Pciops.sort_pcidevs vgpu_pcidevs) in
+		let devs = Pciops.sort_pcidevs vgpu_pcidevs in
 
 		(* The 'unmanaged' PCI devices are in the other_config key: *)
 		let other_pcidevs = Pciops.other_pcidevs_of_vm ~__context vm.API.vM_other_config in
-
-		let unmanaged = List.flatten (Pciops.sort_pcidevs other_pcidevs) in
+		let unmanaged = Pciops.sort_pcidevs other_pcidevs in
 
 		let devs = devs @ unmanaged in
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -542,7 +542,7 @@ module MD = struct
 
 		let open Pci in
 		List.mapi
-			(fun idx (domain, bus, dev, fn) -> {
+			(fun idx (_, (domain, bus, dev, fn)) -> {
 				id = (vm.API.vM_uuid, Printf.sprintf "%04x:%02x:%02x.%01x" domain bus dev fn);
 				position = idx;
 				domain = domain;

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -541,8 +541,8 @@ module MD = struct
 		let devs = devs @ unmanaged in
 
 		let open Pci in
-		List.map
-			(fun (idx, (domain, bus, dev, fn)) -> {
+		List.mapi
+			(fun idx (domain, bus, dev, fn) -> {
 				id = (vm.API.vM_uuid, Printf.sprintf "%04x:%02x:%02x.%01x" domain bus dev fn);
 				position = idx;
 				domain = domain;
@@ -552,7 +552,7 @@ module MD = struct
 				msitranslate = None;
 				power_mgmt = None;
 			})
-			(List.combine (Range.to_list (Range.make 0 (List.length devs))) devs)
+			devs
 
 	let of_vm ~__context (vmref, vm) vbds pci_passthrough =
 		let on_crash_behaviour = function


### PR DESCRIPTION
* Use List.mapi to renumber lists of devices where possible
* Remove unnecessary mismatches between the return types of utility functions and the code which uses them
* Remove duplicated PCI ID format strings added to work around the value restriction

To come: Make the pcidev type abstract