### PR TITLE
VDI.introduce: raise an exception if the `location` field already exists

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -371,6 +371,12 @@ let introduce ~__context ~uuid ~name_label ~name_description ~sR ~_type ~sharabl
   let open Storage_interface in
   debug "introduce uuid=%s name_label=%s sm_config=[ %s ]" uuid name_label (String.concat "; " (List.map (fun (k, v) -> k ^ " = " ^ v) sm_config));  
   Sm.assert_pbd_is_plugged ~__context ~sr:sR;
+  (* Verify that the location field is unique in this SR *)
+  List.iter
+    (fun vdi ->
+       if Db.VDI.get_location ~__context ~self:vdi = location
+       then raise (Api_errors.Server_error (Api_errors.location_not_unique, [ Ref.string_of sR; location ]))
+    ) (Db.SR.get_VDIs ~__context ~self:sR);
   let task = Context.get_task_id __context in	
   let sr' = Db.SR.get_uuid ~__context ~self:sR in
   let module C = Storage_interface.Client(struct let rpc = Storage_access.rpc end) in


### PR DESCRIPTION
Previously this happened in the SMAPIv1 plugins, but the SMAPIv3 doesn't
have an explicit notion of `introduce`, instead it just has `Volume.stat`
which will succeed if the `location` is valid.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>