### PR TITLE
xapi-datamodel: add missing dependency on mustache

### DIFF
--- a/xapi-datamodel.opam
+++ b/xapi-datamodel.opam
@@ -15,4 +15,5 @@ depends: [
   "xapi-database"
   "xapi-libs-transitional"
   "xenstore"
+  "mustache"
 ]


### PR DESCRIPTION
When setting up an empty ocaml switch and installing the dependencies of `xapi` it failed with:
```
### stderr ###
#        ocaml (internal)
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /local/home/edwin/.opam/coverage/lib/ocaml, /local/home/edwin/.opam/coverage/lib/ocaml/compiler-libs
#        ocaml (internal)
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /local/home/edwin/.opam/coverage/lib/ocaml, /local/home/edwin/.opam/coverage/lib/ocaml/compiler-libs
# Error: External library "mustache" not found.
# -> required by "ocaml/idl/jbuild (context default)"
# Hint: try: jbuilder external-lib-deps --missing -p xapi-datamodel @install
```