### PR TITLE
[opam/next] Depend on new tar-unix ocamlfind package

### DIFF
--- a/ocaml/xapi/jbuild
+++ b/ocaml/xapi/jbuild
@@ -85,7 +85,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    oUnit
    sha
    tar
-   tar.unix
+   tar-unix
    xapi-tapctl
    x509
    xapi_version

--- a/xapi.opam
+++ b/xapi.opam
@@ -22,7 +22,7 @@ depends: [
   "sha"
   "ssl"
   "stdext"
-  "tar-format"
+  "tar-unix"
   "vhd-format"
   "x509"
   "xapi-cli-protocol"


### PR DESCRIPTION
This is part of the `opam/next` patches.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>
Signed-off-by: Marcello Seri <marcello.seri@citrix.com>