### PR TITLE
Initialise Mirage RNG on startup

### DIFF
--- a/ocaml/gencert/dune
+++ b/ocaml/gencert/dune
@@ -10,6 +10,7 @@
     forkexec
     mirage-crypto
     mirage-crypto-pk
+    mirage-crypto-rng.unix
     ptime
     ptime.clock.os
     result

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -18,6 +18,11 @@ open Rresult (* introduces >>= >>| and R *)
 
 module D = Debug.Make (struct let name = "gencert_selfcert" end)
 
+(** initialize the random number generator at program startup when this
+module is loaded. *)
+let () = Mirage_crypto_rng_unix.initialize ()
+
+
 (** [write_cert] writes a PKCS12 file to [path]. The typical file
  extension would be ".pem". It attempts to do that atomically by
  writing to a temporary file in the same directory first and renaming


### PR DESCRIPTION
The Mirage crypto modules use a random number generator and it needs to
be initialised. We do this with a side effect during startup: the code
is initialised as the part of the Selfcert module when it initialises
its global values.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>