### PR TITLE
[Cp 26826] fsync XAPI master DB on major lifecycle operations

### DIFF
--- a/ocaml/database/backend_xml.mli
+++ b/ocaml/database/backend_xml.mli
@@ -15,6 +15,6 @@
 open Db_cache_types
 
 val populate: Schema.t -> Parse_db_conf.db_connection -> Database.t
-val flush_dirty: Parse_db_conf.db_connection -> bool
-val flush: Parse_db_conf.db_connection -> Database.t -> unit
+val flush_dirty: ?fsync:bool -> Parse_db_conf.db_connection -> bool
+val flush: ?fsync:bool -> Parse_db_conf.db_connection -> Database.t -> unit
 

--- a/ocaml/database/db_connections.ml
+++ b/ocaml/database/db_connections.ml
@@ -15,8 +15,6 @@ module D = Debug.Make(struct let name = "xapi" end)
 module R = Debug.Make(struct let name = "redo_log" end)
 open D
 
-open Db_cache_types
-
 let get_dbs_and_gen_counts() =
   List.map (fun conn->(Parse_db_conf.generation_read conn, conn)) (Db_conn_store.read_db_connections())
 
@@ -105,10 +103,9 @@ let flush_dirty_and_maybe_exit dbconn ?(fsync=false) exit_spec =
 
 let flush dbconn db =
   debug "About to flush database: %s" dbconn.Parse_db_conf.path;
-  let fsync = dbconn.fsync_enabled in
   Db_conn_store.with_db_conn_lock dbconn
     (fun () ->
-       Backend_xml.flush dbconn db ~fsync
+       Backend_xml.flush dbconn db ~fsync:(dbconn.Parse_db_conf.fsync_enabled)
     )
 
 

--- a/ocaml/database/db_connections.ml
+++ b/ocaml/database/db_connections.ml
@@ -40,8 +40,10 @@ let choose connections = match List.filter exists connections with
     debug "Most recent db is %s (generation %Ld)" most_recent.Parse_db_conf.path gen;
     Some most_recent
 
-let preferred_write_db () =
-  List.hd (Db_conn_store.read_db_connections()) (* !!! FIX ME *)
+let preferred_write_db =
+  match Db_conn_store.read_db_connections() with
+  | [] -> None
+  | db :: _ -> Some db
 
 (* This is set by signal handlers. It instructs the db thread to call exit after the next flush *)
 let exit_on_next_flush = ref false

--- a/ocaml/database/db_xml.ml
+++ b/ocaml/database/db_xml.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 open Db_cache_types
-open Xapi_stdext_unix
 module R = Debug.Make(struct let name = "redo_log" end)
 module D = Debug.Make(struct let name = "database" end)
 
@@ -87,15 +86,13 @@ module To = struct
     flush oc;
     if fsync then begin
       D.debug "fsyncing database before close";
-      Unixext.fsync fd
+      Xapi_stdext_unix.Unixext.fsync fd
     end
 
   let file (filename: string) db : unit =
     let fdescr = Unix.openfile filename [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o600 in
     Xapi_stdext_pervasives.Pervasiveext.finally
-      (fun () -> 
-        fd fdescr db; 
-      )
+      (fun () -> fd fdescr db)
       (fun () -> Unix.close fdescr)
 end
 

--- a/ocaml/database/db_xml.ml
+++ b/ocaml/database/db_xml.ml
@@ -12,6 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 open Db_cache_types
+open Xapi_stdext_unix
 module R = Debug.Make(struct let name = "redo_log" end)
 module D = Debug.Make(struct let name = "database" end)
 
@@ -78,15 +79,23 @@ module To = struct
     TableSet.iter (table (Database.schema db) output) (Database.tableset db);
     Xmlm.output output `El_end
 
-  let fd (fd: Unix.file_descr) db : unit =
+  (* Note: We'd prefer to generate fsync here by reading Db_connections,
+     but that causes a dependency cycle. So we must pass it in explicitly. *)
+  let fd (fd: Unix.file_descr) ?(fsync=false) db : unit =
     let oc = Unix.out_channel_of_descr fd in
     database (Xmlm.make_output (`Channel oc)) db;
-    flush oc
+    flush oc;
+    if fsync then begin
+      D.debug "fsyncing database before close";
+      Unixext.fsync fd
+    end
 
   let file (filename: string) db : unit =
     let fdescr = Unix.openfile filename [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o600 in
     Xapi_stdext_pervasives.Pervasiveext.finally
-      (fun () -> fd fdescr db)
+      (fun () -> 
+        fd fdescr db; 
+      )
       (fun () -> Unix.close fdescr)
 end
 

--- a/ocaml/database/parse_db_conf.ml
+++ b/ocaml/database/parse_db_conf.ml
@@ -30,6 +30,7 @@ type db_connection =
    is_on_remote_storage:bool;
    other_parameters:(string*string) list;
    mutable last_generation_count: Generation.t;
+   mutable fsync_enabled:bool;
   }
 
 let default_write_limit_period = 21600 (* 6 hours *)
@@ -44,6 +45,7 @@ let dummy_conf =
    is_on_remote_storage=false;
    other_parameters=[];
    last_generation_count = Generation.null_generation;
+   fsync_enabled=false;
   }
 
 let make path = { dummy_conf with path = path }
@@ -139,6 +141,7 @@ let parse_db_conf s =
        write_limit_write_cycles=maybe_put_in "write_limit_write_cycles" default_write_cycles int_of_string;
        other_parameters = !key_values; (* the things remaining in key_values at this point are the ones we haven't parsed out explicitly above.. *)
        last_generation_count = Generation.null_generation;
+       fsync_enabled = false;
       } in
     let connections : db_connection list ref = ref [] in
     while !lines<>[] do
@@ -165,5 +168,6 @@ let get_db_conf path =
       write_limit_period=default_write_limit_period;
       write_limit_write_cycles=default_write_cycles;
       other_parameters=["available_this_boot","true"];
-      last_generation_count=Generation.null_generation}]
+      last_generation_count=Generation.null_generation;
+      fsync_enabled=false}]
   end

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -84,11 +84,8 @@ let destroy ~__context ~self =
   let result = Cluster_client.LocalClient.destroy (rpc ~__context) dbg in
   match result with
   | Result.Ok () ->
-    Xapi_stdext_monadic.Opt.iter (fun ch ->
-      Db.Cluster_host.destroy ~__context ~self:ch
-    ) cluster_host;
-    Db.Cluster.destroy ~__context ~self;
-    Xapi_clustering.Daemon.disable ~__context
+    Xapi_cluster_host.host_destroy ~__context ~cluster_host:cluster_host;
+    Db.Cluster.destroy ~__context ~self
   | Result.Error error -> handle_error error
 
 (* helper function; concurrency checks are done in implementation of Cluster.create and Cluster_host.create *)

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -87,6 +87,9 @@ let create ~__context ~cluster ~host =
       | Result.Ok () ->
         Db.Cluster_host.create ~__context ~ref ~uuid ~cluster ~host ~enabled:true
           ~current_operations:[] ~allowed_operations:[] ~other_config:[];
+        (* Clustering is enabled, so fsync is enabled, sync the master DB *)
+        Helpers.call_api_functions ~__context 
+          (fun rpc session_id -> Client.Client.Pool.sync_database rpc session_id); (* This will also fsync *)
         ref
       | Result.Error error -> handle_error error
     )

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -37,6 +37,10 @@ val create_as_necessary : __context:Context.t -> host:API.ref_host -> unit
 (** [create_as_necessary ~__context ~host] calls [sync_required], and if any
     Cluster_host objects are required it will create them *)
 
+val host_destroy : __context:Context.t -> cluster_host:API.ref_Cluster_host option -> unit
+(** [host_destroy ~__context ~cluster_host] calls [Cluster_host.destroy] and 
+    [Xapi_clustering.Daemon.disable]. *)
+
 (******************************************************************************)
 (** {2 External API calls} *)
 

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -13,7 +13,6 @@
  *)
 
 open Cluster_interface
-open Db_cache_types
 
 module D=Debug.Make(struct let name="xapi_clustering" end)
 open D

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -13,6 +13,7 @@
  *)
 
 open Cluster_interface
+open Db_cache_types
 
 module D=Debug.Make(struct let name="xapi_clustering" end)
 open D
@@ -158,6 +159,23 @@ let assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__conte
     )
     srs
 
+let is_clustering_disabled_on_host ~__context host =
+  match find_cluster_host ~__context ~host with
+  | None -> true (* there is no Cluster_host, therefore it is not enabled, therefore it is disabled *)
+  | Some cluster_host -> not (Db.Cluster_host.get_enabled ~__context ~self:cluster_host)
+
+let is_clustering_enabled_on_localhost ~__context =
+  let host = Helpers.get_localhost ~__context in
+  not (is_clustering_disabled_on_host ~__context host)
+
+let set_fsync_mode ~__context enabled =
+  let dbconn = Db_connections.preferred_write_db in
+  Xapi_stdext_monadic.Opt.iter (fun (db:Parse_db_conf.db_connection) ->
+    D.debug "set_fsync_mode: setting %B" enabled;
+    db.fsync_enabled <- enabled
+  ) dbconn
+
+
 module Daemon = struct
   let maybe_call_script ~__context script params =
     match Context.get_test_clusterd_rpc __context with
@@ -169,12 +187,14 @@ module Daemon = struct
     debug "Enabling and starting the clustering daemon";
     maybe_call_script ~__context "/usr/bin/systemctl" [ "enable"; service ];
     maybe_call_script ~__context "/usr/bin/systemctl" [ "start"; service ];
+    set_fsync_mode ~__context true;
     debug "Cluster daemon: enabled & started"
 
   let disable ~__context =
     debug "Disabling and stopping the clustering daemon";
     maybe_call_script ~__context "/usr/bin/systemctl" [ "disable"; service ];
     maybe_call_script ~__context "/usr/bin/systemctl" [ "stop"; service ];
+    set_fsync_mode ~__context false;
     debug "Cluster daemon: disabled & stopped"
 end
 
@@ -188,8 +208,3 @@ let rpc ~__context =
   | Some rpc -> rpc
   | None ->
      Cluster_client.rpc (fun () -> failwith "Can only communicate with xapi-clusterd through message-switch")
-
-let is_clustering_disabled_on_host ~__context host =
-  match find_cluster_host ~__context ~host with
-  | None -> true (* there is no Cluster_host, therefore it is not enabled, therefore it is disabled *)
-  | Some cluster_host -> not (Db.Cluster_host.get_enabled ~__context ~self:cluster_host)

--- a/ocaml/xapi/xapi_fuse.ml
+++ b/ocaml/xapi/xapi_fuse.ml
@@ -42,7 +42,7 @@ let light_fuse_and_run ?(fuse_length = !Xapi_globs.fuse_time) () =
                   		  initialised and the database "mode" set.
                   	       *)
                try
-                 let dbconn = Db_connections.preferred_write_db () in
+                 let dbconn = Xapi_stdext_monadic.Opt.unbox (Db_connections.preferred_write_db) in
                  Db_cache_impl.flush_and_exit dbconn Xapi_globs.restart_return_code
                with e ->
                  warn "Caught an exception flushing database (perhaps it hasn't been initialised yet): %s; restarting immediately" (ExnHelper.string_of_exn e);
@@ -72,7 +72,8 @@ let light_fuse_and_dont_restart ?(fuse_length = !Xapi_globs.fuse_time) () =
                log_and_ignore_exn Xapi_stats.stop;
                log_and_ignore_exn Rrdd.backup_rrds;
                Thread.delay fuse_length;
-               Db_cache_impl.flush_and_exit (Db_connections.preferred_write_db ()) 0) ());
+               let dbconn = Xapi_stdext_monadic.Opt.unbox (Db_connections.preferred_write_db) in
+               Db_cache_impl.flush_and_exit dbconn 0) ());
   (* This is a best-effort attempt to use the database. We must not block the flush_and_exit above, hence
      the use of a background thread. *)
   Helpers.log_exn_continue "setting Host.enabled to false"


### PR DESCRIPTION
Best reviewed commit-by-commit. :)

- Adds a new mutable field `fsync_enabled` to `db_connection`
- Adds an `fsync` flag to `flush` DB functions and fsync the file descriptor before closing if it's set
- Refactor `preferred_write_db` because it used List.Hd which caused tests to fail after a later commit (and had a 9 year old 'FIXME' :) )
- Set `fsync enabled` in xapi startup and when clustering is enabled/disabled
- Add fsync on pool join when clustering is enabled