### PR TITLE
CA-314381: fix race condition in secure boot startup

### DIFF
--- a/.travis-xs-opam.sh
+++ b/.travis-xs-opam.sh
@@ -3,7 +3,7 @@
 set -ex
 
 PACKAGE="xapi"
-PINS="xapi:."
+PINS="xapi:. xapi-cli-protocol:. xapi-client:. xapi-consts:. xapi-database:. xapi-datamodel:. xapi-types:. xe:."
 BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
 DISTRO="debian-9-ocaml-4.07"
 


### PR DESCRIPTION
```
VM1                                 VM2
Sys.file_exists ... -> false
create xapi_uefi_certificates.tar  Sys.file_exists ... -> false
                                   create xapi_uefi_certificates.tar
extract xapi_uefi_certificates.tar
remove xapi_uefi_certificates.tar
                                   extract xapi_uefi_certificates.tar:ENOENT
```

The race condition could be solved either with a lock, or with using
unique names for temporary files.
This patch uses unique names for the temporary file to avoid the race
condition.
