### PR TITLE
[477 idl part2] SR.create API change and sharable flag

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -210,7 +210,7 @@ module SMAPIv1 = struct
                   error "SR.create failed SR:%s error:%s" (Ref.string_of sr) e';
                   raise e
              );
-            device_config
+            List.filter (fun (x,_) -> x <> "SRmaster") device_config
         )
 
     let set_name_label context ~dbg ~sr ~new_name_label =

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -106,6 +106,7 @@ module SMAPIv1 = struct
       virtual_size = vdi_rec.API.vDI_virtual_size;
       physical_utilisation = vdi_rec.API.vDI_physical_utilisation;
       persistent = vdi_rec.API.vDI_on_boot = `persist;
+      sharable = vdi_rec.API.vDI_sharable;
       sm_config = vdi_rec.API.vDI_sm_config;
     }
 

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -208,7 +208,8 @@ module SMAPIv1 = struct
                   let e' = ExnHelper.string_of_exn e in
                   error "SR.create failed SR:%s error:%s" (Ref.string_of sr) e';
                   raise e
-             )
+             );
+            device_config
         )
 
     let set_name_label context ~dbg ~sr ~new_name_label =
@@ -1467,8 +1468,9 @@ let create_sr ~__context ~sr ~name_label ~name_description ~physical_size =
        let pbd, pbd_t = Sm.get_my_pbd_for_sr __context sr in
        let (_ : query_result) = bind ~__context ~pbd in
        let dbg = Ref.string_of (Context.get_task_id __context) in
-       Client.SR.create dbg (Db.SR.get_uuid ~__context ~self:sr) name_label name_description pbd_t.API.pBD_device_config physical_size;
-       unbind ~__context ~pbd
+       let result = Client.SR.create dbg (Db.SR.get_uuid ~__context ~self:sr) name_label name_description pbd_t.API.pBD_device_config physical_size in
+       unbind ~__context ~pbd;
+       result
     )
 
 (* This is because the current backends want SR.attached <=> PBD.currently_attached=true.

--- a/ocaml/xapi/storage_access.mli
+++ b/ocaml/xapi/storage_access.mli
@@ -109,7 +109,7 @@ val diagnostics: __context:Context.t -> string
 val dp_destroy: __context:Context.t -> string -> bool -> unit
 
 (** [create_sr __context sr name_label name_description physical_size] attempts to create an empty SR *)
-val create_sr: __context:Context.t -> sr:API.ref_SR -> name_label:string -> name_description:string -> physical_size:int64 -> unit
+val create_sr: __context:Context.t -> sr:API.ref_SR -> name_label:string -> name_description:string -> physical_size:int64 -> (string * string) list
 
 (** [destroy_sr __context sr] attempts to cleanup and destroy a given SR *)
 val destroy_sr: __context:Context.t -> sr:API.ref_SR -> and_vdis:(API.ref_VDI list) -> unit

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -425,7 +425,8 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
            ~sR:sr ~virtual_size:vdi.virtual_size
            ~physical_utilisation:vdi.physical_utilisation
            ~_type:(try Storage_utils.vdi_type_of_string vdi.ty with _ -> `user)
-           ~sharable:false ~read_only:vdi.read_only
+           ~sharable:vdi.sharable
+           ~read_only:vdi.read_only
            ~xenstore_data:[] ~sm_config:[]
            ~other_config:[] ~storage_lock:false ~location:vdi.vdi
            ~managed:true ~missing:false ~parent:Ref.null ~tags:[]
@@ -495,6 +496,10 @@ let update_vdis ~__context ~sr db_vdis vdi_infos =
        if v.API.vDI_cbt_enabled <> vi.cbt_enabled then begin
          debug "%s cbt_enabled <- %b" (Ref.string_of r) vi.cbt_enabled;
          Db.VDI.set_cbt_enabled ~__context ~self:r ~value:vi.cbt_enabled
+       end;
+       if v.API.vDI_sharable <> vi.sharable then begin
+         debug "%s sharable <- %b" (Ref.string_of r) vi.sharable;
+         Db.VDI.set_sharable ~__context ~self:r ~value:vi.sharable
        end
     ) to_update
 

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -408,6 +408,7 @@ let create ~__context ~name_label ~name_description
     ty = vdi_type;
     read_only = read_only;
     virtual_size = virtual_size;
+    sharable = sharable;
     sm_config = sm_config;
   } in
   let module C = Client(struct let rpc = rpc end) in

--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -114,6 +114,7 @@ def add(session, vdi_uuid, reason):
     host = session.xenapi.host.get_by_uuid(inventory.get_localhost_uuid ())
     sr = session.xenapi.VDI.get_SR(vdi)
     ty = session.xenapi.SR.get_type(sr)
+    sr_uuid = session.xenapi.SR.get_uuid(sr)
 
     # This host's device-config will have info needed to attach SMAPIv3
     # SRs.
@@ -142,7 +143,8 @@ def add(session, vdi_uuid, reason):
     if sm["features"].has_key("VDI_ATTACH_OFFLINE"):
         data["volume-plugin"] = ty
         data["sr-uri"] = device_config['uri']
-        sr = call_volume_plugin(ty, "SR.attach", [ data["sr-uri"] ])
+        data["sr-uuid"] = sr_uuid
+        sr = call_volume_plugin(ty, "SR.attach", [ data["sr-uuid"], data["sr-uri"] ])
         location = session.xenapi.VDI.get_location(vdi)
         stat = call_volume_plugin(ty, "Volume.stat", [ sr, location ])
         data["volume-uri"] = stat["uri"][0]
@@ -231,11 +233,12 @@ def attach(vdi_uuid):
                     path = call_backend_attach(driver, config)
                 else:
                     volume_plugin = read_whole_file(d + "/volume-plugin")
+                    sr_uuid = read_whole_file(d + "/sr-uuid")
                     sr_uri = read_whole_file(d + "/sr-uri")
                     vol_key = read_whole_file(d + "/volume-key")
                     vol_uri = read_whole_file(d + "/volume-uri")
                     scheme = urlparse.urlparse(vol_uri).scheme
-                    sr = call_volume_plugin(volume_plugin, "SR.attach", [ sr_uri ])
+                    sr = call_volume_plugin(volume_plugin, "SR.attach", [ sr_uuid, sr_uri ])
                     attach = call_datapath_plugin(scheme, "Datapath.attach", [ vol_uri, "0" ])
                     path = attach['implementation'][1]
                     call_datapath_plugin(scheme, "Datapath.activate", [ vol_uri, "0" ])


### PR DESCRIPTION
This is part of the SMAPIv3 interface  change from `feature/REQ477/master` branch.

Also expose the `sharable` field to SMAPIv3 (required for the HA statefile and redolog), internally XAPI already tracked this field. SMAPIv1 looked in `sm-config` to find this out, no change there.

This PR needs to be merged together with these ones otherwise the build breaks:
https://github.com/xapi-project/sm-cli/pull/26
https://github.com/xapi-project/xapi-storage/pull/70
https://github.com/xapi-project/xapi-storage-script/pull/56
https://github.com/xapi-project/xcp-idl/pull/202

Build on internal branch `private/edvint/477-idl-part2`. The `feature/REQ477/master` branch that these commits were part of had 2 full nightlies run on it, please let me know what kind of tests should be run on these reduced set of changes.