### PR TITLE
Xapi_vdi.data_destroy: don't call update_allowed_operations

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -596,7 +596,6 @@ let data_destroy ~__context ~self =
   if Db.VDI.get_type ~__context ~self <> `cbt_metadata then begin
     destroy_and_data_destroy_common ~__context ~self ~operation:`data_destroy;
     Db.VDI.set_type ~__context ~self ~value:`cbt_metadata;
-    update_allowed_operations ~__context ~self
   end
 
 let resize_online ~__context ~vdi ~size =


### PR DESCRIPTION
Because it is already updated in the message forwarding layer by
unmark_vdi called from with_sr_andor_vdi, and we use that function for
data_destroy.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>