### PR TITLE
CA-180653: Plug PBDs on master first during DR_task.create

### DIFF
--- a/ocaml/xapi/xapi_dr_task.ml
+++ b/ocaml/xapi/xapi_dr_task.ml
@@ -82,11 +82,13 @@ let try_create_sr_from_record ~__context ~_type ~device_config ~dr_task ~sr_reco
 				Xapi_dr.wait_until_sr_is_ready ~__context ~sr;
 				Db.SR.set_introduced_by ~__context ~self:sr ~value:dr_task
 			with e ->
+				Backtrace.is_important e;
 				(* Clean up if anything goes wrong. *)
 				warn "Could not successfully attach SR %s - caught %s" sr_record.uuid (Printexc.to_string e);
 				let pbds = Db.SR.get_PBDs ~__context ~self:sr in
 				List.iter (fun pbd -> Client.PBD.unplug ~rpc ~session_id ~self:pbd) pbds;
-				Client.SR.forget ~rpc ~session_id ~sr)
+				Client.SR.forget ~rpc ~session_id ~sr;
+				raise e)
 
 let create ~__context ~_type ~device_config ~whitelist =
 	(* Check if licence allows disaster recovery. *)

--- a/ocaml/xapi/xapi_dr_task.ml
+++ b/ocaml/xapi/xapi_dr_task.ml
@@ -88,8 +88,6 @@ let try_create_sr_from_record ~__context ~_type ~device_config ~dr_task ~sr_reco
 				List.iter (fun pbd -> Client.PBD.unplug ~rpc ~session_id ~self:pbd) pbds;
 				Client.SR.forget ~rpc ~session_id ~sr)
 
-(* Add SR records to the database. *)
-(* The SR records will have their introduced_by field set to the DR_task. *)
 let create ~__context ~_type ~device_config ~whitelist =
 	(* Check if licence allows disaster recovery. *)
 	if (not (Pool_features.is_enabled ~__context Features.DR)) then

--- a/ocaml/xapi/xapi_dr_task.mli
+++ b/ocaml/xapi/xapi_dr_task.mli
@@ -1,0 +1,31 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** * Introduce SR records into the database based on a probe result.
+    * Create a PBD for each SR for each host.
+    * Plug all the PBDs.
+    * Set the SR's introduced_by field to the returned DR_task.
+
+    If anything goes wrong, unplug all PBDs which were created, forget the SRs,
+    and re-raise the error. *)
+val create : __context:Context.t ->
+	_type:string ->
+	device_config:(string * string) list ->
+	whitelist:string list ->
+	API.ref_DR_task
+
+(** * Unplug all PBDs for each SR associated with the DR_task.
+    * Forget each SR associated with the DR_task.
+    * Destroy the DR_task. *)
+val destroy : __context:Context.t -> self:API.ref_DR_task -> unit

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -106,26 +106,29 @@ let get_master_slaves_list ~__context =
 let get_slaves_list ~__context =
 	get_master_slaves_list_with_fn ~__context (fun master slaves -> slaves)
 
+let call_fn_on_hosts ~__context hosts f =
+	Helpers.call_api_functions ~__context (fun rpc session_id ->
+		let errs = List.fold_left
+			(fun acc host ->
+				try
+					f ~rpc ~session_id ~host;
+					acc
+				with x ->
+					(host,x)::acc) [] hosts
+		in
+		if List.length errs > 0 then begin
+			warn "Exception raised while performing operation on hosts:";
+			List.iter (fun (host,x) -> warn "Host: %s error: %s" (Ref.string_of host) (ExnHelper.string_of_exn x)) errs;
+			raise (snd (List.hd errs))
+		end)
+
 (* Note: fn exposed in .mli *)
 (** Call the function on the slaves first. When those calls have all
  *  returned, call the function on the master. *)
 let call_fn_on_slaves_then_master ~__context f =
-  (* Get list with master as LAST element: important for ssl_legacy calls *)
-  let hosts = List.rev (get_master_slaves_list ~__context) in
-  Helpers.call_api_functions ~__context (fun rpc session_id -> 
-    let errs = List.fold_left 
-      (fun acc host -> 
-	try
-	  f ~rpc ~session_id ~host;
-	  acc
-	with x -> 
-	  (host,x)::acc) [] hosts
-    in
-    if List.length errs > 0 then begin
-      warn "Exception raised while performing operation on hosts:";
-      List.iter (fun (host,x) -> warn "Host: %s error: %s" (Ref.string_of host) (ExnHelper.string_of_exn x)) errs;
-      raise (snd (List.hd errs))
-    end)
+	(* Get list with master as LAST element: important for ssl_legacy calls *)
+	let hosts = List.rev (get_master_slaves_list ~__context) in
+	call_fn_on_hosts ~__context hosts f
 
 let apply_guest_agent_config ~__context =
 	let f ~rpc ~session_id ~host =

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -122,6 +122,10 @@ let call_fn_on_hosts ~__context hosts f =
 			raise (snd (List.hd errs))
 		end)
 
+let call_fn_on_master_then_slaves ~__context f =
+	let hosts = get_master_slaves_list ~__context in
+	call_fn_on_hosts ~__context hosts f
+
 (* Note: fn exposed in .mli *)
 (** Call the function on the slaves first. When those calls have all
  *  returned, call the function on the master. *)

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -23,6 +23,14 @@ val ha_disable_in_progress : __context:Context.t -> bool
 
 val ha_enable_in_progress : __context:Context.t -> bool
 
+(** Call the function on the master, then on each of the slaves in turn. Useful
+    when attaching an SR to all hosts in the pool. *)
+val call_fn_on_master_then_slaves :
+	__context:Context.t ->
+	(rpc:(Rpc.call -> Rpc.response) ->
+	session_id:API.ref_session -> host:API.ref_host -> 'a) ->
+	unit
+
 (** Call the function on the slaves first. When those calls have all
  *  returned, call the function on the master. *)
 val call_fn_on_slaves_then_master :


### PR DESCRIPTION
Previously the PBDs were plugged in whatever order they were returned by
Db.Host.get_all.

Since commit 5b6d293 PBDs for shared SRs cannot be plugged on slaves
unless they are already plugged on the master.