### PR TITLE
CA-322710: improve clustering error message

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1150,7 +1150,7 @@ let _ =
   error Api_errors.cluster_does_not_have_one_node ["number_of_nodes"]
     ~doc:"An operation failed as it expected the cluster to have only one node but found multiple cluster_hosts." ();
   error Api_errors.no_compatible_cluster_host ["host"]
-    ~doc:"The host does not have a Cluster_host with a compatible cluster stack." ();
+    ~doc:"Clustering is not enabled on this host or pool." ();
   error Api_errors.cluster_force_destroy_failed ["cluster"]
     ~doc:"Force destroy failed on a Cluster_host while force destroying the cluster." ();
   error Api_errors.cluster_stack_in_use ["cluster_stack"]


### PR DESCRIPTION
When trying to repair a GFS2 SR and clustering is disabled I got this error message.
Try to simplify it for the user: they have to enable clustering to fix it, so try to be more obvious in telling the user that the problem is that clustering is not enabled.