### PR TITLE
CP-36099 REQ-403 modelling CA certs in the database

### DIFF
--- a/ocaml/gencert/gencert.ml
+++ b/ocaml/gencert/gencert.ml
@@ -44,7 +44,7 @@ let generate_cert_or_fail ~generator ~path =
 let main ~dbg ~path ~sni =
   let init_inventory () = Inventory.inventory_filename := inventory in
   init_inventory () ;
-  let generator =
+  let generator path =
     match sni with
     | SNI.Default ->
         let name, ip =
@@ -57,10 +57,13 @@ let main ~dbg ~path ~sni =
         in
         let dns_names = Networking_info.dns_names () in
         let ips = [ip] in
-        Gencertlib.Selfcert.host ~name ~dns_names ~ips
+        let (_ : X509.Certificate.t) =
+          Gencertlib.Selfcert.host ~name ~dns_names ~ips path
+        in
+        ()
     | SNI.Xapi_pool ->
         let uuid = Inventory.lookup Inventory._installation_uuid in
-        Gencertlib.Selfcert.xapi_pool ~uuid
+        Gencertlib.Selfcert.xapi_pool ~uuid path
   in
   generate_cert_or_fail ~generator ~path
 

--- a/ocaml/gencert/lib.ml
+++ b/ocaml/gencert/lib.ml
@@ -19,6 +19,8 @@ open Rresult
 
 type t_certificate = Leaf | Chain
 
+let () = Mirage_crypto_rng_unix.initialize ()
+
 let validate_private_key pkcs8_private_key =
   let ensure_key_length = function
     | `RSA priv ->

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -107,7 +107,7 @@ let selfsign issuer extensions key_length days certfile =
   let pkcs12 =
     String.concat "\n\n" [Cstruct.to_string key_pem; Cstruct.to_string cert_pem]
   in
-  write_certs certfile pkcs12
+  write_certs certfile pkcs12 >>| fun () -> cert
 
 let host ~name ~dns_names ~ips pemfile =
   let expire_days = 3650 in
@@ -129,4 +129,5 @@ let xapi_pool ~uuid pemfile =
   in
   let extensions = X509.Extension.empty in
   selfsign issuer extensions key_length expire_days pemfile
+  >>| (fun _ -> ())
   |> R.failwith_error_msg

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -3,7 +3,11 @@ val write_certs : string -> string -> (unit, [> Rresult.R.msg]) result
 [pkcs12] should contain a components of a PKCS12 Certificate *)
 
 val host :
-  name:string -> dns_names:string list -> ips:Cstruct.t list -> string -> unit
+     name:string
+  -> dns_names:string list
+  -> ips:Cstruct.t list
+  -> string
+  -> X509.Certificate.t
 (** [host name dns_names ip path] creates (atomically) a PEM file at
     [path] with [name] as CN, and the following SANs: [dns_names] + [ip] *)
 

--- a/ocaml/idl/datamodel_certificate.ml
+++ b/ocaml/idl/datamodel_certificate.ml
@@ -18,6 +18,13 @@ open Datamodel_roles
 
 let lifecycle = [Published, rel_stockholm, ""]
 
+let certificate_type =
+  Enum ( "certificate_type",
+         [ "ca", "Certificate that is trusted by the whole pool"
+         ; "host", "Certificate that identifies a single host"
+         ]
+       )
+
 let t =
   create_obj
     ~name: _certificate
@@ -32,6 +39,16 @@ let t =
     ~messages_default_allowed_roles:_R_READ_ONLY
     ~contents:
       [ uid   _certificate ~lifecycle
+      ; field ~qualifier:DynamicRO ~lifecycle:[Published, rel_next, ""]
+          (* Any cert records existing before the introduction of the 'name' field
+           * have no name, because they are of type 'host' *)
+          ~ty:String "name" ~default_value:(Some (VString ""))
+          "The name of the certificate, only present on certificates of type 'ca'"
+      ; field ~qualifier:DynamicRO ~lifecycle:[Published, rel_next, ""]
+          (* Any cert records existing before the introduction of the 'host' field
+           * are of type host *)
+          ~ty:certificate_type "type"  ~default_value:(Some (VEnum "host"))
+          "The type of the certificate, either 'ca' or 'host'"
       ; field   ~qualifier:StaticRO ~lifecycle
           ~ty:(Ref _host) "host" ~default_value:(Some (VRef null_ref))
           "The host where the certificate is installed"

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 701
+let schema_minor_vsn = 702
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -872,21 +872,6 @@ let host_query_ha = call ~flags:[`Session]
       ~allowed_roles:_R_POOL_OP
       ()
 
-  let certificate_install = call
-      ~pool_internal:true
-      ~hide_from_docs:true
-      ~name:"certificate_install"
-      ~doc:"Install a TLS CA certificate on this host."
-      ~params:[Ref _host, "host", "The host";
-               String, "name", "A name to give the certificate";
-               String, "cert", "The certificate"]
-      ~allowed_roles:_R_LOCAL_ROOT_ONLY
-      ~lifecycle:
-        [Published, rel_george, "Install TLS CA certificate"
-        ;Deprecated, rel_next, "Use Host.install_ca_certificate instead"
-        ]
-      ()
-
   let install_ca_certificate = call
       ~pool_internal:true
       ~hide_from_docs:true
@@ -898,20 +883,6 @@ let host_query_ha = call ~flags:[`Session]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ~lifecycle:
         [Published, rel_next, "Install TLS CA certificate"
-        ]
-      ()
-
-  let certificate_uninstall = call
-      ~pool_internal:true
-      ~hide_from_docs:true
-      ~name:"certificate_uninstall"
-      ~doc:"Remove a TLS CA certificate from this host."
-      ~params:[Ref _host, "host", "The host";
-               String, "name", "The certificate name"]
-      ~allowed_roles:_R_LOCAL_ROOT_ONLY
-      ~lifecycle:
-        [Published, rel_george, "Install TLS CA certificate"
-        ;Deprecated, rel_next, "Use Host.uninstall_ca_certificate instead"
         ]
       ()
 
@@ -1524,8 +1495,6 @@ let host_query_ha = call ~flags:[`Session]
         retrieve_wlb_evacuate_recommendations;
         install_ca_certificate;
         uninstall_ca_certificate;
-        certificate_install;
-        certificate_uninstall;
         certificate_list;
         crl_install;
         crl_uninstall;

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -983,7 +983,6 @@ let host_query_ha = call ~flags:[`Session]
       ()
 
   let reset_server_certificate = call
-      ~flags:[`Session]
       ~lifecycle:[Published, rel_next, ""]
       ~name:"reset_server_certificate"
       ~doc:"Delete the current TLS server certificate and replace by a new, self-signed one. This should only be used with extreme care."

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "872773fe55299078f775870ca929b613"
+let last_known_schema_hash = "481eed2bac7e125a601e3f5b3131c52d"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1196,7 +1196,7 @@ let gen_cmds rpc session_id =
     ; Client.Certificate.(
         mk get_all get_all_records_where get_by_uuid certificate_record
           "certificate" []
-          ["uuid"; "host"; "fingerprint"]
+          ["uuid"; "type"; "name"; "host"; "fingerprint"]
           rpc session_id)
     ]
 

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -17,6 +17,8 @@ exception Record_failure of string
 
 let to_str = function Rpc.String x -> x | _ -> failwith "Invalid"
 
+let certificate_type_to_string = function `host -> "host" | `ca -> "ca"
+
 let class_to_string cls =
   match cls with
   | `VM ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -4313,6 +4313,12 @@ let certificate_record rpc session_id certificate =
   ; fields=
       [
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.certificate_uuid) ()
+      ; make_field ~name:"type"
+          ~get:(fun () ->
+            (x ()).API.certificate_type
+            |> Record_util.certificate_type_to_string)
+          ()
+      ; make_field ~name:"name" ~get:(fun () -> (x ()).API.certificate_name) ()
       ; make_field ~name:"host"
           ~get:(fun () -> (x ()).API.certificate_host |> get_uuid_from_ref)
           ()

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -19,6 +19,8 @@ module D = Debug.Make (struct let name = "certificates" end)
 
 open D
 
+let () = Mirage_crypto_rng_unix.initialize ()
+
 (* Certificate locations:
   * a) stunnel external             = /etc/xensource/xapi-ssl.pem
   * b) stunnel SNI (internal)       = /etc/xensource/xapi-pool-tls.pem

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -19,6 +19,16 @@ module D = Debug.Make (struct let name = "certificates" end)
 
 open D
 
+(* Certificate locations:
+  * a) stunnel external             = /etc/xensource/xapi-ssl.pem
+  * b) stunnel SNI (internal)       = /etc/xensource/xapi-pool-tls.pem
+  * c) user trusted cert folder     = /etc/stunnel/certs/
+  * d) internal trusted cert folder = /etc/stunnel/certs-pool/
+  * e) appliance trusted bundle     = /etc/stunnel/xapi-stunnel-ca-bundle.pem
+  * f) host-in-pool trusted bundle  = /etc/stunnel/xapi-pool-ca-bundle.pem
+  *
+  * Note that the bundles (e) and (f) are generated automatically using the contents of (c) and (d) respectively *)
+
 type t_trusted = CA_Certificate | CRL
 
 let c_rehash = "/usr/bin/c_rehash"

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -57,6 +57,7 @@
    message-switch-core
    message-switch-unix
    mirage-crypto
+   mirage-crypto-rng.unix
    mtime
    mtime.clock.os
    pam

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1346,11 +1346,6 @@ let install_ca_certificate ~__context ~host ~name ~cert =
 let uninstall_ca_certificate ~__context ~host ~name =
   Certificates.(host_uninstall CA_Certificate name)
 
-(* legacy names *)
-let certificate_uninstall = uninstall_ca_certificate
-
-let certificate_install = install_ca_certificate
-
 let certificate_list ~__context ~host = Certificates.(local_list CA_Certificate)
 
 let crl_install ~__context ~host ~name ~crl =

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -277,12 +277,6 @@ val install_ca_certificate :
 
 val uninstall_ca_certificate : __context:'a -> host:'b -> name:string -> unit
 
-(* legacy names *)
-val certificate_install :
-  __context:'a -> host:'b -> name:string -> cert:string -> unit
-
-val certificate_uninstall : __context:'a -> host:'b -> name:string -> unit
-
 val certificate_list : __context:'a -> host:'b -> string list
 
 val crl_install : __context:'a -> host:'b -> name:string -> crl:string -> unit

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -273,9 +273,10 @@ val get_uncooperative_domains :
   __context:Context.t -> self:[`host] Ref.t -> string list
 
 val install_ca_certificate :
-  __context:'a -> host:'b -> name:string -> cert:string -> unit
+  __context:Context.t -> host:API.ref_host -> name:string -> cert:string -> unit
 
-val uninstall_ca_certificate : __context:'a -> host:'b -> name:string -> unit
+val uninstall_ca_certificate :
+  __context:Context.t -> host:API.ref_host -> name:string -> unit
 
 val certificate_list : __context:'a -> host:'b -> string list
 
@@ -305,7 +306,7 @@ val install_server_certificate :
     remote. This is done to refresh the server certificate used in the
     connections. *)
 
-val emergency_reset_server_certificate : __context:Context.t -> unit
+val emergency_reset_server_certificate : __context:'a -> unit
 
 val reset_server_certificate : __context:Context.t -> host:API.ref_host -> unit
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2130,11 +2130,21 @@ let retrieve_wlb_recommendations ~__context = get_opt_recommendations ~__context
 
 let send_test_post = Remote_requests.send_test_post
 
-let certificate_install = Certificates.(pool_install CA_Certificate)
+let certificate_install ~__context ~name ~cert =
+  let open Certificates in
+  let certificate = pem_of_string cert in
+  pool_install CA_Certificate ~__context ~name ~cert ;
+  let (_ : API.ref_Certificate) =
+    Db_util.add_cert ~__context ~type':(`ca name) certificate
+  in
+  ()
 
 let install_ca_certificate = certificate_install
 
-let certificate_uninstall = Certificates.(pool_uninstall CA_Certificate)
+let certificate_uninstall ~__context ~name =
+  let open Certificates in
+  pool_uninstall CA_Certificate ~__context ~name ;
+  Db_util.remove_ca_cert_by_name ~__context name
 
 let uninstall_ca_certificate = certificate_uninstall
 


### PR DESCRIPTION
This PR adds some new fields to certs in the database. We also make sure that certs are added to the database when they are changed via the API (this means `Host.reset_server_certificate`, `Host.install_server_certificate` and `Pool.install_ca_certificate`)