### PR TITLE
CA-227721: init-script: flush to log on xapi start

### DIFF
--- a/scripts/init.d-xapi
+++ b/scripts/init.d-xapi
@@ -50,10 +50,12 @@ start() {
 	    # clear out qemu coredumps/chroot dirs on system boot:
 	    rm -rf /var/xen/qemu/*
 	    #rm -f ${XAPI_BOOT_TIME_INFO_UPDATED}
+	    echo
 	    exec "@BINDIR@/xapi" -nowatchdog ${xapiflags} \
 		-writereadyfile ${XAPI_STARTUP_COOKIE} -writeinitcomplete ${XAPI_INIT_COMPLETE_COOKIE} -onsystemboot
 		RETVAL=$?
 	else
+	    echo
 	    exec "@BINDIR@/xapi" -nowatchdog ${xapiflags} \
 		-writereadyfile ${XAPI_STARTUP_COOKIE} -writeinitcomplete ${XAPI_INIT_COMPLETE_COOKIE}
 		RETVAL=$?


### PR DESCRIPTION
The start function in the init-script for xapi was writing
"Starting xapi: " with no newline on success, so the text
did not reach the logging system until the next stop; this
caused wrong and confusing logs.

Now the function emits a newline immediately before it
replaces itself with a xapi process.