### PR TITLE
CA-248921: If there is no session in the context, assume it's internal

### DIFF
--- a/ocaml/xapi/xapi_network.ml
+++ b/ocaml/xapi/xapi_network.ml
@@ -206,7 +206,11 @@ let create ~__context ~name_label ~name_description ~mTU ~other_config ~bridge ~
       let networks = Db.Network.get_all ~__context in
       let bridges = List.map (fun self -> Db.Network.get_bridge ~__context ~self) networks in
       let mTU = if mTU <= 0L then 1500L else mTU in
-      let is_internal_session = Db.Session.get_pool ~__context ~self:(Context.get_session_id __context) in
+      let is_internal_session =
+        try
+          Db.Session.get_pool ~__context ~self:(Context.get_session_id __context)
+        with _ -> true
+      in
       let bridge =
         if bridge = "" then
           choose_bridge_name bridges


### PR DESCRIPTION
This happens during the startup sequence, and fixes the fix for CA-248389.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>