### PR TITLE
CP-35584: remove unused parameter for per-connection tls verification

### DIFF
--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -85,17 +85,17 @@ let refresh_console_urls ~__context =
             | "" ->
                 ""
             | address ->
-              let address =
-                match Xapi_stdext_unix.Unixext.domain_of_addr address with
-                | Some x when x = Unix.PF_INET ->
-                  address
-                | Some x when x = Unix.PF_INET6 ->
-                  "[" ^ address ^ "]"
-                | _ ->
-                  ""
-              in
-              Printf.sprintf "https://%s%s?ref=%s" address
-                Constants.console_uri (Ref.string_of console)
+                let address =
+                  match Xapi_stdext_unix.Unixext.domain_of_addr address with
+                  | Some x when x = Unix.PF_INET ->
+                      address
+                  | Some x when x = Unix.PF_INET6 ->
+                      "[" ^ address ^ "]"
+                  | _ ->
+                      ""
+                in
+                Printf.sprintf "https://%s%s?ref=%s" address
+                  Constants.console_uri (Ref.string_of console)
           in
           Db.Console.set_location ~__context ~self:console ~value:url_should_be)
         ())

--- a/ocaml/xapi/remote_requests.ml
+++ b/ocaml/xapi/remote_requests.ml
@@ -46,7 +46,6 @@ type response = Success | Exception of exn | NoResponse
 
 type queued_request = {
     task: API.ref_task
-  ; verify_cert: bool
   ; host: string
   ; port: int
   ; request: Http.Request.t
@@ -57,20 +56,9 @@ type queued_request = {
   ; enable_log: bool
 }
 
-let make_queued_request task verify_cert host port request handler resp
-    resp_mutex resp_cond enable_log =
-  {
-    task
-  ; verify_cert
-  ; host
-  ; port
-  ; request
-  ; handler
-  ; resp
-  ; resp_mutex
-  ; resp_cond
-  ; enable_log
-  }
+let make_queued_request task host port request handler resp resp_mutex resp_cond
+    enable_log =
+  {task; host; port; request; handler; resp; resp_mutex; resp_cond; enable_log}
 
 let shutting_down = ref false
 
@@ -107,11 +95,7 @@ let handle_request req =
   try
     let open Xmlrpc_client in
     let transport =
-      SSL
-        ( SSL.make ~verify_cert:req.verify_cert
-            ~task_id:(Ref.string_of req.task) ()
-        , req.host
-        , req.port )
+      SSL (SSL.make ~task_id:(Ref.string_of req.task) (), req.host, req.port)
     in
     with_transport transport
       (with_http req.request (fun (response, s) ->
@@ -150,8 +134,8 @@ let queue_request req =
       request_queue := req :: !request_queue ;
       Condition.signal request_cond)
 
-let perform_request ~__context ~timeout ~verify_cert ~host ~port ~request
-    ~handler ~enable_log =
+let perform_request ~__context ~timeout ~host ~port ~request ~handler
+    ~enable_log =
   let task = Context.get_task_id __context in
   let resp = ref NoResponse in
   let resp_mutex = Mutex.create () in
@@ -159,8 +143,8 @@ let perform_request ~__context ~timeout ~verify_cert ~host ~port ~request
   Mutex.execute resp_mutex (fun () ->
       let delay = Delay.make () in
       let req =
-        make_queued_request task verify_cert host port request handler resp
-          resp_mutex resp_cond enable_log
+        make_queued_request task host port request handler resp resp_mutex
+          resp_cond enable_log
       in
       start_watcher __context timeout delay req ;
       queue_request req ;
@@ -192,9 +176,8 @@ let send_test_post ~__context ~host ~port ~body =
       Xapi_http.http_request ~keep_alive:false ~body ~headers:[("Host", host)]
         Http.Post "/"
     in
-    perform_request ~__context ~timeout:30.0 ~verify_cert:true ~host
-      ~port:(Int64.to_int port) ~request ~handler:(read_response result)
-      ~enable_log:true ;
+    perform_request ~__context ~timeout:30.0 ~host ~port:(Int64.to_int port)
+      ~request ~handler:(read_response result) ~enable_log:true ;
     !result
   with
   | Timed_out ->

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -295,7 +295,6 @@ let wlb_request ~__context ~host ~port ~auth ~meth ~params ~handler ~enable_log
   let body = wlb_body meth params in
   let request = wlb_request host meth body auth in
   let pool = Helpers.get_pool ~__context in
-  let verify_cert = Db.Pool.get_wlb_verify_cert ~__context ~self:pool in
   let pool_other_config = Db.Pool.get_other_config ~__context ~self:pool in
   let timeout =
     try
@@ -311,8 +310,8 @@ let wlb_request ~__context ~host ~port ~auth ~meth ~params ~handler ~enable_log
          (filtered_headers (Http.Request.to_header_list request)))
       body ;
   try
-    Remote_requests.perform_request ~__context ~timeout ~verify_cert ~host ~port
-      ~request ~handler ~enable_log
+    Remote_requests.perform_request ~__context ~timeout ~host ~port ~request
+      ~handler ~enable_log
   with
   | Remote_requests.Timed_out ->
       raise_timeout timeout


### PR DESCRIPTION
This was used for establishing connections to WLB appliance. Now the
general tls verification setting is used instead.

The commit is mutually dependant with https://github.com/xapi-project/xs-opam/pull/527