### PR TITLE
quicktest: don't rely on the default SR

### DIFF
--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -298,6 +298,8 @@ let all_srs_with_vdi_create session_id =
   |> List.filter (fun sr -> List.mem Quicktest_storage.vdi_create (Quicktest_storage.sm_caps_of_sr session_id sr))
   (* Filter out those without the allowed operation *)
   |> List.filter (fun sr -> List.mem `vdi_create (Client.SR.get_allowed_operations !rpc session_id sr))
+  (* Filter out those with content-type = iso (this confuses the import test logic) *)
+  |> List.filter (fun sr -> Client.SR.get_content_type !rpc session_id sr <> "iso")
 
 (** Create a small VM with a selection of CDs, empty drives, "iso" Disks etc *)
 let setup_export_test_vm session_id = 

--- a/ocaml/xapi/quicktest_vdi_copy.ml
+++ b/ocaml/xapi/quicktest_vdi_copy.ml
@@ -58,14 +58,9 @@ let read_from_vdi ~session_id ~vdi f =
     Http.Get uri in
   http req (fun (_, fd) -> f fd)
 
-let start session_id =
+let start session_id sr =
   let t = make_test "Check VDI.copy delta handling" 1 in
   start t;
-
-  (* Choose the default SR *)
-  let pool = List.hd (Client.Pool.get_all ~rpc:!rpc ~session_id) in
-  let sr = Client.Pool.get_default_SR ~rpc:!rpc ~session_id ~self:pool in
-  debug t (Printf.sprintf "Pool default_SR is %s" (Ref.string_of sr));
 
   (* Create a 4 MiB disk on src_sr *)
   let original =


### PR DESCRIPTION
Some valid configurations don't have a default SR, so quicktest fall back to any other suitable SR. Note that the ISO SR is a bit of an anomaly because it supports the `VDI_CREATE` capability but is usually on read/only storage media. Even when not on read/only storage media, the `SR.content_type=iso` triggers different behaviour on import which we (in the quicktest test) want to avoid.