### PR TITLE
Add LICENSE_RESTRICTION to the error whitelist

### DIFF
--- a/scripts/extensions/pool_update.precheck
+++ b/scripts/extensions/pool_update.precheck
@@ -93,7 +93,8 @@ def parse_control_package(session, yum_url):
 
 def parse_precheck_failure(xmldoc):
     errors = {
-        UPDATE_PRECHECK_FAILED_WRONG_SERVER_VERSION: (FOUND, REQUIRED)
+        UPDATE_PRECHECK_FAILED_WRONG_SERVER_VERSION: (FOUND, REQUIRED),
+        'LICENSE_RESTRICTION': ('feature', )
     }
 
     error = xmldoc.getElementsByTagName(ERROR)[0]


### PR DESCRIPTION
This is a backport from master ec1007b2aa183abac4ce7ee05180443b31787a98:

Extend the list of errorcode handled by parse_precheck_failure().

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>