### PR TITLE
CA-245389: segregation between updates, and separation of stage/updat…

### DIFF
--- a/ocaml/xapi/monitor_dbcalls.ml
+++ b/ocaml/xapi/monitor_dbcalls.ml
@@ -31,14 +31,16 @@ let get_host_memory_changes xc =
   in
   let free_bytes = bytes_of_pages physinfo.Xenctrl.free_pages in
   let total_bytes = bytes_of_pages physinfo.Xenctrl.total_pages in
+  let host_memory_changed =
+    !host_memory_free_cached <> free_bytes ||
+    !host_memory_total_cached <> total_bytes
+  in
+  if host_memory_changed then Some (free_bytes, total_bytes) else None
+
+let set_host_memory_change (free_bytes, total_bytes) =
   Mutex.execute host_memory_m (fun _ ->
-      let host_memory_changed =
-        !host_memory_free_cached <> free_bytes ||
-        !host_memory_total_cached <> total_bytes
-      in
       host_memory_free_cached := free_bytes;
       host_memory_total_cached := total_bytes;
-      if host_memory_changed then Some (free_bytes, total_bytes) else None
     )
 
 let get_vm_memory_changes xc =
@@ -54,11 +56,11 @@ let get_vm_memory_changes xc =
       end
   in
   List.iter process_vm domains;
+  get_updates_map ~before:vm_memory_cached ~after:vm_memory_tmp
+
+let set_vm_memory_changes ?except () =
   Mutex.execute vm_memory_cached_m (fun _ ->
-      let changed_vm_memory =
-        get_updates_map ~before:vm_memory_cached ~after:vm_memory_tmp in
-      transfer_map ~source:vm_memory_tmp ~target:vm_memory_cached;
-      changed_vm_memory
+      transfer_map ?except ~source:vm_memory_tmp ~target:vm_memory_cached
     )
 
 let get_pif_and_bond_changes () =
@@ -81,21 +83,22 @@ let get_pif_and_bond_changes () =
         Hashtbl.add pifs_tmp pif.pif_name pif;
       )
     ) stats;
-  (* Check if any of the bonds have changed since our last reading. *)
-  let bond_changes = Mutex.execute bonds_links_up_cached_m (fun _ ->
-      let changes =
-        get_updates_map ~before:bonds_links_up_cached ~after:bonds_links_up_tmp in
-      transfer_map ~source:bonds_links_up_tmp ~target:bonds_links_up_cached;
-      changes
-    ) in
-  (* Check if any of the PIFs have changed since our last reading. *)
-  let pif_changes = Mutex.execute pifs_cached_m (fun _ ->
-      let changes = get_updates_values ~before:pifs_cached ~after:pifs_tmp in
-      transfer_map ~source:pifs_tmp ~target:pifs_cached;
-      changes
-    ) in
-  (* Return lists of changes. *)
-  pif_changes, bond_changes
+    (* Check if any of the PIFs have changed since our last reading. *)
+    let pif_changes = get_updates_values ~before:pifs_cached ~after:pifs_tmp in
+    (* Check if any of the bonds have changed since our last reading. *)
+    let bond_changes = get_updates_map ~before:bonds_links_up_cached ~after:bonds_links_up_tmp in
+    (* Return lists of changes. *)
+    (pif_changes, bond_changes)
+
+let set_pif_changes ?except () =
+  Mutex.execute pifs_cached_m (fun _ ->
+      transfer_map ?except ~source:pifs_tmp ~target:pifs_cached
+    )
+
+let set_bond_changes ?except () =
+  Mutex.execute bonds_links_up_cached_m (fun _ ->
+      transfer_map ?except ~source:bonds_links_up_tmp ~target:bonds_links_up_cached
+    )
 
 (* This function updates the database for all the slowly changing properties
  * of host memory, VM memory, PIFs, and bonds.
@@ -107,36 +110,66 @@ let pifs_and_memory_update_fn xc =
   Server_helpers.exec_with_new_task "updating VM_metrics.memory_actual fields and PIFs"
     (fun __context ->
        let host = Helpers.get_localhost ~__context in
+       let issues = ref [] in
+
+       let keeps = ref [] in
        List.iter (fun (uuid, memory) ->
            try
              let vm = Db.VM.get_by_uuid ~__context ~uuid in
              let vmm = Db.VM.get_metrics ~__context ~self:vm in
-             if (Db.VM.get_resident_on ~__context ~self:vm =
-                 Helpers.get_localhost ~__context)
+             if (Db.VM.get_resident_on ~__context ~self:vm = host)
              then Db.VM_metrics.set_memory_actual ~__context ~self:vmm ~value:memory
              else clear_cache_for_vm uuid
-           with
-           (* ignore errors related to transient or removed uuids *)
-             Db_exn.Read_missing_uuid(_) -> ()
+           with e ->
+             issues := e :: !issues;
+             keeps := uuid :: !keeps
          ) vm_memory_changes;
-       Monitor_master.update_pifs ~__context host pif_changes;
-       let localhost = Helpers.get_localhost ~__context in
+       set_vm_memory_changes ~except:!keeps ();
+
+       let keeps = ref [] in
        List.iter (fun (bond, links_up) ->
-           let my_bond_pifs = Db.PIF.get_records_where ~__context
-               ~expr:(And (And (Eq (Field "host", Literal (Ref.string_of localhost)),
-                                Not (Eq (Field "bond_master_of", Literal "()"))),
-                           Eq(Field "device", Literal bond))) in
-           let my_bonds = List.map (fun (_, pif) -> List.hd pif.API.pIF_bond_master_of) my_bond_pifs in
-           if (List.length my_bonds) <> 1 then
-             debug "Error: bond %s cannot be found" bond
-           else
-             Db.Bond.set_links_up ~__context ~self:(List.hd my_bonds)
-               ~value:(Int64.of_int links_up)
+           try
+             let my_bond_pifs = Db.PIF.get_records_where ~__context
+                 ~expr:(And (And (Eq (Field "host", Literal (Ref.string_of host)),
+                                  Not (Eq (Field "bond_master_of", Literal "()"))),
+                             Eq(Field "device", Literal bond))) in
+             let my_bonds = List.map (fun (_, pif) -> List.hd pif.API.pIF_bond_master_of) my_bond_pifs in
+             if (List.length my_bonds) <> 1 then
+               debug "Error: bond %s cannot be found" bond
+             else
+               Db.Bond.set_links_up ~__context ~self:(List.hd my_bonds)
+                 ~value:(Int64.of_int links_up)
+           with e ->
+             issues := e :: !issues;
+             keeps := bond :: !keeps
          ) bond_changes;
-       match host_memory_changes with None -> () | Some (free, total) ->
-         let metrics = Db.Host.get_metrics ~__context ~self:localhost in
-         Db.Host_metrics.set_memory_total ~__context ~self:metrics ~value:total;
-         Db.Host_metrics.set_memory_free ~__context ~self:metrics ~value:free
+       set_bond_changes ~except:!keeps ();
+
+       begin
+         try
+           Monitor_master.update_pifs ~__context host pif_changes;
+           set_pif_changes ();
+         with e ->
+           issues := e :: !issues
+       end;
+
+       begin
+         match host_memory_changes with
+         | None -> ()
+         | Some (free, total as c) ->
+           try
+             let metrics = Db.Host.get_metrics ~__context ~self:host in
+             Db.Host_metrics.set_memory_total ~__context ~self:metrics ~value:total;
+             Db.Host_metrics.set_memory_free ~__context ~self:metrics ~value:free;
+             set_host_memory_change c
+           with e ->
+             issues := e :: !issues
+       end;
+
+       List.iter (function
+           | Db_exn.Read_missing_uuid _ -> ()
+           | e -> error "pifs_and_memory_update issue: %s" (ExnHelper.string_of_exn e)
+         ) (List.rev !issues)
     )
 
 let monitor_dbcall_thread () =

--- a/ocaml/xapi/monitor_dbcalls_cache.ml
+++ b/ocaml/xapi/monitor_dbcalls_cache.ml
@@ -38,34 +38,45 @@ let pvs_proxy_tmp    : (string, int) Hashtbl.t = Hashtbl.create 100
 (** [clear_cache_for_pif] removes any current cache for PIF with [pif_name],
  * which forces fresh properties for the PIF into xapi's database. *)
 let clear_cache_for_pif ~pif_name =
-  Mutex.execute pifs_cached_m (fun _ -> Hashtbl.remove pifs_cached pif_name)
+  Mutex.execute pifs_cached_m (fun _ ->
+      Hashtbl.remove pifs_cached pif_name;
+      Hashtbl.remove pifs_tmp pif_name
+    )
 
 (** [clear_cache_for_vm] removes any current cache for VM with [vm_uuid],
  * which forces fresh properties for the VM into xapi's database. *)
 let clear_cache_for_vm ~vm_uuid =
-  Mutex.execute vm_memory_cached_m
-    (fun _ -> Hashtbl.remove vm_memory_cached vm_uuid)
+  Mutex.execute vm_memory_cached_m (fun _ ->
+      Hashtbl.remove vm_memory_cached vm_uuid;
+      Hashtbl.remove vm_memory_tmp vm_uuid
+    )
 
 (** [clear_pvs_status_cache] removes the cache entry for [vm_uuid] *)
 let clear_pvs_status_cache ~vm_uuid =
-  Mutex.execute pvs_proxy_cached_m
-    (fun _ -> Hashtbl.remove pvs_proxy_cached vm_uuid)
+  Mutex.execute pvs_proxy_cached_m (fun _ ->
+      Hashtbl.remove pvs_proxy_cached vm_uuid;
+      Hashtbl.remove pvs_proxy_tmp vm_uuid
+    )
 
 (** Clear the whole cache. This forces fresh properties to be written into
  * xapi's database. *)
 let clear_cache () =
-  let safe_clear ~cache ~lock =
-    Mutex.execute lock (fun _ -> Hashtbl.clear cache) in
-  safe_clear ~cache:pifs_cached ~lock:pifs_cached_m;
-  safe_clear ~cache:bonds_links_up_cached ~lock:bonds_links_up_cached_m;
-  safe_clear ~cache:vm_memory_cached ~lock:vm_memory_cached_m;
+  let safe_clear ~cache ~tmp ~lock =
+    Mutex.execute lock (fun _ -> Hashtbl.clear cache; Hashtbl.clear tmp) in
+  safe_clear ~cache:pifs_cached ~tmp:pifs_tmp ~lock:pifs_cached_m;
+  safe_clear ~cache:bonds_links_up_cached ~tmp:bonds_links_up_tmp ~lock:bonds_links_up_cached_m;
+  safe_clear ~cache:vm_memory_cached ~tmp:vm_memory_tmp ~lock:vm_memory_cached_m;
   Mutex.execute host_memory_m (fun _ ->
       host_memory_free_cached := Int64.zero;
       host_memory_total_cached := Int64.zero;
     )
 
 (* Helper map functions. *)
-let transfer_map ~source ~target =
+let transfer_map ?(except=[]) ~source ~target =
+  List.iter (fun ex ->
+      try Hashtbl.replace source ex (Hashtbl.find target ex)
+      with Not_found -> Hashtbl.remove source ex
+    ) except;
   Hashtbl.clear target;
   Hashtbl.iter (fun k v -> Hashtbl.add target k v) source;
   Hashtbl.clear source


### PR DESCRIPTION
…e/commit

There are two main issues spot in the investigation on SCTX-2488:

1. The updates on multiple metrics are unnecessarily dependent, in that the
failures in updating one metric will abort the whole process and stop other
metrics from being updated.

2. There is no separation of staging, updating, and committing changes when we
do update. Any update is effectively committed (into our record) first, and
then the actual updating takes place. So if any failure occurs during the
actual updating, it still appear (in our record) as committed . So there won't
be any further attempts to retry the failed updating (until next real change
happens on source of the metrics).

In this changeset, we did some code refactoring to address these.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>