### PR TITLE
CA-177513: Push RRDs to slaves correctly

### DIFF
--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -193,20 +193,18 @@ let put_rrd_forwarder (req : Http.Request.t) (s : Unix.file_descr) _ =
 				ignore (Xapi_services.hand_over_connection req s !(Rrd_interface.forwarded_path))
 		)
 
-let is_vm_on_localhost ~__context ~(vm_uuid : string) : bool =
-  let localhost = Helpers.get_localhost ~__context in
+let host_for_vm ~__context ~vm_uuid =
 	let vm = Db.VM.get_by_uuid ~__context ~uuid:vm_uuid in
-	let vm_host = Db.VM.get_resident_on ~__context ~self:vm in
-	localhost = vm_host
+	Db.VM.get_resident_on ~__context ~self:vm
 
 let push_rrd ~__context ~(vm_uuid : string) : unit =
-	let is_on_localhost = is_vm_on_localhost ~__context ~vm_uuid in
-	let domid = vm_uuid_to_domid ~__context ~uuid:vm_uuid in
-	if is_on_localhost then
+	let vm_host = host_for_vm ~__context ~vm_uuid in
+	if vm_host = (Helpers.get_localhost ~__context) then
+		let domid = vm_uuid_to_domid ~__context ~uuid:vm_uuid in
 		log_and_ignore_exn (fun () -> Rrdd.push_rrd_local ~vm_uuid ~domid )
 	else
-		let master = Pool_role.get_master_address () in
-		log_and_ignore_exn (fun () -> Rrdd.push_rrd_remote ~vm_uuid ~remote_address:master)
+		let remote_address = Db.Host.get_address ~__context ~self:vm_host in
+		log_and_ignore_exn (fun () -> Rrdd.push_rrd_remote ~vm_uuid ~remote_address)
 
 let migrate_rrd ~__context ?remote_address ?session_id ~vm_uuid ~host_uuid () =
 	let remote_address = match remote_address with


### PR DESCRIPTION
Since change eae565f, starting a VM on a slave host has caused
a 'Pool_role.This_host_is_a_master' exception to be raised in
Rrdd_proxy.push_rrd.   The VM will start correctly, but no RRDs will
be available.

The exception is only raised when starting a VM on a slave.  In this case,
Rrdd_proxy.push_rrd incorrectly calls Pool_role.get_master_address, which
raises an exception when run on the master.  Rrdd_proxy.push_rrd is only
ever run on the master, so the exception is always raised when starting
a VM on the slave.

Signed-off-by: Euan Harris <euan.harris@citrix.com>