### PR TITLE
CP-25328: update policy file, hubs are always denied

### DIFF
--- a/scripts/usb-policy.conf
+++ b/scripts/usb-policy.conf
@@ -2,9 +2,10 @@
 #  and each rule is (ALLOW | DENY) : ( match )*
 #  and each match is (class|subclass|prot|vid|pid|rel) = hex-number
 # Maximum hex value for class/subclass/prot is FF, and for vid/pid/rel is FFFF
+#
+# USB Hubs (class 09) are always denied, independently of the rules in this file
 DENY: vid=17e9 # All DisplayLink USB displays
 DENY: class=02 # Communications and CDC-Control
-DENY: class=09 # Hub devices
 ALLOW:vid=056a pid=0315 class=03 # Wacom Intuos tablet
 ALLOW:vid=056a pid=0314 class=03 # Wacom Intuos tablet
 ALLOW:vid=056a pid=00fb class=03 # Wacom DTU tablet


### PR DESCRIPTION
Remove the DENY hubs line from policy file, because hubs are always
ignored. Also add comment to make it clear.

Signed-off-by: Xin(Talons) Li <xin.li@citrix.com>