### PR TITLE
CA-229176 fix PVS status cache incoherence - invalidate cache entry when attaching proxy

### DIFF
--- a/ocaml/xapi/monitor_dbcalls_cache.ml
+++ b/ocaml/xapi/monitor_dbcalls_cache.ml
@@ -46,6 +46,11 @@ let clear_cache_for_vm ~vm_uuid =
   Mutex.execute vm_memory_cached_m
     (fun _ -> Hashtbl.remove vm_memory_cached vm_uuid)
 
+(** [clear_pvs_status_cache] removes the cache entry for [vm_uuid] *)
+let clear_pvs_status_cache ~vm_uuid =
+  Mutex.execute pvs_proxy_cached_m
+    (fun _ -> Hashtbl.remove pvs_proxy_cached vm_uuid)
+
 (** Clear the whole cache. This forces fresh properties to be written into
  * xapi's database. *)
 let clear_cache () =

--- a/ocaml/xapi/monitor_pvs_proxy.ml
+++ b/ocaml/xapi/monitor_pvs_proxy.ml
@@ -32,6 +32,18 @@ let find_rrd_files () =
   |> Array.to_list
   |> List.filter (String.startswith metrics_prefix)
 
+  (* The PVS Proxy status cache [pvs_proxy_cached] contains the status
+   * entries from PVS Proxies as reported via RRD. When the status
+   * changes, it is updated in the xapi database. However: The xapi
+   * databse is only updated for proxies that are currently attached.
+   * This can lead to divergence between the cache and the database,
+   * leading to error CA-229176. When the PVS Proxy is attached in
+   * xapi_xenops.ml, the cache entry for the PVS Proxy is invalidated
+   * such that it is picked up again and updated in the xapi database.
+   * Inconsistencies are thus limited to the time between when a PVS
+   * Proxy starts reporting its status and when it is attached.
+   *)
+
 let get_changes () =
   List.iter (fun filename ->
       try

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1709,9 +1709,11 @@ let update_vif ~__context id =
                 | None -> ()
                 | Some proxy ->
                   debug "xenopsd event: Updating PVS_proxy for VIF %s.%s currently_attached <- %b" (fst id) (snd id) state.pvs_rules_active;
-                  if state.pvs_rules_active then
-                    Db.PVS_proxy.set_currently_attached ~__context ~self:proxy ~value:true
-                  else
+                  if state.pvs_rules_active then begin
+                    Db.PVS_proxy.set_currently_attached ~__context ~self:proxy ~value:true;
+                    (* force status to be read again by invalidating cache *)
+                    Monitor_dbcalls_cache.clear_pvs_status_cache (fst id)
+                  end else
                     Pvs_proxy_control.clear_proxy_state ~__context vif proxy
                );
                debug "xenopsd event: Updating VIF %s.%s currently_attached <- %b" (fst id) (snd id) (state.plugged || state.active);


### PR DESCRIPTION
These commits fix the problem that the xapi database would not contain the correct status of a PVS proxy.

The problem is rooted in a caching layer: the status as reported via RRD from PVS proxies is read into a cache. When the cache is updated, this update is propagated to the Xapi database. However, the Xapi database is updated only for attached proxies. This leads to an inconsistency: when the PVS Proxy reached the state of "caching" before it was attached, the Xapi entry would never be updated, staying in status "initialised". The problem is solved by invalidating the cache entry once the PVS proxy is attached. Now the current state is read into the cache and propagated to the Xapi database.

The commit contains code to validate the cache for debugging but it is currently disabled. When switched on one can observer that the cache is temporarily out of sync before a PVS Proxy is attached.