### PR TITLE
maintenance: allow tests to run in a sandbox

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
 profile=ocamlformat
-version=0.14.1
 indicate-multiline-delimiters=closing-on-separate-line
 if-then-else=fit-or-vertical
 dock-collection-brackets=true
@@ -7,3 +6,4 @@ break-struct=natural
 break-separators=before
 break-infix=fit-or-vertical
 break-infix-before-func=false
+sequence-blank-line=preserve-one

--- a/ocaml/database/block_device_io.ml
+++ b/ocaml/database/block_device_io.ml
@@ -669,6 +669,7 @@ let action_read block_dev_fd client datasock target_response_time =
       | _ ->
           raise InvalidBlockDevice
     in
+
     (* the log is empty *)
 
     (* Seek to the start of the chosen half *)

--- a/ocaml/database/database_test.ml
+++ b/ocaml/database/database_test.ml
@@ -710,6 +710,7 @@ functor
       if Client.read_field t "VM" "other_config" valid_ref <> "(('foo' 'bar'))"
       then
         failwith "process_structure_field expected (('foo' 'bar')) 4" ;
+
       (* Check that non-persistent fields are filled with an empty value *)
 
       (* Event tests *)
@@ -749,6 +750,7 @@ functor
         in
         Printf.printf "Created %d VBD records, %.2f calls/sec\n%!" n create_time ;
         let m = 300000 in
+
         (* multiple of 3 *)
 
         (* Time a benign VM create_row, delete_row, read_record sequence *)

--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -631,6 +631,7 @@ let startup log =
               R.info "Using block device at %s" device ;
               (* Check that the block device exists *)
               Unix.access device [Unix.F_OK; Unix.R_OK] ;
+
               (* will throw Unix.Unix_error if not readable *)
 
               (* Start the I/O process *)

--- a/ocaml/idl/dm_api.ml
+++ b/ocaml/idl/dm_api.ml
@@ -167,7 +167,7 @@ let map (field : field -> field) (message : message -> message)
 let map_api_fields (f: field -> field) ((system, relations) : api) : api =
   (map_field f system, relations)
 *)
-let make api = (api : api)
+let make api : api = api
 
 let check api emergency_calls =
   let truefn _ = true in

--- a/ocaml/perftest/histogram.ml
+++ b/ocaml/perftest/histogram.ml
@@ -107,6 +107,7 @@ let _ =
               (List.assoc result max_point)
               1000
           in
+
           (* -- Apply the Weierstrass transform -- *)
 
           (* NB Each call to Hist.convolve (i.e. each VM timing measured) increases the total area under the curve by 1.

--- a/ocaml/perftest/tests.ml
+++ b/ocaml/perftest/tests.ml
@@ -84,6 +84,7 @@ let parallel_with_vms async_op opname n vms rpc session_id test subtest_name =
   let vms_names_uuids =
     List.map (fun (vm, vmr) -> (vm, vmr.API.vM_name_label, vmr.API.vM_uuid)) vms
   in
+
   (* Manage a set of active tasks using the event system. This could be factored out into a more generic
      service if/when necessary *)
 

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -47,3 +47,7 @@
   )
   (action (run ./check-no-xenctrl %{x}))
 )
+
+(env
+  (_ (env-vars (XAPI_TEST 1)))
+)

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -20,7 +20,8 @@ let test_clusterd_rpc ~__context call =
   let test_token = "test_token" in
   match (call.Rpc.name, call.Rpc.params) with
   | "create", _ ->
-      Rpc.{success= true; contents= Rpc.String test_token; is_notification= false}
+      Rpc.
+        {success= true; contents= Rpc.String test_token; is_notification= false}
   | ("enable" | "disable" | "destroy" | "leave"), _ ->
       Rpc.{success= true; contents= Rpc.Null; is_notification= false}
   | "diagnostics", _ ->

--- a/ocaml/tests/test_cluster_host.ml
+++ b/ocaml/tests/test_cluster_host.ml
@@ -150,7 +150,8 @@ let test_clusterd_rpc ~__context call =
       let nall = List.length all in
       Printf.printf "dead_members: %d, all: %d\n" ndead nall ;
       if ndead = nall - 1 then
-        Rpc.{success= true; contents= Rpc.rpc_of_unit (); is_notification= false}
+        Rpc.
+          {success= true; contents= Rpc.rpc_of_unit (); is_notification= false}
       else
         let err =
           Cluster_interface.InternalError "Remaining hosts are not all alive"

--- a/ocaml/tests/test_valid_ref_list.ml
+++ b/ocaml/tests/test_valid_ref_list.ml
@@ -24,8 +24,7 @@ let test_exists =
       Alcotest.(check bool) "false" false (Valid_ref_list.exists f l))
 
 let test_valid_ref_filter =
-  with_vm_list (fun __context ->
-    function
+  with_vm_list (fun __context -> function
     | [vm1; vm2; vm3; vm4] as l ->
         let assert_equal l1 l2 =
           let as_strings = List.map Ref.string_of in
@@ -72,8 +71,7 @@ let test_flat_map =
       assert_equal ["a"; "d_a"; "d"; "d_d"] (Valid_ref_list.flat_map f l))
 
 let test_filter_map =
-  with_vm_list (fun __context ->
-    function
+  with_vm_list (fun __context -> function
     | [vm1; vm2; vm3; vm4] as l ->
         let f vm =
           let n = Db.VM.get_name_label ~__context ~self:vm in

--- a/ocaml/tests/test_xapi_db_upgrade.ml
+++ b/ocaml/tests/test_xapi_db_upgrade.ml
@@ -58,10 +58,9 @@ let upgrade_vm_memory_for_dmc () =
     (r.API.vM_memory_static_min <= r.API.vM_memory_static_max)
 
 let upgrade_bios () =
+  let tmp_filename = "/tmp/previousInventory" in
   let check inventory bios_strings =
-    Xapi_stdext_unix.Unixext.mkdir_safe "/var/tmp" 0o755 ;
-    Xapi_stdext_unix.Unixext.write_string_to_file "/var/tmp/.previousInventory"
-      inventory ;
+    Xapi_stdext_unix.Unixext.write_string_to_file tmp_filename inventory ;
     let __context = T.make_test_database () in
     X.upgrade_bios_strings.fn ~__context ;
     let _, vm_r = List.hd (Db.VM.get_all_records ~__context) in
@@ -71,7 +70,7 @@ let upgrade_bios () =
   check "OEM_MANUFACTURER=Dell" Constants.old_dell_bios_strings ;
   check "OEM_MANUFACTURER=HP" Constants.old_hp_bios_strings ;
   check "" Constants.generic_bios_strings ;
-  Xapi_stdext_unix.Unixext.unlink_safe "/var/tmp/.previousInventory"
+  Xapi_stdext_unix.Unixext.unlink_safe tmp_filename
 
 let update_snapshots () =
   let __context = T.make_test_database () in

--- a/ocaml/tests/test_xapi_xenops.ml
+++ b/ocaml/tests/test_xapi_xenops.ml
@@ -228,6 +228,7 @@ let test_xapi_restart () =
 
 let test_nested_virt_licensing () =
   let __context = make_test_database () in
+
   (* Nested_virt is restricted in the default test database *)
 
   (* List of plaform keys and whether they should be restricted when 'Nested_virt' is restricted.

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3581,6 +3581,7 @@ let vm_install_real printer rpc session_id template name description params =
         Cli_printer.PStderr (msg ^ "\n") |> printer
     ) ;
     Client.VM.provision rpc session_id new_vm ;
+
     (* Client.VM.start rpc session_id new_vm false true; *)
     (* stop install starting VMs *)
 

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -104,13 +104,14 @@ let __get_task_name : (__context:t -> API.ref_task -> string) ref =
 
 let __make_task =
   ref
-    (fun ~__context
-         ~(http_other_config : (string * string) list)
-         ?(description : string option)
-         ?(session_id : API.ref_session option)
-         ?(subtask_of : API.ref_task option)
-         (task_name : string)
-         -> (Ref.null, Uuid.null))
+    (fun
+      ~__context
+      ~(http_other_config : (string * string) list)
+      ?(description : string option)
+      ?(session_id : API.ref_session option)
+      ?(subtask_of : API.ref_task option)
+      (task_name : string)
+    -> (Ref.null, Uuid.null))
 
 let __destroy_task : (__context:t -> API.ref_task -> unit) ref =
   ref (fun ~__context:_ _ -> ())

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -659,6 +659,7 @@ let create_host_cpu ~__context host_info =
                 (XenAPI.Message.create rpc session_id name priority `Host
                    obj_uuid body))
       ) ;
+
       (* Recreate all Host_cpu objects *)
 
       (* Not all /proc/cpuinfo files contain MHz information. *)

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -307,6 +307,7 @@ let update_env __context sync_keys =
         Db.Host.set_bios_strings ~__context ~self:localhost
           ~value:current_bios_strings
       )) ;
+
   (* CA-35549: In a pool rolling upgrade, the master will detect the end of upgrade when the software versions
      	 of all the hosts are the same. It will then assume that (for example) per-host patch records have
      	 been tidied up and attempt to delete orphaned pool-wide patch records. *)

--- a/ocaml/xapi/extauth_plugin_ADpbis.ml
+++ b/ocaml/xapi/extauth_plugin_ADpbis.ml
@@ -276,6 +276,7 @@ module AuthADlw : Auth_signature.AUTH_MODULE = struct
                 debug "Created process pid %s for cmd %s"
                   (Forkhelpers.string_of_pidty pid)
                   debug_cmd ;
+
                 (* Insert this delay to reproduce the cannot write to stdin bug:
                    Thread.delay 5.; *)
                 (* WARNING: we don't close the in_readme because otherwise in the case where the pbis

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -199,6 +199,7 @@ let assert_can_restore_backup ~__context rpc session_id (x : header) =
         None
     with _ -> None
   in
+
   (* This function should be called when a VM/snapshot to import has the same
      	   mac seed as an existing VM. They are considered compatible only in the
      	   following cases:

--- a/ocaml/xapi/pool_db_backup.ml
+++ b/ocaml/xapi/pool_db_backup.ml
@@ -100,6 +100,7 @@ let prepare_database_for_restore ~old_context ~new_context =
   in
   let dom0 = Db.Host.get_control_domain ~__context:new_context ~self:master in
   Db.VM.set_uuid ~__context:new_context ~self:dom0 ~value:my_control_uuid ;
+
   (* Rewrite this host's PIFs' MAC addresses based on device name. *)
 
   (* First inspect the current machine's configuration and build up a table of
@@ -133,6 +134,7 @@ let prepare_database_for_restore ~old_context ~new_context =
         None
     (* no management interface configured *)
   in
+
   (* The PIFs of the master host in the backup need their MAC addresses adjusting
         to match the current machine. For safety the new machine needs to have at least
         the same number and same device names as the backup being restored. (Note that

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -1234,6 +1234,7 @@ let on_xapi_start ~__context =
       let self, _ = List.assoc ty existing in
       try Db.SM.destroy ~__context ~self with _ -> ())
     (Listext.List.set_difference (List.map fst existing) to_keep) ;
+
   (* Synchronize SMAPIv1 plugins *)
 
   (* Create all missing SMAPIv1 plugins *)
@@ -1253,6 +1254,7 @@ let on_xapi_start ~__context =
       Xapi_sm.update_from_query_result ~__context (List.assoc ty existing)
         query_result)
     (Listext.List.intersect smapiv1_drivers (List.map fst existing)) ;
+
   (* Synchronize SMAPIv2 plugins *)
 
   (* Create all missing SMAPIv2 plugins *)

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -280,8 +280,16 @@ let upgrade_bios_strings =
   ; fn=
       (fun ~__context ->
         let oem_manufacturer =
+          let test_path =
+            Option.map
+              (fun _ -> "/tmp/previousInventory")
+              (Sys.getenv_opt "XAPI_TEST")
+          in
+          let inventory_path =
+            Option.value ~default:"/var/tmp/.previousInventory" test_path
+          in
           try
-            let ic = open_in "/var/tmp/.previousInventory" in
+            let ic = open_in inventory_path in
             let rec find_oem_manufacturer () =
               let line = input_line ic in
               match Xapi_inventory.parse_inventory_entry line with

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -479,6 +479,7 @@ module Monitor = struct
                   (Db.Pool.get_ha_host_failures_to_tolerate ~__context
                      ~self:pool)
               in
+
               (* let planned_for = Int64.to_int (Db.Pool.get_ha_plan_exists_for ~__context ~self:pool) in *)
 
               (* First consider whether VM failover actions need to happen.
@@ -511,6 +512,7 @@ module Monitor = struct
                      %s"
                     (ExnHelper.string_of_exn e)
               ) ;
+
               (* At this point the hosts not in the liveset have been declared dead *)
 
               (* Next update the Host_metrics.live value to spot hosts coming back *)
@@ -1110,6 +1112,7 @@ let emergency_ha_disable __context soft =
 
 let ha_release_resources __context localhost =
   Monitor.stop () ;
+
   (* Why aren't we calling Xha_statefile.detach_existing_statefiles?
      Does Db.Pool.get_ha_statefiles return a different set of
      statefiles than Xha_statefile.list_existing_statefiles? *)

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -1078,6 +1078,7 @@ let restart_auto_run_vms ~__context live_set n =
             List.rev_append (f inner) accum)
           [] lst
       in
+
       (* [map_parallel ~order_f f lst] groups objects in [lst] by order number
           (provided by applying [order_f] to each object). For each group of objects
           it then applies [f] to them to produce an 'a TaskChain.t and then executes this

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1532,6 +1532,7 @@ let enable_external_auth ~__context ~host ~config ~service_name ~auth_type =
           (* we persist as much set up configuration now as we can *)
           Db.Host.set_external_auth_service_name ~__context ~self:host
             ~value:service_name ;
+
           (* the ext_auth.on_enable dispatcher called below will store the configuration params, and also *)
           (* filter out any one-time credentials such as the administrator password, so we *)
           (* should not call here 'host.set_external_auth_configuration ~config' *)
@@ -1539,10 +1540,12 @@ let enable_external_auth ~__context ~host ~config ~service_name ~auth_type =
           (* use the special 'named dispatcher' function to call an extauth plugin function even though we have *)
           (* not yet set up the external_auth_type value that will enable generic access to the extauth plugin. *)
           (Ext_auth.nd auth_type).on_enable config ;
+
           (* from this point on, we have successfully enabled the external authentication services. *)
 
           (* Up to this point, we cannot call external auth functions via extauth's generic dispatcher d(). *)
           Db.Host.set_external_auth_type ~__context ~self:host ~value:auth_type ;
+
           (* From this point on, anyone can call external auth functions via extauth.ml's generic dispatcher d(), which depends on the value of external_auth_type. *)
           (* This enables all functions to the external authentication and directory service that xapi makes available to the user, *)
           (* such as external login, subject id/info queries, group membership etc *)
@@ -1675,6 +1678,7 @@ let disable_external_auth_common ?(during_pool_eject = false) ~__context ~host
           host_name_label ;
         (* 2.1 if we are still trying to initialize the external auth service in the xapi.on_xapi_initialize thread, we should stop now *)
         Xapi_globs.event_hook_auth_on_xapi_initialize_succeeded := true ;
+
         (* succeeds because there's no need to initialize anymore *)
 
         (* 3. CP-703: we always revalidate all sessions after the external authentication has been disabled *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -733,8 +733,9 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
             (* CA-51925: local_cache_sr can only be written by Host.enable_local_caching_sr but this API
                				 * call is forwarded to the host in question. Since, during a pool-join, the host is offline,
                				 * we need an alternative way of preserving the value of the local_cache_sr field, so it's
-               				 * been added to the constructor. *) ~local_cache_sr
-          ~chipset_info:host.API.host_chipset_info ~ssl_legacy:false
+               				 * been added to the constructor. *)
+          ~local_cache_sr ~chipset_info:host.API.host_chipset_info
+          ~ssl_legacy:false
       in
       (* Copy other-config into newly created host record: *)
       no_exn
@@ -1453,6 +1454,7 @@ let eject ~__context ~host =
     (* this call will return an exception if something goes wrong *)
     Xapi_host.disable_external_auth_common ~during_pool_eject:true ~__context
       ~host ~config:[] ;
+
     (* FIXME: in the future, we should send the windows AD admin/pass here *)
     (* in order to remove the slave from the AD database during pool-eject *)
 

--- a/ocaml/xapi/xapi_pool_transition.ml
+++ b/ocaml/xapi/xapi_pool_transition.ml
@@ -142,6 +142,7 @@ let attempt_two_phase_commit_of_new_master ~__context (manual : bool)
   debug "Phase 2.1: telling everyone but me to commit" ;
   List.iter tell_host_to_commit peer_addresses ;
   if !hosts_which_failed = [] then set_role Pool_role.Master ;
+
   (* picked up as master on next boot *)
 
   (* If in manual mode then there is an existing master: we must wait for our connection

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -206,6 +206,7 @@ let revalidate_external_session ~__context ~session =
         let session_lifespan = 60.0 *. 30.0 in
         (* allowed session lifespan = 30 minutes *)
         let random_lifespan = Random.float 60.0 *. 10.0 in
+
         (* extra random (up to 10min) lifespan to spread access to external directory *)
 
         (* 2. has the external session expired/does it need revalidation? *)
@@ -224,6 +225,7 @@ let revalidate_external_session ~__context ~session =
           let authenticated_user_sid =
             Db.Session.get_auth_user_sid ~__context ~self:session
           in
+
           (* 2a. revalidate external authentication *)
 
           (* CP-827: if the user was suspended (disabled,expired,locked-out), then we must destroy the session *)

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -1083,6 +1083,7 @@ let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
   Xapi_vdi_helpers.assert_managed ~__context ~vdi ;
   let task_id = Ref.string_of (Context.get_task_id __context) in
   let src = Db.VDI.get_record ~__context ~self:vdi in
+
   (* If 'into' is a valid VDI then we will write into that.
      	   Otherwise we'll create a fresh VDI in 'sr'. *)
 

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -765,17 +765,18 @@ module Vendor_intel = struct
         (Scanf.sscanf line
            "%04x experimental=%c name='%s@' low_gm_sz=%Ld high_gm_sz=%Ld \
             fence_sz=%Ld framebuffer_sz=%Ld max_heads=%Ld resolution=%Ldx%Ld"
-           (fun pdev_id
-                experimental
-                model_name
-                low_gm_sz
-                high_gm_sz
-                fence_sz
-                framebuffer_sz
-                num_heads
-                max_x
-                max_y
-                ->
+           (fun
+             pdev_id
+             experimental
+             model_name
+             low_gm_sz
+             high_gm_sz
+             fence_sz
+             framebuffer_sz
+             num_heads
+             max_x
+             max_y
+           ->
              {
                identifier= Identifier.{pdev_id; low_gm_sz; high_gm_sz; fence_sz}
              ; experimental= experimental <> '0'
@@ -857,12 +858,13 @@ module Vendor_amd = struct
         (Scanf.sscanf line
            "%04x experimental=%c name='%s@' framebuffer_sz=%Ld \
             vgpus_per_pgpu=%Ld"
-           (fun pdev_id (* e.g. "FirePro S7150" has 6929 (PF), 692f (VF) *)
-                experimental
-                model_name (* e.g. PF "FirePro S7150" or VF "FirePro S7150V" *)
-                framebuffer_sz
-                vgpus_per_pgpu
-                ->
+           (fun
+             pdev_id (* e.g. "FirePro S7150" has 6929 (PF), 692f (VF) *)
+             experimental
+             model_name (* e.g. PF "FirePro S7150" or VF "FirePro S7150V" *)
+             framebuffer_sz
+             vgpus_per_pgpu
+           ->
              {
                identifier=
                  Identifier.{pdev_id; framebufferbytes= mib framebuffer_sz}

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1008,6 +1008,7 @@ let migrate_send' ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map
   (* Copy mode means we don't destroy the VM on the source host. We also don't
      	   copy over the RRDs/messages *)
   let copy = try bool_of_string (List.assoc "copy" options) with _ -> false in
+
   (* The first thing to do is to create mirrors of all the disks on the remote.
      We look through the VM's VBDs and all of those of the snapshots. We then
      compile a list of all of the associated VDIs, whether we mirror them or not


### PR DESCRIPTION
Since `/var/tmp` is not writable when inside opam's sandbox, the code for upgrading the database is changed to read the inventory filepath from `/tmp` when running the tests. A environment variable is used, in a similar way to https://github.com/xapi-project/forkexecd/pull/44