### PR TITLE
CA-285596: Suppress host.set_iscsi_iqn during RPU

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -437,13 +437,16 @@ type boot_method =
 
 (** Returns the current value of the pool configuration flag *)
 (** that indicates whether a rolling upgrade is in progress. *)
+let rolling_upgrade_in_progress_of_oc oc =
+  List.mem_assoc Xapi_globs.rolling_upgrade_in_progress oc
+
 (* Note: the reason it's OK to trap exceptions and return false is that -- an exn will only happen if the pool record
    is not present in the database; that only happens on firstboot (when you're a master with no db and you're creating
    the db for the first time). In that context you cannot be in rolling upgrade mode *)
 let rolling_upgrade_in_progress ~__context =
   try
     let pool = get_pool ~__context in
-    List.mem_assoc Xapi_globs.rolling_upgrade_in_progress (Db.Pool.get_other_config ~__context ~self:pool)
+    rolling_upgrade_in_progress_of_oc (Db.Pool.get_other_config ~__context ~self:pool)
   with _ ->
     false
 

--- a/ocaml/xapi/xapi_host_helpers.mli
+++ b/ocaml/xapi/xapi_host_helpers.mli
@@ -121,17 +121,20 @@ module Configuration : sig
       fields in xapi's database. It should be called at startup on every host
       BEFORE the other_config watcher [start_watcher_thread] is started *)
 
-  val watch_other_configs : __context:Context.t -> float -> string -> string
+  val watch_other_configs : __context:Context.t -> float -> (string * bool) -> (string * bool)
   (** [watch_other_configs ~__context timeout] returns a function that performs
       one iteration of watching Host.other_config. If an update occurs this
       will check whether the iscsi_iqn field in other-config is correctly
       reflected in the field Host.iscsi_iqn, and if not it will call
       Host.set_iscsi_iqn with the value specified in other-config. This is
-      intended to be run on the master. The returned function has type
-      [token -> token], where [token] is a string. The initial value should be
-      the empty string, and the returned value should be used for further
-      invocations. This function is exposed only for unit testing, and should
-      not be invoked directly.*)
+      intended to be run on the master. The calls will not be made if the pool
+      is in rolling upgrade mode, so when the pool exits rolling upgrade mode
+      all hosts are checked. The returned function has type [token -> token],
+      where [token] is a (string * bool). The initial value should be a tuple
+      of the empty string and a boolean whose value is true if the pool is
+      currently in rolling pool upgrade mode, and the returned value should be
+      used for further invocations. This function is exposed only for unit
+      testing, and should not be invoked directly.*)
 
   val start_watcher_thread : __context:Context.t -> unit
   (** [start_watcher_thread ~__context] will start a thread that watches the


### PR DESCRIPTION
When the pool is in RPU mode we no longer try to call `host.set_iscsi_iqn`
or `host.set_multipathing` if the database is inconsistent. When the pool
exits RPU mode we then run through the consistency check for all hosts and
do any calls that are necessary.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>