### PR TITLE
Make alcotest a non-test OPAM dependency

### DIFF
--- a/.travis-opam-coverage.sh
+++ b/.travis-opam-coverage.sh
@@ -30,8 +30,6 @@ sudo apt install -y libpci-dev
 opam pin add --no-action xapi .
 opam depext --yes xapi
 opam install --deps-only xapi
-# install the test dependencies
-opam install -y alcotest
 
 # build and test xapi with coverage, then submit the coverage information to coveralls
 

--- a/xapi.opam
+++ b/xapi.opam
@@ -10,7 +10,7 @@ build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
 
 depends: [
   "jbuilder" {build & >= "1.0+beta11"}
-  "alcotest" {test}
+  "alcotest"
   "cdrom"
   "fd-send-recv"
   "message-switch-unix"


### PR DESCRIPTION
Currently this has to be a normal dependency. To ensure test
dependencies are not compiled into xapi, we'll have to make a new
internal xapi library that the unit test binaries will depend on.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>