### PR TITLE
CP-26857: Blocking 'forget' on SR-IOV logical PIF

### DIFF
--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -221,6 +221,14 @@ let assert_no_protection_enabled ~__context ~self =
                   (Api_errors.redo_log_is_enabled, []))
   end
 
+let assert_not_sriov_logical_pif ~__context ~self =
+  let pif_rec = Db.PIF.get_record ~__context ~self in
+  match Xapi_pif_helpers.get_pif_type pif_rec with
+  | Network_sriov_logical _ ->
+    raise Api_errors.(Server_error (internal_error,
+        [Printf.sprintf "Can not forget network SR-IOV logical PIF: %s" (Ref.string_of self)]))
+  | _ -> ()
+
 let abort_if_network_attached_to_protected_vms ~__context ~self =
   (* Abort a PIF.unplug if the Network
      	 * has VIFs connected to protected VMs *)
@@ -529,6 +537,7 @@ let forget ~__context ~self =
   assert_no_tunnels ~__context ~self;
   assert_not_slave_management_pif ~__context ~self;
   assert_no_protection_enabled ~__context ~self;
+  assert_not_sriov_logical_pif ~__context ~self;
 
   let host = Db.PIF.get_host ~__context ~self in
   let t = make_tables ~__context ~host in


### PR DESCRIPTION
This change blocks `PIF.forget` operation on SR-IOV logical PIF.
As this operation on SR-IOV logical PIF is a rare case, only an internal
error is designed for the blocking error.

Signed-off-by: Ming Lu <ming.lu@citrix.com>