### PR TITLE
Enable python tests

### DIFF
--- a/.travis-python-nosetests.sh
+++ b/.travis-python-nosetests.sh
@@ -3,4 +3,7 @@
 
 set -uex
 
+sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
+sudo apt-get install -y python-mock python-nose
+
 nosetests scripts scripts/examples scripts/examples/python

--- a/.travis-python-nosetests.sh
+++ b/.travis-python-nosetests.sh
@@ -1,0 +1,6 @@
+# SUMMARY:
+# Run python unittests using nose
+
+set -uex
+
+nosetests scripts scripts/examples scripts/examples/python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: c
 sudo: required
 services: docker
-script: bash ./.travis-$BUILD_METHOD.sh
+script:
+    - bash ./.travis-$BUILD_METHOD.sh
+    - cd scripts && nosetests
+before_install:
+    - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
+    - sudo apt-get install -y python-mock python-nose
 env:
     global:
         # for BUILD_METHOD=xenserver-build-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: c
 sudo: required
 services: docker
-script:
-    - bash ./.travis-$BUILD_METHOD.sh
-    - nosetests scripts/ scripts/examples scripts/examples/python
+script: bash ./.travis-$BUILD_METHOD.sh
 before_install:
     - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
     - sudo apt-get install -y python-mock python-nose
@@ -13,6 +11,7 @@ env:
         - secure: tokxJl2litqu/T6UUwzkLRZzlbxnbYqVG2QRKKQz3tkIXyZHQWTS2NAyH7mwDgdBq2dDVSxAUxS1jWq/vGraX7MmbVz37Pz8wjykoIfIRtQuEx+REDAvAzWSw+1LTpUf7ZcI+F2SpgJrnH87uN5AAc220UqIx8TvAtGrita+2+o=
     matrix:
         - BUILD_METHOD=xenserver-build-env
+        - BUILD_METHOD=python-nosetests
         - BUILD_METHOD=opam-coverage
 notifications:
     slack: citrix:BHYQZbI8m036ELU21gZil75Y

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: c
 sudo: required
 services: docker
 script: bash ./.travis-$BUILD_METHOD.sh
-before_install:
-    - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
-    - sudo apt-get install -y python-mock python-nose
 env:
     global:
         # for BUILD_METHOD=xenserver-build-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 services: docker
 script:
     - bash ./.travis-$BUILD_METHOD.sh
-    - cd scripts && nosetests
+    - nosetests scripts/ scripts/examples scripts/examples/python
 before_install:
     - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
     - sudo apt-get install -y python-mock python-nose


### PR DESCRIPTION
This PR includes the installation of `nose` and `python-mock` in Travis, and the execution of `nosetests` in `scripts/ scripts/examples scripts/examples/python`.

At the moment no test is present and no test is run. From now on, any python unittest dropped in such folders will be executed in the travis build.

Some example tests (with their travis builds) are available at https://github.com/mseri/xen-api/tree/test-nose.

We should consider running the python tests first, given how faster they are...

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>