### PR TITLE
Clean up & deprecate crashdump

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -87,6 +87,9 @@ let ely_release_schema_minor_vsn = 108
 let falcon_release_schema_major_vsn = 5
 let falcon_release_schema_minor_vsn = 120
 
+let inverness_release_schema_major_vsn = 5
+let inverness_release_schema_minor_vsn = 120
+
 (* List of tech-preview releases. Fields in these releases are not guaranteed to be retained when
  * upgrading to a full release. *)
 let tech_preview_releases = [
@@ -228,6 +231,12 @@ let get_product_releases in_product_since =
     | x::xs when code_name_of_release x = in_product_since -> "closed"::in_product_since::(List.map code_name_of_release xs)
     | x::xs -> go_through_release_order xs
   in go_through_release_order release_order
+
+let inverness_release =
+  { internal = get_product_releases rel_inverness
+  ; opensource = get_oss_releases None
+  ; internal_deprecated_since = None
+  }
 
 let falcon_release =
   { internal = get_product_releases rel_falcon

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6633,7 +6633,7 @@ let crashdump_destroy = call
 
 (** A crashdump for a particular VM, stored in a particular VDI *)
 let crashdump =
-  create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:None ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_crashdump ~descr:"A VM crashdump"
+  create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:None ~internal_deprecated_since:(Some rel_inverness) ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_crashdump ~descr:"A VM crashdump"
     ~gen_events:true
     ~doccomments:[]
     ~messages_default_allowed_roles:_R_POOL_OP

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -65,6 +65,8 @@ type api_release = {
     branding: string;
 }
 
+(* When you add a new release, use the version number of the latest release,
+   and "Unreleased" for the branding, until the actual values are finalised. *)
 let release_order_full = [{
       code_name     = Some rel_rio;
       version_major = 1;

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -56,6 +56,7 @@ let rel_indigo = "indigo"
 let rel_dundee = "dundee"
 let rel_ely = "ely"
 let rel_falcon = "falcon"
+let rel_inverness = "inverness"
 
 type api_release = {
     code_name: string option;
@@ -179,6 +180,12 @@ let release_order_full = [{
       version_major = 2;
       version_minor = 7;
       branding   = "XenServer 7.2";
+    }; {
+      code_name     = Some rel_inverness;
+      (** TODO replace with the actual version numbers when Inverness is released *)
+      version_major = 2;
+      version_minor = 7;
+      branding   = "Unreleased";
     };
   ]
 

--- a/ocaml/xapi/xapi_crashdump.ml
+++ b/ocaml/xapi/xapi_crashdump.ml
@@ -11,15 +11,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-exception Not_implemented
 
 let nothrow f () = try f() with _ -> ()
-
-let create ~__context ~vM ~vDI =
-  let cdumpref = Ref.make() in
-  let uuid = Uuid.to_string (Uuid.make_uuid()) in
-  Db.Crashdump.create ~__context ~ref:cdumpref ~uuid ~vM ~vDI ~other_config:[];
-  cdumpref
 
 let destroy ~__context ~self =
   Stdext.Pervasiveext.finally

--- a/ocaml/xapi/xapi_crashdump.ml
+++ b/ocaml/xapi/xapi_crashdump.ml
@@ -12,14 +12,14 @@
  * GNU Lesser General Public License for more details.
  *)
 
-let nothrow f () = try f() with _ -> ()
-
 let destroy ~__context ~self =
   Stdext.Pervasiveext.finally
-    (nothrow (fun ()->
-         let vdi = Db.Crashdump.get_VDI ~__context ~self in
-         Helpers.call_api_functions ~__context
-           (fun rpc session_id ->
-              Client.Client.VDI.destroy rpc session_id vdi)))
+    (Helpers.log_exn_continue
+       "destroying crashdump"
+       (fun ()->
+          let vdi = Db.Crashdump.get_VDI ~__context ~self in
+          Helpers.call_api_functions ~__context
+            (fun rpc session_id ->
+               Client.Client.VDI.destroy rpc session_id vdi)))
     (fun ()->
        Db.Crashdump.destroy ~__context ~self)


### PR DESCRIPTION
* Deprecate the `crashdump` XenAPI class
* Remove dead code and duplicated functions. (We don't really use this XenAPI class anyway.)