### PR TITLE
CA-223802 [xso-672] When existing network is deactivated and new netw…

### DIFF
--- a/ocaml/xapi/suite.ml
+++ b/ocaml/xapi/suite.ml
@@ -60,6 +60,7 @@ let base_suite =
     Test_sdn_controller.test;
     Test_event.test;
     Test_extauth_plugin_ADpbis.test;
+    Test_guest_agent.test;
   ]
 
 let handlers = [

--- a/ocaml/xapi/test_guest_agent.ml
+++ b/ocaml/xapi/test_guest_agent.ml
@@ -1,0 +1,371 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open OUnit
+open Test_highlevel
+
+module Networks = Generic.Make (struct
+    module Io = struct
+      type input_t = string list
+      type output_t = (string * string) list
+
+      let string_of_input_t = Test_printers.(list string)
+      let string_of_output_t = Test_printers.(assoc_list string string)
+    end
+
+    type 'a tree = T of 'a * 'a tree list
+
+    let rec add_path_to_tree (T(root, children)) = function
+      | [] -> (T(root, children))
+      | node :: rest_of_path ->
+        try 
+          let T(_, children_of_node) = List.find (fun (T(n, _)) -> n = node) children in
+          let t = add_path_to_tree (T(node, children_of_node)) rest_of_path in
+          T(root, t :: (List.filter (fun (T(n, _)) -> n <> node) children))
+        with Not_found ->
+          T(root, (add_path_to_tree (T(node, [])) rest_of_path) :: children)
+
+    let construct_tree tree path =
+      let open Stdext.Xstringext in
+      let nodes = String.split_f (fun s -> s = '/') path in
+      add_path_to_tree tree nodes
+
+    let rec list_helper children = function
+      | [] -> List.map (fun (T(node, _)) -> node) children
+      | node :: rest_of_path ->
+        try
+          let T(_, children_of_node) = List.find (fun (T(n, _)) -> n = node) children in
+          list_helper children_of_node rest_of_path
+        with Not_found -> []
+
+    let list (T(root, children)) path =
+      let open Stdext.Xstringext in
+      let nodes = String.split_f (fun s -> s = '/') path in
+      list_helper children nodes
+
+
+    let transform input = 
+      let tree = List.fold_left construct_tree (T("", [])) input in
+      Xapi_guest_agent.networks "attr" (list tree)
+
+    let tests = [
+      (* basic cases *)
+      [ "attr/vif/0/ipv6/0";
+      ], [ "attr/vif/0/ipv6/0", "0/ipv6/0";
+      ];
+
+      [ "attr/vif/0/ipv4/0";
+      ], [ "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+      ];
+
+      [ "attr/eth0/ip";
+      ], [ "attr/eth0/ip", "0/ip";
+           "attr/eth0/ip", "0/ipv4/0";
+      ];
+
+      [ "attr/eth0/ipv6/0/addr";
+      ], [ "attr/eth0/ip", "0/ip";
+           "attr/eth0/ip", "0/ipv4/0";
+           "attr/eth0/ipv6/0/addr", "0/ipv6/0";
+      ];
+
+
+      (* index *)
+      [ "attr/vif/1/ipv6/2";
+      ], [ "attr/vif/1/ipv6/2", "1/ipv6/2";
+      ];
+
+      [ "attr/vif/1/ipv4/2";
+      ], [ "attr/vif/1/ipv4/2", "1/ip";
+           "attr/vif/1/ipv4/2", "1/ipv4/2";
+      ];
+
+      [ "attr/eth1/ip";
+      ], [ "attr/eth1/ip", "1/ip";
+           "attr/eth1/ip", "1/ipv4/0";
+      ];
+
+      [ "attr/eth1/ipv6/2/addr";
+      ], [ "attr/eth1/ip", "1/ip";
+           "attr/eth1/ip", "1/ipv4/0";
+           "attr/eth1/ipv6/2/addr", "1/ipv6/2";
+      ];
+
+      (* multiple ip addrs *)
+      [ "attr/vif/0/ipv6/0";
+        "attr/vif/0/ipv6/1";
+      ], [ "attr/vif/0/ipv6/1", "0/ipv6/1";
+           "attr/vif/0/ipv6/0", "0/ipv6/0";
+      ];
+
+      [ "attr/vif/0/ipv4/0";
+        "attr/vif/0/ipv4/1";
+      ], [ "attr/vif/0/ipv4/1", "0/ipv4/1";
+           "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+      ];
+
+      [ "attr/eth0/ip";
+        "attr/eth0/ipv6/0/addr";
+      ], [ "attr/eth0/ip", "0/ip";
+           "attr/eth0/ip", "0/ipv4/0";
+           "attr/eth0/ipv6/0/addr", "0/ipv6/0";
+      ];
+
+      [ "attr/vif/0/ipv4/0";
+        "attr/vif/0/ipv6/0";
+      ], [ "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+           "attr/vif/0/ipv6/0", "0/ipv6/0";
+      ];
+
+      [ "attr/eth0/ip";
+        "attr/vif/0/ipv4/0";
+        "attr/eth0/ipv6/0/addr";
+        "attr/vif/0/ipv6/0";
+      ], [ "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+           "attr/vif/0/ipv6/0", "0/ipv6/0";
+      ];
+
+      (* multiple vifs and multiple ip addrs *)
+      [ "attr/vif/0/ipv6/0";
+        "attr/vif/0/ipv6/1";
+        "attr/vif/1/ipv6/0";
+        "attr/vif/1/ipv6/1";
+      ], [ "attr/vif/0/ipv6/1", "0/ipv6/1";
+           "attr/vif/0/ipv6/0", "0/ipv6/0";
+           "attr/vif/1/ipv6/1", "1/ipv6/1";
+           "attr/vif/1/ipv6/0", "1/ipv6/0";
+      ];
+
+      [ "attr/vif/0/ipv4/0";
+        "attr/vif/0/ipv4/1";
+        "attr/vif/1/ipv4/0";
+        "attr/vif/1/ipv4/1";
+      ], [ "attr/vif/0/ipv4/1", "0/ipv4/1";
+           "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+           "attr/vif/1/ipv4/1", "1/ipv4/1";
+           "attr/vif/1/ipv4/0", "1/ip";
+           "attr/vif/1/ipv4/0", "1/ipv4/0";
+      ];
+
+      (* exceptions *)
+      [ "attr/vif/0/ipv4/a";
+        "attr/vif/0/ipv4/1";
+      ], [];
+    ]
+  end)
+
+module Initial_guest_metrics = Generic.Make (struct
+    module Io = struct
+      type input_t = (string * string) list
+      type output_t = (string * string) list
+
+      let string_of_input_t = Test_printers.(assoc_list string string)
+      let string_of_output_t = Test_printers.(assoc_list string string)
+    end
+
+    type 'a mtree = 
+      | Lf of 'a * 'a
+      | Mt of 'a * 'a mtree list
+
+    let has_name name = function
+      | Lf (n, _) -> n = name
+      | Mt (n, _) -> n = name
+
+    let get_name = function
+      | Lf (n, _) -> n
+      | Mt (n, _) -> n
+
+    let rec add_leaf_to_mtree paths leaf_value = function
+      | Lf _ -> raise (Failure "Can't add a leaf on a leaf")
+      | Mt (root, children) ->
+        (match paths with
+         | [] ->
+           (match children with
+            | [] -> Lf(root, leaf_value)
+            | _ -> raise (Failure "Can't add a leaf on a tree node"))
+         | node :: rest_paths ->
+           try 
+             let t = List.find (has_name node) children in
+             (match t with
+              | Lf (_, _) -> raise (Failure "Can't overwrite an existing leaf")
+              | Mt (node, children_of_node) ->
+                let mt = add_leaf_to_mtree rest_paths leaf_value (Mt(node, children_of_node)) in
+                Mt(root, mt :: (List.filter (fun n -> not (has_name node n)) children)))
+           with Not_found -> 
+             Mt(root, (add_leaf_to_mtree rest_paths leaf_value (Mt(node, []))) :: children))
+
+    let construct_mtree mtree (path, leaf_value) =
+      let open Stdext.Xstringext in
+      let nodes = String.split_f (fun s -> s = '/') path in
+      add_leaf_to_mtree nodes leaf_value mtree
+
+    let rec list_helper children = function
+      | [] -> List.map get_name children
+      | node :: rest_paths ->
+        try
+          match List.find (has_name node) children with
+          | Lf (_, _) -> []
+          | Mt (_, children_of_node) -> list_helper children_of_node rest_paths
+        with Not_found -> []
+
+    let list mtree path =
+      match mtree with
+      | Lf (_, _) -> []
+      | Mt (_, children) ->
+        let open Stdext.Xstringext in
+        let paths = String.split_f (fun s -> s = '/') path in
+        list_helper children paths
+
+    let rec lookup_helper mtree = function
+      | [] -> 
+        (match mtree with
+         | Lf (_, v) -> Some v
+         | Mt (_, _) -> None)
+      | node :: rest_paths ->
+        (match mtree with
+         | Lf (l, v) -> lookup_helper (Lf(l, v)) rest_paths
+         | Mt (_, children) -> 
+           try
+             lookup_helper (List.find (has_name node) children) rest_paths
+           with Not_found -> None)
+
+    let lookup mtree path =
+        let open Stdext.Xstringext in
+        let paths = String.split_f (fun s -> s = '/') path in
+        lookup_helper mtree paths
+
+
+    let transform input = 
+      let tree = List.fold_left construct_mtree (Mt("", [])) input in
+      let guest_metrics = Xapi_guest_agent.get_initial_guest_metrics (lookup tree) (list tree) in
+      guest_metrics.Xapi_guest_agent.networks
+
+
+    let tests = [
+      (* basic cases *)
+      [ "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/vif/0/ipv4/0", "192.168.0.1";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+      ];
+
+      [ "attr/eth0/ip", "192.168.0.1";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+      ];
+
+      [ "attr/eth0/ipv6/0/addr", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      (* index *)
+      [ "attr/vif/1/ipv6/2", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "1/ipv6/2", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/vif/1/ipv4/2", "192.168.0.1";
+      ], [ "1/ip", "192.168.0.1";
+           "1/ipv4/2", "192.168.0.1";
+      ];
+
+      [ "attr/eth1/ip", "192.168.0.1";
+      ], [ "1/ip", "192.168.0.1";
+           "1/ipv4/0", "192.168.0.1";
+      ];
+
+      [ "attr/eth1/ipv6/2/addr", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "1/ipv6/2", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      (* multiple ip addrs *)
+      [ "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+        "attr/vif/0/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd07";
+      ], [ "0/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd07";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/vif/0/ipv4/0", "192.168.0.1";
+        "attr/vif/0/ipv4/1", "192.168.1.1";
+      ], [ "0/ipv4/1", "192.168.1.1";
+           "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+      ];
+
+      [ "attr/eth0/ip", "192.168.0.1";
+        "attr/eth0/ipv6/0/addr", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/vif/0/ipv4/0", "192.168.0.1";
+        "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/eth0/ip", "192.168.0.1";
+        "attr/vif/0/ipv4/0", "192.168.0.1";
+        "attr/eth0/ipv6/0/addr", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+        "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      (* multiple vifs and multiple ip addrs *)
+      [ "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+        "attr/vif/0/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd07";
+        "attr/vif/1/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd16";
+        "attr/vif/1/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd17";
+      ], [ "0/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd07";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+           "1/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd17";
+           "1/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd16";
+      ];
+
+      [ "attr/vif/0/ipv4/0", "192.168.0.1";
+        "attr/vif/0/ipv4/1", "192.168.0.2";
+        "attr/vif/1/ipv4/0", "192.168.1.1";
+        "attr/vif/1/ipv4/1", "192.168.1.2";
+      ], [ "0/ipv4/1", "192.168.0.2";
+           "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+           "1/ipv4/1", "192.168.1.2";
+           "1/ip", "192.168.1.1";
+           "1/ipv4/0", "192.168.1.1";
+      ];
+
+      (* exceptions *)
+      [ "attr/vif/0/ipv4/a", "192.168.0.1";
+        "attr/vif/0/ipv4/1", "192.168.0.1";
+      ], [];
+    ]
+  end)
+
+let test =
+  "test_guest_agent" >:::
+  [
+    "test_networks" >::: Networks.tests;
+    "test_get_initial_guest_metrics" >::: Initial_guest_metrics.tests;
+  ]

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -66,6 +66,17 @@ let extend base str = Printf.sprintf "%s/%s" base str
  * attr/eth0/ip -> 0/ip
  * attr/eth0/ipv6/0/addr -> 0/ipv6/0
  * attr/eth0/ipv6/1/addr -> 0/ipv6/1
+ *
+ * Example output on new xenstore protocol:
+ * attr/vif/0/ipv4/0 -> 0/ipv4/0
+ * attr/vif/0/ipv4/1 -> 0/ipv4/1
+ * attr/vif/0/ipv6/0 -> 0/ipv6/0
+ * attr/vif/0/ipv6/1 -> 0/ipv6/1
+ *
+ * For the compatibility of XAPI clients, outputs of both protocols 
+ * will be generated. I.E.
+ * attr/eth0/ip -> 0/ip; 0/ipv4/0
+ * attr/vif/0/ipv4/0 -> 0/ip; 0/ipv4/0
  * *)
 let networks path (list: string -> string list) =
   (* Find all ipv6 addresses under a path. *)
@@ -76,10 +87,11 @@ let networks path (list: string -> string list) =
   (* Find the ipv4 address under a path, and the ipv6 addresses if they exist. *)
   let find_all_ips path prefix =
     let ipv4 = (extend path "ip", extend prefix "ip") in
+    let ipv4_with_idx = (extend path "ip", extend prefix "ipv4/0") in
     if List.mem "ipv6" (list path) then
-      ipv4 :: (find_ipv6 (extend path "ipv6") (extend prefix "ipv6"))
+      ipv4 :: (ipv4_with_idx :: (find_ipv6 (extend path "ipv6") (extend prefix "ipv6")))
     else
-      [ipv4]
+      [ipv4; ipv4_with_idx]
   in
   (* Find all "ethn", "xenbrn" or newer interface standard names
    * [see https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/]
@@ -112,10 +124,49 @@ let networks path (list: string -> string list) =
          | Some pair -> pair :: acc
       ) [] (list path)
   in
-  path
-  |> find_eths
-  |> List.map (fun (path, prefix) -> find_all_ips path prefix)
-  |> List.concat
+  let find_vifs vif_path =
+    let extract_vif acc vif_id = ((extend vif_path vif_id), vif_id) :: acc in  
+    List.fold_left extract_vif [] (list vif_path)
+  in
+  let cmp a b = 
+    try 
+      compare (int_of_string a) (int_of_string b) 
+    with Failure _ -> 
+      error "String (\"%s\" or \"%s\") can't be converted into an integer as index of IP" a b;
+      raise (Failure "Failed to compare")
+  in
+  let find_all_vif_ips vif_path vif_id = 
+    (*  vif_path: attr/vif/0 *)
+    (*  vif_id: 0 *)
+    let extract_ip_ver vif_id acc ip_ver = 
+      let ip_addr_ids = list (extend vif_path ip_ver)  in
+      let extract_ip_addr vif_id ip_ver acc ip_addr_id = 
+        let key_left = Printf.sprintf "%s/%s/%s" vif_path ip_ver ip_addr_id in
+        let key_right = Printf.sprintf "%s/%s/%s" vif_id ip_ver ip_addr_id in
+        match acc with
+        | [] when ip_ver = "ipv4"  -> 
+          [(key_left, (extend vif_id "ip")); (key_left, key_right)]
+        | _ -> (key_left, key_right) :: acc
+      in  
+      try 
+        (List.fold_left (extract_ip_addr vif_id ip_ver) [] (List.stable_sort cmp ip_addr_ids)) @ acc
+      with Failure _ ->
+        error "Failed to extract IP address for vif %s." vif_id;
+        []
+    in
+    let ip_vers = List.filter (fun a -> a = "ipv4" || a = "ipv6") (list vif_path) in
+    List.fold_left (extract_ip_ver vif_id) [] ip_vers
+  in
+  match find_vifs (extend path "vif") with
+  | [] ->
+    path
+    |> find_eths
+    |> List.map (fun (path, prefix) -> find_all_ips path prefix)
+    |> List.concat
+  | vif_pair_list ->
+    vif_pair_list
+    |> List.map (fun (vif_path, vif_id) -> find_all_vif_ips vif_path vif_id)
+    |> List.concat
 
 (* One key is placed in the other map per control/* key in xenstore. This
    catches keys like "feature-shutdown" "feature-hibernate" "feature-reboot"


### PR DESCRIPTION
…ork is added, 'Networking' tab of the VM shows incorrect information.

This change is applied on the function that for a VM , reading "/local/domain/X/attr" from xenstore and generate networks information for multiple XAPI clients, like XenCenter. 

This change is originated from the change on xenstore protocol change between guest agent and XAPI:
http://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=26b4f4da890e6d829390a8a1ecaec6ce10ecf57d

Without this change. the output of networks in xenstore will be like:
0/ip: 10.158.180.56; 0/ipv6/0: fe80:0000:0000:0000:7870:94ff:fe52:dd06

With this change, the output of networks in xenstore will be like:
0/ip: 10.158.180.56; 0/ipv4/0: 10.158.180.56; 0/ipv6/0: fe80:0000:0000:0000:7870:94ff:fe52:dd06

