### PR TITLE
maintenance: prepare for ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,9 @@
+profile=ocamlformat
+version=0.14.1
+indicate-multiline-delimiters=closing-on-separate-line
+if-then-else=fit-or-vertical
+dock-collection-brackets=true
+break-struct=natural
+break-separators=before
+break-infix=fit-or-vertical
+break-infix-before-func=false

--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,0 +1,2 @@
+# datamodel files have it's own format
+ocaml/idl/datamodel*

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ XAPIDOC=_build/install/default/xapi/doc
 JOBS = $(shell getconf _NPROCESSORS_ONLN)
 PROFILE=release
 
-.PHONY: build clean test doc python reindent install uninstall
+.PHONY: build clean test doc python format install uninstall
 
 build:
 	dune build @install -j $(JOBS) --profile=$(PROFILE)
@@ -37,8 +37,8 @@ doc-json:
 	dune build --profile=$(PROFILE) ocaml/idl/json_backend/gen_json.exe
 	dune exec --profile=$(PROFILE) -- ocaml/idl/json_backend/gen_json.exe -destdir _build/install/default/jekyll
 
-reindent:
-	git ls-files '*.ml*' '**/*.ml*' | xargs ocp-indent --syntax cstruct -i
+format:
+	dune build @fmt --auto-promote
 
 install: build doc
 	mkdir -p $(DESTDIR)$(SBINDIR)

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
-(lang dune 1.9)
+(lang dune 1.11)
 (allow_approximate_merlin)
+(using fmt 1.2 (enabled_for ocaml))

--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -57,10 +57,10 @@ let read_field_internal t tblname fldname objref db =
 let read_field t tblname fldname objref =
   Schema.Value.marshal (read_field_internal t tblname fldname objref (get_database t))
 
-(** Finds the longest XML-compatible UTF-8 prefix of the given *)
-(** string, by truncating the string at the first incompatible *)
-(** character. Writes a warning to the debug log if truncation *)
-(** occurs.                                                    *)
+(** Finds the longest XML-compatible UTF-8 prefix of the given
+    string, by truncating the string at the first incompatible
+    character. Writes a warning to the debug log if truncation
+    occurs. *)
 let ensure_utf8_xml string =
   let length = String.length string in
   let prefix = Xapi_stdext_encodings.Encodings.UTF8_XML.longest_valid_prefix string in

--- a/ocaml/database/db_globs.ml
+++ b/ocaml/database/db_globs.ml
@@ -18,6 +18,7 @@ let redo_log_max_block_time_writedelta = ref 2.
 let redo_log_max_block_time_writedb = ref 30.
 
 (** {3 Settings related to the exponential back-off of repeated attempts to reconnect after failure} *)
+
 (** The initial backoff delay, in seconds *)
 let redo_log_initial_backoff_delay = 2
 

--- a/ocaml/database/redo_log.mli
+++ b/ocaml/database/redo_log.mli
@@ -17,8 +17,10 @@
 
 val get_static_device : string -> string option
 (** Finds an attached metadata VDI with a given reason *)
+
 val minimum_vdi_size : int64
 (** Minimum size for redo log VDI *)
+
 val redo_log_sm_config : (string * string) list
 (** SM config for redo log VDI *)
 
@@ -43,10 +45,13 @@ type redo_log = {
 
 val is_enabled : redo_log -> bool
 (** Returns [true] iff writing deltas to the block device is enabled. *)
+
 val enable : redo_log -> string -> unit
 (** Enables writing deltas to the block device. Subsequent modifications to the database will be persisted to the block device. Takes a static-VDI reason as argument to select the device to use. *)
+
 val enable_block : redo_log -> string -> unit
 (** Enables writing deltas to the block device. Subsequent modifications to the database will be persisted to the block device. Takes a path as argument to select the device to use. *)
+
 val disable : redo_log -> unit
 (** Disables writing deltas to the block device. Subsequent modifications to the database will not be persisted to the block device. *)
 
@@ -58,9 +63,12 @@ val redo_log_events: (string * bool) Event.channel
 
 val startup : redo_log -> unit
 (** Start the I/O process. Will do nothing if it's already started. *)
+
 val shutdown : redo_log -> unit
+
 (** Stop the I/O process. Will do nothing if it's not already started. *)
 val switch : redo_log -> string -> unit
+
 (** Start using the VDI with the given reason as redo-log, discarding the current one. *)
 
 (** {Keeping track of existing redo_log instances} *)

--- a/ocaml/database/test_schemas.ml
+++ b/ocaml/database/test_schemas.ml
@@ -99,7 +99,7 @@ let schema =
     Schema.major_vsn = 1;
     minor_vsn = 1;
     database = database;
-    (** indexed by table name, a list of (this field, foreign table, foreign field) *)
+    (* indexed by table name, a list of (this field, foreign table, foreign field) *)
     one_to_many = one_to_many;
     many_to_many = Schema.ForeignMap.empty;
   }

--- a/ocaml/quicktest/quicktest_vdi.ml
+++ b/ocaml/quicktest/quicktest_vdi.ml
@@ -1,7 +1,7 @@
 module A = Quicktest_args
 
-(** If VDI_CREATE and VDI_DELETE are present then make sure VDIs appear and disappear correctly *)
-(** VDI_CREATE should make a fresh disk; VDI_DELETE should remove it *)
+(** If VDI_CREATE and VDI_DELETE are present then make sure VDIs appear and disappear correctly
+    VDI_CREATE should make a fresh disk; VDI_DELETE should remove it *)
 let vdi_create_destroy rpc session_id sr_info () =
   let sr = sr_info.Qt.sr in
   (* Request the following sizes and demand the disk is at least this big (or our data won't fit!) *)
@@ -67,8 +67,8 @@ let vdi_resize_test rpc session_id sr_info () =
       end
     )
 
-(** Make sure that I can't call VDI.db_forget *)
-(** VDI.db_forget should always fail without authorisation *)
+(** Make sure that I can't call VDI.db_forget
+    VDI.db_forget should always fail without authorisation *)
 let vdi_db_forget rpc session_id sr_info () =
   Qt.VDI.with_any rpc session_id sr_info (fun vdi ->
       try
@@ -120,7 +120,7 @@ let vdi_bad_introduce rpc session_id sr_info () =
 (** When cloning/snapshotting perform field by field comparisons to look for
     problems *)
 let check_clone_snapshot_fields rpc session_id original_vdi new_vdi =
-  (** Clones and snapshots should have some identical fields and some different
+  (* Clones and snapshots should have some identical fields and some different
       fields: *)
   let clone_snapshot_fields =
     [ `Same, "virtual_size", (fun vdi -> vdi.API.vDI_virtual_size |> Int64.to_string)
@@ -191,8 +191,9 @@ let vdi_snapshot_in_pool rpc session_id sr_info () =
     )
 
 (** Make sure that VDI_CREATE; plug; VDI_DESTROY; VDI_CREATE; plug results in a device of
-    the correct size in dom0 *)
-(** Checking the disk size is correct when a disk is plugged in *)
+    the correct size in dom0.
+
+    Checking the disk size is correct when a disk is plugged in *)
 let vdi_create_destroy_plug_checksize rpc session_id sr_info () =
   let exception Not_this_host in
   (* Query /sys to find the actual size of the plugged in device *)

--- a/ocaml/tests/test_clustering_allowed_operations.ml
+++ b/ocaml/tests/test_clustering_allowed_operations.ml
@@ -112,7 +112,7 @@ let with_cluster_host_op ~__context self op =
 let test_clustering_ops_disallowed_during_rolling_upgrade () =
   let __context = Test_common.make_test_database () in
 
-  (** Helpers for testing clustering operations forbidden during rolling pool upgrade *)
+  (* Helpers for testing clustering operations forbidden during rolling pool upgrade *)
   let test_clustering_ops_should_pass with_cluster_fn self ops =
     List.iter
       (fun op ->

--- a/ocaml/xapi-aux/pool_role.mli
+++ b/ocaml/xapi-aux/pool_role.mli
@@ -27,10 +27,13 @@ val get_role: unit -> t
 
 (** Returns true if this node is a master *)
 val is_master: unit -> bool
+
 (** Returns true if this node is a slave *)
 val is_slave: unit -> bool
+
 (** Returns true if this node is broken *)
 val is_broken: unit -> bool
+
 (** Returns true if this is a unit test *)
 val is_unit_test: unit -> bool
 

--- a/ocaml/xapi-types/compression_algorithms.ml
+++ b/ocaml/xapi-types/compression_algorithms.ml
@@ -13,6 +13,7 @@
  *)
 
 (** Types used to store compression algorithms: ***************************)
+
 (** Supported compression algorithms *)
 type t =
   | Gzip

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -12,7 +12,8 @@
  * GNU Lesser General Public License for more details.
  *)
 (** The main callback function.
- * @group API Messaging
+
+    @group API Messaging
 *)
 
 (** Actions module *)
@@ -103,6 +104,7 @@ module Actions = struct
   module Certificate = Certificates
   module Diagnostics = Xapi_diagnostics
 end
+
 (** Use the server functor to make an XML-RPC dispatcher. *)
 module Forwarder = Message_forwarding.Forward (Actions)
 module Server = Server.Make (Actions) (Forwarder)
@@ -110,7 +112,6 @@ module Server = Server.Make (Actions) (Forwarder)
 
 
 (** Here are the functions to forward calls made on the unix domain socket on a slave to a master *)
-
 module D=Debug.Make(struct let name="api_server" end)
 open D
 

--- a/ocaml/xapi/cancel_tasks.ml
+++ b/ocaml/xapi/cancel_tasks.ml
@@ -94,8 +94,8 @@ let master_finished_initial_cancel = ref false
 let cancelled_c = Condition.create ()
 let cancelled_m = Mutex.create ()
 
-(** Mark tasks that are pending or cancelling on this host as cancelled *)
-(** This function is called by master on behalf of slave, when slave sends a "Pool.hello" msg on reconnect *)
+(** Mark tasks that are pending or cancelling on this host as cancelled
+    This function is called by master on behalf of slave, when slave sends a "Pool.hello" msg on reconnect *)
 let cancel_tasks_on_host ~__context ~host_opt =
   Stdext.Threadext.Mutex.execute cancelled_m
     (fun () ->

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -168,14 +168,18 @@ let rec mkints = function
   | 0 -> []
   | n -> (mkints (n - 1) @ [n])
 
-(** Ensures that the database has all the necessary records for domain *)
-(** zero, and that the records are up-to-date. Includes the following: *)
-(**     1. The domain zero record.                                     *)
-(**     2. The domain zero console record.                             *)
-(**     3. The domain zero metrics record.                             *)
-(** This function makes sure there is exactly one record of each type. *)
-(** It updates existing records if they are found, or else creates new *)
-(** records for any records that are missing.                          *)
+(** Ensures that the database has all the necessary records for domain
+    zero, and that the records are up-to-date. Includes the following:
+
+        1. The domain zero record.
+
+        2. The domain zero console record.
+
+        3. The domain zero metrics record.
+
+    This function makes sure there is exactly one record of each type.
+    It updates existing records if they are found, or else creates new
+    records for any records that are missing. *)
 let rec ensure_domain_zero_records ~__context ~host (host_info: host_info) : unit =
   maybe_upgrade_domain_zero_record ~__context ~host host_info;
   let domain_zero_ref = ensure_domain_zero_record ~__context host_info in

--- a/ocaml/xapi/daemon_manager.ml
+++ b/ocaml/xapi/daemon_manager.ml
@@ -21,11 +21,13 @@ type daemon_check =
   | Function of (unit -> bool)
 
 type daemon_state = [
-    `unmanaged |
+    `unmanaged
     (** No threads which care about the state of the daemon are running. *)
-    `should_start |
+    |
+    `should_start
     (** Daemon should be started when the last thread exits
         	    with_daemon_stopped. *)
+    |
     `should_not_start
     (** Daemon should not be started when the last thread exits
         	    with_daemon_stopped. *)

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -12,7 +12,8 @@
  * GNU Lesser General Public License for more details.
  *)
 (** Code to bring the database up-to-date when a host starts up.
- *  @group Main Loop and Start-up
+
+    @group Main Loop and Start-up
 *)
 
 module Rrdd = Rrd_client.Client
@@ -242,7 +243,7 @@ let update_env __context sync_keys =
   let localhost = Helpers.get_localhost_uncached ~__context in
   Xapi_globs.localhost_ref := localhost;
 
-  (** Normally the resident_on field would be set by the helper which creates
+  (* Normally the resident_on field would be set by the helper which creates
       the task, but it uses this `localhost_ref` to do so, which we have only
       just initialized above. Therefore we manually set it here *)
   let task_ref = Context.get_task_id __context in

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -251,7 +251,7 @@ let update_pif_addresses ~__context =
   List.iter (fun self -> update_pif_address ~__context ~self) pifs
 
 
-(* Note that both this and `make_timeboxed_rpc` are almost always 
+(* Note that both this and `make_timeboxed_rpc` are almost always
  * partially applied, returning a function of type 'Rpc.request -> Rpc.response'.
  * The body is therefore not evaluated until the RPC call is actually being
  * made. *)
@@ -459,8 +459,8 @@ type boot_method =
   | Direct of direct_boot_t
   | Indirect of indirect_boot_t
 
-(** Returns the current value of the pool configuration flag *)
-(** that indicates whether a rolling upgrade is in progress. *)
+(** Returns the current value of the pool configuration flag
+   that indicates whether a rolling upgrade is in progress. *)
 let rolling_upgrade_in_progress_of_oc oc =
   List.mem_assoc Xapi_globs.rolling_upgrade_in_progress oc
 
@@ -1074,6 +1074,7 @@ let queue_thread f =
 module type POLICY = sig
   type t
   val standard : t
+
   (** Used by operations like VM.start which want to paper over transient glitches but want to fail
       		    quickly if the objects are persistently locked (eg by a VDI.clone) *)
   val fail_quickly : t
@@ -1244,7 +1245,7 @@ end = struct (* can't place these functions in task helpers due to circular depe
             (fun rpc session_id -> Client.Client.Event.from ~rpc ~session_id ~classes ~token ~timeout:30.0) in
         debug "Using events to wait for tasks: %s" (String.concat "," classes);
         let from = Event_types.event_from_of_rpc from in
-        cb (); (** be careful not to include logic in `cb` that could modify tasks we are waiting on indefinitely *)
+        cb (); (* be careful not to include logic in `cb` that could modify tasks we are waiting on indefinitely *)
         process from.Event_types.token
       end else
         ()
@@ -1254,7 +1255,7 @@ end = struct (* can't place these functions in task helpers due to circular depe
   let wait_for = wait_for_ ~propagate_cancel:false Stdlib.Fun.id
 
   let wait_for_mirror ~__context ~t =
-    (** Whilst we wait for task [t], mirror some of its properties in our task *)
+    (* Whilst we wait for task [t], mirror some of its properties in our task *)
     let our_task = Context.get_task_id __context in
     let mirror =
       if t = our_task then Stdlib.Fun.id

--- a/ocaml/xapi/memory_check.ml
+++ b/ocaml/xapi/memory_check.ml
@@ -19,8 +19,8 @@ let ( --- ) = Int64.sub
 let ( *** ) = Int64.mul
 let ( /// ) = Int64.div
 
-(** Calculates the amounts of 'normal' and 'shadow' host memory needed *)
-(** to run the given guest with the given amount of guest memory.      *)
+(** Calculates the amounts of 'normal' and 'shadow' host memory needed
+    to run the given guest with the given amount of guest memory. *)
 let vm_compute_required_memory vm_record guest_memory_kib =
   let vcpu_count = Int64.to_int vm_record.API.vM_VCPUs_max in
   let target_mib = Memory.mib_of_kib_used guest_memory_kib in
@@ -108,12 +108,12 @@ let vm_compute_used_memory ~__context policy vm_ref =
    		request is more than the total free.
 *)
 type host_memory_summary = {
-  (** The maximum amount of memory that guests can use on this host. *)
-  host_maximum_guest_memory_bytes: int64;
-  (** list of VMs which have a domain running here *)
-  resident: API.ref_VM list;
-  (** list of VMs which are in the process of having a domain created here *)
-  scheduled: API.ref_VM list;
+    host_maximum_guest_memory_bytes: int64
+        (** The maximum amount of memory that guests can use on this host. *)
+  ; resident: API.ref_VM list
+        (** list of VMs which have a domain running here *)
+  ; scheduled: API.ref_VM list
+        (** list of VMs which are in the process of having a domain created here *)
 }
 
 open Db_filter_types

--- a/ocaml/xapi/memory_check.mli
+++ b/ocaml/xapi/memory_check.mli
@@ -31,12 +31,15 @@
    		request is more than the total free.
 *)
 type host_memory_summary = {
+  host_maximum_guest_memory_bytes: int64
   (** The maximum amount of memory that guests can use on this host. *)
-  host_maximum_guest_memory_bytes: int64;
+  ;
+  resident: API.ref_VM list
   (** list of VMs which have a domain running here *)
-  resident: API.ref_VM list;
+  ;
+  scheduled: API.ref_VM list
   (** list of VMs which are in the process of having a domain created here *)
-  scheduled: API.ref_VM list;
+  ;
 }
 
 (** Different users will wish to use a different VM accounting policy, depending

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1682,7 +1682,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       let forward_migrate_send () =
         let forward_internal_async () =
           forward_vm_op ~local_fn ~__context ~vm (fun session_id rpc ->
-            (** try InternalAsync.VM.migrate_send first to avoid long running idle stunnel connection
+            (* try InternalAsync.VM.migrate_send first to avoid long running idle stunnel connection
               * fall back on Async.VM.migrate_send if slave doesn't support InternalAsync *)
             Helpers.try_internal_async ~__context
               API.ref_VM_of_rpc
@@ -3464,7 +3464,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       forward_sr_op ~local_fn ~__context ~self:sr
         (fun session_id rpc ->
            Client.SR.forget_data_source_archives rpc session_id sr data_source)
-    
+
     let get_live_hosts ~__context ~sr =
       info "SR.get_live_hosts: SR = '%s'" (sr_uuid ~__context sr);
       Local.SR.get_live_hosts ~__context ~sr

--- a/ocaml/xapi/static_vdis.ml
+++ b/ocaml/xapi/static_vdis.ml
@@ -28,7 +28,7 @@ let permanent_vdi_attach ~__context ~vdi ~reason =
   info "permanent_vdi_attach: vdi = %s; sr = %s"
     (Ref.string_of vdi) (Ref.string_of (Db.VDI.get_SR ~__context ~self:vdi));
 
-  (** Disallow attaching VDIs that only have changed block tracking metadata *)
+  (* Disallow attaching VDIs that only have changed block tracking metadata *)
   if (Db.VDI.get_type ~__context ~self:vdi) = `cbt_metadata then begin
     error "Static_vdis.permanent_vdi_attach: the given VDI has type cbt_metadata";
     raise (Api_errors.Server_error(Api_errors.vdi_incompatible_type, [ Ref.string_of vdi; Record_util.vdi_type_to_string `cbt_metadata ]))

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -796,7 +796,7 @@ module SMAPIv1 = struct
            let _, vdi_rec = find_vdi ~__context sr vdi in
            let vdis = explore 0 StringMap.empty vdi_rec.API.vDI_location |> invert |> IntMap.bindings |> List.map snd |> List.concat in
            let vdi_recs = List.map (fun l -> StringMap.find l locations) vdis in
-           (** We drop cbt_metadata VDIs that do not have any actual data *)
+           (* We drop cbt_metadata VDIs that do not have any actual data *)
            let vdi_recs = List.filter (fun r -> r.API.vDI_type <> `cbt_metadata) vdi_recs in
            List.map (fun x -> vdi_info_of_vdi_rec __context x) vdi_recs
         )

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -715,7 +715,7 @@ let receive_start ~dbg ~sr ~vdi_info ~id ~similar =
   let on_fail : (unit -> unit) list ref = ref [] in
 
   let vdis = Local.SR.scan dbg sr in
-  (** We drop cbt_metadata VDIs that do not have any actual data *)
+  (* We drop cbt_metadata VDIs that do not have any actual data *)
   let vdis = List.filter (fun vdi -> vdi.ty <> "cbt_metadata") vdis in
 
   let leaf_dp = Local.DP.create dbg (Uuid.string_of_uuid (Uuid.make_uuid ())) in
@@ -900,7 +900,7 @@ let copy ~task ~dbg ~sr ~vdi ~dp ~url ~dest =
       let similars = List.map (fun vdi -> vdi.content_id) similar_vdis in
       debug "Similar VDIs = [ %s ]" (String.concat "; " (List.map (fun x -> Printf.sprintf "(vdi=%s,content_id=%s)" (Storage_interface.Vdi.string_of x.vdi) x.content_id) similar_vdis));
       let remote_vdis = Remote.SR.scan dbg dest in
-      (** We drop cbt_metadata VDIs that do not have any actual data *)
+      (* We drop cbt_metadata VDIs that do not have any actual data *)
       let remote_vdis = List.filter (fun vdi -> vdi.ty <> "cbt_metadata") remote_vdis in
 
       let nearest = List.fold_left

--- a/ocaml/xapi/stream_vdi.ml
+++ b/ocaml/xapi/stream_vdi.ml
@@ -52,8 +52,8 @@ let with_open_vdi __context rpc session_id vdi_ref mode flags perms f =
     sort on the externalised reference (used as a 'directory name') *)
 let vdi_ordering (a,_,_) (b,_,_) = compare a b
 
-(** Lock a bunch of VDIs and then call <f> with them sorted via <vdi_ordering> *)
-(** the function 'f' is responsible for doing attach/activate then deactivate/detach at the end *)
+(** Lock a bunch of VDIs and then call <f> with them sorted via <vdi_ordering>
+    the function 'f' is responsible for doing attach/activate then deactivate/detach at the end *)
 let for_each_vdi __context f prefix_vdis =
   let sorted_prefix_vdis = List.sort vdi_ordering prefix_vdis in
   List.iter f sorted_prefix_vdis
@@ -151,7 +151,7 @@ let flag_zero = 2l
 
 (** [descriptor_list] should be a list of non-overlapping extents, ordered from
     lowest offset to highest.
-    [offset] is the current offset needed to translate from relative extents to 
+    [offset] is the current offset needed to translate from relative extents to
     absolute chunk numbers *)
 let get_chunk_numbers_in_increasing_order descriptor_list offset =
   (* Output increasing range includes start and end points *)
@@ -408,11 +408,11 @@ let recv_all_vdi refresh_session ifd (__context:Context.t) rpc session_id ~has_i
              in
              Unixext.really_read ifd buffer 0 (Int64.to_int length);
              Unix.write ofd buffer 0 (Int64.to_int length) |> ignore;
-             
+
              let buffer_string = Bytes.unsafe_to_string buffer in
              let csum_hdr = Tar_unix.Header.get_next_header ifd in (* Header of the checksum file *)
              let csum_file_name = csum_hdr.Tar_unix.Header.file_name in
-	     	 
+
              let csum = (* Infer checksum algorithm from the file extension *)
                 match Filename.extension csum_file_name with
                 | m when m = checksum_extension_xxh -> Printf.sprintf "%016LX" (XXHash.XXH64.hash buffer_string)

--- a/ocaml/xapi/thread_queue.ml
+++ b/ocaml/xapi/thread_queue.ml
@@ -44,7 +44,7 @@ let make ?max_q_length ?(name="unknown") (process_fn: 'a process_fn) : 'a t =
     let items = List.rev (Queue.fold (fun acc (description, _) -> description::acc) [] q) in
     Printf.sprintf "[ %s ](%d)" (String.concat "; " items) (List.length items) in
 
-  (** The background thread *)
+  (* The background thread *)
   let t = ref None in
 
   let thread_body () =

--- a/ocaml/xapi/vhd_tool_wrapper.ml
+++ b/ocaml/xapi/vhd_tool_wrapper.ml
@@ -113,6 +113,7 @@ let find_backend_device path =
         )
     | _ -> raise Not_found
   with _ -> None
+
 (** [vhd_of_device path] returns (Some vhd) where 'vhd' is the vhd leaf backing a particular device [path] or None.
     [path] may either be a blktap2 device *or* a blkfront device backed by a blktap2 device. If the latter then
     the script must be run in the same domain as blkback. *)

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -1163,7 +1163,7 @@ let disable_internal __context =
 
   let hosts = Db.Host.get_all ~__context in
 
-  (** Attempt the HA disable via the statefile, returning true if successful and false
+  (* Attempt the HA disable via the statefile, returning true if successful and false
       		otherwise. If false then we'll retry with the no-statefile procedure *)
   let attempt_disable_through_statefile () =
     info "I have statefile access -- setting pool state to invalid";
@@ -1218,7 +1218,7 @@ let disable_internal __context =
            ) errors
       ) in
 
-  (** Attempt the HA disable without the statefile. *)
+  (* Attempt the HA disable without the statefile. *)
   let attempt_disable_without_statefile () =
 
     (* This is the no-statefile procedure: *)

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -752,7 +752,7 @@ let restart_auto_run_vms ~__context live_set n =
          | Ok _ -> TaskChains.ok ()
        in
 
-       (** [ordered_map_concat f lst]
+       (* [ordered_map_concat f lst]
         * traverses the list in order, maps each inner list through [f]
         * and concatenates the result *)
        let ordered_map_concat f lst =
@@ -764,7 +764,7 @@ let restart_auto_run_vms ~__context live_set n =
              List.rev_append (f inner) accum) [] lst
        in
 
-       (** [map_parallel ~order_f f lst] groups objects in [lst] by order number
+       (* [map_parallel ~order_f f lst] groups objects in [lst] by order number
            (provided by applying [order_f] to each object). For each group of objects
            it then applies [f] to them to produce an 'a TaskChain.t and then executes this
            set of TaskChain.t values in parallel until they each of the TaskChain.t

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -498,7 +498,7 @@ let prepare_for_poweroff_precheck ~__context ~host =
   Xapi_host_helpers.assert_host_disabled ~__context ~host
 
 let prepare_for_poweroff ~__context ~host =
-  (** Do not run assert_host_disabled here, continue even if the host is
+  (* Do not run assert_host_disabled here, continue even if the host is
       enabled: the host is already shutting down when this function gets called *)
 
   let i_am_master = Pool_role.is_master () in

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -378,8 +378,8 @@ let nvidia_vf_setup ~__context ~pf ~enable =
   let addr_of pci = Xenops_interface.Pci.address_of_string pci in
   let dequarantine pci = Xapi_pci.dequarantine ~__context (addr_of pci) in
 
-  (** [num_vfs pci] returns the number of PCI VFs of [pci] or 0 if
-    * [pci] is not an SRIOV device
+  (* [num_vfs pci] returns the number of PCI VFs of [pci] or 0 if
+     [pci] is not an SRIOV device
     *)
   let num_vfs pci =
     let path = Printf.sprintf "/sys/bus/pci/devices/%s/sriov_numvfs" pci in

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -26,8 +26,10 @@ open Unixext
 
 module D = Debug.Make(struct let name="xapi_pool_update" end)
 open D
-(** Updates contain their own metadata in XML format. When the signature has been verified
-    the update is executed with argument "info" and it emits XML like the following:
+
+(** Updates contain their own metadata in XML format. When the signature has
+    been verified the update is executed with argument "info" and it emits XML
+    like the following:
 
       <update
         name-label="XS70E002" uuid="12acfd0a-0246-4fa7-ba00-2d0e474b3650"
@@ -44,7 +46,7 @@ type update_info = {
   key: string;
   installation_size: int64;
   after_apply_guidance: API.after_apply_guidance list;
-  enforce_homogeneity: bool; (* true = all hosts in a pool must have this update *)
+  enforce_homogeneity: bool; (** true = all hosts in a pool must have this update *)
 }
 
 (** Mount a filesystem somewhere, with optional type *)

--- a/ocaml/xapi/xapi_pusb_helpers.ml
+++ b/ocaml/xapi/xapi_pusb_helpers.ml
@@ -91,7 +91,7 @@ let get_local_usb usbs =
   |> USBSet.of_list
 
 let get_script_stdout () =
-  (** usb_scan is a script that will get all the usb details in current host, which will return json format data *)
+  (* usb_scan is a script that will get all the usb details in current host, which will return json format data *)
   let usb_scan_script = "/opt/xensource/libexec/usb_scan.py" in
   try
     let stdout, stderr = Forkhelpers.execute_command_get_output usb_scan_script [] in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -818,24 +818,24 @@ let add_to_NVRAM ~__context ~self ~key ~value =
 (* Use set_memory_dynamic_range instead *)
 let set_memory_target_live ~__context ~self ~target = ()
 
-(** The default upper bound on the acceptable difference between *)
-(** actual memory usage and target memory usage when waiting for *)
-(** a running VM to reach its current memory target.             *)
+(** The default upper bound on the acceptable difference between
+    actual memory usage and target memory usage when waiting for
+    a running VM to reach its current memory target.             *)
 let wait_memory_target_tolerance_bytes = Int64.(mul 1L (mul 1024L 1024L))
 
-(** Returns true if (and only if) the   *)
-(** specified argument is a power of 2. *)
+(** Returns true if (and only if) the
+    specified argument is a power of 2. *)
 let is_power_of_2 n =
   (n > 1) && (n land (0 - n) = n)
 
-(** Waits for a running VM to reach its current memory target. *)
-(** This function waits until the following condition is true: *)
-(**                                                            *)
-(**     abs (memory_actual - memory_target) <= tolerance       *)
-(**                                                            *)
-(** If the task associated with this function is cancelled or  *)
-(** if the time-out counter exceeds its limit, this function   *)
-(** raises a server error and terminates.                      *)
+(** Waits for a running VM to reach its current memory target.
+    This function waits until the following condition is true:
+
+        abs (memory_actual - memory_target) <= tolerance
+
+    If the task associated with this function is cancelled or
+    if the time-out counter exceeds its limit, this function
+    raises a server error and terminates.                      *)
 let wait_memory_target_live ~__context ~self =
   let timeout_seconds = int_of_float !Xapi_globs.wait_memory_target_timeout in
   let tolerance_bytes = wait_memory_target_tolerance_bytes in

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -778,8 +778,8 @@ let choose_host_for_vm_no_wlb ~__context ~vm ~snapshot =
     let validate_host = vm_can_run_on_host ~__context ~vm ~snapshot ~do_memory_check:false in
     List.flatten host_lists |> Xapi_vm_placement.select_host __context vm validate_host
 
-(* choose_host_for_vm will use WLB as long as it is enabled and there *)
-(* is no pool.other_config["wlb_choose_host_disable"] = "true".       *)
+(** choose_host_for_vm will use WLB as long as it is enabled and there
+    is no pool.other_config["wlb_choose_host_disable"] = "true". *)
 let choose_host_uses_wlb ~__context =
   Workload_balancing.check_wlb_enabled ~__context &&
   not (
@@ -790,9 +790,9 @@ let choose_host_uses_wlb ~__context =
       (Db.Pool.get_other_config ~__context
          ~self:(Helpers.get_pool ~__context)))
 
-(** Given a virtual machine, returns a host it can boot on, giving   *)
-(** priority to an affinity host if one is present. WARNING: called  *)
-(** while holding the global lock from the message forwarding layer. *)
+(** Given a virtual machine, returns a host it can boot on, giving
+    priority to an affinity host if one is present. WARNING: called
+    while holding the global lock from the message forwarding layer. *)
 let choose_host_for_vm ~__context ~vm ~snapshot =
   if choose_host_uses_wlb ~__context then
     try

--- a/ocaml/xapi/xha_interface.ml
+++ b/ocaml/xapi/xha_interface.ml
@@ -18,8 +18,8 @@ open Listext
 
 (* === Common XML operations === *)
 
-(** Generates an XML leaf element of the form: *)
-(**     <name>value</name>                     *)
+(** Generates an XML leaf element of the form:
+    [<name>value</name>] *)
 let xml_leaf_element name value =
   Xml.Element (
     name, [], [Xml.PCData value]
@@ -31,22 +31,22 @@ let xml_element_has_name name element =
   | Xml.Element (name_, _, _) -> name = name_
   | _                         -> false
 
-(** Returns a sub-list of the given element list, containing *)
-(** only those elements with the specified name.             *)
+(** Returns a sub-list of the given element list, containing
+    only those elements with the specified name. *)
 let xml_elements_with_name elements name =
   List.filter (xml_element_has_name name) elements
 
-(** Returns the first element with the specified name from *)
-(** the given element list.                                *)
+(** Returns the first element with the specified name from
+    the given element list. *)
 let first_xml_element_with_name elements name =
   try
     Some (List.find (xml_element_has_name name) elements)
   with
     Not_found -> None
 
-(** Parses an XML element of the form "<name>value</value>".  *)
-(** Returns a (name, value) string pair, where the arguments  *)
-(** are stripped of leading and trailing whitespace.          *)
+(** Parses an XML element of the form "<name>value</value>".
+    Returns a (name, value) string pair, where the arguments
+    are stripped of leading and trailing whitespace. *)
 let hash_table_entry_of_leaf_xml_element = function
   | Xml.Element (name, _, Xml.PCData (value) :: values) ->
     Some (
@@ -56,17 +56,18 @@ let hash_table_entry_of_leaf_xml_element = function
   | Xml.Element (name, _, []) -> Some (String.strip String.isspace name, "")
   | _ -> None
 
-(** Parses a list of XML elements of the form:    *)
-(**     <name0>value0</name0>                     *)
-(**     <name1>value1</name1>                     *)
-(**     <name2>value2</name2>                     *)
-(**     ...                                       *)
-(** Returns a string hash table with an entry for *)
-(** each element matched:                         *)
-(**     (name0 -> value0)                         *)
-(**     (name1 -> value1)                         *)
-(**     (name2 -> value2)                         *)
-(**     ...                                       *)
+(** Parses a list of XML elements of the form:
+        <name0>value0</name0>
+        <name1>value1</name1>
+        <name2>value2</name2>
+        ...
+    Returns a string hash table with an entry for
+    each element matched:
+        (name0 -> value0)
+        (name1 -> value1)
+        (name2 -> value2)
+        ...
+ *)
 let hash_table_of_leaf_xml_element_list list =
   Hashtblext.of_list (
     List.filter_map hash_table_entry_of_leaf_xml_element list
@@ -92,8 +93,8 @@ module DaemonConfiguration = struct
       address = host_t.host_address;
     }
 
-    (** Converts the given HA daemon host configuration *)
-    (** into an XML element tree.                       *)
+    (** Converts the given HA daemon host configuration
+        into an XML element tree. *)
     let to_xml_element host =
       Xml.Element (
         "host", [], [
@@ -182,8 +183,8 @@ module DaemonConfiguration = struct
   let int_parameter (name, param) =
     Opt.default [] (Opt.map (fun x -> [ xml_leaf_element name (string_of_int x) ]) param)
 
-  (** Converts the given HA daemon configuration *)
-  (** into an XML element tree.                  *)
+  (** Converts the given HA daemon configuration
+      into an XML element tree. *)
   let to_xml_element config = Xml.Element (
       "xhad-config",
       [("version", "1.0")],
@@ -230,8 +231,8 @@ module DaemonConfiguration = struct
       ]
     )
 
-  (** Converts the given HA daemon configuration *)
-  (** into an XML string.                        *)
+  (** Converts the given HA daemon configuration
+      into an XML string. *)
   let to_xml_string config =
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" ^ (
       Xml.to_string_fmt (
@@ -274,9 +275,9 @@ module LiveSetInformation = struct
       excluded: bool
     }
 
-    (** Creates a new host record from a host XML element. *)
-    (** The element must contain valid child elements for  *)
-    (** each member of the host record type.               *)
+    (** Creates a new host record from a host XML element.
+        The element must contain valid child elements for
+        each member of the host record type. *)
     let of_xml_element = function
       | Xml.Element ("host", _, children) ->
         begin
@@ -427,8 +428,8 @@ module LiveSetInformation = struct
     warning_on_local_host: Warning.t option;
   }
 
-  (** Creates a new HA live set information record *)
-  (** from the given list of XML elements.         *)
+  (** Creates a new HA live set information record
+      from the given list of XML elements. *)
   let of_xml_element_list elements = {
     hosts = Hashtblext.of_list (
         List.map
@@ -466,8 +467,8 @@ module LiveSetInformation = struct
     );
   }
 
-  (** Creates a new HA live set information record *)
-  (** from the given root XML element.             *)
+  (** Creates a new HA live set information record
+      from the given root XML element. *)
   let of_xml_element = function
     | Xml.Element ("ha_liveset_info", _, children) ->
       of_xml_element_list children

--- a/ocaml/xapi/xha_interface.mli
+++ b/ocaml/xapi/xha_interface.mli
@@ -147,9 +147,9 @@ module LiveSetInformation : sig
     warning_on_local_host: Warning.t option;
   }
 
-  (** Creates a new HA live set information record from the *)
-  (** given XML document string. Raises Invalid_argument if *)
-  (** the given string is either invalid or incomplete.     *)
+  (** Creates a new HA live set information record from the
+      given XML document string. Raises Invalid_argument if
+      the given string is either invalid or incomplete. *)
   val of_xml_string : string -> t
 
   (** Creates a compact one-line summary suitable for debug logging *)


### PR DESCRIPTION
With this change ocamlformat can be applied to the code without errors.

Ignors all the datamodel files as the format is quite special there and applying ocamlformat makes it hard to read.