### PR TITLE
CP-30032: spawn varstore-rm in a chroot

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -194,8 +194,7 @@ let varstore_rm_with_sandbox ~__context ~vm_uuid f =
   let domid = 0 in
   let chroot, socket_path = Xenops_sandbox.Varstore_guard.start dbg ~domid ~vm_uuid ~paths:[] in
   Xapi_stdext_pervasives.Pervasiveext.finally (fun () -> f chroot socket_path)
-    (fun () ->
-       let (_: string list) = Xenops_sandbox.Varstore_guard.stop dbg ~domid ~paths:[] in ())
+    (fun () -> Xenops_sandbox.Varstore_guard.stop dbg ~domid)
 
 let nvram_post_clone ~__context ~self ~uuid =
   match Db.VM.get_NVRAM ~__context ~self with


### PR DESCRIPTION
Previously we've run it as root, sandbox it instead.
There is no domain id associated with a VM clone, so we just use
the same user `qemu_base + 0` for sandboxing. This is less than ideal, but better than running as root.

