### PR TITLE
CP-17923: Conditionally set Xenopsd Vbd.backend to Local

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -184,6 +184,7 @@ let owner_key = "owner" (* set in VBD other-config to indicate that clients can 
 let vbd_backend_key = "backend-kind" (* set in VBD other-config *)
 let vbd_polling_duration_key = "polling-duration" (* set in VBD other-config *)
 let vbd_polling_idle_threshold_key = "polling-idle-threshold" (* set in VBD other-config *)
+let vbd_backend_local_key = "backend-local" (* set in VBD other-config *)
 
 let using_vdi_locking_key = "using-vdi-locking" (* set in Pool other-config to indicate that we should use storage-level (eg VHD) locking *)
 


### PR DESCRIPTION
Xenopsd has the ability to handle paths to block devices in dom0 which
don't require Xenopsd to do a SMAPI attach and activate.

We now trigger this functionality based on the a VBD.other-config field.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>