### PR TITLE
CP-34942: update dmidecode parser for angstrom 0.14

### DIFF
--- a/ocaml/tests/test_bios_strings.ml
+++ b/ocaml/tests/test_bios_strings.ml
@@ -108,8 +108,10 @@ let check_values = Alcotest.(check @@ list @@ pair string string)
 
 let check_records = Alcotest.(check @@ result (list alco_record) string)
 
+let parse_string = Angstrom.parse_string ~consume:Prefix P.records
+
 let values_from_string str =
-  match Angstrom.parse_string P.records str with
+  match parse_string str with
   | Ok (r :: _) ->
       r.values
   | Ok [] ->
@@ -118,15 +120,14 @@ let values_from_string str =
       []
 
 let test_parser () =
-  check_records "Empty string produces an empty list" (Ok [])
-    (Angstrom.parse_string P.records "") ;
+  check_records "Empty string produces an empty list" (Ok []) (parse_string "") ;
   check_records "Invalid records must be discarded and stop the parser" (Ok [])
-    (Angstrom.parse_string P.records invalid_string) ;
+    (parse_string invalid_string) ;
   check_records "Two records with same name is valid input"
     (Ok baseboard_two_record)
-    (Angstrom.parse_string P.records baseboard_two_string) ;
+    (parse_string baseboard_two_string) ;
   check_records "Arrays must be parsed as multi-line values" (Ok with_array)
-    (Angstrom.parse_string P.records with_array_string)
+    (parse_string with_array_string)
 
 let test_baseboard () =
   check_values "Baseboard values must have empty values when input is empty"

--- a/ocaml/xapi/bios_strings.ml
+++ b/ocaml/xapi/bios_strings.ml
@@ -135,7 +135,7 @@ let get_strings name keys key_values =
 
 let get_dmidecode_strings e_type name =
   let output = get_output_of_type e_type in
-  match Angstrom.parse_string P.records output with
+  match Angstrom.parse_string ~consume:Prefix P.records output with
   | Ok (r :: _) ->
       r.values
   | Ok [] ->


### PR DESCRIPTION
The code relied on previous behavior to only parse a prefix and not the
whole text. This means in practice that if a failure is found the parser
emits the list of successfully parsed records instead of failing.

Should be merged along https://github.com/xapi-project/xs-opam/pull/524