### PR TITLE
CA-302194 XSI-87 apply guest agent config on start

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2323,7 +2323,11 @@ let on_xapi_restart ~__context =
       ()
     ) (all_known_xenopsds ());
 
-  resync_all_vms ~__context
+  resync_all_vms ~__context;
+  info "applying guest agent configuration during restart";
+  let pool = Helpers.get_pool ~__context in
+  let config = Db.Pool.get_guest_agent_config ~__context ~self:pool in
+  apply_guest_agent_config ~__context config
 
 let assert_resident_on ~__context ~self =
   let localhost = Helpers.get_localhost ~__context in


### PR DESCRIPTION
The /guest_agent_features tree in xenstore disappears during reboot. To
make sure it is re-created, we call apply_guest_agent_config() during
xapi startup.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>