### PR TITLE
Plumb VDI.set_name_label and VDI.set_name_description through the SMA…

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -538,6 +538,20 @@ module SMAPIv1 = struct
 		let snapshot = snapshot_and_clone "VDI.snapshot" Sm.vdi_snapshot true
 		let clone = snapshot_and_clone "VDI.clone" Sm.vdi_clone false
 
+	let set_name_label context ~dbg ~sr ~vdi ~new_name_label =
+                Server_helpers.exec_with_new_task "VDI.set_name_label" ~subtask_of:(Ref.of_string dbg)
+                    (fun __context ->
+                        let self, _ = find_vdi ~__context sr vdi in
+                        Db.VDI.set_name_label ~__context ~self ~value:new_name_label
+                    )
+ 
+	let set_name_description context ~dbg ~sr ~vdi ~new_name_description =
+                Server_helpers.exec_with_new_task "VDI.set_name_description" ~subtask_of:(Ref.of_string dbg)
+                    (fun __context ->
+                        let self, _ = find_vdi ~__context sr vdi in
+                        Db.VDI.set_name_description ~__context ~self ~value:new_name_description
+                    )
+
         let resize context ~dbg ~sr ~vdi ~new_size =
             try
                 let vi = for_vdi ~dbg ~sr ~vdi "VDI.resize"

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -488,6 +488,20 @@ module Wrapper = functor(Impl: Server_impl) -> struct
 		let snapshot = snapshot_and_clone "VDI.snapshot" Impl.VDI.snapshot
 		let clone = snapshot_and_clone "VDI.clone" Impl.VDI.clone
 
+	let set_name_label context ~dbg ~sr ~vdi ~new_name_label =
+		info "VDI.set_name_label dbg:%s sr:%s vdi:%s new_name_label:%s" dbg sr vdi new_name_label;
+		with_vdi sr vdi
+			(fun () ->
+				Impl.VDI.set_name_label context ~dbg ~sr ~vdi ~new_name_label
+			)
+
+	let set_name_description context ~dbg ~sr ~vdi ~new_name_description =
+		info "VDI.set_name_description dbg:%s sr:%s vdi:%s new_name_description:%s" dbg sr vdi new_name_description;
+		with_vdi sr vdi
+			(fun () ->
+				Impl.VDI.set_name_description context ~dbg ~sr ~vdi ~new_name_description
+			)
+
         let resize context ~dbg ~sr ~vdi ~new_size =
             info "VDI.resize dbg:%s sr:%s vdi:%s new_size:%Ld" dbg sr vdi new_size;
             with_vdi sr vdi

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -67,6 +67,9 @@ module Debug_print_impl = struct
                 );
             info
 
+	let set_name_label context ~dbg ~sr ~vdi ~new_name_label = ()
+	let set_name_description context ~dbg ~sr ~vdi ~new_name_description = ()
+
 		let snapshot context ~dbg ~sr ~vdi_info =
 			create context ~dbg ~sr ~vdi_info
 		let clone = snapshot

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -181,6 +181,12 @@ module Mux = struct
 		let create context ~dbg ~sr ~vdi_info =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.create ~dbg ~sr ~vdi_info
+		let set_name_label context ~dbg ~sr ~vdi ~new_name_label =
+			let module C = Client(struct let rpc = of_sr sr end) in
+			C.VDI.set_name_label ~dbg ~sr ~vdi ~new_name_label
+		let set_name_description context ~dbg ~sr ~vdi ~new_name_description =
+			let module C = Client(struct let rpc = of_sr sr end) in
+			C.VDI.set_name_description ~dbg ~sr ~vdi ~new_name_description
         let snapshot context ~dbg ~sr ~vdi_info =
             let module C = Client(struct let rpc = of_sr sr end) in
             C.VDI.snapshot ~dbg ~sr ~vdi_info

--- a/ocaml/xapi/storage_proxy.ml
+++ b/ocaml/xapi/storage_proxy.ml
@@ -59,6 +59,8 @@ module Proxy = functor(RPC: RPC) -> struct
 		let epoch_end _ = Client.VDI.epoch_end
 
 		let create _ = Client.VDI.create
+		let set_name_label _ = Client.VDI.set_name_label
+		let set_name_description _ = Client.VDI.set_name_description
 		let snapshot _ = Client.VDI.snapshot
 		let clone _ = Client.VDI.clone
 		let destroy _ = Client.VDI.destroy


### PR DESCRIPTION
…PIv2

This allows storage backends to persist these values.

This depends on: [xapi-project/xcp-idl#80]

Signed-off-by: David Scott <dave.scott@eu.citrix.com>