### PR TITLE
Fix test_assert_space_available unit test

### DIFF
--- a/ocaml/xapi/test_pool_update.ml
+++ b/ocaml/xapi/test_pool_update.ml
@@ -32,11 +32,9 @@ let test_pool_update_refcount () =
   Xapi_pool_update.with_dec_refcount ~__context ~uuid ~vdi (fun ~__context ~uuid ~vdi -> ())
 
 let test_assert_space_available () =
-  let stat = statvfs "./" in
-  let free_bytes = Int64.mul stat.f_frsize stat.f_bfree in
-  Xapi_pool_update.assert_space_available "./" (Int64.div free_bytes 3L);
+  let free_bytes = 1_000_000L in
   assert_raises_api_error Api_errors.out_of_space
-    (fun () -> Xapi_pool_update.assert_space_available "./" (Int64.div free_bytes 2L))
+    (fun () -> Xapi_pool_update.assert_space_available ~get_free_bytes:(fun _ -> free_bytes) "./" (Int64.div free_bytes 2L))
 
 let test =
   "test_pool_update" >:::

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -301,11 +301,13 @@ let extract_update_info ~__context ~vdi ~verify =
     )
     (fun () -> detach_helper ~__context ~uuid:vdi_uuid ~vdi)
 
-let assert_space_available ?(multiplier=3L) update_dir update_size =
-  let stat = statvfs update_dir in
-  let free_bytes =
+let get_free_bytes path =
+    let stat = statvfs path in
     (* block size times free blocks *)
-    Int64.mul stat.f_frsize stat.f_bfree in
+    Int64.mul stat.f_frsize stat.f_bfree
+
+let assert_space_available ?(multiplier=3L) ?(get_free_bytes=get_free_bytes) update_dir update_size =
+  let free_bytes = get_free_bytes update_dir in
   let really_required = Int64.mul multiplier update_size in
   if really_required > free_bytes
   then


### PR DESCRIPTION
In the unit test, mock the function that gets free space of the filesystem to
avoid concurrency issues.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>