### PR TITLE
CA-184494: Make static-vdis refer to org.xen.xapi.storage for SMAPIv3

### DIFF
--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -10,7 +10,8 @@ main_dir = "/etc/xensource/static-vdis"
 xapi_storage_script = "/usr/libexec/xapi-storage-script"
 
 def call_volume_plugin(name, command, args):
-    args = [ xapi_storage_script + "/volume/org.xen.xcp.storage." + name + "/" + command, "static-vdis" ] + args
+    args = [(xapi_storage_script + "/volume/org.xen.xapi.storage." + name + "/"
+             + command), "static-vdis"] + args
     output = subprocess.check_output(args)
     return json.loads(output)
 


### PR DESCRIPTION
org.xen.xcp.storage doesn't exist anymore, which causes static-vdis to fail
when working on SMAPIv3 volumes.

Signed-off-by: Robert Breker <robert.breker@citrix.com>