### PR TITLE
CA-166748: cleanup SXM after XAPI restart

### DIFF
--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -13,7 +13,7 @@ OCAMLINCLUDES = ../idl ../idl/ocaml_backend \
 
 UseCamlp4(rpclib.syntax, features storage_impl xapi_udhcpd storage_migrate \
           xapi_services system_domains cancel_tests config_file_sync updates \
-          vhd_tool_wrapper)
+          sparse_dd_wrapper vhd_tool_wrapper)
 
 CFLAGS += -std=gnu99 -Wall -Werror -I$(shell ocamlc -where)
 

--- a/ocaml/xapi/sparse_dd_wrapper.ml
+++ b/ocaml/xapi/sparse_dd_wrapper.ml
@@ -35,6 +35,25 @@ type t = {
   exn : exn option ref;
 }
 
+(* Store sparse_dd pids on disk so we can kill them after a xapi restart *)
+module State = struct
+  type pids = int list with rpc
+
+  let filename = ref "/var/run/nonpersistent/sparse_dd_pids.json"
+
+  let m = Mutex.create ()
+
+  let load () = try Unixext.string_of_file !filename |> Jsonrpc.of_string |> pids_of_rpc with _ -> []
+  let save pids = rpc_of_pids pids |> Jsonrpc.to_string |> Unixext.write_string_to_file !filename
+
+  let unsafe_add pid = let pids = load () in save (pid::pids)
+  let unsafe_remove pid = let pids = load () in save (List.filter (fun x -> x <> pid) pids)
+
+  let add pid = Mutex.execute m (fun () -> unsafe_add pid)
+  let remove pid = Mutex.execute m (fun () -> unsafe_remove pid)
+  let list () = Mutex.execute m load
+end
+
 exception Cancelled
 
 (** Use the new external sparse_dd program *)
@@ -57,6 +76,8 @@ let dd_internal progress_cb base prezeroed infile outfile size =
 				debug "%s %s" sparse_dd_path (String.concat " " args);
 				let pid = Forkhelpers.safe_close_and_exec None (Some pipe_write) (Some log_fd) []
 					sparse_dd_path args in
+				let intpid = Forkhelpers.getpid pid in
+				State.add intpid;
 				close pipe_write;
 				progress_cb (Started pid);
 				(* Read Progress: output from the binary *)
@@ -74,7 +95,9 @@ let dd_internal progress_cb base prezeroed infile outfile size =
 							raise e
 						end
 					) () pipe_read;
-				match Forkhelpers.waitpid pid with
+				let r = Forkhelpers.waitpid pid in
+				State.remove intpid;
+				match r with
 				| (_, Unix.WEXITED 0) -> progress_cb (Finished None)
 				| (_, Unix.WEXITED 5) -> error "sparse_dd received NBD error"; failwith "sparse_dd NBD error"
 				| (_, Unix.WEXITED n) -> error "sparse_dd exit: %d" n; failwith "sparse_dd"
@@ -91,7 +114,7 @@ let dd_internal progress_cb base prezeroed infile outfile size =
 	(fun () ->
 		close pipe_read;
 		close pipe_write)
-	
+
 let dd ?(progress_cb=(fun _ -> ())) ?base prezeroed =
 	dd_internal (function | Continuing x -> progress_cb x | _ -> ()) base prezeroed
 

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -93,22 +93,17 @@ module State = struct
 	let find id h = op false (fun a -> try Some (Hashtbl.find a id) with _ -> None) h
 	let remove id h = op true (fun a ->	Hashtbl.remove a id) h
 
-	let add_to_active_local_mirrors id url dest_sr remote_dp local_dp mirror_vdi remote_url tapdev =
-		let open Send_state in 
-		let alm = {url; dest_sr; remote_dp; local_dp; mirror_vdi; remote_url; tapdev; failed=false; watchdog=None} in
-		add id active_send $ Send alm; alm
+	let add_to_active_local_mirrors id alm =
+	    add id active_send $ Send alm; alm
 			
-	let add_to_active_receive_mirrors id sr dummy_vdi leaf_vdi leaf_dp parent_vdi remote_vdi =
-		let open Receive_state in 
-		let arm = {sr; dummy_vdi; leaf_vdi; leaf_dp; parent_vdi; remote_vdi} in
-		add id active_recv $ Receive arm; arm
+	let add_to_active_receive_mirrors id arm =
+	    add id active_recv $ Receive arm; arm
 									  
 	let find_active_local_mirror id =
 		Opt.Monad.bind (find id active_send) (function | Send s -> Some s | _ -> None)
 
 	let find_active_receive_mirror id =
 		Opt.Monad.bind (find id active_recv) (function | Receive r -> Some r | _ -> None)
-
 end
 
 
@@ -374,7 +369,16 @@ let start' ~task ~dbg ~sr ~vdi ~dp ~url ~dest =
 				failwith "Not attached"
 		in
 		debug "Adding to active local mirrors: id=%s" id;
-		let alm = State.add_to_active_local_mirrors id url dest mirror_dp dp result.Mirror.mirror_vdi.vdi url tapdev in
+		let alm = State.add_to_active_local_mirrors id State.Send_state.({
+		  url;
+		  dest_sr=dest;
+		  remote_dp=mirror_dp;
+		  local_dp=dp;
+		  mirror_vdi=result.Mirror.mirror_vdi.vdi;
+		  remote_url=url;
+		  tapdev;
+		  failed=false;
+		  watchdog=None}) in
 		debug "Added";
 
 		debug "About to snapshot VDI = %s" (string_of_vdi_info local_vdi);
@@ -513,7 +517,13 @@ let receive_start ~dbg ~sr ~vdi_info ~id ~similar =
 
 		debug "Parent disk content_id=%s" parent.content_id;
 		
-		ignore(State.add_to_active_receive_mirrors id sr dummy.vdi leaf.vdi leaf_dp parent.vdi vdi_info.vdi);
+		ignore(State.add_to_active_receive_mirrors id State.Receive_state.({
+		  sr;
+		  dummy_vdi=dummy.vdi;
+		  leaf_vdi=leaf.vdi;
+		  leaf_dp;
+		  parent_vdi=parent.vdi;
+		  remote_vdi=vdi_info.vdi}));
 		
 		let nearest_content_id = Opt.map (fun x -> x.content_id) nearest in
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -818,6 +818,7 @@ let server_init() =
     Server_helpers.exec_with_new_task "server_init" (fun __context ->
     Startup.run ~__context [
     "XAPI SERVER STARTING", [], print_server_starting_message;
+    "Killing stray sparse_dd processes", [], Sparse_dd_wrapper.killall;
     "Parsing inventory file", [], Xapi_inventory.read_inventory;
     "Config (from file) for outgoing stunnels", [], set_stunnel_legacy_inv;
     "Setting stunnel timeout", [], set_stunnel_timeout;


### PR DESCRIPTION
This was reported as  "SCTX-2047: XenMotion fails due to a leaked storage datapath after SXM".  The root cause of this issue was: if XAPI is restarted while a SXM is in progress, XAPI would totally forget about the fact that there is an unfinished SXM in progress. In these cases, there would be dangling sparse_dd processes and datapaths leaked around, which will forbid further operations on objects sharing the same resources. This pull req will persists the relevant SXM information and lets XAPI do the cleanup (if necessary) based  on that during its startup.