### PR TITLE
CP-25141 SCTX-2619 fix sync from xenopsd in on_xapi_restart

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2021,19 +2021,24 @@ let on_xapi_restart ~__context =
   (* Sync VM state in Xapi for VMs running by local Xenopsds *)
   List.iter (fun ((id, state), queue_name) ->
       let vm = vm_of_id ~__context id in
+      let reset_vm_to vm powerstate =
+        Xapi_vm_lifecycle.force_state_reset ~__context
+          ~self:vm ~value:powerstate;
+        info "Reset power state of VM %s to %s (%s)"
+          id (Record_util.power_to_string powerstate) __LOC__ in
       let xapi_power_state =
         xenapi_of_xenops_power_state (Some state.Vm.power_state) in
-      Xapi_vm_lifecycle.force_state_reset ~__context ~self:vm ~value:xapi_power_state;
       match xapi_power_state with
       | `Running | `Paused ->
+        reset_vm_to vm xapi_power_state;
         Db.VM.set_resident_on ~__context ~self:vm ~value:localhost;
         add_caches id;
         refresh_vm ~__context ~self:vm;
       | `Suspended | `Halted ->
         let module Client = (val make_client queue_name : XENOPS) in
         Client.VM.remove dbg id;
-        if List.exists (fun (id', _) -> id' = id) resident_vms_in_db
-        then Db.VM.set_resident_on ~__context ~self:vm ~value:Ref.null;
+        if List.exists (fun (id', _) -> id' = id) resident_vms_in_db then
+          reset_vm_to vm xapi_power_state;
     ) xenopsd_vms_in_xapi;
 
   (* Sync VM state in Xapi for VMs not running on this host *)


### PR DESCRIPTION
When xapi starts, it queries xenopsd about the state of local VMs. In
SCTX-2619 we found that xenopsd passed data about a VM that was *not*
resident locally but was left over from a previous failed migration to
local host. This data was erroneously used to reset the power state of
that non-local VM. This commit fixes this.

If xenopsd reports the VM as running, it must indeed be resident on the
local host - so we reset the state of the VM to what xenopsd is
reporting.

If xenopsd reports the VM as suspended or halted, we only reset the
state of the VM if xapi believes the VM is resident on localhost.
Previously it would reset the state regardless - which caused the error.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>

CP-25141 log when VM's powerstate is reset

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>