### PR TITLE
CA-322708 - VM should not be allowed to start during dead storage migration

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -115,8 +115,6 @@ let is_allowed_concurrently ~(op : API.vm_operations) ~current_ops =
     ; ([`migrate_send], `metadata_export)
     ; ([`migrate_send], `clean_shutdown)
     ; ([`migrate_send], `clean_reboot)
-    ; ([`migrate_send], `start)
-    ; ([`migrate_send], `start_on)
     ]
   in
   let state_machine () =


### PR DESCRIPTION
During VM storage migration it was possible to start the VM.

This leads to errors (VDI in use and illegal storage transition).
To resolve this issue the start and start_on operation were removed from the allowed_operations list in the is_allowed_concurrently function.
This removes the Start and Start On operations from the XenCenter vm menu, thus preventing the user from encountering the errors.

Signed-off-by: Gheorghe Burac <gheorghe.burac@citrix.com>