### PR TITLE
CA-300210: Add 'CIPHER_SERVER_PREFERENCE' option in xapi ssl config file.

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -111,6 +111,7 @@ cert = ${PEMFILE}
 ciphers = !SSLv2:${GOOD_CIPHERS}${EXTRA_CIPHERS}
 curve = secp384r1
 TIMEOUTclose = 0
+options = CIPHER_SERVER_PREFERENCE
 options = NO_SSLv2
 EOF
     if [ $BACK_COMPAT = 0 ]; then


### PR DESCRIPTION
To meet the requirement, add `CIPHER_SERVER_PREFERENCE` to let the server use the preference of cipher. 
Test passed. 

Signed-off-by: Min Li <min.li1@citrix.com>