### PR TITLE
CP-34379 don't proceed with rotation if PSR state is inconsistent

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1327,7 +1327,7 @@ let host_query_ha = call ~flags:[`Session]
 
   let notify_accept_new_pool_secret = call
     ~name:"notify_accept_new_pool_secret"
-    ~lifecycle:[Published, rel_next, ""]
+    ~lifecycle:[Published, rel_stockholm_psr, ""]
     ~doc:"Notifies host that they must begin accepting requests containing the new pool secret"
     ~params:[
       Ref _host, "host", "The host";
@@ -1340,7 +1340,7 @@ let host_query_ha = call ~flags:[`Session]
 
   let notify_send_new_pool_secret = call
     ~name:"notify_send_new_pool_secret"
-    ~lifecycle:[Published, rel_next, ""]
+    ~lifecycle:[Published, rel_stockholm_psr, ""]
     ~doc:"Notifies host that they must begin sending requests with the new pool secret"
     ~params:[
       Ref _host, "host", "The host";
@@ -1353,7 +1353,7 @@ let host_query_ha = call ~flags:[`Session]
 
   let cleanup_pool_secret = call
     ~name:"cleanup_pool_secret"
-    ~lifecycle:[Published, rel_next, ""]
+    ~lifecycle:[Published, rel_stockholm_psr, ""]
     ~doc:"Cleanup old pool secret on recipient host"
     ~params:[
       Ref _host, "host", "The host";

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1331,6 +1331,7 @@ let host_query_ha = call ~flags:[`Session]
     ~doc:"Notifies host that they must begin accepting requests containing the new pool secret"
     ~params:[
       Ref _host, "host", "The host";
+      SecretString, "old_ps", "Old pool secret";
       SecretString, "new_ps", "New pool secret"
     ]
     ~allowed_roles:_R_LOCAL_ROOT_ONLY
@@ -1343,6 +1344,7 @@ let host_query_ha = call ~flags:[`Session]
     ~doc:"Notifies host that they must begin sending requests with the new pool secret"
     ~params:[
       Ref _host, "host", "The host";
+      SecretString, "old_ps", "Old pool secret";
       SecretString, "new_ps", "New pool secret"
     ]
     ~allowed_roles:_R_LOCAL_ROOT_ONLY
@@ -1354,7 +1356,9 @@ let host_query_ha = call ~flags:[`Session]
     ~lifecycle:[Published, rel_next, ""]
     ~doc:"Cleanup old pool secret on recipient host"
     ~params:[
-      Ref _host, "host", "The host"
+      Ref _host, "host", "The host";
+      SecretString, "old_ps", "Old pool secret";
+      SecretString, "new_ps", "New pool secret"
     ]
     ~allowed_roles:_R_LOCAL_ROOT_ONLY
     ~hide_from_docs:true

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -634,7 +634,7 @@ open Datamodel_types
       ()
 
   let rotate_secret = call
-    ~in_product_since:rel_next
+    ~in_product_since:rel_stockholm_psr
     ~name:"rotate_secret"
     ~params:[]
     ~errs:[ Api_errors.internal_error
@@ -762,6 +762,6 @@ open Datamodel_types
          ; field ~qualifier:RW ~in_product_since:rel_ely ~default_value:(Some (VBool false)) ~ty:Bool "live_patching_disabled" "The pool-wide flag to show if the live patching feauture is disabled or not."
          ; field ~in_product_since:rel_inverness ~qualifier:DynamicRO ~ty:Bool ~default_value:(Some (VBool false)) "igmp_snooping_enabled" "true if IGMP snooping is enabled in the pool, false otherwise."
          ; field ~in_product_since:rel_quebec ~qualifier:RW ~ty:String ~default_value:(Some (VString "")) "uefi_certificates" "The UEFI certificates allowing Secure Boot"
-         ; field ~in_product_since:rel_next ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "is_psr_pending" "True if either a PSR is running or we are waiting for a PSR to be re-run"
+         ; field ~in_product_since:rel_stockholm_psr ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "is_psr_pending" "True if either a PSR is running or we are waiting for a PSR to be re-run"
          ])
       ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -762,5 +762,6 @@ open Datamodel_types
          ; field ~qualifier:RW ~in_product_since:rel_ely ~default_value:(Some (VBool false)) ~ty:Bool "live_patching_disabled" "The pool-wide flag to show if the live patching feauture is disabled or not."
          ; field ~in_product_since:rel_inverness ~qualifier:DynamicRO ~ty:Bool ~default_value:(Some (VBool false)) "igmp_snooping_enabled" "true if IGMP snooping is enabled in the pool, false otherwise."
          ; field ~in_product_since:rel_quebec ~qualifier:RW ~ty:String ~default_value:(Some (VString "")) "uefi_certificates" "The UEFI certificates allowing Secure Boot"
+         ; field ~in_product_since:rel_next ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "is_psr_pending" "True if either a PSR is running or we are waiting for a PSR to be re-run"
          ])
       ()

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -267,8 +267,8 @@ let release_order_full = [{
      code_name     = Some rel_stockholm;
      version_major = 2;
      version_minor = 15;
-     branding      = "Unreleased";
-     release_date  = None;
+     branding      = "Citrix Hypervisor 8.2";
+     release_date  = Some "June 2020";
    }; {
      code_name     = Some rel_next;
      version_major = 2;

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -64,7 +64,7 @@ let rel_naples = "naples"
 let rel_oslo = "oslo"
 let rel_quebec = "quebec"
 let rel_stockholm = "stockholm"
-let rel_next = "next"
+let rel_stockholm_psr = "stockholm_psr"
 
 type api_release = {
   code_name: string option;
@@ -270,10 +270,10 @@ let release_order_full = [{
      branding      = "Citrix Hypervisor 8.2";
      release_date  = Some "June 2020";
    }; {
-     code_name     = Some rel_next;
+     code_name     = Some rel_stockholm_psr;
      version_major = 2;
-     version_minor = 16;
-     branding      = "Unreleased";
+     version_minor = 15;
+     branding      = "Citrix Hypervisor 8.2 Hotfix n";
      release_date  = None;
    }
   ]

--- a/ocaml/tests/test_common.ml
+++ b/ocaml/tests/test_common.ml
@@ -283,7 +283,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~vswitch_controller ~igmp_snooping_enabled ~current_operations
     ~allowed_operations ~restrictions ~other_config ~ha_cluster_stack
     ~guest_agent_config ~cpu_info ~policy_no_vendor_device
-    ~live_patching_disabled ~uefi_certificates ;
+    ~live_patching_disabled ~uefi_certificates ~is_psr_pending:false ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/tests/test_psr.ml
+++ b/ocaml/tests/test_psr.ml
@@ -155,7 +155,7 @@ functor
           | _ ->
               f ())
 
-    let tell_cleanup_old_pool_secret =
+    let tell_cleanup_old_pool_secret _ =
       iter_host (fun h ->
           let f () = h.staged_pool_secret <- None in
           match h.fistpoint with
@@ -166,7 +166,7 @@ functor
           | _ ->
               f ())
 
-    let cleanup_master () =
+    let cleanup_master _ =
       let f () =
         master.member.staged_pool_secret <- None ;
         master.psr_state.checkpoint <- None ;

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -42,7 +42,7 @@ let create_pool_record ~__context =
       ~other_config:[Xapi_globs.memory_ratio_hvm; Xapi_globs.memory_ratio_pv]
       ~ha_cluster_stack:"xhad" ~guest_agent_config:[] ~cpu_info:[]
       ~policy_no_vendor_device:false ~live_patching_disabled:false
-      ~uefi_certificates:""
+      ~uefi_certificates:"" ~is_psr_pending:false
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3366,27 +3366,33 @@ functor
           value ;
         Local.Host.set_uefi_certificates ~__context ~host ~value
 
-      let notify_accept_new_pool_secret ~__context ~host ~new_ps =
+      let notify_accept_new_pool_secret ~__context ~host ~old_ps ~new_ps =
         (* we do not need to verify the old pool secret here, since it has
            already been verified (see xapi_http.assert_credentials_ok) *)
         info "Host.notify_accept_new_pool_secret: host='%s'"
           (host_uuid ~__context host) ;
-        let local_fn = Local.Host.notify_accept_new_pool_secret ~host ~new_ps in
+        let local_fn =
+          Local.Host.notify_accept_new_pool_secret ~host ~old_ps ~new_ps
+        in
         do_op_on ~__context ~host ~local_fn (fun session_id rpc ->
-            Client.Host.notify_accept_new_pool_secret rpc session_id host new_ps)
+            Client.Host.notify_accept_new_pool_secret rpc session_id host old_ps
+              new_ps)
 
-      let notify_send_new_pool_secret ~__context ~host ~new_ps =
+      let notify_send_new_pool_secret ~__context ~host ~old_ps ~new_ps =
         info "Host.notify_send_new_pool_secret: host='%s'"
           (host_uuid ~__context host) ;
-        let local_fn = Local.Host.notify_send_new_pool_secret ~host ~new_ps in
+        let local_fn =
+          Local.Host.notify_send_new_pool_secret ~host ~old_ps ~new_ps
+        in
         do_op_on ~__context ~host ~local_fn (fun session_id rpc ->
-            Client.Host.notify_send_new_pool_secret rpc session_id host new_ps)
+            Client.Host.notify_send_new_pool_secret rpc session_id host old_ps
+              new_ps)
 
-      let cleanup_pool_secret ~__context ~host =
+      let cleanup_pool_secret ~__context ~host ~old_ps ~new_ps =
         info "Host.cleanup_pool_secret: host='%s'" (host_uuid ~__context host) ;
-        let local_fn = Local.Host.cleanup_pool_secret ~host in
+        let local_fn = Local.Host.cleanup_pool_secret ~host ~old_ps ~new_ps in
         do_op_on ~__context ~host ~local_fn (fun session_id rpc ->
-            Client.Host.cleanup_pool_secret rpc session_id host)
+            Client.Host.cleanup_pool_secret rpc session_id host old_ps new_ps)
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -1677,6 +1677,15 @@ let enable __context heartbeat_srs configuration =
   let pool = Helpers.get_pool ~__context in
   if Db.Pool.get_ha_enabled ~__context ~self:pool then
     raise (Api_errors.Server_error (Api_errors.ha_is_enabled, [])) ;
+  if Xapi_pool_helpers.pool_secret_rotation_pending ~__context then
+    raise
+      Api_errors.(
+        Server_error
+          ( internal_error
+          , [
+              "a pool secret rotation is pending, please complete it before \
+               attempting to enable HA"
+            ] )) ;
   Pool_features.assert_enabled ~__context ~f:Features.HA ;
   (* Check that all of our 'disallow_unplug' PIFs are currently attached *)
   let unplugged_ununpluggable_pifs =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2382,10 +2382,11 @@ let set_multipathing ~__context ~host ~value =
     ~value:(string_of_bool value) ;
   Xapi_host_helpers.Configuration.set_multipathing value
 
-let notify_accept_new_pool_secret ~__context ~host ~new_ps =
-  Xapi_psr.notify_new ~new_ps
+let notify_accept_new_pool_secret ~__context ~host ~old_ps ~new_ps =
+  Xapi_psr.notify_new ~__context ~old_ps ~new_ps
 
-let notify_send_new_pool_secret ~__context ~host ~new_ps =
-  Xapi_psr.notify_send ~new_ps
+let notify_send_new_pool_secret ~__context ~host ~old_ps ~new_ps =
+  Xapi_psr.notify_send ~__context ~old_ps ~new_ps
 
-let cleanup_pool_secret ~__context ~host = Xapi_psr.cleanup ()
+let cleanup_pool_secret ~__context ~host ~old_ps ~new_ps =
+  Xapi_psr.cleanup ~__context ~old_ps ~new_ps

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -480,9 +480,22 @@ val set_multipathing :
   __context:Context.t -> host:API.ref_host -> value:bool -> unit
 
 val notify_accept_new_pool_secret :
-  __context:Context.t -> host:API.ref_host -> new_ps:SecretString.t -> unit
+     __context:Context.t
+  -> host:API.ref_host
+  -> old_ps:SecretString.t
+  -> new_ps:SecretString.t
+  -> unit
 
 val notify_send_new_pool_secret :
-  __context:Context.t -> host:API.ref_host -> new_ps:SecretString.t -> unit
+     __context:Context.t
+  -> host:API.ref_host
+  -> old_ps:SecretString.t
+  -> new_ps:SecretString.t
+  -> unit
 
-val cleanup_pool_secret : __context:Context.t -> host:API.ref_host -> unit
+val cleanup_pool_secret :
+     __context:Context.t
+  -> host:API.ref_host
+  -> old_ps:SecretString.t
+  -> new_ps:SecretString.t
+  -> unit

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -142,6 +142,9 @@ let ha_disable_in_progress ~__context =
   else
     false
 
+let pool_secret_rotation_pending ~__context =
+  Db.Pool.get_is_psr_pending ~__context ~self:(Helpers.get_pool ~__context)
+
 let get_master_slaves_list_with_fn ~__context fn =
   let _unsorted_hosts = Db.Host.get_all ~__context in
   let master = Helpers.get_master ~__context in

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -32,6 +32,8 @@ val ha_disable_in_progress : __context:Context.t -> bool
 
 val ha_enable_in_progress : __context:Context.t -> bool
 
+val pool_secret_rotation_pending : __context:Context.t -> bool
+
 val call_fn_on_master_then_slaves :
      __context:Context.t
   -> (   rpc:(Rpc.call -> Rpc.response)

--- a/ocaml/xapi/xapi_psr.ml
+++ b/ocaml/xapi/xapi_psr.ml
@@ -274,8 +274,7 @@ functor
           Client.Host.cleanup_pool_secret rpc session_id host)
 
     let cleanup_master =
-      cleanup_internal
-        ~additional_files_to_remove:[checkpoint_path; checkpoint_tmp_path]
+      cleanup_internal ~additional_files_to_remove:[checkpoint_path]
   end
 
 let notify_new ~new_ps =

--- a/ocaml/xapi/xapi_psr.mli
+++ b/ocaml/xapi/xapi_psr.mli
@@ -26,11 +26,14 @@ type 'a r = (unit, failure * 'a) result
 val start : __context:Context.t -> unit
 
 (* expose client implementations *)
-val notify_new : new_ps:SecretString.t -> unit
+val notify_new :
+  __context:Context.t -> old_ps:SecretString.t -> new_ps:SecretString.t -> unit
 
-val notify_send : new_ps:SecretString.t -> unit
+val notify_send :
+  __context:Context.t -> old_ps:SecretString.t -> new_ps:SecretString.t -> unit
 
-val cleanup : unit -> unit
+val cleanup :
+  __context:Context.t -> old_ps:SecretString.t -> new_ps:SecretString.t -> unit
 
 (* the rest is exposed for unit testing *)
 
@@ -65,10 +68,10 @@ module type Impl = sig
 
   val tell_send_new_pool_secret : pool_secrets -> host -> unit
 
-  val tell_cleanup_old_pool_secret : host -> unit
+  val tell_cleanup_old_pool_secret : pool_secrets -> host -> unit
 
   (* cleanup master _after_ the members *)
-  val cleanup_master : unit -> unit
+  val cleanup_master : pool_secrets -> unit
 end
 
 module Make : functor (Impl : Impl) -> sig

--- a/ocaml/xapi/xapi_psr_util.ml
+++ b/ocaml/xapi/xapi_psr_util.ml
@@ -5,8 +5,6 @@ module Unixext = Stdext.Unixext
 
 let checkpoint_path = "/var/lib/xcp/psr_cp"
 
-let checkpoint_tmp_path = "/var/lib/xcp/psr_cp.tmp"
-
 let old_pool_secret_backup_path = "/var/lib/xcp/ptoken.old"
 
 let new_pool_secret_backup_path = "/var/lib/xcp/ptoken.new"


### PR DESCRIPTION
We add some sanity checks before performing PSR
operations.

The main motivation for this is that if the master
changes after a failed PSR then we want to block
the next PSR. The idea is to avoid lockout at all
costs, even though manual intervention may be
required to fix the issue.
