### PR TITLE
Further tweaks to make building the pdf more environment agnostic.

### DIFF
--- a/ocaml/doc/README.md
+++ b/ocaml/doc/README.md
@@ -8,4 +8,4 @@ install `pandoc` and `pdflatex`.
 
 To convert the images only, run `sh doc-convert.sh`.
 
-To also generated the pdf run `sh doc-convert.sh --pdf`.
+To also generate the pdf run `sh doc-convert.sh --pdf`.

--- a/ocaml/doc/doc-convert.sh
+++ b/ocaml/doc/doc-convert.sh
@@ -4,8 +4,8 @@ set -x
 
 GRAPHVIZ_FLAGS="-Tpng"
 
-dot vm-lifecycle.dot ${GRAPHVIZ_FLAGS} -o img-vm-lifecycle
-dot classes.dot ${GRAPHVIZ_FLAGS} -o img-classes
+dot vm-lifecycle.dot ${GRAPHVIZ_FLAGS} -o vm-lifecycle.png
+dot classes.dot ${GRAPHVIZ_FLAGS} -o classes.png
 
 if  [ ! "$1" = "--pdf" ]; then
     exit 0

--- a/ocaml/doc/templates/cover.mustache
+++ b/ocaml/doc/templates/cover.mustache
@@ -1,11 +1,11 @@
 ---
 title: |
   \IfFileExists{logo.pdf}{\includegraphics[width=150px]{logo.pdf}\break}{}
-  Citrix XenServer Management API\
+  Citrix XenServer Management API\break
   Version {{api_version_major}}.{{api_version_minor}}
 date: |
-  Published {{current_month}}-{{current_year}}\
-  \
+  Published {{current_month}}-{{current_year}}\break
+  \break
   &copy; 2006-{{current_year}} Citrix Systems, Inc. All Rights Reserved.
 
 papersize: A4

--- a/ocaml/doc/vm-lifecycle.md
+++ b/ocaml/doc/vm-lifecycle.md
@@ -3,7 +3,7 @@
 The following diagram shows the states that a VM can be in
 and the API calls that can be used to move the VM between these states.
 
-![VM lifecycle](img-vm-lifecycle "VM Lifecycle")
+![VM lifecycle](vm-lifecycle.png "VM Lifecycle")
 
 ## VM boot parameters
 

--- a/ocaml/doc/wire-protocol.md
+++ b/ocaml/doc/wire-protocol.md
@@ -51,12 +51,12 @@ These types are mapped onto XML-RPC types in a straight-forward manner:
     </array>
 ```
 
-* for types `k` and `v`, our type `(k → v) map` maps onto an
+* for types `k` and `v`, our type `(k -> v) map` maps onto an
   XML-RPC `<struct>`, with the key as the name of the struct.  Note that the
-  `(k → v) map` type is only valid when `k` is a `string`, `ref`, or
+  `(k -> v) map` type is only valid when `k` is a `string`, `ref`, or
   `int`, and in each case the keys of the maps are stringified as
-  above. For example, the `(string → double) map` containing the mappings
-  _Mike → 2.3_ and _John → 1.2_ would be represented as:
+  above. For example, the `(string -> double) map` containing the mappings
+  _Mike &#45;&gt; 2.3_ and _John &#45;&gt; 1.2_ would be represented as:
 
 ```xml
     <value>

--- a/ocaml/idl/markdown_backend.ml
+++ b/ocaml/idl/markdown_backend.ml
@@ -76,7 +76,7 @@ let rec of_ty_verbatim = function
   | DateTime -> "datetime"
   | Enum (name, things) -> name
   | Set x -> sprintf "%s set" (of_ty_verbatim x)
-  | Map (a, b) -> sprintf "(%s → %s) map" (of_ty_verbatim a) (of_ty_verbatim b)
+  | Map (a, b) -> sprintf "(%s -> %s) map" (of_ty_verbatim a) (of_ty_verbatim b)
   | Ref obj -> obj ^ " ref"
   | Record obj -> obj ^ " record"
 
@@ -89,7 +89,7 @@ let rec of_ty = function
   | DateTime -> "datetime"
   | Enum (name, things) -> escape name
   | Set x -> (of_ty x) ^ " set"
-  | Map (a, b) -> "(" ^ (of_ty a) ^ " → " ^ (of_ty b) ^ ") map"
+  | Map (a, b) -> "(" ^ (of_ty a) ^ " &#45;&gt; " ^ (of_ty b) ^ ") map"
   | Ref obj -> (escape obj) ^ " ref"
   | Record obj -> (escape obj) ^ " record"
 
@@ -309,7 +309,7 @@ Fields that are bound together are shown in the following table:
   printer "
 The following figure represents bound fields (as specified above) diagramatically, using crow's foot notation to specify one-to-one, one-to-many or many-to-many relationships:
 
-![Class relationships](img-classes 'Class relationships')
+![Class relationships](classes.png 'Class relationships')
 
 ## Types
 
@@ -333,7 +333,7 @@ The following type constructors are used:
 |:-----------------|:-------------------------------------------------------|
 |_c_ ref           |reference to an object of class _c_                     |
 |_t_ set           |a set of elements of type _t_                           |
-|(_a → b_) map     |a table mapping values of type _a_ to values of type _b_|
+|(_a &#45;&gt; b_) map     |a table mapping values of type _a_ to values of type _b_|
 
 ### Enumeration types
 
@@ -405,9 +405,9 @@ like this:
 Note that `ErrorDescription` value is an array of string values. The
 first element of the array is an error code; the remainder of the array are
 strings representing error parameters relating to that code.  In this case,
-the client has attempted to add the mapping _Customer →
+the client has attempted to add the mapping _Customer &#45;&gt;
 eSpiel Incorporated_ to a Map, but it already contains the mapping
-_Customer → eSpiel Inc._, and so the request has failed.
+_Customer &#45;&gt; eSpiel Inc._, and so the request has failed.
 
 Each possible error code is documented in the following section.
 


### PR DESCRIPTION
It seems not all systems understand notation the same way and to keep things simple and maintenance overheads low I'd rather we didn't have to resort to installing too many packages. The suggested changes work ok with only pandoc and texlive on centos 7 and ubuntu 16 (presumably on mac too).