### PR TITLE
Update readme and maintainer info

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ Xen-enabled hosts and resource pools, and co-ordinates resources
 within the pool. Xapi exposes the Xen API interface for many
 languages and is a component of the XenServer project.
 Xen API is written mostly in [OCaml](http://caml.inria.fr/ocaml/)
-4.01.0.
+4.04.2
 
 Xapi is the main component produced by the Linux Foundation's
 [Xapi Project](http://xenproject.org/developers/teams/xapi.html).

--- a/README.markdown
+++ b/README.markdown
@@ -37,20 +37,6 @@ more time for review.
 Maintainers
 -----------
 
-This is a short list of people who currently maintain this project.
-
-* Christian Lindig <christian.lindig@citrix.com>
-* Euan Harris <euan.harris@citrix.com>
-* Frederico Mazzone <frederico.mazzone@citrix.com>
-* Gabor Igloi <gabor.igloi@citrix.com>
-* Jon Ludlam <jonathan.ludlam@citrix.com>
-* Konstantina Chremmou <konstantina.chremmou@citrix.com>
-* Marcello Seri <marcello.seri@citrix.com>
-* Rob Hoes <rob.hoes@citrix.com>
-* Sharad Yadav <sharad.yadav@citrix.com>
-* Thomas Sanders <thomas.sanders@citrix.com>
-* Zheng Li <zheng.li@citrix.com>
-
 You can usually find the developers hanging out in #xen-api on
 freenode. We are also reachable on the xen-api@lists.xenproject.org mailing
 list.

--- a/README.markdown
+++ b/README.markdown
@@ -21,8 +21,7 @@ Build and Install
 The build install instructions are currently being written. The Xapi
 Project contains a large list of dependencies and sub-projects, which
 are actually quite difficult to build independently. To build xen-api
-from source, we recommend using [dune (previously named jbuilder)](https://github.com/ocaml/dune)
-and [opam](https://opam.ocaml.org/doc/Manual.html) using the [xs-opam](https://github.com/xapi-project/xs-opam) remote.
+from source, we recommend using [opam](https://opam.ocaml.org/doc/Manual.html) with the [xs-opam](https://github.com/xapi-project/xs-opam) remote (detailed explanation in [readme](https://github.com/xapi-project/xs-opam/blob/master/README.md).
 
 Contributions
 -------------

--- a/README.markdown
+++ b/README.markdown
@@ -21,7 +21,7 @@ Build and Install
 The build install instructions are currently being written. The Xapi
 Project contains a large list of dependencies and sub-projects, which
 are actually quite difficult to build independently. To build xen-api
-from source, we recommend using [xenserver-core](https://github.com/xenserver/xenserver-core).
+from source, we recommend using [dune (previously named jbuilder)](https://github.com/ocaml/dune)
 
 Contributions
 -------------

--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,7 @@ The build install instructions are currently being written. The Xapi
 Project contains a large list of dependencies and sub-projects, which
 are actually quite difficult to build independently. To build xen-api
 from source, we recommend using [dune (previously named jbuilder)](https://github.com/ocaml/dune)
+and [opam](https://opam.ocaml.org/doc/Manual.html) using the [xs-opam](https://github.com/xapi-project/xs-opam) remote.
 
 Contributions
 -------------

--- a/README.markdown
+++ b/README.markdown
@@ -37,9 +37,7 @@ more time for review.
 Maintainers
 -----------
 
-You can usually find the developers hanging out in #xen-api on
-freenode. We are also reachable on the xen-api@lists.xenproject.org mailing
-list.
+Maintainers can be contacted via this mailing list: `xen-api@lists.xenproject.org`
 
 Licensing
 ---------


### PR DESCRIPTION
This PR seeks to update the information a newcomer would see when looking to either build or contribute to xapi, such as:

- the maintainers list (switched out for mailing list address)
- the OCaml version Xapi builds on
- build instructions (may be worth removing these too?)