### PR TITLE
SXM: Carry out the VDI/VIF map checks in assert_can_migrate

### DIFF
--- a/ocaml/test/OMakefile
+++ b/ocaml/test/OMakefile
@@ -52,6 +52,7 @@ OCAML_OBJS = \
 	test_pgpu_helpers \
 	test_storage_migrate_state \
 	test_vm_helpers \
+	test_vm_migrate \
 	test_xenopsd_metadata \
 	test_ca121350 \
 	test_workload_balancing \

--- a/ocaml/test/suite.ml
+++ b/ocaml/test/suite.ml
@@ -42,6 +42,7 @@ let base_suite =
 			Test_pgpu_helpers.test;
 			Test_storage_migrate_state.test;
 			Test_vm_helpers.test;
+			Test_vm_migrate.test;
 			Test_xenopsd_metadata.test;
 			Test_workload_balancing.test;
 			Test_cpuid_helpers.test;

--- a/ocaml/test/test_vm_migrate.ml
+++ b/ocaml/test/test_vm_migrate.ml
@@ -1,0 +1,68 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open OUnit
+open Test_common
+
+let mac1 = "00:00:00:00:00:01"
+let mac2 = "00:00:00:00:00:02"
+
+let test_infer_vif_map_empty () =
+	let __context = make_test_database () in
+	assert_equal
+		(Xapi_vm_migrate.infer_vif_map ~__context [] [])
+		[]
+
+let test_infer_vif_map () =
+	let __context = make_test_database () in
+	let vm_vif1 = make_vif ~__context ~mAC:mac1 () in
+	let vm_vif2 = make_vif ~__context ~mAC:mac2 () in
+	let snap_vif1 = make_vif ~__context ~mAC:mac1 () in
+	let snap_vif2 = make_vif ~__context ~mAC:mac2 () in
+	(* In reality this network won't be in the local database, but for our
+	 * purposes it is a meaningless UUID so it's OK for it to be in the local
+	 * database. *)
+	let network1 = make_network ~__context () in
+	(* Check that a map with a single VIF -> network pair is unchanged. *)
+	assert_equal
+		(Xapi_vm_migrate.infer_vif_map ~__context [vm_vif1] [vm_vif1, network1])
+		[vm_vif1, network1];
+	(* Check that a missing VIF is caught. *)
+	assert_raises
+		Api_errors.(Server_error (vif_not_in_map, [Ref.string_of vm_vif2]))
+		(fun () ->
+			Xapi_vm_migrate.infer_vif_map ~__context
+				[vm_vif1; vm_vif2]
+				[vm_vif1, network1]);
+	(* Check that a snapshot VIF is mapped implicitly. *)
+	let inferred_map =
+		Xapi_vm_migrate.infer_vif_map ~__context
+			[vm_vif1; snap_vif1]
+			[vm_vif1, network1]
+	in
+	assert_equal (List.assoc snap_vif1 inferred_map) network1;
+	(* Check that an orphaned, unmapped snapshot VIF is caught. *)
+	assert_raises
+		Api_errors.(Server_error (vif_not_in_map, [Ref.string_of snap_vif2]))
+		(fun () ->
+			Xapi_vm_migrate.infer_vif_map ~__context
+				[vm_vif1; snap_vif1; snap_vif2]
+				[vm_vif1, network1])
+
+let test =
+	"test_vm_migrate" >:::
+		[
+			"test_infer_vif_map_empty" >:: test_infer_vif_map_empty;
+			"test_infer_vif_map" >:: test_infer_vif_map;
+		]

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1000,15 +1000,20 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
       Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host:remote.dest_host
         ~remote:(remote.rpc, remote.session) ();
 
-    (* Ignore vdi_map for now since we won't be doing any mirroring. *)
     try
+      let vdi_map =
+        List.map (fun (vdi, sr) -> {
+            local_vdi_reference = vdi;
+            remote_vdi_reference = None;
+          })
+          vdi_map in
       let vif_map =
         List.map (fun (vif, network) -> {
             local_vif_reference = vif;
             remote_network_reference = network;
           })
           vif_map in
-      assert (inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map:[] ~vif_map ~dry_run:true ~live:true ~copy = [])
+      assert (inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~dry_run:true ~live:true ~copy = [])
     with Xmlrpc_client.Connection_reset ->
       raise (Api_errors.Server_error(Api_errors.cannot_contact_host, [remote.remote_ip]))
 


### PR DESCRIPTION
This is a subset of the changes from #2594 