### PR TITLE
[CA-271014] Only get local SRs on the physical utilisation thread

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1016,7 +1016,7 @@ let get_all_plugged_srs ~__context =
     Eq (Field "currently_attached", Literal "true")) in
   List.setify (List.map (fun self -> Db.PBD.get_SR ~__context ~self) pbds_plugged_in)
 
-let get_all_plugged_srs_local ~__context =
+let get_local_plugged_srs ~__context =
   let localhost = get_localhost __context in
   let localhost = Ref.string_of localhost in
   let my_pbds_plugged_in = Db.PBD.get_refs_where  ~__context ~expr:(And (

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1012,8 +1012,8 @@ let i_am_srmaster ~__context ~sr =
   get_srmaster ~__context ~sr = get_localhost ~__context
 
 let get_all_plugged_srs ~__context =
-  let pbds = Db.PBD.get_all ~__context in
-  let pbds_plugged_in = List.filter (fun self -> Db.PBD.get_currently_attached ~__context ~self) pbds in
+  let pbds_plugged_in = Db.PBD.get_refs_where ~__context ~expr:(
+    Eq (Field "currently_attached", Literal "true")) in
   List.setify (List.map (fun self -> Db.PBD.get_SR ~__context ~self) pbds_plugged_in)
 
 let get_all_plugged_srs_local ~__context =

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1016,6 +1016,16 @@ let get_all_plugged_srs ~__context =
   let pbds_plugged_in = List.filter (fun self -> Db.PBD.get_currently_attached ~__context ~self) pbds in
   List.setify (List.map (fun self -> Db.PBD.get_SR ~__context ~self) pbds_plugged_in)
 
+let get_all_plugged_srs_local ~__context =
+  let localhost = get_localhost __context in
+  let localhost = Ref.string_of localhost in
+  let my_pbds_plugged_in = Db.PBD.get_refs_where  ~__context ~expr:(And (
+    Eq (Field "host", Literal localhost),
+    Eq (Field "currently_attached", Literal "true")
+  ))
+  in
+  List.setify (List.map (fun self -> Db.PBD.get_SR ~__context ~self) my_pbds_plugged_in)
+
 let find_health_check_task ~__context ~sr =
   Db.Task.get_refs_where ~__context ~expr:(And (
       Eq (Field "name__label", Literal Xapi_globs.sr_health_check_task_label),

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -665,7 +665,7 @@ let physical_utilisation_thread ~__context () =
   let sr_cache : bool SRMap.t ref = ref SRMap.empty in
 
   let srs_to_update () =
-    let plugged_srs = Helpers.get_all_plugged_srs_local ~__context in
+    let plugged_srs = Helpers.get_local_plugged_srs ~__context in
     (* Remove SRs that are no longer plugged *)
     sr_cache := SRMap.filter (fun sr _ -> List.mem sr plugged_srs) !sr_cache;
     (* Cache wether we should manage stats for newly plugged SRs *)

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -665,7 +665,7 @@ let physical_utilisation_thread ~__context () =
   let sr_cache : bool SRMap.t ref = ref SRMap.empty in
 
   let srs_to_update () =
-    let plugged_srs = Helpers.get_all_plugged_srs ~__context in
+    let plugged_srs = Helpers.get_all_plugged_srs_local ~__context in
     (* Remove SRs that are no longer plugged *)
     sr_cache := SRMap.filter (fun sr _ -> List.mem sr plugged_srs) !sr_cache;
     (* Cache wether we should manage stats for newly plugged SRs *)


### PR DESCRIPTION
This greatly improves the performance of the pool master in a large pool. The current loop means that every 2 minutes each host in the pool queries, for each PBD (regardless of which host it's on), whether it's currently attached, and its SR. It then updates the xapi database with the RRDD physical utilisation value for those SRs it has the data. As an optimisation therefore, this commit adds a new method to only get PBDs on the calling host, and then the SRs for those will be those that it can update the RRDD data for.

The issue with this physical utilisation thread is the overhead on the pool master, which must handle all the database queries. This is now only one query to get the PBDs currently attached on the calling host, plus one more for each PBD currently plugged on localhost (to get its SR). It was previously one query to get all PBDs on the pool (regardless of host), plus an extra two queries for each PBD to get its currently_attached and then its SR.

If a pool has n hosts with m PBDs each (all currently attached), then we previously had n hosts making 2nm+1 database queries each every 2 minutes, and we now have n hosts making 1+m database queries each every 2 minutes.

Passing BVT: suite run 73964
Also see the ticket for examples of performance improvement from this fix on a large pool

Signed-off-by: Callum McIntyre <callum.mcintyre@citrix.com>