### PR TITLE
REQ-627 CP-32057 narrow definition of "related" PCIs

### DIFF
--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -220,8 +220,10 @@ let update_pcis ~__context =
                let r, _, _, _ = List.find (fun (_, rc, _, _) -> rc.Db_actions.pCI_pci_id = address) pfs
                in r)
           with Not_found ->
-            warn "failed to update PCI dependencies for %s" (Ref.string_of pref);
-            []
+            let msg = Printf.sprintf
+              "failed to update PCI dependencies for %s (%s)"
+              (Ref.string_of pref) __LOC__ in
+            raise Api_errors.(Server_error (internal_error,[msg]))
         in
         Db.PCI.set_dependencies ~__context ~self:pref ~value:dependencies;
         update remaining

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -45,27 +45,48 @@ let address_of_dev x =
   let open Pci.Pci_dev in
   Printf.sprintf "%04x:%02x:%02x.%d" x.domain x.bus x.dev x.func
 
-(** [is_virtual_pci "0000:37:00.4"] is true, if this designates a
- * virtual PCI function (VF), false otherwise. Only a VF has a "physfn"
- * symbolic link.
- *)
-let is_virtual_pci addr =
-  let path = Printf.sprintf "/sys/bus/pci/devices/%s/physfn" addr in
-  try
-    ignore @@ Unix.readlink path; true
-  with _ -> false
+(* Check for a PCI device whether it is virtual and remember the result
+ * such that it can be looked up later *)
+module PCIcache: sig
+  type t
+  type addr = string (* "0000:37:00.4" *)
+  val make: unit -> t
+  val is_virtual: t -> addr -> bool
+end = struct
+  type t = (string, bool) Hashtbl.t
+  type addr = string
+
+  (** [is_virtual_pci "0000:37:00.4"] is true, if this designates a
+   * virtual PCI function (VF), false otherwise. Only a VF has a "physfn"
+   * symbolic link.
+   *)
+  let is_virtual addr =
+    let path = Printf.sprintf "/sys/bus/pci/devices/%s/physfn" addr in
+    try
+      ignore @@ Unix.readlink path; true
+    with _ -> false
+
+  let make () = Hashtbl.create 100
+  let is_virtual t addr =
+    try
+      Hashtbl.find t addr
+    with Not_found ->
+      let v = is_virtual addr in
+      Hashtbl.replace t addr v; v
+end
+
 
 (** [is_related_to x y] is true, if two non-virtual PCI devices
  *  only differ in their function.
  *)
-let is_related_to (x:Pci.Pci_dev.t) (y:Pci.Pci_dev.t) =
+let is_related_to cache (x:Pci.Pci_dev.t) (y:Pci.Pci_dev.t) =
   let open Pci.Pci_dev in
   x.domain = y.domain
   && x.bus = y.bus
   && x.dev = y.dev
   && x.func <> y.func
-  && not @@ is_virtual_pci @@ address_of_dev x
-  && not @@ is_virtual_pci @@ address_of_dev y
+  && not @@ PCIcache.is_virtual cache @@ address_of_dev x
+  && not @@ PCIcache.is_virtual cache @@ address_of_dev y
 
 let get_host_pcis () =
   let default ~msg v =
@@ -76,6 +97,7 @@ let get_host_pcis () =
   let open Pci in
   with_access (fun access ->
       let devs = get_devices access in
+      let cache = PCIcache.make () in
       List.map (fun d ->
           let open Pci_dev in
           debug "get_host_pcis: vendor=%04x device=%04x class=%04x"
@@ -105,7 +127,7 @@ let get_host_pcis () =
                           ; name = lookup_class_name access d.device_class
                                    |> default ~msg:"class name" }
           in
-          let related_devs = List.filter (is_related_to d) devs in
+          let related_devs = List.filter (is_related_to cache d) devs in
           { address;
             vendor; device; subsystem_vendor; subsystem_device; pci_class;
             related = List.map address_of_dev related_devs; driver_name; 

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -354,7 +354,9 @@ let nvidia_sriov_pcis ~__context vgpus =
   |> List.filter_map (fun vgpu -> Db.VGPU.get_type ~__context ~self:vgpu
     |> fun typ -> Db.VGPU_type.get_implementation ~__context ~self:typ
     |> function
-      | `nvidia_sriov -> Some (Db.VGPU.get_PCI ~__context ~self:vgpu)
+      | `nvidia_sriov ->
+          let pci = Db.VGPU.get_PCI ~__context ~self:vgpu in
+          if Db.is_valid_ref __context pci then Some pci else None
       | _ -> None)
 
 (** Take an internal VM record and a proposed operation. Return None iff the operation


### PR DESCRIPTION
PCI devices are considered to be related if they only differ in their
function. Related PCI devices are passed to a guest together.
This definition is insufficient when dealing with virtual functions,
which must be excluded.

This commit narrows the definition of "related" accordingly: virtual PCI
devices are excluded. In addition, the commit tries to make the
definition more explicit by defining predicates.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>