### PR TITLE
CP-22597: Add vGPU-to-GPU-group map to SXM migration

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -240,6 +240,9 @@ let falcon_release =
   ; internal_deprecated_since=None
   }
 
+(* WARN: get rid of this when the release time comes *)
+let vgpu_migration_stub_release = falcon_release
+
 let dundee_plus_release =
   { internal = get_product_releases rel_dundee_plus
   ; opensource=get_oss_releases None
@@ -2450,12 +2453,15 @@ let vm_migrate_send = call
     ~name: "migrate_send"
     ~in_product_since:rel_tampa
     ~doc: "Migrate the VM to another host.  This can only be called when the specified VM is in the Running state."
-    ~params:[Ref _vm, "vm", "The VM";
-             Map(String,String), "dest", "The result of a Host.migrate_receive call.";
-             Bool, "live", "Live migration";
-             Map (Ref _vdi, Ref _sr), "vdi_map", "Map of source VDI to destination SR";
-             Map (Ref _vif, Ref _network), "vif_map", "Map of source VIF to destination network";
-             Map (String, String), "options", "Other parameters"]
+    ~versioned_params:
+      [{param_type=Ref _vm; param_name="vm"; param_doc="The VM"; param_release=tampa_release; param_default=None};
+       {param_type=Map(String,String); param_name="dest"; param_doc="The result of a Host.migrate_receive call."; param_release=tampa_release;  param_default=None};
+       {param_type=Bool; param_name="live"; param_doc="Live migration"; param_release=tampa_release; param_default=None};
+       {param_type=Map (Ref _vdi, Ref _sr); param_name="vdi_map"; param_doc="Map of source VDI to destination SR"; param_release=tampa_release; param_default=None};
+       {param_type=Map (Ref _vif, Ref _network); param_name="vif_map"; param_doc="Map of source VIF to destination network"; param_release=tampa_release; param_default=None};
+       {param_type=Map (String, String); param_name="options"; param_doc="Other parameters"; param_release=tampa_release; param_default=None};
+       {param_type=Map (Ref _vgpu, Ref _gpu_group); param_name="vgpu_map"; param_doc="Map of source vGPU to destination GPU group"; param_release=vgpu_migration_stub_release; param_default=Some (VMap [])}
+      ]
     ~result:(Ref _vm, "The reference of the newly created VM in the destination pool")
     ~errs:[Api_errors.vm_bad_power_state; Api_errors.license_restriction]
     ~allowed_roles:_R_VM_POWER_ADMIN
@@ -2465,13 +2471,15 @@ let vm_assert_can_migrate = call
     ~name:"assert_can_migrate"
     ~in_product_since:rel_tampa
     ~doc:"Assert whether a VM can be migrated to the specified destination."
-    ~params:[
-      Ref _vm, "vm", "The VM";
-      Map(String,String), "dest", "The result of a VM.migrate_receive call.";
-      Bool, "live", "Live migration";
-      Map (Ref _vdi, Ref _sr), "vdi_map", "Map of source VDI to destination SR";
-      Map (Ref _vif, Ref _network), "vif_map", "Map of source VIF to destination network";
-      Map (String, String), "options", "Other parameters" ]
+    ~versioned_params:
+      [{param_type=Ref _vm; param_name="vm"; param_doc="The VM"; param_release=tampa_release; param_default=None};
+       {param_type=Map(String,String); param_name="dest"; param_doc="The result of a VM.migrate_receive call."; param_release=tampa_release;  param_default=None};
+       {param_type=Bool; param_name="live"; param_doc="Live migration"; param_release=tampa_release; param_default=None};
+       {param_type=Map (Ref _vdi, Ref _sr); param_name="vdi_map"; param_doc="Map of source VDI to destination SR"; param_release=tampa_release; param_default=None};
+       {param_type=Map (Ref _vif, Ref _network); param_name="vif_map"; param_doc="Map of source VIF to destination network"; param_release=tampa_release; param_default=None};
+       {param_type=Map (String, String); param_name="options"; param_doc="Other parameters"; param_release=tampa_release; param_default=None};
+       {param_type=Map (Ref _vgpu, Ref _gpu_group); param_name="vgpu_map"; param_doc="Map of source vGPU to destination GPU group"; param_release=vgpu_migration_stub_release; param_default=Some (VMap [])}
+      ]
     ~allowed_roles:_R_VM_POWER_ADMIN
     ~errs:[Api_errors.license_restriction]
     ()
@@ -2486,6 +2494,7 @@ let vm_assert_can_migrate_sender = call
       Bool, "live", "Live migration";
       Map (Ref _vdi, Ref _sr), "vdi_map", "Map of source VDI to destination SR";
       Map (Ref _vif, Ref _network), "vif_map", "Map of source VIF to destination network";
+      Map (Ref _vgpu, Ref _gpu_group), "vgpu_map", "Map of source vGPU to destination GPU group";
       Map (String, String), "options", "Other parameters" ]
     ~allowed_roles:_R_VM_POWER_ADMIN
     ~hide_from_docs:true

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -130,3 +130,6 @@ let storage_migrate_vif_map_key = "maps_to"
 
 (* Abstract size value for tracking PGPU utilisation. *)
 let pgpu_default_size = Int64.mul 1024L 1024L
+
+(* Used to specify mapping of vGPUs to pGPU groups on the remote machine. Stored in VGPU.other_config *)
+let storage_migrate_vgpu_map_key = "maps_to"

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2724,7 +2724,7 @@ let vm_retrieve_wlb_recommendations printer rpc session_id params =
     failwith ("Parameter '"^name^"' is not a field of the VM class. Failed to select VM for operation.")
 
 let vm_migrate_sxm_params = ["remote-master"; "remote-username"; "vif"; "remote-password";
-                             "remote-network"; "vdi"]
+                             "remote-network"; "vdi"; "vgpu"]
 
 let vm_migrate printer rpc session_id params =
   (* Hack to match host-uuid and host-name for backwards compatibility *)
@@ -2794,6 +2794,11 @@ let vm_migrate printer rpc session_id params =
              let vdi = Client.VDI.get_by_uuid rpc session_id vdi_uuid in
              let sr = Client.SR.get_by_uuid remote_rpc remote_session sr_uuid in
              vdi,sr) (read_map_params "vdi" params) in
+         
+         let vgpu_map = List.map (fun (vgpu_uuid,gpu_group_uuid) ->
+             let vgpu = Client.VGPU.get_by_uuid rpc session_id vgpu_uuid in
+             let gpu_group = Client.GPU_group.get_by_uuid remote_rpc remote_session gpu_group_uuid in
+             vgpu,gpu_group) (read_map_params "vgpu" params) in
 
          let default_sr =
            try let pools = Client.Pool.get_all remote_rpc remote_session in
@@ -2833,7 +2838,7 @@ let vm_migrate printer rpc session_id params =
            vdi_map ;
          let token = Client.Host.migrate_receive remote_rpc remote_session host network options in
          let new_vm =
-           do_vm_op ~include_control_vms:false ~include_template_vms:true printer rpc session_id (fun vm -> Client.VM.migrate_send rpc session_id (vm.getref ()) token true vdi_map vif_map options)
+           do_vm_op ~include_control_vms:false ~include_template_vms:true printer rpc session_id (fun vm -> Client.VM.migrate_send rpc session_id (vm.getref ()) token true vdi_map vif_map options vgpu_map)
              params (["host"; "host-uuid"; "host-name"; "live"; "force"; "copy"] @ vm_migrate_sxm_params) |> List.hd in
          if get_bool_param params "copy" then
            printer (Cli_printer.PList [Client.VM.get_uuid remote_rpc remote_session new_vm])

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1675,22 +1675,22 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       update_vif_operations ~__context ~vm;
       Cpuid_helpers.update_cpu_flags ~__context ~vm ~host
 
-    let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
+    let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options =
       info "VM.assert_can_migrate_sender: VM = '%s'" (vm_uuid ~__context vm);
-      let local_fn = Local.VM.assert_can_migrate_sender ~vm ~dest ~live ~vdi_map ~vif_map ~options in
+      let local_fn = Local.VM.assert_can_migrate_sender ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options in
       forward_vm_op ~local_fn ~__context ~vm
-        (fun session_id rpc -> Client.VM.assert_can_migrate_sender rpc session_id vm dest live vdi_map vif_map options)
+        (fun session_id rpc -> Client.VM.assert_can_migrate_sender rpc session_id vm dest live vdi_map vif_map vgpu_map options)
 
-    let assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
+    let assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map =
       info "VM.assert_can_migrate: VM = '%s'" (vm_uuid ~__context vm);
       (* Run the checks that can be done using just the DB directly on the master *)
-      Local.VM.assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options;
+      Local.VM.assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options;
       (* Run further checks on the sending host *)
-      assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options
+      assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options
 
-    let migrate_send ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
+    let migrate_send ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map =
       info "VM.migrate_send: VM = '%s'" (vm_uuid ~__context vm);
-      let local_fn = Local.VM.migrate_send ~vm ~dest ~live ~vdi_map ~vif_map ~options in
+      let local_fn = Local.VM.migrate_send ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options in
       let forwarder =
         if Xapi_vm_lifecycle.is_live ~__context ~self:vm then
           let host = List.assoc Xapi_vm_migrate._host dest |> Ref.of_string in
@@ -1711,9 +1711,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
              fst (forward_to_suitable_host ~local_fn ~__context ~vm ~snapshot ~host_op:`vm_migrate op)) in
       with_vm_operation ~__context ~self:vm ~doc:"VM.migrate_send" ~op:`migrate_send
         (fun () ->
-           assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options;
+           assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options;
            forwarder ~local_fn ~__context ~vm
-             (fun session_id rpc -> Client.VM.migrate_send rpc session_id vm dest live vdi_map vif_map options)
+             (fun session_id rpc -> Client.VM.migrate_send rpc session_id vm dest live vdi_map vif_map options vgpu_map)
         )
 
     let send_trigger ~__context ~vm ~trigger =

--- a/ocaml/xapi/xapi_pgpu_helpers.mli
+++ b/ocaml/xapi/xapi_pgpu_helpers.mli
@@ -64,5 +64,6 @@ val assert_capacity_exists_for_VGPU_type :
 val assert_destination_pgpu_is_compatible_with_vm :
   __context:Context.t ->
   vm:API.ref_VM ->
+  vgpu_map:(API.ref_VGPU * API.ref_GPU_group) list ->
   host:API.ref_host ->
   ?remote:(Rpc.call -> Rpc.response Client.Id.t) * 'a Ref.t -> unit -> unit

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1215,7 +1215,7 @@ let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu
   Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context
     ~vm ~vgpu_map ~host:remote.dest_host ?remote:remote_for_migration_type ()
 
-let migrate_send  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options =
+let migrate_send  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map =
   with_migrate (fun () ->
       migrate_send' ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options)
 

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -234,7 +234,7 @@ let pool_migrate ~__context ~vm ~host ~options =
   let xenops_vgpu_map = infer_vgpu_map ~__context vm in
 
   (* Check pGPU compatibility for Nvidia vGPUs *)
-  Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context ~vm ~host ();
+  Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context ~vm ~host ~vgpu_map:[] ();
 
   Xapi_xenops.Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid (fun () ->
       try
@@ -308,6 +308,11 @@ type vif_transfer_record = {
   remote_network_reference : API.ref_network;
 }
 
+type vgpu_transfer_record = {
+  local_vgpu_reference : API.ref_VGPU;
+  remote_gpu_group_reference : API.ref_GPU_group;
+}
+
 (* If VM's suspend_SR is set to the local SR, it won't be visible to
    the destination host after an intra-pool storage migrate *)
 let intra_pool_fix_suspend_sr ~__context host vm =
@@ -341,7 +346,7 @@ let intra_pool_vdi_remap ~__context vm vdi_map =
          Not_found -> ())
     vdis_and_callbacks
 
-let inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~dry_run ~live ~copy =
+let inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~vgpu_map ~dry_run ~live ~copy =
   List.iter (fun vdi_record ->
       let vdi = vdi_record.local_vdi_reference in
       Db.VDI.remove_from_other_config ~__context ~self:vdi
@@ -359,6 +364,14 @@ let inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~dry_r
       Db.VIF.add_to_other_config ~__context ~self:vif
         ~key:Constants.storage_migrate_vif_map_key
         ~value:(Ref.string_of vif_record.remote_network_reference)) vif_map;
+
+  List.iter (fun vgpu_record ->
+      let vgpu = vgpu_record.local_vgpu_reference in
+      Db.VGPU.remove_from_other_config ~__context ~self:vgpu
+        ~key:Constants.storage_migrate_vgpu_map_key;
+      Db.VGPU.add_to_other_config ~__context ~self:vgpu
+        ~key:Constants.storage_migrate_vgpu_map_key
+        ~value:(Ref.string_of vgpu_record.remote_gpu_group_reference)) vgpu_map;
 
   let vm_export_import = {
     Importexport.vm = vm; dry_run = dry_run; live = live; send_snapshots = not copy;
@@ -380,7 +393,13 @@ let inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~dry_r
             Db.VIF.remove_from_other_config ~__context
               ~self:vif_record.local_vif_reference
               ~key:Constants.storage_migrate_vif_map_key)
-         vif_map)
+         vif_map;
+       List.iter
+         (fun vgpu_record ->
+            Db.VGPU.remove_from_other_config ~__context
+              ~self:vgpu_record.local_vgpu_reference
+              ~key:Constants.storage_migrate_vgpu_map_key)
+         vgpu_map;)
 
 module VDIMap = Map.Make(struct type t = API.ref_VDI let compare = compare end)
 let update_snapshot_info ~__context ~dbg ~url ~vdi_map ~snapshots_map =
@@ -730,7 +749,7 @@ let check_vdi_map ~__context vms_vdis vdi_map =
         error "VDI:SR map not fully specified for VDI %s" vdi_uuid ;
         raise (Api_errors.Server_error(Api_errors.vdi_not_in_map, [ Ref.string_of vconf.vdi ]))) vms_vdis)
 
-let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
+let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options =
   SMPERF.debug "vm.migrate_send called vm:%s" (Db.VM.get_uuid ~__context ~self:vm);
 
   let open Xapi_xenops in
@@ -918,10 +937,16 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
                     local_vif_reference = vif;
                     remote_network_reference = network;
                   })
-                vif_map
+                vif_map in
+            let vgpu_map =
+              List.map (fun (vgpu, gpu_group) -> {
+                    local_vgpu_reference = vgpu;
+                    remote_gpu_group_reference = gpu_group;
+                  })
+                vgpu_map
             in
             inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map
-              ~vif_map ~dry_run:false ~live:true ~copy
+              ~vif_map ~vgpu_map ~dry_run:false ~live:true ~copy
           in
           let vm = List.hd vms in
           let () = if ha_always_run_reset then XenAPI.VM.set_ha_always_run ~rpc:remote.rpc ~session_id:remote.session ~self:vm ~value:false in
@@ -1083,7 +1108,7 @@ let migration_type ~__context ~remote =
     debug "This is a cross-pool migration";
     `cross_pool
 
-let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
+let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map =
   assert_licensed_storage_motion ~__context ;
 
   let remote = remote_of_dest dest in
@@ -1168,12 +1193,18 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
               remote_network_reference = network;
             })
           vif_map in
-      if not (inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~dry_run:true ~live:true ~copy = []) then
+      let vgpu_map =
+        List.map (fun (vgpu, gpu_group) -> {
+              local_vgpu_reference = vgpu;
+              remote_gpu_group_reference = gpu_group;
+            })
+          vgpu_map in
+      if not (inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~vgpu_map ~dry_run:true ~live:true ~copy = []) then
         raise Api_errors.(Server_error(internal_error, ["assert_can_migrate: inter_pool_metadata_transfer returned a nonempty list"]))
     with Xmlrpc_client.Connection_reset ->
       raise (Api_errors.Server_error(Api_errors.cannot_contact_host, [remote.remote_ip]))
 
-let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
+let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options =
   (* Check that the destination host has compatible pGPUs -- if needed *)
   let remote = remote_of_dest dest in
   let remote_for_migration_type =
@@ -1182,11 +1213,11 @@ let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~opti
     | `cross_pool -> Some (remote.rpc, remote.session)
   in
   Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context
-    ~vm ~host:remote.dest_host ?remote:remote_for_migration_type ()
+    ~vm ~vgpu_map ~host:remote.dest_host ?remote:remote_for_migration_type ()
 
-let migrate_send  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
+let migrate_send  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options =
   with_migrate (fun () ->
-      migrate_send' ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options)
+      migrate_send' ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options)
 
 let vdi_pool_migrate ~__context ~vdi ~sr ~options =
 
@@ -1235,8 +1266,8 @@ let vdi_pool_migrate ~__context ~vdi ~sr ~options =
   TaskHelper.set_cancellable ~__context;
   Helpers.call_api_functions ~__context (fun rpc session_id ->
       let dest = XenAPI.Host.migrate_receive ~rpc ~session_id ~host:dest_host ~network ~options in
-      assert_can_migrate ~__context ~vm ~dest ~live:true ~vdi_map ~vif_map:[] ~options:[];
-      assert_can_migrate_sender ~__context ~vm ~dest ~live:true ~vdi_map ~vif_map:[] ~options:[];
-      ignore(migrate_send ~__context ~vm ~dest ~live:true ~vdi_map ~vif_map:[] ~options:[])
+      assert_can_migrate ~__context ~vm ~dest ~live:true ~vdi_map ~vif_map:[] ~vgpu_map:[] ~options:[];
+      assert_can_migrate_sender ~__context ~vm ~dest ~live:true ~vdi_map ~vif_map:[] ~vgpu_map:[] ~options:[];
+      ignore(migrate_send ~__context ~vm ~dest ~live:true ~vdi_map ~vif_map:[] ~vgpu_map:[] ~options:[])
     ) ;
   Db.VBD.get_VDI ~__context ~self:vbd

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -569,6 +569,7 @@ module MD = struct
       position = int_of_string vgpu.Db_actions.vGPU_device;
       physical_pci_address;
       implementation;
+      other_config = [];
     }
 
   let of_gvt_g_vgpu ~__context vm vgpu =
@@ -603,6 +604,7 @@ module MD = struct
         position = int_of_string vgpu.Db_actions.vGPU_device;
         physical_pci_address;
         implementation;
+        other_config = [];
       }
     with
     | Not_found -> failwith "Intel GVT-g settings not specified"
@@ -632,6 +634,7 @@ module MD = struct
         position = int_of_string vgpu.Db_actions.vGPU_device;
         physical_pci_address;
         implementation;
+        other_config = [];
       }
     with
     | Not_found -> failwith "AMD MxGPU settings not specified"
@@ -658,6 +661,7 @@ module MD = struct
             Xenops_interface.Pci.address_of_string
               (List.assoc Vm_platform.vgpu_pci_id vm.API.vM_platform);
           implementation;
+          other_config = [];
         }]
     end else
       List.fold_left


### PR DESCRIPTION
This PR also meant to address the potential issue discovered reviewing https://github.com/xapi-project/xen-api/pull/3058

However it looks like this was a non-issue, in the sense that a failure in calling `allocate_vm_to_host` during SXM migration would trigger the cleanup already in there, while a failure later on during the migration would anyway trigger the cleanup on the remote host that will take care of everything else.

This PR needs a small change to xapi-idl to introduce the other_config field to the vgpu interface, this is needed as temporary store to mimick the map functionality that we are already using for vifs and vbds.