### PR TITLE
xapi.spec: Add build-time requirement on xen-ocaml-devel

### DIFF
--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -50,6 +50,7 @@ BuildRequires: ocaml-tar-devel
 BuildRequires: python2-devel
 BuildRequires: ocaml-rrdd-plugin-devel
 BuildRequires: ocaml-pci-devel >= 0.2.0
+BuildRequires: xen-ocaml-devel
 Requires: hwdata
 Requires: ocaml-xcp-inventory
 Requires: redhat-lsb-core


### PR DESCRIPTION
xen-ocaml-devel provides the Xenctrl module, amongst other things.