### PR TITLE
CA-340484 bump xapi version in DB after upgrade/update

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -409,7 +409,7 @@ let create_root_user ~__context =
   let all = Db.User.get_records_where ~__context ~expr:(Eq(Field "short_name", Literal short_name)) in
   if all = [] then Db.User.create ~__context ~ref ~fullname ~short_name ~uuid ~other_config:[]
 
-let get_xapi_verstring () =
+let get_xapi_version () =
   Printf.sprintf "%d.%d" Constants.version_major Constants.version_minor
 
 (** Create assoc list of Supplemental-Pack information.
@@ -482,7 +482,7 @@ let make_software_version ~__context host_info =
   Xapi_globs.software_version () @
   v6_version @
   [
-    "xapi", get_xapi_verstring ();
+    "xapi", get_xapi_version ();
     "xen", Option.value ~default:"(unknown)" host_info.xen_verstring;
     "linux", host_info.linux_verstring;
     "xencenter_min", Xapi_globs.xencenter_min_verstring;

--- a/ocaml/xapi/create_misc.mli
+++ b/ocaml/xapi/create_misc.mli
@@ -44,4 +44,4 @@ val create_host_cpu : __context:Context.t -> host_info -> unit
 val create_pool_cpuinfo : __context:Context.t -> unit
 val create_chipset_info : __context:Context.t -> host_info -> unit
 val create_updates_requiring_reboot_info : __context:Context.t -> host:[`host] Ref.t -> unit
-val get_xapi_verstring : unit -> string
+val get_xapi_version : unit -> string

--- a/ocaml/xapi/create_misc.mli
+++ b/ocaml/xapi/create_misc.mli
@@ -44,3 +44,4 @@ val create_host_cpu : __context:Context.t -> host_info -> unit
 val create_pool_cpuinfo : __context:Context.t -> unit
 val create_chipset_info : __context:Context.t -> host_info -> unit
 val create_updates_requiring_reboot_info : __context:Context.t -> host:[`host] Ref.t -> unit
+val get_xapi_verstring : unit -> string

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -89,10 +89,10 @@ let refresh_localhost_info ~__context info =
   let old_software_version = Db.Host.get_software_version ~__context ~self:host in
   match List.assoc_opt "xapi" old_software_version with
   | None              -> D.error "host is missing xapi version. ref = %s" (Ref.string_of host)
-  | Some xapi_version -> (
-    let current_xapi_verstring = Create_misc.get_xapi_verstring () in
-    if xapi_version <> current_xapi_verstring then
-      let value = ("xapi", current_xapi_verstring) :: List.remove_assoc "xapi" old_software_version in
+  | Some old_xapi_version -> (
+    let current_xapi_version = Create_misc.get_xapi_version () in
+    if old_xapi_version <> current_xapi_version then
+      let value = ("xapi", current_xapi_version) :: List.remove_assoc "xapi" old_software_version in
       Db.Host.set_software_version ~__context ~self:host ~value
   );
 

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -84,6 +84,18 @@ let refresh_localhost_info ~__context info =
   Create_misc.create_software_version ~__context info;
   Db.Host.set_API_version_major ~__context ~self:host ~value:Datamodel_common.api_version_major;
   Db.Host.set_API_version_minor ~__context ~self:host ~value:Datamodel_common.api_version_minor;
+
+  (* update xapi version *)
+  let old_software_version = Db.Host.get_software_version ~__context ~self:host in
+  match List.assoc_opt "xapi" old_software_version with
+  | None              -> D.error "host is missing xapi version. ref = %s" (Ref.string_of host)
+  | Some xapi_version -> (
+    let current_xapi_verstring = Create_misc.get_xapi_verstring () in
+    if xapi_version <> current_xapi_verstring then
+      let value = ("xapi", current_xapi_verstring) :: List.remove_assoc "xapi" old_software_version in
+      Db.Host.set_software_version ~__context ~self:host ~value
+  );
+
   Db.Host.set_virtual_hardware_platform_versions ~__context ~self:host ~value:Xapi_globs.host_virtual_hardware_platform_versions;
   Db.Host.set_hostname ~__context ~self:host ~value:info.hostname;
   let caps =


### PR DESCRIPTION
We got round to bumping the hardcoded API version in b81af6e, but
the API version is also stored in the DB, which was not changed.
This was causing problems with the firstboot create-guest-template
service since ultimately it gets a host's API version from the DB,
and then uses that version to perform a template import, leading to
an IMPORT_INCOMPATIBLE_VERSION error.