### PR TITLE
CP-13189 TLS ciphersuite TLS_RSA_WITH_AES_128_CBC_SHA

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -64,8 +64,9 @@ writeconffile () {
     # interface is enabled or disabled.
     . /etc/xensource-inventory
 
-    # (This "good" list is just for testing this script; it needs choosing properly.)
-    GOOD_CIPHERS='TLSv1.2'
+    # (This "good" list must match, or at least contain one of, the
+    # good_ciphers in xen-api-libs-transitional/stunnel/stunnel.ml)
+    GOOD_CIPHERS='RSA+AES128-SHA'
     BACK_COMPAT_CIPHERS='RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA'
 
     if [ -n "${STUNNEL_IDLE_TIMEOUT}" ]; then


### PR DESCRIPTION
For incoming connections to XAPI, this commit implements the
recommendation from the Citrix security team that XenServer should
use only ciphersuite TLS_RSA_WITH_AES_128_CBC_SHA for TLSv1.2.

(The exception is when the host ssl-legacy setting is switched on for
backward compatibility).

This recommendation is based on a combination of criteria:
* technical (security) considerations
* legal considerations
* compatibility with third-party TLSv1.2 clients

This commit relies on a corresponding commit in another repository to
set the ciphersuite used for outgoing connections from xapi, so that
XenServer hosts will be able to communicate with one another.
