### PR TITLE
CA-166757: Deprecating "destination-sr-uuid" param during vm-migrate

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1192,8 +1192,8 @@ let rec cmdtable_data : (string*cmd_spec) list =
    "vm-migrate",
     {
       reqd=[];
-      optn=["live"; "host"; "host-uuid"; "remote-master"; "remote-username"; "remote-password"; "remote-network"; "destination-sr-uuid"; "force"; "vif:"; "vdi:"];
-      help="Migrate the selected VM(s). The parameter '--live' will migrate the VM without shutting it down. The 'host' parameter matches can be either the name or the uuid of the host. If you are migrating a VM to a remote pool, you will need to specify the remote-master, remote-username, and remote-password parameters. remote-master is the network address of the master host. To migrate to a particular host within a remote pool, you may additionally specify the host or host-uuid parameters. The vif and vdi mapping parameters take the form 'vif:<source vif uuid>=<dest network uuid>' and 'vdi:<source vdi uuid>=<dest sr uuid>'. You may simplify this mapping by using the destination-sr-uuid parameter. Unfortunately, destination uuids cannot be tab-completed.";
+      optn=["live"; "host"; "host-uuid"; "remote-master"; "remote-username"; "remote-password"; "remote-network"; "force"; "vif:"; "vdi:"];
+      help="Migrate the selected VM(s). The parameter '--live' will migrate the VM without shutting it down. The 'host' parameter matches can be either the name or the uuid of the host. If you are migrating a VM to a remote pool, you will need to specify the remote-master, remote-username, and remote-password parameters. remote-master is the network address of the master host. To migrate to a particular host within a remote pool, you may additionally specify the host or host-uuid parameters. The vif and vdi mapping parameters take the form 'vif:<source vif uuid>=<dest network uuid>' and 'vdi:<source vdi uuid>=<dest sr uuid>'. Unfortunately, destination uuids cannot be tab-completed.";
       implementation=No_fd Cli_operations.vm_migrate;
       flags=[Standard; Vm_selectors];
     };

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2509,7 +2509,7 @@ let vm_retrieve_wlb_recommendations printer rpc session_id params =
 			failwith ("Parameter '"^name^"' is not a field of the VM class. Failed to select VM for operation.")
 
 let vm_migrate_sxm_params = ["remote-master"; "remote-username"; "vif"; "remote-password";
-							 "remote-network"; "destination-sr-uuid"; "vdi"]
+							 "remote-network"; "vdi"]
 
 let vm_migrate printer rpc session_id params =
 	(* Hack to match host-uuid and host-name for backwards compatibility *)
@@ -2570,15 +2570,10 @@ let vm_migrate printer rpc session_id params =
 						vdi,sr) (read_map_params "vdi" params) in
 
 					let default_sr =
-						if List.mem_assoc "destination-sr-uuid" params
-						then let sr_uuid = List.assoc "destination-sr-uuid" params in
-							 try Some (Client.SR.get_by_uuid remote_rpc remote_session sr_uuid)
-							 with _ -> failwith (Printf.sprintf "Couldn't find destination SR: %s" sr_uuid)
-						else try let pools = Client.Pool.get_all remote_rpc remote_session in
-								 printer (Cli_printer.PMsg "Selecting remote pool's default SR for migrating VDIs") ;
-								 Some (Client.Pool.get_default_SR remote_rpc remote_session
-										   (List.hd pools))
-						     with _ -> None in
+						try let pools = Client.Pool.get_all remote_rpc remote_session in
+							printer (Cli_printer.PMsg "Selecting remote pool's default SR for migrating VDIs") ;
+							Some (Client.Pool.get_default_SR remote_rpc remote_session (List.hd pools))
+						with _ -> None in
 
 					let vdi_map = match default_sr with
 						| None -> vdi_map


### PR DESCRIPTION
1) Cross pool vm migrate:
vdi:vdiuuid=sruuid map can be provided to define destination sr
or default sr of destination pool is taken as a destination sr

2) Intra pool vm migrate:
default sr of a pool is taken as a destination sr

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>