### PR TITLE
CA-115552: Move VGPU reservation to the master

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -779,7 +779,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				Helpers.set_boot_record ~__context ~self:vm snapshot
 			end;
 			(* Once this is set concurrent VM.start calls will start checking the memory used by this VM *)
-			Db.VM.set_scheduled_to_be_resident_on ~__context ~self:vm ~value:host
+			Db.VM.set_scheduled_to_be_resident_on ~__context ~self:vm ~value:host;
+			Vgpuops.create_vgpus ~__context host (vm, snapshot)
+				(Helpers.will_boot_hvm ~__context ~self:vm)
 
 		(* For start/start_on/resume/resume_on/migrate *)
 		let finally_clear_host_operation ~__context ~host ?host_op () = match host_op with

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -18,55 +18,12 @@ open Listext
 open Xstringext
 open Threadext
 
-let reservations : (API.ref_PCI, int64) Hashtbl.t = Hashtbl.create 5
 let m = Mutex.create ()
 
 let get_free_functions ~__context pci =
 	let assignments = List.length (Db.PCI.get_attached_VMs ~__context ~self:pci) in
 	let functions = Int64.to_int (Db.PCI.get_functions ~__context ~self:pci) in
 	functions - assignments
-
-let reserve ~__context pci =
-	Mutex.execute m (fun () ->
-		let pci_id = Db.PCI.get_pci_id ~__context ~self:pci in
-		(* Only attempt to make a reservation if the PCI device is actually free *)
-		if get_free_functions ~__context pci <= 0 then begin
-			debug "PCI device %s is already in use by another VM" pci_id;
-			false
-		end else begin
-			(* Get a timestamp in nano seconds *)
-			let timestamp = Oclock.gettime Oclock.monotonic in
-			let reserved =
-				try
-					let timestamp' = Hashtbl.find reservations pci in
-					if Int64.sub timestamp timestamp' > Int64.of_float 3e11 then begin
-						(* The previous reservation has expired, so remove it *)
-						Hashtbl.remove reservations pci;
-						false
-					end else begin
-						debug "PCI device %s was reserved by another VM just %Ldms ago"
-							pci_id (Int64.div (Int64.sub timestamp timestamp') 1000000L);
-						true
-					end
-				with Not_found ->
-					false
-			in
-			if reserved then
-				false
-			else begin
-				debug "Adding a temporary reservation for PCI device %s" pci_id;
-				Hashtbl.add reservations pci timestamp;
-				true
-			end
-		end
-	)
-
-let unreserve ~__context pci =
-	Mutex.execute m (fun () ->
-		let pci_id = Db.PCI.get_pci_id ~__context ~self:pci in
-		debug "Removing any temporary reservations for PCI device %s" pci_id;
-		Hashtbl.remove reservations pci
-	)
 
 let unassign_all_for_vm ~__context vm =
 	(* Db.VM.set_attached_PCIs ~__context ~self:vm ~value:[] *)

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -15,15 +15,6 @@
  * @group Virtual-Machine Management
  *)
 
-(** Check whether a given PCI device is free. If so, make a temporary
- *  reservation, such that no other VM can steal it before the device
- *  has been passed through. A reservation automatically expires after
- *  5 minutes. *)
-val reserve : __context:Context.t -> [ `PCI ] Ref.t -> bool
-
-(** Explicitly release any temporary reservation on a given PCI device. *)
-val unreserve : __context:Context.t -> [ `PCI ] Ref.t -> unit
-
 (** Check if a given PCI device is free. *)
 val get_free_functions : __context:Context.t -> [ `PCI ] Ref.t -> int
 

--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -64,7 +64,8 @@ let create_passthrough_vgpu ~__context ~vm vgpu available_pgpus pcis =
 				Ref.string_of vgpu.gpu_group_ref
 			]))
 		| Some (pgpu, pci) ->
-			Db.VGPU.set_resident_on ~__context ~self:vgpu.vgpu_ref ~value:pgpu;
+			Db.VGPU.set_scheduled_to_be_resident_on ~__context
+				~self:vgpu.vgpu_ref ~value:pgpu;
 			List.filter (fun g -> g <> pgpu) available_pgpus,
 			pci :: pcis
 	)

--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -69,10 +69,9 @@ let create_passthrough_vgpu ~__context ~vm vgpu available_pgpus pcis =
 			pci :: pcis
 	)
 
-let add_pcis_to_vm ~__context vm passthru_vgpus =
+let add_pcis_to_vm ~__context host vm passthru_vgpus =
 	let pcis =
 		if passthru_vgpus <> [] then begin
-			let host = Helpers.get_localhost ~__context in
 			let pgpus = Db.Host.get_PGPUs ~__context ~self:host in
 			let _, pcis =
 				List.fold_left
@@ -104,9 +103,8 @@ let add_pcis_to_vm ~__context vm passthru_vgpus =
 	let value = String.concat "," (List.map Pciops.to_string devs) in
 	Db.VM.add_to_other_config ~__context ~self:vm ~key:Xapi_globs.vgpu_pci ~value
 
-let create_virtual_vgpu ~__context vm vgpu =
+let create_virtual_vgpu ~__context host vm vgpu =
 	debug "Creating virtual VGPUs";
-	let host = Helpers.get_localhost ~__context in
 	let available_pgpus = Db.Host.get_PGPUs ~__context ~self:host in
 	let compatible_pgpus = Db.GPU_group.get_PGPUs ~__context ~self:vgpu.gpu_group_ref in
 	let pgpus = List.intersect compatible_pgpus available_pgpus in
@@ -146,17 +144,17 @@ let create_virtual_vgpu ~__context vm vgpu =
 				~self:vgpu.vgpu_ref ~value:pgpu;
 	)
 
-let add_vgpus_to_vm ~__context vm vgpus =
+let add_vgpus_to_vm ~__context host vm vgpus =
 	(* Only support a maximum of one virtual GPU per VM for now. *)
 	match vgpus with
 	| [] -> ()
-	| vgpu :: _ -> create_virtual_vgpu ~__context vm vgpu
+	| vgpu :: _ -> create_virtual_vgpu ~__context host vm vgpu
 
 let vgpu_manual_setup_of_vm vm_r =
 	List.mem_assoc Xapi_globs.vgpu_manual_setup_key vm_r.API.vM_platform &&
 	(List.assoc Xapi_globs.vgpu_manual_setup_key vm_r.API.vM_platform = "true")
 
-let create_vgpus ~__context (vm, vm_r) hvm =
+let create_vgpus ~__context host (vm, vm_r) hvm =
 	let vgpus = vgpus_of_vm ~__context vm_r in
 	if vgpus <> [] then begin
 		if not hvm then
@@ -169,9 +167,9 @@ let create_vgpus ~__context (vm, vm_r) hvm =
 	in
 	if virtual_vgpus <> [] && not (Pool_features.is_enabled ~__context Features.VGPU) then
 		raise (Api_errors.Server_error (Api_errors.feature_restricted, []));
-	add_pcis_to_vm ~__context vm passthru_vgpus;
+	add_pcis_to_vm ~__context host vm passthru_vgpus;
 	if not (vgpu_manual_setup_of_vm vm_r)
-	then add_vgpus_to_vm ~__context vm virtual_vgpus
+	then add_vgpus_to_vm ~__context host vm virtual_vgpus
 
 let list_pcis_for_passthrough ~__context ~vm =
 	try

--- a/ocaml/xapi/vgpuops.mli
+++ b/ocaml/xapi/vgpuops.mli
@@ -20,7 +20,8 @@
 (** Assign a list of PCI devices to a VM for GPU passthrough, store them in
 	other_config:vgpu_pci *)
 val create_vgpus :
-  __context:Context.t -> (API.ref_VM * API.vM_t) -> bool -> unit
+  __context:Context.t ->
+  (API.ref_host) ->(API.ref_VM * API.vM_t) -> bool -> unit
 
 (** Check whether a VM has the platform flag that indicates its VGPU is being
  *  set up manually. *)

--- a/ocaml/xapi/xapi_vgpu.ml
+++ b/ocaml/xapi/xapi_vgpu.ml
@@ -62,12 +62,7 @@ let destroy ~__context ~self =
 		raise (Api_errors.Server_error (Api_errors.operation_not_allowed, ["vGPU currently attached to a running VM"]));
 	Db.VGPU.destroy ~__context ~self
 
-let resident_mutex = Mutex.create ()
-let atomic_set_resident_on ~__context ~self ~value =
-	Threadext.Mutex.execute resident_mutex
-		(fun () ->
-			Db.VGPU.set_scheduled_to_be_resident_on ~__context ~self ~value:Ref.null;
-			Db.VGPU.set_resident_on ~__context ~self ~value)
+let atomic_set_resident_on ~__context ~self ~value = assert false
 
 let copy ~__context ~vm vgpu =
 	let all = Db.VGPU.get_record ~__context ~self:vgpu in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -188,7 +188,6 @@ let set_xenstore_data ~__context ~self ~value =
 
 let start ~__context ~vm ~start_paused ~force =
 	let vmr = Db.VM.get_record ~__context ~self:vm in
-	Vgpuops.create_vgpus ~__context (vm, vmr) (Helpers.will_boot_hvm ~__context ~self:vm);
 	if vmr.API.vM_ha_restart_priority = Constants.ha_restart
 	then begin
 		Db.VM.set_ha_always_run ~__context ~self:vm ~value:true;

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1711,10 +1711,6 @@ let update_pci ~__context id =
 							else if (not attached_in_db) && state.plugged
 							then Db.PCI.add_attached_VMs ~__context ~self:pci ~value:vm;
 
-							(* Release any temporary reservations of this PCI device, as it is now permanently
-							 * assigned or unassigned. *)
-							Pciops.unreserve ~__context pci;
-
 							match vgpu_opt with
 							| Some vgpu -> begin
 								let scheduled =


### PR DESCRIPTION
Make vGPU -> pGPU allocation consistent with VM -> host allocation, in that all reservations are made on the master, via the `scheduled_to_be_resident_on` field, with the global lock held.

Manual tests run in a pool of two hosts with one K1 board each:

* Bootstorm 16x K160q-equipped VMs
* Bootstorm 8x K1 passthrough VMs

Automated tests run:

* dundeevgpuk1func.seq