### PR TITLE
CP-24647 replace oclock with mtime, use it for periodic scheduler

### DIFF
--- a/ocaml/.merlin
+++ b/ocaml/.merlin
@@ -1,9 +1,0 @@
-PKG oUnit
-PKG ppx_deriving_rpc rpclib ppx_sexp_conv sexpr threads http-svr gzip uuid xcp xml-light2 uuid xcp xcp-inventory oPasswd pciutil pci ezxenstore oclock sha tar tar.unix tapctl xenctrl xcp.rrd xcp.storage xcp.xen xcp.network xcp.v6 xcp.memory rrdd-plugin cdrom netdev stdext stunnel systemd xapi-test-utils
-B +threads
-S ../_build/ocaml/**
-B ../_build/ocaml/**
-S ./
-B ./
-S ./**
-B ./**

--- a/ocaml/xapi/ipq.ml
+++ b/ocaml/xapi/ipq.ml
@@ -14,7 +14,7 @@
 (* Imperative priority queue *)
 
 type 'a event = { ev: 'a;
-                  time: float }
+                  time: Mtime.t }
 
 type 'a t = {mutable size : int; mutable data : 'a event array }
 
@@ -47,8 +47,9 @@ let add h x =
   let d = h.data in
   (* moving [x] up in the heap *)
   let rec moveup i =
+    let (>>) = Mtime.is_later in
     let fi = (i - 1) / 2 in
-    if i > 0 && (d.(fi).time > x.time) then begin
+    if i > 0 && (d.(fi).time >> x.time) then begin
       d.(i) <- d.(fi);
       moveup fi
     end else
@@ -70,12 +71,13 @@ let remove h s =
   (* moving [x] down in the heap *)
   let rec movedown i =
     let j = 2 * i + 1 in
+    let (<<) = Mtime.is_earlier in
     if j < n then
       let j =
         let j' = j + 1 in
         if j' < n && (d.(j').time < d.(j).time) then j' else j
       in
-      if (d.(j).time < x.time) then begin
+      if (d.(j).time << x.time) then begin
         d.(i) <- d.(j);
         movedown j
       end else

--- a/ocaml/xapi/jbuild
+++ b/ocaml/xapi/jbuild
@@ -71,7 +71,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    pciutil
    pci
    ezxenstore
-   oclock
+   mtime.clock.os
    oUnit
    sha
    tar

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -727,8 +727,8 @@ let reqs_outstanding_timeout = 150.0 (* Tapdisk should time out after 2 mins. We
 let pre_deactivate_hook ~dbg ~dp ~sr ~vdi =
   let open State.Send_state in
   let id = State.mirror_id_of (sr,vdi) in
-  let start_time = Oclock.gettime Oclock.monotonic in
-  let get_delta () = (Int64.to_float (Int64.sub (Oclock.gettime Oclock.monotonic) start_time)) /. 1.0e9 in
+  let start = Mtime_clock.counter () in
+  let get_delta () = Mtime_clock.count start |> Mtime.Span.to_s in
   State.find_active_local_mirror id |>
   Opt.iter (fun s ->
       try

--- a/xapi.opam
+++ b/xapi.opam
@@ -37,7 +37,7 @@ depends: [
   "xapi-forkexecd"
   "vhd-format"
   "nbd"
-  "oclock"
+  "mtime"
   "ounit"
   "rpc"
   "ssl"


### PR DESCRIPTION
This is the second attempt to move the periodic scheduler to a monotonic clock. The PR contains two commits:

* f9c544ac9 replaces the oclock with mtime 
* 3630167ab moves the periodic scheduler to use mtime

Previously with using oclock for the periodic scheduler we saw xapi locking up and suspected problems in oclock. This PR has been tested:

* running unit tests that exhibited the problem in the past
* running builds on Jenkins that exercised unit tests
*  BVT run 72144