### PR TITLE
CA-239947: Restrict VM allowed_operations check to VMSS type `snapsho…

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -920,6 +920,7 @@ let set_protection_policy ~__context ~self ~value =
 	raise (Api_errors.Server_error (Api_errors.message_removed, []))
 
 let set_snapshot_schedule ~__context ~self ~value =
+	Pool_features.assert_enabled ~__context ~f:Features.VMSS;
 	(* Validate the VMSS Ref *)
 	let is_vmss_valid_ref = Db.is_valid_ref __context value in
 	if not (is_vmss_valid_ref || (value = Ref.null) || (Ref.string_of value = "")) then
@@ -931,12 +932,15 @@ let set_snapshot_schedule ~__context ~self ~value =
 		if Db.VM.get_is_a_template ~__context ~self then
 			(* Do not assign templates to a VMSS. *)
 			raise (Api_errors.Server_error(Api_errors.vm_is_template, [Ref.string_of self]));
-		(* Check VM allowed operation support the snapshot type of VMSS *)
-		let allowed_operations = Db.VM.get_allowed_operations ~__context ~self in
+		(* Check VM allowed operations for VMSS snapshot_type=snapshot_with_quiesce *)
 		let snapshot_type = Db.VMSS.get_type ~__context ~self:value in
-		if not (List.exists (fun ty -> ty == snapshot_type) allowed_operations) then
-			raise (Api_errors.Server_error(Api_errors.operation_not_allowed,
-				["VM doesn't support snapshot_type " ^ (Record_util.vmss_type_to_string snapshot_type)]));
+		if snapshot_type = `snapshot_with_quiesce then begin
+			Pool_features.assert_enabled ~__context ~f:Features.VSS;
+			let allowed_operations = Db.VM.get_allowed_operations ~__context ~self in
+			if not (List.exists (fun ty -> ty = snapshot_type) allowed_operations) then
+				raise (Api_errors.Server_error(Api_errors.operation_not_allowed,
+					["VM doesn't support snapshot_type " ^ (Record_util.vmss_type_to_string snapshot_type)]));
+		end
 	end;
 	Db.VM.set_snapshot_schedule ~__context ~self ~value;
 	update_allowed_operations ~__context ~self

--- a/ocaml/xapi/xapi_vmss.ml
+++ b/ocaml/xapi/xapi_vmss.ml
@@ -91,20 +91,19 @@ let set_schedule ~__context ~self ~value =
 	Db.VMSS.set_schedule ~__context ~self ~value
 
 let set_type ~__context ~self ~value =
-	(* Check VMs associated to VMSS supports the new snapshot type *)
 	assert_licensed ~__context;
-	if value = `snapshot_with_quiesce then
+	(* For VMSS snapshot_type=snapshot_with_quiesce, Check VMs supports the snapshot_with_quiesce *)
+	if value = `snapshot_with_quiesce then begin
 		Pool_features.assert_enabled ~__context ~f:Features.VSS;
-	let snapshot_type = Record_util.vmss_type_to_string value in
-	let vms = Db.VMSS.get_VMs ~__context ~self in
-	if vms <> [] then
-		List.iter (fun vm ->
+		let snapshot_type = Record_util.vmss_type_to_string value in
+		Db.VMSS.get_VMs ~__context ~self
+		|> List.iter (fun vm ->
 			let allowed_operations = Db.VM.get_allowed_operations ~__context ~self:vm in
-			if not (List.exists (fun ty -> (Record_util.vm_operation_to_string ty) = snapshot_type)
-				allowed_operations) then
+			if not (List.exists (fun ty -> (Record_util.vm_operation_to_string ty) = snapshot_type) allowed_operations) then
 				raise (Api_errors.Server_error(Api_errors.operation_not_allowed,
 					[Ref.string_of vm ; "VM doesn't support snapshot_type " ^ snapshot_type]));
-		) vms;
+		)
+	end;
 	Db.VMSS.set_type ~__context ~self ~value
 
 (* Workaround for `param-set` calling `remove_from_schedule` first then `add_to_schedule`


### PR DESCRIPTION
…t_with_quiesce

Following the VMPR, Halted VMs were allowed to be added to VMPP of type
`checkpoint and `snapshot. VMSS must follow the same behaviour.

Since VMSS supports new type `snapshot_with_quiesce.
VM allowed_operations must be checked to support `snapshot_with_quiesce:
1) While adding VM to VMSS of type `snapshot_with_quiesce.
2) While changing the type of VMSS to `snapshot_with_quiesce.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>