### PR TITLE
CA-289735: do not disable clustering daemon on shutdown from xapi-domains

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -515,7 +515,6 @@ let prepare_for_poweroff ~__context ~host =
 
   Xapi_ha.before_clean_shutdown_or_reboot ~__context ~host;
   Xapi_pbd.unplug_all_pbds ~__context;
-  Xapi_cluster_host.disable_clustering ~__context;
 
   if not i_am_master then
     Remote_requests.stop_request_thread();


### PR DESCRIPTION
Just unplug the PBDs, and allow the clustering daemon to shut itself
down using the `xapi-clusterd-shutdown.service` unit.

This is to avoid a circular dependency between `xapi-domains`, `dlm`,
and `remote-fs` that prevents `dlm` from getting stopped from inside
`xapi-domains` on shutdown.

This needs to be merged together with matching PR on the clustering daemon.