### PR TITLE
Enable SMAPIv3

### DIFF
--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -10,7 +10,6 @@ inventory = /etc/xensource-inventory
 # True to use the message switch; false for direct Unix domain socket
 # comms
 # use-switch = true
-use-switch = false
 
 # Configure the logging policy:
 # logconfig = @ETCDIR@/log.conf
@@ -53,6 +52,7 @@ disable-logging-for = http db_write redo_log api_readonly
 
 # The full list of xenopsd instances to manage. These must all be running.
 # xenopsd-queues = org.xen.xcp.xenops.xenlight,org.xen.xcp.xenops.classic,org.xen.xcp.xenops.simulator
+xenopsd-queues = org.xen.xcp.xenops.classic
 
 # The default xenopsd to use for VMs, unless a per-VM override is specified
 # xenopsd-default = org.xen.xcp.xenops.xenlight

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -56,6 +56,7 @@ xenopsd-queues = org.xen.xcp.xenops.classic
 
 # The default xenopsd to use for VMs, unless a per-VM override is specified
 # xenopsd-default = org.xen.xcp.xenops.xenlight
+xenopsd-default = org.xen.xcp.xenops.classic
 
 # List of PCI vendor IDs for which to enable integrated GPU passthrough
 igd-passthru-vendor-whitelist = 8086


### PR DESCRIPTION
This enables the plumbing so that it's (hopefully) easy to experiment with SMAPIv3 plugins.

This requires xen-api-libs-specs#110

The combination of fixes passed a BVT via the trunk-ring3-smapiv3on-take3 branch.