### PR TITLE
[For Review] CA-225070-v2: Refined order of xapi/xhad/attach-static-vdis start/stop

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4475,7 +4475,9 @@ let host_emergency_ha_disable = call ~flags:[`Session]
     ~name:"emergency_ha_disable"
     ~in_oss_since:None
     ~in_product_since:rel_orlando
-    ~params:[]
+    ~versioned_params:
+      [{param_type=Bool; param_name="soft"; param_doc="Disable HA temporarily, revert upon host reboot or further changes, idempotent"; param_release=dundee_plus_release; param_default=Some(VBool false)};
+      ]
     ~doc:"This call disables HA on the local host. This should only be used with extreme care."
     ~allowed_roles:_R_POOL_OP
     ()

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -4393,8 +4393,9 @@ let host_emergency_management_reconfigure printer rpc session_id params =
 
 let host_emergency_ha_disable printer rpc session_id params =
   let force = get_bool_param params "force" in
+  let soft = get_bool_param params "soft" in
   if not force then failwith "This operation is extremely dangerous and may cause data loss. This operation must be forced (use --force).";
-  Client.Host.emergency_ha_disable rpc session_id
+  Client.Host.emergency_ha_disable rpc session_id soft
 
 let host_management_reconfigure printer rpc session_id params =
   let pif = Client.PIF.get_by_uuid rpc session_id (List.assoc "pif-uuid" params) in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2154,9 +2154,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Host.local_management_reconfigure: interface = '%s'" interface;
       Local.Host.local_management_reconfigure ~__context ~interface
 
-    let emergency_ha_disable ~__context =
-      info "Host.emergency_ha_disable";
-      Local.Host.emergency_ha_disable ~__context
+    let emergency_ha_disable ~__context ~soft =
+      info "Host.emergency_ha_disable: soft = '%b'" soft;
+      Local.Host.emergency_ha_disable ~__context ~soft
 
     (* Dummy implementation for a deprecated API method. *)
     let get_uncooperative_resident_VMs ~__context ~self =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -728,7 +728,7 @@ let abort_new_master ~__context ~address = Xapi_ha.abort_new_master __context ad
 
 let update_master ~__context ~host ~master_address = assert false
 
-let emergency_ha_disable ~__context = Xapi_ha.emergency_ha_disable __context
+let emergency_ha_disable ~__context ~soft = Xapi_ha.emergency_ha_disable __context soft
 
 (* This call can be used to _instruct_ a slave that it has to take a persistent backup (force=true).
    If force=false then this is a hint from the master that the client may want to take a backup; in this

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -110,7 +110,7 @@ val propose_new_master : __context:'a -> address:string -> manual:'b -> unit
 val commit_new_master : __context:Context.t -> address:string -> unit
 val abort_new_master : __context:'a -> address:string -> unit
 val update_master : __context:'a -> host:'b -> master_address:'c -> 'd
-val emergency_ha_disable : __context:'a -> unit
+val emergency_ha_disable : __context:'a -> soft:bool -> unit
 val request_backup :
   __context:Context.t -> host:API.ref_host -> generation:int64 -> force:bool -> unit
 val request_config_file_sync : __context:'a -> host:'b -> hash:string -> unit

--- a/scripts/attach-static-vdis.service
+++ b/scripts/attach-static-vdis.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Attach statically-configured VDIs to dom0
 Before=xapi.service
+After=network.target nfs-client.target xcp-networkd.service
 
 [Service]
 Type=oneshot

--- a/scripts/examples/python/shutdown.py
+++ b/scripts/examples/python/shutdown.py
@@ -240,6 +240,7 @@ def main(session, host_uuid, force):
         rc += parallel_clean_shutdown(session, get_running_domains(session, host))
     else:
         rc += serial_hard_shutdown(session, get_running_domains(session, host))
+
     return rc
 
 if __name__ == "__main__":

--- a/scripts/xapi-domains.service
+++ b/scripts/xapi-domains.service
@@ -8,8 +8,8 @@ Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=@INVENTORY@
 ExecStart=@BINDIR@/xapi-autostart-vms
-ExecStop=@LIBEXECDIR@/shutdown $INSTALLATION_UUID
-ExecStop=@LIBEXECDIR@/shutdown --force $INSTALLATION_UUID
+ExecStop=/bin/sh -c "/opt/xensource/libexec/shutdown $INSTALLATION_UUID || /opt/xensource/libexec/shutdown --force $INSTALLATION_UUID"
+ExecStop=/opt/xensource/bin/xe host-emergency-ha-disable force=true soft=true
 
 # Generous 24hr timeout that corresponding to the max evacuation time of a host
 # with memory close to our support limit. Finer grained timeout control depends


### PR DESCRIPTION
This is an alternative version of #2827.

It's slightly better as it doesn't hard wire the xhad (the default cluster-stack) commands. But it comes with the cost of adding an optional parameter to an existing API method.