### PR TITLE
Port test_clustering to Alcotest

### DIFF
--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -64,7 +64,6 @@ let base_suite =
     Test_pusb.test;
     Test_host_helpers.test;
     Test_clustering_allowed_operations.test;
-    Test_clustering.test;
   ]
 
 let () =

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -63,7 +63,6 @@ let base_suite =
     Test_network.test;
     Test_pusb.test;
     Test_host_helpers.test;
-    Test_clustering_allowed_operations.test;
   ]
 
 let () =

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -17,12 +17,7 @@ let () =
     ; "Test_daemon_manager", Test_daemon_manager.test
     ; "Test_cluster", Test_cluster.test
     ; "Test_cluster_host", Test_cluster_host.test
-    ; "Test_get_required_cluster_stacks", Test_clustering.test_get_required_cluster_stacks
-    ; "Test_find_cluster_host", Test_clustering.test_find_cluster_host
-    ; "Test_assert_cluster_host_enabled", Test_clustering.test_assert_cluster_host_enabled
-    ; "Test_assert_cluster_host_is_enabled_for_matching_sms", Test_clustering.test_assert_cluster_host_is_enabled_for_matching_sms
-    ; "Test_clustering_lock_only_taken_if_needed", Test_clustering.test_clustering_lock_only_taken_if_needed
-    ; "Test_assert_pif_prerequisites", Test_clustering.test_assert_pif_prerequisites
+    ; "Test_clustering", Test_clustering.test
     ; "Test_clustering_allowed_operations", Test_clustering_allowed_operations.test
     ]
 

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -4,8 +4,9 @@ let () =
   (* Alcotest hides the standard output of successful tests,
      so we will probably not exceed the 4MB limit in Traivs *)
   Debug.log_to_stdout ();
-  Alcotest.run "Base suite"
-    ([ "Test_valid_ref_list", Test_valid_ref_list.test
+  (* and_exit is set by default, set to false so we don't exit before executing other suites *)
+  Alcotest.run "Base suite" ~and_exit:false
+    [ "Test_valid_ref_list", Test_valid_ref_list.test
     ; "Test_vdi_allowed_operations", Test_vdi_allowed_operations.test
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
     ; "Test_host", Test_host.test
@@ -14,9 +15,16 @@ let () =
     ; "Test_vlan", Test_vlan.test
     ; "Test_agility", Test_agility.test
     ; "Test_daemon_manager", Test_daemon_manager.test
-    ; "Test_cluster", Test_cluster.test
-    ; "Test_cluster_host", Test_cluster_host.test
     ]
-    @
-    Test_clustering.test
-    )
+  ;
+  Alcotest.run "Clustering suite"
+    [ "Test_cluster", Test_cluster.test
+    ; "Test_cluster_host", Test_cluster_host.test
+    ; "Test_get_required_cluster_stacks", Test_clustering.test_get_required_cluster_stacks
+    ; "Test_find_cluster_host", Test_clustering.test_find_cluster_host
+    ; "Test_assert_cluster_host_enabled", Test_clustering.test_assert_cluster_host_enabled
+    ; "Test_assert_cluster_host_is_enabled_for_matching_sms", Test_clustering.test_assert_cluster_host_is_enabled_for_matching_sms
+    ; "Test_clustering_lock_only_taken_if_needed", Test_clustering.test_clustering_lock_only_taken_if_needed
+    ; "Test_assert_pif_prerequisites", Test_clustering.test_assert_pif_prerequisites
+    ]
+

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -5,7 +5,7 @@ let () =
      so we will probably not exceed the 4MB limit in Traivs *)
   Debug.log_to_stdout ();
   Alcotest.run "Base suite"
-    [ "Test_valid_ref_list", Test_valid_ref_list.test
+    ([ "Test_valid_ref_list", Test_valid_ref_list.test
     ; "Test_vdi_allowed_operations", Test_vdi_allowed_operations.test
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
     ; "Test_host", Test_host.test
@@ -17,3 +17,6 @@ let () =
     ; "Test_cluster", Test_cluster.test
     ; "Test_cluster_host", Test_cluster_host.test
     ]
+    @
+    Test_clustering.test
+    )

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -23,5 +23,6 @@ let () =
     ; "Test_assert_cluster_host_is_enabled_for_matching_sms", Test_clustering.test_assert_cluster_host_is_enabled_for_matching_sms
     ; "Test_clustering_lock_only_taken_if_needed", Test_clustering.test_clustering_lock_only_taken_if_needed
     ; "Test_assert_pif_prerequisites", Test_clustering.test_assert_pif_prerequisites
+    ; "Test_clustering_allowed_operations", Test_clustering_allowed_operations.test
     ]
 

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -4,8 +4,8 @@ let () =
   (* Alcotest hides the standard output of successful tests,
      so we will probably not exceed the 4MB limit in Traivs *)
   Debug.log_to_stdout ();
-  (* and_exit is set by default, set to false so we don't exit before executing other suites *)
-  Alcotest.run "Base suite" ~and_exit:false
+
+  Alcotest.run "Base suite"
     [ "Test_valid_ref_list", Test_valid_ref_list.test
     ; "Test_vdi_allowed_operations", Test_vdi_allowed_operations.test
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
@@ -15,10 +15,7 @@ let () =
     ; "Test_vlan", Test_vlan.test
     ; "Test_agility", Test_agility.test
     ; "Test_daemon_manager", Test_daemon_manager.test
-    ]
-  ;
-  Alcotest.run "Clustering suite"
-    [ "Test_cluster", Test_cluster.test
+    ; "Test_cluster", Test_cluster.test
     ; "Test_cluster_host", Test_cluster_host.test
     ; "Test_get_required_cluster_stacks", Test_clustering.test_get_required_cluster_stacks
     ; "Test_find_cluster_host", Test_clustering.test_find_cluster_host

--- a/ocaml/tests/test_clustering.ml
+++ b/ocaml/tests/test_clustering.ml
@@ -12,249 +12,259 @@
  * GNU Lesser General Public License for more details.
  *)
 
-(** Tests for the Xapi_clustering module *)
+(** Test for the Xapi_clustering module *)
 
 module T = Test_common
 
-(** Tests Xapi_clustering.get_required_cluster_stacks *)
+(** Test Xapi_clustering.get_required_cluster_stacks *)
+
+let assert_equal ~msg ~required_cluster_stacks ~to_set =
+  let module S = Set.Make(String) in
+  let setify sl = sl |> S.of_list |> S.elements in
+  Alcotest.(check (slist string String.compare)) msg
+    (setify required_cluster_stacks) (setify to_set)
+
+let test_zero_sms_in_database () =
+  let __context = T.make_test_database () in
+  let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"" in
+  assert_equal
+    ~msg:"Asserted by test_zero_sms_in_database"
+    ~required_cluster_stacks ~to_set:[]
+
+let test_zero_sms_with_matching_type_which_do_require_cluster_stack () =
+  let __context = T.make_test_database () in
+  let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["stack1"; "corosync"] () in
+  let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["corosync"] () in
+  let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"type1" in
+  assert_equal
+    ~msg:"Asserted by test_zero_sms_with_matching_type_which_do_require_cluster_stack"
+    ~required_cluster_stacks ~to_set:[]
+
+let test_one_sm_with_matching_type_which_doesnt_require_cluster_stack () =
+  let __context = T.make_test_database () in
+  let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:[] () in
+  let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"type1" in
+  assert_equal
+    ~msg:"Asserted by test_one_sm_with_matching_type_which_doesnt_require_cluster_stack"
+    ~required_cluster_stacks ~to_set:[]
+
+let test_one_sm_with_matching_type_which_does_require_cluster_stack () =
+  let __context = T.make_test_database () in
+  let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:["corosync"] () in
+  let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"type1" in
+  assert_equal
+    ~msg:"Asserted by test_one_sm_with_matching_type_which_does_require_cluster_stack"
+    ~required_cluster_stacks ~to_set:["corosync"]
+
+(* there should probably never be more than one SM of a particular type, but
+   test it here anyway to see that the behavior of the function is as
+   expected in that situation. *)
+let test_multiple_sms_with_some_matching_type_with_some_requiring_cluster_stack () =
+  let __context = T.make_test_database () in
+  let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:[] () in
+  let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:["corosync"] () in
+  let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:["stack1"; "corosync"] () in
+  let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["corosync"] () in
+  let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["stack1"] () in
+  let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["stack1"; "corosync"] () in
+  let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"type1" in
+  assert_equal
+    ~msg:"Asserted by test_multiple_sms_with_some_matching_type_with_some_requiring_cluster_stack"
+    ~required_cluster_stacks ~to_set:["stack1"; "corosync"]
+
 let test_get_required_cluster_stacks =
-  let assert_equal ~required_cluster_stacks ~to_set =
-    let module S = Ounit_comparators.StringSet in
-    S.assert_equal (S.of_list to_set) (S.of_list required_cluster_stacks)
-  in
-
-  let test_zero_sms_in_database () =
-    let __context = T.make_test_database () in
-    let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"" in
-    assert_equal ~required_cluster_stacks ~to_set:[]
-  in
-
-  let test_zero_sms_with_matching_type_which_do_require_cluster_stack () =
-    let __context = T.make_test_database () in
-    let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["stack1"; "corosync"] () in
-    let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["corosync"] () in
-    let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"type1" in
-    assert_equal ~required_cluster_stacks ~to_set:[]
-  in
-
-  let test_one_sm_with_matching_type_which_doesnt_require_cluster_stack () =
-    let __context = T.make_test_database () in
-    let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:[] () in
-    let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"type1" in
-    assert_equal ~required_cluster_stacks ~to_set:[]
-  in
-
-  let test_one_sm_with_matching_type_which_does_require_cluster_stack () =
-    let __context = T.make_test_database () in
-    let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:["corosync"] () in
-    let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"type1" in
-    assert_equal ~required_cluster_stacks ~to_set:["corosync"]
-  in
-
-  (* there should probably never be more than one SM of a particular type, but
-     test it here anyway to see that the behavior of the function is as
-     expected in that situation. *)
-  let test_multiple_sms_with_some_matching_type_with_some_requiring_cluster_stack () =
-    let __context = T.make_test_database () in
-    let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:[] () in
-    let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:["corosync"] () in
-    let _ = T.make_sm ~__context ~_type:"type1" ~required_cluster_stack:["stack1"; "corosync"] () in
-    let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["corosync"] () in
-    let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["stack1"] () in
-    let _ = T.make_sm ~__context ~_type:"type2" ~required_cluster_stack:["stack1"; "corosync"] () in
-    let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type:"type1" in
-    assert_equal ~required_cluster_stacks ~to_set:["stack1"; "corosync"]
-  in
-
-  let open OUnit in
-  "test_get_required_cluster_stacks" >:::
-  [ "test_zero_sms_in_database" >:: test_zero_sms_in_database
-  ; "test_zero_sms_with_matching_type_which_do_require_cluster_stack" >:: test_zero_sms_with_matching_type_which_do_require_cluster_stack
-  ; "test_one_sm_with_matching_type_which_doesnt_require_cluster_stack" >:: test_one_sm_with_matching_type_which_doesnt_require_cluster_stack
-  ; "test_one_sm_with_matching_type_which_does_require_cluster_stack" >:: test_one_sm_with_matching_type_which_does_require_cluster_stack
-  ; "test_multiple_sms_with_some_matching_type_with_some_requiring_cluster_stack" >:: test_multiple_sms_with_some_matching_type_with_some_requiring_cluster_stack
+  [ "test_zero_sms_in_database", `Quick, test_zero_sms_in_database
+  ; "test_zero_sms_with_matching_type_which_do_require_cluster_stack", `Quick, test_zero_sms_with_matching_type_which_do_require_cluster_stack
+  ; "test_one_sm_with_matching_type_which_doesnt_require_cluster_stack", `Quick, test_one_sm_with_matching_type_which_doesnt_require_cluster_stack
+  ; "test_one_sm_with_matching_type_which_does_require_cluster_stack", `Quick, test_one_sm_with_matching_type_which_does_require_cluster_stack
+  ; "test_multiple_sms_with_some_matching_type_with_some_requiring_cluster_stack", `Quick, test_multiple_sms_with_some_matching_type_with_some_requiring_cluster_stack
   ]
 
-(** Tests Xapi_clustering.find_cluster_host *)
+
+(** Test Xapi_clustering.find_cluster_host *)
+
+let test_find_cluster_host_finds_zero_cluster_hosts () =
+  let __context = T.make_test_database () in
+  let host = Db.Host.get_all ~__context |> List.hd in
+  Alcotest.(check (option (Alcotest_comparators.ref ())))
+    "find_cluster_host should return None"
+    (Xapi_clustering.find_cluster_host ~__context ~host) None
+
+let test_find_cluster_host_finds_one_cluster_host () =
+  let __context = T.make_test_database () in
+  let host = Db.Host.get_all ~__context |> List.hd in
+  let ref = T.make_cluster_host ~__context ~host () in
+  let _ = T.make_cluster_host ~__context ~host:(Ref.make ()) () in
+  Alcotest.(check (option (Alcotest_comparators.ref ())))
+    (Printf.sprintf "find_cluster_host should return (Some %s)" (Ref.string_of ref))
+    (Xapi_clustering.find_cluster_host ~__context ~host) (Some ref)
+
+let test_find_cluster_host_finds_multiple_cluster_hosts () =
+  let __context = T.make_test_database () in
+  let host = Db.Host.get_all ~__context |> List.hd in
+  let _ = T.make_cluster_host ~__context ~host () in
+  let _ = T.make_cluster_host ~__context ~host () in
+  Alcotest.check_raises
+    "test_find_cluster_host_finds_multiple_cluster_hosts should throw an internal error"
+    (Api_errors.Server_error(Api_errors.internal_error,["Multiple cluster_hosts found for host"; (Ref.string_of host)]))
+    (fun () -> ignore (Xapi_clustering.find_cluster_host ~__context ~host))
+
 let test_find_cluster_host =
-  let test_find_cluster_host_finds_zero_cluster_hosts () =
-    let __context = T.make_test_database () in
-    let host = Db.Host.get_all ~__context |> List.hd in
-    OUnit.assert_bool "find_cluster_host should return None"
-      (Xapi_clustering.find_cluster_host ~__context ~host = None)
-  in
-
-  let test_find_cluster_host_finds_one_cluster_host () =
-    let __context = T.make_test_database () in
-    let host = Db.Host.get_all ~__context |> List.hd in
-    let ref = T.make_cluster_host ~__context ~host () in
-    let _ = T.make_cluster_host ~__context ~host:(Ref.make ()) () in
-    OUnit.assert_bool "find_cluster_host should return (Some ref)"
-      (Xapi_clustering.find_cluster_host ~__context ~host = Some ref)
-  in
-
-  let test_find_cluster_host_finds_multiple_cluster_hosts () =
-    let __context = T.make_test_database () in
-    let host = Db.Host.get_all ~__context |> List.hd in
-    let _ = T.make_cluster_host ~__context ~host () in
-    let _ = T.make_cluster_host ~__context ~host () in
-    T.assert_raises_api_error Api_errors.internal_error
-      (fun () -> Xapi_clustering.find_cluster_host ~__context ~host)
-  in
-
-  let open OUnit in
-  "test_find_cluster_host" >:::
-  [ "test_find_cluster_host_finds_zero_cluster_hosts" >:: test_find_cluster_host_finds_zero_cluster_hosts
-  ; "test_find_cluster_host_finds_one_cluster_host" >:: test_find_cluster_host_finds_one_cluster_host
-  ; "test_find_cluster_host_finds_multiple_cluster_hosts" >:: test_find_cluster_host_finds_multiple_cluster_hosts
+  [ "test_find_cluster_host_finds_zero_cluster_hosts", `Quick, test_find_cluster_host_finds_zero_cluster_hosts
+  ; "test_find_cluster_host_finds_one_cluster_host", `Quick, test_find_cluster_host_finds_one_cluster_host
+  ; "test_find_cluster_host_finds_multiple_cluster_hosts", `Quick, test_find_cluster_host_finds_multiple_cluster_hosts
   ]
 
-(** Tests Xapi_clustering.assert_cluster_host_enabled *)
+
+(** Test Xapi_clustering.assert_cluster_host_enabled *)
+
+let test_assert_cluster_host_is_enabled_when_it_is_enabled () =
+  let __context = T.make_test_database () in
+  let self = T.make_cluster_host ~__context ~enabled:true () in
+  try
+    (Xapi_clustering.assert_cluster_host_enabled ~__context ~self ~expected:true)
+  with _ ->
+    Alcotest.fail "test_assert_cluster_host_is_enabled_when_it_is_enabled should fail"
+
+let test_assert_cluster_host_is_enabled_when_it_is_disabled () =
+  let __context = T.make_test_database () in
+  let self = T.make_cluster_host ~__context ~enabled:false () in
+  Alcotest.check_raises
+    "test_assert_cluster_host_is_enabled_when_it_is_disabled should raise clustering_disabled"
+    (Api_errors.Server_error(Api_errors.clustering_disabled, [Ref.string_of self]))
+    (fun () -> Xapi_clustering.assert_cluster_host_enabled ~__context ~self ~expected:true)
+
+let test_assert_cluster_host_is_disabled_when_it_is_enabled () =
+  let __context = T.make_test_database () in
+  let self = T.make_cluster_host ~__context ~enabled:true () in
+  Alcotest.check_raises
+    "test_assert_cluster_host_is_disabled_when_it_is_enabled should raise clustering_enabled"
+    Api_errors.(Server_error(clustering_enabled, [Ref.string_of self]))
+    (fun () -> Xapi_clustering.assert_cluster_host_enabled ~__context ~self ~expected:false)
+
+let test_assert_cluster_host_is_disabled_when_it_is_disabled () =
+  let __context = T.make_test_database () in
+  let self = T.make_cluster_host ~__context ~enabled:false () in
+  try Xapi_clustering.assert_cluster_host_enabled ~__context ~self ~expected:false
+  with _ -> Alcotest.fail "asserting cluster_host is disabled fails when cluster_host is disabled"
+
 let test_assert_cluster_host_enabled =
-  let test_assert_cluster_host_is_enabled_when_it_is_enabled () =
-    let __context = T.make_test_database () in
-    let self = T.make_cluster_host ~__context ~enabled:true () in
-    try Xapi_clustering.assert_cluster_host_enabled ~__context ~self ~expected:true
-    with _ -> OUnit.assert_failure "asserting cluster_host is enabled fails when cluster_host is enabled"
-  in
-
-  let test_assert_cluster_host_is_enabled_when_it_is_disabled () =
-    let __context = T.make_test_database () in
-    let self = T.make_cluster_host ~__context ~enabled:false () in
-    T.assert_raises_api_error Api_errors.clustering_disabled ~args:[Ref.string_of self]
-      (fun () -> Xapi_clustering.assert_cluster_host_enabled ~__context ~self ~expected:true)
-  in
-
-  let test_assert_cluster_host_is_disabled_when_it_is_enabled () =
-    let __context = T.make_test_database () in
-    let self = T.make_cluster_host ~__context ~enabled:true () in
-    T.assert_raises_api_error Api_errors.clustering_enabled ~args:[Ref.string_of self]
-      (fun () -> Xapi_clustering.assert_cluster_host_enabled ~__context ~self ~expected:false)
-  in
-
-  let test_assert_cluster_host_is_disabled_when_it_is_disabled () =
-    let __context = T.make_test_database () in
-    let self = T.make_cluster_host ~__context ~enabled:false () in
-    try Xapi_clustering.assert_cluster_host_enabled ~__context ~self ~expected:false
-    with _ -> OUnit.assert_failure "asserting cluster_host is disabled fails when cluster_host is disabled"
-  in
-
-  let open OUnit in
-  "test_assert_cluster_host_enabled" >:::
-  [ "test_assert_cluster_host_is_enabled_when_it_is_enabled" >:: test_assert_cluster_host_is_enabled_when_it_is_enabled
-  ; "test_assert_cluster_host_is_enabled_when_it_is_disabled" >:: test_assert_cluster_host_is_enabled_when_it_is_disabled
-  ; "test_assert_cluster_host_is_disabled_when_it_is_enabled" >:: test_assert_cluster_host_is_disabled_when_it_is_enabled
-  ; "test_assert_cluster_host_is_disabled_when_it_is_disabled" >:: test_assert_cluster_host_is_disabled_when_it_is_disabled
+  [ "test_assert_cluster_host_is_enabled_when_it_is_enabled", `Quick, test_assert_cluster_host_is_enabled_when_it_is_enabled
+  ; "test_assert_cluster_host_is_enabled_when_it_is_disabled", `Quick, test_assert_cluster_host_is_enabled_when_it_is_disabled
+  ; "test_assert_cluster_host_is_disabled_when_it_is_enabled", `Quick, test_assert_cluster_host_is_disabled_when_it_is_enabled
+  ; "test_assert_cluster_host_is_disabled_when_it_is_disabled", `Quick, test_assert_cluster_host_is_disabled_when_it_is_disabled
   ]
 
-(** Tests Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms *)
+
+(** Test Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms *)
+
+let make_scenario ?(cluster_host=(Some true)) () =
+  let __context = T.make_test_database () in
+  let host = Db.Host.get_all ~__context |> List.hd in
+  let cluster, cluster_host = match cluster_host with
+    | None -> Ref.null, Ref.null
+    | Some cluster_host_enabled ->
+      let cluster, cluster_host = T.make_cluster_and_cluster_host ~__context () in
+      Db.Cluster_host.set_host ~__context ~self:cluster_host ~value:host;
+      Db.Cluster_host.set_enabled ~__context ~self:cluster_host ~value:cluster_host_enabled;
+      cluster, cluster_host
+  in
+  let _sm_1 : _ API.Ref.t= T.make_sm ~__context ~_type:"gfs2" ~required_cluster_stack:["corosync"] () in
+  let _sm_2 : _ API.Ref.t= T.make_sm ~__context ~_type:"lvm" ~required_cluster_stack:[] () in
+  __context, host, cluster, cluster_host
+
+let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled () =
+  let __context, host, cluster, cluster_host = make_scenario () in
+  Alcotest.(check unit)
+    "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled should pass"
+    (Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"gfs2") ()
+
+let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist () =
+  let __context, host, cluster, cluster_host = make_scenario () in
+  Alcotest.(check unit)
+    "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist should pass"
+    (Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"sr_type_with_no_matching_sm") ()
+
+let test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_is_disabled () =
+  let __context, host, cluster, cluster_host = make_scenario ~cluster_host:(Some false) () in
+  Alcotest.check_raises
+    "test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_is_disabled should raise clustering_disabled"
+    Api_errors.(Server_error(clustering_disabled, [Ref.string_of cluster_host]))
+    (fun () -> Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"gfs2")
+
+let test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists () =
+  let __context, host, cluster, cluster_host = make_scenario ~cluster_host:None () in
+  Alcotest.check_raises
+    "test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists should raise no_compatible_cluster_host"
+    Api_errors.(Server_error(no_compatible_cluster_host, [Ref.string_of host]))
+    (fun () -> Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"gfs2")
+
+let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed () =
+  let __context, host, cluster, cluster_host = make_scenario ~cluster_host:(Some false) () in
+  Alcotest.(check unit)
+    "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed should pass"
+    (Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"lvm") ()
+
+let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed () =
+  let __context, host, cluster, cluster_host = make_scenario ~cluster_host:None () in
+  Alcotest.(check unit)
+    "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed should pass"
+    (Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"lvm") ()
+
 let test_assert_cluster_host_is_enabled_for_matching_sms =
-  let make_scenario ?(cluster_host=(Some true)) () =
-    let __context = T.make_test_database () in
-    let host = Db.Host.get_all ~__context |> List.hd in
-    let cluster, cluster_host = match cluster_host with
-      | None -> Ref.null, Ref.null
-      | Some cluster_host_enabled ->
-        let cluster, cluster_host = T.make_cluster_and_cluster_host ~__context () in
-        Db.Cluster_host.set_host ~__context ~self:cluster_host ~value:host;
-        Db.Cluster_host.set_enabled ~__context ~self:cluster_host ~value:cluster_host_enabled;
-        cluster, cluster_host
-    in
-    let _sm_1 : _ API.Ref.t= T.make_sm ~__context ~_type:"gfs2" ~required_cluster_stack:["corosync"] () in
-    let _sm_2 : _ API.Ref.t= T.make_sm ~__context ~_type:"lvm" ~required_cluster_stack:[] () in
-    __context, host, cluster, cluster_host
-  in
-
-  let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled () =
-    let __context, host, cluster, cluster_host = make_scenario () in
-    OUnit.assert_equal (Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"gfs2") ()
-  in
-
-  let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist () =
-    let __context, host, cluster, cluster_host = make_scenario () in
-    OUnit.assert_equal (Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"sr_type_with_no_matching_sm") ()
-  in
-
-  let test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_is_disabled () =
-    let __context, host, cluster, cluster_host = make_scenario ~cluster_host:(Some false) () in
-    T.assert_raises_api_error Api_errors.clustering_disabled ~args:[Ref.string_of cluster_host]
-      (fun () -> Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"gfs2")
-  in
-
-  let test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists () =
-    let __context, host, cluster, cluster_host = make_scenario ~cluster_host:None () in
-    T.assert_raises_api_error Api_errors.no_compatible_cluster_host ~args:[Ref.string_of host]
-      (fun () -> Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"gfs2")
-  in
-
-  let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed () =
-    let __context, host, cluster, cluster_host = make_scenario ~cluster_host:(Some false) () in
-    OUnit.assert_equal (Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"lvm") ()
-  in
-
-  let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed () =
-    let __context, host, cluster, cluster_host = make_scenario ~cluster_host:None () in
-    OUnit.assert_equal (Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:"lvm") ()
-  in
-
-  let open OUnit in
-  "test_assert_cluster_host_is_enabled_for_matching_sms" >:::
-  [ "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled" >:: test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled
-  ; "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist" >:: test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist
-  ; "test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_is_disabled" >:: test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_is_disabled
-  ; "test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists" >:: test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists
-  ; "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed" >:: test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed
-  ; "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed" >:: test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed
+  [ "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled", `Quick, test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled
+  ; "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist", `Quick, test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist
+  ; "test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_is_disabled", `Quick, test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_is_disabled
+  ; "test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists", `Quick, test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists
+  ; "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed", `Quick, test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed
+  ; "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed", `Quick, test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed
   ]
 
 
-(** Tests clustering lock is only taken if needed *)
-let test_clustering_lock_only_taken_if_needed = 
-  let nest_with_clustering_lock_if_needed ~__context ~timeout ~type1 ~type2 ~on_deadlock ~on_no_deadlock =
-    Helpers.timebox
-      ~timeout:timeout
-      ~otherwise: on_deadlock
-      (fun () ->
-        Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type:type1 (fun () -> 
-          Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type:type2 (fun () ->
-            on_no_deadlock ()        
+(** Test clustering lock is only taken if needed *)
+
+let nest_with_clustering_lock_if_needed ~__context ~timeout ~type1 ~type2 ~on_deadlock ~on_no_deadlock =
+  Helpers.timebox
+    ~timeout:timeout
+    ~otherwise: on_deadlock
+    (fun () ->
+       Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type:type1
+        (fun () ->
+          Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type:type2
+          (fun () -> on_no_deadlock ()
           )
         )
-      )
-  in
+    )
 
-  let test_clustering_lock_only_taken_if_needed_nested_calls () =
-    let __context = T.make_test_database () in
-    let _ = T.make_sm ~__context ~_type:"type_corosync" ~required_cluster_stack:["corosync"] () in
-    let _ = T.make_sm ~__context ~_type:"type_nocluster" ~required_cluster_stack:[] () in
+let test_clustering_lock_only_taken_if_needed_nested_calls () =
+  let __context = T.make_test_database () in
+  let _ = T.make_sm ~__context ~_type:"type_corosync" ~required_cluster_stack:["corosync"] () in
+  let _ = T.make_sm ~__context ~_type:"type_nocluster" ~required_cluster_stack:[] () in
 
-    nest_with_clustering_lock_if_needed
-      ~__context
-      ~timeout:1.0
-      ~type1: "type_corosync"
-      ~type2: "type_nocluster"
-      ~on_deadlock: (fun () -> failwith "Unexpected deadlock when making nested calls to with_clustering_lock_if_needed")
-      ~on_no_deadlock: (fun () -> ())
-  in
+  nest_with_clustering_lock_if_needed
+    ~__context
+    ~timeout:1.0
+    ~type1: "type_corosync"
+    ~type2: "type_nocluster"
+    ~on_deadlock: (fun () -> failwith "Unexpected deadlock when making nested calls to with_clustering_lock_if_needed")
+    ~on_no_deadlock: (fun () -> ())
 
-  let test_clustering_lock_taken_when_needed_nested_calls () = 
-    let __context = T.make_test_database () in
-    let _ = T.make_sm ~__context ~_type:"type_corosync1" ~required_cluster_stack:["corosync"] () in
-    let _ = T.make_sm ~__context ~_type:"type_corosync2" ~required_cluster_stack:["corosync"] () in
+let test_clustering_lock_taken_when_needed_nested_calls () =
+  let __context = T.make_test_database () in
+  let _ = T.make_sm ~__context ~_type:"type_corosync1" ~required_cluster_stack:["corosync"] () in
+  let _ = T.make_sm ~__context ~_type:"type_corosync2" ~required_cluster_stack:["corosync"] () in
 
-    nest_with_clustering_lock_if_needed
-      ~__context
-      ~timeout:0.1
-      ~type1: "type_corosync1"
-      ~type2: "type_corosync2"
-      ~on_deadlock: (fun () -> ())
-      ~on_no_deadlock: (fun () -> failwith "Nesting calls to with_clustering_lock_if_needed should deadlock if both require a cluster stack, lock not taken or not working as expected.")
-  in
+  nest_with_clustering_lock_if_needed
+    ~__context
+    ~timeout:0.1
+    ~type1: "type_corosync1"
+    ~type2: "type_corosync2"
+    ~on_deadlock: (fun () -> ())
+    ~on_no_deadlock: (fun () -> failwith "Nesting calls to with_clustering_lock_if_needed should deadlock if both require a cluster stack, lock not taken or not working as expected.")
 
-  let open OUnit in
-  "test_clustering_lock_only_taken_if_needed" >:::
-  [ "test_clustering_lock_only_taken_if_needed_nested_calls" >:: test_clustering_lock_only_taken_if_needed_nested_calls
-  ; "test_clustering_lock_taken_when_needed_nested_calls" >:: test_clustering_lock_taken_when_needed_nested_calls
+let test_clustering_lock_only_taken_if_needed =
+  [ "test_clustering_lock_only_taken_if_needed_nested_calls", `Quick, test_clustering_lock_only_taken_if_needed_nested_calls
+  ; "test_clustering_lock_taken_when_needed_nested_calls", `Quick, test_clustering_lock_taken_when_needed_nested_calls
   ]
 
 let test_assert_pif_prerequisites () =
@@ -265,7 +275,8 @@ let test_assert_pif_prerequisites () =
   let exn = "we_havent_decided_on_the_exception_yet" in
   let pifref = Test_common.make_pif ~__context ~network ~host:localhost () in
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  OUnit.assert_raises
+  Alcotest.check_raises
+    "test_assert_pif_prerequisites should fail at first"
     (Failure exn)
     (fun () ->
       try
@@ -275,7 +286,8 @@ let test_assert_pif_prerequisites () =
   (* Put in IPv4 info *)
   Db.PIF.set_IP ~__context ~self:pifref ~value:"1.1.1.1";
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  OUnit.assert_raises
+  Alcotest.check_raises
+    "test_assert_pif_prerequisites should fail after setting IPv4 info"
     (Failure exn)
     (fun () ->
       try
@@ -284,7 +296,8 @@ let test_assert_pif_prerequisites () =
         failwith exn);
   Db.PIF.set_currently_attached ~__context ~self:pifref ~value:true;
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  OUnit.assert_raises
+  Alcotest.check_raises
+    "test_assert_pif_prerequisites should fail after setting attached:true"
     (Failure exn)
     (fun () ->
       try
@@ -293,15 +306,15 @@ let test_assert_pif_prerequisites () =
         failwith exn);
   Db.PIF.set_disallow_unplug ~__context ~self:pifref ~value:true;
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
-  OUnit.assert_equal (Xapi_clustering.assert_pif_prerequisites pif) ()
+  Alcotest.(check unit)
+    "assert_pif_prerequisites should pass after setting disallow_unplug:true"
+    (Xapi_clustering.assert_pif_prerequisites pif) ()
 
 let test =
-  let open OUnit in
-  "test_clustering" >:::
-  [ test_get_required_cluster_stacks
-  ; test_find_cluster_host
-  ; test_assert_cluster_host_enabled
-  ; test_assert_cluster_host_is_enabled_for_matching_sms
-  ; test_clustering_lock_only_taken_if_needed
-  ; "test_assert_pif_prerequisites" >:: test_assert_pif_prerequisites
+  [ "Test_get_required_cluster_stacks", test_get_required_cluster_stacks
+  ; "Test_find_cluster_host", test_find_cluster_host
+  ; "Test_assert_cluster_host_enabled", test_assert_cluster_host_enabled
+  ; "Test_assert_cluster_host_is_enabled_for_matching_sms", test_assert_cluster_host_is_enabled_for_matching_sms
+  ; "Test_clustering_lock_only_taken_if_needed", test_clustering_lock_only_taken_if_needed
+  ; "Test_assert_pif_prerequisites", [ "test_assert_pif_prerequisites", `Quick, test_assert_pif_prerequisites ]
   ]

--- a/ocaml/tests/test_clustering.ml
+++ b/ocaml/tests/test_clustering.ml
@@ -310,11 +310,6 @@ let test_assert_pif_prerequisites () =
     "assert_pif_prerequisites should pass after setting disallow_unplug:true"
     (Xapi_clustering.assert_pif_prerequisites pif) ()
 
-let test =
-  [ "Test_get_required_cluster_stacks", test_get_required_cluster_stacks
-  ; "Test_find_cluster_host", test_find_cluster_host
-  ; "Test_assert_cluster_host_enabled", test_assert_cluster_host_enabled
-  ; "Test_assert_cluster_host_is_enabled_for_matching_sms", test_assert_cluster_host_is_enabled_for_matching_sms
-  ; "Test_clustering_lock_only_taken_if_needed", test_clustering_lock_only_taken_if_needed
-  ; "Test_assert_pif_prerequisites", [ "test_assert_pif_prerequisites", `Quick, test_assert_pif_prerequisites ]
-  ]
+let test_assert_pif_prerequisites =
+  [ "test_assert_pif_prerequisites", `Quick, test_assert_pif_prerequisites ]
+

--- a/ocaml/tests/test_clustering.ml
+++ b/ocaml/tests/test_clustering.ml
@@ -313,3 +313,11 @@ let test_assert_pif_prerequisites () =
 let test_assert_pif_prerequisites =
   [ "test_assert_pif_prerequisites", `Quick, test_assert_pif_prerequisites ]
 
+let test =
+  ( test_get_required_cluster_stacks
+  @ test_find_cluster_host
+  @ test_assert_cluster_host_enabled
+  @ test_assert_cluster_host_is_enabled_for_matching_sms
+  @ test_clustering_lock_only_taken_if_needed
+  @ test_assert_pif_prerequisites
+  )

--- a/ocaml/tests/test_clustering_allowed_operations.ml
+++ b/ocaml/tests/test_clustering_allowed_operations.ml
@@ -12,8 +12,9 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
 open Test_common
+
+let assert_true msg x = Alcotest.(check bool) msg true x
 
 (** cluster_create is not allowed if a cluster already exists *)
 let test_pool_cluster_create_not_allowed_when_cluster_exists () =
@@ -22,7 +23,7 @@ let test_pool_cluster_create_not_allowed_when_cluster_exists () =
   let _, _ = make_cluster_and_cluster_host ~__context () in
   Xapi_pool_helpers.update_allowed_operations ~__context ~self;
   let allowed_ops = Db.Pool.get_allowed_operations ~__context ~self in
-  assert_bool "Pool.allowed_operations should not contain 'cluster_create'"
+  assert_true "Pool.allowed_operations should not contain 'cluster_create'"
     (not (List.mem `cluster_create allowed_ops))
 
 (** cluster_create is not allowed if any pool operations are in progress *)
@@ -32,7 +33,7 @@ let test_pool_cluster_create_not_allowed_during_pool_ops () =
   Xapi_pool_helpers.with_pool_operation ~__context ~self ~doc:"" ~op:`ha_enable
     (fun () ->
        let allowed_ops = Db.Pool.get_allowed_operations ~__context ~self in
-       assert_bool "Pool.allowed_operations should not contain 'cluster_create'"
+       assert_true "Pool.allowed_operations should not contain 'cluster_create'"
          (not (List.mem `cluster_create allowed_ops)))
 
 (** cluster_create is allowed if the pool has no cluster AND there are no pool
@@ -42,7 +43,7 @@ let test_pool_cluster_create_allowed () =
   let self = Db.Pool.get_all ~__context |> List.hd in
   Xapi_pool_helpers.update_allowed_operations ~__context ~self;
   let allowed_ops = Db.Pool.get_allowed_operations ~__context ~self in
-  assert_bool "Pool.allowed_operations should contain 'cluster_create'"
+  assert_true "Pool.allowed_operations should contain 'cluster_create'"
     (List.mem `cluster_create allowed_ops)
 
 (** no cluster operations are allowed if cluster operations are in progress *)
@@ -52,7 +53,7 @@ let test_cluster_ops_not_allowed_during_cluster_op () =
   Xapi_cluster_helpers.with_cluster_operation ~__context ~self ~doc:"" ~op:`add
     (fun () ->
        let allowed_ops = Db.Cluster.get_allowed_operations ~__context ~self in
-       assert_bool "Cluster.allowed_operations should be empty" (allowed_ops = []))
+       assert_true "Cluster.allowed_operations should be empty" (allowed_ops = []))
 
 (** all cluster operations are allowed if no cluster operations are in progress *)
 let test_all_cluster_ops_allowed_when_no_cluster_ops_in_progress () =
@@ -63,7 +64,7 @@ let test_all_cluster_ops_allowed_when_no_cluster_ops_in_progress () =
   List.iter (fun op ->
       let msg = Printf.sprintf "Cluster.allowed_operations should contain '%s'"
           (Record_util.cluster_operation_to_string op) in
-      assert_bool msg (List.mem `add allowed_ops)
+      assert_true msg (List.mem `add allowed_ops)
     ) Xapi_cluster_helpers.all_cluster_operations
 
 (** if the cluster_host is enabled and there are no cluster_host operations in progress
@@ -73,9 +74,9 @@ let test_cluster_host_disable_allowed () =
   let _, self = make_cluster_and_cluster_host ~__context () in
   Xapi_cluster_host_helpers.update_allowed_operations ~__context ~self;
   let allowed_ops = Db.Cluster_host.get_allowed_operations ~__context ~self in
-  assert_bool "Cluster_host.allowed_operations should contain 'disable'"
+  assert_true "Cluster_host.allowed_operations should contain 'disable'"
     (List.mem `disable allowed_ops);
-  assert_bool "Cluster_host.allowed_operations should contain 'enable'"
+  assert_true "Cluster_host.allowed_operations should contain 'enable'"
     (List.mem `enable allowed_ops)
 
 (** if the cluster_host is disabled and there are no cluster_host operations in progress
@@ -86,9 +87,9 @@ let test_cluster_host_enable_allowed () =
   Db.Cluster_host.set_enabled ~__context ~self ~value:false;
   Xapi_cluster_host_helpers.update_allowed_operations ~__context ~self;
   let allowed_ops = Db.Cluster_host.get_allowed_operations ~__context ~self in
-  assert_bool "Cluster_host.allowed_operations should contain 'enable'"
+  assert_true "Cluster_host.allowed_operations should contain 'enable'"
     (List.mem `enable allowed_ops);
-  assert_bool "Cluster_host.allowed_operations should contain 'disable'"
+  assert_true "Cluster_host.allowed_operations should contain 'disable'"
     (List.mem `disable allowed_ops)
 
 (** no cluster_host operations are allowed if cluster_host operations are in progress *)
@@ -98,17 +99,15 @@ let test_cluster_host_ops_not_allowed_during_cluster_host_op () =
   Xapi_cluster_host_helpers.with_cluster_host_operation ~__context ~self ~doc:"" ~op:`disable
     (fun () ->
        let allowed_ops = Db.Cluster_host.get_allowed_operations ~__context ~self in
-       assert_bool "Cluster_host.allowed_operations should be empty" (allowed_ops = []))
+       assert_true "Cluster_host.allowed_operations should be empty" (allowed_ops = []))
 
 let test =
-  "test_clustering_allowed_operations" >:::
-  [
-    "test_pool_cluster_create_not_allowed_when_cluster_exists" >:: test_pool_cluster_create_not_allowed_when_cluster_exists;
-    "test_pool_cluster_create_not_allowed_during_pool_ops" >:: test_pool_cluster_create_not_allowed_during_pool_ops;
-    "test_pool_cluster_create_allowed" >:: test_pool_cluster_create_allowed;
-    "test_cluster_ops_not_allowed_during_cluster_op" >:: test_cluster_ops_not_allowed_during_cluster_op;
-    "test_all_cluster_ops_allowed_when_no_cluster_ops_in_progress" >:: test_all_cluster_ops_allowed_when_no_cluster_ops_in_progress;
-    "test_cluster_host_disable_allowed" >:: test_cluster_host_disable_allowed;
-    "test_cluster_host_enable_allowed" >:: test_cluster_host_enable_allowed;
-    "test_cluster_host_ops_not_allowed_during_cluster_host_op" >:: test_cluster_host_ops_not_allowed_during_cluster_host_op;
+  [ "test_pool_cluster_create_not_allowed_when_cluster_exists", `Quick, test_pool_cluster_create_not_allowed_when_cluster_exists
+  ; "test_pool_cluster_create_not_allowed_during_pool_ops", `Quick, test_pool_cluster_create_not_allowed_during_pool_ops
+  ; "test_pool_cluster_create_allowed", `Quick, test_pool_cluster_create_allowed
+  ; "test_cluster_ops_not_allowed_during_cluster_op", `Quick, test_cluster_ops_not_allowed_during_cluster_op
+  ; "test_all_cluster_ops_allowed_when_no_cluster_ops_in_progress", `Quick, test_all_cluster_ops_allowed_when_no_cluster_ops_in_progress
+  ; "test_cluster_host_disable_allowed", `Quick, test_cluster_host_disable_allowed
+  ; "test_cluster_host_enable_allowed", `Quick, test_cluster_host_enable_allowed
+  ; "test_cluster_host_ops_not_allowed_during_cluster_host_op", `Quick, test_cluster_host_ops_not_allowed_during_cluster_host_op
   ]


### PR DESCRIPTION
Motivation: Alcotest allows for cleaner error reporting and debugging. Additionally, I will be submitting a PR that adds a unit test to test_clustering which is written in Alcotest, hence a port was necessary.

Changes in test_clustering:
- `assert_equal` now uses an Alcotest comparator
- every individual unit test is now a toplevel function

Changes in test_clustering_allowed_operations:
- OUnit.assert_bool -> Alcotest.(check bool)