### PR TITLE
Rename VDI.export_changed_blocks to VDI.list_changed_blocks

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6008,7 +6008,7 @@ let storage_operations =
           "vdi_enable_cbt", "Enabling changed block tracking for a VDI";
           "vdi_disable_cbt", "Disabling changed block tracking for a VDI";
           "vdi_data_destroy", "Deleting the data of the VDI";
-          "vdi_export_changed_blocks", "Exporting a bitmap that shows the changed blocks between two VDIs";
+          "vdi_list_changed_blocks", "Exporting a bitmap that shows the changed blocks between two VDIs";
           "vdi_set_on_boot", "Setting the on_boot field of the VDI";
           "pbd_create", "Creating a PBD for this SR";
           "pbd_destroy", "Destroying one of this SR's PBDs"; ])
@@ -6334,7 +6334,7 @@ let vdi_operations =
           "enable_cbt", "Enabling changed block tracking for a VDI";
           "disable_cbt", "Disabling changed block tracking for a VDI";
           "data_destroy", "Deleting the data of the VDI";
-          "export_changed_blocks", "Exporting a bitmap that shows the changed blocks between two VDIs";
+          "list_changed_blocks", "Exporting a bitmap that shows the changed blocks between two VDIs";
           "set_on_boot", "Setting the on_boot field of the VDI";
           "blocked", "Operations on this VDI are temporarily blocked";
         ])
@@ -6609,8 +6609,8 @@ let vdi_data_destroy = call
     ~allowed_roles:_R_VM_ADMIN
     ()
 
-let vdi_export_changed_blocks = call
-    ~name:"export_changed_blocks"
+let vdi_list_changed_blocks = call
+    ~name:"list_changed_blocks"
     ~in_oss_since:None
     ~in_product_since:rel_inverness
     ~params:
@@ -6676,7 +6676,7 @@ let vdi =
                vdi_disable_cbt;
                vdi_set_cbt_enabled;
                vdi_data_destroy;
-               vdi_export_changed_blocks;
+               vdi_list_changed_blocks;
                vdi_get_nbd_info;
               ]
     ~contents:

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1993,12 +1993,12 @@ let rec cmdtable_data : (string*cmd_spec) list =
       implementation=No_fd Cli_operations.vdi_data_destroy;
       flags=[];
     };
-    "vdi-export-changed-blocks",
+    "vdi-list-changed-blocks",
     {
       reqd=["vdi-from"; "vdi-to"];
       optn=[];
       help="Write the changed blocks between the two given VDIs to the standard output as a base64-encoded bitmap string.";
-      implementation=With_fd Cli_operations.vdi_export_changed_blocks;
+      implementation=With_fd Cli_operations.vdi_list_changed_blocks;
       flags=[];
     };
     "diagnostic-vdi-status",

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1260,10 +1260,10 @@ let vdi_data_destroy printer rpc session_id params =
   let vdi = Client.VDI.get_by_uuid rpc session_id (List.assoc "uuid" params) in
   Client.VDI.data_destroy rpc session_id vdi
 
-let vdi_export_changed_blocks socket _ rpc session_id params =
+let vdi_list_changed_blocks socket _ rpc session_id params =
   let vdi_from = Client.VDI.get_by_uuid rpc session_id (List.assoc "vdi-from" params) in
   let vdi_to = Client.VDI.get_by_uuid rpc session_id (List.assoc "vdi-to" params) in
-  let bitmap = Client.VDI.export_changed_blocks ~rpc ~session_id ~vdi_from ~vdi_to in
+  let bitmap = Client.VDI.list_changed_blocks ~rpc ~session_id ~vdi_from ~vdi_to in
   marshal socket (Command (Print bitmap))
 
 let diagnostic_vdi_status printer rpc session_id params =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3610,14 +3610,14 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
            forward_vdi_op ~local_fn ~__context ~self
              (fun session_id rpc -> Client.VDI.data_destroy rpc session_id self))
 
-    let export_changed_blocks ~__context ~vdi_from ~vdi_to =
-      info "VDI.export_changed_blocks: vdi_from  = '%s'; vdi_to = '%s'" (vdi_uuid ~__context vdi_from) (vdi_uuid ~__context vdi_to);
-      let local_fn = Local.VDI.export_changed_blocks ~vdi_from ~vdi_to in
+    let list_changed_blocks ~__context ~vdi_from ~vdi_to =
+      info "VDI.list_changed_blocks: vdi_from  = '%s'; vdi_to = '%s'" (vdi_uuid ~__context vdi_from) (vdi_uuid ~__context vdi_to);
+      let local_fn = Local.VDI.list_changed_blocks ~vdi_from ~vdi_to in
       let vdi_to_sr = Db.VDI.get_SR ~__context ~self:vdi_to in
-      with_sr_andor_vdi ~__context ~sr:(vdi_to_sr, `vdi_export_changed_blocks) ~vdi:(vdi_to, `export_changed_blocks) ~doc:"VDI.export_changed_blocks"
+      with_sr_andor_vdi ~__context ~sr:(vdi_to_sr, `vdi_list_changed_blocks) ~vdi:(vdi_to, `list_changed_blocks) ~doc:"VDI.list_changed_blocks"
         (fun () ->
            forward_vdi_op ~local_fn ~__context ~self:vdi_to
-             (fun session_id rpc -> Client.VDI.export_changed_blocks ~rpc ~session_id ~vdi_from ~vdi_to))
+             (fun session_id rpc -> Client.VDI.list_changed_blocks ~rpc ~session_id ~vdi_from ~vdi_to))
 
     let get_nbd_info ~__context ~self =
       info "VDI.get_nbd_info: vdi  = '%s'" (vdi_uuid ~__context self);

--- a/ocaml/xapi/record_util.ml
+++ b/ocaml/xapi/record_util.ml
@@ -112,7 +112,7 @@ let vdi_operation_to_string: API.vdi_operations -> string = function
   | `enable_cbt -> "enable_cbt"
   | `disable_cbt -> "disable_cbt"
   | `data_destroy -> "data_destroy"
-  | `export_changed_blocks -> "export_changed_blocks"
+  | `list_changed_blocks -> "list_changed_blocks"
   | `set_on_boot -> "set_on_boot"
   | `blocked -> "blocked"
 
@@ -134,7 +134,7 @@ let sr_operation_to_string: API.storage_operations -> string = function
   | `vdi_disable_cbt -> "VDI.disable_cbt"
   | `vdi_set_on_boot -> "VDI.set_on_boot"
   | `vdi_data_destroy -> "VDI.data_destroy"
-  | `vdi_export_changed_blocks -> "VDI.export_changed_blocks"
+  | `vdi_list_changed_blocks -> "VDI.list_changed_blocks"
   | `pbd_create -> "PBD.create"
   | `pbd_destroy -> "PBD.destroy"
 

--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -220,10 +220,10 @@ let vdi_data_destroy dconf driver sr vdi =
   let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_data_destroy" [] in
   Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
 
-let vdi_export_changed_blocks dconf driver sr ~vdi_from ~vdi_to =
-  debug "vdi_export_changed_blocks" driver (sprintf "sr=%s vdi_from=%s vdi_to=%s" (Ref.string_of sr) (Ref.string_of vdi_from) (Ref.string_of vdi_to));
+let vdi_list_changed_blocks dconf driver sr ~vdi_from ~vdi_to =
+  debug "vdi_list_changed_blocks" driver (sprintf "sr=%s vdi_from=%s vdi_to=%s" (Ref.string_of sr) (Ref.string_of vdi_from) (Ref.string_of vdi_to));
   srmaster_only dconf;
-  let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi_from dconf "vdi_export_changed_blocks" [ Ref.string_of vdi_to ] in
+  let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi_from dconf "vdi_list_changed_blocks" [ Ref.string_of vdi_to ] in
   Sm_exec.parse_string (Sm_exec.exec_xmlrpc (driver_filename driver) call)
 
 let session_has_internal_sr_access ~__context ~sr =

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -848,18 +848,18 @@ module SMAPIv1 = struct
       call_cbt_function context ~f:Sm.vdi_data_destroy ~f_name:"VDI.data_destroy" ~dbg ~sr ~vdi;
       set_content_id context ~dbg ~sr ~vdi ~content_id:"/No content: this is a cbt_metadata VDI/"
 
-    let export_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to =
+    let list_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to =
       try
-        Server_helpers.exec_with_new_task "VDI.export_changed_blocks" ~subtask_of:(Ref.of_string dbg)
+        Server_helpers.exec_with_new_task "VDI.list_changed_blocks" ~subtask_of:(Ref.of_string dbg)
           (fun __context ->
              let vdi_from = find_vdi ~__context sr vdi_from |> fst in
-             for_vdi ~dbg ~sr ~vdi:vdi_to "VDI.export_changed_blocks"
+             for_vdi ~dbg ~sr ~vdi:vdi_to "VDI.list_changed_blocks"
                (fun device_config _type sr vdi_to ->
-                  Sm.vdi_export_changed_blocks device_config _type sr ~vdi_from ~vdi_to
+                  Sm.vdi_list_changed_blocks device_config _type sr ~vdi_from ~vdi_to
                ))
       with
       | Smint.Not_implemented_in_backend ->
-        raise (Unimplemented "VDI.export_changed_blocks")
+        raise (Unimplemented "VDI.list_changed_blocks")
       | Api_errors.Server_error(code, params) ->
         raise (Backend_error(code, params))
       | Sm.MasterOnly -> redirect sr

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -593,11 +593,11 @@ module Wrapper = functor(Impl: Server_impl) -> struct
         )
 
     (** The [sr] parameter is the SR of VDI [vdi_to]. *)
-    let export_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to =
-      info "VDI.export_changed_blocks dbg:%s sr:%s vdi_from:%s vdi_to:%s" dbg sr vdi_from vdi_to;
+    let list_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to =
+      info "VDI.list_changed_blocks dbg:%s sr:%s vdi_from:%s vdi_to:%s" dbg sr vdi_from vdi_to;
       with_vdi sr vdi_to
         (fun () ->
-           Impl.VDI.export_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to
+           Impl.VDI.list_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to
         )
 
   end

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -169,7 +169,7 @@ module Debug_print_impl = struct
     let enable_cbt context ~dbg ~sr ~vdi = assert false
     let disable_cbt context ~dbg ~sr ~vdi = assert false
     let data_destroy context ~dbg ~sr ~vdi = assert false
-    let export_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to = assert false
+    let list_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to = assert false
 
 
   end

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -264,9 +264,9 @@ module Mux = struct
     let data_destroy context ~dbg ~sr ~vdi =
       let module C = Client(struct let rpc = of_sr sr end) in
       C.VDI.data_destroy ~dbg ~sr ~vdi
-    let export_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to =
+    let list_changed_blocks context ~dbg ~sr ~vdi_from ~vdi_to =
       let module C = Client(struct let rpc = of_sr sr end) in
-      C.VDI.export_changed_blocks ~dbg ~sr ~vdi_from ~vdi_to
+      C.VDI.list_changed_blocks ~dbg ~sr ~vdi_from ~vdi_to
 
   end
 

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -37,7 +37,7 @@ open Record_util
 
 let all_ops : API.storage_operations_set =
   [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy; `vdi_resize; `vdi_clone; `vdi_snapshot; `vdi_mirror;
-    `vdi_enable_cbt; `vdi_disable_cbt; `vdi_data_destroy; `vdi_export_changed_blocks; `vdi_set_on_boot; `vdi_introduce; `update; `pbd_create; `pbd_destroy ]
+    `vdi_enable_cbt; `vdi_disable_cbt; `vdi_data_destroy; `vdi_list_changed_blocks; `vdi_set_on_boot; `vdi_introduce; `update; `pbd_create; `pbd_destroy ]
 
 let sm_cap_table : (API.storage_operations * _) list =
   [ `vdi_create, Smint.Vdi_create;
@@ -48,7 +48,7 @@ let sm_cap_table : (API.storage_operations * _) list =
     `vdi_enable_cbt, Smint.Vdi_configure_cbt;
     `vdi_disable_cbt, Smint.Vdi_configure_cbt;
     `vdi_data_destroy, Smint.Vdi_configure_cbt;
-    `vdi_export_changed_blocks, Smint.Vdi_configure_cbt;
+    `vdi_list_changed_blocks, Smint.Vdi_configure_cbt;
     `vdi_set_on_boot, Smint.Vdi_reset_on_boot;
     `update, Smint.Sr_update;
     (* We fake clone ourselves *)

--- a/ocaml/xapi/xapi_vdi.mli
+++ b/ocaml/xapi/xapi_vdi.mli
@@ -212,7 +212,7 @@ val disable_cbt :
   __context:Context.t -> self:API.ref_VDI -> unit
 val set_cbt_enabled :
   __context:Context.t -> self:API.ref_VDI -> value:bool -> unit
-val export_changed_blocks :
+val list_changed_blocks :
   __context:Context.t -> vdi_from:API.ref_VDI -> vdi_to:API.ref_VDI -> string
 val get_nbd_info :
   __context:Context.t -> self:API.ref_VDI -> string list


### PR DESCRIPTION
Because the latter is clearer. People found the function name
export_changed_blocks confusing, because it suggested that the actual
data of the changed blocks will be "exported".

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>