### PR TITLE
CP-12292: Allow a script to list PIFs that should not be managed by xapi

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -796,6 +796,11 @@ let disable_logging_for= ref []
 
 let igd_passthru_vendor_whitelist = ref []
 
+(* The ibft-to-ignore script returns NICs listed in the ISCSI Boot Firmware Table.
+ * These NICs (probably just one for now) are used to boot from, and should be marked
+ * with PIF.managed = false during a PIF.scan. *)
+let non_managed_pifs = ref "/opt/xensource/libexec/ibft-to-ignore"
+
 type xapi_globs_spec_ty = | Float of float ref | Int of int ref
 
 let xapi_globs_spec =
@@ -974,6 +979,7 @@ module Resources = struct
 		"startup-script-hook", startup_script_hook, "Executed during startup";
 		"rolling-upgrade-script-hook", rolling_upgrade_script_hook, "Executed when a rolling upgrade is detected starting or stopping";
 		"xapi-message-script", xapi_message_script, "Executed when messages are generated if email feature is disabled";
+		"non-managed-pifs", non_managed_pifs, "Executed during PIF.scan to find out which NICs should not be managed by xapi";
 	]
 	let essential_files = [
 		"pool_config_file", pool_config_file, "Pool configuration file";

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -170,6 +170,9 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # Directory containing trusted guest provisioning scripts
 # post-install-scripts-dir = @OPTDIR@/packages/post-install-scripts
 
+# Executed during PIF.scan to find out which NICs should not be managed by xapi
+# non-managed-pifs = @LIBEXECDIR@/ibft-to-ignore
+
 # Tweak timeouts: ################################################
 
 # If the slave's connection to the master blocks for longer than
@@ -324,3 +327,4 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # The delay between each attempt to connect to the block device I/O
 # process
 # redo_log_connect_delay = 0.1
+


### PR DESCRIPTION
Xapi executes the script during a PIF.scan to set the PIF.managed accordingly.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>