### PR TITLE
Zstd VM export take 2

### DIFF
--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -62,6 +62,7 @@ type feature =
   | USB_passthrough
   | Network_sriov
   | Corosync
+  | Zstd_export
 [@@deriving rpc]
 
 type orientation = Positive | Negative
@@ -113,6 +114,7 @@ let keys_of_features =
     USB_passthrough, ("restrict_usb_passthrough", Negative, "USB_passthrough");
     Network_sriov, ("restrict_network_sriov", Negative, "Network_sriov");
     Corosync, ("restrict_corosync", Negative, "Corosync");
+    Zstd_export, ("restrict_zstd_export", Negative, "Zstd_export");
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi-types/features.mli
+++ b/ocaml/xapi-types/features.mli
@@ -62,6 +62,7 @@ type feature =
   | USB_passthrough              (** Enable the use of USB passthrough. *)
   | Network_sriov                (** Enable the use of Network SRIOV. *)
   | Corosync                     (** Enable the use of corosync. *)
+  | Zstd_export                  (** Enable the use of VM export with zstd compression. *)
 
 (** Convert RPC into {!feature}s *)
 val feature_of_rpc : Rpc.t -> feature

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -84,6 +84,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-xenopsd
    xapi-netdev
    yojson
+   zstd
   )
   (preprocess (pps ppx_deriving_rpc %s))
 )

--- a/ocaml/xapi/export.ml
+++ b/ocaml/xapi/export.ml
@@ -605,8 +605,21 @@ let handler (req: Request.t) s _ =
 
   Xapi_http.assert_credentials_ok "VM.export" ~http_action:"get_export" req s;
 
-  let use_compression = List.mem_assoc Constants.use_compression req.Request.query && List.assoc Constants.use_compression req.Request.query = "true" in
-  debug "Using compression: %b" use_compression;
+  let compression_algorithm =
+    if List.mem_assoc Constants.use_compression req.Request.query
+    then
+      match List.assoc Constants.use_compression req.Request.query with
+      | "true" | "gzip" -> Some Gzip
+      | "zstd"          -> Some Zstd
+      | _               -> None
+    else None
+  in
+
+  debug "Using compression: %s"
+    (match compression_algorithm with
+    | Some Gzip -> "Gzip"
+    | Some Zstd -> "Zstd"
+    | None      -> "None");
   (* Perform the SR reachability check using a fresh context/task because
      we don't want to complete the task in the forwarding case *)
 
@@ -674,9 +687,10 @@ let handler (req: Request.t) s _ =
                     (fun () ->
                        Http_svr.headers s headers;
                        let go fd = export refresh_session __context rpc session_id fd vm_ref preserve_power_state in
-                       if use_compression
-                       then Gzip.compress s go
-                       else go s
+                       match compression_algorithm with
+                       | Some Gzip -> Gzip.compress s go
+                       | Some Zstd -> Zstd.compress s go
+                       | None      -> go s
                     )
 
                  (* Exceptions are handled by Xapi_http.with_context *)

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1462,11 +1462,11 @@ let assert_filename_is hdr =
 
 (** Takes an fd and a function, tries first to read the first tar block
     and checks for the existence of 'ova.xml'. If that fails then pipe
-    the lot through gzip and try again *)
+    the lot through an appropriate decompressor and try again *)
 let with_open_archive fd ?length f =
   (* Read the first header's worth into a buffer *)
   let buffer = Cstruct.create Tar_unix.Header.length in
-  let retry_with_gzip = ref true in
+  let retry_with_compression = ref true in
   try
     Tar_unix.really_read fd buffer;
 
@@ -1475,16 +1475,39 @@ let with_open_archive fd ?length f =
     assert_filename_is hdr;
 
     (* successfully opened uncompressed stream *)
-    retry_with_gzip := false;
+    retry_with_compression := false;
     let xml = read_xml hdr fd in
     Tar_unix.Archive.skip fd (Tar_unix.Header.compute_zero_padding_length hdr);
     f xml fd
   with e ->
-    if not(!retry_with_gzip) then raise e;
-    debug "Failed to directly open the archive; trying gzip";
+    if not(!retry_with_compression) then raise e;
+
+    let decompress =
+      (* discern whether the file is compressed with gzip or zstd *)
+      let gzip_magic = "\x1f\x8b" in
+      let zstd_magic = "\x28\xb5\x2f\xfd" in
+      let gzip =
+        Cstruct.equal
+          (Cstruct.of_string gzip_magic)
+          (Cstruct.sub buffer 0 (String.length gzip_magic))
+      in
+      let zstd =
+        Cstruct.equal
+          (Cstruct.of_string zstd_magic)
+          (Cstruct.sub buffer 0 (String.length zstd_magic))
+      in
+      if gzip then begin
+        debug "Failed to directly open the archive; trying gzip";
+        Gzip.decompress
+      end else if zstd then begin
+        debug "Failed to directly open the archive; trying zstd";
+        Zstd.decompress
+      end else raise e
+    in
+
     let feeder pipe_in = finally
         (fun () ->
-           Gzip.decompress pipe_in
+           decompress pipe_in
              (fun compressed_in ->
                 (* Write the initial buffer *)
                 Unix.set_close_on_exec compressed_in;

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -34,6 +34,11 @@ type version = {
   export_vsn: int; (* 0 if missing, indicates eg whether to expect sha1sums in the stream *)
 }
 
+(** Supported compression algorithms *)
+type compression_algorithm =
+  | Gzip
+  | Zstd
+
 let rpc_of_version x =
   let open Xapi_globs in
   Rpc.Dict(

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -39,6 +39,17 @@ type compression_algorithm =
   | Gzip
   | Zstd
 
+let compression_algorithm_of_string = function
+  | "true"
+  | "gzip" -> Some Gzip
+  | "zstd" -> Some Zstd
+  | _      -> None
+
+let string_of_compression_algorithm = function
+  | None      -> "false"
+  | Some Gzip -> "gzip"
+  | Some Zstd -> "zstd"
+
 let rpc_of_version x =
   let open Xapi_globs in
   Rpc.Dict(

--- a/xapi.opam
+++ b/xapi.opam
@@ -57,6 +57,7 @@ depends: [
   "xenctrl"
   "xml-light2"
   "yojson"
+  "zstd"
 ]
 depexts: [
   ["hwdata" "libpci-dev" "libpam-dev"] {os-distribution = "debian"}


### PR DESCRIPTION
This is just cherry-picked from the original pull request, #3797, with one extra commit that changes the logic for trying gzip - now xapi will attempt to decompress with gzip any file that is not an uncompressed tar file or compressed with zstd.

Hopefully this will reduce the risk of regression. I have tested importing uncompressed archives, as well as archives compressed with gzip, zip and zstd.