### PR TITLE
Checksum 

### DIFF
--- a/ocaml/seahash/dune
+++ b/ocaml/seahash/dune
@@ -1,0 +1,16 @@
+(rule
+	(deps (source_tree libseahash))
+	(targets libseahash_stubs.a)
+	(action
+		(bash "make -C libseahash && cp libseahash/libseahash_stubs.a libseahash_stubs.a")
+	)
+)
+
+(library
+	(name seahash)
+	(self_build_stubs_archive (seahash))
+	(libraries
+		ctypes
+		ctypes.foreign
+	)
+)

--- a/ocaml/seahash/hash.ml
+++ b/ocaml/seahash/hash.ml
@@ -1,0 +1,16 @@
+open Ctypes
+open Foreign
+
+let bytes = foreign "bytes" (ocaml_bytes @-> uint64_t @-> returning uint64_t)
+let file = foreign "file" (string @-> returning uint64_t)
+
+let to_hex hash =
+	Printf.sprintf "%016LX" hash;;
+
+let bytes buff = 
+	let size = Unsigned.UInt64.of_int (Bytes.length buff) in
+	Unsigned.UInt64.to_int64(bytes (ocaml_bytes_start buff) size);;
+
+let file name = 
+	close_in (open_in_bin name); (* To emulate the behaviour of the Digest class, also throws an error if the file does not exist *)
+	Unsigned.UInt64.to_int64(file name);; (* We know the file exists at this point *)

--- a/ocaml/seahash/hash.ml
+++ b/ocaml/seahash/hash.ml
@@ -1,8 +1,11 @@
 open Ctypes
 open Foreign
 
-let bytes = foreign "bytes" (ocaml_bytes @-> uint64_t @-> returning uint64_t)
-let file = foreign "file" (string @-> returning uint64_t)
+let bytes = foreign "hash_bytes" (ocaml_bytes @-> uint64_t @-> returning uint64_t)
+let file = foreign "hash_filedesc" (int @-> returning uint64_t)
+
+let fd_of_int (x: int) : Unix.file_descr = Obj.magic x;;
+let int_of_fd (x: Unix.file_descr) : int = Obj.magic x;;
 
 let to_hex hash =
 	Printf.sprintf "%016LX" hash;;
@@ -11,6 +14,17 @@ let bytes buff =
 	let size = Unsigned.UInt64.of_int (Bytes.length buff) in
 	Unsigned.UInt64.to_int64(bytes (ocaml_bytes_start buff) size);;
 
-let file name = 
-	close_in (open_in_bin name); (* To emulate the behaviour of the Digest class, also throws an error if the file does not exist *)
-	Unsigned.UInt64.to_int64(file name);; (* We know the file exists at this point *)
+let file file_name = 
+	if Sys.is_directory file_name || not(Sys.file_exists file_name)
+	then raise Not_found
+	else begin
+		let fd = Unix.openfile file_name [O_RDONLY] 0o666 in
+		let csum = Unsigned.UInt64.to_int64(file (int_of_fd fd)) in
+		
+		if csum = 0L
+		then raise End_of_file (* Unexpected EOF *)
+		else begin
+			Unix.close fd;
+			csum
+		end
+	end

--- a/ocaml/seahash/libseahash/Makefile
+++ b/ocaml/seahash/libseahash/Makefile
@@ -1,6 +1,6 @@
 
 all:
-	gcc -O3 -std=c11 -c seahash.c -o libseahash_stubs.a
+	cc -O3 -std=gnu11 -c seahash.c -o libseahash_stubs.a
 
 clean:
 	rm -f ./libseahash_stubs.a

--- a/ocaml/seahash/libseahash/Makefile
+++ b/ocaml/seahash/libseahash/Makefile
@@ -1,0 +1,6 @@
+
+all:
+	gcc -O3 -std=c11 -c seahash.c -o libseahash_stubs.a
+
+clean:
+	rm -f ./libseahash_stubs.a

--- a/ocaml/seahash/libseahash/seahash.c
+++ b/ocaml/seahash/libseahash/seahash.c
@@ -1,0 +1,167 @@
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+/*
+	This code is a C implementation of the SeaHash algorithm (see: http://ticki.github.io/blog/seahash-explained/)
+	The author also provides a reference implemenation written in Rust, the license for this reference implementation is below: 
+*/
+
+/*
+	The MIT License (MIT)
+
+	Copyright (c) 2016 Ticki
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+-fsyntax-only
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+*/
+
+#define BUFF_SIZE (61440)
+
+uint64_t A, B, C, D;
+
+void init() {
+	// These default values come from the SeaHash specification
+	A = 0x16F11FE89B0D677C,
+	B = 0xB480A793D8E6C86C,
+	C = 0x6FE2E5AAF078EBC9,
+	D = 0x14F994A4C5259381;
+}
+
+uint64_t diffuse(uint64_t x) {
+	const uint64_t p = 0x6EED0E9DA4D94A4F;
+	x *= p;
+	x ^= (x >> 32) >> (x >> 60);
+	x *= p;
+	return x;
+}
+
+uint64_t finalise(const uint64_t size) {
+	A ^= B;
+	C ^= D;
+	A ^= C;
+	A ^= size;
+	return diffuse(A);
+}
+
+void rotate(uint64_t x) {
+	x = diffuse(A ^ x);
+	A = B; // Rotate the lanes
+	B = C;
+	C = D;
+	D = x;
+}
+
+void update(const void *data, const uint64_t size) {
+	const uint64_t freq = ((size >> 3) >> 2);
+	const uint64_t *head = (uint64_t *) data;
+
+	for(uint64_t i = 0; i < freq; i++) {
+		// NB: we assume little-endian, as we currently only support x86-64 systems
+		A ^= *head++;
+		B ^= *head++;
+		C ^= *head++;
+		D ^= *head++;
+
+		A = diffuse(A);
+		B = diffuse(B);
+		C = diffuse(C);
+		D = diffuse(D);
+	}
+
+	const uint8_t remain = size - (size & 0xFFFFFFFFFFFFFFE0); // How many bytes weren't hashed above (n < 32)
+	if(remain == 0) return; // Expected case for most common data lengths (e.g. 1MB, 1GB etc.)
+
+	for(uint8_t i = 0; i < (remain >> 3); i++) { // For each 8-byte value that remains
+		rotate(*head++);
+	}
+
+	const uint8_t rem = (remain % sizeof(uint64_t)); // How many bytes there are left (n < 8)
+	if(rem == 0) return;
+
+	const uint8_t *body = (uint8_t *) head;
+	uint64_t x = 0;
+
+	// NB: we read backwards because we need little-endian
+	for(uint8_t i = 1; i <= rem; i++) {
+		x <<= 8;
+		x += body[rem - i];
+	}
+
+	rotate(x);
+}
+
+uint64_t bytes(const void *data, const uint64_t size) {
+	init();
+	update(data, size);
+	return finalise(size);
+}
+
+uint64_t file(const char *name) {
+	FILE *in = fopen(name, "rb");
+	if(in == NULL) {
+		fprintf(stderr, "Cannot open file: %s\n", name);
+		return 0;		
+	}
+	init();
+	uint8_t *data[BUFF_SIZE];
+
+	uint64_t sum = 0;
+	for(;;) {
+		const uint64_t size = (uint64_t) fread(data, 1, BUFF_SIZE, in);
+		if(size == 0) break; // EOF
+		update(data, size);
+		sum += size;
+	}
+
+	fclose(in);
+	return finalise(sum);
+}
+
+int main(int argc, char **argv) {
+	char temp[4096];
+
+	char *a = ""; // 0 bytes
+	strcpy(temp, a);
+	assert(bytes(a, 0) == 0xC920CA43256FDCB9);
+
+	char *b = "Hello, World!"; // 13 bytes
+	strcpy(temp, b);
+	assert(bytes(temp, 13) == 0x2EC2572966D006FD);
+
+	char *d = "g0VugDZm43UU4KvVMczhoO0LvDIsAG8F1"; // 33 bytes
+	strcpy(temp, d);
+	assert(bytes(temp, 33) == 0x709F6C5CF482869E);
+
+	char *f = "gBy7IsF6xgDww7IHAW7u1XCBgqw1NKG2e7rW1kjJ57Om18lF"; // 48 bytes
+	strcpy(temp, f);
+	assert(bytes(temp, 48) == 0x187E2EE0343CCDC3);
+
+	char *c = "V8lL08akfSYCQpDtKyAH56SQNORwpF4rxXn9H2wDvWKDR5Rn3mdJBftuDSCEZvI"; // 63 bytes
+	strcpy(temp, c);
+	assert(bytes(temp, 63) == 0x8FDCA544A6B3476F);
+
+	for(size_t i = 0; i < sizeof(temp); i++) temp[i] = i;
+	assert(bytes(temp, sizeof(temp)) == 0xE8010714612E6C70);
+
+	file(*argv); 
+
+	puts("Tests Passed!");
+}
+

--- a/ocaml/seahash/libseahash/seahash.c
+++ b/ocaml/seahash/libseahash/seahash.c
@@ -5,31 +5,7 @@
 
 /*
 	This code is a C implementation of the SeaHash algorithm (see: http://ticki.github.io/blog/seahash-explained/)
-	The author also provides a reference implemenation written in Rust, the license for this reference implementation is below: 
-*/
-
-/*
-	The MIT License (MIT)
-
-	Copyright (c) 2016 Ticki
-
-	Permission is hereby granted, free of charge, to any person obtaining a copy
-	of this software and associated documentation files (the "Software"), to deal
-	in the Software without restriction, including without limitation the rights
-	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-	copies of the Software, and to permit persons to whom the Software is
-	furnished to do so, subject to the following conditions:
-
-	The above copyright notice and this permission notice shall be included in all
-	copies or substantial portions of the Software.
--fsyntax-only
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-	SOFTWARE.
+	The author also provides a reference implemenation written in Rust (which follows the MIT license). 
 */
 
 #define BUFF_SIZE (61440)
@@ -135,6 +111,7 @@ uint64_t file(const char *name) {
 }
 
 int main(int argc, char **argv) {
+	// These hash outputs were precomputed using the SeaHash reference implementation (which is written in Rust).
 	char temp[4096];
 
 	char *a = ""; // 0 bytes

--- a/ocaml/seahash/libseahash/seahash.c
+++ b/ocaml/seahash/libseahash/seahash.c
@@ -5,22 +5,27 @@
 
 /*
 	This code is a C implementation of the SeaHash algorithm (see: http://ticki.github.io/blog/seahash-explained/)
-	The author also provides a reference implemenation written in Rust (which follows the MIT license). 
+	The author also provides a reference implemenation written in Rust (which follows the MIT license).
 */
 
-#define BUFF_SIZE (61440)
+#define BUFF_SIZE (16384)
 
-uint64_t A, B, C, D;
+struct SeaState {
+	uint64_t A, B, C, D;
+};
 
-void init() {
-	// These default values come from the SeaHash specification
-	A = 0x16F11FE89B0D677C,
-	B = 0xB480A793D8E6C86C,
-	C = 0x6FE2E5AAF078EBC9,
-	D = 0x14F994A4C5259381;
+typedef struct SeaState SeaState;
+
+static inline SeaState init() {
+	SeaState s;
+	s.A = 0x16F11FE89B0D677C,
+	s.B = 0xB480A793D8E6C86C,
+	s.C = 0x6FE2E5AAF078EBC9,
+	s.D = 0x14F994A4C5259381;
+	return s;
 }
 
-uint64_t diffuse(uint64_t x) {
+static inline uint64_t diffuse(uint64_t x) {
 	const uint64_t p = 0x6EED0E9DA4D94A4F;
 	x *= p;
 	x ^= (x >> 32) >> (x >> 60);
@@ -28,44 +33,40 @@ uint64_t diffuse(uint64_t x) {
 	return x;
 }
 
-uint64_t finalise(const uint64_t size) {
-	A ^= B;
-	C ^= D;
-	A ^= C;
-	A ^= size;
-	return diffuse(A);
+static inline uint64_t finalise(SeaState *state, const uint64_t size) {
+	return diffuse(state->A ^ state->B ^ state->C ^ state->D ^ size);
 }
 
-void rotate(uint64_t x) {
-	x = diffuse(A ^ x);
-	A = B; // Rotate the lanes
-	B = C;
-	C = D;
-	D = x;
+static inline void rotate(SeaState *state, uint64_t x) {
+	x = diffuse(state->A ^ x);
+	state->A = state->B; // Rotate the lanes
+	state->B = state->C;
+	state->C = state->D;
+	state->D = x;
 }
 
-void update(const void *data, const uint64_t size) {
+void update(SeaState *state, const void *data, const uint64_t size) {
 	const uint64_t freq = ((size >> 3) >> 2);
 	const uint64_t *head = (uint64_t *) data;
 
 	for(uint64_t i = 0; i < freq; i++) {
 		// NB: we assume little-endian, as we currently only support x86-64 systems
-		A ^= *head++;
-		B ^= *head++;
-		C ^= *head++;
-		D ^= *head++;
+		state->A ^= *head++;
+		state->B ^= *head++;
+		state->C ^= *head++;
+		state->D ^= *head++;
 
-		A = diffuse(A);
-		B = diffuse(B);
-		C = diffuse(C);
-		D = diffuse(D);
+		state->A = diffuse(state->A);
+		state->B = diffuse(state->B);
+		state->C = diffuse(state->C);
+		state->D = diffuse(state->D);
 	}
 
-	const uint8_t remain = size - (size & 0xFFFFFFFFFFFFFFE0); // How many bytes weren't hashed above (n < 32)
+	const uint8_t remain = size & 0x1F; // How many bytes weren't hashed above (n < 32)
 	if(remain == 0) return; // Expected case for most common data lengths (e.g. 1MB, 1GB etc.)
 
 	for(uint8_t i = 0; i < (remain >> 3); i++) { // For each 8-byte value that remains
-		rotate(*head++);
+		rotate(state, *head++);
 	}
 
 	const uint8_t rem = (remain % sizeof(uint64_t)); // How many bytes there are left (n < 8)
@@ -80,34 +81,33 @@ void update(const void *data, const uint64_t size) {
 		x += body[rem - i];
 	}
 
-	rotate(x);
+	rotate(state, x);
 }
 
-uint64_t bytes(const void *data, const uint64_t size) {
-	init();
-	update(data, size);
-	return finalise(size);
+uint64_t hash_bytes(const void *data, const uint64_t size) {
+	SeaState state = init();
+	update(&state, data, size);
+	return finalise(&state, size);
 }
 
-uint64_t file(const char *name) {
-	FILE *in = fopen(name, "rb");
-	if(in == NULL) {
-		fprintf(stderr, "Cannot open file: %s\n", name);
-		return 0;		
-	}
-	init();
-	uint8_t *data[BUFF_SIZE];
+uint64_t hash_file(FILE *in) {
+	SeaState state = init();
+	uint64_t data[BUFF_SIZE >> 3];
 
 	uint64_t sum = 0;
 	for(;;) {
-		const uint64_t size = (uint64_t) fread(data, 1, BUFF_SIZE, in);
-		if(size == 0) break; // EOF
-		update(data, size);
+		const uint64_t size = (uint64_t) fread(data, 1, sizeof(data), in);
+		if(size == 0) if(feof(in)) break; else return 0;
+		update(&state, data, size);
 		sum += size;
 	}
 
-	fclose(in);
-	return finalise(sum);
+	return finalise(&state, sum);
+}
+
+uint64_t hash_filedesc(int fd) {
+	FILE *in = fdopen(fd, "rb");
+	return hash_file(in);
 }
 
 int main(int argc, char **argv) {
@@ -116,29 +116,30 @@ int main(int argc, char **argv) {
 
 	char *a = ""; // 0 bytes
 	strcpy(temp, a);
-	assert(bytes(a, 0) == 0xC920CA43256FDCB9);
+	assert(hash_bytes(a, 0) == 0xC920CA43256FDCB9);
 
 	char *b = "Hello, World!"; // 13 bytes
 	strcpy(temp, b);
-	assert(bytes(temp, 13) == 0x2EC2572966D006FD);
+	assert(hash_bytes(temp, 13) == 0x2EC2572966D006FD);
 
 	char *d = "g0VugDZm43UU4KvVMczhoO0LvDIsAG8F1"; // 33 bytes
 	strcpy(temp, d);
-	assert(bytes(temp, 33) == 0x709F6C5CF482869E);
+	assert(hash_bytes(temp, 33) == 0x709F6C5CF482869E);
 
 	char *f = "gBy7IsF6xgDww7IHAW7u1XCBgqw1NKG2e7rW1kjJ57Om18lF"; // 48 bytes
 	strcpy(temp, f);
-	assert(bytes(temp, 48) == 0x187E2EE0343CCDC3);
+	assert(hash_bytes(temp, 48) == 0x187E2EE0343CCDC3);
 
 	char *c = "V8lL08akfSYCQpDtKyAH56SQNORwpF4rxXn9H2wDvWKDR5Rn3mdJBftuDSCEZvI"; // 63 bytes
 	strcpy(temp, c);
-	assert(bytes(temp, 63) == 0x8FDCA544A6B3476F);
+	assert(hash_bytes(temp, 63) == 0x8FDCA544A6B3476F);
 
 	for(size_t i = 0; i < sizeof(temp); i++) temp[i] = i;
-	assert(bytes(temp, sizeof(temp)) == 0xE8010714612E6C70);
+	assert(hash_bytes(temp, sizeof(temp)) == 0xE8010714612E6C70);
 
-	file(*argv); 
+	FILE *in = fopen(*argv, "rb");
+	hash_file(in);
+	fclose(in);
 
 	puts("Tests Passed!");
 }
-

--- a/ocaml/seahash/libseahash/seahash.c
+++ b/ocaml/seahash/libseahash/seahash.c
@@ -110,7 +110,7 @@ uint64_t hash_filedesc(int fd) {
 	return hash_file(in);
 }
 
-int main(int argc, char **argv) {
+/*int main(int argc, char **argv) {
 	// These hash outputs were precomputed using the SeaHash reference implementation (which is written in Rust).
 	char temp[4096];
 
@@ -142,4 +142,4 @@ int main(int argc, char **argv) {
 	fclose(in);
 
 	puts("Tests Passed!");
-}
+}*/

--- a/ocaml/xapi/jbuild
+++ b/ocaml/xapi/jbuild
@@ -54,6 +54,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29-52))
   (modules (:standard \ xapi_main))
   (libraries (
+   seahash
    unixpwd
    pam
    pciutil

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -939,7 +939,7 @@ let set_name_description ~__context ~self ~value =
   update ~__context ~vdi:self
 
 let checksum ~__context ~self =
-  let do_checksum f = Digest.to_hex (Digest.file f) in
+  let do_checksum f = Seahash.Hash.to_hex (Seahash.Hash.file f) in
   Helpers.call_api_functions ~__context
     (fun rpc session_id -> Sm_fs_ops.with_block_attached_device __context rpc session_id self `RO do_checksum)
 


### PR DESCRIPTION
VDI checksumming is now done using fast non-cryptographic hash functions. This change replaces calls to the Sha1 and Digest class with calls to a SeaHash binding. 