### PR TITLE
Fix build: drop Xcp_coverage

### DIFF
--- a/ocaml/auth/dune
+++ b/ocaml/auth/dune
@@ -1,13 +1,3 @@
-(* -*- tuareg -*- *)
-
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name pam)
   (c_names
@@ -17,6 +7,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (c_flags -I/usr/lib64/ocaml)
   (c_library_flags -lpam)
   (wrapped false)
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/cdrommon/dune
+++ b/ocaml/cdrommon/dune
@@ -1,13 +1,3 @@
-(* -*- tuareg -*- *)
-
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
-
 (executable
   (name cdrommon)
   (public_name cdrommon)
@@ -18,6 +8,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     unix
     xapi-stdext-unix
   )
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/database/dune
+++ b/ocaml/database/dune
@@ -1,12 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
-
 (ocamllex db_filter_lex)
 (ocamlyacc db_filter_parse)
 
@@ -38,7 +29,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xapi-idl
   )
   (wrapped false)
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv %s))
+  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
 
 (executable
@@ -95,28 +86,26 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (name runtest)
   (deps (:x unit_test_marshall.exe))
   (package xapi-database)
-  (action (run %%{x}))
+  (action (run %{x}))
 )
 
 (alias
   (name runtest)
   (deps (:x unit_test_sql.exe) sql_msg_example.txt)
   (package xapi-database)
-  (action (run %%{x}))
+  (action (run %{x}))
 )
 
 (alias
   (name runtest)
   (deps (:x database_server_main.exe))
   (package xapi-database)
-  (action (run %%{x} --master db.xml --test))
+  (action (run %{x} --master db.xml --test))
 )
 
 (alias
   (name runtest)
   (deps (:x db_cache_test.exe))
   (package xapi-database)
-  (action (run %%{x}))
+  (action (run %{x}))
 )
-
-|} coverage_rewriter

--- a/ocaml/db_process/dune
+++ b/ocaml/db_process/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name xapi_db_process)
   (public_name xapi-db-process)
@@ -16,6 +8,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-database
    xapi-idl  ;for the Debug module
   )
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/doc/dune
+++ b/ocaml/doc/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name jsapi)
   (flags (:standard))
@@ -17,7 +9,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    gzip
    mustache
   )
-  (preprocess (pps ppx_deriving_rpc %s))
+  (preprocess (pps ppx_deriving_rpc))
 )
 
 (alias
@@ -27,7 +19,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     (source_tree templates)
   )
   (package xapi-datamodel)
-  (action (run %%{x}))
+  (action (run %{x}))
 )
 
 (alias
@@ -37,6 +29,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     (source_tree templates)
   )
   (package xapi-datamodel)
-  (action (run %%{x}))
+  (action (run %{x}))
 )
-|} coverage_rewriter

--- a/ocaml/events/dune
+++ b/ocaml/events/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name event_listen)
   (public_name event_listen)
@@ -14,6 +6,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    http-svr
    xapi-client
   )
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name xapi_datamodel)
   (public_name xapi-datamodel)
@@ -38,7 +30,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-stdext-unix
   )
   (wrapped false)
-  (preprocess (pps ppx_deriving_rpc %s))
+  (preprocess (pps ppx_deriving_rpc))
 )
 
 (executable
@@ -53,4 +45,3 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-datamodel
   )
 )
-|} coverage_rewriter

--- a/ocaml/idl/json_backend/dune
+++ b/ocaml/idl/json_backend/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name gen_json)
   (libraries
@@ -14,13 +6,11 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-stdext-unix
    xapi-stdext-std
   )
-  %s
 )
 
 (alias
   (name runtest)
   (deps (:x gen_json.exe))
   (package xapi-datamodel)
-  (action (run %%{x}))
+  (action (run %{x}))
 )
-|} coverage_rewriter

--- a/ocaml/idl/ocaml_backend/dune
+++ b/ocaml/idl/ocaml_backend/dune
@@ -1,12 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
-
 (executable
   (name gen_api_main)
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29))
@@ -19,6 +10,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-stdext-pervasives
    xapi-stdext-std
   )
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/mpathalert/dune
+++ b/ocaml/mpathalert/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name mpathalert)
   (public_name mpathalert)
@@ -19,6 +11,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xapi-stdext-threads
     xapi-stdext-unix
   )
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/perftest/dune
+++ b/ocaml/perftest/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name perftest)
   (public_name perftest)
@@ -24,6 +16,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xapi-idl
     xml-light2
   )
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/ptoken/dune
+++ b/ocaml/ptoken/dune
@@ -1,16 +1,6 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name genptoken)
   (public_name genptoken)
   (package xapi)
   (libraries uuid)
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/quicktest/dune
+++ b/ocaml/quicktest/dune
@@ -1,12 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
-
 (executable
   (name quicktest)
   (public_name quicktestbin)
@@ -25,6 +16,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xapi-stdext-unix
     xenctrl
   )
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv %s))
+  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
-|} coverage_rewriter

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -1,12 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
-
 (executables
   (names suite_alcotest)
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29-52))
@@ -16,7 +7,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xapi_internal
     xapi-stdext-date
   )
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv %s))
+  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
 
 (alias
@@ -26,7 +17,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     (:x suite_alcotest.exe)
     (source_tree test_data)
   )
-  (action (run %%{x}))
+  (action (run %{x}))
 )
 
 (alias
@@ -35,6 +26,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   (deps
     (:x ../xapi/xapi_main.exe)
   )
-  (action (run ./check-no-xenctrl %%{x}))
+  (action (run ./check-no-xenctrl %{x}))
 )
-|} coverage_rewriter

--- a/ocaml/util/dune
+++ b/ocaml/util/dune
@@ -1,14 +1,6 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (rule
   (targets build_info.ml)
-  (action (with-stdout-to %%{targets} (run "date" "+let date=\"%%Y-%%m-%%d\"")))
+  (action (with-stdout-to %{targets} (run "date" "+let date=\"%Y-%m-%d\"")))
 )
 
 (library
@@ -21,6 +13,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-inventory
   )
   (wrapped false)
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/vncproxy/dune
+++ b/ocaml/vncproxy/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name vncproxy)
   (public_name vncproxy)
@@ -16,6 +8,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-stdext-unix
    xapi-stdext-pervasives
   )
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/xapi-cli-protocol/dune
+++ b/ocaml/xapi-cli-protocol/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name xapi_cli_protocol)
   (public_name xapi-cli-protocol)
@@ -14,6 +6,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-stdext-unix
   )
   (wrapped false)
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/xapi-client/dune
+++ b/ocaml/xapi-client/dune
@@ -1,15 +1,7 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (rule
   (targets client.ml)
   (deps ../idl/ocaml_backend/gen_api_main.exe)
-  (action (run %%{deps} -filterinternal true -filter closed -mode client -output %%{targets}))
+  (action (run %{deps} -filterinternal true -filter closed -mode client -output %{targets}))
 )
 
 (library
@@ -22,6 +14,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-stdext-date
   )
   (wrapped false)
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/xapi-consts/dune
+++ b/ocaml/xapi-consts/dune
@@ -1,15 +1,5 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name xapi_consts)
   (public_name xapi-consts)
   (wrapped false)
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/xapi-types/dune
+++ b/ocaml/xapi-types/dune
@@ -1,15 +1,7 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (rule
   (targets aPI.ml)
   (deps ../idl/ocaml_backend/gen_api_main.exe)
-  (action (run %%{deps} -filterinternal true -filter closed -mode api -output %%{targets}))
+  (action (run %{deps} -filterinternal true -filter closed -mode api -output %{targets}))
 )
 
 (library
@@ -27,6 +19,5 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-idl
   )
   (wrapped false)
-  (preprocess (pps ppx_deriving_rpc %s))
+  (preprocess (pps ppx_deriving_rpc))
 )
-|} coverage_rewriter

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -1,39 +1,31 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "bisect_ppx"
-  | _ -> ""
-  | exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (rule
   (targets server.ml)
   (deps ../idl/ocaml_backend/gen_api_main.exe)
-  (action (run %%{deps} -filterinternal true -gendebug -filter closed -mode server -output %%{targets}))
+  (action (run %{deps} -filterinternal true -gendebug -filter closed -mode server -output %{targets}))
 )
 
 (rule
   (targets db_actions.ml)
   (deps ../idl/ocaml_backend/gen_api_main.exe)
-  (action (run %%{deps} -filterinternal false -filter nothing -mode db -output %%{targets}))
+  (action (run %{deps} -filterinternal false -filter nothing -mode db -output %{targets}))
 )
 
 (rule
   (targets custom_actions.ml)
   (deps ../idl/ocaml_backend/gen_api_main.exe)
-  (action (run %%{deps} -filterinternal true -filter closed -mode actions -output %%{targets}))
+  (action (run %{deps} -filterinternal true -filter closed -mode actions -output %{targets}))
 )
 
 (rule
   (targets rbac_static.ml)
   (deps ../idl/ocaml_backend/gen_api_main.exe)
-  (action (run %%{deps} -filterinternal true -filter closed -mode rbac -output %%{targets}))
+  (action (run %{deps} -filterinternal true -filter closed -mode rbac -output %{targets}))
 )
 
 (rule
   (targets rbac_static.csv)
   (deps ../idl/ocaml_backend/gen_api_main.exe)
-  (action (run %%{deps} -filterinternal true -gendebug -filter closed -mode rbac -output %%{targets}))
+  (action (run %{deps} -filterinternal true -gendebug -filter closed -mode rbac -output %{targets}))
 )
 
 (install
@@ -89,7 +81,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    yojson
    zstd
   )
-  (preprocess (pps ppx_deriving_rpc %s))
+  (preprocess (pps ppx_deriving_rpc))
 )
 
 (executable
@@ -102,4 +94,3 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi_internal
   )
 )
-|} coverage_rewriter

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -189,8 +189,6 @@ let init_args() =
   (* Immediately register callback functions *)
   register_callback_fns();
   Xcp_service.configure ~options:Xapi_globs.all_options ~resources:Xapi_globs.Resources.xcp_resources ();
-  Xcp_coverage.init "xapi";
-  Xcp_coverage.dispatcher_init "xapi";
   if not !Xcp_client.use_switch
   then begin
     debug "Xcp_client.use_switch=false: resetting list of xenopsds";

--- a/ocaml/xe-cli/dune
+++ b/ocaml/xe-cli/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name newcli)
   (public_name xe)
@@ -18,6 +10,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    xapi-stdext-std
    xapi-stdext-unix
   )
-  %s
 )
-|} coverage_rewriter

--- a/ocaml/xsh/dune
+++ b/ocaml/xsh/dune
@@ -1,11 +1,3 @@
-(* -*- tuareg -*- *)
-let coverage_rewriter =
-  match Sys.getenv "BISECT_ENABLE" with
-  | "YES" -> "(preprocess (pps bisect_ppx -conditional))"
-  | _ -> ""
-| exception Not_found -> ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name xsh)
   (public_name xsh)
@@ -14,6 +6,4 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
    stunnel
    threads
   )
-  %s
 )
-|} coverage_rewriter


### PR DESCRIPTION
This has been removed from xcp-idl and causing the build to fail now.
Also simplify the dune files and drop unused coverage from there too.