### PR TITLE
CP-30614: Use rrd files to gather memory statistics

### DIFF
--- a/ocaml/xapi/monitor_dbcalls.ml
+++ b/ocaml/xapi/monitor_dbcalls.ml
@@ -23,44 +23,6 @@ open Threadext
 module D = Debug.Make(struct let name = "monitor_dbcalls" end)
 open D
 
-let get_host_memory_changes xc =
-  let physinfo = Xenctrl.physinfo xc in
-  let bytes_of_pages pages =
-    Memory.bytes_of_pages (Int64.of_nativeint pages)
-  in
-  let free_bytes = bytes_of_pages physinfo.Xenctrl.free_pages in
-  let total_bytes = bytes_of_pages physinfo.Xenctrl.total_pages in
-  let host_memory_changed =
-    !host_memory_free_cached <> free_bytes ||
-    !host_memory_total_cached <> total_bytes
-  in
-  if host_memory_changed then Some (free_bytes, total_bytes) else None
-
-let set_host_memory_change (free_bytes, total_bytes) =
-  Mutex.execute host_memory_m (fun _ ->
-      host_memory_free_cached := free_bytes;
-      host_memory_total_cached := total_bytes;
-    )
-
-let get_vm_memory_changes xc =
-  let domains = Xenctrl.domain_getinfolist xc 0 in
-  let process_vm dom =
-    let open Xenctrl in
-    if not dom.dying then
-      begin
-        let uuid = Uuid.string_of_uuid (Uuid.uuid_of_int_array dom.handle) in
-        let memory = Memory.bytes_of_pages (Int64.of_nativeint dom.total_memory_pages) in
-        Hashtbl.add vm_memory_tmp uuid memory
-      end
-  in
-  List.iter process_vm domains;
-  get_updates_map ~before:vm_memory_cached ~after:vm_memory_tmp
-
-let set_vm_memory_changes ?except () =
-  Mutex.execute vm_memory_cached_m (fun _ ->
-      transfer_map ?except ~source:vm_memory_tmp ~target:vm_memory_cached
-    )
-
 let get_pif_and_bond_changes () =
   (* Read fresh PIF information from networkd. *)
   let open Network_stats in
@@ -101,28 +63,12 @@ let set_bond_changes ?except () =
 (* This function updates the database for all the slowly changing properties
  * of host memory, VM memory, PIFs, and bonds.
 *)
-let pifs_and_memory_update_fn xc =
-  let host_memory_changes = get_host_memory_changes xc in
-  let vm_memory_changes = get_vm_memory_changes xc in
+let pifs_update_fn () =
   let pif_changes, bond_changes = get_pif_and_bond_changes () in
-  Server_helpers.exec_with_new_task "updating VM_metrics.memory_actual fields and PIFs"
+  Server_helpers.exec_with_new_task "updating PIFs"
     (fun __context ->
        let host = Helpers.get_localhost ~__context in
        let issues = ref [] in
-
-       let keeps = ref [] in
-       List.iter (fun (uuid, memory) ->
-           try
-             let vm = Db.VM.get_by_uuid ~__context ~uuid in
-             let vmm = Db.VM.get_metrics ~__context ~self:vm in
-             if (Db.VM.get_resident_on ~__context ~self:vm = host)
-             then Db.VM_metrics.set_memory_actual ~__context ~self:vmm ~value:memory
-             else clear_cache_for_vm uuid
-           with e ->
-             issues := e :: !issues;
-             keeps := uuid :: !keeps
-         ) vm_memory_changes;
-       set_vm_memory_changes ~except:!keeps ();
 
        let keeps = ref [] in
        List.iter (fun (bond, links_up) ->
@@ -151,19 +97,6 @@ let pifs_and_memory_update_fn xc =
            issues := e :: !issues
        end;
 
-       begin
-         match host_memory_changes with
-         | None -> ()
-         | Some (free, total as c) ->
-           try
-             let metrics = Db.Host.get_metrics ~__context ~self:host in
-             Db.Host_metrics.set_memory_total ~__context ~self:metrics ~value:total;
-             Db.Host_metrics.set_memory_free ~__context ~self:metrics ~value:free;
-             set_host_memory_change c
-           with e ->
-             issues := e :: !issues
-       end;
-
        List.iter (function
            | Db_exn.Read_missing_uuid _ -> ()
            | e -> error "pifs_and_memory_update issue: %s" (ExnHelper.string_of_exn e)
@@ -171,15 +104,15 @@ let pifs_and_memory_update_fn xc =
     )
 
 let monitor_dbcall_thread () =
-  Xenctrl.with_intf (fun xc ->
-      while true do
-        try
-          pifs_and_memory_update_fn xc;
-          Monitor_pvs_proxy.update ();
-          Thread.delay 5.
-        with e ->
-          debug "monitor_dbcall_thread would have died from: %s; restarting in 30s."
-            (ExnHelper.string_of_exn e);
-          Thread.delay 30.
-      done
-    )
+  while true do
+    try
+      pifs_update_fn ();
+      Monitor_mem_host.update ();
+      Monitor_mem_vms.update ();
+      Monitor_pvs_proxy.update ();
+      Thread.delay 5.
+    with e ->
+      info "monitor_dbcall_thread would have died from: %s; restarting in 30s."
+        (ExnHelper.string_of_exn e);
+      Thread.delay 30.
+  done

--- a/ocaml/xapi/monitor_mem_host.ml
+++ b/ocaml/xapi/monitor_mem_host.ml
@@ -1,0 +1,83 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module Mtxext = Stdext.Threadext.Mutex
+module Lstext = Stdext.Listext.List
+module Mcache = Monitor_dbcalls_cache
+
+module D = Debug.Make(struct let name = "monitor_mem_host" end)
+open D
+
+let get_changes () =
+  let named_dss = List.flatten (List.map (fun filename ->
+      try
+        let datasources = Monitor_types.datasources_from_filename filename in
+        Mcache.log_errors_from filename;
+
+        datasources
+        |> Lstext.filter_map (function
+          | Rrd.Host, ds when List.mem ds.Ds.ds_name ["memory_total_kib"; "memory_free_kib"]
+              -> Some ds
+          | _ -> None (* we are only interested in Host memory stats *)
+          )
+        |> List.map (function ds ->
+          let value =
+            match ds.Ds.ds_value with
+            | Rrd.VT_Int64 v -> Memory.bytes_of_kib v
+            | Rrd.VT_Float v -> Memory.bytes_of_kib (Int64.of_float v)
+            | Rrd.VT_Unknown -> -1L
+          in
+          ds.Ds.ds_name, value
+          )
+      with e ->
+        if not (Mcache.is_ignored filename) then begin
+          error "Unable to read host memory metrics from %s: %s" filename (Printexc.to_string e);
+          Mcache.ignore_errors_from filename
+        end;
+        []
+    ) (Monitor_types.find_rrd_files Xapi_globs.metrics_prefix_mem_host)) in
+
+  let free_bytes = List.assoc_opt "memory_free_kib" named_dss in
+  let total_bytes = List.assoc_opt "memory_total_kib" named_dss in
+
+  (* Check if anything has changed since our last reading. *)
+  match free_bytes, total_bytes with
+   | (Some free, Some total) when
+      !Mcache.host_memory_free_cached <> free ||
+      !Mcache.host_memory_total_cached <> total ->
+     Some (free, total)
+   | _ -> None
+
+let set_changes (free_bytes, total_bytes) =
+  Mtxext.execute Mcache.host_memory_m (fun _ ->
+      Mcache.host_memory_free_cached := free_bytes;
+      Mcache.host_memory_total_cached := total_bytes;
+    )
+
+let update () =
+  Server_helpers.exec_with_new_task "Updating host memory metrics"
+    (fun __context ->
+    let changes = get_changes () in
+    match changes with
+    | None -> ()
+    | Some (free, total as c) ->
+      try
+        let host = Helpers.get_localhost ~__context in
+        let metrics = Db.Host.get_metrics ~__context ~self:host in
+        Db.Host_metrics.set_memory_total ~__context ~self:metrics ~value:total;
+        Db.Host_metrics.set_memory_free ~__context ~self:metrics ~value:free;
+        set_changes c
+      with e ->
+        error "Unable to update host memory metrics: %s" (Printexc.to_string e);
+    )

--- a/ocaml/xapi/monitor_mem_vms.ml
+++ b/ocaml/xapi/monitor_mem_vms.ml
@@ -1,0 +1,75 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module Mtxext = Stdext.Threadext.Mutex
+module Lstext = Stdext.Listext.List
+module Mcache = Monitor_dbcalls_cache
+
+module D = Debug.Make(struct let name = "monitor_mem_vms" end)
+open D
+
+let get_changes () =
+  List.iter (fun filename ->
+      try
+        let datasources = Monitor_types.datasources_from_filename filename in
+        Mcache.log_errors_from filename;
+
+        datasources
+        |> Lstext.filter_map (function
+          | Rrd.VM vm_uuid, ds when ds.Ds.ds_name = "memory"
+              -> Some (vm_uuid, ds)
+          | _ -> None (* we are only interested in VM stats *)
+          )
+        |> List.iter (function vm_uuid, ds ->
+          let value =
+            match ds.Ds.ds_value with
+            | Rrd.VT_Int64 v -> v
+            | Rrd.VT_Float v -> Int64.of_float v
+            | Rrd.VT_Unknown -> -1L
+          in
+          Hashtbl.add Mcache.vm_memory_tmp vm_uuid value
+          )
+      with e ->
+        if not (Mcache.is_ignored filename) then begin
+          error "Unable to read memory usage for VM %s: %s" filename (Printexc.to_string e);
+          Mcache.ignore_errors_from filename
+        end
+    ) (Monitor_types.find_rrd_files Xapi_globs.metrics_prefix_mem_vms);
+
+  (* Check if anything has changed since our last reading. *)
+  Mcache.get_updates_map ~before:Mcache.vm_memory_cached ~after:Mcache.vm_memory_tmp
+
+let set_changes ?except () =
+  Mtxext.execute Mcache.vm_memory_cached_m (fun _ ->
+      Mcache.transfer_map ?except ~source:Mcache.vm_memory_tmp ~target:Mcache.vm_memory_cached
+    )
+
+let update () =
+  Server_helpers.exec_with_new_task "Updating VM memory usage"
+    (fun __context ->
+      let host = Helpers.get_localhost ~__context in
+      let keeps = ref [] in
+      List.iter (fun (vm_uuid, memory) ->
+          try
+            let vm = Db.VM.get_by_uuid ~__context ~uuid:vm_uuid in
+            let vmm = Db.VM.get_metrics ~__context ~self:vm in
+            if (Db.VM.get_resident_on ~__context ~self:vm = host)
+            then Db.VM_metrics.set_memory_actual ~__context ~self:vmm ~value:memory
+            else Mcache.clear_cache_for_vm vm_uuid;
+          with e ->
+            keeps := vm_uuid :: !keeps;
+            error "Unable to update memory usage for VM %s: %s" vm_uuid (Printexc.to_string e);
+        ) (get_changes ()) ;
+      set_changes ~except:!keeps ()
+    )

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -567,6 +567,8 @@ let cpu_info_features_hvm_key = "features_hvm"
 (** Metrics *)
 
 let metrics_root = "/dev/shm/metrics"
+let metrics_prefix_mem_host = "xcp-rrdd-mem_host"
+let metrics_prefix_mem_vms = "xcp-rrdd-mem_vms"
 let metrics_prefix_pvs_proxy = "pvsproxy-"
 
 (** Path to trigger file for Network Reset. *)


### PR DESCRIPTION
Depends on https://github.com/xapi-project/xcp-rrdd/pull/95

Remove code dependent of xenctrl for gathering memory statistics.

Both VM and Host statistics for memory got moved to their respective
files. They follow the same structure as monitor_pvs_proxy.

Cherry-pick of d68fc970a0ebfb8b66ae874dd91b769785ca4005