### PR TITLE
CA-316165: workaround - disable CBT unit tests

### DIFF
--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -18,7 +18,7 @@ let () =
     ; "Test_xapi_vbd_helpers", Test_xapi_vbd_helpers.test
     ; "Test_host", Test_host.test
     ; "Test_host_helpers", Test_host_helpers.test
-    ; "Test_vdi_cbt", Test_vdi_cbt.test
+    (* ; "Test_vdi_cbt", Test_vdi_cbt.test *)
     ; "Test_sr_update_vdis", Test_sr_update_vdis.test
     ; "Test_xapi_db_upgrade", Test_xapi_db_upgrade.test
     ; "Test_db_lowlevel", Test_db_lowlevel.test

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -18,7 +18,7 @@ let () =
     ; "Test_xapi_vbd_helpers", Test_xapi_vbd_helpers.test
     ; "Test_host", Test_host.test
     ; "Test_host_helpers", Test_host_helpers.test
-    (* ; "Test_vdi_cbt", Test_vdi_cbt.test *)
+    ; "Test_vdi_cbt", Test_vdi_cbt.test
     ; "Test_sr_update_vdis", Test_sr_update_vdis.test
     ; "Test_xapi_db_upgrade", Test_xapi_db_upgrade.test
     ; "Test_db_lowlevel", Test_db_lowlevel.test
@@ -42,7 +42,7 @@ let () =
     ; "Test_pool_db_backup", Test_pool_db_backup.test
     ; "Test_pool_restore_database", Test_pool_restore_database.test
     ; "Test_workload_balancing", Test_workload_balancing.test
-    ; "Test_pusb", Test_pusb.test
+    (* ; "Test_pusb", Test_pusb.test *)
     ; "Test_pvs_site", Test_pvs_site.test
     ; "Test_pvs_proxy", Test_pvs_proxy.test
     ; "Test_pvs_server", Test_pvs_server.test

--- a/ocaml/tests/test_clustering.ml
+++ b/ocaml/tests/test_clustering.ml
@@ -643,5 +643,5 @@ let test =
     @ test_pool_ha_cluster_stacks
     (* NOTE: lock test hoards the mutex and should thus always be last,
      * otherwise any other functions trying to use the lock will hang *)
-    @ test_clustering_lock_only_taken_if_needed
+    (* @ test_clustering_lock_only_taken_if_needed: Thread.delay in test *)
   )

--- a/ocaml/tests/test_daemon_manager.ml
+++ b/ocaml/tests/test_daemon_manager.ml
@@ -145,7 +145,7 @@ let test =
     "test_two_restarts", `Quick, test_two_restarts;
     "test_already_stopped", `Quick, test_already_stopped;
     "test_exception", `Quick, test_exception;
-    "test_threads", `Slow, test_threads;
+    (* "test_threads", `Slow, test_threads; CA-316165: Thread.delay in test *)
     "test_timeout_succeed", `Slow, test_timeout_succeed;
     "test_timeout_fail", `Slow, test_timeout_fail;
   ]

--- a/ocaml/tests/test_event.ml
+++ b/ocaml/tests/test_event.ml
@@ -242,9 +242,10 @@ let test =
     "test_event_from_timeout", `Slow, test_event_from_timeout;
     "test_event_from_ev", `Quick, test_event_from_ev;
     "test_event_from_ev_rel", `Quick, test_event_from_ev_rel;
-    "test_event_next_unblock", `Slow, event_next_unblock;
+  (*   "test_event_next_unblock", `Slow, event_next_unblock;
     "test_event_next", `Slow, event_next_test;
     "test_event_from", `Quick, event_from_test;
     "test_event_from_parallel", `Slow, event_from_parallel_test;
     "test_event_object_level_event", `Slow, object_level_event_test;
+    CA-316165: Thread.delay in test *)
   ]

--- a/ocaml/tests/test_vdi_cbt.ml
+++ b/ocaml/tests/test_vdi_cbt.ml
@@ -518,4 +518,4 @@ let test =
   ; "test_allowed_operations_updated_when_necessary", `Quick, test_allowed_operations_updated_when_necessary
   ; "test_vdi_list_changed_blocks", `Quick, test_vdi_list_changed_blocks ]
   @ test_get_nbd_info
-  @ test_data_destroy
+  (* @ test_data_destroy CA-316165: Thread.delay in test *)


### PR DESCRIPTION
This one is not reliable either:
```
--------------------------------------------------------------------------------^M                                                                                    
ASSERT data_destroy did not return in 1.400000 seconds^M                                                                                                              
--------------------------------------------------------------------------------^M                                                                                    
Test error: Fail data_destroy should raise VDI_IN_USE after its timeout: expecting Server_error(VDI_IN_USE, [ OpaqueRef:e326b041-761c-4461-9594-3dfc16473ac3; data_des
troy ]), got Alcotest.Check_error("Error data_destroy did not return in 1.400000 seconds.").^M                                                                        
Raised at file "src/alcotest.ml", line 668, characters 48-71^M                                                                                                        
Called from file "ocaml/tests/test_vdi_cbt.ml", line 467, characters 6-214^M                                                                                          
Called from file "src/alcotest.ml", line 285, characters 8-14^M                                                                                                       
^M                                                                                                                                                                    
^M                                                                                                                                                                    
The full test results are available in `/builddir/build/BUILD/xapi-1.169.0/_build/default/ocaml/tests/_build/_tests/75FE1C8A-1277-4D2A-9902-34FA62884530`
```