### PR TITLE
CA-325330 add error for VGPU driver incompatibility

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -280,6 +280,8 @@ let _ =
     ~doc:"Cannot create a virtual GPU that is incompatible with the existing types on the VM." ();
   error Api_errors.vgpu_destination_incompatible ["reason"; "vgpu"; "host"]
     ~doc:"The VGPU is not compatible with any PGPU in the destination." ();
+  error Api_errors.vgpu_guest_driver_limit ["reason"; "vm"; "host"]
+    ~doc:"The guest driver does not support VGPU migration." ();
   error Api_errors.nvidia_tools_error ["host"]
     ~doc:"Nvidia tools error. Please ensure that the latest Nvidia tools are installed" ();
   error Api_errors.vm_pci_bus_full ["VM"]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -318,6 +318,7 @@ let vgpu_type_not_supported = "VGPU_TYPE_NOT_SUPPORTED"
 let vgpu_type_not_compatible_with_running_type = "VGPU_TYPE_NOT_COMPATIBLE_WITH_RUNNING_TYPE"
 let vgpu_type_not_compatible = "VGPU_TYPE_NOT_COMPATIBLE"
 let vgpu_destination_incompatible = "VGPU_DESTINATION_INCOMPATIBLE"
+let vgpu_guest_driver_limit = "VGPU_GUEST_DRIVER_LIMIT"
 let nvidia_tools_error = "NVIDIA_TOOLS_ERROR"
 let vm_pci_bus_full = "VM_PCI_BUS_FULL"
 

--- a/ocaml/xapi/xapi_gpumon.ml
+++ b/ocaml/xapi/xapi_gpumon.ml
@@ -125,6 +125,15 @@ module Nvidia = struct
       | Gpumon_interface.Compatible ->
         info "VM %s Nvidia vGPU is compatible with the destination pGPU on host %s"
           (Ref.string_of vm) (Ref.string_of dest_host)
+      | Gpumon_interface.(Incompatible reasons)
+        when List.mem Gpumon_interface.Guest_driver reasons ->
+        raise Api_errors.(Server_error (
+            vgpu_guest_driver_limit,
+            [ String.concat ", " (List.map reason_to_string reasons)
+            (* There could be multiple reasons *)
+            ; Ref.string_of vm
+            ; Ref.string_of dest_host
+            ]))
       | Gpumon_interface.(Incompatible reasons) ->
         raise Api_errors.(Server_error (
             vgpu_destination_incompatible,


### PR DESCRIPTION
Add a more specific API error message for when the Nvidia host driver
does not support migration as is the case for Linux.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>