### PR TITLE
CA-189771: If host does not have new feature keys, don't update VM fe…

### DIFF
--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -150,15 +150,18 @@ let update_cpu_flags ~__context ~vm ~host =
 		with Not_found -> ""
 	in
 	debug "VM last boot CPU features: %s" current_features;
-	let host_vendor, host_features =
-		let host_cpu_info = Db.Host.get_cpu_info ~__context ~self:host in
-		get_flags_for_vm ~__context vm host_cpu_info
-	in
-	let new_features = upgrade_features ~__context ~vm
-		(features_of_string host_features) (features_of_string current_features)
-		|> string_of_features in
-	if new_features <> current_features then
-		set_flags ~__context vm host_vendor new_features
+	try
+		let host_vendor, host_features =
+			let host_cpu_info = Db.Host.get_cpu_info ~__context ~self:host in
+			get_flags_for_vm ~__context vm host_cpu_info
+		in
+		let new_features = upgrade_features ~__context ~vm
+			(features_of_string host_features) (features_of_string current_features)
+			|> string_of_features in
+		if new_features <> current_features then
+			set_flags ~__context vm host_vendor new_features
+	with Not_found ->
+		debug "Host does not have new levelling feature keys - not upgrading VM's flags"
 
 let get_host_compatibility_info ~__context ~vm ~host ~remote =
 	let cpu_info =


### PR DESCRIPTION
…atures

During migration, the master tries to update the VM's CPU features to
the new levelling v2 format.   This is the correct thing to do when the
VM is moving from a non-upgraded host to an upgraded host during rolling
pool upgrade.  However, during RPU the master may also move a VM from
one non-upgraded host to another non-upgraded host.   In this case the
flags should not be updated.   In fact, they cannot be updated, because
the hosts do not have the levelling v2 features_pv and features_hvm flags.
Their absence causes update_cpu_flags to fail with a 'Not_found' exception
which bubbles up from Cpuid_helpers.get_cpu_flags.

This patch makes update_cpu_flags a no-op when the host does not have the
required features.   This should only occur during a 'sideways' migration
during RPU because we do not permit 'downhill' migrations to earlier
versions.   During an 'uphill' migration, the destination host will have
the new flags so the update will happen as before.

In this case, Cpuid_helpers.update_cpu_flags should do nothing.

Signed-off-by: Euan Harris <euan.harris@citrix.com>