### PR TITLE
CA-285840: Check for host liveness in the new stunnel hook

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -167,8 +167,18 @@ let register_callback_fns() =
     Locking_helpers.Thread_state.acquired (Locking_helpers.Process("stunnel", pid)) in
   let unset_stunnelpid task_opt pid =
     Locking_helpers.Thread_state.released (Locking_helpers.Process("stunnel", pid)) in
+  let stunnel_destination_is_ok addr =
+    Server_helpers.exec_with_new_task "check_stunnel_destination" (fun __context ->
+      let hosts = Db.Host.get_refs_where ~__context ~expr:(
+        Eq (Field "address", Literal addr)
+      ) in
+      match hosts with
+      | [host] -> (try Message_forwarding.check_live ~__context host; true with _ -> false)
+      | _ -> true)
+  in
   Xmlrpc_client.Internal.set_stunnelpid_callback := Some set_stunnelpid;
   Xmlrpc_client.Internal.unset_stunnelpid_callback := Some unset_stunnelpid;
+  Xmlrpc_client.Internal.destination_is_ok := Some stunnel_destination_is_ok;
   TaskHelper.init ()
 
 


### PR DESCRIPTION
In the stunnel connection retry loop a new hook has been added to allow
for a test to be run before going around the loop. This commit populates
the hook with a function to check for host_metrics.live so that if a
host has been marked as dead we exit the retry loop quickly.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>