### PR TITLE
CP-12980: maintain import behaviour on package

### DIFF
--- a/scripts/examples/python/XenAPI/__init__.py
+++ b/scripts/examples/python/XenAPI/__init__.py
@@ -1,1 +1,1 @@
-from . import XenAPI
+from .XenAPI import *


### PR DESCRIPTION
This keeps backwards compatibility with unpackaged XenAPI.py,
Previously users importing had to change imports to `from XenAPI import XenAPI`