### PR TITLE
Backporting patches for floppy support

### DIFF
--- a/ocaml/client_records/record_util.ml
+++ b/ocaml/client_records/record_util.ml
@@ -324,6 +324,7 @@ let string_to_vbd_type s =
 	match String.lowercase s with
 		| "cd" -> `CD
 		| "disk" -> `Disk
+		| "floppy" -> `Floppy
 		| _ -> raise (Record_failure ("Expected 'CD' or 'Disk', got "^s))
 
 let power_to_string h =

--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -1158,7 +1158,7 @@ let vbd_record rpc session_id vbd =
       ~set:(fun boot -> Client.VBD.set_bootable rpc session_id vbd (safe_bool_of_string "bootable" boot)) ();
     make_field ~name:"mode" ~get:(fun () -> match (x ()).API.vBD_mode with `RO -> "RO" | `RW -> "RW") 
       ~set:(fun mode -> Client.VBD.set_mode rpc session_id vbd (Record_util.string_to_vbd_mode mode)) ();
-    make_field ~name:"type" ~get:(fun () -> match (x ()).API.vBD_type with `CD -> "CD" | `Disk -> "Disk")
+    make_field ~name:"type" ~get:(fun () -> match (x ()).API.vBD_type with `CD -> "CD" | `Disk -> "Disk" | `Floppy -> "Floppy")
       ~set:(fun ty -> Client.VBD.set_type rpc session_id vbd (Record_util.string_to_vbd_type ty)) ();
     make_field ~name:"unpluggable" ~get:(fun () -> string_of_bool (x ()).API.vBD_unpluggable)
       ~set:(fun unpluggable -> Client.VBD.set_unpluggable rpc session_id vbd (safe_bool_of_string "unpluggable" unpluggable)) ();

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5721,7 +5721,8 @@ let vbd_mode = Enum ("vbd_mode", [ "RO", "only read-only access will be allowed"
 
 let vbd_type = Enum ("vbd_type",
 		     [ "CD", "VBD will appear to guest as CD"; 
-		       "Disk", "VBD will appear to guest as disk" ])
+		       "Disk", "VBD will appear to guest as disk";
+                       "Floppy", "VBD will appear as a floppy"])
 
 let vbd_operations =
   Enum ("vbd_operations", 

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -811,7 +811,7 @@ module VBD : HandlerTools = struct
 
 			let vbd_record = { vbd_record with API.vBD_VM = vm } in
 			match vbd_record.API.vBD_type, exists vbd_record.API.vBD_VDI state.table with
-			| `CD, false ->
+			| `CD, false | `Floppy, false  ->
 				if original_vm.API.vM_power_state <> `Suspended then
 					Create { vbd_record with API.vBD_VDI = Ref.null; API.vBD_empty = true }  (* eject *)
 				else

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -133,7 +133,7 @@ let create  ~__context ~vM ~vDI ~userdevice ~bootable ~mode ~_type ~unpluggable 
 	| _ ->
 
 	Mutex.execute autodetect_mutex (fun () ->
-		let possibilities = Xapi_vm_helpers.allowed_VBD_devices ~__context ~vm:vM in
+		let possibilities = Xapi_vm_helpers.allowed_VBD_devices ~__context ~vm:vM ~_type in
 
 		if not (valid_device userdevice) || (userdevice = "autodetect" && possibilities = []) then
 			raise (Api_errors.Server_error (Api_errors.invalid_device,[userdevice]));
@@ -141,7 +141,10 @@ let create  ~__context ~vM ~vDI ~userdevice ~bootable ~mode ~_type ~unpluggable 
 		(* Resolve the "autodetect" into a fixed device name now *)
 		let userdevice =
 			if userdevice = "autodetect"
-			then string_of_int (Device_number.to_disk_number (List.hd possibilities)) (* already checked for [] above *)
+			then match _type with
+				 (* already checked for [] above *)
+				 | `Floppy -> Device_number.to_linux_device (List.hd possibilities)
+				 | `CD | `Disk -> string_of_int (Device_number.to_disk_number (List.hd possibilities))
 			else userdevice
 		in
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -721,7 +721,7 @@ let get_possible_hosts ~__context ~vm =
 	let snapshot = Db.VM.get_record ~__context ~self:vm in
 	get_possible_hosts_for_vm ~__context ~vm ~snapshot
 
-let get_allowed_VBD_devices ~__context ~vm = List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (allowed_VBD_devices ~__context ~vm)
+let get_allowed_VBD_devices ~__context ~vm = List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (allowed_VBD_devices ~__context ~vm ~_type:`Disk)
 let get_allowed_VIF_devices = allowed_VIF_devices
 
 (** Mark all currently-attached VBDs and VIFs as reserved, call some function and then

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -803,6 +803,7 @@ let allowed_VBD_devices_HVM            = vbd_inclusive_range true 0 3
 let allowed_VBD_devices_HVM_PP         = vbd_inclusive_range true 0 15
 let allowed_VBD_devices_PV             = vbd_inclusive_range false 0 15
 let allowed_VBD_devices_control_domain = vbd_inclusive_range false 0 255
+let allowed_VBD_devices_HVM_floppy     = List.map (fun x -> Device_number.make (Device_number.Floppy, x, 0)) (inclusive_range 0 1)
 
 let allowed_VIF_devices_HVM    = vif_inclusive_range 0 3
 let allowed_VIF_devices_HVM_PP = vif_inclusive_range 0 6
@@ -827,7 +828,7 @@ let all_used_VBD_devices ~__context ~self =
 
 	List.concat (List.map possible_VBD_devices_of_string existing_devices)
 
-let allowed_VBD_devices ~__context ~vm =
+let allowed_VBD_devices ~__context ~vm ~_type =
 	let is_hvm = Helpers.will_boot_hvm ~__context ~self:vm in
 	let is_control_domain = Db.VM.get_is_control_domain ~__context ~self:vm in
 	let is_pp =
@@ -835,11 +836,13 @@ let allowed_VBD_devices ~__context ~vm =
 			let guest_metrics = Db.VM.get_guest_metrics ~__context ~self:vm in
 			(Db.VM_guest_metrics.get_PV_drivers_version ~__context ~self:guest_metrics) <> []
 		with _ -> false in
-	let all_devices = match is_hvm,is_pp,is_control_domain with
-		| false, _, true  -> allowed_VBD_devices_control_domain
-		| false, _, false -> allowed_VBD_devices_PV
-		| true, false, _  -> allowed_VBD_devices_HVM
-		| true, true, _   -> allowed_VBD_devices_HVM_PP
+	let all_devices = match is_hvm,is_pp,is_control_domain,_type with
+		| true, _, _, `Floppy  -> allowed_VBD_devices_HVM_floppy
+		| false, _, _, `Floppy -> [] (* floppy is not supported on PV *)
+		| false, _, true, _    -> allowed_VBD_devices_control_domain
+		| false, _, false, _   -> allowed_VBD_devices_PV
+		| true, false, _, _    -> allowed_VBD_devices_HVM
+		| true, true, _, _     -> allowed_VBD_devices_HVM_PP
 	in
 	(* Filter out those we've already got VBDs for *)
 	let used_devices = all_used_VBD_devices ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -803,7 +803,7 @@ let allowed_VBD_devices_HVM            = vbd_inclusive_range true 0 3
 let allowed_VBD_devices_HVM_PP         = vbd_inclusive_range true 0 15
 let allowed_VBD_devices_PV             = vbd_inclusive_range false 0 15
 let allowed_VBD_devices_control_domain = vbd_inclusive_range false 0 255
-let allowed_VBD_devices_HVM_floppy     = List.map (fun x -> Device_number.make (Device_number.Floppy, x, 0)) (inclusive_range 0 1)
+let allowed_VBD_devices_HVM_floppy     = List.map (fun x -> Device_number.make (Device_number.FloppyBus, x, 0)) (inclusive_range 0 1)
 
 let allowed_VIF_devices_HVM    = vif_inclusive_range 0 3
 let allowed_VIF_devices_HVM_PP = vif_inclusive_range 0 6

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1243,9 +1243,17 @@ let update_vbd ~__context (id: (string * string)) =
 					let vbds = Db.VM.get_VBDs ~__context ~self:vm in
 					let vbdrs = List.map (fun self -> self, Db.VBD.get_record ~__context ~self) vbds in
 					let linux_device = snd id in
-					let disk_number = Device_number.of_linux_device (snd id) |> Device_number.to_disk_number |> string_of_int in
+					let device_number = Device_number.of_linux_device linux_device in
+					(* only try matching against disk number if the device is not a floppy (as "0" shouldn't match "fda") *)
+					let disk_number =
+						match Device_number.spec device_number with
+							| (Device_number.Ide,_,_)
+							| (Device_number.Xen,_,_) -> Some (device_number |> Device_number.to_disk_number |> string_of_int)
+							| _ -> None in
 					debug "VM %s VBD userdevices = [ %s ]" (fst id) (String.concat "; " (List.map (fun (_,r) -> r.API.vBD_userdevice) vbdrs));
-					let vbd, vbd_r = List.find (fun (_, vbdr) -> vbdr.API.vBD_userdevice = linux_device || vbdr.API.vBD_userdevice = disk_number) vbdrs in
+					let vbd, vbd_r = List.find (fun (_, vbdr) -> vbdr.API.vBD_userdevice = linux_device || 
+																(Opt.is_some disk_number && vbdr.API.vBD_userdevice = Opt.unbox disk_number)) vbdrs in
+					debug "VBD %s.%s matched device %s" (fst id) (snd id) vbd_r.API.vBD_userdevice;
 					Opt.iter
 						(fun (vb, state) ->
 							let currently_attached = state.plugged || state.active in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -386,7 +386,10 @@ module MD = struct
 			position = Some device_number;
 			mode = if vbd.API.vBD_mode = `RO then ReadOnly else ReadWrite;
 			backend = disk_of_vdi ~__context ~self:vbd.API.vBD_VDI;
-			ty = if vbd.API.vBD_type = `Disk then Disk else CDROM;
+			ty = (match vbd.API.vBD_type with
+				| `Disk -> Disk
+				| `CD -> CDROM
+				| `Floppy -> Floppy);
 			unpluggable = vbd.API.vBD_unpluggable;
 			extra_backend_keys = backend_kind_keys;
 			extra_private_keys = [];

--- a/ocaml/xenops-cli/xn.ml
+++ b/ocaml/xenops-cli/xn.ml
@@ -152,6 +152,7 @@ let print_disk vbd =
 		| Vbd.ReadWrite -> "w" in
 	let ty = match vbd.Vbd.ty with
 		| Vbd.CDROM -> ":cdrom"
+        | Vbd.Floppy -> ":floppy"
 		| Vbd.Disk -> "" in
 	let source = print_source vbd.Vbd.backend in
 	Printf.sprintf "%s,%s%s,%s" source device_number ty mode
@@ -193,6 +194,7 @@ let print_disk vbd =
 		| Vbd.ReadWrite -> "w" in
 	let ty = match vbd.Vbd.ty with
 		| Vbd.CDROM -> ":cdrom"
+        | Vbd.Floppy -> ":floppy"
 		| Vbd.Disk -> "" in
 	let source = print_source vbd.Vbd.backend in
 	Printf.sprintf "%s,%s%s,%s" source device_number ty mode
@@ -548,7 +550,11 @@ let vbd_list x =
 			let id = snd vbd.Vbd.id in
 			let position = Opt.default "None" (Opt.map Device_number.to_linux_device vbd.Vbd.position) in
 			let mode = if vbd.Vbd.mode = Vbd.ReadOnly then "RO" else "RW" in
-			let ty = match vbd.Vbd.ty with Vbd.CDROM -> "CDROM" | Vbd.Disk -> "HDD" in
+			let ty = match vbd.Vbd.ty with 
+                | Vbd.CDROM -> "CDROM" 
+                | Vbd.Floppy -> "Floppy"
+                | Vbd.Disk -> "HDD" 
+            in
 			let plugged = if state.Vbd.plugged then "X" else " " in
 			let disk = Opt.default "" (Opt.map (function
 				| Local x -> x |> trim 32

--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -339,15 +339,17 @@ let physty_of_string s =
 	| "file" -> File
 	| _      -> invalid_arg "physty_of_string"
 
-type devty = CDROM | Disk
+type devty = CDROM | Disk | Floppy
 
 let string_of_devty = function
 	| CDROM -> "cdrom"
 	| Disk  -> "disk"
+    | Floppy -> "floppy"
 
 let devty_of_string = function
 	| "cdrom" -> CDROM
 	| "disk"  -> Disk
+    | "floppy" -> Floppy
 	| _       -> invalid_arg "devty_of_string"
 
 let add_backend_keys ~xs (x: device) subdir keys =

--- a/ocaml/xenops/device.ml
+++ b/ocaml/xenops/device.ml
@@ -524,7 +524,10 @@ let add_async ~xs ~hvm x domid =
 		"backend-id", string_of_int x.backend_domid;
 		"state", string_of_int (Xenbus_utils.int_of Xenbus_utils.Initialising);
 		"virtual-device", string_of_int devid;
-		"device-type", if x.dev_type = CDROM then "cdrom" else "disk";
+        "device-type", match x.dev_type with
+            | CDROM  -> "cdrom"
+            | Disk   -> "disk"
+            | Floppy -> "floppy";
 	];
 	Hashtbl.add_list back_tbl [
 		"frontend-id", sprintf "%u" domid;

--- a/ocaml/xenops/device.mli
+++ b/ocaml/xenops/device.mli
@@ -40,7 +40,7 @@ sig
 	val physty_of_string : string -> physty
 	val uses_blktap : phystype:physty -> bool
 
-	type devty = CDROM | Disk
+	type devty = CDROM | Disk | Floppy
 	val string_of_devty : devty -> string
 	val devty_of_string : string -> devty
 

--- a/ocaml/xenops/device_number.ml
+++ b/ocaml/xenops/device_number.ml
@@ -1,6 +1,7 @@
 type bus_type =
 	| Xen 
 	| Scsi
+    | Floppy
 	| Ide
 with rpc
 
@@ -9,9 +10,10 @@ type spec = bus_type * int * int with rpc
 type t = spec with rpc
 
 let to_debug_string = function
-	| (Xen, disk, partition)  -> Printf.sprintf "Xen(%d, %d)"  disk partition
-	| (Scsi, disk, partition) -> Printf.sprintf "Scsi(%d, %d)" disk partition
-	| (Ide, disk, partition)  -> Printf.sprintf "Ide(%d, %d)"  disk partition
+	| (Xen,    disk, partition)  -> Printf.sprintf "Xen(%d, %d)"  disk partition
+	| (Scsi,   disk, partition) -> Printf.sprintf "Scsi(%d, %d)" disk partition
+    | (Floppy, disk, partition) -> Printf.sprintf "Floppy(%d, %d)" disk partition
+	| (Ide,    disk, partition)  -> Printf.sprintf "Ide(%d, %d)"  disk partition
 
 (* ocamlp4-friendly operators *)
 let (<|) = (lsl)
@@ -26,15 +28,17 @@ let make (x: spec) : t =
 	let max_xen = ((1 <| 20) - 1), 15 in
 	let max_scsi = 15, 15 in
 	let max_ide = if use_deprecated_ide_encoding then 19, 63 else 3, 63 in
+    let max_floppy = 2, 0 in
 	let assert_in_range description (disk_limit, partition_limit) (disk, partition) = 
 		if disk < 0 || (disk > disk_limit) 
 		then failwith (Printf.sprintf "%s disk number out of range 0 <= %d <= %d" description disk disk_limit);
 		if partition < 0 || partition > partition_limit 
 		then failwith (Printf.sprintf "%s partition number out of range 0 <= %d <= %d" description partition partition_limit) in
 	begin match x with
-		| Xen, disk, partition -> assert_in_range "xen" max_xen (disk, partition)
-		| Scsi, disk, partition -> assert_in_range "scsi" max_scsi (disk, partition)
-		| Ide, disk, partition -> assert_in_range "ide" max_ide (disk, partition)
+		| Xen,    disk, partition -> assert_in_range "xen" max_xen (disk, partition)
+		| Scsi,   disk, partition -> assert_in_range "scsi" max_scsi (disk, partition)
+        | Floppy, disk, partition -> assert_in_range "floppy" max_floppy (disk, partition)
+		| Ide,    disk, partition -> assert_in_range "ide" max_ide (disk, partition)
 	end;
 	x
 
@@ -46,10 +50,11 @@ let standard_ide_table = [ 3; 22 ]
 let deprecated_ide_table = standard_ide_table @ [ 33; 34; 56; 57; 88; 89; 90; 91 ]
 
 let to_xenstore_int = function
-	| Xen, disk, partition when disk < 16 -> (202 <| 8) || (disk <| 4)       || partition
-	| Xen, disk, partition                -> (1 <| 28)  || (disk <| 8)       || partition
-	| Scsi, disk, partition               -> (8 <| 8)   || (disk <| 4)       || partition
-	| Ide, disk, partition                ->
+	| Xen,    disk, partition when disk < 16 -> (202 <| 8) || (disk <| 4)       || partition
+	| Xen,    disk, partition                -> (1 <| 28)  || (disk <| 8)       || partition
+	| Scsi,   disk, partition               -> (8 <| 8)   || (disk <| 4)       || partition
+    | Floppy, disk, partition               -> (203 <| 8) || (disk <| 4)       || partition
+	| Ide,    disk, partition                ->
 		let m = List.nth deprecated_ide_table (disk / 2) in
 		let n = disk - (disk / 2) * 2 in (* NB integers behave differently to reals *)
 		(m <| 8) || (n <| 6) || partition
@@ -62,6 +67,7 @@ let of_xenstore_int x =
 	else match x >| 8 with
 		| 202 -> Xen, (x >| 4) && ((1 <| 4) - 1), x && ((1 <| 4) - 1)
 		| 8   -> Scsi, (x >| 4) && ((1 <| 4) - 1), x && ((1 <| 4) - 1)
+        | 203 -> Floppy, (x >| 4) && ((1 <| 4) - 1), x && ((1 <| 4) - 1)
 		| n   ->
 			let idx = snd(List.fold_left (fun (i, res) e -> i+1, if e = n then i else res) (0, -1) deprecated_ide_table) in
 			if idx < 0
@@ -96,9 +102,10 @@ let int26_of_string x =
 let to_linux_device = 
 	let p x = if x = 0 then "" else string_of_int x in 
 	function
-		| Xen,  disk, part -> Printf.sprintf "xvd%s%s" (string_of_int26 disk) (p part)
-		| Scsi, disk, part -> Printf.sprintf "sd%s%s"  (string_of_int26 disk) (p part)
-		| Ide,  disk, part -> Printf.sprintf "xvd%s%s"  (string_of_int26 disk) (p part)
+		| Xen,    disk, part -> Printf.sprintf "xvd%s%s" (string_of_int26 disk) (p part)
+		| Scsi,   disk, part -> Printf.sprintf "sd%s%s"  (string_of_int26 disk) (p part)
+        | Floppy, disk, part -> Printf.sprintf "fd%s%s"  (string_of_int26 disk) (p part)
+		| Ide,    disk, part -> Printf.sprintf "xvd%s%s" (string_of_int26 disk) (p part)
 
 let of_linux_device x =
 	let letter c = 'a' <= c && (c <= 'z') in
@@ -135,6 +142,9 @@ let of_linux_device x =
 		| 's' :: 'd' :: rest ->
 			let disk, partition = parse_b26_int rest in
 			Scsi, disk, partition
+        | 'f' :: 'd' :: rest ->
+            let disk, partition = parse_b26_int rest in
+            Floppy, disk, partition
 		| 'h' :: 'd' :: rest ->
 			let disk, partition = parse_b26_int rest in
 			Ide, disk, partition
@@ -153,6 +163,7 @@ type disk_number = int
 let to_disk_number = function
 	| Xen, disk, _ -> disk
 	| Scsi, disk, _ -> disk
+    | Floppy, disk, _ -> disk
 	| Ide, disk, _ -> disk
 
 let of_disk_number hvm n = 

--- a/ocaml/xenops/device_number.mli
+++ b/ocaml/xenops/device_number.mli
@@ -1,8 +1,9 @@
 (** Disks are attached to particular bus types: *)
 type bus_type =
-	| Xen  (** A xen paravirtualised bus *)
-	| Scsi (** A SCSI bus *)
-	| Ide  (** An IDE bus *)
+	| Xen     (** A xen paravirtualised bus *)
+	| Scsi    (** A SCSI bus *)
+    | Floppy  (** A floppy bus *)
+	| Ide     (** An IDE bus *)
 
 (** A specification for a device number. There are more valid specifications than
     valid device numbers because of hardware and/or protocol limits. *)

--- a/ocaml/xenops/device_number.mli
+++ b/ocaml/xenops/device_number.mli
@@ -2,7 +2,7 @@
 type bus_type =
 	| Xen     (** A xen paravirtualised bus *)
 	| Scsi    (** A SCSI bus *)
-    | Floppy  (** A floppy bus *)
+    | FloppyBus  (** A floppy bus *)
 	| Ide     (** An IDE bus *)
 
 (** A specification for a device number. There are more valid specifications than

--- a/ocaml/xenops/xenops_interface.ml
+++ b/ocaml/xenops/xenops_interface.ml
@@ -219,7 +219,7 @@ module Vbd = struct
 
 	type mode = ReadOnly | ReadWrite
 
-	type ty = CDROM | Disk
+	type ty = CDROM | Disk | Floppy
 
 	type id = string * string
 

--- a/ocaml/xenops/xenops_server_xen.ml
+++ b/ocaml/xenops/xenops_server_xen.ml
@@ -1699,6 +1699,7 @@ module VBD = struct
 						dev_type = (match vbd.ty with
 							| CDROM -> Device.Vbd.CDROM
 							| Disk -> Device.Vbd.Disk
+                            | Floppy -> Device.Vbd.Floppy
 						);
 						unpluggable = vbd.unpluggable;
 						protocol = None;


### PR DESCRIPTION
This is primarily needed right now to enable packer integration for OSes that require a floppy drive for autoinstalls (e.g. Windows).

I've re-created the patches as best I could to preserve history/authorship and created a fix up commit to handle the alterations required for the pre-disaggregation of XAPI.