### PR TITLE
Port pool-join rules from Honolulu to Master CP-23535

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4242,7 +4242,13 @@ let pool_update =
         field     ~in_product_since:rel_ely ~default_value:(Some (VSet [])) ~in_oss_since:None ~qualifier:StaticRO ~ty:(Set pool_update_after_apply_guidance) "after_apply_guidance" "What the client should do after this update has been applied.";
         field     ~in_oss_since:None ~qualifier:StaticRO ~ty:(Ref _vdi) "vdi" "VDI the update was uploaded to";
         field     ~in_product_since:rel_ely ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Set (Ref _host)) "hosts" "The hosts that have applied this update.";
-        field     ~in_product_since:rel_honolulu
+        field     ~in_product_since:rel_inverness
+                  ~default_value:(Some (VMap []))
+                  ~in_oss_since:None
+                  ~ty:(Map(String, String))
+                  "other_config"
+                  "additional configuration";
+        field     ~in_product_since:rel_inverness
                   ~default_value:(Some (VBool false))
                   ~in_oss_since:None
                   ~qualifier:StaticRO

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 131
+let schema_minor_vsn = 132
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -4242,6 +4242,13 @@ let pool_update =
         field     ~in_product_since:rel_ely ~default_value:(Some (VSet [])) ~in_oss_since:None ~qualifier:StaticRO ~ty:(Set pool_update_after_apply_guidance) "after_apply_guidance" "What the client should do after this update has been applied.";
         field     ~in_oss_since:None ~qualifier:StaticRO ~ty:(Ref _vdi) "vdi" "VDI the update was uploaded to";
         field     ~in_product_since:rel_ely ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Set (Ref _host)) "hosts" "The hosts that have applied this update.";
+        field     ~in_product_since:rel_honolulu
+                  ~default_value:(Some (VBool false))
+                  ~in_oss_since:None
+                  ~qualifier:StaticRO
+                  ~ty:Bool
+                  "enforce_homogeneity"
+                  "Flag - if true, all hosts in a pool must apply this update";
       ]
     ()
 

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -56,6 +56,7 @@ let rel_indigo = "indigo"
 let rel_dundee = "dundee"
 let rel_ely = "ely"
 let rel_falcon = "falcon"
+let rel_honolulu = "honolulu"
 let rel_inverness = "inverness"
 
 type api_release = {
@@ -177,6 +178,12 @@ let release_order_full = [{
       version_major = 2;
       version_minor = 6;
       branding   = "XenServer 7.1";
+    }; {
+      code_name     = Some rel_honolulu;
+      (** TODO replace with the actual version numbers when Honolulu is released *)
+      version_major = 2;
+      version_minor = 6;
+      branding   = "Unreleased";
     }; {
       code_name     = Some rel_falcon;
       version_major = 2;

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -1095,6 +1095,7 @@ let pool_update_record rpc session_id update =
         make_field ~name:"installation-size"   ~get:(fun () -> Int64.to_string (x ()).API.pool_update_installation_size) ();
         make_field ~name:"hosts"               ~get:(fun () -> String.concat ", " (get_hosts ())) ~get_set:get_hosts ();
         make_field ~name:"after-apply-guidance" ~get:(fun () -> String.concat ", " (after_apply_guidance ())) ~get_set:after_apply_guidance ();
+        make_field ~name:"enforce-homogeneity" ~get:(fun () -> string_of_bool (x ()).API.pool_update_enforce_homogeneity) ();
       ]}
 
 let host_cpu_record rpc session_id host_cpu =

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -363,6 +363,7 @@ let make_pool_update ~__context
     ?(key="")
     ?(after_apply_guidance=[])
     ?(enforce_homogeneity=false)
+    ?(other_config=[])
     ?(vdi=Ref.null) () =
   let update_info = Xapi_pool_update.
     { uuid
@@ -372,6 +373,7 @@ let make_pool_update ~__context
     ; key
     ; installation_size
     ; after_apply_guidance
+    ; other_config
     ; enforce_homogeneity
     } in
   Xapi_pool_update.create_update_record ~__context ~update:ref ~update_info ~vdi;

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -353,9 +353,26 @@ let make_pvs_cache_storage ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ~ref ~uuid ~host ~sR ~site ~size ~vDI;
   ref
 
-let make_pool_update ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
-    ?(name_label="") ?(name_description="") ?(version="") ?(installation_size=0L) ?(key="")
-    ?(after_apply_guidance=[]) ?(vdi=Ref.null) () =
-  let update_info = Xapi_pool_update.{uuid; name_label; name_description; version; key; installation_size; after_apply_guidance} in
+let make_pool_update ~__context
+    ?(ref=Ref.make ())
+    ?(uuid=make_uuid ())
+    ?(name_label="")
+    ?(name_description="")
+    ?(version="")
+    ?(installation_size=0L)
+    ?(key="")
+    ?(after_apply_guidance=[])
+    ?(enforce_homogeneity=false)
+    ?(vdi=Ref.null) () =
+  let update_info = Xapi_pool_update.
+    { uuid
+    ; name_label
+    ; name_description
+    ; version
+    ; key
+    ; installation_size
+    ; after_apply_guidance
+    ; enforce_homogeneity
+    } in
   Xapi_pool_update.create_update_record ~__context ~update:ref ~update_info ~vdi;
   ref

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -157,7 +157,8 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
       Helpers.call_api_functions ~__context (fun rpc session_id ->
         updates_on ~rpc ~session_id local_host) in
     (* iterate over all pool hosts and compare patches to local host *)
-    Client.Host.get_all rpc session_id |> List.iter (fun pool_host ->
+    Client.Pool.get_all rpc session_id |> List.iter (fun pool ->
+      let pool_host = Client.Pool.get_master rpc session_id pool in
       let remote_updates = updates_on rpc session_id pool_host in
       if not (S.equal local_updates remote_updates) then begin
         let remote_uuid  = Client.Host.get_uuid rpc session_id pool_host in

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -163,14 +163,17 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
       if not (S.equal local_updates remote_updates) then begin
         let remote_uuid  = Client.Host.get_uuid rpc session_id pool_host in
         let diff xs ys   = S.diff xs ys |> S.elements |> String.concat "," in
-        let reason       = [remote_uuid] in
+        let reason       =
+          Printf.sprintf "Updates on local host %s and pool host %s differ"
+            (Db.Host.get_name_label ~__context ~self:local_host)
+            (Client.Host.get_name_label rpc session_id pool_host) in
         error
           "Pool join: Updates differ. Only on pool host %s: {%s} -- only on local host %s: {%s}"
           remote_uuid
           (diff remote_updates local_updates)
           local_uuid
           (diff local_updates remote_updates);
-        raise Api_errors.(Server_error(pool_hosts_not_homogeneous,reason))
+        raise Api_errors.(Server_error(pool_hosts_not_homogeneous,[reason]))
       end)
   in
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -143,6 +143,36 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
     end
   in
 
+  let assert_homogeneous_updates () =
+    let module S      = Helpers.StringSet in
+    let local_host    = Helpers.get_localhost ~__context in
+    let local_uuid    = Db.Host.get_uuid ~__context ~self:local_host in
+    let updates_on ~rpc ~session_id host =
+      Client.Host.get_updates ~rpc ~session_id ~self:host
+      |> List.map (fun self -> Client.Pool_update.get_record ~rpc ~session_id ~self)
+      |> List.filter (fun upd -> upd.API.pool_update_enforce_homogeneity = true)
+      |> List.map (fun upd -> upd.API.pool_update_uuid)
+      |> S.of_list in
+    let local_updates =
+      Helpers.call_api_functions ~__context (fun rpc session_id ->
+        updates_on ~rpc ~session_id local_host) in
+    (* iterate over all pool hosts and compare patches to local host *)
+    Client.Host.get_all rpc session_id |> List.iter (fun pool_host ->
+      let remote_updates = updates_on rpc session_id pool_host in
+      if not (S.equal local_updates remote_updates) then begin
+        let remote_uuid  = Client.Host.get_uuid rpc session_id pool_host in
+        let diff xs ys   = S.diff xs ys |> S.elements |> String.concat "," in
+        let reason       = [remote_uuid] in
+        error
+          "Pool join: Updates differ. Only on pool host %s: {%s} -- only on local host %s: {%s}"
+          remote_uuid
+          (diff remote_updates local_updates)
+          local_uuid
+          (diff local_updates remote_updates);
+        raise Api_errors.(Server_error(pool_hosts_not_homogeneous,reason))
+      end)
+  in
+
   (* CP-700: Restrict pool.join if AD configuration of slave-to-be does not match *)
   (* that of master of pool-to-join *)
   let assert_external_auth_matches () =
@@ -403,6 +433,7 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
   (* CA-247399: check first the API version and then the database schema *)
   assert_api_version_matches ();
   assert_db_schema_matches ();
+  assert_homogeneous_updates ();
   assert_homogeneous_primary_address_type ()
 
 let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) : API.ref_host =

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -156,7 +156,7 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
     let local_updates =
       Helpers.call_api_functions ~__context (fun rpc session_id ->
         updates_on ~rpc ~session_id local_host) in
-    (* iterate over all pool hosts and compare patches to local host *)
+    (* compare updates on host and pool master *)
     Client.Pool.get_all rpc session_id |> List.iter (fun pool ->
       let pool_host = Client.Pool.get_master rpc session_id pool in
       let remote_updates = updates_on rpc session_id pool_host in

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -44,6 +44,7 @@ type update_info = {
   key: string;
   installation_size: int64;
   after_apply_guidance: API.after_apply_guidance list;
+  enforce_homogeneity: bool; (* true = all hosts in a pool must have this update *)
 }
 
 (** Mount a filesystem somewhere, with optional type *)
@@ -259,6 +260,9 @@ let parse_update_info xml =
       with
       | _ -> []
     in
+    let enforce_homogeneity =
+      Vm_platform.is_true ~key:"enforce-homogeneity" ~platformdata:attr ~default:false
+    in
     let is_name_description_node = function
       | Xml.Element ("name-description", _, _) -> true
       | _ -> false
@@ -267,16 +271,15 @@ let parse_update_info xml =
       | Xml.Element("name-description", _, [ Xml.PCData s ]) -> s
       | _ -> raise (Api_errors.Server_error(Api_errors.invalid_update, ["missing <name-description> in update.xml"]))
     in
-    let update_info = {
-      uuid = uuid;
-      name_label = name_label;
-      name_description = name_description;
-      version = version;
-      key = Filename.basename key;
-      installation_size = installation_size;
-      after_apply_guidance = guidance;
-    } in
-    update_info
+      { uuid
+      ; name_label
+      ; name_description
+      ; version
+      ; key = Filename.basename key
+      ; installation_size
+      ; after_apply_guidance = guidance
+      ; enforce_homogeneity
+      }
   | _ -> raise (Api_errors.Server_error(Api_errors.invalid_update, ["missing <update> in update.xml"]))
 
 let extract_applied_update_info applied_uuid  =
@@ -371,6 +374,7 @@ let create_update_record ~__context ~update ~update_info ~vdi =
     ~key:update_info.key
     ~after_apply_guidance:update_info.after_apply_guidance
     ~vdi:vdi
+    ~enforce_homogeneity:update_info.enforce_homogeneity
 
 let introduce ~__context ~vdi =
   if Db.VDI.get_type ~__context ~self:vdi = `cbt_metadata then begin

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -488,7 +488,11 @@ let resync_host ~__context ~host =
         let pool_patch_ref = Xapi_pool_patch.pool_patch_of_update ~__context update_ref in
         let uuid = Db.Pool_update.get_uuid ~__context ~self:update_ref in
         let mtime = (Unix.stat (Filename.concat update_applied_dir uuid)).Unix.st_mtime in
-        Xapi_pool_patch.write_patch_applied_db ~__context ~date:mtime ~self:pool_patch_ref ~host ()
+        Xapi_pool_patch.write_patch_applied_db ~__context ~date:mtime ~self:pool_patch_ref ~host ();
+        (* The enforce_homogeneity flag is now stored in an update. In
+         * Honolulu it was stored in pool patches. To avoid any confusion, we
+         * delete it there. CA-260352 *)
+        Db.Pool_patch.remove_from_other_config ~__context ~self:pool_patch_ref ~key:"enforce_homogeneity";
       ) update_refs;
     Create_misc.create_updates_requiring_reboot_info ~__context ~host;
     Create_misc.create_software_version ~__context

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -44,6 +44,7 @@ type update_info = {
   key: string;
   installation_size: int64;
   after_apply_guidance: API.after_apply_guidance list;
+  other_config: (string * string) list;
   enforce_homogeneity: bool; (* true = all hosts in a pool must have this update *)
 }
 
@@ -278,6 +279,7 @@ let parse_update_info xml =
       ; key = Filename.basename key
       ; installation_size
       ; after_apply_guidance = guidance
+      ; other_config = []
       ; enforce_homogeneity
       }
   | _ -> raise (Api_errors.Server_error(Api_errors.invalid_update, ["missing <update> in update.xml"]))
@@ -374,6 +376,7 @@ let create_update_record ~__context ~update ~update_info ~vdi =
     ~key:update_info.key
     ~after_apply_guidance:update_info.after_apply_guidance
     ~vdi:vdi
+    ~other_config:[]
     ~enforce_homogeneity:update_info.enforce_homogeneity
 
 let introduce ~__context ~vdi =


### PR DESCRIPTION
This PR is a collection of cherry-picks that brings the implementation of pool-join rules from Honolulu to Master. It contains one additional commit to fix a comment in the code that became misleading after a code change. Pool join does:

* check that the set of updates marked as enforced are identical on joining host and master
* on restart, updates are read and in particular checked for the new attribute "enforce-homogeneity"
* error messages are made to fit into the existing scheme (using strings) but might need revising to avoid problems with i18n in the future.