### PR TITLE
CP-30756: Replace Base64 library

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -3097,7 +3097,7 @@ let host_license_add fd printer rpc session_id params =
   | Some license ->
     debug "Checking license [%s]" license;
     (try
-       Client.Host.license_add rpc session_id host (Base64.encode license);
+       Client.Host.license_add rpc session_id host (Base64.encode_string license);
        marshal fd (Command (Print "License applied."))
      with _ ->
        marshal fd (Command (PrintStderr "Failed to apply license file.\n"));

--- a/ocaml/xapi/rbac_audit.ml
+++ b/ocaml/xapi/rbac_audit.ml
@@ -232,7 +232,7 @@ let zip data = (* todo: remove i/o, make this more efficient *)
               let cin = Unix.in_channel_of_descr fd_in in
               let cin_len = in_channel_length cin in
               zdata := (Bytes.create cin_len);
-              for i = 1 to cin_len do 
+              for i = 1 to cin_len do
                 Bytes.set !zdata (i-1) (input_char cin);
               done
            )

--- a/ocaml/xapi/rbac_audit.ml
+++ b/ocaml/xapi/rbac_audit.ml
@@ -240,7 +240,7 @@ let zip data = (* todo: remove i/o, make this more efficient *)
       )
       (fun ()-> Sys.remove tmp_path)
     ;
-    let b64zdata = Xapi_stdext_base64.Base64.encode (Bytes.unsafe_to_string !zdata) in
+    let b64zdata = Base64.encode_string (Bytes.unsafe_to_string !zdata) in
     b64zdata
   with e->
     D.debug "error %s zipping data: %s" (ExnHelper.string_of_exn e) data;

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -213,7 +213,7 @@ let filtered_headers headers =
     headers
 
 let encoded_auth un pw =
-  Base64.encode (Printf.sprintf "%s:%s" un pw)
+  Base64.encode_string (Printf.sprintf "%s:%s" un pw)
 
 let wlb_encoded_auth ~__context =
   let pool = Helpers.get_pool ~__context in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1467,7 +1467,7 @@ let apply_edition ~__context ~host ~edition ~force =
 let license_add ~__context ~host ~contents =
   let license =
     try
-      Base64.decode contents
+      Base64.decode_exn contents
     with _ ->
       error "Base64 decoding of supplied license has failed";
       raise Api_errors.(Server_error(license_processing_error, []))

--- a/xapi.opam
+++ b/xapi.opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "alcotest"
+  "base64"
   "cdrom"
   "ctypes"
   "ctypes-foreign"


### PR DESCRIPTION
Now we use Base64 3.1.0 instead of using the extended custom library.


The encoding functions should be safe to replace.

For the decoding there are 2 possible issues:
* The new calls could fail more frequently because not they are not sanitized anymore. (especially for gpumon)
* The exception from the call in ocaml/xapi/xapi_gpumon.ml, Line 103 are not caught: how to report the failing call?