### PR TITLE
CA-195429: logrotate xensource.log when over 100M

### DIFF
--- a/scripts/OMakefile
+++ b/scripts/OMakefile
@@ -35,7 +35,8 @@ install:
 	$(IPROG) license-check.py $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) mail-alarm $(DESTDIR)$(LIBEXECDIR)
 	$(IDATA) audit-logrotate $(DESTDIR)/etc/logrotate.d/audit
-	$(IDATA) xapi-logrotate $(DESTDIR)/etc/logrotate.d/xapi
+	$(IDATA) xapi-logrotate.conf $(DESTDIR)/etc/xapi.d/xapi-logrotate.conf
+	$(IDATA) xapi-logrotate.sh $(DESTDIR)/etc/xapi.d/xapi-logrotate.sh
 	$(IPROG) xapi-wait-init-complete $(DESTDIR)$(BINDIR)
 	$(IPROG) xapi-autostart-vms $(DESTDIR)$(BINDIR)
 	$(IPROG) udhcpd.skel $(DESTDIR)$(ETCDIR)/udhcpd.skel
@@ -123,6 +124,8 @@ install:
 	$(IPROG) pv2hvm $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)/etc/cron.daily
 	$(IDATA) license-check $(DESTDIR)/etc/cron.daily/
+	mkdir -p $(DESTDIR)/etc/cron.d
+	$(IDATA) xapi-logrotate.cron $(DESTDIR)/etc/cron.d/xapi-logrotate.cron
 	mkdir -p $(DESTDIR)/opt/xensource/gpg
 	$(IDATA) gpg/secring.gpg $(DESTDIR)/opt/xensource/gpg/
 	$(IDATA) gpg/pubring.gpg $(DESTDIR)/opt/xensource/gpg/

--- a/scripts/OMakefile
+++ b/scripts/OMakefile
@@ -35,8 +35,8 @@ install:
 	$(IPROG) license-check.py $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) mail-alarm $(DESTDIR)$(LIBEXECDIR)
 	$(IDATA) audit-logrotate $(DESTDIR)/etc/logrotate.d/audit
-	$(IDATA) xapi-logrotate.conf $(DESTDIR)/etc/xapi.d/xapi-logrotate.conf
-	$(IDATA) xapi-logrotate.sh $(DESTDIR)/etc/xapi.d/xapi-logrotate.sh
+	$(IDATA) xapi-logrotate.conf $(DESTDIR)$(ETCDIR)
+	$(IPROG) xapi-logrotate.sh $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) xapi-wait-init-complete $(DESTDIR)$(BINDIR)
 	$(IPROG) xapi-autostart-vms $(DESTDIR)$(BINDIR)
 	$(IPROG) udhcpd.skel $(DESTDIR)$(ETCDIR)/udhcpd.skel

--- a/scripts/xapi-logrotate
+++ b/scripts/xapi-logrotate
@@ -1,7 +1,0 @@
-/var/log/xensource.log {
-    missingok
-    sharedscripts
-    postrotate
-               /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
-    endscript
-}

--- a/scripts/xapi-logrotate.conf
+++ b/scripts/xapi-logrotate.conf
@@ -1,0 +1,39 @@
+# see "man logrotate" for details
+# rotate log files daily
+daily
+
+# keep one months worth of backlogs
+rotate 31
+
+# create new (empty) log files after rotating old ones
+create
+
+# compress log files
+compress
+delaycompress
+
+# All the general settings above are copied from /etc/logrotate.conf
+# as installed by the logrotate RPM.
+
+/var/log/xensource.log {
+    missingok
+
+    # Without this we would run scripts (e.g. postrotate) once for each file
+    # rotated, rather than once for the whole lot.
+    # (Makes no difference since we are considering only one log file anyway.)
+    sharedscripts
+
+    # When rotating, remove any rotated logs older than this many days.
+    maxage 31
+
+    # Rotate when file exceeds this size, even if we rotated it today already.
+    maxsize 100M
+
+    # Keep up to this many old files.
+    # (When considering total size, expect a compression factor around 10-20.)
+    rotate 100
+
+    postrotate
+               /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}

--- a/scripts/xapi-logrotate.cron
+++ b/scripts/xapi-logrotate.cron
@@ -1,3 +1,3 @@
 # Run at 40 minutes past the hour,
 # every hour, day-of-month, month, day-of-week
-40   *  *  *  * root /etc/xapi.d/xapi-logrotate.sh
+40   *  *  *  * root /opt/xensource/libexec/xapi-logrotate.sh

--- a/scripts/xapi-logrotate.cron
+++ b/scripts/xapi-logrotate.cron
@@ -1,0 +1,3 @@
+# Run at 40 minutes past the hour,
+# every hour, day-of-month, month, day-of-week
+40   *  *  *  * root /etc/xapi.d/xapi-logrotate.sh

--- a/scripts/xapi-logrotate.sh
+++ b/scripts/xapi-logrotate.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-/usr/sbin/logrotate /etc/xapi.d/xapi-logrotate.conf
+/usr/sbin/logrotate /etc/xensource/xapi-logrotate.conf
 EXITVALUE=$?
 if [ $EXITVALUE != 0 ]; then
     /usr/bin/logger -t $0 "ALERT exited abnormally with [$EXITVALUE]"

--- a/scripts/xapi-logrotate.sh
+++ b/scripts/xapi-logrotate.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+/usr/sbin/logrotate /etc/xapi.d/xapi-logrotate.conf
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t $0 "ALERT exited abnormally with [$EXITVALUE]"
+fi
+exit 0

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -185,8 +185,8 @@ rm -rf $RPM_BUILD_ROOT
 %config(noreplace) /etc/xapi.conf
 /etc/logrotate.d/audit
 /etc/logrotate.d/v6d
-/etc/logrotate.d/xapi
 /etc/pam.d/xapi
+/etc/cron.d/xapi-logrotate.cron
 /etc/cron.daily/license-check
 /etc/rc.d/init.d/management-interface
 /etc/rc.d/init.d/perfmon
@@ -222,6 +222,8 @@ rm -rf $RPM_BUILD_ROOT
 /etc/xapi.d/plugins/install-supp-pack
 /etc/xapi.d/plugins/disk-space
 /etc/xapi.d/extensions
+/etc/xapi.d/xapi-logrotate.conf
+%attr(0755,root,root) /etc/xapi.d/xapi-logrotate.sh
 %config(noreplace) /etc/xensource/db.conf
 %config(noreplace) /etc/xensource/db.conf.rio
 /etc/xensource/master.d/01-example

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -222,8 +222,7 @@ rm -rf $RPM_BUILD_ROOT
 /etc/xapi.d/plugins/install-supp-pack
 /etc/xapi.d/plugins/disk-space
 /etc/xapi.d/extensions
-/etc/xapi.d/xapi-logrotate.conf
-%attr(0755,root,root) /etc/xapi.d/xapi-logrotate.sh
+%config(noreplace) /etc/xensource/xapi-logrotate.conf
 %config(noreplace) /etc/xensource/db.conf
 %config(noreplace) /etc/xensource/db.conf.rio
 /etc/xensource/master.d/01-example
@@ -312,6 +311,7 @@ rm -rf $RPM_BUILD_ROOT
 @OPTDIR@/libexec/update-mh-info
 @OPTDIR@/libexec/upload-wrapper
 @OPTDIR@/libexec/xapi-health-check
+@OPTDIR@/libexec/xapi-logrotate.sh
 @OPTDIR@/libexec/xapi-rolling-upgrade
 @OPTDIR@/libexec/xha-lc
 @OPTDIR@/libexec/xe-syslog-reconfigure


### PR DESCRIPTION
A new cron job calls a new shell-script which calls logrotate
with a new configuration file (based on the old one).

The job runs once per minute, and as well as rotating daily,
it rotates if the file is larger than 100M.
