### PR TITLE
Allow migrate_send during RPU

### DIFF
--- a/ocaml/tests/test_vm_check_operation_error.ml
+++ b/ocaml/tests/test_vm_check_operation_error.ml
@@ -118,13 +118,13 @@ let test_migration_allowed_when_cbt_enabled_vdis_are_not_moved () =
         (Xapi_vm_lifecycle.check_operation_error ~__context ~ref:vM ~op:`migrate_send ~strict:true)
     )
 
-let test_sxm_disallowed_when_rum () =
+let test_sxm_allowed_when_rum () =
   with_test_vm (fun __context vm_ref ->
     let master = Test_common.make_host __context () in
     let pool = Test_common.make_pool ~__context ~master () in
     Db.Pool.add_to_other_config ~__context ~self:pool ~key:Xapi_globs.rolling_upgrade_in_progress ~value:"x";
     compare_errors
-      (Some(Api_errors.not_supported_during_upgrade, [ ]))
+      None
       (Xapi_vm_lifecycle.check_operation_error ~__context ~ref:vm_ref ~op:`migrate_send ~strict:false);
     Db.Pool.remove_from_other_config ~__context ~self:pool ~key:Xapi_globs.rolling_upgrade_in_progress;
     compare_errors
@@ -136,6 +136,6 @@ let test =
   [ "test_null_vdi", `Quick, test_null_vdi
   ; "test_operation_checks_allowed", `Quick, test_operation_checks_allowed
   ; "test_migration_allowed_when_cbt_enabled_vdis_are_not_moved", `Quick, test_migration_allowed_when_cbt_enabled_vdis_are_not_moved
-  ; "test_sxm_disallowed_when_rum", `Quick, test_sxm_disallowed_when_rum
+  ; "test_sxm_allowed_when_rum", `Quick, test_sxm_allowed_when_rum
   ; "test_vm_set_nvram when VM is running", `Quick, test_vm_set_nvram_running
   ]

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -378,6 +378,7 @@ let rpu_allowed_vm_operations = [
   `hard_shutdown;
   `import;
   `make_into_template;
+  `migrate_send;
   `pause;
   `pool_migrate;
   `power_state_reset;


### PR DESCRIPTION
It is needed to avoid downtime during RPU when VMs are running on local
storage and is already allowed for cross-pool storage migration between
mismatching XAPI versions, provided the destination has a higher version.

Related to #3764

I must admit that there may be a good reason why it was disabled in the first place, but I think that the reasons might not be valid anymore. If you look at the commit history, it was removed with commit 6760dad which says "Migrate_send wasn't a Miami operation". My guess is that the list of allowed actions was downgraded to those that "Miami" was able to handle. If I'm right, it has become less and less likely that someone would attempt an upgrade from that version (is it supported at all?).

Local migration tests went fine.