### PR TITLE
CA-293858: Further prevention of logrotate running on old partition s…

### DIFF
--- a/scripts/xapi-logrotate.sh
+++ b/scripts/xapi-logrotate.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# If we're using the old partitioning scheme there's no need to run this.
+if ! grep -q /var/log /proc/mounts; then
+  exit 0
+fi
+
 /usr/sbin/logrotate /etc/xensource/xapi-logrotate.conf
 EXITVALUE=$?
 if [ $EXITVALUE != 0 ]; then


### PR DESCRIPTION
…cheme

There's a firstboot script that attempts to prevent the new logrotate script
running when you've got the old-style partition layout. It does this by moving
the cron file aside. Unfortunately the cron file belongs to the xapi RPM and
hence installing any newer xapi-core RPM puts the file back in place.

This is a quick-fix solution that applies the same logic that the firstboot
script uses to detect old-style partitioning and bails out if it sees it.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>