### PR TITLE
Add emergency call to reset TLS server certificates

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5589,6 +5589,7 @@ let emergency_calls =
     (Datamodel_host.t,Datamodel_host.get_system_status_capabilities);
     (Datamodel_host.t,Datamodel_host.is_in_emergency_mode);
     (Datamodel_host.t,Datamodel_host.shutdown_agent);
+    (Datamodel_host.t,Datamodel_host.emergency_reset_server_certificate);
   ]
 
 (** Whitelist of calls that will not get forwarded from the slave to master via the unix domain socket *)

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -958,7 +958,6 @@ let host_query_ha = call ~flags:[`Session]
       ()
 
   let install_server_certificate = call
-      ~in_oss_since:None
       ~lifecycle:[Published, rel_stockholm, ""]
       ~name:"install_server_certificate"
       ~doc:"Install the TLS server certificate."
@@ -977,6 +976,15 @@ let host_query_ha = call ~flags:[`Session]
          ; param_release=stockholm_release; param_default=Some (VString "")}
         ]
       ~allowed_roles:_R_POOL_ADMIN
+      ()
+
+  let emergency_reset_server_certificate = call
+      ~flags:[`Session]
+      ~lifecycle:[Published, rel_stockholm, ""]
+      ~name:"emergency_reset_server_certificate"
+      ~doc:"Delete the current TLS server certificate and replace by a new, self-signed one. This should only be used with extreme care."
+      ~versioned_params: []
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
   let get_server_certificate = call
@@ -1402,6 +1410,7 @@ let host_query_ha = call ~flags:[`Session]
         certificate_sync;
         get_server_certificate;
         install_server_certificate;
+        emergency_reset_server_certificate;
         update_pool_secret;
         update_master;
         attach_static_vdis;

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -698,6 +698,15 @@ let rec cmdtable_data : (string*cmd_spec) list =
       flags=[ Neverforward ];
     };
 
+    "host-emergency-reset-server-certificate",
+    {
+      reqd=[];
+      optn=[];
+      help="Deletes the current TLS server certificate in the host and installs a new, self-signed one.";
+      implementation=No_fd_local_session Cli_operations.host_emergency_reset_server_certificate;
+      flags=[ Neverforward ];
+    };
+
     "host-management-reconfigure",
     {
       reqd=["pif-uuid"];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -809,7 +809,7 @@ let gen_cmds rpc session_id =
     ; Client.Network_sriov.(mk get_all get_all_records_where get_by_uuid network_sriov_record "network-sriov" [] ["uuid"; "physical-pif"; "logical-pif"; "requires-reboot"; "configuration-mode"] rpc session_id)
     ; Client.Cluster.(mk get_all get_all_records_where get_by_uuid cluster_record "cluster" [] ["uuid";"cluster-hosts";"cluster-token";"cluster-stack";"allowed-operations";"current-operations";"pool-auto-join";"cluster-config";"other-config"] rpc session_id)
     ; Client.Cluster_host.(mk get_all get_all_records_where get_by_uuid cluster_host_record "cluster-host" [] ["uuid";"cluster";"pif";"host";"enabled";"allowed-operations";"current-operations";"other-config"] rpc session_id)
-    ; Client.Certificate.(mk get_all get_all_records_where get_by_uuid certificate_record "certificate" [] ["uuid";"host";"fingerprint"]rpc session_id)
+    ; Client.Certificate.(mk get_all get_all_records_where get_by_uuid certificate_record "certificate" [] ["uuid";"host";"fingerprint"] rpc session_id)
     ]
 
 let message_create printer rpc session_id params =
@@ -4503,6 +4503,9 @@ let host_emergency_ha_disable printer rpc session_id params =
   let soft = get_bool_param params "soft" in
   if not force then failwith "This operation is extremely dangerous and may cause data loss. This operation must be forced (use --force).";
   Client.Host.emergency_ha_disable rpc session_id soft
+
+let host_emergency_reset_server_certificate printer rpc session_id params =
+  Client.Host.emergency_reset_server_certificate ~rpc ~session_id
 
 let host_management_reconfigure printer rpc session_id params =
   let pif = Client.PIF.get_by_uuid rpc session_id (List.assoc "pif-uuid" params) in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2626,6 +2626,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
         raise (Api_errors.Server_error(Api_errors.internal_error,
           ["Generation of alerts for server certificate expiration failed."]))
 
+    let emergency_reset_server_certificate ~__context =
+      Local.Host.emergency_reset_server_certificate ~__context
+
     let attach_static_vdis ~__context ~host ~vdi_reason_map =
       info "Host.attach_static_vdis: host = '%s'; vdi/reason pairs = [ %s ]" (host_uuid ~__context host)
         (String.concat "; " (List.map (fun (a, b) ->  Ref.string_of a ^ "/" ^ b) vdi_reason_map));

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -211,6 +211,9 @@ val install_server_certificate :
     remote. This is done to refresh the server certificate used in the
     connections. *)
 
+val emergency_reset_server_certificate :
+  __context:Context.t -> unit
+
 val detect_nonhomogeneous_external_auth_in_host :
   __context:Context.t -> host:API.ref_host -> unit
 val enable_external_auth :


### PR DESCRIPTION
If successful it deletes the current certificate and places a new,
self-signed on instead. It also deletes the database record of the
server certificate currently installed in the host.
This call is only available locally only.

Its implementation is barebones as it's replicating what happens when gencert is called on first startup.

This is meant to change with https://github.com/xapi-project/xen-api/tree/feature/REQ-811/master and after both features get merged the bash script will be replaced by an ocaml binary, as well as xapi making an effort to add the existing self-signed cert to the database.