### PR TITLE
fixup! REQ-627 pass PCI VF for GPU SR-IOV to xenopsd

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -660,12 +660,19 @@ module MD = struct
     }
 
   (** Return the virtual function (VF) for a VGPU operated in SR-IOV
-   * mode, or None otherwise
+   * mode, or None otherwise. In particular, return None when a VGPU
+   * is passed trough completely.
    *)
   let sriov_vf ~__context vgpu =
+    let is_sriov () =
+      let ty = vgpu.Db_actions.vGPU_type in
+      match Db.VGPU_type.get_implementation ~__context ~self:ty with
+      | `nvidia_sriov -> true
+      | _             -> false in
     match vgpu.Db_actions.vGPU_PCI with
     | pci when pci = Ref.null -> None
     | pci when not (Db.is_valid_ref __context pci) -> None
+    | _   when not @@ is_sriov () -> None
     | pci ->
         Db.PCI.get_pci_id ~__context ~self:pci
         |> fun str -> Xenops_interface.Pci.address_of_string str


### PR DESCRIPTION
This fixes an oversight in an earlier commit: xapi creates a vgpu object which it passes to xenopsd. This contains a VF PCI field. We have to make sure to use it only when we are indeed using SRIOV mode. This code checks the implementation of the VGPU to decide this.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>