### PR TITLE
Make xapi compile with ocaml 4.03 and 4.04

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,0 +1,3 @@
+# OASIS_START
+# OASIS_STOP
+<ocaml/xapi/cli_operations.ml>: warn(-52)

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -678,6 +678,7 @@ let make_param_funs getall getallrecs getbyuuid record class_name def_filters de
         try
           set v
         with
+        (* XXX: -- warning 52 -- this might break with new ocaml compilers *)
           (Failure "int_of_string") -> failwith ("Parameter "^k^" must be an integer")
         | (Failure "float_of_string") -> failwith ("Parameter "^k^" must be a floating-point number")
         | (Invalid_argument "bool_of_string") -> failwith ("Parameter "^k^" must be a boolean (true or false)")
@@ -1839,7 +1840,7 @@ let select_vms ?(include_control_vms = false) ?(include_template_vms = false) rp
   let params = if not include_template_vms then ("is-a-template"    , "false") :: params else params in
   let vm_name_or_ref = try Some (
       (* Escape every quote character *)
-      List.assoc "vm" params |> Stdext.Xstringext.String.replace "\"" "\\\""
+      List.assoc "vm" params |> String.replace "\"" "\\\""
     ) with _ -> None in
   let params, where_clause = match vm_name_or_ref with
     | None -> params, "true"

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -647,6 +647,10 @@ let choose_host_uses_wlb ~__context =
          ~self:(Helpers.get_pool ~__context)))
 
 
+(* This is a stub used in the pattern_matching below to silence a
+ * warning in the newer ocaml compilers *)
+exception Float_of_string_failure
+
 (** Given a virtual machine, returns a host it can boot on, giving   *)
 (** priority to an affinity host if one is present. WARNING: called  *)
 (** while holding the global lock from the message forwarding layer. *)
@@ -662,8 +666,9 @@ let choose_host_for_vm ~__context ~vm ~snapshot =
             | ["WLB"; "0.0"; rec_id; zero_reason] ->
               filter_and_convert tl
             | ["WLB"; stars; rec_id] ->
-              (h, float_of_string stars, rec_id)
-              :: filter_and_convert tl
+                let st = try float_of_string stars with Failure _ -> raise Float_of_string_failure
+                in
+                (h, st, rec_id) :: filter_and_convert tl
             | _ -> filter_and_convert tl
           end
         | [] -> []
@@ -728,7 +733,7 @@ let choose_host_for_vm ~__context ~vm ~snapshot =
         with _ -> ()
       end;
       choose_host_for_vm_no_wlb ~__context ~vm ~snapshot
-    | Failure "float_of_string" ->
+    | Float_of_string_failure ->
       debug "Star ratings from wlb could not be parsed to floats. \
              				Using original algorithm";
       choose_host_for_vm_no_wlb ~__context ~vm ~snapshot

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -435,7 +435,7 @@ module MD = struct
             let rate = Int64.of_string (List.assoc "kbps" qos_params) in
             Some (rate, timeslice)
           with
-          | Failure "int_of_string" ->
+          | Failure _ (* int_of_string *) ->
             log_qos_failure "parameter \"kbps\" not an integer"; None
           | Not_found ->
             log_qos_failure "necessary parameter \"kbps\" not found"; None
@@ -604,8 +604,7 @@ module MD = struct
       }
     with
     | Not_found -> failwith "Intel GVT-g settings not specified"
-    | Failure "int_of_string" ->
-      failwith "Intel GVT-g settings invalid"
+    | Failure _ (* int_of_string *)-> failwith "Intel GVT-g settings invalid"
 
   let of_mxgpu_vgpu ~__context vm vgpu =
     let open Vgpu in
@@ -630,8 +629,7 @@ module MD = struct
       }
     with
     | Not_found -> failwith "AMD MxGPU settings not specified"
-    | Failure "int_of_string" ->
-      failwith "AMD MxGPU settings invalid"
+    | Failure _ (* int_of_string *) -> failwith "AMD MxGPU settings invalid"
 
   let vgpus_of_vm ~__context (vmref, vm) =
     let open Vgpu in


### PR DESCRIPTION
This PR introduces a minimal amount of changes to silence a new warning introduced in ocaml 4.03 that was previously breaking the build.

In most cases it was possible to refactor the code minimally and safely. For `cli_operations.ml` this was not possible and instead we are silencing the warning (and leaving a new comment mentioning the potential break in a future compiler -- newer than 4.05+).