### PR TITLE
travis: follow validator recommendations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: c
-sudo: required
+os: linux
+dist: xenial
 services: docker
 script: bash ./.travis-$BUILD_METHOD.sh
 env:
-    matrix:
+    jobs:
         - BUILD_METHOD=xs-opam
         - BUILD_METHOD=python-nosetests
         - BUILD_METHOD=python-nosetests-3
-notifications:
-    slack: citrix:BHYQZbI8m036ELU21gZil75Y
-matrix:
+jobs:
     fast_finish: true
     allow_failures:
         - env: BUILD_METHOD=python-nosetests-3


### PR DESCRIPTION
Now `.travis.yml` follows best practices:
* `sudo` doesn't have an effect anymore
* `os` and `dist` have defaults, but it's better to set them
* `matrix` is no `jobs`
* the slack token was not encrypted and it had been invalidated in any case.