### PR TITLE
CP-23026 mark new field 'enforce_homogeneity' as introduced in rel_honolulu

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4241,7 +4241,7 @@ let pool_update =
         field     ~in_product_since:rel_ely ~default_value:(Some (VSet [])) ~in_oss_since:None ~qualifier:StaticRO ~ty:(Set pool_update_after_apply_guidance) "after_apply_guidance" "What the client should do after this update has been applied.";
         field     ~in_oss_since:None ~qualifier:StaticRO ~ty:(Ref _vdi) "vdi" "VDI the update was uploaded to";
         field     ~in_product_since:rel_ely ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Set (Ref _host)) "hosts" "The hosts that have applied this update.";
-        field     ~in_product_since:rel_ely
+        field     ~in_product_since:rel_honolulu
                   ~default_value:(Some (VBool false))
                   ~in_oss_since:None
                   ~qualifier:StaticRO

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -56,6 +56,7 @@ let rel_indigo = "indigo"
 let rel_dundee = "dundee"
 let rel_ely = "ely"
 let rel_falcon = "falcon"
+let rel_honolulu = "honolulu"
 let rel_inverness = "inverness"
 
 type api_release = {
@@ -177,6 +178,11 @@ let release_order_full = [{
       version_major = 2;
       version_minor = 6;
       branding   = "XenServer 7.1";
+    }; {
+      code_name     = Some rel_honolulu;
+      version_major = 2;
+      version_minor = 6;
+      branding   = "XenServer 7.1 CU1";
     }; {
       code_name     = Some rel_falcon;
       version_major = 2;

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -180,9 +180,10 @@ let release_order_full = [{
       branding   = "XenServer 7.1";
     }; {
       code_name     = Some rel_honolulu;
+      (** TODO replace with the actual version numbers when Honolulu is released *)
       version_major = 2;
       version_minor = 6;
-      branding   = "XenServer 7.1 CU1";
+      branding   = "Unreleased";
     }; {
       code_name     = Some rel_falcon;
       version_major = 2;

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -111,6 +111,40 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
         raise (Api_errors.Server_error (code, ["The pool uses v6d. Pool edition list = " ^ pool_edn_list_str]))
   in
 
+  (** [assert_version_matches] takes a list of [keys] into
+   * [API.host_software_version] and compares each version on
+   * localhost and pool master. A version difference or an
+   * undefined key leads to an assertion and blocks a host to join.
+   *)
+  let assert_version_matches keys =
+    let local =
+      Helpers.get_localhost ~__context
+      |> fun self -> Db.Host.get_record ~__context ~self
+      |> fun r -> r.API.host_software_version in
+    let master =
+      get_master rpc session_id
+      |> fun self -> Client.Host.get_record ~rpc ~session_id ~self
+      |> fun r -> r.API.host_software_version  in
+    let api_error fmt =
+      Printf.kprintf (fun msg ->
+        raise Api_errors.(Server_error(pool_hosts_not_homogeneous,[msg]))) fmt in
+    let compare key =
+      try
+        let local_v  = List.assoc key local  in
+        let master_v = List.assoc key master in
+        if local_v <> master_v then begin
+          error "pool join: software versions differ localhost[%s]=%s <> master[%s]=%s"
+            key local_v key master_v;
+          api_error "localhost[%s]=%s master[%s]=%s" (* avoid i18n *)
+            key local_v key master_v;
+        end
+      with Not_found ->
+        error "pool join: software version for key %s is undefined" key;
+        api_error "%s" key (* avoid i18n *)
+    in
+      List.iter compare keys
+  in
+
   let assert_api_version_matches () =
     let master = get_master rpc session_id in
     let candidate_slave = Helpers.get_localhost ~__context in
@@ -434,6 +468,7 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
   assert_api_version_matches ();
   assert_db_schema_matches ();
   assert_homogeneous_updates ();
+  assert_version_matches Xapi_globs.([_product_version; _product_brand]);
   assert_homogeneous_primary_address_type ()
 
 let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) : API.ref_host =


### PR DESCRIPTION

This commit fixes an oversight: the new field in the API Pool_update.enforce_homogeneity was introduced for Honolulu, which must be defined first.