### PR TITLE
CA-316165: workaround - disable nondeterministic unit test

### DIFF
--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -50,6 +50,6 @@ let () =
     ; "Test_vm_placement", Test_vm_placement.test
     ; "Test_vm_memory_constraints", Test_vm_memory_constraints.test
     ; "Test_xapi_xenops", Test_xapi_xenops.test
-    ; "Test_network_event_loop", Test_network_event_loop.test
+    (* ; "Test_network_event_loop", Test_network_event_loop.test disabled due to CA-316165 *)
     ]
 


### PR DESCRIPTION
It uses Thread.delay and assumes that events get processed within 0.4s.
That may not be enough if the CI is under high load.

Should be replaced with looking for events and a (larger) timeout
instead. Disable for now to restore build stability.