### PR TITLE
Expose xen's scheduler granularity into the `Host`

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1364,6 +1364,34 @@ let host_query_ha = call ~flags:[`Session]
     ~hide_from_docs:true
     ()
 
+  let host_sched_gran = Enum("host_sched_gran", [
+    "core", "core scheduling";
+    "cpu", "CPU scheduling";
+    "socket", "socket scheduling";
+  ])
+
+  let set_sched_gran = call
+    ~name:"set_sched_gran"
+    ~lifecycle:[Prototyped, rel_next, ""]
+    ~doc:"Sets xen's sched-gran on a host. See: https://xenbits.xen.org/docs/unstable/misc/xen-command-line.html#sched-gran-x86"
+    ~params:[
+      Ref _host, "self", "The host";
+      host_sched_gran, "value", "The sched-gran to apply to a host"
+    ]
+    ~allowed_roles:_R_LOCAL_ROOT_ONLY
+    ()
+
+  let get_sched_gran = call
+    ~name:"get_sched_gran"
+    ~lifecycle:[Prototyped, rel_next, ""]
+    ~doc:"Gets xen's sched-gran on a host"
+    ~params:[
+      Ref _host, "self", "The host";
+    ]
+    ~allowed_roles:_R_LOCAL_ROOT_ONLY
+    ~result:(host_sched_gran, "The host's sched-gran")
+    ()
+
   (** Hosts *)
   let t =
     create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_host ~descr:"A physical host" ~gen_events:true
@@ -1485,6 +1513,8 @@ let host_query_ha = call ~flags:[`Session]
         notify_accept_new_pool_secret;
         notify_send_new_pool_secret;
         cleanup_pool_secret;
+        set_sched_gran;
+        get_sched_gran;
       ]
       ~contents:
         ([ uid _host;

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -593,6 +593,25 @@ let host_display_to_string h =
   | `disable_on_reboot ->
       "disable_on_reboot"
 
+let host_sched_gran_of_string s =
+  match String.lowercase_ascii s with
+  | "core" ->
+      `core
+  | "cpu" ->
+      `cpu
+  | "socket" ->
+      `socket
+  | _ ->
+      raise (Record_failure ("Expected 'core','cpu', 'socket', got " ^ s))
+
+let host_sched_gran_to_string = function
+  | `core ->
+      "core"
+  | `cpu ->
+      "cpu"
+  | `socket ->
+      "socket"
+
 let pgpu_dom0_access_to_string x = host_display_to_string x
 
 let string_to_vdi_onboot s =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3404,6 +3404,20 @@ functor
         let local_fn = Local.Host.cleanup_pool_secret ~host ~old_ps ~new_ps in
         do_op_on ~__context ~host ~local_fn (fun session_id rpc ->
             Client.Host.cleanup_pool_secret rpc session_id host old_ps new_ps)
+
+      let set_sched_gran ~__context ~self ~value =
+        info "Host.set_sched_gran: host='%s' sched='%s'"
+          (host_uuid ~__context self)
+          (Record_util.host_sched_gran_to_string value) ;
+        let local_fn = Local.Host.set_sched_gran ~self ~value in
+        do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
+            Client.Host.set_sched_gran rpc session_id self value)
+
+      let get_sched_gran ~__context ~self =
+        info "Host.get_sched_gran: host='%s'" (host_uuid ~__context self) ;
+        let local_fn = Local.Host.get_sched_gran ~self in
+        do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
+            Client.Host.get_sched_gran rpc session_id self)
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -253,6 +253,8 @@ let tools_sr_pbd_device_config =
 
 let create_tools_sr = ref false
 
+let allow_host_sched_gran_modification = ref false
+
 let default_template_key = "default_template"
 
 let base_template_name_key = "base_template_name"
@@ -1119,6 +1121,10 @@ let other_options =
     , Arg.Set create_tools_sr
     , (fun () -> string_of_bool !create_tools_sr)
     , "Indicates whether to create an SR for Tools ISOs" )
+  ; ( "allow-host-sched-gran-modification"
+    , Arg.Set allow_host_sched_gran_modification
+    , (fun () -> string_of_bool !allow_host_sched_gran_modification)
+    , "Allows to modify the host's scheduler granularity" )
   ]
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -500,3 +500,9 @@ val cleanup_pool_secret :
   -> old_ps:SecretString.t
   -> new_ps:SecretString.t
   -> unit
+
+val set_sched_gran :
+  __context:Context.t -> self:API.ref_host -> value:API.host_sched_gran -> unit
+
+val get_sched_gran :
+  __context:Context.t -> self:API.ref_host -> API.host_sched_gran


### PR DESCRIPTION
Solves https://github.com/xapi-project/xen-api/issues/4154 & https://github.com/xcp-ng/xcp/issues/407

This PR adds 2 new methods to the `Host` object:
- `set_sched_gran`: sets Xen's scheduler granularity (either `core`, `cpu` or `socket`)
- `get_sched_gran`: gets Xen's scheduler granularity

It uses `/opt/xensource/libexec/xen-cmdline`

This allows a user to select the xen's scheduler granularity and choose between efficiency and safety. For instance core scheduling prevents cross domain side-channel attack while being more efficient than disabling hyperthreading.
