### PR TITLE
drop debug/graph: not built anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,6 @@ install: build doc
 	scripts/install.sh 755 _build/install/default/bin/mpathalert $(DESTDIR)$(OPTDIR)/bin/mpathalert
 # ocaml/license
 	scripts/install.sh 755 _build/install/default/bin/daily-license-check $(DESTDIR)$(LIBEXECDIR)/daily-license-check
-# ocaml/graph
-	scripts/install.sh 755 _build/install/default/bin/graph $(DESTDIR)$(OPTDIR)/debug/graph
 # ocaml/events
 	scripts/install.sh 755 _build/install/default/bin/event_listen $(DESTDIR)$(OPTDIR)/debug/event_listen
 # ocaml/db_process


### PR DESCRIPTION
7d3504290fa0dd5f139d582df33597fb6cc5f721 dropped the whole ocaml/graph/
Travis was not catching this problem because it uses opam rules (jbuilder) to install things, and not the Makefile.