### PR TITLE
Further BVT fixes

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -65,7 +65,8 @@ let configure disable_warn_error varpatchdir etcdir optdir plugindir extensiondi
       Printf.sprintf "CLUSTER_STACK_ROOT=%s" cluster_stack_root;
       Printf.sprintf "BINDIR=%s" bindir;
       Printf.sprintf "SBINDIR=%s" sbindir;
-      Printf.sprintf "UDEVDIR=%s" udevdir
+      Printf.sprintf "UDEVDIR=%s" udevdir;
+      Printf.sprintf "export DISABLE_WARN_ERROR VARPATCHDIR ETCDIR OPTDIR PLUGINDIR EXTENSIONDIR HOOKSDIR INVENTORY XAPICONF LIBEXECDIR SCRIPTSDIR SHAREDIR WEBDIR CLUSTER_STACK_ROOT BINDIR SBINDIR UDEVDIR";
     ] in
   output_file config_mk lines
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,23 +1,5 @@
 include ../config.mk
 
-export DISABLE_WARN_ERROR
-export VARPATCHDIR
-export ETCDIR
-export OPTDIR
-export PLUGINDIR
-export EXTENSIONDIR
-export HOOKSDIR
-export INVENTORY
-export XAPICONF
-export LIBEXECDIR
-export SCRIPTSDIR
-export SHAREDIR
-export WEBDIR
-export CLUSTER_STACK_ROOT
-export BINDIR
-export SBINDIR
-export UDEVDIR
-
 SITE_DIR=$(shell python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 IPROG=./install.sh 755


### PR DESCRIPTION
The install.sh script is used in scripts, hence the previous commit,
but it's also used elsewhere. This shifts the export command into
the config.mk makefile fragment that's included, making it work
everywhere where the variables are needed.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>