### PR TITLE
CP-26430:fix auto-completion error of network-sriov

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -105,7 +105,15 @@ _xe()
                     pvs-cache-storage-*)
                         # Chop off at the third '-' and append 'list'
                         cmd="$(echo ${OLDSTYLE_WORDS[1]} | cut -d- -f1-3)-list";;
-                    host-cpu-*|host-crashdump-*|gpu-group-*|vgpu-type-*|pvs-server-*|pvs-proxy-*|pvs-site-*|sdn-controller-*|network-sriov-*)
+                    host-cpu-*|\
+                    host-crashdump-*|\
+                    gpu-group-*|\
+                    vgpu-type-*|\
+                    pvs-server-*|\
+                    pvs-proxy-*|\
+                    pvs-site-*|\
+                    sdn-controller-*|\
+                    network-sriov-*)
                         # Chop off at the second '-' and append 'list'
                         cmd="$(echo ${OLDSTYLE_WORDS[1]} | cut -d- -f1-2)-list";;
                     *)

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -105,7 +105,7 @@ _xe()
                     pvs-cache-storage-*)
                         # Chop off at the third '-' and append 'list'
                         cmd="$(echo ${OLDSTYLE_WORDS[1]} | cut -d- -f1-3)-list";;
-                    host-cpu-*|host-crashdump-*|gpu-group-*|vgpu-type-*|pvs-server-*|pvs-proxy-*|pvs-site-*|sdn-controller-*)
+                    host-cpu-*|host-crashdump-*|gpu-group-*|vgpu-type-*|pvs-server-*|pvs-proxy-*|pvs-site-*|sdn-controller-*|network-sriov-*)
                         # Chop off at the second '-' and append 'list'
                         cmd="$(echo ${OLDSTYLE_WORDS[1]} | cut -d- -f1-2)-list";;
                     *)


### PR DESCRIPTION
To support auto-completion for uuid of network-sriov-*, need to chop off `network-sriov-*` at the second '-' and append the list.
Signed-off-by: Min Li <min.li1@citrix.com>