### PR TITLE
CA-290840: VM.attached_PCIs field not properly cleanup when reverting…

### DIFF
--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -433,6 +433,8 @@ let do_not_copy = [
   "consoles"; "VBDs"; "VIFs"; "VGPUs"; "VUSBs";
   (* Stateful fields that will be reset anyway *)
   "power_state";
+  (* Attached PCIs should not revert from snapshot *)
+  "attached_PCIs";
 ]
 
 let overrides = [


### PR DESCRIPTION
… from snapshot

When reverting from a snapshot, VM.attached_PCIs reverts from snapshot. However
as this field is automatically updated when updating corresponding
PCI.attached_VMs, and PCI.attached_VMs has already been cleanup when shutting down
the VM, so it is impossible to cleanup the value of VM.attached_PCIs which
reverts from the snapshot.

This patch prevents reverting of VM.attached_PCIs when reverting from snapshot.

Signed-off-by: Yang Qian <yang.qian@citrix.com>