### PR TITLE
Convert test_network_event loop_alcotest and avoid calling the firewall script with repeated interfaces

### DIFF
--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -53,7 +53,6 @@ let base_suite =
     Test_network_sriov.test;
     Test_xapi_vbd_helpers.test;
     Test_sr_update_vdis.test;
-    Test_network_event_loop.test;
     Test_network.test;
     Test_host_helpers.test;
   ]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -32,5 +32,6 @@ let () =
     ; "Test_event", Test_event.test
     ; "Test_vm_placement", Test_vm_placement.test
     ; "Test_vm_memory_constraints", Test_vm_memory_constraints.test
+    ; "Test_network_event_loop", Test_network_event_loop.test
     ]
 

--- a/ocaml/tests/test_network_event_loop.ml
+++ b/ocaml/tests/test_network_event_loop.ml
@@ -40,17 +40,18 @@ let test_network_event_loop ~no_nbd_networks_at_start () =
       )
   in
 
+  let param_set = Alcotest.(slist string String.compare) in
+
   let assert_received_params msg expected =
     Thread.delay delay;
     match !received_params with
-    | None -> OUnit.assert_failure ("The update_firewall function was not called: " ^ msg)
-    | Some p ->
-      Ounit_comparators.StringSet.(assert_equal (of_list expected) (of_list p))
+    | None -> Alcotest.fail ("The update_firewall function was not called: " ^ msg)
+    | Some p -> Alcotest.(check param_set) msg expected p
   in
 
   let assert_not_called msg () =
     Thread.delay delay;
-    OUnit.assert_equal ~msg:("update_firewall shouldn't have been called: " ^ msg) None !received_params
+    Alcotest.(check (option param_set)) ("update_firewall shouldn't have been called: " ^ msg) None !received_params
   in
 
   let network1 = Test_common.make_network ~__context ~bridge:"bridge1" () in
@@ -170,8 +171,6 @@ let test_network_event_loop ~no_nbd_networks_at_start () =
   assert_received_params "NBD has been enabled on network4" ["bridge4"]
 
 let test =
-  let ((>:::), (>::)) = OUnit.((>:::), (>::)) in
-  "test_network_event_loop" >:::
-  [ "test_network_event_loop_with_no_networks_at_start" >:: (test_network_event_loop ~no_nbd_networks_at_start:true)
-  ; "test_network_event_loop_with_some_networks_at_start" >:: (test_network_event_loop ~no_nbd_networks_at_start:false)
+  [ "test_network_event_loop_with_no_networks_at_start", `Slow, (test_network_event_loop ~no_nbd_networks_at_start:true)
+  ; "test_network_event_loop_with_some_networks_at_start", `Slow, (test_network_event_loop ~no_nbd_networks_at_start:false)
   ]

--- a/ocaml/xapi/network_event_loop.ml
+++ b/ocaml/xapi/network_event_loop.ml
@@ -57,6 +57,7 @@ let _watch_networks_for_nbd_changes __context ~update_firewall ~wait_after_event
             pifs
         in
         let interfaces = List.map (fun network -> Db.Network.get_bridge ~__context ~self:network) allowed_connected_networks in
+        let interfaces = Xapi_stdext_std.Listext.List.setify interfaces in
         let needs_firewall_update = match allowed_interfaces with
           | Some allowed_interfaces ->
             not (Xapi_stdext_std.Listext.List.set_equiv interfaces allowed_interfaces)


### PR DESCRIPTION
Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>