### PR TITLE
CA-269367: Fix missing row PUSB while updating VUSB

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1957,6 +1957,7 @@ let update_vusb ~__context (id: (string * string)) =
           let pusb, pusb_r =
             Db.VM.get_VUSBs ~__context ~self:vm
             |> List.map (fun vusb -> Db.VUSB.get_attached ~__context ~self:vusb)
+            |> List.filter (fun attached -> Db.is_valid_ref __context attached)
             |> List.map (fun self -> self, Db.PUSB.get_record ~__context ~self)
             |> List.find (fun (_, pusbr) -> "vusb" ^ pusbr.API.pUSB_path= (snd id))
           in


### PR DESCRIPTION
This PR is to fix the error log that when updating VUSB  in update_vusb funciton, which throw missing row PUSB.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>