### PR TITLE
Add Pool.enable_tls_verification to the API and include IP address in SANs of self-signed certs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Pull configuration from xs-opam
         run: |
-          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/feature/REQ-403/tools/xs-opam-ci.env | cut -f2 -d " " > .env
 
       - name: Load environment file
         id: dotenv

--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -66,18 +66,17 @@ let force_connection_reset () =
        		   combination, we pop out (remove) its links until Not_found is raised.
        		   Here, we have two such combinations, i.e. verify_cert=true/false, as
        		   host and port are fixed values. *)
-    let rec purge_stunnels verify_cert =
+    let rec purge_stunnels () =
       match
-        Stunnel_cache.with_remove host port verify_cert @@ fun st ->
+        Stunnel_cache.with_remove ~try_all:true host port @@ fun st ->
         try Stunnel.disconnect ~wait:false ~force:true st with _ -> ()
       with
       | None ->
           () (* not found in cache: stop *)
       | Some () ->
-          purge_stunnels verify_cert
+          purge_stunnels ()
     in
-    purge_stunnels true ;
-    purge_stunnels false ;
+    purge_stunnels () ;
     info
       "force_connection_reset: all cached connections to the master have been \
        purged"

--- a/ocaml/gencert/dune
+++ b/ocaml/gencert/dune
@@ -8,6 +8,7 @@
     astring
     cstruct
     forkexec
+    ipaddr
     mirage-crypto
     mirage-crypto-pk
     mirage-crypto-rng.unix

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -43,22 +43,35 @@ let expire_in days =
   | None ->
       R.error_msgf "can't represent %d as time span" days
 
-let add_dns_names extension = function
-  | [] ->
-      extension
-  | names ->
-      X509.Extension.(
-        add Subject_alt_name
-          (false, X509.General_name.(singleton DNS names))
-          extension)
+let sans alt_names ip =
+  let ip_cstruct =
+    Ipaddr.of_string ip
+    |> Stdlib.Result.to_option
+    |> Option.map (function
+         | Ipaddr.V4 addr ->
+             Cstruct.of_string (Ipaddr.V4.to_octets addr)
+         | Ipaddr.V6 addr ->
+             Cstruct.of_string (Ipaddr.V6.to_octets addr))
+  in
+  let sans =
+    X509.General_name.(
+      singleton DNS alt_names
+      |>
+      match ip_cstruct with
+      | None ->
+          D.error "selfcert.ml: failed to convert ip='%s' to cstruct" ip ;
+          Fun.id
+      | Some ip ->
+          add IP [ip])
+  in
+  X509.Extension.(add Subject_alt_name (false, sans) X509.Extension.empty)
 
-let sign days key pubkey issuer req alt_names =
+let sign days privkey pubkey issuer req alt_names ip =
   expire_in days >>= fun (valid_from, valid_until) ->
-  match (key, pubkey) with
+  match (privkey, pubkey) with
   | `RSA priv, `RSA pub when Rsa.pub_of_priv priv = pub ->
-      let extensions = add_dns_names X509.Extension.empty alt_names in
-      X509.Signing_request.sign ~valid_from ~valid_until ~extensions req key
-        issuer
+      X509.Signing_request.sign ~valid_from ~valid_until
+        ~extensions:(sans alt_names ip) req privkey issuer
       |> R.reword_error (fun _ -> Printf.sprintf "signing failed" |> R.msg)
   | _ ->
       R.error_msgf "public/private keys don't match (%s)" __LOC__
@@ -88,7 +101,7 @@ let generate_private_key length =
   let stdout, _stderr = call_openssl args in
   stdout
 
-let selfsign name alt_names length days certfile =
+let selfsign cn alt_names length days certfile ip =
   let rsa =
     try
       generate_private_key length
@@ -108,10 +121,10 @@ let selfsign name alt_names length days certfile =
   let privkey = `RSA rsa in
   let pubkey = `RSA (Rsa.pub_of_priv rsa) in
   let issuer =
-    [X509.Distinguished_name.(Relative_distinguished_name.singleton (CN name))]
+    [X509.Distinguished_name.(Relative_distinguished_name.singleton (CN cn))]
   in
   let req = X509.Signing_request.create issuer privkey in
-  sign days privkey pubkey issuer req alt_names >>= fun cert ->
+  sign days privkey pubkey issuer req alt_names ip >>= fun cert ->
   let key_pem = X509.Private_key.encode_pem privkey in
   let cert_pem = X509.Certificate.encode_pem cert in
   let pkcs12 =
@@ -119,10 +132,9 @@ let selfsign name alt_names length days certfile =
   in
   write_certs certfile pkcs12
 
-let host name alt_names pemfile =
+let host cn alt_names pemfile ip =
   let expire_days = 3650 in
   let length = 2048 in
   (* make sure name is part of alt_names because CN is deprecated and
      that there are no duplicates *)
-  let alt = Astring.String.uniquify (name :: alt_names) in
-  selfsign name alt length expire_days pemfile |> R.failwith_error_msg
+  selfsign cn alt_names length expire_days pemfile ip |> R.failwith_error_msg

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -2,6 +2,6 @@ val write_certs : string -> string -> (unit, [> Rresult.R.msg]) result
 (** [write_certs path pkcs12] writes [pkcs12] to [path] atomically.
 [pkcs12] should contain a components of a PKCS12 Certificate *)
 
-val host : string -> string list -> string -> unit
-(** [certify hostname alt_names path] creates (atomically) a PEM file at
-[path] for hostname with alternative names [alt_names]. *)
+val host : string -> string list -> string -> string -> unit
+(** [host cn alt_names path ip] creates (atomically) a PEM file at
+    [path] with [cn], and the following SANs: [alt_names] + [ip] *)

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -505,6 +505,14 @@ open Datamodel_types
       ~allowed_roles:_R_READ_ONLY
       ()
 
+  let enable_tls_verification = call
+    ~flags:[`Session]
+    ~lifecycle:[Published, rel_next, ""]
+    ~name:"enable_tls_verification"
+    ~doc:"Enable TLS server certificate verification"
+    ~allowed_roles:_R_POOL_ADMIN
+    ()
+
   let enable_redo_log = call
       ~in_oss_since:None
       ~in_product_since:rel_midnight_ride
@@ -745,6 +753,7 @@ open Datamodel_types
         ; crl_list
         ; certificate_sync
         ; assert_can_enable_tls_verification
+        ; enable_tls_verification
         ; enable_redo_log
         ; disable_redo_log
         ; audit_log_append
@@ -804,6 +813,7 @@ open Datamodel_types
          ; field ~in_product_since:rel_inverness ~qualifier:DynamicRO ~ty:Bool ~default_value:(Some (VBool false)) "igmp_snooping_enabled" "true if IGMP snooping is enabled in the pool, false otherwise."
          ; field ~in_product_since:rel_quebec ~qualifier:RW ~ty:String ~default_value:(Some (VString "")) "uefi_certificates" "The UEFI certificates allowing Secure Boot"
          ; field ~in_product_since:rel_stockholm_psr ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "is_psr_pending" "True if either a PSR is running or we are waiting for a PSR to be re-run"
-         ; field ~qualifier:DynamicRO ~lifecycle:[Published, rel_next, ""] ~ty:(Set (Ref _certificate)) "certificates" "CA certificates installed in the pool";
+         ; field ~qualifier:DynamicRO ~lifecycle:[Published, rel_next, ""] ~ty:(Set (Ref _certificate)) "certificates" "CA certificates installed in the pool"
+         ; field ~qualifier:DynamicRO ~in_product_since:rel_next ~lifecycle:[Published, rel_next, ""] ~ty:Bool ~default_value:(Some (VBool false)) "tls_verification_enabled" "True iff TLS certificate verification is enabled"
          ])
       ()

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -286,7 +286,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~vswitch_controller ~igmp_snooping_enabled ~current_operations
     ~allowed_operations ~restrictions ~other_config ~ha_cluster_stack
     ~guest_agent_config ~cpu_info ~policy_no_vendor_device
-    ~live_patching_disabled ~uefi_certificates ~is_psr_pending:false ;
+    ~live_patching_disabled ~uefi_certificates ~is_psr_pending:false
+    ~tls_verification_enabled:false ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -424,6 +424,14 @@ let rec cmdtable_data : (string * cmd_spec) list =
           No_fd Cli_operations.pool_assert_can_enable_tls_verification
       ; flags= []
       } )
+  ; ( "pool-enable-tls-verification"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Enable TLS certificate verification"
+      ; implementation= No_fd Cli_operations.pool_enable_tls_verification
+      ; flags= []
+      } )
   ; ( "pool-set-vswitch-controller"
     , {
         reqd= ["address"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1622,6 +1622,9 @@ let pool_rotate_secret printer rpc session_id _params =
 let pool_assert_can_enable_tls_verification printer rpc session_id _params =
   Client.Pool.assert_can_enable_tls_verification rpc session_id
 
+let pool_enable_tls_verification printer rpc session_id _params =
+  Client.Pool.enable_tls_verification rpc session_id
+
 let vdi_type_of_string = function
   | "system" ->
       `system

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -383,3 +383,9 @@ let pool_config_file = ref (Filename.concat "/etc/xensource" "pool.conf")
 let gencert = ref "/opt/xensource/libexec/gencert"
 
 let openssl_path = ref "/usr/bin/openssl"
+
+(* we store this locally so that when slaves initially establish connections
+   to the master, they know whether or not to verify certificates.
+   [ Db.Pool.tls_verification_enabled ] is not sufficient because it requires
+   that initial master connection *)
+let tls_verification_enabled = "tls_verification_enabled"

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -43,6 +43,7 @@ let create_pool_record ~__context =
       ~ha_cluster_stack:"xhad" ~guest_agent_config:[] ~cpu_info:[]
       ~policy_no_vendor_device:false ~live_patching_disabled:false
       ~uefi_certificates:"" ~is_psr_pending:false
+      ~tls_verification_enabled:false
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1837,7 +1837,8 @@ end = struct
     let use_script =
       try
         Unix.access !Xapi_globs.gen_pool_secret_script [Unix.X_OK] ;
-        Xapi_inventory.lookup ~default:"false" "CC_PREPARATIONS" |> bool_of_string
+        Xapi_inventory.lookup ~default:"false" "CC_PREPARATIONS"
+        |> bool_of_string
       with _ -> false
     in
     if use_script then

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -922,6 +922,18 @@ functor
         info "Pool.assert_can_enable_tls_verification: pool = '%s'"
           (current_pool_uuid ~__context) ;
         Local.Pool.assert_can_enable_tls_verification ~__context
+
+      let enable_tls_verification ~__context =
+        info "Pool.enable_tls_verification: pool = '%s'"
+          (current_pool_uuid ~__context) ;
+        let self = Helpers.get_pool ~__context in
+        let local_fn = Local.Pool.enable_tls_verification in
+        Local.Pool.assert_can_enable_tls_verification ~__context ;
+        Db.Pool.set_tls_verification_enabled ~__context ~self ~value:true ;
+        Xapi_pool_helpers.get_master_slaves_list ~__context
+        |> List.iter (fun host ->
+               do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
+                   Client.Pool.enable_tls_verification rpc session_id))
     end
 
     module VM = struct

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1406,15 +1406,26 @@ let install_server_certificate ~__context ~host ~certificate ~private_key
 let reset_server_certificate ~__context ~host =
   let self = Helpers.get_localhost ~__context in
   let xapi_ssl_pem = !Xapi_globs.server_cert_path in
-  let common_name, alt_names =
-    match Gencertlib.Lib.hostnames () with
-    | cn :: alt ->
-        (cn, alt)
-    | [] ->
-        (Helper_hostname.get_hostname (), [])
-    (* should never happen *)
+  let ip =
+    match Helpers.get_management_ip_addr ~__context with
+    | None ->
+        let msg =
+          "xapi_host.ml:reset_server_certificate: failed to get management IP"
+        in
+        D.error "%s" msg ;
+        raise Api_errors.(Server_error (internal_error, [msg]))
+    | Some ip ->
+        ip
   in
-  Gencertlib.Selfcert.host common_name alt_names xapi_ssl_pem ;
+  let alt_names =
+    match Gencertlib.Lib.hostnames () with
+    | [] ->
+        (* should never happen *) [Helper_hostname.get_hostname ()]
+    | xs ->
+        xs
+  in
+  let cn = ip in
+  Gencertlib.Selfcert.host cn alt_names xapi_ssl_pem ip ;
   (* Reset stunnel to try to restablish TLS connections *)
   Xapi_mgmt_iface.reconfigure_stunnel ~__context ;
   (* Delete records of the server certificate in this host *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2839,3 +2839,6 @@ let alert_failed_login_attempts () =
             ~body:stats)
 
 let assert_can_enable_tls_verification ~__context = ()
+
+let enable_tls_verification ~__context =
+  Localdb.put Constants.tls_verification_enabled "true"

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -331,3 +331,5 @@ val rotate_secret : __context:Context.t -> unit
 val alert_failed_login_attempts : unit -> unit
 
 val assert_can_enable_tls_verification : __context:Context.t -> unit
+
+val enable_tls_verification : __context:Context.t -> unit


### PR DESCRIPTION
Here we implement a naive version of `Pool.enable_tls_verification` by setting the global flag in the stunnel library.

We also change the way that xapi generates self-signed slightly, by making the IP address the CN, and adding the IP as a SAN.

Sibling: https://github.com/xapi-project/xen-api-libs-transitional/pull/85