### PR TITLE
Remove local definitions of the |> operator

### DIFF
--- a/ocaml/license/license_init.ml
+++ b/ocaml/license/license_init.ml
@@ -15,8 +15,6 @@
 module D = Debug.Make(struct let name="license" end)
 open D
 
-let ( |> ) a b = b a
-
 (* Dependency injection for unit tests *)
 module type V6clientS = module type of V6client
 let v6client = ref (module V6client : V6clientS)

--- a/ocaml/test/mock.ml
+++ b/ocaml/test/mock.ml
@@ -12,8 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-let ( |> ) a b = b a
-
 module Database = struct
 
 	let _schema = Datamodel_schema.of_datamodel () ;;

--- a/ocaml/test/suite.ml
+++ b/ocaml/test/suite.ml
@@ -14,8 +14,6 @@
 
 open OUnit
 
-let ( |> ) a b = b a
-
 let base_suite =
 	"base_suite" >:::
 		[

--- a/ocaml/xapi/cancel_tests.ml
+++ b/ocaml/xapi/cancel_tests.ml
@@ -14,8 +14,6 @@
 open Client
 open Pervasiveext
 
-let ( |> ) a b = b a
-
 let debug (fmt: ('a , unit, string, unit) format4) =
   (* Convert calendar time, x, to tm in UTC *)
   let of_float x = 


### PR DESCRIPTION
We no longer support versions of OCaml which don't have this operator
in the standard library.

Signed-off-by: Euan Harris <euan.harris@citrix.com>