### PR TITLE
Backport a few fixes/refine for CC feature to Havana

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -218,6 +218,18 @@ let get_product_releases in_product_since =
     | x::xs -> if x=in_product_since then "closed"::x::xs else go_through_release_order xs
   in go_through_release_order release_order
 
+let havana_release =
+  { internal = get_product_releases rel_havana
+  ; opensource = get_oss_releases None
+  ; internal_deprecated_since = None
+  }
+
+let ely_release =
+  { internal = get_product_releases rel_ely
+  ; opensource = get_oss_releases None
+  ; internal_deprecated_since = None
+  }
+
 let dundee_plus_release =
   { internal = get_product_releases rel_dundee_plus
   ; opensource=get_oss_releases None
@@ -4079,6 +4091,10 @@ let pool_update_attach = call
     ~in_oss_since:None
     ~in_product_since:rel_ely
     ~params:[ Ref _pool_update, "self", "The update to be attached"]
+    ~versioned_params:[
+      {param_type=Ref _pool_update; param_name="self"; param_doc="The update to be attached"; param_release=ely_release; param_default=None};
+      {param_type=Bool; param_name="use_localhost_proxy"; param_doc="Use the localhost proxy"; param_release=havana_release; param_default=Some (VBool false)};
+    ]
     ~result:(String, "The file URL of pool update")
     ~allowed_roles:_R_POOL_OP
     ()

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -57,6 +57,7 @@ let rel_dundee = "dundee"
 let rel_dundee_plus = "dundee-plus"
 let rel_ely = "ely"
 let rel_honolulu = "honolulu"
+let rel_havana = "havana"
 
 let release_order =
   [ rel_rio
@@ -81,6 +82,7 @@ let release_order =
   ; rel_dundee_plus
   ; rel_ely
   ; rel_honolulu
+  ; rel_havana
   ]
 
 exception Unknown_release of string

--- a/ocaml/test/test_pool_update.ml
+++ b/ocaml/test/test_pool_update.ml
@@ -24,12 +24,11 @@ let test_pool_update_destroy () =
 
 let test_pool_update_refcount () =
   let __context = Mock.make_context_with_new_db "Mock context" in
-  let uuid = Helpers.get_localhost_uuid () in
   let vdi = make_vdi ~__context ~virtual_size:4096L () in
-  Xapi_pool_update.with_inc_refcount ~__context ~uuid ~vdi (fun ~__context ~uuid ~vdi -> ());
-  Xapi_pool_update.with_inc_refcount ~__context ~uuid ~vdi (fun ~__context ~uuid ~vdi -> assert_equal 0 1);
-  Xapi_pool_update.with_dec_refcount ~__context ~uuid ~vdi (fun ~__context ~uuid ~vdi -> assert_equal 0 1);
-  Xapi_pool_update.with_dec_refcount ~__context ~uuid ~vdi (fun ~__context ~uuid ~vdi -> ())
+  Xapi_pool_update.with_inc_refcount ~__context ~uuid:"a" ~vdi (fun ~__context ~uuid ~vdi -> ());
+  Xapi_pool_update.with_inc_refcount ~__context ~uuid:"a" ~vdi (fun ~__context ~uuid ~vdi -> assert_equal 0 1);
+  Xapi_pool_update.with_dec_refcount ~__context ~uuid:"a" ~vdi (fun ~__context ~uuid ~vdi -> assert_equal 0 1);
+  Xapi_pool_update.with_dec_refcount ~__context ~uuid:"a" ~vdi (fun ~__context ~uuid ~vdi -> ())
 
 let test_assert_space_available () =
   let stat = statvfs "./" in
@@ -40,16 +39,16 @@ let test_assert_space_available () =
 
 let test_download_restriction () =
   Xapi_globs.host_update_dir := ".";
-  let assert_no_dots s =
+  let assert_no_dots (_, s) =
     assert_raises Not_found (fun () -> String.index s '.')
   in
   let test path =
     path
     |> Filename.concat Constants.get_pool_update_download_uri
-    |> Xapi_pool_update.path_from_uri
+    |> Xapi_pool_update.path_and_host_from_uri
     |> assert_no_dots
   in
-  List.iter test ["myfile"; ".."; "%2e%2e"]
+  List.iter test ["/myfile"; "/.."; "/%2e%2e"]
 
 let test =
   "test_pool_update" >:::

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -154,10 +154,10 @@ let read_localhost_info () =
     machine_serial_name = lookup_inventory_nofail Xapi_inventory._machine_serial_name;
     total_memory_mib = total_memory_mib;
     dom0_static_max = dom0_static_max;
-    ssl_legacy = try (
-      bool_of_string (
-        Xapi_inventory.lookup Xapi_inventory._stunnel_legacy ~default:"true")
-    ) with _ -> true;
+    ssl_legacy = if not (Helpers.stunnel_should_use_legacy ()) then false else
+      try
+        bool_of_string (Xapi_inventory.lookup Xapi_inventory._stunnel_legacy ~default:"true")
+      with _ -> true;
   }
 
 (** Returns the maximum of two values. *)

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1294,3 +1294,9 @@ let retry ~__context ~doc ?(policy = Policy.standard) f =
 
 let retry_with_global_lock ~__context ~doc ?policy f =
   retry ~__context ~doc ?policy (fun () -> with_global_lock f)
+
+(* For Havana,stunnel use legacy by default, set legacy=false when cc enable *)
+let stunnel_should_use_legacy () =
+  try
+    not (bool_of_string (Xapi_inventory.lookup "CC_PREPARATIONS" ~default:"false"))
+  with _ -> true

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3923,13 +3923,13 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       info "Pool_update.destroy: pool update = '%s'" (pool_update_uuid ~__context self);
       Local.Pool_update.destroy ~__context ~self
 
-    let attach ~__context ~self =
+    let attach ~__context ~self ~use_localhost_proxy =
       info "Pool_update.attach: pool update = '%s'" (pool_update_uuid ~__context self);
-      let local_fn = Local.Pool_update.attach ~self in
+      let local_fn = Local.Pool_update.attach ~self ~use_localhost_proxy in
       let update_vdi = Db.Pool_update.get_vdi ~__context ~self in
       if Db.is_valid_ref __context update_vdi then
         VDI.forward_vdi_op ~local_fn ~__context ~self:update_vdi
-        (fun session_id rpc -> Client.Pool_update.attach rpc session_id self)
+        (fun session_id rpc -> Client.Pool_update.attach ~rpc ~session_id ~self ~use_localhost_proxy)
       else
         raise (Api_errors.Server_error(Api_errors.cannot_find_update, [(pool_update_uuid ~__context self)]))
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -632,7 +632,8 @@ let set_stunnel_legacy_inv ~__context () =
     );
   Stunnel.set_legacy_ciphersuites !Xapi_globs.ciphersuites_legacy_outbound;
   let s = Xapi_inventory.lookup Xapi_inventory._stunnel_legacy ~default:"true" in
-  let legacy = try
+  let legacy = if not (Helpers.stunnel_should_use_legacy ()) then false else
+    try
       bool_of_string s
     with e ->
       error "Invalid inventory value for %s: expected a Boolean; found %s" Xapi_inventory._stunnel_legacy s;

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -934,7 +934,7 @@ let xenopsd_queues = ref ([
 
 let default_xenopsd = ref "org.xen.xapi.xenops.xenlight"
 
-let ciphersuites_good_outbound = ref "!EXPORT:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-SHA256:AES128-SHA:AES128-SHA256"
+let ciphersuites_good_outbound = ref "!EXPORT:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-SHA256:AES128-SHA256"
 let ciphersuites_legacy_outbound = ref "RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+DES-CBC3-SHA"
 
 let gpumon_stop_timeout = ref 10.0

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -593,7 +593,7 @@ let proxy_request req s host_uuid =
       let transport = Xmlrpc_client.(SSL(SSL.make (), ip, 443)) in
       Xmlrpc_client.with_transport transport (fun fd ->
         Unixext.really_write_string fd (Http.Request.to_wire_string req);
-        Unixext.proxy s fd)
+        Unixext.proxy (Unix.dup s) (Unix.dup fd))
     |None ->
       debug "Caught exception while get Host by uuid %s" host_uuid;
       Http_svr.response_badrequest ~req s

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -193,9 +193,8 @@ let create_yum_config ~__context ~self ~url =
   ; if signed then Printf.sprintf ("gpgkey=file:///etc/pki/rpm-gpg/%s") key else ""
   ]
 
-let attach_helper ~__context ~uuid ~vdi =
+let attach_helper ~__context ~uuid ~vdi ~use_localhost_proxy =
   let host = Helpers.get_localhost ~__context in
-  let ip = Db.Host.get_address ~__context ~self:host in
   with_inc_refcount ~__context ~uuid ~vdi
     (fun ~__context ~uuid ~vdi ->
        let mount_point_parent_dir = String.concat "/" [!Xapi_globs.host_update_dir; uuid] in
@@ -215,12 +214,13 @@ let attach_helper ~__context ~uuid ~vdi =
        with_api_errors (mount device) mount_point;
        debug "pool_update.attach_helper Mounted %s" mount_point
     );
-  "http://" ^ ip ^ Constants.get_pool_update_download_uri ^ uuid ^ "/vdi"
+  let ip = if use_localhost_proxy then "127.0.0.1" else Db.Host.get_address ~__context ~self:host in
+  "http://" ^ ip ^ Constants.get_pool_update_download_uri ^ (Db.Host.get_uuid ~__context ~self:host) ^ "/" ^ uuid ^ "/vdi"
 
-let attach ~__context ~self =
+let attach ~__context ~self ~use_localhost_proxy =
   let uuid = Db.Pool_update.get_uuid ~__context ~self in
   let vdi = Db.Pool_update.get_vdi ~__context ~self in
-  create_yum_config ~__context ~self ~url:(attach_helper ~__context ~uuid ~vdi)
+  create_yum_config ~__context ~self ~url:(attach_helper ~__context ~uuid ~vdi ~use_localhost_proxy)
 
 exception Bad_update_info
 exception Invalid_update_uuid of string
@@ -291,7 +291,7 @@ let extract_update_info ~__context ~vdi ~verify =
   let vdi_uuid = Db.VDI.get_uuid ~__context ~self:vdi in
   finally
     (fun () ->
-       let url = attach_helper ~__context ~uuid:vdi_uuid ~vdi in
+       let url = attach_helper ~__context ~uuid:vdi_uuid ~vdi ~use_localhost_proxy:true in
        let update_path = Printf.sprintf "%s/%s/vdi" !Xapi_globs.host_update_dir vdi_uuid in
        debug "pool_update.extract_update_info get url='%s', will parse_file in '%s'" url update_path;
        let xml = try
@@ -569,21 +569,49 @@ let resync_host ~__context ~host =
     Db_gc_util.gc_Host_patches ~__context
   end
 
-let path_from_uri uri =
+let path_and_host_from_uri uri =
   (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
-  String.sub_to_end uri (String.length Constants.get_pool_update_download_uri)
-  |> Filename.concat !Xapi_globs.host_update_dir
-  |> Uri.pct_decode
-  |> Stdext.Unixext.resolve_dot_and_dotdot
+  let host_and_path = String.sub_to_end uri (String.length Constants.get_pool_update_download_uri) in
+  match String.split ~limit:2 '/' host_and_path with
+  | [host; untrusted_path] ->
+    let resolved_path = untrusted_path
+      |> Filename.concat !Xapi_globs.host_update_dir
+      |> Uri.pct_decode
+      |> Stdext.Unixext.resolve_dot_and_dotdot
+    in
+    (host,resolved_path)
+  | _ -> failwith "Expecting both host and path in the uri"
+
+let proxy_request req s host_uuid =
+  Server_helpers.exec_with_new_task "pool_update_proxy_request" (fun __context ->
+    let host =
+      try Some (Db.Host.get_by_uuid ~__context ~uuid:host_uuid) with _ -> None
+    in
+    match host with
+    |Some host ->
+      let ip = Db.Host.get_address ~__context ~self:host in
+      let transport = Xmlrpc_client.(SSL(SSL.make (), ip, 443)) in
+      Xmlrpc_client.with_transport transport (fun fd ->
+        Unixext.really_write_string fd (Http.Request.to_wire_string req);
+        Unixext.proxy s fd)
+    |None ->
+      debug "Caught exception while get Host by uuid %s" host_uuid;
+      Http_svr.response_badrequest ~req s
+  )
 
 let pool_update_download_handler (req: Request.t) s _ =
   debug "pool_update.pool_update_download_handler URL %s" req.Request.uri;
-  let filepath = path_from_uri req.Request.uri in
+  req.Request.close <- true;
+  let localhost_uuid = Helpers.get_localhost_uuid () in
+  let (host_uuid, filepath) = path_and_host_from_uri req.Request.uri in
   debug "pool_update.pool_update_download_handler %s" filepath;
-  if not(String.startswith !Xapi_globs.host_update_dir filepath) || not (Sys.file_exists filepath) then begin
-    debug "Rejecting request for file: %s (outside of or not existed in directory %s)" filepath !Xapi_globs.host_update_dir;
-    Http_svr.response_forbidden ~req s
-  end else begin
-    Fileserver.response_file s filepath;
-    req.Request.close <- true
+  if host_uuid <> localhost_uuid then
+    proxy_request req s host_uuid
+  else begin
+    if not(String.startswith !Xapi_globs.host_update_dir filepath) || not (Sys.file_exists filepath) then begin
+      debug "Rejecting request for file: %s (outside of or not existed in directory %s)" filepath !Xapi_globs.host_update_dir;
+      Http_svr.response_forbidden ~req s
+    end else begin
+      Fileserver.response_file s filepath
+    end
   end

--- a/scripts/extensions/pool_update.apply
+++ b/scripts/extensions/pool_update.apply
@@ -127,7 +127,7 @@ if __name__ == '__main__':
 
         # Apply the update.
         try:
-            yum_conf = session.xenapi.pool_update.attach(update)
+            yum_conf = session.xenapi.pool_update.attach(update, True)
             try:
                 os.makedirs(os.path.dirname(yum_conf_file))
             except OSError as e:

--- a/scripts/extensions/pool_update.precheck
+++ b/scripts/extensions/pool_update.precheck
@@ -250,7 +250,7 @@ if __name__ == '__main__':
 
         # attach and get the yum configuration
         # generate the yum configuration file
-        yum_conf = session.xenapi.pool_update.attach(update)
+        yum_conf = session.xenapi.pool_update.attach(update, True)
         yum_conf_file = os.path.join(TMP_DIR, update_uuid, 'yum.conf')
         try:
             os.makedirs(os.path.dirname(yum_conf_file))

--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -102,6 +102,7 @@ cert = ${PEMFILE}
 ciphers = !SSLv2:${GOOD_CIPHERS}${EXTRA_CIPHERS}
 curve = secp384r1
 TIMEOUTclose = 0
+options = CIPHER_SERVER_PREFERENCE
 options = NO_SSLv2
 EOF
     if [ $BACK_COMPAT = 0 ]; then

--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -66,7 +66,7 @@ writeconffile () {
 
     # (This "good" list must match, or at least contain one of,
     #  the ciphersuites-good-outbound list in /etc/xapi.conf.)
-    GOOD_CIPHERS='ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-SHA256:AES128-SHA:AES128-SHA256'
+    GOOD_CIPHERS='ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-SHA256:AES128-SHA256'
     BACK_COMPAT_CIPHERS='RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA'
 
     if [ -n "${STUNNEL_IDLE_TIMEOUT}" ]; then


### PR DESCRIPTION
This PR contains several fixes and refine:
1. CA-299944: Proxy requests to updates
2. CP-29687: Remove TLS_RSA_WITH_AES_128_CBC_SHA(AES128-SHA) for CC 
3. CA-300210: Add 'CIPHER_SERVER_PREFERENCE' option in xapi ssl config
4. CA-300650: Set ssl legacy = false for Havana in CC mode.
5. CA-300715: Use dup fd to avoid close twice.

1.2.3 get reviewed already, the 4,5 commit is new and targets only in Havana branch.
As there is minor conflict in Havana build, I need to refine a little tomorrow but needs to get reviewed at first on UK daytime today.
Please help to review, thanks @robhoes 