### PR TITLE
CA-198613: Fix RPU from Boston

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1056,7 +1056,9 @@ let handler req fd _ =
                     task |> wait_for_task queue_name dbg |> assume_task_succeeded queue_name dbg |> ignore
                   | None ->
                     debug "We did not get a task id to wait for!!"
-                end
+                end;
+                (* Looks like this might be necessary for RPU from Boston *)
+                Xapi_xenops.set_resident_on ~__context ~self:vm
               )
           );
 


### PR DESCRIPTION
Boston doesn't call 'migrate_complete', and hence we need to do
a bit extra on the memory image handler.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>