### PR TITLE
CA-325988: Limit BIOS strings to a single line

### DIFF
--- a/ocaml/xapi/bios_strings.ml
+++ b/ocaml/xapi/bios_strings.ml
@@ -20,7 +20,7 @@ let dmidecode_prog = "/usr/sbin/dmidecode"
 let remove_invisible str =
   let l = String.split '\n' str in
   let l = List.filter (fun s -> not (String.startswith "#" s)) l in
-  let str = String.concat "" l in
+  let str = match l with | [] -> "" | hd :: _ -> hd in
   String.fold_left (fun s c -> if c >= ' ' && c <= '~' then s ^ (String.of_char c) else s) "" str
 
 let trim str =


### PR DESCRIPTION
In the case where more than one line is found in `remove_invisible` we assume that there are multiple values and pick the first one.

This is safe to do on all 3 usages of the function:
1. When used for oem_strings the string is guaranteed to not contain any eols (the string always ends at the first eol after it starts: `String.index_from result b '\n'`)
2. When used for hp_rombios anything that is not "COMPAQ" gets converted to "" (the 6 bytes that get read); eols are irrelevant in this case.
3. When used in `get_bios_string` none of the values gathered are expected to contain eols (manufacturer names, versions and serial numbers)