### PR TITLE
Remove some host params that have to be localhost

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -342,10 +342,10 @@ let update_env __context sync_keys =
     );
 
   switched_sync Xapi_globs.sync_pci_devices (fun () ->
-      Xapi_pci.update_pcis ~__context ~host:localhost;
+      Xapi_pci.update_pcis ~__context;
     );
 
   switched_sync Xapi_globs.sync_gpus (fun () ->
-      Xapi_pgpu.update_gpus ~__context ~localhost;
+      Xapi_pgpu.update_gpus ~__context;
     );
 

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -75,7 +75,8 @@ let get_local_pcis_and_records ~__context =
 let get_local_pci_refs ~__context =
   get_local ~__context Db.PCI.get_refs_where
 
-let update_pcis ~__context ~host =
+let update_pcis ~__context =
+  let host = Helpers.get_localhost ~__context in
   let existing = List.filter_map
       (fun pref ->
          let prec = Db.PCI.get_record_internal ~__context ~self:pref in

--- a/ocaml/xapi/xapi_pci.mli
+++ b/ocaml/xapi/xapi_pci.mli
@@ -35,8 +35,8 @@ val get_local_pcis_and_records : __context:Context.t -> (API.ref_PCI * Db_action
 (** A list of refs for the PCI DB objects of the local host *)
 val get_local_pci_refs : __context:Context.t -> API.ref_PCI list
 
-(** Synchronise the PCI objects in the database with the actual devices in the host. *)
-val update_pcis : __context:Context.t -> host:API.ref_host -> unit
+(** Synchronise the PCI objects in the database with the actual devices in the local host. *)
+val update_pcis : __context:Context.t -> unit
 
 (** Get the PCI id of the host's display device. *)
 val get_system_display_device : unit -> string option

--- a/ocaml/xapi/xapi_pgpu.mli
+++ b/ocaml/xapi/xapi_pgpu.mli
@@ -15,9 +15,9 @@
  * @group Graphics
 *)
 
-(** Synchronise the PGPU objects in the database with the actual devices in the host.
- *  The caller must ensure that the localhost parameter is indeed the local host. *)
-val update_gpus : __context:Context.t -> localhost:API.ref_host -> unit
+(** Synchronise the PGPU objects in the database with the actual devices
+ *  in the local host. *)
+val update_gpus : __context:Context.t -> unit
 
 (** Enable one of the VGPU types supported by the PGPU. *)
 val add_enabled_VGPU_types : __context:Context.t ->


### PR DESCRIPTION
In some functions that took a host parameter that had to be the
local host, I have removed that parameter and made the functions
call Helpers.get_localhost instead.

That get_localhost function has not been changed here: it looks
as if it could be optimised by using Xapi_globs.localhost_ref when
it has been set, but that approach causes failures in our current
test code.
