### PR TITLE
CP-29857: defer setting device-model until VM.start

### DIFF
--- a/ocaml/tests/test_platformdata.ml
+++ b/ocaml/tests/test_platformdata.ml
@@ -166,12 +166,19 @@ module SanityCheck = Generic.Make(struct
         (* Check UEFI configuration - qemu upstream *)
         make_firmware_ok "qemu-upstream" (Some uefi);
         make_firmware_ok "qemu-upstream-compat" (Some uefi);
+        make_firmware_ok "qemu-upstream-uefi" (Some uefi);
 
         (* Check UEFI configuration - qemu-trad incompatibility *)
         (([ "device-model", "qemu-trad" ], Some uefi, false, 0L, 0L, `hvm),
          Either.Left(Api_errors.Server_error(Api_errors.invalid_value,
                                              ["platform:device-model";
                                               "UEFI boot is not supported with qemu-trad"])));
+
+        (* Check BIOS configuration - qemu-upstream-uefi incompatibility *)
+        (([ "device-model", "qemu-upstream-uefi" ], Some Bios, false, 0L, 0L, `hvm),
+         Either.Left(Api_errors.Server_error(Api_errors.invalid_value,
+                                             ["platform:device-model";
+                                              "BIOS boot is not supported with qemu-upstream-uefi"])));
       ]
   end)
 

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -470,6 +470,7 @@ module VM : HandlerTools = struct
         vm_record with API.vM_platform =
                          (Xapi_vm_helpers.ensure_device_model_profile_present ~__context
                             ~domain_type:vm_record.API.vM_domain_type
+                            ~is_a_template:vm_record.API.vM_is_a_template
                             vm_record.API.vM_platform)
       }
       in

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -138,6 +138,10 @@ let sanity_check ~platformdata ?firmware ~vcpu_max ~vcpu_at_startup ~domain_type
     raise (Api_errors.Server_error(Api_errors.invalid_value,
                                    ["platform:device-model";
                                     "UEFI boot is not supported with qemu-trad"]));
+  | "qemu-upstream-uefi", Some Xenops_types.Vm.Bios ->
+    raise (Api_errors.Server_error(Api_errors.invalid_value,
+                                   ["platform:device-model";
+                                    "BIOS boot is not supported with qemu-upstream-uefi"]));
   | exception Not_found -> ()
   | _ -> ()
   end;

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -111,7 +111,7 @@ let is_true ~key ~platformdata ~default =
 let is_valid_device_model ~key ~platformdata =
   try
     match List.assoc key platformdata with
-    | "qemu-upstream-compat" -> true
+    | "qemu-upstream-compat" | "qemu-upstream-uefi" | "qemu-upstream" -> true
     | _ -> false
   with Not_found ->
     false

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -53,6 +53,8 @@ let fallback_device_model_stage_3      = "qemu-upstream-compat"
 let fallback_device_model_stage_4      = fallback_device_model_stage_3
 let fallback_device_model_default_value = fallback_device_model_stage_3
 
+let fallback_device_model_default_value_uefi = "qemu-upstream-uefi"
+
 (* This is only used to block the 'present multiple physical cores as one big hyperthreaded core' feature *)
 let filtered_flags = [
   acpi;

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -538,7 +538,7 @@ let upgrade_vm_platform_device_model =
         ( "platform"
         , string_to_assoc str
           |> Xapi_vm_helpers.ensure_device_model_profile_present
-            ~__context ~domain_type
+            ~__context ~domain_type ~is_a_template:false
           |> assoc_to_string
         )
       | other -> other in
@@ -553,9 +553,10 @@ let upgrade_vm_platform_device_model =
           (* update VM record *)
           let domain_type = Db.VM.get_domain_type ~__context ~self:vm in
           let platform    = Db.VM.get_platform ~__context ~self:vm in
+          let is_a_template = Db.VM.get_is_a_template ~__context ~self:vm in
           let platform' =
             Xapi_vm_helpers.ensure_device_model_profile_present
-              ~__context ~domain_type platform in
+              ~__context ~domain_type ~is_a_template platform in
           Db.VM.set_platform ~__context ~self:vm ~value:platform';
           (* update snapshot meta data *)
           Db.VM.get_snapshot_metadata ~__context ~self:vm

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -253,12 +253,6 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
   let is_vmss_snapshot =
       is_a_snapshot && (Xapi_vmss.is_vmss_snapshot ~__context) in
 
-  let platform =
-    all.Db_actions.vM_platform
-    |> (Xapi_vm_helpers.ensure_device_model_profile_present
-          ~__context ~domain_type:all.Db_actions.vM_domain_type)
-  in
-
   (* create a new VM *)
   Db.VM.create ~__context
     ~ref
@@ -300,7 +294,7 @@ let copy_vm_record ?(snapshot_info_record) ~__context ~vm ~disk_op ~new_name ~ne
     ~hVM_boot_params:all.Db_actions.vM_HVM_boot_params
     ~hVM_shadow_multiplier:all.Db_actions.vM_HVM_shadow_multiplier
     ~suspend_VDI:Ref.null
-    ~platform
+    ~platform:all.Db_actions.vM_platform
     ~pV_kernel:all.Db_actions.vM_PV_kernel
     ~pV_ramdisk:all.Db_actions.vM_PV_ramdisk
     ~pV_args:all.Db_actions.vM_PV_args

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -1180,13 +1180,15 @@ let with_vm_operation ~__context ~self ~doc ~op ?(strict=true) ?policy f =
          _ -> ())
 
 (* Device Model Profiles *)
-let ensure_device_model_profile_present ~__context ~domain_type ?(default_value=Vm_platform.fallback_device_model_default_value) platform =
+let ensure_device_model_profile_present ~__context ~domain_type ~is_a_template ?(default_value=Vm_platform.fallback_device_model_default_value) platform =
   let needs_qemu = Helpers.needs_qemu_from_domain_type domain_type in
   let default = Vm_platform.(device_model, default_value) in
   let trad    = Vm_platform.(device_model, fallback_device_model_stage_1) in
-  if not needs_qemu || List.mem_assoc Vm_platform.device_model platform then
-    (* upgrade existing Device Model entry *)
-    platform |> List.map (fun entry -> if entry = trad then default else entry)
-  else (* only add device-model to an HVM VM platform if it is not already there *)
-    default :: platform
+  if is_a_template then platform
+  else
+    if not needs_qemu || List.mem_assoc Vm_platform.device_model platform then
+      (* upgrade existing Device Model entry *)
+      platform |> List.map (fun entry -> if entry = trad then default else entry)
+    else (* only add device-model to an HVM VM platform if it is not already there *)
+      default :: platform
 


### PR DESCRIPTION
We want to be able to choose BIOS/UEFI boot mode from XenCenter, so the device-model should not be part of the template.
Did a basic smoke test on this, and will run more tests.