### PR TITLE
CP-16625 new quicktest option -template-uuid for template

### DIFF
--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -802,18 +802,20 @@ let with_vm s f =
     (* SKIP *)
     ()
 
-(** [with_vm' uuid session f] excutes [f session vm] on a freshly 
- * installed VM identified * by its [uuid]. The VM is uninstalled after
+(** [with_template uuid session f] excutes [f session vm] on a freshly 
+ * installed VM identified by template [uuid]. The VM is uninstalled after
  * execution *)
 
-let with_vm' uuid (session: 'a Ref.t) f = 
+let with_template uuid (session: 'a Ref.t) f = 
     let sprintf = Printf.sprintf in
-    let msg     = sprintf "Setting up VM %s" uuid in
+    let msg     = sprintf "Setting up VM frm template %s" uuid in
     let test    = make_test msg 0 in
       begin
         start test;
-        let vm = install_vm' test session uuid in f session vm;
-        uninstall_vm' test uuid;
+        let vm = install_vm' test session uuid in 
+            ( ignore (f session vm)
+            ; vm_uninstall test session vm
+            );
         success test;
       end
 
@@ -921,9 +923,9 @@ let _ =
 				maybe_run_test "vdi" (fun () -> vdi_test s);
 				maybe_run_test "async" (fun () -> async_test s);
 				maybe_run_test "import" (fun () -> import_export_test s);
-				maybe_run_test "vhd" (fun () -> with_vm' uuid s test_vhd_locking_hook);
-				maybe_run_test "powercycle" (fun () -> with_vm' uuid s vm_powercycle_test);
-				maybe_run_test "lifecycle" (fun () -> with_vm' uuid s Quicktest_lifecycle.test);
+				maybe_run_test "vhd" (fun () -> with_template uuid s test_vhd_locking_hook);
+				maybe_run_test "powercycle" (fun () -> with_template uuid s vm_powercycle_test);
+				maybe_run_test "lifecycle" (fun () -> with_template uuid s Quicktest_lifecycle.test);
 				maybe_run_test "copy" (fun () -> Quicktest_vdi_copy.start s sr);
 			with
 				| Api_errors.Server_error (a,b) ->

--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -905,9 +905,17 @@ let _ =
 		if List.mem name !tests_to_run then f () in
 
 	Stunnel.set_good_ciphersuites "!EXPORT:RSA+AES128-SHA256";
-	let s = init_session !username !password in
-        let all_srs = all_srs_with_vdi_create s in
-        let sr = List.hd all_srs in
+	let s = 
+    try
+      init_session !username !password 
+    with Unix.Unix_error(Unix.ENOENT, "connect",_) ->
+      begin
+        Printf.eprintf "failed to open local socket -- giving up\n";
+        exit 1
+      end
+    in
+  let all_srs = all_srs_with_vdi_create s in
+  let sr = List.hd all_srs in
 	finally
 		(fun () ->
 			(try

--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -604,8 +604,9 @@ let powercycle_test session_id vm =
 	start test;
 	(* avoid the race whereby reboot requests are ignored if too early *)
 	let delay () = 
-		debug test "Pausing for 10s";
-		Thread.delay 10. in
+        let secs = 2.0 in
+		debug test @@ Printf.sprintf "Pausing for %3.1fs" secs;
+		Thread.delay secs in
 	debug test (Printf.sprintf "Trying to enable VM.clone for suspended VMs pool-wide");
 	let pool = get_pool session_id in
 	let enabled_csvm = 

--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -862,13 +862,13 @@ let _ =
         | _             -> true
     in
     let default_tests   = List.filter is_default all_tests in
-    let template        = ref "uuid-for-vm-template---------------" in
+    let template        = ref "" in
 
 	let tests_to_run = ref default_tests in (* default is everything *)
     let sprintf = Printf.sprintf in
     let fprintf = Printf.fprintf in
 	Arg.parse [
-        "-template-uuid",
+    "-template-uuid",
             Arg.Set_string template,
             "UUID of VM template to use for tests";
 		"-xe-path", 
@@ -935,7 +935,11 @@ let _ =
 				maybe_run_test "async" (fun () -> async_test s);
 				maybe_run_test "import" (fun () -> import_export_test s);
 				maybe_run_test "vhd" (fun () -> with_template !template s test_vhd_locking_hook);
-				maybe_run_test "powercycle" (fun () -> with_template !template s vm_powercycle_test);
+				maybe_run_test "powercycle" (fun () -> 
+          (* fall back to old behavior if no template provided *)
+          match !template with
+          | ""    -> with_vm            s vm_powercycle_test 
+          | uuid  -> with_template uuid s vm_powercycle_test);
 				maybe_run_test "lifecycle" (fun () -> with_template !template s Quicktest_lifecycle.test);
 				maybe_run_test "copy" (fun () -> Quicktest_vdi_copy.start s sr);
 			with
@@ -944,3 +948,5 @@ let _ =
 				| e ->
 					output_string stderr (Printexc.to_string e))
 		) (fun () -> summarise ())
+
+(* vim: set ts=2 noet: *)

--- a/ocaml/xapi/quicktest_common.ml
+++ b/ocaml/xapi/quicktest_common.ml
@@ -199,13 +199,13 @@ let cli_cmd test args =
       failed test (Printexc.to_string e);
       failwith "CLI failed"
 
-(** [install_vm' test session uuid] installs a VM from a template 
+(** [install_vm_from_template uuid test session uuid] installs a VM from a template 
  * identified by its UUID *)
-let install_vm' test (session: 'a Ref.t)  template =
-  let label     = "quicktest-" ^ String.sub template 0 8 in
+let install_vm_from_template uuid test (session: 'a Ref.t)  =
+  let label     = "quicktest-" ^ String.sub uuid 0 8 in
   let vm_uuid   = cli_cmd test 
     [ "vm-install"
-    ; "template-uuid=" ^ template
+    ; "template-uuid=" ^ uuid
     ; "new-name-label=" ^ label 
     ] in
   let vm = Client.VM.get_by_uuid !rpc session vm_uuid in

--- a/ocaml/xapi/quicktest_common.ml
+++ b/ocaml/xapi/quicktest_common.ml
@@ -199,6 +199,23 @@ let cli_cmd test args =
       failed test (Printexc.to_string e);
       failwith "CLI failed"
 
+(** [install_vm' test session uuid] installs a VM from a template 
+ * identified by its UUID *)
+let install_vm' test (session: 'a Ref.t)  uuid_templ =
+  let label     = "quicktest-" ^ String.sub uuid_templ 0 8 in
+  let uuid_vm   = cli_cmd test 
+    [ "vm-install"
+    ; "template-uuid=" ^ uuid_templ
+    ; "new-name-label=" ^ label 
+    ] 
+  in
+    Client.VM.get_by_uuid !rpc session uuid_vm 
+
+(** [unistall_vm' test uuid] unistalls a VM identified by its UUID *)
+let uninstall_vm' (test:test_description) uuid =
+  ignore(cli_cmd test [ "vm-uninstall"; "uuid=" ^ uuid; "--force" ])
+
+
 let vm_install test session_id template name = 
   let newvm_uuid = cli_cmd test [ "vm-install"; "template-uuid=" ^ template; "new-name-label=" ^ name ] in
   Client.VM.get_by_uuid !rpc session_id newvm_uuid 

--- a/ocaml/xapi/quicktest_common.ml
+++ b/ocaml/xapi/quicktest_common.ml
@@ -201,19 +201,16 @@ let cli_cmd test args =
 
 (** [install_vm' test session uuid] installs a VM from a template 
  * identified by its UUID *)
-let install_vm' test (session: 'a Ref.t)  uuid_templ =
-  let label     = "quicktest-" ^ String.sub uuid_templ 0 8 in
-  let uuid_vm   = cli_cmd test 
+let install_vm' test (session: 'a Ref.t)  template =
+  let label     = "quicktest-" ^ String.sub template 0 8 in
+  let vm_uuid   = cli_cmd test 
     [ "vm-install"
-    ; "template-uuid=" ^ uuid_templ
+    ; "template-uuid=" ^ template
     ; "new-name-label=" ^ label 
-    ] 
-  in
-    Client.VM.get_by_uuid !rpc session uuid_vm 
-
-(** [unistall_vm' test uuid] unistalls a VM identified by its UUID *)
-let uninstall_vm' (test:test_description) uuid =
-  ignore(cli_cmd test [ "vm-uninstall"; "uuid=" ^ uuid; "--force" ])
+    ] in
+  let vm = Client.VM.get_by_uuid !rpc session vm_uuid in
+  let () = Client.VM.set_PV_args !rpc session vm "noninteractive" in
+    vm
 
 
 let vm_install test session_id template name = 

--- a/ocaml/xapi/quicktest_lifecycle.ml
+++ b/ocaml/xapi/quicktest_lifecycle.ml
@@ -134,7 +134,7 @@ let one s vm test =
 				if Client.VM.get_power_state !rpc s vm = `Halted
 				then Client.VM.start !rpc s vm false false;
 				(* wait for the guest to actually start up *)
-				Thread.delay 15.;
+				Thread.delay 2.; (* was 15.0, reduced for Unikernel *)
 
 				let call_api = function
 					| Shutdown Clean -> Client.VM.clean_shutdown !rpc s vm

--- a/ocaml/xapi/quicktest_lifecycle.ml
+++ b/ocaml/xapi/quicktest_lifecycle.ml
@@ -69,9 +69,13 @@ let string_of_test x =
 	| None             -> "Nothing       " 
 	| Some x           -> f x in
   Printf.sprintf "%s %s %s -> %s" 
-	  (dm string_of_api x.api) (dm string_of_parallel_op x.parallel_op) (string_of_code_path x.code_path)
-	  (match expected_result x with None -> "invalid" | Some y -> string_of_result y)
-open List
+	  (dm string_of_api x.api) 
+      (dm string_of_parallel_op x.parallel_op) 
+      (string_of_code_path x.code_path)
+	  ( match expected_result x with 
+      | None -> "invalid" 
+      | Some y -> string_of_result y
+      )
 
 let all_possible_tests =
   let all_api_variants x = 
@@ -89,11 +93,13 @@ let all_possible_tests =
   let all_code_path_variants x = 
 	[ { x with code_path = Sync };
 	  { x with code_path = Event };
-	  { x with code_path = Both } ] in
+	  { x with code_path = Both } ] 
+  in
+    [   { api = None ; parallel_op = None ; code_path = Sync } ]
+    |> List.map all_api_variants            |> List.concat
+    |> List.map all_parallel_op_variants    |> List.concat
+    |> List.map all_code_path_variants      |> List.concat
 
-  let xs = [ { api = None; parallel_op = None; code_path = Sync } ] in
-  concat (map all_code_path_variants (concat (map all_parallel_op_variants (concat (map all_api_variants xs)))))
-			
 let all_valid_tests = List.filter (fun t -> expected_result t <> None) all_possible_tests
 
 	  (*


### PR DESCRIPTION
Previously in `quicktest`, the name of the template used by tests `lifecycle`, `vhd` and `powercycle`was hard coded. This patch introduces a new option `-template-uuid` that takes the UUID for a template to use for these tests. As a consequence, this option should be used when running these tests. 

1. New option `-template-uuid`
2. Catch exception when no domain socket is found at startup of quicktest
3. Reduced some delays, assuming we will use a fast-booting uni-kernel in the future
4. Some code cleanup to get rid over overly long lines