### PR TITLE
CA-198283: Configure Stunnel in xsh for host-sync

### DIFF
--- a/ocaml/xapi/xapi_sync.ml
+++ b/ocaml/xapi/xapi_sync.ml
@@ -34,6 +34,12 @@ let sync_host ~__context host =
 				and remotepath = Printf.sprintf "%s:%s" address Xapi_globs.xapi_blob_location
 				and session = Xapi_session.slave_login ~__context ~host:(Helpers.get_localhost ~__context) ~psecret:!Xapi_globs.pool_secret in
 				Unix.putenv "XSH_SESSION" (Ref.string_of session);
+				Unix.putenv "XSH_SSL_LEGACY" (string_of_bool (Db.Host.get_ssl_legacy ~__context ~self:host));
+				(match !Xapi_globs.ciphersuites_good_outbound with
+					| Some c -> Unix.putenv "XSH_GOOD_CIPHERSUITES" c
+					| None -> raise (Api_errors.Server_error (Api_errors.internal_error,["Xapi_sync found no good ciphersuites in Xapi_globs."]))
+				);
+				Unix.putenv "XSH_LEGACY_CIPHERSUITES" !Xapi_globs.ciphersuites_legacy_outbound;
 
 				let output,log = Forkhelpers.execute_command_get_output
 					~env:(Unix.environment ())

--- a/ocaml/xsh/xsh.ml
+++ b/ocaml/xsh/xsh.ml
@@ -73,6 +73,12 @@ let open_tcp_ssl server =
 let _ =
   let host = Sys.argv.(1) in
   let cmd = Sys.argv.(2) in
+  Stunnel.set_legacy_protocol_and_ciphersuites_allowed
+	  (try bool_of_string (Sys.getenv "XSH_SSL_LEGACY") with _ -> failwith "ssl_legacy not specified");
+  Stunnel.set_good_ciphersuites
+	  (try Sys.getenv "XSH_GOOD_CIPHERSUITES" with _ -> failwith "Good ciphersuites not specified");
+  Stunnel.set_legacy_ciphersuites
+	  (try Sys.getenv "XSH_LEGACY_CIPHERSUITES" with _ -> "");
   let session = try Sys.getenv "XSH_SESSION" with _ -> failwith "Session not provided" in
   let args = List.map (fun arg -> "&arg="^arg) (List.tl (List.tl (List.tl (Array.to_list Sys.argv)))) in
   let req = Printf.sprintf "CONNECT /remotecmd?session_id=%s&cmd=%s%s http/1.0\r\n\r\n" session cmd (String.concat "" args) in


### PR DESCRIPTION
When synchronising non-database data across the pool, now
we honour xapi's ssl_legacy and ciphersuites settings.

Signed-off-by: Thomas Sanders <thomas.sanders@citrix.com>