### PR TITLE
Revert "CA-339526 make gc_compact call public"

### DIFF
--- a/ocaml/idl/datamodel_diagnostics.ml
+++ b/ocaml/idl/datamodel_diagnostics.ml
@@ -4,6 +4,7 @@ let gc_compact = call
     ~name:"gc_compact"
     ~in_product_since:Datamodel_types.rel_stockholm
     ~doc:"Perform a full major collection and compact the heap on a host"
+    ~hide_from_docs:true
     ~params:[Ref _host, "host", "The host to perform GC"]
     ~errs:[]
     ~allowed_roles:Datamodel_roles._R_POOL_OP


### PR DESCRIPTION
This leads to a build failure in the SDK generator. Reverting it for the
moment.

This reverts commit d39fcf2994ef29df9e1545fe2a63d3ee15031473.