### PR TITLE
CP-26199: Send alerts when Cluster_host.resync_host fails

### DIFF
--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -132,3 +132,7 @@ let host_cpu_features_down = addMessage "HOST_CPU_FEATURES_DOWN" 3L
 let host_cpu_features_up = addMessage "HOST_CPU_FEATURES_UP" 5L
 let pool_cpu_features_down = addMessage "POOL_CPU_FEATURES_DOWN" 5L
 let pool_cpu_features_up = addMessage "POOL_CPU_FEATURES_UP" 5L
+
+(* Cluster messages *)
+let cluster_host_creation_failed = addMessage "CLUSTER_HOST_CREATION_FAILED" 3L
+let cluster_host_enable_failed = addMessage "CLUSTER_HOST_ENABLE_FAILED" 3L


### PR DESCRIPTION
`Cluster_host.resync_host` is iterated over all hosts in a pool by `Cluster.pool_resync`, and is also called at startup as part of the task `resync cluster host state`.

Question: should the new messages have a different priority? Also open to suggestions to make the formatting less awful.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>