### PR TITLE
Hyphenate xe cli params instead of using underscores

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -845,8 +845,8 @@ let gen_cmds rpc session_id =
     ; Client.USB_group.(mk get_all get_all_records_where get_by_uuid usb_group_record "usb-group" [] ["uuid";"name-label";"name-description"] rpc session_id)
     ; Client.VUSB.(mk get_all get_all_records_where get_by_uuid vusb_record "vusb" [] ["uuid";"vm-uuid"; "usb-group-uuid"] rpc session_id)
     ; Client.Network_sriov.(mk get_all get_all_records_where get_by_uuid network_sriov_record "network-sriov" [] ["uuid"; "physical-pif"; "logical-pif"; "requires-reboot"; "configuration-mode"] rpc session_id)
-    ; Client.Cluster.(mk get_all get_all_records_where get_by_uuid cluster_record "cluster" [] ["uuid";"cluster_hosts";"network";"cluster_token";"cluster_stack";"allowed_operations";"current_operations";"pool_auto_join";"cluster_config";"other_config"] rpc session_id)
-    ; Client.Cluster_host.(mk get_all get_all_records_where get_by_uuid cluster_host_record "cluster-host" [] ["uuid";"cluster";"host";"enabled";"allowed_operations";"current_operations";"other_config"] rpc session_id)
+    ; Client.Cluster.(mk get_all get_all_records_where get_by_uuid cluster_record "cluster" [] ["uuid";"cluster-hosts";"network";"cluster-token";"cluster-stack";"allowed-operations";"current-operations";"pool-auto-join";"cluster-config";"other-config"] rpc session_id)
+    ; Client.Cluster_host.(mk get_all get_all_records_where get_by_uuid cluster_host_record "cluster-host" [] ["uuid";"cluster";"host";"enabled";"allowed-operations";"current-operations";"other-config"] rpc session_id)
     ]
 
 (* NB, might want to put these back in at some point

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -2140,41 +2140,41 @@ let cluster_record rpc session_id cluster =
       [ make_field ~name:"uuid"
           ~get:(fun () -> (x ()).API.cluster_uuid)
           ()
-      ; make_field ~name:"cluster_hosts"
+      ; make_field ~name:"cluster-hosts"
           ~get:(fun () -> String.concat "; " (List.map (fun r -> get_uuid_from_ref r) (x ()).API.cluster_cluster_hosts))
           ~get_set:(fun () -> List.map get_uuid_from_ref (x ()).API.cluster_cluster_hosts)
           ()
       ; make_field ~name:"network"
           ~get:(fun () -> (x ()).API.cluster_network |> get_uuid_from_ref)
           ()
-      ; make_field ~name:"cluster_token"
+      ; make_field ~name:"cluster-token"
           ~get:(fun () -> (x ()).API.cluster_cluster_token)
           ()
-      ; make_field ~name:"cluster_stack"
+      ; make_field ~name:"cluster-stack"
           ~get:(fun () -> (x ()).API.cluster_cluster_stack)
           ()
-      ; make_field ~name:"token_timeout"
+      ; make_field ~name:"token-timeout"
           ~get:(fun () -> Int64.to_string((x ()).API.cluster_token_timeout))
           ()
-      ; make_field ~name:"token_timeout_coefficient"
+      ; make_field ~name:"token-timeout-coefficient"
           ~get:(fun () -> Int64.to_string((x ()).API.cluster_token_timeout_coefficient))
           ()
-      ; make_field ~name:"allowed_operations"
+      ; make_field ~name:"allowed-operations"
           ~get:(fun () -> String.concat "; " (List.map Record_util.cluster_operation_to_string (x ()).API.cluster_allowed_operations))
           ~get_set:(fun () -> List.map Record_util.cluster_operation_to_string (x ()).API.cluster_allowed_operations)
           ()
-      ; make_field ~name:"current_operations"
+      ; make_field ~name:"current-operations"
           ~get:(fun () -> String.concat "; " (List.map (fun (task,op) -> Record_util.cluster_operation_to_string op) (x ()).API.cluster_current_operations))
           ~get_set:(fun () -> List.map (fun (task,op) -> Record_util.cluster_operation_to_string op) (x ()).API.cluster_current_operations)
           ()
-      ; make_field ~name:"pool_auto_join"
+      ; make_field ~name:"pool-auto-join"
           ~get:(fun () -> (x ()).API.cluster_pool_auto_join |> string_of_bool)
           ()
-      ; make_field ~name:"cluster_config"
+      ; make_field ~name:"cluster-config"
           ~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.cluster_cluster_config)
           ~get_map:(fun () -> (x ()).API.cluster_cluster_config)
           ()
-      ; make_field ~name:"other_config"
+      ; make_field ~name:"other-config"
           ~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.cluster_other_config)
           ~get_map:(fun () -> (x ()).API.cluster_other_config)
           ~add_to_map:(fun k v -> Client.Cluster.add_to_other_config rpc session_id cluster k v)
@@ -2204,15 +2204,15 @@ let cluster_host_record rpc session_id cluster_host =
       ; make_field ~name:"enabled"
           ~get:(fun () -> (x ()).API.cluster_host_enabled |> string_of_bool)
           ()
-      ; make_field ~name:"allowed_operations"
+      ; make_field ~name:"allowed-operations"
           ~get:(fun () -> String.concat "; " (List.map Record_util.cluster_host_operation_to_string (x ()).API.cluster_host_allowed_operations))
           ~get_set:(fun () -> List.map Record_util.cluster_host_operation_to_string (x ()).API.cluster_host_allowed_operations)
           ()
-      ; make_field ~name:"current_operations"
+      ; make_field ~name:"current-operations"
           ~get:(fun () -> String.concat "; " (List.map (fun (task,op) -> Record_util.cluster_host_operation_to_string op) (x ()).API.cluster_host_current_operations))
           ~get_set:(fun () -> List.map (fun (task,op) -> Record_util.cluster_host_operation_to_string op) (x ()).API.cluster_host_current_operations)
           ()
-      ; make_field ~name:"other_config"
+      ; make_field ~name:"other-config"
           ~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.cluster_host_other_config)
           ~get_map:(fun () -> (x ()).API.cluster_host_other_config)
           ()


### PR DESCRIPTION
CLI parameters with underscores are generally an anomaly as we tend to hyphenate them instead.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>