### PR TITLE
CA-189725: support new systemd network interfaces naming in the VM guest metrics

### DIFF
--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -85,25 +85,29 @@ let networks path (list: string -> string list) =
    * [see https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/]
    * under a path. *)
   let find_eths path =
-    let extract eth =
+    let extract_network_keys eth =
       let iface_prefixes =
         ["eth"; "xenbr"; "eno"; "ens"; "emp"; "enx"] in
-      let rec extract' prefixes eth =
+      let string_after_prefix ~prefix str =
+        let prefix_len = String.length prefix in
+        let size = String.length str - prefix_len in
+        let after_prefix = String.sub str prefix_len size in
+        after_prefix
+      in
+      let rec extract prefixes eth =
         match prefixes with
         | [] -> None
         | prefix :: rest ->
           if String.startswith prefix eth then
-            let prefix_len = String.length prefix in
-            let size = String.length eth - prefix_len in
-            let n = String.sub eth prefix_len size in
+            let n = string_after_prefix ~prefix eth in
             Some (extend path eth, n)
           else
-            extract' rest eth
-      in extract' iface_prefixes eth
+            extract rest eth
+      in extract iface_prefixes eth
     in
     List.fold_left
       (fun acc eth ->
-         match extract eth with
+         match extract_network_keys eth with
          | None -> acc
          | Some pair -> pair :: acc
       ) [] (list path)

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -101,17 +101,12 @@ let networks path (list: string -> string list) =
             extract' rest eth
       in extract' iface_prefixes eth
     in
-    let unfiltered_networks =
-      List.fold_left
-        (fun acc eth ->
-           match extract eth with
-           | None -> acc
-           | Some pair -> pair :: acc
-        ) [] (list path)
-    in
-    (* We remove duplicates because we cannot rule out collisions,
-     * e.g. if eth1 and ens1 are both present *)
-    List.sort_uniq (fun (m, _) (m', _) -> String.compare m m') unfiltered_networks
+    List.fold_left
+      (fun acc eth ->
+         match extract eth with
+         | None -> acc
+         | Some pair -> pair :: acc
+      ) [] (list path)
   in
   path
   |> find_eths


### PR DESCRIPTION
Systemd naming scheme standard changed to support a broader range of interface names. This was to improve the stability of interfaces' naming across reboots and hardware changes. For reference see: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames

This PR adds the support for the new network interface names and allows their extraction from xenstore paths, so that the `networks` field of the `VM guest metrics` contains the correct informations.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>