### PR TITLE
opam: update dependencies

### DIFF
--- a/xapi.opam
+++ b/xapi.opam
@@ -51,7 +51,6 @@ depends: [
   "xapi-database"
   "xapi-datamodel"
   "xapi-stdext-date"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"
   "xapi-stdext-threads"

--- a/xe.opam
+++ b/xe.opam
@@ -10,6 +10,7 @@ build: [[ "dune" "build" "-p" name ]]
 depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
+  "fpath"
   "stunnel"
   "base-threads"
   "xapi-cli-protocol"


### PR DESCRIPTION
recently fpath was introduced and stdext-monadic was removed, update the
opam metadata to reflect this

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>