### PR TITLE
CA-32641 Orphaned dbsync tasks cleaned up

### DIFF
--- a/ocaml/xapi/dbsync.ml
+++ b/ocaml/xapi/dbsync.ml
@@ -47,6 +47,8 @@ let create_host_metrics ~__context =
 
 
 let update_env () =
+  Server_helpers.exec_with_new_task "set localhost_ref"
+    (fun __context -> Xapi_globs.localhost_ref := Helpers.get_localhost ~__context);
   Server_helpers.exec_with_new_task "dbsync (update_env)" ~task_in_database:true
     (fun __context ->
        let other_config =

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -241,9 +241,6 @@ let update_env __context sync_keys =
       create_localhost ~__context info;
     );
 
-  (* record who we are in xapi_globs *)
-  Xapi_globs.localhost_ref := Helpers.get_localhost ~__context;
-
   switched_sync Xapi_globs.sync_set_cache_sr (fun () ->
       try
         let cache_sr = Db.Host.get_local_cache_sr ~__context ~self:(Helpers.get_localhost ~__context) in


### PR DESCRIPTION
When xapi repeatedly fails to start it was not
clearing failed dbsync tasks from the database.
Assigning the `resident_on` field fixes this
for a pool scenario.

Signed-off-by: lippirk <ben.anson@citrix.com>