### PR TITLE
DHCP on HIMN must advertise routers by default

### DIFF
--- a/ocaml/xapi/xapi_udhcpd.ml
+++ b/ocaml/xapi/xapi_udhcpd.ml
@@ -140,8 +140,8 @@ module Udhcpd_conf = struct
 		let network = Helpers.get_guest_installer_network ~__context in
 		let other_config = Db.Network.get_other_config ~__context ~self:network in
 		let include_gw =
-			try List.assoc ip_disable_gw_key other_config = "true"
-			with Not_found -> false in
+			try not (List.assoc ip_disable_gw_key other_config = "true")
+			with Not_found -> true in
 		let include_pxe =
 			try List.assoc pxe_server_key other_config = "true"
 			with Not_found -> false in


### PR DESCRIPTION
The advertising of the routers (gateway) can be disabled by setting an
other-config key on the HIMN. The meaning of this key was accidentally reversed
in 090dd2cf408c50930f547dac4aa4c759373a376f.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>