### PR TITLE
CA-233306: Delete the VDI when invoking Pool_update.pool_clean

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -414,7 +414,8 @@ let pool_clean ~__context ~self =
   debug "pool_update.pool_clean %s" pool_update_name;
   detach ~__context ~self;
   let vdi = Db.Pool_update.get_vdi ~__context ~self in
-  Db.VDI.destroy ~__context ~self:vdi;
+  Helpers.call_api_functions ~__context
+    (fun rpc session_id -> Client.VDI.destroy rpc session_id vdi);
   Db.Pool_update.set_vdi ~__context ~self ~value:Ref.null
 
 let destroy ~__context ~self =


### PR DESCRIPTION
Db.VDI.destroy in Pool_update.pool_clean just removes the Xapi database record.
It should invoke Client.VDI.destroy instead and remove both the VDI and the database record.

Signed-off-by: Hui Zhang <hui.zhang@citrix.com>