### PR TITLE
CA-335033 avoid idle connections during VDI copy

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4557,7 +4557,15 @@ functor
         (* Try forward the request to a host which can have access to both source
            and destination SR. *)
         let op session_id rpc =
-          Client.VDI.copy rpc session_id vdi sr base_vdi into_vdi
+          let sync_op () =
+            Client.VDI.copy rpc session_id vdi sr base_vdi into_vdi
+          in
+          let async_op () =
+            Client.InternalAsync.VDI.copy rpc session_id vdi sr base_vdi
+              into_vdi
+          in
+          Helpers.try_internal_async ~__context API.ref_VDI_of_rpc async_op
+            sync_op
         in
         with_sr_andor_vdi ~__context
           ~vdi:(vdi, `copy)


### PR DESCRIPTION
Prefer to use Client.InternalAsync.VDI.copy over
Client.VDI.copy to avoid long running idle
connections when instructing a slave to perform
a VDI.copy.

For more information see CA-333610, where the
same problem was fixed for VM.migrate_send