### PR TITLE
CA-328130 Fix usb_scan tests

### DIFF
--- a/scripts/test_usb_scan.py
+++ b/scripts/test_usb_scan.py
@@ -147,6 +147,7 @@ class TestUsbScan(unittest.TestCase):
                     "version": " 1.10",
                     "idProduct": "0302",
                     "bDeviceClass": "00",
+                    "speed": "480"
                 }
             }
         ]
@@ -170,7 +171,8 @@ class TestUsbScan(unittest.TestCase):
                 "version": "1.10",
                 "vendor-id": "096e",
                 "path": "1-2",
-                "serial": ""
+                "serial": "",
+                "speed": "480"
             }
         ]
         self.test_usb_common(devices, interfaces, results)
@@ -190,6 +192,7 @@ class TestUsbScan(unittest.TestCase):
                     "version": " 1.10",
                     "idProduct": "0302",
                     "bDeviceClass": "00",
+                    "speed": "12"
                 }
             }
         ]
@@ -213,7 +216,8 @@ class TestUsbScan(unittest.TestCase):
                 "version": "1.10",
                 "vendor-id": "096e",
                 "path": "1-2.1",
-                "serial": ""
+                "serial": "",
+                "speed": "12"
             }
         ]
         self.test_usb_common(devices, interfaces, results)


### PR DESCRIPTION
Fixes failing tests introduced in da190399972fcaf2643892434091d2a29a97e2d2

This happened because usb_scan.py now reads the
usb speed from udev, causing failing tests, and
this field was missing in test_usb_scan.py

Signed-off-by: lippirk <ben.anson@citrix.com>