### PR TITLE
Do not loose backtrace in RBAC

### DIFF
--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -225,6 +225,7 @@ let check ?(extra_dmsg = "") ?(extra_msg = "") ?args ?(keys = []) ~__context ~fn
         ?sexpr_of_args ?args ~result () ;
       result
     with error ->
+      Backtrace.is_important error;
       (* catch all exceptions *)
       Rbac_audit.allowed_post_fn_error ~__context ~session_id ~action
         ~permission ?sexpr_of_args ?args ~error () ;


### PR DESCRIPTION
In CA-343787 we got an incorrect backtrace:
```
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] host.apply_edition D:8d81d8dc6320 failed with exception Not_found
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] Raised Not_found
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 1/13 xapi Raised at file hashtbl.ml, line 194
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 2/13 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 3/13 xapi Called from file lib/backtrace.ml, line 114
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 4/13 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 35
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 5/13 xapi Called from file ocaml/xapi/xapi_local_session.ml, line 44
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 6/13 xapi Called from file ocaml/xapi/rbac.ml, line 231
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 7/13 xapi Called from file ocaml/xapi/server_helpers.ml, line 103
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 8/13 xapi Called from file string.ml, line 115
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 9/13 xapi Called from file sexp.ml, line 112
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 10/13 xapi Called from file ocaml/xapi/server_helpers.ml, line 121
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 11/13 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 12/13 xapi Called from file string.ml, line 115
Sep  1 09:36:29 localhost xapi: [error||1089 INET :::80||backtrace] 13/13 xapi Called from file sexp.ml, line 112
```

xapi_local_session.ml:44 has a try/catch, so the Not_found couldn't have
escaped from that!
The top of the stacktrace is missing.

After adding the is_important call we get a better one:
```
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] host.apply_edition D:22de234493bf failed with exception Not_found
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] Raised Not_found
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 1/19 xapi Raised at file hashtbl.ml, line 194
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 2/19 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 3/19 xapi Called from file list.ml, line 191
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 4/19 xapi Called from file ocaml/xapi/xapi_host.ml, line 1785
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 5/19 xapi Called from file ocaml/xapi/message_forwarding.ml, line 128
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 6/19 xapi Called from file ocaml/xapi/rbac.ml, line 223
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 7/19 xapi Called from file hashtbl.ml, line 194
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 8/19 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 9/19 xapi Called from file lib/backtrace.ml, line 114
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 10/19 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 35
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 11/19 xapi Called from file ocaml/xapi/xapi_local_session.ml, line 44
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 12/19 xapi Called from file ocaml/xapi/rbac.ml, line 232
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 13/19 xapi Called from file ocaml/xapi/server_helpers.ml, line 103
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 14/19 xapi Called from file string.ml, line 115
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 15/19 xapi Called from file sexp.ml, line 112
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 16/19 xapi Called from file ocaml/xapi/server_helpers.ml, line 121
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 17/19 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 18/19 xapi Called from file string.ml, line 115
Sep  1 10:37:28 localhost xapi: [error||179 UNIX /var/lib/xcp/xapi||backtrace] 19/19 xapi Called from file sexp.ml, line 112
```

This indicates a problem in xenopsd (cpu_info not set), which is not
debuggable and fixable.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>