### PR TITLE
fix compatibility for older python (doesn't know context [SSL])

### DIFF
--- a/scripts/examples/python/XenAPI.py
+++ b/scripts/examples/python/XenAPI.py
@@ -129,7 +129,8 @@ class Session(xmlrpclib.ServerProxy):
                  allow_none=1, ignore_ssl=False):
 
         # Fix for CA-172901 (+ Python 2.4 compatibility)
-        if not (sys.version_info[0] <= 2 and sys.version_info[1] < 7) \
+        # Fix for context=ctx ( < Python 2.7.9 compatibility)
+        if not (sys.version_info[0] <= 2 and sys.version_info[1] <= 7 and sys.version_info[2] <= 9 ) \
                 and ignore_ssl:
             import ssl
             ctx = ssl._create_unverified_context()


### PR DESCRIPTION
older version of python doesn't know about SSL context in xmlrpclib. 

[root@xxx ~]# python --version
Python 2.7.5
[root@xxx ~]# pydoc xmlrpclib | grep __init__
     |  __init__(self, data=None)
     |  __init__(self, value=0)
     |  __init__(...)
     |      x.__init__(...) initializes x; see help(type(x)) for signature
     |  __init__(self, target)
     |  __init__(self, faultCode, faultString, **extra)
     |  __init__(self, response)
     |  __init__(self, encoding=None, allow_none=0)
     |  __init__(self, server)
     |  __init__(self, results)
     |  __init__(self, url, errcode, errmsg, headers)
     |  __init__(...)
     |      x.__init__(...) initializes x; see help(type(x)) for signature
     |  __init__(self, use_datetime=0)
     |  __init__(self, uri, transport=None, encoding=None, verbose=0, allow_none=0, use_datetime=0)
     |  __init__(self, uri, transport=None, encoding=None, verbose=0, allow_none=0, use_datetime=0)
     |  __init__(self, target)
     |  __init__(self, use_datetime=0)
     |  __init__(self, use_datetime=0)
