### PR TITLE
CA-326241 Set resident_on manually for first task

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -242,7 +242,14 @@ let update_env __context sync_keys =
     );
 
   (* record who we are in xapi_globs *)
-  Xapi_globs.localhost_ref := Helpers.get_localhost ~__context;
+  let localhost = Helpers.get_localhost ~__context in
+  Xapi_globs.localhost_ref := localhost;
+
+  (** Normally the resident_on field would be set by the helper which creates
+      the task, but it uses this `localhost_ref` to do so, which we have only
+      just initialized above. Therefore we manually set it here *)
+  let task_ref = Context.get_task_id __context in
+  Db.Task.set_resident_on ~__context ~self:task_ref ~value:localhost;
 
   switched_sync Xapi_globs.sync_set_cache_sr (fun () ->
       try
@@ -269,7 +276,6 @@ let update_env __context sync_keys =
       Create_misc.create_host_cpu ~__context info;
     );
 
-  let localhost = Helpers.get_localhost ~__context in
 
   switched_sync Xapi_globs.sync_create_domain_zero (fun () ->
       debug "creating domain 0";


### PR DESCRIPTION
Attempt two to fix Orphaned dbsync tasks not
being cleaned up. The first 'fix' was breaking
and was reverted in
e0aa8df8fce51be8543c77940b5f706a4712f91a

Server_helpers.exec_with_new_task uses the
global localhost_ref to set the resident on field
for the tasks it creates. However this global
variable is actually assigned during the first
task, so we must set it manually in this case.

Signed-off-by: lippirk <ben.anson@citrix.com>