### PR TITLE
CP-18021 remove dependency on tetex-latex

### DIFF
--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -17,7 +17,6 @@ BuildRequires: ocaml-camlp4-devel
 BuildRequires: ocaml-findlib
 BuildRequires: ocaml-ocamldoc
 BuildRequires: pam-devel
-BuildRequires: tetex-latex
 BuildRequires: xen-devel
 BuildRequires: libffi-devel
 BuildRequires: zlib-devel


### PR DESCRIPTION

This commit removes tetex-latex as a build dependency. The dependency
isn't required and causes 95 latex-related RPM packages to be installed
at build time (representing about 25% of all packages at build time).

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>