### PR TITLE
CP-22274: Replace string_trim with built-in String.trim

### DIFF
--- a/ocaml/xapi/extauth_plugin_ADpbis.ml
+++ b/ocaml/xapi/extauth_plugin_ADpbis.ml
@@ -34,17 +34,6 @@ struct
 
   let splitlines s = String.split_f (fun c -> c = '\n') (String.replace "#012" "\n" s)
 
-  let rec string_trim s =
-    let l = String.length s in
-    if l = 0 then
-      s
-    else if s.[0] = ' ' || s.[0] = '\t' || s.[0] = '\n' || s.[0] = '\r' then
-      string_trim (String.sub s 1 (l-1))
-    else if s.[l-1] = ' ' || s.[l-1] = '\t' || s.[l-1] = '\n' || s.[l-1] = '\r' then
-      string_trim (String.sub s 0 (l-1))
-    else
-      s
-
   let pbis_common_with_password (password:string) (pbis_cmd:string) (pbis_args:string list) =
     let debug_cmd = pbis_cmd ^ " " ^ (List.fold_left (fun p pp -> p^" "^pp) " " pbis_args) in
     try
@@ -211,8 +200,8 @@ struct
             debug "parse %s: currkey=[%s] line=[%s]" debug_cmd currkey line;
             if List.length slices > 1 then
               begin
-                let key = string_trim (List.hd slices) in
-                let value = string_trim (List.nth slices 1) in
+                let key = String.trim (List.hd slices) in
+                let value = String.trim (List.nth slices 1) in
                 debug "parse %s: key=[%s] value=[%s] currkey=[%s]" debug_cmd key value currkey;
                 if String.length value > 0 then
                   (acc @ [(key, value)], "")
@@ -221,7 +210,7 @@ struct
               end
             else
               let key = currkey in
-              let value = string_trim line in
+              let value = String.trim line in
               debug "parse %s: key=[%s] value=[%s] currkey=[%s]" debug_cmd key value currkey;
               (acc @ [(key, value)], currkey)
           ) in
@@ -327,7 +316,7 @@ struct
         let v = String.replace ")" "|" v in
         let v = String.replace "sid =" "|" v in
         let vs = String.split_f (fun c -> c = '|') v in
-        let sid = string_trim (List.nth vs 1) in
+        let sid = String.trim (List.nth vs 1) in
         debug "pbis_get_group_sids_byname %s get sid=[%s]" _subject_name sid;
         sid
       ) (List.filter (fun (n,v)->n="") subject_attrs)


### PR DESCRIPTION
Signed-off-by: Liang Dai <liang.dai1@citrix.com>

Move `string_trim` outside for unit test according to @jonludlam ’s advice.