### PR TITLE
CA-325988: pass both boards to xenstore

### DIFF
--- a/ocaml/xapi/bios_strings.ml
+++ b/ocaml/xapi/bios_strings.ml
@@ -21,7 +21,7 @@ let remove_invisible str =
   let l = String.split_on_char '\n' str in
   let l = List.filter (fun s -> not (String.startswith "#" s)) l in
   let str = String.concat "\n" l in
-  String.fold_left (fun s c -> if c >= ' ' && c <= '~' then s ^ (String.of_char c) else s) "" str
+  String.fold_left (fun s c -> if (c >= ' ' && c <= '~') || c = '\n' then s ^ (String.of_char c) else s) "" str
 
 (* obtain the BIOS string with the given name from dmidecode *)
 let get_bios_string name =


### PR DESCRIPTION
Entries for multiple boards separate with newlines (as in dmidecode),
but perhaps a better design here would be to have separate xenstore
subkeys for baseboard-manufacturer/0 and baseboard-manufacturer/1.

The board type is lost and not passed through at the moment either.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>