### PR TITLE
CA-271857: Add a fix for start-of-day xenopsd sync

### DIFF
--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -44,7 +44,7 @@ let make_localhost ~__context ?(features=Features.all_features) () =
     linux_verstring = "something";
     hostname = "localhost";
     uuid = Xapi_inventory.lookup Xapi_inventory._installation_uuid;
-    dom0_uuid = "dom0-uuid";
+    dom0_uuid = Xapi_inventory.lookup Xapi_inventory._control_domain_uuid;
     oem_manufacturer = None;
     oem_model = None;
     oem_build_number = None;
@@ -73,6 +73,7 @@ let make_localhost ~__context ?(features=Features.all_features) () =
 (** Make a simple in-memory database containing a single host and dom0 VM record. *)
 let make_test_database ?(conn=Mock.Database.conn) ?(reuse=false) ?features () =
   let __context = Mock.make_context_with_new_db ~conn ~reuse "mock" in
+  Helpers.domain_zero_ref_cache := None;
   make_localhost ~__context ?features ();
   __context
 


### PR DESCRIPTION
This PR fixes an issue with the start-of-day sync of xapi and xenopsd that occurs when there are non-dom0 control domains.