### PR TITLE
CP-18294/Bromium maintain nested_vir, nomigrate, hvm as reported by xenopsd

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -769,6 +769,12 @@ let vm_record rpc session_id vm =
 			make_field ~name:"console-uuids"
 				~get:(fun () -> String.concat "; " (List.map get_uuid_from_ref (x ()).API.vM_consoles))
 				~get_set:(fun () -> List.map get_uuid_from_ref (x ()).API.vM_consoles) ();
+			make_field ~name:"nomigrate"
+				~get:(fun () -> default "false" (may (fun m ->
+					string_of_bool m.API.vM_metrics_nomigrate) (xm ()) )) ();
+			make_field ~name:"nested-virt"
+				~get:(fun () -> default "false" (may (fun m ->
+					string_of_bool m.API.vM_metrics_nested_virt) (xm ()) )) ();
 			make_field ~name:"platform"
 				~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.vM_platform)
 				~add_to_map:(fun k v -> Client.VM.add_to_platform rpc session_id vm k v)

--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -769,6 +769,9 @@ let vm_record rpc session_id vm =
 			make_field ~name:"console-uuids"
 				~get:(fun () -> String.concat "; " (List.map get_uuid_from_ref (x ()).API.vM_consoles))
 				~get_set:(fun () -> List.map get_uuid_from_ref (x ()).API.vM_consoles) ();
+			make_field ~name:"hvm"
+				~get:(fun () -> default "false" (may (fun m ->
+					string_of_bool m.API.vM_metrics_hvm) (xm ()) )) ();
 			make_field ~name:"nomigrate"
 				~get:(fun () -> default "false" (may (fun m ->
 					string_of_bool m.API.vM_metrics_nomigrate) (xm ()) )) ();

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7500,7 +7500,7 @@ let vm_metrics =
 		  "other_config" "additional configuration"
 		  ~persist:false
 		; field ~in_product_since:rel_ely ~default_value:(Some (VBool false))
-		  ~ty:Bool
+		  ~ty:Bool ~qualifier:DynamicRO
 		  "hvm" "hardware virtual machine"
 		  ~persist:false
 		; field ~in_product_since:rel_ely ~default_value:(Some (VBool false))

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 100
+let schema_minor_vsn = 101
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -7498,6 +7498,18 @@ let vm_metrics =
 		; field ~in_product_since:rel_orlando ~default_value:(Some (VMap []))
 		  ~ty:(Map(String, String))
 		  "other_config" "additional configuration"
+		  ~persist:false
+		; field ~in_product_since:rel_ely ~default_value:(Some (VBool false))
+		  ~ty:Bool
+		  "hvm" "hardware virtual machine"
+		  ~persist:false
+		; field ~in_product_since:rel_ely ~default_value:(Some (VBool false))
+		  ~ty:Bool
+		  "nested_virt" "VM supports nested virtualisation"
+		  ~persist:false
+		; field ~in_product_since:rel_ely ~default_value:(Some (VBool false))
+		  ~ty:Bool
+		  "nomigrate" "VM is immobile and can't migrate between hosts"
 		  ~persist:false
 		]
 		()

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7504,11 +7504,11 @@ let vm_metrics =
 		  "hvm" "hardware virtual machine"
 		  ~persist:false
 		; field ~in_product_since:rel_ely ~default_value:(Some (VBool false))
-		  ~ty:Bool
+		  ~ty:Bool ~qualifier:DynamicRO
 		  "nested_virt" "VM supports nested virtualisation"
 		  ~persist:false
 		; field ~in_product_since:rel_ely ~default_value:(Some (VBool false))
-		  ~ty:Bool
+		  ~ty:Bool ~qualifier:DynamicRO
 		  "nomigrate" "VM is immobile and can't migrate between hosts"
 		  ~persist:false
 		]

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7467,22 +7467,40 @@ let vm_vcpu_metrics =
     field ~qualifier:DynamicRO ~ty:(Map (Int, Set String)) "flags" "CPU flags (blocked,online,running)" ~persist:false;
   ]
 
-let vm_metrics = 
-    create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_vm_metrics ~descr:"The metrics associated with a VM"
-      ~gen_events:true
-      ~doccomments:[]
-      ~messages_default_allowed_roles:_R_VM_ADMIN
-      ~messages:[] ~contents:
-      [ uid _vm_metrics;
-	namespace ~name:"memory" ~contents:vm_memory_metrics ();
-	namespace ~name:"VCPUs" ~contents:vm_vcpu_metrics ();
-	field ~qualifier:DynamicRO ~ty:(Set (String)) "state" "The state of the guest, eg blocked, dying etc" ~persist:false;
-	field ~qualifier:DynamicRO ~ty:DateTime "start_time" "Time at which this VM was last booted";
-	field ~in_oss_since:None ~qualifier:DynamicRO ~ty:DateTime "install_time" "Time at which the VM was installed";
-	field ~qualifier:DynamicRO ~ty:DateTime "last_updated" "Time at which this information was last updated" ~persist:false;
-	field ~in_product_since:rel_orlando ~default_value:(Some (VMap [])) ~ty:(Map(String, String)) "other_config" "additional configuration" ~persist:false;
-      ]
-	()
+let vm_metrics =
+	create_obj
+		~in_db:true
+		~in_product_since:rel_rio
+		~in_oss_since:oss_since_303
+		~internal_deprecated_since:None
+		~persist:PersistEverything
+		~gen_constructor_destructor:false
+		~name:_vm_metrics
+		~descr:"The metrics associated with a VM"
+		~gen_events:true
+		~doccomments:[]
+		~messages_default_allowed_roles:_R_VM_ADMIN
+		~messages:[]
+		~contents:
+		[ uid _vm_metrics
+		; namespace ~name:"memory" ~contents:vm_memory_metrics ()
+		; namespace ~name:"VCPUs" ~contents:vm_vcpu_metrics ()
+		; field ~qualifier:DynamicRO ~ty:(Set (String))
+		  "state" "The state of the guest, eg blocked, dying etc"
+		  ~persist:false
+		; field ~qualifier:DynamicRO ~ty:DateTime
+		  "start_time" "Time at which this VM was last booted"
+		; field ~in_oss_since:None ~qualifier:DynamicRO ~ty:DateTime
+		  "install_time" "Time at which the VM was installed"
+		; field ~qualifier:DynamicRO ~ty:DateTime
+		  "last_updated" "Time at which this information was last updated"
+		  ~persist:false
+		; field ~in_product_since:rel_orlando ~default_value:(Some (VMap []))
+		  ~ty:(Map(String, String))
+		  "other_config" "additional configuration"
+		  ~persist:false
+		]
+		()
 
 let tristate_type = Enum ("tristate_type",
 [

--- a/ocaml/test/test_no_migrate.ml
+++ b/ocaml/test/test_no_migrate.ml
@@ -17,96 +17,55 @@ open Test_common
 
 module LC = Xapi_vm_lifecycle
 
-let critical =
+let ops =
 	[ `suspend
 	; `checkpoint
 	; `pool_migrate
 	; `migrate_send
 	]
 
+let op_string = function
+	| `suspend      -> "suspend"
+	| `checkpoint   -> "checkpoint"
+	| `pool_migrate -> "pool_migrate"
+	| `migrate_send -> "migrate_send"
+	| _             -> "other"
 
-type mobility = Mobile | Static
-
-let platforms =
-	[ Static, ["nested-virt","true"]
-	; Mobile, ["nested-virt","false"]
-	; Static, ["nomigrate","true"]
-	; Mobile, ["nomigrate","false"]
-	; Static, ["nomigrate","true"; "nested-virt", "true"]
-	; Static, ["nomigrate","true"; "nested-virt", "false"]
-	; Mobile, ["nomigrate","false"; "nested-virt", "false"]
-	; Static, ["nomigrate","false"; "nested-virt", "true"]
-	; Static, ["nomigrate","TRUE"]
-	; Static, ["nomigrate","1"]
-	; Static, ["nested-virt","1"]
-	; Mobile, ["nested-virt","0"]
+let testcases =
+	(*nest , nomig, force, permitted *)
+	[ false, false, false, true
+	; false, false, true , true
+	; false, true , false, false
+	; false, true , true , true
+	; true , false, false, false
+	; true , false, true , true
+	; true , true , false, false
+	; true , true , true , true
 	]
 
-let simple () =
+let test (nv, nm, force, permitted) op =
 	let __context = make_test_database () in
 	let vm        = make_vm ~__context ~hVM_boot_policy:"" () in
+	let metrics   = Db.VM.get_metrics ~__context ~self:vm in
+	let strict    = not force in
 		( Db.VM.set_power_state ~__context ~self:vm ~value:`Running
-		; LC.get_operation_error ~__context ~self:vm ~op:`suspend ~strict:true
+		; Db.VM_metrics.set_nested_virt ~__context ~self:metrics ~value:nv
+		; Db.VM_metrics.set_nomigrate   ~__context ~self:metrics ~value:nm
+		; LC.get_operation_error ~__context ~self:vm ~op ~strict
 		|> function
-		| None          -> assert_bool "success" true
-		| Some (x,xs)   -> assert_failure (String.concat "|" (x::xs))
+		| None        when permitted     -> assert_bool "success" true
+		| None                           -> assert_failure (op_string op)
+		| Some (x,xs) when not permitted -> assert_bool "success" true
+		| Some (x,xs)                    -> assert_failure (op_string op)
 		)
 
-let base () =
-	let __context = make_test_database () in
-	let vm        = make_vm ~__context ~hVM_boot_policy:"" () in
-		( Db.VM.set_power_state ~__context ~self:vm ~value:`Running
-		; assert_equal ~msg:"suspend" None
-			 (LC.get_operation_error ~__context ~self:vm ~op:`suspend ~strict:true)
-		; assert_equal ~msg:"checkpoint" None
-			 (LC.get_operation_error ~__context ~self:vm ~op:`checkpoint ~strict:true)
-		; assert_equal ~msg:"pool_migrate" None
-			 (LC.get_operation_error ~__context ~self:vm ~op:`pool_migrate ~strict:true)
-		; assert_equal ~msg:"migrate_send" None
-			 (LC.get_operation_error ~__context ~self:vm ~op:`migrate_send ~strict:true)
-		)
-
-(** [with_platform] checks that mobility is signaled according to the
- * values found in the platform flags *)
-let with_platform () =
-	let __context = make_test_database () in
-	let self      = make_vm ~__context ~hVM_boot_policy:"" () in
-	let test platform predicate =
-		( Db.VM.set_power_state ~__context ~self ~value:`Running
-		; Db.VM.set_platform ~__context ~self ~value:platform
-		; Helpers.set_boot_record ~__context ~self
-			(Db.VM.get_record ~__context ~self)
-		; critical (* check all critical operations *)
-		|> List.map (fun op -> LC.get_operation_error ~__context ~self ~op ~strict:true)
-		|> List.for_all predicate
-		|> assert_bool "with_platform"
-		) in
-	let predicate = function
-	| Mobile  -> (=)  None    (* mobile, no error expected *)
-	| Static  -> (<>) None in (* not mobile, expect an error message *)
-	List.iter (fun (mobile, platform) -> test platform (predicate mobile)) platforms
-
-(** [override] checks that migration is always possible when --force is
- * used *)
-let override () =
-	let __context = make_test_database () in
-	let self      = make_vm ~__context ~hVM_boot_policy:"" () in
-	let test platform =
-		( Db.VM.set_power_state ~__context ~self ~value:`Running
-		; Db.VM.set_platform ~__context ~self ~value:platform
-		; Helpers.set_boot_record ~__context ~self
-			(Db.VM.get_record ~__context ~self)
-		; critical (* check all critical operations *)
-		|> List.map (fun op -> LC.get_operation_error ~__context ~self ~op ~strict:false)
-		|> List.for_all ((=) None) (* should not see any error *)
-		|> assert_bool "override"
-		) in
-	List.iter (fun (_, platform) -> test platform) platforms
+let test' op =
+	testcases |> List.iter (fun t -> test t op)
 
 let test = "test_no_migrate" >:::
-	[ "test_no_migrate_00" >:: simple
-	; "test_no_migrate_01" >:: base
-	; "test_no_migrate_02" >:: with_platform
-	; "test_no_migrate_03" >:: override
+	[ "test_no_migrate_00" >:: (fun () -> test' `suspend)
+	; "test_no_migrate_01" >:: (fun () -> test' `checkpoint)
+	; "test_no_migrate_02" >:: (fun () -> test' `pool_migrate)
+	; "test_no_migrate_03" >:: (fun () -> test' `migrate_send)
 	]
 

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -315,18 +315,25 @@ and create_domain_zero_guest_metrics_record ~__context ~domain_zero_metrics_ref 
 	let rec mkints = function
 		| 0 -> []
 		| n -> (mkints (n - 1) @ [n]) in
-	Db.VM_metrics.create ~__context ~ref: domain_zero_metrics_ref ~uuid: (Uuid.to_string (Uuid.make_uuid ()))
+	Db.VM_metrics.create
+		~__context
+		~ref:domain_zero_metrics_ref
+		~uuid:(Uuid.to_string (Uuid.make_uuid ()))
 		~memory_actual: memory_constraints.target
-		~vCPUs_utilisation: (List.map (fun x -> Int64.of_int x, 0.) (mkints vcpus))
-		~vCPUs_number: (Int64.of_int vcpus)
+		~vCPUs_utilisation:(List.map (fun x -> Int64.of_int x, 0.) (mkints vcpus))
+		~vCPUs_number:(Int64.of_int vcpus)
 		~vCPUs_CPU:[]
 		~vCPUs_params:[]
-		~vCPUs_flags: []
-		~state: []
-		~start_time: Date.never
-		~install_time: Date.never
-		~last_updated: Date.never
-		~other_config:[];
+		~vCPUs_flags:[]
+		~state:[]
+		~start_time:Date.never
+		~install_time:Date.never
+		~last_updated:Date.never
+		~other_config:[]
+		~hvm:false
+		~nomigrate:false
+		~nested_virt:false
+		;
 
 and update_domain_zero_record ~__context ~domain_zero_ref (host_info: host_info) : unit =
 	(* Write the updated memory constraints to the database, if the VM is not

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -183,26 +183,32 @@ let create_tools_sr_noexn __context =
 	)
 
 let ensure_vm_metrics_records_exist __context =
-  List.iter (fun vm ->
-				 let m = Db.VM.get_metrics ~__context ~self:vm in
-				 if not(Db.is_valid_ref __context m) then begin
-				   info "Regenerating missing VM_metrics record for VM %s" (Ref.string_of vm);
-				   let m = Ref.make () in
-				   let uuid = Uuid.to_string (Uuid.make_uuid ()) in
-				   Db.VM_metrics.create ~__context ~ref:m ~uuid
-					   ~vCPUs_number:0L
-					   ~vCPUs_utilisation:[] ~memory_actual:0L
-					   ~vCPUs_CPU:[]
-					   ~vCPUs_params:[]
-					   ~vCPUs_flags:[]
-					   ~start_time:Stdext.Date.never
-					   ~install_time:Stdext.Date.never
-					   ~state: []
-					   ~last_updated:(Stdext.Date.of_float 0.)
-					   ~other_config:[];
-				   Db.VM.set_metrics ~__context ~self:vm ~value:m
-				 end
-			) (Db.VM.get_all __context)
+	List.iter (fun vm ->
+		let m = Db.VM.get_metrics ~__context ~self:vm in
+		if not(Db.is_valid_ref __context m) then begin
+			info "Regenerating missing VM_metrics record for VM %s" (Ref.string_of vm);
+			let m = Ref.make () in
+			let uuid = Uuid.to_string (Uuid.make_uuid ()) in
+			Db.VM_metrics.create
+				~__context ~ref:m
+				~uuid
+				~vCPUs_number:0L
+				~vCPUs_utilisation:[]
+				~memory_actual:0L
+				~vCPUs_CPU:[]
+				~vCPUs_params:[]
+				~vCPUs_flags:[]
+				~start_time:Stdext.Date.never
+				~install_time:Stdext.Date.never
+				~state: []
+				~last_updated:(Stdext.Date.of_float 0.)
+				~other_config:[]
+				~hvm:false
+				~nested_virt:false
+				~nomigrate:false
+				;
+		 Db.VM.set_metrics ~__context ~self:vm ~value:m
+	 end) (Db.VM.get_all __context)
 
 let ensure_vm_metrics_records_exist_noexn __context = Helpers.log_exn_continue "ensuring VM_metrics flags exist" ensure_vm_metrics_records_exist __context
 

--- a/ocaml/xapi/monitor_master.ml
+++ b/ocaml/xapi/monitor_master.ml
@@ -43,8 +43,10 @@ let set_vm_metrics ~__context ~vm ~memory ~cpus =
 	let metrics = Db.VM.get_metrics ~__context ~self:vm in
 	if not (Db.is_valid_ref __context metrics) then (
 		let ref = Ref.make () in
-		Db.VM_metrics.create ~__context ~ref ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
-			~memory_actual:0L ~vCPUs_number:0L
+		Db.VM_metrics.create ~__context ~ref
+			~uuid:(Uuid.to_string (Uuid.make_uuid ()))
+			~memory_actual:0L
+			~vCPUs_number:0L
 			~vCPUs_utilisation:[]
 			~vCPUs_CPU:[]
 			~vCPUs_params:[]
@@ -53,7 +55,11 @@ let set_vm_metrics ~__context ~vm ~memory ~cpus =
 			~start_time:Date.never
 			~install_time:Date.never
 			~last_updated:Date.never
-			~other_config:[];
+			~other_config:[]
+			~hvm:false
+			~nested_virt:false
+			~nomigrate:false
+			;
 		Db.VM.set_metrics ~__context ~self:vm ~value:ref
 	);
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -486,7 +486,11 @@ let create ~__context ~name_label ~name_description
 		~start_time:Date.never
 		~install_time:Date.never
 		~last_updated:Date.never
-		~other_config:[];
+		~other_config:[]
+		~hvm:false
+		~nested_virt:false
+		~nomigrate:false
+		;
 	Db.VM.create ~__context ~ref:vm_ref ~uuid:(Uuid.to_string uuid)
 		~power_state:(`Halted) ~allowed_operations:[]
 		~current_operations:[]

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -253,7 +253,11 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
 		~install_time:(default Date.never (may (fun x -> x.Db_actions.vM_metrics_install_time) m))
 		~state:(default [] (may (fun x -> x.Db_actions.vM_metrics_state) m))
 		~last_updated:(default Date.never (may (fun x -> x.Db_actions.vM_metrics_last_updated) m))
-		~other_config:(default [] (may (fun x -> x.Db_actions.vM_metrics_other_config) m));	
+		~other_config:(default [] (may (fun x -> x.Db_actions.vM_metrics_other_config) m))
+		~nomigrate:(default false (may (fun x -> x.Db_actions.vM_metrics_nomigrate) m))
+		~hvm:(default false (may (fun x -> x.Db_actions.vM_metrics_hvm) m))
+		~nested_virt:(default false (may (fun x -> x.Db_actions.vM_metrics_nested_virt) m))
+		;
 
 	let guest_metrics = Xapi_vm_helpers.copy_guest_metrics ~__context ~vm in
 

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -273,7 +273,7 @@ let check_protection_policy ~vmr ~op ~ref_str =
  * migrate if strict=false.
  *
  * The values of [platform:nomigrate] and [platform:nested-virt] are
- * captured by Xeoopsd when a VM starts, reported to Xapi, and kept in
+ * captured by Xenopsd when a VM starts, reported to Xapi, and kept in
  * the VM_metrics data model.
  *
  **)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1446,6 +1446,28 @@ let update_vm ~__context id =
 									end;
 								) state.domids;
 						) info;
+					if different (fun x -> x.nomigrate) then begin
+						Opt.iter
+							(fun (_, state) ->
+								let metrics = Db.VM.get_metrics ~__context ~self in
+								debug "xenopsd event: Updating VM %s nomigrate <- %s"
+									id (string_of_bool state.Vm.nomigrate);
+								Db.VM_metrics.set_nomigrate ~__context ~self:metrics
+										~value:state.Vm.nomigrate;
+							)
+							info
+					end;
+					if different (fun x -> x.nested_virt) then begin
+						Opt.iter
+							(fun (_, state) ->
+								let metrics = Db.VM.get_metrics ~__context ~self in
+								debug "xenopsd event: Updating VM %s nested_virt <- %s"
+									id (string_of_bool state.Vm.nested_virt);
+								Db.VM_metrics.set_nested_virt ~__context ~self:metrics
+										~value:state.Vm.nested_virt;
+							)
+							info
+					end;
 					if different (fun x -> x.vcpu_target) then begin
 						Opt.iter
 							(fun (_, state) ->

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1412,6 +1412,28 @@ let update_vm ~__context id =
 											error "Caught %s: while updating VM %s guest_agent" (Printexc.to_string e) id
 									) state.domids
 							) info in
+					if different (fun x -> x.nomigrate) then begin
+						Opt.iter
+							(fun (_, state) ->
+								let metrics = Db.VM.get_metrics ~__context ~self in
+								debug "xenopsd event: Updating VM %s nomigrate <- %s"
+									id (string_of_bool state.Vm.nomigrate);
+								Db.VM_metrics.set_nomigrate ~__context ~self:metrics
+										~value:state.Vm.nomigrate;
+							)
+							info
+					end;
+					if different (fun x -> x.nested_virt) then begin
+						Opt.iter
+							(fun (_, state) ->
+								let metrics = Db.VM.get_metrics ~__context ~self in
+								debug "xenopsd event: Updating VM %s nested_virt <- %s"
+									id (string_of_bool state.Vm.nested_virt);
+								Db.VM_metrics.set_nested_virt ~__context ~self:metrics
+										~value:state.Vm.nested_virt;
+							)
+							info
+					end;
 					let update_pv_drivers_detected () =
 						Opt.iter
 							(fun (_, state) ->
@@ -1446,28 +1468,6 @@ let update_vm ~__context id =
 									end;
 								) state.domids;
 						) info;
-					if different (fun x -> x.nomigrate) then begin
-						Opt.iter
-							(fun (_, state) ->
-								let metrics = Db.VM.get_metrics ~__context ~self in
-								debug "xenopsd event: Updating VM %s nomigrate <- %s"
-									id (string_of_bool state.Vm.nomigrate);
-								Db.VM_metrics.set_nomigrate ~__context ~self:metrics
-										~value:state.Vm.nomigrate;
-							)
-							info
-					end;
-					if different (fun x -> x.nested_virt) then begin
-						Opt.iter
-							(fun (_, state) ->
-								let metrics = Db.VM.get_metrics ~__context ~self in
-								debug "xenopsd event: Updating VM %s nested_virt <- %s"
-									id (string_of_bool state.Vm.nested_virt);
-								Db.VM_metrics.set_nested_virt ~__context ~self:metrics
-										~value:state.Vm.nested_virt;
-							)
-							info
-					end;
 					if different (fun x -> x.vcpu_target) then begin
 						Opt.iter
 							(fun (_, state) ->

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1412,6 +1412,17 @@ let update_vm ~__context id =
 											error "Caught %s: while updating VM %s guest_agent" (Printexc.to_string e) id
 									) state.domids
 							) info in
+					if different (fun x -> x.hvm) then begin
+						Opt.iter
+							(fun (_, state) ->
+								let metrics = Db.VM.get_metrics ~__context ~self in
+								debug "xenopsd event: Updating VM %s hvm <- %s"
+									id (string_of_bool state.Vm.hvm);
+								Db.VM_metrics.set_hvm ~__context ~self:metrics
+										~value:state.Vm.hvm;
+							)
+							info
+					end;
 					if different (fun x -> x.nomigrate) then begin
 						Opt.iter
 							(fun (_, state) ->


### PR DESCRIPTION
When a VM starts, xenopsd records the current values of `platform:nomigrate` and `platform:nested_virt`. These are reported to xapi via xcp-idl. This PR adds code to xapi to pick up these values (as well as the value of `hvm`) and to store them in the `VM_metrics` class. The values of `nomigrate` and `nested_virt` are used in `xapi_vm_lifecycle.ml:is_mobile` to decide the mobility of VMs in the Bromium context. Previously this code used the actual values from `platform`, which is wrong because it can be manipulated over the lifetime of the VM.

I have manually verified on a DT machine that indeed the values are picked up by xenopds when a VM boots, are reported correctly and indeed block migration of VMs.