### PR TITLE
Bump schema for REQ-453

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 600
+let schema_minor_vsn = 601
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5


### PR DESCRIPTION
This is needed since the original schema bump done for REQ-453 was invalidated by the merge for REQ-811.