### PR TITLE
CP-31450: Add domid to Datapath.attach

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -426,7 +426,7 @@ module SMAPIv1 = struct
       | Api_errors.Server_error(code, params) ->
         raise (Storage_error (Backend_error(code, params)))
 
-    let attach2 context ~dbg ~dp ~sr ~vdi ~read_write =
+    let attach2 context ~dbg ~dp ~sr ~vdi ~vm ~read_write =
       try
         let backend =
           for_vdi ~dbg ~sr ~vdi "VDI.attach2"
@@ -1362,7 +1362,8 @@ let attach_and_activate ~__context ~vbd ~domid f =
        on_vdi ~__context ~vbd ~domid
          (fun rpc dbg dp sr vdi ->
             let module C = Storage_interface.StorageAPI(Idl.Exn.GenClient(struct let rpc = rpc end)) in
-            let attach_info = C.VDI.attach2 dbg dp sr vdi read_write in
+            let vm = (Storage_interface.Vm.of_string (string_of_int domid)) in
+            let attach_info = C.VDI.attach2 dbg dp sr vdi vm read_write in
             C.VDI.activate dbg dp sr vdi;
             f attach_info
          )

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -417,7 +417,7 @@ module SMAPIv1 = struct
       per_host_key ~__context ~prefix:"read-caching-reason"
 
 
-    let epoch_begin context ~dbg ~sr ~vdi ~persistent =
+    let epoch_begin context ~dbg ~sr ~vdi ~vm ~persistent =
       try
         for_vdi ~dbg ~sr ~vdi "VDI.epoch_begin"
           (fun device_config _type sr self ->
@@ -426,7 +426,7 @@ module SMAPIv1 = struct
       | Api_errors.Server_error(code, params) ->
         raise (Storage_error (Backend_error(code, params)))
 
-    let attach2 context ~dbg ~dp ~sr ~vdi ~vm ~read_write =
+    let attach2 context ~dbg ~dp ~sr ~vdi ~read_write =
       try
         let backend =
           for_vdi ~dbg ~sr ~vdi "VDI.attach2"
@@ -467,6 +467,10 @@ module SMAPIv1 = struct
       with Api_errors.Server_error(code, params) ->
         raise (Storage_error (Backend_error(code, params)))
 
+    let attach3 context ~dbg ~dp ~sr ~vdi ~vm ~read_write =
+      (*Throw away vm argument as does nothing in SMAPIv1*)
+      attach2 context ~dbg ~dp ~sr ~vdi ~read_write
+
     let attach _ =
       failwith "We'll never get here: attach is implemented in Storage_impl.Wrapper"
 
@@ -490,7 +494,10 @@ module SMAPIv1 = struct
       with Api_errors.Server_error(code, params) ->
         raise (Storage_error (Backend_error(code, params)))
 
-    let deactivate context ~dbg ~dp ~sr ~vdi =
+    let activate3 context ~dbg ~dp ~sr ~vdi ~vm =
+      activate context ~dbg ~dp ~sr ~vdi
+
+    let deactivate context ~dbg ~dp ~sr ~vdi ~vm =
       try
         for_vdi ~dbg ~sr ~vdi "VDI.deactivate"
           (fun device_config _type sr self ->
@@ -507,7 +514,7 @@ module SMAPIv1 = struct
       with Api_errors.Server_error(code, params) ->
         raise (Storage_error (Backend_error(code, params)))
 
-    let detach context ~dbg ~dp ~sr ~vdi =
+    let detach context ~dbg ~dp ~sr ~vdi ~vm =
       try
         for_vdi ~dbg ~sr ~vdi "VDI.detach"
           (fun device_config _type sr self ->
@@ -526,7 +533,7 @@ module SMAPIv1 = struct
       with Api_errors.Server_error(code, params) ->
         raise (Storage_error (Backend_error(code, params)))
 
-    let epoch_end context ~dbg ~sr ~vdi =
+    let epoch_end context ~dbg ~sr ~vdi ~vm =
       try
         for_vdi ~dbg ~sr ~vdi "VDI.epoch_end"
           (fun device_config _type sr self ->
@@ -1363,8 +1370,8 @@ let attach_and_activate ~__context ~vbd ~domid f =
          (fun rpc dbg dp sr vdi ->
             let module C = Storage_interface.StorageAPI(Idl.Exn.GenClient(struct let rpc = rpc end)) in
             let vm = (Storage_interface.Vm.of_string (string_of_int domid)) in
-            let attach_info = C.VDI.attach2 dbg dp sr vdi vm read_write in
-            C.VDI.activate dbg dp sr vdi;
+            let attach_info = C.VDI.attach3 dbg dp sr vdi vm read_write in
+            C.VDI.activate3 dbg dp sr vdi vm;
             f attach_info
          )
     )

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -346,15 +346,15 @@ module Wrapper = functor(Impl: Server_impl) -> struct
             | Vdi_automaton.Nothing -> vdi_t
             | Vdi_automaton.Attach ro_rw ->
               let read_write = (ro_rw = Vdi_automaton.RW) in
-              let x = Impl.VDI.attach2 context ~dbg ~dp ~sr ~vdi ~vm ~read_write in
+              let x = Impl.VDI.attach3 context ~dbg ~dp ~sr ~vdi ~vm ~read_write in
               { vdi_t with Vdi.attach_info = Some x }
             | Vdi_automaton.Activate ->
-              Impl.VDI.activate context ~dbg ~dp ~sr ~vdi; vdi_t
+              Impl.VDI.activate3 context ~dbg ~dp ~sr ~vdi ~vm; vdi_t
             | Vdi_automaton.Deactivate ->
               Storage_migrate.pre_deactivate_hook ~dbg ~dp ~sr ~vdi;
-              Impl.VDI.deactivate context ~dbg ~dp ~sr ~vdi; vdi_t
+              Impl.VDI.deactivate context ~dbg ~dp ~sr ~vdi ~vm; vdi_t
             | Vdi_automaton.Detach ->
-              Impl.VDI.detach context ~dbg ~dp ~sr ~vdi;
+              Impl.VDI.detach context ~dbg ~dp ~sr ~vdi ~vm;
               Storage_migrate.post_detach_hook ~sr ~vdi ~dp;
               vdi_t
           in
@@ -373,7 +373,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
       in
       List.fold_left perform_one vdi_t ops
 
-    let perform_nolock context ~dbg ~dp ~sr ~vdi ?(vm=(vm_of_s "")) this_op =
+    let perform_nolock context ~dbg ~dp ~sr ~vdi ~vm this_op =
       match Host.find sr !Host.host with
       | None -> raise (Storage_error (Sr_not_attached (s_of_sr sr)))
       | Some sr_t ->
@@ -419,7 +419,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
         vdi_t'
 
     (* Attempt to remove a possibly-active datapath associated with [vdi] *)
-    let destroy_datapath_nolock context ~dbg ~dp ~sr ~vdi ~allow_leak =
+    let destroy_datapath_nolock context ~dbg ~dp ~sr ~vdi ~vm ~allow_leak =
       match Host.find sr !Host.host with
       | None -> raise (Storage_error (Sr_not_attached (s_of_sr sr)))
       | Some sr_t ->
@@ -430,7 +430,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
             begin
               try
                 ignore(List.fold_left (fun _ op ->
-                    perform_nolock context ~dbg ~dp ~sr ~vdi op
+                    perform_nolock context ~dbg ~dp ~sr ~vdi ~vm op
                   ) vdi_t ops)
               with e ->
                 if not allow_leak
@@ -449,7 +449,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
             end) (Sr.find vdi sr_t)
 
     (* Attempt to clear leaked datapaths associed with this vdi *)
-    let remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi which next =
+    let remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm which next =
       let dps = match Host.find sr !Host.host with
         | None -> []
         | Some sr_t ->
@@ -461,7 +461,7 @@ module Wrapper = functor(Impl: Server_impl) -> struct
       let failures = List.fold_left (fun acc dp ->
           info "Attempting to destroy datapath dp:%s sr:%s vdi:%s" dp (s_of_sr sr) (s_of_vdi vdi);
           try
-            destroy_datapath_nolock context ~dbg ~dp ~sr ~vdi ~allow_leak:false;
+            destroy_datapath_nolock context ~dbg ~dp ~sr ~vdi ~vm ~allow_leak:false;
             acc
           with e -> e :: acc
         ) [] dps in
@@ -469,30 +469,36 @@ module Wrapper = functor(Impl: Server_impl) -> struct
       | [] -> next ()
       | f :: fs -> raise f
 
-    let epoch_begin context ~dbg ~sr ~vdi ~persistent =
-      info "VDI.epoch_begin dbg:%s sr:%s vdi:%s persistent:%b" dbg (s_of_sr sr) (s_of_vdi vdi) persistent;
+    let epoch_begin context ~dbg ~sr ~vdi ~vm ~persistent =
+      info "VDI.epoch_begin dbg:%s sr:%s vdi:%s vm:%s persistent:%b" dbg (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) persistent;
       with_vdi sr vdi
         (fun () ->
-           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.leaked
+           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
              (fun () ->
-                Impl.VDI.epoch_begin context ~dbg ~sr ~vdi ~persistent
+                Impl.VDI.epoch_begin context ~dbg ~sr ~vdi ~vm ~persistent
              ))
 
-    let attach2 context ~dbg ~dp ~sr ~vdi ~vm ~read_write =
-      info "VDI.attach2 dbg:%s dp:%s sr:%s vdi:%s vm:%s read_write:%b" dbg dp (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) read_write;
+    let attach3 context ~dbg ~dp ~sr ~vdi ~vm ~read_write =
+      info "VDI.attach3 dbg:%s dp:%s sr:%s vdi:%s vm:%s read_write:%b" dbg dp (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) read_write;
       with_vdi sr vdi
         (fun () ->
-           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.leaked
+           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
              (fun () ->
                 let state = perform_nolock context ~dbg ~dp ~sr ~vdi ~vm 
                     (Vdi_automaton.Attach (if read_write then Vdi_automaton.RW else Vdi_automaton.RO)) in
                 Opt.unbox state.Vdi.attach_info
              ))
 
+    let attach2 context ~dbg ~dp ~sr ~vdi ~read_write =
+      info "VDI.attach2 dbg:%s dp:%s sr:%s vdi:%s read_write:%b" dbg dp (s_of_sr sr) (s_of_vdi vdi) read_write;
+      (*Support calls from older XAPI during migrate operation (dom 0 attach )*)
+      let vm = (vm_of_s "0") in
+      attach3 context ~dbg ~dp ~sr ~vdi ~vm ~read_write
+
     let attach context ~dbg ~dp ~sr ~vdi ~read_write =
       info "VDI.attach dbg:%s dp:%s sr:%s vdi:%s read_write:%b" dbg dp (s_of_sr sr) (s_of_vdi vdi) read_write;
-      let vm = (vm_of_s "") in
-      let backend = attach2 context ~dbg ~dp ~sr ~vdi ~vm ~read_write in
+      let vm = (vm_of_s "0") in
+      let backend = attach3 context ~dbg ~dp ~sr ~vdi ~vm ~read_write in
       (* VDI.attach2 should be used instead, VDI.attach is only kept for
          backwards-compatibility, because older xapis call Remote.VDI.attach during SXM.
          However, they ignore the return value, so in practice it does not matter what
@@ -513,37 +519,44 @@ module Wrapper = functor(Impl: Server_impl) -> struct
       | _, _, blockdev::_ -> response blockdev.Storage_interface.path
       | [], [], [] -> raise (Storage_interface.Storage_error (Backend_error (Api_errors.internal_error, ["No File, BlockDev, or XenDisk implementation in Datapath.attach response: " ^ (Storage_interface.(rpc_of backend) backend |> Jsonrpc.to_string)])))
 
+    let activate3 context ~dbg ~dp ~sr ~vdi ~vm =
+      info "VDI.activate3 dbg:%s dp:%s sr:%s vdi:%s vm:%s" dbg dp (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm);
+      with_vdi sr vdi
+        (fun () ->
+           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
+             (fun () ->
+                ignore(perform_nolock context ~dbg ~dp ~sr ~vdi ~vm Vdi_automaton.Activate)))
+        
+
     let activate context ~dbg ~dp ~sr ~vdi =
-      info "VDI.activate dbg:%s dp:%s sr:%s vdi:%s" dbg dp (s_of_sr sr) (s_of_vdi vdi);
-      with_vdi sr vdi
-        (fun () ->
-           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.leaked
-             (fun () ->
-                ignore(perform_nolock context ~dbg ~dp ~sr ~vdi Vdi_automaton.Activate)))
+      info "VDI.activate dbg:%s dp:%s sr:%s vdi:%s " dbg dp (s_of_sr sr) (s_of_vdi vdi);
+      (*Support calls from older XAPI during migrate operation (dom 0 attach )*)
+      let vm = (vm_of_s "0") in
+      activate3 context ~dbg ~dp ~sr ~vdi ~vm 
 
-    let deactivate context ~dbg ~dp ~sr ~vdi =
-      info "VDI.deactivate dbg:%s dp:%s sr:%s vdi:%s" dbg dp (s_of_sr sr) (s_of_vdi vdi);
+    let deactivate context ~dbg ~dp ~sr ~vdi ~vm =
+      info "VDI.deactivate dbg:%s dp:%s sr:%s vdi:%s vm:%s" dbg dp (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm);
       with_vdi sr vdi
         (fun () ->
-           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.leaked
+           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
              (fun () ->
-                ignore (perform_nolock context ~dbg ~dp ~sr ~vdi Vdi_automaton.Deactivate)))
+                ignore (perform_nolock context ~dbg ~dp ~sr ~vdi ~vm Vdi_automaton.Deactivate)))
 
-    let detach context ~dbg ~dp ~sr ~vdi =
-      info "VDI.detach dbg:%s dp:%s sr:%s vdi:%s" dbg dp (s_of_sr sr) (s_of_vdi vdi);
+    let detach context ~dbg ~dp ~sr ~vdi ~vm =
+      info "VDI.detach dbg:%s dp:%s sr:%s vdi:%s vm:%s" dbg dp (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm);
       with_vdi sr vdi
         (fun () ->
-           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.leaked
+           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
              (fun () ->
-                ignore (perform_nolock context ~dbg ~dp ~sr ~vdi Vdi_automaton.Detach)))
+                ignore (perform_nolock context ~dbg ~dp ~sr ~vdi ~vm Vdi_automaton.Detach)))
 
-    let epoch_end context ~dbg ~sr ~vdi =
-      info "VDI.epoch_end dbg:%s sr:%s vdi:%s" dbg (s_of_sr sr) (s_of_vdi vdi);
+    let epoch_end context ~dbg ~sr ~vdi ~vm =
+      info "VDI.epoch_end dbg:%s sr:%s vdi:%s vm:%s" dbg (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm);
       with_vdi sr vdi
         (fun () ->
-           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.leaked
+           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
              (fun () ->
-                Impl.VDI.epoch_end context ~dbg ~sr ~vdi
+                Impl.VDI.epoch_end context ~dbg ~sr ~vdi ~vm
              ))
 
     let create context ~dbg ~sr ~vdi_info =
@@ -586,11 +599,12 @@ module Wrapper = functor(Impl: Server_impl) -> struct
            Impl.VDI.resize context ~dbg ~sr ~vdi ~new_size
         )
 
-    let destroy_and_data_destroy call_name call_f context ~dbg ~sr ~vdi =
+    let destroy_and_data_destroy call_name call_f context ~dbg ~sr ~vdi  = 
       info "%s dbg:%s sr:%s vdi:%s" call_name dbg (s_of_sr sr) (s_of_vdi vdi);
       with_vdi sr vdi
         (fun () ->
-           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi Vdi.all
+           let vm = vm_of_s "" in 
+           remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.all
              (fun () ->
                 call_f context ~dbg ~sr ~vdi
              )
@@ -751,7 +765,8 @@ module Wrapper = functor(Impl: Server_impl) -> struct
         | Some (vdi, vdi_t) -> (
             locker vdi (fun () ->
                 try
-                  VDI.destroy_datapath_nolock context ~dbg ~dp ~sr ~vdi ~allow_leak;
+                  let vm = vm_of_s "" in 
+                  VDI.destroy_datapath_nolock context ~dbg ~dp ~sr ~vdi ~vm ~allow_leak;
                   None
                 with e -> Some e
               )

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -271,7 +271,7 @@ let tapdisk_of_attach_info (backend:Storage_interface.backend) =
 let with_activated_disk ~dbg ~sr ~vdi ~dp f =
   let attached_vdi =
     Opt.map (fun vdi ->
-        let backend = Local.VDI.attach2 dbg dp sr vdi (vm_of_s "") false in
+        let backend = Local.VDI.attach3 dbg dp sr vdi (vm_of_s "0") false in
         vdi, backend
       ) vdi
   in
@@ -283,7 +283,7 @@ let with_activated_disk ~dbg ~sr ~vdi ~dp f =
               let (_, blockdevs, files, _) = Storage_interface.implementations_of_backend backend in
               match blockdevs, files with
               | ({ path })::_, _ | _, ({ path })::_ ->
-                Local.VDI.activate dbg dp sr vdi;
+                Local.VDI.activate3 dbg dp sr vdi (vm_of_s "0");
                 path
               | [], [] ->
                 raise (Storage_interface.Storage_error (Backend_error (Api_errors.internal_error, ["No BlockDevice or File implementation in Datapath.attach response: " ^ (Storage_interface.(rpc_of backend) backend |> Jsonrpc.to_string)])))
@@ -292,9 +292,9 @@ let with_activated_disk ~dbg ~sr ~vdi ~dp f =
        in
        finally
          (fun () -> f path)
-         (fun () -> Opt.iter (fun vdi -> Local.VDI.deactivate dbg dp sr vdi) vdi)
+         (fun () -> Opt.iter (fun vdi -> Local.VDI.deactivate dbg dp sr vdi (vm_of_s "0")) vdi)
     )
-    (fun () -> Opt.iter (fun (vdi, _) -> Local.VDI.detach dbg dp sr vdi) attached_vdi)
+    (fun () -> Opt.iter (fun (vdi, _) -> Local.VDI.detach dbg dp sr vdi (vm_of_s "0")) attached_vdi)
 
 let perform_cleanup_actions =
   List.iter
@@ -371,7 +371,7 @@ let copy' ~task ~dbg ~sr ~vdi ~url ~dest ~dest_vdi =
 
     Pervasiveext.finally (fun () ->
         debug "activating RW datapath %s on remote" remote_dp;
-        ignore(Remote.VDI.attach2 dbg remote_dp dest dest_vdi (vm_of_s "") true);
+        ignore(Remote.VDI.attach2 dbg remote_dp dest dest_vdi true);
         Remote.VDI.activate dbg remote_dp dest dest_vdi;
 
         with_activated_disk ~dbg ~sr ~vdi:base_vdi ~dp:base_dp
@@ -729,8 +729,8 @@ let receive_start ~dbg ~sr ~vdi_info ~id ~similar =
     on_fail := (fun () -> Local.VDI.destroy dbg sr dummy.vdi) :: !on_fail;
     debug "Created dummy snapshot for mirror receive: %s" (string_of_vdi_info dummy);
 
-    let _ = Local.VDI.attach2 dbg leaf_dp sr leaf.vdi (vm_of_s "") true in
-    Local.VDI.activate dbg leaf_dp sr leaf.vdi;
+    let _ = Local.VDI.attach3 dbg leaf_dp sr leaf.vdi (vm_of_s "0") true in
+    Local.VDI.activate3 dbg leaf_dp sr leaf.vdi (vm_of_s "0");
 
     let nearest = List.fold_left
         (fun acc content_id -> match acc with

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -212,9 +212,9 @@ module Mux = struct
     (* We need to include this to satisfy the SMAPIv2 signature *)
     let attach () ~dbg ~dp ~sr ~vdi ~read_write =
       failwith "We'll never get here: attach is implemented in Storage_impl.Wrapper"
-    let attach2 () ~dbg ~dp ~sr ~vdi ~read_write =
+    let attach2 () ~dbg ~dp ~sr ~vdi ~vm ~read_write =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
-      C.VDI.attach2 dbg dp sr vdi read_write
+      C.VDI.attach2 dbg dp sr vdi vm read_write
     let activate () ~dbg ~dp ~sr ~vdi =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
       C.VDI.activate dbg dp sr vdi

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -206,27 +206,33 @@ module Mux = struct
     let set_persistent () ~dbg ~sr ~vdi ~persistent =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
       C.VDI.set_persistent dbg sr vdi persistent
-    let epoch_begin () ~dbg ~sr ~vdi ~persistent =
+    let epoch_begin () ~dbg ~sr ~vdi ~vm ~persistent =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
-      C.VDI.epoch_begin dbg sr vdi persistent
+      C.VDI.epoch_begin dbg sr vdi vm persistent
     (* We need to include this to satisfy the SMAPIv2 signature *)
     let attach () ~dbg ~dp ~sr ~vdi ~read_write =
       failwith "We'll never get here: attach is implemented in Storage_impl.Wrapper"
-    let attach2 () ~dbg ~dp ~sr ~vdi ~vm ~read_write =
+    let attach2 () ~dbg ~dp ~sr ~vdi ~read_write =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
-      C.VDI.attach2 dbg dp sr vdi vm read_write
+      C.VDI.attach2 dbg dp sr vdi read_write
+    let attach3 () ~dbg ~dp ~sr ~vdi ~vm ~read_write =
+      let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
+      C.VDI.attach3 dbg dp sr vdi vm read_write
     let activate () ~dbg ~dp ~sr ~vdi =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
       C.VDI.activate dbg dp sr vdi
-    let deactivate () ~dbg ~dp ~sr ~vdi =
+    let activate3 () ~dbg ~dp ~sr ~vdi ~vm =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
-      C.VDI.deactivate dbg dp sr vdi
-    let detach () ~dbg ~dp ~sr ~vdi =
+      C.VDI.activate3 dbg dp sr vdi vm
+    let deactivate () ~dbg ~dp ~sr ~vdi ~vm =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
-      C.VDI.detach dbg dp sr vdi
-    let epoch_end () ~dbg ~sr ~vdi =
+      C.VDI.deactivate dbg dp sr vdi vm
+    let detach () ~dbg ~dp ~sr ~vdi ~vm =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
-      C.VDI.epoch_end dbg sr vdi
+      C.VDI.detach dbg dp sr vdi vm
+    let epoch_end () ~dbg ~sr ~vdi ~vm =
+      let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
+      C.VDI.epoch_end dbg sr vdi vm
     let get_by_name () ~dbg ~sr ~name =
       let module C = StorageAPI(Idl.Exn.GenClient(struct let rpc = of_sr sr end)) in
       C.VDI.get_by_name dbg sr name

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -663,7 +663,8 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far t
         let read_write = true in
         (* DP set up is only essential for MIRROR.start/stop due to their open ended pattern.
            It's not necessary for copy which will take care of that itself. *)
-        ignore(SMAPI.VDI.attach2 dbg new_dp vconf.sr vconf.location read_write);
+	let vm = (Storage_interface.Vm.of_string "") in
+        ignore(SMAPI.VDI.attach2 dbg new_dp vconf.sr vconf.location vm read_write);
         SMAPI.VDI.activate dbg new_dp vconf.sr vconf.location;
         let id = Storage_migrate.State.mirror_id_of (vconf.sr,vconf.location) in (* Layering violation!! *)
         ignore(Storage_access.register_mirror __context id);

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -663,8 +663,8 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far t
         let read_write = true in
         (* DP set up is only essential for MIRROR.start/stop due to their open ended pattern.
            It's not necessary for copy which will take care of that itself. *)
-	let vm = (Storage_interface.Vm.of_string "") in
-        ignore(SMAPI.VDI.attach2 dbg new_dp vconf.sr vconf.location vm read_write);
+	let vm = (Storage_interface.Vm.of_string "0") in
+        ignore(SMAPI.VDI.attach3 dbg new_dp vconf.sr vconf.location vm read_write);
         SMAPI.VDI.activate dbg new_dp vconf.sr vconf.location;
         let id = Storage_migrate.State.mirror_id_of (vconf.sr,vconf.location) in (* Layering violation!! *)
         ignore(Storage_access.register_mirror __context id);


### PR DESCRIPTION
We now honour the existing API of Datapath.attach by
passing the domid of vm that the vbd is being attached to.

This will enable a qemu process per vm.

Signed-off-by: ben sims <ben.sims@citrix.com>