### PR TITLE
CA-216724: Prevent control domains other than dom0 from disappearing …

### DIFF
--- a/ocaml/xapi/export.ml
+++ b/ocaml/xapi/export.ml
@@ -476,7 +476,7 @@ let metadata_handler (req: Request.t) s _ =
 					let all_vms = Db.VM.get_all_records ~__context in
 					let interesting_vms = List.filter (fun (_, vm) ->
 						not (is_default_template vm)
-						&& (not vm.API.vM_is_control_domain)
+						&& (not (Helpers.is_domain_zero ~__context (Db.VM.get_by_uuid ~__context ~uuid:vm.API.vM_uuid)))
 					) all_vms in
 					List.map fst interesting_vms
 				end else

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -313,8 +313,9 @@ let get_user ~__context username =
 
 let is_domain_zero ~__context vm_ref =
   let host_ref = Db.VM.get_resident_on ~__context ~self:vm_ref in
-  Db.VM.get_is_control_domain ~__context ~self:vm_ref
-  && Db.Host.get_control_domain ~__context ~self:host_ref = vm_ref
+  (Db.VM.get_is_control_domain ~__context ~self:vm_ref)
+  	&& (Db.is_valid_ref __context host_ref)
+  	&& (Db.Host.get_control_domain ~__context ~self:host_ref = vm_ref)
 
 exception No_domain_zero of string
 let domain_zero_ref_cache = ref None

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -166,10 +166,8 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
 		let my_vms = Db.VM.get_all_records ~__context in
  		let my_running_vms =
 			List.filter
-				(fun (_,vmrec) -> 
-					(not vmrec.API.vM_is_control_domain) && vmrec.API.vM_power_state = `Running
-				)
-				my_vms in
+				(fun (_,vmrec) -> (not (Helpers.is_domain_zero ~__context (Db.VM.get_by_uuid ~__context ~uuid:vmrec.API.vM_uuid)))
+			&& vmrec.API.vM_power_state = `Running) my_vms in
 		if List.length my_running_vms > 0 then begin
 			error "The current host has running or suspended VMs: it cannot join a new pool";
 			raise (Api_errors.Server_error(Api_errors.pool_joining_host_cannot_have_running_VMs, []))


### PR DESCRIPTION
…on pool-join

Ensure we (1) count them in the running VMs during the prechecks and (2) include
them in the exported metadata to be re-imported on join.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>