### PR TITLE
Fix kpartx arguments in xe-edit-bootloader

### DIFF
--- a/scripts/xe-edit-bootloader
+++ b/scripts/xe-edit-bootloader
@@ -37,7 +37,7 @@ while getopts "hu:n:p:f:" opt ; do
     h) usage ;;
     u) vm_uuid=${OPTARG} ;;
     n) vm_name="${OPTARG}" ;;
-    p) device_number=${OPTARG} ;;
+    p) device_number=p${OPTARG} ;;
     f) default_file_list="${OPTARG}" ;;
     *) echo "Invalid option"; usage ;;
     esac

--- a/scripts/xe-edit-bootloader
+++ b/scripts/xe-edit-bootloader
@@ -84,7 +84,7 @@ function cleanup {
       rmdir ${mnt}
    fi
 
-   kpartx -d ${device}
+   kpartx -dvspp ${device}
 
    if [ ! -z "${vbd_uuid}" ]; then
       echo -n "Unplugging VBD: "
@@ -187,7 +187,7 @@ if [ ! -b ${device} ]; then
   exit 1
 fi
 
-kpartx -av ${device}
+kpartx -avspp ${device}
 mapped_device="/dev/mapper/${vdi_uuid}"
 
 echo -n "Waiting for ${mapped_device}${device_number}: "


### PR DESCRIPTION
For reference, see https://github.com/openSUSE/multipath-tools/blob/master/kpartx/kpartx.c#L114
kpartx will attempt to determine the delimiter based on the device name - my reading is if we have a device name that ends in a digit, a 'p' delimiter will be automatically added by default. If the device name ends in any other character the delimiter is not added by default.

The only way to make this consistent is to request a delimiter on the command line (https://github.com/openSUSE/multipath-tools/blob/master/kpartx/kpartx.c#L382 will set delim != NULL)