### PR TITLE
opam: add xapi-test-utils OPAM dependency

### DIFF
--- a/opam
+++ b/opam
@@ -9,6 +9,7 @@ build-test: [make "test" ]
 remove: ["rm" "%{bin}%/xapi"]
 depends: [
   "ocamlfind"
+  "xapi-test-utils"
   "xapi-idl" {>= "0.12.2"}
   "xapi-libs-transitional"
   "xen-api-client"


### PR DESCRIPTION
Add the missing xapi-test-utils OPAM dependency to the opam file. It is
declared as a "BuildRequires" in the spec file of xapi, but it was missing from
the opam file. With this dependency added, the OPAM build of xapi works again.

The corresponding PR for opam-repo-dev is https://github.com/xapi-project/opam-repo-dev/pull/127

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>