### PR TITLE
CP-34463: pool.conf should use FQDN

### DIFF
--- a/ocaml/gencert/gencert.ml
+++ b/ocaml/gencert/gencert.ml
@@ -41,9 +41,9 @@ let main ~dbg ~path =
         x
   in
   let sans =
-    match Lib.hostnames () with
+    match Lib.dns_sans () with
     | [] ->
-        D.error "could not find any hostnames" ;
+        D.error "could not find any SANs" ;
         exit 1
     | xs ->
         xs

--- a/ocaml/gencert/lib.mli
+++ b/ocaml/gencert/lib.mli
@@ -14,8 +14,10 @@
 
 val get_management_ip_addr : dbg:string -> string option
 
-val hostnames : unit -> string list
-(** Try to get all FQDNs, use the hostname if none are available *)
+val fqdn_of_hostname : string -> string option
+
+val dns_sans : unit -> string list
+(** List of all subject alternative names for this host *)
 
 val install_server_certificate :
      ?pem_chain:string option

--- a/ocaml/xapi-aux/pool_role.ml
+++ b/ocaml/xapi-aux/pool_role.ml
@@ -23,11 +23,7 @@ module D = Debug.Make (struct let name = "pool_role" end)
 open D
 
 (** The role of this node *)
-type t =
-  | Master
-  | Slave of string
-  (* IP address *)
-  | Broken
+type t = Master | Slave of string | Broken
 
 let role = ref None
 
@@ -101,8 +97,8 @@ exception This_host_is_broken
 
 let get_master_address () =
   match get_role () with
-  | Slave ip ->
-      ip
+  | Slave addr ->
+      addr
   | Master ->
       raise This_host_is_a_master
   | Broken ->

--- a/ocaml/xapi-aux/pool_role.mli
+++ b/ocaml/xapi-aux/pool_role.mli
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type t = Master | Slave of string  (** IP address *) | Broken
+type t = Master | Slave of string  (** IP address or FQDN *) | Broken
 
 val with_pool_role_lock : (unit -> unit) -> unit
 
@@ -41,4 +41,5 @@ exception This_host_is_a_master
 exception This_host_is_broken
 
 val get_master_address : unit -> string
-(** If this node is a slave, returns the IP address of its master *)
+
+(** If this node is a slave, returns the address of its master. *)

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1021,15 +1021,16 @@ let is_valid_MAC mac =
          acc && String.length s = 2 && validchar s.[0] && validchar s.[1])
        true l
 
-(** Returns true if the supplied IP address looks like one of mine *)
+(** Returns true if the supplied address looks like one of mine *)
 let this_is_my_address ~__context address =
   let dbg = Context.string_of_task __context in
-  let inet_addrs =
+  let ipv4s =
     Net.Interface.get_ipv4_addr dbg
       (Xapi_inventory.lookup Xapi_inventory._management_interface)
   in
-  let addresses = List.map Unix.string_of_inet_addr (List.map fst inet_addrs) in
-  List.mem address addresses
+  let addresses = List.map Unix.string_of_inet_addr (List.map fst ipv4s) in
+  let hostnames = Gencertlib.Lib.dns_sans () in
+  List.mem address (List.append addresses hostnames)
 
 (** Returns the list of hosts thought to be live *)
 let get_live_hosts ~__context =

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1041,44 +1041,6 @@ let get_live_hosts ~__context =
       try Db.Host_metrics.get_live ~__context ~self:metrics with _ -> false)
     hosts
 
-let gethostbyname_family host family =
-  let throw_resolve_error () =
-    failwith (Printf.sprintf "Couldn't resolve hostname: %s" host)
-  in
-  let getaddr x =
-    match x with
-    | Unix.ADDR_INET (addr, port) ->
-        addr
-    | _ ->
-        failwith "Expected ADDR_INET"
-  in
-  let he =
-    Unix.getaddrinfo host ""
-      [Unix.AI_SOCKTYPE Unix.SOCK_STREAM; Unix.AI_FAMILY family]
-  in
-  if List.length he = 0 then
-    throw_resolve_error () ;
-  Unix.string_of_inet_addr (getaddr (List.hd he).Unix.ai_addr)
-
-(** Return the first address we find for a hostname *)
-let gethostbyname host =
-  let throw_resolve_error () =
-    failwith (Printf.sprintf "Couldn't resolve hostname: %s" host)
-  in
-  let pref =
-    Record_util.primary_address_type_of_string
-      (Xapi_inventory.lookup Xapi_inventory._management_address_type)
-  in
-  try
-    gethostbyname_family host
-      (if pref = `IPv4 then Unix.PF_INET else Unix.PF_INET6)
-  with _ -> (
-    try
-      gethostbyname_family host
-        (if pref = `IPv4 then Unix.PF_INET6 else Unix.PF_INET)
-    with _ -> throw_resolve_error ()
-  )
-
 (** Indicate whether VM.clone should be allowed on suspended VMs *)
 let clone_suspended_vm_enabled ~__context =
   try

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1418,7 +1418,7 @@ let reset_server_certificate ~__context ~host =
         ip
   in
   let alt_names =
-    match Gencertlib.Lib.hostnames () with
+    match Gencertlib.Lib.dns_sans () with
     | [] ->
         (* should never happen *) [Helper_hostname.get_hostname ()]
     | xs ->

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1340,7 +1340,6 @@ let emergency_transition_to_master ~__context =
 let emergency_reset_master ~__context ~master_address =
   if Localdb.get Constants.ha_armed = "true" then
     raise (Api_errors.Server_error (Api_errors.ha_is_enabled, [])) ;
-  let master_address = Helpers.gethostbyname master_address in
   Xapi_pool_transition.become_another_masters_slave master_address
 
 let recover_slaves ~__context =

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1345,12 +1345,15 @@ let emergency_reset_master ~__context ~master_address =
 
 let recover_slaves ~__context =
   let hosts = Db.Host.get_all ~__context in
+  let self = !Xapi_globs.localhost_ref in
   let my_address =
-    Db.Host.get_address ~__context ~self:!Xapi_globs.localhost_ref
+    Db.Host.get_hostname ~__context ~self
+    |> Gencertlib.Lib.fqdn_of_hostname
+    |> Option.value ~default:(Db.Host.get_address ~__context ~self)
   in
   let recovered_hosts = ref [] in
   let recover_slave hostref =
-    if not (hostref = !Xapi_globs.localhost_ref) then
+    if not (hostref = self) then
       try
         let local_fn = emergency_reset_master ~master_address:my_address in
         (* We have to use a new context here because the slave is currently doing a


### PR DESCRIPTION
Slaves store an address to the master in pool.conf. Historically this
has been an IP address, however for REQ-403 we need to use an fqdn
instead.