### PR TITLE
Error message improvement.

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -452,7 +452,7 @@ let _ =
   error Api_errors.host_master_cannot_talk_back [ "ip" ]
     ~doc:"The master reports that it cannot talk back to the slave on the supplied management IP address." ();
   error Api_errors.host_unknown_to_master [ "host" ]
-    ~doc:"The master says the host is not known to it. Perhaps the Host was deleted from the master's database, the slave is pointing to the wrong master, or a pool secret rotation failed?" ();
+    ~doc:"The master says the server is not known to it. Is the server in the master's database and pointing to the correct master? Are all servers using the same pool secret?" ();
   error Api_errors.host_broken []
     ~doc:"This server failed in the middle of an automatic failover operation and needs to retry the failover action." ();
   error Api_errors.host_has_resident_vms [ "host" ]


### PR DESCRIPTION
This message has an override in xen-api-sdk which corrects the language. This practice should generally be avoided, unless absolutely necessary, because the content of the override may get out of sync as it has happened in this case. This PR corrects the original message and this one https://github.com/xapi-project/xen-api-sdk/pull/177 removes the outdated SDK override.