### PR TITLE
CA-163618: Make read_caching key a per-VDI, per-host property

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -311,6 +311,9 @@ module SMAPIv1 = struct
 		let vdi_read_write = Hashtbl.create 10
 		let vdi_read_write_m = Mutex.create ()
 		let vdi_read_caching_m = Mutex.create ()
+		let vdi_read_caching_key ~__context =
+			let host_uuid = Db.Host.get_uuid ~__context ~self:(Helpers.get_localhost ~__context) in
+			Printf.sprintf "%s%s" Xapi_globs.read_caching_sm_config_key_prefix host_uuid
 
 		let epoch_begin context ~dbg ~sr ~vdi =
 			try
@@ -330,11 +333,10 @@ module SMAPIv1 = struct
 							(* Record whether the VDI is benefiting from read caching *)
 							Server_helpers.exec_with_new_task "VDI.attach" ~subtask_of:(Ref.of_string dbg) (fun __context ->
 								let read_caching = not attach_info_v1.Smint.o_direct in
+								let key = vdi_read_caching_key ~__context in
 								Mutex.execute vdi_read_caching_m (fun () ->
-									Db.VDI.remove_from_sm_config ~__context ~self
-										~key:Xapi_globs.read_caching_sm_config_key;
-									Db.VDI.add_to_sm_config ~__context ~self
-										~key:Xapi_globs.read_caching_sm_config_key
+									Db.VDI.remove_from_sm_config ~__context ~self ~key;
+									Db.VDI.add_to_sm_config ~__context ~self ~key
 										~value:(string_of_bool read_caching)
 								)
 							);
@@ -391,8 +393,9 @@ module SMAPIv1 = struct
 					(fun device_config _type sr self ->
 						Sm.vdi_detach device_config _type sr self;
 						Server_helpers.exec_with_new_task "VDI.detach" ~subtask_of:(Ref.of_string dbg) (fun __context ->
+							let key = vdi_read_caching_key ~__context in
 							Mutex.execute vdi_read_caching_m (fun () ->
-								Db.VDI.remove_from_sm_config ~__context ~self ~key:Xapi_globs.read_caching_sm_config_key
+								Db.VDI.remove_from_sm_config ~__context ~self ~key
 							)
 						)
 					);

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -191,7 +191,7 @@ let vbd_backend_key = "backend-kind" (* set in VBD other-config *)
 
 let using_vdi_locking_key = "using-vdi-locking" (* set in Pool other-config to indicate that we should use storage-level (eg VHD) locking *)
 
-let read_caching_sm_config_key = "read-caching-enabled"
+let read_caching_sm_config_key_prefix = "read-caching-enabled-on-"
 
 let mac_seed = "mac_seed" (* set in a VM to generate MACs by hash chaining *)
 


### PR DESCRIPTION
As well as solving race conditions, this actually better reflects the reality
of the underlying implementation since a VDI is reference counted and only ever
attached at most once per host.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>