### PR TITLE
CA-325582 backport to 7.1 CU2

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -181,9 +181,9 @@ let hosts_with_several_srs ~__context srs =
 (* Given an SR, return a PBD to use for some storage operation. *)
 (* In the case of SR.destroy and forget we need to be able to forward the SR
    operation when all PBDs are unplugged. This is the reason for the
-   consider_unplugged_pbds optional argument below. All other SR ops only
+   consider_unplugged_pbds argument below. All other SR ops only
    consider plugged PBDs. *)
-let choose_pbds_for_sr ?(consider_unplugged_pbds=false) ~__context ~self () =
+let choose_pbds_for_sr ~consider_unplugged_pbds ~__context ~self () =
   let module R = Stdlib.Result in
   let all_pbds = Db.SR.get_PBDs ~__context ~self in
   let plugged_pbds = List.filter (fun self -> Db.PBD.get_currently_attached ~__context ~self) all_pbds in
@@ -207,8 +207,8 @@ let choose_pbds_for_sr ?(consider_unplugged_pbds=false) ~__context ~self () =
   | []   -> Error `Sr_no_pbds
   | pbds -> Ok pbds)
 
-let choose_pbd_for_sr ?consider_unplugged_pbds ~__context ~self () =
-  match choose_pbds_for_sr ?consider_unplugged_pbds ~__context ~self () with
+let choose_pbd_for_sr ~consider_unplugged_pbds ~__context ~self () =
+  match choose_pbds_for_sr ~consider_unplugged_pbds ~__context ~self () with
   | Ok (x::_)         -> x
   | Ok []             -> failwith "expected 'choose_pbds_for_sr' to return a non-empty list"
   | Error `Sr_no_pbds -> raise (Api_errors.Server_error(Api_errors.sr_no_pbds, [ Ref.string_of self ]))
@@ -1517,7 +1517,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
                if Db.VM.get_power_state ~__context ~self:snapshot = `Suspended then begin
                  let suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:snapshot in
                  let sr = Db.VDI.get_SR ~__context ~self:suspend_VDI in
-                 let pbd = choose_pbd_for_sr ~__context ~self:sr () in
+                 let pbd = choose_pbd_for_sr ~consider_unplugged_pbds:false ~__context ~self:sr () in
                  let host = Db.PBD.get_host ~__context ~self:pbd in
                  let metrics = Db.Host.get_metrics ~__context ~self:host in
                  let live = Db.is_valid_ref __context metrics && (Db.Host_metrics.get_live ~__context ~self:metrics) in
@@ -2015,7 +2015,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
     let import ~__context ~url ~sr ~full_restore ~force =
       info "VM.import: url = '%s' sr='%s' force='%b'" url (Ref.string_of sr) force;
-      let pbd = choose_pbd_for_sr ~__context ~self:sr () in
+      let pbd = choose_pbd_for_sr ~consider_unplugged_pbds:false ~__context ~self:sr () in
       let host = Db.PBD.get_host ~__context ~self:pbd in
       do_op_on ~local_fn:(Local.VM.import ~url ~sr ~full_restore ~force) ~__context ~host (fun session_id rpc -> Client.VM.import rpc session_id url sr full_restore force)
 
@@ -3072,8 +3072,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
     (* -------- Forwarding helper functions: ------------------------------------ *)
 
     (* Forward SR operation to host that has a suitable plugged (or unplugged) PBD  *)
-    let forward_sr_op ?consider_unplugged_pbds ~local_fn ~__context ~self op =
-      let pbd = choose_pbd_for_sr ?consider_unplugged_pbds ~__context ~self () in
+    let forward_sr_op ?(consider_unplugged_pbds=false) ~local_fn ~__context ~self op =
+      let pbd = choose_pbd_for_sr ~consider_unplugged_pbds ~__context ~self () in
       let host = Db.PBD.get_host ~__context ~self:pbd in
       do_op_on ~local_fn ~__context ~host op
 
@@ -3140,24 +3140,36 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
     let destroy ~__context ~sr =
       info "SR.destroy: SR = '%s'" (sr_uuid ~__context sr);
-      let local_fn = Local.SR.destroy ~sr in
+      let local_destroy = Local.SR.destroy ~sr in
+      let local_forget = Local.SR.forget ~sr in
       with_sr_marked ~__context ~sr ~doc:"SR.destroy" ~op:`destroy
         (fun () ->
           Xapi_sr.assert_all_pbds_unplugged ~__context ~sr;
           Xapi_sr.assert_sr_not_indestructible ~__context ~sr;
           Xapi_sr.assert_sr_not_local_cache ~__context ~sr;
 
-          forward_sr_op ~consider_unplugged_pbds:true ~local_fn ~__context ~self:sr
-            (fun session_id rpc -> Client.SR.destroy rpc session_id sr))
+          forward_sr_op ~consider_unplugged_pbds:true ~local_fn:local_destroy ~__context ~self:sr
+            (fun session_id rpc -> Client.SR.destroy rpc session_id sr);
+
+          forward_sr_all_op ~consider_unplugged_pbds:true ~local_fn:local_forget ~__context ~self:sr
+            (fun session_id rpc -> Client.SR.forget rpc session_id sr);
+
+          (* don't forward - this is just a db call *)
+          Xapi_sr.really_forget ~__context ~sr
+        )
 
     let forget ~__context ~sr =
       info "SR.forget: SR = '%s'" (sr_uuid ~__context sr);
+      let local_fn = Local.SR.forget ~sr in
       with_sr_marked ~__context ~sr ~doc:"SR.forget" ~op:`forget
         (fun () ->
           Xapi_sr.assert_all_pbds_unplugged ~__context ~sr;
+          forward_sr_all_op ~consider_unplugged_pbds:true ~local_fn ~__context ~self:sr
+            (fun session_id rpc -> Client.SR.forget rpc session_id sr);
 
-          (* don't forward this is just a db call *)
-          Local.SR.forget ~__context ~sr)
+          (* don't forward - this is just a db call *)
+          Xapi_sr.really_forget ~__context ~sr
+        )
 
     let update ~__context ~sr =
       info "SR.update: SR = '%s'" (sr_uuid ~__context sr);

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -271,12 +271,8 @@ let create  ~__context ~host ~device_config ~(physical_size:int64) ~name_label ~
   sr_ref
 
 let assert_all_pbds_unplugged ~__context ~sr =
-  let any_pbds_attached_to_sr = Db.PBD.get_all_records ~__context
-  |> List.exists (fun (_ref, pbd) ->
-      pbd.API.pBD_SR = sr && pbd.API.pBD_currently_attached)
-  in
-
-  if any_pbds_attached_to_sr then
+  let pbds = Db.SR.get_PBDs ~__context ~self:sr in
+  if List.exists (fun self -> Db.PBD.get_currently_attached ~__context ~self) pbds then
     raise (Api_errors.Server_error(Api_errors.sr_has_pbd, [ Ref.string_of sr ]))
 
 let assert_sr_not_indestructible ~__context ~sr =
@@ -348,9 +344,32 @@ let maybe_copy_sr_rrds ~__context ~sr =
     with Rrd_interface.Archive_failed(msg) ->
       warn "Archiving of SR RRDs to stats VDI failed: %s" msg
 
+(* CA-325582: Because inactive metrics are kept always loaded in memory and SR
+   metrics are stored as host one, we are forced to send an explicit message
+   to xcp-rrdd to get the metrics unloaded from memory whenever the SR is
+   about to be removed from the database. i.e. just before a destroy or a
+   forget. Since all pbds provided by the SR are unplugged at that time there
+   are no more metrics about the sr being created, the current ones can be
+   deleted. On top of that the metrics should have been archived to disk when
+   each PBD got unplugged. *)
+let unload_metrics_from_memory ~__context ~sr =
+  let short_uuid = String.sub (Db.SR.get_uuid ~__context ~self:sr) 0 8 in
+  let is_sr_metric = Astring.String.is_suffix ~affix:short_uuid in
+
+  (* SR data sources are currently stored in memory as host ones.
+     Pick the ones that match the short uuid and remove them,
+     this prevents these metrics from being archived *)
+  Rrdd.query_possible_host_dss ()
+  |> Listext.filter_map (fun ds ->
+      if is_sr_metric ds.Data_source.name then
+        Some ds.Data_source.name
+      else
+        None)
+  |> List.iter (fun ds_name -> Rrdd.forget_host_ds ds_name)
+
 (* Remove SR record from database without attempting to remove SR from disk.
    Assumes all PBDs created from the SR have been unplugged. *)
-let forget  ~__context ~sr =
+let really_forget ~__context ~sr =
   let pbds = Db.SR.get_PBDs ~__context ~self:sr in
   let vdis = Db.SR.get_VDIs ~__context ~self:sr in
 
@@ -358,20 +377,24 @@ let forget  ~__context ~sr =
   List.iter (fun self -> Db.VDI.destroy ~__context ~self) vdis;
   Db.SR.destroy ~__context ~self:sr
 
-(** Remove SR from disk and its record from the database. This operation uses
-   the SR's associated PBD record on current host to determine device_config
-   required by SR backend. *)
+(* Hijack forget function to be able to unload metrics in slaves
+   as well as the master. The actual removal from the database
+   can be called in the master directly from the edge of the API,
+   in message_forwarding *)
+let forget ~__context ~sr =
+  unload_metrics_from_memory ~__context ~sr
+
+(* Remove SR from disk. This operation uses the SR's associated PBD record on
+   current host to determine device_config required by SR backend.
+   This function does _not_ remove the SR record from the database. *)
 let destroy  ~__context ~sr =
   let vdis_to_destroy =
     if should_manage_stats ~__context sr then [find_or_create_rrd_vdi ~__context ~sr]
     else [] in
-
   Storage_access.destroy_sr ~__context ~sr ~and_vdis:vdis_to_destroy;
 
   let sm_cfg = Db.SR.get_sm_config ~__context ~self:sr in
-
-  Xapi_secret.clean_out_passwds ~__context sm_cfg;
-  forget ~__context ~sr
+  Xapi_secret.clean_out_passwds ~__context sm_cfg
 
 let update ~__context ~sr =
   let open Storage_access in

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -25,6 +25,10 @@ open Db_filter_types
 open API
 open Client
 
+module String = Xstringext.String
+
+module List = Listext.List
+
 (* internal api *)
 
 module D=Debug.Make(struct let name="xapi" end)
@@ -354,13 +358,13 @@ let maybe_copy_sr_rrds ~__context ~sr =
    each PBD got unplugged. *)
 let unload_metrics_from_memory ~__context ~sr =
   let short_uuid = String.sub (Db.SR.get_uuid ~__context ~self:sr) 0 8 in
-  let is_sr_metric = Astring.String.is_suffix ~affix:short_uuid in
+  let is_sr_metric = String.endswith short_uuid in
 
   (* SR data sources are currently stored in memory as host ones.
      Pick the ones that match the short uuid and remove them,
      this prevents these metrics from being archived *)
   Rrdd.query_possible_host_dss ()
-  |> Listext.filter_map (fun ds ->
+  |> List.filter_map (fun ds ->
       if is_sr_metric ds.Data_source.name then
         Some ds.Data_source.name
       else


### PR DESCRIPTION
To help avoid memory usage growing in xcp-rrdd, we delete SR metrics whenever an SR is forgotten or destroyed