### PR TITLE
CA-256116 rename pool and host functions that handle CA certs

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -873,8 +873,6 @@ let host_query_ha = call ~flags:[`Session]
       ()
 
   let certificate_install = call
-      ~in_oss_since:None
-      ~in_product_since:rel_george
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_install"
@@ -883,11 +881,27 @@ let host_query_ha = call ~flags:[`Session]
                String, "name", "A name to give the certificate";
                String, "cert", "The certificate"]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ~lifecycle:
+        [Published, rel_george, "Install TLS CA certificate"
+        ;Deprecated, rel_next, "Use Host.install_ca_certificate instead"
+        ]
+      ()
+  
+  let install_ca_certificate = call
+      ~pool_internal:true
+      ~hide_from_docs:true
+      ~name:"install_ca_certificate"
+      ~doc:"Install a TLS CA certificate on this host."
+      ~params:[Ref _host, "host", "The host";
+               String, "name", "A name to give the certificate";
+               String, "cert", "The certificate"]
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ~lifecycle:
+        [Published, rel_next, "Install TLS CA certificate"
+        ]
       ()
 
   let certificate_uninstall = call
-      ~in_oss_since:None
-      ~in_product_since:rel_george
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_uninstall"
@@ -895,11 +909,26 @@ let host_query_ha = call ~flags:[`Session]
       ~params:[Ref _host, "host", "The host";
                String, "name", "The certificate name"]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ~lifecycle:
+        [Published, rel_george, "Install TLS CA certificate"
+        ;Deprecated, rel_next, "Use Host.uninstall_ca_certificate instead"
+        ]
+      ()
+
+  let uninstall_ca_certificate = call
+      ~pool_internal:true
+      ~hide_from_docs:true
+      ~name:"uninstall_ca_certificate"
+      ~doc:"Remove a TLS CA certificate from this host."
+      ~params:[Ref _host, "host", "The host";
+               String, "name", "The certificate name"]
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ~lifecycle:
+        [Published, rel_next, "Uninstall TLS CA certificate"
+        ]
       ()
 
   let certificate_list = call
-      ~in_oss_since:None
-      ~in_product_since:rel_george
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"certificate_list"
@@ -907,6 +936,10 @@ let host_query_ha = call ~flags:[`Session]
       ~params:[Ref _host, "host", "The host"]
       ~result:(Set(String),"All installed certificates")
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ~lifecycle:
+        [Published, rel_george, "List installed TLS CA certificate"
+        ;Deprecated, rel_next, "Use openssl to inspect certificate?"
+        ]
       ()
 
   let crl_install = call
@@ -915,7 +948,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"crl_install"
-      ~doc:"Install a TLS Certificate Revocation List to this host."
+      ~doc:"Install a TLS CA-issued Certificate Revocation List to this host."
       ~params:[Ref _host, "host", "The host";
                String, "name", "A name to give the CRL";
                String, "crl", "The CRL"]
@@ -928,7 +961,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"crl_uninstall"
-      ~doc:"Uninstall a TLS certificate revocation list from this host."
+      ~doc:"Uninstall a TLS CA-issued certificate revocation list from this host."
       ~params:[Ref _host, "host", "The host";
                String, "name", "The CRL name"]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
@@ -940,7 +973,7 @@ let host_query_ha = call ~flags:[`Session]
       ~pool_internal:true
       ~hide_from_docs:true
       ~name:"crl_list"
-      ~doc:"List the filenames of all installed TLS Certificate Revocation Lists."
+      ~doc:"List the filenames of all installed TLS CA-issued Certificate Revocation Lists."
       ~params:[Ref _host, "host", "The host"]
       ~result:(Set(String),"All installed CRLs")
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
@@ -1441,6 +1474,8 @@ let host_query_ha = call ~flags:[`Session]
         enable_external_auth;
         disable_external_auth;
         retrieve_wlb_evacuate_recommendations;
+        install_ca_certificate;
+        uninstall_ca_certificate;
         certificate_install;
         certificate_uninstall;
         certificate_list;

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -457,7 +457,7 @@ open Datamodel_types
       ~allowed_roles:_R_POOL_OP
       ~lifecycle:
         [Published, rel_george, "List installed TLS CA certificate"
-        ;Deprecated, rel_next, "XXX What use instead?"
+        ;Deprecated, rel_next, "Use openssl to inspect certificate"
         ]
       ()
 

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -405,31 +405,60 @@ open Datamodel_types
       ()
 
   let certificate_install = call
-      ~in_oss_since:None
-      ~in_product_since:rel_george
       ~name:"certificate_install"
       ~doc:"Install a TLS CA certificate, pool-wide."
       ~params:[String, "name", "A name to give the certificate";
-               String, "cert", "The certificate"]
+               String, "cert", "The certificate in PEM format"]
       ~allowed_roles:_R_POOL_OP
+      ~lifecycle:
+        [Published, rel_george, "Install TLS CA certificate"
+        ;Deprecated, rel_next, "Use Pool.install_ca_certificate instead"
+        ]
       ()
 
+
+  let install_ca_certificate = call
+      ~name:"install_ca_certificate"
+      ~doc:"Install a TLS CA certificate, pool-wide."
+      ~params:[String, "name", "A name to give the certificate";
+               String, "cert", "The certificate in PEM format"]
+      ~allowed_roles:_R_POOL_OP
+      ~lifecycle:
+        [Published, rel_next, "Install TLS CA certificate"
+        ]
+      ()
+
+
   let certificate_uninstall = call
-      ~in_oss_since:None
-      ~in_product_since:rel_george
       ~name:"certificate_uninstall"
       ~doc:"Remove a pool-wide TLS CA certificate."
       ~params:[String, "name", "The certificate name"]
       ~allowed_roles:_R_POOL_OP
+      ~lifecycle:
+        [Published, rel_george, "Install TLS CA certificate"
+        ;Deprecated, rel_next, "Use Pool.uninstall_ca_certificate instead"
+        ]
+      ()
+
+  let uninstall_ca_certificate = call
+      ~name:"uninstall_ca_certificate"
+      ~doc:"Remove a pool-wide TLS CA certificate."
+      ~params:[String, "name", "The certificate name"]
+      ~allowed_roles:_R_POOL_OP
+      ~lifecycle:
+        [Published, rel_next, "Uninstall TLS CA certificate"
+        ]
       ()
 
   let certificate_list = call
-      ~in_oss_since:None
-      ~in_product_since:rel_george
       ~name:"certificate_list"
       ~doc:"List the names of all installed TLS CA certificates."
       ~result:(Set(String),"All installed certificates")
       ~allowed_roles:_R_POOL_OP
+      ~lifecycle:
+        [Published, rel_george, "List installed TLS CA certificate"
+        ;Deprecated, rel_next, "XXX What use instead?"
+        ]
       ()
 
   let crl_install = call
@@ -701,6 +730,8 @@ open Datamodel_types
         ; certificate_install
         ; certificate_uninstall
         ; certificate_list
+        ; install_ca_certificate
+        ; uninstall_ca_certificate
         ; crl_install
         ; crl_uninstall
         ; crl_list

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -378,7 +378,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= []
       ; help= "List the names of all installed TLS CA certificates."
       ; implementation= No_fd Cli_operations.pool_certificate_list
-      ; flags= [Deprecated ["XXX What use instead"]]
+      ; flags= [Deprecated ["Use openssl to inspect certificate"]]
       } )
   ; ( "pool-crl-install"
     , {

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -345,15 +345,31 @@ let rec cmdtable_data : (string * cmd_spec) list =
         reqd= ["filename"]
       ; optn= []
       ; help= "Install a TLS CA certificate, pool-wide."
-      ; implementation= With_fd Cli_operations.pool_certificate_install
-      ; flags= []
+      ; implementation= With_fd Cli_operations.pool_install_ca_certificate
+      ; flags= [Deprecated ["Use pool-install-ca-certificate"]]
       } )
   ; ( "pool-certificate-uninstall"
     , {
         reqd= ["name"]
       ; optn= []
       ; help= "Uninstall a pool-wide TLS CA certificate."
-      ; implementation= No_fd Cli_operations.pool_certificate_uninstall
+      ; implementation= No_fd Cli_operations.pool_uninstall_ca_certificate
+      ; flags= [Deprecated ["Use pool-uninstall-ca-certificate"]]
+      } )
+  ; ( "pool-install-ca-certificate"
+    , {
+        reqd= ["filename"]
+      ; optn= []
+      ; help= "Install a TLS CA certificate, pool-wide."
+      ; implementation= With_fd Cli_operations.pool_install_ca_certificate
+      ; flags= []
+      } )
+  ; ( "pool-uninstall-ca-certificate"
+    , {
+        reqd= ["name"]
+      ; optn= []
+      ; help= "Uninstall a pool-wide TLS CA certificate."
+      ; implementation= No_fd Cli_operations.pool_uninstall_ca_certificate
       ; flags= []
       } )
   ; ( "pool-certificate-list"
@@ -362,13 +378,13 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= []
       ; help= "List the names of all installed TLS CA certificates."
       ; implementation= No_fd Cli_operations.pool_certificate_list
-      ; flags= []
+      ; flags= [Deprecated ["XXX What use instead"]]
       } )
   ; ( "pool-crl-install"
     , {
         reqd= ["filename"]
       ; optn= []
-      ; help= "Install a TLS Certificate Revocation List, pool-wide."
+      ; help= "Install a TLS CA-issued Certificate Revocation List, pool-wide."
       ; implementation= With_fd Cli_operations.pool_crl_install
       ; flags= []
       } )
@@ -376,7 +392,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
     , {
         reqd= ["name"]
       ; optn= []
-      ; help= "Uninstall a pool-wide TLS Certificate Revocation List."
+      ; help= "Uninstall a pool-wide TLS CA-issued Certificate Revocation List."
       ; implementation= No_fd Cli_operations.pool_crl_uninstall
       ; flags= []
       } )
@@ -385,7 +401,8 @@ let rec cmdtable_data : (string * cmd_spec) list =
         reqd= []
       ; optn= []
       ; help=
-          "List the names of all installed TLS Certificate Revocation Lists."
+          "List the names of all installed TLS CA-issued Certificate \
+           Revocation Lists."
       ; implementation= No_fd Cli_operations.pool_crl_list
       ; flags= []
       } )

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1563,20 +1563,20 @@ let pool_send_test_post printer rpc session_id params =
     (Cli_printer.PMsg
        (Client.Pool.send_test_post ~rpc ~session_id ~host ~port ~body))
 
-let pool_certificate_install fd printer rpc session_id params =
+let pool_install_ca_certificate fd printer rpc session_id params =
   let filename = List.assoc "filename" params in
   match get_client_file fd filename with
   | Some cert ->
-      Client.Pool.certificate_install ~rpc ~session_id
+      Client.Pool.install_ca_certificate ~rpc ~session_id
         ~name:(Filename.basename filename)
         ~cert
   | None ->
       marshal fd (Command (PrintStderr "Failed to read certificate\n")) ;
       raise (ExitWithError 1)
 
-let pool_certificate_uninstall printer rpc session_id params =
+let pool_uninstall_ca_certificate printer rpc session_id params =
   let name = List.assoc "name" params in
-  Client.Pool.certificate_uninstall ~rpc ~session_id ~name
+  Client.Pool.uninstall_ca_certificate ~rpc ~session_id ~name
 
 let pool_certificate_list printer rpc session_id params =
   printer (Cli_printer.PList (Client.Pool.certificate_list ~rpc ~session_id))

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -228,9 +228,9 @@ let sync_certs kind ~__context master_certs host =
         (fun rpc session_id host ->
           Client.Host.certificate_list rpc session_id host)
         (fun rpc session_id host c cert ->
-          Client.Host.certificate_install rpc session_id host c cert)
+          Client.Host.install_ca_certificate rpc session_id host c cert)
         (fun rpc session_id host c ->
-          Client.Host.certificate_uninstall rpc session_id host c)
+          Client.Host.uninstall_ca_certificate rpc session_id host c)
         ~__context master_certs host
   | CRL ->
       sync_certs_crls CRL

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3153,14 +3153,14 @@ functor
             Client.Host.disable_external_auth rpc session_id host config)
 
       let install_ca_certificate ~__context ~host ~name ~cert =
-        let local_fn = Local.Host.certificate_install ~host ~name ~cert in
+        let local_fn = Local.Host.install_ca_certificate ~host ~name ~cert in
         do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
-            Client.Host.certificate_install rpc session_id host name cert)
+            Client.Host.install_ca_certificate rpc session_id host name cert)
 
       let uninstall_ca_certificate ~__context ~host ~name =
-        let local_fn = Local.Host.certificate_uninstall ~host ~name in
+        let local_fn = Local.Host.uninstall_ca_certificate ~host ~name in
         do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
-            Client.Host.certificate_uninstall rpc session_id host name)
+            Client.Host.uninstall_ca_certificate rpc session_id host name)
 
       (* legacy names *)
       let certificate_install = install_ca_certificate

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3152,15 +3152,20 @@ functor
         do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
             Client.Host.disable_external_auth rpc session_id host config)
 
-      let certificate_install ~__context ~host ~name ~cert =
+      let install_ca_certificate ~__context ~host ~name ~cert =
         let local_fn = Local.Host.certificate_install ~host ~name ~cert in
         do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
             Client.Host.certificate_install rpc session_id host name cert)
 
-      let certificate_uninstall ~__context ~host ~name =
+      let uninstall_ca_certificate ~__context ~host ~name =
         let local_fn = Local.Host.certificate_uninstall ~host ~name in
         do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
             Client.Host.certificate_uninstall rpc session_id host name)
+
+      (* legacy names *)
+      let certificate_install = install_ca_certificate
+
+      let certificate_uninstall = uninstall_ca_certificate
 
       let certificate_list ~__context ~host =
         let local_fn = Local.Host.certificate_list ~host in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1340,11 +1340,16 @@ let get_uncooperative_resident_VMs ~__context ~self = []
 (* Dummy implementation for a deprecated API method. *)
 let get_uncooperative_domains ~__context ~self = []
 
-let certificate_install ~__context ~host ~name ~cert =
+let install_ca_certificate ~__context ~host ~name ~cert =
   Certificates.(host_install CA_Certificate name cert)
 
-let certificate_uninstall ~__context ~host ~name =
+let uninstall_ca_certificate ~__context ~host ~name =
   Certificates.(host_uninstall CA_Certificate name)
+
+(* legacy names *)
+let certificate_uninstall = uninstall_ca_certificate
+
+let certificate_install = install_ca_certificate
 
 let certificate_list ~__context ~host = Certificates.(local_list CA_Certificate)
 

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -272,6 +272,12 @@ val get_uncooperative_resident_VMs :
 val get_uncooperative_domains :
   __context:Context.t -> self:[`host] Ref.t -> string list
 
+val install_ca_certificate :
+  __context:'a -> host:'b -> name:string -> cert:string -> unit
+
+val uninstall_ca_certificate : __context:'a -> host:'b -> name:string -> unit
+
+(* legacy names *)
 val certificate_install :
   __context:'a -> host:'b -> name:string -> cert:string -> unit
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2130,7 +2130,11 @@ let send_test_post = Remote_requests.send_test_post
 
 let certificate_install = Certificates.(pool_install CA_Certificate)
 
+let install_ca_certificate = certificate_install
+
 let certificate_uninstall = Certificates.(pool_uninstall CA_Certificate)
+
+let uninstall_ca_certificate = certificate_uninstall
 
 let certificate_list ~__context = Certificates.(local_list CA_Certificate)
 

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -240,7 +240,12 @@ val send_test_post :
 val certificate_install :
   __context:Context.t -> name:string -> cert:string -> unit
 
+val install_ca_certificate :
+  __context:Context.t -> name:string -> cert:string -> unit
+
 val certificate_uninstall : __context:Context.t -> name:string -> unit
+
+val uninstall_ca_certificate : __context:Context.t -> name:string -> unit
 
 val certificate_list : __context:'a -> string list
 


### PR DESCRIPTION
Make it more obvious that pool and host functions are handling CA-issued certificates by renaming them while keeping the old name around but deprecated.