### PR TITLE
CP-34472 Generate alerts every hour about failed login attempts

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -115,6 +115,8 @@ let _ =
   (* Session errors *)
   error Api_errors.session_authentication_failed []
     ~doc:"The credentials given by the user are incorrect, so access has been denied, and you have not been issued a session handle." ();
+  error Api_errors.session_authorization_failed ["username"; "msg"]
+    ~doc:"The credentials given by the user are correct, but the user could not be authorized, so access has been denied, and you have not been issued a session handle." ();
   error Api_errors.session_invalid ["handle"]
     ~doc:"You gave an invalid session reference. It may have been invalidated by a server restart, or timed out. You should get a new session handle, using one of the session.login_ calls. This error does not invalidate the current connection. The handle parameter echoes the bad value given." ();
   error Api_errors.change_password_rejected [ "msg" ]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -69,4 +69,5 @@ let () =
     @ Test_datamodel_utils.tests
     @ Test_psr.tests
     @ Test_context.tests
+    @ Test_session.tests
     )

--- a/ocaml/tests/test_session.ml
+++ b/ocaml/tests/test_session.ml
@@ -19,17 +19,18 @@ let success_login ~__context ~uname ~originator ~now () =
   Xapi_session._record_login_failure ~__context ~now ~uname ~originator
     ~record:`log_and_alert Fun.id
 
-let make_ctx ~user_agent =
+let make_ctx ~user_agent ~client_ip =
   let open Context in
-  match user_agent with
-  | None ->
-      make "test_ctx"
-  | Some _ ->
-      let rq = {Http.Request.empty with user_agent} in
-      (* it doesn't matter which fd is used to here, we are just satisying the
-         type system. we use stderr because then we don't need to worry about
-         closing it *)
-      make ~origin:(Http (rq, Unix.stderr)) "text_ctx"
+  let additional_headers =
+    client_ip
+    |> Option.fold ~none:[] ~some:(fun x ->
+           [("STUNNEL_PROXY", Printf.sprintf "TCP6 %s another_ip 443 80" x)])
+  in
+  let rq = {Http.Request.empty with user_agent; additional_headers} in
+  (* it doesn't matter which fd is used to here, we are just satisying the
+     type system. we use stderr because then we don't need to worry about
+     closing it *)
+  make ~origin:(Http (rq, Unix.stderr)) "text_ctx"
 
 let repeat n f =
   for _ = 1 to n do
@@ -37,7 +38,7 @@ let repeat n f =
   done
 
 let run_unknown_client_logins () =
-  let __context = make_ctx ~user_agent:None in
+  let __context = make_ctx ~user_agent:None ~client_ip:None in
   repeat 50
     (success_login ~__context ~uname:(Some "good_user")
        ~originator:(Some "nice_origin") ~now) ;
@@ -47,8 +48,13 @@ let run_unknown_client_logins () =
        ~originator:(Some "nice_origin") ~now)
 
 let run_known_client_logins () =
-  let __context = make_ctx ~user_agent:(Some "UA") in
-  let __context_no_UA = make_ctx ~user_agent:None in
+  let __context =
+    make_ctx ~user_agent:(Some "UA") ~client_ip:(Some "4.3.2.1")
+  in
+  let __context_no_UA = make_ctx ~user_agent:None ~client_ip:(Some "5.4.3.2") in
+  let __context_no_client_ip =
+    make_ctx ~user_agent:(Some "UA") ~client_ip:None
+  in
   repeat 50
     (success_login ~__context ~uname:(Some "good_user")
        ~originator:(Some "nice_origin") ~now) ;
@@ -60,7 +66,8 @@ let run_known_client_logins () =
        ~originator:(Some "origin2") ~now) ;
   repeat 4 (fail_login ~__context ~uname:None ~originator:None ~now) ;
   repeat 6
-    (fail_login ~__context ~uname:(Some "usr4") ~originator:None ~now:future) ;
+    (fail_login ~__context:__context_no_client_ip ~uname:(Some "usr4")
+       ~originator:None ~now:future) ;
   let () =
     (* this client fails now and then in the future (to test timestamp) *)
     repeat 9
@@ -101,6 +108,7 @@ let test_failed_logins_from_known_clients_only () =
 <known>
 <username>usr5</username>
 <originator>origin5</originator>
+<ip>5.4.3.2</ip>
 <number>10</number>
 <date>20200922T15:03:13Z</date>
 </known>
@@ -112,6 +120,7 @@ let test_failed_logins_from_known_clients_only () =
 </known>
 <known>
 <useragent>UA</useragent>
+<ip>4.3.2.1</ip>
 <number>4</number>
 <date>20200922T14:57:11Z</date>
 </known>
@@ -130,6 +139,7 @@ let test_failed_logins_from_both_known_and_unknown_clients () =
 <known>
 <username>usr5</username>
 <originator>origin5</originator>
+<ip>5.4.3.2</ip>
 <number>10</number>
 <date>20200922T15:03:13Z</date>
 </known>
@@ -141,6 +151,7 @@ let test_failed_logins_from_both_known_and_unknown_clients () =
 </known>
 <known>
 <useragent>UA</useragent>
+<ip>4.3.2.1</ip>
 <number>4</number>
 <date>20200922T14:57:11Z</date>
 </known>

--- a/ocaml/tests/test_session.ml
+++ b/ocaml/tests/test_session.ml
@@ -1,0 +1,168 @@
+open Test_common
+module Date = Xapi_stdext_date.Date
+
+let now = Date.of_string "2020-09-22T14:57:11Z"
+
+let future = Date.of_string "2020-09-22T15:03:13Z"
+
+let fail_login ~__context ~uname ~originator ~now () =
+  try
+    Xapi_session._record_login_failure ~__context ~now ~uname ~originator
+      ~record:`log_and_alert (fun () ->
+        if Random.bool () then
+          raise Api_errors.(Server_error (session_authentication_failed, []))
+        else
+          raise (Auth_signature.Auth_failure "Auth failure"))
+  with e -> ()
+
+let success_login ~__context ~uname ~originator ~now () =
+  Xapi_session._record_login_failure ~__context ~now ~uname ~originator
+    ~record:`log_and_alert Fun.id
+
+let make_ctx ~user_agent =
+  let open Context in
+  match user_agent with
+  | None ->
+      make "test_ctx"
+  | Some _ ->
+      let rq = {Http.Request.empty with user_agent} in
+      (* it doesn't matter which fd is used to here, we are just satisying the
+         type system. we use stderr because then we don't need to worry about
+         closing it *)
+      make ~origin:(Http (rq, Unix.stderr)) "text_ctx"
+
+let repeat n f =
+  for _ = 1 to n do
+    f ()
+  done
+
+let run_unknown_client_logins () =
+  let __context = make_ctx ~user_agent:None in
+  repeat 50
+    (success_login ~__context ~uname:(Some "good_user")
+       ~originator:(Some "nice_origin") ~now) ;
+  repeat 10 (fail_login ~__context ~uname:None ~originator:None ~now) ;
+  repeat 50
+    (success_login ~__context ~uname:(Some "good_user")
+       ~originator:(Some "nice_origin") ~now)
+
+let run_known_client_logins () =
+  let __context = make_ctx ~user_agent:(Some "UA") in
+  let __context_no_UA = make_ctx ~user_agent:None in
+  repeat 50
+    (success_login ~__context ~uname:(Some "good_user")
+       ~originator:(Some "nice_origin") ~now) ;
+  repeat 2
+    (fail_login ~__context:__context_no_UA ~uname:(Some "usr1") ~now
+       ~originator:(Some "origin1")) ;
+  repeat 3
+    (fail_login ~__context:__context_no_UA ~uname:None
+       ~originator:(Some "origin2") ~now) ;
+  repeat 4 (fail_login ~__context ~uname:None ~originator:None ~now) ;
+  repeat 6
+    (fail_login ~__context ~uname:(Some "usr4") ~originator:None ~now:future) ;
+  let () =
+    (* this client fails now and then in the future (to test timestamp) *)
+    repeat 9
+      (fail_login ~__context:__context_no_UA ~uname:(Some "usr5")
+         ~originator:(Some "origin5") ~now) ;
+    repeat 1
+      (fail_login ~__context:__context_no_UA ~uname:(Some "usr5")
+         ~originator:(Some "origin5") ~now:future)
+  in
+  repeat 50
+    (success_login ~__context ~uname:(Some "good_user")
+       ~originator:(Some "nice_origin") ~now:future)
+
+let test_fetching_failed_login_stats_twice_yields_none () =
+  let _ = Xapi_session.get_failed_login_stats () in
+  let stats = Xapi_session.get_failed_login_stats () in
+  Alcotest.(check @@ option string)
+    "no extra stats have been accumulated" stats None
+
+let test_only_failed_logins_from_unknown_clients () =
+  let _ = Xapi_session.get_failed_login_stats () in
+  run_unknown_client_logins () ;
+  let stats = Xapi_session.get_failed_login_stats () |> Option.get in
+  Alcotest.(check string)
+    "report talks about unknown clients only"
+    {|<body>
+<unknown>10</unknown>
+</body>|} stats
+
+let test_failed_logins_from_known_clients_only () =
+  let _ = Xapi_session.get_failed_login_stats () in
+  run_known_client_logins () ;
+  let stats = Xapi_session.get_failed_login_stats () |> Option.get in
+  Alcotest.(check string)
+    "report talks about known clients only"
+    {|<body>
+<total>25</total>
+<known>
+<username>usr5</username>
+<originator>origin5</originator>
+<number>10</number>
+<date>20200922T15:03:13Z</date>
+</known>
+<known>
+<username>usr4</username>
+<useragent>UA</useragent>
+<number>6</number>
+<date>20200922T15:03:13Z</date>
+</known>
+<known>
+<useragent>UA</useragent>
+<number>4</number>
+<date>20200922T14:57:11Z</date>
+</known>
+</body>|}
+    stats
+
+let test_failed_logins_from_both_known_and_unknown_clients () =
+  let _ = Xapi_session.get_failed_login_stats () in
+  run_known_client_logins () ;
+  run_unknown_client_logins () ;
+  let stats = Xapi_session.get_failed_login_stats () |> Option.get in
+  Alcotest.(check string)
+    "report talks about unknown and known clients"
+    {|<body>
+<total>35</total>
+<known>
+<username>usr5</username>
+<originator>origin5</originator>
+<number>10</number>
+<date>20200922T15:03:13Z</date>
+</known>
+<known>
+<username>usr4</username>
+<useragent>UA</useragent>
+<number>6</number>
+<date>20200922T15:03:13Z</date>
+</known>
+<known>
+<useragent>UA</useragent>
+<number>4</number>
+<date>20200922T14:57:11Z</date>
+</known>
+<unknown>10</unknown>
+</body>|}
+    stats
+
+let tests =
+  [
+    ( "AuthFail"
+    , [
+        ( "test_fetching_failed_login_stats_twice_yields_none"
+        , `Quick
+        , test_fetching_failed_login_stats_twice_yields_none )
+      ; ( "test_only_failed_logins_from_unknown_clients"
+        , `Quick
+        , test_only_failed_logins_from_unknown_clients )
+      ; ( "test_failed_logins_from_clients"
+        , `Quick
+        , test_failed_logins_from_known_clients_only )
+      ; ( "test_failed_logins_from_both_known_and_unknown_clients"
+        , `Quick
+        , test_failed_logins_from_both_known_and_unknown_clients )
+      ] )
+  ]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -60,6 +60,8 @@ let field_type_error = "FIELD_TYPE_ERROR"
 
 let session_authentication_failed = "SESSION_AUTHENTICATION_FAILED"
 
+let session_authorization_failed = "SESSION_AUTHORIZATION_FAILED"
+
 let session_invalid = "SESSION_INVALID"
 
 let change_password_rejected = "CHANGE_PASSWORD_REJECTED"

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -306,3 +306,5 @@ let host_server_certificate_expiring_07 =
 
 let host_server_certificate_expired =
   addMessage "HOST_SERVER_CERTIFICATE_EXPIRED" 1L
+
+let failed_login_attempts = addMessage "FAILED_LOGIN_ATTEMPTS" 3L

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -340,5 +340,8 @@ let get_client context =
   |> Option.map (fun (http, ip) ->
          Printf.sprintf "%s %s" (string_of_http_t http) (Ipaddr.to_string ip))
 
+let get_client_ip context =
+  context.client |> Option.map (fun (_, ip) -> Ipaddr.to_string ip)
+
 let get_user_agent context =
   match context.origin with Internal -> None | Http (rq, _) -> rq.user_agent

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -339,3 +339,6 @@ let get_client context =
   context.client
   |> Option.map (fun (http, ip) ->
          Printf.sprintf "%s %s" (string_of_http_t http) (Ipaddr.to_string ip))
+
+let get_user_agent context =
+  match context.origin with Internal -> None | Http (rq, _) -> rq.user_agent

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -134,4 +134,6 @@ val get_test_clusterd_rpc : t -> (Rpc.call -> Rpc.response) option
 
 val get_client : t -> string option
 
+val get_client_ip : t -> string option
+
 val get_user_agent : t -> string option

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -133,3 +133,5 @@ val set_test_clusterd_rpc : t -> (Rpc.call -> Rpc.response) -> unit
 val get_test_clusterd_rpc : t -> (Rpc.call -> Rpc.response) option
 
 val get_client : t -> string option
+
+val get_user_agent : t -> string option

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -92,4 +92,8 @@ let register () =
     (Xapi_periodic_scheduler.Periodic hb_timer) 240.0 hb_func ;
   Xapi_periodic_scheduler.add_to_queue "Update monitor configuration"
     (Xapi_periodic_scheduler.Periodic 3600.0) 3600.0
-    Monitor_master.update_configuration_from_master
+    Monitor_master.update_configuration_from_master ;
+  if master then
+    Xapi_periodic_scheduler.add_to_queue "Periodic alert failed login attempts"
+      (Xapi_periodic_scheduler.Periodic 3600.0) 3600.0
+      Xapi_pool.alert_failed_login_attempts

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -322,3 +322,5 @@ val remove_from_guest_agent_config :
   __context:Context.t -> self:API.ref_pool -> key:string -> unit
 
 val rotate_secret : __context:Context.t -> unit
+
+val alert_failed_login_attempts : unit -> unit

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -54,7 +54,11 @@ let do_external_auth uname pwd =
 
 let do_local_auth uname pwd =
   Mutex.execute serialize_auth (fun () ->
-      Pam.authenticate uname (Bytes.unsafe_to_string pwd))
+      try Pam.authenticate uname (Bytes.unsafe_to_string pwd)
+      with Failure msg ->
+        raise
+          Api_errors.(
+            Server_error (session_authentication_failed, [uname; msg])))
 
 let do_local_change_password uname newpwd =
   Mutex.execute serialize_auth (fun () ->

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -45,24 +45,27 @@ end = struct
       user_agent: string option
     ; uname: string option
     ; originator: string option
+    ; ip: string option
   }
 
   let client_of_info ~__context ~originator ~uname =
     let user_agent = Context.get_user_agent __context in
+    let ip = Context.get_client_ip __context in
     (* check to make sure we have at least _some_ information *)
     if
-      [user_agent; originator; uname]
+      [user_agent; originator; uname; ip]
       |> List.for_all (function None | Some "" -> true | _ -> false)
     then
       None
     else
-      Some {originator; uname; user_agent}
+      Some {originator; uname; user_agent; ip}
 
   let string_of_client x =
     [
       ("username", x.uname)
     ; ("originator", x.originator)
     ; ("useragent", x.user_agent)
+    ; ("ip", x.ip)
     ]
     |> List.filter_map (fun (label, value) ->
            match value with

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -27,6 +27,232 @@ open Client
 open Auth_signature
 open Extauth
 
+module AuthFail : sig
+  (* stats are reset each time you query, so if there hasn't
+     been a failed login attempt since the last time the stats
+     were queried, you won't get any stats *)
+  val get_stats_string : unit -> string option
+
+  val on_fail :
+       __context:Context.t
+    -> now:Date.iso8601
+    -> uname:string option
+    -> originator:string option
+    -> record:[< `log_only | `log_and_alert]
+    -> unit
+end = struct
+  type client = {
+      user_agent: string option
+    ; uname: string option
+    ; originator: string option
+  }
+
+  let client_of_info ~__context ~originator ~uname =
+    let user_agent = Context.get_user_agent __context in
+    (* check to make sure we have at least _some_ information *)
+    if
+      [user_agent; originator; uname]
+      |> List.for_all (function None | Some "" -> true | _ -> false)
+    then
+      None
+    else
+      Some {originator; uname; user_agent}
+
+  let string_of_client x =
+    [
+      ("username", x.uname)
+    ; ("originator", x.originator)
+    ; ("useragent", x.user_agent)
+    ]
+    |> List.filter_map (fun (label, value) ->
+           match value with
+           | None | Some "" ->
+               None
+           | Some value ->
+               Some (Printf.sprintf "<%s>%s</%s>" label value label))
+    |> String.concat "\n"
+
+  type client_failed_attempts = {
+      client: client
+    ; num_failed_attempts: int
+    ; last_failed_attempt: Date.iso8601
+  }
+
+  let up_to_3 xs x =
+    let rec merge = function
+      | [] ->
+          [x]
+      | y :: ys ->
+          if x.num_failed_attempts >= y.num_failed_attempts then
+            x :: y :: ys
+          else
+            y :: merge ys
+    in
+    let rec keep ctr xs =
+      match (ctr, xs) with
+      | ctr, x :: xs when ctr > 0 ->
+          x :: keep (ctr - 1) xs
+      | _ ->
+          []
+    in
+    merge xs |> keep 3
+
+  let string_of_client_failed_attempts x =
+    Printf.sprintf {|
+<known>
+%s
+<number>%i</number>
+<date>%s</date>
+</known>|}
+      (string_of_client x.client)
+      x.num_failed_attempts
+      (Date.to_string x.last_failed_attempt)
+
+  type stats = {
+      total_num_failed_attempts: int
+    ; top_3_worst_clients: client_failed_attempts list
+          (* not necessarily 3, but <=3 *)
+    ; unknown_client_failed_attempts: int
+  }
+
+  let string_of_stats
+      {
+        total_num_failed_attempts
+      ; top_3_worst_clients
+      ; unknown_client_failed_attempts
+      } =
+    let unknown =
+      if unknown_client_failed_attempts = 0 then
+        ""
+      else
+        Printf.sprintf {|
+<unknown>%i</unknown>|} unknown_client_failed_attempts
+    in
+    let known_with_total =
+      if List.length top_3_worst_clients = 0 then
+        ""
+      else
+        Printf.sprintf {|
+<total>%i</total>%s|} total_num_failed_attempts
+          (top_3_worst_clients
+          |> List.map string_of_client_failed_attempts
+          |> String.concat ""
+          )
+    in
+    Printf.sprintf {|<body>%s%s
+</body>|} known_with_total unknown
+
+  module Stats : sig
+    val get : unit -> stats option
+
+    (* returns the number of failures from this client since last call to [ get ] *)
+    val record_client : client -> now:Date.iso8601 -> int
+
+    (* returns number of failures from unknown clients since last call to [ get ] *)
+    val record_unknown : unit -> int
+  end = struct
+    let m = Mutex.create ()
+
+    let unknown_ctr = ref 0
+
+    let record_unknown () =
+      Mutex.execute m (fun () ->
+          let ctr = !unknown_ctr + 1 in
+          unknown_ctr := ctr ;
+          ctr)
+
+    type key = client
+
+    type value = {num_failed_attempts: int; last_failed_attempt: Date.iso8601}
+
+    type table_t = (key, value) Hashtbl.t
+
+    let table = Hashtbl.create 10
+
+    let record_client k ~now =
+      Mutex.execute m (fun () ->
+          match Hashtbl.find_opt table k with
+          | None ->
+              Hashtbl.add table k
+                {num_failed_attempts= 1; last_failed_attempt= now} ;
+              1
+          | Some ({num_failed_attempts} : value) ->
+              let num_failed_attempts = num_failed_attempts + 1 in
+              Hashtbl.replace table k
+                {num_failed_attempts; last_failed_attempt= now} ;
+              num_failed_attempts)
+
+    let get () =
+      let reset () =
+        Hashtbl.reset table ;
+        unknown_ctr := 0
+      in
+      Mutex.execute m (fun () ->
+          let unknown_client_failed_attempts = !unknown_ctr in
+          if Hashtbl.length table = 0 && unknown_client_failed_attempts = 0 then
+            None
+          else
+            let num_known_client_failed_attempts, top_3_worst_clients =
+              Hashtbl.fold
+                (fun client {num_failed_attempts; last_failed_attempt}
+                     (ctr, worst_so_far) ->
+                  ( ctr + num_failed_attempts
+                  , up_to_3 worst_so_far
+                      {client; num_failed_attempts; last_failed_attempt} ))
+                table (0, [])
+            in
+            reset () ;
+            Some
+              {
+                total_num_failed_attempts=
+                  num_known_client_failed_attempts
+                  + unknown_client_failed_attempts
+              ; top_3_worst_clients
+              ; unknown_client_failed_attempts
+              })
+  end
+
+  let get_stats_string () = Stats.get () |> Option.map string_of_stats
+
+  let on_fail ~__context ~now ~uname ~originator ~record =
+    try
+      match (client_of_info ~__context ~uname ~originator, record) with
+      | None, `log_only ->
+          warn "login failure from unknown client"
+      | None, `log_and_alert ->
+          let total_unknown_login_failures = Stats.record_unknown () in
+          warn "login failure from unknown client, total= %i"
+            total_unknown_login_failures
+      | Some client, `log_only ->
+          info "failed login attempt by client: %s" (string_of_client client)
+      | Some client, _ ->
+          let num_failed_attempts = Stats.record_client client ~now in
+          info "failed login attempt #%i by client: %s" num_failed_attempts
+            (string_of_client client)
+    with e ->
+      (* we don't expect this function to fail, but if it does we don't want to block callers *)
+      error "AuthFail.on_fail_with_uname: unexpected error: '%s'"
+        (Printexc.to_string e)
+end
+
+let _record_login_failure ~__context ~now ~uname ~originator ~record f =
+  let on_fail e =
+    AuthFail.on_fail ~__context ~now ~uname ~originator ~record ;
+    raise e
+  in
+  try f () with
+  | Auth_signature.Auth_failure _ as e ->
+      on_fail e
+  | Api_errors.Server_error (code, _) as e
+    when code = Api_errors.session_authentication_failed ->
+      on_fail e
+
+let record_login_failure ~__context ~uname ~originator ~record f =
+  let now = Date.localtime () in
+  _record_login_failure ~__context ~now ~uname ~originator ~record f
+
+let get_failed_login_stats = AuthFail.get_stats_string
+
 let local_superuser = "root"
 
 let xapi_internal_originator = "xapi"

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -238,7 +238,7 @@ let _record_login_failure ~__context ~now ~uname ~originator ~record f =
       on_fail e
 
 let record_login_failure ~__context ~uname ~originator ~record f =
-  let now = Date.localtime () in
+  let now = Unix.time () |> Date.of_float in
   _record_login_failure ~__context ~now ~uname ~originator ~record f
 
 let get_failed_login_stats = AuthFail.get_stats_string

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -79,23 +79,10 @@ end = struct
   }
 
   let up_to_3 xs x =
-    let rec merge = function
-      | [] ->
-          [x]
-      | y :: ys ->
-          if x.num_failed_attempts >= y.num_failed_attempts then
-            x :: y :: ys
-          else
-            y :: merge ys
-    in
-    let rec keep ctr xs =
-      match (ctr, xs) with
-      | ctr, x :: xs when ctr > 0 ->
-          x :: keep (ctr - 1) xs
-      | _ ->
-          []
-    in
-    merge xs |> keep 3
+    List.stable_sort
+      (fun a b -> Int.compare b.num_failed_attempts a.num_failed_attempts)
+      (x :: xs)
+    |> Listext.List.take 3
 
   let string_of_client_failed_attempts x =
     Printf.sprintf {|
@@ -129,7 +116,7 @@ end = struct
 <unknown>%i</unknown>|} unknown_client_failed_attempts
     in
     let known_with_total =
-      if List.length top_3_worst_clients = 0 then
+      if top_3_worst_clients = [] then
         ""
       else
         Printf.sprintf {|

--- a/ocaml/xapi/xapi_session.mli
+++ b/ocaml/xapi/xapi_session.mli
@@ -83,3 +83,23 @@ val create_readonly_session :
 
 val create_from_db_file :
   __context:Context.t -> filename:string -> API.ref_session
+
+(* for unit testing *)
+val _record_login_failure :
+     __context:Context.t
+  -> now:Xapi_stdext_date.Date.iso8601
+  -> uname:string option
+  -> originator:string option
+  -> record:[< `log_only | `log_and_alert]
+  -> (unit -> 'a)
+  -> 'a
+
+val record_login_failure :
+     __context:Context.t
+  -> uname:string option
+  -> originator:string option
+  -> record:[< `log_only | `log_and_alert]
+  -> (unit -> 'a)
+  -> 'a
+
+val get_failed_login_stats : unit -> string option


### PR DESCRIPTION
This is a port to master from the REQ-403 branch.
These are cherry-picks from https://github.com/xapi-project/xen-api/pull/4218, https://github.com/xapi-project/xen-api/pull/4249 and [`1e2cafc` (#4284)](https://github.com/xapi-project/xen-api/pull/4284/commits/1e2cafcb385aaa0406a7ad474c28f45372b65fcb)

I didn't mark them as cherry-picks because these are from an unmerged feature branch.

The first two commits had conflicts because the function to expose the client was already added to master.