### PR TITLE
CP-12616: Use a string identifier to help uniquely identify VGPU_type objects

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 87
+let schema_minor_vsn = 88
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -67,7 +67,7 @@ let cream_release_schema_major_vsn = 5
 let cream_release_schema_minor_vsn = 73
 
 let dundee_release_schema_major_vsn = 5
-let dundee_release_schema_minor_vsn = 87
+let dundee_release_schema_minor_vsn = 88
 
 (* the schema vsn of the last release: used to determine whether we can upgrade or not.. *)
 let last_release_schema_major_vsn = creedence_release_schema_major_vsn
@@ -8364,6 +8364,7 @@ let vgpu_type =
 			field ~qualifier:DynamicRO ~ty:(Set (Ref _gpu_group)) ~lifecycle:[Published, rel_vgpu_productisation, ""] "supported_on_GPU_groups" "List of GPU groups in which at least one PGPU supports this VGPU type";
 			field ~qualifier:DynamicRO ~ty:(Set (Ref _gpu_group)) ~lifecycle:[Published, rel_vgpu_productisation, ""] "enabled_on_GPU_groups" "List of GPU groups in which at least one have this VGPU type enabled";
 			field ~qualifier:StaticRO ~ty:vgpu_type_implementation ~lifecycle:[Published, rel_dundee, ""] ~default_value:(Some (VEnum "passthrough")) "implementation" "The internal implementation of this VGPU type";
+			field ~qualifier:StaticRO ~ty:String ~lifecycle:[Published, rel_dundee, ""] ~default_value:(Some (VString "")) "identifier" "Key used to identify VGPU types and avoid creating duplicates - this field is used internally and not intended for interpretation by API clients";
 		]
 	()
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8354,8 +8354,8 @@ let vgpu_type =
 			field ~qualifier:StaticRO ~ty:String ~lifecycle:[Published, rel_vgpu_tech_preview, ""] ~default_value:(Some (VString "")) "model_name" "Model name associated with the VGPU type";
 			field ~qualifier:StaticRO ~ty:Int ~lifecycle:[Published, rel_vgpu_tech_preview, ""] ~default_value:(Some (VInt 0L)) "framebuffer_size" "Framebuffer size of the VGPU type, in bytes";
 			field ~qualifier:StaticRO ~ty:Int ~lifecycle:[Published, rel_vgpu_tech_preview, ""] ~default_value:(Some (VInt 0L)) "max_heads" "Maximum number of displays supported by the VGPU type";
-			field ~qualifier:StaticRO ~ty:Int ~lifecycle:[Published, rel_vgpu_productisation, ""] ~default_value:(Some (VInt 0L)) "max_resolution_x" "Maximum resultion (width) supported by the VGPU type";
-			field ~qualifier:StaticRO ~ty:Int ~lifecycle:[Published, rel_vgpu_productisation, ""] ~default_value:(Some (VInt 0L)) "max_resolution_y" "Maximum resoltion (height) supported by the VGPU type";
+			field ~qualifier:StaticRO ~ty:Int ~lifecycle:[Published, rel_vgpu_productisation, ""] ~default_value:(Some (VInt 0L)) "max_resolution_x" "Maximum resolution (width) supported by the VGPU type";
+			field ~qualifier:StaticRO ~ty:Int ~lifecycle:[Published, rel_vgpu_productisation, ""] ~default_value:(Some (VInt 0L)) "max_resolution_y" "Maximum resolution (height) supported by the VGPU type";
 			field ~qualifier:StaticRO ~ty:Int ~lifecycle:[Published, rel_vgpu_tech_preview, ""] ~internal_only:true ~default_value:(Some (VInt 0L)) "size" "Abstract size for tracking PGPU utilisation";
 			field ~qualifier:DynamicRO ~ty:(Set (Ref _pgpu)) ~lifecycle:[Published, rel_vgpu_tech_preview, ""] "supported_on_PGPUs" "List of PGPUs that support this VGPU type";
 			field ~qualifier:DynamicRO ~ty:(Set (Ref _pgpu)) ~lifecycle:[Published, rel_vgpu_tech_preview, ""] "enabled_on_PGPUs" "List of PGPUs that have this VGPU type enabled";

--- a/ocaml/test/test_common.ml
+++ b/ocaml/test/test_common.ml
@@ -251,8 +251,9 @@ let make_vgpu ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ()) ?(vM=Ref.null)
 let make_vgpu_type ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
 		?(vendor_name="") ?(model_name="") ?(framebuffer_size=0L) ?(max_heads=0L)
 		?(max_resolution_x=0L) ?(max_resolution_y=0L) ?(size=0L)
-		?(internal_config=[]) ?(implementation=`passthrough) () =
+		?(internal_config=[]) ?(implementation=`passthrough)
+		?(identifier="") () =
 	Db.VGPU_type.create ~__context ~ref ~uuid ~vendor_name ~model_name
 		~framebuffer_size ~max_heads ~max_resolution_x ~max_resolution_y ~size
-		~internal_config ~implementation;
+		~internal_config ~implementation ~identifier;
 	ref

--- a/ocaml/test/test_vgpu_common.ml
+++ b/ocaml/test/test_vgpu_common.ml
@@ -23,7 +23,12 @@ let k100 = {
 	max_resolution_y = 1200L;
 	size = Int64.div Constants.pgpu_default_size 8L;
 	internal_config = [];
-	implementation = `nvidia;
+	identifier = Identifier.(Nvidia {
+		pdev_id = 0x0ff2;
+		psubdev_id = None;
+		vdev_id = 0x0fe7;
+		vsubdev_id = 0x101e;
+	});
 }
 
 let k140q = {
@@ -35,7 +40,12 @@ let k140q = {
 	max_resolution_y = 1600L;
 	size = Int64.div Constants.pgpu_default_size 4L;
 	internal_config = [];
-	implementation = `nvidia;
+	identifier = Identifier.(Nvidia {
+		pdev_id = 0x0ff2;
+		psubdev_id = None;
+		vdev_id = 0x0ff7;
+		vsubdev_id = 0x1037;
+	});
 }
 
 let k200 = {
@@ -47,7 +57,12 @@ let k200 = {
 	max_resolution_y = 1200L;
 	size = Int64.div Constants.pgpu_default_size 8L;
 	internal_config = [];
-	implementation = `nvidia;
+	identifier = Identifier.(Nvidia {
+		pdev_id = 0x11bf;
+		psubdev_id = None;
+		vdev_id = 0x118d;
+		vsubdev_id = 0x101d;
+	});
 }
 
 let k240q = {
@@ -59,7 +74,12 @@ let k240q = {
 	max_resolution_y = 1600L;
 	size = Int64.div Constants.pgpu_default_size 4L;
 	internal_config = [];
-	implementation = `nvidia;
+	identifier = Identifier.(Nvidia {
+		pdev_id = 0x11bf;
+		psubdev_id = None;
+		vdev_id = 0x11b0;
+		vsubdev_id = 0x101a;
+	});
 }
 
 let k260q = {
@@ -71,7 +91,12 @@ let k260q = {
 	max_resolution_y = 1600L;
 	size = Int64.div Constants.pgpu_default_size 2L;
 	internal_config = [];
-	implementation = `nvidia;
+	identifier = Identifier.(Nvidia {
+		pdev_id = 0x11bf;
+		psubdev_id = None;
+		vdev_id = 0x11b0;
+		vsubdev_id = 0x101b;
+	});
 }
 
 let k1_vgpu_types = [

--- a/ocaml/test/test_vgpu_type.ml
+++ b/ocaml/test/test_vgpu_type.ml
@@ -160,6 +160,24 @@ let test_identifier_lookup () =
 		test_model_name
 		(Db.VGPU_type.get_model_name ~__context ~self:k100_ref_1)
 
+let test_vendor_model_lookup () =
+	let __context = make_test_database () in
+	let k100_ref_1 = find_or_create ~__context k100 in
+	(* Set the identifier to the empty string, as if we have upgraded from an old
+	 * version that did not have the identifier field. *)
+	Db.VGPU_type.set_identifier ~__context ~self:k100_ref_1 ~value:"";
+	let k100_ref_2 = find_or_create ~__context k100 in
+	(* Make sure the new ref is the same as the old ref, i.e. no new VGPU_type has
+	 * been created. *)
+	assert_equal
+		~msg:"New k100 type was created erroneously"
+		k100_ref_1 k100_ref_2;
+	(* Make sure the identifier field has been updated. *)
+	assert_equal
+		~msg:"k100 identifier was not updated."
+		(Identifier.to_string k100.identifier)
+		(Db.VGPU_type.get_identifier ~__context ~self:k100_ref_1)
+
 let test =
 	"test_vgpu_type" >:::
 		[
@@ -167,4 +185,5 @@ let test =
 			"print_nv_types" >:: print_nv_types;
 			"test_find_or_create" >:: test_find_or_create;
 			"test_identifier_lookup" >:: test_identifier_lookup;
+			"test_vendor_model_lookup" >:: test_vendor_model_lookup;
 		]

--- a/ocaml/test/test_vgpu_type.ml
+++ b/ocaml/test/test_vgpu_type.ml
@@ -93,20 +93,20 @@ let print_nv_types () =
 
 let test_find_or_create () =
 	let __context = make_test_database () in
-	let k100_ref = find_or_create ~__context k100 in
+	let k100_ref_1 = find_or_create ~__context k100 in
 	(* Check the VGPU type created in the DB has the expected fields. *)
 	assert_equal
 		~msg:"k100 framebuffer_size is incorrect"
 		k100.framebuffer_size
-		(Db.VGPU_type.get_framebuffer_size ~__context ~self:k100_ref);
+		(Db.VGPU_type.get_framebuffer_size ~__context ~self:k100_ref_1);
 	assert_equal
 		~msg:"k100 max_heads is incorrect"
 		k100.max_heads
-		(Db.VGPU_type.get_max_heads ~__context ~self:k100_ref);
+		(Db.VGPU_type.get_max_heads ~__context ~self:k100_ref_1);
 	assert_equal
 		~msg:"k100 size is incorrect"
 		k100.size
-		(Db.VGPU_type.get_size ~__context ~self:k100_ref);
+		(Db.VGPU_type.get_size ~__context ~self:k100_ref_1);
 	(* Simulate an update of framebuffer_size, max_heads and size as if the
 	 * config file had been updated. *)
 	let new_k100 = {
@@ -117,21 +117,26 @@ let test_find_or_create () =
 	} in
 	(* We can ignore the result as it should be the same as the VGPU_type ref
 	 * obtained earlier. *)
-	let (_: API.ref_VGPU_type) = find_or_create ~__context new_k100 in
+	let k100_ref_2 = find_or_create ~__context new_k100 in
+	(* Make sure the new ref is the same as the old ref, i.e. no new VGPU_type has
+	 * been created. *)
+	assert_equal
+		~msg:"New k100 type was created erroneously"
+		k100_ref_1 k100_ref_2;
 	(* Make sure the existing VGPU type object in the database
 	 * has been updated. *)
 	assert_equal
 		~msg:"k100 framebuffer_size was not updated"
 		new_k100.framebuffer_size
-		(Db.VGPU_type.get_framebuffer_size ~__context ~self:k100_ref);
+		(Db.VGPU_type.get_framebuffer_size ~__context ~self:k100_ref_1);
 	assert_equal
 		~msg:"k100 max_heads was not updated"
 		new_k100.max_heads
-		(Db.VGPU_type.get_max_heads ~__context ~self:k100_ref);
+		(Db.VGPU_type.get_max_heads ~__context ~self:k100_ref_1);
 	assert_equal
 		~msg:"k100 size was not updated"
 		new_k100.size
-		(Db.VGPU_type.get_size ~__context ~self:k100_ref)
+		(Db.VGPU_type.get_size ~__context ~self:k100_ref_1)
 
 let test =
 	"test_vgpu_type" >:::

--- a/ocaml/test/test_vgpu_type.ml
+++ b/ocaml/test/test_vgpu_type.ml
@@ -138,10 +138,33 @@ let test_find_or_create () =
 		new_k100.size
 		(Db.VGPU_type.get_size ~__context ~self:k100_ref_1)
 
+let test_identifier_lookup () =
+	let test_vendor_name = "test_vendor_name" in
+	let test_model_name = "test_model_name" in
+	let __context = make_test_database () in
+	let k100_ref_1 = find_or_create ~__context k100 in
+	let k100_ref_2 = find_or_create ~__context
+		{k100 with vendor_name = test_vendor_name; model_name = test_model_name} in
+	(* Make sure the new ref is the same as the old ref, i.e. no new VGPU_type has
+	 * been created. *)
+	assert_equal
+		~msg:"New k100 type was created erroneously"
+		k100_ref_1 k100_ref_2;
+	(* Make sure the VGPU_type's vendor and model names have been updated. *)
+	assert_equal
+		~msg:"k100 vendor_name was not updated"
+		test_vendor_name
+		(Db.VGPU_type.get_vendor_name ~__context ~self:k100_ref_1);
+	assert_equal
+		~msg:"k100 model_name was not updated"
+		test_model_name
+		(Db.VGPU_type.get_model_name ~__context ~self:k100_ref_1)
+
 let test =
 	"test_vgpu_type" >:::
 		[
 			"test_of_conf_file" >:: OfConfFile.test;
 			"print_nv_types" >:: print_nv_types;
 			"test_find_or_create" >:: test_find_or_create;
+			"test_identifier_lookup" >:: test_identifier_lookup;
 		]

--- a/ocaml/xapi/db_gc.ml
+++ b/ocaml/xapi/db_gc.ml
@@ -72,7 +72,7 @@ let gc_VGPU_types ~__context =
 	match garbage with
 	| [] -> ()
 	| _ ->
-		debug "GC-ing the follwing unused and unsupported VGPU_types: [ %s ]"
+		debug "GC-ing the following unused and unsupported VGPU_types: [ %s ]"
 			(String.concat "; " (List.map Ref.string_of (List.map fst garbage)));
 		List.iter (fun (self, _) -> Db.VGPU_type.destroy ~__context ~self) garbage
 

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1095,7 +1095,8 @@ module VGPUType : HandlerTools = struct
 		| Some (vgpu_type, _) -> Found_VGPU_type vgpu_type
 		| None ->
 			warn
-				"Unable to find VGPU_type (%s,%s) - creating a new record"
+				"Unable to find VGPU_type (%s,%s,%s) - creating a new record"
+				vgpu_type_record.API.vGPU_type_identifier
 				vgpu_type_record.API.vGPU_type_vendor_name
 				vgpu_type_record.API.vGPU_type_model_name;
 			Create vgpu_type_record

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1073,13 +1073,22 @@ module VGPUType : HandlerTools = struct
 	let precheck __context config rpc session_id state x =
 		let vgpu_type_record = API.Legacy.From.vGPU_type_t "" x.snapshot in
 
-		(* Look up VGPU types using the vendor name and model name. *)
+		(* First look up VGPU types using the identifier string. *)
 		let compatible_types =
-			Client.VGPU_type.get_all_records_where rpc session_id
+			match Client.VGPU_type.get_all_records_where rpc session_id
 				(Printf.sprintf
-					"field \"vendor_name\"=\"%s\" and field \"model_name\"=\"%s\""
-					vgpu_type_record.API.vGPU_type_vendor_name
-					vgpu_type_record.API.vGPU_type_model_name)
+					"field \"identifier\"=\"%s\""
+					vgpu_type_record.API.vGPU_type_identifier)
+			with
+			| [] -> begin
+				(* If that fails, look up using the vendor name and model name. *)
+				Client.VGPU_type.get_all_records_where rpc session_id
+					(Printf.sprintf
+						"field \"vendor_name\"=\"%s\" and field \"model_name\"=\"%s\""
+						vgpu_type_record.API.vGPU_type_vendor_name
+						vgpu_type_record.API.vGPU_type_model_name)
+			end
+			| types -> types
 		in
 
 		match choose_one compatible_types with

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1121,7 +1121,8 @@ module VGPUType : HandlerTools = struct
 							~max_resolution_y:value.API.vGPU_type_max_resolution_y
 							~size:0L
 							~internal_config:[]
-							~implementation:value.API.vGPU_type_implementation)
+							~implementation:value.API.vGPU_type_implementation
+							~identifier:value.API.vGPU_type_identifier)
 					vgpu_type_record
 			in
 			state.cleanup <- (fun __context rpc session_id -> Db.VGPU_type.destroy __context vgpu_type) :: state.cleanup;

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -32,7 +32,7 @@ let create ~__context ~pCI ~gPU_group ~host ~other_config
 		~supported_VGPU_types ~size ~dom0_access 
 		~is_system_display_device =
 	let pgpu = Ref.make () in
-	let uuid = Uuid.to_string (Uuid.make_uuid ()) in
+	let uuid = Uuidm.to_string (Uuidm.create `V4) in
 	let supported_VGPU_max_capacities =
 		calculate_max_capacities ~__context ~pCI ~size ~supported_VGPU_types
 	in

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -273,8 +273,9 @@ module Intel = struct
 			Db.PCI.get_pci_id ~__context ~self:pci
 			|> address_of_string
 		in
-		let device, device_name =
+		let vendor_name, device, device_name =
 			Pci.(with_access (fun access ->
+				let vendor_name = lookup_vendor_name access intel_vendor_id in
 				let device =
 					List.find
 						(fun device ->
@@ -289,7 +290,7 @@ module Intel = struct
 						device.Pci_dev.vendor_id
 						device.Pci_dev.device_id
 				in
-				device, device_name))
+				vendor_name, device, device_name))
 		in
 		let bar_size =
 			List.nth device.Pci.Pci_dev.size 2
@@ -298,7 +299,7 @@ module Intel = struct
 		let vgpus_per_pgpu = bar_size /// 1024L /// 1024L /// 128L --- 1L in
 		let vgpu_size = Constants.pgpu_default_size /// vgpus_per_pgpu in
 		{
-			vendor_name = "Intel";
+			vendor_name;
 			model_name = "Intel GVT-g on " ^ device_name;
 			framebuffer_size = mib 256L;
 			max_heads = 1L;

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -46,7 +46,7 @@ let passthrough_gpu = {
 let create ~__context ~vendor_name ~model_name ~framebuffer_size ~max_heads
 		~max_resolution_x ~max_resolution_y ~size ~internal_config ~implementation =
 	let ref = Ref.make () in
-	let uuid = Uuid.to_string (Uuid.make_uuid ()) in
+	let uuid = Uuidm.to_string (Uuidm.create `V4) in
 	Db.VGPU_type.create ~__context ~ref ~uuid ~vendor_name ~model_name
 		~framebuffer_size ~max_heads ~max_resolution_x ~max_resolution_y
 		~size ~internal_config ~implementation;

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -44,12 +44,13 @@ let passthrough_gpu = {
 }
 
 let create ~__context ~vendor_name ~model_name ~framebuffer_size ~max_heads
-		~max_resolution_x ~max_resolution_y ~size ~internal_config ~implementation =
+		~max_resolution_x ~max_resolution_y ~size ~internal_config ~implementation
+		~identifier =
 	let ref = Ref.make () in
 	let uuid = Uuidm.to_string (Uuidm.create `V4) in
 	Db.VGPU_type.create ~__context ~ref ~uuid ~vendor_name ~model_name
 		~framebuffer_size ~max_heads ~max_resolution_x ~max_resolution_y
-		~size ~internal_config ~implementation;
+		~size ~internal_config ~implementation ~identifier;
 	debug "VGPU_type ref='%s' created (vendor_name = '%s'; model_name = '%s')"
 		(Ref.string_of ref) vendor_name model_name;
 	ref
@@ -105,6 +106,7 @@ let find_or_create ~__context vgpu_type =
 			~size:vgpu_type.size
 			~internal_config:vgpu_type.internal_config
 			~implementation:vgpu_type.implementation
+			~identifier:""
 	| _ ->
 		failwith "Error: Multiple vGPU types exist with the same configuration."
 


### PR DESCRIPTION
Design: http://xapi-project.github.io/xapi/futures/vgpu-type-identifiers.html