### PR TITLE
CP-34643: Replace deprecated usages of pervasiveext

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_rbac.ml
+++ b/ocaml/idl/ocaml_backend/gen_rbac.ml
@@ -15,11 +15,9 @@
 (* permissions in the datamodel. *)
 (* marcusg 21/07/2009*)
 
-module O = Ocaml_syntax
 module DT = Datamodel_types
 module DU = Datamodel_utils
 module DM = Datamodel
-module OU = Ocaml_utils
 module Client = Gen_client
 open DT
 
@@ -149,11 +147,6 @@ let writer_role name nroles =
   ^ Printf.sprintf "  role_subroles = get_refs %s;\n" (permissions_label name)
   ^ Printf.sprintf "  }\n"
 
-(*
-let get_ref name =
-	List.map (fun p->(*Ref.of_string*) (role_ref name)) permissions
-*)
-
 (* the output of this function generates ocaml/autogen/rbac-static.ml *)
 let writer_stdout static_roles_permissions static_permissions_roles =
   let nperms = List.length static_permissions_roles in
@@ -258,12 +251,11 @@ let get_http_permissions_roles =
     (fun acc (http_permission, (_, _, _, _, some_roles, sub_actions)) ->
       acc
       @
-      let open Xapi_stdext_pervasives in
-      let roles = Pervasiveext.default [] some_roles in
+      let roles = Option.value ~default:[] some_roles in
       (Datamodel.rbac_http_permission_prefix ^ http_permission, roles)
       :: List.map (* sub_actions for this http_permission *)
            (fun (sub_action, some_roles) ->
-             let roles = Pervasiveext.default [] some_roles in
+             let roles = Option.value ~default:[] some_roles in
              ( Datamodel.rbac_http_permission_prefix
                ^ http_permission
                ^ "/"
@@ -273,9 +265,8 @@ let get_http_permissions_roles =
     [] Datamodel.http_actions
 
 let get_extra_permissions_roles =
-  let open Xapi_stdext_pervasives in
   List.map
-    (fun (p, rs) -> (p, Pervasiveext.default [] rs))
+    (fun (p, rs) -> (p, Option.value ~default:[] rs))
     Datamodel.extra_permissions
 
 (* Returns a (permission, static_role list) list generated from datamodel.ml *)

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -18,7 +18,6 @@
 open Cli_protocol
 open Cli_util
 open Cli_cmdtable
-open Xapi_stdext_pervasives.Pervasiveext
 module Date = Xapi_stdext_date.Date
 module Listext = Xapi_stdext_std.Listext.List
 module Unixext = Xapi_stdext_unix.Unixext
@@ -1763,8 +1762,10 @@ let vdi_clone printer rpc session_id params =
     try Some (List.assoc "new-name-description" params) with Not_found -> None
   in
   let newvdi = Client.VDI.clone rpc session_id vdi driver_params in
-  maybe (fun x -> Client.VDI.set_name_label rpc session_id newvdi x) name_label ;
-  maybe
+  Option.iter
+    (fun x -> Client.VDI.set_name_label rpc session_id newvdi x)
+    name_label ;
+  Option.iter
     (fun x -> Client.VDI.set_name_description rpc session_id newvdi x)
     name_description ;
   let newuuid = Client.VDI.get_uuid rpc session_id newvdi in
@@ -3816,11 +3817,10 @@ let vm_clone_aux clone_op cloned_string printer include_template_vms rpc
       params
       ["new-name-label"; "new-name-description"]
   in
-  ignore
-    (may
-       (fun desc ->
-         Client.VM.set_name_description rpc session_id (List.hd new_vms) desc)
-       desc) ;
+  Option.iter
+    (fun desc ->
+      Client.VM.set_name_description rpc session_id (List.hd new_vms) desc)
+    desc ;
   printer
     (Cli_printer.PList
        (List.map (fun vm -> Client.VM.get_uuid rpc session_id vm) new_vms))
@@ -3870,10 +3870,9 @@ let snapshot_op op printer rpc session_id params =
   let uuid = get_snapshot_uuid params in
   let ref = get_snapshotVM_by_uuid rpc session_id uuid in
   let new_ref = op ~rpc ~session_id ~vm:ref ~new_name in
-  ignore
-    (may
-       (fun desc -> Client.VM.set_name_description rpc session_id new_ref desc)
-       desc) ;
+  Option.iter
+    (fun desc -> Client.VM.set_name_description rpc session_id new_ref desc)
+    desc ;
   let new_uuid = Client.VM.get_uuid ~rpc ~session_id ~self:new_ref in
   printer (Cli_printer.PList [new_uuid])
 
@@ -3918,11 +3917,10 @@ let vm_copy printer rpc session_id params =
       params
       ["new-name-label"; "sr-uuid"; "new-name-description"]
   in
-  ignore
-    (may
-       (fun desc ->
-         Client.VM.set_name_description rpc session_id (List.hd new_vms) desc)
-       desc) ;
+  Option.iter
+    (fun desc ->
+      Client.VM.set_name_description rpc session_id (List.hd new_vms) desc)
+    desc ;
   printer
     (Cli_printer.PList
        (List.map (fun vm -> Client.VM.get_uuid rpc session_id vm) new_vms))

--- a/ocaml/xapi/cancel_tasks.ml
+++ b/ocaml/xapi/cancel_tasks.ml
@@ -212,9 +212,11 @@ let cancel_tasks_on_host ~__context ~host_opt =
              Xapi_host_helpers.cancel_tasks ~__context ~self
                ~all_tasks_in_db:tasks ~task_ids))
         all_hosts ;
-      let open Xapi_stdext_pervasives.Pervasiveext in
       let hosts =
-        default (Db.Host.get_all ~__context) (may (fun x -> [x]) host_opt)
+        Option.fold
+          ~none:(Db.Host.get_all ~__context)
+          ~some:(fun x -> [x])
+          host_opt
       in
       List.iter
         (safe_wrapper "host_helpers - cancel tasks" (fun self ->

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -22,7 +22,6 @@ module Unixext = Xapi_stdext_unix.Unixext
 module Date = Xapi_stdext_date.Date
 open Create_misc
 open Client
-open Xapi_stdext_pervasives.Pervasiveext
 open Network
 
 module D = Debug.Make (struct let name = "dbsync" end)
@@ -149,7 +148,7 @@ let record_host_memory_properties ~__context info =
             (Printexc.to_string e) ;
           None
       in
-      maybe
+      Option.iter
         (fun boot_memory_bytes ->
           (* Host memory overhead comes from multiple sources:         *)
           (* 1. obvious overhead: (e.g. Xen, crash kernel).            *)

--- a/ocaml/xapi/session_check.ml
+++ b/ocaml/xapi/session_check.ml
@@ -13,8 +13,6 @@
  *)
 (* Session checking **********************************************************)
 
-open Xapi_stdext_pervasives.Pervasiveext
-
 exception Non_master_login_on_slave
 
 module D = Debug.Make (struct let name = "session_check" end)
@@ -25,8 +23,9 @@ open D
 let check_local_session_hook = ref None
 
 let is_local_session __context session_id =
-  default false
-    (may (fun f -> f ~__context ~session_id) !check_local_session_hook)
+  Option.fold ~none:false
+    ~some:(fun f -> f ~__context ~session_id)
+    !check_local_session_hook
 
 (* intra_pool_only is true iff the call that's invoking this check can only be called from host<->host intra-pool communication *)
 let check ~intra_pool_only ~session_id =

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -79,7 +79,7 @@ let refresh_internal ~__context ~self =
         ~device:pif.API.pIF_device)
     Ref.string_of ;
   maybe_update_database "MTU" pif.API.pIF_MTU Db.PIF.set_MTU
-    (Int64.of_int ++ fun () -> Net.Interface.get_mtu dbg bridge)
+    (fun () -> Int64.of_int (Net.Interface.get_mtu dbg bridge))
     Int64.to_string ;
   if pif.API.pIF_physical then
     maybe_update_database "capabilities" pif.API.pIF_capabilities

--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -17,7 +17,9 @@
 module D = Debug.Make (struct let name = "xapi_services" end)
 
 open D
-open Xapi_stdext_pervasives.Pervasiveext
+
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
+
 open Xapi_stdext_threads.Threadext
 module Unixext = Xapi_stdext_unix.Unixext
 open Constants
@@ -27,7 +29,7 @@ type driver_list = Storage_interface.query_result list [@@deriving rpcty]
 let list_sm_drivers ~__context =
   let all =
     List.map
-      (Smint.query_result_of_sr_driver_info ++ Sm.info_of_driver)
+      (fun x -> Smint.query_result_of_sr_driver_info (Sm.info_of_driver x))
       (Sm.supported_drivers ())
   in
   Storage_interface.rpc_of driver_list all

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -16,7 +16,6 @@
 *)
 
 open Client
-open Xapi_stdext_pervasives.Pervasiveext
 module Date = Xapi_stdext_date.Date
 open Event_types
 
@@ -49,12 +48,12 @@ let wait_for_subtask ?progress_minmax ~__context task =
       let process_copy_task task_rec =
         (* Update progress *)
         let myprogress =
-          may
+          Option.map
             (fun (min, max) ->
               min +. ((max -. min) *. task_rec.API.task_progress))
             progress_minmax
         in
-        maybe
+        Option.iter
           (fun value ->
             Db_actions.DB_Action.Task.set_progress ~__context ~self:main_task
               ~value)
@@ -152,7 +151,7 @@ let clone_single_vdi ?progress rpc session_id disk_op ~__context vdi
   in
   (* This particular clone takes overall progress from startprogress to endprogress *)
   let progress_minmax =
-    may
+    Option.map
       (fun (done_so_far, size, total) ->
         let startprogress = Int64.to_float done_so_far /. total in
         let endprogress =


### PR DESCRIPTION
This removes all the deprecation warnings.