### PR TITLE
XOP-908/CA-279498: Zero-extend CPU features when comparing old and new sets

### DIFF
--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -50,7 +50,8 @@ let zero_extend arr len =
 (** Calculate the intersection of two feature sets.
  *  Intersection with the empty set is treated as identity, so that intersection
  *  can be folded easily starting with an accumulator of [||].
- *  If both sets are non-empty and of differing lengths, set is longer than the other, the shorter one is zero-extended to match it.
+ *  If both sets are non-empty and of differing lengths, and one set is longer
+ *  than the other, the shorter one is zero-extended to match it.
  *  The returned set is the same length as the longer of the two arguments.  *)
 let intersect left right =
   match left, right with
@@ -66,6 +67,11 @@ let intersect left right =
       out.(i) <- Int64.logand left.(i) right.(i)
     done;
     out
+
+(** equality check that zero-extends if lengths differ *)
+let is_equal left right =
+  let len = max (Array.length left) (Array.length right) in
+  (zero_extend left len) = (zero_extend right len)
 
 (** is_subset left right returns true if left is a subset of right *)
 let is_subset left right =

--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -75,12 +75,12 @@ let is_equal left right =
 
 (** is_subset left right returns true if left is a subset of right *)
 let is_subset left right =
-  intersect left right = left
+  is_equal (intersect left right) left
 
 (** is_strict_subset left right returns true if left is a strict subset of right
     (left is a subset of right, but left and right are not equal) *)
 let is_strict_subset left right =
-  (is_subset left right) && (left <> right)
+  (is_subset left right) && (not (is_equal left right))
 
 (** Field definitions for checked string map access *)
 let features_t   = Map_check.pickler features_of_string string_of_features

--- a/ocaml/xapi/cpuid_helpers.mli
+++ b/ocaml/xapi/cpuid_helpers.mli
@@ -36,6 +36,7 @@ val assert_vm_is_compatible :
 val extend : int64 array -> int64 array -> int64 array
 val zero_extend : int64 array -> int -> int64 array
 val intersect : int64 array -> int64 array -> int64 array
+val is_equal : int64 array -> int64 array -> bool
 val is_subset : int64 array -> int64 array -> bool
 val is_strict_subset : int64 array -> int64 array -> bool
 

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -537,10 +537,10 @@ let create_host_cpu ~__context =
 
   let before = getf ~default:[||] features_hvm old_cpu_info in
   let after = stat.cpu_info.features_hvm in
-  if before <> after && before <> [||] then begin
+  if not (is_equal before after) && before <> [||] then begin
     let lost = is_strict_subset (intersect before after) before in
     let gained = is_strict_subset (intersect before after) after in
-    let body = Printf.sprintf "The CPU features of host have changed.%s%s"
+    let body = Printf.sprintf "The CPU features of this host have changed.%s%s"
         (if lost then " Some features have gone away." else "")
         (if gained then " Some features were added." else "")
     in
@@ -612,7 +612,7 @@ let create_pool_cpuinfo ~__context =
 
   let before = getf ~default:[||] features_hvm old_cpuinfo in
   let after = getf ~default:[||] features_hvm pool_cpuinfo in
-  if before <> after && before <> [||] then begin
+  if not (is_equal before after) && before <> [||] then begin
     let lost = is_strict_subset (intersect before after) before in
     let gained = is_strict_subset (intersect before after) after in
     let body = Printf.sprintf "The pool-level CPU features have changed.%s%s"

--- a/ocaml/xapi/test_cpuid_helpers.ml
+++ b/ocaml/xapi/test_cpuid_helpers.ml
@@ -214,21 +214,28 @@ module Comparisons = Generic.Make (struct
       Cpuid_helpers.(is_subset a b, is_strict_subset a b)
 
     let tests = [
-      (* Some of this behaviour is counterintuitive because
-                       feature flags are automatically zero-extended when
-                       compared *)
+      (* The following are counterintuitive, because intersection with the empty
+       * set is treated as identity, and intersection is used in is_subset.
+       * Since there are no empty feature sets in reality, these are artificial
+       * scenarios. *)
       ([| |], [| |]),            (true, false);
       ([| 1L; 2L; 3L |], [| |]), (true, true);
       ([| |], [| 1L; 2L; 3L |]), (false, false);
 
+      (* Note that feature flags are automatically zero-extended when compared.
+       * These tests are relevant in upgrade scenarios, if new CPUID leaves are
+       * introduced. *)
       ([| 7L; 3L |], [| 5L; |]), (false, false);
-      ([| 5L; |], [| 7L; 3L |]), (false, false);
+      ([| 5L; |], [| 7L; 3L |]), (true, true);
 
       ([| 1L |],     [| 1L |]),     (true, false);
-      ([| 1L |],     [| 1L; 0L |]), (false, false);
-      ([| 1L; 0L |], [| 1L |]),     (true, true);
+      ([| 1L |],     [| 1L; 0L |]), (true, false);
+      ([| 1L; 0L |], [| 1L |]),     (true, false);
 
-      (features_of_string "07cbfbff-04082201-20100800-00000001-00000000-00000000-00000000-00000000-00000000", features_of_string "07c9cbf5-80082201-20100800-00000001-00000000-00000000-00000000-00000000-00000000"), (false, false);
+      (* Below are the more common cases *)
+      (features_of_string "07cbfbff-04082201-20100800-00000001-00000000-00000000-00000000-00000000-00000000",
+       features_of_string "07c9cbf5-80082201-20100800-00000001-00000000-00000000-00000000-00000000-00000000"),
+       (false, false);
 
       ([| 0b00000000L |], [| 0b11111111L |]), (true, true);
       ([| 0b11111111L |], [| 0b11111111L |]), (true, false);

--- a/ocaml/xapi/test_cpuid_helpers.ml
+++ b/ocaml/xapi/test_cpuid_helpers.ml
@@ -202,6 +202,35 @@ module Intersect = Generic.Make (struct
   end)
 
 
+module Equality = Generic.Make (struct
+    module Io = struct
+      type input_t = int64 array * int64 array
+      type output_t = bool
+      let string_of_input_t = Test_printers.(pair (array int64) (array int64))
+      let string_of_output_t = Test_printers.bool
+    end
+
+    let transform = fun (a, b) ->
+      Cpuid_helpers.(is_equal a b)
+
+    let tests = [
+      ([| |], [| |]),            true;
+      ([| 1L; 2L; 3L |], [| 1L; 2L; 3L |]), true;
+      ([| 1L; 2L; 3L |], [| |]), false;
+      ([| |], [| 1L; 2L; 3L |]), false;
+
+      ([| 7L; 0L |], [| 7L; |]), true;
+      ([| 7L; |], [| 7L; 0L |]), true;
+      ([| 7L; 1L; 0L |], [| 7L; 1L |]), true;
+
+      ([| 7L; 1L |], [| 7L; 1L |]), true;
+      ([| 7L; 1L |], [| 7L; |]), false;
+      ([| 7L; |],    [| 7L; 1L |]), false;
+      ([| 1L; 7L |], [| 7L; 1L |]), false;
+    ]
+  end)
+
+
 module Comparisons = Generic.Make (struct
     module Io = struct
       type input_t = int64 array * int64 array
@@ -499,6 +528,8 @@ let test =
     ZeroExtend.tests;
     "test_intersect" >:::
     Intersect.tests;
+    "test_equality" >:::
+    Equality.tests;
     "test_comparisons" >:::
     Comparisons.tests;
     "test_accessors" >:::


### PR DESCRIPTION
Backport of #3400.