### PR TITLE
Revert "CA-342527: Avoid traversing lists when possible"

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -211,7 +211,7 @@ let operation (obj : obj) (x : message) =
   let rbac_check_begin =
     if has_session_arg then
       [
-        "let arg_name_params = List.combine ("
+        "let arg_names = "
         ^ List.fold_right
             (fun arg args -> "\"" ^ arg ^ "\"::" ^ args)
             orig_string_args
@@ -223,7 +223,7 @@ let operation (obj : obj) (x : message) =
             else
               "[]"
             )
-        ^ ") __params in"
+        ^ " in"
       ; "let key_names = "
         ^ List.fold_right
             (fun arg args -> "\"" ^ arg ^ "\"::" ^ args)
@@ -231,7 +231,7 @@ let operation (obj : obj) (x : message) =
             "[]"
         ^ " in"
       ; "let rbac __context fn = Rbac.check session_id __call \
-         ~args:arg_name_params ~keys:key_names ~__context ~fn in"
+         ~args:(arg_names,__params) ~keys:key_names ~__context ~fn in"
       ]
     else
       ["let rbac __context fn = fn() in"]
@@ -525,11 +525,10 @@ let gen_module api : O.Module.t =
                  ; "      let session_id = ref_session_of_rpc session_id_rpc in"
                  ; "      Session_check.check false session_id;"
                  ; "      (* based on the Host.call_extension call *)"
-                 ; "      let arg_name_params = List.combine \
-                    (\"session_id\"::__call::[]) __params in"
+                 ; "      let arg_names = \"session_id\"::__call::[] in"
                  ; "      let key_names = [] in"
                  ; "      let rbac __context fn = Rbac.check session_id \
-                    \"Host.call_extension\" ~args:arg_name_params \
+                    \"Host.call_extension\" ~args:(arg_names,__params) \
                     ~keys:key_names ~__context ~fn in"
                  ; "      Server_helpers.forward_extension ~__context rbac { \
                     call with Rpc.name = __call }"

--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -12,6 +12,8 @@
  * GNU Lesser General Public License for more details.
  *)
 
+open Xapi_stdext_std.Listext
+
 module D = Debug.Make (struct let name = "rbac" end)
 
 open D
@@ -106,7 +108,7 @@ let get_keyERR_permission_name permission err = permission ^ "/keyERR:" ^ err
 let permission_of_action ?args ~keys _action =
   (* all permissions are in lowercase, see gen_rbac.writer_ *)
   let action = String.lowercase_ascii _action in
-  if keys = [] then
+  if List.length keys < 1 then
     (* most actions do not use rbac-guarded map keys in the arguments *)
     action
   else (* only actions with rbac-guarded map keys fall here *)
@@ -115,39 +117,64 @@ let permission_of_action ?args ~keys _action =
         (* this should never happen *)
         debug "DENYING access: no args for keyed-action %s" action ;
         get_keyERR_permission_name action "DENY_NOARGS" (* will always deny *)
-    | Some keys_values -> (
-      match List.assoc_opt "key" keys_values with
-      | None ->
-          (* this should never happen *)
-          debug "DENYING access: no 'key' argument in the action %s" action ;
-          get_keyERR_permission_name action "DENY_NOKEY"
-      | Some (Rpc.String key_name_in_args) -> (
-        try
-          let key_name =
-            List.find
-              (fun key_name ->
-                if Astring.String.is_suffix ~affix:"*" key_name then
-                  (* resolve wildcards at the end *)
-                  Astring.String.is_prefix
-                    ~affix:(String.sub key_name 0 (String.length key_name - 1))
-                    key_name_in_args
-                else (* no wildcards to resolve *)
-                  key_name = key_name_in_args)
-              keys
-          in
-          get_key_permission_name action (String.lowercase_ascii key_name)
-        with Not_found ->
-          (* expected, key_in_args is not rbac-protected *)
-          action
-      )
-      | Some value ->
+    | Some (arg_keys, arg_values) ->
+        if List.length arg_keys <> List.length arg_values then (
           (* this should never happen *)
           debug
-            "DENYING access: wrong XML value [%s] in the 'key' argument of \
-             action %s"
-            (Rpc.to_string value) action ;
-          get_keyERR_permission_name action "DENY_NOVALUE"
-    )
+            "DENYING access: arg_keys and arg_values lengths don't match: \
+             arg_keys=[%s], arg_values=[%s]"
+            (List.fold_left (fun ss s -> ss ^ s ^ ",") "" arg_keys)
+            (List.fold_left
+               (fun ss s -> ss ^ Rpc.to_string s ^ ",")
+               "" arg_values) ;
+          get_keyERR_permission_name action "DENY_WRGLEN" (* will always deny *)
+        ) else (* keys and values have the same length *)
+          let rec get_permission_name_of_keys arg_keys arg_values =
+            match (arg_keys, arg_values) with
+            | [], [] | _, [] | [], _ ->
+                (* this should never happen *)
+                debug "DENYING access: no 'key' argument in the action %s"
+                  action ;
+                get_keyERR_permission_name action "DENY_NOKEY"
+                (* deny by default *)
+            | k :: ks, v :: vs -> (
+                if k <> "key" (* "key" is defined in datamodel_utils.ml *) then
+                  get_permission_name_of_keys ks vs
+                else (* found "key" in args *)
+                  match v with
+                  | Rpc.String key_name_in_args -> (
+                    try
+                      (*debug "key_name_in_args=%s, keys=[%s]" key_name_in_args ((List.fold_left (fun ss s->ss^s^",") "" keys)) ;*)
+                      let key_name =
+                        List.find
+                          (fun key_name ->
+                            if Astring.String.is_suffix ~affix:"*" key_name then
+                              (* resolve wildcards at the end *)
+                              Astring.String.is_prefix
+                                ~affix:
+                                  (String.sub key_name 0
+                                     (String.length key_name - 1))
+                                key_name_in_args
+                            else (* no wildcards to resolve *)
+                              key_name = key_name_in_args)
+                          keys
+                      in
+                      get_key_permission_name action
+                        (String.lowercase_ascii key_name)
+                    with Not_found ->
+                      (* expected, key_in_args is not rbac-protected *)
+                      action
+                  )
+                  | _ ->
+                      (* this should never happen *)
+                      debug
+                        "DENYING access: wrong XML value [%s] in the 'key' \
+                         argument of action %s"
+                        (Rpc.to_string v) action ;
+                      get_keyERR_permission_name action "DENY_NOVALUE"
+              )
+          in
+          get_permission_name_of_keys arg_keys arg_values
 
 let is_permission_in_session ~session_id ~permission ~session =
   let find_linear elem set = List.exists (fun e -> e = elem) set in

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -75,8 +75,10 @@ let append_to_master_audit_log __context action line =
           Client.Pool.audit_log_append ~rpc ~session_id ~line)
 
 let rbac_audit_params_of (req : Request.t) =
-  req.Request.cookie @ req.Request.query
-  |> List.map (fun (n, v) -> (n, Rpc.String v))
+  let all = req.Request.cookie @ req.Request.query in
+  List.fold_right
+    (fun (n, v) (acc_n, acc_v) -> (n :: acc_n, Rpc.String v :: acc_v))
+    all ([], [])
 
 let assert_credentials_ok realm ?(http_action = realm) ?(fn = Rbac.nofn)
     (req : Request.t) ic =


### PR DESCRIPTION
This reverts commit 517562e412a1e0984e32e1f8da2178745d48e2b3.

The change caused internal errors when a list of names could not be
generated that match the number of parameters in calls with defaults,
such as migrate_receive.