### PR TITLE
CP-23537: Add Pool.nbd_networks, setter, CLI

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5249,6 +5249,17 @@ let network_detach_for_vm = call
     ~allowed_roles:_R_VM_POWER_ADMIN
     ()
 
+let network_set_nbd_enabled = call
+    ~name:"set_nbd_enabled"
+    ~doc:"Specify whether hosts will expose the Network Block Device service on this network."
+    ~params:[
+      Ref _network, "network", "The network";
+      Bool, "value", "Whether to use the network for NBD";
+    ]
+    ~in_product_since:rel_inverness
+    ~allowed_roles:_R_POOL_ADMIN
+    ()
+
 (** A virtual network *)
 let network =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:true ~name:_network ~descr:"A virtual network" ~gen_events:true
@@ -5256,7 +5267,7 @@ let network =
     ~messages_default_allowed_roles:_R_VM_ADMIN (* vm admins can create/destroy networks without PIFs *)
     ~doc_tags:[Networking]
     ~messages:[network_attach; network_pool_introduce; network_create_new_blob; network_set_default_locking_mode;
-               network_attach_for_vm; network_detach_for_vm]
+               network_attach_for_vm; network_detach_for_vm; network_set_nbd_enabled]
     ~contents:
       ([
         uid _network;

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2066,6 +2066,22 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
       implementation=No_fd Cli_operations.net_attach;
       flags=[Hidden];
     };
+    "network-enable-nbd",
+    {
+      reqd=["uuid"];
+      optn=[];
+      help="Specify that hosts will expose the NBD service on this network.";
+      implementation=No_fd Cli_operations.net_enable_nbd;
+      flags=[];
+    };
+    "network-disable-nbd",
+    {
+      reqd=["uuid"];
+      optn=[];
+      help="Specify that hosts will not expose the NBD service on this network.";
+      implementation=No_fd Cli_operations.net_disable_nbd;
+      flags=[];
+    };
     "vif-create",
     {
       reqd=["device";"network-uuid";"vm-uuid"];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1656,6 +1656,14 @@ let net_attach printer rpc session_id params =
   let host = Client.Host.get_by_uuid rpc session_id (List.assoc "host-uuid" params) in
   let () = Client.Network.attach rpc session_id network host in ()
 
+let net_enable_nbd printer rpc session_id params =
+  let network = Client.Network.get_by_uuid rpc session_id (List.assoc "uuid" params) in
+  Client.Network.set_nbd_enabled rpc session_id network true
+
+let net_disable_nbd printer rpc session_id params =
+  let network = Client.Network.get_by_uuid rpc session_id (List.assoc "uuid" params) in
+  Client.Network.set_nbd_enabled rpc session_id network false
+
 let vm_create printer rpc session_id params =
   let name_label=List.assoc "name-label" params in
   let name_description=List.assoc_default "name-description" params "" in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2748,6 +2748,10 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let local_fn = Local.Network.detach_for_vm ~host ~vm in
       do_op_on ~local_fn ~__context ~host
         (fun session_id rpc -> Client.Network.detach_for_vm rpc session_id host vm)
+
+    let set_nbd_enabled ~__context ~network ~value =
+      info "Network.set_nbd_enabled: network = '%s'; value = %b" (network_uuid ~__context network) value;
+      Local.Network.set_nbd_enabled ~__context ~network ~value
   end
 
   module VIF = struct

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -672,6 +672,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Pool.remove_from_guest_agent_config: pool = '%s'; key = '%s'"
         (pool_uuid ~__context self) key;
       Local.Pool.remove_from_guest_agent_config ~__context ~self ~key
+
+    let set_nbd_networks ~__context ~self ~networks =
+      info "Pool.set_nbd_networks: pool = '%s'; networks = '%s'"
+        (pool_uuid ~__context self)
+        (String.concat "; " (List.map Ref.string_of networks));
+      Local.Pool.set_nbd_networks ~__context ~self ~networks
   end
 
   module VM = struct

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -448,6 +448,8 @@ let net_record rpc session_id net =
         ~get:(fun () -> Record_util.network_default_locking_mode_to_string (x ()).API.network_default_locking_mode)
         ~set:(fun value -> Client.Network.set_default_locking_mode rpc session_id net
                  (Record_util.string_to_network_default_locking_mode value)) ();
+      make_field ~name:"nbd-enabled"
+        ~get:(fun () -> (x ()).API.network_pool_using_nbd <> Ref.null |> string_of_bool) ();
     ]}
 
 
@@ -538,6 +540,7 @@ let pool_record rpc session_id pool =
       make_field ~name:"cpu_info" ~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.pool_cpu_info) ~get_map:(fun () -> (x ()).API.pool_cpu_info) ();
       make_field ~name:"policy-no-vendor-device" ~get:(fun () -> string_of_bool (x ()).API.pool_policy_no_vendor_device) ~set:(fun s -> Client.Pool.set_policy_no_vendor_device rpc session_id pool (safe_bool_of_string "policy-no-vendor-device" s)) ();
       make_field ~name:"live-patching-disabled"  ~get:(fun () -> string_of_bool (x ()).API.pool_live_patching_disabled) ~set:(fun s -> Client.Pool.set_live_patching_disabled rpc session_id pool (safe_bool_of_string "live-patching-disabled" s)) ();
+      make_field ~name:"nbd-networks" ~get:(fun () -> String.concat "; " (List.map Ref.string_of (x ()).API.pool_nbd_networks)) ();
     ]}
 
 let vmss_record rpc session_id vmss =

--- a/ocaml/xapi/xapi_network.ml
+++ b/ocaml/xapi/xapi_network.ml
@@ -331,3 +331,13 @@ let with_networks_attached_for_vm ~__context ?host ~vm f =
         error "Caught %s while detaching networks" (string_of_exn e)
     end;
     raise e
+
+let set_nbd_enabled ~__context ~network ~value =
+  let self = network in
+  (* If the pool_using_nbd field is null, the network is currently disabled for NBD.
+   * Only set field if it is not currently the specified value. *)
+  if (Db.Network.get_pool_using_nbd ~__context ~self = Ref.null) = value
+  then Db.Network.set_pool_using_nbd ~__context ~self ~value:(
+    if value then Db.Pool.get_all ~__context |> List.hd
+    else Ref.null
+  )

--- a/ocaml/xapi/xapi_network.ml
+++ b/ocaml/xapi/xapi_network.ml
@@ -190,7 +190,8 @@ let pool_introduce ~__context ~name_label ~name_description ~mTU ~other_config ~
   Db.Network.create ~__context ~ref:r ~uuid:(Uuid.to_string uuid)
     ~current_operations:[] ~allowed_operations:[]
     ~name_label ~name_description ~mTU ~bridge ~managed
-    ~other_config ~blobs:[] ~tags:[] ~default_locking_mode:`unlocked ~assigned_ips:[];
+    ~other_config ~blobs:[] ~tags:[] ~default_locking_mode:`unlocked ~assigned_ips:[]
+    ~pool_using_nbd:Ref.null;
   r
 
 let rec choose_bridge_name bridges =
@@ -227,7 +228,8 @@ let create ~__context ~name_label ~name_description ~mTU ~other_config ~bridge ~
       Db.Network.create ~__context ~ref:r ~uuid:(Uuid.to_string uuid)
         ~current_operations:[] ~allowed_operations:[]
         ~name_label ~name_description ~mTU ~bridge ~managed
-        ~other_config ~blobs:[] ~tags ~default_locking_mode:`unlocked ~assigned_ips:[];
+        ~other_config ~blobs:[] ~tags ~default_locking_mode:`unlocked ~assigned_ips:[]
+        ~pool_using_nbd:Ref.null;
       r
     )
 

--- a/ocaml/xapi/xapi_network.mli
+++ b/ocaml/xapi/xapi_network.mli
@@ -131,3 +131,9 @@ val with_networks_attached_for_vm :
 
 val assert_network_is_managed :
   __context:Context.t -> self:[`network] Ref.t -> unit
+
+val set_nbd_enabled :
+  __context:Context.t ->
+  network:API.ref_network ->
+  value:bool ->
+  unit

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -276,6 +276,7 @@ let find_or_create_network (bridge: string) (device: string) ~__context =
         ~name_description:"" ~mTU:1500L
         ~bridge ~managed:true ~other_config:[] ~blobs:[]
         ~tags:[] ~default_locking_mode:`unlocked ~assigned_ips:[]
+        ~pool_using_nbd:Ref.null
     in
     net_ref
 

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -199,3 +199,5 @@ val add_to_guest_agent_config :
   __context:Context.t -> self:API.ref_pool -> key:string -> value:string -> unit
 val remove_from_guest_agent_config :
   __context:Context.t -> self:API.ref_pool -> key:string -> unit
+val set_nbd_networks :
+  __context:Context.t -> self:API.ref_pool -> networks:API.ref_network list -> unit


### PR DESCRIPTION
This new field does not yet have any effects.

It is to be used for controlling the networks on which the hosts will
expose the NBD service.