### PR TITLE
CAR-2259: Faster VM import and export

### DIFF
--- a/ocaml/test/OMakefile
+++ b/ocaml/test/OMakefile
@@ -1,6 +1,6 @@
 OCAMLPACKS = oUnit sexpr xcp xmlm stunnel xml-light2 http-svr uuid	\
              netdev tapctl xenctrl xenctrlext xenstore-compat	\
-             pciutil oclock gzip sha1 xcp.network xcp.rrd xcp.storage	\
+             pciutil oclock gzip sha1 sha.sha1 xcp.network xcp.rrd xcp.storage	\
              xcp.xen xcp.memory tar tar.unix oPasswd xcp-inventory \
              rrdd-plugin pci xapi-test-utils
 

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -1,6 +1,6 @@
 OCAMLPACKS = oclock xml-light2 cdrom pciutil sexpr xcp stunnel		\
              http-svr netdev tapctl rpclib xenstore-compat	\
-             uuid gzip sha1 xcp.network xcp.rrd xcp.storage	\
+             uuid gzip sha1 sha.sha1 xcp.network xcp.rrd xcp.storage	\
              xcp.xen xcp.memory tar tar.unix oPasswd xcp-inventory \
              rrdd-plugin pci
 

--- a/ocaml/xapi/stream_vdi.ml
+++ b/ocaml/xapi/stream_vdi.ml
@@ -94,11 +94,8 @@ let write_block ~__context filename buffer ofd len =
   let hdr = Tar_unix.Header.make filename (Int64.of_int len) in
 
   try
-	let csum = Sha1sum.sha1sum
-	  (fun checksumfd ->
-		   Tar_unix.write_block hdr (fun ofd -> Tar_unix.Archive.multicast_n_string buffer 
-									[ ofd; checksumfd ] len) ofd
-	  ) in
+	let csum = Sha1.to_hex (Sha1.string buffer) in
+	Tar_unix.write_block hdr (fun ofd -> Tar_unix.Archive.multicast_n_string buffer [ ofd ] len ) ofd;
 	(* Write the checksum as a separate file *)
 	let hdr' = Tar_unix.Header.make (filename ^ checksum_extension) (Int64.of_int (String.length csum)) in
 	Tar_unix.write_block hdr' (fun ofd -> ignore(Unix.write ofd csum 0 (String.length csum))) ofd

--- a/ocaml/xapi/stream_vdi.ml
+++ b/ocaml/xapi/stream_vdi.ml
@@ -262,10 +262,11 @@ let recv_all refresh_session ifd (__context:Context.t) rpc session_id vsn force 
 		  done
 	      end;
 		
-	    let csum = Sha1sum.sha1sum
-	      (fun checksumfd ->
-		 Tar_unix.Archive.multicast_n ifd [ ofd; checksumfd ] length) in
-	    
+	    let buffer = String.make (Int64.to_int length) '\000' in
+	    Unixext.really_read ifd buffer 0 (Int64.to_int length);
+	    Tar_unix.Archive.multicast_n_string buffer [ ofd ] (Int64.to_int length);
+	    let csum = Sha1.to_hex (Sha1.string buffer) in
+	
 	    checksum_table := (file_name, csum) :: !checksum_table;
 
 	    Tar_unix.Archive.skip ifd (Tar_unix.Header.compute_zero_padding_length hdr);

--- a/opam
+++ b/opam
@@ -32,6 +32,7 @@ depends: [
   "opasswd" {>= "0.9.3"}
   "xapi-rrdd-plugin"
   "pci" {>= "0.2.0"}
+  "sha"
 ]
 depexts: [
   [["centos"] ["pam-devel"]]


### PR DESCRIPTION
This patch series adds some vhd-tool VDI import and export performance features to Xapi to improve its VM import and export performance. This is considered a better option than calling vhd-tool from Xapi, because adding Xapi VM import and export features to vhd-tool is considerably more difficult and error-prone.

The resulting VM import and export performance in Xapi is better than the corresponding VDI import and export performance in vhd-tool, for the same amount of VDI data:

| Time for a 10GiB VDI with random data | `xe vm-export`                         | `vhd-tool export` | `xe vm-import`                         | `vhd-tool import` | 
|---------------------------------------|----------------------------------------|-------------------|----------------------------------------|-------------------|
| before patches                        | 131s (sha1sum)                         | 68s (ocaml-sha)   | 102s (sha1sum)                         | 66s (ocaml-sha)   |  
| after patches                         |  60s **(faster than vhd-tool export)** |                   |  56s **(faster than vhd-tool import)** |                   | 