### PR TITLE
CA-115552: Remove race during VM.start in vgpu allocation

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -779,7 +779,10 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				Helpers.set_boot_record ~__context ~self:vm snapshot
 			end;
 			(* Once this is set concurrent VM.start calls will start checking the memory used by this VM *)
-			Db.VM.set_scheduled_to_be_resident_on ~__context ~self:vm ~value:host
+			Db.VM.set_scheduled_to_be_resident_on ~__context ~self:vm ~value:host;
+			(* Creating the VGPU so that concurrent calls can consider this vgpu *)
+			let vmr = Db.VM.get_record ~__context ~self:vm in
+			Vgpuops.create_virtual_gpus ~__context (vm, vmr) (Helpers.will_boot_hvm ~__context ~self:vm) host
 
 		(* For start/start_on/resume/resume_on/migrate *)
 		let finally_clear_host_operation ~__context ~host ?host_op () = match host_op with

--- a/ocaml/xapi/vgpuops.mli
+++ b/ocaml/xapi/vgpuops.mli
@@ -19,7 +19,10 @@
 
 (** Assign a list of PCI devices to a VM for GPU passthrough, store them in
 	other_config:vgpu_pci *)
-val create_vgpus :
+val create_virtual_gpus :
+  __context:Context.t -> (API.ref_VM * API.vM_t) -> bool -> API.ref_host -> unit
+
+val create_passthrough_gpus :
   __context:Context.t -> (API.ref_VM * API.vM_t) -> bool -> unit
 
 (** Check whether a VM has the platform flag that indicates its VGPU is being

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -188,7 +188,7 @@ let set_xenstore_data ~__context ~self ~value =
 
 let start ~__context ~vm ~start_paused ~force =
 	let vmr = Db.VM.get_record ~__context ~self:vm in
-	Vgpuops.create_vgpus ~__context (vm, vmr) (Helpers.will_boot_hvm ~__context ~self:vm);
+	Vgpuops.create_passthrough_gpus ~__context (vm, vmr) (Helpers.will_boot_hvm ~__context ~self:vm);
 	if vmr.API.vM_ha_restart_priority = Constants.ha_restart
 	then begin
 		Db.VM.set_ha_always_run ~__context ~self:vm ~value:true;


### PR DESCRIPTION
The fix removes the race condition during VM.start in vgpu allocation.
The VGPU.set_scheduled_to_be_resident_on was invoked from outside the lock
which results in an incorrect calculation of pGPU capacity in hosts.

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>