### PR TITLE
CP-29757: block SXM of encrypted VDIs

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -732,6 +732,8 @@ let _ =
     ~doc:"The requested operation is not allowed for VDIs with CBT enabled or VMs having such VDIs, and CBT is enabled for the specified VDI." ();
   error Api_errors.vdi_no_cbt_metadata [ "vdi" ]
     ~doc:"The requested operation is not allowed because the specified VDI does not have changed block tracking metadata." ();
+  error Api_errors.vdi_is_encrypted [ "vdi" ]
+    ~doc:"The requested operation is not allowed because the specified VDI is encrypted." ();
   error Api_errors.vdi_copy_failed []
     ~doc:"The VDI copy action has failed" ();
   error Api_errors.vdi_on_boot_mode_incompatible_with_operation []

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -268,6 +268,7 @@ let vdi_on_boot_mode_incompatible_with_operation = "VDI_ON_BOOT_MODE_INCOMPATIBL
 let vdi_not_in_map = "VDI_NOT_IN_MAP"
 let vdi_cbt_enabled = "VDI_CBT_ENABLED"
 let vdi_no_cbt_metadata = "VDI_NO_CBT_METADATA"
+let vdi_is_encrypted = "VDI_IS_ENCRYPTED"
 let vif_not_in_map = "VIF_NOT_IN_MAP"
 let cannot_create_state_file = "CANNOT_CREATE_STATE_FILE"
 

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -150,7 +150,7 @@ let assert_can_migrate_vdis ~__context ~vdi_map =
   let assert_not_encrypted vdi =
     let sm_config = Db.VDI.get_sm_config ~__context ~self:vdi in
     if List.exists (fun (key, _value) -> key = "key_hash") sm_config then
-      failwith ("Migration of encrypted VDI " ^ (Ref.string_of vdi) ^ " is not allowed")
+      raise Api_errors.(Server_error(vdi_is_encrypted, [Ref.string_of vdi]))
   in
   List.iter (fun (vdi, target_sr) ->
       if target_sr <> (Db.VDI.get_SR ~__context ~self:vdi) then begin


### PR DESCRIPTION
This will not block the "Move VM" operation on a halted VM in XenCenter,
because XenCenter moves the VM manually by copying the VDIs of the VM
and creating & plugging new VBDs.

But this is fine, because we wanted to block SXM of encrypted VDIs for
XenAPI users. And both the VM.migrate_send call and "xe vm-migrate" will
be blocked for encrypted VDIs, even if the VM is halted.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>