### PR TITLE
CA-267687: Logs of VBD operation check that inspects operations of VBD's VDI do not match returned errors

### DIFF
--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -182,10 +182,6 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
         vdi_record.Db_actions.vDI_current_operations
     in
     if vdi_operations_besides_copy then begin
-      debug "VBD operation %s not allowed because VDI.current-operations = [ %s ]"
-        (String.concat ";" (List.map vbd_operation_to_string current_ops))
-        (String.concat "; "
-           (List.map (fun (task, op) -> task ^ " -> " ^ (vdi_operation_to_string op)) vdi_record.Db_actions.vDI_current_operations));
       let concurrent_op = snd (List.hd vdi_record.Db_actions.vDI_current_operations) in
       set_errors Api_errors.other_operation_in_progress
         [ "VDI"; Ref.string_of vdi; vdi_operation_to_string concurrent_op] [ `attach; `plug; `insert ]


### PR DESCRIPTION
If operations of VBD's VDI is not copy(mirror), then the log will shows
"VBD operation  not allowed because VDI.current-operations =    "
unconditionally, this is wrong because only attach/plug/insert will be blocked
for VBD, other operations will succeed and also with the confusing log.

Signed-off-by: Min Li <min.li1@citrix.com>