### PR TITLE
Support extra_args for vGPU configration

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4778,6 +4778,7 @@ module VGPU = struct
         field ~qualifier:DynamicRO ~ty:(Ref _pgpu) ~lifecycle:[Published, rel_vgpu_tech_preview, ""] "resident_on" "The PGPU on which this VGPU is running" ~default_value:(Some (VRef null_ref));
         field ~qualifier:DynamicRO ~ty:(Ref _pgpu) ~lifecycle:[Published, rel_dundee, ""] "scheduled_to_be_resident_on" "The PGPU on which this VGPU is scheduled to run" ~default_value:(Some (VRef null_ref));
         field ~qualifier:DynamicRO ~ty:(Map (String,String)) ~lifecycle:[Published, rel_inverness, ""] ~default_value:(Some (VMap [])) "compatibility_metadata" "VGPU metadata to determine whether a VGPU can migrate between two PGPUs";
+        field ~qualifier:RW ~ty:String ~lifecycle:[Published, rel_plymouth, ""] ~default_value:(Some (VString "")) "extra_args" "Extra arguments for vGPU and passed to demu";
       ]
       ()
 end

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -277,7 +277,7 @@ let _ =
   error Api_errors.vgpu_type_not_compatible_with_running_type ["pgpu"; "type"; "running_type"]
     ~doc:"VGPU type is not compatible with one or more of the VGPU types currently running on this PGPU" ();
   error Api_errors.vgpu_type_not_compatible ["type"]
-    ~doc:"You try to create a VGPU that is not compatible with existing types on the VM." ();
+    ~doc:"You tried to create a VGPU that is not compatible with existing types on the VM." ();
   error Api_errors.vgpu_destination_incompatible ["reason"; "vgpu"; "host"]
     ~doc:"The VGPU is not compatible with any PGPU in the destination." ();
   error Api_errors.nvidia_tools_error ["host"]

--- a/ocaml/tests/test_common.ml
+++ b/ocaml/tests/test_common.ml
@@ -358,11 +358,12 @@ let make_vgpu ~__context
     ?(resident_on=Ref.null)
     ?(scheduled_to_be_resident_on=Ref.null)
     ?(compatibility_metadata=[])
+    ?(extra_args="")
     () =
   Db.VGPU.create ~__context
     ~ref ~uuid ~vM ~gPU_group ~device ~currently_attached
     ~other_config ~_type ~resident_on ~scheduled_to_be_resident_on
-    ~compatibility_metadata
+    ~compatibility_metadata ~extra_args
     ;
   ref
 

--- a/ocaml/tests/test_vgpu_common.ml
+++ b/ocaml/tests/test_vgpu_common.ml
@@ -212,6 +212,7 @@ let make_vgpu ~__context
     ?(resident_on=Ref.null)
     ?(scheduled_to_be_resident_on=Ref.null)
     ?(uuid=Test_common.make_uuid())
+    ?(extra_args="")
     vgpu_type =
   let vgpu_type_ref = find_or_create ~__context vgpu_type in
   (* For the passthrough VGPU type, create a VM and mark it as attached to the
@@ -233,7 +234,8 @@ let make_vgpu ~__context
     ~uuid
     ~gPU_group
     ~resident_on
-    ~scheduled_to_be_resident_on ()
+    ~scheduled_to_be_resident_on
+    ~extra_args ()
 
 let make_pgpu ~__context ?address ?(host=Ref.null) ?(gPU_group=Ref.null) pgpu =
   let pCI = Test_common.make_pci ~__context ?pci_id:address ~host ~functions:1L () in

--- a/ocaml/tests/test_xenopsd_metadata.ml
+++ b/ocaml/tests/test_xenopsd_metadata.ml
@@ -274,6 +274,7 @@ module GenerateVGPUMetadata =
                                            config_file = None;
                                            type_id = "type_id_1";
                                            uuid = uuid_with_index 0;
+                                           extra_args = "";
                 })
               ];
               (* One Intel vGPU. *)
@@ -346,6 +347,7 @@ module GenerateMultiVGPUMetadata =
                                            config_file = None;
                                            type_id = "type_id_1";
                                            uuid = uuid_with_index 0;
+                                           extra_args = ""
                 });
                 Xenops_interface.Vgpu.(Nvidia {
                                            physical_pci_address = None;
@@ -353,6 +355,7 @@ module GenerateMultiVGPUMetadata =
                                            config_file = None;
                                            type_id = "type_id_1";
                                            uuid = uuid_with_index 1;
+                                           extra_args = ""
                 })
               ];
               (* 4 NVIDIA vGPUs. *)
@@ -367,6 +370,7 @@ module GenerateMultiVGPUMetadata =
                                            config_file = None;
                                            type_id = "type_id_1";
                                            uuid = uuid_with_index 0;
+                                           extra_args = ""
                 });
                 Xenops_interface.Vgpu.(Nvidia {
                                            physical_pci_address = None;
@@ -374,6 +378,7 @@ module GenerateMultiVGPUMetadata =
                                            config_file = None;
                                            type_id = "type_id_1";
                                            uuid = uuid_with_index 1;
+                                           extra_args = ""
                 });
                 Xenops_interface.Vgpu.(Nvidia {
                                            physical_pci_address = None;
@@ -381,6 +386,7 @@ module GenerateMultiVGPUMetadata =
                                            config_file = None;
                                            type_id = "type_id_1";
                                            uuid = uuid_with_index 2;
+                                           extra_args = ""
                 });
                 Xenops_interface.Vgpu.(Nvidia {
                                            physical_pci_address = None;
@@ -388,6 +394,7 @@ module GenerateMultiVGPUMetadata =
                                            config_file = None;
                                            type_id = "type_id_1";
                                            uuid = uuid_with_index 3;
+                                           extra_args = ""
                 })                
               ];
             ]

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -1766,6 +1766,9 @@ let vgpu_record rpc session_id vgpu =
             "%s:(%d bytes)" k (String.length v))
           |> String.concat "; "
          ) ();
+      make_field ~name:"extra_args"
+        ~get:(fun () -> (x ()).API.vGPU_extra_args)
+        ~set:(fun v -> Client.VGPU.set_extra_args rpc session_id vgpu v) ();
     ]
   }
 

--- a/ocaml/xapi/xapi_vgpu.ml
+++ b/ocaml/xapi/xapi_vgpu.ml
@@ -84,6 +84,7 @@ let create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type ~powerstate_
         ~currently_attached:false ~other_config ~_type ~resident_on:Ref.null
         ~scheduled_to_be_resident_on:Ref.null
         ~compatibility_metadata:[]
+        ~extra_args:""
       ;
     );
   debug "VGPU ref='%s' created (VM = '%s', type = '%s')" (Ref.string_of vgpu) (Ref.string_of vM) (Ref.string_of _type);

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -666,6 +666,7 @@ module MD = struct
     let type_id = Db.VGPU_type.get_internal_config ~__context ~self:vgpu_type 
                   |> List.assoc Xapi_globs.vgpu_type_id in
     let uuid = vgpu.Db_actions.vGPU_uuid in
+    let extra_args = vgpu.Db_actions.vGPU_extra_args in
     let implementation =
       Nvidia {
         physical_pci_address = None; (* unused *)
@@ -673,6 +674,7 @@ module MD = struct
         virtual_pci_address = Some virtual_pci_address;
         type_id  = type_id;
         uuid;
+        extra_args;
       }
     in {
       id = (vm.API.vM_uuid, vgpu.Db_actions.vGPU_device);


### PR DESCRIPTION
Signed-off-by: Lin Liu <lin.liu@citrix.com>

As titled, add support for extra_args for vgpu.

Customer can set extra args for the vgpu by command 
```xe vgpu-param-set uuid=xxxx extra_args="key1=v1,key2=v2"```
This is very similer to the previous verion of 
``` xe vm-param-set uuid=xxx platform:vgpu_extra_args="key1=v1,key2=v2"```