### PR TITLE
Stockholm bugfix backports

### DIFF
--- a/ocaml/tests/test_pool_update.ml
+++ b/ocaml/tests/test_pool_update.ml
@@ -26,7 +26,7 @@ let test_pool_update_refcount () =
   let assert_equal =
     Alcotest.(check int) "assertion called by test_pool_update_refcount"
   in
-  let __context = Mock.make_context_with_new_db "Mock context" in
+  let __context = make_test_database () in
   let vdi = make_vdi ~__context ~virtual_size:4096L () in
   Xapi_pool_update.with_inc_refcount ~__context ~uuid:"a" ~vdi
     (fun ~__context ~uuid ~vdi -> ()) ;

--- a/ocaml/xapi/extauth_plugin_ADpbis.ml
+++ b/ocaml/xapi/extauth_plugin_ADpbis.ml
@@ -734,83 +734,94 @@ module AuthADlw : Auth_signature.AUTH_MODULE = struct
     In addition, there are some event hooks that auth modules implement as follows:
 *)
 
-  let _is_pbis_server_available max =
-    let username = "KRBTGT" in
-    (* domain name prefix automatically added by our internal AD plugin functions *)
-    let rec test i =
-      (* let's test this many times *)
-      if i > max then
-        false (* we give up *)
-      else
-        (* let's test *)
-
-        (* (1) we _need_ to use a username contained in our domain, otherwise test (2) doesn't work *)
-        (* Microsoft KB/Q243330 article provides the KRBTGT account as a well-known built-in SID in AD *)
-        (* Microsoft KB/Q229909 article says that KRBTGT account cannot be renamed or enabled, making *)
-        (* it the perfect target for such a test using a username (Administrator account can be renamed). *)
-        try
-          let username = "KRBTGT" in
-          (* domain name prefix automatically added by our internal AD plugin functions *)
-          let sid = get_subject_identifier username in
-          (* use our well-known KRBTGT builtin username in AD *)
-          (* OK, we found this username! *)
-          debug
-            "Request %i/%i to external authentication server successful: user \
-             %s was found"
-            i max username ;
-          (* (2) CA-25427: test (1) above may succeed (because of pbis caching stale AD information) *)
-          (* even though the AD domain is offline (error 32888), usually because /etc/resolv.conf is not *)
-          (* pointing to the AD server. This test should catch if the domain is offline by calling find-by-sid *)
-          (* using a domain SID. We must use a _domain_ SID. A universal SID like S-1-1-0 doesn't work for this test. *)
-          let (_ : (string * string) list) = query_subject_information sid in
-          (* use KRBTGT's domain SID *)
-          debug
-            "Request %i/%i to external authentication server successful: sid \
-             %s was found"
-            i max sid ;
-          true
+  let _is_pbis_server_available max_tries =
+    (* we _need_ to use a username contained in our domain, otherwise the following tests won't work.
+       Microsoft KB/Q243330 article provides the KRBTGT account as a well-known built-in SID in AD
+       Microsoft KB/Q229909 article says that KRBTGT account cannot be renamed or enabled, making
+       it the perfect target for such a test using a username (Administrator account can be renamed) *)
+    let krbtgt = "KRBTGT" in
+    let try_clear_cache () =
+      (* the primary purpose of this function is to clear the cache so that
+         [ try_fetch_sid ] is forced to perform an end to end query to the
+         AD server. as such, we don't care if krbtgt was not originally in
+         the cache *)
+      match get_full_subject_name krbtgt with
+      | exception e ->
+          info
+            "_is_pbis_server_available: failed to get full subject name for %s"
+            krbtgt ;
+          Error ()
+      | full_username -> (
+        match
+          ignore
+            (pbis_common "/opt/pbis/bin/ad-cache"
+               ["--delete-user"; "--name"; full_username])
         with
-        | Not_found ->
-            (* that means that pbis is responding to at least cached subject queries. *)
-            (* in this case, KRBTGT wasn't found in the AD domain. this usually indicates that the *)
-            (* AD domain is offline/inaccessible to pbis, which will cause problems, specially *)
-            (* to the ssh python hook-script, so we need to try again until KRBTGT is found, indicating *)
-            (* that the domain is online and accessible to pbis queries *)
-            debug
-              "Request %i/%i to external authentication server returned KRBTGT \
-               Not_found, waiting 5 secs to try again"
-              i max ;
-            Thread.delay 5.0 ;
-            (*wait 5 seconds*)
-            (* try again *)
-            test (i + 1)
-        | e ->
-            (* ERROR: anything else means that the server is NOT responding adequately *)
-            debug
-              "Request %i/%i to external authentication server failed, waiting \
-               5 secs to try again: %s"
-              i max
+        | () | (exception Not_found) ->
+            Ok ()
+        | exception e ->
+            debug "Failed to remove user %s from cache: %s" full_username
               (ExnHelper.string_of_exn e) ;
-            Thread.delay 5.0 ;
-            (*wait 5 seconds*)
-            (* try again *)
-            test (i + 1)
+            Error ()
+      )
     in
-    debug "Testing if external authentication server is accepting requests..." ;
-    let full_username = get_full_subject_name username in
-    ( try
-        ignore
-          (pbis_common "/opt/pbis/bin/ad-cache"
-             ["--delete-user"; "--name"; full_username])
+    let try_fetch_sid () =
+      try
+        let sid = get_subject_identifier krbtgt in
+        debug
+          "Request to external authentication server successful: user %s was \
+           found"
+          krbtgt ;
+        let (_ : (string * string) list) = query_subject_information sid in
+        debug
+          "Request to external authentication server successful: sid %s was \
+           found"
+          sid ;
+        Ok ()
       with
-    | Not_found ->
-        ()
-    | e ->
-        debug "Failed to remove user %s from cache: %s" full_username
-          (ExnHelper.string_of_exn e) ;
-        raise e
-    ) ;
-    test 0
+      | Not_found ->
+          (* that means that pbis is responding to at least cached subject queries.
+             in this case, KRBTGT wasn't found in the AD domain. this usually indicates that the
+             AD domain is offline/inaccessible to pbis, which will cause problems, specially
+             to the ssh python hook-script, so we need to try again until KRBTGT is found, indicating
+             that the domain is online and accessible to pbis queries *)
+          debug
+            "Request to external authentication server returned KRBTGT \
+             Not_found" ;
+          Error ()
+      | e ->
+          debug
+            "Request to external authentication server failed for reason: %s"
+            (ExnHelper.string_of_exn e) ;
+          Error ()
+    in
+    let rec go i =
+      if i > max_tries then (
+        info
+          "Testing external authentication server failed after %i tries, \
+           giving up!"
+          max_tries ;
+        false
+      ) else (
+        debug
+          "Testing if external authentication server is accepting requests... \
+           attempt %i of %i"
+          i max_tries ;
+        let ( >>= ) = Rresult.( >>= ) in
+        (* if we don't remove krbtgt from the cache before
+           query subject information about krbtgt, then
+           [ try_fetch_sid ] would erroneously return success
+           in the case that PBIS is running locally, but the
+           AD domain is offline *)
+        match try_clear_cache () >>= try_fetch_sid with
+        | Error () ->
+            Thread.delay 5.0 ;
+            (go [@tailcall]) (i + 1)
+        | Ok () ->
+            true
+      )
+    in
+    go 0
 
   let is_pbis_server_available max =
     Locking_helpers.Named_mutex.execute mutex_check_availability (fun () ->

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1319,15 +1319,7 @@ let backup_rrds ~__context ~host ~delay =
 
 let get_servertime ~__context ~host = Date.of_float (Unix.gettimeofday ())
 
-let get_server_localtime ~__context ~host =
-  let gmt_time = Unix.gettimeofday () in
-  let local_time = Unix.localtime gmt_time in
-  Date.of_string
-    (Printf.sprintf "%04d%02d%02dT%02d:%02d:%02d"
-       (local_time.Unix.tm_year + 1900)
-       (local_time.Unix.tm_mon + 1)
-       local_time.Unix.tm_mday local_time.Unix.tm_hour local_time.Unix.tm_min
-       local_time.Unix.tm_sec)
+let get_server_localtime ~__context ~host = Date.localtime ()
 
 let enable_binary_storage ~__context ~host =
   Unixext.mkdir_safe Xapi_globs.xapi_blob_location 0o700 ;

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -114,7 +114,7 @@ let start ~__context ?addr () =
   Http_svr.start Xapi_http.server socket ;
   management_interface_server := socket :: !management_interface_server ;
   restart_stunnel ~__context ~accept ;
-  if Pool_role.is_master () && !listening_all then
+  if Pool_role.is_master () && addr = None then
     (* NB if we synchronously bring up the management interface on a master with a blank
        		   database this can fail... this is ok because the database will be synchronised later *)
     Server_helpers.exec_with_new_task "refreshing consoles" (fun __context ->

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -98,8 +98,35 @@ let updates_to_attach_count_tbl : (string, int) Hashtbl.t = Hashtbl.create 10
 
 let updates_to_attach_count_tbl_mutex = Mutex.create ()
 
+let get_update_vbds ~__context ~vdi =
+  let dom0 = Helpers.get_domain_zero ~__context in
+  Db.VDI.get_VBDs ~__context ~self:vdi
+  |> List.filter (fun self -> Db.VBD.get_VM ~__context ~self = dom0)
+
+let get_mount_dir_opt ~__context ~uuid =
+  let mount_dir = Filename.concat !Xapi_globs.host_update_dir uuid in
+  if Sys.file_exists mount_dir then Some mount_dir else None
+
+let assert_update_vbds_attached ~__context ~vdi =
+  let unplugged =
+    get_update_vbds ~__context ~vdi
+    |> List.filter (fun self ->
+           not (Db.VBD.get_currently_attached ~__context ~self))
+  in
+  match unplugged with
+  | [] ->
+      ()
+  | _ ->
+      let msg =
+        Printf.sprintf
+          "pool_update: expected VBDs=[ %s ] to be attached but they aren't!"
+          (unplugged |> List.map Ref.string_of |> String.concat "; ")
+      in
+      raise Api_errors.(Server_error (internal_error, [msg]))
+
 let with_dec_refcount ~__context ~uuid ~vdi f =
   Mutex.execute updates_to_attach_count_tbl_mutex (fun () ->
+      assert_update_vbds_attached ~__context ~vdi ;
       let count =
         try Hashtbl.find updates_to_attach_count_tbl uuid with _ -> 0
       in
@@ -119,20 +146,8 @@ let with_inc_refcount ~__context ~uuid ~vdi f =
       debug "pool_update.attach_helper refcount='%d'" count ;
       if count = 0 then
         f ~__context ~uuid ~vdi ;
+      assert_update_vbds_attached ~__context ~vdi ;
       Hashtbl.replace updates_to_attach_count_tbl uuid (count + 1))
-
-let get_locally_attached ~__context ~uuid ~vdi =
-  let mount_dir = Filename.concat !Xapi_globs.host_update_dir uuid in
-  let mount_dir_opt =
-    if Sys.file_exists mount_dir then Some mount_dir else None
-  in
-  let dom0 = Helpers.get_domain_zero ~__context in
-  let vbds =
-    List.filter
-      (fun self -> Db.VBD.get_VM ~__context ~self = dom0)
-      (Db.VDI.get_VBDs ~__context ~self:vdi)
-  in
-  (mount_dir_opt, vbds)
 
 let detach_helper ~__context ~uuid ~vdi =
   with_dec_refcount ~__context ~uuid ~vdi (fun ~__context ~uuid ~vdi ->
@@ -146,15 +161,12 @@ let detach_helper ~__context ~uuid ~vdi =
           ("detach_helper: unmounting " ^ mount_point)
           (fun () -> umount mount_point)
           () ;
+      let vbds = get_update_vbds ~__context ~vdi in
       Helpers.call_api_functions ~__context (fun rpc session_id ->
-          let dom0 = Helpers.get_domain_zero ~__context in
-          let vbds = Client.VDI.get_VBDs ~rpc ~session_id ~self:vdi in
           List.iter
             (fun self ->
-              if Client.VBD.get_VM ~rpc ~session_id ~self = dom0 then (
-                Client.VBD.unplug ~rpc ~session_id ~self ;
-                Client.VBD.destroy ~rpc ~session_id ~self
-              ))
+              Client.VBD.unplug ~rpc ~session_id ~self ;
+              Client.VBD.destroy ~rpc ~session_id ~self)
             vbds) ;
       if try Sys.is_directory mount_point_parent_dir with _ -> false then (
         Helpers.log_exn_continue
@@ -594,7 +606,9 @@ let detach_attached_updates __context =
   |> List.iter (fun self ->
          let uuid = Db.Pool_update.get_uuid ~__context ~self in
          let vdi = Db.Pool_update.get_vdi ~__context ~self in
-         match get_locally_attached ~__context ~uuid ~vdi with
+         match
+           (get_mount_dir_opt ~__context ~uuid, get_update_vbds ~__context ~vdi)
+         with
          | None, [] ->
              ()
          | _ ->

--- a/scripts/extensions/pool_update.precheck
+++ b/scripts/extensions/pool_update.precheck
@@ -91,11 +91,16 @@ def failure_message(code, params):
 
 
 def parse_control_package(session, yum_url):
-    if yum_url.startswith('http://'):
-        update_xml = urllib2.urlopen(yum_url + '/update.xml').read()
-        xmldoc = xml.dom.minidom.parse(StringIO.StringIO(update_xml))
-    else:
-        raise PrecheckFailure('Incorrect yum repo')
+    if not yum_url.startswith('http://'):
+        raise PrecheckFailure('Incorrect yum repo: %s' % yum_url)
+
+    update_xml_url = yum_url + '/update.xml'
+    try:
+        update_xml = urllib2.urlopen(update_xml_url).read()
+    except:
+        raise PrecheckFailure("Couldn't fetch update.xml from '%s'" % update_xml_url)
+    xmldoc = xml.dom.minidom.parse(StringIO.StringIO(update_xml))
+
     items = xmldoc.getElementsByTagName('update')
     if not items:
         raise PrecheckFailure('Missing <update> in update.xml')

--- a/scripts/host-backup-restore/host-backup
+++ b/scripts/host-backup-restore/host-backup
@@ -37,5 +37,4 @@ tar --exclude 'tmp/*' --exclude 'tmp/.*' --exclude 'var/crash/*' --exclude 'var/
     --exclude 'var/xsconfig/*' --exclude 'var/xsconfig/.*' \
     --exclude 'var/xapi/[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*' \
     --warning='no-file-ignored' \
-    --sparse --preserve-permissions --to-stdout --gzip --one-file-system -C / -c . 
-
+    --sparse --preserve-permissions --to-stdout --gzip --one-file-system -C / -c . boot/efi


### PR DESCRIPTION
In preparation for a hotfix on 8.2, we backport the necessary bugfixes (some have been backported already). We will also backport REQ-819, but we'll do that separately.

In particular, we already have a PR open for backporting CA-344268 (https://github.com/xapi-project/xen-api/pull/4215) - we'll close it and include the change here to reduce the number of PRs.

All the backports were cleanly applied.