### PR TITLE
Tidy up allowed_operations code for vGPU migration and suspend

### DIFF
--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -116,3 +116,5 @@ let delay_xenopsd_event_threads () = fistpoint "delay_xenopsd_event_threads"
 
 let allowed_unsigned_patches () = fistpoint_read "allowed_unsigned_patches"
 
+(** Allows migration and suspension of VMs with NVIDIA vGPUs. *)
+let allow_nvidia_vgpu_migration () = fistpoint "allow_nvidia_vgpu_migration"

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -230,7 +230,7 @@ let check_vgpu ~__context ~op ~ref_str ~vgpus =
 					acc && (implementation = `nvidia))
 				true vgpus
 		in
-		if all_nvidia_vgpus
+		if all_nvidia_vgpus && (Xapi_fist.allow_nvidia_vgpu_migration ())
 		then None
 		else Some (Api_errors.vm_has_vgpu, [ref_str])
 	end

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -220,7 +220,7 @@ let check_pci ~op ~ref_str =
 
 let check_vgpu ~op ~ref_str =
 	match op with
-	| `suspend | `checkpoint | `pool_migrate | `migrate_send -> Some (Api_errors.vm_has_vgpu, [ref_str])
+	| `checkpoint | `migrate_send -> Some (Api_errors.vm_has_vgpu, [ref_str])
 	| _ -> None
 
 (* VM cannot be converted into a template while it is a member of an appliance. *)


### PR DESCRIPTION
* Restrict migration/suspend to NVIDIA vGPUs only
* Add a FIST point to allow vGPU migration/suspend