### PR TITLE
CA-195644: Handle the change in the xs-firstboot package

### DIFF
--- a/ocaml/xapi/xapi_fuse.ml
+++ b/ocaml/xapi/xapi_fuse.ml
@@ -56,7 +56,7 @@ let light_fuse_and_reboot_after_eject() =
 	    (fun ()->
 	       Thread.delay !Xapi_globs.fuse_time;
 	       (* this activates firstboot script and reboots the host *)
-		   ignore (Forkhelpers.execute_command_get_output "/sbin/service" [ "firstboot"; "activate" ]);
+		   ignore (Forkhelpers.execute_command_get_output "/sbin/xs-firstboot" [ "reset-and-reboot" ]);
            ()
 	    ) ())
 


### PR DESCRIPTION
XenServer has moved the firstboot service to systemd and this does not support
arbitrary actions. As such, when we eject from a pool, calling `service
firstboot activate` does not work.

The package has been revised and we now need to call the script directly
(rather than exercise via `service`) and the verb has been changed to be more
semantically meaningful: from `activate` to `reset-and-reboot`.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>