### PR TITLE
CA-310971: consider enabling the host again after plugging in clustered PBDs in HA mode

### DIFF
--- a/ocaml/xapi/create_storage.ml
+++ b/ocaml/xapi/create_storage.ml
@@ -53,7 +53,8 @@ let plug_unplugged_pbds __context =
          then debug "Not replugging PBD %s: already plugged in" (Ref.string_of self)
          else Xapi_pbd.plug ~__context ~self
        with e -> debug "Could not plug in pbd '%s': %s" (Db.PBD.get_uuid ~__context ~self) (Printexc.to_string e))
-    my_pbds
+    my_pbds;
+  Xapi_host_helpers.consider_enabling_host ~__context
 
 (* Create a PBD which connects this host to the SR, if one doesn't already exist *)
 let maybe_create_pbd rpc session_id sr device_config me =


### PR DESCRIPTION
When HA is enabled the host only gets enabled if all its PBDs got
plugged.
However clustered PBDs only get plugged after quorum is established,
which might be after the startup sequence has finished.

There is a watcher thread for that, and when the clustered PBDs do get
plugged in we should attempt to enable the host again.

Rerunning the xenrt test that was consistently failing before on this GFS2 HA test is now passing.