### PR TITLE
CI: use github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,75 @@
+name: Build and test
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # run daily, this refreshes the cache
+    - cron: '13 2 * * *'
+
+jobs:
+  python-test:
+    name: Python tests
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ["", "-3"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run python tests
+        run: bash ./.travis-python-nosetests${{ matrix.test }}.sh
+
+  ocaml-test:
+    name: Ocaml tests
+    runs-on: ubuntu-20.04
+    env:
+      package: "xapi-cli-protocol xapi-client xapi-consts xapi-database xapi-datamodel xapi-types xapi xe"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Pull configuration from xs-opam
+        run: |
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+
+      - name: Load environment file
+        id: dotenv
+        uses: falti/dotenv-action@v0.2.4
+
+      - name: Retrieve date for cache key
+        id: cache-key
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+
+      - name: Restore opam cache
+        id: opam-cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.opam"
+          # invalidate cache daily, gets built daily using a scheduled job
+          key: ${{ steps.cache-key.outputs.date }}
+
+      - name: Use ocaml
+        uses: avsm/setup-ocaml@v1.1.0
+        with:
+          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repository: ${{ steps.dotenv.outputs.repository }}
+
+      - name: Install dependencies
+        run: |
+          opam pin add . --no-action
+          opam depext -u ${{ env.package }}
+          opam install ${{ env.package }} --deps-only --with-test -v
+
+      - name: Build
+        run: |
+          opam exec -- ./configure
+          opam exec -- make
+        env:
+          XAPI_VERSION: "v0.0.0-${{ github.sha }}"
+
+      - name: Run tests
+        run: opam exec -- make test


### PR DESCRIPTION
This approach substitutes the current shellscript for travis, as just simply running like in https://github.com/xapi-project/xs-opam/pull/468 produced failures.

The part that loads the .env file is a bit clunky since it needs to remove ` export ` from every line.

This approach has the benefit that it better shows how a developer would build and test the repository using an opam switch instead of running an opaque scripts that only is run for CI.

When running the jobs now it's plain simple how much do the steps take, most of the time being spent compiling the dependencies. Cache is used to speed up build by about 8 minutes, the cache is invalidated daily to minimize problems with packages in xs-opam that are not versioned and use 'master' as their version.

A daily scheduled run serves as a way to retest the build without a cache and rebuild the cache to spped up any jobs thay may be generated by PRs that day.

Sample run: https://github.com/psafont/xen-api/actions/runs/172460064

A similar setup is needed to enable testing in `1.249-lcm`, a bit more thinking is needed around the cache, as scheduled runs are only triggered for `master` branch.