### PR TITLE
Add mkdir before doing ocamlfind install

### DIFF
--- a/ocaml/xapi-cli-protocol/OMakefile
+++ b/ocaml/xapi-cli-protocol/OMakefile
@@ -14,6 +14,7 @@ INSTALL_PATH = $(DESTDIR)/$(shell ocamlfind printconf destdir)
 export
 
 lib-install: META
+	mkdir -p $(INSTALL_PATH)
 	ocamlfind install -destdir $(INSTALL_PATH) -ldconf ignore xapi-cli-protocol META $(addsuffixes .cmi, $(OBJS)) $(if $(BYTE_ENABLED), xapi-cli-protocol.cma) $(if $(NATIVE_ENABLED), xapi-cli-protocol.cmxa xapi-cli-protocol.a $(addsuffixes .cmx, $(OBJS)))
 
 .PHONY: lib-uninstall


### PR DESCRIPTION
Installing a library can fail if the directory is not created
ahead of it. This is now analogous to the OMakefile for the
other libraries.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>