### PR TITLE
Prevent changes to NVRAM field while a VM is running

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -887,6 +887,31 @@ let power_behaviour =
       ~allowed_roles:_R_VM_ADMIN
       ()
 
+  let remove_from_NVRAM = call ~flags:[`Session]
+      ~name:"remove_from_NVRAM"
+      ~lifecycle:[Prototyped, rel_naples, ""]
+      ~params:[Ref _vm, "self", "The VM";
+               String, "key", "The key"]
+      ~allowed_roles:_R_VM_ADMIN
+      ()
+
+  let add_to_NVRAM = call ~flags:[`Session]
+      ~name:"add_to_NVRAM"
+      ~lifecycle:[Prototyped, rel_naples, ""]
+      ~params:[Ref _vm, "self", "The VM";
+               String, "key", "The key";
+               String, "value", "The value"]
+      ~allowed_roles:_R_VM_ADMIN
+      ()
+
+  let set_NVRAM = call ~flags:[`Session]
+      ~name:"set_NVRAM"
+      ~lifecycle:[Prototyped, rel_naples, ""]
+      ~params:[Ref _vm, "self", "The VM";
+               Map(String, String), "value", "The value"]
+      ~allowed_roles:_R_VM_ADMIN
+      ()
+
   let send_sysrq = call
       ~name:"send_sysrq"
       ~in_product_since:rel_rio
@@ -1164,6 +1189,7 @@ let power_behaviour =
               "changing_shadow_memory_live", "Changing the shadow memory for a running VM.";
               "changing_VCPUs", "Changing VCPU settings for a halted VM.";
               "changing_VCPUs_live", "Changing VCPU settings for a running VM.";
+              "changing_NVRAM", "Changing NVRAM for a halted VM.";
               "assert_operation_valid", "";
               "data_source_op", "Add, remove, query or list data sources";
               "update_allowed_operations", "";
@@ -1243,6 +1269,9 @@ let set_HVM_boot_policy = call ~flags:[`Session]
                   pool_migrate; pool_migrate_complete;
                   set_vcpus_number_live;
                   add_to_VCPUs_params_live;
+                  set_NVRAM;
+                  add_to_NVRAM;
+                  remove_from_NVRAM;
                   set_ha_restart_priority;  (* updates the allowed-operations of the VM *)
                   set_ha_always_run;        (* updates the allowed-operations of the VM *)
                   compute_memory_overhead;
@@ -1401,9 +1430,9 @@ let set_HVM_boot_policy = call ~flags:[`Session]
              ]
            ~default_value:(Some (VEnum "unspecified")) "domain_type" "The type of domain that will be created when the VM is started";
 
-           field ~lifecycle:[Prototyped, rel_naples, ""] ~ty:(Map(String, String)) "NVRAM"
+           field ~lifecycle:[Prototyped, rel_naples, ""] ~qualifier:StaticRO ~ty:(Map(String, String)) "NVRAM"
              ~default_value:(Some (VMap []))
-             "initial value for guest NVRAM (containing UEFI variables, etc)";
+             "initial value for guest NVRAM (containing UEFI variables, etc). Cannot be changed while the VM is running";
          ])
       ()
 

--- a/ocaml/tests/test_vm_check_operation_error.ml
+++ b/ocaml/tests/test_vm_check_operation_error.ml
@@ -11,6 +11,7 @@ let all_vm_operations =
   ; `changing_shadow_memory
   ; `changing_shadow_memory_live
   ; `changing_static_range
+  ; `changing_NVRAM
   ; `checkpoint
   ; `clean_reboot
   ; `clean_shutdown

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1751,6 +1751,24 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
            forward_vm_op ~local_fn ~__context ~vm:self
              (fun session_id rpc -> Client.VM.add_to_VCPUs_params_live rpc session_id self key value))
 
+    let set_NVRAM ~__context ~self ~value =
+      info "VM.set_NVRAM: self='%s'" (vm_uuid ~__context self);
+      with_vm_operation ~__context ~self ~doc:"VM.set_NVRAM" ~op:`changing_NVRAM
+        (fun () ->
+           Local.VM.set_NVRAM ~__context ~self ~value)
+
+    let remove_from_NVRAM ~__context ~self ~key =
+      info "VM.remove_from_NVRAM: self='%s', key='%s'" (vm_uuid ~__context self) key;
+      with_vm_operation ~__context ~self ~doc:"VM.remove_from_NVRAM" ~op:`changing_NVRAM
+        (fun () ->
+           Local.VM.remove_from_NVRAM ~__context ~self ~key)
+
+    let add_to_NVRAM ~__context ~self ~key ~value =
+      info "VM.add_to_NVRAM: self='%s', key='%s'" (vm_uuid ~__context self) key;
+      with_vm_operation ~__context ~self ~doc:"VM.add_to_NVRAM" ~op:`changing_NVRAM
+        (fun () ->
+           Local.VM.add_to_NVRAM ~__context ~self ~key ~value)
+
     let set_VCPUs_max ~__context ~self ~value =
       info "VM.set_VCPUs_max: self = %s; value = %Ld"
         (vm_uuid ~__context self) value;

--- a/ocaml/xapi/record_util.ml
+++ b/ocaml/xapi/record_util.ml
@@ -59,6 +59,7 @@ let vm_operation_table =
     `resume, "resume";
     `resume_on, "resume_on";
     `changing_VCPUs_live, "changing_VCPUs_live";
+    `changing_NVRAM, "changing_NVRAM";
     `start, "start";
     `start_on, "start_on";
     `suspend, "suspend";

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -740,6 +740,15 @@ let set_VCPUs_number_live ~__context ~self ~nvcpu =
 let add_to_VCPUs_params_live ~__context ~self ~key ~value =
   raise (Api_errors.Server_error (Api_errors.not_implemented, [ "add_to_VCPUs_params_live" ]))
 
+let set_NVRAM ~__context ~self ~value =
+  Db.VM.set_NVRAM ~__context ~self ~value
+
+let remove_from_NVRAM ~__context ~self ~key =
+  Db.VM.remove_from_NVRAM ~__context ~self ~key
+
+let add_to_NVRAM ~__context ~self ~key ~value =
+  Db.VM.add_to_NVRAM ~__context ~self ~key ~value
+
 (* Use set_memory_dynamic_range instead *)
 let set_memory_target_live ~__context ~self ~target = ()
 

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -167,6 +167,12 @@ val set_VCPUs_number_live :
   __context:Context.t -> self:API.ref_VM -> nvcpu:int64 -> unit
 val add_to_VCPUs_params_live :
   __context:'a -> self:API.ref_VM -> key:'b -> value:'c -> 'd
+val set_NVRAM :
+  __context:Context.t -> self:API.ref_VM -> value:(string*string) list -> unit
+val remove_from_NVRAM :
+  __context:Context.t -> self:API.ref_VM -> key:string -> unit
+val add_to_NVRAM :
+  __context:Context.t -> self:API.ref_VM -> key:string -> value:string -> unit
 val set_memory_dynamic_range :
   __context:Context.t ->
   self:API.ref_VM -> min:Int64.t -> max:Int64.t -> unit

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -41,6 +41,7 @@ let allowed_power_states ~__context ~vmr ~(op:API.vm_operations) =
   | `changing_static_range
   | `changing_memory_limits       -> `Halted :: (if vmr.Db_actions.vM_is_control_domain then [`Running] else [])
   | `changing_shadow_memory
+  | `changing_NVRAM
   | `make_into_template
   | `provision
   | `start
@@ -203,6 +204,7 @@ let check_template ~vmr ~op ~ref_str =
     `changing_memory_limits;
     `changing_shadow_memory;
     `changing_VCPUs;
+    `changing_NVRAM;
     `clone;
     `copy;
     `export;
@@ -568,7 +570,7 @@ let update_allowed_operations ~__context ~self =
        `start; `start_on; `pause; `unpause; `clean_shutdown; `clean_reboot;
        `hard_shutdown; `hard_reboot; `suspend; `resume; `resume_on; `export; `destroy;
        `provision; `changing_VCPUs_live; `pool_migrate; `migrate_send; `make_into_template; `changing_static_range;
-       `changing_shadow_memory; `changing_dynamic_range]
+       `changing_shadow_memory; `changing_dynamic_range; `changing_NVRAM]
   in
   (* FIXME: need to be able to deal with rolling-upgrade for orlando as well *)
   let allowed =


### PR DESCRIPTION
The coresponding varstored changes got merged, so this is ready for review/merge now.