### PR TITLE
Reduce amount of deprecation warnings when compiling xapi

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_rbac.ml
+++ b/ocaml/idl/ocaml_backend/gen_rbac.ml
@@ -65,12 +65,12 @@ let hash2uuid str =
   in
   Uuid.string_of_uuid (Uuid.uuid_of_int_array (int_array hex))
 
-let replace_char _str c1 c2 =
-  let str = String.copy _str in (*defensive copy*)
-  for i=0 to String.length str -1 do
-    if str.[i]=c1 then str.[i]<-c2 else ()
-  done;
-  str
+let replace_char str c1 c2 =
+  let buf = Bytes.of_string str in (*defensive copy*)
+  String.iteri (fun i _ ->
+    if str.[i]=c1 then Bytes.set buf i c2 else ()
+  ) str;
+  Bytes.unsafe_to_string buf
 
 let role_uuid name = hash2uuid name
 

--- a/ocaml/rfb/rfb_randomtest.ml
+++ b/ocaml/rfb/rfb_randomtest.ml
@@ -33,7 +33,7 @@ let server (s: Unix.file_descr) =
         (* Update the whole thing *)
         let buffer = Bytes.create (w * h * !bpp / 8) in
         for i = 0 to String.length buffer - 1 do
-          buffer.[i] <- char_of_int (Random.int 255)
+          Bytes.set buffer i (char_of_int @@ Random.int 255)
         done;
         let raw = { FramebufferUpdate.Raw.buffer = buffer } in
         let update = { FramebufferUpdate.x = 0; y = 0; w = w; h = h;

--- a/ocaml/xapi-cli-protocol/cli_protocol.ml
+++ b/ocaml/xapi-cli-protocol/cli_protocol.ml
@@ -98,12 +98,12 @@ let marshal_int32 x =
   and b = (x >> 8) && 0xffl
   and c = (x >> 16) && 0xffl
   and d = (x >> 24) && 0xffl in
-  let result = String.make 4 '\000' in
-  result.[0] <- char_of_int (Int32.to_int a);
-  result.[1] <- char_of_int (Int32.to_int b);
-  result.[2] <- char_of_int (Int32.to_int c);
-  result.[3] <- char_of_int (Int32.to_int d);
-  result
+  let set buf pos v =
+    Bytes.set buf pos (char_of_int @@ Int32.to_int v)
+  in
+  let result = Bytes.make 4 '\000' in
+  List.iteri (set result) [a;b;c;d];
+  Bytes.unsafe_to_string result
 
 let marshal_int x = marshal_int32 (Int32.of_int x)
 

--- a/ocaml/xapi-client/tasks.ml
+++ b/ocaml/xapi-client/tasks.ml
@@ -69,7 +69,7 @@ let with_tasks_destroy ~rpc ~session_id ~timeout ~tasks =
           if Client.Task.get_status ~rpc ~session_id ~self:task = `pending then
             Client.Task.cancel ~rpc ~session_id ~task) tasks;
       (* cancel is not immediate, give it a reasonable chance to take effect *)
-      wait_for_all_inner ~rpc ~session_id ~all_timeout:60. ~tasks;
+      wait_for_all_inner ~rpc ~session_id ~all_timeout:60. ~tasks |> ignore;
       false
     end else true
   in

--- a/ocaml/xapi/cli_progress_bar.ml
+++ b/ocaml/xapi/cli_progress_bar.ml
@@ -22,7 +22,7 @@ module Make(T: Floatable) = struct
     max_value: T.t;
     mutable current_value: T.t;
     width: int;
-    line: string;
+    mutable line: string;
     mutable spin_index: int;
     start_time: float;
     mutable summarised: bool;
@@ -62,11 +62,13 @@ module Make(T: Floatable) = struct
 
   let string_of_bar t =
     let w = bar_width t t.current_value in
-    t.line.[1] <- spinner.(t.spin_index);
+    let line = Bytes.of_string t.line in
+    Bytes.set line 1 spinner.(t.spin_index);
     t.spin_index <- (t.spin_index + 1) mod (Array.length spinner);
     for i = 0 to w - 1 do
-      t.line.[prefix + i] <- (if i = w - 1 then '>' else '#')
+      Bytes.set line (prefix + i) (if i = w - 1 then '>' else '#')
     done;
+    t.line <- Bytes.unsafe_to_string line;
     let percent = Printf.sprintf "%3d" (percent t) in
     String.blit percent 0 t.line (t.width - 19) 3;
     let eta = eta t in

--- a/ocaml/xapi/extauth_plugin_ADpbis.ml
+++ b/ocaml/xapi/extauth_plugin_ADpbis.ml
@@ -445,16 +445,17 @@ struct
   let query_subject_information subject_identifier =
 
     let unmap_lw_space_chars lwname =
-      let defensive_copy = String.copy lwname in
+      let defensive_copy = Bytes.of_string lwname in
       (* CA-29006: map chars in names back to original space chars in windows-names *)
       (* we use + as the pbis space-replacement because it's an invalid NT-username char in windows *)
       (* the space-replacement char used by pbis is defined at /etc/pbis/lsassd.conf *)
       let current_lw_space_replacement = '+' in
-      for i = 0 to String.length defensive_copy - 1
-      do
-        if defensive_copy.[i] = current_lw_space_replacement then defensive_copy.[i] <- ' '
-      done;
-      defensive_copy
+      String.iteri (fun i c ->
+        if c = current_lw_space_replacement then
+          Bytes.set defensive_copy i ' '
+        else ()
+      ) lwname;
+      Bytes.unsafe_to_string defensive_copy
     in
     let get_value name ls = if List.mem_assoc name ls then List.assoc name ls else "" in
     let infolist = pbis_get_all_byid subject_identifier in

--- a/ocaml/xapi/record_util.ml
+++ b/ocaml/xapi/record_util.ml
@@ -542,7 +542,7 @@ let domain_type_to_string = function
   | `unspecified -> "unspecified"
 
 let domain_type_of_string x =
-  match String.lowercase x with
+  match String.lowercase_ascii x with
   | "hvm" -> `hvm
   | "pv" -> `pv
   | "pv-in-pvh" -> `pv_in_pvh

--- a/ocaml/xapi/sparse_encoding.ml
+++ b/ocaml/xapi/sparse_encoding.ml
@@ -51,16 +51,11 @@ module Marshal = struct
     and f = (x >>> 40) &&& 0xffL
     and g = (x >>> 48) &&& 0xffL
     and h = (x >>> 56) &&& 0xffL in
-    let result = String.make 8 '\000' in
-    result.[0] <- char_of_int (Int64.to_int a);
-    result.[1] <- char_of_int (Int64.to_int b);
-    result.[2] <- char_of_int (Int64.to_int c);
-    result.[3] <- char_of_int (Int64.to_int d);
-    result.[4] <- char_of_int (Int64.to_int e);
-    result.[5] <- char_of_int (Int64.to_int f);
-    result.[6] <- char_of_int (Int64.to_int g);
-    result.[7] <- char_of_int (Int64.to_int h);
-    result
+    let result = Bytes.make 8 '\000' in
+    List.iteri (fun i v ->
+      Bytes.set result i (char_of_int @@ Int64.to_int v)
+    ) [a; b; c; d; e; f; g; h];
+    Bytes.unsafe_to_string result
   let int32 x =
     let (>>>) a b = Int32.shift_right_logical a b
     and (&&&) a b = Int32.logand a b in
@@ -68,12 +63,11 @@ module Marshal = struct
     and b = (x >>> 8) &&& 0xffl
     and c = (x >>> 16) &&& 0xffl
     and d = (x >>> 24) &&& 0xffl in
-    let result = String.make 4 '\000' in
-    result.[0] <- char_of_int (Int32.to_int a);
-    result.[1] <- char_of_int (Int32.to_int b);
-    result.[2] <- char_of_int (Int32.to_int c);
-    result.[3] <- char_of_int (Int32.to_int d);
-    result
+    let result = Bytes.make 4 '\000' in
+    List.iteri (fun i v ->
+      Bytes.set result i (char_of_int @@ Int32.to_int v)
+    ) [a; b; c; d];
+    Bytes.unsafe_to_string result
 
 end
 

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -79,7 +79,7 @@ let string_of_sm_result f = function
   | SMSuccess x -> Printf.sprintf "Success: %s" (f x)
   | SMFailure e -> Printf.sprintf "Failure: %s" (Printexc.to_string e)
 
-let partition l = List.partition (success ++ snd) l
+let partition l = List.partition (fun (_,x) -> success x) l
 
 let choose x = snd(List.hd x)
 

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -65,7 +65,7 @@ let refresh_internal ~__context ~self =
       (Db.PIF.get_MAC)
       (Db.PIF.set_MAC)
       (fun () -> Net.Interface.get_mac dbg device)
-      (id);
+      (fun x -> x);
 
   maybe_update_database "PCI"
     (Db.PIF.get_PCI)

--- a/ocaml/xapi/xapi_sm.ml
+++ b/ocaml/xapi/xapi_sm.ml
@@ -27,7 +27,7 @@ open Fun
 (* We treat versions as '.'-separated integer lists under the usual
    lexicographic ordering. *)
 type version = int list
-let version_of_string = List.map int_of_string ++ (String.split '.')
+let version_of_string s = List.map int_of_string (String.split_on_char '.' s)
 
 module D=Debug.Make(struct let name="xapi" end)
 open D


### PR DESCRIPTION
This will not solve all the warnings, but it moves slowly in the direction that we need to make xapi safe-string compliant and warning free