### PR TITLE
CA-325988: Use one baseboard value when more than one is on the system

### DIFF
--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -53,6 +53,7 @@ let () =
     ; "Test_network_event_loop", Test_network_event_loop.test
     ; "Test_vgpu_type", Test_vgpu_type.test
     ; "Test_storage_migrate_state", Test_storage_migrate_state.test
+    ; "Test_bios_strings", Test_bios_strings.test
     ] @ Test_guest_agent.tests
       @ Test_nm.tests
       @ Test_xenopsd_metadata.tests

--- a/ocaml/tests/test_bios_strings.ml
+++ b/ocaml/tests/test_bios_strings.ml
@@ -1,0 +1,118 @@
+(** This module tests the dmidecode processing
+ *)
+open Bios_strings
+
+let load_test_data file = Stdext.Unixext.string_of_file @@ "test_data/" ^ file
+
+let baseboard_two_string = load_test_data "bios_baseboard_two.dmidecode"
+
+let baseboard_two_record = [
+  { name="Base Board Information"
+  ; values=[ "Manufacturer", "TestA Inc."
+           ; "Product Name", "Not Specified"
+           ; "Version", "A0"
+           ; "Serial Number", " .DEADBEEF"
+           ; "Asset Tag", "          "
+           ; "Features", "Board is a hosting board\nBoard is removable\nBoard is replaceable\nBoard is hot swappable"
+           ; "Location In Chassis", "Slot 00"
+           ; "Type", "Server Blade"
+           ]
+  };
+  { name="Base Board Information"
+  ; values=[ "Manufacturer", "TestB Inc."
+           ; "Product Name", "      "
+           ; "Version", "   "
+           ; "Serial Number", "FOOBAR"
+           ; "Asset Tag", "          "
+           ; "Features", "Board is removable\nBoard is replaceable\nBoard is hot swappable"
+           ; "Location In Chassis", "Slot 00"
+           ; "Type", "Interconnect Board"
+           ]
+  }]
+
+let baseboard_two =
+  [ "baseboard-manufacturer", "TestA Inc."
+  ; "baseboard-product-name", ""
+  ; "baseboard-version", "A0"
+  ; "baseboard-serial-number", ".DEADBEEF"
+  ]
+
+let baseboard_empty =
+  [ "baseboard-manufacturer", ""
+  ; "baseboard-product-name", ""
+  ; "baseboard-version", ""
+  ; "baseboard-serial-number", ""
+  ]
+
+let oem_string = load_test_data "bios_oem.dmidecode"
+
+let oem_empty =
+  [ "oem-1", "Xen"
+  ; "oem-2", "MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"
+  ]
+
+let oem = oem_empty @
+  [ "oem-3", "Test System"
+  ; "oem-4", "1[087C]"
+  ; "oem-5", "3[1.0]"
+  ; "oem-6", "12[www.test.com]"
+  ; "oem-7", "14[1]"
+  ; "oem-8", "15[0]"
+  ; "oem-9", "27[10567471934]"
+  ]
+
+let invalid_string = load_test_data "bios_invalid.dmidecode"
+
+let with_array_string = load_test_data "bios_with_array.dmidecode"
+
+let with_array = [
+  { name="BIOS Language Information"
+  ; values=[ "Installable Languages", "en|US|iso8859-1\n<BAD INDEX>"
+           ; "Currently Installed Language", "en|US|iso8859-1"
+           ]
+  }]
+
+let pp_record fmt {name; values} =
+  Format.fprintf fmt "{name=%s; values=%a}" name Fmt.(Dump.list @@ pair ~sep:comma string string) values
+
+let alco_record = Alcotest.testable pp_record (=)
+
+let check_values = Alcotest.(check @@ list @@ pair string string)
+let check_records = Alcotest.(check @@ result (list alco_record) string)
+
+let values_from_string str =
+  match Angstrom.parse_string P.records str with
+  | Ok (r :: _) -> r.values
+  | Ok [] -> []
+  | Error msg -> []
+
+let test_parser () =
+  check_records "Empty string produces an empty list" (Ok [])
+    (Angstrom.parse_string P.records "");
+
+  check_records "Invalid records must be discarded and stop the parser" (Ok [])
+    (Angstrom.parse_string P.records invalid_string);
+
+  check_records "Two records with same name is valid input" (Ok baseboard_two_record)
+    (Angstrom.parse_string P.records baseboard_two_string);
+
+  check_records "Arrays must be parsed as multi-line values" (Ok with_array)
+    (Angstrom.parse_string P.records with_array_string)
+
+let test_baseboard () =
+  check_values "Baseboard values must have empty values when input is empty" baseboard_empty
+    (get_baseboard_strings @@ fun _ _ -> []);
+  check_values "Second baseboard values must be discarded" baseboard_two
+    (get_baseboard_strings @@ fun _ _ -> values_from_string baseboard_two_string)
+
+let test_oem () =
+  check_values "OEM default values must be used when input is empty" oem_empty
+    (get_oem_strings @@ fun _ _ -> []);
+  check_values "OEM default values must be listed first" oem
+    (get_oem_strings @@ fun _ _ -> values_from_string oem_string)
+
+let test =
+  [ "Test baseboard strings", `Quick, test_baseboard
+  ; "Test oem strings", `Quick, test_oem
+  ; "Test parser", `Quick, test_parser
+  ]

--- a/ocaml/tests/test_data/bios_baseboard_two.dmidecode
+++ b/ocaml/tests/test_data/bios_baseboard_two.dmidecode
@@ -1,0 +1,27 @@
+Base Board Information
+	Manufacturer: TestA Inc.
+	Product Name: Not Specified
+	Version: A0
+	Serial Number:  .DEADBEEF
+	Asset Tag:           
+	Features:
+		Board is a hosting board
+		Board is removable
+		Board is replaceable
+		Board is hot swappable
+	Location In Chassis: Slot 00
+	Type: Server Blade
+
+Base Board Information
+	Manufacturer: TestB Inc.
+	Product Name:       
+	Version:    
+	Serial Number: FOOBAR
+	Asset Tag:           
+	Features:
+		Board is removable
+		Board is replaceable
+		Board is hot swappable
+	Location In Chassis: Slot 00
+	Type: Interconnect Board
+

--- a/ocaml/tests/test_data/bios_invalid.dmidecode
+++ b/ocaml/tests/test_data/bios_invalid.dmidecode
@@ -1,0 +1,8 @@
+Bogus Data
+	valid: line
+	invalid:
+	lines:
+
+Discarded Data
+	discarded: line
+

--- a/ocaml/tests/test_data/bios_oem.dmidecode
+++ b/ocaml/tests/test_data/bios_oem.dmidecode
@@ -1,0 +1,9 @@
+OEM Strings
+	String 1: Test System
+	String 2: 1[087C]
+	String 3: 3[1.0]
+	String 4: 12[www.test.com]
+	String 5: 14[1]
+	String 6: 15[0]
+	String 7: 27[10567471934]
+

--- a/ocaml/tests/test_data/bios_with_array.dmidecode
+++ b/ocaml/tests/test_data/bios_with_array.dmidecode
@@ -1,0 +1,6 @@
+BIOS Language Information
+	Installable Languages: 2
+		en|US|iso8859-1
+		<BAD INDEX>
+	Currently Installed Language: en|US|iso8859-1
+

--- a/ocaml/xapi/bios_strings.ml
+++ b/ocaml/xapi/bios_strings.ml
@@ -13,15 +13,11 @@
  *)
 module D = Debug.Make(struct let name="bios_strings" end)
 open D
-open Stdext.Xstringext
 
 let dmidecode_prog = "/usr/sbin/dmidecode"
 
 let remove_invisible str =
-  let l = String.split_on_char '\n' str in
-  let l = List.filter (fun s -> not (String.startswith "#" s)) l in
-  let str = String.concat "\n" l in
-  String.fold_left (fun s c -> if c >= ' ' && c <= '~' then s ^ (String.of_char c) else s) "" str
+  Astring.String.filter (fun c -> c >= ' ' && c <= '~') str
 
 (* A single record from the output of dmidecode,
  * without its type, handle nor size.
@@ -154,8 +150,9 @@ let get_hp_rombios () =
         (fun () -> Unix.close mem)
     with _ -> ()
   end;
-  let hp_rombios = Bytes.unsafe_to_string hp_rombios in
-  if String.trim (remove_invisible hp_rombios) = "COMPAQ" then "COMPAQ" else ""
+  match Bytes.unsafe_to_string hp_rombios with
+  | "COMPAQ" -> "COMPAQ"
+  | _ -> ""
 
 (* Get host bios strings *)
 let get_host_bios_strings ~__context =

--- a/ocaml/xapi/bios_strings.ml
+++ b/ocaml/xapi/bios_strings.ml
@@ -121,6 +121,13 @@ let get_dmidecode_strings e_type name =
   | Ok [] -> warn "No %s records found" name; []
   | Error msg -> warn "Command dmidecode failed for %s: %s" name msg; []
 
+let get_baseboard_strings decode =
+  let keys = ["baseboard-manufacturer"; "baseboard-product-name";
+              "baseboard-version"; "baseboard-serial-number"] in
+  let name = "baseboard" in
+  decode "2" name
+  |> get_strings name keys
+
 (* Obtain the Type 11 OEM strings from dmidecode, and prepend with the standard ones. *)
 let get_oem_strings decode =
   let standard = Xapi_globs.standard_type11_strings in
@@ -152,11 +159,10 @@ let get_host_bios_strings ~__context =
   (* named BIOS strings *)
   let dmidecode_strings = ["bios-vendor"; "bios-version"; "system-manufacturer";
                            "system-product-name"; "system-version"; "system-serial-number";
-                           "baseboard-manufacturer"; "baseboard-product-name";
-                           "baseboard-version"; "baseboard-serial-number";
                            ] in
   let named_strings = List.map (fun str -> str, (get_bios_string str)) dmidecode_strings in
+  let baseboard_strings = get_baseboard_strings get_dmidecode_strings in
   let oem_strings = get_oem_strings get_dmidecode_strings in
   (* HP-specific ROMBIOS OEM string *)
   let hp_rombios = ["hp-rombios", get_hp_rombios ()] in
-  named_strings @ oem_strings @ hp_rombios
+  named_strings @ baseboard_strings @ oem_strings @ hp_rombios

--- a/ocaml/xapi/bios_strings.mli
+++ b/ocaml/xapi/bios_strings.mli
@@ -16,3 +16,19 @@
 (** Obtains the BIOS strings of localhost. *)
 val get_host_bios_strings :
   __context:Context.t -> (string * string) list
+
+(** Exposed to test the module *)
+
+type record = { name : string; values : (string * string) list; }
+
+module P : sig
+    val records : record list Angstrom.t
+end
+
+val get_output_of_type : string -> string
+
+val get_baseboard_strings :
+  (string -> string -> (string * string) list) -> (string * string) list
+
+val get_oem_strings :
+  (string -> string -> (string * string) list) -> (string * string) list

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -48,6 +48,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29-52))
   (modules (:standard \ xapi_main))
   (libraries
+   angstrom
    unixpwd
    pam
    pciutil

--- a/xapi.opam
+++ b/xapi.opam
@@ -11,7 +11,8 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "alcotest"
+  "alcotest" {with-test}
+  "angstrom"
   "base64"
   "cdrom"
   "ctypes"


### PR DESCRIPTION
The current code uses `dmidecode -s` to gather baseboard values.
This is problematic because it's impossible to distinguish between multiple values and a single value with multiple lines.

This adds parser using the angstrom library which can replace all ad-hoc code that was used before. As an example, there's a commit that replaces how OEM info is gathered.

Parser has been dev-tested with outputs from workstations and servers

- [x] Include tests for parser
- [x] Integration testing
- [x] Replace oem code
- [x] Replace baseboard code
- [x] Replace bios code
- [x] Replace system code