### PR TITLE
API: more strict typing for 'a Ref.t conversions from Rpc.t

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -143,8 +143,8 @@ let gen_client_types highapi =
         ]; [
           "module Ref = struct";
           "  include Ref";
-          "  let rpc_of_t _ x = rpc_of_string (Ref.string_of x)";
-          "  let t_of_rpc _ x = of_string (string_of_rpc x);";
+          "  let rpc_of_t (_:'a -> Rpc.t) (x: 'a Ref.t) = rpc_of_string (Ref.string_of x)";
+          "  let t_of_rpc (_:Rpc.t -> 'a) x : 'a t = of_string (string_of_rpc x);";
           "end";
         ]; [
           "module Date = struct";

--- a/ocaml/xapi/cpuid_helpers.mli
+++ b/ocaml/xapi/cpuid_helpers.mli
@@ -31,7 +31,7 @@ val assert_vm_is_compatible :
   __context:Context.t ->
   vm:[ `VM ] API.Ref.t ->
   host:[ `host ] API.Ref.t ->
-  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * 'a Ref.t -> unit -> unit
+  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * [<`session] Ref.t -> unit -> unit
 
 val extend : int64 array -> int64 array -> int64 array
 val zero_extend : int64 array -> int -> int64 array

--- a/ocaml/xapi/xapi_pgpu_helpers.mli
+++ b/ocaml/xapi/xapi_pgpu_helpers.mli
@@ -66,4 +66,4 @@ val assert_destination_pgpu_is_compatible_with_vm :
   vm:API.ref_VM ->
   vgpu_map:(API.ref_VGPU * API.ref_GPU_group) list ->
   host:API.ref_host ->
-  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * 'a Ref.t -> unit -> unit
+  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * [<`session] Ref.t -> unit -> unit

--- a/ocaml/xapi/xapi_vdi.mli
+++ b/ocaml/xapi/xapi_vdi.mli
@@ -165,7 +165,7 @@ val clone :
 val copy :
   __context:Context.t ->
   vdi:[ `VDI ] API.Ref.t ->
-  sr:'a Ref.t ->
+  sr:[<`SR] Ref.t ->
   base_vdi:API.ref_VDI ->
   into_vdi:[ `VDI ] API.Ref.t Client.Id.t -> [ `VDI ] API.Ref.t Client.Id.t
 val force_unlock : __context:'a -> vdi:'b -> 'c

--- a/ocaml/xapi/xapi_vm_clone.mli
+++ b/ocaml/xapi/xapi_vm_clone.mli
@@ -42,7 +42,7 @@ val make_driver_params:
  * same order as the [vbds] parameter. *)
 val safe_clone_disks:
   (Rpc.call -> Rpc.response Client.Id.t) ->
-  'a Ref.t ->
+  [<`session] Ref.t ->
   disk_op_t ->
   __context:Context.t ->
   [ `VBD ] API.Ref.t list ->
@@ -52,10 +52,10 @@ val safe_clone_disks:
 val clone_single_vdi:
   ?progress:int64 * int64 * float ->
   (Rpc.call -> Rpc.response Client.Id.t) ->
-  'a Ref.t ->
+  [<`session] Ref.t ->
   disk_op_t ->
   __context:Context.t ->
-  'b Ref.t -> (string * string) list ->
+  [<`VDI] Ref.t -> (string * string) list ->
   API.ref_VDI
 
 (* NB this function may be called when the VM is suspended for copy/clone operations. Snapshot can be done in live.*)


### PR DESCRIPTION
[`Foo] Ref.t and [`Bar] Ref.t were both accepted in rpc_of_ref_foo, becase it was
accepting 'a Ref.t.
They are strings underneath so this was working but could lead to bugs not being
detected at compile time: such as looking up the wrong object by uuid, and then passing it to a create function on another object.

Annotate the generated rpc_of_t and t_of_rpc functions to make sure that the
ignored value is of the right type.
Now rpc_of_ref_foo accepts only [`Foo] Ref.t.

Update some interfaces that are now more strictly typed.
