### PR TITLE
CA-181227: add 'lvmofcoe' to sm-plugins list in xapi.conf

### DIFF
--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -151,7 +151,7 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # sm-dir =  @OPTDIR@/sm
 
 # Whitelist of SM plugins
-sm-plugins=cifs ext nfs iscsi lvmoiscsi dummy file hba udev iso lvm lvmohba
+sm-plugins=cifs ext nfs iscsi lvmoiscsi dummy file hba udev iso lvm lvmohba lvmofcoe
 
 # Directory containing tools ISO
 # tools-sr-dir = @OPTDIR@/packages/iso


### PR DESCRIPTION
Without this the plugin won't show up in the SM list.