### PR TITLE
maintenance: fix build when system compiler != 4.08

### DIFF
--- a/ocaml/auth/dune
+++ b/ocaml/auth/dune
@@ -4,7 +4,6 @@
     xa_auth
     xa_auth_stubs
   )
-  (c_flags -I/usr/lib64/ocaml)
   (c_library_flags -lpam)
   (wrapped false)
 )

--- a/ocaml/tests/common/suite_init.ml
+++ b/ocaml/tests/common/suite_init.ml
@@ -1,5 +1,5 @@
 let harness_init () =
-  Xapi_stdext_unix.Unixext.mkdir_safe (Test_common.working_area) 0o755 ;
+  Xapi_stdext_unix.Unixext.mkdir_safe Test_common.working_area 0o755 ;
   (* Alcotest hides the standard output of successful tests,
      so we will probably not exceed the 4MB limit in Travis *)
   Debug.log_to_stdout () ;

--- a/ocaml/tests/test_daemon_manager.ml
+++ b/ocaml/tests/test_daemon_manager.ml
@@ -146,6 +146,6 @@ let test =
   ; ("test_timeout_fail", `Slow, test_timeout_fail)
   ]
 
-let () = 
+let () =
   Suite_init.harness_init () ;
   Alcotest.run "Daemon Manager suite" [("Test_daemon_manager", test)]


### PR DESCRIPTION
We should normally only use things as set up by an opam switch, however here we were also linking in things from the system OCaml compiler, for no good reason AFAICT. Removing the `/usr/lib64/ocaml` flag still makes everything link inside a `pxc` buildenv, and it also fixes the build when the system compiler != opam compiler. (E.g. Fedora 32 has OCaml 4.10 as system compiler)