### PR TITLE
CA-316165: Convert some Thread.delay to Delay.wait

### DIFF
--- a/ocaml/tests/test_vdi_cbt.ml
+++ b/ocaml/tests/test_vdi_cbt.ml
@@ -12,6 +12,7 @@
 -  GNU Lesser General Public License for more details.
   *)
 
+open Stdext
 
 let register_smapiv2_server (module S: Storage_interface.Server_impl) sr_ref =
   let module S = Storage_interface.Server(S)() in
@@ -386,13 +387,12 @@ let test_data_destroy =
       in
       let destroy_vbd () = Db.VBD.destroy ~__context ~self:vbd in
       let data_destroy ~timeout =
-        (* We need a 1-second tolerance here, otherwise the test will fail *)
-        let timebox_timeout = timeout +. 1.0 in
-        let completed = ref false in
+        (* It could return earlier normally, but this is the longest we'd wait in case of extreme situation *)
+        let timebox_timeout = timeout +. 1.0 *. 10. in
+        let wait_hdl = Threadext.Delay.make() in
         let raisedexn = ref None in
-        ignore (bg (fun () -> (try Xapi_vdi._data_destroy ~__context ~self:vDI ~timeout with e -> raisedexn := Some e); completed := true));
-        Thread.delay timebox_timeout;
-        if not !completed then
+        ignore (bg (fun () -> (try Xapi_vdi._data_destroy ~__context ~self:vDI ~timeout with e -> raisedexn := Some e); Threadext.Delay.signal wait_hdl));
+        if Threadext.Delay.wait wait_hdl timebox_timeout then
           Alcotest.fail (Printf.sprintf "data_destroy did not return in %f seconds" timebox_timeout);
         match !raisedexn with
         | None -> ()


### PR DESCRIPTION
Following suggestions on the ticket, here we convert some unconditional wait
(Thread.delay) to conditional wait (Delay.wait).

The pattern is, in these tests we expect to observe something to happen, but it
has to be within a reasonable time frame. From testing point of view, we can
not assume a function will always return (especially if it was implemented
wrong) and we certainly don't want to wait indefinitely.

Previously with Thread.delay, we unconditionally wait for a timeout, then check
the observed value. Not pretty, but it doesn't require any kind of
collaboration from the observed party. The problem is, if we set the timeout
tight, it might time out if the system is extremely stressed. But if we set the
timeout too relax, we end up wasting time every single run.

Now With Delay.wait, we wait conditionally on both a timeout and a
signal/condition. In these case, we can now set the timeout generously (say,
times higher than the usual value, as a real hard timeout), but knowing that in
most cases the wait will end much earlier as usual (upon some
signal/condition) instead of breaking out of the timeout.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>