### PR TITLE
CA-242706: call update_getty at xapi startup

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -185,6 +185,15 @@ let update_pif_address ~__context ~self =
   with _ ->
     debug "Bridge %s is not up; not updating IP" bridge
 
+let update_getty () =
+  (* Running update-issue service on best effort basis *)
+  try
+    ignore (Forkhelpers.execute_command_get_output !Xapi_globs.update_issue_script []);
+    ignore (Forkhelpers.execute_command_get_output !Xapi_globs.kill_process_script ["-q"; "-HUP"; "mingetty"; "agetty"])
+  with e ->
+    debug "update_getty at %s caught exception: %s"
+      __LOC__ (Printexc.to_string e)
+
 let set_gateway ~__context ~pif ~bridge =
   let dbg = Context.string_of_task __context in
   try

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -300,7 +300,8 @@ let bring_up_management_if ~__context () =
         warn "Failed to acquire a management IP address"
     end;
     (* Start the Host Internal Management Network, if needed. *)
-    Xapi_network.check_himn ~__context
+    Xapi_network.check_himn ~__context;
+    Helpers.update_getty ()
   with e ->
     debug "Caught exception bringing up management interface: %s" (ExnHelper.string_of_exn e)
 

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -167,15 +167,6 @@ let wait_for_management_ip ~__context =
         done; end);
   !ip
 
-let update_getty () =
-  (* Running update-issue service on best effort basis *)
-  try
-    ignore (Forkhelpers.execute_command_get_output !Xapi_globs.update_issue_script []);
-    ignore (Forkhelpers.execute_command_get_output !Xapi_globs.kill_process_script ["-q"; "-HUP"; "mingetty"; "agetty"])
-  with e ->
-    debug "update_getty at %s caught exception: %s"
-      __LOC__ (Printexc.to_string e)
-
 let on_dom0_networking_change ~__context =
   debug "Checking to see if hostname or management IP has changed";
   (* Need to update:
@@ -198,13 +189,13 @@ let on_dom0_networking_change ~__context =
         debug "Changing Host.address in database to: %s" ip;
         Db.Host.set_address ~__context ~self:localhost ~value:ip;
         debug "Refreshing console URIs";
-        update_getty ();
+        Helpers.update_getty ();
         Dbsync_master.refresh_console_urls ~__context
       end
     | None ->
       if Db.Host.get_address ~__context ~self:localhost <> "" then begin
         debug "Changing Host.address in database to: '' (host has no management IP address)";
-        update_getty ();
+        Helpers.update_getty ();
         Db.Host.set_address ~__context ~self:localhost ~value:""
       end
   end;


### PR DESCRIPTION
During xapi startup, the on_dom0_networking_change function does not
recognize the IP address change, as it gets set in the database at an
earlier startup phase. This commit adds an unconditional call to the
update_getty function during startup.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>