### PR TITLE
CA-300115 lower VM.assert_operation_valid permissions

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1209,7 +1209,7 @@ let assert_operation_valid = call
     ~doc:"Check to see whether this operation is acceptable in the current state of the system, raising an error if the operation is invalid for some reason"
     ~params:[Ref _vm, _self, "reference to the object";
              operations, "op", "proposed operation" ]
-    ~allowed_roles:_R_POOL_ADMIN
+    ~allowed_roles:_R_READ_ONLY
     ()
 
 let update_allowed_operations = call


### PR DESCRIPTION
Set the permissions for VN.assert_operation_valid to READ_ONLY as this
call doesn't mutate anything and does not reveal critical information.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>