### PR TITLE
Backports: XOP-948, using jemalloc in xapi

### DIFF
--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -39,6 +39,18 @@ let all_ops : API.storage_operations_set =
   [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy; `vdi_resize; `vdi_clone; `vdi_snapshot; `vdi_mirror;
     `vdi_introduce; `update; `pbd_create; `pbd_destroy ]
 
+(* This list comes from
+ * https://github.com/xenserver/xen-api/blob/tampa-bugfix/ocaml/xapi/xapi_sr_operations.ml#L36-L38
+ * *)
+
+let all_rpu_ops : API.storage_operations_set =
+  [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy;
+  `vdi_resize; `vdi_clone; `vdi_snapshot; `vdi_introduce; `update;
+  `pbd_create; `pbd_destroy ]
+
+let disallowed_during_rpu : API.storage_operations_set =
+  List.filter (fun x -> not (List.mem x all_rpu_ops)) all_ops
+
 let sm_cap_table =
   [ `vdi_create, Smint.Vdi_create;
     `vdi_destroy, Smint.Vdi_delete;
@@ -80,6 +92,10 @@ let valid_operations ~__context ?op record _ref' : table =
     List.iter (fun op ->
         if Hashtbl.find table op = None
         then Hashtbl.replace table op (Some(code, params))) ops in
+
+  if Helpers.rolling_upgrade_in_progress ~__context then begin
+    set_errors Api_errors.not_supported_during_upgrade [] disallowed_during_rpu
+  end;
 
   (* Policy:
      Anyone may attach and detach VDIs in parallel but we serialise

--- a/scripts/init.d-xapi
+++ b/scripts/init.d-xapi
@@ -46,6 +46,10 @@ start() {
             fi
 	fi
 
+	# Let's have jemalloc
+	export LD_PRELOAD="/usr/lib64/libjemalloc.so.1"
+	export MALLOC_CONF="narenas:1,tcache:false,lg_dirty_mult:22"
+
 	if [ -e ${XAPI_BOOT_TIME_INFO_UPDATED} ]; then
 	    # clear out qemu coredumps/chroot dirs on system boot:
 	    rm -rf /var/xen/qemu/*

--- a/scripts/init.d-xapi
+++ b/scripts/init.d-xapi
@@ -46,10 +46,6 @@ start() {
             fi
 	fi
 
-	# Let's have jemalloc
-	export LD_PRELOAD="/usr/lib64/libjemalloc.so.1"
-	export MALLOC_CONF="narenas:1,tcache:false,lg_dirty_mult:22"
-
 	if [ -e ${XAPI_BOOT_TIME_INFO_UPDATED} ]; then
 	    # clear out qemu coredumps/chroot dirs on system boot:
 	    rm -rf /var/xen/qemu/*

--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -4,6 +4,8 @@ After=syslog.target forkexecd.service xcp-networkd.service message-switch.servic
 Conflicts=shutdown.target
 
 [Service]
+Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
+Environment="MALLOC_CONF=narenas:1,tcache:false,lg_dirty_mult:22"
 Type=simple
 Restart=on-failure
 ExecStart=@LIBEXECDIR@/xapi-init start


### PR DESCRIPTION
* c37f26fb0 HFX-2314 Move jemalloc into xapi.service (was: CA-289625)        
* 614b19e6c HFX-2314 CA-289625: Use jemalloc                                 
* 1f3682f27 HFX-2327 XOP-948: Restrict SR allowed_operations during RPU 

The backport of XOP-948 was done manually and tests were not backported because they rely on Alcotest which is not used in this branch.

