### PR TITLE
CP-33121: Remove Stdext.monadic usages

### DIFF
--- a/ocaml/database/database_test.ml
+++ b/ocaml/database/database_test.ml
@@ -11,7 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open Xapi_stdext_monadic
 open Xapi_stdext_unix
 
 let name_label = "name__label"
@@ -110,7 +109,11 @@ module Tests = functor(Client: Db_interface.DB_ACCESS) -> struct
         try Some (Client.read_field t tblname name_label real_ref)
         with _ -> None in
       if name_label' <> real_name_label
-      then failwith (Printf.sprintf "check_ref_index %s key %s: ref_index name_label = %s; db has %s" tblname key (Opt.default "None" name_label') (Opt.default "None" real_name_label))
+      then failwith (Printf.sprintf
+          "check_ref_index %s key %s: ref_index name_label = %s; db has %s"
+          tblname key
+          (Option.value ~default:"None" name_label')
+          (Option.value ~default:"None" real_name_label))
 
 
   open Xapi_stdext_pervasives

--- a/ocaml/database/dune
+++ b/ocaml/database/dune
@@ -21,7 +21,6 @@
     gzip
     uuid
     xapi-stdext-encodings
-    xapi-stdext-monadic
     xapi-stdext-pervasives
     xapi-stdext-std
     xapi-stdext-threads

--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -14,7 +14,6 @@
 open Xapi_stdext_pervasives.Pervasiveext
 open Xapi_stdext_threads.Threadext
 open Xapi_stdext_std.Xstringext
-open Xapi_stdext_monadic
 open Xapi_stdext_unix
 
 module R = Debug.Make(struct let name = "redo_log" end)
@@ -103,7 +102,7 @@ let cannot_connect_fn log =
   if !(log.currently_accessible) then begin
     R.debug "Signalling unable to access redo log";
     Event.sync (Event.send redo_log_events (log.name, false));
-    Opt.iter (fun callback -> callback false) log.state_change_callback
+    Option.iter (fun callback -> callback false) log.state_change_callback
   end;
   log.currently_accessible := false
 
@@ -111,7 +110,7 @@ let can_connect_fn log =
   if not !(log.currently_accessible) then begin
     R.debug "Signalling redo log is healthy";
     Event.sync (Event.send redo_log_events (log.name, true));
-    Opt.iter (fun callback -> callback true) log.state_change_callback
+    Option.iter (fun callback -> callback true) log.state_change_callback
   end;
   log.currently_accessible := true
 
@@ -784,7 +783,7 @@ let database_callback event db =
       else None
   in
 
-  Opt.iter (fun entry ->
+  Option.iter (fun entry ->
       with_active_redo_logs (fun log ->
           write_delta (Db_cache_types.Manifest.generation (Db_cache_types.Database.manifest db)) entry
             (fun () ->

--- a/ocaml/database/ref_index.ml
+++ b/ocaml/database/ref_index.ml
@@ -23,7 +23,7 @@ type indexrec = {
   _ref:string
 }
 let string_of (x: indexrec) =
-  Printf.sprintf "%s%s" x.uuid (Option.value ~default:"" (Option.map (fun name -> Printf.sprintf " (%s)" name) x.name_label))
+  Printf.sprintf "%s%s" x.uuid (Option.fold ~none:"" ~some:(fun name -> Printf.sprintf " (%s)" name) x.name_label)
 
 let lookup key =
   let t = Db_backend.make () in

--- a/ocaml/database/ref_index.ml
+++ b/ocaml/database/ref_index.ml
@@ -16,7 +16,6 @@
    on a slave -- so don't ever call them on slaves! :) *)
 
 open Db_cache_types
-open Xapi_stdext_monadic
 
 type indexrec = {
   name_label:string option;
@@ -24,7 +23,7 @@ type indexrec = {
   _ref:string
 }
 let string_of (x: indexrec) =
-  Printf.sprintf "%s%s" x.uuid (Opt.default "" (Opt.map (fun name -> Printf.sprintf " (%s)" name) x.name_label))
+  Printf.sprintf "%s%s" x.uuid (Option.value ~default:"" (Option.map (fun name -> Printf.sprintf " (%s)" name) x.name_label))
 
 let lookup key =
   let t = Db_backend.make () in
@@ -35,6 +34,4 @@ let lookup key =
       uuid = Schema.Value.Unsafe_cast.string (Row.find Db_names.uuid row);
       _ref = Schema.Value.Unsafe_cast.string (Row.find Db_names.ref row);
     } in
-  Opt.map r (Database.lookup_key key db)
-
-
+  Option.map r (Database.lookup_key key db)

--- a/ocaml/doc/dune
+++ b/ocaml/doc/dune
@@ -4,7 +4,9 @@
   (libraries
    xapi-datamodel
    xapi-consts
-   stdext
+   xapi-stdext-pervasives
+   xapi-stdext-std
+   xapi-stdext-unix
    uuid
    gzip
    mustache

--- a/ocaml/doc/jsapi.ml
+++ b/ocaml/doc/jsapi.ml
@@ -12,9 +12,9 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Stdext
-open Xstringext
-open Pervasiveext
+open Xapi_stdext_std.Xstringext
+open Xapi_stdext_pervasives.Pervasiveext
+module Unixext = Xapi_stdext_unix.Unixext
 open Datamodel
 open Datamodel_types
 
@@ -39,12 +39,12 @@ let generate_files api_dir =
     let name = obj.name in
     let s = Jsonrpc.to_string (rpc_of_obj obj) in
     let fname = name ^ ".json" in
-    Stdext.Unixext.write_string_to_file (Filename.concat api_dir fname) ("clsdoc = " ^ s);
+    Unixext.write_string_to_file (Filename.concat api_dir fname) ("clsdoc = " ^ s);
     name
   in
   let names = List.map create_json objs in
   let class_list = String.concat ", " (List.map (fun s -> "'" ^ s ^ "'") names) in
-  Stdext.Unixext.write_string_to_file (Filename.concat api_dir "index.json") ("classes = [" ^ class_list ^ "]");
+  Unixext.write_string_to_file (Filename.concat api_dir "index.json") ("classes = [" ^ class_list ^ "]");
 
 
   let changes_in_release rel =
@@ -85,11 +85,11 @@ let generate_files api_dir =
     in
     let release_info = String.concat ", " (List.map search_obj objs) in
     let fname = (code_name_of_release rel) ^ ".json" in
-    Stdext.Unixext.write_string_to_file (Filename.concat api_dir fname) ("release_info = [" ^ release_info ^ "]")
+    Unixext.write_string_to_file (Filename.concat api_dir fname) ("release_info = [" ^ release_info ^ "]")
   in
   List.iter changes_in_release release_order;
   let release_list = String.concat ", " (List.map (fun s -> "'" ^ (code_name_of_release s) ^ "'") release_order) in
-  Stdext.Unixext.write_string_to_file (Filename.concat api_dir "releases.json") ("releases = [" ^ release_list ^ "]")
+  Unixext.write_string_to_file (Filename.concat api_dir "releases.json") ("releases = [" ^ release_list ^ "]")
 
 let json_releases =
   let json_of_rel x = `O [
@@ -102,7 +102,7 @@ let json_releases =
   `O [ "releases", `A (List.map json_of_rel release_order) ]
 
 let render_template template_file json output_file =
-  let templ =  Stdext.Unixext.string_of_file template_file |> Mustache.of_string in
+  let templ =  Unixext.string_of_file template_file |> Mustache.of_string in
   let rendered = Mustache.render templ json in
   let out_chan = open_out output_file in
   finally (fun () -> output_string out_chan rendered)
@@ -113,7 +113,7 @@ let _ =
   parse_args ();
 
   let api_dir = Filename.concat !destdir "api" in
-  Stdext.Unixext.mkdir_rec api_dir 0o755;
+  Unixext.mkdir_rec api_dir 0o755;
 
   generate_files api_dir;
 

--- a/ocaml/idl/datamodel_schema.ml
+++ b/ocaml/idl/datamodel_schema.ml
@@ -43,7 +43,7 @@ let of_datamodel () =
       default =
         if issetref
         then Some (Value.Set [])
-        else Xapi_stdext_monadic.Opt.map Datamodel_values.to_db f.Datamodel_types.default_value ;
+        else Option.map Datamodel_values.to_db f.Datamodel_types.default_value ;
       ty = ty;
       issetref = issetref;
     } in

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -27,7 +27,6 @@
    xapi-consts
    xapi-database
    xapi-stdext-date
-   xapi-stdext-monadic
    xapi-stdext-std
    xapi-stdext-unix
   )

--- a/ocaml/quicktest/dune
+++ b/ocaml/quicktest/dune
@@ -9,7 +9,6 @@
     xapi_internal
     xapi-consts
     xapi-stdext-date
-    xapi-stdext-monadic
     xapi-stdext-pervasives
     xapi-stdext-std
     xapi-stdext-threads

--- a/ocaml/quicktest/quicktest_vm_import_export.ml
+++ b/ocaml/quicktest/quicktest_vm_import_export.ml
@@ -5,9 +5,9 @@ let name_of_sr rpc session_id self =
   Client.Client.SR.get_name_label ~rpc ~session_id ~self
 
 let vm_import ?(metadata_only=false) ?(preserve=false) ?sr rpc session_id filename =
-  let sr_uuid = Xapi_stdext_monadic.Opt.map (fun sr -> Client.Client.SR.get_uuid rpc session_id sr) sr in
+  let sr_uuid = Option.map (fun sr -> Client.Client.SR.get_uuid rpc session_id sr) sr in
   let args = [ "vm-import"; "filename=" ^ filename ] in
-  let args = args @ (Xapi_stdext_monadic.Opt.default [] (Xapi_stdext_monadic.Opt.map (fun x -> [ "sr-uuid=" ^ x ]) sr_uuid)) in
+  let args = args @ (Option.value ~default:[] (Option.map (fun x -> [ "sr-uuid=" ^ x ]) sr_uuid)) in
   let args = if metadata_only then args @ [ "metadata=true" ] else args in
   let args = if preserve then args @ [ "preserve=true" ] else args in
   let newvm_uuids = String.split_on_char ',' (Qt.cli_cmd args) in

--- a/ocaml/quicktest/quicktest_vm_import_export.ml
+++ b/ocaml/quicktest/quicktest_vm_import_export.ml
@@ -7,7 +7,7 @@ let name_of_sr rpc session_id self =
 let vm_import ?(metadata_only=false) ?(preserve=false) ?sr rpc session_id filename =
   let sr_uuid = Option.map (fun sr -> Client.Client.SR.get_uuid rpc session_id sr) sr in
   let args = [ "vm-import"; "filename=" ^ filename ] in
-  let args = args @ (Option.value ~default:[] (Option.map (fun x -> [ "sr-uuid=" ^ x ]) sr_uuid)) in
+  let args = args @ (Option.fold ~none:[] ~some:(fun x -> [ "sr-uuid=" ^ x ]) sr_uuid) in
   let args = if metadata_only then args @ [ "metadata=true" ] else args in
   let args = if preserve then args @ [ "preserve=true" ] else args in
   let newvm_uuids = String.split_on_char ',' (Qt.cli_cmd args) in

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -4,7 +4,14 @@
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29-52))
   (libraries
     alcotest
+    astring
+    fmt
     xapi_internal
+    xapi-stdext-date
+    xapi-stdext-std
+    xapi-stdext-threads
+    xapi-stdext-unix
+    xapi-test-utils
   )
   (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
   (deps (source_tree test_data))

--- a/ocaml/tests/test_bios_strings.ml
+++ b/ocaml/tests/test_bios_strings.ml
@@ -2,7 +2,7 @@
  *)
 open Bios_strings
 
-let load_test_data file = Stdext.Unixext.string_of_file @@ "test_data/" ^ file
+let load_test_data file = Xapi_stdext_unix.Unixext.string_of_file @@ "test_data/" ^ file
 
 let baseboard_two_string = load_test_data "bios_baseboard_two.dmidecode"
 

--- a/ocaml/tests/test_common.ml
+++ b/ocaml/tests/test_common.ml
@@ -467,7 +467,7 @@ let make_client_params ~__context =
   let rpc = Api_server.Server.dispatch_call req Unix.stdout in
   let session_id =
     let session_id = Ref.make () in
-    let now = Stdext.Date.of_float (Unix.time ()) in
+    let now = Xapi_stdext_date.Date.of_float (Unix.time ()) in
     let _: _ API.Ref.t = make_session ~__context ~ref:session_id ~this_host:(Helpers.get_localhost ~__context) ~last_active:now ~is_local_superuser:true ~validation_time:now ~auth_user_name:"root" ~originator:"test" () in
     session_id
   in

--- a/ocaml/tests/test_event.ml
+++ b/ocaml/tests/test_event.ml
@@ -14,11 +14,10 @@
 
 open Test_common
 open Event_types
-open Stdext
-open Threadext
+open Xapi_stdext_threads.Threadext
 
 let event_setup_common = Test_event_common.event_setup_common
-  
+
 let test_event_from_ev () =
   (* Test that creating an object generates an event for that object *)
   let __context, session_id = event_setup_common () in

--- a/ocaml/tests/test_guest_agent.ml
+++ b/ocaml/tests/test_guest_agent.ml
@@ -36,8 +36,7 @@ module Networks = Generic.MakeStateless (struct
           T(root, (add_path_to_tree (T(node, [])) rest_of_path) :: children)
 
     let construct_tree tree path =
-      let open Stdext.Xstringext in
-      let nodes = String.split_f (fun s -> s = '/') path in
+      let nodes = Xapi_stdext_std.Xstringext.String.split_f (fun s -> s = '/') path in
       add_path_to_tree tree nodes
 
     let rec list_helper children = function
@@ -49,8 +48,7 @@ module Networks = Generic.MakeStateless (struct
         with Not_found -> []
 
     let list (T(root, children)) path =
-      let open Stdext.Xstringext in
-      let nodes = String.split_f (fun s -> s = '/') path in
+      let nodes = Xapi_stdext_std.Xstringext.String.split_f (fun s -> s = '/') path in
       list_helper children nodes
 
 
@@ -213,8 +211,7 @@ module Initial_guest_metrics = Generic.MakeStateless (struct
              Mt(root, (add_leaf_to_mtree rest_paths leaf_value (Mt(node, []))) :: children))
 
     let construct_mtree mtree (path, leaf_value) =
-      let open Stdext.Xstringext in
-      let nodes = String.split_f (fun s -> s = '/') path in
+      let nodes = Xapi_stdext_std.Xstringext.String.split_f (fun s -> s = '/') path in
       add_leaf_to_mtree nodes leaf_value mtree
 
     let rec list_helper children = function
@@ -230,9 +227,8 @@ module Initial_guest_metrics = Generic.MakeStateless (struct
       match mtree with
       | Lf (_, _) -> []
       | Mt (_, children) ->
-        let open Stdext.Xstringext in
-        let paths = String.split_f (fun s -> s = '/') path in
-        list_helper children paths
+        let nodes = Xapi_stdext_std.Xstringext.String.split_f (fun s -> s = '/') path in
+        list_helper children nodes
 
     let rec lookup_helper mtree = function
       | [] ->
@@ -248,9 +244,8 @@ module Initial_guest_metrics = Generic.MakeStateless (struct
            with Not_found -> None)
 
     let lookup mtree path =
-        let open Stdext.Xstringext in
-        let paths = String.split_f (fun s -> s = '/') path in
-        lookup_helper mtree paths
+        let nodes = Xapi_stdext_std.Xstringext.String.split_f (fun s -> s = '/') path in
+        lookup_helper mtree nodes
 
 
     let transform input =

--- a/ocaml/tests/test_helpers.ml
+++ b/ocaml/tests/test_helpers.ml
@@ -14,7 +14,6 @@
 
 open Test_common
 open Test_highlevel
-open Stdext
 
 type pif = {device: string; management: bool; other_config: (string * string) list}
 
@@ -54,13 +53,13 @@ module DetermineGateway = Generic.MakeStateful(struct
                                              ) pifs
 
                                          let extract_output __context (_, mgmt) =
-                                           let management_interface = Stdext.Opt.map (fun device ->
+                                           let management_interface = Option.map (fun device ->
                                                let open Db_filter_types in
                                                let pifs = Db.PIF.get_refs_where ~__context ~expr:(Eq (Field "device", Literal device)) in
                                                List.hd pifs
                                              ) mgmt in
                                            let gateway, dns = Helpers.determine_gateway_and_dns_ifs ~__context ?management_interface () in
-                                           let get_device = Stdext.Opt.map (fun (self, _) -> Db.PIF.get_device ~__context ~self) in
+                                           let get_device = Option.map (fun (self, _) -> Db.PIF.get_device ~__context ~self) in
                                            get_device gateway,
                                            get_device dns
 
@@ -109,45 +108,46 @@ module DetermineGateway = Generic.MakeStateful(struct
                                          ]
                                        end)
 
+let string_of_unit_result = Fmt.(str "%a" Dump.(result ~ok:(any "()") ~error:exn))
+
 module PortCheckers = Generic.MakeStateless (struct
     module Io = struct
       type input_t = (int * string)
-      type output_t = (exn, unit) Either.t
+      type output_t = (unit, exn) result
 
-      let string_of_input_t = Test_printers.(pair int string)
-      let string_of_output_t = Test_printers.(either exn unit)
+      let string_of_input_t = Fmt.(str "%a" Dump.(pair int string))
+      let string_of_output_t = string_of_unit_result
     end
 
     open Api_errors
-    open Either
 
     let transform (port, name) =
       try
-        Right (Helpers.assert_is_valid_tcp_udp_port ~port ~name)
+        Ok (Helpers.assert_is_valid_tcp_udp_port ~port ~name)
       with e ->
-        Left e
+        Error e
 
     let tests = `QuickAndAutoDocumented [
       (-22, "myport"),
-      left (Server_error
+      Error (Server_error
               (value_not_supported,
                ["myport"; "-22"; "Port out of range"]));
       (0, "myport"),
-      left (Server_error
+      Error (Server_error
               (value_not_supported,
                ["myport"; "0"; "Port out of range"]));
       (1, "myport"),
-      Right ();
+      Ok ();
       (1234, "myport"),
-      Right ();
+      Ok ();
       (65535, "myport"),
-      Right ();
+      Ok ();
       (65536, "myport"),
-      left (Server_error
+      Error (Server_error
               (value_not_supported,
                ["myport"; "65536"; "Port out of range"]));
       (123456, "myport"),
-      left (Server_error
+      Error (Server_error
               (value_not_supported,
                ["myport"; "123456"; "Port out of range"]));
     ]
@@ -156,41 +156,40 @@ module PortCheckers = Generic.MakeStateless (struct
 module PortRangeCheckers = Generic.MakeStateless (struct
     module Io = struct
       type input_t = ((int * string) * (int * string))
-      type output_t = (exn, unit) Either.t
+      type output_t = (unit, exn) result
 
       let string_of_input_t =
-        Test_printers.(pair (pair int string) (pair int string))
-      let string_of_output_t = Test_printers.(either exn unit)
+        Fmt.(str "%a" Dump.(pair (pair int string) (pair int string)))
+      let string_of_output_t = string_of_unit_result
     end
 
     open Api_errors
-    open Either
 
     let transform ((first_port, first_name), (last_port, last_name)) =
       try
-        Right (Helpers.assert_is_valid_tcp_udp_port_range
+        Ok (Helpers.assert_is_valid_tcp_udp_port_range
                  ~first_port ~first_name ~last_port ~last_name)
-      with e -> Left e
+      with e -> Error e
 
     let tests = `QuickAndAutoDocumented [
       ((-22, "first_port"), (1234, "last_port")),
-      left (Server_error
+      Error (Server_error
               (value_not_supported,
                ["first_port"; "-22"; "Port out of range"]));
       ((1, "first_port"), (1234, "last_port")),
-      Right ();
+      Ok ();
       ((1234, "first_port"), (1234, "last_port")),
-      Right ();
+      Ok ();
       ((1234, "first_port"), (5678, "last_port")),
-      Right ();
+      Ok ();
       ((1234, "first_port"), (65535, "last_port")),
-      Right ();
+      Ok ();
       ((1234, "first_port"), (123456, "last_port")),
-      Left (Server_error
+      Error (Server_error
               (value_not_supported,
                ["last_port"; "123456"; "Port out of range"]));
       ((5678, "first_port"), (1234, "last_port")),
-      Left (Server_error
+      Error (Server_error
               (value_not_supported,
                ["last_port"; "1234"; "last_port smaller than first_port"]));
     ]
@@ -199,88 +198,86 @@ module PortRangeCheckers = Generic.MakeStateless (struct
 module IPCheckers = Generic.MakeStateless (struct
     module Io = struct
       type input_t = [`ipv4 | `ipv6] * string * string
-      type output_t = (exn, unit) Either.t
+      type output_t = (unit, exn) result
 
       let string_of_input_t =
         let open Test_printers in
         let kind : [`ipv4 | `ipv6] printer = function `ipv4 -> "IPv4" | `ipv6 -> "IPv6" in
         tuple3 kind string string
 
-      let string_of_output_t = Test_printers.(either exn unit)
+      let string_of_output_t = string_of_unit_result
     end
 
-    open Either
     open Api_errors
 
     let transform (kind, field, address) =
       try
-        Right (Helpers.assert_is_valid_ip kind field address)
+        Ok (Helpers.assert_is_valid_ip kind field address)
       with e ->
-        Left e
+        Error e
 
     let tests = `QuickAndAutoDocumented [
-      (`ipv4, "address", "192.168.0.1"), (Right ());
-      (`ipv4, "address", "255.255.255.0"), (Right ());
-      (`ipv4, "address1", ""), (Left (Server_error(invalid_ip_address_specified, ["address1"])));
-      (`ipv4, "address2", "192.168.0.300"), (Left (Server_error(invalid_ip_address_specified, ["address2"])));
-      (`ipv4, "address3", "192.168.0"), (Left (Server_error(invalid_ip_address_specified, ["address3"])));
-      (`ipv4, "address4", "bad-address"), (Left (Server_error(invalid_ip_address_specified, ["address4"])));
-      (`ipv6, "address5", "192.168.0.1"), (Left (Server_error(invalid_ip_address_specified, ["address5"])));
+      (`ipv4, "address", "192.168.0.1"), (Ok ());
+      (`ipv4, "address", "255.255.255.0"), (Ok ());
+      (`ipv4, "address1", ""), (Error (Server_error(invalid_ip_address_specified, ["address1"])));
+      (`ipv4, "address2", "192.168.0.300"), (Error (Server_error(invalid_ip_address_specified, ["address2"])));
+      (`ipv4, "address3", "192.168.0"), (Error (Server_error(invalid_ip_address_specified, ["address3"])));
+      (`ipv4, "address4", "bad-address"), (Error (Server_error(invalid_ip_address_specified, ["address4"])));
+      (`ipv6, "address5", "192.168.0.1"), (Error (Server_error(invalid_ip_address_specified, ["address5"])));
 
-      (`ipv6, "address", "fe80::bae8:56ff:fe29:894a"), (Right ());
-      (`ipv6, "address", "fe80:0000:0000:0000:bae8:56ff:fe29:894a"), (Right ());
-      (`ipv6, "address", "::1"), (Right ());
-      (`ipv6, "address1", ""), (Left (Server_error(invalid_ip_address_specified, ["address1"])));
-      (`ipv6, "address2", "fe80:0000:0000:0000:bae8:56ff:fe29:894a:0000"), (Left (Server_error(invalid_ip_address_specified, ["address2"])));
-      (`ipv6, "address3", "bad-address"), (Left (Server_error(invalid_ip_address_specified, ["address3"])));
-      (`ipv4, "address4", "fe80::bae8:56ff:fe29:894a"), (Left (Server_error(invalid_ip_address_specified, ["address4"])));
-      (`ipv6, "address5", "ze80::bae8:56ff:fe29:894a"), (Left (Server_error(invalid_ip_address_specified, ["address5"])));
+      (`ipv6, "address", "fe80::bae8:56ff:fe29:894a"), (Ok ());
+      (`ipv6, "address", "fe80:0000:0000:0000:bae8:56ff:fe29:894a"), (Ok ());
+      (`ipv6, "address", "::1"), (Ok ());
+      (`ipv6, "address1", ""), (Error (Server_error(invalid_ip_address_specified, ["address1"])));
+      (`ipv6, "address2", "fe80:0000:0000:0000:bae8:56ff:fe29:894a:0000"), (Error (Server_error(invalid_ip_address_specified, ["address2"])));
+      (`ipv6, "address3", "bad-address"), (Error (Server_error(invalid_ip_address_specified, ["address3"])));
+      (`ipv4, "address4", "fe80::bae8:56ff:fe29:894a"), (Error (Server_error(invalid_ip_address_specified, ["address4"])));
+      (`ipv6, "address5", "ze80::bae8:56ff:fe29:894a"), (Error (Server_error(invalid_ip_address_specified, ["address5"])));
     ]
   end)
 
 module CIDRCheckers = Generic.MakeStateless (struct
     module Io = struct
       type input_t = [`ipv4 | `ipv6] * string * string
-      type output_t = (exn, unit) Either.t
+      type output_t = (unit, exn) result
 
       let string_of_input_t =
         let open Test_printers in
         let kind : [`ipv4 | `ipv6] printer = function `ipv4 -> "IPv4" | `ipv6 -> "IPv6" in
         tuple3 kind string string
 
-      let string_of_output_t = Test_printers.(either exn unit)
+      let string_of_output_t = string_of_unit_result
     end
 
-    open Either
     open Api_errors
 
     let transform (kind, field, cidr) =
       try
-        Right (Helpers.assert_is_valid_cidr kind field cidr)
+        Ok (Helpers.assert_is_valid_cidr kind field cidr)
       with e ->
-        Left e
+        Error e
 
     let tests = `QuickAndAutoDocumented [
-      (`ipv4, "address", "192.168.0.1/24"), (Right ());
-      (`ipv4, "address", "255.255.255.0/32"), (Right ());
-      (`ipv4, "address1", ""), (Left (Server_error(invalid_cidr_address_specified, ["address1"])));
-      (`ipv4, "address1", "192.168.0.2"), (Left (Server_error(invalid_cidr_address_specified, ["address1"])));
-      (`ipv4, "address1", "192.168.0.2/33"), (Left (Server_error(invalid_cidr_address_specified, ["address1"])));
-      (`ipv4, "address1", "192.168.0.2/x"), (Left (Server_error(invalid_cidr_address_specified, ["address1"])));
-      (`ipv4, "address2", "192.168.0.300/10"), (Left (Server_error(invalid_cidr_address_specified, ["address2"])));
-      (`ipv4, "address3", "192.168.0/20"), (Left (Server_error(invalid_cidr_address_specified, ["address3"])));
-      (`ipv4, "address4", "bad-address/24"), (Left (Server_error(invalid_cidr_address_specified, ["address4"])));
-      (`ipv6, "address5", "192.168.0.1/24"), (Left (Server_error(invalid_cidr_address_specified, ["address5"])));
+      (`ipv4, "address", "192.168.0.1/24"), (Ok ());
+      (`ipv4, "address", "255.255.255.0/32"), (Ok ());
+      (`ipv4, "address1", ""), (Error (Server_error(invalid_cidr_address_specified, ["address1"])));
+      (`ipv4, "address1", "192.168.0.2"), (Error (Server_error(invalid_cidr_address_specified, ["address1"])));
+      (`ipv4, "address1", "192.168.0.2/33"), (Error (Server_error(invalid_cidr_address_specified, ["address1"])));
+      (`ipv4, "address1", "192.168.0.2/x"), (Error (Server_error(invalid_cidr_address_specified, ["address1"])));
+      (`ipv4, "address2", "192.168.0.300/10"), (Error (Server_error(invalid_cidr_address_specified, ["address2"])));
+      (`ipv4, "address3", "192.168.0/20"), (Error (Server_error(invalid_cidr_address_specified, ["address3"])));
+      (`ipv4, "address4", "bad-address/24"), (Error (Server_error(invalid_cidr_address_specified, ["address4"])));
+      (`ipv6, "address5", "192.168.0.1/24"), (Error (Server_error(invalid_cidr_address_specified, ["address5"])));
 
-      (`ipv6, "address", "fe80::bae8:56ff:fe29:894a/64"), (Right ());
-      (`ipv6, "address", "fe80:0000:0000:0000:bae8:56ff:fe29:894a/80"), (Right ());
-      (`ipv6, "address", "::1/128"), (Right ());
-      (`ipv6, "address1", ""), (Left (Server_error(invalid_cidr_address_specified, ["address1"])));
-      (`ipv6, "address2", "fe80::bae8:56ff:fe29:894a:0000/129"), (Left (Server_error(invalid_cidr_address_specified, ["address2"])));
-      (`ipv6, "address2", "fe80::bae8:56ff:fe29:894a:0000"), (Left (Server_error(invalid_cidr_address_specified, ["address2"])));
-      (`ipv6, "address3", "bad-address/64"), (Left (Server_error(invalid_cidr_address_specified, ["address3"])));
-      (`ipv4, "address4", "fe80::bae8:56ff:fe29:894a/64"), (Left (Server_error(invalid_cidr_address_specified, ["address4"])));
-      (`ipv6, "address5", "ze80::bae8:56ff:fe29:894a/64"), (Left (Server_error(invalid_cidr_address_specified, ["address5"])));
+      (`ipv6, "address", "fe80::bae8:56ff:fe29:894a/64"), (Ok ());
+      (`ipv6, "address", "fe80:0000:0000:0000:bae8:56ff:fe29:894a/80"), (Ok ());
+      (`ipv6, "address", "::1/128"), (Ok ());
+      (`ipv6, "address1", ""), (Error (Server_error(invalid_cidr_address_specified, ["address1"])));
+      (`ipv6, "address2", "fe80::bae8:56ff:fe29:894a:0000/129"), (Error (Server_error(invalid_cidr_address_specified, ["address2"])));
+      (`ipv6, "address2", "fe80::bae8:56ff:fe29:894a:0000"), (Error (Server_error(invalid_cidr_address_specified, ["address2"])));
+      (`ipv6, "address3", "bad-address/64"), (Error (Server_error(invalid_cidr_address_specified, ["address3"])));
+      (`ipv4, "address4", "fe80::bae8:56ff:fe29:894a/64"), (Error (Server_error(invalid_cidr_address_specified, ["address4"])));
+      (`ipv6, "address5", "ze80::bae8:56ff:fe29:894a/64"), (Error (Server_error(invalid_cidr_address_specified, ["address5"])));
     ]
   end)
 

--- a/ocaml/tests/test_host.ml
+++ b/ocaml/tests/test_host.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Stdext
 open Test_common
 
 module D=Debug.Make(struct let name="test_xapi_xenops" end)

--- a/ocaml/tests/test_network_event_loop.ml
+++ b/ocaml/tests/test_network_event_loop.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Stdext
+module Threadext = Xapi_stdext_threads.Threadext
 
 let test_network_event_loop ~no_nbd_networks_at_start () =
   let __context, _ = Test_event_common.event_setup_common () in

--- a/ocaml/tests/test_pgpu_helpers.ml
+++ b/ocaml/tests/test_pgpu_helpers.ml
@@ -12,8 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Stdext
-open Either
 open Test_common
 open Test_highlevel
 open Test_vgpu_common

--- a/ocaml/tests/test_platformdata.ml
+++ b/ocaml/tests/test_platformdata.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Stdext
 open Test_highlevel
 
 let firmware_type_printer v =
@@ -24,7 +23,7 @@ let uefi = Xenops_types.Vm.Uefi Xenops_types.Nvram_uefi_variables.default_t
 module SanityCheck = Generic.MakeStateless(struct
     module Io = struct
       type input_t = ((string * string) list * Xenops_types.Vm.firmware_type option * bool * int64 * int64 * [ `hvm | `pv | `pv_in_pvh ])
-      type output_t = (exn, (string * string) list) Either.t
+      type output_t = ((string * string) list, exn) result
 
       let string_of_input_t (platformdata, firmware, filter, vcpu_max, vcpu_startup, domain_type) =
         Printf.sprintf "(platformdata = %s, firmware = %s, filter_out_unknowns = %b, vcpu_max = %Ld,
@@ -33,13 +32,16 @@ module SanityCheck = Generic.MakeStateless(struct
           (firmware |> Test_printers.option firmware_type_printer)
           (filter) (vcpu_max) (vcpu_startup) (Record_util.domain_type_to_string domain_type)
 
-      let string_of_output_t = Test_printers.(either exn (assoc_list string string))
+      let pp_list_assoc fmt_fst fmt_snd =
+        Fmt.(Dump.list @@ pair ~sep:(any "=") fmt_fst fmt_snd)
+      let string_of_output_t x =
+        Fmt.(str "%a" Dump.(result ~ok:(pp_list_assoc string string) ~error:exn) x)
     end
 
     let transform (platformdata, firmware, filter_out_unknowns, vcpu_max, vcpu_at_startup, domain_type) =
-      try Either.Right (Vm_platform.sanity_check ~platformdata ?firmware ~vcpu_max
+      try Ok (Vm_platform.sanity_check ~platformdata ?firmware ~vcpu_max
         ~vcpu_at_startup ~domain_type ~filter_out_unknowns)
-      with e -> Either.Left e
+      with e -> Error e
 
     let tests =
       let usb_defaults = [
@@ -48,7 +50,7 @@ module SanityCheck = Generic.MakeStateless(struct
       ] in
       let make_firmware_ok dm firmware =
         ((["device-model", dm], firmware, false, 0L, 0L, `hvm),
-         Either.Right (usb_defaults @ ["device-model", dm]))
+         Ok (usb_defaults @ ["device-model", dm]))
       in
       let open Xenops_interface.Vm in
       `QuickAndAutoDocumented [
@@ -59,26 +61,26 @@ module SanityCheck = Generic.MakeStateless(struct
             "whatever", "def";
             "viridian", "true";
           ], None, true, 0L, 0L, `pv),
-         Either.Right (usb_defaults @
+         Ok (usb_defaults @
                        [
                          "pae", "true";
                          "viridian", "true";
                        ]));
         (* Check that usb and usb_tablet are turned on by default. *)
         (([], None, false, 0L, 0L, `pv),
-         Either.Right (usb_defaults));
+         Ok (usb_defaults));
         (* Check that an invalid tsc_mode gets filtered out. *)
         ((["tsc_mode", "17";], None, false, 0L, 0L, `pv),
-         Either.right (usb_defaults));
+         Ok (usb_defaults));
         (* Check that an invalid parallel port gets filtered out. *)
         ((["parallel", "/dev/random"], None, false, 0L, 0L, `pv),
-         Either.Right (usb_defaults));
+         Ok (usb_defaults));
         (* Check that we can't set usb_tablet to true if usb is false. *)
         (([
             "usb", "false";
             "usb_tablet", "true";
           ], None, false, 0L, 0L, `pv),
-         Either.Right ([
+         Ok ([
              "usb", "false";
              "usb_tablet", "false";
            ]));
@@ -87,13 +89,13 @@ module SanityCheck = Generic.MakeStateless(struct
             "usb", "false";
             "usb_tablet", "false";
           ], None, false, 0L, 0L, `pv),
-         Either.Right ([
+         Ok ([
              "usb", "false";
              "usb_tablet", "false";
            ]));
         (* Check that we can disable the parallel port. *)
         ((["parallel", "none"], None, false, 0L, 0L, `pv),
-         Either.Right (usb_defaults @
+         Ok (usb_defaults @
                        ["parallel", "none"]));
         (* Check that a set of valid fields is unchanged (apart from
            			 * the ordering, which changes due to the implementation of
@@ -106,7 +108,7 @@ module SanityCheck = Generic.MakeStateless(struct
             "viridian", "true";
             "usb", "true";
           ], None, false, 0L, 0L, `pv),
-         Either.Right ([
+         Ok ([
              "usb", "true";
              "usb_tablet", "false";
              "parallel", "/dev/parport2";
@@ -121,7 +123,7 @@ module SanityCheck = Generic.MakeStateless(struct
             "parallel", "/dev/parport0";
             "tsc_mode", "blah";
           ], None, false, 0L, 0L, `pv),
-         Either.Right (usb_defaults @
+         Ok (usb_defaults @
                        [
                          "pae", "true";
                          "parallel", "/dev/parport0";
@@ -130,7 +132,7 @@ module SanityCheck = Generic.MakeStateless(struct
         (([
             "cores-per-socket", "3";
           ], None, false, 6L, 6L, `hvm),
-         Either.Right (usb_defaults @
+         Ok (usb_defaults @
                        [
                          "cores-per-socket", "3";
                        ]));
@@ -138,7 +140,7 @@ module SanityCheck = Generic.MakeStateless(struct
         (([
             "cores-per-socket", "3";
           ], None, false, 0L, 0L, `pv),
-         Either.Right (usb_defaults @
+         Ok (usb_defaults @
                        [
                          "cores-per-socket", "3";
                        ]));
@@ -146,28 +148,28 @@ module SanityCheck = Generic.MakeStateless(struct
         (([
             "cores-per-socket", "4";
           ], None, false, 6L, 6L, `hvm),
-         Either.Left (Api_errors.Server_error(Api_errors.invalid_value,
+         Error (Api_errors.Server_error(Api_errors.invalid_value,
                                               ["platform:cores-per-socket (value 4)";
                                                "VCPUs_max (value 6) must be a multiple of cores-per-socket"])));
         (* Check VCPUs configuration - hvm failure scenario*)
         (([
             "cores-per-socket", "0";
           ], None, false, 6L, 6L, `hvm),
-         Either.Left (Api_errors.Server_error(Api_errors.invalid_value,
+         Error (Api_errors.Server_error(Api_errors.invalid_value,
                                               ["platform:cores-per-socket (value 0)";
                                                "VCPUs_max (value 6) must be a multiple of cores-per-socket"])));
         (* Check VCPUs configuration - hvm failure scenario*)
         (([
             "cores-per-socket", "-1";
           ], None, false, 6L, 6L, `hvm),
-         Either.Left (Api_errors.Server_error(Api_errors.invalid_value,
+         Error (Api_errors.Server_error(Api_errors.invalid_value,
                                               ["platform:cores-per-socket (value -1)";
                                                "VCPUs_max (value 6) must be a multiple of cores-per-socket"])));
         (* Check VCPUs configuration - hvm failure scenario*)
         (([
             "cores-per-socket", "abc";
           ], None, false, 6L, 5L, `hvm),
-         Either.Left(Api_errors.Server_error(Api_errors.invalid_value,
+         Error(Api_errors.Server_error(Api_errors.invalid_value,
                                              ["platform:cores-per-socket (value abc)";
                                               "Value is not a valid int"])));
 
@@ -183,13 +185,13 @@ module SanityCheck = Generic.MakeStateless(struct
 
         (* Check UEFI configuration - qemu-trad incompatibility *)
         (([ "device-model", "qemu-trad" ], Some uefi, false, 0L, 0L, `hvm),
-         Either.Left(Api_errors.Server_error(Api_errors.invalid_value,
+         Error(Api_errors.Server_error(Api_errors.invalid_value,
                                              ["platform:device-model";
                                               "UEFI boot is not supported with qemu-trad"])));
 
         (* Check BIOS configuration - qemu-upstream-uefi incompatibility *)
         (([ "device-model", "qemu-upstream-uefi" ], Some Bios, false, 0L, 0L, `hvm),
-         Either.Left(Api_errors.Server_error(Api_errors.invalid_value,
+         Error(Api_errors.Server_error(Api_errors.invalid_value,
                                              ["platform:device-model";
                                               "BIOS boot is not supported with qemu-upstream-uefi"])));
       ]

--- a/ocaml/tests/test_pool_license.ml
+++ b/ocaml/tests/test_pool_license.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Stdext
+module Date = Xapi_stdext_date.Date
 open Test_highlevel
 
 type host_license_state = {

--- a/ocaml/tests/test_sdn_controller.ml
+++ b/ocaml/tests/test_sdn_controller.ml
@@ -13,7 +13,6 @@
  *)
 
 module T = Test_common
-open Stdext.Unixext
 
 let test_sdn_controller_introduce_ok () =
   let protocol = `ssl in

--- a/ocaml/tests/test_storage_migrate_state.ml
+++ b/ocaml/tests/test_storage_migrate_state.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Stdext
 open Test_highlevel
 
 module StorageMigrateState = struct
@@ -72,9 +71,9 @@ module MapOf = Generic.MakeStateful(struct
   open Storage_migrate.State
 
   let load_input () (send, recv, copy) =
-    Opt.iter (fun (id, send) -> add id send) send;
-    Opt.iter (fun (id, recv) -> add id recv) recv;
-    Opt.iter (fun (id, copy) -> add id copy) copy
+    Option.iter (fun (id, send) -> add id send) send;
+    Option.iter (fun (id, recv) -> add id recv) recv;
+    Option.iter (fun (id, copy) -> add id copy) copy
 
   let extract_output () _ = map_of ()
 

--- a/ocaml/tests/test_vdi_cbt.ml
+++ b/ocaml/tests/test_vdi_cbt.ml
@@ -12,7 +12,7 @@
 -  GNU Lesser General Public License for more details.
   *)
 
-open Stdext
+module Threadext = Xapi_stdext_threads.Threadext
 
 let register_smapiv2_server (module S: Storage_interface.Server_impl) sr_ref =
   let module S = Storage_interface.Server(S)() in
@@ -21,7 +21,7 @@ let register_smapiv2_server (module S: Storage_interface.Server_impl) sr_ref =
   Storage_mux.register sr_ref rpc "" dummy_query_result
 
 let make_smapiv2_storage_server ?vdi_enable_cbt ?vdi_disable_cbt ?vdi_list_changed_blocks ?vdi_data_destroy ?vdi_snapshot ?vdi_clone () =
-  let default = Xapi_stdext_monadic.Opt.default in
+  let default def = Option.value ~default:def in
   (module struct
     include (Storage_skeleton: module type of Storage_skeleton with module VDI := Storage_skeleton.VDI)
     module VDI = struct

--- a/ocaml/tests/test_xapi_db_upgrade.ml
+++ b/ocaml/tests/test_xapi_db_upgrade.ml
@@ -15,6 +15,8 @@
 module T = Test_common
 module X = Xapi_db_upgrade
 
+module Date = Xapi_stdext_date.Date
+
 let upgrade_vm_memory_for_dmc () =
   let __context = T.make_test_database () in
 
@@ -90,16 +92,16 @@ let update_snapshots () =
   let a = T.make_vm ~__context ~name_label:"a" () in
   let a_snap = T.make_vm ~__context ~name_label:"a snap" () in
   Db.VM.set_snapshot_of ~__context ~self:a_snap ~value:a;
-  Db.VM.set_snapshot_time ~__context ~self:a_snap ~value:(Stdext.Date.of_float 1.);
+  Db.VM.set_snapshot_time ~__context ~self:a_snap ~value:(Date.of_float 1.);
 
   let b = T.make_vm ~__context ~name_label:"b" () in
   let b_snap = T.make_vm ~__context ~name_label:"b snap" () in
   Db.VM.set_snapshot_of ~__context ~self:b_snap ~value:b;
-  Db.VM.set_snapshot_time ~__context ~self:b_snap ~value:(Stdext.Date.of_float 1.);
+  Db.VM.set_snapshot_time ~__context ~self:b_snap ~value:(Date.of_float 1.);
 
   let b_snap2 = T.make_vm ~__context ~name_label:"b snap2" () in
   Db.VM.set_snapshot_of ~__context ~self:b_snap2 ~value:b;
-  Db.VM.set_snapshot_time ~__context ~self:b_snap2 ~value:(Stdext.Date.of_float 2.);
+  Db.VM.set_snapshot_time ~__context ~self:b_snap2 ~value:(Date.of_float 2.);
 
   X.update_snapshots.fn ~__context;
 

--- a/ocaml/tests/test_xapi_xenops.ml
+++ b/ocaml/tests/test_xapi_xenops.ml
@@ -185,7 +185,7 @@ let test_xapi_restart_inner () =
     raise e
 
 let test_xapi_restart () =
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () -> match Backtrace.with_backtraces test_xapi_restart_inner with `Ok x -> x | `Error (e,_b) -> raise e)
     unsetup_simulator
 

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -2137,8 +2137,7 @@ let host_install_server_certificate fd printer rpc session_id params =
   |> get_file_or_fail fd "private key"
   in
   let certificate_chain = List.assoc_opt "certificate-chain" params
-  |> Option.map (get_file_or_fail fd "certificate chain")
-  |> Option.value ~default:""
+  |> Option.fold ~none:"" ~some:(get_file_or_fail fd "certificate chain")
   in
   ignore (do_host_op rpc session_id ~multiple:false (fun _ host ->
       let host = host.getref () in

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -56,7 +56,7 @@ let forward args s session =
   let open Xmlrpc_client in
   let transport = SSL(SSL.make (), Pool_role.get_master_address (), !Constants.https_port) in
   let body =
-    let args = Opt.default [] (Opt.map (fun s -> [ Printf.sprintf "session_id=%s" (Ref.string_of s) ]) session) @ args in
+    let args = Option.value ~default:[] (Option.map (fun s -> [ Printf.sprintf "session_id=%s" (Ref.string_of s) ]) session) @ args in
     String.concat "\r\n" args in
   let user_agent = Printf.sprintf "xapi/%s" Datamodel_common.api_version_string in
   let request = Http.Request.make ~version:"1.0" ~user_agent ~body

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -56,7 +56,7 @@ let forward args s session =
   let open Xmlrpc_client in
   let transport = SSL(SSL.make (), Pool_role.get_master_address (), !Constants.https_port) in
   let body =
-    let args = Option.value ~default:[] (Option.map (fun s -> [ Printf.sprintf "session_id=%s" (Ref.string_of s) ]) session) @ args in
+    let args = Option.fold ~none:[] ~some:(fun s -> [ Printf.sprintf "session_id=%s" (Ref.string_of s) ]) session @ args in
     String.concat "\r\n" args in
   let user_agent = Printf.sprintf "xapi/%s" Datamodel_common.api_version_string in
   let request = Http.Request.make ~version:"1.0" ~user_agent ~body

--- a/ocaml/xapi/console.ml
+++ b/ocaml/xapi/console.ml
@@ -58,7 +58,7 @@ let address_of_console __context console : address option =
         None
     end
   in
-  debug "VM %s console port: %s" (Ref.string_of vm) (Opt.default "None" (Opt.map (fun x -> "Some " ^ (string_of_address x)) address_option));
+  debug "VM %s console port: %s" (Ref.string_of vm) (Option.value ~default:"None" (Option.map (fun x -> "Some " ^ (string_of_address x)) address_option));
   address_option
 
 let real_proxy __context _ _ vnc_port s =
@@ -114,7 +114,7 @@ let ws_proxy __context req protocol address s =
 
   (* Ensure we always close the socket *)
   Pervasiveext.finally (fun () ->
-      let upgrade_successful = Opt.map (fun sock ->
+      let upgrade_successful = Option.map (fun sock ->
           try
             let result = (sock,Some (Ws_helpers.upgrade req s)) in
             result
@@ -122,7 +122,7 @@ let ws_proxy __context req protocol address s =
             (sock,None)) sock
       in
 
-      Opt.iter (function
+      Option.iter (function
           | (sock,Some ty) -> begin
               let wsprotocol = match ty with
                 | Ws_helpers.Hixie76 -> "hixie76"
@@ -135,7 +135,7 @@ let ws_proxy __context req protocol address s =
               Http_svr.headers s (Http.http_501_method_not_implemented ())
             end) upgrade_successful)
     (fun () ->
-       Opt.iter (fun sock -> Unix.close sock) sock)
+       Option.iter (fun sock -> Unix.close sock) sock)
 
 
 

--- a/ocaml/xapi/console.ml
+++ b/ocaml/xapi/console.ml
@@ -58,7 +58,7 @@ let address_of_console __context console : address option =
         None
     end
   in
-  debug "VM %s console port: %s" (Ref.string_of vm) (Option.value ~default:"None" (Option.map (fun x -> "Some " ^ (string_of_address x)) address_option));
+  debug "VM %s console port: %s" (Ref.string_of vm) (Option.fold ~none:"None" ~some:(fun x -> "Some " ^ (string_of_address x)) address_option);
   address_option
 
 let real_proxy __context _ _ vnc_port s =

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -101,7 +101,7 @@ let count_cpus () =
 let read_dom0_memory_usage () =
   try
     let map = Balloon.parse_proc_xen_balloon () in
-    let lookup = fun x -> Opt.unbox (List.assoc x map) in
+    let lookup = fun x -> Option.get (List.assoc x map) in
     let keys = [Balloon._low_mem_balloon; Balloon._high_mem_balloon; Balloon._current_allocation] in
     let values = List.map lookup keys in
     let result = List.fold_left Int64.add 0L values in
@@ -138,7 +138,7 @@ let read_localhost_info ~__context =
   let open Xenops_interface.Host in
   {
     name_label = this_host_name;
-    xen_verstring = Opt.map (fun s -> s.hypervisor.version) stat;
+    xen_verstring = Option.map (fun s -> s.hypervisor.version) stat;
     linux_verstring;
     hostname = this_host_name;
     uuid = me;
@@ -150,9 +150,9 @@ let read_localhost_info ~__context =
     machine_serial_name = lookup_inventory_nofail _machine_serial_name;
     total_memory_mib;
     dom0_static_max;
-    cpu_info = Opt.map (fun s -> s.cpu_info) stat;
-    chipset_info = Opt.map (fun s -> s.chipset_info) stat;
-    hypervisor = Opt.map (fun s -> s.hypervisor) stat;
+    cpu_info = Option.map (fun s -> s.cpu_info) stat;
+    chipset_info = Option.map (fun s -> s.chipset_info) stat;
+    hypervisor = Option.map (fun s -> s.hypervisor) stat;
   }
 
 (** Returns the maximum of two values. *)
@@ -479,7 +479,7 @@ let make_software_version ~__context host_info =
   v6_version @
   [
     "xapi", get_xapi_verstring ();
-    "xen", Opt.default "(unknown)" host_info.xen_verstring;
+    "xen", Option.value ~default:"(unknown)" host_info.xen_verstring;
     "linux", host_info.linux_verstring;
     "xencenter_min", Xapi_globs.xencenter_min_verstring;
     "xencenter_max", Xapi_globs.xencenter_max_verstring;

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -64,7 +64,6 @@
    xapi-cli-protocol
    xapi_cli_server
    xapi_aux
-   xapi-test-utils
    stdext
    threads
    xapi-idl

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -246,8 +246,8 @@ let update_pif_addresses ~__context =
       )
     ) in
   let gateway_if, dns_if = determine_gateway_and_dns_ifs ~__context () in
-  Opt.iter (fun (pif, bridge) -> set_gateway ~__context ~pif ~bridge) gateway_if;
-  Opt.iter (fun (pif, bridge) -> set_DNS ~__context ~pif ~bridge) dns_if;
+  Option.iter (fun (pif, bridge) -> set_gateway ~__context ~pif ~bridge) gateway_if;
+  Option.iter (fun (pif, bridge) -> set_DNS ~__context ~pif ~bridge) dns_if;
   List.iter (fun self -> update_pif_address ~__context ~self) pifs
 
 

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -693,12 +693,12 @@ module VDI : HandlerTools = struct
             vdi_records
             |> List.filter (fun (_, vdir) -> vdir.API.vDI_location = location && vdir.API.vDI_SR = sr)
             |> choose_one
-            |> Opt.map fst in
+            |> Option.map fst in
           let find_by_uuid uuid =
             vdi_records
             |> List.filter (fun (_, vdir) -> vdir.API.vDI_uuid = uuid)
             |> choose_one
-            |> Opt.map fst in
+            |> Option.map fst in
           let _scsiid = "SCSIid" in
           let scsiid_of vdi_record =
             if List.mem_assoc _scsiid vdi_record.API.vDI_sm_config
@@ -727,7 +727,7 @@ module VDI : HandlerTools = struct
                 | None ->
                   begin match find_by_scsiid destination with
                     | Some (rf, rc) ->
-                      info "VDI %s (SCSIid %s) mapped to %s (SCSIid %s) by user" vdi_record.API.vDI_uuid (Opt.default "None" (scsiid_of vdi_record)) rc.API.vDI_uuid (Opt.default "None" (scsiid_of rc));
+                      info "VDI %s (SCSIid %s) mapped to %s (SCSIid %s) by user" vdi_record.API.vDI_uuid (Option.value ~default:"None" (scsiid_of vdi_record)) rc.API.vDI_uuid (Option.value ~default:"None" (scsiid_of rc));
                       Some rf
                     | None -> None
                   end
@@ -738,7 +738,7 @@ module VDI : HandlerTools = struct
                | Some x ->
                  begin match find_by_scsiid x with
                    | Some (rf, rc) ->
-                     info "VDI %s (SCSIid %s) mapped to %s (SCSIid %s) by user" vdi_record.API.vDI_uuid (Opt.default "None" (scsiid_of vdi_record)) rc.API.vDI_uuid (Opt.default "None" (scsiid_of rc));
+                     info "VDI %s (SCSIid %s) mapped to %s (SCSIid %s) by user" vdi_record.API.vDI_uuid (Option.value ~default:"None" (scsiid_of vdi_record)) rc.API.vDI_uuid (Option.value ~default:"None" (scsiid_of rc));
                      Some rf
                    | None -> None
                  end
@@ -1471,7 +1471,7 @@ let with_open_archive fd ?length f =
     Tar_unix.really_read fd buffer;
 
     (* we assume the first block is not all zeroes *)
-    let hdr = Opt.unbox (Tar_unix.Header.unmarshal buffer) in
+    let hdr = Option.get (Tar_unix.Header.unmarshal buffer) in
     assert_filename_is hdr;
 
     (* successfully opened uncompressed stream *)
@@ -1509,7 +1509,7 @@ let with_open_archive fd ?length f =
                 Unix.set_close_on_exec compressed_in;
                 debug "Writing initial buffer";
                 Tar_unix.really_write compressed_in buffer;
-                let limit = (Opt.map
+                let limit = (Option.map
                                (fun x -> Int64.sub x (Int64.of_int Tar_unix.Header.length)) length) in
                 let n = Unixext.copy_file ?limit fd compressed_in in
                 debug "Written a total of %d + %Ld bytes" Tar_unix.Header.length n))

--- a/ocaml/xapi/import_raw_vdi.ml
+++ b/ocaml/xapi/import_raw_vdi.ml
@@ -27,7 +27,7 @@ open Pervasiveext
 open Client
 
 let fail_task_in_request (req: Request.t) (s: Unix.file_descr) e =
-  ignore(Xapi_http.ref_param_of_req req "task_id"|> Stdext.Opt.map (fun task_id -> TaskHelper.failed ~__context:(Context.from_forwarded_task task_id) e));
+  ignore(Xapi_http.ref_param_of_req req "task_id"|> Option.map (fun task_id -> TaskHelper.failed ~__context:(Context.from_forwarded_task task_id) e));
   Http_svr.headers s (Http.http_400_badrequest ())
 
 exception HandleError of exn * (string list) (* Exception to put into the task * headers to return to the client *)

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -74,7 +74,7 @@ let version_of_rpc = function
 (** An exported VM has a header record: *)
 type header = {
   version: version;
-  objects: obj list 
+  objects: obj list
 } [@@deriving rpc]
 
 exception Version_mismatch of string
@@ -240,7 +240,7 @@ let remote_metadata_export_import ~__context ~rpc ~session_id ~remote_address ~r
                with_transport (Unix Xapi_globs.unix_domain_socket)
                  (with_http get
                    (fun (r, ifd) ->
-                     debug "Content-length: %s" (Stdext.Opt.default "None" (Stdext.Opt.map Int64.to_string r.Http.Response.content_length));
+                     debug "Content-length: %s" (Option.value ~default:"None" (Option.map Int64.to_string r.Http.Response.content_length));
                      let put = { put with Http.Request.content_length = r.Http.Response.content_length } in
                      debug "Connecting to %s:%d" remote_address !Constants.https_port;
                      (* Spawn a cached stunnel instance. Otherwise, once metadata tranmission completes, the connection

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -240,7 +240,7 @@ let remote_metadata_export_import ~__context ~rpc ~session_id ~remote_address ~r
                with_transport (Unix Xapi_globs.unix_domain_socket)
                  (with_http get
                    (fun (r, ifd) ->
-                     debug "Content-length: %s" (Option.value ~default:"None" (Option.map Int64.to_string r.Http.Response.content_length));
+                     debug "Content-length: %s" (Option.fold ~none:"None" ~some:Int64.to_string r.Http.Response.content_length);
                      let put = { put with Http.Request.content_length = r.Http.Response.content_length } in
                      debug "Connecting to %s:%d" remote_address !Constants.https_port;
                      (* Spawn a cached stunnel instance. Otherwise, once metadata tranmission completes, the connection

--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -100,7 +100,7 @@ module Thread_state = struct
       ) snapshot in
     let resources_of_ts ts =
       List.map fst ts.acquired_resources @
-      (Opt.default [] (Opt.map (fun (r, _) -> [ r ]) ts.waiting_for)) in
+      (Option.value ~default:[] (Option.map (fun (r, _) -> [ r ]) ts.waiting_for)) in
     let all_resources =
       List.setify
         (IntMap.fold (fun _ ts acc -> resources_of_ts ts @ acc ) snapshot [] ) in

--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -100,7 +100,7 @@ module Thread_state = struct
       ) snapshot in
     let resources_of_ts ts =
       List.map fst ts.acquired_resources @
-      (Option.value ~default:[] (Option.map (fun (r, _) -> [ r ]) ts.waiting_for)) in
+      (Option.fold ~none:[] ~some:(fun (r, _) -> [ r ]) ts.waiting_for) in
     let all_resources =
       List.setify
         (IntMap.fold (fun _ ts acc -> resources_of_ts ts @ acc ) snapshot [] ) in

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -355,8 +355,8 @@ let bring_pif_up ~__context ?(management_interface=false) (pif: API.ref_PIF) =
             let persistent = is_dom0_interface rc in
             let gateway_if, dns_if = Helpers.determine_gateway_and_dns_ifs ~__context
                 ?management_interface:(if management_interface then Some pif else None) () in
-            Opt.iter (fun (_, name) -> Net.set_gateway_interface dbg name) gateway_if;
-            Opt.iter (fun (_, name) -> Net.set_dns_interface dbg name) dns_if;
+            Option.iter (fun (_, name) -> Net.set_gateway_interface dbg name) gateway_if;
+            Option.iter (fun (_, name) -> Net.set_dns_interface dbg name) dns_if;
 
             (* Setup network infrastructure *)
             let cleanup, bridge_config, interface_config = create_bridges ~__context rc net_rc in

--- a/ocaml/xapi/pvs_proxy_control.ml
+++ b/ocaml/xapi/pvs_proxy_control.ml
@@ -310,11 +310,11 @@ let find_proxy_for_vif ~__context ~vif =
 
 (* Called on VM start *)
 let maybe_start_proxy_for_vif ~__context ~vif =
-  Opt.iter
+  Option.iter
     (fun p -> start_proxy ~__context vif p |> ignore)
     (find_proxy_for_vif ~__context ~vif)
 
 let maybe_stop_proxy_for_vif ~__context ~vif =
-  Opt.iter
+  Option.iter
     (stop_proxy ~__context vif)
     (find_proxy_for_vif ~__context ~vif)

--- a/ocaml/xapi/remote_requests.ml
+++ b/ocaml/xapi/remote_requests.ml
@@ -114,7 +114,7 @@ let handle_request req =
   with
   | exn ->
     if req.enable_log then
-      warn "Exception handling remote request %s: %s" (Opt.default "" req.request.Http.Request.body)
+      warn "Exception handling remote request %s: %s" (Option.value ~default:"" req.request.Http.Request.body)
         (ExnHelper.string_of_exn exn);
     signal_result req (Exception exn)
 

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -74,7 +74,7 @@ let make_call ?driver_params ?sr_sm_config ?vdi_sm_config ?vdi_type ?vdi_locatio
   Server_helpers.exec_with_new_task "sm_exec"
     (fun __context ->
        (* Only allow a subset of calls if the SR has been introduced by a DR task. *)
-       Opt.iter (fun sr ->
+       Option.iter (fun sr ->
            if Db.is_valid_ref __context (Db.SR.get_introduced_by ~__context ~self:sr) then
              if not(List.mem cmd ["sr_attach"; "sr_detach"; "vdi_attach"; "vdi_detach"; "vdi_activate"; "vdi_deactivate"; "sr_probe"; "sr_scan"; "sr_content_type"]) then
                raise (Storage_interface.Storage_error (Backend_error(Api_errors.operation_not_allowed,

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -60,7 +60,7 @@ let find_vdi ~__context sr vdi =
 let find_content ~__context ?sr name =
   (* PR-1255: the backend should do this for us *)
   let open Db_filter_types in
-  let expr = Option.value ~default:True (Option.map (fun sr -> Eq(Field "SR", Literal (Ref.string_of (Db.SR.get_by_uuid ~__context ~uuid:(s_of_sr sr) )))) sr) in
+  let expr = Option.fold ~none:True ~some:(fun sr -> Eq(Field "SR", Literal (Ref.string_of (Db.SR.get_by_uuid ~__context ~uuid:(s_of_sr sr) )))) sr in
   let all = Db.VDI.get_records_where ~__context ~expr in
   List.find
     (fun (_, vdi_rec) ->

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -60,7 +60,7 @@ let find_vdi ~__context sr vdi =
 let find_content ~__context ?sr name =
   (* PR-1255: the backend should do this for us *)
   let open Db_filter_types in
-  let expr = Opt.default True (Opt.map (fun sr -> Eq(Field "SR", Literal (Ref.string_of (Db.SR.get_by_uuid ~__context ~uuid:(s_of_sr sr) )))) sr) in
+  let expr = Option.value ~default:True (Option.map (fun sr -> Eq(Field "SR", Literal (Ref.string_of (Db.SR.get_by_uuid ~__context ~uuid:(s_of_sr sr) )))) sr) in
   let all = Db.VDI.get_records_where ~__context ~expr in
   List.find
     (fun (_, vdi_rec) ->
@@ -842,7 +842,7 @@ module SMAPIv1 = struct
       (* peer_ip/session_ref/vdi_ref *)
       Server_helpers.exec_with_new_task "VDI.get_url" ~subtask_of:(Ref.of_string dbg)
         (fun __context ->
-           let ip = Helpers.get_management_ip_addr ~__context |> Opt.unbox in
+           let ip = Helpers.get_management_ip_addr ~__context |> Option.get in
            let rpc = Helpers.make_rpc ~__context in
            let localhost = Helpers.get_localhost ~__context in
            (* XXX: leaked *)
@@ -1346,7 +1346,7 @@ let reset ~__context ~vm =
   let dbg = Context.get_task_id __context in
   transform_storage_exn
     (fun () ->
-       Opt.iter
+       Option.iter
          (fun pbd ->
             let sr_uuid = Db.SR.get_uuid ~__context ~self:(Db.PBD.get_SR ~__context ~self:pbd) in
             let sr = Storage_interface.Sr.of_string sr_uuid in

--- a/ocaml/xapi/storage_impl.ml
+++ b/ocaml/xapi/storage_impl.ml
@@ -189,7 +189,7 @@ module Vdi = struct
     set_dp_state dp state' t
 
   let to_string_list x =
-    let title = Printf.sprintf "%s (device=%s)" (Vdi_automaton.string_of_state (superstate x)) (Option.value ~default:"None" (Option.map (fun x -> "Some " ^ Jsonrpc.to_string (Storage_interface.(rpc_of backend) x)) x.attach_info)) in
+    let title = Printf.sprintf "%s (device=%s)" (Vdi_automaton.string_of_state (superstate x)) (Option.fold ~none:"None" ~some:(fun x -> "Some " ^ Jsonrpc.to_string (Storage_interface.(rpc_of backend) x)) x.attach_info) in
     let of_dp (dp, state) = Printf.sprintf "DP: %s: %s%s" dp (Vdi_automaton.string_of_state state) (if List.mem dp x.leaked then "  ** LEAKED" else "") in
     title :: (List.map indent (List.map of_dp x.dps))
 end

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -740,8 +740,8 @@ let receive_start ~dbg ~sr ~vdi_info ~id ~similar =
              with Not_found -> None) None similar in
 
     debug "Nearest VDI: content_id=%s vdi=%s"
-      (Option.value ~default:"None" (Option.map (fun x -> x.content_id) nearest))
-      (Option.value ~default:"None" (Option.map (fun x -> Storage_interface.Vdi.string_of x.vdi) nearest));
+      (Option.fold ~none:"None" ~some:(fun x -> x.content_id) nearest)
+      (Option.fold ~none:"None" ~some:(fun x -> Storage_interface.Vdi.string_of x.vdi) nearest);
 
     let parent = match nearest with
       | Some vdi ->
@@ -911,8 +911,8 @@ let copy ~task ~dbg ~sr ~vdi ~dp ~url ~dest =
                with Not_found -> None) None similars in
 
       debug "Nearest VDI: content_id=%s vdi=%s"
-        (Option.value ~default:"None" (Option.map (fun x -> x.content_id) nearest))
-        (Option.value ~default:"None" (Option.map (fun x -> Storage_interface.Vdi.string_of x.vdi) nearest));
+        (Option.fold ~none:"None" ~some:(fun x -> x.content_id) nearest)
+        (Option.fold ~none:"None" ~some:(fun x -> Storage_interface.Vdi.string_of x.vdi) nearest);
       let remote_base = match nearest with
         | Some vdi ->
           debug "Cloning VDI";

--- a/ocaml/xapi/valid_ref_list.ml
+++ b/ocaml/xapi/valid_ref_list.ml
@@ -14,10 +14,10 @@ let filter f = List.filter (default_on_missing_ref f false)
 
 let for_all f l = not (exists (fun x -> not @@ f x) l)
 
-let map f = Stdext.Listext.List.filter_map (default_on_missing_ref (fun x -> Some (f x)) None)
+let map f = List.filter_map (default_on_missing_ref (fun x -> Some (f x)) None)
 
 let iter f = List.iter (default_on_missing_ref f ())
 
 let flat_map f l = List.map (default_on_missing_ref f []) l |> List.flatten
 
-let filter_map f l = map f l |> List.filter ((<>) None) |> List.map Xapi_stdext_monadic.Opt.unbox
+let filter_map f l = List.filter_map Fun.id (map f l)

--- a/ocaml/xapi/vhd_tool_wrapper.ml
+++ b/ocaml/xapi/vhd_tool_wrapper.ml
@@ -131,7 +131,7 @@ let vhd_of_device path =
        | _ ->
          debug "Device %s has an unknown driver" path;
          None in
-  find_backend_device path |> Stdext.Opt.default path |> tapdisk_of_path
+  find_backend_device path |> Option.value ~default:path |> tapdisk_of_path
 
 let send progress_cb ?relative_to (protocol: string) (dest_format: string) (s: Unix.file_descr) (path: string) (prefix: string) =
   let s' = Uuidm.to_string (Uuidm.create `V4) in

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -86,7 +86,7 @@ let destroy ~__context ~self =
       let n = List.length cluster_hosts in
       raise Api_errors.(Server_error(cluster_does_not_have_one_node, [string_of_int n]))
   in
-  Xapi_stdext_monadic.Opt.iter (fun ch ->
+  Option.iter (fun ch ->
     assert_cluster_host_has_no_attached_sr_which_requires_cluster_stack ~__context ~self:ch;
     Xapi_cluster_host.force_destroy ~__context ~self:ch
   ) cluster_host;

--- a/ocaml/xapi/xapi_gpu_group.ml
+++ b/ocaml/xapi/xapi_gpu_group.ml
@@ -123,15 +123,15 @@ let get_remaining_capacity_internal ~__context ~self ~vgpu_type =
            Xapi_pgpu_helpers.get_remaining_capacity_internal ~pre_allocate_list:[]
              ~__context ~self:pgpu ~vgpu_type
          with
-         | Either.Left e -> (capacity, e :: exceptions)
-         | Either.Right n -> (Int64.add n capacity, exceptions))
+         | Error e -> (capacity, e :: exceptions)
+         | Ok n -> (Int64.add n capacity, exceptions))
       (0L, []) pgpus
   in
   if capacity > 0L
-  then Either.Right capacity
-  else Either.Left (choose_exception exceptions)
+  then Ok capacity
+  else Error (choose_exception exceptions)
 
 let get_remaining_capacity ~__context ~self ~vgpu_type =
   match get_remaining_capacity_internal ~__context ~self ~vgpu_type with
-  | Either.Left e -> 0L
-  | Either.Right capacity -> capacity
+  | Error e -> 0L
+  | Ok capacity -> capacity

--- a/ocaml/xapi/xapi_gpu_group.mli
+++ b/ocaml/xapi/xapi_gpu_group.mli
@@ -40,7 +40,7 @@ val get_remaining_capacity_internal :
   __context:Context.t ->
   self: [ `GPU_group ] Ref.t ->
   vgpu_type:[ `VGPU_type ] Ref.t ->
-  (exn, int64) Stdext.Either.t
+  (int64, exn) result
 
 val get_remaining_capacity :
   __context:Context.t ->

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -313,7 +313,7 @@ module Monitor = struct
                 raise e in
             debug "Liveset: %s" (Xha_interface.LiveSetInformation.to_summary_string liveset);
             (* All hosts: Feed the current latency values into the per-host RRDs (if available) *)
-            Opt.iter
+            Option.iter
               (fun local ->
                  (* Assume all values are ms *)
                  let statefile = float_of_int (local.Xha_interface.LiveSetInformation.RawStatus.statefile_latency) /. 1000. in
@@ -325,7 +325,7 @@ module Monitor = struct
 
             (* All hosts: create alerts from per-host warnings (if available) *)
             debug "Processing warnings";
-            Opt.iter
+            Option.iter
               (fun warning ->
                  warning_statefile_lost warning.Xha_interface.LiveSetInformation.Warning.statefile_lost;
                  warning_heartbeat_approaching_timeout warning.Xha_interface.LiveSetInformation.Warning.heartbeat_approaching_timeout;

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -231,7 +231,7 @@ let string_of_configuration_change ~__context (x: configuration_change) =
     (String.concat "; " (List.map (fun (h, (vm_ref, vm_t)) -> Printf.sprintf "%s %s (%s)" (string_of_host h) (Ref.short_string_of vm_ref) vm_t.API.vM_name_label) x.old_vms_leaving))
     (String.concat "; " (List.map (fun (h, (vm_ref, vm_t)) -> Printf.sprintf "%s %s (%s)" (string_of_host h) (Ref.short_string_of vm_ref) vm_t.API.vM_name_label) x.old_vms_arriving))
     (String.concat "; " (List.map string_of_host x.hosts_to_disable))
-    (Stdext.Opt.default "no change" (Stdext.Opt.map string_of_int x.num_failures))
+    (Option.value ~default:"no change" (Option.map string_of_int x.num_failures))
     (String.concat "; " (List.map Ref.short_string_of x.new_vms_to_protect))
 
 (* Deterministic function which chooses a single host to 'pin' a non-agile VM to. Note we don't consider only live hosts:
@@ -283,7 +283,7 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set ?(change=no_con
      	   will use their new memory_static_max: so we always use a live 'VM.get_record' and not a 'last_booted_record' *)
 
   (* Allow the num_failures to be overriden *)
-  let (num_failures: int) = Stdext.Opt.default num_failures change.num_failures in
+  let (num_failures: int) = Option.value ~default:num_failures change.num_failures in
 
   (* All the VMs to protect; these VMs may or may not be currently running anywhere: they will be offline when a host has
      	   failed and possibly initially during the enable-ha transient. *)

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -231,7 +231,7 @@ let string_of_configuration_change ~__context (x: configuration_change) =
     (String.concat "; " (List.map (fun (h, (vm_ref, vm_t)) -> Printf.sprintf "%s %s (%s)" (string_of_host h) (Ref.short_string_of vm_ref) vm_t.API.vM_name_label) x.old_vms_leaving))
     (String.concat "; " (List.map (fun (h, (vm_ref, vm_t)) -> Printf.sprintf "%s %s (%s)" (string_of_host h) (Ref.short_string_of vm_ref) vm_t.API.vM_name_label) x.old_vms_arriving))
     (String.concat "; " (List.map string_of_host x.hosts_to_disable))
-    (Option.value ~default:"no change" (Option.map string_of_int x.num_failures))
+    (Option.fold ~none:"no change" ~some:string_of_int x.num_failures)
     (String.concat "; " (List.map Ref.short_string_of x.new_vms_to_protect))
 
 (* Deterministic function which chooses a single host to 'pin' a non-agile VM to. Note we don't consider only live hosts:

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -423,7 +423,7 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set ?(change=no_con
   non_agile_restart_plan @ agile_restart_plan, config, vms_not_restarted, not_agile_vms <> []
 
 (** Returned by the plan_for_n_failures function *)
-type result =
+type plan_status =
   | Plan_exists_for_all_VMs
   | Plan_exists_excluding_non_agile_VMs
   | No_plan_exists

--- a/ocaml/xapi/xapi_ha_vm_failover.mli
+++ b/ocaml/xapi/xapi_ha_vm_failover.mli
@@ -24,7 +24,7 @@ val restart_auto_run_vms : __context:Context.t -> API.ref_host list -> int -> un
 val compute_evacuation_plan : __context:Context.t -> int -> API.ref_host list -> (API.ref_VM * API.vM_t) list -> (API.ref_VM * API.ref_host) list
 
 (** Abstract result of the background HA planning function *)
-type result =
+type plan_status =
   | Plan_exists_for_all_VMs             (** All protected VMs could be restarted *)
   | Plan_exists_excluding_non_agile_VMs (** Excluding 'trivial' failures due to non-agile VMs, all protected VMs could be restarted *)
   | No_plan_exists                      (** Not all protected VMs could be restarted *)
@@ -45,7 +45,7 @@ val no_configuration_change : configuration_change
 val update_pool_status : __context:Context.t -> ?live_set:API.ref_host list -> unit -> bool
 
 (** Consider all possible failures of 'n' hosts *)
-val plan_for_n_failures : __context:Context.t -> all_protected_vms:((API.ref_VM * API.vM_t) list) -> ?live_set:API.ref_host list -> ?change:configuration_change -> int -> result
+val plan_for_n_failures : __context:Context.t -> all_protected_vms:((API.ref_VM * API.vM_t) list) -> ?live_set:API.ref_host list -> ?change:configuration_change -> int -> plan_status
 
 (** Compute the maximum plan size we can currently find *)
 val compute_max_host_failures_to_tolerate : __context:Context.t -> ?live_set:API.ref_host list -> ?protected_vms:((API.ref_VM * API.vM_t) list) -> unit -> int64

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1775,7 +1775,7 @@ let sync_pif_currently_attached ~__context ~host ~bridges =
   List.iter
     (fun (pif, pif_r) ->
        let bridge = List.assoc pif pif_to_bridge in
-       let currently_attached = Opt.default false (Opt.map (fun x -> List.mem x bridges) bridge) in
+       let currently_attached = Option.value ~default:false (Option.map (fun x -> List.mem x bridges) bridge) in
        if pif_r.API.pIF_currently_attached <> currently_attached then begin
          Db.PIF.set_currently_attached ~__context ~self:pif ~value:currently_attached;
          debug "PIF %s currently_attached <- %b" (Ref.string_of pif) currently_attached;
@@ -1811,7 +1811,7 @@ let migrate_receive ~__context ~host ~network ~options =
   let sm_url = Printf.sprintf "http://%s/services/SM?session_id=%s" ip new_session_id in
   let xenops_url = Printf.sprintf "http://%s/services/xenops?session_id=%s" ip new_session_id in
   let master_address = try Pool_role.get_master_address () with Pool_role.This_host_is_a_master ->
-    Opt.unbox (Helpers.get_management_ip_addr ~__context) in
+    Option.get (Helpers.get_management_ip_addr ~__context) in
 
   let master_url = Printf.sprintf "http://%s/" master_address in
   [ Xapi_vm_migrate._sm, sm_url;

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1775,7 +1775,7 @@ let sync_pif_currently_attached ~__context ~host ~bridges =
   List.iter
     (fun (pif, pif_r) ->
        let bridge = List.assoc pif pif_to_bridge in
-       let currently_attached = Option.value ~default:false (Option.map (fun x -> List.mem x bridges) bridge) in
+       let currently_attached = Option.fold ~none:false ~some:(fun x -> List.mem x bridges) bridge in
        if pif_r.API.pIF_currently_attached <> currently_attached then begin
          Db.PIF.set_currently_attached ~__context ~self:pif ~value:currently_attached;
          debug "PIF %s currently_attached <- %b" (Ref.string_of pif) currently_attached;

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -125,7 +125,7 @@ let run ~__context ~mgmt_enabled =
           start ~__context ~addr:"127.0.0.1" ();
           listening_localhost := true
         end;
-        Opt.iter (fun addr ->
+        Option.iter (fun addr ->
             if not !listening_himn then begin
               start ~__context ~addr ();
               listening_himn := true

--- a/ocaml/xapi/xapi_pgpu_helpers.mli
+++ b/ocaml/xapi/xapi_pgpu_helpers.mli
@@ -45,7 +45,7 @@ val get_remaining_capacity_internal :
   self:API.ref_PGPU ->
   vgpu_type:API.ref_VGPU_type ->
   pre_allocate_list:(API.ref_VGPU * API.ref_PGPU) list ->
-  (exn, int64) Stdext.Either.t
+  (int64, exn) result
 
 (* Return the number of VGPUs of the specified type for which capacity
  * remains on the PGPU. *)
@@ -63,7 +63,7 @@ val assert_capacity_exists_for_VGPU_type :
   vgpu_type:API.ref_VGPU_type -> unit
 
 (** Check that the PGPU selected is compatible with the VM VGPU.
- *  Currently checks only nvml compatibility if Nvidia VGPUs 
+ *  Currently checks only nvml compatibility if Nvidia VGPUs
  *  are detected. *)
 val assert_destination_pgpu_is_compatible_with_vm :
   __context:Context.t ->
@@ -74,9 +74,9 @@ val assert_destination_pgpu_is_compatible_with_vm :
   ?remote:(Rpc.call -> Rpc.response Client.Id.t) * [<`session] Ref.t -> unit -> unit
 
 (** Check that the host has a PGPU compatible with the VM VGPU.
- *  Currently checks only nvml compatibility if Nvidia VGPUs 
+ *  Currently checks only nvml compatibility if Nvidia VGPUs
  *  are detected. *)
-val assert_destination_has_pgpu_compatible_with_vm : 
+val assert_destination_has_pgpu_compatible_with_vm :
   __context:Context.t ->
   vm:API.ref_VM ->
   vgpu_map:(API.ref_VGPU * API.ref_GPU_group) list ->

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -52,7 +52,7 @@ let refresh_internal ~__context ~self =
      	 *)
   let maybe_update_database
       field_name db_value set_field get_value print_value =
-    Opt.iter
+    Option.iter
       (fun value ->
          if value <> db_value
          then begin
@@ -62,7 +62,7 @@ let refresh_internal ~__context ~self =
              (print_value value);
            set_field ~__context ~self ~value
          end)
-      (Opt.of_exception (fun () -> get_value ())) in
+      (try Some (get_value ()) with _ -> None) in
 
   if pif.API.pIF_physical then
     maybe_update_database "MAC"

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -311,10 +311,10 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
     let my_compatibility_info = compatibility_info my_software_version in
     if master_compatibility_info <> my_compatibility_info then begin
       debug "master PLATFORM_VERSION = %s, master compatibility name = %s; my PLATFORM_VERSION = %s, my compatibility name = %s; "
-        (Opt.default "Unknown" (fst master_compatibility_info))
-        (Opt.default "Unknown" (snd master_compatibility_info))
-        (Opt.default "Unknown" (fst my_compatibility_info))
-        (Opt.default "Unknown" (snd my_compatibility_info));
+        (Option.value ~default:"Unknown" (fst master_compatibility_info))
+        (Option.value ~default:"Unknown" (snd master_compatibility_info))
+        (Option.value ~default:"Unknown" (fst my_compatibility_info))
+        (Option.value ~default:"Unknown" (snd my_compatibility_info));
       raise (Api_errors.Server_error(Api_errors.pool_hosts_not_compatible, []))
     end in
 
@@ -1099,7 +1099,7 @@ let eject ~__context ~host =
     (* unplug all my PBDs; will deliberately fail if any unplugs fail *)
     unplug_pbds ~__context host;
 
-    Xapi_clustering.find_cluster_host ~__context ~host |> Xapi_stdext_monadic.Opt.iter (fun cluster_host ->
+    Xapi_clustering.find_cluster_host ~__context ~host |> Option.iter (fun cluster_host ->
         debug "Pool.eject: leaving cluster";
         (* PBDs need to be unplugged first for this to succeed *)
         Helpers.call_api_functions ~__context (fun rpc session_id ->

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -96,14 +96,14 @@ let scan_one ~__context ?callback sr =
                       (fun () ->
                          scan_finished sr;
                          debug "Scan of SR %s complete." sr_uuid;
-                         Opt.iter (fun f ->
+                         Option.iter (fun f ->
                              debug "Starting callback for SR %s." sr_uuid;
                              f ();
                              debug "Callback for SR %s finished." sr_uuid) callback)
                   )) ())
   else
     (* If a callback was supplied but a scan is already in progress, call the callback once the scan is complete. *)
-    Opt.iter (fun f ->
+    Option.iter (fun f ->
         ignore (Thread.create
                   (fun () ->
                      debug "Tried to scan SR %s but scan already in progress - waiting for scan to complete." sr_uuid;
@@ -289,7 +289,7 @@ let probe_ext =
     API.{
       probe_result_configuration = configuration;
       probe_result_complete = complete;
-      probe_result_sr = Xapi_stdext_monadic.Opt.map to_xenapi_sr_stat sr;
+      probe_result_sr = Option.map to_xenapi_sr_stat sr;
       probe_result_extra_info = extra_info
     }
   in

--- a/ocaml/xapi/xapi_udhcpd.ml
+++ b/ocaml/xapi/xapi_udhcpd.ml
@@ -160,7 +160,7 @@ let write_config_nolock ~__context ip_router =
 
 let restart_nolock () =
   let pid = try Unixext.pidfile_read !Xapi_globs.udhcpd_pidfile with _ -> None in
-  Opt.iter Unixext.kill_and_wait pid;
+  Option.iter Unixext.kill_and_wait pid;
   let (_: string * string) = execute_command_get_output !Xapi_globs.busybox [ "udhcpd"; !Xapi_globs.udhcpd_conf ] in
   let start = Mtime_clock.counter () in
   let rec wait_for_pid n =
@@ -234,7 +234,7 @@ let maybe_add_lease ~__context vif =
 let get_ip ~__context vif =
   let vif = Ref.string_of vif in
   Mutex.execute mutex (fun () ->
-      Opt.map (fun l -> l.ip) (find_lease_nolock vif)
+      Option.map (fun l -> l.ip) (find_lease_nolock vif)
     )
 
 let init () =

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -250,7 +250,7 @@ let assert_vm_supports_quiesce_snapshot ~__context ~self =
       try
         let vdi = Db.VBD.get_VDI ~__context ~self:vbd in
         let sm_config = Db.VDI.get_sm_config ~__context ~self:vdi in
-        Xapi_vm_lifecycle.assoc_opt "on_boot" sm_config = Some "reset"
+        List.assoc_opt "on_boot" sm_config = Some "reset"
       with _ -> false
     ) vmr.Db_actions.vM_VBDs then
     raise (Api_errors.Server_error(Api_errors.vdi_on_boot_mode_incompatible_with_operation, [ ]));

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -426,7 +426,7 @@ let inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map ~vgpu_
       let vdi = vdi_record.local_vdi_reference in
       Db.VDI.remove_from_other_config ~__context ~self:vdi
         ~key:Constants.storage_migrate_vdi_map_key;
-      Opt.iter (fun remote_vdi_reference ->
+      Option.iter (fun remote_vdi_reference ->
           Db.VDI.add_to_other_config ~__context ~self:vdi
             ~key:Constants.storage_migrate_vdi_map_key
             ~value:(Ref.string_of remote_vdi_reference))

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1203,27 +1203,27 @@ module Xenops_cache = struct
   let update_vbd id info =
     let existing = Option.value ~default:empty (find (fst id)) in
     let vbds' = List.filter (fun (vbd_id, _) -> vbd_id <> id) existing.vbds in
-    update (fst id) { existing with vbds = Option.value ~default:vbds' (Option.map (fun info -> (id, info) :: vbds') info) }
+    update (fst id) { existing with vbds = Option.fold ~none:vbds' ~some:(fun info -> (id, info) :: vbds') info }
 
   let update_vif id info =
     let existing = Option.value ~default:empty (find (fst id)) in
     let vifs' = List.filter (fun (vif_id, _) -> vif_id <> id) existing.vifs in
-    update (fst id) { existing with vifs = Option.value ~default:vifs' (Option.map (fun info -> (id, info) :: vifs') info) }
+    update (fst id) { existing with vifs = Option.fold ~none:vifs' ~some:(fun info -> (id, info) :: vifs') info }
 
   let update_pci id info =
     let existing = Option.value ~default:empty (find (fst id)) in
     let pcis' = List.filter (fun (pci_id, _) -> pci_id <> id) existing.pcis in
-    update (fst id) { existing with pcis = Option.value ~default:pcis' (Option.map (fun info -> (id, info) :: pcis') info) }
+    update (fst id) { existing with pcis = Option.fold ~none:pcis' ~some:(fun info -> (id, info) :: pcis') info }
 
   let update_vgpu id info =
     let existing = Option.value ~default:empty (find (fst id)) in
     let vgpus' = List.filter (fun (vgpu_id, _) -> vgpu_id <> id) existing.vgpus in
-    update (fst id) { existing with vgpus = Option.value ~default:vgpus' (Option.map (fun info -> (id, info) :: vgpus') info) }
+    update (fst id) { existing with vgpus = Option.fold ~none:vgpus' ~some:(fun info -> (id, info) :: vgpus') info }
 
   let update_vusb id info =
     let existing = Option.value ~default:empty (find (fst id)) in
     let vusbs' = List.filter (fun (vusb_id, _) -> vusb_id <> id) existing.vusbs in
-    update (fst id) { existing with vusbs = Option.value ~default:vusbs' (Option.map (fun info -> (id, info) :: vusbs') info) }
+    update (fst id) { existing with vusbs = Option.fold ~none:vusbs' ~some:(fun info -> (id, info) :: vusbs') info }
 
   let update_vm id info =
     let existing = Option.value ~default:empty (find id) in

--- a/ocaml/xapi/xha_interface.ml
+++ b/ocaml/xapi/xha_interface.ml
@@ -180,7 +180,7 @@ module DaemonConfiguration = struct
     }
 
   let int_parameter (name, param) =
-    Opt.default [] (Opt.map (fun x -> [ xml_leaf_element name (string_of_int x) ]) param)
+    Option.value ~default:[] (Option.map (fun x -> [ xml_leaf_element name (string_of_int x) ]) param)
 
   (** Converts the given HA daemon configuration *)
   (** into an XML element tree.                  *)

--- a/ocaml/xapi/xha_interface.ml
+++ b/ocaml/xapi/xha_interface.ml
@@ -180,7 +180,7 @@ module DaemonConfiguration = struct
     }
 
   let int_parameter (name, param) =
-    Option.value ~default:[] (Option.map (fun x -> [ xml_leaf_element name (string_of_int x) ]) param)
+    Option.fold ~none:[] ~some:(fun x -> [ xml_leaf_element name (string_of_int x) ]) param
 
   (** Converts the given HA daemon configuration *)
   (** into an XML element tree.                  *)

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -23,7 +23,6 @@ depends: [
   "base-threads"
   "uuid"
   "xapi-stdext-encodings"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"
   "xapi-stdext-threads"

--- a/xapi-datamodel.opam
+++ b/xapi-datamodel.opam
@@ -17,7 +17,6 @@ depends: [
   "xapi-consts"
   "xapi-database"
   "xapi-stdext-date"
-  "xapi-stdext-monadic"
   "xapi-stdext-std"
   "xapi-stdext-unix"
 ]

--- a/xapi.opam
+++ b/xapi.opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
-  "alcotest" {with-test}
+  "alcotest" # needed to generate the quicktest binary
   "angstrom"
   "base64"
   "cdrom"
@@ -56,7 +56,7 @@ depends: [
   "xapi-stdext-threads"
   "xapi-stdext-unix"
   "xapi-tapctl"
-  "xapi-test-utils"
+  "xapi-test-utils" {with-test}
   "xapi-types"
   "xapi-xenopsd"
   "xapi-idl"


### PR DESCRIPTION
Most of the changes involve changing Either to result and Opt to Option.

The changes for Opt are mechanical and have been automated, for Either some fine-tuning for pretty printers, most of it was mechanical as well, please check the changes around vgpu code that were done as part of removing Either from the testcode. 

Some of the mechanical substitutions made:
```
sed -i "s/Opt.iter/Option.iter/g"
sed -i "s/Opt.map/Option.map/g"
sed -i "s/Opt.default /Option.value ~default:/g"
sed -i "s/Opt.unbox/Option.get/g"
sed -i "s/Opt.is_some/Option.is_some/g"
sed -i "s/Stdext.Option/Option/g"
```

Xapi does not depend anymore on xapi-test-utils for building, quicktest didn't really need it.

There's is still quite a bit of work to get rid of the parent Stdext package from xapi, 174 files still use it. I'll see if I can automate most of the changes, even if it is to use the subpackage directly.