### PR TITLE
Should not check usb-passthrough licence when xapi starting

### DIFF
--- a/ocaml/xapi/xapi_pusb.ml
+++ b/ocaml/xapi/xapi_pusb.ml
@@ -76,7 +76,6 @@ let start_thread f =
 
 let scan ~__context ~host =
   (* notify that scan is required. *)
-  Pool_features.assert_enabled ~__context ~f:Features.USB_passthrough;
   Mutex.execute mutex (fun () ->
       scan_required := true;
       Condition.broadcast cond


### PR DESCRIPTION
Signed-off-by: Yang Qian <yang.qian@citrix.com>