### PR TITLE
[From REQ-477] Cherry-pick testing changes around SMAPIv3

### DIFF
--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -44,6 +44,7 @@ type t = { session_id: API.ref_session option;
            task_name: string; (* Name for dummy task FIXME: used only for dummy task, as real task as their name in the database *)
            database: Db_ref.t;
            dbg: string;
+           mutable test_rpc: (Rpc.call -> Rpc.response) option
          }
 
 let get_session_id x =
@@ -114,6 +115,7 @@ let get_initial () =
     task_name = "initial_task";
     database = default_database ();
     dbg = "initial_task";
+    test_rpc = None;
   }
 
 (* ref fn used to break the cyclic dependency between context, db_actions and taskhelper *)
@@ -180,6 +182,7 @@ let from_forwarded_task ?(__context=get_initial ()) ?(http_other_config=[]) ?ses
     task_name = task_name;
     database = default_database ();
     dbg = dbg;
+    test_rpc = None;
   }
 
 let make ?(__context=get_initial ()) ?(http_other_config=[]) ?(quiet=false) ?subtask_of ?session_id ?(database=default_database ()) ?(task_in_database=false) ?task_description ?(origin=Internal) task_name =
@@ -213,6 +216,7 @@ let make ?(__context=get_initial ()) ?(http_other_config=[]) ?(quiet=false) ?sub
     forwarded_task = false;
     task_name = task_name;
     dbg = dbg;
+    test_rpc = None;
   }
 
 let get_http_other_config http_req =
@@ -235,3 +239,7 @@ let of_http_req ?session_id ~generate_task_for ~supports_async ~label ~http_req 
     else
       make ?session_id ~http_other_config ~origin:(Http(http_req,fd)) label
 
+let set_test_rpc context rpc =
+  context.test_rpc <- Some rpc
+
+let get_test_rpc context = context.test_rpc

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -121,3 +121,5 @@ val __make_task :
    ?subtask_of:API.ref_task -> string -> API.ref_task * API.ref_task Uuid.t)
     ref
 
+val set_test_rpc : t -> (Rpc.call -> Rpc.response) -> unit
+val get_test_rpc : t -> (Rpc.call -> Rpc.response) option

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -300,22 +300,11 @@ let call_api_functions_internal ~__context f =
          with e ->
            debug "Helpers.call_api_functions failed to logout: %s (ignoring)" (Printexc.to_string e))
 
-
-(* Note: `test_fn` here is a mechanism for providing an alternative to an API
-   call _only for unit testing_ - if !test_mode above is true this function will
-   call the test code instead of `f`, as API calls currently do not work in the
-   unit test context. This is ONLY intended as a LAST RESORT mechanism if
-   there's no other way of achieving this effect. We should move the code in
-   the direction where this sort of thing is unnecessary. *)
-let test_mode = ref false
-let call_api_functions ~__context ?test_fn f =
-  if not !test_mode
-  then call_api_functions_internal ~__context f
-  else begin
-    match test_fn with
-    | Some fn -> fn ()
-    | None -> failwith "Test mode API function unset"
-  end
+let call_api_functions ~__context f =
+  match Context.get_test_rpc __context with
+  | Some rpc -> f rpc (Ref.of_string "fake_session")
+  | None ->
+    call_api_functions_internal ~__context f
 
 let call_emergency_mode_functions hostname f =
   let open Xmlrpc_client in

--- a/ocaml/xapi/mock_rpc.ml
+++ b/ocaml/xapi/mock_rpc.ml
@@ -1,0 +1,39 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* Mock RPC for testing *)
+
+let rpc __context call =
+  match call.Rpc.name, call.Rpc.params with
+  | "event.from", [_session_id_rpc;classes_rpc;token_rpc;timeout_rpc] ->
+    let open API in
+    let classes = string_set_of_rpc classes_rpc in
+    let token = string_of_rpc token_rpc in
+    let timeout = float_of_rpc timeout_rpc in
+    let contents = Xapi_event.from ~__context ~classes ~token ~timeout in
+    Rpc.{success=true; contents = contents |> Xmlrpc.to_string |> Xmlrpc.of_string}
+  | "VM.update_allowed_operations", [session_id_rpc;self_rpc] ->
+    let open API in
+    let _session_id = ref_session_of_rpc session_id_rpc in
+    let self = ref_VM_of_rpc self_rpc in
+    Xapi_vm_lifecycle.update_allowed_operations ~__context ~self;
+    Rpc.{success=true; contents=Rpc.String ""}
+  | "VM.atomic_set_resident_on", [session_id_rpc;vm_rpc;host_rpc]->
+    let open API in
+    let _session_id = ref_session_of_rpc session_id_rpc in
+    let vm = ref_VM_of_rpc vm_rpc in
+    let host = ref_host_of_rpc host_rpc in
+    Db.VM.set_resident_on ~__context ~self:vm ~value:host;
+    Rpc.{success=true; contents=Rpc.String ""}
+  | _ -> failwith "Unexpected RPC"

--- a/ocaml/xapi/network_event_loop.ml
+++ b/ocaml/xapi/network_event_loop.ml
@@ -32,7 +32,6 @@ let _watch_networks_for_nbd_changes __context ~update_firewall ~wait_after_event
       Helpers.call_api_functions ~__context
         (fun rpc session_id ->
            Client.Client.Event.from ~rpc ~session_id ~classes ~token ~timeout |> Event_types.event_from_of_rpc)
-        ~test_fn:(fun () -> Xapi_event.from ~__context ~classes ~token ~timeout |> Event_types.parse_event_from)
     in
     from.Event_types.token
   in

--- a/ocaml/xapi/test_event_common.ml
+++ b/ocaml/xapi/test_event_common.ml
@@ -16,7 +16,9 @@ let start_periodic_scheduler () =
 let event_setup_common () =
   start_periodic_scheduler ();
   let __context = Test_common.make_test_database () in
+  Context.set_test_rpc __context (Mock_rpc.rpc __context);
   let session_id = Test_common.make_session ~__context () in
   let __context = Mock.Context.make ~session_id "session context" in
+  Context.set_test_rpc __context (Mock_rpc.rpc __context);
   (__context, session_id)
 

--- a/ocaml/xapi/test_network_event_loop.ml
+++ b/ocaml/xapi/test_network_event_loop.ml
@@ -14,10 +14,7 @@
 
 let test_network_event_loop ~no_nbd_networks_at_start () =
   let __context, _ = Test_event_common.event_setup_common () in
-  (* We need to set test_mode to true to ensure that the event loop will use
-     the local Xapi_events.from function instead of the Client module, which
-     would cause the test to fail. *)
-  Helpers.test_mode := true;
+  Context.set_test_rpc __context (Mock_rpc.rpc __context);
 
   let localhost = Helpers.get_localhost ~__context in
   let other_host = Test_common.make_host ~__context () in

--- a/ocaml/xapi/test_vdi_cbt.ml
+++ b/ocaml/xapi/test_vdi_cbt.ml
@@ -264,9 +264,6 @@ mffVFwXJ7B8kLP5BeRyBi6nwLhjd
 let setup_test_for_data_destroy ?(vdi_data_destroy=(fun _ ~dbg ~sr ~vdi -> ())) () =
   (* data_destroy uses the event mechanism, this is required to make the unit test work *)
   let __context, _ = Test_event.event_setup_common () in
-  (* data_destroy uses the Client module to watch for events, we need to ensure
-     the local function is called instead to make the unit test work. *)
-  Helpers.test_mode := true;
 
   let sR = make_mock_server_infrastructure ~__context in
   let vdi = Test_common.make_vdi ~__context ~is_a_snapshot:true ~managed:true ~cbt_enabled:true ~sR () in
@@ -283,9 +280,8 @@ let test_allowed_operations_updated_when_necessary () =
   (* Populate the allowed_operations list after creating the VDI *)
   Xapi_vdi.update_allowed_operations ~__context ~self;
   assert_allowed_operations "contains `copy for a newly-created VDI" (fun ops -> List.mem `copy ops);
-  let (rpc, session_id) = Test_common.make_client_params ~__context in
-  (* Call data_destroy through the client, as allowed_operations may be updated in the message forwarding layer *)
-  Client.Client.VDI.data_destroy ~rpc ~session_id ~self;
+  (* Call data_destroy through the the message forwarding layer *)
+  Api_server.Forwarder.VDI.data_destroy ~__context ~self;
   assert_allowed_operations "does not contain `copy after VDI has been data-destroyed" (fun ops -> not @@ List.mem `copy ops)
 
 let test_data_destroy =
@@ -352,7 +348,7 @@ let test_data_destroy =
       (Db.VDI.get_type ~__context ~self:vdi)
   in
 
-  (** If [realistic_timing] is true, the tests will use the Client module and
+  (** If [realistic_timing] is true, the tests will use the Message_forwarding module and
       the original timeouts, otherwise they will call the implementation in
       Xapi_vdi directly with a smaller timeout to make the tests faster. The
       former leads to more comprehensive tests, as it goes through message
@@ -376,8 +372,7 @@ let test_data_destroy =
     let uses_client = realistic_timing in
     let call_data_destroy ~__context ~self =
       if uses_client then begin
-        let (rpc, session_id) = Test_common.make_client_params ~__context in
-        Client.Client.VDI.data_destroy ~rpc ~session_id ~self
+        Api_server.Forwarder.VDI.data_destroy ~__context ~self
       end else
         Xapi_vdi._data_destroy ~__context ~self ~timeout
     in

--- a/ocaml/xapi/test_xapi_xenops.ml
+++ b/ocaml/xapi/test_xapi_xenops.ml
@@ -5,6 +5,7 @@ open Test_vgpu_common
 module D=Debug.Make(struct let name="test_xapi_xenops" end)
 open D
 
+
 let test_enabled_in_xenguest () =
   let should_raise = ["foo";"";"banana";"2"] in
   let should_be_true = ["TRUE";"tRuE";"1";"true"] in
@@ -55,8 +56,8 @@ let unsetup_simulator () =
 
 let test_xapi_restart_inner () =
   let __context = make_test_database () in
+  Context.set_test_rpc __context (Mock_rpc.rpc __context);
   setup_simulator ();
-  Helpers.test_mode := true;
   let open Xenops_interface in
   let open Xapi_xenops_queue in
   let module Client = (val make_client "simulator" : XENOPS) in

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -614,7 +614,6 @@ let wait_for_vbds_to_be_unplugged_and_destroyed ~__context ~self ~timeout =
       Helpers.call_api_functions ~__context
         (fun rpc session_id ->
            Client.Event.from ~rpc ~session_id ~classes ~token ~timeout |> Event_types.event_from_of_rpc)
-        ~test_fn:(fun () -> Xapi_event.from ~__context ~classes ~token ~timeout |> Event_types.parse_event_from)
     in
     List.iter (fun event -> debug "wait_for_vbds_to_be_unplugged_and_destroyed: got event %s" (Event_types.string_of_event event)) from.Event_types.events;
     (from.Event_types.token, most_recent_vbds_field from.Event_types.events)
@@ -997,7 +996,7 @@ let enable_cbt ~__context ~self =
 
 let disable_cbt = change_cbt_status ~new_cbt_enabled:false ~caller_name:"VDI.disable_cbt"
 
-let set_cbt_enabled ~__context ~self ~value = 
+let set_cbt_enabled ~__context ~self ~value =
   if Db.VDI.get_cbt_enabled ~__context ~self <> value then begin
     Db.VDI.set_cbt_enabled ~__context ~self ~value:value;
     update_allowed_operations ~__context ~self

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1647,7 +1647,6 @@ let update_vm ~__context id =
           Xenops_cache.update_vm id (Opt.map snd info);
           if !should_update_allowed_operations then
             Helpers.call_api_functions ~__context
-              ~test_fn:(fun () -> Xapi_vm_lifecycle.update_allowed_operations ~__context ~self)
               (fun rpc session_id -> XenAPI.VM.update_allowed_operations ~rpc ~session_id ~self);
         end
   with e ->
@@ -2422,7 +2421,7 @@ let set_resident_on ~__context ~self =
   debug "VM %s set_resident_on" id;
   let localhost = Helpers.get_localhost ~__context in
   Helpers.call_api_functions ~__context
-    ~test_fn:(fun () -> Db.VM.set_resident_on ~__context ~self ~value:localhost)
+
     (fun rpc session_id -> XenAPI.VM.atomic_set_resident_on rpc session_id self localhost);
   debug "Signalling xenapi event thread to re-register, and xenopsd events to sync";
   refresh_vm ~__context ~self;


### PR DESCRIPTION
CP-24206: check snapshot works when VDI is activated on different hosts
CA-271525: Add a test_rpc field to the context
CA-271525: Move over all uses of 'test_mode' to use the mock rpc function instead.