### PR TITLE
CA-330979: set current_domain_type for slaves

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -367,6 +367,7 @@ and update_domain_zero_metrics_record ~__context ~domain_zero_ref =
   let metrics   = Db.VM.get_metrics ~__context ~self:domain_zero_ref in
   let cpus      = count_cpus () in
   let cpus'     = Int64.of_int cpus in
+  Db.VM_metrics.set_current_domain_type ~__context ~self:metrics ~value:Xapi_globs.domain_zero_domain_type;
   Db.VM_metrics.set_VCPUs_number ~__context ~self:metrics ~value:cpus';
   Db.VM_metrics.set_VCPUs_utilisation ~__context ~self:metrics
     ~value:(List.map (fun x -> Int64.of_int x, 0.) (mkints cpus))


### PR DESCRIPTION
ff50be0b3b20102ca49cd252d32bdaea89619e06 made it an error to have an
unspecified current domain type at VBD plug time.

Dom0 of slave hosts always had an unspecified current_domain_type,
a bug caused by the pool join code.

When a slave joins a pool we import all VMs, and the import code deals
only with halted VMs (it sets current_domain_type to `unspecified`).
However Dom0 is special: it is the only VM allowed to be running when
joining a pool, so we must fix up the current_domain_type.
Do this in the function that updates other fields of Dom0's metric
record on startup to ensure it is always correct.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>