### PR TITLE
Two commits for fixing-up of repository funciton

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1314,7 +1314,8 @@ let rmtree path =
     | _ ->
         Unix.unlink path
   in
-  try rm path
+  try
+    if Sys.file_exists path then rm path
   with exn ->
     let exn' = Printexc.to_string exn in
     let msg = Printf.sprintf "failed to remove %s: %s" path exn' in

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -244,8 +244,7 @@ let cleanup_pool_repo () =
     clean_yum_cache !Xapi_globs.pool_repo_name;
     Unixext.unlink_safe (Filename.concat !Xapi_globs.yum_repos_config_dir
                            !Xapi_globs.pool_repo_name);
-    if Sys.file_exists !Xapi_globs.local_pool_repo_dir then
-      Helpers.rmtree !Xapi_globs.local_pool_repo_dir
+    Helpers.rmtree !Xapi_globs.local_pool_repo_dir
   with e ->
     error "Failed to cleanup pool repository: %s" (ExnHelper.string_of_exn e);
     raise Api_errors.(Server_error (repository_cleanup_failed, []))

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -244,7 +244,8 @@ let cleanup_pool_repo () =
     clean_yum_cache !Xapi_globs.pool_repo_name;
     Unixext.unlink_safe (Filename.concat !Xapi_globs.yum_repos_config_dir
                            !Xapi_globs.pool_repo_name);
-    Helpers.rmtree !Xapi_globs.local_pool_repo_dir
+    if Sys.file_exists !Xapi_globs.local_pool_repo_dir then
+      Helpers.rmtree !Xapi_globs.local_pool_repo_dir
   with e ->
     error "Failed to cleanup pool repository: %s" (ExnHelper.string_of_exn e);
     raise Api_errors.(Server_error (repository_cleanup_failed, []))

--- a/ocaml/xapi/xapi_pool_transition.ml
+++ b/ocaml/xapi/xapi_pool_transition.ml
@@ -206,7 +206,8 @@ let become_another_masters_slave master_address =
     debug "Setting pool.conf to point to %s" master_address ;
     set_role new_role ;
     run_external_scripts false ;
-    Xapi_fuse.light_fuse_and_run ()
+    Xapi_fuse.light_fuse_and_run () ;
+    Repository.cleanup_pool_repo () (* For simplicity, it's safe to cleanup on all slaves *)
   )
 
 (** If we just transitioned slave -> master (as indicated by the localdb flag) then generate a single alert *)

--- a/ocaml/xapi/xapi_pool_transition.ml
+++ b/ocaml/xapi/xapi_pool_transition.ml
@@ -206,8 +206,8 @@ let become_another_masters_slave master_address =
     debug "Setting pool.conf to point to %s" master_address ;
     set_role new_role ;
     run_external_scripts false ;
-    Xapi_fuse.light_fuse_and_run () ;
-    Repository.cleanup_pool_repo () (* For simplicity, it's safe to cleanup on all slaves *)
+    Repository.cleanup_pool_repo () ; (* For simplicity, it's safe to cleanup on all slaves *)
+    Xapi_fuse.light_fuse_and_run ()
   )
 
 (** If we just transitioned slave -> master (as indicated by the localdb flag) then generate a single alert *)


### PR DESCRIPTION
 Two commits for fixing-up:

Fixup: Repository: Check existence before removing repo dir
    This commit adds an existence checking before removing the local pool repository
    directory. This fixes bug in cases of inital pool.set_repository and changing
    pool master.

Fixup: Repository: Cleanup local pool repo when becoming a new slave
    This commit adds cleanup when a host becoming a new slave.