### PR TITLE
Send coverage to coveralls using OPAM Travis build

### DIFF
--- a/.travis-opam-coverage.sh
+++ b/.travis-opam-coverage.sh
@@ -1,0 +1,33 @@
+# SUMMARY:
+# Builds & tests xapi with coverage in a Ubuntu 16.04 Docker container with
+# OCaml 4.02.3, then uploads the coverage information to coveralls.
+
+set -uex
+
+# Currently there is no way of specifying OPAM depexts for multiple versions of
+# a given disto, and our current depexts only work with Ubuntu >= 16.04, due to
+# a change in packages (libsystemd-dev). Since the build environments of Travis
+# are older then Ubuntu 16.04, we have to run the build in a Docker container
+# with an appropriate Ubuntu version.
+# We need to pass some Travis environment variables to the container to enable
+# uploading to coveralls and detection of Travis CI.
+docker run --rm --volume=$PWD:/mnt --workdir=/mnt \
+  --env "TRAVIS=$TRAVIS" \
+  --env "TRAVIS_JOB_ID=$TRAVIS_JOB_ID" \
+  ocaml/opam:ubuntu-16.04_ocaml-4.02.3 \
+  bash -uex -c '
+# replace the base remote with xs-opam
+opam repository remove default
+opam repository add xs-opam https://github.com/xapi-project/xs-opam.git
+
+# install the dependencies of xapi
+opam pin add --no-action xapi .
+opam depext --yes xapi
+opam install --deps-only xapi
+
+# build and test xapi with coverage, then submit the coverage information to coveralls
+sudo apt-get install --yes wget
+wget https://raw.githubusercontent.com/simonjbeaumont/ocaml-travis-coveralls/master/travis-coveralls.sh
+COV_CONF="./configure" bash -ex travis-coveralls.sh
+'
+

--- a/.travis-xenserver-build-env.sh
+++ b/.travis-xenserver-build-env.sh
@@ -1,0 +1,19 @@
+# SUMMARY:
+# Builds and tests xapi using xenserver-build-env, which installs the
+# dependencies as RPMs.
+
+set -uex
+
+wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh
+
+# only run deploy.sh when the build succeeds
+env \
+  CONTAINER_NAME=build-env \
+  OCAMLRUNPARAM=b \
+  REPO_PACKAGE_NAME=xapi \
+  REPO_CONFIGURE_CMD=./configure \
+  REPO_BUILD_CMD=make \
+  REPO_TEST_CMD='make test' \
+  REPO_DOC_CMD='make doc-json' \
+  bash travis-build-repo.sh && \
+  ( ( test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh ) || true )

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
 language: c
+sudo: required
 services: docker
-install:
-        - wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh
-script: bash travis-build-repo.sh
-after_success:
-    - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh
-sudo: true
+script: bash ./.travis-$BUILD_METHOD.sh
 env:
     global:
-        - CONTAINER_NAME=build-env
-        - OCAMLRUNPARAM=b
-        - REPO_PACKAGE_NAME=xapi
-        - REPO_CONFIGURE_CMD=./configure
-        - REPO_BUILD_CMD=make
-        - REPO_TEST_CMD='make test'
-        - REPO_DOC_CMD='make doc-json'
+        # for BUILD_METHOD=xenserver-build-env
         - secure: tokxJl2litqu/T6UUwzkLRZzlbxnbYqVG2QRKKQz3tkIXyZHQWTS2NAyH7mwDgdBq2dDVSxAUxS1jWq/vGraX7MmbVz37Pz8wjykoIfIRtQuEx+REDAvAzWSw+1LTpUf7ZcI+F2SpgJrnH87uN5AAc220UqIx8TvAtGrita+2+o=
     matrix:
-        - OCAML_VERSION=4.02
+        - BUILD_METHOD=xenserver-build-env
+        - BUILD_METHOD=opam-coverage
 notifications:
     slack: citrix:BHYQZbI8m036ELU21gZil75Y
+matrix:
+    fast_finish: true
+    allow_failures:
+        - env: BUILD_METHOD=opam-coverage

--- a/opam
+++ b/opam
@@ -1,39 +1,57 @@
-opam-version: "1"
-maintainer: "dave.scott@citrix.com"
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [
-  ["./configure" "--disable-warn-error" "--varpatchdir" "%{prefix}%/var/patch" "--optdir" "%{lib}%/xcp" "--plugindir" "%{lib}%/xcp/plugins" "--hooksdir" "%{prefix}%/etc/hook-scripts" "--xapiconf" "%{prefix}%/etc/xapi.conf" "--libexecdir" "%{lib}%/xcp/bin" "--scriptsdir" "%{lib}%/xcp/scripts" "--sharedir" "%{share}%/xcp" "--webdir" "%{share}%/xcp/web" "--cluster-stack-root" "%{lib}%/xcp/bin/cluster-stack" "--bindir" "%{bin}%" "--sbindir" "%{bin}%" "--etcdir" "%{prefix}%/etc"]
+  ["./configure"]
   [make]
-  ["install" "-m" "0755" "ocaml/xapi/xapi.opt" "%{bin}%/xapi"]
 ]
-build-test: [make "test" ]
-remove: ["rm" "%{bin}%/xapi"]
+install: [
+    ["oasis" "setup"]
+    ["ocaml" "setup.ml" "-install"]
+]
+build-test: [make "test"]
+remove: [
+    ["oasis" "setup"]
+    ["ocaml" "setup.ml" "-uninstall"]
+    ["ocamlfind" "remove" "xapi"]
+    ["ocamlfind" "remove" "xapi-client"]
+    ["ocamlfind" "remove" "xapi-cli-protocol"]
+    ["ocamlfind" "remove" "xapi-consts"]
+    ["ocamlfind" "remove" "xapi-datamodel"]
+    ["ocamlfind" "remove" "xapi-database"]
+    ["ocamlfind" "remove" "xapi-types"]
+]
 depends: [
-  "ocamlfind"
+  "oasis" {build}
+  "ocamlfind" {build}
   "xapi-test-utils"
-  "xapi-idl" {>= "0.12.2"}
+  "xapi-idl"
   "xapi-libs-transitional"
   "xen-api-client"
   "xapi-netdev"
-  "omake"
   "cdrom"
   "fd-send-recv"
   "xapi-forkexecd"
-  "libvhd"
+  "vhd-format"
   "nbd"
   "oclock"
   "ounit"
   "rpc"
   "ssl"
-  "xapi-stdext" {>= "0.13.0"}
+  "xapi-stdext"
   "xapi-tapctl"
   "xenctrl"
   "xenstore"
   "xapi-inventory"
   "tar-format"
-  "opasswd" {>= "0.9.3"}
+  "opasswd"
   "xapi-rrdd-plugin"
-  "pci" {>= "0.2.0"}
+  "pci"
   "sha"
+  "xapi-xenopsd"
 ]
 depexts: [
   [["centos"] ["pam-devel"]]


### PR DESCRIPTION
Add a new build to the build matrix that uses OPAM with the `xs-opam` repo & computes the coverage of the unit tests (without quicktests).
I kept the OPAM build simple, and did not make it general, it is only used for the coverage report.