### PR TITLE
CP-32138: rely on systemd to have wsproxy available

### DIFF
--- a/ocaml/xapi/console.ml
+++ b/ocaml/xapi/console.ml
@@ -103,29 +103,12 @@ let real_proxy __context _ _ vnc_port s =
     debug "Proxy exited"
   with exn -> debug "error: %s" (ExnHelper.string_of_exn exn)
 
-let check_wsproxy () =
-  try
-    let pid = int_of_string (Unixext.string_of_file "/var/run/wsproxy.pid") in
-    Unix.kill pid 0 ; true
-  with _ -> false
-
-let ensure_proxy_running () =
-  if check_wsproxy () then
-    ()
-  else (
-    ignore
-      (Forkhelpers.execute_command_get_output "/opt/xensource/libexec/wsproxy"
-         []) ;
-    Thread.delay 1.0
-  )
-
 let ws_proxy __context req protocol address s =
   let addr = match address with Port p -> string_of_int p | Path p -> p in
-  ensure_proxy_running () ;
   let protocol =
     match protocol with `rfb -> "rfb" | `vt100 -> "vt100" | `rdp -> "rdp"
   in
-  let real_path = Filename.concat "/var/lib/xcp" "wsproxy" in
+  let real_path = Filename.concat "/var/lib/xcp" "websockproxy" in
   let sock =
     try Some (Fecomms.open_unix_domain_sock_client real_path)
     with e ->

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -64,6 +64,8 @@ install:
 	$(IDATA) mpathalert.service $(DESTDIR)/usr/lib/systemd/system/mpathalert.service
 	$(IDATA) xapi-init-complete.target $(DESTDIR)/usr/lib/systemd/system/xapi-init-complete.target
 	$(IDATA) xapi-wait-init-complete.service $(DESTDIR)/usr/lib/systemd/system/xapi-wait-init-complete.service
+	$(IDATA) wsproxy.service $(DESTDIR)/usr/lib/systemd/system/wsproxy.service
+	$(IDATA) wsproxy.socket $(DESTDIR)/usr/lib/systemd/system/wsproxy.socket
 	$(IDATA) network-init.service $(DESTDIR)/usr/lib/systemd/system/network-init.service
 	$(IDATA) control-domain-params-init.service $(DESTDIR)/usr/lib/systemd/system/control-domain-params-init.service
 	$(IDATA) 10-stunnel-increase-number-of-file-descriptors.conf $(DESTDIR)/etc/systemd/system/stunnel@xapi.service.d/10-stunnel-increase-number-of-file-descriptors.conf

--- a/scripts/wsproxy.service
+++ b/scripts/wsproxy.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Websocket proxy
+
+[Service]
+ExecStart=@LIBEXECDIR@/wsproxy
+StandardInput=socket
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/wsproxy.socket
+++ b/scripts/wsproxy.socket
@@ -1,0 +1,5 @@
+[Socket]
+ListenStream=/var/lib/xcp/websockproxy
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Changes the name of the socket used from wsproxy to ws_proxy as systemd
does not have a capability to take over existing sockets. This would
have been a problem when upgrading as xapi does not clean up the socket
and cannot be controlled in all cases.

Must be merged along https://github.com/xapi-project/wsproxy/pull/23