### PR TITLE
Travis: if travis tests fail exit with code 1

### DIFF
--- a/.travis-xenserver-build-env.sh
+++ b/.travis-xenserver-build-env.sh
@@ -9,7 +9,7 @@ export OCAMLRUNPARAM=b
 export REPO_PACKAGE_NAME=xapi
 export REPO_CONFIGURE_CMD=./configure
 export REPO_BUILD_CMD=make
-export REPO_TEST_CMD='make test >test.log || { tail test.log; grep E: test.log; }'
+export REPO_TEST_CMD='make test >test.log || { tail test.log; grep E: test.log; exit 1; }'
 export REPO_DOC_CMD='make doc-json'
 
 wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh


### PR DESCRIPTION
We have reduced the verbosity of the travis tests and printed only the error.
Make sure we actually exit with an error-code when the tests fail!

I just noticed that I got a green tick on one of my PRs  to the feature branch, but the test actually failed and printed the error.
This was an oversight from my previous PR which introduced the log shrinking in the first place.