### PR TITLE
CA-223671: Don't run xapi-domains.service with restart on %postun xapi-core rpm.

### DIFF
--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -176,7 +176,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %postun core
 %systemd_postun_with_restart cdrommon@.service
-%systemd_postun_with_restart xapi-domains.service
+%systemd_postun xapi-domains.service
 %systemd_postun_with_restart perfmon.service
 %systemd_postun_with_restart genptoken.service
 %systemd_postun_with_restart xapi.service


### PR DESCRIPTION

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>