### PR TITLE
CA-223461: Add more info to redo_log and block_device_io logging.

### DIFF
--- a/ocaml/database/block_device_io.ml
+++ b/ocaml/database/block_device_io.ml
@@ -772,7 +772,7 @@ let _ =
       try
         (* Open the block device *)
         let block_dev_fd = open_block_device !block_dev target_startup_response_time in
-        R.info "Opened block device.";
+        R.info "Opened block device '%s'" !block_dev;
 
         finally
           (fun () ->
@@ -811,6 +811,7 @@ let _ =
           )
           (fun () ->
              (* Ensure that the block device FD is always closed *)
+             R.info "Closing block device '%s'" !block_dev;
              ignore_exn (fun () -> Unix.close block_dev_fd)
           )
       with (* problems opening block device *)

--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -472,7 +472,7 @@ let maybe_retry f log =
 (* Close any existing socket and kill the corresponding process. *)
 let shutdown log =
   if is_enabled log then begin
-    R.debug "Shutting down connection to I/O process";
+    R.debug "Shutting down connection to I/O process for '%s'" log.name;
     try
       begin
         match !(log.pid) with
@@ -498,7 +498,7 @@ let shutdown log =
               Mutex.execute log.dying_processes_mutex
                 (fun () -> log.num_dying_processes := !(log.num_dying_processes) + 1);
               ignore(Forkhelpers.waitpid p);
-              R.debug "Finished waiting for process %d" ipid;
+              R.debug "Finished waiting for process with pid %d" ipid;
               Mutex.execute log.dying_processes_mutex
                 (fun () -> log.num_dying_processes := !(log.num_dying_processes) - 1)
             ) ());
@@ -511,7 +511,7 @@ let shutdown log =
               Unixext.unlink_safe sockpath
             ) [ctrlsockpath; datasockpath]
       end;
-    with _ -> () (* ignore any errors *)
+    with e -> R.error "Caught %s: while shutting down connection to I/O process" (Printexc.to_string e); () (* ignore any errors *)
   end
 
 let broken log =


### PR DESCRIPTION
1) Print the exception raised for `Redo_log.shutdown`.
2) Print the block device path while opening and closing it.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>