### PR TITLE
CA-224335 re-start agetty only after change of IP address

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -165,6 +165,15 @@ let wait_for_management_ip ~__context =
         done; end);
   !ip
 
+let update_getty () =
+  (* Running update-issue service on best effort basis *)
+  try
+    ignore (Forkhelpers.execute_command_get_output !Xapi_globs.update_issue_script []);
+    ignore (Forkhelpers.execute_command_get_output !Xapi_globs.kill_process_script ["-q"; "-HUP"; "mingetty"; "agetty"])
+  with e ->
+    debug "update_getty at %s caught exception: %s"
+      __LOC__ (Printexc.to_string e)
+
 let on_dom0_networking_change ~__context =
   debug "Checking to see if hostname or management IP has changed";
   (* Need to update:
@@ -187,21 +196,18 @@ let on_dom0_networking_change ~__context =
         debug "Changing Host.address in database to: %s" ip;
         Db.Host.set_address ~__context ~self:localhost ~value:ip;
         debug "Refreshing console URIs";
+        update_getty ();
         Dbsync_master.refresh_console_urls ~__context
       end
     | None ->
       if Db.Host.get_address ~__context ~self:localhost <> "" then begin
         debug "Changing Host.address in database to: '' (host has no management IP address)";
+        update_getty ();
         Db.Host.set_address ~__context ~self:localhost ~value:""
       end
   end;
   Helpers.update_domain_zero_name ~__context localhost new_hostname;
-  (* Running update-issue service on best effort basis *)
-  try
-    ignore (Forkhelpers.execute_command_get_output !Xapi_globs.update_issue_script []);
-    ignore (Forkhelpers.execute_command_get_output !Xapi_globs.kill_process_script ["-q"; "-HUP"; "mingetty"; "agetty"])
-  with _ -> ();
-    debug "Signalling anyone waiting for the management IP address to change";
-    Mutex.execute management_ip_mutex
-      (fun () -> Condition.broadcast management_ip_cond)
+  debug "Signalling anyone waiting for the management IP address to change";
+  Mutex.execute management_ip_mutex
+    (fun () -> Condition.broadcast management_ip_cond)
 


### PR DESCRIPTION
This commit addresses agetty being restarted so frequently that systemd
would block it. We now limit restarts to situation where we know that
the IP address has changed. This should bring down the frequency.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>