### PR TITLE
CA-266936: pciutils: use the file dump in a temp file if possible

### DIFF
--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -12,6 +12,9 @@
  * GNU Lesser General Public License for more details.
  *)
 
+ module D=Debug.Make(struct let name="xapi_pci_helpers" end)
+ open D
+
 type pci_property = {
   id: int;
   name: string;
@@ -28,8 +31,15 @@ type pci = {
 }
 
 let get_host_pcis () =
+  let from_dump =
+    try
+      Some (Filename.temp_file "pci" "dump")
+    with e ->
+      debug "Unable to create tempfile for libcpi dump: %s" (Printexc.to_string e);
+      None
+  in
   let open Pci in
-  with_access (fun access ->
+  with_access ?from_dump (fun access ->
       let devs = get_devices access in
       List.map (fun d ->
           let open Pci_dev in

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -444,8 +444,17 @@ module Vendor = functor (V : VENDOR) -> struct
     in
     let whitelist = read_whitelist ~whitelist ~device_id in
     let vendor_name, device =
-      Pci.(with_access (fun access ->
-          let vendor_name = lookup_vendor_name access V.vendor_id in
+      let from_dump =
+        try
+          Some (Filename.temp_file "pci" "dump")
+        with e ->
+          debug "Unable to create tempfile for libcpi dump: %s" (Printexc.to_string e);
+          None
+      in
+      Pci.(with_access ?from_dump (fun access ->
+          let vendor_name =
+            lookup_vendor_name access V.vendor_id
+          in
           let device =
             List.find
               (fun device ->


### PR DESCRIPTION
Rarely `xap`i is booting and updating the PCI records while the data in
`sysfs` is being written/changed. This invalidated the `access` structure
and caused a segmentation fault.

By using the `dump` access, that in practice means dumping the
equivalent of `pci -x` in a temporary file (see man pciutils) we can
make sure that the data is not changing under our feet.

This seems to have resolved the segmentation fault, at the price of
potentially having partial information about the pci devices on the
host. This did not seem to affect system tests, and in the worst case
scenario, after a toolstack restart all the pci devices are detected.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>