### PR TITLE
CP-14229: Remove old CPU levelling functions from datamodel and CLI

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4346,6 +4346,7 @@ let host_set_cpu_features = call ~flags:[`Session]
     String, "features", "The features string (32 hexadecimal digits)"
   ]
   ~allowed_roles:_R_POOL_OP
+  ~lifecycle:[Published, rel_midnight_ride, ""; Removed, rel_dundee, "Manual CPU feature setting was removed"]
   ()
   
 let host_reset_cpu_features = call ~flags:[`Session]
@@ -4356,6 +4357,7 @@ let host_reset_cpu_features = call ~flags:[`Session]
     Ref _host, "host", "The host"
   ]
   ~allowed_roles:_R_POOL_OP
+  ~lifecycle:[Published, rel_midnight_ride, ""; Removed, rel_dundee, "Manual CPU feature setting was removed"]
   ()
 
 let host_reset_networking = call

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -814,24 +814,6 @@ let rec cmdtable_data : (string*cmd_spec) list =
       flags=[];
     };
 
-   "host-set-cpu-features",
-    {
-      reqd=["features"];
-      optn=["uuid"];
-      help="Attempts to mask the host's physical-CPU features to match the given features. The given string must be a 32-digit hexadecimal number (optionally containing spaces), as given by host-get-cpu-features.";
-      implementation=No_fd Cli_operations.host_set_cpu_features;
-      flags=[];
-    };
-
-   "host-reset-cpu-features",
-    {
-      reqd=[];
-      optn=["uuid"];
-      help="Removes the feature mask of the host's physical CPU (if any).";
-      implementation=No_fd Cli_operations.host_reset_cpu_features;
-      flags=[];
-    };
-
    "host-enable-display",
     {
       reqd=["uuid"];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -4150,23 +4150,6 @@ let host_get_cpu_features printer rpc session_id params =
 	let features = List.assoc "features" cpu_info in
 	printer (Cli_printer.PMsg features)
 
-let host_set_cpu_features printer rpc session_id params =
-	let host =
-		if List.mem_assoc "uuid" params then
-			Client.Host.get_by_uuid rpc session_id (List.assoc "uuid" params)
-		else
-			get_host_from_session rpc session_id in
-	let features = List.assoc "features" params in
-	Client.Host.set_cpu_features rpc session_id host features
-
-let host_reset_cpu_features printer rpc session_id params =
-	let host =
-		if List.mem_assoc "uuid" params then
-			Client.Host.get_by_uuid rpc session_id (List.assoc "uuid" params)
-		else
-			get_host_from_session rpc session_id in
-	Client.Host.reset_cpu_features rpc session_id host
-
 let host_enable_display printer rpc session_id params =
 	let host = Client.Host.get_by_uuid rpc session_id (List.assoc "uuid" params) in
 	let result = Client.Host.enable_display rpc session_id host in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2446,16 +2446,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let local_fn = Local.Host.refresh_pack_info ~host in
 			do_op_on ~local_fn ~__context ~host (fun session_id rpc -> Client.Host.refresh_pack_info rpc session_id host)
 
-		let set_cpu_features ~__context ~host ~features =
-			info "Host.set_cpu_features: host = '%s'; features = '%s'" (host_uuid ~__context host) features;
-			let local_fn = Local.Host.set_cpu_features ~host ~features in
-			do_op_on ~local_fn ~__context ~host (fun session_id rpc -> Client.Host.set_cpu_features rpc session_id host features)
-
-		let reset_cpu_features ~__context ~host =
-			info "Host.reset_cpu_features: host = '%s'" (host_uuid ~__context host);
-			let local_fn = Local.Host.reset_cpu_features ~host in
-			do_op_on ~local_fn ~__context ~host (fun session_id rpc -> Client.Host.reset_cpu_features rpc session_id host)
-
 		let reset_networking ~__context ~host =
 			info "Host.reset_networking: host = '%s'" (host_uuid ~__context host);
 			Local.Host.reset_networking ~__context ~host

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1326,52 +1326,6 @@ let reset_networking ~__context ~host =
 		Db.PIF.destroy ~__context ~self;
 	) local_pifs
 
-(* CPU feature masking *)
-
-let set_cpu_features ~__context ~host ~features =
-	debug "Set CPU features";
-	(* check restrictions *)
-	if not (Pool_features.is_enabled ~__context Features.CPU_masking) then
-		raise (Api_errors.Server_error (Api_errors.feature_restricted, []));
-
-	let cpuid = Cpuid.read_cpu_info () in
-
-	(* parse features string *)
-	let features =
-		try Cpuid.string_to_features features
-		with Cpuid.InvalidFeatureString e ->
-			raise (Api_errors.Server_error (Api_errors.invalid_feature_string, [e]))
-	in
-
-	(* check masking is possible *)
-	begin try
-		Cpuid.assert_maskability cpuid cpuid.Cpuid.manufacturer features
-	with
-	| Cpuid.MaskingNotSupported e ->
-		raise (Api_errors.Server_error (Api_errors.cpu_feature_masking_not_supported, [e]))
-	| Cpuid.InvalidFeatureString e ->
-		raise (Api_errors.Server_error (Api_errors.invalid_feature_string, [e]))
-	| Cpuid.ManufacturersDiffer -> () (* cannot happen *)
-	end;
-
-	(* add masks to Xen command line *)
-	ignore (Xen_cmdline.delete_cpuid_masks ["cpuid_mask_ecx"; "cpuid_mask_edx"; "cpuid_mask_ext_ecx"; "cpuid_mask_ext_edx"]);
-	let new_masks = Cpuid.xen_masking_string cpuid features in
-	ignore (Xen_cmdline.set_cpuid_masks new_masks);
-
-	(* update database *)
-	let cpu_info = Db.Host.get_cpu_info ~__context ~self:host in
-	let cpu_info = List.replace_assoc "features_after_reboot" (Cpuid.features_to_string features) cpu_info in
-	Db.Host.set_cpu_info ~__context ~self:host ~value:cpu_info
-
-let reset_cpu_features ~__context ~host =
-	debug "Reset CPU features";
-	ignore (Xen_cmdline.delete_cpuid_masks ["cpuid_mask_ecx"; "cpuid_mask_edx"; "cpuid_mask_ext_ecx"; "cpuid_mask_ext_edx"]);
-	let cpu_info = Db.Host.get_cpu_info ~__context ~self:host in
-	let physical_features = List.assoc "physical_features" cpu_info in
-	let cpu_info = List.replace_assoc "features_after_reboot" physical_features cpu_info in
-	Db.Host.set_cpu_info ~__context ~self:host ~value:cpu_info
-
 (* Local storage caching *)
 
 let enable_local_storage_caching ~__context ~host ~sr =

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -257,12 +257,6 @@ val apply_edition_internal : __context:Context.t -> host:API.ref_host ->
 
 (** {2 CPU Feature Masking} *)
  
-(** Set the CPU features to be used after a reboot, if the given features string is valid. *)
-val set_cpu_features : __context:Context.t -> host:API.ref_host -> features:string -> unit
-
-(** Remove the feature mask, such that after a reboot all features of the CPU are enabled. *)
-val reset_cpu_features : __context:Context.t -> host:API.ref_host -> unit
-
 (** Control the local caching behaviour of the host *)
 val enable_local_storage_caching : __context:Context.t -> host:API.ref_host -> sr:API.ref_SR -> unit
 val disable_local_storage_caching : __context:Context.t -> host:API.ref_host -> unit


### PR DESCRIPTION
Signed-off-by: Euan Harris <euan.harris@citrix.com>