### PR TITLE
CA-258652/SCTX-2565: Get initial host memory from squeezed

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -140,17 +140,16 @@ let record_host_memory_properties ~__context =
 
   let metrics = Db.Host.get_metrics ~__context ~self in
   Db.Host_metrics.set_memory_total ~__context ~self:metrics ~value:total_memory_bytes;
-  let boot_memory_file = Xapi_globs.initial_host_free_memory_file in
-  let boot_memory_string =
+  let boot_memory_bytes =
     try
-      Some (Unixext.string_of_file boot_memory_file)
+      let dbg = Context.string_of_task __context in
+      Some (Memory_client.Client.get_host_initial_free_memory dbg)
     with e ->
-      warn "Could not read host free memory file. This may prevent \
-            			VMs from being started on this host. (%s)" (Printexc.to_string e);
+      warn "Failed to get host free memory from ballooning service. This may \
+        prevent VMs from being started on this host. (%s)" (Printexc.to_string e);
       None in
   maybe
-    (fun boot_memory_string ->
-       let boot_memory_bytes = Int64.of_string boot_memory_string in
+    (fun boot_memory_bytes ->
        (* Host memory overhead comes from multiple sources:         *)
        (* 1. obvious overhead: (e.g. Xen, crash kernel).            *)
        (*    appears as used memory.                                *)
@@ -174,7 +173,7 @@ let record_host_memory_properties ~__context =
        Db.Host.set_memory_overhead ~__context ~self ~value:
          (obvious_overhead_memory_bytes ++ nonobvious_overhead_memory_bytes);
     )
-    boot_memory_string
+    boot_memory_bytes
 
 (* -- used this for testing uniqueness constraints executed on slave do not kill connection.
    Committing commented out vsn of this because it might be useful again..

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -482,50 +482,6 @@ let resynchronise_ha_state () =
     (* Critical that we don't continue as a master and use shared resources *)
     error "Caught exception resynchronising state of HA system: %s" (ExnHelper.string_of_exn e)
 
-(* Calculates the amount of free memory on the host at boot time. *)
-(* Returns a result that is equivalent to (T - X), where:         *)
-(*     T = total memory in host.                                  *)
-(*     X = host virtualization overhead:                          *)
-(*         memory used by Xen code, heap and crash kernel.        *)
-(* Actually returns the current value of (F + S + Z), where:      *)
-(*     F = host free memory.                                      *)
-(*     S = host scrub memory.                                     *)
-(*     Z = host memory used by domain 0.                          *)
-(* This relies on the equivalence (T = X + F + S + Z).            *)
-(* Warning! This function assumes that:                           *)
-(*     1. Domain 0 is currently in an unballooned state.          *)
-(*     2. No other domains have been started.                     *)
-let calculate_boot_time_host_free_memory () =
-  let ( + ) = Nativeint.add in
-  let open Xenctrl in
-  let host_info = with_intf (fun xc -> physinfo xc) in
-  let host_free_pages = host_info.free_pages in
-  let host_scrub_pages = host_info.scrub_pages in
-  match Create_misc.read_dom0_memory_usage () with
-  | None -> failwith "can't query balloon driver"
-  | Some domain0_bytes ->
-    let domain0_total_pages = XenopsMemory.pages_of_bytes_used domain0_bytes in
-    let boot_time_host_free_pages =
-      host_free_pages + host_scrub_pages + (Int64.to_nativeint domain0_total_pages) in
-    let boot_time_host_free_kib =
-      pages_to_kib (Int64.of_nativeint boot_time_host_free_pages) in
-    Int64.mul 1024L boot_time_host_free_kib
-
-(* Read the free memory on the host and record this in the db. This is used *)
-(* as the baseline for memory calculations in the message forwarding layer. *)
-let record_boot_time_host_free_memory () =
-  if not (Unixext.file_exists Xapi_globs.initial_host_free_memory_file) then begin
-    try
-      let free_memory = calculate_boot_time_host_free_memory () in
-      Unixext.mkdir_rec (Filename.dirname Xapi_globs.initial_host_free_memory_file) 0o700;
-      Unixext.write_string_to_file
-        Xapi_globs.initial_host_free_memory_file
-        (Int64.to_string free_memory)
-    with e ->
-      error "Could not record host free memory. This may prevent VMs from being started on this host. (%s)"
-        (Printexc.to_string e)
-  end
-
 (** Reset the networking-related metadata for this host if the command [xe-reset-networking]
  *  was executed before the restart. *)
 let check_network_reset () =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -86,7 +86,6 @@ let http_realm = "xapi"
 let log_config_file = ref (Filename.concat "/etc/xensource" "log.conf")
 let remote_db_conf_fragment_path = ref (Filename.concat "/etc/xensource" "remote.db.conf")
 let cpu_info_file = ref (Filename.concat "/etc/xensource" "boot_time_cpus")
-let initial_host_free_memory_file = "/var/run/nonpersistent/xapi/boot_time_memory"
 let requires_reboot_file = "/var/run/nonpersistent/xapi/host-requires-reboot"
 let using_rrds = ref false
 

--- a/ocaml/xapi/xapi_main.ml
+++ b/ocaml/xapi/xapi_main.ml
@@ -36,7 +36,4 @@ let _ =
   Stdext.Unixext.mkdir_rec (Filename.concat "/var/lib/xcp" "debug") 0o700;
   Unix.chdir (Filename.concat "/var/lib/xcp" "debug");
 
-  (* WARNING! Never move this function call into the list of startup tasks. *)
-  record_boot_time_host_free_memory ();
-
   watchdog server_init


### PR DESCRIPTION
Prior to this fix, xapi was responsible for calculating the
initial host free memory and recording it in a file in dom0.
This caused an issue on hosts with a CVM; xapi would exclude
the CVM memory in its calculation but it would include it in
subsequent reboots; this happened because, on firstboot, the
CVM is started after xapi, but on reboots it starts before.

squeezed always starts before the CVM and xapi, so the
calculation is moved to squeezed to ensure predictable
behaviour.