### PR TITLE
CA-322450 xe-restore-metadata: ImportError: fsimage

### DIFF
--- a/scripts/probe-device-for-file
+++ b/scripts/probe-device-for-file
@@ -3,7 +3,10 @@
 # Checks for the existence of a file on a device
 
 import os, sys
-import fsimage
+try:
+   import xenfsimage
+except ImportError:
+   import fsimage as xenfsimage
 from contextlib import contextmanager
 
 # https://stackoverflow.com/a/17954769
@@ -45,7 +48,7 @@ if __name__ == "__main__":
     try:
         # CA-316241 - fsimage prints to stderr
         with stderr_redirected(to="/dev/null"):
-            fs = fsimage.open(device, 0)
+            fs = xenfsimage.open(device, 0)
             if fs.file_exists(file):
                 os._exit(0)
     except:


### PR DESCRIPTION
The Python module fsimage has been renamed to xenfsimage as part of Xen 4.12.
This commit changes the client accordingly.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>