### PR TITLE
CA-105021: Set Console.location to empty if Host.address is empty

### DIFF
--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -69,8 +69,10 @@ let refresh_console_urls ~__context =
 		Helpers.log_exn_continue (Printf.sprintf "Updating console: %s" (Ref.string_of console)) (fun () ->
 			let vm = Db.Console.get_VM ~__context ~self:console in
 			let host = Db.VM.get_resident_on ~__context ~self:vm in
-			let address = Db.Host.get_address ~__context ~self:host in
-			let url_should_be = Printf.sprintf "https://%s%s?ref=%s" address Constants.console_uri (Ref.string_of console) in
+			let url_should_be = match Db.Host.get_address ~__context ~self:host with
+			| "" -> ""
+			| address ->
+				Printf.sprintf "https://%s%s?ref=%s" address Constants.console_uri (Ref.string_of console) in
 			Db.Console.set_location ~__context ~self:console ~value:url_should_be
 		) ()
 	) (Db.Console.get_all ~__context)

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -65,17 +65,15 @@ let set_master_pool_reference ~__context =
 	Db.Pool.set_master ~__context ~self:pool ~value:(Helpers.get_localhost ~__context)
 
 let refresh_console_urls ~__context =
-  List.iter
-    (fun console ->
-       Helpers.log_exn_continue (Printf.sprintf "Updating console: %s" (Ref.string_of console))
-	 (fun () ->
-	    let vm = Db.Console.get_VM ~__context ~self:console in
-	    let host = Db.VM.get_resident_on ~__context ~self:vm in
-	    let address = Db.Host.get_address ~__context ~self:host in
-	    let url_should_be = Printf.sprintf "https://%s%s?ref=%s" address Constants.console_uri (Ref.string_of console) in
-	    Db.Console.set_location ~__context ~self:console ~value:url_should_be
-	 ) ()
-    ) (Db.Console.get_all ~__context)
+	List.iter (fun console ->
+		Helpers.log_exn_continue (Printf.sprintf "Updating console: %s" (Ref.string_of console)) (fun () ->
+			let vm = Db.Console.get_VM ~__context ~self:console in
+			let host = Db.VM.get_resident_on ~__context ~self:vm in
+			let address = Db.Host.get_address ~__context ~self:host in
+			let url_should_be = Printf.sprintf "https://%s%s?ref=%s" address Constants.console_uri (Ref.string_of console) in
+			Db.Console.set_location ~__context ~self:console ~value:url_should_be
+		) ()
+	) (Db.Console.get_all ~__context)
 
 (** CA-15449: after a pool restore database VMs which were running on slaves now have dangling resident_on fields.
     If these are control domains we destroy them, otherwise we reset them to Halted. *)


### PR DESCRIPTION
The usual form for the console URL is:

    https://<host-ip-address>/console?ref=<console-ref>

However, when the host doesn't have an IP address because, for example,
the host management network has been disabled, then the console URL
becomes

    https:///console?ref=<console-ref>

which doesn't make sense. It doesn't make sense, either, to maintain the
IP address that the host _used_ to have because this IP might be in use
somewhere else if, for example, there was a DHCP server running on the
network.

This patch sets the location URL to the empty string if the host doesn't
have an address on the network.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>