### PR TITLE
CP 18172 - Implement allowed-operations checks for Bromium

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -51,6 +51,7 @@ let vm_hvm_required = "VM_HVM_REQUIRED"
 let vm_no_vcpus = "VM_NO_VCPUS"
 let vm_toomany_vcpus = "VM_TOO_MANY_VCPUS"
 let vm_is_protected = "VM_IS_PROTECTED"
+let vm_cant_migrate = "VM_CANT_MIGRATE"
 
 let host_in_use = "HOST_IN_USE"
 let host_in_emergency_mode = "HOST_IN_EMERGENCY_MODE"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1335,8 +1335,10 @@ let _ =
 		~doc:"The VM cannot be imported unforced because it is either the same version or an older version of an existing VM." ();
 
 	error Api_errors.vm_call_plugin_rate_limit ["VM"; "interval"; "wait"]
-		~doc:"There is a minimal interval required between consecutive plugin calls made on the same VM, please wait before retry." ()
+		~doc:"There is a minimal interval required between consecutive plugin calls made on the same VM, please wait before retry." ();
 
+	error Api_errors.vm_cant_migrate ["VM"]
+		~doc:"The VM can't migrate because it is either explicitly blocked or it uses nested virtualisation"
 
 let _ =
     message (fst Api_messages.ha_pool_overcommitted) ~doc:"Pool has become overcommitted: it can no longer guarantee to restart protected VMs if the configured number of hosts fail." ();

--- a/ocaml/test/OMakefile
+++ b/ocaml/test/OMakefile
@@ -62,6 +62,7 @@ OCAML_OBJS = \
 	../license/daily_license_check \
 	test_daily_license_check \
 	test_dbsync_master \
+	test_no_migrate \
 
 OCamlProgram(suite, suite $(OCAML_OBJS) )
 

--- a/ocaml/test/suite.ml
+++ b/ocaml/test/suite.ml
@@ -52,6 +52,7 @@ let base_suite =
 			(* Test_ca121350.test; *)
 			Test_daily_license_check.test;
 			Test_dbsync_master.test;
+			Test_no_migrate.test;
 		]
 
 let handlers = [

--- a/ocaml/test/test_no_migrate.ml
+++ b/ocaml/test/test_no_migrate.ml
@@ -1,0 +1,128 @@
+(*
+ * Copyright (C) 2016 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open OUnit
+open Test_common
+
+module LC = Xapi_vm_lifecycle
+
+let critical =
+	[ `suspend
+	; `checkpoint
+	; `pool_migrate
+	; `migrate_send
+	]
+
+let ops =
+	[ `assert_operation_valid
+	; `awaiting_memory_live
+	; `call_plugin
+	; `changing_dynamic_range
+	; `changing_memory_limits
+	; `changing_memory_live
+	; `changing_shadow_memory
+	; `changing_shadow_memory_live
+	; `changing_static_range
+	; `changing_VCPUs
+	; `changing_VCPUs_live
+	; `checkpoint
+	; `clean_reboot
+	; `clean_shutdown
+	; `clone
+	; `copy
+	; `create_template
+	; `csvm
+	; `data_source_op
+	; `destroy
+	; `export
+	; `get_boot_record
+	; `hard_reboot
+	; `hard_shutdown
+	; `import
+	; `make_into_template
+	; `metadata_export
+	; `migrate_send
+	; `pause
+	; `pool_migrate
+	; `power_state_reset
+	; `provision
+	; `query_services
+	; `resume
+	; `resume_on
+	; `revert
+	; `reverting
+	; `send_sysrq
+	; `send_trigger
+	; `shutdown
+	; `snapshot
+	; `snapshot_with_quiesce
+	; `start
+	; `start_on
+	; `suspend
+	; `unpause
+	; `update_allowed_operations
+	]
+
+let base_case () =
+	let __context = make_test_database () in
+	let vm        = make_vm ~__context () in
+		( Db.VM.set_power_state ~__context ~self:vm ~value:`Running
+		; assert_equal ~msg:"suspend" None
+			 (LC.get_operation_error ~__context ~self:vm ~op:`suspend ~strict:false)
+		; assert_equal ~msg:"checkpoint" None
+			 (LC.get_operation_error ~__context ~self:vm ~op:`checkpoint ~strict:false)
+		; assert_equal ~msg:"pool_migrate" None
+			 (LC.get_operation_error ~__context ~self:vm ~op:`pool_migrate ~strict:false)
+		; assert_equal ~msg:"migrate_send" None
+			 (LC.get_operation_error ~__context ~self:vm ~op:`migrate_send ~strict:false)
+		)
+
+let with_platform platform check () =
+	let __context = make_test_database () in
+	let self      = make_vm ~__context () in
+	let ()        =
+		( Db.VM.set_power_state ~__context ~self ~value:`Running
+		; Db.VM.set_platform ~__context ~self ~value:platform
+		; Helpers.set_boot_record ~__context ~self
+			(Db.VM.get_record ~__context ~self)
+		) in
+	critical (* check all critical operations *)
+	|> List.map (fun op -> LC.get_operation_error ~__context ~self ~op ~strict:false)
+	|> List.for_all check
+	|> assert_bool "with_platform"
+
+let test =
+	let migrate = (=)  None  in (* no errors *)
+	let dont    = (<>) None  in (* errors - can't migrate *)
+	"test_no_migrate" >:::
+	[ "test_no_migrate_00" >:: base_case
+	; "test_no_migrate_01" >:: with_platform []                         migrate
+	; "test_no_migrate_02" >:: with_platform ["nested-virt","true"]     dont
+	; "test_no_migrate_03" >:: with_platform ["nested-virt","false"]    migrate
+	; "test_no_migrate_04" >:: with_platform ["nomigrate","true"]       dont
+	; "test_no_migrate_05" >:: with_platform ["nomigrate","false"]      migrate
+	; "test_no_migrate_06"
+		>:: with_platform ["nomigrate","true"; "nested-virt", "true"]     dont
+	; "test_no_migrate_07"
+		>:: with_platform ["nomigrate","true"; "nested-virt", "false"]    dont
+	; "test_no_migrate_08"
+		>:: with_platform ["nomigrate","false"; "nested-virt", "false"]   migrate
+	; "test_no_migrate_09"
+		>:: with_platform ["nomigrate","false"; "nested-virt", "true"]    dont
+	; "test_no_migrate_10" >:: with_platform ["nomigrate","TRUE"]       dont
+	; "test_no_migrate_12" >:: with_platform ["nomigrate","1"]          dont
+	; "test_no_migrate_12" >:: with_platform ["nested-virt","1"]        dont
+	; "test_no_migrate_13" >:: with_platform ["nested-virt","2"]        migrate
+	; "test_no_migrate_14" >:: with_platform ["nested-virt","0"]        migrate
+	]

--- a/ocaml/test/test_no_migrate.ml
+++ b/ocaml/test/test_no_migrate.ml
@@ -24,56 +24,6 @@ let critical =
 	; `migrate_send
 	]
 
-let ops =
-	[ `assert_operation_valid
-	; `awaiting_memory_live
-	; `call_plugin
-	; `changing_dynamic_range
-	; `changing_memory_limits
-	; `changing_memory_live
-	; `changing_shadow_memory
-	; `changing_shadow_memory_live
-	; `changing_static_range
-	; `changing_VCPUs
-	; `changing_VCPUs_live
-	; `checkpoint
-	; `clean_reboot
-	; `clean_shutdown
-	; `clone
-	; `copy
-	; `create_template
-	; `csvm
-	; `data_source_op
-	; `destroy
-	; `export
-	; `get_boot_record
-	; `hard_reboot
-	; `hard_shutdown
-	; `import
-	; `make_into_template
-	; `metadata_export
-	; `migrate_send
-	; `pause
-	; `pool_migrate
-	; `power_state_reset
-	; `provision
-	; `query_services
-	; `resume
-	; `resume_on
-	; `revert
-	; `reverting
-	; `send_sysrq
-	; `send_trigger
-	; `shutdown
-	; `snapshot
-	; `snapshot_with_quiesce
-	; `start
-	; `start_on
-	; `suspend
-	; `unpause
-	; `update_allowed_operations
-	]
-
 let base_case () =
 	let __context = make_test_database () in
 	let vm        = make_vm ~__context () in

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -261,6 +261,22 @@ let check_protection_policy ~vmr ~op ~ref_str =
 		[ref_str; Ref.string_of vmr.Db_actions.vM_protection_policy])
 	| _ -> None
 
+(** Some VMs can't migrate. The predicate [check_migratable] is true, if and
+ * only if a VM can migrate. A VM cannot migrate, if in its
+ * [last_booted_record] any of the following values are true:
+ * [platform:nomingrate], [platform:nested-virt]. If we cannot find
+ * a boot record this mea
+ **)
+let check_migratable vm =
+	let get key platform = (* absent key is equivalent to false *)
+		try List.assoc key platform |> bool_of_string with Not_found -> false in
+	match vm.Db_actions.vM_last_booted_record with
+	| ""  -> true (* no last boot record exists, VM is not yet started *)
+	| xml ->
+		Helpers.parse_boot_record ~string:xml
+		|> fun lbr -> lbr.API.vM_platform
+		|> fun plf -> not (get "nomigrate" plf) && not (get "nested-virt" plf)
+
 (** Take an internal VM record and a proposed operation. Return None iff the operation
     would be acceptable; otherwise Some (Api_errors.<something>, [list of strings])
     corresponding to the first error found. Checking stops at the first error.
@@ -316,6 +332,19 @@ let check_operation_error ~__context ~vmr ~vmgmr ~ref ~clone_suspended_vm_enable
 		if op = `revert && (not is_snapshot)
 		then Some (Api_errors.only_revert_snapshot, [])
 		else None) in
+
+	(* Migration must be blocked if nested virtualisation is active *)
+	let current_error = check current_error (fun () ->
+		match op with
+		| `suspend
+		| `checkpoint
+		| `pool_migrate
+		| `migrate_send ->
+			if check_migratable vmr
+			then None
+			else Some (Api_errors.vm_cant_migrate, [ref_str])
+		| _ -> None
+		) in
 
 	(* Check if the VM is a control domain (eg domain 0).            *)
 	(* FIXME: Instead of special-casing for the control domain here, *)

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -264,12 +264,15 @@ let check_protection_policy ~vmr ~op ~ref_str =
 (** Some VMs can't migrate. The predicate [check_migratable] is true, if and
  * only if a VM can migrate. A VM cannot migrate, if in its
  * [last_booted_record] any of the following values are true:
- * [platform:nomingrate], [platform:nested-virt]. If we cannot find
+ * [platform:nomigrate], [platform:nested-virt]. If we cannot find
  * a boot record this mea
  **)
 let check_migratable vm =
+	let to_bool str = str |> String.lowercase |> function
+		| "true" | "yes" | "1" -> true
+		| _                    -> false in
 	let get key platform = (* absent key is equivalent to false *)
-		try List.assoc key platform |> bool_of_string with Not_found -> false in
+		try List.assoc key platform |> to_bool with Not_found -> false in
 	match vm.Db_actions.vM_last_booted_record with
 	| ""  -> true (* no last boot record exists, VM is not yet started *)
 	| xml ->


### PR DESCRIPTION
This PR adds checks to `xapi_vm_lifecycle.ml` to signal that VM migration is prohibited if certain platform values are found in the `last_booted_record`:

* `platform:nomigrate` equals `true` or `1`
* `platform:nested-virt` equals `true` or `1`

Migration is prohibited if any of the above two conditions is met. VM migration is always permitted if no `last_booted_record` is found.