### PR TITLE
CA-271852 XenServer build date hardcoded to 1970-01-01

### DIFF
--- a/ocaml/util/jbuild
+++ b/ocaml/util/jbuild
@@ -1,7 +1,12 @@
+(rule
+ ((targets (build_info.ml))
+  (action  (with-stdout-to ${@} (run "date" "+let date=\"%Y-%m-%d\"")))))
+
 (library
  ((name xapi_version)
   (modules (
    xapi_version
+   build_info
   ))
   (libraries (
    xcp

--- a/ocaml/util/xapi_version.ml
+++ b/ocaml/util/xapi_version.ml
@@ -8,6 +8,6 @@
 
 let git_id = ""
 let hostname = "localhost"
-let date = "1970-01-01"
+let date = Build_info.date
 let xapi_version_major = 1
 let xapi_version_minor = 20


### PR DESCRIPTION
Get build date from `xensource-inventory` instead of hard coding to `1970-01-01`.
This PR depends on the change of other repos, I have recorded them in the ticket.
Signed-off-by: Yang Qian <yang.qian@citrix.com>