### PR TITLE
CA-280981: Import dom0 record on pool join

### DIFF
--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -232,7 +232,7 @@ let remote_metadata_export_import ~__context ~rpc ~session_id ~remote_address ~r
   let open Xmlrpc_client in
 
   let local_export_request = match which with
-    | `All -> "all=true"
+    | `All -> "all=true&include_dom0=true"
     | `Only {vm=vm; send_snapshots=send_snapshots} -> Printf.sprintf "export_snapshots=%b&ref=%s" send_snapshots (Ref.string_of vm) in
 
   let remote_import_request =


### PR DESCRIPTION
This record may contain data, e.g. perfmon settings in other-config, that we would like to keep in the pool. Previously, the dom0 record was recreated in the pool after xapi first restart as a slave.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>