### PR TITLE
CA-246262: Bash completion performance fix

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -138,7 +138,8 @@ _xe()
             params)
                 val=$(final_comma_separated_param "$value")
                 class=`echo ${OLDSTYLE_WORDS[1]} | cut -d- -f1`
-                params=`${xe} ${class}-list params=all 2>/dev/null| cut -d: -f1 | sed -e s/\(.*\)//g -e s/^\ *//g -e s/\ *$//g`
+                obj=`${xe} ${class}-list params=uuid --minimal 2>/dev/null | cut -d, -f1`
+                params=`${xe} ${class}-list params=all uuid=${obj} 2>/dev/null| cut -d: -f1 | sed -e s/\(.*\)//g -e s/^\ *//g -e s/\ *$//g`
                 IFS=$'\n,'
                 set_completions "$params,all" "$val"
                 return 0


### PR DESCRIPTION
When completing 'params', consider only one object to get the complete
list of possible params rather than all objects

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>