### PR TITLE
CA-333441 - restarting ISCSI daemon after setting initiator IQN

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -382,6 +382,9 @@ let startup_script_hook = ref "xapi-startup-script"
 (* Executed when a rolling upgrade is detected starting or stopping *)
 let rolling_upgrade_script_hook = ref "xapi-rolling-upgrade"
 
+(* Sets IQN and restarts iSCSI daemon if required *)
+let set_iSCSI_initiator_script =  ref "/opt/xensource/libexec/set-iscsi-initiator"
+
 (* Executed during startup when the host is authed with AD
  * or the host is joining or leaving AD *)
 let domain_join_cli_cmd = ref "/opt/pbis/bin/domainjoin-cli"
@@ -1200,6 +1203,8 @@ module Resources = struct
     ; ( "openssl_path"
       , Constants.openssl_path
       , "Path for openssl command to generate RSA keys" )
+    ; ( "set-iscsi-initiator", set_iSCSI_initiator_script
+      , "Path to set-iscsi-initiator script")
     ]
 
   let nonessential_executables =

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -392,7 +392,7 @@ module Host_requires_reboot = struct
 end
 
 module Configuration = struct
-  let make_initiatorname_config iqn hostname =
+  let make_set_initiator_args iqn hostname =
     (* CA-18000: there is a 30 character limit to the initiator when talking to
        Dell MD3000i filers, so we limit the size of the initiator name in all cases *)
     let hostname_chopped =
@@ -401,14 +401,12 @@ module Configuration = struct
       else
         hostname
     in
-    Printf.sprintf "InitiatorName=%s\nInitiatorAlias=%s\n" iqn hostname_chopped
+    [iqn; hostname_chopped]
 
   let set_initiator_name iqn =
     let hostname = Unix.gethostname () in
-    let config_file = make_initiatorname_config iqn hostname in
-    Unixext.write_string_to_file
-      !Xapi_globs.iscsi_initiator_config_file
-      config_file
+    let args = make_set_initiator_args iqn hostname in
+    ignore(Helpers.call_script !Xapi_globs.set_iSCSI_initiator_script args)
 
   let set_multipathing enabled =
     let flag = !Xapi_globs.multipathing_config_file in


### PR DESCRIPTION
Setting the initiator IQN after attempting to connect
to and iSCSI target using an older IQN causes the daemon
to not be updated with the new IQN.

The daemon needs to be restarted in order to update
the IQN value used.

Signed-off-by: Gheorghe Burac <gheorghe.burac@citrix.com>