### PR TITLE
CA-109863: Toolstack will not balloon when VM migrate

### DIFF
--- a/ocaml/xapi/memory_check.ml
+++ b/ocaml/xapi/memory_check.ml
@@ -55,6 +55,7 @@ type accounting_policy =
 	| Dynamic_min
 		(** use dynamic_min: liberal: assumes that guests always co-operate. *)
 	| Actual
+		(** use memory_actual: liberal: use memory actual when VM migrate. *)
 
 (** Common logic of vm_compute_start_memory and vm_compute_used_memory *)
 let choose_memory_required ~policy ~memory_dynamic_min ~memory_dynamic_max ~memory_static_max ~memory_actual =
@@ -64,7 +65,6 @@ let choose_memory_required ~policy ~memory_dynamic_min ~memory_dynamic_max ~memo
 		| Static_max -> memory_static_max
 		| Actual -> memory_actual
 
-
 (** Calculates the amount of memory required in both 'normal' and 'shadow'
 memory, to start a VM. If the given VM is a PV guest and if memory ballooning
 is enabled, this function returns values derived from the VM's dynamic memory
@@ -72,16 +72,19 @@ target (since PV guests are able to start in a pre-ballooned state). If memory
 ballooning is not enabled or if the VM is an HVM guest, this function returns
 values derived from the VM's static memory maximum (since currently HVM guests
 are not able to start in a pre-ballooned state). *)
-let vm_compute_start_memory ~__context ?(policy=Dynamic_min) ?(memory_actual=0L) vm_record =
+let vm_compute_start_memory ~__context ?(policy=Dynamic_min) ?vm_metrics vm_record =
 	if Xapi_fist.disable_memory_checks ()
 	then (0L, 0L)
 	else
+		let memory_actual = match vm_metrics with
+		| Some vmm -> Db.VM_metrics.get_memory_actual ~__context ~self:vmm
+		| None -> vm_record.API.vM_memory_dynamic_min in
 		let memory_required = choose_memory_required
 			~policy: policy
 			~memory_dynamic_min: vm_record.API.vM_memory_dynamic_min
 			~memory_dynamic_max: vm_record.API.vM_memory_dynamic_max
 			~memory_static_max:  vm_record.API.vM_memory_static_max 
-			~memory_actual: memory_actual in
+			~memory_actual in
 		vm_compute_required_memory vm_record
 			(XenopsMemory.kib_of_bytes_used memory_required)
 
@@ -93,6 +96,8 @@ let vm_compute_used_memory ~__context policy vm_ref =
 	if Xapi_fist.disable_memory_checks () then 0L else
 	let vm_main_record = Db.VM.get_record ~__context ~self:vm_ref in
 	let vm_boot_record = Helpers.get_boot_record ~__context ~self:vm_ref in
+	let vm_metrics = Db.VM.get_metrics ~__context ~self:vm_ref in
+	let memory_actual = Db.VM_metrics.get_memory_actual ~__context ~self:vm_metrics in
 
 	let memory_required = choose_memory_required
 		~policy: policy
@@ -100,7 +105,7 @@ let vm_compute_used_memory ~__context policy vm_ref =
 		(* ToDo: Is vm_main_record or vm_boot_record the right thing for dynamic_max? *)
 		~memory_dynamic_max: vm_main_record.API.vM_memory_dynamic_max 
 		~memory_static_max:  vm_boot_record.API.vM_memory_static_max 
-		~memory_actual:0L in
+		~memory_actual in
 	memory_required +++ vm_main_record.API.vM_memory_overhead
 
 let vm_compute_resume_memory ~__context vm_ref =

--- a/ocaml/xapi/memory_check.mli
+++ b/ocaml/xapi/memory_check.mli
@@ -48,6 +48,7 @@ type accounting_policy =
 		(** use dynamic_max: fairly conservative: useful for dom0 for HA. *)
 	| Dynamic_min
 		(** use dynamic_min: liberal: assumes that guests always co-operate. *)
+	| Actual
 
 (** Return a host's memory summary from live database contents. *)
 val get_host_memory_summary : __context:Context.t -> host:API.ref_host ->
@@ -56,7 +57,7 @@ val get_host_memory_summary : __context:Context.t -> host:API.ref_host ->
 val vm_compute_required_memory : API.vM_t -> int64 -> int64 * int64
 
 val vm_compute_start_memory : __context:Context.t ->
-	?policy:accounting_policy -> API.vM_t -> int64 * int64
+	?policy:accounting_policy -> ?memory_actual:int64 -> API.vM_t -> int64 * int64
 
 val vm_compute_used_memory : __context:Context.t -> accounting_policy ->
 	[`VM] Ref.t -> int64

--- a/ocaml/xapi/memory_check.mli
+++ b/ocaml/xapi/memory_check.mli
@@ -49,6 +49,7 @@ type accounting_policy =
 	| Dynamic_min
 		(** use dynamic_min: liberal: assumes that guests always co-operate. *)
 	| Actual
+		(** use memory_actual: liberal: use memory actual when VM migrate. *)
 
 (** Return a host's memory summary from live database contents. *)
 val get_host_memory_summary : __context:Context.t -> host:API.ref_host ->
@@ -57,7 +58,7 @@ val get_host_memory_summary : __context:Context.t -> host:API.ref_host ->
 val vm_compute_required_memory : API.vM_t -> int64 -> int64 * int64
 
 val vm_compute_start_memory : __context:Context.t ->
-	?policy:accounting_policy -> ?memory_actual:int64 -> API.vM_t -> int64 * int64
+	?policy:accounting_policy -> ?vm_metrics:[`VM_metrics] Ref.t -> API.vM_t -> int64 * int64
 
 val vm_compute_used_memory : __context:Context.t -> accounting_policy ->
 	[`VM] Ref.t -> int64

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -838,7 +838,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 		let reserve_memory_for_vm ~__context ~vm ~snapshot ~host ?host_op f =
 			Helpers.with_global_lock
 				(fun () ->
-					Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host:host ~snapshot ?host_op ();
+					Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host:host ~snapshot ?operation:host_op ();
 					(* NB in the case of migrate although we are about to increase free memory on the sending host
 					   we ignore this because if a failure happens while a VM is in-flight it will still be considered
 					   on both hosts, potentially breaking the failover plan. *)
@@ -3408,7 +3408,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 							let host =
 								if host <> Ref.null then host else
 									let choose_fn ~host =
-										Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~snapshot ~host ~host_op:`vm_migrate ();
+										Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~snapshot ~host ~operation:`vm_migrate ();
 										Xapi_vm_helpers.assert_can_see_specified_SRs ~__context ~reqd_srs:[sr] ~host in
 									Xapi_vm_helpers.choose_host ~__context ~vm ~choose_fn () in
 							(snapshot, host) in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -835,10 +835,10 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
 		(* Used by VM.start_on, VM.resume_on, VM.migrate to verify a host has enough resource and to
 		   'allocate_vm_to_host' (ie set the 'scheduled_to_be_resident_on' field) *)
-		let reserve_memory_for_vm ~__context ~vm ~snapshot ~host ?host_op f =
+		let reserve_memory_for_vm ~__context ~vm ~snapshot ~host ?host_op ?(do_migrate_check=false) f =
 			Helpers.with_global_lock
 				(fun () ->
-					Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host:host ~snapshot ();
+					Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host:host ~snapshot ~do_migrate_check ();
 					(* NB in the case of migrate although we are about to increase free memory on the sending host
 					   we ignore this because if a failure happens while a VM is in-flight it will still be considered
 					   on both hosts, potentially breaking the failover plan. *)
@@ -1606,7 +1606,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					   have to be revisited since the destination VM would already be occupying memory
 					   and there won't be any need to account for its memory. *)
 					let dest_vm = Mtc.get_peer_vm_or_self ~__context ~self:vm in
-					reserve_memory_for_vm ~__context ~vm:dest_vm ~host ~snapshot ~host_op:`vm_migrate
+					reserve_memory_for_vm ~__context ~vm:dest_vm ~host ~snapshot ~host_op:`vm_migrate ~do_migrate_check:true
 						(fun () ->
 							forward_vm_op ~local_fn ~__context ~vm
 								(fun session_id rpc -> Client.VM.pool_migrate rpc session_id vm host options)));
@@ -3408,7 +3408,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 							let host =
 								if host <> Ref.null then host else
 									let choose_fn ~host =
-										Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~snapshot ~host ();
+										Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~snapshot ~host ~do_migrate_check:true();
 										Xapi_vm_helpers.assert_can_see_specified_SRs ~__context ~reqd_srs:[sr] ~host in
 									Xapi_vm_helpers.choose_host ~__context ~vm ~choose_fn () in
 							(snapshot, host) in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -57,7 +57,8 @@ let assert_can_boot_here ~__context ~self ~host =
 	let snapshot = Db.VM.get_record ~__context ~self in
 	if Helpers.rolling_upgrade_in_progress ~__context then
 		Helpers.assert_platform_version_is_same_on_master ~__context ~host ~self;
-	assert_can_boot_here ~__context ~self ~host ~snapshot ()
+	let do_migrate_check = if Db.VM.get_power_state ~__context ~self <> `Running then false else true in
+	assert_can_boot_here ~__context ~self ~host ~snapshot ~do_migrate_check ()
 
 let retrieve_wlb_recommendations ~__context ~vm =
 	let snapshot = Db.VM.get_record ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -60,7 +60,7 @@ let assert_can_boot_here ~__context ~self ~host =
 	if Db.VM.get_power_state ~__context ~self <> `Running then 
 		assert_can_boot_here ~__context ~self ~host ~snapshot ()
 	else 
-		assert_can_boot_here ~__context ~self ~host ~snapshot ~host_op:`vm_migrate ()
+		assert_can_boot_here ~__context ~self ~host ~snapshot ~operation:`vm_migrate ()
 
 let retrieve_wlb_recommendations ~__context ~vm =
 	let snapshot = Db.VM.get_record ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -57,8 +57,10 @@ let assert_can_boot_here ~__context ~self ~host =
 	let snapshot = Db.VM.get_record ~__context ~self in
 	if Helpers.rolling_upgrade_in_progress ~__context then
 		Helpers.assert_platform_version_is_same_on_master ~__context ~host ~self;
-	let do_migrate_check = if Db.VM.get_power_state ~__context ~self <> `Running then false else true in
-	assert_can_boot_here ~__context ~self ~host ~snapshot ~do_migrate_check ()
+	if Db.VM.get_power_state ~__context ~self <> `Running then 
+		assert_can_boot_here ~__context ~self ~host ~snapshot ()
+	else 
+		assert_can_boot_here ~__context ~self ~host ~snapshot ~host_op:`vm_migrate ()
 
 let retrieve_wlb_recommendations ~__context ~vm =
 	let snapshot = Db.VM.get_record ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -481,12 +481,12 @@ let assert_host_supports_hvm ~__context ~self ~host =
 	if not(host_supports_hvm) then
 		raise (Api_errors.Server_error (Api_errors.vm_hvm_required, [Ref.string_of self]))
 
-let assert_enough_memory_available ~__context ~self ~host ~snapshot ?host_op ()=
+let assert_enough_memory_available ~__context ~self ~host ~snapshot ?operation ()=
 	let host_mem_available =
 		Memory_check.host_compute_free_memory_with_maximum_compression
 			~__context ~host (Some self) in
 	let vm_metrics = Db.VM.get_metrics ~__context ~self in
-	let policy = match host_op with
+	let policy = match operation with
 		| Some op -> if op <> `vm_migrate then Memory_check.Dynamic_min else Memory_check.Actual
 		| None -> Memory_check.Dynamic_min in
 	let main, shadow =
@@ -526,7 +526,7 @@ let assert_enough_memory_available ~__context ~self ~host ~snapshot ?host_op ()=
 
  * XXX: we ought to lock this otherwise we may violate our constraints under load
  *)
-let assert_can_boot_here ~__context ~self ~host ~snapshot ?(do_sr_check=true) ?(do_memory_check=true) ?host_op () =
+let assert_can_boot_here ~__context ~self ~host ~snapshot ?(do_sr_check=true) ?(do_memory_check=true) ?operation () =
 	debug "Checking whether VM %s can run on host %s" (Ref.string_of self) (Ref.string_of host);
 	validate_basic_parameters ~__context ~self ~snapshot;
 	assert_host_is_live ~__context ~host;
@@ -542,7 +542,7 @@ let assert_can_boot_here ~__context ~self ~host ~snapshot ?(do_sr_check=true) ?(
 	if Helpers.will_boot_hvm ~__context ~self then
 		assert_host_supports_hvm ~__context ~self ~host;
 	if do_memory_check then
-		assert_enough_memory_available ~__context ~self ~host ~snapshot ?host_op ();
+		assert_enough_memory_available ~__context ~self ~host ~snapshot ?operation ();
 	debug "All fine, VM %s can run on host %s!" (Ref.string_of self) (Ref.string_of host)
 
 let retrieve_wlb_recommendations ~__context ~vm ~snapshot =

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -481,22 +481,21 @@ let assert_host_supports_hvm ~__context ~self ~host =
 	if not(host_supports_hvm) then
 		raise (Api_errors.Server_error (Api_errors.vm_hvm_required, [Ref.string_of self]))
 
-let assert_enough_memory_available ~__context ~self ~host ~snapshot ~do_migrate_check=
+let assert_enough_memory_available ~__context ~self ~host ~snapshot ?host_op ()=
 	let host_mem_available =
 		Memory_check.host_compute_free_memory_with_maximum_compression
 			~__context ~host (Some self) in
-	let vmm = Db.VM.get_metrics ~__context ~self in
-	let memory_actual = Db.VM_metrics.get_memory_actual ~__context ~self:vmm in
-	let policy = if do_migrate_check && (memory_actual != 0L) then Memory_check.Actual else Memory_check.Dynamic_min in
+	let vm_metrics = Db.VM.get_metrics ~__context ~self in
+	let policy = match host_op with
+		| Some op -> if op <> `vm_migrate then Memory_check.Dynamic_min else Memory_check.Actual
+		| None -> Memory_check.Dynamic_min in
 	let main, shadow =
-		Memory_check.vm_compute_start_memory ~__context snapshot ~policy ~memory_actual in
+		Memory_check.vm_compute_start_memory ~__context snapshot ~policy ~vm_metrics in
 	let mem_reqd_for_vm = Int64.add main shadow in
-	debug "host %s do_migrate_check = %b; available_memory = %Ld; memory_required = %Ld; memory_actual = %Ld"
+	debug "host %s; available_memory = %Ld; memory_required = %Ld"
 		(Db.Host.get_name_label ~self:host ~__context)
-		do_migrate_check
 		host_mem_available
-		mem_reqd_for_vm
-		memory_actual;
+		mem_reqd_for_vm;
 	if host_mem_available < mem_reqd_for_vm then
 		raise (Api_errors.Server_error (
 			Api_errors.host_not_enough_free_memory,
@@ -527,7 +526,7 @@ let assert_enough_memory_available ~__context ~self ~host ~snapshot ~do_migrate_
 
  * XXX: we ought to lock this otherwise we may violate our constraints under load
  *)
-let assert_can_boot_here ~__context ~self ~host ~snapshot ?(do_sr_check=true) ?(do_memory_check=true) ?(do_migrate_check=false)() =
+let assert_can_boot_here ~__context ~self ~host ~snapshot ?(do_sr_check=true) ?(do_memory_check=true) ?host_op () =
 	debug "Checking whether VM %s can run on host %s" (Ref.string_of self) (Ref.string_of host);
 	validate_basic_parameters ~__context ~self ~snapshot;
 	assert_host_is_live ~__context ~host;
@@ -543,7 +542,7 @@ let assert_can_boot_here ~__context ~self ~host ~snapshot ?(do_sr_check=true) ?(
 	if Helpers.will_boot_hvm ~__context ~self then
 		assert_host_supports_hvm ~__context ~self ~host;
 	if do_memory_check then
-		assert_enough_memory_available ~__context ~self ~host ~snapshot ~do_migrate_check;
+		assert_enough_memory_available ~__context ~self ~host ~snapshot ?host_op ();
 	debug "All fine, VM %s can run on host %s!" (Ref.string_of self) (Ref.string_of host)
 
 let retrieve_wlb_recommendations ~__context ~vm ~snapshot =

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -795,7 +795,7 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 	| `intra_pool host ->
 		if (not force) && live then Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host ();
 		let snapshot = Helpers.get_boot_record ~__context ~self:vm in
-		Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_sr_check:false ();
+		Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_sr_check:false ~do_migrate_check:true ();
 		(* Prevent VMs from being migrated onto a host with a lower platform version *)
 		Helpers.assert_host_versions_not_decreasing ~__context
 			~host_from:(Helpers.LocalObject source_host_ref)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -795,7 +795,7 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 	| `intra_pool host ->
 		if (not force) && live then Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host ();
 		let snapshot = Helpers.get_boot_record ~__context ~self:vm in
-		Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_sr_check:false ~do_migrate_check:true ();
+		Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_sr_check:false ~host_op:`vm_migrate ();
 		(* Prevent VMs from being migrated onto a host with a lower platform version *)
 		Helpers.assert_host_versions_not_decreasing ~__context
 			~host_from:(Helpers.LocalObject source_host_ref)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -795,7 +795,7 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 	| `intra_pool host ->
 		if (not force) && live then Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host ();
 		let snapshot = Helpers.get_boot_record ~__context ~self:vm in
-		Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_sr_check:false ~host_op:`vm_migrate ();
+		Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_sr_check:false ~operation:`vm_migrate ();
 		(* Prevent VMs from being migrated onto a host with a lower platform version *)
 		Helpers.assert_host_versions_not_decreasing ~__context
 			~host_from:(Helpers.LocalObject source_host_ref)


### PR DESCRIPTION
For VM migrate, will use current memory actual to do the memory check

Signed-off-by: chengz <cheng.zhang@citrix.com>