### PR TITLE
Allow storage backends to supply a uuid (or not)

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -66,6 +66,7 @@ module SMAPIv1 = struct
 			else vdi_rec.API.vDI_location (* PR-1255 *)
 		in {
 			vdi = vdi_rec.API.vDI_location;
+			uuid = Some vdi_rec.API.vDI_uuid;
 			content_id = content_id; (* PR-1255 *)
 			name_label = vdi_rec.API.vDI_name_label;
 			name_description = vdi_rec.API.vDI_name_description;

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -471,6 +471,7 @@ let create_vdi_test sr =
         (Client.SR.attach ~dbg ~sr ~device_config:[]);
 	let vdi_info = {
 		vdi = "";
+		uuid = None;
 		content_id = "";
 		name_label = "name_label";
 		name_description = "name_description";

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -338,16 +338,10 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
 	(* Create the new ones *)
 	let db_vdi_map = StringMap.fold
 		(fun loc vdi m ->
-			(* If vdi looks like a UUID, use it as the UUID for this VDI *)
-			let x = 
-				try Filename.chop_extension vdi.vdi
-				with Invalid_argument _ -> vdi.vdi in
 			let ref = Ref.make () in
-			let uuid_len = 36 in
-			let uuid = 
-				if String.length x == uuid_len && Uuid.is_uuid x
-				then Uuid.of_string x
-				else Uuid.make_uuid () in
+			let uuid = match vdi.uuid with
+				| Some x -> Uuid.of_string x
+				| None -> Uuid.make_uuid () in
 
 			debug "Creating VDI: %s (ref=%s)" (string_of_vdi_info vdi) (Ref.string_of ref);
 			Db.VDI.create ~__context ~ref ~uuid:(Uuid.string_of_uuid uuid)

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -265,24 +265,6 @@ let update_vdi_db ~__context ~sr newvdi =
 		| (vdi, _) :: _ -> vdi
 		| [] -> failwith (Printf.sprintf "newvdi failed to create a VDI for %s" (string_of_vdi_info newvdi))
 
-let default_vdi_info =
-	let open Storage_interface in {
-		vdi = "";
-		content_id = "";
-		name_label = "";
-		name_description = "";
-		ty = "user";
-		metadata_of_pool = "";
-		is_a_snapshot = false;
-		snapshot_time = Date.to_string Date.never;
-		snapshot_of = "";
-		read_only = false;
-		virtual_size = 0L;
-		physical_utilisation = 0L;
-		persistent = true;
-		sm_config = [];
-	}
-
 let create ~__context ~name_label ~name_description
         ~sR ~virtual_size ~_type
         ~sharable ~read_only ~other_config ~xenstore_data ~sm_config ~tags =


### PR DESCRIPTION
For SMAPIv1 backends, there is no change: backends supply the uuid.

For SMAPIv2 and SMAPIv3 backends, the backend can supply a uuid which will then be used for the VDI's uuid. If nothing is supplied then a uuid will be generated as before.

This depends on [xapi-project/xcp-idl#85]