### PR TITLE
CP-12148: Inherit auto_update_drivers and hardware_platform_version on VM.clone

### DIFF
--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -335,8 +335,8 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
 		~suspend_SR:Ref.null
 		~version:0L
 		~generation_id
-		~hardware_platform_version:0L
-		~auto_update_drivers:false
+		~hardware_platform_version:all.Db_actions.vM_hardware_platform_version
+		~auto_update_drivers:all.Db_actions.vM_auto_update_drivers
 	;
 
 	(* update the VM's parent field in case of snapshot. Note this must be done after "ref"


### PR DESCRIPTION
Not using the default of "false", but use the value of the VM clone from.

Signed-off-by: chengz <cheng.zhang@citrix.com>