### PR TITLE
CA-341155: Fix console refresh when starting management server

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -105,7 +105,7 @@ let start ~__context ?addr () =
   management_interface_server := socket :: !management_interface_server;
 
   restart_stunnel ~__context ~accept;
-  if Pool_role.is_master () && !listening_all then begin
+  if Pool_role.is_master () && addr = None then begin
     (* NB if we synchronously bring up the management interface on a master with a blank
        		   database this can fail... this is ok because the database will be synchronised later *)
     Server_helpers.exec_with_new_task "refreshing consoles"


### PR DESCRIPTION
The intention of the if-statement in `start` is to only refresh the consoles on
the master if management is enabled, which is the case when the server is
running on all IP addresses. The `listening_all` ref, however, is updated only
_after_ the call to the `start` function. Instead refer to the `addr` parameter.

Backport of 07b62434.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>