### PR TITLE
Update xapi.opam to match xs-opam meta data

### DIFF
--- a/xapi.opam
+++ b/xapi.opam
@@ -43,6 +43,7 @@ depends: [
   "xenctrl"
   "xenstore"
   "yojson"
+  "alcotest"
 ]
 depexts: [
   [["debian"] ["hwdata" "libpci-dev" "libpam-dev"]]


### PR DESCRIPTION
This adds a dependency as it is found (and tested) in the xs-opam
repository.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>