### PR TITLE
CA-178240: Shrink SR.scan race window

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3381,6 +3381,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 							Client.VDI.update ~rpc ~session_id ~vdi))
 
 		let forget ~__context ~vdi =
+			info "VDI.forget: VDI = '%s'" (vdi_uuid ~__context vdi);
 			with_sr_andor_vdi ~__context ~vdi:(vdi, `forget) ~doc:"VDI.forget"
 				(fun () ->
 					Local.VDI.forget ~__context ~vdi)

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -421,9 +421,9 @@ let scan ~__context ~sr =
 		(fun () ->
 			let sr_uuid = Db.SR.get_uuid ~__context ~self:sr in
 			let vs = C.SR.scan ~dbg:(Ref.string_of task) ~sr:sr_uuid in
-			let sr_info = C.SR.stat ~dbg:(Ref.string_of task) ~sr:sr_uuid in
 			let db_vdis = Db.VDI.get_records_where ~__context ~expr:(Eq(Field "SR", Literal sr')) in
 			update_vdis ~__context ~sr:sr db_vdis vs;
+			let sr_info = C.SR.stat ~dbg:(Ref.string_of task) ~sr:sr_uuid in
 			let virtual_allocation = List.fold_left Int64.add 0L (List.map (fun v -> v.virtual_size) vs) in
 			Db.SR.set_virtual_allocation ~__context ~self:sr ~value:virtual_allocation;
 			Db.SR.set_physical_size ~__context ~self:sr ~value:sr_info.total_space;


### PR DESCRIPTION
The longer the time between calling Storage_access.SR.scan and checking
the database to see what needs updating, the more time there is for
something to change behind the scenes - for instance, the SM GC could
call VDI.forget. Moving the SR.stat call means that this window is much
smaller.