### PR TITLE
CA-276638, CA-281320: Catch handle_invalid in Valid_ref_list

### DIFF
--- a/ocaml/xapi/valid_ref_list.ml
+++ b/ocaml/xapi/valid_ref_list.ml
@@ -5,6 +5,8 @@ let default_on_missing_ref f default x =
   with
   | Db_exn.DBCache_NotFound ("missing reference", _, _) -> default
   | Db_exn.DBCache_NotFound ("missing row", _, _) -> default
+  (* When using the Client module, we get this exception for invalid references: *)
+  | Api_errors.(Server_error (handle_invalid, _ )) when handle_invalid = Api_errors.handle_invalid -> default
 
 let exists f = List.exists (default_on_missing_ref f false)
 


### PR DESCRIPTION
This exception is thrown when we use the Client module.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>