### PR TITLE
CA-302538: Disallow restore across partition layout changes

### DIFF
--- a/scripts/host-backup-restore/host-restore
+++ b/scripts/host-backup-restore/host-restore
@@ -33,6 +33,19 @@ trap error EXIT ERR
 mount $DEVICE $TMP
 tar -C $TMP -xzp
 
+# The dom0 partition layout changed between 6.x and 7.x and restoring backups
+# from the old partition layout does not work in some cases so fail the
+# restore operation.
+
+CUR_VER="$PRODUCT_VERSION"
+. "$TMP@INVENTORY@"
+PREV_VER="$PRODUCT_VERSION"
+
+if [ "${CUR_VER%%.*}" -ge 7 -a "${PREV_VER%%.*}" -lt 7 ]; then
+    echo "Cannot restore backup created with a different partition layout."
+    exit 1
+fi
+
 # The installer checks for this file when looking for a backup partition.
 touch $TMP/.xen-backup-partition
 


### PR DESCRIPTION
Don't allow restoring a backup from XS < 7.0 which uses the old dom0
partition layout on a 7.x+ host which uses a newer partition layout
since there are some cases where it results in an unbootable host.