### PR TITLE
CP-24611:  add lib yojson used by PUSB scan

### DIFF
--- a/ocaml/xapi/jbuild
+++ b/ocaml/xapi/jbuild
@@ -98,6 +98,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    rrdd-plugin
    xenopsd
    netdev
+   yojson
   ))
  )
 )


### PR DESCRIPTION
As now use jbuilder, lib yojson is missed. This is to add it. 