### PR TITLE
[REQ477] CP-27544: Add/modify cluster logging

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4291,7 +4291,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         )
 
     let destroy ~__context ~self =
-      info "Cluster.destroy";
+      info "Cluster.destroy cluster: %s" (Ref.string_of self);
       Xapi_cluster_helpers.with_cluster_operation ~__context ~self ~doc:"Cluster.destroy" ~op:`destroy
         (fun () ->
            Local.Cluster.destroy ~__context ~self)
@@ -4301,21 +4301,21 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       Local.Cluster.pool_create ~__context ~network ~cluster_stack ~token_timeout ~token_timeout_coefficient
 
     let pool_force_destroy ~__context ~self =
-      info "Cluster.pool_force_destroy";
+      info "Cluster.pool_force_destroy cluster: %s" (Ref.string_of self);
       Local.Cluster.pool_force_destroy ~__context ~self
 
     let pool_destroy ~__context ~self =
-      info "Cluster.pool_destroy";
+      info "Cluster.pool_destroy cluster %s" (Ref.string_of self);
       Local.Cluster.pool_destroy ~__context ~self
 
     let pool_resync ~__context ~self =
-      info "Cluster.pool_resync";
+      info "Cluster.pool_resync cluster: %s" (Ref.string_of self);
       Local.Cluster.pool_resync ~__context ~self
   end
 
   module Cluster_host = struct
     let create ~__context ~cluster ~host =
-      info "Cluster_host.create";
+      info "Cluster_host.create with cluster:%s, host:%s" (Ref.string_of cluster) (Ref.string_of host);
       let local_fn = Local.Cluster_host.create ~cluster ~host in
       Xapi_cluster_helpers.with_cluster_operation ~__context ~self:cluster ~doc:"Cluster.add" ~op:`add
         (fun () ->
@@ -4326,21 +4326,21 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         )
 
     let destroy ~__context ~self =
-      info "Cluster_host.destroy";
+      info "Cluster_host.destroy cluster_host: %s" (Ref.string_of self);
       let local_fn = Local.Cluster_host.destroy ~self in
       let host = Db.Cluster_host.get_host ~__context ~self in
       do_op_on ~__context ~local_fn ~host
         (fun session_id rpc -> Client.Cluster_host.destroy rpc session_id self)
 
     let force_destroy ~__context ~self =
-      info "Cluster_host.force_destroy";
+      info "Cluster_host.force_destroy cluster_host: %s" (Ref.string_of self);
       let local_fn = Local.Cluster_host.force_destroy ~self in
       let host = Db.Cluster_host.get_host ~__context ~self in
       do_op_on ~__context ~local_fn ~host
         (fun session_id rpc -> Client.Cluster_host.force_destroy rpc session_id self)
 
     let enable ~__context ~self =
-      info "Cluster_host.enable";
+      info "Cluster_host.enable cluster_host %s" (Ref.string_of self);
       let cluster = Db.Cluster_host.get_cluster ~__context ~self in
       let local_fn = Local.Cluster_host.enable ~self in
       let host = Db.Cluster_host.get_host ~__context ~self in
@@ -4352,7 +4352,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
                   (fun session_id rpc -> Client.Cluster_host.enable rpc session_id self)))
 
     let disable ~__context ~self =
-      info "Cluster_host.disable";
+      info "Cluster_host.disable cluster_host: %s" (Ref.string_of self);
       let cluster = Db.Cluster_host.get_cluster ~__context ~self in
       let local_fn = Local.Cluster_host.disable ~self in
       let host = Db.Cluster_host.get_host ~__context ~self in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -64,7 +64,7 @@ let call_slave_with_session remote_rpc_fn __context host (task_opt: API.ref_task
   let hostname = Db.Host.get_address ~__context ~self:host in
   let session_id = Xapi_session.login_no_password ~__context ~uname:None ~host ~pool:true ~is_local_superuser:true ~subject:(Ref.null) ~auth_user_sid:"" ~auth_user_name:"" ~rbac_permissions:[] in
   Pervasiveext.finally
-    (fun ()->f session_id (remote_rpc_fn __context hostname task_opt))
+    (fun () -> f session_id (remote_rpc_fn __context hostname task_opt))
     (fun () -> Xapi_session.destroy_db_session ~__context ~self:session_id)
 
 let call_slave_with_local_session remote_rpc_fn __context host (task_opt: API.ref_task option) f =

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -49,7 +49,7 @@ let sync_required ~__context ~host =
         if cluster_rec.API.cluster_pool_auto_join
         then Some cluster_ref
         else None
-      | _ -> raise Api_errors.(Server_error (cluster_does_not_have_one_node, [ Ref.string_of host ]))
+      | _ -> raise Api_errors.(Server_error (internal_error, [ "Host cannot be associated with more than one cluster_host"; Ref.string_of host ]))
     end
   | _ -> raise Api_errors.(Server_error (internal_error, ["Cannot have more than one Cluster object per pool currently"]))
 

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -49,9 +49,9 @@ let sync_required ~__context ~host =
         if cluster_rec.API.cluster_pool_auto_join
         then Some cluster_ref
         else None
-      | _ -> failwith "Internal error: More than one cluster_host object associated with this host"
+      | _ -> raise Api_errors.(Server_error (cluster_does_not_have_one_node, [ Ref.string_of host ]))
     end
-  | _ -> failwith "Internal error: Cannot have more than one Cluster object per pool currently"
+  | _ -> raise Api_errors.(Server_error (internal_error, ["Cannot have more than one Cluster object per pool currently"]))
 
 let create_as_necessary ~__context ~host =
   match sync_required ~__context ~host with
@@ -97,8 +97,11 @@ let create ~__context ~cluster ~host =
       | Result.Ok () ->
         Db.Cluster_host.create ~__context ~ref ~uuid ~cluster ~host ~enabled:true
           ~current_operations:[] ~allowed_operations:[] ~other_config:[];
+        debug "Cluster_host.create was successful; cluster_host: %s" (Ref.string_of ref);
         ref
-      | Result.Error error -> handle_error error
+      | Result.Error error ->
+        warn "Error occurred during Cluster_host.create";
+        handle_error error
     )
 
 let force_destroy ~__context ~self =
@@ -110,8 +113,11 @@ let force_destroy ~__context ~self =
   match result with
   | Result.Ok () ->
     Db.Cluster_host.destroy ~__context ~self;
+    debug "Cluster_host.force_destroy was successful";
     Xapi_clustering.Daemon.disable ~__context
-  | Result.Error error -> handle_error error
+  | Result.Error error ->
+    warn "Error occurred during Cluster_host.force_destroy";
+    handle_error error
 
 let destroy ~__context ~self =
   let dbg = Context.string_of_task __context in
@@ -121,13 +127,16 @@ let destroy ~__context ~self =
   assert_cluster_host_enabled ~__context ~self ~expected:true;
   let result = Cluster_client.LocalClient.leave (rpc ~__context) dbg in
   match result with
+  (* can't include refs in case those were successfully destroyed *)
   | Result.Ok () ->
     Db.Cluster_host.destroy ~__context ~self;
+    debug "Cluster_host.destroy was successful";
     Xapi_clustering.Daemon.disable ~__context
-  | Result.Error error -> handle_error error
+  | Result.Error error ->
+    warn "Error occurred during Cluster_host.destroy";
+    handle_error error
 
 let enable ~__context ~self =
-  (* TODO: debug/error/info logging *)
   with_clustering_lock (fun () ->
       let dbg = Context.string_of_task __context in
       let host = Db.Cluster_host.get_host ~__context ~self in
@@ -150,12 +159,14 @@ let enable ~__context ~self =
       let result = Cluster_client.LocalClient.enable (rpc ~__context) dbg init_config in
       match result with
       | Result.Ok () ->
-        Db.Cluster_host.set_enabled ~__context ~self ~value:true
-      | Result.Error error -> handle_error error
+        Db.Cluster_host.set_enabled ~__context ~self ~value:true;
+        debug "Cluster_host.enable was successful for cluster_host: %s" (Ref.string_of self)
+      | Result.Error error ->
+        warn "Error encountered when enabling cluster_host %s" (Ref.string_of self);
+        handle_error error
     )
 
 let disable ~__context ~self =
-  (* TODO: debug/error/info logging *)
   with_clustering_lock (fun () ->
       let dbg = Context.string_of_task __context in
       let host = Db.Cluster_host.get_host ~__context ~self in
@@ -168,8 +179,11 @@ let disable ~__context ~self =
       let result = Cluster_client.LocalClient.disable (rpc ~__context) dbg in
       match result with
       | Result.Ok () ->
-          Db.Cluster_host.set_enabled ~__context ~self ~value:false
-      | Result.Error error -> handle_error error
+        Db.Cluster_host.set_enabled ~__context ~self ~value:false;
+        debug "Cluster_host.disable was successful for cluster_host: %s" (Ref.string_of self)
+      | Result.Error error ->
+        warn "Error encountered when disabling cluster_host %s" (Ref.string_of self);
+        handle_error error
     )
 
 let disable_clustering ~__context =
@@ -177,6 +191,6 @@ let disable_clustering ~__context =
   match Xapi_clustering.find_cluster_host ~__context ~host with
   | None -> info "No cluster host found"
   | Some self ->
-     info "Disabling cluster host";
+     info "Disabling cluster_host %s" (Ref.string_of self);
      disable ~__context ~self
 

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -43,11 +43,11 @@ let pif_of_host ~__context (network : API.ref_network) (host : API.ref_host) =
   | _ ->
     let msg = Printf.sprintf "No PIF found for host:%s and network:%s" (Ref.string_of host) (Ref.string_of network) in
     debug "%s" msg;
-    failwith msg
+    raise Api_errors.(Server_error (internal_error, [ msg ]))
 
 let ip_of_pif (ref,record) =
   let ip = record.API.pIF_IP in
-  if ip = "" then failwith (Printf.sprintf "PIF %s does not have any IP" (Ref.string_of ref));
+  if ip = "" then raise Api_errors.(Server_error (pif_has_no_network_configuration, [ Ref.string_of ref ]));
   Cluster_interface.IPv4 ip
 
 (** [assert_pif_prerequisites (pif_ref,pif_rec)] raises an exception if any of
@@ -136,8 +136,7 @@ let assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type
    xapi-clusterd daemon running on the target host *)
 let assert_operation_host_target_is_localhost ~__context ~host =
   if host <> Helpers.get_localhost ~__context then
-    let msg = "A clustering operation was attempted from the wrong host" in
-    raise Api_errors.(Server_error (internal_error, [msg]))
+    raise Api_errors.(Server_error (internal_error, [ "A clustering operation was attempted from the wrong host" ]))
 
 let assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__context ~self =
   let cluster = Db.Cluster_host.get_cluster ~__context ~self in

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -75,9 +75,10 @@ let handle_error = function
   | Unix_error message -> failwith ("Unix Error: " ^ message)
 
 let assert_cluster_host_can_be_created ~__context ~host =
-  if Db.Cluster_host.get_refs_where ~__context
-      ~expr:Db_filter_types.(Eq(Literal (Ref.string_of host),Field "host")) <> [] then
-    failwith "Cluster host cannot be created because it already exists"
+  match Db.Cluster_host.get_refs_where ~__context
+      ~expr:Db_filter_types.(Eq(Literal (Ref.string_of host),Field "host")) with
+  | [] -> ()
+  | _ -> raise Api_errors.(Server_error (internal_error, [ "Cluster host cannot be created because it already exists" ]))
 
 (** One of the cluster stacks returned by
     [get_required_cluster_stacks context sr_sm_type]

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -124,11 +124,15 @@ let assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type
         let cluster = Db.Cluster_host.get_cluster ~__context ~self:cluster_host in
         Db.Cluster.get_cluster_stack ~__context ~self:cluster
       in
+      let error_no_cluster_host_found condition =
+        debug "No_cluster_host found%s" condition;
+        raise Api_errors.(Server_error (no_compatible_cluster_host, [Ref.string_of host]))
+      in
       begin match find_cluster_host ~__context ~host with
         | Some cluster_host when (List.mem (cluster_stack_of ~cluster_host) required_cluster_stacks) ->
           assert_cluster_host_enabled ~__context ~self:cluster_host ~expected:true
-        | Some _ (* incompatible cluster host *) | None ->
-          raise Api_errors.(Server_error (no_compatible_cluster_host, [Ref.string_of host]))
+        | Some _ -> error_no_cluster_host_found " with matching cluster_stack"
+        | None -> error_no_cluster_host_found ""
       end
   end
 

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -48,7 +48,6 @@ let pif_of_host ~__context (network : API.ref_network) (host : API.ref_host) =
 let ip_of_pif (ref,record) =
   let ip = record.API.pIF_IP in
   if ip = "" then failwith (Printf.sprintf "PIF %s does not have any IP" (Ref.string_of ref));
-  debug "Got IP %s for PIF %s" ip (Ref.string_of ref);
   Cluster_interface.IPv4 ip
 
 (** [assert_pif_prerequisites (pif_ref,pif_rec)] raises an exception if any of
@@ -60,6 +59,7 @@ let ip_of_pif (ref,record) =
     {- that the PIF has disallow_unplug set}
     }*)
 let assert_pif_prerequisites pif =
+  let (ref, record) = pif in
   let assert_pif_permaplugged (ref,record) =
     if not record.API.pIF_disallow_unplug then
       raise Api_errors.(Server_error (pif_allows_unplug, [ record.API.pIF_uuid ] ));
@@ -67,7 +67,8 @@ let assert_pif_prerequisites pif =
       raise Api_errors.(Server_error (required_pif_is_unplugged, [ record.API.pIF_uuid ] ))
   in
   assert_pif_permaplugged pif;
-  ignore(ip_of_pif pif)
+  ignore (ip_of_pif pif);
+  debug "Got IP %s for PIF %s" record.API.pIF_IP (Ref.string_of ref)
 
 let handle_error = function
   | InternalError message -> raise Api_errors.(Server_error (internal_error, [ message ]))

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -59,16 +59,16 @@ let ip_of_pif (ref,record) =
     {- that the PIF has disallow_unplug set}
     }*)
 let assert_pif_prerequisites pif =
-  let (ref, record) = pif in
-  let assert_pif_permaplugged (ref,record) =
+  let (pif_ref, record) = pif in
+  let assert_pif_permaplugged (pif_ref,record) =
     if not record.API.pIF_disallow_unplug then
-      raise Api_errors.(Server_error (pif_allows_unplug, [ record.API.pIF_uuid ] ));
+      raise Api_errors.(Server_error (pif_allows_unplug, [ Ref.string_of pif_ref ] ));
     if not record.pIF_currently_attached then
-      raise Api_errors.(Server_error (required_pif_is_unplugged, [ record.API.pIF_uuid ] ))
+      raise Api_errors.(Server_error (required_pif_is_unplugged, [ Ref.string_of pif_ref ] ))
   in
   assert_pif_permaplugged pif;
   ignore (ip_of_pif pif);
-  debug "Got IP %s for PIF %s" record.API.pIF_IP (Ref.string_of ref)
+  debug "Got IP %s for PIF %s" record.API.pIF_IP (Ref.string_of pif_ref)
 
 let handle_error = function
   | InternalError message -> raise Api_errors.(Server_error (internal_error, [ message ]))


### PR DESCRIPTION
This PR adds logging to Cluster and Cluster_host API calls where necessary, as well as updating existing log comments to provide object OpaqueRefs where possible.

In particular, debugging comments indicate whether an API call returned successfully, to make the logs more explicit, such as clearly indicating that an error occurred during the specific API call before a backtrace is logged.