### PR TITLE
CA-351391: Make certificate alerts ignore CA certs

### DIFF
--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -49,7 +49,8 @@ let execute rpc session existing_messages (host, alert) =
      In the case there are alerts regarding the host but no alert is pending
      they are not destroyed since no alert is automatically dismissed. *)
   match alert with
-  | Some (message, (alert, priority)) ->
+  | Some (message, (alert, priority)) -> (
+    try
       let host_uuid = XenAPI.Host.get_uuid rpc session host in
       let messages_in_host =
         List.filter
@@ -72,6 +73,10 @@ let execute rpc session existing_messages (host, alert) =
             message
         in
         ()
+    with Api_errors.(Server_error (handle_invalid, _)) ->
+      (* this happens when the host reference is invalid *)
+      ()
+  )
   | None ->
       ()
 


### PR DESCRIPTION
Currently it's assumed by the alert generator that all certificates have
a valid reference to a host. This is not true anymore as we model CA
certificates.

Ignore the error when the assumption does not hold for the time being