### PR TITLE
CA-224327: Use `https` connection while calling `import/export_raw_vd…

### DIFF
--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -357,7 +357,7 @@ end
 
 
 let return_302_redirect (req: Http.Request.t) s address =
-  let url = Printf.sprintf "%s://%s%s?%s" (if Context.is_unencrypted s then "http" else "https") address req.Http.Request.uri (String.concat "&" (List.map (fun (a,b) -> a^"="^b) req.Http.Request.query)) in
+  let url = Printf.sprintf "https://%s%s?%s" address req.Http.Request.uri (String.concat "&" (List.map (fun (a,b) -> a^"="^b) req.Http.Request.query)) in
   let headers = Http.http_302_redirect url in
   debug "HTTP 302 redirect to: %s" url;
   Http_svr.headers s headers


### PR DESCRIPTION
…i` to remote Host.

`import_raw_vdi` http handler runs on localhost. In case the VDI
residing on the SR is not visible to localhost then a remote Host
is identified where the SR is visible. In that case http redirect
call is made to remote Host address, this must use https connection.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>