### PR TITLE
CP-10978: Implement host-level display configuration

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4036,6 +4036,14 @@ let host_get_server_certificate = call
   ~allowed_roles:_R_POOL_OP
   ()
 
+let host_display =
+	Enum ("host_display", [
+		"enabled", "This host is outputting its console to a physical display device";
+		"disable_on_reboot", "The host will stop outputting its console to a physical display device on next boot";
+		"disabled", "This host is not outputting its console to a physical display device";
+		"enable_on_reboot", "The host will start outputting its console to a physical display device on next boot";
+	])
+
 let host_operations =
   Enum ("host_allowed_operations", 
 	[ "provision", "Indicates this host is able to provision another VM"; 
@@ -4367,6 +4375,7 @@ let host =
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pci)) "PCIs" "List of PCI devices in the host";
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pgpu)) "PGPUs" "List of physical GPUs in the host";
 	field ~qualifier:RW ~in_product_since:rel_tampa ~default_value:(Some (VMap [])) ~ty:(Map (String, String)) "guest_VCPUs_params" "VCPUs params to apply to all resident guests";
+	field ~qualifier:RW ~in_product_since:rel_cream ~default_value:(Some (VEnum "enabled")) ~ty:host_display "display" "indicates whether the host is configured to output its console to a physical display device";
  ])
 	()
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4244,6 +4244,28 @@ let host_sync_pif_currently_attached = call ~flags:[`Session]
 	~allowed_roles:_R_POOL_OP
 	()
 
+let host_enable_display = call
+	~name:"enable_display"
+	~lifecycle:[Published, rel_cream, ""]
+	~doc:"Enable console output to the physical display device next time this host boots"
+	~params:[
+		Ref _host, "host", "The host";
+	]
+	~result:(host_display, "This host's physical display usage")
+	~allowed_roles:_R_POOL_OP
+	()
+
+let host_disable_display = call
+	~name:"disable_display"
+	~lifecycle:[Published, rel_cream, ""]
+	~doc:"Disable console output to the physical display device next time this host boots"
+	~params:[
+		Ref _host, "host", "The host";
+	]
+	~result:(host_display, "This host's physical display usage")
+	~allowed_roles:_R_POOL_OP
+	()
+
 (** Hosts *)
 let host =
     create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_host ~descr:"A physical host" ~gen_events:true
@@ -4328,6 +4350,8 @@ let host =
 		 host_sync_pif_currently_attached;
 		 host_migrate_receive;
 		 host_declare_dead;
+		 host_enable_display;
+		 host_disable_display;
 		 ]
       ~contents:
         ([ uid _host;

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -188,6 +188,7 @@ XAPI_MODULES = $(COMMON) \
 	api_server \
 	create_misc \
 	xapi_host \
+	xapi_host_display \
 	xapi_plugins \
 	xapi_fuse \
 	db_gc \

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -307,6 +307,10 @@ let update_env __context sync_keys =
 	 been tidied up and attempt to delete orphaned pool-wide patch records. *)
 
   (* refresh host info fields *)
+	switched_sync Xapi_globs.sync_host_display (fun () ->
+		Xapi_host.sync_display ~__context ~host:localhost
+	);
+
   switched_sync Xapi_globs.sync_refresh_localhost_info (fun () -> 
     refresh_localhost_info ~__context info;
   );

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2527,6 +2527,18 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 		let migrate_receive ~__context ~host ~network ~options =
 			info "Host.migrate_receive: host = '%s'; network = '%s'" (host_uuid ~__context host) (network_uuid ~__context network);
 			Local.Host.migrate_receive ~__context ~host ~network ~options
+
+		let enable_display ~__context ~host =
+			info "Host.enable_display: host = '%s'" (host_uuid ~__context host);
+			let local_fn = Local.Host.enable_display ~host in
+			do_op_on ~local_fn ~__context ~host
+				(fun session_id rpc -> Client.Host.enable_display rpc session_id host)
+
+		let disable_display ~__context ~host =
+			info "Host.disable_display: host = '%s'" (host_uuid ~__context host);
+			let local_fn = Local.Host.disable_display ~host in
+			do_op_on ~local_fn ~__context ~host
+				(fun session_id rpc -> Client.Host.disable_display rpc session_id host)
 	end
 
 	module Host_crashdump = struct

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -118,7 +118,7 @@ let pci_hiding_key_eq = pci_hiding_key ^ "="
 let xen_cmdline_path = "/opt/xensource/libexec/xen-cmdline"
 
 let get_pci_hidden_raw_value () =
-	let cmd = xen_cmdline_path ^ " --get-xen " ^ pci_hiding_key in
+	let cmd = xen_cmdline_path ^ " --get-dom0 " ^ pci_hiding_key in
 	let raw_kv_string = Helpers.get_process_output cmd in
 	(* E.g. "xen-pciback.hide=(0000:00:02.0)(0000:00:02.1)\n" or just "\n" *)
 	if String.startswith raw_kv_string pci_hiding_key_eq then
@@ -159,7 +159,7 @@ let _hide_pci ~__context pci =
 		let p = pcidev_of_pci ~__context pci in
 		let devs = p::(get_hidden_pcidevs ()) in
 		let valstr = List.fold_left (fun acc d -> acc ^ (paren_of d)) "" devs in
-		let cmd = Printf.sprintf "%s --set-xen %s'%s'"
+		let cmd = Printf.sprintf "%s --set-dom0 %s'%s'"
 			xen_cmdline_path pci_hiding_key_eq valstr in
 		let _ = Helpers.get_process_output cmd in
 		()
@@ -180,7 +180,7 @@ let _unhide_pci ~__context pci =
 		let cmd = match new_value with
 			| "" -> Printf.sprintf "%s --delete-xen %s"
 				xen_cmdline_path pci_hiding_key
-			| _ -> Printf.sprintf "%s --set-xen %s'%s'"
+			| _ -> Printf.sprintf "%s --set-dom0 %s'%s'"
 				xen_cmdline_path pci_hiding_key_eq new_value
 		in
 		let _ = Helpers.get_process_output cmd in

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -121,7 +121,7 @@ let get_pci_hidden_raw_value () =
 	let cmd = xen_cmdline_path ^ " --get-dom0 " ^ pci_hiding_key in
 	let raw_kv_string = Helpers.get_process_output cmd in
 	(* E.g. "xen-pciback.hide=(0000:00:02.0)(0000:00:02.1)\n" or just "\n" *)
-	if String.startswith raw_kv_string pci_hiding_key_eq then
+	if String.startswith pci_hiding_key_eq raw_kv_string then
 		let keylen = String.length pci_hiding_key_eq in
 		(* rtrim to remove trailing newline *)
 		String.rtrim(String.sub_to_end raw_kv_string keylen)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -331,6 +331,7 @@ let sync_switch_off = "nosync" (* Set the following keys to this value to disabl
 let sync_local_vdi_activations = "sync_local_vdi_activations"
 let sync_create_localhost = "sync_create_localhost"
 let sync_enable_localhost = "sync_enable_localhost"
+let sync_host_display = "sync_host_display"
 let sync_refresh_localhost_info = "sync_refresh_localhost_info"
 let sync_record_host_memory_properties = "sync_record_host_memory_properties"
 let sync_copy_license_to_db = "sync_copy_license_to_db"

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1584,3 +1584,24 @@ let migrate_receive ~__context ~host ~network ~options =
 	  Xapi_vm_migrate._session_id, new_session_id;
 	  Xapi_vm_migrate._master, master_url;
 	]
+
+let update_display ~__context ~host ~action =
+	let db_current = Db.Host.get_display ~__context ~self:host in
+	let db_new = match db_current, action with
+	| `enabled,           `enable
+	| `disable_on_reboot, `enable  -> `enabled
+	| `disabled,          `enable
+	| `enable_on_reboot,  `enable  -> `enable_on_reboot
+	| `enabled,           `disable
+	| `disable_on_reboot, `disable -> `disable_on_reboot
+	| `disabled,          `disable
+	| `enable_on_reboot,  `disable -> `disabled
+	in
+	Db.Host.set_display ~__context ~self:host ~value:db_new;
+	db_new
+
+let enable_display ~__context ~host =
+	update_display ~__context ~host ~action:`enable
+
+let disable_display ~__context ~host =
+	update_display ~__context ~host ~action:`disable

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -606,6 +606,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
 	~power_on_config:[]
 	~local_cache_sr
 	~guest_VCPUs_params:[]
+	~display:`enabled
   ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.of_float (Unix.gettimeofday ()));

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1613,3 +1613,12 @@ let enable_display ~__context ~host =
 
 let disable_display ~__context ~host =
 	update_display ~__context ~host ~action:`disable
+
+let sync_display ~__context ~host=
+	if !Xapi_globs.on_system_boot then begin
+		let status = match Xapi_host_display.status () with
+		| `enabled | `unknown -> `enabled
+		| `disabled -> `disabled
+		in
+		Db.Host.set_display ~__context ~self:host ~value:status
+	end

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1597,7 +1597,8 @@ let update_display ~__context ~host ~action =
 	| `disabled,          `disable
 	| `enable_on_reboot,  `disable -> `disabled
 	in
-	Db.Host.set_display ~__context ~self:host ~value:db_new;
+	if db_new <> db_current
+	then Db.Host.set_display ~__context ~self:host ~value:db_new;
 	db_new
 
 let enable_display ~__context ~host =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1586,17 +1586,24 @@ let migrate_receive ~__context ~host ~network ~options =
 	]
 
 let update_display ~__context ~host ~action =
+	let open Xapi_host_display in
 	let db_current = Db.Host.get_display ~__context ~self:host in
-	let db_new = match db_current, action with
-	| `enabled,           `enable
-	| `disable_on_reboot, `enable  -> `enabled
-	| `disabled,          `enable
-	| `enable_on_reboot,  `enable  -> `enable_on_reboot
-	| `enabled,           `disable
-	| `disable_on_reboot, `disable -> `disable_on_reboot
-	| `disabled,          `disable
-	| `enable_on_reboot,  `disable -> `disabled
+	let db_new, actual_action = match db_current, action with
+	| `enabled,           `enable  -> `enabled,           None
+	| `disable_on_reboot, `enable  -> `enabled,           Some `enable
+	| `disabled,          `enable  -> `enable_on_reboot,  Some `enable
+	| `enable_on_reboot,  `enable  -> `enable_on_reboot,  None
+	| `enabled,           `disable -> `disable_on_reboot, Some `disable
+	| `disable_on_reboot, `disable -> `disable_on_reboot, None
+	| `disabled,          `disable -> `disabled,          None
+	| `enable_on_reboot,  `disable -> `disabled,          Some `disable
 	in
+	begin
+		match actual_action with
+		| None -> ()
+		| Some `disable -> disable ()
+		| Some `enable  -> enable ()
+	end;
 	if db_new <> db_current
 	then Db.Host.set_display ~__context ~self:host ~value:db_new;
 	db_new

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -292,3 +292,5 @@ val migrate_receive : __context:Context.t -> host:API.ref_host -> network:API.re
 val enable_display : __context:Context.t -> host:API.ref_host -> API.host_display
 
 val disable_display : __context:Context.t -> host:API.ref_host -> API.host_display
+
+val sync_display : __context:Context.t -> host:API.ref_host -> unit

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -288,3 +288,7 @@ val sync_tunnels : __context:Context.t -> host:API.ref_host -> unit
 val sync_pif_currently_attached : __context:Context.t -> host:API.ref_host -> bridges:string list -> unit
 
 val migrate_receive : __context:Context.t -> host:API.ref_host -> network:API.ref_network -> options:API.string_to_string_map -> API.string_to_string_map
+
+val enable_display : __context:Context.t -> host:API.ref_host -> API.host_display
+
+val disable_display : __context:Context.t -> host:API.ref_host -> API.host_display

--- a/ocaml/xapi/xapi_host_display.ml
+++ b/ocaml/xapi/xapi_host_display.ml
@@ -1,0 +1,33 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Stringext
+
+let script = "/opt/xensource/libexec/host-display"
+
+let call_script ~command =
+	let (stdout, _) = Forkhelpers.execute_command_get_output script [command]
+	in String.strip String.isspace stdout
+
+let disable () =
+	let (_: string) = call_script "disable" in ()
+
+let enable () =
+	let (_: string) = call_script "enable" in ()
+
+let status () =
+	match call_script "status" with
+	| "disabled" -> `disabled
+	| "enabled" -> `enabled
+	| _ -> `unknown

--- a/ocaml/xapi/xapi_host_display.mli
+++ b/ocaml/xapi/xapi_host_display.mli
@@ -1,0 +1,19 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val disable : unit -> unit
+
+val enable : unit -> unit
+
+val status : unit -> [ `disabled | `enabled | `unknown ]

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -109,8 +109,6 @@ let get_host_pcis pci_db =
 	in
 	link_related_pcis [] pcis
 
-let is_hidden_from_dom0 pci = true
-
 let igd_is_whitelisted ~__context pci =
 	let vendor_id = Db.PCI.get_vendor_id ~__context ~self:pci in
 	List.mem vendor_id !Xapi_globs.igd_passthru_vendor_whitelist

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -60,7 +60,7 @@ let update_gpus ~__context ~host =
 		| [] -> cur
 		| pci :: remaining_pcis ->
 			let determine_dom0_access pci =
-				if Xapi_pci_helpers.is_hidden_from_dom0 pci
+				if Pciops.is_pci_hidden ~__context pci
 				then `disabled
 				else `enabled
 			in
@@ -68,7 +68,7 @@ let update_gpus ~__context ~host =
 			let is_system_display_device = (system_display_device = pci_addr) in
 			let supported_VGPU_types =
 				if is_system_display_device
-				&& not Xapi_pci_helpers.(is_hidden_from_dom0 pci && igd_is_whitelisted ~__context pci)
+				&& not (Pciops.is_pci_hidden ~__context pci && Xapi_pci_helpers.igd_is_whitelisted ~__context pci)
 				then []
 				else Xapi_vgpu_type.find_or_create_supported_types ~__context ~pci_db pci
 			in

--- a/scripts/OMakefile
+++ b/scripts/OMakefile
@@ -107,6 +107,7 @@ install:
 	$(IPROG) set-hostname $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) update-mh-info $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) host-bugreport-upload $(DESTDIR)$(LIBEXECDIR)/host-bugreport-upload
+	$(IPROG) host-display $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) xe-backup-metadata $(DESTDIR)$(BINDIR)
 	$(IPROG) xe-restore-metadata $(DESTDIR)$(BINDIR)
 	$(IPROG) link-vms-by-sr.py $(DESTDIR)$(LIBEXECDIR)

--- a/scripts/host-display
+++ b/scripts/host-display
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+"""
+This script can be used to enable, disable or query the status of dom0 and
+xen's use of the primary display device.
+
+n.b. the value returned by the "status" command will be correct as of the next
+boot (assuming that the boot config is not modified further), and is not
+necessarily correct at the time this script is called.
+"""
+
+import os
+import os.path
+import subprocess
+import sys
+import syslog
+from xcp.bootloader import Bootloader
+
+COMMAND_NAME = sys.argv[0]
+SHORT_COMMAND_NAME = os.path.basename(COMMAND_NAME)
+
+XE_SERIAL = 'xe-serial'
+XEN_CMDLINE = '/opt/xensource/libexec/xen-cmdline'
+
+def send_to_syslog(msg):
+    """ Send a message to syslog. """
+    pid = os.getpid()
+    syslog.syslog("%s[%d] - %s" %(SHORT_COMMAND_NAME, pid, msg))
+
+def doexec(args):
+    """Execute a subprocess, then return its return code, stdout and stderr"""
+    send_to_syslog(args)
+    proc = subprocess.Popen(
+        args,
+        stdin=None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True)
+    rc = proc.wait()
+    stdout = proc.stdout
+    stderr = proc.stderr
+    return (rc, stdout, stderr)
+
+def disable(bootloader):
+    """
+        Configure the host not to output its console to the physical display on
+        next boot.
+    """
+    if bootloader.default == XE_SERIAL:
+        doexec([XEN_CMDLINE, "--set-xen", "console=com1"])
+    else:
+        doexec([XEN_CMDLINE, "--delete-dom0", "console=tty0"])
+        doexec([XEN_CMDLINE, "--delete-xen", "console"])
+
+def enable(bootloader):
+    """
+        Configure the host to output its console to the physical display on
+        next boot.
+    """
+    if bootloader.default == XE_SERIAL:
+        doexec([XEN_CMDLINE, "--set-xen", "console=com1,vga"])
+    else:
+        doexec([XEN_CMDLINE, "--set-xen", "console=vga"])
+        doexec([XEN_CMDLINE, "--set-dom0", "console=tty0"])
+
+def status(_):
+    """
+        Determine from the bootloader config whether the host is currently
+        configured to output its console to the physical display.
+    """
+    (_, stdout, _) = doexec([XEN_CMDLINE, "--get-xen", "console"])
+    if "vga" in stdout.readline().strip():
+        sys.stdout.write("enabled")
+    else:
+        sys.stdout.write("disabled")
+
+COMMANDS = {
+    'disable': disable,
+    'enable': enable,
+    'status': status
+}
+
+def usage():
+    """ Display a usage string. """
+    command_names = COMMANDS.keys()
+    command_names.sort()
+    print "Usage:"
+    print "    %s {%s}" % (sys.argv[0], '|'.join(command_names))
+
+def main():
+    """ Program entry point. """
+    if len(sys.argv) == 2 and sys.argv[1] in COMMANDS.keys():
+        bootloader = Bootloader.loadExisting()
+        command = COMMANDS[sys.argv[1]]
+        command(bootloader)
+    else:
+        usage()
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -242,6 +242,7 @@ rm -rf $RPM_BUILD_ROOT
 @OPTDIR@/libexec/generate_ssl_cert
 @OPTDIR@/libexec/host-backup
 @OPTDIR@/libexec/host-bugreport-upload
+@OPTDIR@/libexec/host-display
 @OPTDIR@/libexec/host-restore
 @OPTDIR@/libexec/interface-reconfigure
 @OPTDIR@/libexec/interface-visualise


### PR DESCRIPTION
Introduces the API field `host.display`, and the API calls `host.enable_display` and `host.disable_display`.

This allows an API client to enable or disable host console output the system display device.

Also includes some fixes to related code.