### PR TITLE
[From REQ-477] Cherry-pick a few miscellaneous changes 

### DIFF
--- a/ocaml/tests/suite_init.ml
+++ b/ocaml/tests/suite_init.ml
@@ -17,6 +17,7 @@ let start_server handlers =
   Xapi.listen_unix_socket "/tmp/xapi-test/xapi-unit-test-socket"
 
 let harness_init () =
+  Debug.log_to_stdout ();
   Printexc.record_backtrace true;
   Inventory.inventory_filename :=
     Filename.concat Test_common.working_area "xcp-inventory";

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -974,12 +974,3 @@ module Local_domain_socket = struct
     let str = Xmlrpc.string_of_response result in
     Http_svr.response_str req s str
 end
-
-open Xmlrpc_client
-let local_url = Http.Url.(File { path = Filename.concat "/var/lib/xcp" "storage" }, { uri = "/"; query_params = [] })
-
-let rpc ~srcstr ~dststr url call =
-  XMLRPC_protocol.rpc ~transport:(transport_of_url url)
-    ~srcstr ~dststr ~http:(xmlrpc ~version:"1.0" ?auth:(Http.Url.auth_of url) ~query:(Http.Url.get_query_params url) (Http.Url.get_uri url)) call
-
-module Local = Client(struct let rpc = rpc ~srcstr:"smapiv2" ~dststr:"smapiv2" local_url end)

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -558,6 +558,7 @@ module Monitor = struct
                 end
               end
             with e ->
+              log_backtrace ();
               debug "Exception in HA monitor thread: %s" (ExnHelper.string_of_exn e);
               Thread.delay !Xapi_globs.ha_monitor_interval
           done;

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -19,6 +19,9 @@ val assert_operation_valid : __context:Context.t ->
 
 val update_allowed_operations : __context:Context.t -> self:API.ref_pool -> unit
 
+val with_pool_operation : __context:Context.t -> self:API.ref_pool ->
+  doc:string -> op:API.pool_allowed_operations -> (unit -> 'a) -> 'a
+
 val ha_disable_in_progress : __context:Context.t -> bool
 
 val ha_enable_in_progress : __context:Context.t -> bool

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -360,6 +360,8 @@ let update ~__context ~sr =
     (fun () ->
        let sr' = Db.SR.get_uuid ~__context ~self:sr in
        let sr_info = C.SR.stat ~dbg:(Ref.string_of task) ~sr:sr' in
+       Db.SR.set_name_label ~__context ~self:sr ~value:sr_info.name_label;
+       Db.SR.set_name_description ~__context ~self:sr ~value:sr_info.name_description;
        Db.SR.set_physical_size ~__context ~self:sr ~value:sr_info.total_space;
        Db.SR.set_physical_utilisation ~__context ~self:sr ~value:(Int64.sub sr_info.total_space sr_info.free_space);
        Db.SR.set_clustered ~__context ~self:sr ~value:sr_info.clustered;


### PR DESCRIPTION
- CP-24688: Refactor `with_pool_operation` to be easily testable
- Storage_impl: drop dead code 
- CA-271525: Log everything from the unit-test suite
- CA-272147: Fix SR.set_name_label and _description for SMAPIv3
- CA-277346: log backtrace when parsing HA liveset

The first commit needed a small fix due to the change in Datamodel, the others applied cleanly.