### PR TITLE
CA-195652: Cause Xenopsd to cleanup before creating new domains

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -675,8 +675,6 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 		debug "Migration complete";
 		SMPERF.debug "vm.migrate_send: migration complete vm:%s" vm_uuid;
 
-		Xapi_xenops.refresh_vm ~__context ~self:vm;
-
 		XenAPI.VM.pool_migrate_complete remote_rpc session_id new_vm dest_host_ref;
 		
 		(* And we're finished *)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -154,10 +154,14 @@ let pool_migrate ~__context ~vm ~host ~options =
 	with exn ->
 		error "xenops: VM.migrate %s: caught %s" vm_uuid (Printexc.to_string exn);
 		(* We do our best to tidy up the state left behind *)
-		let _, state = XenopsAPI.VM.stat dbg vm_uuid in
-		if Xenops_interface.(state.Vm.power_state = Suspended) then begin
-			debug "xenops: %s: shutting down suspended VM" vm_uuid;
-			Xapi_xenops.shutdown ~__context ~self:vm None;
+		begin
+			try
+				let _, state = XenopsAPI.VM.stat dbg vm_uuid in
+				if Xenops_interface.(state.Vm.power_state = Suspended) then begin
+					debug "xenops: %s: shutting down suspended VM" vm_uuid;
+					Xapi_xenops.shutdown ~__context ~self:vm None;
+				end;
+			with _ -> ()
 		end;
 		match exn with
 		| Xenops_interface.Failed_to_acknowledge_shutdown_request ->

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -139,7 +139,7 @@ let pool_migrate ~__context ~vm ~host ~options =
 	let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
 	try
 		Xapi_network.with_networks_attached_for_vm ~__context ~vm ~host (fun () ->
-			Xapi_xenops.with_events_suppressed ~__context ~self:vm (fun () ->
+			Xapi_xenops.Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid (fun () ->
 				(* XXX: PR-1255: the live flag *)
 				info "xenops: VM.migrate %s to %s" vm_uuid xenops_url;
 				migrate_with_retry ~__context queue_name dbg vm_uuid [] [] xenops_url;
@@ -662,7 +662,7 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 		(* It's acceptable for the VM not to exist at this point; shutdown commutes with storage migrate *)
 		begin
 			try
-				Xapi_xenops.with_events_suppressed ~__context ~self:vm (fun () ->
+				Xapi_xenops.Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid (fun () ->
 						migrate_with_retry ~__context queue_name dbg vm_uuid xenops_vdi_map xenops_vif_map xenops;
 						Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid;
 					)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2343,11 +2343,26 @@ let set_memory_dynamic_range ~__context ~self min max =
 			Events_from_xenopsd.wait queue_name dbg id ()
 		)
 
+let maybe_cleanup_vm ~__context ~self =
+	let dbg = Context.string_of_task __context in
+	let queue_name = queue_of_vm ~__context ~self in
+	let id = id_of_vm ~__context ~self in
+	if vm_exists_in_xenopsd queue_name dbg id then begin
+		warn "Stale VM detected in xenopsd, calling refresh_vm to sync state";
+		(* ignore VM events; we just want Xenopsd in a consistent state *)
+		with_events_suppressed ~__context ~self (fun () ->
+			refresh_vm ~__context ~self;
+		);
+	end
+
 let start ~__context ~self paused =
 	let dbg = Context.string_of_task __context in
 	let queue_name = queue_of_vm ~__context ~self in
 	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
+			maybe_cleanup_vm ~__context ~self;
+			if vm_exists_in_xenopsd queue_name dbg vm_id then
+				raise (Bad_power_state (Running, Halted));
 			(* For all devices which we want xenopsd to manage, set currently_attached = true
 			   so the metadata is pushed. *)
 			let vbds =
@@ -2435,6 +2450,10 @@ let reboot ~__context ~self timeout =
 			assert_resident_on ~__context ~self;
 			let id = id_of_vm ~__context ~self in
 			let dbg = Context.string_of_task __context in
+			maybe_cleanup_vm ~__context ~self;
+			(* If Xenopsd no longer knows about the VM after cleanup it was shutdown *)
+			if not (vm_exists_in_xenopsd queue_name dbg id) then
+				raise (Bad_power_state (Halted, Running));
 			(* Ensure we have the latest version of the VM metadata before the reboot *)
 			Events_from_xapi.wait ~__context ~self;
 			info "xenops: VM.reboot %s" id;
@@ -2520,6 +2539,9 @@ let resume ~__context ~self ~start_paused ~force =
 	let queue_name = queue_of_vm ~__context ~self in
 	transform_xenops_exn ~__context ~vm:self queue_name
 		(fun () ->
+			maybe_cleanup_vm ~__context ~self;
+			if vm_exists_in_xenopsd queue_name dbg vm_id then
+				raise (Bad_power_state (Running, Suspended));
 			let vdi = Db.VM.get_suspend_VDI ~__context ~self in
 			let disk = disk_of_vdi ~__context ~self:vdi |> Opt.unbox in
 			let module Client = (val make_client queue_name : XENOPS) in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2168,6 +2168,8 @@ let refresh_vm ~__context ~self =
 
 let with_events_suppressed ~__context ~self f =
 	let vm = id_of_vm ~__context ~self in
+	let queue_name = queue_of_vm ~__context ~self in
+	let dbg = Context.string_of_task __context in
 	debug "suppressing xenops events on VM: %s" vm;
 	Mutex.execute events_suppressed_on_m
 		(fun () ->
@@ -2180,6 +2182,7 @@ let with_events_suppressed ~__context ~self f =
 					Hashtbl.remove events_suppressed_on vm
 				);
 			debug "re-enabled xenops events on VM: %s" vm;
+			Events_from_xenopsd.wait queue_name dbg vm ();
 		)
 
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2614,7 +2614,6 @@ let vbd_plug ~__context ~self =
 							Client.VBD.plug dbg id |> sync_with_task __context queue_name;
 						)
 				) (fun () -> refresh_vm ~__context ~self:vm);
-			Events_from_xenopsd.wait queue_name dbg (fst vbd.Vbd.id) ();
 			assert (Db.VBD.get_currently_attached ~__context ~self)
 		)
 
@@ -2726,7 +2725,6 @@ let vif_plug ~__context ~self =
 							)
 					) (fun () -> refresh_vm ~__context ~self:vm)
 			);
-			Events_from_xenopsd.wait queue_name dbg (fst vif.Vif.id) ();
 			assert (Db.VIF.get_currently_attached ~__context ~self)
 		)
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2171,7 +2171,7 @@ let with_events_suppressed ~__context ~self f =
 	debug "suppressing xenops events on VM: %s" vm;
 	Mutex.execute events_suppressed_on_m
 		(fun () ->
-			Hashtbl.replace events_suppressed_on vm ()
+			Hashtbl.add events_suppressed_on vm ()
 		);
 	finally f
 		(fun () ->


### PR DESCRIPTION
This pull request addresses several issues with the handling of events between Xapi and Xenopsd.

Prior to this patch series there were some race-conditions on error paths that could cause 2 domains to be concurrently running for the same VM due to events being missed by Xapi and Xapi not syncing with events before doing lifecycle operations.

Among the commits in this pull-request, these are the ones that are of most interest with respect to re-gaining thread safety:

	4486f94: CA-195652: Stack with_events_suppressed calls …
	cd12c21: CA-195652: Sync with Xenopsd events after suppression …
	b5ff609: CA-195652: Cause Xenopsd to cleanup before creating new domains …
	e768829: CA-195652: Wait for events to be un-suppressed after suppression …
	f6b51b3: CA-195652: Refresh VM after re-enabling events from Xenopsd …
	b962fcd: CA-195652: Handle pool_migrate errors with events suppressed …