### PR TITLE
CA-246335: Only allow miami-era VM operations during rolling upgrade …

### DIFF
--- a/ocaml/xapi/test_vm_check_operation_error.ml
+++ b/ocaml/xapi/test_vm_check_operation_error.ml
@@ -35,10 +35,25 @@ let test_migration_disallowed_when_cbt_enabled () =
         (Xapi_vm_lifecycle.check_operation_error ~__context ~ref:vm_ref ~op:`migrate_send ~strict:true)
     )
 
+let test_sxm_disallowed_when_rum () =
+  with_test_vm (fun __context vm_ref ->
+    let master = Test_common.make_host __context () in
+    let pool = Test_common.make_pool ~__context ~master () in
+    Db.Pool.add_to_other_config ~__context ~self:pool ~key:Xapi_globs.rolling_upgrade_in_progress ~value:"x";
+    OUnit.assert_equal
+      (Some(Api_errors.not_supported_during_upgrade, [ ]))
+      (Xapi_vm_lifecycle.check_operation_error ~__context ~ref:vm_ref ~op:`migrate_send ~strict:false);
+    Db.Pool.remove_from_other_config ~__context ~self:pool ~key:Xapi_globs.rolling_upgrade_in_progress;
+    OUnit.assert_equal
+      None
+      (Xapi_vm_lifecycle.check_operation_error ~__context ~ref:vm_ref ~op:`migrate_send ~strict:false)
+  )
+
 let test =
   let open OUnit in
   "test_vm_check_operation_error" >:::
   [ "test_null_vdi" >:: test_null_vdi
   ; "test_operation_checks_allowed" >:: test_operation_checks_allowed
   ; "test_migration_disallowed_when_cbt_enabled" >:: test_migration_disallowed_when_cbt_enabled
+  ; "test_sxm_disallowed_when_rum" >:: test_sxm_disallowed_when_rum
   ]

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -423,7 +423,7 @@ let host_operations_miami = [
   `provision;
 ]
 
-let vm_operations_miami = [
+let rpu_allowed_vm_operations = [
   `assert_operation_valid;
   `changing_memory_live;
   `changing_shadow_memory_live;

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -547,6 +547,13 @@ let check_operation_error ~__context ~ref ~op ~strict =
       end else None
     ) in
 
+  let current_error = check current_error (fun () ->
+    if Helpers.rolling_upgrade_in_progress ~__context &&
+       not (List.mem op Xapi_globs.vm_operations_miami)
+    then Some (Api_errors.not_supported_during_upgrade, [])
+    else None)
+  in
+
   current_error
 
 let get_operation_error ~__context ~self ~op ~strict =

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -549,7 +549,7 @@ let check_operation_error ~__context ~ref ~op ~strict =
 
   let current_error = check current_error (fun () ->
     if Helpers.rolling_upgrade_in_progress ~__context &&
-       not (List.mem op Xapi_globs.vm_operations_miami)
+       not (List.mem op Xapi_globs.rpu_allowed_vm_operations)
     then Some (Api_errors.not_supported_during_upgrade, [])
     else None)
   in
@@ -574,7 +574,7 @@ let update_allowed_operations ~__context ~self =
   (* FIXME: need to be able to deal with rolling-upgrade for orlando as well *)
   let allowed =
     if Helpers.rolling_upgrade_in_progress ~__context
-    then Listext.List.intersect allowed Xapi_globs.vm_operations_miami
+    then Listext.List.intersect allowed Xapi_globs.rpu_allowed_vm_operations
     else allowed
   in
   Db.VM.set_allowed_operations ~__context ~self ~value:allowed;


### PR DESCRIPTION
…mode

We had code to limit the contents of allowed_operations, but nothing to
actually prevent the operations being performed, so a CLI user could do
anything.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>