### PR TITLE
CA-206602: Preserve Host.ssl_legacy on pool-join

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4071,6 +4071,7 @@ let host_create_params =
     {param_type=Map(String,String); param_name="license_server"; param_doc="Contact information of the license server"; param_release=midnight_ride_release; param_default=Some(VMap [VString "address", VString "localhost"; VString "port", VString "27000"])};
     {param_type=Ref _sr; param_name="local_cache_sr"; param_doc="The SR that is used as a local cache"; param_release=cowley_release; param_default=(Some (VRef (Ref.string_of Ref.null)))};
     {param_type=Map(String,String); param_name="chipset_info"; param_doc="Information about chipset features"; param_release=boston_release; param_default=Some(VMap [])};
+    {param_type=Bool; param_name="ssl_legacy"; param_doc="Allow SSLv3 protocol and ciphersuites as used by older XenServers. This controls both incoming and outgoing connections."; param_release=dundee_release; param_default=Some (VBool true)};
   ]
 
 let host_create = call
@@ -4659,7 +4660,7 @@ let host =
 		"chipset_info" "Information about chipset features";
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pci)) "PCIs" "List of PCI devices in the host";
 	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pgpu)) "PGPUs" "List of physical GPUs in the host";
-	field ~qualifier:DynamicRO ~lifecycle:[Published, rel_dundee, ""] ~ty:Bool ~default_value:(Some (VBool true)) "ssl_legacy" "Allow SSLv3 protocol and ciphersuites as used by older XenServers. This controls both incoming and outgoing connections. When this is set to a different value, the host immediately restarts its SSL/TLS listening service; typically this takes less than a second but existing connections to it will be broken. XenAPI login sessions will remain valid.";
+	field ~qualifier:StaticRO ~lifecycle:[Published, rel_dundee, ""] ~ty:Bool ~default_value:(Some (VBool true)) "ssl_legacy" "Allow SSLv3 protocol and ciphersuites as used by older XenServers. This controls both incoming and outgoing connections. When this is set to a different value, the host immediately restarts its SSL/TLS listening service; typically this takes less than a second but existing connections to it will be broken. XenAPI login sessions will remain valid.";
 	field ~qualifier:RW ~in_product_since:rel_tampa ~default_value:(Some (VMap [])) ~ty:(Map (String, String)) "guest_VCPUs_params" "VCPUs params to apply to all resident guests";
 	field ~qualifier:RW ~in_product_since:rel_cream ~default_value:(Some (VEnum "enabled")) ~ty:host_display "display" "indicates whether the host is configured to output its console to a physical display device";
 	field ~qualifier:DynamicRO ~in_product_since:rel_cream ~default_value:(Some (VSet [VInt 0L])) ~ty:(Set (Int)) "virtual_hardware_platform_versions" "The set of versions of the virtual hardware platform that the host can offer to its guests";

--- a/ocaml/test/test_common.ml
+++ b/ocaml/test/test_common.ml
@@ -51,6 +51,7 @@ let make_localhost ~__context =
 		machine_serial_name = None;
 		total_memory_mib = 1024L;
 		dom0_static_max = XenopsMemory.bytes_of_mib 512L;
+		ssl_legacy = false;
 	} in
 
 	Dbsync_slave.create_localhost ~__context host_info;
@@ -96,9 +97,9 @@ let make_vm ~__context ?(name_label="name_label") ?(name_description="descriptio
 let make_host ~__context ?(uuid=make_uuid ()) ?(name_label="host")
 		?(name_description="description") ?(hostname="localhost") ?(address="127.0.0.1")
 		?(external_auth_type="") ?(external_auth_service_name="") ?(external_auth_configuration=[])
-		?(license_params=[]) ?(edition="free") ?(license_server=[]) ?(local_cache_sr=Ref.null) ?(chipset_info=[]) () =
+		?(license_params=[]) ?(edition="free") ?(license_server=[]) ?(local_cache_sr=Ref.null) ?(chipset_info=[]) ?(ssl_legacy=false) () =
 
-	Xapi_host.create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info
+	Xapi_host.create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info ~ssl_legacy
 
 let make_pif ~__context ~network ~host ?(device="eth0") ?(mAC="C0:FF:EE:C0:FF:EE") ?(mTU=1500L)
 		?(vLAN=(-1L)) ?(physical=true) ?(ip_configuration_mode=`None) ?(iP="") ?(netmask="")

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -42,6 +42,7 @@ type host_info = {
 	machine_serial_name: string option;
 	total_memory_mib: int64;
 	dom0_static_max: int64;
+	ssl_legacy: bool;
 }
 
 (* NB: this is dom0's view of the world, not Xen's. *)
@@ -109,6 +110,10 @@ let read_localhost_info () =
 		machine_serial_name = lookup_inventory_nofail Xapi_inventory._machine_serial_name;
 		total_memory_mib = total_memory_mib;
 		dom0_static_max = dom0_static_max;
+		ssl_legacy = try (
+			bool_of_string (
+				Xapi_inventory.lookup Xapi_inventory._stunnel_legacy ~default:"true")
+		) with _ -> true;
 	}
 
 (** Returns the maximum of two values. *)

--- a/ocaml/xapi/create_misc.mli
+++ b/ocaml/xapi/create_misc.mli
@@ -26,6 +26,7 @@ type host_info = {
   machine_serial_name : string option;
   total_memory_mib : int64;
   dom0_static_max : int64;
+  ssl_legacy : bool;
 }
 
 val read_dom0_memory_usage : unit -> int64 option

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -52,7 +52,7 @@ let create_localhost ~__context info =
 	~hostname:info.hostname ~address:ip 
 	~external_auth_type:"" ~external_auth_service_name:"" ~external_auth_configuration:[] 
 	~license_params:[] ~edition:"" ~license_server:["address", "localhost"; "port", "27000"]
-	~local_cache_sr:Ref.null ~chipset_info:[]
+	~local_cache_sr:Ref.null ~chipset_info:[] ~ssl_legacy:info.ssl_legacy
     in ()		
 
 (* TODO cat /proc/stat for btime ? *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -565,7 +565,7 @@ let is_host_alive ~__context ~host =
 	false
   end
 
-let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info =
+let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~external_auth_type ~external_auth_service_name ~external_auth_configuration ~license_params ~edition ~license_server ~local_cache_sr ~chipset_info ~ssl_legacy =
 
   let make_new_metrics_object ref =
 	Db.Host_metrics.create ~__context ~ref
@@ -606,7 +606,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
 	~power_on_mode:""
 	~power_on_config:[]
 	~local_cache_sr
-	~ssl_legacy:true
+	~ssl_legacy
 	~guest_VCPUs_params:[]
 	~display:`enabled
 	~virtual_hardware_platform_versions:(if host_is_us then Xapi_globs.host_virtual_hardware_platform_versions else [0L])

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -87,6 +87,7 @@ val create :
   license_server:(string * string) list ->
   local_cache_sr:[ `SR ] Ref.t ->
   chipset_info:(string * string) list ->
+  ssl_legacy:bool ->
   [ `host ] Ref.t
 val destroy : __context:Context.t -> self:API.ref_host -> unit
 val declare_dead : __context:Context.t -> host:API.ref_host -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1722,17 +1722,15 @@ let assert_mac_seeds_available ~__context ~self ~seeds =
 		raise (Api_errors.Server_error
 			(Api_errors.duplicate_mac_seed, [StringSet.choose problem_mac_seeds]))
 
-let disable_ssl_legacy ~__context ~self =
+let set_ssl_legacy_on_each_host ~__context ~self ~value =
 	let f ~rpc ~session_id ~host =
-		Client.Host.set_ssl_legacy ~rpc ~session_id ~self:host ~value:false
+		Client.Host.set_ssl_legacy ~rpc ~session_id ~self:host ~value
 	in
 	Xapi_pool_helpers.call_fn_on_slaves_then_master ~__context f
 
-let enable_ssl_legacy ~__context ~self =
-	let f ~rpc ~session_id ~host =
-		Client.Host.set_ssl_legacy ~rpc ~session_id ~self:host ~value:true
-	in
-	Xapi_pool_helpers.call_fn_on_slaves_then_master ~__context f
+let disable_ssl_legacy = set_ssl_legacy_on_each_host ~value:false
+
+let enable_ssl_legacy = set_ssl_legacy_on_each_host ~value:true
 
 let has_extension ~__context ~self ~name =
 	try

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -386,6 +386,7 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
 				 * been added to the constructor. *)
 				~local_cache_sr
 				~chipset_info:host.API.host_chipset_info
+				~ssl_legacy:host.API.host_ssl_legacy
 			in
 
 			(* Copy other-config into newly created host record: *)


### PR DESCRIPTION
A new ssl_legacy parameter for the Host constructor message.

When a host is joining a pool and calls that constructor on the pool
master, supply the ssl_legacy parameter so as to maintain the existing
value.
