### PR TITLE
CP-20432: MxGPU: Load kernel module; add VF pcis to DB

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -346,6 +346,6 @@ let update_env __context sync_keys =
     );
 
   switched_sync Xapi_globs.sync_gpus (fun () ->
-      Xapi_pgpu.update_gpus ~__context ~host:localhost;
+      Xapi_pgpu.update_gpus ~__context ~localhost;
     );
 

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -28,15 +28,20 @@ let get_free_functions ~__context pci =
 
 (* http://wiki.xen.org/wiki/Bus:Device.Function_%28BDF%29_Notation *)
 (* It might be possible to refactor this but attempts so far have failed. *)
-let bdf_fmt            = format_of_string    "%04x:%02x:%02x.%01x"
-let slash_bdf_scan_fmt = format_of_string "%d/%04x:%02x:%02x.%01x"
-let slash_bdf_prnt_fmt = format_of_string "%d/%04x:%02x:%02x.%01x"
-let bdf_paren_prnt_fmt = format_of_string   "(%04x:%02x:%02x.%01x)"
-let bdf_paren_scan_fmt = format_of_string   "(%04x:%02x:%02x.%01x)"
+let bdf_fmt            = format_of_string    "%04x:%02x:%02x.%01x!"
+let bdf_fmt_ignore     = format_of_string    "%_4x:%_2x:%_2x.%_1x%!"
+let slash_bdf_scan_fmt = format_of_string "%d/%04x:%02x:%02x.%01x!"
+let slash_bdf_prnt_fmt = format_of_string "%d/%04x:%02x:%02x.%01x!"
+let bdf_paren_prnt_fmt = format_of_string   "(%04x:%02x:%02x.%01x)!"
+let bdf_paren_scan_fmt = format_of_string   "(%04x:%02x:%02x.%01x)!"
 
 let pcidev_of_pci ~__context pci =
   let bdf_str = Db.PCI.get_pci_id ~__context ~self:pci in
   Scanf.sscanf bdf_str bdf_fmt (fun a b c d -> (a, b, c, d))
+
+let is_bdf_format str =
+  try Scanf.sscanf str bdf_fmt_ignore true
+  with Scanf.Scan_failure _ | Failure _ | End_of_file -> false
 
 (* Confusion: the n/xxxx:xx:xx.x syntax originally meant PCI device
    xxxx:xx:xx.x should be plugged into bus number n. HVM guests don't have

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -34,6 +34,9 @@ val to_string: (int * (int * int * int * int)) -> string
 (** Return the PCI device as a tuple *)
 val of_string: string -> (int * (int * int * int * int))
 
+(** True if the string matches BDF format, e.g. c002:8c:b3.a (all digits hex) *)
+val is_bdf_format: string -> bool
+
 (** Check whether a PCI device will be hidden from the dom0 kernel on boot. *)
 val is_pci_hidden: __context:Context.t -> [ `PCI ] Ref.t -> bool
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -794,6 +794,8 @@ let xen_livepatch_list = ref "/usr/sbin/xen-livepatch list"
 
 let kpatch_list = ref "/usr/sbin/kpatch list"
 
+let modprobe_path = ref "/usr/sbin/modprobe"
+
 (* The bfs-interfaces script returns boot from SAN NICs.
  * All ISCSI Boot Firmware Table (ibft) NICs should be marked
  * with PIF.managed = false and all FCoE boot from SAN * NICs
@@ -984,6 +986,9 @@ let other_options = [
 
   "kpatch_list", Arg.Set_string kpatch_list,
   (fun () -> !kpatch_list), "Command to query current kernel patch list";
+
+  "modprobe_path", Arg.Set_string modprobe_path,
+  (fun () -> !modprobe_path), "Location of the modprobe(8) command: should match $(which modprobe)";
 ]
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -64,6 +64,17 @@ let create ~__context ~class_id ~class_name ~vendor_id ~vendor_name ~device_id
   debug "PCI %s, %s, %s created" pci_id vendor_name device_name;
   p
 
+let get_local ~__context getter =
+  let localhost = Helpers.get_localhost ~__context in
+  let expr = Db_filter_types.(Eq (Field "host", Literal (Ref.string_of localhost))) in
+  getter ~__context ~expr
+
+let get_local_pcis_and_records ~__context =
+  get_local ~__context Db.PCI.get_internal_records_where
+
+let get_local_pci_refs ~__context =
+  get_local ~__context Db.PCI.get_refs_where
+
 let update_pcis ~__context ~host =
   let existing = List.filter_map
       (fun pref ->

--- a/ocaml/xapi/xapi_pci.mli
+++ b/ocaml/xapi/xapi_pci.mli
@@ -29,6 +29,12 @@ val int_of_id : string -> int
 (** Get an identifier for this PCI device **)
 val string_of_pci : __context:Context.t -> self:API.ref_PCI -> string
 
+(** A list of (ref, record) pairs for the PCI DB objects of the local host *)
+val get_local_pcis_and_records : __context:Context.t -> (API.ref_PCI * Db_actions.pCI_t) list
+
+(** A list of refs for the PCI DB objects of the local host *)
+val get_local_pci_refs : __context:Context.t -> API.ref_PCI list
+
 (** Synchronise the PCI objects in the database with the actual devices in the host. *)
 val update_pcis : __context:Context.t -> host:API.ref_host -> unit
 

--- a/ocaml/xapi/xapi_pgpu.mli
+++ b/ocaml/xapi/xapi_pgpu.mli
@@ -15,8 +15,9 @@
  * @group Graphics
 *)
 
-(** Synchronise the PGPU objects in the database with the actual devices in the host. *)
-val update_gpus : __context:Context.t -> host:API.ref_host -> unit
+(** Synchronise the PGPU objects in the database with the actual devices in the host.
+ *  The caller must ensure that the localhost parameter is indeed the local host. *)
+val update_gpus : __context:Context.t -> localhost:API.ref_host -> unit
 
 (** Enable one of the VGPU types supported by the PGPU. *)
 val add_enabled_VGPU_types : __context:Context.t ->
@@ -48,3 +49,9 @@ val enable_dom0_access : __context:Context.t -> self:API.ref_PGPU ->
 
 val disable_dom0_access : __context:Context.t -> self:API.ref_PGPU ->
   API.pgpu_dom0_access
+
+(* For AMD MxGPU. Acts on the local host only.
+ * Ensures that the "gim" kernel module is loaded on localhost,
+ * that PCI DB entries exist for the VF PCI devices reported by the module,
+ * and that those entries have the "physical_function" field set correctly. *)
+val mxgpu_vf_setup : __context:Context.t -> unit


### PR DESCRIPTION
In a new function Xapi_pgpu.mxgpu_vf_setup (to be called on starting a
VM that uses a vGPU backed by an MxGPU physical device) we:
* ensure the kernel module (driver) is loaded,
* add database entries for the new PCI devices that appear for the
  Virtual Functions, and
* link each of them to its Physical Function.

Incidentally add some utility functions:
* Picops.is_bdf_format
* Xapi_pci.get_local_pcis_and_records
* Xapi_pci.get_local_pci_refs
