### PR TITLE
CA-274957: simplify and reorganise Nvidia VGPU compatibility check

### DIFF
--- a/ocaml/xapi/xapi_pgpu_helpers.ml
+++ b/ocaml/xapi/xapi_pgpu_helpers.ml
@@ -238,7 +238,7 @@ let assert_destination_has_pgpu_compatible_with_vm ~__context ~vm ~vgpu_map ~hos
     ) vgpu_map;
 
   (* Check that there is a potential pgpu candidate for each of the other vgpus *)
+  let pgpus = get_pgpus_of_host host in
   List.iter (fun vgpu -> 
-      let pgpus = get_pgpus_of_host host in
       test_compatibility vgpu pgpus
     ) unmapped

--- a/ocaml/xapi/xapi_pgpu_helpers.mli
+++ b/ocaml/xapi/xapi_pgpu_helpers.mli
@@ -58,10 +58,21 @@ val assert_capacity_exists_for_VGPU_type :
   self:API.ref_PGPU ->
   vgpu_type:API.ref_VGPU_type -> unit
 
-(** Check that the host has a PGPU compatible with the VM VGPU.
+(** Check that the PGPU selected is compatible with the VM VGPU.
  *  Currently checks only nvml compatibility if Nvidia VGPUs 
  *  are detected. *)
 val assert_destination_pgpu_is_compatible_with_vm :
+  __context:Context.t ->
+  vm:API.ref_VM ->
+  vgpu:API.ref_VGPU ->
+  pgpu:API.ref_PGPU ->
+  host:API.ref_host ->
+  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * 'a Ref.t -> unit -> unit
+
+(** Check that the host has a PGPU compatible with the VM VGPU.
+ *  Currently checks only nvml compatibility if Nvidia VGPUs 
+ *  are detected. *)
+val assert_destination_has_pgpu_compatible_with_vm : 
   __context:Context.t ->
   vm:API.ref_VM ->
   vgpu_map:(API.ref_VGPU * API.ref_GPU_group) list ->

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -248,15 +248,14 @@ let pool_migrate ~__context ~vm ~host ~options =
 
   (* Check pGPU compatibility for Nvidia vGPUs - at this stage we already know
    * the vgpu <-> pgpu mapping. *)
-  let vgpus_map = List.map
-      (fun vgpu ->
-         let pgpu = Db.VGPU.get_scheduled_to_be_resident_on ~__context ~self:vgpu in
-         vgpu, pgpu)
-      (Db.VM.get_VGPUs ~__context ~self:vm)
-  in
-  List.iter (fun (vgpu, pgpu) ->
-      Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context ~vm ~host ~vgpu ~pgpu ()
-    ) vgpus_map;
+  Db.VM.get_VGPUs ~__context ~self:vm
+  |> List.map
+    (fun vgpu ->
+       vgpu, Db.VGPU.get_scheduled_to_be_resident_on ~__context ~self:vgpu)
+  |> List.iter (fun (vgpu, pgpu) ->
+      Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context
+        ~vm ~host ~vgpu ~pgpu ()
+    );
 
   Xapi_xenops.Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid (fun () ->
       try

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -246,8 +246,17 @@ let pool_migrate ~__context ~vm ~host ~options =
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
   let xenops_vgpu_map = infer_vgpu_map ~__context vm in
 
-  (* Check pGPU compatibility for Nvidia vGPUs *)
-  Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context ~vm ~host ~vgpu_map:[] ();
+  (* Check pGPU compatibility for Nvidia vGPUs - at this stage we already know
+   * the vgpu <-> pgpu mapping. *)
+  let vgpus_map = List.map
+      (fun vgpu ->
+         let pgpu = Db.VGPU.get_scheduled_to_be_resident_on ~__context ~self:vgpu in
+         vgpu, pgpu)
+      (Db.VM.get_VGPUs ~__context ~self:vm)
+  in
+  List.iter (fun (vgpu, pgpu) ->
+      Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context ~vm ~host ~vgpu ~pgpu ()
+    ) vgpus_map;
 
   Xapi_xenops.Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid (fun () ->
       try
@@ -1244,7 +1253,7 @@ let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu
     | `intra_pool -> None
     | `cross_pool -> Some (remote.rpc, remote.session)
   in
-  Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm ~__context
+  Xapi_pgpu_helpers.assert_destination_has_pgpu_compatible_with_vm ~__context
     ~vm ~vgpu_map ~host:remote.dest_host ?remote:remote_for_migration_type ()
 
 let migrate_send  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map =


### PR DESCRIPTION
The function `assert_destination_pgpu_is_compatible_with_vm`
had a heuristic to select the destination pgpu that was
filtering over vgpu implementation, however this is `nvidia`
for any Nvidia card, resulting in potentially meaningless
choices.

The function was also assuming that the user-defined
vgpu_map was complete (all vgpus would be mapped) but
this is often not the case.

The function was called in two migration places, in one
we had preselected the pgpu, making any heuristic
a potential source of errors.

This commit splits the check into two assertions:
- `assert_destination_pgpu_is_compatible_with_vm`, to be called
  when the destination pgpu has already been selected
- `assert_destination_has_pgpu_compatible_with_vm`, using
  a heuristic (based on the one used by vm-import) to
  select a suitable pgpu group.

The new heuristic selects a gpu group by filtering
over the gpu types, making sure that the destination
group is compatible with the origin group.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>