### PR TITLE
CA-203414: Upgrade CPU features in pool_migrate_complete after SXM

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -209,6 +209,7 @@ let pool_migrate_complete ~__context ~vm ~host =
   let dbg = Context.string_of_task __context in
   let queue_name = Xapi_xenops_queue.queue_of_vm ~__context ~self:vm in
   if Xapi_xenops.vm_exists_in_xenopsd queue_name dbg id then begin
+    Cpuid_helpers.update_cpu_flags ~__context ~vm ~host;
     Xapi_xenops.set_resident_on ~__context ~self:vm;
     Xapi_xenops.add_caches id;
     Xapi_xenops.refresh_vm ~__context ~self:vm;


### PR DESCRIPTION
The last_boot_CPU_flags field of a VM that is migrated to a newer-version host
in another pool (SXM) was not updated in the xapi DB. This would not make the
migration itself fail, because the receiving xenopsd upgrades the featureset
itself before restoring the domain. However, after the migration, xapi would
overwrite the featureset in xenopsd's VM metadata with the one from the xapi
DB, which was still out-of-date. For this reason, a following reboot may fail.

This patch ensures that the last_boot_CPU_flags field is updated immediately
after a cross-pool migration finishes, in the pool_migration_complete call.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>