### PR TITLE
CP-25699 Refine PIF type check related stuff

### DIFF
--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -217,35 +217,6 @@ let destroy_vlan ~__context vlan =
   in
   [bridge, false]
 
-let get_bond pif_rc =
-  match pif_rc.API.pIF_bond_master_of with
-  | [] -> None
-  | bond :: _ ->
-    Some bond
-
-let get_vlan pif_rc =
-  if pif_rc.API.pIF_VLAN_master_of = Ref.null then
-    None
-  else
-    Some pif_rc.API.pIF_VLAN_master_of
-
-let get_tunnel pif_rc =
-  if pif_rc.API.pIF_tunnel_access_PIF_of = [] then
-    None
-  else
-    Some (List.hd pif_rc.API.pIF_tunnel_access_PIF_of)
-
-let get_pif_type pif_rc =
-  match get_vlan pif_rc with
-  | Some vlan -> `vlan_pif vlan
-  | None ->
-    match get_bond pif_rc with
-    | Some bond -> `bond_pif bond
-    | None ->
-      match get_tunnel pif_rc with
-      | Some tunnel -> `tunnel_pif tunnel
-      | None -> `phy_pif
-
 let linux_pif_config pif_type pif_rc properties mtu persistent =
   (* If we are using linux bridge rather than OVS, then we need to
      	 * configure the "pif" that represents the vlan or bond.
@@ -264,13 +235,13 @@ let rec create_bridges ~__context pif_rc net_rc =
   let other_config = determine_other_config ~__context pif_rc net_rc in
   let persistent = is_dom0_interface pif_rc in
   let igmp_snooping = Some (Db.Pool.get_igmp_snooping_enabled ~__context ~self:(Helpers.get_pool ~__context)) in
-  match get_pif_type pif_rc with
-  | `tunnel_pif _ ->
+  match Xapi_pif_helpers.get_pif_type pif_rc with
+  | Tunnel_access _ ->
     [],
     [net_rc.API.network_bridge, {default_bridge with bridge_mac=(Some pif_rc.API.pIF_MAC);
                                                      igmp_snooping; other_config; persistent_b=persistent}],
     []
-  | `vlan_pif vlan ->
+  | VLAN_untagged vlan ->
     let original_pif_rc = pif_rc in
     let slave = Db.VLAN.get_tagged_PIF ~__context ~self:vlan in
     let pif_rc = Db.PIF.get_record ~__context ~self:slave in
@@ -283,14 +254,14 @@ let rec create_bridges ~__context pif_rc net_rc =
     cleanup,
     create_vlan ~__context vlan persistent @ bridge_config,
     interface_config
-  | `bond_pif bond ->
+  | Bond_master bond ->
     let cleanup, bridge_config, interface_config = create_bond ~__context bond mtu persistent in
     let interface_config = (*  Add configuration for the bond pif itself *)
       linux_pif_config `bond_pif pif_rc pif_rc.API.pIF_properties mtu persistent
       :: interface_config
     in
     cleanup, bridge_config, interface_config
-  | `phy_pif  ->
+  | Physical _ ->
     let cleanup =
       if pif_rc.API.pIF_bond_slave_of <> Ref.null then
         destroy_bond ~__context ~force:true pif_rc.API.pIF_bond_slave_of
@@ -304,12 +275,14 @@ let rec create_bridges ~__context pif_rc net_rc =
     [net_rc.API.network_bridge, {default_bridge with ports; bridge_mac=(Some pif_rc.API.pIF_MAC);
                                                      igmp_snooping; other_config; persistent_b=persistent}],
     [pif_rc.API.pIF_device, {default_interface with mtu; ethtool_settings; ethtool_offload; persistent_i=persistent}]
+  | Network_sriov_logical _ ->
+    raise (Api_errors.Server_error (Api_errors.internal_error, ["Should not create bridge for SRIOV logical PIF"]))
 
 let rec destroy_bridges ~__context ~force pif_rc bridge =
-  match get_pif_type pif_rc with
-  | `tunnel_pif _ ->
+  match Xapi_pif_helpers.get_pif_type pif_rc with
+  | Tunnel_access _ ->
     [bridge, false]
-  | `vlan_pif vlan ->
+  | VLAN_untagged vlan ->
     let cleanup = destroy_vlan ~__context vlan in
     let slave = Db.VLAN.get_tagged_PIF ~__context ~self:vlan in
     let rc = Db.PIF.get_record ~__context ~self:slave in
@@ -318,10 +291,12 @@ let rec destroy_bridges ~__context ~force pif_rc bridge =
       (destroy_bridges ~__context ~force rc bridge) @ cleanup
     else
       cleanup
-  | `bond_pif bond ->
+  | Bond_master bond ->
     destroy_bond ~__context ~force bond
-  | `phy_pif  ->
+  | Physical _ ->
     [bridge, false]
+  | Network_sriov_logical _ ->
+    raise (Api_errors.Server_error (Api_errors.internal_error, ["Should not destroy bridge for SRIOV logical PIF"]))
 
 let determine_static_routes net_rc =
   if List.mem_assoc "static-routes" net_rc.API.network_other_config then

--- a/ocaml/xapi/test_common.ml
+++ b/ocaml/xapi/test_common.ml
@@ -162,6 +162,9 @@ let make_pif ~__context ~network ~host ?(device="eth0") ?(mAC="C0:FF:EE:C0:FF:EE
     ~iP ~netmask ~gateway ~dNS ~bond_slave_of ~vLAN_master_of ~management ~other_config ~disallow_unplug
     ~ipv6_configuration_mode ~iPv6 ~ipv6_gateway ~primary_address_type ~managed ~properties
 
+let make_vlan ~__context ~tagged_PIF ~untagged_PIF ~tag ?(other_config=[]) () =
+  Xapi_vlan.pool_introduce ~__context ~tagged_PIF ~untagged_PIF ~tag ~other_config
+
 let make_network ~__context ?(name_label="net") ?(name_description="description") ?(mTU=1500L)
     ?(other_config=[]) ?(bridge="xenbr0") ?(managed=true) ?(purpose=[]) () =
   Xapi_network.pool_introduce ~__context ~name_label ~name_description ~mTU ~other_config ~bridge ~managed ~purpose

--- a/ocaml/xapi/test_vlan.ml
+++ b/ocaml/xapi/test_vlan.ml
@@ -89,15 +89,19 @@ let test_create_pif_not_a_bond_slave () =
 
 let test_create_pif_not_vlan_slave () =
   let __context = make_test_database () in
-  let tag = 3201L in
   let host = make_host ~__context () in
   let network = make_network ~__context () in
+  let tagged_PIF = make_pif ~__context ~network ~host () in
   let vlan_network = make_network ~__context ~bridge:"xapi0" () in
-  let tagged_PIF = make_pif ~__context ~network ~host ~vLAN:0L () in
+  let untagged_PIF = make_pif ~__context ~network:vlan_network ~host ~vLAN:0L () in
+  let _ = make_vlan ~__context ~tagged_PIF ~untagged_PIF ~tag:0L () in
+  let vlan_network2 = make_network ~__context ~bridge:"xapi02" () in
   assert_raises_api_error
     Api_errors.pif_is_vlan
-    ~args:[Ref.string_of tagged_PIF]
-    (fun () -> Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network)
+    ~args:[Ref.string_of untagged_PIF]
+    (fun () ->
+       let tag = 3201L in
+       Xapi_vlan.create ~__context ~tagged_PIF:untagged_PIF ~tag ~network:vlan_network2)
 
 let test_create_invalid_tag () =
   let __context = make_test_database () in

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -334,19 +334,11 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
       (* 7. Members must have the same PIF properties *)
       (* 8. Only the primary PIF should have a non-None IP configuration *)
       List.iter (fun self ->
-          let bond = Db.PIF.get_bond_slave_of ~__context ~self in
-          let bonded = try ignore(Db.Bond.get_uuid ~__context ~self:bond); true with _ -> false in
-          if bonded
-          then raise (Api_errors.Server_error (Api_errors.pif_already_bonded, [ Ref.string_of self ]));
-          if Db.PIF.get_VLAN ~__context ~self <> -1L
-          then raise (Api_errors.Server_error (Api_errors.pif_vlan_exists, [ Db.PIF.get_device_name ~__context ~self] ));
-          if Db.PIF.get_tunnel_access_PIF_of ~__context ~self <> []
-          then raise (Api_errors.Server_error (Api_errors.is_tunnel_access_pif, [Ref.string_of self]));
+          Xapi_pif_helpers.assert_pif_is_managed ~__context ~self;
+          Xapi_pif_helpers.bond_is_allowed_on_pif ~__context ~self;
           let pool = Helpers.get_pool ~__context in
           if Db.Pool.get_ha_enabled ~__context ~self:pool && Db.PIF.get_management ~__context ~self
           then raise (Api_errors.Server_error(Api_errors.ha_cannot_change_bond_status_of_mgmt_iface, []));
-          if Db.PIF.get_managed ~__context ~self <> true
-          then raise (Api_errors.Server_error (Api_errors.pif_unmanaged, [Ref.string_of self]));
         ) members;
       let hosts = List.map (fun self -> Db.PIF.get_host ~__context ~self) members in
       if List.length (List.setify hosts) <> 1

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -213,10 +213,6 @@ let assert_not_management_pif ~__context ~self =
   if Db.PIF.get_management ~__context ~self then
     raise (Api_errors.Server_error (Api_errors.pif_is_management_iface, [ Ref.string_of self ]))
 
-let assert_pif_is_managed ~__context ~self =
-  if Db.PIF.get_managed ~__context ~self <> true then
-    raise (Api_errors.Server_error (Api_errors.pif_unmanaged, [Ref.string_of self]))
-
 let assert_not_slave_management_pif ~__context ~self =
   if true
   && Pool_role.is_slave ()
@@ -637,7 +633,7 @@ let destroy ~__context ~self =
        Client.Client.VLAN.destroy rpc session_id vlan)
 
 let reconfigure_ipv6 ~__context ~self ~mode ~iPv6 ~gateway ~dNS =
-  assert_pif_is_managed ~__context ~self;
+  Xapi_pif_helpers.assert_pif_is_managed ~__context ~self;
   assert_no_protection_enabled ~__context ~self;
 
   if gateway <> "" then
@@ -686,7 +682,7 @@ let reconfigure_ipv6 ~__context ~self ~mode ~iPv6 ~gateway ~dNS =
     end
 
 let reconfigure_ip ~__context ~self ~mode ~iP ~netmask ~gateway ~dNS =
-  assert_pif_is_managed ~__context ~self;
+  Xapi_pif_helpers.assert_pif_is_managed ~__context ~self;
   assert_no_protection_enabled ~__context ~self;
 
   if mode = `Static then begin
@@ -784,7 +780,7 @@ let set_property ~__context ~self ~name ~value =
     ) (self :: vlan_pifs)
 
 let rec unplug ~__context ~self =
-  assert_pif_is_managed ~__context ~self;
+  Xapi_pif_helpers.assert_pif_is_managed ~__context ~self;
   assert_no_protection_enabled ~__context ~self;
   assert_not_management_pif ~__context ~self;
   let host = Db.PIF.get_host ~__context ~self in
@@ -808,7 +804,7 @@ let rec unplug ~__context ~self =
   Nm.bring_pif_down ~__context self
 
 let rec plug ~__context ~self =
-  assert_pif_is_managed ~__context ~self;
+  Xapi_pif_helpers.assert_pif_is_managed ~__context ~self;
   let tunnel = Db.PIF.get_tunnel_access_PIF_of ~__context ~self in
   if tunnel <> []
   then begin

--- a/ocaml/xapi/xapi_pif_helpers.ml
+++ b/ocaml/xapi/xapi_pif_helpers.ml
@@ -1,0 +1,145 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+open API
+module D=Debug.Make(struct let name="xapi" end)
+open D
+
+(* Any given PIF should belongs only one of the following types *)
+type pif_type_t =
+  | Tunnel_access of ref_tunnel
+  | VLAN_untagged of ref_VLAN
+  | Network_sriov_logical of ref_network_sriov
+  | Bond_master of ref_Bond
+  | Physical of pIF_t
+
+let pif_type_to_string = function
+  | Tunnel_access _ -> "Tunnel_access"
+  | VLAN_untagged _ -> "VLAN_untagged"
+  | Network_sriov_logical _ -> "Network_sriov_logical"
+  | Bond_master _ -> "Bond_master"
+  | Physical _ -> "Physical"
+
+let is_tunnel_access_pif pif_rec =
+  match pif_rec.API.pIF_tunnel_access_PIF_of with
+  | tunnel :: _ -> Some (Tunnel_access tunnel)
+  | _ -> None
+
+let is_vlan_master_pif pif_rec =
+  let vlan = pif_rec.API.pIF_VLAN_master_of in
+  if vlan = Ref.null then None else Some (VLAN_untagged vlan)
+
+let is_sriov_logical_pif pif_rec =
+  match pif_rec.API.pIF_sriov_logical_PIF_of with
+  | sriov :: _ -> Some (Network_sriov_logical sriov)
+  | _ -> None
+
+let is_bond_master_pif pif_rec =
+  match pif_rec.API.pIF_bond_master_of with
+  | bond :: _ -> Some (Bond_master bond)
+  | _ -> None
+
+let is_physical_pif pif_rec =
+  if pif_rec.API.pIF_physical then Some (Physical pif_rec) else None
+
+let (>>=) (ret, pif_rec) f =
+  match ret, pif_rec with
+  | Some _ as v, _ -> v, pif_rec
+  | None, _ -> f pif_rec, pif_rec
+
+let get_pif_type pif_rec =
+  match (None, pif_rec)
+    >>= is_tunnel_access_pif
+    >>= is_vlan_master_pif
+    >>= is_sriov_logical_pif
+    >>= is_bond_master_pif
+    >>= is_physical_pif
+  with
+  | Some v, _ -> v
+  | None, _ -> raise (Api_errors.Server_error (Api_errors.internal_error, [Printf.sprintf "Cannot calculate PIF type of %s" pif_rec.API.pIF_uuid]))
+
+(** This function aims to get a list of types of the PIFs underneath the given PIF *)
+(* The root PIF underneath should be Physical or Bond_master *)
+let get_pif_topo ~__context ~pif_rec =
+  let rec get_pif_type_till_root ret pif_rec =
+    let pif_t = get_pif_type pif_rec in
+    match pif_t with
+    | Tunnel_access tunnel ->
+      let tunnel_rec = Db.Tunnel.get_record ~__context ~self:tunnel in
+      let pif_ref = tunnel_rec.API.tunnel_transport_PIF in
+      let pif_rec = Db.PIF.get_record ~__context ~self:pif_ref in
+      get_pif_type_till_root (pif_t :: ret) pif_rec
+    | VLAN_untagged vlan ->
+      let vlan_rec = Db.VLAN.get_record ~__context ~self:vlan in
+      let pif_ref = vlan_rec.API.vLAN_tagged_PIF in
+      let pif_rec = Db.PIF.get_record ~__context ~self:pif_ref in
+      get_pif_type_till_root (pif_t :: ret) pif_rec
+    | Network_sriov_logical sriov ->
+      let sriov_rec = Db.Network_sriov.get_record ~__context ~self:sriov in
+      let pif_ref = sriov_rec.API.network_sriov_physical_PIF in
+      let pif_rec = Db.PIF.get_record ~__context ~self:pif_ref in
+      get_pif_type_till_root (pif_t :: ret) pif_rec
+    | Bond_master _
+    | Physical _ ->
+      pif_t :: ret
+  in
+  let pif_t_list = get_pif_type_till_root [] pif_rec in
+  let pif_t_list = List.rev pif_t_list in
+  debug "PIF type of %s is: %s" pif_rec.API.pIF_uuid (String.concat " " (List.map pif_type_to_string pif_t_list));
+  pif_t_list
+
+let vlan_is_allowed_on_pif ~__context ~tagged_PIF ~tag =
+  let pif_rec = Db.PIF.get_record ~__context ~self:tagged_PIF in
+  match get_pif_topo ~__context ~pif_rec with
+  | Physical pif_rec :: _ when pif_rec.API.pIF_bond_slave_of <> Ref.null ->
+    (* Disallow creating on bond slave *)
+    (* Here we rely on the implementation to guarantee that `Phisycal` is a terminating case *)
+    raise (Api_errors.Server_error (Api_errors.cannot_add_vlan_to_bond_slave, [Ref.string_of tagged_PIF]))
+  | VLAN_untagged _ :: _ ->
+    (* Check that the tagged PIF is not a VLAN itself - CA-25160. This check can be skipped using the allow_vlan_on_vlan FIST point. *)
+    if not (Xapi_fist.allow_vlan_on_vlan()) then
+      raise (Api_errors.Server_error (Api_errors.pif_is_vlan, [Ref.string_of tagged_PIF]))
+  | Tunnel_access _ :: _ ->
+    raise (Api_errors.Server_error (Api_errors.is_tunnel_access_pif, [Ref.string_of tagged_PIF]))
+  | _ -> ()
+
+let tunnel_is_allowed_on_pif ~__context ~transport_PIF =
+  let pif_rec = Db.PIF.get_record ~__context ~self:transport_PIF in
+  match get_pif_topo ~__context ~pif_rec with
+  | Physical pif_rec :: _ when pif_rec.API.pIF_bond_slave_of <> Ref.null ->
+    (* Disallow creating on bond slave *)
+    (* Here we rely on the implementation to guarantee that `Phisycal` is a terminating case *)
+    raise (Api_errors.Server_error (Api_errors.cannot_add_tunnel_to_bond_slave, [Ref.string_of transport_PIF]))
+  | Tunnel_access _ :: _ ->
+    raise (Api_errors.Server_error (Api_errors.is_tunnel_access_pif, [Ref.string_of transport_PIF]));
+  | _ -> ()
+
+let bond_is_allowed_on_pif ~__context ~self =
+  let pif_rec = Db.PIF.get_record ~__context ~self in
+  match get_pif_topo ~__context ~pif_rec with
+  | Physical pif_rec :: _ when pif_rec.API.pIF_bond_slave_of <> Ref.null ->
+    (* Disallow creating on bond slave *)
+    (* Here we rely on the implementation to guarantee that `Phisycal` is a terminating case *)
+    let bond = pif_rec.API.pIF_bond_slave_of in
+    let bonded = try ignore(Db.Bond.get_uuid ~__context ~self:bond); true with _ -> false in
+    if bonded
+    then raise (Api_errors.Server_error (Api_errors.pif_already_bonded, [ Ref.string_of self ]))
+  | VLAN_untagged _ :: _ ->
+    raise (Api_errors.Server_error (Api_errors.pif_vlan_exists, [Db.PIF.get_device_name ~__context ~self] ))
+  | Tunnel_access _ :: _ ->
+    raise (Api_errors.Server_error (Api_errors.is_tunnel_access_pif, [Ref.string_of self]))
+  | _ -> ()
+
+let assert_pif_is_managed ~__context ~self =
+  if Db.PIF.get_managed ~__context ~self <> true then
+    raise (Api_errors.Server_error (Api_errors.pif_unmanaged, [Ref.string_of self]))

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -45,19 +45,10 @@ let create_internal ~__context ~host ~tagged_PIF ~tag ~network ~device =
 
 let create ~__context ~tagged_PIF ~tag ~network =
   Xapi_network.assert_network_is_managed ~__context ~self:network;
-  if Db.PIF.get_managed ~__context ~self:tagged_PIF <> true then
-    raise (Api_errors.Server_error (Api_errors.pif_unmanaged, [Ref.string_of tagged_PIF]));
-
   let host = Db.PIF.get_host ~__context ~self:tagged_PIF in
   Xapi_pif.assert_no_other_local_pifs ~__context ~host ~network;
-
-  if Db.PIF.get_bond_slave_of ~__context ~self:tagged_PIF <> Ref.null then
-    raise (Api_errors.Server_error (Api_errors.cannot_add_vlan_to_bond_slave, [Ref.string_of tagged_PIF]));
-
-  (* Check that the tagged PIF is not a VLAN itself - CA-25160. This check can be skipped using the allow_vlan_on_vlan FIST point. *)
-  let origtag = Db.PIF.get_VLAN ~__context ~self:tagged_PIF in
-  if origtag >= 0L && not (Xapi_fist.allow_vlan_on_vlan()) then
-    raise (Api_errors.Server_error (Api_errors.pif_is_vlan, [Ref.string_of tagged_PIF]));
+  Xapi_pif_helpers.assert_pif_is_managed ~__context ~self:tagged_PIF;
+  Xapi_pif_helpers.vlan_is_allowed_on_pif ~__context ~tagged_PIF ~tag;
 
   (* Check the VLAN tag is sensible;  4095 is reserved for implementation use (802.1Q) *)
   if tag<0L || tag>4094L then
@@ -67,11 +58,9 @@ let create ~__context ~tagged_PIF ~tag ~network =
   let vlans = Db.VLAN.get_records_where ~__context
       ~expr:(Db_filter_types.And (Db_filter_types.Eq (Db_filter_types.Field "tagged_PIF", Db_filter_types.Literal (Ref.string_of tagged_PIF)),
                                   Db_filter_types.Eq (Db_filter_types.Field "tag", Db_filter_types.Literal (Int64.to_string tag)))) in
-  if vlans <> [] then
-    raise (Api_errors.Server_error (Api_errors.pif_vlan_exists, [device]));
-
-  if Db.PIF.get_tunnel_access_PIF_of ~__context ~self:tagged_PIF <> [] then
-    raise (Api_errors.Server_error (Api_errors.is_tunnel_access_pif, [Ref.string_of tagged_PIF]));
+  if vlans <> [] then begin
+    raise (Api_errors.Server_error (Api_errors.pif_vlan_exists, [device]))
+  end;
 
   (* Check the VLAN is not in use by the kernel *)
   let open Network in


### PR DESCRIPTION
1. Add Xapi_pif_helpers.ml contains:
  + Add get_pif_type to get PIF type
  + Add X_is_allowed_on_pif serial functions to exectue check before creating
  VLAN, bond and tunnel
2. Add support of sriov PIF in nm.bring_pif_up and nm.bring_pif_down
3. Apply Xapi_pif_helpers.get_pif_type in nm.ml
4. Refine VLAN UT

Signed-off-by: Yang Qian <yang.qian@citrix.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xen-api/3431)
<!-- Reviewable:end -->
