### PR TITLE
Correct the use of Xenctrl.Halt

### DIFF
--- a/ocaml/xapi/quicktest_lifecycle.ml
+++ b/ocaml/xapi/quicktest_lifecycle.ml
@@ -145,7 +145,7 @@ let one s vm test =
 					| { api = None; parallel_op = Some x } ->
 						let reason = match x with
 							| Internal_reboot -> Xenctrl.Reboot
-							| Internal_halt -> Xenctrl.Halt
+							| Internal_halt -> Xenctrl.Poweroff
 							| Internal_crash -> Xenctrl.Crash
 							| Internal_suspend -> Xenctrl.Suspend in
 						begin 


### PR DESCRIPTION
Xenctrl.Halt has always been incorrect in the libxc bindings (and should have
been Watchdog).  This was fixed upstream in
http://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=87a16694248e80195943741bb9f857edd6a6bf51,
but subsequently causes a compilation error in xenopsd.

Instead of shutting the domain down with a Watchdog signal, use Poweroff.
This fixes the build against upstream Xen.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>