### PR TITLE
Xapi_vdi.snapshot: remove logic setting cbt_enabled in the DB

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -578,8 +578,6 @@ let snapshot ~__context ~vdi ~driver_params =
   (* Record the fact this is a snapshot *)
   Db.VDI.set_is_a_snapshot ~__context ~self:newvdi ~value:true;
   Db.VDI.set_snapshot_of ~__context ~self:newvdi ~value:vdi;
-  (* Inherit the cbt_enabled field from the snapshotted VDI *)
-  Db.VDI.set_cbt_enabled ~__context ~self:newvdi ~value:(Db.VDI.get_cbt_enabled ~__context ~self:vdi);
 
   update_allowed_operations ~__context ~self:newvdi;
   newvdi


### PR DESCRIPTION
We should not try to guess here whether CBT is enabled or not on the
snapshotted VDIs. SM should be responsible for updating this VDI field
in the DB, instead of xapi trying to guess and keep track of it, as SM
is in the best position to know when CBT is enabled, and it is already
setting this field during SR scan.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>