### PR TITLE
Use guarded matching instead of matching exact error message strings

### DIFF
--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -375,14 +375,14 @@ let action_write_db marker generation_count write_fn sock datasockpath =
          write_fn datasock;
          R.debug "Finished writing database to data socket";
        with
-       | Sys_error("Connection reset by peer") ->
+       | Sys_error(x) when x=("Connection reset by peer") ->
          (* CA-41914: Note that if the block_device_io process internally
           * throws Timeout (or indeed any other exception), it will forcibly
           * close this connection, we'll see a Sys_error("Connection reset by
           * peer"). This can be safely suppressed because we'll hear all the
           * gory details in the response we read over the control socket. *)
          R.warn "I/O process forcibly closed the data socket while trying to write database to it. Await the response to see why it did that.";
-       | e ->
+       | Sys_error(_) as e | e ->
          (* We'll re-raise other exceptions, though. *)
          R.error "Got an unexpected exception while trying to write database to the data socket: %s. Re-raising." (Printexc.to_string e);
          raise e

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -695,10 +695,11 @@ let make_param_funs getall getallrecs getbyuuid record class_name def_filters de
         try
           set v
         with
-        (* XXX: -- warning 52 -- this might break with new ocaml compilers *)
-          (Failure "int_of_string") -> failwith ("Parameter "^k^" must be an integer")
-        | (Failure "float_of_string") -> failwith ("Parameter "^k^" must be a floating-point number")
-        | (Invalid_argument "bool_of_string") -> failwith ("Parameter "^k^" must be a boolean (true or false)")
+          (Failure x) when x="int_of_string" -> failwith ("Parameter "^k^" must be an integer")
+        | (Failure x) when x="float_of_string" -> failwith ("Parameter "^k^" must be a floating-point number")
+        | (Failure _) as e -> raise e
+        | (Invalid_argument x) when x="bool_of_string" -> failwith ("Parameter "^k^" must be a boolean (true or false)")
+        | (Invalid_argument _) as e -> raise e
         | e -> raise e
     in
     List.iter set_field set_params;


### PR DESCRIPTION
Warning 52 is triggered by match statements like `with (Failure "hd") -> [...]`.
This commit changes these match statements to guarded matches with catch-all cases,
satisfying the compiler warning without changing functionality.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>