### PR TITLE
CA-250757: refresh software version after update been applied

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -468,7 +468,8 @@ let resync_host ~__context ~host =
         let pool_patch_ref = Xapi_pool_patch.pool_patch_of_update ~__context update_ref in
         Xapi_pool_patch.write_patch_applied_db ~__context ~self:pool_patch_ref ~host ()
       ) update_refs;
-    Create_misc.create_updates_requiring_reboot_info ~__context ~host
+    Create_misc.create_updates_requiring_reboot_info ~__context ~host;
+    Create_misc.create_software_version ~__context
   end
   else Db.Host.set_updates ~__context ~self:host ~value:[];
 


### PR DESCRIPTION
This change it to add a refresh after update been applied, so software version of:
xen_livepatches and kernel_livepatches
can update in time.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>