### PR TITLE
CP-23026 CA-258536 update update records at startup

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -452,16 +452,23 @@ let resync_host ~__context ~host =
     debug "pool_update.resync_host scanning directory %s for applied updates" update_applied_dir;
     let updates_applied = try Array.to_list (Sys.readdir update_applied_dir) with _ -> [] in
     let update_uuids = List.filter (fun update -> Uuid.is_uuid update) updates_applied in
-    let not_existing_uuids = List.filter (fun update_uuid ->
-        try ignore (Db.Pool_update.get_by_uuid ~__context ~uuid:update_uuid); false
-        with _ -> true) update_uuids in
-
+    let exists uuid =
+      try Some (Db.Pool_update.get_by_uuid ~__context ~uuid)
+      with _ -> None in
     (* Handle the updates rolluped and create records accordingly *)
     List.iter (fun update_uuid ->
         let update_info = extract_applied_update_info update_uuid in
-        let update = Ref.make () in
-        create_update_record ~__context ~update:update ~update_info ~vdi:Ref.null
-      ) not_existing_uuids;
+        ( match exists update_uuid with
+          | Some self ->
+            (* re-interpret the enforce_homogeneity flag CP-258536 *)
+            debug "pool_update.resync_host: update %s exists - updating it" update_uuid;
+            Db.Pool_update.set_enforce_homogeneity ~__context ~self
+              ~value:update_info.enforce_homogeneity
+          | None ->
+            let update = Ref.make () in
+            debug "pool_update.resync_host: update %s not in database - creating it" update_uuid;
+            create_update_record ~__context ~update:update ~update_info ~vdi:Ref.null
+        )) update_uuids;
     let update_refs = List.map (fun update_uuid ->
         Db.Pool_update.get_by_uuid ~__context ~uuid:update_uuid) update_uuids in
     Db.Host.set_updates ~__context ~self:host ~value:update_refs;


### PR DESCRIPTION
This commit changes the behaviour of Xapi_pool_update.resync_host which
reads the updates from the file system and is called during startup.
Previously, new updates records were created for updates that were
unknown. This commit changes this this behaviour: for an update found in
the file system a potentially existing record is partially updated.

The rationale for this change is that an updated xapi at startup might
interpret an existing update's meta data differently than before. This
provides an opportunity to correct previous wrong or inconvenient
interpretations. This particular instance was triggered by the
introduction of the enforce_homogeneity attribute.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>