### PR TITLE
CP-18919: Licence-control VM.set_VCPUs_number_live

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2249,10 +2249,15 @@ let host_migrate_receive = call
 let set_vcpus_number_live = call
     ~name:"set_VCPUs_number_live"
     ~in_product_since:rel_rio
+    ~lifecycle:[
+        Published, rel_rio, "Set the number of VCPUs for a running VM";
+        Changed, rel_ely, "Unless the feature is explicitly enabled for every host in the pool, this fails with Api_errors.license_restriction.";
+    ]
     ~doc:"Set the number of VCPUs for a running VM"
     ~params:[Ref _vm, "self", "The VM";
              Int, "nvcpu", "The number of VCPUs"]
     ~allowed_roles:_R_VM_ADMIN
+    ~errs:[Api_errors.operation_not_allowed; Api_errors.license_restriction]
     ()
 
 let vm_set_VCPUs_max = call ~flags:[`Session]

--- a/ocaml/xapi/features.ml
+++ b/ocaml/xapi/features.ml
@@ -52,6 +52,7 @@ type feature =
   | Ssl_legacy_switch
   | Nested_virt
   | Live_patching
+  | Live_set_vcpus
 with rpc
 
 type orientation = Positive | Negative
@@ -93,6 +94,7 @@ let keys_of_features =
     Ssl_legacy_switch, ("restrict_ssl_legacy_switch", Negative, "Ssl_legacy_switch");
     Nested_virt, ("restrict_nested_virt", Negative, "Nested_virt");
     Live_patching, ("restrict_live_patching", Negative, "Live_patching");
+    Live_set_vcpus, ("restrict_set_vcpus_number_live", Negative, "Live_set_vcpus");
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi/features.mli
+++ b/ocaml/xapi/features.mli
@@ -52,6 +52,7 @@ type feature =
   | Ssl_legacy_switch            (** Enable the control switch for SSL/TLS legacy-mode. *)
   | Nested_virt                  (** Enable the use of nested virtualisation *)
   | Live_patching                (** Enable the use of live patching feature. *)
+  | Live_set_vcpus               (** Enable setting the number of virtual CPUs of a running VM. *)
 
 (** Convert RPC into {!feature}s *)
 val feature_of_rpc : Rpc.t -> feature

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -690,8 +690,10 @@ let set_VCPUs_at_startup ~__context ~self ~value =
   update_memory_overhead ~__context ~vm:self
 
 (** Sets the number of VCPUs for a {b Running} PV guest.
-    @raise Api_errors.operation_not_allowed if [self] is an HVM guest. *)
+    @raise Api_errors.operation_not_allowed if [self] is an HVM guest.
+    @raise Api_errors.license_restriction if the feature for this function is not permitted. *)
 let set_VCPUs_number_live ~__context ~self ~nvcpu =
+  Pool_features.assert_enabled ~__context ~f:Features.Live_set_vcpus;
   Xapi_xenops.set_vcpus ~__context ~self nvcpu;
   (* Strictly speaking, PV guest memory overhead depends on the number of  *)
   (* vCPUs. Although our current overhead calculation uses a conservative  *)


### PR DESCRIPTION
Do not merge this until the feature has been added to the relevant licence definitions.
As it is, this will build but then any installed XenServer will not permit the use of the function.
