### PR TITLE
Rename ibft-to-ignore script to bfs-interface.

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -831,10 +831,11 @@ let igd_passthru_vendor_whitelist = ref []
 
 let gvt_g_whitelist = ref "/etc/gvt-g-whitelist"
 
-(* The ibft-to-ignore script returns NICs listed in the ISCSI Boot Firmware Table.
- * These NICs (probably just one for now) are used to boot from, and should be marked
- * with PIF.managed = false during a PIF.scan. *)
-let non_managed_pifs = ref "/opt/xensource/libexec/ibft-to-ignore"
+(* The bfs-interfaces script returns boot from SAN NICs.
+ * All ISCSI Boot Firmware Table (ibft) NICs should be marked
+ * with PIF.managed = false and all FCoE boot from SAN * NICs
+ * should be set with disallow-unplug=true, during a PIF.scan. *)
+let non_managed_pifs = ref "/opt/xensource/libexec/bfs-interfaces"
 
 let manage_xenvmd = ref true
 

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -187,7 +187,8 @@ sm-plugins=cifs ext nfs iscsi lvmoiscsi dummy file hba rawhba udev iso lvm lvmoh
 # post-install-scripts-dir = @OPTDIR@/packages/post-install-scripts
 
 # Executed during PIF.scan to find out which NICs should not be managed by xapi
-# non-managed-pifs = @LIBEXECDIR@/ibft-to-ignore
+# and which NICs should be disallowed unplug.
+# non-managed-pifs = @LIBEXECDIR@/bfs-interfaces
 
 # Tweak timeouts: ################################################
 


### PR DESCRIPTION
ibft-to-ignore is now renamed to bfs-interface and it returns space
separated list of IBFT NICs and FCoE boot from SAN NICs.

Signed-off-by: Anoob Soman <anoob.soman@citrix.com>