### PR TITLE
CA-325582: Force unloading SR metrics from memory on destroy and forget

### DIFF
--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -426,6 +426,8 @@ let maybe_copy_sr_rrds ~__context ~sr =
 
 (* Removes the SR and dependent objects from the database (VDIs and PBDs).
    This function is meant to be used only inside this module.
+   Also removes the associated metrics from xcp-rrdd until SR metrics are
+   correctly reported as SR ones (CA-325582)
  *)
 let _destroy ~__context ~sr =
   (* CA-325582: Since the pbds are not mounted anymore there are no more


### PR DESCRIPTION
While this might interfere with the archival of SR metrics due to lifecycle mismatch of SR and Host; this is preferable to have an unusable system due to memory bloat in xcp-rrdd.

The proper solution is to report these metrics as SR ones and not as Host ones, but the migration needs a bit of thought.

Depends on https://github.com/xapi-project/xcp-rrdd/pull/106