### PR TITLE
CA-259579: Introduce ballooning timeout before migration error

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1052,7 +1052,8 @@ let _ =
     ~doc:"You attempted to start a VM that's attached to more than one VDI with a timeoffset marked as reset-on-boot." ();
   error Api_errors.vms_failed_to_cooperate [ ]
     ~doc:"The given VMs failed to release memory when instructed to do so" ();
-
+  error Api_errors.ballooning_timeout_before_migration [ "vm" ]
+    ~doc:"Timeout trying to balloon down memory before VM migration. If the error occurs repeatedly, consider increasing the memory-dynamic-min value." ();
 
   (* Storage errors *)
   error Api_errors.sr_not_attached ["sr"]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -410,6 +410,7 @@ let duplicate_mac_seed = "DUPLICATE_MAC_SEED"
 let client_error = "CLIENT_ERROR"
 
 let ballooning_disabled = "BALLOONING_DISABLED"
+let ballooning_timeout_before_migration = "BALLOONING_TIMEOUT_BEFORE_MIGRATION"
 
 let ha_host_is_armed = "HA_HOST_IS_ARMED"
 let ha_is_enabled = "HA_IS_ENABLED"

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -226,11 +226,13 @@ let pool_migrate ~__context ~vm ~host ~options =
         end;
         match exn with
         | Xenops_interface.Failed_to_acknowledge_shutdown_request ->
-          raise (Api_errors.Server_error (Api_errors.vm_failed_shutdown_ack, []))
+          raise Api_errors.(Server_error (vm_failed_shutdown_ack, []))
         | Xenops_interface.Cancelled _ ->
           TaskHelper.raise_cancelled ~__context
         | Xenops_interface.Storage_backend_error (code, _) ->
-          raise (Api_errors.Server_error (Api_errors.sr_backend_failure, [code]))
+          raise Api_errors.(Server_error (sr_backend_failure, [code]))
+        | Xenops_interface.Ballooning_timeout_before_migration ->
+          raise Api_errors.(Server_error (ballooning_timeout_before_migration, [Ref.string_of vm]))
         | _ -> raise exn
     )
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2308,7 +2308,6 @@ let transform_xenops_exn ~__context ~vm queue_name f =
       | Vms_failed_to_cooperate vms ->
         let vms' = List.map (fun uuid -> Db.VM.get_by_uuid ~__context ~uuid |> Ref.string_of) vms in
         reraise Api_errors.vms_failed_to_cooperate vms'
-      | Ballooning_error(code, descr) -> internal "ballooning error: %s %s" code descr
       | IO_error -> reraise Api_errors.vdi_io_error ["I/O error saving VM suspend image"]
       | Failed_to_contact_remote_service x -> internal "failed to contact: %s" x
       | Hook_failed(script, reason, stdout, i) -> reraise Api_errors.xapi_hook_failed [ script; reason; stdout; i ]

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2325,6 +2325,8 @@ let transform_xenops_exn ~__context ~vm queue_name f =
       | Failed_to_start_emulator (uuid, name, msg) ->
         let vm = Db.VM.get_by_uuid ~__context ~uuid in
         reraise Api_errors.failed_to_start_emulator [Ref.string_of vm; name; msg]
+      | Ballooning_timeout_before_migration ->
+        reraise Api_errors.ballooning_timeout_before_migration [Ref.string_of vm]
       | e -> raise e
     end
 


### PR DESCRIPTION
See https://github.com/xapi-project/xenopsd/pull/359 for the context