### PR TITLE
CP-20787: Allocate VF for MxGPU VGPU types when starting VM

### DIFF
--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -21,11 +21,6 @@ open Threadext
 
 let m = Mutex.create ()
 
-let get_free_functions ~__context pci =
-  let assignments = List.length (Db.PCI.get_attached_VMs ~__context ~self:pci) in
-  let functions = Int64.to_int (Db.PCI.get_functions ~__context ~self:pci) in
-  functions - assignments
-
 (* http://wiki.xen.org/wiki/Bus:Device.Function_%28BDF%29_Notation *)
 (* It might be possible to refactor this but attempts so far have failed. *)
 let bdf_fmt            = format_of_string    "%04x:%02x:%02x.%01x!"

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -159,3 +159,17 @@ let dev_of (id, (domain, bus, dev, fn)) = dev
 
 (** Return the function of a PCI device *)
 let fn_of (id, (domain, bus, dev, fn)) = fn
+
+(** Find a free virtual function given a physical function (SR-IOV) *)
+(* TODO: Fix the obvious race... we need a `PCI.scheduled_to_be_attached_to` *)
+let get_free_virtual_function ~__context pf =
+  let rec search = function
+    | [] -> None
+    | vf :: vfs ->
+      if Db.PCI.get_attached_VMs ~__context ~self:vf = [] then
+        Some vf
+      else
+        search vfs
+  in
+  Db.PCI.get_virtual_functions ~__context ~self:pf
+  |> search

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -57,3 +57,7 @@ val dev_of: (int * (int * int * int * int)) -> int
 
 (** Return the function of a PCI device *)
 val fn_of: (int * (int * int * int * int)) -> int
+
+(** Find a free virtual function given a physical function (SR-IOV) *)
+val get_free_virtual_function :
+  __context:Context.t -> [ `PCI ] Ref.t -> [ `PCI ] Ref.t option

--- a/ocaml/xapi/pciops.mli
+++ b/ocaml/xapi/pciops.mli
@@ -15,9 +15,6 @@
  * @group Virtual-Machine Management
 *)
 
-(** Check if a given PCI device is free. *)
-val get_free_functions : __context:Context.t -> [ `PCI ] Ref.t -> int
-
 (** Return the PCI DBDF string for a PCI object *)
 val pcidev_of_pci: __context:Context.t -> API.ref_PCI -> (int * int * int * int)
 

--- a/ocaml/xapi/test_vgpu_common.ml
+++ b/ocaml/xapi/test_vgpu_common.ml
@@ -209,7 +209,7 @@ let make_vgpu ~__context
     then vm_ref
     else Test_common.make_vm ~__context ()
   in
-  if (Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type_ref)
+  if (Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type_ref = Some `PF)
   && (Db.is_valid_ref __context resident_on)
   then begin
     let pci_ref = Db.PGPU.get_PCI ~__context ~self:resident_on in

--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -24,6 +24,7 @@ type vgpu = {
   devid: int;
   other_config: (string * string) list;
   type_ref: API.ref_VGPU_type;
+  requires_passthrough: [ `PF | `VF ] option;
 }
 
 let vgpu_of_vgpu ~__context vm_r vgpu =
@@ -34,6 +35,7 @@ let vgpu_of_vgpu ~__context vm_r vgpu =
     devid = int_of_string vgpu_r.API.vGPU_device;
     other_config = vgpu_r.API.vGPU_other_config;
     type_ref = vgpu_r.API.vGPU_type;
+    requires_passthrough = Xapi_vgpu.requires_passthrough ~__context ~self:vgpu;
   }
 
 let vgpus_of_vm ~__context vm_r =
@@ -155,7 +157,7 @@ let create_vgpus ~__context host (vm, vm_r) hvm =
   end;
   let (passthru_vgpus, virtual_vgpus) =
     List.partition
-      (fun v -> Xapi_vgpu.requires_passthrough ~__context ~self:v.vgpu_ref = Some `PF)
+      (fun v -> v.requires_passthrough = Some `PF)
       vgpus
   in
   if virtual_vgpus <> [] && not (Pool_features.is_enabled ~__context Features.VGPU) then

--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -78,7 +78,7 @@ let add_pcis_to_vm ~__context host vm passthru_vgpus =
     end else
       [] in
   (* Add a platform key to the VM if any of the PCIs are integrated GPUs;
-     	 * otherwise remove the key. *)
+   * otherwise remove the key. *)
   Db.VM.remove_from_platform ~__context
     ~self:vm ~key:Xapi_globs.igd_passthru_key;
   if List.exists

--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -155,7 +155,7 @@ let create_vgpus ~__context host (vm, vm_r) hvm =
   end;
   let (passthru_vgpus, virtual_vgpus) =
     List.partition
-      (fun v -> Xapi_vgpu.requires_passthrough ~__context ~self:v.vgpu_ref)
+      (fun v -> Xapi_vgpu.requires_passthrough ~__context ~self:v.vgpu_ref = Some `PF)
       vgpus
   in
   if virtual_vgpus <> [] && not (Pool_features.is_enabled ~__context Features.VGPU) then

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -23,7 +23,7 @@ let calculate_max_capacities ~__context ~pCI ~size ~supported_VGPU_types =
     (fun vgpu_type ->
        let max_capacity =
          if Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type
-         then Db.PCI.get_functions ~__context ~self:pCI
+         then 1L
          else Int64.div size (Db.VGPU_type.get_size ~__context ~self:vgpu_type)
        in
        vgpu_type, max_capacity)

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -22,7 +22,7 @@ let calculate_max_capacities ~__context ~pCI ~size ~supported_VGPU_types =
   List.map
     (fun vgpu_type ->
        let max_capacity =
-         if Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type
+         if Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type = Some `PF
          then 1L
          else Int64.div size (Db.VGPU_type.get_size ~__context ~self:vgpu_type)
        in

--- a/ocaml/xapi/xapi_pgpu_helpers.ml
+++ b/ocaml/xapi/xapi_pgpu_helpers.ml
@@ -97,8 +97,8 @@ let get_remaining_capacity_internal ~__context ~self ~vgpu_type =
     if Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type
     then begin
       (* For passthrough VGPUs, we check that there are functions available,
-         			 * and subtract from this list the number of VGPUs scheduled to run on
-         			 * this PGPU. *)
+       * and subtract from this list the number of VGPUs scheduled to run on
+       * this PGPU. *)
       let pci = Db.PGPU.get_PCI ~__context ~self in
       let scheduled_VGPUs = get_scheduled_VGPUs ~__context ~self in
       convert_capacity
@@ -107,7 +107,7 @@ let get_remaining_capacity_internal ~__context ~self ~vgpu_type =
             (List.length scheduled_VGPUs)))
     end else begin
       (* For virtual VGPUs, we calculate the number of times the VGPU_type's
-         			 * size fits into the PGPU's (size - utilisation). *)
+       * size fits into the PGPU's (size - utilisation). *)
       let pgpu_size = Db.PGPU.get_size ~__context ~self in
       let utilisation =
         List.fold_left

--- a/ocaml/xapi/xapi_pgpu_helpers.ml
+++ b/ocaml/xapi/xapi_pgpu_helpers.ml
@@ -94,7 +94,7 @@ let get_remaining_capacity_internal ~__context ~self ~vgpu_type =
                  Ref.string_of vgpu_type
                ]))
     in
-    if Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type then
+    if Xapi_vgpu_type.requires_passthrough ~__context ~self:vgpu_type = Some `PF then
       (* For passthrough VGPUs, which means passing through an entire PGPU to a
        * VM, the remaining capacity is binary. We simply return 0 if the PCI
        * device is currently passed-through to a VM, or is scheduled to be,

--- a/ocaml/xapi/xapi_vgpu.mli
+++ b/ocaml/xapi/xapi_vgpu.mli
@@ -41,4 +41,5 @@ val copy :
 
 (* Determine whether a VGPU requires passthrough of an entire PGPU, or
  * will be only require part of the PGPU. *)
-val requires_passthrough : __context:Context.t -> self:API.ref_VGPU -> bool
+val requires_passthrough : __context:Context.t -> self:API.ref_VGPU ->
+  [ `PF | `VF ] option

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -664,4 +664,7 @@ let find_or_create_supported_types ~__context ~pci =
   find_or_create_supported_types ~__context ~pci
 
 let requires_passthrough ~__context ~self =
-  Db.VGPU_type.get_implementation ~__context ~self = `passthrough
+  match Db.VGPU_type.get_implementation ~__context ~self with
+  | `passthrough     -> Some `PF (* Requires passthough of a physical function (entire device) *)
+  | `mxgpu           -> Some `VF (* Requires passthough of a virtual function (SR-IOV) *)
+  | `nvidia | `gvt_g -> None     (* Does not require any passthrough *)

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -298,7 +298,7 @@ let assert_can_see_networks ~__context ~self ~host =
  * passthrough. *)
 let vm_needs_iommu ~__context ~self =
   List.exists
-    (fun vgpu -> Xapi_vgpu.requires_passthrough ~__context ~self:vgpu)
+    (fun vgpu -> Xapi_vgpu.requires_passthrough ~__context ~self:vgpu <> None)
     (Db.VM.get_VGPUs ~__context ~self)
 
 let assert_host_has_iommu ~__context ~host =


### PR DESCRIPTION
Most of these patches refactor the current code, to make things easier to implement the final bits, and should by themselves not change anything. The real changes are in the commits marked with the CP-number. Next step: fix the race condition that exists when choosing free VFs.