### PR TITLE
CA-160970: Recreate CD VBDs after a revert to snapshot

### DIFF
--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -271,8 +271,12 @@ let safe_destroy_vdi ~__context ~rpc ~session_id vdi =
 (* This operation destroys the data of the dest VM.                                    *)
 let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 	let snap_vbds = Db.VM.get_VBDs ~__context ~self:snapshot in
-	let snap_vbds_without_cd = List.filter (fun vbd -> Db.VBD.get_type ~__context ~self:vbd <> `CD) snap_vbds in
-	let snap_vdis = List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) snap_vbds_without_cd in
+	let snap_vbds_disk, snap_vbds_cd =
+		List.partition
+			(fun vbd -> Db.VBD.get_type ~__context ~self:vbd <> `CD)
+			snap_vbds
+	in
+	let snap_vdis = List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) snap_vbds_disk in
 	let vdis_snap_of = List.map (fun vdi -> Db.VDI.get_snapshot_of ~__context ~self:vdi) snap_vdis in
 	let snap_vifs = Db.VM.get_VIFs ~__context ~self:snapshot in
 	let snap_vgpus = Db.VM.get_VGPUs ~__context ~self:snapshot in
@@ -301,7 +305,8 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 
 		debug "Cloning the snapshoted disks";
 		let driver_params = Xapi_vm_clone.make_driver_params () in
-		let cloned_disks = Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone ~__context snap_vbds_without_cd driver_params in
+		let cloned_disks = Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone ~__context snap_vbds_disk driver_params in
+		let cloned_cds = Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone ~__context snap_vbds_cd driver_params in
 		TaskHelper.set_progress ~__context 0.5;
 
 		debug "Updating the snapshot_of fields for relevant VDIs";
@@ -321,7 +326,7 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 		try
 			debug "Copying the VBDs";
 			let (_ : [`VBD] Ref.t list) =
-				List.map (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd) cloned_disks in
+				List.map (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd) (cloned_disks @ cloned_cds) in
 			(* XXX: no VBDs stored in the LBR now *)
 			(*
 			(* To include the case of checkpoints we must also update the VBD references in the LBR *)


### PR DESCRIPTION
Instead of ignoring the snapshot's CD VBDs, we clone them as normal to
the new VM. However, we still disregard the CD VBDs when fixing up the
snapshot_of links.