### PR TITLE
CA-267946: Avoid Db.is_valid_ref RPC call when Ref is NULL

### DIFF
--- a/ocaml/xapi/db.ml
+++ b/ocaml/xapi/db.ml
@@ -17,6 +17,8 @@
 
 include Db_actions.DB_Action
 let is_valid_ref __context r =
-  let t = Context.database_of __context in
-  let module DB = (val (Db_cache.get t) : Db_interface.DB_ACCESS) in
-  DB.is_valid_ref t (Ref.string_of r)
+  if r = Ref.null then false
+  else
+    let t = Context.database_of __context in
+    let module DB = (val (Db_cache.get t) : Db_interface.DB_ACCESS) in
+    DB.is_valid_ref t (Ref.string_of r)


### PR DESCRIPTION
e.g. in `update_allowed_operations` avoid repeated RPC calls that we know are
always going to return false when the field is not set.

Of course we'll still do the RPC call when it is not NULL to validate the ref.