### PR TITLE
Fixes for VDI and SR allowed_operations

### DIFF
--- a/ocaml/test/test_common.ml
+++ b/ocaml/test/test_common.ml
@@ -138,8 +138,32 @@ let make_pool ~__context ~master ?(name_label="") ?(name_description="")
 		~restrictions ~other_config ~ha_cluster_stack;
 	pool_ref
 
+let default_sm_features = [
+	"SR_PROBE", 1L;
+	"SR_UPDATE", 1L;
+	"VDI_CREATE", 1L;
+	"VDI_DELETE", 1L;
+	"VDI_ATTACH", 1L;
+	"VDI_DETACH", 1L;
+	"VDI_UPDATE", 1L;
+	"VDI_CLONE", 1L;
+	"VDI_SNAPSHOT", 1L;
+	"VDI_RESIZE", 1L;
+	"VDI_GENERATE_CONFIG", 1L;
+	"VDI_RESET_ON_BOOT", 2L;
+]
+
+let make_sm ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ()) ?(_type="sm")
+	?(name_label="") ?(name_description="") ?(vendor="") ?(copyright="")
+	?(version="") ?(required_api_version="") ?(capabilities=[]) ?(features=default_sm_features)
+	?(configuration=[]) ?(other_config=[]) ?(driver_filename="/dev/null") () =
+        Db.SM.create ~__context ~ref:ref ~uuid ~_type ~name_label ~name_description
+		~vendor ~copyright ~version ~required_api_version ~capabilities ~features
+		~configuration ~other_config ~driver_filename;
+	ref
+
 let make_sr ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ()) ?(name_label="") ?(name_description="") ?(allowed_operations=[])
-		?(current_operations=[]) ?(virtual_allocation=0L) ?(physical_utilisation=0L) ?(physical_size=0L) ?(_type="")
+		?(current_operations=[]) ?(virtual_allocation=0L) ?(physical_utilisation=0L) ?(physical_size=0L) ?(_type="sm")
 		?(content_type="") ?(shared=true) ?(other_config=[]) ?(tags=[]) ?(default_vdi_visibility=true)
 		?(sm_config=[]) ?(blobs=[]) ?(local_cache_enabled=false) ?(introduced_by=Ref.make ()) () =
 	Db.SR.create ~__context ~ref ~uuid ~name_label ~name_description ~allowed_operations

--- a/ocaml/test/test_vdi_allowed_operations.ml
+++ b/ocaml/test/test_vdi_allowed_operations.ml
@@ -18,37 +18,8 @@ open Test_common
 (* Helpers for testing Xapi_vdi.check_operation_error *)
 
 let setup_test ~__context ~vdi_fun =
+	let _sm_ref = make_sm ~__context () in
 	let sr_ref = make_sr ~__context () in
-	let sr_uuid = Db.SR.get_uuid ~__context ~self:sr_ref in
-	(* Register the SR with a dummy processor which has a sensible
-	 * set of features. *)
-	Storage_mux.register sr_uuid
-		(fun _ -> Rpc.({success = true; contents = Null}))
-		"0"
-		Storage_interface.({
-			driver = "";
-			name = "";
-			description = "";
-			vendor = "";
-			copyright = "";
-			version = "";
-			required_api_version = "";
-			features = [
-				"SR_PROBE";
-				"SR_UPDATE";
-				"VDI_CREATE";
-				"VDI_DELETE";
-				"VDI_ATTACH";
-				"VDI_DETACH";
-				"VDI_UPDATE";
-				"VDI_CLONE";
-				"VDI_SNAPSHOT";
-				"VDI_RESIZE";
-				"VDI_GENERATE_CONFIG";
-				"VDI_RESET_ON_BOOT/2";
-			];
-			configuration = []
-		});
 	let (_: API.ref_PBD) = make_pbd ~__context ~sR:sr_ref () in
 	let vdi_ref = make_vdi ~__context ~sR:sr_ref () in
 	vdi_fun vdi_ref;

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -108,8 +108,7 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
 
 			(* NB RO vs RW sharing checks are done in xapi_vbd.ml *)
 
-			let sr_uuid = Db.SR.get_uuid ~__context ~self:sr in
-			let sm_features = Xapi_sr_operations.features_of_sr_internal ~_type:sr_type ~uuid:sr_uuid in
+			let sm_features = Xapi_sr_operations.features_of_sr_internal ~__context ~_type:sr_type in
 
 			let blocked_by_attach =
 				if operation_can_be_performed_live
@@ -687,7 +686,7 @@ let set_metadata_of_pool ~__context ~self ~value =
 let set_on_boot ~__context ~self ~value =
 	let sr = Db.VDI.get_SR ~__context ~self in
 	let sr_record = Db.SR.get_record_internal ~__context ~self:sr in
-	let sm_features = Xapi_sr_operations.features_of_sr sr_record in
+	let sm_features = Xapi_sr_operations.features_of_sr ~__context sr_record in
 
 	if not Smint.(has_capability Vdi_reset_on_boot sm_features) then
 		raise (Api_errors.Server_error(Api_errors.sr_operation_not_supported,[Ref.string_of sr]));

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -321,6 +321,7 @@ let create ~__context ~name_label ~name_description
 	Db.VDI.set_sharable ~__context ~self:db_vdi ~value:sharable;
 	Db.VDI.set_tags ~__context ~self:db_vdi ~value:tags;
 	Db.VDI.set_xenstore_data ~__context ~self:db_vdi ~value:xenstore_data;
+	update_allowed_operations ~__context ~self:db_vdi;
 	db_vdi
 
 (* Make the database record only *)

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -186,7 +186,7 @@ let checkpoint ~__context ~vm ~new_name =
 
 				(* Check if SR has snapshot feature *)
 				let sr_has_snapshot_feature sr =
-					if not Smint.(has_capability Vdi_snapshot (Xapi_sr_operations.features_of_sr sr)) then false
+					if not Smint.(has_capability Vdi_snapshot (Xapi_sr_operations.features_of_sr ~__context sr)) then false
 					else true
 				in
 


### PR DESCRIPTION
- Update `VDI.allowed_operations` after `VDI.create`: otherwise we can't destroy the disk immediately from XenCenter
- Use the `SM` table to drive `SR.allowed_operations`: otherwise the computations don't work for SMAPIv3.