### PR TITLE
Fix operators which clash with Camlp4 quotation markers

### DIFF
--- a/ocaml/xapi/cli_protocol.ml
+++ b/ocaml/xapi/cli_protocol.ml
@@ -113,13 +113,13 @@ let marshal_list f x =
 type context = string * int (* offset *)
 
 let unmarshal_int32 (s, offset) = 
-  let (<<) a b = Int32.shift_left a b
-  and (||) a b = Int32.logor a b in
+  let (<<<) a b = Int32.shift_left a b
+  and (|||) a b = Int32.logor a b in
   let a = Int32.of_int (int_of_char (s.[offset + 0])) 
   and b = Int32.of_int (int_of_char (s.[offset + 1])) 
   and c = Int32.of_int (int_of_char (s.[offset + 2])) 
   and d = Int32.of_int (int_of_char (s.[offset + 3])) in
-  (a << 0) || (b << 8) || (c << 16) || (d << 24), (s, offset + 4)
+  (a <<< 0) ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24), (s, offset + 4)
 
 let unmarshal_int pos = 
   let x, pos = unmarshal_int32 pos in

--- a/ocaml/xapi/sparse_encoding.ml
+++ b/ocaml/xapi/sparse_encoding.ml
@@ -17,8 +17,8 @@
 
 module Unmarshal = struct
 	let int64 (s, offset) = 
-		let (<<) a b = Int64.shift_left a b
-		and (||) a b = Int64.logor a b in
+		let (<<<) a b = Int64.shift_left a b
+		and (|||) a b = Int64.logor a b in
 		let a = Int64.of_int (int_of_char (s.[offset + 0])) 
 		and b = Int64.of_int (int_of_char (s.[offset + 1])) 
 		and c = Int64.of_int (int_of_char (s.[offset + 2])) 
@@ -27,30 +27,30 @@ module Unmarshal = struct
 		and f = Int64.of_int (int_of_char (s.[offset + 5]))
 		and g = Int64.of_int (int_of_char (s.[offset + 6]))
 		and h = Int64.of_int (int_of_char (s.[offset + 7])) in
-		(a << 0) || (b << 8) || (c << 16) || (d << 24) || (e << 32) || (f << 40) || (g << 48) || (h << 56), 
+		(a <<< 0) ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24) ||| (e <<< 32) ||| (f <<< 40) ||| (g <<< 48) ||| (h <<< 56), 
 		(s, offset + 8)
 	let int32 (s, offset) = 
-		let (<<) a b = Int32.shift_left a b
-		and (||) a b = Int32.logor a b in
+		let (<<<) a b = Int32.shift_left a b
+		and (|||) a b = Int32.logor a b in
 		let a = Int32.of_int (int_of_char (s.[offset + 0])) 
 		and b = Int32.of_int (int_of_char (s.[offset + 1])) 
 		and c = Int32.of_int (int_of_char (s.[offset + 2])) 
 		and d = Int32.of_int (int_of_char (s.[offset + 3])) in
-		(a << 0) || (b << 8) || (c << 16) || (d << 24), (s, offset + 4)
+		(a <<< 0) ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24), (s, offset + 4)
 end
 
 module Marshal = struct
 	let int64 x = 
-		let (>>) a b = Int64.shift_right_logical a b
-		and (&&) a b = Int64.logand a b in
-		let a = (x >> 0) && 0xffL 
-		and b = (x >> 8) && 0xffL
-		and c = (x >> 16) && 0xffL
-		and d = (x >> 24) && 0xffL
-		and e = (x >> 32) && 0xffL
-		and f = (x >> 40) && 0xffL
-		and g = (x >> 48) && 0xffL
-		and h = (x >> 56) && 0xffL in
+		let (>>>) a b = Int64.shift_right_logical a b
+		and (&&&) a b = Int64.logand a b in
+		let a = (x >>> 0) &&& 0xffL 
+		and b = (x >>> 8) &&& 0xffL
+		and c = (x >>> 16) &&& 0xffL
+		and d = (x >>> 24) &&& 0xffL
+		and e = (x >>> 32) &&& 0xffL
+		and f = (x >>> 40) &&& 0xffL
+		and g = (x >>> 48) &&& 0xffL
+		and h = (x >>> 56) &&& 0xffL in
 		let result = String.make 8 '\000' in
 		result.[0] <- char_of_int (Int64.to_int a);
 		result.[1] <- char_of_int (Int64.to_int b);
@@ -62,12 +62,12 @@ module Marshal = struct
 		result.[7] <- char_of_int (Int64.to_int h);
 		result
 	let int32 x = 
-		let (>>) a b = Int32.shift_right_logical a b
-		and (&&) a b = Int32.logand a b in
-		let a = (x >> 0) && 0xffl 
-		and b = (x >> 8) && 0xffl
-		and c = (x >> 16) && 0xffl
-		and d = (x >> 24) && 0xffl in
+		let (>>>) a b = Int32.shift_right_logical a b
+		and (&&&) a b = Int32.logand a b in
+		let a = (x >>> 0) &&& 0xffl 
+		and b = (x >>> 8) &&& 0xffl
+		and c = (x >>> 16) &&& 0xffl
+		and d = (x >>> 24) &&& 0xffl in
 		let result = String.make 4 '\000' in
 		result.[0] <- char_of_int (Int32.to_int a);
 		result.[1] <- char_of_int (Int32.to_int b);


### PR DESCRIPTION
Change the locally defined << and >> operators to <<< and >>>.
For consistency, also change definitions of && and ||.   This avoids
a clash with Camlp4's quotation markers and allows us to use bisect on
these files.

Signed-off-by: Euan Harris <euan.harris@citrix.com>