### PR TITLE
CA-287865: Forwarded task calling Message_forwarding.xxx resulting cu…

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -600,8 +600,9 @@ let is_slave ~__context ~host = not (Pool_role.is_master ())
 
 let ask_host_if_it_is_a_slave ~__context ~host =
   let local_fn = is_slave ~host in
-  Message_forwarding.do_op_on_localsession_nolivecheck ~local_fn ~__context
-    ~host (fun session_id rpc -> Client.Client.Pool.is_slave rpc session_id host)
+  Server_helpers.exec_with_subtask ~__context "host.ask_host_if_it_is_a_slave" (fun ~__context ->
+    (Message_forwarding.do_op_on_localsession_nolivecheck ~local_fn ~__context
+      ~host (fun session_id rpc -> Client.Client.Pool.is_slave rpc session_id host)))
 
 let is_host_alive ~__context ~host =
   (* If the host is marked as not-live then assume we don't need to contact it to verify *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1360,8 +1360,9 @@ let hello ~__context ~host_uuid ~host_address =
       (* Nb. next call is purely there to establish that we can talk back to the host that initiated this call *)
       (* We don't care about the return type, only that no exception is raised while talking to it *)
       (try
-         ignore(Message_forwarding.do_op_on_nolivecheck_no_retry ~local_fn ~__context ~host:host_ref
-                  (fun session_id rpc -> Client.Pool.is_slave rpc session_id host_ref))
+         ignore(Server_helpers.exec_with_subtask ~__context "pool.hello.is_slave" (fun ~__context ->
+             (Message_forwarding.do_op_on_nolivecheck_no_retry ~local_fn ~__context ~host:host_ref
+                  (fun session_id rpc -> Client.Pool.is_slave rpc session_id host_ref))))
        with Api_errors.Server_error(code, [ "pool.is_slave"; "1"; "2" ]) as e when code = Api_errors.message_parameter_count_mismatch ->
          debug "Caught %s: this host is a Rio box" (ExnHelper.string_of_exn e)
           | Api_errors.Server_error(code, _) as e when code = Api_errors.host_still_booting ->


### PR DESCRIPTION
…rrent task being early marked completed

This issue is raised found due to on forwarded task, some call further to be forwarded
will still be done in the same task so resulting the current task marked as completed
when the forwarding call completes (actually should be some sub task). In some situation,
this will cause further issue like task being destroyed by GC.

The original issue is from pool.hello. However when making code change, similar
issue is spotted in xapi_host.ml. So similar changes is done for xapi_host.ml.

Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>