### PR TITLE
CP-26333 Add PIF.PCI field

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5659,6 +5659,7 @@ let pif =
       field ~lifecycle:[Published, rel_inverness, ""] ~qualifier:DynamicRO ~ty:pif_igmp_status ~default_value:(Some (VEnum "unknown")) "igmp_snooping_status" "The IGMP snooping status of the corresponding network bridge";
       field ~in_oss_since:None ~ty:(Set (Ref _network_sriov)) ~in_product_since:rel_kolkata ~qualifier:DynamicRO "sriov_physical_PIF_of" "Indicates which network_sriov this interface is physical of";
       field ~in_oss_since:None ~ty:(Set (Ref _network_sriov)) ~in_product_since:rel_kolkata ~qualifier:DynamicRO "sriov_logical_PIF_of" "Indicates which network_sriov this interface is logical of";
+      field ~qualifier:DynamicRO ~ty:(Ref _pci) ~lifecycle:[Published, rel_kolkata, ""] ~default_value:(Some (VRef null_ref)) "PCI" "Link to underlying PCI device";
     ]
     ()
 

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -302,6 +302,10 @@ let update_env __context sync_keys =
   update_physical_networks ~__context;
 *)
 
+  switched_sync Xapi_globs.sync_pci_devices (fun () ->
+      Xapi_pci.update_pcis ~__context;
+    );
+
   switched_sync Xapi_globs.sync_pif_params (fun () ->
       debug "resynchronising PIF params";
       resynchronise_pif_params ~__context;
@@ -338,10 +342,6 @@ let update_env __context sync_keys =
 
   switched_sync Xapi_globs.sync_chipset_info (fun () ->
       Create_misc.create_chipset_info ~__context;
-    );
-
-  switched_sync Xapi_globs.sync_pci_devices (fun () ->
-      Xapi_pci.update_pcis ~__context;
     );
 
   switched_sync Xapi_globs.sync_gpus (fun () ->

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -376,7 +376,7 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
         ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
         ~vLAN_master_of:Ref.null ~management:false ~other_config:[] ~disallow_unplug:false
         ~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true
-        ~properties:pif_properties ~capabilities:[];
+        ~properties:pif_properties ~capabilities:[] ~pCI:Ref.null;
       Db.Bond.create ~__context ~ref:bond ~uuid:(Uuid.to_string (Uuid.make_uuid ())) ~master:master ~other_config:[]
         ~primary_slave ~mode ~properties ~links_up:0L;
 

--- a/ocaml/xapi/xapi_tunnel.ml
+++ b/ocaml/xapi/xapi_tunnel.ml
@@ -43,7 +43,7 @@ let create_internal ~__context ~transport_PIF ~network ~host =
     ~ip_configuration_mode:`None ~iP:"" ~netmask:"" ~gateway:"" ~dNS:"" ~bond_slave_of:Ref.null
     ~vLAN_master_of:Ref.null
     ~management:false ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
-    ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true ~properties:[] ~capabilities:[];
+    ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true ~properties:[] ~capabilities:[] ~pCI:Ref.null;
   Db.Tunnel.create ~__context ~ref:tunnel ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
     ~access_PIF ~transport_PIF ~status:["active", "false"] ~other_config:[];
   tunnel, access_PIF

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -38,7 +38,7 @@ let create_internal ~__context ~host ~tagged_PIF ~tag ~network ~device =
     ~vLAN_master_of:vlan ~management:false
     ~other_config:[] ~disallow_unplug:false
     ~ipv6_configuration_mode:`None ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true
-    ~properties:[] ~capabilities:[];
+    ~properties:[] ~capabilities:[] ~pCI:Ref.null;
 
   let () = Db.VLAN.create ~__context ~ref:vlan ~uuid:vlan_uuid ~tagged_PIF ~untagged_PIF ~tag ~other_config:[] in
   vlan, untagged_PIF


### PR DESCRIPTION
1. Set PIF.pci of physical PIF to corresponding pci ref when creating
2. Set PIF.pci of vlan master PIF to the PIF.pci of the underlying PIF
3. Set PIF.pci of Bond master or tunnel PIF to Ref.null
4. Refresh PIF.pci on xapi restarting for all kinds of PIFs

Signed-off-by: Yang Qian <yang.qian@citrix.com>