### PR TITLE
CA-264331: Remove unused shutdown ack timeout setting

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -645,7 +645,6 @@ let pool_db_sync_interval = ref 300.
 (* blob/message/rrd file syncing - sync once a day *)
 let pool_data_sync_interval = ref 86400.
 
-let domain_shutdown_ack_timeout = ref 10.
 let domain_shutdown_total_timeout = ref 1200.
 
 (* The actual reboot delay will be a random value between base and base + extra *)
@@ -827,7 +826,6 @@ let xapi_globs_spec =
     "pif_reconfigure_ip_timeout", Float pif_reconfigure_ip_timeout;
     "pool_db_sync_interval", Float pool_db_sync_interval;
     "pool_data_sync_interval", Float pool_data_sync_interval;
-    "domain_shutdown_ack_timeout", Float domain_shutdown_ack_timeout;
     "domain_shutdown_total_timeout", Float domain_shutdown_total_timeout;
     "emergency_reboot_delay_base", Float emergency_reboot_delay_base;
     "emergency_reboot_delay_extra", Float emergency_reboot_delay_extra;

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -245,10 +245,6 @@ sm-plugins=ext nfs iscsi lvmoiscsi dummy file hba rawhba udev iso lvm lvmohba lv
 # hosts
 # pool_data_sync_interval = 86400 # a day in seconds
 
-# time to wait for in-guest PV drivers to acknowledge a shutdown request
-# before we conclude that the drivers have failed
-# domain_shutdown_ack_timeout = 10
-
 # time to wait for a domain to shutdown before we conclude the operation
 # has failed. Note it can take a long time to shutdown if (for example)
 # the OS has decided to install a large set of patches.


### PR DESCRIPTION
This setting was previously configurable from the `xapi.conf` file,
when xenopsd was still a part of xapi. When they split, the setting
was not transferred and nor was it wired up to be used by xenopsd.

This commit removes the setting from xapi.

A corresponding commit in xenopsd adds it there and makes it
configurable in `xenopsd.conf`.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>