### PR TITLE
CP-15277: allow vif|vbd hotplug if guest claims support

### DIFF
--- a/ocaml/client_records/record_util.ml
+++ b/ocaml/client_records/record_util.ml
@@ -460,6 +460,12 @@ let on_boot_to_string onboot =
 		| `reset -> "reset"
 		| `persist -> "persist"
 
+let tristate_to_string tristate =
+	match tristate with
+		| `yes -> "true"
+		| `no -> "false"
+		| `unspecified -> "unspecified"
+
 let wrap f err x = try f x with _ -> err x
 let generic_error x = raise (Record_failure ("Unknown value: "^x))
 let rpc_to_string = function | Rpc.String s -> s | _ -> failwith "Bad RPC type in record_util"

--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -882,6 +882,10 @@ let vm_record rpc session_id vm =
 				~get:(fun () -> default nid (may (fun m -> string_of_bool m.API.vM_guest_metrics_live) (xgm ()) )) ();
 			make_field ~name:"guest-metrics-last-updated"
 				~get:(fun () -> default nid (may (fun m -> Date.to_string m.API.vM_guest_metrics_last_updated) (xgm ()) )) ();
+			make_field ~name:"can-use-hotplug-vbd"
+				~get:(fun () -> default nid (may (fun m -> Record_util.tristate_to_string m.API.vM_guest_metrics_can_use_hotplug_vbd) (xgm ()) )) ();
+			make_field ~name:"can-use-hotplug-vif"
+				~get:(fun () -> default nid (may (fun m -> Record_util.tristate_to_string m.API.vM_guest_metrics_can_use_hotplug_vif) (xgm ()) )) ();
 			make_field ~name:"cooperative"
 				(* NB this can receive VM_IS_SNAPSHOT *)
 				~get:(fun () -> string_of_bool (try Client.VM.get_cooperative rpc session_id vm with _ -> true))

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 90
+let schema_minor_vsn = 91
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -70,7 +70,7 @@ let indigo_release_schema_major_vsn = 5
 let indigo_release_schema_minor_vsn = 74
 
 let dundee_release_schema_major_vsn = 5
-let dundee_release_schema_minor_vsn = 90
+let dundee_release_schema_minor_vsn = 91
 
 (* the schema vsn of the last release: used to determine whether we can upgrade or not.. *)
 let last_release_schema_major_vsn = cream_release_schema_major_vsn
@@ -7344,6 +7344,13 @@ let vm_metrics =
       ]
 	()
 
+let tristate_type = Enum ("tristate_type",
+[
+	"yes", "Known to be true";
+	"no", "Known to be false";
+	"unspecified", "Unknown or unspecified";
+])
+
 (* Some of this stuff needs to persist (like PV drivers vsns etc.) so we know about what's likely to be in the VM even when it's off.
    Other things don't need to persist, so we specify these on a per-field basis *)
 let vm_guest_metrics =
@@ -7389,6 +7396,8 @@ let vm_guest_metrics =
       field ~qualifier:DynamicRO ~ty:DateTime "last_updated" "Time at which this information was last updated";
       field ~in_product_since:rel_orlando ~default_value:(Some (VMap [])) ~ty:(Map(String, String)) "other_config" "additional configuration";
       field ~qualifier:DynamicRO ~in_product_since:rel_orlando ~default_value:(Some (VBool false)) ~ty:Bool "live" "True if the guest is sending heartbeat messages via the guest agent";
+      field ~qualifier:DynamicRO ~lifecycle:[Published, rel_dundee, "To be used where relevant and available instead of checking PV driver version."] ~ty:tristate_type ~default_value:(Some (VEnum "unspecified")) "can_use_hotplug_vbd" "The guest's statement of whether it supports VBD hotplug, i.e. whether it is capable of responding immediately to instantiation of a new VBD by bringing online a new PV block device. If the guest states that it is not capable, then the VBD plug and unplug operations will not be allowed while the guest is running.";
+      field ~qualifier:DynamicRO ~lifecycle:[Published, rel_dundee, "To be used where relevant and available instead of checking PV driver version."] ~ty:tristate_type ~default_value:(Some (VEnum "unspecified")) "can_use_hotplug_vif" "The guest's statement of whether it supports VIF hotplug, i.e. whether it is capable of responding immediately to instantiation of a new VIF by bringing online a new PV network device. If the guest states that it is not capable, then the VIF plug and unplug operations will not be allowed while the guest is running.";
     ]
     ()
 

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -544,7 +544,10 @@ module GuestMetrics : HandlerTools = struct
 			~other:gm_record.API.vM_guest_metrics_other
 			~last_updated:gm_record.API.vM_guest_metrics_last_updated
 			~other_config:gm_record.API.vM_guest_metrics_other_config
-			~live:gm_record.API.vM_guest_metrics_live;
+			~live:gm_record.API.vM_guest_metrics_live
+			~can_use_hotplug_vbd:gm_record.API.vM_guest_metrics_can_use_hotplug_vbd
+			~can_use_hotplug_vif:gm_record.API.vM_guest_metrics_can_use_hotplug_vif
+		;
 		state.table <- (x.cls, x.id, Ref.string_of gm) :: state.table
 end
 

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -242,7 +242,7 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
 	      let new_ref = Ref.make () and new_uuid = Uuid.to_string (Uuid.make_uuid ()) in
 	      Db.VM_guest_metrics.create ~__context ~ref:new_ref ~uuid:new_uuid
 		~os_version:os_version ~pV_drivers_version:pv_drivers_version ~pV_drivers_up_to_date:false ~memory:[] ~disks:[] ~networks:networks ~other:other
-		~storage_paths_optimized:false ~network_paths_optimized:false ~last_updated:(Date.of_float last_updated) ~other_config:[] ~live:true;
+		~storage_paths_optimized:false ~network_paths_optimized:false ~last_updated:(Date.of_float last_updated) ~other_config:[] ~live:true ~can_use_hotplug_vbd:`unspecified ~can_use_hotplug_vif:`unspecified;
 	      Db.VM.set_guest_metrics ~__context ~self ~value:new_ref; 
 	      (* We've just set the thing to live, let's make sure it's not in the dead list *)
 		  let sl xs = String.concat "; " (List.map (fun (k, v) -> k ^ ": " ^ v) xs) in

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -325,8 +325,11 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
 		  end
 	  end;
 
-	  (* We base some of our allowed-operations decisions on the presence/absence of PV drivers *)
-	  if pv_drivers_version_cached <> pv_drivers_version then begin
+	  (* We base some of our allowed-operations decisions on these advertised features and the presence/absence of PV drivers. *)
+	  if pv_drivers_version_cached <> pv_drivers_version
+	    || can_use_hotplug_vbd_cached <> can_use_hotplug_vbd
+	    || can_use_hotplug_vif_cached <> can_use_hotplug_vif
+	  then begin
 	    Helpers.call_api_functions ~__context (fun rpc session_id -> Client.Client.VM.update_allowed_operations rpc session_id self);
 	  end;	  
 	end (* else debug "Ignored spurious guest agent update" *)

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -127,17 +127,29 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
     end
   ) vm_current_ops;
 
-  (* HVM guests only support plug/unplug IF they have PV drivers *)
+  (* HVM guests MAY support plug/unplug IF they have PV drivers. Assume
+   * all drivers have such support unless they specify that they do not. *)
   (* They can only eject/insert CDs not plug/unplug *)
   let vm_gm = Db.VM.get_guest_metrics ~__context ~self:vm in
   let vm_gmr = try Some (Db.VM_guest_metrics.get_record_internal ~__context ~self:vm_gm) with _ -> None in  
   if power_state = `Running && Helpers.has_booted_hvm ~__context ~self:vm then begin
-    (match Xapi_pv_driver_version.make_error_opt (Xapi_pv_driver_version.of_guest_metrics vm_gmr) vm with
-     | Some(code, params) -> set_errors code params [ `plug; `unplug; `unplug_force ]
-     | None -> ());
+    let plug_ops = [ `plug; `unplug; `unplug_force ] in
+    let fallback () =
+      match Xapi_pv_driver_version.make_error_opt (Xapi_pv_driver_version.of_guest_metrics vm_gmr) vm with
+        | Some(code, params) -> set_errors code params plug_ops
+        | None -> () in
+
+    (match vm_gmr with
+      | None -> fallback ()
+      | Some gmr ->
+        (match gmr.Db_actions.vM_guest_metrics_can_use_hotplug_vbd with
+          | `yes -> () (* Drivers have made an explicit claim of support. *)
+          | `no -> set_errors Api_errors.operation_not_allowed ["VM states it does not support VBD hotplug."] plug_ops
+          | `unspecified -> fallback ())
+    );
     if record.Db_actions.vBD_type = `CD
     then set_errors Api_errors.operation_not_allowed 
-      [ "HVM CDROMs cannot be hotplugged/unplugged, only inserted or ejected" ] [ `plug; `unplug; `unplug_force ]
+      [ "HVM CDROMs cannot be hotplugged/unplugged, only inserted or ejected" ] plug_ops
   end;
 
   (* When a VM is suspended, no operations are allowed for CD. *)

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -76,13 +76,25 @@ let valid_operations ~__context record _ref' : table =
     end
   ) vm_current_ops;
 
-  (* HVM guests only support plug/unplug IF they have PV drivers *)
+  (* HVM guests MAY support plug/unplug IF they have PV drivers. Assume
+   * all drivers have such support unless they specify that they do not. *)
   let vm_gm = Db.VM.get_guest_metrics ~__context ~self:vm in
   let vm_gmr = try Some (Db.VM_guest_metrics.get_record_internal ~__context ~self:vm_gm) with _ -> None in
   if power_state = `Running && Helpers.has_booted_hvm ~__context ~self:vm
-  then (match Xapi_pv_driver_version.make_error_opt (Xapi_pv_driver_version.of_guest_metrics vm_gmr) vm with
-  | Some(code, params) -> set_errors code params [ `plug; `unplug ]
-  | None -> ());
+  then (
+    let fallback () =
+      match Xapi_pv_driver_version.make_error_opt (Xapi_pv_driver_version.of_guest_metrics vm_gmr) vm with
+        | Some(code, params) -> set_errors code params [ `plug; `unplug ]
+        | None -> () in
+
+    match vm_gmr with
+      | None -> fallback ()
+      | Some gmr -> (
+        match gmr.Db_actions.vM_guest_metrics_can_use_hotplug_vif with
+          | `yes -> () (* Drivers have made an explicit claim of support. *)
+          | `no -> set_errors Api_errors.operation_not_allowed ["VM states it does not support VIF hotplug."] [`plug; `unplug]
+          | `unspecified -> fallback ())
+  );
 
   table
 

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -861,7 +861,10 @@ let copy_guest_metrics ~__context ~vm =
 			~other:all.API.vM_guest_metrics_other
 			~last_updated:all.API.vM_guest_metrics_last_updated
 			~other_config:all.API.vM_guest_metrics_other_config
-			~live:all.API.vM_guest_metrics_live;
+			~live:all.API.vM_guest_metrics_live
+			~can_use_hotplug_vbd:all.API.vM_guest_metrics_can_use_hotplug_vbd
+			~can_use_hotplug_vif:all.API.vM_guest_metrics_can_use_hotplug_vif
+		;
 		ref
 	with _ ->
 		Ref.null


### PR DESCRIPTION
Where an HVM guest has specified that it does or does not support
hotplug of VIF or VBD, we use this to decide whether to allow the
relevant operations.  Otherwise, we fall back to the old heuristic
of allowing them iff the guest has announced a PV driver version.
