### PR TITLE
xapi-types, xapi-database, idl: fix transitive dependencies issues

### DIFF
--- a/ocaml/database/backend_xml.ml
+++ b/ocaml/database/backend_xml.ml
@@ -24,7 +24,7 @@ let unmarshall schema dbconn =
   then Db_xml.From.file schema filename
   else
     let compressed = Unix.openfile filename [ Unix.O_RDONLY ] 0o0 in
-    Stdext.Pervasiveext.finally
+    Xapi_stdext_pervasives.Pervasiveext.finally
       (fun () ->
          let result = ref None in
          Gzip.decompress_passive compressed
@@ -50,11 +50,12 @@ let populate schema dbconn =
    current state of the global in-memory cache *)
 
 let flush dbconn db =
+  let open Xapi_stdext_unix in
   let time = Unix.gettimeofday() in
 
   let do_flush_xml db filename =
     Redo_log.flush_db_to_all_active_redo_logs db;
-    Stdext.Unixext.atomic_write_to_file filename 0o0644
+    Unixext.atomic_write_to_file filename 0o0644
       (fun fd ->
          if not dbconn.Parse_db_conf.compress
          then Db_xml.To.fd fd db
@@ -65,7 +66,7 @@ let flush dbconn db =
 
   let do_flush_gen db filename =
     let generation = Manifest.generation (Database.manifest db) in
-    Stdext.Unixext.write_string_to_file filename (Generation.to_string generation) in
+    Unixext.write_string_to_file filename (Generation.to_string generation) in
 
   let filename = dbconn.Parse_db_conf.path in
   do_flush_xml db filename;

--- a/ocaml/database/block_device_io.ml
+++ b/ocaml/database/block_device_io.ml
@@ -88,8 +88,8 @@
  *               "empty|nack"  otherwise
  *)
 
-open Stdext
-open Pervasiveext
+open Xapi_stdext_pervasives.Pervasiveext
+open Xapi_stdext_unix
 
 let name = "block_device_io"
 module R = Debug.Make(struct let name = name end)

--- a/ocaml/database/db_backend.ml
+++ b/ocaml/database/db_backend.ml
@@ -69,7 +69,7 @@ let blow_away_non_persistent_fields (schema: Schema.t) db =
 let db_registration_mutex = Mutex.create ()
 let foreign_databases: ((string, Db_ref.t) Hashtbl.t) = Hashtbl.create 5
 
-open Stdext.Threadext
+open Xapi_stdext_threads.Threadext
 let create_registered_session create_session db_ref =
   Mutex.execute db_registration_mutex
     (fun () ->

--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -63,7 +63,7 @@ let read_field t tblname fldname objref =
 (** occurs.                                                    *)
 let ensure_utf8_xml string =
   let length = String.length string in
-  let prefix = Stdext.Encodings.UTF8_XML.longest_valid_prefix string in
+  let prefix = Xapi_stdext_encodings.Encodings.UTF8_XML.longest_valid_prefix string in
   if length > String.length prefix then
     warn "string truncated to: '%s'." prefix;
   prefix
@@ -297,7 +297,7 @@ let load connections default_schema =
     | None -> db in (* empty *)
 
   let empty = Database.update_manifest (Manifest.update_schema (fun _ -> Some (default_schema.Schema.major_vsn, default_schema.Schema.minor_vsn))) (Database.make default_schema) in
-  let open Stdext.Fun in
+  let open Xapi_stdext_deprecated.Fun in
   let db =
     ((Db_backend.blow_away_non_persistent_fields default_schema)
      ++ Db_upgrade.generic_database_upgrade
@@ -364,7 +364,7 @@ let spawn_db_flush_threads() =
                                then
                                  begin
                                    (* debug "[%s] considering flush" db_path; *)
-                                   let was_anything_flushed = Stdext.Threadext.Mutex.execute Db_lock.global_flush_mutex (fun ()->flush_dirty dbconn) in
+                                   let was_anything_flushed = Xapi_stdext_threads.Threadext.Mutex.execute Db_lock.global_flush_mutex (fun ()->flush_dirty dbconn) in
                                    if was_anything_flushed then
                                      begin
                                        my_writes_this_period := !my_writes_this_period + 1;

--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -296,14 +296,14 @@ let load connections default_schema =
     | Some c -> Backend_xml.populate default_schema c
     | None -> db in (* empty *)
 
-  let empty = Database.update_manifest (Manifest.update_schema (fun _ -> Some (default_schema.Schema.major_vsn, default_schema.Schema.minor_vsn))) (Database.make default_schema) in
-  let open Xapi_stdext_deprecated.Fun in
-  let db =
-    ((Db_backend.blow_away_non_persistent_fields default_schema)
-     ++ Db_upgrade.generic_database_upgrade
-     ++ populate) empty in
+  let empty = Database.update_manifest (Manifest.update_schema (fun _ -> Some (default_schema.Schema.major_vsn, default_schema.Schema.minor_vsn))) (Database.make default_schema)
+  in
 
-  db
+  empty
+  |> populate
+  |> Db_upgrade.generic_database_upgrade
+  |> Db_backend.blow_away_non_persistent_fields default_schema
+
 
 
 let sync conns db =

--- a/ocaml/database/db_cache_test.ml
+++ b/ocaml/database/db_cache_test.ml
@@ -13,7 +13,7 @@
  *)
 
 open Db_cache_types
-open Stdext.Fun
+open Xapi_stdext_deprecated.Fun
 
 let create_test_db () =
   let schema = Test_schemas.many_to_many in

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -130,7 +130,7 @@ module Table = struct
     let new_len,new_deleted =
       if t.deleted_len + 1 < upper_length_deleted_queue
       then t.deleted_len + 1, (new_element::t.deleted)
-      else lower_length_deleted_queue + 1, (new_element::(Stdext.Listext.List.take lower_length_deleted_queue t.deleted))
+      else lower_length_deleted_queue + 1, (new_element::(Xapi_stdext_std.Listext.List.take lower_length_deleted_queue t.deleted))
     in
     {rows = StringRowMap.remove g key t.rows;
      deleted_len = new_len;

--- a/ocaml/database/db_conn_store.ml
+++ b/ocaml/database/db_conn_store.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 (* ------------------- List of db connections that are active (read from db.conf file) *)
-open Stdext
+open Xapi_stdext_threads
 
 let db_connections : Parse_db_conf.db_connection list ref = ref [] (* initalised by ocaml/xapi/xapi.ml *)
 

--- a/ocaml/database/db_connections.ml
+++ b/ocaml/database/db_connections.ml
@@ -46,13 +46,14 @@ let exit_on_next_flush = ref false
 
 
 (* db flushing thread refcount: the last thread out of the door does the exit(0) when flush_on_exit is true *)
+open Xapi_stdext_threads
 let db_flush_thread_refcount_m = Mutex.create()
 let db_flush_thread_refcount = ref 0
 let inc_db_flush_thread_refcount() =
-  Stdext.Threadext.Mutex.execute db_flush_thread_refcount_m
+  Threadext.Mutex.execute db_flush_thread_refcount_m
     (fun () -> db_flush_thread_refcount := !db_flush_thread_refcount + 1)
 let dec_and_read_db_flush_thread_refcount() =
-  Stdext.Threadext.Mutex.execute db_flush_thread_refcount_m
+  Threadext.Mutex.execute db_flush_thread_refcount_m
     (fun () ->
        db_flush_thread_refcount := !db_flush_thread_refcount - 1;
        !db_flush_thread_refcount

--- a/ocaml/database/db_interface.ml
+++ b/ocaml/database/db_interface.ml
@@ -14,7 +14,7 @@
 
 type response =
   | String of string
-  | Bigbuf of Stdext.Bigbuffer.t
+  | Bigbuf of Xapi_stdext_bigbuffer.Bigbuffer.t
 
 (** A generic RPC interface *)
 module type RPC = sig

--- a/ocaml/database/db_lock.ml
+++ b/ocaml/database/db_lock.ml
@@ -16,8 +16,8 @@
 module D = Debug.Make(struct let name = "db_lock" end)
 open D
 
-open Stdext.Threadext
-open Stdext.Pervasiveext
+open Xapi_stdext_threads.Threadext
+open Xapi_stdext_pervasives.Pervasiveext
 
 (* Withlock takes dbcache_mutex, and ref-counts to allow the same thread to re-enter without blocking as many times
    as it wants. *)

--- a/ocaml/database/db_remote_cache_access_v1.ml
+++ b/ocaml/database/db_remote_cache_access_v1.ml
@@ -1,5 +1,5 @@
 
-open Stdext.Threadext
+open Xapi_stdext_threads.Threadext
 
 module DBCacheRemoteListener = struct
   open Db_rpc_common_v1
@@ -128,5 +128,5 @@ let handler req bio _ =
   let body_xml = Xml.parse_string body in
   let reply_xml = DBCacheRemoteListener.process_xmlrpc body_xml in
   let response = Xml.to_bigbuffer reply_xml in
-  Http_svr.response_fct req fd (Stdext.Bigbuffer.length response)
-    (fun fd -> Stdext.Bigbuffer.to_fct response (fun s -> ignore(Unix.write fd s 0 (String.length s))))
+  Http_svr.response_fct req fd (Xapi_stdext_bigbuffer.Bigbuffer.length response)
+    (fun fd -> Xapi_stdext_bigbuffer.Bigbuffer.to_fct response (fun s -> ignore(Unix.write fd s 0 (String.length s))))

--- a/ocaml/database/db_upgrade.ml
+++ b/ocaml/database/db_upgrade.ml
@@ -30,7 +30,6 @@ let generic_database_upgrade db =
              TableSet.add g tblname Table.empty ts) ts created_table_names) db in
 
   (* for each table, go through and fill in missing default values *)
-  let open Xapi_stdext_deprecated.Fun in
   List.fold_left
     (fun db tblname ->
        let tbl = TableSet.find tblname (Database.tableset db) in
@@ -40,6 +39,11 @@ let generic_database_upgrade db =
          Table.add g objref row tbl in
        let tbl = Table.fold add_fields_to_row tbl Table.empty in
        let g = Manifest.generation (Database.manifest db) in
-       ((Database.update ++ (TableSet.update g tblname Table.empty)) (fun _ -> tbl)) db
+       let perform_update =
+         (fun _ -> tbl)
+         |> TableSet.update g tblname Table.empty
+         |> Database.update
+       in
+       perform_update db
     ) db schema_table_names
 

--- a/ocaml/database/db_upgrade.ml
+++ b/ocaml/database/db_upgrade.ml
@@ -21,7 +21,7 @@ open Db_cache_types
 let generic_database_upgrade db =
   let existing_table_names = TableSet.fold (fun name _ _ acc -> name :: acc) (Database.tableset db) [] in
   let schema_table_names = Schema.table_names (Database.schema db) in
-  let created_table_names = Stdext.Listext.List.set_difference schema_table_names existing_table_names in
+  let created_table_names = Xapi_stdext_std.Listext.List.set_difference schema_table_names existing_table_names in
   let g = Manifest.generation (Database.manifest db) in
   let db = Database.update
       (fun ts ->
@@ -30,7 +30,7 @@ let generic_database_upgrade db =
              TableSet.add g tblname Table.empty ts) ts created_table_names) db in
 
   (* for each table, go through and fill in missing default values *)
-  let open Stdext.Fun in
+  let open Xapi_stdext_deprecated.Fun in
   List.fold_left
     (fun db tblname ->
        let tbl = TableSet.find tblname (Database.tableset db) in

--- a/ocaml/database/db_xml.ml
+++ b/ocaml/database/db_xml.ml
@@ -157,10 +157,9 @@ module From = struct
     let g = Int64.of_string (List.assoc _generation_count manifest) in
     let (major_vsn, minor_vsn) = schema_vsn_of_manifest manifest in
     let manifest = Manifest.make major_vsn minor_vsn g in
-    let open Xapi_stdext_deprecated.Fun in
-    ((Database.update_manifest (fun _ -> manifest))
-     ++ (Database.update_tableset (fun _ -> ts)))
-      (Database.make schema)
+    (Database.make schema)
+    |> Database.update_tableset (fun _ -> ts)
+    |> Database.update_manifest (fun _ -> manifest)
 
 
   let file schema xml_filename =

--- a/ocaml/database/db_xml.ml
+++ b/ocaml/database/db_xml.ml
@@ -85,7 +85,7 @@ module To = struct
 
   let file (filename: string) db : unit =
     let fdescr = Unix.openfile filename [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o600 in
-    Stdext.Pervasiveext.finally
+    Xapi_stdext_pervasives.Pervasiveext.finally
       (fun () -> fd fdescr db)
       (fun () -> Unix.close fdescr)
 end
@@ -157,7 +157,7 @@ module From = struct
     let g = Int64.of_string (List.assoc _generation_count manifest) in
     let (major_vsn, minor_vsn) = schema_vsn_of_manifest manifest in
     let manifest = Manifest.make major_vsn minor_vsn g in
-    let open Stdext.Fun in
+    let open Xapi_stdext_deprecated.Fun in
     ((Database.update_manifest (fun _ -> manifest))
      ++ (Database.update_tableset (fun _ -> ts)))
       (Database.make schema)
@@ -165,7 +165,7 @@ module From = struct
 
   let file schema xml_filename =
     let input = open_in xml_filename in
-    Stdext.Pervasiveext.finally
+    Xapi_stdext_pervasives.Pervasiveext.finally
       (fun () -> database schema (Xmlm.make_input (`Channel input)))
       (fun () -> close_in input)
 

--- a/ocaml/database/jbuild
+++ b/ocaml/database/jbuild
@@ -39,7 +39,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    gzip
    uuid
    xapi-stdext-bigbuffer
-   xapi-stdext-deprecated
    xapi-stdext-encodings
    xapi-stdext-monadic
    xapi-stdext-pervasives

--- a/ocaml/database/jbuild
+++ b/ocaml/database/jbuild
@@ -31,7 +31,6 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    block_device_io
   ))
   (libraries (
-   ppx_deriving_rpc
    rpclib
    ppx_sexp_conv
    sexpr
@@ -39,6 +38,14 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    http-svr
    gzip
    uuid
+   xapi-stdext-bigbuffer
+   xapi-stdext-deprecated
+   xapi-stdext-encodings
+   xapi-stdext-monadic
+   xapi-stdext-pervasives
+   xapi-stdext-std
+   xapi-stdext-threads
+   xapi-stdext-unix
    xcp
   ))
   (wrapped false)

--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -18,7 +18,7 @@
    restarts in emergency mode.
 *)
 
-open Stdext.Threadext
+open Xapi_stdext_threads.Threadext
 
 type db_record = (string * string) list * (string * (string list)) list
 module D = Debug.Make(struct let name = "master_connection" end)
@@ -66,7 +66,7 @@ let force_connection_reset () =
   match !my_connection with
   | None -> ()
   | Some st_proc ->
-    (info "stunnel reset pid=%d fd=%d" (Stunnel.getpid st_proc.Stunnel.pid) (Stdext.Unixext.int_of_file_descr st_proc.Stunnel.fd);
+    (info "stunnel reset pid=%d fd=%d" (Stunnel.getpid st_proc.Stunnel.pid) (Xapi_stdext_unix.Unixext.int_of_file_descr st_proc.Stunnel.fd);
      Unix.kill (Stunnel.getpid st_proc.Stunnel.pid) Sys.sigterm)
 
 (* whenever a call is made that involves read/write to the master connection, a timestamp is
@@ -79,7 +79,7 @@ let last_master_connection_call : float option ref = ref None
    mutual exclusion provided by the database lock here anyway) *)
 let with_timestamp f =
   last_master_connection_call := Some (Unix.gettimeofday());
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     f
     (fun ()->last_master_connection_call := None)
 
@@ -133,7 +133,7 @@ let open_secure_connection () =
   let fd_closed = Thread.wait_timed_read st_proc.Stunnel.fd 5. in
   let proc_quit = try Unix.kill (Stunnel.getpid st_proc.Stunnel.pid) 0; false with e -> true in
   if not fd_closed && not proc_quit then begin
-    info "stunnel connected pid=%d fd=%d" (Stunnel.getpid st_proc.Stunnel.pid) (Stdext.Unixext.int_of_file_descr st_proc.Stunnel.fd);
+    info "stunnel connected pid=%d fd=%d" (Stunnel.getpid st_proc.Stunnel.pid) (Xapi_stdext_unix.Unixext.int_of_file_descr st_proc.Stunnel.fd);
     my_connection := Some st_proc;
     !on_database_connection_established ()
   end else begin
@@ -190,11 +190,12 @@ let do_db_xml_rpc_persistent_with_reopen ~host ~path (req: string) : Db_interfac
                   let res = match response.Http.Response.content_length with
                     | None -> raise Content_length_required
                     | Some l -> begin
+                        let open Xapi_stdext_unix in
                         if (Int64.to_int l) <= Sys.max_string_length then
-                          Db_interface.String (Stdext.Unixext.really_read_string fd (Int64.to_int l))
+                          Db_interface.String (Unixext.really_read_string fd (Int64.to_int l))
                         else
-                          let buf = Stdext.Bigbuffer.make () in
-                          Stdext.Unixext.really_read_bigbuffer fd buf l;
+                          let buf = Xapi_stdext_bigbuffer.Bigbuffer.make () in
+                          Unixext.really_read_bigbuffer fd buf l;
                           Db_interface.Bigbuf buf
                       end
                   in

--- a/ocaml/database/parse_db_conf.ml
+++ b/ocaml/database/parse_db_conf.ml
@@ -13,8 +13,9 @@
  *)
 (* !!! This needs to be moved out of xapi and into the database directory; probably being merged with db_connections !!! *)
 
-open Stdext
-open Xstringext
+open Xapi_stdext_std.Xstringext
+open Xapi_stdext_unix
+
 module D=Debug.Make(struct let name="xapi" end)
 open D
 

--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -11,10 +11,11 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open Stdext
-open Pervasiveext
-open Threadext
-open Xstringext
+open Xapi_stdext_pervasives.Pervasiveext
+open Xapi_stdext_threads.Threadext
+open Xapi_stdext_std.Xstringext
+open Xapi_stdext_monadic
+open Xapi_stdext_unix
 
 module R = Debug.Make(struct let name = "redo_log" end)
 

--- a/ocaml/database/ref_index.ml
+++ b/ocaml/database/ref_index.ml
@@ -16,7 +16,7 @@
    on a slave -- so don't ever call them on slaves! :) *)
 
 open Db_cache_types
-open Stdext
+open Xapi_stdext_monadic
 
 type indexrec = {
   name_label:string option;

--- a/ocaml/database/static_vdis_list.ml
+++ b/ocaml/database/static_vdis_list.ml
@@ -15,7 +15,7 @@
  * @group Storage
 *)
 
-open Stdext
+open Xapi_stdext_unix
 
 (** Represents the configuration of a static (ie attached on boot) vdi *)
 type vdi = {

--- a/ocaml/database/string_marshall_helper.ml
+++ b/ocaml/database/string_marshall_helper.ml
@@ -23,7 +23,7 @@ open D
 
 let ensure_utf8_xml string =
   let length = String.length string in
-  let prefix = Stdext.Encodings.UTF8_XML.longest_valid_prefix string in
+  let prefix = Xapi_stdext_encodings.Encodings.UTF8_XML.longest_valid_prefix string in
   if length > String.length prefix then
     warn "Whilst doing 'set' of structured field, string truncated to: '%s'." prefix;
   prefix

--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -148,7 +148,7 @@ let gen_client_types highapi =
           "end";
         ]; [
           "module Date = struct";
-          "  open Stdext";
+          "  open Xapi_stdext_date";
           "  include Date";
           "  let rpc_of_iso8601 x = DateTime (Date.to_string x)";
           "  let iso8601_of_rpc = function String x | DateTime x -> Date.of_string x | _ -> failwith \"Date.iso8601_of_rpc\"";

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -315,14 +315,15 @@ let gen_module api : O.Module.t =
           ~body: (
             [
               "let __call, __params = call.Rpc.name, call.Rpc.params in";
-              "List.iter (fun p -> let s = Rpc.to_string p in if not (Stdext.Encodings.UTF8_XML.is_valid s) then";
+              "List.iter (fun p -> let s = Rpc.to_string p in if not (Xapi_stdext_encodings.Encodings.UTF8_XML.is_valid s) then";
               "raise (Api_errors.Server_error(Api_errors.invalid_value, [\"Invalid UTF-8 string in parameter\"; s])))  __params;";
               "let __async = Server_helpers.is_async __call in";
               "let __label = __call in";
               "let __call = if __async then Server_helpers.remove_async_prefix __call else __call in";
               "let subtask_of = if http_req.Http.Request.task <> None then http_req.Http.Request.task else http_req.Http.Request.subtask_of in";
               "let http_other_config = Context.get_http_other_config http_req in";
-              "Server_helpers.exec_with_new_task (\"dispatch:\"^__call^\"\") ~http_other_config ?subtask_of:(Stdext.Pervasiveext.may Ref.of_string subtask_of) (fun __context ->";
+              "let may f = function | None -> None | Some x -> Some (f x) in";
+              "Server_helpers.exec_with_new_task (\"dispatch:\"^__call^\"\") ~http_other_config ?subtask_of:(may Ref.of_string subtask_of) (fun __context ->";
 (*
 	      "if not (Hashtbl.mem supress_printing_for_these_messages __call) then ";
 	      debug "%s %s" [ "__call"; "(if __async then \"(async)\" else \"\")" ];

--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -165,4 +165,8 @@ let of_assoc_list l =
     with _ ->
       if List.mem f enabled_when_unknown then Some f else None
   in
-  Stdext.Listext.List.filter_map get_feature all_features
+  (* Filter_map to avoid having to carry the whole xapi-stdext-std *)
+  List.fold_right (fun f acc ->
+    match get_feature f with
+    | Some v -> v :: acc 
+    | None -> acc) all_features []

--- a/ocaml/xapi-types/jbuild
+++ b/ocaml/xapi-types/jbuild
@@ -32,11 +32,11 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (libraries (
    astring
    http-svr
-   ppx_deriving_rpc
    rpclib
    threads
    uuidm
    xapi-consts
+   xapi-stdext-date
   ))
   (wrapped false)
  )

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -14,7 +14,6 @@ depends: [
   "xapi-libs-transitional"
   "xapi-idl"
   "xapi-stdext-bigbuffer"
-  "xapi-stdext-deprecated"
   "xapi-stdext-encodings"
   "xapi-stdext-monadic"
   "xapi-stdext-pervasives"

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -13,4 +13,12 @@ depends: [
   "ppx_sexp_conv"
   "xapi-libs-transitional"
   "xapi-idl"
+  "xapi-stdext-bigbuffer"
+  "xapi-stdext-deprecated"
+  "xapi-stdext-encodings"
+  "xapi-stdext-monadic"
+  "xapi-stdext-pervasives"
+  "xapi-stdext-std"
+  "xapi-stdext-threads"
+  "xapi-stdext-unix"
 ]

--- a/xapi-types.opam
+++ b/xapi-types.opam
@@ -15,5 +15,6 @@ depends: [
   "xapi-consts"
   "xapi-datamodel"
   "xapi-libs-transitional"
+  "xapi-stdext-date"
 ]
 


### PR DESCRIPTION
And overall cleanup of dependencies. Includes the removal of `xapi-stdext-deprecated` from the database but does _not_ include the removal of `xstringext`.

This PR blocks the release of https://github.com/xapi-project/xen-api-libs-transitional/pull/35 as it removes the transitive dependencies re-added here.