### PR TITLE
Support SXM from pre-levelling-v2 hosts

### DIFF
--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -46,6 +46,12 @@ let zero_extend arr len =
 	let zero_arr = Array.make len 0L in 
 	extend arr zero_arr
 
+(** If arr is shorter than len elements, extend with 32-bit ones up to len elements.
+ *  Otherwise, truncate arr to len elements. *)
+let one_extend arr len =
+	let one_arr = Array.make len 0xffffffffL in (* we only use the lower 32 bits *)
+	extend arr one_arr
+
 (** Calculate the intersection of two feature sets.
  *  Intersection with the empty set is treated as identity, so that intersection
  *  can be folded easily starting with an accumulator of [||].

--- a/ocaml/xapi/cpuid_helpers.mli
+++ b/ocaml/xapi/cpuid_helpers.mli
@@ -36,6 +36,7 @@ val assert_vm_is_compatible :
 
 val extend : int64 array -> int64 array -> int64 array
 val zero_extend : int64 array -> int -> int64 array
+val one_extend : int64 array -> int -> int64 array
 val intersect : int64 array -> int64 array -> int64 array
 val is_subset_or_equal : int64 array -> int64 array -> bool
 val is_subset : int64 array -> int64 array -> bool


### PR DESCRIPTION
To support VMs migrated from hosts that do not support the new CPU levelling
("levelling v2"), the `host.cpu_info:features` key is set to (approximately)
what it would be on such hosts.  To do this, we take the HVM features of the
host, and add in any features that we don't care about for migration, such that
the absence of such features will not cause a migration to be disallowed from
the sender.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>