### PR TITLE
CA-300644: return immediately when attach-static-vdis failed

### DIFF
--- a/scripts/init.d-attach-static-vdis
+++ b/scripts/init.d-attach-static-vdis
@@ -39,6 +39,7 @@ attach_all(){
 	    if [ $? -ne 0 ]; then
 	       RC=1
 	       logger "Attempt to attach VDI: ${UUID} failed -- skipping (Error was: ${OUTPUT})"
+	       return $RC
 	    fi
 	done
 	return $RC


### PR DESCRIPTION
The PR https://github.com/xapi-project/xen-api/pull/3772 has been merged to 1.14-lcm branch, this PR is for the master. 

See passed Ring3 BST: 97644.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>