### PR TITLE
Improve HA parameter derived from timeout

### DIFF
--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -202,12 +202,12 @@ module Timeouts = struct
     (* xHA interface section 4.1.4.1.1 Formula of key timeouts *)
     (* t >= 10 *)
     (* All other values are derived from this single parameter *)
-    let round expr = float_of_int t |> expr |> ( +. ) 0.5 |> int_of_float in
     if t < 10 then failwith "constraint violation: timeout >= 10" ;
     (* heart beats are cheap but unreliable b/c of UDP - have many *)
-    let heart_beat_interval = 3 in
-    (* state file is slow but realiable  - have 20 *)
-    let state_file_interval = round (fun t -> max 5.0 (t /. 20.0)) in
+    let interval = (t + 10)/10 in (* interval used previously *)
+    let heart_beat_interval = min interval 3 in
+    (* state file is slow but realiable  - have 20 when possible *)
+    let state_file_interval = max 2 (t / 20) in
     let heart_beat_timeout = t in
     let state_file_timeout = t in
     let heart_beat_watchdog_timeout = heart_beat_timeout in

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -201,14 +201,17 @@ module Timeouts = struct
   let derive (t : int) =
     (* xHA interface section 4.1.4.1.1 Formula of key timeouts *)
     (* t >= 10 *)
-    if t < 10 then failwith "constraint violation: timeout >= 10" ;
     (* All other values are derived from this single parameter *)
-    let heart_beat_interval = (t + 10) / 10 in
-    let state_file_interval = heart_beat_interval in
+    let round expr = float_of_int t |> expr |> ( +. ) 0.5 |> int_of_float in
+    if t < 10 then failwith "constraint violation: timeout >= 10" ;
+    (* heart beats are cheap but unreliable b/c of UDP - have many *)
+    let heart_beat_interval = 3 in
+    (* state file is slow but realiable  - have 20 *)
+    let state_file_interval = round (fun t -> max 5.0 (t /. 20.0)) in
     let heart_beat_timeout = t in
     let state_file_timeout = t in
-    let heart_beat_watchdog_timeout = t in
-    let state_file_watchdog_timeout = t + 15 in
+    let heart_beat_watchdog_timeout = heart_beat_timeout in
+    let state_file_watchdog_timeout = state_file_timeout + 15 in
     let boot_join_timeout = t + 60 in
     let enable_join_timeout = boot_join_timeout in
     {


### PR DESCRIPTION
This changes how essential parameters for the HA daemon are derived from
the xe pool-ha-enable timeout parameter. So far, the network heartbeat
was always configured to use 10 heartbeats in an interval. There is good
reason to believe that this contributed to the unreliability of HA.  HA
uses two heartbeats:

(1) UDP network heartbeat - fast and unreliable
(2) State file heartbeat - slow and reliable

HA's network heartbeat is sensitive to network congestion and with only
10 heartbeats configured before a timeout would trigger HA, it was easy
for HA to trigger. This patch addresses the asymmetry of the heartbeats:

* We want more network heartbeats than storage heartbeats because they
  are cheap but can be lost.
* We want a minimum time to pass between heartbeats - less for network
  and more for storage heartbeats.
* We configure many network and 20 storage heartbeats per interval.

This leads to the following parameters

t  = user-provided timeout in seconds
hb = number of network heart beats per timeout interval
sf = number of statefile heart beats per timeout interval

t    hb  sf
-----------
10   5   5
20   6   10
30   10  15
40   13  20
60   20  20 = this is the default
90   30  22
120  40  20
180  60  20

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>