### PR TITLE
Revert "CA-290024: Reject booting pv-iommu VMs on a host where the pr…

### DIFF
--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -204,21 +204,6 @@ let assert_startup_complete () =
     (fun () -> if not (!startup_complete) then
         raise (Api_errors.Server_error (Api_errors.host_still_booting, [])))
 
-let assert_host_pviommu_ready =
-  let is_ready = ref false in
-  fun () ->
-    (if not !is_ready then
-       try
-         let s = Unixext.string_of_file "/sys/kernel/pv_iommu_ready" in
-         is_ready := Scanf.sscanf s " %d " (=) 1;
-       with _ ->
-         (* If we had difficulty reading/converting the key (e.g. the key
-            doesn't exist), we'll assume the flag is not accountable (e.g.
-            from previous releases with no such key) and simply go ahead. *)
-         is_ready := true);
-    if not !is_ready then
-      raise (Api_errors.Server_error (Api_errors.host_still_booting, []))
-
 let consider_enabling_host_nolock ~__context =
   debug "Xapi_host_helpers.consider_enabling_host_nolock called";
   (* If HA is enabled only consider marking the host as enabled if all the storage plugs in successfully.

--- a/ocaml/xapi/xapi_host_helpers.mli
+++ b/ocaml/xapi/xapi_host_helpers.mli
@@ -94,10 +94,6 @@ val assert_startup_complete : unit -> unit
 (** [assert_startup_complete ()] will raise `host_still_booting` if the startup
     sequence is not yet complete. *)
 
-val assert_host_pviommu_ready : unit -> unit
-(** [assert_host_pviommu_ready ()] will raise `host_still_booting` if the pviommu
-    is not ready acccording to /sys/kernel/pv_iommu_ready. *)
-
 module Host_requires_reboot : sig
   val set : unit -> unit
   (** [set ()] is used to signal the host needs a reboot. This could be, for

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -272,9 +272,6 @@ let start ~__context ~vm ~start_paused ~force =
   if sriov_networks <> [] then
     Pool_features.assert_enabled ~__context ~f:Features.Network_sriov;
 
-  if Xapi_vm_helpers.vm_needs_pviommu ~__context ~self:vm then
-    Xapi_host_helpers.assert_host_pviommu_ready ();
-
   if not force then
     assert_memory_constraints ~__context ~vm vmr.API.vM_platform;
 

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -345,11 +345,6 @@ let vm_needs_iommu ~__context ~self =
     (fun vgpu -> Xapi_vgpu.requires_passthrough ~__context ~self:vgpu <> None)
     (Db.VM.get_VGPUs ~__context ~self)
 
-let vm_needs_pviommu ~__context ~self =
-  List.exists
-    (fun vgpu -> Xapi_vgpu.requires_passthrough ~__context ~self:vgpu = None)
-    (Db.VM.get_VGPUs ~__context ~self)
-
 let assert_host_has_iommu ~__context ~host =
   let chipset_info = Db.Host.get_chipset_info ~__context ~self:host in
   if List.assoc "iommu" chipset_info <> "true" then


### PR DESCRIPTION
…emap is yet to complete"

This patch caused undesirable behaviour in clients that do not handle the
failure to start these VMs. Instead, the start call will be processed and made
to block until PV-IOMMU is ready.

This reverts commit 7dda14362b7f68bf2827c3d823a00cb645394118.