### PR TITLE
CA-273306: assert the correct VM power_state during VM.checkpoint

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -239,27 +239,27 @@ let check_pci ~op ~ref_str =
   | _ -> None
 
 let check_vgpu ~__context ~op ~ref_str ~vgpus =
+  let vgpu_migration_enabled () =
+    let pool = Helpers.get_pool ~__context in
+    let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
+    try
+      List.assoc "restrict_vgpu_migration" restrictions = "false"
+    with Not_found -> false
+  in
+  let all_nvidia_vgpus () =
+    List.fold_left
+      (fun acc vgpu ->
+         let vgpu_type = Db.VGPU.get_type ~__context ~self:vgpu in
+         let implementation =
+           Db.VGPU_type.get_implementation ~__context ~self:vgpu_type in
+         acc && (implementation = `nvidia))
+      true vgpus
+  in
   match op with
-  | `pool_migrate | `migrate_send | `suspend | `checkpoint -> begin
-      let vgpu_migration_enabled =
-        let pool = Helpers.get_pool ~__context in
-        let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
-        try
-          List.assoc "restrict_vgpu_migration" restrictions = "false"
-        with Not_found -> false
-      in
-      let all_nvidia_vgpus =
-        List.fold_left
-          (fun acc vgpu ->
-             let vgpu_type = Db.VGPU.get_type ~__context ~self:vgpu in
-             let implementation =
-               Db.VGPU_type.get_implementation ~__context ~self:vgpu_type in
-             acc && (implementation = `nvidia))
-          true vgpus
-      in
-      if vgpu_migration_enabled && all_nvidia_vgpus then None
-      else Some (Api_errors.vm_has_vgpu, [ref_str])
-    end
+  | `pool_migrate | `migrate_send | `suspend | `checkpoint
+    when vgpu_migration_enabled () && all_nvidia_vgpus () -> None
+  | `pool_migrate | `migrate_send | `suspend | `checkpoint ->
+    Some (Api_errors.vm_has_vgpu, [ref_str])
   | _ -> None
 
 (* VM cannot be converted into a template while it is a member of an appliance. *)


### PR DESCRIPTION
    The `xapi_vgpu.create` function expects that the passed vm record is always
    in the Halted power_state. However, during a VM.checkpoint, the power_state
    of the VM is Suspended and causes the internal Halted assertion to fail.
 
    This commit creates an internal `create'` function that parameterizes the
    expected power_state. This parameter is then used by the existing functions:
    * The original `xapi_vgpu.create` function behaves exactly as before, and it
    continues to "expect" the Halted power_state at all times.
    * The `xapi_vgpu.copy` function, called during VM snapshot, checkpoint and
    clone, expects the power_state of the VM associated with the VGPU, which
    conforms with the following successfully tested values:
 
    | Operation                 | expected VM power_state during VGPU.copy |
    +---------------------------+------------------------------------------+
    | VM.checkpoint             | Suspended                                |
    | VM.snapshot               | Halted                                   |
    | VM.revert_from_checkpoint | Halted                                   |
    | VM.clone                  | Halted                                   |