### PR TITLE
travis: load vars from xs-opam repo

### DIFF
--- a/.travis-xs-opam.sh
+++ b/.travis-xs-opam.sh
@@ -5,9 +5,9 @@ set -ex
 PACKAGE="xapi"
 PINS="xapi:. xapi-cli-protocol:. xapi-client:. xapi-consts:. xapi-database:. xapi-datamodel:. xapi-types:. xe:."
 BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
-DISTRO="debian-unstable"
-OCAML_VERSION="4.07"
 
 wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+. xs-opam-ci.env
 . .travis-docker.sh
 


### PR DESCRIPTION
restrict loading the new vars to the script testing xs-opam repo