### PR TITLE
Define constants for checking cluster token values

### DIFF
--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -24,7 +24,7 @@ let test_clusterd_rpc ~__context call =
   | ("enable" | "disable" | "destroy" | "leave"), _ ->
     Rpc.{success = true; contents = Rpc.Null }
   | name, params ->
-    failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))
+    Alcotest.failf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params))
 
 let test_rpc ~__context call =
   match call.Rpc.name, call.Rpc.params with
@@ -37,9 +37,10 @@ let test_rpc ~__context call =
     Xapi_cluster.destroy ~__context ~self:(ref_Cluster_of_rpc self);
     Rpc.{success = true; contents = Rpc.String "" }
   | name, params ->
-    failwith (Printf.sprintf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params)))
+    Alcotest.failf "Unexpected RPC: %s(%s)" name (String.concat " " (List.map Rpc.to_string params))
 
-let create_cluster ~__context ?(cluster_stack=Constants.default_smapiv3_cluster_stack) ?(test_clusterd_rpc=test_clusterd_rpc) () =
+let create_cluster ~__context ?(cluster_stack=Constants.default_smapiv3_cluster_stack)
+  ?(test_clusterd_rpc=test_clusterd_rpc) ?(token_timeout=1.) ?(token_timeout_coefficient=1.) () =
   Context.set_test_rpc __context (test_rpc ~__context);
   Context.set_test_clusterd_rpc __context (test_clusterd_rpc ~__context);
   let network = Test_common.make_network ~__context () in
@@ -48,7 +49,7 @@ let create_cluster ~__context ?(cluster_stack=Constants.default_smapiv3_cluster_
   Db.PIF.set_IP ~__context ~self:pIF ~value:"192.0.2.1";
   Db.PIF.set_currently_attached ~__context ~self:pIF ~value:true;
   Db.PIF.set_disallow_unplug ~__context ~self:pIF ~value:true;
-  Xapi_cluster.create ~__context ~pIF ~cluster_stack ~pool_auto_join:true ~token_timeout:1. ~token_timeout_coefficient:1.
+  Xapi_cluster.create ~__context ~pIF ~cluster_stack ~pool_auto_join:true ~token_timeout ~token_timeout_coefficient
 
 let test_create_destroy_status () =
   let __context = Test_common.make_test_database () in
@@ -66,29 +67,40 @@ let test_enable () =
   end;
   pool_destroy ~__context ~self:cluster
 
-let test_invalid_cluster_stack () =
+let test_invalid_parameters () =
   let __context = Test_common.make_test_database () in
   let cluster_stack = "invalid_cluster_stack" in
   Alcotest.check_raises
     "Cluster.create should fail upon receiving an invalid cluster stack"
     Api_errors.(Server_error (invalid_cluster_stack, [ cluster_stack ]))
-    (fun () -> create_cluster ~__context ~cluster_stack () |> ignore)
+    (fun () -> create_cluster ~__context ~cluster_stack () |> ignore);
+
+  Alcotest.check_raises
+    "token_timeout < minimum threshold"
+    Api_errors.(Server_error (invalid_value, [ "token_timeout"; "0.5" ]))
+    (fun () -> create_cluster ~__context ~token_timeout:0.5 () |> ignore);
+
+  Alcotest.check_raises
+    "token_timeout_coefficient < minimum threshold"
+    Api_errors.(Server_error (invalid_value, [ "token_timeout_coefficient"; "0.6" ]))
+    (fun () -> create_cluster ~__context ~token_timeout_coefficient:0.6 () |> ignore)
+
 
 let test_create_cleanup () =
   let __context = Test_common.make_test_database () in
-  let test_failed_clusterd_rpc ~__context call =
+  let test_clusterd_rpc ~__context call =
     match call.Rpc.name, call.Rpc.params with
     | "create", _ ->
        Rpc.{ success = false
            ; contents = Rpcmarshal.marshal
-                          (Cluster_interface.error.Rpc.Types.ty)
-                          (Cluster_interface.InternalError "Cluster.create failed")
+                          Cluster_interface.error.Rpc.Types.ty
+                          Cluster_interface.(InternalError "Cluster.create failed")
            }
     | _, _ ->
      Rpc.{success = true; contents = Rpc.Null }
   in
   try
-    create_cluster ~__context ~test_clusterd_rpc:test_failed_clusterd_rpc () |> ignore;
+    create_cluster ~__context ~test_clusterd_rpc () |> ignore;
     Alcotest.fail "Cluster.create should have failed"
   with
   | e ->
@@ -98,11 +110,11 @@ let test_create_cleanup () =
       [] (Db.Cluster.get_all ~__context);
     Alcotest.(check (slist (Alcotest_comparators.ref ()) compare))
       "Cluster_host refs should be destroyed"
-    [] (Db.Cluster_host.get_all ~__context)
+      [] (Db.Cluster_host.get_all ~__context)
 
 let test =
   [ "test_create_destroy_service_status", `Quick, test_create_destroy_status
   ; "test_enable", `Quick, test_enable
-  ; "test_invalid_cluster_stack", `Quick, test_invalid_cluster_stack
+  ; "test_invalid_parameters", `Quick, test_invalid_parameters
   ; "test_create_cleanup", `Quick, test_create_cleanup
   ]

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -142,3 +142,6 @@ let storage_migrate_vgpu_map_key = "maps_to"
 (* Corosync timeout default values *)
 let default_token_timeout_s = 20.0
 let default_token_timeout_coefficient_s = 1.0
+(* Minimum threshold for token timeout parameters *)
+let minimum_token_timeout_s = 1.0
+let minimum_token_timeout_coefficient_s = 0.65

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -20,9 +20,11 @@ open D
 (* TODO: update allowed_operations on boot/toolstack-restart *)
 
 let validate_params ~token_timeout ~token_timeout_coefficient =
-  let invalid_value x y = raise (Api_errors.(Server_error (invalid_value, [ x; y ]))) in
-  if token_timeout < 1.0 then invalid_value "token_timeout" (string_of_float token_timeout);
-  if token_timeout_coefficient < 0.65 then invalid_value "token_timeout_coefficient" (string_of_float token_timeout_coefficient)
+  let invalid_value x y = raise (Api_errors.(Server_error (invalid_value, [ x; string_of_float y ]))) in
+  if token_timeout < Constants.minimum_token_timeout_s then
+    invalid_value "token_timeout" token_timeout;
+  if token_timeout_coefficient < Constants.minimum_token_timeout_coefficient_s then
+    invalid_value "token_timeout_coefficient" token_timeout_coefficient
 
 let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout ~token_timeout_coefficient =
   assert_cluster_stack_valid ~cluster_stack;


### PR DESCRIPTION
Just as the default cluster token timeout values are stored as constants rather than inline, it makes sense to do this for the minimum threshold for token timeout values.