### PR TITLE
CA-281638: Set pool.ha_cluster_stack for Cluster.create/destroy

### DIFF
--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -20,24 +20,24 @@ let test_clusterd_rpc ~__context call =
   let token = "test_token" in
   match call.Rpc.name, call.Rpc.params with
   | "create", _ ->
-     Rpc.{success = true; contents = Rpc.String token }
+    Rpc.{success = true; contents = Rpc.String token }
   | ("enable" | "disable" | "destroy" | "leave"), _ ->
-     Rpc.{success = true; contents = Rpc.Null }
+    Rpc.{success = true; contents = Rpc.Null }
   | name, params ->
-     failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))
+    failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))
 
 let test_rpc ~__context call =
   match call.Rpc.name, call.Rpc.params with
   | "Cluster_host.destroy", [self] ->
-     let open API in
-     Xapi_cluster_host.destroy ~__context ~self:(ref_Cluster_host_of_rpc self);
-     Rpc.{success = true; contents = Rpc.String "" }
+    let open API in
+    Xapi_cluster_host.destroy ~__context ~self:(ref_Cluster_host_of_rpc self);
+    Rpc.{success = true; contents = Rpc.String "" }
   | "Cluster.destroy", [_session; self] ->
-     let open API in
-     Xapi_cluster.destroy ~__context ~self:(ref_Cluster_of_rpc self);
-     Rpc.{success = true; contents = Rpc.String "" }
+    let open API in
+    Xapi_cluster.destroy ~__context ~self:(ref_Cluster_of_rpc self);
+    Rpc.{success = true; contents = Rpc.String "" }
   | name, params ->
-     failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))
+    failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))
 
 let create_cluster ~__context ?(cluster_stack=Constants.default_smapiv3_cluster_stack) () =
   Context.set_test_rpc __context (test_rpc ~__context);

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -14,12 +14,14 @@
 
 open Xapi_cluster
 
+(** NOTE: This mock rpc is also used by tests in test_clustering *)
+
 let test_clusterd_rpc ~__context call =
   let token = "test_token" in
   match call.Rpc.name, call.Rpc.params with
   | "create", _ ->
      Rpc.{success = true; contents = Rpc.String token }
-  | ("enable" | "disable" | "destroy"), _ ->
+  | ("enable" | "disable" | "destroy" | "leave"), _ ->
      Rpc.{success = true; contents = Rpc.Null }
   | name, params ->
      failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))

--- a/ocaml/tests/test_clustering.ml
+++ b/ocaml/tests/test_clustering.ml
@@ -231,11 +231,11 @@ let nest_with_clustering_lock_if_needed ~__context ~timeout ~type1 ~type2 ~on_de
     ~otherwise: on_deadlock
     (fun () ->
        Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type:type1
-        (fun () ->
-          Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type:type2
-          (fun () -> on_no_deadlock ()
-          )
-        )
+         (fun () ->
+            Xapi_clustering.with_clustering_lock_if_needed ~__context ~sr_sm_type:type2
+              (fun () -> on_no_deadlock ()
+              )
+         )
     )
 
 let test_clustering_lock_only_taken_if_needed_nested_calls () =
@@ -281,10 +281,10 @@ let test_assert_pif_prerequisites () =
     "test_assert_pif_prerequisites should fail at first"
     (Failure exn)
     (fun () ->
-      try
-        Xapi_clustering.assert_pif_prerequisites pif
-      with _ ->
-        failwith exn);
+       try
+         Xapi_clustering.assert_pif_prerequisites pif
+       with _ ->
+         failwith exn);
   (* Put in IPv4 info *)
   Db.PIF.set_IP ~__context ~self:pifref ~value:"1.1.1.1";
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
@@ -292,20 +292,20 @@ let test_assert_pif_prerequisites () =
     "test_assert_pif_prerequisites should fail after setting IPv4 info"
     (Failure exn)
     (fun () ->
-      try
-        Xapi_clustering.assert_pif_prerequisites pif
-      with _ ->
-        failwith exn);
+       try
+         Xapi_clustering.assert_pif_prerequisites pif
+       with _ ->
+         failwith exn);
   Db.PIF.set_currently_attached ~__context ~self:pifref ~value:true;
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
   Alcotest.check_raises
     "test_assert_pif_prerequisites should fail after setting attached:true"
     (Failure exn)
     (fun () ->
-      try
-        Xapi_clustering.assert_pif_prerequisites pif
-      with _ ->
-        failwith exn);
+       try
+         Xapi_clustering.assert_pif_prerequisites pif
+       with _ ->
+         failwith exn);
   Db.PIF.set_disallow_unplug ~__context ~self:pifref ~value:true;
   let pif = Xapi_clustering.pif_of_host ~__context network localhost in
   Alcotest.(check unit)
@@ -382,8 +382,8 @@ let test_default = "default_sm_stack_value_used_in_place_of_xhad"
 
 let choose_cluster_stack_should_select cluster_stack ~__context =
   Alcotest.(check string) "choose_cluster_stack"
-  cluster_stack
-  (Cluster_stack_constraints.choose_cluster_stack ~__context)
+    cluster_stack
+    (Cluster_stack_constraints.choose_cluster_stack ~__context)
 
 let choose_cluster_stack_should_fail_with_conflict ~__context =
   Alcotest.check_raises
@@ -433,10 +433,10 @@ let test_choose_cluster_stack_sms_no_clusters () =
 
   (* Remove conflict, now first LVM stack will be selected *)
   begin match Db.SR.get_PBDs ~__context ~self:sm_sr with
-  | [ pBD ] ->
-    Db.PBD.set_currently_attached ~__context ~self:pBD ~value:false;
-    Db.SR.destroy ~__context ~self:sm_sr
-  | _ -> Alcotest.fail "only one PBD should be plugged into this SR"
+    | [ pBD ] ->
+      Db.PBD.set_currently_attached ~__context ~self:pBD ~value:false;
+      Db.SR.destroy ~__context ~self:sm_sr
+    | _ -> Alcotest.fail "only one PBD should be plugged into this SR"
   end;
   choose_cluster_stack_should_select default_smapiv3 ~__context;
 
@@ -572,14 +572,14 @@ let test_pool_ha_cluster_stacks =
 
 let test =
   ( test_get_required_cluster_stacks
-  @ test_find_cluster_host
-  @ test_assert_cluster_host_enabled
-  @ test_assert_cluster_host_is_enabled_for_matching_sms
-  @ test_assert_pif_prerequisites
-  @ test_disallow_unplug_ro_with_clustering_enabled
-  @ test_choose_cluster_stack
-  @ test_pool_ha_cluster_stacks
-  (* NOTE: lock test hoards the mutex and should thus always be last,
-   * otherwise any other functions trying to use the lock will hang *)
-  @ test_clustering_lock_only_taken_if_needed
+    @ test_find_cluster_host
+    @ test_assert_cluster_host_enabled
+    @ test_assert_cluster_host_is_enabled_for_matching_sms
+    @ test_assert_pif_prerequisites
+    @ test_disallow_unplug_ro_with_clustering_enabled
+    @ test_choose_cluster_stack
+    @ test_pool_ha_cluster_stacks
+    (* NOTE: lock test hoards the mutex and should thus always be last,
+     * otherwise any other functions trying to use the lock will hang *)
+    @ test_clustering_lock_only_taken_if_needed
   )

--- a/ocaml/xapi/cluster_stack_constraints.ml
+++ b/ocaml/xapi/cluster_stack_constraints.ml
@@ -28,24 +28,24 @@ let required_cluster_stack ~__context =
   let required_stacks = List.filter_map (fun pbd ->
       let sr = Db.PBD.get_SR ~__context ~self:pbd in
       let sr_type = Db.SR.get_type ~__context ~self:sr in
-        match List.assoc sr_type constraints with
-        | exception Not_found -> begin
+      match List.assoc sr_type constraints with
+      | exception Not_found -> begin
           error "SR type not found in SM table.";
           failwith "SR type not found in SM table." end
-        | [] -> None    (* No constraints *)
-        | l ->  Some l  (* Any one of these will do *)
+      | [] -> None    (* No constraints *)
+      | l ->  Some l  (* Any one of these will do *)
     ) pbds in
   let failwith_cluster_stack_conflict () =
-      error "Conflicting cluster stack demands.";
-      failwith "Conflicting cluster stack demands."
+    error "Conflicting cluster stack demands.";
+    failwith "Conflicting cluster stack demands."
   in
   match required_stacks with
   | [] ->
     (* None of the attached SRs have constraints *)
     begin match active_cluster_stack with
-    | [] -> None
-    | [ stack ] -> Some stack
-    | _ -> failwith_cluster_stack_conflict ()
+      | [] -> None
+      | [ stack ] -> Some stack
+      | _ -> failwith_cluster_stack_conflict ()
     end
   | [stacks] ->
     (* There is one SR with constraints; pick the first alternative. *)
@@ -93,7 +93,7 @@ let assert_cluster_stack_compatible ~__context sr =
            ()  (* Constraints satisfied *)
          else
            raise Api_errors.(Server_error
-                    (incompatible_cluster_stack_active, [String.concat "," alternatives]))
+                               (incompatible_cluster_stack_active, [String.concat "," alternatives]))
       )
     | [] ->
       error "SR type not found in SM table.";

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -68,6 +68,7 @@ let create ~__context ~network ~cluster_stack ~pool_auto_join ~token_timeout ~to
           ~current_operations:[] ~allowed_operations:[] ~other_config:[];
         Xapi_cluster_host_helpers.update_allowed_operations ~__context ~self:cluster_host_ref;
         D.debug "Created Cluster: %s and Cluster_host: %s" (Ref.string_of cluster_ref) (Ref.string_of cluster_host_ref);
+        set_ha_cluster_stack ~__context;
         cluster_ref
       | Result.Error error ->
         D.warn "Error occurred during Cluster.create";
@@ -95,6 +96,7 @@ let destroy ~__context ~self =
     ) cluster_host;
     Db.Cluster.destroy ~__context ~self;
     D.debug "Cluster destroyed successfully";
+    set_ha_cluster_stack ~__context;
     Xapi_clustering.Daemon.disable ~__context
   | Result.Error error ->
     D.warn "Error occurred during Cluster.destroy";

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -146,9 +146,6 @@ let enable ~__context ~self =
       let pif = pif_of_host ~__context network host in
       assert_pif_prerequisites pif;
 
-      let pool = Helpers.get_pool ~__context in
-      if Db.Pool.get_ha_enabled ~__context ~self:pool then
-        Db.Pool.set_ha_cluster_stack ~__context ~self:pool ~value:Constants.default_smapiv3_cluster_stack;
       let ip = ip_of_pif pif in
       let init_config = {
         Cluster_interface.local_ip = ip;
@@ -173,9 +170,6 @@ let disable ~__context ~self =
       assert_operation_host_target_is_localhost ~__context ~host;
       assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__context ~self;
 
-      let pool = Helpers.get_pool ~__context in
-      if Db.Pool.get_ha_enabled ~__context ~self:pool then
-        Db.Pool.set_ha_cluster_stack ~__context ~self:pool ~value:"xhad";
       let result = Cluster_client.LocalClient.disable (rpc ~__context) dbg in
       match result with
       | Result.Ok () ->

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -17,6 +17,12 @@ open Cluster_interface
 module D=Debug.Make(struct let name="xapi_clustering" end)
 open D
 
+(* Called by Cluster.create/destroy *)
+let set_ha_cluster_stack ~__context =
+  let self = Helpers.get_pool ~__context in
+  let value = Cluster_stack_constraints.choose_cluster_stack ~__context in
+  Db.Pool.set_ha_cluster_stack ~__context ~self ~value
+
 (* host-local clustering lock *)
 let clustering_lock_m = Mutex.create ()
 


### PR DESCRIPTION
This is a follow-up to my previous PR [here](https://github.com/xapi-project/xen-api/pull/3539), which set the pool's HA cluster stack for `Cluster_host.enable/disable`. Unfortunately this wasn't enough to automatically update the value, so now this PR should cover the introduction and destruction of a cluster, along with enabling and disabling clustering.

Note: I'm adding unit tests _but_ they use a change made [in this PR](https://github.com/xapi-project/xen-api/pull/3554), which should be merged first.