### PR TITLE
CA-187179: Refine error message of pool auth disable

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -928,9 +928,11 @@ let _ =
   error Api_errors.pool_auth_disable_failed ["host";"message"]
     ~doc:"The pool failed to disable the external authentication of at least one host." ();
   error Api_errors.pool_auth_disable_failed_wrong_credentials ["host";"message"]
-    ~doc:"The pool failed to disable the external authentication of at least one host." ();
+    ~doc:"External authentication has been disabled with errors: Some AD machine accounts were not disabled on the AD server due to invalid credentials." ();
   error Api_errors.pool_auth_disable_failed_permission_denied ["host";"message"]
-    ~doc:"The pool failed to disable the external authentication of at least one host." ();
+    ~doc:"External authentication has been disabled with errors: Your AD machine account was not disabled on the AD server as permission was denied." ();
+  error Api_errors.pool_auth_disable_failed_invalid_account ["host";"message"]
+    ~doc:"External authentication has been disabled with errors: Some AD machine accounts were not disabled on the AD server due to invalid account." ();
   error Api_errors.pool_joining_host_must_have_same_api_version ["host_api_version";"master_api_version"]
     ~doc:"The host joining the pool must have the same API version as the pool master." ();
   error Api_errors.pool_joining_host_must_have_same_db_schema ["host_db_schema";"master_db_schema"]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -493,6 +493,7 @@ let pool_auth_enable_failed_duplicate_hostname = pool_auth_enable_failed^"_DUPLI
 let pool_auth_disable_failed = pool_auth_prefix^auth_disable_failed
 let pool_auth_disable_failed_wrong_credentials = pool_auth_disable_failed^auth_suffix_wrong_credentials
 let pool_auth_disable_failed_permission_denied = pool_auth_disable_failed^auth_suffix_permission_denied
+let pool_auth_disable_failed_invalid_account = pool_auth_disable_failed^auth_suffix_invalid_account
 let subject_cannot_be_resolved = "SUBJECT_CANNOT_BE_RESOLVED"
 let auth_service_error = "AUTH_SERVICE_ERROR"
 let subject_already_exists = "SUBJECT_ALREADY_EXISTS"


### PR DESCRIPTION
When disable external auth, although failed, the external auth been disabled.
So refine the error message.

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>