### PR TITLE
CA-226028 support vm-start --force for memory limits under nested-virt

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -735,15 +735,6 @@ module MD = struct
     let pci_msitranslate =
       if vm.API.vM_VGPUs <> [] then false else pci_msitranslate in
 
-    (* CP-18860: check memory limits if using nested_virt *)
-    if Vm_platform.is_true ~key:"nested-virt" ~platformdata ~default:false
-    then
-      begin
-        let module C = Xapi_vm_memory_constraints.Vm_memory_constraints in
-        let c = C.get ~__context ~vm_ref:vmref in
-        C.assert_valid_and_pinned_at_static_max c
-      end;
-
     {
       id = vm.API.vM_uuid;
       name = vm.API.vM_name_label;


### PR DESCRIPTION
This commit moves the memory limit check into VM.start where it can be
overridden using --force.

Signed-off-by: Christian Lindig christian.lindig@citrix.com
