### PR TITLE
[alternative to https://github.com/xapi-project/xen-api/pull/2996] CA-242706,CA-193907: regard IP changed at startup

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -471,7 +471,7 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
            debug "could not update MTU field on PIF %s" rc.API.pIF_uuid
         );
 
-        Xapi_mgmt_iface.on_dom0_networking_change ~__context
+        Xapi_mgmt_iface.on_dom0_networking_change ~__context ~startup:false
       end
     )
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -295,7 +295,7 @@ let bring_up_management_if ~__context () =
         (* Make sure everyone is up to speed *)
         ignore (Thread.create (fun () -> Server_helpers.exec_with_new_task "dom0 networking update"
                                   ~subtask_of:(Context.get_task_id __context)
-                                  (fun __context -> Xapi_mgmt_iface.on_dom0_networking_change ~__context)) ())
+                                  (fun __context -> Xapi_mgmt_iface.on_dom0_networking_change ~startup:true ~__context)) ())
       | None ->
         warn "Failed to acquire a management IP address"
     end;

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -131,7 +131,7 @@ let assert_bacon_mode ~__context ~host =
 
 let signal_networking_change ~__context =
   Helpers.update_pif_addresses ~__context;
-  Xapi_mgmt_iface.on_dom0_networking_change ~__context
+  Xapi_mgmt_iface.on_dom0_networking_change ~__context ~startup:false
 
 let signal_cdrom_event ~__context params =
   let find_vdi_name sr name =
@@ -776,7 +776,7 @@ let change_management_interface ~__context interface primary_address_type =
   Xapi_mgmt_iface.run ~__context ~mgmt_enabled:true;
   (* once the inventory file has been rewritten to specify new interface, sync up db with
      	   state of world.. *)
-  Xapi_mgmt_iface.on_dom0_networking_change ~__context
+  Xapi_mgmt_iface.on_dom0_networking_change ~__context ~startup:false
 
 let local_management_reconfigure ~__context ~interface =
   (* Only let this one through if we are in emergency mode, otherwise use

--- a/ocaml/xapi/xapi_mgmt_iface.mli
+++ b/ocaml/xapi/xapi_mgmt_iface.mli
@@ -23,7 +23,7 @@ val wait_for_management_ip : __context:Context.t -> string
 
 (** Called anywhere we suspect dom0's networking (hostname, IP address) has been changed
     underneath us (eg by dhclient) *)
-val on_dom0_networking_change : __context:Context.t -> unit
+val on_dom0_networking_change : __context:Context.t -> startup:bool -> unit
 
 (** Update the inventory file with the given interface (used for management traffic). *)
 val change : string -> [< `IPv4 | `IPv6 ] -> unit


### PR DESCRIPTION
in the Xapi_mgmt_iface.on_dom0_networking_change function, even if the
database already holds the correct value, because it gets set earlier in
the startup sequence. For that reason, the function did not detect a
changed IP address at startup, and did not execute the necessary
triggers. This commit changes the situation so that these "triggers" are
always executed at startup, even if the IP address did not change
between reboots.

The fix for CA-224335 moved the update_getty trigger into a branch in
this function, to only call it when the IP is actually changed, and
reduce the number of times this function is called, because that was
essentially the problem - it was called too many times. I think this
commit will not reintroduce this problem, because for all the other
calls of Xapi_mgmt_iface.on_dom0_networking_change, this function is
still guarded by the "if", it is only during startup that it's
unconditionally executed.

This commit is just a superficial workaround that does not fix the
underlying problem - that the host's ip address and the functions and
database records depending on it are not tied together and are not
guaranteed to be executed/updated when the former changes.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>