### PR TITLE
CA-244659: Disable cancellation of some xapi tasks

### DIFF
--- a/ocaml/xapi/taskHelper.mli
+++ b/ocaml/xapi/taskHelper.mli
@@ -46,7 +46,7 @@ type id =
 
 val id_to_task_exn : id -> API.ref_task
 val task_to_id_exn : API.ref_task -> id
-val register_task : Context.t -> id -> unit
+val register_task : Context.t -> ?cancellable:bool -> id -> unit
 val unregister_task : Context.t -> id -> unit
 
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2607,7 +2607,7 @@ let suspend ~__context ~self =
             try
               let dbg = Context.string_of_task __context in
               info "xenops: VM.suspend %s to %s" id (disk |> rpc_of_disk |> Jsonrpc.to_string);
-              Client.VM.suspend dbg id disk |> sync_with_task __context queue_name;
+              Client.VM.suspend dbg id disk |> sync_with_task __context ~cancellable:false queue_name;
               Events_from_xenopsd.wait queue_name dbg id ();
               Xapi_vm_lifecycle.assert_final_power_state_is ~__context ~self ~expected:`Suspended;
               if not(Db.VM.get_resident_on ~__context ~self = Ref.null) then
@@ -2652,10 +2652,10 @@ let resume ~__context ~self ~start_paused ~force =
                 Xapi_network.with_networks_attached_for_vm ~__context ~vm:self
                   (fun () ->
                      info "xenops: VM.resume %s from %s" id (disk |> rpc_of_disk |> Jsonrpc.to_string);
-                     Client.VM.resume dbg id disk |> sync_with_task __context queue_name;
+                     Client.VM.resume dbg id disk |> sync_with_task __context ~cancellable:false queue_name;
                      if not start_paused then begin
                        info "xenops: VM.unpause %s" id;
-                       Client.VM.unpause dbg id |> sync_with_task __context queue_name;
+                       Client.VM.unpause dbg id |> sync_with_task __context ~cancellable:false queue_name;
                      end;
                   )
              )

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1897,7 +1897,7 @@ let update_vgpu ~__context id =
 exception Not_a_xenops_task
 let wrap queue_name id = TaskHelper.Xenops (queue_name, id)
 let unwrap x = match x with | TaskHelper.Xenops (queue_name, id) -> queue_name, id | _ -> raise Not_a_xenops_task
-let register_task __context queue_name id = TaskHelper.register_task __context (wrap queue_name id); id
+let register_task __context ?cancellable queue_name id = TaskHelper.register_task __context ?cancellable (wrap queue_name id); id
 let unregister_task __context queue_name id = TaskHelper.unregister_task __context (wrap queue_name id); id
 
 let update_task ~__context queue_name id =
@@ -2303,11 +2303,11 @@ let update_debug_info __context t =
          debug "Failed to add %s = %s to task %s: %s" k v (Ref.string_of task) (Printexc.to_string e)
     ) debug_info
 
-let sync_with_task_result __context queue_name x =
+let sync_with_task_result __context ?cancellable queue_name x =
   let dbg = Context.string_of_task __context in
-  x |> register_task __context queue_name |> wait_for_task queue_name dbg |> unregister_task __context queue_name |> success_task queue_name (update_debug_info __context) dbg
+  x |> register_task __context ?cancellable queue_name |> wait_for_task queue_name dbg |> unregister_task __context queue_name |> success_task queue_name (update_debug_info __context) dbg
 
-let sync_with_task __context queue_name x = sync_with_task_result __context queue_name x |> ignore
+let sync_with_task __context ?cancellable queue_name x = sync_with_task_result __context ?cancellable queue_name x |> ignore
 
 let sync __context queue_name x =
   let dbg = Context.string_of_task __context in


### PR DESCRIPTION
... as they are based on destructive operations, and might leave user with surprises once cancelled while progressing.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>