### PR TITLE
Update version number in xapi.spec.in to 1.20.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ xapi.spec: xapi.spec.in
 srpm: xapi.spec
 	mkdir -p $(RPM_SOURCESDIR) $(RPM_SPECSDIR) $(RPM_SRPMSDIR)
 	while ! [ -d .git ]; do cd ..; done; \
-	git archive --prefix=xapi-1.20.0/ --format=tar HEAD | bzip2 -z > $(RPM_SOURCESDIR)/xapi-1.20.0.tar.bz2 # xen-api/Makefile
+	git archive --prefix=xapi-1.20.1/ --format=tar HEAD | bzip2 -z > $(RPM_SOURCESDIR)/xapi-1.20.1.tar.bz2 # xen-api/Makefile
 	cp $(JQUERY) $(JQUERY_TREEVIEW) $(RPM_SOURCESDIR)
 	make -C $(REPO) version
 	rm -f $(RPM_SOURCESDIR)/xapi-version.patch

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -2,7 +2,7 @@
 
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
-Version: 1.20.0
+Version: 1.20.1
 Release: @RPM_RELEASE@
 Group:   System/Hypervisor
 License: LGPL+linking exception


### PR DESCRIPTION
To keep it in sync with the actual version of xapi. The version tag
v1.20.1 should be at this commit.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>