### PR TITLE
CA-177425: Fixing enable_ha call

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -684,7 +684,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				(String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) configuration))
 				cluster_stack ;
 			let pool = Helpers.get_pool ~__context in
-			with_pool_operation ~__context ~doc:"Pool.ha_disable" ~self:pool ~op:`ha_disable
+			with_pool_operation ~__context ~doc:"Pool.ha_enable" ~self:pool ~op:`ha_enable
 				(fun () ->
 					Local.Pool.enable_ha __context heartbeat_srs configuration cluster_stack
 				)


### PR DESCRIPTION
enable_ha call passed wrong op:`ha_disable during assert_operation_valid

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>

My Bad: During git rebase for PR https://github.com/xapi-project/xen-api/pull/2260 it had occurred.