### PR TITLE
CP-14531: Configurable outgoing TLS ciphersuites

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -693,6 +693,11 @@ let set_stunnel_timeout () =
 (* Consult inventory, because to do DB lookups we must contact the
  * master, and to do that we need to start an outgoing stunnel. *)
 let set_stunnel_legacy_inv ~__context () =
+  Stunnel.set_good_ciphersuites (match !Xapi_globs.ciphersuites_good_outbound with
+    | None -> raise (Api_errors.Server_error (Api_errors.internal_error,["Configuration file does not specify ciphersuites-good-outbound."]))
+    | Some s -> s
+  );
+  Stunnel.set_legacy_ciphersuites !Xapi_globs.ciphersuites_legacy_outbound;
   let s = Xapi_inventory.lookup Xapi_inventory._stunnel_legacy ~default:"true" in
   let legacy = try
 	  bool_of_string s

--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -64,8 +64,8 @@ writeconffile () {
     # interface is enabled or disabled.
     . /etc/xensource-inventory
 
-    # (This "good" list must match, or at least contain one of, the
-    # good_ciphers in xen-api-libs-transitional/stunnel/stunnel.ml)
+    # (This "good" list must match, or at least contain one of,
+    #  the ciphersuites-good-outbound list in /etc/xapi.conf.)
     GOOD_CIPHERS='RSA+AES128-SHA'
     BACK_COMPAT_CIPHERS='RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA'
 

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -71,6 +71,17 @@ igd-passthru-vendor-whitelist = 8086
 # kinds of Intel hardware.
 # gvt-g-whitelist = /etc/gvt-g-whitelist
 
+# Preferred ciphersuites used for outgoing TLS connections.
+# This string is used for the "ciphers" field in stunnel configuration.
+# This "good" list must match, or at least contain one of,
+# the GOOD_CIPHERS in @LIBEXECDIR@/xapissl
+ciphersuites-good-outbound = !EXPORT:RSA+AES128-SHA
+
+# Additional ciphersuites for backward compatibility in outgoing
+# TLS connections, used in addition to "ciphersuites-good-outbound"
+# if the host has ssl_legacy=true.
+ciphersuites-legacy-outbound = RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA
+
 # Paths to utilities: ############################################
 
 search-path = @LIBEXECDIR@:@BINDIR@


### PR DESCRIPTION
Instead of being hard-coded in the Stunnel library module, these are
read from xapi.conf and passed to the Stunnel module on xapi start-up.

Compiling the new code relies on a corresponding change to the Stunnel
module in the xen-api-libs-transitional repository.
