### PR TITLE
Fix type of assert_destination_pgpu_is_compatible_with_vm

### DIFF
--- a/ocaml/xapi/xapi_pgpu_helpers.mli
+++ b/ocaml/xapi/xapi_pgpu_helpers.mli
@@ -67,7 +67,7 @@ val assert_destination_pgpu_is_compatible_with_vm :
   vgpu:API.ref_VGPU ->
   pgpu:API.ref_PGPU ->
   host:API.ref_host ->
-  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * 'a Ref.t -> unit -> unit
+  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * [<`session] Ref.t -> unit -> unit
 
 (** Check that the host has a PGPU compatible with the VM VGPU.
  *  Currently checks only nvml compatibility if Nvidia VGPUs 
@@ -77,4 +77,4 @@ val assert_destination_has_pgpu_compatible_with_vm :
   vm:API.ref_VM ->
   vgpu_map:(API.ref_VGPU * API.ref_GPU_group) list ->
   host:API.ref_host ->
-  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * 'a Ref.t -> unit -> unit
+  ?remote:(Rpc.call -> Rpc.response Client.Id.t) * [<`session] Ref.t -> unit -> unit


### PR DESCRIPTION
This fix limits the type of
assert_destination_pgpu_is_compatible_with_vm in the interface (MLI)
file to be more specific. This is required to make it compile after
rebasing onto more recent versions of Xapi.

  'a Ref.t becomes [<`session] Ref.t

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>