### PR TITLE
.merlin: search source dir for source files first before _build

### DIFF
--- a/ocaml/.merlin
+++ b/ocaml/.merlin
@@ -1,9 +1,9 @@
 PKG oUnit
 PKG ppx_deriving_rpc rpclib ppx_sexp_conv sexpr threads http-svr gzip uuid xcp xml-light2 uuid xcp xcp-inventory oPasswd pciutil pci ezxenstore oclock sha tar tar.unix tapctl xenctrl xcp.rrd xcp.storage xcp.xen xcp.network xcp.v6 xcp.memory rrdd-plugin cdrom netdev stdext stunnel systemd xapi-test-utils
 B +threads
+S ../_build/ocaml/**
+B ../_build/ocaml/**
 S ./
 B ./
 S ./**
 B ./**
-S ../_build/ocaml/**
-B ../_build/ocaml/**


### PR DESCRIPTION
Sometimes I go to the definition of a symbol from a different file using
merlin, and edit that file. However, with the old merlin file I jumped
to the source file in the _build directory, and my modifications got
lost after a "make clean".

I changed the order of entries in the .merlin file, so that for existing
source files, we will go to the source directory now instead of _build,
but auto-generated files are still found in the _build directory.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>