### PR TITLE
CA-226000: Old patches are not removed on Host Upgrade

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -445,7 +445,17 @@ let resync_host ~__context ~host =
       ) update_refs;
     Create_misc.create_updates_requiring_reboot_info ~__context ~host
   end
-  else Db.Host.set_updates ~__context ~self:host ~value:[]
+  else Db.Host.set_updates ~__context ~self:host ~value:[];
+
+  (* Remove any pool_patch objects that don't have a corresponding pool_update object *)
+  Db.Pool_patch.get_all ~__context
+  |> List.filter (fun self -> Db.Pool_patch.get_pool_update ~__context ~self = Ref.null)
+  |> List.iter (fun self -> Db.Pool_patch.destroy ~__context ~self);
+
+  (* Clean updates that don't have a corresponding patch record *)
+  Db.Pool_update.get_all ~__context
+  |> List.filter (fun self -> Xapi_pool_patch.pool_patch_of_update ~__context self = Ref.null)
+  |> List.iter (fun self -> destroy ~__context ~self)
 
 let pool_update_download_handler (req: Request.t) s _ =
   debug "pool_update.pool_update_download_handler URL %s" req.Request.uri;


### PR DESCRIPTION
Remove any pool_patch objects that don't have a corresponding
pool_update object

Signed-off-by: Liang Dai <liang.dai1@citrix.com>