### PR TITLE
CA-284492: Ignore vGPU live-migratability in migrate_send for halted VMs

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -243,7 +243,7 @@ let check_pci ~op ~ref_str =
   | `suspend | `checkpoint | `pool_migrate | `migrate_send -> Some (Api_errors.vm_has_pci_attached, [ref_str])
   | _ -> None
 
-let check_vgpu ~__context ~op ~ref_str ~vgpus =
+let check_vgpu ~__context ~op ~ref_str ~vgpus ~power_state =
   let vgpu_migration_enabled () =
     let pool = Helpers.get_pool ~__context in
     let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
@@ -279,6 +279,8 @@ let check_vgpu ~__context ~op ~ref_str ~vgpus =
     | _ -> false
   in
   match op with
+  | `migrate_send
+    when power_state = `Halted -> None
   | `pool_migrate | `migrate_send
     when vgpu_migration_enabled ()
       && List.for_all is_migratable  vgpus
@@ -507,7 +509,7 @@ let check_operation_error ~__context ~ref =
   (* The VM has a VGPU, check if the operation is allowed*)
   let current_error = check current_error (fun () ->
       if vmr.Db_actions.vM_VGPUs <> []
-      then check_vgpu ~__context ~op ~ref_str ~vgpus:vmr.Db_actions.vM_VGPUs
+      then check_vgpu ~__context ~op ~ref_str ~vgpus:vmr.Db_actions.vM_VGPUs ~power_state
       else None) in
 
   (* The VM has a VUSB, check if the operation is allowed*)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1278,8 +1278,10 @@ let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu
     | `intra_pool -> None
     | `cross_pool -> Some (remote.rpc, remote.session)
   in
-  Xapi_pgpu_helpers.assert_destination_has_pgpu_compatible_with_vm ~__context
-    ~vm ~vgpu_map ~host:remote.dest_host ?remote:remote_for_migration_type ()
+  (* We only need to check compatibility for "live" vGPUs *)
+  if Db.VM.get_power_state ~__context ~self:vm <> `Halted then
+    Xapi_pgpu_helpers.assert_destination_has_pgpu_compatible_with_vm ~__context
+      ~vm ~vgpu_map ~host:remote.dest_host ?remote:remote_for_migration_type ()
 
 let migrate_send  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map =
   with_migrate (fun () ->


### PR DESCRIPTION
If a VM is not running, then we don't have to worry about being able to
live-migrate its vGPUs, so don't bother checking if the vGPU supports it.

Note that the `migrate_send` operation in use for VM.migrate_send, but also for
VDI.pool_migrate.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>