### PR TITLE
CP-31980: Update Nvidia host driver white list that support multiple …

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -894,7 +894,7 @@ let sm_plugins = ref [ ]
 let accept_sm_plugin name =
   List.(fold_left (||) false (map (function `All -> true | `Sm x -> String.lowercase_ascii x = String.lowercase_ascii name) !sm_plugins))
 
-let nvidia_multi_vgpu_enabled_driver_versions = ref ["430.19"]
+let nvidia_multi_vgpu_enabled_driver_versions = ref ["430.19";"430.42";"440.00+"]
 let nvidia_default_host_driver_version = "0.0"
 
 let other_options = [


### PR DESCRIPTION
CP-31980: Update Nvidia host driver white list that support multiple vGPU

1. Nvidia provide a new dev version of host driver 430.42 support
multiple vGPU
2. Nvidia confirmed all host drivers after 440.xx should support
multiple vGPU

Signed-off-by: Lin Liu <lin.liu@citrix.com>