### PR TITLE
Increase quicktest code coverage by adding the following unused XenAPI calls

### DIFF
--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -845,6 +845,7 @@ let _ =
     "vhd";
     "copy";
     "import_raw_vdi";
+    "pbd-bvt";
   ] in
   let default_tests = List.filter (fun x -> not(List.mem x [ "lifecycle"; "vhd" ])) all_tests in
 
@@ -877,6 +878,7 @@ let _ =
        (try
           maybe_run_test "encodings" Quicktest_encodings.run_from_within_quicktest;
           maybe_run_test "vm-memory-constraints" Quicktest_vm_memory_constraints.run_from_within_quicktest;
+          maybe_run_test "pbd-bvt" (fun () -> Quicktest_bvt.start s !rpc);
           maybe_run_test "vm-placement" Quicktest_vm_placement.run_from_within_quicktest;
           maybe_run_test "storage" (fun () -> Quicktest_storage.go s);
           if not !using_unix_domain_socket then maybe_run_test "http" Quicktest_http.run_from_within_quicktest;

--- a/ocaml/xapi/quicktest_bvt.ml
+++ b/ocaml/xapi/quicktest_bvt.ml
@@ -1,10 +1,8 @@
+(* demonstrative example of how quicktest code should be written *)
 open Client
 open Quicktest_common
 
-(* alias PBD module for convenience 
- * also has scope for generalising verification
- * between PBDs and VBDs for common API calls
- * e.g. both have get_uuid, get_other_config etc. *)
+(* alias PBD module for convenience *)
 module P = Client.PBD
 
 let start session_id rpc =

--- a/ocaml/xapi/quicktest_bvt.ml
+++ b/ocaml/xapi/quicktest_bvt.ml
@@ -20,9 +20,10 @@ let start session_id rpc =
     try
       start uuid_t;
       let uuid = with_pbd P.get_uuid pbd in
-      if with_api P.get_by_uuid ~uuid = pbd then success uuid_t
+      if with_api P.get_by_uuid ~uuid = pbd
+      then success uuid_t
       else failed uuid_t "'get_by_uuid' failed";
-    with e -> debug uuid_t (ExnHelper.string_of_exn e); in
+    with e -> failed uuid_t (ExnHelper.string_of_exn e); in
 
   (* main function to run test suite *)
   let run_tests () =
@@ -35,6 +36,5 @@ let start session_id rpc =
       success test;
     with
     | (Failure hd) -> failed test "Error: no PBD available"
-    | e -> debug test (ExnHelper.string_of_exn e);
-           failed test ""
+    | e -> failed test (ExnHelper.string_of_exn e);
   in run_tests () ;

--- a/ocaml/xapi/quicktest_bvt.ml
+++ b/ocaml/xapi/quicktest_bvt.ml
@@ -1,0 +1,40 @@
+open Client
+open Quicktest_common
+
+(* alias PBD module for convenience 
+ * also has scope for generalising verification
+ * between PBDs and VBDs for common API calls
+ * e.g. both have get_uuid, get_other_config etc. *)
+module P = Client.PBD
+
+let start session_id rpc =
+
+  (* helper functions for API/PBD calls *)
+  let with_api fn = fn ~rpc ~session_id in
+  let with_pbd fn pbd = with_api fn ~self:pbd in
+
+  (* checks get_uuid returns correct UUID by comparing
+   * the PBD returned by get_by_uuid *)
+  let uuid_test pbd =
+    let uuid_t = make_test "Testing 'get_by_uuid', 'get_uuid'" 4 in
+    try
+      start uuid_t;
+      let uuid = with_pbd P.get_uuid pbd in
+      if with_api P.get_by_uuid ~uuid = pbd then success uuid_t
+      else failed uuid_t "'get_by_uuid' failed";
+    with e -> debug uuid_t (ExnHelper.string_of_exn e); in
+
+  (* main function to run test suite *)
+  let run_tests () =
+    let test = make_test "Begin PBD verification" 2 in
+    try
+      start test;
+      let pbd = List.hd (with_api P.get_all) in
+      uuid_test pbd;
+      debug test "PBD verification complete";
+      success test;
+    with
+    | (Failure hd) -> failed test "Error: no PBD available"
+    | e -> debug test (ExnHelper.string_of_exn e);
+           failed test ""
+  in run_tests () ;


### PR DESCRIPTION
Increase quicktest code coverage by adding the following unused XenAPI calls:

- Client.PBD.get_all
- Client.PBD.get_uuid
- Client.PBD.get_by_uuid

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>