### PR TITLE
CA-315688: Bumped API version to 2.14 for the plymouth release

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -100,7 +100,7 @@ let tech_preview_releases = [
 (* Normally xencenter_min_verstring and xencenter_max_verstring in the xapi_globs should be set to the same value,
  * but there are exceptions: please consult the XenCenter maintainers if in doubt. *)
 let api_version_major = 2L
-let api_version_minor = 13L
+let api_version_minor = 14L
 let api_version_string =
   Printf.sprintf "%Ld.%Ld" api_version_major api_version_minor
 let api_version_vendor = "XenSource"

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -61,6 +61,7 @@ let rel_jura = "jura"
 let rel_kolkata = "kolkata"
 let rel_lima = "lima"
 let rel_naples = "naples"
+let rel_oslo = "oslo"
 let rel_plymouth = "plymouth"
 
 type api_release = {
@@ -249,9 +250,15 @@ let release_order_full = [{
      branding      = "Citrix Hypervisor 8.0";
      release_date  = Some "March 2019";
    }; {
-     code_name     = Some rel_plymouth;
+     code_name     = Some rel_oslo;
      version_major = 2;
      version_minor = 13;
+     branding      = "Unreleased";
+     release_date  = None;
+   }; {
+     code_name     = Some rel_plymouth;
+     version_major = 2;
+     version_minor = 14;
      branding      = "Unreleased";
      release_date  = None;
    }

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -92,7 +92,7 @@ let release_order_full = [{
      version_major = 1;
      version_minor = 2;
      branding      = "XenServer 4.1.1";
-     release_date  = None;
+     release_date  = Some ""; (* unknown date *)
    }; {
      code_name     = Some rel_orlando;
      version_major = 1;
@@ -104,7 +104,7 @@ let release_order_full = [{
      version_major = 1;
      version_minor = 3;
      branding      = "XenServer 5.0 Update 1";
-     release_date  = None;
+     release_date  = Some ""; (* unknown date *)
    }; {
      code_name     = None;
      version_major = 1;
@@ -158,7 +158,7 @@ let release_order_full = [{
      version_major = 2;
      version_minor = 0;
      branding      = "XenServer 6.2 SP1 Tech-Preview";
-     release_date  = None;
+     release_date  = Some ""; (* unknown date *)
    }; {
      code_name     = Some rel_vgpu_productisation;
      version_major = 2;

--- a/ocaml/idl/json_backend/gen_json.ml
+++ b/ocaml/idl/json_backend/gen_json.ml
@@ -364,6 +364,7 @@ let _ =
     (string_of_json 0 release_info);
 
   let release_yaml = function
+    | {release_date = None} -> ""
     | {code_name = Some x; version_major; version_minor; branding = y;} -> Printf.sprintf "%s: %s\n" x y
     | _ -> ""
   in
@@ -377,13 +378,14 @@ let _ =
   Xapi_stdext_unix.Unixext.mkdir_rec class_md_dir 0o755;
 
   let release_md = function
+  | {release_date = None} -> ()
   | {code_name = Some x; version_major; version_minor; branding; release_date = y} ->
     ["---";
     "layout: xenapi-release";
     Printf.sprintf "release: %s" x;
     "release_index: true";
     "---\n";
-    match y with Some z -> Printf.sprintf "Released in %s.\n" z | _ -> "";
+    match y with Some "" -> "" | Some z -> Printf.sprintf "Released in %s.\n" z | _ -> "";
     ] |>
     String.concat "\n" |>
     Xapi_stdext_unix.Unixext.write_string_to_file (Filename.concat release_md_dir (Printf.sprintf "%s.md" x))


### PR DESCRIPTION
Also, do not autogenerate placeholders for unreleased API versions in the docs.