### PR TITLE
CP-20679: Use base64 to encode and decode the `pgpu_metadata`

### DIFF
--- a/ocaml/xapi/xapi_gpumon.ml
+++ b/ocaml/xapi/xapi_gpumon.ml
@@ -43,8 +43,11 @@ module Nvidia = struct
 
   (* N.B. the pgpu must be in the local host where this function runs *)
   let get_pgpu_compatibility_metadata ~dbg ~pgpu_pci_address =
-    let get = Gpumon_client.Client.Nvidia.get_pgpu_metadata in
-    [key, get dbg pgpu_pci_address]
+    let metadata =
+      pgpu_pci_address
+      |> Gpumon_client.Client.Nvidia.get_pgpu_metadata dbg 
+      |> Stdext.Base64.encode
+    in [key, metadata]
 
   (* N.B. the vgpu (and the vm) must be in the local host where this function runs *)
   let assert_pgpu_is_compatibile_with_vm ~__context ~vm ~vgpu ~pgpu =
@@ -54,6 +57,7 @@ module Nvidia = struct
       try
         Db.PGPU.get_compatibility_metadata ~__context ~self:pgpu
         |> List.assoc key
+        |> Stdext.Base64.decode
       with
       | Not_found ->
           debug "Key %s is missing from the compatibility_metadata for pgpu %s" key (Ref.string_of pgpu);

--- a/ocaml/xapi/xapi_gpumon.mli
+++ b/ocaml/xapi/xapi_gpumon.mli
@@ -22,7 +22,7 @@ module Nvidia : sig
 
   (** Fetch metadata about the PGPU from the driver, and return
    *  [(key, metadata)] where key is a fixed value and metadata
-   *  is the opaque string of data from the graphics driver.
+   *  is the base64 encoded opaque string of data from the graphics driver.
    *  IMPORTANT: This must be called on the host that has the GPU installed in it. *)
   val get_pgpu_compatibility_metadata:
     dbg: string ->


### PR DESCRIPTION
This provides a safe way to pass the opaque blob as an ascii string and
avoid possible encoding issue in the serialization and deserialization
of the database field.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>