### PR TITLE
CP-22446: add cbt_enabled to vdi_info type

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -102,6 +102,7 @@ module SMAPIv1 = struct
         then Db.VDI.get_uuid ~__context ~self:vdi_rec.API.vDI_snapshot_of
         else "";
       read_only = vdi_rec.API.vDI_read_only;
+      cbt_enabled = vdi_rec.API.vDI_cbt_enabled;
       virtual_size = vdi_rec.API.vDI_virtual_size;
       physical_utilisation = vdi_rec.API.vDI_physical_utilisation;
       persistent = vdi_rec.API.vDI_on_boot = `persist;

--- a/ocaml/xapi/storage_impl_test.ml
+++ b/ocaml/xapi/storage_impl_test.ml
@@ -486,6 +486,7 @@ let create_vdi_test sr =
     snapshot_time = "";
     snapshot_of = "";
     read_only = false;
+    cbt_enabled = false;
     physical_utilisation = 10L;
     metadata_of_pool = "";
     persistent = true;

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -432,7 +432,7 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
            ~metadata_of_pool:(Ref.of_string vdi.metadata_of_pool)
            ~metadata_latest:false
            ~is_tools_iso:(get_is_tools_iso vdi)
-           ~cbt_enabled:false;
+           ~cbt_enabled:vdi.cbt_enabled;
          StringMap.add vdi.vdi (ref, Db.VDI.get_record ~__context ~self:ref) m
       ) to_create db_vdi_map in
   (* Update the ones which already exist, and the ones which were just created
@@ -490,6 +490,10 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
        if v.API.vDI_is_tools_iso <> is_tools_iso then begin
          debug "%s is_tools_iso <- %b" (Ref.string_of r) is_tools_iso;
          Db.VDI.set_is_tools_iso ~__context ~self:r ~value:is_tools_iso
+       end;
+       if v.API.vDI_cbt_enabled <> vi.cbt_enabled then begin
+         debug "%s cbt_enabled <- %b" (Ref.string_of r) vi.cbt_enabled;
+         Db.VDI.set_cbt_enabled ~__context ~self:r ~value:vi.cbt_enabled
        end
     ) to_update
 

--- a/scripts/examples/smapiv2.py
+++ b/scripts/examples/smapiv2.py
@@ -75,6 +75,7 @@ vdi_info_types = {
     "snapshot_time": type(""),
     "snapshot_of": type(""),
     "read_only": type(True),
+    "cbt_enabled": type(True),
     "virtual_size": type(""),
     "physical_utilisation": type("")
 }


### PR DESCRIPTION
This PR contains the xapi changes required for for adding cbt_enabled to vdi_info SMAPIv2 type.