### PR TITLE
CA-174475 Make 2048-bit Diffie-Hellman prime for TLS certificate

### DIFF
--- a/scripts/generate_ssl_cert
+++ b/scripts/generate_ssl_cert
@@ -35,7 +35,7 @@ CN = ${CN}
 
 openssl genrsa 1024 > privkey.rsa
 openssl req -batch -new -x509 -key privkey.rsa -days 3650 -config config -out cert.csr
-openssl dhparam 512 > dh.pem
+openssl dhparam 2048 > dh.pem
 
 popd
 


### PR DESCRIPTION
When creating a certificate to use for TLS, we were generating 512-bit
Diffie-Hellman parameters. This is rejected as too short by several
clients. Now we have changed from 512 to 2048.

Generating DH parameters of this length tends to take anything from a
few seconds to a few minutes.

This commit does not address the issue of existing certificates from
XenServers upgraded from (say) XenServer 6.5.
