### PR TITLE
CP-32678: Add API to to install server certificates

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 504
+let schema_minor_vsn = 600
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -200,6 +200,12 @@ let get_product_releases in_product_since =
     | x::xs -> go_through_release_order xs
   in go_through_release_order release_order
 
+let stockholm_release =
+  { internal = get_product_releases rel_stockholm
+  ; opensource = get_oss_releases None
+  ; internal_deprecated_since = None
+  }
+
 let quebec_release =
   { internal = get_product_releases rel_quebec
   ; opensource = get_oss_releases None

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1032,27 +1032,27 @@ let _ =
     ~doc:"The specified CRL is corrupt or unreadable." ();
 
   error Api_errors.server_certificate_key_invalid []
-    ~doc:"Provided key is not in a pem-encoded PKCS#8 format." ();
+    ~doc:"The provided key is not in a pem-encoded PKCS#8 format." ();
   error Api_errors.server_certificate_key_algorithm_not_supported ["algorithm_oid"]
-    ~doc:"Provided key uses an unsupported algorithm." ();
+    ~doc:"The provided key uses an unsupported algorithm." ();
   error Api_errors.server_certificate_key_rsa_length_not_supported ["length"]
-    ~doc:"Provided RSA key does not have a length between 2048 and 4096." ();
+    ~doc:"The provided RSA key does not have a length between 2048 and 4096." ();
   error Api_errors.server_certificate_key_rsa_multi_not_supported []
-    ~doc:"Provided RSA key is using more than 2 primes, expecting only 2." ();
+    ~doc:"The provided RSA key is using more than 2 primes, expecting only 2." ();
 
   error Api_errors.server_certificate_invalid []
-    ~doc:"Provided certificate is not in a pem-encoded X509." ();
+    ~doc:"The provided certificate is not in a pem-encoded X509." ();
     error Api_errors.server_certificate_key_mismatch []
-    ~doc:"Provided key does not match the provided certificate's public key." ();
+    ~doc:"The provided key does not match the provided certificate's public key." ();
   error Api_errors.server_certificate_not_valid_yet ["now"; "not_before"]
-    ~doc:"Provided certificate is not valid yet." ();
+    ~doc:"The provided certificate is not valid yet." ();
   error Api_errors.server_certificate_expired ["now"; "not_after"]
-    ~doc:"Provided certificate has expired." ();
+    ~doc:"The provided certificate has expired." ();
   error Api_errors.server_certificate_signature_not_supported []
-    ~doc:"Provided certificate is not using the SHA256 (SHA2) signature algorithm." ();
+    ~doc:"The provided certificate is not using the SHA256 (SHA2) signature algorithm." ();
 
   error Api_errors.server_certificate_chain_invalid []
-    ~doc:"Provided intermediate certificates are not in a pem-encoded X509." ();
+    ~doc:"The provided intermediate certificates are not in a pem-encoded X509." ();
 
   error Api_errors.vmpp_has_vm []
     ~doc:"There is at least one VM assigned to this protection policy." ();

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -878,7 +878,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_install"
-      ~doc:"Install an SSL certificate to this host."
+      ~doc:"Install a TLS CA certificate to this host."
       ~params:[Ref _host, "host", "The host";
                String, "name", "A name to give the certificate";
                String, "cert", "The certificate"]
@@ -891,7 +891,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_uninstall"
-      ~doc:"Remove an SSL certificate from this host."
+      ~doc:"Remove a TLS CA certificate from this host."
       ~params:[Ref _host, "host", "The host";
                String, "name", "The certificate name"]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
@@ -903,7 +903,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_list"
-      ~doc:"List all installed SSL certificates."
+      ~doc:"List the filenames of all installed TLS CA certificates."
       ~params:[Ref _host, "host", "The host"]
       ~result:(Set(String),"All installed certificates")
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
@@ -915,7 +915,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"crl_install"
-      ~doc:"Install an SSL certificate revocation list to this host."
+      ~doc:"Install a TLS Certificate Revocation List to this host."
       ~params:[Ref _host, "host", "The host";
                String, "name", "A name to give the CRL";
                String, "crl", "The CRL"]
@@ -928,7 +928,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"crl_uninstall"
-      ~doc:"Remove an SSL certificate revocation list from this host."
+      ~doc:"Uninstall a TLS certificate revocation list from this host."
       ~params:[Ref _host, "host", "The host";
                String, "name", "The CRL name"]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
@@ -940,7 +940,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"crl_list"
-      ~doc:"List all installed SSL certificate revocation lists."
+      ~doc:"List the filenames of all installed TLS Certificate Revocation Lists."
       ~params:[Ref _host, "host", "The host"]
       ~result:(Set(String),"All installed CRLs")
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
@@ -952,7 +952,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_sync"
-      ~doc:"Resync installed SSL certificates and CRLs."
+      ~doc:"Makes installed TLS CA certificates and CRLs available to all programs using OpenSSL."
       ~params:[Ref _host, "host", "The host"]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -878,7 +878,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_install"
-      ~doc:"Install a TLS CA certificate to this host."
+      ~doc:"Install a TLS CA certificate on this host."
       ~params:[Ref _host, "host", "The host";
                String, "name", "A name to give the certificate";
                String, "cert", "The certificate"]
@@ -952,9 +952,31 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_sync"
-      ~doc:"Makes installed TLS CA certificates and CRLs available to all programs using OpenSSL."
+      ~doc:"Make installed TLS CA certificates and CRLs available to all programs using OpenSSL."
       ~params:[Ref _host, "host", "The host"]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ()
+
+  let install_server_certificate = call
+      ~in_oss_since:None
+      ~lifecycle:[Published, rel_stockholm, ""]
+      ~name:"install_server_certificate"
+      ~doc:"Install the TLS server certificate."
+      ~versioned_params:
+        [{ param_type=Ref _host; param_name="host"; param_doc="The host"
+         ; param_release=stockholm_release; param_default=None}
+        ;{ param_type=String; param_name="certificate"
+         ; param_doc="The server certificate, in PEM form"
+         ; param_release=stockholm_release; param_default=None}
+        ;{ param_type=String; param_name="private_key"
+         ; param_doc="The unencrypted private key used to sign the certificate, \
+                      in PKCS#8 form"
+         ; param_release=stockholm_release; param_default=None}
+        ;{ param_type=String; param_name="certificate_chain"
+         ; param_doc="The certificate chain, in PEM form"
+         ; param_release=stockholm_release; param_default=Some (VString "")}
+        ]
+      ~allowed_roles:_R_POOL_ADMIN
       ()
 
   let get_server_certificate = call
@@ -1379,6 +1401,7 @@ let host_query_ha = call ~flags:[`Session]
         crl_list;
         certificate_sync;
         get_server_certificate;
+        install_server_certificate;
         update_pool_secret;
         update_master;
         attach_static_vdis;

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -407,7 +407,7 @@ open Datamodel_types
       ~in_oss_since:None
       ~in_product_since:rel_george
       ~name:"certificate_install"
-      ~doc:"Install an SSL certificate pool-wide."
+      ~doc:"Install a TLS CA certificate, pool-wide."
       ~params:[String, "name", "A name to give the certificate";
                String, "cert", "The certificate"]
       ~allowed_roles:_R_POOL_OP
@@ -417,7 +417,7 @@ open Datamodel_types
       ~in_oss_since:None
       ~in_product_since:rel_george
       ~name:"certificate_uninstall"
-      ~doc:"Remove an SSL certificate."
+      ~doc:"Remove a pool-wide TLS CA certificate."
       ~params:[String, "name", "The certificate name"]
       ~allowed_roles:_R_POOL_OP
       ()
@@ -426,7 +426,7 @@ open Datamodel_types
       ~in_oss_since:None
       ~in_product_since:rel_george
       ~name:"certificate_list"
-      ~doc:"List all installed SSL certificates."
+      ~doc:"List the names of all installed TLS CA certificates."
       ~result:(Set(String),"All installed certificates")
       ~allowed_roles:_R_POOL_OP
       ()
@@ -435,7 +435,7 @@ open Datamodel_types
       ~in_oss_since:None
       ~in_product_since:rel_george
       ~name:"crl_install"
-      ~doc:"Install an SSL certificate revocation list, pool-wide."
+      ~doc:"Install a TLS Certificate Revocation List, pool-wide."
       ~params:[String, "name", "A name to give the CRL";
                String, "cert", "The CRL"]
       ~allowed_roles:_R_POOL_OP
@@ -445,7 +445,7 @@ open Datamodel_types
       ~in_oss_since:None
       ~in_product_since:rel_george
       ~name:"crl_uninstall"
-      ~doc:"Remove an SSL certificate revocation list."
+      ~doc:"Remove a pool-wide TLS Certificate Revocation List."
       ~params:[String, "name", "The CRL name"]
       ~allowed_roles:_R_POOL_OP
       ()
@@ -454,8 +454,8 @@ open Datamodel_types
       ~in_oss_since:None
       ~in_product_since:rel_george
       ~name:"crl_list"
-      ~doc:"List all installed SSL certificate revocation lists."
-      ~result:(Set(String), "All installed CRLs")
+      ~doc:"List the names of all installed TLS Certificate Revocation Lists."
+      ~result:(Set(String), "The names of all installed CRLs")
       ~allowed_roles:_R_POOL_OP
       ()
 
@@ -463,7 +463,7 @@ open Datamodel_types
       ~in_oss_since:None
       ~in_product_since:rel_george
       ~name:"certificate_sync"
-      ~doc:"Sync SSL certificates from master to slaves."
+      ~doc:"Copy the TLS CA certificates and CRLs of the master to all slaves."
       ~allowed_roles:_R_POOL_OP
       ()
 
@@ -729,7 +729,7 @@ open Datamodel_types
          ; field ~in_product_since:rel_george ~qualifier:DynamicRO ~ty:String ~default_value:(Some (VString "")) "wlb_username" "Username for accessing the workload balancing host"
          ; field ~in_product_since:rel_george ~internal_only:true ~qualifier:DynamicRO ~ty:(Ref _secret) "wlb_password" "Password for accessing the workload balancing host"
          ; field ~in_product_since:rel_george ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "wlb_enabled" "true if workload balancing is enabled on the pool, false otherwise"
-         ; field ~in_product_since:rel_george ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "wlb_verify_cert" "true if communication with the WLB server should enforce SSL certificate verification."
+         ; field ~in_product_since:rel_george ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "wlb_verify_cert" "true if communication with the WLB server should enforce TLS certificate verification."
          ; field ~in_oss_since:None ~in_product_since:rel_midnight_ride ~qualifier:DynamicRO ~ty:Bool ~default_value:(Some (VBool false)) "redo_log_enabled" "true a redo-log is to be used other than when HA is enabled, false otherwise"
          ; field ~in_oss_since:None ~in_product_since:rel_midnight_ride ~qualifier:DynamicRO ~ty:(Ref _vdi) ~default_value:(Some (VRef null_ref)) "redo_log_vdi" "indicates the VDI to use for the redo-log other than when HA is enabled"
          ; field ~in_oss_since:None ~qualifier:DynamicRO ~ty:String ~default_value:(Some (VString "")) "vswitch_controller" "address of the vswitch controller"

--- a/ocaml/tests/test_certificates.ml
+++ b/ocaml/tests/test_certificates.ml
@@ -122,12 +122,18 @@ let invalid_keys_tests =
   invalid_private_keys
 
 let test_valid_cert cert time pkey () =
-  validate_certificate Leaf cert time pkey
+  let _leaf:X509.Certificate.t = validate_certificate Leaf cert time pkey in
+  ()
 
 let test_invalid_cert cert time pkey error reason () =
   Alcotest.check_raises ""
     (server_error error reason)
-    (fun () -> validate_certificate Leaf cert time pkey)
+    (fun () ->
+      let _leaf:X509.Certificate.t =
+        validate_certificate Leaf cert time pkey
+      in
+      ()
+    )
 
 let load_pkcs8 name =
   X509.Private_key.decode_pem (Cstruct.of_string (load_test_data name))
@@ -160,7 +166,12 @@ let test_corrupt_leaf_cert (cert_name, pkey_name, time, error, reason) =
   let test_cert = load_pkcs8 pkey_name >>| fun pkey ->
     let test () = Alcotest.check_raises ""
       (server_error error reason)
-      (fun () -> validate_certificate Leaf cert time pkey)
+      (fun () ->
+        let _leaf:X509.Certificate.t =
+          validate_certificate Leaf cert time pkey
+        in
+        ()
+      )
     in
     test
   in
@@ -180,12 +191,18 @@ let invalid_leaf_cert_tests =
   List.map test_invalid_leaf_cert invalid_leaf_certificates
 
 let test_valid_cert_chain chain time pkey () =
-  validate_certificate Chain chain time pkey
+  let _leaf:X509.Certificate.t = validate_certificate Chain chain time pkey in
+  ()
 
 let test_invalid_cert_chain cert time pkey error reason () =
   Alcotest.check_raises ""
     (server_error error reason)
-    (fun () -> validate_certificate Chain cert time pkey)
+    (fun () ->
+      let _leaf:X509.Certificate.t =
+        validate_certificate Chain cert time pkey
+      in
+      ()
+    )
 
 let valid_chain_cert_tests =
   let time = time_of_rfc3339 "2020-02-01T00:00:00+00:00" in

--- a/ocaml/tests/test_certificates.ml
+++ b/ocaml/tests/test_certificates.ml
@@ -232,6 +232,23 @@ let invalid_chain_cert_tests =
     "Validation of an unsupported certificate chain", `Quick, test_cert)
   corrupt_chain_certificates
 
+let hashables =
+  [ "foobar",
+    "C3:AB:8F:F1:37:20:E8:AD:90:47:DD:39:46:6B:3C:89:74:E5:92:C2:FA:38:3D:4A:39:60:71:4C:AE:F0:C4:F2"
+  ]
+
+let pp_hash_test =
+  List.map (fun (hashable, expected) ->
+    let test_hash () =
+      let digest = Cstruct.of_string hashable
+      |> Nocrypto.Hash.digest `SHA256
+      in
+      Alcotest.(check string) "fingerprints must match" expected (Certificates.pp_hash digest)
+    in
+    Printf.sprintf {|Validation of hash printing of "%s"|} hashable,
+    `Quick, Ok test_hash)
+  hashables
+
 let load_test = function
   | name, speed, Ok test ->
       name, speed, test
@@ -241,6 +258,7 @@ let load_test = function
 
 let all_tests = valid_keys_tests @ invalid_keys_tests @
                 valid_leaf_cert_tests @ invalid_leaf_cert_tests @
-                valid_chain_cert_tests @ invalid_chain_cert_tests
+                valid_chain_cert_tests @ invalid_chain_cert_tests @
+                pp_hash_test
 
 let test = List.map load_test all_tests

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -394,7 +394,7 @@ let validate_certificate kind pem now private_key =
     | Ok [] -> raise_server_error [] ""
     | Error (`Msg (err, msg)) -> raise_server_error msg err
 
-let install_server_certificate ?(pem_chain = None) pkcs8_private_key pem_leaf  =
+let install_server_certificate ?(pem_chain = None) ~pem_leaf ~pkcs8_private_key =
   let now = match Ptime.of_float_s (Unix.time ()) with
     | Some time -> time
     | None ->

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -54,6 +54,19 @@ let to_string = function
   | CA_Certificate -> "CA certificate"
   | CRL -> "CRL"
 
+(** {pp_hash hash} outputs the hexadecimal representation of the {hash}
+    adding a semicolon between every octet, in uppercase.
+ *)
+let pp_hash hash =
+  let hex = Hex.(show @@ of_cstruct hash) in
+  let length = 3 * (String.length hex) / 2 - 1 in
+  let value_of i = match (i + 1) mod 3 with
+  | 0 -> ':'
+  | _ ->
+      Char.uppercase_ascii hex.[(i - (i + 1) / 3)]
+  in
+  String.init length value_of
+
 let safe_char c =
   match c with
   | 'A'..'Z'

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2622,9 +2622,18 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
     {
       reqd=[];
       optn=[];
-      help="Get the installed server SSL certificate.";
+      help="Get the server TLS certificate of a host";
       implementation=No_fd Cli_operations.host_get_server_certificate;
       flags=[Host_selectors]
+    };
+
+    "host-server-certificate-install",
+    {
+      reqd=["certificate"; "private-key"];
+      optn=["certificate-chain"];
+      help="Install a server TLS certificate on a host";
+      implementation=With_fd Cli_operations.host_install_server_certificate;
+      flags=[ Host_selectors ];
     };
 
     "secret-create",

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -360,7 +360,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     {
       reqd=["filename"];
       optn=[];
-      help="Install an SSL certificate, pool-wide.";
+      help="Install a TLS CA certificate, pool-wide.";
       implementation=With_fd Cli_operations.pool_certificate_install;
       flags=[];
     };
@@ -369,7 +369,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     {
       reqd=["name"];
       optn=[];
-      help="Uninstall an SSL certificate.";
+      help="Uninstall a pool-wide TLS CA certificate.";
       implementation=No_fd Cli_operations.pool_certificate_uninstall;
       flags=[];
     };
@@ -378,7 +378,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     {
       reqd=[];
       optn=[];
-      help="List all installed SSL certificates.";
+      help="List the names of all installed TLS CA certificates.";
       implementation=No_fd Cli_operations.pool_certificate_list;
       flags=[];
     };
@@ -387,7 +387,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     {
       reqd=["filename"];
       optn=[];
-      help="Install an SSL certificate revocation list, pool-wide.";
+      help="Install a TLS Certificate Revocation List, pool-wide.";
       implementation=With_fd Cli_operations.pool_crl_install;
       flags=[];
     };
@@ -396,7 +396,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     {
       reqd=["name"];
       optn=[];
-      help="Uninstall an SSL certificate revocation list.";
+      help="Uninstall a pool-wide TLS Certificate Revocation List.";
       implementation=No_fd Cli_operations.pool_crl_uninstall;
       flags=[];
     };
@@ -405,7 +405,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     {
       reqd=[];
       optn=[];
-      help="List all installed SSL certificate revocation lists.";
+      help="List the names of all installed TLS Certificate Revocation Lists.";
       implementation=No_fd Cli_operations.pool_crl_list;
       flags=[];
     };
@@ -414,7 +414,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
     {
       reqd=[];
       optn=[];
-      help="Sync SSL certificates and certificate revocation lists from master to slaves.";
+      help="Copy the TLS CA certificates and CRLs of the master to all slaves.";
       implementation=No_fd Cli_operations.pool_certificate_sync;
       flags=[];
     };

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2605,6 +2605,33 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         (fun session_id rpc ->
            Client.Host.get_server_certificate rpc session_id host)
 
+    let install_server_certificate ~__context ~host ~certificate ~private_key ~certificate_chain =
+      let task = Context.get_task_id __context in
+      let local_fn =
+        Local.Host.install_server_certificate
+          ~host
+          ~certificate
+          ~private_key
+          ~certificate_chain
+      in
+      let success () =
+        let progress = Db.Task.get_progress ~__context ~self:task in
+        if progress = 1. then Some () else None
+      in
+
+      let fn () = do_op_on ~local_fn ~__context ~host
+        (fun session_id rpc ->
+          Client.Host.install_server_certificate
+            rpc
+            session_id
+            host
+            certificate
+            private_key
+            certificate_chain
+        );
+      in
+      tolerate_connection_loss fn success 30.
+
     let attach_static_vdis ~__context ~host ~vdi_reason_map =
       info "Host.attach_static_vdis: host = '%s'; vdi/reason pairs = [ %s ]" (host_uuid ~__context host)
         (String.concat "; " (List.map (fun (a, b) ->  Ref.string_of a ^ "/" ^ b) vdi_reason_map));

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1157,7 +1157,7 @@ let install_server_certificate ~__context ~host ~certificate ~private_key ~certi
   in
   let fingerprint =
     X509.Certificate.fingerprint Nocrypto.(`SHA256) certificate
-    |> Cstruct.to_string
+    |> Certificates.pp_hash
   in
   let uuid = Uuid.(to_string (make_uuid ())) in
   let ref = Ref.make () in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1129,6 +1129,48 @@ let certificate_sync ~__context ~host =
 let get_server_certificate ~__context ~host =
   Certificates.get_server_certificate ()
 
+let install_server_certificate ~__context ~host ~certificate ~private_key ~certificate_chain =
+  if Db.Pool.get_ha_enabled ~__context ~self:(Helpers.get_pool ~__context) then
+    raise Api_errors.(Server_error (ha_is_enabled, []));
+
+  let current_server_certs = Db.Certificate.get_all_records ~__context
+  |> List.filter_map (fun (reference, record) ->
+    if record.API.certificate_host = host then
+        Some reference
+    else
+        None
+    )
+  in
+
+  let pem_chain = match certificate_chain with
+  | ""        -> None
+  | pem_chain -> Some pem_chain
+  in
+  let certificate =
+    Certificates.install_server_certificate
+      ~pem_leaf:certificate ~pkcs8_private_key:private_key ~pem_chain
+  in
+  let date_of_ptime time = Date.of_float (Ptime.to_float_s time) in
+  let dates_of_ptimes (a, b) = (date_of_ptime a, date_of_ptime b) in
+  let not_before, not_after =
+    dates_of_ptimes (X509.Certificate.validity certificate)
+  in
+  let fingerprint =
+    X509.Certificate.fingerprint Nocrypto.(`SHA256) certificate
+    |> Cstruct.to_string
+  in
+  let uuid = Uuid.(to_string (make_uuid ())) in
+  let ref = Ref.make () in
+
+  List.iter (fun self -> Db.Certificate.destroy ~__context ~self) current_server_certs;
+  Db.Certificate.create ~__context ~ref ~uuid ~host ~not_before ~not_after ~fingerprint;
+
+  let task = Context.get_task_id __context in
+  (* mark task as done *)
+  Db.Task.set_progress ~__context ~self:task ~value:1.0;
+  (* sever all connections done with stunnel *)
+  Xapi_mgmt_iface.reconfigure_stunnel ~__context
+
 (* CA-24856: detect non-homogeneous external-authentication config in pool *)
 let detect_nonhomogeneous_external_auth_in_host ~__context ~host =
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1106,13 +1106,13 @@ let get_uncooperative_resident_VMs ~__context ~self = []
 let get_uncooperative_domains ~__context ~self = []
 
 let certificate_install ~__context ~host ~name ~cert =
-  Certificates.(host_install Certificate name cert)
+  Certificates.(host_install CA_Certificate name cert)
 
 let certificate_uninstall ~__context ~host ~name =
-  Certificates.(host_uninstall Certificate name)
+  Certificates.(host_uninstall CA_Certificate name)
 
 let certificate_list ~__context ~host =
-  Certificates.(local_list Certificate)
+  Certificates.(local_list CA_Certificate)
 
 let crl_install ~__context ~host ~name ~crl =
   Certificates.(host_install CRL name crl)
@@ -1124,10 +1124,10 @@ let crl_list ~__context ~host =
   Certificates.(local_list CRL)
 
 let certificate_sync ~__context ~host =
-  Certificates.local_sync()
+  Certificates.local_sync ()
 
 let get_server_certificate ~__context ~host =
-  Certificates.get_server_certificate()
+  Certificates.get_server_certificate ()
 
 (* CA-24856: detect non-homogeneous external-authentication config in pool *)
 let detect_nonhomogeneous_external_auth_in_host ~__context ~host =

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -195,6 +195,22 @@ val crl_uninstall : __context:'a -> host:'b -> name:string -> unit
 val crl_list : __context:'a -> host:'b -> string list
 val certificate_sync : __context:'a -> host:'b -> unit
 val get_server_certificate : __context:'a -> host:'b -> string
+val install_server_certificate :
+  __context:Context.t ->
+  host:[ `host ] Ref.t ->
+  certificate:string ->
+  private_key:string ->
+  certificate_chain:string ->
+  unit
+(** Installs a server certificate to a host.
+    Some sanity checks are run before the installation to prevent some cases
+    of broken pools. e.g. the certificate's public key must match the private
+    key.
+    After the installation is successful all stunnel instances are restarted,
+    expect to the connection used to make this call to be dropped if it's
+    remote. This is done to refresh the server certificate used in the
+    connections. *)
+
 val detect_nonhomogeneous_external_auth_in_host :
   __context:Context.t -> host:API.ref_host -> unit
 val enable_external_auth :

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1657,9 +1657,9 @@ let retrieve_wlb_recommendations ~__context =
 
 let send_test_post = Remote_requests.send_test_post
 
-let certificate_install = Certificates.(pool_install Certificate)
-let certificate_uninstall = Certificates.(pool_uninstall Certificate)
-let certificate_list ~__context = Certificates.(local_list Certificate)
+let certificate_install = Certificates.(pool_install CA_Certificate)
+let certificate_uninstall = Certificates.(pool_uninstall CA_Certificate)
+let certificate_list ~__context = Certificates.(local_list CA_Certificate)
 
 let crl_install = Certificates.(pool_install CRL)
 let crl_uninstall = Certificates.(pool_uninstall CRL)


### PR DESCRIPTION
Adds an API call to install user-created server certificates.

This does _not_ add parameters to xe.

Draft PR as I have some doubts around severing the connection between hosts when the certificates need to be reloaded. Especially regarding the DB update that needs to be done, and the function that checks whether the recovery of the connection happened successfully.

If something is not clear from the code or the commit messages please let me know.