### PR TITLE
VDI.epoch_begin: add persistent argument

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -347,7 +347,7 @@ module SMAPIv1 = struct
 			per_host_key ~__context ~prefix:"read-caching-reason"
 
 
-		let epoch_begin context ~dbg ~sr ~vdi =
+		let epoch_begin context ~dbg ~sr ~vdi ~persistent =
 			try
 				for_vdi ~dbg ~sr ~vdi "VDI.epoch_begin"
 					(fun device_config _type sr self ->

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -416,13 +416,13 @@ module Wrapper = functor(Impl: Server_impl) -> struct
 			| [] -> next ()
 			| f :: fs -> raise f
 
-		let epoch_begin context ~dbg ~sr ~vdi =
-			info "VDI.epoch_begin dbg:%s sr:%s vdi:%s" dbg sr vdi;
+		let epoch_begin context ~dbg ~sr ~vdi ~persistent =
+			info "VDI.epoch_begin dbg:%s sr:%s vdi:%s persistent:%b" dbg sr vdi persistent;
 			with_vdi sr vdi
 				(fun () ->
 					remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.leaked
 						(fun () ->
-							Impl.VDI.epoch_begin context ~dbg ~sr ~vdi
+							Impl.VDI.epoch_begin context ~dbg ~sr ~vdi ~persistent
 						))
 
 		let attach context ~dbg ~dp ~sr ~vdi ~read_write =

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -89,7 +89,7 @@ module Debug_print_impl = struct
                     end
                 )
 
-		let epoch_begin context ~dbg ~sr ~vdi = ()
+		let epoch_begin context ~dbg ~sr ~vdi ~persistent = ()
 
 		let stat context ~dbg ~sr ~vdi = assert false
 

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -205,9 +205,9 @@ module Mux = struct
 		let set_persistent context ~dbg ~sr ~vdi ~persistent =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.set_persistent ~dbg ~sr ~vdi ~persistent
-		let epoch_begin context ~dbg ~sr ~vdi =
+		let epoch_begin context ~dbg ~sr ~vdi ~persistent =
 			let module C = Client(struct let rpc = of_sr sr end) in
-			C.VDI.epoch_begin ~dbg ~sr ~vdi
+			C.VDI.epoch_begin ~dbg ~sr ~vdi ~persistent
 		let attach context ~dbg ~dp ~sr ~vdi ~read_write =
 			let module C = Client(struct let rpc = of_sr sr end) in
 			C.VDI.attach ~dbg ~dp ~sr ~vdi ~read_write

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -450,6 +450,7 @@ module MD = struct
 			extra_backend_keys = backend_kind_keys;
 			extra_private_keys = [];
 			qos = qos ty;
+			persistent = (try Db.VDI.get_on_boot ~__context ~self:vbd.API.vBD_VDI = `persist with _ -> true);
 		}
 
 	let of_vif ~__context ~vm ~vif =


### PR DESCRIPTION
Rather than relying on the SMAPIv2 implementation storing the
persistent flag (via `VDI.set_persistent`) we pass it as an
argument to `VDI.epoch_begin` instead.

This depends on [xapi-project/xcp-idl#83]

Signed-off-by: David Scott <dave.scott@eu.citrix.com>