### PR TITLE
CA-119941: Block vm-migration if VDIs are on rawHBA SR

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -505,6 +505,7 @@ let vm_has_checkpoint = "VM_HAS_CHECKPOINT"
 
 let mirror_failed = "MIRROR_FAILED"
 let too_many_storage_migrates = "TOO_MANY_STORAGE_MIGRATES"
+let vdi_on_rawhba_sr = "VDI_ON_RAWHBA_SR"
 let unimplemented_in_sm_backend = "UNIMPLEMENTED_IN_SM_BACKEND"
 
 let vm_call_plugin_rate_limit = "VM_CALL_PLUGIN_RATE_LIMIT"

--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -505,7 +505,7 @@ let vm_has_checkpoint = "VM_HAS_CHECKPOINT"
 
 let mirror_failed = "MIRROR_FAILED"
 let too_many_storage_migrates = "TOO_MANY_STORAGE_MIGRATES"
-let vdi_on_rawhba_sr = "VDI_ON_RAWHBA_SR"
+let sr_does_not_support_migration = "SR_DOES_NOT_SUPPORT_MIGRATION"
 let unimplemented_in_sm_backend = "UNIMPLEMENTED_IN_SM_BACKEND"
 
 let vm_call_plugin_rate_limit = "VM_CALL_PLUGIN_RATE_LIMIT"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -917,8 +917,8 @@ let _ =
     ~doc:"The VDI mirroring cannot be performed" ();
   error Api_errors.too_many_storage_migrates [ "number" ]
     ~doc:"You reached the maximal number of concurrently migrating VMs." ();
-  error Api_errors.vdi_on_rawhba_sr [ "vdi" ]
-    ~doc:"You attempted to migrate a VDI which is on rawHBA SR." ();
+  error Api_errors.sr_does_not_support_migration [ "sr" ]
+    ~doc:"You attempted to migrate a VDI on SR which doesn't have snapshot capability" ();
   error Api_errors.vm_failed_shutdown_ack []
     ~doc:"VM didn't acknowledge the need to shutdown." ();
   error Api_errors.vm_shutdown_timeout [ "vm"; "timeout" ]

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -917,6 +917,8 @@ let _ =
     ~doc:"The VDI mirroring cannot be performed" ();
   error Api_errors.too_many_storage_migrates [ "number" ]
     ~doc:"You reached the maximal number of concurrently migrating VMs." ();
+  error Api_errors.vdi_on_rawhba_sr [ "vdi" ]
+    ~doc:"You attempted to migrate a VDI which is on rawHBA SR." ();
   error Api_errors.vm_failed_shutdown_ack []
     ~doc:"VM didn't acknowledge the need to shutdown." ();
   error Api_errors.vm_shutdown_timeout [ "vm"; "timeout" ]

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -57,15 +57,25 @@ open Storage_interface
 open Listext
 open Fun
 
-let assert_vdi_on_rawhba ~__context ~vdi_map ~remote_rpc ~session_id =
+let assert_sr_support_migration ~__context ~vdi_map ~remote_rpc ~session_id =
+	(* Get destination host SM record *)
+	let sm_record = XenAPI.SM.get_all_records remote_rpc session_id in
 	List.iter (fun (vdi, sr) ->
+		(* Check VDIs must not be present on SR which doesn't have snapshot capability *)
 		let source_sr = Db.VDI.get_SR ~__context ~self:vdi in
-		(* Check VDIs must not be present on rawHBA source SR 
-		 * OR VDIs must not be mirrored to rawHBA destination SR
-		 * *)
-		if (Db.SR.get_type ~__context ~self:source_sr = "rawhba") ||
-		(XenAPI.SR.get_type remote_rpc session_id sr = "rawhba") then
-			raise (Api_errors.Server_error(Api_errors.vdi_on_rawhba_sr, [Ref.string_of vdi]))
+		let sr_record = Db.SR.get_record_internal ~__context ~self:source_sr in
+		let sr_features = Xapi_sr_operations.features_of_sr ~__context sr_record in
+		if not Smint.(has_capability Vdi_snapshot sr_features) then
+			raise (Api_errors.Server_error(Api_errors.sr_does_not_support_migration, [Ref.string_of source_sr]));
+		(* Check VDIs must not be mirrored to SR which doesn't have snapshot capability *)
+		let sr_type = XenAPI.SR.get_type remote_rpc session_id sr in
+		let sm_capabilities =
+			match List.filter (fun (_, r) -> r.API.sM_type = sr_type) sm_record with
+			| [ _, plugin ] -> plugin.API.sM_capabilities
+			| _ -> []
+		in
+		if not (List.exists (fun cp -> cp = "Vdi_snapshot") sm_capabilities) then
+			raise (Api_errors.Server_error(Api_errors.sr_does_not_support_migration, [Ref.string_of sr]))
 	) vdi_map
 
 let assert_licensed_storage_motion ~__context =
@@ -837,8 +847,8 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 			~host_to;
 		(* Check the host can support the VM's required version of virtual hardware platform *)
 		Xapi_vm_helpers.assert_hardware_platform_support ~__context ~vm ~host:host_to;
-		(* Check VDIs are not on rawHBA SR *)
-		assert_vdi_on_rawhba ~__context ~vdi_map ~remote_rpc ~session_id;
+		(* Check VDIs are not on SR which doesn't have snapshot capability *)
+		assert_sr_support_migration ~__context ~vdi_map ~remote_rpc ~session_id;
 
 		(*Check that the remote host is enabled and not in maintenance mode*)
 		let check_host_enabled = XenAPI.Host.get_enabled remote_rpc session_id (dest_host_ref) in


### PR DESCRIPTION
Cross-pool vm-migration must be blocked if VDIs are on rawHBA
source SR or VDIs going to be mirrored to rawHBA destination SR.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>