### PR TITLE
Set default heads to 1 for MxGPU

### DIFF
--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -636,7 +636,7 @@ module Vendor_amd = struct
         vendor_name;
         model_name = conf.model_name;
         framebuffer_size = conf.identifier.framebufferbytes;
-        max_heads = 0L;
+        max_heads = 1L;
         max_resolution_x = 0L;
         max_resolution_y = 0L;
         size = vgpu_size;


### PR DESCRIPTION
XenCenter assumes 0 heads == passthrough.
Default to the same number of heads as shown for GVT-g (1).

Signed-off-by: Bob Ball <bob.ball@citrix.com>