### PR TITLE
REQ-403 CP-34472 include IP address in login fail alerts

### DIFF
--- a/ocaml/tests/test_session.ml
+++ b/ocaml/tests/test_session.ml
@@ -19,17 +19,18 @@ let success_login ~__context ~uname ~originator ~now () =
   Xapi_session._record_login_failure ~__context ~now ~uname ~originator
     ~record:`log_and_alert Fun.id
 
-let make_ctx ~user_agent =
+let make_ctx ~user_agent ~client_ip =
   let open Context in
-  match user_agent with
-  | None ->
-      make "test_ctx"
-  | Some _ ->
-      let rq = {Http.Request.empty with user_agent} in
-      (* it doesn't matter which fd is used to here, we are just satisying the
-         type system. we use stderr because then we don't need to worry about
-         closing it *)
-      make ~origin:(Http (rq, Unix.stderr)) "text_ctx"
+  let additional_headers =
+    client_ip
+    |> Option.fold ~none:[] ~some:(fun x ->
+           [("STUNNEL_PROXY", Printf.sprintf "TCP6 %s another_ip 443 80" x)])
+  in
+  let rq = {Http.Request.empty with user_agent; additional_headers} in
+  (* it doesn't matter which fd is used to here, we are just satisying the
+     type system. we use stderr because then we don't need to worry about
+     closing it *)
+  make ~origin:(Http (rq, Unix.stderr)) "text_ctx"
 
 let repeat n f =
   for _ = 1 to n do
@@ -37,7 +38,7 @@ let repeat n f =
   done
 
 let run_unknown_client_logins () =
-  let __context = make_ctx ~user_agent:None in
+  let __context = make_ctx ~user_agent:None ~client_ip:None in
   repeat 50
     (success_login ~__context ~uname:(Some "good_user")
        ~originator:(Some "nice_origin") ~now) ;
@@ -47,8 +48,13 @@ let run_unknown_client_logins () =
        ~originator:(Some "nice_origin") ~now)
 
 let run_known_client_logins () =
-  let __context = make_ctx ~user_agent:(Some "UA") in
-  let __context_no_UA = make_ctx ~user_agent:None in
+  let __context =
+    make_ctx ~user_agent:(Some "UA") ~client_ip:(Some "4.3.2.1")
+  in
+  let __context_no_UA = make_ctx ~user_agent:None ~client_ip:(Some "5.4.3.2") in
+  let __context_no_client_ip =
+    make_ctx ~user_agent:(Some "UA") ~client_ip:None
+  in
   repeat 50
     (success_login ~__context ~uname:(Some "good_user")
        ~originator:(Some "nice_origin") ~now) ;
@@ -60,7 +66,8 @@ let run_known_client_logins () =
        ~originator:(Some "origin2") ~now) ;
   repeat 4 (fail_login ~__context ~uname:None ~originator:None ~now) ;
   repeat 6
-    (fail_login ~__context ~uname:(Some "usr4") ~originator:None ~now:future) ;
+    (fail_login ~__context:__context_no_client_ip ~uname:(Some "usr4")
+       ~originator:None ~now:future) ;
   let () =
     (* this client fails now and then in the future (to test timestamp) *)
     repeat 9
@@ -101,6 +108,7 @@ let test_failed_logins_from_known_clients_only () =
 <known>
 <username>usr5</username>
 <originator>origin5</originator>
+<ip>5.4.3.2</ip>
 <number>10</number>
 <date>20200922T15:03:13Z</date>
 </known>
@@ -112,6 +120,7 @@ let test_failed_logins_from_known_clients_only () =
 </known>
 <known>
 <useragent>UA</useragent>
+<ip>4.3.2.1</ip>
 <number>4</number>
 <date>20200922T14:57:11Z</date>
 </known>
@@ -130,6 +139,7 @@ let test_failed_logins_from_both_known_and_unknown_clients () =
 <known>
 <username>usr5</username>
 <originator>origin5</originator>
+<ip>5.4.3.2</ip>
 <number>10</number>
 <date>20200922T15:03:13Z</date>
 </known>
@@ -141,6 +151,7 @@ let test_failed_logins_from_both_known_and_unknown_clients () =
 </known>
 <known>
 <useragent>UA</useragent>
+<ip>4.3.2.1</ip>
 <number>4</number>
 <date>20200922T14:57:11Z</date>
 </known>

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -340,5 +340,8 @@ let get_client context =
   |> Option.map (fun (http, ip) ->
          Printf.sprintf "%s %s" (string_of_http_t http) (Ipaddr.to_string ip))
 
+let get_client_ip context =
+  context.client |> Option.map (fun (_, ip) -> Ipaddr.to_string ip)
+
 let get_user_agent context =
   match context.origin with Internal -> None | Http (rq, _) -> rq.user_agent

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -134,4 +134,6 @@ val get_test_clusterd_rpc : t -> (Rpc.call -> Rpc.response) option
 
 val get_client : t -> string option
 
+val get_client_ip : t -> string option
+
 val get_user_agent : t -> string option

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -45,24 +45,27 @@ end = struct
       user_agent: string option
     ; uname: string option
     ; originator: string option
+    ; ip: string option
   }
 
   let client_of_info ~__context ~originator ~uname =
     let user_agent = Context.get_user_agent __context in
+    let ip = Context.get_client_ip __context in
     (* check to make sure we have at least _some_ information *)
     if
-      [user_agent; originator; uname]
+      [user_agent; originator; uname; ip]
       |> List.for_all (function None | Some "" -> true | _ -> false)
     then
       None
     else
-      Some {originator; uname; user_agent}
+      Some {originator; uname; user_agent; ip}
 
   let string_of_client x =
     [
       ("username", x.uname)
     ; ("originator", x.originator)
     ; ("useragent", x.user_agent)
+    ; ("ip", x.ip)
     ]
     |> List.filter_map (fun (label, value) ->
            match value with


### PR DESCRIPTION
Now that we have access to client IP addresses in xapi, we can now
improve the auth failure alerts to give a finer grained view of who
failed to login.