### PR TITLE
Use xs-opam's uefi branch for travis

### DIFF
--- a/.travis-xs-opam.sh
+++ b/.travis-xs-opam.sh
@@ -5,6 +5,7 @@ set -ex
 PACKAGE="xapi"
 PINS="xapi:. xapi-cli-protocol:. xapi-client:. xapi-consts:. xapi-database:. xapi-datamodel:. xapi-types:. xe:."
 BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
+BASE_REMOTE_BRANCH="uefi"
 DISTRO="debian-unstable"
 OCAML_VERSION="4.07"
 


### PR DESCRIPTION
This allows xen-api to be built against the uefi branch of xenopsd instead of the master one.

Note: This commit must not be merged into the master branch.