### PR TITLE
CP-25015: nbd-firewall-config.sh in "make install"

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -63,6 +63,7 @@ install:
 	mkdir -p $(DESTDIR)/etc/sysconfig
 	$(IPROG) sysconfig-xapi $(DESTDIR)/etc/sysconfig/xapi
 	$(IPROG) generate_ssl_cert $(DESTDIR)$(LIBEXECDIR)
+	$(IPROG) nbd-firewall-config.sh $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) fix_firewall.sh $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)$(OPTDIR)/debug
 	$(IPROG) debug_ha_query_liveset $(DESTDIR)$(OPTDIR)/debug


### PR DESCRIPTION
This script is now included in the "install" target of the
relevant Makefile.