### PR TITLE
Backport: Add pool join check CP-23026: pool/host must have same "enforced" updates

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -1032,6 +1032,7 @@ let pool_update_record rpc session_id update =
         make_field ~name:"installation-size"   ~get:(fun () -> Int64.to_string (x ()).API.pool_update_installation_size) ();
         make_field ~name:"hosts"               ~get:(fun () -> String.concat ", " (get_hosts ())) ~get_set:get_hosts ();
         make_field ~name:"after-apply-guidance" ~get:(fun () -> String.concat ", " (after_apply_guidance ())) ~get_set:after_apply_guidance ();
+        make_field ~name:"enforce-homogeneity" ~get:(fun () -> string_of_bool (x ()).API.pool_update_enforce_homogeneity) ();
       ]}
 
 let host_cpu_record rpc session_id host_cpu =

--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -306,6 +306,9 @@ let pool_joining_host_must_have_physical_management_nic = "POOL_JOINING_HOST_MUS
 let pool_joining_external_auth_mismatch = "POOL_JOINING_EXTERNAL_AUTH_MISMATCH"
 let pool_joining_host_must_have_same_product_version = "POOL_JOINING_HOST_MUST_HAVE_SAME_PRODUCT_VERSION"
 let pool_joining_host_must_only_have_physical_pifs = "POOL_JOINING_HOST_MUST_ONLY_HAVE_PHYSICAL_PIFS"
+let pool_joining_host_must_have_same_api_version = "POOL_JOINING_HOST_MUST_HAVE_SAME_API_VERSION"
+let pool_joining_host_must_have_same_db_schema = "POOL_JOINING_HOST_MUST_HAVE_SAME_DB_SCHEMA"
+
 
 (*workload balancing*)
 let wlb_not_initialized = "WLB_NOT_INITIALIZED"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -879,6 +879,10 @@ let _ =
     ~doc:"The pool failed to disable the external authentication of at least one host." ();
   error Api_errors.pool_auth_disable_failed_permission_denied ["host";"message"]
     ~doc:"The pool failed to disable the external authentication of at least one host." ();
+  error Api_errors.pool_joining_host_must_have_same_api_version ["host_api_version";"master_api_version"]
+    ~doc:"The host joining the pool must have the same API version as the pool master." ();
+  error Api_errors.pool_joining_host_must_have_same_db_schema ["host_db_schema";"master_db_schema"]
+    ~doc:"The host joining the pool must have the same database schema as the pool master." ();
 
   (* External directory service *)
   error Api_errors.subject_cannot_be_resolved []
@@ -4128,6 +4132,13 @@ let pool_update =
         field     ~in_product_since:rel_ely ~default_value:(Some (VSet [])) ~in_oss_since:None ~qualifier:StaticRO ~ty:(Set pool_update_after_apply_guidance) "after_apply_guidance" "What the client should do after this update has been applied.";
         field     ~in_oss_since:None ~qualifier:StaticRO ~ty:(Ref _vdi) "vdi" "VDI the update was uploaded to";
         field     ~in_product_since:rel_ely ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Set (Ref _host)) "hosts" "The hosts that have applied this update.";
+        field     ~in_product_since:rel_honolulu
+                  ~default_value:(Some (VBool false))
+                  ~in_oss_since:None
+                  ~qualifier:StaticRO
+                  ~ty:Bool
+                  "enforce_homogeneity"
+                  "Flag - if true, all hosts in a pool must apply this update";
       ]
     ()
 

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -56,6 +56,7 @@ let rel_indigo = "indigo"
 let rel_dundee = "dundee"
 let rel_dundee_plus = "dundee-plus"
 let rel_ely = "ely"
+let rel_honolulu = "honolulu"
 
 let release_order =
   [ rel_rio
@@ -79,6 +80,7 @@ let release_order =
   ; rel_dundee
   ; rel_dundee_plus
   ; rel_ely
+  ; rel_honolulu
   ]
 
 exception Unknown_release of string

--- a/ocaml/test/test_common.ml
+++ b/ocaml/test/test_common.ml
@@ -350,9 +350,26 @@ let make_pvs_cache_storage ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ~ref ~uuid ~host ~sR ~site ~size ~vDI;
   ref
 
-let make_pool_update ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
-    ?(name_label="") ?(name_description="") ?(version="") ?(installation_size=0L) ?(key="")
-    ?(after_apply_guidance=[]) ?(vdi=Ref.null) () =
-  let update_info = Xapi_pool_update.{uuid; name_label; name_description; version; key; installation_size; after_apply_guidance} in
+let make_pool_update ~__context
+    ?(ref=Ref.make ())
+    ?(uuid=make_uuid ())
+    ?(name_label="")
+    ?(name_description="")
+    ?(version="")
+    ?(installation_size=0L)
+    ?(key="")
+    ?(after_apply_guidance=[])
+    ?(enforce_homogeneity=false)
+    ?(vdi=Ref.null) () =
+  let update_info = Xapi_pool_update.
+    { uuid
+    ; name_label
+    ; name_description
+    ; version
+    ; key
+    ; installation_size
+    ; after_apply_guidance
+    ; enforce_homogeneity
+    } in
   Xapi_pool_update.create_update_record ~__context ~update:ref ~update_info ~vdi;
   ref

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -123,6 +123,8 @@ let _xapi_major = "xapi_major"
 let _xapi_minor = "xapi_minor"
 let _export_vsn = "export_vsn"
 let _dbv = "dbv"
+let _db_schema = "db_schema"
+
 
 (* When comparing two host versions, always treat a host that has platform_version defined as newer
  * than any host that does not have platform_version defined.

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -44,6 +44,7 @@ type update_info = {
   key: string;
   installation_size: int64;
   after_apply_guidance: API.after_apply_guidance list;
+  enforce_homogeneity: bool; (* true = all hosts in a pool must have this update *)
 }
 
 (** Mount a filesystem somewhere, with optional type *)
@@ -258,6 +259,9 @@ let parse_update_info xml =
       with
       | _ -> []
     in
+    let enforce_homogeneity =
+      Vm_platform.is_true ~key:"enforce-homogeneity" ~platformdata:attr ~default:false
+    in
     let is_name_description_node = function
       | Xml.Element ("name-description", _, _) -> true
       | _ -> false
@@ -266,16 +270,15 @@ let parse_update_info xml =
       | Xml.Element("name-description", _, [ Xml.PCData s ]) -> s
       | _ -> raise (Api_errors.Server_error(Api_errors.invalid_update, ["missing <name-description> in update.xml"]))
     in
-    let update_info = {
-      uuid = uuid;
-      name_label = name_label;
-      name_description = name_description;
-      version = version;
-      key = Filename.basename key;
-      installation_size = installation_size;
-      after_apply_guidance = guidance;
-    } in
-    update_info
+      { uuid
+      ; name_label
+      ; name_description
+      ; version
+      ; key = Filename.basename key
+      ; installation_size
+      ; after_apply_guidance = guidance
+      ; enforce_homogeneity
+      }
   | _ -> raise (Api_errors.Server_error(Api_errors.invalid_update, ["missing <update> in update.xml"]))
 
 let extract_applied_update_info applied_uuid  =
@@ -368,6 +371,7 @@ let create_update_record ~__context ~update ~update_info ~vdi =
     ~key:update_info.key
     ~after_apply_guidance:update_info.after_apply_guidance
     ~vdi:vdi
+    ~enforce_homogeneity:update_info.enforce_homogeneity
 
 let introduce ~__context ~vdi =
   ignore(Unixext.mkdir_safe Xapi_globs.host_update_dir 0o755);


### PR DESCRIPTION
This is a backport from the master branch. The main difference is that we don't 
increment the API version because that would make it equal to the API version of
another release. It's also worth noting this commit replaces an existing overly
restrictive check with this new one.

This commit modifies checks before a host can join a pool.
The joining host compares its set of updates with the updates on each
host in the pool.  These sets must be equal for the host being able to join
the pool.  The comparison only considers updates that are marked as
enforce-homogeneity="true" in their update.xml definition -- see below.
This attribute is new. The absence of the enforce-homogeneity attribute
in an update defaults to enforce-homogeneity=false. This makes the code
backward compatible with updates that don't have this annotation.

Typically, code updates will have enforce-homogeneity=true but driver
updates will have enforce-homogeneity=false such that hosts in the pool
can have different sets of drivers but have the same code updates.

The implementation changes the datamodel: class pool_update gets a new
field enforce_homogeneity. Note: the API version is not incremented
because this would make the API version equal to the one of another
release. We are taking a risk here.

    <update after-apply-guidance="restartHost" build-number="XS71ECU1/58"
      control="control-XS71ECU1" enforce-homogeneity="true"
      installation-size="566138764" key="RPM-GPG-KEY-XS-Eng-Test.pub"
      name-label="XS71ECU1" uuid="5eea06f3-4990-497d-af7a-d0bba6f9f96a"
      version="1.0">

      <name-description>Cumulative Update 1 (CU-1)</name-description>
      <rollsup name-label="XS71E001" uuid="fc438a32-0214-4193-8676-9feb121c6997"/>
      <rollsup name-label="XS71E002" uuid="9768c0f1-d111-4ee4-ac85-fe9ee37b5726"/>
      <rollsup name-label="XS71E003" uuid="b80ea320-f9ae-414c-a14d-781861b5c0ac"/>
      <rollsup name-label="XS71E004" uuid="a4ebb0e4-bfcb-48da-8b42-4673d3111d29"/>
      <rollsup name-label="XS71E005" uuid="d2df0c4f-eaf6-4778-a754-19a8b7739b5c"/>
      <rollsup name-label="XS71E006" uuid="008f1b43-8f02-40a4-8475-28f15dbfd1fc"/>
      <rollsup name-label="XS71E007" uuid="04bcb1f7-3bdc-440d-9cac-9d2a87746b24"/>
      <rollsup name-label="XS71E008" uuid="e3c382d7-dba5-4809-9901-d0d15ee02ad9"/>
    </update>

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>
  
 