### PR TITLE
dependency of xapi-project/xcp-networkd#173 - allow use of already enabled sr-iov virtual functions in xapi managed sr-iov networks

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4344,6 +4344,7 @@ module Network_sriov = struct
     [
       "sysfs", "Configure network sriov by sysfs, do not need reboot";
       "modprobe", "Configure network sriov by modprobe, need reboot";
+      "manual", "Configure network sriov manually";
       "unknown", "Unknown mode";
     ])
 

--- a/ocaml/xapi/record_util.ml
+++ b/ocaml/xapi/record_util.ml
@@ -515,6 +515,7 @@ let vusb_operation_to_string = function
 let network_sriov_configuration_mode_to_string = function
   | `sysfs -> "sysfs"
   | `modprobe -> "modprobe"
+  | `manual -> "manual"
   | `unknown -> "unknown"
 
 (* string_to_string_map_to_string *)


### PR DESCRIPTION
The additions in this pull request are direct dependencies of xapi-project/xcp-networkd#173. Needed to allow the configuration/management of sr-iov networks in xapi, using adapters with already enabled sr-iov/vfs.

This pull request adds:
 * `sriov_configuration_mode`: `` `manual``
 * `Net.Sriov.enable` return `Manual_successful`
 * `` `manual`` mode in `network_sriov_configuration_mode_to_string`
 * handling of `` `manual`` sr-iov networks in `require_operation_on_pci_device`
 * and in `can_be_up_without_reboot`

`require_operation_on_pci_device`: Returns `false` for manually configured devices, as the virtual functions on the device are not managed by xapi. Prevents accidental disabling of user enabled vfs on manually configured devices.
`can_be_up_without_reboot`: uses same mechanism as modprobe interface and probes attached and remaining capacity, as a working sysfs interface can not be assumed to be present


