### PR TITLE
CA-265050:  Only consider VDIs attached to non-snapshot VMs as attached in the VDI op checks

### DIFF
--- a/ocaml/xapi/ounit_comparators.ml
+++ b/ocaml/xapi/ounit_comparators.ml
@@ -7,3 +7,5 @@ struct
 end
 
 module StringSet = OUnitDiff.SetMake(StringDiff)
+
+module StringList = OUnitDiff.ListSimpleMake(StringDiff)

--- a/ocaml/xapi/safe_list.ml
+++ b/ocaml/xapi/safe_list.ml
@@ -1,0 +1,13 @@
+
+let default_on_missing_ref f default x =
+  try
+    f x
+  with
+  | Db_exn.DBCache_NotFound ("missing reference", _, _) -> default
+  | Db_exn.DBCache_NotFound ("missing row", _, _) -> default
+
+let map f = Stdext.Listext.List.filter_map (default_on_missing_ref (fun x -> Some (f x)) None)
+
+let filter f = List.filter (default_on_missing_ref f false)
+
+let flat_map f l = List.map (default_on_missing_ref f []) l |> List.flatten

--- a/ocaml/xapi/safe_list.mli
+++ b/ocaml/xapi/safe_list.mli
@@ -1,0 +1,7 @@
+(** Ignore exceptions that can happen due to invalid references and just skip them *)
+
+val map : ('a -> 'b) -> 'a list -> 'b list
+
+val filter : ('a -> bool) -> 'a list -> 'a list
+
+val flat_map : ('a -> 'b list) -> 'a list -> 'b list

--- a/ocaml/xapi/suite.ml
+++ b/ocaml/xapi/suite.ml
@@ -66,6 +66,7 @@ let base_suite =
     Test_vlan.test;
     Test_xapi_vbd_helpers.test;
     Test_sr_update_vdis.test;
+    Test_safe_list.test;
   ]
 
 let handlers = [

--- a/ocaml/xapi/test_safe_list.ml
+++ b/ocaml/xapi/test_safe_list.ml
@@ -1,0 +1,41 @@
+
+let assert_equal l1 l2 = Ounit_comparators.StringList.(assert_equal l1 l2)
+
+let with_vm_list f () =
+  let __context = Mock.make_context_with_new_db "Mock context" in
+  let vm1 = Test_common.make_vm ~__context ~name_label:"a" ~name_description:"d_a" () in
+  let vm2 = Ref.null in
+  let vm3 = Test_common.make_vm ~__context ~name_label:"c" ~name_description:"d_c" () in
+  Db.VM.destroy ~__context ~self:vm3;
+  let vm4 = Test_common.make_vm ~__context ~name_label:"d" ~name_description:"d_d" () in
+  f __context [vm1; vm2; vm3; vm4]
+
+let test_map =
+  with_vm_list (fun __context l ->
+      let f vm = Db.VM.get_name_label ~__context ~self:vm in
+      assert_equal ["a"; "d"] (Safe_list.map f l)
+    )
+
+(* Be careful: the OUnit module has a function with the same name *)
+let test_filter =
+  with_vm_list (fun __context l ->
+      match l with
+      | [vm1; vm2; vm3; vm4] as l->
+        let f vm = Db.VM.get_name_label ~__context ~self:vm = "a" in
+        OUnit.assert_equal [vm1] (Safe_list.filter f l)
+      | _ -> failwith "Our test list should have 4 elements"
+    )
+
+let test_flat_map =
+  with_vm_list (fun __context l ->
+      let f vm = [(Db.VM.get_name_label ~__context ~self:vm); (Db.VM.get_name_description ~__context ~self:vm)] in
+      assert_equal ["a"; "d_a"; "d"; "d_d"] (Safe_list.flat_map f l)
+    )
+
+let test =
+  let ((>:::), (>::)) = OUnit.((>:::), (>::)) in
+  "test_safe_list" >:::
+  [ "test_map" >:: test_map
+  ; "test_filter" >:: test_filter
+  ; "test_flat_map" >:: test_flat_map
+  ]

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -116,6 +116,11 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
          snapshot's VBDs to true, and this would block operations that require
          the VDI to be detached. *)
       let my_active_vbd_records =
+        (* Use Safe_list to ignore exceptions due to invalid references that
+           could propagate to the message forwarding layer, which calls this
+           function to check for errors - these exceptions would prevent the
+           actual XenAPI function from being run. Checks called from the
+           message forwarding layer should not fail with an exception. *)
         my_active_vbd_records |> Safe_list.filter
           (fun vbd ->
              let vm = vbd.Db_actions.vBD_VM in


### PR DESCRIPTION
To fix CA-265050, where some CBT ops were disallowed on VDI snapshots
that were attached to VM snapshots.

This happened because the VM.checkpoint XenAPI function, which is called
when one takes a "disk and memory snapshot" from XenCenter, saves the
currently_attached fields of the snapshotted VM's VBDs in the
currently_attached fields of the VM snapshot's VBDs. This is different
from how this field is normally used: this field becomes true when the
VBDs actually get attached, and when the VM is shut down, the
currently_attached fields of the VBDs become false.

This confused the VDI checks in Xapi_vdi.check_operation_error, they
thought that since currently_attached is true, the VDI is actually
attached - which is usually true, but not in this case. In this case,
the VBDs just link the VDIs to a snapshot VM, but don't represent an
actual physical attachment of the VDI in SM. As a result, the checks
disallowed VDI.export_changed_blocks, and VDI.data_destroy on these
VDIs.

I had to update some of the existing tests because now only VDIs that
are attached to an actual non-snapshot VM are considered attached.

I have used safe list functions that ignore exceptions due to invalid references
in the newly-added filtering. This can happen when some references to
other XenAPI classes become (or are already) invalid while the checks
are running, and causes an exception in the message forwarding layer
which calls this function to check for errors, which will prevent the
actual XenAPI function from being run. See CA-255128 for an example of
this kind of issue.