### PR TITLE
CA-196701: Prevent hang during host shutdown

### DIFF
--- a/scripts/init.d-xapi-domains
+++ b/scripts/init.d-xapi-domains
@@ -6,6 +6,12 @@
 # chkconfig: 345 99 00
 # description: Start/stop XE VMs
 
+### BEGIN INIT INFO
+# Required-Start:    $remote_fs
+# Short-Description: Start/stop XE VMs
+# Description: Stop domains automatically when domain 0 shuts down.
+### END INIT INFO
+
 SHUTDOWN="@LIBEXECDIR@/shutdown"
 
 if [ ! -e /proc/xen/privcmd ] || \


### PR DESCRIPTION
In some cases when there are running VMs on a remote filesystem like NFS
and the host is rebooted, the NFS mount is unmounted before xapi-domains
has run (to move or shutdown the VMs). The unmount fails because it is
in use. Later, after all processes have been killed, unmount is
attempted again which causes the host to hang because the network has
been shutdown.

To prevent the hang, add a dependency for xapi-domains on $remote_fs.
This means that during shutdown, xapi-domains will run before remote
filesystems are unmounted. The unmount will then succeed, preventing the
reboot from later hanging.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>