### PR TITLE
CA-286165: Remove PCI dependencies of VFs from the same PF.

### DIFF
--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -105,6 +105,7 @@ let add_pcis_to_vm ~__context host vm pci =
   let devs : ((int * (int * int * int * int))) list = List.rev (snd (List.fold_left (fun (i, acc) pci -> i + 1, (i, pci) :: acc) (0, []) devs)) in
   (* Update VM other_config for PCI passthrough *)
   let value = String.concat "," (List.map Pciops.to_string devs) in
+  debug "Adding PCIs to a VM with 'other config': %s" value; 
   Db.VM.add_to_other_config ~__context ~self:vm ~key:Xapi_globs.vgpu_pci ~value
 
 let reserve_free_virtual_function ~__context vm pf =


### PR DESCRIPTION
The PCI bus path of SR-IOV VFs have the same function number, but actually different VFs do not have PCI dependencies with each other. So here we remove dependencies of VFs from the same PF

Signed-off-by: Wei Xie <wei.xie@citrix.com>