### PR TITLE
Add build shortcut for VS Code

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "taskName": "make",
+            "type": "shell",
+            "command": "make test",
+            "problemMatcher": "$ocamlc",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Press Ctrl+Shift+B to `make test` from the editor terminal!

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>