### PR TITLE
HA master shutdown

### DIFF
--- a/ocaml/xapi/suite.ml
+++ b/ocaml/xapi/suite.ml
@@ -106,6 +106,8 @@ let harness_destroy () = ()
 
 let () =
   Printexc.record_backtrace true;
+  (* exceeds 4MB limit in Travis *)
+  Debug.disable ~level:Syslog.Debug "xapi";
   Inventory.inventory_filename :=
     Filename.concat Test_common.working_area "xcp-inventory";
   harness_init ();

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -1566,5 +1566,19 @@ let before_clean_shutdown_or_reboot ~__context ~host =
           info "Still waiting to reboot after %.2f seconds" (Unix.gettimeofday () -. start)
         done
     end;
-    List.iter Static_vdis.detach_only (Static_vdis.list())
+
+    (* We must do this before attempting to detach the VDI holding the redo log,
+       otherwise we would either get an error later or hang.
+
+       Note that Xha_metadata_vdi is a VDI with reason = ha_metadata_vdi_reason and type=`redo_log:
+       type=`metadata is for DR *)
+    debug "About to close active redo logs";
+    Redo_log.with_active_redo_logs (Redo_log.shutdown);
+
+    (* We cannot call ha_release_resources because we want to keep HA armed on reboot *)
+    debug "About to detach static VDIs";
+
+    List.iter (Static_vdis.detach_only) (Static_vdis.list ());
+
+    debug "Detached static VDIs"
   end

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -558,6 +558,7 @@ module Monitor = struct
                 end
               end
             with e ->
+              log_backtrace ();
               debug "Exception in HA monitor thread: %s" (ExnHelper.string_of_exn e);
               Thread.delay !Xapi_globs.ha_monitor_interval
           done;

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -488,8 +488,17 @@ let shutdown_and_reboot_common ~__context ~host label description operation cmd 
   if Db.Host.get_enabled ~__context ~self:host
   then raise (Api_errors.Server_error (Api_errors.host_not_disabled, []));
 
+  if (Pool_role.is_master ()) then
+       (* We are the master and we are about to shutdown HA and redo log:
+          prevent slaves from sending (DB) requests.
+          If we are the slave we cannot shutdown the request thread yet
+          because we might need it when unplugging the PBDs
+        *)
+       Remote_requests.stop_request_thread();
+
   Xapi_ha.before_clean_shutdown_or_reboot ~__context ~host;
   Xapi_pbd.unplug_all_pbds ~__context;
+
   Remote_requests.stop_request_thread();
 
   (* Push the Host RRD to the master. Note there are no VMs running here so we don't have to worry about them. *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -488,7 +488,8 @@ let shutdown_and_reboot_common ~__context ~host label description operation cmd 
   if Db.Host.get_enabled ~__context ~self:host
   then raise (Api_errors.Server_error (Api_errors.host_not_disabled, []));
 
-  if (Pool_role.is_master ()) then
+  let i_am_master = Pool_role.is_master () in
+  if i_am_master then
        (* We are the master and we are about to shutdown HA and redo log:
           prevent slaves from sending (DB) requests.
           If we are the slave we cannot shutdown the request thread yet
@@ -499,7 +500,8 @@ let shutdown_and_reboot_common ~__context ~host label description operation cmd 
   Xapi_ha.before_clean_shutdown_or_reboot ~__context ~host;
   Xapi_pbd.unplug_all_pbds ~__context;
 
-  Remote_requests.stop_request_thread();
+  if not i_am_master then
+    Remote_requests.stop_request_thread();
 
   (* Push the Host RRD to the master. Note there are no VMs running here so we don't have to worry about them. *)
   if not(Pool_role.is_master ())


### PR DESCRIPTION
When shutting the HA master we must ensure that we disable the redo log, otherwise we hang/fail when detaching the static VDIs or unplugging the PBD.

We should also ensure that slaves can no longer make requests to the master DB after we've started  to shutdown the master. This is done for now by moving where we stop the remote request thread, but it could also be done by killing the listening stunnel as discussed in the morning.

Tested on REQ-477 branch and was able to shutdown the HA master successfully several times.

While testing also found another bug in the new HA scripts, and I added a commit here that made debugging that easier.