### PR TITLE
CA-122248: Avoid returning duplicate events in event.from

### DIFF
--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -292,6 +292,20 @@ let event_inject_test session_id =
   then failed test "Failed to see injected event"
   else success test
 
+module StringSet=Set.Make(String)
+
+let event_from_number_test session_id =
+  let test = make_test "Event.from test" 0 in
+  start test;
+  let events = Client.Event.from !rpc session_id [ "vm" ] "" 10. |> event_from_of_rpc in
+  let (_,f) = List.fold_left (fun (set,failed) ev ->
+    let reference = ev.reference in
+    if StringSet.mem reference set
+    then (set,true)
+    else (StringSet.add reference set, failed)) (StringSet.empty, false) events.events in
+  if f
+  then failed test "Object seen twice in events"
+  else success test
 
 let all_srs_with_vdi_create session_id =
   Quicktest_storage.list_srs session_id
@@ -872,6 +886,7 @@ let _ =
           (*				maybe_run_test "event" (fun () -> object_level_event_test s);*)
           maybe_run_test "event" (fun () -> event_message_test s);
           maybe_run_test "event" (fun () -> event_inject_test s);
+          maybe_run_test "event" (fun () -> event_from_number_test s);
           maybe_run_test "vdi" (fun () -> vdi_test s);
           maybe_run_test "async" (fun () -> async_test s);
           maybe_run_test "import" (fun () -> import_export_test s);

--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -441,7 +441,7 @@ let from_inner __context session subs from from_t deadline =
                  if Subscription.object_matches subs (String.lowercase table) objref then begin
                    let last = max last (max modified deleted) in (* mtime guaranteed to always be larger than ctime *)
                    ((if created > !last_generation then (table, objref, created)::creates else creates),
-                    (if modified > !last_generation then (table, objref, modified)::mods else mods),
+                    (if modified > !last_generation && not (created > !last_generation) then (table, objref, modified)::mods else mods), (* Only have a mod event if we don't have a created event *)
                     deletes, last)
                  end else begin
                    (creates,mods,deletes,last)


### PR DESCRIPTION
Avoid returning duplicate events in event.from. This PR also adds a test for this in quicktest.