### PR TITLE
CA-228573: close the out channel to signal the end of transfer

### DIFF
--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -515,6 +515,7 @@ let main_loop ifd ofd =
                    copy_with_heartbeat file_ch oc heartbeat_fun;
                    marshal ofd (Response OK))
                 (fun () ->
+                   (try close_out oc with _ -> ());
                    (try close_in file_ch with _ -> ()))
             | 302 ->
               let newloc = List.assoc "location" headers in


### PR DESCRIPTION
The behavior was changed after #2819. With changeset 664e9bf, we removed the
logic of closing input channel (which looks correct by itself), but we should
probably close the output channel at that point instead, which would signal the
end of transfer.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>