### PR TITLE
Add dependency on ctypes to xapi.opam

### DIFF
--- a/xapi.opam
+++ b/xapi.opam
@@ -12,6 +12,8 @@ depends: [
   "jbuilder" {build & >= "1.0+beta11"}
   "alcotest"
   "cdrom"
+  "ctypes" {>= "0.4"}
+  "ctypes-foreign" {>= "0.4"}
   "fd-send-recv"
   "message-switch-unix"
   "mtime"


### PR DESCRIPTION
Xapi vendors ocaml-pci but fails to declare dependencies on ctypes which are used by ocaml-pci. This commit adds them to xapi.opam.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>