### PR TITLE
Revert "Revert "CA-334811 assign xapi version automatically""

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,25 @@ include config.mk
 XAPIDOC=_build/install/default/xapi/doc
 JOBS = $(shell getconf _NPROCESSORS_ONLN)
 PROFILE=release
+XAPI_VERSION ?= $(shell git describe --always --dirty || echo "NO_GIT")
 
 .PHONY: build clean test doc python format install uninstall
 
 build:
-	dune build @install -j $(JOBS) --profile=$(PROFILE)
+	XAPI_VERSION=$(XAPI_VERSION) dune build @install -j $(JOBS) --profile=$(PROFILE)
 
 # Quickly verify that the code compiles, without actually building it
 check:
-	dune build @check -j $(JOBS) --profile=$(PROFILE)
+	XAPI_VERSION=$(XAPI_VERSION) dune build @check -j $(JOBS) --profile=$(PROFILE)
 
 clean:
 	dune clean
 
 test:
-	dune runtest --profile=$(PROFILE) --no-buffer -j $(JOBS)
+	XAPI_VERSION=$(XAPI_VERSION) dune runtest --profile=$(PROFILE) --no-buffer -j $(JOBS)
 
 doc:
-	dune build --profile=$(PROFILE) ocaml/idl/datamodel_main.exe
+	XAPI_VERSION=$(XAPI_VERSION) dune build --profile=$(PROFILE) ocaml/idl/datamodel_main.exe
 	dune build --profile=$(PROFILE) -f @ocaml/doc/jsapigen
 	mkdir -p $(XAPIDOC)/html
 	cp -r _build/default/ocaml/doc/api $(XAPIDOC)/html

--- a/ocaml/util/dune
+++ b/ocaml/util/dune
@@ -1,6 +1,7 @@
 (rule
   (targets build_info.ml)
-  (action (with-stdout-to %{targets} (run "date" "+let date=\"%Y-%m-%d\"")))
+  (deps gen_build_info_ml.sh)
+  (action (with-stdout-to %{targets} (bash "./gen_build_info_ml.sh")))
 )
 
 (library

--- a/ocaml/util/gen_build_info_ml.sh
+++ b/ocaml/util/gen_build_info_ml.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+DATE=$(date "+%Y-%m-%d")
+
+if [[ -z "$XAPI_VERSION" ]]; then
+  printf "XAPI_VERSION not set" 1>&2
+  exit 1
+fi
+XAPI_VERSION="${XAPI_VERSION#v}"
+
+printf "let date = \"%s\"\n\n" "$DATE"
+printf "let version = \"%s\"\n" "$XAPI_VERSION"

--- a/ocaml/util/xapi_version.ml
+++ b/ocaml/util/xapi_version.ml
@@ -9,5 +9,8 @@
 let git_id = ""
 let hostname = "localhost"
 let date = Build_info.date
-let xapi_version_major = 1
-let xapi_version_minor = 20
+let (xapi_version_major, xapi_version_minor) =
+  try
+    Scanf.sscanf Build_info.version "%d.%d.%s" (fun maj min _rest -> (maj, min))
+  with _ ->
+    failwith (Printf.sprintf "Couldn't determine xapi version - got unexpected XAPI_VERSION='%s'" Build_info.version)

--- a/xapi-cli-protocol.opam
+++ b/xapi-cli-protocol.opam
@@ -4,6 +4,7 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [[ "dune" "build" "-p" name ]]
 
 depends: [

--- a/xapi-client.opam
+++ b/xapi-client.opam
@@ -4,6 +4,7 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [[ "dune" "build" "-p" name ]]
 
 depends: [

--- a/xapi-consts.opam
+++ b/xapi-consts.opam
@@ -4,6 +4,7 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [[ "dune" "build" "-p" name ]]
 
 depends: [

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -4,6 +4,7 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}

--- a/xapi-datamodel.opam
+++ b/xapi-datamodel.opam
@@ -4,6 +4,7 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [[ "dune" "build" "-p" name ]]
 
 depends: [

--- a/xapi-types.opam
+++ b/xapi-types.opam
@@ -4,6 +4,7 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [[ "dune" "build" "-p" name ]]
 
 depends: [

--- a/xapi.opam
+++ b/xapi.opam
@@ -4,6 +4,7 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/xe.opam
+++ b/xe.opam
@@ -4,6 +4,7 @@ authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [[ "dune" "build" "-p" name ]]
 
 depends: [


### PR DESCRIPTION
This reverts commit 5c05f22a187908b6c832113803607b2758e95264.
We have found the bug in guest-templates-json: it was running on a
slave, when it shouldn't.

Try to restore the version number change and the stricter check.

Running a build and will do some tests.

