### PR TITLE
CA-205589: Preserve has_vendor_device on DB upgrade

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -69,6 +69,12 @@ let cream_release_schema_minor_vsn = 73
 let indigo_release_schema_major_vsn = 5
 let indigo_release_schema_minor_vsn = 74
 
+(* This is to support upgrade from Dundee tech-preview versions and other nearly-Dundee versions.
+ * The field has_vendor_device was added while minor vsn was 90, then became meaningful later;
+ * the first published tech preview in which the feature was active had datamodel minor vsn 91. *)
+let meaningful_vm_has_vendor_device_schema_major_vsn = 5
+let meaningful_vm_has_vendor_device_schema_minor_vsn = 91
+
 let dundee_release_schema_major_vsn = 5
 let dundee_release_schema_minor_vsn = 91
 

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -52,6 +52,9 @@ let creedence = Datamodel.creedence_release_schema_major_vsn, Datamodel.creedenc
 let cream = Datamodel.cream_release_schema_major_vsn, Datamodel.cream_release_schema_minor_vsn
 let dundee = Datamodel.dundee_release_schema_major_vsn, Datamodel.dundee_release_schema_minor_vsn
 
+(* This is to support upgrade from Dundee tech-preview versions *)
+let vsn_with_meaningful_has_vendor_device = Datamodel.meaningful_vm_has_vendor_device_schema_major_vsn, Datamodel.meaningful_vm_has_vendor_device_schema_minor_vsn
+
 let upgrade_alert_priority = {
 	description = "Upgrade alert priority";
 	version = (fun _ -> true);
@@ -377,7 +380,7 @@ let add_default_pif_properties = {
 
 let default_has_vendor_device_false = {
 	description = "Defaulting has_vendor_device false";
-	version = (fun x -> x < dundee);
+	version = (fun x -> x < vsn_with_meaningful_has_vendor_device);
 	fn = fun ~__context ->
 		List.iter
 			(fun self -> Db.VM.set_has_vendor_device ~__context ~self ~value:false)


### PR DESCRIPTION
We already had a DB upgrade rule to set VM.has_vendor_device to false
on upgrade from a pre-Dundee version of the DB schema.

Now instead of "pre-Dundee", the rule is applied if the schema version
is older than the first tech-preview in which the has_vendor_device
field controlled the presence of the device. (In the previous schema
version and tech preview, the field was present but had no effect.)