### PR TITLE
Revert "CP-28951: Add message of xen low memory alarm"

### DIFF
--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -132,7 +132,6 @@ let host_cpu_features_down = addMessage "HOST_CPU_FEATURES_DOWN" 3L
 let host_cpu_features_up = addMessage "HOST_CPU_FEATURES_UP" 5L
 let pool_cpu_features_down = addMessage "POOL_CPU_FEATURES_DOWN" 5L
 let pool_cpu_features_up = addMessage "POOL_CPU_FEATURES_UP" 5L
-let host_low_memory = addMessage "HOST_LOW_MEMORY" 2L
 
 (* Cluster messages *)
 let cluster_host_enable_failed = addMessage "CLUSTER_HOST_ENABLE_FAILED" 3L


### PR DESCRIPTION
This reverts commit a2886374d4fc786de71a7574978051d2bc1aca0f.
It turned out that we didn't need this.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>