### PR TITLE
CP-13468: Eagerly allocate (fully inflate) suspend VDIs

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -311,6 +311,7 @@ let shared_db_pool_key = "shared_db_sr"
 (* Names of storage parameters *)
 let _sm_vm_hint = "vmhint"
 let _sm_epoch_hint = "epochhint"
+let _sm_initial_allocation = "initial_allocation"
 
 let i18n_key = "i18n-key"
 let i18n_original_value_prefix = "i18n-original-value-"

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2416,7 +2416,7 @@ let suspend ~__context ~self =
 			let sm_config = [
 				Xapi_globs._sm_vm_hint, id;
 				(* Fully inflate the VDI if the SR supports thin provisioning *)
-				Xapi_globs._sm_initial_allocation, "1.0";
+				Xapi_globs._sm_initial_allocation, (Int64.to_string space_needed);
 			] in
 			Helpers.call_api_functions ~__context
 				(fun rpc session_id ->

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2413,7 +2413,11 @@ let suspend ~__context ~self =
 			(* XXX: this needs to be at boot time *)
 			let space_needed = Int64.(add (of_float (to_float vm_t.Vm.memory_static_max *. 1.2 *. 1.05)) 104857600L) in
 			let suspend_SR = Helpers.choose_suspend_sr ~__context ~vm:self in
-			let sm_config = [Xapi_globs._sm_vm_hint, id] in
+			let sm_config = [
+				Xapi_globs._sm_vm_hint, id;
+				(* Fully inflate the VDI if the SR supports thin provisioning *)
+				Xapi_globs._sm_initial_allocation, "1.0";
+			] in
 			Helpers.call_api_functions ~__context
 				(fun rpc session_id ->
 					let vdi =


### PR DESCRIPTION
When doing a VM.suspend we know "exactly" how much space is going to be used by the operation. We should therefore fully inflate the VDI to its virtual size to avoid the dynamic allocation overhead.