### PR TITLE
CA-228680: Improve error message when VM crashes before VM.start finishes

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1876,7 +1876,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
     let query_data_source ~__context ~self ~data_source =
       info "VM.query_data_source: VM = '%s'; data source = '%s'" (vm_uuid ~__context self) data_source;
-      Xapi_vm_lifecycle.assert_power_state_in ~__context ~self ~allowed:[`Running; `Paused];
+      Xapi_vm_lifecycle.assert_initial_power_state_in ~__context ~self ~allowed:[`Running; `Paused];
       let local_fn = Local.VM.query_data_source ~self ~data_source in
       forward_vm_op ~local_fn ~__context ~vm:self
         (fun session_id rpc -> Client.VM.query_data_source rpc session_id self data_source)
@@ -3339,7 +3339,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let vbds = Db.VDI.get_VBDs ~__context ~self in
       List.iter (fun vbd ->
           let vm = Db.VBD.get_VM ~__context ~self:vbd in
-          Xapi_vm_lifecycle.assert_power_state_is ~__context ~self:vm ~expected:`Halted
+          Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self:vm ~expected:`Halted
         ) vbds
 
     let set_on_boot ~__context ~self ~value =

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -34,7 +34,7 @@ let assert_attachable ~__context ~self : unit =
 
 let set_mode ~__context ~self ~value =
   let vm = Db.VBD.get_VM ~__context ~self in
-  Xapi_vm_lifecycle.assert_power_state_is ~__context ~self:vm ~expected:`Halted;
+  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self:vm ~expected:`Halted;
   Db.VBD.set_mode ~__context ~self ~value
 
 let plug ~__context ~self =

--- a/ocaml/xapi/xapi_vgpu.ml
+++ b/ocaml/xapi/xapi_vgpu.ml
@@ -26,7 +26,7 @@ let create ~__context  ~vM ~gPU_group ~device ~other_config ~_type =
   let uuid = Uuid.to_string (Uuid.make_uuid ()) in
   if not (Pool_features.is_enabled ~__context Features.GPU) then
     raise (Api_errors.Server_error (Api_errors.feature_restricted, []));
-  Xapi_vm_lifecycle.assert_power_state_is ~__context ~self:vM ~expected:`Halted;
+  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self:vM ~expected:`Halted;
   if not(valid_device device) then
     raise (Api_errors.Server_error (Api_errors.invalid_device, [device]));
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -789,7 +789,7 @@ let set_HVM_shadow_multiplier ~__context ~self ~value =
 
 (** Sets the HVM shadow multiplier for a {b Running} VM. Runs on the slave. *)
 let set_shadow_multiplier_live ~__context ~self ~multiplier =
-  Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:`Running;
+  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self ~expected:`Running;
 
   validate_HVM_shadow_multiplier multiplier;
 
@@ -1022,7 +1022,7 @@ let recover ~__context ~self ~session_to ~force =
   ignore (Xapi_dr.recover_vms ~__context ~vms:[self] ~session_to ~force)
 
 let set_suspend_VDI ~__context ~self ~value =
-  Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:`Suspended;
+  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self ~expected:`Suspended;
   let src_vdi = Db.VM.get_suspend_VDI ~__context ~self in
   let dst_vdi = value in
   if src_vdi <> dst_vdi then
@@ -1175,7 +1175,7 @@ let assert_can_set_has_vendor_device ~__context ~self ~value =
      	 * we allow restoration of a VM from a snapshot. *)
   then Pool_features.assert_enabled ~__context ~f:Features.PCI_device_for_auto_update;
 
-  Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:`Halted
+  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self ~expected:`Halted
 
 let set_has_vendor_device ~__context ~self ~value =
   assert_can_set_has_vendor_device ~__context ~self ~value;


### PR DESCRIPTION
Also fixed indentation.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>