### PR TITLE
CA-336735: preserve formatting of stars for wlb recommendations

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -60,9 +60,17 @@ let assert_can_boot_here ~__context ~self ~host =
   assert_can_boot_here ~__context ~self ~host ~snapshot ~do_cpuid_check:true ()
 
 let retrieve_wlb_recommendations ~__context ~vm =
+  let compat_string_of_float f =
+    let repr = string_of_float f in
+    (* Original format has always at least one fractional decimal digit *)
+    if Astring.String.is_suffix ~affix:"." repr then
+      repr ^ "0"
+    else
+      repr
+  in
   let transform_for_api = function
     | host, Workload_balancing.(Recommendation {source; id; score}) ->
-      host, [source; (string_of_float score); id]
+      host, [source; (compat_string_of_float score); id]
     | host, Workload_balancing.(Impossible {source; id; reason}) ->
       host, [source; "0.0"; id; reason]
   in


### PR DESCRIPTION
Interfaces such as xe were exposing this string, with the conversion to
and from float the format was changed. With this make an extra effort to
preserve the formatting for the usual range of values.

Values lower than 0.0001 will still show up with the exponential format:
9.99e-5