### PR TITLE
CP-25797 Add net SR-IOV model

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -174,8 +174,7 @@ let _vdi_nbd_server_info = "vdi_nbd_server_info"
 let _pusb = "PUSB"
 let _usb_group = "USB_group"
 let _vusb = "VUSB"
-
-
+let _net_sriov = "NET_sriov"
 (** All the various static role names *)
 
 let role_pool_admin = "pool-admin"
@@ -5634,6 +5633,8 @@ let pif =
       field ~in_oss_since:None ~ty:(Set(Ref _bond)) ~in_product_since:rel_miami ~qualifier:DynamicRO "bond_master_of" "Indicates this PIF represents the results of a bond";
       field ~in_oss_since:None ~ty:(Ref _vlan) ~in_product_since:rel_miami ~qualifier:DynamicRO "VLAN_master_of" "Indicates wich VLAN this interface receives untagged traffic from" ~default_value:(Some (VRef ""));
       field ~in_oss_since:None ~ty:(Set(Ref _vlan)) ~in_product_since:rel_miami ~qualifier:DynamicRO "VLAN_slave_of" "Indicates which VLANs this interface transmits tagged traffic to";
+      field ~in_oss_since:None ~ty:(Ref _net_sriov) ~in_product_since:rel_jura ~qualifier:DynamicRO "sriov_master_of" "Indicates which net_sriov this interface is physical of" ~default_value:(Some (VRef ""));
+      field ~in_oss_since:None ~ty:(Ref _net_sriov) ~in_product_since:rel_jura ~qualifier:DynamicRO "sriov_slave_of" "Indicates which net_sriov this interface is logical of" ~default_value:(Some (VRef ""));
       field ~in_oss_since:None ~ty:Bool ~in_product_since:rel_miami ~qualifier:DynamicRO "management" "Indicates whether the control software is listening for connections on this interface" ~default_value:(Some (VBool false));
       field ~in_product_since:rel_miami ~default_value:(Some (VMap [])) ~ty:(Map(String, String)) "other_config" "Additional configuration";
       field ~in_product_since:rel_orlando ~default_value:(Some (VBool false)) ~ty:Bool "disallow_unplug" "Prevent this PIF from being unplugged; set this to notify the management tool-stack that the PIF has a special use and should not be unplugged under any circumstances (e.g. because you're running storage traffic over it)";
@@ -6066,6 +6067,7 @@ let vif =
          field ~ty:vif_ipv6_configuration_mode ~in_product_since:rel_dundee ~qualifier:DynamicRO "ipv6_configuration_mode" "Determines whether IPv6 addresses are configured on the VIF" ~default_value:(Some (VEnum "None"));
          field ~ty:(Set (String)) ~in_product_since:rel_dundee ~qualifier:DynamicRO "ipv6_addresses" "IPv6 addresses in CIDR format" ~default_value:(Some (VSet []));
          field ~ty:String ~in_product_since:rel_dundee ~qualifier:DynamicRO "ipv6_gateway" "IPv6 gateway (the empty string means that no gateway is set)" ~default_value:(Some (VString ""));
+         field ~ty:(Ref _pci) ~in_product_since:rel_jura ~qualifier:DynamicRO "attached_pci" "pci of which this vif attached (sriov vif)" ~default_value:(Some (VRef null_ref));
        ])
     ()
 
@@ -9200,6 +9202,50 @@ let alert =
     ()
 *)
 
+let net_sriov_create = call
+    ~name:"create"
+    ~doc:"Create a net-sriov on specified pif"
+    ~params:[Ref _pif, "pif", "PIF which to enable sriov";
+             Ref _network, "network", "Network to link SRIOV"]
+    ~result:(Ref _net_sriov, "The reference of the created SRIOV object")
+    ~in_product_since:rel_jura
+    ~allowed_roles:_R_POOL_OP
+    ()
+
+let net_sriov_destroy = call
+    ~name:"destroy"
+    ~doc:"Destroy a net-sriov"
+    ~params:[Ref _net_sriov, "self", "SRIOV to destroy"]
+    ~in_product_since:rel_jura
+    ~allowed_roles:_R_POOL_OP
+    ()
+
+(** network sriov **)
+module NET_sriov = struct
+  let obj =
+    create_obj
+      ~name:_net_sriov
+      ~descr:"network-sriov which connects logical pif and physical pif"
+      ~doccomments:[]
+      ~gen_constructor_destructor:false
+      ~gen_events:true
+      ~in_db:true
+      ~lifecycle:[Published, rel_jura, ""]
+      ~messages:[net_sriov_create; net_sriov_destroy]
+      ~messages_default_allowed_roles:_R_POOL_OP
+      ~persist:PersistEverything
+      ~in_oss_since:None
+      ~contents:
+        ([
+          uid _net_sriov;
+          field ~qualifier:StaticRO ~ty:(Ref _pif) ~in_product_since:rel_jura "physical_PIF" "physical pif which the ner_sriov created" ~default_value:(Some (VRef ""));
+          field ~qualifier:StaticRO ~ty:(Ref _pif) ~in_product_since:rel_jura "logical_PIF" "logical pif after sriov enabled for physical pif" ~default_value:(Some (VRef ""));
+          field ~qualifier:RW ~ty:(Map(String, String)) ~in_product_since:rel_jura "other_config" "additional configuration" ~default_value:(Some (VMap []));
+        ])
+      ()
+end
+let net_sriov = NET_sriov.obj
+
 (** PCI devices *)
 
 let pci =
@@ -10245,6 +10291,7 @@ let all_system =
     pusb;
     usb_group;
     vusb;
+    net_sriov;
   ]
 
 (** These are the pairs of (object, field) which are bound together in the database schema *)
@@ -10428,6 +10475,7 @@ let expose_get_all_messages_for = [
   _pvs_cache_storage;
   _feature;
   _sdn_controller;
+  _net_sriov;
   (* _vdi_nbd_server_info must NOT be included here *)
   _pusb;
   _usb_group;

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -58,6 +58,7 @@ let rel_ely = "ely"
 let rel_falcon = "falcon"
 let rel_honolulu = "honolulu"
 let rel_inverness = "inverness"
+let rel_jura = "jura"
 
 type api_release = {
     code_name: string option;
@@ -192,6 +193,12 @@ let release_order_full = [{
     }; {
       code_name     = Some rel_inverness;
       (** TODO replace with the actual version numbers when Inverness is released *)
+      version_major = 2;
+      version_minor = 7;
+      branding   = "Unreleased";
+    };{
+      code_name     = Some rel_jura;
+      (** TODO replace with the actual version numbers when Jura is released *)
       version_major = 2;
       version_minor = 7;
       branding   = "Unreleased";

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -95,6 +95,7 @@ module Actions = struct
   module PUSB = Xapi_pusb
   module USB_group = Xapi_usb_group
   module VUSB = Xapi_vusb
+  module NET_sriov = Xapi_net_sriov
 end
 (** Use the server functor to make an XML-RPC dispatcher. *)
 module Forwarder = Message_forwarding.Forward (Actions)

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1576,6 +1576,24 @@ let rec cmdtable_data : (string*cmd_spec) list =
       flags=[];
     };
 
+    "net-sriov-create",
+    {
+      reqd=["pif-uuid";"network-uuid"];
+      optn=[];
+      help="Create a new net-sriov on a pif.";
+      implementation=No_fd Cli_operations.NET_sriov.sriov_create;
+      flags=[];
+    };
+
+    "net-sriov-destroy",
+    {
+      reqd=["uuid"];
+      optn=[];
+      help="Destroy a net-sriov.";
+      implementation=No_fd Cli_operations.NET_sriov.sriov_destroy;
+      flags=[];
+    };
+
     "pif-unplug",
     {
       reqd=["uuid"];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -824,6 +824,7 @@ let gen_cmds rpc session_id =
     ; Client.PUSB.(mk get_all get_all_records_where get_by_uuid pusb_record "pusb" [] ["uuid"; "path"; "product-id"; "product-desc"; "vendor-id"; "vendor-desc"; "serial"; "version";"description"] rpc session_id)
     ; Client.USB_group.(mk get_all get_all_records_where get_by_uuid usb_group_record "usb-group" [] ["uuid";"name-label";"name-description"] rpc session_id)
     ; Client.VUSB.(mk get_all get_all_records_where get_by_uuid vusb_record "vusb" [] ["uuid";"vm-uuid"; "usb-group-uuid"] rpc session_id)
+    ; Client.NET_sriov.(mk get_all get_all_records_where get_by_uuid net_sriov_record "net-sriov" [] ["uuid"; "physical-pif"; "logical-pif"] rpc session_id)
     ]
 
 (* NB, might want to put these back in at some point
@@ -3957,6 +3958,19 @@ let tunnel_destroy printer rpc session_id params =
   let uuid = List.assoc "uuid" params in
   let tunnel = Client.Tunnel.get_by_uuid rpc session_id uuid in
   Client.Tunnel.destroy rpc session_id tunnel
+
+module NET_sriov = struct
+  let sriov_create printer rpc session_id params =
+    let pif = Client.PIF.get_by_uuid rpc session_id (List.assoc "pif-uuid" params) in
+    let network = Client.Network.get_by_uuid rpc session_id (List.assoc "network-uuid" params) in
+    let sriov = Client.NET_sriov.create rpc session_id pif network in
+    let uuid = Client.NET_sriov.get_uuid rpc session_id sriov in
+    printer (Cli_printer.PList [uuid])
+
+  let sriov_destroy printer rpc session_id params =
+    let sriov = Client.NET_sriov.get_by_uuid rpc session_id (List.assoc "uuid" params) in
+    ignore(Client.NET_sriov.destroy rpc session_id sriov)
+end
 
 let pif_reconfigure_ip printer rpc session_id params =
   let read_optional_case_insensitive key =

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -42,6 +42,9 @@ let log_exn_continue msg f x = try f x with e -> debug "Ignoring exception: %s w
 let choose_network_name_for_pif device =
   Printf.sprintf "Pool-wide network associated with %s" device
 
+let choose_network_name_for_sriov device =
+  Printf.sprintf "SR-IOV network associated with %s" device
+
 (** Once the server functor has been instantiated, set this reference to the appropriate
     "fake_rpc" (loopback non-HTTP) rpc function. This is used by the CLI, which passes in
     the HTTP request headers it has already received together with its active file descriptor. *)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -336,6 +336,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         Ref.string_of bond
     with _ -> "invalid"
 
+  let net_sriov_uuid ~__context sriov =
+    try if Pool_role.is_master () then
+        Db.NET_sriov.get_uuid __context sriov
+      else
+        Ref.string_of sriov
+    with _ -> "invalid"
 
   let pif_uuid ~__context pif =
     try if Pool_role.is_master () then
@@ -4270,6 +4276,21 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
     let destroy ~__context ~self =
       info "VUSB.destroy: VUSB = '%s'" (vusb_uuid ~__context self);
       Local.VUSB.destroy ~__context ~self
+  end
+
+  module NET_sriov = struct
+    let create ~__context ~pif ~network =
+      info "NET_sriov.create : pif = '%s' , network = '%s' " (pif_uuid ~__context pif) (network_uuid ~__context network);
+      let local_fn = Local.NET_sriov.create ~pif ~network in
+      let host = Db.PIF.get_host ~__context ~self:pif in
+      do_op_on ~__context ~local_fn ~host (fun session_id rpc -> Client.NET_sriov.create rpc session_id pif network)
+
+    let destroy ~__context ~self =
+      info "NET_sriov.destroy : net_sriov = '%s'" (net_sriov_uuid ~__context self);
+      let local_fn = Local.NET_sriov.destroy ~self in
+      let physical_pif = Db.NET_sriov.get_physical_PIF ~__context ~self in
+      let host = Db.PIF.get_host ~__context ~self:physical_pif in
+      do_op_on ~__context ~local_fn ~host (fun session_id rpc -> Client.NET_sriov.destroy rpc session_id self)
   end
 
 end

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -217,6 +217,21 @@ let message_record rpc session_id message =
       ]
   }
 
+let net_sriov_record rpc session_id net_sriov =
+  let _ref = ref net_sriov in
+  let empty_record = ToGet (fun () -> Client.NET_sriov.get_record rpc session_id !_ref) in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  { setref=(fun r -> _ref := r; record := empty_record );
+    setrefrec=(fun (a,b) -> _ref := a; record := Got b);
+    record=x;
+    getref=(fun () -> !_ref);
+    fields =
+      [
+        make_field ~name:"uuid"                     ~get:(fun () -> (x ()).API.nET_sriov_uuid) ();
+        make_field ~name:"physical-pif-uuid"        ~get:(fun () -> get_uuid_from_ref (x ()).API.nET_sriov_physical_PIF) ();
+        make_field ~name:"logical-pif-uuid"         ~get:(fun () -> get_uuid_from_ref (x ()).API.nET_sriov_logical_PIF) ();
+      ]}
 
 let pif_record rpc session_id pif =
   let _ref = ref pif in
@@ -242,6 +257,8 @@ let pif_record rpc session_id pif =
         make_field ~name:"VLAN"         ~get:(fun () -> (Int64.to_string (x ()).API.pIF_VLAN)) ();
         make_field ~name:"bond-master-of" ~get:(fun () -> String.concat "; " (List.map (fun pif -> get_uuid_from_ref pif) (x ()).API.pIF_bond_master_of)) ();
         make_field ~name:"bond-slave-of"  ~get:(fun () -> get_uuid_from_ref (x ()).API.pIF_bond_slave_of) ();
+        make_field ~name:"sriov-master-of" ~get:(fun () -> get_uuid_from_ref (x ()).API.pIF_sriov_master_of) ();
+        make_field ~name:"sriov-slave-of"  ~get:(fun () -> get_uuid_from_ref (x ()).API.pIF_sriov_slave_of) ();
         make_field ~name:"tunnel-access-PIF-of" ~get:(fun () -> String.concat "; " (List.map (fun pif -> get_uuid_from_ref pif) (x ()).API.pIF_tunnel_access_PIF_of)) ();
         make_field ~name:"tunnel-transport-PIF-of"  ~get:(fun () -> String.concat "; " (List.map (fun pif -> get_uuid_from_ref pif) (x ()).API.pIF_tunnel_transport_PIF_of)) ();
         make_field ~name:"management"   ~get:(fun () -> string_of_bool ((x ()).API.pIF_management)) ();
@@ -404,6 +421,7 @@ let vif_record rpc session_id vif =
         make_field ~name:"ipv6-configuration-mode" ~get:(fun () -> Record_util.vif_ipv6_configuration_mode_to_string (x ()).API.vIF_ipv6_configuration_mode) ();
         make_field ~name:"ipv6-addresses" ~get:(fun () -> String.concat "; " (x ()).API.vIF_ipv6_addresses) ();
         make_field ~name:"ipv6-gateway" ~get:(fun () -> (x ()).API.vIF_ipv6_gateway) ();
+        make_field ~name:"attached_pci" ~get:(fun () -> try get_uuid_from_ref (x ()).API.vIF_attached_pci with _ -> nid) ();
       ]}
 
 

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -182,7 +182,7 @@ let make_vif ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ~currently_attached ~status_code ~status_detail ~runtime_properties
     ~other_config ~metrics ~locking_mode ~ipv4_allowed ~ipv6_allowed
     ~ipv4_configuration_mode ~ipv4_addresses ~ipv4_gateway
-    ~ipv6_configuration_mode ~ipv6_addresses ~ipv6_gateway;
+    ~ipv6_configuration_mode ~ipv6_addresses ~ipv6_gateway ~attached_pci:Ref.null;
   ref
 
 let make_pool ~__context ~master ?(name_label="") ?(name_description="")

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -374,7 +374,7 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
         ~device ~device_name ~network ~host ~mAC ~mTU:(-1L) ~vLAN:(-1L) ~metrics
         ~physical:false ~currently_attached:false ~igmp_snooping_status:`unknown
         ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
-        ~vLAN_master_of:Ref.null ~management:false ~other_config:[] ~disallow_unplug:false
+        ~vLAN_master_of:Ref.null ~sriov_master_of:Ref.null ~sriov_slave_of:Ref.null ~management:false ~other_config:[] ~disallow_unplug:false
         ~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true
         ~properties:pif_properties ~capabilities:[];
       Db.Bond.create ~__context ~ref:bond ~uuid:(Uuid.to_string (Uuid.make_uuid ())) ~master:master ~other_config:[]

--- a/ocaml/xapi/xapi_net_sriov.mli
+++ b/ocaml/xapi/xapi_net_sriov.mli
@@ -1,0 +1,28 @@
+(*
+ * Copyright (C) 2017 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** Create a SRIOV. *)
+val create :
+  __context:Context.t ->
+  pif:[ `PIF ] Ref.t ->
+  network:[ `network ] Ref.t ->
+  [ `NET_sriov ] Ref.t
+
+
+(** Destroy a SRIOV. *)
+val destroy : __context:Context.t -> self:[ `NET_sriov ] Ref.t -> unit
+
+
+
+

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -353,7 +353,8 @@ let pool_introduce
       ~mAC ~mTU ~vLAN ~metrics
       ~physical ~currently_attached:false ~igmp_snooping_status:`unknown
       ~ip_configuration_mode ~iP ~netmask ~gateway ~dNS
-      ~bond_slave_of:Ref.null ~vLAN_master_of ~management
+      ~bond_slave_of:Ref.null ~vLAN_master_of ~sriov_master_of:Ref.null
+      ~sriov_slave_of:Ref.null ~management
       ~other_config ~disallow_unplug ~ipv6_configuration_mode
       ~iPv6 ~ipv6_gateway ~primary_address_type ~managed ~properties ~capabilities:[] in
   pif_ref
@@ -392,7 +393,8 @@ let introduce_internal
       ~device ~device_name:device ~network:net_ref ~host ~mAC
       ~mTU ~vLAN ~metrics ~physical ~currently_attached:false ~igmp_snooping_status:`unknown
       ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:""
-      ~dNS:"" ~bond_slave_of:Ref.null ~vLAN_master_of ~management:false
+      ~dNS:"" ~bond_slave_of:Ref.null ~vLAN_master_of ~sriov_master_of:Ref.null
+      ~sriov_slave_of:Ref.null ~management:false
       ~other_config:[] ~disallow_unplug ~ipv6_configuration_mode:`None
       ~iPv6:[] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed
       ~properties:default_properties ~capabilities:capabilities in

--- a/ocaml/xapi/xapi_tunnel.ml
+++ b/ocaml/xapi/xapi_tunnel.ml
@@ -41,7 +41,8 @@ let create_internal ~__context ~transport_PIF ~network ~host =
     ~device ~device_name ~network ~host ~mAC ~mTU:(-1L) ~vLAN:(-1L) ~metrics
     ~physical:false ~currently_attached:false ~igmp_snooping_status:`unknown
     ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
-    ~vLAN_master_of:Ref.null ~management:false ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
+    ~vLAN_master_of:Ref.null ~sriov_master_of:Ref.null ~sriov_slave_of:Ref.null
+    ~management:false ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
     ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true ~properties:[] ~capabilities:[];
   Db.Tunnel.create ~__context ~ref:tunnel ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
     ~access_PIF ~transport_PIF ~status:["active", "false"] ~other_config:[];

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -235,8 +235,8 @@ let create ~__context ~device ~network ~vM
            ~runtime_properties:[] ~other_config
            ~metrics ~locking_mode
            ~ipv4_allowed ~ipv6_allowed
-           ~ipv4_configuration_mode ~ipv4_addresses ~ipv4_gateway 
-           ~ipv6_configuration_mode ~ipv6_addresses ~ipv6_gateway in ()
+           ~ipv4_configuration_mode ~ipv4_addresses ~ipv4_gateway
+           ~ipv6_configuration_mode ~ipv6_addresses ~ipv6_gateway ~attached_pci:Ref.null in ()
     );
   update_allowed_operations ~__context ~self:ref;
   debug "VIF ref='%s' created (VM = '%s'; MAC address = '%s')" (Ref.string_of ref) (Ref.string_of vM) mAC; 

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -35,7 +35,8 @@ let create_internal ~__context ~host ~tagged_PIF ~tag ~network ~device =
     ~device ~device_name:device ~network ~host ~mAC:vlan_mac ~mTU ~vLAN:tag ~metrics
     ~physical:false ~currently_attached:false ~igmp_snooping_status:`unknown
     ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
-    ~vLAN_master_of:vlan ~management:false ~other_config:[] ~disallow_unplug:false
+    ~vLAN_master_of:vlan ~sriov_master_of:Ref.null ~sriov_slave_of:Ref.null ~management:false
+    ~other_config:[] ~disallow_unplug:false
     ~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true
     ~properties:[] ~capabilities:[];
 


### PR DESCRIPTION
1. Add net SR-IOV object
2. Add required fields when creating pif/vif object
3. Add net sriov cli interface for create/destroy
4. Add faked SRIOV module in api-server and xapi_net_sriov signature simultaneously. (Implementation of this module will submit in another PR in the future)

Signed-off-by: Min Li <min.li1@citrix.com>
Signed-off-by: Yang Qian <yang.qian@citrix.com>