### PR TITLE
Remove spammy log lines

### DIFF
--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -37,8 +37,7 @@ let get_driver_name address =
       match Astring.String.cut ~sep:"/" ~rev:true driver_path with
       | Some (prefix, suffix) -> Some suffix
       | None -> None
-    with e -> 
-      debug "get_driver_name: for %s failed with %s" address (Printexc.to_string e); 
+    with _ ->
       None
 
 let get_host_pcis () =


### PR DESCRIPTION
It appears to be very common for devices in dom0 to not have a driver link
(/sys/bus/pci/devices/XX/driver), i.e. to not be bound to a driver. This
currently leads to lots of alarming lines in the logs. However, it is nothing
to worry about, and not worth logging.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>