### PR TITLE
CP-23535 Port pool-join rules from Master

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 120
+let schema_minor_vsn = 121
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -4210,6 +4210,19 @@ let pool_update =
         field     ~in_product_since:rel_ely ~default_value:(Some (VSet [])) ~in_oss_since:None ~qualifier:StaticRO ~ty:(Set pool_update_after_apply_guidance) "after_apply_guidance" "What the client should do after this update has been applied.";
         field     ~in_oss_since:None ~qualifier:StaticRO ~ty:(Ref _vdi) "vdi" "VDI the update was uploaded to";
         field     ~in_product_since:rel_ely ~in_oss_since:None ~qualifier:DynamicRO ~ty:(Set (Ref _host)) "hosts" "The hosts that have applied this update.";
+        field     ~in_product_since:rel_inverness
+                  ~default_value:(Some (VMap []))
+                  ~in_oss_since:None
+                  ~ty:(Map(String, String))
+                  "other_config"
+                  "additional configuration";
+        field     ~in_product_since:rel_inverness
+                  ~default_value:(Some (VBool false))
+                  ~in_oss_since:None
+                  ~qualifier:StaticRO
+                  ~ty:Bool
+                  "enforce_homogeneity"
+                  "Flag - if true, all hosts in a pool must apply this update";
       ]
     ()
 

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -57,6 +57,8 @@ let rel_dundee = "dundee"
 let rel_dundee_plus = "dundee-plus"
 let rel_ely = "ely"
 let rel_falcon = "falcon"
+let rel_honolulu = "honolulu"
+let rel_inverness = "inverness"
 
 let release_order =
   [ rel_rio
@@ -81,6 +83,8 @@ let release_order =
   ; rel_dundee_plus
   ; rel_ely
   ; rel_falcon
+  ; rel_honolulu
+  ; rel_inverness
   ]
 
 exception Unknown_release of string

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -1095,6 +1095,7 @@ let pool_update_record rpc session_id update =
         make_field ~name:"installation-size"   ~get:(fun () -> Int64.to_string (x ()).API.pool_update_installation_size) ();
         make_field ~name:"hosts"               ~get:(fun () -> String.concat ", " (get_hosts ())) ~get_set:get_hosts ();
         make_field ~name:"after-apply-guidance" ~get:(fun () -> String.concat ", " (after_apply_guidance ())) ~get_set:after_apply_guidance ();
+        make_field ~name:"enforce-homogeneity" ~get:(fun () -> string_of_bool (x ()).API.pool_update_enforce_homogeneity) ();
       ]}
 
 let host_cpu_record rpc session_id host_cpu =

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -352,9 +352,28 @@ let make_pvs_cache_storage ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ~ref ~uuid ~host ~sR ~site ~size ~vDI;
   ref
 
-let make_pool_update ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
-    ?(name_label="") ?(name_description="") ?(version="") ?(installation_size=0L) ?(key="")
-    ?(after_apply_guidance=[]) ?(vdi=Ref.null) () =
-  let update_info = Xapi_pool_update.{uuid; name_label; name_description; version; key; installation_size; after_apply_guidance} in
+let make_pool_update ~__context
+    ?(ref=Ref.make ())
+    ?(uuid=make_uuid ())
+    ?(name_label="")
+    ?(name_description="")
+    ?(version="")
+    ?(installation_size=0L)
+    ?(key="")
+    ?(after_apply_guidance=[])
+    ?(enforce_homogeneity=false)
+    ?(other_config=[])
+    ?(vdi=Ref.null) () =
+  let update_info = Xapi_pool_update.
+    { uuid
+    ; name_label
+    ; name_description
+    ; version
+    ; key
+    ; installation_size
+    ; after_apply_guidance
+    ; other_config
+    ; enforce_homogeneity
+    } in
   Xapi_pool_update.create_update_record ~__context ~update:ref ~update_info ~vdi;
   ref


### PR DESCRIPTION
This commit ports the pool-join rules from release/honolulu/master. The
rules implement the following behaviour:

* Updates can be now marked as enforced (XML attribute
  enforce-homogeneity=true) and the code recognises these.
* Pool join checks that the set of enforced updates is the same on the
  host joining the pool and the pool master.
* At startup, Xapi reads in resync_host() applied updates from the file
  system and updates its record. In particular, it re-reads the
  enforce-homogeneity attribute.
* In the Honolulu (7.1.1) release, the enforce-homogeneity flag was
  stored in a pool-patch object to avoid changing the pool-update class.
  This is now rectified and the flag is stored properly in pool-update.
  When updates are read at startup, a possibly existing flag in
  a pool-patch is removed to avoid confusion and redundancy.

This code went on release/honolulu/master through a series of
iterations. The following issues have been fixed:

* CP-23026
* CA-259405
* CA-259288
* CA-258536

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>