### PR TITLE
 CA-290006 update snapshot device model profile

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1199,6 +1199,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
                (fun vbds ->
                   with_vifs_marked ~__context ~vm ~doc:"VM.start" ~op:`attach
                     (fun vifs ->
+                       Xapi_vm_helpers.ensure_domain_type_is_specified ~__context ~self:vm;
                        (* The start operation makes use of the cached memory overhead *)
                        (* value when reserving memory. It's important to recalculate  *)
                        (* the cached value before performing the start since there's  *)
@@ -1253,6 +1254,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
              (fun vbds ->
                 with_vifs_marked ~__context ~vm ~doc:"VM.start_on" ~op:`attach
                   (fun vifs ->
+                     Xapi_vm_helpers.ensure_domain_type_is_specified ~__context ~self:vm;
                      (* The start operation makes use of the cached memory overhead *)
                      (* value when reserving memory. It's important to recalculate  *)
                      (* the cached value before performing the start since there's  *)
@@ -1579,6 +1581,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
           (fun () ->
              with_vbds_marked ~__context ~vm ~doc:"VM.resume" ~op:`attach
                (fun vbds ->
+                  Xapi_vm_helpers.ensure_domain_type_is_specified ~__context ~self:vm;
                   let snapshot = Db.VM.get_record ~__context ~self:vm in
                   let (), host = forward_to_suitable_host ~local_fn ~__context ~vm ~snapshot ~host_op:`vm_resume
                       (fun session_id rpc -> Client.VM.resume rpc session_id vm start_paused force) in
@@ -1610,6 +1613,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         (fun () ->
            with_vbds_marked ~__context ~vm ~doc:"VM.resume_on" ~op:`attach
              (fun vbds ->
+                Xapi_vm_helpers.ensure_domain_type_is_specified ~__context ~self:vm;
                 let snapshot = Db.VM.get_record ~__context ~self:vm in
                 reserve_memory_for_vm ~__context ~vm ~host ~snapshot ~host_op:`vm_resume
                   (fun () ->

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -44,6 +44,13 @@ let derive_domain_type ~hVM_boot_policy =
   else
     `hvm
 
+(* Ensure that the domain-type is specified; upgrade from boot policy if needed *)
+let ensure_domain_type_is_specified ~__context ~self =
+  if Db.VM.get_domain_type ~__context ~self = `unspecified then
+    Db.VM.get_HVM_boot_policy ~__context ~self
+    |> fun hbp -> derive_domain_type ~hVM_boot_policy:hbp
+    |> fun value -> Db.VM.set_domain_type ~__context ~self ~value
+
 let derive_hvm_boot_policy ~domain_type =
   if domain_type = `hvm then
     Constants.hvm_boot_policy_bios_order

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -241,7 +241,7 @@ let checkpoint ~__context ~vm ~new_name =
 (********************************************************************************)
 
 (* The following code have to run on the master as it manipulates the DB cache directly. *)
-let copy_vm_fields ~__context ~metadata ~dst ~do_not_copy ~default_values =
+let copy_vm_fields ~__context ~metadata ~dst ~do_not_copy ~overrides =
   if not (Pool_role.is_master ()) then
     raise Api_errors.(Server_error(internal_error, ["copy_vm_fields: Aborting because the host is not master"]));
   debug "copying metadata into %s" (Ref.string_of dst);
@@ -250,8 +250,8 @@ let copy_vm_fields ~__context ~metadata ~dst ~do_not_copy ~default_values =
   List.iter
     (fun (key,value) ->
        let value =
-         if List.mem_assoc key default_values
-         then List.assoc key default_values
+         if List.mem_assoc key overrides
+         then List.assoc key overrides
          else value in
        if not (List.mem key do_not_copy)
        then DB.write_field db Db_names.vm (Ref.string_of dst) key value)
@@ -435,7 +435,7 @@ let do_not_copy = [
   "power_state";
 ]
 
-let default_values = [
+let overrides = [
   Db_names.ha_always_run, "false";
 ]
 
@@ -463,7 +463,7 @@ let revert_vm_fields ~__context ~snapshot ~vm =
     if post_MNR
     then do_not_copy
     else extended_do_not_copy in
-  copy_vm_fields ~__context ~metadata:snap_metadata ~dst:vm ~do_not_copy ~default_values;
+  copy_vm_fields ~__context ~metadata:snap_metadata ~dst:vm ~do_not_copy ~overrides;
   TaskHelper.set_progress ~__context 0.1
 
 let revert ~__context ~snapshot ~vm =
@@ -516,7 +516,7 @@ let	create_vm_from_snapshot ~__context ~snapshot =
              ~__context rpc session_id snap_record in
          begin try
              Db.VM.set_uuid ~__context ~self:new_vm ~value:vm_uuid;
-             copy_vm_fields ~__context ~metadata:snap_metadata ~dst:new_vm ~do_not_copy:do_not_copy ~default_values;
+             copy_vm_fields ~__context ~metadata:snap_metadata ~dst:new_vm ~do_not_copy:do_not_copy ~overrides;
              List.iter (fun (snap,_) -> Db.VM.set_snapshot_of ~__context ~self:snap ~value:new_vm) snapshots;
              new_vm
            with e ->


### PR DESCRIPTION
A snapshot stores all relevant VM meta data inside VM.snapshot_metadata
which contains a platform value, which in turn contains a device model
profile. This needs to be updated when xapi's database is updated but so
far was not. Confusingly, the VM.platform field of a snapshot is not
used when restoring a snapshot. This commit updates the device model
profile inside the snapshot metadata.
    
Snapshot meta data is encoded as an s-expression. Updating it thus
requires decoding, updating, and encoding it again.

This fix also pulls in CA-290874 from the master branch to make sure the domain
type is handled correctly in snapshots.
