### PR TITLE
CA-213224: Avoid concurrent internal bridge creation

### DIFF
--- a/ocaml/xapi/xapi_network.ml
+++ b/ocaml/xapi/xapi_network.ml
@@ -20,14 +20,24 @@ open D
 open Db_filter
 open Network
 
+let internal_bridge_m = Mutex.create ()
+
 let create_internal_bridge ~__context ~bridge ~uuid ~persist =
-	debug "Creating internal bridge %s (uuid:%s)" bridge uuid;
 	let dbg = Context.string_of_task __context in
 	let current = Net.Bridge.get_all dbg () in
-	if not(List.mem bridge current) then begin
-		let other_config = ["network-uuids", uuid] in
-		Net.Bridge.create dbg ~name:bridge ~other_config ();
-	end;
+	if List.mem bridge current then
+		(* No serialisation needed in this case *)
+		debug "Internal bridge %s exists" bridge
+	else
+		(* Atomic test-and-set process *)
+		Mutex.execute internal_bridge_m (fun () ->
+			let current = Net.Bridge.get_all dbg () in
+			if not(List.mem bridge current) then begin
+				let other_config = ["network-uuids", uuid] in
+				debug "Creating internal bridge %s (uuid:%s)" bridge uuid;
+				Net.Bridge.create dbg ~name:bridge ~other_config ();
+			end
+		);
 	Net.Bridge.set_persistent dbg ~name:bridge ~value:persist
 
 let set_himn_ip ~__context bridge other_config =


### PR DESCRIPTION
When two threads try to bring up the same internal bridge (which can happen if
we boot two VMs attached to the same internal network in parallel), there is a
chance of confliction as bridge creation steps are not atomic.

Signed-off-by: Zheng Li <dev@zheng.li>