### PR TITLE
CP-32398 must not use POD when using SRIOV vGPU

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -225,15 +225,26 @@ let unpause ~__context ~vm =
 let set_xenstore_data ~__context ~self ~value =
   Xapi_xenops.set_xenstore_data ~__context ~self value
 
-(* CP-18860: check memory limits if using nested_virt on start *)
+let is_sriov_vgpu ~__context vgpu =
+  let vgpu = Db.VGPU.get_record_internal ~__context ~self:vgpu in
+  let ty = vgpu.Db_actions.vGPU_type in
+  match Db.VGPU_type.get_implementation ~__context ~self:ty with
+  | `nvidia_sriov -> true
+  | _             -> false
+
 let assert_memory_constraints ~__context ~vm platformdata =
-  if Vm_platform.is_true ~key:"nested-virt" ~platformdata ~default:false
-  then
-    begin
-      let module C = Xapi_vm_memory_constraints.Vm_memory_constraints in
-      let c = C.get ~__context ~vm_ref:vm in
-      C.assert_valid_and_pinned_at_static_max ~constraints:c ~reason:"nested virt"
-    end
+  let module C = Xapi_vm_memory_constraints.Vm_memory_constraints in
+  if Vm_platform.is_true ~key:"nested-virt" ~platformdata ~default:false then begin
+    (* CP-18860: check memory limits if using nested_virt on start *)
+    let c = C.get ~__context ~vm_ref:vm in
+    C.assert_valid_and_pinned_at_static_max ~constraints:c ~reason:"nested virt"
+  end;
+  let vgpus = Db.VM.get_VGPUs ~__context ~self:vm in
+  if List.exists (is_sriov_vgpu ~__context) vgpus then begin
+    (* CP-32398: must not use POD when using SRIOV vGPU *)
+    let c = C.get ~__context ~vm_ref:vm in
+    C.assert_valid_and_pinned_at_static_max ~constraints:c ~reason:"SRIOV vGPU"
+  end
 
 (* Note: it is important that we use the pool-internal API call, VM.atomic_set_resident_on, to set resident_on and clear
    scheduled_to_be_resident_on atomically. This prevents concurrent API calls on the master from accounting for the


### PR DESCRIPTION
Add a check into VM start to check its memory configuration if the VM
has an SRIOV vGPU. We disable ballooning (DMC) and POD (populate on
demand) by pinning memory to static max. The main point is disabling POD
but we found it difficult to implement while still permitting
ballooning. So we are disabling both by demanding that the memory
configuration is fixed at the upper limit at the start of the VM.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>