### PR TITLE
maintenance: detect schema updates which are missing version bumps

### DIFF
--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -50,3 +50,9 @@
    xapi-datamodel
   )
 )
+
+(test
+  (name schematest)
+  (modules schematest)
+  (libraries xapi_datamodel)
+)

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,0 +1,27 @@
+let hash x = Digest.string x |> Digest.to_hex
+
+(* BEWARE: if this changes, check that schema has been bumped accordingly *)
+let last_known_schema_hash = "5a6605a08c21f658bebcbfee9e93dc62"
+
+let current_schema_hash : string =
+  let open Datamodel_types in
+  let hash_of_obj x =
+    List.map rpc_of_content x.contents
+    |> List.map Jsonrpc.to_string
+    |> String.concat ""
+    |> hash
+  in
+  Datamodel.all_system |> List.map hash_of_obj |> String.concat ":" |> hash
+
+let () =
+  if last_known_schema_hash <> current_schema_hash then (
+    Printf.eprintf
+      {|
+
+New schema hash ('%s') doesn't match the last known one. Please bump the
+datamodel schema versions if necessary, and update 'last_known_schema_hash'.
+
+|}
+      current_schema_hash ;
+    exit 1
+  )


### PR DESCRIPTION
Implementation of @edwintorok 's suggestion to use hashing to detect datamodel changes: https://github.com/xapi-project/xen-api/pull/4274#pullrequestreview-543739076