### PR TITLE
CA-183547: Allow VDI.introduce if the location is not unique in the SR except the VDI in question

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -362,10 +362,11 @@ let introduce ~__context ~uuid ~name_label ~name_description ~sR ~_type ~sharabl
   let open Storage_interface in
   debug "introduce uuid=%s name_label=%s sm_config=[ %s ]" uuid name_label (String.concat "; " (List.map (fun (k, v) -> k ^ " = " ^ v) sm_config));  
   Sm.assert_pbd_is_plugged ~__context ~sr:sR;
-  (* Verify that the location field is unique in this SR *)
+  (* Verify that the location field is unique in this SR - ignore if the vdi is being introduced with same location*)
   List.iter
     (fun vdi ->
        if Db.VDI.get_location ~__context ~self:vdi = location
+            && Db.VDI.get_uuid ~__context ~self:vdi <> uuid
        then raise (Api_errors.Server_error (Api_errors.location_not_unique, [ Ref.string_of sR; location ]))
     ) (Db.SR.get_VDIs ~__context ~self:sR);
   let task = Context.get_task_id __context in	


### PR DESCRIPTION
VDI.introduce should not be accepted by toolstack if the location is
not unique in the SR. However, if a VDI is being introduced with the
location being same as that before, then it should be allowed.
This is required in the case, where VDI.introduce is used to set the
VDI.managed = true, for e.g., in iSCSI SR

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>