### PR TITLE
Backport patches for fixing VDI upload

### DIFF
--- a/ocaml/xapi/import_raw_vdi.ml
+++ b/ocaml/xapi/import_raw_vdi.ml
@@ -59,8 +59,8 @@ let localhost_handler rpc session_id vdi (req: Request.t) (s: Unix.file_descr) =
 										content_type ] in
 									Http_svr.headers s headers;
 									if chunked
-									then Vhd_tool_wrapper.receive (Vhd_tool_wrapper.update_task_progress __context) "raw" "chunked" s path "" prezeroed
-									else Vhd_tool_wrapper.receive (Vhd_tool_wrapper.update_task_progress __context) (Importexport.Format.to_string format) "none" s path "" prezeroed
+									then Vhd_tool_wrapper.receive (Vhd_tool_wrapper.update_task_progress __context) "raw" "chunked" s None path "" prezeroed
+									else Vhd_tool_wrapper.receive (Vhd_tool_wrapper.update_task_progress __context) (Importexport.Format.to_string format) "none" s req.Request.content_length path "" prezeroed
 								);
 						TaskHelper.complete ~__context [];
 				with e ->

--- a/ocaml/xapi/vhd_tool_wrapper.ml
+++ b/ocaml/xapi/vhd_tool_wrapper.ml
@@ -63,7 +63,7 @@ let run_vhd_tool progress_cb args s s' path =
     | Failure(out, e) -> error "vhd-tool output: %s" out; raise e
   ) (fun () -> close pipe_read; close pipe_write)
 
-let receive progress_cb format protocol (s: Unix.file_descr) (path: string) (prefix: string) (prezeroed: bool) =
+let receive progress_cb format protocol (s: Unix.file_descr) (length: int64 option) (path: string) (prefix: string) (prezeroed: bool) =
   let s' = Uuid.(to_string (make_uuid ())) in
   let args = [ "serve";
                "--source-format"; format;
@@ -75,7 +75,11 @@ let receive progress_cb format protocol (s: Unix.file_descr) (path: string) (pre
                "--progress";
                "--machine";
                "--direct";
-             ] @ (if prezeroed then [ "--prezeroed" ] else []) in
+             ] @
+             (match length with
+              | Some x -> [ "--destination-size"; Int64.to_string x ]
+              | None -> []) @
+             (if prezeroed then [ "--prezeroed" ] else []) in
   run_vhd_tool progress_cb args s s' path
 
 open Fun

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -112,10 +112,6 @@ let create  ~__context ~vM ~vDI ~userdevice ~bootable ~mode ~_type ~unpluggable 
 	if _type <> `CD && empty
 	then raise (Api_errors.Server_error(Api_errors.vbd_not_removable_media, [ "in constructor" ]));
 
-	(* Prevent VBDs being created which are of type "CD" which are
-	   not either .iso files or CD block devices *)
-	if _type = `CD && not(empty)
-	then Xapi_vdi_helpers.assert_vdi_is_valid_iso ~__context ~vdi:vDI;
 	(* Prevent RW VBDs being created pointing to RO VDIs *)
 	if mode = `RW && Db.VDI.get_read_only ~__context ~self:vDI
 	then raise (Api_errors.Server_error(Api_errors.vdi_readonly, [ Ref.string_of vDI ]));
@@ -217,7 +213,6 @@ let assert_ok_to_insert ~__context ~vbd ~vdi =
     assert_not_suspended ~__context ~vm;
     assert_removable ~__context ~vbd;
     assert_empty ~__context ~vbd;
-	Xapi_vdi_helpers.assert_vdi_is_valid_iso ~__context ~vdi;
     Xapi_vdi_helpers.assert_managed ~__context ~vdi;
 	assert_doesnt_make_vm_non_agile ~__context ~vm ~vdi
 

--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -23,14 +23,6 @@ open Threadext
 module D=Debug.Debugger(struct let name="xapi" end)
 open D
 
-(* We only support .iso files (from an iso SR) and block devices from
-   a local magic SR (eg /dev/hda) but NOT phantom_vbd block attach isos *)
-let assert_vdi_is_valid_iso ~__context ~vdi = 
-	let sr = Db.VDI.get_SR ~__context ~self:vdi in
-	let ct = Db.SR.get_content_type ~__context ~self:sr in
-	if ct <> "iso"
-	then raise (Api_errors.Server_error(Api_errors.vdi_is_not_iso, [ Ref.string_of vdi; ct ]))
-
 (* CA-26514: Block operations on 'unmanaged' VDIs *)
 let assert_managed ~__context ~vdi = 
   if not (Db.VDI.get_managed ~__context ~self:vdi)


### PR DESCRIPTION
Several fixes for XAPI's `import_raw_vdi` call were made on trunk that would be worth backporting to enable Packer/Supp pack integration.