### PR TITLE
CP-23198: verify results of calling VDI.data_destroy

### DIFF
--- a/ocaml/xapi/test_vdi_allowed_operations.ml
+++ b/ocaml/xapi/test_vdi_allowed_operations.ml
@@ -301,6 +301,10 @@ let all_cbt_operations = [`enable_cbt; `disable_cbt; `data_destroy] in
           let _: _ API.Ref.t = Test_common.make_vbd ~__context ~vDI:vdi ~vM ~currently_attached:true () in
           pass_data_destroy vdi
         ) ,         Some (Api_errors.vdi_in_use, []) ;
+
+        (fun vdi -> pass_data_destroy vdi;
+          Db.VDI.set_type ~__context ~self:vdi ~value:`cbt_metadata
+        ) ,         None ;
       ] in
 
   "test_cbt" >:::

--- a/ocaml/xapi/test_vdi_allowed_operations.ml
+++ b/ocaml/xapi/test_vdi_allowed_operations.ml
@@ -167,7 +167,7 @@ let test_ca126097 () =
 
 (** Tests for the checks related to changed block tracking *)
 let test_cbt =
-  let all_cbt_operations = [`enable_cbt; `disable_cbt] in
+let all_cbt_operations = [`enable_cbt; `disable_cbt; `data_destroy] in
   let for_vdi_operations ops f () = ops |> List.iter f in
   let for_cbt_enable_disable = for_vdi_operations [`enable_cbt; `disable_cbt] in
 

--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -1,3 +1,17 @@
+(*
+-  Copyright (C) 2017 Citrix Systems Inc.
+-
+-  This program is free software; you can redistribute it and/or modify
+-  it under the terms of the GNU Lesser General Public License as published
+-  by the Free Software Foundation; version 2.1 only. with the special
+-  exception on linking described in file LICENSE.
+-
+-  This program is distributed in the hope that it will be useful,
+-  but WITHOUT ANY WARRANTY; without even the implied warranty of
+-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-  GNU Lesser General Public License for more details.
+  *)
+
 
 let register_smapiv2_server (module S: Storage_interface.Server_impl with type context = unit) sr_ref =
   let module S = Storage_interface.Server(S) in

--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -234,53 +234,6 @@ let test_allowed_operations_updated_when_necessary () =
   Client.Client.VDI.data_destroy ~rpc ~session_id ~self;
   assert_allowed_operations "does not contain `copy after VDI has been data-destroyed" (fun ops -> not @@ List.mem `copy ops)
 
-(* Confirm VDI.data_destroy changes requisite fields of VDI *)
-let test_vdi_after_data_destroy () =
-  try
-    let __context = Test_common.make_test_database () in
-    let sR,vDI = make_mock_server_infrastructure ~__context in
-    Db.VDI.set_type ~__context ~self:vDI ~value:`suspend;
-    let vM = Test_common.make_vm ~__context () in
-    let vBD = Test_common.make_vbd ~__context ~uuid:"VBD-1" ~vDI ~vM ~currently_attached:false () in
-    let _: _ API.Ref.t = Test_common.make_vbd ~__context ~uuid:"VBD-1" ~vDI ~vM ~currently_attached:false () in
-
-    let check_vdi_is_snapshot_and_type ~vDI ~snapshot ~vdi_type ~managed =
-      OUnit.assert_equal ~msg:("VDI type should be set to " ^ (Record_util.vdi_type_to_string vdi_type))
-        (Db.VDI.get_type ~__context ~self:vDI) vdi_type;
-      OUnit.assert_equal ~msg:("VDI managed should be set to " ^ (if managed then "true" else "false"))
-        (Db.VDI.get_managed ~__context ~self:vDI) managed;
-      let word = if snapshot then "" else " not" in
-      OUnit.assert_equal ~msg:("VDI should" ^ word ^ " be a snapshot")
-        (Db.VDI.get_is_a_snapshot ~__context ~self:vDI) snapshot
-    in
-    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`suspend ~managed:true;
-
-    (* set vDI as the suspend VDI of vM *)
-    Db.VM.set_suspend_VDI ~__context ~self:vM ~value:vDI;
-    OUnit.assert_equal ~msg:"VM.suspend_VDI should point to previously created VDI"
-      (Db.VM.get_suspend_VDI ~__context ~self:vM) vDI;
-
-    OUnit.assert_equal ~msg:"VDI should link to previously created VBD"
-     (Db.VDI.get_VBDs ~__context ~self:vDI) [vBD];
-
-    (* run VDI.data_destroy, check it has updated VDI fields *)
-    Xapi_vdi.data_destroy ~__context ~self:vDI;
-
-    OUnit.assert_equal ~msg:"VDI.data_destroy should set VDI type to cbt_metadata"
-      (Db.VDI.get_type ~__context ~self:vDI) `cbt_metadata;
-
-    OUnit.assert_equal ~msg:"VDI.data_destroy should destroy all associated VBDs"
-      (Db.VDI.get_VBDs ~__context ~self:vDI) [];
-
-    OUnit.assert_equal ~msg:"VM.suspend_VDI should be set to null"
-      (Db.VM.get_suspend_VDI ~__context ~self:vM) Ref.null;
-
-    (* check for idempotence for metadata snapshot VDIs *)
-    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`cbt_metadata ~managed:true;
-    Xapi_vdi.data_destroy ~__context ~self:vDI;
-    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`cbt_metadata ~managed:true;
-  with e -> failwith (ExnHelper.string_of_exn e)
-
 let test =
   let open OUnit in
   "test_vdi_cbt" >:::
@@ -289,5 +242,65 @@ let test =
   ; "test_clone_and_snapshot_correctly_sets_cbt_enabled_field" >:: test_clone_and_snapshot_correctly_sets_cbt_enabled_field
   ; test_get_nbd_info
   ; "test_allowed_operations_updated_when_necessary" >:: test_allowed_operations_updated_when_necessary
-  ; "test_vdi_after_data_destroy" >:: test_vdi_after_data_destroy
+  ]
+
+(* Confirm VDI.data_destroy changes requisite fields of VDI *)
+let test_vdi_after_data_destroy () =
+  let __context = Test_common.make_test_database () in
+  let sR,vDI = make_mock_server_infrastructure ~__context in
+  Db.VDI.set_type ~__context ~self:vDI ~value:`suspend;
+  let vM = Test_common.make_vm ~__context () in
+  let vBD = Test_common.make_vbd ~__context ~uuid:"VBD-1" ~vDI ~vM ~currently_attached:false () in
+  let _: _ API.Ref.t = Test_common.make_vbd ~__context ~uuid:"VBD-1" ~vDI ~vM ~currently_attached:false () in
+
+  let check_vdi_is_snapshot_and_type ~vDI ~snapshot ~vdi_type ~managed =
+    OUnit.assert_equal ~msg:("VDI type should be set to " ^ (Record_util.vdi_type_to_string vdi_type))
+      (Db.VDI.get_type ~__context ~self:vDI) vdi_type;
+    OUnit.assert_equal ~msg:("VDI managed should be set to " ^ (if managed then "true" else "false"))
+      (Db.VDI.get_managed ~__context ~self:vDI) managed;
+    let word = if snapshot then "" else " not" in
+    OUnit.assert_equal ~msg:("VDI should" ^ word ^ " be a snapshot")
+      (Db.VDI.get_is_a_snapshot ~__context ~self:vDI) snapshot
+  in
+  check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`suspend ~managed:true;
+
+  (* set vDI as the suspend VDI of vM *)
+  Db.VM.set_suspend_VDI ~__context ~self:vM ~value:vDI;
+  OUnit.assert_equal ~msg:"VM.suspend_VDI should point to previously created VDI"
+    (Db.VM.get_suspend_VDI ~__context ~self:vM) vDI;
+
+  OUnit.assert_equal ~msg:"VDI should link to previously created VBD"
+   (Db.VDI.get_VBDs ~__context ~self:vDI) [vBD];
+
+  (* run VDI.data_destroy, check it has updated VDI fields *)
+  Xapi_vdi.data_destroy ~__context ~self:vDI;
+
+  OUnit.assert_equal ~msg:"VDI.data_destroy should set VDI type to cbt_metadata"
+    (Db.VDI.get_type ~__context ~self:vDI) `cbt_metadata;
+
+  OUnit.assert_equal ~msg:"VDI.data_destroy should destroy all associated VBDs"
+    (Db.VDI.get_VBDs ~__context ~self:vDI) [];
+
+  OUnit.assert_equal ~msg:"VM.suspend_VDI should be set to null"
+    (Db.VM.get_suspend_VDI ~__context ~self:vM) Ref.null;
+
+  (* check for idempotence for metadata snapshot VDIs *)
+  check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`cbt_metadata ~managed:true;
+  Xapi_vdi.data_destroy ~__context ~self:vDI;
+  check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`cbt_metadata ~managed:true
+
+(* check VDI.data_destroy throws VDI_NOT_MANAGED if managed:false *)
+let test_vdi_managed_data_destroy () =
+  let __context = Test_common.make_test_database () in
+  let _,vDI = make_mock_server_infrastructure ~__context in
+  Db.VDI.set_managed ~__context ~self:vDI ~value:false;
+  OUnit.assert_raises ~msg:"VDI managed field should be set to true"
+    Api_errors.(Server_error (vdi_not_managed, [Ref.string_of vDI]))
+    (fun () -> Xapi_vdi.data_destroy ~__context ~self:vDI)
+
+let test_vdi_data_destroy =
+  let open OUnit in
+  "test_vdi_data_destroy" >:::
+  [ "test_vdi_after_data_destroy" >:: test_vdi_after_data_destroy
+  ; "test_vdi_managed_data_destroy" >:: test_vdi_managed_data_destroy
   ]

--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -37,6 +37,17 @@ let register_smapiv2_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_data_destroy ?
   let s = make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_data_destroy ?vdi_snapshot ?vdi_clone () in
   register_smapiv2_server s sr_ref
 
+(* create host -> (SM) -> SR -> PBD -> VDI infrastructure for
+   mock storage layer, return SR and VDI *)
+let make_mock_server_infrastructure ~__context =
+  let host = Helpers.get_localhost ~__context in
+  let _: _ API.Ref.t = Test_common.make_sm ~__context () in
+  let sR = Test_common.make_sr ~__context ~is_tools_sr:false () in
+  let _: _ API.Ref.t = Test_common.make_pbd ~__context ~host ~sR ~currently_attached:true () in
+  let vDI = Test_common.make_vdi ~__context ~is_a_snapshot:true ~managed:true ~cbt_enabled:true ~sR () in
+  register_smapiv2_server ~vdi_data_destroy:(fun _ ~dbg ~sr ~vdi -> ()) (Db.SR.get_uuid ~__context ~self:sR);
+  (sR,vDI)
+
 let test_cbt_enable_disable () =
   let __context = Test_common.make_test_database () in
   let sr_ref = Test_common.make_sr ~__context () in
@@ -227,26 +238,22 @@ let test_allowed_operations_updated_when_necessary () =
 let test_vdi_after_data_destroy () =
   try
     let __context = Test_common.make_test_database () in
-
-    (* Create host -> (SM) -> (PBD) -> SR -> VDI -> (VBD) -> VM infrastructure
-       in order to run VDI.data_destroy and test suspended VMs *)
-    let host = Helpers.get_localhost ~__context in
-    let _: _ API.Ref.t = Test_common.make_sm ~__context () in
-    let sR = Test_common.make_sr ~__context ~_type:"sm" ~is_tools_sr:false () in
-    let _: _ API.Ref.t = Test_common.make_pbd ~__context ~host ~sR ~currently_attached:true () in
-    let vDI = Test_common.make_vdi ~__context ~is_a_snapshot:true ~managed:true ~cbt_enabled:true ~_type:`suspend ~sR () in
+    let sR,vDI = make_mock_server_infrastructure ~__context in
+    Db.VDI.set_type ~__context ~self:vDI ~value:`suspend;
     let vM = Test_common.make_vm ~__context () in
+    let vBD = Test_common.make_vbd ~__context ~uuid:"VBD-1" ~vDI ~vM ~currently_attached:false () in
     let _: _ API.Ref.t = Test_common.make_vbd ~__context ~uuid:"VBD-1" ~vDI ~vM ~currently_attached:false () in
-    register_smapiv2_server ~vdi_data_destroy:(fun _ ~dbg ~sr ~vdi -> ()) (Db.SR.get_uuid ~__context ~self:sR);
 
-    let check_vdi_is_snapshot_and_type ~vDI ~snapshot ~vdi_type =
+    let check_vdi_is_snapshot_and_type ~vDI ~snapshot ~vdi_type ~managed =
       OUnit.assert_equal ~msg:("VDI type should be set to " ^ (Record_util.vdi_type_to_string vdi_type))
         (Db.VDI.get_type ~__context ~self:vDI) vdi_type;
+      OUnit.assert_equal ~msg:("VDI managed should be set to " ^ (if managed then "true" else "false"))
+        (Db.VDI.get_managed ~__context ~self:vDI) managed;
       let word = if snapshot then "" else " not" in
       OUnit.assert_equal ~msg:("VDI should" ^ word ^ " be a snapshot")
         (Db.VDI.get_is_a_snapshot ~__context ~self:vDI) snapshot
     in
-    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`suspend;
+    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`suspend ~managed:true;
 
     (* set vDI as the suspend VDI of vM *)
     Db.VM.set_suspend_VDI ~__context ~self:vM ~value:vDI;
@@ -254,8 +261,7 @@ let test_vdi_after_data_destroy () =
       (Db.VM.get_suspend_VDI ~__context ~self:vM) vDI;
 
     OUnit.assert_equal ~msg:"VDI should link to previously created VBD"
-      (List.map (fun vbd -> Db.VBD.get_uuid ~__context ~self:vbd)
-         (Db.VDI.get_VBDs ~__context ~self:vDI)) ["VBD-1"];
+     (Db.VDI.get_VBDs ~__context ~self:vDI) [vBD];
 
     (* run VDI.data_destroy, check it has updated VDI fields *)
     Xapi_vdi.data_destroy ~__context ~self:vDI;
@@ -270,9 +276,9 @@ let test_vdi_after_data_destroy () =
       (Db.VM.get_suspend_VDI ~__context ~self:vM) Ref.null;
 
     (* check for idempotence for metadata snapshot VDIs *)
-    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`cbt_metadata;
+    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`cbt_metadata ~managed:true;
     Xapi_vdi.data_destroy ~__context ~self:vDI;
-    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`cbt_metadata;
+    check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`cbt_metadata ~managed:true;
   with e -> failwith (ExnHelper.string_of_exn e)
 
 let test =

--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -263,7 +263,7 @@ let test_vdi_after_data_destroy () =
     OUnit.assert_equal ~msg:"VDI.data_destroy should set VDI type to cbt_metadata"
       (Db.VDI.get_type ~__context ~self:vDI) `cbt_metadata;
 
-    OUnit.assert_equal ~msg:"VDI.data_destroy should destroy all attached VBDs"
+    OUnit.assert_equal ~msg:"VDI.data_destroy should destroy all associated VBDs"
       (Db.VDI.get_VBDs ~__context ~self:vDI) [];
 
     OUnit.assert_equal ~msg:"VM.suspend_VDI should be set to null"

--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -234,32 +234,22 @@ let test_allowed_operations_updated_when_necessary () =
   Client.Client.VDI.data_destroy ~rpc ~session_id ~self;
   assert_allowed_operations "does not contain `copy after VDI has been data-destroyed" (fun ops -> not @@ List.mem `copy ops)
 
-let test =
-  let open OUnit in
-  "test_vdi_cbt" >:::
-  [ "test_cbt_enable_disable" >:: test_cbt_enable_disable
-  ; "test_set_metadata_of_pool_doesnt_allow_cbt_metadata_vdi" >:: test_set_metadata_of_pool_doesnt_allow_cbt_metadata_vdi
-  ; "test_clone_and_snapshot_correctly_sets_cbt_enabled_field" >:: test_clone_and_snapshot_correctly_sets_cbt_enabled_field
-  ; test_get_nbd_info
-  ; "test_allowed_operations_updated_when_necessary" >:: test_allowed_operations_updated_when_necessary
-  ]
-
 (* Confirm VDI.data_destroy changes requisite fields of VDI *)
 let test_vdi_after_data_destroy () =
   let __context = Test_common.make_test_database () in
   let sR,vDI = make_mock_server_infrastructure ~__context in
   Db.VDI.set_type ~__context ~self:vDI ~value:`suspend;
   let vM = Test_common.make_vm ~__context () in
-  let vBD = Test_common.make_vbd ~__context ~uuid:"VBD-1" ~vDI ~vM ~currently_attached:false () in
-  let _: _ API.Ref.t = Test_common.make_vbd ~__context ~uuid:"VBD-1" ~vDI ~vM ~currently_attached:false () in
+  let vBD = Test_common.make_vbd ~__context ~vDI ~vM ~currently_attached:false () in
 
   let check_vdi_is_snapshot_and_type ~vDI ~snapshot ~vdi_type ~managed =
-    OUnit.assert_equal ~msg:("VDI type should be set to " ^ (Record_util.vdi_type_to_string vdi_type))
+    let open Printf in
+    OUnit.assert_equal ~msg:(sprintf "VDI type should be set to %s" (Record_util.vdi_type_to_string vdi_type))
       (Db.VDI.get_type ~__context ~self:vDI) vdi_type;
-    OUnit.assert_equal ~msg:("VDI managed should be set to " ^ (if managed then "true" else "false"))
+    OUnit.assert_equal ~msg:(sprintf "VDI managed should be set to %b" managed)
       (Db.VDI.get_managed ~__context ~self:vDI) managed;
     let word = if snapshot then "" else " not" in
-    OUnit.assert_equal ~msg:("VDI should" ^ word ^ " be a snapshot")
+    OUnit.assert_equal ~msg:(sprintf "VDI should%s be a snapshot" word)
       (Db.VDI.get_is_a_snapshot ~__context ~self:vDI) snapshot
   in
   check_vdi_is_snapshot_and_type ~vDI ~snapshot:true ~vdi_type:`suspend ~managed:true;
@@ -270,7 +260,7 @@ let test_vdi_after_data_destroy () =
     (Db.VM.get_suspend_VDI ~__context ~self:vM) vDI;
 
   OUnit.assert_equal ~msg:"VDI should link to previously created VBD"
-   (Db.VDI.get_VBDs ~__context ~self:vDI) [vBD];
+    (Db.VDI.get_VBDs ~__context ~self:vDI) [vBD];
 
   (* run VDI.data_destroy, check it has updated VDI fields *)
   Xapi_vdi.data_destroy ~__context ~self:vDI;
@@ -294,13 +284,20 @@ let test_vdi_managed_data_destroy () =
   let __context = Test_common.make_test_database () in
   let _,vDI = make_mock_server_infrastructure ~__context in
   Db.VDI.set_managed ~__context ~self:vDI ~value:false;
-  OUnit.assert_raises ~msg:"VDI managed field should be set to true"
+  OUnit.assert_raises ~msg:"VDI.data_destroy only works on managed VDI"
     Api_errors.(Server_error (vdi_not_managed, [Ref.string_of vDI]))
     (fun () -> Xapi_vdi.data_destroy ~__context ~self:vDI)
 
-let test_vdi_data_destroy =
+let test =
   let open OUnit in
-  "test_vdi_data_destroy" >:::
-  [ "test_vdi_after_data_destroy" >:: test_vdi_after_data_destroy
-  ; "test_vdi_managed_data_destroy" >:: test_vdi_managed_data_destroy
+  "test_vdi_cbt" >:::
+  [ "test_cbt_enable_disable" >:: test_cbt_enable_disable
+  ; "test_set_metadata_of_pool_doesnt_allow_cbt_metadata_vdi" >:: test_set_metadata_of_pool_doesnt_allow_cbt_metadata_vdi
+  ; "test_clone_and_snapshot_correctly_sets_cbt_enabled_field" >:: test_clone_and_snapshot_correctly_sets_cbt_enabled_field
+  ; test_get_nbd_info
+  ; "test_allowed_operations_updated_when_necessary" >:: test_allowed_operations_updated_when_necessary
+  ; "test_vdi_data_destroy" >:::
+    [ "test_vdi_after_data_destroy" >:: test_vdi_after_data_destroy
+    ; "test_vdi_managed_data_destroy" >:: test_vdi_managed_data_destroy
+    ]
   ]


### PR DESCRIPTION
As in CBT design brief v12, PR verifies the following results of calling VDI.data_destroy :
- VBDs are no longer associated with VDI
- If VDI is the suspend VDI of a suspended VM, after the call VM.suspend_VM is set to Ref.null
- VDI type set to cbt_metadata
- idempotence for metadata snapshot VDIs