### PR TITLE
CA-286364: When creating guest_metrics, ensure all fields reflect cur…

### DIFF
--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -239,7 +239,7 @@ let get_initial_guest_metrics (lookup: string -> string option) (list: string ->
   {pv_drivers_version; os_version; networks; other; memory; device_id; last_updated; can_use_hotplug_vbd; can_use_hotplug_vif;}
 
 
-let create_and_set_guest_metrics (lookup: string -> string option) (list: string -> string list) ~__context ~domid ~uuid =
+let create_and_set_guest_metrics (lookup: string -> string option) (list: string -> string list) ~__context ~domid ~uuid ~pV_drivers_detected =
   let initial_gm = get_initial_guest_metrics lookup list
   in
   let self = Db.VM.get_by_uuid ~__context ~uuid in
@@ -250,10 +250,10 @@ let create_and_set_guest_metrics (lookup: string -> string option) (list: string
     ~uuid:new_gm_uuid
     ~os_version:initial_gm.os_version
     ~pV_drivers_version:initial_gm.pv_drivers_version
-    ~pV_drivers_up_to_date:false
+    ~pV_drivers_up_to_date:pV_drivers_detected
     ~memory:[] ~disks:[]
     ~networks:initial_gm.networks
-    ~pV_drivers_detected:false
+    ~pV_drivers_detected
     ~other:initial_gm.other
     ~last_updated:(Date.of_float initial_gm.last_updated)
     ~other_config:[]
@@ -275,7 +275,7 @@ let create_and_set_guest_metrics (lookup: string -> string option) (list: string
 
 
 (** Reset all the guest metrics for a particular VM *)
-let all (lookup: string -> string option) (list: string -> string list) ~__context ~domid ~uuid =
+let all (lookup: string -> string option) (list: string -> string list) ~__context ~domid ~uuid ~pV_drivers_detected =
   let {pv_drivers_version; os_version; networks; other; memory; device_id;
        last_updated; can_use_hotplug_vbd; can_use_hotplug_vif;} = get_initial_guest_metrics lookup list
   in
@@ -345,7 +345,7 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
           then existing
           else
             (* if it doesn't exist, make a fresh one *)
-            create_and_set_guest_metrics lookup list ~__context ~domid ~uuid
+            create_and_set_guest_metrics lookup list ~__context ~domid ~uuid ~pV_drivers_detected
         in
 
         (* We unconditionally reset the database values but observe that the database

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1407,7 +1407,15 @@ let update_vm ~__context id =
                    List.iter
                      (fun domid ->
                         try
-                          let new_gm_ref = Xapi_guest_agent.create_and_set_guest_metrics (lookup state) (list state) ~__context ~domid ~uuid:id in
+                          let new_gm_ref =
+                            Xapi_guest_agent.create_and_set_guest_metrics
+                              (lookup state)
+                              (list state)
+                              ~__context
+                              ~domid
+                              ~uuid:id
+                              ~pV_drivers_detected:state.pv_drivers_detected
+                          in
                           debug "xenopsd event: created guest metrics %s for VM %s" (Ref.string_of new_gm_ref) id
                         with e ->
                           error "Caught %s: while creating VM %s guest metrics" (Printexc.to_string e) id
@@ -1437,7 +1445,7 @@ let update_vm ~__context id =
                    (fun domid ->
                       try
                         debug "xenopsd event: Updating VM %s domid %d guest_agent" id domid;
-                        Xapi_guest_agent.all (lookup state) (list state) ~__context ~domid ~uuid:id
+                        Xapi_guest_agent.all (lookup state) (list state) ~__context ~domid ~uuid:id ~pV_drivers_detected:state.pv_drivers_detected
                       with e ->
                         error "Caught %s: while updating VM %s guest_agent" (Printexc.to_string e) id
                    ) state.domids


### PR DESCRIPTION
…rent state

In CA-286364, a reboot happened on a VM that had PV tools installed. This
triggered xapi's updates-from-xenopsd to look at the new state. This was slow
for other reasons and by the time we were looking at the events the VM had
reloaded its PV drivers.

When we notice a VM has a different start time we delete and recreate the guest
metrics. This object was, prior to this change, created with `PV_drivers_detected`
taking the default value of `false`.

We then took a look at the value of 'PV_drivers_detected' in the current state
of the VM and noticed that it hadn't changed since we last looked at it (before
the VM rebooted) - so we didn't set the field in the database.

The change in this CS ensures we always create the guest_metrics with the current
state of the VM, which we were already doing for all other fields in
`VM_guest_metrics`.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>