### PR TITLE
CP-13830 Pool.enable_ssl_legacy: change master last.

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4326,8 +4326,8 @@ let host_set_power_on_mode = call
 
 let host_set_ssl_legacy = call
 	~name:"set_ssl_legacy"
-	~lifecycle:[Prototyped, rel_dundee, ""]
-	~doc:"Enable/disable SSLv3 for interoperability with older versions of XenServer"
+	~lifecycle:[Published, rel_dundee, ""]
+	~doc:"Enable/disable SSLv3 for interoperability with older versions of XenServer. When this is set to a different value, the host immediately restarts its SSL/TLS listening service; typically this takes less than a second but existing connections to it will be broken. XenAPI login sessions will remain valid."
 	~params:[
 		Ref _host, "self", "The host";
 		Bool, "value", "True to allow SSLv3 and ciphersuites as used in old XenServer versions";
@@ -4615,7 +4615,7 @@ let host =
 		"chipset_info" "Information about chipset features";
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pci)) "PCIs" "List of PCI devices in the host";
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pgpu)) "PGPUs" "List of physical GPUs in the host";
-	field ~qualifier:DynamicRO ~lifecycle:[Prototyped, rel_dundee, ""] ~ty:Bool ~default_value:(Some (VBool true)) "ssl_legacy" "Allow SSLv3 protocol and ciphersuites as used by older XenServers";
+	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_dundee, ""] ~ty:Bool ~default_value:(Some (VBool true)) "ssl_legacy" "Allow SSLv3 protocol and ciphersuites as used by older XenServers. This controls both incoming and outgoing connections. When this is set to a different value, the host immediately restarts its SSL/TLS listening service; typically this takes less than a second but existing connections to it will be broken. XenAPI login sessions will remain valid.";
 	field ~qualifier:RW ~in_product_since:rel_tampa ~default_value:(Some (VMap [])) ~ty:(Map (String, String)) "guest_VCPUs_params" "VCPUs params to apply to all resident guests";
 	field ~qualifier:RW ~in_product_since:rel_cream ~default_value:(Some (VEnum "enabled")) ~ty:host_display "display" "indicates whether the host is configured to output its console to a physical display device";
 	field ~qualifier:DynamicRO ~in_product_since:rel_cream ~default_value:(Some (VSet [VInt 0L])) ~ty:(Set (Int)) "virtual_hardware_platform_versions" "The set of versions of the virtual hardware platform that the host can offer to its guests";
@@ -6651,10 +6651,10 @@ let pool_enable_ssl_legacy = call
 	~name:"enable_ssl_legacy"
 	~in_oss_since:None
 	~lifecycle:[
-		Prototyped, rel_dundee, "Sets ssl_legacy true on each host.";
+		Published, rel_dundee, "";
 	]
 	~params:[Ref _pool, "self", "(ignored)";]
-	~doc:"Sets ssl_legacy true on each host: see Host.ssl_legacy"
+	~doc:"Sets ssl_legacy true on each host, pool-master last. See Host.ssl_legacy and Host.set_ssl_legacy."
 	~allowed_roles:_R_POOL_OP
 	()
 
@@ -6662,10 +6662,10 @@ let pool_disable_ssl_legacy = call
 	~name:"disable_ssl_legacy"
 	~in_oss_since:None
 	~lifecycle:[
-		Prototyped, rel_dundee, "Sets ssl_legacy false on each host.";
+		Published, rel_dundee, "";
 	]
 	~params:[Ref _pool, "self", "(ignored)";]
-	~doc:"Sets ssl_legacy true on each host: see Host.ssl_legacy"
+	~doc:"Sets ssl_legacy true on each host, pool-master last. See Host.ssl_legacy and Host.set_ssl_legacy."
 	~allowed_roles:_R_POOL_OP
 	()
 

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -119,7 +119,9 @@ val ha_schedule_plan_recomputation : __context:'a -> unit
 
 (** {2 (Fill in Title!)} *)
 
-val call_fn_on_hosts :
+(** Call the function on the slaves first. When those calls have all
+ *  returned, call the function on the master. *)
+val call_fn_on_slaves_then_master :
   __context:Context.t ->
   (rpc:(Rpc.call -> Rpc.response) ->
    session_id:API.ref_session -> host:[ `host ] Ref.t -> 'a) ->


### PR DESCRIPTION
Same for Pool.disable_ssl_legacy.

This is so that an API client calling one of these functions can
assume that if its SSL/TLS connection is closed by the server, all
hosts in the pool have been updated.

Also some datamodel changes for the ssl_legacy items:
* Improve (add to) documentation strings.
* Lifecycle change: they are now Published (not Prototyped).
