### PR TITLE
 CP-27911: Alcotest unit test ports

### DIFF
--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -40,7 +40,6 @@ let base_suite =
     Test_sdn_controller.test;
     Test_extauth_plugin_ADpbis.test;
     Test_guest_agent.test;
-    Test_network_sriov.test;
   ]
 
 let () =

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -41,7 +41,6 @@ let base_suite =
     Test_extauth_plugin_ADpbis.test;
     Test_guest_agent.test;
     Test_network_sriov.test;
-    Test_xapi_vbd_helpers.test;
   ]
 
 let () =

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -42,7 +42,6 @@ let base_suite =
     Test_extauth_plugin_ADpbis.test;
     Test_guest_agent.test;
     Test_tunnel.test;
-    Test_bond.test;
     Test_network_sriov.test;
     Test_xapi_vbd_helpers.test;
   ]

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -36,7 +36,6 @@ let base_suite =
     Test_pool_cpuinfo.test;
     (* Test_ca121350.test; *)
     Test_dbsync_master.test;
-    Test_xapi_xenops.test;
     Test_pvs_server.test;
     Test_pvs_cache_storage.test;
     Test_sdn_controller.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -36,7 +36,6 @@ let base_suite =
     Test_pool_cpuinfo.test;
     (* Test_ca121350.test; *)
     Test_dbsync_master.test;
-    Test_pvs_server.test;
     Test_pvs_cache_storage.test;
     Test_sdn_controller.test;
     Test_extauth_plugin_ADpbis.test;

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -47,7 +47,6 @@ let base_suite =
     Test_network_sriov.test;
     Test_xapi_vbd_helpers.test;
     Test_sr_update_vdis.test;
-    Test_host_helpers.test;
   ]
 
 let () =

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -41,7 +41,6 @@ let base_suite =
     Test_sdn_controller.test;
     Test_extauth_plugin_ADpbis.test;
     Test_guest_agent.test;
-    Test_tunnel.test;
     Test_network_sriov.test;
     Test_xapi_vbd_helpers.test;
   ]

--- a/ocaml/tests/suite.ml
+++ b/ocaml/tests/suite.ml
@@ -45,7 +45,6 @@ let base_suite =
     Test_bond.test;
     Test_network_sriov.test;
     Test_xapi_vbd_helpers.test;
-    Test_sr_update_vdis.test;
   ]
 
 let () =

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -20,6 +20,7 @@ let () =
     ; "Test_db_lowlevel", Test_db_lowlevel.test
     ; "Test_vlan", Test_vlan.test
     ; "Test_network", Test_network.test
+    ; "Test_bond", Test_bond.test
     ; "Test_agility", Test_agility.test
     ; "Test_daemon_manager", Test_daemon_manager.test
     ; "Test_cluster", Test_cluster.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -13,6 +13,7 @@ let () =
     ; "Test_no_migrate", Test_no_migrate.test
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
     ; "Test_host", Test_host.test
+    ; "Test_host_helpers", Test_host_helpers.test
     ; "Test_vdi_cbt", Test_vdi_cbt.test
     ; "Test_xapi_db_upgrade", Test_xapi_db_upgrade.test
     ; "Test_db_lowlevel", Test_db_lowlevel.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -12,6 +12,7 @@ let () =
     ; "Test_vm_migrate", Test_vm_migrate.test
     ; "Test_no_migrate", Test_no_migrate.test
     ; "Test_vm_check_operation_error", Test_vm_check_operation_error.test
+    ; "Test_xapi_vbd_helpers", Test_xapi_vbd_helpers.test
     ; "Test_host", Test_host.test
     ; "Test_host_helpers", Test_host_helpers.test
     ; "Test_vdi_cbt", Test_vdi_cbt.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -40,6 +40,7 @@ let () =
     ; "Test_event", Test_event.test
     ; "Test_vm_placement", Test_vm_placement.test
     ; "Test_vm_memory_constraints", Test_vm_memory_constraints.test
+    ; "Test_xapi_xenops", Test_xapi_xenops.test
     ; "Test_network_event_loop", Test_network_event_loop.test
     ]
 

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -21,6 +21,7 @@ let () =
     ; "Test_vlan", Test_vlan.test
     ; "Test_network", Test_network.test
     ; "Test_bond", Test_bond.test
+    ; "Test_tunnel", Test_tunnel.test
     ; "Test_agility", Test_agility.test
     ; "Test_daemon_manager", Test_daemon_manager.test
     ; "Test_cluster", Test_cluster.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -38,6 +38,7 @@ let () =
     ; "Test_pusb", Test_pusb.test
     ; "Test_pvs_site", Test_pvs_site.test
     ; "Test_pvs_proxy", Test_pvs_proxy.test
+    ; "Test_pvs_server", Test_pvs_server.test
     ; "Test_clustering", Test_clustering.test
     ; "Test_clustering_allowed_operations", Test_clustering_allowed_operations.test
     ; "Test_event", Test_event.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -21,6 +21,7 @@ let () =
     ; "Test_db_lowlevel", Test_db_lowlevel.test
     ; "Test_vlan", Test_vlan.test
     ; "Test_network", Test_network.test
+    ; "Test_network_sriov", Test_network_sriov.test
     ; "Test_bond", Test_bond.test
     ; "Test_tunnel", Test_tunnel.test
     ; "Test_agility", Test_agility.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -15,6 +15,7 @@ let () =
     ; "Test_host", Test_host.test
     ; "Test_host_helpers", Test_host_helpers.test
     ; "Test_vdi_cbt", Test_vdi_cbt.test
+    ; "Test_sr_update_vdis", Test_sr_update_vdis.test
     ; "Test_xapi_db_upgrade", Test_xapi_db_upgrade.test
     ; "Test_db_lowlevel", Test_db_lowlevel.test
     ; "Test_vlan", Test_vlan.test

--- a/ocaml/tests/test_bond.ml
+++ b/ocaml/tests/test_bond.ml
@@ -12,153 +12,150 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
+module T = Test_common
 
-let gen_members = mknlist 2
+let gen_members = T.mknlist 2
 
 let test_create_on_unmanaged_pif () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let create_member = create_physical_pif ~__context ~host ~managed:false in
-  let network = make_network ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let create_member = (T.create_physical_pif ~__context ~host ~managed:false) in
+  let network = T.make_network ~__context () in
   let members = gen_members create_member in
-  assert_raises_api_error
-    Api_errors.pif_unmanaged
-    ~args:[Ref.string_of (List.hd members)]
-    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_on_unmanaged_pif"
+    Api_errors.(Server_error (pif_unmanaged, [Ref.string_of (List.hd members)]))
+    (fun () -> (Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[]) |> ignore )
 
 let test_create_network_already_connected () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
-  let connected_pif = create_physical_pif ~__context ~network ~host () in
-  let create_member = create_physical_pif ~__context ~host in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
+  let connected_pif = T.create_physical_pif ~__context ~network ~host () in
+  let create_member = T.create_physical_pif ~__context ~host in
   let members = gen_members create_member in
-  assert_raises_api_error
-    Api_errors.network_already_connected
-    ~args:[Ref.string_of host; Ref.string_of connected_pif]
-    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_network_already_connected"
+    Api_errors.(Server_error (network_already_connected, [Ref.string_of host; Ref.string_of connected_pif]))
+    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[] |> ignore)
 
 let test_create_member_is_bond_slave () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
   let create_member () =
-    let members = gen_members (create_physical_pif ~__context ~host) in
-    let _ = create_bond_pif ~__context ~host ~members () in
+    let members = gen_members (T.create_physical_pif ~__context ~host) in
+    let _ = T.create_bond_pif ~__context ~host ~members () in
     List.hd members
   in
   let members = gen_members create_member in
-  assert_raises_api_error
-    Api_errors.pif_already_bonded
-    ~args:[Ref.string_of (List.hd members)]
-    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_member_is_bond_slave"
+    Api_errors.(Server_error (pif_already_bonded, [Ref.string_of (List.hd members)]))
+    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[] |> ignore)
 
 let test_create_member_is_vlan_master_on_physical () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
   let create_member () =
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    create_vlan_pif ~__context ~host ~pif:physical_PIF ~vlan:1L ()
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    T.create_vlan_pif ~__context ~host ~pif:physical_PIF ~vlan:1L ()
   in
   let members = gen_members create_member in
-  assert_raises_api_error
-    Api_errors.pif_vlan_exists
-    ~args:[Db.PIF.get_device_name ~__context ~self:(List.hd members)]
-    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_member_is_vlan_master_on_physical"
+    Api_errors.(Server_error (pif_vlan_exists, [Db.PIF.get_device_name ~__context ~self:(List.hd members)]))
+    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[] |> ignore)
 
 let test_create_member_is_vlan_master_on_sriov () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
   let create_member () =
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF () in
-    create_vlan_pif ~__context ~host ~pif:sriov_logical_PIF ~vlan:1L ()
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF () in
+    T.create_vlan_pif ~__context ~host ~pif:sriov_logical_PIF ~vlan:1L ()
   in
   let members = gen_members create_member in
-  assert_raises_api_error
-    Api_errors.pif_vlan_exists
-    ~args:[Db.PIF.get_device_name ~__context ~self:(List.hd members)]
-    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_member_is_vlan_master_on_sriov"
+    Api_errors.(Server_error (pif_vlan_exists, [Db.PIF.get_device_name ~__context ~self:(List.hd members)]))
+    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[] |> ignore)
 
 let test_create_member_is_sriov_logical () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
   let create_member () =
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    create_sriov_pif ~__context ~pif:physical_PIF ()
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    T.create_sriov_pif ~__context ~pif:physical_PIF ()
   in
   let members = gen_members create_member in
-  assert_raises_api_error
-    Api_errors.pif_is_sriov_logical
-    ~args:[Ref.string_of (List.hd members)]
-    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_member_is_sriov_logical"
+    Api_errors.(Server_error (pif_is_sriov_logical, [Ref.string_of (List.hd members)]))
+    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[] |> ignore)
 
 let test_create_member_is_tunnel_access () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
   let create_member () =
-    let transport_PIF = create_physical_pif ~__context ~host () in
-    create_tunnel_pif ~__context ~host ~pif:transport_PIF ()
+    let transport_PIF = T.create_physical_pif ~__context ~host () in
+    T.create_tunnel_pif ~__context ~host ~pif:transport_PIF ()
   in
   let members = gen_members create_member in
-  assert_raises_api_error
-    Api_errors.is_tunnel_access_pif
-    ~args:[Ref.string_of (List.hd members)]
-    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_member_is_tunnel_access"
+    Api_errors.(Server_error (is_tunnel_access_pif, [Ref.string_of (List.hd members)]))
+    (fun () -> Xapi_bond.create ~__context ~network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[] |> ignore)
 
 let test_create_bond_into_sriov_network () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_network =
-    let host = make_host ~__context () in
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF () in
+    let host = T.make_host ~__context () in
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF () in
     Db.PIF.get_network ~__context ~self:sriov_logical_PIF
   in
   let members =
-    let host = make_host ~__context () in
-    let create_member = create_physical_pif ~__context ~host in
+    let host = T.make_host ~__context () in
+    let create_member = T.create_physical_pif ~__context ~host in
     gen_members create_member
   in
-  assert_raises_api_error
-    Api_errors.network_incompatible_with_bond
-    ~args:[Ref.string_of sriov_network]
-    (fun () -> Xapi_bond.create ~__context ~network:sriov_network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_bond_into_sriov_network"
+    Api_errors.(Server_error (network_incompatible_with_bond, [Ref.string_of sriov_network]))
+    (fun () -> Xapi_bond.create ~__context ~network:sriov_network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[] |> ignore)
 
 let test_create_bond_into_sriov_vlan_network () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_vlan_network =
-    let host = make_host ~__context () in
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF () in
-    let vlan_pif = create_vlan_pif ~__context ~host ~vlan:1L ~pif:sriov_logical_PIF () in
+    let host = T.make_host ~__context () in
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF () in
+    let vlan_pif = T.create_vlan_pif ~__context ~host ~vlan:1L ~pif:sriov_logical_PIF () in
     Db.PIF.get_network ~__context ~self:vlan_pif
   in
   let members =
-    let host = make_host ~__context () in
-    let create_member = create_physical_pif ~__context ~host in
+    let host = T.make_host ~__context () in
+    let create_member = T.create_physical_pif ~__context ~host in
     gen_members create_member
   in
-  assert_raises_api_error
-    Api_errors.network_incompatible_with_bond
-    ~args:[Ref.string_of sriov_vlan_network]
-    (fun () -> Xapi_bond.create ~__context ~network:sriov_vlan_network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[])
+  Alcotest.check_raises
+    "test_create_bond_into_sriov_vlan_network"
+    Api_errors.(Server_error (network_incompatible_with_bond, [Ref.string_of sriov_vlan_network]))
+    (fun () -> Xapi_bond.create ~__context ~network:sriov_vlan_network ~members ~mAC:"ff:ff:ff:ff:ff:ff" ~mode:`activebackup ~properties:[] |> ignore)
 
 let test =
-  "test_bond" >:::
-  [
-    "test_create_on_unmanaged_pif" >:: test_create_on_unmanaged_pif;
-    "test_create_network_already_connected" >:: test_create_network_already_connected;
-    "test_create_member_is_bond_slave" >:: test_create_member_is_bond_slave;
-    "test_create_member_is_vlan_master_on_physical" >:: test_create_member_is_vlan_master_on_physical;
-    "test_create_member_is_vlan_master_on_sriov" >:: test_create_member_is_vlan_master_on_sriov;
-    "test_create_member_is_sriov_logical" >:: test_create_member_is_sriov_logical;
-    "test_create_member_is_tunnel_access" >:: test_create_member_is_tunnel_access;
-    "test_create_bond_into_sriov_network" >:: test_create_bond_into_sriov_network;
-    "test_create_bond_into_sriov_vlan_network" >:: test_create_bond_into_sriov_vlan_network;
+  [ "test_create_on_unmanaged_pif", `Quick, test_create_on_unmanaged_pif
+  ; "test_create_network_already_connected", `Quick, test_create_network_already_connected
+  ; "test_create_member_is_bond_slave", `Quick, test_create_member_is_bond_slave
+  ; "test_create_member_is_vlan_master_on_physical", `Quick, test_create_member_is_vlan_master_on_physical
+  ; "test_create_member_is_vlan_master_on_sriov", `Quick, test_create_member_is_vlan_master_on_sriov
+  ; "test_create_member_is_sriov_logical", `Quick, test_create_member_is_sriov_logical
+  ; "test_create_member_is_tunnel_access", `Quick, test_create_member_is_tunnel_access
+  ; "test_create_bond_into_sriov_network", `Quick, test_create_bond_into_sriov_network
+  ; "test_create_bond_into_sriov_vlan_network", `Quick, test_create_bond_into_sriov_vlan_network
   ]

--- a/ocaml/tests/test_network_sriov.ml
+++ b/ocaml/tests/test_network_sriov.ml
@@ -12,228 +12,254 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
+module T = Test_common
 
 let test_create_internal () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let physical_PIF = create_physical_pif ~__context ~host () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let physical_PIF = T.create_physical_pif ~__context ~host () in
   let physical_rec = Db.PIF.get_record ~__context ~self:physical_PIF in
-  let network = make_network ~__context ~bridge:"xapi0" () in
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
   let sriov, logical_PIF = Xapi_network_sriov.create_internal ~__context ~physical_PIF ~physical_rec ~network in
-  assert_equal sriov (List.hd (Db.PIF.get_sriov_physical_PIF_of ~__context ~self:physical_PIF));
-  assert_equal sriov (List.hd (Db.PIF.get_sriov_logical_PIF_of ~__context ~self:logical_PIF));
-  assert_equal physical_PIF (Db.Network_sriov.get_physical_PIF ~__context ~self:sriov);
-  assert_equal logical_PIF (Db.Network_sriov.get_logical_PIF ~__context ~self:sriov);
-  assert_equal network (Db.PIF.get_network ~__context ~self:logical_PIF);
-  assert_equal host (Db.PIF.get_host ~__context ~self:logical_PIF)
+  Alcotest.check Alcotest_comparators.(ref ())
+    "test_create_internal sriov_ physical_PIF"
+    sriov
+    (List.hd (Db.PIF.get_sriov_physical_PIF_of ~__context ~self:physical_PIF));
+  Alcotest.check Alcotest_comparators.(ref ())
+    "test_create_internal sriov_logical_PIF"
+    sriov
+    (List.hd (Db.PIF.get_sriov_logical_PIF_of ~__context ~self:logical_PIF));
+  Alcotest.check Alcotest_comparators.(ref ())
+    "test_create_internal physical_PIF"
+    physical_PIF
+    (Db.Network_sriov.get_physical_PIF ~__context ~self:sriov);
+  Alcotest.check Alcotest_comparators.(ref ())
+    "test_create_internal logical_PIF"
+    logical_PIF
+    (Db.Network_sriov.get_logical_PIF ~__context ~self:sriov);
+  Alcotest.check Alcotest_comparators.(ref ())
+    "test_create_internal network"
+    network
+    (Db.PIF.get_network ~__context ~self:logical_PIF);
+  Alcotest.check Alcotest_comparators.(ref ())
+    "test_create_internal host"
+    host
+    (Db.PIF.get_host ~__context ~self:logical_PIF)
 
 let test_create_on_unmanaged_pif () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let physical_PIF = create_physical_pif ~__context ~host ~managed:false () in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.pif_unmanaged
-    ~args:[Ref.string_of physical_PIF]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif:physical_PIF ~network)
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let physical_PIF = T.create_physical_pif ~__context ~host ~managed:false () in
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_unmanaged_pif"
+    Api_errors.(Server_error (pif_unmanaged, [Ref.string_of physical_PIF]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif:physical_PIF ~network |> ignore)
 
 let test_create_network_already_connected () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
-  let physical_PIF = create_physical_pif ~__context ~host ~network () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
+  let physical_PIF = T.create_physical_pif ~__context ~host ~network () in
   Db.PIF.set_capabilities ~__context ~self:physical_PIF ~value:["sriov"];
-  assert_raises_api_error
-    Api_errors.network_already_connected
-    ~args:[Ref.string_of host; Ref.string_of physical_PIF]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif:physical_PIF ~network)
+  Alcotest.check_raises
+    "test_create_network_already_connected"
+    Api_errors.(Server_error (network_already_connected, [Ref.string_of host; Ref.string_of physical_PIF]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif:physical_PIF ~network |> ignore)
 
 let test_create_on_bond_master () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let pif =
-    let members = mknlist 2 (create_physical_pif ~__context ~host) in
-    create_bond_pif ~__context ~host ~members ()
+    let members = T.mknlist 2 (T.create_physical_pif ~__context ~host) in
+    T.create_bond_pif ~__context ~host ~members ()
   in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.pif_is_not_physical
-    ~args:[Ref.string_of pif]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_bond_master"
+    Api_errors.(Server_error (pif_is_not_physical, [Ref.string_of pif]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_create_on_tunnel_access () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let pif =
-    let transport_PIF = create_physical_pif ~__context ~host () in
-    create_tunnel_pif ~__context ~host ~pif:transport_PIF ()
+    let transport_PIF = T.create_physical_pif ~__context ~host () in
+    T.create_tunnel_pif ~__context ~host ~pif:transport_PIF ()
   in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.pif_is_not_physical
-    ~args:[Ref.string_of pif]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_tunnel_access"
+    Api_errors.(Server_error (pif_is_not_physical, [Ref.string_of pif]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_create_on_sriov_logical () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let pif =
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    create_sriov_pif ~__context ~pif:physical_PIF ()
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    T.create_sriov_pif ~__context ~pif:physical_PIF ()
   in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.pif_is_not_physical
-    ~args:[Ref.string_of pif]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_sriov_logical"
+    Api_errors.(Server_error (pif_is_not_physical, [Ref.string_of pif]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_create_on_vlan () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let pif =
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    create_vlan_pif ~__context ~host ~vlan:1L ~pif:physical_PIF ()
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    T.create_vlan_pif ~__context ~host ~vlan:1L ~pif:physical_PIF ()
   in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.pif_is_not_physical
-    ~args:[Ref.string_of pif]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_vlan"
+    Api_errors.(Server_error (pif_is_not_physical, [Ref.string_of pif]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_create_on_vlan_on_sriov_logical () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let pif =
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF () in
-    create_vlan_pif ~__context ~host ~vlan:1L ~pif:sriov_logical_PIF ()
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF () in
+    T.create_vlan_pif ~__context ~host ~vlan:1L ~pif:sriov_logical_PIF ()
   in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.pif_is_not_physical
-    ~args:[Ref.string_of pif]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_vlan_on_sriov_logical"
+    Api_errors.(Server_error (pif_is_not_physical, [Ref.string_of pif]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_create_on_pif_already_enabled_sriov () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let pif =
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    let _ = create_sriov_pif ~__context ~pif:physical_PIF () in
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    let _ = T.create_sriov_pif ~__context ~pif:physical_PIF () in
     physical_PIF
   in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.network_sriov_already_enabled
-    ~args:[Ref.string_of pif]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_pif_already_enabled_sriov"
+    Api_errors.(Server_error (network_sriov_already_enabled, [Ref.string_of pif]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_create_on_pif_not_have_sriov_capability () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let pif = create_physical_pif ~__context ~host () in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.pif_is_not_sriov_capable
-    ~args:[Ref.string_of pif]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let pif = T.create_physical_pif ~__context ~host () in
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_pif_not_have_sriov_capability"
+    Api_errors.(Server_error (pif_is_not_sriov_capable, [Ref.string_of pif]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_create_on_network_not_compatible_sriov () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context ~bridge:"xapi0" () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
   let _ =
     (* attach non sriov PIF to the network *)
-    let host = make_host ~__context () in
-    create_physical_pif ~__context ~host ~network ()
+    let host = T.make_host ~__context () in
+    T.create_physical_pif ~__context ~host ~network ()
   in
-  let pif = create_physical_pif ~__context ~host () in
+  let pif = T.create_physical_pif ~__context ~host () in
   Db.PIF.set_capabilities ~__context ~self:pif ~value:["sriov"];
-  assert_raises_api_error
-    Api_errors.network_incompatible_with_sriov
-    ~args:[Ref.string_of network]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  Alcotest.check_raises
+    "test_create_on_network_not_compatible_sriov"
+    Api_errors.(Server_error (network_incompatible_with_sriov, [Ref.string_of network]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_create_sriov_with_different_pci_type_into_one_network () =
-  let __context = make_test_database () in
-  let network = make_network ~__context ~bridge:"xapi0" () in
+  let __context = T.make_test_database () in
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
   let _ =
     (* attach sriov PIF to the network *)
-    let host = make_host ~__context () in
+    let host = T.make_host ~__context () in
     let physical_PIF =
-      let pif = create_physical_pif ~__context ~host ~network () in
+      let pif = T.create_physical_pif ~__context ~host ~network () in
       Db.PIF.set_capabilities ~__context ~self:pif ~value:["sriov"];
-      let pci = make_pci ~__context ~vendor_id:"101" ~device_id:"2" () in
+      let pci = T.make_pci ~__context ~vendor_id:"101" ~device_id:"2" () in
       Db.PIF.set_PCI ~__context ~self:pif ~value:pci;
       pif
     in
-    create_sriov_pif ~__context ~pif:physical_PIF ~network ()
+    T.create_sriov_pif ~__context ~pif:physical_PIF ~network ()
   in
   let pif =
-    let host = make_host ~__context () in
-    let pif = create_physical_pif ~__context ~host () in
+    let host = T.make_host ~__context () in
+    let pif = T.create_physical_pif ~__context ~host () in
     Db.PIF.set_capabilities ~__context ~self:pif ~value:["sriov"];
-    let pci = make_pci ~__context ~vendor_id:"99" ~device_id:"1" () in
+    let pci = T.make_pci ~__context ~vendor_id:"99" ~device_id:"1" () in
     Db.PIF.set_PCI ~__context ~self:pif ~value:pci;
     pif
   in
   Db.PIF.set_capabilities ~__context ~self:pif ~value:["sriov"];
-  assert_raises_api_error
-    Api_errors.network_has_incompatible_sriov_pifs
-    ~args:[Ref.string_of pif; Ref.string_of network]
-    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network)
+  Alcotest.check_raises
+    "test_create_sriov_with_different_pci_type_into_one_network"
+    Api_errors.(Server_error (network_has_incompatible_sriov_pifs, [Ref.string_of pif; Ref.string_of network]))
+    (fun () -> Xapi_network_sriov.create ~__context ~pif ~network |> ignore)
 
 let test_require_operation_on_pci_device_not_attached_not_need_reboot () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_logical_PIF, sriov=
-    let host = make_host ~__context () in
-    let network = make_network ~__context ~bridge:"xapi0" () in
-    let physical_PIF = create_physical_pif ~__context ~host ~network () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF ~network () in
+    let host = T.make_host ~__context () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
+    let physical_PIF = T.create_physical_pif ~__context ~host ~network () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF ~network () in
     Db.PIF.set_currently_attached ~__context ~self:sriov_logical_PIF ~value:false;
     let sriov = List.hd (Db.PIF.get_sriov_logical_PIF_of ~__context ~self:sriov_logical_PIF) in
     Db.Network_sriov.set_requires_reboot ~__context ~self:sriov ~value:false;
     sriov_logical_PIF, sriov
   in
-  assert_equal false (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_not_attached_not_need_reboot"
+    false
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 let test_require_operation_on_pci_device_sysfs () =
   (* Need operate pci device when Network_sriov.configuration_mode = `sysfs *)
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_logical_PIF, sriov =
-    let host = make_host ~__context () in
-    let network = make_network ~__context ~bridge:"xapi0" () in
-    let physical_PIF = create_physical_pif ~__context ~host ~network () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF ~network () in
+    let host = T.make_host ~__context () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
+    let physical_PIF = T.create_physical_pif ~__context ~host ~network () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF ~network () in
     Db.PIF.set_currently_attached ~__context ~self:sriov_logical_PIF ~value:true;
     let sriov = List.hd (Db.PIF.get_sriov_logical_PIF_of ~__context ~self:sriov_logical_PIF) in
     Db.Network_sriov.set_requires_reboot ~__context ~self:sriov ~value:false;
     Db.Network_sriov.set_configuration_mode ~__context ~self:sriov ~value:`sysfs;
     sriov_logical_PIF, sriov
   in
-  assert_equal true (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_sysfs"
+    true
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 let test_require_operation_on_pci_device_unknown () =
   (* Need not operate pci device when Network_sriov.configuration_mode = `Unknown *)
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_logical_PIF, sriov =
-    let host = make_host ~__context () in
-    let network = make_network ~__context ~bridge:"xapi0" () in
-    let physical_PIF = create_physical_pif ~__context ~host ~network () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF ~network () in
+    let host = T.make_host ~__context () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
+    let physical_PIF = T.create_physical_pif ~__context ~host ~network () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF ~network () in
     Db.PIF.set_currently_attached ~__context ~self:sriov_logical_PIF ~value:true;
     let sriov = List.hd (Db.PIF.get_sriov_logical_PIF_of ~__context ~self:sriov_logical_PIF) in
     Db.Network_sriov.set_requires_reboot ~__context ~self:sriov ~value:false;
     Db.Network_sriov.set_configuration_mode ~__context ~self:sriov ~value:`unknown;
     sriov_logical_PIF, sriov
   in
-  assert_equal false (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_unknown"
+    false
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 let create_physical_pif_with_driver ~__context ~host ~network ?(driver_name="") () =
-  let physical_PIF = create_physical_pif ~__context ~host ~network () in
-  let pci = make_pci ~__context ~vendor_id:"99" ~device_id:"1" ~driver_name () in
+  let physical_PIF = T.create_physical_pif ~__context ~host ~network () in
+  let pci = T.make_pci ~__context ~vendor_id:"99" ~device_id:"1" ~driver_name () in
   Db.PIF.set_PCI ~__context ~self:physical_PIF ~value:pci;
   physical_PIF
 
@@ -242,41 +268,47 @@ let test_require_operation_on_pci_device_modprobe_0 () =
   (* No other sriov has same driver with me.
      I am currently attached.
      So operate the device.*)
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_logical_PIF, sriov =
-    let host = make_host ~__context () in
-    let network = make_network ~__context ~bridge:"xapi0" () in
+    let host = T.make_host ~__context () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
     let physical_PIF = create_physical_pif_with_driver ~__context ~host ~network () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF ~network () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF ~network () in
     Db.PIF.set_currently_attached ~__context ~self:sriov_logical_PIF ~value:true;
     let sriov = List.hd (Db.PIF.get_sriov_logical_PIF_of ~__context ~self:sriov_logical_PIF) in
     Db.Network_sriov.set_requires_reboot ~__context ~self:sriov ~value:false;
     Db.Network_sriov.set_configuration_mode ~__context ~self:sriov ~value:`modprobe;
     sriov_logical_PIF, sriov
   in
-  assert_equal true (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_modprobe_0"
+    true
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 let test_require_operation_on_pci_device_modprobe_1 () =
   (* No other sriov has same driver with me.
      I am not currently attached but will enable after reboot
      So operate the device.*)
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_logical_PIF, sriov =
-    let host = make_host ~__context () in
-    let network = make_network ~__context ~bridge:"xapi0" () in
+    let host = T.make_host ~__context () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
     let physical_PIF = create_physical_pif_with_driver ~__context ~host ~network () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF ~network () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF ~network () in
     Db.PIF.set_currently_attached ~__context ~self:sriov_logical_PIF ~value:false;
     let sriov = List.hd (Db.PIF.get_sriov_logical_PIF_of ~__context ~self:sriov_logical_PIF) in
     Db.Network_sriov.set_requires_reboot ~__context ~self:sriov ~value:true;
     Db.Network_sriov.set_configuration_mode ~__context ~self:sriov ~value:`modprobe;
     sriov_logical_PIF, sriov
   in
-  assert_equal true (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_modprobe_1"
+    true
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 let create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached ~requires_reboot =
   let physical_PIF = create_physical_pif_with_driver ~__context ~host ~network ~driver_name () in
-  let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF ~network () in
+  let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF ~network () in
   Db.PIF.set_currently_attached ~__context ~self:sriov_logical_PIF ~value:currently_attached;
   let sriov = List.hd (Db.PIF.get_sriov_logical_PIF_of ~__context ~self:sriov_logical_PIF) in
   Db.Network_sriov.set_requires_reboot ~__context ~self:sriov ~value:requires_reboot;
@@ -287,93 +319,103 @@ let test_require_operation_on_pci_device_modprobe_2 () =
   (* There are 1 other sriov has same driver name with me.
      I am currently attached but the other one is not currently attached and do not require reboot.
      So operate the device. *)
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let driver_name = "mock_driver" in
   let _ =
-    let network = make_network ~__context ~bridge:"xapi0" () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
     create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached:false ~requires_reboot:false
   in
   let sriov_logical_PIF, sriov =
-    let network = make_network ~__context ~bridge:"xapi1" () in
+    let network = T.make_network ~__context ~bridge:"xapi1" () in
     create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached:true ~requires_reboot:false
   in
-  assert_equal true (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_modprobe_2"
+    true
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 let test_require_operation_on_pci_device_modprobe_3 () =
   (* There are 1 other sriov has same driver name with me.
      I am currently attached and the other one is currently attached.
      So do NOT operate the device. *)
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let driver_name = "mock_driver" in
   let _ =
-    let network = make_network ~__context ~bridge:"xapi0" () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
     create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached:true ~requires_reboot:false
   in
   let sriov_logical_PIF, sriov =
-    let network = make_network ~__context ~bridge:"xapi1" () in
+    let network = T.make_network ~__context ~bridge:"xapi1" () in
     create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached:true ~requires_reboot:false
   in
-  assert_equal false (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_modprobe_3"
+    false
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 let test_require_operation_on_pci_device_modprobe_4 () =
   (* There are 1 other sriov has same driver name with me.
      I am NOT currently attached but require reboot. The other one is NOT currently attached and NOT require reboot.
      So operate the device.*)
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let driver_name = "mock_driver" in
   let _ =
-    let network = make_network ~__context ~bridge:"xapi0" () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
     create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached:false ~requires_reboot:false
   in
   let sriov_logical_PIF, sriov =
-    let network = make_network ~__context ~bridge:"xapi1" () in
+    let network = T.make_network ~__context ~bridge:"xapi1" () in
     create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached:false ~requires_reboot:true
   in
-  assert_equal true (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_modprobe_4"
+    true
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 let test_require_operation_on_pci_device_modprobe_5 () =
   (* There are 1 other sriov has same driver name with me.
      I am NOT currently attached and require reboot. The other one is NOT currently attached but require reboot.
      So do NOT operate the device. *)
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let driver_name = "mock_driver" in
   let _ =
-    let network = make_network ~__context ~bridge:"xapi0" () in
+    let network = T.make_network ~__context ~bridge:"xapi0" () in
     create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached:false ~requires_reboot:true
   in
   let sriov_logical_PIF, sriov =
-    let network = make_network ~__context ~bridge:"xapi1" () in
+    let network = T.make_network ~__context ~bridge:"xapi1" () in
     create_modprobe_sriov_logical_pif_with_driver ~__context ~host ~network ~driver_name ~currently_attached:false ~requires_reboot:true
   in
-  assert_equal false (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
+  Alcotest.(check bool)
+    "test_require_operation_on_pci_device_modprobe_5"
+    false
+    (Xapi_network_sriov_helpers.require_operation_on_pci_device ~__context ~sriov ~self:sriov_logical_PIF)
 
 
 let test =
-  "test_network_sriov" >:::
-  [
-    "test_create_internal" >:: test_create_internal;
-    "test_create_on_unmanaged_pif" >:: test_create_on_unmanaged_pif;
-    "test_create_network_already_connected" >:: test_create_network_already_connected;
-    "test_create_on_bond_master" >:: test_create_on_bond_master;
-    "test_create_on_tunnel_access" >:: test_create_on_tunnel_access;
-    "test_create_on_sriov_logical" >:: test_create_on_sriov_logical;
-    "test_create_on_vlan" >:: test_create_on_vlan;
-    "test_create_on_vlan_on_sriov_logical" >:: test_create_on_vlan_on_sriov_logical;
-    "test_create_on_pif_already_enabled_sriov" >:: test_create_on_pif_already_enabled_sriov;
-    "test_create_on_pif_not_have_sriov_capability" >:: test_create_on_pif_not_have_sriov_capability;
-    "test_create_on_network_not_compatible_sriov" >:: test_create_on_network_not_compatible_sriov;
-    "test_create_sriov_with_different_pci_type_into_one_network" >:: test_create_sriov_with_different_pci_type_into_one_network;
-    "test_require_operation_on_pci_device_not_attached_not_need_reboot" >:: test_require_operation_on_pci_device_not_attached_not_need_reboot;
-    "test_require_operation_on_pci_device_sysfs" >:: test_require_operation_on_pci_device_sysfs;
-    "test_require_operation_on_pci_device_unknown" >:: test_require_operation_on_pci_device_unknown;
-    "test_require_operation_on_pci_device_modprobe_0" >:: test_require_operation_on_pci_device_modprobe_0;
-    "test_require_operation_on_pci_device_modprobe_1" >:: test_require_operation_on_pci_device_modprobe_1;
-    "test_require_operation_on_pci_device_modprobe_2" >:: test_require_operation_on_pci_device_modprobe_2;
-    "test_require_operation_on_pci_device_modprobe_3" >:: test_require_operation_on_pci_device_modprobe_3;
-    "test_require_operation_on_pci_device_modprobe_4" >:: test_require_operation_on_pci_device_modprobe_4;
-    "test_require_operation_on_pci_device_modprobe_5" >:: test_require_operation_on_pci_device_modprobe_5;
+  [ "test_create_internal", `Quick, test_create_internal
+  ; "test_create_on_unmanaged_pif", `Quick, test_create_on_unmanaged_pif
+  ; "test_create_network_already_connected", `Quick, test_create_network_already_connected
+  ; "test_create_on_bond_master", `Quick, test_create_on_bond_master
+  ; "test_create_on_tunnel_access", `Quick, test_create_on_tunnel_access
+  ; "test_create_on_sriov_logical", `Quick, test_create_on_sriov_logical
+  ; "test_create_on_vlan", `Quick, test_create_on_vlan
+  ; "test_create_on_vlan_on_sriov_logical", `Quick, test_create_on_vlan_on_sriov_logical
+  ; "test_create_on_pif_already_enabled_sriov", `Quick, test_create_on_pif_already_enabled_sriov
+  ; "test_create_on_pif_not_have_sriov_capability", `Quick, test_create_on_pif_not_have_sriov_capability
+  ; "test_create_on_network_not_compatible_sriov", `Quick, test_create_on_network_not_compatible_sriov
+  ; "test_create_sriov_with_different_pci_type_into_one_network", `Quick, test_create_sriov_with_different_pci_type_into_one_network
+  ; "test_require_operation_on_pci_device_not_attached_not_need_reboot", `Quick, test_require_operation_on_pci_device_not_attached_not_need_reboot
+  ; "test_require_operation_on_pci_device_sysfs", `Quick, test_require_operation_on_pci_device_sysfs
+  ; "test_require_operation_on_pci_device_unknown", `Quick, test_require_operation_on_pci_device_unknown
+  ; "test_require_operation_on_pci_device_modprobe_0", `Quick, test_require_operation_on_pci_device_modprobe_0
+  ; "test_require_operation_on_pci_device_modprobe_1", `Quick, test_require_operation_on_pci_device_modprobe_1
+  ; "test_require_operation_on_pci_device_modprobe_2", `Quick, test_require_operation_on_pci_device_modprobe_2
+  ; "test_require_operation_on_pci_device_modprobe_3", `Quick, test_require_operation_on_pci_device_modprobe_3
+  ; "test_require_operation_on_pci_device_modprobe_4", `Quick, test_require_operation_on_pci_device_modprobe_4
+  ; "test_require_operation_on_pci_device_modprobe_5", `Quick, test_require_operation_on_pci_device_modprobe_5
   ]

--- a/ocaml/tests/test_pvs_server.ml
+++ b/ocaml/tests/test_pvs_server.ml
@@ -12,164 +12,188 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
+module T = Test_common
 
 let test_unlicensed () =
   let addresses = ["10.80.12.34"] in
   let first_port = 1234L in
   let last_port = 5678L in
-  let __context = make_test_database ~features:[] () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
-  assert_raises
+  let __context = T.make_test_database ~features:[] () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
+  Alcotest.check_raises
+    "test_unlicensed"
     Api_errors.(Server_error (license_restriction, ["PVS_proxy"]))
     (fun () ->
        Xapi_pvs_server.introduce ~__context
-         ~addresses ~first_port ~last_port ~site:valid_site)
+         ~addresses ~first_port ~last_port ~site:valid_site
+    |> ignore)
 
 let test_introduce_ok () =
   let addresses = ["10.80.12.34"] in
   let first_port = 1234L in
   let last_port = 5678L in
-  let __context = make_test_database () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
+  let __context = T.make_test_database () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
   let pvs_server = Xapi_pvs_server.introduce ~__context
       ~addresses ~first_port ~last_port ~site:valid_site
   in
-  assert_equal valid_site
+  Alcotest.check (Alcotest_comparators.ref ())
+    "test_introduce_ok: valid_site"
+    valid_site
     (Db.PVS_server.get_site ~__context ~self:pvs_server);
-  assert_equal addresses
+  Alcotest.(check (slist string compare))
+    "test_introduce_ok: addresses"
+    addresses
     (Db.PVS_server.get_addresses ~__context ~self:pvs_server);
-  assert_equal first_port
+  Alcotest.(check int64)
+    "test_introduce_ok: first_port"
+    first_port
     (Db.PVS_server.get_first_port ~__context ~self:pvs_server);
-  assert_equal last_port
+  Alcotest.(check int64)
+    "test_introduce_ok: last_port"
+    last_port
     (Db.PVS_server.get_last_port ~__context ~self:pvs_server)
 
 let test_introduce_duplicate_addresses () =
   let addresses = ["10.80.12.34"; "10.80.12.34"] in
   let first_port = 1234L in
   let last_port = 5678L in
-  let __context = make_test_database () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
+  let __context = T.make_test_database () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
   let pvs_server = Xapi_pvs_server.introduce ~__context
       ~addresses ~first_port ~last_port ~site:valid_site
   in
-  assert_equal ["10.80.12.34"]
+  Alcotest.(check (slist string compare))
+    "test_introduce_duplicate_addresses"
+    ["10.80.12.34"]
     (Db.PVS_server.get_addresses ~__context ~self:pvs_server)
 
 let test_introduce_multiple_addresses () =
   let addresses = ["10.80.12.34"; "10.80.12.35"] in
   let first_port = 1234L in
   let last_port = 5678L in
-  let __context = make_test_database () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
+  let __context = T.make_test_database () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
   let pvs_server = Xapi_pvs_server.introduce ~__context
       ~addresses ~first_port ~last_port ~site:valid_site
   in
-  assert_equal ["10.80.12.34"; "10.80.12.35"]
+  Alcotest.(check (slist string compare))
+    "test_introduce_multiple_addresses"
+    ["10.80.12.34"; "10.80.12.35"]
     (Db.PVS_server.get_addresses ~__context ~self:pvs_server)
 
 let test_introduce_invalid_address () =
   let addresses = ["123.456"] in
   let first_port = 1234L in
   let last_port = 5678L in
-  let __context = make_test_database () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
-  assert_raises_api_error
-    ~args:["addresses"]
-    Api_errors.invalid_ip_address_specified
+  let __context = T.make_test_database () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
+  Alcotest.check_raises
+    "test_introduce_invalid_address"
+    Api_errors.(Server_error (invalid_ip_address_specified, ["addresses"]))
     (fun () -> Xapi_pvs_server.introduce ~__context
-        ~addresses ~first_port ~last_port ~site:valid_site)
+        ~addresses ~first_port ~last_port ~site:valid_site
+    |> ignore)
 
 let test_introduce_invalid_site () =
   let addresses = ["10.80.12.34"] in
   let first_port = 1234L in
   let last_port = 5678L in
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let invalid_site = Ref.make () in
-  assert_raises_api_error
-    ~args:["site"; Ref.string_of invalid_site]
-    Api_errors.invalid_value
+  Alcotest.check_raises
+    "test_introduce_invalid_site"
+    Api_errors.(Server_error (invalid_value, ["site"; Ref.string_of invalid_site]))
     (fun () -> Xapi_pvs_server.introduce ~__context
-        ~addresses ~first_port ~last_port ~site:invalid_site)
+        ~addresses ~first_port ~last_port ~site:invalid_site
+    |> ignore)
 
 let test_introduce_invalid_low_port () =
   let addresses = ["10.80.12.34"] in
   let first_port = -5L in
   let last_port = 5678L in
-  let __context = make_test_database () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
-  assert_raises_api_error
-    Api_errors.value_not_supported
-    ~args:["first_port"; "-5"; "Port out of range"]
+  let __context = T.make_test_database () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
+  Alcotest.check_raises
+    "test_introduce_invalid_low_port"
+    Api_errors.(Server_error (value_not_supported, ["first_port"; "-5"; "Port out of range"]))
     (fun () -> Xapi_pvs_server.introduce ~__context
-        ~addresses ~first_port ~last_port ~site:valid_site)
+        ~addresses ~first_port ~last_port ~site:valid_site
+    |> ignore)
 
 let test_introduce_invalid_high_port () =
   let addresses = ["10.80.12.34"] in
   let first_port = 1234L in
   let last_port = 345678L in
-  let __context = make_test_database () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
-  assert_raises_api_error
-    Api_errors.value_not_supported
-    ~args:["last_port"; "345678"; "Port out of range"]
+  let __context = T.make_test_database () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
+  Alcotest.check_raises
+    "test_introduce_invalid_high_port"
+    Api_errors.(Server_error (value_not_supported, ["last_port"; "345678"; "Port out of range"]))
     (fun () -> Xapi_pvs_server.introduce ~__context
-        ~addresses ~first_port ~last_port ~site:valid_site)
+        ~addresses ~first_port ~last_port ~site:valid_site
+    |> ignore)
 
 let test_introduce_invalid_ports () =
   let addresses = ["10.80.12.34"] in
   let first_port = 5678L in
   let last_port = 1234L in
-  let __context = make_test_database () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
-  assert_raises_api_error
-    Api_errors.value_not_supported
-    ~args:["last_port"; "1234"; "last_port smaller than first_port"]
+  let __context = T.make_test_database () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
+  Alcotest.check_raises
+    "test_introduce_invalid_ports"
+    Api_errors.(Server_error (value_not_supported, ["last_port"; "1234"; "last_port smaller than first_port"]))
     (fun () -> Xapi_pvs_server.introduce ~__context
-        ~addresses ~first_port ~last_port ~site:valid_site)
+        ~addresses ~first_port ~last_port ~site:valid_site
+    |> ignore)
 
 let test_forget () =
   let addresses = ["10.80.12.34"] in
   let first_port = 1234L in
   let last_port = 5678L in
-  let __context = make_test_database () in
-  let valid_site = make_pvs_site ~__context ~name_label:"site" () in
+  let __context = T.make_test_database () in
+  let valid_site = T.make_pvs_site ~__context ~name_label:"site" () in
   let pvs_server = Xapi_pvs_server.introduce ~__context
       ~addresses ~first_port ~last_port ~site:valid_site
   in
   Xapi_pvs_server.forget ~__context ~self:pvs_server;
-  assert_equal (Db.is_valid_ref __context pvs_server) false
+  Alcotest.(check bool)
+    "test_forget"
+    false (Db.is_valid_ref __context pvs_server)
 
 let test_gc () =
   let addresses = ["10.80.12.34"] in
   let first_port = 1234L in
   let last_port = 5678L in
-  let __context = make_test_database () in
-  let site = make_pvs_site ~__context ~name_label:"site" () in
+  let __context = T.make_test_database () in
+  let site = T.make_pvs_site ~__context ~name_label:"site" () in
   let server = Xapi_pvs_server.introduce ~__context
       ~addresses ~first_port ~last_port ~site
   in
   ( Db_gc_util.gc_PVS_servers ~__context
-  ; assert_equal (Db.PVS_server.get_site ~__context ~self:server) site
+  ; Alcotest.check (Alcotest_comparators.ref ())
+      "test_gc: PVS site"
+      site
+      (Db.PVS_server.get_site ~__context ~self:server)
   ; Db.PVS_server.set_site ~__context ~self:server ~value:Ref.null
   ; Db_gc_util.gc_PVS_servers ~__context (* should collect the server *)
-  ; assert_equal false (Db.is_valid_ref __context server)
+  ; Alcotest.(check bool)
+      "test_gc: PVS server is valid ref"
+      false
+      (Db.is_valid_ref __context server)
   )
 
 
 let test =
-  "test_pvs_server" >:::
-  [
-    "test_unlicensed" >:: test_unlicensed;
-    "test_introduce_ok" >:: test_introduce_ok;
-    "test_introduce_duplicate_addresses" >:: test_introduce_duplicate_addresses;
-    "test_introduce_multiple_addresses" >:: test_introduce_multiple_addresses;
-    "test_introduce_invalid_address" >:: test_introduce_invalid_address;
-    "test_introduce_invalid_site" >:: test_introduce_invalid_site;
-    "test_introduce_invalid_low_port" >:: test_introduce_invalid_low_port;
-    "test_introduce_invalid_high_port" >:: test_introduce_invalid_high_port;
-    "test_introduce_invalid_ports" >:: test_introduce_invalid_ports;
-    "test_gc" >:: test_gc;
-    "test_forget" >:: test_forget;
+  [ "test_unlicensed", `Quick, test_unlicensed
+  ; "test_introduce_ok", `Quick, test_introduce_ok
+  ; "test_introduce_duplicate_addresses", `Quick, test_introduce_duplicate_addresses
+  ; "test_introduce_multiple_addresses", `Quick, test_introduce_multiple_addresses
+  ; "test_introduce_invalid_address", `Quick, test_introduce_invalid_address
+  ; "test_introduce_invalid_site", `Quick, test_introduce_invalid_site
+  ; "test_introduce_invalid_low_port", `Quick, test_introduce_invalid_low_port
+  ; "test_introduce_invalid_high_port", `Quick, test_introduce_invalid_high_port
+  ; "test_introduce_invalid_ports", `Quick, test_introduce_invalid_ports
+  ; "test_gc", `Quick, test_gc
+  ; "test_forget", `Quick, test_forget
   ]

--- a/ocaml/tests/test_tunnel.ml
+++ b/ocaml/tests/test_tunnel.ml
@@ -12,139 +12,152 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
-
+module T = Test_common
 
 let test_create_internal () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
-  let transport_PIF = make_pif ~__context ~network ~host () in
-  let network = make_network ~__context ~bridge:"xapi0" () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
+  let transport_PIF = T.make_pif ~__context ~network ~host () in
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
   let tunnel, access_PIF = Xapi_tunnel.create_internal ~__context ~transport_PIF ~network ~host in
-  assert_equal tunnel (List.hd (Db.PIF.get_tunnel_access_PIF_of ~__context ~self:access_PIF));
-  assert_equal tunnel (List.hd (Db.PIF.get_tunnel_transport_PIF_of ~__context ~self:transport_PIF));
-  assert_equal transport_PIF (Db.Tunnel.get_transport_PIF ~__context ~self:tunnel);
-  assert_equal access_PIF (Db.Tunnel.get_access_PIF ~__context ~self:tunnel);
-  assert_equal network (Db.PIF.get_network ~__context ~self:access_PIF);
-  assert_equal host (Db.PIF.get_host ~__context ~self:access_PIF)
+
+  Alcotest.check (Alcotest_comparators.ref ())
+    "get tunnel access PIF"
+    tunnel
+    (List.hd (Db.PIF.get_tunnel_access_PIF_of ~__context ~self:access_PIF));
+  Alcotest.check (Alcotest_comparators.ref ())
+    "get tunnel transport PIF"
+    tunnel
+    (List.hd (Db.PIF.get_tunnel_transport_PIF_of ~__context ~self:transport_PIF));
+  Alcotest.check (Alcotest_comparators.ref ())
+    "get transport PIF"
+    transport_PIF
+    (Db.Tunnel.get_transport_PIF ~__context ~self:tunnel);
+  Alcotest.check (Alcotest_comparators.ref ())
+    "get access PIF"
+    access_PIF
+    (Db.Tunnel.get_access_PIF ~__context ~self:tunnel);
+  Alcotest.check (Alcotest_comparators.ref ())
+    "get network"
+    network
+    (Db.PIF.get_network ~__context ~self:access_PIF);
+  Alcotest.check (Alcotest_comparators.ref ())
+    "get host"
+    host
+    (Db.PIF.get_host ~__context ~self:access_PIF)
 
 let test_create_on_unmanaged_pif () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let transport_PIF = create_physical_pif ~__context ~host ~managed:false () in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.pif_unmanaged
-    ~args:[Ref.string_of transport_PIF]
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network)
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let transport_PIF = T.create_physical_pif ~__context ~host ~managed:false () in
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_unmanaged_pif"
+    Api_errors.(Server_error (pif_unmanaged, [Ref.string_of transport_PIF]))
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network |> ignore)
 
 let test_create_network_already_connected () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let network = make_network ~__context () in
-  let transport_PIF = create_physical_pif ~__context ~host ~network ~managed:false () in
-  assert_raises_api_error
-    Api_errors.network_already_connected
-    ~args:[Ref.string_of host; Ref.string_of transport_PIF]
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network)
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let network = T.make_network ~__context () in
+  let transport_PIF = T.create_physical_pif ~__context ~host ~network ~managed:false () in
+  Alcotest.check_raises
+    "test_create_network_already_connected"
+    Api_errors.(Server_error (network_already_connected, [Ref.string_of host; Ref.string_of transport_PIF]))
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network |> ignore)
 
 let test_create_on_bond_slave () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
   let transport_PIF =
-    let members = mknlist 2 (create_physical_pif ~__context ~host) in
-    let _ = create_bond_pif ~__context ~host ~members () in
+    let members = T.mknlist 2 (T.create_physical_pif ~__context ~host) in
+    let _ = T.create_bond_pif ~__context ~host ~members () in
     List.hd members
   in
-  let network = make_network ~__context ~bridge:"xapi0" () in
-  assert_raises_api_error
-    Api_errors.cannot_add_tunnel_to_bond_slave
-    ~args:[Ref.string_of transport_PIF]
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network)
+  let network = T.make_network ~__context ~bridge:"xapi0" () in
+  Alcotest.check_raises
+    "test_create_on_bond_slave"
+    Api_errors.(Server_error (cannot_add_tunnel_to_bond_slave, [Ref.string_of transport_PIF]))
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network |> ignore)
 
 let test_create_on_tunnel_access () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let transport_PIF = create_physical_pif ~__context ~host () in
-  let access_PIF = create_tunnel_pif ~__context ~host ~pif:transport_PIF () in
-  let network = make_network ~__context ~bridge:"xapi1" () in
-  assert_raises_api_error
-    Api_errors.is_tunnel_access_pif
-    ~args:[Ref.string_of access_PIF]
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:access_PIF ~network)
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let transport_PIF = T.create_physical_pif ~__context ~host () in
+  let access_PIF = T.create_tunnel_pif ~__context ~host ~pif:transport_PIF () in
+  let network = T.make_network ~__context ~bridge:"xapi1" () in
+  Alcotest.check_raises
+    "test_create_on_tunnel_access"
+    Api_errors.(Server_error (is_tunnel_access_pif, [Ref.string_of access_PIF]))
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:access_PIF ~network |> ignore)
 
 let test_create_on_sriov_logical () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let physical_PIF = create_physical_pif ~__context ~host () in
-  let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF () in
-  let network = make_network ~__context ~bridge:"xapi01" () in
-  assert_raises_api_error
-    Api_errors.cannot_add_tunnel_to_sriov_logical
-    ~args:[Ref.string_of sriov_logical_PIF]
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:sriov_logical_PIF ~network)
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let physical_PIF = T.create_physical_pif ~__context ~host () in
+  let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF () in
+  let network = T.make_network ~__context ~bridge:"xapi01" () in
+  Alcotest.check_raises
+    "test_create_on_sriov_logical"
+    Api_errors.(Server_error (cannot_add_tunnel_to_sriov_logical, [Ref.string_of sriov_logical_PIF]))
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:sriov_logical_PIF ~network |> ignore)
 
 let test_create_on_vlan_on_sriov_logical () =
-  let __context = make_test_database () in
-  let host = make_host ~__context () in
-  let physical_PIF = create_physical_pif ~__context ~host () in
-  let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF () in
-  let transport_PIF = create_vlan_pif ~__context ~host ~pif:sriov_logical_PIF ~vlan:1L () in
-  let network = make_network ~__context ~bridge:"xapi01" () in
-  assert_raises_api_error
-    Api_errors.cannot_add_tunnel_to_vlan_on_sriov_logical
-    ~args:[Ref.string_of transport_PIF]
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network)
+  let __context = T.make_test_database () in
+  let host = T.make_host ~__context () in
+  let physical_PIF = T.create_physical_pif ~__context ~host () in
+  let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF () in
+  let transport_PIF = T.create_vlan_pif ~__context ~host ~pif:sriov_logical_PIF ~vlan:1L () in
+  let network = T.make_network ~__context ~bridge:"xapi01" () in
+  Alcotest.check_raises
+    "test_create_on_vlan_on_sriov_logical"
+    Api_errors.(Server_error (cannot_add_tunnel_to_vlan_on_sriov_logical, [Ref.string_of transport_PIF]))
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network |> ignore)
 
 let test_create_tunnel_into_sriov_network () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_network =
-    let host = make_host ~__context () in
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF () in
+    let host = T.make_host ~__context () in
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF () in
     Db.PIF.get_network ~__context ~self:sriov_logical_PIF
   in
   let pif =
-    let host = make_host ~__context () in
-    create_physical_pif ~__context ~host ()
+    let host = T.make_host ~__context () in
+    T.create_physical_pif ~__context ~host ()
   in
-  assert_raises_api_error
-    Api_errors.network_incompatible_with_tunnel
-    ~args:[Ref.string_of sriov_network]
-    (fun () ->
-       Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_network)
+  Alcotest.check_raises
+    "test_create_tunnel_into_sriov_network"
+    Api_errors.(Server_error (network_incompatible_with_tunnel, [Ref.string_of sriov_network]))
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_network |> ignore)
 
 let test_create_tunnel_into_sriov_vlan_network () =
-  let __context = make_test_database () in
+  let __context = T.make_test_database () in
   let sriov_vlan_network =
-    let host = make_host ~__context () in
-    let physical_PIF = create_physical_pif ~__context ~host () in
-    let sriov_logical_PIF = create_sriov_pif ~__context ~pif:physical_PIF () in
-    let vlan_pif = create_vlan_pif ~__context ~host ~vlan:1L ~pif:sriov_logical_PIF () in
+    let host = T.make_host ~__context () in
+    let physical_PIF = T.create_physical_pif ~__context ~host () in
+    let sriov_logical_PIF = T.create_sriov_pif ~__context ~pif:physical_PIF () in
+    let vlan_pif = T.create_vlan_pif ~__context ~host ~vlan:1L ~pif:sriov_logical_PIF () in
     Db.PIF.get_network ~__context ~self:vlan_pif
   in
   let pif =
-    let host = make_host ~__context () in
-    create_physical_pif ~__context ~host ()
+    let host = T.make_host ~__context () in
+    T.create_physical_pif ~__context ~host ()
   in
-  assert_raises_api_error
-    Api_errors.network_incompatible_with_tunnel
-    ~args:[Ref.string_of sriov_vlan_network]
-    (fun () ->
-       Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_vlan_network)
+  Alcotest.check_raises
+    "test_create_tunnel_into_sriov_vlan_network"
+    Api_errors.(Server_error (network_incompatible_with_tunnel, [Ref.string_of sriov_vlan_network]))
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_vlan_network |> ignore)
 
 let test =
-  "test_tunnel" >:::
-  [
-    "test_create_internal" >:: test_create_internal;
-    "test_create_on_unmanaged_pif" >:: test_create_on_unmanaged_pif;
-    "test_create_network_already_connected" >:: test_create_network_already_connected;
-    "test_create_on_bond_slave" >:: test_create_on_bond_slave;
-    "test_create_on_tunnel_access" >:: test_create_on_tunnel_access;
-    "test_create_on_sriov_logical" >:: test_create_on_sriov_logical;
-    "test_create_on_vlan_on_sriov_logical" >:: test_create_on_vlan_on_sriov_logical;
-    "test_create_tunnel_into_sriov_network" >:: test_create_tunnel_into_sriov_network;
-    "test_create_tunnel_into_sriov_vlan_network" >:: test_create_tunnel_into_sriov_vlan_network;
+  [ "test_create_internal", `Quick, test_create_internal
+  ; "test_create_on_unmanaged_pif", `Quick, test_create_on_unmanaged_pif
+  ; "test_create_network_already_connected", `Quick, test_create_network_already_connected
+  ; "test_create_on_bond_slave", `Quick, test_create_on_bond_slave
+  ; "test_create_on_tunnel_access", `Quick, test_create_on_tunnel_access
+  ; "test_create_on_sriov_logical", `Quick, test_create_on_sriov_logical
+  ; "test_create_on_vlan_on_sriov_logical", `Quick, test_create_on_vlan_on_sriov_logical
+  ; "test_create_tunnel_into_sriov_network", `Quick, test_create_tunnel_into_sriov_network
+  ; "test_create_tunnel_into_sriov_vlan_network", `Quick, test_create_tunnel_into_sriov_vlan_network
   ]

--- a/ocaml/tests/test_xapi_vbd_helpers.ml
+++ b/ocaml/tests/test_xapi_vbd_helpers.ml
@@ -12,48 +12,44 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open OUnit
-open Test_common
+module T = Test_common
 
 (* Helpers for testing Xapi_vbd_helpers.valid_operations *)
 
 let setup_test ~__context ~vdi_fun =
-  let _sm_ref = make_sm ~__context () in
-  let sr_ref = make_sr ~__context () in
-  let (_: API.ref_PBD) = make_pbd ~__context ~sR:sr_ref () in
-  let vm_ref = make_vm ~__context () in
+  let _sm_ref = T.make_sm ~__context () in
+  let sr_ref = T.make_sr ~__context () in
+  let (_: API.ref_PBD) = T.make_pbd ~__context ~sR:sr_ref () in
+  let vm_ref = T.make_vm ~__context () in
   let vdi_ref = vdi_fun sr_ref in
-  let vbd_ref = make_vbd ~vDI:vdi_ref ~vM:vm_ref ~__context () in
+  let vbd_ref = T.make_vbd ~vDI:vdi_ref ~vM:vm_ref ~__context () in
   let vbd_record = Db.VBD.get_record_internal ~__context ~self:vbd_ref in
   vbd_ref, vbd_record
 
-let my_cmp a b = match a,b with
-  | Some(code1, _), Some(code2, _) -> code1 = code2
-  | None, None -> true
-  | _	-> false
-
-let string_of_api_exn_opt = function
-  | None -> "None"
-  | Some (code, args) ->
-    Printf.sprintf "Some (%s, [%s])" code (String.concat "; " args)
-
-let run_assert_equal_with_vdi ~__context ?(cmp = my_cmp) ?(expensive_sharing_checks=true) ~vdi_fun op exc =
+let run_assert_equal_with_vdi ~__context msg ?(expensive_sharing_checks=true) ~vdi_fun op expected_error_if_any =
   let vbd_ref, vbd_record = setup_test ~__context ~vdi_fun in
-  assert_equal
-    ~cmp
-    ~printer:string_of_api_exn_opt
-    exc (Hashtbl.find (Xapi_vbd_helpers.valid_operations ~__context ~expensive_sharing_checks vbd_record vbd_ref) op)
+  let get_error_code_of op =
+    let valid_ops = (Xapi_vbd_helpers.valid_operations ~__context ~expensive_sharing_checks vbd_record vbd_ref) in
+    match Hashtbl.find valid_ops op with
+    | Some (code, _ ) -> Some code
+    | None -> None
+  in
+  Alcotest.(check (option string))
+    msg
+    expected_error_if_any
+    (get_error_code_of op)
 
 (* These are to test Xapi_vbd_helpers.valid_operations against CA-253933 *)
 let test_ca253933_invalid_operations () =
   let __context = Mock.make_context_with_new_db "Mock context" in
-  (* When attach a VDI which is under operation which cannot perform live, should raise other_operation_in_progress *)
+  (* When attaching a VDI which is currently under operation that cannot perform live, should raise other_operation_in_progress *)
   let invalid_operations =  [`resize ; `destroy ; `forget ; `update ; `force_unlock ; `generate_config; `snapshot; `resize_online; `blocked; `clone] in
   let operation_is_invalid op =
     run_assert_equal_with_vdi ~__context
-      ~vdi_fun:(fun sr_ref ->
-          make_vdi ~sR:sr_ref ~__context ~managed:true ~current_operations:[("x", op)] ())
-      `attach (Some(Api_errors.other_operation_in_progress, []))
+      "test_ca253933_invalid_operations"
+      ~vdi_fun:(fun sr_ref -> T.make_vdi ~sR:sr_ref ~__context ~managed:true ~current_operations:[("x", op)] ())
+      `attach
+      (Some Api_errors.other_operation_in_progress)
   in List.iter operation_is_invalid invalid_operations
 
 let test_ca253933_valid_operations () =
@@ -62,15 +58,14 @@ let test_ca253933_valid_operations () =
   let valid_operations = [`mirror; `copy] in
   let operation_is_valid op =
     run_assert_equal_with_vdi ~__context
-      ~vdi_fun:(fun sr_ref ->
-          make_vdi ~sR:sr_ref ~__context ~managed:true ~current_operations:[("x", op)] ())
-      `attach None
+      "test_ca253933_valid_operations"
+      ~vdi_fun:(fun sr_ref -> T.make_vdi ~sR:sr_ref ~__context ~managed:true ~current_operations:[("x", op)] ())
+      `attach
+      None
   in List.iter operation_is_valid valid_operations
 
 let test =
-  "test_xapi_vbd_helpers" >:::
-  [
-    "test_ca253933_invalid_operations" >:: test_ca253933_invalid_operations;
-    "test_ca253933_valid_operations" >:: test_ca253933_valid_operations;
+  [ "test_ca253933_invalid_operations" , `Quick, test_ca253933_invalid_operations
+  ; "test_ca253933_valid_operations" , `Quick, test_ca253933_valid_operations
   ]
 

--- a/ocaml/tests/test_xapi_xenops.ml
+++ b/ocaml/tests/test_xapi_xenops.ml
@@ -1,4 +1,3 @@
-open OUnit
 open Test_common
 open Test_vgpu_common
 
@@ -129,12 +128,12 @@ let test_xapi_restart_inner () =
     in
     let assert_correct_state (vm, running) =
       let name = Db.VM.get_name_label ~__context ~self:vm in
-      assert_bool
+      Alcotest.(check bool)
         (Printf.sprintf "State is correct in xapi (%s)" name)
-        (running = (is_resident vm));
-      assert_bool
+        running (is_resident vm);
+      Alcotest.(check bool)
         (Printf.sprintf "State is correct in xenopsd (%s)" name)
-        (running = (is_running_in_xenopsd vm))
+        running (is_running_in_xenopsd vm)
     in
 
     List.iter (fun vm -> assert_correct_state (vm, true)) [vm1; vm2; vm3; vm4; vm5; vm6; vm7];
@@ -245,9 +244,7 @@ let test_nested_virt_licensing () =
 
 
 let test =
-  "test_xapi_xenops" >:::
-  [
-    "test_nested_virt_licensing" >:: test_nested_virt_licensing;
-    "test_enabled_in_xenguest" >:: test_enabled_in_xenguest;
-    "test_xapi_restart" >:: test_xapi_restart;
+  [ "test_nested_virt_licensing", `Quick, test_nested_virt_licensing
+  ; "test_enabled_in_xenguest", `Quick, test_enabled_in_xenguest
+  ; "test_xapi_restart", `Quick, test_xapi_restart
   ]


### PR DESCRIPTION
Porting the remaining OUnit tests that don't use test_highlevel, as this will require a separate port.