### PR TITLE
CA-241704: switch from 'yum install' to 'yum upgrade'

### DIFF
--- a/scripts/extensions/pool_update.apply
+++ b/scripts/extensions/pool_update.apply
@@ -44,7 +44,7 @@ def failure_message(code, params):
 
 
 def execute_apply(session, update_package, yum_conf_file):
-    cmd = ['yum', 'install', '-y', '--noplugins', '-c', yum_conf_file, update_package]
+    cmd = ['yum', 'upgrade', '-y', '--noplugins', '-c', yum_conf_file, update_package]
     yum_env = os.environ.copy()
     yum_env['LANG'] = 'C'
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)


### PR DESCRIPTION
If an existing update is upgraded (e.g. a device driver) it increases
its version number but retains its original name. When yum is asked to
install the update package it reports it as a no-op as a package of
that name is already present.

Using 'yum upgrade' instead makes upgrades behave as expected. Initial
installs continue to work as well.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>