### PR TITLE
CA-352111: Do not output on cronjobs unless there's an error

### DIFF
--- a/scripts/certificate-check
+++ b/scripts/certificate-check
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if ! grep -q master /etc/xensource/pool.conf; then
-    echo "Not checking certificate expiration for alerts, this is not a master host"
+    # "Not checking certificate expiration for alerts, this is not a master host"
     exit 0
 fi
 


### PR DESCRIPTION
This may trigger users being sent mails with the output, which is
confusing when no errors happened.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>