### PR TITLE
CA-225711: Enable a  pool's redo_log when the pool's default SR is shared

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -471,7 +471,7 @@ let pool_record rpc session_id pool =
         ~get:(fun () -> get_uuid_from_ref (x ()).API.pool_default_SR)
         ~set:(fun x ->
             let sr_ref = if x="" then Ref.null else Client.SR.get_by_uuid rpc session_id x in
-            Client.Pool.set_default_sr rpc session_id pool sr_ref) ();
+            Client.Pool.set_default_SR rpc session_id pool sr_ref) ();
       make_field ~name:"crash-dump-SR"
         ~get:(fun () -> get_uuid_from_ref (x ()).API.pool_crash_dump_SR)
         ~set:(fun x ->

--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -471,7 +471,7 @@ let pool_record rpc session_id pool =
         ~get:(fun () -> get_uuid_from_ref (x ()).API.pool_default_SR)
         ~set:(fun x ->
             let sr_ref = if x="" then Ref.null else Client.SR.get_by_uuid rpc session_id x in
-            Client.Pool.set_default_SR rpc session_id pool sr_ref) ();
+            Client.Pool.set_default_sr rpc session_id pool sr_ref) ();
       make_field ~name:"crash-dump-SR"
         ~get:(fun () -> get_uuid_from_ref (x ()).API.pool_crash_dump_SR)
         ~set:(fun x ->

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6927,7 +6927,7 @@ let pool_remove_from_guest_agent_config = call
     ()
 
 let pool_set_default_sr = call
-    ~name:"set_default_sr"
+    ~name:"set_default_SR"
     ~in_product_since:rel_ely
     ~doc:"Set the default SR for VDIs."
     ~params:

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6926,6 +6926,17 @@ let pool_remove_from_guest_agent_config = call
     ~allowed_roles:_R_POOL_ADMIN
     ()
 
+let pool_set_default_sr = call
+    ~name:"set_default_sr"
+    ~in_product_since:rel_ely
+    ~doc:"Set the default SR for VDIs."
+    ~params:
+      [ Ref _pool, "self", "The pool"
+      ; Ref _sr, "sr", "SR to hold VDIs."
+      ]
+    ~allowed_roles:_R_POOL_ADMIN
+    ()
+
 (** A pool class *)
 let pool =
   create_obj
@@ -6997,13 +7008,14 @@ let pool =
       ; pool_has_extension
       ; pool_add_to_guest_agent_config
       ; pool_remove_from_guest_agent_config
+      ; pool_set_default_sr
       ]
     ~contents:
       ([uid ~in_oss_since:None _pool] @
        [ field ~in_oss_since:None ~qualifier:RW ~ty:String "name_label" "Short name"
        ; field ~in_oss_since:None ~qualifier:RW ~ty:String "name_description" "Description"
        ; field ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Ref _host) "master" "The host that is pool master"
-       ; field ~in_oss_since:None ~qualifier:RW ~ty:(Ref _sr) "default_SR" "Default SR for VDIs"
+       ; field ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Ref _sr) "default_SR" "Default SR for VDIs"
        ; field ~in_oss_since:None ~qualifier:RW ~ty:(Ref _sr) "suspend_image_SR" "The SR in which VDIs for suspend images are created"
        ; field ~in_oss_since:None ~qualifier:RW ~ty:(Ref _sr) "crash_dump_SR" "The SR in which VDIs for crash dumps are created"
        ; field ~in_oss_since:None ~ty:(Map(String, String)) "other_config" "additional configuration" ~map_keys_roles:[("folder",(_R_VM_OP));("XenCenter.CustomFields.*",(_R_VM_OP));("EMPTY_FOLDERS",(_R_VM_OP))]

--- a/ocaml/perftest/createpool.ml
+++ b/ocaml/perftest/createpool.ml
@@ -458,7 +458,7 @@ let create_pool session_id sdkname pool_name key ipbase =
     | l -> Array.of_list l
   in
   let pool_ref = List.hd (Client.Pool.get_all ~rpc ~session_id) in
-  Client.Pool.set_default_sr ~rpc ~session_id ~self:pool_ref ~sr:storages.(0);
+  Client.Pool.set_default_SR ~rpc ~session_id ~self:pool_ref ~sr:storages.(0);
   Client.Pool.set_crash_dump_SR ~rpc ~session_id ~self:pool_ref ~value:storages.(0);
   Client.Pool.set_suspend_image_SR ~rpc ~session_id ~self:pool_ref ~value:storages.(0);
 

--- a/ocaml/perftest/createpool.ml
+++ b/ocaml/perftest/createpool.ml
@@ -458,7 +458,7 @@ let create_pool session_id sdkname pool_name key ipbase =
     | l -> Array.of_list l
   in
   let pool_ref = List.hd (Client.Pool.get_all ~rpc ~session_id) in
-  Client.Pool.set_default_SR ~rpc ~session_id ~self:pool_ref ~value:storages.(0);
+  Client.Pool.set_default_sr ~rpc ~session_id ~self:pool_ref ~sr:storages.(0);
   Client.Pool.set_crash_dump_SR ~rpc ~session_id ~self:pool_ref ~value:storages.(0);
   Client.Pool.set_suspend_image_SR ~rpc ~session_id ~self:pool_ref ~value:storages.(0);
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -652,6 +652,11 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Pool.remove_from_guest_agent_config: pool = '%s'; key = '%s'"
         (pool_uuid ~__context self) key;
       Local.Pool.remove_from_guest_agent_config ~__context ~self ~key
+
+    let set_default_sr ~__context ~self ~sr =
+      info "Pool.set_default_sr: pool = '%s'; sr = '%s'"
+        (pool_uuid ~__context self) (sr_uuid __context sr);
+      Local.Pool.set_default_sr ~__context ~self ~sr
   end
 
   module VM = struct

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -653,10 +653,10 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         (pool_uuid ~__context self) key;
       Local.Pool.remove_from_guest_agent_config ~__context ~self ~key
 
-    let set_default_sr ~__context ~self ~sr =
+    let set_default_SR ~__context ~self ~sr =
       info "Pool.set_default_sr: pool = '%s'; sr = '%s'"
         (pool_uuid ~__context self) (sr_uuid __context sr);
-      Local.Pool.set_default_sr ~__context ~self ~sr
+      Local.Pool.set_default_SR ~__context ~self ~sr
   end
 
   module VM = struct

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1862,7 +1862,7 @@ let remove_from_guest_agent_config ~__context ~self ~key =
   Db.Pool.remove_from_guest_agent_config ~__context ~self ~key;
   Xapi_pool_helpers.apply_guest_agent_config ~__context
 
-let set_default_sr ~__context ~self ~sr =
+let set_default_SR ~__context ~self ~sr =
   Db.Pool.set_default_SR ~__context ~self ~value:sr;
   if Db.SR.get_shared ~__context ~self:sr then begin
     enable_redo_log ~__context ~sr (* CA-225711 *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1861,3 +1861,6 @@ let add_to_guest_agent_config ~__context ~self ~key ~value =
 let remove_from_guest_agent_config ~__context ~self ~key =
   Db.Pool.remove_from_guest_agent_config ~__context ~self ~key;
   Xapi_pool_helpers.apply_guest_agent_config ~__context
+
+let set_default_sr ~__context ~self ~sr =
+  Db.Pool.set_default_SR ~__context ~self ~value:sr

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1863,4 +1863,7 @@ let remove_from_guest_agent_config ~__context ~self ~key =
   Xapi_pool_helpers.apply_guest_agent_config ~__context
 
 let set_default_sr ~__context ~self ~sr =
-  Db.Pool.set_default_SR ~__context ~self ~value:sr
+  Db.Pool.set_default_SR ~__context ~self ~value:sr;
+  if Db.SR.get_shared ~__context ~self:sr then begin
+    enable_redo_log ~__context ~sr (* CA-225711 *)
+  end

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -198,3 +198,5 @@ val add_to_guest_agent_config :
   __context:Context.t -> self:API.ref_pool -> key:string -> value:string -> unit
 val remove_from_guest_agent_config :
   __context:Context.t -> self:API.ref_pool -> key:string -> unit
+
+val set_default_sr : __context:Context.t -> self:API.ref_pool -> sr:API.ref_SR -> unit

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -199,4 +199,4 @@ val add_to_guest_agent_config :
 val remove_from_guest_agent_config :
   __context:Context.t -> self:API.ref_pool -> key:string -> unit
 
-val set_default_sr : __context:Context.t -> self:API.ref_pool -> sr:API.ref_SR -> unit
+val set_default_SR : __context:Context.t -> self:API.ref_pool -> sr:API.ref_SR -> unit


### PR DESCRIPTION
This came out of XOP-765 (VM Machine Status Mismatch between XS and XC console). When setting the default SR for a pool and the SR is share-able ({{SR.shared == true}}), enable the redo-log for the pool.

The code passes the (existing) unit tests.
