### PR TITLE
CA-325988: do not lose newlines from dmidecode

### DIFF
--- a/ocaml/xapi/bios_strings.ml
+++ b/ocaml/xapi/bios_strings.ml
@@ -20,7 +20,7 @@ let dmidecode_prog = "/usr/sbin/dmidecode"
 let remove_invisible str =
   let l = String.split_on_char '\n' str in
   let l = List.filter (fun s -> not (String.startswith "#" s)) l in
-  let str = String.concat "" l in
+  let str = String.concat "\n" l in
   String.fold_left (fun s c -> if c >= ' ' && c <= '~' then s ^ (String.of_char c) else s) "" str
 
 (* obtain the BIOS string with the given name from dmidecode *)


### PR DESCRIPTION
In 4156d7fdcb300a5d72eff0c0fabb8ecd4c98c266 we started to filter out
lines with '#' from dmidecode, however by doing so we also lost newlines
from strings.

Since 94d2ff73711becc9cc92d01606ee38929808eb14 we start getting newlines
in baseboard-strings, and we are reporting the wrong values to the
guest.

So just concatenate with newlines, removing the newlines never seem to
have been the intention of the filtering code here.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>