### PR TITLE
CA-269137: get_nbd_info: get subject from TLS cert

### DIFF
--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -289,3 +289,8 @@ let get_server_certificate () =
     warn "Exception reading server certificate: %s"
       (ExnHelper.string_of_exn e);
     raise_library_corrupt()
+
+let hostnames_of_pem_cert pem =
+  Cstruct.of_string pem |>
+  X509.Encoding.Pem.Certificate.of_pem_cstruct1 |>
+  X509.hostnames

--- a/ocaml/xapi/jbuild
+++ b/ocaml/xapi/jbuild
@@ -66,7 +66,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (package xapi)
   (flags (:standard -bin-annot %s -warn-error +a-3-4-6-9-27-28-29-52))
   (libraries (
-   x509
    oPasswd
    pam
    pciutil
@@ -79,6 +78,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    tar
    tar.unix
    tapctl
+   x509
    xapi_version
    xapi-types
    xapi-client

--- a/ocaml/xapi/jbuild
+++ b/ocaml/xapi/jbuild
@@ -66,6 +66,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (package xapi)
   (flags (:standard -bin-annot %s -warn-error +a-3-4-6-9-27-28-29-52))
   (libraries (
+   x509
    oPasswd
    pam
    pciutil

--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -141,9 +141,40 @@ let test_get_nbd_info =
     (* NBD is not allowed on network_3 *)
     let _: _ API.Ref.t = make_host sr_of_vdi [(network_3, "92.40.98.98", ["10e1:bdb8:05a3:0002:03ae:8a24:0371:0006";"10e1:bdb8:05a3:0002:03ae:8a24:0371:0007"], true)] () in
 
+    let host1_cert = "-----BEGIN CERTIFICATE-----
+MIIBwTCCASqgAwIBAgIJAKl3gkjAjMdWMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV
+BAMTB0hvc3RPbmUwHhcNMTcxMDIwMTU0NzE1WhcNMjcxMDE4MTU0NzE1WjASMRAw
+DgYDVQQDEwdIb3N0T25lMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHL9+o
+102DHs2ZSYFlKeg8sCsKNPr3x2UziG6fvyE6FWtZR0scToxXU8SaAdrDE0floLsy
+TaF+aX1yUfFTA/SqeQ6E78rCRwf30IVJ8gE75oDzjqB0k7jm4lLFJARhiio0WIFy
+/AKitLBZ8o9gD54EtZ7IuhXonMUDZrCBQ8cSOQIDAQABox8wHTAbBgNVHREEFDAS
+ghBob3N0MS5kb21haW4udGxkMA0GCSqGSIb3DQEBCwUAA4GBAAwsd/Sn9jXM4+G+
+qPfHEt6aRLrVbEV5jepgSuatrnCV+duykXjPMMhp3e8+5Q1rbYC/f43UHaFp7QlD
+9d3e/mjzWhfgyBiNjE1Cbd06ZAHKsV1SaU6Y+TVMEOWg0HMishBt80w1dTrQeBOF
+UPwgCGaWtsuDCBHHwHFij3Blm2fd
+-----END CERTIFICATE-----
+"
+    in
+    let host2_cert = "-----BEGIN CERTIFICATE-----
+MIIBwTCCASqgAwIBAgIJAIhSYyKmHX1lMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV
+BAMTB0hvc3RUd28wHhcNMTcxMDIwMTU0NzM4WhcNMjcxMDE4MTU0NzM4WjASMRAw
+DgYDVQQDEwdIb3N0VHdvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCv4Rji
+4mj33QJblsaiQAMVhszuYNg40iI45CaJ9A8VWUw8daqLPEzJZzc6kQemGjaUtLZb
+eYX3vVYMyONjRXstPoiTdTWS1slOV/eQnbJ4N9Lt28aDFvtxBKLByavPK6Km2QdV
+7E1LeZBdYakvABI3QOO38vQ+VVbewSqQlHiemwIDAQABox8wHTAbBgNVHREEFDAS
+ghBob3N0Mi5kb21haW4udGxkMA0GCSqGSIb3DQEBCwUAA4GBAEMsmwc2vioVG7Qf
+vBPXurSr1RittWb0OjzCwevx0fpTjNGFTBTbZJaVrtscPyaI/MZhcRCRJ125E87Q
+Dk813cqiwTs4L2600lHqh3pTUL9X59jwmPqGdgelpQ8hY7uIeAocAiuWVGD42ZZA
+mffVFwXJ7B8kLP5BeRyBi6nwLhjd
+-----END CERTIFICATE-----
+"
+    in
+    let host1_subject = "host1.domain.tld" in
+    let host2_subject = "host2.domain.tld" in
+
     let get_server_certificate ~host =
-      if host = host1 then "host1_cert"
-      else if host = host2 then "host2_cert"
+      if host = host1 then host1_cert
+      else if host = host2 then host2_cert
       else failwith (Printf.sprintf "unexpected host: %s" (Ref.string_of host))
     in
 
@@ -157,32 +188,32 @@ let test_get_nbd_info =
         { vdi_nbd_server_info_exportname;
           vdi_nbd_server_info_address = "92.40.98.91";
           vdi_nbd_server_info_port;
-          vdi_nbd_server_info_cert = "host1_cert";
-          vdi_nbd_server_info_subject = "host1"
+          vdi_nbd_server_info_cert = host1_cert;
+          vdi_nbd_server_info_subject = host1_subject
         };
         { vdi_nbd_server_info_exportname = "/" ^ uuid ^ "?session_id=" ^ session_id;
           vdi_nbd_server_info_address = "92.40.98.92";
           vdi_nbd_server_info_port;
-          vdi_nbd_server_info_cert = "host1_cert";
-          vdi_nbd_server_info_subject = "host1"
+          vdi_nbd_server_info_cert = host1_cert;
+          vdi_nbd_server_info_subject = host1_subject
         };
         { vdi_nbd_server_info_exportname = "/" ^ uuid ^ "?session_id=" ^ session_id;
           vdi_nbd_server_info_address = "92.40.98.94";
           vdi_nbd_server_info_port;
-          vdi_nbd_server_info_cert = "host2_cert";
-          vdi_nbd_server_info_subject = "host2"
+          vdi_nbd_server_info_cert = host2_cert;
+          vdi_nbd_server_info_subject = host2_subject
         };
         { vdi_nbd_server_info_exportname = "/" ^ uuid ^ "?session_id=" ^ session_id;
           vdi_nbd_server_info_address = "[10e1:bdb8:05a3:0002:03ae:8a24:0371:0002]";
           vdi_nbd_server_info_port;
-          vdi_nbd_server_info_cert = "host2_cert";
-          vdi_nbd_server_info_subject = "host2"
+          vdi_nbd_server_info_cert = host2_cert;
+          vdi_nbd_server_info_subject = host2_subject
         };
         { vdi_nbd_server_info_exportname = "/" ^ uuid ^ "?session_id=" ^ session_id;
           vdi_nbd_server_info_address = "[10e1:bdb8:05a3:0002:03ae:8a24:0371:0003]";
           vdi_nbd_server_info_port;
-          vdi_nbd_server_info_cert = "host2_cert";
-          vdi_nbd_server_info_subject = "host2"
+          vdi_nbd_server_info_cert = host2_cert;
+          vdi_nbd_server_info_subject = host2_subject
         };
       ]
     in

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -1072,8 +1072,13 @@ let _get_nbd_info ~__context ~self ~get_server_certificate =
     if ips = [] then [] else
     let cert = get_server_certificate ~host in
     let port = 10809L in
-    (* Stopgap measure: use hostname instead of reading a subject out of the cert. *)
-    let subject = Db.Host.get_hostname ~__context ~self:host in
+    let subject = match Certificates.hostnames_of_pem_cert cert with
+      | [] -> (
+          error "Found no subject DNS names in this hosts's certificate. Returning empty string as subject.";
+          ""
+        )
+      | name :: _ -> name
+    in
     let template = API.{
       vdi_nbd_server_info_exportname = exportname;
       vdi_nbd_server_info_address = "";

--- a/xapi.opam
+++ b/xapi.opam
@@ -10,6 +10,7 @@ build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta11"}
+  "x509"
   "cdrom"
   "fd-send-recv"
   "nbd"

--- a/xapi.opam
+++ b/xapi.opam
@@ -10,7 +10,6 @@ build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta11"}
-  "x509"
   "cdrom"
   "fd-send-recv"
   "nbd"
@@ -24,6 +23,7 @@ depends: [
   "stdext"
   "tar-format"
   "vhd-format"
+  "x509"
   "xapi-cli-protocol"
   "xapi-client"
   "xapi-consts"


### PR DESCRIPTION
Use the x509 library to parse the certificate and read its
DNS subject names, if any.

(This replaces the stopgap of using Host.hostname for the
 value of the "subject" field of the vdi_nbd_server_info objects.)
