### PR TITLE
REQ-453 re-expose reconfigure_stunnel

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.mli
+++ b/ocaml/xapi/xapi_mgmt_iface.mli
@@ -40,3 +40,6 @@ val rebind : __context:Context.t -> unit
 
 (** Start a server thread on the given HIMN address if the server is not yet running *)
 val enable_himn : __context:Context.t -> addr:string -> unit
+
+(** Restart stunnel to make it pick up a change to host.ssl_legacy *)
+val reconfigure_stunnel : __context:Context.t -> unit


### PR DESCRIPTION
REQ-811 removed the ability for arbitrary code inside xapi to restart
stunnel, but this is required for REQ-453, so we reintroduce it.

Signed-off-by: lippirk <ben.anson@citrix.com>