### PR TITLE
CA-282012: enable/disable clustering daemon

### DIFF
--- a/ocaml/xapi/test_cluster.ml
+++ b/ocaml/xapi/test_cluster.ml
@@ -52,21 +52,15 @@ let create_cluster ~__context =
 let test_create_destroy_status () =
   let __context = Test_common.make_test_database () in
   let cluster = create_cluster ~__context in
-  assert_equal ~msg:"cluster daemon started after create" true !Xapi_clustering.Daemon.started;
-  pool_destroy ~__context ~self:cluster;
-  assert_equal ~msg:"cluster daemon not started after destroy" false !Xapi_clustering.Daemon.started
+  pool_destroy ~__context ~self:cluster
 
 let test_enable () =
   let __context = Test_common.make_test_database () in
   let cluster = create_cluster ~__context in
-  assert_equal ~msg:"cluster daemon started" true !Xapi_clustering.Daemon.started;
   (* simulate xapi getting restarted *)
-  Xapi_clustering.Daemon.started := false;
 
   Create_storage.maybe_reenable_cluster_host __context;
-  assert_equal ~msg:"cluster daemon started after enable" true !Xapi_clustering.Daemon.started;
-  pool_destroy ~__context ~self:cluster;
-  assert_equal ~msg:"cluster daemon not started after destroy" false !Xapi_clustering.Daemon.started
+  pool_destroy ~__context ~self:cluster
 
 let test =
   "test_cluster" >:::

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -52,6 +52,7 @@ let create ~__context ~network ~cluster_stack ~pool_auto_join ~token_timeout ~to
         name = None
       } in
 
+      Xapi_clustering.Daemon.enable ~__context;
       let result = Cluster_client.LocalClient.create (rpc ~__context) dbg init_config in
       match result with
       | Result.Ok cluster_token ->
@@ -87,7 +88,7 @@ let destroy ~__context ~self =
       Db.Cluster_host.destroy ~__context ~self:ch
     ) cluster_host;
     Db.Cluster.destroy ~__context ~self;
-    Xapi_clustering.Daemon.stop ~__context
+    Xapi_clustering.Daemon.disable ~__context
   | Result.Error error -> handle_error error
 
 (* helper function; concurrency checks are done in implementation of Cluster.create and Cluster_host.create *)

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -81,6 +81,7 @@ let create ~__context ~cluster ~host =
           pif_of_host ~__context network |>
           ip_of_pif
         ) (Db.Cluster.get_cluster_hosts ~__context ~self:cluster) in
+      Xapi_clustering.Daemon.enable ~__context;
       let result = Cluster_client.LocalClient.join (rpc ~__context) dbg cluster_token ip ip_list in
       match result with
       | Result.Ok () ->
@@ -99,7 +100,7 @@ let force_destroy ~__context ~self =
   match result with
   | Result.Ok () ->
     Db.Cluster_host.destroy ~__context ~self;
-    Xapi_clustering.Daemon.stop ~__context
+    Xapi_clustering.Daemon.disable ~__context
   | Result.Error error -> handle_error error
 
 let destroy ~__context ~self =
@@ -112,7 +113,7 @@ let destroy ~__context ~self =
   match result with
   | Result.Ok () ->
     Db.Cluster_host.destroy ~__context ~self;
-    Xapi_clustering.Daemon.stop ~__context
+    Xapi_clustering.Daemon.disable ~__context
   | Result.Error error -> handle_error error
 
 let enable ~__context ~self =
@@ -147,7 +148,6 @@ let disable ~__context ~self =
       assert_operation_host_target_is_localhost ~__context ~host;
       assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__context ~self;
       let result = Cluster_client.LocalClient.disable (rpc ~__context) dbg in
-      Xapi_clustering.Daemon.stop ~__context;
       match result with
       | Result.Ok () ->
           Db.Cluster_host.set_enabled ~__context ~self ~value:false

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -159,31 +159,21 @@ let assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__conte
     srs
 
 module Daemon = struct
-  let started = ref false
-  let m = Mutex.create ()
-
   let maybe_call_script ~__context script params =
     match Context.get_test_clusterd_rpc __context with
     | Some _ -> debug "in unit test, not calling %s %s" script (String.concat " " params)
     | None -> ignore (Helpers.call_script script params)
 
-  let require ~__context =
-    Stdext.Threadext.Mutex.execute m (fun () ->
-        (* this function gets called on each RPC, it should only call out to `/sbin/service` when needed *)
-        if not !started then begin
-            debug "Cluster daemon: not started, starting it now";
-            maybe_call_script ~__context "/sbin/service" [ "xapi-clusterd"; "start" ];
-            started := true;
-            debug "Cluster daemon: started"
-          end)
+  let service = "xapi-clusterd"
+  let enable ~__context =
+    debug "Enabling and starting the clustering daemon";
+    maybe_call_script ~__context "/usr/bin/systemctl" [ "enable"; service ];
+    maybe_call_script ~__context "/usr/bin/systemctl" [ "start"; service ]
 
-  let stop ~__context =
-    Stdext.Threadext.Mutex.execute m (fun () ->
-        debug "Cluster daemon: stopping";
-        started := false;
-        maybe_call_script ~__context "/sbin/service" [ "xapi-clusterd"; "stop" ];
-        debug "Cluster daemon: stopped"
-      );
+  let disable ~__context =
+    debug "Disabling and stopping the clustering daemon";
+    maybe_call_script ~__context "/usr/bin/systemctl" [ "disable"; service ];
+    maybe_call_script ~__context "/usr/bin/systemctl" [ "stop"; service ]
 end
 
 (* xapi-clusterd only listens on message-switch,
@@ -192,7 +182,6 @@ end
  * Instead of returning an empty URL which wouldn't work just raise an
  * exception. *)
 let rpc ~__context =
-  Daemon.require ~__context;
   match Context.get_test_clusterd_rpc __context with
   | Some rpc -> rpc
   | None ->

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -168,12 +168,14 @@ module Daemon = struct
   let enable ~__context =
     debug "Enabling and starting the clustering daemon";
     maybe_call_script ~__context "/usr/bin/systemctl" [ "enable"; service ];
-    maybe_call_script ~__context "/usr/bin/systemctl" [ "start"; service ]
+    maybe_call_script ~__context "/usr/bin/systemctl" [ "start"; service ];
+    debug "Cluster daemon: enabled & started"
 
   let disable ~__context =
     debug "Disabling and stopping the clustering daemon";
     maybe_call_script ~__context "/usr/bin/systemctl" [ "disable"; service ];
-    maybe_call_script ~__context "/usr/bin/systemctl" [ "stop"; service ]
+    maybe_call_script ~__context "/usr/bin/systemctl" [ "stop"; service ];
+    debug "Cluster daemon: disabled & stopped"
 end
 
 (* xapi-clusterd only listens on message-switch,


### PR DESCRIPTION
Starting the cluster daemon on the first XAPI RPC call doesn't work when HA is
enabled and we need to start clustering from the static-vdis script before XAPI
is fully operational.

Instead of starting/stopping the clustering daemon from XAPI on boot let systemd
do it: just enable/disable the service when a cluster host is created/destroyed.

This still keeps the semantics we wanted, i.e. when clustering is disabled we do
not have a running clustering daemon.

[I'm running a BVT on an internal branch, we should wait until that completes before merging]