### PR TITLE
 CA-220154 - host-backup can fail silently and be considered successful

### DIFF
--- a/scripts/host-backup-restore/host-backup
+++ b/scripts/host-backup-restore/host-backup
@@ -11,15 +11,22 @@
 
 DATE=$(date +%F--%H-%M-%S)
 POOL_DB_BACKUP=/var/backup/pool-database-${DATE}
-EXCLUDE_FILE=${POOL_DB_BACKUP}-exclude
 [ -e ${POOL_DB_BACKUP} ] && rm -f ${POOL_DB_BACKUP}
 mkdir -p $(dirname ${POOL_DB_BACKUP})
-xe pool-dump-database file-name=${POOL_DB_BACKUP}
 
-# List of sockets for tar to ignore. This is just to declutter the log output. 
-pushd / > /dev/null
-find var -type s > "${EXCLUDE_FILE}" 2> /dev/null
-popd > /dev/null
+function cleanup {
+  # Remove the backup of the pool-database. 
+  # We only need it to be present in the tar file.
+  # During restore the tar file is extracted over the backup partition which 
+  # is then made bootable.  Following a reboot the user must manually call 
+  # "xe pool-restore-database" on the pool-database backup file.
+
+  rm -f ${POOL_DB_BACKUP}
+}
+trap cleanup EXIT
+
+set -e
+xe pool-dump-database file-name=${POOL_DB_BACKUP}
 
 # Exclude everything under /tmp (as it is temporary) and everything under /var/crash
 # (as it might contain large sparse files).  The directories themselves still need to
@@ -29,19 +36,6 @@ tar --exclude 'tmp/*' --exclude 'tmp/.*' --exclude 'var/crash/*' --exclude 'var/
     --exclude 'var/log/audit*' \
     --exclude 'var/xsconfig/*' --exclude 'var/xsconfig/.*' \
     --exclude 'var/xapi/[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*' \
-    --exclude-from ${EXCLUDE_FILE} --exclude ${EXCLUDE_FILE} \
+    --warning='no-file-ignored' \
     --sparse --preserve-permissions --to-stdout --gzip --one-file-system -C / -c . 
-
-TAR_EXIT_STATUS=$?
-
-# Remove the backup of the pool-database and the exclude list.
-# We only need it to be present in the tar file.
-# During restore the tar file is extracted over the backup partition which is then made
-# bootable.  Following a reboot the user must manually call "xe pool-restore-database" on 
-# the pool-database backup file.
-
-rm -f ${POOL_DB_BACKUP} ${EXCLUDE_FILE}
-
-# if tar failed we need to know
-exit $TAR_EXIT_STATUS
 

--- a/scripts/host-backup-restore/host-backup
+++ b/scripts/host-backup-restore/host-backup
@@ -9,11 +9,17 @@
 # Create a backup of the pool-database.  This is needed because the state in memory
 # is not guarranteed to be flushed to disk.
 
-DATE=$(date +%F--%k-%M-%S)
+DATE=$(date +%F--%H-%M-%S)
 POOL_DB_BACKUP=/var/backup/pool-database-${DATE}
+EXCLUDE_FILE=${POOL_DB_BACKUP}-exclude
 [ -e ${POOL_DB_BACKUP} ] && rm -f ${POOL_DB_BACKUP}
 mkdir -p $(dirname ${POOL_DB_BACKUP})
 xe pool-dump-database file-name=${POOL_DB_BACKUP}
+
+# List of sockets for tar to ignore. This is just to declutter the log output. 
+pushd / > /dev/null
+find var -type s > "${EXCLUDE_FILE}" 2> /dev/null
+popd > /dev/null
 
 # Exclude everything under /tmp (as it is temporary) and everything under /var/crash
 # (as it might contain large sparse files).  The directories themselves still need to
@@ -23,11 +29,19 @@ tar --exclude 'tmp/*' --exclude 'tmp/.*' --exclude 'var/crash/*' --exclude 'var/
     --exclude 'var/log/audit*' \
     --exclude 'var/xsconfig/*' --exclude 'var/xsconfig/.*' \
     --exclude 'var/xapi/[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*' \
+    --exclude-from ${EXCLUDE_FILE} --exclude ${EXCLUDE_FILE} \
     --sparse --preserve-permissions --to-stdout --gzip --one-file-system -C / -c . 
 
-# Remove the backup of the pool-database.  We only need it to be present in the tar file.
+TAR_EXIT_STATUS=$?
+
+# Remove the backup of the pool-database and the exclude list.
+# We only need it to be present in the tar file.
 # During restore the tar file is extracted over the backup partition which is then made
 # bootable.  Following a reboot the user must manually call "xe pool-restore-database" on 
 # the pool-database backup file.
 
-rm -f ${POOL_DB_BACKUP}
+rm -f ${POOL_DB_BACKUP} ${EXCLUDE_FILE}
+
+# if tar failed we need to know
+exit $TAR_EXIT_STATUS
+


### PR DESCRIPTION
`xe host-backup` invokes an external script (`host-backup`) that terminates successfully also when some of its subcommands fail. This may leave the backup in a partially corrupted state.

As an example, the following is extracted from a log: `host_backup succeeded - returned: tar: -: Wrote only 4096 of 10240 bytes#012tar: Error is not recoverable: exiting now.`

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>