### PR TITLE
CP-16190: Add an API to set the status of Task

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3726,6 +3726,17 @@ let task_destroy = call ~flags:[`Session]
   ~params:[Ref _task, "self", "Reference to the task object"]
   ~allowed_roles:_R_READ_ONLY (* POOL_OP can destroy any tasks, others can destroy only owned tasks *)
   ()
+
+let task_set_status = call ~flags:[`Session]
+  ~in_oss_since:None
+  ~in_product_since:rel_ely
+  ~name:"set_status"
+  ~doc:"Set the task status"
+  ~params:[Ref _task, "self", "Reference to the task object";
+   status_type, "value", "task status value to be set"]
+  ~allowed_roles:_R_READ_ONLY (* POOL_OP can set status for any tasks, others can set status only for owned tasks *)
+  ()
+
 (* this permission allows to destroy any task, instead of only the owned ones *)
 let extra_permission_task_destroy_any = "task.destroy/any"
 
@@ -3736,7 +3747,7 @@ let task =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistNothing ~gen_constructor_destructor:false ~name:_task ~descr:"A long-running asynchronous task" ~gen_events:true
     ~doccomments:[] 
     ~messages_default_allowed_roles:_R_POOL_OP
-    ~messages: [ task_create; task_destroy; task_cancel ]
+    ~messages: [ task_create; task_destroy; task_cancel; task_set_status ]
     ~contents: ([
       uid _task;
       namespace ~name:"name" ~contents:(names oss_since_303 DynamicRO) ();

--- a/ocaml/idl/ocaml_backend/taskHelper.ml
+++ b/ocaml/idl/ocaml_backend/taskHelper.ml
@@ -53,8 +53,8 @@ let make ~__context ~http_other_config ?(description="") ?session_id ?subtask_of
   ref, uuid
 
 let rbac_assert_permission_fn = ref None (* required to break dep-cycle with rbac.ml *)
-let assert_can_destroy ?(ok_if_no_session_in_context=false) ~__context task_id =
-  let assert_permission_task_destroy_any () =
+let assert_op_valid ?(ok_if_no_session_in_context=false) ~__context task_id =
+  let assert_permission_task_op_any () =
     (match !rbac_assert_permission_fn with
       | None -> failwith "no taskhelper.rbac_assert_permission_fn" (* shouldn't ever happen *) 
       | Some fn -> fn ~__context ~permission:Rbac_static.permission_task_destroy_any
@@ -65,7 +65,7 @@ let assert_can_destroy ?(ok_if_no_session_in_context=false) ~__context task_id =
   | None -> (* no session in context *)
     if ok_if_no_session_in_context
     then () (* only internal xapi calls (eg db_gc) have no session in contexts, so rbac can be ignored *)
-    else assert_permission_task_destroy_any () (* will raise "no-session-in-context" exception *)
+    else assert_permission_task_op_any () (* will raise "no-session-in-context" exception *)
   | Some context_session ->
   let is_own_task =
   try
@@ -75,19 +75,19 @@ let assert_can_destroy ?(ok_if_no_session_in_context=false) ~__context task_id =
     (*debug "task_auth_user_sid=%s,context_auth_user_sid=%s" task_auth_user_sid context_auth_user_sid;*)
     (task_auth_user_sid = context_auth_user_sid)
   with e -> 
-    debug "assert_can_destroy: %s" (ExnHelper.string_of_exn e);
+    debug "assert_op_valid: %s" (ExnHelper.string_of_exn e);
     false
   in
   (*debug "IS_OWN_TASK=%b" is_own_task;*)
   (* 1. any subject can destroy its own tasks *)
   if not is_own_task then 
   (* 2. if not own task, has this session permission to destroy any tasks? *)
-  assert_permission_task_destroy_any ()
+  assert_permission_task_op_any ()
 
 let destroy ~__context task_id =
   if not (Ref.is_dummy task_id)  
   then (
-    assert_can_destroy ~ok_if_no_session_in_context:true ~__context task_id;
+    assert_op_valid ~ok_if_no_session_in_context:true ~__context task_id;
     Db_actions.DB_Action.Task.destroy ~__context ~self:task_id
   )
 (*
@@ -186,7 +186,7 @@ let exn_if_cancelling ~__context =
 let cancel ~__context =
   operate_on_db_task ~__context
     (fun self ->
-		assert_can_destroy ~__context self;
+		assert_op_valid ~__context self;
 		let status = Db_actions.DB_Action.Task.get_status ~__context ~self in
 		if status = `pending then begin
 			Db_actions.DB_Action.Task.set_progress ~__context ~self ~value:1.;

--- a/ocaml/idl/ocaml_backend/taskHelper.mli
+++ b/ocaml/idl/ocaml_backend/taskHelper.mli
@@ -38,7 +38,7 @@ val failed : __context:Context.t -> exn -> unit
 
 val init : unit -> unit
 val rbac_assert_permission_fn : (__context:Context.t -> permission:Db_actions.role_t -> unit) option ref
-val assert_can_destroy :  ?ok_if_no_session_in_context:bool -> __context:Context.t ->  [ `task ] Ref.t -> unit
+val assert_op_valid :  ?ok_if_no_session_in_context:bool -> __context:Context.t ->  [ `task ] Ref.t -> unit
 
 type id =
   | Sm of string

--- a/ocaml/xapi/xapi_task.ml
+++ b/ocaml/xapi/xapi_task.ml
@@ -32,7 +32,7 @@ let create ~__context ~label ~description =
 	t
 
 let destroy ~__context ~self =
-  TaskHelper.assert_can_destroy ~__context self;
+  TaskHelper.assert_op_valid ~__context self;
   if TaskHelper.status_is_completed (Db.Task.get_status ~__context ~self) 
   then Db.Task.destroy ~__context ~self
   else Db.Task.add_to_current_operations ~__context ~self ~key:"task" ~value:`destroy
@@ -44,7 +44,12 @@ let cancel ~__context ~task =
 	then failwith (Printf.sprintf "Task.cancel not forwarded to the correct host (expecting %s but this is %s)"
 		(Db.Host.get_hostname ~__context ~self:forwarded_to) (Db.Host.get_hostname ~__context ~self:localhost)
 	);
-	TaskHelper.assert_can_destroy ~__context task;
+	TaskHelper.assert_op_valid ~__context task;
     Db.Task.set_current_operations ~__context ~self:task ~value:[(Ref.string_of (Context.get_task_id __context)), `cancel];
 	if not(Xapi_xenops.task_cancel ~__context ~self:task) && not(Storage_access.task_cancel ~__context ~self:task)
 	then info "Task.cancel is falling back to polling"
+
+let set_status ~__context ~self ~value =
+	TaskHelper.assert_op_valid ~__context self;
+	Db.Task.set_status ~__context ~self ~value
+


### PR DESCRIPTION
There is a requirement from vm scheduled snapshot to
create and destroy task while running vmss policy.
Before destroying the Task, It must be marked as
`success or `failure. For that we need to expose an API
set_status.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>