### PR TITLE
CA-245332: Clear PCI.dependencies for virtual functions

### DIFF
--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -93,7 +93,9 @@ let mxgpu_set_phys_fn_ref ~__context pci_ref pci_rec =
       let expr = Db_filter_types.(And (Eq (Field "pci_id", Literal physfn_addr),
                                        Eq (Field "host", Literal (Ref.string_of host)))) in
       ( match Db.PCI.get_refs_where ~__context ~expr with (* Expect exactly one *)
-        | [pf_ref] -> Db.PCI.set_physical_function ~__context ~self:pci_ref ~value:pf_ref
+        | [pf_ref] ->
+          Db.PCI.set_physical_function ~__context ~self:pci_ref ~value:pf_ref;
+          Db.PCI.set_dependencies ~__context ~self:pci_ref ~value:[]
         | [] -> error "Found no pci with address %s but physfn-link of %s points to it!" physfn_addr pci_addr
         | _ -> error "Found more than one pci with same address! %s" physfn_addr
       );


### PR DESCRIPTION
PCI dependencies link PCI devices (or PCI functions, to be precise) that need
to be passed through to a VM together. The original use case for this was a GPU
card that had a video as well as an audio component, which belong together.
These two would always show up as two separate functions of the same device
on the PCI bus: xxxx:xx:xx.0 and xxxx.xx.xx.1. For this reason, the heuristic
that xapi uses to find dependent devices is based on their common
domain+bus+device parts (the xxxx:xx:xx portion of the bus address).

For SR-IOV devices, however, several virtual functions tend to have a common
domain+bus+device, which leads to all of those being marked as dependent on
each other, and all passed-through to the same VM. This patch fixes it by
extending the heuristic by marking all MxGPU VFs as independent.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>