### PR TITLE
CP-12512 ssl-legacy controls outward stunnels too.

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -687,6 +687,11 @@ let set_stunnel_timeout () =
   with _ ->
     debug "Using default stunnel timeout (usually 43200)"
 
+let set_stunnel_legacy ~__context () =
+  let localhost = Helpers.get_localhost ~__context in
+  let legacy = Db.Host.get_ssl_legacy ~__context ~self:localhost in
+  Stunnel.set_legacy_protocol_and_ciphersuites_allowed legacy
+
 let server_init() =
   let print_server_starting_message() = debug "on_system_boot=%b pool_role=%s" !Xapi_globs.on_system_boot (Pool_role.string_of (Pool_role.get_role ())) in
 
@@ -820,6 +825,7 @@ let server_init() =
      running etc.) -- see CA-11087 *)
     "starting up database engine", [ Startup.OnlyMaster ], start_database_engine;
 	"hi-level database upgrade", [ Startup.OnlyMaster ], Xapi_db_upgrade.hi_level_db_upgrade_rules ~__context;
+    "Setting config for outgoing stunnels", [], set_stunnel_legacy ~__context; (* Requires database access *)
     "bringing up management interface", [], bring_up_management_if ~__context;
     "Starting periodic scheduler", [Startup.OnThread], Xapi_periodic_scheduler.loop;
     "Remote requests", [Startup.OnThread], Remote_requests.handle_requests;

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -883,9 +883,10 @@ let set_hostname_live ~__context ~host ~hostname =
 
 let set_ssl_legacy ~__context ~self ~value =
 	let old = Db.Host.get_ssl_legacy ~__context ~self in
+	info "set_ssl_legacy %B where old=%B" value old;
 	Db.Host.set_ssl_legacy ~__context ~self ~value;
 	if old <> value then (
-		(* TODO change outgoing stunnels as well *)
+		Stunnel.set_legacy_protocol_and_ciphersuites_allowed value;
 		Xapi_mgmt_iface.reconfigure_stunnel ~__context
 	)
 


### PR DESCRIPTION
Host.ssl_legacy now controls the protocol-version and ciphersuites
used by outgoing TLS connections, not just incoming ones.
