### PR TITLE
CP-32681: Add certificates to DB schema

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5465,6 +5465,7 @@ let all_system =
     VUSB.t;
     Datamodel_cluster.t;
     Datamodel_cluster_host.t;
+    Datamodel_certificate.t;
   ]
 
 (** These are the pairs of (object, field) which are bound together in the database schema *)
@@ -5561,6 +5562,8 @@ let all_relations =
     (_feature, "host"), (_host, "features");
     (_network_sriov, "physical_PIF"), (_pif, "sriov_physical_PIF_of");
     (_network_sriov, "logical_PIF"), (_pif, "sriov_logical_PIF_of");
+
+    (_certificate, "host"), (_host, "certificates");
   ]
 
 (** the full api specified here *)
@@ -5659,6 +5662,7 @@ let expose_get_all_messages_for = [
   _vusb;
   _cluster;
   _cluster_host;
+  _certificate;
 ]
 
 let no_task_id_for = [ _task; (* _alert; *) _event ]

--- a/ocaml/idl/datamodel_certificate.ml
+++ b/ocaml/idl/datamodel_certificate.ml
@@ -1,0 +1,51 @@
+(*
+ * Copyright (C) 2020 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Datamodel_types
+open Datamodel_common
+open Datamodel_roles
+
+let lifecycle = [Published, rel_stockholm, ""]
+
+let t =
+  create_obj
+    ~name: _certificate
+    ~descr:"Description"
+    ~doccomments:[]
+    ~gen_constructor_destructor:false
+    ~gen_events:true
+    ~in_db:true
+    ~lifecycle
+    ~persist:PersistEverything
+    ~in_oss_since:None
+    ~messages_default_allowed_roles:_R_READ_ONLY
+    ~contents:
+      [ uid   _certificate ~lifecycle
+      ; field   ~qualifier:StaticRO ~lifecycle
+          ~ty:(Ref _host) "host" ~default_value:(Some (VRef null_ref))
+          "The host where the certificate is installed"
+      ; field ~qualifier:StaticRO ~lifecycle
+          ~ty:(DateTime) "not_before" ~default_value:(Some (VDateTime Date.never))
+          "Date after which the certificate is valid"
+      ; field ~qualifier:StaticRO ~lifecycle
+          ~ty:(DateTime) "not_after" ~default_value:(Some (VDateTime Date.never))
+          "Date before which the certificate is valid"
+      ; field ~qualifier:StaticRO ~lifecycle
+          ~ty:(String) "fingerprint" ~default_value:(Some (VString ""))
+          "The certificate's fingerprint / hash"
+      ]
+    ~messages:
+      [
+      ]
+    ()

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -181,6 +181,7 @@ let _vusb = "VUSB"
 let _network_sriov = "network_sriov"
 let _cluster = "Cluster"
 let _cluster_host = "Cluster_host"
+let _certificate = "Certificate"
 
 let get_oss_releases in_oss_since =
   match in_oss_since with

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1467,6 +1467,7 @@ let host_query_ha = call ~flags:[`Session]
            field ~qualifier:DynamicRO ~lifecycle:[Published, rel_falcon, ""] ~ty:(Set (Ref _feature)) "features" "List of features available on this host";
            field ~qualifier:StaticRO ~lifecycle:[Published, rel_kolkata, ""] ~default_value:(Some (VString "")) ~ty:String "iscsi_iqn" "The initiator IQN for the host";
            field ~qualifier:StaticRO ~lifecycle:[Published, rel_kolkata, ""] ~default_value:(Some (VBool false)) ~ty:Bool "multipathing" "Specifies whether multipathing is enabled";
-           field ~qualifier:StaticRO ~lifecycle:[Published, rel_quebec, ""] ~default_value:(Some (VString "")) ~ty:String "uefi_certificates" "The UEFI certificates allowing Secure Boot"
+           field ~qualifier:StaticRO ~lifecycle:[Published, rel_quebec, ""] ~default_value:(Some (VString "")) ~ty:String "uefi_certificates" "The UEFI certificates allowing Secure Boot";
+           field ~qualifier:DynamicRO ~lifecycle:[Published, rel_stockholm, ""] ~ty:(Set (Ref _certificate)) "certificates" "List of certificates installed in the host";
          ])
       ()

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -25,6 +25,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    escaping
    datamodel_values
    datamodel_schema
+   datamodel_certificate
   )
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29))
   (libraries

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -100,6 +100,7 @@ module Actions = struct
   module Network_sriov = Xapi_network_sriov
   module Cluster = Xapi_cluster
   module Cluster_host = Xapi_cluster_host
+  module Certificate = Certificates
 end
 (** Use the server functor to make an XML-RPC dispatcher. *)
 module Forwarder = Message_forwarding.Forward (Actions)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4524,4 +4524,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       in
       find_first_live other_hosts
   end
+
+  module Certificate = struct end
 end

--- a/ocaml/xapi/records.ml
+++ b/ocaml/xapi/records.ml
@@ -2181,3 +2181,31 @@ let cluster_host_record rpc session_id cluster_host =
           ~get_map:(fun () -> (x ()).API.cluster_host_other_config)
           ()
       ]}
+
+let certificate_record rpc session_id certificate =
+  let _ref = ref certificate in
+  let empty_record = ToGet (fun () -> Client.Certificate.get_record rpc session_id !_ref) in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  { setref    = (fun r -> _ref := r; record:= empty_record)
+  ; setrefrec = (fun (a, b) -> _ref := a; record := Got b)
+  ; record    = x
+  ; getref    = (fun () -> !_ref)
+  ; fields =
+    [ make_field ~name:"uuid"
+      ~get:(fun () -> (x ()).API.certificate_uuid)
+      ()
+    ; make_field ~name:"host"
+      ~get:(fun () -> (x ()).API.certificate_host |> get_uuid_from_ref)
+      ()
+    ; make_field ~name:"not-before"
+      ~get:(fun () -> (x ()).API.certificate_not_before |> Date.to_string)
+      ()
+    ; make_field ~name:"not-after"
+      ~get:(fun () -> (x ()).API.certificate_not_after |> Date.to_string)
+      ()
+    ; make_field ~name:"fingerprint"
+      ~get:(fun () -> (x ()).API.certificate_fingerprint)
+      ()
+    ]
+  }


### PR DESCRIPTION
This allows the xapi to easily expose the server certificates metadata
to clients. In particular their validity period and fingerprint.

There a quite a lot of pulls and levers to configure when adding a class to the schema db, althought they can be changed later on
So there are some things I'm don't know about:
- `~gen_constructor_destructor` what would it be needed for? I would only like to create an object when the certificate is installed.
- I'm unsure whether we want to force a 1 to 1 relationship between host and server certificate. I've added it as a one-to-many in case this could change in the future.

In addition I'm not fond of using the hand-crafted `Date` module from stdext, seems pretty limited.