### PR TITLE
CP-13525: plumb through SR.probe

### DIFF
--- a/ocaml/xapi/storage_access.mli
+++ b/ocaml/xapi/storage_access.mli
@@ -44,6 +44,9 @@ val make_service: string -> string -> System_domains.service
 (** RPC function for calling the main storage multiplexor *)
 val rpc: Rpc.call -> Rpc.response
 
+(** [external_rpc queue_name uri] for calling a particular storage implementation *)
+val external_rpc: string -> (unit -> string) -> Rpc.call -> Rpc.response
+
 (** [datapath_of_vbd domid userdevice] returns the name of the datapath which corresponds
     to device [userdevice] on domain [domid] *)
 val datapath_of_vbd: domid:int -> device:string -> Storage_interface.dp
@@ -107,9 +110,6 @@ val create_sr: __context:Context.t -> sr:API.ref_SR -> physical_size:int64 -> un
 
 (** [destroy_sr __context sr] attempts to cleanup and destroy a given SR *)
 val destroy_sr: __context:Context.t -> sr:API.ref_SR -> unit
-
-(** [probe __context _type device_config sr_sm_config] executes an SR probe *)
-val probe: __context:Context.t -> _type:string -> device_config:(string * string) list -> sr_sm_config:(string * string) list -> string
 
 val event_wait: Storage_interface.debug_info -> (Storage_interface.Dynamic.id -> bool) -> unit
 

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -690,6 +690,9 @@ module Wrapper = functor(Impl: Server_impl) -> struct
 		let locks : (string, unit) Storage_locks.t = Storage_locks.make ()
 		let with_sr sr f = Storage_locks.with_instance_lock locks sr f
 
+		let probe context ~dbg ~queue ~device_config ~sm_config =
+			Impl.SR.probe context ~dbg ~queue ~device_config ~sm_config
+
 		let list context ~dbg =
 			List.map fst (Host.list !Host.host)
 

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -186,7 +186,7 @@ let probe ~__context ~host ~device_config ~_type ~sm_config =
 		(fun () ->
 			match Client.SR.probe ~dbg ~queue ~device_config ~sm_config with
 			| Raw x -> x
-			| Probe _ -> failwith "unimplemented: probe (only raw)"
+			| Probe _ as x -> Xmlrpc.to_string (rpc_of_probe_result x)
 		)
 
 (* Create actually makes the SR on disk, and introduces it into db, and creates PDB record for current host *)

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -173,7 +173,21 @@ let unplug_and_destroy_pbds ~__context ~self =
 let probe ~__context ~host ~device_config ~_type ~sm_config =
 	debug "SR.probe sm_config=[ %s ]" (String.concat "; " (List.map (fun (k, v) -> k ^ " = " ^ v) sm_config));
 	let _type = String.lowercase _type in
-	Storage_access.probe ~__context ~_type ~device_config ~sr_sm_config:sm_config
+	let open Storage_interface in
+	let open Storage_access in
+
+        let queue = !Storage_interface.queue_name ^ "." ^ _type in
+        let uri () = Storage_interface.uri () ^ ".d/" ^ _type in
+        let rpc = external_rpc queue uri in
+        let module Client = Storage_interface.Client(struct let rpc = rpc end) in
+        let dbg = Context.string_of_task __context in
+
+        transform_storage_exn
+		(fun () ->
+			match Client.SR.probe ~dbg ~queue ~device_config ~sm_config with
+			| Raw x -> x
+			| Probe _ -> failwith "unimplemented: probe (only raw)"
+		)
 
 (* Create actually makes the SR on disk, and introduces it into db, and creates PDB record for current host *)
 let create  ~__context ~host ~device_config ~(physical_size:int64) ~name_label ~name_description


### PR DESCRIPTION
All `SR.probe` calls now go through the SMAPIv2, allowing SMAPIv3 implementations to support probe.

Note we now have 2 probe result formats:

1. old raw arbitrary xml
2. structured XML as defined in `Storage_interface.probe_result`

The new structured XML format allows the CLI to properly understand the pretty-print the results.