### PR TITLE
CP-23051: Host.get_server_certificate: all RBAC roles

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4686,12 +4686,12 @@ let host_certificate_sync = call
 
 let host_get_server_certificate = call
     ~in_oss_since:None
-    ~in_product_since:rel_george
+    ~lifecycle:[Published, rel_george, ""; Changed, rel_inverness, "Now available to all RBAC roles."]
     ~name:"get_server_certificate"
-    ~doc:"Get the installed server SSL certificate."
+    ~doc:"Get the installed server public TLS certificate."
     ~params:[Ref _host, "host", "The host"]
-    ~result:(String,"The installed server SSL certificate, in PEM form.")
-    ~allowed_roles:_R_POOL_OP
+    ~result:(String,"The installed server public TLS certificate, in PEM form.")
+    ~allowed_roles:_R_READ_ONLY
     ()
 
 let host_display =


### PR DESCRIPTION
The Host.get_server_certificate function was restricted to the
Pool Operator role and higher.

Now it is available to all RBAC roles.