### PR TITLE
Base pool.cpu_info:features_hvm on HVM-capable hosts only

### DIFF
--- a/ocaml/tests/test_pool_cpuinfo.ml
+++ b/ocaml/tests/test_pool_cpuinfo.ml
@@ -18,10 +18,10 @@ open OUnit
 open Test_highlevel
 module PoolCpuinfo = Generic.Make(Generic.EncapsulateState(struct
                                     module Io = struct
-                                      type input_t = (string * string) list list
+                                      type input_t = ((string * string) list * bool) list
                                       type output_t = (string * string) list
 
-                                      let string_of_input_t = Test_printers.(list (assoc_list string string))
+                                      let string_of_input_t = Test_printers.(list (pair (assoc_list string string) bool))
                                       let string_of_output_t = Test_printers.(assoc_list string string)
                                     end
                                     module State = Test_state.XapiDb
@@ -29,9 +29,12 @@ module PoolCpuinfo = Generic.Make(Generic.EncapsulateState(struct
                                     (* Create a host for each edition in the list. *)
                                     let load_input __context inputs =
                                       List.iter
-                                        (fun cpu_info ->
+                                        (fun (cpu_info, hvm_capable) ->
                                            let host = Test_common.make_host ~__context () in
-                                           Db.Host.set_cpu_info ~__context ~self:host ~value:cpu_info)
+                                           Db.Host.set_cpu_info ~__context ~self:host ~value:cpu_info;
+                                           if hvm_capable then
+                                             Db.Host.set_capabilities ~__context ~self:host ~value:["hvm"]
+                                         )
                                         inputs;
                                       ignore (Test_common.make_pool ~__context
                                                 ~master:(List.hd (Db.Host.get_all ~__context)) ());
@@ -47,39 +50,44 @@ module PoolCpuinfo = Generic.Make(Generic.EncapsulateState(struct
                                         ["vendor", vendor;
                                          "cpu_count", cpu_count;
                                          "socket_count", socket_count;
-                                         "features_hvm", features_pv;
-                                         "features_pv", features_hvm] in
+                                         "features_hvm", features_hvm;
+                                         "features_pv", features_pv] in
 
                                       (* Sort the associaton list so the test framework's comparisons work *)
                                       List.sort compare cpu_info
 
                                     let tests = [
-                                      ([cpu_info "Abacus" "1" "1" "0000000a" "0000000a"],
+                                      ([cpu_info "Abacus" "1" "1" "0000000a" "0000000a", true],
                                        cpu_info "Abacus" "1" "1" "0000000a" "0000000a");
 
-                                      ([cpu_info "Abacus" "2" "4" "0000000a" "0000000a";
-                                        cpu_info "Abacus" "1" "1" "0000000a" "0000000a"],
+                                      ([cpu_info "Abacus" "2" "4" "0000000a" "0000000a", true;
+                                        cpu_info "Abacus" "1" "1" "0000000a" "0000000a", true],
                                        cpu_info "Abacus" "3" "5" "0000000a" "0000000a");
 
-                                      ([cpu_info "Abacus" "8" "2" "0000000a" "00000002";
-                                        cpu_info "Abacus" "4" "1" "0000000f" "00000001"],
+                                      ([cpu_info "Abacus" "8" "2" "0000000a" "00000002", true;
+                                        cpu_info "Abacus" "4" "1" "0000000f" "00000001", true],
                                        cpu_info "Abacus" "12" "3" "0000000a" "00000000");
 
-                                      ([cpu_info "Abacus" "24" "1" "ffffffff-ffffffff" "ffffffff-ffffffff";
-                                        cpu_info "Abacus" "24" "24" "ffffffff-ffffffff" "ffffffff-ffffffff"],
+                                      ([cpu_info "Abacus" "24" "1" "ffffffff-ffffffff" "ffffffff-ffffffff", true;
+                                        cpu_info "Abacus" "24" "24" "ffffffff-ffffffff" "ffffffff-ffffffff", true],
                                        cpu_info "Abacus" "48" "25" "ffffffff-ffffffff" "ffffffff-ffffffff");
 
-                                      ([cpu_info "Abacus" "1" "1" "ffffffff" "ffffffff-ffffffff-ffffffff";
-                                        cpu_info "Abacus" "1" "1" "ffffffff-ffffffff" "ffffffff-ffffffff"],
+                                      ([cpu_info "Abacus" "1" "1" "ffffffff" "ffffffff-ffffffff-ffffffff", true;
+                                        cpu_info "Abacus" "1" "1" "ffffffff-ffffffff" "ffffffff-ffffffff", true],
                                        cpu_info "Abacus" "2" "2" "ffffffff-00000000" "ffffffff-ffffffff-00000000");
 
-                                      ([cpu_info "Abacus" "10" "1" "01230123-5a5a5a5a" "00000002";
-                                        cpu_info "Abacus" "1" "10" "ffff1111-a5a56666" "00004242"],
+                                      ([cpu_info "Abacus" "10" "1" "01230123-5a5a5a5a" "00000002", true;
+                                        cpu_info "Abacus" "1" "10" "ffff1111-a5a56666" "00004242", true],
                                        cpu_info "Abacus" "11" "11" "01230101-00004242" "00000002");
 
+                                      (* Include one host that is not HVM-capable *)
+                                      ([cpu_info "Abacus" "10" "1" "00000000-00000000" "00000002", false;
+                                        cpu_info "Abacus" "1" "10" "ffff1111-a5a56666" "00004242", true],
+                                       cpu_info "Abacus" "11" "11" "ffff1111-a5a56666" "00000002");
+
                                       (* CA-188665: Test a pool containing an old host which doesn't have the new feature keys *)
-                                      ([cpu_info "Abacus" "1" "1" "01230123-5a5a5a5a" "00000002";
-                                        ["cpu_count", "1"; "features", "ffff1111-a5a56666"; "socket_count", "1"; "vendor", "Abacus"]],
+                                      ([cpu_info "Abacus" "1" "1" "01230123-5a5a5a5a" "00000002", true;
+                                        ["cpu_count", "1"; "features", "ffff1111-a5a56666"; "socket_count", "1"; "vendor", "Abacus"], true],
                                        cpu_info "Abacus" "1" "1" "01230123-5a5a5a5a" "00000002");
                                     ]
                                   end))

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1207,3 +1207,10 @@ let get_first_vusb ~__context usb_group =
     raise Api_errors.(Server_error(internal_error,
       [Printf.sprintf "there is no VUSB associated with the USB_group: %s"
       (Ref.string_of usb_group)]))
+
+let host_supports_hvm ~__context host =
+  (* We say that a host supports HVM if any of
+   * the capability strings contains the substring "hvm". *)
+  let capabilities = Db.Host.get_capabilities ~__context ~self:host in
+  List.fold_left (||) false
+    (List.map (fun x -> String.has_substr x "hvm") capabilities)

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -437,12 +437,7 @@ let assert_netsriov_available ~__context ~self ~host =
     ) sriov_networks
 
 let assert_host_supports_hvm ~__context ~self ~host =
-  (* For now we say that a host supports HVM if any of    *)
-  (* the capability strings contains the substring "hvm". *)
-  let capabilities = Db.Host.get_capabilities ~__context ~self:host in
-  let host_supports_hvm = List.fold_left (||) false
-      (List.map (fun x -> String.has_substr x "hvm") capabilities) in
-  if not(host_supports_hvm) then
+  if not (Helpers.host_supports_hvm ~__context host) then
     raise (Api_errors.Server_error (Api_errors.vm_hvm_required, [Ref.string_of self]))
 
 let assert_enough_memory_available ~__context ~self ~host ~snapshot =


### PR DESCRIPTION
This field should be the intersection of the HVM-specific feature sets over all
hosts in the pool that can actually run HVM guests.

The `host.cpu_info:features_hvm` field of non-HVM-capable hosts is a string
with just zeros: no features. Therefore, the intersection currently ends up
disabling all features for HVM guests in the entire pool (including for HVM
capable hosts), which is obviously not what we want.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>