### PR TITLE
Reduce 'make test' output size to fit Travis limit

### DIFF
--- a/ocaml/xapi/suite.ml
+++ b/ocaml/xapi/suite.ml
@@ -101,6 +101,8 @@ let harness_destroy () = ()
 
 let () =
   Printexc.record_backtrace true;
+  (* exceeds 4MB limit in Travis *)
+  Debug.disable ~level:Syslog.Debug "xapi";
   Inventory.inventory_filename :=
     Filename.concat Test_common.working_area "xcp-inventory";
   harness_init ();


### PR DESCRIPTION
Travis has a limit of 4MB, after which it kills the build.
A feature branch was at 5MB before this patch due to having more tests,
after this patch we're down to 3.2MB, but master is failing inexplicably too.

This disables the 'Adding new database table' messages while running the test suite.

4MB limitation seems to be hardcoded in Travis:
https://github.com/travis-ci/travis-ci/issues/1382#issuecomment-23508178
