### PR TITLE
CA-313081 fix moving template between SRs

### DIFF
--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -133,8 +133,7 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
   (* They can only eject/insert CDs not plug/unplug *)
   let vm_gm = Db.VM.get_guest_metrics ~__context ~self:vm in
   let vm_gmr = try Some (Db.VM_guest_metrics.get_record_internal ~__context ~self:vm_gm) with _ -> None in
-  let metrics = Db.VM.get_metrics ~__context ~self:vm in
-  let domain_type = Db.VM_metrics.get_current_domain_type ~__context ~self:metrics in
+  let domain_type = Helpers.domain_type ~__context ~self:vm in
   if power_state = `Running && (domain_type = `hvm) then begin
     let plug_ops = [ `plug; `unplug; `unplug_force ] in
     let fallback () =

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -98,7 +98,9 @@ let set_is_a_template ~__context ~self ~value =
     |> List.unbox_list
     |> List.iter (fun p -> Db.PVS_proxy.destroy ~__context ~self:p);
     (* delete the vm metrics associated with the vm if it exists, when we templat'ize it *)
-    try Db.VM_metrics.destroy ~__context ~self:m with _ -> ()
+    finally
+      (fun () -> Db.VM_metrics.destroy ~__context ~self:m)
+      (fun () -> Db.VM.set_metrics ~__context ~self ~value:(Ref.null))
   end;
   Db.VM.set_is_a_template ~__context ~self ~value
 


### PR DESCRIPTION
When creating a VM template, VM metrics were
destroyed in the DB, but ref was still
hanging around. This meant that performing
a vdi-pool-migrate on that template failed with
'invalid object reference.... class: VM_metrics'.

Fix involves setting the appropriate VM metric
ref to null, and ensuring that the VBD valid
operations are correct for halted VMs.

Signed-off-by: lippirk <ben.anson@citrix.com>