### PR TITLE
CP-18710 - Eliminate spurious stack traces from log files

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -942,10 +942,10 @@ let server_init() =
       "considering executing on-master-start script", [],
         (fun () -> Xapi_pool_transition.run_external_scripts (Pool_role.is_master ()));
       "creating networks", [ Startup.OnlyMaster ], Create_networks.create_networks_localhost;
-      "updating the vswitch controller", [], (fun () -> Helpers.update_vswitch_controller ~__context ~host:(Helpers.get_localhost ~__context)); 
       (* CA-22417: bring up all non-bond slaves so that the SM backends can use storage NIC IP addresses (if the routing
 	 table happens to be right) *)
       "Best-effort bring up of physical NICs", [ Startup.NoExnRaising ], Xapi_pif.start_of_day_best_effort_bring_up;
+      "updating the vswitch controller", [], (fun () -> Helpers.update_vswitch_controller ~__context ~host:(Helpers.get_localhost ~__context));
       "initialising storage", [ Startup.NoExnRaising ],
                 (fun () -> Helpers.call_api_functions ~__context Create_storage.create_storage_localhost);
       (* CA-13878: make sure PBD plugging has happened before attempting to reboot any VMs *)

--- a/scripts/xapi-autostart-vms
+++ b/scripts/xapi-autostart-vms
@@ -16,13 +16,11 @@ XAPI_START_TIMEOUT_SECONDS=240
 
 if [ $? -eq 0 ]; then
 
-    pool=$(xe pool-list params=uuid --minimal 2> /dev/null)
-
-	auto_poweron=$(xe pool-param-get uuid=${pool} param-name=other-config param-key=auto_poweron 2> /dev/null)
-	if [ $? -eq 0 ] && [ "${auto_poweron}" = "true" ]; then
+	auto_poweron_pool=$(xe pool-list params=uuid other-config:auto_poweron=true --minimal 2> /dev/null)
+	
+	if [ $? -eq 0 ] && [ -n "$auto_poweron_pool" ]; then
 		logger "$0 auto_poweron is enabled on the pool-- this is an unsupported configuration."
-		
-    	# if xapi init completed then start vms (best effort, don't report errors)
+		# if xapi init completed then start vms (best effort, don't report errors)
 		xe vm-start other-config:auto_poweron=true power-state=halted --multiple >/dev/null 2>/dev/null || true
 	fi
 fi


### PR DESCRIPTION
Update openvswitch configuration only after the `xenbr*` bridges are configured, avoiding many backtraces.

Use `xe` filtering capabilities to avoid an innocuous backtrace in the logs.