### PR TITLE
CA-209507: Clean up VGPU.scheduled_to_be_resident_on if VM.start fails

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -853,6 +853,16 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 		   choose_host_for_vm.
 		*)
 
+		(* Clear scheduled_to_be_resident_on for a VM and all its vGPUs. *)
+		let clear_scheduled_to_be_resident_on ~__context ~vm =
+			Db.VM.set_scheduled_to_be_resident_on ~__context ~self:vm ~value:Ref.null;
+			List.iter
+				(fun vgpu ->
+					Db.VGPU.set_scheduled_to_be_resident_on ~__context
+						~self:vgpu
+						~value:Ref.null)
+				(Db.VM.get_VGPUs ~__context ~self:vm)
+
 		(* Used by VM.start and VM.resume to choose a host with enough resource and to
 		   'allocate_vm_to_host' (ie set the 'scheduled_to_be_resident_on' field) *)
 		let forward_to_suitable_host ~local_fn ~__context ~vm ~snapshot ?host_op op =
@@ -873,12 +883,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 						(fun () ->
 							finally_clear_host_operation ~__context ~host:suitable_host ?host_op ();
 							(* In certain cases, VM might have been destroyed as a consequence of operation *)
-							if Db.is_valid_ref __context vm then begin
-								Db.VM.set_scheduled_to_be_resident_on ~__context ~self:vm ~value:Ref.null;
-								List.iter
-									(fun vgpu -> Db.VGPU.set_scheduled_to_be_resident_on ~__context ~self:vgpu ~value:Ref.null)
-									(Db.VM.get_VGPUs ~__context ~self:vm)
-							end))
+							if Db.is_valid_ref __context vm
+							then clear_scheduled_to_be_resident_on ~__context ~vm))
 
 		(* Used by VM.start_on, VM.resume_on, VM.migrate to verify a host has enough resource and to
 		   'allocate_vm_to_host' (ie set the 'scheduled_to_be_resident_on' field) *)
@@ -896,10 +902,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					Helpers.with_global_lock
 						(fun () ->
 							finally_clear_host_operation ~__context ~host ?host_op ();
-							Db.VM.set_scheduled_to_be_resident_on ~__context ~self:vm ~value:Ref.null;
-							List.iter
-								(fun vgpu -> Db.VGPU.set_scheduled_to_be_resident_on ~__context ~self:vgpu ~value:Ref.null)
-								(Db.VM.get_VGPUs ~__context ~self:vm)))
+							clear_scheduled_to_be_resident_on ~__context ~vm))
 
 		(**
 		   Used by VM.set_memory_dynamic_range to reserve enough memory for


### PR DESCRIPTION
Without this, the VGPU will be (incorrectly) accounted for in PGPU free
space calculations, even though the VM is not running or starting up.