### PR TITLE
CP-27172: Implement Host.destroy integration with clustering daemon

### DIFF
--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -152,6 +152,11 @@ let t =
           ~ty:(Set (Ref _cluster_host)) "cluster_hosts"
           "A list of the cluster_host objects associated with the Cluster"
 
+      ; field ~qualifier:DynamicRO ~lifecycle:[ Prototyped, rel_lima, "" ]
+          ~ty:(Set String) "pending_forget" ~default_value:(Some (VSet []))
+          "Internal field used by Host.destroy to store the IP of cluster members \
+           marked as permanently dead but not yet removed"
+
       ; field   ~qualifier:StaticRO ~lifecycle
           ~ty:String "cluster_token" ~default_value:(Some (VString ""))
           "The secret key used by xapi-clusterd when it talks to itself on other hosts"

--- a/ocaml/idl/datamodel_cluster_host.ml
+++ b/ocaml/idl/datamodel_cluster_host.ml
@@ -66,6 +66,17 @@ let disable = call
     ~allowed_roles:_R_POOL_ADMIN
     ()
 
+let forget = call
+  ~name:"forget"
+  ~doc:"Permanently remove a dead host from the cluster. This host must never rejoin the cluster."
+  ~params:
+      [ Ref _cluster_host, "self", "the cluster_host to declare permanently dead and forget"
+      ]
+  ~lifecycle:[Prototyped, rel_lima, ""]
+  ~allowed_roles:_R_LOCAL_ROOT_ONLY
+  ~hide_from_docs:true
+  ()
+
 let t =
   create_obj
     ~name: _cluster_host
@@ -111,6 +122,7 @@ let t =
       ; destroy
       ; enable
       ; force_destroy
+      ; forget
       ; disable
       ]
     ()

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 200
+let schema_minor_vsn = 201
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/xapi/db_gc_util.ml
+++ b/ocaml/xapi/db_gc_util.ml
@@ -110,6 +110,13 @@ let gc_VIFs ~__context =
 let gc_PBDs ~__context =
   gc_connector ~__context Db.PBD.get_all Db.PBD.get_record (fun x->valid_ref __context x.pBD_host) (fun x->valid_ref __context x.pBD_SR) Db.PBD.destroy
 
+let gc_Cluster_hosts ~__context =
+  gc_connector ~__context Db.Cluster_host.get_all Db.Cluster_host.get_record
+    (fun x -> valid_ref __context x.cluster_host_host)
+    (* TODO: a PIF after https://github.com/xapi-project/xen-api/pull/3585 *)
+    (fun x -> true)
+    Db.Cluster_host.destroy
+
 let gc_VGPUs ~__context =
   gc_connector ~__context Db.VGPU.get_all Db.VGPU.get_record (fun x->valid_ref __context x.vGPU_VM) (fun x->valid_ref __context x.vGPU_GPU_group)
     (fun ~__context ~self ->
@@ -400,6 +407,7 @@ let timeout_alerts ~__context =
 let gc_subtask_list = [
     "VDIs", gc_VDIs;
     "PIFs", gc_PIFs;
+    "Cluster_host", gc_Cluster_hosts;
     "VBDs", gc_VBDs;
     "crashdumps", gc_crashdumps;
     "VIFs", gc_VIFs;

--- a/ocaml/xapi/db_gc_util.ml
+++ b/ocaml/xapi/db_gc_util.ml
@@ -113,8 +113,7 @@ let gc_PBDs ~__context =
 let gc_Cluster_hosts ~__context =
   gc_connector ~__context Db.Cluster_host.get_all Db.Cluster_host.get_record
     (fun x -> valid_ref __context x.cluster_host_host)
-    (* TODO: a PIF after https://github.com/xapi-project/xen-api/pull/3585 *)
-    (fun x -> true)
+    (fun x -> valid_ref __context x.cluster_host_PIF)
     Db.Cluster_host.destroy
 
 let gc_VGPUs ~__context =

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -2092,6 +2092,10 @@ let cluster_record rpc session_id cluster =
       ; make_field ~name:"token-timeout-coefficient"
           ~get:(fun () -> Int64.to_string((x ()).API.cluster_token_timeout_coefficient))
           ()
+      ; make_field ~name:"pending-forget" ~hidden:true
+          ~get:(fun () -> String.concat "; " (x ()).API.cluster_pending_forget)
+          ~get_set:(fun () -> (x ()).API.cluster_pending_forget)
+          ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () -> String.concat "; " (List.map Record_util.cluster_operation_to_string (x ()).API.cluster_allowed_operations))
           ~get_set:(fun () -> List.map Record_util.cluster_operation_to_string (x ()).API.cluster_allowed_operations)

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -60,7 +60,7 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout ~token_
       match result with
       | Result.Ok cluster_token ->
         D.debug "Got OK from LocalClient.create";
-        Db.Cluster.create ~__context ~ref:cluster_ref ~uuid:cluster_uuid ~cluster_token ~cluster_stack
+        Db.Cluster.create ~__context ~ref:cluster_ref ~uuid:cluster_uuid ~cluster_token ~cluster_stack ~pending_forget:[]
           ~pool_auto_join ~token_timeout:token_timeout_ms ~token_timeout_coefficient:token_timeout_coefficient_ms ~current_operations:[] ~allowed_operations:[] ~cluster_config:[]
           ~other_config:[];
         Db.Cluster_host.create ~__context ~ref:cluster_host_ref ~uuid:cluster_host_uuid ~cluster:cluster_ref ~host ~enabled:true ~pIF

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -75,3 +75,9 @@ val resync_host : __context:Context.t -> host:API.ref_host -> unit
     exists but is not associated with a cluster_host, it creates one. If the
     database indicates the cluster_host is enabled, host_resync enables it
     in the Client layer too. Otherwise, nothing happens. *)
+
+val forget : __context:Context.t -> self:API.ref_Cluster_host -> unit
+(** [forget ~__context ~self] marks the cluster host as permanently removed
+ *  from the cluster. This will only succeed if the rest of the hosts are online,
+ *  so in the case of failure the cluster's pending_forget list will be updated.
+ *  If you declare all your dead hosts as dead one by one the last one should succeed *)


### PR DESCRIPTION
Introduced a new API `Cluster_host.forget`, because declare dead already has a different semantics in Xen API (see comments in commit message for full details).

There is this outstanding TODO on which I'd like some thoughts: "although things could go wrong if we try to join a host with the same IP as one that we are trying to declare as dead... (which can happen due to DHCP)."

If we have 2 hosts dead, declare one of them as dead (it gets added to pending forget), and then try to join a new node which reuses the same IP before marking the 2nd host as dead then we can't really tell the difference between the newly joined host and the one declared as dead.