### PR TITLE
CA-202379: xapi_vm: Serialise VM snapshot operations

### DIFF
--- a/ocaml/xapi/local_work_queue.ml
+++ b/ocaml/xapi/local_work_queue.ml
@@ -33,6 +33,9 @@ let start_vm_lifecycle_queue () =
 (** Put "long running/streaming operations" into their own queue, so vm lifecycle ops can be parallelized with them *)
 let long_running_queue = Thread_queue.make ~name:"long_running_op" vm_lifecycle_queue_process_fn
   
+(** VM.{snapshot} etc are queued here *)
+let snapshot_vm_queue = Thread_queue.make ~name:"vm_snapshot_op" vm_lifecycle_queue_process_fn
+
 (** VM.{start,shutdown,copy,clone} etc are queued here *)
 let normal_vm_queue = Thread_queue.make ~name:"vm_lifecycle_op" vm_lifecycle_queue_process_fn
 


### PR DESCRIPTION
Running 2 snapshots simultaneously is not permitted anyway,
will cause one thread to fail with OTHER_OPERATION_IN_PROGRESS
and delay its execution for a random number of seconds.

Serialising the operation will ensure that two simultaneously
triggered snapshot operations will run one after another
without additional, superfluous delay.

To test the patch i ran the following code:
```
#!/bin/bash

xe vm-snapshot vm=template new-name-label=template_t &
xe vm-snapshot vm=template2 new-name-label=template2_t &
wait
```

Before applying the patch the time to execute the above script was ranging between 5-20 seconds
due to the random back-off delay:

> Async.VDI.snapshot R:dbc05ec471f9|helpers] Waiting for up to 8.931823 seconds before retrying...

Performance results, without the patch:
> [root@perfuk-01-02 ~]#  time ./snap.sh                           
> f80a75cb-ffb9-2cde-12c8-441e46568b40
> 7c3e6089-dc97-fd40-5e49-6c37efd49fb0
> 
> real    0m14.566s
> user    0m0.000s
> sys     0m0.000s

With the patch:

> [root@perfuk-01-02 ~]# time ./snap.sh 
> 1c1ecaa7-7be6-68e1-664c-4b698e0a64e4
> 081150cd-7b5c-99eb-65e1-26d029f852e1
> 
> real    0m3.310s
> user    0m0.000s
> sys     0m0.000s