### PR TITLE
CP-27381: Auto-plug SR-IOV physical PIF; CP-27329: Make Network SR-IOV Sync Do Plug on Slave

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1175,18 +1175,6 @@ let host_query_ha = call ~flags:[`Session]
       ~allowed_roles:_R_POOL_OP
       ()
 
-  let sync_network_sriovs = call ~flags:[`Session]
-      ~name:"sync_network_sriovs"
-      ~lifecycle:[Published, rel_kolkata, ""]
-      ~doc:"Synchronise network sriovs on given host with the master's network sriovs"
-      ~params:[
-        Ref _host, "host", "The host";
-      ]
-      ~hide_from_docs:true
-      ~pool_internal:true
-      ~allowed_roles:_R_POOL_OP
-      ()
-
   let sync_pif_currently_attached = call ~flags:[`Session]
       ~name:"sync_pif_currently_attached"
       ~lifecycle:[]
@@ -1383,7 +1371,6 @@ let host_query_ha = call ~flags:[`Session]
         sm_dp_destroy;
         sync_vlans;
         sync_tunnels;
-        sync_network_sriovs;
         sync_pif_currently_attached;
         migrate_receive;
         declare_dead;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2636,10 +2636,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Host.sync_tunnels: host = '%s'" (host_uuid ~__context host);
       Local.Host.sync_tunnels ~__context ~host
 
-    let sync_network_sriovs ~__context ~host =
-      info "Host.sync_network_sriovs: host = '%s'" (host_uuid ~__context host);
-      Local.Host.sync_network_sriovs ~__context ~host
-
     let sync_pif_currently_attached ~__context ~host ~bridges =
       info "Host.sync_pif_currently_attached: host = '%s'" (host_uuid ~__context host);
       Local.Host.sync_pif_currently_attached ~__context ~host ~bridges

--- a/ocaml/xapi/sync_networking.ml
+++ b/ocaml/xapi/sync_networking.ml
@@ -163,6 +163,48 @@ let copy_tunnels_from_master ~__context () =
 
 (** Copy network-sriovs from master *)
 let copy_network_sriovs_from_master ~__context () =
+  let me = !Xapi_globs.localhost_ref in
+  let master = Helpers.get_master ~__context in
+  let master_sriov_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
+      Eq (Field "host", Literal (Ref.string_of master)),
+      Not (Eq (Field "sriov_logical_PIF_of", Literal "()"))
+    )) in
+  let my_sriov_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
+      Eq (Field "host", Literal (Ref.string_of me)),
+      Not (Eq (Field "sriov_logical_PIF_of", Literal "()"))
+    )) in
+  let my_physical_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
+      Eq (Field "host", Literal (Ref.string_of me)),
+      Eq (Field "physical", Literal "true")
+    )) in
+
   debug "Resynchronising network-sriovs";
-  let host = !Xapi_globs.localhost_ref in
-  Helpers.call_api_functions ~__context (fun rpc session_id -> Client.Host.sync_network_sriovs ~rpc ~session_id ~host)
+  let maybe_create_sriov_for_me (master_pif_ref, master_pif_rec) =
+    let sriov_network = master_pif_rec.API.pIF_network in
+    let existing_pif = List.filter (fun (_, slave_pif_rec) ->
+        slave_pif_rec.API.pIF_network = sriov_network
+      ) my_sriov_pifs in
+    if existing_pif = [] then begin
+      let device = master_pif_rec.API.pIF_device in
+      let pifs = List.filter (fun (_, pif_rec) -> pif_rec.API.pIF_device = device) my_physical_pifs in
+      match pifs with
+      | [] ->
+        info "Cannot sync network sriov because cannot find PIF whose device name is %s" device
+      | (pif_ref, pif_rec) :: _ ->
+        begin
+          try
+            Xapi_network_sriov.create ~__context ~pif:pif_ref ~network:sriov_network |> ignore
+          with
+          | Api_errors.Server_error (err, _) when err = Api_errors.network_has_incompatible_sriov_pifs ->
+            warn "Cannot sync network sriov on slave because PCI device of %s is different from the PIF of master in the same position" pif_rec.API.pIF_uuid
+          | Api_errors.Server_error (err, _) when err = Api_errors.network_sriov_already_enabled ->
+            warn "Cannot sync network sriov on slave because PIF %s on slave has enabled sriov in another network" pif_rec.API.pIF_uuid
+          | Api_errors.Server_error (err, _) when err = Api_errors.pif_is_not_sriov_capable ->
+            warn "Cannot sync network sriov on slave because PIF %s on slave is not sriov capable" pif_rec.API.pIF_uuid
+          | exn ->
+            error "Error occurs when syncing network sriov for PIF %s: %s" pif_rec.API.pIF_uuid (Printexc.to_string exn)
+        end
+    end
+  in
+  List.iter (Helpers.log_exn_continue "resynchronising network sriov on slave" 
+      maybe_create_sriov_for_me) master_sriov_pifs

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1674,49 +1674,6 @@ let sync_tunnels ~__context ~host =
   (* for each of the master's pifs, create a corresponding one on this host if necessary *)
   List.iter maybe_create_tunnel_for_me master_tunnel_pifs
 
-let sync_network_sriovs ~__context ~host =
-  let master = !Xapi_globs.localhost_ref in
-  let master_sriov_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
-      Eq (Field "host", Literal (Ref.string_of master)),
-      Not (Eq (Field "sriov_logical_PIF_of", Literal "()"))
-    )) in
-  let slave_sriov_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
-      Eq (Field "host", Literal (Ref.string_of host)),
-      Not (Eq (Field "sriov_logical_PIF_of", Literal "()"))
-    )) in
-  let slave_physical_pifs = Db.PIF.get_records_where ~__context ~expr:(And (
-      Eq (Field "host", Literal (Ref.string_of host)),
-      Eq (Field "physical", Literal "true")
-    )) in
-  let maybe_create_sriov (master_pif_ref, master_pif_rec) =
-    let sriov_network = master_pif_rec.API.pIF_network in
-    let existing_pif = List.filter (fun (_, slave_pif_rec) ->
-        slave_pif_rec.API.pIF_network = sriov_network
-      ) slave_sriov_pifs in
-    if existing_pif = [] then begin
-      let device = master_pif_rec.API.pIF_device in
-      let pifs = List.filter (fun (_, pif_rec) -> pif_rec.API.pIF_device = device) slave_physical_pifs in
-      match pifs with
-      | [] ->
-        info "Cannot sync network sriov because cannot find PIF whose device name is %s" device
-      | (pif_ref, pif_rec) :: _ ->
-        begin
-          try
-            Xapi_network_sriov.create ~__context ~pif:pif_ref ~network:sriov_network |> ignore
-          with
-          | Api_errors.Server_error (err, _) when err = Api_errors.network_has_incompatible_sriov_pifs ->
-            warn "Cannot sync network sriov on slave because PCI device of %s is different from the PIF of master in the same position" pif_rec.API.pIF_uuid
-          | Api_errors.Server_error (err, _) when err = Api_errors.network_sriov_already_enabled ->
-            warn "Cannot sync network sriov on slave because PIF %s on slave has enabled sriov in another network" pif_rec.API.pIF_uuid
-          | Api_errors.Server_error (err, _) when err = Api_errors.pif_is_not_sriov_capable ->
-            warn "Cannot sync network sriov on slave because PIF %s on slave is not sriov capable" pif_rec.API.pIF_uuid
-          | exn ->
-            error "Error occurs when syncing network sriov for PIF %s: %s" pif_rec.API.pIF_uuid (Printexc.to_string exn)
-        end
-    end
-  in
-  List.iter maybe_create_sriov master_sriov_pifs
-
 let sync_pif_currently_attached ~__context ~host ~bridges =
   (* Produce internal lookup tables *)
   let networks = Db.Network.get_all_records ~__context in

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -293,9 +293,6 @@ val sync_vlans : __context:Context.t -> host:API.ref_host -> unit
 (** Synchronise slave tunnels with master *)
 val sync_tunnels : __context:Context.t -> host:API.ref_host -> unit
 
-(** Synchronise slave network sriovs with master *)
-val sync_network_sriovs : __context:Context.t -> host:API.ref_host -> unit
-
 (** Synchronise PIF.currently_attached fields on given host.
  *  The parameter [bridges] contains a list of bridge names reflecting all bridges that are up. *)
 val sync_pif_currently_attached : __context:Context.t -> host:API.ref_host -> bridges:string list -> unit

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -808,6 +808,12 @@ let rec unplug ~__context ~self =
     debug "PIF is network sriov logical PIF, also bringing down vlan on top of it";
     unplug_vlan_on_sriov ~__context ~self
   end;
+  let sriov = Db.PIF.get_sriov_physical_PIF_of ~__context ~self in
+  if sriov <> [] then begin
+    debug "PIF is network SRIOV physical PIF, also bringing down SRIOV logical PIF";
+    let pif = Db.Network_sriov.get_logical_PIF ~__context ~self:(List.hd sriov)in
+    unplug ~__context ~self:pif
+  end;
   Nm.bring_pif_down ~__context self
 
 let rec plug ~__context ~self =

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -805,7 +805,7 @@ let rec unplug ~__context ~self =
     unplug ~__context ~self:access_PIF
   end;
   if Db.PIF.get_sriov_logical_PIF_of ~__context ~self <> [] then begin
-    debug "PIF is network sriov logical PIF, also bringing down vlan on top of it";
+    debug "PIF is network SRIOV logical PIF, also bringing down vlan on top of it";
     unplug_vlan_on_sriov ~__context ~self
   end;
   let sriov = Db.PIF.get_sriov_physical_PIF_of ~__context ~self in

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -830,6 +830,10 @@ let rec plug ~__context ~self =
         debug "PIF is VLAN master on top of SRIOV logical PIF, also bringing up SRIOV logical PIF";
         plug ~__context ~self:tagged_pif
       end
+    | Network_sriov_logical sriov ->
+      let phy_pif = Db.Network_sriov.get_physical_PIF ~__context ~self:sriov in
+      debug "PIF is SRIOV logical PIF, also bringing up SRIOV physical PIF";
+      plug ~__context ~self:phy_pif
     | Physical pif_rec when pif_rec.API.pIF_bond_slave_of <> Ref.null ->
       raise Api_errors.(Server_error (cannot_plug_bond_slave, [Ref.string_of self]))
     | _ -> ()


### PR DESCRIPTION
Two commits:
CP-27381: Auto-plug SR-IOV physical PIF 

This change aims to bring up physical SR-IOV PIF when plugging logical
SR-IOV PIF. Because we observed that if a physical PIF is unplugged, and 
SR-IOV on this physical PIF can be enabled, but the generated VFs can 
not be used by VM due to the physical PIF's interface is down.


CP-27329: Make Network SR-IOV Sync Do Plug on Slave

During reboot of a slave XenServer in a pool, XAPI logic on slave will
try to synchronize some networks from master. These networks include
bond, sriov, vlan, and tunnel. There is a difference between bond/sriov
and vlan/tunnel: the sync of bond/sriov is done on slave host, while the 
sync of vlan/tunnel is done on master host. This is because sync of
vlan/tunnel is just to create DB objects without plug. Making it done
on master could improve the efficiency of creating DB objects.

But this is not true for bond and sriov, as both of them need to be
plugged in sync, which has to be done on slave.

This change will fix a bug which would cause the plug of sriov done on
master. Instead, it should be done on slave, just like sync of bond
network.

Signed-off-by: Ming Lu <ming.lu@citrix.com>