### PR TITLE
Storage_migrate.receive_start,copy: filter out cbt_metadata VDIs

### DIFF
--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -643,6 +643,8 @@ let receive_start ~dbg ~sr ~vdi_info ~id ~similar =
   let on_fail : (unit -> unit) list ref = ref [] in
 
   let vdis = Local.SR.scan ~dbg ~sr in
+  (** We drop cbt_metadata VDIs that do not have any actual data *)
+  let vdis = List.filter (fun vdi -> vdi.ty <> "cbt_metadata") vdis in
 
   let leaf_dp = Local.DP.create ~dbg ~id:(Uuid.string_of_uuid (Uuid.make_uuid ())) in
 
@@ -821,6 +823,9 @@ let copy ~task ~dbg ~sr ~vdi ~dp ~url ~dest =
       let similars = List.map (fun vdi -> vdi.content_id) similar_vdis in
       debug "Similar VDIs to %s = [ %s ]" vdi (String.concat "; " (List.map (fun x -> Printf.sprintf "(vdi=%s,content_id=%s)" x.vdi x.content_id) vdis));
       let remote_vdis = Remote.SR.scan ~dbg ~sr:dest in
+      (** We drop cbt_metadata VDIs that do not have any actual data *)
+      let remote_vdis = List.filter (fun vdi -> vdi.ty <> "cbt_metadata") remote_vdis in
+
       let nearest = List.fold_left
           (fun acc content_id -> match acc with
              | Some x -> acc


### PR DESCRIPTION
that don't have any actual data, when finding the nearest VDI. This is
to avoid accidentally using a cbt_metadata VDI without data.
The VDI.similar_content call already does this filtering when we look
for similar local VDIs, and this commit extends the filtering to the
remote VDIs that we compare the similar VDIs to.

The content_id of all the cbt_metadata VDIs is set to the same constant,
so this change prevents accidentally matching two of these two each
other when we try to find the nearest VDI.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>