### PR TITLE
database/jbuild: link only ppx_sexp_conv.runtime-lib

### DIFF
--- a/ocaml/database/jbuild
+++ b/ocaml/database/jbuild
@@ -24,7 +24,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   ))
   (libraries (
    rpclib
-   ppx_sexp_conv
+   ppx_sexp_conv.runtime-lib
    sexpr
    threads
    http-svr


### PR DESCRIPTION
The whole ppx_rewriter should not be linked in the executable