### PR TITLE
CA-172901: XenAPI.py, make SSL verification optional

### DIFF
--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -126,9 +126,17 @@ class Session(xmlrpclib.ServerProxy):
     """
 
     def __init__(self, uri, transport=None, encoding=None, verbose=0,
-                 allow_none=1):
+                 allow_none=1, ignore_ssl=False):
+
+        # Fix for CA-172901
+        if ignore_ssl:
+            import ssl
+            ctx = ssl._create_unverified_context()
+        else:
+            ctx = None
+
         xmlrpclib.ServerProxy.__init__(self, uri, transport, encoding,
-                                       verbose, allow_none)
+                                       verbose, allow_none, context=ctx)
         self.transport = transport
         self._session = None
         self.last_login_method = None

--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -132,11 +132,11 @@ class Session(xmlrpclib.ServerProxy):
                 and ignore_ssl:
             import ssl
             ctx = ssl._create_unverified_context()
+            xmlrpclib.ServerProxy.__init__(self, uri, transport, encoding,
+                                           verbose, allow_none, context=ctx)
         else:
-            ctx = None
-
-        xmlrpclib.ServerProxy.__init__(self, uri, transport, encoding,
-                                       verbose, allow_none, context=ctx)
+            xmlrpclib.ServerProxy.__init__(self, uri, transport, encoding,
+                                           verbose, allow_none)
         self.transport = transport
         self._session = None
         self.last_login_method = None
@@ -179,7 +179,7 @@ class Session(xmlrpclib.ServerProxy):
             self.last_login_method = method
             self.last_login_params = params
             self.API_version = self._get_api_version()
-        except socket.error as e:
+        except socket.error, e:
             if e.errno == socket.errno.ETIMEDOUT:
                 raise xmlrpclib.Fault(504, 'The connection timed out')
             else:

--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -127,8 +127,9 @@ class Session(xmlrpclib.ServerProxy):
     def __init__(self, uri, transport=None, encoding=None, verbose=0,
                  allow_none=1, ignore_ssl=False):
 
-        # Fix for CA-172901
-        if ignore_ssl:
+        # Fix for CA-172901 (+ Python 2.4 compatibility)
+        if not (sys.version_info[0] <= 2 and sys.version_info[1] < 7) \
+                and ignore_ssl:
             import ssl
             ctx = ssl._create_unverified_context()
         else:

--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -73,7 +73,6 @@ class Failure(Exception):
         try:
             return str(self.details)
         except Exception, exn:
-            import sys
             print >>sys.stderr, exn
             return "Xen-API failure: %s" % str(self.details)
 


### PR DESCRIPTION
SSL verification is still enabled by default, but can be disabled by
developer for testing purposes by adding the optional parameter
`ignore_ssl` during the Session creation.