### PR TITLE
CA-315107 Create xapi-init-complete systemd target

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -58,6 +58,8 @@ install:
 	$(IDATA) attach-static-vdis.service $(DESTDIR)/usr/lib/systemd/system/attach-static-vdis.service
 	$(IDATA) save-boot-info.service $(DESTDIR)/usr/lib/systemd/system/save-boot-info.service
 	$(IDATA) mpathalert.service $(DESTDIR)/usr/lib/systemd/system/mpathalert.service
+	$(IDATA) xapi-init-complete.target $(DESTDIR)/usr/lib/systemd/system/xapi-init-complete.target
+	$(IDATA) xapi-wait-init-complete.service $(DESTDIR)/usr/lib/systemd/system/xapi-wait-init-complete.service
 	mkdir -p $(DESTDIR)$(ETCDIR)/master.d
 	$(IPROG) on-master-start $(DESTDIR)$(ETCDIR)/master.d/01-example
 	$(IPROG) mpathalert-daemon $(DESTDIR)$(ETCDIR)/master.d/03-mpathalert-daemon

--- a/scripts/xapi-autostart-vms
+++ b/scripts/xapi-autostart-vms
@@ -9,18 +9,10 @@
 
 [ -e /proc/xen ] || exit 0
 
-XAPI_START_TIMEOUT_SECONDS=240
+auto_poweron_pool=$(xe pool-list params=uuid other-config:auto_poweron=true --minimal 2> /dev/null)
 
-# wait for xapi to complete initialisation for a max of XAPI_START_TIMEOUT_SECONDS
-@BINDIR@/xapi-wait-init-complete ${XAPI_START_TIMEOUT_SECONDS}
-
-if [ $? -eq 0 ]; then
-
-	auto_poweron_pool=$(xe pool-list params=uuid other-config:auto_poweron=true --minimal 2> /dev/null)
-	
-	if [ $? -eq 0 ] && [ -n "$auto_poweron_pool" ]; then
-		logger "$0 auto_poweron is enabled on the pool-- this is an unsupported configuration."
-		# if xapi init completed then start vms (best effort, don't report errors)
-		xe vm-start other-config:auto_poweron=true power-state=halted --multiple >/dev/null 2>/dev/null || true
-	fi
+if [ $? -eq 0 ] && [ -n "$auto_poweron_pool" ]; then
+    logger "$0 auto_poweron is enabled on the pool-- this is an unsupported configuration."
+    # if xapi init completed then start vms (best effort, don't report errors)
+    xe vm-start other-config:auto_poweron=true power-state=halted --multiple >/dev/null 2>/dev/null || true
 fi

--- a/scripts/xapi-domains.service
+++ b/scripts/xapi-domains.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Start/stop domains on dom0 start/shutdown
 Requires=proc-xen.mount
-After=remote-fs.target xapi.service
+Wants=xapi-init-complete.target
+After=remote-fs.target xapi-init-complete.target
 
 [Service]
 Type=oneshot

--- a/scripts/xapi-init-complete.target
+++ b/scripts/xapi-init-complete.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Xapi is available
+After=syslog.target
+After=time-sync.target

--- a/scripts/xapi-wait-init-complete.service
+++ b/scripts/xapi-wait-init-complete.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Wait for Xapi to complete initialisation
+Requires=xapi.service
+After=xapi.service
+Before=xapi-init-complete.target
+
+[Service]
+Type=oneshot
+ExecStart=@BINDIR@/xapi-wait-init-complete 240
+RemainAfterExit=yes
+
+[Install]
+WantedBy=xapi-init-complete.target


### PR DESCRIPTION
Create a xapi-init-complete.target and a xapi-wait-init-complete.service
which is wanted by it. The service invokes the existing
xapi-wait-init-complete so that it is only done in one place now.

The SPEC file will need altering to enable the xapi-wait-init-complete
service on installation.

xapi-domains.service (and any other service which needs to start after
Xapi has completed initialisation) can now declare

Wants=xapi-init-complete.target
After=xapi-init-complete.target

to ensure that Xapi will be done initialising before they are started.