### PR TITLE
REQ-627 CA-333495 add Xapi_pci.dequarantine

### DIFF
--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -84,6 +84,16 @@ let get_phyfn_path pci_rec =
     Some (Filename.basename (Unix.readlink path))
   with _ -> None
 
+(** [dequarantine pci] calls into Xenopsd to dequarantine the pci
+ * device. This call is idempotent.
+ *)
+let dequarantine ~__context pci =
+  let open Xapi_xenops_queue in
+  let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
+  let dbg = Context.string_of_task __context in
+  debug "PCI %s dequarantine" (Xenops_interface.Pci.string_of_address pci);
+  Client.PCI.dequarantine dbg pci
+
 (** Update pf and vf settings *)
 (* For virtual function record, set field `physical_function` to its PF PCI record *)
 (* For physical function record, set field `functions` to 1 plus number of its virtual functions *)

--- a/ocaml/xapi/xapi_pci.mli
+++ b/ocaml/xapi/xapi_pci.mli
@@ -50,3 +50,7 @@ val get_system_display_device : unit -> string option
 
 (** Disable decoding for the host's display device. *)
 val disable_system_display_device : unit -> unit
+
+(** dequarantine a PCI device. This is idempotent. *)
+val dequarantine : __context:Context.t -> Xenops_interface.Pci.address -> unit
+

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -375,6 +375,8 @@ let nvidia_vf_setup ~__context ~pf ~enable =
   let bind_path = "/sys/bus/pci/drivers/nvidia/bind" in
   let unbind_path pci = sprintf "/sys/bus/pci/devices/%s/driver/unbind" pci in
   let pci       = Db.PCI.get_pci_id ~__context ~self:pf in
+  let addr_of pci = Xenops_interface.Pci.address_of_string pci in
+  let dequarantine pci = Xapi_pci.dequarantine ~__context (addr_of pci) in
 
   (** [num_vfs pci] returns the number of PCI VFs of [pci] or 0 if
     * [pci] is not an SRIOV device
@@ -434,6 +436,7 @@ let nvidia_vf_setup ~__context ~pf ~enable =
    * already created before xapi was (re)started. *)
   Mutex.execute nvidia_vf_setup_mutex @@ fun () -> begin
     debug "nvidia_vf_setup_mutex - enter";
+    dequarantine pci; (* this is always safe to do *)
     bind_to_nvidia pci;
     activate_vfs pci;
   end;


### PR DESCRIPTION
Before we can bind PCI drivers we need to dequarantine the device. This
is done by calling into Xenopsd to let it do the work. (Hence, this must
happen on the host where the device is.) We employ this in the context
of setting up Nvidia SRIOV devices.

This PR depends on https://github.com/xapi-project/xcp-idl/pull/302 which has been reverted but needs to be active. Because of cross-repo dependencies, Travis is broken.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>