### PR TITLE
CA-220275: increase host evacuation timeout during host shutdown

### DIFF
--- a/scripts/xapi-domains.service
+++ b/scripts/xapi-domains.service
@@ -11,5 +11,10 @@ ExecStart=@BINDIR@/xapi-autostart-vms
 ExecStop=@LIBEXECDIR@/shutdown $INSTALLATION_UUID
 ExecStop=@LIBEXECDIR@/shutdown --force $INSTALLATION_UUID
 
+# Generous 24hr timeout that corresponding to the max evacuation time of a host
+# with memory close to our support limit. Finer grained timeout control depends
+# on the logic in the shutdown script itself.
+TimeoutStopSec=86400
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The previous setting was 240s, which isn't enough for migrating VMs in worst
cases given our current support limit on host memory. This change increases the
uplimit and also adds some parametric flexibility to it.

Signed-off-by: Zheng Li zheng.li3@citrix.com
