### PR TITLE
CA-281178: Update allowed operations in consider_enabling_host

### DIFF
--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -224,6 +224,7 @@ let consider_enabling_host_nolock ~__context =
     if !Xapi_globs.on_system_boot then begin
       debug "Host.enabled: system has just restarted: setting localhost to enabled";
       Db.Host.set_enabled ~__context ~self:localhost ~value:true;
+      update_allowed_operations ~__context ~self:localhost;
       Localdb.put Constants.host_disabled_until_reboot "false";
       (* Start processing pending VM powercycle events *)
       Local_work_queue.start_vm_lifecycle_queue ();
@@ -233,6 +234,7 @@ let consider_enabling_host_nolock ~__context =
       end else begin
         debug "Host.enabled: system not just rebooted && host_disabled_until_reboot not set: setting localhost to enabled";
         Db.Host.set_enabled ~__context ~self:localhost ~value:true;
+        update_allowed_operations ~__context ~self:localhost;
         (* Start processing pending VM powercycle events *)
         Local_work_queue.start_vm_lifecycle_queue ();
       end


### PR DESCRIPTION
In a pool, restarting the toolstack on a slave will go through two
stages: first shutting down, and next booting up again.  In the
shutting-down stage, Host.enabled will be set as false. Then in the
booting-up stage, XAPI will set it back to true in the 'initialising
storage' step.

The bug to be fixed in this ticket is that the allowed_operations of
the slave host is not updated correspondingly when setting 
Host.enabled back to true while booting up.

Signed-off-by: Ming Lu <ming.lu@citrix.com>