### PR TITLE
CA-338602: lwsmd daemon should not be running when AD is not configured

### DIFF
--- a/ocaml/xapi/extauth.ml
+++ b/ocaml/xapi/extauth.ml
@@ -24,10 +24,6 @@ open D
 exception Unknown_extauth_type of string
 exception Extauth_is_disabled
 
-let auth_type_NONE = ""
-let auth_type_AD_Likewise = "AD"
-let auth_type_PAM = "PAM"
-
 module Ext_auth =
 struct
 

--- a/ocaml/xapi/extauth_plugin_ADpbis.ml
+++ b/ocaml/xapi/extauth_plugin_ADpbis.ml
@@ -453,10 +453,10 @@ struct
       (* the space-replacement char used by pbis is defined at /etc/pbis/lsassd.conf *)
       let current_lw_space_replacement = '+' in
       String.iteri (fun i c ->
-        if c = current_lw_space_replacement then
-          Bytes.set defensive_copy i ' '
-        else ()
-      ) lwname;
+          if c = current_lw_space_replacement then
+            Bytes.set defensive_copy i ' '
+          else ()
+        ) lwname;
       Bytes.unsafe_to_string defensive_copy
     in
     let get_value name ls = if List.mem_assoc name ls then List.assoc name ls else "" in

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1184,6 +1184,17 @@ let retry ~__context ~doc ?(policy = Policy.standard) f =
 let retry_with_global_lock ~__context ~doc ?policy f =
   retry ~__context ~doc ?policy (fun () -> with_global_lock f)
 
+(* Retry function f until success or timeout, f should return true on success *)
+let rec retry_until_timeout ?(interval=0.1) ?(timeout=5.) doc f =
+  match f() with
+  | true -> ()
+  | false -> let next_interval = interval *. 1.5 in
+    let next_timeout = timeout -. interval in
+    if next_timeout < 0. then
+      raise Api_errors.(Server_error(internal_error, [Printf.sprintf "retry %s failed" doc]));
+    Thread.delay interval;
+    retry_until_timeout ~interval:next_interval ~timeout:next_timeout doc f
+
 let get_first_pusb ~__context usb_group =
   try
     List.hd (Db.USB_group.get_PUSBs ~__context ~self:usb_group)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2550,7 +2550,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
     let enable_external_auth ~__context ~host ~config ~service_name ~auth_type =
       info "Host.enable_external_auth: host = '%s'; service_name = '%s'; auth_type = '%s'" (host_uuid ~__context host) service_name auth_type;
       (* First assert that the AD feature is enabled if AD is requested *)
-      if auth_type = Extauth.auth_type_AD_Likewise then
+      if auth_type = Xapi_globs.auth_type_AD_Likewise then
         Pool_features.assert_enabled ~__context ~f:Features.AD;
       let local_fn = Local.Host.enable_external_auth ~host ~config ~service_name ~auth_type in
       do_op_on ~local_fn ~__context ~host

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -924,7 +924,7 @@ let server_init() =
         let maybe_wait_for_clustering_ip () =
           let host = Helpers.get_localhost ~__context in
           begin match Xapi_clustering.find_cluster_host ~__context ~host with
-          | Some self ->
+            | Some self ->
               debug "Waiting forever for cluster_host to gain an IP address";
               let ip = Xapi_mgmt_iface.(wait_for_clustering_ip ~__context ~self) in
               debug "Got clustering IP %s, resyncing cluster_host %s" ip (Ref.string_of self);
@@ -932,7 +932,7 @@ let server_init() =
               debug "Attempting to re-plug remaining unplugged PBDs";
               Helpers.call_api_functions ~__context (fun rpc session_id ->
                   Create_storage.plug_unplugged_pbds __context)
-          | None -> ()
+            | None -> ()
           end;
           Helpers.call_api_functions ~__context (fun rcp session_id ->
               ignore(Create_storage.check_for_unplugged_pbds ~__context ~alert:true))
@@ -957,6 +957,8 @@ let server_init() =
           (* Start the external authentification plugin *)
           "Calling extauth_hook_script_before_xapi_initialize", [ Startup.NoExnRaising ],
           (fun () -> call_extauth_hook_script_before_xapi_initialize ~__context);
+          "Initializing lwsmd service", [ Startup.NoExnRaising ],
+          (fun () -> Extauth_plugin_ADpbis.Lwsmd.init_service ~__context);
           "Calling on_xapi_initialize event hook in the external authentication plugin", [ Startup.NoExnRaising; Startup.OnThread ],
           (fun () -> event_hook_auth_on_xapi_initialize_async ~__context);
           "Cleanup attached pool_updates when start", [ Startup.NoExnRaising ],

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -293,6 +293,10 @@ let startup_script_hook = ref "xapi-startup-script"
 (* Executed when a rolling upgrade is detected starting or stopping *)
 let rolling_upgrade_script_hook = ref "xapi-rolling-upgrade"
 
+(* Executed during startup when the host is authed with AD
+ * or the host is joining or leaving AD *)
+let domain_join_cli_cmd = ref "/opt/pbis/bin/domainjoin-cli"
+
 (* When set to true indicates that the host has still booted so we're initialising everything
    from scratch e.g. shared storage, sampling boot free mem etc *)
 let on_system_boot = ref false
@@ -979,6 +983,7 @@ module Resources = struct
     "rolling-upgrade-script-hook", rolling_upgrade_script_hook, "Executed when a rolling upgrade is detected starting or stopping";
     "xapi-message-script", xapi_message_script, "Executed when messages are generated if email feature is disabled";
     "non-managed-pifs", non_managed_pifs, "Executed during PIF.scan to find out which NICs should not be managed by xapi";
+    "domain_join_cli_cmd", domain_join_cli_cmd, "Command to manage pbis related service";
     "update-issue", update_issue_script, "Running update-service when configuring the management interface";
     "killall", kill_process_script, "Executed to kill process";
     "nbd-firewall-config", nbd_firewall_config_script, "Executed after NBD-related networking changes to configure the firewall for NBD";

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -466,6 +466,11 @@ let redo_log_alert_key = "metadata_lun_alerts"
 let serialize_pool_enable_disable_extauth = Mutex.create()
 (* CP-695: controls our asynchronous persistent initialization of the external authentication service during Xapi.server_init *)
 
+(* Auth types *)
+let auth_type_NONE = ""
+let auth_type_AD_Likewise = "AD"
+let auth_type_PAM = "PAM"
+
 let event_hook_auth_on_xapi_initialize_succeeded = ref false
 
 (** {2 CPUID feature masking} *)

--- a/ocaml/xapi/xapi_subject.ml
+++ b/ocaml/xapi/xapi_subject.ml
@@ -36,7 +36,7 @@ let create ~__context ~subject_identifier ~other_config =
   (* If at least one of the hosts uses AD external auth, then assert that the AD feature is enabled *)
   let hosts = Db.Host.get_all ~__context in
   let auth_types = List.map (fun self -> Db.Host.get_external_auth_type ~__context ~self) hosts in
-  if List.exists (fun x -> x = Extauth.auth_type_AD_Likewise) auth_types then
+  if List.exists (fun x -> x = Xapi_globs.auth_type_AD_Likewise) auth_types then
     Pool_features.assert_enabled ~__context ~f:Features.AD;
 
   (* we need to find if subject is already in the pool *)


### PR DESCRIPTION
CA-338602: lwsmd daemon should not be running when AD is not configured
    
    This commit suppose lwsmd service is not bootup by default, and
    manage lwsmd service as follows
    1. during xapi start, it will start lwsmd if the host is authed
    with AD
    2. start lwsmd during enabling AD auth
    3. stop lwsmd during disabling AD auth
    
    Signed-off-by: Lin Liu <lin.liu@citrix.com>