### PR TITLE
Revert "CA-223754 move periodic scheduler to a monotonic clock"

### DIFF
--- a/ocaml/xapi/ipq.ml
+++ b/ocaml/xapi/ipq.ml
@@ -14,7 +14,7 @@
 (* Imperative priority queue *)
 
 type 'a event = { ev: 'a;
-                  time: Int64.t }
+                  time: float }
 
 type 'a t = {mutable size : int; mutable data : 'a event array }
 


### PR DESCRIPTION
This reverts commit cafce7226210123536a632493340a3136b9dad4f.

The `event_from_parallel_test` unit test occasionally hangs in `event.from`,
even though a 2s timeout is applied. This may be due to the clock changes, so
reverting this, just in case.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>