### PR TITLE
CA-287929: fix incorrect log message (11428 > 11428)

### DIFF
--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -568,7 +568,7 @@ let get_since_for_events ~__context since =
                       if gen > since then Some (gen, Xapi_event.Message.Create (_ref, msg)) else None)
                    !in_memory_cache)
          | (last_in_memory, _, _) :: _ ->
-           debug "get_since_for_events: last_in_memory (%Ld) > since (%Ld): Using slow message lookup" last_in_memory since;
+           debug "get_since_for_events: last_in_memory (%Ld) >= since (%Ld): Using slow message lookup" last_in_memory since;
            None
          | _ ->
            warn "get_since_for_events: no in_memory_cache!";


### PR DESCRIPTION
It was claiming that 11428 > 11428.
`Apr 13 17:48:00 xrtuk-08-03 xapi: [debug|xrtuk-08-03|135913 INET :::80|event.from D:1764185364b8|xapi] get_since_for_events: last_in_memory (11428) > since (11428): Using slow message lookup`

If you look at the code this is reached when `last_in_memory >= since`, and I think the code is correct: if the last message you have is equal to since, i.e. you do not have anything older then you cannot be sure whether you have all the messages with `t=since` because some of the messages that do not fit into the cache might have `t=since` too, thus you have to fall back to the slow lookup.
I think the code is doing the right thing