### PR TITLE
CP-28117: restart VMs in parallel when recovering from a host failure in HA

### DIFF
--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -379,6 +379,7 @@ module Monitor = struct
               try
                 Xapi_ha_vm_failover.restart_auto_run_vms ~__context liveset_refs to_tolerate
               with e ->
+                log_backtrace ();
                 error "Caught unexpected exception when executing restart plan: %s" (ExnHelper.string_of_exn e)
             end;
 

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -713,6 +713,7 @@ let restart_auto_run_vms ~__context live_set n =
       Xapi_alert.add ~msg:Api_messages.ha_protected_vm_restart_failed ~cls:`VM ~obj_uuid ~body:""
     end in
 
+  let open TaskChains.Infix in
   (* execute the plan *)
   Helpers.call_api_functions ~__context
     (fun rpc session_id ->
@@ -738,28 +739,47 @@ let restart_auto_run_vms ~__context live_set n =
            if attempt_restart then begin
              Hashtbl.replace last_start_attempt vm (Unix.gettimeofday ());
              match host with
-             | None -> Client.Client.VM.start rpc session_id vm false true
-             | Some h -> Client.Client.VM.start_on rpc session_id vm h false true
+             | None -> Client.Client.Async.VM.start rpc session_id vm false true
+             | Some h -> Client.Client.Async.VM.start_on rpc session_id vm h false true
            end else failwith (Printf.sprintf "VM: %s restart attempt delayed for 120s" (Ref.string_of vm)) in
-         try
-           go ();
-           true
-         with
-         | Api_errors.Server_error(code, params) when code = Api_errors.ha_operation_would_break_failover_plan ->
+         TaskChains.task go >>= function
+         | Result.Error Api_errors.Server_error(code, params) when code = Api_errors.ha_operation_would_break_failover_plan ->
            (* This should never happen since the planning code would always allow the restart of a protected VM... *)
            error "Caught exception HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN: setting pool as overcommitted and retrying";
            ignore (mark_pool_as_overcommitted ~__context ~live_set : bool);
            begin
-             try
-               go ();
-               true
-             with e ->
-               error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
-               false
+             TaskChains.task go >>= function
+             | Result.Ok _ -> TaskChains.ok ()
+             | Result.Error e -> error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
+               TaskChains.fail e
            end
-         | e ->
+         | Result.Error e ->
            error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
-           false in
+           TaskChains.fail e
+         | Result.Ok _ -> TaskChains.ok ()
+       in
+
+       (** [ordered_map_concat f lst]
+        * traverses the list in order, maps each inner list through [f]
+        * and concatenates the result *)
+       let ordered_map_concat f lst =
+        debug "Processing %d parallel groups" (List.length lst);
+        (* the iteration order is important here for preserving the VM start order *)
+        List.fold_left (fun accum inner ->
+             (* the order of elements in the result doesn't matter,
+              * they were launched in parallel *)
+             List.rev_append (f inner) accum) [] lst
+       in
+
+       let map_parallel ~order f lst =
+         lst
+         |> Helpers.group_by ~ordering:`ascending order
+         |> ordered_map_concat (fun same_order ->
+             same_order
+             |> List.rev_map fst
+             |> List.rev_map f
+             |> TaskChains.parallel ~__context ~rpc ~session_id)
+       in
 
        (* Build a list of bools, one per Halted protected VM indicating whether we managed to start it or not *)
        let started =
@@ -767,23 +787,23 @@ let restart_auto_run_vms ~__context live_set n =
            (* If the Pool is overcommitted the restart priority will make the difference between a VM restart or not,
               					   while if we're undercommitted the restart priority only affects the timing slightly. *)
            let all = List.filter (fun (_, r) -> r.API.vM_power_state = `Halted) all_protected_vms in
-           let all = List.sort by_order all in
            warn "Failed to find plan to restart all protected VMs: falling back to simple VM.start in priority order";
-           List.map (fun (vm, _) -> vm, restart_vm vm ()) all
+           map_parallel ~order (fun (vm, vmr) -> (vm, vmr), restart_vm vm ()) all
          end else begin
            (* Walk over the VMs in priority order, starting each on the planned host *)
-           let all = List.sort by_order (List.map (fun (vm, _) -> vm, Db.VM.get_record ~__context ~self:vm) plan) in
-           List.map (fun (vm, _) ->
-               vm, (if List.mem_assoc vm plan
+           let all = List.map (fun (vm, _) -> vm, Db.VM.get_record ~__context ~self:vm) plan in
+           map_parallel ~order (fun (vm, vmr) ->
+               (vm,vmr), if List.mem_assoc vm plan
                     then restart_vm vm ~host:(List.assoc vm plan) ()
-                    else false)) all
+                    else TaskChains.fail (Failure "VM has no plan")) all
          end in
        (* Perform one final restart attempt of any that weren't started. *)
-       let started = List.map (fun (vm, started) -> match started with
-           | true -> vm, true
-           | false -> vm, restart_vm vm ()) started in
+       let started = map_parallel ~order:(fun (vminfo, _) -> order vminfo)
+           (fun ((vm,_), started) -> match started with
+           | Result.Ok () -> vm, TaskChains.ok ()
+           | Result.Error _ -> vm, restart_vm vm ()) started in
        (* Send an alert for any failed VMs *)
-       List.iter (fun (vm, started) -> if not started then consider_sending_failed_alert_for vm) started;
+       List.iter (fun (vm, started) -> if started <> Result.Ok () then consider_sending_failed_alert_for vm) started;
 
        (* Forget about previously failed VMs which have gone *)
        let vms_we_know_about = List.map fst started in
@@ -797,16 +817,18 @@ let restart_auto_run_vms ~__context live_set n =
           			   ok since this is 'best-effort'). NOTE we do not use the restart_vm function above as this will mark the
           			   pool as overcommitted if an HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN is received (although this should never
           			   happen it's better safe than sorry) *)
-       List.iter
+       map_parallel ~order:(fun vm -> order (vm, Db.VM.get_record ~__context ~self:vm))
          (fun vm ->
-            try
-              if Db.VM.get_power_state ~__context ~self:vm = `Halted
+              vm, if Db.VM.get_power_state ~__context ~self:vm = `Halted
               && Db.VM.get_ha_restart_priority ~__context ~self:vm = Constants.ha_restart_best_effort
-              then Client.Client.VM.start rpc session_id vm false true
-            with e ->
-              error "Failed to restart best-effort VM %s (%s): %s"
-                (Db.VM.get_uuid ~__context ~self:vm)
-                (Db.VM.get_name_label ~__context ~self:vm)
-                (ExnHelper.string_of_exn e)) !reset_vms
-
+              then TaskChains.task (fun () -> Client.Client.Async.VM.start rpc session_id vm false true)
+              else TaskChains.ok (Rpc.Null)) !reset_vms
+       |> List.iter (fun (vm, result) ->
+           match result with
+           | Result.Error e ->
+             error "Failed to restart best-effort VM %s (%s): %s"
+               (Db.VM.get_uuid ~__context ~self:vm)
+               (Db.VM.get_name_label ~__context ~self:vm)
+               (ExnHelper.string_of_exn e)
+           | Result.Ok _ -> ())
     )

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -15,6 +15,164 @@
 module D = Debug.Make(struct let name="xapi_ha_vm_failover" end)
 open D
 
+type task_result = (Rpc.t, exn) result
+
+(** [result_of_task ~__context task] returns the status of [task]
+ * unless it is still pending. Exceptions are converted into [Result.Error] *)
+let result_of_task ~__context self : task_result option =
+  try match Db.Task.get_status ~__context ~self with
+    | `pending -> None
+    | `success ->
+      Some (Result.Ok (match Db.Task.get_result ~__context ~self with
+          | "" -> Rpc.Null
+          | s -> Xmlrpc.of_string s))
+    | `cancelled -> Some (Result.Error (Failure "Cancelled"))
+    | `cancelling -> Some (Result.Error (Failure "Cancelling"))
+    | `failure ->
+      Some (match Db.Task.get_error_info ~__context ~self with
+          | [] -> Result.Error (Failure "Unknown error")
+          | code :: params -> Result.Error (Api_errors.Server_error (code, params)))
+  with e ->
+    (* cannot fetch task status, maybe task got destroyed *)
+    Backtrace.is_important e;
+    Some (Result.Error e)
+
+
+module TaskChains : sig
+  (** the type of delayed task related actions *)
+  type +'a t
+
+  val return : 'a -> 'a t
+
+  val ok : 'a -> ('a, exn) Result.result t
+
+  val fail : exn -> ('a, exn) Result.result t
+
+  val task : (unit -> API.ref_task) -> task_result t
+  (**[task f] is an action that evaluates to the result of task [f ()] *)
+
+  val fmap : ('a -> 'b) -> 'a t -> 'b t
+  (** [fmap f t] will map the final result of action [t] through the function [f].
+     * It is not guaranteed that [f] is executed as soon as the result of [t] is available. *)
+
+  (** this module is meant to be opened, defines only an infix operator,
+   * avoids polluting the namespace with other functions *)
+  module Infix : sig
+    val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+    (** [m >>= k] monadic bind: executes [k] with the result of [m] computation.
+     * It is not guaranteed that [k] is executed as soon as the result of [m] is available.
+     * *)
+  end
+
+  val eval : __context:Context.t -> 'a t -> 'a t
+  (** [eval ~__context t] will either return [t] unchanged,
+      or evaluate the next action after receiving the result of the contained task.
+      If the action raises an exception, that exceptions propagates out of this function *)
+
+  val parallel :
+    __context:Context.t -> rpc:(Rpc.call -> Rpc.response)
+    -> session_id:API.ref_session -> ('a * ('b, exn) Result.result t) list
+    -> ('a * ('b, exn) Result.result) list
+  (** [parallel ~__context lst] groups actions in [lst] by order number and
+   * executes all actions with same order number in parallel.
+   * In the current implementation binds and fmaps are executed after waiting for all tasks of same
+   * order number to complete.
+   * Returns the results from [lst], in an unspecified order, hence each item in [lst] is a tuple
+   * with arbitrary data (e.g. a VM ref) as first element, and the action as second:
+   * this way the results will be associated with some meaningful data.
+   *
+   * e.g. given : [task1_order0 >>= action1 , task2_order1, task3_order0 >>= action2]
+   * we first launch task1 and task3, when both task1 and task3 has finished we execute
+   * action1 and action2 recursively to completion.
+   * Only then we launch task2 and waits for its completion.
+  *)
+end = struct
+  (** structured like a Freer Monad *)
+  type +'a t =
+    | Completed of 'a
+        (** [Completed result] an action that has finished, sometimes refered to as 'pure' *)
+    | Task of API.ref_task * (task_result -> 'a t)
+        (** [Task(task, next)] a task, and a function to call when the task finishes (continuation).
+     * This is an impure action. *)
+
+  (* Constructors *)
+
+  let return x = Completed x
+
+  let ok x = Completed (Result.Ok x)
+
+  let fail e = Completed (Result.Error e)
+
+  let wrap f = try f () with e -> Backtrace.is_important e ; fail e
+
+  let task f = wrap (fun () -> Task (f (), return))
+
+  (* Operations *)
+
+  let rec fmap f = function
+    | Completed x ->
+        (* just map the result through [f] if we already have it *)
+        Completed (f x)
+    | Task (task, task_next) ->
+        (* If everything was immediately available then the result would be:
+       * [f (task_next (result_of_task task))]
+       * However we first need to wait for the task to finish,
+       * and when we receive the result from the task, we need to map it through
+       * [task_next] and then through [f].
+       * The type system helps to ensure that the pipeline below is correct *)
+        Task (task, fun x -> x |> task_next |> fmap f)
+
+
+  module Infix = struct
+    let rec ( >>= ) m k =
+      match m with
+      | Completed x -> k x
+      | Task (task, next) ->
+          (* similar reasoning as above, when we get the result we need to chain the computations,
+         * refer to http://okmij.org/ftp/Computation/free-monad.html for a deeper theoretical explanation *)
+          Task (task, fun x -> next x >>= k)
+  end
+
+  let eval ~__context = function
+    | Completed _ as t -> t
+    | Task (task, next) as t ->
+      match result_of_task ~__context task with
+      | None -> t
+      | Some result ->
+          log_and_ignore_exn (fun () -> Xapi_task.destroy ~__context ~self:task) ;
+          next result
+
+
+  let classify completed lst =
+    List.fold_left
+      (fun (completed, pending, tasks) -> function
+        | k, Completed r -> ((k, r) :: completed, pending, tasks)
+        | (_, Task (task, _)) as t -> (completed, t :: pending, task :: tasks)
+        )
+      (completed, [], []) lst
+
+
+  let parallel ~__context ~rpc ~session_id lst =
+    let rec loop completed lst =
+      (* find any pending tasks we can wait for right now *)
+      match classify completed lst with
+      | completed, [], [] ->
+        debug "All %d parallel actions have completed" (List.length completed);
+        completed
+      | completed, pending, tasks ->
+          debug "Waiting for %d tasks" (List.length tasks);
+          Tasks.wait_for_all ~rpc ~session_id ~tasks ;
+          debug "Waited for %d tasks, evaluating next actions" (List.length tasks);
+          pending
+          |> List.rev_map (fun (k, v) ->
+                 (k, wrap (fun () -> eval ~__context v)) )
+          |> loop completed
+    in
+    debug "Starting to process %d parallel actions" (List.length lst);
+    loop [] lst
+end
+
+
 (* Return a list of (ref, record) pairs for all VMs which are marked as always_run *)
 let all_protected_vms ~__context =
   let vms = Db.VM.get_all_records ~__context in

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -15,7 +15,7 @@
 module D = Debug.Make(struct let name="xapi_ha_vm_failover" end)
 open D
 
-type task_result = (Rpc.t, exn) result
+type task_result = (Rpc.t, exn) Result.result
 
 (** [result_of_task ~__context task] returns the status of [task]
  * unless it is still pending. Exceptions are converted into [Result.Error] *)

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -21,11 +21,11 @@ let all_protected_vms ~__context =
   List.filter (fun (_, vm_rec) -> Helpers.vm_should_always_run vm_rec.API.vM_ha_always_run vm_rec.API.vM_ha_restart_priority) vms
 
 (* Comparison function which can be used to sort a list of VM ref, record by order *)
-let by_order (vm_ref1,vm_rec1) (vm_ref2,vm_rec2) =
+let order (vm_ref,vm_rec) =
   let negative_high x = if x<0L then Int64.max_int else x in
-  let vm1_order = negative_high (vm_rec1.API.vM_order) in
-  let vm2_order = negative_high (vm_rec2.API.vM_order) in
-  compare vm1_order vm2_order
+  negative_high (vm_rec.API.vM_order)
+
+let by_order a b = compare (order a) (order b)
 
 let ($) x y = x y
 


### PR DESCRIPTION
I have dev-tested this using VMs created by this script, and then turning the power off on an HA slave, and watching VMs get restarted in the correct order (first all with order=0 got started in parallel, then order=1, then order=2).
```
#!/bin/bash
set -e
MEMORY='16MiB'
N=50
ORDER=2

if [ ! -f /boot/guest/test-vm.xen.gz ]; then
        wget https://github.com/xapi-project/xen-test-vm/releases/download/0.0.5/test-vm.xen.gz
        sha256sum test-vm.xen.gz
        mkdir -p /boot/guest
        mv test-vm.xen.gz /boot/guest
fi


. /etc/xensource-inventory
host_uuid="$INSTALLATION_UUID"

SR=$(xe pool-list params=default-SR --minimal)

for order in $(seq 0 "$ORDER"); do
    for i in $(seq 1 "$N"); do
        vm_uuid=$(xe vm-create name-label="mirage-$order-$i-$MEMORY")
        xe vm-param-set PV-kernel=/boot/guest/test-vm.xen.gz uuid="$vm_uuid"
        xe vm-memory-limits-set uuid="$vm_uuid" static-min="$MEMORY" dynamic-min="$MEMORY" dynamic-max="$MEMORY" static-max="$MEMORY"
        xe vm-param-set uuid="$vm_uuid" ha-restart-priority=restart
        xe vm-param-set uuid="$vm_uuid" order="$order"
        for i in $(seq 1 3); do
            vdi_uuid=$( xe vdi-create sr-uuid="$SR" name-label="mirage-$order-$i-$MEMORY-disk" virtual-size=1MiB)
            xe vbd-create vdi-uuid=$vdi_uuid vm-uuid=$vm_uuid device=autodetect >/dev/null
        done
    done
done
```

I'd love to have some unit tests for the VM restart code, but I couldn't find any. Should new unit tests be written for the HA VM restart code, or just the new helper module?