### PR TITLE
CA-289140: fix host boot when run concurrently with SR.forget

### DIFF
--- a/ocaml/xapi/create_storage.ml
+++ b/ocaml/xapi/create_storage.ml
@@ -34,7 +34,7 @@ let plug_all_pbds __context =
          else Xapi_pbd.plug ~__context ~self
        with e ->
          result := false;
-         error "Could not plug in pbd '%s': %s" (Db.PBD.get_uuid ~__context ~self) (Printexc.to_string e))
+         error "Could not plug in pbd '%s': %s" pbd_record.API.pBD_uuid (Printexc.to_string e))
     my_pbds;
   !result
 

--- a/ocaml/xapi/create_storage.ml
+++ b/ocaml/xapi/create_storage.ml
@@ -32,7 +32,10 @@ let plug_all_pbds __context =
          if pbd_record.API.pBD_currently_attached
          then debug "Not replugging PBD %s: already plugged in" (Ref.string_of self)
          else Xapi_pbd.plug ~__context ~self
-       with e ->
+       with
+       | Db_exn.DBCache_NotFound(_, "PBD", _) as e ->
+           debug "Ignoring PBD/SR that got deleted before we plugged it: %s" (Printexc.to_string e)
+       | e ->
          result := false;
          error "Could not plug in pbd '%s': %s" pbd_record.API.pBD_uuid (Printexc.to_string e))
     my_pbds;

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -1366,6 +1366,7 @@ let resynchronise_pbds ~__context ~pbds =
   debug "Currently-attached SRs: [ %s ]" (String.concat "; " srs);
   List.iter
     (fun self ->
+     try
        let sr = Db.SR.get_uuid ~__context ~self:(Db.PBD.get_SR ~__context ~self) in
        let value = List.mem sr srs in
        debug "Setting PBD %s currently_attached <- %b" (Ref.string_of self) value;
@@ -1377,6 +1378,9 @@ let resynchronise_pbds ~__context ~pbds =
          error "Service implementing SR %s has failed. Performing emergency reset of SR state" sr;
          Client.SR.reset (Ref.string_of dbg) sr;
          Db.PBD.set_currently_attached ~__context ~self ~value:false;
+     with Db_exn.DBCache_NotFound(_, ("PBD"|"SR"), _) as e ->
+       debug "Ignoring PBD/SR that got deleted before we resynchronised: %s" (Printexc.to_string e)
+
     ) pbds
 
 (* -------------------------------------------------------------------------------- *)


### PR DESCRIPTION
In CA-289140 I've run SR.forget on a shared SR at the same time as another host was booting in the pool. That host did a `Helpers.get_my_pbds`, got a list of PBDs, then SR.forget ran and deleted a PBD, followed by an exception when `plug_all_pbds` tried to plug the PBD that no longer existed.

Ignoring not found errors on PBD plug on startup would avoid these race conditions. Another possibility would be to block the SR.forget itself while any host is booting via `blocked_operatiosn`, but that would risk the operation to be blocked forever if a host fails to boot completely (e.g. crashes).