### PR TITLE
CA-262941:  	Remove "xe vdi-get-nbd-info" CLI command

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2001,14 +2001,6 @@ let rec cmdtable_data : (string*cmd_spec) list =
       implementation=With_fd Cli_operations.vdi_export_changed_blocks;
       flags=[];
     };
-    "vdi-get-nbd-info",
-    {
-      reqd=["uuid"];
-      optn=[];
-      help="Returns a list of URIs specifying how to access the VDI via the NBD server of XenServer. NBD clients should connect to the IP address and port specified in one of the returned URIs, and pass the whole URI to the NBD server as the requested export name.";
-      implementation=No_fd Cli_operations.vdi_get_nbd_info;
-      flags=[];
-    };
     "diagnostic-vdi-status",
     {
       reqd=["uuid"];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1266,11 +1266,6 @@ let vdi_export_changed_blocks socket _ rpc session_id params =
   let bitmap = Client.VDI.export_changed_blocks ~rpc ~session_id ~vdi_from ~vdi_to in
   marshal socket (Command (Print bitmap))
 
-let vdi_get_nbd_info printer rpc session_id params =
-  let vdi = Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "uuid" params) in
-  let uris = Client.VDI.get_nbd_info ~rpc ~session_id ~self:vdi in
-  printer (Cli_printer.PList uris)
-
 let diagnostic_vdi_status printer rpc session_id params =
   let vdi = Client.VDI.get_by_uuid rpc session_id (List.assoc "uuid" params) in
   let vdi_r = vdi_record rpc session_id vdi in


### PR DESCRIPTION
Remove this command, as it currently does not work, because each CLI
command create a new session that it closes when it finishes.

We cannot accept a session parameter or return a dedicated newly-created
session from this command until we have implemented command-line session
handling.

This reverts commit c9d1e6ebce641d49aa0421ef88e2fea2f1d373d8.