### PR TITLE
Revert "CP-11136: Fix field-name: hyphens not underscores"

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -1050,7 +1050,7 @@ let host_record rpc session_id host =
 				~get_map:(fun () -> (x ()).API.host_guest_VCPUs_params) 
 				~add_to_map:(fun k v -> Client.Host.add_to_guest_VCPUs_params rpc session_id host k v)
 				~remove_from_map:(fun k -> Client.Host.remove_from_guest_VCPUs_params rpc session_id host k) ();
-			make_field ~name:"virtual-hardware-platform-versions" 
+			make_field ~name:"virtual_hardware_platform_versions" 
 				~get:(fun () -> String.concat "; " (List.map Int64.to_string (x ()).API.host_virtual_hardware_platform_versions)) 
 				~get_set:(fun () -> List.map Int64.to_string (x ()).API.host_virtual_hardware_platform_versions) ();
 		]}


### PR DESCRIPTION
Reverts xapi-project/xen-api#2172

It turns out that the code in the xen-api-sdk repository cannot cope with a Set of Int, which is used by the virtual hardware platform version features.

Therefore reverting this for now, until the sdk code has been extended to cope.

(Must revert this before reverting #2169.)