### PR TITLE
CA-342171 fix get_server_localtime

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1319,15 +1319,7 @@ let backup_rrds ~__context ~host ~delay =
 
 let get_servertime ~__context ~host = Date.of_float (Unix.gettimeofday ())
 
-let get_server_localtime ~__context ~host =
-  let gmt_time = Unix.gettimeofday () in
-  let local_time = Unix.localtime gmt_time in
-  Date.of_string
-    (Printf.sprintf "%04d%02d%02dT%02d:%02d:%02d"
-       (local_time.Unix.tm_year + 1900)
-       (local_time.Unix.tm_mon + 1)
-       local_time.Unix.tm_mday local_time.Unix.tm_hour local_time.Unix.tm_min
-       local_time.Unix.tm_sec)
+let get_server_localtime ~__context ~host = Date.localtime ()
 
 let enable_binary_storage ~__context ~host =
   Unixext.mkdir_safe Xapi_globs.xapi_blob_location 0o700 ;


### PR DESCRIPTION
We previously changed the Stdext.Date library to
only accept UTC. This of course doesn't work
correctly when we are trying to work with a
server's localtime. The library has been modified
to handle non-UTC times again, so we use those
changes here.