### PR TITLE
CP-31118: Avoid xapi as module name in logs

### DIFF
--- a/ocaml/xapi/attach_helpers.ml
+++ b/ocaml/xapi/attach_helpers.ml
@@ -14,7 +14,7 @@
 open Stdext.Pervasiveext
 open Client
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="attach_helpers" end)
 open D
 
 let timeout = 300. (* 5 minutes, should never take this long *)

--- a/ocaml/xapi/config_file_sync.ml
+++ b/ocaml/xapi/config_file_sync.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="config_file_sync" end)
 open D
 
 open Stdext.Xstringext

--- a/ocaml/xapi/fileserver.ml
+++ b/ocaml/xapi/fileserver.ml
@@ -20,7 +20,7 @@ open Http
 open Stdext.Xstringext
 open Stdext.Pervasiveext
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="fileserver" end)
 open D
 
 let escape uri =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -22,7 +22,7 @@ open Server_helpers
 open Client
 open Db_filter_types
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="message_forwarding" end)
 open D
 
 module Audit = Debug.Make(struct let name="audit" end)

--- a/ocaml/xapi/static_vdis.ml
+++ b/ocaml/xapi/static_vdis.ml
@@ -15,7 +15,7 @@
  * @group Storage
 *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="static_vdis" end)
 open D
 
 open Stdext

--- a/ocaml/xapi/vbdops.ml
+++ b/ocaml/xapi/vbdops.ml
@@ -15,7 +15,7 @@
  * @group Storage
 *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="vbdops" end)
 open D
 
 module L = Debug.Make(struct let name="license" end)

--- a/ocaml/xapi/vpx.ml
+++ b/ocaml/xapi/vpx.ml
@@ -1,4 +1,4 @@
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="vpx" end)
 open D
 
 type serverType = XenServer | ESXServer | VirtualCenter | HyperVServer

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
  * GNU Lesser General Public License for more details.
  *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_bond" end)
 open D
 
 open Stdext

--- a/ocaml/xapi/xapi_dr.ml
+++ b/ocaml/xapi/xapi_dr.ml
@@ -17,7 +17,7 @@ open Stdext
 open Listext
 open Threadext
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_dr" end)
 open D
 
 (* -------------------------- VDI caching ----------------------------------- *)

--- a/ocaml/xapi/xapi_dr_task.ml
+++ b/ocaml/xapi/xapi_dr_task.ml
@@ -16,7 +16,7 @@ open Client
 open Stdext
 open Xstringext
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_dr_task" end)
 open D
 
 let make_task ~__context =

--- a/ocaml/xapi/xapi_extensions.ml
+++ b/ocaml/xapi/xapi_extensions.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_extensions" end)
 open D
 
 (* The Xapi_globs.xapi_extensions_root contain scripts which are invoked with

--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -17,7 +17,7 @@
 
 open Stdext
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_fist" end)
 open D
 
 (** {2 (Fill in title!)} *)

--- a/ocaml/xapi/xapi_gpumon.ml
+++ b/ocaml/xapi/xapi_gpumon.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_gpumon" end)
 open D
 
 let gpumon = "xcp-rrdd-gpumon"

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -25,7 +25,7 @@ open Create_misc
 open Network
 open Workload_balancing
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_host" end)
 open D
 
 let set_emergency_mode_error code params = Xapi_globs.emergency_mode_error := Api_errors.Server_error(code, params)

--- a/ocaml/xapi/xapi_host_backup.ml
+++ b/ocaml/xapi/xapi_host_backup.ml
@@ -21,7 +21,7 @@ open Pervasiveext
 open Forkhelpers
 open Helpers
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_host_backup" end)
 open D
 
 let host_backup_handler_core ~__context s =

--- a/ocaml/xapi/xapi_host_crashdump.ml
+++ b/ocaml/xapi/xapi_host_crashdump.ml
@@ -21,7 +21,7 @@ open Pervasiveext
 open Xstringext
 open Xapi_support
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_host_crashdump" end)
 open D
 
 

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -15,7 +15,7 @@
  * @group Host Management
 *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_host_helpers" end)
 open D
 
 open Stdext

--- a/ocaml/xapi/xapi_host_patch.ml
+++ b/ocaml/xapi/xapi_host_patch.ml
@@ -15,7 +15,7 @@
  * @group Host Management
 *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_host_patch" end)
 open D
 
 let destroy ~__context ~self =

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -13,7 +13,7 @@
  *)
 (* Functions to help create HTTP handlers which check the user is properly authenticated. *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_http" end)
 open D
 
 let validate_session __context session_id realm =

--- a/ocaml/xapi/xapi_logs_download.ml
+++ b/ocaml/xapi/xapi_logs_download.ml
@@ -14,7 +14,7 @@
 open Http
 open Forkhelpers
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_logs_download" end)
 open D
 
 let logs_download_handler (req: Request.t) s _ =

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -33,7 +33,7 @@ open Listext
 open Xstringext
 open Threadext
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_message" end)
 open D
 
 let message_dir = Xapi_globs.xapi_blob_location ^ "/messages"

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -16,7 +16,7 @@ open Stdext
 open Pervasiveext
 open Threadext
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_mgmt_iface" end)
 open D
 
 (** Keep track of the management interface server thread *)

--- a/ocaml/xapi/xapi_plugins.ml
+++ b/ocaml/xapi/xapi_plugins.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_plugins" end)
 open D
 
 (* Allow xapi 'plugins' (ie scripts) which can be dropped onto individual host dom0s

--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -18,7 +18,7 @@
 
 open Client
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_pool_patch" end)
 open D
 (** Patches contain their own metadata in XML format. When the signature has been verified
     the patch is executed with argument "info" and it emits XML like the following:

--- a/ocaml/xapi/xapi_pool_transition.ml
+++ b/ocaml/xapi/xapi_pool_transition.ml
@@ -19,7 +19,7 @@ open Stdext
 open Threadext
 open Client
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_pool_transition" end)
 open D
 
 (** Execute scripts in the "master-scripts" dir when changing role from master

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -24,7 +24,7 @@ open Client
 open Stdext.Threadext
 open Unixext
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_pool_update" end)
 open D
 (** Updates contain their own metadata in XML format. When the signature has been verified
     the update is executed with argument "info" and it emits XML like the following:

--- a/ocaml/xapi/xapi_pusb.ml
+++ b/ocaml/xapi/xapi_pusb.ml
@@ -16,7 +16,7 @@ open Stdext
 open Listext
 open Threadext
 open Xapi_pusb_helpers
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_pusb" end)
 open D
 
 let create ~__context ~uSB_group ~host ~other_config ~path

--- a/ocaml/xapi/xapi_sdn_controller.ml
+++ b/ocaml/xapi/xapi_sdn_controller.ml
@@ -14,7 +14,7 @@
 
 open Network
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_sdn_controller" end)
 open D
 
 let db_introduce ~__context ~protocol ~address ~port =

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -18,7 +18,7 @@
 
 (* include Custom_actions.DebugVersion.Session *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_session" end)
 open D
 open Stdext
 open Threadext

--- a/ocaml/xapi/xapi_support.ml
+++ b/ocaml/xapi/xapi_support.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_support" end)
 open D
 
 let support_url = "ftp://support.xensource.com/uploads/"

--- a/ocaml/xapi/xapi_task.ml
+++ b/ocaml/xapi/xapi_task.ml
@@ -15,7 +15,7 @@
  * @group XenAPI functions
 *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_task" end)
 open D
 
 let create ~__context ~label ~description =

--- a/ocaml/xapi/xapi_templates.ml
+++ b/ocaml/xapi/xapi_templates.ml
@@ -22,7 +22,7 @@
     leave the VM in a state such that it comes up properly on subsequent reboots. *)
 
 (** Should make a dummy one of these for in-guest installers: *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_templates" end)
 open D
 
 (** A record which describes a disk provision request *)

--- a/ocaml/xapi/xapi_templates_install.ml
+++ b/ocaml/xapi/xapi_templates_install.ml
@@ -22,7 +22,7 @@ open Forkhelpers
 open Xapi_templates
 open Attach_helpers
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_templates_install" end)
 open D
 
 let is_whitelisted script =

--- a/ocaml/xapi/xapi_tunnel.ml
+++ b/ocaml/xapi/xapi_tunnel.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_tunnel" end)
 open D
 
 open Db_filter_types

--- a/ocaml/xapi/xapi_vif.ml
+++ b/ocaml/xapi/xapi_vif.ml
@@ -15,7 +15,7 @@
 open Stdext
 open Listext
 open Xapi_vif_helpers
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vif" end)
 open D
 
 let assert_operation_valid ~__context ~self ~(op:API.vif_operations) =

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vlan" end)
 open D
 
 (* Dummy MAC used by the VLAN *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -25,7 +25,7 @@ open Xmlrpc_sexpr
  * If VM.{start,resume}_on is supplied another host reference, they will fail.
 *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vm" end)
 open D
 
 exception InvalidOperation of string

--- a/ocaml/xapi/xapi_vm_appliance.ml
+++ b/ocaml/xapi/xapi_vm_appliance.ml
@@ -14,7 +14,7 @@
 
 open Client
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vm_appliance" end)
 open D
 
 module Int64Map = Map.Make(struct type t = int64 let compare = compare end)

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -20,7 +20,7 @@ open Client
 open Pervasiveext
 open Event_types
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vm_clone" end)
 open D
 
 let delete_disks rpc session_id disks =

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -18,7 +18,7 @@
 open Stdext
 open Listext
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vm_lifecycle" end)
 open D
 
 module Rrdd = Rrd_client.Client

--- a/ocaml/xapi/xapi_vm_lifecycle_helpers.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle_helpers.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
  
- module D = Debug.Make(struct let name="xapi" end)
+ module D = Debug.Make(struct let name="xapi_vm_lifecycle_helpers" end)
  open D
  
  (** VM is considered as "live" when it's either Running or Paused, i.e. with a live domain *)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -24,7 +24,7 @@ open Stdext
 open Pervasiveext
 open Threadext
 
-module DD=Debug.Make(struct let name="xapi" end)
+module DD=Debug.Make(struct let name="xapi_vm_migrate" end)
 open DD
 
 module SMPERF=Debug.Make(struct let name="SMPERF" end)

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -18,7 +18,7 @@
 
 open Client
 open Stdext.Listext
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vm_snapshot" end)
 open D
 
 (*************************************************************************************************)

--- a/ocaml/xapi/xapi_vmpp.ml
+++ b/ocaml/xapi/xapi_vmpp.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vmpp" end)
 open D
 
 let raise_removed () =

--- a/ocaml/xapi/xapi_vmss.ml
+++ b/ocaml/xapi/xapi_vmss.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vmss" end)
 open D
 
 open Map_check

--- a/ocaml/xapi/xapi_vncsnapshot.ml
+++ b/ocaml/xapi/xapi_vncsnapshot.ml
@@ -15,7 +15,7 @@
 open Http
 open Forkhelpers
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vncsnapshot" end)
 open D
 
 let vncsnapshot = "/usr/bin/vncsnapshot"

--- a/ocaml/xapi/xapi_vusb.ml
+++ b/ocaml/xapi/xapi_vusb.ml
@@ -14,7 +14,7 @@
 
 open Stdext
 open Threadext
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xapi_vusb" end)
 open D
 
 let m = Mutex.create ()

--- a/ocaml/xapi/xha_metadata_vdi.ml
+++ b/ocaml/xapi/xha_metadata_vdi.ml
@@ -15,7 +15,7 @@
  * @group High Availability (HA)
 *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xha_metadata_vdi" end)
 open D
 
 open Client

--- a/ocaml/xapi/xha_statefile.ml
+++ b/ocaml/xapi/xha_statefile.ml
@@ -15,7 +15,7 @@
  * @group High Availability (HA)
 *)
 
-module D = Debug.Make(struct let name="xapi" end)
+module D = Debug.Make(struct let name="xha_statefile" end)
 open D
 
 (** Reason associated with the static VDI attach, to help identify these later *)


### PR DESCRIPTION
Instead use the filename as is more informative to locate the code that
produces the loglines.

This changes the modules that were missed by
44a0cfcc09198b8273f908c93d0ff18c6b2d6b5c

The change was generated by running

```
$ for file in (rg --files-with-matches -F "Debug.Make(struct let name=\"xapi\" end)")
      set filename (echo (basename (string split -r -m1 . $file)[1]))
      sed -i "s/name=\"xapi\"/name=\"$filename\"/g" "$file"
  end
```