### PR TITLE
CA-260638 Bonds are created on interfaces which participates in FCoE

### DIFF
--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -340,6 +340,8 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
           let pool = Helpers.get_pool ~__context in
           if Db.Pool.get_ha_enabled ~__context ~self:pool && Db.PIF.get_management ~__context ~self
           then raise (Api_errors.Server_error(Api_errors.ha_cannot_change_bond_status_of_mgmt_iface, []));
+          if Db.PIF.get_capabilities ~__context ~self |> List.mem "fcoe" then
+            Xapi_pif.assert_fcoe_not_in_use ~__context ~self
         ) members;
       let hosts = List.map (fun self -> Db.PIF.get_host ~__context ~self) members in
       if List.length (List.setify hosts) <> 1

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -294,3 +294,6 @@ val assert_no_other_local_pifs :
   __context:Context.t ->
   host:[ `host ] Ref.t -> network:[ `network ] Ref.t -> unit
 
+(** Ensure PIF has no FCOE SR in use *)
+val assert_fcoe_not_in_use:
+  __context:Context.t -> self:[`PIF] Ref.t -> unit


### PR DESCRIPTION
When creating bond, ensure slave PIF are not participating FCOE.

Signed-off-by: Yang Qian <yang.qian@citrix.com>