### PR TITLE
CA-185036: Set hostname with hostnamectl.

### DIFF
--- a/scripts/set-hostname
+++ b/scripts/set-hostname
@@ -13,6 +13,6 @@ HOSTNAME=$1
 sed -i -e "s/^\(HOSTNAME=\).*$/\1$1/g" /etc/sysconfig/network
 
 # Set current hostname
-hostname "$HOSTNAME"
+hostnamectl set-hostname "$HOSTNAME"
 
 exit 0


### PR DESCRIPTION
Since CentOS 7 hostnamectl tool is used to configure hostname.

Signed-off-by: Hui Zhang <hui.zhang@citrix.com>