### PR TITLE
CP-27560 move to Device Model "qemu-upstream-compat"

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -7,7 +7,7 @@ open Datamodel_roles
               You do not have to bump vsn if you change/add/remove a message *)
 
 let schema_major_vsn = 5
-let schema_minor_vsn = 141
+let schema_minor_vsn = 142
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -50,7 +50,7 @@ let fallback_device_model_stage_1      = "qemu-trad"
 let fallback_device_model_stage_2      = fallback_device_model_stage_1
 let fallback_device_model_stage_3      = "qemu-upstream-compat"
 let fallback_device_model_stage_4      = fallback_device_model_stage_3
-let fallback_device_model_default_value = fallback_device_model_stage_1
+let fallback_device_model_default_value = fallback_device_model_stage_3
 
 (* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)
 let filtered_flags = [

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -522,16 +522,15 @@ let upgrade_vswitch_controller = {
         ignore (Xapi_sdn_controller.introduce ~__context ~protocol:`ssl ~address ~port:6632L)
 }
 
-let default_vm_platform_device_model = {
-  description = "Initialising unset VM.platform.device-model profiles";
-  version = (fun x -> x < jura);                                     (* initialise only for upgrades from previous versions before jura *)
+let upgrade_vm_platform_device_model = {
+  description = "Set or upgrade VM.platform.device-model profiles";
+  version = (fun _x -> true);
   fn = fun ~__context ->
     Db.VM.get_all ~__context
     |> List.iter (fun vm ->
          Db.VM.get_platform ~__context ~self:vm
          |> Xapi_vm_helpers.ensure_device_model_profile_present ~__context
             ~domain_type:(Db.VM.get_domain_type ~__context ~self:vm)
-            ~default_value:Vm_platform.fallback_device_model_stage_1 (* fallback device model profile from previous version before jura *)
          |> fun value ->
             Db.VM.set_platform ~__context ~self:vm ~value
        )
@@ -588,7 +587,7 @@ let rules = [
   update_tools_sr_pbd_device_config;
   upgrade_recommendations_for_gpu_passthru;
   upgrade_vswitch_controller;
-  default_vm_platform_device_model;
+  upgrade_vm_platform_device_model;
 ]
 
 (* Maybe upgrade most recent db *)

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -1155,7 +1155,10 @@ let with_vm_operation ~__context ~self ~doc ~op ?(strict=true) ?policy f =
 let ensure_device_model_profile_present ~__context ~domain_type ?(default_value=Vm_platform.fallback_device_model_default_value) platform =
   let needs_qemu = Helpers.needs_qemu_from_domain_type domain_type in
   let default = Vm_platform.(device_model, default_value) in
+  let trad    = Vm_platform.(device_model, fallback_device_model_stage_1) in
   if not needs_qemu || List.mem_assoc Vm_platform.device_model platform then
-    platform
+    (* upgrade existing Device Model entry *)
+    platform |> List.map (fun entry -> if entry = trad then default else entry)
   else (* only add device-model to an HVM VM platform if it is not already there *)
     default :: platform
+


### PR DESCRIPTION
The commits implement that imported and existing VMs use Device Model "qemu-upstream-compat". The change is implemented in ensure_device_model_profile_present() that either assigns this as the new default, or updates an existing device model. This function is also called during a xapi upgrade.

