### PR TITLE
CA-281638: Set Pool.ha_cluster_stack when enabling/disabling clustering

### DIFF
--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -136,6 +136,10 @@ let enable ~__context ~self =
       let network = Db.Cluster.get_network ~__context ~self:cluster in
       let pif = pif_of_host ~__context network host in
       assert_pif_prerequisites pif;
+
+      let pool = Helpers.get_pool ~__context in
+      if Db.Pool.get_ha_enabled ~__context ~self:pool then
+        Db.Pool.set_ha_cluster_stack ~__context ~self:pool ~value:"corosync";
       let ip = ip_of_pif pif in
       let init_config = {
         Cluster_interface.local_ip = ip;
@@ -157,6 +161,10 @@ let disable ~__context ~self =
       let host = Db.Cluster_host.get_host ~__context ~self in
       assert_operation_host_target_is_localhost ~__context ~host;
       assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__context ~self;
+
+      let pool = Helpers.get_pool ~__context in
+      if Db.Pool.get_ha_enabled ~__context ~self:pool then
+        Db.Pool.set_ha_cluster_stack ~__context ~self:pool ~value:"xhad";
       let result = Cluster_client.LocalClient.disable (rpc ~__context) dbg in
       match result with
       | Result.Ok () ->


### PR DESCRIPTION
If HA enabled on pool:
- set ha_cluster_stack to "corosync" when enabling clustering
- set ha_cluster_stack to "xhad" when disabling clustering

Linebreak separates assertions from API call logic

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>