### PR TITLE
CA-166748: cleanup SXM after XAPI restart

### DIFF
--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -13,7 +13,7 @@ OCAMLINCLUDES = ../idl ../idl/ocaml_backend \
 
 UseCamlp4(rpclib.syntax, features storage_impl xapi_udhcpd storage_migrate \
           xapi_services system_domains cancel_tests config_file_sync updates \
-          vhd_tool_wrapper)
+          sparse_dd_wrapper vhd_tool_wrapper)
 
 CFLAGS += -std=gnu99 -Wall -Werror -I$(shell ocamlc -where)
 

--- a/ocaml/xapi/sparse_dd_wrapper.ml
+++ b/ocaml/xapi/sparse_dd_wrapper.ml
@@ -35,6 +35,25 @@ type t = {
   exn : exn option ref;
 }
 
+(* Store sparse_dd pids on disk so we can kill them after a xapi restart *)
+module State = struct
+  type pids = int list with rpc
+
+  let filename = ref "/var/run/nonpersistent/xapi/sparse_dd_pids.json"
+
+  let m = Mutex.create ()
+
+  let load () = try Unixext.string_of_file !filename |> Jsonrpc.of_string |> pids_of_rpc with _ -> []
+  let save pids = rpc_of_pids pids |> Jsonrpc.to_string |> Unixext.write_string_to_file !filename
+
+  let unsafe_add pid = let pids = load () in save (pid::pids)
+  let unsafe_remove pid = let pids = load () in save (List.filter (fun x -> x <> pid) pids)
+
+  let add pid = Mutex.execute m (fun () -> unsafe_add pid)
+  let remove pid = Mutex.execute m (fun () -> unsafe_remove pid)
+  let list () = Mutex.execute m load
+end
+
 exception Cancelled
 
 (** Use the new external sparse_dd program *)
@@ -57,6 +76,8 @@ let dd_internal progress_cb base prezeroed infile outfile size =
 				debug "%s %s" sparse_dd_path (String.concat " " args);
 				let pid = Forkhelpers.safe_close_and_exec None (Some pipe_write) (Some log_fd) []
 					sparse_dd_path args in
+				let intpid = Forkhelpers.getpid pid in
+				State.add intpid;
 				close pipe_write;
 				progress_cb (Started pid);
 				(* Read Progress: output from the binary *)
@@ -74,7 +95,9 @@ let dd_internal progress_cb base prezeroed infile outfile size =
 							raise e
 						end
 					) () pipe_read;
-				match Forkhelpers.waitpid pid with
+				let r = Forkhelpers.waitpid pid in
+				State.remove intpid;
+				match r with
 				| (_, Unix.WEXITED 0) -> progress_cb (Finished None)
 				| (_, Unix.WEXITED 5) -> error "sparse_dd received NBD error"; failwith "sparse_dd NBD error"
 				| (_, Unix.WEXITED n) -> error "sparse_dd exit: %d" n; failwith "sparse_dd"
@@ -91,7 +114,7 @@ let dd_internal progress_cb base prezeroed infile outfile size =
 	(fun () ->
 		close pipe_read;
 		close pipe_write)
-	
+
 let dd ?(progress_cb=(fun _ -> ())) ?base prezeroed =
 	dd_internal (function | Continuing x -> progress_cb x | _ -> ()) base prezeroed
 

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -24,7 +24,7 @@ open Pervasiveext
 open Xmlrpc_client
 open Threadext
 
-let local_url () = Http.Url.(Http { host="127.0.0.1"; auth=None; port=None; ssl=true }, { uri = "/services/SM"; query_params=["pool_secret",!Xapi_globs.pool_secret] } )
+let local_url () = Http.Url.(Http { host="127.0.0.1"; auth=None; port=None; ssl=false }, { uri = "/services/SM"; query_params=["pool_secret",!Xapi_globs.pool_secret] } )
 let remote_url ip = Http.Url.(Http { host=ip; auth=None; port=None; ssl=true }, { uri = "/services/SM"; query_params=["pool_secret",!Xapi_globs.pool_secret] } )
 
 open Storage_interface

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -57,33 +57,54 @@ module State = struct
 		} with rpc
 	end
 
-	type mirror = 
-		| Send of Send_state.t		
-		| Receive of Receive_state.t with rpc
+	module Copy_state = struct
+		type t = {
+			base_dp : dp;
+			leaf_dp : dp;
+		} with rpc
+	end
 
-	type t = (string, mirror) Hashtbl.t with rpc
+	type operation =
+		| Send of Send_state.t		
+		| Receive of Receive_state.t
+		| Copy of Copy_state.t with rpc
+
+	type t = (string, operation) Hashtbl.t with rpc
 
 	let active_send : t = Hashtbl.create 10
 	let active_recv : t = Hashtbl.create 10
+	let active_copy : t = Hashtbl.create 10
+
 	let loaded = ref false
 	let mutex = Mutex.create () 
 
-	let path send = Printf.sprintf "/var/run/nonpersistent/storage_mirrors_%s.json"
-		(if send then "send" else "recv")
+	type opty = OSend | OReceive | OCopy
+
+	let path ty = match ty with
+		| OSend -> "/var/run/nonpersistent/storage_mirrors_send.json"
+		| OReceive -> "/var/run/nonpersistent/storage_mirrors_recv.json"
+		| OCopy -> "/var/run/nonpersistent/storage_mirrors_copy.json"
 
 	let to_string r = rpc_of_t r |> Jsonrpc.to_string
 	let of_string s = Jsonrpc.of_string s |> t_of_rpc
-	let id_of (sr,vdi) = Printf.sprintf "%s/%s" sr vdi
-	let of_id id = match String.split '/' id with
+	let mirror_id_of (sr,vdi) = Printf.sprintf "%s/%s" sr vdi
+	let of_mirror_id id = match String.split '/' id with
 		| sr::rest -> (sr,String.concat "/" rest)
+		| _ -> failwith "Bad id"
+	let copy_id_of (sr,vdi) = Printf.sprintf "copy/%s/%s" sr vdi
+	let of_copy_id id =
+		match String.split '/' id with
+		| op :: sr :: rest when op="copy" -> (sr,(String.concat "/" rest))
 		| _ -> failwith "Bad id"
 
 	let load () =
 		let load path hashtbl = Unixext.string_of_file path |> of_string |> Hashtbl.iter (Hashtbl.replace hashtbl) in
-		try load (path true) active_send; load (path false) active_recv with _ -> ()
+		try load (path OSend) active_send; load (path OReceive) active_recv; load (path OCopy) active_copy with _ -> ()
 	let save () = 
-		to_string active_send |> Unixext.write_string_to_file (path true);
-		to_string active_recv |> Unixext.write_string_to_file (path false)
+		to_string active_send |> Unixext.write_string_to_file (path OSend);
+		to_string active_recv |> Unixext.write_string_to_file (path OReceive);
+		to_string active_recv |> Unixext.write_string_to_file (path OCopy)
+
 	let op s f h = Mutex.execute mutex (fun () -> if not !loaded then load (); let r = f h in if s then save (); r)
 	let map_of () =	
 		let m1 = op false (fun h -> Hashtbl.fold (fun k v acc -> (k,v)::acc) h []) active_send in
@@ -99,11 +120,17 @@ module State = struct
 	let add_to_active_receive_mirrors id arm =
 		add id active_recv $ Receive arm; arm
 
+	let add_to_active_copy id s =
+		add id active_copy $ Copy s; s
+
 	let find_active_local_mirror id =
 		Opt.Monad.bind (find id active_send) (function | Send s -> Some s | _ -> None)
 
 	let find_active_receive_mirror id =
 		Opt.Monad.bind (find id active_recv) (function | Receive r -> Some r | _ -> None)
+
+	let find_active_copy id =
+		Opt.Monad.bind (find id active_copy) (function | Copy s -> Some s | _ -> None)
 end
 
 
@@ -288,8 +315,8 @@ let stop ~dbg ~id =
 	(* Find the local VDI *)
 	let alm = State.find_active_local_mirror id in
 	match alm with 
-		| Some alm -> 
-			let sr,vdi = State.of_id id in
+		| Some alm ->
+			let sr,vdi = State.of_mirror_id id in
 			let vdis = Local.SR.scan ~dbg ~sr in
 			let local_vdi =
 				try List.find (fun x -> x.vdi = vdi) vdis
@@ -318,7 +345,7 @@ let start' ~task ~dbg ~sr ~vdi ~dp ~url ~dest =
 		try List.find (fun x -> x.vdi = vdi) vdis
 		with Not_found -> failwith (Printf.sprintf "Local VDI %s not found" vdi) in
 
-	let id = State.id_of (sr,local_vdi.vdi) in
+	let id = State.mirror_id_of (sr,local_vdi.vdi) in
 
 	(* A list of cleanup actions to perform if the operation should fail. *)
 	let on_fail : (unit -> unit) list ref = ref [] in
@@ -464,7 +491,7 @@ let stat ~dbg ~id =
 		| (None, Some _) -> [Sending]
 		| (None, None) -> raise (Does_not_exist ("mirror",id))
 	in
-	let (sr,vdi) = of_id id in
+	let (sr,vdi) = of_mirror_id id in
 	let src = match (s1,s2) with | (Some (Receive x), _) -> x.Receive_state.remote_vdi | (_,Some (Send x)) -> vdi | _ -> failwith "Invalid" in
 	let dst = match (s1,s2) with | (Some (Receive x), _) -> x.Receive_state.leaf_vdi | (_,Some (Send x)) -> x.Send_state.mirror_vdi | _ -> failwith "Invalid" in
 	{ Mirror.source_vdi = src; dest_vdi = dst; state; failed; }
@@ -560,7 +587,7 @@ let reqs_outstanding_timeout = 150.0 (* Tapdisk should time out after 2 mins. We
 
 let pre_deactivate_hook ~dbg ~dp ~sr ~vdi =
 	let open State.Send_state in
-	let id = State.id_of (sr,vdi) in
+	let id = State.mirror_id_of (sr,vdi) in
 	let start_time = Oclock.gettime Oclock.monotonic in
  	let get_delta () = (Int64.to_float (Int64.sub (Oclock.gettime Oclock.monotonic) start_time)) /. 1.0e9 in
 	State.find_active_local_mirror id |> 
@@ -597,7 +624,7 @@ let pre_deactivate_hook ~dbg ~dp ~sr ~vdi =
 
 let post_detach_hook ~sr ~vdi ~dp = 
 	let open State.Send_state in
-	let id = State.id_of (sr,vdi) in
+	let id = State.mirror_id_of (sr,vdi) in
 	State.find_active_local_mirror id |> 
 			Opt.iter (fun r -> 
 				let remote_url = Http.Url.of_string r.url in

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -69,7 +69,7 @@ module State = struct
 	end
 
 	type operation =
-		| Send of Send_state.t		
+		| Send of Send_state.t
 		| Receive of Receive_state.t
 		| Copy of Copy_state.t with rpc
 
@@ -103,20 +103,25 @@ module State = struct
 
 	let load () =
 		let load path hashtbl = Unixext.string_of_file path |> of_string |> Hashtbl.iter (Hashtbl.replace hashtbl) in
-		try load (path OSend) active_send; load (path OReceive) active_recv; load (path OCopy) active_copy with _ -> ()
+		List.iter (fun (ty, tbl) -> try load (path ty) tbl with _ -> ()) [ OSend, active_send; OReceive, active_recv; OCopy, active_copy ];
+		loaded := true
+
 	let save () = 
 		to_string active_send |> Unixext.write_string_to_file (path OSend);
 		to_string active_recv |> Unixext.write_string_to_file (path OReceive);
-		to_string active_recv |> Unixext.write_string_to_file (path OCopy)
+		to_string active_copy |> Unixext.write_string_to_file (path OCopy)
 
 	let op s f h = Mutex.execute mutex (fun () -> if not !loaded then load (); let r = f h in if s then save (); r)
 	let map_of () =	
 		let m1 = op false (fun h -> Hashtbl.fold (fun k v acc -> (k,v)::acc) h []) active_send in
-		op false (fun h -> Hashtbl.fold (fun k v acc -> (k,v)::acc) h m1) active_recv
+		let m2 = op false (fun h -> Hashtbl.fold (fun k v acc -> (k,v)::acc) h m1) active_recv in
+		let m3 = op false (fun h -> Hashtbl.fold (fun k v acc -> (k,v)::acc) h m2) active_copy in
+		m3
 
 	let add id h s = op true (fun a -> Hashtbl.replace a id s) h
 	let find id h = op false (fun a -> try Some (Hashtbl.find a id) with _ -> None) h
 	let remove id h = op true (fun a ->	Hashtbl.remove a id) h
+	let clear h = op true Hashtbl.clear h
 
 	let add_to_active_local_mirrors id alm =
 		add id active_send $ Send alm; alm
@@ -185,7 +190,7 @@ let tapdisk_of_attach_info attach_info =
 			None
 		| _ -> 
 			debug "Device %s has an unknown driver" path;
-			None 
+			None
 
 
 let with_activated_disk ~dbg ~sr ~vdi ~dp f =
@@ -280,7 +285,7 @@ let copy' ~task ~dbg ~sr ~vdi ~url ~dest ~dest_vdi =
 			debug "activating RW datapath %s on remote=%s/%s" remote_dp dest dest_vdi;
 			ignore(Remote.VDI.attach ~dbg ~sr:dest ~vdi:dest_vdi ~dp:remote_dp ~read_write:true);
 			Remote.VDI.activate ~dbg ~dp:remote_dp ~sr:dest ~vdi:dest_vdi;
-			
+
 			with_activated_disk ~dbg ~sr ~vdi:base_vdi ~dp:base_dp
 				(fun base_path ->
 					with_activated_disk ~dbg ~sr ~vdi:(Some vdi) ~dp:leaf_dp
@@ -337,6 +342,16 @@ let stop ~dbg ~id =
 			(* Disable mirroring on the local machine *)
 			let snapshot = Local.VDI.snapshot ~dbg ~sr ~vdi_info:local_vdi in
 			Local.VDI.destroy ~dbg ~sr ~vdi:snapshot.vdi;
+			(* Destroy the snapshot, if it still exists *)
+			let snap = try Some (List.find (fun x -> List.mem_assoc "base_mirror" x.sm_config && List.assoc "base_mirror" x.sm_config = id) vdis) with _ -> None in
+			begin
+				match snap with
+				| Some s ->
+					debug "Found snapshot VDI: %s" s.vdi;
+					Local.VDI.destroy ~dbg ~sr ~vdi:s.vdi
+				| None ->
+					debug "Snapshot VDI already cleaned up"
+			end;
 			let remote_url = Http.Url.of_string alm.State.Send_state.remote_url in
 			let module Remote = Client(struct let rpc = rpc ~srcstr:"smapiv2" ~dststr:"dst_smapiv2" remote_url end) in
 			(try Remote.DATA.MIRROR.receive_cancel ~dbg ~id with _ -> ());
@@ -506,12 +521,42 @@ let stat ~dbg ~id =
 	let src = match (s1,s2) with | (Some (Receive x), _) -> x.Receive_state.remote_vdi | (_,Some (Send x)) -> vdi | _ -> failwith "Invalid" in
 	let dst = match (s1,s2) with | (Some (Receive x), _) -> x.Receive_state.leaf_vdi | (_,Some (Send x)) -> x.Send_state.mirror_vdi | _ -> failwith "Invalid" in
 	{ Mirror.source_vdi = src; dest_vdi = dst; state; failed; }
-	
+
 let list ~dbg =
 	let m = State.map_of () in
 	let ids = List.map fst m |> Listext.List.setify in
 	List.map (fun id ->
 		(id,stat dbg id)) ids
+
+let killall ~dbg =
+	let m = State.map_of () in
+	List.iter (function
+		| (id, State.Send x) ->
+			begin
+				debug "Send in progress: %s" id;
+				List.iter log_and_ignore_exn
+					[ (fun () -> stop dbg id);
+					  (fun () -> Local.DP.destroy ~dbg ~dp:x.State.Send_state.local_dp ~allow_leak:true) ]
+			end
+		| (id, State.Copy x) ->
+			 begin
+				 debug "Copy in progress: %s" id;
+				 List.iter log_and_ignore_exn
+					 [ (fun () -> Local.DP.destroy ~dbg ~dp:x.State.Copy_state.leaf_dp ~allow_leak:true);
+					   (fun () -> Local.DP.destroy ~dbg ~dp:x.State.Copy_state.base_dp ~allow_leak:true) ];
+				 let remote_url = Http.Url.of_string x.State.Copy_state.remote_url in
+				 let module Remote = Client(struct let rpc = rpc ~srcstr:"smapiv2" ~dststr:"dst_smapiv2" remote_url end) in
+				 List.iter log_and_ignore_exn
+					 [ (fun () -> Remote.DP.destroy ~dbg ~dp:x.State.Copy_state.remote_dp ~allow_leak:true);
+					   (fun () -> Remote.VDI.destroy ~dbg ~sr:x.State.Copy_state.dest_sr ~vdi:x.State.Copy_state.copy_vdi) ]
+			 end
+		| (id, State.Receive x) ->
+			 begin
+				 debug "Receive in progress: %s" id;
+				 log_and_ignore_exn (fun () -> Local.DATA.MIRROR.receive_cancel ~dbg ~id)
+			 end
+	) m;
+	List.iter State.clear [State.active_send; State.active_recv; State.active_copy]
 
 let receive_start ~dbg ~sr ~vdi_info ~id ~similar =
 	let on_fail : (unit -> unit) list ref = ref [] in
@@ -575,9 +620,6 @@ let receive_start ~dbg ~sr ~vdi_info ~id ~similar =
 		List.iter (fun op -> try op () with e -> debug "Caught exception in on_fail: %s" (Printexc.to_string e)) !on_fail;
 		raise e
 
-let log_exn_and_continue s f =
-	try f () with e -> debug "Ignorning exception '%s' while %s" (Printexc.to_string e) s
-
 let receive_finalize ~dbg ~id =
 	let record = State.find_active_receive_mirror id in
 	let open State.Receive_state in Opt.iter (fun r -> Local.DP.destroy ~dbg ~dp:r.leaf_dp ~allow_leak:false) record;
@@ -586,9 +628,9 @@ let receive_finalize ~dbg ~id =
 let receive_cancel ~dbg ~id =
 	let record = State.find_active_receive_mirror id in
 	let open State.Receive_state in Opt.iter (fun r ->
-		log_exn_and_continue "cancelling receive" (fun () -> Local.DP.destroy ~dbg ~dp:r.leaf_dp ~allow_leak:false);
+		log_and_ignore_exn (fun () -> Local.DP.destroy ~dbg ~dp:r.leaf_dp ~allow_leak:false);
 		List.iter (fun v -> 
-			log_exn_and_continue "cancelling receive" (fun () -> Local.VDI.destroy ~dbg ~sr:r.sr ~vdi:v)
+			log_and_ignore_exn (fun () -> Local.VDI.destroy ~dbg ~sr:r.sr ~vdi:v)
 		) [r.dummy_vdi; r.leaf_vdi; r.parent_vdi]
 	) record;
 	State.remove id State.active_recv
@@ -642,7 +684,7 @@ let post_detach_hook ~sr ~vdi ~dp =
 				let module Remote = Client(struct let rpc = rpc ~srcstr:"smapiv2" ~dststr:"dst_smapiv2" remote_url end) in
 				let t = Thread.create (fun () ->
 					debug "Calling receive_finalize";
-					log_exn_and_continue "in detach hook" 
+					log_and_ignore_exn
 						(fun () -> Remote.DATA.MIRROR.receive_finalize ~dbg:"Mirror-cleanup" ~id);
 					debug "Finished calling receive_finalize";
 					State.remove id State.active_send;
@@ -742,7 +784,7 @@ let wrap ~dbg f =
 			signal task.Storage_task.id
 		)) () in
 	task.Storage_task.id
-		
+
 let start ~dbg ~sr ~vdi ~dp ~url ~dest = 
 	wrap ~dbg (fun task -> start' ~task ~dbg ~sr ~vdi ~dp ~url ~dest)
 

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -61,6 +61,10 @@ module State = struct
 		type t = {
 			base_dp : dp;
 			leaf_dp : dp;
+			remote_dp : dp;
+			dest_sr: sr;
+			copy_vdi: vdi;
+			remote_url : string;
 		} with rpc
 	end
 
@@ -184,20 +188,20 @@ let tapdisk_of_attach_info attach_info =
 			None 
 
 
-let with_activated_disk ~dbg ~sr ~vdi f =
+let with_activated_disk ~dbg ~sr ~vdi ~dp f =
 	let path =
 		Opt.map (fun vdi -> 
-			let attach_info = Local.VDI.attach ~dbg ~dp:"migrate" ~sr ~vdi ~read_write:false in
+			let attach_info = Local.VDI.attach ~dbg ~dp ~sr ~vdi ~read_write:false in
 			let path = attach_info.params in
-			Local.VDI.activate ~dbg ~dp:"migrate" ~sr ~vdi;
+			Local.VDI.activate ~dbg ~dp ~sr ~vdi;
 			path) vdi in
 	finally
 		(fun () -> f path)
 		(fun () ->
 			Opt.iter
 				(fun vdi ->
-					Local.VDI.deactivate ~dbg ~dp:"migrate" ~sr ~vdi;
-					Local.VDI.detach ~dbg ~dp:"migrate" ~sr ~vdi)
+					Local.VDI.deactivate ~dbg ~dp ~sr ~vdi;
+					Local.VDI.detach ~dbg ~dp ~sr ~vdi)
 				vdi)
 
 let perform_cleanup_actions =
@@ -258,21 +262,28 @@ let copy' ~task ~dbg ~sr ~vdi ~url ~dest ~dest_vdi =
 
 
 	try
-		let dp = Uuid.string_of_uuid (Uuid.make_uuid ()) in
-		let dest_vdi_url = Http.Url.set_uri remote_url (Printf.sprintf "%s/nbd/%s/%s/%s" (Http.Url.get_uri remote_url) dest dest_vdi dp) |> Http.Url.to_string in
+		let remote_dp = Uuid.string_of_uuid (Uuid.make_uuid ()) in
+		let base_dp = Uuid.string_of_uuid (Uuid.make_uuid ()) in
+		let leaf_dp = Uuid.string_of_uuid (Uuid.make_uuid ()) in
+		let dest_vdi_url = Http.Url.set_uri remote_url (Printf.sprintf "%s/nbd/%s/%s/%s" (Http.Url.get_uri remote_url) dest dest_vdi remote_dp) |> Http.Url.to_string in
 
 		debug "copy remote=%s/%s NBD URL = %s" dest dest_vdi dest_vdi_url;
+
+		let id=State.copy_id_of (sr,vdi) in
+		debug "Persisting state for copy (id=%s)" id;
+		ignore(State.add_to_active_copy id (State.Copy_state.({
+		  base_dp; leaf_dp; remote_dp; dest_sr=dest; copy_vdi=remote_vdi.vdi; remote_url=url})));
 
 		SMPERF.debug "mirror.copy: copy initiated local_vdi:%s dest_vdi:%s" vdi dest_vdi;
 
 		Pervasiveext.finally (fun () -> 
-			debug "activating RW datapath %s on remote=%s/%s" dp dest dest_vdi;
-			ignore(Remote.VDI.attach ~dbg ~sr:dest ~vdi:dest_vdi ~dp ~read_write:true);
-			Remote.VDI.activate ~dbg ~dp ~sr:dest ~vdi:dest_vdi;
+			debug "activating RW datapath %s on remote=%s/%s" remote_dp dest dest_vdi;
+			ignore(Remote.VDI.attach ~dbg ~sr:dest ~vdi:dest_vdi ~dp:remote_dp ~read_write:true);
+			Remote.VDI.activate ~dbg ~dp:remote_dp ~sr:dest ~vdi:dest_vdi;
 			
-			with_activated_disk ~dbg ~sr ~vdi:base_vdi
+			with_activated_disk ~dbg ~sr ~vdi:base_vdi ~dp:base_dp
 				(fun base_path ->
-					with_activated_disk ~dbg ~sr ~vdi:(Some vdi)
+					with_activated_disk ~dbg ~sr ~vdi:(Some vdi) ~dp:leaf_dp
 						(fun src ->
 							let dd = Sparse_dd_wrapper.start ~progress_cb:(progress_callback 0.05 0.9 task) ?base:base_path true (Opt.unbox src) 
 								dest_vdi_url remote_vdi.virtual_size in
@@ -285,7 +296,7 @@ let copy' ~task ~dbg ~sr ~vdi ~url ~dest ~dest_vdi =
 				);
 			)
 			(fun () -> 
-				Remote.DP.destroy ~dbg ~dp ~allow_leak:false);
+				Remote.DP.destroy ~dbg ~dp:remote_dp ~allow_leak:false);
 
 		SMPERF.debug "mirror.copy: copy complete local_vdi:%s dest_vdi:%s" vdi dest_vdi;
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -818,6 +818,7 @@ let server_init() =
     Server_helpers.exec_with_new_task "server_init" (fun __context ->
     Startup.run ~__context [
     "XAPI SERVER STARTING", [], print_server_starting_message;
+    "Killing stray sparse_dd processes", [], Sparse_dd_wrapper.killall;
     "Parsing inventory file", [], Xapi_inventory.read_inventory;
     "Config (from file) for outgoing stunnels", [], set_stunnel_legacy_inv;
     "Setting stunnel timeout", [], set_stunnel_timeout;

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -818,7 +818,6 @@ let server_init() =
     Server_helpers.exec_with_new_task "server_init" (fun __context ->
     Startup.run ~__context [
     "XAPI SERVER STARTING", [], print_server_starting_message;
-    "Killing stray sparse_dd processes", [], Sparse_dd_wrapper.killall;
     "Parsing inventory file", [], Xapi_inventory.read_inventory;
     "Config (from file) for outgoing stunnels", [], set_stunnel_legacy_inv;
     "Setting stunnel timeout", [], set_stunnel_timeout;
@@ -835,6 +834,7 @@ let server_init() =
 	"Starting SM internal event service", [], Storage_task.Updates.Scheduler.start;
 	"Starting SM service", [], Storage_access.start;
 	"Starting SM xapi event service", [], Storage_access.events_from_sm;
+    "Killing stray sparse_dd processes", [], Sparse_dd_wrapper.killall;
     "Registering http handlers", [], (fun () -> List.iter Xapi_http.add_handler common_http_handlers);
     "Registering master-only http handlers", [ Startup.OnlyMaster ], (fun () -> List.iter Xapi_http.add_handler master_only_http_handlers);
     "Listening unix socket", [], (fun () -> listen_unix_socket Xapi_globs.unix_domain_socket);
@@ -987,7 +987,7 @@ let server_init() =
       "wait management interface to come up", [ Startup.NoExnRaising ], wait_management_interface;
       "considering sending a master transition alert", [ Startup.NoExnRaising; Startup.OnlyMaster ], 
           Xapi_pool_transition.consider_sending_alert __context;
-
+      "Cancelling in-progress storage migrations", [], (fun () -> Storage_migrate.killall ~dbg:"xapi init");
       (* Start the external authentification plugin *)
       "Calling extauth_hook_script_before_xapi_initialize", [ Startup.NoExnRaising ],
           (fun () -> call_extauth_hook_script_before_xapi_initialize ~__context);


### PR DESCRIPTION
This was reported as "SCTX-2047: XenMotion fails due to a leaked storage datapath after SXM". The root cause of this issue was: if XAPI is restarted while a SXM is in progress, XAPI would totally forget about the fact that there is an unfinished SXM in progress. In these cases, there would be dangling sparse_dd processes and datapaths leaked around, which will forbid further operations on objects sharing the same resources. This pull req will persists the relevant SXM information and lets XAPI do the cleanup (if necessary) based on that during its startup.