### PR TITLE
Fix cluster_stack_in_use error message

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1154,7 +1154,7 @@ let _ =
   error Api_errors.cluster_force_destroy_failed ["cluster"]
     ~doc:"Force destroy failed on a Cluster_host while force destroying the cluster." ();
   error Api_errors.cluster_stack_in_use ["cluster_stack"]
-    ~doc:"The cluster stack is already in use." ();
+    ~doc:"The cluster stack is still in use by at least one plugged PBD." ();
   error Api_errors.invalid_cluster_stack [ "cluster_stack" ]
     ~doc:"The cluster stack provided is not supported." ();
   error Api_errors.pif_not_attached_to_host [ "pif"; "host" ]


### PR DESCRIPTION
In CA-336253 xe cluster-pool-destroy failed with a confusing error message saying that the cluster stack is already in use.
The reason for the failure was that a PBD unplug has previously failed (but XenRT didn't notice and ignored it), which then caused this failure in destroy.

Improve the error message to say that something earlier failed.

@MarkSymsCtx FYI