### PR TITLE
CP-17469: Treat all known PCI classes as managed

### DIFF
--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -25,11 +25,6 @@ let get_free_functions ~__context pci =
 	let functions = Int64.to_int (Db.PCI.get_functions ~__context ~self:pci) in
 	functions - assignments
 
-let unassign_all_for_vm ~__context vm =
-	(* Db.VM.set_attached_PCIs ~__context ~self:vm ~value:[] *)
-	let pcis = Db.VM.get_attached_PCIs ~__context ~self:vm in
-	List.iter (fun self -> Db.PCI.remove_attached_VMs ~__context ~self ~value:vm) pcis
-
 (* http://wiki.xen.org/wiki/Bus:Device.Function_%28BDF%29_Notation *)
 (* It might be possible to refactor this but attempts so far have failed. *)
 let bdf_fmt            = format_of_string    "%04x:%02x:%02x.%01x"

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -18,9 +18,6 @@
 (** Check if a given PCI device is free. *)
 val get_free_functions : __context:Context.t -> [ `PCI ] Ref.t -> int
 
-(** Mark all PCI devices for a given VM as unattached. *)
-val unassign_all_for_vm : __context:Context.t -> [ `VM ] Ref.t -> unit
-
 (** Return the PCI DBDF string for a PCI object *)
 val pcidev_of_pci: __context:Context.t -> API.ref_PCI -> (int * int * int * int)
 

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -17,16 +17,22 @@ open D
 open Listext
 open Xstringext
 
-type base_class = Display_controller | Network_controller
+type base_class =
+	| Storage_controller
+	| Network_controller
+	| Display_controller
 
 let is_class_of_kind kind id =
 	let base_class_id_of_kind = function
+	| Storage_controller -> 0x0100
+	| Network_controller -> 0x0200
 	| Display_controller -> 0x0300
-	| Network_controller -> 0x0200 in
+	in
 	(* The base_class is the most-significant byte of the class ID *)
 	id land 0xff00 = base_class_id_of_kind kind
 
 let managed_classes = [
+	Storage_controller;
 	Network_controller;
 	Display_controller;
 ]

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -26,7 +26,10 @@ let is_class_of_kind kind id =
 	(* The base_class is the most-significant byte of the class ID *)
 	id land 0xff00 = base_class_id_of_kind kind
 
-let managed_classes = [Display_controller]
+let managed_classes = [
+	Network_controller;
+	Display_controller;
+]
 
 let string_of_pci ~__context ~self =
 	let pci = Db.PCI.get_record_internal ~__context ~self in

--- a/ocaml/xapi/xapi_pci.mli
+++ b/ocaml/xapi/xapi_pci.mli
@@ -15,7 +15,10 @@
  *)
 
 (** Types of PCI devices. *)
-type base_class = Display_controller | Network_controller
+type base_class =
+	| Storage_controller
+	| Network_controller
+	| Display_controller
 
 (* Check if an class ID is of a given base class *)
 val is_class_of_kind : base_class -> int -> bool


### PR DESCRIPTION
This means that the VM.attached_PCIs will be updated when the VM is
started and shutdown and this will inform the VM.allowed_operations.

For example, VMs with PCI-passthrough (using the other-config:pci key)
will have the same operation restrictions as a VM using GPU-passthrough
(previously the only class of managed PCI device). Presently the
operations restricted based on attached PCI devices are:

* suspend
* checkpoint
* pool_migrate
* migrate_send

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>