### PR TITLE
Remove dead code from ocaml/util

### DIFF
--- a/ocaml/util/ocamltest.ml
+++ b/ocaml/util/ocamltest.ml
@@ -43,16 +43,7 @@ let assert_equal ?to_string x y =
          )
       )
 
-let assert_equal_bool   = assert_equal ~to_string:string_of_bool
-let assert_equal_float  = assert_equal ~to_string:string_of_float
-let assert_equal_int    = assert_equal ~to_string:string_of_int
-let assert_equal_int32  = assert_equal ~to_string:Int32.to_string
-let assert_equal_int64  = assert_equal ~to_string:Int64.to_string
-let assert_equal_string = assert_equal ~to_string:(fun s -> s)
-
 (* === Other assertions === *)
-
-let successful fn = try fn (); true with _ -> false
 
 let assert_true x = assert x
 
@@ -70,83 +61,7 @@ let assert_raises_match exception_match fn =
 let assert_raises expected =
   assert_raises_match (function exn -> exn = expected)
 
-let assert_raises_any f =
-  try
-    f ();
-    raise Failure_expected
-  with failure ->
-    ()
-
 let fail message = raise (Fail (message))
-
-let skip message = raise (Skip (message))
-
-(* === Console styles === *)
-
-type style = Reset | Bold | Reverse | Dim | Red | Green | Blue | Yellow | Black
-
-let int_of_style = function
-  | Reset  ->  0
-  | Bold   ->  1
-  | Dim    ->  2
-  | Reverse->  7
-  | Black  -> 30
-  | Red    -> 31
-  | Green  -> 32
-  | Yellow -> 33
-  | Blue   -> 34
-
-let string_of_style value = string_of_int (int_of_style value)
-
-let escape = String.make 1 (char_of_int 0x1b)
-
-(** Whether or not to disable pretty-printing. *)
-let ugly = ref false
-
-let style values =
-  if !ugly then "" else
-    sprintf "%s[%sm" escape (String.concat ";" (List.map (string_of_style) values))
-
-(* === Indices === *)
-
-let index_of_test =
-  let rec build prefix = function
-    | Case (name, description, case) ->
-      [(prefix ^ name, Case (name, description, case))]
-    | Suite (name, description, tests) ->
-      (prefix ^ name, Suite (name, description, tests)) ::
-      (List.flatten (List.map (build (prefix ^ name ^ ".")) tests))
-  in
-  build ""
-
-let string_of_index_entry = function
-  | (key, Case  (_, description, _))
-  | (key, Suite (_, description, _))
-    -> (style [Bold]) ^ key ^ (style [Reset]) ^ "\n    " ^ description
-
-let string_of_index index =
-  "\n" ^ (String.concat "\n" (List.map string_of_index_entry index)) ^ "\n"
-
-let max x y = if x > y then x else y
-
-let longest_key_of_index index =
-  List.fold_left
-    (fun longest_key (key, _) ->
-       max longest_key (String.length key))
-    0 index
-
-(* === Runners === *)
-
-type test_result = {passed: int; failed: int; skipped: int}
-
-let add_result
-    {passed = p1     ; failed = f1     ; skipped = s1     }
-    {passed =      p2; failed =      f2; skipped =      s2} =
-  {passed = p1 + p2; failed = f1 + f2; skipped = s1 + s2}
-
-let singleton_pass = {passed = 1; failed = 0; skipped = 0}
-let singleton_fail = {passed = 0; failed = 1; skipped = 0}
-let singleton_skip = {passed = 0; failed = 0; skipped = 1}
 
 (** True if (and only if) the currently-executing  *)
 (** test has generated one or more debug messages. *)
@@ -159,99 +74,9 @@ let start_debugging () =
       print_endline "\n"
     end
 
-(** Runs the given test. *)
-let run test =
-
-  let longest_key_width = longest_key_of_index (index_of_test test) in
-
-  (** Runs the given test with the given name prefix. *)
-  let rec run (test : test) (name_prefix : string) : test_result =
-    match test with
-    | Case (name, description, fn) ->
-      run_case (name_prefix ^ name, description, fn)
-    | Suite (name, description, tests) ->
-      run_suite (name_prefix ^ name, description, tests)
-
-  (** Runs the given test case. *)
-  and run_case (name, description, fn) =
-
-    let pre_status_padding =
-      String.make (longest_key_width - (String.length name)) ' ' in
-
-    let generate_status_string colour result =
-      sprintf "%s\t[%s%s%s]" pre_status_padding (style [colour; Bold]) result (style [Reset])
-    in
-
-    let describe_current_test () =
-      printf "%stesting %s%s" (style [Bold]) name (style [Reset]);
-      flush stdout
-    in
-
-    let display_start_message () =
-      describe_current_test ();
-      debugging := false
-    in
-
-    let display_finish_message colour result =
-      if !debugging
-      then
-        begin
-          print_endline "";
-          describe_current_test ();
-        end;
-      print_endline (generate_status_string colour result)
-    in
-
-    display_start_message ();
-    try
-      fn ();
-      display_finish_message Green "pass";
-      singleton_pass
-    with
-    | Skip (message) ->
-      display_finish_message Blue "skip";
-      printf "\nskipped: %s\n\n" message;
-      singleton_skip
-    | Fail (message) ->
-      display_finish_message Red "fail";
-      printf "\nfailed: %s\n\n" message;
-      singleton_fail
-    | failure ->
-      display_finish_message Red "fail";
-      printf "\nfailed: %s\n%s\n"
-        (Printexc.to_string failure)
-        (Printexc.get_backtrace ());
-      singleton_fail
-
-  (** Runs the given test suite. *)
-  and run_suite (name, description, tests) =
-    flush stdout;
-    let result = List.fold_left (
-        fun accumulating_result test ->
-          add_result accumulating_result (run test (name ^ "."))
-      ) {passed = 0; failed = 0; skipped = 0} tests in
-    result
-  in
-
-  Printexc.record_backtrace true;
-  printf "\n";
-  let {passed = passed; failed = failed; skipped = skipped} = run test "" in
-  printf "\n";
-  printf " tested [%s%i%s]\n" (style [Bold]) (passed + failed + skipped) (style [Reset]);
-  printf " passed [%s%i%s]\n" (style [Bold]) (passed                   ) (style [Reset]);
-  printf " failed [%s%i%s]\n" (style [Bold]) (         failed          ) (style [Reset]);
-  printf "skipped [%s%i%s]\n" (style [Bold]) (                  skipped) (style [Reset]);
-  printf "\n";
-  {passed = passed; failed = failed; skipped = skipped}
-
 let print_endline string =
   start_debugging ();
   print_endline string;
-  flush stdout
-
-let print_string string =
-  start_debugging ();
-  print_string string;
   flush stdout
 
 (* === Factories === *)
@@ -267,50 +92,3 @@ let make_test_suite name description suite =
 
 let make_module_test_suite name suite =
   Suite (name, sprintf "Tests the %s module." name, suite)
-
-(* === Command line interface === *)
-
-(** Argument values. *)
-let list = ref false
-let name = ref None
-
-(** Argument definitions. *)
-let arguments =
-  [
-    "-list",
-    Arg.Set list,
-    "lists the tests available in this module";
-    "-name",
-    Arg.String (fun name' -> name := Some name'),
-    "runs the test with the given name";
-    "-ugly",
-    Arg.Set ugly,
-    "disables pretty-printing";
-  ]
-
-(** For now, ignore anonymous arguments. *)
-let process_anonymous_argument string = ()
-
-(** For now, present a blank usage message. *)
-let usage = ""
-
-let make_command_line_interface test =
-  (* TODO: Use stderr in appropriate places when presented with failures. *)
-  Arg.parse arguments process_anonymous_argument usage;
-  let index = index_of_test test in
-  if !list
-  then
-    begin
-      print_endline (string_of_index index);
-      flush stdout
-    end
-  else
-    begin
-      let {passed = passed; failed = failed; skipped = skipped} = run
-          (match !name with
-           | Some name -> (List.assoc name index)
-           | None -> test)
-      in
-      flush stdout;
-      exit (if failed = 0 then 0 else 1)
-    end

--- a/ocaml/util/ocamltest.mli
+++ b/ocaml/util/ocamltest.mli
@@ -27,31 +27,10 @@ exception Skip of string
 (** Raised when a failure was expected, but not detected. *)
 exception Failure_expected
 
-(** Returns true if and only if the given function raises no exceptions. *)
-val successful : (unit -> 'a) -> bool
-
 (** Asserts that the given values are logically equal. If the values *)
 (** are not equal, this function uses the optional string conversion *)
 (** function to generate a failure message with the non-equal values.*)
 val assert_equal : ?to_string:('a -> string) -> 'a -> 'a -> unit
-
-(** Asserts that the given Boolean values are equal. *)
-val assert_equal_bool : bool -> bool -> unit
-
-(** Asserts that the given floating-point values are equal. *)
-val assert_equal_float : float -> float -> unit
-
-(** Asserts that the given integer values are equal. *)
-val assert_equal_int : int -> int -> unit
-
-(** Asserts that the given 32-bit integer values are equal. *)
-val assert_equal_int32 : int32 -> int32 -> unit
-
-(** Asserts that the given 64-bit integer values are equal. *)
-val assert_equal_int64 : int64 -> int64 -> unit
-
-(** Asserts that the given strings are equal. *)
-val assert_equal_string : string -> string -> unit
 
 (** Asserts that the given value is true. *)
 val assert_true : bool -> unit
@@ -66,20 +45,11 @@ val assert_raises_match : (exn -> bool) -> (unit -> 'a) -> unit
 (** Asserts that the given function raises the given exception. *)
 val assert_raises : exn -> (unit -> 'a) -> unit
 
-(** Asserts that the given function fails with any exception. *)
-val assert_raises_any : (unit -> 'a) -> unit
-
 (** Indicates that the current test has failed, with the given message. *)
 val fail : string -> unit
 
-(** Indicates that the current test should be skipped, with the given message. *)
-val skip : string -> unit
-
 (** Prints a debugging message, followed by a newline character. *)
 val print_endline : string -> unit
-
-(** Prints a debugging message. *)
-val print_string : string -> unit
 
 (** Makes a test case. *)
 val make_test_case : name -> description -> case -> test
@@ -92,6 +62,3 @@ val make_test_suite : name -> description -> suite -> test
 
 (** Makes a module test suite with a default description. *)
 val make_module_test_suite : name -> suite -> test
-
-(** Makes the given test accessible from the command-line. *)
-val make_command_line_interface : test -> unit

--- a/ocaml/util/stats.mli
+++ b/ocaml/util/stats.mli
@@ -17,11 +17,6 @@ val summarise : unit -> (string * string) list
 (** Time the given function and attribute the result to the named population *)
 val time_this : string -> (unit -> 'a) -> 'a
 
-(** [sample thing t] records new time [t] for population named [thing] *)
-val sample : string -> float -> unit
-
-type dbcallty = Read | Write | Create | Drop
-val log_db_call : string option -> string -> dbcallty -> unit
 val summarise_db_calls : unit -> (string list * string list * string list * string list * (string * ((string * string) list)) list * (int * ((string * string) list)) list)
 
 val log_stats : bool ref


### PR DESCRIPTION
Please let me know if I removed something that's needed.

In the future we should completely get rid of the Ocamltest module, and move to the functions provided by alcotest/ounit, but this is a good first step towards removing that file.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>