### PR TITLE
CA-276638: Quicktest_cbt: don't fail in cleanup due to VDI refs becoming invalid

### DIFF
--- a/ocaml/xapi/quicktest_cbt.ml
+++ b/ocaml/xapi/quicktest_cbt.ml
@@ -215,11 +215,12 @@ let test ~session_id =
            begin
              debug cbt_test "Destroying VDIs created in test. . .";
              (VDI.get_all ~session_id ~rpc:!rpc)
-             |> List.filter
+             (* Avoid invalid reference errors due to SM removing VDIs from DB *)
+             |> Valid_ref_list.filter
                (fun vdi -> (VDI.get_name_label ~session_id ~rpc:!rpc ~self:vdi = name_label)
                            && (VDI.get_name_description ~session_id ~rpc:!rpc ~self:vdi = name_description)
                )
-             |> List.iter (fun vdi -> VDI.destroy ~session_id ~rpc:!rpc ~self:vdi);
+             |> Valid_ref_list.iter (fun vdi -> VDI.destroy ~session_id ~rpc:!rpc ~self:vdi);
              debug cbt_test "Successfully destroyed all VDIs created for CBT test\n"
            end
         ) in

--- a/ocaml/xapi/test_valid_ref_list.ml
+++ b/ocaml/xapi/test_valid_ref_list.ml
@@ -91,6 +91,15 @@ let test_filter_map =
       | _ -> failwith "The test list should contain 4 VMs"
     )
 
+let test_iter =
+  with_vm_list (fun __context l ->
+      let processed = ref [] in
+      let f vm =
+        processed := !processed @ [(Db.VM.get_name_label ~__context ~self:vm)]
+      in
+      Valid_ref_list.iter f l;
+      assert_equal ["a"; "d"] !processed
+    )
 
 let test =
   let ((>:::), (>::)) = OUnit.((>:::), (>::)) in
@@ -101,4 +110,5 @@ let test =
   ; "test_for_all" >:: test_for_all
   ; "test_flat_map" >:: test_flat_map
   ; "test_filter_map" >:: test_filter_map
+  ; "test_iter" >:: test_iter
   ]

--- a/ocaml/xapi/valid_ref_list.ml
+++ b/ocaml/xapi/valid_ref_list.ml
@@ -14,6 +14,8 @@ let for_all f l = not (exists (fun x -> not @@ f x) l)
 
 let map f = Stdext.Listext.List.filter_map (default_on_missing_ref (fun x -> Some (f x)) None)
 
+let iter f = List.iter (default_on_missing_ref f ())
+
 let flat_map f l = List.map (default_on_missing_ref f []) l |> List.flatten
 
 let filter_map f l = map f l |> List.filter ((<>) None) |> List.map Xapi_stdext_monadic.Opt.unbox

--- a/ocaml/xapi/valid_ref_list.mli
+++ b/ocaml/xapi/valid_ref_list.mli
@@ -8,6 +8,8 @@ val for_all : ('a -> bool) -> 'a list -> bool
 
 val map : ('a -> 'b) -> 'a list -> 'b list
 
+val iter : ('a -> unit) -> 'a list -> unit
+
 val flat_map : ('a -> 'b list) -> 'a list -> 'b list
 
 val filter_map : ('a -> 'b option) -> 'a list -> 'b list


### PR DESCRIPTION
There is a race condition where we get the list of VDIs, but before we
process them some of them get removed from the DB, and the cleanup fails
with an invalid ref error.

This can happen for example when SM creates an internal VDI record in
the DB, and then later it removes it, in parallel with the cleanup at
the end of the CBT quicktest.