### PR TITLE
Allow guests to see floppies

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1338,8 +1338,8 @@ let vbd_create printer rpc session_id params =
   let _type =
     if List.mem_assoc "type" params
     then match String.lowercase_ascii (List.assoc "type" params) with
-      | "cd" -> `CD | "disk" -> `Disk
-      | x -> failwith (Printf.sprintf "Unknown type: %s (should be \"cd\" or \"disk\"" x)
+      | "cd" -> `CD | "disk" -> `Disk | "floppy" -> `Floppy
+      | x -> failwith (Printf.sprintf {|"Unknown type: %s (should be "cd", "disk" or "floppy"|} x)
     else `Disk in
   let unpluggable = get_bool_param params ~default:true "unpluggable" in
   if _type=`Disk && empty then failwith "Empty VBDs can only be made for type=CD";

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -168,7 +168,7 @@ let create  ~__context ~vM ~vDI ~userdevice ~bootable ~mode ~_type ~unpluggable 
     Mutex.execute autodetect_mutex (fun () ->
         let possibilities = Xapi_vm_helpers.allowed_VBD_devices ~__context ~vm:vM ~_type in
 
-        if not (valid_device userdevice) || (userdevice = "autodetect" && possibilities = []) then
+        if not (valid_device userdevice ~_type) || (userdevice = "autodetect" && possibilities = []) then
           raise (Api_errors.Server_error (Api_errors.invalid_device,[userdevice]));
 
         (* Resolve the "autodetect" into a fixed device name now *)

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -166,7 +166,11 @@ let create  ~__context ~vM ~vDI ~userdevice ~bootable ~mode ~_type ~unpluggable 
   | _ ->
 
     Mutex.execute autodetect_mutex (fun () ->
-        let possibilities = Xapi_vm_helpers.allowed_VBD_devices ~__context ~vm:vM ~_type in
+        let possibilities =
+          match Xapi_vm_helpers.allowed_VBD_devices ~__context ~vm:vM ~_type with
+          | `Supported,           xs -> xs
+          | `FloppyPVUnsupported, _  -> raise (Api_errors.Server_error (Api_errors.not_implemented, ["VBD of type 'floppy' is not supported on PV domain"]))
+        in
 
         if not (valid_device userdevice ~_type) || (userdevice = "autodetect" && possibilities = []) then
           raise (Api_errors.Server_error (Api_errors.invalid_device,[userdevice]));

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -274,7 +274,7 @@ let clear_current_operations ~__context ~self =
 
 
 (** Check if the device string has the right form *)
-let valid_device dev =
+let valid_device dev ~_type =
   let check_rest rest = (* checks the rest of the device name = [] is ok, or a number is ok *)
     if rest=[]
     then true
@@ -284,10 +284,13 @@ let valid_device dev =
   in
   dev = "autodetect" ||
   match String.explode dev with
-  | 's' :: 'd' :: ('a'..'p') :: rest -> check_rest rest
+  | 's' :: 'd' ::        ('a'..'p') :: rest -> check_rest rest
   | 'x' :: 'v' :: 'd' :: ('a'..'p') :: rest -> check_rest rest
-  | 'h' :: 'd' :: ('a'..'p') :: rest -> check_rest rest
-  | _ -> try let n = int_of_string dev in n >= 0 || n <16 with _ -> false
+  | 'h' :: 'd' ::        ('a'..'p') :: rest -> check_rest rest
+  | 'f' :: 'd' ::        ('a'..'b') :: rest -> check_rest rest (* QEMU only supports up to 2 floppy drives, hence fda or fdb *)
+  | _ -> match _type with
+         | `Floppy -> false
+         | _       -> try let n = int_of_string dev in n >= 0 || n <16 with _ -> false
 
 (** VBD.destroy doesn't require any interaction with xen *)
 let destroy  ~__context ~self =

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1024,7 +1024,11 @@ let get_possible_hosts ~__context ~vm =
   let snapshot = Db.VM.get_record ~__context ~self:vm in
   get_possible_hosts_for_vm ~__context ~vm ~snapshot
 
-let get_allowed_VBD_devices ~__context ~vm = List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (snd @@ allowed_VBD_devices ~__context ~vm ~_type:`Disk)
+let get_allowed_VBD_devices ~__context ~vm =
+  List.append
+    (List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (snd @@ allowed_VBD_devices ~__context ~vm ~_type:`Disk))
+    (List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (snd @@ allowed_VBD_devices ~__context ~vm ~_type:`Floppy))
+
 let get_allowed_VIF_devices = allowed_VIF_devices
 
 (* Undocumented Rio message, deprecated in favour of standard VM.clone *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1024,7 +1024,7 @@ let get_possible_hosts ~__context ~vm =
   let snapshot = Db.VM.get_record ~__context ~self:vm in
   get_possible_hosts_for_vm ~__context ~vm ~snapshot
 
-let get_allowed_VBD_devices ~__context ~vm = List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (allowed_VBD_devices ~__context ~vm ~_type:`Disk)
+let get_allowed_VBD_devices ~__context ~vm = List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (snd @@ allowed_VBD_devices ~__context ~vm ~_type:`Disk)
 let get_allowed_VIF_devices = allowed_VIF_devices
 
 (* Undocumented Rio message, deprecated in favour of standard VM.clone *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1024,11 +1024,7 @@ let get_possible_hosts ~__context ~vm =
   let snapshot = Db.VM.get_record ~__context ~self:vm in
   get_possible_hosts_for_vm ~__context ~vm ~snapshot
 
-let get_allowed_VBD_devices ~__context ~vm =
-  List.append
-    (List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (snd @@ allowed_VBD_devices ~__context ~vm ~_type:`Disk))
-    (List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (snd @@ allowed_VBD_devices ~__context ~vm ~_type:`Floppy))
-
+let get_allowed_VBD_devices ~__context ~vm = List.map (fun d -> string_of_int (Device_number.to_disk_number d)) (snd @@ allowed_VBD_devices ~__context ~vm ~_type:`Disk)
 let get_allowed_VIF_devices = allowed_VIF_devices
 
 (* Undocumented Rio message, deprecated in favour of standard VM.clone *)


### PR DESCRIPTION
This is a backport of CA-330162 to 8.1.

It includes what I hope is a fix for failing BVTs.

Needs to go in alongside https://github.com/xapi-project/xenopsd/pull/691