### PR TITLE
CP-32678: update to X509 0.9.0

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -1065,7 +1065,7 @@ let _get_nbd_info ~__context ~self ~get_server_certificate =
         let port = 10809L in
         let module Host_set = X509.Certificate.Host_set in
         let select_a_hostname = function
-          | set when set = Host_set.empty ->
+          | set when Host_set.is_empty set ->
               Error (`Msg "Found no subject DNS names in this hosts's certificate.")
           | set ->
               let strict_or_wildcard = function


### PR DESCRIPTION
Previously hostname could be empty if there were no hostnames available
in the certificate.
Now the hostname from xapi's database is picked instead.

This PR needs https://github.com/xapi-project/xs-opam/pull/433 as it's a breaking change.