### PR TITLE
Port test_cluster and test_cluster_host to Alcotest framework

### DIFF
--- a/ocaml/xapi/alcotest_comparators.ml
+++ b/ocaml/xapi/alcotest_comparators.ml
@@ -4,3 +4,8 @@ let error_code =
   let fmt = Fmt.pair Fmt.string (Fmt.list Fmt.string) in
   let cmp aa bb = fst aa = fst bb in
   Alcotest.testable fmt cmp
+
+let ref () =
+  let fmt = Fmt.of_to_string Ref.string_of in
+  let cmp = (=) in
+  Alcotest.testable fmt cmp

--- a/ocaml/xapi/suite.ml
+++ b/ocaml/xapi/suite.ml
@@ -68,7 +68,6 @@ let base_suite =
     Test_network_event_loop.test;
     Test_network.test;
     Test_pusb.test;
-    Test_cluster_host.test;
     Test_clustering_allowed_operations.test;
     Test_host_helpers.test;
     Test_clustering.test;

--- a/ocaml/xapi/suite.ml
+++ b/ocaml/xapi/suite.ml
@@ -70,7 +70,6 @@ let base_suite =
     Test_pusb.test;
     Test_cluster_host.test;
     Test_clustering_allowed_operations.test;
-    Test_cluster.test;
     Test_host_helpers.test;
     Test_clustering.test;
   ]

--- a/ocaml/xapi/suite_alcotest.ml
+++ b/ocaml/xapi/suite_alcotest.ml
@@ -10,4 +10,5 @@ let () =
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
     ; "Test_host", Test_host.test
     ; "Test_cluster", Test_cluster.test
+    ; "Test_cluster_host", Test_cluster_host.test
     ]

--- a/ocaml/xapi/suite_alcotest.ml
+++ b/ocaml/xapi/suite_alcotest.ml
@@ -9,4 +9,5 @@ let () =
     ; "Test_vdi_allowed_operations", Test_vdi_allowed_operations.test
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
     ; "Test_host", Test_host.test
+    ; "Test_cluster", Test_cluster.test
     ]

--- a/ocaml/xapi/test_cluster.ml
+++ b/ocaml/xapi/test_cluster.ml
@@ -13,7 +13,6 @@
  *)
 
 open Xapi_cluster
-open OUnit
 
 let test_clusterd_rpc ~__context call =
   let token = "test_token" in
@@ -63,8 +62,6 @@ let test_enable () =
   pool_destroy ~__context ~self:cluster
 
 let test =
-  "test_cluster" >:::
-  [
-    "test_create_destroy_service_status" >:: test_create_destroy_status;
-    "test_enable" >:: test_enable;
+  [ "test_create_destroy_service_status", `Quick, test_create_destroy_status
+  ; "test_enable", `Quick, test_enable
   ]

--- a/ocaml/xapi/test_cluster_host.ml
+++ b/ocaml/xapi/test_cluster_host.ml
@@ -67,8 +67,7 @@ let test_fix_prereq () =
   let localhost = Helpers.get_localhost ~__context in
   let pifref = Test_common.make_pif ~__context ~network ~host:localhost () in
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  Alcotest.check_raises
-  (Printf.sprintf "This test should raise (Failure %s)" exn)
+  Alcotest.check_raises "Should fail when checking PIF prequisites"
     (Failure exn)
     (fun () ->
       try
@@ -79,7 +78,7 @@ let test_fix_prereq () =
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
   Xapi_cluster_host.fix_pif_prerequisites ~__context pif;
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  Alcotest.(check unit) "Assert PIF prerequisites without raising exception"
+  Alcotest.(check unit) "Assert PIF prerequisites without error"
     (Xapi_clustering.assert_pif_prerequisites pif) ()
 
 let test_create_as_necessary () =

--- a/ocaml/xapi/test_cluster_host.ml
+++ b/ocaml/xapi/test_cluster_host.ml
@@ -113,10 +113,11 @@ let test_destroy_forbidden_when_sr_attached () =
     Test_common.make_sr ~__context ~_type:sr_type ()
   in
   let _pbd : _ API.Ref.t = Test_common.make_pbd ~__context ~host ~sR ~currently_attached:true () in
+  let msg = ("Host has attached SR whose SM requires cluster stack " ^ cluster_stack) in
   Alcotest.check_raises
-    "Should raise (Failure \"Host has attached SR whose SM requires cluster stack\")"
+    ("Should raise (Failure " ^ msg ^ ")")
     (* TODO: update this when the exceptions are finalized *)
-    (Failure ("Host has attached SR whose SM requires cluster stack " ^ cluster_stack))
+    (Failure msg)
     (fun () -> Xapi_cluster_host.destroy ~__context ~self:cluster_host)
 
 

--- a/ocaml/xapi/test_cluster_host.ml
+++ b/ocaml/xapi/test_cluster_host.ml
@@ -23,7 +23,7 @@ let create_cluster ~__context pool_auto_join =
     ~current_operations:[] ~pool_auto_join ~cluster_config:[] ~other_config:[];
   cluster_ref
 
-let assert_option =
+let assert_ref_option =
   Alcotest.(check (option (Alcotest_comparators.ref ()) ))
 
 let test_dbsync_join () =
@@ -31,14 +31,14 @@ let test_dbsync_join () =
   let cluster = create_cluster ~__context true in
   let localhost = Helpers.get_localhost ~__context in
   let result = sync_required ~__context ~host:localhost in
-  assert_option "Cluster option" result (Some (cluster))
+  assert_ref_option "Cluster option" result (Some (cluster))
 
 let test_dbsync_nojoin () =
   let __context = Test_common.make_test_database () in
   let _cluster = create_cluster ~__context false in
   let localhost = Helpers.get_localhost ~__context in
   let result = sync_required ~__context ~host:localhost in
-  assert_option "Cluster option" result None
+  assert_ref_option "Cluster option" result None
 
 let pif_plug_rpc __context call =
   match call.Rpc.name, call.Rpc.params with
@@ -91,10 +91,10 @@ let test_create_as_necessary () =
   Db.PIF.set_IP ~__context ~self:pifref ~value:"1.1.1.1";
   let _pif = Xapi_clustering.pif_of_host ~__context network localhost in
   let result = sync_required ~__context ~host:localhost in
-  assert_option "Cluster option" result (Some cluster);
+  assert_ref_option "Cluster option" result (Some cluster);
   Xapi_cluster_host.create_as_necessary ~__context ~host:localhost;
   let result = sync_required ~__context ~host:localhost in
-  assert_option "Cluster option" result None
+  assert_ref_option "Cluster option" result None
 
 (* CA-275728 *)
 let test_destroy_forbidden_when_sr_attached () =

--- a/ocaml/xapi/test_cluster_host.ml
+++ b/ocaml/xapi/test_cluster_host.ml
@@ -19,25 +19,26 @@ let create_cluster ~__context pool_auto_join =
   let cluster_uuid = Uuidm.to_string (Uuidm.create `V4) in
   let network = Test_common.make_network ~__context () in
   Db.Cluster.create ~__context ~ref:cluster_ref ~uuid:cluster_uuid ~network ~cluster_token:"token"
-    ~cluster_stack:"corosync" ~token_timeout:5000L ~token_timeout_coefficient:1000L ~allowed_operations:[] 
+    ~cluster_stack:"corosync" ~token_timeout:5000L ~token_timeout_coefficient:1000L ~allowed_operations:[]
     ~current_operations:[] ~pool_auto_join ~cluster_config:[] ~other_config:[];
   cluster_ref
+
+let assert_option =
+  Alcotest.(check (option (Alcotest_comparators.ref ()) ))
 
 let test_dbsync_join () =
   let __context = Test_common.make_test_database () in
   let cluster = create_cluster ~__context true in
   let localhost = Helpers.get_localhost ~__context in
   let result = sync_required ~__context ~host:localhost in
-  OUnit.assert_equal result (Some (cluster))
+  assert_option "Cluster option" result (Some (cluster))
 
 let test_dbsync_nojoin () =
   let __context = Test_common.make_test_database () in
   let _cluster = create_cluster ~__context false in
   let localhost = Helpers.get_localhost ~__context in
   let result = sync_required ~__context ~host:localhost in
-  OUnit.assert_equal result None
-
-open OUnit
+  assert_option "Cluster option" result None
 
 let pif_plug_rpc __context call =
   match call.Rpc.name, call.Rpc.params with
@@ -66,7 +67,8 @@ let test_fix_prereq () =
   let localhost = Helpers.get_localhost ~__context in
   let pifref = Test_common.make_pif ~__context ~network ~host:localhost () in
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  assert_raises
+  Alcotest.check_raises
+  (Printf.sprintf "This test should raise (Failure %s)" exn)
     (Failure exn)
     (fun () ->
       try
@@ -77,7 +79,8 @@ let test_fix_prereq () =
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
   Xapi_cluster_host.fix_pif_prerequisites ~__context pif;
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  assert_equal (Xapi_clustering.assert_pif_prerequisites pif) ()
+  Alcotest.(check unit) "Assert PIF prerequisites without raising exception"
+    (Xapi_clustering.assert_pif_prerequisites pif) ()
 
 let test_create_as_necessary () =
   let __context = Test_common.make_test_database () in
@@ -89,10 +92,10 @@ let test_create_as_necessary () =
   Db.PIF.set_IP ~__context ~self:pifref ~value:"1.1.1.1";
   let _pif = Xapi_clustering.pif_of_host ~__context network localhost in
   let result = sync_required ~__context ~host:localhost in
-  OUnit.assert_equal result (Some cluster);
+  assert_option "Cluster option" result (Some cluster);
   Xapi_cluster_host.create_as_necessary ~__context ~host:localhost;
   let result = sync_required ~__context ~host:localhost in
-  OUnit.assert_equal result None
+  assert_option "Cluster option" result None
 
 (* CA-275728 *)
 let test_destroy_forbidden_when_sr_attached () =
@@ -110,18 +113,17 @@ let test_destroy_forbidden_when_sr_attached () =
     Test_common.make_sr ~__context ~_type:sr_type ()
   in
   let _pbd : _ API.Ref.t = Test_common.make_pbd ~__context ~host ~sR ~currently_attached:true () in
-  OUnit.assert_raises
+  Alcotest.check_raises
+    "Should raise (Failure \"Host has attached SR whose SM requires cluster stack\")"
     (* TODO: update this when the exceptions are finalized *)
     (Failure ("Host has attached SR whose SM requires cluster stack " ^ cluster_stack))
     (fun () -> Xapi_cluster_host.destroy ~__context ~self:cluster_host)
 
 
 let test =
-  "test_cluster_host" >:::
-  [
-    "test_dbsync_join" >:: test_dbsync_join;
-    "test_dbsync_nojoin" >:: test_dbsync_nojoin;
-    "test_fix_prerequisites" >:: test_fix_prereq;
-    "test_create_as_necessary" >:: test_create_as_necessary;
-    "test_destroy_forbidden_when_sr_attached" >:: test_destroy_forbidden_when_sr_attached;
+  [ "test_dbsync_join", `Quick, test_dbsync_join
+  ; "test_dbsync_nojoin", `Quick, test_dbsync_nojoin
+  ; "test_fix_prerequisites", `Quick, test_fix_prereq
+  ; "test_create_as_necessary", `Quick, test_create_as_necessary
+  ; "test_destroy_forbidden_when_sr_attached", `Quick, test_destroy_forbidden_when_sr_attached
   ]


### PR DESCRIPTION
This enables cleaner test output and follows the initiative to move away from OUnit in favour of Alcoport for toolstack unit tests.