### PR TITLE
CP-29134 Update versions for Naples release

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 300
+let schema_minor_vsn = 400
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -100,7 +100,7 @@ let tech_preview_releases = [
 (* Normally xencenter_min_verstring and xencenter_max_verstring in the xapi_globs should be set to the same value,
  * but there are exceptions: please consult the XenCenter maintainers if in doubt. *)
 let api_version_major = 2L
-let api_version_minor = 11L
+let api_version_minor = 12L
 let api_version_string =
   Printf.sprintf "%Ld.%Ld" api_version_major api_version_minor
 let api_version_vendor = "XenSource"

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -61,6 +61,7 @@ let rel_jura = "jura"
 let rel_kolkata = "kolkata"
 let rel_lima = "lima"
 let rel_naples = "naples"
+let rel_oslo = "oslo"
 
 type api_release = {
   code_name: string option;
@@ -245,9 +246,15 @@ let release_order_full = [{
      code_name     = Some rel_naples;
      version_major = 2;
      version_minor = 12;
+     branding      = "Citrix Hypervisor 8.0";
+     release_date  = Some "March 2019";
+   }; {
+     code_name     = Some rel_oslo;
+     version_major = 2;
+     version_minor = 13;
      branding      = "Unreleased";
      release_date  = None;
-   };
+   }
   ]
 (* When you add a new release, use the version number of the latest release, "Unreleased"
    for the branding and None for the release date, until the actual values are finalised. *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -52,8 +52,8 @@ let xapi_user_agent = "xapi/"^(string_of_int version_major)^"."^(string_of_int v
  *
  * Please consult the XenCenter maintainers before changing these numbers, because a corresponding change
  * will need to be made in XenCenter *)
-let xencenter_min_verstring = "2.11"
-let xencenter_max_verstring = "2.11"
+let xencenter_min_verstring = "2.12"
+let xencenter_max_verstring = "2.12"
 
 (* linux pack vsn key in host.software_version (used for a pool join restriction *)
 let linux_pack_vsn_key = "xs:linux"


### PR DESCRIPTION
This commit updates version numbers for the Naples release and adds a
record for the Oslo release.

* Database Version: 5.400
* API Version: 2.12
* Branding

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>