### PR TITLE
CP-30559 Use the API to add the uefi certificates

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2714,10 +2714,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
     let set_uefi_certificates ~__context ~host ~value =
       info "Host.set_uefi_certificates: host='%s' value='%s'" (host_uuid ~__context host) value;
-      let local_fn = Local.Host.set_uefi_certificates ~host ~value in
-      do_op_on ~local_fn ~__context ~host
-        (fun session_id rpc ->
-        Client.Host.set_uefi_certificates rpc session_id host value)
+      Local.Host.set_uefi_certificates ~__context ~host ~value
+
   end
 
   module Host_crashdump = struct

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -532,6 +532,9 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
       (* Copy other-config into newly created host record: *)
       no_exn (fun () -> Client.Host.set_other_config ~rpc ~session_id ~self:ref ~value:host.API.host_other_config) ();
 
+      (* Copy the uefi-certificates into the newly created host record *)
+      no_exn (fun () -> Client.Host.set_uefi_certificates ~rpc ~session_id ~host:ref ~value:host.API.host_uefi_certificates) ();
+
       (* Copy the crashdump SR *)
       let my_crashdump_sr = Db.Host.get_crash_dump_sr ~__context ~self:host_ref in
       if my_crashdump_sr <> Ref.null then begin


### PR DESCRIPTION
Take the uefi certificates from the 'old' host, and use the API to copy
them to the 'new' host. This has the added benefit of setting the pool
certificates, if they don't already exist

Message forwarding hasn't started yet because the host is still offline,
so only do the set locally

Signed-off-by: Richard Davies <richard.davies@citrix.com>