### PR TITLE
CA-224975: PVS-cache: Handle cache VDIs on non-persistent SR

### DIFF
--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -280,6 +280,7 @@ XAPI_MODULES = $(COMMON) \
 	xapi_pvs_proxy \
 	xapi_pvs_cache_storage \
 	pvs_proxy_control \
+	pvs_cache_vdi \
 
 OCamlProgram(xapi, xapi_main $(XAPI_MODULES))
 

--- a/ocaml/xapi/pvs_cache_vdi.ml
+++ b/ocaml/xapi/pvs_cache_vdi.ml
@@ -1,0 +1,84 @@
+(*
+ * Copyright (C) 2016 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make(struct let name = "pvs_cache_vdi" end)
+open D
+
+open Db_filter_types
+
+let create_vdi ~__context ~sR ~size =
+  info "Creating new PVS-cache VDI";
+  Helpers.call_api_functions ~__context (fun rpc session_id ->
+      Client.Client.VDI.create ~rpc ~session_id
+        ~name_label:"PVS cache VDI"
+        ~name_description:"PVS cache VDI"
+        ~sR
+        ~virtual_size:size
+        ~_type:`pvs_cache
+        ~sharable:false
+        ~read_only:false
+        ~other_config:[]
+        ~xenstore_data:[]
+        ~sm_config:[]
+        ~tags:[]
+    )
+
+(* Before simply returning the VDI from the DB, check if it actually
+  still exists on disk. The VDI may have gone away if it was on a
+  non-persistent SR (e.g. on a RAM disk). *)
+let get_vdi ~__context ~self =
+  let vdi = Db.PVS_cache_storage.get_VDI ~__context ~self in
+  (* If there is already an attached VBD for the VDI, then we assume that all is well. *)
+  let vbds = Db.VBD.get_refs_where ~__context ~expr:(
+    And (
+      Eq (Field "VDI", Literal (Ref.string_of vdi)),
+      Eq (Field "currently_attached", Literal "true")
+    )
+  ) in
+  if vbds <> [] then
+    Some vdi
+  else begin
+    (* Scan the SR. This will cause the removal of VDI records that are not backed
+       by an actual volume on the SR. *)
+    let sr = Db.PVS_cache_storage.get_SR ~__context ~self in
+    Helpers.call_api_functions ~__context (fun rpc session_id ->
+      Client.Client.SR.scan ~rpc ~session_id ~sr
+    );
+    (* If our VDI reference is still valid, then we're good. *)
+    if Db.is_valid_ref __context vdi then
+      Some vdi
+    else begin
+      info "PVS-cache VDI %s is no longer present on the SR" (Ref.string_of vdi);
+      None
+    end
+  end
+
+let get_or_recreate_vdi ~__context ~self =
+  match get_vdi ~__context ~self with
+  | None ->
+    let sR = Db.PVS_cache_storage.get_SR ~__context ~self in
+    let size = Db.PVS_cache_storage.get_size ~__context ~self in
+    let vdi = create_vdi ~__context ~sR ~size in
+    Db.PVS_cache_storage.set_VDI ~__context ~self ~value:vdi;
+    vdi
+  | Some vdi -> vdi
+
+let destroy_vdi ~__context ~self =
+  match get_vdi ~__context ~self with
+  | None -> () (* The VDI doesn't exist anymore; nothing to do. *)
+  | Some vdi ->
+    Helpers.call_api_functions ~__context
+      (fun rpc session_id ->
+         Client.Client.VDI.destroy ~rpc ~session_id ~self:vdi
+      )

--- a/ocaml/xapi/pvs_proxy_control.ml
+++ b/ocaml/xapi/pvs_proxy_control.ml
@@ -185,7 +185,7 @@ let find_cache_vdi ~__context ~host ~site =
   | [] ->
     raise No_cache_sr_available
   | pcs :: _ ->
-    Db.PVS_cache_storage.get_VDI ~__context ~self:pcs
+    Pvs_cache_vdi.get_or_recreate_vdi ~__context ~self:pcs
 
 let start_proxy ~__context vif proxy =
   let dbg = Context.string_of_task __context in

--- a/ocaml/xapi/xapi_pvs_cache_storage.ml
+++ b/ocaml/xapi/xapi_pvs_cache_storage.ml
@@ -17,29 +17,6 @@ module E = Api_errors
 let api_error msg xs = raise (E.Server_error (msg, xs))
 let str ref = Ref.string_of ref
 
-let create_vdi ~__context ~sR ~size =
-  Helpers.call_api_functions ~__context (fun rpc session_id ->
-      Client.Client.VDI.create ~rpc ~session_id
-        ~name_label:"PVS cache VDI"
-        ~name_description:"PVS cache VDI"
-        ~sR
-        ~virtual_size:size
-        ~_type:`pvs_cache
-        ~sharable:false
-        ~read_only:false
-        ~other_config:[]
-        ~xenstore_data:[]
-        ~sm_config:[]
-        ~tags:[]
-    )
-
-let destroy_vdi ~__context ~self =
-  let vdi = Db.PVS_cache_storage.get_VDI ~__context ~self in
-  Helpers.call_api_functions ~__context
-    (fun rpc session_id ->
-       Client.Client.VDI.destroy ~rpc ~session_id ~self:vdi
-    )
-
 let assert_not_already_present ~__context site host =
   let caches = Db.PVS_site.get_cache_storage ~__context ~self:site in
   let hosts = List.map (fun pcs -> Db.PVS_cache_storage.get_host ~__context ~self:pcs) caches in
@@ -50,7 +27,7 @@ let create ~__context ~host ~sR ~site ~size =
   assert_not_already_present ~__context site host;
   let cache_storage = Ref.make () in
   let uuid = Uuidm.to_string (Uuidm.create `V4) in
-  let vDI = create_vdi ~__context ~sR ~size in
+  let vDI = Pvs_cache_vdi.create_vdi ~__context ~sR ~size in
   Db.PVS_cache_storage.create ~__context ~ref:cache_storage ~uuid ~host ~sR ~site ~vDI ~size;
   cache_storage
 
@@ -70,5 +47,5 @@ let destroy ~__context ~self =
   assert_not_in_use ~__context self;
   let site = Db.PVS_cache_storage.get_site ~__context ~self in
   Pvs_proxy_control.remove_site_on_localhost ~__context ~site;
-  destroy_vdi ~__context ~self;
+  Pvs_cache_vdi.destroy_vdi ~__context ~self;
   Db.PVS_cache_storage.destroy ~__context ~self


### PR DESCRIPTION
PVS-cache supports a new kind of SR that is based on a RAM disk. A consequence
is that the contents of the SR disappear when the host is rebooted, while
leaving the VDI records behind in the database, and PVS_cache_storage.VDI
fields may be invalid.

To handle this, we now check whether the PVS_cache_storage.VDI that is needed
when a PVS-cached VM is started still actually exists. If not, it will be
recreated. Furthermore, in PVS_cache_storage.destroy, we ignore errors about
the VDI not existing anymore.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>