### PR TITLE
CP-18024: Allow XAPI extensions to be invoked on a specific host

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3055,6 +3055,26 @@ let host_call_plugin = call
   ~allowed_roles:_R_POOL_ADMIN
   ()
 
+let host_has_extension = call
+  ~name:"has_extension"
+  ~in_product_since:rel_dundee_plus
+  ~doc:"Return true if the extension is available on the host"
+  ~params:[Ref _host, "host", "The host";
+	   String, "name", "The name of the API call";]
+  ~result:(Bool, "True if the extension exists, false otherwise")
+  ~allowed_roles:_R_POOL_ADMIN
+  ()
+
+let host_call_extension = call
+  ~name:"call_extension"
+  ~in_product_since:rel_dundee_plus
+  ~doc:"Call a XenAPI extension on this host"
+  ~params:[Ref _host, "host", "The host";
+	   String, "call", "Rpc call for the extension";]
+  ~result:(String, "Result from the extension")
+  ~allowed_roles:_R_POOL_ADMIN
+  ()
+
 let host_enable_binary_storage = call
   ~name:"enable_binary_storage"
   ~in_product_since:rel_orlando
@@ -4593,6 +4613,8 @@ let host =
 		 host_backup_rrds;
 		 host_create_new_blob;
 		 host_call_plugin;
+		 host_has_extension;
+		 host_call_extension;
 		 host_get_servertime;
 		 host_get_server_localtime;
 		 host_enable_binary_storage;
@@ -5707,12 +5729,14 @@ let lvhd_enable_thin_provisioning = call
    ~in_product_since:rel_dundee
    ~allowed_roles:_R_POOL_ADMIN
    ~params:[
+     Ref _host, "host", "The LVHD Host to upgrade to being thin-provisioned.";
      Ref _sr, "SR", "The LVHD SR to upgrade to being thin-provisioned.";
      Int, "initial_allocation", "The initial amount of space to allocate to a newly-created VDI in bytes";
      Int, "allocation_quantum", "The amount of space to allocate to a VDI when it needs to be enlarged in bytes";
    ]
    ~doc:"Upgrades an LVHD SR to enable thin-provisioning. Future VDIs created in this SR will be thinly-provisioned, although existing VDIs will be left alone. Note that the SR must be attached to the SRmaster for upgrade to work."
-   ~forward_to:(Extension "LVHD.enable_thin_provisioning")
+   ~forward_to:(HostExtension "LVHD.enable_thin_provisioning")
+   ~result:(String, "Message from LVHD.enable_thin_provisioning extension")
    ()  
 
 let lvhd = 

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -162,7 +162,7 @@ and param = {param_type:ty; param_name:string; param_doc:string; param_release: 
 
 and doc_tag = VM_lifecycle | Snapshots | Networking | Memory | Windows
 
-and forward = Extension of string
+and forward = Extension of string | HostExtension of string
 
 (** Types of RPC messages; in addition to those generated for object fields *)
 and message = { 

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2615,7 +2615,7 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
 			optn=[];
 			help="Enable thin-provisioning on an LVHD SR.";
 			implementation=No_fd Cli_operations.lvhd_enable_thin_provisioning;
-			flags=[];
+			flags=[Host_selectors];
 		}
   ]
 

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -4645,8 +4645,14 @@ let pgpu_disable_dom0_access printer rpc session_id params =
 	printer (Cli_printer.PMsg (Record_util.pgpu_dom0_access_to_string result))
 
 let lvhd_enable_thin_provisioning printer rpc session_id params =
-	let uuid = List.assoc "sr-uuid" params in
+	let sr_uuid = List.assoc "sr-uuid" params in
 	let initial_allocation = Record_util.bytes_of_string "initial-allocation" (List.assoc "initial-allocation" params) in
 	let allocation_quantum = Record_util.bytes_of_string "allocation-quantum" (List.assoc "allocation-quantum" params) in
-	let ref = Client.SR.get_by_uuid rpc session_id uuid in
-	Client.LVHD.enable_thin_provisioning rpc session_id ref initial_allocation allocation_quantum
+	ignore(
+		do_host_op rpc session_id (fun _ host ->
+			let host_ref = host.getref () in
+			let sr_ref = Client.SR.get_by_uuid rpc session_id sr_uuid in
+			Client.LVHD.enable_thin_provisioning rpc session_id host_ref sr_ref initial_allocation allocation_quantum
+		) params ["sr-uuid"; "initial-allocation";"allocation-quantum"]
+	)
+

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2369,6 +2369,18 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			do_op_on ~local_fn ~__context ~host
 				(fun session_id rpc -> Client.Host.call_plugin rpc session_id host plugin fn args)
 
+		let call_extension ~__context ~host ~call =
+			info "Host.call_extension host = '%s'; call = '%s'" (host_uuid ~__context host) call;
+			let local_fn = Local.Host.call_extension ~host ~call in
+			do_op_on ~local_fn ~__context ~host
+				(fun session_id rpc -> Client.Host.call_extension rpc session_id host call)
+
+		let has_extension ~__context ~host ~name =
+			info "Host.has_extension: host = '%s'; name = '%s'" (host_uuid ~__context host) name;
+			let local_fn = Local.Host.has_extension ~host ~name in
+			do_op_on ~local_fn ~__context ~host
+				(fun session_id rpc -> Client.Host.has_extension rpc session_id host name)
+
 		let sync_data ~__context ~host =
 			info "Host.sync_data: host = '%s'" (host_uuid ~__context host);
 			Local.Host.sync_data ~__context ~host

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -960,7 +960,13 @@ let call_plugin ~__context ~host ~plugin ~fn ~args =
 	then call_extauth_plugin ~__context ~host ~fn ~args
 	else Xapi_plugins.call_plugin (Context.get_session_id __context) plugin fn args
 
-let has_extension ~__context ~name =
+(* this is the generic extension call available to xapi users *)
+let call_extension ~__context ~host ~call =
+	let rpc = Jsonrpc.call_of_string call in
+	let response = Xapi_extensions.call_extension rpc in
+	Jsonrpc.string_of_response response
+
+let has_extension ~__context ~host ~name =
 	try
 		let (_: string) = Xapi_extensions.find_extension name in
 		true

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -166,6 +166,12 @@ val call_plugin :
   __context:Context.t ->
   host:[ `host ] Ref.t ->
   plugin:string -> fn:string -> args:(string * string) list -> string
+val call_extension :
+  __context:Context.t ->
+  host:[ `host ] Ref.t -> call:string -> string
+val has_extension :
+  __context:Context.t ->
+  host:[ `host ] Ref.t -> name:string -> bool
 val sync_data : __context:Context.t -> host:API.ref_host -> unit
 val backup_rrds : __context:Context.t -> host:'b -> delay:float -> unit
 val get_servertime : __context:'a -> host:'b -> Stdext.Date.iso8601

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1741,11 +1741,12 @@ let disable_ssl_legacy = set_ssl_legacy_on_each_host ~value:false
 let enable_ssl_legacy = set_ssl_legacy_on_each_host ~value:true
 
 let has_extension ~__context ~self ~name =
-	try
-		let (_: string) = Xapi_extensions.find_extension name in
-		true
-	with _ ->
-		false
+	let hosts = Db.Host.get_all ~__context in
+	List.for_all (fun host ->
+		Helpers.call_api_functions ~__context (fun rpc session_id ->
+			Client.Host.has_extension rpc session_id host name
+		)
+	) hosts
 
 let guest_agent_config_requirements =
 	let open Map_check in


### PR DESCRIPTION
The current design for CAR-2245 assumes that a client can perform update operations on both master and slaves. It would be preferable to implement the server-side behavior as a XAPI extension (to enable it to be easily updated).

This PR is to allow XAPI extensions to be invoked on a specific host.