### PR TITLE
REQ-638: Support checkpoint for  Nvidia vGPU enabled VMs

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -279,7 +279,7 @@ let check_vgpu ~__context ~op ~ref_str ~vgpus ~power_state =
   | `pool_migrate | `migrate_send
     when List.for_all is_migratable  vgpus
       && List.for_all is_suspendable vgpus -> None
-  | `suspend
+  | `suspend | `checkpoint
     when List.for_all is_suspendable vgpus -> None
   | `pool_migrate | `migrate_send | `suspend | `checkpoint ->
     Some (Api_errors.vm_has_vgpu, [ref_str])

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -221,8 +221,6 @@ let checkpoint ~__context ~vm ~new_name =
   (* restore the power state of the VM *)
   if power_state = `Running
   then begin
-    let localhost = Helpers.get_localhost ~__context in
-    Db.VM.set_resident_on ~__context ~self:vm ~value:localhost;
     debug "Performing a slow resume";
     Xapi_xenops.resume ~__context ~self:vm ~start_paused:false ~force:false;
   end;

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2897,7 +2897,8 @@ let suspend ~__context ~self =
               Client.VM.suspend dbg id d |> sync_with_task __context ~cancellable:false queue_name;
               Events_from_xenopsd.wait queue_name dbg id ();
               Xapi_vm_lifecycle.assert_final_power_state_is ~__context ~self ~expected:`Suspended;
-              if not(Db.VM.get_resident_on ~__context ~self = Ref.null) then
+              if not(Xapi_vm_lifecycle.checkpoint_in_progress ~__context ~vm:self)
+              && not(Db.VM.get_resident_on ~__context ~self = Ref.null) then
                 raise Api_errors.(Server_error(internal_error, [
                     Printf.sprintf "suspend: The VM %s is still resident on the host" (Ref.string_of self)]));
             with e ->


### PR DESCRIPTION
To support checkpoint for Nvidia vGPU enabled VMs, this PR contains:

- Remove restriction for VMs with vGPUs
- Do not clear `resident_on` for VM and VGPU in checkpoint.

Signed-off-by: Talons Lee <xin.li@citrix.com>
Signed-off-by: Min Li <min.li1@citrix.com>