### PR TITLE
CA-248243: Include the html xenserver flavour of the docs in the build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ build: setup.data
 
 doc: setup.data build
 	$(SETUP) -doc $(DOCFLAGS)
+	./jsapi.native -destdir _build/ocaml/doc
 
 test: setup.data build
 	$(SETUP) -test $(TESTFLAGS)
@@ -90,3 +91,9 @@ install: setup.data rbac_static.csv
 	scripts/install.sh 755 block_device_io.native $(DESTDIR)$(LIBEXECDIR)/block_device_io
 # Libraries
 	ocaml setup.ml -install
+# xenserver html docs
+	mkdir -p $(DESTDIR)$(DOCDIR)/html/xenserver
+	cp -r -L _build/ocaml/doc/api $(DESTDIR)$(DOCDIR)/html/xenserver
+	cd ocaml/doc && cp *.js *.html *.css *.png $(DESTDIR)$(DOCDIR)/html/xenserver
+	cp ocaml/doc/xenserver/* $(DESTDIR)$(DOCDIR)/html/xenserver
+

--- a/_oasis
+++ b/_oasis
@@ -413,6 +413,19 @@ Executable genptoken
   BuildDepends:
     uuid
 
+Executable jsapi
+  CompiledObject:   best
+  Path:             ocaml/doc
+  Install:          false
+  MainIs:           jsapi.ml
+  BuildDepends:
+    xapi-datamodel,
+    xapi-consts,
+    stdext,
+    uuid,
+    gzip
+
+
 ############################################################################
 ############################################################################
 #################################### TESTS #################################

--- a/configure.ml
+++ b/configure.ml
@@ -31,6 +31,7 @@ let cluster_stack_root = dir "cluster-stack-root" "/usr/libexec/xapi/cluster-sta
 let bindir = dir "bindir" "/opt/xensource/bin" "BINDIR" "binaries"
 let sbindir = dir "sbindir" "/opt/xensource/bin" "BINDIR" "system binaries"
 let udevdir = dir "udevdir" "/etc/udev" "UDEVDIR" "udev scripts"
+let docdir = dir "docdir" "/usr/share/xapi/doc" "DOCDIR" "XenAPI documentation"
 
 let info =
   let doc = "Configures a package" in
@@ -59,7 +60,8 @@ let configure
     cluster_stack_root
     bindir
     sbindir
-    udevdir =
+    udevdir
+    docdir =
 
   (* Write config.mk *)
   let vars = [
@@ -80,6 +82,7 @@ let configure
     "BINDIR", bindir;
     "SBINDIR", sbindir;
     "UDEVDIR", udevdir;
+    "DOCDIR", docdir;
   ] in
   let lines = List.map (fun (k,v) -> Printf.sprintf "%s=%s" k v) vars in
   let export = Printf.sprintf "export %s"
@@ -98,7 +101,7 @@ let configure_t =
   Term.(pure configure $ disable_warn_error $ varpatchdir $ etcdir $
         optdir $ plugindir $ extensiondir $ hooksdir $ inventory $
         xapiconf $ libexecdir $ scriptsdir $ sharedir $ webdir $
-        cluster_stack_root $ bindir $ sbindir $ udevdir )
+        cluster_stack_root $ bindir $ sbindir $ udevdir $ docdir )
 
 let () =
   match

--- a/ocaml/doc/branding.js
+++ b/ocaml/doc/branding.js
@@ -63,6 +63,8 @@ function get_release_name(s)
 		return 'XenServer 6.5 SP1';
 	case 'dundee':
 		return 'XenServer 7.0';
+	case 'ely':
+		return 'XenServer 7.1';
 	default:
 		return (s + ' (unreleased)');
 	}

--- a/ocaml/doc/xenserver/branding.js
+++ b/ocaml/doc/xenserver/branding.js
@@ -63,6 +63,8 @@ function get_release_name(s)
 		return 'XenServer 6.5 SP1';
 	case 'dundee':
 		return 'XenServer 7.0';
+	case 'ely':
+		return 'XenServer 7.1';
 	default:
 		return 'Unreleased';
 	}


### PR DESCRIPTION
Also: updated branding for ely; modified jsapi.ml to accept the target directory
as a parameter.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>