### PR TITLE
CP 18860 - Restrict setting memory limits for Bromium VMs

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -511,6 +511,8 @@ let _ =
     ~doc:"You attempted an operation which would have resulted in duplicate keys in the database." ();
   error Api_errors.location_not_unique ["SR"; "location"]
     ~doc:"A VDI with the specified location already exists within the SR" ();
+  error Api_errors.memory_constraint_violation ["constraint"]
+    ~doc:"The dynamic memory range does not satisfy the following constraint." (); 
 
   (* Session errors *)
   error Api_errors.session_authentication_failed []

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -512,7 +512,7 @@ let _ =
   error Api_errors.location_not_unique ["SR"; "location"]
     ~doc:"A VDI with the specified location already exists within the SR" ();
   error Api_errors.memory_constraint_violation ["constraint"]
-    ~doc:"The dynamic memory range does not satisfy the following constraint." (); 
+    ~doc:"The dynamic memory range does not satisfy the following constraint." ();
 
   (* Session errors *)
   error Api_errors.session_authentication_failed []

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -298,7 +298,7 @@ let nested_virt ~__context vm metrics =
 
 let is_mobile ~__context vm strict =
   let metrics = Db.VM.get_metrics ~__context ~self:vm in
-  (not @@ nomigrate ~__context vm metrics 
+  (not @@ nomigrate ~__context vm metrics
    && not @@ nested_virt ~__context vm metrics)
   || not strict
 

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -371,18 +371,6 @@ let check_operation_error ~__context ~vmr ~vmgmr ~ref ~clone_suspended_vm_enable
       | _ -> None
     ) in
 
-  (* CP-18860: can't set dynamic mem range when using nested virt *)
-  let current_error = check current_error (fun () ->
-      match op with
-      | `changing_dynamic_range ->
-        let metrics = Db.VM.get_metrics ~__context ~self:ref in
-        if nested_virt ~__context ref metrics then
-          Some (Api_errors.vm_cant_use_dyn_memory, [ref_str])
-        else 
-          None
-      | _ -> None
-    ) in
-
   (* Check if the VM is a control domain (eg domain 0).            *)
   (* FIXME: Instead of special-casing for the control domain here, *)
   (* make use of the Helpers.ballooning_enabled_for_vm function.   *)

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -279,18 +279,28 @@ let check_protection_policy ~vmr ~op ~ref_str =
  * If the VM_metrics object does not exist, it implies the VM is not
  * running - in which case we use the current values from the database.
  **)
+
+let nomigrate ~__context vm metrics =
+  try
+    Db.VM_metrics.get_nomigrate ~__context ~self:metrics
+  with _ ->
+    let platformdata = Db.VM.get_platform ~__context ~self:vm in
+    let key = "nomigrate" in
+    Vm_platform.is_true ~key ~platformdata ~default:false
+
+let nested_virt ~__context vm metrics =
+  try
+    Db.VM_metrics.get_nested_virt ~__context ~self:metrics
+  with _ ->
+    let platformdata = Db.VM.get_platform ~__context ~self:vm in
+    let key = "nested-virt" in
+    Vm_platform.is_true ~key ~platformdata ~default:false
+
 let is_mobile ~__context vm strict =
   let metrics = Db.VM.get_metrics ~__context ~self:vm in
-  try
-    let nomigrate   = Db.VM_metrics.get_nomigrate ~__context ~self:metrics in
-    let nested_virt = Db.VM_metrics.get_nested_virt ~__context ~self:metrics in
-    (not nomigrate && not nested_virt) || not strict
-  with _ ->
-    (* No VM_metrics *)
-    let not_true platformdata key =
-      not @@ Vm_platform.is_true ~key ~platformdata ~default:false in
-    let platform = Db.VM.get_platform ~__context ~self:vm in
-    (not_true platform "nomigrate" && not_true platform "nested-virt") || not strict
+  (not @@ nomigrate ~__context vm metrics 
+   && not @@ nested_virt ~__context vm metrics)
+  || not strict
 
 
 (** Take an internal VM record and a proposed operation. Return None iff the operation
@@ -358,6 +368,18 @@ let check_operation_error ~__context ~vmr ~vmgmr ~ref ~clone_suspended_vm_enable
       | `migrate_send
         when not (is_mobile ~__context ref strict) ->
         Some (Api_errors.vm_is_immobile, [ref_str])
+      | _ -> None
+    ) in
+
+  (* CP-18860: can't set dynamic mem range when using nested virt *)
+  let current_error = check current_error (fun () ->
+      match op with
+      | `changing_dynamic_range ->
+        let metrics = Db.VM.get_metrics ~__context ~self:ref in
+        if nested_virt ~__context ref metrics then
+          Some (Api_errors.vm_cant_use_dyn_memory, [ref_str])
+        else 
+          None
       | _ -> None
     ) in
 

--- a/ocaml/xapi/xapi_vm_memory_constraints.ml
+++ b/ocaml/xapi/xapi_vm_memory_constraints.ml
@@ -51,19 +51,22 @@ module Vm_memory_constraints : T = struct
 
   include Vm_memory_constraints.Vm_memory_constraints
 
+  let order_constraint =
+    "Memory limits must satisfy: \
+     static_min ≤ dynamic_min ≤ dynamic_max ≤ static_max"
+  let equality_constraint =
+    "Memory limits must satisfy: \
+     static_min ≤ dynamic_min = dynamic_max = static_max"
+
   let assert_valid ~constraints =
     if not (are_valid ~constraints)
     then raise (Api_errors.Server_error (
-        Api_errors.memory_constraint_violation,
-        ["Memory limits must satisfy: \
-          				static_min ≤ dynamic_min ≤ dynamic_max ≤ static_max"]))
+      Api_errors.memory_constraint_violation, [order_constraint]))
 
   let assert_valid_and_pinned_at_static_max ~constraints =
     if not (are_valid_and_pinned_at_static_max ~constraints)
     then raise (Api_errors.Server_error (
-        Api_errors.memory_constraint_violation,
-        ["Memory limits must satisfy: \
-          				static_min ≤ dynamic_min = dynamic_max = static_max"]))
+      Api_errors.memory_constraint_violation, [equality_constraint]))
 
   let assert_valid_for_current_context ~__context ~vm ~constraints =
     let is_control_domain = Db.VM.get_is_control_domain ~__context ~self:vm in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -708,6 +708,16 @@ module MD = struct
     (* CA-55754: temporarily disable msitranslate when GPU is passed through. *)
     let pci_msitranslate =
       if vm.API.vM_VGPUs <> [] then false else pci_msitranslate in
+
+    (* CP-18860: check memory limits if using nested_virt *)
+    if Vm_platform.is_true ~key:"nested-virt" ~platformdata ~default:false
+    then
+      begin
+        let module C = Xapi_vm_memory_constraints.Vm_memory_constraints in
+        let c = C.get ~__context ~vm_ref:vmref in
+        C.assert_valid_and_pinned_at_static_max c
+      end;
+
     {
       id = vm.API.vM_uuid;
       name = vm.API.vM_name_label;


### PR DESCRIPTION

> The toolstack shall not allowed the setting of a dynamic memory range on a VM configured with nested virt (i.e. it will enforce memory dynamic-min = dynamic-max = static-max)". 

The PR prohibits to set memory limits when a VM uses nested virtualisation. However, I'm not sure that I cover all cases here and I'm inviting @jonludlam in particular to review this. Currently the only VM operation being blocked is `changing_dynamic_range`.

As part of this I slightly refactored the `is_mobile` predicate which is also used in the context of limiting VM operations for Bromium VMs.

The PR includes a unit test.

