### PR TITLE
CA-241130: Retrieved recommendations not as expected

### DIFF
--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -675,13 +675,6 @@ let get_evacuation_recoms ~__context ~uuid =
       []
     else
       match inner_xml with
-      | (Xml.Element ( _, _, children)) when List.exists 
-        (function 
-          | Xml.Element ("CanPlaceAllVMs",_,_) -> true
-          | _ -> false
-        ) children 
-        -> []
-        (*CanPlaceAllVMs tag, No recommendations to give. *)
       | (Xml.Element ( _, _, _)) ->
         begin
           match (descend_and_match ["Recommendations"] inner_xml) with


### PR DESCRIPTION
WLB return CanPlaceAllVMs to indicate all vms have
been placed on a host.
Currently, xapi thinks no recommendation is provided from WLB
if it detects CanPlaceAllVMs field.
This commit fix this error and let xapi ignore CanPlaceAllVMs since
xapi does not make use of it at all

Signed-off-by: Lin Liu <lin.liu@citrix.com>