### PR TITLE
xapissl: re-read MANAGEMENT_INTERFACE in each retry

### DIFF
--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -71,7 +71,7 @@ writec () {
 writeconffile () {
     # Initial boilerplate which is valid whether the management
     # interface is enabled or disabled.
-    . /etc/xensource-inventory
+    . @INVENTORY@
 
     # (This "good" list must match, or at least contain one of,
     #  the ciphersuites-good-outbound list in /etc/xapi.conf.)

--- a/scripts/init.d-xapissl
+++ b/scripts/init.d-xapissl
@@ -58,6 +58,8 @@ mgmt_ip() {
             else
                 sleep 1
             fi
+            # MANAGEMENT_INTERFACE may have changed. Re-read it.
+            . @INVENTORY@
         done
     fi
 }


### PR DESCRIPTION
   If the old MANAGEMENT_INTERFACE is not configured, e.g. cable unplugged,
    xapissl will loop forever, even MANAGEMENT_INTERFACE is re-set to another
    interface during the loop.