### PR TITLE
REQ-403 CP-34468 add Host.reset_server_certificate

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
 profile=ocamlformat
-version=0.14.1
 indicate-multiline-delimiters=closing-on-separate-line
 if-then-else=fit-or-vertical
 dock-collection-brackets=true

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1011,9 +1011,18 @@ let host_query_ha = call ~flags:[`Session]
       ~allowed_roles:_R_POOL_ADMIN
       ()
 
+  let reset_server_certificate = call
+      ~flags:[`Session]
+      ~lifecycle:[Published, rel_next, ""]
+      ~name:"reset_server_certificate"
+      ~doc:"Delete the current TLS server certificate and replace by a new, self-signed one. This should only be used with extreme care."
+      ~params:[Ref _host, "host", "The host"]
+      ~allowed_roles:_R_POOL_ADMIN
+      ()
+
   let emergency_reset_server_certificate = call
       ~flags:[`Session]
-      ~lifecycle:[Published, rel_stockholm, ""]
+      ~lifecycle:[ Published, rel_stockholm, ""]
       ~name:"emergency_reset_server_certificate"
       ~doc:"Delete the current TLS server certificate and replace by a new, self-signed one. This should only be used with extreme care."
       ~versioned_params: []
@@ -1514,6 +1523,7 @@ let host_query_ha = call ~flags:[`Session]
         get_server_certificate;
         install_server_certificate;
         emergency_reset_server_certificate;
+        reset_server_certificate;
         update_pool_secret;
         update_master;
         attach_static_vdis;

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -695,6 +695,17 @@ let rec cmdtable_data : (string * cmd_spec) list =
             Cli_operations.host_emergency_reset_server_certificate
       ; flags= [Neverforward]
       } )
+  ; ( "host-reset-server-certificate"
+    , {
+        reqd= []
+      ; optn= []
+      ; flags= [Host_selectors]
+      ; help=
+          "Deletes the current TLS server certificate in the host and installs \
+           a new, self-signed one."
+      ; implementation=
+          No_fd_local_session Cli_operations.host_reset_server_certificate
+      } )
   ; ( "host-management-reconfigure"
     , {
         reqd= ["pif-uuid"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -6595,6 +6595,14 @@ let host_emergency_ha_disable printer rpc session_id params =
 let host_emergency_reset_server_certificate printer rpc session_id params =
   Client.Host.emergency_reset_server_certificate ~rpc ~session_id
 
+let host_reset_server_certificate printer rpc session_id params =
+  ignore
+    (do_host_op rpc session_id ~multiple:false
+       (fun _ host ->
+         let host = host.getref () in
+         Client.Host.reset_server_certificate ~rpc ~session_id ~host)
+       params [])
+
 let host_management_reconfigure printer rpc session_id params =
   let pif =
     Client.PIF.get_by_uuid rpc session_id (List.assoc "pif-uuid" params)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3230,6 +3230,11 @@ functor
                     failed."
                  ] ))
 
+      let reset_server_certificate ~__context ~host =
+        let local_fn = Local.Host.reset_server_certificate ~host in
+        do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
+            Client.Host.reset_server_certificate ~rpc ~session_id ~host)
+
       let emergency_reset_server_certificate ~__context =
         Local.Host.emergency_reset_server_certificate ~__context
 

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -313,6 +313,8 @@ val install_server_certificate :
 
 val emergency_reset_server_certificate : __context:Context.t -> unit
 
+val reset_server_certificate : __context:Context.t -> host:API.ref_host -> unit
+
 val detect_nonhomogeneous_external_auth_in_host :
   __context:Context.t -> host:API.ref_host -> unit
 


### PR DESCRIPTION
Deprecate Host.emergency_reset_server_certificate and add
Host.reset_server_certificate. The new method is synonym for the old one
but can be called by the pool admin.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>