### PR TITLE
CP-34602: test get_server_localtime and message.get_since

### DIFF
--- a/ocaml/quicktest/quicktest.ml
+++ b/ocaml/quicktest/quicktest.ml
@@ -33,6 +33,7 @@ let () =
           , Quicktest_vdi_ops_data_integrity.tests () )
         ; ("Quicktest_max_vdi_size", Quicktest_max_vdi_size.tests ())
         ; ("Quicktest_static_vdis", Quicktest_static_vdis.tests ())
+        ; ("Quicktest_date", Quicktest_date.tests ())
         ]
         @
         if not !Quicktest_args.using_unix_domain_socket then

--- a/ocaml/quicktest/quicktest_date.ml
+++ b/ocaml/quicktest/quicktest_date.ml
@@ -1,0 +1,38 @@
+module Client = Client.Client
+module Date = Xapi_stdext_date.Date
+
+let test_host_get_server_localtime rpc session_id () =
+  let host = Client.Host.get_by_uuid ~rpc ~session_id ~uuid:Qt.localhost_uuid in
+  let (_ : Date.iso8601) =
+    Client.Host.get_server_localtime ~rpc ~session_id ~host
+  in
+  ()
+
+let test_message_get_since rpc session_id () =
+  let test_with_format format' =
+    let stdout, _ =
+      Forkhelpers.execute_command_get_output "/bin/date"
+        [Printf.sprintf "+%s" format'; "-d"; "yesterday"]
+    in
+    let yesterday = String.trim stdout |> Date.of_string in
+    let (_ : ('a API.Ref.t * API.message_t) list) =
+      Client.Message.get_since ~rpc ~session_id ~since:yesterday
+    in
+    ()
+  in
+  [
+    "%Y-%m-%dT%H:%M:%SZ"
+  ; "%Y-%m-%dT%H:%M:%S"
+  ; "%Y%m%dT%H:%M:%SZ"
+  ; "%Y%m%dT%H:%M:%S"
+  ]
+  |> List.iter test_with_format
+
+let tests () =
+  let open Qt_filter in
+  [
+    [("host.get_server_localtime", `Quick, test_host_get_server_localtime)]
+    |> conn
+  ; [("message.get_since", `Quick, test_message_get_since)] |> conn
+  ]
+  |> List.concat


### PR DESCRIPTION
Here we add integration tests for API methods which were broken by changes made to the stdext date library

Requires https://github.com/xapi-project/stdext/pull/58
