### PR TITLE
python: fix typo in readme, add link to examples

### DIFF
--- a/scripts/examples/python/README.md
+++ b/scripts/examples/python/README.md
@@ -7,7 +7,7 @@ To install the package, enable the virtual environment where it's going to be us
 Examples
 --------
 
-The examples now will not work unless they have been placed in the same directory as `XenAPI.py` or `XenAPI` package from PyPI has been installed (`pip installed XenAPI`)
+The [examples](https://github.com/xapi-project/xen-api/tree/master/scripts/examples/python) will not work unless they have been placed in the same directory as `XenAPI.py` or `XenAPI` package from PyPI has been installed (`pip install XenAPI`)
 
 Packaging
 =========


### PR DESCRIPTION
It's not clear what the examples are when the readme is in PyPI as
there are no examples in the package.