### PR TITLE
Revert "Factor out all_vm_operations"

### DIFF
--- a/ocaml/xapi/test_vm_check_operation_error.ml
+++ b/ocaml/xapi/test_vm_check_operation_error.ml
@@ -1,4 +1,54 @@
 
+let all_vm_operations =
+  [ `assert_operation_valid
+  ; `awaiting_memory_live
+  ; `call_plugin
+  ; `changing_VCPUs
+  ; `changing_VCPUs_live
+  ; `changing_dynamic_range
+  ; `changing_memory_limits
+  ; `changing_memory_live
+  ; `changing_shadow_memory
+  ; `changing_shadow_memory_live
+  ; `changing_static_range
+  ; `checkpoint
+  ; `clean_reboot
+  ; `clean_shutdown
+  ; `clone
+  ; `copy
+  ; `create_template
+  ; `csvm
+  ; `data_source_op
+  ; `destroy
+  ; `export
+  ; `get_boot_record
+  ; `hard_reboot
+  ; `hard_shutdown
+  ; `import
+  ; `make_into_template
+  ; `metadata_export
+  ; `migrate_send
+  ; `pause
+  ; `pool_migrate
+  ; `power_state_reset
+  ; `provision
+  ; `query_services
+  ; `resume
+  ; `resume_on
+  ; `revert
+  ; `reverting
+  ; `send_sysrq
+  ; `send_trigger
+  ; `shutdown
+  ; `snapshot
+  ; `snapshot_with_quiesce
+  ; `start
+  ; `start_on
+  ; `suspend
+  ; `unpause
+  ; `update_allowed_operations
+  ]
+
 let with_test_vm f =
   let __context = Mock.make_context_with_new_db "Mock context" in
   let vm_ref = Test_common.make_vm ~__context () in
@@ -14,7 +64,7 @@ let test_null_vdi () =
       let () = ignore(Test_common.make_vbd ~__context ~vM:vm_ref ~_type:`CD ~mode:`RO ~empty:true ~vDI:Ref.null ()) in
       List.iter
         (fun op -> ignore(Xapi_vm_lifecycle.check_operation_error ~__context ~ref:vm_ref ~op ~strict:true))
-        Xapi_vm_lifecycle.all_vm_operations
+        all_vm_operations
     )
 
 (* Operations that check the validity of other VM operations should

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -23,56 +23,6 @@ open D
 
 module Rrdd = Rrd_client.Client
 
-let all_vm_operations =
-  [ `assert_operation_valid
-  ; `awaiting_memory_live
-  ; `call_plugin
-  ; `changing_VCPUs
-  ; `changing_VCPUs_live
-  ; `changing_dynamic_range
-  ; `changing_memory_limits
-  ; `changing_memory_live
-  ; `changing_shadow_memory
-  ; `changing_shadow_memory_live
-  ; `changing_static_range
-  ; `checkpoint
-  ; `clean_reboot
-  ; `clean_shutdown
-  ; `clone
-  ; `copy
-  ; `create_template
-  ; `csvm
-  ; `data_source_op
-  ; `destroy
-  ; `export
-  ; `get_boot_record
-  ; `hard_reboot
-  ; `hard_shutdown
-  ; `import
-  ; `make_into_template
-  ; `metadata_export
-  ; `migrate_send
-  ; `pause
-  ; `pool_migrate
-  ; `power_state_reset
-  ; `provision
-  ; `query_services
-  ; `resume
-  ; `resume_on
-  ; `revert
-  ; `reverting
-  ; `send_sysrq
-  ; `send_trigger
-  ; `shutdown
-  ; `snapshot
-  ; `snapshot_with_quiesce
-  ; `start
-  ; `start_on
-  ; `suspend
-  ; `unpause
-  ; `update_allowed_operations
-  ]
-
 let assoc_opt key assocs = Opt.of_exception (fun () -> List.assoc key assocs)
 let bool_of_assoc key assocs = match assoc_opt key assocs with
   | Some v -> v = "1" || String.lowercase v = "true"
@@ -563,7 +513,14 @@ let update_allowed_operations ~__context ~self =
     | None -> op :: accu
     | _    -> accu
   in
-  let allowed = List.fold_left check [] all_vm_operations in
+  let allowed =
+    List.fold_left check []
+      [`snapshot; `copy; `clone; `revert; `checkpoint; `snapshot_with_quiesce;
+       `start; `start_on; `pause; `unpause; `clean_shutdown; `clean_reboot;
+       `hard_shutdown; `hard_reboot; `suspend; `resume; `resume_on; `export; `destroy;
+       `provision; `changing_VCPUs_live; `pool_migrate; `migrate_send; `make_into_template; `changing_static_range;
+       `changing_shadow_memory; `changing_dynamic_range]
+  in
   (* FIXME: need to be able to deal with rolling-upgrade for orlando as well *)
   let allowed =
     if Helpers.rolling_upgrade_in_progress ~__context


### PR DESCRIPTION
Looping through more elemnts during VM.update_allowed_operations has a
performance impact. This commit restores the list of operations that we
check in VM.update_allowed_operations to the original set, which does
not include all VM operations.

This reverts commit 5497ab7b4569cd3422c0674295b92619294b8a09.