### PR TITLE
CA-182869: Revert "CAR-1744: Escape the value strings passed between xe command and CLI server"

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2799,11 +2799,10 @@ let rec parse_params_2 xs =
 		  q::qs -> (convert_switch p,q)::parse_params_2 qs
 		| _ -> failwith (Printf.sprintf "Switch %s requires a parameter\n" p)
 	    else
-              let param_name, rest = match String.split ~limit:2 '=' p with
-                | h1 :: h2 :: _ -> h1, Scanf.unescaped h2
-                | h1 :: _ -> h1, ""
-                | _ -> assert false in
-              (param_name,rest)::parse_params_2 ps
+	      let list = String.split '=' p in
+	      let param_name=List.hd list in
+	      let rest = String.concat "=" (List.tl list) in
+	      (param_name,rest)::parse_params_2 ps
 	  end
     | [] -> []
 

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -187,7 +187,6 @@ let parse_args =
     | arg :: args ->
         match parse_eql arg with
         | Some(k, v) when set_keyword(k,v) -> process_args args
-        | Some(k, v) -> (k ^ "=" ^ String.escaped v) :: process_args args
         | _ -> arg :: process_args args in
 
   fun args ->


### PR DESCRIPTION
This reverts commit ed6840d8ac3e89d5e4a62fb09b2bcc9cb78e6909.

This patch was unescaping escaped values on the CLI, causing problems
with the XenRT RBAC tests.