### PR TITLE
CA-331142: stunnel on server side close SSL sock unexpectedly

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -113,7 +113,7 @@ connect = 80
 cert = ${PEMFILE}
 ciphers = !SSLv2:${GOOD_CIPHERS}${EXTRA_CIPHERS}
 curve = secp384r1
-TIMEOUTclose = 0
+TIMEOUTclose = 1
 options = CIPHER_SERVER_PREFERENCE
 options = NO_SSLv2
 EOF


### PR DESCRIPTION
The issue to be fixed in this commit is that stunnel on server side may
close SSL connection without sending SSL alert firstly.

The case looks like that a stunnel client requests more than 640KB data
from stunnel server. When the stunnel on server side finds that its
backend (XAPI) closes the local socket, it sets `shutdown_wants_write`
as 1 so that in next receiving loop it expects to send SSL alert. But
actually before sending the SSL alert, it closes SSL connection.

This is due to `TIMEOUTclose` is set to 0. The stunnel on server side
returns from `s_poll_wait` with timeout, returns from transfer loop, and
eventually closes the SSL connection from TCP's point of view.

This is not a 100% reproducible issue.

Setting the `TIMEOUTclose` to 1 can make stunnel on server side get a
chance to wait for the SSL socket ready for sending SSL alert.

The history of `TIMEOUTclose` being set to 0 is CA-59191. The issue can
not be hit by latest stunnel and XenServer.

Signed-off-by: Ming Lu <ming.lu@citrix.com>