### PR TITLE
Port unit tests to Alcotest

### DIFF
--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -28,7 +28,6 @@ let base_suite =
     Test_pool_license.test;
     Test_features.test;
     Test_pool_restore_database.test;
-    Test_pool_update.test;
     Test_platformdata.test;
     Test_sm_features.test;
     Test_pci_helpers.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -22,7 +22,6 @@ let base_suite =
     Test_http.test;
     Test_pool_db_backup.test;
     Test_xapi_db_upgrade.test;
-    Test_ca91480.test;
     Test_ha_vm_failover.test;
     Test_map_check.test;
     Test_pool_apply_edition.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -40,7 +40,6 @@ let base_suite =
     Test_storage_migrate_state.test;
     Test_vm.test;
     Test_vm_helpers.test;
-    Test_vm_migrate.test;
     Test_xenopsd_metadata.test;
     Test_workload_balancing.test;
     Test_cpuid_helpers.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -43,7 +43,6 @@ let base_suite =
     (* Test_ca121350.test; *)
     Test_dbsync_master.test;
     Test_xapi_xenops.test;
-    Test_pvs_site.test;
     Test_pvs_proxy.test;
     Test_pvs_server.test;
     Test_pvs_cache_storage.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -31,7 +31,6 @@ let base_suite =
     Test_pool_update.test;
     Test_platformdata.test;
     Test_sm_features.test;
-    Test_gpu_group.test;
     Test_pci_helpers.test;
     Test_vgpu_type.test;
     Test_pgpu.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -56,7 +56,6 @@ let base_suite =
     Test_sr_update_vdis.test;
     Test_network_event_loop.test;
     Test_network.test;
-    Test_pusb.test;
     Test_host_helpers.test;
     Test_clustering_allowed_operations.test;
     Test_clustering.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -43,7 +43,6 @@ let base_suite =
     (* Test_ca121350.test; *)
     Test_dbsync_master.test;
     Test_xapi_xenops.test;
-    Test_pvs_proxy.test;
     Test_pvs_server.test;
     Test_pvs_cache_storage.test;
     Test_sdn_controller.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -24,7 +24,6 @@ let base_suite =
     Test_xapi_db_upgrade.test;
     Test_ha_vm_failover.test;
     Test_map_check.test;
-    Test_pool_apply_edition.test;
     Test_pool_license.test;
     Test_features.test;
     Test_pool_restore_database.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -46,7 +46,6 @@ let base_suite =
     (* Test_ca121350.test; *)
     Test_dbsync_master.test;
     Test_xapi_xenops.test;
-    Test_no_migrate.test;
     Test_pvs_site.test;
     Test_pvs_proxy.test;
     Test_pvs_server.test;

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -7,8 +7,8 @@ let () =
   Alcotest.run "Base suite"
     [ "Test_valid_ref_list", Test_valid_ref_list.test
     ; "Test_vdi_allowed_operations", Test_vdi_allowed_operations.test
-    ; "Test_vm_migrate", Test_vm_migrate.test;
-    ; "Test_no_migrate", Test_no_migrate.test;
+    ; "Test_vm_migrate", Test_vm_migrate.test
+    ; "Test_no_migrate", Test_no_migrate.test
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
     ; "Test_host", Test_host.test
     ; "Test_vdi_cbt", Test_vdi_cbt.test
@@ -23,6 +23,7 @@ let () =
     ; "Test_gpu_group", Test_gpu_group.test
     ; "Test_pool_apply_edition", Test_pool_apply_edition.test
     ; "Test_pool_update", Test_pool_update.test
-    ; "Test_pusb", Test_pusb.test;
+    ; "Test_pusb", Test_pusb.test
     ; "Test_pvs_site", Test_pvs_site.test
+    ; "Test_pvs_proxy", Test_pvs_proxy.test
     ]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -20,4 +20,5 @@ let () =
     ; "Test_cluster_host", Test_cluster_host.test
     ; "Test_client", Test_client.test
     ; "Test_ca91480", Test_ca91480.test
+    ; "Test_gpu_group", Test_gpu_group.test
     ]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -22,4 +22,5 @@ let () =
     ; "Test_ca91480", Test_ca91480.test
     ; "Test_gpu_group", Test_gpu_group.test
     ; "Test_pool_update", Test_pool_update.test
+    ; "Test_pusb", Test_pusb.test;
     ]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -7,6 +7,7 @@ let () =
   Alcotest.run "Base suite"
     [ "Test_valid_ref_list", Test_valid_ref_list.test
     ; "Test_vdi_allowed_operations", Test_vdi_allowed_operations.test
+    ; "Test_vm_migrate", Test_vm_migrate.test;
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
     ; "Test_host", Test_host.test
     ; "Test_vdi_cbt", Test_vdi_cbt.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -24,4 +24,5 @@ let () =
     ; "Test_pool_apply_edition", Test_pool_apply_edition.test
     ; "Test_pool_update", Test_pool_update.test
     ; "Test_pusb", Test_pusb.test;
+    ; "Test_pvs_site", Test_pvs_site.test
     ]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -8,6 +8,7 @@ let () =
     [ "Test_valid_ref_list", Test_valid_ref_list.test
     ; "Test_vdi_allowed_operations", Test_vdi_allowed_operations.test
     ; "Test_vm_migrate", Test_vm_migrate.test;
+    ; "Test_no_migrate", Test_no_migrate.test;
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
     ; "Test_host", Test_host.test
     ; "Test_vdi_cbt", Test_vdi_cbt.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -18,4 +18,5 @@ let () =
     ; "Test_cluster", Test_cluster.test
     ; "Test_cluster_host", Test_cluster_host.test
     ; "Test_client", Test_client.test
+    ; "Test_ca91480", Test_ca91480.test
     ]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -21,6 +21,7 @@ let () =
     ; "Test_client", Test_client.test
     ; "Test_ca91480", Test_ca91480.test
     ; "Test_gpu_group", Test_gpu_group.test
+    ; "Test_pool_apply_edition", Test_pool_apply_edition.test
     ; "Test_pool_update", Test_pool_update.test
     ; "Test_pusb", Test_pusb.test;
     ]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -21,4 +21,5 @@ let () =
     ; "Test_client", Test_client.test
     ; "Test_ca91480", Test_ca91480.test
     ; "Test_gpu_group", Test_gpu_group.test
+    ; "Test_pool_update", Test_pool_update.test
     ]

--- a/ocaml/tests/test_ca91480.ml
+++ b/ocaml/tests/test_ca91480.ml
@@ -2,12 +2,9 @@
    VBDs, VIFs, VGPUs, PCIs, VM_metrics, and VM_guest_metrics, but none
    of these objects should actually exist in the DB.  *)
 
-open OUnit
-open Test_common
-
 let setup_fixture () =
-  let __context = make_test_database () in
-  let self = make_vm ~__context () in
+  let __context = Test_common.make_test_database () in
+  let self = Test_common.make_vm ~__context () in
 
   let fake_v f = f ~__context ~self ~value:(Ref.make ())
   and fake_m f = f ~__context ~self ~key:"fake" ~value:(Ref.make ())
@@ -26,7 +23,5 @@ let test_vm_destroy () =
   Xapi_vm_helpers.destroy ~__context ~self
 
 let test =
-  "test_ca91480" >:::
-  [
-    "test_vm_destroy" >:: test_vm_destroy;
+  [ "test_vm_destroy", `Quick, test_vm_destroy
   ]

--- a/ocaml/tests/test_pool_apply_edition.ml
+++ b/ocaml/tests/test_pool_apply_edition.ml
@@ -12,14 +12,12 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-
 let apply_edition_succeed ~__context ~host ~edition =
   Db.Host.set_edition ~__context ~self:host ~value:edition
 
 let apply_edition_fail_host_offline ~__context ~host ~edition =
-  raise (Api_errors.Server_error
-           (Api_errors.host_offline, [Ref.string_of host]))
+  raise Api_errors.(Server_error
+           (host_offline, [Ref.string_of host]))
 
 let setup ~host_count ~edition =
   let __context = Test_common.make_test_database () in
@@ -41,10 +39,10 @@ let test_basic_operation () =
   List.iter
     (fun host ->
        let new_edition = Db.Host.get_edition ~__context ~self:host in
-       assert_equal
-         ~msg:(Printf.sprintf
-                 "Testing that host %s has had the new license applied"
-                 (Ref.string_of host))
+       Alcotest.(check string)
+         (Printf.sprintf
+             "Testing that host %s has had the new license applied"
+             (Ref.string_of host))
          "per-socket"
          new_edition)
     hosts
@@ -61,26 +59,23 @@ let test_rollback_logic () =
     then apply_edition_fail_host_offline ~__context ~host ~edition
     else apply_edition_succeed ~__context ~host ~edition
   in
-  assert_raises ~msg:"Testing that HOST_OFFLINE is successfully propagated"
-    (Api_errors.Server_error
-       (Api_errors.host_offline, [Ref.string_of offline_host]))
+  Alcotest.check_raises "Testing that HOST_OFFLINE is successfully propagated"
+    Api_errors.(Server_error (host_offline, [Ref.string_of offline_host]))
     (fun () ->
        Xapi_pool_license.apply_edition_with_rollback
          ~__context ~hosts ~edition:"per-socket" ~apply_fn);
   List.iter
     (fun host ->
        let new_edition = Db.Host.get_edition ~__context ~self:host in
-       assert_equal
-         ~msg:(Printf.sprintf
-                 "Testing that host %s has been rolled back to free edition"
-                 (Ref.string_of host))
+       Alcotest.(check string)
+         (Printf.sprintf
+           "Testing that host %s has been rolled back to free edition"
+           (Ref.string_of host))
          "free"
          new_edition)
     hosts
 
 let test =
-  "pool_apply_edition" >:::
-  [
-    "test_basic_operation" >:: test_basic_operation;
-    "test_rollback_logic" >:: test_rollback_logic;
+  [ "test_basic_operation", `Quick, test_basic_operation
+  ; "test_rollback_logic", `Quick, test_rollback_logic
   ]

--- a/ocaml/tests/test_pusb.ml
+++ b/ocaml/tests/test_pusb.ml
@@ -12,12 +12,9 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
-
 let create_base_environment () =
-  let __context = make_test_database () in
-  let pusb = make_sr ~__context () in
+  let __context = Test_common.make_test_database () in
+  let pusb = Test_common. make_sr ~__context () in
   __context, pusb
 
 let start_thread ~__context info =
@@ -26,7 +23,7 @@ let start_thread ~__context info =
   Xapi_pusb.start_thread f
 
 let test_scan_with_usb_add_and_remove () =
-  let __context = make_test_database () in
+  let __context = Test_common.make_test_database () in
   let test_pusb = "[{
                     \"product-desc\": \"\",
                     \"product-id\": \"5591\",
@@ -51,10 +48,10 @@ let test_scan_with_usb_add_and_remove () =
 
   Xapi_pusb.scan ~__context ~host;
   Thread.delay 1.0;
-  assert_equal 1 (List.length (Db.PUSB.get_all_records ~__context))
+  Alcotest.(check int)
+    "test_scan_with_usb_add_and_remove called assertion for number of PUSB records"
+    1 (List.length (Db.PUSB.get_all_records ~__context))
 
 let test =
-  "test_pusb" >:::
-  [
-	"test_scan_with_usb_add_and_remove" >:: test_scan_with_usb_add_and_remove;
+  [	"test_scan_with_usb_add_and_remove", `Quick, test_scan_with_usb_add_and_remove
   ]

--- a/ocaml/tests/test_pvs_proxy.ml
+++ b/ocaml/tests/test_pvs_proxy.ml
@@ -12,88 +12,113 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
+module T = Test_common
 
 let test_unlicensed () =
-  let __context = make_test_database ~features:[] () in
-  let site = make_pvs_site ~__context () in
-  let vIF = make_vif ~__context ~device:"0" () in
-  assert_raises
+  let __context = T.make_test_database ~features:[] () in
+  let site = T.make_pvs_site ~__context () in
+  let vIF = T.make_vif ~__context ~device:"0" () in
+  Alcotest.check_raises
+    "test_unlicensed should raise license_restriction"
     Api_errors.(Server_error (license_restriction, ["PVS_proxy"]))
-    (fun () -> Xapi_pvs_proxy.create ~__context ~site ~vIF)
+    (fun () -> ignore (Xapi_pvs_proxy.create ~__context ~site ~vIF))
 
 let test_create_ok () =
-  let __context = make_test_database () in
-  let site = make_pvs_site ~__context () in
-  let vIF = make_vif ~__context ~device:"0" () in
+  let __context = T.make_test_database () in
+  let site = T.make_pvs_site ~__context () in
+  let vIF = T.make_vif ~__context ~device:"0" () in
   let pvs_proxy = Xapi_pvs_proxy.create ~__context
       ~site ~vIF in
-  assert_equal site (Db.PVS_proxy.get_site ~__context ~self:pvs_proxy);
-  assert_equal vIF (Db.PVS_proxy.get_VIF ~__context ~self:pvs_proxy)
+  Alcotest.(check (Alcotest_comparators.ref ()))
+    "test_create_ok testing get_site"
+    site (Db.PVS_proxy.get_site ~__context ~self:pvs_proxy);
+  Alcotest.(check (Alcotest_comparators.ref ()))
+    "test_create_ok testing get_VIF"
+    vIF (Db.PVS_proxy.get_VIF ~__context ~self:pvs_proxy)
 
 let test_create_invalid_device () =
-  let __context = make_test_database () in
-  let site = make_pvs_site ~__context () in
-  let vIF = make_vif ~__context ~device:"1" () in
-  assert_raises_api_error
-    Api_errors.invalid_device
-    ~args:["1"]
-    (fun () -> Xapi_pvs_proxy.create ~__context ~site ~vIF)
+  let __context = T.make_test_database () in
+  let site = T.make_pvs_site ~__context () in
+  let vIF = T.make_vif ~__context ~device:"1" () in
+  Alcotest.check_raises
+    "test_create_invalid_device should raise invalid_device"
+    Api_errors.(Server_error
+                  (invalid_device, ["1"]))
+    (fun () -> ignore (Xapi_pvs_proxy.create ~__context ~site ~vIF))
 
 let test_create_invalid_site () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let site = Ref.make () in
-  let vIF = make_vif ~__context ~device:"0" () in
-  assert_raises_api_error
-    Api_errors.invalid_value
-    ~args:["site"; Ref.string_of site]
-    (fun () -> Xapi_pvs_proxy.create ~__context ~site ~vIF)
+  let vIF = T.make_vif ~__context ~device:"0" () in
+  Alcotest.check_raises
+    "test_create_invalid_site should raise invalid_value"
+    Api_errors.(Server_error
+                  (invalid_value, ["site"; Ref.string_of site]))
+    (fun () -> ignore (Xapi_pvs_proxy.create ~__context ~site ~vIF))
 
 let test_create_invalid_vif () =
-  let __context = make_test_database () in
-  let site = make_pvs_site ~__context () in
+  let __context = T.make_test_database () in
+  let site = T.make_pvs_site ~__context () in
   let vIF = Ref.make () in
-  assert_raises_api_error
-    Api_errors.invalid_value
-    ~args:["VIF"; Ref.string_of vIF]
-    (fun () -> Xapi_pvs_proxy.create ~__context ~site ~vIF)
+  Alcotest.check_raises
+    "test_create_invalid_vif should raise invalid_value"
+    Api_errors.(Server_error
+                  (invalid_value, ["VIF"; Ref.string_of vIF]))
+    (fun () -> ignore (Xapi_pvs_proxy.create ~__context ~site ~vIF))
 
 let test_destroy () =
-  let __context = make_test_database () in
-  let site = make_pvs_site ~__context () in
-  let vIF = make_vif ~__context ~device:"0" () in
+  let __context = T.make_test_database () in
+  let site = T.make_pvs_site ~__context () in
+  let vIF = T.make_vif ~__context ~device:"0" () in
   let pvs_proxy = Xapi_pvs_proxy.create ~__context ~site ~vIF in
   Xapi_pvs_proxy.destroy ~__context ~self:pvs_proxy;
-  assert_equal (Db.is_valid_ref __context pvs_proxy) false
+  Alcotest.(check bool)
+    "test_destroy: PVS proxy ref should no longer be valid"
+    false (Db.is_valid_ref __context pvs_proxy)
 
 let test_gc_proxy () =
-  let __context = make_test_database () in
-  let site = make_pvs_site ~__context () in
-  let vIF = make_vif ~__context ~device:"0" () in
+  let __context = T.make_test_database () in
+  let site = T.make_pvs_site ~__context () in
+  let vIF = T.make_vif ~__context ~device:"0" () in
   let proxy = Xapi_pvs_proxy.create ~__context ~site ~vIF in
+  (* compare API refs *)
+  let compare_refs msg x y =
+    Alcotest.(check (Alcotest_comparators.ref ()))
+      msg
+      x y
+  in
   ( Db_gc_util.gc_PVS_proxies ~__context
-  ; assert_equal (Db.PVS_proxy.get_site ~__context ~self:proxy) site
-  ; assert_equal (Db.PVS_proxy.get_VIF ~__context ~self:proxy) vIF
+  ; compare_refs
+      "test_gc_proxy: get_site"
+      site (Db.PVS_proxy.get_site ~__context ~self:proxy)
+  ; compare_refs
+      "test_gc_proxy: get_VIF"
+      vIF (Db.PVS_proxy.get_VIF ~__context ~self:proxy)
   ; Db.PVS_proxy.set_site ~__context ~self:proxy ~value:Ref.null
   ; Db_gc_util.gc_PVS_proxies ~__context (* should collect the proxy *)
-  ; assert_equal false (Db.is_valid_ref __context proxy));
+  ; Alcotest.(check bool)
+      "test_gc_proxy: proxy ref should be invalid"
+      false (Db.is_valid_ref __context proxy));
   let proxy = Xapi_pvs_proxy.create ~__context ~site ~vIF in
   ( Db_gc_util.gc_PVS_proxies ~__context
-  ; assert_equal (Db.PVS_proxy.get_site ~__context ~self:proxy) site
-  ; assert_equal (Db.PVS_proxy.get_VIF ~__context ~self:proxy) vIF
+  ; compare_refs
+    "test_gc_proxy: get_site (newly created proxy)"
+      site (Db.PVS_proxy.get_site ~__context ~self:proxy)
+  ; compare_refs
+      "test_gc_proxy: get_VIF (newly created proxy)"
+      vIF (Db.PVS_proxy.get_VIF ~__context ~self:proxy)
   ; Db.PVS_proxy.set_VIF ~__context ~self:proxy ~value:Ref.null
   ; Db_gc_util.gc_PVS_proxies ~__context (* should collect the proxy *)
-  ; assert_equal false (Db.is_valid_ref __context proxy))
+  ; Alcotest.(check bool)
+      "test_gc_proxy: proxy ref has been set to null"
+      false (Db.is_valid_ref __context proxy))
 
 let test =
-  "test_pvs_proxy" >:::
-  [
-    "test_unlicensed" >:: test_unlicensed;
-    "test_create_ok" >:: test_create_ok;
-    "test_create_invalid_device" >:: test_create_invalid_device;
-    "test_create_invalid_site" >:: test_create_invalid_site;
-    "test_create_invalid_vif" >:: test_create_invalid_vif;
-    "test_destroy" >:: test_destroy;
-    "test_gc_proxy" >:: test_gc_proxy
+  [ "test_unlicensed", `Quick, test_unlicensed
+  ; "test_create_ok", `Quick, test_create_ok
+  ; "test_create_invalid_device", `Quick, test_create_invalid_device
+  ; "test_create_invalid_site", `Quick, test_create_invalid_site
+  ; "test_create_invalid_vif", `Quick, test_create_invalid_vif
+  ; "test_destroy", `Quick, test_destroy
+  ; "test_gc_proxy", `Quick, test_gc_proxy
   ]

--- a/ocaml/tests/test_pvs_site.ml
+++ b/ocaml/tests/test_pvs_site.ml
@@ -12,8 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
+module T = Test_common
 
 let name_label = "my_pvs_site"
 let name_description = "about my_pvs_site"
@@ -22,70 +21,79 @@ let pVS_uuid = "my_pvs_uuid"
 let cleanup_storage _ _ = ()
 
 let test_unlicensed () =
-  let __context = make_test_database ~features:[] () in
-  assert_raises
+  let __context = T.make_test_database ~features:[] () in
+  Alcotest.check_raises
+    "test_unlicensed: should raise license_restriction"
     Api_errors.(Server_error (license_restriction, ["PVS_proxy"]))
-    (fun () -> Xapi_pvs_site.introduce ~__context ~name_label ~name_description ~pVS_uuid)
+    (fun () -> ignore (Xapi_pvs_site.introduce ~__context ~name_label ~name_description ~pVS_uuid))
 
 let test_introduce () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let pvs_site = Xapi_pvs_site.introduce ~__context ~name_label ~name_description ~pVS_uuid in
-  assert_equal name_label (Db.PVS_site.get_name_label ~__context ~self:pvs_site);
-  assert_equal [] (Db.PVS_site.get_cache_storage ~__context ~self:pvs_site)
+  Alcotest.(check string)
+    "test_introduce: checking name_label"
+    name_label (Db.PVS_site.get_name_label ~__context ~self:pvs_site);
+  Alcotest.(check (list (Alcotest_comparators.ref ())))
+    "test_introduce: cache storage should be empty"
+    [] (Db.PVS_site.get_cache_storage ~__context ~self:pvs_site)
 
 let test_forget_ok () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let pvs_site = Xapi_pvs_site.introduce ~__context ~name_label ~name_description ~pVS_uuid in
   Xapi_pvs_site.forget_internal ~__context ~self:pvs_site ~cleanup_storage;
-  assert_equal (Db.is_valid_ref __context pvs_site) false
+  Alcotest.(check bool)
+    "test_forget_ok: PVS site ref should no longer be recognised"
+    false (Db.is_valid_ref __context pvs_site)
 
 let test_forget_stopped_proxy () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let pvs_site = Xapi_pvs_site.introduce ~__context ~name_label ~name_description ~pVS_uuid in
   let (_: API.ref_PVS_proxy) =
-    make_pvs_proxy ~__context ~site:pvs_site ~currently_attached:false () in
+    T.make_pvs_proxy ~__context ~site:pvs_site ~currently_attached:false () in
   Xapi_pvs_site.forget_internal ~__context ~self:pvs_site ~cleanup_storage;
-  assert_equal (Db.is_valid_ref __context pvs_site) false
+  Alcotest.(check bool)
+    "test_forget_stopped_proxy: PVS site ref should no longer be recognised"
+    false (Db.is_valid_ref __context pvs_site)
 
 let test_forget_running_proxy () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let pvs_site = Xapi_pvs_site.introduce ~__context ~name_label ~name_description ~pVS_uuid in
   let pvs_proxy =
-    make_pvs_proxy ~__context ~site:pvs_site ~currently_attached:true () in
-  assert_raises_api_error
-    Api_errors.pvs_site_contains_running_proxies
-    ~args:[Ref.string_of pvs_proxy]
+    T.make_pvs_proxy ~__context ~site:pvs_site ~currently_attached:true () in
+  Alcotest.check_raises
+    "test_forget_running_proxy should raise Api_errors.pvs_site_contains_running_proxies"
+    Api_errors.(Server_error
+                  (pvs_site_contains_running_proxies, [Ref.string_of pvs_proxy]))
     (fun () -> Xapi_pvs_site.forget_internal ~__context ~self:pvs_site ~cleanup_storage)
 
 let test_forget_server () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let pvs_site = Xapi_pvs_site.introduce ~__context ~name_label ~name_description ~pVS_uuid in
-  let pvs_server = make_pvs_server ~__context ~site:pvs_site () in
-  assert_raises_api_error
-    Api_errors.pvs_site_contains_servers
-    ~args:[Ref.string_of pvs_server]
+  let pvs_server = T.make_pvs_server ~__context ~site:pvs_site () in
+  Alcotest.check_raises
+    "test_forget_server should raise Api_errors.pvs_site_contains_servers"
+    Api_errors.(Server_error
+                  (pvs_site_contains_servers, [Ref.string_of pvs_server]))
     (fun () -> Xapi_pvs_site.forget_internal ~__context ~self:pvs_site ~cleanup_storage)
 
 let test_forget_running_proxy_and_server () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let pvs_site = Xapi_pvs_site.introduce ~__context ~name_label ~name_description ~pVS_uuid in
   let pvs_proxy =
-    make_pvs_proxy ~__context ~site:pvs_site ~currently_attached:true () in
-  let (_: API.ref_PVS_server) = make_pvs_server ~__context ~site:pvs_site () in
-  assert_raises_api_error
-    Api_errors.pvs_site_contains_running_proxies
-    ~args:[Ref.string_of pvs_proxy]
+    T.make_pvs_proxy ~__context ~site:pvs_site ~currently_attached:true () in
+  let (_: API.ref_PVS_server) = T.make_pvs_server ~__context ~site:pvs_site () in
+  Alcotest.check_raises
+    "test_forget_running_proxy_and_server: should raise pvs_site_contains_running_proxies"
+    Api_errors.(Server_error
+                  (pvs_site_contains_running_proxies, [Ref.string_of pvs_proxy]))
     (fun () -> Xapi_pvs_site.forget_internal ~__context ~self:pvs_site ~cleanup_storage)
 
 let test =
-  "test_pvs_site" >:::
-  [
-    "test_unlicensed" >:: test_unlicensed;
-    "test_introduce" >:: test_introduce;
-    "test_forget_ok" >:: test_forget_ok;
-    "test_forget_stopped_proxy" >:: test_forget_stopped_proxy;
-    "test_forget_running_proxy" >:: test_forget_running_proxy;
-    "test_forget_server" >:: test_forget_server;
-    "test_forget_running_proxy_and_server" >::
-    test_forget_running_proxy_and_server;
+  [ "test_unlicensed", `Quick, test_unlicensed
+  ; "test_introduce", `Quick, test_introduce
+  ; "test_forget_ok", `Quick, test_forget_ok
+  ; "test_forget_stopped_proxy", `Quick, test_forget_stopped_proxy
+  ; "test_forget_running_proxy", `Quick, test_forget_running_proxy
+  ; "test_forget_server", `Quick, test_forget_server
+  ; "test_forget_running_proxy_and_server", `Quick, test_forget_running_proxy_and_server
   ]

--- a/ocaml/tests/test_vlan.ml
+++ b/ocaml/tests/test_vlan.ml
@@ -166,7 +166,7 @@ let test =
   [
     "test_pool_introduce", `Quick, test_pool_introduce;
     "test_create_internal", `Quick, test_create_internal;
-    "test_create_unmanged_pif", `Quick, test_create_unmanaged_pif;
+    "test_create_unmanaged_pif", `Quick, test_create_unmanaged_pif;
     "test_create_network_already_connected", `Quick, test_create_network_already_connected;
     "test_create_pif_not_a_bond_slave", `Quick, test_create_pif_not_a_bond_slave;
     "test_create_pif_not_vlan_slave", `Quick, test_create_pif_not_vlan_slave;

--- a/ocaml/tests/test_vm_migrate.ml
+++ b/ocaml/tests/test_vm_migrate.ml
@@ -12,57 +12,60 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
-
 let mac1 = "00:00:00:00:00:01"
 let mac2 = "00:00:00:00:00:02"
 
+let check_network_map =
+  Alcotest.(check (slist
+                    (pair
+                      (Alcotest_comparators.ref ())
+                      (Alcotest_comparators.ref ()))
+                    compare))
+
 let test_infer_vif_map_empty () =
-  let __context = make_test_database () in
-  assert_equal
-    (Xapi_vm_migrate.infer_vif_map ~__context [] [])
+  let __context = Test_common.make_test_database () in
+  check_network_map "Asserted by test_infer_vif_map_empty"
     []
+    (Xapi_vm_migrate.infer_vif_map ~__context [] [])
 
 let test_infer_vif_map () =
-  let __context = make_test_database () in
-  let vm_vif1 = make_vif ~__context ~mAC:mac1 () in
-  let vm_vif2 = make_vif ~__context ~mAC:mac2 () in
-  let snap_vif1 = make_vif ~__context ~mAC:mac1 () in
-  let snap_vif2 = make_vif ~__context ~mAC:mac2 () in
+  let __context = Test_common.make_test_database () in
+  let vm_vif1 = Test_common.make_vif ~__context ~mAC:mac1 () in
+  let vm_vif2 = Test_common.make_vif ~__context ~mAC:mac2 () in
+  let snap_vif1 = Test_common.make_vif ~__context ~mAC:mac1 () in
+  let snap_vif2 = Test_common.make_vif ~__context ~mAC:mac2 () in
   (* In reality this network won't be in the local database, but for our
      	 * purposes it is a meaningless UUID so it's OK for it to be in the local
      	 * database. *)
-  let network1 = make_network ~__context () in
-  (* Check that a map with a single VIF -> network pair is unchanged. *)
-  assert_equal
+  let network1 = Test_common.make_network ~__context () in
+  check_network_map
+    "test_infer_vif_map: check that a map with a single VIF -> network pair is unchanged"
     (Xapi_vm_migrate.infer_vif_map ~__context [vm_vif1] [vm_vif1, network1])
     [vm_vif1, network1];
-  (* Check that a missing VIF is caught. *)
-  assert_raises
+  Alcotest.check_raises
+    "test_infer_vif_map: check that a missing VIF is caught"
     Api_errors.(Server_error (vif_not_in_map, [Ref.string_of vm_vif2]))
-    (fun () ->
-       Xapi_vm_migrate.infer_vif_map ~__context
+    (fun () -> ignore
+       (Xapi_vm_migrate.infer_vif_map ~__context
          [vm_vif1; vm_vif2]
-         [vm_vif1, network1]);
-  (* Check that a snapshot VIF is mapped implicitly. *)
+         [vm_vif1, network1]));
   let inferred_map =
     Xapi_vm_migrate.infer_vif_map ~__context
       [vm_vif1; snap_vif1]
       [vm_vif1, network1]
   in
-  assert_equal (List.assoc snap_vif1 inferred_map) network1;
-  (* Check that an orphaned, unmapped snapshot VIF is caught. *)
-  assert_raises
+  Alcotest.(check (Alcotest_comparators.ref ()))
+    "test_infer_vif_map: check that a snapshot VIF is mapped implicitly"
+    (List.assoc snap_vif1 inferred_map) network1;
+  Alcotest.check_raises
+    "Check that an orphaned, unmapped snapshot VIF is caught."
     Api_errors.(Server_error (vif_not_in_map, [Ref.string_of snap_vif2]))
-    (fun () ->
-       Xapi_vm_migrate.infer_vif_map ~__context
+    (fun () -> ignore
+       (Xapi_vm_migrate.infer_vif_map ~__context
          [vm_vif1; snap_vif1; snap_vif2]
-         [vm_vif1, network1])
+         [vm_vif1, network1]))
 
 let test =
-  "test_vm_migrate" >:::
-  [
-    "test_infer_vif_map_empty" >:: test_infer_vif_map_empty;
-    "test_infer_vif_map" >:: test_infer_vif_map;
+  [ "test_infer_vif_map_empty", `Quick, test_infer_vif_map_empty
+  ; "test_infer_vif_map", `Quick, test_infer_vif_map
   ]


### PR DESCRIPTION
Spent a lot of time on trains lately, so ported the following unit tests from OUnit to the Alcotest framework:

- test_vm_migrate
- test_ca91480
- test_no_migrate
- test_gpu_group
- test_pool_update
- test_pusb
- test_pool_apply_edition
- test_pvs_site
- test_pvs_proxy