### PR TITLE
CP-29605: Write function to query sparseness of VDIs on GFS2 SRs and do sparse data export

### DIFF
--- a/.travis-opam-coverage.sh
+++ b/.travis-opam-coverage.sh
@@ -15,7 +15,7 @@ set -ex
 docker run --rm --volume=$PWD:/mnt --workdir=/mnt \
   --env "TRAVIS=$TRAVIS" \
   --env "TRAVIS_JOB_ID=$TRAVIS_JOB_ID" \
-  ocaml/opam:ubuntu-16.04_ocaml-4.04.2 \
+  ocaml/opam2:ubuntu-18.04-ocaml-4.06 \
   bash -ex -c '
 sudo apt-get update
 

--- a/.travis-xs-opam.sh
+++ b/.travis-xs-opam.sh
@@ -15,7 +15,7 @@ set -ex
 docker run --rm --volume=$PWD:/mnt --workdir=/mnt \
   --env "TRAVIS=$TRAVIS" \
   --env "TRAVIS_JOB_ID=$TRAVIS_JOB_ID" \
-  ocaml/opam:ubuntu-16.04_ocaml-4.06.0 \
+  ocaml/opam2:ubuntu-18.04-ocaml-4.06 \
   bash -ex -c '
 sudo apt-get update
 

--- a/ocaml/quicktest/qt_filter.ml
+++ b/ocaml/quicktest/qt_filter.ml
@@ -178,8 +178,14 @@ module SR = struct
   let has_capabilities caps =
     sr_filter (fun i -> Xapi_stdext_std.Listext.List.subset caps i.Qt.capabilities)
 
-  let not_type _type =
-    sr_filter (fun i -> Client.Client.SR.get_type ~rpc:!A.rpc ~session_id:!session_id ~self:i.Qt.sr <> _type)
+  (* Helper to filter SRs of specific types *)
+  let has_one_of_types types sr_info =
+    List.mem (Client.Client.SR.get_type ~rpc:!A.rpc ~session_id:!session_id ~self:sr_info.Qt.sr) types
+
+  let has_type sr_type = sr_filter (has_one_of_types [sr_type])
+
+  let not_type sr_type =
+    sr_filter (fun i -> Client.Client.SR.get_type ~rpc:!A.rpc ~session_id:!session_id ~self:i.Qt.sr <> sr_type)
 
   let is_smapiv1 sr_info = sr_info.Qt.required_sm_api_version < "3.0"
 
@@ -189,10 +195,7 @@ module SR = struct
   let smapiv3 =
     sr_filter (fun i -> not (is_smapiv1 i))
 
-  let has_type types sr_info =
-    List.mem (Client.Client.SR.get_type ~rpc:!A.rpc ~session_id:!session_id ~self:sr_info.Qt.sr) types
-
-  let thin_pro = sr_filter (has_type ["gfs2"; "nfs"; "smb"; "ext"; "file"])
+  let thin_pro = sr_filter (has_one_of_types ["gfs2"; "nfs"; "smb"; "ext"; "file"])
 
   (** Creates a [Alcotest.test_case] from the given [storage_test_case] using the
       specified session ID and SR *)

--- a/ocaml/quicktest/qt_filter.mli
+++ b/ocaml/quicktest/qt_filter.mli
@@ -56,6 +56,9 @@ module SR : sig
   val allowed_operations : API.storage_operations_set -> srs -> srs
   val has_capabilities : string list -> srs -> srs
 
+  val has_type : string -> srs -> srs
+  (** Selects SRs of the given type *)
+
   val not_type : string -> srs -> srs
   (** Filters out SRs of the given type *)
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -201,6 +201,8 @@ let base_template_name_key = "base_template_name"
 let vbd_task_key = "task_id"
 let related_to_key = "related_to"
 
+let get_nbd_extents = "/opt/xensource/libexec/get_nbd_extents.py"
+
 (* other-config keys to sync over when mirroring/remapping/importing a VDI *)
 let vdi_other_config_sync_keys = [ "config-drive" ]
 


### PR DESCRIPTION
Try to use sparseness information in case the vdi to be exported in tar format has an associated NBD.
This will speed-up dramatically XVA VM export (tar) and vdi-export (tar) in case the VDI is scarcely written.