### PR TITLE
CA-285897: Filter out un-attached VF-backed vifs in PCI metadata

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -326,11 +326,13 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough vgpu =
   | _ -> raise Api_errors.(Server_error (internal_error, ["invalid boot configuration"]))
 
 let list_net_sriov_vf_pcis ~__context ~vm =
-  List.filter_map (fun vif ->
-    match backend_of_vif ~__context ~vif with
-    | Network.Sriov {domain; bus; dev; fn} -> Some (domain, bus, dev, fn)
-    | _ -> None
-  ) vm.API.vM_VIFs
+  vm.API.vM_VIFs
+  |> List.filter (fun self -> Db.VIF.get_currently_attached ~__context ~self)
+  |> List.filter_map (fun vif ->
+         match backend_of_vif ~__context ~vif with
+         | Network.Sriov {domain; bus; dev; fn} -> Some (domain, bus, dev, fn)
+         | _ -> None
+     )
 
 module MD = struct
   (** Convert between xapi DB records and xenopsd records *)


### PR DESCRIPTION
The background logic is that XAPI will try to construct all information
on a VM as metadata and push this metadata to Xenopsd to manage the VM.
Particularly the logic on vifs are: for the `start` of VM, XAPI will try
to push all vifs, no matter attached or not, to Xenopsd; while for the
`reboot` of VM, it will try to push the vifs which are currently
attached only.

SR-IOV VF backed vifs should follow same logic. This means XAPI should
not push the VFs' PCIs which are backend of un-attached vifs also.

This fix adds a filter on contructing PCI metata to filter out the vifs
which are backed by VF PCIs and currently un-attached.

Signed-off-by: Ming Lu <ming.lu@citrix.com>