### PR TITLE
[MERGE xenserver/xenserver-build-env#76 first!!] Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
         - CONTAINER_NAME=build-env
         - OCAMLRUNPARAM=b
         - REPO_PACKAGE_NAME=xapi
+        - GIT_BRANCH=falcon
         - REPO_CONFIGURE_CMD=./configure
         - REPO_BUILD_CMD=make
         - REPO_TEST_CMD='make test'


### PR DESCRIPTION
Explicitly set XS branch name in .travis.yml, because the git branch name does not match the XS branch name in this
case. This will fix the Travis build as Travis will now use the correct
RPMs.

This commit depends on the PR https://github.com/xenserver/xenserver-build-env/pull/76, which makes it possible to use a git branch name that is different from the XS branch, and explicitly set it in the GIT_BRANCH environment variable.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>