### PR TITLE
REQ-720: CP-31058: Datamodel changes for multiple Nvidia VGPU support

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4823,7 +4823,9 @@ module VGPU_type = struct
         field ~qualifier:DynamicRO ~ty:(Set (Ref _gpu_group)) ~lifecycle:[Published, rel_vgpu_productisation, ""] "enabled_on_GPU_groups" "List of GPU groups in which at least one have this VGPU type enabled";
         field ~qualifier:StaticRO ~ty:implementation ~lifecycle:[Published, rel_dundee, ""] ~default_value:(Some (VEnum "passthrough")) "implementation" "The internal implementation of this VGPU type";
         field ~qualifier:StaticRO ~ty:String ~lifecycle:[Published, rel_dundee, ""] ~default_value:(Some (VString "")) "identifier" "Key used to identify VGPU types and avoid creating duplicates - this field is used internally and not intended for interpretation by API clients";
-        field ~qualifier: StaticRO ~ty:Bool ~lifecycle:[Published, rel_dundee, ""] ~default_value:(Some (VBool false)) "experimental" "Indicates whether VGPUs of this type should be considered experimental";
+        field ~qualifier:StaticRO ~ty:Bool ~lifecycle:[Published, rel_dundee, ""] ~default_value:(Some (VBool false)) "experimental" "Indicates whether VGPUs of this type should be considered experimental";
+        field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle:[Published, rel_plymouth, ""] ~default_value:(Some (VSet [])) "compatible_types_in_vm" "List of VGPU types which are compatible in one VM";
+        field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle:[Published, rel_plymouth, ""] ~internal_only:true ~default_value:(Some (VSet [])) "compatible_types_on_pgpu" "List of VGPU types which are compatible on one PGPU";
       ]
       ()
 end

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 400
+let schema_minor_vsn = 401
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/tests/test_common.ml
+++ b/ocaml/tests/test_common.ml
@@ -370,10 +370,12 @@ let make_vgpu_type ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ?(vendor_name="") ?(model_name="") ?(framebuffer_size=0L) ?(max_heads=0L)
     ?(max_resolution_x=0L) ?(max_resolution_y=0L) ?(size=0L)
     ?(internal_config=[]) ?(implementation=`passthrough)
-    ?(identifier="") ?(experimental=false) () =
+    ?(identifier="") ?(experimental=false)
+    ?(compatible_types_in_vm=[]) ?(compatible_types_on_pgpu=[]) () =
   Db.VGPU_type.create ~__context ~ref ~uuid ~vendor_name ~model_name
     ~framebuffer_size ~max_heads ~max_resolution_x ~max_resolution_y ~size
-    ~internal_config ~implementation ~identifier ~experimental;
+    ~internal_config ~implementation ~identifier ~experimental
+    ~compatible_types_in_vm ~compatible_types_on_pgpu;
   ref
 
 let make_pvs_site ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())

--- a/ocaml/tests/test_vgpu_common.ml
+++ b/ocaml/tests/test_vgpu_common.ml
@@ -32,6 +32,8 @@ let k100 = {
       vsubdev_id = 0x101e;
     });
   experimental = false;
+  compatible_types_in_vm = [];
+  compatible_types_on_pgpu = [];
 }
 
 let k140q = {
@@ -52,6 +54,8 @@ let k140q = {
       vsubdev_id = 0x1037;
     });
   experimental = false;
+  compatible_types_in_vm = [];
+  compatible_types_on_pgpu = [];
 }
 
 let k200 = {
@@ -72,6 +76,8 @@ let k200 = {
       vsubdev_id = 0x101d;
     });
   experimental = false;
+  compatible_types_in_vm = [];
+  compatible_types_on_pgpu = [];
 }
 
 let k240q = {
@@ -92,6 +98,8 @@ let k240q = {
       vsubdev_id = 0x101a;
     });
   experimental = false;
+  compatible_types_in_vm = [];
+  compatible_types_on_pgpu = [];
 }
 
 let k260q = {
@@ -112,6 +120,8 @@ let k260q = {
       vsubdev_id = 0x101b;
     });
   experimental = false;
+  compatible_types_in_vm = [];
+  compatible_types_on_pgpu = [];
 }
 
 let k1_vgpu_types = [
@@ -147,6 +157,8 @@ let gvt_g_041a = {
       fence_sz = 4L;
     });
   experimental = false;
+  compatible_types_in_vm = [];
+  compatible_types_on_pgpu = [];
 }
 
 let intel_041a_vgpu_types = [

--- a/ocaml/tests/test_vgpu_type.ml
+++ b/ocaml/tests/test_vgpu_type.ml
@@ -62,6 +62,8 @@ module NvidiaTest = struct
             max_x = 1920L;
             max_y = 1200L;
             file_path = "test_data/test_vgpu_subdevid.conf";
+            compatible_types_in_vm = [];
+            compatible_types_on_pgpu = [];
           });
         "test_data/test_vgpu_nosubdevid.conf",
         Nvidia_old.({
@@ -77,6 +79,8 @@ module NvidiaTest = struct
             max_x = 1920L;
             max_y = 1200L;
             file_path = "test_data/test_vgpu_nosubdevid.conf";
+            compatible_types_in_vm = [];
+            compatible_types_on_pgpu = [];
           });
       ]
     end)
@@ -131,6 +135,8 @@ module NvidiaTest = struct
               max_x = 1920L;
               max_y = 1200L;
               file_path = "test_data/nvidia-whitelist.xml";
+              compatible_types_in_vm = [];
+              compatible_types_on_pgpu = [];
             })
         ];
         ("test_data/nvidia-whitelist.xml", 0x3334),
@@ -148,6 +154,8 @@ module NvidiaTest = struct
               max_x = 1920L;
               max_y = 1200L;
               file_path = "test_data/nvidia-whitelist.xml";
+              compatible_types_in_vm = [];
+              compatible_types_on_pgpu = [];
             })
         ];
         ("test_data/nvidia-whitelist.xml", 0x3335),
@@ -165,6 +173,8 @@ module NvidiaTest = struct
               max_x = 2400L;
               max_y = 1600L;
               file_path = "test_data/nvidia-whitelist.xml";
+              compatible_types_in_vm = [];
+              compatible_types_on_pgpu = [];
             });
           Vendor_nvidia.({
               identifier = Identifier.({
@@ -179,6 +189,8 @@ module NvidiaTest = struct
               max_x = 1920L;
               max_y = 1200L;
               file_path = "test_data/nvidia-whitelist.xml";
+              compatible_types_in_vm = [];
+              compatible_types_on_pgpu = [];
             })
         ];
         

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2738,7 +2738,7 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
     "vgpu-create",
     {
       reqd=["vm-uuid";"gpu-group-uuid"];
-      optn=["vgpu-type-uuid"]; (* "device" should be added here once we allow >1 vGPU/VM *)
+      optn=["vgpu-type-uuid"; "device"];
       help="Create a vGPU.";
       implementation=No_fd Cli_operations.vgpu_create;
       flags=[];

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1199,7 +1199,9 @@ module VGPUType : HandlerTools = struct
                  ~internal_config:[]
                  ~implementation:value.API.vGPU_type_implementation
                  ~identifier:value.API.vGPU_type_identifier
-                 ~experimental:value.API.vGPU_type_experimental)
+                 ~experimental:value.API.vGPU_type_experimental
+                 ~compatible_types_in_vm:value.API.vGPU_type_compatible_types_in_vm
+                 ~compatible_types_on_pgpu:[])
             vgpu_type_record
         in
         state.cleanup <- (fun __context rpc session_id -> Db.VGPU_type.destroy __context vgpu_type) :: state.cleanup;

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -1748,6 +1748,7 @@ let vgpu_record rpc session_id vgpu =
       make_field ~name:"uuid" ~get:(fun () -> (x ()).API.vGPU_uuid) ();
       make_field ~name:"vm-uuid" ~get:(fun () -> get_uuid_from_ref (x ()).API.vGPU_VM) ();
       make_field ~name:"vm-name-label" ~get:(fun () -> get_name_from_ref (x ()).API.vGPU_VM) ();
+      make_field ~name:"device" ~get:(fun () -> (x ()).API.vGPU_device) ();
       make_field ~name:"gpu-group-uuid" ~get:(fun () -> try get_uuid_from_ref (x ()).API.vGPU_GPU_group with _ -> nid) ();
       make_field ~name:"gpu-group-name-label" ~get:(fun () -> try get_name_from_ref (x ()).API.vGPU_GPU_group with _ -> nid) ();
       make_field ~name:"currently-attached" ~get:(fun () -> string_of_bool (x ()).API.vGPU_currently_attached) ();
@@ -1800,6 +1801,8 @@ let vgpu_type_record rpc session_id vgpu_type =
       make_field ~name:"VGPU-uuids" ~get:(fun () -> String.concat "; " (List.map (fun v -> get_uuid_from_ref v) (x ()).API.vGPU_type_VGPUs)) ();
       make_field ~name:"experimental"
         ~get:(fun () -> string_of_bool (x ()).API.vGPU_type_experimental) ();
+      make_field ~name:"compatible-types-in-vm"
+        ~get:(fun () -> String.concat "; " (x ()).API.vGPU_type_compatible_types_in_vm) ();
     ]
   }
 

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -102,6 +102,8 @@ type vgpu_type = {
   internal_config : (string * string) list;
   identifier : Identifier.t;
   experimental : bool;
+  compatible_types_in_vm : string list;
+  compatible_types_on_pgpu : string list;
 }
 
 let passthrough_gpu = {
@@ -115,16 +117,19 @@ let passthrough_gpu = {
   internal_config = [];
   identifier = Identifier.Passthrough;
   experimental = false;
+  compatible_types_in_vm = [];
+  compatible_types_on_pgpu = [];
 }
 
 let create ~__context ~vendor_name ~model_name ~framebuffer_size ~max_heads
     ~max_resolution_x ~max_resolution_y ~size ~internal_config ~implementation
-    ~identifier ~experimental =
+    ~identifier ~experimental ~compatible_types_in_vm ~compatible_types_on_pgpu =
   let ref = Ref.make () in
   let uuid = Uuidm.to_string (Uuidm.create `V4) in
   Db.VGPU_type.create ~__context ~ref ~uuid ~vendor_name ~model_name
     ~framebuffer_size ~max_heads ~max_resolution_x ~max_resolution_y
-    ~size ~internal_config ~implementation ~identifier ~experimental;
+    ~size ~internal_config ~implementation ~identifier ~experimental
+    ~compatible_types_in_vm ~compatible_types_on_pgpu;
   debug "VGPU_type ref='%s' created (vendor_name = '%s'; model_name = '%s')"
     (Ref.string_of ref) vendor_name model_name;
   ref
@@ -215,6 +220,14 @@ let find_or_create ~__context vgpu_type =
       Db.VGPU_type.set_experimental ~__context
         ~self:vgpu_type_ref
         ~value:vgpu_type.experimental;
+    if vgpu_type.compatible_types_in_vm <> rc.Db_actions.vGPU_type_compatible_types_in_vm then
+      Db.VGPU_type.set_compatible_types_in_vm ~__context
+        ~self:vgpu_type_ref
+        ~value:vgpu_type.compatible_types_in_vm;
+    if vgpu_type.compatible_types_on_pgpu <> rc.Db_actions.vGPU_type_compatible_types_on_pgpu then
+      Db.VGPU_type.set_compatible_types_on_pgpu ~__context
+        ~self:vgpu_type_ref
+        ~value:vgpu_type.compatible_types_on_pgpu;
     vgpu_type_ref
   | None ->
     create ~__context ~vendor_name:vgpu_type.vendor_name
@@ -228,6 +241,8 @@ let find_or_create ~__context vgpu_type =
       ~implementation
       ~identifier:(Identifier.to_string vgpu_type.identifier)
       ~experimental:vgpu_type.experimental
+      ~compatible_types_in_vm:vgpu_type.compatible_types_in_vm
+      ~compatible_types_on_pgpu:vgpu_type.compatible_types_on_pgpu 
 
 
 module Passthrough = struct
@@ -253,6 +268,8 @@ module Nvidia_old = struct
     max_x : int64;
     max_y : int64;
     file_path : string;
+    compatible_types_in_vm : string list;
+    compatible_types_on_pgpu : string list;
   }
 
   let of_conf_file file_path =
@@ -280,6 +297,7 @@ module Nvidia_old = struct
             (fun pdev_id -> pdev_id, None)
       in
       (* NVIDIA key is "device_id:subdevice_id", N.B. not subvendor id *)
+      (* Since old config file doesn't include multiple or compatible list, define empty list here *)
       Scanf.sscanf (List.assoc "plugin0.vdev_id" args) "\"0x%x:0x%x\"" (fun vdev_id vsubdev_id ->
           Scanf.sscanf (List.assoc "plugin0.max_resolution" args) "%Ldx%Ld" (fun max_x max_y ->
               let framebufferlength = Int64.of_string
@@ -294,8 +312,11 @@ module Nvidia_old = struct
                   vdev_id;
                   vsubdev_id;
                 }) in
+              let compatible_types_in_vm = [] in
+              let compatible_types_on_pgpu = [] in
               {identifier; framebufferlength;
-               num_heads; max_instance; max_x; max_y; file_path}
+               num_heads; max_instance; max_x; max_y; file_path; 
+               compatible_types_in_vm; compatible_types_on_pgpu}
             )
         )
     with e ->
@@ -376,11 +397,13 @@ module Nvidia_old = struct
         and size = Int64.div Constants.pgpu_default_size conf.max_instance
         and internal_config = [Xapi_globs.vgpu_config_key, conf.file_path]
         and identifier = Nvidia conf.identifier
-        and experimental = false in
+        and experimental = false
+        and compatible_types_in_vm = []
+        and compatible_types_on_pgpu = [] in
         let vgpu_type = {
           vendor_name; model_name; framebuffer_size; max_heads;
           max_resolution_x; max_resolution_y; size; internal_config;
-          identifier; experimental}
+          identifier; experimental; compatible_types_in_vm; compatible_types_on_pgpu}
         in
         build_vgpu_types pci_access (vgpu_type :: ac) tl
     in
@@ -467,24 +490,25 @@ module Vendor = functor (V : VENDOR) -> struct
       ~is_pci_hidden =
     let vgpu_types = make_vgpu_types ~__context ~pci in
     (* Temporarily fall back to old nvidia module *)
-    if vendor_id = Nvidia_old.vendor_id then begin
+    info "Using new Nvidia config file";
+    (* if vendor_id = Nvidia_old.vendor_id then begin
       info "Temporarily fall back to old nvidia conf file parser";
       Nvidia_old.find_or_create_supported_types ~__context ~pci
         ~is_system_display_device
         ~is_host_display_enabled
         ~is_pci_hidden
-    end else
-      let passthrough_types =
-        if is_system_display_device && (is_host_display_enabled || not is_pci_hidden)
-        then []
-        else [passthrough_gpu]
-      in
-      let types = match V.pt_when_vgpu, passthrough_types, vgpu_types with
-        | false, passthrough_types, [] -> passthrough_types
-        | false, _, vgpu_types -> vgpu_types
-        | true, passthrough_types, vgpu_types -> passthrough_types @ vgpu_types
-      in
-      List.map (find_or_create ~__context) types
+    end else *)
+    let passthrough_types =
+      if is_system_display_device && (is_host_display_enabled || not is_pci_hidden)
+      then []
+      else [passthrough_gpu]
+    in
+    let types = match V.pt_when_vgpu, passthrough_types, vgpu_types with
+      | false, passthrough_types, [] -> passthrough_types
+      | false, _, vgpu_types -> vgpu_types
+      | true, passthrough_types, vgpu_types -> passthrough_types @ vgpu_types
+    in
+    List.map (find_or_create ~__context) types
 end
 
 let read_whitelist_line_by_line ~whitelist ~device_id ~parse_line ~device_id_of_conf =
@@ -507,6 +531,8 @@ module Vendor_nvidia = struct
     max_x : int64;
     max_y : int64;
     file_path : string;
+    compatible_types_in_vm : string list;
+    compatible_types_on_pgpu : string list;
   }
 
   let vendor_id = 0x10de
@@ -601,8 +627,21 @@ module Vendor_nvidia = struct
             vsubdev_id = int_of_string (get_attr "subsystemId" devid);
           } in
         let file_path = whitelist in
+        (* Multiple vgpu support:
+           - Read  'multiVgpuSupported' from config, 1L indicates this type support multiple 
+           - Currently always initialize 'compatible_types_on_pgpu' to itself only since we 
+             don't support yet *)
+        let multi_vgpu_supported = Int64.of_string (get_data (find_one_by_name "multiVgpuSupported" vgpu_type)) in
+        info "Getting multiple vGPU supported from config file: %Ld" multi_vgpu_supported;
+        let name = get_attr "name" vgpu_type in
+        let compatible_types_in_vm, compatible_types_on_pgpu = 
+          match multi_vgpu_supported with
+          | 1L -> [name], [name]
+          | _ -> [], [name]
+        in
         Some {identifier; framebufferlength;
-         num_heads; max_instance; max_x; max_y; file_path}
+         num_heads; max_instance; max_x; max_y; file_path;
+         compatible_types_in_vm; compatible_types_on_pgpu}
       else
         None
     ) vgpu_types
@@ -652,6 +691,8 @@ module Vendor_nvidia = struct
       internal_config = [Xapi_globs.vgpu_config_key, conf.file_path];
       identifier = Nvidia conf.identifier;
       experimental = false;
+      compatible_types_in_vm = conf.compatible_types_in_vm;
+      compatible_types_on_pgpu = conf.compatible_types_on_pgpu;
     }
 end
 
@@ -753,6 +794,8 @@ module Vendor_intel = struct
         internal_config = internal_config;
         identifier = GVT_g conf.identifier;
         experimental = conf.experimental;
+        compatible_types_in_vm = [];
+        compatible_types_on_pgpu = [conf.model_name];
       }
 end
 
@@ -829,6 +872,8 @@ module Vendor_amd = struct
         internal_config = internal_config;
         identifier = MxGPU conf.identifier;
         experimental = conf.experimental;
+        compatible_types_in_vm = [];
+        compatible_types_on_pgpu = [conf.model_name];
       }
 
 end


### PR DESCRIPTION
 - Add compatible_types_in_vm and compatible_types_on_pgpu into
   vgpu_type, show the first one in parameter list.
 - Change to use new way to read from NVIDIA config file and
   initilize compatible* list.
 - Add device as an option paramater in vgpu.create and show
   in parameter list.
 - Update test cases accordingly.

 Signed-off-by: Min Li <min.li1@citrix.com>