### PR TITLE
CA-270463 block VM suspend if vGPU driver doesn't support it

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -239,27 +239,27 @@ let check_pci ~op ~ref_str =
   | _ -> None
 
 let check_vgpu ~__context ~op ~ref_str ~vgpus =
+  let vgpu_migration_enabled () =
+    let pool = Helpers.get_pool ~__context in
+    let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
+    try
+      List.assoc "restrict_vgpu_migration" restrictions = "false"
+    with Not_found -> false
+  in
+  let all_nvidia_vgpus () =
+    List.fold_left
+      (fun acc vgpu ->
+         let vgpu_type = Db.VGPU.get_type ~__context ~self:vgpu in
+         let implementation =
+           Db.VGPU_type.get_implementation ~__context ~self:vgpu_type in
+         acc && (implementation = `nvidia))
+      true vgpus
+  in
   match op with
-  | `pool_migrate | `migrate_send | `suspend | `checkpoint -> begin
-      let vgpu_migration_enabled =
-        let pool = Helpers.get_pool ~__context in
-        let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
-        try
-          List.assoc "restrict_vgpu_migration" restrictions = "false"
-        with Not_found -> false
-      in
-      let all_nvidia_vgpus =
-        List.fold_left
-          (fun acc vgpu ->
-             let vgpu_type = Db.VGPU.get_type ~__context ~self:vgpu in
-             let implementation =
-               Db.VGPU_type.get_implementation ~__context ~self:vgpu_type in
-             acc && (implementation = `nvidia))
-          true vgpus
-      in
-      if vgpu_migration_enabled && all_nvidia_vgpus then None
-      else Some (Api_errors.vm_has_vgpu, [ref_str])
-    end
+  | `pool_migrate | `migrate_send | `suspend | `checkpoint
+    when vgpu_migration_enabled () && all_nvidia_vgpus () -> None
+  | `pool_migrate | `migrate_send | `suspend | `checkpoint ->
+    Some (Api_errors.vm_has_vgpu, [ref_str])
   | _ -> None
 
 (* VM cannot be converted into a template while it is a member of an appliance. *)


### PR DESCRIPTION
Suspending a VM must be blocked if the vGPU driver does not support it. This PR extends xapi_vm_lifecycle.check_vgpu() to check for it. The check implements a heuristic: if a pGPU does not provide metadata for compatibility checks (that are required when resuming the VM on a host), we assume suspending is not supported.

This PR refactors the existing code to use `List.for_all` for checking that all vGPUs have the necessary properties.

This has been manually tested: a VM using a vGPU driver that does not provide compatibility metadata can't be suspended because it is not an allowed operation.