### PR TITLE
CP-36100 extend update-ca-bundle to handle pool certs

### DIFF
--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -22,7 +22,6 @@ module D = Debug.Make (struct let name = "gencert_selfcert" end)
 module is loaded. *)
 let () = Mirage_crypto_rng_unix.initialize ()
 
-
 (** [write_cert] writes a PKCS12 file to [path]. The typical file
  extension would be ".pem". It attempts to do that atomically by
  writing to a temporary file in the same directory first and renaming

--- a/scripts/update-ca-bundle.sh
+++ b/scripts/update-ca-bundle.sh
@@ -5,6 +5,12 @@
 
 set -e
 
-mkdir -p /etc/stunnel
-find /etc/stunnel/certs -name '*.pem' | xargs cat > /etc/stunnel/xapi-stunnel-ca-bundle.pem.tmp
-mv /etc/stunnel/xapi-stunnel-ca-bundle.pem.tmp /etc/stunnel/xapi-stunnel-ca-bundle.pem
+ST="/etc/stunnel"
+
+mkdir -p ${ST}/certs
+find ${ST}/certs -name '*.pem' | xargs cat > ${ST}/xapi-stunnel-ca-bundle.tmp
+mv ${ST}/xapi-stunnel-ca-bundle.tmp ${ST}/xapi-stunnel-ca-bundle.pem
+
+mkdir -p ${ST}/certs-pool
+find ${ST}/certs-pool -name '*.pem' | xargs cat > ${ST}/xapi-pool-ca-bundle.tmp
+mv ${ST}/xapi-pool-ca-bundle.tmp ${ST}/xapi-pool-ca-bundle.pem


### PR DESCRIPTION
update-ca-bundle.sh takes indvidicual certificates and bundles them into
a single *.pem for Stunnel to use. Extend this to handle
certificates both in

* /etc/stunnel/certs
* /etc/stunnel/certs-pool

Typically only certifcates in one of the two directories would be
updated and hence need to be re-bundled. However, the operation is so
cheap that the complexity of doing this selectively is not worth it. We
could pass an argument to this script to let it do work more
selectively.

This fixes also a bug: the directory find(1) operates on needs to exist.
The mkdir(1) call ensures it does.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>