### PR TITLE
CP-35761: Add feature flag for TLS certificate checking

### DIFF
--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -60,6 +60,7 @@ type feature =
   | Corosync
   | Zstd_export
   | Pool_secret_rotation
+  | Certificate_verification
 [@@deriving rpc]
 
 type orientation = Positive | Negative
@@ -116,6 +117,8 @@ let keys_of_features =
   ; (Zstd_export, ("restrict_zstd_export", Negative, "Zstd_export"))
   ; ( Pool_secret_rotation
     , ("restrict_pool_secret_rotation", Negative, "Pool_secret_rotation") )
+  ; (Certificate_verification
+    , ("restrict_certificate_verification", Negative, "Certificate_verification") )
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi-types/features.mli
+++ b/ocaml/xapi-types/features.mli
@@ -67,6 +67,7 @@ type feature =
   | Corosync  (** Enable the use of corosync. *)
   | Zstd_export  (** Enable the use of VM export with zstd compression. *)
   | Pool_secret_rotation  (** Enable Pool Secret Rotation *)
+  | Certificate_verification (** Used by XenCenter *)
 
 val feature_of_rpc : Rpc.t -> feature
 (** Convert RPC into {!feature}s *)


### PR DESCRIPTION
TLS Certificate checking requires clients to change their behavior when
doing certain operations (like pool joins). This flag is meant to aid
them to detect which behaviour to use

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>