### PR TITLE
CA-192191: Upgrade CPU flags after domain has migrated

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1590,8 +1590,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
 			with_vm_operation ~__context ~self:vm ~doc:"VM.pool_migrate" ~op:`pool_migrate
 				(fun () ->
-					(* Update CPU feature set, which will be passed to xenopsd *)
-					Cpuid_helpers.update_cpu_flags ~__context ~vm ~host;
 					(* Make sure the target has enough memory to receive the VM *)
 					let snapshot = Helpers.get_boot_record ~__context ~self:vm in
 					(* MTC:  An MTC-protected VM has a peer VM on the destination host to which
@@ -1609,7 +1607,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 							forward_vm_op ~local_fn ~__context ~vm
 								(fun session_id rpc -> Client.VM.pool_migrate rpc session_id vm host options)));
 			update_vbd_operations ~__context ~vm;
-			update_vif_operations ~__context ~vm
+			update_vif_operations ~__context ~vm;
+			Cpuid_helpers.update_cpu_flags ~__context ~vm ~host
 
 		let migrate_send ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 			info "VM.migrate_send: VM = '%s'" (vm_uuid ~__context vm);


### PR DESCRIPTION
Previously, we would upgrade a VM's CPU flags before asking the host on
which it was resident to migrate it.  If the older host tried to read
the CPU flags while preparing to migrate the VM, it would see new-style
feature flags, which it could not understand, causing it to raise an
exception.

Now, we upgrade the CPU flags after the VM has been migrated.   During an
upgrade, if the VM does not have appropriate feature flags, xenguest
will give it maximum features for the destination host, then Xapi will
apply proper new-style features which will be used for all subsequent
migrations.   The older host will never see the new-style features.

Signed-off-by: Euan Harris <euan.harris@citrix.com>