### PR TITLE
CP-12901: add a notion of XenAPI "extensions"

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -66,6 +66,9 @@ if $(not $(defined-env OPTDIR))
 if $(not $(defined-env PLUGINDIR))
   PLUGINDIR=/etc/xapi.d/plugins
   export
+if $(not $(defined-env EXTENSIONDIR))
+  EXTENSIONDIR=/etc/xapi.d/extensions
+  export
 if $(not $(defined-env HOOKSDIR))
   HOOKSDIR=/etc/xapi.d
   export

--- a/configure.ml
+++ b/configure.ml
@@ -19,6 +19,7 @@ let varpatchdir = dir "varpatchdir" "/var/patch" "VARPATCHDIR" "hotfixes"
 let etcdir = dir "etcdir" "/etc/xensource" "ETCDIR" "configuration files"
 let optdir = dir "optdir" "/opt/xensource" "OPTDIR" "system files"
 let plugindir = dir "plugindir" "/etc/xapi.d/plugins" "PLUGINDIR" "xapi plugins"
+let extensiondir = dir "extensiondir" "/etc/xapi.d/extensions" "PLUGINDIR" "XenAPI extensions"
 let hooksdir = dir "hooksdir" "/etc/xapi.d" "HOOKSDIR" "hook scripts"
 let inventory = path "inventory" "/etc/xensource-inventory" "INVENTORY" "the inventory file"
 let xapiconf = dir "xapiconf" "/etc/xapi.conf" "XAPICONF" "xapi master config file"
@@ -41,8 +42,8 @@ let output_file filename lines =
   List.iter (output_string oc) lines;
   close_out oc
 
-let configure disable_warn_error varpatchdir etcdir optdir plugindir hooksdir inventory xapiconf libexecdir scriptsdir sharedir webdir cluster_stack_root bindir sbindir udevdir =
-  Printf.printf "Configuring with the following params:\n\tdisable_warn_error=%b\n\tvarpatchdir=%s\n\tetcdir=%s\n\toptdir=%s\n\tplugindir=%s\n\thooksdir=%s\n\tinventory=%s\n\txapiconf=%s\n\tlibexecdir=%s\n\tscriptsdir=%s\n\tsharedir=%s\n\twebdir=%s\n\tcluster_stack_root=%s\n\tbindir=%s\n\tsbindir=%s\n\tudevdir=%s\n\n" disable_warn_error varpatchdir etcdir optdir plugindir hooksdir inventory xapiconf libexecdir scriptsdir sharedir webdir cluster_stack_root bindir sbindir udevdir;
+let configure disable_warn_error varpatchdir etcdir optdir plugindir extensiondir hooksdir inventory xapiconf libexecdir scriptsdir sharedir webdir cluster_stack_root bindir sbindir udevdir =
+  Printf.printf "Configuring with the following params:\n\tdisable_warn_error=%b\n\tvarpatchdir=%s\n\tetcdir=%s\n\toptdir=%s\n\tplugindir=%s\n\textensiondir=%s\n\thooksdir=%s\n\tinventory=%s\n\txapiconf=%s\n\tlibexecdir=%s\n\tscriptsdir=%s\n\tsharedir=%s\n\twebdir=%s\n\tcluster_stack_root=%s\n\tbindir=%s\n\tsbindir=%s\n\tudevdir=%s\n\n" disable_warn_error varpatchdir etcdir optdir plugindir extensiondir hooksdir inventory xapiconf libexecdir scriptsdir sharedir webdir cluster_stack_root bindir sbindir udevdir;
 
   (* Write config.mk *)
   let lines = 
@@ -53,6 +54,7 @@ let configure disable_warn_error varpatchdir etcdir optdir plugindir hooksdir in
       Printf.sprintf "ETCDIR=%s" etcdir;
       Printf.sprintf "OPTDIR=%s" optdir;
       Printf.sprintf "PLUGINDIR=%s" plugindir;
+      Printf.sprintf "EXTENSIONDIR=%s" extensiondir;
       Printf.sprintf "HOOKSDIR=%s" hooksdir;
       Printf.sprintf "INVENTORY=%s" inventory; 
       Printf.sprintf "XAPICONF=%s" xapiconf;
@@ -67,7 +69,7 @@ let configure disable_warn_error varpatchdir etcdir optdir plugindir hooksdir in
     ] in
   output_file config_mk lines
 
-let configure_t = Term.(pure configure $ disable_warn_error $ varpatchdir $ etcdir $ optdir $ plugindir $ hooksdir $ inventory $ xapiconf $ libexecdir $ scriptsdir $ sharedir $ webdir $ cluster_stack_root $ bindir $ sbindir $ udevdir )
+let configure_t = Term.(pure configure $ disable_warn_error $ varpatchdir $ etcdir $ optdir $ plugindir $ extensiondir $ hooksdir $ inventory $ xapiconf $ libexecdir $ scriptsdir $ sharedir $ webdir $ cluster_stack_root $ bindir $ sbindir $ udevdir )
 
 let () = 
   match 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -305,7 +305,8 @@ let call ~name ?(doc="") ?(in_oss_since=Some "3.0.3") ?in_product_since ?interna
 	?(pool_internal=false)
 	~allowed_roles
 	?(map_keys_roles=[])
-	?(params=[]) ?versioned_params ?lifecycle ?(doc_tags=[]) () =
+	?(params=[]) ?versioned_params ?lifecycle ?(doc_tags=[])
+	?forward_to () =
 	(* if you specify versioned_params then these get put in the params field of the message record;
 	 * otherwise params go in with no default values and param_release=call_release...
 	 *)
@@ -356,6 +357,7 @@ let call ~name ?(doc="") ?(in_oss_since=Some "3.0.3") ?in_product_since ?interna
 		msg_allowed_roles = allowed_roles;
 		msg_map_keys_roles = map_keys_roles;
 		msg_doc_tags = doc_tags;
+		msg_forward_to = forward_to;
 	}
 
 let assert_operation_valid enum cls self = call 
@@ -5599,6 +5601,7 @@ let lvhd_enable_thin_provisioning = call
      Int, "allocation_quantum", "The amount of space to allocate to a VDI when it needs to be enlarged in bytes";
    ]
    ~doc:"Upgrades an LVHD SR to enable thin-provisioning. Future VDIs created in this SR will be thinly-provisioned, although existing VDIs will be left alone. Note that the SR must be attached to the SRmaster for upgrade to work."
+   ~forward_to:(Extension "LVHD.enable_thin_provisioning")
    ()  
 
 let lvhd = 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5605,7 +5605,7 @@ let lvhd_enable_thin_provisioning = call
    ()  
 
 let lvhd = 
-  create_obj ~in_db:false ~in_product_since:rel_dundee ~in_oss_since:None ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_lvhd ~descr:"LVHD SR specific operations"
+  create_obj ~in_db:true ~in_product_since:rel_dundee ~in_oss_since:None ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_lvhd ~descr:"LVHD SR specific operations"
     ~gen_events:true
     ~doccomments:[]
     ~messages_default_allowed_roles:_R_POOL_ADMIN

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -90,6 +90,7 @@ let _host_patch = "host_patch"
 let _hostcpu = "host_cpu"
 let _sr = "SR"
 let _sm = "SM"
+let _lvhd = "LVHD"
 let _vm = "VM"
 let _vm_metrics = "VM_metrics"
 let _vm_guest_metrics = "VM_guest_metrics"
@@ -5587,6 +5588,30 @@ let storage_plugin =
      ])
     ()
 
+let lvhd_enable_thin_provisioning = call
+   ~name:"enable_thin_provisioning"
+   ~in_oss_since:None
+   ~in_product_since:rel_dundee
+   ~allowed_roles:_R_POOL_ADMIN
+   ~params:[
+     Ref _sr, "SR", "The LVHD SR to upgrade to being thin-provisioned.";
+     Int, "initial_allocation", "The initial amount of space to allocate to a newly-created VDI in bytes";
+     Int, "allocation_quantum", "The amount of space to allocate to a VDI when it needs to be enlarged in bytes";
+   ]
+   ~doc:"Upgrades an LVHD SR to enable thin-provisioning. Future VDIs created in this SR will be thinly-provisioned, although existing VDIs will be left alone. Note that the SR must be attached to the SRmaster for upgrade to work."
+   ()  
+
+let lvhd = 
+  create_obj ~in_db:false ~in_product_since:rel_dundee ~in_oss_since:None ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_lvhd ~descr:"LVHD SR specific operations"
+    ~gen_events:true
+    ~doccomments:[]
+    ~messages_default_allowed_roles:_R_POOL_ADMIN
+    ~messages:[ 
+      lvhd_enable_thin_provisioning;
+    ]
+    ~contents: []
+    ()
+
 (* --- rws: removed this after talking to Andy and Julian
 let filesystem =
   { name = _filesystem; description = "An on-disk filesystem";
@@ -8492,6 +8517,7 @@ let all_system =
 		vlan;
 		storage_plugin;
 		storage_repository;
+		lvhd;
 		vdi;
 		vbd;
 		vbd_metrics;

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6667,6 +6667,18 @@ let pool_disable_ssl_legacy = call
 	~allowed_roles:_R_POOL_OP
 	()
 
+let pool_has_extension = call
+	~name:"has_extension"
+	~in_product_since:rel_dundee
+	~doc:"Return true if the extension is available on the pool"
+	~params:[
+		Ref _pool, "self", "The pool";
+		String, "name", "The name of the API call"
+	]
+	~result:(Bool, "True if the extension exists, false otherwise")
+	~allowed_roles:_R_POOL_ADMIN
+	()
+
 (** A pool class *)
 let pool =
 	create_obj
@@ -6735,6 +6747,7 @@ let pool =
 			; pool_apply_edition
 			; pool_enable_ssl_legacy
 			; pool_disable_ssl_legacy
+			; pool_has_extension
 			]
 		~contents:
 			([uid ~in_oss_since:None _pool] @

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5612,7 +5612,9 @@ let lvhd =
     ~messages:[ 
       lvhd_enable_thin_provisioning;
     ]
-    ~contents: []
+    ~contents: [
+      uid _lvhd;
+    ]
     ()
 
 (* --- rws: removed this after talking to Andy and Julian

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -153,6 +153,8 @@ and param = {param_type:ty; param_name:string; param_doc:string; param_release: 
 
 and doc_tag = VM_lifecycle | Snapshots | Networking | Memory | Windows
 
+and forward = Extension of string
+
 (** Types of RPC messages; in addition to those generated for object fields *)
 and message = { 
     msg_name: string;
@@ -177,6 +179,7 @@ and message = {
     msg_allowed_roles: string list option;
     msg_map_keys_roles: (string * (string list option)) list;
     msg_doc_tags: doc_tag list;
+    msg_forward_to: forward option; (* proxy the RPC elsewhere *)
 } 
 
 and field = {

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -212,6 +212,36 @@ and mess = {
     mess_doc: string;
 } with rpc
 
+let default_message = {
+    msg_name = "";
+    msg_params = [];
+    msg_result = None;
+    msg_errors = [];
+    msg_doc = "This message has no documentation.";
+    msg_async = true;
+    msg_session = true;
+    msg_secret = false;
+    msg_pool_internal = true;
+    msg_db_only = false;
+    msg_release = {
+      internal=["Never released"];
+      opensource=[];
+      internal_deprecated_since=None;
+    };
+    msg_lifecycle = [];
+    msg_has_effect = true;
+    msg_force_custom = None;
+    msg_no_current_operations = false;
+    msg_tag = Custom;
+    msg_obj_name = "";
+    msg_custom_marshaller = false;
+    msg_hide_from_docs = true;
+    msg_allowed_roles = None;
+    msg_map_keys_roles = [];
+    msg_doc_tags = [];
+    msg_forward_to = None;
+}
+
 (** Getters and Setters will be generated for each field, depending on the qualifier. 
     Namespaces allow fields to be grouped together (and this can get reflected in the XML
     document structure)

--- a/ocaml/idl/datamodel_utils.ml
+++ b/ocaml/idl/datamodel_utils.ml
@@ -227,6 +227,7 @@ let new_messages_of_field x order fld =
 		 msg_allowed_roles = None;
 		 msg_map_keys_roles = [];
 		 msg_doc_tags = [];
+		 msg_forward_to = None
 	       } in
   let getter = { common with
 		   msg_name = prefix "get_";
@@ -339,6 +340,7 @@ let messages_of_obj (x: obj) document_order : message list =
 		 msg_map_keys_roles = [];
 		 msg_obj_name=x.name;
 		 msg_doc_tags = [];
+		 msg_forward_to = None;
 		 } in
   (* Constructor *)
   let ctor = { common with 

--- a/ocaml/idl/ocaml_backend/OMakefile
+++ b/ocaml/idl/ocaml_backend/OMakefile
@@ -113,7 +113,8 @@ SERVER_OBJS = ../../database/escaping locking_helpers \
 	../../autogen/rbac_static \
 	../../xapi/helper_hostname \
 	../../xapi/helper_process \
-	../../xapi/xmlrpc_sexpr
+	../../xapi/xmlrpc_sexpr \
+	../../xapi/xapi_extensions
 
 XAPI_CLIENT_OBJS = \
 	../../util/version \

--- a/ocaml/idl/ocaml_backend/gen_empty_custom.ml
+++ b/ocaml/idl/ocaml_backend/gen_empty_custom.ml
@@ -50,7 +50,7 @@ let operation_requires_side_effect ({ msg_tag = tag } as msg) =
   | FromField(Setter, fld) -> fld.DT.field_has_effect
   | FromObject(GetRecord | GetByUuid | GetByLabel | GetAll | GetAllRecordsWhere | GetAllRecords) -> false
   | FromObject(_) -> true
-  | Custom -> msg.DT.msg_has_effect
+  | Custom -> msg.DT.msg_has_effect && msg.DT.msg_forward_to = None
   | _ -> false
 
 let make_custom_api api =

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -210,9 +210,9 @@ let operation (obj: obj) (x: message) =
 			in
 
 	let gen_body () = match x.DT.msg_forward_to with
-	| Some Plugin name ->
+	| Some Extension name ->
 		[
-			"Server_helpers.forward_plugin \"call.Rpc.name\" rbac call"
+			"Server_helpers.forward_extension ~__context rbac call"
 		]
 	| None ->
 		let module_prefix = if (Gen_empty_custom.operation_requires_side_effect x) then _custom else _db_defaults in

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -35,10 +35,10 @@ let is_session_arg arg =
   let converter = O.type_of_param arg in
   ((binding = "session_id") && (converter = "ref_session"))
 
-let from_rpc arg =
+let from_rpc ?(ignore=false) arg =
 	let binding = O.string_of_param arg in
 	let converter = O.type_of_param arg in
-	Printf.sprintf "let %s = %s_of_rpc %s_rpc in" binding converter binding
+	Printf.sprintf "let %s%s = %s_of_rpc %s_rpc in" (if ignore then "_" else "") binding converter binding
 
 let read_msg_parameter msg_parameter =
   from_rpc 
@@ -167,12 +167,15 @@ let operation (obj: obj) (x: message) =
   in
   let rbac_check_end = if has_session_arg then [] else [] in
   let unmarshall_code =
+    (* If we are forwarding the call then we don't want to emit a warning
+       because we know we don't need the arguments *)
+    let ignore = x.DT.msg_forward_to <> None in
     (
       (* If we're a constructor then unmarshall all the fields from the constructor record, passed as a struct *)
       if is_ctor then [from_rpc Client.session; from_ctor_record]
 	(* Otherwise, go read non-default fields from pattern match; if we have default fields then we need to
 	   get those from the 'default_fields' arg *)
-      else  List.map from_rpc args_without_default_values)
+      else  List.map (fun a -> from_rpc ~ignore:(ignore && not (is_session_arg a)) a) args_without_default_values)
 
     (* and for every default value we try to get this from default_args or default it *)
     @ (
@@ -206,7 +209,12 @@ let operation (obj: obj) (x: message) =
 				else []
 			in
 
-	let gen_body () =
+	let gen_body () = match x.DT.msg_forward_to with
+	| Some Plugin name ->
+		[
+			"Server_helpers.forward_plugin \"call.Rpc.name\" rbac call"
+		]
+	| None ->
 		let module_prefix = if (Gen_empty_custom.operation_requires_side_effect x) then _custom else _db_defaults in
 		let common_let_decs =
 			[

--- a/ocaml/idl/ocaml_backend/server_helpers.ml
+++ b/ocaml/idl/ocaml_backend/server_helpers.ml
@@ -153,4 +153,5 @@ let exec_with_subtask ~__context ?task_in_database ?task_description task_name f
 	let new_context = Context.make ~subtask_of ?session_id ?task_in_database ?task_description task_name in
 	exec_with_context ~__context:new_context f
 
-let forward_plugin name rbac call = failwith name
+let forward_extension ~__context rbac call =
+  rbac __context (fun () -> Xapi_extensions.call_extension call)

--- a/ocaml/idl/ocaml_backend/server_helpers.ml
+++ b/ocaml/idl/ocaml_backend/server_helpers.ml
@@ -152,3 +152,5 @@ let exec_with_subtask ~__context ?task_in_database ?task_description task_name f
 	let session_id = try Some (Context.get_session_id __context) with _ -> None in
 	let new_context = Context.make ~subtask_of ?session_id ?task_in_database ?task_description task_name in
 	exec_with_context ~__context:new_context f
+
+let forward_plugin name rbac call = failwith name

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -37,7 +37,7 @@ module Actions = struct
 	module VMPP = Xapi_vmpp
 	module VM_appliance = Xapi_vm_appliance
 	module DR_task = Xapi_dr_task
-
+	module LVHD = struct end
 	module Host = Xapi_host
 	module Host_crashdump = Xapi_host_crashdump
 	module Pool = Xapi_pool

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2611,6 +2611,15 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
 			implementation=No_fd Cli_operations.pgpu_disable_dom0_access;
 			flags=[]
 		};
+
+		"lvhd-enable-thin-provisioning",
+		{
+			reqd=["sr-uuid"; "initial-allocation"; "allocation-quantum"];
+			optn=[];
+			help="Enable thin-provisioning on an LVHD SR.";
+			implementation=No_fd Cli_operations.lvhd_enable_thin_provisioning;
+			flags=[];
+		}
   ]
 
 let cmdtable : (string, cmd_spec) Hashtbl.t =

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -4563,3 +4563,10 @@ let pgpu_disable_dom0_access printer rpc session_id params =
 	let ref = Client.PGPU.get_by_uuid rpc session_id uuid in
 	let result = Client.PGPU.disable_dom0_access rpc session_id ref in
 	printer (Cli_printer.PMsg (Record_util.pgpu_dom0_access_to_string result))
+
+let lvhd_enable_thin_provisioning printer rpc session_id params =
+	let uuid = List.assoc "sr-uuid" params in
+	let initial_allocation = Record_util.bytes_of_string "initial-allocation" (List.assoc "initial-allocation" params) in
+	let allocation_quantum = Record_util.bytes_of_string "allocation-quantum" (List.assoc "allocation-quantum" params) in
+	let ref = Client.SR.get_by_uuid rpc session_id uuid in
+	Client.LVHD.enable_thin_provisioning rpc session_id ref initial_allocation allocation_quantum

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3794,5 +3794,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 	end
 
 	module VGPU_type = struct end
+	module LVHD = struct end
 end
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -634,6 +634,11 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 		let disable_ssl_legacy ~__context ~self =
 			info "Pool.disable_ssl_legacy: pool = '%s'" (pool_uuid ~__context self);
 			Local.Pool.disable_ssl_legacy ~__context ~self
+
+		let has_extension ~__context ~self ~name =
+			info "Pool.has_extension: pool = '%s'; name = '%s'" (pool_uuid ~__context self) name;
+			Local.Pool.has_extension ~__context ~self ~name
+
 	end
 
 	module VM = struct

--- a/ocaml/xapi/xapi_extensions.ml
+++ b/ocaml/xapi/xapi_extensions.ml
@@ -1,0 +1,55 @@
+(*
+ * Copyright (C) 2015 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+module D = Debug.Make(struct let name="xapi" end)
+open D
+
+(* The Xapi_globs.xapi_extensions_root contain scripts which are invoked with
+   XenAPI XMLRPC on stdin, and must respond with XenAPI XMLRPC on stdout. *)
+
+(* Only scripts in the Xapi_globs.xapi_extensions_root can be called *)
+let find_extension name =
+	let all = try Array.to_list (Sys.readdir !Xapi_globs.xapi_extensions_root) with _ -> [] in
+	(* Sys.readdir output doesn't include "." or ".." *)
+	if List.mem name all
+	then Filename.concat !Xapi_globs.xapi_extensions_root name
+	else raise (Api_errors.Server_error(Api_errors.message_method_unknown, [name]))
+
+(* Execute the extension with XMLRPC-over-cmdline/stdout convention. *)
+let call_extension rpc =
+	try
+		let path = find_extension rpc.Rpc.name in
+
+		let output, _ =
+			try
+				Forkhelpers.execute_command_get_output_send_stdin path [ "--xmlrpc" ] (Xmlrpc.string_of_call rpc)
+			with
+			| Forkhelpers.Spawn_internal_error(log, output, Unix.WSTOPPED i) ->
+				raise (Api_errors.Server_error (Api_errors.internal_error, [path; "task stopped"; output; log ]))
+			| Forkhelpers.Spawn_internal_error(log, output, Unix.WSIGNALED i) ->
+				raise (Api_errors.Server_error (Api_errors.internal_error, [path; Printf.sprintf "signal: %s" (Unixext.string_of_signal i); output; log ]))
+			| Forkhelpers.Spawn_internal_error(log, output, Unix.WEXITED i) ->
+				raise (Api_errors.Server_error (Api_errors.internal_error, [path; "non-zero exit"; output; log ])) in
+		begin
+			try
+				Xmlrpc.response_of_string output
+			with e ->
+				raise (Api_errors.Server_error(Api_errors.internal_error, [ path; "failed to parse extension output"; output; Printexc.to_string e ]))
+		end;
+	with
+	| Api_errors.Server_error(code, params) ->
+		API.response_of_failure code params
+	| e ->
+		error "Unexpected exception calling extension %s: %s" rpc.Rpc.name (Printexc.to_string e);
+		Debug.log_backtrace e (Backtrace.get e);
+		API.response_of_failure Api_errors.internal_error [ rpc.Rpc.name; Printexc.to_string e ]	

--- a/ocaml/xapi/xapi_extensions.mli
+++ b/ocaml/xapi/xapi_extensions.mli
@@ -1,0 +1,25 @@
+(*
+ * Copyright (C) 2015 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* The Xapi_globs.xapi_extensions_root contain scripts which are invoked with
+   XenAPI XMLRPC on stdin, and must respond with XenAPI XMLRPC on stdout. *)
+
+val find_extension: string -> string
+(** [find_extension] returns the full path to extension [name], or raises
+    the API error [message_method_unknown[ *)
+
+val call_extension: Rpc.call -> Rpc.response
+(** [call_extension call] invokes the named extension, returning the response.
+    Note this function never raises; but may return a XenAPI error like
+    [message_method_unknown] *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -419,6 +419,9 @@ let max_clock_skew = 5. *. 60. (* 5 minutes *)
 (* Optional directory containing XenAPI plugins *)
 let xapi_plugins_root = ref "/etc/xapi.d/plugins"
 
+(* Optional directory containing XenAPI extensions *)
+let xapi_extensions_root = ref "/etc/xapi.d/extensions"
+
 (** CA-18377: Providing lists of operations that were supported by the Miami release. *)
 (** For now, we check against these lists when sending data across the wire that may  *)
 (** be read by a Miami host, and remove any items that are not found on the lists.    *)
@@ -1038,6 +1041,7 @@ module Resources = struct
 		"packs-dir", packs_dir, "Directory containing supplemental pack data";
 		"xapi-hooks-root", xapi_hooks_root, "Root directory for xapi hooks";
 		"xapi-plugins-root", xapi_plugins_root, "Optional directory containing XenAPI plugins";
+		"xapi-extensions-root", xapi_extensions_root, "Optional directory containing XenAPI extensions";
 		"static-vdis-root", static_vdis_dir, "Optional directory for configuring static VDIs";
 	]
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -940,6 +940,13 @@ let call_plugin ~__context ~host ~plugin ~fn ~args =
 	then call_extauth_plugin ~__context ~host ~fn ~args
 	else Xapi_plugins.call_plugin (Context.get_session_id __context) plugin fn args
 
+let has_extension ~__context ~name =
+	try
+		let (_: string) = Xapi_extensions.find_extension name in
+		true
+	with _ ->
+		false
+
 let sync_data ~__context ~host =
   Xapi_sync.sync_host __context host (* Nb, no attempt to wrap exceptions yet *)
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1810,3 +1810,10 @@ let enable_ssl_legacy ~__context ~self =
 		Client.Host.set_ssl_legacy ~rpc ~session_id ~self:host ~value:true
 	in
 	call_fn_on_hosts ~__context f
+
+let has_extension ~__context ~self ~name =
+	try
+		let (_: string) = Xapi_extensions.find_extension name in
+		true
+	with _ ->
+		false

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -201,3 +201,5 @@ val assert_mac_seeds_available : __context:Context.t -> self:API.ref_pool -> see
 
 val disable_ssl_legacy : __context:Context.t -> self:API.ref_pool -> unit
 val enable_ssl_legacy : __context:Context.t -> self:API.ref_pool -> unit
+
+val has_extension : __context:Context.t -> self:API.ref_pool -> name:string -> bool

--- a/scripts/OMakefile
+++ b/scripts/OMakefile
@@ -103,6 +103,7 @@ install:
 	$(IPROG) sysconfig-perfmon $(DESTDIR)/etc/sysconfig/perfmon
 	$(IPROG) perfmon $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)$(EXTENSIONDIR)
+	$(IPROG) extensions/Test.test $(DESTDIR)$(EXTENSIONDIR)
 	mkdir -p $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/perfmon $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/extauth-hook $(DESTDIR)$(PLUGINDIR)

--- a/scripts/OMakefile
+++ b/scripts/OMakefile
@@ -102,6 +102,7 @@ install:
 	mkdir -p $(DESTDIR)/etc/sysconfig
 	$(IPROG) sysconfig-perfmon $(DESTDIR)/etc/sysconfig/perfmon
 	$(IPROG) perfmon $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(EXTENSIONDIR)
 	mkdir -p $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/perfmon $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/extauth-hook $(DESTDIR)$(PLUGINDIR)

--- a/scripts/extensions/Test.test
+++ b/scripts/extensions/Test.test
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import xmlrpclib, sys
+
+def success_message(result):
+    rpcparams = { 'Status': 'Success', 'Value': result }
+    return xmlrpclib.dumps((rpcparams, ), '', True)
+
+def failure_message(code, params):
+    rpcparams = { 'Status': 'Failure', 'ErrorDescription': [ code ] + params }
+    return xmlrpclib.dumps((rpcparams, ), '', True)
+
+if __name__ == "__main__":
+    txt = sys.stdin.read()
+    req = xmlrpclib.loads(txt)
+    print (failure_message("CODE", [ "a", "b" ]))
+    #print (success_message(""))
+
+

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -218,6 +218,7 @@ rm -rf $RPM_BUILD_ROOT
 /etc/xapi.d/plugins/iovirt
 /etc/xapi.d/plugins/install-supp-pack
 /etc/xapi.d/plugins/disk-space
+/etc/xapi.d/extensions
 %config(noreplace) /etc/xensource/db.conf
 %config(noreplace) /etc/xensource/db.conf.rio
 /etc/xensource/master.d/01-example


### PR DESCRIPTION
A XenAPI extension implements a single XenAPI call, outside of xapi. The extension can either be

- *declared*: represented in the data model as a message, with `forward_to` set. This is preferred since it formalises the argument types, result types, documentation strings, acceptable errors, lifecycle and ensures first-class support in the SDK
- *undeclared*: an API which isn't declared in the datamodel can still be invoked, if the implementation is found to be present at runtime.

If an *undeclared* API is created then the definition *must* still be added to the master branch, so that future builds of the SDK will include it. The useful thing is that the very same undeclared API *implementation* can be added to an older dom0 (e.g. in another RPM) and will work. Hopefully for a lot of use-cases this is better than using "plugins" (which lack SDK support and have weaker type checking).

By default extensions are placed in `/etc/xapi.d/extensions` and are executable files named after the API call (e.g. `LVHD.enable_thin_provisioning`). The calling convention is: the program is executed with the argument `--xmlrpc` and the full XenAPI XMLRPC request is sent to stdin. The program should run and print the XenAPI XMLRPC response on stdout. If the process fails (exits non-zero) then this is considered an internal error.

Note this adds a declaration for `LVHD.enable_thin_provisioning` as an example.

This relies on [xapi-project/forkexecd#9]

This needs to be merged at the same time as [xapi-project/xen-api-sdk#52]