### PR TITLE
CA-321787: Block migrate/suspend/resume when there is no pGPU compatible with vGPU

### DIFF
--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -65,6 +65,7 @@ let allocate_vgpu_to_gpu ?(dry_run=false) ?(pre_allocate_list=[]) ~__context vm 
   (* Make a asso list as follows
    * [(p1,capacity1);(p2,capacity2)...] *)
   let pgpu_capacity_assoc = List.intersect compatible_pgpus available_pgpus
+                            |> List.filter (fun pgpu -> Xapi_gpumon.Nvidia.vgpu_pgpu_are_compatible ~__context ~pgpu ~vgpu:vgpu.vgpu_ref) (* Filter all compatible pGPUs *)
                             |> List.map (fun self -> (self, Xapi_pgpu_helpers.get_remaining_capacity  ~__context ~pre_allocate_list ~self ~vgpu_type))
                             |> List.filter (fun (_,capacity) -> capacity > 0L ) in
 

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -312,12 +312,7 @@ let get_remaining_capacity ~__context ~self ~vgpu_type =
 
 let assert_can_run_VGPU ~__context ~self ~vgpu =
   let vgpu_type = Db.VGPU.get_type ~__context ~self:vgpu in
-  Xapi_pgpu_helpers.assert_capacity_exists_for_VGPU_type ~__context ~self ~vgpu_type;
-
-  (** Check whether Nvidia NVML allow the vGPU by gpumon *)
-  let nvidia_compatible = Xapi_gpumon.Nvidia.vgpu_pgpu_are_compatible ~__context ~vgpu ~pgpu:self in
-  if not nvidia_compatible then
-    raise (Api_errors.Server_error(Api_errors.internal_error, [ "Gpumon report pgpu is not compatible with the vgpu"; Ref.string_of self; Ref.string_of vgpu_type]))
+  Xapi_pgpu_helpers.assert_capacity_exists_for_VGPU_type ~__context ~self ~vgpu_type
 
 let update_dom0_access ~__context ~self ~action =
   let db_current = Db.PGPU.get_dom0_access ~__context ~self in


### PR DESCRIPTION
This commit check the NVML compatibility of the vGPU and the pGPU.
The vGPU can only be assigned bo a pGPU with NVML compatibility



1. The `Xapi_gpumon.Nvidia.vgpu_pgpu_are_compatible` is moved to Xapi_pgpu.assert_can_run_VGPU in https://github.com/xapi-project/xen-api/pull/3855/files#diff-3fb19a7212efdf3b669fd4374ac02838L315 as I throught every pGPU assert need such checks. But it caused other inconsistency behaviors when doing the RPU. So I revert it back.
2. Add the  `Xapi_gpumon.Nvidia.vgpu_pgpu_are_compatible` when allocate a vGPU to a pGPU to guarantee only the compatible pGPUs are allocated.
