### PR TITLE
Test_highlevel: Make test families for highlevel tests

### DIFF
--- a/ocaml/test/test_helpers.ml
+++ b/ocaml/test/test_helpers.ml
@@ -125,5 +125,5 @@ let test =
 	"test_helpers" >:::
 		[
 			"test_vm_agility_with_vgpu" >:: test_vm_agility_with_vgpu;
-			"test_determine_gateway" >:: DetermineGateway.test;
+			"test_determine_gateway" >::: DetermineGateway.tests;
 		]

--- a/ocaml/test/test_highlevel.ml
+++ b/ocaml/test/test_highlevel.ml
@@ -88,17 +88,21 @@ module Generic = struct
 	(* Create functions which will actually run a test or tests. *)
 	module Make(T: STATELESS_TEST) = struct
 		let test_equal ~input ~expected_output =
-			let actual_output = T.transform input in
-			assert_equal
-				~msg:(Printf.sprintf
-					"Failure: input = %s, output = %s, expected output = %s"
-					(T.Io.string_of_input_t input)
-					(T.Io.string_of_output_t actual_output)
-					(T.Io.string_of_output_t expected_output))
-				actual_output expected_output
+			let title = Printf.sprintf "%s -> %s" 
+				(T.Io.string_of_input_t input)
+				(T.Io.string_of_output_t expected_output) in
+			title >:: (fun () -> 
+				let actual_output = T.transform input in
+				assert_equal
+					~msg:(Printf.sprintf
+						"Failure: input = %s, output = %s, expected output = %s"
+						(T.Io.string_of_input_t input)
+						(T.Io.string_of_output_t actual_output)
+						(T.Io.string_of_output_t expected_output))
+					actual_output expected_output)
 
-		let test () =
-			List.iter
+		let tests =
+			List.map
 				(fun (input, expected_output) -> test_equal ~input ~expected_output)
 				T.tests
 	end

--- a/ocaml/test/test_http.ml
+++ b/ocaml/test/test_http.ml
@@ -51,5 +51,5 @@ end)
 let test =
 	"test_http" >:::
 		[
-			"test_fix_cookie" >:: FixCookie.test;
+			"test_fix_cookie" >::: FixCookie.tests;
 		]

--- a/ocaml/test/test_map_check.ml
+++ b/ocaml/test/test_map_check.ml
@@ -102,6 +102,6 @@ end)
 let test =
 	"test_map_check" >:::
 		[
-			"test_add_defaults" >:: AddDefaults.test;
-			"test_validate_kvpair" >:: ValidateKVPair.test;
+			"test_add_defaults" >::: AddDefaults.tests;
+			"test_validate_kvpair" >::: ValidateKVPair.tests;
 		]

--- a/ocaml/test/test_pgpu_helpers.ml
+++ b/ocaml/test/test_pgpu_helpers.ml
@@ -93,5 +93,5 @@ end))
 let test =
 	"test_pgpu_helpers" >:::
 		[
-			"test_get_remaining_capacity" >:: GetRemainingCapacity.test;
+			"test_get_remaining_capacity" >::: GetRemainingCapacity.tests;
 		]

--- a/ocaml/test/test_platformdata.ml
+++ b/ocaml/test/test_platformdata.ml
@@ -157,5 +157,5 @@ end)
 let test =
 	"platformdata" >:::
 		[
-			"test_platform_sanity_check" >:: SanityCheck.test
+			"test_platform_sanity_check" >::: SanityCheck.tests
 		]

--- a/ocaml/test/test_pool_license.ml
+++ b/ocaml/test/test_pool_license.ml
@@ -196,8 +196,8 @@ end))
 let test =
 	"pool_license" >:::
 		[
-			"test_compare_dates" >:: CompareDates.test;
-			"test_pool_expiry_date" >:: PoolExpiryDate.test;
-			"test_pool_edition" >:: PoolEdition.test;
-			"test_pool_license_state" >:: PoolLicenseState.test;
+			"test_compare_dates" >::: CompareDates.tests;
+			"test_pool_expiry_date" >::: PoolExpiryDate.tests;
+			"test_pool_edition" >::: PoolEdition.tests;
+			"test_pool_license_state" >::: PoolLicenseState.tests;
 		]

--- a/ocaml/test/test_sm_features.ml
+++ b/ocaml/test/test_sm_features.ml
@@ -232,7 +232,7 @@ end))
 let test =
 	"test_sm_features" >:::
 		[
-			"test_parse_smapiv1_features" >:: ParseSMAPIv1Features.test;
-			"test_create_smapiv2_features" >:: CreateSMAPIv2Features.test;
-			"test_create_sm_object" >:: CreateSMObject.test;
+			"test_parse_smapiv1_features" >::: ParseSMAPIv1Features.tests;
+			"test_create_smapiv2_features" >::: CreateSMAPIv2Features.tests;
+			"test_create_sm_object" >::: CreateSMObject.tests;
 		]

--- a/ocaml/test/test_storage_migrate_state.ml
+++ b/ocaml/test/test_storage_migrate_state.ml
@@ -108,6 +108,6 @@ let test =
 	Storage_migrate.State.persist_root := Test_common.working_area;
 	"test_storage_migrate_state" >:::
 		[
-			"test_map_of" >:: MapOf.test;
+			"test_map_of" >::: MapOf.tests;
 			"test_clear" >:: test_clear;
 		]

--- a/ocaml/test/test_vgpu_type.ml
+++ b/ocaml/test/test_vgpu_type.ml
@@ -314,10 +314,10 @@ let test_vendor_model_lookup () =
 let test =
 	"test_vgpu_type" >:::
 		[
-			"test_of_conf_file" >:: NvidiaTest.OfConfFile.test;
+			"test_of_conf_file" >::: NvidiaTest.OfConfFile.tests;
 			"print_nv_types" >:: NvidiaTest.print_nv_types;
-			"read_whitelist_line" >:: IntelTest.ReadWhitelistLine.test;
-			"read_whitelist" >:: IntelTest.ReadWhitelist.test;
+			"read_whitelist_line" >::: IntelTest.ReadWhitelistLine.tests;
+			"read_whitelist" >::: IntelTest.ReadWhitelist.tests;
 			"test_find_or_create" >:: test_find_or_create;
 			"test_identifier_lookup" >:: test_identifier_lookup;
 			"test_vendor_model_lookup" >:: test_vendor_model_lookup;

--- a/ocaml/test/test_xenopsd_metadata.ml
+++ b/ocaml/test/test_xenopsd_metadata.ml
@@ -230,7 +230,7 @@ end))
 let test =
 	"test_xenopsd_metadata" >:::
 		[
-			"test_hvm_serial" >:: HVMSerial.test;
-			"test_videomode" >:: VideoMode.test;
-			"test_videoram" >:: VideoRam.test;
+			"test_hvm_serial" >::: HVMSerial.tests;
+			"test_videomode" >::: VideoMode.tests;
+			"test_videoram" >::: VideoRam.tests;
 		]


### PR DESCRIPTION
With this change, OUnit reports each testcase, rather than
only reporting groups of tests created by Test_highlevel
modules.

Signed-off-by: Euan Harris <euan.harris@citrix.com>