### PR TITLE
CA-264428: Use --batch when calling gpg

### DIFF
--- a/scripts/import-update-key
+++ b/scripts/import-update-key
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-gpgopts="--homedir=/opt/xensource/gpg"
+gpgopts="--homedir=/opt/xensource/gpg --batch"
 
 set -e
 


### PR DESCRIPTION
If the `import-update-key` script is used when a TTY is not available (e.g.
during RPM installation), it can result in a situation where the key is
imported, but not marked as trusted. By passing `--batch` we avoid this
situation.

Signed-off-by: Alex Brett <alex.brett@citrix.com>