### PR TITLE
CP-24982:  Add set_passthrough_enabled

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -9884,6 +9884,17 @@ module PUSB = struct
       ~allowed_roles:_R_POOL_OP
       ()
 
+  let set_passthrough_enabled = call
+      ~name:"set_passthrough_enabled"
+      ~lifecycle
+      ~params:[
+        Ref _pusb, "self",  "this PUSB";
+        Bool,     "value", "passthrough is enabled when true and disabled with false"
+      ]
+      ~allowed_roles:_R_POOL_OP
+      ()
+
+
   let obj =
     create_obj
       ~name: _pusb
@@ -9910,12 +9921,13 @@ module PUSB = struct
          field ~qualifier:StaticRO ~ty:String ~lifecycle "serial" "serial of the USB device" ~default_value:(Some (VString ""));
          field ~qualifier:StaticRO ~ty:String ~lifecycle "version" "USB device version" ~default_value:(Some (VString ""));
          field ~qualifier:StaticRO ~ty:String ~lifecycle "description" "USB device description" ~default_value:(Some (VString ""));
-         field ~qualifier:RW ~ty:Bool ~lifecycle "passthrough_enabled" "enabled for passthrough" ~default_value:(Some (VBool false));
+         field ~qualifier:DynamicRO ~ty:Bool ~lifecycle "passthrough_enabled" "enabled for passthrough" ~default_value:(Some (VBool false));
          field ~qualifier:RW ~ty:(Map (String,String)) ~lifecycle:[Published, rel_inverness, ""] "other_config" "additional configuration" ~default_value:(Some (VMap []));
         ]
       ~messages:
         [
           scan;
+          set_passthrough_enabled;
         ]
       ()
 end

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1057,6 +1057,9 @@ let _ =
     ~doc:"The given VMs failed to release memory when instructed to do so" ();
   error Api_errors.ballooning_timeout_before_migration [ "vm" ]
     ~doc:"Timeout trying to balloon down memory before VM migration. If the error occurs repeatedly, consider increasing the memory-dynamic-min value." ();
+  error Api_errors.vm_requires_vusb ["vm"; "USB_group"]
+    ~doc:"You attempted to run a VM on a host on which the VUSB required by the VM cannot be allocated on any PUSBs in the USB_group needed by the VM
+." ();
 
   (* Storage errors *)
   error Api_errors.sr_not_attached ["sr"]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -226,6 +226,7 @@ let vdi_not_sparse = "VDI_NOT_SPARSE"
 let vdi_is_a_physical_device = "VDI_IS_A_PHYSICAL_DEVICE"
 let vdi_is_not_iso = "VDI_IS_NOT_ISO"
 let vbd_cds_must_be_readonly = "VBD_CDS_MUST_BE_READONLY"
+let vm_requires_vusb = "VM_REQUIRES_VUSB"
 (* CA-83260 *)
 let disk_vbd_must_be_readwrite_for_hvm = "DISK_VBD_MUST_BE_READWRITE_FOR_HVM"
 let host_cd_drive_empty = "HOST_CD_DRIVE_EMPTY"

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4192,17 +4192,69 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
   end
 
   module VUSB = struct
+   let update_vusb_operations ~__context ~vusb =
+      Helpers.with_global_lock
+        (fun () ->
+           try
+             Xapi_vusb_helpers.update_allowed_operations ~__context ~self:vusb
+           with _ -> ())
+
+    let unmark_vusb ~__context ~vusb ~doc ~op =
+      let task_id = Ref.string_of (Context.get_task_id __context) in
+      log_exn ~doc:("unmarking VUSB after " ^ doc)
+        (fun self ->
+           if Db.is_valid_ref __context self then begin
+             Db.VUSB.remove_from_current_operations ~__context ~self ~key:task_id;
+             Xapi_vusb_helpers.update_allowed_operations ~__context ~self;
+             Helpers.Early_wakeup.broadcast (Datamodel._vusb, Ref.string_of vusb)
+           end)
+        vusb
+
+    let mark_vusb ~__context ~vusb ~doc ~op =
+      let task_id = Ref.string_of (Context.get_task_id __context) in
+      log_exn ~doc:("marking VUSB for " ^ doc)
+        (fun self ->
+           Xapi_vusb_helpers.assert_operation_valid ~__context ~self ~op;
+           Db.VUSB.add_to_current_operations ~__context ~self ~key:task_id ~value:op;
+           Xapi_vusb_helpers.update_allowed_operations ~__context ~self) vusb
+
+    let with_vusb_marked ~__context ~vusb ~doc ~op f =
+      Helpers.retry_with_global_lock ~__context ~doc (fun () -> mark_vusb ~__context ~vusb ~doc ~op);
+      finally
+        (fun () -> f ())
+        (fun () -> Helpers.with_global_lock (fun () -> unmark_vusb ~__context ~vusb ~doc ~op))
+
+    (* -------- Forwarding helper functions: ------------------------------------ *)
+
+    (* Forward to host that has resident VM that this VUSB references *)
+    let forward_vusb_op ~local_fn ~__context ~self op =
+      let vm = Db.VUSB.get_VM ~__context ~self in
+      let host_resident_on = Db.VM.get_resident_on ~__context ~self:vm in
+      if host_resident_on = Ref.null
+      then local_fn ~__context
+      else do_op_on ~local_fn ~__context ~host:host_resident_on op
+
+    (* -------------------------------------------------------------------------- *)
+
     let create ~__context ~vM ~uSB_group ~other_config =
       info "VUSB.create: VM = '%s'; USB_group = '%s'" (vm_uuid ~__context vM) (usb_group_uuid ~__context uSB_group);
-      Local.VUSB.create ~__context ~vM ~uSB_group ~other_config
+      let vusb = Local.VUSB.create ~__context ~vM ~uSB_group ~other_config in
+      Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vM;
+      vusb
 
     let unplug ~__context ~self =
       info "VUSB.unplug: VUSB = '%s'" (vusb_uuid ~__context self);
-      debug "VUSB.unplug to do"
+      let local_fn = Local.VUSB.unplug ~self in
+      with_vusb_marked ~__context ~vusb:self ~doc:"VUSB.unplug" ~op:`unplug
+        (fun () ->
+           forward_vusb_op ~local_fn ~__context ~self
+             (fun session_id rpc -> Client.VUSB.unplug rpc session_id self));
+      update_vusb_operations ~__context ~vusb:self
 
     let destroy ~__context ~self =
       info "VUSB.destroy: VUSB = '%s'" (vusb_uuid ~__context self);
-      Local.VUSB.destroy ~__context ~self
+      Local.VUSB.destroy ~__context ~self;
+      Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:(Db.VUSB.get_VM ~__context ~self)
   end
 
 end

--- a/ocaml/xapi/vusbops.ml
+++ b/ocaml/xapi/vusbops.ml
@@ -1,0 +1,63 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+module D=Debug.Make(struct let name="vusbops" end)
+open D
+
+open Stdext
+open Listext
+
+type vusb = {
+  vusb_ref: API.ref_VUSB;
+  usb_group_ref: API.ref_USB_group;
+  other_config: (string * string) list;
+}
+
+let vusb_of_vusb ~__context vm_r vusb =
+  let vusb_r = Db.VUSB.get_record ~__context ~self:vusb in
+  {
+    vusb_ref = vusb;
+    usb_group_ref = vusb_r.API.vUSB_USB_group;
+    other_config = vusb_r.API.vUSB_other_config;
+  }
+
+let vusbs_of_vm ~__context vm_r =
+  List.map (vusb_of_vusb ~__context vm_r) vm_r.API.vM_VUSBs
+
+let allocate_vusb_to_usb ~__context vm host vusb =
+  let available_pusbs = Db.Host.get_PUSBs ~__context ~self:host in
+  let compatible_pusbs = Db.USB_group.get_PUSBs ~__context ~self:vusb.usb_group_ref in
+  let pusbs = List.intersect compatible_pusbs available_pusbs in
+
+  (** We currently only have one pusb in usb_group. So compatible_pusbs will only have one PUSB,
+    and pusbs will have no more than one PUSB. *)
+  match pusbs with
+  | [] -> raise (Api_errors.Server_error (Api_errors.vm_requires_vusb, [ Ref.string_of vm; Ref.string_of vusb.usb_group_ref;]))
+  | pusb :: _ ->
+    Db.VUSB.set_attached ~__context ~self:vusb.vusb_ref ~value:pusb;
+    Db.PUSB.set_attached ~__context ~self:pusb ~value:vusb.vusb_ref
+
+let add_vusbs_to_vm ~__context host vm vusbs =
+  match vusbs with
+  | [] -> ()
+  | (v :: vs) as vusbs' -> List.iter (fun vusb -> allocate_vusb_to_usb ~__context vm host vusb) vusbs'
+
+(* Note that this function is called from Message_forwarding.allocate_vm_to_host,
+ * only on the pool master, and with the global lock held. We therefore do not
+ * need any further locking in any of the functions above, where resources are
+ * reserved. *)
+let create_vusbs ~__context host (vm, vm_r) hvm =
+  let vusbs = vusbs_of_vm ~__context vm_r in
+  if vusbs <> [] && not hvm then
+      raise (Api_errors.Server_error (Api_errors.feature_requires_hvm, ["VUSB- and USB-passthrough needs HVM"]));
+  add_vusbs_to_vm ~__context host vm vusbs

--- a/ocaml/xapi/vusbops.mli
+++ b/ocaml/xapi/vusbops.mli
@@ -1,0 +1,23 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** Module that handles assigning vUSBs to VMs.
+ * @group Virtual-Machine Management
+*)
+
+
+(** Assign a list of USB devices to a VM for USB passthrough *)
+val create_vusbs :
+  __context:Context.t ->
+  (API.ref_host) ->(API.ref_VM * API.vM_t) -> bool -> unit

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -818,6 +818,8 @@ let kpatch_list = ref "/usr/sbin/kpatch list"
 
 let modprobe_path = ref "/usr/sbin/modprobe"
 
+let usb_path = "usb_path"
+
 (* The bfs-interfaces script returns boot from SAN NICs.
  * All ISCSI Boot Firmware Table (ibft) NICs should be marked
  * with PIF.managed = false and all FCoE boot from SAN * NICs

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -38,7 +38,7 @@ exception InvalidOperation of string
 let assert_operation_valid = Xapi_vm_lifecycle.assert_operation_valid ~strict:true
 
 let update_allowed_operations ~__context ~self =
-  Helpers.log_exn_continue "updating allowed operations of VBDs/VIFs/VDIs in VM.update_allowed_operations"
+  Helpers.log_exn_continue "updating allowed operations of VBDs/VIFs/VDIs/VUSBs in VM.update_allowed_operations"
     (fun () ->
        List.iter
          (fun vbd ->
@@ -50,7 +50,11 @@ let update_allowed_operations ~__context ~self =
        List.iter
          (fun vif ->
             Xapi_vif_helpers.update_allowed_operations ~__context ~self:vif)
-         (Db.VM.get_VIFs ~__context ~self)
+         (Db.VM.get_VIFs ~__context ~self);
+       List.iter
+         (fun vusb ->
+            Xapi_vusb_helpers.update_allowed_operations ~__context ~self:vusb)
+         (Db.VM.get_VUSBs ~__context ~self)
     ) ();
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self
 

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -158,6 +158,8 @@ let destroy  ~__context ~self =
   (try Db.VM_metrics.destroy ~__context ~self:vm_metrics with _ -> ());
   let vm_guest_metrics = Db.VM.get_guest_metrics ~__context ~self in
   (try Db.VM_guest_metrics.destroy ~__context ~self:vm_guest_metrics with _ -> ());
+  let vusbs = Db.VM.get_VUSBs ~__context ~self in
+  List.iter (fun vusb -> try Db.VUSB.destroy ~__context ~self:vusb with _ -> ()) vusbs;
 
   Db.VM.destroy ~__context ~self
 

--- a/ocaml/xapi/xapi_vusb.ml
+++ b/ocaml/xapi/xapi_vusb.ml
@@ -31,7 +31,7 @@ let create ~__context ~vM ~uSB_group ~other_config =
   vusb
 
 let unplug ~__context ~self =
-  debug "unplug vusb to do"
+  Xapi_xenops.vusb_unplug ~__context ~self
 
 let destroy ~__context ~self =
   debug "VUSB.destroy (uuid = %s; ref = %s)" (Db.VUSB.get_uuid ~__context ~self) (Ref.string_of self);

--- a/ocaml/xapi/xapi_vusb.ml
+++ b/ocaml/xapi/xapi_vusb.ml
@@ -23,6 +23,17 @@ let m = Mutex.create ()
 let create ~__context ~vM ~uSB_group ~other_config =
   let vusb = Ref.make () in
   let uuid = Uuid.to_string (Uuid.make_uuid ()) in
+  let attached_vusbs = Db.VM.get_VUSBs ~__context ~self:vM in
+  (* At most 6 VUSBS can be attached to one vm *)
+  if List.length attached_vusbs > 5 then
+    raise (Api_errors.Server_error(Api_errors.operation_not_allowed,
+                      [Printf.sprintf "vm '%s' can attach at most 6 VUSBs. " (Ref.string_of vM)]));
+  let vusbs = Db.USB_group.get_VUSBs ~__context ~self:uSB_group in
+  (* Currently USB_group only have one PUSB. So when vusb is created with a USB_group,
+      another vusb can not create with the same USB_group. *)
+  if vusbs <> [] then
+    raise (Api_errors.Server_error(Api_errors.operation_not_allowed,
+                      [Printf.sprintf "USB_group '%s' has a vusb bound with, need to destroy the bound VUSB firstly. " (Ref.string_of uSB_group)]));
   Mutex.execute m (fun () ->
       Db.VUSB.create ~__context ~ref:vusb ~uuid ~current_operations:[] ~allowed_operations:[] ~vM ~uSB_group
       ~other_config ~attached:Ref.null;

--- a/ocaml/xapi/xapi_vusb_helpers.ml
+++ b/ocaml/xapi/xapi_vusb_helpers.ml
@@ -1,0 +1,100 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+ open Stdext.Xstringext
+
+module D=Debug.Make(struct let name="xapi" end)
+open D
+
+(**************************************************************************************)
+(* current/allowed operations checking                                                *)
+
+open Record_util
+
+let all_ops : API.vusb_operations_set = [`attach; `plug; `unplug]
+
+type table = (API.vusb_operations, ((string * (string list)) option)) Hashtbl.t
+
+let valid_operations ~__context record _ref': table =
+  let _ref = Ref.string_of _ref' in
+  let current_ops = record.Db_actions.vUSB_current_operations in
+  (* Policy:
+    * one operation at a time
+    * a running VM can do plug depending on whether the VUSB is already attached to VM.
+    * a running VM can do unplug depending on whether the VUSB is already attached to VM.
+    *
+  *)
+  let table : table = Hashtbl.create 10 in
+  List.iter (fun x -> Hashtbl.replace table x None) all_ops;
+  let set_errors (code: string) (params: string list) (ops: API.vusb_operations_set) =
+    List.iter (fun op ->
+        if Hashtbl.find table op = None
+        then Hashtbl.replace table op (Some(code, params))) ops in
+
+
+  (* Any current_operations preclude everything else *)
+  if current_ops <> [] then begin
+    debug "No operations are valid because current-operations = [ %s ]"
+      (String.concat "; "
+         (List.map (fun (task, op) -> task ^ " -> " ^ (vusb_operation_to_string op)) current_ops));
+    let concurrent_op = snd (List.hd current_ops) in
+    set_errors Api_errors.other_operation_in_progress
+      [ "VUSB"; _ref; vusb_operation_to_string concurrent_op ] all_ops;
+  end;
+
+  let vm = Db.VUSB.get_VM ~__context ~self:_ref' in
+  let power_state = Db.VM.get_power_state ~__context ~self:vm in
+  let plugged =
+    if record.Db_actions.vUSB_attached <> Ref.null then
+      true
+    else
+      false
+  in
+  (match power_state, plugged with
+   | `Running, true -> set_errors Api_errors.device_already_attached [ _ref ] [ `plug]
+   | `Running, false -> set_errors Api_errors.device_already_detached [ _ref ] [ `unplug]
+   | _,_ ->
+   let actual = Record_util.power_to_string power_state in
+   let expected = Record_util.power_to_string `Running in
+   set_errors Api_errors.vm_bad_power_state [ Ref.string_of vm; expected; actual ] [ `plug; `unplug ]);
+
+  let vm_current_ops = Db.VM.get_current_operations ~__context ~self:vm in
+  List.iter (fun (task,op) ->
+      if List.mem op [ `clean_shutdown; `hard_shutdown; `suspend; `pause ] then begin
+        let current_op_str = "Current operation on VM:" ^ (Ref.string_of vm) ^ " is "
+                             ^ (Record_util.vm_operation_to_string op) in
+        set_errors Api_errors.operation_not_allowed [ current_op_str ] [ `plug; `unplug ]
+      end
+    ) vm_current_ops;
+  table
+
+let throw_error (table: table) op =
+  if not(Hashtbl.mem table op)
+  then raise (Api_errors.Server_error(Api_errors.internal_error,
+                         [ Printf.sprintf "xapi_vusb_helpers.assert_operation_valid unknown operation: %s" (vusb_operation_to_string op) ]));
+
+  match Hashtbl.find table op with
+  | Some (code, params) -> raise (Api_errors.Server_error(code, params))
+  | None -> ()
+
+let update_allowed_operations ~__context ~self : unit =
+  let all = Db.VUSB.get_record_internal ~__context ~self in
+  let valid = valid_operations ~__context all self in
+  let keys = Hashtbl.fold (fun k v acc -> if v = None then k :: acc else acc) valid [] in
+  Db.VUSB.set_allowed_operations ~__context ~self ~value:keys
+
+let assert_operation_valid ~__context ~self ~(op:API.vusb_operations) =
+  let all = Db.VUSB.get_record_internal ~__context ~self in
+  let table = valid_operations ~__context all self in
+  throw_error table op

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -671,6 +671,32 @@ module MD = struct
         )
         [] vm.API.vM_VGPUs
 
+  let of_vusb ~__context ~vm ~pusb =
+    let open Vusb in
+    try
+      let path = pusb.API.pUSB_path in
+      let pathList= Xstringext.String.split '-' path in
+      let hostbus = List.nth pathList 0 in
+      let hostport = List.nth pathList 1 in
+      (** Here version can be 1.10/2.00/3.00, so just get the first character *)
+      let version = List.hd (Xstringext.String.split '.' pusb.API.pUSB_version) in
+      {
+        id = (vm.API.vM_uuid, "vusb"^path);
+        hostbus = hostbus;
+        hostport = hostport;
+        version = version;
+        path = path;
+      }
+    with
+      | _ -> failwith "PUSB settings invalid"
+
+  let vusbs_of_vm ~__context (vmref, vm) =
+    let vusbs = List.map (fun self -> Db.VUSB.get_record ~__context ~self) vm.API.vM_VUSBs in
+    let pusbs = List.map (fun vusb -> Db.PUSB.get_record ~__context ~self:vusb.API.vUSB_attached) vusbs in
+    let vusbs' = List.map (fun pusb -> of_vusb ~__context ~vm ~pusb) pusbs in
+    vusbs'
+
+
   let of_vm ~__context (vmref, vm) vbds pci_passthrough vgpu =
     let on_crash_behaviour = function
       | `preserve -> [ Vm.Pause ]
@@ -903,6 +929,7 @@ let create_metadata ~__context ~upgrade ~self =
   let vifs' = List.map (fun vif -> MD.of_vif ~__context ~vm ~vif) vifs in
   let pcis = MD.pcis_of_vm ~__context (self, vm) in
   let vgpus = MD.vgpus_of_vm ~__context (self, vm) in
+  let vusbs = MD.vusbs_of_vm ~__context (self, vm) in
   let domains =
     (* For suspended VMs, we may need to translate the last_booted_record from the old format. *)
     if vm.API.vM_power_state = `Suspended || upgrade then begin
@@ -915,6 +942,7 @@ let create_metadata ~__context ~upgrade ~self =
     vifs = vifs';
     pcis = pcis;
     vgpus = vgpus;
+    vusbs = vusbs;
     domains = domains
   }
 
@@ -973,6 +1001,7 @@ module Xenops_cache = struct
     vifs: (Vif.id * Vif.state) list;
     pcis: (Pci.id * Pci.state) list;
     vgpus: (Vgpu.id * Vgpu.state) list;
+    vusbs: (Vusb.id * Vusb.state) list;
   }
   let empty = {
     vm = None;
@@ -980,6 +1009,7 @@ module Xenops_cache = struct
     vifs = [];
     pcis = [];
     vgpus = [];
+    vusbs = [];
   }
 
   let cache = Hashtbl.create 10 (* indexed by Vm.id *)
@@ -1037,6 +1067,14 @@ module Xenops_cache = struct
       else None
     | _ -> None
 
+  let find_vusb id : Vusb.state option =
+    match find (fst id) with
+    | Some { vusbs = vusbs } ->
+      if List.mem_assoc id vusbs
+      then Some (List.assoc id vusbs)
+      else None
+    | _ -> None
+
   let update id t =
     Mutex.execute metadata_m
       (fun () ->
@@ -1064,6 +1102,11 @@ module Xenops_cache = struct
     let existing = Opt.default empty (find (fst id)) in
     let vgpus' = List.filter (fun (vgpu_id, _) -> vgpu_id <> id) existing.vgpus in
     update (fst id) { existing with vgpus = Opt.default vgpus' (Opt.map (fun info -> (id, info) :: vgpus') info) }
+
+  let update_vusb id info =
+    let existing = Opt.default empty (find (fst id)) in
+    let vusbs' = List.filter (fun (vusb_id, _) -> vusb_id <> id) existing.vusbs in
+    update (fst id) { existing with vusbs = Opt.default vusbs' (Opt.map (fun info -> (id, info) :: vusbs') info) }
 
   let update_vm id info =
     let existing = Opt.default empty (find id) in
@@ -1893,6 +1936,46 @@ let update_vgpu ~__context id =
   with e ->
     error "xenopsd event: Caught %s while updating VGPU" (string_of_exn e)
 
+let update_vusb ~__context (id: (string * string)) =
+  try
+    let open Vusb in
+    if Events_from_xenopsd.are_suppressed (fst id)
+    then debug "xenopsd event: ignoring event for VM (VM %s migrating away)" (fst id)
+    else
+      let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
+      let localhost = Helpers.get_localhost ~__context in
+      if Db.VM.get_resident_on ~__context ~self:vm <> localhost
+      then debug "xenopsd event: ignoring event for VUSB (VM %s not resident)" (fst id)
+      else
+        let previous = Xenops_cache.find_vusb id in
+        let dbg = Context.string_of_task __context in
+        let module Client = (val make_client (queue_of_vm ~__context ~self:vm) : XENOPS) in
+        let info = try Some(Client.VUSB.stat dbg id) with _ -> None in
+        if Opt.map snd info = previous
+        then debug "xenopsd event: ignoring event for VUSB %s.%s: metadata has not changed" (fst id) (snd id)
+        else begin
+          let vusbs = Db.VM.get_VUSBs ~__context ~self:vm in
+          let pusbs = List.map (fun vusb -> Db.VUSB.get_attached ~__context ~self:vusb) vusbs in
+          let pusbrs = List.map (fun self -> self, Db.PUSB.get_record ~__context ~self) pusbs in
+
+          let pusb, pusb_r = List.find (fun (_, pusbr) -> "vusb" ^ pusbr.API.pUSB_path= (snd id)) pusbrs in
+          let vusb = Db.PUSB.get_attached ~__context ~self:pusb in
+          Opt.iter
+            (fun (ub, state) ->
+               debug "xenopsd event: Updating USB %s.%s; plugged <- %b" (fst id) (snd id)  state.plugged;
+               if not state.plugged then begin
+                 Db.VUSB.set_attached ~__context ~self:vusb ~value:Ref.null;
+                 Db.PUSB.set_attached ~__context ~self:pusb ~value:Ref.null;
+                 debug "VUSB.remove %s.%s" (fst id) (snd id);
+                 (try Client.VUSB.remove dbg id with e -> debug "VUSB.remove failed: %s" (Printexc.to_string e))
+               end
+            ) info;
+          Xenops_cache.update_vusb id (Opt.map snd info);
+          Xapi_vusb_helpers.update_allowed_operations ~__context ~self:vusb
+        end
+  with e ->
+    error "xenopsd event: Caught %s while updating VUSB" (string_of_exn e)
+
 exception Not_a_xenops_task
 let wrap queue_name id = TaskHelper.Xenops (queue_name, id)
 let unwrap x = match x with | TaskHelper.Xenops (queue_name, id) -> queue_name, id | _ -> raise Not_a_xenops_task
@@ -1970,6 +2053,10 @@ let rec events_watch ~__context cancel queue_name from =
                debug "xenops event on VGPU %s.%s" (fst id) (snd id);
                update_vgpu ~__context id
              end
+           | Vusb id ->
+             if Events_from_xenopsd.are_suppressed (fst id)
+             then debug "ignoring xenops event on Vusb %s.%s" (fst id) (snd id);
+             update_vusb ~__context id
            | Task id ->
              debug "xenops event on Task %s" id;
              update_task ~__context queue_name id
@@ -3032,3 +3119,42 @@ let task_cancel ~__context ~self =
   with
   | Not_found -> false
   | Not_a_xenops_task -> false
+
+let md_of_vusb ~__context ~self =
+  let vm = Db.VUSB.get_VM ~__context ~self in
+  let vusb = Db.VUSB.get_record ~__context ~self in
+  let pusb =Db.PUSB.get_record ~__context ~self:vusb.API.vUSB_attached in
+  MD.of_vusb ~__context ~vm:(Db.VM.get_record ~__context ~self:vm) ~pusb:pusb
+
+let vusb_unplug_hvm ~__context ~self =
+  let vm = Db.VUSB.get_VM ~__context ~self in
+  let queue_name = queue_of_vm ~__context ~self:vm in
+  transform_xenops_exn ~__context ~vm queue_name
+    (fun () ->
+       assert_resident_on ~__context ~self:vm;
+       let vusb = md_of_vusb ~__context ~self in
+       info "xenops: VUSB.unplug %s.%s" (fst vusb.Vusb.id) (snd vusb.Vusb.id);
+       let dbg = Context.string_of_task __context in
+       let module Client = (val make_client queue_name : XENOPS) in
+       Client.VUSB.unplug dbg vusb.Vusb.id |> sync_with_task __context queue_name;
+       Events_from_xenopsd.wait queue_name dbg (fst vusb.Vusb.id) ();
+       if (Db.VUSB.get_attached ~__context ~self <> Ref.null) then
+         raise Api_errors.(Server_error(internal_error, [
+             Printf.sprintf "vusb_unplug: Unable to unplug VUSB %s" (Ref.string_of self)]))
+    )
+
+let vusb_plugable ~__context ~self =
+  let dbg = Context.string_of_task __context in
+  let vm = Db.VUSB.get_VM ~__context ~self in
+  let id = Db.VM.get_uuid ~__context ~self:vm in
+  let queue_name = queue_of_vm ~__context ~self:vm in
+  let module Client = (val make_client queue_name : XENOPS) in
+  let _, state = Client.VM.stat dbg id in
+  state.Vm.hvm
+
+let vusb_unplug ~__context ~self =
+  if vusb_plugable ~__context ~self then
+    vusb_unplug_hvm ~__context ~self
+  else
+    raise Api_errors.(Server_error(internal_error, [
+             Printf.sprintf "vusb_unplug: Unable to unplug vusb %s" (Ref.string_of self)]))


### PR DESCRIPTION
This is PR is to set_passthrough_enabled for PUSB
    1. when passthrough_enabled is set true, then we need remove
       then corresponding vdis if the usb_path in sm_config equals path
       in PUSB.
    2. when passthrough_enabled is set to false, if the USB is plugged
       to vm, need to throw error that user should unplug it firstly.
       Then we need to re-introduce the corresponding vdis.
