### PR TITLE
Revert CP-23026 pool join rules until automated testing is available

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 132
+let schema_minor_vsn = 131
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -4241,13 +4241,6 @@ let pool_update =
         field     ~in_product_since:rel_ely ~default_value:(Some (VSet [])) ~in_oss_since:None ~qualifier:StaticRO ~ty:(Set pool_update_after_apply_guidance) "after_apply_guidance" "What the client should do after this update has been applied.";
         field     ~in_oss_since:None ~qualifier:StaticRO ~ty:(Ref _vdi) "vdi" "VDI the update was uploaded to";
         field     ~in_product_since:rel_ely ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Set (Ref _host)) "hosts" "The hosts that have applied this update.";
-        field     ~in_product_since:rel_honolulu
-                  ~default_value:(Some (VBool false))
-                  ~in_oss_since:None
-                  ~qualifier:StaticRO
-                  ~ty:Bool
-                  "enforce_homogeneity"
-                  "Flag - if true, all hosts in a pool must apply this update";
       ]
     ()
 

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -56,7 +56,6 @@ let rel_indigo = "indigo"
 let rel_dundee = "dundee"
 let rel_ely = "ely"
 let rel_falcon = "falcon"
-let rel_honolulu = "honolulu"
 let rel_inverness = "inverness"
 
 type api_release = {
@@ -178,12 +177,6 @@ let release_order_full = [{
       version_major = 2;
       version_minor = 6;
       branding   = "XenServer 7.1";
-    }; {
-      code_name     = Some rel_honolulu;
-      (** TODO replace with the actual version numbers when Honolulu is released *)
-      version_major = 2;
-      version_minor = 6;
-      branding   = "Unreleased";
     }; {
       code_name     = Some rel_falcon;
       version_major = 2;

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -1095,7 +1095,6 @@ let pool_update_record rpc session_id update =
         make_field ~name:"installation-size"   ~get:(fun () -> Int64.to_string (x ()).API.pool_update_installation_size) ();
         make_field ~name:"hosts"               ~get:(fun () -> String.concat ", " (get_hosts ())) ~get_set:get_hosts ();
         make_field ~name:"after-apply-guidance" ~get:(fun () -> String.concat ", " (after_apply_guidance ())) ~get_set:after_apply_guidance ();
-        make_field ~name:"enforce-homogeneity" ~get:(fun () -> string_of_bool (x ()).API.pool_update_enforce_homogeneity) ();
       ]}
 
 let host_cpu_record rpc session_id host_cpu =

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -353,26 +353,9 @@ let make_pvs_cache_storage ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ~ref ~uuid ~host ~sR ~site ~size ~vDI;
   ref
 
-let make_pool_update ~__context
-    ?(ref=Ref.make ())
-    ?(uuid=make_uuid ())
-    ?(name_label="")
-    ?(name_description="")
-    ?(version="")
-    ?(installation_size=0L)
-    ?(key="")
-    ?(after_apply_guidance=[])
-    ?(enforce_homogeneity=false)
-    ?(vdi=Ref.null) () =
-  let update_info = Xapi_pool_update.
-    { uuid
-    ; name_label
-    ; name_description
-    ; version
-    ; key
-    ; installation_size
-    ; after_apply_guidance
-    ; enforce_homogeneity
-    } in
+let make_pool_update ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
+    ?(name_label="") ?(name_description="") ?(version="") ?(installation_size=0L) ?(key="")
+    ?(after_apply_guidance=[]) ?(vdi=Ref.null) () =
+  let update_info = Xapi_pool_update.{uuid; name_label; name_description; version; key; installation_size; after_apply_guidance} in
   Xapi_pool_update.create_update_record ~__context ~update:ref ~update_info ~vdi;
   ref

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -143,36 +143,6 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
     end
   in
 
-  let assert_homogeneous_updates () =
-    let module S      = Helpers.StringSet in
-    let local_host    = Helpers.get_localhost ~__context in
-    let local_uuid    = Db.Host.get_uuid ~__context ~self:local_host in
-    let updates_on ~rpc ~session_id host =
-      Client.Host.get_updates ~rpc ~session_id ~self:host
-      |> List.map (fun self -> Client.Pool_update.get_record ~rpc ~session_id ~self)
-      |> List.filter (fun upd -> upd.API.pool_update_enforce_homogeneity = true)
-      |> List.map (fun upd -> upd.API.pool_update_uuid)
-      |> S.of_list in
-    let local_updates =
-      Helpers.call_api_functions ~__context (fun rpc session_id ->
-        updates_on ~rpc ~session_id local_host) in
-    (* iterate over all pool hosts and compare patches to local host *)
-    Client.Host.get_all rpc session_id |> List.iter (fun pool_host ->
-      let remote_updates = updates_on rpc session_id pool_host in
-      if not (S.equal local_updates remote_updates) then begin
-        let remote_uuid  = Client.Host.get_uuid rpc session_id pool_host in
-        let diff xs ys   = S.diff xs ys |> S.elements |> String.concat "," in
-        let reason       = [remote_uuid] in
-        error
-          "Pool join: Updates differ. Only on pool host %s: {%s} -- only on local host %s: {%s}"
-          remote_uuid
-          (diff remote_updates local_updates)
-          local_uuid
-          (diff local_updates remote_updates);
-        raise Api_errors.(Server_error(pool_hosts_not_homogeneous,reason))
-      end)
-  in
-
   (* CP-700: Restrict pool.join if AD configuration of slave-to-be does not match *)
   (* that of master of pool-to-join *)
   let assert_external_auth_matches () =
@@ -433,7 +403,6 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
   (* CA-247399: check first the API version and then the database schema *)
   assert_api_version_matches ();
   assert_db_schema_matches ();
-  assert_homogeneous_updates ();
   assert_homogeneous_primary_address_type ()
 
 let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) : API.ref_host =


### PR DESCRIPTION
This commit reverts commits that together implement the pool join rules
that consider only "enforced" updates. This code will be added back once
automated testing is in place. See CP-23026 and CP-22959.

modified:   ocaml/idl/datamodel.ml
modified:   ocaml/idl/datamodel_types.ml
modified:   ocaml/xapi/records.ml
modified:   ocaml/xapi/test_common.ml
modified:   ocaml/xapi/xapi_pool.ml
modified:   ocaml/xapi/xapi_pool_update.ml

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>