### PR TITLE
CP-25121, CP-26147: Prevent clustering operations during rolling pool upgrade or concurrently

### DIFF
--- a/ocaml/quicktest/quicktest_cluster.ml
+++ b/ocaml/quicktest/quicktest_cluster.ml
@@ -1,0 +1,85 @@
+
+module Q = Quicktest_common
+module C = Client.Client
+
+let is_empty = function | [] -> true | _ -> false
+let rpc = !Q.rpc
+
+(* [Q.failed test.Q.name string_of_failure] removes [test] from a test Hashtbl
+ * and is therefore only called once, in the try-with statement.
+ * This exception is raised within the try-with body to trigger
+ * [Q.failed test string_of_failure] *)
+exception Abort_test of string
+
+(** --- Helpers for IP reconfiguration tests --- *)
+
+let reconfigure_ipv4 ~session_id ~self ~dNS =
+  let netmask = C.PIF.get_netmask ~session_id ~rpc ~self in
+  let iP = C.PIF.get_IP ~session_id ~rpc ~self in
+  let gateway = C.PIF.get_gateway ~session_id ~rpc ~self in
+  let mode = C.PIF.get_ip_configuration_mode ~session_id ~rpc ~self in
+  C.PIF.reconfigure_ip ~session_id ~rpc ~self ~iP ~dNS ~gateway ~netmask ~mode
+
+let reconfigure_ipv6 ~session_id ~self ~dNS =
+
+  (* confirm valid IPv6 strings exist *)
+  let iPv6_lst = (C.PIF.get_IPv6 ~session_id ~rpc ~self) |> List.filter ((<>) "") in
+  if is_empty iPv6_lst
+  then raise (Abort_test "No valid IPv6 strings exist.");
+
+  let gateway = C.PIF.get_ipv6_gateway ~session_id ~rpc ~self in
+  let mode = C.PIF.get_ipv6_configuration_mode ~session_id ~rpc ~self in
+  let iPv6 = List.hd iPv6_lst in
+  C.PIF.reconfigure_ipv6 ~session_id ~rpc ~self ~iPv6 ~dNS ~gateway ~mode
+
+(** --- Test skeleton, receives environment params before running  --- *)
+let test_reconfigure_ip ~ipv6 ~session_id ~(self : API.ref_PIF) =
+  let ip_string = if ipv6 then "IPv6" else "IPv4" in
+  let test =
+    Q.make_test (Printf.sprintf "Testing reconfiguring %s with clustering." ip_string) 4
+  in
+  try
+    Q.start test;
+
+    let dNS = C.PIF.get_DNS ~session_id ~rpc ~self in
+    if ipv6
+    then reconfigure_ipv6 ~session_id ~self ~dNS
+    else reconfigure_ipv4 ~session_id ~self ~dNS;
+
+    Q.failed test "PIF.reconfigure_ip should raise CLUSTERING_ENABLED"
+  with
+  | Api_errors.(Server_error(code,_)) when code=Api_errors.clustering_enabled
+      -> Q.debug test (Printf.sprintf "%s raised as expected." Api_errors.clustering_enabled);
+         Q.success test
+  | Api_errors.(Server_error(_,_)) -> () (* Don't fail on other API errors, only test clustering *)
+  | Abort_test s -> Q.failed test s
+  | e -> Q.failed test (ExnHelper.string_of_exn e)
+
+(** --- Check environment before calling test --- *)
+let test session_id =
+  let test_all_pifs = Q.make_test "Testing IP reconfiguration with and without clustering." 2 in
+  try
+    print_newline ();
+    Q.start test_all_pifs;
+    print_newline ();
+
+    let enabled_cluster_hosts =
+      List.filter
+        (fun self -> C.Cluster_host.get_enabled ~session_id ~rpc ~self)
+        (C.Cluster_host.get_all ~session_id ~rpc)
+    in
+    if is_empty enabled_cluster_hosts
+    then Q.debug test_all_pifs "No PIFS with clustering enabled, skipping tests."
+    else begin
+      enabled_cluster_hosts
+      |> List.map
+        (fun self -> C.Cluster_host.get_PIF ~session_id ~rpc ~self)
+      |> List.iter
+        (fun self ->
+          test_reconfigure_ip ~ipv6:false ~session_id ~self
+            (* IPv6 clusters not yet supported, can run this line once they are:
+               test_reconfigure_ip ~ipv6:true ~session_id ~self *)
+        );
+      Q.success test_all_pifs
+    end
+  with e -> Q.failed test_all_pifs (ExnHelper.string_of_exn e)

--- a/ocaml/tests/test_clustering_allowed_operations.ml
+++ b/ocaml/tests/test_clustering_allowed_operations.ml
@@ -108,9 +108,9 @@ let test_clustering_ops_disallowed_during_rolling_upgrade () =
   let test_clustering_ops_should_pass with_cluster_fn self ops =
     List.iter
       (fun op ->
-        Alcotest.(check unit)
-          "Clustering operations should be allowed"
-          () (with_cluster_fn self op)
+         Alcotest.(check unit)
+           "Clustering operations should be allowed"
+           () (with_cluster_fn self op)
       ) ops
   in
   let with_cluster_op self op =
@@ -148,10 +148,10 @@ let test_clustering_ops_disallowed_during_rolling_upgrade () =
   (* Only cluster_host lifecycle changes valid during RPU, not cluster membership changes *)
   List.iter
     (fun op ->
-      Alcotest.check_raises
-        "Other than cluster_host enable/disable, no clustering operations should be allowed during RPU"
-        Api_errors.(Server_error (not_supported_during_upgrade, []))
-        (fun () -> with_cluster_op cluster op)
+       Alcotest.check_raises
+         "Other than cluster_host enable/disable, no clustering operations should be allowed during RPU"
+         Api_errors.(Server_error (not_supported_during_upgrade, []))
+         (fun () -> with_cluster_op cluster op)
     ) [ `add ; `remove ; `destroy];
 
   test_clustering_ops_should_pass

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -832,11 +832,11 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
     let clear_reserved_netsriov_vfs_on ~__context ~vm =
       Db.VM.get_VIFs ~__context ~self:vm
       |> List.iter (fun vif ->
-            let vf =  Db.VIF.get_reserved_pci ~__context ~self:vif in
-            Db.VIF.set_reserved_pci ~__context ~self:vif ~value:Ref.null;
-            if Db.is_valid_ref __context vf
-            then Db.PCI.set_scheduled_to_be_attached_to ~__context ~self:vf ~value:Ref.null
-          )
+          let vf =  Db.VIF.get_reserved_pci ~__context ~self:vif in
+          Db.VIF.set_reserved_pci ~__context ~self:vif ~value:Ref.null;
+          if Db.is_valid_ref __context vf
+          then Db.PCI.set_scheduled_to_be_attached_to ~__context ~self:vf ~value:Ref.null
+        )
 
     (* Notes on memory checking/reservation logic:
        		   When computing the hosts free memory we consider all VMs resident_on (ie running
@@ -1656,11 +1656,11 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
            let source_host = Db.VM.get_resident_on ~__context ~self:vm in
 
            let to_equal_or_greater_version = Helpers.host_versions_not_decreasing ~__context
-             ~host_from:(Helpers.LocalObject source_host)
-             ~host_to:(Helpers.LocalObject host) in
+               ~host_from:(Helpers.LocalObject source_host)
+               ~host_to:(Helpers.LocalObject host) in
 
            if (Helpers.rolling_upgrade_in_progress ~__context) && (not to_equal_or_greater_version) then
-               raise (Api_errors.Server_error (Api_errors.not_supported_during_upgrade, []));
+             raise (Api_errors.Server_error (Api_errors.not_supported_during_upgrade, []));
 
            (* Make sure the target has enough memory to receive the VM *)
            let snapshot = Db.VM.get_record ~__context ~self:vm in
@@ -1696,8 +1696,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
              * forward the call to the source. *)
             let snapshot = Db.VM.get_record ~__context ~self:vm in
             (fun ~local_fn ~__context ~vm op ->
-              allocate_vm_to_host ~__context ~vm ~host ~snapshot ~host_op:`vm_migrate ();
-              forward_vm_op ~local_fn ~__context ~vm op)
+               allocate_vm_to_host ~__context ~vm ~host ~snapshot ~host_op:`vm_migrate ();
+               forward_vm_op ~local_fn ~__context ~vm op)
           else
             (* Cross pool: just forward to the source host. Resources on the
              * destination will be reserved separately. *)
@@ -1709,8 +1709,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       with_vm_operation ~__context ~self:vm ~doc:"VM.migrate_send" ~op:`migrate_send
         (fun () ->
            Server_helpers.exec_with_subtask ~__context "VM.assert_can_migrate" (fun ~__context ->
-             assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options
-           );
+               assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options
+             );
            forwarder ~local_fn ~__context ~vm
              (fun session_id rpc -> Client.VM.migrate_send rpc session_id vm dest live vdi_map vif_map options vgpu_map)
         )
@@ -1986,7 +1986,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let local_fn = Local.VM.s3_resume ~vm in
       forward_vm_op ~local_fn ~__context ~vm (fun session_id rpc -> Client.VM.s3_resume rpc session_id vm)
 
-   let set_bios_strings ~__context ~self ~value =
+    let set_bios_strings ~__context ~self ~value =
       info "VM.set_bios_strings: self = '%s'; value = '%s'" (vm_uuid ~__context self)
         (String.concat "; " (List.map (fun (k,v) -> k ^ "=" ^ v) value));
       Local.VM.set_bios_strings ~__context ~self ~value
@@ -2672,14 +2672,14 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let local_fn = Local.Host.set_iscsi_iqn ~host ~value in
       do_op_on ~local_fn ~__context ~host
         (fun session_id rpc ->
-          Client.Host.set_iscsi_iqn rpc session_id host value)
+           Client.Host.set_iscsi_iqn rpc session_id host value)
 
     let set_multipathing ~__context ~host ~value =
       info "Host.set_multipathing: host='%s' value='%s'" (host_uuid ~__context host) (string_of_bool value);
       let local_fn = Local.Host.set_multipathing ~host ~value in
       do_op_on ~local_fn ~__context ~host
         (fun session_id rpc ->
-          Client.Host.set_multipathing rpc session_id host value)
+           Client.Host.set_multipathing rpc session_id host value)
   end
 
   module Host_crashdump = struct
@@ -4080,7 +4080,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let update_vdi = Db.Pool_update.get_vdi ~__context ~self in
       if Db.is_valid_ref __context update_vdi then
         VDI.forward_vdi_op ~local_fn ~__context ~self:update_vdi
-        (fun session_id rpc -> Client.Pool_update.pool_clean rpc session_id self)
+          (fun session_id rpc -> Client.Pool_update.pool_clean rpc session_id self)
       else
         info "Pool_update.pool_clean: pool update '%s' has already been cleaned." (pool_update_uuid ~__context self)
 
@@ -4094,7 +4094,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let update_vdi = Db.Pool_update.get_vdi ~__context ~self in
       if Db.is_valid_ref __context update_vdi then
         VDI.forward_vdi_op ~local_fn ~__context ~self:update_vdi
-        (fun session_id rpc -> Client.Pool_update.attach rpc session_id self)
+          (fun session_id rpc -> Client.Pool_update.attach rpc session_id self)
       else
         raise (Api_errors.Server_error(Api_errors.cannot_find_update, [(pool_update_uuid ~__context self)]))
 
@@ -4104,7 +4104,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let update_vdi = Db.Pool_update.get_vdi ~__context ~self in
       if Db.is_valid_ref __context update_vdi then
         VDI.forward_vdi_op ~local_fn ~__context ~self:update_vdi
-        (fun session_id rpc -> Client.Pool_update.detach rpc session_id self)
+          (fun session_id rpc -> Client.Pool_update.detach rpc session_id self)
       else
         raise (Api_errors.Server_error(Api_errors.cannot_find_update, [(pool_update_uuid ~__context self)]))
 
@@ -4214,7 +4214,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
   end
 
   module VUSB = struct
-   let update_vusb_operations ~__context ~vusb =
+    let update_vusb_operations ~__context ~vusb =
       Helpers.with_global_lock
         (fun () -> Xapi_vusb_helpers.update_allowed_operations ~__context ~self:vusb)
 
@@ -4350,8 +4350,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let cluster = Db.Cluster_host.get_cluster ~__context ~self in
       Xapi_cluster_helpers.with_cluster_operation ~__context ~self:cluster ~doc:"Cluster_host.destroy" ~op:`remove
         (fun () ->
-          do_op_on ~__context ~local_fn ~host
-            (fun session_id rpc -> Client.Cluster_host.destroy rpc session_id self)
+           do_op_on ~__context ~local_fn ~host
+             (fun session_id rpc -> Client.Cluster_host.destroy rpc session_id self)
         )
 
     let force_destroy ~__context ~self =
@@ -4361,8 +4361,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let cluster = Db.Cluster_host.get_cluster ~__context ~self in
       Xapi_cluster_helpers.with_cluster_operation ~__context ~self:cluster ~doc:"Cluster_host.force_destroy" ~op:`remove
         (fun () ->
-          do_op_on ~__context ~local_fn ~host
-            (fun session_id rpc -> Client.Cluster_host.force_destroy rpc session_id self)
+           do_op_on ~__context ~local_fn ~host
+             (fun session_id rpc -> Client.Cluster_host.force_destroy rpc session_id self)
         )
 
     let enable ~__context ~self =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4313,19 +4313,20 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Cluster.get_network";
       Local.Cluster.get_network ~__context ~self
 
+    (* Pool operations don't need a lock, they call other locked functions *)
     let pool_create ~__context ~network ~cluster_stack ~token_timeout ~token_timeout_coefficient =
-      info "Cluster.pool_create";
+      info "Cluster.pool_create"; (* iterates over Cluster_host.create *)
       Local.Cluster.pool_create ~__context ~network ~cluster_stack ~token_timeout ~token_timeout_coefficient
 
-    let pool_force_destroy ~__context ~self =
+    let pool_force_destroy ~__context ~self = (* iterates over Cluster_host.destroy *)
       info "Cluster.pool_force_destroy cluster: %s" (Ref.string_of self);
       Local.Cluster.pool_force_destroy ~__context ~self
 
-    let pool_destroy ~__context ~self =
+    let pool_destroy ~__context ~self = (* iterates Cluster_host.destroy *)
       info "Cluster.pool_destroy cluster %s" (Ref.string_of self);
       Local.Cluster.pool_destroy ~__context ~self
 
-    let pool_resync ~__context ~self =
+    let pool_resync ~__context ~self = (* iterates Cluster_host.enable and Cluster_host where necessary*)
       info "Cluster.pool_resync cluster: %s" (Ref.string_of self);
       Local.Cluster.pool_resync ~__context ~self
   end
@@ -4346,15 +4347,23 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Cluster_host.destroy cluster_host: %s" (Ref.string_of self);
       let local_fn = Local.Cluster_host.destroy ~self in
       let host = Db.Cluster_host.get_host ~__context ~self in
-      do_op_on ~__context ~local_fn ~host
-        (fun session_id rpc -> Client.Cluster_host.destroy rpc session_id self)
+      let cluster = Db.Cluster_host.get_cluster ~__context ~self in
+      Xapi_cluster_helpers.with_cluster_operation ~__context ~self:cluster ~doc:"Cluster_host.destroy" ~op:`remove
+        (fun () ->
+          do_op_on ~__context ~local_fn ~host
+            (fun session_id rpc -> Client.Cluster_host.destroy rpc session_id self)
+        )
 
     let force_destroy ~__context ~self =
       info "Cluster_host.force_destroy cluster_host: %s" (Ref.string_of self);
       let local_fn = Local.Cluster_host.force_destroy ~self in
       let host = Db.Cluster_host.get_host ~__context ~self in
-      do_op_on ~__context ~local_fn ~host
-        (fun session_id rpc -> Client.Cluster_host.force_destroy rpc session_id self)
+      let cluster = Db.Cluster_host.get_cluster ~__context ~self in
+      Xapi_cluster_helpers.with_cluster_operation ~__context ~self:cluster ~doc:"Cluster_host.force_destroy" ~op:`remove
+        (fun () ->
+          do_op_on ~__context ~local_fn ~host
+            (fun session_id rpc -> Client.Cluster_host.force_destroy rpc session_id self)
+        )
 
     let enable ~__context ~self =
       info "Cluster_host.enable cluster_host %s" (Ref.string_of self);

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -911,6 +911,7 @@ let server_init() =
              	 table happens to be right) *)
           "Best-effort bring up of physical and sriov NICs", [ Startup.NoExnRaising ], Xapi_pif.start_of_day_best_effort_bring_up;
           "Create any necessary cluster_host objects", [ Startup.NoExnRaising ], (fun () -> Xapi_cluster_host.create_as_necessary __context (Helpers.get_localhost ~__context));
+          "resync cluster host state", [], (fun () -> Xapi_cluster_host.resync_host ~__context ~host:Helpers.(get_localhost ~__context));
           "updating the vswitch controller", [], (fun () -> Helpers.update_vswitch_controller ~__context ~host:(Helpers.get_localhost ~__context));
           "initialising storage", [ Startup.NoExnRaising ],
           (fun () -> Helpers.call_api_functions ~__context Create_storage.create_storage_localhost);

--- a/ocaml/xapi/xapi_cluster_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_helpers.ml
@@ -53,7 +53,12 @@ let get_operation_error ~__context ~self ~op =
       let current_ops = cr.Db_actions.cluster_current_operations in
       if (current_ops <> []) && not (is_allowed_concurrently ~op ~current_ops)
       then report_concurrent_operations_error ~current_ops ~ref_str
-      else None) in
+      else begin
+        match (Helpers.rolling_upgrade_in_progress ~__context), op with
+          | true, (`add | `remove | `destroy) -> Some (Api_errors.not_supported_during_upgrade, [])
+          | _, _                              -> None
+       end)
+  in
   current_error
 
 let assert_operation_valid ~__context ~self ~op =
@@ -68,16 +73,9 @@ let update_allowed_operations ~__context ~self =
     | _    -> accu
   in
   let allowed = List.fold_left check [] all_cluster_operations in
-  (* TODO: check if we need RPU-related checks here for restricting allowed_operations
-     based on if an RPU is in progress...
-  let allowed =
-    if Helpers.rolling_upgrade_in_progress ~__context
-    then Listext.List.intersect allowed Xapi_globs.rpu_allowed_cluster_host_operations
-    else allowed
-  in *)
   Db.Cluster.set_allowed_operations ~__context ~self ~value:allowed
 
-(** Add to the cluster host's current_operations, call a function and then remove from the
+(** Add to the cluster's current_operations, call a function and then remove from the
     current operations. Ensure allowed_operations is kept up to date throughout. *)
 let with_cluster_operation ~__context ~(self : [`Cluster] API.Ref.t) ~doc ~op ?policy f =
   let task_id = Ref.string_of (Context.get_task_id __context) in

--- a/ocaml/xapi/xapi_cluster_host_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_host_helpers.ml
@@ -67,13 +67,6 @@ let update_allowed_operations ~__context ~self =
     | _    -> accu
   in
   let allowed = List.fold_left check [] all_cluster_host_operations in
-  (* TODO: check if we need RPU-related checks here for restricting allowed_operations
-     based on if an RPU is in progress...
-  let allowed =
-    if Helpers.rolling_upgrade_in_progress ~__context
-    then Listext.List.intersect allowed Xapi_globs.rpu_allowed_cluster_operations
-    else allowed
-  in *)
   Db.Cluster_host.set_allowed_operations ~__context ~self ~value:allowed
 
 (** Add to the cluster host's current_operations, call a function and then remove from the

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -57,6 +57,10 @@ let valid_operations ~__context record _ref' =
   else
     set_errors Api_errors.ha_not_enabled [] [ `ha_disable ];
 
+  (* cluster create cannot run during a rolling pool upgrade *)
+  if Helpers.rolling_upgrade_in_progress ~__context then
+    set_errors Api_errors.not_supported_during_upgrade [] [ `cluster_create ];
+
   (* cluster create cannot run if a cluster already exists on the pool *)
   begin match Db.Cluster.get_all ~__context with
     | [_] -> set_errors Api_errors.cluster_already_exists [] [ `cluster_create ]


### PR DESCRIPTION
Prevent all clustering operations during a rolling pool upgrade, wrap all clustering calls in a clustering lock, and add a test to check for this.