### PR TITLE
Plumb VDI.introduce through the SMAPIv2

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -585,6 +585,21 @@ module SMAPIv1 = struct
 				error "VDI.stat caught: %s" (Printexc.to_string e);
 				raise (Vdi_does_not_exist vdi)
 
+		let introduce context ~dbg ~sr ~uuid ~sm_config ~location =
+			try
+				Server_helpers.exec_with_new_task "VDI.introduce" ~subtask_of:(Ref.of_string dbg)
+					(fun __context ->
+                        			let sr = Db.SR.get_by_uuid ~__context ~uuid:sr in
+						let vi =
+							Sm.call_sm_functions ~__context ~sR:sr
+								(fun device_config sr_type ->
+									Sm.vdi_introduce device_config sr_type sr uuid sm_config location) in
+                        			newvdi ~__context vi
+					)
+			with e ->
+				error "VDI.introduce caught: %s" (Printexc.to_string e);
+				raise (Vdi_does_not_exist location)
+
 		let set_persistent context ~dbg ~sr ~vdi ~persistent =
             try
                 Server_helpers.exec_with_new_task "VDI.set_persistent" ~subtask_of:(Ref.of_string dbg)

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -509,6 +509,10 @@ module Wrapper = functor(Impl: Server_impl) -> struct
 			info "VDI.stat dbg:%s sr:%s vdi:%s" dbg sr vdi;
 			Impl.VDI.stat context ~dbg ~sr ~vdi
 
+		let introduce context ~dbg ~sr ~uuid ~sm_config ~location =
+			info "VDI.introduce dbg:%s sr:%s uuid:%s sm_config:%s location:%s" dbg sr uuid (String.concat ", " (List.map (fun (k, v) -> k ^ ":" ^ v) sm_config)) location;
+			Impl.VDI.introduce context ~dbg ~sr ~uuid ~sm_config ~location
+
 		let set_persistent context ~dbg ~sr ~vdi ~persistent =
 			info "VDI.set_persistent dbg:%s sr:%s vdi:%s persistent:%b" dbg sr vdi persistent;
 			with_vdi sr vdi

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -90,6 +90,8 @@ module Debug_print_impl = struct
 
 		let stat context ~dbg ~sr ~vdi = assert false
 
+		let introduce context ~dbg ~sr ~uuid ~sm_config ~location = assert false
+
 		let set_persistent context ~dbg ~sr ~vdi ~persistent = ()
 
 		let attach context ~dbg ~dp ~sr ~vdi ~read_write =

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -196,6 +196,9 @@ module Mux = struct
 		let stat context ~dbg ~sr ~vdi =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.stat ~dbg ~sr ~vdi
+		let introduce context ~dbg ~sr ~uuid ~sm_config ~location =
+			let module C = Client(struct let rpc = of_sr sr end) in
+			C.VDI.introduce ~dbg ~sr ~uuid ~sm_config ~location
 		let set_persistent context ~dbg ~sr ~vdi ~persistent =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.set_persistent ~dbg ~sr ~vdi ~persistent

--- a/ocaml/xapi/storage_proxy.ml
+++ b/ocaml/xapi/storage_proxy.ml
@@ -64,6 +64,7 @@ module Proxy = functor(RPC: RPC) -> struct
 		let destroy _ = Client.VDI.destroy
 		let resize _ = Client.VDI.resize
 		let stat _ = Client.VDI.stat
+		let introduce _ = Client.VDI.introduce
 		let set_persistent _ = Client.VDI.set_persistent
 		let get_by_name _ = Client.VDI.get_by_name
 		let set_content_id _ = Client.VDI.set_content_id


### PR DESCRIPTION
This allows it to be converted into a simple Volume.stat in the
SMAPIv3 (no special support required)

This depends on [xapi-project/xcp-idl#81]

Signed-off-by: David Scott <dave.scott@eu.citrix.com>