### PR TITLE
CA-187174: Unplug master PBDs last during DR_task.destroy

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -581,6 +581,9 @@ let get_shared_srs ~__context =
 
 let get_pool ~__context = List.hd (Db.Pool.get_all ~__context)
 
+let get_master ~__context =
+	Db.Pool.get_master ~__context ~self:(get_pool ~__context)
+
 let get_main_ip_address ~__context =
   try Pool_role.get_master_address () with _ -> "127.0.0.1"
 


### PR DESCRIPTION
Since 3378d71 attempting to unplug a master PBD for a shared SR while
slave PBDs are stil plugged raises an error.