### PR TITLE
CA-241301: Don't push RRD for VM if it is not running

### DIFF
--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -214,7 +214,9 @@ let host_for_vm ~__context ~vm_uuid =
 
 let push_rrd ~__context ~(vm_uuid : string) : unit =
   let vm_host = host_for_vm ~__context ~vm_uuid in
-  if vm_host = (Helpers.get_localhost ~__context) then
+  if vm_host = Ref.null then
+    warn "push_rrd: VM not running, so not pushing its RRD"
+  else if vm_host = (Helpers.get_localhost ~__context) then
     let domid = vm_uuid_to_domid ~__context ~uuid:vm_uuid in
     log_and_ignore_exn (fun () -> Rrdd.push_rrd_local ~vm_uuid ~domid)
   else


### PR DESCRIPTION
The function `Rrdd_proxy.push_rrd` is called from message_forwarding at the end
of a VM start or resume. It looks up the VM's host of residence, assuming the
VM is now running. If it has already crashed (for whatever reason), then the VM
isn't resident anywhere, and we should not attempt to push the RRD. The
start/resume call will still succeed in this case, because the VM crashed
_after_ starting/resuming it.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>