### PR TITLE
CA-204474: Wait for cancelled operations to finish before proceeding with hard shutdown/reboot

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -308,13 +308,12 @@ let hard_reboot ~__context ~vm =
 	match Db.VM.get_power_state ~__context ~self:vm with
 	| `Running
 	| `Paused ->
-		Xapi_xenops.shutdown ~__context ~self:vm None;
+		Xapi_xenops.reboot ~__context ~self:vm None
 	| `Halted ->
-		()
+		start ~__context ~vm ~start_paused:false ~force:false
 	| `Suspended ->
 		raise (Api_errors.Server_error (Api_errors.vm_bad_power_state, [Ref.string_of vm; Record_util.power_to_string `Running; Record_util.power_to_string `Suspended]))
-	end;
-	start ~__context ~vm ~start_paused:false ~force:false
+	end
 
 let clean_reboot ~__context ~vm =
 	update_vm_virtual_hardware_platform_version ~__context ~vm;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -269,7 +269,7 @@ let wait_for_tasks ~__context ~tasks =
 let cancel ~__context ~vm ~ops =
   let cancelled = List.filter_map (fun (task,op) ->
     if List.mem op ops then begin
-      debug "Cancelling VM.%s for VM.hard_shutdown/reboot" (Record_util.vm_operation_to_string op);
+      info "Cancelling VM.%s for VM.hard_shutdown/reboot" (Record_util.vm_operation_to_string op);
       Helpers.call_api_functions ~__context
         (fun rpc session_id -> try Client.Task.cancel ~rpc ~session_id ~task:(Ref.of_string task) with _ -> ());
       Some (Ref.of_string task)


### PR DESCRIPTION
Failing to do this has caused problems as it violates the principle that there should only be one operation per VM talking to xenopsd at a time.