### PR TITLE
sr_health_check: Actually make the thread start instead of dead code

### DIFF
--- a/ocaml/tests/test_xapi_xenops.ml
+++ b/ocaml/tests/test_xapi_xenops.ml
@@ -60,7 +60,7 @@ let test_xapi_restart_inner () =
   let open Xenops_interface in
   let open Xapi_xenops_queue in
   let module Client = (val make_client "simulator" : XENOPS) in
-  let _ = Client.VM.list "dbg" in
+  let _ : 'a list = Client.VM.list "dbg" () in
   let (cancel,th) =
     let cancel = ref false in
     let th = Thread.create (

--- a/ocaml/xapi/debug_populate.ml
+++ b/ocaml/xapi/debug_populate.ml
@@ -71,9 +71,9 @@ let rec make_vdis_and_vbds __context vmref i =
       let vdi = Xapi_vdi.pool_introduce
           ~__context ~uuid ~name_label ~name_description ~sR ~_type ~sharable ~read_only ~other_config ~location ~xenstore_data ~sm_config ~managed ~virtual_size ~physical_utilisation ~metadata_of_pool ~is_a_snapshot ~snapshot_time ~snapshot_of ~cbt_enabled in
 
-      let _ =
+      let _:[`VBD] Ref.t =
         Xapi_vbd.create ~__context ~vM:vmref ~vDI:vdi ~userdevice:(string_of_int i) ~bootable:true ~mode:`RW ~_type:`Disk ~empty:false
-          ~qos_algorithm_type:"" ~qos_algorithm_params:[] in
+          ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~other_config:[] ~unpluggable:false in
       make_vdis_and_vbds __context vmref (i-1)
     end
 

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -233,7 +233,7 @@ let sr_health_check ~__context ~self =
           let task = Client.Task.create ~rpc ~session_id
               ~label:Xapi_globs.sr_health_check_task_label ~description:(Ref.string_of self) in
           Xapi_host_helpers.update_allowed_operations_all_hosts ~__context;
-          let _ = Thread.create (fun () ->
+          let _ : Thread.t = Thread.create (fun () ->
               let rec loop () =
                 Thread.delay 30.;
                 let info = C.SR.stat dbg (Storage_interface.Sr.of_string (Db.SR.get_uuid ~__context ~self)) in
@@ -247,7 +247,7 @@ let sr_health_check ~__context ~self =
                 end
               in
               loop ()
-            )
+            ) ()
           in ()
         )
     end


### PR DESCRIPTION
OCaml 4.08.1+rc1 found this:
```
File "ocaml/xapi/xapi_sr_operations.ml", line 236, characters 18-705:
236 | ..................Thread.create (fun () ->
237 |               let rec loop () =
238 |                 Thread.delay 30.;
239 |                 let info = C.SR.stat dbg (Storage_interface.Sr.of_string (Db.SR.get_uuid ~__context ~self)) in
240 |                 if not (Db.Task.get_status ~__context ~self:task = `cancelling) &&
...
247 |                 end
248 |               in
249 |               loop ()
250 |             )
Error (warning 5): this function application is partial,
```

And it is indeed correct, this is dead code, we never actually created
the thread, because the `_` was of type `unit -> Thread.t`.
Be explicit about the type of the ignored argument and fix it.

None of the SMAPIv3 SRs that we have actually implement a recovering
health check status, but when they do it would be confusing to have this
code that looks sort of OK but be completely broken.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>