### PR TITLE
xapi: oPasswd -> opasswd for support to version 1.0.2

### DIFF
--- a/ocaml/xapi/jbuild
+++ b/ocaml/xapi/jbuild
@@ -66,7 +66,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (package xapi)
   (flags (:standard -bin-annot %s -warn-error +a-3-4-6-9-27-28-29-52))
   (libraries (
-   oPasswd
+   opasswd
    pam
    pciutil
    pci


### PR DESCRIPTION
This depends on https://github.com/xapi-project/xs-opam/pull/179
Build will be broken until that is released

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>