### PR TITLE
CA-161538: Checking xen-backend in link of /sys/class/net/*/device/drive...

### DIFF
--- a/ocaml/network/network_utils.ml
+++ b/ocaml/network/network_utils.ml
@@ -86,9 +86,10 @@ module Sysfs = struct
 
 	let is_physical name =
 		try
-			let link = Unix.readlink (getpath name "device") in
-			(* filter out device symlinks which look like /../../../devices/xen-backend/vif- *)
-			not(List.mem "xen-backend" (String.split '/' link))
+			let devpath = getpath name "device" in
+			let driver_link = Unix.readlink (devpath ^ "/driver") in
+			(* filter out symlinks under device/driver which look like /../../../devices/xen-backend/vif- *)
+			not(List.mem "xen-backend" (String.split '/' driver_link))
 		with _ -> false
 
 	let get_carrier name =


### PR DESCRIPTION
...r to identify vifs. It backport the CA-137227 in ocaml/network/network_utils.ml

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>