### PR TITLE
CA-178651: FCoE NIC is not prevented from unplugging

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -605,6 +605,8 @@ let _ =
     ~doc:"This host has no PIF on the given network." ();
   error Api_errors.pif_does_not_allow_unplug [ "PIF" ]
     ~doc:"The operation you requested cannot be performed because the specified PIF does not allow unplug." ();
+  error Api_errors.pif_has_fcoe_sr_in_use ["PIF"; "SR"]
+    ~doc:"The operation you requested cannot be performed because the specified PIF has fcoe sr in use." ();
   error Api_errors.pif_unmanaged [ "PIF" ]
     ~doc:"The operation you requested cannot be performed because the specified PIF is not managed by xapi." ();
   error Api_errors.pif_has_no_network_configuration [ "PIF" ]
@@ -5436,6 +5438,10 @@ let pif_unplug = call
     ~params:[Ref _pif, "self", "the PIF object to unplug"]
     ~in_product_since:rel_miami
     ~allowed_roles:_R_POOL_OP
+    ~errs:[Api_errors.ha_operation_would_break_failover_plan;
+           Api_errors.vif_in_use;
+           Api_errors.pif_does_not_allow_unplug;
+           Api_errors.pif_has_fcoe_sr_in_use]
     ()
 
 let pif_ip_configuration_mode = Enum ("ip_configuration_mode",

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -118,6 +118,7 @@ let pif_incompatible_primary_address_type = "PIF_INCOMPATIBLE_PRIMARY_ADDRESS_TY
 let required_pif_is_unplugged = "REQUIRED_PIF_IS_UNPLUGGED"
 let pif_not_present = "PIF_NOT_PRESENT"
 let pif_does_not_allow_unplug = "PIF_DOES_NOT_ALLOW_UNPLUG"
+let pif_has_fcoe_sr_in_use = "PIF_HAS_FCOE_SR_IN_USE"
 let pif_unmanaged = "PIF_UNMANAGED"
 let cannot_plug_bond_slave = "CANNOT_PLUG_BOND_SLAVE"
 let cannot_add_vlan_to_bond_slave = "CANNOT_ADD_VLAN_TO_BOND_SLAVE"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -839,6 +839,8 @@ let usb_path = "usb_path"
  * should be set with disallow-unplug=true, during a PIF.scan. *)
 let non_managed_pifs = ref "/opt/xensource/libexec/bfs-interfaces"
 
+let fcoe_driver = ref "/opt/xensource/libexec/fcoe_driver"
+
 let xen_cmdline_script = ref "/opt/xensource/libexec/xen-cmdline"
 
 let sr_health_check_task_label = "SR Recovering"
@@ -1085,6 +1087,7 @@ module Resources = struct
     "xsh", xsh, "Path to xsh binary";
     "static-vdis", static_vdis, "Path to static-vdis script";
     "xen-cmdline-script", xen_cmdline_script, "Path to xen-cmdline script";
+    "fcoe-driver", fcoe_driver, "Execute during PIF unplug to get the lun devices related with the ether interface of the PIF";
   ]
   let nonessential_executables = [
     "startup-script-hook", startup_script_hook, "Executed during startup";


### PR DESCRIPTION
Prevent unplugging PIF which is used by FCoE

Signed-off-by: Yang Qian <yang.qian@citrix.com>

When unplugging PIF, if the PIF is used by FCoE SR, we should prevent the action.