### PR TITLE
CA-347543 use /usr/bin/pool_secret_wrapper only if CC

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1837,7 +1837,7 @@ end = struct
     let use_script =
       try
         Unix.access !Xapi_globs.gen_pool_secret_script [Unix.X_OK] ;
-        true
+        Xapi_inventory.lookup ~default:"false" "CC_PREPARATIONS" |> bool_of_string
       with _ -> false
     in
     if use_script then


### PR DESCRIPTION
Cherry picked from the Stockholm lcm branch: c360718c26ee5fe14b84023becd892d241260ec4

We want the default to be that we use /dev/urandom to generate pool secrets, rather than using /usr/bin/pool_secret_wrapper. You can change the default by setting CC_PREPARATIONS=true