### PR TITLE
REQ-403 emergency disable tls verification

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5626,6 +5626,7 @@ let emergency_calls =
     (Datamodel_host.t,Datamodel_host.is_in_emergency_mode);
     (Datamodel_host.t,Datamodel_host.shutdown_agent);
     (Datamodel_host.t,Datamodel_host.emergency_reset_server_certificate);
+    (Datamodel_host.t,Datamodel_host.emergency_disable_tls_verification);
   ]
 
 (** Whitelist of calls that will not get forwarded from the slave to master via the unix domain socket *)

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1434,6 +1434,17 @@ let host_query_ha = call ~flags:[`Session]
     ~result:(host_sched_gran, "The host's sched-gran")
     ()
 
+  let emergency_disable_tls_verification = call
+      ~flags:[`Session]
+      ~name:"emergency_disable_tls_verification"
+      ~lifecycle:[Published, rel_next, ""]
+      ~in_oss_since:None
+      ~in_product_since:rel_next
+      ~params:[]
+      ~doc:"Disable TLS verification for this host only"
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ()
+
   (** Hosts *)
   let t =
     create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_host ~descr:"A physical host" ~gen_events:true
@@ -1560,6 +1571,7 @@ let host_query_ha = call ~flags:[`Session]
         cleanup_pool_secret;
         set_sched_gran;
         get_sched_gran;
+        emergency_disable_tls_verification;
       ]
       ~contents:
         ([ uid _host;

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -712,6 +712,16 @@ let rec cmdtable_data : (string * cmd_spec) list =
             Cli_operations.host_emergency_reset_server_certificate
       ; flags= [Neverforward]
       } )
+  ; ( "host-emergency-disable-tls-verification"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Disable TLS verification for this host only"
+      ; implementation=
+          No_fd_local_session
+            Cli_operations.host_emergency_disable_tls_verification
+      ; flags= [Neverforward]
+      } )
   ; ( "host-reset-server-certificate"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -6602,6 +6602,9 @@ let host_emergency_ha_disable printer rpc session_id params =
 let host_emergency_reset_server_certificate printer rpc session_id params =
   Client.Host.emergency_reset_server_certificate ~rpc ~session_id
 
+let host_emergency_disable_tls_verification printer rpc session_id _params =
+  Client.Host.emergency_disable_tls_verification ~rpc ~session_id
+
 let host_reset_server_certificate printer rpc session_id params =
   ignore
     (do_host_op rpc session_id ~multiple:false

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -308,3 +308,5 @@ let host_server_certificate_expired =
   addMessage "HOST_SERVER_CERTIFICATE_EXPIRED" 1L
 
 let failed_login_attempts = addMessage "FAILED_LOGIN_ATTEMPTS" 3L
+
+let local_health_check = addMessage "LOCAL_HEALTH_CHECK" 3L

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -923,6 +923,9 @@ functor
           (current_pool_uuid ~__context) ;
         Local.Pool.assert_can_enable_tls_verification ~__context
 
+      (* this ought to be
+         (a) idempotent
+         (b) capable of re-enabling verification on hosts who have had verification emergency disabled *)
       let enable_tls_verification ~__context =
         info "Pool.enable_tls_verification: pool = '%s'"
           (current_pool_uuid ~__context) ;
@@ -3476,6 +3479,10 @@ functor
         let local_fn = Local.Host.get_sched_gran ~self in
         do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
             Client.Host.get_sched_gran rpc session_id self)
+
+      let emergency_disable_tls_verification ~__context =
+        info "Host.emergency_disable_tls_verification" ;
+        Local.Host.emergency_disable_tls_verification ~__context
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2461,3 +2461,38 @@ let emergency_disable_tls_verification ~__context =
   Localdb.put Constants.tls_verification_enabled "false" ;
   (* disable verification now *)
   Stunnel.set_verify_tls_certs false
+
+let health_check ~__context =
+  let tls_verification_enabled_locally =
+    Localdb.get_with_default Constants.tls_verification_enabled "false"
+    |> bool_of_string
+  in
+  let tls_verification_enabled_pool_wide =
+    Db.Pool.get_tls_verification_enabled ~__context
+      ~self:(Helpers.get_pool ~__context)
+  in
+  (* Only add an alert if (a) we found a problem and (b) an alert doesn't already exist *)
+  if
+    tls_verification_enabled_pool_wide
+    && tls_verification_enabled_pool_wide <> tls_verification_enabled_locally
+  then
+    let alert_exists =
+      Helpers.call_api_functions ~__context (fun rpc session ->
+          Client.Client.Message.get_all_records rpc session
+          |> List.exists (fun (_, record) ->
+                 record.API.message_name = fst Api_messages.local_health_check))
+    in
+
+    if not alert_exists then
+      let self = Helpers.get_localhost ~__context in
+      let host = Db.Host.get_name_label ~__context ~self in
+      let msg =
+        "TLS verification is enabled on the pool but overriden on a host"
+      in
+      let body =
+        Printf.sprintf "<body><message>%s</message><host>%s</host></body>" msg
+          host
+      in
+      Xapi_alert.add ~msg:Api_messages.local_health_check ~cls:`Host
+        ~obj_uuid:(Db.Host.get_uuid ~__context ~self)
+        ~body

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2452,3 +2452,12 @@ let get_sched_gran ~__context ~self =
     error "Failed to get sched-gran: %s" (Printexc.to_string e) ;
     raise
       Api_errors.(Server_error (internal_error, ["Failed to get sched-gran"]))
+
+let emergency_disable_tls_verification ~__context =
+  (* NB: this introduces a discrepancy between state.db and local.db, but
+     this should be fixable by executing Pool.enable_tls_verification again *)
+
+  (* disable verification for next xapi restart *)
+  Localdb.put Constants.tls_verification_enabled "false" ;
+  (* disable verification now *)
+  Stunnel.set_verify_tls_certs false

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -514,3 +514,5 @@ val set_sched_gran :
 
 val get_sched_gran :
   __context:Context.t -> self:API.ref_host -> API.host_sched_gran
+
+val emergency_disable_tls_verification : __context:'a -> unit

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -516,3 +516,5 @@ val get_sched_gran :
   __context:Context.t -> self:API.ref_host -> API.host_sched_gran
 
 val emergency_disable_tls_verification : __context:'a -> unit
+
+val health_check : __context:Context.t -> unit

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -96,4 +96,8 @@ let register () =
   if master then
     Xapi_periodic_scheduler.add_to_queue "Periodic alert failed login attempts"
       (Xapi_periodic_scheduler.Periodic 3600.0) 3600.0
-      Xapi_pool.alert_failed_login_attempts
+      Xapi_pool.alert_failed_login_attempts ;
+  Xapi_periodic_scheduler.add_to_queue "Local health check"
+    (Xapi_periodic_scheduler.Periodic 600.) 600. (fun () ->
+      Server_helpers.exec_with_new_task "Local health check" (fun __context ->
+          Xapi_host.health_check ~__context))


### PR DESCRIPTION
An escape hatch is needed in case communication breaks down in a pool.
Importantly verification will only be disabled for the host on which you
make this emergency call. This introduces a discrepancy between the pool
database and the local database, which can be fixed by executing
Pool.enable_tls_verification once again.