### PR TITLE
Move a deprecated module before it breaks

### DIFF
--- a/ocaml/auth/xa_auth_stubs.c
+++ b/ocaml/auth/xa_auth_stubs.c
@@ -24,6 +24,7 @@
 #include <caml/custom.h>
 #include <caml/fail.h>
 #include <caml/callback.h>
+#include <caml/signals.h>
 
 #include "xa_auth.h"
 

--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -56,7 +56,7 @@ let fix_cookie = function
         in extract_comps_inner 0 [] n
       in
 
-      let comps = bounded_split_delim (Re.compile (Re_emacs.re "[;,][ \t]*")) str_cookie 0 in
+      let comps = bounded_split_delim (Re.compile (Re.Emacs.re "[;,][ \t]*")) str_cookie 0 in
 
       (* We don't handle $Path, $Domain, $Port, $Version (or $anything $else) *)
       let cookies = List.filter (fun s -> s.[0] != '$') comps in


### PR DESCRIPTION
and add a missing header from one of our c-stubs