### PR TITLE
CP-26145: prevent vgpu-migration of VMs between pre-Jura and Jura/later hosts during RPU

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -618,6 +618,8 @@ let sort_by_schwarzian ?(descending=false) f list =
   List.sort (fun (_, x') (_, y') -> comp x' y') |>
   List.map (fun (x, _) -> x)
 
+let platform_version_inverness = [2;4;0]
+
 let version_string_of : __context:Context.t -> [`host] api_object -> string =
   fun ~__context host ->
     try


### PR DESCRIPTION
This patch attempts a best-effort approach to detect if the host the VM is
attempting to vgpu-migrate from is Jura or later. If this sending host is
earlier than Jura, it prevents the vgpu-migrating capability for the VM so that
the migration operation will not be allowed for this VM. This is specially
useful during an RPU, where in the same pool the master will be running the new
updated Jura code with this patch but the slaves not and vgpu-migration cannot
be allowed because it's known to deliberately fail between pre-Jura and
Jura/later hosts.

Other similar VM lifecycle operations (suspend, checkpoint) are still allowed
since they don't involve moving the VM to another host using an incompatible
vgpu-migration protocol.

This patch **_REQUIRES_** that Jura and later hosts use a platform_version that
is strictly greater than (>) the value 2.4.0.

This patch does not prevent cross-pool vgpu-migration between pre-Jura and
Jura/later hosts.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>

---
Merge dependencies:

- Please only merge this patch after https://github.com/xapi-project/xenopsd/pull/432 has been merged.
- Please only merge this patch after the platform_version has been updated to 2.4.1 or greater (CP-26171).