### PR TITLE
CP-27272: Fix for VM without SR-IOV VIFs start failed

### DIFF
--- a/ocaml/tests/test_vm_helpers.ml
+++ b/ocaml/tests/test_vm_helpers.ml
@@ -280,12 +280,13 @@ let test_netsriov_available_succeeds () =
       let vm = make_vm_with_vif ~__context ~network:network_on_h in
       assert_netsriov_available ~__context ~self:vm ~host:h')
 
+(* If a host without a SR-IOV network was chosen,then the assert_can_see_networks will raise `vm_requires_net` before `assert_netsriov_available` *)
 let test_netsriov_available_fails_no_netsriov () =
   on_pool_of_intel_i350 (fun __context h _ _ ->
       let sriov_network = List.find (fun network -> Xapi_network_sriov_helpers.is_sriov_network ~__context ~self:network) (Db.Network.get_all ~__context) in
       let vm = make_vm_with_vif ~__context ~network:sriov_network in
-      assert_raises_api_error Api_errors.internal_error (fun () ->
-          assert_netsriov_available ~__context ~self:vm ~host:h))
+      assert_raises_api_error Api_errors.vm_requires_net (fun () ->
+          assert_can_see_networks ~__context ~self:vm ~host:h))
 
 let test_netsriov_available_fails_no_capacity () =
   on_pool_of_intel_i350 (fun __context _ h' _ ->
@@ -295,11 +296,14 @@ let test_netsriov_available_fails_no_capacity () =
           List.exists (fun pif -> h' = Db.PIF.get_host ~__context ~self:pif) pifs
         ) sriov_networks in
       let vm = make_vm_with_vif ~__context ~network:network_on_h in
-      let pif = Xapi_network_sriov_helpers.get_local_underlying_pif ~__context ~network:network_on_h ~host:h' in
-      let pci = Db.PIF.get_PCI ~__context ~self:pif in
-      make_allocated_vfs ~__context ~vm ~pci ~num:8L;
-      assert_raises_api_error Api_errors.network_sriov_insufficient_capacity (fun () ->
-          assert_netsriov_available ~__context ~self:vm ~host:h'))
+      match Xapi_network_sriov_helpers.get_local_underlying_pif ~__context ~network:network_on_h ~host:h' with
+      | None -> failwith "Test-failure: Cannot get underlying pif from sr-iov network"
+      | Some pif ->
+        let pci = Db.PIF.get_PCI ~__context ~self:pif in
+        make_allocated_vfs ~__context ~vm ~pci ~num:8L;
+        assert_raises_api_error Api_errors.network_sriov_insufficient_capacity (fun () ->
+            assert_netsriov_available ~__context ~self:vm ~host:h')
+      )
 
 let assert_grouping_of_sriov ~__context ~network ~expection_groups =
   let host_lists = Xapi_network_sriov_helpers.group_hosts_by_best_sriov ~__context ~network in
@@ -369,10 +373,13 @@ let test_group_hosts_netsriov_with_allocated () =
             List.exists (fun pif -> h' = Db.PIF.get_host ~__context ~self:pif) pifs
           ) sriov_networks in
         let vm = make_vm_with_vif ~__context ~network:network_on_h in
-        let pif = Xapi_network_sriov_helpers.get_local_underlying_pif ~__context ~network:network_on_h ~host:h' in
-        let pci = Db.PIF.get_PCI ~__context ~self:pif in
-        make_allocated_vfs ~__context ~vm ~pci ~num:2L;
-        assert_grouping_of_sriov ~__context ~network:n2 ~expection_groups:[ [(h'',8L)]; [(h',6L)] ]
+        begin match Xapi_network_sriov_helpers.get_local_underlying_pif ~__context ~network:network_on_h ~host:h' with
+        | None -> failwith "Test-failure: Cannot get underlying pif from sr-iov network"
+        | Some pif ->
+          let pci = Db.PIF.get_PCI ~__context ~self:pif in
+          make_allocated_vfs ~__context ~vm ~pci ~num:2L;
+          assert_grouping_of_sriov ~__context ~network:n2 ~expection_groups:[ [(h'',8L)]; [(h',6L)] ]
+        end
       | _ -> failwith "Test-failure: Unexpected number of sriov network in test" )
 
 let test_get_group_key_vgpu () =

--- a/ocaml/xapi/xapi_network_sriov_helpers.ml
+++ b/ocaml/xapi/xapi_network_sriov_helpers.ml
@@ -151,12 +151,8 @@ let get_sriov_networks_from_vm ~__context ~vm =
 (* Get localhost underlying pif with for the sr-iov network *)
 let get_local_underlying_pif ~__context ~network ~host =
   match Xapi_network_attach_helpers.get_local_pifs ~__context ~network ~host with
-    | [] -> raise Api_errors.(Server_error (internal_error, ["Cannot get local pif on network"]))
-    | pif :: _ ->
-      begin match get_underlying_pif ~__context ~pif with
-      | Some pif -> pif
-      | None -> raise Api_errors.(Server_error (internal_error, ["Cannot get underlying pif on sriov network"]))
-      end
+  | [] -> None
+  | pif :: _ -> get_underlying_pif ~__context ~pif
 
 (* Get remaining capacity for localhost on the given network, return None if no underlying_pif found or capacity = 0L *)
 let get_remaining_capacity_on_host ~__context ~host ~network =
@@ -199,14 +195,17 @@ let group_hosts_by_best_sriov ~__context ~network =
     host_lists @ [unattached_hosts]
   else host_lists
 
-(* If exn happens during vifs reservation ,reserved vfs will be cleared *)
+(* If exn happens during vifs reservation ,reserved vfs will be cleared. Nothing will be done while cannot get underlying pif *)
 let reserve_sriov_vfs ~__context ~host ~vm =
   let vifs = Db.VM.get_VIFs ~__context ~self:vm in
   List.iter (fun vif ->
       let network = Db.VIF.get_network ~__context ~self:vif in
-      let pif =  get_local_underlying_pif ~__context ~network ~host in
-      let pci = Db.PIF.get_PCI ~__context ~self:pif in
-      match Pciops.reserve_free_virtual_function ~__context vm pci with
-      | Some vf -> Db.VIF.set_reserved_pci ~__context ~self:vif ~value:vf
-      | None -> raise Api_errors.(Server_error (internal_error, ["No free virtual function found"]))
+      match get_local_underlying_pif ~__context ~network ~host with
+      | None -> ()
+      | Some pif ->
+        let pci = Db.PIF.get_PCI ~__context ~self:pif in
+        begin match Pciops.reserve_free_virtual_function ~__context vm pci with
+        | Some vf -> Db.VIF.set_reserved_pci ~__context ~self:vif ~value:vf
+        | None -> raise Api_errors.(Server_error (internal_error, ["No free virtual function found"]))
+        end
   ) vifs

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -418,8 +418,9 @@ let assert_netsriov_available ~__context ~self ~host =
         let required, pif = List.assoc network acc in
         (network,(required + 1,pif)) :: (List.remove_assoc network acc)
       with Not_found ->
-        let pif = Xapi_network_sriov_helpers.get_local_underlying_pif ~__context ~network ~host in
-        (network,(1,pif)) :: acc
+        match Xapi_network_sriov_helpers.get_local_underlying_pif ~__context ~network ~host with
+        | Some pif -> (network,(1,pif)) :: acc
+        | None -> acc
     ) [] (Db.VM.get_VIFs ~__context ~self)
   in
   List.iter (fun (network, (required,pif)) ->


### PR DESCRIPTION
This is a fix for host selection and reserve VF when vm without sr-iov VIF.
The function `get_local_underlying_pif ` was called in `assert_netsriov_available` and `reserve_sriov_vfs`.
These two functions will be called unconditionally when host selection and after selection to reserve VFs, so `get_local_underlying_pif ` should not raise an exception when no pif found due to exn will impacts VM start which hasn't sr-iov VIF.

Signed-off-by: Min Li <min.li1@citrix.com>