### PR TITLE
CP-20679: Optimise some bits, simplify others

### DIFF
--- a/ocaml/xapi/xapi_gpumon.ml
+++ b/ocaml/xapi/xapi_gpumon.ml
@@ -42,10 +42,8 @@ module Nvidia = struct
   let key = "nvidia"
 
   (* N.B. the pgpu must be in the local host where this function runs *)
-  let get_pgpu_compatibility_metadata ~__context ~pgpu =
+  let get_pgpu_compatibility_metadata ~dbg ~pgpu_pci_address =
     let get = Gpumon_client.Client.Nvidia.get_pgpu_metadata in
-    let pci = Db.PGPU.get_PCI ~__context ~self:pgpu in
-    let address = Db.PCI.get_pci_id ~__context ~self:pci in
-    [key, get "xapi_gpumon" address]
+    [key, get dbg pgpu_pci_address]
 
 end (* Nvidia *)

--- a/ocaml/xapi/xapi_gpumon.mli
+++ b/ocaml/xapi/xapi_gpumon.mli
@@ -25,8 +25,8 @@ module Nvidia : sig
    *  is the opaque string of data from the graphics driver.
    *  IMPORTANT: This must be called on the host that has the GPU installed in it. *)
   val get_pgpu_compatibility_metadata:
-    __context:Context.t ->
-    pgpu:[ `PGPU ] API.Ref.t ->
-    (string * string Gpumon_client.Client.RPCM.t) list
+    dbg: string ->
+    pgpu_pci_address: string ->
+    (string * string) list
 
 end

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -29,13 +29,19 @@ let calculate_max_capacities ~__context ~pCI ~size ~supported_VGPU_types =
        vgpu_type, max_capacity)
     supported_VGPU_types
 
-let set_compatibility_metadata ~__context ~pgpu =
-  let pci = Db.PGPU.get_PCI ~__context ~self:pgpu in
-  if Db.PCI.get_vendor_id ~__context ~self:pci = Xapi_pci.id_of_int Xapi_vgpu_type.Nvidia.vendor_id then (
-     let () = Db.PGPU.set_compatibility_metadata ~__context ~self:pgpu
-       ~value:(Xapi_gpumon.Nvidia.get_pgpu_compatibility_metadata ~__context ~pgpu)
-     in ()
-  )
+let fetch_compatibility_metadata ~__context ~pgpu_pci =
+  if Db.PCI.get_vendor_id ~__context ~self:pgpu_pci =
+    Xapi_pci.id_of_int Xapi_vgpu_type.Nvidia.vendor_id
+  then (
+     let dbg = Context.string_of_task __context in
+     let pgpu_pci_address = Db.PCI.get_pci_id ~__context ~self:pgpu_pci in
+     Xapi_gpumon.Nvidia.get_pgpu_compatibility_metadata ~dbg ~pgpu_pci_address
+  ) else []
+
+let populate_compatibility_metadata ~__context ~pgpu ~pgpu_pci =
+  let () = Db.PGPU.set_compatibility_metadata ~__context ~self:pgpu
+    ~value:(fetch_compatibility_metadata ~__context ~pgpu_pci)
+  in ()
 
 let create ~__context ~pCI ~gPU_group ~host ~other_config
     ~supported_VGPU_types ~size ~dom0_access
@@ -49,12 +55,11 @@ let create ~__context ~pCI ~gPU_group ~host ~other_config
     ~gPU_group ~host ~other_config ~size
     ~supported_VGPU_max_capacities ~dom0_access
     ~is_system_display_device
-    ~compatibility_metadata:[];
+    ~compatibility_metadata:(fetch_compatibility_metadata ~__context ~pgpu_pci:pCI);
   Db.PGPU.set_supported_VGPU_types ~__context
     ~self:pgpu ~value:supported_VGPU_types;
   Db.PGPU.set_enabled_VGPU_types ~__context
     ~self:pgpu ~value:supported_VGPU_types;
-  set_compatibility_metadata ~__context ~pgpu;
   debug "PGPU ref='%s' created (host = '%s')" (Ref.string_of pgpu) (Ref.string_of host);
   pgpu
 
@@ -143,7 +148,7 @@ let update_gpus ~__context ~host =
           Db.PGPU.set_is_system_display_device ~__context
             ~self:rf
             ~value:is_system_display_device;
-          set_compatibility_metadata ~__context ~pgpu:rf;
+          populate_compatibility_metadata ~__context ~pgpu:rf ~pgpu_pci:pci;
           (rf, rc)
         with Not_found ->
           (* If a new PCI has appeared then we know this is a system boot.


### PR DESCRIPTION
A small optimisation: pass the appropriate value of
compatibility_metadata to the PGPU constructor, rather than creating
the object and then populating the field afterwards.

Doing this involved changing some of the underlying functions, and
we make fewer database lookups now.

Also the code now passes the correct debug-string to the xcp-idl
xmlrpc call that fetches the gpgu metadata.

Also removed some needless detail from a specified return-type in an
mli file.