### PR TITLE
CP-35372: Repository: datamodel, sync and "/udpates/"

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5500,6 +5500,7 @@ let all_system =
     Datamodel_cluster_host.t;
     Datamodel_certificate.t;
     Datamodel_diagnostics.t;
+    Datamodel_repository.t;
   ]
 
 (** These are the pairs of (object, field) which are bound together in the database schema *)
@@ -5695,6 +5696,7 @@ let expose_get_all_messages_for = [
   _cluster;
   _cluster_host;
   _certificate;
+  _repository;
 ]
 
 let no_task_id_for = [ _task; (* _alert; *) _event ]
@@ -5781,6 +5783,9 @@ let http_actions = [
   ("post_jsonrpc", (Post, Constants.jsonrpc_uri, false, [], _R_READ_ONLY, []));
   ("post_jsonrpc_options", (Options, Constants.jsonrpc_uri, false, [], _R_READ_ONLY, []));
   ("get_pool_update_download", (Get, Constants.get_pool_update_download_uri, false, [], _R_READ_ONLY, []));
+  ("get_repository", (Get, Constants.get_repository_uri, false, [], _R_READ_ONLY, []));
+  ("get_host_updates", (Get, Constants.get_host_updates_uri, false, [], _R_POOL_OP, []));
+  ("get_updates", (Get, Constants.get_updates_uri, true, [], _R_POOL_OP, []));
 ]
 
 (* these public http actions will NOT be checked by RBAC *)
@@ -5799,6 +5804,7 @@ let public_http_actions_with_no_rbac_check =
     "post_jsonrpc";
     "post_jsonrpc_options";
     "get_pool_update_download";
+    "get_repository";
   ]
 
 (* permissions not associated with any object message or field *)

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -189,6 +189,7 @@ let _cluster = "Cluster"
 let _cluster_host = "Cluster_host"
 let _certificate = "Certificate"
 let _diagnostics = "Diagnostics"
+let _repository = "Repository"
 
 let get_oss_releases in_oss_since =
   match in_oss_since with

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1198,7 +1198,41 @@ let _ =
     ~doc:"No other cluster host was reachable when joining" ();
 
   error Api_errors.xen_incompatible []
-    ~doc:"The current version of Xen or its control libraries is incompatible with the Toolstack." ()
+    ~doc:"The current version of Xen or its control libraries is incompatible with the Toolstack." ();
+
+  (* repository and updates errors *)
+  error Api_errors.set_repository_in_progress []
+    ~doc:"The operation could not be performed because setting repository is in progress." ();
+  error Api_errors.updates_sync_in_progress []
+    ~doc:"The operation could not be performed because updates syncing is in progress." ();
+  error Api_errors.updates_get_in_progress []
+    ~doc:"The operation could not be performed because updates getting is in progress." ();
+  error Api_errors.invalid_updateinfo_xml []
+    ~doc:"The content of updateinfo.xml is invalid." ();
+  error Api_errors.invalid_repository_name ["name"]
+    ~doc:"The name of repository is invalid." ();
+  error Api_errors.invalid_base_url ["url"]
+    ~doc:"The base url in the repository is invalid." ();
+  error Api_errors.repository_already_exists []
+    ~doc:"The repository already exists." ();
+  error Api_errors.repository_is_in_use []
+    ~doc:"The repository is in use." ();
+  error Api_errors.no_repository_enabled []
+    ~doc:"There is no repository being enabled." ();
+  error Api_errors.get_host_updates_failed ["uuid"]
+    ~doc:"Failed to get available updates from a host." ();
+  error Api_errors.local_pool_repo_cleanup_failed []
+    ~doc:"Failed to clean up local pool repository on master." ();
+  error Api_errors.invalid_repomd_xml []
+    ~doc:"The content of repomd.xml is invalid." ();
+  error Api_errors.no_updateinfo_xml []
+    ~doc:"No updateinfo.xml." ();
+  error Api_errors.reposync_in_progress []
+    ~doc:"The pool is syncing with remote YUM repository." ();
+  error Api_errors.reposync_failed []
+    ~doc:"Syning with remote YUM repository failed." ();
+  error Api_errors.no_local_pool_repository []
+    ~doc:"Local pool repository does not exist." ()
 
 
 

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -8,6 +8,9 @@ open Datamodel_types
             "ha_disable", "Indicates this pool is in the process of disabling HA";
             "cluster_create", "Indicates this pool is in the process of creating a cluster";
             "designate_new_master", "Indicates this pool is in the process of changing master";
+            "set_repository", "Indicates this pool is in the process of setting repository";
+            "updates_sync", "Indicates this pool is in the process of syncing updates";
+            "updates_list", "Indicates this pool is in the process of listing updates";
           ])
 
   let enable_ha = call
@@ -647,6 +650,25 @@ open Datamodel_types
     ~allowed_roles:_R_POOL_ADMIN
     ()
 
+  let set_repository = call
+      ~name:"set_repository"
+      ~in_product_since:rel_next
+      ~doc:"Set the enabled repository for updates"
+      ~params:[Ref _repository, "value", "The repository to be enabled"]
+      ~allowed_roles:_R_POOL_ADMIN
+      ()
+
+  let updates_sync = call
+      ~name:"updates_sync"
+      ~in_product_since:rel_next
+      ~doc:"Sync with the enabled repository"
+      ~params:[
+        Bool, "force", "If true local mirroring repo will be removed before syncing"
+      ]
+      ~result:(String, "The SHA256 hash of updateinfo.xml.gz")
+      ~allowed_roles:_R_POOL_OP
+      ()
+
   (** A pool class *)
   let t =
     create_obj
@@ -721,6 +743,8 @@ open Datamodel_types
         ; add_to_guest_agent_config
         ; remove_from_guest_agent_config
         ; rotate_secret
+        ; set_repository
+        ; updates_sync
         ]
       ~contents:
         ([uid ~in_oss_since:None _pool] @
@@ -764,5 +788,6 @@ open Datamodel_types
          ; field ~in_product_since:rel_inverness ~qualifier:DynamicRO ~ty:Bool ~default_value:(Some (VBool false)) "igmp_snooping_enabled" "true if IGMP snooping is enabled in the pool, false otherwise."
          ; field ~in_product_since:rel_quebec ~qualifier:RW ~ty:String ~default_value:(Some (VString "")) "uefi_certificates" "The UEFI certificates allowing Secure Boot"
          ; field ~in_product_since:rel_stockholm_psr ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "is_psr_pending" "True if either a PSR is running or we are waiting for a PSR to be re-run"
+         ; field ~in_product_since:rel_next ~qualifier:DynamicRO ~ty:(Ref _repository) ~default_value:(Some (VRef null_ref)) "repository" "The enabled repository for updates"
          ])
       ()

--- a/ocaml/idl/datamodel_repository.ml
+++ b/ocaml/idl/datamodel_repository.ml
@@ -1,0 +1,82 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Datamodel_types
+open Datamodel_common
+open Datamodel_roles
+
+let lifecycle = [Published, rel_next, ""]
+
+let introduce = call
+    ~name:"introduce"
+    ~in_oss_since:None
+    ~in_product_since:rel_next
+    ~doc:"Create a new repository record in the database only"
+    ~params:[
+      String, "name_label", "The name of the repository";
+      String, "binary_url", "Base URL of binary packages in this repository";
+      String, "source_url", "Base URL of source pacakges in this repository";
+    ]
+    ~result:(Ref _repository, "The ref of the created repository record.")
+    ~allowed_roles:_R_POOL_OP
+    ()
+
+let forget = call
+    ~name:"forget"
+    ~in_oss_since:None
+    ~in_product_since:rel_next
+    ~doc:"Remove a repository record from the database"
+    ~params:[Ref _repository, "self", "The repository to forget about"]
+    ~allowed_roles:_R_POOL_OP
+    ()
+
+let t =
+  create_obj
+    ~name: _repository
+    ~descr:"Repository for updates"
+    ~doccomments:[]
+    ~gen_constructor_destructor:false
+    ~gen_events:true
+    ~in_db:true
+    ~lifecycle
+    ~persist:PersistEverything
+    ~in_oss_since:None
+    ~messages_default_allowed_roles:_R_POOL_OP
+    ~messages: [introduce; forget]
+
+    ~contents:
+      [ uid       _repository ~lifecycle;
+        namespace ~name:"name" ~contents:(names None StaticRO) ();
+        field     ~qualifier:StaticRO ~lifecycle
+          ~ty:String
+          ~default_value:(Some (VString ""))
+          "binary_url"
+          "Base URL of binary packages in this repository";
+        field     ~qualifier:StaticRO ~lifecycle
+          ~ty:String
+          ~default_value:(Some (VString ""))
+          "source_url"
+          "Base URL of source pacakges in this repository";
+        field     ~qualifier:DynamicRO ~lifecycle
+          ~ty:String
+          ~default_value:(Some (VString ""))
+          "hash"
+          "SHA256 checksum of latest updateinfo.xml.gz in this repository";
+        field     ~qualifier:DynamicRO ~lifecycle
+          ~ty:Bool
+          ~default_value:(Some (VBool false))
+          "up_to_date"
+          "True if all hosts in pool is up to date with this repository";
+      ]
+    ()

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -19,6 +19,7 @@
    datamodel_schema
    datamodel_certificate
    datamodel_diagnostics
+   datamodel_repository
   )
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29))
   (libraries

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -275,7 +275,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(ha_cluster_stack = !Xapi_globs.cluster_stack_default)
     ?(guest_agent_config = []) ?(cpu_info = [])
     ?(policy_no_vendor_device = false) ?(live_patching_disabled = false)
-    ?(uefi_certificates = "") () =
+    ?(uefi_certificates = "") ?(repository = Ref.null) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -286,7 +286,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~vswitch_controller ~igmp_snooping_enabled ~current_operations
     ~allowed_operations ~restrictions ~other_config ~ha_cluster_stack
     ~guest_agent_config ~cpu_info ~policy_no_vendor_device
-    ~live_patching_disabled ~uefi_certificates ~is_psr_pending:false ;
+    ~live_patching_disabled ~uefi_certificates ~is_psr_pending:false ~repository;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -422,6 +422,14 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; implementation= No_fd Cli_operations.pool_rotate_secret
       ; flags= []
       } )
+  ; ( "pool-updates-sync"
+    , {
+        reqd= []
+      ; optn= ["force"]
+      ; help= "Sync with remote YUM repository, pool-wide."
+      ; implementation= With_fd Cli_operations.pool_updates_sync
+      ; flags= []
+      } )
   ; ( "host-is-in-emergency-mode"
     , {
         reqd= []
@@ -3091,6 +3099,22 @@ let rec cmdtable_data : (string * cmd_spec) list =
           "Destroy a cluster host object forcefully, effectively leaving the \
            cluster"
       ; implementation= No_fd Cli_operations.Cluster_host.force_destroy
+      ; flags= []
+      } )
+  ; ( "repository-introduce"
+    , {
+        reqd= ["name-label"; "binary-url"; "source-url"]
+      ; optn= []
+      ; help= "Create a repository object representing a YUM repository."
+      ; implementation= No_fd Cli_operations.Repository.introduce
+      ; flags= []
+      } )
+  ; ( "repository-forget"
+    , {
+        reqd= ["uuid"]
+      ; optn= []
+      ; help= "Forget about a repository."
+      ; implementation= No_fd Cli_operations.Repository.forget
       ; flags= []
       } )
   ]

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -145,6 +145,12 @@ let pool_operation_to_string = function
       "cluster_create"
   | `designate_new_master ->
       "designate_new_master"
+  | `set_repository ->
+      "set_repository"
+  | `updates_sync ->
+      "updates_sync"
+  | `updates_list ->
+      "updates_list"
 
 let host_operation_to_string = function
   | `provision ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1214,6 +1214,15 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"uefi-certificates" ~hidden:true
           ~get:(fun () -> (x ()).API.pool_uefi_certificates)
           ()
+      ; make_field ~name:"repository"
+          ~get:(fun () -> get_uuid_from_ref (x ()).API.pool_repository)
+          ~set:(fun x ->
+            let ref =
+              if x = "" then Ref.null
+              else Client.Repository.get_by_uuid rpc session_id x
+            in
+            Client.Pool.set_repository rpc session_id ref)
+          ()
       ]
   }
 
@@ -4482,6 +4491,47 @@ let certificate_record rpc session_id certificate =
           ()
       ; make_field ~name:"fingerprint"
           ~get:(fun () -> (x ()).API.certificate_fingerprint)
+          ()
+      ]
+  }
+
+let repository_record rpc session_id repository =
+  let _ref = ref repository in
+  let empty_record =
+    ToGet (fun () -> Client.Repository.get_record rpc session_id !_ref)
+  in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  {
+    setref=
+      (fun r ->
+        _ref := r ;
+        record := empty_record)
+  ; setrefrec=
+      (fun (a, b) ->
+        _ref := a ;
+        record := Got b)
+  ; record= x
+  ; getref= (fun () -> !_ref)
+  ; fields=
+      [
+        make_field ~name:"uuid"
+          ~get:(fun () -> (x ()).API.repository_uuid)
+          ()
+      ; make_field ~name:"name-label"
+          ~get:(fun () -> (x ()).API.repository_name_label)
+          ()
+      ; make_field ~name:"binary-url"
+          ~get:(fun () -> (x ()).API.repository_binary_url)
+          ()
+      ; make_field ~name:"source-url"
+          ~get:(fun () -> (x ()).API.repository_source_url)
+          ()
+      ; make_field ~name:"hash"
+          ~get:(fun () -> (x ()).API.repository_hash)
+          ()
+      ; make_field ~name:"up-to-date"
+          ~get:(fun () -> string_of_bool (x ()).API.repository_up_to_date)
           ()
       ]
   }

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1201,3 +1201,35 @@ let vcpu_max_not_cores_per_socket_multiple =
 let designate_new_master_in_progress = "DESIGNATE_NEW_MASTER_IN_PROGRESS"
 
 let pool_secret_rotation_pending = "POOL_SECRET_ROTATION_PENDING"
+
+let set_repository_in_progress = "SET_REPOSITORY_IN_PROGRESS"
+
+let updates_sync_in_progress = "UPDATES_SYNC_IN_PROGRESS"
+
+let updates_get_in_progress = "UPDATES_GET_IN_PROGRESS"
+
+let invalid_updateinfo_xml = "INVALID_UPDATEINFO_XML"
+
+let invalid_repository_name = "INVALID_REPOSITORY_NAME"
+
+let invalid_base_url = "INVALID_BASE_URL"
+
+let repository_already_exists = "REPOSITORY_ALREADY_EXISTS"
+
+let repository_is_in_use = "REPOSITORY_IS_IN_USE"
+
+let no_repository_enabled = "NO_REPOSITORY_ENABLED"
+
+let get_host_updates_failed = "GET_HOST_UPDATES_FAILED"
+
+let local_pool_repo_cleanup_failed = "LOCAL_POOL_REPO_CLEANUP_FAILED"
+
+let invalid_repomd_xml = "INVALID_REPOMD_XML"
+
+let no_updateinfo_xml = "NO_UPDATEINDO_XML"
+
+let reposync_in_progress = "REPOSYNC_IN_PROGGRESS"
+
+let reposync_failed = "REPOSYNC_FAILED"
+
+let no_local_pool_repository = "NO_LOCAL_POOL_REPOSITORY"

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -152,6 +152,13 @@ let audit_log_uri = "/audit_log"
 let get_pool_update_download_uri = "/update/"
 
 (* ocaml/xapi/xapi_pool_update.ml *)
+
+let get_repository_uri = "/repository/" (* ocaml/xapi/repository.ml *)
+
+let get_host_updates_uri = "/host_updates/" (* ocaml/xapi/repository.ml *)
+
+let get_updates_uri = "/updates/" (* ocaml/xapi/repository.ml *)
+
 let default_usb_speed = -1.
 
 let use_compression = "use_compression"

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -130,6 +130,7 @@ module Actions = struct
   module Cluster_host = Xapi_cluster_host
   module Certificate = Certificates
   module Diagnostics = Xapi_diagnostics
+  module Repository = Repository
 end
 
 (** Use the server functor to make an XML-RPC dispatcher. *)

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -42,7 +42,7 @@ let create_pool_record ~__context =
       ~other_config:[Xapi_globs.memory_ratio_hvm; Xapi_globs.memory_ratio_pv]
       ~ha_cluster_stack:"xhad" ~guest_agent_config:[] ~cpu_info:[]
       ~policy_no_vendor_device:false ~live_patching_disabled:false
-      ~uefi_certificates:"" ~is_psr_pending:false
+      ~uefi_certificates:"" ~is_psr_pending:false ~repository:Ref.null
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -610,6 +610,14 @@ functor
           Ref.string_of vusb
       with _ -> "invalid"
 
+     let repository_uuid ~__context repository =
+       try
+         if Pool_role.is_master () then
+           Db.Repository.get_uuid __context repository
+         else
+           Ref.string_of repository
+       with _ -> "invalid"
+
     module Session = Local.Session
     module Auth = Local.Auth
     module Subject = Local.Subject
@@ -886,6 +894,16 @@ functor
       let rotate_secret ~__context =
         info "Pool.rotate_secret: pool = '%s'" (current_pool_uuid ~__context) ;
         Local.Pool.rotate_secret ~__context
+
+      let set_repository ~__context ~value =
+        info "Pool.set_repository : pool = '%s'; value = %s"
+          (current_pool_uuid ~__context) (repository_uuid ~__context value);
+        Local.Pool.set_repository ~__context ~value
+
+      let updates_sync ~__context ~force =
+        info "Pool.updates_sync : pool = '%s'; false = %s"
+          (current_pool_uuid ~__context) (string_of_bool force);
+        Local.Pool.updates_sync ~__context ~force
     end
 
     module VM = struct
@@ -5647,4 +5665,15 @@ functor
     end
 
     module Certificate = struct end
+
+    module Repository = struct
+      let introduce ~__context ~name_label ~binary_url ~source_url =
+        info "Repository.introduce: name = '%s'; binary_url = '%s'; source_url = '%s'"
+          name_label binary_url source_url;
+        Local.Repository.introduce ~__context ~name_label ~binary_url ~source_url
+
+      let forget ~__context ~self =
+        info "Repository.forget: self = '%s'" (repository_uuid ~__context self);
+        Local.Repository.forget ~__context ~self
+    end
   end

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -1,0 +1,975 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module Unixext = Xapi_stdext_unix.Unixext
+
+module D = Debug.Make (struct let name = "repository" end)
+
+open D
+
+module UpdateIdSet = Set.Make (String)
+
+module GuidanceStrSet = Set.Make (String)
+
+let owner_ro = 0o400
+let capacity_in_parallel = 16
+let yum_repos_config_dir  = "/etc/yum.repos.d"
+let cached_repomd_xml_path = "/var/cache/yum/x86_64/7/citrix-normal/repomd.xml"
+let cmd_yum_config_manager = "/usr/bin/yum-config-manager"
+let cmd_reposync = "/usr/bin/reposync"
+let cmd_createrepo = "/usr/bin/createrepo_c"
+let cmd_modifyrepo = "/usr/bin/modifyrepo_c"
+let cmd_yum = "/usr/bin/yum"
+let cmd_rm = "/usr/bin/rm"
+let cmd_rpm = "/usr/bin/rpm"
+
+let reposync_mutex = Mutex.create ()
+let exposing_pool_repo_mutex = Mutex.create ()
+
+(* TODO: determine the format of updateinfo.xml *)
+
+type guidance =
+  | RebootHost
+  | RestartToolstack
+  | EvacuateHost
+  | RestartDeviceModel
+
+type guidance_kind = Absolute | Recommended
+
+let string_of_guidance = function
+  | RebootHost -> "RebootHost"
+  | RestartToolstack -> "RestartToolstack"
+  | EvacuateHost -> "EvacuateHost"
+  | RestartDeviceModel -> "RestartDeviceModel"
+
+exception Unknown_guidance
+
+let guidance_of_string = function
+  | "RebootHost" -> RebootHost
+  | "RestartToolstack" -> RestartToolstack
+  | "EvacuateHost" -> EvacuateHost
+  | "RestartDeviceModel" -> RestartDeviceModel
+  | _ -> raise Unknown_guidance
+
+type inequality = Lt | Eq | Gt
+
+let string_of_inequality = function
+  | Lt -> "<"
+  | Eq -> "="
+  | Gt -> ">"
+
+exception Invalid_inequalities
+
+let inequalities_of_string = function
+  | "gte" -> [Gt; Eq]
+  | "lte" -> [Lt; Eq]
+  | "gt"  -> [Gt]
+  | "lt"  -> [Lt]
+  | "eq"  -> [Eq]
+  | _ -> raise Invalid_inequalities
+
+let string_of_inequalities = function
+  | [Gt; Eq] | [Eq; Gt] -> ">="
+  | [Lt; Eq] | [Eq; Lt] -> "<="
+  | [Gt] -> ">"
+  | [Lt] -> "<"
+  | [Eq] -> "="
+  | _ -> raise Invalid_inequalities
+
+type segment_of_version =
+  | Int of int
+  | Str of string
+
+type applicability = {
+    name: string
+  ; inequalities: inequality list
+  ; epoch: string
+  ; version: string
+  ; release: string
+}
+
+let string_of_applicability a =
+  Printf.sprintf "%s%s%s-%s"
+    a.name (string_of_inequalities a.inequalities) a.version a.release
+
+type updateinfo = {
+    id: string
+  ; summary: string
+  ; description: string
+  ; rec_guidances: guidance list
+  ; abs_guidances: guidance list
+  ; guidance_applicabilities: applicability list
+  ; spec_info: string
+  ; url: string
+}
+
+let string_of_updateinfo ui =
+  Printf.sprintf "id=%s rec_guidances=%s abs_guidances=%s guidance_applicabilities=%s"
+    ui.id
+    (String.concat ";" (List.map string_of_guidance ui.rec_guidances))
+    (String.concat ";" (List.map string_of_guidance ui.abs_guidances))
+    (String.concat ";" (List.map string_of_applicability ui.guidance_applicabilities))
+
+type updateinfo_md = {
+    checksum: string
+  ; open_checksum: string
+  ; location: string
+  ; timestamp: int
+  ; size: int
+  ; open_size: int
+}
+
+type update = {
+    name: string
+  ; arch: string
+  ; old_ver_rel: string option
+  ; new_ver_rel: string
+  ; update_id: string
+}
+
+let compare_ver v1 v2 =
+  let normalize v =
+    v
+    |> Str.split (Str.regexp "\\.")
+    |> List.map (fun s -> try Int (int_of_string s) with _ -> Str s)
+  in
+  let compare_str v1 v2 f =
+    let r = String.compare v1 v2 in
+    if r < 0 then Lt
+    else if r > 0 then Gt
+    else f ()
+  in
+  let rec compare_segments l1 l2 =
+    match l1, l2 with
+    | c1 :: t1, c2 :: t2 ->
+      let f () = compare_segments t1 t2 in
+      (match c1, c2 with
+       | Int v1, Int v2 ->
+         if v1 > v2 then Gt
+         else if v1 = v2 then f ()
+         else Lt
+       | Int v1, Str v2 -> compare_str (string_of_int v1) v2 f
+       | Str v1, Int v2 -> compare_str v1 (string_of_int v2) f
+       | Str v1, Str v2 -> compare_str v1 v2 f)
+    | c1 :: t1, [] -> Gt
+    | [], c2 :: t2 -> Lt
+    | [], [] -> Eq
+  in
+  let r = compare_segments (normalize v1) (normalize v2) in
+  debug "version/release comparison between  %s and %s: %s" v1 v2 (string_of_inequality r);
+  r
+
+let eval_applicability ~version ~release ~applicability =
+  let ver = applicability.version in
+  let rel = applicability.release in
+  let eval_applicability' inequality =
+    match inequality, (compare_ver version ver), (compare_ver release rel) with
+    | Lt, Lt, _ | Lt, Eq, Lt | Eq, Eq, Eq | Gt, Gt, _ | Gt, Eq, Gt -> true
+    | _ -> false
+  in
+  List.exists eval_applicability' applicability.inequalities
+
+let eval_guidance_for_one_update ~updates_info ~update ~kind =
+  let ver, rel =
+    match update.old_ver_rel with
+    | Some v_r ->
+      begin match Str.split (Str.regexp "-") v_r with
+        | v :: r :: [] -> v, r
+        | _ ->
+          raise Api_errors.(
+              Server_error (internal_error,
+                            ["Invalid version and release in evaluating guidances"]))
+      end
+    | None ->
+      raise Api_errors.(
+          Server_error (internal_error,
+                        ["Missing old version and release in evaluating guidances"]))
+  in 
+  let is_applicable (a : applicability) =
+    if update.name = a.name then
+      eval_applicability ~version:ver ~release:rel ~applicability:a
+    else false
+  in
+  let updateinfo = List.assoc update.update_id updates_info in
+  let applicabilities = updateinfo.guidance_applicabilities in
+  match (List.exists is_applicable applicabilities), applicabilities with
+  | true, _ | false, [] -> 
+    debug "Evaluating applicability for package %s in update %s returns true."
+      update.name updateinfo.id;
+    begin match kind with
+      | Absolute -> List.map string_of_guidance updateinfo.abs_guidances
+      | Recommended -> List.map string_of_guidance updateinfo.rec_guidances
+    end
+    |> GuidanceStrSet.of_list
+  | false, _ :: _ ->
+    debug "Evaluating applicability for package %s in update %s returns false."
+      update.name updateinfo.id;
+    GuidanceStrSet.empty
+
+let resort_guidances gs=
+  match GuidanceStrSet.find_opt "RebootHost" gs with
+  | Some _ -> GuidanceStrSet.singleton "RebootHost"
+  | None -> gs
+
+let eval_guidances ~updates_info ~updates ~kind =
+  List.fold_left (fun acc u ->
+      GuidanceStrSet.union acc (eval_guidance_for_one_update ~updates_info ~update:u ~kind)
+  ) GuidanceStrSet.empty updates
+  |> resort_guidances
+  |> GuidanceStrSet.elements
+
+let create_repository_record ~__context ~name_label ~binary_url ~source_url =
+  let ref = Ref.make () in
+  let uuid = Uuidm.to_string (Uuidm.create `V4) in
+  Db.Repository.create
+    ~__context
+    ~ref
+    ~uuid
+    ~name_label
+    ~name_description:""
+    ~binary_url
+    ~source_url
+    ~hash:""
+    ~up_to_date:false;
+  ref
+
+let assert_name_is_valid ~name_label =
+    match Str.string_match (Str.regexp "^[A-Za-z0-9\\-]+$") name_label 0 with
+    | true -> ()
+    | false -> raise Api_errors.(Server_error (invalid_repository_name, [name_label]))
+
+let assert_url_is_valid ~url =
+  match List.exists (fun domain_name ->
+      let r = Str.regexp
+          (Printf.sprintf
+             "^https?://[A-Za-z0-9\\-]+\\.%s(:[0-9]+)?/[A-Za-z0-9\\-/\\$]+$"
+             domain_name)
+      in
+      Str.string_match r url 0
+    ) !Xapi_globs.repository_domain_name_whitelist with
+  | true -> ()
+  | false -> raise Api_errors.(Server_error (invalid_base_url, [url]))
+
+let introduce ~__context ~name_label ~binary_url ~source_url =
+  assert_name_is_valid ~name_label;
+  assert_url_is_valid ~url:binary_url;
+  assert_url_is_valid ~url:source_url;
+  match Db.Repository.get_by_name_label ~__context ~label:name_label with
+  | [] -> create_repository_record  ~__context ~name_label ~binary_url ~source_url
+  | _ ->
+    error "A repository with same name_label '%s' already exists" name_label;
+    raise Api_errors.(Server_error (repository_already_exists, []))
+
+let forget ~__context ~self =
+  let pool = Helpers.get_pool ~__context in
+  let enabled = Db.Pool.get_repository ~__context ~self:pool in
+  if enabled = self then
+    raise Api_errors.(Server_error (repository_is_in_use, []))
+  else
+    Db.Repository.destroy ~__context ~self
+
+let get_enabled_repository ~__context =
+  let pool = Helpers.get_pool ~__context in
+  match Db.Pool.get_repository ~__context ~self:pool with
+  | ref when ref <> Ref.null -> ref
+  | _ ->
+      raise Api_errors.(Server_error (no_repository_enabled, []))
+
+let remove_local_repo_conf_files () =
+  List.iter (fun n ->
+    let path = yum_repos_config_dir ^ "/" ^ n in
+    let stat = Unix.lstat path in
+    let matched = Str.string_match (Str.regexp "^local-.+\\.repo$") n 0 in
+    match stat.Unix.st_kind = Unix.S_REG, matched with
+    | true, true ->
+        debug "removing local YUM repository config file: %s" path;
+        Unixext.unlink_safe path
+    | _ -> ()
+  ) (Array.to_list (Sys.readdir yum_repos_config_dir))
+
+let clean_yum_cache ~prefix ~name =
+  try
+    let params =
+        [
+          "--disablerepo=*";
+          Printf.sprintf "--enablerepo=%s-%s" prefix name;
+          "clean";
+          "expire-cache";
+        ]
+    in
+    ignore (Helpers.call_script cmd_yum params);
+    ()
+  with _ -> warn "Unable to clean YUM cache of %s-%s" prefix name
+
+let with_local_repository ~__context f =
+  let ref = get_enabled_repository ~__context in
+  let name = Db.Repository.get_name_label ~__context ~self:ref in
+  let master_addr =
+    try Pool_role.get_master_address ()
+    with Pool_role.This_host_is_a_master ->
+      Option.get (Helpers.get_management_ip_addr ~__context)
+  in
+  let url = Printf.sprintf "https://%s/repository/" master_addr in
+  let file_path = Printf.sprintf "%s/local-%s.repo" yum_repos_config_dir name in
+  let content = String.concat "\n"
+      [
+        Printf.sprintf "[local-%s]" name;
+        Printf.sprintf "name=local-%s" name;
+        Printf.sprintf "baseurl=%s" url;
+        "enabled=1";
+        "gpgcheck=1";
+        "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Citrix";
+      ]
+  in
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+      remove_local_repo_conf_files ();
+      Unixext.atomic_write_to_file file_path owner_ro (fun fd ->
+          Unixext.really_write_string fd content |> ignore);
+      let config_params =
+          [
+            "--save";
+            Printf.sprintf "--setopt=local-%s.sslverify=false" name;
+            Printf.sprintf "local-%s" name;
+          ]
+      in
+      ignore (Helpers.call_script cmd_yum_config_manager config_params);
+      f name)
+    (fun () ->
+       clean_yum_cache ~prefix:"local" ~name;
+       remove_local_repo_conf_files ())
+
+let split_rpm_name s =
+  (* s I.E. "libpath-utils-0.2.1-29.el7.x86_64" *)
+  let r = Str.regexp "^\\(.+\\)\\.\\(noarch\\|x86_64\\)$" in
+  match Str.string_match r s 0 with
+  | true ->
+    (try
+       let pkg = Str.replace_first r "\\1" s in (* pkg is, I.E. "libpath-utils-0.2.1-29.el7" *)
+       let arch = Str.replace_first r "\\2" s in
+       let pos1 = String.rindex pkg '-' in
+       let pos2 = String.rindex_from pkg (pos1 - 1) '-' in
+       let rel = String.sub pkg (pos1 + 1) ((String.length pkg) - pos1 - 1) in
+       let ver = String.sub pkg (pos2 + 1) (pos1 - pos2 - 1) in
+       let name = String.sub pkg 0 pos2 in
+       debug "%s -> name=%s version=%s release=%s arch=%s" s name ver rel arch;
+       Some (name, ver, rel, arch)
+     with e ->
+       let msg =
+         Printf.sprintf "Failed to split rpm name '%s': %s" s (ExnHelper.string_of_exn e) in
+       raise Api_errors.(Server_error (internal_error, [msg])))
+  | false -> None
+
+let get_installed_pkgs () =
+  Helpers.call_script cmd_rpm ["-qa"]
+  |> Str.split (Str.regexp "\n")
+  |> List.filter_map split_rpm_name
+  |> List.map (fun (name, ver, rel, arch) -> ((name ^ "." ^ arch), (ver ^ "-" ^ rel)))
+
+let get_host_updates_in_json ~__context ~installed ~uuid =
+  with_local_repository ~__context (fun name ->
+      clean_yum_cache ~prefix:"local" ~name;
+      let repo_name = Printf.sprintf "local-%s" name in
+      let params_of_updateinfo_list =
+        [
+          "-q"; "--disablerepo=*"; Printf.sprintf "--enablerepo=%s" repo_name;
+          "updateinfo"; "list"; "updates";
+        ]
+      in
+      let assert_error output =
+        let errors = ["Updateinfo file is not valid XML"] in
+        let open Xapi_stdext_std.Xstringext in
+        List.iter (fun err ->
+          if String.has_substr output err then (
+            error "Error from 'yum updateinfo list': %s" err;
+            raise Api_errors.(Server_error (invalid_updateinfo_xml, [])))
+          else ()) errors;
+        output
+      in
+      let rpm2updates =
+        Helpers.call_script cmd_yum params_of_updateinfo_list
+        |> assert_error
+        |> Str.split (Str.regexp "\n")
+        |> List.filter_map (fun l ->
+            match Str.split(Str.regexp " +") l with
+            | update_id :: _ :: rpm_name :: []  -> Some (rpm_name, update_id)
+            | _ -> None)
+      in
+      let params_of_list =
+        [
+          "-q"; "--disablerepo=*"; Printf.sprintf "--enablerepo=%s" repo_name;
+          "list"; "updates";
+        ]
+      in
+      let installed_pkgs = match installed with
+        | true -> get_installed_pkgs ()
+        | false -> []
+      in
+      let updates =
+        Helpers.call_script cmd_yum params_of_list
+        |> Str.split (Str.regexp "\n")
+        |> List.filter_map (fun l ->
+            match Str.split(Str.regexp " +") l with
+            | "Updated" :: "Packages" :: [] -> None
+            | name_arch :: ver_rel :: repo :: [] when repo = repo_name ->
+              (* xsconsole.x86_64  10.1.11-34  local-normal *)
+              begin match Str.split(Str.regexp "\\.") name_arch with
+                | name :: arch :: [] ->
+                  let l2 =
+                    begin match installed with
+                      | true ->
+                        (try
+                           [("oldVerRel", `String (List.assoc name_arch installed_pkgs))]
+                         with _ -> 
+                           error "no installed package found for %s" name_arch;
+                           raise Api_errors.(Server_error (get_host_updates_failed, [uuid])))
+                      | false -> []
+                    end
+                  in
+                  let rpm_name = Printf.sprintf "%s-%s.%s" name ver_rel arch in
+                  (try
+                     let l = [("name", `String name);
+                              ("arch", `String arch);
+                              ("newVerRel", `String ver_rel);
+                              ("updateId", `String (List.assoc rpm_name rpm2updates))]
+                     in
+                     Some (`Assoc (l @ l2))
+                   with _ -> 
+                     error "no update found for %s" rpm_name;
+                     raise Api_errors.(Server_error (invalid_updateinfo_xml, [])))
+                | _ -> None
+              end
+            | _ -> None)
+      in
+      (* TODO: live patches *)
+      `Assoc [("updates", `List updates)])
+
+let cleanup ~__context ~self ~prefix =
+  if self <> Ref.null then
+    let name = Db.Repository.get_name_label ~__context ~self in
+    try
+      clean_yum_cache ~prefix ~name;
+      ignore (Helpers.call_script
+                cmd_rm
+                ["-f"; (Printf.sprintf "/etc/yum.repos.d/%s-%s.repo" prefix name)]);
+      ignore (Helpers.call_script cmd_rm ["-rf"; !Xapi_globs.local_pool_repo_dir]);
+      ()
+    with e ->
+      error "Failed to cleanup local pool repository: %s" (ExnHelper.string_of_exn e);
+      raise Api_errors.(Server_error (local_pool_repo_cleanup_failed, []))
+
+let parse_repomd xml_path =
+  let empty_updateinfo_md = {
+      checksum = ""
+    ; open_checksum = ""
+    ; location = ""
+    ; timestamp = 0
+    ; size = 0
+    ; open_size = 0
+    }
+  in
+  match Sys.file_exists xml_path with
+  | false ->
+    error "No repomd.xml found";
+    raise Api_errors.(Server_error (invalid_repomd_xml, []))
+  | true ->
+    begin match Xml.parse_file xml_path with
+     | Xml.Element ("repomd", _, children) ->
+       let get_updateinfo_node = function
+         | Xml.Element ("data", attrs, nodes) ->
+           (match List.assoc_opt "type" attrs with
+            | Some "updateinfo" -> Some nodes
+            | _ -> None)
+         | _ -> None
+       in
+       begin match List.filter_map get_updateinfo_node children with
+        | [l] ->
+          List.fold_left (fun md n ->
+              try
+                match n with
+                | Xml.Element ("checksum", _, [Xml.PCData v]) ->
+                  {md with checksum = v}
+                | Xml.Element ("open-checksum", _, [Xml.PCData v]) ->
+                  {md with open_checksum = v}
+                | Xml.Element ("location", attrs, _) ->
+                  {md with location = (List.assoc "href" attrs)}
+                | Xml.Element ("timestamp", _, [Xml.PCData v]) ->
+                  {md with timestamp = int_of_string v}
+                | Xml.Element ("size", _, [Xml.PCData v]) ->
+                  {md with size = int_of_string v}
+                | Xml.Element ("open-size", _, [Xml.PCData v]) ->
+                  {md with open_size = int_of_string v}
+                | _ ->
+                  debug "Unknown node in <updateinfo>, ignore it";
+                  md
+              with _ ->
+                error "Unexpected 'updateinfo' node";
+                raise Api_errors.(Server_error (invalid_repomd_xml, []))
+          ) empty_updateinfo_md l
+        | _ ->
+          error "Missing or multiple 'updateinfo' node(s)";
+          raise Api_errors.(Server_error (invalid_repomd_xml, []))
+       end
+     | _ ->
+       error "Missing 'repomd' node";
+       raise Api_errors.(Server_error (invalid_repomd_xml, []))
+     | exception e ->
+       error "Failed to parse repomd.xml: %s" (ExnHelper.string_of_exn e);
+       raise Api_errors.(Server_error (invalid_repomd_xml, []))
+    end
+
+let parse_guidances ~gs =
+  List.map (fun g ->
+      match g with
+      | Xml.Element ("guidance", _, [Xml.PCData v]) ->
+        guidance_of_string v
+      | _ -> 
+        error "Unknown node in <absolute|recommended_guidances>";
+        raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+  ) gs
+
+let parse_applicabilities ~apps =
+  let empty_applicability = {
+      name = ""
+    ; inequalities = []
+    ; epoch = ""
+    ; version = ""
+    ; release = ""
+    }
+  in
+  List.map (fun a ->
+      match a with
+      | Xml.Element ("applicability", _, children) ->
+        List.fold_left (fun a n ->
+            match n with
+            | Xml.Element ("inequality", _, [Xml.PCData v]) ->
+              { a with inequalities = (inequalities_of_string v) }
+            | Xml.Element ("epoch", _, [Xml.PCData v]) ->
+              { a with epoch = v }
+            | Xml.Element ("version", _, [Xml.PCData v]) ->
+              { a with version = v }
+            | Xml.Element ("release", _, [Xml.PCData v]) ->
+              { a with release = v }
+            | Xml.Element ("name", _, [Xml.PCData v]) ->
+              { a with name = v }
+            | _ ->
+              error "Unknown node in <applicability>";
+              raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+        ) empty_applicability children
+      | _ ->
+        error "Unknown node in <guidance_applicabilities>";
+        raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+  ) apps
+
+let parse_updateinfo_xml_file xml_file_path =
+  let empty_updateinfo = {
+      id = ""
+    ; summary = ""
+    ; description = ""
+    ; rec_guidances = []
+    ; abs_guidances = []
+    ; guidance_applicabilities = []
+    ; spec_info = ""
+    ; url = ""
+    }
+  in
+  match Xml.parse_file xml_file_path with
+  | Xml.Element  ("updates", _, children) ->
+    List.filter_map (fun n ->
+        match n with
+        | Xml.Element ("update", _, update_nodes) ->
+          let ui = List.fold_left (fun acc node ->
+              match node with
+              | Xml.Element ("id", _, [Xml.PCData v]) ->
+                { acc with id = v }
+              | Xml.Element ("url", _, [Xml.PCData v]) ->
+                { acc with url = v }
+              | Xml.Element ("special_info", _, [Xml.PCData v]) ->
+                { acc with spec_info = v }
+              | Xml.Element ("summary", _, [Xml.PCData v]) ->
+                { acc with summary = v }
+              | Xml.Element ("description", _, [Xml.PCData v]) ->
+                { acc with description = v }
+              | Xml.Element ("recommended_guidances", _, gs) ->
+                { acc with rec_guidances = (parse_guidances gs) }
+              | Xml.Element ("absolute_guidances", _, gs) ->
+                { acc with abs_guidances = (parse_guidances gs) }
+              | Xml.Element ("guidance_applicabilities", _, apps) ->
+                { acc with guidance_applicabilities = (parse_applicabilities apps) }
+              | _ -> acc
+            ) empty_updateinfo update_nodes
+          in
+          debug "updateinfo: %s" (string_of_updateinfo ui);
+          Some ui
+        | _ -> None
+    ) children
+    |> List.map (fun updateinfo -> (updateinfo.id, updateinfo))
+  | _ ->
+    error "Failed to parse updateinfo.xml: missing <updates>";
+    raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+  | exception e ->
+    error "Failed to parse updateinfo.xml: %s" (ExnHelper.string_of_exn e);
+    raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+
+let with_updateinfo_xml gz_path f =
+  let tmpfile, tmpch = Filename.open_temp_file ~mode:[Open_text] "updateinfo" ".xml" in
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+      Xapi_stdext_pervasives.Pervasiveext.finally
+        (fun () ->
+           try
+             Unixext.with_file gz_path [Unix.O_RDONLY] 0o0
+               (fun gz_fd_in ->
+                  Gzip.decompress_passive gz_fd_in (fun fd_in ->
+                      let ic = Unix.in_channel_of_descr fd_in in
+                      try
+                        while true do
+                          let line = input_line ic in
+                          output_string tmpch (line ^ "\n")
+                        done
+                      with End_of_file -> ()))
+           with e ->
+             error "Failed to decompress updateinfo.xml.gz: %s" (ExnHelper.string_of_exn e);
+             raise Api_errors.(Server_error (invalid_updateinfo_xml, [])))
+        (fun () -> close_out tmpch);
+      f tmpfile)
+    (fun () -> Sys.remove tmpfile)
+
+let parse_updateinfo ~prefix ~name ~hash =
+  let repo_dir = Printf.sprintf "%s/%s-%s" !Xapi_globs.local_pool_repo_dir prefix name in
+  let repodata_dir = repo_dir ^ "/repodata" in
+  let repomd_xml_path = repodata_dir ^ "/repomd.xml" in
+  let md = parse_repomd repomd_xml_path in
+  let updateinfo_xml_gz_path = repo_dir ^ "/" ^ md.location in
+  if hash <> md.checksum then error "unexpected mismatch between XAPI DB and YUM DB";
+  match Sys.file_exists updateinfo_xml_gz_path with
+  | false -> raise Api_errors.(Server_error (no_updateinfo_xml, []))
+  | true ->
+    with_updateinfo_xml updateinfo_xml_gz_path parse_updateinfo_xml_file
+
+let http_get_host_updates_in_json ~__context ~host ~installed =
+  let host_session_id =
+    Xapi_session.login_no_password ~__context ~uname:None ~host ~pool:true
+      ~is_local_superuser:true ~subject:Ref.null ~auth_user_sid:""
+      ~auth_user_name:"" ~rbac_permissions:[]
+  in
+  let request = Xapi_http.http_request
+      ~cookie:[("session_id", Ref.string_of host_session_id)]
+      ~query:[("installed", (string_of_bool installed))]
+      Http.Get Constants.get_host_updates_uri
+  in
+  let host_name = (Db.Host.get_hostname ~__context ~self:host) in
+  let host_addr = Db.Host.get_address ~__context ~self:host in
+  let open Xmlrpc_client in
+  let transport = SSL (SSL.make () ~verify_cert:false, host_addr, !Constants.https_port) in
+  debug "getting host updates on %s (addr %s) by HTTP GET" host_name host_addr;
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+      try
+        let json_str =
+          with_transport transport
+            (with_http request (fun (response, fd) ->
+                 Xapi_stdext_unix.Unixext.string_of_fd fd))
+        in
+        debug "host %s returned updates: %s" host_name json_str;
+        Yojson.Basic.from_string json_str
+      with e ->
+        let uuid = Db.Host.get_uuid ~__context ~self:host in
+        error "Failed to get updates from host uuid='%s': %s" uuid (ExnHelper.string_of_exn e);
+        raise Api_errors.(Server_error (get_host_updates_failed, [uuid])))
+    (fun () -> Xapi_session.destroy_db_session ~__context ~self:host_session_id)
+
+let run_in_parallel ~funs ~capacity =
+  let rec run_in_parallel' acc funs capacity =
+    let rec split_for_first_n acc n l =
+      match n, l with
+      | n, h::t when n > 0 -> split_for_first_n (h :: acc) (n - 1) t
+      | _ -> acc, l
+    in
+    let run f =
+      let result = ref `Not_started in
+      let wrapper r = try r := `Succ (f ()) with e -> r := `Fail e in
+      let th = Thread.create wrapper result in
+      th, result
+    in
+    let get_result (th, result) =
+      Thread.join th;
+      match !result with
+      | `Not_started -> `Error (Failure "The thread in run_in_parallel is not started")
+      | `Succ s -> `Ok s
+      | `Fail e -> `Error e
+    in
+    let to_be_run, remaining = split_for_first_n [] capacity funs in
+    match to_be_run with
+    | [] -> acc
+    | _ -> 
+      let finished =
+        List.map run to_be_run
+        |> List.map get_result
+        |> List.map (function `Ok s -> s | `Error e -> raise e)
+      in
+      run_in_parallel' (List.rev_append finished acc) remaining capacity
+  in
+  run_in_parallel' [] funs capacity
+
+let write_yum_config ~__context ~self ~prefix =
+  let name = Db.Repository.get_name_label ~__context ~self in
+  let file_path = Printf.sprintf "/etc/yum.repos.d/%s-%s.repo" prefix name in
+  let binary_url = Db.Repository.get_binary_url  ~__context ~self in
+  let source_url = Db.Repository.get_source_url  ~__context ~self in
+  let content = String.concat "\n"
+      [
+        Printf.sprintf "[%s-%s]" prefix name;
+        Printf.sprintf "name=%s-%s" prefix name;
+        Printf.sprintf "baseurl=%s" binary_url;
+        "enabled=0";
+        if !Xapi_globs.repository_gpgcheck then "gpgcheck=1" else "gpgcheck=0";
+        "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Citrix";
+        "";
+        Printf.sprintf "[%s-%s-source]" prefix name;
+        Printf.sprintf "name=%s-%s-source" prefix name;
+        Printf.sprintf "baseurl=%s" source_url;
+        "enabled=0";
+        if !Xapi_globs.repository_gpgcheck then "gpgcheck=1" else "gpgcheck=0";
+        "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Citrix";
+       ]
+  in
+  Unixext.atomic_write_to_file file_path owner_ro (fun fd ->
+    Unixext.really_write_string fd content |> ignore);
+  name
+
+let sync ~__context ~self ~prefix =
+  try
+    remove_local_repo_conf_files ();
+    let name = write_yum_config ~__context ~self ~prefix in
+    let config_params =
+        [
+          "--save";
+          "repo_gpgcheck=1";
+          Printf.sprintf "%s-%s" prefix name;
+        ]
+    in
+    ignore (Helpers.call_script cmd_yum_config_manager config_params);
+    (* sync with remote repository *)
+    let sync_params =
+        [
+          "-p"; !Xapi_globs.local_pool_repo_dir;
+          "--downloadcomps";
+          "--download-metadata";
+          if !Xapi_globs.repository_gpgcheck then "--gpgcheck" else "";
+          "--delete";
+          Printf.sprintf "--repoid=%s-%s" prefix name;
+        ]
+    in
+    Unixext.mkdir_rec !Xapi_globs.local_pool_repo_dir 0o700;
+    clean_yum_cache ~prefix ~name;
+    ignore (Helpers.call_script cmd_reposync sync_params)
+  with e ->
+    error "Failed to sync with remote YUM repository: %s" (ExnHelper.string_of_exn e);
+    raise Api_errors.(Server_error (reposync_failed, []))
+
+let create_pool_repository ~__context ~self ~prefix =
+  let name = Db.Repository.get_name_label ~__context ~self in
+  match Sys.file_exists !Xapi_globs.local_pool_repo_dir with
+  | true ->
+    let repo_dir = Printf.sprintf "%s/%s-%s"
+        !Xapi_globs.local_pool_repo_dir prefix name
+    in
+    ignore (Helpers.call_script cmd_createrepo [repo_dir]);
+    let md = parse_repomd cached_repomd_xml_path in
+    let updateinfo_xml_gz_path =
+      Printf.sprintf "%s/%s-updateinfo.xml.gz" repo_dir md.checksum
+    in
+    begin match Sys.file_exists updateinfo_xml_gz_path with
+      | true ->
+        with_updateinfo_xml updateinfo_xml_gz_path (fun xml_file_path ->
+            ignore (Helpers.call_script cmd_modifyrepo
+                      ["--remove"; "updateinfo"; repo_dir ^ "/repodata"]);
+            ignore (Helpers.call_script cmd_modifyrepo
+                      ["--mdtype"; "updateinfo"; xml_file_path; repo_dir ^ "/repodata"]))
+      | false -> raise Api_errors.(Server_error (no_updateinfo_xml, []))
+    end
+  | false ->
+    error "local pool repository directory %s does not exists" !Xapi_globs.local_pool_repo_dir;
+    raise Api_errors.(Server_error (no_local_pool_repository, []))
+
+let with_pool_repository ~__context ~self ~prefix f =
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+        Mutex.lock exposing_pool_repo_mutex;
+        f ())
+    (fun () -> Mutex.unlock exposing_pool_repo_mutex)
+
+let is_local_pool_repo_enabled () =
+  match Mutex.try_lock exposing_pool_repo_mutex with
+  | true ->
+    Mutex.unlock exposing_pool_repo_mutex;
+    false
+  | false -> true
+
+let reposync_try_lock () =
+  Mutex.try_lock reposync_mutex
+
+let reposync_unlock () =
+  Mutex.unlock reposync_mutex
+
+let with_reposync_lock f =
+  if Mutex.try_lock reposync_mutex then
+    Xapi_stdext_pervasives.Pervasiveext.finally
+      (fun () -> f ())
+      (fun () -> Mutex.unlock reposync_mutex)
+  else
+    raise Api_errors.(Server_error (reposync_in_progress, []))
+
+let get_local_repomd_xml_path ~__context ~self ~prefix =
+  let name = Db.Repository.get_name_label ~__context ~self in
+  Printf.sprintf "%s/%s-%s/repodata/repomd.xml" !Xapi_globs.local_pool_repo_dir prefix name
+
+let try_set_available_updates ~__context ~self ~prefix =
+  let hosts = Db.Host.get_all ~__context in
+  let xml_path = get_local_repomd_xml_path ~__context ~self ~prefix in
+  let md = parse_repomd xml_path in
+  let hash = md.checksum in
+  let not_up_to_date host () =
+    let json = http_get_host_updates_in_json ~__context ~host ~installed:false in
+    (* TODO: live patches *)
+    match Yojson.Basic.Util.member "updates" json with
+    | `List [] -> false
+    | _ -> true
+    | exception e ->
+      let uuid = Db.Host.get_uuid ~__context ~self:host in
+      error "Invalid updates from host uuid='%s': %s" uuid (ExnHelper.string_of_exn e);
+      raise Api_errors.(Server_error (get_host_updates_failed, [uuid]))
+  in
+  let funs = List.map (fun h -> not_up_to_date h) hosts in
+  let rets_of_hosts = run_in_parallel funs capacity_in_parallel in
+  let is_all_up_to_date = not (List.exists (fun b -> b) rets_of_hosts) in
+  Db.Repository.set_up_to_date ~__context ~self  ~value:is_all_up_to_date;
+  Db.Repository.set_hash ~__context ~self ~value:hash;
+  hash
+
+let update_of_json j =
+  let open Yojson.Basic.Util in
+  let u = {
+    name = (member "name" j |> to_string);
+    arch = (member "arch" j |> to_string);
+    new_ver_rel = (member "newVerRel" j |> to_string);
+    old_ver_rel = (try Some (member "oldVerRel" j |> to_string) with _ -> None);
+    update_id = (member "updateId" j |> to_string)
+    }
+  in
+  let old_ver_rel = match u.old_ver_rel with
+    | Some vr -> vr
+    | None -> "<Unknown>"
+  in
+  debug "in update %s: %s.%s will be updated as %s -> %s"
+    u.update_id u.name u.arch old_ver_rel u.new_ver_rel;
+  u
+
+let get_pool_updates_in_json ~__context ~prefix ~hosts =
+  let ref = get_enabled_repository ~__context in
+  let hash = Db.Repository.get_hash ~__context ~self:ref in
+  let name = Db.Repository.get_name_label ~__context ~self:ref in
+  let updates_info = parse_updateinfo ~prefix ~name ~hash in
+  let updates_of_hosts, ids_of_updates = List.fold_left (fun (acc1, acc2) host ->
+      let updates =
+        http_get_host_updates_in_json ~__context ~host ~installed:true
+        |> Yojson.Basic.Util.member "updates"
+        |> Yojson.Basic.Util.to_list
+        |> List.map update_of_json
+      in
+      let rpms, uids = List.fold_left (fun (acc_rpms, acc_uids) u ->
+          ( ((Printf.sprintf "%s-%s.%s.rpm" u.name u.new_ver_rel u.arch) :: acc_rpms),
+            (UpdateIdSet.add u.update_id acc_uids) )
+        ) ([], UpdateIdSet.empty) updates
+      in
+      let rec_guidances = List.map (fun g -> `String g)
+          (eval_guidances ~updates_info ~updates ~kind:Recommended)
+      in
+      let abs_guidances = List.map (fun g -> `String g)
+          (eval_guidances ~updates_info ~updates ~kind:Absolute)
+      in
+      let json_of_host = `Assoc [
+          ("ref", `String (Ref.string_of host));
+          ("recommended-guidance", `List rec_guidances);
+          ("absolute-guidance", `List abs_guidances);
+          ("RPMS", `List (List.map (fun r -> `String r) rpms));
+          ("updates", `List (List.map (fun uid -> `String uid) (UpdateIdSet.elements uids)))]
+      in
+      ( (json_of_host :: acc1), (UpdateIdSet.union uids acc2) )
+    ) ([], UpdateIdSet.empty) hosts
+  in
+  `Assoc [
+    ("hosts", `List updates_of_hosts);
+    ("updates", `List (UpdateIdSet.elements ids_of_updates |> List.map (fun x -> `String x)));
+    ("hash", `String hash)]
+
+let get_repository_handler (req : Http.Request.t) s _ =
+  let open Http in
+  let open Xapi_stdext_std.Xstringext in
+  debug "Repository.get_repository_handler URL %s" req.Request.uri ;
+  req.Request.close <- true ;
+  match is_local_pool_repo_enabled () with
+  | true ->
+    (try
+      let repo_name =
+        let l = List.filter_map (fun n ->
+            let path = !Xapi_globs.local_pool_repo_dir ^ "/" ^ n in
+            let stat = Unix.lstat path in
+            begin match stat.Unix.st_kind = Unix.S_DIR with
+              | true -> Some n
+              | false -> None
+            end
+          ) (Array.to_list (Sys.readdir !Xapi_globs.local_pool_repo_dir))
+        in
+        begin match l with
+          | [d] -> d
+          | _ ->
+            let msg = "Multiple or no repositories are under local pool repository directory" in
+            raise Api_errors.(Server_error (internal_error, [msg]))
+        end
+      in
+      let resolved_path =
+        let len = String.length Constants.get_repository_uri in
+        begin match String.sub_to_end req.Request.uri len with
+          | untrusted_path ->
+            untrusted_path
+            |> Filename.concat repo_name
+            |> Filename.concat !Xapi_globs.local_pool_repo_dir
+            |> Uri.pct_decode
+            |> Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot
+          | exception e ->
+            let msg =
+              Printf.sprintf "Failed to get path from uri': %s" (ExnHelper.string_of_exn e)
+            in
+            raise Api_errors.(Server_error (internal_error, [msg]))
+        end
+      in
+      let p = !Xapi_globs.local_pool_repo_dir ^ "/" ^ repo_name ^ "/" in
+      begin match (String.startswith p resolved_path), (Sys.file_exists resolved_path) with
+        | true, true ->
+          Fileserver.response_file s resolved_path
+        | _ ->
+          error
+            "Rejecting request for file: %s (outside of or not existed in directory %s)"
+            resolved_path !Xapi_globs.local_pool_repo_dir;
+          Http_svr.response_forbidden ~req s
+      end
+    with e ->
+      error
+        "Failed to serve for request on uri %s: %s" req.Request.uri (ExnHelper.string_of_exn e);
+      Http_svr.response_forbidden ~req s)
+  | false ->
+    error "Rejecting request: local pool repository is not enabled";
+    Http_svr.response_forbidden ~req s

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -1,0 +1,86 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val introduce :
+     __context:Context.t
+  -> name_label:string
+  -> binary_url:string
+  -> source_url:string
+  -> [`Repository] API.Ref.t
+
+val forget :
+    __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> unit
+
+val get_host_updates_in_json :
+     __context:Context.t
+  -> installed:bool
+  -> uuid:string
+  -> Yojson.Basic.t
+
+val get_enabled_repository :
+     __context:Context.t
+  -> [`Repository] API.Ref.t
+
+val cleanup :
+     __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> prefix:string
+  -> unit
+
+val with_reposync_lock : (unit -> 'a) -> 'a
+
+val reposync_try_lock : unit -> bool
+
+val reposync_unlock : unit -> unit
+
+val sync:
+     __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> prefix:string
+  -> unit
+
+val create_pool_repository :
+     __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> prefix:string
+  -> unit
+
+val with_pool_repository :
+     __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> prefix:string
+  -> (unit -> 'a)
+  -> 'a
+
+val try_set_available_updates :
+     __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> prefix:string
+  -> string
+
+val get_pool_updates_in_json :
+     __context:Context.t 
+  -> prefix:string
+  -> hosts:[`host] API.Ref.t list
+  -> Yojson.Basic.t
+
+val get_repository_handler :
+     Http.Request.t
+  -> Unix.file_descr
+  -> 'a
+  -> unit
+
+val with_updateinfo_xml : string -> (string -> 'a) -> 'a

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -708,6 +708,9 @@ let master_only_http_handlers =
     ("post_remote_db_access", Http_svr.BufIO remote_database_access_handler)
   ; ( "post_remote_db_access_v2"
     , Http_svr.BufIO remote_database_access_handler_v2 )
+  ; ( "get_repository"
+    , Http_svr.FdIO Repository.get_repository_handler)
+  ; ("get_updates", Http_svr.FdIO Xapi_pool.get_updates_handler)
   ]
 
 let common_http_handlers =
@@ -765,6 +768,7 @@ let common_http_handlers =
   ; ("post_jsonrpc_options", Http_svr.BufIO Api_server.options_callback)
   ; ( "get_pool_update_download"
     , Http_svr.FdIO Xapi_pool_update.pool_update_download_handler )
+  ; ("get_host_updates", Http_svr.FdIO Xapi_host.get_host_updates_handler)
   ]
 
 let listen_unix_socket sock_path =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -830,6 +830,8 @@ let modprobe_path = ref "/usr/sbin/modprobe"
 
 let usb_path = "usb_path"
 
+let local_pool_repo_dir = ref "/var/lib/yum-mirror"
+
 (* The bfs-interfaces script returns boot from SAN NICs.
  * All ISCSI Boot Firmware Table (ibft) NICs should be marked
  * with PIF.managed = false and all FCoE boot from SAN * NICs
@@ -851,6 +853,12 @@ let sr_health_check_task_label = "SR Recovering"
 let domain_zero_domain_type = `pv
 
 let gen_pool_secret_script = ref "/usr/bin/pool_secret_wrapper"
+
+let repository_domain_name_whitelist = ref []
+
+let repository_prefix = ref "citrix"
+
+let repository_gpgcheck = ref true
 
 type xapi_globs_spec_ty = Float of float ref | Int of int ref
 
@@ -1129,6 +1137,15 @@ let other_options =
     , Arg.Set allow_host_sched_gran_modification
     , (fun () -> string_of_bool !allow_host_sched_gran_modification)
     , "Allows to modify the host's scheduler granularity" )
+  ; gen_list_option "repository-domain-name-whitelist"
+      "space-separated list of allowed domain name in base URL in repository."
+      (fun s -> s)
+      (fun s -> s)
+      repository_domain_name_whitelist
+  ; ( "repository-gpgcheck"
+    , Arg.Set repository_gpgcheck 
+    , (fun () -> string_of_bool !repository_gpgcheck)
+    , "turn gpgcheck on/off" )
   ]
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2432,3 +2432,21 @@ let get_sched_gran ~__context ~self =
     error "Failed to get sched-gran: %s" (Printexc.to_string e) ;
     raise
       Api_errors.(Server_error (internal_error, ["Failed to get sched-gran"]))
+
+let get_host_updates_handler (req : Http.Request.t) s _ =
+  let uuid = Helpers.get_localhost_uuid () in
+  debug "Xapi_host: received reqeust to get available updates on host uuid = '%s'" uuid;
+  req.Http.Request.close <- true;
+  let query = req.Http.Request.query in
+  Xapi_http.with_context "Getting available updates on host" req s (fun __context ->
+      let installed = match List.assoc "installed" query with
+          | v -> bool_of_string v
+          | exception Not_found -> false
+      in
+      let json_str = Yojson.Basic.pretty_to_string
+          (Repository.get_host_updates_in_json ~__context ~installed ~uuid)
+      in
+      let size = Int64.of_int (String.length json_str) in
+      Http_svr.headers s (Http.http_200_ok_with_content size ~keep_alive:false ()
+          @ [Http.Hdr.content_type ^ ": application/json"]);
+      Unixext.really_write_string s json_str |> ignore)

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -506,3 +506,9 @@ val set_sched_gran :
 
 val get_sched_gran :
   __context:Context.t -> self:API.ref_host -> API.host_sched_gran
+
+val get_host_updates_handler :
+     Http.Request.t
+  -> Unix.file_descr
+  -> 'a
+  -> unit

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -322,3 +322,19 @@ val remove_from_guest_agent_config :
   __context:Context.t -> self:API.ref_pool -> key:string -> unit
 
 val rotate_secret : __context:Context.t -> unit
+
+val set_repository :
+     __context:Context.t
+  -> value:[`Repository] API.Ref.t
+  -> unit
+
+val updates_sync :
+    __context:Context.t
+  -> force:bool
+  -> string
+
+val get_updates_handler :
+     Http.Request.t
+  -> Unix.file_descr
+  -> 'a
+  -> unit

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -25,7 +25,15 @@ let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 (* psr is not included in this list because it can be considered in progress
    in between api calls (i.e. wrapping it inside with_pool_operation won't work) *)
 let all_operations =
-  [`ha_enable; `ha_disable; `cluster_create; `designate_new_master]
+  [
+    `ha_enable
+  ; `ha_disable
+  ; `cluster_create
+  ; `designate_new_master
+  ; `set_repository
+  ; `updates_sync
+  ; `updates_list
+  ]
 
 (** Returns a table of operations -> API error options (None if the operation would be ok) *)
 let valid_operations ~__context record _ref' =
@@ -48,6 +56,9 @@ let valid_operations ~__context record _ref' =
     ; (`ha_disable, Api_errors.ha_disable_in_progress, [])
     ; (`cluster_create, Api_errors.cluster_create_in_progress, [])
     ; (`designate_new_master, Api_errors.designate_new_master_in_progress, [])
+    ; (`set_repository, Api_errors.set_repository_in_progress, [])
+    ; (`updates_sync, Api_errors.updates_sync_in_progress, [])
+    ; (`updates_list, Api_errors.updates_get_in_progress, [])
     ]
   in
   List.iter

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -201,6 +201,12 @@ sm-plugins=ext nfs iscsi lvmoiscsi dummy file hba rawhba udev iso lvm lvmohba lv
 # Path to xen-cmdline script
 # xen-cmdline-script = @LIBEXECDIR@/xen-cmdline
 
+# Whitelist of domain name pattern in binary-url and source-url in repository
+repository-domain-name-whitelist=cloud.com citrix.com
+
+# Turning on/off gpgcheck for remote YUM repository
+# repository-gpgcheck = true
+
 # Tweak timeouts: ################################################
 
 # If the slave's connection to the master blocks for longer than


### PR DESCRIPTION
This is a part of changes for repository functions in XAPI.

The repository function makes XAPI be able to get and apply updates which are
synced from a remote YUM repository.

In this commit, following details are implemented:
1. a new datamodel for repository and related changes on existing datamodels;
2. a new XAPI API pool.updates_sync;
3. a new XAPI HTTP GET endpoint "/udpates/" to get the details of available
updates.