### PR TITLE
Update PCI class fields on update_pcis

### DIFF
--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -98,6 +98,11 @@ let update_pcis ~__context ~host =
 					then Db.PCI.set_subsystem_device_id ~__context ~self:rf ~value:subsystem_device_id;
 					if rc.Db_actions.pCI_subsystem_device_name <> subsystem_device_name
 					then Db.PCI.set_subsystem_device_name ~__context ~self:rf ~value:subsystem_device_name;
+					(* sync the class information. *)
+					if rc.Db_actions.pCI_class_id <> id_of_int pci.pci_class.id
+					then Db.PCI.set_class_id ~__context ~self:rf ~value:(id_of_int pci.pci_class.id);
+					if rc.Db_actions.pCI_class_name <> pci.pci_class.name
+					then Db.PCI.set_class_name ~__context ~self:rf ~value:pci.pci_class.name;
 					(* sync the attached VMs. *)
 					let attached_VMs = List.filter (Db.is_valid_ref __context) rc.Db_actions.pCI_attached_VMs in
 					if attached_VMs <> rc.Db_actions.pCI_attached_VMs then

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -73,10 +73,16 @@ let update_pcis ~__context ~host =
 		| pci :: remaining_pcis ->
 			let obj =
 				try
+					let (subsystem_vendor_id, subsystem_vendor_name) =
+						strings_of_pci_property pci.subsystem_vendor in
+					let (subsystem_device_id, subsystem_device_name) =
+						strings_of_pci_property pci.subsystem_device in
 					let (rf, rc) = List.find (fun (rf, rc) ->
 						rc.Db_actions.pCI_pci_id = pci.address &&
 						rc.Db_actions.pCI_vendor_id = id_of_int pci.vendor.id &&
-						rc.Db_actions.pCI_device_id = id_of_int pci.device.id)
+						rc.Db_actions.pCI_device_id = id_of_int pci.device.id &&
+						rc.Db_actions.pCI_subsystem_vendor_id = subsystem_vendor_id &&
+						rc.Db_actions.pCI_subsystem_device_id = subsystem_device_id)
 						existing in
 					(* sync the vendor name. *)
 					if rc.Db_actions.pCI_vendor_name <> pci.vendor.name
@@ -84,18 +90,10 @@ let update_pcis ~__context ~host =
 					(* sync the device name. *)
 					if rc.Db_actions.pCI_device_name <> pci.device.name
 					then Db.PCI.set_device_name ~__context ~self:rf ~value:pci.device.name;
-					(* sync the subsystem vendor fields. *)
-					let subsystem_vendor_id, subsystem_vendor_name =
-						strings_of_pci_property pci.subsystem_vendor in
-					if rc.Db_actions.pCI_subsystem_vendor_id <> subsystem_vendor_id
-					then Db.PCI.set_subsystem_vendor_id ~__context ~self:rf ~value:subsystem_vendor_id;
+					(* sync the subsystem vendor name. *)
 					if rc.Db_actions.pCI_subsystem_vendor_name <> subsystem_vendor_name
 					then Db.PCI.set_subsystem_vendor_name ~__context ~self:rf ~value:subsystem_vendor_name;
-					(* sync the subsystem device fields. *)
-					let subsystem_device_id, subsystem_device_name =
-						strings_of_pci_property pci.subsystem_device in
-					if rc.Db_actions.pCI_subsystem_device_id <> subsystem_device_id
-					then Db.PCI.set_subsystem_device_id ~__context ~self:rf ~value:subsystem_device_id;
+					(* sync the subsystem device name. *)
 					if rc.Db_actions.pCI_subsystem_device_name <> subsystem_device_name
 					then Db.PCI.set_subsystem_device_name ~__context ~self:rf ~value:subsystem_device_name;
 					(* sync the class information. *)


### PR DESCRIPTION
This is required for upgrades from 6.5 where we weren't storing the whole class ID. We only stored the most significant byte as a string. For example, display controllers have PCI class `03xx` and we were storing `03` in the database for `PCI.class_id`. The new code stores the whole class ID and checks that the 16-bit integer has the right base class to determine whether or not to create a PGPU. This changeset updates the class fields on the PCI object when Xapi starts and will result in any PCIs with `class_id` `03` be updated to have their full class ID.