### PR TITLE
Travis: fix the coverage build

### DIFF
--- a/.travis-opam-coverage.sh
+++ b/.travis-opam-coverage.sh
@@ -18,6 +18,8 @@ docker run --rm --volume=$PWD:/mnt --workdir=/mnt \
   bash -uex -c '
 sudo apt-get update
 
+sudo chown -R $(whoami) .
+
 # replace the base remote with xs-opam
 opam repository remove default
 opam repository add xs-opam https://github.com/xapi-project/xs-opam.git


### PR DESCRIPTION
By changing the owner of the /mnt directory containing the source from
root to the current user.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>