### PR TITLE
CA-272126: Don't get NVidia vGPU types from XML file for now.

### DIFF
--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -456,7 +456,7 @@ module Vendor = functor (V : VENDOR) -> struct
       ~is_pci_hidden =
     let vgpu_types = make_vgpu_types ~__context ~pci in
     (* Temporarily fall back to old nvidia module *)
-    if vgpu_types = [] && vendor_id = Nvidia_old.vendor_id then begin
+    if vendor_id = Nvidia_old.vendor_id then begin
       info "Temporarily fall back to old nvidia conf file parser";
       Nvidia_old.find_or_create_supported_types ~__context ~pci
         ~is_system_display_device


### PR DESCRIPTION
This bypasses the changes from b66e46cc, until low-level bits have been fixed.

This is the "smallest" fix for this issue. We already have a fallback to the
old method for the case that the XML is invalid. We'll now take that path even
when the XML did give us some valid vGPU types.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>