### PR TITLE
SCTX-2115: Force lifecycle operations should cancel clean operations

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1424,7 +1424,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			with_vm_operation ~__context ~self:vm ~doc:"VM.hard_shutdown" ~op:`hard_shutdown
 				(fun () ->
 				  List.iter (fun (task,op) ->
-				    if op = `clean_shutdown then
+				    if List.mem op [ `clean_shutdown; `clean_reboot; `hard_reboot ] then
 				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
 
 					(* If VM is actually suspended and we ask to hard_shutdown, we need to
@@ -1463,7 +1463,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			with_vm_operation ~__context ~self:vm ~doc:"VM.hard_reboot" ~op:`hard_reboot
 				(fun () ->
 				  List.iter (fun (task,op) ->
-				    if op = `clean_reboot then
+				    if List.mem op [ `clean_shutdown; `clean_reboot ] then
 				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
 
 

--- a/ocaml/xapi/mtc.ml
+++ b/ocaml/xapi/mtc.ml
@@ -276,12 +276,6 @@ let update_vm_state_if_necessary ~__context ~vm =
       raise e
   end
 
-(* Raises an exception if the destination VM is not in the expected power state:  halted *)
-let verify_dest_vm_power_state ~__context ~vm =
-  let actual = Db.VM.get_power_state ~__context ~self:vm in
-  if actual != `Halted then
-    raise(Api_errors.Server_error(Api_errors.vm_bad_power_state, [Ref.string_of vm; "halted"; (Record_util.power_to_string actual)]))
-
 (* Returns true if VDI is accessed by an MTC-protected VM *)
 let is_vdi_accessed_by_protected_VM ~__context ~vdi =
 

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -33,9 +33,7 @@ let assert_attachable ~__context ~self : unit =
 
 let set_mode ~__context ~self ~value =
 	let vm = Db.VBD.get_VM ~__context ~self in
-	let power_state = Db.VM.get_power_state ~__context ~self:vm in
-	if power_state <> `Halted
-	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [Ref.string_of vm; Record_util.power_to_string `Halted; Record_util.power_to_string power_state]));
+	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self:vm ~expected:`Halted;
 	Db.VBD.set_mode ~__context ~self ~value
 
 let plug ~__context ~self =

--- a/ocaml/xapi/xapi_vgpu.ml
+++ b/ocaml/xapi/xapi_vgpu.ml
@@ -26,10 +26,7 @@ let create ~__context  ~vM ~gPU_group ~device ~other_config ~_type =
 	let uuid = Uuid.to_string (Uuid.make_uuid ()) in
 	if not (Pool_features.is_enabled ~__context Features.GPU) then
 		raise (Api_errors.Server_error (Api_errors.feature_restricted, []));
-	let vm_power_state = Db.VM.get_power_state ~__context ~self:vM in
-	if (vm_power_state <> `Halted) then
-		raise (Api_errors.Server_error (Api_errors.vm_bad_power_state,
-			Ref.string_of vM :: List.map Record_util.power_to_string [`Halted; vm_power_state]));
+	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self:vM ~expected:`Halted;
 	if not(valid_device device) then
 		raise (Api_errors.Server_error (Api_errors.invalid_device, [device]));
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -161,15 +161,6 @@ let set_memory_limits ~__context ~self
 	Vm_memory_constraints.set ~__context ~vm_ref:self ~constraints;
 	update_memory_overhead ~__context ~vm:self
 
-(* CA-12940: sanity check to make sure this never happens again *)
-let assert_power_state_is ~__context ~vm ~expected =
-	let actual = Db.VM.get_power_state ~__context ~self:vm in
-	if actual <> expected
-	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [
-								Ref.string_of vm;
-								Record_util.power_to_string expected;
-								Record_util.power_to_string actual ]))
-
 (* If HA is enabled on the Pool and the VM is marked as always_run then block the action *)
 let assert_not_ha_protected ~__context ~vm =
 	let pool = Helpers.get_pool ~__context in

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -66,17 +66,6 @@ val set_memory_limits :
   self:[ `VM ] Ref.t ->
   static_min:Int64.t ->
   static_max:Int64.t -> dynamic_min:Int64.t -> dynamic_max:Int64.t -> unit
-val assert_power_state_is :
-  __context:Context.t ->
-  vm:[ `VM ] Ref.t ->
-  expected:[< `Halted
-            | `Migrating
-            | `Paused
-            | `Running
-            | `ShuttingDown
-            | `Suspended
-            > `Halted `Paused `Running `Suspended ] ->
-  unit
 val assert_not_ha_protected : __context:Context.t -> vm:[ `VM ] Ref.t -> unit
 val pause : __context:Context.t -> vm:API.ref_VM -> unit
 val unpause : __context:Context.t -> vm:API.ref_VM -> unit

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -504,3 +504,12 @@ let get_operation_error ~__context ~self ~op ~strict =
 let is_live ~__context ~self =
 	let power_state = Db.VM.get_power_state ~__context ~self in
 	power_state = `Running || power_state = `Paused
+
+type power_state = [ `Halted | `Paused | `Running | `Suspended ]
+let assert_power_state_is ~__context ~self ~(expected:power_state) =
+	let actual = Db.VM.get_power_state ~__context ~self in
+	if actual <> expected
+	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [
+								Ref.string_of self;
+								Record_util.power_to_string expected;
+								Record_util.power_to_string actual ]))

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -506,10 +506,12 @@ let is_live ~__context ~self =
 	power_state = `Running || power_state = `Paused
 
 type power_state = [ `Halted | `Paused | `Running | `Suspended ]
-let assert_power_state_is ~__context ~self ~(expected:power_state) =
+let assert_power_state_in ~__context ~self ~(allowed:power_state list) =
 	let actual = Db.VM.get_power_state ~__context ~self in
-	if actual <> expected
+	if not (List.mem actual allowed)
 	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [
 								Ref.string_of self;
-								Record_util.power_to_string expected;
+                List.map Record_util.power_to_string allowed |> String.concat ";";
 								Record_util.power_to_string actual ]))
+
+let assert_power_state_is ~expected = assert_power_state_in ~allowed:[expected]

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -505,13 +505,12 @@ let is_live ~__context ~self =
 	let power_state = Db.VM.get_power_state ~__context ~self in
 	power_state = `Running || power_state = `Paused
 
-type power_state = [ `Halted | `Paused | `Running | `Suspended ]
-let assert_power_state_in ~__context ~self ~(allowed:power_state list) =
+let assert_power_state_in ~__context ~self ~allowed =
 	let actual = Db.VM.get_power_state ~__context ~self in
 	if not (List.mem actual allowed)
 	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [
-								Ref.string_of self;
-                List.map Record_util.power_to_string allowed |> String.concat ";";
-								Record_util.power_to_string actual ]))
+		Ref.string_of self;
+		List.map Record_util.power_to_string allowed |> String.concat ";";
+		Record_util.power_to_string actual ]))
 
 let assert_power_state_is ~expected = assert_power_state_in ~allowed:[expected]

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -892,7 +892,7 @@ let handler req fd _ =
 			let dbg = Context.string_of_task __context in
 			let queue_name = Xapi_xenops_queue.queue_of_vm ~__context ~self:vm in
 			Xapi_network.with_networks_attached_for_vm ~__context ~vm (fun () ->
-				Xapi_xenops.transform_xenops_exn ~__context queue_name (fun () ->
+				Xapi_xenops.transform_xenops_exn ~__context ~vm queue_name (fun () ->
 					debug "Sending VM %s configuration to xenopsd" (Ref.string_of vm);
 					let id = Xapi_xenops.Xenopsd_metadata.push ~__context ~upgrade:true ~self:vm in
 					info "xenops: VM.receive_memory %s" id;

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1843,7 +1843,7 @@ let success_task queue_name f dbg id =
 
 (* Catch any uncaught xenops exceptions and transform into the most relevant XenAPI error.
    We do not want a XenAPI client to see a raw xenopsd error. *)
-let transform_xenops_exn ~__context queue_name f =
+let transform_xenops_exn ~__context ~vm queue_name f =
 	try
 		f ()
 	with e ->
@@ -1864,9 +1864,9 @@ let transform_xenops_exn ~__context queue_name f =
 		| Domain_not_built -> internal "domain has not been built"
 		| Invalid_vcpus n -> internal "the maximum number of vcpus configured for this VM is currently: %d" n
 		| Bad_power_state(found, expected) ->
-			let f x = x |> (fun x -> Some x) |> xenapi_of_xenops_power_state |> Record_util.power_state_to_string in
+			let f x = xenapi_of_xenops_power_state (Some x) |> Record_util.power_state_to_string in
 			let found = f found and expected = f expected in
-			reraise Api_errors.vm_bad_power_state [ expected; found ]
+			reraise Api_errors.vm_bad_power_state [ Ref.string_of vm; expected; found ]
 		| Failed_to_acknowledge_shutdown_request ->
 			reraise Api_errors.vm_failed_shutdown_ack []
 		| Failed_to_shutdown(id, timeout) ->
@@ -1970,7 +1970,7 @@ let sync __context queue_name x =
 
 let pause ~__context ~self =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.pause %s" id;
@@ -1983,7 +1983,7 @@ let pause ~__context ~self =
 
 let unpause ~__context ~self =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.unpause %s" id;
@@ -1996,7 +1996,7 @@ let unpause ~__context ~self =
 
 let request_rdp ~__context ~self enabled =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.request_rdp %s %b" id enabled;
@@ -2008,7 +2008,7 @@ let request_rdp ~__context ~self enabled =
 
 let set_xenstore_data ~__context ~self xsdata =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.set_xenstore_data %s" id;
@@ -2020,7 +2020,7 @@ let set_xenstore_data ~__context ~self xsdata =
 
 let set_vcpus ~__context ~self n =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.set_vcpus %s" id;
@@ -2043,7 +2043,7 @@ let set_vcpus ~__context ~self n =
 
 let set_shadow_multiplier ~__context ~self target =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.set_shadow_multiplier %s" id;
@@ -2064,7 +2064,7 @@ let set_shadow_multiplier ~__context ~self target =
 
 let set_memory_dynamic_range ~__context ~self min max =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.set_memory_dynamic_range %s" id;
@@ -2077,7 +2077,7 @@ let set_memory_dynamic_range ~__context ~self min max =
 let start ~__context ~self paused =
 	let dbg = Context.string_of_task __context in
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			(* For all devices which we want xenopsd to manage, set currently_attached = true
 			   so the metadata is pushed. *)
@@ -2144,7 +2144,7 @@ let start ~__context ~self paused =
 
 let start ~__context ~self paused =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			try
 				start ~__context ~self paused
@@ -2161,7 +2161,7 @@ let start ~__context ~self paused =
 
 let reboot ~__context ~self timeout =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self;
 			let id = id_of_vm ~__context ~self in
@@ -2177,7 +2177,7 @@ let reboot ~__context ~self timeout =
 
 let shutdown ~__context ~self timeout =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self;
 			let id = id_of_vm ~__context ~self in
@@ -2198,7 +2198,7 @@ let shutdown ~__context ~self timeout =
 
 let suspend ~__context ~self =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self;
 			let id = id_of_vm ~__context ~self in
@@ -2245,7 +2245,7 @@ let suspend ~__context ~self =
 let resume ~__context ~self ~start_paused ~force =
 	let dbg = Context.string_of_task __context in
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let vdi = Db.VM.get_suspend_VDI ~__context ~self in
 			let disk = disk_of_vdi ~__context ~self:vdi |> Opt.unbox in
@@ -2286,7 +2286,7 @@ let resume ~__context ~self ~start_paused ~force =
 
 let s3suspend ~__context ~self =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			let dbg = Context.string_of_task __context in
@@ -2298,7 +2298,7 @@ let s3suspend ~__context ~self =
 
 let s3resume ~__context ~self =
 	let queue_name = queue_of_vm ~__context ~self in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			let dbg = Context.string_of_task __context in
@@ -2324,7 +2324,7 @@ let md_of_vbd ~__context ~self =
 let vbd_plug ~__context ~self =
 	let vm = Db.VBD.get_VM ~__context ~self in
 	let queue_name = queue_of_vm ~__context ~self:vm in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self:vm;
 			Events_from_xapi.wait ~__context ~self:vm;
@@ -2348,7 +2348,7 @@ let vbd_plug ~__context ~self =
 let vbd_unplug ~__context ~self force =
 	let vm = Db.VBD.get_VM ~__context ~self in
 	let queue_name = queue_of_vm ~__context ~self:vm in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self:vm;
 			let vbd = md_of_vbd ~__context ~self in
@@ -2368,7 +2368,7 @@ let vbd_unplug ~__context ~self force =
 let vbd_eject_hvm ~__context ~self =
 	let vm = Db.VBD.get_VM ~__context ~self in
 	let queue_name = queue_of_vm ~__context ~self:vm in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self:vm;
 			let vbd = md_of_vbd ~__context ~self in
@@ -2385,7 +2385,7 @@ let vbd_eject_hvm ~__context ~self =
 let vbd_insert_hvm ~__context ~self ~vdi =
 	let vm = Db.VBD.get_VM ~__context ~self in
 	let queue_name = queue_of_vm ~__context ~self:vm in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self:vm;
 			let vbd = md_of_vbd ~__context ~self in
@@ -2434,7 +2434,7 @@ let md_of_vif ~__context ~self =
 let vif_plug ~__context ~self =
 	let vm = Db.VIF.get_VM ~__context ~self in
 	let queue_name = queue_of_vm ~__context ~self:vm in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self:vm;
 			Events_from_xapi.wait ~__context ~self:vm;
@@ -2462,7 +2462,7 @@ let vm_set_vm_data ~__context ~self = ()
 let vif_set_locking_mode ~__context ~self =
 	let vm = Db.VIF.get_VM ~__context ~self in
 	let queue_name = queue_of_vm ~__context ~self:vm in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self:vm;
 			let vif = md_of_vif ~__context ~self in
@@ -2476,7 +2476,7 @@ let vif_set_locking_mode ~__context ~self =
 let vif_unplug ~__context ~self force =
 	let vm = Db.VIF.get_VM ~__context ~self in
 	let queue_name = queue_of_vm ~__context ~self:vm in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self:vm;
 			let vif = md_of_vif ~__context ~self in
@@ -2492,7 +2492,7 @@ let vif_unplug ~__context ~self force =
 let vif_move ~__context ~self network =
 	let vm = Db.VIF.get_VM ~__context ~self in
 	let queue_name = queue_of_vm ~__context ~self:vm in
-	transform_xenops_exn ~__context queue_name
+	transform_xenops_exn ~__context ~vm queue_name
 		(fun () ->
 			assert_resident_on ~__context ~self:vm;
 			let vif = md_of_vif ~__context ~self in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1847,6 +1847,7 @@ let transform_xenops_exn ~__context queue_name f =
 	try
 		f ()
 	with e ->
+		Backtrace.is_important e;
 		let reraise code params =
 			error "Re-raising as %s [ %s ]" code (String.concat "; " params);
 			let e' = Api_errors.Server_error(code, params) in


### PR DESCRIPTION
Some commits for refactoring and suchlike, then the behaviour change.

This is an improvement but does not solve the problem completely: if a
clean shutdown or reboot is in progress on a VM on a slave then a hard
shutdown will cancel it, but then the VM does not shut down (but a
subsequent hard shutdown will work).
