### PR TITLE
CA-269591: Clean vusb attached field when vm shutdown

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -629,6 +629,15 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
            Db.PCI.set_scheduled_to_be_attached_to ~__context ~self:pci ~value:Ref.null
       )
       (Db.PCI.get_all ~__context);
+      List.iter
+        (fun vusb ->
+           let attached = Db.VUSB.get_attached ~__context ~self:vusb in
+           if attached <> Ref.null then begin
+             Db.VUSB.set_attached ~__context ~self:vusb ~value:Ref.null;
+             Db.PUSB.set_attached ~__context ~self:attached ~value:Ref.null
+           end;
+           Xapi_vusb_helpers.clear_current_operations ~__context ~self:vusb;
+      ) (Db.VM.get_VUSBs ~__context ~self);
     (* Blank the requires_reboot flag *)
     Db.VM.set_requires_reboot ~__context ~self ~value:false
   end;

--- a/ocaml/xapi/xapi_vusb_helpers.ml
+++ b/ocaml/xapi/xapi_vusb_helpers.ml
@@ -98,3 +98,10 @@ let assert_operation_valid ~__context ~self ~(op:API.vusb_operations) =
   let all = Db.VUSB.get_record_internal ~__context ~self in
   let table = valid_operations ~__context all self in
   throw_error table op
+
+let clear_current_operations ~__context ~self =
+  if (Db.VUSB.get_current_operations ~__context ~self)<>[] then
+    begin
+      Db.VUSB.set_current_operations ~__context ~self ~value:[];
+      update_allowed_operations ~__context ~self
+    end

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2729,7 +2729,15 @@ let shutdown ~__context ~self timeout =
               raise Api_errors.(Server_error(internal_error, [
                   Printf.sprintf "shutdown: The VBD %s is still attached to VM %s"
                     (Ref.string_of vbd) (Ref.string_of self)]))
-         ) (Db.VM.get_VBDs ~__context ~self)
+         ) (Db.VM.get_VBDs ~__context ~self);
+       List.iter
+         (fun vusb ->
+            let attached = Db.VUSB.get_attached ~__context ~self:vusb in
+            if attached <> Ref.null then begin
+              Db.VUSB.set_attached ~__context ~self:vusb ~value:Ref.null;
+              Db.PUSB.set_attached ~__context ~self:attached ~value:Ref.null
+            end
+         ) (Db.VM.get_VUSBs ~__context ~self);
     )
 
 let suspend ~__context ~self =

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2596,13 +2596,6 @@ let maybe_cleanup_vm ~__context ~self =
     Xenopsd_metadata.delete ~__context id;
   end
 
-let clear_vusb_attched ~__context ~self =
-  List.iter (fun vusb -> let pusb = Db.VUSB.get_attached ~__context ~self:vusb in
-              Db.VUSB.set_attached ~__context ~self:vusb ~value:Ref.null;
-              if Db.is_valid_ref __context pusb then
-                Db.PUSB.set_attached ~__context ~self:pusb ~value:Ref.null
-            ) (Db.VM.get_VUSBs ~__context ~self)
-
 let start ~__context ~self paused force =
   let dbg = Context.string_of_task __context in
   let queue_name = queue_of_vm ~__context ~self in
@@ -2656,9 +2649,6 @@ let start ~__context ~self paused force =
         check_power_state_is ~__context ~self ~expected:(if paused then `Paused else `Running)
       with e ->
         error "Caught exception starting VM: %s" (string_of_exn e);
-        (* when vm start failed, we need to clear the attached field of vusb.
-           Now we handle it in the exception, but need to fix it later.*)
-        clear_vusb_attched ~__context ~self;
         set_resident_on ~__context ~self;
         raise e
     )

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2733,15 +2733,7 @@ let shutdown ~__context ~self timeout =
               raise Api_errors.(Server_error(internal_error, [
                   Printf.sprintf "shutdown: The VBD %s is still attached to VM %s"
                     (Ref.string_of vbd) (Ref.string_of self)]))
-         ) (Db.VM.get_VBDs ~__context ~self);
-       List.iter
-         (fun vusb ->
-            let attached = Db.VUSB.get_attached ~__context ~self:vusb in
-            if attached <> Ref.null then begin
-              Db.VUSB.set_attached ~__context ~self:vusb ~value:Ref.null;
-              Db.PUSB.set_attached ~__context ~self:attached ~value:Ref.null
-            end
-         ) (Db.VM.get_VUSBs ~__context ~self);
+         ) (Db.VM.get_VBDs ~__context ~self)
     )
 
 let suspend ~__context ~self =

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2597,7 +2597,11 @@ let maybe_cleanup_vm ~__context ~self =
   end
 
 let clear_vusb_attched ~__context ~self =
-  List.iter (fun vusb -> Db.VUSB.set_attached ~__context ~self:vusb ~value:Ref.null) (Db.VM.get_VUSBs ~__context ~self)
+  List.iter (fun vusb -> let pusb = Db.VUSB.get_attached ~__context ~self:vusb in
+              Db.VUSB.set_attached ~__context ~self:vusb ~value:Ref.null;
+              if Db.is_valid_ref __context pusb then
+                Db.PUSB.set_attached ~__context ~self:pusb ~value:Ref.null
+            ) (Db.VM.get_VUSBs ~__context ~self)
 
 let start ~__context ~self paused force =
   let dbg = Context.string_of_task __context in


### PR DESCRIPTION
1.This solution is to slove the issue that vusb doesn't exist in xenopsd when reboot vm.
Another PR https://github.com/xapi-project/xenopsd/pull/406 in xenopsd will remove unplug vusb when vm shutdown. So xapi will check vusb attached when vm shutdown.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>