### PR TITLE
CP-32649: Use Stdlib's Result

### DIFF
--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -59,7 +59,7 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout ~token_
       Xapi_clustering.Daemon.enable ~__context;
       let result = Cluster_client.LocalClient.create (rpc ~__context) dbg init_config in
       match Idl.IdM.run @@ (Cluster_client.IDL.T.get result) with
-      | Result.Ok cluster_token ->
+      | Ok cluster_token ->
         D.debug "Got OK from LocalClient.create";
         Db.Cluster.create ~__context ~ref:cluster_ref ~uuid:cluster_uuid ~cluster_token ~cluster_stack ~pending_forget:[]
           ~pool_auto_join ~token_timeout ~token_timeout_coefficient ~current_operations:[] ~allowed_operations:[] ~cluster_config:[]
@@ -70,7 +70,7 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout ~token_
         D.debug "Created Cluster: %s and Cluster_host: %s" (Ref.string_of cluster_ref) (Ref.string_of cluster_host_ref);
         set_ha_cluster_stack ~__context;
         cluster_ref
-      | Result.Error error ->
+      | Error error ->
         D.warn "Error occurred during Cluster.create";
         handle_error error
     )

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -91,12 +91,12 @@ let join_internal ~__context ~self =
         Cluster_client.LocalClient.join (rpc ~__context) dbg cluster_token ip ip_list
       in
       match Idl.IdM.run @@ Cluster_client.IDL.T.get result with
-      | Result.Ok () ->
+      | Ok () ->
         debug "Cluster join create was successful for cluster_host %s" (Ref.string_of self);
         Db.Cluster_host.set_joined ~__context ~self ~value:true;
         Db.Cluster_host.set_enabled ~__context ~self ~value:true;
         debug "Cluster_host %s joined and enabled" (Ref.string_of self)
-      | Result.Error error ->
+      | Error error ->
         warn "Error occurred when joining cluster_host %s" (Ref.string_of self);
         handle_error error
   )
@@ -147,11 +147,11 @@ let destroy_op ~__context ~self ~force =
       in
       let result = local_fn (rpc ~__context) dbg in
       match Idl.IdM.run @@ (Cluster_client.IDL.T.get result) with
-      | Result.Ok () ->
+      | Ok () ->
         Db.Cluster_host.destroy ~__context ~self;
         debug "Cluster_host.%s was successful" fn_str;
         Xapi_clustering.Daemon.disable ~__context
-      | Result.Error error ->
+      | Error error ->
         warn "Error occurred during Cluster_host.%s" fn_str;
         if force then begin
           let ref_str = Ref.string_of self in
@@ -187,14 +187,14 @@ let forget ~__context ~self =
       let pending = List.map ip_of_str pending in
       let result = Cluster_client.LocalClient.declare_dead (rpc ~__context) dbg pending in
       match Idl.IdM.run @@ (Cluster_client.IDL.T.get result) with
-      | Result.Ok () ->
+      | Ok () ->
         debug "Successfully forgot permanently dead hosts, setting pending forget to empty";
         Db.Cluster.set_pending_forget ~__context ~self:cluster ~value:[];
         (* must not disable the daemon here, because we declared another unreachable node dead,
          * not the current one *)
         Db.Cluster_host.destroy ~__context ~self;
         debug "Cluster_host.forget was successful"
-      | Result.Error error ->
+      | Error error ->
         warn "Error encountered when declaring dead cluster_host %s (did you declare all dead hosts yet?)" (Ref.string_of self);
         handle_error error
     )
@@ -222,10 +222,10 @@ let enable ~__context ~self =
       end;
       let result = Cluster_client.LocalClient.enable (rpc ~__context) dbg init_config in
       match Idl.IdM.run @@ (Cluster_client.IDL.T.get result) with
-      | Result.Ok () ->
+      | Ok () ->
         Db.Cluster_host.set_enabled ~__context ~self ~value:true;
         debug "Cluster_host.enable was successful for cluster_host: %s" (Ref.string_of self)
-      | Result.Error error ->
+      | Error error ->
         warn "Error encountered when enabling cluster_host %s" (Ref.string_of self);
         handle_error error
     )
@@ -239,10 +239,10 @@ let disable ~__context ~self =
 
       let result = Cluster_client.LocalClient.disable (rpc ~__context) dbg in
       match Idl.IdM.run @@ (Cluster_client.IDL.T.get result) with
-      | Result.Ok () ->
+      | Ok () ->
         Db.Cluster_host.set_enabled ~__context ~self ~value:false;
         debug "Cluster_host.disable was successful for cluster_host: %s" (Ref.string_of self)
-      | Result.Error error ->
+      | Error error ->
         warn "Error encountered when disabling cluster_host %s" (Ref.string_of self);
         handle_error error
     )

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -236,11 +236,11 @@ let assert_cluster_host_quorate ~__context ~self =
   let result = Cluster_client.LocalClient.diagnostics (rpc ~__context) "assert_cluster_host_quorate"
   in
   match Idl.IdM.run @@ Cluster_client.IDL.T.get result with
-  | Result.Ok diag ->
+  | Ok diag ->
     debug "Local cluster host is quorate: %b" diag.Cluster_interface.is_quorate;
     if not diag.Cluster_interface.is_quorate then
       raise Api_errors.(Server_error (cluster_host_not_joined, [Ref.string_of self]))
-  | Result.Error error ->
+  | Error error ->
     warn "Cannot query cluster host quorate status";
     handle_error error
 


### PR DESCRIPTION
The library result is deprecated and it doesn't have the same interface as the standard library.