### PR TITLE
CP-28753: add CLUSTER_HOST_FENCING message

### DIFF
--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -136,3 +136,4 @@ let pool_cpu_features_up = addMessage "POOL_CPU_FEATURES_UP" 5L
 (* Cluster messages *)
 let cluster_host_creation_failed = addMessage "CLUSTER_HOST_CREATION_FAILED" 3L
 let cluster_host_enable_failed = addMessage "CLUSTER_HOST_ENABLE_FAILED" 3L
+let cluster_host_fencing = addMessage "CLUSTER_HOST_FENCING" 2L


### PR DESCRIPTION
This message is created by clustering daemon fencing hooks,
and needed by XenCenter to localise the message.