### PR TITLE
CP-20344: Enhance set_vswitch_controller to set protocol and port

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7061,6 +7061,14 @@ let pool_audit_log_append = call
     ~allowed_roles:_R_POOL_ADMIN
     ()
 
+let protocol = Enum ("protocol", [
+    "ssl", "ssl protocol";
+    "pssl", "pssl protocol";
+    "tcp", "tcp protocol";
+    "ptcp", "ptcp protocol";
+    "None", "no protocol";
+     ])
+
 let pool_set_vswitch_controller = call
     ~in_oss_since:None
     ~in_product_since:rel_midnight_ride
@@ -7068,7 +7076,11 @@ let pool_set_vswitch_controller = call
       Published, rel_midnight_ride, "Set the IP address of the vswitch controller.";
       Extended, rel_cowley, "Allow to be set to the empty string (no controller is used)."]
     ~name:"set_vswitch_controller"
-    ~params:[String, "address", "IP address of the vswitch controller."]
+    ~versioned_params:[
+      {param_type=String; param_name="address"; param_doc="IP address of the vswitch controller."; param_release=tampa_release; param_default=(Some (VString ""))};
+      {param_type=Int; param_name="port"; param_doc="For active protocol, designate the port of the vswitch controller. For passive protocol, designate the port to listen for connection request."; param_release=dundee_plus_release; param_default=(Some (VInt 0L)) };
+      {param_type=protocol; param_name="protocol"; param_doc="Protocol to connect with vswitch controller.";param_release=dundee_plus_release; param_default=(Some (VEnum ""))}
+    ]
     ~doc:"Set the IP address of the vswitch controller."
     ~allowed_roles:_R_POOL_OP
     ()

--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -41,6 +41,10 @@ let overrides = [
   "event_operation",(
     "let rpc_of_event_operation x = match x with | `add -> Rpc.String \"add\" | `del -> Rpc.String \"del\" | `_mod -> Rpc.String \"mod\"\n"^
     "let event_operation_of_rpc x = match x with | Rpc.String \"add\" -> `add | Rpc.String \"del\" -> `del | Rpc.String \"mod\" -> `_mod | _ -> failwith \"Unmarshalling error\"");
+  "protocol",(
+    "let rpc_of_protocol x = match x with `ssl -> Rpc.String \"ssl\" | `pssl-> Rpc.String \"pssl\" | `tcp -> Rpc.String \"tcp\" | `ptcp-> Rpc.String \"ptcp\" | `None-> Rpc.String \"\" \n"^
+    "let protocol_of_rpc x = match x with Rpc.String \"ssl\" -> `ssl| Rpc.String \"pssl\" -> `pssl | Rpc.String \"tcp\" -> `tcp | Rpc.String \"ptcp\" -> `ptcp | Rpc.String \"\" -> `None  |_ -> failwith \"invalid protocol\"\n");
+
 
 ]
 

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -412,8 +412,8 @@ let rec cmdtable_data : (string*cmd_spec) list =
 
     "pool-set-vswitch-controller",
     {
-      reqd=["address"];
-      optn=[];
+      reqd=[];
+      optn=["address";"port-num";"protocol"];
       help="Set the IP address of the vswitch controller.";
       implementation=No_fd Cli_operations.pool_set_vswitch_controller;
       flags=[Hidden];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1098,8 +1098,12 @@ let pool_disable_redo_log printer rpc session_id params =
   Client.Pool.disable_redo_log ~rpc ~session_id
 
 let pool_set_vswitch_controller printer rpc session_id params =
-  let address = List.assoc "address" params in
-  Client.Pool.set_vswitch_controller ~rpc ~session_id ~address
+  let address = try List.assoc "address" params with _ -> "" in
+  let port = try Int64.of_string (List.assoc "port-num" params) with _ -> 0L in
+  let protocol_str = try List.assoc "protocol" params with _ -> "" in
+  let protocol = Helpers.vswitch_protocol_of_string protocol_str in
+  debug "port: %Ld protocol: %s address: %s" port protocol_str address;
+  Client.Pool.set_vswitch_controller ~rpc ~session_id ~address ~port ~protocol
 
 let pool_enable_ssl_legacy printer rpc session_id params =
   let self = get_pool_with_default rpc session_id params "uuid" in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -628,9 +628,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Pool.disable_redo_log: pool = '%s'" (current_pool_uuid ~__context);
       Local.Pool.disable_redo_log ~__context
 
-    let set_vswitch_controller ~__context ~address =
-      info "Pool.set_vswitch_controller: pool = '%s'; address = '%s'" (current_pool_uuid ~__context) address;
-      Local.Pool.set_vswitch_controller ~__context ~address
+    let set_vswitch_controller ~__context ~address ~port ~protocol =
+      info "Pool.set_vswitch_controller: pool = '%s'; address = '%s'; port = '%Ld'; protocal='%s'" (current_pool_uuid ~__context) address port (Helpers.vswitch_protocol_to_string protocol);
+      Local.Pool.set_vswitch_controller ~__context ~address ~port ~protocol
 
     let get_license_state ~__context ~self =
       info "Pool.get_license_state: pool = '%s'" (pool_uuid ~__context self);

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -177,7 +177,7 @@ val enable_redo_log : __context:Context.t -> sr:[`SR] Ref.t -> unit
 val disable_redo_log : __context:Context.t -> unit
 
 (** VSwitch Controller *)
-val set_vswitch_controller : __context:Context.t -> address:string -> unit
+val set_vswitch_controller : __context:Context.t -> address:string -> port:int64-> protocol:API.protocol-> unit
 val audit_log_append : __context:Context.t -> line:string -> unit
 
 val test_archive_target : __context:Context.t -> self:API.ref_pool -> config:API.string_to_string_map -> string


### PR DESCRIPTION
This commit enable customer to set protocol and port for their ovs
manager.

When IP address, protocol and port are  set by this API, these
information is stored in xapi database with format conform with
OVS, as follows,

| protocol | address| port |result |
|:-----------|------------:|------------:|:------------:|
|        |10.71.216.120|    |  10.71.216.120  |backward compatible|
|ssl/tcp |10.71.216.120|6632|tcp:10.71.216.120:6636 |             |
|pssl/ptcp|10.71.216.120|6632|pssl:6640:10.71.76.186|             |
|pssl/ptcp|            |6632|    pssl:6640    |                   |

Signed-off-by: Lin Liu <lin.liu@citrix.com>