### PR TITLE
CA-314290: Allow to specify SMBIOS type2 info from the toolstack

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1019,7 +1019,7 @@ let power_behaviour =
   let set_bios_strings = call
       ~name: "set_bios_strings"
       ~in_product_since:rel_inverness
-      ~doc:"Set custom BIOS strings to this VM. VM will be given a default set of BIOS strings, only some of which can be overridden by the supplied values. Allowed keys are: 'bios-vendor', 'bios-version', 'system-manufacturer', 'system-product-name', 'system-version', 'system-serial-number', 'enclosure-asset-tag'"
+      ~doc:"Set custom BIOS strings to this VM. VM will be given a default set of BIOS strings, only some of which can be overridden by the supplied values. Allowed keys are: 'bios-vendor', 'bios-version', 'system-manufacturer', 'system-product-name', 'system-version', 'system-serial-number', 'enclosure-asset-tag', 'baseboard-manufacturer', 'baseboard-product-name', 'baseboard-version', 'baseboard-serial-number', 'baseboard-asset-tag', 'baseboard-location-in-chassis', 'enclosure-asset-tag'"
       ~params:[Ref _vm, "self", "The VM to modify";
                Map (String, String), "value", "The custom BIOS strings as a list of key-value pairs"]
       ~allowed_roles:_R_VM_ADMIN

--- a/ocaml/tests/test_vm.ml
+++ b/ocaml/tests/test_vm.ml
@@ -44,130 +44,75 @@ module VMSetBiosStrings = Generic.Make (Generic.EncapsulateState (struct
   let bios_str1 = ["bios-vendor", "Test"; "bios-version", "Test Inc. A08"]
   let bios_str2 = ["system-manufacturer", "Test Inc."; "system-product-name", "Test bios strings"; "system-version", "8.1.1 SP1 build 8901"; "system-serial-number", "test-test-test-test"]
   let bios_str3 = ["enclosure-asset-tag", "testassettag12345"]
+  let bios_str4 = ["baseboard-manufacturer", "TestB Inc."; "baseboard-product-name", "TestB pro"; "baseboard-version", "TestB v1.0"; "baseboard-serial-number", "TestB s12345"; "baseboard-asset-tag", "TestB asset"; "baseboard-location-in-chassis", "TestB loc"]
 
-  let tests = [
-    (* Invalid BIOS string key *)
-    ["xxxx", "test"],
-    Either.Left Api_errors.(Server_error
-      (invalid_value,
-      ["xxxx"; "Unknown key"]));
+  let default_settings = [
+      "bios-vendor", "Xen";
+      "bios-version", "";
+      "system-manufacturer", "Xen";
+      "system-product-name", "HVM domU";
+      "system-version", "";
+      "system-serial-number", "";
+      "baseboard-manufacturer", "";
+      "baseboard-product-name", "";
+      "baseboard-version", "";
+      "baseboard-serial-number", "";
+      "baseboard-asset-tag", "";
+      "baseboard-location-in-chassis", "";
+      "enclosure-asset-tag", "";
+      "hp-rombios", "";
+      "oem-1", "Xen";
+      "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"]
 
-    (* Empty value *)
-    ["enclosure-asset-tag", ""],
-    Either.Left Api_errors.(Server_error
-      (invalid_value,
-      ["enclosure-asset-tag"; "Value provided is empty"]));
+  let update_list dl nl =
+      List.map (fun (k, v) -> if List.mem_assoc k nl then k, List.assoc k nl else k, v) dl
 
-    (* Value having more than 512 charactors *)
-    ["enclosure-asset-tag", big_str],
-    Either.Left Api_errors.(Server_error
-      (invalid_value,
-      ["enclosure-asset-tag"; (Printf.sprintf "%s has length more than %d characters" big_str Xapi_globs.bios_string_limit_size)]));
+  let rec combination (l:('a * 'b) list list) =
+      match l with
+      | [] -> []
+      | hd :: [] ->
+        [hd]
+      | hd :: tl ->
+        let r = combination tl in
+        hd :: (List.map (fun v -> hd @ v) r) @ r
 
-    (* Value having non printable ascii characters *)
-    ["enclosure-asset-tag", non_printable_str1],
-    Either.Left Api_errors.(Server_error
-      (invalid_value,
-      ["enclosure-asset-tag"; non_printable_str1 ^ " has non-printable ASCII characters"]));
-
-    ["enclosure-asset-tag", non_printable_str2],
-    Either.Left Api_errors.(Server_error
-      (invalid_value,
-      ["enclosure-asset-tag"; non_printable_str2 ^ " has non-printable ASCII characters"]));
-
+  let tests =
     (* Correct value *)
-    bios_str1,
-    Either.Right [
-      "bios-vendor", "Test";
-      "bios-version", "Test Inc. A08";
-      "system-manufacturer", "Xen";
-      "system-product-name", "HVM domU";
-      "system-version", "";
-      "system-serial-number", "";
-      "enclosure-asset-tag", "";
-      "hp-rombios", "";
-      "oem-1", "Xen";
-      "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"];
+    let valid_settings = combination [bios_str1; bios_str2; bios_str3; bios_str4] in
+    (List.map (fun settings ->
+         settings, Either.Right (update_list default_settings settings)
+    ) valid_settings) @
+    [
+      (* Invalid BIOS string key *)
+      ["xxxx", "test"],
+      Either.Left Api_errors.(Server_error
+        (invalid_value,
+        ["xxxx"; "Unknown key"]));
 
-    bios_str2,
-    Either.Right [
-      "bios-vendor", "Xen";
-      "bios-version", "";
-      "system-manufacturer", "Test Inc.";
-      "system-product-name", "Test bios strings";
-      "system-version", "8.1.1 SP1 build 8901";
-      "system-serial-number", "test-test-test-test";
-      "enclosure-asset-tag", "";
-      "hp-rombios", "";
-      "oem-1", "Xen";
-      "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"];
+      (* Empty value *)
+      ["enclosure-asset-tag", ""],
+      Either.Left Api_errors.(Server_error
+        (invalid_value,
+        ["enclosure-asset-tag"; "Value provided is empty"]));
 
-    bios_str3,
-    Either.Right [
-      "bios-vendor", "Xen";
-      "bios-version", "";
-      "system-manufacturer", "Xen";
-      "system-product-name", "HVM domU";
-      "system-version", "";
-      "system-serial-number", "";
-      "enclosure-asset-tag", "testassettag12345";
-      "hp-rombios", "";
-      "oem-1", "Xen";
-      "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"];
+      (* Value having more than 512 charactors *)
+      ["enclosure-asset-tag", big_str],
+      Either.Left Api_errors.(Server_error
+        (invalid_value,
+        ["enclosure-asset-tag"; (Printf.sprintf "%s has length more than %d characters" big_str Xapi_globs.bios_string_limit_size)]));
 
-    (bios_str1 @ bios_str2),
-    Either.Right [
-      "bios-vendor", "Test";
-      "bios-version", "Test Inc. A08";
-      "system-manufacturer", "Test Inc.";
-      "system-product-name", "Test bios strings";
-      "system-version", "8.1.1 SP1 build 8901";
-      "system-serial-number", "test-test-test-test";
-      "enclosure-asset-tag", "";
-      "hp-rombios", "";
-      "oem-1", "Xen";
-      "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"];
+      (* Value having non printable ascii characters *)
+      ["enclosure-asset-tag", non_printable_str1],
+      Either.Left Api_errors.(Server_error
+        (invalid_value,
+        ["enclosure-asset-tag"; non_printable_str1 ^ " has non-printable ASCII characters"]));
 
-    (bios_str1 @ bios_str3),
-    Either.Right [
-      "bios-vendor", "Test";
-      "bios-version", "Test Inc. A08";
-      "system-manufacturer", "Xen";
-      "system-product-name", "HVM domU";
-      "system-version", "";
-      "system-serial-number", "";
-      "enclosure-asset-tag", "testassettag12345";
-      "hp-rombios", "";
-      "oem-1", "Xen";
-      "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"];
-
-    (bios_str2 @ bios_str3),
-    Either.Right [
-      "bios-vendor", "Xen";
-      "bios-version", "";
-      "system-manufacturer", "Test Inc.";
-      "system-product-name", "Test bios strings";
-      "system-version", "8.1.1 SP1 build 8901";
-      "system-serial-number", "test-test-test-test";
-      "enclosure-asset-tag", "testassettag12345";
-      "hp-rombios", "";
-      "oem-1", "Xen";
-      "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"];
-
-    (bios_str1 @ bios_str2 @ bios_str3),
-    Either.Right [
-      "bios-vendor", "Test";
-      "bios-version", "Test Inc. A08";
-      "system-manufacturer", "Test Inc.";
-      "system-product-name", "Test bios strings";
-      "system-version", "8.1.1 SP1 build 8901";
-      "system-serial-number", "test-test-test-test";
-      "enclosure-asset-tag", "testassettag12345";
-      "hp-rombios", "";
-      "oem-1", "Xen";
-      "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"];
-
+      ["enclosure-asset-tag", non_printable_str2],
+      Either.Left Api_errors.(Server_error
+        (invalid_value,
+        ["enclosure-asset-tag"; non_printable_str2 ^ " has non-printable ASCII characters"]));
   ]
+
 end))
 
 let test =

--- a/ocaml/xapi/bios_strings.ml
+++ b/ocaml/xapi/bios_strings.ml
@@ -73,7 +73,10 @@ let get_host_bios_strings ~__context =
   info "Getting host BIOS strings.";
   (* named BIOS strings *)
   let dmidecode_strings = ["bios-vendor"; "bios-version"; "system-manufacturer";
-                           "system-product-name"; "system-version"; "system-serial-number"] in
+                           "system-product-name"; "system-version"; "system-serial-number";
+                           "baseboard-manufacturer"; "baseboard-product-name";
+                           "baseboard-version"; "baseboard-serial-number";
+                           ] in
   let named_strings = List.map (fun str -> str, (get_bios_string str)) dmidecode_strings in
   (* type 11 OEM strings *)
   let oem_strings = get_oem_strings () in

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -501,6 +501,12 @@ let settable_vm_bios_string_keys =
    "system-product-name";
    "system-version";
    "system-serial-number";
+   "baseboard-manufacturer";
+   "baseboard-product-name";
+   "baseboard-version";
+   "baseboard-serial-number";
+   "baseboard-asset-tag";
+   "baseboard-location-in-chassis";
    "enclosure-asset-tag"]
 
 (** Type 11 strings that are always included *)
@@ -516,6 +522,12 @@ let generic_bios_strings =
    "system-product-name", "HVM domU";
    "system-version", "";
    "system-serial-number", "";
+   "baseboard-manufacturer", "";
+   "baseboard-product-name", "";
+   "baseboard-version", "";
+   "baseboard-serial-number", "";
+   "baseboard-asset-tag", "";
+   "baseboard-location-in-chassis", "";
    "enclosure-asset-tag", "";
    "hp-rombios", ""] @ standard_type11_strings
 


### PR DESCRIPTION
The SMBIOS type 2 info is required for some guest app to run properly.
This commit let the toolstack accept those strings and write to xenstore.

Signed-off-by: Talons Lee <xin.li@citrix.com>