### PR TITLE
CP-25795: Add new VIF backend for network SR-IOV

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -130,6 +130,29 @@ let backend_of_network net =
   end else
     Network.Local net.API.network_bridge (* PR-1255 *)
 
+let backend_of_vif ~__context ~vif =
+  let vif_record = Db.VIF.get_record_internal ~__context ~self:vif in
+  let net = Db.Network.get_record ~__context ~self:vif_record.Db_actions.vIF_network in
+  let host = Helpers.get_localhost ~__context in
+  let pifs = Xapi_network_attach_helpers.get_local_pifs ~__context
+    ~network:vif_record.Db_actions.vIF_network ~host
+  in
+  match pifs with
+  | [] -> backend_of_network net
+  | pif :: _ ->
+    let pif_rec = Db.PIF.get_record ~__context ~self:pif in
+    let l = Xapi_pif_helpers.get_pif_topo ~__context ~pif_rec in
+    if List.exists (function Xapi_pif_helpers.Network_sriov_logical _ -> true | _ -> false) l then
+      begin
+        if vif_record.Db_actions.vIF_reserved_pci <> Ref.null then
+          let (domain, bus, dev, fn) =
+            Pciops.pcidev_of_pci ~__context vif_record.Db_actions.vIF_reserved_pci in
+          Network.Sriov {domain; bus; dev; fn}
+        else raise (Api_errors.(Server_error (internal_error,
+            [Printf.sprintf "No reserved_pci for network SR-IOV vif %s" (Ref.string_of vif)])))
+      end
+    else backend_of_network net
+
 let find f map default feature =
   try
     let v = List.assoc feature map in
@@ -450,11 +473,11 @@ module MD = struct
       | `locked, _ -> Vif.Locked { Vif.ipv4 = vif.API.vIF_ipv4_allowed; ipv6 = vif.API.vIF_ipv6_allowed }
       | `unlocked, _ -> Vif.Unlocked
       | `disabled, _ -> Vif.Disabled in
+    let host = Helpers.get_localhost ~__context in
+    let pifs = Xapi_network_attach_helpers.get_local_pifs ~__context ~network:vif.API.vIF_network ~host in
     let carrier =
       if !Xapi_globs.pass_through_pif_carrier then
         (* We need to reflect the carrier of the local PIF on the network (if any) *)
-        let host = Helpers.get_localhost ~__context in
-        let pifs = Xapi_network_attach_helpers.get_local_pifs ~__context ~network:vif.API.vIF_network ~host in
         match pifs with
         | [] -> true (* Internal network; consider as "always up" *)
         | pif :: _ ->
@@ -491,6 +514,12 @@ module MD = struct
         (of_pvs_proxy ~__context vif)
         (Pvs_proxy_control.find_proxy_for_vif ~__context ~vif:vif_ref)
     in
+    let vlan = match pifs with
+      | [] -> None
+      | pif :: _ ->
+        let vlan = Db.PIF.get_VLAN ~__context ~self:pif in
+        if vlan < 0L then None else Some vlan
+    in
     let open Vif in {
       id = (vm.API.vM_uuid, vif.API.vIF_device);
       position = int_of_string vif.API.vIF_device;
@@ -498,14 +527,14 @@ module MD = struct
       carrier = carrier;
       mtu = mtu;
       rate = rate;
-      backend = backend_of_network net;
+      backend = backend_of_vif ~__context ~vif:vif_ref;
       other_config = vif.API.vIF_other_config;
       locking_mode = locking_mode;
       extra_private_keys;
       ipv4_configuration = ipv4_configuration;
       ipv6_configuration = ipv6_configuration;
       pvs_proxy;
-      vlan = None
+      vlan = vlan;
     }
 
   let pcis_of_vm ~__context (vmref, vm) =
@@ -1757,26 +1786,30 @@ let update_vif ~__context id =
                  (try Client.VIF.remove dbg id with e -> debug "VIF.remove failed: %s" (Printexc.to_string e))
                end;
 
-               if state.plugged then begin
-                 (* sync MTU *)
-                 (try
-                    match state.device with
-                    | None -> failwith (Printf.sprintf "could not determine device id for VIF %s.%s" (fst id) (snd id))
-                    | Some device ->
-                      let dbg = Context.string_of_task __context in
-                      let mtu = Net.Interface.get_mtu dbg ~name:device in
-                      Db.VIF.set_MTU ~__context ~self:vif ~value:(Int64.of_int mtu)
-                  with _ ->
-                    debug "could not update MTU field on VIF %s.%s" (fst id) (snd id));
+               begin match backend_of_vif ~__context ~vif with
+                 | Network.Sriov _ -> ()
+                 | Network.Local _ | Network.Remote _ ->
+                   if state.plugged then begin
+                     (* sync MTU *)
+                     (try
+                        match state.device with
+                        | None -> failwith (Printf.sprintf "could not determine device id for VIF %s.%s" (fst id) (snd id))
+                        | Some device ->
+                          let dbg = Context.string_of_task __context in
+                          let mtu = Net.Interface.get_mtu dbg ~name:device in
+                          Db.VIF.set_MTU ~__context ~self:vif ~value:(Int64.of_int mtu)
+                      with _ ->
+                        debug "could not update MTU field on VIF %s.%s" (fst id) (snd id));
 
-                 (* Clear monitor cache for associated PIF if pass_through_pif_carrier is set *)
-                 if !Xapi_globs.pass_through_pif_carrier then
-                   let host = Helpers.get_localhost ~__context in
-                   let pifs = Xapi_network_attach_helpers.get_local_pifs ~__context ~network:vifr.API.vIF_network ~host in
-                   List.iter (fun pif ->
-                       let pif_name = Db.PIF.get_device ~__context ~self:pif in
-                       Monitor_dbcalls_cache.clear_cache_for_pif ~pif_name
-                     ) pifs
+                     (* Clear monitor cache for associated PIF if pass_through_pif_carrier is set *)
+                     if !Xapi_globs.pass_through_pif_carrier then
+                       let host = Helpers.get_localhost ~__context in
+                       let pifs = Xapi_network_attach_helpers.get_local_pifs ~__context ~network:vifr.API.vIF_network ~host in
+                       List.iter (fun pif ->
+                           let pif_name = Db.PIF.get_device ~__context ~self:pif in
+                           Monitor_dbcalls_cache.clear_cache_for_pif ~pif_name
+                         ) pifs
+                   end
                end;
                (match Pvs_proxy_control.find_proxy_for_vif ~__context ~vif with
                 | None -> ()
@@ -3071,17 +3104,21 @@ let vif_move ~__context ~self network =
        assert_resident_on ~__context ~self:vm;
        let vif = md_of_vif ~__context ~self in
        info "xenops: VIF.move %s.%s" (fst vif.Vif.id) (snd vif.Vif.id);
-       let network = Db.Network.get_record ~__context ~self:network in
-       let backend = backend_of_network network in
-       let dbg = Context.string_of_task __context in
-       let module Client = (val make_client queue_name : XENOPS) in
-       (* Nb., at this point, the database shows the vif on the new network *)
-       Xapi_network.attach_for_vif ~__context ~vif:self ();
-       Client.VIF.move dbg vif.Vif.id backend |> sync_with_task __context queue_name;
-       Events_from_xenopsd.wait queue_name dbg (fst vif.Vif.id) ();
-       if not (Db.VIF.get_currently_attached ~__context ~self) then
-         raise Api_errors.(Server_error(internal_error, [
-             Printf.sprintf "vif_move: Unable to plug moved VIF %s" (Ref.string_of self)]))
+       let backend = backend_of_vif ~__context ~vif:self in
+       match backend with
+       | Network.Sriov _ -> raise Api_errors.(Server_error(internal_error, [
+         Printf.sprintf "vif_move: Unable to move a network SR-IOV backed VIF %s"
+           (Ref.string_of self)]))
+       | _ ->
+         let dbg = Context.string_of_task __context in
+         let module Client = (val make_client queue_name : XENOPS) in
+         (* Nb., at this point, the database shows the vif on the new network *)
+         Xapi_network.attach_for_vif ~__context ~vif:self ();
+         Client.VIF.move dbg vif.Vif.id backend |> sync_with_task __context queue_name;
+         Events_from_xenopsd.wait queue_name dbg (fst vif.Vif.id) ();
+         if not (Db.VIF.get_currently_attached ~__context ~self) then
+           raise Api_errors.(Server_error(internal_error, [
+               Printf.sprintf "vif_move: Unable to plug moved VIF %s" (Ref.string_of self)]))
     )
 
 let vif_set_ipv4_configuration ~__context ~self =

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -123,11 +123,11 @@ let vdi_of_disk ~__context x = match String.split ~limit:2 '/' x with
     None
 
 let backend_of_network net =
-  if List.mem_assoc "backend_vm" net.API.network_other_config then begin
+  try
     let backend_vm = List.assoc "backend_vm" net.API.network_other_config in
     debug "Using VM %s as backend for VIF on network %s" backend_vm net.API.network_uuid;
     Network.Remote (backend_vm, net.API.network_bridge)
-  end else
+  with Not_found ->
     Network.Local net.API.network_bridge (* PR-1255 *)
 
 let backend_of_vif ~__context ~vif =


### PR DESCRIPTION
Three commits in this PR:
1. Support network SR-IOV VF backed vif. Add a new function to get backend of vif.
2. Add PCIs of network SR-IOV VFs into metadata.
3. Enhance backend_of_network function to reduce duplicate DB access.

Signed-off-by: Ming Lu ming.lu@citrix.com