### PR TITLE
CP-29250 Removing oldval, and adding a unit test

### DIFF
--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -79,7 +79,7 @@ let write_field_locked t tblname objref fldname newval =
       | _ -> ()
     end;
     update_database t (set_field tblname objref fldname newval);
-    Database.notify (WriteField(tblname, objref, fldname, current_val, newval)) (get_database t)
+    Database.notify (WriteField(tblname, objref, fldname, newval)) (get_database t)
   end
 
 let write_field t tblname objref fldname newval =

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -217,7 +217,7 @@ end
 (** The core database updates (RefreshRow and PreDelete is more of an 'event') *)
 type update =
   | RefreshRow of string (* tblname *) * string (* objref *)
-  | WriteField of string (* tblname *) * string (* objref *) * string (* fldname *) * Schema.Value.t (* oldval *) * Schema.Value.t (* newval *)
+  | WriteField of string (* tblname *) * string (* objref *) * string (* fldname *) * Schema.Value.t (* newval *)
   | PreDelete of string (* tblname *) * string (* objref *)
   | Delete of string (* tblname *) * string (* objref *) * (string * Schema.Value.t) list (* values *)
   | Create of string (* tblname *) * string (* objref *) * (string * Schema.Value.t) list (* values *)

--- a/ocaml/database/db_cache_types.mli
+++ b/ocaml/database/db_cache_types.mli
@@ -116,7 +116,7 @@ end
 (** The core database updates (RefreshRow and PreDelete is more of an 'event') *)
 type update =
   | RefreshRow of string (* tblname *) * string (* objref *)
-  | WriteField of string (* tblname *) * string (* objref *) * string (* fldname *) * Schema.Value.t (* oldval *) * Schema.Value.t (* newval *)
+  | WriteField of string (* tblname *) * string (* objref *) * string (* fldname *) * Schema.Value.t (* newval *)
   | PreDelete of string (* tblname *) * string (* objref *)
   | Delete of string (* tblname *) * string (* objref *) * (string * Schema.Value.t) list (* values *)
   | Create of string (* tblname *) * string (* objref *) * (string * Schema.Value.t) list (* values *)

--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -767,8 +767,8 @@ let database_callback event db =
     match event with
     | Db_cache_types.RefreshRow (tblname, objref) ->
       None
-    | Db_cache_types.WriteField (tblname, objref, fldname, oldval, newval) ->
-      R.debug "WriteField(%s, %s, %s, %s, %s)" tblname objref fldname (Schema.Value.marshal oldval) (Schema.Value.marshal newval);
+    | Db_cache_types.WriteField (tblname, objref, fldname,  newval) ->
+      R.debug "WriteField(%s, %s, %s, %s)" tblname objref fldname (Schema.Value.marshal newval);
       if Schema.is_field_persistent (Db_cache_types.Database.schema db) tblname fldname
       then Some (WriteField(tblname, objref, fldname, Schema.Value.marshal newval))
       else None

--- a/ocaml/xapi/eventgen.ml
+++ b/ocaml/xapi/eventgen.ml
@@ -75,19 +75,6 @@ open Db_action_helper
 let database_callback event db =
   let context = Context.make "eventgen" in
 
-  let other_tbl_refs tblname = follow_references tblname in
-  let other_tbl_refs_for_this_field tblname fldname =
-    List.filter (fun (_,fld) -> fld=fldname) (other_tbl_refs tblname) in
-
-  let is_valid_ref = function
-    | Schema.Value.String r ->
-      begin
-        try
-          ignore(Database.table_of_ref r db);
-          true
-        with _ -> false
-      end
-    | _ -> false in
 
   match event with
   | RefreshRow (tblname, objref) ->
@@ -101,32 +88,10 @@ let database_callback event db =
       | Some record ->
         events_notify ~snapshot:record tblname "mod" objref;
     end
-  | WriteField (tblname, objref, fldname, oldval, newval) ->
-    let events_old_val =
-      if is_valid_ref oldval then
-        let oldval = Schema.Value.Unsafe_cast.string oldval in
-        events_of_other_tbl_refs
-          (List.map (fun (tbl,fld) ->
-               (tbl, oldval, find_get_record tbl ~__context:context ~self:oldval)) (other_tbl_refs_for_this_field tblname fldname))
-      else [] in
-    let events_new_val =
-      if is_valid_ref newval then
-        let newval = Schema.Value.Unsafe_cast.string newval in
-        events_of_other_tbl_refs
-          (List.map (fun (tbl,fld) ->
-               (tbl, newval, find_get_record tbl ~__context:context ~self:newval)) (other_tbl_refs_for_this_field tblname fldname))
-      else []
-    in
+  | WriteField (tblname, objref, fldname, newval) ->
     (* Generate event *)
     let snapshot = find_get_record tblname ~__context:context ~self:objref in
     let record = snapshot() in
-    List.iter (function
-        | tbl, ref, None ->
-          error "Failed to send MOD event for %s %s" tbl ref;
-          Printf.printf "Failed to send MOD event for %s %s\n%!" tbl ref;
-        | tbl, ref, Some s ->
-          events_notify ~snapshot:s tbl "mod" ref
-      ) events_old_val;
     begin match record with
       | None ->
         error "Failed to send MOD event for %s %s" tblname objref;
@@ -134,13 +99,6 @@ let database_callback event db =
       | Some record ->
         events_notify ~snapshot:record tblname "mod" objref;
     end;
-    List.iter (function
-        | tbl, ref, None ->
-          error "Failed to send MOD event for %s %s" tbl ref;
-          Printf.printf "Failed to send MOD event for %s %s\n%!" tbl ref;
-        | tbl, ref, Some s ->
-          events_notify ~snapshot:s tbl "mod" ref
-      ) events_new_val;
   | PreDelete(tblname, objref) ->
     begin match find_get_record tblname ~__context:context ~self:objref () with
       | None ->
@@ -154,10 +112,8 @@ let database_callback event db =
     let other_tbl_refs =
       List.fold_left (fun accu (remote_tbl,fld) ->
           let fld_value = List.assoc fld kv in
-          if is_valid_ref fld_value then begin
-            let fld_value = Schema.Value.Unsafe_cast.string fld_value in
-            (remote_tbl, fld_value, find_get_record remote_tbl ~__context:context ~self:fld_value) :: accu
-          end else accu)
+          let fld_value = Schema.Value.Unsafe_cast.string fld_value in
+            (remote_tbl, fld_value, find_get_record remote_tbl ~__context:context ~self:fld_value) :: accu)
         [] other_tbl_refs in
     let other_tbl_ref_events = events_of_other_tbl_refs other_tbl_refs in
     List.iter (function
@@ -174,23 +130,22 @@ let database_callback event db =
     let other_tbl_refs =
       List.fold_left (fun accu (tbl,fld) ->
           let fld_value = List.assoc fld kv in
-          if is_valid_ref fld_value then begin
             let fld_value = Schema.Value.Unsafe_cast.string fld_value in
-            (tbl, fld_value, find_get_record tbl ~__context:context ~self:fld_value) :: accu
-          end else accu)
+            (tbl, fld_value, find_get_record tbl ~__context:context ~self:fld_value) :: accu)
         [] other_tbl_refs in
     let other_tbl_events = events_of_other_tbl_refs other_tbl_refs in
     begin match snapshot() with
       | None ->
         error "Failed to generate ADD event for %s %s" tblname new_objref;
-        (*				Printf.printf "Failed to generate ADD event for %s %s\n%!" tblname new_objref; *)
+        (*              Printf.printf "Failed to generate ADD event for %s %s\n%!" tblname new_objref; *)
       | Some snapshot ->
         events_notify ~snapshot tblname "add" new_objref;
     end;
     List.iter (function
         | tbl, ref, None ->
           error "Failed to generate MOD event for %s %s" tbl ref;
-          (* 				Printf.printf "Failed to generate MOD event for %s %s\n%!" tbl ref;*)
+          (*                Printf.printf "Failed to generate MOD event for %s %s\n%!" tbl ref;*)
         | tbl, ref, Some s ->
           events_notify ~snapshot:s tbl "mod" ref
       ) other_tbl_events
+


### PR DESCRIPTION
In the 'good old days', VM and VBD entries were linked to each other and when a VBD was created, the vm reference was entered. To fill in the entry in the VM record, a fake event was triggered to cause an update. If this vbd is then moved from one vm to another, the old value of the vm is needed to update the vbd record in the vm afterwards. Because the method for linking of the two records has changed, this is just a bit of tidying, with a unit test to ensure the behaviour is maintained.

Signed-off-by: Richard Davies <richard.davies@citrix.com>