### PR TITLE
CA-229347: Pool_update.introduce doesn't need dom0 free disk space 3 times of the update size.

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -368,7 +368,6 @@ let introduce ~__context ~vdi =
   (*If current disk free space is smaller than 1MB raise exception*)
   assert_space_available ~multiplier:1L Xapi_globs.host_update_dir (Int64.mul 1024L 1024L);
   let update_info = extract_update_info ~__context ~vdi ~verify in
-  ignore(assert_space_available Xapi_globs.host_update_dir update_info.installation_size);
   try
     let update = Db.Pool_update.get_by_uuid ~__context ~uuid:update_info.uuid in
     let vdi_of_update = Db.Pool_update.get_vdi ~__context ~self:update in


### PR DESCRIPTION

Signed-off-by: Hui Zhang <hui.zhang@citrix.com>