### PR TITLE
Revert "CA-326174: fix race condition between SR.scan and VDI.forget"

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1795,7 +1795,6 @@ module SR = struct
             "vdi_data_destroy", "Deleting the data of the VDI";
             "vdi_list_changed_blocks", "Exporting a bitmap that shows the changed blocks between two VDIs";
             "vdi_set_on_boot", "Setting the on_boot field of the VDI";
-            "vdi_forget", "Forgetting a VDI";
             "pbd_create", "Creating a PBD for this SR";
             "pbd_destroy", "Destroying one of this SR's PBDs"; ])
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3565,8 +3565,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
     let forget ~__context ~vdi =
       info "VDI.forget: VDI = '%s'" (vdi_uuid ~__context vdi);
-      let sR = Db.VDI.get_SR ~__context ~self:vdi in
-      with_sr_andor_vdi ~__context ~sr:(sR, `vdi_forget) ~vdi:(vdi, `forget) ~doc:"VDI.forget"
+      with_sr_andor_vdi ~__context ~vdi:(vdi, `forget) ~doc:"VDI.forget"
         (fun () ->
            Local.VDI.forget ~__context ~vdi)
 

--- a/ocaml/xapi/record_util.ml
+++ b/ocaml/xapi/record_util.ml
@@ -141,7 +141,6 @@ let sr_operation_to_string: API.storage_operations -> string = function
   | `vdi_set_on_boot -> "VDI.set_on_boot"
   | `vdi_data_destroy -> "VDI.data_destroy"
   | `vdi_list_changed_blocks -> "VDI.list_changed_blocks"
-  | `vdi_forget -> "VDI.forget"
   | `pbd_create -> "PBD.create"
   | `pbd_destroy -> "PBD.destroy"
 

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -36,7 +36,7 @@ open D
 open Record_util
 
 let all_ops : API.storage_operations_set =
-  [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy; `vdi_forget; `vdi_resize; `vdi_clone; `vdi_snapshot; `vdi_mirror;
+  [ `scan; `destroy; `forget; `plug; `unplug; `vdi_create; `vdi_destroy; `vdi_resize; `vdi_clone; `vdi_snapshot; `vdi_mirror;
     `vdi_enable_cbt; `vdi_disable_cbt; `vdi_data_destroy; `vdi_list_changed_blocks; `vdi_set_on_boot; `vdi_introduce; `update; `pbd_create; `pbd_destroy ]
 
 (* This list comes from https://github.com/xenserver/xen-api/blob/tampa-bugfix/ocaml/xapi/xapi_sr_operations.ml#L36-L38 *)
@@ -150,7 +150,7 @@ let valid_operations ~__context ?op record _ref' : table =
   in
 
   let check_parallel_ops ~__context record =
-    let safe_to_parallelise = [`plug; `vdi_forget] in
+    let safe_to_parallelise = [`plug] in
     let current_ops = List.setify (List.map snd current_ops) in
 
     (* If there are any current operations, all the non_parallelisable operations


### PR DESCRIPTION
This causes a deadlock between xapi, SM and SMGC, since SMGC takes an SM-side SR-lock, and attempts to do aVDI.forget, while a VDI.create is already running on xapi side, attempting to take the SR-lock on the SM side.
SMGC cannot proceeed because VDI.forget gets rejected by xapi due to VDI.create being in progress, and VDI.create cannot proceed because SMGC holds the lock.

Revert the change for now, to properly fix this would be better if SM was taking all the locks (as in SMAPIv3), or at least we should only forbid SR.scan+VDI.forget in parallel, not VDI.forget+VDI.create