### PR TITLE
CA-268761: Trailing whitespaces are lost by the xapi database

### DIFF
--- a/ocaml/database/xml_spaces.ml
+++ b/ocaml/database/xml_spaces.ml
@@ -66,7 +66,7 @@ let map2_unlikely f s =
     s
 
 let protect_fn = function
-  |  ' ', Some ' ' -> Replace (protect_char, '_' )
+  |  ' ',       _  -> Expand  (protect_char, '.' )
   | '\t',       _  -> Expand  (protect_char, 't' )
   | '\n',       _  -> Expand  (protect_char, 'n' )
   | '\r',       _  -> Expand  (protect_char, 'r' )
@@ -75,7 +75,9 @@ let protect_fn = function
   |   _ ,       _  -> No_change
 
 let unprotect_fn = function
+  (* CA-268761: this is only for backward compatibility *)
   | c, Some '_' when c=protect_char -> Replace (' ', ' ')
+  | c, Some '.' when c=protect_char -> Compress ' '
   | c, Some 't' when c=protect_char -> Compress '\t'
   | c, Some 'n' when c=protect_char -> Compress '\n'
   | c, Some 'r' when c=protect_char -> Compress '\r'


### PR DESCRIPTION
This is an issue in how xapi serialises the fields in the database xml dump.
Xapi creates row tags that have all the fields set as attributes and
by spec spaces in attrributes are stripped and normalised.
Currently xapi uses an internal encoding/decoding that escapse the
character that would otherwise be stripped, with the possible
exception of one space at the beginnin of the content and one
at the end.

This PR changes this escape mechanism by escaping all white spaces
singularly instead of in pairs. The unescape mechanism is
kept backward compatible.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>