### PR TITLE
Use HTTP to /services/SM for both local and remote cases

### DIFF
--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -24,7 +24,7 @@ open Pervasiveext
 open Xmlrpc_client
 open Threadext
 
-let local_url = Http.Url.(File { path = Filename.concat "/var/lib/xcp" "storage" }, { uri = "/"; query_params = [] })
+let local_url () = Http.Url.(Http { host="127.0.0.1"; auth=None; port=None; ssl=true }, { uri = "/services/SM"; query_params=["pool_secret",!Xapi_globs.pool_secret] } )
 let remote_url ip = Http.Url.(Http { host=ip; auth=None; port=None; ssl=true }, { uri = "/services/SM"; query_params=["pool_secret",!Xapi_globs.pool_secret] } )
 
 open Storage_interface
@@ -144,7 +144,7 @@ let vdi_info x =
 		| Some (Vdi_info v) -> v
 		| _ -> failwith "Runtime type error: expecting Vdi_info"
 
-module Local = Client(struct let rpc = rpc ~srcstr:"smapiv2" ~dststr:"smapiv2" local_url end)
+module Local = Client(struct let rpc call = rpc ~srcstr:"smapiv2" ~dststr:"smapiv2" (local_url ()) call end)
 
 let tapdisk_of_attach_info attach_info =
 	let path = attach_info.params in

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -51,7 +51,7 @@ let with_migrate f =
 	
 
 module XenAPI = Client
-module SMAPI = Storage_interface.Client(struct let rpc = Storage_migrate.rpc ~srcstr:"xapi" ~dststr:"smapiv2" Storage_migrate.local_url end)
+module SMAPI = Storage_interface.Client(struct let rpc call = Storage_migrate.rpc ~srcstr:"xapi" ~dststr:"smapiv2" (Storage_migrate.local_url ()) call end)
 
 open Storage_interface
 open Listext


### PR DESCRIPTION
This avoids using the Unix domain socket which won't exist if you're
using a message switch.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>