### PR TITLE
CA-181059: Consider enabling host after xapi startup is in last stage.

### DIFF
--- a/ocaml/xapi/create_storage.ml
+++ b/ocaml/xapi/create_storage.ml
@@ -104,8 +104,7 @@ let create_storage (me: API.ref_host) rpc session_id __context : unit =
   if not(all_pbds_ok) then begin
     let obj_uuid = Helpers.get_localhost_uuid () in
     Xapi_alert.add ~msg:Api_messages.pbd_plug_failed_on_server_start ~cls:`Host ~obj_uuid ~body:"";
-  end;
-  Xapi_host_helpers.consider_enabling_host ~__context
+  end
       
 
 let create_storage_localhost rpc session_id : unit =

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -963,6 +963,7 @@ let server_init() =
 			"Starting SR physical utilisation scanning", [Startup.OnThread], (Xapi_sr.physical_utilisation_thread ~__context);
 			"Caching metadata VDIs created by foreign pools.", [ Startup.OnlyMaster; ], cache_metadata_vdis;
 			"Stats reporting thread", [], Xapi_stats.start;
+			"Consider enabling host", [], (fun () -> Xapi_host_helpers.consider_enabling_host ~__context);
     ];
 						    
     if !debug_dummy_data then (


### PR DESCRIPTION
It's early to mark the host as enabled when host joining a pool
has not synchronised bonds, VLANs and tunnels from master.
Moving the enabling host functionality from storage initialising step
to the end of xapi startup sequence.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>