### PR TITLE
[smapiv3 merge] Implement & move to VDI.attach2 SMAPIv2 call, deprecate VDI.attach

### DIFF
--- a/ocaml/xapi/attach_helpers.ml
+++ b/ocaml/xapi/attach_helpers.ml
@@ -100,3 +100,18 @@ let with_vbds rpc session_id __context vm vdis mode f =
                         (fun self -> safe_unplug rpc session_id self)) !vbds;
            List.iter (Helpers.log_exn_continue "destroying VBD on VM"
                         (fun self -> Client.VBD.destroy rpc session_id self)) !vbds))
+
+(** Separates the implementations of the given backend returned from
+    the VDI.attach2 SMAPIv2 call based on their type *)
+let implementations_of_backend backend =
+  let open Storage_interface in
+  List.fold_left
+    (fun (xendisks, blockdevices, files, nbds) implementation ->
+       match implementation with
+       | XenDisk xendisk -> (xendisk::xendisks, blockdevices, files, nbds)
+       | BlockDevice blockdevice -> (xendisks, blockdevice::blockdevices, files, nbds)
+       | File file -> (xendisks, blockdevices, file::files, nbds)
+       | Nbd nbd -> (xendisks, blockdevices, files, nbd::nbds)
+    )
+    ([], [], [], [])
+    backend.implementations

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -447,7 +447,7 @@ module SMAPIv1 = struct
                    XenDisk {
                      params = attach_info_v1.Smint.params;
                      extra = attach_info_v1.Smint.xenstore_data;
-                     backend_type = "Tapdisk3"
+                     backend_type = "vbd3"
                    };
                    (* We always get a BlockDevice from SMAPIv3, never a File, not even for ISOs *)
                    BlockDevice {

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -449,12 +449,11 @@ module SMAPIv1 = struct
                      extra = attach_info_v1.Smint.xenstore_data;
                      backend_type = "vbd3"
                    };
-                   (* We always get a BlockDevice from SMAPIv3, never a File, not even for ISOs *)
+                   (* Currently we always get a BlockDevice from SMAPIv1, never a File, not even for ISOs *)
                    BlockDevice {
                      path = attach_info_v1.Smint.params
                    }
-                 ];
-                 domain_uuid = "0"
+                 ]
                }
             ) in
         Mutex.execute vdi_read_write_m

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -421,14 +421,14 @@ module SMAPIv1 = struct
       | Api_errors.Server_error(code, params) ->
         raise (Backend_error(code, params))
 
-    let attach context ~dbg ~dp ~sr ~vdi ~read_write =
+    let attach2 context ~dbg ~dp ~sr ~vdi ~read_write =
       try
-        let attach_info =
-          for_vdi ~dbg ~sr ~vdi "VDI.attach"
+        let backend =
+          for_vdi ~dbg ~sr ~vdi "VDI.attach2"
             (fun device_config _type sr self ->
                let attach_info_v1 = Sm.vdi_attach device_config _type sr self read_write in
                (* Record whether the VDI is benefiting from read caching *)
-               Server_helpers.exec_with_new_task "VDI.attach" ~subtask_of:(Ref.of_string dbg) (fun __context ->
+               Server_helpers.exec_with_new_task "VDI.attach2" ~subtask_of:(Ref.of_string dbg) (fun __context ->
                    let read_caching = not attach_info_v1.Smint.o_direct in
                    let on_key = read_caching_key ~__context in
                    let reason_key = read_caching_reason_key ~__context in
@@ -442,16 +442,29 @@ module SMAPIv1 = struct
                            ~value:(attach_info_v1.Smint.o_direct_reason)
                      )
                  );
-               { params = attach_info_v1.Smint.params;
-                 o_direct = attach_info_v1.Smint.o_direct;
-                 o_direct_reason = attach_info_v1.Smint.o_direct_reason;
-                 xenstore_data = attach_info_v1.Smint.xenstore_data; }
+               {
+                 implementations = [
+                   XenDisk {
+                     params = attach_info_v1.Smint.params;
+                     extra = attach_info_v1.Smint.xenstore_data;
+                     backend_type = "Tapdisk3"
+                   };
+                   (* We always get a BlockDevice from SMAPIv3, never a File, not even for ISOs *)
+                   BlockDevice {
+                     path = attach_info_v1.Smint.params
+                   }
+                 ];
+                 domain_uuid = "0"
+               }
             ) in
         Mutex.execute vdi_read_write_m
           (fun () -> Hashtbl.replace vdi_read_write (sr, vdi) read_write);
-        attach_info
+        backend
       with Api_errors.Server_error(code, params) ->
         raise (Backend_error(code, params))
+
+    let attach _ =
+      failwith "We'll never get here: attach is implemented in Storage_impl.Wrapper"
 
     let activate context ~dbg ~dp ~sr ~vdi =
       try
@@ -1344,7 +1357,7 @@ let attach_and_activate ~__context ~vbd ~domid f =
        on_vdi ~__context ~vbd ~domid
          (fun rpc dbg dp sr vdi ->
             let module C = Storage_interface.Client(struct let rpc = rpc end) in
-            let attach_info = C.VDI.attach dbg dp sr vdi read_write in
+            let attach_info = C.VDI.attach2 dbg dp sr vdi read_write in
             C.VDI.activate dbg dp sr vdi;
             f attach_info
          )

--- a/ocaml/xapi/storage_access.mli
+++ b/ocaml/xapi/storage_access.mli
@@ -74,7 +74,7 @@ val transform_storage_exn: (unit -> 'a) -> 'a
     [attach_info] is the result of attaching a VDI which is also activated.
     This should be used everywhere except the migrate code, where we want fine-grained
     control of the ordering of attach/activate/deactivate/detach *)
-val attach_and_activate: __context:Context.t -> vbd:API.ref_VBD -> domid:int -> (Storage_interface.attach_info -> 'a) -> 'a
+val attach_and_activate: __context:Context.t -> vbd:API.ref_VBD -> domid:int -> (Storage_interface.backend -> 'a) -> 'a
 
 (** [deactivate_and_detach __context vbd domid] idempotent function which ensures
     that any attached or activated VDI gets properly deactivated and detached. *)

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -467,12 +467,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
       | file::_, _, _ -> response file.Storage_interface.path
       | _, blockdev::_, _ -> response blockdev.Storage_interface.path
       | _, _, xendisk::_ ->
-        let backend_kind = match xendisk.Storage_interface.backend_type with
-          | "Tapdisk3" -> "vbd3"
-          | "Qdisk" -> "qdisk"
-          | "Blkback" -> "vbd"
-          | x -> x
-        in
+        let backend_kind = xendisk.Storage_interface.backend_type in
         response ~backend_kind ~xenstore_data:xendisk.Storage_interface.extra xendisk.Storage_interface.params
       | [], [], [] -> raise (Storage_interface.Backend_error (Api_errors.internal_error, ["No File, BlockDev, or XenDisk implementation in Datapath.attach response: " ^ (rpc_of_backend backend |> Jsonrpc.to_string)]))
 

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -452,23 +452,25 @@ module Wrapper = functor(Impl: Server_impl) -> struct
     let attach context ~dbg ~dp ~sr ~vdi ~read_write =
       info "VDI.attach dbg:%s dp:%s sr:%s vdi:%s read_write:%b" dbg dp sr vdi read_write;
       let backend = attach2 context ~dbg ~dp ~sr ~vdi ~read_write in
-			(* VDI.attach2 should be used instead, VDI.attach is only kept for
-				 backwards-compatibility, because older xapis call Remote.VDI.attach during SXM.
-				 However, they ignore the return value, so in practice it does not matter what
-				 we return from here. *)
+      (* VDI.attach2 should be used instead, VDI.attach is only kept for
+         backwards-compatibility, because older xapis call Remote.VDI.attach during SXM.
+         However, they ignore the return value, so in practice it does not matter what
+         we return from here. *)
       let (xendisks, blockdevs, files, _nbds) = Attach_helpers.implementations_of_backend backend in
-      let response ?(backend_kind="vbd3") ?(xenstore_data=[]) params =
-        let xenstore_data = if List.mem_assoc "backend-kind" xenstore_data then xenstore_data else ["backend-kind", backend_kind] @ xenstore_data in
-        (* XXX We've thrown o_direct info away from the SMAPIv1 info during the conversion to SMAPIv3 attach info *)
-        { params; xenstore_data; o_direct = true; o_direct_reason = "" }
+      let response params =
+        (* We've thrown o_direct info away from the SMAPIv1 info during the conversion to SMAPIv3 attach info *)
+        (* The removal of these fields does not break read caching info propagation for SMAPIv1
+         * (REQ-49), because we put this information into the VDI's sm_config elsewhere,
+         * and XenCenter looks at the relevant sm_config keys. *)
+        { params; xenstore_data = []; o_direct = true; o_direct_reason = "" }
       in
       (* If Nbd is returned, then XenDisk must also be returned from attach2 *)
-      match files, blockdevs, xendisks with
-      | file::_, _, _ -> response file.Storage_interface.path
-      | _, blockdev::_, _ -> response blockdev.Storage_interface.path
-      | _, _, xendisk::_ ->
+      match xendisks, files, blockdevs with
+      | xendisk::_, _, _ ->
         let backend_kind = xendisk.Storage_interface.backend_type in
         response ~backend_kind ~xenstore_data:xendisk.Storage_interface.extra xendisk.Storage_interface.params
+      | _, file::_, _ -> response file.Storage_interface.path
+      | _, _, blockdev::_ -> response blockdev.Storage_interface.path
       | [], [], [] -> raise (Storage_interface.Backend_error (Api_errors.internal_error, ["No File, BlockDev, or XenDisk implementation in Datapath.attach response: " ^ (rpc_of_backend backend |> Jsonrpc.to_string)]))
 
     let activate context ~dbg ~dp ~sr ~vdi =

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -110,7 +110,7 @@ let string_of_date x = Date.to_string (Date.of_float x)
 module Vdi = struct
   (** Represents the information known about a VDI *)
   type t = {
-    attach_info :  attach_info option;    (** Some path when attached; None otherwise *)
+    attach_info :  backend option;    (** Some path when attached; None otherwise *)
     dps: (Dp.t * Vdi_automaton.state) list; (** state of the VDI from each dp's PoV *)
     leaked: Dp.t list;                        (** "leaked" dps *)
   } [@@deriving rpc]
@@ -156,7 +156,7 @@ module Vdi = struct
     set_dp_state dp state' t
 
   let to_string_list x =
-    let title = Printf.sprintf "%s (device=%s)" (Vdi_automaton.string_of_state (superstate x)) (Opt.default "None" (Opt.map (fun x -> "Some " ^ Jsonrpc.to_string (rpc_of_attach_info x)) x.attach_info)) in
+    let title = Printf.sprintf "%s (device=%s)" (Vdi_automaton.string_of_state (superstate x)) (Opt.default "None" (Opt.map (fun x -> "Some " ^ Jsonrpc.to_string (rpc_of_backend x)) x.attach_info)) in
     let of_dp (dp, state) = Printf.sprintf "DP: %s: %s%s" dp (Vdi_automaton.string_of_state state) (if List.mem dp x.leaked then "  ** LEAKED" else "") in
     title :: (List.map indent (List.map of_dp x.dps))
 end
@@ -306,7 +306,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
             | Vdi_automaton.Nothing -> vdi_t
             | Vdi_automaton.Attach ro_rw ->
               let read_write = (ro_rw = Vdi_automaton.RW) in
-              let x = Impl.VDI.attach context ~dbg ~dp ~sr ~vdi ~read_write in
+              let x = Impl.VDI.attach2 context ~dbg ~dp ~sr ~vdi ~read_write in
               { vdi_t with Vdi.attach_info = Some x }
             | Vdi_automaton.Activate ->
               Impl.VDI.activate context ~dbg ~dp ~sr ~vdi; vdi_t
@@ -438,8 +438,8 @@ module Wrapper = functor(Impl: Server_impl) -> struct
                 Impl.VDI.epoch_begin context ~dbg ~sr ~vdi ~persistent
              ))
 
-    let attach context ~dbg ~dp ~sr ~vdi ~read_write =
-      info "VDI.attach dbg:%s dp:%s sr:%s vdi:%s read_write:%b" dbg dp sr vdi read_write;
+    let attach2 context ~dbg ~dp ~sr ~vdi ~read_write =
+      info "VDI.attach2 dbg:%s dp:%s sr:%s vdi:%s read_write:%b" dbg dp sr vdi read_write;
       with_vdi sr vdi
         (fun () ->
            remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.leaked
@@ -448,6 +448,33 @@ module Wrapper = functor(Impl: Server_impl) -> struct
                     (Vdi_automaton.Attach (if read_write then Vdi_automaton.RW else Vdi_automaton.RO)) in
                 Opt.unbox state.Vdi.attach_info
              ))
+
+    let attach context ~dbg ~dp ~sr ~vdi ~read_write =
+      info "VDI.attach dbg:%s dp:%s sr:%s vdi:%s read_write:%b" dbg dp sr vdi read_write;
+      let backend = attach2 context ~dbg ~dp ~sr ~vdi ~read_write in
+			(* VDI.attach2 should be used instead, VDI.attach is only kept for
+				 backwards-compatibility, because older xapis call Remote.VDI.attach during SXM.
+				 However, they ignore the return value, so in practice it does not matter what
+				 we return from here. *)
+      let (xendisks, blockdevs, files, _nbds) = Attach_helpers.implementations_of_backend backend in
+      let response ?(backend_kind="vbd3") ?(xenstore_data=[]) params =
+        let xenstore_data = if List.mem_assoc "backend-kind" xenstore_data then xenstore_data else ["backend-kind", backend_kind] @ xenstore_data in
+        (* XXX We've thrown o_direct info away from the SMAPIv1 info during the conversion to SMAPIv3 attach info *)
+        { params; xenstore_data; o_direct = true; o_direct_reason = "" }
+      in
+      (* If Nbd is returned, then XenDisk must also be returned from attach2 *)
+      match files, blockdevs, xendisks with
+      | file::_, _, _ -> response file.Storage_interface.path
+      | _, blockdev::_, _ -> response blockdev.Storage_interface.path
+      | _, _, xendisk::_ ->
+        let backend_kind = match xendisk.Storage_interface.backend_type with
+          | "Tapdisk3" -> "vbd3"
+          | "Qdisk" -> "qdisk"
+          | "Blkback" -> "vbd"
+          | x -> x
+        in
+        response ~backend_kind ~xenstore_data:xendisk.Storage_interface.extra xendisk.Storage_interface.params
+      | [], [], [] -> raise (Storage_interface.Backend_error (Api_errors.internal_error, ["No File, BlockDev, or XenDisk implementation in Datapath.attach response: " ^ (rpc_of_backend backend |> Jsonrpc.to_string)]))
 
     let activate context ~dbg ~dp ~sr ~vdi =
       info "VDI.activate dbg:%s dp:%s sr:%s vdi:%s" dbg dp sr vdi;

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -467,8 +467,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
       (* If Nbd is returned, then XenDisk must also be returned from attach2 *)
       match xendisks, files, blockdevs with
       | xendisk::_, _, _ ->
-        let backend_kind = xendisk.Storage_interface.backend_type in
-        response ~backend_kind ~xenstore_data:xendisk.Storage_interface.extra xendisk.Storage_interface.params
+        response xendisk.Storage_interface.params
       | _, file::_, _ -> response file.Storage_interface.path
       | _, _, blockdev::_ -> response blockdev.Storage_interface.path
       | [], [], [] -> raise (Storage_interface.Backend_error (Api_errors.internal_error, ["No File, BlockDev, or XenDisk implementation in Datapath.attach response: " ^ (rpc_of_backend backend |> Jsonrpc.to_string)]))

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -229,29 +229,45 @@ let vdi_info x =
 
 module Local = Client(struct let rpc call = rpc ~srcstr:"smapiv2" ~dststr:"smapiv2" (local_url ()) call end)
 
-let tapdisk_of_attach_info attach_info =
-  let path = attach_info.params in
-  try
-    match Tapctl.of_device (Tapctl.create ()) path with
-    | tapdev, _, _ -> Some tapdev
-  with Tapctl.Not_blktap ->
-    debug "Device %s is not controlled by blktap" path;
+let tapdisk_of_attach_info (backend:Storage_interface.backend) =
+  let xendisks, _, _, _ = Attach_helpers.implementations_of_backend backend in
+  match xendisks with
+  | xendisk :: _ -> begin
+      let path = xendisk.Storage_interface.params in
+      try
+        match Tapctl.of_device (Tapctl.create ()) path with
+        | tapdev, _, _ -> Some tapdev
+      with Tapctl.Not_blktap ->
+        debug "Device %s is not controlled by blktap" path;
+        None
+         | Tapctl.Not_a_device ->
+           debug "%s is not a device" path;
+           None
+         | _ ->
+           debug "Device %s has an unknown driver" path;
+           None
+    end
+  | [] ->
+    debug "No XenDisk implementation in backend: %s" (Storage_interface.rpc_of_backend backend |> Rpc.to_string);
     None
-     | Tapctl.Not_a_device ->
-       debug "%s is not a device" path;
-       None
-     | _ ->
-       debug "Device %s has an unknown driver" path;
-       None
 
 
 let with_activated_disk ~dbg ~sr ~vdi ~dp f =
   let path =
-    Opt.map (fun vdi ->
-        let attach_info = Local.VDI.attach ~dbg ~dp ~sr ~vdi ~read_write:false in
-        let path = attach_info.params in
-        Local.VDI.activate ~dbg ~dp ~sr ~vdi;
-        path) vdi in
+    Opt.map
+      (fun vdi ->
+         let backend = Local.VDI.attach2 ~dbg ~dp ~sr ~vdi ~read_write:false in
+         let (_, blockdevs, files, _) = Attach_helpers.implementations_of_backend backend in
+         match blockdevs, files with
+         | ({ path })::_, _ | _, ({ path })::_ ->
+           Local.VDI.activate ~dbg ~dp ~sr ~vdi;
+           path
+         | [], [] ->
+           Local.VDI.detach ~dbg ~dp ~sr ~vdi;
+           raise (Storage_interface.Backend_error (Api_errors.internal_error, ["No BlockDevice or File implementation in Datapath.attach response: " ^ (rpc_of_backend backend |> Jsonrpc.to_string)]))
+      )
+      vdi
+  in
   finally
     (fun () -> f path)
     (fun () ->
@@ -335,7 +351,7 @@ let copy' ~task ~dbg ~sr ~vdi ~url ~dest ~dest_vdi =
 
     Pervasiveext.finally (fun () ->
         debug "activating RW datapath %s on remote=%s/%s" remote_dp dest dest_vdi;
-        ignore(Remote.VDI.attach ~dbg ~sr:dest ~vdi:dest_vdi ~dp:remote_dp ~read_write:true);
+        ignore(Remote.VDI.attach2 ~dbg ~sr:dest ~vdi:dest_vdi ~dp:remote_dp ~read_write:true);
         Remote.VDI.activate ~dbg ~dp:remote_dp ~sr:dest ~vdi:dest_vdi;
 
         with_activated_disk ~dbg ~sr ~vdi:base_vdi ~dp:base_dp
@@ -682,7 +698,7 @@ let receive_start ~dbg ~sr ~vdi_info ~id ~similar =
     on_fail := (fun () -> Local.VDI.destroy ~dbg ~sr ~vdi:dummy.vdi) :: !on_fail;
     debug "Created dummy snapshot for mirror receive: %s" (string_of_vdi_info dummy);
 
-    let _ = Local.VDI.attach ~dbg ~dp:leaf_dp ~sr ~vdi:leaf.vdi ~read_write:true in
+    let _ = Local.VDI.attach2 ~dbg ~dp:leaf_dp ~sr ~vdi:leaf.vdi ~read_write:true in
     Local.VDI.activate ~dbg ~dp:leaf_dp ~sr ~vdi:leaf.vdi;
 
     let nearest = List.fold_left

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -123,29 +123,9 @@ module Mux = struct
         )
   end
   module DP = struct
-    let create context ~dbg ~id = id (* XXX: is this pointless? *)
-    let destroy context ~dbg ~dp ~allow_leak =
-      (* Tell each plugin about this *)
-      match fail_or choose (multicast (fun sr rpc ->
-          let module C = Client(struct let rpc = of_sr sr end) in
-          C.DP.destroy ~dbg ~dp ~allow_leak)) with
-      | SMSuccess x -> x
-      | SMFailure e -> raise e
-
-    let diagnostics context () =
-      forall (fun sr rpc ->
-          let module C = Client(struct let rpc = of_sr sr end) in
-          C.DP.diagnostics ()
-        )
-
-    let attach_info context ~dbg ~sr ~vdi ~dp =
-      let module C = Client(struct let rpc = of_sr sr end) in
-      C.DP.attach_info ~dbg ~sr ~vdi ~dp
-
-    let stat_vdi context ~dbg ~sr ~vdi =
-      let module C = Client(struct let rpc = of_sr sr end) in
-      C.DP.stat_vdi ~dbg ~sr ~vdi
-
+    (* We'll never get here, because DP is implemented in
+       Storage_impl.Wrapper(Impl), and it never calls Impl.DP *)
+    include Storage_skeleton.DP
   end
   module SR = struct
     include Storage_skeleton.SR
@@ -225,9 +205,12 @@ module Mux = struct
     let epoch_begin context ~dbg ~sr ~vdi ~persistent =
       let module C = Client(struct let rpc = of_sr sr end) in
       C.VDI.epoch_begin ~dbg ~sr ~vdi ~persistent
+    (* We need to include this to satisfy the SMAPIv2 signature *)
     let attach context ~dbg ~dp ~sr ~vdi ~read_write =
+      failwith "We'll never get here: attach is implemented in Storage_impl.Wrapper"
+    let attach2 context ~dbg ~dp ~sr ~vdi ~read_write =
       let module C = Client(struct let rpc = of_sr sr end) in
-      C.VDI.attach ~dbg ~dp ~sr ~vdi ~read_write
+      C.VDI.attach2 ~dbg ~dp ~sr ~vdi ~read_write
     let activate context ~dbg ~dp ~sr ~vdi =
       let module C = Client(struct let rpc = of_sr sr end) in
       C.VDI.activate ~dbg ~dp ~sr ~vdi

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -659,7 +659,7 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far t
         let read_write = true in
         (* DP set up is only essential for MIRROR.start/stop due to their open ended pattern.
            It's not necessary for copy which will take care of that itself. *)
-        ignore(SMAPI.VDI.attach ~dbg ~dp:new_dp ~sr:vconf.sr ~vdi:vconf.location ~read_write);
+        ignore(SMAPI.VDI.attach2 ~dbg ~dp:new_dp ~sr:vconf.sr ~vdi:vconf.location ~read_write);
         SMAPI.VDI.activate ~dbg ~dp:new_dp ~sr:vconf.sr ~vdi:vconf.location;
         ignore(Storage_access.register_mirror __context vconf.location);
         SMAPI.DATA.MIRROR.start ~dbg ~sr:vconf.sr ~vdi:vconf.location ~dp:new_dp ~url:remote.sm_url ~dest:dest_sr_uuid

--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -229,6 +229,19 @@ def disconnect_nbd_device(nbd_device):
         ['/opt/xensource/libexec/nbd_client_manager.py', 'disconnect',
          '--device', nbd_device])
 
+
+def parse_nbd_uri(uri):
+    parts = uri.split(':')
+    exportname_prefix = 'exportname='
+    if len(parts) != 3 or \
+            parts[0:2] != ['nbd', 'unix'] or \
+            not parts[3].startswith(exportname_prefix):
+        raise Exception('Got invalid NBD URI for SM backend: ' + uri)
+    socket_path = parts[2]
+    exportname = parts[3][len(exportname_prefix):]
+    return (socket_path, exportname)
+
+
 def attach(vdi_uuid):
     found = False
     for existing in list():
@@ -255,14 +268,18 @@ def attach(vdi_uuid):
                     scheme = urlparse.urlparse(vol_uri).scheme
                     sr = sr_attach(volume_plugin, configuration)
                     attach = call_datapath_plugin(scheme, "Datapath.attach", [ vol_uri, "0" ])
-                    path = attach['implementation'][1]
+                    (name, implementation) = \
+                            next((name, impl)
+                                 for (name, impl)
+                                 in attach['implementations']
+                                 if name in ['BlockDevice', 'File', 'Nbd'])
                     call_datapath_plugin(scheme, "Datapath.activate", [ vol_uri, "0" ])
-                    nbd_prefix = 'hack|nbd:unix:'
-                    nbd = path.startswith(nbd_prefix)
-                    if nbd:
-                        path = path[len(nbd_prefix):]
-                        socket_path = path.split('|')[0]
-                        path = connect_nbd(socket_path, 'qemu_node')
+                    if name in ['BlockDevice', 'File']:
+                        path = implementation['path']
+                    elif name == 'Nbd':
+                        uri = implementation['uri']
+                        (path, exportname) = parse_nbd_uri(uri)
+                        path = connect_nbd(path=path, exportname=exportname)
 
                 os.symlink(path, d + "/disk")
                 return d + "/disk"


### PR DESCRIPTION
We cannot change the original VDI.attach call, because during SXM, older
xapis call Remote.VDI.attach, therefore changing it's return type would
break backward compatibility and SXM. Therefore I kept the old
VDI.attach for backward compatibility, it just calls attach2 at the
Storage_impl layer and transforms its return type. Although that is not
strictly necessary, because in older xapis we ignore the return type of the
Remote.VDI.attach call.

Now only older xapis will be calling the deprecated VDI.attach during
SXM, newer versions starting from this one will use the new VDI.attach2
call.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xen-api/3633)
<!-- Reviewable:end -->
