### PR TITLE
Improve unit test coverage for cpuinfo_helpers

### DIFF
--- a/ocaml/test/test_cpuid_helpers.ml
+++ b/ocaml/test/test_cpuid_helpers.ml
@@ -186,30 +186,31 @@ module Intersect = Generic.Make (struct
 end)
 
 
-module IsSubsetOrEqual = Generic.Make (struct
+module Comparisons = Generic.Make (struct
 	module Io = struct
 		type input_t = int64 array * int64 array
-		type output_t = bool
+		type output_t = (bool * bool)
 		let string_of_input_t = Test_printers.(pair (array int64) (array int64))
-		let string_of_output_t = Test_printers.bool
+		let string_of_output_t = Test_printers.(pair bool bool)
 	end
 
-	let transform = fun (a, b) -> Cpuid_helpers.is_subset_or_equal a b
+	let transform = fun (a, b) -> 
+		Cpuid_helpers.(is_subset_or_equal a b, is_subset a b)
 
 	let tests = [
 		(* Some of this behaviour is counterintuitive because
                    feature flags are automatically zero-extended when 
                    compared *)
-		([| |], [| |]),            true;
-		([| 1L; 2L; 3L |], [| |]), true;
-		([| |], [| 1L; 2L; 3L |]), false;
+		([| |], [| |]),            (true, false);
+		([| 1L; 2L; 3L |], [| |]), (true, true);
+		([| |], [| 1L; 2L; 3L |]), (false, false);
 
-		([| 7L; 3L |], [| 5L; |]), false;
-		([| 5L; |], [| 7L; 3L |]), false;
+		([| 7L; 3L |], [| 5L; |]), (false, false);
+		([| 5L; |], [| 7L; 3L |]), (false, false);
 
-		([| 1L |],     [| 1L |]),     true;
-		([| 1L |],     [| 1L; 0L |]), false;
-		([| 1L; 0L |], [| 1L |]),     true;
+		([| 1L |],     [| 1L |]),     (true, false);
+		([| 1L |],     [| 1L; 0L |]), (false, false);
+		([| 1L; 0L |], [| 1L |]),     (true, true);
 	]
 end)
 
@@ -402,8 +403,8 @@ let test =
 				ZeroExtend.test;
 			"test_intersect" >:: 
 				Intersect.test;
-			"test_is_subset_or_equal" >:: 
-				IsSubsetOrEqual.test;
+			"test_comparisons" >:: 
+				Comparisons.test;
 			"test_upgrade" >::
 				Upgrade.test;
 			"test_accessors" >::

--- a/ocaml/test/test_cpuid_helpers.ml
+++ b/ocaml/test/test_cpuid_helpers.ml
@@ -186,6 +186,34 @@ module Intersect = Generic.Make (struct
 end)
 
 
+module IsSubsetOrEqual = Generic.Make (struct
+	module Io = struct
+		type input_t = int64 array * int64 array
+		type output_t = bool
+		let string_of_input_t = Test_printers.(pair (array int64) (array int64))
+		let string_of_output_t = Test_printers.bool
+	end
+
+	let transform = fun (a, b) -> Cpuid_helpers.is_subset_or_equal a b
+
+	let tests = [
+		(* Some of this behaviour is counterintuitive because
+                   feature flags are automatically zero-extended when 
+                   compared *)
+		([| |], [| |]),            true;
+		([| 1L; 2L; 3L |], [| |]), true;
+		([| |], [| 1L; 2L; 3L |]), false;
+
+		([| 7L; 3L |], [| 5L; |]), false;
+		([| 5L; |], [| 7L; 3L |]), false;
+
+		([| 1L |],     [| 1L |]),     true;
+		([| 1L |],     [| 1L; 0L |]), false;
+		([| 1L; 0L |], [| 1L |]),     true;
+	]
+end)
+
+
 module Upgrade = Generic.Make (struct
 	module Io = struct
 		type input_t = string * string
@@ -374,6 +402,8 @@ let test =
 				ZeroExtend.test;
 			"test_intersect" >:: 
 				Intersect.test;
+			"test_is_subset_or_equal" >:: 
+				IsSubsetOrEqual.test;
 			"test_upgrade" >::
 				Upgrade.test;
 			"test_accessors" >::

--- a/ocaml/test/test_cpuid_helpers.ml
+++ b/ocaml/test/test_cpuid_helpers.ml
@@ -388,6 +388,96 @@ module ResetCPUFlags = Generic.Make(Generic.EncapsulateState(struct
 	]
 end))
 
+
+module UpdateCPUFlags = Generic.Make(Generic.EncapsulateState(struct
+	module Io = struct
+		type input_t = (string * string * (string * string) list) list
+		type output_t = string list
+
+		let string_of_input_t = 
+			Test_printers.(list 
+				(tuple3 string string (assoc_list string string)))
+		let string_of_output_t = Test_printers.(list string)
+	end
+	module State = XapiDb
+
+	let features_hvm = "feedface-feedface"
+	let features_pv  = "deadbeef-deadbeef"
+
+	let load_input __context cases =
+		let cpu_info = [
+			"cpu_count", "1";
+			"socket_count", "1";
+			"vendor", "Abacus";
+			"features_pv", features_pv;
+			"features_hvm", features_hvm;
+		] and master = Test_common.make_host ~__context () in
+		Db.Host.set_cpu_info ~__context ~self:master ~value:cpu_info;
+		ignore (Test_common.make_pool ~__context ~master ~cpu_info ());
+
+		let vms = List.map
+			(fun (name_label, hVM_boot_policy, last_boot_flags) ->
+				let self = Test_common.make_vm ~__context ~name_label 
+					~hVM_boot_policy () in
+				Db.VM.set_last_boot_CPU_flags ~__context ~self 
+					~value:last_boot_flags;
+				self)
+			cases in
+		List.iter (fun vm -> Cpuid_helpers.update_cpu_flags ~__context ~vm ~host:master) vms
+
+	let extract_output __context vms =
+		let get_flags (label, _, _) =
+			let self = List.hd (Db.VM.get_by_name_label ~__context ~label) in
+			let flags = Db.VM.get_last_boot_CPU_flags ~__context ~self in
+			try List.assoc Xapi_globs.cpu_info_features_key flags 
+			with Not_found -> ""
+		in List.map get_flags vms
+		
+	let tests = [
+		(* HVM *)
+		(["a", "BIOS order", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus";
+		               cpu_info_features_key, "cafecafe-cafecafe"])], 
+		 ["cafecafe-cafecafe"]);
+		(["a", "BIOS order", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus";
+		               cpu_info_features_key, "cafecafe"])], 
+		 ["cafecafe-feedface"]);
+		(["a", "BIOS order", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus";
+		               cpu_info_features_key, "cafecafe-feedface"])], 
+		 ["cafecafe-feedface"]);
+		(["a", "BIOS order", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus";
+		               cpu_info_features_key, ""])], 
+		 ["feedface-feedface"]);
+		(["a", "BIOS order", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus"])], 
+		 ["feedface-feedface"]);
+
+		(* PV *)
+		(["a", "", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus";
+		               cpu_info_features_key, "cafecafe-cafecafe"])], 
+		 ["cafecafe-cafecafe"]);
+		(["a", "", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus";
+		               cpu_info_features_key, "cafecafe"])], 
+		 ["cafecafe-deadbeef"]);
+		(["a", "", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus";
+		               cpu_info_features_key, "cafecafe-deadbeef"])], 
+		 ["cafecafe-deadbeef"]);
+		(["a", "", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus";
+		               cpu_info_features_key, ""])], 
+		 ["deadbeef-deadbeef"]);
+		(["a", "", 
+		  Xapi_globs.([cpu_info_vendor_key, "Abacus"])], 
+		 ["deadbeef-deadbeef"]);
+	]
+end))
+
 let test =
 	"test_cpuid_helpers" >:::
 		[
@@ -415,4 +505,6 @@ let test =
 				Modifiers.test;
 			"test_reset_cpu_flags" >::
 				ResetCPUFlags.test;
+			"test_update_cpu_flags" >::
+				UpdateCPUFlags.test;
 		]

--- a/ocaml/test/test_cpuid_helpers.ml
+++ b/ocaml/test/test_cpuid_helpers.ml
@@ -311,6 +311,54 @@ module Modifiers = Generic.Make (struct
 end)
 
 
+module ResetCPUFlags = Generic.Make(Generic.EncapsulateState(struct
+	module Io = struct
+		type input_t = (string * string) list
+		type output_t = string list
+
+		let string_of_input_t = Test_printers.(list (pair string string))
+		let string_of_output_t = Test_printers.(list string)
+	end
+	module State = XapiDb
+
+	let features_hvm = "feedface-feedface"
+	let features_pv  = "deadbeef-deadbeef"
+
+	let load_input __context vms =
+		let cpu_info = [
+			"cpu_count", "1";
+			"socket_count", "1";
+			"vendor", "Abacus";
+			"features_pv", features_pv;
+			"features_hvm", features_hvm;
+		] and master = Test_common.make_host ~__context () in
+		Db.Host.set_cpu_info ~__context ~self:master ~value:cpu_info;
+		ignore (Test_common.make_pool ~__context ~master ~cpu_info ());
+
+		List.iter
+			(fun (name_label, hVM_boot_policy) ->
+				ignore (Test_common.make_vm ~__context ~name_label 
+					~hVM_boot_policy ()))
+			vms
+
+	let extract_output __context vms =
+		let get_flags (label, _) =
+			let vm = List.hd (Db.VM.get_by_name_label ~__context ~label) in
+			Cpuid_helpers.reset_cpu_flags ~__context ~vm;
+			let flags = Db.VM.get_last_boot_CPU_flags ~__context ~self:vm in
+			try List.assoc Xapi_globs.cpu_info_features_key flags 
+			with Not_found -> ""
+		in List.map get_flags vms
+		
+
+	(* Tuples of ((features_hvm * features_pv) list, (expected last_boot_CPU_flags) *)
+	let tests = [
+		(["a", "BIOS order"], [features_hvm]);
+		(["a", ""], [features_pv]);
+		(["a", "BIOS order"; "b", ""], [features_hvm; features_pv]);
+	]
+end))
+
 let test =
 	"test_cpuid_helpers" >:::
 		[
@@ -334,4 +382,6 @@ let test =
 				Setters.test;
 			"test_modifiers" >::
 				Modifiers.test;
+			"test_reset_cpu_flags" >::
+				ResetCPUFlags.test;
 		]

--- a/ocaml/test/test_printers.ml
+++ b/ocaml/test/test_printers.ml
@@ -26,6 +26,7 @@ let int       : int printer       = Printf.sprintf "%d"
 let string    : string printer    = Printf.sprintf "%S"
 let char      : char printer      = Printf.sprintf "%C"
 let float     : float printer     = Printf.sprintf "%F" 
+let bool      : bool printer      = Printf.sprintf "%B" 
 let exn       : exn printer       = Printexc.to_string
 
 

--- a/ocaml/test/test_printers.ml
+++ b/ocaml/test/test_printers.ml
@@ -19,6 +19,7 @@ type 'a printer = 'a -> string
 
 (** Printers for basic types *)
 
+let unit      : unit printer      = (fun () -> "()")
 let int64     : int64 printer     = Printf.sprintf "%Ld"
 let int32     : int32 printer     = Printf.sprintf "%ld"
 let nativeint : nativeint printer = Printf.sprintf "%nd"
@@ -36,6 +37,11 @@ let option : 'a printer -> 'a option printer = fun pr x ->
 	match x with
 	| None -> "None"
 	| Some s -> pr s |> Printf.sprintf "Some %s"
+
+let either : 'a printer -> 'b printer -> ('a, 'b) Either.t printer = fun pr_a pr_b x ->
+	match x with
+	| Either.Left a ->  pr_a a |> Printf.sprintf "Left %s"
+	| Either.Right b -> pr_b b |> Printf.sprintf "Right %s"
 
 (* Utility function to bracket a string *)
 let bracket l r x = Printf.sprintf "%s%s%s" l x r

--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -115,7 +115,7 @@ let set_flags ~__context self vendor features =
 
 (* Reset last_boot_CPU_flags with the vendor and feature set.
  * On VM.start, the feature set is inherited from the pool level (PV or HVM) *)
-let reset_cpu_flags ~__context ~vm ~host =
+let reset_cpu_flags ~__context ~vm =
 	let pool_vendor, pool_features =
 		let pool = Helpers.get_pool ~__context in
 		let pool_cpu_info = Db.Pool.get_cpu_info ~__context ~self:pool in

--- a/ocaml/xapi/cpuid_helpers.mli
+++ b/ocaml/xapi/cpuid_helpers.mli
@@ -19,7 +19,6 @@ val features_of_string : string -> int64 array
 val reset_cpu_flags :
   __context:Context.t ->
   vm:[ `VM ] API.Ref.t ->
-  host:[ `host ] API.Ref.t ->
   unit
 
 val update_cpu_flags :

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -208,8 +208,7 @@ let start ~__context ~vm ~start_paused ~force =
 	update_vm_virtual_hardware_platform_version ~__context ~vm;
 	
 	(* Reset CPU feature set, which will be passed to xenopsd *)
-	let host = Helpers.get_localhost ~__context in
-	Cpuid_helpers.reset_cpu_flags ~__context ~vm ~host;
+	Cpuid_helpers.reset_cpu_flags ~__context ~vm;
 
 	(* If the VM has any vGPUs, gpumon must remain stopped until the
 	 * VM has started. *)


### PR DESCRIPTION
Almost 100% coverage - missing the invalid CPU features don't care mask and remote host compatibility cases for assert_vm_is_compatible.