### PR TITLE
REQ-403 deprecate Pool.wlb_verify_cert flag, but ensure it still works

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -796,6 +796,9 @@ open Datamodel_types
          ; field ~in_product_since:rel_george ~internal_only:true ~qualifier:DynamicRO ~ty:(Ref _secret) "wlb_password" "Password for accessing the workload balancing host"
          ; field ~in_product_since:rel_george ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "wlb_enabled" "true if workload balancing is enabled on the pool, false otherwise"
          ; field ~in_product_since:rel_george ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "wlb_verify_cert" "true if communication with the WLB server should enforce TLS certificate verification."
+             ~lifecycle:[
+               Published, rel_george, "";
+               Deprecated, rel_next, "Deprecated: to enable TLS verification use Pool.enable_tls_verification instead";]
          ; field ~in_oss_since:None ~in_product_since:rel_midnight_ride ~qualifier:DynamicRO ~ty:Bool ~default_value:(Some (VBool false)) "redo_log_enabled" "true a redo-log is to be used other than when HA is enabled, false otherwise"
          ; field ~in_oss_since:None ~in_product_since:rel_midnight_ride ~qualifier:DynamicRO ~ty:(Ref _vdi) ~default_value:(Some (VRef null_ref)) "redo_log_vdi" "indicates the VDI to use for the redo-log other than when HA is enabled"
          ; field ~in_oss_since:None ~qualifier:DynamicRO ~ty:String ~default_value:(Some (VString "")) "vswitch_controller" "address of the vswitch controller"

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -85,17 +85,17 @@ let refresh_console_urls ~__context =
             | "" ->
                 ""
             | address ->
-                let address =
-                  match Xapi_stdext_unix.Unixext.domain_of_addr address with
-                  | Some x when x = Unix.PF_INET ->
-                      address
-                  | Some x when x = Unix.PF_INET6 ->
-                      "[" ^ address ^ "]"
-                  | _ ->
-                      ""
-                in
-                Printf.sprintf "https://%s%s?ref=%s" address
-                  Constants.console_uri (Ref.string_of console)
+              let address =
+                match Xapi_stdext_unix.Unixext.domain_of_addr address with
+                | Some x when x = Unix.PF_INET ->
+                  address
+                | Some x when x = Unix.PF_INET6 ->
+                  "[" ^ address ^ "]"
+                | _ ->
+                  ""
+              in
+              Printf.sprintf "https://%s%s?ref=%s" address
+                Constants.console_uri (Ref.string_of console)
           in
           Db.Console.set_location ~__context ~self:console ~value:url_should_be)
         ())

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -85,17 +85,17 @@ let refresh_console_urls ~__context =
             | "" ->
                 ""
             | address ->
-              let address =
-                match Xapi_stdext_unix.Unixext.domain_of_addr address with
-                | Some x when x = Unix.PF_INET ->
-                  address
-                | Some x when x = Unix.PF_INET6 ->
-                  "[" ^ address ^ "]"
-                | _ ->
-                  ""
-              in
-              Printf.sprintf "https://%s%s?ref=%s" address
-                Constants.console_uri (Ref.string_of console)
+                let address =
+                  match Xapi_stdext_unix.Unixext.domain_of_addr address with
+                  | Some x when x = Unix.PF_INET ->
+                      address
+                  | Some x when x = Unix.PF_INET6 ->
+                      "[" ^ address ^ "]"
+                  | _ ->
+                      ""
+                in
+                Printf.sprintf "https://%s%s?ref=%s" address
+                  Constants.console_uri (Ref.string_of console)
           in
           Db.Console.set_location ~__context ~self:console ~value:url_should_be)
         ())

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -295,6 +295,7 @@ let wlb_request ~__context ~host ~port ~auth ~meth ~params ~handler ~enable_log
   let body = wlb_body meth params in
   let request = wlb_request host meth body auth in
   let pool = Helpers.get_pool ~__context in
+  let verify_cert = Db.Pool.get_wlb_verify_cert ~__context ~self:pool in
   let pool_other_config = Db.Pool.get_other_config ~__context ~self:pool in
   let timeout =
     try
@@ -310,8 +311,8 @@ let wlb_request ~__context ~host ~port ~auth ~meth ~params ~handler ~enable_log
          (filtered_headers (Http.Request.to_header_list request)))
       body ;
   try
-    Remote_requests.perform_request ~__context ~timeout ~host ~port ~request
-      ~handler ~enable_log
+    Remote_requests.perform_request ~__context ~timeout ~verify_cert ~host ~port
+      ~request ~handler ~enable_log
   with
   | Remote_requests.Timed_out ->
       raise_timeout timeout

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -380,7 +380,7 @@ let check_operation_error ~__context ?(sr_records = []) ?(pbd_records = [])
                       None
                 | `snapshot when record.Db_actions.vDI_sharable ->
                     Some (Api_errors.vdi_is_sharable, [_ref])
-                | `snapshot | `copy when reset_on_boot ->
+                | (`snapshot | `copy) when reset_on_boot ->
                     Some
                       ( Api_errors.vdi_on_boot_mode_incompatible_with_operation
                       , [] )


### PR DESCRIPTION
We need to thread the `wlb_verify_cert` flag to the stunnel client library, so that even if Pool.tls_verification_enabled is not set, wlb verification still works as expected

Needs to go in simultaneously with https://github.com/xapi-project/xen-api-libs-transitional/pull/89 - expect CI here to fail