### PR TITLE
CP-26197, CP-25397: Do not run xapi-clusterd if clustering is turned off

### DIFF
--- a/.travis-xenserver-build-env.sh
+++ b/.travis-xenserver-build-env.sh
@@ -9,7 +9,7 @@ export OCAMLRUNPARAM=b
 export REPO_PACKAGE_NAME=xapi
 export REPO_CONFIGURE_CMD=./configure
 export REPO_BUILD_CMD=make
-export REPO_TEST_CMD='make test >test.log || { tail test.log; grep E: test.log; }'
+export REPO_TEST_CMD='make test >test.log || { tail test.log; grep E: test.log; exit 1; }'
 export REPO_DOC_CMD='make doc-json'
 
 wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -44,7 +44,8 @@ type t = { session_id: API.ref_session option;
            task_name: string; (* Name for dummy task FIXME: used only for dummy task, as real task as their name in the database *)
            database: Db_ref.t;
            dbg: string;
-           mutable test_rpc: (Rpc.call -> Rpc.response) option
+           mutable test_rpc: (Rpc.call -> Rpc.response) option;
+           mutable test_clusterd_rpc: (Rpc.call -> Rpc.response) option
          }
 
 let get_session_id x =
@@ -116,6 +117,7 @@ let get_initial () =
     database = default_database ();
     dbg = "initial_task";
     test_rpc = None;
+    test_clusterd_rpc = None;
   }
 
 (* ref fn used to break the cyclic dependency between context, db_actions and taskhelper *)
@@ -183,6 +185,7 @@ let from_forwarded_task ?(__context=get_initial ()) ?(http_other_config=[]) ?ses
     database = default_database ();
     dbg = dbg;
     test_rpc = None;
+    test_clusterd_rpc = None;
   }
 
 let make ?(__context=get_initial ()) ?(http_other_config=[]) ?(quiet=false) ?subtask_of ?session_id ?(database=default_database ()) ?(task_in_database=false) ?task_description ?(origin=Internal) task_name =
@@ -217,6 +220,7 @@ let make ?(__context=get_initial ()) ?(http_other_config=[]) ?(quiet=false) ?sub
     task_name = task_name;
     dbg = dbg;
     test_rpc = None;
+    test_clusterd_rpc = None;
   }
 
 let get_http_other_config http_req =
@@ -243,3 +247,8 @@ let set_test_rpc context rpc =
   context.test_rpc <- Some rpc
 
 let get_test_rpc context = context.test_rpc
+
+let set_test_clusterd_rpc context rpc =
+  context.test_clusterd_rpc <- Some rpc
+
+let get_test_clusterd_rpc context = context.test_clusterd_rpc

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -123,3 +123,6 @@ val __make_task :
 
 val set_test_rpc : t -> (Rpc.call -> Rpc.response) -> unit
 val get_test_rpc : t -> (Rpc.call -> Rpc.response) option
+
+val set_test_clusterd_rpc : t -> (Rpc.call -> Rpc.response) -> unit
+val get_test_clusterd_rpc : t -> (Rpc.call -> Rpc.response) option

--- a/ocaml/xapi/create_storage.ml
+++ b/ocaml/xapi/create_storage.ml
@@ -42,14 +42,13 @@ let maybe_reenable_cluster_host __context =
   let host = Helpers.get_localhost __context in
   match Xapi_clustering.find_cluster_host ~__context ~host with
   | Some self ->
-      if not (Db.Cluster_host.get_enabled ~__context ~self) then
-        Xapi_cluster_host.enable ~__context ~self
+     Xapi_cluster_host.enable ~__context ~self
   | None -> ()
 
 let plug_unplugged_pbds __context =
   (* If the plug is to succeed for SM's requiring a cluster stack
    * we have to enable the cluster stack too if we have one *)
-  maybe_reenable_cluster_host __context;
+  log_and_ignore_exn(fun () -> maybe_reenable_cluster_host __context);
   let my_pbds = Helpers.get_my_pbds __context in
   List.iter
     (fun (self, pbd_record) ->

--- a/ocaml/xapi/suite.ml
+++ b/ocaml/xapi/suite.ml
@@ -73,8 +73,9 @@ let base_suite =
     Test_pusb.test;
     Test_cluster_host.test;
     Test_clustering_allowed_operations.test;
-    Test_clustering.test;
+    Test_cluster.test;
     Test_host_helpers.test;
+    Test_clustering.test;
   ]
 
 let handlers = [

--- a/ocaml/xapi/test_cluster.ml
+++ b/ocaml/xapi/test_cluster.ml
@@ -1,0 +1,76 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Xapi_cluster
+open OUnit
+
+let test_clusterd_rpc ~__context call =
+  let token = "test_token" in
+  match call.Rpc.name, call.Rpc.params with
+  | "create", _ ->
+     Rpc.{success = true; contents = Rpc.String token }
+  | ("enable" | "disable" | "destroy"), _ ->
+     Rpc.{success = true; contents = Rpc.Null }
+  | name, params ->
+     failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))
+
+let test_rpc ~__context call =
+  match call.Rpc.name, call.Rpc.params with
+  | "Cluster_host.destroy", [self] ->
+     let open API in
+     Xapi_cluster_host.destroy ~__context ~self:(ref_Cluster_host_of_rpc self);
+     Rpc.{success = true; contents = Rpc.String "" }
+  | "Cluster.destroy", [_session; self] ->
+     let open API in
+     Xapi_cluster.destroy ~__context ~self:(ref_Cluster_of_rpc self);
+     Rpc.{success = true; contents = Rpc.String "" }
+  | name, params ->
+     failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))
+
+let create_cluster ~__context =
+  Context.set_test_rpc __context (test_rpc ~__context);
+  Context.set_test_clusterd_rpc __context (test_clusterd_rpc ~__context);
+  let network = Test_common.make_network ~__context () in
+  let localhost = Helpers.get_localhost ~__context in
+  let pifref = Test_common.make_pif ~__context ~network ~host:localhost () in
+  Db.PIF.set_IP ~__context ~self:pifref ~value:"192.0.2.1";
+  Db.PIF.set_currently_attached ~__context ~self:pifref ~value:true;
+  Db.PIF.set_disallow_unplug ~__context ~self:pifref ~value:true;
+  Xapi_cluster.create ~__context ~network ~cluster_stack:"corosync" ~pool_auto_join:true ~token_timeout:1. ~token_timeout_coefficient:1.
+
+let test_create_destroy_status () =
+  let __context = Test_common.make_test_database () in
+  let cluster = create_cluster ~__context in
+  assert_equal ~msg:"cluster daemon started after create" true !Xapi_clustering.Daemon.started;
+  pool_destroy ~__context ~self:cluster;
+  assert_equal ~msg:"cluster daemon not started after destroy" false !Xapi_clustering.Daemon.started
+
+let test_enable () =
+  let __context = Test_common.make_test_database () in
+  let cluster = create_cluster ~__context in
+  assert_equal ~msg:"cluster daemon started" true !Xapi_clustering.Daemon.started;
+  (* simulate xapi getting restarted *)
+  Xapi_clustering.Daemon.started := false;
+
+  Create_storage.maybe_reenable_cluster_host __context;
+  assert_equal ~msg:"cluster daemon started after enable" true !Xapi_clustering.Daemon.started;
+  pool_destroy ~__context ~self:cluster;
+  assert_equal ~msg:"cluster daemon not started after destroy" false !Xapi_clustering.Daemon.started
+
+let test =
+  "test_cluster" >:::
+  [
+    "test_create_destroy_service_status" >:: test_create_destroy_status;
+    "test_enable" >:: test_enable;
+  ]

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -52,7 +52,7 @@ let create ~__context ~network ~cluster_stack ~pool_auto_join ~token_timeout ~to
         name = None
       } in
 
-      let result = Cluster_client.LocalClient.create rpc dbg init_config in
+      let result = Cluster_client.LocalClient.create (rpc ~__context) dbg init_config in
       match result with
       | Result.Ok cluster_token ->
         D.debug "Got OK from LocalClient.create";
@@ -72,11 +72,12 @@ let destroy ~__context ~self =
   assert_cluster_has_one_node ~__context ~self;
   let cluster_host = Db.Cluster.get_cluster_hosts ~__context ~self |> List.hd in
   assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__context ~self:cluster_host;
-  let result = Cluster_client.LocalClient.destroy rpc dbg in
+  let result = Cluster_client.LocalClient.destroy (rpc ~__context) dbg in
   match result with
   | Result.Ok () ->
     Db.Cluster_host.destroy ~__context ~self:cluster_host;
-    Db.Cluster.destroy ~__context ~self
+    Db.Cluster.destroy ~__context ~self;
+    Xapi_clustering.Daemon.stop ~__context
   | Result.Error error -> handle_error error
 
 (* helper function; concurrency checks are done in implementation of Cluster.create and Cluster_host.create *)


### PR DESCRIPTION
Start the cluster daemon when:
* a Cluster_host / Cluster object is created
* on startup when we try to re-enable the Cluster_host

Stop the cluster daemon when:
* we destroy the Cluster_host or Cluster object

In general before any RPC call to the cluster daemon it has to be started.
So remember whether we started it or not, and if we didn't start it when it gets
the first RPC.

We could have made the daemon socket activated, but see CA-265469 systemd
retries don't work with socket activation reliably.

Also modified xenserver-release by dropping our branch to avoid auto-starting on boot.

This avoids having the xapi-clusterd ports open when nothing uses it.

Wrote unit tests for Cluster/Cluster_host creation/destruction with a mock RPC.

Jenkins test pending.