### PR TITLE
CP-27001 Update pci status after enable/disable sriov

### DIFF
--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -76,6 +76,37 @@ let get_local_pcis_and_records ~__context =
 let get_local_pci_refs ~__context =
   get_local ~__context Db.PCI.get_refs_where
 
+(** Update pf and vf settings *)
+(* For virtual function record, set field `physical_function` to its PF PCI record *)
+(* For physical function record, set field `functions` to 1 plus number of its virtual functions *)
+let update_pf_vf_relations ~__context ~pcis =
+  let pci_path x = Printf.sprintf "/sys/bus/pci/devices/%s/physfn" x
+  in
+  let get_phyfn_path pci_rec =
+    let path = pci_path pci_rec.Db_actions.pCI_pci_id in
+    try
+      (*if can't read link from the path,then it's a physical function*)
+      Some (Filename.basename (Unix.readlink path))
+    with _ -> None
+  in
+  let set_phyfn (vf_ref, vf_rec, phyfn_path) pfs =
+    match phyfn_path with
+    | Some phyfn_path ->
+      begin
+        try
+          let pf, _, _ = List.find (fun (_, pf_rec, _) -> phyfn_path = pf_rec.Db_actions.pCI_pci_id) pfs in
+          if vf_rec.Db_actions.pCI_physical_function <> pf then Db.PCI.set_physical_function ~__context ~self:vf_ref ~value:pf
+        with Not_found ->
+          error "Failed to find physical function of vf %s" vf_rec.Db_actions.pCI_uuid
+      end
+    | None -> ()
+  in
+  let pfs, vfs = pcis
+                 |> List.map (fun (pci_ref, pci_rec) -> pci_ref, pci_rec, get_phyfn_path pci_rec)
+                 |> List.partition (fun (_, _, phyfn_path) -> phyfn_path = None) in
+  (* set physical function for vfs *)
+  List.iter (fun vf -> set_phyfn vf pfs) vfs
+
 let update_pcis ~__context =
   let host = Helpers.get_localhost ~__context in
   let existing = List.filter_map
@@ -188,7 +219,8 @@ let update_pcis ~__context =
 
   let current = List.map (fun ((pref, prec), _) -> pref, prec) current in
   let obsolete = List.set_difference existing current in
-  List.iter (fun (self, _) -> Db.PCI.destroy ~__context ~self) obsolete
+  List.iter (fun (self, _) -> Db.PCI.destroy ~__context ~self) obsolete;
+  update_pf_vf_relations ~__context ~pcis:current
 
 let with_vga_arbiter ~readonly f =
   Unixext.with_file

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -100,52 +100,11 @@ let sync_pci_hidden ~__context ~pgpu ~pci =
     | `enabled | `disable_on_reboot -> false
   end
 
-(* If this PCI device is by AMD and if (ON THE HOST RUNNING THIS CODE) it has
- * a valid-looking phys_fn symlink in its entry under /sys/bus/pci/...
- * then:
- *   assume it is a Virtual Function (we should already have checked it is a display device)
- *   set the physical_function field in its DB object to point to its PF PCI object
- *   return true meaning it is a VF (even if we couldn't find a PF PCI object for it)
- * else return false *)
-(* This is not in the .mli *)
-let mxgpu_set_phys_fn_ref ~__context pci_ref pci_rec =
-  Xapi_pci.int_of_id (pci_rec.Db_actions.pCI_vendor_id) = Xapi_vgpu_type.Vendor_amd.vendor_id &&
-  pci_rec.Db_actions.pCI_virtual_functions = [] && (* i.e. we don't already know it is a phys fn *)
-  (* A better name for pci_id would be pci_address. *)
-  let pci_addr = pci_rec.Db_actions.pCI_pci_id in
-  (* E.g. path = "/sys/bus/pci/devices/0000:88:00.0/" *)
-  let path = Printf.sprintf "/sys/bus/pci/devices/%s/physfn" pci_addr in
-  try (
-    (* No problem if there's no such symlink: we'll handle the exception. *)
-    let physfn_addr = Filename.basename(Unix.readlink path) in
-    (* Expect physfn_addr to look like "0000:8c:01.0" from link-target "../0000:8c:01.0" *)
-    (* If it does then look up Db ref with that pci_id (i.e. address), and create a link in DB *)
-    if Pciops.is_bdf_format physfn_addr then (
-      let host = Helpers.get_localhost ~__context in
-      let expr = Db_filter_types.(And (Eq (Field "pci_id", Literal physfn_addr),
-                                       Eq (Field "host", Literal (Ref.string_of host)))) in
-      ( match Db.PCI.get_refs_where ~__context ~expr with (* Expect exactly one *)
-        | [pf_ref] ->
-          Db.PCI.set_physical_function ~__context ~self:pci_ref ~value:pf_ref;
-          Db.PCI.set_dependencies ~__context ~self:pci_ref ~value:[]
-        | [] -> error "Found no pci with address %s but physfn-link of %s points to it!" physfn_addr pci_addr
-        | _ -> error "Found more than one pci with same address! %s" physfn_addr
-      );
-      true (* It was a Virtual Function PCI device so we don't want a pgpu for it. *)
-    ) else false
-  ) (* Unix_error from blind attempt to read symlink that might not exist *)
-  with Unix.Unix_error _ -> false
-
-(* This has the important side-effect of updating the physical_function field
- * of the PCI object in the database iff the PCI device turns out to be a VF
- * of an AMD MxGPU on the local host (in which case we return false).
- * Returns true iff pci_ref seems to represent a PHYSICAL gpu (not a VF) on the
- * LOCAL host. *)
 let is_local_pgpu ~__context (pci_ref, pci_rec) =
   let localhost = Helpers.get_localhost ~__context in
   pci_rec.Db_actions.pCI_host = localhost
   && Xapi_pci.(is_class_of_kind Display_controller (int_of_id (pci_rec.Db_actions.pCI_class_id)))
-  && not (mxgpu_set_phys_fn_ref ~__context pci_ref pci_rec) (* Ignore PCIs discovered to be Virtual Functions. *)
+  && pci_rec.Db_actions.pCI_physical_function = Ref.null
 
 (* Makes DB match reality for pgpus on local host *)
 let update_gpus ~__context =
@@ -153,9 +112,8 @@ let update_gpus ~__context =
   let system_display_device = Xapi_pci.get_system_display_device () in
   let existing_pgpus = List.filter (fun (rf, rc) -> rc.API.pGPU_host = host) (Db.PGPU.get_all_records ~__context) in
   let pcis =
-    (* Important side-effects in is_local_pgpu *)
-    List.filter (is_local_pgpu ~__context)
-      (Xapi_pci.get_local_pcis_and_records ~__context)
+    Xapi_pci.get_local_pcis_and_records ~__context
+    |> List.filter (is_local_pgpu ~__context)
     |> List.map (function pci_ref, _ -> pci_ref) in
   let is_host_display_enabled =
     match Db.Host.get_display ~__context ~self:host with
@@ -404,9 +362,3 @@ let mxgpu_vf_setup ~__context =
   (* Update the gpus even if the module was present already, in case it was
    * already loaded before xapi was (re)started. *)
   Xapi_pci.update_pcis ~__context;
-  (* Potential optimisation: make update_pcis return a value telling whether
-   * it changed anything, and stop here if it did not. *)
-  List.iter
-    (* Important side-effects in is_local_pgpu *)
-    (fun pci_ref -> ignore (is_local_pgpu ~__context pci_ref))
-    (Xapi_pci.get_local_pcis_and_records ~__context)


### PR DESCRIPTION
1. Update virtual/physical function relations when updating pci devices
2. call update_pci after bring up/down sriov logical pifs
3. refine gpu code of updating pgpu records, eliminate the annoying side effect

Signed-off-by: Yang Qian <yang.qian@citrix.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xen-api/3465)
<!-- Reviewable:end -->
