### PR TITLE
CP-26076 block VM.checkpoint on any VM with a vGPU

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -258,7 +258,7 @@ let check_vgpu ~__context ~op ~ref_str ~vgpus =
     | _ -> false
   in
   match op with
-  | `pool_migrate | `migrate_send | `suspend | `checkpoint
+  | `pool_migrate | `migrate_send | `suspend
     when vgpu_migration_enabled ()
       && List.for_all is_suspendable vgpus -> None
   | `pool_migrate | `migrate_send | `suspend | `checkpoint ->


### PR DESCRIPTION
Checkpoint-ing a VM has been permitted for VMs/vGPUs that support
migration. I always has been blocked for all other VMs/vGPUs.  This
commit removes the ability to checkpoint a VM/vGPU that can be migrated
and suspended.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>