### PR TITLE
Assert that a VM is running or paused in VM.query_data_source

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1867,6 +1867,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
 		let query_data_source ~__context ~self ~data_source =
 			info "VM.query_data_source: VM = '%s'; data source = '%s'" (vm_uuid ~__context self) data_source;
+			Xapi_vm_lifecycle.assert_power_state_in ~__context ~self ~allowed:[`Running; `Paused];
 			let local_fn = Local.VM.query_data_source ~self ~data_source in
 			forward_vm_op ~local_fn ~__context ~vm:self
 				(fun session_id rpc -> Client.VM.query_data_source rpc session_id self data_source)


### PR DESCRIPTION
Recent changes to forward_vm_op meant that this function no longer raises the
power-state exception that VM.query_data_source relies on, so we add they
assertion back but in query_data_source itself.

Other function that use forward_vm_op have any power-state checks done already
as part of with_vm_operation, but VM.query_data_source was an exception.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>