### PR TITLE
CA-191314: Block SXM if it would break any HA plan

### DIFF
--- a/ocaml/idl/constants.ml
+++ b/ocaml/idl/constants.ml
@@ -124,6 +124,9 @@ let path xs = "/" ^ (String.concat "/" xs)
 (* Used to identify remote VDIs that are mirrors. Stored in VDI.other_config *)
 let storage_migrate_vdi_map_key = "maps_to"
 
+(* Used to identify remote SRs which will hold mirrored VDIs. Stored in VDI.other_config *)
+let storage_migrate_sr_map_key = "maps_to_sr"
+
 (* Used to specify mapping of VIFs to networks on the remote machine. Stored in VIF.other_config *)
 let storage_migrate_vif_map_key = "maps_to"
 

--- a/ocaml/test/test_ha_vm_failover.ml
+++ b/ocaml/test/test_ha_vm_failover.ml
@@ -349,18 +349,19 @@ module AssertNewVMPreservesHAPlan = Generic.Make(Generic.EncapsulateState(struct
 	module Io = struct
 		open Xapi_ha_vm_failover
 
-		type input_t = (pool * vm)
+		type input_t = (pool * vm * bool)
 		type output_t = (exn, unit) Either.t
 
-		let string_of_input_t = Test_printers.pair string_of_pool string_of_vm
+		let string_of_input_t =
+			Test_printers.(tuple3 string_of_pool string_of_vm bool)
 		let string_of_output_t = Test_printers.(either Printexc.to_string unit)
 	end
 
 	module State = XapiDb
 
-	let load_input __context (pool, _) = setup ~__context pool
+	let load_input __context (pool, _, _) = setup ~__context pool
 
-	let extract_output __context (pool, vm) =
+	let extract_output __context (pool, vm, in_db) =
 		let open Db_filter_types in
 		let local_sr =
 			Db.SR.get_refs_where ~__context
@@ -382,10 +383,47 @@ module AssertNewVMPreservesHAPlan = Generic.Make(Generic.EncapsulateState(struct
 				~expr:(Eq (Field "bridge", Literal "xenbr0"))
 			|> List.hd
 		in
-		let vm_ref =
-			load_vm ~__context ~vm ~local_sr ~shared_sr ~local_net ~shared_net in
+		let vm_resources =
+			if in_db then begin
+				let vm_ref =
+					load_vm ~__context ~vm ~local_sr ~shared_sr ~local_net ~shared_net in
+				Agility.VMResources.of_ref ~__context vm_ref
+			end else begin
+				let host = Helpers.get_master ~__context in
+				let local_srs =
+					if List.exists (fun (vbd:vbd) -> not vbd.agile) vm.vbds
+					then [local_sr] else []
+				in
+				let shared_srs =
+					if List.exists (fun (vbd:vbd) -> vbd.agile) vm.vbds
+					then [shared_sr] else []
+				in
+				let local_nets =
+					if List.exists (fun (vif:vif) -> not vif.agile) vm.vifs
+					then [local_net] else []
+				in
+				let shared_nets =
+					if List.exists (fun (vif:vif) -> vif.agile) vm.vifs
+					then [shared_net] else []
+				in
+				let vm_ref = make_vm ~__context
+					~ha_always_run:vm.ha_always_run
+					~ha_restart_priority:vm.ha_restart_priority
+					~memory_static_min:vm.memory ~memory_dynamic_min:vm.memory
+					~memory_dynamic_max:vm.memory ~memory_static_max:vm.memory
+					~name_label:vm.name_label ()
+				in
+				let vm_rec = Db.VM.get_record ~__context ~self:vm_ref in
+				Db.VM.destroy ~__context ~self:vm_ref;
+				Agility.VMResources.({
+					status = `Incoming host;
+					vm_rec;
+					networks = local_nets @ shared_nets;
+					srs = local_srs @ shared_srs;
+				})
+			end
+		in
 		try
-			let vm_resources = Agility.VMResources.of_ref ~__context vm_ref in
 			Either.Right
 				(Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context
 					vm_resources)
@@ -417,7 +455,8 @@ module AssertNewVMPreservesHAPlan = Generic.Make(Generic.EncapsulateState(struct
 				ha_restart_priority = "restart";
 				memory = gib 120L;
 				name_label = "vm2";
-			}
+			},
+			true
 		),
 		Either.Right ();
 		(* 2 host pool, two VMs using almost all of one host's memory;
@@ -447,7 +486,8 @@ module AssertNewVMPreservesHAPlan = Generic.Make(Generic.EncapsulateState(struct
 				ha_restart_priority = "restart";
 				memory = gib 120L;
 				name_label = "vm2";
-			}
+			},
+			true
 		),
 		Either.Left (Api_errors.(Server_error (ha_operation_would_break_failover_plan, [])));
 		(* 2 host pool which is already overcommitted. Attempting to add another VM
@@ -485,7 +525,8 @@ module AssertNewVMPreservesHAPlan = Generic.Make(Generic.EncapsulateState(struct
 				ha_restart_priority = "restart";
 				memory = gib 120L;
 				name_label = "vm2";
-			}
+			},
+			true
 		),
 		Either.Right ();
 	]

--- a/ocaml/test/test_ha_vm_failover.ml
+++ b/ocaml/test/test_ha_vm_failover.ml
@@ -113,12 +113,13 @@ let load_host ~__context ~host ~local_sr ~shared_sr ~local_net ~shared_net =
 	Db.Host_metrics.set_memory_total ~__context
 		~self:metrics ~value:host.memory_total;
 
-	let (_ : API.ref_VM list) =
-		List.map
-			(fun vm ->
-				load_vm ~__context ~vm ~local_sr ~shared_sr ~local_net ~shared_net)
-			host.vms
-	in
+	List.iter
+		(fun vm ->
+			let vm_ref =
+				load_vm ~__context ~vm ~local_sr ~shared_sr ~local_net ~shared_net in
+			if vm.running
+			then Db.VM.set_resident_on ~__context ~self:vm_ref ~value:host_ref)
+		host.vms;
 	host_ref
 
 let setup ~__context {master; slaves; ha_host_failures_to_tolerate} =

--- a/ocaml/test/test_ha_vm_failover.ml
+++ b/ocaml/test/test_ha_vm_failover.ml
@@ -384,8 +384,11 @@ module AssertNewVMPreservesHAPlan = Generic.Make(Generic.EncapsulateState(struct
 		in
 		let vm_ref =
 			load_vm ~__context ~vm ~local_sr ~shared_sr ~local_net ~shared_net in
-		try Either.Right
-			(Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm_ref)
+		try
+			let vm_resources = Agility.VMResources.of_ref ~__context vm_ref in
+			Either.Right
+				(Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context
+					vm_resources)
 		with e -> Either.Left e
 
 	(* n.b. incoming VMs have ha_always_run = false; otherwise they will be

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -213,12 +213,14 @@ let assert_can_restore_backup ~__context rpc session_id (x: header) =
 				existing_vms)
 		import_vms
 
-let assert_can_live_import __context rpc session_id vm_record =
+let assert_can_live_import __context rpc session_id state vm_record =
+	let pool = Helpers.get_pool ~__context in
+	let localhost = Helpers.get_localhost ~__context in
+
 	let assert_memory_available () =
-		let host = Helpers.get_localhost ~__context in
 		let host_mem_available =
 			Memory_check.host_compute_free_memory_with_maximum_compression
-				~__context ~host None in
+				~__context ~host:localhost None in
 		let main, shadow =
 			Memory_check.vm_compute_start_memory ~__context vm_record in
 		let mem_reqd_for_vm = Int64.add main shadow in
@@ -230,8 +232,46 @@ let assert_can_live_import __context rpc session_id vm_record =
 					Int64.to_string host_mem_available;
 				]))
 	in
-	if vm_record.API.vM_power_state = `Running || vm_record.API.vM_power_state = `Paused
-	then assert_memory_available ()
+
+	let assert_ha_plan_exists () =
+		if Db.Pool.get_ha_enabled ~__context ~self:pool then begin
+			(* Determine which SRs and networks the VM will use. *)
+			(* These are required for the HA planner to determine the VM's agility. *)
+			let srs = vm_record.API.vM_VBDs
+				|> List.map (fun vbd -> find_in_export (Ref.string_of vbd) state.export)
+				|> List.map (API.Legacy.From.vBD_t "")
+				|> List.filter (fun vbd -> not vbd.API.vBD_empty)
+				|> List.map (fun vbd -> find_in_export (Ref.string_of vbd.API.vBD_VDI) state.export)
+				|> List.map (API.Legacy.From.vDI_t "")
+				|> List.map (fun vdi -> List.assoc Constants.storage_migrate_sr_map_key vdi.API.vDI_other_config)
+				|> List.map Ref.of_string
+				|> Listext.List.setify
+			in
+			let networks = vm_record.API.vM_VIFs
+				|> List.map (fun vif -> find_in_export (Ref.string_of vif) state.export)
+				|> List.map (API.Legacy.From.vIF_t "")
+				|> List.map (fun vif -> List.assoc Constants.storage_migrate_vif_map_key vif.API.vIF_other_config)
+				|> List.map Ref.of_string
+				|> Listext.List.setify
+			in
+			let vm_resources = Agility.VMResources.({
+				status = `Incoming localhost;
+				vm_rec = vm_record;
+				networks;
+				srs;
+			}) in
+			if vm_record.API.vM_ha_restart_priority = Constants.ha_restart
+			then Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm_resources
+			else
+				Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context
+					~arriving:[localhost, vm_resources] ()
+		end
+	in
+
+	if List.mem vm_record.API.vM_power_state [ `Paused; `Running ] then begin
+		assert_memory_available ();
+		assert_ha_plan_exists ()
+	end
 
 (* The signature for a set of functions which we must provide to be able to import an object type. *)
 module type HandlerTools = sig
@@ -344,7 +384,7 @@ module VM : HandlerTools = struct
 			match import_action with
 			| Replace (_, vm_record) | Clean_import vm_record ->
 					if is_live config
-					then assert_can_live_import __context rpc session_id vm_record;
+					then assert_can_live_import __context rpc session_id state vm_record;
 					import_action
 			| _ -> import_action
 		end

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -795,13 +795,13 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			| None -> ()
 
 		let check_vm_preserves_ha_plan ~__context ~vm ~snapshot ~host =
+			let vm_resources =
+				Agility.VMResources.of_ref_and_record ~__context vm snapshot in
 			if true
 				&& (snapshot.API.vM_ha_restart_priority = Constants.ha_restart)
 				&& (not snapshot.API.vM_ha_always_run)
-			then
-				Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm
-			else
-				Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, (vm, snapshot)] ()
+			then Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm_resources
+			else Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, vm_resources] ()
 
 		(* README: Note on locking -- forward_to_suitable_host and reserve_memory_for_vm are only
 		   called in a context where the current_operations field for the VM object contains the

--- a/ocaml/xapi/xapi_ha_vm_failover.mli
+++ b/ocaml/xapi/xapi_ha_vm_failover.mli
@@ -14,6 +14,8 @@
 (**
  * @group High Availability (HA)
  *)
+
+module VMR = Agility.VMResources
  
 val all_protected_vms : __context:Context.t -> (API.ref_VM * API.vM_t) list 
 
@@ -32,11 +34,11 @@ type result =
 (** Passed to the planner to reason about other possible configurations, used to block operations which would 
     destroy the HA VM restart plan. *)
 type configuration_change = {
-  old_vms_leaving: (API.ref_host * (API.ref_VM * API.vM_t)) list;   (** existing VMs which are leaving *)
-  old_vms_arriving: (API.ref_host * (API.ref_VM * API.vM_t)) list;  (** existing VMs which are arriving *)
+  old_vms_leaving: (API.ref_host * VMR.t) list;                     (** existing VMs which are leaving *)
+  old_vms_arriving: (API.ref_host * VMR.t) list;                    (** existing VMs which are arriving *)
   hosts_to_disable: API.ref_host list;                              (** hosts to pretend to disable *)
   num_failures: int option;                                         (** new number of failures to consider *)
-  new_vms_to_protect: API.ref_VM list;                              (** new VMs to restart *)  
+  new_vms_to_protect: VMR.t list;                                   (** new VMs to restart *)
 }
 
 val no_configuration_change : configuration_change
@@ -51,7 +53,7 @@ val plan_for_n_failures : __context:Context.t -> all_protected_vms:((API.ref_VM 
 val compute_max_host_failures_to_tolerate : __context:Context.t -> ?live_set:API.ref_host list -> ?protected_vms:((API.ref_VM * API.vM_t) list) -> unit -> int64
 
 (** HA admission control functions: aim is to block operations which would make us become overcommitted: *)  
-val assert_vm_placement_preserves_ha_plan : __context:Context.t -> ?leaving:(API.ref_host * (API.ref_VM * API.vM_t)) list -> ?arriving:(API.ref_host * (API.ref_VM * API.vM_t)) list -> unit -> unit
+val assert_vm_placement_preserves_ha_plan : __context:Context.t -> ?leaving:(API.ref_host * VMR.t) list -> ?arriving:(API.ref_host * VMR.t) list -> unit -> unit
 val assert_host_disable_preserves_ha_plan : __context:Context.t -> API.ref_host -> unit
 val assert_nfailures_change_preserves_ha_plan : __context:Context.t -> int -> unit
-val assert_new_vm_preserves_ha_plan : __context:Context.t -> API.ref_VM -> unit
+val assert_new_vm_preserves_ha_plan : __context:Context.t -> VMR.t -> unit

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -89,8 +89,10 @@ let set_ha_restart_priority ~__context ~self ~value =
 	if true
 		&& current <> Constants.ha_restart
 		&& value = Constants.ha_restart then begin
-			if Db.VM.get_power_state ~__context ~self != `Halted then
-				Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context self;
+			if Db.VM.get_power_state ~__context ~self != `Halted then begin
+				Agility.VMResources.of_ref ~__context self |>
+				Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context
+			end;
 			let pool = Helpers.get_pool ~__context in
 			if Db.Pool.get_ha_enabled ~__context ~self:pool then
 				let (_: bool) = Xapi_ha_vm_failover.update_pool_status ~__context () in ()


### PR DESCRIPTION
The HA planner previously handled pairs of type `(API.ref_VM * API.vM_t)` - these changes replace this with a new type, `VMResources.t`, which can represent a VM which may or may not be in the local database. This allows the HA planner to take VMs into account when they are incoming via SXM.

When performing a VM metadata import, if the incoming VM is live and HA is enabled the metadata import code will construct a VMResources.t and pass this to the HA planner.