### PR TITLE
CA-337903 xapi-domains requires stunnel

### DIFF
--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -15,6 +15,7 @@ After=xcp-networkd.service
 After=xcp-rrdd.service
 After=xenopsd-xc.service
 After=xenstored.service
+After=stunnel@xapi.service
 
 Conflicts=shutdown.target
 


### PR DESCRIPTION
Stunnel is required to start/stop domains on slaves.

Fixes CA-337894 (and other related bugs).

Signed-off-by: lippirk <ben.anson@citrix.com>