### PR TITLE
CA-285349: split `unplug_all_pbds` into two internal functions

### DIFF
--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -153,3 +153,12 @@ let disable ~__context ~self =
           Db.Cluster_host.set_enabled ~__context ~self ~value:false
       | Result.Error error -> handle_error error
     )
+
+let disable_clustering ~__context =
+  let host = Helpers.get_localhost ~__context in
+  match Xapi_clustering.find_cluster_host ~__context ~host with
+  | None -> info "No cluster host found"
+  | Some self ->
+     info "Disabling cluster host";
+     disable ~__context ~self
+

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -64,3 +64,8 @@ val disable : __context:Context.t -> self:API.ref_Cluster_host -> unit
 (** [disable ~__context ~self] is the implementation of the XenAPI call
     'Cluster_host.disable'. It will call xapi-clusterd and ask it to leave the
     cluster. This requires all cluster members to be online. *)
+
+val disable_clustering : __context:Context.t -> unit
+(** [disable_clustering ~__context] is a wrapper for Xapi_cluster_host.disable
+    which finds the local cluster_host [self], calls [disable ~__context self]
+    and logs its actions. *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -517,6 +517,7 @@ let prepare_for_poweroff ~__context ~host =
 
   Xapi_ha.before_clean_shutdown_or_reboot ~__context ~host;
   Xapi_pbd.unplug_all_pbds ~__context;
+  Xapi_pbd.disable_clustering ~__context;
 
   if not i_am_master then
     Remote_requests.stop_request_thread();

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -517,7 +517,7 @@ let prepare_for_poweroff ~__context ~host =
 
   Xapi_ha.before_clean_shutdown_or_reboot ~__context ~host;
   Xapi_pbd.unplug_all_pbds ~__context;
-  Xapi_pbd.disable_clustering ~__context;
+  Xapi_cluster_host.disable_clustering ~__context;
 
   if not i_am_master then
     Remote_requests.stop_request_thread();

--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -236,8 +236,8 @@ let get_locally_attached ~__context =
             Eq (Field "host", Literal (Ref.string_of host)),
             Eq (Field "currently_attached", Literal "true"))))
 
-(* Called on shutdown: it unplugs all the PBDs and disables the cluster host.
-   If anything fails it throws an exception *)
+(* unplug_all_pbds and disable_clustering are called on shutdown
+ * Both throw exceptions if anything fails *)
 let unplug_all_pbds ~__context =
   info "Unplugging all SRs plugged on local host";
   (* best effort unplug of all PBDs *)
@@ -247,10 +247,13 @@ let unplug_all_pbds ~__context =
          TaskHelper.exn_if_cancelling ~__context;
          debug "Unplugging PBD %s" uuid;
          unplug ~__context ~self:pbd);
-  debug "Finished unplug_all_pbds";
+  debug "Finished unplug_all_pbds"
+
+let disable_clustering ~__context =
   let host = Helpers.get_localhost ~__context in
   match Xapi_clustering.find_cluster_host ~__context ~host with
   | None -> info "No cluster host found"
   | Some self ->
      info "Disabling cluster host";
      Xapi_cluster_host.disable ~__context ~self
+

--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -236,8 +236,9 @@ let get_locally_attached ~__context =
             Eq (Field "host", Literal (Ref.string_of host)),
             Eq (Field "currently_attached", Literal "true"))))
 
-(* unplug_all_pbds and disable_clustering are called on shutdown
- * Both throw exceptions if anything fails *)
+(* Host calls unplug_all_pbds on shutdown,
+ * followed by Xapi_cluster_host.disable_clustering.
+ * Both functions throw exceptions if anything fails *)
 let unplug_all_pbds ~__context =
   info "Unplugging all SRs plugged on local host";
   (* best effort unplug of all PBDs *)
@@ -248,12 +249,4 @@ let unplug_all_pbds ~__context =
          debug "Unplugging PBD %s" uuid;
          unplug ~__context ~self:pbd);
   debug "Finished unplug_all_pbds"
-
-let disable_clustering ~__context =
-  let host = Helpers.get_localhost ~__context in
-  match Xapi_clustering.find_cluster_host ~__context ~host with
-  | None -> info "No cluster host found"
-  | Some self ->
-     info "Disabling cluster host";
-     Xapi_cluster_host.disable ~__context ~self
 


### PR DESCRIPTION
As per the GFS2 PR review, this change splits `Xapi_pbd.unplug_all_pbds` into two separate internal functions; one to unplug all PBDs and one to disable clustering, allowing for better decoupling of these functions. The external `Xapi_pbds.unplug_all_pbds` interface and logic is unchanged.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>