### PR TITLE
CP-34462 add wireframe to implement Pool.assert_can_enable_tls_verification

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -497,6 +497,14 @@ open Datamodel_types
       ~allowed_roles:_R_POOL_OP
       ()
 
+  let assert_can_enable_tls_verification = call
+      ~flags:[`Session]
+      ~lifecycle:[Published, rel_next, ""]
+      ~name:"assert_can_enable_tls_verification"
+      ~doc:"Check that TLS verification can be enabled"
+      ~allowed_roles:_R_READ_ONLY
+      ()
+
   let enable_redo_log = call
       ~in_oss_since:None
       ~in_product_since:rel_midnight_ride
@@ -736,6 +744,7 @@ open Datamodel_types
         ; crl_uninstall
         ; crl_list
         ; certificate_sync
+        ; assert_can_enable_tls_verification
         ; enable_redo_log
         ; disable_redo_log
         ; audit_log_append

--- a/ocaml/idl/dm_api.ml
+++ b/ocaml/idl/dm_api.ml
@@ -167,7 +167,7 @@ let map (field : field -> field) (message : message -> message)
 let map_api_fields (f: field -> field) ((system, relations) : api) : api =
   (map_field f system, relations)
 *)
-let make api = (api : api)
+let make api : api = api
 
 let check api emergency_calls =
   let truefn _ = true in

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -20,7 +20,8 @@ let test_clusterd_rpc ~__context call =
   let test_token = "test_token" in
   match (call.Rpc.name, call.Rpc.params) with
   | "create", _ ->
-      Rpc.{success= true; contents= Rpc.String test_token; is_notification= false}
+      Rpc.
+        {success= true; contents= Rpc.String test_token; is_notification= false}
   | ("enable" | "disable" | "destroy" | "leave"), _ ->
       Rpc.{success= true; contents= Rpc.Null; is_notification= false}
   | "diagnostics", _ ->

--- a/ocaml/tests/test_cluster_host.ml
+++ b/ocaml/tests/test_cluster_host.ml
@@ -150,7 +150,8 @@ let test_clusterd_rpc ~__context call =
       let nall = List.length all in
       Printf.printf "dead_members: %d, all: %d\n" ndead nall ;
       if ndead = nall - 1 then
-        Rpc.{success= true; contents= Rpc.rpc_of_unit (); is_notification= false}
+        Rpc.
+          {success= true; contents= Rpc.rpc_of_unit (); is_notification= false}
       else
         let err =
           Cluster_interface.InternalError "Remaining hosts are not all alive"

--- a/ocaml/tests/test_valid_ref_list.ml
+++ b/ocaml/tests/test_valid_ref_list.ml
@@ -24,8 +24,7 @@ let test_exists =
       Alcotest.(check bool) "false" false (Valid_ref_list.exists f l))
 
 let test_valid_ref_filter =
-  with_vm_list (fun __context ->
-    function
+  with_vm_list (fun __context -> function
     | [vm1; vm2; vm3; vm4] as l ->
         let assert_equal l1 l2 =
           let as_strings = List.map Ref.string_of in
@@ -72,8 +71,7 @@ let test_flat_map =
       assert_equal ["a"; "d_a"; "d"; "d_d"] (Valid_ref_list.flat_map f l))
 
 let test_filter_map =
-  with_vm_list (fun __context ->
-    function
+  with_vm_list (fun __context -> function
     | [vm1; vm2; vm3; vm4] as l ->
         let f vm =
           let n = Db.VM.get_name_label ~__context ~self:vm in

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -415,6 +415,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; implementation= No_fd Cli_operations.pool_certificate_sync
       ; flags= []
       } )
+  ; ( "pool-assert-can-enable-tls-verification"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Check that TLS verification can be enabled"
+      ; implementation=
+          No_fd Cli_operations.pool_assert_can_enable_tls_verification
+      ; flags= []
+      } )
   ; ( "pool-set-vswitch-controller"
     , {
         reqd= ["address"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1619,6 +1619,9 @@ let pool_disable_ssl_legacy printer rpc session_id params =
 let pool_rotate_secret printer rpc session_id _params =
   Client.Pool.rotate_secret rpc session_id
 
+let pool_assert_can_enable_tls_verification printer rpc session_id _params =
+  Client.Pool.assert_can_enable_tls_verification rpc session_id
+
 let vdi_type_of_string = function
   | "system" ->
       `system

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -104,13 +104,14 @@ let __get_task_name : (__context:t -> API.ref_task -> string) ref =
 
 let __make_task =
   ref
-    (fun ~__context
-         ~(http_other_config : (string * string) list)
-         ?(description : string option)
-         ?(session_id : API.ref_session option)
-         ?(subtask_of : API.ref_task option)
-         (task_name : string)
-         -> (Ref.null, Uuid.null))
+    (fun
+      ~__context
+      ~(http_other_config : (string * string) list)
+      ?(description : string option)
+      ?(session_id : API.ref_session option)
+      ?(subtask_of : API.ref_task option)
+      (task_name : string)
+    -> (Ref.null, Uuid.null))
 
 let __destroy_task : (__context:t -> API.ref_task -> unit) ref =
   ref (fun ~__context:_ _ -> ())

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -917,6 +917,11 @@ functor
       let rotate_secret ~__context =
         info "Pool.rotate_secret: pool = '%s'" (current_pool_uuid ~__context) ;
         Local.Pool.rotate_secret ~__context
+
+      let assert_can_enable_tls_verification ~__context =
+        info "Pool.assert_can_enable_tls_verification: pool = '%s'"
+          (current_pool_uuid ~__context) ;
+        Local.Pool.assert_can_enable_tls_verification ~__context
     end
 
     module VM = struct

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -733,8 +733,9 @@ let rec create_or_get_host_on_master __context rpc session_id (host_ref, host) :
             (* CA-51925: local_cache_sr can only be written by Host.enable_local_caching_sr but this API
                				 * call is forwarded to the host in question. Since, during a pool-join, the host is offline,
                				 * we need an alternative way of preserving the value of the local_cache_sr field, so it's
-               				 * been added to the constructor. *) ~local_cache_sr
-          ~chipset_info:host.API.host_chipset_info ~ssl_legacy:false
+               				 * been added to the constructor. *)
+          ~local_cache_sr ~chipset_info:host.API.host_chipset_info
+          ~ssl_legacy:false
       in
       (* Copy other-config into newly created host record: *)
       no_exn

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2836,3 +2836,5 @@ let alert_failed_login_attempts () =
             ~obj_uuid:
               (Db.Pool.get_uuid ~__context ~self:(Helpers.get_pool ~__context))
             ~body:stats)
+
+let assert_can_enable_tls_verification ~__context = ()

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -329,3 +329,5 @@ val remove_from_guest_agent_config :
 val rotate_secret : __context:Context.t -> unit
 
 val alert_failed_login_attempts : unit -> unit
+
+val assert_can_enable_tls_verification : __context:Context.t -> unit

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -765,17 +765,18 @@ module Vendor_intel = struct
         (Scanf.sscanf line
            "%04x experimental=%c name='%s@' low_gm_sz=%Ld high_gm_sz=%Ld \
             fence_sz=%Ld framebuffer_sz=%Ld max_heads=%Ld resolution=%Ldx%Ld"
-           (fun pdev_id
-                experimental
-                model_name
-                low_gm_sz
-                high_gm_sz
-                fence_sz
-                framebuffer_sz
-                num_heads
-                max_x
-                max_y
-                ->
+           (fun
+             pdev_id
+             experimental
+             model_name
+             low_gm_sz
+             high_gm_sz
+             fence_sz
+             framebuffer_sz
+             num_heads
+             max_x
+             max_y
+           ->
              {
                identifier= Identifier.{pdev_id; low_gm_sz; high_gm_sz; fence_sz}
              ; experimental= experimental <> '0'
@@ -857,12 +858,13 @@ module Vendor_amd = struct
         (Scanf.sscanf line
            "%04x experimental=%c name='%s@' framebuffer_sz=%Ld \
             vgpus_per_pgpu=%Ld"
-           (fun pdev_id (* e.g. "FirePro S7150" has 6929 (PF), 692f (VF) *)
-                experimental
-                model_name (* e.g. PF "FirePro S7150" or VF "FirePro S7150V" *)
-                framebuffer_sz
-                vgpus_per_pgpu
-                ->
+           (fun
+             pdev_id (* e.g. "FirePro S7150" has 6929 (PF), 692f (VF) *)
+             experimental
+             model_name (* e.g. PF "FirePro S7150" or VF "FirePro S7150V" *)
+             framebuffer_sz
+             vgpus_per_pgpu
+           ->
              {
                identifier=
                  Identifier.{pdev_id; framebufferbytes= mib framebuffer_sz}


### PR DESCRIPTION

Add a wireframe to implement Pool.assert_can_enable_tls_verification as
an API call and make it available in the CLI.

This might require some re-formatting to avoid conflicts.