### PR TITLE
CA-342171 fix get_server_localtime

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -855,9 +855,10 @@ let host_query_ha = call ~flags:[`Session]
       ~name:"get_server_localtime"
       ~in_oss_since:None
       ~in_product_since:rel_cowley
+      ~lifecycle:[Published, rel_cowley, ""; Changed, rel_next, "Return string instead of datetime"]
       ~params:[Ref _host, "host", "The host whose clock should be queried"]
       ~doc:"This call queries the host's clock for the current time in the host's local timezone"
-      ~result:(DateTime, "The current local time")
+      ~result:(String, "The current local time")
       ~allowed_roles:_R_READ_ONLY
       ()
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1322,12 +1322,11 @@ let get_servertime ~__context ~host = Date.of_float (Unix.gettimeofday ())
 let get_server_localtime ~__context ~host =
   let gmt_time = Unix.gettimeofday () in
   let local_time = Unix.localtime gmt_time in
-  Date.of_string
-    (Printf.sprintf "%04d%02d%02dT%02d:%02d:%02d"
-       (local_time.Unix.tm_year + 1900)
-       (local_time.Unix.tm_mon + 1)
-       local_time.Unix.tm_mday local_time.Unix.tm_hour local_time.Unix.tm_min
-       local_time.Unix.tm_sec)
+  Printf.sprintf "%04d%02d%02dT%02d:%02d:%02d"
+    (local_time.Unix.tm_year + 1900)
+    (local_time.Unix.tm_mon + 1)
+    local_time.Unix.tm_mday local_time.Unix.tm_hour local_time.Unix.tm_min
+    local_time.Unix.tm_sec
 
 let enable_binary_storage ~__context ~host =
   Unixext.mkdir_safe Xapi_globs.xapi_blob_location 0o700 ;

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -259,7 +259,7 @@ val backup_rrds : __context:Context.t -> host:'b -> delay:float -> unit
 
 val get_servertime : __context:'a -> host:'b -> Stdext.Date.iso8601
 
-val get_server_localtime : __context:'a -> host:'b -> Stdext.Date.iso8601
+val get_server_localtime : __context:'a -> host:'b -> string
 
 val enable_binary_storage : __context:Context.t -> host:[`host] Ref.t -> unit
 


### PR DESCRIPTION
Fix get_server_localtime by using a string to represent the localtime, rather than Date.iso8601, which is supposed to be UTC