### PR TITLE
CA-269728: Unplug the USB from host, not detach the vusb from VM

### DIFF
--- a/ocaml/xapi/xapi_pusb.ml
+++ b/ocaml/xapi/xapi_pusb.ml
@@ -47,11 +47,10 @@ let scan_start ~__context usbs =
 
   List.filter (fun (rf, rc) -> USBSet.mem (extract_known_usb_info rc) (USBSet.diff known_usb local_usb)) (Db.PUSB.get_all_records ~__context)
   |> List.iter (fun (self, _) ->
-                  let usb_group = Db.PUSB.get_USB_group ~__context ~self in
-                  Db.PUSB.destroy ~__context ~self;
-                  let vusbs = Db.USB_group.get_VUSBs ~__context ~self:usb_group in
-                  List.iter (fun vusb -> Db.VUSB.destroy ~__context ~self:vusb) vusbs;
-                  Db.USB_group.destroy ~__context ~self:usb_group)
+                  try
+                    Xapi_pusb_helpers.destroy_pusb ~__context self;
+                  with _ -> error "failure while removing PUSB: %s" (Ref.string_of self);
+                )
 
 let cond = Condition.create ()
 let mutex = Mutex.create ()

--- a/ocaml/xapi/xapi_pusb.ml
+++ b/ocaml/xapi/xapi_pusb.ml
@@ -49,7 +49,7 @@ let scan_start ~__context usbs =
   |> List.iter (fun (self, _) ->
                   try
                     Xapi_pusb_helpers.destroy_pusb ~__context self;
-                  with _ -> error "failure while removing PUSB: %s" (Ref.string_of self);
+                  with e -> error "Caught exception while removing PUSB %s: %s" (Ref.string_of self) (Printexc.to_string e);
                 )
 
 let cond = Condition.create ()

--- a/ocaml/xapi/xapi_pusb_helpers.ml
+++ b/ocaml/xapi/xapi_pusb_helpers.ml
@@ -126,8 +126,8 @@ let destroy_pusb ~__context pusb =
     let currently_attached = Db.VUSB.get_currently_attached ~__context ~self:vusb in
     if currently_attached then
       Helpers.call_api_functions ~__context (fun rpc session_id ->
-        Client.Client.VUSB.unplug rpc session_id vusb)
+        Client.Client.VUSB.unplug rpc session_id vusb);
+    Db.VUSB.destroy ~__context ~self:vusb
   ) vusbs;
-  List.iter (fun vusb -> Db.VUSB.destroy ~__context ~self:vusb) vusbs;
   Db.PUSB.destroy ~__context ~self:pusb;
   Db.USB_group.destroy ~__context ~self:usb_group

--- a/ocaml/xapi/xapi_pusb_helpers.ml
+++ b/ocaml/xapi/xapi_pusb_helpers.ml
@@ -118,3 +118,16 @@ let find_or_create ~__context pusb =
   let name_label = "Group of " ^ pusb_rec.Db_actions.pUSB_vendor_id ^ " " ^ pusb_rec.Db_actions.pUSB_product_id ^ " USBs" in
   let group = Xapi_usb_group.create ~__context ~name_label ~name_description:"" ~other_config:[] in
   group
+
+let destroy_pusb ~__context pusb =
+  let usb_group = Db.PUSB.get_USB_group ~__context ~self:pusb in
+  let vusbs = Db.USB_group.get_VUSBs ~__context ~self:usb_group in
+  List.iter (fun vusb ->
+    let currently_attached = Db.VUSB.get_currently_attached ~__context ~self:vusb in
+    if currently_attached then
+      Helpers.call_api_functions ~__context (fun rpc session_id ->
+        Client.Client.VUSB.unplug rpc session_id vusb)
+  ) vusbs;
+  List.iter (fun vusb -> Db.VUSB.destroy ~__context ~self:vusb) vusbs;
+  Db.PUSB.destroy ~__context ~self:pusb;
+  Db.USB_group.destroy ~__context ~self:usb_group


### PR DESCRIPTION
1.When unplug usb from host, we need to unplug vusb from vm if it is attached to vm.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>