### PR TITLE
Test CBT VDI operations with quicktest

### DIFF
--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -844,6 +844,7 @@ let _ =
     "lifecycle";
     "vhd";
     "copy";
+    "cbt";
     "import_raw_vdi";
     "pbd-bvt";
   ] in

--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -882,7 +882,7 @@ let _ =
           maybe_run_test "pbd-bvt" (fun () -> Quicktest_bvt.start s !rpc);
           maybe_run_test "cbt" (fun () -> Quicktest_cbt.start s);
           maybe_run_test "vm-placement" Quicktest_vm_placement.run_from_within_quicktest;
-    (*      maybe_run_test "storage" (fun () -> Quicktest_storage.go s); *)
+          maybe_run_test "storage" (fun () -> Quicktest_storage.go s);
           if not !using_unix_domain_socket then maybe_run_test "http" Quicktest_http.run_from_within_quicktest;
           maybe_run_test "event" event_next_unblocking_test;
           maybe_run_test "event" (fun () -> event_next_test s);

--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -880,7 +880,7 @@ let _ =
           maybe_run_test "encodings" Quicktest_encodings.run_from_within_quicktest;
           maybe_run_test "vm-memory-constraints" Quicktest_vm_memory_constraints.run_from_within_quicktest;
           maybe_run_test "pbd-bvt" (fun () -> Quicktest_bvt.start s !rpc);
-          maybe_run_test "cbt" (fun () -> Quicktest_cbt.start s);
+          maybe_run_test "cbt" (fun () -> Quicktest_cbt.test s);
           maybe_run_test "vm-placement" Quicktest_vm_placement.run_from_within_quicktest;
           maybe_run_test "storage" (fun () -> Quicktest_storage.go s);
           if not !using_unix_domain_socket then maybe_run_test "http" Quicktest_http.run_from_within_quicktest;

--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -882,7 +882,7 @@ let _ =
           maybe_run_test "pbd-bvt" (fun () -> Quicktest_bvt.start s !rpc);
           maybe_run_test "cbt" (fun () -> Quicktest_cbt.start s);
           maybe_run_test "vm-placement" Quicktest_vm_placement.run_from_within_quicktest;
-          maybe_run_test "storage" (fun () -> Quicktest_storage.go s);
+    (*      maybe_run_test "storage" (fun () -> Quicktest_storage.go s); *)
           if not !using_unix_domain_socket then maybe_run_test "http" Quicktest_http.run_from_within_quicktest;
           maybe_run_test "event" event_next_unblocking_test;
           maybe_run_test "event" (fun () -> event_next_test s);

--- a/ocaml/xapi/quicktest.ml
+++ b/ocaml/xapi/quicktest.ml
@@ -879,6 +879,7 @@ let _ =
           maybe_run_test "encodings" Quicktest_encodings.run_from_within_quicktest;
           maybe_run_test "vm-memory-constraints" Quicktest_vm_memory_constraints.run_from_within_quicktest;
           maybe_run_test "pbd-bvt" (fun () -> Quicktest_bvt.start s !rpc);
+          maybe_run_test "cbt" (fun () -> Quicktest_cbt.start s);
           maybe_run_test "vm-placement" Quicktest_vm_placement.run_from_within_quicktest;
           maybe_run_test "storage" (fun () -> Quicktest_storage.go s);
           if not !using_unix_domain_socket then maybe_run_test "http" Quicktest_http.run_from_within_quicktest;

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -20,9 +20,9 @@ let start session_id =
   let open Client in
 
   (* Helper for test failure due to unexpected error *)
-  let report_failure error test_name test =
-    raise Test_failed (Printf.sprintf "%s failed: %s" test_name
-                         (ExnHelper.string_of_exn error)) in
+  let report_failure error test =
+    failed test (Printf.sprintf "%s failed: %s" test.name
+                   (ExnHelper.string_of_exn error)) in
 
   (* Define exception so that if test fails, exception is passed to try-with statement and fails there
    * so that the test only fails once and doesn't erroneously assume the test never started *)
@@ -60,7 +60,7 @@ let start session_id =
         start enable_cbt_test;
         test_assert ~test:enable_cbt_test
           (not (VDI.get_cbt_enabled ~session_id ~rpc:!rpc ~self:vDI))
-          ~msg:"VDI.cbt_enabled field should be set to false for new VDIs, but wasn't ";
+          ~msg:"VDI.cbt_enabled field should be set to false for new VDIs";
         VDI.enable_cbt ~session_id ~rpc:!rpc ~self:vDI;
         test_assert ~test:enable_cbt_test
           (get_cbt_status vDI)
@@ -72,7 +72,7 @@ let start session_id =
         success enable_cbt_test
       with
       | Test_failed msg -> failed enable_cbt_test msg
-      | e -> report_failure e "enable/disable CBT" enable_cbt_test in
+      | e -> report_failure e enable_cbt_test in
 
     (* For each test, check the given sR is capable of the associated operations
      * If not, skip that test, otherwise run it *)
@@ -118,4 +118,4 @@ let start session_id =
     debug cbt_test "Finished testing changed block tracking";
     success cbt_test
   with
-  | e -> report_failure e "CBT" cbt_test
+  | e -> report_failure e cbt_test

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -22,30 +22,39 @@ let start session_id =
     failed test (Printf.sprintf "%s failed: %s" test_name
                    (ExnHelper.string_of_exn error)) in
 
+
   let test_assert ~test op ~msg =
     try assert op with assert_failure -> failed test msg in
-
-  let test_compare ~test l_op r_op ~msg =
-    let op = (l_op=r_op) in
-    test_assert ~test ~op ~msg in
-
 
   (* Overall test suite runs smaller unit tests *)
   let cbt_test = make_test "Testing changed block tracking" 2 in
   try
     start cbt_test;
-    (* Create new VDI, attach to lvm SR *)
+
+    (* generate list of SRs attached to a host *)
+    let list_of_attached_srs =
+      let is_attached sr =
+        let pbds = SR.get_PBDs ~session_id ~rpc:!rpc ~self:sr in
+        List.fold_left (||) false
+          (List.map (fun pbd ->
+               PBD.get_currently_attached ~session_id ~rpc:!rpc ~self:pbd
+             ) pbds) in
+      List.filter is_attached (SR.get_all ~session_id ~rpc:!rpc) in
+
+    (* find lvm SR (that passes data_destroy) to attach new VDI *)
     let sR = List.filter
-        (fun sr -> (SR.get_type ~session_id ~rpc:!rpc ~self:sr) = "lvm")
-        (SR.get_all ~session_id ~rpc:!rpc)
-             |> List.hd in
+        (fun sr ->
+           ((SR.get_type ~session_id ~rpc:!rpc ~self:sr) = "lvm")
+           && (not (SR.get_is_tools_sr ~session_id ~rpc:!rpc ~self:sr))
+        ) list_of_attached_srs |> List.hd in
+
     let vDI = VDI.create ~session_id ~rpc:!rpc ~name_label:"qt-cbt"
         ~name_description:"VDI for CBT quicktest" ~_type:`user ~sR
         ~sharable:false ~other_config:[] ~read_only:false ~sm_config:[]
         ~virtual_size:(2L ** mib) ~xenstore_data:[] ~tags:[] in
 
     (* Test enable/disable CBT, test cbt_enabled:false for new VDI *)
-    let enable_disable_cbt_test () =
+    let enable_disable_cbt_test vDI =
       let enable_cbt_test = make_test "Testing VDI.enable/disable_CBT" 4 in
       let get_cbt_status vDI = VDI.get_cbt_enabled ~session_id ~rpc:!rpc ~self:vDI in
       let test = enable_cbt_test in
@@ -60,16 +69,23 @@ let start session_id =
           ~msg:"VDI.enable_cbt failed";
         VDI.disable_cbt ~session_id ~rpc:!rpc ~self:vDI;
         test_assert ~test
-          (get_cbt_status vDI) (* disable_cbt fails *)
+          (not (get_cbt_status vDI)) (* disable_cbt fails *)
           ~msg:"VDI.disable_CBT failed";
         success enable_cbt_test;
       with e -> report_failure e "enable/disable CBT" enable_cbt_test in
 
     (* Call unit tests *)
-    enable_disable_cbt_test ();
+    let run_tests ~vDI =
+      List.iter (fun test -> test vDI)
+        [ enable_disable_cbt_test
+        ]; in
 
-    (* Finally, destroy VDI *)
-    VDI.destroy ~session_id ~rpc:!rpc ~self:vDI;
+    (* Finally, destroy VDI regardless of how test suite progresses *)
+    Xapi_stdext_pervasives.Pervasiveext.finally
+      (fun () -> run_tests ~vDI)
+      (fun () -> VDI.destroy ~session_id ~rpc:!rpc ~self:vDI);
+
+    (* Overall test will fail if VDI.destroy messes up, or any other exception is thrown *)
     success cbt_test
   with
   | (Failure hd) -> failed cbt_test "Could not find lvm SR, cannot create VDI"

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -26,6 +26,15 @@ let start session_id =
     try assert op with assert_failure -> failed test msg in
 
   (* Overall test suite runs smaller unit tests *)
+  let test_compare ~test l_op r_op ~msg =
+    let op = (l_op = r_op) in test_assert ~test op ~msg in
+
+  let name_description = "VDI for CBT quicktest" in
+  let make_vdi_from sR = (* SR has VDI.create as allowed *)
+    VDI.create ~session_id ~rpc:!rpc ~name_label:"qt-cbt" ~name_description ~_type:`user
+      ~sharable:false ~other_config:[] ~read_only:false ~sm_config:[] ~virtual_size:(2L ** mib)
+      ~xenstore_data:[] ~tags:[] ~sR in
+
   let cbt_test = make_test "Testing changed block tracking" 2 in
   try
     start cbt_test;

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -24,8 +24,8 @@ let start session_id =
     raise Test_failed (Printf.sprintf "%s failed: %s" test_name
                          (ExnHelper.string_of_exn error)) in
 
-  (* Define exception to return error message to the test try/with and fail within that,
-   * as calling 'failed test' in a function called within the test leads to Hashtbl problems *)
+  (* Define exception so that if test fails, exception is passed to try-with statement and fails there
+   * so that the test only fails once and doesn't erroneously assume the test never started *)
   let test_assert ~test op ~msg =
     if not op then raise (Test_failed msg) in
 

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -31,9 +31,21 @@ let start session_id =
 
   let name_description = "VDI for CBT quicktest" in
   let make_vdi_from sR = (* SR has VDI.create as allowed *)
-    VDI.create ~session_id ~rpc:!rpc ~name_label:"qt-cbt" ~name_description ~_type:`user
-      ~sharable:false ~other_config:[] ~read_only:false ~sm_config:[] ~virtual_size:(2L ** mib)
-      ~xenstore_data:[] ~tags:[] ~sR in
+    VDI.create
+      ~sR
+      ~session_id
+      ~rpc:!rpc
+      ~name_label:"qt-cbt"
+      ~name_description
+      ~_type:`user
+      ~sharable:false
+      ~read_only:false
+      ~virtual_size:(2L ** mib)
+      ~xenstore_data:[]
+      ~other_config:[]
+      ~tags:[]
+      ~sm_config:[]
+  in
 
   let cbt_test = make_test "Testing changed block tracking" 2 in
   try
@@ -63,7 +75,8 @@ let start session_id =
 
     let run_test_suite ~sR ~vDI =
       let sr_ops = (SR.get_allowed_operations ~session_id ~rpc:!rpc ~self:sR) in
-      [ (fun () -> enable_disable_cbt_test ~vDI), [ `vdi_enable_cbt ; `vdi_disable_cbt ]
+      [ (fun () -> enable_disable_cbt_test ~vDI) ,
+        [ `vdi_enable_cbt ; `vdi_disable_cbt ]
       ]
       |> List.iter
         (fun (test,list_vdi_ops) ->

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -25,10 +25,6 @@ let start session_id =
   let test_assert ~test op ~msg =
     try assert op with assert_failure -> failed test msg in
 
-  (* Overall test suite runs smaller unit tests *)
-  let test_compare ~test l_op r_op ~msg =
-    let op = (l_op = r_op) in test_assert ~test op ~msg in
-
   let name_description = "VDI for CBT quicktest" in
   let make_vdi_from sR = (* SR has VDI.create as allowed *)
     VDI.create ~session_id ~rpc:!rpc ~name_label:"qt-cbt" ~name_description ~_type:`user
@@ -60,42 +56,36 @@ let start session_id =
         success enable_cbt_test
       with e -> report_failure e "enable/disable CBT" enable_cbt_test in
 
-    let name_description = "VDI for CBT quicktest" in
-    let make_vdi_from sR = (* SR has VDI.create as allowed *)
-      VDI.create ~session_id ~rpc:!rpc ~name_label:"qt-cbt" ~name_description ~_type:`user
-        ~sharable:false ~other_config:[] ~read_only:false ~sm_config:[] ~virtual_size:(2L ** mib)
-        ~xenstore_data:[] ~tags:[] ~sR in
-
     let run_test_suite ~sR ~vDI =
       let sr_ops = (SR.get_allowed_operations ~session_id ~rpc:!rpc ~self:sR) in
-      List.iter
+      [ (fun () -> enable_disable_cbt_test ~vDI), [ `vdi_enable_cbt ; `vdi_disable_cbt ]
+      ]
+      |> List.iter
         (fun (test,list_vdi_ops) ->
            if List.for_all (fun vdi_op -> List.mem vdi_op sr_ops) list_vdi_ops
-           then test ();
-        ) [ (fun () -> enable_disable_cbt_test ~vDI), [ `vdi_enable_cbt ; `vdi_disable_cbt ]
-          ]
-    ; in
+           then test ())
+    in
 
     (* Try running test suite, definitively destroy all VDIs created, regardless of success or errors *)
     let handle_storage_objects ~sR ~vDI =
       Xapi_stdext_pervasives.Pervasiveext.finally
         (fun () -> run_test_suite ~sR ~vDI)
         (fun () ->
-           List.filter (fun vdi -> (VDI.get_name_label ~session_id ~rpc:!rpc ~self:vdi = "qt-cbt")
-                                   && (VDI.get_name_description ~session_id ~rpc:!rpc ~self:vdi = name_description)
-                       )  (VDI.get_all ~session_id ~rpc:!rpc)
+           (VDI.get_all ~session_id ~rpc:!rpc)
+           |> List.filter (fun vdi -> (VDI.get_name_label ~session_id ~rpc:!rpc ~self:vdi = "qt-cbt")
+                                      && (VDI.get_name_description ~session_id ~rpc:!rpc ~self:vdi = name_description))
            |> List.iter (fun vdi -> VDI.destroy ~session_id ~rpc:!rpc ~self:vdi);
         ) in
 
     (* Obtain list of SRs capable of creating VDIs, and run them all through test suite *)
-    let srs_can_create_vdi =
-      List.filter (fun sR -> List.mem `vdi_create (SR.get_allowed_operations ~session_id ~rpc:!rpc ~self:sR)
-                  ) (SR.get_all ~session_id ~rpc:!rpc) in
-    List.iteri (fun i sR ->
-        debug cbt_test (Printf.sprintf "Testing SR %d of %d" (i+1) (List.length srs_can_create_vdi));
+    (SR.get_all ~session_id ~rpc:!rpc)
+    |> List.filter (fun sR -> (List.mem `vdi_create (SR.get_allowed_operations ~session_id ~rpc:!rpc ~self:sR))
+                              && (SR.get_type ~session_id ~rpc:!rpc ~self:sR <> "iso"))
+    |> List.iteri (fun i sR ->
+        debug cbt_test (Printf.sprintf "Testing SR: \"%s\"" (SR.get_name_label ~session_id ~rpc:!rpc ~self:sR));
         let vDI = make_vdi_from sR in
         handle_storage_objects ~sR ~vDI
-      ) srs_can_create_vdi;
+      );
 
     (* Overall test will fail if VDI.destroy messes up, or any other exception is thrown *)
     debug cbt_test "Finished testing changed block tracking";

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -27,7 +27,7 @@ let start session_id =
   (* Define own exception to return error message to the test try/with and fail within that,
    * as calling 'failed test' in a function called within the test leads to Hashtbl problems *)
   let test_assert ~test op ~msg =
-    try assert op with (Assert_failure _) -> raise (Test_assertion_failed msg) in
+    if not op then raise (Test_assertion_failed msg) in
 
   let name_description = "VDI for CBT quicktest" in
   let make_vdi_from sR = (* SR has VDI.create as allowed *)

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -17,15 +17,24 @@ open Quicktest_common
 let start session_id =
   let open Client in
 
-  (* helper for test failure due to unexpected error *)
+  (* Helper for test failure due to unexpected error *)
   let report_failure error test_name test =
-    failed test (Printf.sprintf "%s failed: %s" test_name  (ExnHelper.string_of_exn error)) in
+    failed test (Printf.sprintf "%s failed: %s" test_name
+                   (ExnHelper.string_of_exn error)) in
 
-  (* overall test suite runs smaller unit tests *)
+  let test_assert ~test op ~msg =
+    try assert op with assert_failure -> failed test msg in
+
+  let test_compare ~test l_op r_op ~msg =
+    let op = (l_op=r_op) in
+    test_assert ~test ~op ~msg in
+
+
+  (* Overall test suite runs smaller unit tests *)
   let cbt_test = make_test "Testing changed block tracking" 2 in
   try
     start cbt_test;
-    (* find an lvm SR to attach new VDI to *)
+    (* Create new VDI, attach to lvm SR *)
     let sR = List.filter
         (fun sr -> (SR.get_type ~session_id ~rpc:!rpc ~self:sr) = "lvm")
         (SR.get_all ~session_id ~rpc:!rpc)
@@ -33,29 +42,35 @@ let start session_id =
     let vDI = VDI.create ~session_id ~rpc:!rpc ~name_label:"qt-cbt"
         ~name_description:"VDI for CBT quicktest" ~_type:`user ~sR
         ~sharable:false ~other_config:[] ~read_only:false ~sm_config:[]
-        ~virtual_size:(4L ** mib) ~xenstore_data:[] ~tags:[] in
+        ~virtual_size:(2L ** mib) ~xenstore_data:[] ~tags:[] in
 
-    (* test enable/disable CBT, test cbt_enabled:false for new VDI *)
+    (* Test enable/disable CBT, test cbt_enabled:false for new VDI *)
     let enable_disable_cbt_test () =
       let enable_cbt_test = make_test "Testing VDI.enable/disable_CBT" 4 in
       let get_cbt_status vDI = VDI.get_cbt_enabled ~session_id ~rpc:!rpc ~self:vDI in
+      let test = enable_cbt_test in
       try
         start enable_cbt_test;
-        assert (not (VDI.get_cbt_enabled ~session_id ~rpc:!rpc ~self:vDI));
+        test_assert ~test
+          (not (VDI.get_cbt_enabled ~session_id ~rpc:!rpc ~self:vDI))
+          ~msg:"VDI.cbt_enabled field should be set to false for new VDIs, but wasn't ";
         VDI.enable_cbt ~session_id ~rpc:!rpc ~self:vDI;
-        if get_cbt_status vDI
-        then begin (* enable_cbt works *)
-          VDI.disable_cbt ~session_id ~rpc:!rpc ~self:vDI;
-          if get_cbt_status vDI (* disable_cbt fails *)
-          then failed enable_cbt_test "VDI.disable_CBT failed"
-          else success enable_cbt_test end
-        else failed enable_cbt_test "VDI.enable_CBT failed"
+        test_assert ~test
+          (get_cbt_status vDI)
+          ~msg:"VDI.enable_cbt failed";
+        VDI.disable_cbt ~session_id ~rpc:!rpc ~self:vDI;
+        test_assert ~test
+          (get_cbt_status vDI) (* disable_cbt fails *)
+          ~msg:"VDI.disable_CBT failed";
+        success enable_cbt_test;
       with e -> report_failure e "enable/disable CBT" enable_cbt_test in
 
-    (* call unit tests *)
+    (* Call unit tests *)
     enable_disable_cbt_test ();
+
+    (* Finally, destroy VDI *)
     VDI.destroy ~session_id ~rpc:!rpc ~self:vDI;
     success cbt_test
   with
-  | (Failure hd) -> failed cbt_test "could not find lvm SR, cannot create VDI"
-  | e -> failed cbt_test (ExnHelper.string_of_exn e)
+  | (Failure hd) -> failed cbt_test "Could not find lvm SR, cannot create VDI"
+  | e -> report_failure e "CBT" cbt_test

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -22,7 +22,7 @@ let start session_id =
     failed test (Printf.sprintf "%s failed: %s" test_name  (ExnHelper.string_of_exn error)) in
 
   (* overall test suite runs smaller unit tests *)
-  let cbt_test = make_test "Testing CBT feature" 4 in
+  let cbt_test = make_test "Testing changed block tracking" 2 in
   try
     start cbt_test;
     (* find an lvm SR to attach new VDI to *)
@@ -37,7 +37,7 @@ let start session_id =
 
     (* test enable/disable CBT, test cbt_enabled:false for new VDI *)
     let enable_disable_cbt_test () =
-      let enable_cbt_test = make_test "Testing VDI.enable/disable_CBT" 2 in
+      let enable_cbt_test = make_test "Testing VDI.enable/disable_CBT" 4 in
       let get_cbt_status vDI = VDI.get_cbt_enabled ~session_id ~rpc:!rpc ~self:vDI in
       try
         start enable_cbt_test;

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -1,0 +1,49 @@
+(* COPYRIGHT HERE *)
+
+open Client
+open Quicktest_common
+let start session_id =
+  let open Client in
+
+  (* helper for test failure due to unexpected error *)
+  let report_failure error test_name test =
+    failed test (Printf.sprintf "%s failed: %s" test_name  (ExnHelper.string_of_exn error)) in
+
+  (* overall test suite runs smaller unit tests *)
+  let cbt_test = make_test "Testing CBT feature" 4 in
+  try
+    start cbt_test;
+    (* find an lvm SR to attach new VDI to *)
+    let sR = List.filter
+        (fun sr -> (SR.get_type ~session_id ~rpc:!rpc ~self:sr) = "lvm")
+        (SR.get_all ~session_id ~rpc:!rpc)
+             |> List.hd in
+    let vDI = VDI.create ~session_id ~rpc:!rpc ~name_label:"qt-cbt"
+        ~name_description:"VDI for CBT quicktest" ~_type:`user ~sR
+        ~sharable:false ~other_config:[] ~read_only:false ~sm_config:[]
+        ~virtual_size:(4L ** mib) ~xenstore_data:[] ~tags:[] in
+
+    (* test enable/disable CBT, test cbt_enabled:false for new VDI *)
+    let enable_disable_cbt_test () =
+      let enable_cbt_test = make_test "Testing VDI.enable/disable_CBT" 2 in
+      let get_cbt_status vDI = VDI.get_cbt_enabled ~session_id ~rpc:!rpc ~self:vDI in
+      try
+        start enable_cbt_test;
+        assert (not (VDI.get_cbt_enabled ~session_id ~rpc:!rpc ~self:vDI));
+        VDI.enable_cbt ~session_id ~rpc:!rpc ~self:vDI;
+        if get_cbt_status vDI
+        then begin (* enable_cbt works *)
+          VDI.disable_cbt ~session_id ~rpc:!rpc ~self:vDI;
+          if get_cbt_status vDI (* disable_cbt fails *)
+          then failed enable_cbt_test "VDI.disable_CBT failed"
+          else success enable_cbt_test end
+        else failed enable_cbt_test "VDI.enable_CBT failed"
+      with e -> report_failure e "enable/disable CBT" enable_cbt_test in
+
+    (* call unit tests *)
+    enable_disable_cbt_test ();
+    VDI.destroy ~session_id ~rpc:!rpc ~self:vDI;
+    success cbt_test
+  with
+  | (Failure hd) -> failed cbt_test "could not find lvm SR, cannot create VDI"
+  | e -> failed cbt_test (ExnHelper.string_of_exn e)

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -1,4 +1,16 @@
-(* COPYRIGHT HERE *)
+(*
+ * Copyright (C) 2017 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
 
 open Client
 open Quicktest_common

--- a/ocaml/xapi/valid_ref_list.ml
+++ b/ocaml/xapi/valid_ref_list.ml
@@ -17,4 +17,3 @@ let map f = Stdext.Listext.List.filter_map (default_on_missing_ref (fun x -> Som
 let flat_map f l = List.map (default_on_missing_ref f []) l |> List.flatten
 
 let filter_map f l = map f l |> List.filter ((<>) None) |> List.map Xapi_stdext_monadic.Opt.unbox
-


### PR DESCRIPTION
Test does the following:
  - search for an lvm SR
  - create a VDI attached to it
  - test cbt_enabled:false for newly created VDI
  - call enable_CBT and disable_CBT
  - destroy VDI

In future:
- snapshot newly created VDI
- test data_destroy does the following:
  -- update content_id field to specified string
  -- update type to CBT_metadata
- destroy snapshot VDI