### PR TITLE
CA-339329 firstboot scripts shouldn't sync DB when ugprading

### DIFF
--- a/scripts/generate-iscsi-iqn
+++ b/scripts/generate-iscsi-iqn
@@ -7,6 +7,9 @@ set -e
 export FIRSTBOOT_DATA_DIR=/etc/firstboot.d/data
 export XENSOURCE_INVENTORY=/etc/xensource-inventory
 
+UPGRADE="false"
+[ -r ${FIRSTBOOT_DATA_DIR}/host.conf ] && . ${FIRSTBOOT_DATA_DIR}/host.conf
+
 . ${XENSOURCE_INVENTORY}
 IQN_CONF=${FIRSTBOOT_DATA_DIR}/iqn.conf
 
@@ -55,7 +58,10 @@ xe host-param-set uuid=${INSTALLATION_UUID} iscsi_iqn="${IQN}"
 echo Set iSCSI IQN: "${IQN}"
 echo IQN=\'"${IQN}"\' >${IQN_CONF}
 
-# Ensure changes are synced to disk
-xe pool-sync-database
+
+if [ "$UPGRADE" != "true" ]; then
+  # Ensure changes are synced to disk
+  xe pool-sync-database
+fi
 
 touch /var/lib/misc/ran-generate-iscsi-iqn

--- a/scripts/network-init
+++ b/scripts/network-init
@@ -23,7 +23,6 @@ pif_attached() {
 }
 
 prepare_networking() {
-    [ "$UPGRADE" = true ] && return 0
 
     $XE pif-scan host-uuid=${INSTALLATION_UUID}
 
@@ -109,11 +108,15 @@ rename_network_label() {
     done
 }
 
-prepare_networking
-rename_network_label
 
-# Ensure changes are synced to disk
-xe pool-sync-database
+if [ "$UPGRADE" = "true" ]; then
+    rename_network_label
+else
+    prepare_networking
+    rename_network_label
+    # Ensure changes are synced to disk
+    xe pool-sync-database
+fi
 
 touch /var/lib/misc/ran-network-init
 exit 0


### PR DESCRIPTION
There are 4 problematic scripts - we fix 2 of them here.

To preserve old behaviour of the firstboot scripts, we don't sync the
DB during an upgrade.

If we do sync the DB during an upgrade, then we get an error complaining
that incoming DBs have an incompatible schema version. This happens
because hosts are told to send the the minimally compliant Miami DB
- see pool_db_backup.ml.