### PR TITLE
CA-254515: Check DB and new VDIs when updating VDI.snapshot_of

### DIFF
--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -392,13 +392,9 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
       | _, _, _ -> None
     ) db_vdi_map scan_vdi_map in
 
-  let find_snapshoted_vdi loc =
-    (* We check the to_create map in case the snapshoted VDI is one of the VDIs
-       being created (after realising that it exists in the SR but not the database).
-       This may happen if the snapshoted VDI _and_ the snapshot VDI are both in the
-       SR but not the database, and we are creating both now. *)
-    if StringMap.mem loc to_create
-    then Ref.of_string (StringMap.find loc to_create).snapshot_of
+  let find_vdi db_vdi_map loc =
+    if StringMap.mem loc db_vdi_map
+    then fst (StringMap.find loc db_vdi_map)
     else
       (* CA-254515: Also check for the snapshoted VDI in the database *)
       try Db.VDI.get_by_uuid ~__context ~uuid:loc
@@ -415,7 +411,7 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
        Db.VDI.destroy ~__context ~self:r
     ) to_delete;
   (* Create the new ones *)
-  let _ = StringMap.fold
+  let db_vdi_map = StringMap.fold
       (fun loc vdi m ->
          let ref = Ref.make () in
          let uuid = match vdi.uuid with
@@ -427,7 +423,7 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
            ~name_label:vdi.name_label ~name_description:vdi.name_description
            ~current_operations:[] ~allowed_operations:[]
            ~is_a_snapshot:vdi.is_a_snapshot
-           ~snapshot_of:(find_snapshoted_vdi vdi.snapshot_of)
+           ~snapshot_of:(find_vdi db_vdi_map vdi.snapshot_of) (* is this needed if we re/set the snapshot_of field right after? alternative?.. *)
            ~snapshot_time:(Date.of_string vdi.snapshot_time)
            ~sR:sr ~virtual_size:vdi.virtual_size
            ~physical_utilisation:vdi.physical_utilisation
@@ -442,6 +438,19 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
            ~is_tools_iso:(get_is_tools_iso vdi);
          StringMap.add vdi.vdi (ref, Db.VDI.get_record ~__context ~self:ref) m
       ) to_create db_vdi_map in
+  (* CA-254515: Update the snapshot_of field for the newly-created VDIs. We must do
+     this after creating them all because it's possible that the newly-created VDIs
+     above included snapshoted VDIs and their snapshots, which were not yet in the 
+     database and so would have had their snapshot_of field reference set to null. *)
+  StringMap.iter
+    (fun loc (vi:vdi_info) ->
+       let snapshot_ref = find_vdi db_vdi_map vi.snapshot_of in
+       let snapshot_of_str = Ref.string_of snapshot_ref.snapshot_of in
+       if loc <> snapshot_of_str then begin
+         debug "%s snapshot_of <- %s" (Ref.string_of snapshot_ref) snapshot_of_str;
+         Db.VDI.set_snapshot_of ~__context ~self:snapshot_ref ~value:snapshot_ref.snapshot_of
+       end
+    ) to_create;
   (* Update the ones which already exist *)
   StringMap.iter
     (fun loc (r, v, (vi: vdi_info)) ->
@@ -471,7 +480,7 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
          debug "%s snapshot_time <- %s" (Ref.string_of r) vi.snapshot_time;
          Db.VDI.set_snapshot_time ~__context ~self:r ~value:(Date.of_string vi.snapshot_time)
        end;
-       let snapshot_of = find_snapshoted_vdi vi.snapshot_of in
+       let snapshot_of = find_vdi db_vdi_map vi.snapshot_of in
        if v.API.vDI_snapshot_of <> snapshot_of then begin
          debug "%s snapshot_of <- %s" (Ref.string_of r) (Ref.string_of snapshot_of);
          Db.VDI.set_snapshot_of ~__context ~self:r ~value:snapshot_of

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -395,7 +395,11 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
   let find_vdi db_vdi_map loc =
     if StringMap.mem loc db_vdi_map
     then fst (StringMap.find loc db_vdi_map)
-    else Ref.null in
+    else
+      (* CA-254515: Also check for the snapshoted VDI in the database *)
+      try Db.VDI.get_by_uuid ~__context ~uuid:loc 
+      with _ -> Ref.null
+  in
 
   let get_is_tools_iso vdi =
     List.mem_assoc "xs-tools" vdi.sm_config && List.assoc "xs-tools" vdi.sm_config = "true" in


### PR DESCRIPTION
The VDI snapshot's `snapshot_of` field would become a null reference if
its name_label or name_description field was changed, or if vdi-update
was called on it. This was happening because it was only checking the
VDI map argument passed into the `find_vdi` function, which did not
contain the VDI that was originally snapshoted.

Now, if the map argument does not contain the snapshoted VDI, `find_vdi`
will check the database for the snapshoted VDI, which it should find if
it still exists, and hence will no longer return a null reference and
will retain its original `snapshot_of` value.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>