### PR TITLE
Host.set_iscsi_iqn: reject empty string

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1762,6 +1762,7 @@ let allocate_resources_for_vm ~__context ~self ~vm ~live =
   ()
 
 let set_iscsi_iqn ~__context ~host ~value =
+  if value = "" then raise Api_errors.(Server_error (invalid_value, ["value"; value]));
   (* Note, the following sequence is carefully written - see the
      other-config watcher thread in xapi_host_helpers.ml *)
   Db.Host.remove_from_other_config ~__context ~self:host ~key:"iscsi_iqn";


### PR DESCRIPTION
Because it's invalid.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>