### PR TITLE
CA-203169: let xenopsd work out whether PV drivers are detected

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -877,10 +877,6 @@ let vm_record rpc session_id vm =
 			make_field ~name:"networks"
 				~get:(fun () -> default nid (may (fun m -> Record_util.s2sm_to_string "; " m.API.vM_guest_metrics_networks) (xgm ()) ))
 				~get_map:(fun () -> default [] (may (fun m -> m.API.vM_guest_metrics_networks) (xgm ()))) ();
-			make_field ~name:"network-paths-optimized"
-				~get:(fun () -> default nid (may (fun m -> string_of_bool m.API.vM_guest_metrics_network_paths_optimized) (xgm ()) )) ();
-			make_field ~name:"storage-paths-optimized"
-				~get:(fun () -> default nid (may (fun m -> string_of_bool m.API.vM_guest_metrics_storage_paths_optimized) (xgm ()) )) ();
 			make_field ~name:"PV-drivers-detected"
 				~get:(fun () -> default nid (may (fun m -> string_of_bool m.API.vM_guest_metrics_PV_drivers_detected) (xgm ()) )) ();
 			make_field ~name:"other"

--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -881,6 +881,8 @@ let vm_record rpc session_id vm =
 				~get:(fun () -> default nid (may (fun m -> string_of_bool m.API.vM_guest_metrics_network_paths_optimized) (xgm ()) )) ();
 			make_field ~name:"storage-paths-optimized"
 				~get:(fun () -> default nid (may (fun m -> string_of_bool m.API.vM_guest_metrics_storage_paths_optimized) (xgm ()) )) ();
+			make_field ~name:"PV-drivers-detected"
+				~get:(fun () -> default nid (may (fun m -> string_of_bool m.API.vM_guest_metrics_PV_drivers_detected) (xgm ()) )) ();
 			make_field ~name:"other"
 				~get:(fun () -> default nid (may (fun m -> Record_util.s2sm_to_string "; " m.API.vM_guest_metrics_other) (xgm ()) ))
 				~get_map:(fun () -> default [] (may (fun m -> m.API.vM_guest_metrics_other) (xgm()))) ();

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -69,11 +69,14 @@ let cream_release_schema_minor_vsn = 73
 let indigo_release_schema_major_vsn = 5
 let indigo_release_schema_minor_vsn = 74
 
+let dundee_tech_preview_release_schema_major_vsn = 5
+let dundee_tech_preview_release_schema_minor_vsn = 91
+
 (* This is to support upgrade from Dundee tech-preview versions and other nearly-Dundee versions.
  * The field has_vendor_device was added while minor vsn was 90, then became meaningful later;
  * the first published tech preview in which the feature was active had datamodel minor vsn 91. *)
-let meaningful_vm_has_vendor_device_schema_major_vsn = 5
-let meaningful_vm_has_vendor_device_schema_minor_vsn = 91
+let meaningful_vm_has_vendor_device_schema_major_vsn = dundee_tech_preview_release_schema_major_vsn
+let meaningful_vm_has_vendor_device_schema_minor_vsn = dundee_tech_preview_release_schema_minor_vsn
 
 let dundee_release_schema_major_vsn = 5
 let dundee_release_schema_minor_vsn = 93
@@ -81,6 +84,13 @@ let dundee_release_schema_minor_vsn = 93
 (* the schema vsn of the last release: used to determine whether we can upgrade or not.. *)
 let last_release_schema_major_vsn = cream_release_schema_major_vsn
 let last_release_schema_minor_vsn = cream_release_schema_minor_vsn
+
+(* List of tech-preview releases. Fields in these releases are not guaranteed to be retained when
+ * upgrading to a full release. *)
+let tech_preview_releases = [
+	vgpu_tech_preview_release_schema_major_vsn,   vgpu_tech_preview_release_schema_minor_vsn;
+	dundee_tech_preview_release_schema_major_vsn, dundee_tech_preview_release_schema_minor_vsn;
+]
 
 (** Bindings for currently specified releases *)
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7425,19 +7425,9 @@ let vm_guest_metrics =
       field ~qualifier:DynamicRO ~ty:Bool ~in_oss_since:None
         ~lifecycle:[
           Published, rel_rio, "true if the PV drivers appear to be up to date";
-          Deprecated, rel_dundee, "Deprecated in favour of network_paths_optimized and storage_paths_optimized, and redefined in terms of them"
+          Deprecated, rel_dundee, "Deprecated in favour of PV_drivers_detected, and redefined in terms of it"
         ]
-      "PV_drivers_up_to_date" "Logical AND of network_paths_optimized and storage_paths_optimized";
-      field ~qualifier:DynamicRO ~ty:Bool ~in_oss_since:None ~default_value:(Some (VBool false))
-        ~lifecycle:[
-          Published, rel_dundee, "Network paths are optimized with backend";
-        ]
-      "network_paths_optimized" "True if the network paths are optimized with PV driver";
-      field ~qualifier:DynamicRO ~ty:Bool ~in_oss_since:None ~default_value:(Some (VBool false))
-        ~lifecycle:[
-          Published, rel_dundee, "Storage paths are optimized with backend";
-        ]
-      "storage_paths_optimized" "True if the storage paths are optimized with PV driver";
+      "PV_drivers_up_to_date" "Logically equivalent to PV_drivers_detected";
       field ~qualifier:DynamicRO ~ty:(Map(String, String))
         ~lifecycle:[
           Published, rel_rio, "free/used/total";

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 92
+let schema_minor_vsn = 93
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -76,7 +76,7 @@ let meaningful_vm_has_vendor_device_schema_major_vsn = 5
 let meaningful_vm_has_vendor_device_schema_minor_vsn = 91
 
 let dundee_release_schema_major_vsn = 5
-let dundee_release_schema_minor_vsn = 91
+let dundee_release_schema_minor_vsn = 93
 
 (* the schema vsn of the last release: used to determine whether we can upgrade or not.. *)
 let last_release_schema_major_vsn = cream_release_schema_major_vsn
@@ -7457,6 +7457,7 @@ let vm_guest_metrics =
       field ~qualifier:DynamicRO ~in_product_since:rel_orlando ~default_value:(Some (VBool false)) ~ty:Bool "live" "True if the guest is sending heartbeat messages via the guest agent";
       field ~qualifier:DynamicRO ~lifecycle:[Published, rel_dundee, "To be used where relevant and available instead of checking PV driver version."] ~ty:tristate_type ~default_value:(Some (VEnum "unspecified")) "can_use_hotplug_vbd" "The guest's statement of whether it supports VBD hotplug, i.e. whether it is capable of responding immediately to instantiation of a new VBD by bringing online a new PV block device. If the guest states that it is not capable, then the VBD plug and unplug operations will not be allowed while the guest is running.";
       field ~qualifier:DynamicRO ~lifecycle:[Published, rel_dundee, "To be used where relevant and available instead of checking PV driver version."] ~ty:tristate_type ~default_value:(Some (VEnum "unspecified")) "can_use_hotplug_vif" "The guest's statement of whether it supports VIF hotplug, i.e. whether it is capable of responding immediately to instantiation of a new VIF by bringing online a new PV network device. If the guest states that it is not capable, then the VIF plug and unplug operations will not be allowed while the guest is running.";
+      field ~qualifier:DynamicRO ~lifecycle:[Published, rel_dundee, ""] ~ty:Bool ~default_value:(Some (VBool false)) "PV_drivers_detected" "At least one of the guest's devices has successfully connected to the backend.";
     ]
     ()
 

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -549,8 +549,6 @@ module GuestMetrics : HandlerTools = struct
 			~memory:gm_record.API.vM_guest_metrics_memory
 			~disks:gm_record.API.vM_guest_metrics_disks
 			~networks:gm_record.API.vM_guest_metrics_networks
-			~network_paths_optimized:gm_record.API.vM_guest_metrics_network_paths_optimized
-			~storage_paths_optimized:gm_record.API.vM_guest_metrics_storage_paths_optimized
 			~pV_drivers_detected:gm_record.API.vM_guest_metrics_PV_drivers_detected
 			~other:gm_record.API.vM_guest_metrics_other
 			~last_updated:gm_record.API.vM_guest_metrics_last_updated

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -551,6 +551,7 @@ module GuestMetrics : HandlerTools = struct
 			~networks:gm_record.API.vM_guest_metrics_networks
 			~network_paths_optimized:gm_record.API.vM_guest_metrics_network_paths_optimized
 			~storage_paths_optimized:gm_record.API.vM_guest_metrics_storage_paths_optimized
+			~pV_drivers_detected:gm_record.API.vM_guest_metrics_PV_drivers_detected
 			~other:gm_record.API.vM_guest_metrics_other
 			~last_updated:gm_record.API.vM_guest_metrics_last_updated
 			~other_config:gm_record.API.vM_guest_metrics_other_config

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -387,6 +387,17 @@ let default_has_vendor_device_false = {
 			(Db.VM.get_all ~__context)
 }
 
+let default_pv_drivers_detected_false = {
+	description = "Defaulting PV_drivers_detected false";
+	version = (fun x -> x < dundee);
+	fn = fun ~__context ->
+		List.iter
+			(fun self ->
+				let gm = Db.VM.get_guest_metrics ~__context ~self in
+				Db.VM_guest_metrics.set_PV_drivers_detected ~__context ~self:gm ~value:false)
+			(Db.VM.get_all ~__context)
+}
+
 let populate_pgpu_vgpu_types = {
 	description = "Populating lists of VGPU types on existing PGPUs";
 	version = (fun x -> x <= clearwater);
@@ -498,6 +509,7 @@ let rules = [
 	set_vgpu_types;
 	add_default_pif_properties;
 	default_has_vendor_device_false;
+	default_pv_drivers_detected_false;
 	remove_restricted_pbd_keys;
 	upgrade_recommendations_for_gpu_passthru;
 ]

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -273,7 +273,7 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
 	      let new_ref = Ref.make () and new_uuid = Uuid.to_string (Uuid.make_uuid ()) in
 	      Db.VM_guest_metrics.create ~__context ~ref:new_ref ~uuid:new_uuid
 		~os_version:os_version ~pV_drivers_version:pv_drivers_version ~pV_drivers_up_to_date:false ~memory:[] ~disks:[] ~networks:networks ~other:other
-		~storage_paths_optimized:false ~network_paths_optimized:false ~last_updated:(Date.of_float last_updated) ~other_config:[] ~live:true ~can_use_hotplug_vbd:`unspecified ~can_use_hotplug_vif:`unspecified;
+		~storage_paths_optimized:false ~network_paths_optimized:false ~pV_drivers_detected:false ~last_updated:(Date.of_float last_updated) ~other_config:[] ~live:true ~can_use_hotplug_vbd:`unspecified ~can_use_hotplug_vif:`unspecified;
 	      Db.VM.set_guest_metrics ~__context ~self ~value:new_ref; 
 	      (* We've just set the thing to live, let's make sure it's not in the dead list *)
 		  let sl xs = String.concat "; " (List.map (fun (k, v) -> k ^ ": " ^ v) xs) in

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -98,33 +98,6 @@ let networks path (list: string -> string list) =
 		|> List.map (fun (path, prefix) -> find_all_ips path prefix)
 		|> List.concat
 
-(* This function is passed the "device/vif" node, a function it can use to
- * find the directory listing of sub-nodes and a function to retrieve the value
- * with the given path.
- * If "state" of all VIFs are "4", the return value is true
- * which means the network paths are optimized.
- * Or else the return value is false.
- *)
-let network_paths_optimized path (list: string -> string list) (lookup: string -> string option) =
-	List.fold_left (fun result vif_id ->
-		let vif_state = lookup (extend (extend path vif_id) "state") in
-		result && (vif_state = Some "4")
-	) true (list path)
-
-(* This function is passed the "device/vbd" node, a function it can use to
- * find the directory listing of sub-nodes and a function to retrieve the value
- * with the given path.
- * If "state" of all VBDs (except cdrom) are "4", the return value is true
- * which means the storage paths are optimized.
- * Or else the return value is false.
- *)
-let storage_paths_optimized path (list: string -> string list) (lookup: string -> string option) =
-	List.fold_left (fun result vbd_id ->
-		let vbd_state = lookup (extend (extend path vbd_id) "state") in
-		let vbd_type = lookup (extend (extend path vbd_id) "device-type") in
-		result && (vbd_state = Some "4" || vbd_type = Some "cdrom")
-	) true (list path)
-
 (* One key is placed in the other map per control/* key in xenstore. This
    catches keys like "feature-shutdown" "feature-hibernate" "feature-reboot"
    "feature-sysrq" *)
@@ -145,9 +118,6 @@ type guest_metrics_t = {
     other: m;
     memory: m;
     device_id: m;
-    network_paths_optimized: bool;
-    storage_paths_optimized: bool;
-    pv_drivers_up_to_date: bool;
     last_updated: float;
     can_use_hotplug_vbd: API.tristate_type;
     can_use_hotplug_vif: API.tristate_type;
@@ -182,14 +152,10 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
   and networks = to_map (networks "attr" list)
   and other = List.append (to_map (other all_control)) ts
   and memory = to_map memory
-  and network_paths_optimized = network_paths_optimized "device/vif" list lookup
-  and storage_paths_optimized = storage_paths_optimized "device/vbd" list lookup
   and last_updated = Unix.gettimeofday () in
   let can_use_hotplug_vbd = get_tristate "feature/hotplug/vbd" in
   let can_use_hotplug_vif = get_tristate "feature/hotplug/vif" in
 
-  let pv_drivers_up_to_date = network_paths_optimized && storage_paths_optimized in
-  
   (* let num = Mutex.execute mutex (fun () -> Hashtbl.fold (fun _ _ c -> 1 + c) cache 0) in 
   debug "Number of entries in hashtbl: %d" num; *)
 
@@ -222,9 +188,6 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
 		  other = [];
 		  memory = [];
 		  device_id = [];
-		  network_paths_optimized = false;
-		  storage_paths_optimized = false;
-		  pv_drivers_up_to_date = false;
 		  last_updated = 0.0;
 		  can_use_hotplug_vbd = `unspecified;
 		  can_use_hotplug_vif = `unspecified;
@@ -237,7 +200,7 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
   then begin
 
       (* Only if the data is valid, cache it (CA-20353) *)
-      Mutex.execute mutex (fun () -> Hashtbl.replace cache domid {pv_drivers_version; os_version; networks; other; memory; device_id; network_paths_optimized; storage_paths_optimized; pv_drivers_up_to_date; last_updated; can_use_hotplug_vbd; can_use_hotplug_vif;});
+      Mutex.execute mutex (fun () -> Hashtbl.replace cache domid {pv_drivers_version; os_version; networks; other; memory; device_id; last_updated; can_use_hotplug_vbd; can_use_hotplug_vif;});
 
       (* We update only if any actual data has changed *)
       if ( guest_metrics_cached.pv_drivers_version <> pv_drivers_version 
@@ -248,13 +211,7 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
 	   ||
 	   guest_metrics_cached.other <> other
      ||
-     guest_metrics_cached.device_id <> device_id
-     ||
-     guest_metrics_cached.network_paths_optimized <> network_paths_optimized
-     ||
-     guest_metrics_cached.storage_paths_optimized <> storage_paths_optimized
-     ||
-     guest_metrics_cached.pv_drivers_up_to_date <> pv_drivers_up_to_date)
+     guest_metrics_cached.device_id <> device_id)
      ||
      guest_metrics_cached.can_use_hotplug_vbd <> can_use_hotplug_vbd
      ||
@@ -273,7 +230,7 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
 	      let new_ref = Ref.make () and new_uuid = Uuid.to_string (Uuid.make_uuid ()) in
 	      Db.VM_guest_metrics.create ~__context ~ref:new_ref ~uuid:new_uuid
 		~os_version:os_version ~pV_drivers_version:pv_drivers_version ~pV_drivers_up_to_date:false ~memory:[] ~disks:[] ~networks:networks ~other:other
-		~storage_paths_optimized:false ~network_paths_optimized:false ~pV_drivers_detected:false ~last_updated:(Date.of_float last_updated) ~other_config:[] ~live:true ~can_use_hotplug_vbd:`unspecified ~can_use_hotplug_vif:`unspecified;
+		~pV_drivers_detected:false ~last_updated:(Date.of_float last_updated) ~other_config:[] ~live:true ~can_use_hotplug_vbd:`unspecified ~can_use_hotplug_vif:`unspecified;
 	      Db.VM.set_guest_metrics ~__context ~self ~value:new_ref; 
 	      (* We've just set the thing to live, let's make sure it's not in the dead list *)
 		  let sl xs = String.concat "; " (List.map (fun (k, v) -> k ^ ": " ^ v) xs) in
@@ -292,15 +249,6 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
 	  if(guest_metrics_cached.other <> other) then begin
 	    Db.VM_guest_metrics.set_other ~__context ~self:gm ~value:other;
 	    Helpers.call_api_functions ~__context (fun rpc session_id -> Client.Client.VM.update_allowed_operations rpc session_id self);
-	  end;
-	  if(guest_metrics_cached.network_paths_optimized <> network_paths_optimized) then begin
-	  	Db.VM_guest_metrics.set_network_paths_optimized ~__context ~self:gm ~value:network_paths_optimized;
-	  end;
-	  if(guest_metrics_cached.storage_paths_optimized <> storage_paths_optimized) then begin
-	  	Db.VM_guest_metrics.set_storage_paths_optimized ~__context ~self:gm ~value:storage_paths_optimized;
-	  end;
-	  if(guest_metrics_cached.pv_drivers_up_to_date <> pv_drivers_up_to_date) then begin
-	  	Db.VM_guest_metrics.set_PV_drivers_up_to_date ~__context ~self:gm ~value:pv_drivers_up_to_date;
 	  end;
 	  if(guest_metrics_cached.can_use_hotplug_vbd <> can_use_hotplug_vbd) then begin
 	  	Db.VM_guest_metrics.set_can_use_hotplug_vbd ~__context ~self:gm ~value:can_use_hotplug_vbd;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1144,17 +1144,7 @@ let assert_can_set_has_vendor_device ~__context ~self ~value =
 	 * we allow restoration of a VM from a snapshot. *)
 	then Pool_features.assert_enabled ~__context ~f:Features.PCI_device_for_auto_update;
 
-	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:`Halted;
-
-	let old_val = Db.VM.get_has_vendor_device ~__context ~self in
-	if old_val <> value then (
-		let vm_gm = Db.VM.get_guest_metrics ~__context ~self in
-		let network_optimized = try Db.VM_guest_metrics.get_network_paths_optimized ~__context ~self:vm_gm with _ -> false in
-		let storage_optimized = try Db.VM_guest_metrics.get_storage_paths_optimized ~__context ~self:vm_gm with _ -> false in
-		if storage_optimized || network_optimized
-		then
-			raise (Api_errors.Server_error(Api_errors.vm_pv_drivers_in_use, [ Ref.string_of self ]))
-	)
+	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:`Halted
 
 let set_has_vendor_device ~__context ~self ~value =
 	assert_can_set_has_vendor_device ~__context ~self ~value;

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -858,6 +858,7 @@ let copy_guest_metrics ~__context ~vm =
 			~networks:all.API.vM_guest_metrics_networks
 			~network_paths_optimized:all.API.vM_guest_metrics_network_paths_optimized
 			~storage_paths_optimized:all.API.vM_guest_metrics_storage_paths_optimized
+			~pV_drivers_detected:all.API.vM_guest_metrics_PV_drivers_detected
 			~other:all.API.vM_guest_metrics_other
 			~last_updated:all.API.vM_guest_metrics_last_updated
 			~other_config:all.API.vM_guest_metrics_other_config

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -856,8 +856,6 @@ let copy_guest_metrics ~__context ~vm =
 			~memory:all.API.vM_guest_metrics_memory
 			~disks:all.API.vM_guest_metrics_disks
 			~networks:all.API.vM_guest_metrics_networks
-			~network_paths_optimized:all.API.vM_guest_metrics_network_paths_optimized
-			~storage_paths_optimized:all.API.vM_guest_metrics_storage_paths_optimized
 			~pV_drivers_detected:all.API.vM_guest_metrics_PV_drivers_detected
 			~other:all.API.vM_guest_metrics_other
 			~last_updated:all.API.vM_guest_metrics_last_updated

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1507,7 +1507,8 @@ let update_vm ~__context id =
 							(fun (_, state) ->
 								let gm = Db.VM.get_guest_metrics ~__context ~self in
 								debug "xenopsd event: Updating VM %s PV drivers detected %b" id state.pv_drivers_detected;
-								Db.VM_guest_metrics.set_PV_drivers_detected ~__context ~self:gm ~value:state.pv_drivers_detected
+								Db.VM_guest_metrics.set_PV_drivers_detected ~__context ~self:gm ~value:state.pv_drivers_detected;
+								Db.VM_guest_metrics.set_PV_drivers_up_to_date ~__context ~self:gm ~value:state.pv_drivers_detected
 							) info in
 					Opt.iter
 						(fun (_, state) ->

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1502,6 +1502,13 @@ let update_vm ~__context id =
 											error "Caught %s: while updating VM %s guest_agent" (Printexc.to_string e) id
 									) state.domids
 							) info in
+					let update_pv_drivers_detected () =
+						Opt.iter
+							(fun (_, state) ->
+								let gm = Db.VM.get_guest_metrics ~__context ~self in
+								debug "xenopsd event: Updating VM %s PV drivers detected %b" id state.pv_drivers_detected;
+								Db.VM_guest_metrics.set_PV_drivers_detected ~__context ~self:gm ~value:state.pv_drivers_detected
+							) info in
 					Opt.iter
 						(fun (_, state) ->
 							List.iter
@@ -1510,6 +1517,7 @@ let update_vm ~__context id =
 										debug "xenopsd event: VM %s domid %d uncooperative_balloon_driver = %b" id domid state.uncooperative_balloon_driver;
 									end;
 									if different (fun x -> x.guest_agent) then check_guest_agent ();
+									if different (fun x -> x.pv_drivers_detected) then update_pv_drivers_detected ();
 
 									if different (fun x -> x.xsdata_state) then begin
 										try


### PR DESCRIPTION
Track the value of PV_drivers_detected returned from xenopsd rather than deducing this as "storage_paths_optimized" and "network_paths_optimized" from the xenstore data exported from xenopsd.