### PR TITLE
CA-300644: return immediately when attach-static-vdis failed

### DIFF
--- a/scripts/init.d-attach-static-vdis
+++ b/scripts/init.d-attach-static-vdis
@@ -39,6 +39,7 @@ attach_all(){
 	    if [ $? -ne 0 ]; then
 	       RC=1
 	       logger "Attempt to attach VDI: ${UUID} failed -- skipping (Error was: ${OUTPUT})"
+	       return $RC
 	    fi
 	done
 	return $RC


### PR DESCRIPTION
When slave host cannot connect to NFS server(HA metadata VDI and HA state file VDI reside on), from the XenRT case it drops the port to NFS, the slave will in emergency mode, but when NFS server comes back by allowing the port in iptables, what's  expected is the slave host will quit emergency mode. But we met a scenario that when attaching first VDI(the NFS didn't come back), the attach-static-vdis will fail, but succeed on attaching the second one(as now NFS server can be accessed). Xapi will marked it as failed and retry to attach the VDIs after 10s, so in the second round, the first VDI will be attached successfully(Because it failed in the first round) and then the second VDI will fail to attach(as it succeeds in the first round).

Even though we discussed in the ticket CA-300644 that the test may need to rethink the procedure. But I raised this PR to know why we didn't return immediately when attaching VDI failed? Is it by design? 
And I didn't come up with a reason not to do this change.

