### PR TITLE
CP-14811: Support SXM from pre-levelling-v2 hosts

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -419,7 +419,9 @@ let create_host_cpu ~__context =
 		"model", stat.cpu_info.model;
 		"stepping", stat.cpu_info.stepping;
 		"flags", stat.cpu_info.flags;
-		"features", Cpuid_helpers.string_of_features stat.cpu_info.features;
+		(* To support VMs migrated from hosts which do not support CPU levelling v2,
+		   set the "features" key to what it would be on such hosts. *)
+		"features", Cpuid_helpers.string_of_features stat.cpu_info.features_oldstyle;
 		"features_pv", Cpuid_helpers.string_of_features stat.cpu_info.features_pv;
 		"features_hvm", Cpuid_helpers.string_of_features stat.cpu_info.features_hvm;
 	] in


### PR DESCRIPTION
When a pre-levelling-v2 host is asked to storage-migrate a VM to
a post-levelling-v2 host, the older host will compare its local CPU
features to the 'features' flag sent by the new host.   The new host
must send its features key in the old, pre-levelling-v2 format so that
the older host can understand it.

Signed-off-by: Euan Harris <euan.harris@citrix.com>