### PR TITLE
CP-9895: Added originator for xapi login_with_password

### DIFF
--- a/ocaml/events/event_listen.py
+++ b/ocaml/events/event_listen.py
@@ -7,7 +7,7 @@ if len(sys.argv) <> 4:
     raise "Expected arguments: <url> <username> <password>"
 
 server = xmlrpclib.Server(sys.argv[1]);
-session = server.session.login_with_password(sys.argv[2], sys.argv[3])['Value']
+session = server.session.login_with_password(sys.argv[2], sys.argv[3], "1.0", "xen-api-event-listen.py")['Value']
 
 server.event.register(session, ["*"])
 while True:

--- a/ocaml/idl/binding_sanity_checks/hannesscript.py
+++ b/ocaml/idl/binding_sanity_checks/hannesscript.py
@@ -16,7 +16,7 @@ def dictionary_list_partial_print(title, dictionary_list, keys ):
 
 #log in to the master
 session=XenAPI.Session(SERVER)
-session.login_with_password(USERNAME, PASSWORD)
+session.login_with_password(USERNAME, PASSWORD, '1.0', 'xen-api-hannesscript.py')
 sx=session.xenapi
 
 #first, we'll find all the hosts, and get the information we care about from each

--- a/ocaml/idl/binding_sanity_checks/nagios_plugins/check_pool.py
+++ b/ocaml/idl/binding_sanity_checks/nagios_plugins/check_pool.py
@@ -55,11 +55,11 @@ try:
     host_is_slave=False
     try:
         session=XenAPI.Session('https://'+options.hostname)
-        session.login_with_password(options.username, options.password)
+        session.login_with_password(options.username, options.password, '1.0' ,'xen-api-tutorial-check-pool.py')
     except XenAPI.Failure, e:
         if e.details[0]=='HOST_IS_SLAVE':
             session=XenAPI.Session('https://'+e.details[1])
-            session.login_with_password(options.username, options.password)
+            session.login_with_password(options.username, options.password, '1.0' ,'xen-api-tutorial-check-pool.py')
             host_is_slave=True
         else:
             raise

--- a/ocaml/idl/binding_sanity_checks/sanitychecklib.py
+++ b/ocaml/idl/binding_sanity_checks/sanitychecklib.py
@@ -19,7 +19,7 @@ test_vm_name='sanitycheck VM'
 
 def gs(server, username, password):
     session = XenAPI.Session('http://'+server)
-    session.login_with_password(username, password)
+    session.login_with_password(username, password, '1.0', 'xen-api-sanity-check')
     return session
 
 def getsession():

--- a/ocaml/idl/binding_sanity_checks/tutorial_examples/XenAPI.py
+++ b/ocaml/idl/binding_sanity_checks/tutorial_examples/XenAPI.py
@@ -106,7 +106,7 @@ class Session(xmlrpclib.ServerProxy):
     Example:
 
     session = Session('http://localhost/')
-    session.login_with_password('me', 'mypassword')
+    session.login_with_password('me', 'mypassword', '1.0', 'xen-api-tutorial-xenapi.py')
     session.xenapi.VM.start(vm_uuid)
     session.xenapi.session.logout()
     """

--- a/ocaml/idl/binding_sanity_checks/tutorial_examples/cpu_use.py
+++ b/ocaml/idl/binding_sanity_checks/tutorial_examples/cpu_use.py
@@ -21,7 +21,7 @@ def print_metrics(sx):
 def main(url, username, password):
     while True:
         session = XenAPI.Session(url)
-        session.login_with_password(username, password)
+        session.login_with_password(username, password, '1.0' ,'xen-api-tutorial-cpu-use.py'
         print_metrics(session.xenapi)
         session.logout()
         time.sleep(5)

--- a/ocaml/idl/binding_sanity_checks/tutorial_examples/dbgraph.py
+++ b/ocaml/idl/binding_sanity_checks/tutorial_examples/dbgraph.py
@@ -142,7 +142,7 @@ def main(url, username, password):
     global object_database
 
     session = XenAPI.Session(url)
-    session.login_with_password(username, password)
+    session.login_with_password(username, password, '1.0', 'xen-api-tutorial-dbgraph.py')
     sx=session.xenapi
 
     #read all the objects we're interested in from Xapi.

--- a/ocaml/idl/binding_sanity_checks/tutorial_examples/helloxapi.py
+++ b/ocaml/idl/binding_sanity_checks/tutorial_examples/helloxapi.py
@@ -20,6 +20,6 @@ if __name__ == "__main__":
 
     print "List of non-template VMs on %s" % url
     session = XenAPI.Session(url)
-    session.login_with_password(username, password)
+    session.login_with_password(username, password, '1.0', 'xen-api-tutorial-helloxapi.py')
     main(session.xenapi)
     session.logout()

--- a/ocaml/idl/binding_sanity_checks/tutorial_examples/nagios_plugin.py
+++ b/ocaml/idl/binding_sanity_checks/tutorial_examples/nagios_plugin.py
@@ -55,11 +55,11 @@ try:
     host_is_slave=False
     try:
         session=XenAPI.Session('https://'+options.hostname)
-        session.login_with_password(options.username, options.password)
+        session.login_with_password(options.username, options.password,, '1.0' ,'xen-api-tutorial-plugin.py')
     except XenAPI.Failure, e:
         if e.details[0]=='HOST_IS_SLAVE':
             session=XenAPI.Session('https://'+e.details[1])
-            session.login_with_password(options.username, options.password)
+            session.login_with_password(options.username, options.password, '1.0' ,'xen-api-tutorial-plugin.py')
             host_is_slave=True
         else:
             raise

--- a/ocaml/idl/binding_sanity_checks/tutorial_examples/nagios_snippet.py
+++ b/ocaml/idl/binding_sanity_checks/tutorial_examples/nagios_snippet.py
@@ -4,7 +4,7 @@ hostname, username, password = "ivory", "root", "password"
 
 import XenAPI
 session=XenAPI.Session('https://'+hostname)
-session.login_with_password(username, password)
+session.login_with_password(username, password, '1.0' ,'xen-api-tutorial-snippet.py')
 sx=session.xenapi
  
 # partition the hosts according to whether they're alive or not

--- a/ocaml/idl/binding_sanity_checks/tutorial_examples/nagios_snippet2.py
+++ b/ocaml/idl/binding_sanity_checks/tutorial_examples/nagios_snippet2.py
@@ -4,11 +4,11 @@ import XenAPI
  
 try:
     session=XenAPI.Session('https://'+hostname)
-    session.login_with_password(username, password)
+    session.login_with_password(username, password, '1.0' ,'xen-api-tutorial-snippet2.py')
 except XenAPI.Failure, e:
     if e.details[0]=='HOST_IS_SLAVE':
         session=XenAPI.Session('https://'+e.details[1])
-        session.login_with_password(username, password)
+        session.login_with_password(username, password, '1.0' ,'xen-api-tutorial-snippet2.py')
     else:
         raise
 

--- a/ocaml/idl/ocaml_backend/python/list_vms.py
+++ b/ocaml/idl/ocaml_backend/python/list_vms.py
@@ -2,7 +2,7 @@
 
 import xmlrpclib
 server = xmlrpclib.Server("http://melton:8086");
-session = server.session.login_with_password("root", "xenroot")['Value']
+session = server.session.login_with_password("root", "xenroot", "1.0", "xen-api-list-vms.py")['Value']
 print session
 vms = server.VM.get_all(session)['Value']
 print vms

--- a/ocaml/idl/ocaml_backend/python/pause_vm.py
+++ b/ocaml/idl/ocaml_backend/python/pause_vm.py
@@ -2,5 +2,5 @@
 
 import xmlrpclib
 server = xmlrpclib.Server("http://localhost:8086");
-session = server.Session.do_login_with_password("user", "passwd")['Value']
+session = server.Session.do_login_with_password("user", "passwd", "1.0", "xen-api-pause-vm.py")['Value']
 server.VM.do_pause(session, '7366a41a-e50e-b891-fa0c-ca5b4d2e3f1c')

--- a/ocaml/idl/ocaml_backend/python/test_client.py
+++ b/ocaml/idl/ocaml_backend/python/test_client.py
@@ -12,7 +12,7 @@ server = xmlrpclib.Server(url);
 
 # Call the server and get our result.
 print "Logging in... ",
-session = server.Session.do_login_with_password("user", "passwd")
+session = server.Session.do_login_with_password("user", "passwd", "1.0", "xen-api-test-client.py")
 print "OK"
 print "Session ID: \""+session+"\""
 vm_list = server.VM.do_list(session)

--- a/ocaml/idl/ocaml_backend/python/unpause_vm.py
+++ b/ocaml/idl/ocaml_backend/python/unpause_vm.py
@@ -2,5 +2,5 @@
 
 import xmlrpclib
 server = xmlrpclib.Server("http://localhost:8086");
-session = server.Session.do_login_with_password("user", "passwd")['Value']
+session = server.Session.do_login_with_password("user", "passwd", "1.0", "xen-api-unpause-vm.py")['Value']
 server.VM.do_unpause(session, '7366a41a-e50e-b891-fa0c-ca5b4d2e3f1c')

--- a/ocaml/idl/wire-protocol.tex
+++ b/ocaml/idl/wire-protocol.tex
@@ -175,10 +175,13 @@ The following transport layers are currently supported:
 The XML-RPC interface is session-based; before you can make arbitrary RPC calls
 you must login and initiate a session. For example:
 \begin{verbatim}
-   session_id    session.login_with_password(string uname, string pwd)
+   session_id    session.login_with_password(string uname, string pwd, string version, string originator)
 \end{verbatim}
 Where {\tt uname} and {\tt password} refer to your username and password
+while {\tt version} and {\tt originator} are optional and refer to the api version and client name 
 respectively, as defined by the Xen administrator.
+(The {\tt version} is ignored at present though. A client that doesn't want to specify it can 
+send uname, pwd, '', originator)
 The {\tt session\_id} returned by {\tt session.login\_with\_password} is passed
 to subequent RPC calls as an authentication token.
 
@@ -247,7 +250,7 @@ Acquire a session reference by logging in with a username and password
 key {\tt 'Value'} in the resulting dictionary)
 
 \begin{verbatim}
->>> session = xen.session.login_with_password("user", "passwd")['Value']
+>>> session = xen.session.login_with_password("user", "passwd", "version", "originator")['Value']
 \end{verbatim}
 
 When serialised, this call looks like the following:
@@ -262,6 +265,12 @@ When serialised, this call looks like the following:
     </param>
     <param>
       <value><string>passwd</string></value>
+    </param>
+    <param>
+      <value><string>version</string></value>
+    </param>
+    <param>
+      <value><string>originator</string></value>
     </param>
   </params>
 </methodCall>

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2527,7 +2527,7 @@ let vm_migrate printer rpc session_id params =
 				XMLRPC_protocol.rpc ~srcstr:"cli" ~dststr:"dst_xapi" ~transport:(SSL(SSL.make ~use_fork_exec_helper:false (), ip, 443)) ~http xml in
 			let username = List.assoc "remote-username" params in
 			let password = List.assoc "remote-password" params in
-			let remote_session = Client.Session.login_with_password remote_rpc username password "1.3" "" in
+			let remote_session = Client.Session.login_with_password remote_rpc username password "1.3" Xapi_globs.xapi_user_agent in
 			finally
 				(fun () ->
 					let host, host_record =

--- a/ocaml/xapi/create_storage_main.ml
+++ b/ocaml/xapi/create_storage_main.ml
@@ -31,6 +31,6 @@ let _ =
   let http = xmlrpc ~version:"1.0" "/" in
   let rpc xml = XML_protocol.rpc ~transport:(TCP(!host, !port)) ~http xml in
   let session_id = Client.Session.login_with_password ~rpc 
-    ~uname:!username ~pwd:!password ~version:Xapi_globs.api_version_string ~originator:"" in
+    ~uname:!username ~pwd:!password ~version:Xapi_globs.api_version_string ~originator:Xapi_globs.xapi_user_agent in
   create_storage_localhost rpc session_id;
   Client.Session.logout ~rpc ~session_id

--- a/ocaml/xapi/tests/looper.py
+++ b/ocaml/xapi/tests/looper.py
@@ -17,7 +17,7 @@ server = xapi.Server(url);
 
 # Call the server and get our result.
 print "Logging in... ",
-session = server.Session.login_with_password("user", "passwd")
+session = server.Session.login_with_password("user", "passwd", "1.0", "xen-api-tests-looper")
 print "OK"
 print "Session ID: \""+session+"\""
 vm_list = server.VM.get_all(session)

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -147,7 +147,7 @@ let assert_credentials_ok realm ?(http_action=realm) ?(fn=Rbac.nofn) (req: Reque
 	| Some (Http.Basic(username, password)) ->
 	  begin
 	    let session_id = try
-	      Client.Session.login_with_password inet_rpc username password Xapi_globs.api_version_string ""
+	      Client.Session.login_with_password inet_rpc username password Xapi_globs.api_version_string Xapi_globs.xapi_user_agent
 	    with _ -> raise (Http.Unauthorised realm)
 	    in
 	    Pervasiveext.finally
@@ -187,7 +187,7 @@ let with_context ?(dummy=false) label (req: Request.t) (s: Unix.file_descr) f =
 	        | Some (Http.Basic(username, password)) ->
 		    begin
 		      try
-			Client.Session.login_with_password inet_rpc username password Xapi_globs.api_version_string "", true
+			Client.Session.login_with_password inet_rpc username password Xapi_globs.api_version_string Xapi_globs.xapi_user_agent, true
 		      with Api_errors.Server_error(code, params) when code = Api_errors.session_authentication_failed ->
 			raise (Http.Unauthorised label)
 		    end

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -694,7 +694,7 @@ let join_common ~__context ~master_address ~master_username ~master_password ~fo
 	a host that does not support pooling then an error will be thrown at this stage *)
 	let rpc = rpc master_address in
 	let session_id =
-		try Client.Session.login_with_password rpc master_username master_password Xapi_globs.api_version_string ""
+		try Client.Session.login_with_password rpc master_username master_password Xapi_globs.api_version_string Xapi_globs.xapi_user_agent
 		with Http_client.Http_request_rejected _ | Http_client.Http_error _ ->
 			raise (Api_errors.Server_error(Api_errors.pool_joining_host_service_failed, [])) in
 

--- a/scripts/InterfaceReconfigure.py
+++ b/scripts/InterfaceReconfigure.py
@@ -494,7 +494,7 @@ class DatabaseCache(object):
 
             if not session_ref:
                 log("No session ref given on command line, logging in.")
-                session.xenapi.login_with_password("root", "")
+                session.xenapi.login_with_password("root", "", "1.0", "xen-api-scripts-interface-reconfigure.py")
             else:
                 session._session = session_ref
 

--- a/scripts/backup-sr-metadata.py
+++ b/scripts/backup-sr-metadata.py
@@ -28,7 +28,7 @@ def set_if_exists(xml, record, key):
    
 def main(argv):
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password("", "")
+    session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-backup-sr-metadata")
 
     try:
         opts, args = getopt.getopt(argv, "hf:", [])

--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -120,7 +120,7 @@ class Session(xmlrpclib.ServerProxy):
     Example:
 
     session = Session('http://localhost/')
-    session.login_with_password('me', 'mypassword')
+    session.login_with_password('me', 'mypassword', '1.0', 'xen-api-scripts-xenapi.py')
     session.xenapi.VM.start(vm_uuid)
     session.xenapi.session.logout()
     """

--- a/scripts/examples/python/XenAPI.py.html
+++ b/scripts/examples/python/XenAPI.py.html
@@ -127,7 +127,7 @@ _RECONNECT_AND_RETRY = (<B><FONT COLOR="#A020F0">lambda</FONT></B> _ : ())
     Example:
 
     session = Session('http://localhost/')
-    session.login_with_password('me', 'mypassword')
+    session.login_with_password('me', 'mypassword', '1.0', 'xen-api-scripts-xenapi.py')
     session.xenapi.VM.start(vm_uuid)
     session.xenapi.session.logout()
     &quot;&quot;&quot;</FONT></B>

--- a/scripts/examples/python/exportimport.py
+++ b/scripts/examples/python/exportimport.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
   vdi_uuid = sys.argv[4]
   # First acquire a valid session by logging in:
   xapi = XenAPI.Session(url)
-  xapi.xenapi.login_with_password(username, password)
+  xapi.xenapi.login_with_password(username, password, '1.0', 'xen-api-scripts-exportimport.py')
   dst_vdi = None
   try:
     src_vdi = xapi.xenapi.VDI.get_by_uuid(vdi_uuid)

--- a/scripts/examples/python/fixpbds.py
+++ b/scripts/examples/python/fixpbds.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     # First acquire a valid session by logging in:
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-fixpbds.py")
     main(session,sr,map)
 
 

--- a/scripts/examples/python/fixpbds.py.html
+++ b/scripts/examples/python/fixpbds.py.html
@@ -67,7 +67,7 @@
 
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-fixpbds.py")
     main(session,sr,map)
 
 

--- a/scripts/examples/python/install.py
+++ b/scripts/examples/python/install.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     password = sys.argv[3]
     # First acquire a valid session by logging in:
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-install.py")
     try:
         main(session)
     except Exception, e:

--- a/scripts/examples/python/install.py.html
+++ b/scripts/examples/python/install.py.html
@@ -140,7 +140,7 @@
     password = sys.argv[3]
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-install.py")
     <B><FONT COLOR="#A020F0">try</FONT></B>:
         main(session)
     <B><FONT COLOR="#A020F0">except</FONT></B> Exception, e:

--- a/scripts/examples/python/license.py
+++ b/scripts/examples/python/license.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     password = sys.argv[3]
     # First acquire a valid session by logging in:
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, '1.0', 'xen-api-scripts-license.py')
     main(session)
     session.xenapi.session.logout()
 

--- a/scripts/examples/python/license.py.html
+++ b/scripts/examples/python/license.py.html
@@ -56,7 +56,7 @@ filename = <B><FONT COLOR="#BC8F8F">&quot;license&quot;</FONT></B> <I><FONT COLO
     password = sys.argv[3]
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, '1.0', 'xen-api-scripts-license.py')
     main(session)
     session.xenapi.session.logout()
 

--- a/scripts/examples/python/lvhd-api-test.py
+++ b/scripts/examples/python/lvhd-api-test.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         sys.exit(1)
     name = sys.argv[1]
     x = XenAPI.xapi_local()
-    x.xenapi.login_with_password("root", "")
+    x.xenapi.login_with_password("root", "", "1.0", "xen-api-scripts-lvhd-api-test.py")
     try:
         go(x, name)
     finally:

--- a/scripts/examples/python/mini-xenrt.py
+++ b/scripts/examples/python/mini-xenrt.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     
     x = xmlrpclib.Server(sys.argv[1])
     key = sys.argv[2]
-    session = x.session.login_with_password("root", "xenroot")["Value"]
+    session = x.session.login_with_password("root", "xenroot", "1.0", "xen-api-scripts-minixenrt.py")["Value"]
     vms = x.VM.get_all_records(session)["Value"]
 
     workers = []

--- a/scripts/examples/python/monitor-unwanted-domains.py
+++ b/scripts/examples/python/monitor-unwanted-domains.py
@@ -26,7 +26,7 @@ def list_paused_domains():
 def should_domain_be_somewhere_else(localhost_uuid, (domid, uuid)):
     try:
         x = XenAPI.xapi_local()
-        x.xenapi.login_with_password("root", "")
+        x.xenapi.login_with_password("root", "", "1.0", "xen-api-scripts-monitor-unwanted-domains.py")
         try:
             try:
                 vm = x.xenapi.VM.get_by_uuid(uuid)

--- a/scripts/examples/python/permute.py
+++ b/scripts/examples/python/permute.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     iterations = int(sys.argv[4])
     # First acquire a valid session by logging in:
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-permute.py")
     try:
         for i in range(iterations):
             main(session, i)

--- a/scripts/examples/python/permute.py.html
+++ b/scripts/examples/python/permute.py.html
@@ -92,7 +92,7 @@
     iterations = int(sys.argv[4])
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-permute.py")
     <B><FONT COLOR="#A020F0">try</FONT></B>:
         <B><FONT COLOR="#A020F0">for</FONT></B> i <B><FONT COLOR="#A020F0">in</FONT></B> range(iterations):
             main(session, i)

--- a/scripts/examples/python/powercycle.py
+++ b/scripts/examples/python/powercycle.py
@@ -69,6 +69,6 @@ if __name__ == "__main__":
     password = sys.argv[3]
     # First acquire a valid session by logging in:
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-powercycle.py")
     main(session)
 

--- a/scripts/examples/python/powercycle.py.html
+++ b/scripts/examples/python/powercycle.py.html
@@ -80,7 +80,7 @@
     password = sys.argv[3]
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-powercycle.py"
     main(session)
 
 </PRE>

--- a/scripts/examples/python/renameif.py
+++ b/scripts/examples/python/renameif.py
@@ -159,7 +159,7 @@ def renameif(session):
 
 if __name__ == "__main__":
     session = XenAPI.xapi_local()
-    session.login_with_password("", "")
+    session.login_with_password("", "", "1.0", "xen-api-scripts-renameifs.py")
     try:
         renameif(session)
     finally:

--- a/scripts/examples/python/rotate.html
+++ b/scripts/examples/python/rotate.html
@@ -80,7 +80,7 @@
     password = sys.argv[3]
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-rotate")
     main(session)
 
 </PRE>

--- a/scripts/examples/python/shell.py
+++ b/scripts/examples/python/shell.py
@@ -92,11 +92,11 @@ if __name__ == "__main__":
         username = sys.argv[2]
         password = sys.argv[3]
         session = XenAPI.Session(url)
-        session.xenapi.login_with_password(username, password)
+        session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-shell.py")
         cmdAt = 4
     else:
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password("", "")
+        session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-shell.py")
         cmdAt = 2
 
     # We want to support directly executing the cmd line,

--- a/scripts/examples/python/shell.py.html
+++ b/scripts/examples/python/shell.py.html
@@ -87,7 +87,7 @@ atexit.register(logout)
     password = sys.argv[3]
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-shell.py")
 
     Shell().cmdloop(<B><FONT COLOR="#BC8F8F">'Welcome to the XenServer shell. (Try &quot;VM.get_all&quot;)'</FONT></B>)
 </PRE>

--- a/scripts/examples/python/vm_start_async.py
+++ b/scripts/examples/python/vm_start_async.py
@@ -56,6 +56,6 @@ if __name__ == "__main__":
     password = sys.argv[3]
     # First acquire a valid session by logging in:
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-vm-start-async.py")
     main(session)
  

--- a/scripts/examples/python/vm_start_async.py.html
+++ b/scripts/examples/python/vm_start_async.py.html
@@ -67,7 +67,7 @@
     password = sys.argv[3]
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-vm-start-async.py")
     main(session)
  
 </PRE>

--- a/scripts/examples/python/watch-all-event-contents.py
+++ b/scripts/examples/python/watch-all-event-contents.py
@@ -78,5 +78,5 @@ if __name__ == "__main__":
         session = XenAPI.xapi_local()
     else:
         session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, '1.0', 'xen-api-scripts-watch-event-contents.py')
     main(session)

--- a/scripts/examples/python/watch-all-events.py
+++ b/scripts/examples/python/watch-all-events.py
@@ -67,5 +67,5 @@ if __name__ == "__main__":
     password = sys.argv[3]
     # First acquire a valid session by logging in:
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-watch-all-events.py")
     main(session)

--- a/scripts/examples/python/watch-all-events.py.html
+++ b/scripts/examples/python/watch-all-events.py.html
@@ -78,7 +78,7 @@
     password = sys.argv[3]
     <I><FONT COLOR="#B22222"># First acquire a valid session by logging in:
 </FONT></I>    session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-watch-all-events.py")
     main(session)
 </PRE>
 <HR>

--- a/scripts/hatests
+++ b/scripts/hatests
@@ -88,7 +88,7 @@ if len(args) != 1 :
 
 #connection
 s = XenAPI.Session('http://localhost')
-s.login_with_password('root', 'xenroot')
+s.login_with_password('root', 'xenroot', '1.0', 'xen-api-scripts-hatest')
 
 #Getting all the installed and running VMs with dom-id > 0
 slaves = []
@@ -107,14 +107,14 @@ for k, v in vmrecords.iteritems() :
 #finding out which one is the master
 svm = XenAPI.Session("http://" +  slaves[0][1])
 try :
-    svm.login_with_password('root', 'xenroot')
+    svm.login_with_password('root', 'xenroot', '1.0', 'xen-api-scripts-hatest')
     masterref = svm.xenapi.pool.get_all_records().values()[0]['master']
     masterrecord = svm.xenapi.host.get_record(masterref)
     masterip = masterrecord['address']
 except XenAPI.Failure, inst:
     masterip = inst.details[1]
     svm = XenAPI.Session("http://" +  masterip)
-    svm.login_with_password('root', 'xenroot')
+    svm.login_with_password('root', 'xenroot', '1.0', 'xen-api-scripts-hatest')
     masterref = svm.xenapi.pool.get_all_records().values()[0]['master']
 for i in slaves :
     if masterip == i[1] :
@@ -235,7 +235,7 @@ for k, ip in slaves :
 print "Connecting to " + master[1] + "..."
 svm = XenAPI.Session("http://" +  master[1])
 try :
-    svm.login_with_password('root', 'xenroot')
+    svm.login_with_password('root', 'xenroot', '1.0', 'xen-api-scripts-hatest')
     check(svm, master[1])
 except XenAPI.Failure, inst:
     if inst.details[0] == "HOST_IS_SLAVE" :
@@ -247,7 +247,7 @@ for slave in slaves :
     print "Connecting to " + slave[1] + "..."
     svm = XenAPI.Session("http://" +  slave[1])
     try:
-        svm.login_with_password('root', 'xenroot')
+        svm.login_with_password('root', 'xenroot', '1.0', 'xen-api-scripts-hatest')
         print "Connection succeeded! Is %s still a slave?" % slave[1]
         check(svm, slave[1])
     except XenAPI.Failure, inst:

--- a/scripts/import-boxgrinder.py
+++ b/scripts/import-boxgrinder.py
@@ -258,7 +258,7 @@ if __name__ == "__main__":
         reopenlog(settings["log"])
 
     server = xmlrpclib.Server(settings["server"])
-    session = value(server.session.login_with_password(settings["username"], settings["password"]))
+    session = value(server.session.login_with_password(settings["username"], settings["password"], "1.0", "xen-api-scripts-import-boxgrinder"))
     try:
         (vm, vdis) = import_metadata(server, session, args[0])
         for filename in vdis.keys():

--- a/scripts/interface-reconfigure-test
+++ b/scripts/interface-reconfigure-test
@@ -581,7 +581,7 @@ def main(argv=None):
 if __name__ == "__main__":
     try:
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password("root", "")
+        session.xenapi.login_with_password("root", "", "1.0", "xen-api-scripts-interface-reconfig-test")
         rc = main()
     finally:
         session.xenapi.session.logout()

--- a/scripts/link-vms-by-sr.py
+++ b/scripts/link-vms-by-sr.py
@@ -20,7 +20,7 @@ def usage():
    
 def main(argv):
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password("", "")
+    session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-linkvmsbysr.py")
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hd:", [])

--- a/scripts/mail-alarm
+++ b/scripts/mail-alarm
@@ -35,7 +35,7 @@ def log_err(err):
 
 def get_pool_name():
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password(ma_username, "")
+    session.xenapi.login_with_password(ma_username, "", "1.0", "xen-api-scripts-mail-alarm")
     try:
         opaque_ref = session.xenapi.pool.get_all()[0]
         pool_name = session.xenapi.pool.get_name_label(opaque_ref)
@@ -50,7 +50,7 @@ def get_pool_name():
 
 def get_pool_other_config():
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password(ma_username, "")
+    session.xenapi.login_with_password(ma_username, "", "1.0", "xen-api-scripts-mail-alarm")
     try:
         opaque_ref = session.xenapi.pool.get_all()[0]
         return session.xenapi.pool.get_other_config(opaque_ref)
@@ -59,7 +59,7 @@ def get_pool_other_config():
 
 def get_VM_params(uuid):
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password(ma_username, "")
+    session.xenapi.login_with_password(ma_username, "", "1.0", "xen-api-scripts-mail-alarm")
     try:
         try:
             opaque_ref = session.xenapi.VM.get_by_uuid(uuid)
@@ -71,7 +71,7 @@ def get_VM_params(uuid):
 
 def get_host_params(uuid):
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password(ma_username, "")
+    session.xenapi.login_with_password(ma_username, "", "1.0", "xen-api-scripts-mail-alarm")
     try:
         try:
             opaque_ref = session.xenapi.host.get_by_uuid(uuid)

--- a/scripts/perfmon
+++ b/scripts/perfmon
@@ -103,7 +103,7 @@ class XapiSession(XenAPI.Session):
     """
     def __init__(self):
         XenAPI.Session.__init__(self, "http://_var_xapi_xapi", transport=XenAPI.UDSTransport())
-        self.xenapi.login_with_password("", "")
+        self.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-perfmon")
     def __del__ (self):
         self.xenapi.session.logout()
     def id(self):

--- a/scripts/print-custom-templates
+++ b/scripts/print-custom-templates
@@ -16,7 +16,7 @@ atexit.register(logout)
 def main(argv):
     try:
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password("", "")
+        session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-custom-template")
 
         templates = session.xenapi.VM.get_all_records_where('field "is_a_template" = "true" and field "is_a_snapshot" = "false"' )
     except:

--- a/scripts/restore-sr-metadata.py
+++ b/scripts/restore-sr-metadata.py
@@ -25,7 +25,7 @@ def usage():
 
 def main(argv):
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password("", "")
+    session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-restore-sr-metadata")
 
     try:
         opts, args = getopt.getopt(argv, "hf:u:", [])

--- a/scripts/scalability-tests/event-count.py
+++ b/scripts/scalability-tests/event-count.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     password = sys.argv[3]
     
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-eventcount.py")
     try:
         main(session)
     finally:

--- a/scripts/scalability-tests/ping-master.py
+++ b/scripts/scalability-tests/ping-master.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     password = sys.argv[3]
     
     session = XenAPI.Session(url)
-    session.xenapi.login_with_password(username, password)
+    session.xenapi.login_with_password(username, password, "1.0", "xen-api-scripts-pingmaster.py")
     try:
         main(session)
     finally:

--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -194,7 +194,7 @@ if  __name__ == "__main__":
             print
     elif sys.argv[1] == "add" and len(sys.argv) == 4:
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password("root", "")        
+        session.xenapi.login_with_password("root", "", "1.0", "xen-api-scripts-static-vdis")        
         try:
             add(session, sys.argv[2], sys.argv[3])
         finally:

--- a/scripts/templates/debian
+++ b/scripts/templates/debian
@@ -98,7 +98,7 @@ if __name__ == "__main__":
 
     server = xapi_local ()
     try:
-        session_id = server.session.login_with_password('','')['Value']
+        session_id = server.session.login_with_password('','','1.0','xen-api-scripts-debian')['Value']
         uuid = server.VM.get_uuid(session_id, vm)['Value']
         mountpoint = "/tmp/installer/%s" % (uuid)
     finally:
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         run("/usr/bin/unzip -p %s swap.img | dd of=%s oflag=direct bs=1M", xgt, xvdb)
 
         try:
-            session_id = server.session.login_with_password('','')['Value']
+            session_id = server.session.login_with_password('','','1.0','xen-api-scripts-debian')['Value']
             vbds = server.VM.get_VBDs(session_id, vm)['Value']
             for i in vbds:
                 dev = server.VBD.get_userdevice(session_id, i)['Value']

--- a/scripts/time-vm-boots.py
+++ b/scripts/time-vm-boots.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
         sys.exit(1)
     # First acquire a valid session by logging in:
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password("", "")
+    session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-timevmboots.py")
 
     # We start watching all Halted VMs
     all = session.xenapi.VM.get_all_records()


### PR DESCRIPTION
The login_with_password XenAPI call takes an "originator"
string as its fourth parameter.

If a client does this, then it gets its own pool of xapi sessions.
Moreover it will not have its xapi sessions destroyed prematurely
as a result of some other misbehaving client that keeps creating
sessions and not logging out of them.

This patch adds the "originator" to all invokes of
login_with_password.

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>