### PR TITLE
Remove warning 3 (deprecated feature)

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -34,7 +34,7 @@ if $(equal $(DISABLE_WARN_ERROR), true)
 else
   WARN = -warn-error
 
-OCAMLFLAGS = -g -dtypes -bin-annot -thread $(WARN) +a-4-6-9-27-28-29
+OCAMLFLAGS = -g -dtypes -bin-annot -thread $(WARN) +a-3-4-6-9-27-28-29
 
 # c compiling stuff
 OCAMLCFLAGS += -g


### PR DESCRIPTION
We need this because mutable Strings are deprecated.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>