### PR TITLE
CP-28116: reintroduce VM quicktests

### DIFF
--- a/ocaml/quicktest/qt.mli
+++ b/ocaml/quicktest/qt.mli
@@ -39,10 +39,12 @@ end
 module VM : sig
   module Template : sig
     val other : string
-    val find : rpc -> API.ref_session -> string -> API.ref_VM
+    val find : rpc -> API.ref_session -> string -> API.ref_VM option
+    (** Returns the first template, if any, whose name starts with the given string *)
   end
 
-  val install : rpc -> API.ref_session -> string -> string -> API.ref_VM
+  val with_new : rpc -> API.ref_session -> template:API.ref_VM -> (API.ref_VM -> 'a) -> 'a
+
   val dom0_of_host : rpc -> API.ref_session -> API.ref_host -> API.ref_VM
   (** Return a host's domain zero *)
 

--- a/ocaml/quicktest/qt_filter.ml
+++ b/ocaml/quicktest/qt_filter.ml
@@ -213,3 +213,11 @@ module SR = struct
 end
 
 let sr = SR.f
+
+let vm_template template_name =
+  for_each
+    (fun (name, speed, test) ->
+       match Qt.VM.Template.find !A.rpc !session_id template_name with
+       | None -> []
+       | Some vm_template -> [(name, speed, test vm_template)]
+    )

--- a/ocaml/quicktest/qt_filter.mli
+++ b/ocaml/quicktest/qt_filter.mli
@@ -60,3 +60,4 @@ end
 
 val sr : SR.srs -> (Qt.sr_info -> 'b, 'b) filter
 
+val vm_template : string -> (API.ref_VM -> 'b, 'b) filter

--- a/ocaml/quicktest/quicktest.ml
+++ b/ocaml/quicktest/quicktest.ml
@@ -30,6 +30,7 @@ let () =
          ; "Quicktest_iso_sr", Quicktest_iso_sr.tests ()
          ; "Quicktest_async_calls", Quicktest_async_calls.tests ()
          ; "Quicktest_vm_import_export", Quicktest_vm_import_export.tests ()
+         ; "Quicktest_vm_lifecycle", Quicktest_vm_lifecycle.tests ()
          ; "Quicktest_vdi_ops_data_integrity", Quicktest_vdi_ops_data_integrity.tests ()
          ; "Quicktest_max_vdi_size", Quicktest_max_vdi_size.tests ()
          ; "Quicktest_static_vdis", Quicktest_static_vdis.tests ()

--- a/ocaml/quicktest/quicktest_vm_import_export.ml
+++ b/ocaml/quicktest/quicktest_vm_import_export.ml
@@ -23,84 +23,86 @@ let vm_uninstall rpc session_id vm =
   let uuid = Client.Client.VM.get_uuid rpc session_id vm in
   ignore(Qt.cli_cmd [ "vm-uninstall"; "uuid=" ^ uuid; "--force" ])
 
-(** Create a small VM with a selection of CDs, empty drives, "iso" Disks etc *)
-let setup_export_test_vm rpc session_id sr =
+(** Set up export test: create a small VM with a selection of CDs, empty drives, "iso" Disks etc *)
+let with_setup rpc session_id sr vm_template f =
   print_endline "Setting up test VM";
-  let t = Qt.VM.Template.find rpc session_id Qt.VM.Template.other in
-  let uuid = Client.Client.VM.get_uuid rpc session_id t in
+  let uuid = Client.Client.VM.get_uuid rpc session_id vm_template in
   print_endline (Printf.sprintf "Template has uuid: %s%!" uuid);
-  let vm = Qt.VM.install rpc session_id uuid "quicktest-export" in
-  print_endline (Printf.sprintf "Installed new VM");
-  let cd =
-    let tools_iso_filter = "field \"is_tools_iso\"=\"true\"" in
-    match Client.Client.VDI.get_all_records_where rpc session_id tools_iso_filter with
-    | (vdi, _)::_ -> vdi
-    | [] ->
-      Alcotest.fail "setup_export_test_vm: Failed to find tools ISO VDI";
-  in
-  print_endline (Printf.sprintf "Using SR: %s" (name_of_sr rpc session_id sr));
-  let vdi = Client.Client.VDI.create rpc session_id "small"
-      "description" sr 4194304L `user false false [] [] [] [] in
-  ignore(Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:cd ~userdevice:"0" ~bootable:false
-           ~mode:`RO ~_type:`CD ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]);
-  ignore(Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:cd ~userdevice:"1" ~bootable:false
-           ~mode:`RO ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]);
-  ignore(Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:cd ~userdevice:"2" ~bootable:false
-           ~mode:`RO ~_type:`CD ~unpluggable:true ~empty:true ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]);
-  ignore(Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~userdevice:"3" ~bootable:false
-           ~mode:`RW ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[Xapi_globs.owner_key,""]
-           ~qos_algorithm_type:"" ~qos_algorithm_params:[]);
-  vm
+  Qt.VM.with_new rpc session_id ~template:vm_template
+    (fun vm ->
+      print_endline (Printf.sprintf "Installed new VM");
+      let cd =
+        let tools_iso_filter = "field \"is_tools_iso\"=\"true\"" in
+        match Client.Client.VDI.get_all_records_where rpc session_id tools_iso_filter with
+        | (vdi, _)::_ -> vdi
+        | [] ->
+          Alcotest.fail "setup_export_test_vm: Failed to find tools ISO VDI";
+      in
+      print_endline (Printf.sprintf "Using SR: %s" (name_of_sr rpc session_id sr));
+      let vdi = Client.Client.VDI.create rpc session_id "small"
+          "description" sr 4194304L `user false false [] [] [] [] in
+      ignore(Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:cd ~userdevice:"0" ~bootable:false
+               ~mode:`RO ~_type:`CD ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]);
+      ignore(Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:cd ~userdevice:"1" ~bootable:false
+               ~mode:`RO ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]);
+      ignore(Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:cd ~userdevice:"2" ~bootable:false
+               ~mode:`RO ~_type:`CD ~unpluggable:true ~empty:true ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]);
+      ignore(Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~userdevice:"3" ~bootable:false
+               ~mode:`RW ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[Xapi_globs.owner_key,""]
+               ~qos_algorithm_type:"" ~qos_algorithm_params:[]);
+      f vm
+    )
 
-let import_export_test rpc session_id sr_info () =
+let import_export_test rpc session_id sr_info vm_template () =
   let sr = sr_info.Qt.sr in
-  let vm = setup_export_test_vm rpc session_id sr in
-  let by_device = List.map (fun vbd -> Client.Client.VBD.get_userdevice rpc session_id vbd, vbd) (Client.Client.VM.get_VBDs rpc session_id vm) in
+  with_setup rpc session_id sr vm_template
+    (fun vm ->
+       let by_device = List.map (fun vbd -> Client.Client.VBD.get_userdevice rpc session_id vbd, vbd) (Client.Client.VM.get_VBDs rpc session_id vm) in
 
-  Xapi_stdext_unix.Unixext.unlink_safe export_filename;
-  vm_export rpc session_id vm export_filename;
-  let all_srs = Qt_filter.SR.(list_srs (all |> not_iso |> (allowed_operations [`vdi_create]))) in
-  List.iter
-    (fun sr_info ->
-       let sr = sr_info.Qt.sr in
-       print_endline (Printf.sprintf "Attempting import to SR: %s" (name_of_sr rpc session_id sr));
-       let vm' = List.hd (vm_import ~sr rpc session_id export_filename) in
-       let vbds = Client.Client.VM.get_VBDs rpc session_id vm' in
+       Xapi_stdext_unix.Unixext.unlink_safe export_filename;
+       vm_export rpc session_id vm export_filename;
+       let all_srs = Qt_filter.SR.(list_srs (all |> not_iso |> (allowed_operations [`vdi_create]))) in
+       List.iter
+         (fun sr_info ->
+            let sr = sr_info.Qt.sr in
+            print_endline (Printf.sprintf "Attempting import to SR: %s" (name_of_sr rpc session_id sr));
+            let vm' = List.hd (vm_import ~sr rpc session_id export_filename) in
+            let vbds = Client.Client.VM.get_VBDs rpc session_id vm' in
 
-       if List.length vbds <> (List.length by_device) then Alcotest.fail "Wrong number of VBDs after import";
-       List.iter (fun vbd ->
-           let all = Client.Client.VBD.get_record rpc session_id vbd in
-           let orig_vbd = List.assoc all.API.vBD_userdevice by_device in
-           let orig_vbd = Client.Client.VBD.get_record rpc session_id orig_vbd in
+            if List.length vbds <> (List.length by_device) then Alcotest.fail "Wrong number of VBDs after import";
+            List.iter (fun vbd ->
+                let all = Client.Client.VBD.get_record rpc session_id vbd in
+                let orig_vbd = List.assoc all.API.vBD_userdevice by_device in
+                let orig_vbd = Client.Client.VBD.get_record rpc session_id orig_vbd in
 
-           (* type, empty should match *)
-           if all.API.vBD_type <> orig_vbd.API.vBD_type
-           then Alcotest.fail (Printf.sprintf "Device %s varies in type" all.API.vBD_userdevice);
-           if all.API.vBD_empty <> orig_vbd.API.vBD_empty
-           then Alcotest.fail (Printf.sprintf "Device %s varies in emptiness" all.API.vBD_userdevice);
-           match all.API.vBD_userdevice with
-           | "0" | "1" | "2" ->
-             (* VDI should be the same *)
-             if all.API.vBD_VDI <> orig_vbd.API.vBD_VDI
-             then Alcotest.fail
-                 (Printf.sprintf "Device %s varies in VDIness (original = %s; new = %s)"
-                    all.API.vBD_userdevice
-                    (Client.Client.VDI.get_uuid rpc session_id orig_vbd.API.vBD_VDI)
-                    (Client.Client.VDI.get_uuid rpc session_id all.API.vBD_VDI)
-                 )
-           | "3" ->
-             (* VDI should be different *)
-             if all.API.vBD_VDI = orig_vbd.API.vBD_VDI
-             then Alcotest.fail (Printf.sprintf "Device %s should not vary in VDIness" all.API.vBD_userdevice)
-           | _ -> Alcotest.fail (Printf.sprintf "Unhandled device number: %s" all.API.vBD_userdevice)) vbds;
-       vm_uninstall rpc session_id vm'
-    ) all_srs;
-  vm_uninstall rpc session_id vm;
-  Unix.unlink export_filename
+                (* type, empty should match *)
+                if all.API.vBD_type <> orig_vbd.API.vBD_type
+                then Alcotest.fail (Printf.sprintf "Device %s varies in type" all.API.vBD_userdevice);
+                if all.API.vBD_empty <> orig_vbd.API.vBD_empty
+                then Alcotest.fail (Printf.sprintf "Device %s varies in emptiness" all.API.vBD_userdevice);
+                match all.API.vBD_userdevice with
+                | "0" | "1" | "2" ->
+                  (* VDI should be the same *)
+                  if all.API.vBD_VDI <> orig_vbd.API.vBD_VDI
+                  then Alcotest.fail
+                      (Printf.sprintf "Device %s varies in VDIness (original = %s; new = %s)"
+                         all.API.vBD_userdevice
+                         (Client.Client.VDI.get_uuid rpc session_id orig_vbd.API.vBD_VDI)
+                         (Client.Client.VDI.get_uuid rpc session_id all.API.vBD_VDI)
+                      )
+                | "3" ->
+                  (* VDI should be different *)
+                  if all.API.vBD_VDI = orig_vbd.API.vBD_VDI
+                  then Alcotest.fail (Printf.sprintf "Device %s should not vary in VDIness" all.API.vBD_userdevice)
+                | _ -> Alcotest.fail (Printf.sprintf "Unhandled device number: %s" all.API.vBD_userdevice)) vbds;
+            vm_uninstall rpc session_id vm'
+         ) all_srs;
+       Unix.unlink export_filename
+    )
 
 let tests () =
   let open Qt_filter in
-  [ ["import_export_test", `Slow, import_export_test] |> conn |> sr SR.(all |> allowed_operations [`vdi_create])
+  [ ["import_export_test", `Slow, import_export_test] |> conn |> sr SR.(all |> allowed_operations [`vdi_create]) |> vm_template Qt.VM.Template.other
   ]
   |> List.concat
 

--- a/ocaml/quicktest/quicktest_vm_lifecycle.ml
+++ b/ocaml/quicktest/quicktest_vm_lifecycle.ml
@@ -1,0 +1,103 @@
+
+type api_call =
+  | Shutdown
+  | Reboot
+[@@deriving rpcty]
+
+type api_mode =
+  | Clean
+  | Hard
+[@@deriving rpcty]
+
+type api = api_mode * api_call [@@deriving rpcty]
+
+type internal_op =
+  | Internal_reboot
+  | Internal_halt
+  | Internal_crash
+[@@deriving rpcty]
+
+type result =
+  | Rebooted
+  | Halted
+[@@deriving rpcty]
+
+type test = Api of api | Internal_op of internal_op [@@deriving rpcty]
+
+let expected_result = function
+  | Api (_, Shutdown) -> Halted
+  | Api (_, Reboot) -> Rebooted
+  | Internal_op (Internal_halt | Internal_crash) -> Halted
+  | Internal_op Internal_reboot -> Rebooted
+
+let string_of_test test =
+  let string_of ty x = Rpcmarshal.marshal ty x |> Rpc.to_string in
+  Printf.sprintf "%s -> %s"
+    (string_of typ_of_test test)
+    (string_of typ_of_result (expected_result test))
+
+let all_possible_tests =
+  (* We omit clean shutdown & reboot because the VM not be PV and will lack
+     these features *)
+  [ Api (Hard, Shutdown)
+  ; Api (Hard, Reboot)
+  ; Internal_op Internal_reboot
+  ; Internal_op Internal_halt
+  ; Internal_op Internal_crash
+  ]
+
+let one rpc s vm test =
+  print_endline ("Running test " ^ (string_of_test test));
+  if Client.Client.VM.get_power_state rpc s vm = `Halted
+  then Client.Client.VM.start rpc s vm false false;
+  (* wait for the guest to actually start up *)
+  Thread.delay 15.;
+
+  let call_api = function
+    | Clean, Shutdown -> Client.Client.VM.clean_shutdown rpc s vm
+    | Hard, Shutdown -> Client.Client.VM.hard_shutdown rpc s vm
+    | Clean, Reboot -> Client.Client.VM.clean_reboot rpc s vm
+    | Hard, Reboot -> Client.Client.VM.hard_reboot rpc s vm in
+
+  let domid = Client.Client.VM.get_domid rpc s vm in
+  begin match test with
+    | Internal_op internal_op ->
+      (* The Xenctrl module is used in xenopsd *)
+      let reason = match internal_op with
+        | Internal_reboot -> Xenctrl.Reboot
+        | Internal_halt -> Xenctrl.Poweroff
+        | Internal_crash -> Xenctrl.Crash
+      in
+      begin
+        try
+          Xenctrl.with_intf (fun xc -> Xenctrl.domain_shutdown xc (Int64.to_int domid) reason)
+        with e ->
+          Printf.printf "Ignoring exception: %s" (Printexc.to_string e)
+      end
+    | Api api -> call_api api
+  end;
+
+  let wait_for_domid p =
+    let start = Unix.gettimeofday () in
+    let finished = ref false in
+    while Unix.gettimeofday () -. start < 300. && (not !finished) do
+      finished := p (Client.Client.VM.get_domid rpc s vm);
+      if not !finished then Thread.delay 1.
+    done;
+    if not !finished then failwith "timeout"
+  in
+
+  begin match expected_result test with
+    | Rebooted -> wait_for_domid (fun domid' -> domid <> domid')
+    | Halted -> wait_for_domid (fun domid' -> domid' = -1L)
+  end
+
+let test rpc session_id vm_template () =
+  Qt.VM.with_new rpc session_id ~template:vm_template
+    (fun vm -> List.iter (one rpc session_id vm) all_possible_tests)
+
+let tests () =
+  let open Qt_filter in
+  [ [ "VM lifecycle tests", `Slow, test ] |> conn |> vm_template "CoreOS"
+  ]
+  |> List.concat


### PR DESCRIPTION
I haven't reintroduced the other two VM quicktests that I've deleted, test_vhd_locking_hook, and vm_powercycle_test, because I think the former does not fail in case of product fault, and the latter is complex.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>