### PR TITLE
Backports from Master

### DIFF
--- a/ocaml/idl/ocaml_backend/server_helpers.ml
+++ b/ocaml/idl/ocaml_backend/server_helpers.ml
@@ -58,7 +58,7 @@ let parameter_count_mismatch_failure func expected received =
 
 (** WARNING: the context is destroyed when execution is finished if the task is not forwarded, in database and not called asynchronous. *)
 (*  FIXME: This function should not be used for external call : we should add a proper .mli file to hide it. *)
-let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) f =
+let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) ?(has_task=false) f =
   (* Execute fn f in specified __context, marshalling result with "marshaller".
      If has_task is set then __context has a real task in it that has to be completed. *)
   let exec () =
@@ -67,6 +67,9 @@ let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) f 
        already been taken by the master
        2. If we are the master, locks are only necessary for the potentially-forwarded
        (ie side-effecting) operations and not things like the database layer *)
+
+    (* For forwarded task, we should not complete it here, the server which forward the task will complete it. However for the task forwarded by client, which param `has_task` is set with `true`, we have to complete it also. *)
+    let need_complete = has_task || (not (Context.forwarded_task __context)) in
     try
       let result =
         if not(Pool_role.is_master ())
@@ -79,8 +82,7 @@ let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) f 
             (* use the forwarding layer (NB this might make a local call ultimately) *)
             forward ~local_fn:f ~__context
       in
-      (* For forwarded task, we should not complete it here, the server which forward the task will complete it *)
-      begin
+      if need_complete then begin
         match marshaller with
         | None    -> TaskHelper.complete ~__context None
         | Some fn -> TaskHelper.complete ~__context (Some (fn result))
@@ -89,11 +91,11 @@ let exec_with_context ~__context ?marshaller ?f_forward ?(called_async=false) f 
     with
     | Api_errors.Server_error (a,b) as e when a = Api_errors.task_cancelled ->
       Backtrace.is_important e;
-      TaskHelper.cancel ~__context;
+      if need_complete then TaskHelper.cancel ~__context;
       raise e
     | e ->
       Backtrace.is_important e;
-      TaskHelper.failed ~__context e;
+      if need_complete then TaskHelper.failed ~__context e;
       raise e
   in
   Locking_helpers.Thread_state.with_named_thread (Context.get_task_name __context) (Context.get_task_id __context)
@@ -145,6 +147,7 @@ let exec_with_new_task ?http_other_config ?quiet ?subtask_of ?session_id ?task_i
 let exec_with_forwarded_task ?http_other_config ?session_id ?origin task_id f =
   exec_with_context
     ~__context:(Context.from_forwarded_task ?http_other_config ?session_id ?origin task_id)
+    ~has_task:true
     (fun ~__context -> f __context)
 
 let exec_with_subtask ~__context ?task_in_database ?task_description task_name f =

--- a/ocaml/test/suite.ml
+++ b/ocaml/test/suite.ml
@@ -59,6 +59,7 @@ let base_suite =
     Test_pvs_server.test;
     Test_pvs_cache_storage.test;
     Test_extauth_plugin_ADpbis.test;
+    Test_guest_agent.test;
   ]
 
 let handlers = [

--- a/ocaml/xapi/test_guest_agent.ml
+++ b/ocaml/xapi/test_guest_agent.ml
@@ -1,0 +1,371 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open OUnit
+open Test_highlevel
+
+module Networks = Generic.Make (struct
+    module Io = struct
+      type input_t = string list
+      type output_t = (string * string) list
+
+      let string_of_input_t = Test_printers.(list string)
+      let string_of_output_t = Test_printers.(assoc_list string string)
+    end
+
+    type 'a tree = T of 'a * 'a tree list
+
+    let rec add_path_to_tree (T(root, children)) = function
+      | [] -> (T(root, children))
+      | node :: rest_of_path ->
+        try 
+          let T(_, children_of_node) = List.find (fun (T(n, _)) -> n = node) children in
+          let t = add_path_to_tree (T(node, children_of_node)) rest_of_path in
+          T(root, t :: (List.filter (fun (T(n, _)) -> n <> node) children))
+        with Not_found ->
+          T(root, (add_path_to_tree (T(node, [])) rest_of_path) :: children)
+
+    let construct_tree tree path =
+      let open Stdext.Xstringext in
+      let nodes = String.split_f (fun s -> s = '/') path in
+      add_path_to_tree tree nodes
+
+    let rec list_helper children = function
+      | [] -> List.map (fun (T(node, _)) -> node) children
+      | node :: rest_of_path ->
+        try
+          let T(_, children_of_node) = List.find (fun (T(n, _)) -> n = node) children in
+          list_helper children_of_node rest_of_path
+        with Not_found -> []
+
+    let list (T(root, children)) path =
+      let open Stdext.Xstringext in
+      let nodes = String.split_f (fun s -> s = '/') path in
+      list_helper children nodes
+
+
+    let transform input = 
+      let tree = List.fold_left construct_tree (T("", [])) input in
+      Xapi_guest_agent.networks "attr" (list tree)
+
+    let tests = [
+      (* basic cases *)
+      [ "attr/vif/0/ipv6/0";
+      ], [ "attr/vif/0/ipv6/0", "0/ipv6/0";
+      ];
+
+      [ "attr/vif/0/ipv4/0";
+      ], [ "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+      ];
+
+      [ "attr/eth0/ip";
+      ], [ "attr/eth0/ip", "0/ip";
+           "attr/eth0/ip", "0/ipv4/0";
+      ];
+
+      [ "attr/eth0/ipv6/0/addr";
+      ], [ "attr/eth0/ip", "0/ip";
+           "attr/eth0/ip", "0/ipv4/0";
+           "attr/eth0/ipv6/0/addr", "0/ipv6/0";
+      ];
+
+
+      (* index *)
+      [ "attr/vif/1/ipv6/2";
+      ], [ "attr/vif/1/ipv6/2", "1/ipv6/2";
+      ];
+
+      [ "attr/vif/1/ipv4/2";
+      ], [ "attr/vif/1/ipv4/2", "1/ip";
+           "attr/vif/1/ipv4/2", "1/ipv4/2";
+      ];
+
+      [ "attr/eth1/ip";
+      ], [ "attr/eth1/ip", "1/ip";
+           "attr/eth1/ip", "1/ipv4/0";
+      ];
+
+      [ "attr/eth1/ipv6/2/addr";
+      ], [ "attr/eth1/ip", "1/ip";
+           "attr/eth1/ip", "1/ipv4/0";
+           "attr/eth1/ipv6/2/addr", "1/ipv6/2";
+      ];
+
+      (* multiple ip addrs *)
+      [ "attr/vif/0/ipv6/0";
+        "attr/vif/0/ipv6/1";
+      ], [ "attr/vif/0/ipv6/1", "0/ipv6/1";
+           "attr/vif/0/ipv6/0", "0/ipv6/0";
+      ];
+
+      [ "attr/vif/0/ipv4/0";
+        "attr/vif/0/ipv4/1";
+      ], [ "attr/vif/0/ipv4/1", "0/ipv4/1";
+           "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+      ];
+
+      [ "attr/eth0/ip";
+        "attr/eth0/ipv6/0/addr";
+      ], [ "attr/eth0/ip", "0/ip";
+           "attr/eth0/ip", "0/ipv4/0";
+           "attr/eth0/ipv6/0/addr", "0/ipv6/0";
+      ];
+
+      [ "attr/vif/0/ipv4/0";
+        "attr/vif/0/ipv6/0";
+      ], [ "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+           "attr/vif/0/ipv6/0", "0/ipv6/0";
+      ];
+
+      [ "attr/eth0/ip";
+        "attr/vif/0/ipv4/0";
+        "attr/eth0/ipv6/0/addr";
+        "attr/vif/0/ipv6/0";
+      ], [ "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+           "attr/vif/0/ipv6/0", "0/ipv6/0";
+      ];
+
+      (* multiple vifs and multiple ip addrs *)
+      [ "attr/vif/0/ipv6/0";
+        "attr/vif/0/ipv6/1";
+        "attr/vif/1/ipv6/0";
+        "attr/vif/1/ipv6/1";
+      ], [ "attr/vif/0/ipv6/1", "0/ipv6/1";
+           "attr/vif/0/ipv6/0", "0/ipv6/0";
+           "attr/vif/1/ipv6/1", "1/ipv6/1";
+           "attr/vif/1/ipv6/0", "1/ipv6/0";
+      ];
+
+      [ "attr/vif/0/ipv4/0";
+        "attr/vif/0/ipv4/1";
+        "attr/vif/1/ipv4/0";
+        "attr/vif/1/ipv4/1";
+      ], [ "attr/vif/0/ipv4/1", "0/ipv4/1";
+           "attr/vif/0/ipv4/0", "0/ip";
+           "attr/vif/0/ipv4/0", "0/ipv4/0";
+           "attr/vif/1/ipv4/1", "1/ipv4/1";
+           "attr/vif/1/ipv4/0", "1/ip";
+           "attr/vif/1/ipv4/0", "1/ipv4/0";
+      ];
+
+      (* exceptions *)
+      [ "attr/vif/0/ipv4/a";
+        "attr/vif/0/ipv4/1";
+      ], [];
+    ]
+  end)
+
+module Initial_guest_metrics = Generic.Make (struct
+    module Io = struct
+      type input_t = (string * string) list
+      type output_t = (string * string) list
+
+      let string_of_input_t = Test_printers.(assoc_list string string)
+      let string_of_output_t = Test_printers.(assoc_list string string)
+    end
+
+    type 'a mtree = 
+      | Lf of 'a * 'a
+      | Mt of 'a * 'a mtree list
+
+    let has_name name = function
+      | Lf (n, _) -> n = name
+      | Mt (n, _) -> n = name
+
+    let get_name = function
+      | Lf (n, _) -> n
+      | Mt (n, _) -> n
+
+    let rec add_leaf_to_mtree paths leaf_value = function
+      | Lf _ -> raise (Failure "Can't add a leaf on a leaf")
+      | Mt (root, children) ->
+        (match paths with
+         | [] ->
+           (match children with
+            | [] -> Lf(root, leaf_value)
+            | _ -> raise (Failure "Can't add a leaf on a tree node"))
+         | node :: rest_paths ->
+           try 
+             let t = List.find (has_name node) children in
+             (match t with
+              | Lf (_, _) -> raise (Failure "Can't overwrite an existing leaf")
+              | Mt (node, children_of_node) ->
+                let mt = add_leaf_to_mtree rest_paths leaf_value (Mt(node, children_of_node)) in
+                Mt(root, mt :: (List.filter (fun n -> not (has_name node n)) children)))
+           with Not_found -> 
+             Mt(root, (add_leaf_to_mtree rest_paths leaf_value (Mt(node, []))) :: children))
+
+    let construct_mtree mtree (path, leaf_value) =
+      let open Stdext.Xstringext in
+      let nodes = String.split_f (fun s -> s = '/') path in
+      add_leaf_to_mtree nodes leaf_value mtree
+
+    let rec list_helper children = function
+      | [] -> List.map get_name children
+      | node :: rest_paths ->
+        try
+          match List.find (has_name node) children with
+          | Lf (_, _) -> []
+          | Mt (_, children_of_node) -> list_helper children_of_node rest_paths
+        with Not_found -> []
+
+    let list mtree path =
+      match mtree with
+      | Lf (_, _) -> []
+      | Mt (_, children) ->
+        let open Stdext.Xstringext in
+        let paths = String.split_f (fun s -> s = '/') path in
+        list_helper children paths
+
+    let rec lookup_helper mtree = function
+      | [] -> 
+        (match mtree with
+         | Lf (_, v) -> Some v
+         | Mt (_, _) -> None)
+      | node :: rest_paths ->
+        (match mtree with
+         | Lf (l, v) -> lookup_helper (Lf(l, v)) rest_paths
+         | Mt (_, children) -> 
+           try
+             lookup_helper (List.find (has_name node) children) rest_paths
+           with Not_found -> None)
+
+    let lookup mtree path =
+        let open Stdext.Xstringext in
+        let paths = String.split_f (fun s -> s = '/') path in
+        lookup_helper mtree paths
+
+
+    let transform input = 
+      let tree = List.fold_left construct_mtree (Mt("", [])) input in
+      let guest_metrics = Xapi_guest_agent.get_initial_guest_metrics (lookup tree) (list tree) in
+      guest_metrics.Xapi_guest_agent.networks
+
+
+    let tests = [
+      (* basic cases *)
+      [ "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/vif/0/ipv4/0", "192.168.0.1";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+      ];
+
+      [ "attr/eth0/ip", "192.168.0.1";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+      ];
+
+      [ "attr/eth0/ipv6/0/addr", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      (* index *)
+      [ "attr/vif/1/ipv6/2", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "1/ipv6/2", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/vif/1/ipv4/2", "192.168.0.1";
+      ], [ "1/ip", "192.168.0.1";
+           "1/ipv4/2", "192.168.0.1";
+      ];
+
+      [ "attr/eth1/ip", "192.168.0.1";
+      ], [ "1/ip", "192.168.0.1";
+           "1/ipv4/0", "192.168.0.1";
+      ];
+
+      [ "attr/eth1/ipv6/2/addr", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "1/ipv6/2", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      (* multiple ip addrs *)
+      [ "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+        "attr/vif/0/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd07";
+      ], [ "0/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd07";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/vif/0/ipv4/0", "192.168.0.1";
+        "attr/vif/0/ipv4/1", "192.168.1.1";
+      ], [ "0/ipv4/1", "192.168.1.1";
+           "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+      ];
+
+      [ "attr/eth0/ip", "192.168.0.1";
+        "attr/eth0/ipv6/0/addr", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/vif/0/ipv4/0", "192.168.0.1";
+        "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      [ "attr/eth0/ip", "192.168.0.1";
+        "attr/vif/0/ipv4/0", "192.168.0.1";
+        "attr/eth0/ipv6/0/addr", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+        "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ], [ "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+      ];
+
+      (* multiple vifs and multiple ip addrs *)
+      [ "attr/vif/0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+        "attr/vif/0/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd07";
+        "attr/vif/1/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd16";
+        "attr/vif/1/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd17";
+      ], [ "0/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd07";
+           "0/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd06";
+           "1/ipv6/1", "fe80:0000:0000:0000:7870:94ff:fe52:dd17";
+           "1/ipv6/0", "fe80:0000:0000:0000:7870:94ff:fe52:dd16";
+      ];
+
+      [ "attr/vif/0/ipv4/0", "192.168.0.1";
+        "attr/vif/0/ipv4/1", "192.168.0.2";
+        "attr/vif/1/ipv4/0", "192.168.1.1";
+        "attr/vif/1/ipv4/1", "192.168.1.2";
+      ], [ "0/ipv4/1", "192.168.0.2";
+           "0/ip", "192.168.0.1";
+           "0/ipv4/0", "192.168.0.1";
+           "1/ipv4/1", "192.168.1.2";
+           "1/ip", "192.168.1.1";
+           "1/ipv4/0", "192.168.1.1";
+      ];
+
+      (* exceptions *)
+      [ "attr/vif/0/ipv4/a", "192.168.0.1";
+        "attr/vif/0/ipv4/1", "192.168.0.1";
+      ], [];
+    ]
+  end)
+
+let test =
+  "test_guest_agent" >:::
+  [
+    "test_networks" >::: Networks.tests;
+    "test_get_initial_guest_metrics" >::: Initial_guest_metrics.tests;
+  ]

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -66,6 +66,17 @@ let extend base str = Printf.sprintf "%s/%s" base str
  * attr/eth0/ip -> 0/ip
  * attr/eth0/ipv6/0/addr -> 0/ipv6/0
  * attr/eth0/ipv6/1/addr -> 0/ipv6/1
+ *
+ * Example output on new xenstore protocol:
+ * attr/vif/0/ipv4/0 -> 0/ipv4/0
+ * attr/vif/0/ipv4/1 -> 0/ipv4/1
+ * attr/vif/0/ipv6/0 -> 0/ipv6/0
+ * attr/vif/0/ipv6/1 -> 0/ipv6/1
+ *
+ * For the compatibility of XAPI clients, outputs of both protocols 
+ * will be generated. I.E.
+ * attr/eth0/ip -> 0/ip; 0/ipv4/0
+ * attr/vif/0/ipv4/0 -> 0/ip; 0/ipv4/0
  * *)
 let networks path (list: string -> string list) =
   (* Find all ipv6 addresses under a path. *)
@@ -76,10 +87,11 @@ let networks path (list: string -> string list) =
   (* Find the ipv4 address under a path, and the ipv6 addresses if they exist. *)
   let find_all_ips path prefix =
     let ipv4 = (extend path "ip", extend prefix "ip") in
+    let ipv4_with_idx = (extend path "ip", extend prefix "ipv4/0") in
     if List.mem "ipv6" (list path) then
-      ipv4 :: (find_ipv6 (extend path "ipv6") (extend prefix "ipv6"))
+      ipv4 :: (ipv4_with_idx :: (find_ipv6 (extend path "ipv6") (extend prefix "ipv6")))
     else
-      [ipv4]
+      [ipv4; ipv4_with_idx]
   in
   (* Find all "ethn", "xenbrn" or newer interface standard names
    * [see https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/]
@@ -112,10 +124,49 @@ let networks path (list: string -> string list) =
          | Some pair -> pair :: acc
       ) [] (list path)
   in
-  path
-  |> find_eths
-  |> List.map (fun (path, prefix) -> find_all_ips path prefix)
-  |> List.concat
+  let find_vifs vif_path =
+    let extract_vif acc vif_id = ((extend vif_path vif_id), vif_id) :: acc in  
+    List.fold_left extract_vif [] (list vif_path)
+  in
+  let cmp a b = 
+    try 
+      compare (int_of_string a) (int_of_string b) 
+    with Failure _ -> 
+      error "String (\"%s\" or \"%s\") can't be converted into an integer as index of IP" a b;
+      raise (Failure "Failed to compare")
+  in
+  let find_all_vif_ips vif_path vif_id = 
+    (*  vif_path: attr/vif/0 *)
+    (*  vif_id: 0 *)
+    let extract_ip_ver vif_id acc ip_ver = 
+      let ip_addr_ids = list (extend vif_path ip_ver)  in
+      let extract_ip_addr vif_id ip_ver acc ip_addr_id = 
+        let key_left = Printf.sprintf "%s/%s/%s" vif_path ip_ver ip_addr_id in
+        let key_right = Printf.sprintf "%s/%s/%s" vif_id ip_ver ip_addr_id in
+        match acc with
+        | [] when ip_ver = "ipv4"  -> 
+          [(key_left, (extend vif_id "ip")); (key_left, key_right)]
+        | _ -> (key_left, key_right) :: acc
+      in  
+      try 
+        (List.fold_left (extract_ip_addr vif_id ip_ver) [] (List.stable_sort cmp ip_addr_ids)) @ acc
+      with Failure _ ->
+        error "Failed to extract IP address for vif %s." vif_id;
+        []
+    in
+    let ip_vers = List.filter (fun a -> a = "ipv4" || a = "ipv6") (list vif_path) in
+    List.fold_left (extract_ip_ver vif_id) [] ip_vers
+  in
+  match find_vifs (extend path "vif") with
+  | [] ->
+    path
+    |> find_eths
+    |> List.map (fun (path, prefix) -> find_all_ips path prefix)
+    |> List.concat
+  | vif_pair_list ->
+    vif_pair_list
+    |> List.map (fun (vif_path, vif_id) -> find_all_vif_ips vif_path vif_id)
+    |> List.concat
 
 (* One key is placed in the other map per control/* key in xenstore. This
    catches keys like "feature-shutdown" "feature-hibernate" "feature-reboot"

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -183,7 +183,7 @@ let get_initial_guest_metrics (lookup: string -> string option) (list: string ->
   {pv_drivers_version; os_version; networks; other; memory; device_id; last_updated; can_use_hotplug_vbd; can_use_hotplug_vif;}
 
 
-let create_and_set_guest_metrics (lookup: string -> string option) (list: string -> string list) ~__context ~domid ~uuid =
+let create_and_set_guest_metrics (lookup: string -> string option) (list: string -> string list) ~__context ~domid ~uuid ~pV_drivers_detected =
   let initial_gm = get_initial_guest_metrics lookup list
   in
   let self = Db.VM.get_by_uuid ~__context ~uuid in
@@ -194,10 +194,10 @@ let create_and_set_guest_metrics (lookup: string -> string option) (list: string
     ~uuid:new_gm_uuid
     ~os_version:initial_gm.os_version
     ~pV_drivers_version:initial_gm.pv_drivers_version
-    ~pV_drivers_up_to_date:false
+    ~pV_drivers_up_to_date:pV_drivers_detected
     ~memory:[] ~disks:[]
     ~networks:initial_gm.networks
-    ~pV_drivers_detected:false
+    ~pV_drivers_detected
     ~other:initial_gm.other
     ~last_updated:(Date.of_float initial_gm.last_updated)
     ~other_config:[]
@@ -219,7 +219,7 @@ let create_and_set_guest_metrics (lookup: string -> string option) (list: string
 
 
 (** Reset all the guest metrics for a particular VM *)
-let all (lookup: string -> string option) (list: string -> string list) ~__context ~domid ~uuid =
+let all (lookup: string -> string option) (list: string -> string list) ~__context ~domid ~uuid ~pV_drivers_detected =
   let {pv_drivers_version; os_version; networks; other; memory; device_id;
        last_updated; can_use_hotplug_vbd; can_use_hotplug_vif;} = get_initial_guest_metrics lookup list
   in
@@ -289,7 +289,7 @@ let all (lookup: string -> string option) (list: string -> string list) ~__conte
           then existing
           else
             (* if it doesn't exist, make a fresh one *)
-            create_and_set_guest_metrics lookup list ~__context ~domid ~uuid
+            create_and_set_guest_metrics lookup list ~__context ~domid ~uuid ~pV_drivers_detected
         in
 
         (* We unconditionally reset the database values but observe that the database

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -382,6 +382,7 @@ module Monitor = struct
               try
                 Xapi_ha_vm_failover.restart_auto_run_vms ~__context liveset_refs to_tolerate
               with e ->
+                log_backtrace ();
                 error "Caught unexpected exception when executing restart plan: %s" (ExnHelper.string_of_exn e)
             end;
 

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -692,6 +692,7 @@ let restart_auto_run_vms ~__context live_set n =
       Xapi_alert.add ~msg:Api_messages.ha_protected_vm_restart_failed ~cls:`VM ~obj_uuid ~body:""
     end in
 
+  let open TaskChains.Infix in
   (* execute the plan *)
   Helpers.call_api_functions ~__context
     (fun rpc session_id ->
@@ -717,28 +718,56 @@ let restart_auto_run_vms ~__context live_set n =
            if attempt_restart then begin
              Hashtbl.replace last_start_attempt vm (Unix.gettimeofday ());
              match host with
-             | None -> Client.Client.VM.start rpc session_id vm false true
-             | Some h -> Client.Client.VM.start_on rpc session_id vm h false true
+             | None -> Client.Client.Async.VM.start rpc session_id vm false true
+             | Some h -> Client.Client.Async.VM.start_on rpc session_id vm h false true
            end else failwith (Printf.sprintf "VM: %s restart attempt delayed for 120s" (Ref.string_of vm)) in
-         try
-           go ();
-           true
-         with
-         | Api_errors.Server_error(code, params) when code = Api_errors.ha_operation_would_break_failover_plan ->
+         TaskChains.task go >>= function
+         | Result.Error Api_errors.Server_error(code, params) when code = Api_errors.ha_operation_would_break_failover_plan ->
            (* This should never happen since the planning code would always allow the restart of a protected VM... *)
            error "Caught exception HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN: setting pool as overcommitted and retrying";
            ignore (mark_pool_as_overcommitted ~__context ~live_set : bool);
            begin
-             try
-               go ();
-               true
-             with e ->
-               error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
-               false
+             TaskChains.task go >>= function
+             | Result.Ok _ -> TaskChains.ok ()
+             | Result.Error e -> error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
+               TaskChains.fail e
            end
-         | e ->
+         | Result.Error e ->
            error "Caught exception trying to restart VM %s: %s" (Ref.string_of vm) (ExnHelper.string_of_exn e);
-           false in
+           TaskChains.fail e
+         | Result.Ok _ -> TaskChains.ok ()
+       in
+
+       (** [ordered_map_concat f lst]
+        * traverses the list in order, maps each inner list through [f]
+        * and concatenates the result *)
+       let ordered_map_concat f lst =
+        debug "Processing %d parallel groups" (List.length lst);
+        (* the iteration order is important here for preserving the VM start order *)
+        List.fold_left (fun accum inner ->
+             (* the order of elements in the result doesn't matter,
+              * they were launched in parallel *)
+             List.rev_append (f inner) accum) [] lst
+       in
+
+       (** [map_parallel ~order_f f lst] groups objects in [lst] by order number 
+           (provided by applying [order_f] to each object). For each group of objects
+           it then applies [f] to them to produce an 'a TaskChain.t and then executes this
+           set of TaskChain.t values in parallel until they each of the TaskChain.t 
+           values has been executed to completion. It then begins work on the next group
+           of objects. 
+
+           The return is a list of 'a Result.results
+       *)
+       let map_parallel ~order_f f lst =
+         lst
+         |> Helpers.group_by ~ordering:`ascending order_f
+         |> ordered_map_concat (fun same_order ->
+             same_order
+             |> List.rev_map fst
+             |> List.rev_map f
+             |> TaskChains.parallel ~__context ~rpc ~session_id)
+       in
 
        (* Build a list of bools, one per Halted protected VM indicating whether we managed to start it or not *)
        let started =
@@ -746,23 +775,23 @@ let restart_auto_run_vms ~__context live_set n =
            (* If the Pool is overcommitted the restart priority will make the difference between a VM restart or not,
               					   while if we're undercommitted the restart priority only affects the timing slightly. *)
            let all = List.filter (fun (_, r) -> r.API.vM_power_state = `Halted) all_protected_vms in
-           let all = List.sort by_order all in
            warn "Failed to find plan to restart all protected VMs: falling back to simple VM.start in priority order";
-           List.map (fun (vm, _) -> vm, restart_vm vm ()) all
+           map_parallel ~order_f (fun (vm, vmr) -> (vm, vmr), restart_vm vm ()) all
          end else begin
            (* Walk over the VMs in priority order, starting each on the planned host *)
-           let all = List.sort by_order (List.map (fun (vm, _) -> vm, Db.VM.get_record ~__context ~self:vm) plan) in
-           List.map (fun (vm, _) ->
-               vm, (if List.mem_assoc vm plan
+           let all = List.map (fun (vm, _) -> vm, Db.VM.get_record ~__context ~self:vm) plan in
+           map_parallel ~order_f (fun (vm, vmr) ->
+               (vm,vmr), if List.mem_assoc vm plan
                     then restart_vm vm ~host:(List.assoc vm plan) ()
-                    else false)) all
+                    else TaskChains.fail (Failure "VM has no plan")) all
          end in
        (* Perform one final restart attempt of any that weren't started. *)
-       let started = List.map (fun (vm, started) -> match started with
-           | true -> vm, true
-           | false -> vm, restart_vm vm ()) started in
+       let started = map_parallel ~order_f:(fun (vminfo, _) -> order_f vminfo)
+           (function
+            | (vm,_), Result.Ok () -> vm, TaskChains.ok ()
+            | (vm,_), Result.Error _ -> vm, restart_vm vm ()) started in
        (* Send an alert for any failed VMs *)
-       List.iter (fun (vm, started) -> if not started then consider_sending_failed_alert_for vm) started;
+       List.iter (fun (vm, started) -> if started <> Result.Ok () then consider_sending_failed_alert_for vm) started;
 
        (* Forget about previously failed VMs which have gone *)
        let vms_we_know_about = List.map fst started in
@@ -776,16 +805,18 @@ let restart_auto_run_vms ~__context live_set n =
           			   ok since this is 'best-effort'). NOTE we do not use the restart_vm function above as this will mark the
           			   pool as overcommitted if an HA_OPERATION_WOULD_BREAK_FAILOVER_PLAN is received (although this should never
           			   happen it's better safe than sorry) *)
-       List.iter
+       map_parallel ~order_f:(fun vm -> order_f (vm, Db.VM.get_record ~__context ~self:vm))
          (fun vm ->
-            try
-              if Db.VM.get_power_state ~__context ~self:vm = `Halted
+              vm, if Db.VM.get_power_state ~__context ~self:vm = `Halted
               && Db.VM.get_ha_restart_priority ~__context ~self:vm = Constants.ha_restart_best_effort
-              then Client.Client.VM.start rpc session_id vm false true
-            with e ->
-              error "Failed to restart best-effort VM %s (%s): %s"
-                (Db.VM.get_uuid ~__context ~self:vm)
-                (Db.VM.get_name_label ~__context ~self:vm)
-                (ExnHelper.string_of_exn e)) !reset_vms
-
+              then TaskChains.task (fun () -> Client.Client.Async.VM.start rpc session_id vm false true)
+              else TaskChains.ok (Rpc.Null)) !reset_vms
+       |> List.iter (fun (vm, result) ->
+           match result with
+           | Result.Error e ->
+             error "Failed to restart best-effort VM %s (%s): %s"
+               (Db.VM.get_uuid ~__context ~self:vm)
+               (Db.VM.get_name_label ~__context ~self:vm)
+               (ExnHelper.string_of_exn e)
+           | Result.Ok _ -> ())
     )

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -21,11 +21,11 @@ let all_protected_vms ~__context =
   List.filter (fun (_, vm_rec) -> Helpers.vm_should_always_run vm_rec.API.vM_ha_always_run vm_rec.API.vM_ha_restart_priority) vms
 
 (* Comparison function which can be used to sort a list of VM ref, record by order *)
-let by_order (vm_ref1,vm_rec1) (vm_ref2,vm_rec2) =
+let order_f (vm_ref,vm_rec) =
   let negative_high x = if x<0L then Int64.max_int else x in
-  let vm1_order = negative_high (vm_rec1.API.vM_order) in
-  let vm2_order = negative_high (vm_rec2.API.vM_order) in
-  compare vm1_order vm2_order
+  negative_high (vm_rec.API.vM_order)
+
+let by_order a b = compare (order_f a) (order_f b)
 
 let ($) x y = x y
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -554,8 +554,9 @@ let is_slave ~__context ~host = not (Pool_role.is_master ())
 
 let ask_host_if_it_is_a_slave ~__context ~host =
   let local_fn = is_slave ~host in
-  Message_forwarding.do_op_on_localsession_nolivecheck ~local_fn ~__context
-    ~host (fun session_id rpc -> Client.Client.Pool.is_slave rpc session_id host)
+  Server_helpers.exec_with_subtask ~__context "host.ask_host_if_it_is_a_slave" (fun ~__context ->
+    (Message_forwarding.do_op_on_localsession_nolivecheck ~local_fn ~__context
+      ~host (fun session_id rpc -> Client.Client.Pool.is_slave rpc session_id host)))
 
 let is_host_alive ~__context ~host =
   (* If the host is marked as not-live then assume we don't need to contact it to verify *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1135,8 +1135,9 @@ let hello ~__context ~host_uuid ~host_address =
       (* Nb. next call is purely there to establish that we can talk back to the host that initiated this call *)
       (* We don't care about the return type, only that no exception is raised while talking to it *)
       (try
-         ignore(Message_forwarding.do_op_on_nolivecheck_no_retry ~local_fn ~__context ~host:host_ref
-                  (fun session_id rpc -> Client.Pool.is_slave rpc session_id host_ref))
+         ignore(Server_helpers.exec_with_subtask ~__context "pool.hello.is_slave" (fun ~__context ->
+             (Message_forwarding.do_op_on_nolivecheck_no_retry ~local_fn ~__context ~host:host_ref
+                  (fun session_id rpc -> Client.Pool.is_slave rpc session_id host_ref))))
        with Api_errors.Server_error(code, [ "pool.is_slave"; "1"; "2" ]) as e when code = Api_errors.message_parameter_count_mismatch ->
          debug "Caught %s: this host is a Rio box" (ExnHelper.string_of_exn e)
           | Api_errors.Server_error(code, _) as e when code = Api_errors.host_still_booting ->

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1303,7 +1303,15 @@ let update_vm ~__context id =
                    List.iter
                      (fun domid ->
                         try
-                          let new_gm_ref = Xapi_guest_agent.create_and_set_guest_metrics (lookup state) (list state) ~__context ~domid ~uuid:id in
+                          let new_gm_ref =
+                            Xapi_guest_agent.create_and_set_guest_metrics
+                              (lookup state)
+                              (list state)
+                              ~__context
+                              ~domid
+                              ~uuid:id
+                              ~pV_drivers_detected:state.pv_drivers_detected
+                          in
                           debug "xenopsd event: created guest metrics %s for VM %s" (Ref.string_of new_gm_ref) id
                         with e ->
                           error "Caught %s: while creating VM %s guest metrics" (Printexc.to_string e) id
@@ -1333,7 +1341,7 @@ let update_vm ~__context id =
                    (fun domid ->
                       try
                         debug "xenopsd event: Updating VM %s domid %d guest_agent" id domid;
-                        Xapi_guest_agent.all (lookup state) (list state) ~__context ~domid ~uuid:id
+                        Xapi_guest_agent.all (lookup state) (list state) ~__context ~domid ~uuid:id ~pV_drivers_detected:state.pv_drivers_detected
                       with e ->
                         error "Caught %s: while updating VM %s guest_agent" (Printexc.to_string e) id
                    ) state.domids

--- a/scripts/xapi-logrotate.sh
+++ b/scripts/xapi-logrotate.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# If we're using the old partitioning scheme there's no need to run this.
+if ! grep -q /var/log /proc/mounts; then
+  exit 0
+fi
+
 /usr/sbin/logrotate /etc/xensource/xapi-logrotate.conf
 EXITVALUE=$?
 if [ $EXITVALUE != 0 ]; then


### PR DESCRIPTION
This PR contains a series of backports from the master branch. All commits were cherry-picked and did not require manual changes. Below are the key commits:

* f446487c4 2018-04-12 CA-287865: Forwarded task calling Message_forwarding.xxx result.. Rob Hoes
* 7c31dd1de 2018-04-13 CA-287863: xe vm-shutdown complete the task too early             Yang Qian
* 3f9e67c5f 2018-04-13 CA-287863: Reorgnize the code                                     Yang Qian   
* 7c35d0685 2018-04-04 CA-286364: When creating guest_metrics, ensure all fields refle.. ..cello Seri
* 10b5068f0 2017-05-23 CA-223802 [xso-672] When existing network is deactivated and ne.. Rob Hoes
* 06e538067 2018-06-12 CP-28117: restart HA VMs in parallel when recovering from host .. Jon Ludlam  
* 5f620523e 2018-06-12 CP-28117: introduce helper module for running tasks in parallel   Jon Ludlam  
*  359148035 2018-06-12 CP-28117: refactor by_order                                       Jon Ludlam  
* 492ebeb19 2018-06-12 CP-28117: log backtrace from `restart_auto_run_vms`               Jon Ludlam  
* 201d131b5 2018-07-13 CA-293858: Further prevention of logrotate running on old parti.. Jon Ludlam 