### PR TITLE
CA-267946: Check operation db memoize

### DIFF
--- a/ocaml/database/db_cache.ml
+++ b/ocaml/database/db_cache.ml
@@ -46,3 +46,13 @@ let apply_delta_to_cache entry db_ref =
   | Redo_log.WriteField(tblname, objref, fldname, newval) ->
     debug "Redoing write_field %s (%s) [%s -> %s]" tblname objref fldname newval;
     DB.write_field db_ref tblname objref fldname newval
+
+(* local lazy caches of objects *)
+type 'a lzy = Got of 'a | ToGet of (unit -> 'a)
+
+let lzy_get a =
+  match !a with
+  | Got x -> x
+  | ToGet f -> let x = f () in a := Got x; x
+
+(* End of cache code *)

--- a/ocaml/xapi/db.ml
+++ b/ocaml/xapi/db.ml
@@ -40,7 +40,7 @@ module LazyMemo : sig
       i.e. this is a shorter syntax for [memo f !!v] *)
   val ($!) : ('a -> 'b) -> 'a t -> 'b t
 end = struct
-  type 'a t = 'a Records.lzy ref
+  type 'a t = 'a Db_cache.lzy ref
 
 (* Lazy.t is not thread-safe (it can raise Lazy.undefined), so use a ref instead.
    We only want to initiate the (potentially RPC) call when we know we are
@@ -49,11 +49,11 @@ end = struct
    same value multiple times, but in assert_valid you only need some values for
    the current operation.
 *)
-  let memo f v = ref (Records.ToGet (fun () -> f v))
+  let memo f v = ref (Db_cache.ToGet (fun () -> f v))
 
-  let memoU f = ref (Records.ToGet f)
+  let memoU f = ref (Db_cache.ToGet f)
 
-  let (!!) = Records.lzy_get
+  let (!!) = Db_cache.lzy_get
 
   let ($!) f v = memo f !!v
 end

--- a/ocaml/xapi/db.ml
+++ b/ocaml/xapi/db.ml
@@ -20,3 +20,40 @@ let is_valid_ref __context r =
   let t = Context.database_of __context in
   let module DB = (val (Db_cache.get t) : Db_interface.DB_ACCESS) in
   DB.is_valid_ref t (Ref.string_of r)
+
+module LazyMemo : sig
+  type 'a t
+
+  (** [memo f v] constructs an ['a LazyMemo.t] lazy value for [f v] that is only evaluated the first time it is used.
+  *)
+  val memo : ('a -> 'b) -> 'a -> 'b t
+
+  (** [memoU f] constructs an ['a LazyMemo.t] equivalent to [memo f ()] *)
+  val memoU : (unit -> 'a) -> 'a t
+
+  (** [!! v] forces the evaluation of the lazy value [v].
+      If the evaluation succeeds the result is memoized and [f v] is not called again for the liftime of [v].
+  *)
+  val (!!) : 'a t -> 'a
+
+  (** [f $ v] constructs a new lazy value that will call [f !!v] when evaluated,
+      i.e. this is a shorter syntax for [memo f !!v] *)
+  val ($!) : ('a -> 'b) -> 'a t -> 'b t
+end = struct
+  type 'a t = 'a Records.lzy ref
+
+(* Lazy.t is not thread-safe (it can raise Lazy.undefined), so use a ref instead.
+   We only want to initiate the (potentially RPC) call when we know we are
+   going to need the result, and then memoize it for the lifetime of this value.
+   Useful for example in update_allowed_operations where sometimes you need the
+   same value multiple times, but in assert_valid you only need some values for
+   the current operation.
+*)
+  let memo f v = ref (Records.ToGet (fun () -> f v))
+
+  let memoU f = ref (Records.ToGet f)
+
+  let (!!) = Records.lzy_get
+
+  let ($!) f v = memo f !!v
+end

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -75,16 +75,6 @@ let safe_i64_of_string field str =
 let safe_bool_of_string field str =
   try bool_of_string str with _ -> raise (Record_util.Record_failure ("Failed to parse parameter '"^field^"': expecting a boolean (true or false)"))
 
-(* local lazy caches of objects *)
-type 'a lzy = Got of 'a | ToGet of (unit -> 'a)
-
-let lzy_get a =
-  match !a with
-  | Got x -> x
-  | ToGet f -> let x = f () in a := Got x; x
-
-(* End of cache code *)
-
 exception CLI_failed_to_find_param of string
 let field_lookup recs name = match List.filter (fun x -> x.name = name) recs with
   | [ x ] -> x

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -367,7 +367,7 @@ let maybe_get_guest_metrics ~__context ~ref =
     corresponding to the first error found. Checking stops at the first error.
     The "strict" param sets whether we require feature-flags for ops that need guest
     support: ops in the suspend-like and shutdown-like categories. *)
-let check_operation_error ~__context ~ref ~op ~strict =
+let check_operation_error ~__context ~ref =
   let vmr = Db.VM.get_record_internal ~__context ~self:ref in
   let vmgmr = maybe_get_guest_metrics ~__context ~ref:(vmr.Db_actions.vM_guest_metrics) in
   let ref_str = Ref.string_of ref in
@@ -376,176 +376,177 @@ let check_operation_error ~__context ~ref ~op ~strict =
   let is_snapshot = vmr.Db_actions.vM_is_a_snapshot in
   let vdis = List.filter_map (fun vbd -> try Some (Db.VBD.get_VDI ~__context ~self:vbd) with _ -> None) vmr.Db_actions.vM_VBDs |> List.filter (Db.is_valid_ref __context) in
 
-  (* Check if the operation has been explicitly blocked by the/a user *)
-  let current_error = None in
+  (fun ~op ~strict ->
 
-  let check c f = match c with | Some e -> Some e | None -> f () in
+     (* Check if the operation has been explicitly blocked by the/a user *)
+     let current_error = None in
 
-  let current_error = check current_error (fun () ->
-      Opt.map (fun v -> Api_errors.operation_blocked, [ref_str; v])
-        (assoc_opt op vmr.Db_actions.vM_blocked_operations)) in
+     let check c f = match c with | Some e -> Some e | None -> f () in
 
-  (* Always check the power state constraint of the operation first *)
-  let current_error = check current_error (fun () ->
-      if not (is_allowed_sequentially ~__context ~vmr ~power_state ~op)
-      then report_power_state_error ~__context ~vmr ~power_state ~op ~ref_str
-      else None) in
+     let current_error = check current_error (fun () ->
+         Opt.map (fun v -> Api_errors.operation_blocked, [ref_str; v])
+           (assoc_opt op vmr.Db_actions.vM_blocked_operations)) in
 
-  (* if other operations are in progress, check that the new operation is allowed concurrently with them. *)
-  let current_error = check current_error (fun () ->
-      let current_ops = vmr.Db_actions.vM_current_operations in
-      if List.length current_ops <> 0 && not (is_allowed_concurrently ~op ~current_ops)
-      then report_concurrent_operations_error ~current_ops ~ref_str
-      else None) in
+     (* Always check the power state constraint of the operation first *)
+     let current_error = check current_error (fun () ->
+         if not (is_allowed_sequentially ~__context ~vmr ~power_state ~op)
+         then report_power_state_error ~__context ~vmr ~power_state ~op ~ref_str
+         else None) in
 
-  (* if the VM is a template, check the template behavior exceptions. *)
-  let current_error = check current_error (fun () ->
-      if is_template && not is_snapshot
-      then check_template ~vmr ~op ~ref_str
-      else None) in
+     (* if other operations are in progress, check that the new operation is allowed concurrently with them. *)
+     let current_error = check current_error (fun () ->
+         let current_ops = vmr.Db_actions.vM_current_operations in
+         if List.length current_ops <> 0 && not (is_allowed_concurrently ~op ~current_ops)
+         then report_concurrent_operations_error ~current_ops ~ref_str
+         else None) in
 
-  (* if the VM is a snapshot, check the snapshot behavior exceptions. *)
-  let current_error = check current_error (fun () ->
-      if is_snapshot
-      then check_snapshot ~vmr ~op ~ref_str
-      else None) in
+     (* if the VM is a template, check the template behavior exceptions. *)
+     let current_error = check current_error (fun () ->
+         if is_template && not is_snapshot
+         then check_template ~vmr ~op ~ref_str
+         else None) in
 
-  (* if the VM is neither a template nor a snapshot, do not allow provision and revert. *)
-  let current_error = check current_error (fun () ->
-      if op = `provision && (not is_template)
-      then Some (Api_errors.only_provision_template, [])
-      else None) in
+     (* if the VM is a snapshot, check the snapshot behavior exceptions. *)
+     let current_error = check current_error (fun () ->
+         if is_snapshot
+         then check_snapshot ~vmr ~op ~ref_str
+         else None) in
 
-  let current_error = check current_error (fun () ->
-      if op = `revert && (not is_snapshot)
-      then Some (Api_errors.only_revert_snapshot, [])
-      else None) in
+     (* if the VM is neither a template nor a snapshot, do not allow provision and revert. *)
+     let current_error = check current_error (fun () ->
+         if op = `provision && (not is_template)
+         then Some (Api_errors.only_provision_template, [])
+         else None) in
 
-  (* Some ops must be blocked if VM is not mobile *)
-  let current_error = check current_error (fun () ->
-      match op with
-      | `suspend
-      | `checkpoint
-      | `pool_migrate
-      | `migrate_send
-        when not (is_mobile ~__context ref strict) ->
-        Some (Api_errors.vm_is_immobile, [ref_str])
-      | _ -> None
-    ) in
+     let current_error = check current_error (fun () ->
+         if op = `revert && (not is_snapshot)
+         then Some (Api_errors.only_revert_snapshot, [])
+         else None) in
 
-  let current_error =
-    let metrics = Db.VM.get_metrics ~__context ~self:ref in
-    check current_error (fun () ->
-      match op with
-      | `changing_dynamic_range
-        when nested_virt ~__context ref metrics && strict ->
-        Some (Api_errors.vm_is_using_nested_virt, [ref_str])
-      | _ -> None
-    ) in
+     (* Some ops must be blocked if VM is not mobile *)
+     let current_error = check current_error (fun () ->
+         match op with
+         | `suspend
+         | `checkpoint
+         | `pool_migrate
+         | `migrate_send
+           when not (is_mobile ~__context ref strict) ->
+           Some (Api_errors.vm_is_immobile, [ref_str])
+         | _ -> None
+       ) in
+
+     let current_error =
+       let metrics = Db.VM.get_metrics ~__context ~self:ref in
+       check current_error (fun () ->
+           match op with
+           | `changing_dynamic_range
+             when nested_virt ~__context ref metrics && strict ->
+             Some (Api_errors.vm_is_using_nested_virt, [ref_str])
+           | _ -> None
+         ) in
 
 
-  (* Check if the VM is a control domain (eg domain 0).            *)
-  (* FIXME: Instead of special-casing for the control domain here, *)
-  (* make use of the Helpers.ballooning_enabled_for_vm function.   *)
-  let current_error = check current_error (fun () ->
-      let vm_ref = Db.VM.get_by_uuid ~__context ~uuid:vmr.Db_actions.vM_uuid in
-      if Helpers.is_domain_zero ~__context vm_ref
-      && (op = `changing_VCPUs
-          || op = `destroy)
-      then Some (Api_errors.operation_not_allowed, ["This operation is not allowed on dom0"])
-      else if vmr.Db_actions.vM_is_control_domain
-           && op <> `data_source_op
-           && op <> `changing_memory_live
-           && op <> `awaiting_memory_live
-           && op <> `metadata_export
-           && op <> `changing_dynamic_range
-           && op <> `changing_memory_limits
-           && op <> `changing_static_range
-           && op <> `start
-           && op <> `start_on
-           && op <> `changing_VCPUs
-           && op <> `destroy
-      then Some (Api_errors.operation_not_allowed, ["This operation is not allowed on a control domain"])
-      else None) in
+     (* Check if the VM is a control domain (eg domain 0).            *)
+     (* FIXME: Instead of special-casing for the control domain here, *)
+     (* make use of the Helpers.ballooning_enabled_for_vm function.   *)
+     let current_error = check current_error (fun () ->
+         let vm_ref () = Db.VM.get_by_uuid ~__context ~uuid:vmr.Db_actions.vM_uuid in
+         if (op = `changing_VCPUs || op = `destroy) && Helpers.is_domain_zero ~__context (vm_ref ())
+         then Some (Api_errors.operation_not_allowed, ["This operation is not allowed on dom0"])
+         else if vmr.Db_actions.vM_is_control_domain
+              && op <> `data_source_op
+              && op <> `changing_memory_live
+              && op <> `awaiting_memory_live
+              && op <> `metadata_export
+              && op <> `changing_dynamic_range
+              && op <> `changing_memory_limits
+              && op <> `changing_static_range
+              && op <> `start
+              && op <> `start_on
+              && op <> `changing_VCPUs
+              && op <> `destroy
+         then Some (Api_errors.operation_not_allowed, ["This operation is not allowed on a control domain"])
+         else None) in
 
-  (* check for any HVM guest feature needed by the op *)
-  let current_error = check current_error (fun () ->
-      check_op_for_feature ~__context ~vmr ~vmgmr ~power_state ~op ~ref ~strict
-    ) in
+     (* check for any HVM guest feature needed by the op *)
+     let current_error = check current_error (fun () ->
+         check_op_for_feature ~__context ~vmr ~vmgmr ~power_state ~op ~ref ~strict
+       ) in
 
-  (* check if the dynamic changeable operations are still valid *)
-  let current_error = check current_error (fun () ->
-      if op = `snapshot_with_quiesce &&
-         (Pervasiveext.maybe_with_default true
-            (fun gm -> let other = gm.Db_actions.vM_guest_metrics_other in
-              not (List.mem_assoc "feature-quiesce" other || List.mem_assoc "feature-snapshot" other))
-            vmgmr)
-      then Some (Api_errors.vm_snapshot_with_quiesce_not_supported, [ ref_str ])
-      else None) in
+     (* check if the dynamic changeable operations are still valid *)
+     let current_error = check current_error (fun () ->
+         if op = `snapshot_with_quiesce &&
+            (Pervasiveext.maybe_with_default true
+               (fun gm -> let other = gm.Db_actions.vM_guest_metrics_other in
+                 not (List.mem_assoc "feature-quiesce" other || List.mem_assoc "feature-snapshot" other))
+               vmgmr)
+         then Some (Api_errors.vm_snapshot_with_quiesce_not_supported, [ ref_str ])
+         else None) in
 
-  (* Check for an error due to VDI caching/reset behaviour *)
-  let current_error = check current_error (fun () ->
-      let vdis_reset_and_caching = List.filter_map (fun vdi ->
-          try
-            let sm_config = Db.VDI.get_sm_config ~__context ~self:vdi in
-            Some ((assoc_opt "on_boot" sm_config = Some "reset"), (bool_of_assoc "caching" sm_config))
-          with _ -> None) vdis in
-      if op = `checkpoint || op = `snapshot || op = `suspend || op = `snapshot_with_quiesce
-      then (* If any vdi exists with on_boot=reset, then disallow checkpoint, snapshot, suspend *)
-        if List.exists fst vdis_reset_and_caching
-        then Some (Api_errors.vdi_on_boot_mode_incompatible_with_operation,[])
-        else None
-      else if op = `pool_migrate then
-        (* If any vdi exists with on_boot=reset and caching is enabled, disallow migrate *)
-        if List.exists (fun (reset,caching) -> reset && caching) vdis_reset_and_caching
-        then Some (Api_errors.vdi_on_boot_mode_incompatible_with_operation,[])
-        else None
-      else None) in
+     (* Check for an error due to VDI caching/reset behaviour *)
+     let current_error = check current_error (fun () ->
+         let vdis_reset_and_caching = List.filter_map (fun vdi ->
+             try
+               let sm_config = Db.VDI.get_sm_config ~__context ~self:vdi in
+               Some ((assoc_opt "on_boot" sm_config = Some "reset"), (bool_of_assoc "caching" sm_config))
+             with _ -> None) vdis in
+         if op = `checkpoint || op = `snapshot || op = `suspend || op = `snapshot_with_quiesce
+         then (* If any vdi exists with on_boot=reset, then disallow checkpoint, snapshot, suspend *)
+           if List.exists fst vdis_reset_and_caching
+           then Some (Api_errors.vdi_on_boot_mode_incompatible_with_operation,[])
+           else None
+         else if op = `pool_migrate then
+           (* If any vdi exists with on_boot=reset and caching is enabled, disallow migrate *)
+           if List.exists (fun (reset,caching) -> reset && caching) vdis_reset_and_caching
+           then Some (Api_errors.vdi_on_boot_mode_incompatible_with_operation,[])
+           else None
+         else None) in
 
-  (* If a PCI device is passed-through, check if the operation is allowed *)
-  let current_error = check current_error (fun () ->
-      if vmr.Db_actions.vM_attached_PCIs <> []
-      then check_pci ~op ~ref_str
-      else None) in
+     (* If a PCI device is passed-through, check if the operation is allowed *)
+     let current_error = check current_error (fun () ->
+         if vmr.Db_actions.vM_attached_PCIs <> []
+         then check_pci ~op ~ref_str
+         else None) in
 
-  (* The VM has a VGPU, check if the operation is allowed*)
-  let current_error = check current_error (fun () ->
-      if vmr.Db_actions.vM_VGPUs <> []
-      then check_vgpu ~__context ~op ~ref_str ~vgpus:vmr.Db_actions.vM_VGPUs
-      else None) in
+     (* The VM has a VGPU, check if the operation is allowed*)
+     let current_error = check current_error (fun () ->
+         if vmr.Db_actions.vM_VGPUs <> []
+         then check_vgpu ~__context ~op ~ref_str ~vgpus:vmr.Db_actions.vM_VGPUs
+         else None) in
 
-  (* Check for errors caused by VM being in an appliance. *)
-  let current_error = check current_error (fun () ->
-      if Db.is_valid_ref __context vmr.Db_actions.vM_appliance
-      then check_appliance ~vmr ~op ~ref_str
-      else None) in
+     (* Check for errors caused by VM being in an appliance. *)
+     let current_error = check current_error (fun () ->
+         if Db.is_valid_ref __context vmr.Db_actions.vM_appliance
+         then check_appliance ~vmr ~op ~ref_str
+         else None) in
 
-  (* Check for errors caused by VM being assigned to a protection policy. *)
-  let current_error = check current_error (fun () ->
-      if Db.is_valid_ref __context vmr.Db_actions.vM_protection_policy
-      then check_protection_policy ~vmr ~op ~ref_str
-      else None) in
+     (* Check for errors caused by VM being assigned to a protection policy. *)
+     let current_error = check current_error (fun () ->
+         if Db.is_valid_ref __context vmr.Db_actions.vM_protection_policy
+         then check_protection_policy ~vmr ~op ~ref_str
+         else None) in
 
-  (* Check for errors caused by VM being assigned to a snapshot schedule. *)
-  let current_error = check current_error (fun () ->
-      if Db.is_valid_ref __context vmr.Db_actions.vM_snapshot_schedule
-      then check_snapshot_schedule ~vmr ~ref_str op
-      else None) in
+     (* Check for errors caused by VM being assigned to a snapshot schedule. *)
+     let current_error = check current_error (fun () ->
+         if Db.is_valid_ref __context vmr.Db_actions.vM_snapshot_schedule
+         then check_snapshot_schedule ~vmr ~ref_str op
+         else None) in
 
-  (* Check whether this VM needs to be a system domain. *)
-  let current_error = check current_error (fun () ->
-      if op = `query_services && not (bool_of_assoc "is_system_domain" vmr.Db_actions.vM_other_config)
-      then Some (Api_errors.not_system_domain, [ ref_str ])
-      else None) in
+     (* Check whether this VM needs to be a system domain. *)
+     let current_error = check current_error (fun () ->
+         if op = `query_services && not (bool_of_assoc "is_system_domain" vmr.Db_actions.vM_other_config)
+         then Some (Api_errors.not_system_domain, [ ref_str ])
+         else None) in
 
-  let current_error = check current_error (fun () ->
-    if Helpers.rolling_upgrade_in_progress ~__context &&
-       not (List.mem op Xapi_globs.rpu_allowed_vm_operations)
-    then Some (Api_errors.not_supported_during_upgrade, [])
-    else None)
-  in
+     let current_error = check current_error (fun () ->
+         if Helpers.rolling_upgrade_in_progress ~__context &&
+            not (List.mem op Xapi_globs.rpu_allowed_vm_operations)
+         then Some (Api_errors.not_supported_during_upgrade, [])
+         else None)
+     in
 
-  current_error
+     current_error
+  )
 
 let get_operation_error ~__context ~self ~op ~strict =
   check_operation_error ~__context ~ref:self ~op ~strict
@@ -556,8 +557,9 @@ let assert_operation_valid ~__context ~self ~op ~strict =
   | Some (a,b) -> raise (Api_errors.Server_error (a,b))
 
 let update_allowed_operations ~__context ~self =
+  let check_operation_error = check_operation_error ~__context ~ref:self in
   let check accu op =
-    match check_operation_error ~__context ~ref:self ~op ~strict:true with
+    match check_operation_error ~op ~strict:true with
     | None -> op :: accu
     | _    -> accu
   in

--- a/ocaml/xapi/xapi_vm_memory_constraints.ml
+++ b/ocaml/xapi/xapi_vm_memory_constraints.ml
@@ -52,8 +52,9 @@ module Vm_memory_constraints : T = struct
   include Vm_memory_constraints.Vm_memory_constraints
 
   let nested_virt ~__context vm =
-    let metrics = Db.VM.get_metrics ~__context ~self:vm in
-    Xapi_vm_lifecycle.nested_virt ~__context vm metrics
+    let metrics = Db.LazyMemo.memoU (fun () -> Db.VM.get_metrics ~__context ~self:vm) in
+    let platformdata = Db.LazyMemo.memoU (fun () -> Db.VM.get_platform ~__context ~self:vm) in
+    Xapi_vm_lifecycle.nested_virt ~__context metrics platformdata
 
   let order_constraint =
     "Memory limits must satisfy: \


### PR DESCRIPTION
This improves upon https://github.com/xapi-project/xen-api/pull/3276 by storing the results of expensive Db RPC calls, and by only making them when necessary. 

(it implements the lazy operation in a safe way, `Lazy.t` is documented to be not thread-safe, and can raise `Lazy.Undefined` if used from 2 threads. although in update_allowed_operations we only ever use it from one thread, I didn't want to set a bad precedent of using thread-unsafe functions in threaded code).

On a 2 host pool this improves VM.clone from ~0.7s to ~0.5s, performance test pending for a 4 host pool.
Opened the PR to discuss the general approach.
