### PR TITLE
CP-23026 add database schema version to software_version ()

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -474,6 +474,7 @@ let make_software_version ~__context =
     "xencenter_min", Xapi_globs.xencenter_min_verstring;
     "xencenter_max", Xapi_globs.xencenter_max_verstring;
     "network_backend", Network_interface.string_of_kind (Net.Bridge.get_kind dbg ());
+    Xapi_globs._db_schema, Printf.sprintf "%d.%d" Datamodel.schema_major_vsn Datamodel.schema_minor_vsn;
   ] @
   (option_to_list "oem_manufacturer" info.oem_manufacturer) @
   (option_to_list "oem_model" info.oem_model) @


### PR DESCRIPTION
Function assert_db_schema_matches relies on the database schema version
being available from Client.Host.get_software_version. This commit adds
the code that puts it there. It is backported from the master branch.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>