### PR TITLE
CA-337929 remove gencert xapi-wait-init-complete dependency

### DIFF
--- a/scripts/gencert.service
+++ b/scripts/gencert.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Generate xapi ssl certificate
-Requires=xapi.service forkexecd.service xapi-init-complete.target
-After=xapi.service forkexecd.service xapi-init-complete.target
+Requires=forkexecd.service
+After=forkexecd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
stunnel@xapi.service depends on gencert, so if the
xapi-wait-init-complete service fails, it takes 4 minutes for stunnel to
start. This was seen when rebooting slaves, but is easily fixed by
removing this dependency