### PR TITLE
CA-178795: Set the newly created host record as enabled=false

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -581,7 +581,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
   Db.Host.create ~__context ~ref:host
 	~current_operations:[] ~allowed_operations:[]
 	~software_version:(Xapi_globs.software_version ())
-	~enabled:true
+	~enabled:false
 	~aPI_version_major:Xapi_globs.api_version_major
 	~aPI_version_minor:Xapi_globs.api_version_minor
 	~aPI_version_vendor:Xapi_globs.api_version_vendor


### PR DESCRIPTION
Newly created host will be marked as enabled=false till
Xapi is starting on the host.
Once Xapi startup sequence is running, Initialising storage step
will mark host as enabled=true.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>