### PR TITLE
Faster Checksum Algorithm

### DIFF
--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -57,6 +57,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    mtime
    mtime.clock.os
    sha
+   xxhash
    tar
    tar-unix
    xapi-tapctl

--- a/ocaml/xapi/stream_vdi.ml
+++ b/ocaml/xapi/stream_vdi.ml
@@ -21,6 +21,7 @@ open Debug
 open Http
 open Forkhelpers
 open Pervasiveext
+open XXHash
 
 exception Failure of string
 
@@ -33,7 +34,8 @@ let chunk_size = Int64.mul 1024L 1024L (* 1 MiB *)
 (** Maximum range for sparseness query *)
 let max_sparseness_size = Int64.mul 10240L chunk_size
 
-let checksum_extension = ".checksum"
+let checksum_extension = ".xxhash"
+let checksum_supported_extension = [checksum_extension; ".checksum"] (* Supported checksum formats, .checksum == SHA1 *)
 
 type vdi = string (* directory prefix in tar file *) * API.ref_VDI * Int64.t (* size to send/recieve *)
 
@@ -91,7 +93,7 @@ let made_progress __context progress n =
 let write_block ~__context filename buffer ofd len =
   let hdr = Tar_unix.Header.make filename (Int64.of_int len) in
   try
-    let csum = Sha1.to_hex (Sha1.string (Bytes.unsafe_to_string buffer)) in
+    let csum = Printf.sprintf "%016LX" (XXH64.hash (Bytes.unsafe_to_string buffer)) in
     Tar_unix.write_block hdr (fun ofd -> Unix.write ofd buffer 0 len |> ignore) ofd;
     (* Write the checksum as a separate file *)
     let hdr' = Tar_unix.Header.make (filename ^ checksum_extension) (Int64.of_int (String.length csum)) in
@@ -308,12 +310,12 @@ let send_all refresh_session ofd ~__context rpc session_id (prefix_vdis: vdi lis
 exception Invalid_checksum of string
 
 (* Rio GA and later only *)
-let verify_inline_checksum ifd checksum_table =
-  let hdr = Tar_unix.Header.get_next_header ifd in
+let verify_inline_checksum ifd checksum_table hdr =
   let file_name = hdr.Tar_unix.Header.file_name in
+  let extension = Filename.extension file_name in
   let length = hdr.Tar_unix.Header.file_size in
-  if not(String.endswith checksum_extension file_name) then begin
-    let msg = Printf.sprintf "Expected to find an inline checksum, found file called: %s" file_name in
+  if not(List.mem extension checksum_supported_extension) then begin
+    let msg = Printf.sprintf "Expected to find a supported inline checksum file, instead found a file called: %s" file_name in
     error "%s" msg;
     raise (Failure msg)
   end;
@@ -324,7 +326,7 @@ let verify_inline_checksum ifd checksum_table =
     let csum = Bytes.unsafe_to_string csum in
     Tar_unix.Archive.skip ifd (Tar_unix.Header.compute_zero_padding_length hdr);
     (* Look up the relevant file_name in the checksum_table *)
-    let original_file_name = String.sub file_name 0 (String.length file_name - (String.length checksum_extension)) in
+    let original_file_name = Filename.remove_extension file_name in
     let csum' = List.assoc original_file_name !checksum_table in
     if csum <> csum' then begin
       error "File %s checksum mismatch (%s <> %s)" original_file_name csum csum';
@@ -407,18 +409,25 @@ let recv_all_vdi refresh_session ifd (__context:Context.t) rpc session_id ~has_i
              in
              Unixext.really_read ifd buffer 0 (Int64.to_int length);
              Unix.write ofd buffer 0 (Int64.to_int length) |> ignore;
-             let csum = Sha1.to_hex (Sha1.string (Bytes.unsafe_to_string buffer)) in
+             
+             let buffer_string = Bytes.unsafe_to_string buffer in
+             
+             let csum_hdr = Tar_unix.Header.get_next_header ifd in
+             
+             let csum = if hdr.Tar_unix.Header.file_name <> checksum_extension 
+             	then Sha1.to_hex (Sha1.string buffer_string)
+             	else Printf.sprintf "%016LX" (XXH64.hash buffer_string)
+     	     in
 
              checksum_table := (file_name, csum) :: !checksum_table;
 
              Tar_unix.Archive.skip ifd (Tar_unix.Header.compute_zero_padding_length hdr);
              made_progress __context progress (Int64.add skipped_size length);
 
-
              if has_inline_checksums then
                begin
                  try
-                   verify_inline_checksum ifd checksum_table;
+                   verify_inline_checksum ifd checksum_table csum_hdr;
                  with
                  | Invalid_checksum s as e ->
                    if not(force) then raise e

--- a/xapi.opam
+++ b/xapi.opam
@@ -60,9 +60,9 @@ depends: [
   "yojson"
 ]
 depexts: [
-  ["hwdata" "libpci-dev" "libpam-dev"] {os-distribution = "debian"}
-  ["hwdata" "libpci-dev" "libpam-dev"] {os-distribution = "ubuntu"}
-  ["hwdata" "pciutils-devel" "pam-devel"] {os-distribution = "centos"}
+  ["hwdata" "libpci-dev" "libpam-dev" "libxxhash-dev" "libxxhash0"] {os-distribution = "debian"}
+  ["hwdata" "libpci-dev" "libpam-dev" "libxxhash-dev" "libxxhash0"] {os-distribution = "ubuntu"}
+  ["hwdata" "pciutils-devel" "pam-devel" "xxhash-devel" "xxhash-libs"] {os-distribution = "centos"}
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"
 description: """

--- a/xapi.opam
+++ b/xapi.opam
@@ -28,6 +28,7 @@ depends: [
   "rrdd-plugin"
   "sexpr"
   "sha"
+  "xxhash"
   "stdext"
   "stunnel"
   "tar"


### PR DESCRIPTION
With these changes Xapi should see significant performance improvements when doing VM and VDI imports and exports. Formal benchmarks will be finished in the next day or so. These changes are also maintain backwards compatability. 

Moved from SHA1 checksum to xxHash checksum as per discussion. The xxHash checksum bindings come from opam: https://opam.ocaml.org/packages/xxhash/ and information about the xxHash algorithm can be found here: https://github.com/Cyan4973/xxHash
