### PR TITLE
CA-249810: Change pool update related log format

### DIFF
--- a/scripts/extensions/pool_update.apply
+++ b/scripts/extensions/pool_update.apply
@@ -49,7 +49,9 @@ def execute_apply(session, update_package, yum_conf_file):
     yum_env['LANG'] = 'C'
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
     output, _ = p.communicate()
-    xcp.logger.info('pool_update.apply %r returncode=%r output=%r', cmd, p.returncode, output)
+    xcp.logger.info('pool_update.apply %r returncode=%r output:', cmd, p.returncode)
+    for line in output.split('\n'):
+        xcp.logger.info(line)
     if p.returncode != 0:
         if ERROR_MESSAGE_DOWNLOAD_PACKAGE in output:
             raise InvalidUpdate('Missing package(s) in the update.')
@@ -67,7 +69,9 @@ def remove_group(group, yum_conf_file):
     cmd = ['yum', 'group', 'mark', 'remove', group, '-c', yum_conf_file]
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
     output, _ = p.communicate()
-    xcp.logger.info('pool_update.apply %r returncode=%r output=%r', cmd, p.returncode, output)
+    xcp.logger.info('pool_update.apply %r returncode=%r output:', cmd, p.returncode)
+    for line in output.split('\n'):
+        xcp.logger.info(line)
     if p.returncode != 0:
         raise ApplyFailure(output)
 

--- a/scripts/extensions/pool_update.precheck
+++ b/scripts/extensions/pool_update.precheck
@@ -123,7 +123,9 @@ def execute_precheck(session, control_package, yum_conf_file, update_precheck_fi
     yum_env['LANG'] = 'C'
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
     output, _ = p.communicate()
-    xcp.logger.info('pool_update.precheck %r returncode=%r output=%r', cmd, p.returncode, output)
+    xcp.logger.info('pool_update.precheck %r returncode=%r output:', cmd, p.returncode)
+    for line in output.split('\n'):
+        xcp.logger.info(line)
     if p.returncode != 0:
         if ERROR_MESSAGE_DOWNLOAD_PACKAGE in output:
             raise InvalidUpdate('Missing package(s) in the update')
@@ -186,7 +188,9 @@ def execute_precheck(session, control_package, yum_conf_file, update_precheck_fi
     if os.path.isfile(update_precheck_file):
         pp = subprocess.Popen(update_precheck_file, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
         precheck_output, _ = pp.communicate()
-        xcp.logger.info('pool_update.precheck %r precheck_output=%r', update_precheck_file, precheck_output)
+        xcp.logger.info('pool_update.precheck %r precheck_output:', update_precheck_file)
+        for line in precheck_output.split('\n'):
+            xcp.logger.info(line)
         if pp.returncode != 0:
             regex = ERROR_XML_START + '.+' + ERROR_XML_END
             m = re.search(regex, precheck_output, flags=re.DOTALL)


### PR DESCRIPTION
Current log of pool_update.apply and pool_update.precheck are
using %r for output string format which lead to illegible logging,
this patch will split the execution output before logging, so it's
user friendly format.

Signed-off-by: Huan Xie <huan.xie@citrix.com>