### PR TITLE
REQ-627 don't use SRIOV for VGPU by default

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -900,7 +900,7 @@ type nvidia_t4_sriov =
   | Nvidia_LEGACY
   | Nvidia_DEFAULT
 
-let nvidia_t4_sriov = ref Nvidia_T4_SRIOV
+let nvidia_t4_sriov = ref Nvidia_DEFAULT
 
 let other_options = [
   gen_list_option "sm-plugins"


### PR DESCRIPTION
Define the default how to to address an NVidia VGPU: consult
vgpuConfig.xml. Currently no customer should have a configuration that
enables SRIOV. For development we can still enable SRIOV on T4 cards
explicitly.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>