### PR TITLE
REQ-627 more options to infer SRIOV mode

### DIFF
--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -470,7 +470,7 @@ module Vendor_nvidia = struct
           List.mem (int_of_string id)
             [230; 231; 232; 233; 234; 225; 226;
              227; 228; 229; 222; 252; 223; 224]
-        with Not_found | Failure _ -> false
+        with Failure _ -> false
       in
       let id = get_attr "id" vgpu_type in
       if List.mem_assoc id vgpu_ids then


### PR DESCRIPTION
This supersedes commit "REQ-627 add hack to identify SR-IOV GPUs".

Previously we addressed NVidia T4 cards using SR-IOV provided it is
activated in the global configuration switch nvidia_t4_sriov. The T4
cards were detected based on their IDs.

This commit introduces more options based on the value of
nvidia_t4_sriov in xapi.conf:

* "default" - the addressing mode is taken from vgpuConfig.xml
* "true"    - T4 cards are addressed using SR-IOV, legacy otherwise
* "false"   - all cards are addressed using legacy mode

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>