### PR TITLE
maintenance: ensure all fistpoints work as expected

### DIFF
--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -79,9 +79,9 @@ let simulate_blocking_planner () = fistpoint "simulate_blocking_planner"
  *  NB: these are evaluated once at run time and not again - no dynamic changing here :-) *)
 
 (** Reduce blob sync period to 5 minutes *)
-let reduce_blob_sync_interval = fistpoint "reduce_blob_sync_interval"
+let reduce_blob_sync_interval () = fistpoint "reduce_blob_sync_interval"
 
-let reduce_rrd_backup_interval = fistpoint "reduce_rrd_backup_interval"
+let reduce_rrd_backup_interval () = fistpoint "reduce_rrd_backup_interval"
 
 let force_remote_vdi_copy () = fistpoint "force_remote_vdi_copy"
 

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -22,7 +22,7 @@ let register () =
   let master = Pool_role.is_master () in
   (* blob/message/rrd file syncing - sync once a day *)
   let sync_timer =
-    if Xapi_fist.reduce_blob_sync_interval then
+    if Xapi_fist.reduce_blob_sync_interval () then
       60.0 *. 5.0
     else
       !Xapi_globs.pool_data_sync_interval
@@ -30,7 +30,7 @@ let register () =
   let sync_func () = Xapi_sync.do_sync () in
   let sync_delay =
     (* 10 mins if fist point there - to ensure rrd sync happens first *)
-    if Xapi_fist.reduce_blob_sync_interval then 60.0 *. 10.0 else 7200.
+    if Xapi_fist.reduce_blob_sync_interval () then 60.0 *. 10.0 else 7200.
   in
   (* Heartbeat to show the queue is still running - will be more useful when there's less logging! *)
   let hb_timer = 3600.0 in
@@ -38,7 +38,7 @@ let register () =
   let hb_func () = debug "Periodic scheduler heartbeat" in
   (* Periodic backup of RRDs *)
   let rrdbackup_timer =
-    if Xapi_fist.reduce_rrd_backup_interval then
+    if Xapi_fist.reduce_rrd_backup_interval () then
       60.0 *. 5.0
     else
       !Xapi_globs.rrd_backup_interval
@@ -55,7 +55,7 @@ let register () =
                  0.0 hosts)))
   in
   let rrdbackup_delay =
-    if Xapi_fist.reduce_rrd_backup_interval then 60.0 *. 6.0 else 3600.0
+    if Xapi_fist.reduce_rrd_backup_interval () then 60.0 *. 6.0 else 3600.0
   in
   let session_revalidation_func () =
     Server_helpers.exec_with_new_task "session_revalidation_func"


### PR DESCRIPTION
The existence of two fistpoints was only ever checked
when the Xapi_fist module is loaded at runtime, and
that result cached. I.e. from xapi's point of view,
these two fistpoints would be either always present,
or always not present. Instead we want to query the
filesystem each time we check for a fistpoint.

Signed-off-by: lippirk <ben.anson@citrix.com>