### PR TITLE
Update xapi version number to 1.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ xapi.spec: xapi.spec.in
 srpm: xapi.spec
 	mkdir -p $(RPM_SOURCESDIR) $(RPM_SPECSDIR) $(RPM_SRPMSDIR)
 	while ! [ -d .git ]; do cd ..; done; \
-	git archive --prefix=xapi-1.10.0/ --format=tar HEAD | bzip2 -z > $(RPM_SOURCESDIR)/xapi-1.10.0.tar.bz2 # xen-api/Makefile
+	git archive --prefix=xapi-1.20.0/ --format=tar HEAD | bzip2 -z > $(RPM_SOURCESDIR)/xapi-1.20.0.tar.bz2 # xen-api/Makefile
 	cp $(JQUERY) $(JQUERY_TREEVIEW) $(RPM_SOURCESDIR)
 	make -C $(REPO) version
 	rm -f $(RPM_SOURCESDIR)/xapi-version.patch

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -2,7 +2,7 @@
 
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
-Version: 1.10.0
+Version: 1.20.0
 Release: @RPM_RELEASE@
 Group:   System/Hypervisor
 License: LGPL+linking exception


### PR DESCRIPTION
Use a larger minor version number to ensure that the ely-bugfix version
of xapi can increment the minor version number a few times before
collision - we have to ensure that the version number of xapi in the
master branch of xapi-project/xen-api is always higher than the one in
the ely-bugfix branch of xenserver/xen-api.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>