### PR TITLE
CP-14151: Extend pif scan to set disallow-unplug=true fcoe bfs interfaces

### DIFF
--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -228,6 +228,7 @@ val introduce_internal :
   vLAN_master_of:[ `VLAN ] Ref.t ->
   ?metrics:[ `PIF_metrics ] Ref.t ->
   managed:bool ->
+  ?disallow_unplug:bool ->
   unit ->
   [ `PIF ] Ref.t
   


### PR DESCRIPTION
FCoE boot from SAN NIC should be made un-pluggable.
This commit extends pif scan routine to set disallow-unplug=true for all
fcoe boot from SAN interfaces.

Signed-off-by: Anoob Soman <anoob.soman@citrix.com>