### PR TITLE
CP-29169: call varstore-rm on UEFI VM clone

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -733,6 +733,8 @@ let firewall_port_config_script = ref "/etc/xapi.d/plugins/firewall-port"
 
 let nbd_client_manager_script = ref "/opt/xensource/libexec/nbd_client_manager.py"
 
+let varstore_rm = ref "/usr/bin/varstore-rm"
+
 let disable_logging_for= ref []
 
 let nvidia_whitelist = ref "/usr/share/nvidia/vgpu/vgpuConfig.xml"
@@ -1018,6 +1020,7 @@ module Resources = struct
     "nbd-firewall-config", nbd_firewall_config_script, "Executed after NBD-related networking changes to configure the firewall for NBD";
     "firewall-port-config", firewall_port_config_script, "Executed when starting/stopping xapi-clusterd to configure firewall port";
     "nbd_client_manager", nbd_client_manager_script, "Executed to safely connect to and disconnect from NBD devices using nbd-client";
+    "varstore-rm", varstore_rm, "Executed to clear certain UEFI variables during clone"
   ]
   let essential_files = [
     "pool_config_file", pool_config_file, "Pool configuration file";

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -427,6 +427,10 @@ let clone ?(snapshot_info_record) disk_op ~__context ~vm ~new_name =
                      else clone_single_vdi rpc session_id disk_op ~__context original driver_params) in
 
               Db.VM.set_suspend_VDI ~__context ~self:ref ~value:suspend_VDI;
+
+              if not is_a_snapshot then
+                Xapi_xenops.nvram_post_clone ~__context ~self:ref ~uuid;
+
               Db.VM.remove_from_current_operations ~__context ~self:ref ~key:task_id;
               Xapi_vm_lifecycle.force_state_reset ~__context ~self:ref ~value:new_power_state;
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -188,6 +188,18 @@ let firmware_of_vm vm =
         bad]))
   | exception Not_found -> default_firmware
 
+let nvram_post_clone ~__context ~self ~uuid =
+  match Db.VM.get_NVRAM ~__context ~self with
+  | [] -> ()
+  | original ->
+    let uuid = Uuid.to_string uuid in
+    info "VM %s was cloned: clearing certain UEFI variables" uuid;
+    let (_: string*string) =
+      Forkhelpers.execute_command_get_output
+        !Xapi_globs.varstore_rm ["-c"; uuid] in
+    if Db.VM.get_NVRAM ~__context ~self <> original then
+      debug "VM %s: NVRAM changed due to clone" uuid
+
 let rtc_timeoffset_of_vm ~__context (vm, vm_t) vbds =
   let timeoffset = string vm_t.API.vM_platform "0" Vm_platform.timeoffset in
   (* If any VDI has on_boot = reset AND has a VDI.other_config:timeoffset

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -163,5 +163,6 @@ install:
 	$(IDATA) mail-languages/en-US.json $(DESTDIR)/etc/xapi.d/mail-languages
 	$(IDATA) mail-languages/zh-CN.json $(DESTDIR)/etc/xapi.d/mail-languages
 	$(IDATA) mail-languages/ja-JP.json $(DESTDIR)/etc/xapi.d/mail-languages
-	
+# uefi
+	mkdir -p $(DESTDIR)/etc/xapi.d/efi-clone
 


### PR DESCRIPTION
On clone certain UEFI variables may need to be cleared.
Call `varstore-rm -c <uuid>` to perform this.

The actual variables to clear are defined in the `/etc/xapi.d/efi-clone` directory,
however the format of NVRAM is managed by `varstored`, hence XAPI can't
clear them itself and needs to invoke the helper executable.

There is a related specfile change to make this directory owned by XAPI, however this builds even with the old specfile.