### PR TITLE
Move jemalloc into xapi.service (was: CA-289625)

### DIFF
--- a/scripts/init.d-xapi
+++ b/scripts/init.d-xapi
@@ -46,10 +46,6 @@ start() {
             fi
 	fi
 
-	# Let's have jemalloc
-	export LD_PRELOAD="/usr/lib64/libjemalloc.so.1"
-	export MALLOC_CONF="narenas:1,tcache:false,lg_dirty_mult:22"
-
 	if [ -e ${XAPI_BOOT_TIME_INFO_UPDATED} ]; then
 	    # clear out qemu coredumps/chroot dirs on system boot:
 	    rm -rf /var/xen/qemu/*

--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -19,6 +19,8 @@ After=xenstored.service
 Conflicts=shutdown.target
 
 [Service]
+Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
+Environment="MALLOC_CONF=narenas:1,tcache:false,lg_dirty_mult:22"
 Type=simple
 Restart=on-failure
 ExecStart=@LIBEXECDIR@/xapi-init start


### PR DESCRIPTION
We set environment variables to make xapi use the jemalloc library. Move
the code for this into the systemd service file to align with other
toolstack daemons.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>