### PR TITLE
XSO-974: correctly reflect datamodel changes in stockholm

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1486,7 +1486,7 @@ end
 (* These are included in vbds and vifs -- abstracted here to keep both these uses consistent *)
 let device_status_fields =
   [
-    field ~ty:Bool ~qualifier:StaticRO ~default_value:(Some (VBool false)) ~lifecycle:[Changed, rel_stockholm, "Become static to allow plugged VIF and VBD creation for Suspended VM"] "currently_attached" "is the device currently attached (erased on reboot)";
+    field ~ty:Bool ~qualifier:StaticRO ~default_value:(Some (VBool false)) ~lifecycle:[Changed, rel_next, "Become static to allow plugged VIF and VBD creation for Suspended VM"] "currently_attached" "is the device currently attached (erased on reboot)";
     field ~ty:Int ~qualifier:DynamicRO "status_code" "error/success code associated with last attach-operation (erased on reboot)";
     field ~ty:String ~qualifier:DynamicRO "status_detail" "error/success information associated with last attach-operation status (erased on reboot)";
     field ~ty:(Map(String, String)) ~qualifier:DynamicRO "runtime_properties" "Device runtime properties"
@@ -3013,7 +3013,7 @@ module VBD = struct
            field ~qualifier:StaticRO ~ty:(Ref _vm) "VM" "the virtual machine";
            field ~qualifier:StaticRO ~ty:(Ref _vdi) "VDI" "the virtual disk";
 
-           field ~qualifier:StaticRO ~ty:String ~default_value:(Some (VString "")) ~lifecycle:[Changed, rel_stockholm, "Become static to allow plugged VBD creation for Suspended VM"] "device" "device seen by the guest e.g. hda1";
+           field ~qualifier:StaticRO ~ty:String ~default_value:(Some (VString "")) ~lifecycle:[Changed, rel_next, "Become static to allow plugged VBD creation for Suspended VM"] "device" "device seen by the guest e.g. hda1";
            field "userdevice" "user-friendly device name e.g. 0,1,2,etc.";
            field ~ty:Bool "bootable" "true if this VBD is bootable";
            field ~qualifier:StaticRO ~ty:mode "mode" "the mode the VBD should be mounted with";

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1284,7 +1284,7 @@ let set_NVRAM_EFI_variables = call ~flags:[`Session]
                    ]
       ~lifecycle:[
         Published, rel_rio, "";
-        Changed, rel_stockholm, "possibility to create a VM in suspended mode with a suspend_VDI set";
+        Changed, rel_next, "possibility to create a VM in suspended mode with a suspend_VDI set";
       ]
       ~messages_default_allowed_roles:_R_VM_ADMIN
       ~messages:[ snapshot; snapshot_with_quiesce; clone; copy; revert; checkpoint;
@@ -1363,12 +1363,12 @@ let set_NVRAM_EFI_variables = call ~flags:[`Session]
         ([ uid _vm;
          ] @ (allowed_and_current_operations operations) @ [
            namespace ~name:"name" ~contents:(names oss_since_303 RW) ();
-           field ~writer_roles:_R_VM_OP ~qualifier:StaticRO ~default_value:(Some (VEnum "Halted")) ~lifecycle:[Changed, rel_stockholm, "Become static to allow Suspended VM creation"] ~ty:power_state "power_state" "Current power state of the machine";
+           field ~writer_roles:_R_VM_OP ~qualifier:StaticRO ~default_value:(Some (VEnum "Halted")) ~lifecycle:[Changed, rel_next, "Become static to allow Suspended VM creation"] ~ty:power_state "power_state" "Current power state of the machine";
 
            field ~ty:Int "user_version" "Creators of VMs and templates may store version information here.";
            field ~effect:true ~ty:Bool "is_a_template" "true if this is a template. Template VMs can never be started, they are used only for cloning other VMs";
            field ~ty:Bool ~default_value:(Some (VBool false)) ~qualifier:DynamicRO ~writer_roles:_R_POOL_ADMIN ~lifecycle:[Published, rel_falcon, "Identifies default templates"] "is_default_template" "true if this is a default template. Default template VMs can never be started or migrated, they are used only for cloning other VMs";
-           field ~qualifier:StaticRO ~default_value:(Some (VRef null_ref)) ~lifecycle:[Changed, rel_stockholm, "Become static to allow Suspended VM creation"] ~ty:(Ref _vdi) "suspend_VDI" "The VDI that a suspend image is stored on. (Only has meaning if VM is currently suspended)";
+           field ~qualifier:StaticRO ~default_value:(Some (VRef null_ref)) ~lifecycle:[Changed, rel_next, "Become static to allow Suspended VM creation"] ~ty:(Ref _vdi) "suspend_VDI" "The VDI that a suspend image is stored on. (Only has meaning if VM is currently suspended)";
 
            field ~writer_roles:_R_VM_POWER_ADMIN ~qualifier:DynamicRO ~ty:(Ref _host) "resident_on" "the host the VM is currently resident on";
            field ~writer_roles:_R_VM_POWER_ADMIN ~in_oss_since:None ~qualifier:DynamicRO ~default_value:(Some (VRef null_ref)) ~ty:(Ref _host) "scheduled_to_be_resident_on" "the host on which the VM is due to be started/resumed/migrated. This acts as a memory reservation indicator";
@@ -1403,7 +1403,7 @@ let set_NVRAM_EFI_variables = call ~flags:[`Session]
            (* This was an internal field in Rio, Miami beta1, Miami beta2 but is now exposed so that
               	   it will be included automatically in Miami GA exports and can be restored, important if
               	   the VM is in a suspended state *)
-           field ~in_oss_since:None ~internal_only:false ~in_product_since:rel_miami ~qualifier:StaticRO ~ty:String "last_booted_record" "marshalled value containing VM record at time of last boot, updated dynamically to reflect the runtime state of the domain" ~default_value:(Some (VString ""));
+           field ~in_oss_since:None ~internal_only:false ~in_product_since:rel_miami ~lifecycle:[Changed, rel_next, "Become static to allow Suspended VM creation"] ~qualifier:StaticRO ~ty:String "last_booted_record" "marshalled value containing VM record at time of last boot, updated dynamically to reflect the runtime state of the domain" ~default_value:(Some (VString ""));
            field ~in_oss_since:None ~ty:String "recommendations" "An XML specification of recommended values and ranges for properties of this VM";
            field ~effect:true ~in_oss_since:None ~ty:(Map(String, String)) ~in_product_since:rel_miami ~qualifier:RW "xenstore_data" "data to be inserted into the xenstore tree (/local/domain/<domid>/vm-data) after the VM is created." ~default_value:(Some (VMap []));
            field ~writer_roles:_R_POOL_OP ~in_oss_since:None ~ty:Bool ~in_product_since:rel_orlando ~internal_deprecated_since:rel_boston ~qualifier:StaticRO "ha_always_run" "if true then the system will attempt to keep the VM running as much as possible." ~default_value:(Some (VBool false));


### PR DESCRIPTION
The datamodel changes in https://github.com/xapi-project/xen-api/pull/4057 incorrectly state that were introduced in the stockholm release, this feature was only added after stockhlm branched off.