### PR TITLE
CA-293399: Corrupted PCI information in xapi database

### DIFF
--- a/ocaml/pci/lib/pci.ml
+++ b/ocaml/pci/lib/pci.ml
@@ -83,7 +83,11 @@ let with_string ?(size=1024) f =
    * to the lifetime of the input parameter, which can be moved
    * by the GC and cause problems. *)
   let buf = CArray.make char ~initial:'\x00' size in
-  f (CArray.start buf) size
+  let s = CArray.start buf in
+  let r = f s size in
+  (* Keep `s` alive through the C binding invocation in `f` *)
+  ignore (Sys.opaque_identity (List.hd [s]));
+  r
 
 let lookup_class_name pci_access class_id =
   with_string (fun buf size ->


### PR DESCRIPTION
The language binding to the C function is:
```
foreign "pci_lookup_name"
    (Pci_access.t @-> ptr char @-> int @-> int @-> int @-> returning string_opt)
```
The return value `string_opt` is constructed by the memory content of the second
parameter `ptr char`, however the corresponding OCaml value of `ptr char` is
GC-able (because we no longer reference it) before coping it to the return
value. So the return value may be incorrect.

Indeed this is bug of CTypes that it does not keep the OCaml variable alive
through the C binding invocation.

We make a local function call to foll the compiler to make the corresponding
OCaml variable alive through the C binding invocation.

Signed-off-by: Yang Qian <yang.qian@citrix.com>