### PR TITLE
CP-18759 - Eliminate spurious stack traces from log files (2)

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -709,8 +709,8 @@ let make_param_funs getall getallrecs getbyuuid record class_name def_filters de
 		let param_name = List.assoc "param-name" params in
 		let param_key = List.assoc "param-key" params in
 		match field_lookup record param_name with
-			| { get_set = Some g; remove_from_set = Some f } -> if List.mem param_key (g ()) then f param_key else failwith "Key is not in the set"
-			| { get_map = Some g; remove_from_map = Some f } -> if List.mem_assoc param_key (g ()) then f param_key else failwith "Key is not in map"
+			| { get_set = Some g; remove_from_set = Some f } -> if List.mem param_key (g ()) then f param_key else failwith (Printf.sprintf "Key %s is not in the set" param_key)
+			| { get_map = Some g; remove_from_map = Some f } -> if List.mem_assoc param_key (g ()) then f param_key else failwith (Printf.sprintf "Key %s is not in map" param_key)
 			| { get_set = Some _; remove_from_set = None }
 			| { get_map = Some _; remove_from_map = None } -> failwith "Cannot remove parameters from read-only map"
 			| _ -> failwith "Can only remove from parameters of type Set or Map"

--- a/scripts/xe-set-iscsi-iqn
+++ b/scripts/xe-set-iscsi-iqn
@@ -30,5 +30,4 @@ fi
 
 . @INVENTORY@
 
-${XE} host-param-remove uuid=${INSTALLATION_UUID} param-name=${configmap} param-key=${configkey} || true
-${XE} host-param-set uuid=${INSTALLATION_UUID} ${configmap}-${configkey}=${iqn}
+${XE} host-param-set uuid=${INSTALLATION_UUID} ${configmap}:${configkey}=${iqn}


### PR DESCRIPTION
This is a minor fix to avoid a parameter lookup that was generating spurious backtraces in the log files. 

While investigating this I've noticed that only some of the error messages where explicitly identifying which key was the cause of the error, so I added the information to the other error messages as well.