### PR TITLE
Revert "When GuestMetrics are NULL, `update_vm` is partial"

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1460,11 +1460,8 @@ let update_vm ~__context id =
               (fun (_, state) ->
                  let gm = Db.VM.get_guest_metrics ~__context ~self in
                  debug "xenopsd event: Updating VM %s PV drivers detected %b" id state.pv_drivers_detected;
-                 try
-                   Db.VM_guest_metrics.set_PV_drivers_detected ~__context ~self:gm ~value:state.pv_drivers_detected;
-                   Db.VM_guest_metrics.set_PV_drivers_up_to_date ~__context ~self:gm ~value:state.pv_drivers_detected
-                 with e ->
-                   error "Caught %s: while updating VM %s PV driver detection" (Printexc.to_string e) id
+                 Db.VM_guest_metrics.set_PV_drivers_detected ~__context ~self:gm ~value:state.pv_drivers_detected;
+                 Db.VM_guest_metrics.set_PV_drivers_up_to_date ~__context ~self:gm ~value:state.pv_drivers_detected
               ) info in
           Opt.iter
             (fun (_, state) ->


### PR DESCRIPTION
Reverts xapi-project/xen-api#2781, because it seems to have caused a regression (CA-223387), and there are plans to do this differently anyway.