### PR TITLE
CP-29698 expunge Xenctrl.with_intf

### DIFF
--- a/ocaml/quicktest/quicktest_vm_lifecycle.ml
+++ b/ocaml/quicktest/quicktest_vm_lifecycle.ml
@@ -70,7 +70,7 @@ let one rpc s vm test =
       in
       begin
         try
-          Xenctrl.with_intf (fun xc -> Xenctrl.domain_shutdown xc (Int64.to_int domid) reason)
+          Xenctrlx.with_intf (fun xc -> Xenctrl.domain_shutdown xc (Int64.to_int domid) reason)
         with e ->
           Printf.printf "Ignoring exception: %s" (Printexc.to_string e)
       end

--- a/ocaml/tests/cancel_tests.ml
+++ b/ocaml/tests/cancel_tests.ml
@@ -277,7 +277,7 @@ let test ({ session_id = session_id; vm = vm; id = id } as env) (op, n) =
            match xs.Xs.directory (Printf.sprintf "/vm/%s/domains" id) with
            | [ domid ] ->
              let open Xenctrl in
-             with_intf
+             Xenctrlx.with_intf
                (fun xc ->
                   let di = domain_getinfo xc (int_of_string domid) in
                   f (Some di)

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -89,7 +89,7 @@ let refresh_localhost_info ~__context info =
   Db.Host.set_virtual_hardware_platform_versions ~__context ~self:host ~value:Xapi_globs.host_virtual_hardware_platform_versions;
   Db.Host.set_hostname ~__context ~self:host ~value:info.hostname;
   let caps = try
-      String.split ' ' (Xenctrl.with_intf (fun xc -> Xenctrl.version_capabilities xc))
+      String.split ' ' (Xenctrlx.with_intf (fun xc -> Xenctrl.version_capabilities xc))
     with _ ->
       warn "Unable to query hypervisor capabilities";
       [] in

--- a/ocaml/xapi/monitor_dbcalls.ml
+++ b/ocaml/xapi/monitor_dbcalls.ml
@@ -173,7 +173,7 @@ let pifs_and_memory_update_fn xc =
     )
 
 let monitor_dbcall_thread () =
-  Xenctrl.with_intf (fun xc ->
+  Xenctrlx.with_intf (fun xc ->
       while true do
         try
           pifs_and_memory_update_fn xc;

--- a/ocaml/xapi/monitor_types.ml
+++ b/ocaml/xapi/monitor_types.ml
@@ -42,7 +42,7 @@ let vif_device_of_string x =
   try
     let ty = String.sub x 0 3 and params = String.sub_to_end x 3 in
     let domid, devid = Scanf.sscanf params "%d.%d" (fun x y -> x,y) in
-    let di = Xenctrl.with_intf (fun xc -> Xenctrl.domain_getinfo xc domid) in
+    let di = Xenctrlx.with_intf (fun xc -> Xenctrl.domain_getinfo xc domid) in
     let uuid = Uuid.uuid_of_int_array di.Xenctrl.handle |> Uuid.to_string in
     let vif = (uuid, string_of_int devid) in
     match ty with

--- a/ocaml/xapi/xenctrlx.ml
+++ b/ocaml/xapi/xenctrlx.ml
@@ -1,0 +1,27 @@
+
+module D = Debug.Make(struct let name = "xenctrlx" end)
+
+let handle = ref None
+
+let with_intf f =
+  match !handle with
+    | Some xc -> f xc
+    | None ->
+      let xc =
+        try
+          Xenctrl.interface_open ()
+        with
+        | e ->
+            let msg = Printexc.to_string e in
+            failwith @@ "failed to open xenctrl interface: "^msg
+      in
+        handle := Some (xc);
+        f xc
+ 
+let close () =
+  match !handle with
+  | Some xc -> Xenctrl.interface_close xc
+  | None    -> ()
+
+let () = at_exit close
+

--- a/ocaml/xapi/xenctrlx.mli
+++ b/ocaml/xapi/xenctrlx.mli
@@ -1,0 +1,4 @@
+
+(** replacement for Xenctrl.with_intf *)
+val with_intf: (Xenctrl.handle -> 'a) -> 'a
+


### PR DESCRIPTION
Xenctrl.with_intf is deprecated. The local replacement opens a
connection only once and remembers it.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>