### PR TITLE
CA-228029: Fix update destroy failure in xe-install-supplemental-pack when exception happens

### DIFF
--- a/scripts/xe-install-supplemental-pack
+++ b/scripts/xe-install-supplemental-pack
@@ -31,7 +31,15 @@ done
 iso="$1"
 [ -n "$iso" ] || usage
 
+function clean_up {
+  set +e
+  xe update-pool-clean uuid=$update_uuid
+  hosts=$(xe update-param-get param-name=hosts uuid=$update_uuid)
+  [ -z "$hosts" ] && xe update-destroy uuid=$update_uuid
+  set -e
+}
+
 update_uuid=$(xe update-upload file-name="$iso" ${sr_uuid:+sr-uuid=$sr_uuid})
-trap "set +e; xe update-pool-clean uuid=$update_uuid; xe update-destroy uuid=$update_uuid； set -e" ERR
+trap clean_up ERR
 xe update-apply uuid=$update_uuid host=$INSTALLATION_UUID
 xe update-pool-clean uuid=$update_uuid

--- a/scripts/xe-install-supplemental-pack
+++ b/scripts/xe-install-supplemental-pack
@@ -32,6 +32,6 @@ iso="$1"
 [ -n "$iso" ] || usage
 
 update_uuid=$(xe update-upload file-name="$iso" ${sr_uuid:+sr-uuid=$sr_uuid})
-trap "xe update-pool-clean uuid=$update_uuid" EXIT ERR
-trap "xe update-destroy uuid=$update_uuid" ERR
+trap "set +e; xe update-pool-clean uuid=$update_uuid; xe update-destroy uuid=$update_uuid； set -e" ERR
 xe update-apply uuid=$update_uuid host=$INSTALLATION_UUID
+xe update-pool-clean uuid=$update_uuid


### PR DESCRIPTION
The problem here is that for code like
trap "xe update-pool-clean uuid=$update_uuid" EXIT ERR
trap "xe update-destroy uuid=$update_uuid" ERR

In testing, it will call xe update-destroy first.
After xe update-destroy, xe update-pool-clean will have no object to refer.

We expect the code will call pool_clean first then destroy.
But what we wrote in trap seems cannot make sure this sequence

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>