### PR TITLE
CA-304576: Allow checkpoint on suspended VM with Nvidia vGPU

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -279,6 +279,8 @@ let check_vgpu ~__context ~op ~ref_str ~vgpus ~power_state =
   | `pool_migrate | `migrate_send
     when List.for_all is_migratable  vgpus
       && List.for_all is_suspendable vgpus -> None
+  | `checkpoint
+    when power_state = `Suspended -> None
   | `suspend | `checkpoint
     when List.for_all is_suspendable vgpus -> None
   | `pool_migrate | `migrate_send | `suspend | `checkpoint ->


### PR DESCRIPTION
XS support checkpoint when VM in suspend state:
https://docs.citrix.com/en-us/xenserver/current-release/dr/snapshots.html

When VM with Nvidia vGPU becoming a suspended state, it will update
allowed_operations to exclude checkpoint which is not correct.

This commit is refining to check the power_state and is_nvidia to
decide checkpoint permission.

So now there are two conditions to allow checkpoint for vGPUs VMs:
1. Checking all vgpus on VM are suspendable by calling `is_suspendable`
2. power state is `suspended` and the vGPU type is `NVIDIA`

Signed-off-by: Min Li <min.li1@citrix.com>