### PR TITLE
CA-188565: perfmon's SRMonitor should ignore IO throughput

### DIFF
--- a/scripts/perfmon
+++ b/scripts/perfmon
@@ -738,6 +738,7 @@ class SRMonitor(ObjectMonitor):
             else: return 'sum'
         elif config_tag == 'rrd_regex':
             if variable_name == 'physical_utilisation': return 'physical_utilisation|size'
+            elif variable_name == "sr_io_throughput_total_per_host": return '_$_DUMMY__' # (these are to drive Host RRDs and so are handled by the HOSTMonitor)
             else: raise XmlConfigException, "variable %s: no default rrd_regex - please specify one" % variable_name
         elif config_tag == 'alarm_trigger_period':      return '60'   # 1 minute
         elif config_tag == 'alarm_auto_inhibit_period': return '3600' # 1 hour


### PR DESCRIPTION
There is an optimisation for configuring SR IO throughput alerts in perfmon:
Since commit 9a4ce078b (CP-2190), you can add perfmon config
`sr_io_throughput_total_per_host` to the SR record in prefrence to adding
`sr_io_throughput_total_<uuid>` to each of the host records.

This patch makes the recently added SRMonitor ignore this configuration option
on the SR record since it cannot process it.

Moving the processing of `sr_io_throughput_total_per_host` to the SRMonitor was
considered but it is not possible since the monitors of each kind only process
RRDs of the same kind (e.g. VM, Host, and now SR) and these throughput RRDs are
actually Host RRDs.

This allows IO throughput alerts to be configured on SRs that export SR RRDs
(currently just the new thinly-provisioned block SR) and also use the physical
utilisation alert on these SRs.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>