### PR TITLE
Eliminate fd leak in timebox

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1141,8 +1141,9 @@ let timebox ~timeout ~otherwise f =
           with e ->
             result := fun () -> raise e);
          Unix.close fd_out) () in
-  let _ = Thread.wait_timed_read fd_in timeout in
+  let finished = Thread.wait_timed_read fd_in timeout in
   Unix.close fd_in;
+  if not finished then ignore_exn (fun () -> Unix.close fd_out);
   !result ()
 
 (**************************************************************************************)


### PR DESCRIPTION
In function `timebox`, we create a new thread to handle the real stuff, but once
the stuff hangs forever, it will result in fd of one endian of the pipe leak.
So if the stuff times out, close the fd and ignore any exception if occurs. (The
main and new thread may close the fd at the same time once the stuff finished suddenly.)

Signed-off-by: Yang Qian <yang.qian@citrix.com>