### PR TITLE
Cannot is one word.

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1194,7 +1194,7 @@ module PIF = struct
                     "Indicates whether the interface is managed by xapi. If \
                      it is not, then xapi will not configure the interface, \
                      the commands PIF.plug/unplug/reconfigure_ip(v6) \
-                     can not be used, nor can the interface be bonded or have \
+                     cannot be used, nor can the interface be bonded or have \
                      VLANs based on top through xapi." ~default_value:(Some (VBool true));
                   field ~lifecycle:[Published, rel_creedence, ""] ~qualifier:DynamicRO ~ty:(Map(String, String)) ~default_value:(Some (VMap [])) "properties" "Additional configuration properties for the interface.";
                   field ~lifecycle:[Published, rel_dundee, ""] ~qualifier:DynamicRO ~ty:(Set(String)) ~default_value:(Some (VSet [])) "capabilities" "Additional capabilities on the interface.";

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -220,7 +220,7 @@ let _ =
   error Api_errors.cannot_forget_sriov_logical [ "PIF" ]
     ~doc:"This is a network SR-IOV logical PIF and cannot do forget on it" ();
   error Api_errors.incompatible_pif_properties []
-    ~doc:"These PIFs can not be bonded, because their properties are different." ();
+    ~doc:"These PIFs cannot be bonded, because their properties are different." ();
   error Api_errors.slave_requires_management_iface []
     ~doc:"The management interface on a slave cannot be disabled because the slave would enter emergency mode." ();
   error Api_errors.vif_in_use [ "network"; "VIF" ]
@@ -441,7 +441,7 @@ let _ =
   error Api_errors.host_broken []
     ~doc:"This host failed in the middle of an automatic failover operation and needs to retry the failover action" ();
   error Api_errors.host_has_resident_vms [ "host" ]
-    ~doc:"This host can not be forgotten because there are some user VMs still running" ();
+    ~doc:"This host cannot be forgotten because there are some user VMs still running" ();
 
   error Api_errors.not_supported_during_upgrade []
     ~doc:"This operation is not supported during an upgrade." ();

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -1154,7 +1154,7 @@ let disable_internal __context =
      	   If the master has access to the state file (how do we determine this)?
      	   * ha_set_pool_state(invalid)
      	   If the master hasn't access to the state file but all hosts are available via heartbeat
-     	   * set the flag "can not be master and no VM failover decision on next boot"
+     	   * set the flag "cannot be master and no VM failover decision on next boot"
      	   * ha_disarm_fencing()
      	   * ha_stop_daemon()
      	   Otherwise we'll be fenced *)
@@ -1379,7 +1379,7 @@ let enable __context heartbeat_srs configuration =
 
   (* Steps from 8.7 Enabling HA in Marathon spec:
      	 * 1. Bring up state file VDI(s)
-     	 * 2. Clear the flag "can not be master and no VM failover decision on next boot"
+     	 * 2. Clear the flag "cannot be master and no VM failover decision on next boot"
      	 * 3. XAPI stops its internal heartbeats with other hosts in the pool
      	 * 4. ha_set_pool_state(init) *)
 

--- a/ocaml/xapi/xapi_vusb.ml
+++ b/ocaml/xapi/xapi_vusb.ml
@@ -31,14 +31,14 @@ let create ~__context ~vM ~uSB_group ~other_config =
       raise (Api_errors.Server_error (Api_errors.too_many_vusbs, ["6"]));
     let vusbs = Db.USB_group.get_VUSBs ~__context ~self:uSB_group in
     (* Currently USB_group only have one PUSB. So when vusb is created with a USB_group,
-        another vusb can not create with the same USB_group. *)
+        another vusb cannot create with the same USB_group. *)
     if vusbs <> [] then
       raise (Api_errors.Server_error(Api_errors.usb_group_conflict, [Ref.string_of uSB_group]));
     (* We won't attach VUSB when VM ha_restart_priority is set to 'restart'  *)
     let ha_restart_priority = Db.VM.get_ha_restart_priority ~__context ~self:vM in
     match ha_restart_priority with
     | hp when hp = Constants.ha_restart -> raise (Api_errors.Server_error(Api_errors.operation_not_allowed,
-      [Printf.sprintf "VM %s ha_restart_priority has been set to 'restart', can not create VUSB for it. " (Ref.string_of vM)]))
+      [Printf.sprintf "VM %s ha_restart_priority has been set to 'restart', cannot create VUSB for it. " (Ref.string_of vM)]))
     | _ ->
       Db.VUSB.create ~__context ~ref:vusb ~uuid ~current_operations:[] ~allowed_operations:[] ~vM ~uSB_group
         ~other_config ~currently_attached:false;


### PR DESCRIPTION
The API erros at least need to be correct because they are visible to the users and exposed on the UI.