### PR TITLE
CP-35372: Repository: HTTPs endpoint "/updates"

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5785,6 +5785,7 @@ let http_actions = [
   ("get_pool_update_download", (Get, Constants.get_pool_update_download_uri, false, [], _R_READ_ONLY, []));
   ("get_repository", (Get, Constants.get_repository_uri, false, [], _R_READ_ONLY, []));
   ("get_host_updates", (Get, Constants.get_host_updates_uri, false, [], _R_POOL_OP, []));
+  ("get_updates", (Get, Constants.get_updates_uri, true, [], _R_POOL_OP, []));
 ]
 
 (* these public http actions will NOT be checked by RBAC *)

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1224,7 +1224,11 @@ let _ =
   error Api_errors.invalid_updateinfo_xml []
     ~doc:"The updateinfo.xml is invalid." ();
   error Api_errors.get_host_updates_failed ["ref"]
-    ~doc:"Failed to get available updates from a host." ()
+    ~doc:"Failed to get available updates from a host." ();
+  error Api_errors.get_updates_failed []
+    ~doc:"Failed to get available updates from the pool." ();
+  error Api_errors.get_updates_in_progress []
+    ~doc:"The operation could not be performed because getting updates is in progress." ()
 
 
 let _ =

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -10,6 +10,7 @@ open Datamodel_types
             "designate_new_master", "Indicates this pool is in the process of changing master";
             "set_repository", "Indicates this pool is in the process of configuring repository";
             "sync_updates", "Indicates this pool is in the process of syncing updates";
+            "get_updates", "Indicates this pool is in the process of getting updates";
           ])
 
   let enable_ha = call

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -149,6 +149,8 @@ let pool_operation_to_string = function
       "set_repository"
   | `sync_updates ->
       "sync_updates"
+  | `get_updates ->
+      "get_updates"
 
 let host_operation_to_string = function
   | `provision ->

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1227,3 +1227,7 @@ let invalid_updateinfo_xml = "INVALID_UPDATEINFO_XML"
 let get_host_updates_failed = "GET_HOST_UPDATES_FAILED"
 
 let invalid_repomd_xml = "INVALID_REPOMD_XML"
+
+let get_updates_failed = "GET_UPDATES_FAILED"
+
+let get_updates_in_progress = "GET_UPDATES_IN_PROGRESS"

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -157,6 +157,8 @@ let get_repository_uri = "/repository" (* ocaml/xapi/repository.ml *)
 
 let get_host_updates_uri = "/host_updates" (* ocaml/xapi/repository.ml *)
 
+let get_updates_uri = "/updates" (* ocaml/xapi/repository.ml *)
+
 let default_usb_speed = -1.
 
 let use_compression = "use_compression"

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -53,3 +53,10 @@ val get_host_updates_in_json :
      __context:Context.t
   -> installed:bool
   -> Yojson.Basic.t
+
+val get_pool_updates_in_json :
+     __context:Context.t
+  -> hosts:[`host] API.Ref.t list
+  -> Yojson.Basic.t
+
+val with_pool_repository : (unit -> 'a) -> 'a

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -58,5 +58,3 @@ val get_pool_updates_in_json :
      __context:Context.t
   -> hosts:[`host] API.Ref.t list
   -> Yojson.Basic.t
-
-val with_pool_repository : (unit -> 'a) -> 'a

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -709,6 +709,7 @@ let master_only_http_handlers =
   ; ( "post_remote_db_access_v2"
     , Http_svr.BufIO remote_database_access_handler_v2 )
   ; ( "get_repository", Http_svr.FdIO Repository.get_repository_handler)
+  ; ("get_updates", Http_svr.FdIO Xapi_pool.get_updates_handler)
   ]
 
 let common_http_handlers =

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -334,3 +334,9 @@ val sync_updates :
   -> self:API.ref_pool
   -> force:bool
   -> string
+
+val get_updates_handler :
+     Http.Request.t
+  -> Unix.file_descr
+  -> 'a
+  -> unit

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -32,6 +32,7 @@ let all_operations =
   ; `designate_new_master
   ; `set_repository
   ; `sync_updates
+  ; `get_updates
   ]
 
 (** Returns a table of operations -> API error options (None if the operation would be ok) *)
@@ -57,6 +58,7 @@ let valid_operations ~__context record _ref' =
     ; (`designate_new_master, Api_errors.designate_new_master_in_progress, [])
     ; (`set_repository, Api_errors.set_repository_in_progress, [])
     ; (`sync_updates, Api_errors.sync_updates_in_progress, [])
+    ; (`get_updates, Api_errors.get_updates_in_progress, [])
     ]
   in
   List.iter


### PR DESCRIPTION
This commit implements HTTPs endpoint "/updates" for repository function.

With this HTTPs endpoint, user can get the available updates from hosts in the
pool.

Signed-off-by: Ming Lu <ming.lu@citrix.com>