### PR TITLE
CP-18173 add check to vm lifecycle: no migration when using nested virt

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -51,6 +51,7 @@ let vm_hvm_required = "VM_HVM_REQUIRED"
 let vm_no_vcpus = "VM_NO_VCPUS"
 let vm_toomany_vcpus = "VM_TOO_MANY_VCPUS"
 let vm_is_protected = "VM_IS_PROTECTED"
+let vm_is_immobile= "VM_IS_IMMOBILE"
 
 let host_in_use = "HOST_IN_USE"
 let host_in_emergency_mode = "HOST_IN_EMERGENCY_MODE"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1337,8 +1337,10 @@ let _ =
 		~doc:"The VM cannot be imported unforced because it is either the same version or an older version of an existing VM." ();
 
 	error Api_errors.vm_call_plugin_rate_limit ["VM"; "interval"; "wait"]
-		~doc:"There is a minimal interval required between consecutive plugin calls made on the same VM, please wait before retry." ()
+		~doc:"There is a minimal interval required between consecutive plugin calls made on the same VM, please wait before retry." ();
 
+	error Api_errors.vm_is_immobile ["VM"]
+		~doc:"The VM is configured in a way that prevents it from being mobile." ()
 
 let _ =
     message (fst Api_messages.ha_pool_overcommitted) ~doc:"Pool has become overcommitted: it can no longer guarantee to restart protected VMs if the configured number of hosts fail." ();

--- a/ocaml/test/OMakefile
+++ b/ocaml/test/OMakefile
@@ -63,6 +63,7 @@ OCAML_OBJS = \
 	test_daily_license_check \
 	test_dbsync_master \
 	test_xapi_xenops \
+	test_no_migrate \
 
 OCamlProgram(suite, suite $(OCAML_OBJS) )
 

--- a/ocaml/test/suite.ml
+++ b/ocaml/test/suite.ml
@@ -53,6 +53,7 @@ let base_suite =
 			Test_daily_license_check.test;
 			Test_dbsync_master.test;
 			Test_xapi_xenops.test;
+			Test_no_migrate.test;
 		]
 
 let handlers = [

--- a/ocaml/test/test_no_migrate.ml
+++ b/ocaml/test/test_no_migrate.ml
@@ -1,0 +1,112 @@
+(*
+ * Copyright (C) 2016 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open OUnit
+open Test_common
+
+module LC = Xapi_vm_lifecycle
+
+let critical =
+	[ `suspend
+	; `checkpoint
+	; `pool_migrate
+	; `migrate_send
+	]
+
+
+type mobility = Mobile | Static
+
+let platforms =
+	[ Static, ["nested-virt","true"]
+	; Mobile, ["nested-virt","false"]
+	; Static, ["nomigrate","true"]
+	; Mobile, ["nomigrate","false"]
+	; Static, ["nomigrate","true"; "nested-virt", "true"]
+	; Static, ["nomigrate","true"; "nested-virt", "false"]
+	; Mobile, ["nomigrate","false"; "nested-virt", "false"]
+	; Static, ["nomigrate","false"; "nested-virt", "true"]
+	; Static, ["nomigrate","TRUE"]
+	; Static, ["nomigrate","1"]
+	; Static, ["nested-virt","1"]
+	; Mobile, ["nested-virt","0"]
+	]
+
+let simple () =
+	let __context = make_test_database () in
+	let vm        = make_vm ~__context ~hVM_boot_policy:"" () in
+		( Db.VM.set_power_state ~__context ~self:vm ~value:`Running
+		; LC.get_operation_error ~__context ~self:vm ~op:`suspend ~strict:true
+		|> function
+		| None          -> assert_bool "success" true
+		| Some (x,xs)   -> assert_failure (String.concat "|" (x::xs))
+		)
+
+let base () =
+	let __context = make_test_database () in
+	let vm        = make_vm ~__context ~hVM_boot_policy:"" () in
+		( Db.VM.set_power_state ~__context ~self:vm ~value:`Running
+		; assert_equal ~msg:"suspend" None
+			 (LC.get_operation_error ~__context ~self:vm ~op:`suspend ~strict:true)
+		; assert_equal ~msg:"checkpoint" None
+			 (LC.get_operation_error ~__context ~self:vm ~op:`checkpoint ~strict:true)
+		; assert_equal ~msg:"pool_migrate" None
+			 (LC.get_operation_error ~__context ~self:vm ~op:`pool_migrate ~strict:true)
+		; assert_equal ~msg:"migrate_send" None
+			 (LC.get_operation_error ~__context ~self:vm ~op:`migrate_send ~strict:true)
+		)
+
+(** [with_platform] checks that mobility is signaled according to the
+ * values found in the platform flags of the last_booted_record *)
+let with_platform () =
+	let __context = make_test_database () in
+	let self      = make_vm ~__context ~hVM_boot_policy:"" () in
+	let test platform predicate =
+		( Db.VM.set_power_state ~__context ~self ~value:`Running
+		; Db.VM.set_platform ~__context ~self ~value:platform
+		; Helpers.set_boot_record ~__context ~self
+			(Db.VM.get_record ~__context ~self)
+		; critical (* check all critical operations *)
+		|> List.map (fun op -> LC.get_operation_error ~__context ~self ~op ~strict:true)
+		|> List.for_all predicate
+		|> assert_bool "with_platform"
+		) in
+	let predicate = function
+	| Mobile  -> (=)  None    (* mobile, no error expected *)
+	| Static  -> (<>) None in (* not mobile, expect an error message *)
+	List.iter (fun (mobile, platform) -> test platform (predicate mobile)) platforms
+
+(** [override] checks that migration is always possible when --force is
+ * used *)
+let override () =
+	let __context = make_test_database () in
+	let self      = make_vm ~__context ~hVM_boot_policy:"" () in
+	let test platform =
+		( Db.VM.set_power_state ~__context ~self ~value:`Running
+		; Db.VM.set_platform ~__context ~self ~value:platform
+		; Helpers.set_boot_record ~__context ~self
+			(Db.VM.get_record ~__context ~self)
+		; critical (* check all critical operations *)
+		|> List.map (fun op -> LC.get_operation_error ~__context ~self ~op ~strict:false)
+		|> List.for_all ((=) None) (* should not see any error *)
+		|> assert_bool "override"
+		) in
+	List.iter (fun (_, platform) -> test platform) platforms
+
+let test = "test_no_migrate" >:::
+	[ "test_no_migrate_00" >:: simple
+	; "test_no_migrate_01" >:: base
+	; "test_no_migrate_02" >:: with_platform
+	; "test_no_migrate_03" >:: override
+	]
+

--- a/ocaml/test/test_platformdata.ml
+++ b/ocaml/test/test_platformdata.ml
@@ -31,7 +31,7 @@ module SanityCheck = Generic.Make(struct
 	end
 
 	let transform (platformdata, filter_out_unknowns, vcpu_max, vcpu_at_startup, hvm) =
-		try Either.Right (Xapi_xenops.Platform.sanity_check ~platformdata ~vcpu_max ~vcpu_at_startup ~hvm ~filter_out_unknowns)
+		try Either.Right (Vm_platform.sanity_check ~platformdata ~vcpu_max ~vcpu_at_startup ~hvm ~filter_out_unknowns)
 		with e -> Either.Left e
 
 	let tests =

--- a/ocaml/test/test_xapi_xenops.ml
+++ b/ocaml/test/test_xapi_xenops.ml
@@ -13,8 +13,8 @@ let test_enabled_in_xenguest () =
 
   let k = "test_key" in
   let p v = [k,v] in
-  let val_fn p = Xapi_xenops.Platform.is_true ~key:k ~platformdata:p ~default:false in
-  let valid_fn p = Xapi_xenops.Platform.is_valid ~key:k ~platformdata:p in
+  let val_fn p = Vm_platform.is_true ~key:k ~platformdata:p ~default:false in
+  let valid_fn p = Vm_platform.is_valid ~key:k ~platformdata:p in
 
   (* Empty list should be valid *)
   if not (valid_fn []) then err "[]";
@@ -61,7 +61,7 @@ let test_nested_virt_licensing () =
     begin
       try
         Db.Pool.set_restrictions ~__context ~self:pool ~value:["restrict_nested_virt","true"];
-        Xapi_xenops.Platform.check_restricted_flags ~__context platform;
+        Vm_platform.check_restricted_flags ~__context platform;
         if should_raise
         then
           failwith
@@ -77,7 +77,7 @@ let test_nested_virt_licensing () =
 
     (* If the feature is unrestricted, nothing should raise an exception *)
     Db.Pool.set_restrictions ~__context ~self:pool ~value:["restrict_nested_virt","false"];
-    Xapi_xenops.Platform.check_restricted_flags ~__context platform
+    Vm_platform.check_restricted_flags ~__context platform
   in
 
   List.iter check_one nested_virt_checks

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -277,6 +277,7 @@ XAPI_MODULES = $(COMMON) \
 	../util/rpc_retry \
 	xapi \
 	cluster_stack_constraints \
+	vm_platform \
 
 OCamlProgram(xapi, xapi_main $(XAPI_MODULES))
 

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -1,0 +1,167 @@
+(*
+ * Copyright (C) 2016 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Stdext
+open Xstringext
+open Listext
+
+(* Keys we push through to xenstore. *)
+let acpi = "acpi"
+let apic = "apic"
+let nx = "nx"
+let pae = "pae"
+let viridian = "viridian"
+let acpi_s3 = "acpi_s3"
+let acpi_s4 = "acpi_s4"
+let mmio_size_mib = "mmio_size_mib"
+let revision = "revision"
+let device_id = "device_id"
+let tsc_mode = "tsc_mode"
+let device_model = "device-model"
+let xenguest = "xenguest"
+let pv_kernel_max_size = "pv-kernel-max-size"
+let pv_ramdisk_max_size = "pv-ramdisk-max-size"
+let pv_postinstall_kernel_max_size = "pv-postinstall-kernel-max-size"
+let pv_postinstall_ramdisk_max_size = "pv-postinstall-ramdisk-max-size"
+let usb = "usb"
+let usb_tablet = "usb_tablet"
+let parallel = "parallel"
+let vga = "vga"
+let vgpu_pci_id = Xapi_globs.vgpu_pci_key
+let vgpu_config = Xapi_globs.vgpu_config_key
+let igd_passthru_key = Xapi_globs.igd_passthru_key
+let featureset = "featureset"
+let nested_virt = "nested-virt"
+
+(* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)
+let filtered_flags = [
+  acpi;
+  apic;
+  nx;
+  pae;
+  viridian;
+  acpi_s3;
+  acpi_s4;
+  mmio_size_mib;
+  revision;
+  device_id;
+  tsc_mode;
+  device_model;
+  xenguest;
+  pv_kernel_max_size;
+  pv_ramdisk_max_size;
+  pv_postinstall_kernel_max_size;
+  pv_postinstall_ramdisk_max_size;
+  usb;
+  usb_tablet;
+  parallel;
+  vga;
+  vgpu_pci_id;
+  vgpu_config;
+  featureset;
+  nested_virt;
+]
+
+(* Other keys we might want to write to the platform map. *)
+let timeoffset = "timeoffset"
+let generation_id = "generation-id"
+
+(* Helper functions. *)
+(* [is_valid key platformdata] returns true if:
+   1. The key is _not_ in platformdata (absence of key is valid) or
+   2. The key is in platformdata, associated with a booleanish value *)
+let is_valid ~key ~platformdata =
+  (not (List.mem_assoc key platformdata)) ||
+  (match List.assoc key platformdata |> String.lowercase with
+  | "true" | "1" | "false" | "0" -> true
+  | v -> false)
+
+let is_true ~key ~platformdata ~default =
+  try
+    match List.assoc key platformdata |> String.lowercase with
+    | "true" | "1" -> true
+    | "false" | "0" -> false
+    | _ -> default (* Check for validity using is_valid if required *)
+  with Not_found ->
+    default
+
+let sanity_check ~platformdata ~vcpu_max ~vcpu_at_startup ~hvm ~filter_out_unknowns =
+  (* Filter out unknown flags, if applicable *)
+  let platformdata =
+    if filter_out_unknowns
+    then List.filter (fun (k, v) -> List.mem k filtered_flags) platformdata
+    else platformdata
+  in
+  (* Filter out invalid TSC modes. *)
+  let platformdata =
+    List.filter
+      (fun (k, v) -> k <> tsc_mode || List.mem v ["0"; "1"; "2"; "3"])
+      platformdata
+  in
+  (* Sanity check for HVM domains with invalid VCPU configuration*)
+  if hvm && (List.mem_assoc "cores-per-socket" platformdata) then
+  begin
+    try
+      let cores_per_socket = int_of_string(List.assoc "cores-per-socket" platformdata) in
+      (* cores per socket has to be in multiples of VCPUs_max and VCPUs_at_startup *)
+      if (((Int64.to_int(vcpu_max) mod cores_per_socket) <> 0)
+        || ((Int64.to_int(vcpu_at_startup) mod cores_per_socket) <> 0)) then
+        raise (Api_errors.Server_error(Api_errors.invalid_value,
+          ["platform:cores-per-socket";
+          "VCPUs_max/VCPUs_at_startup must be a multiple of this field"]))
+    with Failure msg ->
+      raise (Api_errors.Server_error(Api_errors.invalid_value, ["platform:cores-per-socket";
+        Printf.sprintf "value = %s is not a valid int" (List.assoc "cores-per-socket" platformdata)]))
+  end;
+  (* Add usb emulation flags.
+     Make sure we don't send usb=false and usb_tablet=true,
+     as that wouldn't make sense. *)
+  let usb_enabled =
+    is_true ~key:usb ~platformdata ~default:true in
+  let usb_tablet_enabled =
+    if usb_enabled
+    then is_true ~key:usb_tablet ~platformdata ~default:true
+    else false
+  in
+  let platformdata =
+    List.update_assoc
+      [(usb, string_of_bool usb_enabled);
+        (usb_tablet, string_of_bool usb_tablet_enabled)]
+      platformdata
+  in
+  (* Filter out invalid values for the "parallel" key. We don't want to give
+   * guests access to anything other than a real parallel port. *)
+  let platformdata =
+    let is_valid_parallel_flag = function
+      | "none" -> true
+      | dev -> String.startswith "/dev/parport" dev
+    in
+    List.filter
+      (fun (k, v) -> k <> parallel || is_valid_parallel_flag v)
+      platformdata
+  in
+  platformdata
+
+
+let check_restricted_flags ~__context platform =
+  if not (is_valid nested_virt platform) then
+    raise (Api_errors.Server_error
+      (Api_errors.invalid_value,
+       [Printf.sprintf "platform:%s" nested_virt;
+        List.assoc nested_virt platform]));
+
+  if is_true nested_virt platform false
+  then Pool_features.assert_enabled ~__context ~f:Features.Nested_virt
+
+

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -197,7 +197,7 @@ let start ~__context ~vm ~start_paused ~force =
 
 	(* Check to see if we're using any restricted platform kvs. This raises
 	   an exception if so *)
-	Xapi_xenops.Platform.check_restricted_flags ~__context vmr.API.vM_platform;
+	Vm_platform.check_restricted_flags ~__context vmr.API.vM_platform;
 
 	(* Clear out any VM guest metrics record. Guest metrics will be updated by
 	 * the running VM and for now they might be wrong, especially network

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -269,19 +269,10 @@ let check_protection_policy ~vmr ~op ~ref_str =
  * [platform:nested-virt]. If we cannot find a boot record the VM can
  * migrate. A VM can always migrate if strict=false.
  *
- * This function cannot use Xapi_xenops.Platform.is_true as it would
- * create a dependency cycle.
  **)
 let is_mobile strict vm =
-	let is_true ~key ~platform ~default = (* from Xapi_xenops *)
-		try
-			match List.assoc key platform |> String.lowercase with
-			| "true"  | "1" -> true
-			| "false" | "0" -> false
-			| _ -> default (* Check for validity using is_valid if required *)
-		with Not_found -> default in
-	let not_true platform key =
-		not @@ is_true ~key ~platform ~default:false in
+	let not_true platformdata key =
+		not @@ Vm_platform.is_true ~key ~platformdata ~default:false in
 	match strict, vm.Db_actions.vM_last_booted_record with
 	| false, _  -> true (* --force overrides actual checks *)
 	| true , "" -> true (* no LBR exists, VM is not yet started *)


### PR DESCRIPTION
The check is a little more exhaustive: Migration, suspension, and checkpointing must be blocked if either nested virtualisation is active or platform:nomigrate is true. This can be overridden with --force. The commit contains unit tests.

_This commit will be updated to use a library function that interprets boolean values from platform flags._

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>