### PR TITLE
CA-334951: Ignore 0-star recommendations from WLB

### DIFF
--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -24,6 +24,12 @@ open D
 
 exception Xml_parse_failure of string
 
+type impossible_load = {id : string; source : string; reason : string}
+
+type load = {id : string; source : string; score: float}
+
+type vm_recommendation = Impossible of impossible_load | Recommendation of load
+
 let request_mutex = Locking_helpers.Named_mutex.create "WLB"
 
 let raise_url_invalid url =
@@ -393,6 +399,7 @@ let val_num i =
 
 let retrieve_vm_recommendations ~__context ~vm =
   assert_wlb_enabled ~__context;
+  let meth = "VMGetRecommendations" in
   let params =
     sprintf "%s\n<VmUuid>%s</VmUuid>" (pool_uuid_param ~__context)
       (Db.VM.get_uuid ~__context ~self:vm)
@@ -400,30 +407,40 @@ let retrieve_vm_recommendations ~__context ~vm =
   let handle_response inner_xml =
     let extract_data place_recommendation =
       try
-        let h = Db.Host.get_by_uuid ~__context
-            ~uuid:(data_from_leaf
-                     (descend_and_match ["HostUuid"] place_recommendation)) in
-        if (is_parent_to place_recommendation "Stars")
-        then
-          (h, ["WLB";
-               val_num (data_from_leaf (descend_and_match
-                                          ["Stars"] place_recommendation));
-               val_num (data_from_leaf (descend_and_match
-                                          ["RecommendationId"] place_recommendation))])
-        else
-          (h, ["WLB"; "0.0";
-               val_num (data_from_leaf (descend_and_match
-                                          ["RecommendationId"] place_recommendation));
-               data_from_leaf (descend_and_match
-                                 ["ZeroScoreReason"] place_recommendation)])
+        let get_child_data tag = if is_parent_to place_recommendation tag then
+            Some (descend_and_match [tag] place_recommendation |> data_from_leaf)
+          else
+            None
+        in
+
+        let source = "WLB" in
+        let host_uuid = data_from_leaf
+          (descend_and_match ["HostUuid"] place_recommendation)
+        in
+        let host = Db.Host.get_by_uuid ~__context ~uuid:host_uuid in
+        let id = val_num (data_from_leaf
+          (descend_and_match ["RecommendationId"] place_recommendation))
+        in
+        let (>>|) o f = Option.map f o in
+        let zero_reason = get_child_data "ZeroScoreReason" in
+        let stars = get_child_data "Stars" >>| val_num >>| float_of_string in
+        let recommendation = match stars, zero_reason with
+        | Some score, _ ->
+          Recommendation {id; source; score}
+        | None, Some reason ->
+          Impossible {id; source; reason}
+        | None, None ->
+          Impossible {id; source; reason="Unknown"}
+        in
+        (host, recommendation)
       with
       | Xml_parse_failure error ->
         (* let this parse error carry on upwards,  perform_wlb_request will catch it and check the rest of the xml for an error code *)
         raise (Xml_parse_failure error)
       | Db_exn.Read_missing_uuid (_,_,_)
       | Db_exn.Too_many_values (_,_,_) ->
-        raise_malformed_response' "VMGetRecommendations"
-          "Invalid VM or host UUID" "unknown"
+        raise_malformed_response meth
+          "Invalid VM or host UUID" place_recommendation
     in
     let recs = descend_and_match ["Recommendations"] inner_xml in
     if (is_childless recs)
@@ -434,15 +451,14 @@ let retrieve_vm_recommendations ~__context ~vm =
       | Xml.Element ( _, _, children) ->
         if ((List.length children) != List.length((Helpers.get_live_hosts ~__context)))
         then
-          raise_malformed_response "VMGetRecommendations"
+          raise_malformed_response meth
             "List of returned reccomendations is not equal to the number of hosts in pool"
             inner_xml
         else
           List.map (fun x -> extract_data x) children
       | _ -> assert false (*the is_childless should catch this *)
   in
-  perform_wlb_request ~meth:"VMGetRecommendations" ~params ~handle_response
-    ~__context ()
+  perform_wlb_request ~meth ~params ~handle_response ~__context ()
 
 let init_wlb ~__context ~wlb_url ~wlb_username ~wlb_password ~xenserver_username ~xenserver_password =
   assert_wlb_licensed ~__context;

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -407,30 +407,28 @@ let retrieve_vm_recommendations ~__context ~vm =
   let handle_response inner_xml =
     let extract_data place_recommendation =
       try
-        let get_child_data tag = if is_parent_to place_recommendation tag then
-            Some (descend_and_match [tag] place_recommendation |> data_from_leaf)
-          else
-            None
+        let get_child_data tag =
+            descend_and_match [tag] place_recommendation |> data_from_leaf
         in
 
         let source = "WLB" in
-        let host_uuid = data_from_leaf
-          (descend_and_match ["HostUuid"] place_recommendation)
-        in
+        let host_uuid = get_child_data "HostUuid" in
         let host = Db.Host.get_by_uuid ~__context ~uuid:host_uuid in
-        let id = val_num (data_from_leaf
-          (descend_and_match ["RecommendationId"] place_recommendation))
-        in
-        let (>>|) o f = Option.map f o in
+        let id = get_child_data "RecommendationId" |> val_num in
         let zero_reason = get_child_data "ZeroScoreReason" in
-        let stars = get_child_data "Stars" >>| val_num >>| float_of_string in
+        let stars = get_child_data "Stars" |> val_num |> float_of_string in
+
         let recommendation = match stars, zero_reason with
-        | Some score, _ ->
-          Recommendation {id; source; score}
-        | None, Some reason ->
+        | 0., reason ->
           Impossible {id; source; reason}
-        | None, None ->
-          Impossible {id; source; reason="Unknown"}
+        | score, "None" ->
+          Recommendation {id; source; score}
+        | score, reason ->
+          raise_malformed_response meth (Printf.sprintf
+            "Recommendation has both a non-zero score (%f) \
+             and a reason for zero (%s)"
+            score reason)
+           place_recommendation
         in
         (host, recommendation)
       with

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -60,8 +60,15 @@ let assert_can_boot_here ~__context ~self ~host =
   assert_can_boot_here ~__context ~self ~host ~snapshot ~do_cpuid_check:true ()
 
 let retrieve_wlb_recommendations ~__context ~vm =
+  let transform_for_api = function
+    | host, Workload_balancing.(Recommendation {source; id; score}) ->
+      host, [source; (string_of_float score); id]
+    | host, Workload_balancing.(Impossible {source; id; reason}) ->
+      host, [source; "0.0"; id; reason]
+  in
   let snapshot = Db.VM.get_record ~__context ~self:vm in
-  retrieve_wlb_recommendations ~__context ~vm ~snapshot
+  List.map transform_for_api (retrieve_wlb_recommendations ~__context ~vm ~snapshot)
+
 
 let assert_agile ~__context ~self = Agility.vm_assert_agile ~__context ~self
 

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -536,40 +536,53 @@ let assert_can_boot_here ~__context ~self ~host ~snapshot ~do_cpuid_check ?(do_s
   debug "All fine, VM %s can run on host %s!" (Ref.string_of self) (Ref.string_of host)
 
 let retrieve_wlb_recommendations ~__context ~vm ~snapshot =
-  (* we have already checked the number of returned entries is correct in retrieve_vm_recommendations
-     	   But checking that there are no duplicates is also quite cheap, put them in a hash and overwrite duplicates *)
-  let recs = Hashtbl.create 12 in
-  List.iter
-    (function
-      | host, (Recommendation {source; id; score} as recomm) -> (
-       try
-         assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_cpuid_check:true ();
-         Hashtbl.replace recs host recomm
-       with
-       (* CPUID checks are being removed from WLB, this will become the responsibility of XAPI
-        * (and ultimately Xen/libxc). Previously WLB would've assigned a score of 0.0 and a reason
-        * of "HostCPUFeaturesIncompatible" to hosts that can't boot a VM due to CPU features missing.
-        * WLB could call assert_can_boot_here instead of doing its own CPUID checks, however that
-        * would add a lot of extra API calls (at least Number_of_hosts * Number_of_VMs).
-        * Instead do this check in XAPI itself, and override WLB's response for backwards compatibility
-        * with 0.0, and the same reason code that WLB would've used. This should keep observable behaviour
-        * identical and work both with old and new WLBs.
-        *)
-       | Api_errors.Server_error(x, _) when x=Api_errors.vm_incompatible_with_this_host ->
-           Hashtbl.replace recs host (Impossible {source; id; reason="HostCPUFeaturesIncompatible"})
-       | Api_errors.Server_error(x, y) ->
-           let reason = String.concat ";" (x :: y) in
-           Hashtbl.replace recs host (Impossible {source; id; reason})
+  let module HostMap = Map.Make(struct type t = API.ref_host let compare = Stdlib.compare end) in
+  let compatible_vm_or_impossible (host, recommendation) =
+    let recommendation = match recommendation with
+    | Recommendation {source; id; score} -> (
+      try
+        assert_can_boot_here ~__context ~self:vm ~host ~snapshot ~do_cpuid_check:true ();
+        recommendation
+      with
+      (* CPUID checks are being removed from WLB, this will become the responsibility of XAPI
+       * (and ultimately Xen/libxc). Previously WLB would've assigned a score of 0.0 and a reason
+       * of "HostCPUFeaturesIncompatible" to hosts that can't boot a VM due to CPU features missing.
+       * WLB could call assert_can_boot_here instead of doing its own CPUID checks, however that
+       * would add a lot of extra API calls (at least Number_of_hosts * Number_of_VMs).
+       * Instead do this check in XAPI itself, and override WLB's response for backwards compatibility
+       * with 0.0, and the same reason code that WLB would've used. This should keep observable behaviour
+       * identical and work both with old and new WLBs.
+       *)
+      | Api_errors.Server_error(x, _) when x=Api_errors.vm_incompatible_with_this_host ->
+        Impossible {source; id; reason="HostCPUFeaturesIncompatible"}
+      | Api_errors.Server_error(x, y) ->
+        let reason = String.concat ";" (x :: y) in
+        Impossible {source; id; reason}
       )
-      | host, impossible_load ->
-        Hashtbl.replace recs host impossible_load
-    )(retrieve_vm_recommendations ~__context ~vm);
-  if ((Hashtbl.length recs) <> (List.length (Helpers.get_live_hosts ~__context)))
-  then
-    raise_malformed_response' "VMGetRecommendations"
-      "Number of unique recommendations does not match number of potential hosts" "Unknown"
-  else
-    Hashtbl.fold (fun k v tl -> (k,v) :: tl) recs []
+    | impossible_load ->
+      impossible_load
+    in
+    host, recommendation
+  in
+  let only_for_all_live_hosts_or_raise recs =
+    (* Recommendations cannot have hosts that are not active and there must
+       at least one per active host *)
+    let live_hosts = Helpers.get_live_hosts ~__context in
+    if HostMap.cardinal recs <> List.length live_hosts then
+      raise_malformed_response' "VMGetRecommendations"
+        "VM recommendations must only target live hosts and target all of them"
+        "Unknown"
+    else ();
+    recs
+  in
+  (* Make sure a single recommendation is present per host. *)
+  retrieve_vm_recommendations ~__context ~vm
+  |> List.to_seq
+  |> HostMap.of_seq
+  |> only_for_all_live_hosts_or_raise
+  |> HostMap.to_seq
+  |> Seq.map compatible_vm_or_impossible
+  |> List.of_seq
 
 (** Returns the subset of all hosts to which the given function [choose_fn]
     can be applied without raising an exception. If the optional [vm] argument is


### PR DESCRIPTION
Before, if all the recommendations were 0 for some reason xapi would needlessly migrate all the VMs.

This also introduces a small change in the API in the case an internal error happened when processing a retrieve_wlb_recommendations API call: now it's more consistent and more data is returned.

After talking with @liulinC it's clear that vm recommendation always contains both the `Stars` field and the `ZeroScore`. The code now expects those values to be congruent or it considers the whole response nonsense.