### PR TITLE
XSI-804 ensure HVM boot params consistent

### DIFF
--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -163,6 +163,8 @@ let hvm_boot_policy_bios_order = "BIOS order"
    Value is the boot string we send to qemu-dm (eg cd, dc, dcn, etc) *)
 let hvm_boot_params_order = "order"
 
+let hvm_default_boot_order = "cd"
+
 (* Key we put in VM.other_config when we upgrade a VM from Zurich/Geneva to Rio *)
 let vm_upgrade_time = "upgraded at"
 

--- a/ocaml/xapi/import_xva.ml
+++ b/ocaml/xapi/import_xva.ml
@@ -71,7 +71,13 @@ let make __context rpc session_id srid (vms, vdis) =
             other_platform
       in
       let hVM_boot_policy = if vm.is_hvm then "BIOS order" else "" in
-      let hVM_boot_params = if vm.is_hvm then [("order", "cd")] else [] in
+      let hVM_boot_params =
+        if vm.is_hvm then
+          let open Constants in
+          [(hvm_boot_params_order, hvm_default_boot_order)]
+        else
+          []
+      in
       let domain_type = Xapi_vm_helpers.derive_domain_type ~hVM_boot_policy in
       let vm_ref =
         Client.VM.create ~rpc ~session_id ~name_label:(vm.vm_name ^ " import")

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -412,7 +412,9 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough vgpu =
     ; boot_order=
         (* XSI-804 avoid boot orders which are the empty string, as qemu
          * will silently fail to start the VM *)
-        assume_default_if_null_empty vm.API.vM_HVM_boot_params "cd" "order"
+        (let open Constants in
+        assume_default_if_null_empty vm.API.vM_HVM_boot_params
+          hvm_default_boot_order hvm_boot_params_order)
     ; qemu_disk_cmdline= bool vm.API.vM_platform false "qemu_disk_cmdline"
     ; qemu_stubdom= false
     ; (* Obsolete: implementation removed *)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -198,6 +198,14 @@ let find f map default feature =
 
 let string = find (fun x -> x)
 
+let assume_default_if_null_empty map default feature =
+  match List.assoc_opt feature map with
+  | None | Some "" ->
+      D.info "assuming default setting %s=%s" feature default ;
+      default
+  | Some x ->
+      x
+
 let int = find int_of_string
 
 let bool = find (function "1" -> true | "0" -> false | x -> bool_of_string x)
@@ -401,7 +409,10 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough vgpu =
     ; vnc_ip= None (*None PR-1255*)
     ; pci_emulations
     ; pci_passthrough
-    ; boot_order= string vm.API.vM_HVM_boot_params "cd" "order"
+    ; boot_order=
+        (* XSI-804 avoid boot orders which are the empty string, as qemu
+         * will silently fail to start the VM *)
+        assume_default_if_null_empty vm.API.vM_HVM_boot_params "cd" "order"
     ; qemu_disk_cmdline= bool vm.API.vM_platform false "qemu_disk_cmdline"
     ; qemu_stubdom= false
     ; (* Obsolete: implementation removed *)


### PR DESCRIPTION
HVM VMs need a boot order in order for qemu to successfully start them.
This check ensures early and obvious failure when the boot order is not
present, whereas previously VM.start would silently fail.