### PR TITLE
CP-20411: AMD MxGPU in datamodel and vgpu-type

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8633,6 +8633,8 @@ let pci =
       field ~qualifier:StaticRO ~ty:(Ref _host) ~lifecycle:[Published, rel_boston, ""] "host" "Physical machine that owns the PCI device" ~default_value:(Some (VRef null_ref));
       field ~qualifier:StaticRO ~ty:String ~lifecycle:[Published, rel_boston, ""] "pci_id" "PCI ID of the physical device" ~default_value:(Some (VString ""));
       field ~qualifier:DynamicRO ~ty:Int ~lifecycle:[] ~default_value:(Some (VInt 1L)) "functions" "Number of physical + virtual PCI functions" ~internal_only:true;
+      field ~qualifier:DynamicRO ~ty:(Set (Ref _pci)) ~lifecycle:[Published, rel_falcon, ""] "virtual_functions" "Set of VF PCI devices provided by this physical (PF) PCI device" ~internal_only:true;
+      field ~qualifier:StaticRO ~ty:(Ref _pci) ~lifecycle:[Published, rel_falcon, ""] "physical_function" "The PF (physical PCI device) that provides this VF" ~default_value:(Some (VRef null_ref)) ~internal_only:true;
       field ~qualifier:DynamicRO ~ty:(Set (Ref _vm)) ~lifecycle:[] "attached_VMs"
         "VMs that currently have a function of this PCI device passed-through to them" ~internal_only:true;
       field ~qualifier:DynamicRO ~ty:(Set (Ref _pci)) ~lifecycle:[Published, rel_boston, ""] "dependencies" "List of dependent PCI devices" ~ignore_foreign_key:true;
@@ -8984,6 +8986,7 @@ let vgpu_type_implementation =
       "passthrough", "Pass through an entire physical GPU to a guest";
       "nvidia", "vGPU using NVIDIA hardware";
       "gvt_g", "vGPU using Intel GVT-g";
+      "mxgpu", "vGPU using AMD MxGPU";
     ])
 
 let vgpu_type =
@@ -9436,6 +9439,7 @@ let all_relations =
     (_pci, "host"), (_host, "PCIs");
     (_pgpu, "host"), (_host, "PGPUs");
     (_pci, "attached_VMs"), (_vm, "attached_PCIs");
+    (_pci, "physical_function"), (_pci, "virtual_functions");
 
     (_vdi, "metadata_of_pool"), (_pool, "metadata_VDIs");
     (_sr, "introduced_by"), (_dr_task, "introduced_SRs");

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -56,6 +56,7 @@ let rel_indigo = "indigo"
 let rel_dundee = "dundee"
 let rel_dundee_plus = "dundee-plus"
 let rel_ely = "ely"
+let rel_falcon = "falcon"
 
 let release_order =
   [ rel_rio
@@ -79,6 +80,7 @@ let release_order =
   ; rel_dundee
   ; rel_dundee_plus
   ; rel_ely
+  ; rel_falcon
   ]
 
 exception Unknown_release of string

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -276,12 +276,12 @@ let make_vdi ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ()) ?(name_label="")
 let make_pci ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ()) ?(class_id="")
     ?(class_name="") ?(vendor_id="") ?(vendor_name="") ?(device_id="")
     ?(device_name="") ?(host=Ref.null) ?(pci_id="0000:00:00.0") ?(functions=0L)
-    ?(dependencies=[]) ?(other_config=[]) ?(subsystem_vendor_id="")
+    ?(physical_function=Ref.null) ?(dependencies=[]) ?(other_config=[]) ?(subsystem_vendor_id="")
     ?(subsystem_vendor_name="") ?(subsystem_device_id="")
     ?(subsystem_device_name="") () =
   Db.PCI.create ~__context ~ref ~uuid ~class_id ~class_name ~vendor_id
-    ~vendor_name ~device_id ~device_name ~host ~pci_id ~functions ~dependencies
-    ~other_config ~subsystem_vendor_id ~subsystem_vendor_name
+    ~vendor_name ~device_id ~device_name ~host ~pci_id ~functions ~physical_function
+    ~dependencies ~other_config ~subsystem_vendor_id ~subsystem_vendor_name
     ~subsystem_device_id ~subsystem_device_name;
   ref
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -786,6 +786,8 @@ let igd_passthru_vendor_whitelist = ref []
 
 let gvt_g_whitelist = ref "/etc/gvt-g-whitelist"
 
+let mxgpu_whitelist = ref "/etc/mxgpu-whitelist"
+
 let xen_livepatch_list = ref "/usr/sbin/xen-livepatch list"
 
 let kpatch_list = ref "/usr/sbin/kpatch list"
@@ -952,6 +954,9 @@ let other_options = [
 
   "gvt-g-whitelist", Arg.Set_string gvt_g_whitelist,
   (fun () -> !gvt_g_whitelist), "path to the GVT-g whitelist file";
+
+  "mxgpu-whitelist", Arg.Set_string mxgpu_whitelist,
+  (fun () -> !mxgpu_whitelist), "path to the MxGPU whitelist file";
 
   "pass-through-pif-carrier", Arg.Set pass_through_pif_carrier,
   (fun () -> string_of_bool !pass_through_pif_carrier), "reflect physical interface carrier information to VMs by default";

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -50,13 +50,15 @@ let id_of_int hex_id =
   Printf.sprintf "%04x" hex_id
 
 let create ~__context ~class_id ~class_name ~vendor_id ~vendor_name ~device_id
-    ~device_name ~host ~pci_id ~functions ~dependencies ~other_config
+    ~device_name ~host ~pci_id ~functions ~physical_function
+    ~dependencies ~other_config
     ~subsystem_vendor_id ~subsystem_vendor_name
     ~subsystem_device_id ~subsystem_device_name =
   let p = Ref.make () in
   let uuid = Uuid.to_string (Uuid.make_uuid ()) in
   Db.PCI.create ~__context ~ref:p ~uuid ~class_id ~class_name ~vendor_id ~vendor_name ~device_id
-    ~device_name ~host ~pci_id ~functions ~dependencies:[] ~other_config:[]
+    ~device_name ~host ~pci_id ~functions ~physical_function
+    ~dependencies:[] ~other_config:[]
     ~subsystem_vendor_id ~subsystem_vendor_name
     ~subsystem_device_id ~subsystem_device_name;
   debug "PCI %s, %s, %s created" pci_id vendor_name device_name;
@@ -128,7 +130,7 @@ let update_pcis ~__context ~host =
               ~vendor_name:pci.vendor.name
               ~device_id:(id_of_int pci.device.id)
               ~device_name:pci.device.name ~host ~pci_id:pci.address
-              ~functions:1L ~dependencies:[] ~other_config:[]
+              ~functions:1L ~physical_function:Ref.null ~dependencies:[] ~other_config:[]
               ~subsystem_vendor_id ~subsystem_vendor_name
               ~subsystem_device_id ~subsystem_device_name in
           self, Db.PCI.get_record_internal ~__context ~self

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -607,6 +607,9 @@ module MD = struct
     | Failure "int_of_string" ->
       failwith "Intel GVT-g settings invalid"
 
+  let of_mxgpu_vgpu ~__context vm vgpu =
+    failwith "MxGPU not yet implemented"
+
   let vgpus_of_vm ~__context (vmref, vm) =
     let open Vgpu in
     if Vgpuops.vgpu_manual_setup_of_vm vm
@@ -641,7 +644,10 @@ module MD = struct
            | `nvidia ->
              (of_nvidia_vgpu ~__context vm vgpu_record) :: acc
            | `gvt_g ->
-             (of_gvt_g_vgpu ~__context vm vgpu_record) :: acc)
+             (of_gvt_g_vgpu ~__context vm vgpu_record) :: acc
+           | `mxgpu ->
+             (of_mxgpu_vgpu ~__context vm vgpu_record) :: acc
+        )
         [] vm.API.vM_VGPUs
 
   let of_vm ~__context (vmref, vm) vbds pci_passthrough vgpu =


### PR DESCRIPTION
Extend datamodel.ml and xapi_vgpu_type.ml with the new items
that will be needed for running virtual GPUs on AMD MxGPU cards