### PR TITLE
CA-297297 Make create_row idempotent

### DIFF
--- a/.travis-opam-coverage.sh
+++ b/.travis-opam-coverage.sh
@@ -15,7 +15,7 @@ set -ex
 docker run --rm --volume=$PWD:/mnt --workdir=/mnt \
   --env "TRAVIS=$TRAVIS" \
   --env "TRAVIS_JOB_ID=$TRAVIS_JOB_ID" \
-  ocaml/opam:ubuntu-16.04_ocaml-4.04.2 \
+  ocaml/opam2:ubuntu-18.04-ocaml-4.06 \
   bash -ex -c '
 sudo apt-get update
 

--- a/.travis-xs-opam.sh
+++ b/.travis-xs-opam.sh
@@ -15,7 +15,7 @@ set -ex
 docker run --rm --volume=$PWD:/mnt --workdir=/mnt \
   --env "TRAVIS=$TRAVIS" \
   --env "TRAVIS_JOB_ID=$TRAVIS_JOB_ID" \
-  ocaml/opam:ubuntu-16.04_ocaml-4.06.0 \
+  ocaml/opam2:ubuntu-18.04-ocaml-4.06 \
   bash -ex -c '
 sudo apt-get update
 

--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -165,8 +165,19 @@ let create_row_locked t tblname kvs' new_objref =
   update_database t (add_row tblname new_objref row);
   Database.notify (Create(tblname, new_objref, Row.fold (fun k _ v acc -> (k, v) :: acc) row [])) (get_database t)
 
+let fld_check t tblname objref (fldname, value) =
+  let v = Schema.Value.marshal (read_field_internal t tblname fldname objref (get_database t)) in
+  (v = value, fldname, v)
+
 let create_row t tblname kvs' new_objref =
-  with_lock (fun () -> create_row_locked t tblname kvs' new_objref)
+  if is_valid_ref t new_objref then
+      let uniq_check_list = List.map (fld_check t tblname new_objref) kvs' in
+      let failure_opt = List.find_opt (fun (tf, _, _) -> not tf) uniq_check_list in
+      match failure_opt with
+      | Some (_, f, v) -> raise (Integrity_violation (tblname, f, v))
+      | _ -> ()
+  else
+    with_lock (fun () -> create_row_locked t tblname kvs' new_objref)
 
 (* Do linear scan to find field values which match where clause *)
 let read_field_where t rcd =

--- a/ocaml/database/db_exn.ml
+++ b/ocaml/database/db_exn.ml
@@ -15,6 +15,7 @@
 exception Duplicate_key of (*class*) string * (*field*) string * (*uuid*) string * (*key*) string
 exception DBCache_NotFound of string*string*string
 exception Uniqueness_constraint_violation of string*string*string
+exception Integrity_violation of string*string*string
 
 exception Read_missing_uuid of (*class*) string * (*ref*) string * (*uuid*) string
 exception Too_many_values of   (*class*) string * (*ref*) string * (*uuid*) string


### PR DESCRIPTION
If a row already exists, and all of the fields passed in are the same,
we should do nothing and return successfully.

If a row already exists, and any of the fields are different to what was
passed in, we should fail.
 - For this I've created a new exception - Integrity_violation.

I've also updated the database tests to cover these cases

Signed-off-by: Richard Davies <richard.davies@citrix.com>