### PR TITLE
CA-277464: Quicktest_vdi_copy: wait for VBD unplug before destroying VDI

### DIFF
--- a/ocaml/xapi/quicktest_vdi_copy.ml
+++ b/ocaml/xapi/quicktest_vdi_copy.ml
@@ -51,6 +51,17 @@ let read_from_vdi ~session_id ~vdi f =
       Http.Get uri in
   http req (fun (_, fd) -> f fd)
 
+(* Simpler alternative to Xapi_vdi.wait_for_vbds_to_be_unplugged_and_destroyed,
+   using sleep instead of the event system. *)
+let wait_for_no_vbds_then_destroy ~rpc ~session_id self =
+  let wait_for_no_vbds () =
+    let start = Mtime_clock.counter () in
+    let over () = (Mtime_clock.count start |> Mtime.Span.to_s) > 4.0 in
+    while not (over ()) && Client.VDI.get_VBDs ~rpc ~session_id ~self <> [] do Unix.sleepf 0.1 done
+  in
+  wait_for_no_vbds ();
+  Client.VDI.destroy ~rpc ~session_id ~self
+
 let start session_id sr =
   let t = make_test "Check VDI.copy delta handling" 1 in
   start t;
@@ -144,8 +155,7 @@ let start session_id sr =
     );
 
   debug t "Destroying VDI (cleanup)";
-  List.iter (fun self -> Client.VDI.destroy ~rpc:!rpc ~session_id ~self)
-    [ original; snapshot; snapshot_backup; delta_backup ];
+  List.iter (wait_for_no_vbds_then_destroy ~rpc:!rpc ~session_id) [ original; snapshot; snapshot_backup; delta_backup ];
 
   success t
 


### PR DESCRIPTION
I think the issue is that when we call read_from_vdi and send the HTTP
export_raw_vdi GET request, on the server side we tell vhd-tool to write
the VDI in a given format to the file descriptor, and when it returns,
we unplug & destroy the VBD. Maybe vhd-tool closes the TCP connection
when it finishes and then the client sending the HTTP get request
continues to destroy the VDI, before the VBD is unplugged on the server
side.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>