### PR TITLE
REQ-403 pool conf fixes

### DIFF
--- a/ocaml/xapi-aux/pool_role.ml
+++ b/ocaml/xapi-aux/pool_role.ml
@@ -92,6 +92,8 @@ let set_role_for_next_boot r =
   Unixext.write_string_to_file !Constants.pool_config_file (string_of r) ;
   current
 
+let unsafe_set_role_ref r = with_pool_role_lock (fun () -> role := Some r)
+
 let is_master () = get_role () = Master
 
 let is_slave () = match get_role () with Slave _ -> true | _ -> false

--- a/ocaml/xapi-aux/pool_role.mli
+++ b/ocaml/xapi-aux/pool_role.mli
@@ -23,6 +23,12 @@ val get_role : unit -> t
 val set_role_for_next_boot : t -> t
 (** Returns the current role *)
 
+val unsafe_set_role_ref : t -> unit
+(** Sets the value returned by [get_role].
+ *  This is unsafe because the role ref is intended to reflect
+ *  a host's current role, which will not change until you
+ *  restart xapi *)
+
 val is_master : unit -> bool
 (** Returns true if this node is a master *)
 

--- a/ocaml/xapi-aux/pool_role.mli
+++ b/ocaml/xapi-aux/pool_role.mli
@@ -14,13 +14,14 @@
 
 type t = Master | Slave of string  (** IP address or FQDN *) | Broken
 
-val with_pool_role_lock : (unit -> unit) -> unit
-
 val string_of : t -> string
-(** Returns a printable version ot [t] *)
+(** Returns a printable version of [t] *)
 
 val get_role : unit -> t
 (** Returns the role of this node *)
+
+val set_role_for_next_boot : t -> t
+(** Returns the current role *)
 
 val is_master : unit -> bool
 (** Returns true if this node is a master *)

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1833,3 +1833,14 @@ end = struct
     SecretString.write_to_file !Xapi_globs.pool_secret_path ps ;
     Xapi_psr_util.load_psr_pool_secrets ()
 end
+
+let pingable addr =
+  let timeout = "1" in
+  let number_replies = "1" in
+  try
+    let (_ : string * string) =
+      Forkhelpers.execute_command_get_output "/bin/ping"
+        ["-c"; number_replies; "-w"; timeout; addr]
+    in
+    true
+  with _ -> false

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -167,14 +167,7 @@ let wait_for ?(timeout = 120.) f =
   done ;
   !success
 
-let pingable ip () =
-  try
-    let (_ : string * string) =
-      Forkhelpers.execute_command_get_output "/bin/ping"
-        ["-c"; "1"; "-w"; "1"; ip]
-    in
-    true
-  with _ -> false
+let pingable ip () = Helpers.pingable ip
 
 let queryable ~__context transport () =
   let open Xmlrpc_client in

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -595,7 +595,11 @@ let maybe_set_fqdn_in_pool_conf () =
                   "set_fqdn_in_pool_conf: updating pool.conf with master_fqdn: \
                    %s"
                   master_fqdn ;
-                Slave master_fqdn |> Xapi_pool_transition.set_role
+                let r = Slave master_fqdn in
+                Xapi_pool_transition.set_role r ;
+                (* Modifying the ref is justified here because
+                 * we are only correcting the master address *)
+                unsafe_set_role_ref r
               ) else
                 D.info "set_fqdn_in_pool_conf: not modifying pool.conf"
           | None ->


### PR DESCRIPTION
This fixes an issue where the pool role's master address was out of sync between the pool.conf file and the pool role ref