### PR TITLE
CA-285349: replace -only-sr quicktest flag with -default-sr

### DIFF
--- a/ocaml/quicktest/quicktest.ml
+++ b/ocaml/quicktest/quicktest.ml
@@ -828,7 +828,6 @@ let vm_powercycle_test s vm =
   success test
 
 
-
 let _ =
   let all_tests = [
     "storage";
@@ -857,7 +856,7 @@ let _ =
     "-iso-sr-path", Arg.String (fun x -> Quicktest_storage.iso_path := x), "Path to ISO SR";
     "-single", Arg.String (fun x -> tests_to_run := [ x ]), Printf.sprintf "Only run one test (possibilities are %s)" (String.concat ", " all_tests) ;
     "-all", Arg.Unit (fun () -> tests_to_run := all_tests), Printf.sprintf "Run all tests (%s)" (String.concat ", " all_tests);
-    "-only-sr", Arg.String (fun x -> Quicktest_storage.only_sr_name := Some x), "Run tests only on SR with specified name";
+    "-default-sr", Arg.Unit (fun () -> Quicktest_storage.use_default_sr := true), "Only run SR tests on the pool's default SR";
     "-nocolour", Arg.Clear Quicktest_common.use_colour, "Don't use colour in the output" ]
     (fun x -> match !host, !username, !password with
        | "", _, _ -> host := x; rpc := rpc_remote; using_unix_domain_socket := false;

--- a/ocaml/quicktest/quicktest_common.ml
+++ b/ocaml/quicktest/quicktest_common.ml
@@ -253,3 +253,6 @@ let find_guest_installer_network session_id =
 (** Return a host's domain zero *)
 let dom0_of_host session_id host =
   Client.Host.get_control_domain !rpc session_id host
+
+let get_default_sr session_id =
+  Client.Pool.get_default_SR ~session_id ~rpc:!rpc ~self:(get_pool session_id)

--- a/ocaml/quicktest/quicktest_storage.ml
+++ b/ocaml/quicktest/quicktest_storage.ml
@@ -31,22 +31,23 @@ let sr_probe     = "SR_PROBE"
 let sr_update    = "SR_UPDATE"
 
 let iso_path = ref "/opt/xensource/packages/iso"
-
-let only_sr_name = ref None
+let use_default_sr = ref false
 
 (** Return a list of all SRs which have at least one plugged-in PBD ie those
     which we can use for stuff *)
 let list_srs session_id =
-  let all = Client.SR.get_all !rpc session_id in
+  let all =
+    if !use_default_sr
+    then begin
+      print_endline "  Running tests on default SR only";
+      [ (Quicktest_common.get_default_sr session_id) ]
+    end
+    else (Client.SR.get_all !rpc session_id)
+  in
   List.filter (fun sr ->
-      let pbds = Client.SR.get_PBDs !rpc session_id sr in
-      List.fold_left (||) false
-        (List.map (fun pbd -> Client.PBD.get_currently_attached !rpc session_id pbd) pbds)) all
-  (* Filter SR with specific type from CLI *)
-  |> List.filter (fun sr ->
-         match !only_sr_name with
-         | None -> true
-         | Some t -> Client.SR.get_name_label !rpc session_id sr = t)
+    let pbds = Client.SR.get_PBDs !rpc session_id sr in
+    List.fold_left (||) false
+      (List.map (fun pbd -> Client.PBD.get_currently_attached !rpc session_id pbd) pbds)) all
 
 let name_of_sr session_id sr =
   let name_label = Client.SR.get_name_label !rpc session_id sr in
@@ -622,6 +623,5 @@ let go s =
   let srs = list_srs s in
   debug test (Printf.sprintf "Found %d SRs" (List.length srs));
   success test;
-  if !only_sr_name = None then
   packages_iso_test s;
   List.iter (foreach_sr s) srs


### PR DESCRIPTION
As a result of the recent REQ-477 PR review, it was suggested to make the following switch:

- `-only-sr [name-label]`: former flag, only ran quicktests on SRs with a matching `name-label` field
- `-default-sr`: replacement flag, only runs quicktests on the pool's default SR

This flag is passed to all relevant quicktests which iterate through SRs. Currently this only includes the CBT and storage quicktests.