### PR TITLE
CA-193817: Allow GVT-g even when device is hidden from xen/dom0

### DIFF
--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -486,18 +486,13 @@ module Intel = struct
 			~is_host_display_enabled
 			~is_pci_hidden =
 		let types =
-			if is_system_display_device
-			then begin
-				match is_host_display_enabled, is_pci_hidden with
-				| false, true -> [passthrough_gpu]
-				| true, true -> []
-				| _, false ->
-					(make_vgpu_types ~__context
-						~pci ~whitelist:!Xapi_globs.gvt_g_whitelist)
-			end else
-				passthrough_gpu ::
-				(make_vgpu_types ~__context
-					~pci ~whitelist:!Xapi_globs.gvt_g_whitelist)
+			let passthrough_types =
+				if is_system_display_device && (is_host_display_enabled || not is_pci_hidden)
+				then []
+				else [passthrough_gpu]
+			in
+			passthrough_types @
+			(make_vgpu_types ~__context ~pci ~whitelist:!Xapi_globs.gvt_g_whitelist)
 		in
 		List.map (find_or_create ~__context) types
 end


### PR DESCRIPTION
GVT-g is now always enabled, independent of whether the device is hidden
from xen/dom0.

Passthrough of Intel GPUs still requires the device to be hidden from
both xen and dom0.