### PR TITLE
CP-31856: Propagates nbd params to xenopsd

### DIFF
--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -144,7 +144,7 @@ let vdi_attach dconf driver sr vdi writable =
   let result = (Sm_exec.exec_xmlrpc (driver_filename driver) call) in
   try Sm_exec.parse_attach_result result
   with _ ->
-    { params = Sm_exec.parse_attach_result_legacy result; o_direct = true; o_direct_reason = ""; xenstore_data = []; }
+    { params = Sm_exec.parse_attach_result_legacy result; params_nbd = ""; o_direct = true; o_direct_reason = ""; xenstore_data = []; }
 
 let vdi_detach dconf driver sr vdi =
   debug "vdi_detach" driver (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi));

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -265,6 +265,7 @@ let parse_attach_result (xml : Xml.xml) =
   rethrow_parse_failures (Xml.to_string_fmt xml) (fun () ->
       let info = XMLRPC.From.structure xml in
       let params = XMLRPC.From.string (safe_assoc "params" info) in
+      let params_nbd = XMLRPC.From.string (safe_assoc "params_nbd" info) in
       let o_direct =
         try XMLRPC.From.boolean (safe_assoc "o_direct" info)
         with _ -> true
@@ -282,6 +283,7 @@ let parse_attach_result (xml : Xml.xml) =
       in
       {
         params;
+        params_nbd;
         o_direct;
         o_direct_reason;
         xenstore_data;

--- a/ocaml/xapi/smint.ml
+++ b/ocaml/xapi/smint.ml
@@ -142,6 +142,7 @@ let query_result_of_sr_driver_info x = {
 
 type attach_info = {
   params : string;
+  params_nbd: string;
   o_direct : bool;
   o_direct_reason : string;
   xenstore_data : (string * string) list;

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -454,9 +454,11 @@ module SMAPIv1 = struct
                      extra = attach_info_v1.Smint.xenstore_data;
                      backend_type = "vbd3"
                    };
-                   (* Currently we always get a BlockDevice from SMAPIv1, never a File, not even for ISOs *)
                    BlockDevice {
                      path = attach_info_v1.Smint.params
+                   };
+                   Nbd {
+                     uri = attach_info_v1.Smint.params_nbd
                    }
                  ]
                }


### PR DESCRIPTION
I have a candidate build (private/bensi/CP-31856) and all seems well with my local testing.
I need to run this through a Storage BST and a boot storm after the XenRT issues are resolved.

NOTE! The changes in this PR need to be merged in conjunction with the SM changes or everything will be broken!!