### PR TITLE
CP-35372: Repository: pool.sync_updates

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5783,6 +5783,8 @@ let http_actions = [
   ("post_jsonrpc", (Post, Constants.jsonrpc_uri, false, [], _R_READ_ONLY, []));
   ("post_jsonrpc_options", (Options, Constants.jsonrpc_uri, false, [], _R_READ_ONLY, []));
   ("get_pool_update_download", (Get, Constants.get_pool_update_download_uri, false, [], _R_READ_ONLY, []));
+  ("get_repository", (Get, Constants.get_repository_uri, false, [], _R_READ_ONLY, []));
+  ("get_host_updates", (Get, Constants.get_host_updates_uri, false, [], _R_POOL_OP, []));
 ]
 
 (* these public http actions will NOT be checked by RBAC *)
@@ -5801,6 +5803,7 @@ let public_http_actions_with_no_rbac_check =
     "post_jsonrpc";
     "post_jsonrpc_options";
     "get_pool_update_download";
+    "get_repository";
   ]
 
 (* permissions not associated with any object message or field *)

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1223,7 +1223,7 @@ let _ =
     ~doc:"The repomd.xml is invalid." ();
   error Api_errors.invalid_updateinfo_xml []
     ~doc:"The updateinfo.xml is invalid." ();
-  error Api_errors.get_host_updates_failed ["uuid"]
+  error Api_errors.get_host_updates_failed ["ref"]
     ~doc:"Failed to get available updates from a host." ()
 
 

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1214,7 +1214,17 @@ let _ =
   error Api_errors.repository_cleanup_failed []
     ~doc:"Failed to clean up local repository on master." ();
   error Api_errors.no_repository_enabled []
-    ~doc:"There is no repository being enabled." ()
+    ~doc:"There is no repository being enabled." ();
+  error Api_errors.sync_updates_in_progress []
+    ~doc:"The operation could not be performed because syncing updates is in progress." ();
+  error Api_errors.reposync_failed []
+    ~doc:"Syning with remote YUM repository failed." ();
+  error Api_errors.invalid_repomd_xml []
+    ~doc:"The repomd.xml is invalid." ();
+  error Api_errors.invalid_updateinfo_xml []
+    ~doc:"The updateinfo.xml is invalid." ();
+  error Api_errors.get_host_updates_failed ["uuid"]
+    ~doc:"Failed to get available updates from a host." ()
 
 
 let _ =

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -9,6 +9,7 @@ open Datamodel_types
             "cluster_create", "Indicates this pool is in the process of creating a cluster";
             "designate_new_master", "Indicates this pool is in the process of changing master";
             "set_repository", "Indicates this pool is in the process of configuring repository";
+            "sync_updates", "Indicates this pool is in the process of syncing updates";
           ])
 
   let enable_ha = call
@@ -659,6 +660,18 @@ open Datamodel_types
       ~allowed_roles:_R_POOL_ADMIN
       ()
 
+  let sync_updates = call
+      ~name:"sync_updates"
+      ~in_product_since:rel_next
+      ~doc:"Sync with the enabled repository"
+      ~params:[
+        Ref _pool, "self", "The pool";
+        Bool, "force", "If true local mirroring repo will be removed before syncing"
+      ]
+      ~result:(String, "The SHA256 hash of updateinfo.xml.gz")
+      ~allowed_roles:_R_POOL_OP
+      ()
+
   (** A pool class *)
   let t =
     create_obj
@@ -734,6 +747,7 @@ open Datamodel_types
         ; remove_from_guest_agent_config
         ; rotate_secret
         ; set_repository
+        ; sync_updates
         ]
       ~contents:
         ([uid ~in_oss_since:None _pool] @

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -422,6 +422,14 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; implementation= No_fd Cli_operations.pool_rotate_secret
       ; flags= []
       } )
+  ; ( "pool-sync-updates"
+    , {
+        reqd= []
+      ; optn= ["force"]
+      ; help= "Sync updates from remote YUM repository, pool-wide."
+      ; implementation= With_fd Cli_operations.pool_sync_updates
+      ; flags= []
+      } )
   ; ( "host-is-in-emergency-mode"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -427,7 +427,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
         reqd= []
       ; optn= ["force"]
       ; help= "Sync updates from remote YUM repository, pool-wide."
-      ; implementation= With_fd Cli_operations.pool_sync_updates
+      ; implementation= No_fd Cli_operations.pool_sync_updates
       ; flags= []
       } )
   ; ( "host-is-in-emergency-mode"

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1635,7 +1635,7 @@ let pool_disable_ssl_legacy printer rpc session_id params =
 let pool_rotate_secret printer rpc session_id _params =
   Client.Pool.rotate_secret rpc session_id
 
-let pool_sync_updates fd printer rpc session_id params =
+let pool_sync_updates printer rpc session_id params =
   let pool = List.hd (Client.Pool.get_all rpc session_id) in
   let force = get_bool_param params "force" in
   let hash = Client.Pool.sync_updates rpc session_id pool force in

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1635,6 +1635,12 @@ let pool_disable_ssl_legacy printer rpc session_id params =
 let pool_rotate_secret printer rpc session_id _params =
   Client.Pool.rotate_secret rpc session_id
 
+let pool_sync_updates fd printer rpc session_id params =
+  let pool = List.hd (Client.Pool.get_all rpc session_id) in
+  let force = get_bool_param params "force" in
+  let hash = Client.Pool.sync_updates rpc session_id pool force in
+  printer (Cli_printer.PList [hash])
+
 let vdi_type_of_string = function
   | "system" ->
       `system

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -147,6 +147,8 @@ let pool_operation_to_string = function
       "designate_new_master"
   | `set_repository ->
       "set_repository"
+  | `sync_updates ->
+      "sync_updates"
 
 let host_operation_to_string = function
   | `provision ->

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1215,3 +1215,15 @@ let reposync_in_progress = "REPOSYNC_IN_PROGRESS"
 let repository_cleanup_failed = "REPOSITORY_CLEANUP_FAILED"
 
 let no_repository_enabled = "NO_REPOSITORY_ENABLED"
+
+let sync_updates_in_progress = "SYNC_UPDATES_IN_PROGRESS"
+
+let reposync_failed = "REPOSYNC_FAILED"
+
+let createrepo_failed = "CREATEREPO_FAILED"
+
+let invalid_updateinfo_xml = "INVALID_UPDATEINFO_XML"
+
+let get_host_updates_failed = "GET_HOST_UPDATES_FAILED"
+
+let invalid_repomd_xml = "INVALID_REPOMD_XML"

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -153,6 +153,10 @@ let get_pool_update_download_uri = "/update/"
 
 (* ocaml/xapi/xapi_pool_update.ml *)
 
+let get_repository_uri = "/repository" (* ocaml/xapi/repository.ml *)
+
+let get_host_updates_uri = "/host_updates" (* ocaml/xapi/repository.ml *)
+
 let default_usb_speed = -1.
 
 let use_compression = "use_compression"

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1326,13 +1326,46 @@ let resolve_uri_path ~root ~uri_path =
   |> Filename.concat root
   |> Uri.pct_decode
   |> Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot
-  |> (fun x -> match (String.startswith (root^"/") x), (Sys.file_exists x) with
+  |> (fun x -> match (Astring.String.is_prefix ~affix:(root^"/") x), (Sys.file_exists x) with
       | true, true -> x
       | _ ->
         let msg =
           Printf.sprintf "Failed to resolve uri path '%s' under '%s': %s" uri_path root x
         in
         raise Api_errors.(Server_error (internal_error, [msg])))
+
+let run_in_parallel ~funs ~capacity =
+  let rec run_in_parallel' acc funs capacity =
+    let rec split_for_first_n acc n l =
+      match n, l with
+      | n, h::t when n > 0 -> split_for_first_n (h :: acc) (n - 1) t
+      | _ -> acc, l
+    in
+    let run f =
+      let result = ref `Not_started in
+      let wrapper r = try r := `Succ (f ()) with e -> r := `Fail e in
+      let th = Thread.create wrapper result in
+      th, result
+    in
+    let get_result (th, result) =
+      Thread.join th;
+      match !result with
+      | `Not_started -> `Error (Failure "The thread in run_in_parallel is not started")
+      | `Succ s -> `Ok s
+      | `Fail e -> `Error e
+    in
+    let to_be_run, remaining = split_for_first_n [] capacity funs in
+    match to_be_run with
+    | [] -> acc
+    | _ ->
+      let finished =
+        List.map run to_be_run
+        |> List.map get_result
+        |> List.map (function `Ok s -> s | `Error e -> raise e)
+      in
+      run_in_parallel' (List.rev_append finished acc) remaining capacity
+  in
+  run_in_parallel' [] funs capacity
 
 (**************************************************************************************)
 (* The master uses a global mutex to mark database records before forwarding messages *)

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1320,6 +1320,20 @@ let rmtree path =
     let msg = Printf.sprintf "failed to remove %s: %s" path exn' in
     failwith msg
 
+let resolve_uri_path ~root ~uri_path =
+  let open Xapi_stdext_std.Xstringext in
+  uri_path
+  |> Filename.concat root
+  |> Uri.pct_decode
+  |> Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot
+  |> (fun x -> match (String.startswith (root^"/") x), (Sys.file_exists x) with
+      | true, true -> x
+      | _ ->
+        let msg =
+          Printf.sprintf "Failed to resolve uri path '%s' under '%s': %s" uri_path root x
+        in
+        raise Api_errors.(Server_error (internal_error, [msg])))
+
 (**************************************************************************************)
 (* The master uses a global mutex to mark database records before forwarding messages *)
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -899,6 +899,11 @@ functor
         info "Pool.set_repository : pool = '%s'; value = %s"
           (pool_uuid ~__context self) (repository_uuid ~__context value);
         Local.Pool.set_repository ~__context ~self ~value
+
+      let sync_updates ~__context ~self ~force =
+        info "Pool.sync_updates: pool = '%s'; false = %s"
+          (pool_uuid ~__context self) (string_of_bool force);
+        Local.Pool.sync_updates ~__context ~self ~force
     end
 
     module VM = struct

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -18,7 +18,22 @@ module D = Debug.Make (struct let name = "repository" end)
 
 open D
 
+let capacity_in_parallel = 16
+
 let reposync_mutex = Mutex.create ()
+let exposing_pool_repo_mutex = Mutex.create ()
+
+type updateinfo_md = {
+    checksum: string
+  ; location: string
+}
+
+type pkg = {
+    name: string
+  ; version: string
+  ; release: string
+  ; arch: string
+}
 
 let create_repository_record ~__context ~name_label ~name_description ~binary_url ~source_url =
   let ref = Ref.make () in
@@ -39,7 +54,7 @@ let assert_url_is_valid ~url =
   try
     let uri = Uri.of_string url in
     match Uri.scheme uri with
-    | Some "http" | Some "https" -> 
+    | Some "http" | Some "https" ->
       begin match Uri.host uri with
         | Some h ->
           begin match !Xapi_globs.repository_domain_name_allowlist with
@@ -90,7 +105,7 @@ let get_enabled_repository ~__context =
   match Db.Pool.get_repository ~__context ~self:pool with
   | ref when ref <> Ref.null -> ref
   | _ ->
-      raise Api_errors.(Server_error (no_repository_enabled, []))
+    raise Api_errors.(Server_error (no_repository_enabled, []))
 
 let clean_yum_cache name =
   try
@@ -114,3 +129,476 @@ let cleanup_pool_repo () =
   with e ->
     error "Failed to cleanup pool repository: %s" (ExnHelper.string_of_exn e);
     raise Api_errors.(Server_error (repository_cleanup_failed, []))
+
+let remove_repo_conf_file repo_name =
+  let path = Filename.concat !Xapi_globs.yum_repos_config_dir (repo_name ^ ".repo") in
+  Unixext.unlink_safe path
+
+let write_yum_config ?(source_url=None) binary_url repo_name =
+  let file_path = Filename.concat !Xapi_globs.yum_repos_config_dir (repo_name ^ ".repo") in
+  let content_of_binary =
+    [
+      Printf.sprintf "[%s]" repo_name;
+      Printf.sprintf "name=%s" repo_name;
+      Printf.sprintf "baseurl=%s" binary_url;
+      "enabled=0";
+      if !Xapi_globs.repository_gpgcheck then "gpgcheck=1" else "gpgcheck=0";
+      Printf.sprintf "gpgkey=file://%s" !Xapi_globs.gpgkey_path
+    ]
+  in
+  let content_of_source =
+    match source_url with
+    | None -> []
+    | Some url ->
+      [
+        "";
+        Printf.sprintf "[%s-source]" repo_name;
+        Printf.sprintf "name=%s-source" repo_name;
+        Printf.sprintf "baseurl=%s" url;
+        "enabled=0";
+        if !Xapi_globs.repository_gpgcheck then "gpgcheck=1" else "gpgcheck=0";
+        Printf.sprintf "gpgkey=file://%s" !Xapi_globs.gpgkey_path
+      ]
+  in
+  let content = String.concat "\n" (content_of_binary @ content_of_source) in
+  Unixext.atomic_write_to_file file_path 0o400 (fun fd ->
+    Unixext.really_write_string fd content |> ignore)
+
+let sync ~__context ~self =
+  try
+    remove_repo_conf_file !Xapi_globs.pool_repo_name;
+    let binary_url = Db.Repository.get_binary_url  ~__context ~self in
+    let source_url = Db.Repository.get_source_url  ~__context ~self in
+    write_yum_config ~source_url:(Some source_url) binary_url !Xapi_globs.pool_repo_name;
+    let config_params =
+        [
+          "--save";
+          if !Xapi_globs.repository_gpgcheck then "--setopt=repo_gpgcheck=1"
+          else "--setopt=repo_gpgcheck=0";
+          Printf.sprintf "%s" !Xapi_globs.pool_repo_name;
+        ]
+    in
+    ignore (Helpers.call_script !Xapi_globs.yum_config_manager_cmd config_params);
+    (* sync with remote repository *)
+    let sync_params =
+        [
+          "-p"; !Xapi_globs.local_pool_repo_dir;
+          "--downloadcomps";
+          "--download-metadata";
+          if !Xapi_globs.repository_gpgcheck then "--gpgcheck" else "";
+          "--delete";
+          Printf.sprintf "--repoid=%s" !Xapi_globs.pool_repo_name;
+        ]
+    in
+    Unixext.mkdir_rec !Xapi_globs.local_pool_repo_dir 0o700;
+    clean_yum_cache !Xapi_globs.pool_repo_name;
+    ignore (Helpers.call_script !Xapi_globs.reposync_cmd sync_params)
+  with e ->
+    error "Failed to sync with remote YUM repository: %s" (ExnHelper.string_of_exn e);
+    raise Api_errors.(Server_error (reposync_failed, []))
+
+let with_pool_repository f =
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+        Mutex.lock exposing_pool_repo_mutex;
+        f ())
+    (fun () -> Mutex.unlock exposing_pool_repo_mutex)
+
+let parse_repomd xml_path =
+  let assert_valid_repomd = function
+    | { checksum = ""; _ } | { location = ""; _ } ->
+      error "Missing 'checksum' or 'location' in updateinfo in repomod.xml";
+      raise Api_errors.(Server_error (invalid_repomd_xml, []))
+    | umd -> umd
+  in
+  match Sys.file_exists xml_path with
+  | false ->
+    error "No repomd.xml found: %s" xml_path;
+    raise Api_errors.(Server_error (invalid_repomd_xml, []))
+  | true ->
+    begin match Xml.parse_file xml_path with
+     | Xml.Element ("repomd", _, children) ->
+       let get_updateinfo_node = function
+         | Xml.Element ("data", attrs, nodes) ->
+           (match List.assoc_opt "type" attrs with
+            | Some "updateinfo" -> Some nodes
+            | _ -> None)
+         | _ -> None
+       in
+       begin match List.filter_map get_updateinfo_node children with
+        | [l] ->
+          List.fold_left (fun md n ->
+              begin match n with
+                | Xml.Element ("checksum", _, [Xml.PCData v]) -> {md with checksum = v}
+                | Xml.Element ("location", attrs, _) ->
+                  (try {md with location = (List.assoc "href" attrs)}
+                   with _ ->
+                     error "Failed to get location of updateinfo.xml.gz";
+                     raise Api_errors.(Server_error (invalid_repomd_xml, [])))
+                | _ -> md
+              end
+            ) { checksum = ""; location = "" } l
+          |> assert_valid_repomd
+        | _ ->
+          error "Missing or multiple 'updateinfo' node(s)";
+          raise Api_errors.(Server_error (invalid_repomd_xml, []))
+       end
+     | _ ->
+       error "Missing 'repomd' node";
+       raise Api_errors.(Server_error (invalid_repomd_xml, []))
+     | exception e ->
+       error "Failed to parse repomd.xml: %s" (ExnHelper.string_of_exn e);
+       raise Api_errors.(Server_error (invalid_repomd_xml, []))
+    end
+
+let run_in_parallel ~funs ~capacity =
+  let rec run_in_parallel' acc funs capacity =
+    let rec split_for_first_n acc n l =
+      match n, l with
+      | n, h::t when n > 0 -> split_for_first_n (h :: acc) (n - 1) t
+      | _ -> acc, l
+    in
+    let run f =
+      let result = ref `Not_started in
+      let wrapper r = try r := `Succ (f ()) with e -> r := `Fail e in
+      let th = Thread.create wrapper result in
+      th, result
+    in
+    let get_result (th, result) =
+      Thread.join th;
+      match !result with
+      | `Not_started -> `Error (Failure "The thread in run_in_parallel is not started")
+      | `Succ s -> `Ok s
+      | `Fail e -> `Error e
+    in
+    let to_be_run, remaining = split_for_first_n [] capacity funs in
+    match to_be_run with
+    | [] -> acc
+    | _ ->
+      let finished =
+        List.map run to_be_run
+        |> List.map get_result
+        |> List.map (function `Ok s -> s | `Error e -> raise e)
+      in
+      run_in_parallel' (List.rev_append finished acc) remaining capacity
+  in
+  run_in_parallel' [] funs capacity
+
+let http_get_host_updates_in_json ~__context ~host ~installed =
+  let host_session_id =
+    Xapi_session.login_no_password ~__context ~uname:None ~host ~pool:true
+      ~is_local_superuser:true ~subject:Ref.null ~auth_user_sid:""
+      ~auth_user_name:"" ~rbac_permissions:[]
+  in
+  let request = Xapi_http.http_request
+      ~cookie:[("session_id", Ref.string_of host_session_id)]
+      ~query:[("installed", (string_of_bool installed))]
+      Http.Get Constants.get_host_updates_uri
+  in
+  let host_name = (Db.Host.get_hostname ~__context ~self:host) in
+  let host_addr = Db.Host.get_address ~__context ~self:host in
+  let open Xmlrpc_client in
+  let transport = SSL (SSL.make () ~verify_cert:false, host_addr, !Constants.https_port) in
+  debug "getting host updates on %s (addr %s) by HTTP GET" host_name host_addr;
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+      try
+        let json_str =
+          with_transport transport
+            (with_http request (fun (response, fd) ->
+                 Xapi_stdext_unix.Unixext.string_of_fd fd))
+        in
+        debug "host %s returned updates: %s" host_name json_str;
+        Yojson.Basic.from_string json_str
+      with e ->
+        let uuid = Db.Host.get_uuid ~__context ~self:host in
+        error "Failed to get updates from host uuid='%s': %s" uuid (ExnHelper.string_of_exn e);
+        raise Api_errors.(Server_error (get_host_updates_failed, [uuid])))
+    (fun () -> Xapi_session.destroy_db_session ~__context ~self:host_session_id)
+
+let set_available_updates ~__context ~self =
+  let hosts = Db.Host.get_all ~__context in
+  let xml_path =
+    "repodata/repomd.xml"
+    |> Filename.concat !Xapi_globs.pool_repo_name
+    |> Filename.concat !Xapi_globs.local_pool_repo_dir
+  in
+  let md = parse_repomd xml_path in
+  let are_updates_available host () =
+    let json = http_get_host_updates_in_json ~__context ~host ~installed:false in
+    (* TODO: live patches *)
+    match Yojson.Basic.Util.member "updates" json with
+    | `List [] -> false
+    | _ -> true
+    | exception e ->
+      let uuid = Db.Host.get_uuid ~__context ~self:host in
+      error "Invalid updates from host uuid='%s': %s" uuid (ExnHelper.string_of_exn e);
+      raise Api_errors.(Server_error (get_host_updates_failed, [uuid]))
+  in
+  let funs = List.map (fun h -> are_updates_available h) hosts in
+  let rets_of_hosts = run_in_parallel funs capacity_in_parallel in
+  let is_all_up_to_date = not (List.exists (fun b -> b) rets_of_hosts) in
+  Db.Repository.set_up_to_date ~__context ~self ~value:is_all_up_to_date;
+  Db.Repository.set_hash ~__context ~self ~value:(md.checksum);
+  md.checksum
+
+let get_cachedir repo_name =
+  let config_params = [repo_name] in
+  Helpers.call_script !Xapi_globs.yum_config_manager_cmd config_params
+  |> Astring.String.cuts ~sep:"\n"
+  |> List.filter_map (fun kv ->
+      match Astring.String.is_prefix ~affix:"cachedir =" kv with
+      | true -> Some (Scanf.sscanf kv "cachedir = %s" (fun x -> x))
+      | false -> None)
+  |> (function
+      | [x] -> x
+      | _ ->
+        let msg = Printf.sprintf "Not found cachedir for repository %s" repo_name in
+        raise Api_errors.(Server_error (internal_error, [msg])))
+
+let with_updateinfo_xml gz_path f =
+  let tmpfile, tmpch = Filename.open_temp_file ~mode:[Open_text] "updateinfo" ".xml" in
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+      Xapi_stdext_pervasives.Pervasiveext.finally
+        (fun () ->
+           try
+             Unixext.with_file gz_path [Unix.O_RDONLY] 0o0
+               (fun gz_fd_in ->
+                  Gzip.decompress_passive gz_fd_in (fun fd_in ->
+                      let ic = Unix.in_channel_of_descr fd_in in
+                      try
+                        while true do
+                          let line = input_line ic in
+                          output_string tmpch (line ^ "\n")
+                        done
+                      with End_of_file -> ()))
+           with e ->
+             error "Failed to decompress updateinfo.xml.gz: %s" (ExnHelper.string_of_exn e);
+             raise Api_errors.(Server_error (invalid_updateinfo_xml, [])))
+        (fun () -> close_out tmpch);
+      f tmpfile)
+    (fun () -> Unixext.unlink_safe tmpfile)
+
+let create_pool_repository ~__context ~self =
+  let repo_dir = Filename.concat !Xapi_globs.local_pool_repo_dir !Xapi_globs.pool_repo_name in
+  match Sys.file_exists repo_dir with
+  | true ->
+    (try
+       let cachedir = get_cachedir !Xapi_globs.pool_repo_name in
+       let md = parse_repomd (Filename.concat cachedir "repomd.xml") in
+       let updateinfo_xml_gz_path =
+         Filename.concat repo_dir (md.checksum ^ "-updateinfo.xml.gz")
+       in
+       ignore (Helpers.call_script !Xapi_globs.createrepo_cmd [repo_dir]);
+       begin match Sys.file_exists updateinfo_xml_gz_path with
+         | true ->
+           with_updateinfo_xml updateinfo_xml_gz_path (fun xml_file_path ->
+               let repodata_dir = Filename.concat repo_dir "repodata" in
+               ignore (Helpers.call_script !Xapi_globs.modifyrepo_cmd
+                         ["--remove"; "updateinfo"; repodata_dir]);
+               ignore (Helpers.call_script !Xapi_globs.modifyrepo_cmd
+                         ["--mdtype"; "updateinfo"; xml_file_path; repodata_dir]));
+           with_pool_repository (fun () ->
+               set_available_updates ~__context ~self)
+         | false ->
+           error "No updateinfo.xml.gz found: %s" updateinfo_xml_gz_path;
+           raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+       end
+     with
+     | Api_errors.(Server_error (code, _)) as e when code <> Api_errors.internal_error ->
+       raise e
+     | e ->
+       error "Creating local pool repository failed: %s" (ExnHelper.string_of_exn e);
+       raise Api_errors.(Server_error (createrepo_failed, [])))
+  | false ->
+    error "local pool repository directory '%s' does not exist" repo_dir;
+    raise Api_errors.(Server_error (reposync_failed, []))
+
+let with_local_repository ~__context f =
+  let master_addr =
+    try Pool_role.get_master_address ()
+    with Pool_role.This_host_is_a_master ->
+      Option.get (Helpers.get_management_ip_addr ~__context)
+  in
+  let url = Printf.sprintf "https://%s/repository/" master_addr in
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () ->
+      remove_repo_conf_file !Xapi_globs.local_repo_name;
+      write_yum_config url !Xapi_globs.local_repo_name;
+      let config_params =
+          [
+            "--save";
+            Printf.sprintf "--setopt=%s.sslverify=false" !Xapi_globs.local_repo_name;
+            !Xapi_globs.local_repo_name
+          ]
+      in
+      ignore (Helpers.call_script !Xapi_globs.yum_config_manager_cmd config_params);
+      f ())
+    (fun () -> remove_repo_conf_file !Xapi_globs.local_repo_name)
+
+let assert_yum_error output =
+  let errors = ["Updateinfo file is not valid XML"] in
+  let open Xapi_stdext_std.Xstringext in
+  List.iter (fun err ->
+    if String.has_substr output err then (
+      error "Error from 'yum updateinfo list': %s" err;
+      raise Api_errors.(Server_error (invalid_updateinfo_xml, [])))
+    else ()) errors;
+  output
+
+let pkg_of_fullname s =
+  (* s I.E. "libpath-utils-0.2.1-29.el7.x86_64" *)
+  let r = Re.Str.regexp "^\\(.+\\)\\.\\(noarch\\|x86_64\\)$" in
+  match Re.Str.string_match r s 0 with
+  | true ->
+    (try
+       let pkg = Re.Str.replace_first r "\\1" s in (* pkg is, e.g. "libpath-utils-0.2.1-29.el7" *)
+       let arch = Re.Str.replace_first r "\\2" s in (* arch is "<noarch|x86_64>" *)
+       let pos1 = String.rindex pkg '-' in
+       let pos2 = String.rindex_from pkg (pos1 - 1) '-' in
+       let release = String.sub pkg (pos1 + 1) ((String.length pkg) - pos1 - 1) in
+       let version = String.sub pkg (pos2 + 1) (pos1 - pos2 - 1) in
+       let name = String.sub pkg 0 pos2 in
+       Some { name; version; release; arch }
+     with e ->
+       let msg =
+         Printf.sprintf "Failed to split rpm name '%s': %s" s (ExnHelper.string_of_exn e) in
+       raise Api_errors.(Server_error (internal_error, [msg])))
+  | false -> None
+
+let json_of_pkg pkg =
+  `Assoc [
+    ("version", `String pkg.version);
+    ("release", `String pkg.release);
+  ]
+
+let name_arch_of_pkg pkg =
+  pkg.name ^ "." ^ pkg.arch
+
+let get_updates_from_updateinfo () =
+  let params_of_updateinfo_list =
+    [
+      "-q"; "--disablerepo=*"; Printf.sprintf "--enablerepo=%s" !Xapi_globs.local_repo_name;
+      "updateinfo"; "list"; "updates";
+    ]
+  in
+  let sep = Re.Str.regexp " +" in
+  Helpers.call_script !Xapi_globs.yum_cmd params_of_updateinfo_list
+  |> assert_yum_error
+  |> Astring.String.cuts ~sep:"\n"
+  |> List.filter_map (fun line ->
+      match Re.Str.split sep line with
+      | update_id :: _ :: full_name :: []  ->
+        begin match pkg_of_fullname full_name with
+          | Some pkg -> Some ((name_arch_of_pkg pkg), update_id)
+          | None -> None
+        end
+      | _ ->
+        debug "Ignore unrecognized line '%s' in parsing updateinfo list" line;
+        None)
+
+let get_installed_pkgs () =
+  Helpers.call_script !Xapi_globs.rpm_cmd ["-qa"]
+  |> Astring.String.cuts ~sep:"\n"
+  |> List.filter_map pkg_of_fullname
+  |> List.map (fun pkg -> ((name_arch_of_pkg pkg), pkg))
+
+let get_host_updates_in_json ~__context ~installed =
+  try
+    with_local_repository ~__context (fun () ->
+      let rpm2updates = get_updates_from_updateinfo () in
+      let installed_pkgs = match installed with
+        | true -> get_installed_pkgs ()
+        | false -> []
+      in
+      let params_of_list =
+        [
+          "-q"; "--disablerepo=*"; Printf.sprintf "--enablerepo=%s" !Xapi_globs.local_repo_name;
+          "list"; "updates";
+        ]
+      in
+      let sep = Re.Str.regexp " +" in
+      let updates =
+        clean_yum_cache !Xapi_globs.local_repo_name;
+        Helpers.call_script !Xapi_globs.yum_cmd params_of_list
+        |> Astring.String.cuts ~sep:"\n"
+        |> List.filter_map (fun line ->
+            match Re.Str.split sep line with
+            | "Updated" :: "Packages" :: [] -> None
+            | name_arch :: ver_rel :: repo :: [] when repo = !Xapi_globs.local_repo_name ->
+              (* xsconsole.x86_64  10.1.11-34  local-normal *)
+              begin match Astring.String.cuts ~sep:"." name_arch,
+                          Astring.String.cuts ~sep:"-" ver_rel with
+                | name :: arch :: [], version :: release :: [] ->
+                  let new_pkg = { name; version; release; arch } in
+                  let uid_in_json = match List.assoc_opt name_arch rpm2updates with
+                    | Some s -> `String s
+                    | None ->
+                      warn "No update ID found for %s" name_arch;
+                      `Null
+                  in
+                  let l1 = [("name", `String name);
+                            ("arch", `String arch);
+                            ("newVerRel", (json_of_pkg new_pkg));
+                            ("updateId", uid_in_json)]
+                  in
+                  let l2 = match List.assoc_opt name_arch installed_pkgs with
+                    | Some old_pkg ->
+                      [("oldVerRel", (json_of_pkg old_pkg))]
+                    | None -> []
+                  in
+                  Some (`Assoc (l1 @ l2))
+                | _ ->
+                  warn "Can't parse %s and %s" name_arch ver_rel;
+                  None
+              end
+            | _ ->
+              debug "Ignore unrecognized line '%s' in parsing updates list" line;
+              None)
+      in
+      (* TODO: live patches *)
+      `Assoc [("updates", `List updates)])
+  with
+  | Api_errors.(Server_error (code, _)) as e when code <> Api_errors.internal_error ->
+    raise e
+  | e ->
+    let uuid = Helpers.get_localhost_uuid () in
+    error "Failed to get host updates: %s" (ExnHelper.string_of_exn e);
+    raise Api_errors.(Server_error (get_host_updates_failed, [uuid]))
+
+let is_local_pool_repo_enabled () =
+  match Mutex.try_lock exposing_pool_repo_mutex with
+  | true ->
+    Mutex.unlock exposing_pool_repo_mutex;
+    false
+  | false -> true
+
+let get_repository_handler (req : Http.Request.t) s _ =
+  let open Http in
+  let open Xapi_stdext_std.Xstringext in
+  debug "Repository.get_repository_handler URL %s" req.Request.uri ;
+  req.Request.close <- true ;
+  match is_local_pool_repo_enabled () with
+  | true ->
+    (try
+        let len = String.length Constants.get_repository_uri in
+        begin match String.sub_to_end req.Request.uri len with
+          | uri_path ->
+            let root = Filename.concat
+                !Xapi_globs.local_pool_repo_dir !Xapi_globs.pool_repo_name
+            in
+            Fileserver.response_file s (Helpers.resolve_uri_path ~root ~uri_path)
+          | exception e ->
+            let msg =
+              Printf.sprintf "Failed to get path from uri': %s" (ExnHelper.string_of_exn e)
+            in
+            raise Api_errors.(Server_error (internal_error, [msg]))
+        end
+    with e ->
+      error
+        "Failed to serve for request on uri %s: %s" req.Request.uri (ExnHelper.string_of_exn e);
+      Http_svr.response_forbidden ~req s)
+  | false ->
+    error "Rejecting request: local pool repository is not enabled";
+    Http_svr.response_forbidden ~req s

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -32,3 +32,24 @@ val get_enabled_repository :
 val cleanup_pool_repo  : unit -> unit
 
 val with_reposync_lock : (unit -> 'a) -> 'a
+
+val sync:
+     __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> unit
+
+val create_pool_repository :
+     __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> string
+
+val get_repository_handler :
+     Http.Request.t
+  -> Unix.file_descr
+  -> 'a
+  -> unit
+
+val get_host_updates_in_json :
+     __context:Context.t
+  -> installed:bool
+  -> Yojson.Basic.t

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -708,6 +708,7 @@ let master_only_http_handlers =
     ("post_remote_db_access", Http_svr.BufIO remote_database_access_handler)
   ; ( "post_remote_db_access_v2"
     , Http_svr.BufIO remote_database_access_handler_v2 )
+  ; ( "get_repository", Http_svr.FdIO Repository.get_repository_handler)
   ]
 
 let common_http_handlers =
@@ -765,6 +766,7 @@ let common_http_handlers =
   ; ("post_jsonrpc_options", Http_svr.BufIO Api_server.options_callback)
   ; ( "get_pool_update_download"
     , Http_svr.FdIO Xapi_pool_update.pool_update_download_handler )
+  ; ("get_host_updates", Http_svr.FdIO Xapi_host.get_host_updates_handler)
   ]
 
 let listen_unix_socket sock_path =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -874,7 +874,9 @@ let modifyrepo_cmd = ref "/usr/bin/modifyrepo_c"
 
 let rpm_cmd = ref "/usr/bin/rpm"
 
-let gpgkey_path = ref "/etc/pki/rpm-gpg/RPM-GPG-KEY-Citrix"
+let rpm_gpgkey_dir = ref "/etc/pki/rpm-gpg"
+
+let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
 
@@ -1164,6 +1166,10 @@ let other_options =
     , Arg.Set repository_gpgcheck
     , (fun () -> string_of_bool !repository_gpgcheck)
     , "turn gpgcheck on/off" )
+  ; ( "repository-gpgkey-name"
+    , Arg.Set_string repository_gpgkey_name
+    , (fun () -> !repository_gpgkey_name)
+    , "The name of gpg key used by RPM to verify metadata and packages in repository" )
   ]
 
 let all_options = options_of_xapi_globs_spec @ other_options

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -862,6 +862,22 @@ let yum_repos_config_dir  = ref "/etc/yum.repos.d"
 
 let pool_repo_name = ref "remote"
 
+let local_repo_name = ref "local"
+
+let yum_config_manager_cmd = ref "/usr/bin/yum-config-manager"
+
+let reposync_cmd = ref "/usr/bin/reposync"
+
+let createrepo_cmd = ref "/usr/bin/createrepo_c"
+
+let modifyrepo_cmd = ref "/usr/bin/modifyrepo_c"
+
+let rpm_cmd = ref "/usr/bin/rpm"
+
+let gpgkey_path = ref "/etc/pki/rpm-gpg/RPM-GPG-KEY-Citrix"
+
+let repository_gpgcheck = ref true
+
 type xapi_globs_spec_ty = Float of float ref | Int of int ref
 
 let xapi_globs_spec =
@@ -1144,6 +1160,10 @@ let other_options =
       (fun s -> s)
       (fun s -> s)
       repository_domain_name_allowlist
+  ; ( "repository-gpgcheck"
+    , Arg.Set repository_gpgcheck
+    , (fun () -> string_of_bool !repository_gpgcheck)
+    , "turn gpgcheck on/off" )
   ]
 
 let all_options = options_of_xapi_globs_spec @ other_options
@@ -1231,6 +1251,21 @@ module Resources = struct
     ; ( "yum-cmd"
       , yum_cmd
       , "Path to yum command" )
+    ; ( "reposync-cmd"
+      , reposync_cmd
+      , "Path to reposync command" )
+    ; ( "createrepo-cmd"
+      , createrepo_cmd
+      , "Path to createrepo command" )
+    ; ( "modifyrepo-cmd"
+      , modifyrepo_cmd
+      , "Path to modifyrepo command" )
+    ; ( "rpm-cmd"
+      , rpm_cmd
+      , "Path to rpm command" )
+    ; ( "yum-config-manager-cmd"
+      , yum_config_manager_cmd
+      , "Path to yum-config-manager command" )
     ]
 
   let nonessential_executables =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2432,3 +2432,21 @@ let get_sched_gran ~__context ~self =
     error "Failed to get sched-gran: %s" (Printexc.to_string e) ;
     raise
       Api_errors.(Server_error (internal_error, ["Failed to get sched-gran"]))
+
+let get_host_updates_handler (req : Http.Request.t) s _ =
+  let uuid = Helpers.get_localhost_uuid () in
+  debug "Xapi_host: received request to get available updates on host uuid = '%s'" uuid;
+  req.Http.Request.close <- true;
+  let query = req.Http.Request.query in
+  Xapi_http.with_context "Getting available updates on host" req s (fun __context ->
+      let installed = match List.assoc "installed" query with
+          | v -> bool_of_string v
+          | exception Not_found -> false
+      in
+      let json_str = Yojson.Basic.pretty_to_string
+          (Repository.get_host_updates_in_json ~__context ~installed)
+      in
+      let size = Int64.of_int (String.length json_str) in
+      Http_svr.headers s (Http.http_200_ok_with_content size ~keep_alive:false ()
+          @ [Http.Hdr.content_type ^ ": application/json"]);
+      Unixext.really_write_string s json_str |> ignore)

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -506,3 +506,9 @@ val set_sched_gran :
 
 val get_sched_gran :
   __context:Context.t -> self:API.ref_host -> API.host_sched_gran
+
+val get_host_updates_handler :
+     Http.Request.t
+  -> Unix.file_descr
+  -> 'a
+  -> unit

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -328,3 +328,9 @@ val set_repository :
   -> self:API.ref_pool
   -> value:[`Repository] API.Ref.t
   -> unit
+
+val sync_updates :
+    __context:Context.t
+  -> self:API.ref_pool
+  -> force:bool
+  -> string

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -31,6 +31,7 @@ let all_operations =
   ; `cluster_create
   ; `designate_new_master
   ; `set_repository
+  ; `sync_updates
   ]
 
 (** Returns a table of operations -> API error options (None if the operation would be ok) *)
@@ -55,6 +56,7 @@ let valid_operations ~__context record _ref' =
     ; (`cluster_create, Api_errors.cluster_create_in_progress, [])
     ; (`designate_new_master, Api_errors.designate_new_master_in_progress, [])
     ; (`set_repository, Api_errors.set_repository_in_progress, [])
+    ; (`sync_updates, Api_errors.sync_updates_in_progress, [])
     ]
   in
   List.iter


### PR DESCRIPTION
This commit implements 'pool.sync_updates' API for repository function.

The handler of this API will:
1. sync/download latest updates and metadata from remote repository;
2. create local repository on the master host in the pool;
3. check if there are available updates on each host in the pool.

Signed-off-by: Ming Lu <ming.lu@citrix.com>