### PR TITLE
[WIP] Add new pool join-check: pool and host must have same "enforced" updates

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 131
+let schema_minor_vsn = 132
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -4239,6 +4239,13 @@ let pool_update =
         field     ~in_product_since:rel_ely ~default_value:(Some (VSet [])) ~in_oss_since:None ~qualifier:StaticRO ~ty:(Set pool_update_after_apply_guidance) "after_apply_guidance" "What the client should do after this update has been applied.";
         field     ~in_oss_since:None ~qualifier:StaticRO ~ty:(Ref _vdi) "vdi" "VDI the update was uploaded to";
         field     ~in_product_since:rel_ely ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Set (Ref _host)) "hosts" "The hosts that have applied this update.";
+        field     ~in_product_since:rel_ely
+                  ~default_value:(Some (VBool false))
+                  ~in_oss_since:None
+                  ~qualifier:StaticRO
+                  ~ty:Bool
+                  "enforce_homogeneity"
+                  "Flag - if true, all hosts in a pool must apply this update";
       ]
     ()
 

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -1095,6 +1095,7 @@ let pool_update_record rpc session_id update =
         make_field ~name:"installation-size"   ~get:(fun () -> Int64.to_string (x ()).API.pool_update_installation_size) ();
         make_field ~name:"hosts"               ~get:(fun () -> String.concat ", " (get_hosts ())) ~get_set:get_hosts ();
         make_field ~name:"after-apply-guidance" ~get:(fun () -> String.concat ", " (after_apply_guidance ())) ~get_set:after_apply_guidance ();
+        make_field ~name:"enforce-homogeneity" ~get:(fun () -> string_of_bool (x ()).API.pool_update_enforce_homogeneity) ();
       ]}
 
 let host_cpu_record rpc session_id host_cpu =

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -352,9 +352,26 @@ let make_pvs_cache_storage ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ~ref ~uuid ~host ~sR ~site ~size ~vDI;
   ref
 
-let make_pool_update ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
-    ?(name_label="") ?(name_description="") ?(version="") ?(installation_size=0L) ?(key="")
-    ?(after_apply_guidance=[]) ?(vdi=Ref.null) () =
-  let update_info = Xapi_pool_update.{uuid; name_label; name_description; version; key; installation_size; after_apply_guidance} in
+let make_pool_update ~__context
+    ?(ref=Ref.make ())
+    ?(uuid=make_uuid ())
+    ?(name_label="")
+    ?(name_description="")
+    ?(version="")
+    ?(installation_size=0L)
+    ?(key="")
+    ?(after_apply_guidance=[])
+    ?(enforce_homogeneity=false)
+    ?(vdi=Ref.null) () =
+  let update_info = Xapi_pool_update.
+    { uuid
+    ; name_label
+    ; name_description
+    ; version
+    ; key
+    ; installation_size
+    ; after_apply_guidance
+    ; enforce_homogeneity
+    } in
   Xapi_pool_update.create_update_record ~__context ~update:ref ~update_info ~vdi;
   ref

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -163,7 +163,7 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
         let remote_uuid  = Client.Host.get_uuid rpc session_id pool_host in
         let diff xs ys   = S.diff xs ys |> S.elements |> String.concat "," in
         let reason       = [remote_uuid] in
-        info
+        error
           "Pool join: Updates differ. Only on pool host %s: {%s} -- only on local host %s: {%s}"
           remote_uuid
           (diff remote_updates local_updates)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -143,6 +143,36 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
     end
   in
 
+  let assert_homogeneous_updates () =
+    let module S      = Helpers.StringSet in
+    let local_host    = Helpers.get_localhost ~__context in
+    let local_uuid    = Db.Host.get_uuid ~__context ~self:local_host in
+    let updates_on ~rpc ~session_id host =
+      Client.Host.get_updates ~rpc ~session_id ~self:host
+      |> List.map (fun self -> Client.Pool_update.get_record ~rpc ~session_id ~self)
+      |> List.filter (fun upd -> upd.API.pool_update_enforce_homogeneity = true)
+      |> List.map (fun upd -> upd.API.pool_update_uuid)
+      |> S.of_list in
+    let local_updates =
+      Helpers.call_api_functions ~__context (fun rpc session_id ->
+        updates_on ~rpc ~session_id local_host) in
+    (* iterate over all pool hosts and compare patches to local host *)
+    Client.Host.get_all rpc session_id |> List.iter (fun pool_host ->
+      let remote_updates = updates_on rpc session_id pool_host in
+      if not (S.equal local_updates remote_updates) then begin
+        let remote_uuid  = Client.Host.get_uuid rpc session_id pool_host in
+        let diff xs ys   = S.diff xs ys |> S.elements |> String.concat "," in
+        let reason       = [remote_uuid] in
+        info
+          "Pool join: Updates differ. Only on pool host %s: {%s} -- only on local host %s: {%s}"
+          remote_uuid
+          (diff remote_updates local_updates)
+          local_uuid
+          (diff local_updates remote_updates);
+        raise Api_errors.(Server_error(pool_hosts_not_homogeneous,reason))
+      end)
+  in
+
   (* CP-700: Restrict pool.join if AD configuration of slave-to-be does not match *)
   (* that of master of pool-to-join *)
   let assert_external_auth_matches () =
@@ -403,6 +433,7 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
   (* CA-247399: check first the API version and then the database schema *)
   assert_api_version_matches ();
   assert_db_schema_matches ();
+  assert_homogeneous_updates ();
   assert_homogeneous_primary_address_type ()
 
 let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) : API.ref_host =

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -44,6 +44,7 @@ type update_info = {
   key: string;
   installation_size: int64;
   after_apply_guidance: API.after_apply_guidance list;
+  enforce_homogeneity: bool; (* true = all hosts in a pool must have this update *)
 }
 
 (** Mount a filesystem somewhere, with optional type *)
@@ -259,6 +260,9 @@ let parse_update_info xml =
       with
       | _ -> []
     in
+    let enforce_homogeneity =
+      Vm_platform.is_true ~key:"enforce-homogeneity" ~platformdata:attr ~default:false
+    in
     let is_name_description_node = function
       | Xml.Element ("name-description", _, _) -> true
       | _ -> false
@@ -267,16 +271,15 @@ let parse_update_info xml =
       | Xml.Element("name-description", _, [ Xml.PCData s ]) -> s
       | _ -> raise (Api_errors.Server_error(Api_errors.invalid_update, ["missing <name-description> in update.xml"]))
     in
-    let update_info = {
-      uuid = uuid;
-      name_label = name_label;
-      name_description = name_description;
-      version = version;
-      key = Filename.basename key;
-      installation_size = installation_size;
-      after_apply_guidance = guidance;
-    } in
-    update_info
+      { uuid
+      ; name_label
+      ; name_description
+      ; version
+      ; key = Filename.basename key
+      ; installation_size
+      ; after_apply_guidance = guidance
+      ; enforce_homogeneity
+      }
   | _ -> raise (Api_errors.Server_error(Api_errors.invalid_update, ["missing <update> in update.xml"]))
 
 let extract_applied_update_info applied_uuid  =
@@ -371,6 +374,7 @@ let create_update_record ~__context ~update ~update_info ~vdi =
     ~key:update_info.key
     ~after_apply_guidance:update_info.after_apply_guidance
     ~vdi:vdi
+    ~enforce_homogeneity:update_info.enforce_homogeneity
 
 let introduce ~__context ~vdi =
   ignore(Unixext.mkdir_safe Xapi_globs.host_update_dir 0o755);


### PR DESCRIPTION
    This commit adds an additional check before a host can join a pool.
    The joining host compares its set of updates with the updates on each
    host in the pool.  These sets must be equal for the host being able to join
    the pool.  The comparison only considers updates that are marked as
    enforce-homogeneity="true" in their update.xml definition -- see below.
    This attribute is new. The absence of the enforce-homogeneity attribute
    in an update defaults to enforce-homogeneity=false. This makes the code
    backward compatible with updates that don't have this annotation.
    
    Typically, code updates will have enforce-homogeneity=true but driver
    updates will have enforce-homogeneity=false such that hosts in the pool
    can have different sets of drivers but have the same code updates.
    
    The implementation changes the datamodel: class pool_update gets a new
    field enforce_homogeneity.
    
    <update after-apply-guidance="restartHost" build-number="XS71ECU1/58"
      control="control-XS71ECU1" enforce-homogeneity="true"
      installation-size="566138764" key="RPM-GPG-KEY-XS-Eng-Test.pub"
      name-label="XS71ECU1" uuid="5eea06f3-4990-497d-af7a-d0bba6f9f96a"
      version="1.0">
    
      <name-description>Cumulative Update 1 (CU-1)</name-description>
      <rollsup name-label="XS71E001" uuid="fc438a32-0214-4193-8676-9feb121c6997"/>
      <rollsup name-label="XS71E002" uuid="9768c0f1-d111-4ee4-ac85-fe9ee37b5726"/>
      <rollsup name-label="XS71E003" uuid="b80ea320-f9ae-414c-a14d-781861b5c0ac"/>
      <rollsup name-label="XS71E004" uuid="a4ebb0e4-bfcb-48da-8b42-4673d3111d29"/>
      <rollsup name-label="XS71E005" uuid="d2df0c4f-eaf6-4778-a754-19a8b7739b5c"/>
      <rollsup name-label="XS71E006" uuid="008f1b43-8f02-40a4-8475-28f15dbfd1fc"/>
      <rollsup name-label="XS71E007" uuid="04bcb1f7-3bdc-440d-9cac-9d2a87746b24"/>
      <rollsup name-label="XS71E008" uuid="e3c382d7-dba5-4809-9901-d0d15ee02ad9"/>
    </update>
    
    modified:   ocaml/idl/datamodel.ml
    modified:   ocaml/xapi/test_common.ml
    modified:   ocaml/xapi/xapi_pool.ml
    modified:   ocaml/xapi/xapi_pool_update.ml
    
    Signed-off-by: Christian Lindig <christian.lindig@citrix.com>
