### PR TITLE
CP-24805: Update VM.platform.device-model field during Xapi database upgrade

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 132
+let schema_minor_vsn = 133
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -89,6 +89,9 @@ let falcon_release_schema_minor_vsn = 120
 
 let inverness_release_schema_major_vsn = 5
 let inverness_release_schema_minor_vsn = 131
+
+let jura_release_schema_major_vsn = 5
+let jura_release_schema_minor_vsn = schema_minor_vsn (* TODO: make it a constant when jura is released *)
 
 (* List of tech-preview releases. Fields in these releases are not guaranteed to be retained when
  * upgrading to a full release. *)

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -46,6 +46,7 @@ let nested_virt = "nested-virt"
 
 (* The default value of device model should be set as
    'qemu-trad', 'qemu-upstream-compat', 'qemu-upstream' according to QEMU-upstream feature release stages *)
+let fallback_device_model_stage_1      = "qemu-trad"
 let default_device_model_default_value = "qemu-trad"
 
 (* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -50,7 +50,7 @@ let fallback_device_model_stage_1      = "qemu-trad"
 let fallback_device_model_stage_2      = fallback_device_model_stage_1
 let fallback_device_model_stage_3      = "qemu-upstream-compat"
 let fallback_device_model_stage_4      = fallback_device_model_stage_3
-let default_device_model_default_value = fallback_device_model_stage_1
+let fallback_device_model_default_value = fallback_device_model_stage_1
 
 (* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)
 let filtered_flags = [

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -47,7 +47,10 @@ let nested_virt = "nested-virt"
 (* The default value of device model should be set as
    'qemu-trad', 'qemu-upstream-compat', 'qemu-upstream' according to QEMU-upstream feature release stages *)
 let fallback_device_model_stage_1      = "qemu-trad"
-let default_device_model_default_value = "qemu-trad"
+let fallback_device_model_stage_2      = fallback_device_model_stage_1
+let fallback_device_model_stage_3      = "qemu-upstream-compat"
+let fallback_device_model_stage_4      = fallback_device_model_stage_3
+let default_device_model_default_value = fallback_device_model_stage_1
 
 (* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)
 let filtered_flags = [

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -55,6 +55,7 @@ let dundee = Datamodel.dundee_release_schema_major_vsn, Datamodel.dundee_release
 let ely = Datamodel.ely_release_schema_major_vsn, Datamodel.ely_release_schema_minor_vsn
 let falcon = Datamodel.falcon_release_schema_major_vsn, Datamodel.falcon_release_schema_minor_vsn
 let inverness = Datamodel.inverness_release_schema_major_vsn, Datamodel.inverness_release_schema_minor_vsn
+let jura = Datamodel.jura_release_schema_major_vsn, Datamodel.jura_release_schema_minor_vsn
 
 (* This is to support upgrade from Dundee tech-preview versions *)
 let vsn_with_meaningful_has_vendor_device = Datamodel.meaningful_vm_has_vendor_device_schema_major_vsn, Datamodel.meaningful_vm_has_vendor_device_schema_minor_vsn
@@ -508,7 +509,7 @@ let upgrade_vswitch_controller = {
 
 let default_vm_platform_device_model = {
   description = "Initialising unset VM.platform.device-model profiles";
-  version = (fun x -> x <= inverness);                             (* initialise only for upgrades from previous versions before jura *)
+  version = (fun x -> x < jura);                                     (* initialise only for upgrades from previous versions before jura *)
   fn = fun ~__context ->
     Db.VM.get_all ~__context
     |> List.iter (fun vm ->

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -506,6 +506,21 @@ let upgrade_vswitch_controller = {
         ignore (Xapi_sdn_controller.introduce ~__context ~protocol:`ssl ~address ~port:6632L)
 }
 
+let default_vm_platform_device_model = {
+  description = "Initialising unset VM.platform.device-model profiles";
+  version = (fun x -> x <= inverness);                             (* initialise only for upgrades from previous versions before jura *)
+  fn = fun ~__context ->
+    Db.VM.get_all ~__context
+    |> List.iter (fun vm ->
+         Db.VM.get_platform ~__context ~self:vm
+         |> Xapi_vm_helpers.ensure_device_model_profile_present ~__context
+            ~hVM_boot_policy:(Db.VM.get_HVM_boot_policy ~__context ~self:vm)
+            ~default_value:Vm_platform.fallback_device_model_stage_1 (* fallback device model profile from previous version before jura *)
+         |> fun value ->
+            Db.VM.set_platform ~__context ~self:vm ~value
+       )
+}
+
 let rules = [
   upgrade_alert_priority;
   update_mail_min_priority;
@@ -528,6 +543,7 @@ let rules = [
   remove_restricted_pbd_keys;
   upgrade_recommendations_for_gpu_passthru;
   upgrade_vswitch_controller;
+  default_vm_platform_device_model;
 ]
 
 (* Maybe upgrade most recent db *)

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -1010,7 +1010,7 @@ let with_vm_operation ~__context ~self ~doc ~op ?(strict=true) ?policy f =
          _ -> ())
 
 (* Device Model Profiles *)
-let ensure_device_model_profile_present ~__context ~hVM_boot_policy ?(default_value=Vm_platform.default_device_model_default_value) platform =
+let ensure_device_model_profile_present ~__context ~hVM_boot_policy ?(default_value=Vm_platform.fallback_device_model_default_value) platform =
   let is_hvm = hVM_boot_policy <> "" in
   let default = Vm_platform.(device_model, default_value) in
   if not is_hvm || List.mem_assoc Vm_platform.device_model platform then

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -1010,9 +1010,9 @@ let with_vm_operation ~__context ~self ~doc ~op ?(strict=true) ?policy f =
          _ -> ())
 
 (* Device Model Profiles *)
-let ensure_device_model_profile_present ~__context ~hVM_boot_policy platform =
+let ensure_device_model_profile_present ~__context ~hVM_boot_policy ?(default_value=Vm_platform.default_device_model_default_value) platform =
   let is_hvm = hVM_boot_policy <> "" in
-  let default = Vm_platform.(device_model, default_device_model_default_value) in
+  let default = Vm_platform.(device_model, default_value) in
   if not is_hvm || List.mem_assoc Vm_platform.device_model platform then
     platform
   else (* only add device-model to an HVM VM platform if it is not already there *)


### PR DESCRIPTION
If the `VM.platform["device-model"] field of a HVM VM is not set, then
it shall be initialised from the fallback device model profile when
a host is upgraded to a newer version of XenServer, using the Xapi 
database upgrade mechanism. During the upgrade, the database initialises 
this value using the fallback device model profile value for the 
XenServer version that the host is being upgraded from. 

Passed dev-tests in CP-24805.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>