### PR TITLE
REQ-627 CA-328495 not saving vGPU metadata

### DIFF
--- a/ocaml/xapi/xapi_gpumon.ml
+++ b/ocaml/xapi/xapi_gpumon.ml
@@ -56,7 +56,10 @@ module Nvidia = struct
 
   (** [is_nvidia] is true, if [vgpu] is an NVIDIA vGPU *)
   let is_nvidia ~__context ~vgpu =
-    vgpu_impl ~__context vgpu = `nvidia
+    match vgpu_impl ~__context vgpu with
+    | `nvidia       -> true
+    | `nvidia_sriov -> true
+    | _ -> false
 
   (** [reason_to_string] turns an incompatibility reason into a string
    * for reporting it in an error message *)


### PR DESCRIPTION
Xapi saves vGPU compatibility metadata for a vGPU when its VM is
suspended. This was failing for SRIOV vGPUs because they were not
correctly identified by the is_nvidia() predicate.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>