### PR TITLE
CA-282684: VDI migration with vGPU is failing when vGPU size is big

### DIFF
--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -349,8 +349,7 @@ let assert_host_has_iommu ~__context ~host =
   if List.assoc "iommu" chipset_info <> "true" then
     raise (Api_errors.Server_error (Api_errors.vm_requires_iommu, [Ref.string_of host]))
 
-(* Check if there are vgpus not allocated, since we may check the mem/vgpu after reservation 
-   Assumption: a VM can have only one vGPU *)
+(* Check if there are vgpus not allocated, since we may check the mem/vgpu after reservation *)
 let has_non_allocated_vgpus ~__context ~self =
   Db.VM.get_VGPUs ~__context ~self
   |> List.map (fun vgpu -> Db.VGPU.get_scheduled_to_be_resident_on ~__context ~self:vgpu)
@@ -515,6 +514,7 @@ let assert_can_boot_here ~__context ~self ~host ~snapshot ?(do_sr_check=true) ?(
   assert_can_see_networks ~__context ~self ~host;
   if vm_needs_iommu ~__context ~self then
     assert_host_has_iommu ~__context ~host;
+  (* Assumption: a VM can have only one vGPU *)
   if has_non_allocated_vgpus ~__context ~self then
     assert_gpus_available ~__context ~self ~host;
   assert_usbs_available ~__context ~self ~host;

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -349,6 +349,13 @@ let assert_host_has_iommu ~__context ~host =
   if List.assoc "iommu" chipset_info <> "true" then
     raise (Api_errors.Server_error (Api_errors.vm_requires_iommu, [Ref.string_of host]))
 
+(* Check if there are vgpus not allocated, since we may check the mem/vgpu after reservation *)
+let has_non_allocated_vgpus ~__context ~self =
+  let resident_pgpus = Db.VM.get_VGPUs ~__context ~self
+                       |> List.map (fun vgpu -> Db.VGPU.get_scheduled_to_be_resident_on ~__context ~self:vgpu) in
+  let non_allocated = List.filter (fun pgpu -> not (Db.is_valid_ref __context pgpu)) resident_pgpus in
+  non_allocated <> []
+
 let assert_gpus_available ~__context ~self ~host =
   let this = "assert_gpus_available" in
   let vgpus = Db.VM.get_VGPUs ~__context ~self in
@@ -507,7 +514,8 @@ let assert_can_boot_here ~__context ~self ~host ~snapshot ?(do_sr_check=true) ?(
   assert_can_see_networks ~__context ~self ~host;
   if vm_needs_iommu ~__context ~self then
     assert_host_has_iommu ~__context ~host;
-  assert_gpus_available ~__context ~self ~host;
+  if has_non_allocated_vgpus ~__context ~self then
+    assert_gpus_available ~__context ~self ~host;
   assert_usbs_available ~__context ~self ~host;
   assert_netsriov_available ~__context ~self ~host;
   begin match Helpers.domain_type ~__context ~self with


### PR DESCRIPTION
 When VM with GPU implementing VDI migration, resources (memory and Vgpu)
 will be reserved and then Vgpu and memory checks will be performed, when
 Vgpu has big size, checks will fail with no remaining capacity.
 This fix aims to check there has 'non_allocated' vgpus before check the
 GPU resources.

Signed-off-by: Min Li <min.li1@citrix.com>