### PR TITLE
CA-180727: let xensource.log rotate when smaller than 16M

### DIFF
--- a/scripts/xapi-logrotate
+++ b/scripts/xapi-logrotate
@@ -1,6 +1,5 @@
 /var/log/xensource.log {
     missingok
-	size 16M
     sharedscripts
     postrotate
                /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true


### PR DESCRIPTION
Allow logrotate to rotate xensource.log when smaller than 16M.
This will keep size of live logs smaller.

Signed-off-by: Salvatore Cambria <salvatore.cambria@citrix.com>