### PR TITLE
maintenance: remove Pervasives deprecated warnings

### DIFF
--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -32,7 +32,7 @@ end
 module StringMap = struct
   include Map.Make(struct
       type t = string
-      let compare = Pervasives.compare
+      let compare = Stdlib.compare
     end)
   let update key default f t =
     let v = try find key t with Not_found -> default in
@@ -173,7 +173,7 @@ let string_of_common_key = function
 module KeyMap = struct
   include Map.Make(struct
       type t = common_key
-      let compare = Pervasives.compare
+      let compare = Stdlib.compare
     end)
   let add_unique tblname fldname k v t =
     if mem k t

--- a/ocaml/database/schema.ml
+++ b/ocaml/database/schema.ml
@@ -113,7 +113,7 @@ type foreign = (string * string * string) list
 module ForeignMap = struct
   include Map.Make(struct
       type t = string
-      let compare = Pervasives.compare
+      let compare = Stdlib.compare
     end)
 
   type t' = (string * foreign) list

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -669,7 +669,7 @@ let version_of : __context:Context.t -> [`host] api_object -> int list =
     let vs = version_string_of ~__context host
     in List.map int_of_string (String.split '.' vs)
 
-(* Compares host versions, analogous to Pervasives.compare. *)
+(* Compares host versions, analogous to Stdlib.compare. *)
 let compare_host_platform_versions : __context:Context.t -> [`host] api_object -> [`host] api_object -> int =
   fun ~__context host_a host_b ->
     let version_of = version_of ~__context in

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -364,7 +364,7 @@ module Configuration = struct
             end;
             (* Accepted values are "true" and "false" *)
             (* If someone deletes the multipathing other_config key, we don't do anything *)
-            let multipathing = try Some (List.assoc "multipathing" oc |> Pervasives.bool_of_string) with _ -> None in
+            let multipathing = try Some (List.assoc "multipathing" oc |> Stdlib.bool_of_string) with _ -> None in
             begin match multipathing with
               | None -> ()
               | Some multipathing when multipathing <> host_rec.API.host_multipathing ->

--- a/ocaml/xapi/xapi_pgpu_helpers.ml
+++ b/ocaml/xapi/xapi_pgpu_helpers.ml
@@ -68,7 +68,7 @@ let assert_VGPU_type_allowed ~__context ~self ~vgpu_type =
           Ref.string_of self;
           Ref.string_of vgpu_type;
           List.map (fun self-> Db.VGPU.get_type ~__context ~self) allocated_vgpu_list
-          |> List.sort_uniq Pervasives.compare
+          |> List.sort_uniq Stdlib.compare
           |> List.map (fun vgpu_type_ref -> Ref.string_of vgpu_type_ref)
           |> String.concat sep
         ]))


### PR DESCRIPTION
Pervasives is deprecated in ocaml 4.08 - bringing
some compiler warnings to fix. This change is
compatible with 4.07.

Signed-off-by: lippirk <ben.anson@citrix.com>