### PR TITLE
CP-12093: Add a new field "capabilities" to PIF record

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -267,6 +267,8 @@ let pif_record rpc session_id pif =
 		~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.pIF_properties)
 		~get_map:(fun () -> (x ()).API.pIF_properties)
 		~set_in_map:(fun k v -> Client.PIF.set_property rpc session_id pif k v) ();
+	make_field ~name:"capabilities" ~get:(fun () -> String.concat "; " (x ()).API.pIF_capabilities)
+		~get_set:(fun () -> (x ()).API.pIF_capabilities) ();
 	make_field ~name:"io_read_kbs" ~get:(fun () -> 
 	  try 
 	    let host = (x ()).API.pIF_host in

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4944,6 +4944,7 @@ let pif =
 		is managed by xapi. If it is not, then xapi will not configure the interface, the commands PIF.plug/unplug/reconfigure_ip(v6) \
 		can not be used, nor can the interface be bonded or have VLANs based on top through xapi." ~default_value:(Some (VBool true));
 	field ~lifecycle:[Published, rel_creedence, ""] ~qualifier:DynamicRO ~ty:(Map(String, String)) ~default_value:(Some (VMap [])) "properties" "Additional configuration properties for the interface.";
+	field ~lifecycle:[Published, rel_dundee, ""] ~qualifier:DynamicRO ~ty:(Set(String)) ~default_value:(Some (VSet [])) "capabilities" "Additional capabilities on the interface.";
       ]
 	()
 

--- a/ocaml/xapi/network.mli
+++ b/ocaml/xapi/network.mli
@@ -13,6 +13,7 @@ module Net :
 				val exists : string -> name:Network_interface.iface -> bool
 				val get_mac : string -> name:Network_interface.iface -> string
 				val is_up : string -> name:Network_interface.iface -> bool
+				val get_capabilities: string -> name:Network_interface.iface -> string list
 				val get_ipv4_addr :
 					string ->
 					name:Network_interface.iface -> (Unix.inet_addr * int) list

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -398,7 +398,7 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
 			~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
 			~vLAN_master_of:Ref.null ~management:false ~other_config:[] ~disallow_unplug:false
 			~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true
-			~properties:pif_properties;
+			~properties:pif_properties ~capabilities:[];
 		Db.Bond.create ~__context ~ref:bond ~uuid:(Uuid.to_string (Uuid.make_uuid ())) ~master:master ~other_config:[]
 			~primary_slave ~mode ~properties ~links_up:0L;
 

--- a/ocaml/xapi/xapi_tunnel.ml
+++ b/ocaml/xapi/xapi_tunnel.ml
@@ -42,7 +42,7 @@ let create_internal ~__context ~transport_PIF ~network ~host =
 		~physical:false ~currently_attached:false 
 		~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null 
 		~vLAN_master_of:Ref.null ~management:false ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
-	        ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true ~properties:[];
+	        ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true ~properties:[] ~capabilities:[];
 	Db.Tunnel.create ~__context ~ref:tunnel ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
 		~access_PIF ~transport_PIF ~status:["active", "false"] ~other_config:[];
 	tunnel, access_PIF

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -29,7 +29,7 @@ let create_internal ~__context ~host ~tagged_PIF ~tag ~network ~device =
 		~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
 		~vLAN_master_of:vlan ~management:false ~other_config:[] ~disallow_unplug:false
 		~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true
-		~properties:[];
+		~properties:[] ~capabilities:[];
 
 	let () = Db.VLAN.create ~__context ~ref:vlan ~uuid:vlan_uuid ~tagged_PIF ~untagged_PIF ~tag ~other_config:[] in
 	vlan, untagged_PIF


### PR DESCRIPTION
Use fcoe_driver interface to identify fcoe capable NICs.

Capabilities field:
1) ["fcoe"] - represents NIC supports fcoe
2) [] - represents NIC doesn't support fcoe

Signed-off-by: sharad yadav <sharad.yadav@citrix.com>