### PR TITLE
build-env Travis job: fix documentation upload

### DIFF
--- a/.travis-xenserver-build-env.sh
+++ b/.travis-xenserver-build-env.sh
@@ -4,16 +4,16 @@
 
 set -uex
 
+export CONTAINER_NAME=build-env
+export OCAMLRUNPARAM=b
+export REPO_PACKAGE_NAME=xapi
+export REPO_CONFIGURE_CMD=./configure
+export REPO_BUILD_CMD=make
+export REPO_TEST_CMD='make test'
+export REPO_DOC_CMD='make doc-json'
+
 wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh
 
 # only run deploy.sh when the build succeeds
-env \
-  CONTAINER_NAME=build-env \
-  OCAMLRUNPARAM=b \
-  REPO_PACKAGE_NAME=xapi \
-  REPO_CONFIGURE_CMD=./configure \
-  REPO_BUILD_CMD=make \
-  REPO_TEST_CMD='make test' \
-  REPO_DOC_CMD='make doc-json' \
-  bash travis-build-repo.sh && \
+bash travis-build-repo.sh && \
   ( ( test $TRAVIS_PULL_REQUEST = "false" && test $TRAVIS_BRANCH = "master" && bash deploy.sh ) || true )


### PR DESCRIPTION
Export environmental variables instead of setting them for the first
script only with "env", because some of these variables are used by the
deploy.sh script too.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>