### PR TITLE
cdrommon: fix incorred dependencies

### DIFF
--- a/ocaml/cdrommon/cdrommon.ml
+++ b/ocaml/cdrommon/cdrommon.ml
@@ -61,6 +61,6 @@ let () =
     Printf.eprintf "usage: %s <cdrompath>\n" Sys.argv.(0);
     exit 1
   );
-  Stdext.Unixext.daemonize ();
+  Xapi_stdext_unix.Unixext.daemonize ();
   (* check every 2 seconds *)
   check 2 Sys.argv.(1)

--- a/ocaml/cdrommon/jbuild
+++ b/ocaml/cdrommon/jbuild
@@ -3,10 +3,11 @@
   (public_name cdrommon)
   (package xapi)
   (libraries (
-   unix
    cdrom
-   xcp-inventory
    threads
+   unix
+   xapi-stdext-unix
+   xcp-inventory
   ))
  )
 )


### PR DESCRIPTION
This was exposed by the new release of xcp-inventory.
Signed-off-by: Marcello Seri <marcello.seri@citrix.com>