### PR TITLE
Xapi_vdi.update_allowed_operations: consider all VDI ops

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -241,7 +241,7 @@ let update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records
   let allowed =
     let check x = match check_operation_error ~__context ~sr_records ~pbd_records ~vbd_records ha_enabled all self x with None ->  [ x ] | _ -> [] in
     List.fold_left (fun accu op -> check op @ accu) []
-      [ `snapshot; `copy; `clone; `destroy; `resize; `update; `generate_config; `resize_online; `forget ] in
+      (Listext.List.set_difference Xapi_vdi_helpers.all_ops [`blocked]) in
   Db.VDI.set_allowed_operations ~__context ~self ~value:allowed
 
 let update_allowed_operations ~__context ~self : unit =

--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -24,6 +24,25 @@ open Threadext
 module D=Debug.Make(struct let name="xapi" end)
 open D
 
+let all_ops: API.vdi_operations list =
+  [ `blocked
+  ; `clone
+  ; `copy
+  ; `destroy
+  ; `disable_cbt
+  ; `enable_cbt
+  ; `force_unlock
+  ; `forget
+  ; `generate_config
+  ; `mirror
+  ; `resize
+  ; `resize_online
+  ; `scan
+  ; `set_on_boot
+  ; `snapshot
+  ; `update
+  ]
+
 (* CA-26514: Block operations on 'unmanaged' VDIs *)
 let assert_managed ~__context ~vdi =
   if not (Db.VDI.get_managed ~__context ~self:vdi)


### PR DESCRIPTION
except for `blocked.

This function did not consider some VDI operations for some reason, it
only considered a subset of them. Now it considers all VDI operations,
therefore the allowed_operations field of the VDI will now contain new
VDI operations.

The following 6 VDI operations were not considered before by
Xapi_vdi.update_allowed_operations: enable_cbt, disable_cbt,
force_unlock, mirror, scan, set_on_boot. Only the enable_cbt,
disable_cbt, and set_on_boot operations have user-visible VDI methods
with the same name, `mirror is used for VDI.pool_migrate,
VDI.force_unlock is hidden from the docs, and it seems that `scan is not
used at all.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>