### PR TITLE
CA-224331: Detect PV drivers => vif|vbd hotpluggable

### DIFF
--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -138,14 +138,16 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
     let fallback () =
       match Xapi_pv_driver_version.make_error_opt (Xapi_pv_driver_version.of_guest_metrics vm_gmr) vm with
       | Some(code, params) -> set_errors code params plug_ops
-      | None -> () in
-
+      | None -> ()
+    in
     (match vm_gmr with
      | None -> fallback ()
      | Some gmr ->
        (match gmr.Db_actions.vM_guest_metrics_can_use_hotplug_vbd with
         | `yes -> () (* Drivers have made an explicit claim of support. *)
         | `no -> set_errors Api_errors.operation_not_allowed ["VM states it does not support VBD hotplug."] plug_ops
+           (* according to xen docs PV drivers are enough for this to be possible *)
+        | `unspecified when gmr.Db_actions.vM_guest_metrics_PV_drivers_detected -> ()
         | `unspecified -> fallback ())
     );
     if record.Db_actions.vBD_type = `CD

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -85,14 +85,16 @@ let valid_operations ~__context record _ref' : table =
     let fallback () =
       match Xapi_pv_driver_version.make_error_opt (Xapi_pv_driver_version.of_guest_metrics vm_gmr) vm with
       | Some(code, params) -> set_errors code params [ `plug; `unplug ]
-      | None -> () in
-
+      | None -> ()
+    in
     match vm_gmr with
     | None -> fallback ()
     | Some gmr -> (
         match gmr.Db_actions.vM_guest_metrics_can_use_hotplug_vif with
         | `yes -> () (* Drivers have made an explicit claim of support. *)
         | `no -> set_errors Api_errors.operation_not_allowed ["VM states it does not support VIF hotplug."] [`plug; `unplug]
+          (* according to xen docs PV drivers are enough for this to be possible *)
+        | `unspecified when gmr.Db_actions.vM_guest_metrics_PV_drivers_detected -> ()
         | `unspecified -> fallback ())
   );
 

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -15,7 +15,6 @@
  * @group Virtual-Machine Management
 *)
 
-open Xapi_pv_driver_version
 open Stdext
 open Listext
 
@@ -154,7 +153,7 @@ let check_op_for_feature ~__context ~vmr ~vmgmr ~power_state ~op ~ref ~strict =
   if power_state <> `Running ||
      (* PV guests offer support implicitly *)
      not (Helpers.has_booted_hvm_of_record ~__context vmr) ||
-     has_pv_drivers (of_guest_metrics vmgmr) (* Full PV drivers imply all features *)
+     Xapi_pv_driver_version.(has_pv_drivers (of_guest_metrics vmgmr)) (* Full PV drivers imply all features *)
   then None
   else
     let some_err e =


### PR DESCRIPTION
If we detect a guest using PV drivers then we can assume it is safe to
hotplug and unplug VIFs and VBDs.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>