### PR TITLE
CA-275786: Check PIF prerequisites when creating cluster

### DIFF
--- a/ocaml/xapi/test_cluster_host.ml
+++ b/ocaml/xapi/test_cluster_host.ml
@@ -57,45 +57,6 @@ let pif_plug_rpc __context call =
   | _ -> failwith "Unexpected RPC"
 
 
-let test_prereq () =
-  let __context = Test_common.make_test_database () in
-  let exn = "we_havent_decided_on_the_exception_yet" in
-  let cluster = create_cluster ~__context true in
-  let network = Db.Cluster.get_network ~__context ~self:cluster in
-  let localhost = Helpers.get_localhost ~__context in
-  let pifref = Test_common.make_pif ~__context ~network ~host:localhost () in
-  let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  assert_raises
-    (Failure exn)
-    (fun () ->
-      try
-        Xapi_cluster_host.assert_pif_prerequisites pif
-      with _ ->
-        failwith exn);
-  (* Put in IPv4 info *)
-  Db.PIF.set_IP ~__context ~self:pifref ~value:"1.1.1.1";
-  let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  assert_raises
-    (Failure exn)
-    (fun () ->
-      try
-        Xapi_cluster_host.assert_pif_prerequisites pif
-      with _ ->
-        failwith exn);
-  Db.PIF.set_currently_attached ~__context ~self:pifref ~value:true;
-  let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  assert_raises
-    (Failure exn)
-    (fun () ->
-      try
-        Xapi_cluster_host.assert_pif_prerequisites pif
-      with _ ->
-        failwith exn);
-  Db.PIF.set_disallow_unplug ~__context ~self:pifref ~value:true;
-  let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  assert_equal (Xapi_cluster_host.assert_pif_prerequisites pif) ()
-
-
 let test_fix_prereq () =
   let __context = Test_common.make_test_database () in
   Context.set_test_rpc __context (pif_plug_rpc __context);
@@ -116,7 +77,7 @@ let test_fix_prereq () =
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
   Xapi_cluster_host.fix_pif_prerequisites ~__context pif;
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  assert_equal (Xapi_cluster_host.assert_pif_prerequisites pif) ()
+  assert_equal (Xapi_clustering.assert_pif_prerequisites pif) ()
 
 let test_create_as_necessary () =
   let __context = Test_common.make_test_database () in
@@ -160,7 +121,6 @@ let test =
   [
     "test_dbsync_join" >:: test_dbsync_join;
     "test_dbsync_nojoin" >:: test_dbsync_nojoin;
-    "test_prerequisites" >:: test_prereq;
     "test_fix_prerequisites" >:: test_fix_prereq;
     "test_create_as_necessary" >:: test_create_as_necessary;
     "test_destroy_forbidden_when_sr_attached" >:: test_destroy_forbidden_when_sr_attached;

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -411,10 +411,10 @@ let make_cluster_host ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
 let make_cluster_and_cluster_host ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ?(network=Ref.null) ?(cluster_token="") ?(cluster_stack="corosync")
     ?(allowed_operations=[]) ?(current_operations=[]) ?(pool_auto_join=true)
-    ?(token_timeout=5000L) ?(token_timeout_coefficient=1000L) ?(cluster_config=[]) 
-    ?(other_config=[]) () =
+    ?(token_timeout=5000L) ?(token_timeout_coefficient=1000L) ?(cluster_config=[])
+    ?(other_config=[]) ?(host=Ref.null) () =
   Db.Cluster.create ~__context ~ref ~uuid ~network ~cluster_token
     ~cluster_stack ~allowed_operations ~current_operations ~pool_auto_join
     ~token_timeout ~token_timeout_coefficient ~cluster_config ~other_config;
-  let cluster_host_ref = make_cluster_host ~__context ~cluster:ref () in
+  let cluster_host_ref = make_cluster_host ~__context ~cluster:ref ~host () in
   ref, cluster_host_ref

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -19,14 +19,6 @@ open D
 
 (* TODO: update allowed_operations on boot/toolstack-restart *)
 
-(* A PIF being used for clustering must:
-   1. Be plugged
-   2. Be disallow_unplug
-   3. Have an IPv4 address *)
-let assert_pif_prerequisites pif =
-  assert_pif_permaplugged pif;
-  ignore(ip_of_pif pif)
-
 (* We can't fix _all_ of the prerequisites, as we can't automatically
    create an IP address. So what we do here is to at least plug the
    thing in and ensure it has disallow unplug set. *)

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -18,16 +18,6 @@
 (******************************************************************************)
 (** {2 Internal helper functions} *)
 
-val assert_pif_prerequisites : (API.ref_PIF * API.pIF_t) -> unit
-(** [assert_pif_prerequisites (pif_ref,pif_rec)] raises an exception if any of
-    the prerequisites of using a PIF for clustering are unmet. These
-    prerequisites are:
-    {ul
-    {- that the PIF has an IPv4 address}
-    {- that the PIF is currently_attached}
-    {- that the PIF has disallow_unplug set}
-    }*)
-
 val fix_pif_prerequisites : __context:Context.t -> (API.ref_PIF * API.pIF_t) ->
   unit
 (* [fix_pif_prerequisites ~__context (pif_ref,pif_rec)] will fix those


### PR DESCRIPTION
Previously these prerequisites were not checked, and the operation
succeeded when the PIF of the master wasn't permaplugged for example,
and we ended up with a cluster and a Cluster_host.