### PR TITLE
CA-265161: Enable default values for enums

### DIFF
--- a/ocaml/idl/ocaml_backend/genOCaml.ml
+++ b/ocaml/idl/ocaml_backend/genOCaml.ml
@@ -44,7 +44,7 @@ let ty_to_xmlrpc api ty =
     | Enum(_, cs) ->
       let aux (c, _) = constructor_of c^" -> \""^c^"\"" in
       "    fun v -> To.string(match v with\n  "^indent^
-      String.concat ("\n"^indent^"| ") (List.map aux cs)^")"
+      String.concat ("\n"^indent^"| ") (List.map aux cs)^" | `unknown -> failwith \"No marshalling of `unknown\")"
     | Float -> "To.double"
     | Int -> "fun n -> To.string(Int64.to_string n)"
     | Map(key, value) ->
@@ -52,7 +52,7 @@ let ty_to_xmlrpc api ty =
         | Ref x -> "tostring_reference"
         | Enum (name, cs) ->
           let aux (c, _) = Printf.sprintf "%s -> \"%s\"" (constructor_of c) (String.lowercase c) in
-          "   function " ^ (String.concat ("\n" ^ indent ^ "| ") (List.map aux cs))
+          "   function " ^ (String.concat ("\n" ^ indent ^ "| ") ((List.map aux cs) @ ["`unknown -> failwith \"No marshalling of `unknown\""]))
         | key -> "ToString." ^ (alias_of_ty key)
       end in
       let vf = alias_of_ty value in

--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -28,7 +28,7 @@ let overrides = [
     "let rpc_of_vm_operations_to_string_map x = Rpc.Dict (List.map (fun (x,y) -> (match rpc_of_vm_operations x with Rpc.String x -> x | _ -> failwith \"Marshalling error\"), Rpc.String y) x)\n" ^
     "let vm_operations_to_string_map_of_rpc x = match x with Rpc.Dict l -> List.map (function (x,y) -> vm_operations_of_rpc (Rpc.String x), string_of_rpc y) l | _ -> failwith \"Unmarshalling error\"\n");
   "bond_mode",(
-    "let rpc_of_bond_mode x = match x with `balanceslb -> Rpc.String \"balance-slb\" | `activebackup -> Rpc.String \"active-backup\" | `lacp -> Rpc.String \"lacp\"\n"^
+    "let rpc_of_bond_mode x = match x with `balanceslb -> Rpc.String \"balance-slb\" | `activebackup -> Rpc.String \"active-backup\" | `lacp -> Rpc.String \"lacp\" | `unknown -> failwith \"No marshalling `unknown values\" \n"^
     "let bond_mode_of_rpc x = match x with Rpc.String \"balance-slb\" -> `balanceslb | Rpc.String \"active-backup\" -> `activebackup | Rpc.String \"lacp\" -> `lacp | _ -> failwith \"Unmarshalling error in bond-mode\"\n");
   "int64_to_float_map",(
     "let rpc_of_int64_to_float_map x = Rpc.Dict (List.map (fun (x,y) -> Int64.to_string x, Rpc.Float y) x)\n" ^
@@ -40,7 +40,7 @@ let overrides = [
     "let rpc_of_int64_to_string_set_map x = Rpc.Dict (List.map (fun (x,y) -> Int64.to_string x, rpc_of_string_set y) x)\n" ^
     "let int64_to_string_set_map_of_rpc x = match x with Rpc.Dict x -> List.map (fun (x,y) -> Int64.of_string x, string_set_of_rpc y) x | _ -> failwith \"Unmarshalling error\"");
   "event_operation",(
-    "let rpc_of_event_operation x = match x with | `add -> Rpc.String \"add\" | `del -> Rpc.String \"del\" | `_mod -> Rpc.String \"mod\"\n"^
+    "let rpc_of_event_operation x = match x with | `add -> Rpc.String \"add\" | `del -> Rpc.String \"del\" | `_mod -> Rpc.String \"mod\" | `unknown -> failwith \"no marshalling `unknown values\"\n"^
     "let event_operation_of_rpc x = match x with | Rpc.String \"add\" -> `add | Rpc.String \"del\" -> `del | Rpc.String \"mod\" -> `_mod | _ -> failwith \"Unmarshalling error\"");
 
 ]

--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -29,7 +29,7 @@ let overrides = [
     "let vm_operations_to_string_map_of_rpc x = match x with Rpc.Dict l -> List.map (function (x,y) -> vm_operations_of_rpc (Rpc.String x), string_of_rpc y) l | _ -> failwith \"Unmarshalling error\"\n");
   "bond_mode",(
     "let rpc_of_bond_mode x = match x with `balanceslb -> Rpc.String \"balance-slb\" | `activebackup -> Rpc.String \"active-backup\" | `lacp -> Rpc.String \"lacp\" | `unknown -> failwith \"No marshalling `unknown values\" \n"^
-    "let bond_mode_of_rpc x = match x with Rpc.String \"balance-slb\" -> `balanceslb | Rpc.String \"active-backup\" -> `activebackup | Rpc.String \"lacp\" -> `lacp | _ -> failwith \"Unmarshalling error in bond-mode\"\n");
+    "let bond_mode_of_rpc x = match x with Rpc.String \"balance-slb\" -> `balanceslb | Rpc.String \"active-backup\" -> `activebackup | Rpc.String \"lacp\" -> `lacp | Rpc.String _ | Rpc.Enum ((Rpc.String _)::_) -> `unknown | _ -> failwith \"Unmarshalling error in bond-mode\"\n");
   "int64_to_float_map",(
     "let rpc_of_int64_to_float_map x = Rpc.Dict (List.map (fun (x,y) -> Int64.to_string x, Rpc.Float y) x)\n" ^
     "let int64_to_float_map_of_rpc x = match x with Rpc.Dict x -> List.map (fun (x,y) -> Int64.of_string x, float_of_rpc y) x | _ -> failwith \"Unmarshalling error\"");
@@ -41,7 +41,7 @@ let overrides = [
     "let int64_to_string_set_map_of_rpc x = match x with Rpc.Dict x -> List.map (fun (x,y) -> Int64.of_string x, string_set_of_rpc y) x | _ -> failwith \"Unmarshalling error\"");
   "event_operation",(
     "let rpc_of_event_operation x = match x with | `add -> Rpc.String \"add\" | `del -> Rpc.String \"del\" | `_mod -> Rpc.String \"mod\" | `unknown -> failwith \"no marshalling `unknown values\"\n"^
-    "let event_operation_of_rpc x = match x with | Rpc.String \"add\" -> `add | Rpc.String \"del\" -> `del | Rpc.String \"mod\" -> `_mod | _ -> failwith \"Unmarshalling error\"");
+    "let event_operation_of_rpc x = match x with | Rpc.String \"add\" -> `add | Rpc.String \"del\" -> `del | Rpc.String \"mod\" -> `_mod | Rpc.String _ | Rpc.Enum ((Rpc.String _)::_) -> `unknown | _ -> failwith \"Unmarshalling error\"");
 
 ]
 

--- a/ocaml/idl/ocaml_backend/gen_db_actions.ml
+++ b/ocaml/idl/ocaml_backend/gen_db_actions.ml
@@ -57,7 +57,7 @@ let dm_to_string tys : O.Module.t =
         let aux (c, _) = (OU.constructor_of c)^" -> \""^c^"\"" in
         "\n    fun v -> match v with\n      "^
         String.concat "\n    | " (List.map aux cs)
-      (* ^"\n    | _ -> raise (StringEnumTypeError \""^name^"\")" *)
+        ^"\n    | `unknown -> raise (StringEnumTypeError \""^name^"\")"
       | DT.Float -> "Printf.sprintf \"%0.18g\""
       | DT.Int -> "Int64.to_string"
       | DT.Map(key, value) ->

--- a/ocaml/idl/ocaml_backend/ocaml_utils.ml
+++ b/ocaml/idl/ocaml_backend/ocaml_utils.ml
@@ -59,7 +59,7 @@ let ocaml_of_module_name x =
 
 (** Convert an IDL enum into a polymorhic variant. *)
 let ocaml_of_enum list =
-  "[ "^String.concat " | " (List.map constructor_of list)^" ]"
+  "[ "^String.concat " | " (List.map constructor_of list)^" | `unknown ]"
 
 (** Convert an IDL type to a function name; we need to generate functions to
     marshal/unmarshal from XML for each unique IDL type *)

--- a/ocaml/idl/ocaml_backend/ocaml_utils.ml
+++ b/ocaml/idl/ocaml_backend/ocaml_utils.ml
@@ -59,7 +59,7 @@ let ocaml_of_module_name x =
 
 (** Convert an IDL enum into a polymorhic variant. *)
 let ocaml_of_enum list =
-  "[ "^String.concat " | " (List.map constructor_of list)^" | `unknown ]"
+  "[ "^String.concat " | " (List.map constructor_of list)^" | `unknown ] [@default `unknown]"
 
 (** Convert an IDL type to a function name; we need to generate functions to
     marshal/unmarshal from XML for each unique IDL type *)

--- a/ocaml/xapi-types/event_types.ml
+++ b/ocaml/xapi-types/event_types.ml
@@ -75,7 +75,7 @@ let rec rpc_of_event_from e =
 
 open Printf
 
-let string_of_op = function `add -> "add" | `_mod -> "mod" | `del -> "del"
+let string_of_op = function `add -> "add" | `_mod -> "mod" | `del -> "del" | `unknown -> "unknown"
 let op_of_string x = match String.lowercase x with
   | "add" -> `add | "mod" -> `_mod | "del" -> `del
   | x -> failwith (sprintf "Unknown operation type: %s" x)

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -336,6 +336,8 @@ let string_of_task_status task = match task.API.task_status with
     "Cancelling"
   | `cancelled ->
     "Cancelled"
+  | `unknown ->
+    "Unknown"
 
 (*let task_list printer rpc session_id params =
   let internal = try (List.assoc "internal" params)="true" with _ -> false in
@@ -4892,6 +4894,7 @@ let livepatch_status_to_string state =
   | `ok -> "Ok."
   | `ok_livepatch_complete -> "Ok: Patch can be applied without reboot."
   | `ok_livepatch_incomplete -> "Ok: Patch can be applied, but a reboot will be required."
+  | `unknown -> "Unknown status!"
 
 let update_precheck printer rpc session_id params =
   let uuid = List.assoc "uuid" params in

--- a/ocaml/xapi/cli_util.ml
+++ b/ocaml/xapi/cli_util.ml
@@ -69,6 +69,8 @@ let result_from_task rpc session_id remote_task =
     failwith "wait_for_task_completion failed; task is still pending"
   | `success ->
     ()
+  | `unknown ->
+    failwith "unknown task status"
   | `failure ->
     let error_info = Client.Task.get_error_info rpc session_id remote_task in
     let trace = Client.Task.get_backtrace rpc session_id remote_task in
@@ -77,8 +79,6 @@ let result_from_task rpc session_id remote_task =
       | [] -> Failure (Printf.sprintf "Task failed but no error recorded: %s" (Ref.string_of remote_task)) in
     Backtrace.(add exn (t_of_sexp (Sexplib.Sexp.of_string trace)));
     raise exn
-  | `unknown ->
-    failwith "unknown task status"
 
 (** Use the event system to wait for a specific task to complete (succeed, failed or be cancelled) *)
 let wait_for_task_completion = track (fun _ -> ())

--- a/ocaml/xapi/cli_util.ml
+++ b/ocaml/xapi/cli_util.ml
@@ -77,6 +77,8 @@ let result_from_task rpc session_id remote_task =
       | [] -> Failure (Printf.sprintf "Task failed but no error recorded: %s" (Ref.string_of remote_task)) in
     Backtrace.(add exn (t_of_sexp (Sexplib.Sexp.of_string trace)));
     raise exn
+  | `unknown ->
+    failwith "unknown task status"
 
 (** Use the event system to wait for a specific task to complete (succeed, failed or be cancelled) *)
 let wait_for_task_completion = track (fun _ -> ())

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -944,6 +944,9 @@ module VBD : HandlerTools = struct
 
       let vbd_record = { vbd_record with API.vBD_VM = vm } in
       match vbd_record.API.vBD_type, exists vbd_record.API.vBD_VDI state.table with
+      | `unknown, _ ->
+        warn "Unknown VBD type. Ignoring.";
+        Skip
       | `CD, false | `Floppy, false  ->
         if has_booted_hvm || original_vm.API.vM_power_state <> `Suspended then
           Create { vbd_record with API.vBD_VDI = Ref.null; API.vBD_empty = true }  (* eject *)

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -301,6 +301,10 @@ let remote_metadata_export_import ~__context ~rpc ~session_id ~remote_address ~r
                let result = Client.Task.get_result rpc session_id remote_task in
                API.Legacy.From.ref_VM_set "" (Xml.parse_string result)
              end
+           | `unknown -> begin
+              error "Remote metadata import reported unknown task status. This is a failure";
+              raise (Api_errors.Server_error(Api_errors.internal_error, ["Unknown task result enum"]))
+           end
         )
         (fun () -> Client.Task.destroy rpc session_id remote_task )
     )

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -367,6 +367,7 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
           (* Configure IPv4 parameters and DNS *)
           let ipv4_conf, ipv4_gateway, dns =
             match rc.API.pIF_ip_configuration_mode with
+            | `unknown -> raise (Api_errors.Server_error(Api_errors.field_type_error,["ip_configuration_mode"]))
             | `None -> None4, None, ([], [])
             | `DHCP -> DHCP4, None, ([], [])
             | `Static ->
@@ -403,6 +404,7 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
           (* Configure IPv6 parameters *)
           let ipv6_conf, ipv6_gateway =
             match rc.API.pIF_ipv6_configuration_mode with
+            | `unknown -> raise (Api_errors.Server_error(Api_errors.field_type_error,["ipv6_configuration_mode"]))
             | `None -> Linklocal6, None
             | `DHCP -> DHCP6, None
             | `Autoconf -> Autoconf6, None

--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -774,7 +774,8 @@ let async_test session_id =
                  | `success -> "success"
                  | `failure -> "failure"
                  | `cancelling -> "cancelling"
-                 | `cancelled -> "cancelled")
+                 | `cancelled -> "cancelled"
+                 | `unknown -> "unknown")
                 (Client.Task.get_result !rpc session_id task));
   if status=`failure then
     begin

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -216,7 +216,7 @@ let message_record rpc session_id message =
         make_field ~name:"uuid"         ~get:(fun () -> (x ()).API.message_uuid) ();
         make_field ~name:"name"         ~get:(fun () -> (x ()).API.message_name) ();
         make_field ~name:"priority"     ~get:(fun () -> Int64.to_string (x ()).API.message_priority) ();
-        make_field ~name:"class"        ~get:(fun () -> match (x ()).API.message_cls with `VM -> "VM" | `Host -> "Host" | `SR -> "SR" | `Pool -> "Pool" | `VMPP -> "VMPP" | `VMSS -> "VMSS" | `PVS_proxy -> "PVS_proxy") ();
+        make_field ~name:"class"        ~get:(fun () -> match (x ()).API.message_cls with `VM -> "VM" | `Host -> "Host" | `SR -> "SR" | `Pool -> "Pool" | `VMPP -> "VMPP" | `VMSS -> "VMSS" | `PVS_proxy -> "PVS_proxy" | `unknown -> "unknown") ();
         make_field ~name:"obj-uuid"     ~get:(fun () -> (x ()).API.message_obj_uuid) ();
         make_field ~name:"timestamp"    ~get:(fun () -> Date.to_string (x ()).API.message_timestamp) ();
         make_field ~name:"body"         ~get:(fun () -> (x ()).API.message_body) ();
@@ -1033,17 +1033,8 @@ let pool_patch_record rpc session_id patch =
     let host_uuids = List.map (fun x -> Client.Host.get_uuid ~rpc ~session_id ~self:x) host_refs in
     host_uuids
   in
-  let after_apply_guidance_to_string = function
-    | `restartHVM -> "restartHVM"
-    | `restartPV -> "restartPV"
-    | `restartHost -> "restartHost"
-    | `restartXAPI -> "restartXAPI"
-  in
-  let after_apply_guidance_to_string_set =
-    List.map after_apply_guidance_to_string
-  in
   let after_apply_guidance () =
-    after_apply_guidance_to_string_set (x ()).API.pool_patch_after_apply_guidance
+    Record_util.after_apply_guidance_to_string_set (x ()).API.pool_patch_after_apply_guidance
   in
   { setref=(fun r -> _ref := r; record := empty_record );
     setrefrec=(fun (a,b) -> _ref := a; record := Got b);
@@ -1070,17 +1061,8 @@ let pool_update_record rpc session_id update =
     let host_uuids = List.map (fun x -> Client.Host.get_uuid ~rpc ~session_id ~self:x) host_refs in
     host_uuids
   in
-  let after_apply_guidance_to_string = function
-    | `restartHVM -> "restartHVM"
-    | `restartPV -> "restartPV"
-    | `restartHost -> "restartHost"
-    | `restartXAPI -> "restartXAPI"
-  in
-  let after_apply_guidance_to_string_set =
-    List.map after_apply_guidance_to_string
-  in
   let after_apply_guidance () =
-    after_apply_guidance_to_string_set (x ()).API.pool_update_after_apply_guidance
+    Record_util.after_apply_guidance_to_string_set (x ()).API.pool_update_after_apply_guidance
   in
   { setref=(fun r -> _ref := r; record := empty_record );
     setrefrec=(fun (a,b) -> _ref := a; record := Got b);
@@ -1342,9 +1324,9 @@ let vbd_record rpc session_id vbd =
           ~set:(fun dev -> Client.VBD.set_userdevice rpc session_id vbd dev) ();
         make_field ~name:"bootable" ~get:(fun () -> string_of_bool (x ()).API.vBD_bootable)
           ~set:(fun boot -> Client.VBD.set_bootable rpc session_id vbd (safe_bool_of_string "bootable" boot)) ();
-        make_field ~name:"mode" ~get:(fun () -> match (x ()).API.vBD_mode with `RO -> "RO" | `RW -> "RW")
+        make_field ~name:"mode" ~get:(fun () -> match (x ()).API.vBD_mode with `RO -> "RO" | `RW -> "RW" | `unknown -> "unknown")
           ~set:(fun mode -> Client.VBD.set_mode rpc session_id vbd (Record_util.string_to_vbd_mode mode)) ();
-        make_field ~name:"type" ~get:(fun () -> match (x ()).API.vBD_type with `CD -> "CD" | `Disk -> "Disk" | `Floppy -> "Floppy")
+        make_field ~name:"type" ~get:(fun () -> match (x ()).API.vBD_type with `CD -> "CD" | `Disk -> "Disk" | `Floppy -> "Floppy" | `unknown -> "unknown")
           ~set:(fun ty -> Client.VBD.set_type rpc session_id vbd (Record_util.string_to_vbd_type ty)) ();
         make_field ~name:"unpluggable" ~get:(fun () -> string_of_bool (x ()).API.vBD_unpluggable)
           ~set:(fun unpluggable -> Client.VBD.set_unpluggable rpc session_id vbd (safe_bool_of_string "unpluggable" unpluggable)) ();

--- a/ocaml/xapi/sm_fs_ops.ml
+++ b/ocaml/xapi/sm_fs_ops.ml
@@ -33,7 +33,8 @@ let with_open_block_attached_device __context rpc session_id vdi mode f =
     (fun path ->
        let mode' = match mode with
          | `RO -> [ Unix.O_RDONLY ]
-         | `RW -> [ Unix.O_RDWR ] in
+         | `RW -> [ Unix.O_RDWR ]
+         | `unknown -> failwith "Cannot use unknown mode" in
        let fd = Unix.openfile path mode' 0 in
        Stdext.Pervasiveext.finally
          (fun () -> f fd)

--- a/ocaml/xapi/suite.ml
+++ b/ocaml/xapi/suite.ml
@@ -66,6 +66,7 @@ let base_suite =
     Test_vlan.test;
     Test_xapi_vbd_helpers.test;
     Test_sr_update_vdis.test;
+    Test_xapi_vdi.test;
   ]
 
 let handlers = [

--- a/ocaml/xapi/test_storage_common.ml
+++ b/ocaml/xapi/test_storage_common.ml
@@ -1,0 +1,25 @@
+let register_smapiv2_server (module S: Storage_interface.Server_impl with type context = unit) sr_ref =
+let module S = Storage_interface.Server(S) in
+let rpc = S.process () in
+let dummy_query_result = Storage_interface.({ driver=""; name=""; description=""; vendor=""; copyright=""; version=""; required_api_version=""; features=[]; configuration=[]; required_cluster_stack=[] }) in
+Storage_mux.register sr_ref rpc "" dummy_query_result
+
+let make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone () =
+let default a b = match a with
+  | Some a -> a
+  | None -> b
+in
+(module struct
+  include (Storage_skeleton: module type of Storage_skeleton with module VDI := Storage_skeleton.VDI)
+  module VDI = struct
+    include Storage_skeleton.VDI
+    let enable_cbt = default vdi_enable_cbt Storage_skeleton.VDI.enable_cbt
+    let disable_cbt = default vdi_disable_cbt Storage_skeleton.VDI.disable_cbt
+    let snapshot = default vdi_snapshot Storage_skeleton.VDI.snapshot
+    let clone = default vdi_snapshot Storage_skeleton.VDI.clone
+  end
+end : Storage_interface.Server_impl with type context = unit)
+
+let register_smapiv2_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone sr_ref =
+let s = make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone () in
+register_smapiv2_server s sr_ref

--- a/ocaml/xapi/test_storage_common.ml
+++ b/ocaml/xapi/test_storage_common.ml
@@ -4,7 +4,7 @@ let rpc = S.process () in
 let dummy_query_result = Storage_interface.({ driver=""; name=""; description=""; vendor=""; copyright=""; version=""; required_api_version=""; features=[]; configuration=[]; required_cluster_stack=[] }) in
 Storage_mux.register sr_ref rpc "" dummy_query_result
 
-let make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone () =
+let make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone ?vdi_create () =
 let default a b = match a with
   | Some a -> a
   | None -> b
@@ -13,6 +13,7 @@ in
   include (Storage_skeleton: module type of Storage_skeleton with module VDI := Storage_skeleton.VDI)
   module VDI = struct
     include Storage_skeleton.VDI
+    let create = default vdi_create Storage_skeleton.VDI.create
     let enable_cbt = default vdi_enable_cbt Storage_skeleton.VDI.enable_cbt
     let disable_cbt = default vdi_disable_cbt Storage_skeleton.VDI.disable_cbt
     let snapshot = default vdi_snapshot Storage_skeleton.VDI.snapshot
@@ -20,6 +21,6 @@ in
   end
 end : Storage_interface.Server_impl with type context = unit)
 
-let register_smapiv2_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone sr_ref =
-let s = make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone () in
+let register_smapiv2_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone ?vdi_create sr_ref =
+let s = make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone ?vdi_create () in
 register_smapiv2_server s sr_ref

--- a/ocaml/xapi/test_vdi_allowed_operations.ml
+++ b/ocaml/xapi/test_vdi_allowed_operations.ml
@@ -165,6 +165,10 @@ let test_ca126097 () =
           ~value:["mytask", `copy])
     `snapshot (Some (Api_errors.operation_not_allowed, []))
 
+let test_unknown_ops () =
+  let __context = Mock.make_context_with_new_db "Mock context" in
+  run_assert_equal_with_vdi ~__context `unknown (Some (Api_errors.sr_operation_not_supported, ["Unknown operation"]))
+
 (** Tests for the checks related to changed block tracking *)
 let test_cbt =
   let all_cbt_operations = [`enable_cbt; `disable_cbt] in
@@ -320,6 +324,7 @@ let test =
     "test_ca101669" >:: test_ca101669;
     "test_ca125187" >:: test_ca125187;
     "test_ca126097" >:: test_ca126097;
+    "test_unknown_ops" >:: test_unknown_ops;
     test_cbt;
     test_operations_restricted_during_rpu;
   ]

--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -1,29 +1,4 @@
 
-let register_smapiv2_server (module S: Storage_interface.Server_impl with type context = unit) sr_ref =
-  let module S = Storage_interface.Server(S) in
-  let rpc = S.process () in
-  let dummy_query_result = Storage_interface.({ driver=""; name=""; description=""; vendor=""; copyright=""; version=""; required_api_version=""; features=[]; configuration=[]; required_cluster_stack=[] }) in
-  Storage_mux.register sr_ref rpc "" dummy_query_result
-
-let make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone () =
-  let default a b = match a with
-    | Some a -> a
-    | None -> b
-  in
-  (module struct
-    include (Storage_skeleton: module type of Storage_skeleton with module VDI := Storage_skeleton.VDI)
-    module VDI = struct
-      include Storage_skeleton.VDI
-      let enable_cbt = default vdi_enable_cbt Storage_skeleton.VDI.enable_cbt
-      let disable_cbt = default vdi_disable_cbt Storage_skeleton.VDI.disable_cbt
-      let snapshot = default vdi_snapshot Storage_skeleton.VDI.snapshot
-      let clone = default vdi_snapshot Storage_skeleton.VDI.clone
-    end
-  end : Storage_interface.Server_impl with type context = unit)
-
-let register_smapiv2_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone sr_ref =
-  let s = make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_snapshot ?vdi_clone () in
-  register_smapiv2_server s sr_ref
 
 let test_cbt_enable_disable () =
   let __context = Test_common.make_test_database () in
@@ -36,7 +11,7 @@ let test_cbt_enable_disable () =
 
   let enable_cbt_params = ref None in
   let disable_cbt_params = ref None in
-  register_smapiv2_server
+  Test_storage_common.register_smapiv2_server
     ~vdi_enable_cbt:(fun _ ~dbg ~sr ~vdi -> enable_cbt_params := Some (sr, vdi))
     ~vdi_disable_cbt:(fun _ ~dbg ~sr ~vdi -> disable_cbt_params := Some (sr, vdi))
     sr_uuid;
@@ -81,7 +56,7 @@ let test_clone_and_snapshot_correctly_sets_cbt_enabled_field () =
     let uuid = Test_common.make_uuid () in
     Storage_interface.{ default_vdi_info with vdi = uuid }
   in
-  register_smapiv2_server ~vdi_snapshot:stub ~vdi_clone:stub (Db.SR.get_uuid ~__context ~self:sR);
+  Test_storage_common.register_smapiv2_server ~vdi_snapshot:stub ~vdi_clone:stub (Db.SR.get_uuid ~__context ~self:sR);
 
   let snapshot = Xapi_vdi.snapshot ~__context ~vdi ~driver_params:[] in
   assert_cbt_enabled_field_is ~vdi:snapshot ~value:false ~msg:"The cbt_enabled property should be inherited from the snapshotted VDI - it should be false for the snapshot of a VDI with CBT disabled.";

--- a/ocaml/xapi/test_xapi_vdi.ml
+++ b/ocaml/xapi/test_xapi_vdi.ml
@@ -1,0 +1,75 @@
+open OUnit
+
+let vdi_create () ~dbg ~(sr:Storage_interface.sr) ~(vdi_info:Storage_interface.vdi_info) =
+  vdi_info
+
+
+let setup f =
+  let __context = Test_common.make_test_database () in
+  let sR = Test_common.make_sr ~__context () in
+  let sr_uuid = Db.SR.get_uuid ~__context ~self:sR in
+  let host = Helpers.get_localhost ~__context in
+  let _pbd = Test_common.make_pbd ~__context ~host ~sR ~currently_attached:true () in
+  Test_storage_common.register_smapiv2_server
+    ~vdi_create
+    sr_uuid;
+  f ~__context ~sR ~sr_uuid ~host
+
+let test_vdi_create_ok () =
+  setup (fun ~__context ~sR ~sr_uuid ~host ->
+      let vdi_ref = Xapi_vdi.create
+          ~__context
+          ~name_label:"test"
+          ~name_description:"description"
+          ~sR
+          ~virtual_size:1000L
+          ~_type:`crashdump
+          ~sharable:false
+          ~read_only:false
+          ~other_config:[]
+          ~xenstore_data:[]
+          ~sm_config:[]
+          ~tags:[]
+      in
+      assert_equal (Db.VDI.get_name_label ~__context ~self:vdi_ref) "test")
+
+let test_vdi_create_bad_type_fail () =
+  setup (fun ~__context ~sR ~sr_uuid ~host ->
+    Test_common.assert_raises_api_error Api_errors.vdi_incompatible_type (fun () ->
+          Xapi_vdi.create
+            ~__context
+            ~name_label:"test"
+            ~name_description:"description"
+            ~sR
+            ~virtual_size:1000L
+            ~_type:`cbt_metadata
+            ~sharable:false
+            ~read_only:false
+            ~other_config:[]
+            ~xenstore_data:[]
+            ~sm_config:[]
+            ~tags:[]))
+
+let test_vdi_create_bad_type2_fail () =
+  setup (fun ~__context ~sR ~sr_uuid ~host ->
+      Test_common.assert_raises_api_error Api_errors.field_type_error (fun () ->
+          Xapi_vdi.create
+            ~__context
+            ~name_label:"test"
+            ~name_description:"description"
+            ~sR
+            ~virtual_size:1000L
+            ~_type:`unknown
+            ~sharable:false
+            ~read_only:false
+            ~other_config:[]
+            ~xenstore_data:[]
+            ~sm_config:[]
+            ~tags:[]))
+
+let test =
+  "test_xapi_vdi" >::: [
+    "test_vdi_create_ok" >:: test_vdi_create_ok;
+    "test_vdi_create_bad_type_fail" >:: test_vdi_create_bad_type_fail;
+    "test_vdi_create_bad_type2_fail" >:: test_vdi_create_bad_type2_fail;
+  ]

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -345,6 +345,9 @@ let attempt_pool_hello my_ip =
            Some Permanent
          | `ok ->
            None
+         | `unknown ->
+           error "Unknown result from Master";
+           Some Permanent
       )
   with
   | Api_errors.Server_error(code, params) when code = Api_errors.session_authentication_failed ->

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -55,7 +55,7 @@ let class_to_string cls =
   | `VMPP -> "VMPP"
   | `VMSS -> "VMSS"
   | `PVS_proxy -> "PVS_proxy"
-  | _ -> "unknown"
+  | `unknown -> "unknown"
 
 let string_to_class str =
   match str with
@@ -228,6 +228,7 @@ let check_uuid ~__context ~cls ~uuid =
      | `VMPP -> ignore(Db.VMPP.get_by_uuid ~__context ~uuid)
      | `VMSS -> ignore(Db.VMSS.get_by_uuid ~__context ~uuid)
      | `PVS_proxy -> ignore(Db.PVS_proxy.get_by_uuid ~__context ~uuid)
+     | `unknown -> failwith "Unknown message type"
     );
     true
   with _ ->
@@ -377,7 +378,7 @@ let write ~__context ~_ref ~message =
 
 (** create: Create a new message, and write to disk. Returns null ref
     	if write failed, or message ref otherwise. *)
-let create ~__context ~name ~priority ~cls ~obj_uuid ~body =
+let create ~__context ~name ~priority ~(cls:API.cls) ~obj_uuid ~body =
   debug "Message.create %s %Ld %s %s" name priority
     (class_to_string cls) obj_uuid;
 
@@ -406,7 +407,7 @@ let create ~__context ~name ~priority ~cls ~obj_uuid ~body =
   let message = {API.message_name=name;
                  API.message_uuid=uuid;
                  API.message_priority=priority;
-                 API.message_cls=cls;
+                 API.message_cls=cls |> class_to_string |> string_to_class;
                  API.message_obj_uuid=obj_uuid;
                  API.message_timestamp=Date.of_float timestamp;
                  API.message_body=body;}

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -59,7 +59,7 @@ val db_introduce :
   mTU:int64 ->
   vLAN:int64 ->
   physical:bool ->
-  ip_configuration_mode:[< `DHCP | `None | `Static ] ->
+  ip_configuration_mode:API.ip_configuration_mode ->
   iP:string ->
   netmask:string ->
   gateway:string ->
@@ -69,10 +69,10 @@ val db_introduce :
   management:bool ->
   other_config:(string * string) list ->
   disallow_unplug:bool ->
-  ipv6_configuration_mode:[< `DHCP | `None | `Static | `Autoconf ] ->
+  ipv6_configuration_mode:API.ipv6_configuration_mode ->
   iPv6:string list ->
   ipv6_gateway:string ->
-  primary_address_type:[< `IPv4 | `IPv6 ] ->
+  primary_address_type:API.primary_address_type ->
   managed:bool ->
   properties:(string * string) list ->
   [ `PIF ] Ref.t
@@ -112,21 +112,21 @@ val destroy : __context:Context.t -> self:API.ref_PIF -> unit
 val reconfigure_ip :
   __context:Context.t ->
   self:API.ref_PIF ->
-  mode:[`DHCP | `None | `Static] ->
+  mode:API.ip_configuration_mode ->
   iP:string -> netmask:string -> gateway:string -> dNS:string -> unit
 
 (** Change the IPv6 configuration of a PIF *)
 val reconfigure_ipv6 :
   __context:Context.t ->
   self:API.ref_PIF ->
-  mode:[ `DHCP | `None | `Static | `Autoconf ] ->
+  mode:API.ipv6_configuration_mode ->
   iPv6:string -> gateway:string -> dNS:string -> unit
 
 (** Change the primary address type between IPv4 and IPv6 *)
 val set_primary_address_type :
   __context:Context.t ->
   self:API.ref_PIF ->
-  primary_address_type:[`IPv4 | `IPv6 ] -> unit
+  primary_address_type:API.primary_address_type -> unit
 
 (** Set the default properties of a PIF *)
 val set_default_properties :
@@ -199,7 +199,7 @@ val pool_introduce :
   mTU:int64 ->
   vLAN:int64 ->
   physical:bool ->
-  ip_configuration_mode:[< `DHCP | `None | `Static ] ->
+  ip_configuration_mode:API.ip_configuration_mode ->
   iP:string ->
   netmask:string ->
   gateway:string ->
@@ -209,10 +209,10 @@ val pool_introduce :
   management:bool ->
   other_config:(string * string) list ->
   disallow_unplug:bool ->
-  ipv6_configuration_mode:[< `DHCP | `None | `Static | `Autoconf ] ->
+  ipv6_configuration_mode:API.ipv6_configuration_mode ->
   iPv6:string list ->
   ipv6_gateway:string ->
-  primary_address_type:[< `IPv4 | `IPv6 ] ->
+  primary_address_type:API.primary_address_type ->
   managed:bool ->
   properties:(string * string) list ->
   [ `PIF ] Ref.t

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1093,6 +1093,7 @@ let eject ~__context ~host =
       | `None -> "none"
       | `DHCP -> "dhcp"
       | `Static -> "static"
+      | `unknown -> "unknown" (* What else can we do? Eject is pretty terminal anyway... *)
     in
 
     let write_first_boot_management_interface_configuration_file () =
@@ -1269,7 +1270,7 @@ let management_reconfigure ~__context ~network =
       raise (Api_errors.Server_error(Api_errors.pif_not_present, [Ref.string_of host; Ref.string_of network]));
   ) all_hosts;
 
-  let address_type = Db.PIF.get_primary_address_type ~__context ~self:(List.hd pifs_on_network) in 
+  let address_type = Db.PIF.get_primary_address_type ~__context ~self:(List.hd pifs_on_network) in
   List.iter (fun self ->
     let primary_address_type = Db.PIF.get_primary_address_type ~__context ~self in
     if primary_address_type <> address_type then

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -135,6 +135,7 @@ let create  ~__context ~vM ~vDI ~userdevice ~bootable ~mode ~_type ~unpluggable 
             (* already checked for [] above *)
             | `Floppy -> Device_number.to_linux_device (List.hd possibilities)
             | `CD | `Disk -> string_of_int (Device_number.to_disk_number (List.hd possibilities))
+            | `unknown -> raise Api_errors.(Server_error(field_type_error,["type"]))
           else userdevice
         in
 

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -148,7 +148,8 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
         | `no -> set_errors Api_errors.operation_not_allowed ["VM states it does not support VBD hotplug."] plug_ops
            (* according to xen docs PV drivers are enough for this to be possible *)
         | `unspecified when gmr.Db_actions.vM_guest_metrics_PV_drivers_detected -> ()
-        | `unspecified -> fallback ())
+        | `unspecified -> fallback ()
+        | `unknown -> set_errors Api_errors.operation_not_allowed ["Unknown state in VM_guest_metrics.can_use_hotplug_vbd"] plug_ops)
     );
     if record.Db_actions.vBD_type = `CD
     then set_errors Api_errors.operation_not_allowed

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -241,7 +241,7 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
         then Some (Api_errors.vdi_on_boot_mode_incompatible_with_operation, [])
         else None
       | `mirror | `clone | `generate_config | `force_unlock | `set_on_boot | `export_changed_blocks | `blocked | `update -> None
-      | `unknown -> None (* Note, this is caught above *)
+      | `unknown -> Some (Api_errors.sr_operation_not_supported, ["Unknown operation"]) (* Note, this is caught above *)
     end
 
 let assert_operation_valid ~__context ~self ~(op:API.vdi_operations) =

--- a/ocaml/xapi/xapi_vif.mli
+++ b/ocaml/xapi/xapi_vif.mli
@@ -118,13 +118,13 @@ val remove_ipv6_allowed :
 val configure_ipv4 :
   __context:Context.t ->
   self:[ `VIF ] Ref.t ->
-  mode:[`None | `Static] ->
+  mode:API.vif_ipv4_configuration_mode ->
   address:string -> gateway:string -> unit
 
 (** Change the IP configuration of a VIF *)
 val configure_ipv6 :
   __context:Context.t ->
   self:[ `VIF ] Ref.t ->
-  mode:[`None | `Static] ->
+  mode:API.vif_ipv6_configuration_mode ->
   address:string -> gateway:string -> unit
 

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -95,7 +95,10 @@ let valid_operations ~__context record _ref' : table =
         | `no -> set_errors Api_errors.operation_not_allowed ["VM states it does not support VIF hotplug."] [`plug; `unplug]
           (* according to xen docs PV drivers are enough for this to be possible *)
         | `unspecified when gmr.Db_actions.vM_guest_metrics_PV_drivers_detected -> ()
-        | `unspecified -> fallback ())
+        | `unspecified -> fallback ()
+        | `unknown ->
+          (* Safe fallback *)
+          set_errors Api_errors.operation_not_allowed ["VM states it does not support VIF hotplug."] [`plug; `unplug])
   );
 
   table

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -98,7 +98,7 @@ let valid_operations ~__context record _ref' : table =
         | `unspecified -> fallback ()
         | `unknown ->
           (* Safe fallback *)
-          set_errors Api_errors.operation_not_allowed ["VM states it does not support VIF hotplug."] [`plug; `unplug])
+          set_errors Api_errors.operation_not_allowed ["VIF hotplug support status unknown"] [`plug; `unplug])
   );
 
   table

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -29,22 +29,9 @@ val retrieve_wlb_recommendations :
   vm:[ `VM ] Ref.t -> (API.ref_host * string list) list
 val assert_agile : __context:Context.t -> self:[ `VM ] Ref.t -> unit
 val immediate_complete : __context:Context.t -> unit
-val set_actions_after_shutdown :
-  __context:Context.t ->
-  self:[ `VM ] Ref.t -> value:[< `destroy | `restart ] -> unit
-val set_actions_after_reboot :
-  __context:Context.t ->
-  self:[ `VM ] Ref.t -> value:[< `destroy | `restart ] -> unit
-val set_actions_after_crash :
-  __context:Context.t ->
-  self:[ `VM ] Ref.t ->
-  value:[< `coredump_and_destroy
-        | `coredump_and_restart
-        | `destroy
-        | `preserve
-        | `rename_restart
-        | `restart ] ->
-  unit
+val set_actions_after_shutdown : __context:Context.t -> self:API.ref_VM -> value:API.on_normal_exit -> unit
+val set_actions_after_reboot : __context:Context.t -> self:API.ref_VM -> value:API.on_normal_exit -> unit
+val set_actions_after_crash : __context:Context.t -> self:API.ref_VM -> value:API.on_crash_behaviour -> unit
 val set_is_a_template :
   __context:Context.t -> self:[ `VM ] Ref.t -> value:bool -> unit
 val set_is_default_template :
@@ -109,14 +96,9 @@ val create :
   vCPUs_params:(string * string) list ->
   vCPUs_max:int64 ->
   vCPUs_at_startup:int64 ->
-  actions_after_shutdown:[< `destroy | `restart ] ->
-  actions_after_reboot:[< `destroy | `restart ] ->
-  actions_after_crash:[< `coredump_and_destroy
-                      | `coredump_and_restart
-                      | `destroy
-                      | `preserve
-                      | `rename_restart
-                      | `restart ] ->
+  actions_after_shutdown:API.on_normal_exit ->
+  actions_after_reboot:API.on_normal_exit ->
+  actions_after_crash:API.on_crash_behaviour ->
   pV_bootloader:string ->
   pV_kernel:string ->
   pV_ramdisk:string ->

--- a/ocaml/xapi/xapi_vm_appliance_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_appliance_lifecycle.ml
@@ -38,7 +38,7 @@ let check_operation_error ~__context record self op =
         | `hard_shutdown | `shutdown ->
           (fun power_state -> power_state <> `Halted), "All VMs in this appliance are halted."
         | `unknown ->
-          (fun _ -> true), "Unknown power state"
+          (fun _ -> false), "Unknown power state"
       in
       if List.exists predicate power_states then
         None

--- a/ocaml/xapi/xapi_vm_appliance_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_appliance_lifecycle.ml
@@ -37,6 +37,8 @@ let check_operation_error ~__context record self op =
         (* Can hard_shutdown/shutdown if any are not halted. *)
         | `hard_shutdown | `shutdown ->
           (fun power_state -> power_state <> `Halted), "All VMs in this appliance are halted."
+        | `unknown ->
+          (fun _ -> true), "Unknown power state"
       in
       if List.exists predicate power_states then
         None

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -202,6 +202,7 @@ let validate_actions_after_crash ~__context ~self ~value =
   | `coredump_and_destroy -> hvm_cannot_coredump "coredump_and_destroy"
   | `coredump_and_restart -> hvm_cannot_coredump "coredump_and_restart"
   | `destroy | `restart | `preserve -> ()
+  | `unknown -> value_not_supported fld "unknown" "Unknown value"
 
 (* Used to sanity-check parameters before VM start *)
 let validate_basic_parameters ~__context ~self ~snapshot:x =

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -144,6 +144,7 @@ let allowed_power_states ~__context ~vmr ~(op:API.vm_operations) =
   | `update_allowed_operations
   | `query_services
     -> all_power_states
+  | `unknown -> []
 
 (** check if [op] can be done when [vmr] is in [power_state], when no other operation is in progress *)
 let is_allowed_sequentially ~__context ~vmr ~power_state ~op =


### PR DESCRIPTION
This means that when we extend enums in the datamodel, older hosts
will be able to unmarshal them (although they will still not know
what to do with them). This patch causes marshalling of an `unknown
to be an error in all cases, although unmarshalling is OK.

I'd like this reviewed carefully, since the requirement is that we
fail 'safe' on encountering an unknown enum.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>