### PR TITLE
REQ-403 fix first boot failure

### DIFF
--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -202,7 +202,7 @@ let callback1 ?(json_rpc_version = Jsonrpc.V1) is_json req fd call =
   let whitelisted = List.mem call.Rpc.name whitelist in
   let emergency_call = List.mem call.Rpc.name emergency_call_list in
   let is_slave = not (Pool_role.is_master ()) in
-  if !Xapi_globs.slave_emergency_mode && not emergency_call then
+  if !Xapi_globs.host_emergency_mode && not emergency_call then
     raise !Xapi_globs.emergency_mode_error ;
   if
     is_slave

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1634,6 +1634,8 @@ let try_internal_async ~__context (marshaller : Rpc.t -> 'b)
 module SystemdService (Name : sig
   val name : string
 end) : sig
+  val is_active : unit -> bool
+
   val ensure_enabled_and_restart : unit -> unit
 end = struct
   let name = Name.name
@@ -1650,6 +1652,8 @@ end = struct
       )
     in
     exit_code = 0
+
+  let is_active () = is_cmd "is-active"
 
   let is_enabled () = is_cmd "is-enabled"
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -496,8 +496,8 @@ let cache_metadata_vdis () =
 
 (* Called if we cannot contact master at init time *)
 let server_run_in_emergency_mode () =
-  info "Cannot contact master: running in slave emergency mode" ;
-  Xapi_globs.slave_emergency_mode := true ;
+  info "enabling emergency mode on this host" ;
+  Xapi_globs.host_emergency_mode := true ;
   (* signal the init script that it should succeed even though we're bust *)
   Helpers.touch_file !Xapi_globs.ready_file ;
   let emergency_reboot_delay =
@@ -1069,7 +1069,7 @@ let server_init () =
         | Pool_role.Slave _ ->
             info "Running in 'Pool Slave' mode" ;
             (* Set emergency mode until we actually talk to the master *)
-            Xapi_globs.slave_emergency_mode := true ;
+            Xapi_globs.host_emergency_mode := true ;
             (* signal the init script that it should succeed even though we're bust *)
             Helpers.touch_file !Xapi_globs.ready_file ;
             (* Keep trying to log into master *)
@@ -1095,7 +1095,7 @@ let server_init () =
                   Thread.delay !Db_globs.permanent_master_failure_retry_interval
             done ;
             debug "Startup successful" ;
-            Xapi_globs.slave_emergency_mode := false ;
+            Xapi_globs.host_emergency_mode := false ;
             Master_connection.connection_timeout := initial_connection_timeout ;
             ( try
                 (* We can't tolerate an exception in db synchronization so fall back into emergency mode

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -85,8 +85,7 @@ let storage_unix_domain_socket = Filename.concat "/var/lib/xcp" "storage"
 
 let local_database = Filename.concat "/var/lib/xcp" "local.db"
 
-(* if a slave in emergency "cannot see master mode" then this flag is set *)
-let slave_emergency_mode = ref false
+let host_emergency_mode = ref false
 
 (** Whenever in emergency mode we stash an error here so the user can determine what's wrong
     without trawling through logfiles *)

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -997,7 +997,7 @@ let on_server_restart () =
           info
             "Assuming HA is still enabled on the Pool and that our storage \
              system has failed: will retry in 10s" ;
-          Xapi_globs.slave_emergency_mode := true ;
+          Xapi_globs.host_emergency_mode := true ;
           Xapi_globs.emergency_mode_error :=
             Api_errors.Server_error
               (Api_errors.ha_host_cannot_access_statefile, []) ;
@@ -1007,7 +1007,7 @@ let on_server_restart () =
           error
             "ha_start_daemon failed with unexpected error %s: will retry in 10s"
             (Xha_errno.to_string errno) ;
-          Xapi_globs.slave_emergency_mode := true ;
+          Xapi_globs.host_emergency_mode := true ;
           Xapi_globs.emergency_mode_error :=
             Api_errors.Server_error
               (Api_errors.ha_heartbeat_daemon_startup_failed, []) ;
@@ -1018,7 +1018,7 @@ let on_server_restart () =
             "ha_start_daemon failed with unexpected exception: %s -- retrying \
              in 10s"
             (ExnHelper.string_of_exn e) ;
-          Xapi_globs.slave_emergency_mode := true ;
+          Xapi_globs.host_emergency_mode := true ;
           Xapi_globs.emergency_mode_error :=
             Api_errors.Server_error
               (Api_errors.ha_heartbeat_daemon_startup_failed, []) ;

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -38,7 +38,7 @@ let local_assert_healthy ~__context =
   | Pool_role.Broken ->
       raise !Xapi_globs.emergency_mode_error
   | Pool_role.Slave _ ->
-      if !Xapi_globs.slave_emergency_mode then
+      if !Xapi_globs.host_emergency_mode then
         raise !Xapi_globs.emergency_mode_error
 
 let set_power_on_mode ~__context ~self ~power_on_mode ~power_on_config =
@@ -1058,7 +1058,7 @@ let change_management_interface ~__context interface primary_address_type =
 let local_management_reconfigure ~__context ~interface =
   (* Only let this one through if we are in emergency mode, otherwise use
      	 Host.management_reconfigure *)
-  if not !Xapi_globs.slave_emergency_mode then
+  if not !Xapi_globs.host_emergency_mode then
     raise (Api_errors.Server_error (Api_errors.pool_not_in_emergency_mode, [])) ;
   change_management_interface ~__context interface
     (Record_util.primary_address_type_of_string
@@ -1213,7 +1213,7 @@ let set_ssl_legacy ~__context ~self ~value =
   else
     D.info "set_ssl_legacy: called with value: %b - doing nothing" value
 
-let is_in_emergency_mode ~__context = !Xapi_globs.slave_emergency_mode
+let is_in_emergency_mode ~__context = !Xapi_globs.host_emergency_mode
 
 let compute_free_memory ~__context ~host =
   (*** XXX: Use a more appropriate free memory calculation here. *)


### PR DESCRIPTION
Before running '"Update host certificate if changed"' startup task, we need gencert to have created xapi-ssl.pem, otherwise the host will be placed in emergency mode and the first boot scripts will fail.

I've included some refactorings alongside this fix