### PR TITLE
CA-182595 VM.hard_shutdown: use subtask for cancelling

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1312,9 +1312,19 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let local_fn = Local.VM.hard_shutdown ~vm in
 			with_vm_operation ~__context ~self:vm ~doc:"VM.hard_shutdown" ~op:`hard_shutdown
 				(fun () ->
-				  List.iter (fun (task,op) ->
-				    if List.mem op [ `clean_shutdown; `clean_reboot; `hard_reboot ] then
-				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
+					(* Before doing the shutdown we might need to cancel existing operations *)
+					List.iter (fun (task,op) ->
+						if List.mem op [ `clean_shutdown; `clean_reboot; `hard_reboot ] then (
+							(* At the end of the cancellation, if the VM is on a slave then the task doing
+							 * the cancellation will be marked complete (successful).  This would be premature
+							 * for the current task since it still has work to do: first possibly some more
+							 * cancellations, then definitely the VM hard_shutdown. Therefore we must spawn
+							 * a new task to do the cancellation. (But no need to go via API call.) *)
+							Server_helpers.exec_with_subtask ~__context
+								("Cancelling VM." ^ (Record_util.vm_operation_to_string op) ^ " for VM.hard_shutdown")
+								(fun ~__context -> try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ())
+						)
+					) (Db.VM.get_current_operations ~__context ~self:vm);
 
 					(* If VM is actually suspended and we ask to hard_shutdown, we need to
 					   forward to any host that can see the VDIs *)
@@ -1351,11 +1361,15 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let local_fn = Local.VM.hard_reboot ~vm in
 			with_vm_operation ~__context ~self:vm ~doc:"VM.hard_reboot" ~op:`hard_reboot
 				(fun () ->
-				  List.iter (fun (task,op) ->
-				    if List.mem op [ `clean_shutdown; `clean_reboot ] then
-				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
-
-
+					(* Before doing the reboot we might need to cancel existing operations *)
+					List.iter (fun (task,op) ->
+						if List.mem op [ `clean_shutdown; `clean_reboot ] then (
+							(* We must do the cancelling in a subtask: see hard_shutdown comment for reason. *)
+							Server_helpers.exec_with_subtask ~__context
+								("Cancelling VM." ^ (Record_util.vm_operation_to_string op) ^ " for VM.hard_reboot")
+								(fun ~__context -> try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ())
+						)
+					) (Db.VM.get_current_operations ~__context ~self:vm);
 					with_vbds_marked ~__context ~vm ~doc:"VM.hard_reboot" ~op:`attach
 						(fun vbds ->
 							with_vifs_marked ~__context ~vm ~doc:"VM.hard_reboot" ~op:`attach

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -60,11 +60,11 @@ let remote_rpc_retry context hostname (task_opt: API.ref_task option) xml =
 	XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
 let call_slave_with_session remote_rpc_fn __context host (task_opt: API.ref_task option) f =
-	let session_id = Xapi_session.login_no_password ~__context ~uname:None ~host ~pool:true ~is_local_superuser:true ~subject:(Ref.null) ~auth_user_sid:"" ~auth_user_name:"" ~rbac_permissions:[] in
 	let hostname = Db.Host.get_address ~__context ~self:host in
+	let session_id = Xapi_session.login_no_password ~__context ~uname:None ~host ~pool:true ~is_local_superuser:true ~subject:(Ref.null) ~auth_user_sid:"" ~auth_user_name:"" ~rbac_permissions:[] in
 	Pervasiveext.finally
 		(fun ()->f session_id (remote_rpc_fn __context hostname task_opt))
-		(fun ()->Server_helpers.exec_with_new_task ~session_id "local logout in message forwarder" (fun __context -> Xapi_session.logout ~__context))
+		(fun () -> Xapi_session.destroy_db_session ~__context ~self:session_id)
 
 let call_slave_with_local_session remote_rpc_fn __context host (task_opt: API.ref_task option) f =
 	let hostname = Db.Host.get_address ~__context ~self:host in


### PR DESCRIPTION
Also same for VM.hard_reboot.

When Message_forwarding.VM.hard_shutdown cancels other tasks such as
clean_shutdown, now it uses a fresh subtask for each cancellation,
instead of doing the cancellation more directly.

This fixes a bug: if a clean_shutdown task was in progress on a VM on
a slave, then VM.hard_shutdown invoked via "xe vm-shutdown --force"
would fail after cancelling the clean_shutdown. This was because when
the call to the slave (to cancel the clean_shutdown) completes, it
marks the task running it as completed successfully. Since this task
was the main task for the hard_shutdown, the waiter in cli_operations
noticed and destroyed the task, logging out the corresponding xapi
session and telling xe that the command had succeeded. Therefore when
Message_forwarding.VM.hard_shutdown went on to its next step and
tried to tell the slave to shut down the VM, it was using an expired
xapi session so it failed.

Therefore using a new subtask for the cancellation fixes the bug.

The same problem was not observed for "xe vm-reboot --force" because
in Cli_operations.vm_reboot makes a straightforward synchronous call,
whereas vm_shutdown makes an async call and passes the task to the
waiter function.  Nonetheless, the task was still being marked
prematurely as completed, so this commit makes the same change in
Message_forwarding.VM.hard_reboot as in the corresponding shutdown.


Also in this pull-request:
Make call_slave_with_session simpler and safer

Message_forwarding.call_slave_with_session

Overall the effect is the same, but we save creating and destroying a
task, the code is easier to understand, and as soon as the new session
exists, everything else is done with "finally destroy the session".
