### PR TITLE
CP-27343: SR probe: add clustering lock, assert cluster_host enabled

### DIFF
--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -170,20 +170,21 @@ let get_pbds ~__context ~self ~attached ~master_pos =
   | `Last -> slave_pbds @ master_pbds
 
 let call_probe ~__context ~host ~device_config ~_type ~sm_config ~f =
-  debug "SR.probe sm_config=[ %s ]" (String.concat "; " (List.map (fun (k, v) -> k ^ " = " ^ v) sm_config));
-  let _type = String.lowercase_ascii _type in
-  let open Storage_interface in
-  let open Storage_access in
-
-  let queue = !Storage_interface.queue_name ^ "." ^ _type in
-  let uri () = Storage_interface.uri () ^ ".d/" ^ _type in
-  let rpc = external_rpc queue uri in
-  let module Client = Storage_interface.Client(struct let rpc = rpc end) in
-  let dbg = Context.string_of_task __context in
-
-  transform_storage_exn
+  Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type:_type
     (fun () ->
-       Client.SR.probe ~dbg ~queue ~device_config ~sm_config |> f
+      Xapi_clustering.assert_cluster_host_is_enabled_for_matching_sms ~__context ~host ~sr_sm_type:_type;
+
+      debug "SR.probe sm_config=[ %s ]" (String.concat "; " (List.map (fun (k, v) -> k ^ " = " ^ v) sm_config));
+      let _type = String.lowercase_ascii _type in
+
+      let queue = !Storage_interface.queue_name ^ "." ^ _type in
+      let uri () = Storage_interface.uri () ^ ".d/" ^ _type in
+      let rpc = Storage_access.external_rpc queue uri in
+      let module Client = Storage_interface.Client(struct let rpc = rpc end) in
+      let dbg = Context.string_of_task __context in
+
+      Storage_access.transform_storage_exn
+        (fun () -> Client.SR.probe ~dbg ~queue ~device_config ~sm_config |> f )
     )
 
 let probe = call_probe ~f:(


### PR DESCRIPTION
- Added an assertion for SR.probe as it is currently only safe with clustering enabled. 
- Wrapped `Xapi_sr.call_probe` (called by both `SR.probe` and `SR.probe_ext`) in a clustering lock in case the SR is in use elsewhere to prevent database inconsistency
- Removed local opens of `Storage_interface` and `Storage_access`

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>