### PR TITLE
Maintenance: silence Merlin warnings

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
-(lang dune 1.4)
+(lang dune 1.9)
+(allow_approximate_merlin)


### PR DESCRIPTION
  Warning: .merlin generated is inaccurate. Cannot mix preprocessed and
  non preprocessed specificiations.  Split the stanzas into different
  directories or silence this warning by adding
  (allow_approximate_merlin) to your dune-project.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>