### PR TITLE
ci: unpin packages on cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,9 @@ jobs:
       - name: Run tests
         run: opam exec -- make test
 
-      - name: Uninstall unversioned packages
+      - name: Uninstall unversioned packages and remove pins
         # This should purge them from the cache, unversioned package have
         # 'master' as its version
-        run: opam list | awk -F " " '$2 == "master" { print $1 }' |  xargs opam uninstall
+        run: |
+          opam list | awk -F " " '$2 == "master" { print $1 }' |  xargs opam uninstall
+          opam pin list | cut -f1 -d "." | xargs opam unpin


### PR DESCRIPTION
This solves non-fatal error messages happening on the "Installing
dependencies step" when trying to synchronize pins which clutter the logs.

Example: https://github.com/xapi-project/xen-api/runs/1386255257?check_suite_focus=true#step:8:16