### PR TITLE
CA-332605 - Fixed Bad error message for vcpu/cores-per-socket

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -411,6 +411,8 @@ let _ =
     ~doc:"An error occured while restoring the memory image of the specified virtual machine" ();
   error Api_errors.vm_pv_drivers_in_use [ "vm" ]
     ~doc:"VM PV drivers still in use" ();
+  error Api_errors.vcpu_max_not_cores_per_socket_multiple ["vcpu_max"; "cores_per_socket"]
+    ~doc:"VCPUs_max must be a multiple of cores-per-socket" ();
   (* VM appliance errors *)
   error Api_errors.operation_partially_failed [ "operation" ]
     ~doc:"Some VMs belonging to the appliance threw an exception while carrying out the specified operation" ();

--- a/ocaml/tests/test_platformdata.ml
+++ b/ocaml/tests/test_platformdata.ml
@@ -152,28 +152,28 @@ module SanityCheck = Generic.MakeStateless (struct
         ( ([("cores-per-socket", "4")], None, false, 6L, 6L, `hvm)
         , Error
             (Api_errors.Server_error
-               ( Api_errors.invalid_value
+               ( Api_errors.vcpu_max_not_cores_per_socket_multiple
                , [
-                   "platform:cores-per-socket (value 4)"
-                 ; "VCPUs_max (value 6) must be a multiple of cores-per-socket"
+                     "6"
+                   ; "4"
                  ] )) )
       ; (* Check VCPUs configuration - hvm failure scenario*)
         ( ([("cores-per-socket", "0")], None, false, 6L, 6L, `hvm)
         , Error
             (Api_errors.Server_error
-               ( Api_errors.invalid_value
+               ( Api_errors.vcpu_max_not_cores_per_socket_multiple
                , [
-                   "platform:cores-per-socket (value 0)"
-                 ; "VCPUs_max (value 6) must be a multiple of cores-per-socket"
+                   "6"
+                   ; "0"
                  ] )) )
       ; (* Check VCPUs configuration - hvm failure scenario*)
         ( ([("cores-per-socket", "-1")], None, false, 6L, 6L, `hvm)
         , Error
             (Api_errors.Server_error
-               ( Api_errors.invalid_value
+               ( Api_errors.vcpu_max_not_cores_per_socket_multiple
                , [
-                   "platform:cores-per-socket (value -1)"
-                 ; "VCPUs_max (value 6) must be a multiple of cores-per-socket"
+                   "6"
+                   ; "-1"
                  ] )) )
       ; (* Check VCPUs configuration - hvm failure scenario*)
         ( ([("cores-per-socket", "abc")], None, false, 6L, 5L, `hvm)
@@ -181,8 +181,7 @@ module SanityCheck = Generic.MakeStateless (struct
             (Api_errors.Server_error
                ( Api_errors.invalid_value
                , [
-                   "platform:cores-per-socket (value abc)"
-                 ; "Value is not a valid int"
+                 "platform:cores-per-socket"; "abc"
                  ] )) )
       ; (* Check BIOS configuration - qemu trad *)
         make_firmware_ok "qemu-trad" (Some Bios)

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1192,3 +1192,5 @@ let cluster_host_not_joined = "CLUSTER_HOST_NOT_JOINED"
 let no_cluster_hosts_reachable = "NO_CLUSTER_HOSTS_REACHABLE"
 
 let xen_incompatible = "XEN_INCOMPATIBLE"
+
+let vcpu_max_not_cores_per_socket_multiple = "VCPU_MAX_NOT_CORES_PER_SOCKET_MULTIPLE"

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -196,21 +196,17 @@ let sanity_check ~platformdata ?firmware ~vcpu_max ~vcpu_at_startup ~domain_type
         if cps < 1 || vcpus mod cps <> 0 then
           raise
             (Api_errors.Server_error
-               ( Api_errors.invalid_value
+               ( Api_errors.vcpu_max_not_cores_per_socket_multiple
                , [
-                   Printf.sprintf "platform:cores-per-socket (value %d)" cps
-                 ; Printf.sprintf
-                     "VCPUs_max (value %d) must be a multiple of \
-                      cores-per-socket"
-                     vcpus
-                 ] ))
+                   string_of_int vcpus; cps_str
+                 ]
+ ))
       with Failure msg ->
         raise
           (Api_errors.Server_error
              ( Api_errors.invalid_value
              , [
-                 Printf.sprintf "platform:cores-per-socket (value %s)" cps_str
-               ; "Value is not a valid int"
+               "platform:cores-per-socket"; cps_str
                ] ))
   ) ;
   (* Add usb emulation flags.


### PR DESCRIPTION
Creating a Windows 8.1 VM in XenCenter by allocating 1 vCPU and
topology 1 core-per-socket would lead to an incorrectly formatted
error (i.e. "Failed","Starting VM 'Windows 8.1 (64-bit) (1)'
The value 'VCPUs_max must be a multiple of this field' is invalid
for field 'platform:cores-per-socket'.","xrtuk-01-01","Dec 6, 2019 12:55 PM")

The incorrectly formatted error made it more difficult to understand the issue
causing it.


Signed-off-by: Gheorghe Burac <gheorghe.burac@citrix.com>