### PR TITLE
CP-26457: Make multipath configuration a host parameter

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5077,6 +5077,17 @@ let host_set_iscsi_iqn = call
     ~allowed_roles:_R_POOL_OP
     ()
 
+let host_set_multipathing = call
+    ~name:"set_multipathing"
+    ~lifecycle:[Published, rel_kolkata, ""]
+    ~doc:"Specifies whether multipathing is enabled"
+    ~params:[
+      Ref _host, "host", "The host";
+      Bool, "value", "Whether multipathing should be enabled"
+    ]
+    ~allowed_roles:_R_POOL_OP
+    ()
+
 (** Hosts *)
 let host =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_host ~descr:"A physical host" ~gen_events:true
@@ -5170,6 +5181,7 @@ let host =
                 host_mxgpu_vf_setup;
                 host_allocate_resources_for_vm;
                 host_set_iscsi_iqn;
+                host_set_multipathing;
                ]
     ~contents:
       ([ uid _host;
@@ -5225,7 +5237,8 @@ let host =
          field ~qualifier:DynamicRO ~default_value:(Some (VRef null_ref)) ~in_product_since:rel_ely ~ty:(Ref _vm) "control_domain" "The control domain (domain 0)";
          field ~qualifier:DynamicRO ~lifecycle:[Published, rel_ely, ""] ~ty:(Set (Ref _pool_update)) ~ignore_foreign_key:true "updates_requiring_reboot" "List of updates which require reboot";
          field ~qualifier:DynamicRO ~lifecycle:[Published, rel_falcon, ""] ~ty:(Set (Ref _feature)) "features" "List of features available on this host";
-         field ~qualifier:StaticRO ~lifecycle:[Published, rel_kolkata, ""] ~default_value:(Some (VString "")) ~ty:String "iscsi_iqn" "The initiator IQN for the host"
+         field ~qualifier:StaticRO ~lifecycle:[Published, rel_kolkata, ""] ~default_value:(Some (VString "")) ~ty:String "iscsi_iqn" "The initiator IQN for the host";
+         field ~qualifier:StaticRO ~lifecycle:[Published, rel_kolkata, ""] ~default_value:(Some (VBool false)) ~ty:Bool "multipathing" "Specifies whether multipathing is enabled";
        ])
     ()
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2669,6 +2669,13 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       do_op_on ~local_fn ~__context ~host
         (fun session_id rpc ->
           Client.Host.set_iscsi_iqn rpc session_id host value)
+
+    let set_multipathing ~__context ~host ~value =
+      info "Host.set_multipathing: host='%s' value='%s'" (host_uuid ~__context host) (string_of_bool value);
+      let local_fn = Local.Host.set_multipathing ~host ~value in
+      do_op_on ~local_fn ~__context ~host
+        (fun session_id rpc ->
+          Client.Host.set_multipathing rpc session_id host value)
   end
 
   module Host_crashdump = struct

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -1242,6 +1242,8 @@ let host_record rpc session_id host =
         ~get_set:(fun () -> List.map get_uuid_from_ref (x ()).API.host_features) ();
       make_field ~name:"iscsi_iqn"
         ~get:(fun () -> (x ()).API.host_iscsi_iqn) ~set:(fun s -> Client.Host.set_iscsi_iqn rpc session_id host s) ();
+      make_field ~name:"multipathing"
+        ~get:(fun () -> string_of_bool (x ()).API.host_multipathing) ~set:(fun s -> Client.Host.set_multipathing rpc session_id host (safe_bool_of_string "multipathing" s)) ();
     ]}
 
 let vdi_record rpc session_id vdi =

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -149,7 +149,8 @@ let make_host2 ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ()) ?(name_label="
     ~virtual_hardware_platform_versions:[]
     ~control_domain:Ref.null
     ~updates_requiring_reboot:[]
-    ~iscsi_iqn:"";
+    ~iscsi_iqn:""
+    ~multipathing:false;
   ref
 
 let make_pif ~__context ~network ~host ?(device="eth0") ?(mAC="C0:FF:EE:C0:FF:EE") ?(mTU=1500L)

--- a/ocaml/xapi/test_host_helpers.ml
+++ b/ocaml/xapi/test_host_helpers.ml
@@ -22,35 +22,56 @@ let setup_test_oc_watcher () =
     | "host.set_iscsi_iqn", [_session_id_rpc;host_rpc;value_rpc] ->
       let host = API.ref_host_of_rpc host_rpc in
       let v = API.string_of_rpc value_rpc in
-      calls := (host,v) :: !calls;
+      Db.Host.set_iscsi_iqn ~__context ~self:host ~value:v;
+      calls := (host,`set_iscsi_iqn v) :: !calls;
+      Rpc.{success=true; contents=Rpc.String ""}
+    | "host.set_multipathing", [_session_id_rpc;host_rpc;value_rpc] ->
+      let host = API.ref_host_of_rpc host_rpc in
+      let v = API.bool_of_rpc value_rpc in
+      Db.Host.set_multipathing ~__context ~self:host ~value:v;
+      calls := (host,`set_multipathing v) :: !calls;
       Rpc.{success=true; contents=Rpc.String ""}
     | _ -> Mock_rpc.rpc __context call
   in
   Context.set_test_rpc __context test_rpc;
   let host1 = !Xapi_globs.localhost_ref in
   let host2 = Test_common.make_host ~__context () in
-  let watcher = Xapi_host_helpers.InitiatorName.watch_other_configs ~__context 0.0 in
+  let watcher = Xapi_host_helpers.Configuration.watch_other_configs ~__context 0.0 in
   let token = watcher "" in
   (__context, calls, host1, host2, watcher, token)
 
 let test_host1 () =
+  (* Test1: update other_config:iscsi_iqn,multipathing on host1, check they appear in the calls list *)
   let (__context, calls, host1, host2, watcher, token) = setup_test_oc_watcher () in
-  (* Test1: update other_config:iscsi_iqn on host1, check it appears in the calls list *)
+  Db.Host.set_multipathing ~__context ~self:host1 ~value:false;
+
   Db.Host.add_to_other_config ~__context ~self:host1 ~key:"iscsi_iqn" ~value:"test1";
+  let token = watcher token in
+  assert_equal !calls [host1, `set_iscsi_iqn "test1"];
+
+  calls := [];
+  Db.Host.add_to_other_config ~__context ~self:host1 ~key:"multipathing" ~value:"true";
   let _token = watcher token in
-  assert_equal !calls [host1, "test1"]
+  assert_equal !calls [host1, `set_multipathing true]
 
 let test_host2 () =
+  (* Test2: update other_config:iscsi_iqn,multipathing on host2, check they appear in the calls list *)
   let (__context, calls, host1, host2, watcher, token) = setup_test_oc_watcher () in
-  (* Test2: update other_config:iscsi_iqn on host2, check it appears in the calls list *)
+  Db.Host.set_multipathing ~__context ~self:host2 ~value:true;
+
   Db.Host.add_to_other_config ~__context ~self:host2 ~key:"iscsi_iqn" ~value:"test2";
+  let token = watcher token in
+  assert_equal !calls [host2, `set_iscsi_iqn "test2"];
+
+  calls := [];
+  Db.Host.add_to_other_config ~__context ~self:host2 ~key:"multipathing" ~value:"false";
   let _token = watcher token in
-  assert_equal !calls [host2, "test2"]
+  assert_equal !calls [host2, `set_multipathing false]
 
 let test_different_keys () =
   (* Test3: verify that setting other other-config keys causes no set *)
   let (__context, calls, host1, host2, watcher, token) = setup_test_oc_watcher () in
-  Db.Host.add_to_other_config ~__context ~self:host1 ~key:"not_iscsi_iqn" ~value:"test1";
+  Db.Host.add_to_other_config ~__context ~self:host1 ~key:"other_key" ~value:"test1";
   let _token = watcher token in
   assert_equal !calls []
 
@@ -60,7 +81,7 @@ let test_host_set_iscsi_iqn () =
   let (__context, calls, host1, host2, watcher, token) = setup_test_oc_watcher () in
   Db.Host.add_to_other_config ~__context ~self:host1 ~key:"iscsi_iqn" ~value:"test1";
   let token = watcher token in
-  assert_equal !calls [host1, "test1"];
+  assert_equal !calls [host1, `set_iscsi_iqn "test1"];
   calls := [];
   Db.Host.remove_from_other_config ~__context ~self:host1 ~key:"iscsi_iqn";
   let token = watcher token in
@@ -72,12 +93,34 @@ let test_host_set_iscsi_iqn () =
   let _token = watcher token in
   assert_equal !calls []
 
+let test_host_set_multipathing () =
+  (* Test3: verify that sequence of DB calls in Host.set_multipathing don't cause the
+     watcher to invoke further calls *)
+  let (__context, calls, host1, host2, watcher, token) = setup_test_oc_watcher () in
+  Db.Host.set_multipathing ~__context ~self:host2 ~value:false;
+
+  Db.Host.add_to_other_config ~__context ~self:host1 ~key:"multipathing" ~value:"true";
+  let token = watcher token in
+  assert_equal !calls [host1, `set_multipathing true];
+  calls := [];
+
+  Db.Host.remove_from_other_config ~__context ~self:host1 ~key:"multipathing";
+  let token = watcher token in
+  assert_equal !calls [];
+  Db.Host.set_multipathing ~__context ~self:host1 ~value:false;
+  let token = watcher token in
+  assert_equal !calls [];
+  Db.Host.add_to_other_config ~__context ~self:host1 ~key:"multipathing" ~value:"false";
+  let _token = watcher token in
+  assert_equal !calls []
+
 
 let test =
-  "iscsiinitiator" >:::
+  "other_config_watcher" >:::
   [
     "test_host1" >:: test_host1;
     "test_host2" >:: test_host2;
     "test_different_keys" >:: test_different_keys;
     "test_host_set_iscsi_iqn" >:: test_host_set_iscsi_iqn;
+    "test_host_set_multipathing" >:: test_host_set_multipathing;
   ]

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -816,6 +816,7 @@ let server_init() =
           "hi-level database upgrade", [ Startup.OnlyMaster ], Xapi_db_upgrade.hi_level_db_upgrade_rules ~__context;
           "bringing up management interface", [], bring_up_management_if ~__context;
           "Starting periodic scheduler", [Startup.OnThread], Xapi_periodic_scheduler.loop;
+          "Synchronising host configuration files", [], (fun () -> Xapi_host_helpers.Configuration.sync_config_files ~__context);
           "Starting Host other-config watcher", [Startup.OnlyMaster], (fun () -> Xapi_host_helpers.Configuration.start_watcher_thread ~__context);
           "Remote requests", [Startup.OnThread], Remote_requests.handle_requests;
         ];

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -816,7 +816,7 @@ let server_init() =
           "hi-level database upgrade", [ Startup.OnlyMaster ], Xapi_db_upgrade.hi_level_db_upgrade_rules ~__context;
           "bringing up management interface", [], bring_up_management_if ~__context;
           "Starting periodic scheduler", [Startup.OnThread], Xapi_periodic_scheduler.loop;
-          "Starting Host.iscsi_iqn other-config watcher", [Startup.OnlyMaster], (fun () -> Xapi_host_helpers.InitiatorName.start_watcher_thread ~__context);
+          "Starting Host other-config watcher", [Startup.OnlyMaster], (fun () -> Xapi_host_helpers.Configuration.start_watcher_thread ~__context);
           "Remote requests", [Startup.OnThread], Remote_requests.handle_requests;
         ];
         begin match Pool_role.get_role () with

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -763,6 +763,7 @@ let udhcpd_leases_db = ref "/var/lib/xcp/dhcp-leases.db"
 let udhcpd_pidfile = ref "/var/run/udhcpd.pid"
 
 let iscsi_initiator_config_file = ref "/etc/iscsi/initiatorname.iscsi"
+let multipathing_config_file = ref "/var/run/nonpersistent/multipath_enabled"
 
 let busybox = ref "busybox"
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -639,6 +639,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address ~ex
     ~control_domain:Ref.null
     ~updates_requiring_reboot:[]
     ~iscsi_iqn:""
+    ~multipathing:false
   ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.of_float (Unix.gettimeofday ()));
@@ -1766,4 +1767,13 @@ let set_iscsi_iqn ~__context ~host ~value =
   Db.Host.remove_from_other_config ~__context ~self:host ~key:"iscsi_iqn";
   Db.Host.set_iscsi_iqn ~__context ~self:host ~value;
   Db.Host.add_to_other_config ~__context ~self:host ~key:"iscsi_iqn" ~value;
-  Xapi_host_helpers.InitiatorName.set_initiator_name value
+  Xapi_host_helpers.Configuration.set_initiator_name value
+
+let set_multipathing ~__context ~host ~value =
+  (* Note, the following sequence is carefully written - see the
+     other-config watcher thread in xapi_host_helpers.ml *)
+  Db.Host.remove_from_other_config ~__context ~self:host ~key:"multipathing";
+  Db.Host.set_multipathing ~__context ~self:host ~value;
+  Db.Host.add_to_other_config ~__context ~self:host ~key:"multipathing" ~value:(string_of_bool value);
+  Xapi_host_helpers.Configuration.set_multipathing value
+

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -309,3 +309,4 @@ val mxgpu_vf_setup : __context:Context.t -> host:API.ref_host -> unit
 
 val allocate_resources_for_vm : __context:Context.t -> self:API.ref_host -> vm:API.ref_VM -> live:bool -> unit
 val set_iscsi_iqn : __context:Context.t -> host:API.ref_host -> value:string -> unit
+val set_multipathing : __context:Context.t -> host:API.ref_host -> value:bool -> unit

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -293,6 +293,14 @@ module Configuration = struct
       if Sys.file_exists flag then Sys.remove flag
     end
 
+  let sync_config_files ~__context =
+    (* If the host fields are not in sync with the values in other_config,
+       the other_config watcher thread will make sure that these functions will
+       be called again with the up to date values. *)
+    let self = Helpers.get_localhost ~__context in
+    set_initiator_name (Db.Host.get_iscsi_iqn ~__context ~self);
+    set_multipathing (Db.Host.get_multipathing ~__context ~self)
+
   let watch_other_configs ~__context delay =
     let loop token =
       Helpers.call_api_functions ~__context (fun rpc session_id ->

--- a/ocaml/xapi/xapi_host_helpers.mli
+++ b/ocaml/xapi/xapi_host_helpers.mli
@@ -108,6 +108,12 @@ module Configuration : sig
       (usually /var/run/nonpersistent/multipath_enabled) if [enabled] is true,
       otherwise it will remove the file. *)
 
+  val sync_config_files : __context:Context.t -> unit
+  (** [sync_config_files ~__context] ensures that the iscsi iqn and
+      multipathing configuration files reflect the values of the corresponding
+      fields in xapi's database. It should be called at startup on every host
+      BEFORE the other_config watcher [start_watcher_thread] is started *)
+
   val watch_other_configs : __context:Context.t -> float -> string -> string
   (** [watch_other_configs ~__context timeout] returns a function that performs
       one iteration of watching Host.other_config. If an update occurs this

--- a/ocaml/xapi/xapi_host_helpers.mli
+++ b/ocaml/xapi/xapi_host_helpers.mli
@@ -97,11 +97,16 @@ module Host_requires_reboot : sig
   (** [get ()] returns [true] if the host needs to be rebooted *)
 end
 
-module InitiatorName : sig
+module Configuration : sig
   val set_initiator_name : string -> unit
   (** [set_initiator_name iqn] will write the iscsi initiator configuration to
       the file specified in Xapi_globs (usually /etc/iscsi/initiatorname.iscsi)
       *)
+
+  val set_multipathing : bool -> unit
+  (** [set_multipathing enabled] will touch the file specified in Xapi_globs
+      (usually /var/run/nonpersistent/multipath_enabled) if [enabled] is true,
+      otherwise it will remove the file. *)
 
   val watch_other_configs : __context:Context.t -> float -> string -> string
   (** [watch_other_configs ~__context timeout] returns a function that performs


### PR DESCRIPTION
And sync the ISCSI IQN and multipathing config files at startup.