### PR TITLE
CA-342527: simplify code around rbac checks

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -211,7 +211,7 @@ let operation (obj : obj) (x : message) =
   let rbac_check_begin =
     if has_session_arg then
       [
-        "let arg_names = "
+        "let arg_name_params = List.combine ("
         ^ List.fold_right
             (fun arg args -> "\"" ^ arg ^ "\"::" ^ args)
             orig_string_args
@@ -223,7 +223,7 @@ let operation (obj : obj) (x : message) =
             else
               "[]"
             )
-        ^ " in"
+        ^ ") __params in"
       ; "let key_names = "
         ^ List.fold_right
             (fun arg args -> "\"" ^ arg ^ "\"::" ^ args)
@@ -231,7 +231,7 @@ let operation (obj : obj) (x : message) =
             "[]"
         ^ " in"
       ; "let rbac __context fn = Rbac.check session_id __call \
-         ~args:(arg_names,__params) ~keys:key_names ~__context ~fn in"
+         ~args:arg_name_params ~keys:key_names ~__context ~fn in"
       ]
     else
       ["let rbac __context fn = fn() in"]
@@ -525,10 +525,11 @@ let gen_module api : O.Module.t =
                  ; "      let session_id = ref_session_of_rpc session_id_rpc in"
                  ; "      Session_check.check false session_id;"
                  ; "      (* based on the Host.call_extension call *)"
-                 ; "      let arg_names = \"session_id\"::__call::[] in"
+                 ; "      let arg_name_params = List.combine \
+                    (\"session_id\"::__call::[]) __params in"
                  ; "      let key_names = [] in"
                  ; "      let rbac __context fn = Rbac.check session_id \
-                    \"Host.call_extension\" ~args:(arg_names,__params) \
+                    \"Host.call_extension\" ~args:arg_name_params \
                     ~keys:key_names ~__context ~fn in"
                  ; "      Server_helpers.forward_extension ~__context rbac { \
                     call with Rpc.name = __call }"

--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -12,8 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_std.Listext
-
 module D = Debug.Make (struct let name = "rbac" end)
 
 open D
@@ -108,7 +106,7 @@ let get_keyERR_permission_name permission err = permission ^ "/keyERR:" ^ err
 let permission_of_action ?args ~keys _action =
   (* all permissions are in lowercase, see gen_rbac.writer_ *)
   let action = String.lowercase_ascii _action in
-  if List.length keys < 1 then
+  if keys = [] then
     (* most actions do not use rbac-guarded map keys in the arguments *)
     action
   else (* only actions with rbac-guarded map keys fall here *)
@@ -117,64 +115,39 @@ let permission_of_action ?args ~keys _action =
         (* this should never happen *)
         debug "DENYING access: no args for keyed-action %s" action ;
         get_keyERR_permission_name action "DENY_NOARGS" (* will always deny *)
-    | Some (arg_keys, arg_values) ->
-        if List.length arg_keys <> List.length arg_values then (
+    | Some keys_values -> (
+      match List.assoc_opt "key" keys_values with
+      | None ->
+          (* this should never happen *)
+          debug "DENYING access: no 'key' argument in the action %s" action ;
+          get_keyERR_permission_name action "DENY_NOKEY"
+      | Some (Rpc.String key_name_in_args) -> (
+        try
+          let key_name =
+            List.find
+              (fun key_name ->
+                if Astring.String.is_suffix ~affix:"*" key_name then
+                  (* resolve wildcards at the end *)
+                  Astring.String.is_prefix
+                    ~affix:(String.sub key_name 0 (String.length key_name - 1))
+                    key_name_in_args
+                else (* no wildcards to resolve *)
+                  key_name = key_name_in_args)
+              keys
+          in
+          get_key_permission_name action (String.lowercase_ascii key_name)
+        with Not_found ->
+          (* expected, key_in_args is not rbac-protected *)
+          action
+      )
+      | Some value ->
           (* this should never happen *)
           debug
-            "DENYING access: arg_keys and arg_values lengths don't match: \
-             arg_keys=[%s], arg_values=[%s]"
-            (List.fold_left (fun ss s -> ss ^ s ^ ",") "" arg_keys)
-            (List.fold_left
-               (fun ss s -> ss ^ Rpc.to_string s ^ ",")
-               "" arg_values) ;
-          get_keyERR_permission_name action "DENY_WRGLEN" (* will always deny *)
-        ) else (* keys and values have the same length *)
-          let rec get_permission_name_of_keys arg_keys arg_values =
-            match (arg_keys, arg_values) with
-            | [], [] | _, [] | [], _ ->
-                (* this should never happen *)
-                debug "DENYING access: no 'key' argument in the action %s"
-                  action ;
-                get_keyERR_permission_name action "DENY_NOKEY"
-                (* deny by default *)
-            | k :: ks, v :: vs -> (
-                if k <> "key" (* "key" is defined in datamodel_utils.ml *) then
-                  get_permission_name_of_keys ks vs
-                else (* found "key" in args *)
-                  match v with
-                  | Rpc.String key_name_in_args -> (
-                    try
-                      (*debug "key_name_in_args=%s, keys=[%s]" key_name_in_args ((List.fold_left (fun ss s->ss^s^",") "" keys)) ;*)
-                      let key_name =
-                        List.find
-                          (fun key_name ->
-                            if Astring.String.is_suffix ~affix:"*" key_name then
-                              (* resolve wildcards at the end *)
-                              Astring.String.is_prefix
-                                ~affix:
-                                  (String.sub key_name 0
-                                     (String.length key_name - 1))
-                                key_name_in_args
-                            else (* no wildcards to resolve *)
-                              key_name = key_name_in_args)
-                          keys
-                      in
-                      get_key_permission_name action
-                        (String.lowercase_ascii key_name)
-                    with Not_found ->
-                      (* expected, key_in_args is not rbac-protected *)
-                      action
-                  )
-                  | _ ->
-                      (* this should never happen *)
-                      debug
-                        "DENYING access: wrong XML value [%s] in the 'key' \
-                         argument of action %s"
-                        (Rpc.to_string v) action ;
-                      get_keyERR_permission_name action "DENY_NOVALUE"
-              )
-          in
-          get_permission_name_of_keys arg_keys arg_values
+            "DENYING access: wrong XML value [%s] in the 'key' argument of \
+             action %s"
+            (Rpc.to_string value) action ;
+          get_keyERR_permission_name action "DENY_NOVALUE"
+    )
 
 let is_permission_in_session ~session_id ~permission ~session =
   let find_linear elem set = List.exists (fun e -> e = elem) set in

--- a/ocaml/xapi/rbac_audit.ml
+++ b/ocaml/xapi/rbac_audit.ml
@@ -291,11 +291,11 @@ let get_db_namevalue __context name action _ref =
 *)
 let rec sexpr_args_of __context name rpc_value action =
   let is_selected_action_param action_params =
-    if List.mem_assoc action action_params then
-      let params = List.assoc action action_params in
-      List.mem name params
-    else
-      false
+    match List.assoc_opt action action_params with
+    | Some params ->
+        List.mem name params
+    | None ->
+        false
   in
   (* heuristic 1: print descriptive arguments in the xapi call *)
   if
@@ -323,7 +323,7 @@ let rec sexpr_args_of __context name rpc_value action =
              ; SExpr.Node
                  (sexpr_of_parameters __context
                     (action ^ "." ^ name)
-                    (Some (["__structure"], [rpc_value])))
+                    (Some [("__structure", rpc_value)]))
              ; SExpr.String ""
              ; SExpr.String ""
              ])
@@ -365,53 +365,29 @@ let rec sexpr_args_of __context name rpc_value action =
 and
     (* Given an action and its parameters, *)
     (* return the marshalled uuid params and corresponding names *)
-    (*let rec*) sexpr_of_parameters __context action args : SExpr.t list =
+    sexpr_of_parameters __context action args : SExpr.t list =
   match args with
   | None ->
       []
-  | Some (str_names, rpc_values) ->
-      if List.length str_names <> List.length rpc_values then (
-        (* debug mode *)
-        D.warn
-          "cannot marshall arguments for the action %s: name and value list \
-           lengths don't match. str_names=[%s], xml_values=[%s]"
-          action
-          (List.fold_left (fun ss s -> ss ^ s ^ ",") "" str_names)
-          (List.fold_left
-             (fun ss s -> ss ^ Rpc.to_string s ^ ",")
-             "" rpc_values) ;
-        []
-      ) else
-        List.fold_right2
-          (fun str_name rpc_value (params : SExpr.t list) ->
-            if str_name = "session_id" then
+  | Some names_rpc_values ->
+      List.fold_right
+        (fun (str_name, rpc_value) (params : SExpr.t list) ->
+          match (str_name, rpc_value) with
+          | "session_id", _ ->
               params (* ignore session_id param *)
-            else if
+          | "__structure", Rpc.Dict d ->
               (* if it is a constructor structure, need to rewrap params *)
-              str_name = "__structure"
-            then
-              match rpc_value with
-              | Rpc.Dict d ->
-                  let names = List.map fst d in
-                  let values = List.map snd d in
-                  let myparam =
-                    sexpr_of_parameters __context action (Some (names, values))
-                  in
-                  myparam @ params
-              | rpc_value -> (
-                match sexpr_args_of __context str_name rpc_value action with
-                | None ->
-                    params
-                | Some p ->
-                    p :: params
-              )
-            else (* the expected list of xml arguments *)
-              match sexpr_args_of __context str_name rpc_value action with
-              | None ->
-                  params
-              | Some p ->
-                  p :: params)
-          str_names rpc_values []
+              let myparam = sexpr_of_parameters __context action (Some d) in
+              myparam @ params
+          | _ -> (
+            (* the expected list of xml arguments *)
+            match sexpr_args_of __context str_name rpc_value action with
+            | None ->
+                params
+            | Some p ->
+                p :: params
+          ))
+        names_rpc_values []
 
 let has_to_audit action =
   let has_side_effect action =
@@ -452,37 +428,28 @@ let add_dummy_args __context action args =
   match args with
   | None ->
       args
-  | Some (str_names, rpc_values) -> (
-      let rec find_self str_names rpc_values =
-        match (str_names, rpc_values) with
-        | "self" :: _, rpc :: _ ->
-            rpc
-        | _ :: str_names', _ :: rpc_values' ->
-            find_self str_names' rpc_values'
-        | _, _ ->
-            raise Not_found
-      in
-      match action with
-      (* Add VDI info for VBD.destroy *)
-      | "VBD.destroy" -> (
-        try
-          let vbd = API.ref_VBD_of_rpc (find_self str_names rpc_values) in
-          let vdi = DB_Action.VBD.get_VDI __context vbd in
-          Some (str_names @ ["VDI"], rpc_values @ [API.rpc_of_ref_VDI vdi])
-        with e ->
-          D.debug "couldn't get VDI ref for VBD: %s" (ExnHelper.string_of_exn e) ;
-          args
-      )
-      | _ ->
-          args
+  | Some names_rpc -> (
+    match action with
+    (* Add VDI info for VBD.destroy *)
+    | "VBD.destroy" -> (
+      try
+        let vbd = API.ref_VBD_of_rpc (List.assoc "self" names_rpc) in
+        let vdi = DB_Action.VBD.get_VDI ~__context ~self:vbd in
+        let params = names_rpc @ [("VDI", API.rpc_of_ref_VDI vdi)] in
+        Some params
+      with e ->
+        D.debug "couldn't get VDI ref for VBD: %s" (ExnHelper.string_of_exn e) ;
+        args
     )
+    | _ ->
+        args
+  )
 
 let sexpr_of __context session_id allowed_denied ok_error result_error ?args
     ?sexpr_of_args action permission =
   let result_error =
     if result_error = "" then result_error else ":" ^ result_error
   in
-  (*let (params:SExpr.t list) = (string_of_parameters action args) in*)
   SExpr.Node
     [
       SExpr.String (trackid session_id)
@@ -491,8 +458,7 @@ let sexpr_of __context session_id allowed_denied ok_error result_error ?args
     ; SExpr.String allowed_denied
     ; SExpr.String (ok_error ^ result_error)
     ; SExpr.String (call_type_of action)
-    ; (*SExpr.String (Helper_hostname.get_hostname ())::*)
-      SExpr.String action
+    ; SExpr.String action
     ; SExpr.Node
         ( match sexpr_of_args with
         | None ->

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -75,10 +75,8 @@ let append_to_master_audit_log __context action line =
           Client.Pool.audit_log_append ~rpc ~session_id ~line)
 
 let rbac_audit_params_of (req : Request.t) =
-  let all = req.Request.cookie @ req.Request.query in
-  List.fold_right
-    (fun (n, v) (acc_n, acc_v) -> (n :: acc_n, Rpc.String v :: acc_v))
-    all ([], [])
+  req.Request.cookie @ req.Request.query
+  |> List.map (fun (n, v) -> (n, Rpc.String v))
 
 let assert_credentials_ok realm ?(http_action = realm) ?(fn = Rbac.nofn)
     (req : Request.t) ic =


### PR DESCRIPTION
The rbac checks around call arguments spends a lot of effort checking that two lists are always the same length. Since we control the source, we can generate a list of pairs instead. Other list traversals were avoided as well.

Special case for parsing VMPP arguments when log-auditing was removed as the code was not trivial, introduced IO and the VMPP calls were deprecated in 6.0 so the code has been unused since then.

BST + BVT 144004 is mostly green, except for a problem with RPU, xenserver-inventory is not updated after upgrading.

I couldn't find any tests for RBAC, but I would think this code would be excercised a lot in e2e tests anyway.