### PR TITLE
CA-316165: uplift Thread.delay thresholds to make relative timing mor…

### DIFF
--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -42,7 +42,7 @@ let () =
     ; "Test_pool_db_backup", Test_pool_db_backup.test
     ; "Test_pool_restore_database", Test_pool_restore_database.test
     ; "Test_workload_balancing", Test_workload_balancing.test
-    (* ; "Test_pusb", Test_pusb.test *)
+    ; "Test_pusb", Test_pusb.test
     ; "Test_pvs_site", Test_pvs_site.test
     ; "Test_pvs_proxy", Test_pvs_proxy.test
     ; "Test_pvs_server", Test_pvs_server.test
@@ -50,6 +50,6 @@ let () =
     ; "Test_vm_placement", Test_vm_placement.test
     ; "Test_vm_memory_constraints", Test_vm_memory_constraints.test
     ; "Test_xapi_xenops", Test_xapi_xenops.test
-    (* ; "Test_network_event_loop", Test_network_event_loop.test disabled due to CA-316165 *)
+    ; "Test_network_event_loop", Test_network_event_loop.test
     ]
 

--- a/ocaml/tests/test_clustering.ml
+++ b/ocaml/tests/test_clustering.ml
@@ -258,7 +258,7 @@ let test_clustering_lock_taken_when_needed_nested_calls () =
 
   nest_with_clustering_lock_if_needed
     ~__context
-    ~timeout:0.1
+    ~timeout:1.0
     ~type1: "type_corosync1"
     ~type2: "type_corosync2"
     ~on_deadlock: (fun () -> ())
@@ -643,5 +643,5 @@ let test =
     @ test_pool_ha_cluster_stacks
     (* NOTE: lock test hoards the mutex and should thus always be last,
      * otherwise any other functions trying to use the lock will hang *)
-    (* @ test_clustering_lock_only_taken_if_needed: Thread.delay in test *)
+    @ test_clustering_lock_only_taken_if_needed
   )

--- a/ocaml/tests/test_daemon_manager.ml
+++ b/ocaml/tests/test_daemon_manager.ml
@@ -145,7 +145,7 @@ let test =
     "test_two_restarts", `Quick, test_two_restarts;
     "test_already_stopped", `Quick, test_already_stopped;
     "test_exception", `Quick, test_exception;
-    (* "test_threads", `Slow, test_threads; CA-316165: Thread.delay in test *)
+    "test_threads", `Slow, test_threads;
     "test_timeout_succeed", `Slow, test_timeout_succeed;
     "test_timeout_fail", `Slow, test_timeout_fail;
   ]

--- a/ocaml/tests/test_event.ml
+++ b/ocaml/tests/test_event.ml
@@ -242,10 +242,9 @@ let test =
     "test_event_from_timeout", `Slow, test_event_from_timeout;
     "test_event_from_ev", `Quick, test_event_from_ev;
     "test_event_from_ev_rel", `Quick, test_event_from_ev_rel;
-  (*   "test_event_next_unblock", `Slow, event_next_unblock;
+    "test_event_next_unblock", `Slow, event_next_unblock;
     "test_event_next", `Slow, event_next_test;
     "test_event_from", `Quick, event_from_test;
     "test_event_from_parallel", `Slow, event_from_parallel_test;
     "test_event_object_level_event", `Slow, object_level_event_test;
-    CA-316165: Thread.delay in test *)
   ]

--- a/ocaml/tests/test_network_event_loop.ml
+++ b/ocaml/tests/test_network_event_loop.ml
@@ -20,8 +20,8 @@ let test_network_event_loop ~no_nbd_networks_at_start () =
   let other_host = Test_common.make_host ~__context () in
 
   (* We have to wait for a bit for the event loop to notice the changes, without a delay the test will fail. *)
-  let delay = 0.2 in
-  let network_event_loop_wait_after_failure_seconds = 0.4 in
+  let delay = 0.5 in
+  let network_event_loop_wait_after_failure_seconds = 1.0 in
   let received_params = ref None in
 
   (* We simulate failure of the firewall update script this way *)

--- a/ocaml/tests/test_vdi_cbt.ml
+++ b/ocaml/tests/test_vdi_cbt.ml
@@ -404,14 +404,14 @@ let test_data_destroy =
     let test_data_destroy_succeeds_when_unplug_starts_later () =
       let _vdi, start_vbd_unplug, finish_vbd_unplug, destroy_vbd, data_destroy = setup_test () in
       let t = bg (fun () ->
-          Thread.delay 0.05;
+          Thread.delay 0.2;
           start_vbd_unplug ();
-          Thread.delay 0.05;
+          Thread.delay 0.2;
           finish_vbd_unplug ();
-          Thread.delay 0.05;
+          Thread.delay 0.2;
           destroy_vbd ()
         ) in
-      data_destroy ~timeout:0.4;
+      data_destroy ~timeout:1.0;
       Thread.join t
     in
 
@@ -419,13 +419,13 @@ let test_data_destroy =
       let _vdi, start_vbd_unplug, finish_vbd_unplug, destroy_vbd, data_destroy = setup_test () in
       let t = bg (fun () ->
           start_vbd_unplug ();
-          Thread.delay 0.05;
+          Thread.delay 0.2;
           finish_vbd_unplug ();
-          Thread.delay 0.05;
+          Thread.delay 0.2;
           destroy_vbd ()
         ) in
-      Thread.delay 0.02;
-      data_destroy ~timeout:0.4;
+      Thread.delay 0.1;
+      data_destroy ~timeout:1.0;
       Thread.join t
     in
 
@@ -434,39 +434,37 @@ let test_data_destroy =
       let t = bg (fun () ->
           start_vbd_unplug ();
           finish_vbd_unplug ();
-          Thread.delay 0.05;
+          Thread.delay 0.2;
           destroy_vbd ()
         ) in
-      Thread.delay 0.02;
-      data_destroy ~timeout:0.4;
+      Thread.delay 0.1;
+      data_destroy ~timeout:1.0;
       Thread.join t
     in
 
     let test_data_destroy_times_out_when_vbd_does_not_get_unplugged_in_time () =
       let vDI, start_vbd_unplug, finish_vbd_unplug, destroy_vbd, data_destroy = setup_test () in
       let t = bg (fun () ->
-          Thread.delay 0.05;
           start_vbd_unplug ();
           (* finish_vbd_unplug does not happen in time *)
         ) in
       Alcotest.check_raises "data_destroy should raise VDI_IN_USE after its timeout"
         Api_errors.(Server_error (vdi_in_use, [Ref.string_of vDI; "data_destroy"]))
-        (fun () -> data_destroy ~timeout:0.4);
+        (fun () -> data_destroy ~timeout:1.0);
       Thread.join t
     in
 
     let test_data_destroy_times_out_when_vbd_does_not_get_destroyed_in_time () =
       let vDI, start_vbd_unplug, finish_vbd_unplug, destroy_vbd, data_destroy = setup_test () in
       let t = bg (fun () ->
-          Thread.delay 0.05;
           start_vbd_unplug ();
-          Thread.delay 0.05;
+          Thread.delay 0.2;
           finish_vbd_unplug ();
           (* destroy_vbd does not happen in time *)
         ) in
       Alcotest.check_raises "data_destroy should raise VDI_IN_USE after its timeout"
         Api_errors.(Server_error (vdi_in_use, [Ref.string_of vDI; "data_destroy"]))
-        (fun () -> data_destroy ~timeout:0.4);
+        (fun () -> data_destroy ~timeout:1.0);
       Thread.join t
     in
 
@@ -518,4 +516,4 @@ let test =
   ; "test_allowed_operations_updated_when_necessary", `Quick, test_allowed_operations_updated_when_necessary
   ; "test_vdi_list_changed_blocks", `Quick, test_vdi_list_changed_blocks ]
   @ test_get_nbd_info
-  (* @ test_data_destroy CA-316165: Thread.delay in test *)
+  @ test_data_destroy


### PR DESCRIPTION
…e reliable

Some of these time values are set too aggressive (small). So in an extremely
stressed environment,  the deviations caused by the heavy loads could become
comparable/noticeable, and in some cases this lead to the break through of
predefined timeboxes or the change of relative order between steps.

We reviewed these cases one by one. For those in need, we uplift the relevant
delay thresholds, to make the steps higher, so that such issues are less likely.
Some cases already have relatively high thresholds set, which remain untouched.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>