### PR TITLE
CA-287863: xe vm-shutdown complete the task too early

### DIFF
--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -58,7 +58,7 @@ let parameter_count_mismatch_failure func expected received =
 
 (** WARNING: the context is destroyed when execution is finished if the task is not forwarded, in database and not called asynchronous. *)
 (*  FIXME: This function should not be used for external call : we should add a proper .mli file to hide it. *)
-let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) f =
+let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) ?(has_task=false) f =
   (* Execute fn f in specified __context, marshalling result with "marshaller".
      If has_task is set then __context has a real task in it that has to be completed. *)
   let exec () =
@@ -67,6 +67,9 @@ let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) f 
        already been taken by the master
        2. If we are the master, locks are only necessary for the potentially-forwarded
        (ie side-effecting) operations and not things like the database layer *)
+
+    (* For forwarded task, we should not complete it here, the server which forward the task will complete it. However for the task forwarded by client, which param `has_task` is set with `true`, we have to complete it also. *)
+    let need_complete = has_task || (not (Context.forwarded_task __context)) in
     try
       let result =
         if not(Pool_role.is_master ())
@@ -79,8 +82,7 @@ let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) f 
             (* use the forwarding layer (NB this might make a local call ultimately) *)
             forward ~local_fn:f ~__context
       in
-      (* For forwarded task, we should not complete it here, the server which forward the task will complete it *)
-      begin
+      if need_complete then begin
         match marshaller with
         | None    -> TaskHelper.complete ~__context None
         | Some fn -> TaskHelper.complete ~__context (Some (fn result))
@@ -89,11 +91,11 @@ let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) f 
     with
     | Api_errors.Server_error (a,b) as e when a = Api_errors.task_cancelled ->
       Backtrace.is_important e;
-      TaskHelper.cancel ~__context;
+      if need_complete then TaskHelper.cancel ~__context;
       raise e
     | e ->
       Backtrace.is_important e;
-      TaskHelper.failed ~__context e;
+      if need_complete then TaskHelper.failed ~__context e;
       raise e
   in
   Locking_helpers.Thread_state.with_named_thread (Context.get_task_name __context) (Context.get_task_id __context)
@@ -145,6 +147,7 @@ let exec_with_new_task ?http_other_config ?quiet ?subtask_of ?session_id ?task_i
 let exec_with_forwarded_task ?http_other_config ?session_id ?origin task_id f =
   exec_with_context
     ~__context:(Context.from_forwarded_task ?http_other_config ?session_id ?origin task_id)
+    ~has_task:true
     (fun ~__context -> f __context)
 
 let exec_with_subtask ~__context ?task_in_database ?task_description task_name f =


### PR DESCRIPTION
When master forward a task to slave, slave will mark the task as completed once
finish processing it, however when master finishing the forwarding, it will also
mark the task as completed. Furthermore, when slave finished the task, that does
not mean the task is done, there may be some stuff that master has to handle, so
we have to ensure the task only complete once the master finish its work.

Signed-off-by: Yang Qian <yang.qian@citrix.com>