### PR TITLE
CP-26014: Clear reserved_pci in vif when vm with sriov vif halted

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -600,6 +600,7 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
       (fun vif ->
          Db.VIF.set_currently_attached ~__context ~self:vif ~value:false;
          Db.VIF.set_reserved ~__context ~self:vif ~value:false;
+         Db.VIF.set_reserved_pci ~__context ~self:vif ~value:Ref.null;
          Xapi_vif_helpers.clear_current_operations ~__context ~self:vif;
          Opt.iter
            (fun p -> Pvs_proxy_control.clear_proxy_state ~__context vif p)

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -584,9 +584,11 @@ let update_allowed_operations ~__context ~self =
   if Db.is_valid_ref __context appliance then
     Xapi_vm_appliance_lifecycle.update_allowed_operations ~__context ~self:appliance
 
-(** Called on new VMs (clones, imports) and on server start to manually refresh
-    the power state, allowed_operations field etc.  Current-operations won't be
-    cleaned *)
+(** 1.Called on new VMs (clones, imports) and on server start to manually refresh
+ *    the power state, allowed_operations field etc.  Current-operations won't be
+ *    cleaned
+ *  2.Called on update VM when the power state changes
+**)
 let force_state_reset_keep_current_operations ~__context ~self ~value:state =
   if state = `Halted then begin
     (* mark all devices as disconnected *)


### PR DESCRIPTION
When vm is halted, the reserved virtual function doesn't need anymore, it is needed to clear `reserved_pci` on `vif`.

Signed-off-by: Min Li <min.li1@citrix.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xen-api/3410)
<!-- Reviewable:end -->
