### PR TITLE
Add dbsync-exception list to the config file

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -238,9 +238,10 @@ let update_env __context sync_keys =
       try
 	List.assoc key sync_keys = Xapi_globs.sync_switch_off
       with _ -> false
-    in 
+    in
+    let disabled_in_config_file = List.mem key !Xapi_globs.disable_dbsync_for in
     begin 
-      if (not skip_sync)
+      if (not skip_sync) && (not disabled_in_config_file)
       then (debug "Sync: %s" key; f ())
       else debug "Skipping sync keyed: %s" key
     end;

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -355,6 +355,10 @@ let sync_chipset_info = "sync_chipset_info"
 let sync_pci_devices = "sync_pci_devices"
 let sync_gpus = "sync_gpus"
 
+(* Allow dbsync actions to be disabled via the redo log, since the database
+   isn't of much use if xapi won't start. *)
+let disable_dbsync_for = ref []
+
 (* create_storage *)
 let sync_create_pbds = "sync_create_pbds"
 
@@ -930,6 +934,10 @@ let other_options = [
   gen_list_option "disable-logging-for"
     "space-separated list of modules to suppress logging from"
     (fun s -> s) (fun s -> s) disable_logging_for;
+
+  gen_list_option "disable-dbsync-for"
+    "space-separated list of database synchronisation actions to skip"
+    (fun s -> s) (fun s -> s) disable_dbsync_for;
 
   "xenopsd-queues", Arg.String (fun x -> xenopsd_queues := String.split ',' x),
     (fun () -> String.concat "," !xenopsd_queues), "list of xenopsd instances to manage";

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -50,6 +50,9 @@ inventory = /etc/xensource-inventory
 # Disable logging for the following modules
 disable-logging-for = http db_write redo_log api_readonly
 
+# Disable part of the initial database sync
+# disable-dbsync-for =
+
 # The full list of xenopsd instances to manage. These must all be running.
 # xenopsd-queues = org.xen.xapi.xenops.xenlight,org.xen.xapi.xenops.classic,org.xen.xapi.xenops.simulator
 xenopsd-queues = org.xen.xapi.xenops.classic


### PR DESCRIPTION
A failing dbsync causes xapi not to start, which makes the system
unmanageable. Before this patch the only way to skip part of the
dbsync wa to add a pool other-config key; however this is not much
good if xapi won't start and the database is offline.

After this patch you can add

  disable-dbsync-for=sync_pgpus sync_foo sync_bar

in /etc/xpai.conf to fix this problem.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>