### PR TITLE
CP-28117: restart VMs in parallel when recovering from a host failure in HA

### DIFF
--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -379,6 +379,7 @@ module Monitor = struct
               try
                 Xapi_ha_vm_failover.restart_auto_run_vms ~__context liveset_refs to_tolerate
               with e ->
+                log_backtrace ();
                 error "Caught unexpected exception when executing restart plan: %s" (ExnHelper.string_of_exn e)
             end;
 

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -705,6 +705,7 @@ let restart_auto_run_vms ~__context live_set n =
       Xapi_alert.add ~msg:Api_messages.ha_protected_vm_restart_failed ~cls:`VM ~obj_uuid ~body:""
     end in
 
+  let open TaskChains.Infix in
   (* execute the plan *)
   Helpers.call_api_functions ~__context
     (fun rpc session_id ->
@@ -730,28 +731,56 @@ let restart_auto_run_vms ~__context live_set n =
            if attempt_restart then begin
              Hashtbl.replace last_start_attempt vm (Unix.gettimeofday ());
              match host with
-             | None -> Client.Client.VM.start rpc session_id vm false true
-             | Some h -> Client.Client.VM.start_on rpc session_id vm h false true
+             | None -> Client.Client.Async.VM.start rpc session_id vm false true
+             | Some h -> Client.Client.Async.VM.start_on rpc session_id vm h false true
            end else failwith (Printf.sprintf "VM: %s restart attempt delayed for 120s" (Ref.string_of vm)) in
-         try
-           go ();
-           true
-         with
-         | Api_errors.Server_error(code, params) when code = Api_errors.ha_operation_would_break_failover_plan ->
+         TaskChains.task go >>= function
+         | Result.Error Api_errors.Server_error(code, params) when code = Api_errors.ha_operation_would_break_failover_plan ->
            (* This should never happen since the planning code would always allow the restart of a protected VM... *)
            error "Caught exception HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN: setting pool as overcommitted and retrying";
            ignore (mark_pool_as_overcommitted ~__context ~live_set : bool);
            begin
-             try
-               go ();
-               true
-             with e ->
-               error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
-               false
+             TaskChains.task go >>= function
+             | Result.Ok _ -> TaskChains.ok ()
+             | Result.Error e -> error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
+               TaskChains.fail e
            end
-         | e ->
+         | Result.Error e ->
            error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
-           false in
+           TaskChains.fail e
+         | Result.Ok _ -> TaskChains.ok ()
+       in
+
+       (** [ordered_map_concat f lst]
+        * traverses the list in order, maps each inner list through [f]
+        * and concatenates the result *)
+       let ordered_map_concat f lst =
+        debug "Processing %d parallel groups" (List.length lst);
+        (* the iteration order is important here for preserving the VM start order *)
+        List.fold_left (fun accum inner ->
+             (* the order of elements in the result doesn't matter,
+              * they were launched in parallel *)
+             List.rev_append (f inner) accum) [] lst
+       in
+
+       (** [map_parallel ~order_f f lst] groups objects in [lst] by order number 
+           (provided by applying [order_f] to each object). For each group of objects
+           it then applies [f] to them to produce an 'a TaskChain.t and then executes this
+           set of TaskChain.t values in parallel until they each of the TaskChain.t 
+           values has been executed to completion. It then begins work on the next group
+           of objects. 
+
+           The return is a list of 'a Result.results
+       *)
+       let map_parallel ~order_f f lst =
+         lst
+         |> Helpers.group_by ~ordering:`ascending order_f
+         |> ordered_map_concat (fun same_order ->
+             same_order
+             |> List.rev_map fst
+             |> List.rev_map f
+             |> TaskChains.parallel ~__context ~rpc ~session_id)
+       in
 
        (* Build a list of bools, one per Halted protected VM indicating whether we managed to start it or not *)
        let started =
@@ -759,23 +788,23 @@ let restart_auto_run_vms ~__context live_set n =
            (* If the Pool is overcommitted the restart priority will make the difference between a VM restart or not,
               					   while if we're undercommitted the restart priority only affects the timing slightly. *)
            let all = List.filter (fun (_, r) -> r.API.vM_power_state = `Halted) all_protected_vms in
-           let all = List.sort by_order all in
            warn "Failed to find plan to restart all protected VMs: falling back to simple VM.start in priority order";
-           List.map (fun (vm, _) -> vm, restart_vm vm ()) all
+           map_parallel ~order_f (fun (vm, vmr) -> (vm, vmr), restart_vm vm ()) all
          end else begin
            (* Walk over the VMs in priority order, starting each on the planned host *)
-           let all = List.sort by_order (List.map (fun (vm, _) -> vm, Db.VM.get_record ~__context ~self:vm) plan) in
-           List.map (fun (vm, _) ->
-               vm, (if List.mem_assoc vm plan
+           let all = List.map (fun (vm, _) -> vm, Db.VM.get_record ~__context ~self:vm) plan in
+           map_parallel ~order_f (fun (vm, vmr) ->
+               (vm,vmr), if List.mem_assoc vm plan
                     then restart_vm vm ~host:(List.assoc vm plan) ()
-                    else false)) all
+                    else TaskChains.fail (Failure "VM has no plan")) all
          end in
        (* Perform one final restart attempt of any that weren't started. *)
-       let started = List.map (fun (vm, started) -> match started with
-           | true -> vm, true
-           | false -> vm, restart_vm vm ()) started in
+       let started = map_parallel ~order_f:(fun (vminfo, _) -> order_f vminfo)
+           (function
+            | (vm,_), Result.Ok () -> vm, TaskChains.ok ()
+            | (vm,_), Result.Error _ -> vm, restart_vm vm ()) started in
        (* Send an alert for any failed VMs *)
-       List.iter (fun (vm, started) -> if not started then consider_sending_failed_alert_for vm) started;
+       List.iter (fun (vm, started) -> if started <> Result.Ok () then consider_sending_failed_alert_for vm) started;
 
        (* Forget about previously failed VMs which have gone *)
        let vms_we_know_about = List.map fst started in
@@ -789,16 +818,18 @@ let restart_auto_run_vms ~__context live_set n =
           			   ok since this is 'best-effort'). NOTE we do not use the restart_vm function above as this will mark the
           			   pool as overcommitted if an HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN is received (although this should never
           			   happen it's better safe than sorry) *)
-       List.iter
+       map_parallel ~order_f:(fun vm -> order_f (vm, Db.VM.get_record ~__context ~self:vm))
          (fun vm ->
-            try
-              if Db.VM.get_power_state ~__context ~self:vm = `Halted
+              vm, if Db.VM.get_power_state ~__context ~self:vm = `Halted
               && Db.VM.get_ha_restart_priority ~__context ~self:vm = Constants.ha_restart_best_effort
-              then Client.Client.VM.start rpc session_id vm false true
-            with e ->
-              error "Failed to restart best-effort VM %s (%s): %s"
-                (Db.VM.get_uuid ~__context ~self:vm)
-                (Db.VM.get_name_label ~__context ~self:vm)
-                (ExnHelper.string_of_exn e)) !reset_vms
-
+              then TaskChains.task (fun () -> Client.Client.Async.VM.start rpc session_id vm false true)
+              else TaskChains.ok (Rpc.Null)) !reset_vms
+       |> List.iter (fun (vm, result) ->
+           match result with
+           | Result.Error e ->
+             error "Failed to restart best-effort VM %s (%s): %s"
+               (Db.VM.get_uuid ~__context ~self:vm)
+               (Db.VM.get_name_label ~__context ~self:vm)
+               (ExnHelper.string_of_exn e)
+           | Result.Ok _ -> ())
     )

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -21,11 +21,11 @@ let all_protected_vms ~__context =
   List.filter (fun (_, vm_rec) -> Helpers.vm_should_always_run vm_rec.API.vM_ha_always_run vm_rec.API.vM_ha_restart_priority) vms
 
 (* Comparison function which can be used to sort a list of VM ref, record by order *)
-let by_order (vm_ref1,vm_rec1) (vm_ref2,vm_rec2) =
+let order_f (vm_ref,vm_rec) =
   let negative_high x = if x<0L then Int64.max_int else x in
-  let vm1_order = negative_high (vm_rec1.API.vM_order) in
-  let vm2_order = negative_high (vm_rec2.API.vM_order) in
-  compare vm1_order vm2_order
+  negative_high (vm_rec.API.vM_order)
+
+let by_order a b = compare (order_f a) (order_f b)
 
 let ($) x y = x y
 


### PR DESCRIPTION
This is PR #3597 rebased and with minor fixups. The following is from @edwintorok directly copied from the previous PR for reference:

I have dev-tested this using VMs created by this script, and then turning the power off on an HA slave, and watching VMs get restarted in the correct order (first all with order=0 got started in parallel, then order=1, then order=2).
```
#!/bin/bash
set -e
MEMORY='16MiB'
N=50
ORDER=2

if [ ! -f /boot/guest/test-vm.xen.gz ]; then
        wget https://github.com/xapi-project/xen-test-vm/releases/download/0.0.5/test-vm.xen.gz
        sha256sum test-vm.xen.gz
        mkdir -p /boot/guest
        mv test-vm.xen.gz /boot/guest
fi


. /etc/xensource-inventory
host_uuid="$INSTALLATION_UUID"

SR=$(xe pool-list params=default-SR --minimal)

for order in $(seq 0 "$ORDER"); do
    for i in $(seq 1 "$N"); do
        vm_uuid=$(xe vm-create name-label="mirage-$order-$i-$MEMORY")
        xe vm-param-set PV-kernel=/boot/guest/test-vm.xen.gz uuid="$vm_uuid"
        xe vm-memory-limits-set uuid="$vm_uuid" static-min="$MEMORY" dynamic-min="$MEMORY" dynamic-max="$MEMORY" static-max="$MEMORY"
        xe vm-param-set uuid="$vm_uuid" ha-restart-priority=restart
        xe vm-param-set uuid="$vm_uuid" order="$order"
        for i in $(seq 1 3); do
            vdi_uuid=$( xe vdi-create sr-uuid="$SR" name-label="mirage-$order-$i-$MEMORY-disk" virtual-size=1MiB)
            xe vbd-create vdi-uuid=$vdi_uuid vm-uuid=$vm_uuid device=autodetect >/dev/null
        done
    done
done
```

I'd love to have some unit tests for the VM restart code, but I couldn't find any. Should new unit tests be written for the HA VM restart code, or just the new helper module?