### PR TITLE
CP-29084: Rebranding XenServer to Citrix Hypervisor in Toolstack

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ Xapi Project's XenAPI Management Toolstack
 Xen API (or xapi) is a management stack that configures and controls
 Xen-enabled hosts and resource pools, and co-ordinates resources
 within the pool. Xapi exposes the Xen API interface for many
-languages and is a component of the XenServer project.
+languages and is a component of the Citrix Hypervisor project.
 Xen API is written mostly in [OCaml](http://caml.inria.fr/ocaml/)
 4.04.2
 

--- a/ocaml/doc/basics.md
+++ b/ocaml/doc/basics.md
@@ -1,6 +1,6 @@
 # API Basics
 
-This document defines the XenServer Management API - an interface for remotely
+This document defines the Citrix Hypervisor Management API - an interface for remotely
 configuring and controlling virtualised guests running on a Xen-enabled host.
 
 The API is presented here as a set of Remote Procedure Calls (RPCs). There are

--- a/ocaml/doc/index.html
+++ b/ocaml/doc/index.html
@@ -33,7 +33,7 @@
 			<div id="header"></div>
 			<div id="main">
 				<div id="container"><div id="content">
-					<h1 class="title">XenAPI Classes</h1>
+					<h1 class="title">API Classes</h1>
 					<p>Click on a class to view the associated fields and messages.</p>
 
 					<img src="classes.png" usemap="#graph" border="0" />

--- a/ocaml/doc/templates/branding.mustache
+++ b/ocaml/doc/templates/branding.mustache
@@ -13,12 +13,12 @@
  */
 
 function make_title() {
-	document.write('<title>Citrix XenServer Management API</title>');
+	document.write('<title>Citrix Hypervisor Management API</title>');
 }
 
 function make_header(t) {
 	html = '<img src="http://citrix.com/site/resources/v4_includes/css/5.0/citrix_logo.gif" alt="Citrix" width="208px" height="36px" border="0" style="float:left">'
-		+ '<h1 style="float:left; font-size: 24px;"><a href="index.html">XenServer Management API</a></h1>'
+		+ '<h1 style="float:left; font-size: 24px;"><a href="index.html">Citrix Hypervisor Management API</a></h1>'
 	document.getElementById('header').innerHTML = html;
 }
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2633,7 +2633,7 @@ module VDI = struct
       ~in_product_since:rel_boston
       ~params:[Ref _vdi, "self", "The VDI which contains the database to open"]
       ~result:(Ref _session, "A session which can be used to query the database")
-      ~doc:"Load the metadata found on the supplied VDI and return a session reference which can be used in XenAPI calls to query its contents."
+      ~doc:"Load the metadata found on the supplied VDI and return a session reference which can be used in API calls to query its contents."
       ~allowed_roles:_R_POOL_OP
       ()
 

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -591,7 +591,7 @@ let host_query_ha = call ~flags:[`Session]
   let call_plugin = call
       ~name:"call_plugin"
       ~in_product_since:rel_orlando
-      ~doc:"Call a XenAPI plugin on this host"
+      ~doc:"Call an API plugin on this host"
       ~params:[Ref _host, "host", "The host";
                String, "plugin", "The name of the plugin";
                String, "fn", "The name of the function within the plugin";
@@ -614,7 +614,7 @@ let host_query_ha = call ~flags:[`Session]
       ~name:"call_extension"
       ~in_product_since:rel_ely
       ~custom_marshaller:true
-      ~doc:"Call a XenAPI extension on this host"
+      ~doc:"Call an API extension on this host"
       ~params:[Ref _host, "host", "The host";
                String, "call", "Rpc call for the extension";]
       ~result:(String, "Result from the extension")
@@ -1053,7 +1053,7 @@ let host_query_ha = call ~flags:[`Session]
   let set_ssl_legacy = call
       ~name:"set_ssl_legacy"
       ~lifecycle:[Published, rel_dundee, ""]
-      ~doc:"Enable/disable SSLv3 for interoperability with older versions of XenServer. When this is set to a different value, the host immediately restarts its SSL/TLS listening service; typically this takes less than a second but existing connections to it will be broken. XenAPI login sessions will remain valid."
+      ~doc:"Enable/disable SSLv3 for interoperability with older server versions. When this is set to a different value, the host immediately restarts its SSL/TLS listening service; typically this takes less than a second but existing connections to it will be broken. API login sessions will remain valid."
       ~params:[
         Ref _host, "self", "The host";
         Bool, "value", "True to allow SSLv3 and ciphersuites as used in old XenServer versions";
@@ -1430,7 +1430,7 @@ let host_query_ha = call ~flags:[`Session]
            field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pci)) "PCIs" "List of PCI devices in the host";
            field ~qualifier:DynamicRO ~lifecycle:[Published, rel_boston, ""] ~ty:(Set (Ref _pgpu)) "PGPUs" "List of physical GPUs in the host";
            field ~qualifier:DynamicRO ~lifecycle:[Published, rel_inverness, ""] ~ty:(Set (Ref _pusb)) "PUSBs" "List of physical USBs in the host";
-           field ~qualifier:StaticRO ~lifecycle:[Published, rel_dundee, ""] ~ty:Bool ~default_value:(Some (VBool true)) "ssl_legacy" "Allow SSLv3 protocol and ciphersuites as used by older XenServers. This controls both incoming and outgoing connections. When this is set to a different value, the host immediately restarts its SSL/TLS listening service; typically this takes less than a second but existing connections to it will be broken. XenAPI login sessions will remain valid.";
+           field ~qualifier:StaticRO ~lifecycle:[Published, rel_dundee, ""] ~ty:Bool ~default_value:(Some (VBool true)) "ssl_legacy" "Allow SSLv3 protocol and ciphersuites as used by older server versions. This controls both incoming and outgoing connections. When this is set to a different value, the host immediately restarts its SSL/TLS listening service; typically this takes less than a second but existing connections to it will be broken. API login sessions will remain valid.";
            field ~qualifier:RW ~in_product_since:rel_tampa ~default_value:(Some (VMap [])) ~ty:(Map (String, String)) "guest_VCPUs_params" "VCPUs params to apply to all resident guests";
            field ~qualifier:RW ~in_product_since:rel_cream ~default_value:(Some (VEnum "enabled")) ~ty:display "display" "indicates whether the host is configured to output its console to a physical display device";
            field ~qualifier:DynamicRO ~in_product_since:rel_cream ~default_value:(Some (VSet [VInt 0L])) ~ty:(Set (Int)) "virtual_hardware_platform_versions" "The set of versions of the virtual hardware platform that the host can offer to its guests";

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -299,7 +299,7 @@ let power_behaviour =
   let set_is_default_template = call
       ~name:"set_is_default_template"
       ~hide_from_docs:true
-      ~lifecycle: [Published, rel_falcon, "Allows to define XenServer default templates"]
+      ~lifecycle: [Published, rel_falcon, "Allows to define default templates"]
       ~doc:"Makes the specified VM a default template."
       ~params:[
         Ref _vm, "vm", "The VM that will become a default template";
@@ -1111,7 +1111,7 @@ let power_behaviour =
   let call_plugin = call
       ~name:"call_plugin"
       ~in_product_since:rel_cream
-      ~doc:"Call a XenAPI plugin on this vm"
+      ~doc:"Call an API plugin on this vm"
       ~params:[Ref _vm, "vm", "The vm";
                String, "plugin", "The name of the plugin";
                String, "fn", "The name of the function within the plugin";
@@ -1310,7 +1310,7 @@ let set_HVM_boot_policy = call ~flags:[`Session]
 
            field ~ty:Int "user_version" "Creators of VMs and templates may store version information here.";
            field ~effect:true ~ty:Bool "is_a_template" "true if this is a template. Template VMs can never be started, they are used only for cloning other VMs";
-           field ~ty:Bool ~default_value:(Some (VBool false)) ~qualifier:DynamicRO ~writer_roles:_R_POOL_ADMIN ~lifecycle:[Published, rel_falcon, "Identifies XenServer default templates"] "is_default_template" "true if this is a default template. Default template VMs can never be started or migrated, they are used only for cloning other VMs";
+           field ~ty:Bool ~default_value:(Some (VBool false)) ~qualifier:DynamicRO ~writer_roles:_R_POOL_ADMIN ~lifecycle:[Published, rel_falcon, "Identifies default templates"] "is_default_template" "true if this is a default template. Default template VMs can never be started or migrated, they are used only for cloning other VMs";
            field ~qualifier:DynamicRO ~ty:(Ref _vdi) "suspend_VDI" "The VDI that a suspend image is stored on. (Only has meaning if VM is currently suspended)";
 
            field ~writer_roles:_R_VM_POWER_ADMIN ~qualifier:DynamicRO ~ty:(Ref _host) "resident_on" "the host the VM is currently resident on";

--- a/scripts/examples/python/shell.py
+++ b/scripts/examples/python/shell.py
@@ -114,4 +114,4 @@ if __name__ == "__main__":
             sys.exit(3)
         sys.exit(0)
     else:
-        Shell().cmdloop('Welcome to the XenServer shell. (Try "VM.get_all")')
+        Shell().cmdloop('Welcome to the Citrix Hypervisor shell. (Try "VM.get_all")')

--- a/scripts/motd
+++ b/scripts/motd
@@ -1,6 +1,6 @@
 
 
-XenServer simulator VM
+Citrix Hypervisor simulator VM
 
 Language bindings and examples are in /SDK
 

--- a/scripts/xe-backup-metadata
+++ b/scripts/xe-backup-metadata
@@ -5,7 +5,7 @@
 trap "cleanup" TERM INT
 
 if [ ! -e @INVENTORY@ ]; then
-  echo Must run on a XenServer host.
+  echo Must run on a Citrix Hypervisor host.
   exit 1
 fi
 

--- a/scripts/xe-edit-bootloader
+++ b/scripts/xe-edit-bootloader
@@ -5,7 +5,7 @@
 # Script which lets you edit the grub.conf in a Linux guest virtual disk.
 
 if [ ! -e @INVENTORY@ ]; then
-  echo Must run on a XenServer host.
+  echo Must run on a Citrix Hypervisor host.
   exit 1
 fi
 

--- a/scripts/xe-restore-metadata
+++ b/scripts/xe-restore-metadata
@@ -3,7 +3,7 @@
 # Citrix Systems Inc, 2008
 
 if [ ! -e @INVENTORY@ ]; then
-  echo Must run on a XenServer host.
+  echo Must run on a Citrix Hypervisor host.
   exit 1
 fi
 

--- a/scripts/xe-set-iscsi-iqn
+++ b/scripts/xe-set-iscsi-iqn
@@ -11,7 +11,7 @@ XE="@BINDIR@/xe"
 configkey="iscsi_iqn"
 
 if [ ! -f @INVENTORY@ ]; then
-  echo Error: Not a XenServer host
+  echo Error: Not a Citrix Hypervisor host
   exit 1
 fi
 

--- a/scripts/xe-xentrace
+++ b/scripts/xe-xentrace
@@ -31,7 +31,7 @@ done
 SIZE=$((${SIZE_GB} * 1024 * 1024 * 1024))
 
 if [ ! -e @INVENTORY@ ]; then
-  echo Must run on a XenServer host.
+  echo Must run on a Citrix Hypervisor host.
   exit 1
 fi
 


### PR DESCRIPTION
This PR is to change the branding from "XenServer" to "Citrix Hypervisor" in the title and header of SDK API reference pages.

Signed-off-by: Michael Z <michael.zhao@citrix.com>