### PR TITLE
CA-322749: Make toolstack work with old Nvidia drivers

### DIFF
--- a/ocaml/tests/test_xenopsd_metadata.ml
+++ b/ocaml/tests/test_xenopsd_metadata.ml
@@ -231,6 +231,7 @@ module GenerateVGPUMetadata =
           module State = Test_state.XapiDb
 
           let load_input __context (vm_config, pgpus_and_vgpu_types) =
+            Xapi_globs.nvidia_multi_vgpu_enabled_driver_versions := [Xapi_globs.nvidia_default_host_driver_version];
             let vm_ref = load_vm_config __context vm_config in
             List.iteri
               (fun index (pgpu, vgpu_type) ->
@@ -315,6 +316,7 @@ module GenerateMultiVGPUMetadata =
           module State = Test_state.XapiDb
 
           let load_input __context (vm_config, pgpus_and_vgpu_types) =
+            Xapi_globs.nvidia_multi_vgpu_enabled_driver_versions := [Xapi_globs.nvidia_default_host_driver_version];
             let vm_ref = load_vm_config __context vm_config in
             List.iteri
               (fun index (pgpu, vgpu_type) ->

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -447,7 +447,9 @@ let vgt_fence_sz = "vgt_fence_sz"
 let mxgpu_vgpus_per_pgpu = "vgpus_per_pgpu"
 
 let nvidia_vgpu_first_slot_in_guest = 11
-let nvidia_compat_lookup_file = ref "/var/run/nonpersistent/xapi/nvidia_compat_lookup"
+let nvidia_host_driver_file = ref "/usr/lib64/libnvidia-vgpu.so"
+let nvidia_compat_conf_dir = "/usr/share/nvidia/vgx"
+let nvidia_compat_config_file_key = "config_file"
 
 let wlb_timeout = "wlb_timeout"
 let wlb_reports_timeout = "wlb_reports_timeout"
@@ -890,6 +892,9 @@ let sm_plugins = ref [ ]
 let accept_sm_plugin name =
   List.(fold_left (||) false (map (function `All -> true | `Sm x -> String.lowercase_ascii x = String.lowercase_ascii name) !sm_plugins))
 
+let nvidia_multi_vgpu_enabled_driver_versions = ref ["430.19"]
+let nvidia_default_host_driver_version = "0.0"
+
 let other_options = [
   gen_list_option "sm-plugins"
     "space-separated list of storage plugins to allow."
@@ -980,8 +985,9 @@ let other_options = [
   "db_idempotent_map", Arg.Set Db_globs.idempotent_map,
   (fun () -> string_of_bool !Db_globs.idempotent_map), "True if the add_to_<map> API calls should be idempotent";
 
-  "nvidia_compat_lookup_file", Arg.Set_string nvidia_compat_lookup_file,
-  (fun () -> !nvidia_compat_lookup_file), "Path to the file with NVidia vGPU compat data for use by xenopsd";
+  "nvidia_multi_vgpu_enabled_driver_versions", Arg.String (fun x -> nvidia_multi_vgpu_enabled_driver_versions := String.split ',' x),
+  (fun () -> String.concat "," !nvidia_multi_vgpu_enabled_driver_versions), "list of nvidia host driver versions with multiple vGPU supported.
+  if a version end with +, it means any driver version greater or equal than that version";
 ]
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -211,7 +211,7 @@ let update_gpus ~__context =
          (fun (_, pgpu_rec) -> pgpu_rec.API.pGPU_GPU_group)
          (current_pgpus @ obsolete_pgpus))
   in
-  Xapi_vgpu_type.Nvidia_compat.create_compat_lookup_file __context;
+  Xapi_vgpu_type.Nvidia_compat.create_compat_config_file __context;
   Helpers.call_api_functions ~__context
     (fun rpc session_id ->
        List.iter

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -663,16 +663,17 @@ module MD = struct
     let physical_pci_address = get_target_pci_address ~__context vgpu in
     let virtual_pci_address = get_virtual_pci_address ~__context vgpu in
     let vgpu_type = vgpu.Db_actions.vGPU_type in
-    let type_id = Db.VGPU_type.get_internal_config ~__context ~self:vgpu_type 
-                  |> List.assoc Xapi_globs.vgpu_type_id in
+    let type_id, config_file = Db.VGPU_type.get_internal_config ~__context ~self:vgpu_type
+                               |> (fun x -> (List.assoc_opt Xapi_globs.vgpu_type_id x),
+                                            (List.assoc_opt Xapi_globs.nvidia_compat_config_file_key x)) in
     let uuid = vgpu.Db_actions.vGPU_uuid in
     let extra_args = vgpu.Db_actions.vGPU_extra_args in
     let implementation =
       Nvidia {
         physical_pci_address = None; (* unused *)
-        config_file = None; (* unused *)
+        config_file;
         virtual_pci_address;
-        type_id  = Some type_id;
+        type_id;
         uuid = Some uuid;
         extra_args;
       }


### PR DESCRIPTION
This PR make xapi work with old NVidia drivers that has no multiple vGPU support as followings

   - Check whether the Nvidia host installed suport multiple vGPU
   -  Make up old config_file argument for demu in case host driver does not support multiple vGPU
   - Make all VGPU_type does not compatible with any one (including themselves) if host driver does not support multiple vGPU

How xapi judge whether a Nvidia driver support multple vGPU:
Add configration variable nvidia_multi_vgpu_enabled_driver_versions
   
   nvidia_multi_vgpu_enabled_driver_versions is a list and configurable
    in xapi confie file /etc/xapi.conf, it stating the version of Nvidia
    host drivers that have multiple vGPU support. The elements in the list
    have following two formats:
    1. "major_version.minor_versoin": the specific version that support
    multiple vGPU.
    2. "major_version.minor_version+": any version biger than this version
    is taken to support multiple vGPU.
Currently installed Nvidia vGPU version is read from file:  `/usr/lib64/libnvidia-vgpu.so`, per suggested by  Rob.

I will delete the `nvidia_compat_lookup_file` related code after this PR merged.