### PR TITLE
CP-30527: Reduce direct usage of Xenctrl

### DIFF
--- a/ocaml/tests/test_common.ml
+++ b/ocaml/tests/test_common.ml
@@ -514,7 +514,7 @@ let make_cluster_host ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
 let make_cluster_and_cluster_host ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ?(cluster_token="") ?(pIF=Ref.null) ?(cluster_stack=Constants.default_smapiv3_cluster_stack)
     ?(allowed_operations=[]) ?(current_operations=[]) ?(pool_auto_join=true)
-    ?(token_timeout=Constants.default_token_timeout_s) 
+    ?(token_timeout=Constants.default_token_timeout_s)
     ?(token_timeout_coefficient=Constants.default_token_timeout_coefficient_s) ?(cluster_config=[])
     ?(other_config=[]) ?(host=Ref.null) () =
   Db.Cluster.create ~__context ~ref ~uuid ~cluster_token ~pending_forget:[]

--- a/ocaml/tests/test_common.ml
+++ b/ocaml/tests/test_common.ml
@@ -53,6 +53,23 @@ let make_localhost ~__context ?(features=Features.all_features) () =
     total_memory_mib = 1024L;
     dom0_static_max = Memory.bytes_of_mib 512L;
     ssl_legacy = false;
+    cpu_info =
+      { cpu_count = 1
+      ; socket_count = 1
+      ; vendor = ""
+      ; speed = ""
+      ; modelname = ""
+      ; family = ""
+      ; model = ""
+      ; stepping = ""
+      ; flags = ""
+      ; features = [||]
+      ; features_pv = [||]
+      ; features_hvm = [||]
+      ; features_oldstyle = [||]
+    };
+    hypervisor = {version = "unknown"; capabilities = ""};
+    chipset_info = {iommu = false; hvm = false}
   } in
 
   Dbsync_slave.create_localhost ~__context host_info;

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -111,25 +111,13 @@ let read_dom0_memory_usage () =
 
 let read_localhost_info () =
   let xen_verstring, total_memory_mib =
-    try
-      let xc = Xenctrl.interface_open () in
-      Xenctrl.interface_close xc;
-      let open Xapi_xenops_queue in
-      let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
-      let stat = Client.HOST.stat "read_localhost_info" in
-      let xen_verstring = stat.hypervisor.version in
-      let total_memory_mib =
-        Client.HOST.get_total_memory_mib "read_localhost_info" in
-      xen_verstring, total_memory_mib
-    with e ->
-      if Pool_role.is_unit_test ()
-      then "0.0.0", 0L
-      else begin
-        warn "Failed to read xen version";
-        match Balloon.get_memtotal () with
-        | None -> "unknown", 0L
-        | Some x -> "unknown", Int64.(div x (mul 1024L 1024L))
-      end
+    let open Xapi_xenops_queue in
+    let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
+    let stat = Client.HOST.stat "read_localhost_info" in
+    let xen_verstring = stat.hypervisor.version in
+    let total_memory_mib =
+      Client.HOST.get_total_memory_mib "read_localhost_info" in
+    xen_verstring, total_memory_mib
   and linux_verstring =
     let verstring = ref "" in
     let f line =

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -113,13 +113,12 @@ let read_localhost_info () =
   let xen_verstring, total_memory_mib =
     try
       let xc = Xenctrl.interface_open () in
-      let v = Xenctrl.version xc in
       Xenctrl.interface_close xc;
-      let open Xenctrl in
-      let xen_verstring = Printf.sprintf "%d.%d%s" v.major v.minor v.extra in
+      let open Xapi_xenops_queue in
+      let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
+      let stat = Client.HOST.stat "read_localhost_info" in
+      let xen_verstring = stat.hypervisor.version in
       let total_memory_mib =
-        let open Xapi_xenops_queue in
-        let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
         Client.HOST.get_total_memory_mib "read_localhost_info" in
       xen_verstring, total_memory_mib
     with e ->

--- a/ocaml/xapi/create_misc.mli
+++ b/ocaml/xapi/create_misc.mli
@@ -27,18 +27,21 @@ type host_info = {
   total_memory_mib : int64;
   dom0_static_max : int64;
   ssl_legacy : bool;
+  cpu_info : Xenops_interface.Host.cpu_info;
+  chipset_info : Xenops_interface.Host.chipset_info;
+  hypervisor : Xenops_interface.Host.hypervisor;
 }
 
 val read_dom0_memory_usage : unit -> int64 option
-val read_localhost_info : unit -> host_info
+val read_localhost_info : __context:Context.t -> host_info
 
 val ensure_domain_zero_records : __context:Context.t -> host:[`host] Ref.t -> host_info -> unit
 
 val create_root_user : __context:Context.t -> unit
 
-val create_software_version : __context:Context.t -> unit
+val create_software_version : __context:Context.t -> host_info -> unit
 
-val create_host_cpu : __context:Context.t -> unit
+val create_host_cpu : __context:Context.t -> host_info -> unit
 val create_pool_cpuinfo : __context:Context.t -> unit
-val create_chipset_info : __context:Context.t -> unit
+val create_chipset_info : __context:Context.t -> host_info -> unit
 val create_updates_requiring_reboot_info : __context:Context.t -> host:[`host] Ref.t -> unit

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -88,11 +88,11 @@ let refresh_localhost_info ~__context info =
   Db.Host.set_API_version_minor ~__context ~self:host ~value:Datamodel_common.api_version_minor;
   Db.Host.set_virtual_hardware_platform_versions ~__context ~self:host ~value:Xapi_globs.host_virtual_hardware_platform_versions;
   Db.Host.set_hostname ~__context ~self:host ~value:info.hostname;
-  let caps = try
-      String.split ' ' (Xenctrl.with_intf (fun xc -> Xenctrl.version_capabilities xc))
-    with _ ->
-      warn "Unable to query hypervisor capabilities";
-      [] in
+  let open Xapi_xenops_queue in
+  let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
+  let dbg = Context.string_of_task __context in
+  let stat = Client.HOST.stat dbg in
+  let caps = String.split ' ' stat.hypervisor.capabilities in
   Db.Host.set_capabilities ~__context ~self:host ~value:caps;
   Db.Host.set_address ~__context ~self:host ~value:(get_my_ip_addr ~__context);
 

--- a/ocaml/xapi/monitor_dbcalls.ml
+++ b/ocaml/xapi/monitor_dbcalls.ml
@@ -26,8 +26,7 @@ open D
 let get_host_memory_changes xc =
   let physinfo = Xenctrl.physinfo xc in
   let bytes_of_pages pages =
-    let kib = Xenctrl.pages_to_kib (Int64.of_nativeint pages) in
-    Int64.shift_left kib 10
+    Memory.bytes_of_pages (Int64.of_nativeint pages)
   in
   let free_bytes = bytes_of_pages physinfo.Xenctrl.free_pages in
   let total_bytes = bytes_of_pages physinfo.Xenctrl.total_pages in
@@ -50,8 +49,7 @@ let get_vm_memory_changes xc =
     if not dom.dying then
       begin
         let uuid = Uuid.string_of_uuid (Uuid.uuid_of_int_array dom.handle) in
-        let kib = Xenctrl.pages_to_kib (Int64.of_nativeint dom.total_memory_pages) in
-        let memory = Int64.mul kib 1024L in
+        let memory = Memory.bytes_of_pages (Int64.of_nativeint dom.total_memory_pages) in
         Hashtbl.add vm_memory_tmp uuid memory
       end
   in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1162,11 +1162,11 @@ let detect_nonhomogeneous_external_auth_in_host ~__context ~host =
 (* CP-717: Enables external auth/directory service on a single host within the pool with specified config, *)
 (* type and service_name. Fails if an auth/directory service is already enabled for this host (must disable first).*)
 (*
-* Each Host object will contain a string field, external_auth_type which will specify the type of the external auth/directory service.
-	  o In the case of AD, this will contain the string "AD". (If we subsequently allow other types of external auth/directory service to be configured, e.g. LDAP, then new type strings will be defined accordingly)
-	  o When no external authentication service is configured, this will contain the empty string
-* Each Host object will contain a (string*string) Map field, external_auth_configuration. This field is provided so that a particular xapi authentiation module has the option of persistently storing any configuration parameters (represented as key/value pairs) within the agent database.
-* Each Host object will contain a string field, external_auth_service_name, which contains sufficient information to uniquely identify and address the external authentication/directory service. (e.g. in the case of AD this would be a domain name)
+ * Each Host object will contain a string field, external_auth_type which will specify the type of the external auth/directory service.
+   o In the case of AD, this will contain the string "AD". (If we subsequently allow other types of external auth/directory service to be configured, e.g. LDAP, then new type strings will be defined accordingly)
+   o When no external authentication service is configured, this will contain the empty string
+ * Each Host object will contain a (string*string) Map field, external_auth_configuration. This field is provided so that a particular xapi authentiation module has the option of persistently storing any configuration parameters (represented as key/value pairs) within the agent database.
+ * Each Host object will contain a string field, external_auth_service_name, which contains sufficient information to uniquely identify and address the external authentication/directory service. (e.g. in the case of AD this would be a domain name)
 *)
 open Auth_signature
 open Extauth

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1495,7 +1495,8 @@ let license_remove ~__context ~host =
 
 let refresh_pack_info ~__context ~host =
   debug "Refreshing software_version";
-  Create_misc.create_software_version ~__context
+  let host_info = Create_misc.read_localhost_info ~__context in
+  Create_misc.create_software_version ~__context host_info
 
 (* Network reset *)
 

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -503,7 +503,8 @@ let resync_host ~__context ~host =
         Db.Pool_patch.remove_from_other_config ~__context ~self:pool_patch_ref ~key:"enforce_homogeneity";
       ) update_refs;
     Create_misc.create_updates_requiring_reboot_info ~__context ~host;
-    Create_misc.create_software_version ~__context
+    let host_info = Create_misc.read_localhost_info ~__context in
+    Create_misc.create_software_version ~__context host_info
   end
   else Db.Host.set_updates ~__context ~self:host ~value:[];
 

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -113,7 +113,7 @@ let get_locally_attached ~__context ~uuid ~vdi =
     let mount_dir = Filename.concat !Xapi_globs.host_update_dir uuid in
     let mount_dir_opt = if Sys.file_exists mount_dir then Some mount_dir else None in
     let dom0 = Helpers.get_domain_zero ~__context in
-    let vbds = List.filter (fun self -> Db.VBD.get_VM ~__context ~self = dom0) (Db.VDI.get_VBDs ~__context ~self:vdi) in 
+    let vbds = List.filter (fun self -> Db.VBD.get_VM ~__context ~self = dom0) (Db.VDI.get_VBDs ~__context ~self:vdi) in
     (mount_dir_opt, vbds)
 
 let detach_helper ~__context ~uuid ~vdi =
@@ -222,7 +222,7 @@ let attach_helper ~__context ~uuid ~vdi ~use_localhost_proxy =
        with_api_errors (mount device) mount_point;
        debug "pool_update.attach_helper Mounted %s" mount_point
     );
-  let ip = if use_localhost_proxy then "127.0.0.1" else Db.Host.get_address ~__context ~self:host in 
+  let ip = if use_localhost_proxy then "127.0.0.1" else Db.Host.get_address ~__context ~self:host in
   "http://" ^ ip ^ Constants.get_pool_update_download_uri ^ (Db.Host.get_uuid ~__context ~self:host) ^ "/" ^ uuid ^ "/vdi"
 
 let attach ~__context ~self ~use_localhost_proxy =
@@ -400,13 +400,13 @@ let introduce ~__context ~vdi =
     if not (Db.is_valid_ref __context vdi_of_update) then begin
         Db.Pool_update.set_vdi ~__context ~self:update ~value:vdi;
         update
-    end 
-    else if vdi <> vdi_of_update then 
+    end
+    else if vdi <> vdi_of_update then
         raise (Api_errors.Server_error(Api_errors.update_already_exists, [update_info.uuid]))
     else
         update
   with
-  | Db_exn.Read_missing_uuid (_,_,_) -> 
+  | Db_exn.Read_missing_uuid (_,_,_) ->
     let update = Ref.make () in
     create_update_record ~__context ~update ~update_info ~vdi;
     update


### PR DESCRIPTION
This commit tries reduces direct calls to Xenctrl by replacing it with xenopsd communication, it also tries to reduce communication between xapi and xenopsd to gather host information, as well as making it more apparent when it's happening.

I'm unsure about not being able to retrieve the actual memory values when xenopsd is down, feedback on how to tackle this is appreciated.

I'm also unsure on whether it would be beneficial to replace the `make` in the name of methods in `create_misc.ml` to better reflect that they write to the database.

Xenctrl is still used for testing in `ocaml/quicktest/quicktest_vm_lifecycle.ml` and is used to periodically update information about the host in `ocaml/xapi/monitor_dbcalls.ml` and `ocaml/xapi/monitor_types.ml`. This last usage needs a more thought'out approach to not have a negative performance impact.