### PR TITLE
CA-253489: xe update-upload: Add more error handling to the CLI

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -855,7 +855,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     {
       reqd=["file-name"];
       optn=["sr-uuid"];
-      help="Stream new update to the server.";
+      help="Stream new update to the server. The update will be uploaded to the SR <sr-uuid>, or, if it is not specified, to the pool's default SR.";
       implementation=With_fd Cli_operations.update_upload;
       flags=[];
     };

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2402,11 +2402,7 @@ let vm_install_real printer rpc session_id template name description params =
 
   let suspend_sr_ref = match sr_ref with
     | Some sr ->
-      let ref_is_valid = Server_helpers.exec_with_new_task
-          ~session_id "Checking suspend_SR validity"
-          (fun __context -> Db.is_valid_ref __context sr)
-      in
-      if ref_is_valid then
+      if Cli_util.is_valid_ref session_id sr then
         (* sr-uuid and/or sr-name-label was specified - use this as the suspend_SR *)
         sr
       else
@@ -4342,10 +4338,7 @@ let update_upload fd printer rpc session_id params =
       then Client.SR.get_by_uuid rpc session_id (List.assoc "sr-uuid" params)
       else begin
         let sr = Client.Pool.get_default_SR ~rpc ~session_id ~self:(List.hd pools) in
-        let ref_is_valid = Server_helpers.exec_with_new_task
-            ~session_id "Checking default SR validity"
-            (fun __context -> Db.is_valid_ref __context sr) in
-        if ref_is_valid then sr
+        if Cli_util.is_valid_ref session_id sr then sr
         else failwith "No sr-uuid parameter was given, and the pool's default SR \
                        is unspecified or invalid. Please explicitly specify the SR to use \
                        in the sr-uuid parameter, or set the pool's default SR."

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -4341,11 +4341,12 @@ let update_upload fd printer rpc session_id params =
       if List.mem_assoc "sr-uuid" params
       then Client.SR.get_by_uuid rpc session_id (List.assoc "sr-uuid" params)
       else Client.Pool.get_default_SR ~rpc ~session_id ~self:(List.hd pools)
-  in
+    in
     let uri = Printf.sprintf "%s%s?session_id=%s&sr_id=%s&task_id=%s"
         prefix Constants.import_raw_vdi_uri (Ref.string_of session_id) (Ref.string_of sr)(Ref.string_of task_id) in
     let _ = debug "trying to post patch to uri:%s" uri in
-    HttpPut (filename, uri) in
+    HttpPut (filename, uri)
+  in
   let result = track_http_operation fd rpc session_id make_command "host patch upload" in
   let vdi_ref = API.Legacy.From.ref_VDI "" (Xml.parse_string result) in
   let update_ref =

--- a/ocaml/xapi/cli_util.ml
+++ b/ocaml/xapi/cli_util.ml
@@ -178,6 +178,10 @@ let ref_convert x =
   | Some ir ->
     ir.Ref_index.uuid^(match ir.Ref_index.name_label with None->"" | Some x -> " ("^x^")")
 
+let is_valid_ref session_id ref =
+  Server_helpers.exec_with_new_task
+    ~session_id "Checking validity of reference"
+    (fun __context -> Db.is_valid_ref __context ref)
 
 (* Marshal an API-style server-error *)
 let get_server_error code params =


### PR DESCRIPTION
The `Import_raw_vdi` handler sets the wrong task to failed in case of errors: not the task we passed to it in the query, but a newly-created task. As a result, we cannot detect errors that happen in this handler on the CLI side, in the `Cli_util.track` function, when we call `xe update-updload`. This PR adds error checking to the CLI side, thereby fixing CA-253489, there will be a subsequent pull request to fix the task handling in the handler.

Please help with the style and wording of the error and help messages, thanks.