### PR TITLE
REQ-403 fix first boot failure

### DIFF
--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -202,7 +202,7 @@ let callback1 ?(json_rpc_version = Jsonrpc.V1) is_json req fd call =
   let whitelisted = List.mem call.Rpc.name whitelist in
   let emergency_call = List.mem call.Rpc.name emergency_call_list in
   let is_slave = not (Pool_role.is_master ()) in
-  if !Xapi_globs.slave_emergency_mode && not emergency_call then
+  if !Xapi_globs.host_emergency_mode && not emergency_call then
     raise !Xapi_globs.emergency_mode_error ;
   if
     is_slave

--- a/ocaml/xapi/certificates_sync.ml
+++ b/ocaml/xapi/certificates_sync.ml
@@ -54,8 +54,9 @@ let install ~__context ~host cert =
         ( match pool_size ~__context with
         | 1 ->
             let uuid = Db.Certificate.get_uuid ~__context ~self:ref in
+            let name = Astring.String.append uuid ".pem" in
             Certificates.(
-              pool_install CA_Certificate ~__context ~name:uuid ~cert:pem)
+              pool_install CA_Certificate ~__context ~name ~cert:pem)
         | _ ->
             debug "Not installing updated self-signed host cert in pool"
         ) ;
@@ -92,7 +93,9 @@ let install ~__context ~host cert =
                enabled)" ;
             R.ok ()
       )
-  with e -> Error (`Msg ("installation of host certificate failed", []))
+  with e ->
+    error "certificates_sync.install exception: %s" (Printexc.to_string e) ;
+    Error (`Msg ("installation of host certificate failed", []))
 
 (** determine if the database is up to date by comparing the fingerprint
   of xapi-ssl.pem with the entry in the database *)

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -496,8 +496,8 @@ let cache_metadata_vdis () =
 
 (* Called if we cannot contact master at init time *)
 let server_run_in_emergency_mode () =
-  info "Cannot contact master: running in slave emergency mode" ;
-  Xapi_globs.slave_emergency_mode := true ;
+  info "enabling emergency mode on this host" ;
+  Xapi_globs.host_emergency_mode := true ;
   (* signal the init script that it should succeed even though we're bust *)
   Helpers.touch_file !Xapi_globs.ready_file ;
   let emergency_reboot_delay =
@@ -1054,7 +1054,7 @@ let server_init () =
         | Pool_role.Slave _ ->
             info "Running in 'Pool Slave' mode" ;
             (* Set emergency mode until we actually talk to the master *)
-            Xapi_globs.slave_emergency_mode := true ;
+            Xapi_globs.host_emergency_mode := true ;
             (* signal the init script that it should succeed even though we're bust *)
             Helpers.touch_file !Xapi_globs.ready_file ;
             (* Keep trying to log into master *)
@@ -1080,7 +1080,7 @@ let server_init () =
                   Thread.delay !Db_globs.permanent_master_failure_retry_interval
             done ;
             debug "Startup successful" ;
-            Xapi_globs.slave_emergency_mode := false ;
+            Xapi_globs.host_emergency_mode := false ;
             Master_connection.connection_timeout := initial_connection_timeout ;
             ( try
                 (* We can't tolerate an exception in db synchronization so fall back into emergency mode

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -478,9 +478,10 @@ let server_run_in_emergency_mode () =
   wait_to_die () ; exit 0
 
 let update_certificates ~__context () =
+  info "syncing certificates on xapi start" ;
   match Certificates_sync.update ~__context with
   | Ok () ->
-      ()
+      info "successfully synced certificates"
   | Error (`Msg (msg, _)) ->
       error "Failed to update host certificates: %s" msg ;
       server_run_in_emergency_mode ()
@@ -489,6 +490,7 @@ let update_certificates ~__context () =
       server_run_in_emergency_mode ()
 
 let bring_up_management_if ~__context () =
+  update_certificates ~__context |> Xapi_mgmt_iface.add_stunnel_cb ;
   try
     let management_if =
       Xapi_inventory.lookup Xapi_inventory._management_interface
@@ -498,6 +500,7 @@ let bring_up_management_if ~__context () =
         (Xapi_inventory.lookup Xapi_inventory._management_address_type)
     in
     if management_if = "" then (
+      (* we enter this branch during first boot *)
       debug "No management interface defined (management is disabled)" ;
       Xapi_mgmt_iface.run ~__context ~mgmt_enabled:false
     ) else (
@@ -603,7 +606,9 @@ let maybe_set_fqdn_in_pool_conf () =
       ()
 
 (** Reset the networking-related metadata for this host if the command [xe-reset-networking]
- *  was executed before the restart. *)
+ *  was executed before the restart.
+ *  This also gets executed on firstboot, and variables such as MANAGEMENT_INTERFACE are set
+ *  for the first time here *)
 let check_network_reset () =
   try
     (* Raises exception if the file is not there and no reset is required *)
@@ -1021,9 +1026,6 @@ let server_init () =
           ; ( "hi-level database upgrade"
             , [Startup.OnlyMaster]
             , Xapi_db_upgrade.hi_level_db_upgrade_rules ~__context )
-          ; ( "Update host certificate if changed"
-            , []
-            , update_certificates ~__context )
           ; ( "bringing up management interface"
             , []
             , bring_up_management_if ~__context )

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -85,8 +85,7 @@ let storage_unix_domain_socket = Filename.concat "/var/lib/xcp" "storage"
 
 let local_database = Filename.concat "/var/lib/xcp" "local.db"
 
-(* if a slave in emergency "cannot see master mode" then this flag is set *)
-let slave_emergency_mode = ref false
+let host_emergency_mode = ref false
 
 (** Whenever in emergency mode we stash an error here so the user can determine what's wrong
     without trawling through logfiles *)

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -997,7 +997,7 @@ let on_server_restart () =
           info
             "Assuming HA is still enabled on the Pool and that our storage \
              system has failed: will retry in 10s" ;
-          Xapi_globs.slave_emergency_mode := true ;
+          Xapi_globs.host_emergency_mode := true ;
           Xapi_globs.emergency_mode_error :=
             Api_errors.Server_error
               (Api_errors.ha_host_cannot_access_statefile, []) ;
@@ -1007,7 +1007,7 @@ let on_server_restart () =
           error
             "ha_start_daemon failed with unexpected error %s: will retry in 10s"
             (Xha_errno.to_string errno) ;
-          Xapi_globs.slave_emergency_mode := true ;
+          Xapi_globs.host_emergency_mode := true ;
           Xapi_globs.emergency_mode_error :=
             Api_errors.Server_error
               (Api_errors.ha_heartbeat_daemon_startup_failed, []) ;
@@ -1018,7 +1018,7 @@ let on_server_restart () =
             "ha_start_daemon failed with unexpected exception: %s -- retrying \
              in 10s"
             (ExnHelper.string_of_exn e) ;
-          Xapi_globs.slave_emergency_mode := true ;
+          Xapi_globs.host_emergency_mode := true ;
           Xapi_globs.emergency_mode_error :=
             Api_errors.Server_error
               (Api_errors.ha_heartbeat_daemon_startup_failed, []) ;

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -38,7 +38,7 @@ let local_assert_healthy ~__context =
   | Pool_role.Broken ->
       raise !Xapi_globs.emergency_mode_error
   | Pool_role.Slave _ ->
-      if !Xapi_globs.slave_emergency_mode then
+      if !Xapi_globs.host_emergency_mode then
         raise !Xapi_globs.emergency_mode_error
 
 let set_power_on_mode ~__context ~self ~power_on_mode ~power_on_config =
@@ -1058,7 +1058,7 @@ let change_management_interface ~__context interface primary_address_type =
 let local_management_reconfigure ~__context ~interface =
   (* Only let this one through if we are in emergency mode, otherwise use
      	 Host.management_reconfigure *)
-  if not !Xapi_globs.slave_emergency_mode then
+  if not !Xapi_globs.host_emergency_mode then
     raise (Api_errors.Server_error (Api_errors.pool_not_in_emergency_mode, [])) ;
   change_management_interface ~__context interface
     (Record_util.primary_address_type_of_string
@@ -1213,7 +1213,7 @@ let set_ssl_legacy ~__context ~self ~value =
   else
     D.info "set_ssl_legacy: called with value: %b - doing nothing" value
 
-let is_in_emergency_mode ~__context = !Xapi_globs.slave_emergency_mode
+let is_in_emergency_mode ~__context = !Xapi_globs.host_emergency_mode
 
 let compute_free_memory ~__context ~host =
   (*** XXX: Use a more appropriate free memory calculation here. *)

--- a/ocaml/xapi/xapi_mgmt_iface.mli
+++ b/ocaml/xapi/xapi_mgmt_iface.mli
@@ -18,6 +18,9 @@
 val himn_addr : unit -> string option
 (** Local IP address of the HIMN (if any) *)
 
+val add_stunnel_cb : (unit -> unit) -> unit
+(** This will be executed only once, immediately after the trigger of the next stunnel restart *)
+
 val wait_for_management_ip : __context:Context.t -> string
 (** Block until an IP address appears on the management interface *)
 


### PR DESCRIPTION
Rework of https://github.com/xapi-project/xen-api/pull/4286

Fixes:
 - first boot failure where host is put into maintenance mode
 - install failure where CA cert files didn't have a .pem extension