### PR TITLE
CA-339526 make gc_compact call public

### DIFF
--- a/ocaml/idl/datamodel_diagnostics.ml
+++ b/ocaml/idl/datamodel_diagnostics.ml
@@ -4,7 +4,6 @@ let gc_compact = call
     ~name:"gc_compact"
     ~in_product_since:Datamodel_types.rel_stockholm
     ~doc:"Perform a full major collection and compact the heap on a host"
-    ~hide_from_docs:true
     ~params:[Ref _host, "host", "The host to perform GC"]
     ~errs:[]
     ~allowed_roles:Datamodel_roles._R_POOL_OP


### PR DESCRIPTION
Make the new gc_compact API call public:

* because it can be useful for clients
* to cause the SDK export this class, which otherwise would be empty
  and not exported. This causes problems with reading state.db into
  XenCenter, which is now avoided.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>