### PR TITLE
CA-287838: Wait for slave host to be enabled timed out: slave's dom0 …

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -350,6 +350,8 @@ and update_domain_zero_record ~__context ~domain_zero_ref (host_info: host_info)
     Db.VM.set_requires_reboot ~__context ~self:domain_zero_ref ~value:false
   end;
   let localhost = Helpers.get_localhost ~__context in
+  Db.VM.set_power_state ~__context ~self:domain_zero_ref ~value:`Running;
+  Db.VM.set_domid ~__context ~self:domain_zero_ref ~value:0L;
   Helpers.update_domain_zero_name ~__context localhost host_info.hostname
 
 and create_domain_zero_memory_constraints (host_info: host_info) : Vm_memory_constraints.t =


### PR DESCRIPTION
…metadata incomplete

After the fix of CA-280981, we import the dom0 metadata of slave to master
rather than re-create a new VM record for it when slave join a pool. However it
will make the VM record of dom0 of slave in an incorrect state.

This fix aims to fix the VM record state of dom0 of slave when slave restarting
xapi.

Signed-off-by: Yang Qian <yang.qian@citrix.com>