### PR TITLE
[REQ477] CA-286294: Refactor pool_resync, add best-effort host_resync

### DIFF
--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -194,17 +194,14 @@ let pool_destroy ~__context ~self =
   Helpers.call_api_functions ~__context (fun rpc session_id ->
       Client.Client.Cluster.destroy ~rpc ~session_id ~self)
 
-let pool_resync ~__context ~self =
-  (* First ensure that the Cluster_hosts that are enabled in xapi's DB are really enabled *)
-  Db.Cluster_host.get_all ~__context |> List.iter (fun cluster_host ->
-      if Db.Cluster_host.get_enabled ~__context ~self:cluster_host then
-        Helpers.call_api_functions ~__context (fun rpc session_id ->
-            (* We rely on the fact that Cluster_host.enable unconditionally
-               invokes the low-level enable operations and is idempotent. *)
-            Client.Client.Cluster_host.enable ~rpc ~session_id ~self:cluster_host)
-    );
-  (* Then create the missing Cluster_hosts *)
-  let pool_auto_join = Db.Cluster.get_pool_auto_join ~__context ~self in
-  if pool_auto_join then begin
-      Db.Host.get_all ~__context |> List.iter (fun host -> Xapi_cluster_host.create_as_necessary ~__context ~host)
-  end
+let pool_resync ~__context ~(self : API.ref_Cluster) =
+  List.iter
+    (fun host -> log_and_ignore_exn
+        (fun () ->
+           Xapi_cluster_host.resync_host ~__context ~host;
+           if is_clustering_disabled_on_host ~__context host
+           then raise Api_errors.(Server_error (no_compatible_cluster_host, [Ref.string_of host]))
+            (* If host.clustering_enabled then resync_host should successfully
+               find or create a matching cluster_host which is also enabled *)
+        )
+    ) (Xapi_pool_helpers.get_master_slaves_list ~__context)

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -69,3 +69,9 @@ val disable_clustering : __context:Context.t -> unit
 (** [disable_clustering ~__context] is a wrapper for Xapi_cluster_host.disable
     which finds the local cluster_host [self], calls [disable ~__context self]
     and logs its actions. *)
+
+val resync_host : __context:Context.t -> host:API.ref_host -> unit
+(** [resync_host ~__context ~host] checks for any clusters on the host. If one
+    exists but is not associated with a cluster_host, it creates one. If the
+    database indicates the cluster_host is enabled, host_resync enables it
+    in the Client layer too. Otherwise, nothing happens. *)

--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -113,21 +113,16 @@ let check_sharing_constraint ~__context ~sr =
   end
 
 (** If the SR requires some cluster stacks, we resync every compatible Cluster *)
-let resync_cluster_stack_for_sr_type ~__context ~sr_sm_type =
+let resync_cluster_stack_for_sr_type ~__context ~sr_sm_type ~host =
   let required_cluster_stacks = Xapi_clustering.get_required_cluster_stacks ~__context ~sr_sm_type in
   (* This is empty if the SR requires no cluster stack *)
-  let required_clusters =
-    Db.Cluster.get_all_records ~__context
-    |> List.filter (function (cluster_ref, cluster_rec) -> List.mem cluster_rec.API.cluster_cluster_stack required_cluster_stacks)
-  in
-  (* XXX For now, we only support one cluster, when we add support for
-     multiple clusters, we may want to change this behaviour. *)
-  required_clusters
-  |> List.iter
-    (fun (cluster_ref, cluster_rec) ->
-       Helpers.call_api_functions ~__context (fun rpc session_id ->
-           Client.Client.Cluster.pool_resync ~rpc ~session_id ~self:cluster_ref)
-    )
+  match (Xapi_clustering.find_cluster_host ~__context ~host) with
+  | None -> ()
+  | Some cluster_host ->
+  (* check cluster_host associated with both the host and a cluster with a matching cluster_stack *)
+    let self  = Db.Cluster_host.get_cluster ~__context ~self:cluster_host in
+    if List.mem (Db.Cluster.get_cluster_stack ~__context ~self) required_cluster_stacks
+    then Xapi_cluster_host.resync_host ~__context ~host
 
 module C = Storage_interface.Client(struct let rpc = Storage_access.rpc end)
 
@@ -140,12 +135,12 @@ let plug ~__context ~self =
   if not currently_attached then
     let sr = Db.PBD.get_SR ~__context ~self in
     let sr_sm_type = Db.SR.get_type ~__context ~self:sr in
+    let host = Db.PBD.get_host ~__context ~self in
     (* This must NOT be done while holding the lock, because the functions that
        eventually get called also grab the clustering lock. We can call this
        unconditionally because the operations it calls should be idempotent. *)
-    log_and_ignore_exn (fun () -> resync_cluster_stack_for_sr_type ~__context ~sr_sm_type);
+    log_and_ignore_exn (fun () -> resync_cluster_stack_for_sr_type ~__context ~sr_sm_type ~host);
     Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type (fun () ->
-        let host = Db.PBD.get_host ~__context ~self in
         Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type;
         check_sharing_constraint ~__context ~sr;
         let dbg = Ref.string_of (Context.get_task_id __context) in


### PR DESCRIPTION
The current `Xapi_cluster.pool_resync` function duplicates existing logic from `Xapi_clustering.create_as_necessary`, so the following changes were made:

- use `create_as_necessary` instead of duplicating code
- move this and host-enabling logic to `Xapi_cluster_host.host_resync` function (also add to interface)
- iterate over `host_resync` in `pool_resync`
- add logging

(This has passed all unit tests and the GFS2 BVT)