### PR TITLE
CA-244573 XenMotion fails after previously attempted SXM is interrupted by XAPI restart and vm goes into suspended state 

### DIFF
--- a/ocaml/tests/test_storage_migrate_state.ml
+++ b/ocaml/tests/test_storage_migrate_state.ml
@@ -25,12 +25,10 @@ end
 let sample_send_state = Storage_migrate.State.Send_state.({
     url = "url";
     dest_sr = "dest_sr";
-    remote_dp = "remote_dp";
+    remote_info = Some {dp="remote_dp"; vdi="mirror_vdi"; url="remote_url"};
     local_dp = "local_dp";
-    mirror_vdi = "mirror_vdi";
-    remote_url = "remote_url";
-    tapdev = Tapctl.tapdev_of_rpc
-        (Rpc.Dict ["minor", Rpc.Int 0L; "tapdisk_pid", Rpc.Int 0L]);
+    tapdev = Some (Tapctl.tapdev_of_rpc
+        (Rpc.Dict ["minor", Rpc.Int 0L; "tapdisk_pid", Rpc.Int 0L]));
     failed = false;
     watchdog = None;
   })

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -130,10 +130,10 @@ module State = struct
         Hashtbl.iter (Hashtbl.replace table) (hashtbl_of_rpc ~of_rpc:Copy_state.t_of_rpc rpc))
 
   let load () =
-    try load_one (Send_table active_send) with _ -> ();
-      try load_one (Recv_table active_recv) with _ -> ();
-        try load_one (Copy_table active_copy) with _ -> ();
-          loaded := true
+    ignore_exn (fun () -> load_one (Send_table active_send));
+    ignore_exn (fun () -> load_one (Recv_table active_recv));
+    ignore_exn (fun () -> load_one (Copy_table active_copy));
+    loaded := true
 
   let save_one : type a. a table -> unit = (fun table ->
       to_string table |> Unixext.write_string_to_file (path_of_table table))


### PR DESCRIPTION
This PR fixes 2 issues in 2 commits:
1. when recover SXM state from persistent files, we just recover the data of `Send_state` in case of wrong format of code of `try...with...`

2. When executing SXM, the time window between dp creation and persistent is large,
it is possible lead to dp leak if xapi restarted in the time window.
Aiming to mitigate the impact of this issue, this change persistents the dp
before we sending it to remote to shrink the time window.

Signed-off-by: Yang Qian <yang.qian@citrix.com>
