### PR TITLE
Avoid myocamlbuild.ml changing every time you build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ setup.data: setup.ml
 	$(SETUP) -configure $(CONFIGUREFLAGS)
 
 setup.ml: _oasis
-	oasis setup
+	oasis setup -setup-update dynamic
 
 configure:
 	$(SETUP) -configure $(CONFIGUREFLAGS)


### PR DESCRIPTION
Note that this breaks simple use of ocamlfind to build individual things, but that's easily fixed by running 'oasis setup' yourself.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>