### PR TITLE
CP-26717: Update Xapi to use PPX-based Gpumon IDL

### DIFF
--- a/ocaml/xapi/xapi_gpumon.ml
+++ b/ocaml/xapi/xapi_gpumon.ml
@@ -78,15 +78,15 @@ module Nvidia = struct
       let vm    = Db.VGPU.get_VM ~__context ~self:vgpu in
       let domid = Db.VM.get_domid ~__context ~self:vm |> Int64.to_int in
       Db.VGPU.get_resident_on ~__context ~self:vgpu
-      |> fun self -> Db.PGPU.get_PCI ~__context ~self
-                     |> fun self -> Db.PCI.get_pci_id ~__context ~self
-                                    |> Gpumon_client.Client.Nvidia.get_vgpu_metadata dbg domid
-                                    |> function
-                                    | []      -> []
-                                    | [meta]  -> [key, Stdext.Base64.encode meta]
-                                    | _::_    -> failwith @@ Printf.sprintf
-                                        "%s: VM %s (dom %d) has more than one NVIDIA vGPU (%s)"
-                                        this (Ref.string_of vm) domid __LOC__
+      |> (fun self -> Db.PGPU.get_PCI ~__context ~self)
+      |> (fun self -> Db.PCI.get_pci_id ~__context ~self)
+      |> Gpumon_client.Client.Nvidia.get_vgpu_metadata dbg domid
+      |> (function
+          | []      -> []
+          | [meta]  -> [key, Stdext.Base64.encode meta]
+          | _::_    -> failwith @@ Printf.sprintf
+              "%s: VM %s (dom %d) has more than one NVIDIA vGPU (%s)"
+              this (Ref.string_of vm) domid __LOC__)
     with
     | Gpumon_interface.(Gpumon_error NvmlInterfaceNotAvailable) ->
       let host = Helpers.get_localhost ~__context |> Ref.string_of in
@@ -150,8 +150,8 @@ module Nvidia = struct
         |> Stdext.Base64.decode in
       let vgpu_metadata () =
         Db.VGPU.get_compatibility_metadata ~__context ~self:vgpu
-        |> fun md -> [List.assoc key md]
-                     |> List.map Stdext.Base64.decode in
+        |> (fun md -> [List.assoc key md])
+        |> List.map Stdext.Base64.decode in
       match
         Gpumon_client.Client.Nvidia.get_pgpu_vgpu_compatibility
           dbg

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -31,11 +31,11 @@ let calculate_max_capacities ~__context ~pCI ~size ~supported_VGPU_types =
 
 let fetch_compatibility_metadata ~__context ~pgpu_pci =
   if Db.PCI.get_vendor_id ~__context ~self:pgpu_pci =
-    Xapi_pci.id_of_int Xapi_vgpu_type.Nvidia.vendor_id
+     Xapi_pci.id_of_int Xapi_vgpu_type.Nvidia.vendor_id
   then (
-     let dbg = Context.string_of_task __context in
-     let pgpu_pci_address = Db.PCI.get_pci_id ~__context ~self:pgpu_pci in
-     Xapi_gpumon.Nvidia.get_pgpu_compatibility_metadata ~dbg ~pgpu_pci_address
+    let dbg = Context.string_of_task __context in
+    let pgpu_pci_address = Db.PCI.get_pci_id ~__context ~self:pgpu_pci in
+    Xapi_gpumon.Nvidia.get_pgpu_compatibility_metadata ~dbg ~pgpu_pci_address
   ) else []
 
 let maybe_fetch_compatibility_metadata ~__context ~pgpu_pci =
@@ -54,11 +54,11 @@ let populate_compatibility_metadata ~__context ~pgpu ~pgpu_pci =
     Db.PGPU.set_compatibility_metadata ~__context ~self:pgpu ~value
   with
   | Gpumon_interface.(Gpumon_error NvmlInterfaceNotAvailable) ->
-      info "%s: can't get compat data for pgpu_pci:%s, keeping existing data"
-        this (Ref.string_of pgpu_pci)
+    info "%s: can't get compat data for pgpu_pci:%s, keeping existing data"
+      this (Ref.string_of pgpu_pci)
   | err ->
-      debug "%s: obtaining compat data for pgpu_pci:%s failed with %s"
-        this (Ref.string_of pgpu_pci) (Printexc.to_string err)
+    debug "%s: obtaining compat data for pgpu_pci:%s failed with %s"
+      this (Ref.string_of pgpu_pci) (Printexc.to_string err)
 
 let create ~__context ~pCI ~gPU_group ~host ~other_config
     ~supported_VGPU_types ~size ~dom0_access

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -41,7 +41,7 @@ let fetch_compatibility_metadata ~__context ~pgpu_pci =
 let maybe_fetch_compatibility_metadata ~__context ~pgpu_pci =
   try fetch_compatibility_metadata ~__context ~pgpu_pci
   with
-  | Gpumon_interface.NvmlInterfaceNotAvailable -> []
+  | Gpumon_interface.(Gpumon_error NvmlInterfaceNotAvailable) -> []
   | err ->
     debug "fetch_compatibility_metadata for pgpu_pci:%s failed with %s"
       (Ref.string_of pgpu_pci) (Printexc.to_string err);
@@ -53,7 +53,7 @@ let populate_compatibility_metadata ~__context ~pgpu ~pgpu_pci =
     let value = fetch_compatibility_metadata ~__context ~pgpu_pci in
     Db.PGPU.set_compatibility_metadata ~__context ~self:pgpu ~value
   with
-  | Gpumon_interface.NvmlInterfaceNotAvailable ->
+  | Gpumon_interface.(Gpumon_error NvmlInterfaceNotAvailable) ->
       info "%s: can't get compat data for pgpu_pci:%s, keeping existing data"
         this (Ref.string_of pgpu_pci)
   | err ->


### PR DESCRIPTION
This PR is the second of three to port GPU monitoring daemon gpumon to use PPX-based code generation for RPCs.

1. [Port Gpumon interface](https://github.com/xapi-project/xcp-idl/pull/196)
2. this
3. [Port Gpumon](https://github.com/xapi-project/xen-api/pull/3418)