### PR TITLE
CA-320458: Upgrade vGPU default device id from 0 to 11

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4771,7 +4771,7 @@ module VGPU = struct
         uid _vgpu ~lifecycle:[Published, rel_boston, ""];
         field ~qualifier:DynamicRO ~ty:(Ref _vm) ~lifecycle:[Published, rel_boston, ""] "VM" "VM that owns the vGPU";
         field ~qualifier:DynamicRO ~ty:(Ref _gpu_group) ~lifecycle:[Published, rel_boston, ""] "GPU_group" "GPU group used by the vGPU";
-        field ~qualifier:DynamicRO ~ty:String ~lifecycle:[Published, rel_boston, ""] ~default_value:(Some (VString "0")) "device" "Order in which the devices are plugged into the VM";
+        field ~qualifier:DynamicRO ~ty:String ~lifecycle:[Published, rel_boston, "Only 1 vGPU with device id 0 is supported"; Changed, rel_plymouth, "Multiple vGPUs are supported, device refers to guest PCI slot"] ~default_value:(Some (VString "0")) "device" "Guest PCI slot (a value of 0 means auto-assign to first empty slot, valid slot is in range of [11,31] for multi-VGPU purpose)";
         field ~qualifier:DynamicRO ~ty:Bool ~lifecycle:[Published, rel_boston, ""] ~default_value:(Some (VBool false)) "currently_attached" "Reflects whether the virtual device is currently connected to a physical device";
         field ~qualifier:RW ~ty:(Map (String,String)) ~lifecycle:[Published, rel_boston, ""] "other_config" "Additional configuration" ~default_value:(Some (VMap []));
         field ~qualifier:DynamicRO ~ty:(Ref _vgpu_type) ~lifecycle:[Published, rel_vgpu_tech_preview, ""] "type" "Preset type for this VGPU" ~default_value:(Some (VRef null_ref));

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -592,6 +592,19 @@ let upgrade_cluster_timeouts = {
         update_milliseconds Db.Cluster.get_token_timeout_coefficient Db.Cluster.set_token_timeout_coefficient;
     )
 }
+(* For XS Before Naples with single vGPU, it has 0 as its default device number,
+ * For XS After Naples with multiple vGPU, the valid device number is [11,31],
+ * 11 is the default device number.
+ * This function upgrade the default device number *)
+let upgrade_vgpu_default_device_id = {
+  description = "Upgrade default vGPU device ID from 0 to 11";
+  version = (fun _ -> true); (* Always check and update when detected *)
+  fn = fun ~__context ->
+    let previous_default_vgpu_device , default_vgpu_device = "0", "11" in
+    Db.VGPU.get_all ~__context
+    |> List.filter (fun self -> Db.VGPU.get_device ~__context ~self = previous_default_vgpu_device)
+    |> List.iter (fun self -> Db.VGPU.set_device ~__context ~self ~value:default_vgpu_device)
+}
 
 let rules = [
   upgrade_domain_type;
@@ -618,6 +631,7 @@ let rules = [
   upgrade_vswitch_controller;
   upgrade_vm_platform_device_model;
   upgrade_cluster_timeouts;
+  upgrade_vgpu_default_device_id;
 ]
 
 (* Maybe upgrade most recent db *)


### PR DESCRIPTION
Signed-off-by: Lin Liu <lin.liu@citrix.com>

For XS with version before Naples, it has only one vGPU device with 0 as its default id.
For XS from Polymoth, it may have multiple vGPU device, 11 is the default device id.
This commit upgrade the default device ids from 0 to 11 during upgradation.
