### PR TITLE
CAR-2259: add ocaml-sha-devel dependency to xapi

### DIFF
--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -37,6 +37,7 @@ BuildRequires: ocaml-stdext-devel
 BuildRequires: ocaml-tapctl-devel
 BuildRequires: ocaml-cmdliner-devel
 BuildRequires: ocaml-opasswd-devel
+BuildRequires: ocaml-sha-devel
 BuildRequires: git
 BuildRequires: ocaml-xcp-inventory-devel
 BuildRequires: ocaml-xenstore-devel


### PR DESCRIPTION
This is a dependency to build https://github.com/xapi-project/xen-api/pull/2735

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>