### PR TITLE
CA-232290: Task.cancel verify permission before forwarding

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -450,6 +450,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
     include Local.Task
 
     let cancel ~__context ~task =
+      TaskHelper.assert_can_destroy ~__context task;
       let local_fn = cancel ~task in
       let forwarded_to = Db.Task.get_forwarded_to ~__context ~self:task in
       if Db.is_valid_ref __context forwarded_to


### PR DESCRIPTION
By design, an internal superuser session will be created and used for message
forwarding to slaves, so permission checking afterwards (i.e. where the message
is already forwarded) will always return success. So we should make the
permission checking right on the front.

CVE ID: CVE-2017-5573
Security Bulletin: CTX220112

Signed-off-by: Zheng Li <zheng.li3@citrix.com>