### PR TITLE
CA-171273: Disable the http auth tests when using the unix socket

### DIFF
--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -857,7 +857,7 @@ let _ =
 				maybe_run_test "vm-memory-constraints" Quicktest_vm_memory_constraints.run_from_within_quicktest;
 				maybe_run_test "vm-placement" Quicktest_vm_placement.run_from_within_quicktest;
 				maybe_run_test "storage" (fun () -> Quicktest_storage.go s);
-				maybe_run_test "http" Quicktest_http.run_from_within_quicktest;
+				if not !using_unix_domain_socket then maybe_run_test "http" Quicktest_http.run_from_within_quicktest;
 				maybe_run_test "event" event_next_unblocking_test;
 				maybe_run_test "event" (fun () -> event_next_test s);
 				maybe_run_test "event" (fun () -> event_from_test s);


### PR DESCRIPTION
Using the unix domain socket now automatically authenticates, so
these tests now fail. XenRT uses TCP connections, so it still tests
the behaviour.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>