### PR TITLE
CA-343646: generate certificate alerts

### DIFF
--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -41,12 +41,6 @@ let generate_alert epoch (host, expiry) =
     (host, Some (message, alert))
 
 let execute rpc session existing_messages (host, alert) =
-  let host_uuid = XenAPI.Host.get_uuid rpc session host in
-  let messages_in_host =
-    List.filter
-      (fun (_, record) -> record.API.message_obj_uuid = host_uuid)
-      existing_messages
-  in
   (* CA-342551: messages need to be deleted if the pending alert regard the
      same host and has newer, updated information.
      If the pending alert has the same metadata as the existing host message
@@ -56,6 +50,12 @@ let execute rpc session existing_messages (host, alert) =
      they are not destroyed since no alert is automatically dismissed. *)
   match alert with
   | Some (message, (alert, priority)) ->
+      let host_uuid = XenAPI.Host.get_uuid rpc session host in
+      let messages_in_host =
+        List.filter
+          (fun (_, record) -> record.API.message_obj_uuid = host_uuid)
+          existing_messages
+      in
       let is_outdated (ref, record) =
         record.API.message_body <> message
         || record.API.message_name <> alert

--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -47,15 +47,6 @@ let execute rpc session existing_messages (host, alert) =
       (fun (_, record) -> record.API.message_obj_uuid = host_uuid)
       existing_messages
   in
-  let is_outdated (ref, record) =
-    match alert with
-    | None ->
-        true
-    | Some (body, (name, priority)) ->
-        record.API.message_body <> body
-        || record.API.message_name <> name
-        || record.API.message_priority <> priority
-  in
   (* CA-342551: messages need to be deleted if the pending alert regard the
      same host and has newer, updated information.
      If the pending alert has the same metadata as the existing host message
@@ -63,17 +54,25 @@ let execute rpc session existing_messages (host, alert) =
      prevents changing the message UUID.
      In the case there are alerts regarding the host but no alert is pending
      they are not destroyed since no alert is automatically dismissed. *)
-  let outdated_messages = List.filter is_outdated messages_in_host in
-  let replacement_is_pending = List.exists is_outdated messages_in_host in
-  match (alert, replacement_is_pending) with
-  | Some (message, (alert, priority)), true ->
+  match alert with
+  | Some (message, (alert, priority)) ->
+      let is_outdated (ref, record) =
+        record.API.message_body <> message
+        || record.API.message_name <> alert
+        || record.API.message_priority <> priority
+      in
+      let outdated, current = List.partition is_outdated messages_in_host in
+
       List.iter
         (fun (self, _) -> XenAPI.Message.destroy rpc session self)
-        outdated_messages ;
-      ignore
-        (XenAPI.Message.create rpc session alert priority `Host host_uuid
-           message)
-  | _ ->
+        outdated ;
+      if current = [] then
+        let (_ : [> `message] Client.Id.t API.Ref.t) =
+          XenAPI.Message.create rpc session alert priority `Host host_uuid
+            message
+        in
+        ()
+  | None ->
       ()
 
 let alert rpc session =

--- a/ocaml/gencert/lib.ml
+++ b/ocaml/gencert/lib.ml
@@ -96,7 +96,8 @@ let validate_private_key pkcs8_private_key =
                ] )
          else (
            D.info {|Failed to validate private key because "%s"|} err_msg ;
-           `Msg (server_certificate_key_invalid, [])))
+           `Msg (server_certificate_key_invalid, [])
+         ))
   >>= ensure_key_length
 
 let validate_certificate kind pem now private_key =
@@ -135,8 +136,8 @@ let validate_certificate kind pem now private_key =
   | Leaf ->
       X509.Certificate.decode_pem raw_pem
       |> R.reword_error (fun (`Msg err_msg) ->
-          D.info {|Failed to validate certificate because "%s"|} err_msg ;
-          `Msg (server_certificate_invalid, []))
+             D.info {|Failed to validate certificate because "%s"|} err_msg ;
+             `Msg (server_certificate_invalid, []))
       >>= ensure_keys_match private_key
       >>= ensure_validity ~time:now
       >>= ensure_sha256_signature_algorithm

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1910,7 +1910,8 @@ let vm_record rpc session_id vm =
             Record_util.s2sm_to_string "; " (x ()).API.vM_xenstore_data)
           ~add_to_map:(fun k v ->
             Client.VM.add_to_xenstore_data rpc session_id vm k v)
-          ~clear_map:(fun () -> Client.VM.set_xenstore_data ~rpc ~session_id ~self:vm ~value:[])
+          ~clear_map:(fun () ->
+            Client.VM.set_xenstore_data ~rpc ~session_id ~self:vm ~value:[])
           ~remove_from_map:(fun k ->
             Client.VM.remove_from_xenstore_data rpc session_id vm k)
           ~get_map:(fun () -> (x ()).API.vM_xenstore_data)
@@ -2848,7 +2849,8 @@ let vdi_record rpc session_id vdi =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vDI_xenstore_data)
           ~get_map:(fun () -> (x ()).API.vDI_xenstore_data)
-          ~clear_map:(fun () -> Client.VDI.set_xenstore_data ~rpc ~session_id ~self:vdi ~value:[])
+          ~clear_map:(fun () ->
+            Client.VDI.set_xenstore_data ~rpc ~session_id ~self:vdi ~value:[])
           ()
       ; make_field ~name:"sm-config"
           ~get:(fun () ->

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -84,9 +84,9 @@ let refresh_console_urls ~__context =
             | "" ->
                 ""
             | address ->
-              let address = Http.Url.maybe_wrap_IPv6_literal address in
-              Printf.sprintf "https://%s%s?ref=%s" address
-                Constants.console_uri (Ref.string_of console)
+                let address = Http.Url.maybe_wrap_IPv6_literal address in
+                Printf.sprintf "https://%s%s?ref=%s" address
+                  Constants.console_uri (Ref.string_of console)
           in
           Db.Console.set_location ~__context ~self:console ~value:url_should_be)
         ())

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1024,15 +1024,16 @@ let is_valid_MAC mac =
 (** Returns true if the supplied IP address looks like one of mine *)
 let this_is_my_address ~__context address =
   let dbg = Context.string_of_task __context in
-  let inet_addrs = match Unixext.domain_of_addr address with
+  let inet_addrs =
+    match Unixext.domain_of_addr address with
     | Some x when x = Unix.PF_INET ->
-      Net.Interface.get_ipv4_addr dbg
-        (Xapi_inventory.lookup Xapi_inventory._management_interface)
+        Net.Interface.get_ipv4_addr dbg
+          (Xapi_inventory.lookup Xapi_inventory._management_interface)
     | Some x when x = Unix.PF_INET6 ->
-      Net.Interface.get_ipv6_addr dbg
-        (Xapi_inventory.lookup Xapi_inventory._management_interface)
+        Net.Interface.get_ipv6_addr dbg
+          (Xapi_inventory.lookup Xapi_inventory._management_interface)
     | _ ->
-      []
+        []
   in
   let addresses = List.map Unix.string_of_inet_addr (List.map fst inet_addrs) in
   List.mem address addresses
@@ -1843,7 +1844,8 @@ end = struct
     let use_script =
       try
         Unix.access !Xapi_globs.gen_pool_secret_script [Unix.X_OK] ;
-        Xapi_inventory.lookup ~default:"false" "CC_PREPARATIONS" |> bool_of_string
+        Xapi_inventory.lookup ~default:"false" "CC_PREPARATIONS"
+        |> bool_of_string
       with _ -> false
     in
     if use_script then

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -757,7 +757,7 @@ let handler (req : Http.Request.t) fd _ =
           let url =
             Printf.sprintf "https://%s%s?%s"
               (Http.Url.maybe_wrap_IPv6_literal
-                (Pool_role.get_master_address ()))
+                 (Pool_role.get_master_address ()))
               req.Http.Request.uri
               (String.concat "&" (List.map (fun (a, b) -> a ^ "=" ^ b) query))
           in

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -380,7 +380,7 @@ let check_operation_error ~__context ?(sr_records = []) ?(pbd_records = [])
                       None
                 | `snapshot when record.Db_actions.vDI_sharable ->
                     Some (Api_errors.vdi_is_sharable, [_ref])
-                | `snapshot | `copy when reset_on_boot ->
+                | (`snapshot | `copy) when reset_on_boot ->
                     Some
                       ( Api_errors.vdi_on_boot_mode_incompatible_with_operation
                       , [] )


### PR DESCRIPTION
The lastest change prevented creating new alerts created when there were
no other certificate alerts present.

Having no alerts now doesn't dismiss any existing alerts, as stated by the
comment.