### PR TITLE
CP-26340: SR.probe SMAPIv3 changes

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1536,19 +1536,22 @@ let sr_probe printer rpc session_id params =
     match probe_result_of_rpc (Xmlrpc.of_string txt) with
     | Raw x -> printer (Cli_printer.PList [ x ])
     | Probe x ->
-      let sr (uri, x) = [
-        "uri", uri;
+      let sr (config, x) = [
+        "uuid", List.assoc "uuid" config;
         "name-label", x.name_label;
         "name-description", x.name_description;
         "total-space", Int64.to_string x.total_space;
         "free-space", Int64.to_string x.free_space;
       ] in
-      if x.srs <> []
+      if x.attachable <> []
       then printer (Cli_printer.PMsg "The following SRs were found:");
-      printer (Cli_printer.PTable (List.map sr x.srs));
-      if x.uris <> []
-      then printer (Cli_printer.PMsg "The following URIs may contain SRs:");
-      printer (Cli_printer.PList x.uris)
+      printer (Cli_printer.PTable (List.map sr x.attachable));
+      if x.creatable <> []
+      then printer (Cli_printer.PMsg "The following configurations can be used to create SRs:");
+      printer (Cli_printer.PTable x.creatable);
+      if x.incomplete <> []
+      then printer (Cli_printer.PMsg "The following configurations require further probing:");
+      printer (Cli_printer.PTable x.incomplete)
   with _ ->
     printer (Cli_printer.PList [txt])
 


### PR DESCRIPTION
SMAPIv1 returns a `Raw` probe result, that is unaffected.
SMAPIv3 returns a `Probe` result, which got changed in xcp-idl.
Update cli_operations to print the new record.

Instead of a list of URIs and SRs, we now have 3 categories of configurations:
* attachable (usable for SR.attach)
* creatable (usable for SR.create)
* incomplete (usable for further SR.probe)


Has to be merged together with (note this is for `master`, the other xapi PR is for `feature/REQ477/master`):
https://github.com/xapi-project/xapi-storage/pull/74
https://github.com/xapi-project/xcp-idl/pull/208
https://github.com/xapi-project/xapi-storage-script/pull/58
https://github.com/xapi-project/xen-api/pull/3477