### PR TITLE
CP-31268: copy SMBIOS type2 info from host to VM

### DIFF
--- a/ocaml/xapi/bios_strings.ml
+++ b/ocaml/xapi/bios_strings.ml
@@ -90,7 +90,10 @@ let get_host_bios_strings ~__context =
   info "Getting host BIOS strings.";
   (* named BIOS strings *)
   let dmidecode_strings = ["bios-vendor"; "bios-version"; "system-manufacturer";
-                           "system-product-name"; "system-version"; "system-serial-number"] in
+                           "system-product-name"; "system-version"; "system-serial-number";
+                           "baseboard-manufacturer"; "baseboard-product-name";
+                           "baseboard-version"; "baseboard-serial-number";
+                          ] in
   let named_strings = List.map (fun str -> str, (get_bios_string str)) dmidecode_strings in
   (* type 11 OEM strings *)
   let oem_strings = get_oem_strings () in

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -602,6 +602,10 @@ let generic_bios_strings =
    "system-product-name", "HVM domU";
    "system-version", "";
    "system-serial-number", "";
+   "baseboard-manufacturer", "";
+   "baseboard-product-name", "";
+   "baseboard-version", "";
+   "baseboard-serial-number", "";
    "hp-rombios", ""] @ standard_type11_strings
 
 (** BIOS strings of the old (XS 5.5) Dell Edition *)


### PR DESCRIPTION
Backport commit 94d2ff7 without the dependent commits, so only keep the
bios string copy function.

Signed-off-by: Talons Lee <xin.li@citrix.com>