### PR TITLE
Revert "CA-336730 add debugging to help solve template timeout issue"

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -344,22 +344,16 @@ let call_api_functions_internal ~__context f =
   finally
     (fun () -> f rpc session_id)
     (fun () ->
+       (* debug "remote client call finished; logging out"; *)
        if !require_explicit_logout
-       then (
-         debug "Helpers.call_api_functions: explicit log out";
+       then
          try Client.Client.Session.logout rpc session_id
          with e ->
            debug "Helpers.call_api_functions failed to logout: %s (ignoring)" (Printexc.to_string e))
-       else
-        debug "Helpers.call_api_functions: no need to explicitly log out"
-    )
-
 
 let call_api_functions ~__context f =
   match Context.get_test_rpc __context with
-  | Some rpc -> ( debug "helpers.ml:call_api_functions fake_session";
-                  f rpc (Ref.of_string "fake_session")
-                )
+  | Some rpc -> f rpc (Ref.of_string "fake_session")
   | None ->
     call_api_functions_internal ~__context f
 

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1601,13 +1601,11 @@ let with_error_handling f =
     end
 
 (** Import metadata only *)
-let _metadata_handler (req: Request.t) s _ =
+let metadata_handler (req: Request.t) s _ =
   debug "metadata_handler called";
   req.Request.close <- true;
   Xapi_http.with_context "VM.metadata_import" req s
-    (fun __context -> debug "import.ml:metadata_handler: before call_api_functions";
-         Helpers.call_api_functions ~__context (fun rpc session_id ->
-         debug "import.ml:metadata_handler: inside call_api_functions";
+    (fun __context -> Helpers.call_api_functions ~__context (fun rpc session_id ->
          let full_restore = find_query_flag req.Request.query "restore" in
          let force = find_query_flag req.Request.query "force" in
          let dry_run = find_query_flag req.Request.query "dry_run" in
@@ -1660,16 +1658,7 @@ let _metadata_handler (req: Request.t) s _ =
                     end;
                     raise e
                 )
-           )));
-    debug "import.ml:metadata_handler done"
-
-let metadata_handler req s x =
-  try
-    _metadata_handler req s x
-  with e ->
-    debug "import.ml:metadata_handler: exception: %s" (Printexc.to_string e);
-    Backtrace.is_important e;
-    raise e
+           )))
 
 let stream_import __context rpc session_id s content_length refresh_session config =
   let sr = match config.import_type with


### PR DESCRIPTION
This reverts commit 9fd79835aa0e91346491efb1a35f2fd65d06b245.

We are still seeing this issue, but we remove this debug logging for
the next release.

Signed-off-by: lippirk <ben.anson@citrix.com>