### PR TITLE
CAR-1935: VBD other-config polling keys with default values

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -187,6 +187,7 @@ let vhd_parent = "vhd-parent" (* set in VDIs backed by VHDs *)
 let owner_key = "owner" (* set in VBD other-config to indicate that clients can delete the attached VDI on VM uninstall if they want.. *)
 let vbd_backend_key = "backend-kind" (* set in VBD other-config *)
 let vbd_polling_duration_key = "polling-duration" (* set in VBD other-config *)
+let vbd_polling_idle_threshold_key = "polling-idle-threshold" (* set in VBD other-config *)
 
 let using_vdi_locking_key = "using-vdi-locking" (* set in Pool other-config to indicate that we should use storage-level (eg VHD) locking *)
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -186,6 +186,7 @@ let vhd_parent = "vhd-parent" (* set in VDIs backed by VHDs *)
 
 let owner_key = "owner" (* set in VBD other-config to indicate that clients can delete the attached VDI on VM uninstall if they want.. *)
 let vbd_backend_key = "backend-kind" (* set in VBD other-config *)
+let vbd_polling_duration_key = "polling-duration" (* set in VBD other-config *)
 
 let using_vdi_locking_key = "using-vdi-locking" (* set in Pool other-config to indicate that we should use storage-level (eg VHD) locking *)
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -740,6 +740,12 @@ let redo_log_max_startup_time = ref 5.
 (** The delay between each attempt to connect to the block device I/O process *)
 let redo_log_connect_delay = ref 0.1
 
+(** The default time, in µs, in which tapdisk3 will keep polling the vbd ring buffer in expectation for extra requests from the guest *)
+let default_vbd3_polling_duration = ref 1000
+
+(** The default % of idle dom0 cpu above which tapdisk3 will keep polling the vbd ring buffer *)
+let default_vbd3_polling_idle_threshold = ref 50
+
 let nowatchdog = ref false
 
 (* Path to the pool configuration file. *)
@@ -864,6 +870,8 @@ let xapi_globs_spec =
 	  "redo_log_max_block_time_writedb", Float redo_log_max_block_time_writedb;
 	  "redo_log_max_startup_time", Float redo_log_max_startup_time;
 	  "redo_log_connect_delay", Float redo_log_connect_delay;
+	  "default-vbd3-polling-duration", Int default_vbd3_polling_duration;
+	  "default-vbd3-polling-idle-threshold", Int default_vbd3_polling_idle_threshold;
 	]
 
 let options_of_xapi_globs_spec = 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -438,6 +438,7 @@ module MD = struct
 		in
 
 		let backend_kind_keys = other_config_keys Xapi_globs.vbd_backend_key in
+		let poll_duration_keys = other_config_keys Xapi_globs.vbd_polling_duration_key in
 
 		{
 			id = (vm.API.vM_uuid, Device_number.to_linux_device device_number);
@@ -449,7 +450,7 @@ module MD = struct
 				| `CD -> CDROM
 				| `Floppy -> Floppy);
 			unpluggable = vbd.API.vBD_unpluggable;
-			extra_backend_keys = backend_kind_keys;
+			extra_backend_keys = backend_kind_keys @ poll_duration_keys;
 			extra_private_keys = [];
 			qos = qos ty;
 			persistent = (try Db.VDI.get_on_boot ~__context ~self:vbd.API.vBD_VDI = `persist with _ -> true);

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -439,6 +439,7 @@ module MD = struct
 
 		let backend_kind_keys = other_config_keys Xapi_globs.vbd_backend_key in
 		let poll_duration_keys = other_config_keys Xapi_globs.vbd_polling_duration_key in
+		let poll_idle_threshold_keys = other_config_keys Xapi_globs.vbd_polling_idle_threshold_key in
 
 		{
 			id = (vm.API.vM_uuid, Device_number.to_linux_device device_number);
@@ -450,7 +451,7 @@ module MD = struct
 				| `CD -> CDROM
 				| `Floppy -> Floppy);
 			unpluggable = vbd.API.vBD_unpluggable;
-			extra_backend_keys = backend_kind_keys @ poll_duration_keys;
+			extra_backend_keys = backend_kind_keys @ poll_duration_keys @ poll_idle_threshold_keys;
 			extra_private_keys = [];
 			qos = qos ty;
 			persistent = (try Db.VDI.get_on_boot ~__context ~self:vbd.API.vBD_VDI = `persist with _ -> true);

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -428,14 +428,16 @@ module MD = struct
 				warn "Unknown VBD QoS type: %s (try 'ionice')" x;
 				None in
 
-		let backend_kind_keys =
+		let other_config_keys key =
 			let oc = vbd.API.vBD_other_config in
-			let k = Xapi_globs.vbd_backend_key in
+			let k = key in
 			try
 				let v = List.assoc k oc in
 				[(k, v)]
 			with Not_found -> []
 		in
+
+		let backend_kind_keys = other_config_keys Xapi_globs.vbd_backend_key in
 
 		{
 			id = (vm.API.vM_uuid, Device_number.to_linux_device device_number);

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -335,3 +335,11 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # process
 # redo_log_connect_delay = 0.1
 
+# The default time, in µs, in which tapdisk3 will keep polling the
+# vbd ring buffer in expectation for extra requests from the guest
+# default-vbd3-polling-duration = 1000
+
+# The default % of idle dom0 cpu above which tapdisk3 will keep polling
+# the vbd ring buffer
+# default-vbd3-polling-idle-threshold = 50
+


### PR DESCRIPTION
The tapdisk3 polling feature will use new xenstored keys as parameters, populated by XAPI from configuration obtained from the following sources, in priority order:

- other-config:polling-idle-threshold and other-config:polling-duration from the corresponding VBD record
- xapi.conf's default-vbd3-polilng-idle-threshold and default-vbd3-polling-duration
- xapi_glob's internal constants default_vbd3_polling_idle_threshold and default_vbd3_polling_duration

There's also range protection that defaults to a sensible default value acceptable to tapdisk3 in case the result from the sources above specify an out-of-range value.
