### PR TITLE
CA-325582 fix some storage quicktests for pools

### DIFF
--- a/ocaml/quicktest/qt.ml
+++ b/ocaml/quicktest/qt.ml
@@ -38,6 +38,13 @@ let cli_cmd args =
   | e ->
     Alcotest.fail ("CLI failed" ^ (Printexc.to_string e))
 
+(** Look up key in /etc/xensource-inventory *)
+let inventory_lookup k =
+  Xapi_inventory.inventory_filename := "/etc/xensource-inventory";
+  Xapi_inventory.lookup k
+
+let localhost_uuid = inventory_lookup Xapi_inventory._installation_uuid
+
 module Test = struct
   let assert_raises_match exception_match fn =
     try
@@ -119,8 +126,7 @@ module VM = struct
     Client.Client.Host.get_control_domain rpc session_id host
 
   let get_dom0 rpc session_id =
-    Xapi_inventory.inventory_filename := "/etc/xensource-inventory";
-    let uuid = Xapi_inventory.lookup Xapi_inventory._control_domain_uuid in
+    let uuid = inventory_lookup Xapi_inventory._control_domain_uuid in
     Client.Client.VM.get_by_uuid ~rpc ~session_id ~uuid
 end
 

--- a/ocaml/quicktest/qt.mli
+++ b/ocaml/quicktest/qt.mli
@@ -19,6 +19,8 @@ val http : Http.Request.t -> (Http.Response.t * Unix.file_descr -> 'a) -> 'a
 
 val cli_cmd : string list -> string
 
+val localhost_uuid : string
+
 module Test : sig
   val assert_raises_match : (exn -> bool) -> (unit -> 'a) -> unit
   (** This test succeeds if an exception is raised for which the given

--- a/ocaml/quicktest/quicktest_vdi.ml
+++ b/ocaml/quicktest/quicktest_vdi.ml
@@ -1,3 +1,4 @@
+module A = Quicktest_args
 
 (** If VDI_CREATE and VDI_DELETE are present then make sure VDIs appear and disappear correctly *)
 (** VDI_CREATE should make a fresh disk; VDI_DELETE should remove it *)
@@ -166,7 +167,7 @@ let vbd_create_helper ~rpc ~session_id ~vM ~vDI ?(userdevice="autodetect") () : 
 (** Check that snapshot works regardless which host has the VDI activated *)
 let vdi_snapshot_in_pool rpc session_id sr_info () =
   Qt.VDI.with_any rpc session_id sr_info (fun vdi ->
-      let hosts = Client.Client.Host.get_all rpc session_id in
+      let localhost = Client.Client.Host.get_by_uuid ~rpc ~session_id ~uuid:Qt.localhost_uuid in
       let do_test () =
         check_vdi_snapshot rpc session_id vdi
       in
@@ -185,8 +186,7 @@ let vdi_snapshot_in_pool rpc session_id sr_info () =
              Client.Client.VBD.destroy rpc session_id vbd
           )
       in
-      List.iter test_snapshot_on hosts;
-
+      test_snapshot_on localhost;
       do_test ()
     )
 


### PR DESCRIPTION
This does not fix all failures, but some.

Some storage quicktests were failing on pools
because by default it runs each test for each SR
a host can see - including the local storage of
another host in the pool. To fix we add a filter
to remove such SRs.

`vdi_snapshot_in_pool` was also iterating over
hosts - it should not have been, because we
don't necessarily have access to that host's SRs.
Instead, only test snapshot on localhost.

Signed-off-by: lippirk <ben.anson@citrix.com>