### PR TITLE
CA-208614: On pool-join, copy ssl_legacy from master.

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -367,6 +367,12 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
 					create_or_get_sr_on_master __context rpc session_id (my_local_cache_sr, my_local_cache_sr_rec)
 				end in
 
+			(* Look up the value on the master of the pool we are about to join *)
+			let master_ssl = Client.Host.get_ssl_legacy ~rpc ~session_id ~self:(get_master rpc session_id) in
+			(* Set value in inventory (to control initial behaviour on next xapi start)
+			 * but not in the database of the current pool (the one we're about to leave) *)
+			Xapi_inventory.update Xapi_inventory._stunnel_legacy (string_of_bool master_ssl);
+
 			debug "Creating host object on master";
 			let ref = Client.Host.create ~rpc ~session_id
 				~uuid:my_uuid
@@ -386,7 +392,7 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
 				 * been added to the constructor. *)
 				~local_cache_sr
 				~chipset_info:host.API.host_chipset_info
-				~ssl_legacy:host.API.host_ssl_legacy
+				~ssl_legacy:master_ssl
 			in
 
 			(* Copy other-config into newly created host record: *)


### PR DESCRIPTION
When a host is about to join a new pool, it tells its soon-to-be new
pool-master to create a Host DB entry for it; now the host tells the
master to set the Host.ssl_legacy the same as the new master's value
(rather than preserving the host's value).

Also the host updates its local (non-DB) setting so that on next xapi
start (before it contacts the master to query the DB) it will use the
new setting.
