### PR TITLE
xe-enable-ipv6 edits net.ipv6.conf.{ all | default }.disable_ipv6

### DIFF
--- a/scripts/xe-enable-ipv6
+++ b/scripts/xe-enable-ipv6
@@ -23,7 +23,7 @@ fi
 . /etc/xensource-inventory
 
 if [ $1 = "enable" ]; then
-	rm /etc/modprobe.d/disable-ipv6
+	rm /etc/modprobe.d/disable-ipv6.conf
 
 	# Enable IPv6 networking
 	sed -i '/^NETWORKING_IPV6=/d' /etc/sysconfig/network
@@ -46,8 +46,8 @@ elif [ $1 = "disable" ]; then
 	fi
 
 	chkconfig ip6tables off
- 	echo "alias ipv6 no" > /etc/modprobe.d/disable-ipv6
-	echo "alias net-pf-10 off" >> /etc/modprobe.d/disable-ipv6
+ 	echo "alias ipv6 no" > /etc/modprobe.d/disable-ipv6.conf
+	echo "alias net-pf-10 off" >> /etc/modprobe.d/disable-ipv6.conf
 	sed -i '/^NETWORKING_IPV6=/d' /etc/sysconfig/network
 	sed -i '/^IPV6_AUTOCONF=/d' /etc/sysconfig/network
 	echo "NETWORKING_IPV6=NO" >> /etc/sysconfig/network

--- a/scripts/xe-enable-ipv6
+++ b/scripts/xe-enable-ipv6
@@ -32,10 +32,8 @@ if [ $1 = "enable" ]; then
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
 	chkconfig ip6tables on
 
-	sed -i '/^net.ipv6.conf.all.disable_ipv6=/d' /etc/sysctl.d/91-net-ipv6.conf
-	sed -i '/^net.ipv6.conf.default.disable_ipv6=/d' /etc/sysctl.d/91-net-ipv6.conf
-	echo "net.ipv6.conf.all.disable_ipv6=0" >> /etc/sysctl.d/91-net-ipv6.conf
-	echo "net.ipv6.conf.default.disable_ipv6=0" >> /etc/sysctl.d/91-net-ipv6.conf
+	echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/91-net-ipv6.conf
+	echo "net.ipv6.conf.default.disable_ipv6=0" > /etc/sysctl.d/91-net-ipv6.conf
 
 	echo "IPv6 enabled.  You may now need to reboot the host"
 elif [ $1 = "disable" ]; then
@@ -55,10 +53,8 @@ elif [ $1 = "disable" ]; then
 	echo "NETWORKING_IPV6=NO" >> /etc/sysconfig/network
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
 
-	sed -i '/^net.ipv6.conf.all.disable_ipv6=/d' /etc/sysctl.d/91-net-ipv6.conf
-	sed -i '/^net.ipv6.conf.default.disable_ipv6=/d' /etc/sysctl.d/91-net-ipv6.conf
-	echo "net.ipv6.conf.all.disable_ipv6=1" >> /etc/sysctl.d/91-net-ipv6.conf
-	echo "net.ipv6.conf.default.disable_ipv6=1" >> /etc/sysctl.d/91-net-ipv6.conf
+	echo "net.ipv6.conf.all.disable_ipv6=1" > /etc/sysctl.d/91-net-ipv6.conf
+	echo "net.ipv6.conf.default.disable_ipv6=1" > /etc/sysctl.d/91-net-ipv6.conf
 
 	echo "IPv6 disabled.  You may now need to reboot the host"
 else

--- a/scripts/xe-enable-ipv6
+++ b/scripts/xe-enable-ipv6
@@ -33,7 +33,7 @@ if [ $1 = "enable" ]; then
 	chkconfig ip6tables on
 
 	echo "net.ipv6.conf.all.disable_ipv6=0" > /etc/sysctl.d/91-net-ipv6.conf
-	echo "net.ipv6.conf.default.disable_ipv6=0" > /etc/sysctl.d/91-net-ipv6.conf
+	echo "net.ipv6.conf.default.disable_ipv6=0" >> /etc/sysctl.d/91-net-ipv6.conf
 
 	echo "IPv6 enabled.  You may now need to reboot the host"
 elif [ $1 = "disable" ]; then
@@ -54,7 +54,7 @@ elif [ $1 = "disable" ]; then
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
 
 	echo "net.ipv6.conf.all.disable_ipv6=1" > /etc/sysctl.d/91-net-ipv6.conf
-	echo "net.ipv6.conf.default.disable_ipv6=1" > /etc/sysctl.d/91-net-ipv6.conf
+	echo "net.ipv6.conf.default.disable_ipv6=1" >> /etc/sysctl.d/91-net-ipv6.conf
 
 	echo "IPv6 disabled.  You may now need to reboot the host"
 else

--- a/scripts/xe-enable-ipv6
+++ b/scripts/xe-enable-ipv6
@@ -32,8 +32,8 @@ if [ $1 = "enable" ]; then
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
 	chkconfig ip6tables on
 
-	sysctl -q -w "net.ipv6.conf.all.disable_ipv6=0"
-	sysctl -q -w "net.ipv6.conf.default.disable_ipv6=0"
+	echo "net.ipv6.conf.all.disable_ipv6=0" >> /etc/sysctl.d/91-net-ipv6.conf
+	echo "net.ipv6.conf.default.disable_ipv6=0" >> /etc/sysctl.d/91-net-ipv6.conf
 
 	echo "IPv6 enabled.  You may now need to reboot the host"
 elif [ $1 = "disable" ]; then
@@ -53,8 +53,8 @@ elif [ $1 = "disable" ]; then
 	echo "NETWORKING_IPV6=NO" >> /etc/sysconfig/network
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
 
-	sysctl -q -w "net.ipv6.conf.all.disable_ipv6=1"
-	sysctl -q -w "net.ipv6.conf.default.disable_ipv6=1"
+	echo "net.ipv6.conf.all.disable_ipv6=1" >> /etc/sysctl.d/91-net-ipv6.conf
+	echo "net.ipv6.conf.default.disable_ipv6=1" >> /etc/sysctl.d/91-net-ipv6.conf
 
 	echo "IPv6 disabled.  You may now need to reboot the host"
 else

--- a/scripts/xe-enable-ipv6
+++ b/scripts/xe-enable-ipv6
@@ -32,6 +32,8 @@ if [ $1 = "enable" ]; then
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
 	chkconfig ip6tables on
 
+	sed -i '/^net.ipv6.conf.all.disable_ipv6=/d' /etc/sysctl.d/91-net-ipv6.conf
+	sed -i '/^net.ipv6.conf.default.disable_ipv6=/d' /etc/sysctl.d/91-net-ipv6.conf
 	echo "net.ipv6.conf.all.disable_ipv6=0" >> /etc/sysctl.d/91-net-ipv6.conf
 	echo "net.ipv6.conf.default.disable_ipv6=0" >> /etc/sysctl.d/91-net-ipv6.conf
 
@@ -53,6 +55,8 @@ elif [ $1 = "disable" ]; then
 	echo "NETWORKING_IPV6=NO" >> /etc/sysconfig/network
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
 
+	sed -i '/^net.ipv6.conf.all.disable_ipv6=/d' /etc/sysctl.d/91-net-ipv6.conf
+	sed -i '/^net.ipv6.conf.default.disable_ipv6=/d' /etc/sysctl.d/91-net-ipv6.conf
 	echo "net.ipv6.conf.all.disable_ipv6=1" >> /etc/sysctl.d/91-net-ipv6.conf
 	echo "net.ipv6.conf.default.disable_ipv6=1" >> /etc/sysctl.d/91-net-ipv6.conf
 

--- a/scripts/xe-enable-ipv6
+++ b/scripts/xe-enable-ipv6
@@ -23,20 +23,23 @@ fi
 . /etc/xensource-inventory
 
 if [ $1 = "enable" ]; then
-	rm /etc/modprobe.d/disable-ipv6 
-	
+	rm /etc/modprobe.d/disable-ipv6
+
 	# Enable IPv6 networking
 	sed -i '/^NETWORKING_IPV6=/d' /etc/sysconfig/network
 	sed -i '/^IPV6_AUTOCONF=/d' /etc/sysconfig/network
 	echo "NETWORKING_IPV6=YES" >> /etc/sysconfig/network
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
 	chkconfig ip6tables on
-	
+
+	sysctl -q -w "net.ipv6.conf.all.disable_ipv6=0"
+	sysctl -q -w "net.ipv6.conf.default.disable_ipv6=0"
+
 	echo "IPv6 enabled.  You may now need to reboot the host"
 elif [ $1 = "disable" ]; then
 	all_ifaces=`xe pif-list minimal=true`
 	no_ipv6_ifaces=`xe pif-list IPv6-configuration-mode=None minimal=true`
-	
+
 	if [ ${#all_ifaces} -ne ${#no_ipv6_ifaces} ]; then
 		echo "Please re-configure all pool interfaces to disable IPv6 before disabling it on the host."
 		exit 1
@@ -49,7 +52,10 @@ elif [ $1 = "disable" ]; then
 	sed -i '/^IPV6_AUTOCONF=/d' /etc/sysconfig/network
 	echo "NETWORKING_IPV6=NO" >> /etc/sysconfig/network
 	echo "IPV6_AUTOCONF=NO" >> /etc/sysconfig/network
-		
+
+	sysctl -q -w "net.ipv6.conf.all.disable_ipv6=1"
+	sysctl -q -w "net.ipv6.conf.default.disable_ipv6=1"
+
 	echo "IPv6 disabled.  You may now need to reboot the host"
 else
 	syntax

--- a/scripts/xe-enable-ipv6
+++ b/scripts/xe-enable-ipv6
@@ -23,8 +23,6 @@ fi
 . /etc/xensource-inventory
 
 if [ $1 = "enable" ]; then
-	rm /etc/modprobe.d/disable-ipv6.conf
-
 	# Enable IPv6 networking
 	sed -i '/^NETWORKING_IPV6=/d' /etc/sysconfig/network
 	sed -i '/^IPV6_AUTOCONF=/d' /etc/sysconfig/network
@@ -46,8 +44,6 @@ elif [ $1 = "disable" ]; then
 	fi
 
 	chkconfig ip6tables off
- 	echo "alias ipv6 no" > /etc/modprobe.d/disable-ipv6.conf
-	echo "alias net-pf-10 off" >> /etc/modprobe.d/disable-ipv6.conf
 	sed -i '/^NETWORKING_IPV6=/d' /etc/sysconfig/network
 	sed -i '/^IPV6_AUTOCONF=/d' /etc/sysconfig/network
 	echo "NETWORKING_IPV6=NO" >> /etc/sysconfig/network


### PR DESCRIPTION
Would solve: https://github.com/xapi-project/xen-api/issues/4256

This question remains: https://github.com/xapi-project/xen-api/issues/4256#issuecomment-727892082