### PR TITLE
CA-289997: Fix for VDI.allowed_operations

### DIFF
--- a/ocaml/tests/alcotest_comparators.ml
+++ b/ocaml/tests/alcotest_comparators.ml
@@ -48,3 +48,11 @@ let assert_raises_match exception_match fn =
     if not (exception_match failure)
     then raise failure
     else ()
+
+let vdi_operations_set : API.vdi_operations_set Alcotest.testable =
+  let intersect xs ys = List.filter (fun x -> List.mem x ys) xs in 
+  let set_difference a b = List.filter (fun x -> not(List.mem x b)) a in
+  Alcotest.testable (Fmt.of_to_string (fun l -> API.rpc_of_vdi_operations_set l |> Jsonrpc.to_string))
+    (fun o1 o2 ->
+       List.length (intersect o1 o2) = List.length o1 && List.length (set_difference o1 o2) = 0 && List.length (set_difference o2 o1) = 0)
+      

--- a/ocaml/xapi/cancel_tasks.ml
+++ b/ocaml/xapi/cancel_tasks.ml
@@ -58,7 +58,7 @@ let update_all_allowed_operations ~__context =
       List.iter (safe_wrapper "allowed_ops - VDIs"
                    (fun self ->
                     let relevant_vbds = List.filter (fun (_, vbd_record) -> vbd_record.Db_actions.vBD_VDI = self) vbd_records in
-                   Xapi_vdi.update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records ~vbd_records:relevant_vbds)) all_vdis;
+                   Xapi_vdi.update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records ~vbd_records:relevant_vbds () )) all_vdis;
       debug "Finished updating allowed operations: VDI");
   (* SR *)
   time_this "Cancel_tasks.update_all_allowed_operations: SR" (fun () ->

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -283,7 +283,7 @@ let assert_operation_valid ~__context ~self ~(op:API.vdi_operations) =
     None -> ()
   | Some (a,b) -> raise (Api_errors.Server_error (a,b))
 
-let update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records ~vbd_records =
+let update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records ?vbd_records () =
   let pool = Helpers.get_pool ~__context in
   let ha_enabled = Db.Pool.get_ha_enabled ~__context ~self:pool in
 
@@ -307,7 +307,7 @@ let update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records
   in
   let all = Db.VDI.get_record_internal ~__context ~self in
   let allowed =
-    let check x = match check_operation_error ~__context ~sr_records ~pbd_records ~vbd_records ha_enabled all self x with None ->  [ x ] | _ -> [] in
+    let check x = match check_operation_error ~__context ~sr_records ~pbd_records ?vbd_records ha_enabled all self x with None ->  [ x ] | _ -> [] in
     List.fold_left (fun accu op -> check op @ accu) [] all_ops
   in
   let allowed =
@@ -318,7 +318,7 @@ let update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records
   Db.VDI.set_allowed_operations ~__context ~self ~value:allowed
 
 let update_allowed_operations ~__context ~self : unit =
-  update_allowed_operations_internal ~__context ~self ~sr_records:[] ~pbd_records:[] ~vbd_records:[]
+  update_allowed_operations_internal ~__context ~self ~sr_records:[] ~pbd_records:[] ()
 
 let cancel_tasks ~__context ~self ~all_tasks_in_db ~task_ids =
   let ops = Db.VDI.get_current_operations ~__context ~self in

--- a/ocaml/xapi/xapi_vdi.mli
+++ b/ocaml/xapi/xapi_vdi.mli
@@ -41,7 +41,7 @@ val update_allowed_operations_internal :
   self:[ `VDI ] API.Ref.t ->
   sr_records:'a list ->
   pbd_records:('b API.Ref.t * API.pBD_t) list ->
-  vbd_records:('c API.Ref.t * Db_actions.vBD_t) list -> unit
+  ?vbd_records:('c API.Ref.t * Db_actions.vBD_t) list -> unit -> unit
 
 val update_allowed_operations :
   __context:Context.t -> self:[ `VDI ] API.Ref.t -> unit


### PR DESCRIPTION
Fix a confusion between 'None' and 'Some []' leading to the field VDI.allowed_operations being computed without ever referencing any VBDs.