### PR TITLE
CP-23782: Add license restriction for SRIOV usage

### DIFF
--- a/ocaml/xapi/xapi_network_sriov.ml
+++ b/ocaml/xapi/xapi_network_sriov.ml
@@ -38,6 +38,7 @@ let create_internal ~__context ~physical_PIF ~physical_rec ~network =
   sriov, logical_PIF
 
 let create ~__context ~pif ~network =
+  Pool_features.assert_enabled ~__context ~f:Features.Network_sriov;
   Xapi_network.assert_network_is_managed ~__context ~self:network;
   Xapi_pif_helpers.assert_pif_is_managed ~__context ~self:pif;
   let pif_rec = Db.PIF.get_record ~__context ~self:pif in

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -179,6 +179,9 @@ let create ~__context ~device ~network ~vM
     ~ipv6_configuration_mode ~ipv6_addresses ~ipv6_gateway : API.ref_VIF =
   let () = debug "VIF.create running" in
 
+  if Xapi_network_sriov_helpers.is_sriov_network ~__context ~self:network then
+    Pool_features.assert_enabled ~__context ~f:Features.Network_sriov;
+
   if locking_mode = `locked || ipv4_allowed <> [] || ipv6_allowed <> [] then
     assert_locking_licensed ~__context;
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -256,6 +256,10 @@ let start ~__context ~vm ~start_paused ~force =
   if vusbs <> [] then
     Vm_platform.check_restricted_device_model ~__context vmr.API.vM_platform;
 
+  let sriov_networks = Xapi_network_sriov_helpers.get_sriov_networks_from_vm __context vm in
+  if sriov_networks <> [] then
+    Pool_features.assert_enabled ~__context ~f:Features.Network_sriov;
+
   if not force then
     assert_memory_constraints ~__context ~vm vmr.API.vM_platform;
 


### PR DESCRIPTION
The following operations must be blocked if the pool is not licensed appropriately
Enabling SR-IOV on a NIC.
Configuring a VM to use an SR-IOV VF. 
Starting a VM that is configured to use an SR-IOV VF. 

Signed-off-by: Cheng Zhang <cheng.zhang@citrix.com>