### PR TITLE
CA-262059: No SM backends support VDI.resize_online - should be deprecated & removed

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3442,6 +3442,10 @@ let vdi_resize_online = call
     ~name:"resize_online"
     ~in_oss_since:None
     ~in_product_since:rel_rio
+    ~lifecycle: [
+      Published, rel_rio, "Online resize vdi";
+      Removed, rel_inverness, "Remove feature: online resize vdi"
+    ]
     ~params:[Ref _vdi, "vdi", "The VDI to resize"; Int, "size", "The new size of the VDI" ]
     ~doc:"Resize the VDI which may or may not be attached to running guests."
     ~allowed_roles:_R_VM_ADMIN

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3443,8 +3443,8 @@ let vdi_resize_online = call
     ~in_oss_since:None
     ~in_product_since:rel_rio
     ~lifecycle: [
-      Published, rel_rio, "Online resize vdi";
-      Removed, rel_inverness, "Remove feature: online resize vdi"
+      Published, rel_rio, "";
+      Removed, rel_inverness, "Remove feature of online VDI resize because it is not supported by any of the storage backends."
     ]
     ~params:[Ref _vdi, "vdi", "The VDI to resize"; Int, "size", "The new size of the VDI" ]
     ~doc:"Resize the VDI which may or may not be attached to running guests."

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3444,7 +3444,7 @@ let vdi_resize_online = call
     ~in_product_since:rel_rio
     ~lifecycle: [
       Published, rel_rio, "";
-      Removed, rel_inverness, "Remove feature of online VDI resize because it is not supported by any of the storage backends."
+      Removed, rel_inverness, "Online VDI resize is not supported by any of the storage backends."
     ]
     ~params:[Ref _vdi, "vdi", "The VDI to resize"; Int, "size", "The new size of the VDI" ]
     ~doc:"Resize the VDI which may or may not be attached to running guests."

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3441,7 +3441,6 @@ let vdi_resize = call
 let vdi_resize_online = call
     ~name:"resize_online"
     ~in_oss_since:None
-    ~in_product_since:rel_rio
     ~lifecycle: [
       Published, rel_rio, "";
       Removed, rel_inverness, "Online VDI resize is not supported by any of the storage backends."

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3614,15 +3614,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
            forward_vdi_op ~local_fn ~__context ~self:vdi
              (fun session_id rpc -> Client.VDI.resize rpc session_id vdi size))
 
-    let resize_online ~__context ~vdi ~size =
-      info "VDI.resize_online: VDI = '%s'; size = %Ld" (vdi_uuid ~__context vdi) size;
-      let local_fn = Local.VDI.resize_online ~vdi ~size in
-      let sR = Db.VDI.get_SR ~__context ~self:vdi in
-      with_sr_andor_vdi ~__context ~sr:(sR, `vdi_resize) ~vdi:(vdi, `resize_online) ~doc:"VDI.resize_online"
-        (fun () ->
-           forward_vdi_op ~local_fn ~__context ~self:vdi
-             (fun session_id rpc -> Client.VDI.resize_online rpc session_id vdi size))
-
     let generate_config ~__context ~host ~vdi =
       info "VDI.generate_config: VDI = '%s'; host = '%s'" (vdi_uuid ~__context vdi) (host_uuid ~__context host);
       let local_fn = Local.VDI.generate_config ~host ~vdi in

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -721,7 +721,7 @@ let _data_destroy ~__context ~self ~timeout =
 
 let data_destroy = _data_destroy ~timeout:4.0
 
-let resize_online ~__context ~vdi ~size =
+let resize ~__context ~vdi ~size =
   Sm.assert_pbd_is_plugged ~__context ~sr:(Db.VDI.get_SR ~__context ~self:vdi);
   Xapi_vdi_helpers.assert_managed ~__context ~vdi;
   Storage_access.transform_storage_exn
@@ -734,8 +734,6 @@ let resize_online ~__context ~vdi ~size =
        let new_size = C.VDI.resize ~dbg ~sr ~vdi:vdi' ~new_size:size in
        Db.VDI.set_virtual_size ~__context ~self:vdi ~value:new_size
     )
-
-let resize = resize_online
 
 let generate_config ~__context ~host ~vdi =
   Sm.assert_pbd_is_plugged ~__context ~sr:(Db.VDI.get_SR ~__context ~self:vdi);

--- a/ocaml/xapi/xapi_vdi.mli
+++ b/ocaml/xapi/xapi_vdi.mli
@@ -154,8 +154,6 @@ val _data_destroy : __context:Context.t -> self:[ `VDI ] API.Ref.t -> timeout:fl
     for waiting for the VDI's VBDs to disappear is configurable to enable faster
     unit tests. *)
 
-val resize_online :
-  __context:Context.t -> vdi:[ `VDI ] API.Ref.t -> size:int64 -> unit
 val resize :
   __context:Context.t -> vdi:[ `VDI ] API.Ref.t -> size:int64 -> unit
 val generate_config :


### PR DESCRIPTION
Deprecate VDI.resize_online because there are no sm backend support this feature.

Signed-off-by: Yang Qian <yang.qian@citrix.com>