### PR TITLE
CP-30002: xe vm-add-tags/vm-remove-tags

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1205,6 +1205,24 @@ let rec cmdtable_data : (string*cmd_spec) list =
       flags=[Vm_selectors];
     };
 
+    "vm-add-tags",
+    {
+      reqd=["tag"];
+      optn=[];
+      help="Add the given value to the tags field of the given VM. If the value is already in that Set, then do nothing.";
+      implementation=No_fd Cli_operations.vm_add_tags;
+      flags=[Standard;Vm_selectors]
+    };
+
+    "vm-remove-tags",
+    {
+      reqd=["tag"];
+      optn=[];
+      help="Remove the given value from the tags field of the given VM. If the value is not in that Set, then do nothing.";
+      implementation=No_fd Cli_operations.vm_remove_tags;
+      flags=[Standard;Vm_selectors]
+    };
+
     "vm-query-services",
     {
       reqd=[];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -2300,6 +2300,22 @@ let vm_memory_shadow_multiplier_set printer rpc session_id params =
          Client.VM.set_shadow_multiplier_live rpc session_id vm multiplier) params ["multiplier"] in
   ()
 
+let vm_add_tags printer rpc session_id params =
+  ignore(do_vm_op printer rpc session_id
+           (fun vmr ->
+              let vm = vmr.getref () in
+              let tag = List.assoc "tag" params in
+              Client.VM.add_tags rpc session_id vm tag
+            ) params ["tag"])
+
+let vm_remove_tags printer rpc session_id params =
+  ignore(do_vm_op printer rpc session_id
+           (fun vmr ->
+              let vm = vmr.getref () in
+              let tag = List.assoc "tag" params in
+              Client.VM.remove_tags rpc session_id vm tag
+            ) params ["tag"])
+
 let vm_query_services printer rpc session_id params =
   ignore(do_vm_op printer rpc session_id
            (fun vm ->


### PR DESCRIPTION
Xapi has an API to add/remove VM tags that XenCenter uses, but there was no CLI equivalent.
I used this a while ago when doing some large scale boot tests and wanted to group my VMs from the commandline.