### PR TITLE
CA-261112 - make forgetting update by removing its stamp file work

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -537,13 +537,33 @@ let resync_host ~__context ~host =
   if not (Helpers.rolling_upgrade_in_progress ~__context) then begin
     (* Remove any pool_patch objects that don't have a corresponding pool_update object *)
     Db.Pool_patch.get_all ~__context
-    |> List.filter (fun self -> Db.Pool_patch.get_pool_update ~__context ~self = Ref.null)
+    |> List.filter
+       ( fun self -> Db.Pool_patch.get_pool_update ~__context ~self
+       |> Db.is_valid_ref __context
+       |> not
+       )
     |> List.iter (fun self -> Db.Pool_patch.destroy ~__context ~self);
 
     (* Clean updates that don't have a corresponding patch record *)
     Db.Pool_update.get_all ~__context
-    |> List.filter (fun self -> Xapi_pool_patch.pool_patch_of_update ~__context self = Ref.null)
-    |> List.iter (fun self -> destroy ~__context ~self)
+    |> List.filter
+       ( fun self -> Xapi_pool_patch.pool_patch_of_update ~__context self
+       |> Db.is_valid_ref __context
+       |> not
+       )
+    |> List.iter (fun self -> destroy ~__context ~self);
+    (*
+     * If db indicates an update is not applied to any host but the corresponding patch is applied
+     * on some host(s), that means the RPU has completed, the update record should be removed.
+     * (The patch record will be removed along with the update record.)
+    *)
+    Db.Pool_update.get_all ~__context
+    |> List.filter (fun self ->
+         Db.Pool_update.get_hosts ~__context ~self = []
+         && Xapi_pool_patch.pool_patch_of_update ~__context self
+            |> fun self -> Db.Pool_patch.get_host_patches ~__context ~self
+            |> function [] -> false | _ -> true)
+    |> List.iter (fun self -> destroy ~__context ~self);
   end
 
 let pool_update_download_handler (req: Request.t) s _ =


### PR DESCRIPTION
When a stamp file is removed from /var/update/applied, the corresponding
pool update is dis-associated from the host. So far, the corresponding
pool patch was neither dis-associated nor removed, leading to an
inconsistency between pool updates and pool patches. This commit fixes
this:

* To find stale records, it uses is_valid rather than comparing against
  Null
* It removes patches and updates that are (no longer) applied to any
  host. This code is ported from the master branch.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>