### PR TITLE
CP-24904: Omit IP SubjectAltNames from TLS certs

### DIFF
--- a/scripts/generate_ssl_cert
+++ b/scripts/generate_ssl_cert
@@ -19,7 +19,6 @@ if [ -e ${FILE} ]; then
 fi
 
 dnsnames=$((hostname -A; hostname -f) | sort | uniq)
-addresses=$(hostname -I | sort | uniq)
 
 DIR=$(mktemp -d tls-cert-generation-XXXXXXXXXX --tmpdir)
 
@@ -51,12 +50,6 @@ for x in $dnsnames
 do
 	let i=i+1
 	echo "DNS.${i}=${x}" >> config
-done
-i=0
-for x in $addresses
-do
-	let i=i+1
-	echo "IP.${i}=${x}" >> config
 done
 
 openssl genrsa 1024 > privkey.rsa


### PR DESCRIPTION
When autogenerating a self-signed TLS certificate, the Subject
Alternative Names section no longer contains IP subjects, only DNS.