### PR TITLE
Add an SM whitelist

### DIFF
--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -227,7 +227,7 @@ let update_env __context =
      in the db for cancelling *)
   Cancel_tasks.cancel_tasks_on_host ~__context ~host_opt:None;
   (* Update the SM plugin table *)
-  Xapi_sm.on_xapi_start ~__context;
+  Storage_access.on_xapi_start ~__context;
 
   create_tools_sr_noexn __context;
 

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -337,12 +337,16 @@ let get_supported add_fn =
   let check_driver entry =
       if String.endswith "SR" entry then (
         let driver = String.sub entry 0 (String.length entry - 2) in
-        try
-          Unix.access (cmd_name driver) [ Unix.X_OK ];
-          let i = sr_get_driver_info driver in
-          add_fn driver i;
-        with e ->
-          error "Rejecting SM plugin: %s because of exception: %s (executable)" driver (Printexc.to_string e);
+        if not(Xapi_globs.accept_sm_plugin driver)
+        then info "Skipping SMAPIv1 plugin %s: not in sm-plugins whitelist in configuration file" driver
+        else begin
+          try
+            Unix.access (cmd_name driver) [ Unix.X_OK ];
+            let i = sr_get_driver_info driver in
+            add_fn driver i;
+          with e ->
+            error "Rejecting SM plugin: %s because of exception: %s (executable)" driver (Printexc.to_string e)
+        end
       ) in
 
   List.iter 

--- a/ocaml/xapi/storage_access.mli
+++ b/ocaml/xapi/storage_access.mli
@@ -18,6 +18,9 @@
 val start_smapiv1_servers: unit -> unit
 (** start listening for requests backed by SMAPIv1-style plugins *)
 
+val on_xapi_start: __context:Context.t -> unit
+(** Synchronises the known SM plugins with the SM table *)
+
 val start: unit -> unit
 (** once [start ()] returns the storage service is listening for requests on
     its unix domain socket. *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -883,6 +883,7 @@ let trusted_patch_key = ref citrix_patch_key
 
 let gen_list_option name desc of_string string_of opt =
   let parse s =
+    opt := [];
     try
       String.split_f String.isspace s |>
       List.iter (fun x -> opt := (of_string x) :: !opt)
@@ -894,7 +895,16 @@ let gen_list_option name desc of_string string_of opt =
   in
   name, Arg.String parse, get, desc
 
+let sm_plugins = ref [ ]
+
+let accept_sm_plugin name =
+  List.(fold_left (||) false (map (function `All -> true | `Sm x -> String.lowercase x = String.lowercase name) !sm_plugins))
+
 let other_options = [
+  gen_list_option "sm-plugins"
+    "space-separated list of storage plugins to allow."
+    (fun x -> if x = "*" then `All else `Sm x) (fun x -> match x with `All -> "*" | `Sm x -> x) sm_plugins;
+
   "hotfix-fingerprint", Arg.Set_string trusted_patch_key,
     (fun () -> !trusted_patch_key), "Fingerprint of the key used for signed hotfixes";
 

--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -186,9 +186,6 @@ let unplug ~__context ~self =
 			Storage_access.transform_storage_exn
 				(fun () -> C.SR.detach dbg uuid);
 
-			(* This is the last point we can query the plugin's capabilities *)
-			Opt.iter (Xapi_sm.unregister_plugin ~__context) (Storage_mux.query_result_of_sr uuid);
-
             Storage_access.unbind ~__context ~pbd:self;
 			Db.PBD.set_currently_attached ~__context ~self ~value:false;
 

--- a/ocaml/xapi/xapi_sm.ml
+++ b/ocaml/xapi/xapi_sm.ml
@@ -86,35 +86,6 @@ let update_from_query_result ~__context (self, r) query_result =
 
 let is_v1 x = version_of_string x < [ 2; 0 ]
 
-(** Update all SMAPIv1 plugins which have been deleted from the filesystem.
-    The SMAPIv2 ones are dynamically discovered so we leave those alone. *)
-let on_xapi_start ~__context =
-	let existing = List.map (fun (rf, rc) -> rc.API.sM_type, (rf, rc)) (Db.SM.get_all_records ~__context) in
-	let drivers = Sm.supported_drivers () in
-	(* Delete all SM records except those for SMAPIv1 plugins *)
-	List.iter
-		(fun ty ->
-			let self, rc = List.assoc ty existing in
-			if is_v1 rc.API.sM_required_api_version then begin
-				info "Unregistering SM plugin %s since required_api_version (%s) < 2.0 and executable is missing" ty rc.API.sM_required_api_version;
-				try
-					Db.SM.destroy ~__context ~self
-				with _ -> ()
-			end
-		) (List.set_difference (List.map fst existing) drivers);
-	(* Create all missing SMAPIv1 plugins *)
-	List.iter
-		(fun ty ->
-			let query_result = Sm.info_of_driver ty |> Smint.query_result_of_sr_driver_info in
-			create_from_query_result ~__context query_result
-		) (List.set_difference drivers (List.map fst existing));
-	(* Update all existing SMAPIv1 plugins *)
-	List.iter
-		(fun ty ->
-			let query_result = Sm.info_of_driver ty |> Smint.query_result_of_sr_driver_info in
-			update_from_query_result ~__context (List.assoc ty existing) query_result
-		) (List.intersect drivers (List.map fst existing))
-
 let unregister_plugin ~__context query_result =
 	let open Storage_interface in
 	let driver = String.lowercase query_result.driver in

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -143,6 +143,9 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # Directory containing SM plugins
 # sm-dir =  @OPTDIR@/sm
 
+# Whitelist of SM plugins
+sm-plugins=cifs ext nfs iscsi lvmoiscsi dummy file hba udev iso lvm lvmohba
+
 # Directory containing tools ISO
 # tools-sr-dir = @OPTDIR@/packages/iso
 

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -155,6 +155,7 @@ for f in XenAPI XenAPIPlugin inventory; do
 done > core-files
 
 ln -s /var/lib/xcp $RPM_BUILD_ROOT/var/xapi
+mkdir $RPM_BUILD_ROOT/etc/xapi.conf.d
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -196,6 +197,7 @@ rm -rf $RPM_BUILD_ROOT
 /etc/rc.d/init.d/save-boot-info
 %config(noreplace) /etc/sysconfig/perfmon
 %config(noreplace) /etc/sysconfig/xapi
+/etc/xapi.conf.d
 /etc/xapi.d/base-path
 /etc/xapi.d/plugins/DRAC.py
 /etc/xapi.d/plugins/DRAC.pyo


### PR DESCRIPTION
This adds an SM whitelist to xapi.conf and allows configuration file fragments in /etc/xapi.d/conf to override it.

This will need [xapi-project/xcp-idl#86] to actually work.
