### PR TITLE
Remove leftover file generated by OASIS

### DIFF
--- a/ocaml/auth/libpam_stubs.clib
+++ b/ocaml/auth/libpam_stubs.clib
@@ -1,5 +1,0 @@
-# OASIS_START
-# DO NOT EDIT (digest: 8e84c99ac637409174210000967ee2e8)
-xa_auth.o
-xa_auth_stubs.o
-# OASIS_STOP


### PR DESCRIPTION
This file is generated by OASIS, so we don't need to keep it in version
control. I removed it by running the command
```
oasis setup-clean -replace-sections -remove
```
to clean up any files and sections generated by OASIS.