### PR TITLE
CLI: enable tab completion for "xe vdi-list-changed-blocks"

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1995,7 +1995,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     };
     "vdi-list-changed-blocks",
     {
-      reqd=["vdi-from"; "vdi-to"];
+      reqd=["vdi-from-uuid"; "vdi-to-uuid"];
       optn=[];
       help="Write the changed blocks between the two given VDIs to the standard output as a base64-encoded bitmap string.";
       implementation=With_fd Cli_operations.vdi_list_changed_blocks;

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1261,8 +1261,8 @@ let vdi_data_destroy printer rpc session_id params =
   Client.VDI.data_destroy rpc session_id vdi
 
 let vdi_list_changed_blocks socket _ rpc session_id params =
-  let vdi_from = Client.VDI.get_by_uuid rpc session_id (List.assoc "vdi-from" params) in
-  let vdi_to = Client.VDI.get_by_uuid rpc session_id (List.assoc "vdi-to" params) in
+  let vdi_from = Client.VDI.get_by_uuid rpc session_id (List.assoc "vdi-from-uuid" params) in
+  let vdi_to = Client.VDI.get_by_uuid rpc session_id (List.assoc "vdi-to-uuid" params) in
   let bitmap = Client.VDI.list_changed_blocks ~rpc ~session_id ~vdi_from ~vdi_to in
   marshal socket (Command (Print bitmap))
 

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -377,7 +377,7 @@ _xe()
                     else
                         all="--all"
                     fi
-                    if [[ "${fst}" == "into-vdi" || "$fst" == "base-vdi" ]]; then
+                    if [[ "${fst}" == "into-vdi" || "$fst" == "base-vdi" || "$fst" == "vdi-from" || "$fst" == "vdi-to" ]]; then
                         class=vdi
                     else
                         class=${fst}


### PR DESCRIPTION
Append -uuid to vdi-list-changed-blocks param names, and add a special
case for them in ocaml/xe-cli/bash-completion to enable tab completion.

I had to change the bash-completion file, because these parameter names
(vdi-from-uuid and vdi-to-uuid), contain two hyphens - for params
containing only one hyphen and ending with -uuid, tab completion works
automatically.

Signed-off-by: Iglói Gábor <gaborigloi@gmail.com>