### PR TITLE
CA-302194 XSI-87 move code to end of on_xapi_restart

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1990,11 +1990,6 @@ let on_xapi_restart ~__context =
       let (_: Thread.t) = Thread.create events_from_xenopsd queue_name in
       ()
     ) (all_known_xenopsds ());
-  info "applying guest agent configuration during restart";
-  let pool = Helpers.get_pool ~__context in
-  let config = Db.Pool.get_guest_agent_config ~__context ~self:pool in
-  apply_guest_agent_config ~__context config;
-
 
   (* Get a list of all the ids of VMs that Xapi thinks are resident here *)
   let resident_vms_in_db =
@@ -2058,7 +2053,13 @@ let on_xapi_restart ~__context =
   List.iter (fun (id, vm) ->
       Xapi_vm_lifecycle.force_state_reset ~__context ~self:vm ~value:`Halted;
       Db.VM.set_resident_on ~__context ~self:vm ~value:Ref.null;
-    ) xapi_vms_not_in_xenopsd
+  ) xapi_vms_not_in_xenopsd;
+
+  info "applying guest agent configuration during restart";
+  let pool = Helpers.get_pool ~__context in
+  let config = Db.Pool.get_guest_agent_config ~__context ~self:pool in
+  apply_guest_agent_config ~__context config
+
 
 let assert_resident_on ~__context ~self =
   let localhost = Helpers.get_localhost ~__context in


### PR DESCRIPTION
This fixes the previous commit - the code for building the
tree in xen should be run last to be equivalent with the code
on the master branch.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>