### PR TITLE
Fix parsing of platform:cores-per-socket to avoid divide-by-0 error

### DIFF
--- a/ocaml/tests/test_platformdata.ml
+++ b/ocaml/tests/test_platformdata.ml
@@ -147,15 +147,29 @@ module SanityCheck = Generic.MakeStateless(struct
             "cores-per-socket", "4";
           ], None, false, 6L, 6L, `hvm),
          Either.Left (Api_errors.Server_error(Api_errors.invalid_value,
-                                              ["platform:cores-per-socket";
-                                               "VCPUs_max must be a multiple of this field"])));
+                                              ["platform:cores-per-socket (value 4)";
+                                               "VCPUs_max (value 6) must be a multiple of cores-per-socket"])));
+        (* Check VCPUs configuration - hvm failure scenario*)
+        (([
+            "cores-per-socket", "0";
+          ], None, false, 6L, 6L, `hvm),
+         Either.Left (Api_errors.Server_error(Api_errors.invalid_value,
+                                              ["platform:cores-per-socket (value 0)";
+                                               "VCPUs_max (value 6) must be a multiple of cores-per-socket"])));
+        (* Check VCPUs configuration - hvm failure scenario*)
+        (([
+            "cores-per-socket", "-1";
+          ], None, false, 6L, 6L, `hvm),
+         Either.Left (Api_errors.Server_error(Api_errors.invalid_value,
+                                              ["platform:cores-per-socket (value -1)";
+                                               "VCPUs_max (value 6) must be a multiple of cores-per-socket"])));
         (* Check VCPUs configuration - hvm failure scenario*)
         (([
             "cores-per-socket", "abc";
           ], None, false, 6L, 5L, `hvm),
          Either.Left(Api_errors.Server_error(Api_errors.invalid_value,
-                                             ["platform:cores-per-socket";
-                                              "value = abc is not a valid int"])));
+                                             ["platform:cores-per-socket (value abc)";
+                                              "Value is not a valid int"])));
 
         (* Check BIOS configuration - qemu trad *)
         make_firmware_ok "qemu-trad" (Some Bios);


### PR DESCRIPTION
  [root@lcy2-dt106 ~]# xe vm-start uuid=39b8d59d-7cc7-7e71-8107-28ba5e2ad74e
  The server failed to handle your request, due to an internal error. The given message may give details useful for debugging the problem.
  message: Division_by_zero

Also reject a negative cores-per-socket, which is equally nonsensical, and
only gets caught by the sanity checks in the Xen:

  [root@lcy2-dt106 ~]# xe vm-start uuid=39b8d59d-7cc7-7e71-8107-28ba5e2ad74e
  The server failed to handle your request, due to an internal error. The given message may give details useful for debugging the problem.
  message: xenopsd internal error: (Failure
    "Error from xenguesthelper: xenguest: xc_domain_set_cores_per_socket: [22]
    Invalid argument")

Also take the opportunity to make the error messages helpful, by returning the
current values which are being objected to.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>