### PR TITLE
 CA-269366: VDI.get_nbd_info: fix returned IPv6 addresses

### DIFF
--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -173,13 +173,13 @@ let test_get_nbd_info =
           vdi_nbd_server_info_subject = "host2"
         };
         { vdi_nbd_server_info_exportname = "/" ^ uuid ^ "?session_id=" ^ session_id;
-          vdi_nbd_server_info_address = "[10e1:bdb8:05a3:0002:03ae:8a24:0371:0002]";
+          vdi_nbd_server_info_address = "10e1:bdb8:05a3:0002:03ae:8a24:0371:0002";
           vdi_nbd_server_info_port;
           vdi_nbd_server_info_cert = "host2_cert";
           vdi_nbd_server_info_subject = "host2"
         };
         { vdi_nbd_server_info_exportname = "/" ^ uuid ^ "?session_id=" ^ session_id;
-          vdi_nbd_server_info_address = "[10e1:bdb8:05a3:0002:03ae:8a24:0371:0003]";
+          vdi_nbd_server_info_address = "10e1:bdb8:05a3:0002:03ae:8a24:0371:0003";
           vdi_nbd_server_info_port;
           vdi_nbd_server_info_cert = "host2_cert";
           vdi_nbd_server_info_subject = "host2"

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -1047,7 +1047,7 @@ let _get_nbd_info ~__context ~self ~get_server_certificate =
   let get_ips host =
     let get_ips pif =
       let not_empty = (<>) "" in
-      let v6_ips = Db.PIF.get_IPv6 ~__context ~self:pif |> List.filter not_empty |> List.map (fun s -> "[" ^ s ^ "]") in
+      let v6_ips = Db.PIF.get_IPv6 ~__context ~self:pif |> List.filter not_empty in
       let v4_ip = Db.PIF.get_IP ~__context ~self:pif in
       if not_empty v4_ip then v4_ip :: v6_ips else v6_ips
     in


### PR DESCRIPTION
IPv6 addresses should only be surrounded by square brackets when they are part of a URL.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>