### PR TITLE
Open VxLAN port for SDN controller

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -106,7 +106,7 @@ let tech_preview_releases = [
 (* Normally xencenter_min_verstring and xencenter_max_verstring in the xapi_globs should be set to the same value,
  * but there are exceptions: please consult the XenCenter maintainers if in doubt. *)
 let api_version_major = 2L
-let api_version_minor = 15L
+let api_version_minor = 16L
 let api_version_string =
   Printf.sprintf "%Ld.%Ld" api_version_major api_version_minor
 let api_version_vendor = "XenSource"
@@ -200,6 +200,12 @@ let get_product_releases in_product_since =
     | x::xs when code_name_of_release x = in_product_since -> "closed"::in_product_since::(List.map code_name_of_release xs)
     | x::xs -> go_through_release_order xs
   in go_through_release_order release_order
+
+let next_release =
+  { internal = get_product_releases rel_next
+  ; opensource=get_oss_releases None
+  ; internal_deprecated_since=None
+  }
 
 let stockholm_release =
   { internal = get_product_releases rel_stockholm

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -64,6 +64,7 @@ let rel_naples = "naples"
 let rel_oslo = "oslo"
 let rel_quebec = "quebec"
 let rel_stockholm = "stockholm"
+let rel_next = "next"
 
 type api_release = {
   code_name: string option;
@@ -266,6 +267,12 @@ let release_order_full = [{
      code_name     = Some rel_stockholm;
      version_major = 2;
      version_minor = 15;
+     branding      = "Unreleased";
+     release_date  = None;
+   }; {
+     code_name     = Some rel_next;
+     version_major = 2;
+     version_minor = 16;
      branding      = "Unreleased";
      release_date  = None;
    }

--- a/ocaml/tests/test_common.ml
+++ b/ocaml/tests/test_common.ml
@@ -213,7 +213,7 @@ let make_bond ~__context ?(ref=Ref.make ()) ?(uuid=make_uuid ()) ~master ?(other
   Db.Bond.create ~__context ~ref ~uuid ~master ~other_config ~primary_slave ~mode ~properties ~links_up:0L ~auto_update_mac;
   ref
 
-let make_tunnel = Xapi_tunnel.create_internal
+let make_tunnel = Xapi_tunnel.create_internal ~protocol:`gre
 
 let make_network ~__context ?(name_label="net") ?(name_description="description") ?(mTU=1500L)
     ?(other_config=[]) ?(bridge="xenbr0") ?(managed=true) ?(purpose=[]) () =

--- a/ocaml/tests/test_tunnel.ml
+++ b/ocaml/tests/test_tunnel.ml
@@ -20,7 +20,7 @@ let test_create_internal () =
   let network = T.make_network ~__context () in
   let transport_PIF = T.make_pif ~__context ~network ~host () in
   let network = T.make_network ~__context ~bridge:"xapi0" () in
-  let tunnel, access_PIF = Xapi_tunnel.create_internal ~__context ~transport_PIF ~network ~host in
+  let tunnel, access_PIF = Xapi_tunnel.create_internal ~__context ~transport_PIF ~network ~host ~protocol:`gre in
 
   Alcotest.check (Alcotest_comparators.ref ())
     "get tunnel access PIF"
@@ -55,7 +55,7 @@ let test_create_on_unmanaged_pif () =
   Alcotest.check_raises
     "test_create_on_unmanaged_pif"
     Api_errors.(Server_error (pif_unmanaged, [Ref.string_of transport_PIF]))
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network |> ignore)
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network ~protocol:`gre |> ignore)
 
 let test_create_network_already_connected () =
   let __context = T.make_test_database () in
@@ -65,7 +65,7 @@ let test_create_network_already_connected () =
   Alcotest.check_raises
     "test_create_network_already_connected"
     Api_errors.(Server_error (network_already_connected, [Ref.string_of host; Ref.string_of transport_PIF]))
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network |> ignore)
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network ~protocol:`gre |> ignore)
 
 let test_create_on_bond_slave () =
   let __context = T.make_test_database () in
@@ -79,7 +79,7 @@ let test_create_on_bond_slave () =
   Alcotest.check_raises
     "test_create_on_bond_slave"
     Api_errors.(Server_error (cannot_add_tunnel_to_bond_slave, [Ref.string_of transport_PIF]))
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network |> ignore)
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network ~protocol:`gre |> ignore)
 
 let test_create_on_tunnel_access () =
   let __context = T.make_test_database () in
@@ -90,7 +90,7 @@ let test_create_on_tunnel_access () =
   Alcotest.check_raises
     "test_create_on_tunnel_access"
     Api_errors.(Server_error (is_tunnel_access_pif, [Ref.string_of access_PIF]))
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:access_PIF ~network |> ignore)
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:access_PIF ~network ~protocol:`gre |> ignore)
 
 let test_create_on_sriov_logical () =
   let __context = T.make_test_database () in
@@ -101,7 +101,7 @@ let test_create_on_sriov_logical () =
   Alcotest.check_raises
     "test_create_on_sriov_logical"
     Api_errors.(Server_error (cannot_add_tunnel_to_sriov_logical, [Ref.string_of sriov_logical_PIF]))
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:sriov_logical_PIF ~network |> ignore)
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:sriov_logical_PIF ~network ~protocol:`gre |> ignore)
 
 let test_create_on_vlan_on_sriov_logical () =
   let __context = T.make_test_database () in
@@ -113,7 +113,7 @@ let test_create_on_vlan_on_sriov_logical () =
   Alcotest.check_raises
     "test_create_on_vlan_on_sriov_logical"
     Api_errors.(Server_error (cannot_add_tunnel_to_vlan_on_sriov_logical, [Ref.string_of transport_PIF]))
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network |> ignore)
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF ~network ~protocol:`gre |> ignore)
 
 let test_create_tunnel_into_sriov_network () =
   let __context = T.make_test_database () in
@@ -130,7 +130,7 @@ let test_create_tunnel_into_sriov_network () =
   Alcotest.check_raises
     "test_create_tunnel_into_sriov_network"
     Api_errors.(Server_error (network_incompatible_with_tunnel, [Ref.string_of sriov_network]))
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_network |> ignore)
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_network ~protocol:`gre |> ignore)
 
 let test_create_tunnel_into_sriov_vlan_network () =
   let __context = T.make_test_database () in
@@ -148,7 +148,7 @@ let test_create_tunnel_into_sriov_vlan_network () =
   Alcotest.check_raises
     "test_create_tunnel_into_sriov_vlan_network"
     Api_errors.(Server_error (network_incompatible_with_tunnel, [Ref.string_of sriov_vlan_network]))
-    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_vlan_network |> ignore)
+    (fun () -> Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_vlan_network ~protocol:`gre |> ignore)
 
 let test =
   [ "test_create_internal", `Quick, test_create_internal

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1532,7 +1532,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     "tunnel-create",
     {
       reqd=["pif-uuid"; "network-uuid"];
-      optn=[];
+      optn=["protocol"];
       help="Create a new tunnel on a host.";
       implementation=No_fd Cli_operations.tunnel_create;
       flags=[];

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3829,7 +3829,10 @@ let vlan_destroy printer rpc session_id params =
 let tunnel_create printer rpc session_id params =
   let network = Client.Network.get_by_uuid rpc session_id (List.assoc "network-uuid" params) in
   let pif = Client.PIF.get_by_uuid rpc session_id (List.assoc "pif-uuid" params) in
-  let tunnel = Client.Tunnel.create rpc session_id pif network in
+  let protocol = Record_util.tunnel_protocol_of_string (
+    List.assoc_opt "protocol" params |> Option.value ~default:"gre"
+  ) in
+  let tunnel =  Client.Tunnel.create rpc session_id pif network protocol in
   let pif' = Client.Tunnel.get_access_PIF rpc session_id tunnel in
   let uuid = Client.PIF.get_uuid rpc session_id pif' in
   printer (Cli_printer.PList [uuid])

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -526,6 +526,16 @@ let sdn_protocol_to_string = function
   | `ssl -> "ssl"
   | `pssl -> "pssl"
 
+let tunnel_protocol_of_string s =
+  match String.lowercase_ascii s with
+  | "gre" -> `gre
+  | "vxlan" -> `vxlan
+  | _ ->  raise (Record_failure ("Expected 'gre','vxlan', got "^s))
+
+let tunnel_protocol_to_string = function
+  | `gre -> "gre"
+  | `vxlan -> "vxlan"
+
 let pif_igmp_status_to_string = function
   | `enabled -> "enabled"
   | `disabled -> "disabled"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -185,6 +185,7 @@ let tunnel_record rpc session_id tunnel =
           ~add_to_map:(fun k v -> Client.Tunnel.add_to_other_config rpc session_id tunnel k v)
           ~remove_from_map:(fun k -> Client.Tunnel.remove_from_other_config rpc session_id tunnel k)
           ~get_map:(fun () -> (x ()).API.tunnel_other_config) ();
+        make_field ~name:"protocol" ~get:(fun () -> Record_util.tunnel_protocol_to_string (x ()).API.tunnel_protocol) ();
 
       ]
   }

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3051,11 +3051,11 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
   end
 
   module Tunnel = struct
-    let create ~__context ~transport_PIF ~network =
+    let create ~__context ~transport_PIF ~network ~protocol =
       info "Tunnel.create: network = '%s'" (network_uuid ~__context network);
-      let local_fn = Local.Tunnel.create ~transport_PIF ~network in
+      let local_fn = Local.Tunnel.create ~transport_PIF ~network ~protocol in
       do_op_on ~local_fn ~__context ~host:(Db.PIF.get_host ~__context ~self:transport_PIF)
-        (fun session_id rpc -> Client.Tunnel.create rpc session_id transport_PIF network)
+        (fun session_id rpc -> Client.Tunnel.create rpc session_id transport_PIF network protocol)
 
     let destroy ~__context ~self =
       info "Tunnel.destroy: tunnel = '%s'" (tunnel_uuid ~__context self);

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -166,8 +166,9 @@ let move_tunnel ~__context host new_transport_PIF old_tunnel =
   let plugged = Db.PIF.get_currently_attached ~__context ~self:old_access_PIF in
 
   (* Create new tunnel object and access PIF *)
+  let protocol = Db.Tunnel.get_protocol ~__context ~self:old_tunnel in
   let new_tunnel, new_access_PIF =
-    Xapi_tunnel.create_internal ~__context ~transport_PIF:new_transport_PIF ~network ~host in
+    Xapi_tunnel.create_internal ~__context ~transport_PIF:new_transport_PIF ~network ~host ~protocol in
   debug "Created new tunnel %s on bond" (Ref.string_of new_tunnel);
 
   (* Destroy old VLAN and VLAN-master objects *)

--- a/ocaml/xapi/xapi_tunnel.ml
+++ b/ocaml/xapi/xapi_tunnel.ml
@@ -30,7 +30,7 @@ let choose_tunnel_device_name ~__context ~host =
     else name in
   choose 0
 
-let create_internal ~__context ~transport_PIF ~network ~host =
+let create_internal ~__context ~transport_PIF ~network ~host ~protocol =
   let tunnel = Ref.make () in
   let access_PIF = Ref.make () in
   let device = choose_tunnel_device_name ~__context ~host in
@@ -45,10 +45,10 @@ let create_internal ~__context ~transport_PIF ~network ~host =
     ~management:false ~other_config:[] ~disallow_unplug:false ~ipv6_configuration_mode:`None
     ~iPv6:[""] ~ipv6_gateway:"" ~primary_address_type:`IPv4 ~managed:true ~properties:[] ~capabilities:[] ~pCI:Ref.null;
   Db.Tunnel.create ~__context ~ref:tunnel ~uuid:(Uuid.to_string (Uuid.make_uuid ()))
-    ~access_PIF ~transport_PIF ~status:["active", "false"] ~other_config:[];
+    ~access_PIF ~transport_PIF ~status:["active", "false"] ~other_config:[] ~protocol;
   tunnel, access_PIF
 
-let create ~__context ~transport_PIF ~network =
+let create ~__context ~transport_PIF ~network ~protocol =
   Xapi_network.assert_network_is_managed ~__context ~self:network;
   let host = Db.PIF.get_host ~__context ~self:transport_PIF in
   Xapi_pif.assert_no_other_local_pifs ~__context ~host ~network;
@@ -62,7 +62,7 @@ let create ~__context ~transport_PIF ~network =
        if not (List.mem_assoc "network_backend" v && List.assoc "network_backend" v = "openvswitch") then
          raise (Api_errors.Server_error (Api_errors.openvswitch_not_active, []));
     ) hosts;
-  let tunnel, access_PIF = create_internal ~__context ~transport_PIF ~network ~host in
+  let tunnel, access_PIF = create_internal ~__context ~transport_PIF ~network ~host ~protocol in
   Xapi_pif.plug ~__context ~self:access_PIF;
   tunnel
 

--- a/ocaml/xapi/xapi_tunnel.mli
+++ b/ocaml/xapi/xapi_tunnel.mli
@@ -20,6 +20,7 @@ val create :
   __context:Context.t ->
   transport_PIF:[ `PIF ] Ref.t ->
   network:[ `network ] Ref.t ->
+  protocol: API.tunnel_protocol ->
   [ `tunnel ] Ref.t
 
 (** Internal version of [create] without checks/exceptions and auto-plugging *)
@@ -28,6 +29,7 @@ val create_internal :
   transport_PIF:[ `PIF ] Ref.t ->
   network:[ `network ] Ref.t ->
   host:[ `host ] Ref.t ->
+  protocol: API.tunnel_protocol ->
   [ `tunnel ] Ref.t * [ `PIF ] Ref.t
 
 (** Destroy a tunnel. Removes the tunnel object as well as the tunnel access PIF. *)

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -360,8 +360,16 @@ _xe()
                 ;;
 
             protocol) # for sdn-controller
-                IFS=$'\n,'
-                set_completions 'ssl' "$value"
+                case "${OLDSTYLE_WORDS[1]}" in
+                    sdn-controller-introduce)
+                        IFS=$'\n,'
+                        set_completions 'ssl' "$value"
+                        ;;
+                    tunnel-create)
+                        IFS=$'\n,'
+                        set_completions 'gre,vxlan' "$value"
+                        ;;
+                esac
                 return 0
                 ;;
 


### PR DESCRIPTION
The commit opens the VxLAN IANA port (4789 udp) when a SDN controller is introduced and close it when its removed. 

This allow the SDN controller to creates VxLAN without having to manually change iptables rules.