### PR TITLE
CA-276964 on import, set suspend_SR to null when unknown

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -517,7 +517,7 @@ module VM : HandlerTools = struct
       Db.VM.set_transportable_snapshot_id ~__context ~self:vm ~value:vm_record.API.vM_transportable_snapshot_id;
 
       (* VM might have suspend_SR that does not exist on this pool *)
-      if None <> (Helpers.check_sr_exists ~__context
+      if None = (Helpers.check_sr_exists ~__context
                     ~self:vm_record.API.vM_suspend_SR)
       then Db.VM.set_suspend_SR ~__context ~self:vm ~value:Ref.null ;
 


### PR DESCRIPTION
On importing a VM, we must check that its suspend_SR is meaningful and
set it to Null if it isn't. The existing code has the test flipped.

Helpers.check_sr_exists ~__context ~self:vm_record.API.vM_suspend_SR

The above call returns `Some vM_suspend_SR` if it exists and `None`
otherwise. The test needs to look for None but previously did not.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>