### PR TITLE
Update opam files and cleanup xapi-types

### DIFF
--- a/ocaml/xapi-types/event_types.ml
+++ b/ocaml/xapi-types/event_types.ml
@@ -11,7 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open Stdext.Xstringext
 
 (** Types used to store events: *****************************************************************)
 type op = API.event_operation

--- a/ocaml/xapi-types/jbuild
+++ b/ocaml/xapi-types/jbuild
@@ -30,13 +30,13 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (public_name xapi-types)
   (flags (:standard %s))
   (libraries (
-   xapi-consts
-   rpclib
-   ppx_deriving_rpc
-   stdext
-   threads
+   astring
    http-svr
-   uuid
+   ppx_deriving_rpc
+   rpclib
+   threads
+   uuidm
+   xapi-consts
   ))
   (wrapped false)
  )

--- a/xapi-cli-protocol.opam
+++ b/xapi-cli-protocol.opam
@@ -1,0 +1,13 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "stdext"
+]

--- a/xapi-client.opam
+++ b/xapi-client.opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "xapi-datamodel"
+  "xapi-types"
+]
+

--- a/xapi-consts.opam
+++ b/xapi-consts.opam
@@ -1,0 +1,12 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+]

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "rpc"
+  "ppx_sexp_conv"
+  "xapi-libs-transitional"
+  "xapi-idl"
+]

--- a/xapi-datamodel.opam
+++ b/xapi-datamodel.opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "rpc"
+  "stdext"
+  "xapi-consts"
+  "xapi-database"
+  "xapi-libs-transitional"
+  "xenstore"
+]

--- a/xapi-types.opam
+++ b/xapi-types.opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "astring"
+  "rpc"
+  "uuidm"
+  "xapi-consts"
+  "xapi-datamodel"
+  "xapi-libs-transitional"
+]
+

--- a/xapi.opam
+++ b/xapi.opam
@@ -12,7 +12,6 @@ depends: [
   "jbuilder" {build & >= "1.0+beta11"}
   "cdrom"
   "fd-send-recv"
-  "mustache"
   "nbd"
   "mtime"
   "opasswd"
@@ -38,7 +37,6 @@ depends: [
   "xapi-test-utils"
   "xapi-types"
   "xapi-xenopsd"
-  "xen-api-client"
   "xenctrl"
   "xenstore"
 ]

--- a/xapi.opam
+++ b/xapi.opam
@@ -4,55 +4,43 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "https://github.com/xapi-project/xen-api.git"
-build: [
-  ["./configure"]
-  [make]
-]
-install: [
-    ["oasis" "setup"]
-    ["ocaml" "setup.ml" "-install"]
-]
-build-test: [make "test"]
-remove: [
-    ["oasis" "setup"]
-    ["ocaml" "setup.ml" "-uninstall"]
-    ["ocamlfind" "remove" "xapi"]
-    ["ocamlfind" "remove" "xapi-client"]
-    ["ocamlfind" "remove" "xapi-cli-protocol"]
-    ["ocamlfind" "remove" "xapi-consts"]
-    ["ocamlfind" "remove" "xapi-datamodel"]
-    ["ocamlfind" "remove" "xapi-database"]
-    ["ocamlfind" "remove" "xapi-types"]
-]
+
+build: [[ "jbuilder" "build" "-p" name ]]
+build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+
 depends: [
-  "oasis" {build}
-  "ocamlfind" {build}
-  "xapi-test-utils"
-  "xapi-idl"
-  "xapi-libs-transitional"
-  "xen-api-client"
-  "xapi-netdev"
+  "jbuilder" {build & >= "1.0+beta11"}
   "cdrom"
   "fd-send-recv"
-  "xapi-forkexecd"
-  "vhd-format"
+  "mustache"
   "nbd"
   "mtime"
+  "opasswd"
   "ounit"
+  "pci"
   "rpc"
+  "sha"
   "ssl"
-  "xapi-stdext"
-  "xapi-tapctl"
+  "stdext"
+  "tar-format"
+  "vhd-format"
+  "xapi-cli-protocol"
+  "xapi-client"
+  "xapi-consts"
+  "xapi-database"
+  "xapi-datamodel"
+  "xapi-forkexecd"
+  "xapi-idl"
+  "xapi-inventory"
+  "xapi-libs-transitional"
+  "xapi-netdev"
+  "xapi-rrdd-plugin"
+  "xapi-test-utils"
+  "xapi-types"
+  "xapi-xenopsd"
+  "xen-api-client"
   "xenctrl"
   "xenstore"
-  "xapi-inventory"
-  "tar-format"
-  "opasswd"
-  "xapi-rrdd-plugin"
-  "pci"
-  "sha"
-  "xapi-xenopsd"
-  "mustache"
 ]
 depexts: [
   [["centos"] ["pam-devel"]]

--- a/xe.opam
+++ b/xe.opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "xen-api@lists.xen.org" ]
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
+
+build: [[ "jbuilder" "build" "-p" name ]]
+
+depends: [
+  "jbuilder" {build & >= "1.0+beta11"}
+  "stdext"
+  "xapi-cli-protocol"
+  "xapi-libs-transitional"
+]


### PR DESCRIPTION
This will allow us to re-introduce xapi into xs-opam and be able to use selected sub-libraries without the need to have the whole xapi