### PR TITLE
Revert "CA-219717: make xapi require xcp-rrdd"

### DIFF
--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=XenAPI server (XAPI)
 After=syslog.target forkexecd.service xcp-networkd.service message-switch.service v6d.service save-boot-info.service attach-static-vdis.service genptoken.service xcp-rrdd.service xapi-storage-script.service xenopsd-xc.service xenstored.service xcp-networkd.service
-Requires=xcp-rrdd.service
 Conflicts=shutdown.target
 
 [Service]


### PR DESCRIPTION
This reverts commit dce1cc044d931b1fe89721c9471034e5ea882321.

That commit made xapi stop when xcp-rrdd stops, which we don't want. Also it
didn't fix CA-219717, which was actually a problem in the relationship between
xcp-rrdd and forkexecd.