### PR TITLE
CP-34936 don't log result from pool_secret_wrapper

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1833,7 +1833,7 @@ end = struct
       |> String.concat "/"
     in
     let make_script () =
-      try call_script !Xapi_globs.gen_pool_secret_script []
+      try call_script ~log_output:Never !Xapi_globs.gen_pool_secret_script []
       with _ ->
         info "helpers.ml:PoolSecret._make: script failed, using urandom instead" ;
         make_urandom ()

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -43,7 +43,7 @@ let ha_redo_log =
 
 (** Returns the current live set info *)
 let query_liveset () =
-  let txt = call_script ~log_successful_output:false ha_query_liveset [] in
+  let txt = call_script ~log_output:On_failure ha_query_liveset [] in
   Xha_interface.LiveSetInformation.of_xml_string txt
 
 (** Returns true if this node has statefile access *)


### PR DESCRIPTION
We don't want to log the pool secret. So we add a new option to
`call_script` which ensures nothing is logged in either the success case
or the failure case.