### PR TITLE
CA-162159: bump the fd limit in xenconsoled to 16384

### DIFF
--- a/scripts/init.d-xenservices
+++ b/scripts/init.d-xenservices
@@ -62,7 +62,7 @@ start() {
     "@BINDIR@/xenstored" ${XENSTORED_ARG}
 
 	OLD_ULIMIT_N=$(ulimit -n)
-	ulimit -n 4096
+	ulimit -n 16384
 	/usr/sbin/xenconsoled --log=hv --timestamp=hv --log-dir=/var/log/xen
 	ulimit -n $OLD_ULIMIT_N
 	[ -d /var/log/blktap ] || mkdir /var/log/blktap


### PR DESCRIPTION
init.d/xenservices is limiting the max number of fds in xenconsoled to 4096.
xenconsoled uses 4 fds for each vm, so this is limiting the number of vms in
the host to 1000.

Increasing the max number of fds in xenconsoled to 16384 will let the host
start up to 4000 vms, which is a more reasonable limit given the other
current limits in dom0.