### PR TITLE
CA-271491: Creating NFS SR on 64-host pool ~7x slower than 16-host

### DIFF
--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -240,12 +240,15 @@ let create  ~__context ~host ~device_config ~(physical_size:int64) ~name_label ~
   end;
   Helpers.call_api_functions ~__context
     (fun rpc session_id ->
-       List.iter
-         (fun self ->
-            try
-              Client.PBD.plug ~rpc ~session_id ~self
-            with e -> warn "Could not plug PBD '%s': %s" (Db.PBD.get_uuid ~__context ~self) (Printexc.to_string e))
-         pbds);
+       let tasks = List.fold_left (fun tasks self ->
+           try
+             let task = Client.Async.PBD.plug ~rpc ~session_id ~self in
+             task :: tasks
+           with e ->
+             warn "Could not plug PBD '%s': %s" (Db.PBD.get_uuid ~__context ~self) (Printexc.to_string e);
+             tasks)
+           [] pbds in
+       Tasks.wait_for_all ~rpc ~session_id ~tasks);
   sr_ref
 
 let check_no_pbds_attached ~__context ~sr =

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -240,14 +240,7 @@ let create  ~__context ~host ~device_config ~(physical_size:int64) ~name_label ~
   end;
   Helpers.call_api_functions ~__context
     (fun rpc session_id ->
-       let tasks = List.fold_left (fun tasks self ->
-           try
-             let task = Client.Async.PBD.plug ~rpc ~session_id ~self in
-             task :: tasks
-           with e ->
-             warn "Could not plug PBD '%s': %s" (Db.PBD.get_uuid ~__context ~self) (Printexc.to_string e);
-             tasks)
-           [] pbds in
+       let tasks = List.map (fun self -> Client.Async.PBD.plug ~rpc ~session_id ~self) pbds in
        Tasks.wait_for_all ~rpc ~session_id ~tasks);
   sr_ref
 

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -139,7 +139,7 @@ let valid_operations ~__context ?op record _ref' : table =
   in
 
   let check_parallel_ops ~__context record =
-    let safe_to_parallelise = [ ] in
+    let safe_to_parallelise = [`plug] in
     let current_ops = List.setify (List.map snd current_ops) in
 
     (* If there are any current operations, all the non_parallelisable operations


### PR DESCRIPTION
Adding a SR to a large pool(64 hosts) seems very slow which is caused by
serial PBD plug across the pool. This fix is to use async PBD plugwhen creating SR.

By doing this change, I have run Ring3 and Stroage BST which are both
passed(refer to 78821, 78820).

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>