### PR TITLE
CP-13697: record SM `required_cluster_stack`

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -1258,6 +1258,8 @@ let sm_record rpc session_id sm =
 		~get_map:(fun () -> s2i64_to_string (x ()).API.sM_features) ();
     make_field ~name:"configuration" ~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.sM_configuration) ();
     make_field ~name:"driver-filename" ~get:(fun () -> (x ()).API.sM_driver_filename) ();
+    make_field ~name:"required-cluster-stack"
+		~get:(fun () -> String.concat ", " (x ()).API.sM_required_cluster_stack) ();
   ]}
 
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5485,6 +5485,7 @@ let storage_plugin =
        field ~in_oss_since:None ~qualifier:DynamicRO ~in_product_since:rel_clearwater ~ty:(Map(String, Int)) "features" "capabilities of the SM plugin, with capability version numbers" ~default_value:(Some (VMap []));
        field ~in_product_since:rel_miami ~default_value:(Some (VMap [])) ~ty:(Map(String, String)) "other_config" "additional configuration";
        field ~in_product_since:rel_orlando ~qualifier:DynamicRO ~default_value:(Some (VString "")) ~ty:String "driver_filename" "filename of the storage driver";
+       field ~in_product_since:rel_dundee ~qualifier:DynamicRO ~default_value:(Some (VSet [])) ~ty:(Set String) "required_cluster_stack" "The storage plugin requires that one of these cluster stacks is configured and running.";
      ])
     ()
 

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -325,6 +325,7 @@ let parse_sr_get_driver_info driver (xml: Xml.xml) =
     sr_driver_features = features;
     sr_driver_configuration = configuration;
     sr_driver_text_features = text_features;
+    sr_driver_required_cluster_stack = [];
   }
 
 let sr_get_driver_info driver = 

--- a/ocaml/xapi/smint.ml
+++ b/ocaml/xapi/smint.ml
@@ -131,6 +131,7 @@ type sr_driver_info = {
 	sr_driver_features: feature list;
 	sr_driver_text_features: string list;
 	sr_driver_configuration: (string * string) list;
+	sr_driver_required_cluster_stack: string list;
 }
 
 let query_result_of_sr_driver_info x = {
@@ -142,7 +143,8 @@ let query_result_of_sr_driver_info x = {
 	version = x.sr_driver_version;
 	required_api_version = x.sr_driver_required_api_version;
 	features = x.sr_driver_text_features;
-	configuration = x.sr_driver_configuration
+	configuration = x.sr_driver_configuration;
+	required_cluster_stack = x.sr_driver_required_cluster_stack;
 }
 
 type attach_info = {

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -127,7 +127,8 @@ module SMAPIv1 = struct
 			version = "2.0";
 			required_api_version = "2.0";
 			features = [];
-			configuration = []
+			configuration = [];
+			required_cluster_stack = [];
 		}
 
 		let diagnostics context ~dbg =

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -114,7 +114,8 @@ module Mux = struct
 			version = "2.0";
 			required_api_version = "2.0";
 			features = [];
-			configuration = []
+			configuration = [];
+			required_cluster_stack = [];
 		}
 		let diagnostics context ~dbg =
 			forall (fun sr rpc ->

--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -230,7 +230,8 @@ let get_handler (req: Http.Request.t) s _ =
 						version = "2.0";
 						required_api_version = "2.0";
 						features = List.map (fun x -> (path [_services; x])) [ _SM ];
-						configuration = []
+						configuration = [];
+						required_cluster_stack = [];
 					} in
 					respond req (Storage_interface.rpc_of_query_result q) s
 				| _ ->

--- a/ocaml/xapi/xapi_sm.ml
+++ b/ocaml/xapi/xapi_sm.ml
@@ -50,6 +50,7 @@ let create_from_query_result ~__context q =
 			~configuration:q.configuration
 			~other_config:[]
 			~driver_filename:(Sm_exec.cmd_name q.driver)
+			~required_cluster_stack:q.required_cluster_stack
 	end
 
 let update_from_query_result ~__context (self, r) query_result =


### PR DESCRIPTION
The SM plugins can declare that they require a specific cluster stack;
we take note of this information.

This requires: [xapi-project/xcp-idl#87]

Signed-off-by: David Scott <dave.scott@eu.citrix.com>