### PR TITLE
CP-29962: Ignore monitor_config_file for GVT-g VGPU types

### DIFF
--- a/ocaml/tests/test_vgpu_common.ml
+++ b/ocaml/tests/test_vgpu_common.ml
@@ -139,14 +139,12 @@ let gvt_g_041a = {
     Xapi_globs.vgt_low_gm_sz, "128";
     Xapi_globs.vgt_high_gm_sz, "384";
     Xapi_globs.vgt_fence_sz, "4";
-    Xapi_globs.vgt_monitor_config_file, "/etc/gvt-g-monitor.conf";
   ];
   identifier = Identifier.(GVT_g {
       pdev_id = 0x041a;
       low_gm_sz = 128L;
       high_gm_sz = 384L;
       fence_sz = 4L;
-      monitor_config_file = Some "/etc/gvt-g-monitor.conf";
     });
   experimental = false;
 }

--- a/ocaml/tests/test_vgpu_type.ml
+++ b/ocaml/tests/test_vgpu_type.ml
@@ -208,12 +208,11 @@ module IntelTest = struct
   let string_of_vgpu_conf conf =
     let open Identifier in
     let open Vendor_intel in
-    Printf.sprintf "%04x %Ld %Ld %Ld %s %b %s"
+    Printf.sprintf "%04x %Ld %Ld %Ld %b %s"
       conf.identifier.pdev_id
       conf.identifier.low_gm_sz
       conf.identifier.high_gm_sz
       conf.identifier.fence_sz
-      (Test_printers.(option string) conf.identifier.monitor_config_file)
       conf.experimental
       conf.model_name
 
@@ -233,14 +232,13 @@ module IntelTest = struct
         "", None;
         "nonsense123", None;
         (* Test some success cases. *)
-        "1234 experimental=0 name='myvgpu' low_gm_sz=128 high_gm_sz=384 fence_sz=4 framebuffer_sz=128 max_heads=1 resolution=1920x1080 monitor_config_file=/my/file",
+        "1234 experimental=0 name='myvgpu' low_gm_sz=128 high_gm_sz=384 fence_sz=4 framebuffer_sz=128 max_heads=1 resolution=1920x1080",
         Some {
           Vendor_intel.identifier = Identifier.({
               pdev_id = 0x1234;
               low_gm_sz = 128L;
               high_gm_sz = 384L;
               fence_sz = 4L;
-              monitor_config_file = Some "/my/file";
             });
           experimental = false;
           model_name = "myvgpu";
@@ -249,14 +247,13 @@ module IntelTest = struct
           max_x = 1920L;
           max_y = 1080L;
         };
-        "1234 experimental=1 name='myvgpu' low_gm_sz=128 high_gm_sz=384 fence_sz=4 framebuffer_sz=128 max_heads=1 resolution=1920x1080 monitor_config_file=/my/file",
+        "1234 experimental=1 name='myvgpu' low_gm_sz=128 high_gm_sz=384 fence_sz=4 framebuffer_sz=128 max_heads=1 resolution=1920x1080",
         Some {
           Vendor_intel.identifier = Identifier.({
               pdev_id = 0x1234;
               low_gm_sz = 128L;
               high_gm_sz = 384L;
               fence_sz = 4L;
-              monitor_config_file = Some "/my/file";
             });
           experimental = true;
           model_name = "myvgpu";
@@ -293,7 +290,6 @@ module IntelTest = struct
                   low_gm_sz = 128L;
                   high_gm_sz = 384L;
                   fence_sz = 4L;
-                  monitor_config_file = Some "/path/to/file1";
                 });
               experimental = false;
               model_name = "GVT-g on 1234";
@@ -308,7 +304,6 @@ module IntelTest = struct
                   low_gm_sz = 128L;
                   high_gm_sz = 384L;
                   fence_sz = 4L;
-                  monitor_config_file = Some "/path/to/file2";
                 });
               experimental = true;
               model_name = "GVT-g on 1234 (experimental)";
@@ -327,7 +322,6 @@ module IntelTest = struct
                   low_gm_sz = 128L;
                   high_gm_sz = 384L;
                   fence_sz = 4L;
-                  monitor_config_file = Some "/path/to/file1";
                 });
               experimental = false;
               model_name = "GVT-g on 1234";

--- a/ocaml/tests/test_xenopsd_metadata.ml
+++ b/ocaml/tests/test_xenopsd_metadata.ml
@@ -311,7 +311,7 @@ module GenerateVGPUMetadata = Generic.Make(Generic.EncapsulateState(struct
                                                      low_gm_sz = 128L;
                                                      high_gm_sz = 384L;
                                                      fence_sz = 4L;
-                                                     monitor_config_file = Some "/etc/gvt-g-monitor.conf";
+                                                     monitor_config_file = None;
                                                    })
                                                ];
                                              ]

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -446,7 +446,6 @@ let igd_passthru_key = "igd_passthrough"
 let vgt_low_gm_sz = "vgt_low_gm_sz"
 let vgt_high_gm_sz = "vgt_high_gm_sz"
 let vgt_fence_sz = "vgt_fence_sz"
-let vgt_monitor_config_file = "vgt_monitor_config_file"
 
 let mxgpu_vgpus_per_pgpu = "vgpus_per_pgpu"
 

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -43,7 +43,6 @@ module Identifier = struct
     low_gm_sz : int64;
     high_gm_sz : int64;
     fence_sz : int64;
-    monitor_config_file : string option;
   }
 
   type mxgpu_id = {
@@ -73,14 +72,11 @@ module Identifier = struct
           nvidia_id.vdev_id
           nvidia_id.vsubdev_id
       | GVT_g gvt_g_id ->
-        Printf.sprintf "gvt-g,%04x,%Lx,%Lx,%Lx,%s"
+        Printf.sprintf "gvt-g,%04x,%Lx,%Lx,%Lx"
           gvt_g_id.pdev_id
           gvt_g_id.low_gm_sz
           gvt_g_id.high_gm_sz
           gvt_g_id.fence_sz
-          (match gvt_g_id.monitor_config_file with
-           | Some path -> path
-           | None -> "")
       | MxGPU mxgpu_id ->
         Printf.sprintf "mxgpu,%04x,%Lx"
           mxgpu_id.pdev_id
@@ -679,7 +675,7 @@ module Vendor_intel = struct
     try
       Some (Scanf.sscanf
               line
-              "%04x experimental=%c name='%s@' low_gm_sz=%Ld high_gm_sz=%Ld fence_sz=%Ld framebuffer_sz=%Ld max_heads=%Ld resolution=%Ldx%Ld monitor_config_file=%s"
+              "%04x experimental=%c name='%s@' low_gm_sz=%Ld high_gm_sz=%Ld fence_sz=%Ld framebuffer_sz=%Ld max_heads=%Ld resolution=%Ldx%Ld"
               (fun pdev_id
                 experimental
                 model_name
@@ -689,15 +685,13 @@ module Vendor_intel = struct
                 framebuffer_sz
                 num_heads
                 max_x
-                max_y
-                monitor_config_file ->
+                max_y ->
                 {
                   identifier = Identifier.({
                       pdev_id;
                       low_gm_sz;
                       high_gm_sz;
                       fence_sz;
-                      monitor_config_file = Some monitor_config_file;
                     });
                   experimental = (experimental <> '0');
                   model_name;
@@ -746,10 +740,6 @@ module Vendor_intel = struct
           ; vgt_high_gm_sz, Int64.to_string conf.identifier.high_gm_sz
           ; vgt_fence_sz, Int64.to_string conf.identifier.fence_sz
           ]
-        ; match conf.identifier.monitor_config_file with
-          | Some monitor_config_file ->
-            [vgt_monitor_config_file, monitor_config_file]
-          | None -> []
         ]
       in
       Some {

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -699,11 +699,7 @@ module MD = struct
           fence_sz =
             List.assoc Xapi_globs.vgt_fence_sz internal_config
             |> Int64.of_string;
-          monitor_config_file =
-            if List.mem_assoc Xapi_globs.vgt_monitor_config_file internal_config
-            then Some
-                (List.assoc Xapi_globs.vgt_monitor_config_file internal_config)
-            else None;
+          monitor_config_file = None; (* unused *)
         }
       in {
         id = (vm.API.vM_uuid, vgpu.Db_actions.vGPU_device);


### PR DESCRIPTION
This information is no longer required for starting GVT-g VMs, so xapi no
longer needs to read it from the whitelist file and pass it to xenopsd. Note
that, for backwards compatibility, we need to keep the `monitor_config_file`
key in the `Xenops_interface`, but xapi sets it to `None` from now on.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>