### PR TITLE
Backport CP-35021 VM.suspend - assert support for NVidia cards

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -284,6 +284,8 @@ let _ =
     ~doc:"Cannot create a virtual GPU that is incompatible with the existing types on the VM." ();
   error Api_errors.vgpu_destination_incompatible ["reason"; "vgpu"; "host"]
     ~doc:"The VGPU is not compatible with any PGPU in the destination." ();
+  error Api_errors.vgpu_suspension_not_supported ["reason"; "vgpu"; "host"]
+    ~doc:"The VGPU configuration does not support suspension." ();
   error Api_errors.vgpu_guest_driver_limit ["reason"; "vm"; "host"]
     ~doc:"The guest driver does not support VGPU migration." ();
   error Api_errors.nvidia_tools_error ["host"]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -607,6 +607,8 @@ let vgpu_type_not_compatible = "VGPU_TYPE_NOT_COMPATIBLE"
 
 let vgpu_destination_incompatible = "VGPU_DESTINATION_INCOMPATIBLE"
 
+let vgpu_suspension_not_supported = "VGPU_SUSPENSION_NOT_SUPPORTED"
+
 let vgpu_guest_driver_limit = "VGPU_GUEST_DRIVER_LIMIT"
 
 let nvidia_tools_error = "NVIDIA_TOOLS_ERROR"

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -570,8 +570,15 @@ let suspend ~__context ~vm =
   |> List.iter (fun (vgpu, pgpu) ->
          debug "VM.suspend checking vgpu/pgpu support for suspend: %s/%s"
            (Ref.string_of vgpu) (Ref.string_of pgpu) ;
-         Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm
-           ~__context ~vm ~host ~vgpu ~pgpu ()) ;
+         try
+           Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm
+             ~__context ~vm ~host ~vgpu ~pgpu ()
+         with
+         | Api_errors.Server_error (e, params)
+         when e = Api_errors.vgpu_destination_incompatible
+         ->
+           raise
+             Api_errors.(Server_error (vgpu_suspension_not_supported, params))) ;
 
   Xapi_gpumon.update_vgpu_metadata ~__context ~vm ;
   Xapi_xenops.suspend ~__context ~self:vm ;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -560,6 +560,19 @@ let suspend ~__context ~vm =
   Db.VM.set_ha_always_run ~__context ~self:vm ~value:false ;
   debug "Setting ha_always_run on vm=%s as false during VM.suspend"
     (Ref.string_of vm) ;
+
+  (* CP-35021 test support for NVidia suspend by checking that we could
+     migrate to the local host *)
+  let host = Helpers.get_localhost ~__context in
+  Db.VM.get_VGPUs ~__context ~self:vm
+  |> List.filter (fun vgpu -> Db.is_valid_ref __context vgpu)
+  |> List.map (fun self -> (self, Db.VGPU.get_resident_on ~__context ~self))
+  |> List.iter (fun (vgpu, pgpu) ->
+         debug "VM.suspend checking vgpu/pgpu support for suspend: %s/%s"
+           (Ref.string_of vgpu) (Ref.string_of pgpu) ;
+         Xapi_pgpu_helpers.assert_destination_pgpu_is_compatible_with_vm
+           ~__context ~vm ~host ~vgpu ~pgpu ()) ;
+
   Xapi_gpumon.update_vgpu_metadata ~__context ~vm ;
   Xapi_xenops.suspend ~__context ~self:vm ;
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in


### PR DESCRIPTION
Backport of 

* 41204933c 
* 1f09eb799

This adds a check on VM.suspend to prevent suspending of a VM with an NVidia vGPU when the drivers or configuration of the VM don't support it.