### PR TITLE
CA-292063: detach static VDIs when HA is disarmed on boot

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -468,7 +468,8 @@ let resynchronise_ha_state () =
          | true, false ->
            info "HA has been disabled on the Pool while we were offline; disarming HA locally";
            Localdb.put Constants.ha_armed "false";
-           Xapi_ha.Monitor.stop ()
+           let localhost = Helpers.get_localhost ~__context in
+           Xapi_ha.ha_release_resources __context localhost
          | false, true ->
            info "HA has been disabled on localhost but not the Pool.";
            if Pool_role.is_master () then begin

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -1577,19 +1577,19 @@ let before_clean_shutdown_or_reboot ~__context ~host =
           info "Still waiting to reboot after %.2f seconds" (Unix.gettimeofday () -. start)
         done
     end;
+  end;
 
-    (* We must do this before attempting to detach the VDI holding the redo log,
-       otherwise we would either get an error later or hang.
+  (* We must do this before attempting to detach the VDI holding the redo log,
+     otherwise we would either get an error later or hang.
 
-       Note that Xha_metadata_vdi is a VDI with reason = ha_metadata_vdi_reason and type=`redo_log:
-       type=`metadata is for DR *)
-    debug "About to close active redo logs";
-    Redo_log.with_active_redo_logs (Redo_log.shutdown);
+     Note that Xha_metadata_vdi is a VDI with reason = ha_metadata_vdi_reason and type=`redo_log:
+     type=`metadata is for DR *)
+  debug "About to close active redo logs";
+  Redo_log.with_active_redo_logs (Redo_log.shutdown);
 
-    (* We cannot call ha_release_resources because we want to keep HA armed on reboot *)
-    debug "About to detach static VDIs";
+  (* We cannot call ha_release_resources because we want to keep HA armed on reboot *)
+  debug "About to detach static VDIs";
 
-    List.iter (Static_vdis.detach_only) (Static_vdis.list ());
+  List.iter (Static_vdis.detach_only) (Static_vdis.list ());
 
-    debug "Detached static VDIs"
-  end
+  debug "Detached static VDIs"


### PR DESCRIPTION
HA is disarmed on boot if we determine that it got disabled on the pool
while we were off.
However the static VDIs stayed attached, which prevented the PBD from
getting unplugged, e.g. on shutdown. Normally the shutdown code would unplug
these but since HA was disabled that code does not run.

Clean up any static VDIs at the point where we disarm HA on boot by
releasing all HA resources, not just the monitor.
The monitor is stopped when releasing the HA resources, so replace the
call to stop a monitor with releasing the resources.

Dev-tested on a virtual pool and tap-ctl list wasn't showing any active disks after this patch and I was able to unplug the PBDs.