### PR TITLE
CA-322704 error with clustering across subnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ clean:
 test:
 	dune runtest --profile=$(PROFILE) --no-buffer -j $(JOBS)
 
+# e.g. $ make test-filter match=Test_cluster
+# only works with exact name of suite
+test-filter:
+	dune build ./ocaml/tests/suite_alcotest.exe --profile=$(PROFILE) && \
+	cd ./ocaml/tests && dune exec ./suite_alcotest.exe --profile=$(PROFILE) -- test '$(match)' | grep -v '[SKIP]'
+
 doc:
 	dune build --profile=$(PROFILE) ocaml/idl/datamodel_main.exe
 	dune build --profile=$(PROFILE) -f @ocaml/doc/jsapigen

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1165,6 +1165,8 @@ let _ =
     ~doc:"The last cluster host cannot be destroyed. Destroy the cluster instead" ();
   error Api_errors.no_cluster_hosts_reachable ["cluster"]
     ~doc:"No other cluster host was reachable when joining" ();
+  error Api_errors.cluster_inconsistent_subnet []
+    ~doc:"The host joining the cluster is not on the same network" ();
 
   error Api_errors.xen_incompatible []
     ~doc:"The current version of Xen or its control libraries is incompatible with the Toolstack." ()

--- a/ocaml/tests/test_helpers.ml
+++ b/ocaml/tests/test_helpers.ml
@@ -298,10 +298,7 @@ module AreOnSameSubnetTests = Generic.MakeStateless (struct
   let transform (netmask, ips) =
     let netmask = Ipaddr.of_string_exn netmask in
     let ips = List.map Ipaddr.of_string_exn ips in
-    match Helpers.are_on_same_subnet_exn netmask ips with
-    | `Not_same_subnet -> false
-    | `Same_subnet     -> true
-    | `Empty_ips       -> failwith "empty_ips"
+    Helpers.are_on_same_subnet_exn netmask ips
 
   let tests = `QuickAndAutoDocumented [
     ("255.255.255.0", ["192.0.2.0"]),                                true;
@@ -313,6 +310,25 @@ module AreOnSameSubnetTests = Generic.MakeStateless (struct
   ]
 end)
 
+module IntersectIpsTests = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = string list
+    type output_t = string
+
+    let string_of_input_t ips = Printf.sprintf "ips: [%s]" (String.concat "; " ips)
+    let string_of_output_t x = x
+  end
+
+  let transform ips =
+    let ips = List.map Ipaddr.of_string_exn ips in
+    Helpers.intersect_ips_exn ips |> Ipaddr.to_string
+
+  let tests = `QuickAndAutoDocumented [
+    ["255.255.255.0"; "255.255.0.0"], "255.255.0.0";
+    ["255.64.8.1"; "192.63.4.3"; "166.64.8.1"], "128.0.0.1";
+  ]
+end)
+
 let tests = make_suite "helpers_" [
     "determine_gateway", DetermineGateway.tests;
     "assert_is_valid_tcp_udp_port", PortCheckers.tests;
@@ -320,4 +336,5 @@ let tests = make_suite "helpers_" [
     "assert_is_valid_ip", IPCheckers.tests;
     "assert_is_valid_cidr", CIDRCheckers.tests;
     "test_are_on_same_subnet", AreOnSameSubnetTests.tests;
+    "test_intersect_ips", IntersectIpsTests.tests;
   ]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -625,5 +625,6 @@ let invalid_cluster_stack = "INVALID_CLUSTER_STACK"
 let pif_not_attached_to_host = "PIF_NOT_ATTACHED_TO_HOST"
 let cluster_host_not_joined = "CLUSTER_HOST_NOT_JOINED"
 let no_cluster_hosts_reachable = "NO_CLUSTER_HOSTS_REACHABLE"
+let cluster_inconsistent_subnet = "CLUSTER_INCONSISTENT_SUBNET"
 
 let xen_incompatible = "XEN_INCOMPATIBLE"

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -55,6 +55,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    pci
    domain-name
    ezxenstore.core
+   ipaddr
    message-switch-unix
    mtime
    mtime.clock.os

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -51,6 +51,7 @@ let call_api_function_with_alert ~__context ~msg ~cls ~obj_uuid ~body
 (* Create xapi db object for cluster_host, resync_host calls clusterd *)
 let create_internal ~__context ~cluster ~host ~pIF : API.ref_Cluster_host =
   with_clustering_lock __LOC__ (fun () ->
+      assert_cluster_on_pif_subnet ~__context ~cluster ~pIF;
       assert_operation_host_target_is_localhost ~__context ~host;
       assert_pif_attached_to ~host ~pIF ~__context;
       assert_cluster_host_can_be_created ~__context ~host;

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -51,7 +51,7 @@ let call_api_function_with_alert ~__context ~msg ~cls ~obj_uuid ~body
 (* Create xapi db object for cluster_host, resync_host calls clusterd *)
 let create_internal ~__context ~cluster ~host ~pIF : API.ref_Cluster_host =
   with_clustering_lock __LOC__ (fun () ->
-      assert_cluster_on_pif_subnet ~__context ~cluster ~pIF;
+      assert_same_subnet ~__context ~cluster ~pIF;
       assert_operation_host_target_is_localhost ~__context ~host;
       assert_pif_attached_to ~host ~pIF ~__context;
       assert_cluster_host_can_be_created ~__context ~host;

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -154,24 +154,23 @@ let assert_operation_host_target_is_localhost ~__context ~host =
   if host <> Helpers.get_localhost ~__context then
     raise Api_errors.(Server_error (internal_error, [ "A clustering operation was attempted from the wrong host" ]))
 
-let assert_cluster_on_pif_subnet ~__context ~cluster ~pIF =
+(* a new member of a cluster should reside on the same network as the cluster *)
+let assert_same_subnet ~__context ~cluster ~pIF =
   let parse_ip ip_str =
     match Ipaddr.of_string ip_str with
     | Ok ip_addr       -> ip_addr
     (* this shouldn't happen because we shouldn't be storing invalid ips *)
     | Error (`Msg msg) -> raise Api_errors.(Server_error (internal_error, [Printf.sprintf "could not parse ip address (%s), msg: %s" ip_str msg]))
   in
-  let pif_ip = ip_of_pif (pIF, Db.PIF.get_record ~__context ~self:pIF) |> Cluster_interface.str_of_address in
-  let ips = get_network_internal ~__context ~self:cluster |>
-    fun self -> Db.Network.get_assigned_ips ~__context ~self |>
-    List.map snd |>
-    List.cons pif_ip |>
-    List.map parse_ip
-  in
-  let netmask = Db.PIF.get_netmask ~__context ~self:pIF |> parse_ip in
-  match Helpers.are_on_same_subnet_exn netmask ips with
-  | `Same_subnet -> ()
-  | `Not_same_subnet -> raise Api_errors.(Server_error (cluster_inconsistent_subnet, ["pif is not on same subnet as cluster"]))
+  let ip_of_pif pIF = ip_of_pif (pIF, Db.PIF.get_record ~__context ~self:pIF) |> Cluster_interface.str_of_address |> parse_ip in
+  let netmask_of_pif pIF = Db.PIF.get_netmask ~__context ~self:pIF |> parse_ip in
+
+  let network = get_network_internal ~__context ~self:cluster in
+  let pifs = Db.Network.get_PIFs ~__context ~self:network |> List.cons pIF in
+  let ips = List.map ip_of_pif pifs in
+  let netmask = List.map netmask_of_pif pifs |> Helpers.intersect_ips_exn in
+  if not (Helpers.are_on_same_subnet_exn netmask ips) then
+    raise Api_errors.(Server_error (cluster_inconsistent_subnet, ["pif is not on same subnet as cluster"]))
 
 let assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__context ~self =
   let cluster = Db.Cluster_host.get_cluster ~__context ~self in

--- a/xapi.opam
+++ b/xapi.opam
@@ -21,6 +21,7 @@ depends: [
   "ezxenstore"
   "fmt" {with-test}
   "http-svr"
+  "ipaddr"
   "message-switch-unix"
   "mtime"
   "ocaml-migrate-parsetree"


### PR DESCRIPTION
We should not be able to enable clustering in
pools where hosts are in more than one subnet,
because xapi-clusterd won't work. Here we provide
a helpful error message.

Signed-off-by: lippirk <ben.anson@citrix.com>