### PR TITLE
CA-174923: Fixes for VGPU capacity planning

### DIFF
--- a/ocaml/test/test_pgpu.ml
+++ b/ocaml/test/test_pgpu.ml
@@ -39,7 +39,7 @@ let test_can_run_VGPU_succeeds_enabled_types () =
 
 let test_can_run_VGPU_succeeds_same_type () =
 	on_host_with_k2 (fun __context p ->
-		let _ = make_vgpu ~__context ~resident_on:p k260q in
+		let (_:API.ref_VGPU) = make_vgpu ~__context ~resident_on:p k260q in
 		let vgpu = make_vgpu ~__context k260q in
 		Xapi_pgpu.assert_can_run_VGPU ~__context ~self:p ~vgpu)
 
@@ -61,7 +61,7 @@ let test_can_run_VGPU_fails_disabled_type () =
 
 let test_can_run_VGPU_fails_different_type () =
 	on_host_with_k2 (fun __context p ->
-		let _ = make_vgpu ~__context ~resident_on:p k260q in
+		let (_:API.ref_VGPU) = make_vgpu ~__context ~resident_on:p k260q in
 		let vgpu = make_vgpu ~__context k240q in
 		assert_raises_api_error
 			Api_errors.vgpu_type_not_compatible_with_running_type
@@ -70,7 +70,8 @@ let test_can_run_VGPU_fails_different_type () =
 let test_can_run_VGPU_fails_no_capacity () =
 	on_host_with_k2 (fun __context p ->
 		(* Fill up the pGPU with 2 x K260Q *)
-		let _ = List.map (make_vgpu ~__context ~resident_on:p) [k260q; k260q] in
+		let (_:API.ref_VGPU list) =
+			List.map (make_vgpu ~__context ~resident_on:p) [k260q; k260q] in
 		(* Should fail to put another one on *)
 		let vgpu = make_vgpu ~__context k260q in
 		assert_raises_api_error

--- a/ocaml/test/test_pgpu.ml
+++ b/ocaml/test/test_pgpu.ml
@@ -27,25 +27,25 @@ let on_host_with_k2 (f : Context.t -> API.ref_PGPU -> 'a) =
 
 let test_can_run_VGPU_succeeds_empty_pgpu () =
 	on_host_with_k2 (fun __context p ->
-		let vgpu = make_vgpu ~__context Ref.null k260q in
+		let vgpu = make_vgpu ~__context k260q in
 		Xapi_pgpu.assert_can_run_VGPU ~__context ~self:p ~vgpu)
 
 let test_can_run_VGPU_succeeds_enabled_types () =
 	on_host_with_k2 (fun __context p ->
-		let vgpus = List.map (make_vgpu ~__context Ref.null) [k200; k240q; k260q] in
+		let vgpus = List.map (make_vgpu ~__context) [k200; k240q; k260q] in
 		ignore (List.map (fun vgpu ->
 			Xapi_pgpu.assert_can_run_VGPU ~__context ~self:p ~vgpu)
 			vgpus))
 
 let test_can_run_VGPU_succeeds_same_type () =
 	on_host_with_k2 (fun __context p ->
-		let _ = make_vgpu ~__context p k260q in
-		let vgpu = make_vgpu ~__context Ref.null k260q in
+		let _ = make_vgpu ~__context ~resident_on:p k260q in
+		let vgpu = make_vgpu ~__context k260q in
 		Xapi_pgpu.assert_can_run_VGPU ~__context ~self:p ~vgpu)
 
 let test_can_run_VGPU_fails_unsupported_types () =
 	on_host_with_k2 (fun __context p ->
-		let vgpus = List.map (make_vgpu ~__context Ref.null) [k100; k140q] in
+		let vgpus = List.map (make_vgpu ~__context) [k100; k140q] in
 		ignore (List.map (fun vgpu ->
 			assert_raises_api_error Api_errors.vgpu_type_not_supported
 				(fun () -> Xapi_pgpu.assert_can_run_VGPU ~__context ~self:p ~vgpu))
@@ -53,7 +53,7 @@ let test_can_run_VGPU_fails_unsupported_types () =
 
 let test_can_run_VGPU_fails_disabled_type () =
 	on_host_with_k2 (fun __context p ->
-		let vgpu = make_vgpu ~__context Ref.null k200 in
+		let vgpu = make_vgpu ~__context k200 in
 		let vgpu_type = Db.VGPU.get_type ~__context ~self:vgpu in
 		Db.PGPU.remove_enabled_VGPU_types ~__context ~self:p ~value:vgpu_type;
 		assert_raises_api_error Api_errors.vgpu_type_not_enabled
@@ -61,8 +61,8 @@ let test_can_run_VGPU_fails_disabled_type () =
 
 let test_can_run_VGPU_fails_different_type () =
 	on_host_with_k2 (fun __context p ->
-		let _ = make_vgpu ~__context p k260q in
-		let vgpu = make_vgpu ~__context Ref.null k240q in
+		let _ = make_vgpu ~__context ~resident_on:p k260q in
+		let vgpu = make_vgpu ~__context k240q in
 		assert_raises_api_error
 			Api_errors.vgpu_type_not_compatible_with_running_type
 			(fun () -> Xapi_pgpu.assert_can_run_VGPU ~__context ~self:p ~vgpu))
@@ -70,9 +70,9 @@ let test_can_run_VGPU_fails_different_type () =
 let test_can_run_VGPU_fails_no_capacity () =
 	on_host_with_k2 (fun __context p ->
 		(* Fill up the pGPU with 2 x K260Q *)
-		let _ = List.map (make_vgpu ~__context p) [k260q; k260q] in
+		let _ = List.map (make_vgpu ~__context ~resident_on:p) [k260q; k260q] in
 		(* Should fail to put another one on *)
-		let vgpu = make_vgpu ~__context Ref.null k260q in
+		let vgpu = make_vgpu ~__context k260q in
 		assert_raises_api_error
 			Api_errors.pgpu_insufficient_capacity_for_vgpu
 			(fun () -> Xapi_pgpu.assert_can_run_VGPU ~__context ~self:p ~vgpu))
@@ -100,7 +100,7 @@ let test_remaining_capacity_decreases () =
 		let rec check_remaining_capacity_and_fill p c vgpu_type =
 			check_capacity_is ~__context c p vgpu_type;
 			if c > 0L then begin
-				ignore (make_vgpu ~__context p vgpu_type);
+				ignore (make_vgpu ~__context ~resident_on:p vgpu_type);
 				check_remaining_capacity_and_fill p (Int64.sub c 1L) vgpu_type
 			end
 		in
@@ -135,7 +135,7 @@ let test_set_GPU_group_fails_resident_vgpu () =
 			(make_gpu_group ~__context (), make_gpu_group ~__context ())
 		in
 		Xapi_pgpu.set_GPU_group ~__context ~self:p ~value:group;
-		ignore (make_vgpu ~__context p k200);
+		ignore (make_vgpu ~__context ~resident_on:p k200);
 		assert_raises_api_error Api_errors.pgpu_in_use_by_vm (fun () ->
 			Xapi_pgpu.set_GPU_group ~__context ~self:p ~value:group'))
 

--- a/ocaml/test/test_pgpu_helpers.ml
+++ b/ocaml/test/test_pgpu_helpers.ml
@@ -67,6 +67,29 @@ module GetRemainingCapacity = Generic.Make(Generic.EncapsulateState(struct
 		({default_k2 with resident_VGPU_types = [k240q; k240q; k240q]}, k240q), 1L;
 		({default_k2 with resident_VGPU_types = [k260q]}, k260q), 1L;
 		({default_k2 with resident_VGPU_types = [passthrough_gpu]}, passthrough_gpu), 0L;
+		(* Test that scheduled vGPUs also affect the capacity calculations. *)
+		({default_k1 with scheduled_VGPU_types = [k100]}, k100), 7L;
+		({default_k1 with scheduled_VGPU_types = [k100]}, passthrough_gpu), 0L;
+		({default_k1 with scheduled_VGPU_types = [passthrough_gpu]}, k100), 0L;
+		({default_k1 with scheduled_VGPU_types = [passthrough_gpu]}, passthrough_gpu), 0L;
+		({default_k2 with scheduled_VGPU_types = [k200; k200]}, k200), 6L;
+		({default_k2 with scheduled_VGPU_types = [k200]}, passthrough_gpu), 0L;
+		({default_k2 with scheduled_VGPU_types = [passthrough_gpu]}, k200), 0L;
+		({default_k2 with scheduled_VGPU_types = [passthrough_gpu]}, passthrough_gpu), 0L;
+		(* Test that the capacity calculations work with combinations of scheduled
+		 * and resident VGPUs. *)
+		(
+			{default_k1 with
+				resident_VGPU_types = [k100; k100];
+				scheduled_VGPU_types = [k100]},
+			k100
+		), 5L;
+		(
+			{default_k2 with
+				resident_VGPU_types = [k240q; k240q];
+				scheduled_VGPU_types = [k240q]},
+			k240q
+		), 1L;
 	]
 end))
 

--- a/ocaml/test/test_vgpu_common.ml
+++ b/ocaml/test/test_vgpu_common.ml
@@ -88,46 +88,55 @@ let k2_vgpu_types = [
 ]
 
 (* Represents the state of a PGPU, its supported and enabled VGPU types, and
- * the types of the VGPUs running on it. *)
+ * the types of the VGPUs running and scheduled to run on it. *)
 type pgpu_state = {
 	supported_VGPU_types: vgpu_type list;
 	enabled_VGPU_types: vgpu_type list;
 	resident_VGPU_types: vgpu_type list;
+	scheduled_VGPU_types: vgpu_type list;
 }
 
 let default_k1 = {
 	supported_VGPU_types = k1_vgpu_types;
 	enabled_VGPU_types = k1_vgpu_types;
 	resident_VGPU_types = [];
+	scheduled_VGPU_types = [];
 }
 
 let default_k2 = {
 	supported_VGPU_types = k2_vgpu_types;
 	enabled_VGPU_types = k2_vgpu_types;
 	resident_VGPU_types = [];
+	scheduled_VGPU_types = [];
 }
 
 let string_of_vgpu_type vgpu_type =
 	vgpu_type.model_name
 
 let string_of_pgpu_state pgpu =
-	Printf.sprintf "{supported: %s; enabled: %s; resident: %s}"
+	Printf.sprintf "{supported: %s; enabled: %s; resident: %s; scheduled: %s}"
 		(Test_common.string_of_string_list
 			(List.map string_of_vgpu_type pgpu.supported_VGPU_types))
 		(Test_common.string_of_string_list
 			(List.map string_of_vgpu_type pgpu.enabled_VGPU_types))
 		(Test_common.string_of_string_list
 			(List.map string_of_vgpu_type pgpu.resident_VGPU_types))
+		(Test_common.string_of_string_list
+			(List.map string_of_vgpu_type pgpu.scheduled_VGPU_types))
 
-let make_vgpu ~__context pgpu_ref vgpu_type =
+let make_vgpu ~__context
+		?(resident_on=Ref.null)
+		?(scheduled_to_be_resident_on=Ref.null)
+		vgpu_type =
 	let vgpu_type_ref = find_or_create ~__context vgpu_type in
 	(* For the passthrough VGPU type, create a VM and mark it as attached to the
 	 * PGPU's PCI device. *)
 	let vm_ref_opt =
-		if Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type_ref
+		if (Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type_ref)
+			&& (Db.is_valid_ref __context resident_on)
 		then begin
 			let vm_ref = Test_common.make_vm ~__context () in
-			let pci_ref = Db.PGPU.get_PCI ~__context ~self:pgpu_ref in
+			let pci_ref = Db.PGPU.get_PCI ~__context ~self:resident_on in
 			Db.PCI.add_attached_VMs ~__context ~self:pci_ref ~value:vm_ref;
 			Some vm_ref
 		end else None
@@ -135,7 +144,8 @@ let make_vgpu ~__context pgpu_ref vgpu_type =
 	Test_common.make_vgpu ~__context
 		~vM:(Opt.default Ref.null vm_ref_opt)
 		~_type:vgpu_type_ref
-		~resident_on:pgpu_ref ()
+		~resident_on
+		~scheduled_to_be_resident_on ()
 
 let make_pgpu ~__context ?(host=Ref.null) ?(gPU_group=Ref.null) pgpu =
 	let pCI = Test_common.make_pci ~__context ~host ~functions:1L () in
@@ -153,6 +163,13 @@ let make_pgpu ~__context ?(host=Ref.null) ?(gPU_group=Ref.null) pgpu =
 		~enabled_VGPU_types () in
 	List.iter
 		(fun vgpu_type ->
-			let (_: API.ref_VGPU) = (make_vgpu ~__context pgpu_ref vgpu_type) in ())
+			let (_: API.ref_VGPU) =
+				(make_vgpu ~__context ~resident_on:pgpu_ref vgpu_type) in ())
 		pgpu.resident_VGPU_types;
+	List.iter
+		(fun vgpu_type ->
+			let (_: API.ref_VGPU) =
+				(make_vgpu ~__context ~scheduled_to_be_resident_on:pgpu_ref vgpu_type)
+			in ())
+		pgpu.scheduled_VGPU_types;
 	pgpu_ref

--- a/ocaml/test/test_vm_helpers.ml
+++ b/ocaml/test/test_vm_helpers.ml
@@ -43,7 +43,7 @@ let on_pool_of_k1s (f : Context.t -> API.ref_host -> API.ref_host -> API.ref_hos
 		f __context h h' h''
 
 let make_vm_with_vgpu_in_group ~__context vgpu_type gpu_group_ref =
-	let vgpu_ref = make_vgpu ~__context Ref.null vgpu_type
+	let vgpu_ref = make_vgpu ~__context ~resident_on:Ref.null vgpu_type
 	and vm_ref = make_vm ~__context () in
 	Db.VGPU.set_GPU_group ~__context ~self:vgpu_ref ~value:gpu_group_ref;
 	Db.VGPU.set_VM ~__context ~self:vgpu_ref ~value:vm_ref;
@@ -80,7 +80,7 @@ let test_gpus_available_fails_no_capacity () =
 		let pgpus = Db.GPU_group.get_PGPUs ~__context ~self:group in
 		(* Fill up all the PGPUs *)
 		List.iter (fun p ->
-			ignore (make_vgpu ~__context p Xapi_vgpu_type.passthrough_gpu))
+			ignore (make_vgpu ~__context ~resident_on:p Xapi_vgpu_type.passthrough_gpu))
 			pgpus;
 		let vm = make_vm_with_vgpu_in_group ~__context k100 group in
 		assert_raises_api_error Api_errors.vm_requires_gpu
@@ -153,22 +153,22 @@ let test_group_hosts_bf () =
 				k100,  [ [(h',8L);(h'',8L)] ];
 				k140q, [ [(h',4L);(h'',4L)] ];
 			];
-			ignore (make_vgpu ~__context h''_p k100);
+			ignore (make_vgpu ~__context ~resident_on:h''_p k100);
 			assert_expectations ~__context gpu_group [
 				k100,  [ [(h',8L);(h'',8L)] ];
 				k140q, [ [(h',4L);(h'',4L)] ];
 			];
-			ignore (make_vgpu ~__context h''_p' k140q);
+			ignore (make_vgpu ~__context ~resident_on:h''_p' k140q);
 			assert_expectations ~__context gpu_group [
 				k100,  [ [(h',8L)]; [(h'',7L)] ];
 				k140q, [ [(h',4L)]; [(h'',3L)] ];
 			];
-			ignore (make_vgpu ~__context h'_p k100);
+			ignore (make_vgpu ~__context ~resident_on:h'_p k100);
 			assert_expectations ~__context gpu_group [
 				k100,  [ [(h',7L);(h'',7L)] ];
 				k140q, [ [(h'',3L)]; ];
 			];
-			ignore (make_vgpu ~__context h'_p k100);
+			ignore (make_vgpu ~__context ~resident_on:h'_p k100);
 			assert_expectations ~__context gpu_group [
 				k100,  [ [(h'',7L)]; [(h',6L)] ];
 				k140q, [ [(h'',3L)]; ];
@@ -186,22 +186,22 @@ let test_group_hosts_df () =
 				k100,  [ [(h',8L);(h'',8L)] ];
 				k140q, [ [(h',4L);(h'',4L)] ];
 			];
-			ignore (make_vgpu ~__context h''_p k100);
+			ignore (make_vgpu ~__context ~resident_on:h''_p k100);
 			assert_expectations ~__context gpu_group [
 				k100,  [ [(h'',7L)]; [(h',8L)] ];
 				k140q, [ [(h',4L);(h'',4L)] ];
 			];
-			ignore (make_vgpu ~__context h''_p' k140q);
+			ignore (make_vgpu ~__context ~resident_on:h''_p' k140q);
 			assert_expectations ~__context gpu_group [
 				k100,  [ [(h'',7L)]; [(h',8L)] ];
 				k140q, [ [(h'',3L)]; [(h',4L)] ];
 			];
-			ignore (make_vgpu ~__context h'_p k100);
+			ignore (make_vgpu ~__context ~resident_on:h'_p k100);
 			assert_expectations ~__context gpu_group [
 				k100,  [ [(h',7L);(h'',7L)] ];
 				k140q, [ [(h'',3L)]; ];
 			];
-			ignore (make_vgpu ~__context h'_p k100);
+			ignore (make_vgpu ~__context ~resident_on:h'_p k100);
 			assert_expectations ~__context gpu_group [
 				k100,  [ [(h',6L)]; [(h'',7L)] ];
 				k140q, [ [(h'',3L)]; ];


### PR DESCRIPTION
When checking whether a VGPU can run on a PGPU, xapi now needs to check the VGPUs scheduled to run on that PGPU as well as the VGPUs already running.