### PR TITLE
CP-36100-2 Use explicit config for TLS Stunnel verification

### DIFF
--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -158,9 +158,11 @@ let on_database_connection_established = ref (fun () -> ())
 let open_secure_connection () =
   let host = !get_master_address () in
   let port = !Db_globs.https_port in
+  let verify_cert = None in
+  (* CL *)
   Stunnel.with_connect ~use_fork_exec_helper:true ~extended_diagnosis:true
     ~write_to_log:(fun x -> debug "stunnel: %s\n" x)
-    host port
+    ~verify_cert host port
   @@ fun st_proc ->
   let fd_closed = Thread.wait_timed_read Unixfd.(!(st_proc.Stunnel.fd)) 5. in
   let proc_quit =

--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -76,8 +76,9 @@ let force_connection_reset () =
       | Some () ->
           purge_stunnels verify_cert
     in
-    purge_stunnels true ;
-    purge_stunnels false ;
+    purge_stunnels None ;
+    purge_stunnels (Some Stunnel.pool) ;
+    purge_stunnels (Some Stunnel.appliance) ;
     info
       "force_connection_reset: all cached connections to the master have been \
        purged"

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -22,7 +22,6 @@ module D = Debug.Make (struct let name = "gencert_selfcert" end)
 module is loaded. *)
 let () = Mirage_crypto_rng_unix.initialize ()
 
-
 (** [write_cert] writes a PKCS12 file to [path]. The typical file
  extension would be ".pem". It attempts to do that atomically by
  writing to a temporary file in the same directory first and renaming

--- a/ocaml/xapi/remote_requests.ml
+++ b/ocaml/xapi/remote_requests.ml
@@ -150,7 +150,7 @@ let queue_request req =
       request_queue := req :: !request_queue ;
       Condition.signal request_cond)
 
-let perform_request ~__context ~timeout ?verify_cert ~host ~port ~request
+let perform_request ~__context ~timeout ~verify_cert ~host ~port ~request
     ~handler ~enable_log =
   let task = Context.get_task_id __context in
   let resp = ref NoResponse in
@@ -188,11 +188,13 @@ let read_response result response s =
 let send_test_post ~__context ~host ~port ~body =
   try
     let result = ref "" in
+    let verify_cert = None in
+    (* CL *)
     let request =
       Xapi_http.http_request ~keep_alive:false ~body ~headers:[("Host", host)]
         Http.Post "/"
     in
-    perform_request ~__context ~timeout:30.0 ~verify_cert:Stunnel.pool ~host
+    perform_request ~__context ~timeout:30.0 ~verify_cert ~host
       ~port:(Int64.to_int port) ~request ~handler:(read_response result)
       ~enable_log:true ;
     !result

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -295,7 +295,13 @@ let wlb_request ~__context ~host ~port ~auth ~meth ~params ~handler ~enable_log
   let body = wlb_body meth params in
   let request = wlb_request host meth body auth in
   let pool = Helpers.get_pool ~__context in
-  let verify_cert = Db.Pool.get_wlb_verify_cert ~__context ~self:pool in
+  let verify_cert =
+    match Db.Pool.get_wlb_verify_cert ~__context ~self:pool with
+    | true ->
+        Some Stunnel.appliance
+    | false ->
+        None
+  in
   let pool_other_config = Db.Pool.get_other_config ~__context ~self:pool in
   let timeout =
     try
@@ -311,7 +317,7 @@ let wlb_request ~__context ~host ~port ~auth ~meth ~params ~handler ~enable_log
          (filtered_headers (Http.Request.to_header_list request)))
       body ;
   try
-    Remote_requests.perform_request ~__context ~timeout ~verify_cert ~host ~port
+    Remote_requests.perform_request ~__context ~timeout ?verify_cert ~host ~port
       ~request ~handler ~enable_log
   with
   | Remote_requests.Timed_out ->

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -317,7 +317,7 @@ let wlb_request ~__context ~host ~port ~auth ~meth ~params ~handler ~enable_log
          (filtered_headers (Http.Request.to_header_list request)))
       body ;
   try
-    Remote_requests.perform_request ~__context ~timeout ?verify_cert ~host ~port
+    Remote_requests.perform_request ~__context ~timeout ~verify_cert ~host ~port
       ~request ~handler ~enable_log
   with
   | Remote_requests.Timed_out ->

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -305,12 +305,14 @@ let exit_status = ref 1
 
 let with_open_tcp_ssl server f =
   let port = get_xapiport true in
+  let verify_cert = None in
+  (* CL *)
   debug "Connecting via stunnel to [%s] port [%d]\n%!" server port ;
   (* We don't bother closing fds since this requires our close_and_exec wrapper *)
   let open Safe_resources in
   Stunnel.with_connect ~use_fork_exec_helper:false
     ~write_to_log:(fun x -> debug "stunnel: %s\n%!" x)
-    ~extended_diagnosis:(!debug_file <> None) server port
+    ~verify_cert ~extended_diagnosis:(!debug_file <> None) server port
   @@ fun x ->
   let x = Stunnel.move_out_exn x in
   let ic = Unix.in_channel_of_descr (Unix.dup Unixfd.(!(x.Stunnel.fd))) in

--- a/ocaml/xsh/xsh.ml
+++ b/ocaml/xsh/xsh.ml
@@ -73,11 +73,13 @@ let proxy (ain : Unix.file_descr) (aout : Unix.file_descr)
 
 let with_open_tcp_ssl server f =
   let port = 443 in
+  let verify_cert = None in
+  (* CL *)
   (* We don't bother closing fds since this requires our close_and_exec wrapper *)
   let open Safe_resources in
   Stunnel.with_connect ~use_fork_exec_helper:false
     ~write_to_log:(fun _ -> ())
-    server port
+    ~verify_cert server port
   @@ fun x -> f Unixfd.(!(x.Stunnel.fd))
 
 let _ =


### PR DESCRIPTION
When Stunnel creates a conncetion as a client it can verify this
connection using certificates. We have intra pool connections and
connections opened to appliances, which use different verification
methods. This needs to be reflected beyond yes/no. This patch makes
(more) explicit the configuration to use for verifcation.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>