### PR TITLE
[Discussion] Exclude some files from coverage

### DIFF
--- a/.coverage.excludes
+++ b/.coverage.excludes
@@ -1,0 +1,7 @@
+(* This file defines which files are excluded from bisect_ppx code coverage, which is submitted to coveralls *)
+(* See https://github.com/aantron/bisect_ppx/blob/master/doc/advanced.md#Excluding
+   and https://github.com/simonjbeaumont/ocaml-travis-coveralls/#configuration for details *)
+
+file "ocaml/xapi/server.ml"
+file "ocaml/xapi-types/aPI.ml"
+file "ocaml/xapi-client/client.ml"


### PR DESCRIPTION
This PR excludes the following auto-generated files: server.ml, aPI.ml, client.ml. I think we should only exclude those files that we cannot unit-test.
There are more auto-generated files, but some of them have good coverage results. Feel free to suggest a different set of files that we should exclude.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>