### PR TITLE
CA-223676: Check physical connectivity for management interface.

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -63,6 +63,11 @@ let get_pool ~__context = List.hd (Db.Pool.get_all ~__context)
 let get_master ~__context =
   Db.Pool.get_master ~__context ~self:(get_pool ~__context)
 
+let get_management_iface_is_connected ~__context =
+  let dbg = Context.string_of_task __context in
+  Net.Bridge.get_physical_interfaces dbg ~name:(Xapi_inventory.lookup Xapi_inventory._management_interface)
+  |> List.exists (fun name -> Net.Interface.is_connected dbg ~name)
+
 let get_primary_ip_addr ~__context iface primary_address_type =
   if iface = "" then
     None

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -158,10 +158,12 @@ let management_ip_cond = Condition.create ()
 
 let wait_for_management_ip ~__context =
   let ip = ref (match Helpers.get_management_ip_addr ~__context with Some x -> x | None -> "") in
+  let is_connected = ref (Helpers.get_management_iface_is_connected ~__context) in
   Mutex.execute management_ip_mutex
-    (fun () -> begin while !ip = "" do
+    (fun () -> begin while !ip = "" && !is_connected = false do
           Condition.wait management_ip_cond management_ip_mutex;
-          ip := (match Helpers.get_management_ip_addr ~__context with Some x -> x | None -> "")
+          ip := (match Helpers.get_management_ip_addr ~__context with Some x -> x | None -> "");
+          is_connected := (Helpers.get_management_iface_is_connected ~__context)
         done; end);
   !ip
 


### PR DESCRIPTION
Management interface must not be marked as up if IP is acquired
and physical connectivity is down.
This might be possible in case of static ip configuration.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>