### PR TITLE
CA-180767: fix postrotate action

### DIFF
--- a/scripts/v6d-logrotate
+++ b/scripts/v6d-logrotate
@@ -4,6 +4,6 @@
     size 30k
     sharedscripts
     postrotate
-               /usr/bin/killall -HUP syslogd
+               /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }


### PR DESCRIPTION
On CentOS 7 the syslog daemon is not called syslogd. The convention is
to get the PID from syslogd.pid which is populated by whatever daemon
is actually running.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>