### PR TITLE
CA-325988: Add fmt dependency to opam for tests

### DIFF
--- a/xapi.opam
+++ b/xapi.opam
@@ -19,6 +19,7 @@ depends: [
   "ctypes-foreign"
   "domain-name"
   "ezxenstore"
+  "fmt" {with-test}
   "http-svr"
   "message-switch-unix"
   "mtime"


### PR DESCRIPTION
Missed it when adding the demidecode tests