### PR TITLE
XSO-886: Do not add micro version to the pv_drivers_version if the latter is empty.

### DIFF
--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -233,7 +233,7 @@ let get_initial_guest_metrics (lookup: string -> string option) (list: string ->
   (* to avoid breakage whilst 'micro' is added to linux and windows agents, default this field
      to -1 if it's not present in xenstore *)
   let pv_drivers_version =
-    if List.mem_assoc "micro" pv_drivers_version then pv_drivers_version (* already there; do nothing *)
+    if pv_drivers_version = [] || List.mem_assoc "micro" pv_drivers_version then pv_drivers_version (* already there; do nothing *)
     else ("micro","-1")::pv_drivers_version
   in
   {pv_drivers_version; os_version; networks; other; memory; device_id; last_updated; can_use_hotplug_vbd; can_use_hotplug_vif;}


### PR DESCRIPTION
I'm suggesting this change to fix the above issue whereby querying a VM's PV-drivers-version returns on occasion (for example, when it's a new VM without PV drivers) the following:
```
[root@xxxx ~]# xe vm-param-get uuid=2ff4edfd-3477-6507-63fd-e0055a578912 param-name=PV-drivers-version
micro: -1
```
This looks weird because major/minor are not there. The original code adds a micro version to pv_drivers_version if it's missing, but I think this should only happen if pv_drivers_version is not empty.