### PR TITLE
Backport-ca293417-honolulu.patch to Havana

### DIFF
--- a/ocaml/test/test_pool_update.ml
+++ b/ocaml/test/test_pool_update.ml
@@ -38,10 +38,24 @@ let test_assert_space_available () =
   assert_raises_api_error Api_errors.out_of_space
     (fun () -> Xapi_pool_update.assert_space_available "./" (Int64.div free_bytes 2L))
 
+let test_download_restriction () =
+  Xapi_globs.host_update_dir := ".";
+  let assert_no_dots s =
+    assert_raises Not_found (fun () -> String.index s '.')
+  in
+  let test path =
+    path
+    |> Filename.concat Constants.get_pool_update_download_uri
+    |> Xapi_pool_update.path_from_uri
+    |> assert_no_dots
+  in
+  List.iter test ["myfile"; ".."; "%2e%2e"]
+
 let test =
   "test_pool_update" >:::
   [
     "test_pool_update_destroy" >:: test_pool_update_destroy;
     "test_pool_update_refcount" >:: test_pool_update_refcount;
     "test_assert_space_available" >:: test_assert_space_available;
+    "test_download_restriction" >:: test_download_restriction;
   ]

--- a/ocaml/xapi/fileserver.ml
+++ b/ocaml/xapi/fileserver.ml
@@ -53,7 +53,16 @@ let mime_of_extension = function
   | "gif"          -> "image/gif"
   | "png"          -> "image/png"
   | "jpg" | "jpeg" -> "image/jpeg"
+  | "xml"          -> "application/xml"
+  | "rpm"          -> "application/x-rpm"
   | _              -> application_octet_stream
+
+let response_file s file_path =
+  let mime_content_type =
+    let open Stdext.Opt in
+    let ext = map String.lowercase (get_extension file_path) in
+    default application_octet_stream (map mime_of_extension ext) in
+  Http_svr.response_file ~mime_content_type s file_path
 
 let send_file (uri_base: string) (dir: string) (req: Request.t) (bio: Buf_io.t) _ =
   let uri_base_len = String.length uri_base in
@@ -74,12 +83,7 @@ let send_file (uri_base: string) (dir: string) (req: Request.t) (bio: Buf_io.t) 
       let stat = Unix.stat file_path in
       (* if a directory, automatically add index.html *)
       let file_path = if stat.Unix.st_kind = Unix.S_DIR then file_path ^ "/index.html" else file_path in
-
-      let mime_content_type =
-        let open Stdext.Opt in
-        let ext = map String.lowercase (get_extension file_path) in
-        default application_octet_stream (map mime_of_extension ext) in
-      Http_svr.response_file ~mime_content_type s file_path
+      response_file s file_path
     end
   with
     _ -> Http_svr.response_missing s (missing uri)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -652,7 +652,7 @@ let persist_xenopsd_md = "persist_xenopsd_md"
 let persist_xenopsd_md_root = Filename.concat "/var/lib/xcp" "xenopsd_md"
 
 (** {Host updates directory} *)
-let host_update_dir = "/var/update"
+let host_update_dir = ref "/var/update"
 
 (** Dynamic configurations to be read whenever xapi (re)start *)
 

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -112,7 +112,7 @@ let with_inc_refcount ~__context ~uuid ~vdi f =
 let detach_helper ~__context ~uuid ~vdi =
   with_dec_refcount ~__context ~uuid ~vdi
     (fun ~__context ~uuid ~vdi ->
-       let mount_point_parent_dir = String.concat "/" [Xapi_globs.host_update_dir; uuid] in
+       let mount_point_parent_dir = String.concat "/" [!Xapi_globs.host_update_dir; uuid] in
        let mount_point = Filename.concat mount_point_parent_dir "vdi" in
        debug "pool_update.detach_helper %s from %s" uuid mount_point;
        if try Sys.is_directory mount_point with _ -> false then begin
@@ -198,7 +198,7 @@ let attach_helper ~__context ~uuid ~vdi =
   let ip = Db.Host.get_address ~__context ~self:host in
   with_inc_refcount ~__context ~uuid ~vdi
     (fun ~__context ~uuid ~vdi ->
-       let mount_point_parent_dir = String.concat "/" [Xapi_globs.host_update_dir; uuid] in
+       let mount_point_parent_dir = String.concat "/" [!Xapi_globs.host_update_dir; uuid] in
        let mount_point = Filename.concat mount_point_parent_dir "vdi" in
        debug "pool_update.attach_helper %s to %s" uuid mount_point;
        let output, _ = Forkhelpers.execute_command_get_output "/bin/mkdir" ["-p"; mount_point] in
@@ -282,7 +282,7 @@ let parse_update_info xml =
   | _ -> raise (Api_errors.Server_error(Api_errors.invalid_update, ["missing <update> in update.xml"]))
 
 let extract_applied_update_info applied_uuid  =
-  let applied_update = Printf.sprintf "%s/applied/%s" Xapi_globs.host_update_dir applied_uuid in
+  let applied_update = Printf.sprintf "%s/applied/%s" !Xapi_globs.host_update_dir applied_uuid in
   debug "pool_update.extract_applied_update_info, will parse '%s'" applied_update;
   let xml = Xml.parse_file applied_update in
   parse_update_info xml
@@ -292,7 +292,7 @@ let extract_update_info ~__context ~vdi ~verify =
   finally
     (fun () ->
        let url = attach_helper ~__context ~uuid:vdi_uuid ~vdi in
-       let update_path = Printf.sprintf "%s/%s/vdi" Xapi_globs.host_update_dir vdi_uuid in
+       let update_path = Printf.sprintf "%s/%s/vdi" !Xapi_globs.host_update_dir vdi_uuid in
        debug "pool_update.extract_update_info get url='%s', will parse_file in '%s'" url update_path;
        let xml = try
          Xml.parse_file (Filename.concat update_path "update.xml")
@@ -315,7 +315,7 @@ let assert_space_available ?(multiplier=3L) update_dir update_size =
     begin
       error "Not enough space on filesystem to upload update. Required %Ld, \
              but only %Ld available" really_required free_bytes;
-      raise (Api_errors.Server_error (Api_errors.out_of_space, [Xapi_globs.host_update_dir]))
+      raise (Api_errors.Server_error (Api_errors.out_of_space, [!Xapi_globs.host_update_dir]))
     end
 
 exception Cannot_expose_yum_repo_on_slave
@@ -419,9 +419,9 @@ let create_update_record ~__context ~update ~update_info ~vdi =
     ~vdi:vdi
 
 let introduce ~__context ~vdi =
-  ignore(Unixext.mkdir_safe Xapi_globs.host_update_dir 0o755);
+  ignore(Unixext.mkdir_safe !Xapi_globs.host_update_dir 0o755);
   (*If current disk free space is smaller than 1MB raise exception*)
-  assert_space_available ~multiplier:1L Xapi_globs.host_update_dir (Int64.mul 1024L 1024L);
+  assert_space_available ~multiplier:1L !Xapi_globs.host_update_dir (Int64.mul 1024L 1024L);
   let update_info = extract_update_info ~__context ~vdi ~verify in
   try
     let update = Db.Pool_update.get_by_uuid ~__context ~uuid:update_info.uuid in
@@ -569,19 +569,21 @@ let resync_host ~__context ~host =
     Db_gc_util.gc_Host_patches ~__context
   end
 
+let path_from_uri uri =
+  (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
+  String.sub_to_end uri (String.length Constants.get_pool_update_download_uri)
+  |> Filename.concat !Xapi_globs.host_update_dir
+  |> Uri.pct_decode
+  |> Stdext.Unixext.resolve_dot_and_dotdot
+
 let pool_update_download_handler (req: Request.t) s _ =
   debug "pool_update.pool_update_download_handler URL %s" req.Request.uri;
-  (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
-  let filepath = String.sub_to_end req.Request.uri (String.length Constants.get_pool_update_download_uri)
-                 |> Filename.concat Xapi_globs.host_update_dir
-                 |> Stdext.Unixext.resolve_dot_and_dotdot 
-                 |> Uri.pct_decode  in
+  let filepath = path_from_uri req.Request.uri in
   debug "pool_update.pool_update_download_handler %s" filepath;
-
-  if not(String.startswith Xapi_globs.host_update_dir filepath) || not (Sys.file_exists filepath) then begin
-    debug "Rejecting request for file: %s (outside of or not existed in directory %s)" filepath Xapi_globs.host_update_dir;
+  if not(String.startswith !Xapi_globs.host_update_dir filepath) || not (Sys.file_exists filepath) then begin
+    debug "Rejecting request for file: %s (outside of or not existed in directory %s)" filepath !Xapi_globs.host_update_dir;
     Http_svr.response_forbidden ~req s
   end else begin
-    Http_svr.response_file s filepath;
+    Fileserver.response_file s filepath;
     req.Request.close <- true
   end


### PR DESCRIPTION
This PR is for removing the patch `ca293417-honolulu.patch` for Havana to avoid possible conflict.
Build passed in Branch 'private/minl1/backport-patch'. 
The PR #3744 needs to rebase this one after merged.
Signed-off-by: Min Li <min.li1@citrix.com>