### PR TITLE
CA-293678 SXM in partially upgraded pool with pre-7.3 hosts fails mig…

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1684,7 +1684,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
           (fun session_id rpc -> Client.VM.assert_can_migrate_sender rpc session_id vm dest live vdi_map vif_map vgpu_map options)
       with
       | Api_errors.Server_error(code, params) when code=Api_errors.message_method_unknown ->
-        debug "VM.assert_can_migrate_sender not known by destine, assuming older version host no need to do this."
+        warn "VM.assert_can_migrate_sender is not known by destination, assuming it can ignore this check."
 
     let assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map =
       info "VM.assert_can_migrate: VM = '%s'" (vm_uuid ~__context vm);

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1679,8 +1679,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
     let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options =
       info "VM.assert_can_migrate_sender: VM = '%s'" (vm_uuid ~__context vm);
       let local_fn = Local.VM.assert_can_migrate_sender ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map ~options in
-      forward_vm_op ~local_fn ~__context ~vm
-        (fun session_id rpc -> Client.VM.assert_can_migrate_sender rpc session_id vm dest live vdi_map vif_map vgpu_map options)
+      try
+        forward_vm_op ~local_fn ~__context ~vm
+          (fun session_id rpc -> Client.VM.assert_can_migrate_sender rpc session_id vm dest live vdi_map vif_map vgpu_map options)
+      with
+      | Api_errors.Server_error(code, params) when code=Api_errors.message_method_unknown ->
+        debug "VM.assert_can_migrate_sender not known by destine, assuming older version host no need to do this."
 
     let assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~vgpu_map =
       info "VM.assert_can_migrate: VM = '%s'" (vm_uuid ~__context vm);

--- a/ocaml/xapi/rbac_audit.ml
+++ b/ocaml/xapi/rbac_audit.ml
@@ -360,7 +360,7 @@ and
       if (List.length str_names) <> (List.length rpc_values)
       then
         ( (* debug mode *)
-          D.debug "cannot marshall arguments for the action %s: name and value list lengths don't match. str_names=[%s], xml_values=[%s]" action ((List.fold_left (fun ss s->ss^s^",") "" str_names)) ((List.fold_left (fun ss s->ss^(Rpc.to_string s)^",") "" rpc_values));
+          D.warn "cannot marshall arguments for the action %s: name and value list lengths don't match. str_names=[%s], xml_values=[%s]" action ((List.fold_left (fun ss s->ss^s^",") "" str_names)) ((List.fold_left (fun ss s->ss^(Rpc.to_string s)^",") "" rpc_values));
           []
         )
       else


### PR DESCRIPTION
…ration checks

assert_can_migrate_sender is added in 7.3 along with some code reoganization.
So if in any chance this is called from master to slave in RPC but slave is
before 7.3, the slave will raise exception and hance fail the entire code due
to this unknown method.

In assert_can_migrate_sender, it is mostly regarding pgpu check, which may not
be necessary in older release, so just ignore this unknown method.

Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>