### PR TITLE
CA-201093: mail-alarm: Add formatter for log partition usage alerts

### DIFF
--- a/scripts/mail-alarm
+++ b/scripts/mail-alarm
@@ -264,6 +264,31 @@ class Dom0FSUsageAlarmETG(EmailTextGenerator):
              self.value * 100.0,
              self.alarm_trigger_level * 100.0)
 
+class Dom0LogFSUsageAlarmETG(EmailTextGenerator):
+    def __init__(self, cls, obj_uuid, value, alarm_trigger_level):
+        if alarm_trigger_level is None:
+            alarm_trigger_level = 0.9
+        if cls != 'VM':
+            raise Exception, "programmer error - this alarm should only be available for control domain VM"
+        self.params = get_VM_params(obj_uuid)
+        self.cls = cls
+        self.value = value
+        self.alarm_trigger_level = alarm_trigger_level
+
+    def generate_subject(self):
+        pool_name = get_pool_name()
+        return '[%s] %s Alarm: Log partition nearly full on "%s"' % (pool_name,
+                   branding.PRODUCT_BRAND, self.params['name_label'])
+
+    def generate_body(self):
+        return \
+            'The log partition usage on "%s" is at %.1f%%.\n' \
+            'This alarm is set to be triggered when log partition usage is more than %.1f%%.\n' \
+            '\n' % \
+            (self.params['name_label'],
+             self.value * 100.0,
+             self.alarm_trigger_level * 100.0)
+
 class Dom0MemUsageAlarmETG(EmailTextGenerator):
     def __init__(self, cls, obj_uuid, value, alarm_trigger_level):
         if alarm_trigger_level is None:
@@ -414,6 +439,8 @@ class XapiMessage:
                 etg = DiskUsageAlarmETG(self.cls, self.obj_uuid, value, alarm_trigger_period, alarm_trigger_level)
             elif name == 'fs_usage':
                 etg = Dom0FSUsageAlarmETG(self.cls, self.obj_uuid, value, alarm_trigger_level)
+            elif name == 'log_fs_usage':
+                etg = Dom0LogFSUsageAlarmETG(self.cls, self.obj_uuid, value, alarm_trigger_level)
             elif name == 'mem_usage':
                 etg = Dom0MemUsageAlarmETG(self.cls, self.obj_uuid, value, alarm_trigger_level)
             else:


### PR DESCRIPTION
Before this patch, emails would come in unformatted like the following:

    From: noreply@dt04
    To: simon.beaumont@citrix.com
    Date: Tue, 1 Mar 2016 17:34:00 +0000
    Subject: [dt04] XenServer Message: VM 88eea7dc-6b81-4a1e-a43d-86b3eb097fd5
    ALARM

    Field           Value
    -----           -----
    Name:           ALARM
    Priority:       3
    Class:          VM
    Object UUID:    88eea7dc-6b81-4a1e-a43d-86b3eb097fd5
    Timestamp:      20160301T17:33:53Z
    Message UUID:   4116332a-995e-57d1-a318-c9c06a08c918
    Pool name:      dt04
    Body:
    Parameter=log_fs_usage
    Value=0.040000
    Alarm trigger value=0.0
    Alarm trigger period=0

Now they come in formatted like this:

    From: noreply@dt04
    To: simon.beaumont@citrix.com
    Date: Tue, 1 Mar 2016 17:39:56 +0000
    Subject: [dt04] XenServer Alarm: Log partition nearly full on "Control domain
    on host: dt04"

    The log partition usage on "Control domain on host: dt04" is at 4.0%.
    This alarm is set to be triggered when log partition usage is more than 0.0%.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>