### PR TITLE
CA-207577: clear scheduled_to_be_resident_on if create_vgpus fails

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -834,8 +834,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			end;
 			(* Once this is set concurrent VM.start calls will start checking the memory used by this VM *)
 			Db.VM.set_scheduled_to_be_resident_on ~__context ~self:vm ~value:host;
-			Vgpuops.create_vgpus ~__context host (vm, snapshot)
-				(Helpers.will_boot_hvm ~__context ~self:vm)
+			try
+				Vgpuops.create_vgpus ~__context host (vm, snapshot)
+					(Helpers.will_boot_hvm ~__context ~self:vm)
+			with e ->
+				clear_scheduled_to_be_resident_on ~__context ~vm;
+				raise e
 
 		(* For start/start_on/resume/resume_on/migrate *)
 		let finally_clear_host_operation ~__context ~host ?host_op () = match host_op with


### PR DESCRIPTION
create_vgpus could fail if vGPU is not licensed. The VM must not be
left marked as scheduled_to_be_resident_on a host, or it will be
considered to be taking up space on that host.