### PR TITLE
When GuestMetrics are NULL, `update_vm` is partial

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1450,8 +1450,11 @@ let update_vm ~__context id =
               (fun (_, state) ->
                  let gm = Db.VM.get_guest_metrics ~__context ~self in
                  debug "xenopsd event: Updating VM %s PV drivers detected %b" id state.pv_drivers_detected;
-                 Db.VM_guest_metrics.set_PV_drivers_detected ~__context ~self:gm ~value:state.pv_drivers_detected;
-                 Db.VM_guest_metrics.set_PV_drivers_up_to_date ~__context ~self:gm ~value:state.pv_drivers_detected
+                 try
+                   Db.VM_guest_metrics.set_PV_drivers_detected ~__context ~self:gm ~value:state.pv_drivers_detected;
+                   Db.VM_guest_metrics.set_PV_drivers_up_to_date ~__context ~self:gm ~value:state.pv_drivers_detected
+                 with e ->
+                   error "Caught %s: while updating VM %s PV driver detection" (Printexc.to_string e) id
               ) info in
           Opt.iter
             (fun (_, state) ->


### PR DESCRIPTION
This allows the update process to complete.

We could alternatively check for `gm = Ref.null` in `update_pv_drivers_detected`, or ignore any error as done later at line `1514` (although I would rather change that and add a debug line also at that stage). 

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>