### PR TITLE
CA-251254: Force a xenopsd VM metadata update before a pool-migration

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -203,6 +203,7 @@ let pool_migrate ~__context ~vm ~host ~options =
         Xapi_network.with_networks_attached_for_vm ~__context ~vm ~host (fun () ->
             (* XXX: PR-1255: the live flag *)
             info "xenops: VM.migrate %s to %s" vm_uuid xenops_url;
+            Xapi_xenops.Xenopsd_metadata.update ~__context ~self:vm;
             migrate_with_retry ~__context queue_name dbg vm_uuid [] [] xenops_url;
             (* Delete all record of this VM locally (including caches) *)
             Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid;


### PR DESCRIPTION
This is done after the assignment of a new PGPU for the VM (in case the VM has
a VGPU). The metadata update includes the PCI address of the PGPU on the
destination host, which gets passed by xenopsd on the sender to xenopsd on the
destination. If we don't do this, then the destination's xenopsd may have the
wrong PCI address when setting up the VGPU.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>