### PR TITLE
CA-322045: tell XAPI to shut down only once

### DIFF
--- a/scripts/init.d-xapi
+++ b/scripts/init.d-xapi
@@ -75,8 +75,12 @@ stop() {
 
 	# Find out if xapi has died
 	RETRIES=60
+	RETRY_SHUTDOWN_AGENT=1
 	while [ ${RETRIES} -ne 0 ]; do
-		xe host-shutdown-agent 2> /dev/null
+		if [ "${RETRY_SHUTDOWN_AGENT}" -ne 0 ]; then
+			xe host-shutdown-agent 2> /dev/null && RETRY_SHUTDOWN_AGENT=0
+		fi
+		
 		# Finish if all xapis have gone 
 		xapi_pids=$(pidof xapi)
 		if [ -z "$xapi_pids" ]; then


### PR DESCRIPTION
On shutdown XAPI asks xcp-rrdd to backup the RRDs, which can be slow if you have a lot of VMs, SRs, etc.
The shutdown script then asked xapi to shutdown again a second later, which asked xcp-rrdd to save a backup again,
and so on, until finally it gave up after a minute, finally allowing xcp-rrdd to catch up.

If 'xe host-shutdown-agent' succeeds then do not try to repeatedly tell xapi to shut down again,
it heard us the first time. If it fails then do try to tell it to shutdown again.
Either way keep looping until we detect that xapi is down.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>
(cherry picked from commit 6819c90b35f9711dde6567ca4cf2c7ab19f9a4e6)