### PR TITLE
CP-32696: Add alerts for certificate expiration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ install: build doc
 	scripts/install.sh 755 _build/install/default/bin/mpathalert $(DESTDIR)$(OPTDIR)/bin/mpathalert
 # ocaml/license
 	scripts/install.sh 755 _build/install/default/bin/daily-license-check $(DESTDIR)$(LIBEXECDIR)/daily-license-check
+# ocaml/alerts/certificate
+	scripts/install.sh 755 _build/install/default/bin/alert-certificate-check $(DESTDIR)$(LIBEXECDIR)/alert-certificate-check
 # ocaml/events
 	scripts/install.sh 755 _build/install/default/bin/event_listen $(DESTDIR)$(OPTDIR)/debug/event_listen
 # ocaml/db_process

--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -1,0 +1,70 @@
+module XenAPI = Client.Client
+module Date = Xapi_stdext_date.Date
+
+let seconds_per_day = 3600. *. 24.
+let seconds_per_30_days = 30. *. seconds_per_day
+
+let days_until_expiry epoch expiry =
+  int_of_float (expiry /. seconds_per_day -. epoch /. seconds_per_day)
+
+let get_certificate_attributes rpc session =
+  XenAPI.Certificate.get_all_records rpc session
+  |> List.map (fun (_, certificate) ->
+    certificate.API.certificate_host,
+    certificate.API.certificate_not_after
+  )
+
+let generate_alert epoch (host, expiry) =
+  let days = days_until_expiry epoch (Date.to_float expiry) in
+  if days > 30 then
+    host, None
+  else
+    let expiring_message = "The TLS server certificate is expiring soon." in
+    let expired_message = "The TLS server certificate has expired." in
+
+    let body msg =
+      Printf.sprintf "<message>%s</message><date>%s</date>" msg (Date.to_string expiry)
+    in
+    let message, alert =
+      if days < 0 then
+        body expired_message, Api_messages.host_server_certificate_expired
+      else if days < 8 then
+        body expiring_message, Api_messages.host_server_certificate_expiring_07
+      else if days < 15 then
+        body expiring_message, Api_messages.host_server_certificate_expiring_14
+      else
+        body expiring_message, Api_messages.host_server_certificate_expiring_30
+    in
+    host, Some (message, alert)
+
+let execute rpc session (host, alert) =
+  let host_uuid = XenAPI.Host.get_uuid rpc session host in
+  (* we need to remove any host_server_certificate_expiring messages affecting
+     this host as it needs to be refreshed *)
+  let obsolete_messages = XenAPI.Message.get_all_records rpc session
+  |> List.filter_map (fun (ref, record) ->
+      let prefix = Api_messages.host_server_certificate_expiring in
+      if Astring.String.is_prefix ~affix:prefix record.API.message_name
+           && record.API.message_obj_uuid = host_uuid then
+        Some ref
+      else
+        None
+      )
+  in
+  List.iter (fun self -> XenAPI.Message.destroy rpc session self) obsolete_messages;
+
+  match alert with
+  | None ->
+      ()
+  | Some (message, (alert, priority)) ->
+    ignore (XenAPI.Message.create rpc session alert priority `Host host_uuid message)
+
+let alert rpc session =
+  let now = Unix.time () in
+  let send_alert_maybe attributes =
+    attributes
+    |> generate_alert now
+    |> execute rpc session
+  in
+  get_certificate_attributes rpc session
+  |> List.iter send_alert_maybe

--- a/ocaml/alerts/certificate/certificate_check_main.ml
+++ b/ocaml/alerts/certificate/certificate_check_main.ml
@@ -1,0 +1,22 @@
+module XenAPI = Client.Client
+
+let rpc xml =
+  let open Xmlrpc_client in
+  XMLRPC_protocol.rpc
+    ~srcstr:"certificate-check"
+    ~dststr:"xapi"
+    ~transport:(Unix "/var/xapi/xapi")
+    ~http:(xmlrpc ~version:"1.0" "/")
+    xml
+
+let _ =
+  let session = XenAPI.Session.login_with_password
+      ~rpc:rpc
+      ~uname:""
+      ~pwd:""
+      ~version:"1.0"
+      ~originator:"certificate-check"
+  in
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () -> Certificate_check.alert rpc session)
+    (fun () -> XenAPI.Session.logout rpc session)

--- a/ocaml/alerts/certificate/dune
+++ b/ocaml/alerts/certificate/dune
@@ -1,0 +1,20 @@
+(library
+  (name certificate_check)
+  (modules certificate_check)
+  (libraries
+    xapi-client
+    xapi-stdext-date
+  )
+)
+
+(executable
+  (name certificate_check_main)
+  (public_name alert-certificate-check)
+  (package xapi)
+  (modules certificate_check_main)
+  (libraries
+    certificate_check
+    xapi-client
+    xapi-stdext-pervasives
+  )
+)

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -13,6 +13,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29-52))
   (libraries
     alcotest
+    certificate_check
     daily_license_check
     nocrypto.unix
     xapi_internal

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -55,6 +55,7 @@ let () =
     ; "Test_storage_migrate_state", Test_storage_migrate_state.test
     ; "Test_bios_strings", Test_bios_strings.test
     ; "Test_daily_license_check", Test_daily_license_check.test
+    ; "Test_alert_certificate_check", Test_alert_certificate_check.test
     ; "Test_certificates", Test_certificates.test
     ] @ Test_guest_agent.tests
       @ Test_nm.tests

--- a/ocaml/tests/test_alert_certificate_check.ml
+++ b/ocaml/tests/test_alert_certificate_check.ml
@@ -1,0 +1,68 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Certificate_check
+
+let date_of = Xapi_stdext_date.Date.of_string
+
+let check_time = Xapi_stdext_date.Date.to_float (date_of "20200201T02:00:00Z")
+
+let good_samples =
+  [ "20210202T02:00:00Z" ]
+
+let expiring_samples =
+  [ "20200301T02:00:00Z", 29, Api_messages.host_server_certificate_expiring_30
+  ; "20200215T02:00:00Z", 14, Api_messages.host_server_certificate_expiring_14
+  ; "20200208T02:00:00Z", 7, Api_messages.host_server_certificate_expiring_07
+  ; "20200201T02:00:00Z", 0, Api_messages.host_server_certificate_expiring_07
+  ]
+
+let expired_samples =
+  [ "20200102T02:00:00Z" ]
+
+let format_good datestring =
+  ("host", date_of datestring),
+  ("host", None)
+
+let _format (datestring, ppf, alert) =
+  let fmt = Scanf.format_from_string ppf "%s" in
+  ("host", date_of datestring),
+  ("host", Some (Printf.sprintf fmt datestring, alert))
+
+let format_expiring (datestring, days, alert) =
+  let ppf =
+    "<message>The TLS server certificate is expiring soon.</message><date>%s</date>"
+  in
+  _format (datestring, ppf, alert)
+
+let format_expired datestring =
+  let ppf =
+    "<message>The TLS server certificate has expired.</message><date>%s</date>"
+  in
+  _format (datestring, ppf, Api_messages.host_server_certificate_expired)
+
+let certificate_samples =
+  List.map format_good good_samples
+  @ List.map format_expiring expiring_samples
+  @ List.map format_expired expired_samples
+
+let test_alerts (server_certificates, expected) () =
+  let result = generate_alert check_time server_certificates in
+  Alcotest.(check @@ pair string @@ option @@ pair string @@ pair string int64)
+    "certificate_expiry" expected result
+
+let test =
+  List.mapi (fun i spec ->
+    Printf.sprintf "Test certificate checks as run daily #%d" i,
+      `Quick, test_alerts spec) certificate_samples

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -12,13 +12,15 @@
  * GNU Lesser General Public License for more details.
  *)
 
-(*
+(** Each message string in this file has to be unique and it can only have one
+   priority.
+
 Priority Name                  Description
 -------- --------------------- -----------------------------------------------------------------------------
-1        Data-loss imminent    Take action now or your data may be permanently lost (e.g. corrupted)
-2        Service-loss imminent Take action now or some service(s) may fail (e.g. host / VM crash)
-3        Service degraded      Take action now or some service may suffer (e.g. NIC bond degraded without HA)
-4        Service recovered     Notice that something just improved (e.g. NIC bond repaired)
+1        Critical              Take action now or your data may be permanently lost (e.g. corrupted)
+2        Major                 Take action now or some service(s) may fail (e.g. host / VM crash)
+3        Warning               Take action now or some service may suffer (e.g. NIC bond degraded without HA)
+4        Minor                 Notice that something just improved (e.g. NIC bond repaired)
 5        Informational         More day-to-day stuff (e.g. VM started, suspended, shutdown, rebooted etc)
 *)
 
@@ -139,3 +141,10 @@ let cluster_host_enable_failed = addMessage "CLUSTER_HOST_ENABLE_FAILED" 3L
 
 (* raised by external script in clustering daemon, do not delete this: it is not dead code *)
 let cluster_host_fencing = addMessage "CLUSTER_HOST_FENCING" 2L
+
+(* Certificate expiration messages *)
+let host_server_certificate_expiring = "HOST_SERVER_CERTIFICATE_EXPIRING"
+let host_server_certificate_expiring_30 = addMessage (host_server_certificate_expiring ^ "_30") 3L
+let host_server_certificate_expiring_14 = addMessage (host_server_certificate_expiring ^ "_14") 2L
+let host_server_certificate_expiring_07 = addMessage (host_server_certificate_expiring ^ "_07") 1L
+let host_server_certificate_expired = addMessage "HOST_SERVER_CERTIFICATE_EXPIRED" 1L

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2630,7 +2630,13 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
             certificate_chain
         );
       in
-      tolerate_connection_loss fn success 30.
+      tolerate_connection_loss fn success 30.;
+      try
+        let _, _ = Forkhelpers.execute_command_get_output !Xapi_globs.alert_certificate_check [] in
+        ()
+      with Forkhelpers.Spawn_internal_error(_ ,_ , _) ->
+        raise (Api_errors.Server_error(Api_errors.internal_error,
+          ["Generation of alerts for server certificate expiration failed."]))
 
     let attach_static_vdis ~__context ~host ~vdi_reason_map =
       info "Host.attach_static_vdis: host = '%s'; vdi/reason pairs = [ %s ]" (host_uuid ~__context host)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -791,6 +791,8 @@ let list_domains = ref "/usr/bin/list_domains"
 
 let xen_cmdline_script = ref "/opt/xensource/libexec/xen-cmdline"
 
+let alert_certificate_check = ref "alert-certificate-check"
+
 let sr_health_check_task_label = "SR Recovering"
 
 let domain_zero_domain_type = `pv
@@ -1064,7 +1066,8 @@ module Resources = struct
     "static-vdis", static_vdis, "Path to static-vdis script";
     "xen-cmdline-script", xen_cmdline_script, "Path to xen-cmdline script";
     "fcoe-driver", fcoe_driver, "Execute during PIF unplug to get the lun devices related with the ether interface of the PIF";
-    "list_domains", list_domains, "Path to the list_domains command"
+    "list_domains", list_domains, "Path to the list_domains command";
+    "alert-certificate-check", alert_certificate_check, "Path to alert-certificate-check, which generates alerts on about-to-expire server certificates."
   ]
   let nonessential_executables = [
     "startup-script-hook", startup_script_hook, "Executed during startup";

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -138,6 +138,7 @@ install:
 	$(IPROG) pv2hvm $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)/etc/cron.daily
 	$(IPROG) license-check $(DESTDIR)/etc/cron.daily/
+	$(IPROG) certificate-check $(DESTDIR)/etc/cron.daily/
 	mkdir -p $(DESTDIR)/etc/cron.d
 	$(IDATA) xapi-logrotate.cron $(DESTDIR)/etc/cron.d/xapi-logrotate.cron
 	mkdir -p $(DESTDIR)/opt/xensource/gpg

--- a/scripts/certificate-check
+++ b/scripts/certificate-check
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if ! grep -q master /etc/xensource/pool.conf; then
+    echo "Not checking certificate expiration for alerts, this is not a master host"
+    exit 0
+fi
+
+@LIBEXECDIR@/alert-certificate-check >/dev/null 2>&1
+
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t alert-certificate-check "ALERT exited abnormally with [$EXITVALUE]"
+fi
+exit 0


### PR DESCRIPTION
Adds a daily cron job that checks the validity of the certificates for all hosts.
It also checks alerts for hosts with installed certificates and clears them before adding the new alerts.

Depends on https://github.com/xapi-project/xen-api/pull/4038