### PR TITLE
[CP-21359] Remove the multiplier on update size calculations

### DIFF
--- a/scripts/extensions/pool_update.precheck
+++ b/scripts/extensions/pool_update.precheck
@@ -181,7 +181,7 @@ if __name__ == '__main__':
         statvfs = os.statvfs('/')
         available_dom0_disk_size = statvfs.f_frsize * statvfs.f_bavail
         try:
-            required_size = int(int(session.xenapi.pool_update.get_installation_size(update)) * 1.5)
+            required_size = int(session.xenapi.pool_update.get_installation_size(update))
             if required_size > available_dom0_disk_size:
                 print(failure_message(UPDATE_PRECHECK_FAILED_OUT_OF_SPACE,
                     [update_package, str(available_dom0_disk_size), str(required_size)]))

--- a/scripts/plugins/disk-space
+++ b/scripts/plugins/disk-space
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2015 Citrix, Inc.
+# Copyright (C) 2017 Citrix, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,7 +46,7 @@ def check_patch_upload(session, args):
         raise Exception("MISSING_SIZE")
     size = int(args["size"])
     available_size = int(host_disk_space(None, None))
-    return str((2 * size) < available_size)
+    return str(size < available_size)
 
 
 def get_required_space(session, args):
@@ -55,8 +55,7 @@ def get_required_space(session, args):
     if 'size' not in args:
         logger.critical("Missing argument 'size'")
         raise Exception("MISSING_SIZE")
-    size = int(args["size"])
-    return str(2 * size)
+    return args["size"]
 
 
 def get_file_size(f):


### PR DESCRIPTION
See the ticket for full explanation, but for Ely updates we will use the sum of the sizes of the packages in an update as the installation size, instead of the delta of the installed size from the last major release. Since that already represents the worst case space needed we dont't need to multiply it to calculate the required space now.

Justification for keeping the disk-space get_required_space method (which now just returns its args["size"]) is to avoid forcing XenCenter/the client to be aware of this change - they can continue calling the plugin with the new update size and it'll behave as expected.

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>