### PR TITLE
Enable dormant tests

### DIFF
--- a/ocaml/database/db_cache_test.ml
+++ b/ocaml/database/db_cache_test.ml
@@ -60,11 +60,5 @@ let check_many_to_many () =
   then failwith (Printf.sprintf "check_many_to_many: foo(foo:1).foos expected () got %s" (Sexplib.Sexp.to_string (Schema.Value.sexp_of_t foo_bars)));
   ()
 
-open OUnit
-
-let _ =
-  let suite = "db_cache" >:::
-              [
-                "many to many" >:: check_many_to_many;
-              ] in
-  OUnit2.run_test_tt_main (OUnit.ounit2_of_ounit1 suite)
+let () =
+  Alcotest.run "Database cache" ["db_cache", ["many_to_many", `Quick, check_many_to_many]]

--- a/ocaml/database/dune
+++ b/ocaml/database/dune
@@ -45,31 +45,6 @@
 )
 
 (executable
-  (name db_cache_test)
-  (modules db_cache_test)
-  (libraries
-    oUnit
-    xapi-database
-  )
-)
-
-(executable
-  (name unit_test_marshall)
-  (modules
-    unit_test_marshall
-  )
-  (libraries
-    xapi-database
-  )
-)
-
-(executable
-  (name unit_test_sql)
-  (modules unit_test_sql)
-  (libraries xapi-database)
-)
-
-(executable
   (name database_server_main)
   (modules
     database_server_main
@@ -82,18 +57,29 @@
   )
 )
 
-(alias
-  (name runtest)
-  (deps (:x unit_test_marshall.exe))
+(test
+  (name db_cache_test)
   (package xapi-database)
-  (action (run %{x}))
+  (modules db_cache_test)
+  (libraries
+    oUnit
+    xapi-database
+  )
 )
 
-(alias
-  (name runtest)
-  (deps (:x unit_test_sql.exe) sql_msg_example.txt)
+(test
+  (name unit_test_marshall)
   (package xapi-database)
-  (action (run %{x}))
+  (modules unit_test_marshall)
+  (libraries xapi-database)
+)
+
+(test
+  (name unit_test_sql)
+  (package xapi-database)
+  (modules unit_test_sql)
+  (deps sql_msg_example.txt)
+  (libraries xapi-database)
 )
 
 (alias
@@ -101,11 +87,4 @@
   (deps (:x database_server_main.exe))
   (package xapi-database)
   (action (run %{x} --master db.xml --test))
-)
-
-(alias
-  (name runtest)
-  (deps (:x db_cache_test.exe))
-  (package xapi-database)
-  (action (run %{x}))
 )

--- a/ocaml/database/dune
+++ b/ocaml/database/dune
@@ -57,21 +57,14 @@
   )
 )
 
-(test
-  (name db_cache_test)
+(tests
+  (names unit_test_marshall db_cache_test)
   (package xapi-database)
-  (modules db_cache_test)
+  (modules db_cache_test unit_test_marshall)
   (libraries
-    oUnit
+    alcotest
     xapi-database
   )
-)
-
-(test
-  (name unit_test_marshall)
-  (package xapi-database)
-  (modules unit_test_marshall)
-  (libraries xapi-database)
 )
 
 (test
@@ -79,7 +72,10 @@
   (package xapi-database)
   (modules unit_test_sql)
   (deps sql_msg_example.txt)
-  (libraries xapi-database)
+  (libraries
+    alcotest
+    xapi-database
+  )
 )
 
 (alias

--- a/ocaml/database/unit_test_marshall.ml
+++ b/ocaml/database/unit_test_marshall.ml
@@ -79,9 +79,7 @@ let gen_random_4string() =
 (* test marshall unmarshall is id *)
 let tm u m x =
   let s = m x in
-  print_string (Xml.to_string_fmt s);
-  print_string "\n\n";
-  (u s)=x
+  Alcotest.(check bool) (Printf.sprintf "%s" @@ Xml.to_string_fmt s) true (x = (u s))
 
 let test_gtfr_args() =
   tm
@@ -241,18 +239,8 @@ let tests =
     test_find_refs_with_filter_args, "test_find_refs_with_filter_args"
   ]
 
-(*
-let x =
-  expr_of_xml (xml_of_expr test_exp)
-
-let _ =
-  print_string (string_of_expr x)
-*)
-
-exception TestFail of string
-
-let _ =
-  List.iter
-    (fun (f,fname) ->
-       if not (f()) then raise (TestFail fname))
-    tests
+let () =
+  let to_alco (test, name) =
+    name, [name, `Quick, test]
+  in
+  Alcotest.run "Marshalling and unmarshalling database records" (List.map to_alco tests)

--- a/ocaml/database/unit_test_sql.ml
+++ b/ocaml/database/unit_test_sql.ml
@@ -14,12 +14,12 @@
 let xml = Xml.parse_file "sql_msg_example.txt"
 let str = Xml.to_string_fmt xml
 
-let parse() = ignore (Xml.parse_string str)
-let to_string() = ignore (Xml.to_string_fmt xml)
+let parse () = ignore (Xml.parse_string str)
+let to_string () = ignore (Xml.to_string_fmt xml)
 
-let rec repeat f i =
+let rec repeat f i () =
   if i = 0 then ()
-  else (f(); repeat f (i-1))
+  else (f(); repeat f (i-1) ())
 
-let _ = repeat parse 1000
-(* let _ = print_string str *)
+let () =
+  Alcotest.run "Parsing sql messages" ["sql", ["parse", `Quick, repeat parse 1000]]

--- a/ocaml/pci/lib_test/dune
+++ b/ocaml/pci/lib_test/dune
@@ -1,10 +1,5 @@
-(executable
+(test
   (name test_pci)
-  (flags (:standard -safe-string))
+  (deps dump.data)
   (libraries pci oUnit)
 )
-
-;(alias
-; ((name    runtest)
-;  (deps    (test_pci.exe dump.data))
-;  (action  (run ${<}))))

--- a/ocaml/pci/lib_test/test_pci.ml
+++ b/ocaml/pci/lib_test/test_pci.ml
@@ -54,7 +54,7 @@ let test_lookup_functions () =
     test_lookup "Bridge" @@ (lookup_class_name acc 0x0680 |> default);
     test_lookup "Intel Corporation" @@ (lookup_vendor_name acc 0x8086 |> default);
     test_lookup "82371AB/EB/MB PIIX4 ACPI" @@ (lookup_device_name acc 0x8086 0x7113 |> default);
-    test_lookup "Red Hat, Inc" @@ (lookup_subsystem_vendor_name acc 0x1af4 |> default);
+    test_lookup "Red Hat, Inc." @@ (lookup_subsystem_vendor_name acc 0x1af4 |> default);
     test_lookup "Qemu virtual machine" @@ (lookup_subsystem_device_name acc 0x8086 0x7113 0x1af4 0x1100 |> default);
     test_lookup "VGA compatible controller" @@ (lookup_class_name acc 0x0300 |> default);
     test_lookup "VGA controller" @@ (lookup_progif_name acc 0x0300 0x00 |> default);

--- a/ocaml/pci/opam
+++ b/ocaml/pci/opam
@@ -1,25 +1,32 @@
-opam-version: "1.2"
-maintainer:   "simon.beaumont@citrix.com"
-author:       "Si Beaumont"
-homepage:     "https://github.com/simonjbeaumont/ocaml-pci"
-bug-reports:  "https://github.com/simonjbeaumont/ocaml-pci/issues"
-dev-repo:     "https://github.com/simonjbeaumont/ocaml-pci.git"
-
-build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
-build-test: [[ "jbuilder" "runtest" "-p" name "-j" jobs ]]
+opam-version: "2.0"
+synopsis: "Ctypes bindings to libpci for OCaml"
+maintainer: "simon.beaumont@citrix.com"
+authors: "Si Beaumont"
+homepage: "https://github.com/simonjbeaumont/ocaml-pci"
+bug-reports: "https://github.com/simonjbeaumont/ocaml-pci/issues"
 depends: [
+  "ocaml" {>= "4.01.0"}
   "ctypes" {>= "0.4"}
-  "jbuilder" {build}
-  "ounit" {test}
+  "dune" {build}
+  "ounit" {with-test}
 ]
-available: [ocaml-version >= "4.01.0" & os = "linux"]
-depexts: [
-  [["debian"] ["hwdata" "libpci-dev"]]
-  [["ubuntu"] ["hwdata" "libpci-dev"]]
-  [["centos"] ["hwdata" "pciutils-devel"]]
+available: os = "linux"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 post-messages: [
-  "This package requires libpci-dev (>= 3.2.0) to be installed on your system"     {failure & (os = "debian")}
-  "This package requires libpci-dev (>= 3.2.0) to be installed on your system"     {failure & (os = "ubuntu")}
-  "This package requires pciutils-devel (>= 3.2.0) to be installed on your system" {failure & (os = "centos")}
+  "This package requires libpci-dev (>= 3.2.0) to be installed on your system"
+    {failure & os = "debian"}
+  "This package requires libpci-dev (>= 3.2.0) to be installed on your system"
+    {failure & os = "ubuntu"}
+  "This package requires pciutils-devel (>= 3.2.0) to be installed on your system"
+    {failure & os = "centos"}
 ]
+depexts: [
+  ["hwdata" "libpci-dev"] {os-family = "debian"}
+  ["hwdata" "pciutils-dev"] {os-distribution = "alpine"}
+  ["hwdata" "pciutils-devel"] {os-distribution = "centos"}
+  ["hwdata" "pciutil-devel"] {os-distribution = "fedora"}
+]
+dev-repo: "git+https://github.com/simonjbeaumont/ocaml-pci.git"

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -4,15 +4,18 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build: [[ "dune" "build" "-p" name ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
 
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
+  "alcotest" {with-test}
   "gzip"
   "http-svr"
   "ocaml-migrate-parsetree"
-  "ounit"
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "rpclib"

--- a/xapi.opam
+++ b/xapi.opam
@@ -24,7 +24,7 @@ depends: [
   "message-switch-unix"
   "mtime"
   "ocaml-migrate-parsetree"
-  "ounit"
+  "ounit" {with-test} # needed for ocaml-pci
   "pciutil"
   "ppx_deriving_rpc"
   "ppx_sexp_conv"


### PR DESCRIPTION
The PCI tests are not being run, the database tests are not run under opam and the db test  unit_test_sql didn't seem to be run in any case.
Ported the database tests to alcotest so now the ounit dependency can be dropped from xapi.

It's still used to thest ocaml-pci, but that is probably better done upstream, along with the fixes applied in this repo.