### PR TITLE
[CP-18781] Use the correct vif device id in set_MTU or fail

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1639,10 +1639,9 @@ let update_vif ~__context id =
                if state.plugged then begin
                  (* sync MTU *)
                  (try
-                    if Opt.is_none state.device
-                    then failwith (Printf.sprintf "could not determine device id for VIF %s.%s" (fst id) (snd id))
-                    else
-                      let device = Opt.unbox state.device in
+                    match state.device with
+                    | None -> failwith (Printf.sprintf "could not determine device id for VIF %s.%s" (fst id) (snd id))
+                    | Some device ->
                       let dbg = Context.string_of_task __context in
                       let mtu = Net.Interface.get_mtu dbg ~name:device in
                       Db.VIF.set_MTU ~__context ~self:vif ~value:(Int64.of_int mtu)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1639,7 +1639,10 @@ let update_vif ~__context id =
                if state.plugged then begin
                  (* sync MTU *)
                  (try
-                    let device = "vif" ^ (Int64.to_string (Db.VM.get_domid ~__context ~self:vm)) ^ "." ^ (snd id) in
+                   if Opt.is_none state.device
+                   then failwith (Printf.sprintf "could not determine device id for VIF %s.%s" (fst id) (snd id))
+                   else
+                    let device = Opt.unbox state.device in
                     let dbg = Context.string_of_task __context in
                     let mtu = Net.Interface.get_mtu dbg ~name:device in
                     Db.VIF.set_MTU ~__context ~self:vif ~value:(Int64.of_int mtu)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1639,13 +1639,13 @@ let update_vif ~__context id =
                if state.plugged then begin
                  (* sync MTU *)
                  (try
-                   if Opt.is_none state.device
-                   then failwith (Printf.sprintf "could not determine device id for VIF %s.%s" (fst id) (snd id))
-                   else
-                    let device = Opt.unbox state.device in
-                    let dbg = Context.string_of_task __context in
-                    let mtu = Net.Interface.get_mtu dbg ~name:device in
-                    Db.VIF.set_MTU ~__context ~self:vif ~value:(Int64.of_int mtu)
+                    if Opt.is_none state.device
+                    then failwith (Printf.sprintf "could not determine device id for VIF %s.%s" (fst id) (snd id))
+                    else
+                      let device = Opt.unbox state.device in
+                      let dbg = Context.string_of_task __context in
+                      let mtu = Net.Interface.get_mtu dbg ~name:device in
+                      Db.VIF.set_MTU ~__context ~self:vif ~value:(Int64.of_int mtu)
                   with _ ->
                     debug "could not update MTU field on VIF %s.%s" (fst id) (snd id));
 


### PR DESCRIPTION
When updating the MTU of a `VIF` it can happen that the VM `domid` is still out of sync and consequently the computed device id is wrong.
We can use the correct device value passing it via `xenopsd` as a field in `VIF.stat`.

See also: 
xapi-project/xcp-idl#131
xapi-project/xenopsd#288