### PR TITLE
CA-265183: Allow intra-pool migration when CBT-enabled VDIs are not moved

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -538,15 +538,6 @@ let check_operation_error ~__context ~ref ~op ~strict =
       then Some (Api_errors.not_system_domain, [ ref_str ])
       else None) in
 
-  (* For storage migration, check if any of the VM's VDIs has CBT enabled *)
-  let current_error = check current_error (fun () ->
-      let is_cbt_enabled vdi = try Db.VDI.get_cbt_enabled ~__context ~self:vdi with _ -> false in
-      if op = `migrate_send && List.exists is_cbt_enabled vdis then begin
-        let vdi = List.find is_cbt_enabled vdis in
-        Some (Api_errors.vdi_cbt_enabled, [ Ref.string_of vdi ])
-      end else None
-    ) in
-
   let current_error = check current_error (fun () ->
     if Helpers.rolling_upgrade_in_progress ~__context &&
        not (List.mem op Xapi_globs.rpu_allowed_vm_operations)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -790,7 +790,7 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
   let extra_vdis = suspends_vdis @ snapshots_vdis in
 
   let extra_vdi_map =
-    List.filter_map
+    List.map
       (fun vconf ->
          let dest_sr_ref =
            let is_mapped = List.mem_assoc vconf.vdi vdi_map
@@ -819,7 +819,7 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
              error "%s VDI not in VDI->SR map and no remote default SR is set" log_prefix;
              raise (Api_errors.Server_error(Api_errors.vdi_not_in_map, [ Ref.string_of vconf.vdi ]))
            end in
-         Some (vconf.vdi, dest_sr_ref))
+         (vconf.vdi, dest_sr_ref))
       extra_vdis in
 
   let vdi_map = vdi_map @ extra_vdi_map in

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -134,6 +134,19 @@ let assert_sr_support_operations ~__context ~vdi_map ~remote ~ops =
       op_supported_on_dest_sr sr ops sm_record remote;
     )
 
+(** Check that none of the VDIs that are mapped to a different SR have CBT
+    enabled. This function must be called with the complete [vdi_map],
+    which contains all the VDIs of the VM.
+    [check_vdi_map] should be called before this function to verify that this
+    is the case. *)
+let assert_no_cbt_enabled_vdi_migrated ~__context ~vdi_map =
+  List.iter (fun (vdi, target_sr) ->
+      if (Db.VDI.get_cbt_enabled ~__context ~self:vdi) then begin
+        if (target_sr <> (Db.VDI.get_SR ~__context ~self:vdi)) then
+          raise Api_errors.(Server_error(vdi_cbt_enabled, [Ref.string_of vdi]))
+      end
+    ) vdi_map
+
 let assert_licensed_storage_motion ~__context =
   Pool_features.assert_enabled ~__context ~f:Features.Storage_motion
 
@@ -809,6 +822,10 @@ let migrate_send'  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
 
   let vdi_map = vdi_map @ extra_vdi_map in
 
+  (* The vdi_map should be complete at this point - it should include all the
+     VDIs of the VM all extra VDIs in the all_vdis list. *)
+  assert_no_cbt_enabled_vdi_migrated ~__context ~vdi_map;
+
   let dbg = Context.string_of_task __context in
   let open Xapi_xenops_queue in
   let queue_name = queue_of_vm ~__context ~self:vm in
@@ -1053,12 +1070,6 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
   let vms_vdis = List.filter_map (vdi_filter __context true) vbds in
   check_vdi_map ~__context vms_vdis vdi_map;
 
-  (* Prevent SXM when the VM has a VDI on which changed block tracking is enabled *)
-  List.iter (fun vconf ->
-      let vdi = vconf.vdi in
-      if (Db.VDI.get_cbt_enabled ~__context ~self:vdi) then
-        raise Api_errors.(Server_error(vdi_cbt_enabled, [Ref.string_of vdi]))) vms_vdis ;
-
   let migration_type =
     try
       ignore(Db.Host.get_uuid ~__context ~self:remote.dest_host);
@@ -1073,7 +1084,7 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
   let required_sr_operations = [Smint.Vdi_mirror; Smint.Vdi_snapshot] in
   let host_from = Helpers.LocalObject source_host_ref in
 
-  match migration_type with
+  begin match migration_type with
   | `intra_pool ->
     (* Prevent VMs from being migrated onto a host with a lower platform version *)
     let host_to = Helpers.LocalObject remote.dest_host in
@@ -1087,7 +1098,7 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
     Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host:remote.dest_host ~snapshot ~do_sr_check:false ();
     if vif_map <> [] then
       raise (Api_errors.Server_error(Api_errors.operation_not_allowed, [
-          "VIF mapping is not allowed for intra-pool migration"]))
+          "VIF mapping is not allowed for intra-pool migration"]));
 
   | `cross_pool ->
     (* Prevent VMs from being migrated onto a host with a lower platform version *)
@@ -1139,6 +1150,10 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
         raise Api_errors.(Server_error(internal_error, ["assert_can_migrate: inter_pool_metadata_transfer returned a nonempty list"]))
     with Xmlrpc_client.Connection_reset ->
       raise (Api_errors.Server_error(Api_errors.cannot_contact_host, [remote.remote_ip]))
+  end;
+
+  (* check_vdi_map above has already verified that all VDIs are in the vdi_map *)
+  assert_no_cbt_enabled_vdi_migrated ~__context ~vdi_map
 
 let migrate_send  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options =
   with_migrate (fun () ->


### PR DESCRIPTION
By moving the check from the message forwarding layer to the
implementation, because in message forwarding we do not know the VDI to
SR mapping.

I added a check to Xapi_vm_migrate.migrate_send and assert_can_migrate,
checking that no CBT-enabled VDI is mapped to an SR different from its
current one. This is the only check that is done, whether the migration
is cross-pool or intra-pool. I assume the existing checks disallow
mapping a VDI to its current SR in case of cross pool migration, because
this pool's SR is probably not accessible to the remote pool. If this is
true, then cross-pool migration of VMs with CBT-enabled VDIs will never
be allowed, as expected, because all the VDIs have to be mapped to a
different SR.

In assert_can_migrate, I've added the checks for CBT-enabled VDIs to the
end, because unlike the errors checked first, these errors are
recoverable - the user can just disable CBT on the affected VDIs.

The other errors may not be possible to fix, therefore those checks
should take precedence over the CBT checks.

Signed-off-by: Iglói Gábor <gabor.igloi@citrix.com>