### PR TITLE
CA-343117: host-backup: Include /boot/efi in the tarball

### DIFF
--- a/scripts/host-backup-restore/host-backup
+++ b/scripts/host-backup-restore/host-backup
@@ -37,5 +37,4 @@ tar --exclude 'tmp/*' --exclude 'tmp/.*' --exclude 'var/crash/*' --exclude 'var/
     --exclude 'var/xsconfig/*' --exclude 'var/xsconfig/.*' \
     --exclude 'var/xapi/[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*' \
     --warning='no-file-ignored' \
-    --sparse --preserve-permissions --to-stdout --gzip --one-file-system -C / -c . 
-
+    --sparse --preserve-permissions --to-stdout --gzip --one-file-system -C / -c . boot/efi


### PR DESCRIPTION
When using a UEFI-booted host, /boot/efi is a separate mountpoint and so
it does not get included in the backup tarball due to the use of
--one-file-system. This causes the restore to fail due to missing files.
Explicitly include /boot/efi to fix restore with UEFI hosts. Note that
with legacy-booted hosts, /boot/efi is not a separate mountpoint but
including it twice is fine.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>