### PR TITLE
CP-22019: Test VDI.data_destroy

### DIFF
--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -66,7 +66,7 @@ let vdi_data_destroy_test ~session_id ~vDI =
   let test = make_test "Testing VDI.{enable/disable_cbt, data_destroy, snapshot}" 4 in
   try
     start test;
-    let debug_test msg = debug test msg in
+    let debug_test = debug test in
     debug_test "Enabling CBT on original VDI";
     VDI.enable_cbt ~session_id ~rpc:!rpc ~self:vDI;
     test_assert ~test


### PR DESCRIPTION
Test that VDI.data_destroy:
- updates VDI.type to cbt_metadata
- updates content_id to: "/No content: this is a cbt_metadata VDI/"