### PR TITLE
CA-197914: Avoid deadlock by ignoring suppression in set_resident_on

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -983,8 +983,7 @@ let handler req fd _ =
 							task |> wait_for_task queue_name dbg |> assume_task_succeeded queue_name dbg |> ignore
 						| None ->
 							debug "We did not get a task id to wait for!!"
-					end;
-					Xapi_xenops.set_resident_on ~__context ~self:vm
+					end
 				)
 			);
 


### PR DESCRIPTION
By waiting for event suppression to finish in set_resident_on,
localhost migration was deadlocking because pool_migrate_complete
was called with events suppressed on the sender, and this was
in turn calling set_resident_on.

This fix simply ignores event suppression during set_resident_on,
which is safe because we only call set_resident_on when the VM
is just starting, and so we should be protected by the VM's
current_operations.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>