### PR TITLE
CA-171948: Adjust semantics of 'add_to_<map>' in Db layer

### DIFF
--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -266,7 +266,7 @@ let process_structured_field_locked t (key,value) tblname fld objref proc_fn_sel
             let idempotent =
               (proc_fn_selector = AddMap) || !Db_globs.idempotent_map
             in
-            add_to_map idempotent key value existing_str
+            add_to_map ~idempotent key value existing_str
           with Duplicate ->
             error "Duplicate key in set or map: table %s; field %s; ref %s; key %s" tblname fld objref key;
             raise (Duplicate_key (tblname,fld,objref,key));

--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -257,7 +257,7 @@ let process_structured_field_locked t (key,value) tblname fld objref proc_fn_sel
       | AddMap ->
         begin
           try
-            add_to_map key value existing_str
+            add_to_map false key value existing_str
           with Duplicate ->
             error "Duplicate key in set or map: table %s; field %s; ref %s; key %s" tblname fld objref key;
             raise (Duplicate_key (tblname,fld,objref,key));

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -350,7 +350,7 @@ let remove_from_set key t =
   Schema.Value.Set (List.filter (fun x -> x <> key) t)
 
 exception Duplicate
-let add_to_map idempotent key value t =
+let add_to_map ~idempotent key value t =
   let t = Schema.Value.Unsafe_cast.pairs t in
   if List.mem_assoc key t && (not idempotent || List.assoc key t <> value) then raise Duplicate;
   Schema.Value.Pairs ((key, value) :: List.filter (fun (k, _) -> k <> key) t)

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -352,8 +352,8 @@ let remove_from_set key t =
 exception Duplicate
 let add_to_map key value t =
   let t = Schema.Value.Unsafe_cast.pairs t in
-  if List.mem key (List.map fst t) then raise Duplicate;
-  Schema.Value.Pairs ((key, value) :: t)
+  if List.mem_assoc key t && List.assoc key t <> value then raise Duplicate;
+  Schema.Value.Pairs ((key, value) :: List.filter (fun (k, _) -> k <> key) t)
 
 let remove_from_map key t =
   let t = Schema.Value.Unsafe_cast.pairs t in

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -500,4 +500,5 @@ type structured_op_t =
   | RemoveSet
   | AddMap
   | RemoveMap
+  | AddMapLegacy
 [@@deriving rpc]

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -350,9 +350,9 @@ let remove_from_set key t =
   Schema.Value.Set (List.filter (fun x -> x <> key) t)
 
 exception Duplicate
-let add_to_map key value t =
+let add_to_map idempotent key value t =
   let t = Schema.Value.Unsafe_cast.pairs t in
-  if List.mem_assoc key t && List.assoc key t <> value then raise Duplicate;
+  if List.mem_assoc key t && (not idempotent || List.assoc key t <> value) then raise Duplicate;
   Schema.Value.Pairs ((key, value) :: List.filter (fun (k, _) -> k <> key) t)
 
 let remove_from_map key t =

--- a/ocaml/database/db_cache_types.mli
+++ b/ocaml/database/db_cache_types.mli
@@ -146,7 +146,7 @@ end
 exception Duplicate
 val add_to_set : string -> Schema.Value.t -> Schema.Value.t
 val remove_from_set : string -> Schema.Value.t -> Schema.Value.t
-val add_to_map : bool -> string -> string -> Schema.Value.t -> Schema.Value.t
+val add_to_map : idempotent:bool -> string -> string -> Schema.Value.t -> Schema.Value.t
 val remove_from_map : string -> Schema.Value.t -> Schema.Value.t
 
 val set_field : string -> string -> string -> Schema.Value.t -> Database.t -> Database.t

--- a/ocaml/database/db_cache_types.mli
+++ b/ocaml/database/db_cache_types.mli
@@ -146,7 +146,7 @@ end
 exception Duplicate
 val add_to_set : string -> Schema.Value.t -> Schema.Value.t
 val remove_from_set : string -> Schema.Value.t -> Schema.Value.t
-val add_to_map : string -> string -> Schema.Value.t -> Schema.Value.t
+val add_to_map : bool -> string -> string -> Schema.Value.t -> Schema.Value.t
 val remove_from_map : string -> Schema.Value.t -> Schema.Value.t
 
 val set_field : string -> string -> string -> Schema.Value.t -> Database.t -> Database.t

--- a/ocaml/database/db_cache_types.mli
+++ b/ocaml/database/db_cache_types.mli
@@ -169,5 +169,6 @@ type structured_op_t =
   | RemoveSet
   | AddMap
   | RemoveMap
+  | AddMapLegacy
 val structured_op_t_of_rpc: Rpc.t -> structured_op_t
 val rpc_of_structured_op_t: structured_op_t -> Rpc.t

--- a/ocaml/database/db_globs.ml
+++ b/ocaml/database/db_globs.ml
@@ -50,6 +50,9 @@ let static_vdis_dir = ref "/etc/xensource/static-vdis"
 (* Note the following has an equivalent in the xapi layer *)
 let http_limit_max_rpc_size = 300 * 1024 (* 300K *)
 
+(* add_to_map is idempotent *)
+let idempotent_map = ref false
+
 (** Dynamic configurations to be read whenever xapi (re)start *)
 
 let permanent_master_failure_retry_interval = ref 60.

--- a/ocaml/database/db_rpc_common_v1.ml
+++ b/ocaml/database/db_rpc_common_v1.ml
@@ -79,7 +79,9 @@ let marshall_structured_op x =
       AddSet -> "addset"
     | RemoveSet -> "removeset"
     | AddMap -> "addmap"
-    | RemoveMap -> "removemap" in
+    | RemoveMap -> "removemap"
+    | AddMapLegacy -> "addmap" (* Nb, we always use 'non-legacy' mode for remote access *)
+  in
   XMLRPC.To.string str
 let unmarshall_structured_op xml =
   match (XMLRPC.From.string xml) with
@@ -311,4 +313,3 @@ let unmarshall_read_records_where_response xml =
            [ref_xml; rec_xml] -> (XMLRPC.From.string ref_xml, unmarshall_read_record_response rec_xml)
          | _ -> raise DB_remote_marshall_error)
       xml_refs_and_recs_list
-

--- a/ocaml/database/db_rpc_common_v2.ml
+++ b/ocaml/database/db_rpc_common_v2.ml
@@ -34,6 +34,16 @@ module Request = struct
     | Read_records_where of string * Db_filter_types.expr
     | Process_structured_field of (string * string) * string * string * string * Db_cache_types.structured_op_t
   [@@deriving rpc]
+
+  (* Make sure the slave only ever uses the idempotent version *)
+  let rpc_of_t t =
+    let t' =
+      match t with
+      | Process_structured_field (a,b,c,d,Db_cache_types.AddMapLegacy) ->
+        Process_structured_field (a,b,c,d,Db_cache_types.AddMap)
+      | x -> x
+    in
+    rpc_of_t t'
 end
 
 module Response = struct

--- a/ocaml/idl/ocaml_backend/gen_db_actions.ml
+++ b/ocaml/idl/ocaml_backend/gen_db_actions.ml
@@ -312,7 +312,7 @@ let db_action api : O.Module.t =
           (Escaping.escape_id full_name)
           Client._self
       | FromField(Add, { DT.ty = DT.Map(_, _); full_name = full_name }) ->
-        Printf.sprintf "DB.process_structured_field __t (%s,%s) \"%s\" \"%s\" %s AddMap"
+        Printf.sprintf "DB.process_structured_field __t (%s,%s) \"%s\" \"%s\" %s AddMapLegacy"
           Client._key Client._value
           (Escaping.escape_obj obj.DT.name)
           (Escaping.escape_id full_name)
@@ -472,4 +472,3 @@ let db_defaults api : O.Signature.t =
   { O.Signature.name = _db_defaults;
     elements = List.map (fun x -> O.Signature.Module (obj x)) (Dm_api.objects_of_api api)
   }
-

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -980,6 +980,10 @@ let other_options = [
 
   "modprobe_path", Arg.Set_string modprobe_path,
   (fun () -> !modprobe_path), "Location of the modprobe(8) command: should match $(which modprobe)";
+
+  "db_idempotent_map", Arg.Set Db_globs.idempotent_map,
+  (fun () -> string_of_bool !Db_globs.idempotent_map), "True if the add_to_<map> API calls should be idempotent";
+
 ]
 
 let all_options = options_of_xapi_globs_spec @ other_options


### PR DESCRIPTION
This allows the DB add_to_map calls to be idempotent. So if a map contains:

```
[('key','value')]
```

then

```
add_to_map(x,'key','value')
```

will succeed if idempotency is enabled, and fail with `Duplicate_key` if not.

```
add_to_map(x,'key','value2')
```

will always fail with a `Duplicate_key` exception.

By default, this behaviour is turned on when xapi uses the remote DB access from slaves, but turned off on the master. This has the effect of ensuring that the Xen API calls retain their current semantics for now.

The behaviour can be normalised across master/slave via the config file parameter

```
db_idempotent_map
```
which currently defaults to `false`. This default will change at some point in the future.