### PR TITLE
CA-265116 rename and deprecate Pool cert functions

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -411,7 +411,21 @@ open Datamodel_types
       ~params:[String, "name", "A name to give the certificate";
                String, "cert", "The certificate"]
       ~allowed_roles:_R_POOL_OP
+      ~internal_deprecated_since:rel_next
       ()
+
+
+  let install_ca_certificate = call
+      ~in_oss_since:None
+      ~in_product_since:rel_next
+      ~name:"install_ca_certificate"
+      ~doc:"Install a TLS CA certificate, pool-wide."
+      ~params:[String, "name", "A name to give the certificate";
+               String, "cert", "The certificate"]
+      ~allowed_roles:_R_POOL_OP
+      ~internal_deprecated_since:rel_next
+      ()
+
 
   let certificate_uninstall = call
       ~in_oss_since:None
@@ -420,6 +434,17 @@ open Datamodel_types
       ~doc:"Remove a pool-wide TLS CA certificate."
       ~params:[String, "name", "The certificate name"]
       ~allowed_roles:_R_POOL_OP
+      ~internal_deprecated_since:rel_next
+      ()
+
+  let uninstall_ca_certificate = call
+      ~in_oss_since:None
+      ~in_product_since:rel_george
+      ~name:"uninstall_ca_certificate"
+      ~doc:"Remove a pool-wide TLS CA certificate."
+      ~params:[String, "name", "The certificate name"]
+      ~allowed_roles:_R_POOL_OP
+      ~internal_deprecated_since:rel_next
       ()
 
   let certificate_list = call
@@ -429,6 +454,7 @@ open Datamodel_types
       ~doc:"List the names of all installed TLS CA certificates."
       ~result:(Set(String),"All installed certificates")
       ~allowed_roles:_R_POOL_OP
+      ~internal_deprecated_since:rel_next
       ()
 
   let crl_install = call
@@ -687,6 +713,8 @@ open Datamodel_types
         ; certificate_install
         ; certificate_uninstall
         ; certificate_list
+        ; install_ca_certificate
+        ; uninstall_ca_certificate
         ; crl_install
         ; crl_uninstall
         ; crl_list

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -409,7 +409,7 @@ open Datamodel_types
       ~name:"certificate_install"
       ~doc:"Install a TLS CA certificate, pool-wide."
       ~params:[String, "name", "A name to give the certificate";
-               String, "cert", "The certificate"]
+               String, "cert", "The certificate in PEM format"]
       ~allowed_roles:_R_POOL_OP
       ~internal_deprecated_since:rel_next
       ()
@@ -421,9 +421,8 @@ open Datamodel_types
       ~name:"install_ca_certificate"
       ~doc:"Install a TLS CA certificate, pool-wide."
       ~params:[String, "name", "A name to give the certificate";
-               String, "cert", "The certificate"]
+               String, "cert", "The certificate in PEM format"]
       ~allowed_roles:_R_POOL_OP
-      ~internal_deprecated_since:rel_next
       ()
 
 
@@ -444,7 +443,6 @@ open Datamodel_types
       ~doc:"Remove a pool-wide TLS CA certificate."
       ~params:[String, "name", "The certificate name"]
       ~allowed_roles:_R_POOL_OP
-      ~internal_deprecated_since:rel_next
       ()
 
   let certificate_list = call

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -346,9 +346,25 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= []
       ; help= "Install a TLS CA certificate, pool-wide."
       ; implementation= With_fd Cli_operations.pool_certificate_install
-      ; flags= []
+      ; flags= [Deprecated ["Use pool-install-ca-certificate"]]
       } )
   ; ( "pool-certificate-uninstall"
+    , {
+        reqd= ["name"]
+      ; optn= []
+      ; help= "Uninstall a pool-wide TLS CA certificate."
+      ; implementation= No_fd Cli_operations.pool_certificate_uninstall
+      ; flags= [Deprecated ["Use pool-uninstall-ca-certificate"]]
+      } )
+  ; ( "pool-install-ca-certificate"
+    , {
+        reqd= ["filename"]
+      ; optn= []
+      ; help= "Install a TLS CA certificate, pool-wide."
+      ; implementation= With_fd Cli_operations.pool_certificate_install
+      ; flags= []
+      } )
+  ; ( "pool-uninstall-ca-certificate"
     , {
         reqd= ["name"]
       ; optn= []
@@ -362,13 +378,13 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= []
       ; help= "List the names of all installed TLS CA certificates."
       ; implementation= No_fd Cli_operations.pool_certificate_list
-      ; flags= []
+      ; flags= [Deprecated ["Use pool-uninstall-ca-certificate"]]
       } )
   ; ( "pool-crl-install"
     , {
         reqd= ["filename"]
       ; optn= []
-      ; help= "Install a TLS Certificate Revocation List, pool-wide."
+      ; help= "Install a TLS CA-issued Certificate Revocation List, pool-wide."
       ; implementation= With_fd Cli_operations.pool_crl_install
       ; flags= []
       } )
@@ -376,7 +392,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
     , {
         reqd= ["name"]
       ; optn= []
-      ; help= "Uninstall a pool-wide TLS Certificate Revocation List."
+      ; help= "Uninstall a pool-wide TLS CA-issued Certificate Revocation List."
       ; implementation= No_fd Cli_operations.pool_crl_uninstall
       ; flags= []
       } )
@@ -385,7 +401,8 @@ let rec cmdtable_data : (string * cmd_spec) list =
         reqd= []
       ; optn= []
       ; help=
-          "List the names of all installed TLS Certificate Revocation Lists."
+          "List the names of all installed TLS CA-issued Certificate \
+           Revocation Lists."
       ; implementation= No_fd Cli_operations.pool_crl_list
       ; flags= []
       } )

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2130,7 +2130,11 @@ let send_test_post = Remote_requests.send_test_post
 
 let certificate_install = Certificates.(pool_install CA_Certificate)
 
+let install_ca_certificate = certificate_install
+
 let certificate_uninstall = Certificates.(pool_uninstall CA_Certificate)
+
+let uninstall_ca_certificate = certificate_uninstall
 
 let certificate_list ~__context = Certificates.(local_list CA_Certificate)
 

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -240,7 +240,12 @@ val send_test_post :
 val certificate_install :
   __context:Context.t -> name:string -> cert:string -> unit
 
+val install_ca_certificate :
+  __context:Context.t -> name:string -> cert:string -> unit
+
 val certificate_uninstall : __context:Context.t -> name:string -> unit
+
+val uninstall_ca_certificate : __context:Context.t -> name:string -> unit
 
 val certificate_list : __context:'a -> string list
 


### PR DESCRIPTION
The names of some pool certificate functions are misleading. We
deprecate them and introduce the same functionality under better
names.

* certificate_install -> install_ca_certificate
* certificate_uninstall -> uninstall_ca_certificate

Update the CLI documentation for functions that handle Certificate
Revocation Lists.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>