### PR TITLE
CA-291017: Unable to connect server in pool of 64 physical hosts

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -158,6 +158,8 @@ start() {
         "@LIBEXECDIR@/generate_ssl_cert" ${PEMFILE} ${CN}
     fi
     writeconffile
+    # Increase the fd limit to 2048, so stunnel could accept 1000 client connections
+    ulimit -n 2048
     start_daemon ${STUNNEL} ${SSLCONFFILE}
     RETVAL=$?
 


### PR DESCRIPTION
Stunnel restrict it could only use 125/256 of the fds that limited by system. We
set the fd limit to 1024 by default, so stunnel could only use 500 fds for
connection. It is not enough for the master host in pool of 64 hosts when the
pool experiencing high loads.

This fix target to reconfigure the fd limites for xapi and stunnel from 1024 to
4096 to resolve the issue.

Signed-off-by: Yang Qian <yang.qian@citrix.com>