### PR TITLE
 VDI.snapshot, clone: pass down complete vdi_info 

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -67,9 +67,9 @@ let find_content ~__context ?sr name =
 
 let vdi_info_of_vdi_rec __context vdi_rec =
   let content_id =
-    if List.mem_assoc "content_id" vdi_rec.API.vDI_other_config
-    then List.assoc "content_id" vdi_rec.API.vDI_other_config
-    else vdi_rec.API.vDI_location (* PR-1255 *)
+    try
+      List.assoc "content_id" vdi_rec.API.vDI_other_config
+    with Not_found -> vdi_rec.API.vDI_location (* PR-1255 *)
   in {
     vdi = vdi_rec.API.vDI_location;
     uuid = Some vdi_rec.API.vDI_uuid;

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -65,6 +65,34 @@ let find_content ~__context ?sr name =
        || (vdi_rec.API.vDI_location = name) (* PR-1255 *)
     ) all
 
+let vdi_info_of_vdi_rec __context vdi_rec =
+  let content_id =
+    if List.mem_assoc "content_id" vdi_rec.API.vDI_other_config
+    then List.assoc "content_id" vdi_rec.API.vDI_other_config
+    else vdi_rec.API.vDI_location (* PR-1255 *)
+  in {
+    vdi = vdi_rec.API.vDI_location;
+    uuid = Some vdi_rec.API.vDI_uuid;
+    content_id = content_id; (* PR-1255 *)
+    name_label = vdi_rec.API.vDI_name_label;
+    name_description = vdi_rec.API.vDI_name_description;
+    ty = Storage_utils.string_of_vdi_type vdi_rec.API.vDI_type;
+    metadata_of_pool = Ref.string_of vdi_rec.API.vDI_metadata_of_pool;
+    is_a_snapshot = vdi_rec.API.vDI_is_a_snapshot;
+    snapshot_time = Date.to_string vdi_rec.API.vDI_snapshot_time;
+    snapshot_of =
+      if Db.is_valid_ref __context vdi_rec.API.vDI_snapshot_of
+      then Db.VDI.get_uuid ~__context ~self:vdi_rec.API.vDI_snapshot_of
+      else "";
+    read_only = vdi_rec.API.vDI_read_only;
+    cbt_enabled = vdi_rec.API.vDI_cbt_enabled;
+    virtual_size = vdi_rec.API.vDI_virtual_size;
+    physical_utilisation = vdi_rec.API.vDI_physical_utilisation;
+    persistent = vdi_rec.API.vDI_on_boot = `persist;
+    sharable = vdi_rec.API.vDI_sharable;
+    sm_config = vdi_rec.API.vDI_sm_config;
+  }
+
 let redirect sr =
   raise (Redirect (Some (Pool_role.get_master_address ())))
 
@@ -81,34 +109,6 @@ module SMAPIv1 = struct
       	*)
 
   type context = Smint.request
-
-  let vdi_info_of_vdi_rec __context vdi_rec =
-    let content_id =
-      if List.mem_assoc "content_id" vdi_rec.API.vDI_other_config
-      then List.assoc "content_id" vdi_rec.API.vDI_other_config
-      else vdi_rec.API.vDI_location (* PR-1255 *)
-    in {
-      vdi = vdi_rec.API.vDI_location;
-      uuid = Some vdi_rec.API.vDI_uuid;
-      content_id = content_id; (* PR-1255 *)
-      name_label = vdi_rec.API.vDI_name_label;
-      name_description = vdi_rec.API.vDI_name_description;
-      ty = Storage_utils.string_of_vdi_type vdi_rec.API.vDI_type;
-      metadata_of_pool = Ref.string_of vdi_rec.API.vDI_metadata_of_pool;
-      is_a_snapshot = vdi_rec.API.vDI_is_a_snapshot;
-      snapshot_time = Date.to_string vdi_rec.API.vDI_snapshot_time;
-      snapshot_of =
-        if Db.is_valid_ref __context vdi_rec.API.vDI_snapshot_of
-        then Db.VDI.get_uuid ~__context ~self:vdi_rec.API.vDI_snapshot_of
-        else "";
-      read_only = vdi_rec.API.vDI_read_only;
-      cbt_enabled = vdi_rec.API.vDI_cbt_enabled;
-      virtual_size = vdi_rec.API.vDI_virtual_size;
-      physical_utilisation = vdi_rec.API.vDI_physical_utilisation;
-      persistent = vdi_rec.API.vDI_on_boot = `persist;
-      sharable = vdi_rec.API.vDI_sharable;
-      sm_config = vdi_rec.API.vDI_sm_config;
-    }
 
   let vdi_info_from_db ~__context self =
     let vdi_rec = Db.VDI.get_record ~__context ~self in
@@ -569,9 +569,10 @@ module SMAPIv1 = struct
                with _ ->
                  Uuid.string_of_uuid (Uuid.make_uuid ())
              in
+             let snapshot_time = Date.of_float (Unix.gettimeofday ()) in
              Db.VDI.set_name_label ~__context ~self ~value:vdi_info.name_label;
              Db.VDI.set_name_description ~__context ~self ~value:vdi_info.name_description;
-             Db.VDI.set_snapshot_time ~__context ~self ~value:(Date.of_string vdi_info.snapshot_time);
+             Db.VDI.set_snapshot_time ~__context ~self ~value:snapshot_time;
              Db.VDI.set_is_a_snapshot ~__context ~self ~value:is_a_snapshot;
              Db.VDI.remove_from_other_config ~__context ~self ~key:"content_id";
              Db.VDI.add_to_other_config ~__context ~self ~key:"content_id" ~value:content_id;

--- a/ocaml/xapi/storage_access.mli
+++ b/ocaml/xapi/storage_access.mli
@@ -33,6 +33,9 @@ val find_vdi: __context:Context.t -> Storage_interface.sr -> Storage_interface.v
     with [content_id] *)
 val find_content: __context:Context.t -> ?sr:Storage_interface.sr -> Storage_interface.content_id -> API.ref_VDI * API.vDI_t
 
+(** [vdi_info_of_vdi_rec __context vdi_rec] constructs a vdi_info record from information in the given VDI database record. *)
+val vdi_info_of_vdi_rec : Context.t -> API.vDI_t -> Storage_interface.vdi_info
+
 (** [bind __context pbd] causes the storage_access module to choose the most
         appropriate driver implementation for the given [pbd] *)
 val bind: __context:Context.t -> pbd:API.ref_PBD -> Storage_interface.query_result

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -407,6 +407,7 @@ let create ~__context ~name_label ~name_description
     name_description = name_description;
     ty = vdi_type;
     read_only = read_only;
+    cbt_enabled = false;
     virtual_size = virtual_size;
     sharable = sharable;
     sm_config = sm_config;

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -531,20 +531,15 @@ let snapshot_and_clone call_f ~__context ~vdi ~driver_params =
   let sR = Db.VDI.get_SR ~__context ~self:vdi in
   Sm.assert_pbd_is_plugged ~__context ~sr:sR;
   Xapi_vdi_helpers.assert_managed ~__context ~vdi;
-  let a = Db.VDI.get_record_internal ~__context ~self:vdi in
+  let vdi_rec = Db.VDI.get_record ~__context ~self:vdi in
 
   let call_snapshot () =
     let open Storage_access in
     let task = Context.get_task_id __context in
     let open Storage_interface in
-    let vdi' = Db.VDI.get_location ~__context ~self:vdi in
     let vdi_info = {
-      default_vdi_info with
-      vdi = vdi';
-      name_label = a.Db_actions.vDI_name_label;
-      name_description = a.Db_actions.vDI_name_description;
+      (Storage_access.vdi_info_of_vdi_rec __context vdi_rec) with
       sm_config = driver_params;
-      snapshot_time = Date.to_string (Date.of_float (Unix.gettimeofday ()));
     } in
     let sr' = Db.SR.get_uuid ~__context ~self:sR in
     (* We don't use transform_storage_exn because of the clone/copy fallback below *)
@@ -557,14 +552,14 @@ let snapshot_and_clone call_f ~__context ~vdi ~driver_params =
   let newvdi = call_snapshot () in
 
   (* Copy across the metadata which we control *)
-  Db.VDI.set_name_label ~__context ~self:newvdi ~value:a.Db_actions.vDI_name_label;
-  Db.VDI.set_name_description ~__context ~self:newvdi ~value:a.Db_actions.vDI_name_description;
-  Db.VDI.set_type ~__context ~self:newvdi ~value:a.Db_actions.vDI_type;
-  Db.VDI.set_sharable ~__context ~self:newvdi ~value:a.Db_actions.vDI_sharable;
-  Db.VDI.set_other_config ~__context ~self:newvdi ~value:a.Db_actions.vDI_other_config;
-  Db.VDI.set_xenstore_data ~__context ~self:newvdi ~value:a.Db_actions.vDI_xenstore_data;
-  Db.VDI.set_on_boot ~__context ~self:newvdi ~value:a.Db_actions.vDI_on_boot;
-  Db.VDI.set_allow_caching ~__context ~self:newvdi ~value:a.Db_actions.vDI_allow_caching;
+  Db.VDI.set_name_label ~__context ~self:newvdi ~value:vdi_rec.API.vDI_name_label;
+  Db.VDI.set_name_description ~__context ~self:newvdi ~value:vdi_rec.API.vDI_name_description;
+  Db.VDI.set_type ~__context ~self:newvdi ~value:vdi_rec.API.vDI_type;
+  Db.VDI.set_sharable ~__context ~self:newvdi ~value:vdi_rec.API.vDI_sharable;
+  Db.VDI.set_other_config ~__context ~self:newvdi ~value:vdi_rec.API.vDI_other_config;
+  Db.VDI.set_xenstore_data ~__context ~self:newvdi ~value:vdi_rec.API.vDI_xenstore_data;
+  Db.VDI.set_on_boot ~__context ~self:newvdi ~value:vdi_rec.API.vDI_on_boot;
+  Db.VDI.set_allow_caching ~__context ~self:newvdi ~value:vdi_rec.API.vDI_allow_caching;
   newvdi
 
 let snapshot ~__context ~vdi ~driver_params =


### PR DESCRIPTION
We use vdi_info_of_vdi_rec to ensure that the vdi_info we pass down to
SMAPIv2 contains the correct information about the VDI.
Previously when we were debugging an issue, we were looking at the
vdi_info printed out by SMAPIv2, and it was misleading as many of the
fields, such as is_a_snapshot and cbt_enabled, were incorrect because
they were just taken from the default_vdi_info.
I determine the snapshot time in SMAPIv2, to ensure that in the vdi_info
we only have to pass down the fields of the snapshotted VDI, not the new
fields of the snapshot. This means that SMAPIv3 plugins will also have
to set the snapshot time correctly, instead of relying on the old
behaviour.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>