### PR TITLE
Backport of CA-300103 - designate a single Tools SR, delete others

### DIFF
--- a/ocaml/test/test_dbsync_master.ml
+++ b/ocaml/test/test_dbsync_master.ml
@@ -114,7 +114,18 @@ module CreateToolsSR = Generic.Make (Generic.EncapsulateState (struct
     one with is_tools_iso=true *)
       ( [ ("Toolz", "Toolz ISOs", [(Xapi_globs.tools_sr_tag, "true")], false)
         ; ("Other", "Other SR", [extra_oc], true) ]
-      , [(name, description, extra_oc :: other_config)] ) ]
+      , [(name, description, extra_oc :: other_config)] )
+    ; (* Two old SRs - one gets promoted, the other removed *)
+      ( [ ("Toolz"  , "Toolz ISOs"  , [(Xapi_globs.tools_sr_tag, "true")], false)
+        ; ("Toolz 2", "Toolz ISOs 2", [(Xapi_globs.tools_sr_tag, "true")], false)]
+      , [(name, description, other_config)] )
+    ; (* two new SRs, two old SRs - pick first new, remove the others *)
+      ( [ ("Toolz"  , "Toolz ISOs"  , [(Xapi_globs.tools_sr_tag, "true")], true)
+        ; ("Toolz 2", "Toolz ISOs 2", [(Xapi_globs.tools_sr_tag, "true")], true)
+        ; ("Toolz 3", "Toolz ISOs 3", [(Xapi_globs.tools_sr_tag, "true")], false)
+        ; ("Toolz 4", "Toolz ISOs 4", [(Xapi_globs.tools_sr_tag, "true")], false)]
+      , [(name, description, other_config)] )
+    ]
 end))
 
 let test =

--- a/ocaml/test/test_dbsync_master.ml
+++ b/ocaml/test/test_dbsync_master.ml
@@ -16,103 +16,106 @@ open OUnit
 open Test_highlevel
 open Dbsync_master
 
-module CreateToolsSR = Generic.Make(Generic.EncapsulateState(struct
-                                      module Io = struct
-                                        type input_t = (string * string * (string * string) list * bool) list
-                                        type output_t = (string * string * (string * string) list) list
+module CreateToolsSR = Generic.Make (Generic.EncapsulateState (struct
+  module Io = struct
+    type input_t = (string * string * (string * string) list * bool) list
 
-                                        let string_of_input_t = Test_printers.(list (tuple4 string string (assoc_list string string) bool))
-                                        let string_of_output_t = Test_printers.(list (tuple3 string string (assoc_list string string)))
-                                      end
-                                      module State = Test_state.XapiDb
+    type output_t = (string * string * (string * string) list) list
 
-                                      let name = "Tools"
-                                      let description = "Tools ISOs"
-                                      let other_config = [
-                                        Xapi_globs.xensource_internal, "true";
-                                        Xapi_globs.tools_sr_tag, "true";
-                                        Xapi_globs.i18n_key, "xenserver-tools";
-                                        (Xapi_globs.i18n_original_value_prefix ^ "name_label"), name;
-                                        (Xapi_globs.i18n_original_value_prefix ^ "name_description"), description
-                                      ]
+    let string_of_input_t =
+      Test_printers.(
+        list (tuple4 string string (assoc_list string string) bool))
 
-                                      let load_input __context srs =
-                                        let sr_introduce ~uuid ~name_label ~name_description ~_type ~content_type ~shared ~sm_config =
-                                          Test_common.make_sr ~__context ~uuid ~name_label ~name_description ~_type ~content_type ~shared ~sm_config () in
-                                        let maybe_create_pbd sR device_config host =
-                                          Test_common.make_pbd ~__context ~sR ~device_config ~host ()
-                                        in
-                                        Test_common.make_localhost ~__context ();
-                                        List.iter (fun (name_label, name_description, other_config, is_tools_sr) ->
-                                            ignore (Test_common.make_sr ~__context ~name_label ~name_description ~other_config ~is_tools_sr ())
-                                          ) srs;
-                                        Dbsync_master.create_tools_sr __context name description sr_introduce maybe_create_pbd
+    let string_of_output_t =
+      Test_printers.(list (tuple3 string string (assoc_list string string)))
+  end
 
-                                      let extract_output __context vms =
-                                        List.fold_left (fun acc self ->
-                                            if Db.SR.get_is_tools_sr ~__context ~self then (
-                                              Db.SR.get_name_label ~__context ~self,
-                                              Db.SR.get_name_description ~__context ~self,
-                                              Db.SR.get_other_config ~__context ~self)
-                                              :: acc
-                                            else
-                                              acc
-                                          ) [] (Db.SR.get_all ~__context)
+  module State = Test_state.XapiDb
 
-                                      (* And other_config key/value pair we use to prove that and existing Tools SR is
-                                         	 * reused rather than destroyed and recreated. *)
-                                      let extra_oc = "toolz", "true"
+  let name = "Tools"
 
-                                      (* All tests expect the outcome to be one and only one Tools SR with the pre-specified
-                                         	 * name, description and other_config keys *)
-                                      let tests = [
-                                        (* No Tools SR yet *)
-                                        [],
-                                        [name, description, other_config];
+  let description = "Tools ISOs"
 
-                                        (* An existing Tools SR *)
-                                        [
-                                          "Toolz", "Toolz ISOs", [extra_oc], true;
-                                        ],
-                                        [name, description, extra_oc :: other_config];
+  let other_config =
+    [ (Xapi_globs.xensource_internal, "true")
+    ; (Xapi_globs.tools_sr_tag, "true")
+    ; (Xapi_globs.i18n_key, "xenserver-tools")
+    ; (Xapi_globs.i18n_original_value_prefix ^ "name_label", name)
+    ; (Xapi_globs.i18n_original_value_prefix ^ "name_description", description)
+    ]
 
-                                        (* Two existing Tools SRs (bad state!) *)
-                                        [
-                                          "Toolz", "Toolz ISOs", [extra_oc], true;
-                                          "Toolz2", "Toolz ISOs2", [extra_oc], true;
-                                        ],
-                                        [name, description, extra_oc :: other_config];
+  let load_input __context srs =
+    let sr_introduce ~uuid ~name_label ~name_description ~_type ~content_type
+        ~shared ~sm_config =
+      Test_common.make_sr ~__context ~uuid ~name_label ~name_description ~_type
+        ~content_type ~shared ~sm_config ()
+    in
+    let maybe_create_pbd sR device_config host =
+      Test_common.make_pbd ~__context ~sR ~device_config ~host ()
+    in
+    Test_common.make_localhost ~__context () ;
+    List.iter
+      (fun (name_label, name_description, other_config, is_tools_sr) ->
+        ignore
+          (Test_common.make_sr ~__context ~name_label ~name_description
+             ~other_config ~is_tools_sr ()) )
+      srs ;
+    Dbsync_master.create_tools_sr __context name description sr_introduce
+      maybe_create_pbd
 
-                                        (* An existing Tools SR with an old tag *)
-                                        [
-                                          "Toolz", "Toolz ISOs", [Xapi_globs.tools_sr_tag, "true"; extra_oc], false;
-                                        ],
-                                        [name, description, extra_oc :: other_config];
+  let extract_output __context vms =
+    List.fold_left
+      (fun acc self ->
+        if Db.SR.get_is_tools_sr ~__context ~self then
+          ( Db.SR.get_name_label ~__context ~self
+          , Db.SR.get_name_description ~__context ~self
+          , Db.SR.get_other_config ~__context ~self )
+          :: acc
+        else acc )
+      [] (Db.SR.get_all ~__context)
 
-                                        (* An existing Tools SR with another old tag *)
-                                        [
-                                          "Toolz", "Toolz ISOs", [Xapi_globs.xensource_internal, "true"; extra_oc], false;
-                                        ],
-                                        [name, description, extra_oc :: other_config];
+  (* And other_config key/value pair we use to prove that and existing
+   * Tools SR is reused rather than destroyed and recreated. *)
+  let extra_oc = ("toolz", "true")
 
-                                        (* Two existing Tools SRs with different tags; expect to keep the one with is_tools_iso=true *)
-                                        [
-                                          "Other", "Other SR", [extra_oc], true;
-                                          "Toolz", "Toolz ISOs", [Xapi_globs.xensource_internal, "true"], false;
-                                        ],
-                                        [name, description, extra_oc :: other_config];
-
-                                        (* Two existing Tools SRs with different tags; expect to keep the one with is_tools_iso=true *)
-                                        [
-                                          "Toolz", "Toolz ISOs", [Xapi_globs.tools_sr_tag, "true"], false;
-                                          "Other", "Other SR", [extra_oc], true;
-                                        ],
-                                        [name, description, extra_oc :: other_config];
-                                      ]
-                                    end))
+  (* All tests expect the outcome to be one and only one Tools SR with
+   * the pre-specified name, description and other_config keys *)
+  let tests =
+    [ (* No Tools SR yet *)
+      ([], [(name, description, other_config)])
+    ; (* An existing Tools SR *)
+      ( [("Toolz", "Toolz ISOs", [extra_oc], true)]
+      , [(name, description, extra_oc :: other_config)] )
+    ; (* Two existing Tools SRs (bad state!) *)
+      ( [ ("Toolz", "Toolz ISOs", [extra_oc], true)
+        ; ("Toolz2", "Toolz ISOs2", [extra_oc], true) ]
+      , [(name, description, extra_oc :: other_config)] )
+    ; (* An existing Tools SR with an old tag *)
+      ( [ ( "Toolz"
+          , "Toolz ISOs"
+          , [(Xapi_globs.tools_sr_tag, "true"); extra_oc]
+          , false ) ]
+      , [(name, description, extra_oc :: other_config)] )
+    ; (* An existing Tools SR with another old tag *)
+      ( [ ( "Toolz"
+          , "Toolz ISOs"
+          , [(Xapi_globs.xensource_internal, "true"); extra_oc]
+          , false ) ]
+      , [(name, description, extra_oc :: other_config)] )
+    ; (* Two existing Tools SRs with different tags; expect to keep the
+    one with is_tools_iso=true *)
+      ( [ ("Other", "Other SR", [extra_oc], true)
+        ; ( "Toolz"
+          , "Toolz ISOs"
+          , [(Xapi_globs.xensource_internal, "true")]
+          , false ) ]
+      , [(name, description, extra_oc :: other_config)] )
+    ; (* Two existing Tools SRs with different tags; expect to keep the
+    one with is_tools_iso=true *)
+      ( [ ("Toolz", "Toolz ISOs", [(Xapi_globs.tools_sr_tag, "true")], false)
+        ; ("Other", "Other SR", [extra_oc], true) ]
+      , [(name, description, extra_oc :: other_config)] ) ]
+end))
 
 let test =
-  "test_dbsync_master" >:::
-  [
-    "create_tools_sr" >::: CreateToolsSR.tests;
-  ]
+  "test_dbsync_master" >::: ["create_tools_sr" >::: CreateToolsSR.tests]

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -450,21 +450,6 @@ let remove_restricted_pbd_keys = {
       ) (Db.PBD.get_all ~__context)
 }
 
-let update_tools_sr_pbd_device_config = {
-  description = "Updating Tools SR PBD.device_config";
-  version = (fun x -> x <= creedence);
-  fn = fun ~__context ->
-    let tools_srs = List.filter (fun self -> Db.SR.get_is_tools_sr ~__context ~self) (Db.SR.get_all ~__context) in
-    begin match tools_srs with
-    | sr :: others ->
-      (* Let there be only one Tools SR *)
-      List.iter (fun self -> Db.SR.destroy ~__context ~self) others;
-      Db.SR.get_PBDs ~__context ~self:sr
-      |> List.iter (fun self -> Db.PBD.set_device_config ~__context ~self ~value:Xapi_globs.tools_sr_pbd_device_config)
-    | [] -> () (* Do nothing - dbsync_master creates new tools SR *)
-    end
-}
-
 let upgrade_recommendations_for_gpu_passthru = {
   description = "Upgrading recommendations to allow GPU passthrough on HVM Linux guests";
   version = (fun x -> x < cream);
@@ -527,7 +512,6 @@ let rules = [
   default_has_vendor_device_false;
   default_pv_drivers_detected_false;
   remove_restricted_pbd_keys;
-  update_tools_sr_pbd_device_config;
   upgrade_recommendations_for_gpu_passthru;
 ]
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -479,38 +479,56 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
 
   new_host_ref
 
-and create_or_get_sr_on_master __context rpc session_id (sr_ref, sr) : API.ref_SR =
+and create_or_get_sr_on_master __context rpc session_id (sr_ref, sr)
+  : API.ref_SR =
   let my_uuid = sr.API.sR_uuid in
-
   let new_sr_ref =
-    try Client.SR.get_by_uuid ~rpc ~session_id ~uuid:my_uuid
-    with _ ->
+    try Client.SR.get_by_uuid ~rpc ~session_id ~uuid:my_uuid with _ ->
       let my_pbd_ref = List.hd (Db.SR.get_PBDs ~__context ~self:sr_ref) in
       let my_pbd = Db.PBD.get_record ~__context ~self:my_pbd_ref in
       let pbds_on_master = Client.PBD.get_all_records ~rpc ~session_id in
-
-      (* The only possible shared SRs are ISO, as other SRs cannot be shared properly accross pools. *)
+      (* The only possible shared SRs are ISO, as other SRs cannot be shared properly across pools. *)
       (* In this case, if we find a SR with a PBD having the same device_config field, we pick this SR instead of building a new one *)
-      let iso_already_exists_on_master () = List.exists (fun (_,x) -> Listext.List.set_equiv x.API.pBD_device_config my_pbd.API.pBD_device_config) pbds_on_master in
-      if sr.API.sR_shared && sr.API.sR_content_type = "iso" && iso_already_exists_on_master () then begin
-        let similar_pbd_ref, similar_pbd = List.find (fun (_,x) -> Listext.List.set_equiv x.API.pBD_device_config my_pbd.API.pBD_device_config) pbds_on_master in
+      let iso_already_exists_on_master () =
+        List.exists
+          (fun (_, x) ->
+            Listext.List.set_equiv x.API.pBD_device_config
+              my_pbd.API.pBD_device_config )
+          pbds_on_master
+      in
+      if
+        sr.API.sR_shared
+        && sr.API.sR_content_type = "iso"
+        && iso_already_exists_on_master ()
+      then
+        let similar_pbd_ref, similar_pbd =
+          List.find
+            (fun (_, x) ->
+              Listext.List.set_equiv x.API.pBD_device_config
+                my_pbd.API.pBD_device_config )
+            pbds_on_master
+        in
         similar_pbd.API.pBD_SR
-
-      end else begin
-        debug "Found no SR with uuid = '%s' on the master, so creating one." my_uuid;
-        let ref = Client.SR.introduce ~rpc ~session_id
-            ~uuid:my_uuid
+      else (
+        debug "Found no SR with uuid = '%s' on the master, so creating one."
+          my_uuid ;
+        let ref =
+          Client.SR.introduce ~rpc ~session_id ~uuid:my_uuid
             ~name_label:sr.API.sR_name_label
             ~name_description:sr.API.sR_name_description
             ~_type:sr.API.sR_type
             ~content_type:sr.API.sR_content_type
             ~shared:false
-            ~sm_config:sr.API.sR_sm_config in
+            ~sm_config:sr.API.sR_sm_config
+        in
         (* copy other-config into newly created sr record: *)
-        no_exn (fun () -> Client.SR.set_other_config ~rpc ~session_id ~self:ref ~value:sr.API.sR_other_config) ();
-        ref
-      end in
-
+        no_exn
+          (fun () ->
+            Client.SR.set_other_config ~rpc ~session_id ~self:ref
+              ~value:sr.API.sR_other_config )
+          () ;
+        ref )
+  in
   new_sr_ref
 
 let create_or_get_pbd_on_master __context rpc session_id (pbd_ref, pbd) : API.ref_PBD =


### PR DESCRIPTION
This is the backport of CA-300103 - making sure that only one Tools SR exists,
