### PR TITLE
CP-36096: Generate two certificates at startup

### DIFF
--- a/ocaml/gencert/dune
+++ b/ocaml/gencert/dune
@@ -10,7 +10,6 @@
     forkexec
     mirage-crypto
     mirage-crypto-pk
-    mirage-crypto-rng.unix
     ptime
     ptime.clock.os
     result

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -3,6 +3,10 @@ val write_certs : string -> string -> (unit, [> Rresult.R.msg]) result
 [pkcs12] should contain a components of a PKCS12 Certificate *)
 
 val host :
-  cn:string -> dns_names:string list -> ips:Cstruct.t list -> string -> unit
-(** [host cn dns_names ip path] creates (atomically) a PEM file at
-    [path] with [cn], and the following SANs: [dns_names] + [ip] *)
+  name:string -> dns_names:string list -> ips:Cstruct.t list -> string -> unit
+(** [host name dns_names ip path] creates (atomically) a PEM file at
+    [path] with [name] as CN, and the following SANs: [dns_names] + [ip] *)
+
+val xapi_pool : uuid:string -> string -> unit
+(** [xapi_pool uuid path] creates (atomically) a PEM file at [path] with
+    [uuid] as CN *)

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1704,6 +1704,8 @@ module Stunnel : sig
 end = struct
   let cert = !Xapi_globs.server_cert_path
 
+  let pool_cert = !Xapi_globs.server_cert_internal_path
+
   (** protect ourselves from concurrent writes to files *)
   module Config : sig
     val update : accept:string -> unit
@@ -1761,7 +1763,7 @@ end = struct
           ; "[pool]"
           ; "connect = 80"
           ; "sni = xapi:pool"
-          ; Printf.sprintf "cert = %s" cert
+          ; Printf.sprintf "cert = %s" pool_cert
           ]
       in
       let len = String.length conf_contents in

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -731,6 +731,10 @@ let pool_secret_path = ref (Filename.concat "/etc/xensource" "ptoken")
 (* Path to server ssl certificate *)
 let server_cert_path = ref (Filename.concat "/etc/xensource" "xapi-ssl.pem")
 
+(* Path to server certificate used for host-to-host TLS connections *)
+let server_cert_internal_path =
+  ref (Filename.concat "/etc/xensource" "xapi-pool-tls.pem")
+
 let stunnel_cert_path = ref "/etc/stunnel/xapi-stunnel-ca-bundle.pem"
 
 let stunnel_conf = ref "/etc/stunnel/xapi.conf"
@@ -1278,6 +1282,9 @@ module Resources = struct
     ; ("logconfig", log_config_file, "Configure the logging policy")
     ; ("cpu-info-file", cpu_info_file, "Where to cache boot-time CPU info")
     ; ("server-cert-path", server_cert_path, "Path to server ssl certificate")
+    ; ( "server-cert-internal-path"
+      , server_cert_internal_path
+      , "Path to server certificate used for host-to-host TLS connections" )
     ; ("stunnel-cert-path", stunnel_cert_path, "Path to CA ssl certificate")
     ; ( "iscsi_initiatorname"
       , iscsi_initiator_config_file

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1406,7 +1406,7 @@ let install_server_certificate ~__context ~host ~certificate ~private_key
 let reset_server_certificate ~__context ~host =
   let self = Helpers.get_localhost ~__context in
   let xapi_ssl_pem = !Xapi_globs.server_cert_path in
-  let cn, ip =
+  let name, ip =
     let dbg = Context.string_of_task __context in
     match Networking_info.get_management_ip_addr ~dbg with
     | None ->
@@ -1418,7 +1418,7 @@ let reset_server_certificate ~__context ~host =
   in
   let dns_names = Networking_info.dns_names () in
   let ips = [ip] in
-  Gencertlib.Selfcert.host ~cn ~dns_names ~ips xapi_ssl_pem ;
+  Gencertlib.Selfcert.host ~name ~dns_names ~ips xapi_ssl_pem ;
   (* Reset stunnel to try to restablish TLS connections *)
   Xapi_mgmt_iface.reconfigure_stunnel ~__context ;
   (* Delete records of the server certificate in this host *)

--- a/scripts/gencert.service
+++ b/scripts/gencert.service
@@ -1,12 +1,13 @@
 [Unit]
-Description=Generate xapi ssl certificate
+Description=Generate TLS certificates for xapi
 Requires=forkexecd.service
 After=forkexecd.service
 
 [Service]
 User=root
 Type=oneshot
-ExecStart=/opt/xensource/libexec/gencert /etc/xensource/xapi-ssl.pem
+ExecStart=/bin/sh -c '/opt/xensource/libexec/gencert /etc/xensource/xapi-ssl.pem default \
+                   && /opt/xensource/libexec/gencert /etc/xensource/xapi-pool-tls.pem xapi:pool'
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
Now two certificates are generated at startup: the additional
certificate will be used for host-to-host communications and contains
the host UUID as the issuer and subject's Common Name. Its validity
period and key type are the same as the other certificate: 3650 days and
RSA 2048 bits, respectively.

Drops gencert's dependency on mirage_crypto_rng as it doesn't generate
the private keys itself anymore.
