### PR TITLE
CA-292621: ensure PIF has an IP before calling clustering methods

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -142,9 +142,7 @@ let assert_bacon_mode ~__context ~host =
       ));
   debug "Bacon test: VBDs OK"
 
-let signal_networking_change ~__context =
-  Helpers.update_pif_addresses ~__context;
-  Xapi_mgmt_iface.on_dom0_networking_change ~__context
+let signal_networking_change = Xapi_mgmt_iface.on_dom0_networking_change
 
 let signal_cdrom_event ~__context params =
   let find_vdi_name sr name =

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -182,14 +182,14 @@ let wait_for_clustering_ip ~__context ~(self : API.ref_Cluster_host) =
   let pIF = Db.Cluster_host.get_PIF ~__context ~self in
   let network = Db.PIF.get_network ~__context ~self:pIF in
   let bridge = Db.Network.get_bridge ~__context ~self:network in
-  let primary_address_type = Db.PIF.get_primary_address_type ~__context ~self:pIF in
   debug "Waiting for clustering IP on bridge %s (%s)" bridge (Ref.string_of pIF);
-  let get_ip () = Helpers.get_primary_ip_addr ~__context bridge primary_address_type in
+  let get_ip () = match Db.PIF.get_IP ~__context ~self:pIF with "" -> None | s -> Some s in
   let is_connected () = Helpers.get_bridge_is_connected ~__context bridge in
   wait_for_ip get_ip is_connected
 
 let on_dom0_networking_change ~__context =
   debug "Checking to see if hostname or management IP has changed";
+  Helpers.update_pif_addresses ~__context;
   (* Need to update:
      	   1 Host.hostname
      	   2 Host.address


### PR DESCRIPTION
   CA-292621: ensure PIF has an IP before calling clustering methods

    The IP address would be updated asynchronously by the network monitor thread,
    so we can detect there is an IP on the link but fail later when trying to read
    the IP from the DB.
    We cannot simply wait on the condition variable until the DB is updated:
    the condition is not signalled. We could use the event mechanism to wait
    until the IP field gets updated, but that adds more connections to the
    master which hurts large pool scalability.
    Also when we wake up we couldn't been woken up due to a change on
    another PIF, not the one we were watching.

    To avoid race conditions always update the IP addresses of all PIFs on a
    networking change, and check for the presence of an IP address in the DB
    in the clustering network watcher thread.
    That way we know that when we get to the clustering code we will have an
    IP address.