### PR TITLE
CA-288312: Don't update HOSTNAME in /etc/sysconfig/network

### DIFF
--- a/scripts/set-hostname
+++ b/scripts/set-hostname
@@ -9,9 +9,6 @@ fi
 
 HOSTNAME=$1
 
-# Update system configuration
-sed -i -e "s/^\(HOSTNAME=\).*$/\1$1/g" /etc/sysconfig/network
-
 # Set current hostname
 hostnamectl set-hostname "$HOSTNAME"
 


### PR DESCRIPTION
This is no longer required. The following call to `hostnamectl` sets the
current hostname, and also updates `/etc/hostname` to persist it.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>