### PR TITLE
VBD.{unplug, unplug_force_no_safety_check}: remove code duplication

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3347,8 +3347,14 @@ let vbd_unplug_force = call
 
 let vbd_unplug_force_no_safety_check = call
     ~name:"unplug_force_no_safety_check"
-    ~doc:"Forcibly unplug the specified VBD without any safety checks. This is an extremely dangerous operation in the general case that can cause guest crashes and data corruption; it should be called with extreme caution."
+    ~doc:"Deprecated: use 'unplug_force' instead. Forcibly unplug \
+          the specified VBD without any safety checks. This is an \
+          extremely dangerous operation in the general case that \
+          can cause guest crashes and data corruption; it should \
+          be called with extreme caution. Functionally equivalent \
+          with 'unplug_force'."
     ~params:[Ref _vbd, "self", "The VBD to forcibly unplug (no safety checks are applied to test if the device supports surprise-remove)"]
+    ~internal_deprecated_since:rel_ely
     ~hide_from_docs:true
     ~in_product_since:rel_symc
     ~allowed_roles:_R_VM_ADMIN

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3648,11 +3648,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
     let unplug_force_no_safety_check ~__context ~self =
       warn "VBD.unplug_force_no_safety_check: VBD = '%s'" (vbd_uuid ~__context self);
-      let local_fn = Local.VBD.unplug_force_no_safety_check ~self in
-      with_vbd_marked ~__context ~vbd:self ~doc:"VBD.unplug_force_no_safety_check" ~op:`unplug_force
-        (fun () ->
-           forward_vbd_op ~local_fn ~__context ~self (fun session_id rpc -> Client.VBD.unplug_force_no_safety_check rpc session_id self));
-      update_vbd_and_vdi_operations ~__context ~vbd:self
+      unplug_force ~__context ~self
 
     let pause ~__context ~self =
       info "VBD.pause: VBD = '%s'" (vbd_uuid ~__context self);

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -81,12 +81,7 @@ let unplug_force ~__context ~self =
   then unplug ~__context ~self
   else Xapi_xenops.vbd_unplug ~__context ~self true
 
-let unplug_force_no_safety_check ~__context ~self =
-  let vm = Db.VBD.get_VM ~__context ~self in
-  let force_loopback_vbd = Helpers.force_loopback_vbd ~__context in
-  if System_domains.storage_driver_domain_of_vbd ~__context ~vbd:self = vm && not force_loopback_vbd
-  then unplug ~__context ~self
-  else Xapi_xenops.vbd_unplug ~__context ~self true
+let unplug_force_no_safety_check = unplug_force
 
 (** Hold this mutex while resolving the 'autodetect' device names to prevent two concurrent
     VBD.creates racing with each other and choosing the same device. For simplicity keep this


### PR DESCRIPTION
VBD.unplug_force() and VBD.unplug_force_no_safety_check() are identical.
Now the latter is simply another name for the former rather than an
identical implementation.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>