### PR TITLE
CA-194089: allow no-op VM.set_has_vendor_device

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1088,12 +1088,16 @@ let assert_can_set_has_vendor_device ~__context ~self ~value =
 	then Pool_features.assert_enabled ~__context ~f:Features.PCI_device_for_auto_update;
 
 	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:`Halted;
-	let vm_gm = Db.VM.get_guest_metrics ~__context ~self in
-	let network_optimized = try Db.VM_guest_metrics.get_network_paths_optimized ~__context ~self:vm_gm with _ -> false in
-	let storage_optimized = try Db.VM_guest_metrics.get_storage_paths_optimized ~__context ~self:vm_gm with _ -> false in
-	if storage_optimized || network_optimized
-	then
-		raise (Api_errors.Server_error(Api_errors.vm_pv_drivers_in_use, [ Ref.string_of self ]))
+
+	let old_val = Db.VM.get_has_vendor_device ~__context ~self in
+	if old_val <> value then (
+		let vm_gm = Db.VM.get_guest_metrics ~__context ~self in
+		let network_optimized = try Db.VM_guest_metrics.get_network_paths_optimized ~__context ~self:vm_gm with _ -> false in
+		let storage_optimized = try Db.VM_guest_metrics.get_storage_paths_optimized ~__context ~self:vm_gm with _ -> false in
+		if storage_optimized || network_optimized
+		then
+			raise (Api_errors.Server_error(Api_errors.vm_pv_drivers_in_use, [ Ref.string_of self ]))
+	)
 
 let set_has_vendor_device ~__context ~self ~value =
 	assert_can_set_has_vendor_device ~__context ~self ~value;


### PR DESCRIPTION
In Xapi_vm.assert_can_set_has_vendor_device, we were raising an
exception if the PV drivers were in use.  Now we do this check only
if the new value of has_vendor_device is different to the old one.