### PR TITLE
CA-324959: write out the DNS entries that 05-prepare-networking would…

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -978,7 +978,9 @@ let eject ~__context ~host =
           "\nIP=" ^ pif.API.pIF_IP ^
           "\nNETMASK=" ^ pif.API.pIF_netmask ^
           "\nGATEWAY=" ^ pif.API.pIF_gateway ^
-          "\nDNS=" ^ pif.API.pIF_DNS ^ "\n"
+          (pif.API.pIF_DNS |> String.split ','
+          |> List.mapi (fun i -> Printf.sprintf "\nDNS%d=%s" (i+1))
+          |> String.concat "") ^ "\n"
         else
           "\n"
       end in

--- a/scripts/xe-reset-networking
+++ b/scripts/xe-reset-networking
@@ -190,7 +190,7 @@ Type 'no' to cancel.
 			if options.gateway != '':
 				f.write("GATEWAY='" + options.gateway + "'\n")
 			if options.dns != '':
-				f.write("DNS='" + options.dns + "'\n")
+				f.write("DNS1='" + options.dns + "'\n")
 	finally:
 		f.flush()
 		os.fsync(f.fileno())
@@ -207,7 +207,7 @@ Type 'no' to cancel.
 			if options.gateway != '':
 				f.write('GATEWAY=' + options.gateway + '\n')
 			if options.dns != '':
-				f.write('DNS=' + options.dns + '\n')
+				f.write('DNS1=' + options.dns + '\n')
 	finally:
 		f.flush()
 		os.fsync(f.fileno())

--- a/scripts/xe-reset-networking
+++ b/scripts/xe-reset-networking
@@ -207,7 +207,7 @@ Type 'no' to cancel.
 			if options.gateway != '':
 				f.write('GATEWAY=' + options.gateway + '\n')
 			if options.dns != '':
-				f.write('DNS1=' + options.dns + '\n')
+				f.write('DNS=' + options.dns + '\n')
 	finally:
 		f.flush()
 		os.fsync(f.fileno())


### PR DESCRIPTION
… expect

It expects entries of the form DNS%d=%s (starting from 1) and concatenates them with ","
instead of a single DNS= entry.

On master this has been fixed by changing what host-installer/firstboot
scripts do (they would write the DNS= entry), however for the backport
for backwards compatibility we change what the toolstack writes.
Apparently firstboot and xapi always disagreed on the format ever since the DNS= entry was introduced: xapi would write out something that firstboot was not able to restore.

The value written out by xe-reset-networking would contain commas,
but it doesn't really matter because it would just get concatenated
again.

Draft PR, in the process of testing it.