### PR TITLE
[CA-223800] Fix xapi-xenopsd assert-statements

### DIFF
--- a/ocaml/graph/graph.ml
+++ b/ocaml/graph/graph.ml
@@ -58,7 +58,8 @@ let do_rpc rpc name args =
   | Failure(code, strings) -> raise (Api_errors.Server_error(code, strings))
   | Success [] -> invalid_arg "empty result"
   | Success [x] -> x
-  | _           -> assert false
+  | _           -> raise Api_errors.(Server_error(internal_error,
+                                                  ["do_rpc: Unexpected response"]))
 
 let get_all rpc session_id cls =
   let name = Printf.sprintf "%s.get_all_records_where" cls in

--- a/ocaml/xapi/vhd_tool_wrapper.ml
+++ b/ocaml/xapi/vhd_tool_wrapper.ml
@@ -106,7 +106,10 @@ let find_backend_device path =
           let params = xs.Xs.read (Printf.sprintf "%s/params" backend) in
           match String.split '/' backend with
           | "local" :: "domain" :: bedomid :: _ ->
-            assert (self = bedomid);
+            if not (self = bedomid) then
+              raise Api_errors.(Server_error(internal_error, [
+                  Printf.sprintf "find_backend_device: Got domid %s but expected %s"
+                    bedomid self]));
             Some params
           | _ -> raise Not_found
         )

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -166,7 +166,8 @@ let rec descend_and_match tag_names xml =
                  (sprintf "Descend_and_match failed. Node %s not found." hd_tag))
     end
   | _, Xml.PCData _ ->
-    assert false (*This  should never happen as a leaf node is detected in an earlier match and returned *)
+    (* This should never happen as a leaf node is detected in an earlier match and returned *)
+    raise_malformed_response' "unknown" "Method descend_and_match failed. Found orphan leaf node" ""
 
 let data_from_leaf element =
   match element with

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -446,7 +446,12 @@ let evacuate ~__context ~host =
            not (Db.VM.get_is_control_domain ~__context ~self:vm))
         vms
     in
-    assert (List.length vms = 0)
+    let remainder = List.length vms in
+    if not (remainder = 0) then
+      raise Api_errors.(Server_error(internal_error, [
+          Printf.sprintf "evacuate: %d VMs are still resident on %s"
+            remainder (Ref.string_of host)
+        ]))
   end
 
 let retrieve_wlb_evacuate_recommendations ~__context ~self =

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -71,11 +71,19 @@ let refresh_internal ~__context ~self =
     (String.concat "; ")
 
 let refresh ~__context ~host ~self =
-  assert (host = Helpers.get_localhost ~__context);
+  let localhost = Helpers.get_localhost ~__context in
+  if not (host = localhost) then
+    raise Api_errors.(Server_error(internal_error, [
+        Printf.sprintf "refresh: Host mismatch, expected %s but got %s"
+          (Ref.string_of host) (Ref.string_of localhost)]));
   refresh_internal ~__context ~self
 
 let refresh_all ~__context ~host =
-  assert (host = Helpers.get_localhost ~__context);
+  let localhost = Helpers.get_localhost ~__context in
+  if not (host = localhost) then
+    raise Api_errors.(Server_error(internal_error, [
+        Printf.sprintf "refresh_all: Host mismatch, expected %s but got %s"
+          (Ref.string_of host) (Ref.string_of localhost)]));
   (* Only refresh physical or attached PIFs *)
   let pifs = Db.PIF.get_refs_where ~__context ~expr:(And (
       Eq (Field "host", Literal (Ref.string_of host)),

--- a/ocaml/xapi/xapi_templates.ml
+++ b/ocaml/xapi/xapi_templates.ml
@@ -47,7 +47,9 @@ let string2vdi_type s =
   | "ephemeral" -> `ephemeral
   | "suspend" -> `suspend
   | "crashdump" -> `crashdump
-  | _           -> assert false
+  | vdi_st -> raise Api_errors.(Server_error(internal_error, [
+      Printf.sprintf "string2vdi_type: Unknown VDI type \"%s\"" vdi_st
+    ]))
 
 exception Parse_failure
 let disk_of_xml = function

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1045,7 +1045,8 @@ let set_suspend_VDI ~__context ~self ~value =
       match !r with
       | `Succ cs -> cs
       | `Fail e -> raise e
-      | `Pending -> assert false in
+      | `Pending -> raise Api_errors.(Server_error(internal_error, ["set_suspend_VDI: The operation is still `Pending"]))
+    in
     let src_checksum = get_result src_thread src_result in
     let dst_checksum = get_result dst_thread dst_result in
     debug "source suspend_VDI checksum: %s" src_checksum;

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1068,7 +1068,8 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
               remote_network_reference = network;
             })
           vif_map in
-      assert (inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~dry_run:true ~live:true ~copy = [])
+      if not (inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~dry_run:true ~live:true ~copy = []) then
+        raise Api_errors.(Server_error(internal_error, ["assert_can_migrate: inter_pool_metadata_transfer returned a nonempty list"]))
     with Xmlrpc_client.Connection_reset ->
       raise (Api_errors.Server_error(Api_errors.cannot_contact_host, [remote.remote_ip]))
 

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -235,7 +235,8 @@ let checkpoint ~__context ~vm ~new_name =
 
 (* The following code have to run on the master as it manipulates the DB cache directly. *)
 let copy_vm_fields ~__context ~metadata ~dst ~do_not_copy ~default_values =
-  assert (Pool_role.is_master ());
+  if not (Pool_role.is_master ()) then
+    raise Api_errors.(Server_error(internal_error, ["copy_vm_fields: Aborting because the host is not master"]));
   debug "copying metadata into %s" (Ref.string_of dst);
   let db = Context.database_of __context in
   let module DB = (val (Db_cache.get db) : Db_interface.DB_ACCESS) in


### PR DESCRIPTION
Replace all assert statements with appropriate `Server_errors` carrying enough information for debugging.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>