### PR TITLE
CA-312226 XSI-251 clear unexpected vGPU metadata on shutdown

### DIFF
--- a/ocaml/xapi/xapi_gpumon.ml
+++ b/ocaml/xapi/xapi_gpumon.ml
@@ -202,7 +202,8 @@ let update_vgpu_metadata ~__context ~vm =
         if Nvidia.is_nvidia ~__context ~vgpu then
           Nvidia.get_vgpu_compatibility_metadata ~__context ~vgpu
         else [] in
-      Db.VGPU.set_compatibility_metadata ~__context ~self:vgpu ~value)
+      Db.VGPU.set_compatibility_metadata ~__context ~self:vgpu ~value;
+      debug "writing vGPU compat metadata for vGPU %s" (Ref.string_of vgpu))
 
 (** [clear_vgpu_metadata] removes compatibility metadata from all
  * vgpus of [vm]. *)
@@ -213,6 +214,7 @@ let clear_vgpu_metadata ~__context ~vm =
       Db.VGPU.get_compatibility_metadata ~__context ~self:vgpu
       |> List.filter (fun (k,_) -> k <> Nvidia.key)
       |> fun value ->
-      Db.VGPU.set_compatibility_metadata ~__context ~self:vgpu ~value)
+      Db.VGPU.set_compatibility_metadata ~__context ~self:vgpu ~value;
+      debug "clearing vGPU compat metadata for vGPU %s" (Ref.string_of vgpu))
 
 


### PR DESCRIPTION
A vGPU is supposed to hold vGPU compatibility metadata only while it is
suspended. Beyond that, it can deadlock the start of other machines as
it causes gpumon being contacted in vgpu_pgpu_are_compatible() while
gpumon might be is stopped as part of VM.start of another VM. This
commit adds code to detect, log, and remove this metadata when a VM is
halted to avoid the problem.  We still need to find the root cause why
the situation can arise in the first place.
    
Signed-off-by: Christian Lindig <christian.lindig@citrix.com>
