### PR TITLE
datamodel: remove `scan from vdi_operations enum

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6302,8 +6302,7 @@ let vdi_update = call
 
 let vdi_operations =
   Enum ("vdi_operations",
-        [ "scan", "Scanning backends for new or deleted VDIs";
-          "clone", "Cloning the VDI";
+        [ "clone", "Cloning the VDI";
           "copy", "Copying the VDI";
           "resize", "Resizing the VDI";
           "resize_online", "Resizing the VDI which may or may not be online";

--- a/ocaml/xapi/record_util.ml
+++ b/ocaml/xapi/record_util.ml
@@ -98,7 +98,6 @@ let host_operation_to_string = function
   | `vm_migrate -> "VM.migrate"
 
 let vdi_operation_to_string: API.vdi_operations -> string = function
-  | `scan -> "scan"
   | `clone -> "clone"
   | `copy -> "copy"
   | `resize -> "resize"

--- a/ocaml/xapi/test_xapi_vbd_helpers.ml
+++ b/ocaml/xapi/test_xapi_vbd_helpers.ml
@@ -48,7 +48,7 @@ let run_assert_equal_with_vdi ~__context ?(cmp = my_cmp) ?(expensive_sharing_che
 let test_ca253933_invalid_operations () =
   let __context = Mock.make_context_with_new_db "Mock context" in
   (* When attach a VDI which is under operation which cannot perform live, should raise other_operation_in_progress *)
-  let invalid_operations =  [`scan ; `resize ; `destroy ; `forget ; `update ; `force_unlock ; `generate_config; `snapshot; `resize_online; `blocked; `clone] in
+  let invalid_operations =  [`resize ; `destroy ; `forget ; `update ; `force_unlock ; `generate_config; `snapshot; `resize_online; `blocked; `clone] in
   let operation_is_invalid op =
     run_assert_equal_with_vdi ~__context
       ~vdi_fun:(fun sr_ref ->

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -29,7 +29,6 @@ let check_sm_feature_error (op:API.vdi_operations) sm_features sr =
   let required_sm_feature = Smint.(match op with
   | `forget
   | `copy
-  | `scan
   | `force_unlock
   | `blocked
     -> None
@@ -160,13 +159,13 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
       else
       let allowed_for_cbt_metadata_vdi = match op with
         | `clone | `copy | `disable_cbt | `enable_cbt | `mirror | `resize | `resize_online | `snapshot | `set_on_boot -> false
-        | `blocked | `destroy | `force_unlock | `forget | `generate_config | `scan | `update -> true in
+        | `blocked | `destroy | `force_unlock | `forget | `generate_config | `update -> true in
       if not allowed_for_cbt_metadata_vdi && record.Db_actions.vDI_type = `cbt_metadata
       then Some (Api_errors.vdi_incompatible_type, [ _ref; Record_util.vdi_type_to_string `cbt_metadata ])
       else
       let allowed_when_cbt_enabled = match op with
         | `mirror | `set_on_boot -> false
-        | `blocked | `clone | `copy | `destroy | `disable_cbt | `enable_cbt | `force_unlock | `forget | `generate_config | `resize | `resize_online | `scan | `snapshot | `update -> true in
+        | `blocked | `clone | `copy | `destroy | `disable_cbt | `enable_cbt | `force_unlock | `forget | `generate_config | `resize | `resize_online | `snapshot | `update -> true in
       if not allowed_when_cbt_enabled && record.Db_actions.vDI_cbt_enabled
       then Some (Api_errors.vdi_cbt_enabled, [_ref])
       else (
@@ -221,7 +220,7 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
           else if record.Db_actions.vDI_on_boot = `reset
           then Some (Api_errors.vdi_on_boot_mode_incompatible_with_operation, [])
           else None
-        | `mirror | `clone | `generate_config | `scan | `force_unlock | `set_on_boot | `blocked | `update -> None
+        | `mirror | `clone | `generate_config | `force_unlock | `set_on_boot | `blocked | `update -> None
       )
 
 let assert_operation_valid ~__context ~self ~(op:API.vdi_operations) =

--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -37,7 +37,6 @@ let all_ops: API.vdi_operations list =
   ; `mirror
   ; `resize
   ; `resize_online
-  ; `scan
   ; `set_on_boot
   ; `snapshot
   ; `update


### PR DESCRIPTION
It seems that this operation is not currently used.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>