### PR TITLE
CA-341149: Ensure a wait happen when the heartbeat connection fails

### DIFF
--- a/ocaml/xapi/db_gc.ml
+++ b/ocaml/xapi/db_gc.ml
@@ -260,12 +260,12 @@ let start_heartbeat_thread() = Debug.with_thread_named "heartbeat" (fun () ->
                        send_one_heartbeat ~__context rpc session_id;
                        Thread.delay !Xapi_globs.host_heartbeat_interval
                      with
-                     | (Api_errors.Server_error (x,y)) as e ->
-                       if x=Api_errors.session_invalid
-                       then raise e
-                       else debug "Caught exception in heartbeat thread: %s" (ExnHelper.string_of_exn e);
+                     | (Api_errors.Server_error (x,y)) as e
+                       when x=Api_errors.session_invalid ->
+                         raise e
                      | e ->
                        debug "Caught exception in heartbeat thread: %s" (ExnHelper.string_of_exn e);
+                       Thread.delay !Xapi_globs.host_heartbeat_interval
                    done)
             with
             | Api_errors.Server_error(code, params) when code = Api_errors.session_authentication_failed ->


### PR DESCRIPTION
This was happening in some cases, but not all

Backport of https://github.com/xapi-project/xen-api/commit/991de5bfaaee877b9a044b178d23ee56442588e9

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>