### PR TITLE
CA-339656 use HOME when generating SSL certificate

### DIFF
--- a/ocaml/gencert/dune
+++ b/ocaml/gencert/dune
@@ -4,6 +4,7 @@
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29-52))
   (modules lib)
   (libraries
+    forkexec
     mirage-crypto-pk
     mirage-crypto-rng.unix
     ptime
@@ -21,7 +22,6 @@
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29-52))
   (modules gencert)
   (libraries gencertlib
-             forkexec
              xapi-idl)
 )
 

--- a/ocaml/gencert/gencert.ml
+++ b/ocaml/gencert/gencert.ml
@@ -15,16 +15,14 @@
 (* Usage: gencert <path> *)
 
 let inventory = "/etc/xensource-inventory"
-let generate_ssl_cert = "/opt/xensource/libexec/generate_ssl_cert"
 
 module Lib = Gencertlib.Lib
 module D = Debug.Make(struct let name = "gencert" end)
 
 let generate_cert_or_fail ~path ~cn =
-  let args = [path; cn] in
-  let (stdout, stderr) = Forkhelpers.execute_command_get_output generate_ssl_cert args in
-  let (stdout, stderr) = (String.escaped stdout, String.escaped stderr) in
+  let (stdout, stderr) = Lib.call_generate_ssl_cert ~args:[path; cn] in
 
+  let (stdout, stderr) = (String.escaped stdout, String.escaped stderr) in
   D.debug {|generate_ssl_cert stdout: "%s"|} stdout;
   D.debug {|generate_ssl_cert stderr: "%s"|} stderr;
   if Sys.file_exists path then

--- a/ocaml/gencert/gencert.ml
+++ b/ocaml/gencert/gencert.ml
@@ -22,9 +22,13 @@ module D = Debug.Make(struct let name = "gencert" end)
 let generate_cert_or_fail ~path ~cn =
   let (stdout, stderr) = Lib.call_generate_ssl_cert ~args:[path; cn] in
 
-  let (stdout, stderr) = (String.escaped stdout, String.escaped stderr) in
-  D.debug {|generate_ssl_cert stdout: "%s"|} stdout;
-  D.debug {|generate_ssl_cert stderr: "%s"|} stderr;
+  let debug_lines prefix std_x =
+    let lines = String.split_on_char '\n' std_x in
+    List.iter (fun l -> D.debug {|%s: "%s"|} prefix l) lines
+  in
+  debug_lines "generate_ssl_cert stdout" stdout;
+  debug_lines "generate_ssl_cert stderr" stderr;
+
   if Sys.file_exists path then
     D.info "file exists (%s), assuming cert was created" path
   else begin

--- a/ocaml/gencert/lib.ml
+++ b/ocaml/gencert/lib.ml
@@ -17,8 +17,6 @@ module D = Debug.Make(struct let name = "gencert_lib" end)
 
 exception Unexpected_address_type of string
 
-let generate_ssl_cert = "/opt/xensource/libexec/generate_ssl_cert"
-
 let get_management_ip_addr ~dbg =
   let iface = Inventory.lookup Inventory._management_interface in
   try
@@ -42,7 +40,7 @@ let call_generate_ssl_cert ~args =
   | Some h -> h
   in
   let env = [| "PATH=" ^ (String.concat ":" Forkhelpers.default_path); "HOME=" ^ home |] in
-  Forkhelpers.execute_command_get_output generate_ssl_cert ~env args
+  Forkhelpers.execute_command_get_output !Constants.generate_ssl_cert ~env args
 
 open Api_errors
 open Rresult

--- a/ocaml/gencert/lib.mli
+++ b/ocaml/gencert/lib.mli
@@ -13,6 +13,9 @@
  *)
 
 val get_management_ip_addr : dbg:string -> string option
+
+val call_generate_ssl_cert : args:string list -> string * string
+
 val install_server_certificate :
   ?pem_chain:string option ->
   pem_leaf:string ->

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -247,3 +247,5 @@ let xapi_user_agent = "xapi/"^(string_of_int version_major)^"."^(string_of_int v
 
 (* Path to the pool configuration file. *)
 let pool_config_file = ref (Filename.concat "/etc/xensource" "pool.conf")
+
+let generate_ssl_cert = ref "/opt/xensource/libexec/generate_ssl_cert"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -976,7 +976,8 @@ module Resources = struct
     "fcoe-driver", fcoe_driver, "Execute during PIF unplug to get the lun devices related with the ether interface of the PIF";
     "list_domains", list_domains, "Path to the list_domains command";
     "systemctl", systemctl, "Control the systemd system and service manager";
-    "alert-certificate-check", alert_certificate_check, "Path to alert-certificate-check, which generates alerts on about-to-expire server certificates."
+    "alert-certificate-check", alert_certificate_check, "Path to alert-certificate-check, which generates alerts on about-to-expire server certificates.";
+    "generate_ssl_cert", Constants.generate_ssl_cert, "script to generate SSL certificates to be used by XAPI"
   ]
   let nonessential_executables = [
     "startup-script-hook", startup_script_hook, "Executed during startup";

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -26,6 +26,7 @@ open Network
 open Workload_balancing
 
 module D = Debug.Make(struct let name="xapi_host" end)
+module Gencert = Gencertlib.Lib
 open D
 
 let set_emergency_mode_error code params = Xapi_globs.emergency_mode_error := Api_errors.Server_error(code, params)
@@ -1150,10 +1151,9 @@ let install_server_certificate ~__context ~host ~certificate ~private_key ~certi
   Xapi_mgmt_iface.reconfigure_stunnel ~__context
 
 let emergency_reset_server_certificate ~__context =
-  let generate_ssl_cert = "/opt/xensource/libexec/generate_ssl_cert" in
 
   let args = [!Xapi_globs.server_cert_path; Helper_hostname.get_hostname (); "--force"] in
-  ignore @@ Forkhelpers.execute_command_get_output generate_ssl_cert args;
+  ignore @@ Gencert.call_generate_ssl_cert ~args;
 
   (* Reset stunnel to try to restablish TLS connections *)
   Xapi_mgmt_iface.reconfigure_stunnel ~__context;

--- a/scripts/gencert.service
+++ b/scripts/gencert.service
@@ -4,6 +4,7 @@ Requires=forkexecd.service
 After=forkexecd.service
 
 [Service]
+User=root
 Type=oneshot
 ExecStart=/opt/xensource/libexec/gencert /etc/xensource/xapi-ssl.pem
 RemainAfterExit=yes

--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -20,6 +20,7 @@ After=stunnel@xapi.service
 Conflicts=shutdown.target
 
 [Service]
+User=root
 Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
 Environment="MALLOC_CONF=narenas:1,tcache:false,lg_dirty_mult:22"
 Type=simple


### PR DESCRIPTION
openssl was complaining about being "unable to write 'random state'".
A fix for this is to set HOME or RANDFILE. We opt for the former to
avoid depleting the system's entropy.
     
openssl will now write to $HOME/.rnd