### PR TITLE
Bump API version to 2.5

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -38,7 +38,7 @@ let xapi_user_agent = "xapi/"^(string_of_int version_major)^"."^(string_of_int v
 (* Normally xencenter_min_verstring and xencenter_max_verstring below should be set to the same value,
  * but there are exceptions: please consult the XenCenter maintainers if in doubt. *)
 let api_version_major = 2L
-let api_version_minor = 4L
+let api_version_minor = 5L
 let api_version_string =
   Printf.sprintf "%Ld.%Ld" api_version_major api_version_minor
 let api_version_vendor = "XenSource"
@@ -61,8 +61,8 @@ let tools_version = ref tools_version_none
  *
  * Please consult the XenCenter maintainers before changing these numbers, because a corresponding change
  * will need to be made in XenCenter *)
-let xencenter_min_verstring = "2.4"
-let xencenter_max_verstring = "2.4"
+let xencenter_min_verstring = "2.5"
+let xencenter_max_verstring = "2.5"
 
 (* linux pack vsn key in host.software_version (used for a pool join restriction *)
 let linux_pack_vsn_key = "xs:linux"


### PR DESCRIPTION
Cream will have API version 2.4.

Also bump xencenter_[min|max]_verstring.