### PR TITLE
CP-23838 Record per bridge (PIF) IGMP Snooping enable status in xapi …

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5484,6 +5484,13 @@ let pif_set_property = call
     ~allowed_roles:_R_POOL_OP
     ()
 
+let pif_igmp_status =
+  Enum ("pif_igmp_status", [
+      "enabled", "IGMP Snooping is enabled in the corresponding backend bridge.'";
+      "disabled", "IGMP Snooping is disabled in the corresponding backend bridge.'";
+      "unknown", "IGMP snooping status is unknown. If this is a VLAN master, then please consult the underlying VLAN slave PIF."
+    ])
+
 let pif =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_pif ~descr:"A physical network interface (note separate VLANs are represented as several PIFs)"
     ~gen_events:true
@@ -5532,6 +5539,7 @@ let pif =
                                                                                                                            		can not be used, nor can the interface be bonded or have VLANs based on top through xapi." ~default_value:(Some (VBool true));
       field ~lifecycle:[Published, rel_creedence, ""] ~qualifier:DynamicRO ~ty:(Map(String, String)) ~default_value:(Some (VMap [])) "properties" "Additional configuration properties for the interface.";
       field ~lifecycle:[Published, rel_dundee, ""] ~qualifier:DynamicRO ~ty:(Set(String)) ~default_value:(Some (VSet [])) "capabilities" "Additional capabilities on the interface.";
+      field ~lifecycle:[Published, rel_inverness, ""] ~qualifier:DynamicRO ~ty:pif_igmp_status ~default_value:(Some (VEnum "unknown")) "igmp_snooping_status" "The IGMP snooping status of the corresponding network bridge";
     ]
     ()
 

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -468,12 +468,22 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
       end;
 
       (* sync MTU *)
+      begin
       try
         let mtu = Int64.of_int (Net.Interface.get_mtu dbg ~name:bridge) in
         if mtu <> rc.API.pIF_MTU then
           Db.PIF.set_MTU ~__context ~self:pif ~value:mtu
       with _ ->
         warn "could not update MTU field on PIF %s" rc.API.pIF_uuid
+      end;
+      
+      (* sync igmp_snooping_enabled *)
+      if rc.API.pIF_VLAN = -1L then begin
+        let igmp_snooping = Db.Pool.get_igmp_snooping_enabled ~__context ~self:(Helpers.get_pool ~__context) in
+        let igmp_snooping' = if igmp_snooping then `enabled else `disabled in
+        if igmp_snooping' <> rc.API.pIF_igmp_snooping_status then
+          Db.PIF.set_igmp_snooping_status ~__context ~self:pif ~value:igmp_snooping'
+      end
    )
 
 let bring_pif_down ~__context ?(force=false) (pif: API.ref_PIF) =

--- a/ocaml/xapi/record_util.ml
+++ b/ocaml/xapi/record_util.ml
@@ -499,6 +499,11 @@ let sdn_protocol_to_string = function
   | `ssl -> "ssl"
   | `pssl -> "pssl"
 
+let pif_igmp_status_to_string = function
+  | `enabled -> "enabled"
+  | `disabled -> "disabled"
+  | `unknown -> "unknown"
+
 (* string_to_string_map_to_string *)
 let s2sm_to_string sep x =
   String.concat sep (List.map (fun (a,b) -> a^": "^b) x)

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -305,6 +305,7 @@ let pif_record rpc session_id pif =
           ~add_to_map:(fun k v -> Client.PIF.add_to_other_config rpc session_id pif k v)
           ~remove_from_map:(fun k -> Client.PIF.remove_from_other_config rpc session_id pif k)
           ~get_map:(fun () -> (x ()).API.pIF_other_config) ();
+        make_field ~name:"igmp-snooping-status" ~get:(fun () -> Record_util.pif_igmp_status_to_string ((x ()).API.pIF_igmp_snooping_status)) ();
       ] }
 
 let task_record rpc session_id task =

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -372,7 +372,7 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
       let metrics = Xapi_pif.make_pif_metrics ~__context in
       Db.PIF.create ~__context ~ref:master ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
         ~device ~device_name ~network ~host ~mAC ~mTU:(-1L) ~vLAN:(-1L) ~metrics
-        ~physical:false ~currently_attached:false
+        ~physical:false ~currently_attached:false ~igmp_snooping_status:`unknown
         ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
         ~vLAN_master_of:Ref.null ~management:false ~other_config:[] ~disallow_unplug:false
         ~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -351,7 +351,7 @@ let pool_introduce
       ~__context ~ref:pif_ref ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
       ~device ~device_name:device ~network ~host
       ~mAC ~mTU ~vLAN ~metrics
-      ~physical ~currently_attached:false
+      ~physical ~currently_attached:false ~igmp_snooping_status:`unknown
       ~ip_configuration_mode ~iP ~netmask ~gateway ~dNS
       ~bond_slave_of:Ref.null ~vLAN_master_of ~management
       ~other_config ~disallow_unplug ~ipv6_configuration_mode
@@ -390,7 +390,7 @@ let introduce_internal
   let () = Db.PIF.create
       ~__context ~ref:pif ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
       ~device ~device_name:device ~network:net_ref ~host ~mAC
-      ~mTU ~vLAN ~metrics ~physical ~currently_attached:false
+      ~mTU ~vLAN ~metrics ~physical ~currently_attached:false ~igmp_snooping_status:`unknown
       ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:""
       ~dNS:"" ~bond_slave_of:Ref.null ~vLAN_master_of ~management:false
       ~other_config:[] ~disallow_unplug ~ipv6_configuration_mode:`None

--- a/ocaml/xapi/xapi_tunnel.ml
+++ b/ocaml/xapi/xapi_tunnel.ml
@@ -39,7 +39,7 @@ let create_internal ~__context ~transport_PIF ~network ~host =
   let metrics = Db.PIF.get_metrics ~__context ~self:transport_PIF in
   Db.PIF.create ~__context ~ref:access_PIF ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
     ~device ~device_name ~network ~host ~mAC ~mTU:(-1L) ~vLAN:(-1L) ~metrics
-    ~physical:false ~currently_attached:false
+    ~physical:false ~currently_attached:false ~igmp_snooping_status:`unknown
     ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
     ~vLAN_master_of:Ref.null ~management:false ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
     ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true ~properties:[] ~capabilities:[];

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -33,7 +33,7 @@ let create_internal ~__context ~host ~tagged_PIF ~tag ~network ~device =
   let metrics = Db.PIF.get_metrics ~__context ~self:tagged_PIF in
   Db.PIF.create ~__context ~ref:untagged_PIF ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
     ~device ~device_name:device ~network ~host ~mAC:vlan_mac ~mTU ~vLAN:tag ~metrics
-    ~physical:false ~currently_attached:false
+    ~physical:false ~currently_attached:false ~igmp_snooping_status:`unknown
     ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
     ~vLAN_master_of:vlan ~management:false ~other_config:[] ~disallow_unplug:false
     ~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true


### PR DESCRIPTION
…database

In previous commits, feature level toggle is added as per pool. However, as the actual configuration takes place in each OVS bridge, we think it is necessary to record the actual setting per bridge (as one one related to one PIF), for troubleshooting/debug purpose.

Signed-off-by: Yarsin He <yarsin.he@citrix.com>