### PR TITLE
CA-163770: Use f_bfree to check available space for hotfixes

### DIFF
--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -240,7 +240,7 @@ let assert_space_available ?(multiplier=2L) patch_size =
 	let stat = statvfs patch_dir in
 	let free_bytes =
 		(* block size times free blocks *)
-		Int64.mul stat.f_frsize stat.f_bavail in
+		Int64.mul stat.f_frsize stat.f_bfree in
 	let really_required = Int64.mul multiplier patch_size in
 	if really_required > free_bytes
 	then


### PR DESCRIPTION
We should consider the space available for privileged users too.

From `man statvfs`:

struct statvfs {
    ...
    fsblkcnt_t     f_bfree;    /* # free blocks */
    fsblkcnt_t     f_bavail;   /* # free blocks for unprivileged users */
    ...
};

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>