### PR TITLE
Revert "CA-180871: Whitelist the rawhba SR"

### DIFF
--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -151,7 +151,7 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # sm-dir =  @OPTDIR@/sm
 
 # Whitelist of SM plugins
-sm-plugins=cifs ext nfs iscsi lvmoiscsi dummy file hba rawhba udev iso lvm lvmohba lvmofcoe
+sm-plugins=cifs ext nfs iscsi lvmoiscsi dummy file hba udev iso lvm lvmohba lvmofcoe
 
 # Directory containing tools ISO
 # tools-sr-dir = @OPTDIR@/packages/iso


### PR DESCRIPTION
If a plugin is whitelisted but doesn't actually exist, xapi assumes it
is a SMAPIv2 plugin and hangs forever trying to query it. This needs
fixing before we can whitelist rawhba.

This reverts commit a6c4b58277e0f7da6c7e464f0613fd9c12e0d01c.