### PR TITLE
CA-326174: fix race condition between SR.scan and VDI.forget

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1795,6 +1795,7 @@ module SR = struct
             "vdi_data_destroy", "Deleting the data of the VDI";
             "vdi_list_changed_blocks", "Exporting a bitmap that shows the changed blocks between two VDIs";
             "vdi_set_on_boot", "Setting the on_boot field of the VDI";
+            "vdi_forget", "Forgetting a VDI";
             "pbd_create", "Creating a PBD for this SR";
             "pbd_destroy", "Destroying one of this SR's PBDs"; ])
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3565,7 +3565,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
     let forget ~__context ~vdi =
       info "VDI.forget: VDI = '%s'" (vdi_uuid ~__context vdi);
-      with_sr_andor_vdi ~__context ~vdi:(vdi, `forget) ~doc:"VDI.forget"
+      let sR = Db.VDI.get_SR ~__context ~self:vdi in
+      with_sr_andor_vdi ~__context ~sr:(sR, `vdi_forget) ~vdi:(vdi, `forget) ~doc:"VDI.forget"
         (fun () ->
            Local.VDI.forget ~__context ~vdi)
 

--- a/ocaml/xapi/record_util.ml
+++ b/ocaml/xapi/record_util.ml
@@ -141,6 +141,7 @@ let sr_operation_to_string: API.storage_operations -> string = function
   | `vdi_set_on_boot -> "VDI.set_on_boot"
   | `vdi_data_destroy -> "VDI.data_destroy"
   | `vdi_list_changed_blocks -> "VDI.list_changed_blocks"
+  | `vdi_forget -> "VDI.forget"
   | `pbd_create -> "PBD.create"
   | `pbd_destroy -> "PBD.destroy"
 

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -36,7 +36,7 @@ open D
 open Record_util
 
 let all_ops : API.storage_operations_set =
-  [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy; `vdi_resize; `vdi_clone; `vdi_snapshot; `vdi_mirror;
+  [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy; `vdi_forget; `vdi_resize; `vdi_clone; `vdi_snapshot; `vdi_mirror;
     `vdi_enable_cbt; `vdi_disable_cbt; `vdi_data_destroy; `vdi_list_changed_blocks; `vdi_set_on_boot; `vdi_introduce; `update; `pbd_create; `pbd_destroy ]
 
 (* This list comes from https://github.com/xenserver/xen-api/blob/tampa-bugfix/ocaml/xapi/xapi_sr_operations.ml#L36-L38 *)
@@ -150,7 +150,7 @@ let valid_operations ~__context ?op record _ref' : table =
   in
 
   let check_parallel_ops ~__context record =
-    let safe_to_parallelise = [`plug] in
+    let safe_to_parallelise = [`plug; `vdi_forget] in
     let current_ops = List.setify (List.map snd current_ops) in
 
     (* If there are any current operations, all the non_parallelisable operations


### PR DESCRIPTION
VDI.forget was not marking the SR with an in-progress operation so SR.scan could've run while VDI.forget was in progress.
After a VDI.forget the VDI could disappear, causing SR.scan to report a failure.

By default only the plug operation is marked as able to execute concurrently, add VDI.forget to that list:
as long as all we do is run VDI.forget in parallel its fine, but as soon as we try to combine it with
something like SR.scan the SR.scan should get OTHER_OPERATION_IN_PROGRESS error.
VDI.forget should be safe to parallelise because it is just a DB operation, and it was parallelized before.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>