### PR TITLE
CA-338137: Fix upgrade case in generate-iscsi-iqn

### DIFF
--- a/scripts/generate-iscsi-iqn
+++ b/scripts/generate-iscsi-iqn
@@ -38,8 +38,9 @@ geniqn() {
 }
 
 # On upgrade, the host param will already be there - reuse it:
-if [ -n $(xe host-param-get uuid=${INSTALLATION_UUID} param-name=iscsi_iqn 2>/dev/null) ]; then
-    IQN=$(xe host-param-get uuid=${INSTALLATION_UUID} param-name=iscsi_iqn 2>/dev/null)
+IQN_PARAM="$(xe host-param-get uuid=${INSTALLATION_UUID} param-name=iscsi_iqn 2>/dev/null)"
+if [ -n "${IQN_PARAM}" ]; then
+    IQN="${IQN_PARAM}"
 elif xe host-param-get uuid=${INSTALLATION_UUID} param-name=other-config --minimal 2>/dev/null | grep -q "iscsi_iqn:" ; then
     IQN="$(xe host-param-get uuid=${INSTALLATION_UUID} param-name=other-config param-key=iscsi_iqn --minimal)"
 elif [ -n "${IQN_CONF}" ]; then


### PR DESCRIPTION
The generate-iscsi-iqn script sets the iscsi_iqn of a host on first boot, and
also runs on upgrade (this used to be a firstboot script).

Before XS 7.5, there was no dedicated `host.iscsi_iqn` field, and instead the
host IQN was stored in an other-config key. Upon upgrade from pre-Kolkata, the
new `iscsi_iqn` field is initialised to the empty string. In this case, the
generate-iscsi-iqn script is meant to copy the other-config key and reapply the
iscsi_iqn in order to set the new field. If the new field was already set, it
should leave it alone.

However, the if-statement for the latter is wrong and needs quotes. Without
that, it always evaluates to "true", even when `iscsi_iqn` is the empty string,
which causes the IQN to be regenerated rather than preserved.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>