### PR TITLE
CA-329107: Improve the order of cipher suites for stunnel

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -861,7 +861,7 @@ let xenopsd_queues = ref ([
 
 let default_xenopsd = ref "org.xen.xapi.xenops.xenlight"
 
-let ciphersuites_good_outbound = ref "!EXPORT:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-SHA256:AES128-SHA256"
+let ciphersuites_good_outbound = ref "!EXPORT:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:AES256-SHA256:AES128-SHA256"
 let ciphersuites_legacy_outbound = ref "RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+DES-CBC3-SHA"
 
 let gpumon_stop_timeout = ref 10.0

--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -75,7 +75,7 @@ writeconffile () {
 
     # (This "good" list must match, or at least contain one of,
     #  the ciphersuites-good-outbound list in /etc/xapi.conf.)
-    GOOD_CIPHERS='ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384:AES256-SHA256:AES128-SHA256'
+    GOOD_CIPHERS='ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:AES256-SHA256:AES128-SHA256'
     BACK_COMPAT_CIPHERS='RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+RC4-MD5:RSA+DES-CBC3-SHA'
 
     if [ -n "${STUNNEL_IDLE_TIMEOUT}" ]; then


### PR DESCRIPTION
This commit reverses the order of cipher suites from
"ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
to
"ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384".

The reason is that GCM is more secure than CBC (which is used in
CDHE-RSA-AES256-SHA384).