### PR TITLE
CA-180495: Run update-issue service on management_interface re-configure

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -816,6 +816,10 @@ let gpg_homedir = ref "/opt/xensource/gpg"
 
 let static_vdis_dir = ref "/etc/xensource/static-vdis"
 
+let update_issue_script = ref "update-issue"
+
+let kill_process_script = ref "killall"
+
 let disable_logging_for= ref []
 
 let igd_passthru_vendor_whitelist = ref []
@@ -1044,6 +1048,8 @@ module Resources = struct
 		"xapi-message-script", xapi_message_script, "Executed when messages are generated if email feature is disabled";
 		"non-managed-pifs", non_managed_pifs, "Executed during PIF.scan to find out which NICs should not be managed by xapi";
 		"xenvmd", xenvmd_path, "Xenvmd executable for thin-provisioned block storage";
+		"update-issue", update_issue_script, "Running update-service when configuring the management interface";
+		"killall", kill_process_script, "Executed to kill process";
 	]
 	let essential_files = [
 		"pool_config_file", pool_config_file, "Pool configuration file";

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -195,6 +195,11 @@ let on_dom0_networking_change ~__context =
 			end
 	end;
 	Helpers.update_domain_zero_name ~__context localhost new_hostname;
+	(* Running update-issue service on best effort basis *)
+	try
+		ignore (Forkhelpers.execute_command_get_output !Xapi_globs.update_issue_script []);
+		ignore (Forkhelpers.execute_command_get_output !Xapi_globs.kill_process_script ["-q"; "-HUP"; "mingetty"; "agetty"])
+	with _ -> ();
 	debug "Signalling anyone waiting for the management IP address to change";
 	Mutex.execute management_ip_mutex
 		(fun () -> Condition.broadcast management_ip_cond)

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -168,6 +168,12 @@ sm-plugins=ext nfs iscsi lvmoiscsi dummy file hba rawhba udev iso lvm lvmohba lv
 # Path to the xen-cmdline binary
 # xen-cmdline = @LIBEXECDIR@/xen-cmdline
 
+# Path to the update-issue script
+# update-issue-script = /sbin/update-issue
+
+# Path to the kill-process script
+# kill-process-script = /usr/bin/killall
+
 # Root directory for xapi hooks
 # xapi-hooks-root = @HOOKSDIR@
 


### PR DESCRIPTION
File /etc/issue needs to be updated with latest management ip
on performing management_interface re-configure.
This can be achived by running update-issue service.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>