### PR TITLE
CA-310173: use a persistent path for multipath_enabled

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -679,7 +679,7 @@ let udhcpd_leases_db = ref "/var/lib/xcp/dhcp-leases.db"
 let udhcpd_pidfile = ref "/var/run/udhcpd.pid"
 
 let iscsi_initiator_config_file = ref "/etc/iscsi/initiatorname.iscsi"
-let multipathing_config_file = ref "/var/run/nonpersistent/multipath_enabled"
+let multipathing_config_file = ref "/var/lib/xcp/multipath_enabled"
 
 let busybox = ref "busybox"
 

--- a/ocaml/xapi/xapi_host_helpers.mli
+++ b/ocaml/xapi/xapi_host_helpers.mli
@@ -116,7 +116,7 @@ module Configuration : sig
 
   val set_multipathing : bool -> unit
   (** [set_multipathing enabled] will touch the file specified in Xapi_globs
-      (usually /var/run/nonpersistent/multipath_enabled) if [enabled] is true,
+      (usually /var/lib/xcp/multipath_enabled) if [enabled] is true,
       otherwise it will remove the file. *)
 
   val sync_config_files : __context:Context.t -> unit


### PR DESCRIPTION
/var/run/nonpersistent would get wiped on each boot, this normally wouldn't be a problem due to `sync_config_files` which runs on startup, except for HA.
HA requires all this information to be available before XAPI is up, in the attach-static-vdis script.

Changing this requires a coordinated change in sm/xapi-storage-plugins.
/cc @MarkSymsCtx 
