### PR TITLE
REQ-627 introduce option to use SR-IOV for Nvidia T4

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -894,6 +894,7 @@ let accept_sm_plugin name =
 
 let nvidia_multi_vgpu_enabled_driver_versions = ref ["430.19";"430.42";"440.00+"]
 let nvidia_default_host_driver_version = "0.0"
+let nvidia_t4_sriov = ref true
 
 let other_options = [
   gen_list_option "sm-plugins"
@@ -988,6 +989,10 @@ let other_options = [
   "nvidia_multi_vgpu_enabled_driver_versions", Arg.String (fun x -> nvidia_multi_vgpu_enabled_driver_versions := String.split ',' x),
   (fun () -> String.concat "," !nvidia_multi_vgpu_enabled_driver_versions), "list of nvidia host driver versions with multiple vGPU supported.
   if a version end with +, it means any driver version greater or equal than that version";
+
+  "nvidia_t4_sriov", Arg.Set nvidia_t4_sriov,
+  (fun () -> string_of_bool !nvidia_t4_sriov),
+  "When true, address NVidia Tesla T4 GPUs using SR-IOV";
 ]
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -451,7 +451,7 @@ module Vendor_nvidia = struct
     List.filter_map (fun vgpu_type ->
       let is_sriov id =
         try (* IDs of T4 cards *)
-          List.mem (int_of_string id)
+          !Xapi_globs.nvidia_t4_sriov && List.mem (int_of_string id)
             [230; 231; 232; 233; 234; 225; 226;
              227; 228; 229; 222; 252; 223; 224]
         with Not_found | Failure _ -> false


### PR DESCRIPTION
Add a configuration option to assume NVidia Tesal T4 cards are using
SR-IOV mode. The current default is true but should be changed to false
before this is merged to master.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>