### PR TITLE
CA-275120: XenAPI methods only callable by SM are publicly visible

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2016,7 +2016,7 @@ module SR = struct
       ~flags:[`Session]
       ~doc:"Sets the SR's virtual_allocation field"
       ~hide_from_docs:true
-      ~allowed_roles:_R_POOL_OP
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let set_physical_size = call
@@ -2039,7 +2039,7 @@ module SR = struct
                Int, "value", "The new value of the SR's physical utilisation"]
       ~doc:"Sets the SR's physical_utilisation field"
       ~hide_from_docs:true
-      ~allowed_roles:_R_POOL_OP
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let update = call
@@ -2374,7 +2374,7 @@ module VDI = struct
       ~allowed_roles:_R_VM_ADMIN
       ()
 
-  let db_introduce = { pool_introduce with msg_name = "db_introduce"; msg_hide_from_docs = true }
+  let db_introduce = { pool_introduce with msg_name = "db_introduce"; msg_hide_from_docs = true; msg_allowed_roles = _R_LOCAL_ROOT_ONLY }
 
   let db_forget = call
       ~name:"db_forget"
@@ -2383,7 +2383,7 @@ module VDI = struct
       ~doc:"Removes a VDI record from the database"
       ~hide_from_docs:true
       ~in_product_since:rel_miami
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let introduce = call
@@ -2457,7 +2457,7 @@ module VDI = struct
       ~doc:"Sets the VDI's missing field"
       ~hide_from_docs:true
       ~flags:[`Session]
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let set_read_only = call
@@ -2491,7 +2491,7 @@ module VDI = struct
       ~flags:[`Session]
       ~doc:"Sets the VDI's managed field"
       ~hide_from_docs:true
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let set_virtual_size = call
@@ -2503,7 +2503,7 @@ module VDI = struct
       ~flags:[`Session]
       ~doc:"Sets the VDI's virtual_size field"
       ~hide_from_docs:true
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let set_physical_utilisation = call
@@ -2515,7 +2515,7 @@ module VDI = struct
       ~flags:[`Session]
       ~doc:"Sets the VDI's physical_utilisation field"
       ~hide_from_docs:true
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let set_is_a_snapshot = call
@@ -2527,7 +2527,7 @@ module VDI = struct
       ~flags:[`Session]
       ~doc:"Sets whether this VDI is a snapshot"
       ~hide_from_docs:true
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let set_snapshot_of = call
@@ -2539,7 +2539,7 @@ module VDI = struct
       ~flags:[`Session]
       ~doc:"Sets the VDI of which this VDI is a snapshot"
       ~hide_from_docs:true
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let set_snapshot_time = call
@@ -2551,7 +2551,7 @@ module VDI = struct
       ~flags:[`Session]
       ~doc:"Sets the snapshot time of this VDI."
       ~hide_from_docs:true
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let set_metadata_of_pool = call
@@ -2563,7 +2563,7 @@ module VDI = struct
       ~flags:[`Session]
       ~doc:"Records the pool whose metadata is contained by this VDI."
       ~hide_from_docs:true
-      ~allowed_roles:_R_VM_ADMIN
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   (** An API call for debugging and testing only *)

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2381,6 +2381,7 @@ module VDI = struct
       ~in_oss_since:None
       ~params:[Ref _vdi, "vdi", "The VDI to forget about"]
       ~doc:"Removes a VDI record from the database"
+      ~hide_from_docs:true
       ~in_product_since:rel_miami
       ~allowed_roles:_R_VM_ADMIN
       ()

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2374,7 +2374,7 @@ module VDI = struct
       ~allowed_roles:_R_VM_ADMIN
       ()
 
-  let db_introduce = { pool_introduce with msg_name = "db_introduce"; hide_from_docs = true }
+  let db_introduce = { pool_introduce with msg_name = "db_introduce"; msg_hide_from_docs = true }
 
   let db_forget = call
       ~name:"db_forget"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2015,6 +2015,7 @@ module SR = struct
                Int, "value", "The new value of the SR's virtual_allocation"]
       ~flags:[`Session]
       ~doc:"Sets the SR's virtual_allocation field"
+      ~hide_from_docs:true
       ~allowed_roles:_R_POOL_OP
       ()
 
@@ -2037,6 +2038,7 @@ module SR = struct
       ~params:[Ref _sr, "self", "The SR to modify";
                Int, "value", "The new value of the SR's physical utilisation"]
       ~doc:"Sets the SR's physical_utilisation field"
+      ~hide_from_docs:true
       ~allowed_roles:_R_POOL_OP
       ()
 
@@ -2372,7 +2374,7 @@ module VDI = struct
       ~allowed_roles:_R_VM_ADMIN
       ()
 
-  let db_introduce = { pool_introduce with msg_name = "db_introduce"; msg_hide_from_docs = false }
+  let db_introduce = { pool_introduce with msg_name = "db_introduce"; hide_from_docs = true }
 
   let db_forget = call
       ~name:"db_forget"
@@ -2452,6 +2454,7 @@ module VDI = struct
       ~params:[Ref _vdi, "self", "The VDI to modify";
                Bool, "value", "The new value of the VDI's missing field"]
       ~doc:"Sets the VDI's missing field"
+      ~hide_from_docs:true
       ~flags:[`Session]
       ~allowed_roles:_R_VM_ADMIN
       ()
@@ -2486,6 +2489,7 @@ module VDI = struct
                Bool, "value", "The new value of the VDI's managed field"]
       ~flags:[`Session]
       ~doc:"Sets the VDI's managed field"
+      ~hide_from_docs:true
       ~allowed_roles:_R_VM_ADMIN
       ()
 
@@ -2497,6 +2501,7 @@ module VDI = struct
                Int, "value", "The new value of the VDI's virtual size"]
       ~flags:[`Session]
       ~doc:"Sets the VDI's virtual_size field"
+      ~hide_from_docs:true
       ~allowed_roles:_R_VM_ADMIN
       ()
 
@@ -2508,6 +2513,7 @@ module VDI = struct
                Int, "value", "The new value of the VDI's physical utilisation"]
       ~flags:[`Session]
       ~doc:"Sets the VDI's physical_utilisation field"
+      ~hide_from_docs:true
       ~allowed_roles:_R_VM_ADMIN
       ()
 
@@ -2519,6 +2525,7 @@ module VDI = struct
                Bool, "value", "The new value indicating whether this VDI is a snapshot"]
       ~flags:[`Session]
       ~doc:"Sets whether this VDI is a snapshot"
+      ~hide_from_docs:true
       ~allowed_roles:_R_VM_ADMIN
       ()
 
@@ -2530,6 +2537,7 @@ module VDI = struct
                Ref _vdi, "value", "The VDI of which this VDI is a snapshot"]
       ~flags:[`Session]
       ~doc:"Sets the VDI of which this VDI is a snapshot"
+      ~hide_from_docs:true
       ~allowed_roles:_R_VM_ADMIN
       ()
 
@@ -2541,6 +2549,7 @@ module VDI = struct
                DateTime, "value", "The snapshot time of this VDI."]
       ~flags:[`Session]
       ~doc:"Sets the snapshot time of this VDI."
+      ~hide_from_docs:true
       ~allowed_roles:_R_VM_ADMIN
       ()
 
@@ -2552,6 +2561,7 @@ module VDI = struct
                Ref _pool, "value", "The pool whose metadata is contained by this VDI"]
       ~flags:[`Session]
       ~doc:"Records the pool whose metadata is contained by this VDI."
+      ~hide_from_docs:true
       ~allowed_roles:_R_VM_ADMIN
       ()
 


### PR DESCRIPTION
There are some calls, such as VDI.db_introduce and SR.set_physical_utilisation, that are publicly visible, but can only be called by SM, because we call Sm.assert_session_has_internal_sr_access in message forwarding for these functions. We should make these hidden by setting hide_from_docs to true in the datamodel. Going through all of the 'should be hidden' APIs is outside the scope of this ticket. This ticket only concerns hiding the public SR and VDI function that are only callable by SM.

Please refer to the ticket for more discussion.