### PR TITLE
CP-32437: `assert_can_boot_here`  should perform CPUID checks

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -366,6 +366,8 @@ let power_behaviour =
   let assert_can_boot_here = call
       ~name:"assert_can_boot_here"
       ~in_product_since:rel_rio
+      ~lifecycle:[ Published, rel_rio, ""
+                 ; Changed, rel_quebec, "Does additional compatibility checks when VM powerstate is not halted (e.g. CPUID). Use this before calling VM.resume or VM.pool_migrate."]
       ~doc:"Returns an error if the VM could not boot on this host for some reason"
       ~params:[
         Ref _vm, "self", "The VM";
@@ -374,9 +376,24 @@ let power_behaviour =
       ~allowed_roles:_R_READ_ONLY
       ~errs:[
         Api_errors.host_not_enough_free_memory;
+        Api_errors.host_not_enough_pcpus;
+        Api_errors.network_sriov_insufficient_capacity;
+        Api_errors.host_not_live;
+        Api_errors.host_disabled;
+        Api_errors.host_cannot_attach_network;
+        Api_errors.vm_hvm_required;
+        Api_errors.vm_requires_gpu;
+        Api_errors.vm_requires_iommu;
+        Api_errors.vm_requires_net;
         Api_errors.vm_requires_sr;
+        Api_errors.vm_requires_vgpu;
         Api_errors.vm_host_incompatible_version;
         Api_errors.vm_host_incompatible_virtual_hardware_platform_version;
+        Api_errors.invalid_value;
+        Api_errors.memory_constraint_violation;
+        Api_errors.operation_not_allowed;
+        Api_errors.value_not_supported;
+        Api_errors.vm_incompatible_with_this_host;
       ]
       ~doc_tags:[Memory]
       ()

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -239,7 +239,8 @@ let string_of_configuration_change ~__context (x: configuration_change) =
    the planner. *)
 let host_of_non_agile_vm ~__context all_hosts_and_snapshots_sorted (vm, snapshot) =
   match (List.filter (fun (host, _) ->
-      try Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_memory_check:false (); true
+      try Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot
+            ~do_memory_check:false ~do_cpuid_check:false (); true
       with _ -> false) all_hosts_and_snapshots_sorted) with
   | (host, host_snapshot) :: _ ->
     (* Multiple hosts are possible because "not agile" means "not restartable on every host". It is

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -261,7 +261,7 @@ let compute_evacuation_plan_no_wlb ~__context ~host =
             try
               List.iter (fun host ->
                   Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot:record
-                    ~do_memory_check:false ())
+                    ~do_memory_check:false ~do_cpuid_check:true ())
                 target_hosts;
               true
             with (Api_errors.Server_error (code, params)) -> Hashtbl.replace plans vm (Error (code, params)); false
@@ -287,7 +287,7 @@ let compute_evacuation_plan_no_wlb ~__context ~host =
       List.iter (fun (vm, host) ->
           let snapshot = List.assoc vm all_vms in
           begin
-            try Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_memory_check:false ()
+            try Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_memory_check:false ~do_cpuid_check:true ()
             with (Api_errors.Server_error (code, params)) -> Hashtbl.replace plans vm (Error (code, params))
           end;
           if not(Hashtbl.mem plans vm) then Hashtbl.replace plans vm (Migrate host)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -62,7 +62,7 @@ let assert_can_boot_here ~__context ~self ~host =
   let snapshot = Db.VM.get_record ~__context ~self in
   if Helpers.rolling_upgrade_in_progress ~__context then
     Helpers.assert_platform_version_is_same_on_master ~__context ~host ~self;
-  assert_can_boot_here ~__context ~self ~host ~snapshot ()
+  assert_can_boot_here ~__context ~self ~host ~snapshot ~do_cpuid_check:true ()
 
 let retrieve_wlb_recommendations ~__context ~vm =
   let snapshot = Db.VM.get_record ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -535,7 +535,7 @@ let retrieve_wlb_recommendations ~__context ~vm ~snapshot =
   List.iter
     (fun (h, r) ->
        try
-         assert_can_boot_here ~__context ~self:vm ~host:h ~snapshot ();
+         assert_can_boot_here ~__context ~self:vm ~host:h ~snapshot ~do_cpuid_check:false ();
          Hashtbl.replace recs h r;
        with
        | Api_errors.Server_error(x, y) -> Hashtbl.replace recs h (x :: y))
@@ -619,7 +619,7 @@ let get_possible_hosts_for_vm ~__context ~vm ~snapshot =
   let host = Db.VM.get_scheduled_to_be_resident_on ~__context ~self:vm in
   if host <> Ref.null then [ host ] else
     possible_hosts ~__context ~vm
-      ~choose_fn:(assert_can_boot_here ~__context ~self:vm ~snapshot ()) ()
+      ~choose_fn:(assert_can_boot_here ~__context ~self:vm ~snapshot ~do_cpuid_check:false ()) ()
 
 (** Performs an expensive and comprehensive check to determine whether the
     given [guest] can run on the given [host]. Returns true if and only if the

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1253,9 +1253,9 @@ let assert_can_migrate  ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options ~v
 
       (* Check VDIs are not migrating to or from an SR which doesn't have required_sr_operations *)
       assert_sr_support_operations ~__context ~vdi_map ~remote ~ops:required_sr_operations;
-      if not force then Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host:remote.dest_host ();
       let snapshot = Db.VM.get_record ~__context ~self:vm in
-      Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host:remote.dest_host ~snapshot ~do_sr_check:false ();
+      let do_cpuid_check = not force in
+      Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm ~host:remote.dest_host ~snapshot ~do_sr_check:false ~do_cpuid_check ();
       if vif_map <> [] then
         raise (Api_errors.Server_error(Api_errors.operation_not_allowed, [
             "VIF mapping is not allowed for intra-pool migration"]));


### PR DESCRIPTION
Details in the commit messages: this is needed so that XenCenter can use an API call instead of hardcoding/duplicating logic from XAPI.