### PR TITLE
CA-271874: Local-to-local storage migration using CLI, without specif…

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2844,19 +2844,27 @@ let vm_migrate printer rpc session_id params =
              vgpu,gpu_group) (read_map_params "vgpu" params) in
 
          let preferred_sr =
+           (* The preferred SR is determined to be as the SR that the destine host has a PDB attached to it,
+              and among the choices of that the shared is preferred first(as it is recommended to have shared storage
+              in pool to host VMs), and then the one with the maximum available space *)
            try
-             let query = Printf.sprintf "(field \"host\"=\"%s\") and (field \"currently_attached\"=\"true\")" (Ref.string_of host) in
+             let query = Printf.sprintf {|(field "host"="%s") and (field "currently_attached"="true")|} (Ref.string_of host) in
              let host_pbds = Client.PBD.get_all_records_where remote_rpc remote_session query in
-             let srs = List.map (fun (pbd_ref, pbd_rec) -> sr_record remote_rpc remote_session pbd_rec.API.pBD_SR) host_pbds in
+             let srs = List.map (fun (pbd_ref, pbd_rec) -> 
+               pbd_rec.API.pBD_SR, Client.SR.get_record remote_rpc remote_session pbd_rec.API.pBD_SR) host_pbds in
+             (* In the following loop, the current SR:sr' will be compared with previous checked ones, 
+                first if it is an ISO type, then pass this one for selection, then the only shared one from this and
+                prevoius one will be valued, and if not that case (both shared or none shared), choose the one with
+                more space available *)
              let (sr, free_space) = List.fold_left (fun (sr, free_space) sr' ->
-               let sr_rec' = sr'.record () in
+               let sr_rec' = snd sr' in
                if sr_rec'.API.sR_content_type = "iso" then (sr, free_space)
                else
                  let free_space' = Int64.sub sr_rec'.API.sR_physical_size sr_rec'.API.sR_physical_utilisation in
                  match sr with
                  | None -> (Some sr', free_space')
                  | Some sr ->
-                   let sr_rec = sr.record () in
+                   let sr_rec = snd sr in
                    match sr_rec.API.sR_shared, sr_rec'.API.sR_shared with
                    | true, false -> (Some sr, free_space)
                    | false, true -> (Some sr', free_space')
@@ -2864,7 +2872,7 @@ let vm_migrate printer rpc session_id params =
                           else (Some sr, free_space)
                ) (None, Int64.zero) srs in
              match sr with
-             | Some sr -> Some (sr.getref ())
+             | Some sr -> Some (fst sr)
              | _ -> None
            with _ -> None in
 


### PR DESCRIPTION
CA-271874: Local-to-local storage migration using CLI, without specifying VDI-map, fails badly

The issue is regarding the way the default SR is chosen, when no VDI mapping is provided. The current behavior is the default SR of the destine pool will be chosen. However in case of none shared SR in pool and the SR is not on the destine host, there will be problem.

The fix will change the strategy to choose an SR, in that SRs will be chosing based on the PBD the destine host is attached, shared preferred, excluding iso type.

Signed-off-by: Yarsin He <yarsin.he@citrix.com>