### PR TITLE
Move implementations_of_backend to xcp-idl

### DIFF
--- a/ocaml/xapi/attach_helpers.ml
+++ b/ocaml/xapi/attach_helpers.ml
@@ -101,16 +101,3 @@ let with_vbds rpc session_id __context vm vdis mode f =
            List.iter (Helpers.log_exn_continue "destroying VBD on VM"
                         (fun self -> Client.VBD.destroy rpc session_id self)) !vbds))
 
-(** Separates the implementations of the given backend returned from
-    the VDI.attach2 SMAPIv2 call based on their type *)
-let implementations_of_backend backend =
-  List.fold_left
-    (fun (xendisks, blockdevices, files, nbds) implementation ->
-       match implementation with
-       | Storage_interface.XenDisk xendisk -> (xendisk::xendisks, blockdevices, files, nbds)
-       | BlockDevice blockdevice -> (xendisks, blockdevice::blockdevices, files, nbds)
-       | File file -> (xendisks, blockdevices, file::files, nbds)
-       | Nbd nbd -> (xendisks, blockdevices, files, nbd::nbds)
-    )
-    ([], [], [], [])
-    backend.Storage_interface.implementations

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -494,7 +494,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
          backwards-compatibility, because older xapis call Remote.VDI.attach during SXM.
          However, they ignore the return value, so in practice it does not matter what
          we return from here. *)
-      let (xendisks, blockdevs, files, _nbds) = Attach_helpers.implementations_of_backend backend in
+      let (xendisks, blockdevs, files, _nbds) = Storage_interface.implementations_of_backend backend in
       let response params =
         (* We've thrown o_direct info away from the SMAPIv1 info during the conversion to SMAPIv3 attach info *)
         (* The removal of these fields does not break read caching info propagation for SMAPIv1

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -244,7 +244,7 @@ let vdi_info x =
 module Local = StorageAPI(Idl.GenClientExnRpc(struct let rpc call = rpc ~srcstr:"smapiv2" ~dststr:"smapiv2" (local_url ()) call end))
 
 let tapdisk_of_attach_info (backend:Storage_interface.backend) =
-  let xendisks, _, _, _ = Attach_helpers.implementations_of_backend backend in
+  let xendisks, _, _, _ = Storage_interface.implementations_of_backend backend in
   match xendisks with
   | xendisk :: _ -> begin
       let path = xendisk.Storage_interface.params in
@@ -278,7 +278,7 @@ let with_activated_disk ~dbg ~sr ~vdi ~dp f =
        let path =
          Opt.map
            (fun (vdi, backend) ->
-              let (_, blockdevs, files, _) = Attach_helpers.implementations_of_backend backend in
+              let (_, blockdevs, files, _) = Storage_interface.implementations_of_backend backend in
               match blockdevs, files with
               | ({ path })::_, _ | _, ({ path })::_ ->
                 Local.VDI.activate dbg dp sr vdi;

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -73,7 +73,7 @@ let plug ~__context ~self =
     debug "VBD.plug of loopback VBD '%s'" (Ref.string_of self);
     Storage_access.attach_and_activate ~__context ~vbd:self ~domid
       (fun attach_info ->
-         let (xendisks, blockdevs, files, nbds) = Attach_helpers.implementations_of_backend attach_info in
+         let (xendisks, blockdevs, files, nbds) = Storage_interface.implementations_of_backend attach_info in
          let device_path =
            match files, blockdevs, nbds with
            | { path }::_, _, _ | _, { path }::_, _ -> path


### PR DESCRIPTION
This helper has been moved to the storage interface in xcp-idl to reduce
duplication.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>