### PR TITLE
CP-36094 add SNI to stunnel server config

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1736,6 +1736,12 @@ end = struct
           ; "TIMEOUTclose = 1"
           ; "options = CIPHER_SERVER_PREFERENCE"
           ; "sslVersion = TLSv1.2"
+          ; ""
+          ; "# xapi connections use SNI 'pool' to request a cert"
+          ; "[pool]"
+          ; "connect = 80"
+          ; "sni = xapi:pool"
+          ; Printf.sprintf "cert = %s" cert
           ]
       in
       let len = String.length conf_contents in


### PR DESCRIPTION
Add SNI "pool" to the stunnel server configuration. This will be used by
clients to request a specific certificate. For now, this is simply
the self-signed certificate used by xapi.

This is safe to merge into xapi. Currently no client it using the SNI. A client needs
access to the public cert of the server before it makes sense to use this feature
and currently the mechanism to distribute these certificates is not yet in place.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>