### PR TITLE
CA-174968: XenAPI SR.scan: call both SMAPI SR.scan and SR.stat

### DIFF
--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -425,11 +425,15 @@ let scan ~__context ~sr =
 	let sr' = Ref.string_of sr in
 	transform_storage_exn
 		(fun () ->
-			let vs = C.SR.scan ~dbg:(Ref.string_of task) ~sr:(Db.SR.get_uuid ~__context ~self:sr) in
+			let sr_uuid = Db.SR.get_uuid ~__context ~self:sr in
+			let vs = C.SR.scan ~dbg:(Ref.string_of task) ~sr:sr_uuid in
+			let sr_info = C.SR.stat ~dbg:(Ref.string_of task) ~sr:sr_uuid in
 			let db_vdis = Db.VDI.get_records_where ~__context ~expr:(Eq(Field "SR", Literal sr')) in
 			update_vdis ~__context ~sr:sr db_vdis vs;
 			let virtual_allocation = List.fold_left Int64.add 0L (List.map (fun v -> v.virtual_size) vs) in
 			Db.SR.set_virtual_allocation ~__context ~self:sr ~value:virtual_allocation;
+			Db.SR.set_physical_size ~__context ~self:sr ~value:sr_info.total_space;
+			Db.SR.set_physical_utilisation ~__context ~self:sr ~value:(Int64.sub sr_info.total_space sr_info.free_space);
 			Db.SR.remove_from_other_config ~__context ~self:sr ~key:"dirty"
 		)
 


### PR DESCRIPTION
The SMAPIv1 backends update all SR fields in `SR.scan`, whereas
the SMAPIv2 and SMAPIv3 clearly separate the `SR.scan` (list VDIs)
from the `SR.stat` (query SR properties). To avoid confusing clients,
the XenAPI `SR.scan` should do both functions.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>