### PR TITLE
CA-309048 handle domain sockets for wsproxy

### DIFF
--- a/ocaml/xapi/console.ml
+++ b/ocaml/xapi/console.ml
@@ -91,11 +91,9 @@ let ensure_proxy_running () =
 
 let ws_proxy __context req protocol address s =
   let port = match address with
-    | Port p -> p
-    | Path _ ->
-      error "No implementation for web-sockets console proxy to a Unix domain socket";
-      Http_svr.headers s (Http.http_501_method_not_implemented ());
-      failwith "ws_proxy: not implemented" in
+    | Port p -> string_of_int p
+    | Path p -> p
+  in
 
   ensure_proxy_running ();
   let protocol = match protocol with
@@ -129,7 +127,7 @@ let ws_proxy __context req protocol address s =
               let wsprotocol = match ty with
                 | Ws_helpers.Hixie76 -> "hixie76"
                 | Ws_helpers.Hybi10 -> "hybi10" in
-              let message = Printf.sprintf "%s:%s:%d" wsprotocol protocol port in
+              let message = Printf.sprintf "%s:%s:%s" wsprotocol protocol port  in
               let len = String.length message in
               ignore(Unixext.send_fd_substring sock message 0 len [] s)
             end

--- a/ocaml/xapi/console.ml
+++ b/ocaml/xapi/console.ml
@@ -90,7 +90,7 @@ let ensure_proxy_running () =
   end
 
 let ws_proxy __context req protocol address s =
-  let port = match address with
+  let addr = match address with
     | Port p -> string_of_int p
     | Path p -> p
   in
@@ -127,7 +127,7 @@ let ws_proxy __context req protocol address s =
               let wsprotocol = match ty with
                 | Ws_helpers.Hixie76 -> "hixie76"
                 | Ws_helpers.Hybi10 -> "hybi10" in
-              let message = Printf.sprintf "%s:%s:%s" wsprotocol protocol port  in
+              let message = Printf.sprintf "%s:%s:%s" wsprotocol protocol addr in
               let len = String.length message in
               ignore(Unixext.send_fd_substring sock message 0 len [] s)
             end


### PR DESCRIPTION
Add support for using Unix domain sockets for wsproxy requests.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>