### PR TITLE
CA-274079: Removing one Pusb removes all Pusbs in the pool

### DIFF
--- a/ocaml/xapi/xapi_pusb.ml
+++ b/ocaml/xapi/xapi_pusb.ml
@@ -31,10 +31,12 @@ let create ~__context ~uSB_group ~host ~other_config ~path
 
 let scan_start ~__context usbs =
   let host = Helpers.get_localhost ~__context in
-  let known_usb =
+  let local_pusb_records =
     Db.PUSB.get_all_records ~__context
     |> List.filter (fun (rf, rc) -> rc.API.pUSB_host = host)
-    |> get_known_usb
+  in
+  let known_usb =
+    local_pusb_records |> get_known_usb
   in
   let local_usb = get_local_usb usbs in
   (* Create the newly added pusbs *)
@@ -45,7 +47,7 @@ let scan_start ~__context usbs =
                Db.PUSB.set_USB_group ~__context ~self ~value:group
   ) (USBSet.diff local_usb known_usb);
 
-  List.filter (fun (rf, rc) -> USBSet.mem (extract_known_usb_info rc) (USBSet.diff known_usb local_usb)) (Db.PUSB.get_all_records ~__context)
+  List.filter (fun (rf, rc) -> USBSet.mem (extract_known_usb_info rc) (USBSet.diff known_usb local_usb)) local_pusb_records
   |> List.iter (fun (self, _) ->
                   try
                     Xapi_pusb_helpers.destroy_pusb ~__context self;

--- a/ocaml/xapi/xapi_pusb.ml
+++ b/ocaml/xapi/xapi_pusb.ml
@@ -30,6 +30,11 @@ let create ~__context ~uSB_group ~host ~other_config ~path
   pusb
 
 let scan_start ~__context usbs =
+  (* We compute two sets and operate on them:
+     (1) Local USB devices that are not yet in the database - we create entries for them.
+     (2) USB devices only present in the database for the local host - we delete
+     them from the database.
+  *)
   let host = Helpers.get_localhost ~__context in
   let known_pusbs_in_db =
     Db.PUSB.get_all_records ~__context

--- a/ocaml/xapi/xapi_pusb.ml
+++ b/ocaml/xapi/xapi_pusb.ml
@@ -31,23 +31,23 @@ let create ~__context ~uSB_group ~host ~other_config ~path
 
 let scan_start ~__context usbs =
   let host = Helpers.get_localhost ~__context in
-  let local_pusb_records =
+  let known_pusbs_in_db =
     Db.PUSB.get_all_records ~__context
     |> List.filter (fun (rf, rc) -> rc.API.pUSB_host = host)
   in
-  let known_usb =
-    local_pusb_records |> get_known_usb
+  let known_usb_set =
+    known_pusbs_in_db |> get_known_usb
   in
-  let local_usb = get_local_usb usbs in
+  let local_usb_set = get_local_usb usbs in
   (* Create the newly added pusbs *)
   USBSet.iter (fun s -> let self = create ~__context ~uSB_group:(Ref.null) ~host ~other_config:[] ~path:s.USB.path ~vendor_id:s.USB.vendor_id
                    ~vendor_desc:s.USB.vendor_desc ~product_id:s.USB.product_id ~product_desc:s.USB.product_desc ~serial:s.USB.serial
                    ~version:s.USB.version ~description:s.USB.description in
                let group = Xapi_pusb_helpers.find_or_create ~__context self in
                Db.PUSB.set_USB_group ~__context ~self ~value:group
-  ) (USBSet.diff local_usb known_usb);
+  ) (USBSet.diff local_usb_set known_usb_set);
 
-  List.filter (fun (rf, rc) -> USBSet.mem (extract_known_usb_info rc) (USBSet.diff known_usb local_usb)) local_pusb_records
+  List.filter (fun (rf, rc) -> USBSet.mem (extract_known_usb_info rc) (USBSet.diff known_usb_set local_usb_set)) known_pusbs_in_db
   |> List.iter (fun (self, _) ->
                   try
                     Xapi_pusb_helpers.destroy_pusb ~__context self;


### PR DESCRIPTION
Two exactly same pusbs in two hosts of a pool will be deleted when
unplug one of the pusbs, this change is to fix it.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>