### PR TITLE
CP-22019: xapi quicktest checks VDI.update is CBT-compatible

### DIFF
--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -73,8 +73,8 @@ let test_vdi_update ~test ~session_id vDI =
   let vdi_before = list_fields_labels_of vDI in
   VDI.update ~session_id ~rpc:!rpc ~vdi:vDI;
   let vdi_after = list_fields_labels_of vDI in
-  let validate (fd, label) (_fd, _) =
-    test_compare ~test fd _fd ~msg:(Printf.sprintf "VDI update failed: incorrect %s value" label) in
+  let validate (fd_a, label) (fd_b, _) =
+    test_compare ~test fd_a fd_b ~msg:(Printf.sprintf "VDI update failed: incorrect %s value" label) in
   validate (fst vdi_before) (fst vdi_after);
   List.iter2 validate (snd vdi_before) (snd vdi_after)
 

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -136,7 +136,7 @@ let vdi_data_destroy_test ~session_id ~vDI =
   | Test_failed msg -> failed test msg
   | e -> report_failure e test
 
-(* Check VDI.(copy, clone) all properly update cbt_enabled
+(* Check VDI.{copy, clone} all properly update cbt_enabled
  * Debug output included as VDI operations are expensive and take longer than other calls *)
 let vdi_clone_copy_test ~session_id ~sR ~vDI =
   let test = make_test "Testing VDI.clone and VDI.copy" 4 in
@@ -149,8 +149,6 @@ let vdi_clone_copy_test ~session_id ~sR ~vDI =
 
     debug test "Cloning VDI";
     let vdi_clone = VDI.clone ~session_id ~rpc:!rpc ~vdi:vDI ~driver_params:[] in
-    assert_cbt_status false ~test ~session_id ~vDI:vdi_clone
-      ~msg:"VDI.clone failed to set cbt_enabled to false";
 
     (* Test VDI.copy for copying from existing to fresh VDI in same SR *)
     debug test "Copying VDI into a freshly created VDI in same SR";
@@ -165,7 +163,7 @@ let vdi_clone_copy_test ~session_id ~sR ~vDI =
     [ true , vDI , "VDI.copy erroneously reset the original VDI's cbt_enabled to false"
     ; false , into_vdi , "VDI.copy failed to initialise cbt_enabled to false"
     ; false , vdi_copy_fresh , "VDI.copy erroneously reset the copied VDI's cbt_enabled field to true"
-    ; false , vdi_clone , "VDI.copy erroneously reset the cloned VDI's cbt_enabled field to true"
+    ; false , vdi_clone , "VDI.clone failed to set cbt_enabled to false";
     ] |> List.iter
       ( fun (boolean, vDI, msg) ->
           assert_cbt_status boolean ~test ~session_id ~vDI ~msg;

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -60,19 +60,19 @@ let make_vdi_from ~session_id ~sR =
 (* Helper for calling VDI.update and comparing changes in fields
  * after making an API call on a VDI *)
 let test_vdi_update ~test ~session_id vDI =
-  let list_bools_of vDI =
-    let list_bools =
+  let list_fields_labels_of vDI =
+    let list_fields_labels =
       [ VDI.get_cbt_enabled , "cbt-enabled"
       ; VDI.get_is_a_snapshot , "is-a-snapshot"
       ; VDI.get_managed , "managed"
         (* compiler complains if ~session_id and ~rpc switch order *)
       ] |> List.map (fun (getter,label) -> ( getter ~rpc:!rpc ~session_id ~self:vDI , label)) in
-    ( (VDI.get_type ~session_id ~rpc:!rpc ~self:vDI , "type" ), list_bools ) in
+    ( (VDI.get_type ~session_id ~rpc:!rpc ~self:vDI , "type" ), list_fields_labels ) in
 
   (* Call a VDI function like enable_CBT, check fields after,  *)
-  let vdi_before = list_bools_of vDI in
+  let vdi_before = list_fields_labels_of vDI in
   VDI.update ~session_id ~rpc:!rpc ~vdi:vDI;
-  let vdi_after = list_bools_of vDI in
+  let vdi_after = list_fields_labels_of vDI in
   let validate (fd, label) (_fd, _) =
     test_compare ~test fd _fd ~msg:(Printf.sprintf "VDI update failed: incorrect %s value" label) in
   validate (fst vdi_before) (fst vdi_after);

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -78,9 +78,9 @@ let test_vdi_update ~test ~session_id vDI =
   validate (fst vdi_before) (fst vdi_after);
   List.iter2 validate (snd vdi_before) (snd vdi_after)
 
-(* ******************
- * Test declarations
- * ******************)
+(* ------------------ *
+   Test declarations
+ * ------------------ *)
 
 (* Note that tests including expensive VDI operations (snapshot, clone, copy etc)
  * output debug info at most steps to justify waiting time to user
@@ -123,7 +123,9 @@ let vdi_data_destroy_test ~session_id ~vDI =
       ~msg:"VDI.data_destroy failed to update VDI.type";
     assert_cbt_status true ~session_id ~test ~vDI:snapshot
       ~msg:"VDI snapshot cbt_enabled field erroneously set to false";
-    test_vdi_update ~session_id ~test snapshot;
+  (*  test_vdi_update ~session_id ~test snapshot; 
+      temporarily comment this out as it is blocked on CA-273981
+      VDI.update doesn't currently work on cbt-metadata VDIs *)
 
     let content_id_str = "/No content: this is a cbt_metadata VDI/" in
     test_compare ~test
@@ -174,9 +176,9 @@ let vdi_clone_copy_test ~session_id ~sR ~vDI =
   | Test_failed msg -> failed test msg
   | e -> report_failure e test
 
-(* ****************
- *  Test execution
- * ****************)
+(* ---------------- *
+    Test execution
+ * ---------------- *) 
 
 (* Overall test executes individual unit tests *)
 let test ~session_id =

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -64,7 +64,7 @@ let test_vdi_update ~test ~session_id ~vDI =
     let list_bools =
       [ VDI.get_cbt_enabled , "cbt-enabled"
       ; VDI.get_is_a_snapshot , "is-a-snapshot"
-      ; VDI.get_managed , "mananged"
+      ; VDI.get_managed , "managed"
         (* compiler complains if ~session_id and ~rpc switch order *)
       ] |> List.map (fun (getter,label) -> ( getter ~rpc:!rpc ~session_id ~self:vDI , label)) in
     ( (VDI.get_type ~session_id ~rpc:!rpc ~self:vDI , "type" ), list_bools ) in

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -101,9 +101,7 @@ let vdi_data_destroy_test ~session_id ~vDI =
     let snapshot = VDI.snapshot ~session_id ~rpc:!rpc ~vdi:vDI ~driver_params:[] in
     assert_cbt_status true ~session_id ~test ~vDI:snapshot
       ~msg:"VDI.snapshot failed, cbt_enabled field didn't carry over";
-    List.iter
-      (fun vDI -> test_vdi_update ~session_id ~test vDI)
-      [snapshot ; vDI];
+    List.iter (test_vdi_update ~session_id ~test) [snapshot ; vDI];
 
     debug test "Disabling CBT on original VDI";
     VDI.disable_cbt ~session_id ~rpc:!rpc ~self:vDI;
@@ -115,9 +113,7 @@ let vdi_data_destroy_test ~session_id ~vDI =
     let snapshot_no_cbt = VDI.snapshot ~session_id ~rpc:!rpc ~vdi:vDI ~driver_params:[] in
     assert_cbt_status false ~session_id ~test ~vDI:snapshot_no_cbt
       ~msg:"VDI.snapshot failed, cbt_enabled field didn't carry over";
-    List.iter
-      (fun vDI -> test_vdi_update ~session_id ~test vDI)
-      [snapshot_no_cbt ; vDI];
+    List.iter (test_vdi_update ~session_id ~test) [snapshot_no_cbt ; vDI];
 
     debug test "Destroying snapshot VDI data";
     VDI.data_destroy ~session_id ~rpc:!rpc ~self:snapshot;

--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -101,7 +101,9 @@ let vdi_data_destroy_test ~session_id ~vDI =
     let snapshot = VDI.snapshot ~session_id ~rpc:!rpc ~vdi:vDI ~driver_params:[] in
     assert_cbt_status true ~session_id ~test ~vDI:snapshot
       ~msg:"VDI.snapshot failed, cbt_enabled field didn't carry over";
-    test_vdi_update ~session_id ~test ~vDI;
+    List.iter
+      (fun vDI -> test_vdi_update ~session_id ~test vDI)
+      [snapshot ; vDI];
 
     debug test "Disabling CBT on original VDI";
     VDI.disable_cbt ~session_id ~rpc:!rpc ~self:vDI;
@@ -167,6 +169,7 @@ let vdi_clone_copy_test ~session_id ~sR ~vDI =
     [ true , vDI , "VDI.copy erroneously reset the original VDI's cbt_enabled to false"
     ; false , into_vdi , "VDI.copy failed to initialise cbt_enabled to false"
     ; false , vdi_copy_fresh , "VDI.copy erroneously reset the copied VDI's cbt_enabled field to true"
+    ; false , vdi_clone , "VDI.copy erroneously reset the cloned VDI's cbt_enabled field to true"
     ] |> List.iter
       ( fun (boolean, vDI, msg) ->
           assert_cbt_status boolean ~test ~session_id ~vDI ~msg;


### PR DESCRIPTION
Quicktest currently contains 2 tests for CBT:
- one checks VDI.snapshot and VDI.data_destroy retain CBT-relevant VDI fields
- as above but for VDI.copy and VDI.clone

This PR extends those both to call VDI.update after every CBT-relevant call, ensuring VDI.update preserves CBT-relevant fields
Note: this is a preliminary test, ideally would like to set incorrect database values and check for VDI.update to fix them, looking for a way to do this within a quicktest