### PR TITLE
Block PSR if pool operations are running, and vice versa

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -6,7 +6,8 @@ open Datamodel_types
     Enum ("pool_allowed_operations", (* FIXME: This should really be called `pool_operations`, to avoid confusion with the Pool.allowed_operations field *)
           [ "ha_enable", "Indicates this pool is in the process of enabling HA";
             "ha_disable", "Indicates this pool is in the process of disabling HA";
-	    "cluster_create", "Indicates this pool is in the process of creating a cluster";
+            "cluster_create", "Indicates this pool is in the process of creating a cluster";
+            "designate_new_master", "Indicates this pool is in the process of changing master";
           ])
 
   let enable_ha = call

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -145,6 +145,8 @@ let pool_operation_to_string = function
       "ha_disable"
   | `cluster_create ->
       "cluster_create"
+  | `designate_new_master ->
+      "designate_new_master"
 
 let host_operation_to_string = function
   | `provision ->

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1192,3 +1192,7 @@ let cluster_host_not_joined = "CLUSTER_HOST_NOT_JOINED"
 let no_cluster_hosts_reachable = "NO_CLUSTER_HOSTS_REACHABLE"
 
 let xen_incompatible = "XEN_INCOMPATIBLE"
+
+let designate_new_master_in_progress = "DESIGNATE_NEW_MASTER_IN_PROGRESS"
+
+let pool_secret_rotation_pending = "POOL_SECRET_ROTATION_PENDING"

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -712,11 +712,14 @@ functor
         info "Pool.designate_new_master: pool = '%s'; host = '%s'"
           (current_pool_uuid ~__context)
           (host_uuid ~__context host) ;
-        (* Sync the RRDs from localhost to new master *)
-        Xapi_sync.sync_host __context host ;
-        let local_fn = Local.Pool.designate_new_master ~host in
-        do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
-            Client.Pool.designate_new_master rpc session_id host)
+        Xapi_pool_helpers.with_pool_operation ~__context
+          ~self:(Helpers.get_pool ~__context)
+          ~doc:"Pool.designate_new_master" ~op:`designate_new_master (fun () ->
+            (* Sync the RRDs from localhost to new master *)
+            Xapi_sync.sync_host __context host ;
+            let local_fn = Local.Pool.designate_new_master ~host in
+            do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
+                Client.Pool.designate_new_master rpc session_id host))
 
       let management_reconfigure ~__context ~network =
         info "Pool.management_reconfigure: pool = '%s'; network = '%s'"

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -1677,15 +1677,6 @@ let enable __context heartbeat_srs configuration =
   let pool = Helpers.get_pool ~__context in
   if Db.Pool.get_ha_enabled ~__context ~self:pool then
     raise (Api_errors.Server_error (Api_errors.ha_is_enabled, [])) ;
-  if Xapi_pool_helpers.pool_secret_rotation_pending ~__context then
-    raise
-      Api_errors.(
-        Server_error
-          ( internal_error
-          , [
-              "a pool secret rotation is pending, please complete it before \
-               attempting to enable HA"
-            ] )) ;
   Pool_features.assert_enabled ~__context ~f:Features.HA ;
   (* Check that all of our 'disallow_unplug' PIFs are currently attached *)
   let unplugged_ununpluggable_pifs =

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1651,7 +1651,7 @@ let designate_new_master ~__context ~host =
     if Db.Pool.get_ha_enabled ~__context ~self:pool then
       raise (Api_errors.Server_error (Api_errors.ha_is_enabled, [])) ;
     (* Only the master can sync the *current* database; only the master
-       		   knows the current generation count etc. *)
+       knows the current generation count etc. *)
     Helpers.call_api_functions ~__context (fun rpc session_id ->
         Client.Pool.sync_database rpc session_id) ;
     let all_hosts = Db.Host.get_all ~__context in

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -20,6 +20,8 @@ val assert_operation_valid :
 
 val update_allowed_operations : __context:Context.t -> self:API.ref_pool -> unit
 
+(* checks that no other pool ops are running
+   before starting a new pool operation *)
 val with_pool_operation :
      __context:Context.t
   -> self:API.ref_pool
@@ -32,6 +34,9 @@ val ha_disable_in_progress : __context:Context.t -> bool
 
 val ha_enable_in_progress : __context:Context.t -> bool
 
+(* useful when a non-pool operation requires
+   that no pool operations are running. *)
+val assert_no_pool_ops : __context:Context.t -> unit
 
 val call_fn_on_master_then_slaves :
      __context:Context.t

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -12,12 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-val assert_operation_valid :
-     __context:Context.t
-  -> self:API.ref_pool
-  -> op:API.pool_allowed_operations
-  -> unit
-
 val update_allowed_operations : __context:Context.t -> self:API.ref_pool -> unit
 
 (* checks that no other pool ops are running

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -32,7 +32,6 @@ val ha_disable_in_progress : __context:Context.t -> bool
 
 val ha_enable_in_progress : __context:Context.t -> bool
 
-val pool_secret_rotation_pending : __context:Context.t -> bool
 
 val call_fn_on_master_then_slaves :
      __context:Context.t

--- a/ocaml/xapi/xapi_psr.ml
+++ b/ocaml/xapi/xapi_psr.ml
@@ -539,7 +539,10 @@ let start =
               let[@warning "-8"] (master :: members) =
                 assert_all_hosts_alive ()
               in
-              assert_no_ha () ; assert_no_rpu () ; (master, members))
+              assert_no_ha () ;
+              assert_no_rpu () ;
+              Xapi_pool_helpers.assert_no_pool_ops ~__context ;
+              (master, members))
         in
         let module PSR = Make (Impl (struct let __context = __context end)) in
         let r =


### PR DESCRIPTION
We want to avoid the master changing whilst a pool secret
rotation is pending, so in particular we should block
pool-designate-new-master.

We do _not_ block pool-emergency-transition-to-master, but note
that it should not be used lightly.