### PR TITLE
CP-14530: SHA-256 not SHA-1 for TLS (non-legacy)

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -66,7 +66,7 @@ writeconffile () {
 
     # (This "good" list must match, or at least contain one of,
     #  the ciphersuites-good-outbound list in /etc/xapi.conf.)
-    GOOD_CIPHERS='RSA+AES128-SHA'
+    GOOD_CIPHERS='RSA+AES128-SHA256'
     BACK_COMPAT_CIPHERS='RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA'
 
     if [ -n "${STUNNEL_IDLE_TIMEOUT}" ]; then

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -75,7 +75,7 @@ igd-passthru-vendor-whitelist = 8086
 # This string is used for the "ciphers" field in stunnel configuration.
 # This "good" list must match, or at least contain one of,
 # the GOOD_CIPHERS in @LIBEXECDIR@/xapissl
-ciphersuites-good-outbound = !EXPORT:RSA+AES128-SHA
+ciphersuites-good-outbound = !EXPORT:RSA+AES128-SHA256
 
 # Additional ciphersuites for backward compatibility in outgoing
 # TLS connections, used in addition to "ciphersuites-good-outbound"

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -80,7 +80,7 @@ ciphersuites-good-outbound = !EXPORT:RSA+AES128-SHA256
 # Additional ciphersuites for backward compatibility in outgoing
 # TLS connections, used in addition to "ciphersuites-good-outbound"
 # if the host has ssl_legacy=true.
-ciphersuites-legacy-outbound = RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA
+ciphersuites-legacy-outbound = RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+DES-CBC3-SHA
 
 # Paths to utilities: ############################################
 


### PR DESCRIPTION
For both incoming and outgoing TLS connections through
stunnel, when the host is not in ssl-legacy mode, the one
permitted ciphersuite uses SHA-256 rather than SHA-1 now.

(Also removed MD5 from the list of ciphersuites permitted
for outgoing stunnel connections when in ssl-legacy mode.)
