### PR TITLE
CA-145540: Restrict VDI snapshot during VDI copy

### DIFF
--- a/ocaml/test/test_vdi_allowed_operations.ml
+++ b/ocaml/test/test_vdi_allowed_operations.ml
@@ -163,7 +163,7 @@ let test_ca126097 () =
 			Db.VDI.set_current_operations ~__context
 				~self:vdi_ref
 				~value:["mytask", `copy])
-		`snapshot None
+		`snapshot (Some (Api_errors.operation_not_allowed, []))
 
 let test =
 	"test_vdi_allowed_operations" >:::

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -176,6 +176,10 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
 					Some (Api_errors.vdi_is_sharable, [ _ref ])
 				| `snapshot when reset_on_boot ->
 					Some (Api_errors.vdi_on_boot_mode_incompatible_with_operation, [])
+				| `snapshot ->
+				  if List.exists (fun (_, op) -> op = `copy) current_ops
+					then Some (Api_errors.operation_not_allowed, ["Snapshot operation not allowed during copy."])
+				  else None
 				| `copy ->
 					if List.mem record.Db_actions.vDI_type [ `ha_statefile; `redo_log ]
 					then Some (Api_errors.operation_not_allowed, ["VDI containing HA statefile or redo log cannot be copied (check the VDI's allowed operations)."])


### PR DESCRIPTION
This isn't needed on all SR types, but is for some. Longer term plan is to have the SM backends expose a capability saying whether this is necessary or not.