### PR TITLE
xapi-database: add missing xapi-stdext dependency

### DIFF
--- a/ocaml/database/jbuild
+++ b/ocaml/database/jbuild
@@ -31,7 +31,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    block_device_io
   ))
   (libraries (
-   ppx_deriving_rpc
+   stdext
    rpclib
    ppx_sexp_conv
    sexpr

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -13,4 +13,5 @@ depends: [
   "ppx_sexp_conv"
   "xapi-libs-transitional"
   "xapi-idl"
+  "xapi-stdext"
 ]


### PR DESCRIPTION
And remove duplicated `ppx_deriving_rpc`

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>
