### PR TITLE
CP-33774 PSR orchestration

### DIFF
--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -6,6 +6,7 @@
     alcotest
     astring
     fmt
+    rresult
     xapi_internal
     xapi-stdext-date
     xapi-stdext-std

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -79,4 +79,5 @@ let () =
        ; Test_extauth_plugin_ADpbis.tests
        ; Test_helpers.tests
        ; Test_datamodel_utils.tests
+       ; Test_psr.tests
        ])

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -4,77 +4,79 @@ let () =
      so we will probably not exceed the 4MB limit in Travis *)
   Debug.log_to_stdout () ;
   Alcotest.run "Base suite"
-    ([
-       ("Test_valid_ref_list", Test_valid_ref_list.test)
-     ; ("Test_sdn_controller", Test_sdn_controller.test)
-     ; ("Test_pci_helpers", Test_pci_helpers.test)
-     ; ("Test_vdi_allowed_operations", Test_vdi_allowed_operations.test)
-     ; ("Test_sr_allowed_operations", Test_sr_allowed_operations.test)
-     ; ("Test_vm_migrate", Test_vm_migrate.test)
-     ; ("Test_no_migrate", Test_no_migrate.test)
-     ; ("Test_vm_check_operation_error", Test_vm_check_operation_error.test)
-     ; ("Test_vm_helpers", Test_vm_helpers.test)
-     ; ("Test_xapi_vbd_helpers", Test_xapi_vbd_helpers.test)
-     ; ("Test_host", Test_host.test)
-     ; ("Test_host_helpers", Test_host_helpers.test)
-     ; ("Test_vdi_cbt", Test_vdi_cbt.test)
-     ; ("Test_sr_update_vdis", Test_sr_update_vdis.test)
-     ; ("Test_xapi_db_upgrade", Test_xapi_db_upgrade.test)
-     ; ("Test_db_lowlevel", Test_db_lowlevel.test)
-     ; ("Test_vlan", Test_vlan.test)
-     ; ("Test_network", Test_network.test)
-     ; ("Test_network_sriov", Test_network_sriov.test)
-     ; ("Test_bond", Test_bond.test)
-     ; ("Test_tunnel", Test_tunnel.test)
-     ; ("Test_agility", Test_agility.test)
-     ; ("Test_daemon_manager", Test_daemon_manager.test)
-     ; ("Test_cluster", Test_cluster.test)
-     ; ("Test_cluster_host", Test_cluster_host.test)
-     ; ("Test_clustering", Test_clustering.test)
-     ; ( "Test_clustering_allowed_operations"
-       , Test_clustering_allowed_operations.test )
-     ; ("Test_client", Test_client.test)
-     ; ("Test_ca91480", Test_ca91480.test)
-     ; ("Test_pgpu", Test_pgpu.test)
-     ; ("Test_gpu_group", Test_gpu_group.test)
-     ; ("Test_pool_apply_edition", Test_pool_apply_edition.test)
-     ; ("Test_pool_update", Test_pool_update.test)
-     ; ("Test_pool_db_backup", Test_pool_db_backup.test)
-     ; ("Test_pool_restore_database", Test_pool_restore_database.test)
-     ; ("Test_workload_balancing", Test_workload_balancing.test)
-     ; ("Test_pusb", Test_pusb.test)
-     ; ("Test_pvs_site", Test_pvs_site.test)
-     ; ("Test_pvs_proxy", Test_pvs_proxy.test)
-     ; ("Test_pvs_server", Test_pvs_server.test)
-     ; ("Test_event", Test_event.test)
-     ; ("Test_vm_placement", Test_vm_placement.test)
-     ; ("Test_vm_memory_constraints", Test_vm_memory_constraints.test)
-     ; ("Test_xapi_xenops", Test_xapi_xenops.test)
-     ; ("Test_network_event_loop", Test_network_event_loop.test)
-     ; ("Test_vgpu_type", Test_vgpu_type.test)
-     ; ("Test_storage_migrate_state", Test_storage_migrate_state.test)
-     ; ("Test_bios_strings", Test_bios_strings.test)
-     ; ("Test_certificates", Test_certificates.test)
-     ]
-    @ Test_guest_agent.tests
-    @ Test_nm.tests
-    @ Test_xenopsd_metadata.tests
-    @ Test_http.tests
-    @ Test_ha_vm_failover.tests
-    @ Test_map_check.tests
-    @ Test_pool_license.tests
-    @ Test_features.tests
-    @ Test_platformdata.tests
-    @ Test_sm_features.tests
-    @ Test_vgpu_type.tests
-    @ Test_pgpu_helpers.tests
-    @ Test_storage_migrate_state.tests
-    @ Test_vm.tests
-    @ Test_cpuid_helpers.tests
-    @ Test_pool_cpuinfo.tests
-    @ Test_dbsync_master.tests
-    @ Test_pvs_cache_storage.tests
-    @ Test_extauth_plugin_ADpbis.tests
-    @ Test_helpers.tests
-    @ Test_datamodel_utils.tests
-    )
+    (List.concat
+       [
+         [
+           ("Test_valid_ref_list", Test_valid_ref_list.test)
+         ; ("Test_sdn_controller", Test_sdn_controller.test)
+         ; ("Test_pci_helpers", Test_pci_helpers.test)
+         ; ("Test_vdi_allowed_operations", Test_vdi_allowed_operations.test)
+         ; ("Test_sr_allowed_operations", Test_sr_allowed_operations.test)
+         ; ("Test_vm_migrate", Test_vm_migrate.test)
+         ; ("Test_no_migrate", Test_no_migrate.test)
+         ; ("Test_vm_check_operation_error", Test_vm_check_operation_error.test)
+         ; ("Test_vm_helpers", Test_vm_helpers.test)
+         ; ("Test_xapi_vbd_helpers", Test_xapi_vbd_helpers.test)
+         ; ("Test_host", Test_host.test)
+         ; ("Test_host_helpers", Test_host_helpers.test)
+         ; ("Test_vdi_cbt", Test_vdi_cbt.test)
+         ; ("Test_sr_update_vdis", Test_sr_update_vdis.test)
+         ; ("Test_xapi_db_upgrade", Test_xapi_db_upgrade.test)
+         ; ("Test_db_lowlevel", Test_db_lowlevel.test)
+         ; ("Test_vlan", Test_vlan.test)
+         ; ("Test_network", Test_network.test)
+         ; ("Test_network_sriov", Test_network_sriov.test)
+         ; ("Test_bond", Test_bond.test)
+         ; ("Test_tunnel", Test_tunnel.test)
+         ; ("Test_agility", Test_agility.test)
+         ; ("Test_daemon_manager", Test_daemon_manager.test)
+         ; ("Test_cluster", Test_cluster.test)
+         ; ("Test_cluster_host", Test_cluster_host.test)
+         ; ("Test_clustering", Test_clustering.test)
+         ; ( "Test_clustering_allowed_operations"
+           , Test_clustering_allowed_operations.test )
+         ; ("Test_client", Test_client.test)
+         ; ("Test_ca91480", Test_ca91480.test)
+         ; ("Test_pgpu", Test_pgpu.test)
+         ; ("Test_gpu_group", Test_gpu_group.test)
+         ; ("Test_pool_apply_edition", Test_pool_apply_edition.test)
+         ; ("Test_pool_update", Test_pool_update.test)
+         ; ("Test_pool_db_backup", Test_pool_db_backup.test)
+         ; ("Test_pool_restore_database", Test_pool_restore_database.test)
+         ; ("Test_workload_balancing", Test_workload_balancing.test)
+         ; ("Test_pusb", Test_pusb.test)
+         ; ("Test_pvs_site", Test_pvs_site.test)
+         ; ("Test_pvs_proxy", Test_pvs_proxy.test)
+         ; ("Test_pvs_server", Test_pvs_server.test)
+         ; ("Test_event", Test_event.test)
+         ; ("Test_vm_placement", Test_vm_placement.test)
+         ; ("Test_vm_memory_constraints", Test_vm_memory_constraints.test)
+         ; ("Test_xapi_xenops", Test_xapi_xenops.test)
+         ; ("Test_network_event_loop", Test_network_event_loop.test)
+         ; ("Test_vgpu_type", Test_vgpu_type.test)
+         ; ("Test_storage_migrate_state", Test_storage_migrate_state.test)
+         ; ("Test_bios_strings", Test_bios_strings.test)
+         ; ("Test_certificates", Test_certificates.test)
+         ]
+       ; Test_guest_agent.tests
+       ; Test_nm.tests
+       ; Test_xenopsd_metadata.tests
+       ; Test_http.tests
+       ; Test_ha_vm_failover.tests
+       ; Test_map_check.tests
+       ; Test_pool_license.tests
+       ; Test_features.tests
+       ; Test_platformdata.tests
+       ; Test_sm_features.tests
+       ; Test_vgpu_type.tests
+       ; Test_pgpu_helpers.tests
+       ; Test_storage_migrate_state.tests
+       ; Test_vm.tests
+       ; Test_cpuid_helpers.tests
+       ; Test_pool_cpuinfo.tests
+       ; Test_dbsync_master.tests
+       ; Test_pvs_cache_storage.tests
+       ; Test_extauth_plugin_ADpbis.tests
+       ; Test_helpers.tests
+       ; Test_datamodel_utils.tests
+       ])

--- a/ocaml/tests/test_psr.ml
+++ b/ocaml/tests/test_psr.ml
@@ -1,0 +1,340 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+let default_pool_secret = "default_pool_secret"
+
+let new_pool_secret = "new_pool_secret"
+
+(* we could also test with a fistpoint 'During' the computation,
+   but this adds even more complexity to the test *)
+type fistpoint_time = Before | After
+
+let string_of_fistpoint_time = function Before -> "Before" | After -> "After"
+
+type fistpoint_action =
+  | Accept_new_pool_secret
+  | Send_new_pool_secret
+  | Cleanup
+
+let string_of_fistpoint_action = function
+  | Accept_new_pool_secret ->
+      "Accept_new_pool_secret"
+  | Send_new_pool_secret ->
+      "Send_new_pool_secret"
+  | Cleanup ->
+      "Cleanup"
+
+(* we place fistpoints either just before
+   executing some action or just after *)
+type fistpoint = fistpoint_time * fistpoint_action
+
+let string_of_fistpoint (t, p) =
+  Printf.sprintf "%s:%s"
+    (string_of_fistpoint_time t)
+    (string_of_fistpoint_action p)
+
+exception Fistpoint of fistpoint
+
+let () =
+  Printexc.register_printer (function
+    | Fistpoint fp ->
+        Some (string_of_fistpoint fp)
+    | _ ->
+        None)
+
+type host_id = int
+
+type member = {
+    id: host_id
+  ; mutable current_pool_secret: string
+  ; mutable staged_pool_secret: string option
+  ; mutable fistpoint: fistpoint option
+}
+
+type psr_state = {
+    mutable checkpoint: string option
+  ; mutable pool_secret_backups: (string * string) option
+}
+
+(* in the real implementation, the checkpoint and pool secret backups
+   are stored on the master, so we model that here *)
+type master = {member: member; psr_state: psr_state}
+
+type host_t = Master of master | Member of member
+
+let map_r f = Rresult.R.reword_error (fun (failure, e) -> (failure, f e))
+
+let string_of_failure = function
+  | Xapi_psr.Failed_during_accept_new_pool_secret ->
+      "Failed_during_accept_new_pool_secret"
+  | Failed_during_send_new_pool_secret ->
+      "Failed_send_new_pool_secret"
+  | Failed_during_cleanup ->
+      "Failed_during_cleanup"
+
+let string_of_r = function
+  | Ok () ->
+      "Success"
+  | Error (failure, host_id) ->
+      Printf.sprintf "%s: %d" (string_of_failure failure) host_id
+
+let mk_hosts num =
+  if num < 1 then failwith (Printf.sprintf "expected num > 0, but num=%d" num) ;
+  let member =
+    {
+      id= 0
+    ; current_pool_secret= default_pool_secret
+    ; staged_pool_secret= None
+    ; fistpoint= None
+    }
+  in
+  let master =
+    {member; psr_state= {checkpoint= None; pool_secret_backups= None}}
+  in
+  let members = List.init (num - 1) (fun id -> {member with id= id + 1}) in
+  (master, members)
+
+module Impl =
+functor
+  (Hosts : sig
+     val master : master
+
+     val members : member list
+   end)
+  ->
+  struct
+    open Hosts
+
+    type pool_secret = string
+
+    type pool_secrets = pool_secret * pool_secret
+
+    type host = host_t
+
+    let save_checkpoint x = master.psr_state.checkpoint <- Some x
+
+    let retrieve_checkpoint () = master.psr_state.checkpoint
+
+    let backup pool_secrets =
+      master.psr_state.pool_secret_backups <- Some pool_secrets
+
+    let retrieve () = Option.get master.psr_state.pool_secret_backups
+
+    let iter_host f = function Member m -> f m | Master m -> f m.member
+
+    let tell_accept_new_pool_secret (_, staged_pool_secret) =
+      iter_host (fun h ->
+          let f () = h.staged_pool_secret <- Some staged_pool_secret in
+          match h.fistpoint with
+          | Some ((Before, Accept_new_pool_secret) as fp) ->
+              raise (Fistpoint fp)
+          | Some ((After, Accept_new_pool_secret) as fp) ->
+              f () ; raise (Fistpoint fp)
+          | _ ->
+              f ())
+
+    let tell_send_new_pool_secret _ =
+      iter_host (fun h ->
+          let f () = h.current_pool_secret <- Option.get h.staged_pool_secret in
+          match h.fistpoint with
+          | Some ((Before, Send_new_pool_secret) as fp) ->
+              raise (Fistpoint fp)
+          | Some ((After, Send_new_pool_secret) as fp) ->
+              f () ; raise (Fistpoint fp)
+          | _ ->
+              f ())
+
+    let tell_cleanup_old_pool_secret =
+      iter_host (fun h ->
+          let f () = h.staged_pool_secret <- None in
+          match h.fistpoint with
+          | Some ((Before, Cleanup) as fp) ->
+              raise (Fistpoint fp)
+          | Some ((After, Cleanup) as fp) ->
+              f () ; raise (Fistpoint fp)
+          | _ ->
+              f ())
+
+    let cleanup_master () =
+      let f () =
+        master.member.staged_pool_secret <- None ;
+        master.psr_state.checkpoint <- None ;
+        master.psr_state.pool_secret_backups <- None
+      in
+      match master.member.fistpoint with
+      | Some ((Before, Cleanup) as fp) ->
+          raise (Fistpoint fp)
+      | Some ((After, Cleanup) as fp) ->
+          f () ; raise (Fistpoint fp)
+      | _ ->
+          f ()
+  end
+
+module type PSR = sig
+  val start :
+       string * string
+    -> master:master
+    -> members:member list
+    -> host_id Xapi_psr.r
+end
+
+(* the test implementation has been defined above,
+   and we use this function to access it *)
+let mk_psr master members =
+  let module PSR = Xapi_psr.Make (Impl (struct
+    let master = master
+
+    let members = members
+  end)) in
+  let module PSR = struct
+    include PSR
+
+    let start pool_secrets ~master ~members =
+      start pool_secrets ~master:(Master master)
+        ~members:(List.map (fun m -> Member m) members)
+      |> map_r (function Member m -> m.id | Master m -> m.member.id)
+  end in
+  (module PSR : PSR)
+
+let r' = Alcotest.testable (Fmt.of_to_string string_of_r) ( = )
+
+let check_psr_succeeded r exp_pool_secret master members =
+  let hosts = master.member :: members in
+  Alcotest.check r' "PSR should be successful" (Ok ()) r ;
+  List.iter
+    (fun h ->
+      Alcotest.(
+        check string "new pool secret should be correct" exp_pool_secret
+          h.current_pool_secret))
+    hosts ;
+  List.iter
+    (fun h ->
+      Alcotest.(
+        check (option string) "staged_pool_secret is null" None
+          h.staged_pool_secret))
+    hosts ;
+  let psr_state = master.psr_state in
+  Alcotest.(
+    check (option string) "checkpoint was cleaned up" None psr_state.checkpoint) ;
+  Alcotest.(
+    check
+      (option (pair string string))
+      "pool secret backups were cleaned up" None psr_state.pool_secret_backups)
+
+(* we test almost all combinations of hosts and fistpoints. the only
+   case we don't test is one case of master cleanup failure,
+   since it is slightly different - it has its own unit test (see below).
+ *)
+let almost_all_possible_fists ~num_hosts =
+  let multiply fp_times fp_actions host_ids =
+    List.map
+      (fun time ->
+        List.map
+          (fun (action, mk_expected_err) ->
+            List.map
+              (fun host_id ->
+                ((time, action), host_id, mk_expected_err host_id))
+              host_ids)
+          fp_actions)
+      fp_times
+    |> List.concat
+    |> List.concat
+  in
+  let range = List.init num_hosts Fun.id in
+  let open Xapi_psr in
+  let master_fistpoints =
+    multiply [Before; After]
+      [
+        ( Accept_new_pool_secret
+        , fun id -> Error (Failed_during_accept_new_pool_secret, id) )
+      ; ( Send_new_pool_secret
+        , fun id -> Error (Failed_during_send_new_pool_secret, id) )
+      ]
+      [0]
+    |> List.cons ((Before, Cleanup), 0, Error (Failed_during_cleanup, 0))
+  in
+  let member_fistpoints =
+    multiply [Before; After]
+      [
+        ( Accept_new_pool_secret
+        , fun id -> Error (Failed_during_accept_new_pool_secret, id) )
+      ; ( Send_new_pool_secret
+        , fun id -> Error (Failed_during_send_new_pool_secret, id) )
+      ; (Cleanup, fun id -> Error (Failed_during_cleanup, id))
+      ]
+      (List.tl range)
+  in
+  List.append member_fistpoints master_fistpoints
+
+let test_no_fistpoint () =
+  let master, members = mk_hosts 6 in
+  let module PSR = (val mk_psr master members) in
+  let r = PSR.start (default_pool_secret, new_pool_secret) ~master ~members in
+  check_psr_succeeded r new_pool_secret master members
+
+(* try PSR with a fistpoint primed, check that it
+   fails; then retry without any fistpoints and
+   check that it succeeds. *)
+let test_fail_once () =
+  let num_hosts = 3 in
+  let master, members = mk_hosts num_hosts in
+  let module PSR = (val mk_psr master members) in
+  let hosts = master.member :: members in
+  almost_all_possible_fists ~num_hosts
+  |> List.iter (fun (fistpoint, host_id, exp_err) ->
+         let new_pool_secret =
+           Printf.sprintf "%s-%d-%s" new_pool_secret host_id
+             (string_of_fistpoint fistpoint)
+         in
+         let faulty_host = List.nth hosts host_id in
+         faulty_host.fistpoint <- Some fistpoint ;
+         let r =
+           PSR.start (default_pool_secret, new_pool_secret) ~master ~members
+         in
+         Alcotest.check r'
+           (Printf.sprintf "PSR should fail with %s" (string_of_r exp_err))
+           exp_err r ;
+         faulty_host.fistpoint <- None ;
+         let r = PSR.start (default_pool_secret, "not_used") ~master ~members in
+         check_psr_succeeded r new_pool_secret master members)
+
+let test_master_fails_during_cleanup () =
+  let open Xapi_psr in
+  let num_hosts = 6 in
+  let master, members = mk_hosts num_hosts in
+  let module PSR = (val mk_psr master members) in
+  let fistpoint = (After, Cleanup) in
+  let exp_err = Error (Failed_during_cleanup, 0) in
+  master.member.fistpoint <- Some fistpoint ;
+  let r = PSR.start (default_pool_secret, new_pool_secret) ~master ~members in
+  Alcotest.check r'
+    (Printf.sprintf "PSR should fail with %s" (string_of_r exp_err))
+    exp_err r ;
+  master.member.fistpoint <- None ;
+  let r =
+    PSR.start (default_pool_secret, "this_ps_gets_used") ~master ~members
+  in
+  check_psr_succeeded r "this_ps_gets_used" master members
+
+let tests =
+  [
+    ( "PSR"
+    , [
+        ("test_no_fistpoint", `Quick, test_no_fistpoint)
+      ; ("test_fail_once", `Quick, test_fail_once)
+      ; ( "test_master_fails_during_cleanup"
+        , `Quick
+        , test_master_fails_during_cleanup )
+      ] )
+  ]

--- a/ocaml/xapi/xapi_psr.ml
+++ b/ocaml/xapi/xapi_psr.ml
@@ -1,0 +1,155 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** important invariants:
+  * given a list of hosts containing both the master and
+    the members, the master will always be at the head *)
+module D = Debug.Make (struct
+  let name = "xapi_psr"
+end)
+
+type failure =
+  | Failed_during_accept_new_pool_secret
+  | Failed_during_send_new_pool_secret
+  | Failed_during_cleanup
+
+type 'a r = (unit, failure * 'a) result
+
+module type Impl = sig
+  type pool_secret
+
+  type pool_secrets = pool_secret * pool_secret (* (old, new) *)
+
+  type host
+
+  val save_checkpoint : string -> unit
+
+  val retrieve_checkpoint : unit -> string option
+
+  val backup : pool_secrets -> unit
+
+  val retrieve : unit -> pool_secrets
+
+  val tell_accept_new_pool_secret : pool_secrets -> host -> unit
+
+  val tell_send_new_pool_secret : pool_secrets -> host -> unit
+
+  val tell_cleanup_old_pool_secret : host -> unit
+
+  val cleanup_master : unit -> unit
+end
+
+module Make =
+functor
+  (Impl : Impl)
+  ->
+  struct
+    let ( >>= ) = Rresult.( >>= )
+
+    type checkpoint =
+      | No_checkpoint (* ==> previous rotation was successful*)
+      | Accept_new_pool_secret
+      | Send_new_pool_secret
+      | Cleanup_members
+      | Cleanup_master
+    [@@deriving rpcty]
+
+    exception Cannot_parse_checkpoint of string
+
+    let string_of_checkpoint x =
+      Rpcmarshal.marshal checkpoint.Rpc.Types.ty x |> Jsonrpc.to_string
+      |> (* remove leading and trailing '"' *)
+      fun s -> String.sub s 1 (String.length s - 2)
+
+    let checkpoint_of_string s =
+      let rpc = Rpc.rpc_of_string s in
+      match Rpcmarshal.unmarshal checkpoint.Rpc.Types.ty rpc with
+      | Ok x ->
+          x
+      | Error _ ->
+          raise (Cannot_parse_checkpoint s)
+
+    let rec iter_break f = function
+      | [] ->
+          Ok ()
+      | x :: xs ->
+          f x >>= fun _ -> (iter_break [@tailcall]) f xs
+
+    let rec go pool_secrets master members = function
+      | No_checkpoint ->
+          (* if we fail to backup the pool secrets, it doesn't really matter,
+             you can simply restart the rotation *)
+          Impl.backup pool_secrets ;
+          (go [@tailcall]) pool_secrets master members Accept_new_pool_secret
+      | Accept_new_pool_secret ->
+          Impl.save_checkpoint (string_of_checkpoint Accept_new_pool_secret) ;
+          master :: members
+          |> iter_break (fun host ->
+                 try
+                   Impl.tell_accept_new_pool_secret pool_secrets host ;
+                   Ok ()
+                 with e ->
+                   D.error
+                     "failed while telling host to accept new pool secret. \
+                      error= %s"
+                     (Printexc.to_string e) ;
+                   Error (Failed_during_accept_new_pool_secret, host))
+          >>= fun () ->
+          (go [@tailcall]) pool_secrets master members Send_new_pool_secret
+      | Send_new_pool_secret ->
+          Impl.save_checkpoint (string_of_checkpoint Send_new_pool_secret) ;
+          master :: members
+          |> iter_break (fun host ->
+                 try
+                   Impl.tell_send_new_pool_secret pool_secrets host ;
+                   Ok ()
+                 with e ->
+                   D.error
+                     "failed while telling hosts to send new pool secret. \
+                      error= %s"
+                     (Printexc.to_string e) ;
+                   Error (Failed_during_send_new_pool_secret, host))
+          >>= fun () ->
+          (go [@tailcall]) pool_secrets master members Cleanup_members
+      | Cleanup_members ->
+          Impl.save_checkpoint (string_of_checkpoint Cleanup_members) ;
+          members
+          |> iter_break (fun member ->
+                 try
+                   Impl.tell_cleanup_old_pool_secret member ;
+                   Ok ()
+                 with e ->
+                   D.error "failed while telling hosts to cleanup. error= %s"
+                     (Printexc.to_string e) ;
+                   Error (Failed_during_cleanup, member))
+          >>= fun () ->
+          (go [@tailcall]) pool_secrets master members Cleanup_master
+      | Cleanup_master -> (
+          Impl.save_checkpoint (string_of_checkpoint Cleanup_master) ;
+          try Impl.cleanup_master () ; Ok ()
+          with e ->
+            D.error "failed to cleanup the master. error= %s"
+              (Printexc.to_string e) ;
+            Error (Failed_during_cleanup, master)
+        )
+
+    let start pool_secrets ~master ~members =
+      match Impl.retrieve_checkpoint () |> Option.map checkpoint_of_string with
+      | None | Some No_checkpoint ->
+          go pool_secrets master members No_checkpoint
+      | Some checkpoint ->
+          go (Impl.retrieve ()) master members checkpoint
+  end
+
+let start ~__context = failwith "not impl"

--- a/ocaml/xapi/xapi_psr.mli
+++ b/ocaml/xapi/xapi_psr.mli
@@ -1,0 +1,73 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** psr = pool secret rotation
+  * ps = pool secret = ptoken *)
+
+type failure =
+  | Failed_during_accept_new_pool_secret
+  | Failed_during_send_new_pool_secret
+  | Failed_during_cleanup
+
+type 'a r = (unit, failure * 'a) result
+
+(* entry point *)
+val start : __context:Context.t -> unit
+
+(* the rest is exposed for unit testing *)
+
+module type Impl = sig
+  (* real impl uses SecretString.t
+     but tests use string for simplicity *)
+  type pool_secret
+
+  (* the old pool_secret will be used as proof that
+     a host should accept an incoming pool_secret *)
+  (* = (old_pool_secret, new_pool_secret) *)
+  type pool_secrets = pool_secret * pool_secret
+
+  type host
+
+  (* checkpoints should be written to persistent
+     storage in the event that a PSR fails. the
+     next PSR will resume from the last checkpoint *)
+  val save_checkpoint : string -> unit
+
+  val retrieve_checkpoint : unit -> string option
+
+  (* if a PSR fails, the next PSR will use the
+      backed-up pool_secrets *)
+  val backup : pool_secrets -> unit
+
+  val retrieve : unit -> pool_secrets
+
+  (* these tell_* are  executed on each host in the
+     pool. if any call fails, the PSR fails *)
+  val tell_accept_new_pool_secret : pool_secrets -> host -> unit
+
+  val tell_send_new_pool_secret : pool_secrets -> host -> unit
+
+  val tell_cleanup_old_pool_secret : host -> unit
+
+  (* cleanup master _after_ the members *)
+  val cleanup_master : unit -> unit
+end
+
+module Make : functor (Impl : Impl) -> sig
+  open Impl
+
+  (* we model a pool as a list of hosts.
+     we accept pool_secrets as a parameter to avoid non-determinism *)
+  val start : pool_secrets -> master:host -> members:host list -> host r
+end


### PR DESCRIPTION
We implement a function which orchestrates a pool secret rotation.
We handle failure by splitting the PSR into idempotent chunks, and
saving checkpoints at the end of each chunk. This will allow us to
resume from failed PSRs, and importantly reduce the chance of hosts
becoming locked out with the wrong pool secret.

Signed-off-by: lippirk <ben.anson@citrix.com>