### PR TITLE
CP-35280: Install self-signed certificates as trust anchors, add more information to database about certificates

### DIFF
--- a/ocaml/gencert/gencert.ml
+++ b/ocaml/gencert/gencert.ml
@@ -21,7 +21,7 @@ module Lib = Gencertlib.Lib
 module D = Debug.Make (struct let name = "gencert" end)
 
 let generate_cert_or_fail ~path ~cn ~sans ~ip =
-  Gencertlib.Selfcert.host cn sans path ip ;
+  let _ = Gencertlib.Selfcert.generate cn sans path ip in
   if Sys.file_exists path then
     D.info "file exists (%s), assuming cert was created" path
   else (

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -130,7 +130,7 @@ let selfsign cn alt_names length days certfile ip =
     String.concat "\n\n" [Cstruct.to_string key_pem; Cstruct.to_string cert_pem]
   in
   write_certs certfile pkcs12 >>= fun () ->
-  Ok (cert, X509.Certificate.fingerprint `SHA256 cert)
+  Ok (cert, [X509.Certificate.fingerprint `SHA256 cert])
 
 let generate cn alt_names pemfile ip =
   let expire_days = 3650 in

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module C = Cmdliner
 module Rsa = Mirage_crypto_pk.Rsa
 module UX = Xapi_stdext_unix.Unixext
 open Rresult (* introduces >>= >>| and R *)
@@ -130,9 +129,10 @@ let selfsign cn alt_names length days certfile ip =
   let pkcs12 =
     String.concat "\n\n" [Cstruct.to_string key_pem; Cstruct.to_string cert_pem]
   in
-  write_certs certfile pkcs12
+  write_certs certfile pkcs12 >>= fun () ->
+  Ok (cert, X509.Certificate.fingerprint `SHA256 cert)
 
-let host cn alt_names pemfile ip =
+let generate cn alt_names pemfile ip =
   let expire_days = 3650 in
   let length = 2048 in
   (* make sure name is part of alt_names because CN is deprecated and

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -2,6 +2,8 @@ val write_certs : string -> string -> (unit, [> Rresult.R.msg]) result
 (** [write_certs path pkcs12] writes [pkcs12] to [path] atomically.
 [pkcs12] should contain a components of a PKCS12 Certificate *)
 
-val host : string -> string list -> string -> string -> unit
-(** [host cn alt_names path ip] creates (atomically) a PEM file at
-    [path] with [cn], and the following SANs: [alt_names] + [ip] *)
+val generate :
+  string -> string list -> string -> string -> X509.Certificate.t * Cstruct.t list
+(** [generate hostname alt_names path] creates (atomically) a PEM file at
+    [path] for hostname with alternative names [alt_names]. Returns the
+    certificate and the SHA256 fingerprint of its public key. *)

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -3,7 +3,11 @@ val write_certs : string -> string -> (unit, [> Rresult.R.msg]) result
 [pkcs12] should contain a components of a PKCS12 Certificate *)
 
 val generate :
-  string -> string list -> string -> string -> X509.Certificate.t * Cstruct.t list
+     string
+  -> string list
+  -> string
+  -> string
+  -> X509.Certificate.t * Cstruct.t list
 (** [generate hostname alt_names path] creates (atomically) a PEM file at
     [path] for hostname with alternative names [alt_names]. Returns the
-    certificate and the SHA256 fingerprint of its public key. *)
+    certificate and the SHA256 fingerprint of its public key in a list. *)

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -304,6 +304,6 @@ let install_server_certificate ?(pem_chain = None) ~pem_leaf ~pkcs8_private_key
   in
   match installation with
   | Ok (leaf_cert, thumbprints) ->
-      leaf_cert
+      (leaf_cert, thumbprints)
   | Error (`Msg (err, msg)) ->
       raise_server_error msg err

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1377,7 +1377,7 @@ let install_server_certificate ~__context ~host ~certificate ~private_key
   let pem_chain =
     match certificate_chain with "" -> None | pem_chain -> Some pem_chain
   in
-  let certificate =
+  let certificate, root_fingerprints =
     Certificates.install_server_certificate ~pem_leaf:certificate
       ~pkcs8_private_key:private_key ~pem_chain
   in
@@ -1425,7 +1425,9 @@ let reset_server_certificate ~__context ~host =
         xs
   in
   let cn = ip in
-  Gencertlib.Selfcert.host cn alt_names xapi_ssl_pem ip ;
+  let _certificate, _root_fingerprint =
+    Gencertlib.Selfcert.generate cn alt_names xapi_ssl_pem ip
+  in
   (* Reset stunnel to try to restablish TLS connections *)
   Xapi_mgmt_iface.reconfigure_stunnel ~__context ;
   (* Delete records of the server certificate in this host *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1366,6 +1366,55 @@ let certificate_sync ~__context ~host = Certificates.local_sync ()
 let get_server_certificate ~__context ~host =
   Certificates.get_server_certificate ()
 
+let add_certificate_to_db ~__context ~host certificate root_fingerprints =
+  let date_of_ptime time = Date.of_float (Ptime.to_float_s time) in
+  let dates_of_ptimes (a, b) = (date_of_ptime a, date_of_ptime b) in
+  let not_before, not_after =
+    dates_of_ptimes (X509.Certificate.validity certificate)
+  in
+  let raw_fingerprint =
+    X509.Certificate.fingerprint Mirage_crypto.Hash.(`SHA256) certificate
+  in
+  let fingerprint = Certificates.pp_hash raw_fingerprint in
+  let uuid = Uuid.(to_string (make_uuid ())) in
+  let ref = Ref.make () in
+  let _type =
+    if List.mem raw_fingerprint root_fingerprints then `host_and_pool else `host
+  in
+  Db.Certificate.create ~__context ~ref ~uuid ~_type ~host ~pool:Ref.null
+    ~not_before ~not_after ~fingerprint ;
+  (* Link host to trust anchors *)
+  let root_certs =
+    root_fingerprints
+    |> List.map (fun root_fingerprint ->
+           let expr =
+             Db_filter_types.(
+               Eq
+                 ( Field "fingerprint"
+                 , Literal (Certificates.pp_hash root_fingerprint) ))
+           in
+           Db.Certificate.get_refs_where ~__context ~expr)
+    |> List.flatten
+    |> List.sort_uniq Stdlib.compare
+  in
+  Db.Certificate.set_validated_by ~__context ~self:ref ~value:root_certs ;
+  ref
+
+let uninstall_host_certificates ~__context certs =
+  (* uninstall self-signed cert from CA certs and remove host certificates
+     from the database *)
+  List.iter
+    (fun (self, record) ->
+      ( match record.API.certificate_type with
+      | `host_and_pool ->
+          let name = record.API.certificate_uuid in
+          Certificates.(pool_uninstall CA_Certificate) ~__context ~name
+      | _ ->
+          ()
+      ) ;
+      Db.Certificate.destroy ~__context ~self)
+    certs
+
 let install_server_certificate ~__context ~host ~certificate ~private_key
     ~certificate_chain =
   if Db.Pool.get_ha_enabled ~__context ~self:(Helpers.get_pool ~__context) then
@@ -1373,7 +1422,9 @@ let install_server_certificate ~__context ~host ~certificate ~private_key
   let expr =
     Db_filter_types.(Eq (Field "host", Literal (Ref.string_of host)))
   in
-  let current_server_certs = Db.Certificate.get_refs_where ~__context ~expr in
+  let current_server_certs =
+    Db.Certificate.get_records_where ~__context ~expr
+  in
   let pem_chain =
     match certificate_chain with "" -> None | pem_chain -> Some pem_chain
   in
@@ -1381,30 +1432,25 @@ let install_server_certificate ~__context ~host ~certificate ~private_key
     Certificates.install_server_certificate ~pem_leaf:certificate
       ~pkcs8_private_key:private_key ~pem_chain
   in
-  let date_of_ptime time = Date.of_float (Ptime.to_float_s time) in
-  let dates_of_ptimes (a, b) = (date_of_ptime a, date_of_ptime b) in
-  let not_before, not_after =
-    dates_of_ptimes (X509.Certificate.validity certificate)
+  let _cert_ref =
+    add_certificate_to_db ~__context ~host certificate root_fingerprints
   in
-  let fingerprint =
-    X509.Certificate.fingerprint Mirage_crypto.Hash.(`SHA256) certificate
-    |> Certificates.pp_hash
-  in
-  let uuid = Uuid.(to_string (make_uuid ())) in
-  let ref = Ref.make () in
-  List.iter
-    (fun self -> Db.Certificate.destroy ~__context ~self)
-    current_server_certs ;
-  Db.Certificate.create ~__context ~ref ~uuid ~_type:`host ~host ~pool:Ref.null
-    ~not_before ~not_after ~fingerprint ;
+
   let task = Context.get_task_id __context in
   (* mark task as done *)
   Db.Task.set_progress ~__context ~self:task ~value:1.0 ;
   (* sever all connections done with stunnel *)
-  Xapi_mgmt_iface.reconfigure_stunnel ~__context
+  Xapi_mgmt_iface.reconfigure_stunnel ~__context ;
+  uninstall_host_certificates ~__context current_server_certs
 
 let reset_server_certificate ~__context ~host =
   let self = Helpers.get_localhost ~__context in
+  let expr =
+    Db_filter_types.(Eq (Field "host", Literal (Ref.string_of self)))
+  in
+  let current_server_certs =
+    Db.Certificate.get_records_where ~__context ~expr
+  in
   let xapi_ssl_pem = !Xapi_globs.server_cert_path in
   let ip =
     match Helpers.get_management_ip_addr ~__context with
@@ -1425,17 +1471,30 @@ let reset_server_certificate ~__context ~host =
         xs
   in
   let cn = ip in
-  let _certificate, _root_fingerprint =
+  let certificate, root_fingerprint =
     Gencertlib.Selfcert.generate cn alt_names xapi_ssl_pem ip
   in
+
+  let cert = X509.Certificate.encode_pem certificate |> Cstruct.to_string in
+
+  (* install self-signed certificate to the pool's trusted CA certs.
+     Uses a uuid as name to avoid duplicate names. This creates a
+     certificate records to the database as a pool certificate.
+     Since we just generated the private key randomly we know the fingerptint
+     in the database will be unique and we can replace it. *)
+  let name = Uuid.(to_string (make_uuid ())) in
+
+  Helpers.call_api_functions ~__context (fun rpc session_id ->
+      Client.Client.Pool.install_ca_certificate rpc session_id name cert) ;
+
+  let self = Db.Certificate.get_by_uuid ~__context ~uuid:name in
+  Db.Certificate.set_type ~__context ~self ~value:`host_and_pool ;
+  Db.Certificate.set_host ~__context ~self ~value:host ;
+  Db.Certificate.set_validated_by ~__context ~self ~value:[self] ;
+
   (* Reset stunnel to try to restablish TLS connections *)
   Xapi_mgmt_iface.reconfigure_stunnel ~__context ;
-  (* Delete records of the server certificate in this host *)
-  let expr =
-    Db_filter_types.(Eq (Field "host", Literal (Ref.string_of self)))
-  in
-  Db.Certificate.get_refs_where ~__context ~expr
-  |> List.iter (fun self -> Db.Certificate.destroy ~__context ~self)
+  uninstall_host_certificates ~__context current_server_certs
 
 let emergency_reset_server_certificate ~__context =
   let host = Helpers.get_localhost ~__context in


### PR DESCRIPTION
Now the trust anchors that verify a server certificate in a pool are store in the server certificate's database record. This means that CA certificates must be also recorded in the database when installed.

CA certificates are not removed from the database when uninstalled yet. This is for another issue that tackles CA certificates exclusively.

For self-signed certificates, these are generated, installed normally as pool ca certificates with their UUID as names and then the database record is marked as host_and_pool and the host is added to the record, as well as the field verified_by.