### PR TITLE
CP-34465: Add signing fields to certificate records

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5598,6 +5598,8 @@ let all_relations =
     (_network_sriov, "logical_PIF"), (_pif, "sriov_logical_PIF_of");
 
     (_certificate, "host"), (_host, "certificates");
+    (_certificate, "pool"), (_pool, "certificates");
+    (_certificate, "validated_by"), (_certificate, "validates");
   ]
 
 (** the full api specified here *)

--- a/ocaml/idl/datamodel_certificate.ml
+++ b/ocaml/idl/datamodel_certificate.ml
@@ -18,6 +18,13 @@ open Datamodel_roles
 
 let lifecycle = [Published, rel_stockholm, ""]
 
+let certificate_type =
+  Enum ( "certificate_type"
+       , [ "host", "Certificate that identifies a single host"
+         ; "pool", "Certificate that is trusted by the whole pool"
+         ; "host_and_pool", "Certificate that both identifies a host and is trusted by the whole pool."
+         ])
+
 let t =
   create_obj
     ~name: _certificate
@@ -32,9 +39,15 @@ let t =
     ~messages_default_allowed_roles:_R_READ_ONLY
     ~contents:
       [ uid   _certificate ~lifecycle
-      ; field   ~qualifier:StaticRO ~lifecycle
+      ; field ~qualifier:DynamicRO ~lifecycle:[Published, rel_next, ""]
+          ~ty:certificate_type "type"
+          "The type of certificate, can be a host certificate, a CA certificate, or both"
+      ; field ~qualifier:StaticRO ~lifecycle
           ~ty:(Ref _host) "host" ~default_value:(Some (VRef null_ref))
-          "The host where the certificate is installed"
+          "The host that is identified by the certificate"
+      ; field ~qualifier:StaticRO ~lifecycle:[Published, rel_next, ""]
+          ~ty:(Ref _pool) "pool" ~default_value:(Some (VRef null_ref))
+          "The pool that trusts this certificate"
       ; field ~qualifier:StaticRO ~lifecycle
           ~ty:(DateTime) "not_before" ~default_value:(Some (VDateTime Date.never))
           "Date after which the certificate is valid"
@@ -44,6 +57,12 @@ let t =
       ; field ~qualifier:StaticRO ~lifecycle
           ~ty:(String) "fingerprint" ~default_value:(Some (VString ""))
           "The certificate's fingerprint / hash"
+      ; field ~qualifier:DynamicRO ~lifecycle:[Published, rel_next, ""]
+      ~ty:(Set (Ref _certificate)) "validated_by"
+          "The trusted certificates that validate this host certificate"
+      ; field ~qualifier:DynamicRO ~lifecycle:[Published, rel_next, ""]
+          ~ty:(Set (Ref _certificate)) "validates"
+          "The certificates that are validates by this pool certificate"
       ]
     ~messages:
       [

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -795,5 +795,6 @@ open Datamodel_types
          ; field ~in_product_since:rel_inverness ~qualifier:DynamicRO ~ty:Bool ~default_value:(Some (VBool false)) "igmp_snooping_enabled" "true if IGMP snooping is enabled in the pool, false otherwise."
          ; field ~in_product_since:rel_quebec ~qualifier:RW ~ty:String ~default_value:(Some (VString "")) "uefi_certificates" "The UEFI certificates allowing Secure Boot"
          ; field ~in_product_since:rel_stockholm_psr ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "is_psr_pending" "True if either a PSR is running or we are waiting for a PSR to be re-run"
+         ; field ~qualifier:DynamicRO ~lifecycle:[Published, rel_next, ""] ~ty:(Set (Ref _certificate)) "certificates" "CA certificates installed in the pool";
          ])
       ()

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1395,8 +1395,8 @@ let install_server_certificate ~__context ~host ~certificate ~private_key
   List.iter
     (fun self -> Db.Certificate.destroy ~__context ~self)
     current_server_certs ;
-  Db.Certificate.create ~__context ~ref ~uuid ~host ~not_before ~not_after
-    ~fingerprint ;
+  Db.Certificate.create ~__context ~ref ~uuid ~_type:`host ~host ~pool:Ref.null
+    ~not_before ~not_after ~fingerprint ;
   let task = Context.get_task_id __context in
   (* mark task as done *)
   Db.Task.set_progress ~__context ~self:task ~value:1.0 ;


### PR DESCRIPTION
These allow to model certificate chains and let xapi manage which
certificates are to be installed as pool-wide CA certificates, which are
to be installed in a single host, or both.

This change does not ensure that the fields are correctly filled and are up-to-date with the certificates in the filesystem.
To do that several codepaths will need to be modified: Pool CA certificate installation and uninstallation; host certificate reset, host certificate installation; and startup to syncronize CA certificates and server certificate.