### PR TITLE
CA-319960: Remove user KRBTGT from cache before checking

### DIFF
--- a/ocaml/auth/extauth_plugin_ADpbis.ml
+++ b/ocaml/auth/extauth_plugin_ADpbis.ml
@@ -42,6 +42,8 @@ struct
 
   let user_friendly_error_msg = "The Active Directory Plug-in could not complete the command. Additional information in the logs."
 
+  let mutex_check_availability = Locking_helpers.Named_mutex.create "IS_SERVER_AVAILABLE"
+
   let splitlines s = String.split_f (fun c -> c = '\n') (String.replace "#012" "\n" s)
 
   let pbis_common_with_password (password:string) (pbis_cmd:string) (pbis_args:string list) =
@@ -489,7 +491,8 @@ struct
     In addition, there are some event hooks that auth modules implement as follows:
 *)
 
-  let is_pbis_server_available max =
+  let _is_pbis_server_available max =
+    let username = "KRBTGT" in (* domain name prefix automatically added by our internal AD plugin functions *)
     let rec test i = (* let's test this many times *)
       if i > max then false (* we give up *)
       else begin (* let's test *)
@@ -531,8 +534,21 @@ struct
     in
     begin
       debug "Testing if external authentication server is accepting requests...";
+      let full_username = get_full_subject_name username in
+      begin try
+          ignore(pbis_common "/opt/pbis/bin/ad-cache" ["--delete-user"; "--name"; full_username])
+        with
+        | Not_found -> ()
+        | e ->
+          debug "Failed to remove user %s from cache: %s" full_username (ExnHelper.string_of_exn e);
+          raise e
+      end;
       test 0
     end
+
+  let is_pbis_server_available max =
+    Locking_helpers.Named_mutex.execute mutex_check_availability
+      (fun () -> _is_pbis_server_available max)
 
   (* converts from domain.com\user to user@domain.com, in case domain.com is present in the subject_name *)
   let convert_nt_to_upn_username subject_name =


### PR DESCRIPTION
PBIS will return success when it queries user KRBTGT even if the domain is
offline but the user KRBTGT is in the cache. This makes the XAPI fail to
check the availability of domain by this appoach.

This commit adds logic to remove the user KRBTGT from cache before XAPI
checks the availabililty of domain.

Signed-off-by: Ming Lu <ming.lu@citrix.com>