### PR TITLE
CA-216726: Manage control domains more easily

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2258,7 +2258,7 @@ let vm_query_services printer rpc session_id params =
 let vm_start printer rpc session_id params =
 	let force = get_bool_param params "force" in
 	let paused = get_bool_param params "paused" in
-	ignore(do_vm_op printer rpc session_id
+	ignore(do_vm_op ~include_control_vms:true printer rpc session_id
 		(fun vm ->
 			let vm=vm.getref () in
 			let task =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -633,6 +633,10 @@ let network_reset_trigger = "/tmp/network-reset"
 
 let first_boot_dir = "/etc/firstboot.d/"
 
+(** {2 Xenopsd metadata persistence} *)
+
+let persist_xenopsd_md = "persist_xenopsd_md"
+let persist_xenopsd_md_root = Filename.concat "/var/lib/xcp" "xenopsd_md"
 
 (** Dynamic configurations to be read whenever xapi (re)start *)
 
@@ -832,6 +836,8 @@ let disable_logging_for= ref []
 let igd_passthru_vendor_whitelist = ref []
 
 let gvt_g_whitelist = ref "/etc/gvt-g-whitelist"
+
+
 
 (* The bfs-interfaces script returns boot from SAN NICs.
  * All ISCSI Boot Firmware Table (ibft) NICs should be marked


### PR DESCRIPTION
The persistence of xenopsd metadata is to enable VMs to be started before xapi. See the commit message for details. The second commit is just to enable a feature of the API in the CLI.