### PR TITLE
CA-260245: Fix SXM: old host choking on new op (2)

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -454,7 +454,10 @@ let rpu_allowed_vm_operations = [
   `update_allowed_operations;
 ]
 
-let rpu_allowed_vdi_operations = [
+(* Until the Ely release, the vdi_operations enum had stayed unchanged
+ * since 2009 or earlier, but then Ely and some subsequent releases
+ * added new members to the enum. *)
+let pre_ely_vdi_operations = [
   `clone;
   `copy;
   `resize;
@@ -467,6 +470,9 @@ let rpu_allowed_vdi_operations = [
   `generate_config;
   `blocked;
 ]
+
+(* We might consider restricting this further. *)
+let rpu_allowed_vdi_operations = pre_ely_vdi_operations
 
 (* Viridian key name (goes in platform flags) *)
 let viridian_key_name = "viridian"

--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -24,42 +24,6 @@ open Threadext
 module D=Debug.Make(struct let name="xapi" end)
 open D
 
-let all_ops: API.vdi_operations list =
-  [ `blocked
-  ; `clone
-  ; `copy
-  ; `destroy
-  ; `disable_cbt
-  ; `enable_cbt
-  ; `force_unlock
-  ; `forget
-  ; `generate_config
-  ; `mirror
-  ; `resize
-  ; `resize_online
-  ; `set_on_boot
-  ; `snapshot
-  ; `update
-  ]
-
-(* CA-260245: older XenServer versions do not know about these operations,
- * and therefore cannot do storage migration to a XenServer that lists them
- * in a VDI's allowed_operations field.
- * As a temporary measure, we are fixing the symptom by excluding these ops
- * from the allowed_operations list. This is a hack: TECHNICAL DEBT.
- * If we were to continue with this mechanism then any additional new ops would
- * have to be added to this recently_added_ops list, and we would be able to
- * remove items when old-but-supported XenServer versions know about them.
- * We would prefer to do a more general fix for this class of problems; we have
- * one or two approaches in mind. *)
-let recently_added_ops: API.vdi_operations list =
-  (* If/when items are removed from this list, update
-   * test_vdi_allowed_operations.ml to re-enable (and maybe alter)
-   * the relevant part of test_update_allowed_operations. *)
-  [ `enable_cbt
-  ; `disable_cbt
-  ]
-
 (* CA-26514: Block operations on 'unmanaged' VDIs *)
 let assert_managed ~__context ~vdi =
   if not (Db.VDI.get_managed ~__context ~self:vdi)


### PR DESCRIPTION
When populating VDI.allowed_operations, consider only the operations
that existed before the Ely release (corresponding to XenServer 7.1).
(Ely contained the first additions since 2009 or earlier.)

(The previous commit marked CA-260245 was insufficient to fix the SXM.)