### PR TITLE
CP-26022 SR-IOV pool join/leave

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -948,6 +948,8 @@ let _ =
     ~doc:"The host joining the pool must not have any bonds." ();
   error Api_errors.pool_joining_host_has_tunnels []
     ~doc:"The host joining the pool must not have any tunnels." ();
+  error Api_errors.pool_joining_host_has_network_sriovs []
+    ~doc:"The host joining the pool must not have any network SR-IOVs." ();
   error Api_errors.pool_hosts_not_compatible []
     ~doc:"The hosts in this pool are not compatible." ();
   error Api_errors.pool_hosts_not_homogeneous [ "reason" ]

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5008,6 +5008,18 @@ let host_sync_tunnels = call ~flags:[`Session]
     ~allowed_roles:_R_POOL_OP
     ()
 
+let host_sync_network_sriovs = call ~flags:[`Session]
+    ~name:"sync_network_sriovs"
+    ~lifecycle:[Published, rel_kolkata, ""]
+    ~doc:"Synchronise network sriovs on given host with the master's network sriovs"
+    ~params:[
+      Ref _host, "host", "The host";
+    ]
+    ~hide_from_docs:true
+    ~pool_internal:true
+    ~allowed_roles:_R_POOL_OP
+    ()
+
 let host_sync_pif_currently_attached = call ~flags:[`Session]
     ~name:"sync_pif_currently_attached"
     ~lifecycle:[]
@@ -5162,6 +5174,7 @@ let host =
                 host_sm_dp_destroy;
                 host_sync_vlans;
                 host_sync_tunnels;
+                host_sync_network_sriovs;
                 host_sync_pif_currently_attached;
                 host_migrate_receive;
                 host_declare_dead;

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -343,6 +343,7 @@ let pool_joining_host_management_vlan_does_not_match = "POOL_JOINING_HOST_MANAGE
 let pool_joining_host_has_non_management_vlans = "POOL_JOINING_HOST_HAS_NON_MANAGEMENT_VLANS"
 let pool_joining_host_has_bonds = "POOL_JOINING_HOST_HAS_BONDS"
 let pool_joining_host_has_tunnels = "POOL_JOINING_HOST_HAS_TUNNELS"
+let pool_joining_host_has_network_sriovs = "POOL_JOINING_HOST_HAS_NETWORK_SRIOVS"
 
 (*workload balancing*)
 let wlb_not_initialized = "WLB_NOT_INITIALIZED"

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2658,6 +2658,10 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Host.sync_tunnels: host = '%s'" (host_uuid ~__context host);
       Local.Host.sync_tunnels ~__context ~host
 
+    let sync_network_sriovs ~__context ~host =
+      info "Host.sync_network_sriovs: host = '%s'" (host_uuid ~__context host);
+      Local.Host.sync_network_sriovs ~__context ~host
+
     let sync_pif_currently_attached ~__context ~host ~bridges =
       info "Host.sync_pif_currently_attached: host = '%s'" (host_uuid ~__context host);
       Local.Host.sync_pif_currently_attached ~__context ~host ~bridges

--- a/ocaml/xapi/sync_networking.ml
+++ b/ocaml/xapi/sync_networking.ml
@@ -161,3 +161,8 @@ let copy_tunnels_from_master ~__context () =
   let host = !Xapi_globs.localhost_ref in
   Helpers.call_api_functions ~__context (fun rpc session_id -> Client.Host.sync_tunnels ~rpc ~session_id ~host)
 
+(** Copy network-sriovs from master *)
+let copy_network_sriovs_from_master ~__context () =
+  debug "Resynchronising network-sriovs";
+  let host = !Xapi_globs.localhost_ref in
+  Helpers.call_api_functions ~__context (fun rpc session_id -> Client.Host.sync_network_sriovs ~rpc ~session_id ~host)

--- a/ocaml/xapi/sync_networking.mli
+++ b/ocaml/xapi/sync_networking.mli
@@ -19,3 +19,4 @@ val fix_bonds : __context:Context.t -> unit -> unit
 val copy_bonds_from_master : __context:Context.t -> unit -> unit
 val copy_vlans_from_master : __context:Context.t -> unit -> unit
 val copy_tunnels_from_master : __context:Context.t -> unit -> unit
+val copy_network_sriovs_from_master : __context:Context.t -> unit -> unit

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -906,7 +906,7 @@ let server_init() =
           "creating networks", [ Startup.OnlyMaster ], Create_networks.create_networks_localhost;
           (* CA-22417: bring up all non-bond slaves so that the SM backends can use storage NIC IP addresses (if the routing
              	 table happens to be right) *)
-          "Best-effort bring up of physical NICs", [ Startup.NoExnRaising ], Xapi_pif.start_of_day_best_effort_bring_up;
+          "Best-effort bring up of physical and sriov NICs", [ Startup.NoExnRaising ], Xapi_pif.start_of_day_best_effort_bring_up;
           "updating the vswitch controller", [], (fun () -> Helpers.update_vswitch_controller ~__context ~host:(Helpers.get_localhost ~__context));
           "initialising storage", [ Startup.NoExnRaising ],
           (fun () -> Helpers.call_api_functions ~__context Create_storage.create_storage_localhost);

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -916,6 +916,7 @@ let server_init() =
           "watching networks for NBD-related changes", [Startup.OnThread], Network_event_loop.watch_networks_for_nbd_changes;
           (* CA-175353: moving VIFs between networks requires VMs to be resynced *)
           "Synchronising bonds on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_bonds_from_master ~__context;
+          "Synchronising network sriovs on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_network_sriovs_from_master ~__context;
           "Synchronising VLANs on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_vlans_from_master ~__context;
           "Synchronising tunnels on slave with master", [Startup.OnlySlave; Startup.NoExnRaising], Sync_networking.copy_tunnels_from_master ~__context;
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1620,6 +1620,49 @@ let sync_tunnels ~__context ~host =
   (* for each of the master's pifs, create a corresponding one on this host if necessary *)
   List.iter maybe_create_tunnel_for_me master_tunnel_pifs
 
+let sync_network_sriovs ~__context ~host =
+  let master = !Xapi_globs.localhost_ref in
+  let master_sriov_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
+      Eq (Field "host", Literal (Ref.string_of master)),
+      Not (Eq (Field "sriov_logical_PIF_of", Literal "()"))
+    )) in
+  let slave_sriov_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
+      Eq (Field "host", Literal (Ref.string_of host)),
+      Not (Eq (Field "sriov_logical_PIF_of", Literal "()"))
+    )) in
+  let slave_physical_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
+      Eq (Field "host", Literal (Ref.string_of host)),
+      Eq (Field "physical", Literal "true")
+    )) in
+  let maybe_create_sriov (master_pif_ref, master_pif_rec) =
+    let sriov_network = master_pif_rec.API.pIF_network in
+    let existing_pif = List.filter (fun (_, slave_pif_rec) ->
+        slave_pif_rec.API.pIF_network = sriov_network
+      ) slave_sriov_pifs in
+    if existing_pif = [] then begin
+      let device = master_pif_rec.API.pIF_device in
+      let pifs = List.filter (fun (_, pif_rec) -> pif_rec.API.pIF_device = device) slave_physical_pifs in
+      match pifs with
+      | [] ->
+        info "Cannot sync network sriov because cannot find PIF whose device name is %s" device
+      | (pif_ref, pif_rec) :: _ ->
+        begin
+          try
+            Xapi_network_sriov.create ~__context ~pif:pif_ref ~network:sriov_network |> ignore
+          with
+          | Api_errors.Server_error (err, _) when err = Api_errors.network_has_incompatible_sriov_pifs ->
+            warn "Cannot sync network sriov on slave because PCI device of %s is different from the PIF of master in the same position" pif_rec.API.pIF_uuid
+          | Api_errors.Server_error (err, _) when err = Api_errors.network_sriov_already_enabled ->
+            warn "Cannot sync network sriov on slave because PIF %s on slave has enabled sriov in another network" pif_rec.API.pIF_uuid
+          | Api_errors.Server_error (err, _) when err = Api_errors.pif_is_not_sriov_capable ->
+            warn "Cannot sync network sriov on slave because PIF %s on slave is not sriov capable" pif_rec.API.pIF_uuid
+          | exn ->
+            error "Error occurs when syncing network sriov for PIF %s: %s" pif_rec.API.pIF_uuid (Printexc.to_string exn)
+        end
+    end
+  in
+  List.iter maybe_create_sriov master_sriov_pifs
+
 let sync_pif_currently_attached ~__context ~host ~bridges =
   (* Produce internal lookup tables *)
   let networks = Db.Network.get_all_records ~__context in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1519,30 +1519,30 @@ let sync_vlans ~__context ~host =
       Not (Eq (Field "VLAN_master_of", Literal (Ref.string_of Ref.null)))
     )) in
 
-  let get_network_of_pif_underneath_vlan vlan_pif =
-    let vlan = Db.PIF.get_VLAN_master_of ~__context ~self:vlan_pif in
-    let pif_underneath_vlan = Db.VLAN.get_tagged_PIF ~__context ~self:vlan in
-    Db.PIF.get_network ~__context ~self:pif_underneath_vlan
+  let get_network_of_pif_underneath_vlan vlan_pif_rec =
+    match Xapi_pif_helpers.get_pif_topo ~__context ~pif_rec:vlan_pif_rec with
+    | VLAN_untagged vlan :: _ ->
+      let pif_underneath_vlan = Db.VLAN.get_tagged_PIF ~__context ~self:vlan in
+      Db.PIF.get_network ~__context ~self:pif_underneath_vlan
+    | _ -> raise Api_errors.(Server_error(internal_error, [Printf.sprintf "Cannot find vlan from a vlan master PIF:%s" vlan_pif_rec.API.pIF_uuid]))
   in
-
   let maybe_create_vlan (master_pif_ref, master_pif_rec) =
     (* Check to see if the slave has any existing pif(s) that for the specified device, network, vlan... *)
+    (* On the master, we find the pif, p, that underlies the VLAN
+     * (e.g. "eth0" underlies "eth0.25") and then find the network that p's on: *)
+    let network_of_pif_underneath_vlan_on_master = get_network_of_pif_underneath_vlan master_pif_rec in
     let existing_pif = List.filter (fun (slave_pif_ref, slave_pif_record) ->
         (* Is slave VLAN PIF that we're considering (slave_pif_ref) the one that corresponds
            			 * to the master_pif we're considering (master_pif_ref)? *)
         true
         && slave_pif_record.API.pIF_network = master_pif_rec.API.pIF_network
         && slave_pif_record.API.pIF_VLAN = master_pif_rec.API.pIF_VLAN
-        && ((get_network_of_pif_underneath_vlan slave_pif_ref) =
-            (get_network_of_pif_underneath_vlan master_pif_ref))
+        && (get_network_of_pif_underneath_vlan slave_pif_record = network_of_pif_underneath_vlan_on_master)
       ) slave_vlan_pifs in
     (* if I don't have any such pif(s) then make one: *)
-    if List.length existing_pif = 0
+    if existing_pif = []
     then
       begin
-        (* On the master, we find the pif, p, that underlies the VLAN
-           				 * (e.g. "eth0" underlies "eth0.25") and then find the network that p's on: *)
-        let network_of_pif_underneath_vlan_on_master = get_network_of_pif_underneath_vlan master_pif_ref in
         let pifs = Db.PIF.get_records_where ~__context ~expr:(And (
             Eq (Field "host", Literal (Ref.string_of host)),
             Eq (Field "network", Literal (Ref.string_of network_of_pif_underneath_vlan_on_master))
@@ -1578,27 +1578,27 @@ let sync_tunnels ~__context ~host =
       Not (Eq (Field "tunnel_access_PIF_of", Literal "()"))
     )) in
 
-  let get_network_of_transport_pif access_pif =
-    match Db.PIF.get_tunnel_access_PIF_of ~__context ~self:access_pif with
-    | [tunnel] ->
+  let get_network_of_transport_pif access_pif_rec =
+    match Xapi_pif_helpers.get_pif_topo ~__context ~pif_rec:access_pif_rec with
+    | Tunnel_access tunnel :: _ ->
       let transport_pif = Db.Tunnel.get_transport_PIF ~__context ~self:tunnel in
       Db.PIF.get_network ~__context ~self:transport_pif
-    | _ -> failwith (Printf.sprintf "PIF %s has no tunnel_access_PIF_of" (Ref.string_of access_pif))
+    | _ -> raise Api_errors.(Server_error(internal_error, [Printf.sprintf "PIF %s has no tunnel_access_PIF_of" access_pif_rec.API.pIF_uuid]))
   in
 
   let maybe_create_tunnel_for_me (master_pif_ref, master_pif_rec) =
     (* check to see if I have any existing pif(s) that for the specified device, network, vlan... *)
     let existing_pif = List.filter (fun (_, slave_pif_record) ->
         (* Is the slave's tunnel access PIF that we're considering (slave_pif_ref)
-           			 * the one that corresponds to the master's tunnel access PIF we're considering (master_pif_ref)? *)
+         * the one that corresponds to the master's tunnel access PIF we're considering (master_pif_ref)? *)
         slave_pif_record.API.pIF_network = master_pif_rec.API.pIF_network
       ) slave_tunnel_pifs in
     (* If the slave doesn't have any such PIF then make one: *)
-    if List.length existing_pif = 0
+    if existing_pif = []
     then
       begin
         (* On the master, we find the network the tunnel transport PIF is on *)
-        let network_of_transport_pif_on_master = get_network_of_transport_pif master_pif_ref in
+        let network_of_transport_pif_on_master = get_network_of_transport_pif master_pif_rec in
         let pifs = Db.PIF.get_records_where ~__context ~expr:(And (
             Eq (Field "host", Literal (Ref.string_of host)),
             Eq (Field "network", Literal (Ref.string_of network_of_transport_pif_on_master))

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -290,6 +290,9 @@ val sync_vlans : __context:Context.t -> host:API.ref_host -> unit
 (** Synchronise slave tunnels with master *)
 val sync_tunnels : __context:Context.t -> host:API.ref_host -> unit
 
+(** Synchronise slave network sriovs with master *)
+val sync_network_sriovs : __context:Context.t -> host:API.ref_host -> unit
+
 (** Synchronise PIF.currently_attached fields on given host.
  *  The parameter [bridges] contains a list of bridge names reflecting all bridges that are up. *)
 val sync_pif_currently_attached : __context:Context.t -> host:API.ref_host -> bridges:string list -> unit

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -841,47 +841,47 @@ let calculate_pifs_required_at_start_of_day ~__context =
   (* Select all PIFs on the host that are not bond slaves, and are physical, or bond master, or
      	 * have IP configuration. The latter means that any VLAN or tunnel PIFs without IP address
      	 * are excluded. *)
-  Db.PIF.get_records_where ~__context
-    ~expr:(
-      And (
-        Eq (Field "managed", Literal "true"),
+  let pifs = Db.PIF.get_records_where ~__context
+      ~expr:(
         And (
+          Eq (Field "managed", Literal "true"),
           And (
-            Eq (Field "host", Literal (Ref.string_of localhost)),
-            Eq (Field "bond_slave_of", Literal (Ref.string_of Ref.null))
-          ),
-          Or (Or (
-              Not (Eq (Field "bond_master_of", Literal "()")),
-              Eq (Field "physical", Literal "true")),
-              Not (Eq (Field "ip_configuration_mode", Literal "None"))
-            )
+            And (
+              Eq (Field "host", Literal (Ref.string_of localhost)),
+              Eq (Field "bond_slave_of", Literal (Ref.string_of Ref.null))
+            ),
+            Or (Or (
+                Not (Eq (Field "bond_master_of", Literal "()")),
+                Eq (Field "physical", Literal "true")),
+                Not (Eq (Field "ip_configuration_mode", Literal "None"))
+              )
+          )
         )
-      )
-    )
+      ) in
+  let sriov_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
+      Eq (Field "host", Literal (Ref.string_of localhost)),
+      Not (Eq (Field "sriov_logical_PIF_of", Literal "()") )
+    )) in
+  pifs @ sriov_pifs
 
 let start_of_day_best_effort_bring_up () =
-  begin
-    Server_helpers.exec_with_new_task
-      "Bringing up managed physical PIFs"
-      (fun __context ->
-         let dbg = Context.string_of_task __context in
-         debug
-           "Configured network backend: %s"
-           (Network_interface.string_of_kind (Net.Bridge.get_kind dbg ()));
-         (* Clear the state of the network daemon, before refreshing it by plugging
-            				 * the most important PIFs (see above). *)
-         Net.clear_state ();
-         List.iter
-           (fun (pif, pifr) ->
-              Helpers.log_exn_continue
-                (Printf.sprintf
-                   "error trying to bring up pif: %s"
-                   pifr.API.pIF_uuid)
-                (fun pif ->
-                   debug
-                     "Best effort attempt to bring up PIF: %s"
-                     pifr.API.pIF_uuid;
-                   plug ~__context ~self:pif)
-                (pif))
-           (calculate_pifs_required_at_start_of_day ~__context))
-  end
+  Server_helpers.exec_with_new_task
+    "Bringing up managed physical and sriov PIFs"
+    (fun __context ->
+       let dbg = Context.string_of_task __context in
+       debug
+         "Configured network backend: %s"
+         (Network_interface.string_of_kind (Net.Bridge.get_kind dbg ()));
+       (* Clear the state of the network daemon, before refreshing it by plugging
+          * the most important PIFs (see above). *)
+       Net.clear_state ();
+       List.iter
+         (fun (pif, pifr) ->
+            Helpers.log_exn_continue
+              (Printf.sprintf "error trying to bring up pif: %s" pifr.API.pIF_uuid)
+              (fun pif ->
+                 debug "Best effort attempt to bring up PIF: %s" pifr.API.pIF_uuid;
+                 plug ~__context ~self:pif)
+              (pif))
+         (calculate_pifs_required_at_start_of_day ~__context))
+

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -261,6 +261,13 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
       raise (Api_errors.Server_error(Api_errors.pool_joining_host_has_tunnels, []))
     end in
 
+  (* Allow pool-join if host does not have any network-sriovs*)
+  let assert_no_network_sriovs_on_me () =
+    if Db.Network_sriov.get_all ~__context <> [] then begin
+      error "The current host has network SR-IOV enabled: it cannot join a new pool";
+      raise (Api_errors.Server_error(Api_errors.pool_joining_host_has_network_sriovs, []))
+    end in
+
   (* Allow pool-join if host does not have any non-management VLANs *)
   let assert_no_non_management_vlans_on_me () =
     List.iter (fun self ->
@@ -463,6 +470,7 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
   assert_no_shared_srs_on_me ();
   assert_no_bonds_on_me ();
   assert_no_tunnels_on_me ();
+  assert_no_network_sriovs_on_me ();
   assert_no_non_management_vlans_on_me ();
   assert_management_vlan_are_same ();
   assert_external_auth_matches ();


### PR DESCRIPTION
1. Add network sriov precheck for pool join
2. Sync network sriov from master to slave after join
3. Gc sriovs when gc PIFs
4. Best effort bring up sriov logical PIFs when xapi start

Signed-off-by: Yang Qian <yang.qian@citrix.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xen-api/3474)
<!-- Reviewable:end -->
