### PR TITLE
maintenance: Schedule weekly run for 1.249-lcm

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -1,0 +1,84 @@
+name: Build and test (1.249-lcm, scheduled)
+
+on:
+  schedule:
+    # run every Monday, this refreshes the cache
+    - cron: '13 2 * * 1'
+
+jobs:
+  python-test:
+    name: Python tests
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ["", "-3"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: '1.249-lcm'
+
+      - name: Run python tests
+        run: bash .github/python-nosetests${{ matrix.test }}.sh
+
+  ocaml-test:
+    name: Ocaml tests
+    runs-on: ubuntu-20.04
+    env:
+      package: "xapi-cli-protocol xapi-client xapi-consts xapi-database xapi-datamodel xapi-types xapi xe"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: '1.249-lcm'
+
+      - name: Pull configuration from xs-opam
+        run: |
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/release/stockholm/lcm/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+
+      - name: Load environment file
+        id: dotenv
+        uses: falti/dotenv-action@v0.2.4
+
+      - name: Retrieve date for cache key (year-week)
+        id: cache-key
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%W")"
+        shell: bash
+
+      - name: Restore opam cache
+        id: opam-cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.opam"
+          # invalidate cache every week, gets built using a scheduled job
+          key: ${{ steps.cache-key.outputs.date }}-1.249
+
+      - name: Use ocaml
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repository: ${{ steps.dotenv.outputs.repository }}
+
+      - name: Install dependencies
+        run: |
+          opam upgrade
+          opam pin add . --no-action
+          opam depext -u ${{ env.package }}
+          opam install ${{ env.package }} --deps-only --with-test -v
+
+      - name: Build
+        run: |
+          opam exec -- ./configure
+          opam exec -- make
+        env:
+          XAPI_VERSION: "v1.249.0-${{ github.sha }}"
+
+      - name: Run tests
+        run: opam exec -- make test
+
+      - name: Avoid built packages to appear in the cache
+        # only packages in this repository follow a branch, the rest point
+        # to a tag
+        run: opam uninstall ${{ env.package }}

--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -63,9 +63,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          opam upgrade
+          opam update
           opam pin add . --no-action
           opam depext -u ${{ env.package }}
+          opam upgrade
           opam install ${{ env.package }} --deps-only --with-test -v
 
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          opam update
           opam pin add . --no-action
           opam depext -u ${{ env.package }}
+          opam upgrade
           opam install ${{ env.package }} --deps-only --with-test -v
 
       - name: Build
@@ -73,3 +75,8 @@ jobs:
 
       - name: Run tests
         run: opam exec -- make test
+
+      - name: Uninstall unversioned packages
+        # This should purge them from the cache, unversioned package have
+        # 'master' as its version
+        run: opam list | awk -F " " '$2 == "master" { print $1 }' |  xargs opam uninstall


### PR DESCRIPTION
Since the dependencies barely change, I felt like a weekly run / cache
is more than enough for testing. It depends on the rest of the packages
being attached to a commit / tag in opam instead of following a branch.

This commit is indeed on master branch, this is due to a limitation in github actions, it's the same as the scheduled runs in xs-opam: https://github.com/xapi-project/xs-opam/blob/master/.github/workflows/stockholm-lcm.yml