### PR TITLE
Fix incorrect hostname in syslog: send HUP when hostname is changed

### DIFF
--- a/scripts/set-hostname
+++ b/scripts/set-hostname
@@ -12,4 +12,6 @@ HOSTNAME=$1
 # Set current hostname
 hostnamectl set-hostname "$HOSTNAME"
 
+systemctl kill -s HUP rsyslog
+
 exit 0


### PR DESCRIPTION
Prior to this change:

```
/opt/xensource/libexec/set-hostname foo
logger testing
systemctl kill -s HUP rsyslog
logger testing
```
```
Sep 20 14:25:35 piquet root: testing
Sep 20 14:26:30 foo root: testing
```

Thanks to @srowe for the suggestion.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>