### PR TITLE
Ca 325582 clean up dead SR metrics

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -30,6 +30,10 @@ open D
 module Audit = Debug.Make(struct let name="audit" end)
 let info = Audit.debug
 
+module PBDSet = Set.Make (struct
+  type t = API.ref_PBD
+  let compare = Stdlib.compare
+end)
 
 (**************************************************************************************)
 
@@ -161,25 +165,39 @@ let log_exn_ignore ?(doc = "performing unknown operation") f x =
 
 
 (* Given an SR, return a PBD to use for some storage operation. *)
-(* In the case of SR.destroy we need to be able to forward the SR operation when all
-   PBDs are unplugged - this is the reason for the consider_unplugged_pbds optional
-   argument below. All other SR ops only consider plugged PBDs... *)
-let choose_pbd_for_sr ?(consider_unplugged_pbds=false) ~__context ~self () =
+(* In the case of SR.destroy and forget we need to be able to forward the SR
+   operation when all PBDs are unplugged. This is the reason for the
+   consider_unplugged_pbds optional argument below. All other SR ops only
+   consider plugged PBDs. *)
+let choose_pbds_for_sr ?(consider_unplugged_pbds=false) ~__context ~self () =
+  let module R = Stdlib.Result in
   let all_pbds = Db.SR.get_PBDs ~__context ~self in
-  let plugged_pbds = List.filter (fun pbd->Db.PBD.get_currently_attached ~__context ~self:pbd) all_pbds in
+  let plugged_pbds = List.filter (fun self -> Db.PBD.get_currently_attached ~__context ~self) all_pbds in
   let pbds_to_consider = if consider_unplugged_pbds then all_pbds else plugged_pbds in
-  if Helpers.is_sr_shared ~__context ~self then
-    let master = Helpers.get_master ~__context in
-    let master_pbds = Db.Host.get_PBDs ~__context ~self:master in
-    (* shared SR operations must happen on the master *)
-    match Listext.intersect pbds_to_consider master_pbds with
-    | pbd :: _ -> pbd (* ok, master plugged *)
-    | [] -> raise (Api_errors.Server_error(Api_errors.sr_no_pbds, [ Ref.string_of self ])) (* can't do op, master pbd not plugged *)
-  else
-    match pbds_to_consider with
-    | [] -> raise (Api_errors.Server_error(Api_errors.sr_no_pbds, [ Ref.string_of self ]))
-    | pdb :: _ -> pdb
+  let pbds = PBDSet.of_list pbds_to_consider in
+  let pbd_candidates =
+    if Helpers.is_sr_shared ~__context ~self then
+      let master = Helpers.get_master ~__context in
+      let master_pbds = PBDSet.of_list (Db.Host.get_PBDs ~__context ~self:master) in
+      (* Operation run on shared SRs depend on the first pbd of the list to be
+         on the master. *)
+      let sr_master_pbds, rest_pbds = PBDSet.partition (fun pbd -> PBDSet.mem pbd master_pbds) pbds in
+      if PBDSet.is_empty sr_master_pbds then
+        Error `Sr_no_pbds
+      else
+        Ok (List.rev_append (PBDSet.elements sr_master_pbds) (PBDSet.elements rest_pbds))
+    else
+      Ok pbds_to_consider
+  in
+  R.bind pbd_candidates (function
+  | []   -> Error `Sr_no_pbds
+  | pbds -> Ok pbds)
 
+let choose_pbd_for_sr ?consider_unplugged_pbds ~__context ~self () =
+  match choose_pbds_for_sr ?consider_unplugged_pbds ~__context ~self () with
+  | Ok (x::_)         -> x
+  | Ok []             -> failwith "expected 'choose_pbds_for_sr' to return a non-empty list"
+  | Error `Sr_no_pbds -> raise (Api_errors.Server_error(Api_errors.sr_no_pbds, [ Ref.string_of self ]))
 
 let loadbalance_host_operation ~__context ~hosts ~doc ~op (f: API.ref_host -> unit)  =
   let task_id = Ref.string_of (Context.get_task_id __context) in
@@ -1503,10 +1521,10 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         (fun () -> with_vm_operation ~__context ~self:vm ~doc:"VM.reverting" ~op:`reverting
             (fun () ->
                (* We need to do a best-effort check that any suspend_VDI referenced by
-                  							the snapshot (not the current VM) is currently accessible. This is because
-                  							the revert code first clears space by deleting current VDIs before cloning
-                  							the suspend VDI: we want to minimise the probability that the operation fails
-                  							part-way through. *)
+                  the snapshot (not the current VM) is currently accessible. This is because
+                  the revert code first clears space by deleting current VDIs before cloning
+                  the suspend VDI: we want to minimise the probability that the operation fails
+                  part-way through. *)
                if Db.VM.get_power_state ~__context ~self:snapshot = `Suspended then begin
                  let suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:snapshot in
                  let sr = Db.VDI.get_SR ~__context ~self:suspend_VDI in
@@ -3225,6 +3243,20 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         try Xapi_vm_helpers.choose_host ~__context ~choose_fn ~prefer_slaves ()
         with _ -> raise Not_found in
       do_op_on ~local_fn ~__context ~host op
+
+    (* Forward SR operation to all hosts that have suitable, plugged or
+       unplugged PBDs, best effort *)
+    let forward_sr_all_op ?(consider_unplugged_pbds=false) ~local_fn ~__context ~self op =
+      match choose_pbds_for_sr ~consider_unplugged_pbds ~__context ~self () with
+      | Error `Sr_no_pbds -> D.info "forward_sr_all_op: doing nothing - there are no pbds attached to SR (%s)" (Ref.string_of self)
+      | Ok pbds           -> pbds |>
+                             List.map (fun pbd -> Db.PBD.get_host ~__context ~self:pbd) |>
+                             List.iter (fun host ->
+                                 try
+                                   do_op_on ~local_fn ~__context ~host op
+                                 with Api_errors.Server_error (reason, _) when reason = Api_errors.host_offline ->
+                                   () (* allow an offline host to continue the operation *)
+                             )
 
     let set_virtual_allocation ~__context ~self ~value =
       Sm.assert_session_has_internal_sr_access ~__context ~sr:self;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3270,15 +3270,21 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let local_fn = Local.SR.destroy ~sr in
       with_sr_marked ~__context ~sr ~doc:"SR.destroy" ~op:`destroy
         (fun () ->
-           forward_sr_op ~consider_unplugged_pbds:true ~local_fn ~__context ~self:sr
-             (fun session_id rpc -> Client.SR.destroy rpc session_id sr))
+          Xapi_sr.assert_all_pbds_unplugged ~__context ~sr;
+          Xapi_sr.assert_sr_not_indestructible ~__context ~sr;
+          Xapi_sr.assert_sr_not_local_cache ~__context ~sr;
 
-    (* don't forward this is just a db call *)
+          forward_sr_op ~consider_unplugged_pbds:true ~local_fn ~__context ~self:sr
+            (fun session_id rpc -> Client.SR.destroy rpc session_id sr))
+
     let forget ~__context ~sr =
       info "SR.forget: SR = '%s'" (sr_uuid ~__context sr);
       with_sr_marked ~__context ~sr ~doc:"SR.forget" ~op:`forget
         (fun () ->
-           Local.SR.forget ~__context ~sr)
+          Xapi_sr.assert_all_pbds_unplugged ~__context ~sr;
+
+          (* don't forward this is just a db call *)
+          Local.SR.forget ~__context ~sr)
 
     let update ~__context ~sr =
       info "SR.update: SR = '%s'" (sr_uuid ~__context sr);

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -20,7 +20,7 @@ open Printf
 open Stdext
 open Threadext
 open Pervasiveext
-open Listext
+module Listext = Listext.List
 open Db_filter_types
 open API
 open Client
@@ -698,12 +698,12 @@ let assert_can_host_ha_statefile ~__context ~sr =
 let assert_supports_database_replication ~__context ~sr =
   (* Check that each host has a PBD to this SR *)
   let pbds = Db.SR.get_PBDs ~__context ~self:sr in
-  let connected_hosts = List.setify (List.map (fun self -> Db.PBD.get_host ~__context ~self) pbds) in
+  let connected_hosts = Listext.setify (List.map (fun self -> Db.PBD.get_host ~__context ~self) pbds) in
   let all_hosts = Db.Host.get_all ~__context in
   if List.length connected_hosts < (List.length all_hosts) then begin
     error "Cannot enable database replication to SR %s: some hosts lack a PBD: [ %s ]"
       (Ref.string_of sr)
-      (String.concat "; " (List.map Ref.string_of (List.set_difference all_hosts connected_hosts)));
+      (String.concat "; " (List.map Ref.string_of (Listext.set_difference all_hosts connected_hosts)));
     raise (Api_errors.Server_error(Api_errors.sr_no_pbds, [ Ref.string_of sr ]))
   end;
   (* Check that each PBD is plugged in *)

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -368,11 +368,33 @@ let create  ~__context ~host ~device_config ~(physical_size:int64) ~name_label ~
        Tasks.wait_for_all ~rpc ~session_id ~tasks);
   sr_ref
 
-let check_no_pbds_attached ~__context ~sr =
-  let all_pbds_attached_to_this_sr =
-    Db.PBD.get_records_where ~__context ~expr:(And(Eq(Field "SR", Literal (Ref.string_of sr)), Eq(Field "currently_attached", Literal "true"))) in
-  if List.length all_pbds_attached_to_this_sr > 0
-  then raise (Api_errors.Server_error(Api_errors.sr_has_pbd, [ Ref.string_of sr ]))
+let assert_all_pbds_unplugged ~__context ~sr =
+  let any_pbds_attached_to_sr = Db.PBD.get_all_records ~__context
+  |> List.exists (fun (_ref, pbd) ->
+      pbd.API.pBD_SR = sr && pbd.API.pBD_currently_attached)
+  in
+
+  if any_pbds_attached_to_sr then
+    raise (Api_errors.Server_error(Api_errors.sr_has_pbd, [ Ref.string_of sr ]))
+
+let assert_sr_not_indestructible ~__context ~sr =
+  let oc = Db.SR.get_other_config ~__context ~self:sr in
+
+  match List.assoc_opt "indestructible" oc with
+  | Some "true" ->
+    raise (Api_errors.Server_error(Api_errors.sr_indestructible, [ Ref.string_of sr ]))
+  | _ -> ()
+
+let assert_sr_not_local_cache ~__context ~sr =
+  let host_with_sr_as_cache = Db.Host.get_all ~__context
+  |> List.find_opt (fun host ->
+      sr = Db.Host.get_local_cache_sr ~__context ~self:host)
+  in
+
+  match host_with_sr_as_cache with
+  | Some host ->
+    raise (Api_errors.Server_error(Api_errors.sr_is_cache_sr, [ Ref.string_of host ]))
+  | None -> ()
 
 let find_or_create_rrd_vdi ~__context ~sr =
   let open Db_filter_types in
@@ -425,50 +447,29 @@ let maybe_copy_sr_rrds ~__context ~sr =
       warn "Archiving of SR RRDs to stats VDI failed: %s" msg
 
 (* Remove SR record from database without attempting to remove SR from disk.
-   Fail if any PBD still is attached (plugged); force the user to unplug it
-   first. *)
+   Assumes all PBDs created from the SR have been unplugged. *)
 let forget  ~__context ~sr =
-  (* NB we fail if ANY host is connected to this SR *)
-  check_no_pbds_attached ~__context ~sr;
-  List.iter (fun self -> Xapi_pbd.destroy ~__context ~self) (Db.SR.get_PBDs ~__context ~self:sr);
-  let vdis = Db.VDI.get_refs_where ~__context ~expr:(Eq(Field "SR", Literal (Ref.string_of sr))) in
-  List.iter (fun vdi ->  Db.VDI.destroy ~__context ~self:vdi) vdis;
+  let pbds = Db.SR.get_PBDs ~__context ~self:sr in
+  let vdis = Db.SR.get_VDIs ~__context ~self:sr in
+
+  List.iter (fun self -> Xapi_pbd.destroy ~__context ~self) pbds;
+  List.iter (fun self -> Db.VDI.destroy ~__context ~self) vdis;
   Db.SR.destroy ~__context ~self:sr
 
-(** Remove SR from disk and remove SR record from database. (This operation uses the SR's associated
-    PBD record on current host to determine device_config reqd by sr backend) *)
+(** Remove SR from disk and its record from the database. This operation uses
+   the SR's associated PBD record on current host to determine device_config
+   required by SR backend. *)
 let destroy  ~__context ~sr =
-  check_no_pbds_attached ~__context ~sr;
-  let pbds = Db.SR.get_PBDs ~__context ~self:sr in
-
-  (* raise exception if the 'indestructible' flag is set in other_config *)
-  let oc = Db.SR.get_other_config ~__context ~self:sr in
-  if (List.mem_assoc "indestructible" oc) && (List.assoc "indestructible" oc = "true") then
-    raise (Api_errors.Server_error(Api_errors.sr_indestructible, [ Ref.string_of sr ]));
-
-  (* raise exception if SR is being used as local_cache_sr *)
-  let all_hosts = Db.Host.get_all ~__context in
-  List.iter
-    (fun host ->
-       let local_cache_sr = Db.Host.get_local_cache_sr ~__context ~self:host in
-       if local_cache_sr = sr then
-         raise (Api_errors.Server_error(Api_errors.sr_is_cache_sr, [ Ref.string_of host ]));
-    ) all_hosts;
-
   let vdis_to_destroy =
     if should_manage_stats ~__context sr then [find_or_create_rrd_vdi ~__context ~sr]
     else [] in
 
   Storage_access.destroy_sr ~__context ~sr ~and_vdis:vdis_to_destroy;
 
-  (* The sr_delete may have deleted some VDI records *)
-  let vdis = Db.SR.get_VDIs ~__context ~self:sr in
   let sm_cfg = Db.SR.get_sm_config ~__context ~self:sr in
 
   Xapi_secret.clean_out_passwds ~__context sm_cfg;
-  List.iter (fun self -> Xapi_pbd.destroy ~__context ~self) pbds;
-  List.iter (fun vdi ->  Db.VDI.destroy ~__context ~self:vdi) vdis;
-  Db.SR.destroy ~__context ~self:sr
+  forget ~__context ~sr
 
 let update ~__context ~sr =
   let open Storage_access in

--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -19,7 +19,7 @@ open Printf
 open Stdext
 open Threadext
 open Pervasiveext
-open Listext
+module Listext = Listext.List
 open Db_filter_types
 open API
 open Client
@@ -70,7 +70,7 @@ let features_of_sr_internal ~__context ~_type =
   | [] ->
     []
   | (_, sm) :: _ ->
-    Listext.List.filter_map
+    Listext.filter_map
       (fun (name, v) ->
          try
            Some (List.assoc name Smint.string_to_capability_table, v)
@@ -151,14 +151,14 @@ let valid_operations ~__context ?op record _ref' : table =
 
   let check_parallel_ops ~__context record =
     let safe_to_parallelise = [`plug] in
-    let current_ops = List.setify (List.map snd current_ops) in
+    let current_ops = Listext.setify (List.map snd current_ops) in
 
     (* If there are any current operations, all the non_parallelisable operations
        must definitely be stopped *)
     if current_ops <> []
     then set_errors Api_errors.other_operation_in_progress
         [ "SR"; _ref; sr_operation_to_string (List.hd current_ops) ]
-        (List.set_difference all_ops safe_to_parallelise);
+        (Listext.set_difference all_ops safe_to_parallelise);
 
     let all_are_parallelisable = List.fold_left (&&) true
         (List.map (fun op -> List.mem op safe_to_parallelise) current_ops) in


### PR DESCRIPTION
Make sure data sources for an SR are not kept in memory in xcp-rrdd when the SR is destroyed or forgotten.