### PR TITLE
CP-30440: fix tarfile extraction

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1829,8 +1829,8 @@ let allocate_resources_for_vm ~__context ~self ~vm ~live =
 let set_uefi_certificates ~__context ~host ~value =
   Db.Host.set_uefi_certificates ~__context ~self:host ~value;
   let pool = Helpers.get_pool ~__context in
-  if Db.Pool.get_uefi_certificates ~__context ~self:pool  = "" then
-    Db.Pool.set_uefi_certificates ~__context ~self:pool ~value
+  if value <> "" then
+  	Db.Pool.set_uefi_certificates ~__context ~self:pool ~value
 
 let set_iscsi_iqn ~__context ~host ~value =
   if value = "" then raise Api_errors.(Server_error (invalid_value, ["value"; value]));

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -251,9 +251,9 @@ let save_uefi_certificates_to_dir ~__context ~pool ~vm =
       let contents = (Xapi_stdext_base64.Base64.decode (Db.Pool.get_uefi_certificates ~__context ~self:pool)) in
       if contents <> "" then begin
         let filename = "xapi_uefi_certificates.tar" in
-        Unixext.with_file filename [Unix.O_RDWR; Unix.O_CREAT] 0o755 (fun fd ->
-            Unixext.write_string_to_file filename contents;
-            Tar_unix.Archive.extract (fun _ -> !Xapi_globs.varstore_dir) fd);
+        Unixext.write_string_to_file filename contents;
+        Unixext.with_file filename [Unix.O_RDONLY; Unix.O_CREAT] 0o755 (fun fd ->
+            Tar_unix.Archive.extract (Filename.concat !Xapi_globs.varstore_dir) fd);
         debug "UEFI tar file extracted to varstore directory";
         Sys.remove filename
       end


### PR DESCRIPTION
With this change I was able to run 'vm-start' without seeing an exception.