### PR TITLE
Fix unit test failures introduced by multi-vGPU code.

### DIFF
--- a/ocaml/tests/test_common.ml
+++ b/ocaml/tests/test_common.ml
@@ -371,7 +371,9 @@ let make_vgpu_type ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ())
     ?(max_resolution_x=0L) ?(max_resolution_y=0L) ?(size=0L)
     ?(internal_config=[]) ?(implementation=`passthrough)
     ?(identifier="") ?(experimental=false)
-    ?(compatible_types_in_vm=[]) ?(compatible_types_on_pgpu=[]) () =
+    ?(compatible_model_names_in_vm=[]) ?(compatible_model_names_on_pgpu=[]) () =
+  let compatible_types_in_vm = compatible_model_names_in_vm in
+  let compatible_types_on_pgpu = compatible_model_names_on_pgpu in
   Db.VGPU_type.create ~__context ~ref ~uuid ~vendor_name ~model_name
     ~framebuffer_size ~max_heads ~max_resolution_x ~max_resolution_y ~size
     ~internal_config ~implementation ~identifier ~experimental

--- a/ocaml/tests/test_pgpu_helpers.ml
+++ b/ocaml/tests/test_pgpu_helpers.ml
@@ -40,7 +40,7 @@ module GetRemainingCapacity = Generic.Make(Generic.EncapsulateState(struct
                                                let pgpu_ref = List.hd (Db.PGPU.get_all ~__context) in
                                                let vgpu_type_ref = find_or_create ~__context vgpu_type in
                                                Xapi_pgpu_helpers.get_remaining_capacity
-                                                 ~__context ~self:pgpu_ref ~vgpu_type:vgpu_type_ref
+                                                 ~__context ~self:pgpu_ref ~vgpu_type:vgpu_type_ref ~pre_allocate_list:[]
 
                                              let tests = [
                                                (* Test that empty PGPUs have the correct capacity for each virtual

--- a/ocaml/tests/test_vgpu_common.ml
+++ b/ocaml/tests/test_vgpu_common.ml
@@ -32,8 +32,8 @@ let k100 = {
       vsubdev_id = 0x101e;
     });
   experimental = false;
-  compatible_types_in_vm = [];
-  compatible_types_on_pgpu = [];
+  compatible_model_names_in_vm = [];
+  compatible_model_names_on_pgpu = ["GRID K100"];
 }
 
 let k140q = {
@@ -54,8 +54,8 @@ let k140q = {
       vsubdev_id = 0x1037;
     });
   experimental = false;
-  compatible_types_in_vm = [];
-  compatible_types_on_pgpu = [];
+  compatible_model_names_in_vm = [];
+  compatible_model_names_on_pgpu = ["GRID K140Q"];
 }
 
 let k200 = {
@@ -76,8 +76,8 @@ let k200 = {
       vsubdev_id = 0x101d;
     });
   experimental = false;
-  compatible_types_in_vm = [];
-  compatible_types_on_pgpu = [];
+  compatible_model_names_in_vm = [];
+  compatible_model_names_on_pgpu = ["GRID K200"];
 }
 
 let k240q = {
@@ -98,8 +98,8 @@ let k240q = {
       vsubdev_id = 0x101a;
     });
   experimental = false;
-  compatible_types_in_vm = [];
-  compatible_types_on_pgpu = [];
+  compatible_model_names_in_vm = [];
+  compatible_model_names_on_pgpu = ["GRID K240Q"];
 }
 
 let k260q = {
@@ -120,8 +120,8 @@ let k260q = {
       vsubdev_id = 0x101b;
     });
   experimental = false;
-  compatible_types_in_vm = [];
-  compatible_types_on_pgpu = [];
+  compatible_model_names_in_vm = [];
+  compatible_model_names_on_pgpu = ["GRID K260Q"];
 }
 
 let k1_vgpu_types = [
@@ -157,8 +157,8 @@ let gvt_g_041a = {
       fence_sz = 4L;
     });
   experimental = false;
-  compatible_types_in_vm = [];
-  compatible_types_on_pgpu = [];
+  compatible_model_names_in_vm = [];
+  compatible_model_names_on_pgpu = [];
 }
 
 let intel_041a_vgpu_types = [
@@ -208,6 +208,7 @@ let string_of_pgpu_state pgpu =
 
 let make_vgpu ~__context
     ?(vm_ref=Ref.null)
+    ?(gPU_group=Ref.null)
     ?(resident_on=Ref.null)
     ?(scheduled_to_be_resident_on=Ref.null)
     ?(uuid=Test_common.make_uuid())
@@ -230,6 +231,7 @@ let make_vgpu ~__context
     ~vM:vm_ref
     ~_type:vgpu_type_ref
     ~uuid
+    ~gPU_group
     ~resident_on
     ~scheduled_to_be_resident_on ()
 

--- a/ocaml/tests/test_vgpu_type.ml
+++ b/ocaml/tests/test_vgpu_type.ml
@@ -63,8 +63,8 @@ module NvidiaTest = struct
             max_x = 1920L;
             max_y = 1200L;
             file_path = "test_data/test_vgpu_subdevid.conf";
-            compatible_types_in_vm = [];
-            compatible_types_on_pgpu = [];
+            compatible_model_names_in_vm = [];
+            compatible_model_names_on_pgpu = [];
           });
         "test_data/test_vgpu_nosubdevid.conf",
         Nvidia_old.({
@@ -80,8 +80,8 @@ module NvidiaTest = struct
             max_x = 1920L;
             max_y = 1200L;
             file_path = "test_data/test_vgpu_nosubdevid.conf";
-            compatible_types_in_vm = [];
-            compatible_types_on_pgpu = [];
+            compatible_model_names_in_vm = [];
+            compatible_model_names_on_pgpu = [];
           });
       ]
     end)
@@ -137,8 +137,8 @@ module NvidiaTest = struct
               max_y = 1200L;
               file_path = "test_data/nvidia-whitelist.xml";
               type_id = "11";
-              compatible_types_in_vm = [];
-              compatible_types_on_pgpu = ["TYPE FOO1"];
+              compatible_model_names_in_vm = [];
+              compatible_model_names_on_pgpu = ["TYPE FOO1"];
             })
         ];
         ("test_data/nvidia-whitelist.xml", 0x3334),
@@ -157,8 +157,8 @@ module NvidiaTest = struct
               max_y = 1200L;
               file_path = "test_data/nvidia-whitelist.xml";
               type_id = "11";
-              compatible_types_in_vm = [];
-              compatible_types_on_pgpu = ["TYPE FOO1"];
+              compatible_model_names_in_vm = [];
+              compatible_model_names_on_pgpu = ["TYPE FOO1"];
             })
         ];
         ("test_data/nvidia-whitelist.xml", 0x3335),
@@ -177,8 +177,8 @@ module NvidiaTest = struct
               max_y = 1600L;
               file_path = "test_data/nvidia-whitelist.xml";
               type_id = "20";
-              compatible_types_in_vm = [];
-              compatible_types_on_pgpu = ["TYPE FOO2"];
+              compatible_model_names_in_vm = [];
+              compatible_model_names_on_pgpu = ["TYPE FOO2"];
             });
           Vendor_nvidia.({
               identifier = Identifier.({
@@ -194,8 +194,8 @@ module NvidiaTest = struct
               max_y = 1200L;
               file_path = "test_data/nvidia-whitelist.xml";
               type_id = "21";
-              compatible_types_in_vm = [];
-              compatible_types_on_pgpu = ["TYPE FOO3"];
+              compatible_model_names_in_vm = [];
+              compatible_model_names_on_pgpu = ["TYPE FOO3"];
             })
         ];
         


### PR DESCRIPTION
Brief: 
- Fix build error caused by renaming compatible_model_names_in_vm;
- Test new function rank_hosts_by_best_vgpu;
- Cases for multiple vGPUs haven't been added;

Signed-off-by: Michael Z <michael.zhao@citrix.com>