### PR TITLE
VDI.set_metadata_of_pool: only allow `metadata VDI

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -722,11 +722,12 @@ let set_snapshot_time ~__context ~self ~value =
   Db.VDI.set_snapshot_time ~__context ~self ~value
 
 let set_metadata_of_pool ~__context ~self ~value =
-  if (Db.VDI.get_type ~__context ~self) = `cbt_metadata then begin
-    error "VDI.set_metadata_of_pool: called with a VDI of type cbt_metadata (at %s)" __LOC__;
-    raise (Api_errors.Server_error (Api_errors.vdi_incompatible_type, [ Ref.string_of self; Record_util.vdi_type_to_string `cbt_metadata ]))
-  end;
-  Db.VDI.set_metadata_of_pool ~__context ~self ~value
+  let vdi_type = Db.VDI.get_type ~__context ~self in
+  match vdi_type with
+  | `metadata -> Db.VDI.set_metadata_of_pool ~__context ~self ~value
+  | _ ->
+    error "VDI.set_metadata_of_pool: called with a VDI that does not have type metadata (at %s)" __LOC__;
+    raise (Api_errors.Server_error (Api_errors.vdi_incompatible_type, [ Ref.string_of self; Record_util.vdi_type_to_string vdi_type ]))
 
 let set_on_boot ~__context ~self ~value =
   let sr = Db.VDI.get_SR ~__context ~self in


### PR DESCRIPTION
When we run this function from Xapi_sr.find_or_create_metadata_vdis, we
first set the type of the VDI passed to it to `metadata, so this check
is safe to add. Also, in the various VDI handling functions in Xapi_sr
and Xapi_dr, we only consider VDIs of type `metadata, so we should
enforce that a VDI that contains the metadata of a pool has type
`metadata.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>