### PR TITLE
CP-20544: initialize coverage for XAPI itself too

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -189,6 +189,7 @@ let init_args() =
   (* Immediately register callback functions *)
   register_callback_fns();
   Xcp_service.configure ~options:Xapi_globs.all_options ~resources:Xapi_globs.Resources.xcp_resources ();
+  Xcp_coverage.init "xapi";
   Xcp_coverage.dispatcher_init "xapi";
   if not !Xcp_client.use_switch
   then begin


### PR DESCRIPTION
`Xcp_coverage.dispatcher_init` only initializes the message-switch dispatcher
for  coverage messages, but doesn't make XAPI listen for such messages itself.

This meant that xenopsd was collecting coverage info, but XAPI was not.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>