### PR TITLE
CA-197067: DB upgrade rule: has_vendor_device=false

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -405,6 +405,10 @@ module VM : HandlerTools = struct
 					}
 				end else vm_record
 			in
+			let vm_record =
+				if vm_has_field ~x ~name:"has_vendor_device" then vm_record else (
+					{vm_record with API.vM_has_vendor_device = false;}
+				) in
 			let vm_record = {vm_record with API.
 				vM_memory_overhead = Memory_check.vm_compute_memory_overhead vm_record
 			} in

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -132,12 +132,15 @@ let header_of_xmlrpc x =
     objects   = XMLRPC.From.array obj_of_xmlrpc (find _objects);
   }
 
+let vm_has_field ~(x: obj) ~name =
+  let structure = XMLRPC.From.structure x.snapshot in
+  List.mem_assoc name structure
+
 (* This function returns true when the VM record was created pre-ballooning. *)
 let vm_exported_pre_dmc (x: obj) = 
-  let structure = XMLRPC.From.structure x.snapshot in
   (* The VM.parent field was added in rel_midnight_ride, at the same time as ballooning.
      XXX: Replace this with something specific to the ballooning feature if possible. *)
-  not(List.mem_assoc "parent" structure)
+  not (vm_has_field ~x ~name:"parent")
 
 open Client
 

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -375,6 +375,15 @@ let add_default_pif_properties = {
 			(Db.PIF.get_all ~__context)
 }
 
+let default_has_vendor_device_false = {
+	description = "Defaulting has_vendor_device false";
+	version = (fun x -> x < dundee);
+	fn = fun ~__context ->
+		List.iter
+			(fun self -> Db.VM.set_has_vendor_device ~__context ~self ~value:false)
+			(Db.VM.get_all ~__context)
+}
+
 let populate_pgpu_vgpu_types = {
 	description = "Populating lists of VGPU types on existing PGPUs";
 	version = (fun x -> x <= clearwater);
@@ -497,6 +506,7 @@ let rules = [
 	populate_pgpu_vgpu_types;
 	set_vgpu_types;
 	add_default_pif_properties;
+	default_has_vendor_device_false;
 	remove_restricted_pbd_keys;
 	upgrade_recommendations_for_gpu_passthru;
 	set_tools_sr_field;


### PR DESCRIPTION
This is needed because the default value for VM.has_vendor_device
defined in the datamodel is used in two places:
* When upgrading the database from a version that lacks the field
  (where we want it false)
* When VM.create is called without specifying the field
  (where we want it true).

Therefore this new database upgrade rule sets has_vendor_device=false
for each VM, if the upgrade is from a version that lacks the field
(determined by checking whether it is a pre-dundee version).
