### PR TITLE
CA-321930 XSI-374 GPU compatibility check not done on snapshot snapshot

### DIFF
--- a/ocaml/xapi/xapi_gpumon.ml
+++ b/ocaml/xapi/xapi_gpumon.ml
@@ -204,7 +204,9 @@ let update_vgpu_metadata ~__context ~vm =
           Nvidia.get_vgpu_compatibility_metadata ~__context ~vm ~vgpu
         else [] in
       Db.VGPU.set_compatibility_metadata ~__context ~self:vgpu ~value;
-      debug "writing vGPU compat metadata for vGPU %s" (Ref.string_of vgpu))
+      debug "Writing vGPU compat metadata for vGPU %s: [%s]"
+        (Ref.string_of vgpu)
+        (List.map fst value |> String.concat ":"))
 
 (** [clear_vgpu_metadata] removes compatibility metadata from all
  * vgpus of [vm]. *)

--- a/ocaml/xapi/xapi_vgpu.ml
+++ b/ocaml/xapi/xapi_vgpu.ml
@@ -50,7 +50,8 @@ let get_valid_device ~__context ~device ~vM ~vGPUs =
   else
     raise Api_errors.(Server_error (invalid_device, [device]))
 
-let create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type ~powerstate_check =
+let create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type 
+  ~powerstate_check ~compatibility_metadata =
   let vgpu = Ref.make () in
   let uuid = Uuid.to_string (Uuid.make_uuid ()) in
   if not (Pool_features.is_enabled ~__context Features.GPU) then
@@ -86,7 +87,7 @@ let create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type ~powerstate_
       Db.VGPU.create ~__context ~ref:vgpu ~uuid ~vM ~gPU_group ~device:device_id
         ~currently_attached:false ~other_config ~_type ~resident_on:Ref.null
         ~scheduled_to_be_resident_on:Ref.null
-        ~compatibility_metadata:[]
+        ~compatibility_metadata
         ~extra_args:""
       ;
     );
@@ -100,7 +101,8 @@ let create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type ~powerstate_
 *)
 let create ~__context  ~vM ~gPU_group ~device ~other_config ~_type =
   let powerstate_check = not (Db.VM.get_is_a_snapshot ~__context ~self:vM) in
-  create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type ~powerstate_check
+  create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type 
+    ~powerstate_check ~compatibility_metadata:[]
 
 let destroy ~__context ~self =
   let vm = Db.VGPU.get_VM ~__context ~self in
@@ -119,6 +121,7 @@ let copy ~__context ~vm vgpu =
       ~other_config:all.API.vGPU_other_config
       ~_type:all.API.vGPU_type
       ~powerstate_check:false
+      ~compatibility_metadata:all.API.vGPU_compatibility_metadata
   in
   if all.API.vGPU_currently_attached then
     Db.VGPU.set_currently_attached ~__context ~self:vgpu ~value:true;

--- a/ocaml/xapi/xapi_vgpu.ml
+++ b/ocaml/xapi/xapi_vgpu.ml
@@ -50,7 +50,7 @@ let get_valid_device ~__context ~device ~vM ~vGPUs =
   else
     raise Api_errors.(Server_error (invalid_device, [device]))
 
-let create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type 
+let create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type
   ~powerstate_check ~compatibility_metadata =
   let vgpu = Ref.make () in
   let uuid = Uuid.to_string (Uuid.make_uuid ()) in
@@ -81,7 +81,9 @@ let create' ~__context  ~vM ~gPU_group ~device ~other_config ~_type
   if not (List.for_all (is_in_compatible_lists _type) types) then
     raise (Api_errors.Server_error (Api_errors.vgpu_type_not_compatible, [Ref.string_of _type]));
 
-
+  debug "Creating vGPU %s with metadata: [%s]"
+    (Ref.string_of vgpu)
+    (List.map fst compatibility_metadata |> String.concat ":");
   Stdext.Threadext.Mutex.execute m (fun () ->
       let device_id = get_valid_device ~__context ~device ~vM ~vGPUs:existing in
       Db.VGPU.create ~__context ~ref:vgpu ~uuid ~vM ~gPU_group ~device:device_id

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -203,6 +203,7 @@ let checkpoint ~__context ~vm ~new_name =
            then raise (Api_errors.Server_error (Api_errors.sr_operation_not_supported, [Ref.string_of vm])) )
         sr_records ;
       (* suspend the VM *)
+      Xapi_gpumon.update_vgpu_metadata ~__context ~vm;
       Xapi_xenops.suspend ~__context ~self:vm;
     with
     | Api_errors.Server_error(_, _) as e -> raise e


### PR DESCRIPTION
When saving a snapshot, make sure to save VGPU metadata such that it is
available on resume.
