### PR TITLE
CP-23026 bump database schema to 5.109 after change

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 108
+let schema_minor_vsn = 109
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5


### PR DESCRIPTION
The previous commit did not bump the database schema in the belief that
it would run into the version of the Falcon release. However, this is
not the case and it can be safely bumped as it should have been already.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>