### PR TITLE
CA-173622: Enable session.logout()

### DIFF
--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -197,6 +197,8 @@ class Session(xmlrpclib.ServerProxy):
             return _Dispatcher(self.API_version, self.xenapi_request, None)
         elif name.startswith('login') or name.startswith('slave_local'):
             return lambda *params: self._login(name, params)
+        elif name == 'logout':
+            return _Dispatcher(self.API_version, self.xenapi_request, "logout")
         else:
             return xmlrpclib.ServerProxy.__getattr__(self, name)
 


### PR DESCRIPTION
Several API examples exist, including one in the xen-api repo, that use
session.logout directly without going through session.xenapi or
session.xenapi.session.  While this is not the correct way to
logout of the XAPI session, logout is one of the special cases
that needs to be supported from the session object.

Signed-Off-By: Bob Ball <bob.ball@citrix.com>