### PR TITLE
CP-24602, CP-24605: Renamed libraries after porting to jbuilder.

### DIFF
--- a/ocaml/xapi/jbuild
+++ b/ocaml/xapi/jbuild
@@ -77,7 +77,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    sha
    tar
    tar.unix
-   tapctl
+   xapi-tapctl
    x509
    xapi_version
    xapi-types
@@ -100,7 +100,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xcp.updates
    rrdd-plugin
    xapi-xenopsd
-   netdev
+   xapi-netdev
    yojson
   ))
  )


### PR DESCRIPTION
This depends on https://github.com/xapi-project/tapctl/pull/11 and https://github.com/xapi-project/netdev/pull/10.