### PR TITLE
Add mechanism for disabling the primary display device

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1620,5 +1620,7 @@ let sync_display ~__context ~host=
 		| `enabled | `unknown -> `enabled
 		| `disabled -> `disabled
 		in
+		if status = `disabled
+		then Xapi_pci.disable_system_display_device ();
 		Db.Host.set_display ~__context ~self:host ~value:status
 	end

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -159,6 +159,10 @@ let with_vga_arbiter ~readonly f =
 		0o000
 		f
 
+let disable_system_display_device () =
+	with_vga_arbiter ~readonly:false
+		(fun fd -> Unixext.really_write_string fd "decodes none")
+
 let get_system_display_device () =
 	try
 		let line =

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -152,10 +152,17 @@ let update_pcis ~__context ~host =
 	let obsolete = List.set_difference existing current in
 	List.iter (fun (self, _) -> Db.PCI.destroy ~__context ~self) obsolete
 
+let with_vga_arbiter ~readonly f =
+	Unixext.with_file
+		"/dev/vga_arbiter"
+		(if readonly then [Unix.O_RDONLY] else [Unix.O_RDWR])
+		0o000
+		f
+
 let get_system_display_device () =
 	try
 		let line =
-			Unixext.with_file "/dev/vga_arbiter" [Unix.O_RDONLY] 0o000 (fun fd ->
+			with_vga_arbiter ~readonly:true (fun fd ->
 				let data = Unixext.try_read_string ~limit:1024 fd in
 				List.hd (String.split ~limit:2 '\n' data)
 			)

--- a/ocaml/xapi/xapi_pci.mli
+++ b/ocaml/xapi/xapi_pci.mli
@@ -31,3 +31,6 @@ val update_pcis : __context:Context.t -> host:API.ref_host -> unit
 
 (** Get the PCI id of the host's display device. *)
 val get_system_display_device : unit -> string option
+
+(** Disable decoding for the host's display device. *)
+val disable_system_display_device : unit -> unit


### PR DESCRIPTION
If the host display is disabled, disable the host's primary display device.

This is done by writing "decodes none" to /dev/vga_arbiter