### PR TITLE
CP-17631: Don't default HVM keymap to en-us

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -359,7 +359,10 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough vgpu =
 				| _, Some value -> Some value
 				| Some value, None -> Some value
 			end;
-			keymap = Some (string vm.API.vM_platform "en-us" "keymap");
+			keymap = begin
+				try Some (List.assoc "keymap" vm.API.vM_platform)
+				with Not_found -> None
+			end;
 			vnc_ip = None (*None PR-1255*);
 			pci_emulations = pci_emulations;
 			pci_passthrough = pci_passthrough;


### PR DESCRIPTION
Xenopsd is responsible for sorting out the defaults and there's a good
reason to leave it empty as it enables QEMU's ExtendedKeyEvent
extension (see https://github.com/xapi-project/xenopsd/pull/272).

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>