### PR TITLE
CA-347543 use /usr/bin/pool_secret_wrapper only if CC

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1847,7 +1847,7 @@ end = struct
     let use_script =
       try
         Unix.access !Xapi_globs.gen_pool_secret_script [Unix.X_OK] ;
-        true
+        Xapi_inventory.lookup ~default:"false" "CC_PREPARATIONS" |> bool_of_string
       with _ -> false
     in
     if use_script then


### PR DESCRIPTION
Previously we would use /usr/bin/pool_secret_wrapper to generate pool
secrets 'by default'. However this might take a very long time (hours)
if entropy low and little is being generated.

Change the default to use /dev/urandom instead to avoid this issue.