### PR TITLE
CA-293786: Cluster.get_network should not be restricted to pool admin

### DIFF
--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -93,7 +93,7 @@ let get_network = call
       [ Ref _cluster, "self", "the Cluster with the network"
       ]
     ~lifecycle
-    ~allowed_roles:_R_POOL_ADMIN
+    ~allowed_roles:_R_READ_ONLY
     ()
 
 let pool_create = call


### PR DESCRIPTION
This appears to have been due to copying the other API functions definitions as a template when defining this one. There is no reason to restrict this to pool admin, anyone should be able to see the configuration.
Using _R_READ_ONLY is consistent with other `get_` APIs, e.g. `get_data_sources`.