### PR TITLE
CA-326244: do not include host name in log format

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -948,7 +948,6 @@ let set_hostname_live ~__context ~host ~hostname =
       if is_invalid_hostname hostname then
         raise (Api_errors.Server_error (Api_errors.host_name_invalid, [ "hostname contains invalid characters" ]));
       ignore(Forkhelpers.execute_command_get_output !Xapi_globs.set_hostname [hostname]);
-      Debug.invalidate_hostname_cache ();
       Db.Host.set_hostname ~__context ~self:host ~value:hostname;
       Helpers.update_domain_zero_name ~__context host hostname
     )


### PR DESCRIPTION
Syslog outputs it anyway, so it is pointless to include it twice in the
log line, and it complicates the Debug module of xcp-idl.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>