### PR TITLE
Havana Backports

### DIFF
--- a/ocaml/database/backend_xml.ml
+++ b/ocaml/database/backend_xml.ml
@@ -54,7 +54,7 @@ let flush dbconn db =
 
   let do_flush_xml db filename =
     Redo_log.flush_db_to_all_active_redo_logs db;
-    Stdext.Unixext.atomic_write_to_file filename 0o0644
+    Stdext.Unixext.atomic_write_to_file filename 0o0600
       (fun fd ->
          if not dbconn.Parse_db_conf.compress
          then Db_xml.To.fd fd db

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1300,3 +1300,9 @@ let stunnel_should_use_legacy () =
   try
     not (bool_of_string (Xapi_inventory.lookup "CC_PREPARATIONS" ~default:"false"))
   with _ -> true
+
+let env_with_path env_vars =
+  let default_path = [ "/sbin"; "/usr/sbin"; "/bin"; "/usr/bin" ] in
+  Array.of_list @@
+  List.map (fun (k,v) -> Printf.sprintf "%s=%s" k v) (("PATH", String.concat ":" default_path)::env_vars)
+

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2015,7 +2015,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       Local.VM.import_convert ~__context ~_type ~username ~password ~sr ~remote_config
 
     let import ~__context ~url ~sr ~full_restore ~force =
-      info "VM.import: url = '%s' sr='%s' force='%b'" url (Ref.string_of sr) force;
+      info "VM.import: url = '%s' sr='%s' force='%b'" "(url filtered)" (Ref.string_of sr) force;
       let pbd = choose_pbd_for_sr ~consider_unplugged_pbds:false ~__context ~self:sr () in
       let host = Db.PBD.get_host ~__context ~self:pbd in
       do_op_on ~local_fn:(Local.VM.import ~url ~sr ~full_restore ~force) ~__context ~host (fun session_id rpc -> Client.VM.import rpc session_id url sr full_restore force)
@@ -2623,7 +2623,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         (fun session_id rpc -> Client.Host_crashdump.destroy rpc session_id self)
 
     let upload ~__context ~self ~url ~options =
-      info "Host_crashdump.upload: host crashdump = '%s'; url = '%s'" (host_crashdump_uuid ~__context self) url;
+      info "Host_crashdump.upload: host crashdump = '%s'; url = '%s'" (host_crashdump_uuid ~__context self) "(url filtered)";
       let local_fn = Local.Host_crashdump.upload ~self ~url ~options in
       do_op_on ~local_fn ~__context ~host:(Db.Host_crashdump.get_host ~__context ~self)
         (fun session_id rpc -> Client.Host_crashdump.upload rpc session_id self url options)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2264,7 +2264,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
     let bugreport_upload ~__context ~host ~url ~options =
       let filtered_options =
         let filter' ((k, _) as orig) =
-          match Astring.String.trim k with
+          match String.trim k with
           | "password"   -> (k,"(password filtered)")
           | "http_proxy" -> (k,"(proxy filtered)")
           | _            -> orig

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2262,7 +2262,16 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       do_op_on ~local_fn ~__context ~host (fun session_id rpc -> Client.Host.dmesg_clear rpc session_id host)
 
     let bugreport_upload ~__context ~host ~url ~options =
-      info "Host.bugreport_upload: host = '%s'; url = '%s'; options = [ %s ]" (host_uuid ~__context host) url (String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) options));
+      let filtered_options =
+        let filter' ((k, _) as orig) =
+          match Astring.String.trim k with
+          | "password"   -> (k,"(password filtered)")
+          | "http_proxy" -> (k,"(proxy filtered)")
+          | _            -> orig
+        in
+        List.map filter' options
+      in
+      info "Host.bugreport_upload: host = '%s'; url = '%s'; options = [ %s ]" (host_uuid ~__context host) "(url filtered)" (String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) filtered_options));
       let local_fn = Local.Host.bugreport_upload ~host ~url ~options in
       do_op_on ~local_fn ~__context ~host (fun session_id rpc -> Client.Host.bugreport_upload rpc session_id host url options)
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1302,9 +1302,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       update_vif_operations ~__context ~vm
 
     let call_plugin ~__context ~vm ~plugin ~fn ~args =
-      let censor_kws = ["password"] in (* We could censor "username" too, but the current decision was to leave it there. *)
-      let argstrs = List.map (fun (k, v) -> Printf.sprintf "args:%s = '%s'" k (if List.exists (String.has_substr k) censor_kws then "(omitted)" else v)) args in
-      info "VM.call_plugin: VM = '%s'; plugin = '%s'; fn = '%s'; %s" (vm_uuid ~__context vm) plugin fn (String.concat "; " argstrs);
+      info "VM.call_plugin: VM = '%s'; plugin = '%s'; fn = '%s'; args = [ 'hidden' ]" (vm_uuid ~__context vm) plugin fn;
       let local_fn = Local.VM.call_plugin ~vm ~plugin ~fn ~args in
       with_vm_operation ~__context ~self:vm ~doc:"VM.call_plugin" ~op:`call_plugin ~policy:Helpers.Policy.fail_immediately
         (fun () ->
@@ -2406,14 +2404,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       Local.Host.create_new_blob ~__context ~host ~name ~mime_type ~public
 
     let call_plugin ~__context ~host ~plugin ~fn ~args =
-      let plugins_to_protect = [
-        "prepare_host_upgrade.py";
-      ] in
-      if List.mem plugin plugins_to_protect
-      then
-        info "Host.call_plugin host = '%s'; plugin = '%s'; fn = '%s' args = [ 'hidden' ]" (host_uuid ~__context host) plugin fn
-      else
-        info "Host.call_plugin host = '%s'; plugin = '%s'; fn = '%s'; args = [ %s ]" (host_uuid ~__context host) plugin fn (String.concat "; " (List.map (fun (a, b) -> a ^ ": " ^ b) args));
+      info "Host.call_plugin host = '%s'; plugin = '%s'; fn = '%s' args = [ 'hidden' ]" (host_uuid ~__context host) plugin fn;
       let local_fn = Local.Host.call_plugin ~host ~plugin ~fn ~args in
       do_op_on ~local_fn ~__context ~host
         (fun session_id rpc -> Client.Host.call_plugin rpc session_id host plugin fn args)

--- a/ocaml/xapi/storage_utils.ml
+++ b/ocaml/xapi/storage_utils.ml
@@ -17,3 +17,4 @@ let string_of_vdi_type vdi_type =
 
 let vdi_type_of_string str =
   API.vdi_type_of_rpc (Rpc.String str)
+

--- a/ocaml/xapi/xapi_cli.ml
+++ b/ocaml/xapi/xapi_cli.ml
@@ -148,15 +148,20 @@ let exec_command req cmd s session args =
   let p = try List.assoc "password" params with _ -> "" in
   (* Create a list of commands and their associated arguments which might be sensitive. *)
   let commands_and_params_to_hide =
-    let st = String.startswith in
-    let eq = (=) in
-    [
-      eq "user-password-change", ["old"; "new"];
-      st "secret", ["value"];
-      eq "pool-enable-external-auth", ["config:pass"];
-      eq "pool-disable-external-auth", ["config:pass"];
-      eq "host-call-plugin", ["args:url"];
-    ] in
+    let starts affix = String.startswith affix in
+    let ends affix = String.endswith affix in
+    let is = (=) in
+    let always = (fun (_ : string) -> true) in
+    (* case-insensitive contains *)
+    let has substring =
+        substring |> Re.str |> Re.no_case |> Re.compile |> Re.execp in
+     [
+      is "user-password-change", [is "old"; is "new"];
+      has "secret", [is "value"; has "secret"];
+      ends "auth", [is "config:pass"];
+      is "host-call-plugin", [starts "args"];
+      always, [ has "password"; is "url"];
+     ] in
   let rpc = Helpers.get_rpc () req s in
   Cli_frontend.populate_cmdtable rpc Ref.null;
   (* Log the actual CLI command to help diagnose failures like CA-25516 *)
@@ -167,15 +172,13 @@ let exec_command req cmd s session args =
       List.exists
         (fun k -> String.endswith k cmd_name) uninteresting_cmd_postfixes in
     let do_log = if uninteresting then debug else info in
-    let params_to_hide = List.fold_left
+    let param_filters = List.fold_left
         (fun accu (cmd_test, params) -> if cmd_test cmd_name then accu @ params else accu)
         []
         commands_and_params_to_hide
     in
     let must_censor param_name =
-      (* name contains (case-insensitive) "password" or is in list *)
-      Re.execp (Re.compile(Re.no_case(Re.str "password"))) param_name
-      || List.mem param_name params_to_hide
+      List.exists (fun filter -> filter param_name) param_filters
     in
     do_log "xe %s %s" cmd_name (String.concat " " (List.map (fun (k, v) -> let v' = if must_censor k then "(omitted)" else v in k ^ "=" ^ v') params));
     do_rpcs req s u p minimal cmd session args

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -73,7 +73,7 @@ let bugreport_upload ~__context ~host ~url ~options =
     if List.mem_assoc "http_proxy" options
     then List.assoc "http_proxy" options
     else try Unix.getenv "http_proxy" with _ -> "" in
-  let cmd = Printf.sprintf "%s %s %s" !Xapi_globs.host_bugreport_upload url proxy in
+  let cmd = Printf.sprintf "%s %s %s" !Xapi_globs.host_bugreport_upload "(url filtered)" proxy in
   try
     let stdout, stderr = Forkhelpers.execute_command_get_output !Xapi_globs.host_bugreport_upload [ url; proxy ] in
     debug "%s succeeded with stdout=[%s] stderr=[%s]" cmd stdout stderr

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -968,7 +968,7 @@ let extauth_hook_script_name = Extauth.extauth_hook_script_name
 (* this special extauth plugin call is only used inside host.enable/disable extauth to avoid deadlock with the mutex *)
 let call_extauth_plugin_nomutex ~__context ~host ~fn ~args =
   let plugin = extauth_hook_script_name in
-  debug "Calling extauth plugin %s in host %s with event %s and params %s" plugin (Db.Host.get_name_label ~__context ~self:host) fn (List.fold_left (fun a (b,y)->a^"("^b^"="^y^"),") "" args);
+  debug "Calling extauth plugin %s in host %s with event %s" plugin (Db.Host.get_name_label ~__context ~self:host) fn;
   Xapi_plugins.call_plugin (Context.get_session_id __context) plugin fn args
 (* this is the generic extauth plugin call available to xapi users that avoids concurrency problems *)
 let call_extauth_plugin ~__context ~host ~fn ~args =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -75,7 +75,8 @@ let bugreport_upload ~__context ~host ~url ~options =
     else try Unix.getenv "http_proxy" with _ -> "" in
   let cmd = Printf.sprintf "%s %s %s" !Xapi_globs.host_bugreport_upload "(url filtered)" proxy in
   try
-    let stdout, stderr = Forkhelpers.execute_command_get_output !Xapi_globs.host_bugreport_upload [ url; proxy ] in
+    let env = Helpers.env_with_path ["INPUT_URL", url; "PROXY", proxy] in
+    let stdout, stderr = Forkhelpers.execute_command_get_output ~env !Xapi_globs.host_bugreport_upload [] in
     debug "%s succeeded with stdout=[%s] stderr=[%s]" cmd stdout stderr
   with Forkhelpers.Spawn_internal_error(stderr, stdout, status) as e ->
     debug "%s failed with stdout=[%s] stderr=[%s]" cmd stdout stderr;

--- a/ocaml/xapi/xapi_secret.ml
+++ b/ocaml/xapi/xapi_secret.ml
@@ -59,3 +59,15 @@ let duplicate_passwds ~__context strmap =
     else (k, v)
   in
   List.map possibly_duplicate strmap
+
+let move_passwds_to_secrets ~__context strmap =
+  let maybe_move (k, value) =
+    if String.endswith "password" k then
+      let new_k = k ^ "_secret" in
+      warn "Replacing deprecated %s with %s, please avoid using %s in device-config!" k new_k k;
+      let new_sr = create ~__context ~value ~other_config:[] in
+      let new_uuid = Db.Secret.get_uuid ~__context ~self:new_sr in
+      new_k, new_uuid
+    else (k, value)
+  in
+  List.rev_map maybe_move strmap

--- a/scripts/extensions/pool_update.apply
+++ b/scripts/extensions/pool_update.apply
@@ -25,6 +25,8 @@ ERROR_MESSAGE_DOWNLOAD_PACKAGE = 'Error downloading packages:\n'
 ERROR_MESSAGE_START = 'Error: '
 ERROR_MESSAGE_END = 'You could try '
 
+class EnvironmentFailure(Exception):
+    pass
 
 class ApplyFailure(Exception):
     pass
@@ -44,9 +46,18 @@ def failure_message(code, params):
 
 
 def execute_apply(session, update_package, yum_conf_file):
-    cmd = ['yum', 'upgrade', '-y', '--noplugins', '-c', yum_conf_file, update_package]
     yum_env = os.environ.copy()
     yum_env['LANG'] = 'C'
+
+    cmd = ['yum', 'clean', 'all', '--noplugins', '-c', yum_conf_file]
+    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
+    output, _ = p.communicate()
+    for line in output.split('\n'):
+        xcp.logger.info(line)
+    if p.returncode != 0:
+        raise EnvironmentFailure("Error cleaning yum cache")
+
+    cmd = ['yum', 'upgrade', '-y', '--noplugins', '-c', yum_conf_file, update_package]
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
     output, _ = p.communicate()
     xcp.logger.info('pool_update.apply %r returncode=%r output:', cmd, p.returncode)

--- a/scripts/extensions/pool_update.precheck
+++ b/scripts/extensions/pool_update.precheck
@@ -48,6 +48,9 @@ ERROR = 'error'
 FOUND = 'found'
 REQUIRED = 'required'
 
+class EnvironmentFailure(Exception):
+    pass
+
 class PrecheckError(Exception):
     pass
 
@@ -118,9 +121,18 @@ def execute_precheck(session, control_package, yum_conf_file, update_precheck_fi
     livepatch_messages = {'PATCH_PRECHECK_LIVEPATCH_COMPLETE': 'ok_livepatch_complete',
                      'PATCH_PRECHECK_LIVEPATCH_INCOMPLETE': 'ok_livepatch_incomplete',
                      'PATCH_PRECHECK_LIVEPATCH_NOT_APPLICABLE': 'ok'}
-    cmd = ['yum', 'install', '-y', '--noplugins', '-c', yum_conf_file, control_package]
     yum_env = os.environ.copy()
     yum_env['LANG'] = 'C'
+
+    cmd = ['yum', 'clean', 'all', '--noplugins', '-c', yum_conf_file]
+    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
+    output, _ = p.communicate()
+    for line in output.split('\n'):
+        xcp.logger.info(line)
+    if p.returncode != 0:
+        raise EnvironmentFailure("Error cleaning yum cache")
+
+    cmd = ['yum', 'install', '-y', '--noplugins', '-c', yum_conf_file, control_package]
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env)
     output, _ = p.communicate()
     xcp.logger.info('pool_update.precheck %r returncode=%r output:', cmd, p.returncode)

--- a/scripts/host-bugreport-upload
+++ b/scripts/host-bugreport-upload
@@ -6,9 +6,6 @@
 
 DEFAULT_BASE_URL="ftp://support.xensource.com/uploads/"
 
-INPUT_URL=$1
-PROXY=$2
-
 # If the user supplies a bare filename without a URI scheme,
 # we ignore it -- if they _really_ want to upload named files
 # to our support server, they can specify the URI scheme.
@@ -30,5 +27,8 @@ export http_proxy=$PROXY
 export ftp_proxy=$PROXY
 
 logger "Uploading xen-bugtool"
-/usr/sbin/xen-bugtool --output=tar --outfd 1 --yestoall --silent 2>/dev/null | curl -T - $URL 2>&1
+url_file=$(mktemp --suffix="host-bugreport-upload")
+printf 'url = "%s"' $URL > $url_file
+/usr/sbin/xen-bugtool --output=tar --outfd 1 --yestoall --silent 2>/dev/null | curl --config $url_file -T - 2>&1
 
+rm -f $url_file

--- a/scripts/host-bugreport-upload
+++ b/scripts/host-bugreport-upload
@@ -29,6 +29,6 @@ URL="${BASE_URL}${FILENAME}"
 export http_proxy=$PROXY
 export ftp_proxy=$PROXY
 
-logger "Uploading xen-bugtool to '$URL' (via proxy '$PROXY')"
+logger "Uploading xen-bugtool"
 /usr/sbin/xen-bugtool --output=tar --outfd 1 --yestoall --silent 2>/dev/null | curl -T - $URL 2>&1
 


### PR DESCRIPTION
This PR is for a series of backports:

* be8ff590f CA-333712: use wrapped string type for pool internal API calls   
* 010b3759f CA-329466: Simplify logging for plugins' parameters              
* 49bf6d71e CA-329835 Improve logging                                        
* 1523addcd CA-329843: broaden usage of secrets API                          
* 6fe63ab87 CA-330902 host-bugreport-upload args via env vars                
* b69de0058 CA-330902 Improve logging - backport it                          
* cef84c2a7 CA-330902 Improve logging                                        
* 6609d0346 CA-330693: Limit access to state.db to just root                 
* 49351479d CA-330961 Clean the yum cache before prechecking/applying

Except for CA-333712 the backports have not required considerable effort.

