### PR TITLE
CA-215192: Expose vif-move to the CLI

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5383,6 +5383,15 @@ let vif_unplug_force = call
   ~allowed_roles:_R_VM_ADMIN
   ()
 
+let vif_move = call
+  ~name:"move"
+  ~in_product_since:rel_ely
+  ~doc:"Move the specified VIF to the specified network, even while the VM is running"
+  ~params:[Ref _vif, "self", "The VIF to move";
+	   Ref _network, "network", "The network to move it to"]
+  ~allowed_roles:_R_VM_ADMIN
+  ()
+
 let vif_operations =
   Enum ("vif_operations", 
 	[ "attach", "Attempting to attach this VIF to a VM";
@@ -5508,7 +5517,7 @@ let vif =
       ~doccomments:[] 
       ~messages_default_allowed_roles:_R_VM_ADMIN
       ~doc_tags:[Networking]
-      ~messages:[vif_plug; vif_unplug; vif_unplug_force; vif_set_locking_mode;
+      ~messages:[vif_plug; vif_unplug; vif_unplug_force; vif_move; vif_set_locking_mode;
         vif_set_ipv4_allowed; vif_add_ipv4_allowed; vif_remove_ipv4_allowed; vif_set_ipv6_allowed; vif_add_ipv6_allowed; vif_remove_ipv6_allowed; 
 	vif_configure_ipv4; vif_configure_ipv6]
       ~contents:

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2008,6 +2008,14 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
       implementation=No_fd Cli_operations.vif_configure_ipv6;
       flags=[];
     };
+   "vif-move",
+    {
+      reqd=["uuid";"network-uuid"];
+      optn=[];
+      help="Move the VIF to another network.";
+      implementation=No_fd Cli_operations.vif_move;
+      flags=[];
+    };
    "vm-create",
     {
       reqd=["name-label"];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1591,6 +1591,13 @@ let vif_configure_ipv6 printer rpc session_id params =
 	if mode = `Static && address = "" then failwith "Required parameter not found: address";
 	Client.VIF.configure_ipv6 rpc session_id vif mode address gateway
 
+let vif_move printer rpc session_id params =
+	let uuid = List.assoc "uuid" params in
+	let network_uuid = List.assoc "network-uuid" params in
+	let vif = Client.VIF.get_by_uuid rpc session_id uuid in
+	let network = Client.Network.get_by_uuid rpc session_id network_uuid in
+	Client.VIF.move rpc session_id vif network
+
 let net_create printer rpc session_id params =
 	let network = List.assoc "name-label" params in
 	let descr = List.assoc_default "name-description" params "" in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2761,6 +2761,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 		let unplug ~__context ~self = unplug_common ~__context ~self ~force:false
 		let unplug_force ~__context ~self = unplug_common ~__context ~self ~force:true
 
+		let move ~__context ~self ~network =
+			info "VIF.move: VIF = '%s' network = '%s'" (vif_uuid ~__context self) (network_uuid ~__context network);
+			let local_fn = Local.VIF.move ~self ~network in
+			let remote_fn = (fun session_id rpc -> Client.VIF.move rpc session_id self network) in
+			forward_vif_op ~local_fn ~__context ~self remote_fn
+
 		let set_locking_mode ~__context ~self ~value =
 			info "VIF.set_locking_mode: VIF = '%s'; value = '%s'" (vif_uuid ~__context self) (Record_util.vif_locking_mode_to_string value);
 			let local_fn = Local.VIF.set_locking_mode ~self ~value in

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -114,7 +114,7 @@ let move_vlan ~__context host new_slave old_vlan =
 			let new_network = Db.PIF.get_network ~__context ~self:new_master in
 			(* Move VIFs to other VLAN's network *)
 			let vifs = get_local_vifs ~__context host [network] in
-			ignore (List.map (Xapi_vif.move ~__context ~network:new_network) vifs);
+			ignore (List.map (Xapi_vif.move_internal ~__context ~network:new_network) vifs);
 			new_vlan, new_master
 		| [] ->
 			(* VLAN with this tag not yet on bond *)
@@ -135,12 +135,12 @@ let move_vlan ~__context host new_slave old_vlan =
 		debug "Plugging new VLAN";
 		Nm.bring_pif_up ~__context new_master;
 
-		(* Call Xapi_vif.move on VIFs of running VMs to make sure they end up on the right vSwitch *)
+		(* Call Xapi_vif.move_internal on VIFs of running VMs to make sure they end up on the right vSwitch *)
 		let vifs = Db.Network.get_VIFs ~__context ~self:network in
 		let vifs = List.filter (fun vif ->
 			Db.VM.get_resident_on ~__context ~self:(Db.VIF.get_VM ~__context ~self:vif) = host)
 			vifs in
-		ignore (List.map (Xapi_vif.move ~__context ~network:network) vifs);
+		ignore (List.map (Xapi_vif.move_internal ~__context ~network:network) vifs);
 	end
 
 let move_tunnel ~__context host new_transport_PIF old_tunnel =
@@ -163,12 +163,12 @@ let move_tunnel ~__context host new_transport_PIF old_tunnel =
 		debug "Plugging moved tunnel";
 		Nm.bring_pif_up ~__context new_access_PIF;
 
-		(* Call Xapi_vif.move to make sure vifs end up on the right vSwitch *)
+		(* Call Xapi_vif.move_internal to make sure vifs end up on the right vSwitch *)
 		let vifs = Db.Network.get_VIFs ~__context ~self:network in
 		let vifs = List.filter (fun vif ->
 			Db.VM.get_resident_on ~__context ~self:(Db.VIF.get_VM ~__context ~self:vif) = host)
 			vifs in
-		ignore (List.map (Xapi_vif.move ~__context ~network:network) vifs);
+		ignore (List.map (Xapi_vif.move_internal ~__context ~network:network) vifs);
 	end
 
 let move_management ~__context from_pif to_pif =
@@ -202,7 +202,7 @@ let fix_bond ~__context ~bond =
 
 	(* Move VIFs from members to master *)
 	debug "Checking VIFs to move from slaves to master";
-	List.iter (Xapi_vif.move ~__context ~network) local_vifs;
+	List.iter (Xapi_vif.move_internal ~__context ~network) local_vifs;
 
 	begin match List.filter (fun p -> Db.PIF.get_management ~__context ~self:p) members with
 		| management_pif :: _ -> 
@@ -396,7 +396,7 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
 
 		(* Move VIFs from members to master *)
 		debug "Check VIFs to move from slaves to master";
-		List.iter (Xapi_vif.move ~__context ~network) local_vifs;
+		List.iter (Xapi_vif.move_internal ~__context ~network) local_vifs;
 		TaskHelper.set_progress ~__context 0.8;
 
 		(* Set disallow_unplug on the master, if one of the slaves had disallow_unplug = true (see above),
@@ -449,7 +449,7 @@ let destroy ~__context ~self =
 
 		(* Move VIFs from master to slaves *)
 		debug "Check VIFs to move from master to slaves";
-		List.iter (Xapi_vif.move ~__context ~network:primary_slave_network) local_vifs;
+		List.iter (Xapi_vif.move_internal ~__context ~network:primary_slave_network) local_vifs;
 		TaskHelper.set_progress ~__context 0.4;
 
 		(* Move VLANs down *)

--- a/ocaml/xapi/xapi_network_attach_helpers.ml
+++ b/ocaml/xapi/xapi_network_attach_helpers.ml
@@ -12,6 +12,8 @@
  * GNU Lesser General Public License for more details.
  *)
 
+open Stdext
+open Listext
 module D=Debug.Make(struct let name="xapi" end)
 open D
 
@@ -69,4 +71,72 @@ let assert_no_slave ~__context pif =
 let assert_can_attach_network_on_host ~__context ~self ~host =
   let local_pifs = get_local_pifs ~__context ~network:self ~host in
   List.iter (fun pif -> assert_no_slave ~__context pif) local_pifs
+
+let assert_can_see_named_networks ~__context ~vm ~host reqd_nets =
+	let is_network_available_on host net =
+		(* has the network been actualised by one or more PIFs? *)
+		let pifs = Db.Network.get_PIFs ~__context ~self:net in
+		if pifs <> [] then begin
+			(* network is only available if one of  *)
+			(* the PIFs connects to the target host *)
+			let hosts =
+				List.map (fun self -> Db.PIF.get_host ~__context ~self) pifs in
+			List.mem host hosts
+		end else begin
+			let other_config = Db.Network.get_other_config ~__context ~self:net in
+			if List.mem_assoc Xapi_globs.assume_network_is_shared other_config && (List.assoc Xapi_globs.assume_network_is_shared other_config = "true") then begin
+				debug "other_config:%s is set on Network %s" Xapi_globs.assume_network_is_shared (Ref.string_of net);
+				true
+			end else begin
+				(* find all the VIFs on this network and whose VM's are running. *)
+				(* XXX: in many environments this will perform O (Vms) calls to  *)
+				(* VM.getRecord. *)
+				let vifs = Db.Network.get_VIFs ~__context ~self:net in
+				let vms = List.map (fun self -> Db.VIF.get_VM ~__context ~self) vifs in
+				let vms = List.map (fun self -> Db.VM.get_record ~__context ~self) vms in
+				let vms = List.filter (fun vm -> vm.API.vM_power_state = `Running) vms in
+				let hosts = List.map (fun vm -> vm.API.vM_resident_on) vms in
+				(* either not pinned to any host OR pinned to this host already *)
+				hosts = [] || (List.mem host hosts)
+			end
+		end
+	in
+
+	let avail_nets = List.filter (is_network_available_on host) reqd_nets in
+	let not_available = List.set_difference reqd_nets avail_nets in
+
+	List.iter
+		(fun net -> warn "Host %s cannot see Network %s"
+			(Helpers.checknull
+				(fun () -> Db.Host.get_name_label ~__context ~self:host))
+			(Helpers.checknull
+				(fun () -> Db.Network.get_name_label ~__context ~self:net)))
+		not_available;
+	if not_available <> [] then
+		raise (Api_errors.Server_error (Api_errors.vm_requires_net, [
+			Ref.string_of vm;
+			Ref.string_of (List.hd not_available)
+		]));
+
+	(* Also, for each of the available networks, we need to ensure that we can bring it
+	 * up on the specified host; i.e. it doesn't need an enslaved PIF. *)
+	List.iter
+		(fun network->
+			try
+				assert_can_attach_network_on_host
+					~__context
+					~self:network
+					~host
+			(* throw exception more appropriate to this context: *)
+			with exn ->
+				debug
+					"Caught exception while checking if network %s could be attached on host %s:%s"
+					(Ref.string_of network)
+					(Ref.string_of host)
+					(ExnHelper.string_of_exn exn);
+				raise (Api_errors.Server_error (
+					Api_errors.host_cannot_attach_network, [
+						Ref.string_of host; Ref.string_of network ]))
+		)
+		avail_nets
 

--- a/ocaml/xapi/xapi_network_attach_helpers.mli
+++ b/ocaml/xapi/xapi_network_attach_helpers.mli
@@ -37,6 +37,11 @@ val assert_no_slave :
   [ `PIF ] Ref.t ->
   unit
 
+(** Raises an exception if any network cannot be seen *)
+val assert_can_see_named_networks :
+  __context:Context.t ->
+  vm:[ `VM ]Ref.t -> host:[ `host ] Ref.t -> [ `network ] Ref.t list -> unit
+
 (** Raises an exception if the network cannot be attached. *)
 val assert_can_attach_network_on_host :
   __context:Context.t ->

--- a/ocaml/xapi/xapi_vif.ml
+++ b/ocaml/xapi/xapi_vif.ml
@@ -55,12 +55,32 @@ let refresh_filtering_rules ~__context ~self =
 
 (* This function moves a dom0 vif device from one bridge to another, without involving the guest,
  * so it also works on guests that do not support hot(un)plug of VIFs. *)
-let move ~__context ~network vif =
+let move_internal ~__context ~network ?active vif =
 	debug "Moving VIF %s to network %s" (Db.VIF.get_uuid ~__context ~self:vif)
 		(Db.Network.get_uuid ~__context ~self:network);
+	let active =
+		match active with
+		| None -> device_active ~__context ~self:vif
+		| Some x -> x
+	in
 	Db.VIF.set_network ~__context ~self:vif ~value:network;
-	if device_active ~__context ~self:vif
+	if active
 	then Xapi_xenops.vif_move ~__context ~self:vif network
+
+let move ~__context ~self ~network =
+	let active = device_active ~__context ~self in
+	if active
+	then begin
+		let vm = Db.VIF.get_VM ~__context ~self in
+		let host = Db.VM.get_resident_on ~__context ~self:vm in
+		try Xapi_network_attach_helpers.assert_can_see_named_networks ~__context ~vm:vm ~host:host [network] with
+		| Api_errors.Server_error (name, _)
+			when name = Api_errors.vm_requires_net ->
+				raise (Api_errors.Server_error (
+					Api_errors.host_cannot_attach_network, [
+					Ref.string_of host; Ref.string_of network ]))
+	end;
+	move_internal ~__context ~network ~active self
 
 let change_locking_config ~__context ~self ~licence_check f =
 	if licence_check then assert_locking_licensed ~__context;

--- a/ocaml/xapi/xapi_vif.mli
+++ b/ocaml/xapi/xapi_vif.mli
@@ -61,12 +61,20 @@ val destroy : __context:Context.t -> self:[ `VIF ] Ref.t -> unit
 (** {2 Helper Functions} *)
 
 (** Move a VIF to another Network. *)
-val move :
+val move_internal :
 	__context:Context.t ->
 	network:[ `network ] Ref.t ->
+	?active:bool ->
 	[ `VIF ] Ref.t ->
 	unit
-	
+
+(** Move a VIF to another Network. *)
+val move :
+	__context:Context.t ->
+	self:[ `VIF ] Ref.t ->
+	network:[ `network ] Ref.t ->
+	unit
+
 (** Throw error if the given operation is not in the list of allowed operations.
  *  Implemented by {!Xapi_vif_helpers.assert_operation_valid} *)
 val assert_operation_valid :

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -19,6 +19,7 @@ open Stdext
 open Xstringext
 open Printf
 open Xapi_vm_memory_constraints
+open Xapi_network_attach_helpers
 open Listext
 open Fun
 module XenAPI = Client.Client
@@ -277,73 +278,7 @@ let assert_can_see_networks ~__context ~self ~host =
 	let vifs = Db.VM.get_VIFs ~__context ~self in
 	let reqd_nets =
 		List.map (fun self -> Db.VIF.get_network ~__context ~self) vifs in
-
-	let is_network_available_on host net =
-		(* has the network been actualised by one or more PIFs? *)
-		let pifs = Db.Network.get_PIFs ~__context ~self:net in
-		if pifs <> [] then begin
-			(* network is only available if one of  *)
-			(* the PIFs connects to the target host *)
-			let hosts =
-				List.map (fun self -> Db.PIF.get_host ~__context ~self) pifs in
-			List.mem host hosts
-		end else begin
-			let other_config = Db.Network.get_other_config ~__context ~self:net in
-			if List.mem_assoc Xapi_globs.assume_network_is_shared other_config && (List.assoc Xapi_globs.assume_network_is_shared other_config = "true") then begin
-				debug "other_config:%s is set on Network %s" Xapi_globs.assume_network_is_shared (Ref.string_of net);
-				true
-			end else begin
-				(* find all the VIFs on this network and whose VM's are running. *)
-				(* XXX: in many environments this will perform O (Vms) calls to  *)
-				(* VM.getRecord. *)
-				let vifs = Db.Network.get_VIFs ~__context ~self:net in
-				let vms = List.map (fun self -> Db.VIF.get_VM ~__context ~self) vifs in
-				let vms = List.map (fun self -> Db.VM.get_record ~__context ~self) vms in
-				let vms = List.filter (fun vm -> vm.API.vM_power_state = `Running) vms in
-				let hosts = List.map (fun vm -> vm.API.vM_resident_on) vms in
-				(* either not pinned to any host OR pinned to this host already *)
-				hosts = [] || (List.mem host hosts)
-			end
-		end
-	in
-
-	let avail_nets = List.filter (is_network_available_on host) reqd_nets in
-	let not_available = List.set_difference reqd_nets avail_nets in
-
-	List.iter
-		(fun net -> warn "Host %s cannot see Network %s"
-			(Helpers.checknull
-				(fun () -> Db.Host.get_name_label ~__context ~self:host))
-			(Helpers.checknull
-				(fun () -> Db.Network.get_name_label ~__context ~self:net)))
-		not_available;
-	if not_available <> [] then
-		raise (Api_errors.Server_error (Api_errors.vm_requires_net, [
-			Ref.string_of self;
-			Ref.string_of (List.hd not_available)
-		]));
-
-	(* Also, for each of the available networks, we need to ensure that we can bring it
-	 * up on the specified host; i.e. it doesn't need an enslaved PIF. *)
-	List.iter
-		(fun network->
-			try
-				Xapi_network_attach_helpers.assert_can_attach_network_on_host
-					~__context
-					~self:network
-					~host
-			(* throw exception more appropriate to this context: *)
-			with exn ->
-				debug
-					"Caught exception while checking if network %s could be attached on host %s:%s"
-					(Ref.string_of network)
-					(Ref.string_of host)
-					(ExnHelper.string_of_exn exn);
-				raise (Api_errors.Server_error (
-					Api_errors.host_cannot_attach_network, [
-						Ref.string_of host; Ref.string_of network ]))
-		)
-		avail_nets
+	assert_can_see_named_networks ~__context ~vm:self ~host reqd_nets
 
 (* IOMMU (VT-d) is required iff the VM has any vGPUs which require PCI
  * passthrough. *)


### PR DESCRIPTION
Add vif-move command, including sanity checking that the
requested network can be seen from the host running the VM (if it's running)

Replaces https://github.com/xapi-project/xen-api/pull/2697

Signed-off-by: Bob Ball <bob.ball@citrix.com>