### PR TITLE
CP-13878: Improve error message when attempting to start VM with invalid configuration of VCPUs

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -196,6 +196,20 @@ let start ~__context ~vm ~start_paused ~force =
 	end;
 
 
+	(* Sanity check for HVM domains with invalid VCPU configuration*)
+	(*
+	if (Helpers.will_boot_hvm ~__context ~self:vm) && (List.mem_assoc "cores-per-socket" vmr.API.vM_platform) then
+	begin
+		try 
+			let cores_per_socket = int_of_string(List.assoc "cores-per-socket" vmr.API.vM_platform) in
+			(* cores per socket has to be in multiples of VCPUs_max and VCPUs_at_startup *)
+			if (((Int64.to_int(vmr.API.vM_VCPUs_max) mod cores_per_socket) <> 0) 
+				|| ((Int64.to_int(vmr.API.vM_VCPUs_at_startup) mod cores_per_socket) <> 0)) then
+				raise (Api_errors.Server_error(Api_errors.invalid_value, 
+					["Invalid configuration of VCPUs: The number of VCPUs must be multiple of number of cores per socket"]))
+		with _ -> raise (Api_errors.Server_error(Api_errors.invalid_value, ["Invalid value for cores-per-socket"]))
+	end;
+	*)		
 	(* Clear out any VM guest metrics record. Guest metrics will be updated by
 	 * the running VM and for now they might be wrong, especially network
 	 * addresses inherited by a cloned VM. *)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -151,7 +151,7 @@ module Platform = struct
 		with Not_found ->
 			default
 
-	let sanity_check ~platformdata ~filter_out_unknowns =
+	let sanity_check ~platformdata ~vcpu_max ~vcpu_at_startup ~hvm ~filter_out_unknowns =
 		(* Filter out unknown flags, if applicable *)
 		let platformdata =
 			if filter_out_unknowns
@@ -164,6 +164,18 @@ module Platform = struct
 				(fun (k, v) -> k <> tsc_mode || List.mem v ["0"; "1"; "2"; "3"])
 				platformdata
 		in
+		(* Sanity check for HVM domains with invalid VCPU configuration*)
+		if hvm && (List.mem_assoc "cores-per-socket" platformdata) then
+		begin
+			try
+				let cores_per_socket = int_of_string(List.assoc "cores-per-socket" platformdata) in
+				(* cores per socket has to be in multiples of VCPUs_max and VCPUs_at_startup *)
+				if (((Int64.to_int(vcpu_max) mod cores_per_socket) <> 0) 
+					|| ((Int64.to_int(vcpu_at_startup) mod cores_per_socket) <> 0)) then
+					raise (Api_errors.Server_error(Api_errors.invalid_value, ["Invalid configuration of VCPUs: The number of VCPUs 
+								must be multiple of number of cores per socket"]))
+			with _ -> raise (Api_errors.Server_error(Api_errors.invalid_value, ["Invalid value for cores-per-socket"]))
+		end;
 		(* Add usb emulation flags.
 		   Make sure we don't send usb=false and usb_tablet=true,
 		   as that wouldn't make sense. *)
@@ -714,6 +726,9 @@ module MD = struct
 		let platformdata =
 			Platform.sanity_check
 				~platformdata:vm.API.vM_platform
+				~vcpu_max:vm.API.vM_VCPUs_max
+				~vcpu_at_startup:vm.API.vM_VCPUs_at_startup
+				~hvm:(Helpers.will_boot_hvm ~__context ~self:vmref)
 				~filter_out_unknowns:
 					(not(Pool_features.is_enabled ~__context Features.No_platform_filter))
 		in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -172,8 +172,14 @@ module Platform = struct
 				(* cores per socket has to be in multiples of VCPUs_max and VCPUs_at_startup *)
 				if (((Int64.to_int(vcpu_max) mod cores_per_socket) <> 0) 
 					|| ((Int64.to_int(vcpu_at_startup) mod cores_per_socket) <> 0)) then
-					raise (Api_errors.Server_error(Api_errors.invalid_value, ["platform:cores-per-socket"; "VCPUs_max/VCPUs_at_startup must be a multiple of this field"]))
-			with Failure "int_of_string" -> raise (Api_errors.Server_error(Api_errors.invalid_value, ["platform:cores-per-socket"; Printf.sprintf "%s is not a valid int" (List.assoc "cores-per-socket" platformdata)]))
+					raise (Api_errors.Server_error(Api_errors.invalid_value, 
+						["platform:cores-per-socket"; 
+						"VCPUs_max/VCPUs_at_startup must be a multiple of this field"]))
+			with Failure "int_of_string" -> begin
+				debug "Bingo Boy!!";
+				raise (Api_errors.Server_error(Api_errors.invalid_value, ["platform:cores-per-socket"; 
+					Printf.sprintf "%s is not a valid int" (List.assoc "cores-per-socket" platformdata)]))
+				end
 		end;
 		(* Add usb emulation flags.
 		   Make sure we don't send usb=false and usb_tablet=true,

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -175,7 +175,7 @@ module Platform = struct
 					raise (Api_errors.Server_error(Api_errors.invalid_value, 
 						["platform:cores-per-socket"; 
 						"VCPUs_max/VCPUs_at_startup must be a multiple of this field"]))
-			with Failure "int_of_string" -> begin
+			with Failure msg -> begin
 				debug "Bingo Boy!!";
 				raise (Api_errors.Server_error(Api_errors.invalid_value, ["platform:cores-per-socket"; 
 					Printf.sprintf "%s is not a valid int" (List.assoc "cores-per-socket" platformdata)]))

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -175,11 +175,9 @@ module Platform = struct
 					raise (Api_errors.Server_error(Api_errors.invalid_value, 
 						["platform:cores-per-socket"; 
 						"VCPUs_max/VCPUs_at_startup must be a multiple of this field"]))
-			with Failure msg -> begin
-				debug "Bingo Boy!!";
+			with Failure msg ->
 				raise (Api_errors.Server_error(Api_errors.invalid_value, ["platform:cores-per-socket"; 
 					Printf.sprintf "%s is not a valid int" (List.assoc "cores-per-socket" platformdata)]))
-				end
 		end;
 		(* Add usb emulation flags.
 		   Make sure we don't send usb=false and usb_tablet=true,

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -172,9 +172,8 @@ module Platform = struct
 				(* cores per socket has to be in multiples of VCPUs_max and VCPUs_at_startup *)
 				if (((Int64.to_int(vcpu_max) mod cores_per_socket) <> 0) 
 					|| ((Int64.to_int(vcpu_at_startup) mod cores_per_socket) <> 0)) then
-					raise (Api_errors.Server_error(Api_errors.invalid_value, ["Invalid configuration of VCPUs: The number of VCPUs 
-								must be multiple of number of cores per socket"]))
-			with _ -> raise (Api_errors.Server_error(Api_errors.invalid_value, ["Invalid value for cores-per-socket"]))
+					raise (Api_errors.Server_error(Api_errors.invalid_value, ["platform:cores-per-socket"; "VCPUs_max/VCPUs_at_startup must be a multiple of this field"]))
+			with Failure "int_of_string" -> raise (Api_errors.Server_error(Api_errors.invalid_value, ["platform:cores-per-socket"; Printf.sprintf "%s is not a valid int" (List.assoc "cores-per-socket" platformdata)]))
 		end;
 		(* Add usb emulation flags.
 		   Make sure we don't send usb=false and usb_tablet=true,


### PR DESCRIPTION
Add proper error message while attempting to start a HVM domain with
invalid configuration of VCPUs

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>