### PR TITLE
Speed up update_all_allowed_operations: VDI

### DIFF
--- a/ocaml/xapi/cancel_tasks.ml
+++ b/ocaml/xapi/cancel_tasks.ml
@@ -56,7 +56,9 @@ let update_all_allowed_operations ~__context =
       let pbd_records = List.map (fun pbd -> (pbd, Db.PBD.get_record ~__context ~self:pbd)) all_pbds in
       let vbd_records = List.map (fun vbd -> (vbd, Db.VBD.get_record_internal ~__context ~self:vbd)) all_vbds in
       List.iter (safe_wrapper "allowed_ops - VDIs"
-                   (fun self -> Xapi_vdi.update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records ~vbd_records)) all_vdis;
+                   (fun self ->
+                    let relevant_vbds = List.filter (fun (_, vbd_record) -> vbd_record.Db_actions.vBD_VDI = self) vbd_records in
+                   Xapi_vdi.update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records ~vbd_records:relevant_vbds)) all_vdis;
       debug "Finished updating allowed operations: VDI");
   (* SR *)
   time_this "Cancel_tasks.update_all_allowed_operations: SR" (fun () ->


### PR DESCRIPTION
Speed up VDI allowed operations checks with this one weird trick! This is the performance speedup the perf team don't want you to see!

Tested on a pool with ~15000 VDIs and ~15000 VBDs

Before: 
```
May  2 13:35:12 xrtmia-07-26 xapi: [debug|xrtmia-07-26|0 |dbsync (update_env) R:89bd2ce97526|dbsync] Updating allowed operations: VDI
May  2 13:42:53 xrtmia-07-26 xapi: [debug|xrtmia-07-26|0 |dbsync (update_env) R:89bd2ce97526|dbsync] Finished updating allowed operations: VDI
```
(461 seconds)

After:
```
May  2 13:46:59 xrtmia-07-26 xapi: [debug|xrtmia-07-26|0 |dbsync (update_env) R:37ad9661e80b|dbsync] Updating allowed operations: VDI
May  2 13:47:36 xrtmia-07-26 xapi: [debug|xrtmia-07-26|0 |dbsync (update_env) R:37ad9661e80b|dbsync] Finished updating allowed operations: VDI
```
(37 seconds)

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>