### PR TITLE
CA-330961 Clean the yum cache before prechecking/applying an update

### DIFF
--- a/scripts/extensions/pool_update.apply
+++ b/scripts/extensions/pool_update.apply
@@ -25,6 +25,8 @@ ERROR_MESSAGE_DOWNLOAD_PACKAGE = 'Error downloading packages:\n'
 ERROR_MESSAGE_START = 'Error: '
 ERROR_MESSAGE_END = 'You could try '
 
+class EnvironmentFailure(Exception):
+    pass
 
 class ApplyFailure(Exception):
     pass
@@ -44,9 +46,18 @@ def failure_message(code, params):
 
 
 def execute_apply(session, update_package, yum_conf_file):
-    cmd = ['yum', 'upgrade', '-y', '--noplugins', '-c', yum_conf_file, update_package]
     yum_env = os.environ.copy()
     yum_env['LANG'] = 'C'
+
+    cmd = ['yum', 'clean', 'all', '--noplugins', '-c', yum_conf_file]
+    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
+    output, _ = p.communicate()
+    for line in output.split('\n'):
+        xcp.logger.info(line)
+    if p.returncode != 0:
+        raise EnvironmentFailure("Error cleaning yum cache")
+
+    cmd = ['yum', 'upgrade', '-y', '--noplugins', '-c', yum_conf_file, update_package]
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
     output, _ = p.communicate()
     xcp.logger.info('pool_update.apply %r returncode=%r output:', cmd, p.returncode)

--- a/scripts/extensions/pool_update.precheck
+++ b/scripts/extensions/pool_update.precheck
@@ -48,6 +48,9 @@ ERROR = 'error'
 FOUND = 'found'
 REQUIRED = 'required'
 
+class EnvironmentFailure(Exception):
+    pass
+
 class PrecheckError(Exception):
     pass
 
@@ -118,9 +121,18 @@ def execute_precheck(session, control_package, yum_conf_file, update_precheck_fi
     livepatch_messages = {'PATCH_PRECHECK_LIVEPATCH_COMPLETE': 'ok_livepatch_complete',
                      'PATCH_PRECHECK_LIVEPATCH_INCOMPLETE': 'ok_livepatch_incomplete',
                      'PATCH_PRECHECK_LIVEPATCH_NOT_APPLICABLE': 'ok'}
-    cmd = ['yum', 'install', '-y', '--noplugins', '-c', yum_conf_file, control_package]
     yum_env = os.environ.copy()
     yum_env['LANG'] = 'C'
+
+    cmd = ['yum', 'clean', 'all', '--noplugins', '-c', yum_conf_file]
+    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
+    output, _ = p.communicate()
+    for line in output.split('\n'):
+        xcp.logger.info(line)
+    if p.returncode != 0:
+        raise EnvironmentFailure("Error cleaning yum cache")
+
+    cmd = ['yum', 'install', '-y', '--noplugins', '-c', yum_conf_file, control_package]
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
     output, _ = p.communicate()
     xcp.logger.info('pool_update.precheck %r returncode=%r output:', cmd, p.returncode)


### PR DESCRIPTION
It is possible to have two update ISOs which have the same update name, but
contain different versions of the update. The most obvious example is a driver
disk, where we might have different versions depending on the platform version
in use.

There is a potential issue in that yum will cache the repository metadata based
on the name of the repository (which in our case is the name of the update).
If the repository 'on disk' has an older timestamp than the cached data, then
yum will ignore the 'on disk' data, and use the cached information.

In the scenario where a user has erroneously attempted to apply the update from
the wrong version, we can end up in a situation where despite attempting to
apply the correct update, the metadata has been cached from the incorrect one,
and thus yum will refuse to install it due to a dependency failure (this is what
happened in XSI-539).

To avoid this, clear the yum cache before we attempt a precheck or update apply.