### PR TITLE
CA-234510: update db before archiving rrd

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -572,14 +572,14 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
     Db.VM.set_domid ~__context ~self ~value:(-1L)
   end;
 
+  Db.VM.set_power_state ~__context ~self ~value:state;
+  update_allowed_operations ~__context ~self;
+
   if state = `Halted then begin
     (* archive the rrd for this vm *)
     let vm_uuid = Db.VM.get_uuid ~__context ~self in
     log_and_ignore_exn (fun () -> Rrdd.archive_rrd ~vm_uuid ~remote_address:(try Some (Pool_role.get_master_address ()) with _ -> None))
-  end;
-
-  Db.VM.set_power_state ~__context ~self ~value:state;
-  update_allowed_operations ~__context ~self
+  end
 
 (** Called on new VMs (clones, imports) and on server start to manually refresh
     the power state, allowed_operations field etc.  Clean current-operations


### PR DESCRIPTION
The `Rrdd.archive_rrd` operation could wait for a mutex or be stuck in IO operations for some time. In rare cases, this means that the power state (and allowed operations) informations in the database could be wrong for a long time.

By inverting the order of operations, we make sure that the potentially slow operation only happens  after the database state has been completely updated.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>