### PR TITLE
CP-12141: Remove all master/slave knowledge from xcp-rrdd

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -265,14 +265,14 @@ let update_env __context sync_keys =
       let cache_sr = Db.Host.get_local_cache_sr ~__context ~self:(Helpers.get_localhost ~__context) in
       let cache_sr_uuid = Db.SR.get_uuid ~__context ~self:cache_sr in
       Db.SR.set_local_cache_enabled ~__context ~self:cache_sr ~value:true;
-      log_and_ignore_exn (Rrdd.set_cache_sr ~sr_uuid:cache_sr_uuid)
+      log_and_ignore_exn (fun () -> Rrdd.set_cache_sr ~sr_uuid:cache_sr_uuid)
     with _ -> log_and_ignore_exn Rrdd.unset_cache_sr
   );
 
   switched_sync Xapi_globs.sync_load_rrd (fun () -> 
     (* Load the host rrd *)
     Rrdd_proxy.Deprecated.load_rrd ~__context
-      ~uuid:(Helpers.get_localhost_uuid ()) ~is_host:true
+      ~uuid:(Helpers.get_localhost_uuid ())
   );
 
   (* maybe record host memory properties in database *)

--- a/ocaml/xapi/monitor_master.ml
+++ b/ocaml/xapi/monitor_master.ml
@@ -29,7 +29,7 @@ let update_configuration_from_master () =
 		let oc = Db.Pool.get_other_config ~__context ~self:(Helpers.get_pool ~__context) in
 		let new_use_min_max = (List.mem_assoc Xapi_globs.create_min_max_in_new_VM_RRDs oc) &&
 			(List.assoc Xapi_globs.create_min_max_in_new_VM_RRDs oc = "true") in
-		log_and_ignore_exn (Rrdd.update_use_min_max ~value:new_use_min_max);
+		log_and_ignore_exn (fun () -> Rrdd.update_use_min_max ~value:new_use_min_max);
 		let carrier = (List.mem_assoc Xapi_globs.pass_through_pif_carrier_key oc) &&
 			(List.assoc Xapi_globs.pass_through_pif_carrier_key oc = "true") in
 		if !Xapi_globs.pass_through_pif_carrier <> carrier

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -345,7 +345,7 @@ module Monitor = struct
 						let heartbeat_latency = float_of_int local.Xha_interface.LiveSetInformation.RawStatus.heartbeat_latency /. 1000. -. (float_of_int timeouts.Timeouts.heart_beat_interval) in
 						let xapi_latency = float_of_int (local.Xha_interface.LiveSetInformation.RawStatus.xapi_healthcheck_latency) /. 1000. in
 						let statefile_latencies = List.map (fun vdi -> let open Rrd.Statefile_latency in {id = vdi.Static_vdis.uuid; latency = Some statefile}) statefiles in
-						log_and_ignore_exn (Rrdd.HA.enable_and_update ~statefile_latencies ~heartbeat_latency ~xapi_latency)
+						log_and_ignore_exn (fun () -> Rrdd.HA.enable_and_update ~statefile_latencies ~heartbeat_latency ~xapi_latency)
 					) liveset.Xha_interface.LiveSetInformation.raw_status_on_local_host;
 
 				(* All hosts: create alerts from per-host warnings (if available) *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -479,7 +479,7 @@ let shutdown_and_reboot_common ~__context ~host label description operation cmd 
 
 	(* Push the Host RRD to the master. Note there are no VMs running here so we don't have to worry about them. *)
 	if not(Pool_role.is_master ())
-	then log_and_ignore_exn Rrdd.send_host_rrd_to_master;
+	then log_and_ignore_exn ( fun () -> Rrdd.send_host_rrd_to_master ~master_address:(Pool_role.get_master_address () ));
 	(* Also save the Host RRD to local disk for us to pick up when we return. Note there are no VMs running at this point. *)
 	log_and_ignore_exn Rrdd.backup_rrds;
 
@@ -940,7 +940,7 @@ let sync_data ~__context ~host =
 let backup_rrds ~__context ~host ~delay =
 	Xapi_periodic_scheduler.add_to_queue "RRD backup" Xapi_periodic_scheduler.OneShot
 	delay (fun _ ->
-		log_and_ignore_exn (Rrdd.backup_rrds ~save_stats_locally:(Pool_role.is_master ()))
+		log_and_ignore_exn (Rrdd.backup_rrds ~remote_address:(Some (Pool_role.get_master_address ())))
 	)
 
 let get_servertime ~__context ~host =
@@ -1379,7 +1379,7 @@ let enable_local_storage_caching ~__context ~host ~sr =
 		if old_sr <> Ref.null then Db.SR.set_local_cache_enabled ~__context ~self:old_sr ~value:false;
 		Db.Host.set_local_cache_sr ~__context ~self:host ~value:sr;
 		Db.SR.set_local_cache_enabled ~__context ~self:sr ~value:true;
-		log_and_ignore_exn (Rrdd.set_cache_sr ~sr_uuid:(Db.SR.get_uuid ~__context ~self:sr));
+		log_and_ignore_exn (fun () -> Rrdd.set_cache_sr ~sr_uuid:(Db.SR.get_uuid ~__context ~self:sr));
 	end else begin
 		raise (Api_errors.Server_error (Api_errors.sr_operation_not_supported,[]))
 	end

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -335,7 +335,9 @@ let power_state_reset ~__context ~vm =
 
 let suspend ~__context ~vm =
 	Db.VM.set_ha_always_run ~__context ~self:vm ~value:false;
-	Xapi_xenops.suspend ~__context ~self:vm
+	Xapi_xenops.suspend ~__context ~self:vm;
+	let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
+	log_and_ignore_exn (fun () -> Rrdd.archive_rrd ~vm_uuid ~remote_address:(Some (Pool_role.get_master_address ())))
 
 let resume ~__context ~vm ~start_paused ~force = 
 	if Db.VM.get_ha_restart_priority ~__context ~self:vm = Constants.ha_restart
@@ -461,7 +463,7 @@ let destroy  ~__context ~self =
 		(fun child -> try Db.VM.set_parent ~__context ~self:child ~value:parent with _ -> ())
 		(Db.VM.get_children ~__context ~self);
 
-	log_and_ignore_exn (Rrdd.remove_rrd ~uuid:(Db.VM.get_uuid ~__context ~self));
+	log_and_ignore_exn (fun () -> Rrdd.remove_rrd ~uuid:(Db.VM.get_uuid ~__context ~self));
 	destroy ~__context ~self
 
 (* Note: we don't need to call lock_vm around clone or copy. The lock_vm just takes the local

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -472,6 +472,12 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
 		Db.VM.set_scheduled_to_be_resident_on ~__context ~self ~value:Ref.null;
 		Db.VM.set_domid ~__context ~self ~value:(-1L)
 	end;
+        
+        if state = `Halted then begin
+                (* archive the rrd for this vm *)
+                let vm_uuid = Db.VM.get_uuid ~__context ~self in;
+                Rrdd.archive_rrd ~vm_uuid ~remote_address:(Some (Pool_role.get_master_address ())
+        end;
 
 	Db.VM.set_power_state ~__context ~self ~value:state;
 	update_allowed_operations ~__context ~self


### PR DESCRIPTION
This does the following:
* Design made as part of CP-12182 has been implemented in xcp-rrdd and xen-api
* pool_role_shared.ml has been removed from xcp-rrdd. rrdd API calls which
  rely on it have been changed to accept host addresses
* unnecessary () arguments have been removed from API calls in
  rrd_interface.ml

Signed-off-by: Koushik Chakravarty <Koushik.Chakravarty@citrix.com>