### PR TITLE
CA-200924: Suppress events from xapi when calling some xenopsd APIs

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -168,7 +168,7 @@ let pool_migrate ~__context ~vm ~host ~options =
   let ip = Http.Url.maybe_wrap_IPv6_literal (Db.Host.get_address ~__context ~self:host) in
   let xenops_url = Printf.sprintf "http://%s/services/xenops?session_id=%s" ip session_id in
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
-  Xapi_xenops.Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid (fun () ->
+  Xapi_xenops.Events.with_suppressed __context vm queue_name dbg vm_uuid (fun () ->
       try
         Xapi_network.with_networks_attached_for_vm ~__context ~vm ~host (fun () ->
             (* XXX: PR-1255: the live flag *)
@@ -812,7 +812,7 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
       (* It's acceptable for the VM not to exist at this point; shutdown commutes with storage migrate *)
       begin
         try
-	  Xapi_xenops.Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid
+	  Xapi_xenops.Events.with_suppressed __context vm queue_name dbg vm_uuid
             (fun () ->
                migrate_with_retry ~__context queue_name dbg vm_uuid xenops_vdi_map xenops_vif_map remote.xenops_url;
                Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid)
@@ -878,7 +878,7 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
     error "Caught %s: cleaning up" (Printexc.to_string e);
 
     (* We do our best to tidy up the state left behind *)
-    Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid (fun () ->
+    Events.with_suppressed __context vm queue_name dbg vm_uuid (fun () ->
         try
           let _, state = XenopsAPI.VM.stat dbg vm_uuid in
           if Xenops_interface.(state.Vm.power_state = Suspended) then begin

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1307,30 +1307,37 @@ module Events_from_xenopsd = struct
 end
 
 module Events = struct
-  let suppressed_on = Hashtbl.create 10
+  let suppressed_xenopsd = Hashtbl.create 10
+  let suppressed_xapi = Hashtbl.create 10
   let suppressed_on_m = Mutex.create ()
   let suppressed_on_c = Condition.create ()
 
-  let are_suppressed vm =
-    Hashtbl.mem suppressed_on vm
+  let are_suppressed_xenopsd vm =
+    Hashtbl.mem suppressed_xenopsd vm
+
+  let are_suppressed_xapi vm =
+    Hashtbl.mem suppressed_xapi vm
 
   let with_suppressed __context self queue_name dbg vm_id f =
     debug "suppressing xenops and xapi events on VM: %s" vm_id;
     let module Client = (val make_client queue_name : XENOPS) in
     Mutex.execute suppressed_on_m (fun () ->
-      Hashtbl.add suppressed_on vm_id ()
+      Hashtbl.add suppressed_xenopsd vm_id ();
+      Hashtbl.add suppressed_xapi vm_id ()
     );
 
     finally f (fun () ->
       Mutex.execute suppressed_on_m (fun () ->
-        Hashtbl.remove suppressed_on vm_id;
-        if not (Hashtbl.mem suppressed_on vm_id) then begin
-          debug "re-enabled xenops and xapi events on VM: %s; refreshing VM" vm_id;
+        Hashtbl.remove suppressed_xenopsd vm_id;
+        if not (Hashtbl.mem suppressed_xenopsd vm_id) then begin
+          debug "re-enabled xenops events on VM: %s; refreshing VM" vm_id;
           Client.UPDATES.refresh_vm dbg vm_id;
           Events_from_xenopsd.wait queue_name dbg vm_id ();
+          Hashtbl.remove suppressed_xapi vm_id;
+          debug "re-enabled xapi events on VM: %s; refreshing VM" vm_id;
           Events_from_xapi.wait __context self;
-          Condition.broadcast suppressed_on_c;
-        end else while are_suppressed vm_id do
+          Condition.broadcast suppressed_on_c
+        end else while are_suppressed_xenopsd vm_id do
 	  debug "waiting for events to become re-enabled";
           Condition.wait suppressed_on_c suppressed_on_m
 	done;
@@ -1342,7 +1349,7 @@ end
 let update_vm ~__context id =
 	try
 		let open Vm in
-		if Events.are_suppressed id
+		if Events.are_suppressed_xenopsd id
 		then debug "xenopsd event: ignoring event for VM (VM %s migrating away)" id
 		else
 			let self = Db.VM.get_by_uuid ~__context ~uuid:id in
@@ -1618,7 +1625,7 @@ let update_vm ~__context id =
 let update_vbd ~__context (id: (string * string)) =
 	try
 		let open Vbd in
-		if Events.are_suppressed (fst id)
+		if Events.are_suppressed_xenopsd (fst id)
 		then debug "xenopsd event: ignoring event for VM (VM %s migrating away)" (fst id)
 		else
 			let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
@@ -1688,7 +1695,7 @@ let update_vbd ~__context (id: (string * string)) =
 
 let update_vif ~__context id =
 	try
-		if Events.are_suppressed (fst id)
+		if Events.are_suppressed_xenopsd (fst id)
 		then debug "xenopsd event: ignoring event for VIF (VM %s migrating away)" (fst id)
 		else
 			let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
@@ -1748,7 +1755,7 @@ let update_vif ~__context id =
 
 let update_pci ~__context id =
 	try
-		if Events.are_suppressed (fst id)
+		if Events.are_suppressed_xenopsd (fst id)
 		then debug "xenopsd event: ignoring event for PCI (VM %s migrating away)" (fst id)
 		else
 			let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
@@ -1814,7 +1821,7 @@ let update_pci ~__context id =
 
 let update_vgpu ~__context id =
 	try
-		if Events.are_suppressed (fst id)
+		if Events.are_suppressed_xenopsd (fst id)
 		then debug "xenopsd event: ignoring event for VGPU (VM %s migrating away)" (fst id)
 		else
 			let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
@@ -1913,35 +1920,35 @@ let rec events_watch ~__context queue_name from =
 					add_event ev;
 					match ev with 
 						| Vm id ->
-							if Events.are_suppressed id
+							if Events.are_suppressed_xenopsd id
 							then debug "ignoring xenops event on VM %s" id
 							else begin
 								debug "xenops event on VM %s" id;
 								update_vm ~__context id;
 							end
 						| Vbd id ->
-							if Events.are_suppressed (fst id)
+							if Events.are_suppressed_xenopsd (fst id)
 							then debug "ignoring xenops event on VBD %s.%s" (fst id) (snd id)
 							else begin
 								debug "xenops event on VBD %s.%s" (fst id) (snd id);
 								update_vbd ~__context id
 							end
 						| Vif id ->
-							if Events.are_suppressed (fst id)
+							if Events.are_suppressed_xenopsd (fst id)
 							then debug "ignoring xenops event on VIF %s.%s" (fst id) (snd id)
 							else begin
 								debug "xenops event on VIF %s.%s" (fst id) (snd id);
 								update_vif ~__context id
 							end
 						| Pci id ->
-							if Events.are_suppressed (fst id)
+							if Events.are_suppressed_xenopsd (fst id)
 							then debug "ignoring xenops event on PCI %s.%s" (fst id) (snd id)
 							else begin
 								debug "xenops event on PCI %s.%s" (fst id) (snd id);
 								update_pci ~__context id
 							end
 						| Vgpu id ->
-							if Events.are_suppressed (fst id)
+							if Events.are_suppressed_xenopsd (fst id)
 							then debug "ignoring xenops event on VGPU %s.%s" (fst id) (snd id)
 							else begin
 								debug "xenops event on VGPU %s.%s" (fst id) (snd id);
@@ -2096,7 +2103,7 @@ let events_from_xapi () =
 												try
 													let id = id_of_vm ~__context ~self:vm in
 													let resident_here = Db.VM.get_resident_on ~__context ~self:vm = localhost in
-													let suppressed = Events.are_suppressed id in
+													let suppressed = Events.are_suppressed_xapi id in
 													debug "Event on VM %s; resident_here = %b (suppression=%b)" id resident_here suppressed;
 													if resident_here && (not suppressed)
 													then Xenopsd_metadata.update ~__context ~self:vm |> ignore


### PR DESCRIPTION
This is a sticking plaster over the wound left by the severing of xenopsd from xapi. We'll need to address the synchronisation of metadata between the two daemons in a more careful fashion when we can be a bit more brutal about how the event interface works.