### PR TITLE
Support to enable multiple repositories

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5599,6 +5599,8 @@ let all_relations =
     (_network_sriov, "logical_PIF"), (_pif, "sriov_logical_PIF_of");
 
     (_certificate, "host"), (_host, "certificates");
+
+    (_pool, "repositories"), (_repository, "enabled_on");
   ]
 
 (** the full api specified here *)

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5599,8 +5599,6 @@ let all_relations =
     (_network_sriov, "logical_PIF"), (_pif, "sriov_logical_PIF_of");
 
     (_certificate, "host"), (_host, "certificates");
-
-    (_pool, "repositories"), (_repository, "enabled_on");
   ]
 
 (** the full api specified here *)

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1203,8 +1203,8 @@ let _ =
     ~doc:"The current version of Xen or its control libraries is incompatible with the Toolstack." ();
 
   (* repository and updates errors *)
-  error Api_errors.set_repository_in_progress []
-    ~doc:"The operation could not be performed because a repository setup is in progress." ();
+  error Api_errors.configure_repositories_in_progress []
+    ~doc:"The operation could not be performed because other repository(ies) is(are) already being configured." ();
   error Api_errors.invalid_base_url ["url"]
     ~doc:"The base url in the repository is invalid." ();
   error Api_errors.repository_already_exists ["ref"]
@@ -1217,6 +1217,8 @@ let _ =
     ~doc:"Failed to clean up local repository on master." ();
   error Api_errors.no_repository_enabled []
     ~doc:"There is no repository being enabled." ();
+  error Api_errors.multiple_update_repositories_enabled []
+    ~doc:"There is more than one update repository being enabled." ();
   error Api_errors.sync_updates_in_progress []
     ~doc:"The operation could not be performed because syncing updates is in progress." ();
   error Api_errors.reposync_failed []

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -861,6 +861,6 @@ open Datamodel_types
          ; field ~in_product_since:rel_quebec ~qualifier:RW ~ty:String ~default_value:(Some (VString "")) "uefi_certificates" "The UEFI certificates allowing Secure Boot"
          ; field ~in_product_since:rel_stockholm_psr ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "is_psr_pending" "True if either a PSR is running or we are waiting for a PSR to be re-run"
          ; field ~qualifier:DynamicRO ~in_product_since:rel_next ~lifecycle:[Published, rel_next, ""] ~ty:Bool ~default_value:(Some (VBool false)) "tls_verification_enabled" "True iff TLS certificate verification is enabled"
-         ; field ~in_product_since:rel_next ~qualifier:DynamicRO ~ty:(Set (Ref _repository)) "repositories" "The set of currently enabled repositories"
+         ; field ~in_product_since:rel_next ~qualifier:DynamicRO ~ty:(Set (Ref _repository)) ~ignore_foreign_key:true "repositories" ~default_value:(Some (VSet [])) "The set of currently enabled repositories"
          ])
       ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -8,7 +8,7 @@ open Datamodel_types
             "ha_disable", "Indicates this pool is in the process of disabling HA";
             "cluster_create", "Indicates this pool is in the process of creating a cluster";
             "designate_new_master", "Indicates this pool is in the process of changing master";
-            "set_repository", "Indicates this pool is in the process of configuring repository";
+            "configure_repositories", "Indicates this pool is in the process of configuring repositories";
             "sync_updates", "Indicates this pool is in the process of syncing updates";
             "get_updates", "Indicates this pool is in the process of getting updates";
             "apply_updates", "Indicates this pool is in the process of applying updates";
@@ -688,13 +688,35 @@ open Datamodel_types
     ~allowed_roles:_R_POOL_ADMIN
     ()
 
-  let set_repository = call
-      ~name:"set_repository"
+  let set_repositories = call
+      ~name:"set_repositories"
       ~in_product_since:rel_next
-      ~doc:"Set the enabled repository for updates"
+      ~doc:"Set enabled set of repositories"
       ~params:[
         Ref _pool, "self", "The pool";
-        Ref _repository, "value", "The repository to be enabled"
+        Set (Ref _repository), "value", "The set of repositories to be enabled"
+      ]
+      ~allowed_roles:_R_POOL_ADMIN
+      ()
+
+  let add_repository = call
+      ~name:"add_repository"
+      ~in_product_since:rel_next
+      ~doc:"Add a repository to the enabled set"
+      ~params:[
+        Ref _pool, "self", "The pool";
+        Ref _repository, "value", "The repository to be added to the enabled set"
+      ]
+      ~allowed_roles:_R_POOL_ADMIN
+      ()
+
+  let remove_repository = call
+      ~name:"remove_repository"
+      ~in_product_since:rel_next
+      ~doc:"Remove a repository from the enabled set"
+      ~params:[
+        Ref _pool, "self", "The pool";
+        Ref _repository, "value", "The repository to be removed"
       ]
       ~allowed_roles:_R_POOL_ADMIN
       ()
@@ -788,7 +810,9 @@ open Datamodel_types
         ; add_to_guest_agent_config
         ; remove_from_guest_agent_config
         ; rotate_secret
-        ; set_repository
+        ; set_repositories
+        ; add_repository
+        ; remove_repository
         ; sync_updates
         ]
       ~contents:
@@ -837,6 +861,6 @@ open Datamodel_types
          ; field ~in_product_since:rel_quebec ~qualifier:RW ~ty:String ~default_value:(Some (VString "")) "uefi_certificates" "The UEFI certificates allowing Secure Boot"
          ; field ~in_product_since:rel_stockholm_psr ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool false)) "is_psr_pending" "True if either a PSR is running or we are waiting for a PSR to be re-run"
          ; field ~qualifier:DynamicRO ~in_product_since:rel_next ~lifecycle:[Published, rel_next, ""] ~ty:Bool ~default_value:(Some (VBool false)) "tls_verification_enabled" "True iff TLS certificate verification is enabled"
-         ; field ~in_product_since:rel_next ~qualifier:DynamicRO ~ty:(Ref _repository) ~default_value:(Some (VRef null_ref)) "repository" "The enabled repository for updates"
+         ; field ~in_product_since:rel_next ~qualifier:DynamicRO ~ty:(Set (Ref _repository)) "repositories" "The set of currently enabled repositories"
          ])
       ()

--- a/ocaml/idl/datamodel_repository.ml
+++ b/ocaml/idl/datamodel_repository.ml
@@ -70,6 +70,9 @@ let t =
     ~contents:
       [ uid       _repository ~lifecycle;
         namespace ~name:"name" ~contents:(names ~writer_roles:_R_POOL_OP None RW) ();
+        field   ~qualifier:DynamicRO ~lifecycle
+          ~ty:(Set (Ref _pool)) "enabled_on"
+          "The pools where the repository is enabled on";
         field     ~qualifier:StaticRO ~lifecycle
           ~ty:String
           ~default_value:(Some (VString ""))

--- a/ocaml/idl/datamodel_repository.ml
+++ b/ocaml/idl/datamodel_repository.ml
@@ -28,6 +28,7 @@ let introduce = call
       String, "name_description", "The description of the repository";
       String, "binary_url", "Base URL of binary packages in this repository";
       String, "source_url", "Base URL of source packages in this repository";
+      Bool, "update", "True if the repository is an update repository. This means that updateinfo.xml will be parsed";
     ]
     ~result:(Ref _repository, "The ref of the created repository record.")
     ~allowed_roles:_R_POOL_OP
@@ -70,9 +71,6 @@ let t =
     ~contents:
       [ uid       _repository ~lifecycle;
         namespace ~name:"name" ~contents:(names ~writer_roles:_R_POOL_OP None RW) ();
-        field   ~qualifier:DynamicRO ~lifecycle
-          ~ty:(Set (Ref _pool)) "enabled_on"
-          "The pools where the repository is enabled on";
         field     ~qualifier:StaticRO ~lifecycle
           ~ty:String
           ~default_value:(Some (VString ""))
@@ -83,11 +81,16 @@ let t =
           ~default_value:(Some (VString ""))
           "source_url"
           "Base URL of source packages in this repository";
+        field     ~qualifier:StaticRO ~lifecycle
+           ~ty:Bool
+           ~default_value:(Some (VBool false))
+           "update"
+           "True if updateinfo.xml in this repository needs to be parsed";
         field     ~qualifier:DynamicRO ~lifecycle
           ~ty:String
           ~default_value:(Some (VString ""))
           "hash"
-          "SHA256 checksum of latest updateinfo.xml.gz in this repository";
+          "SHA256 checksum of latest updateinfo.xml.gz in this repository if its 'update' is true";
         field     ~qualifier:DynamicRO ~lifecycle
           ~ty:Bool
           ~default_value:(Some (VBool false))

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "5115945f27703c84a08dcc94a10469e5"
+let last_known_schema_hash = "ddaf771dae1e25c706d6bd86d6e264a5"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -276,7 +276,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(ha_cluster_stack = !Xapi_globs.cluster_stack_default)
     ?(guest_agent_config = []) ?(cpu_info = [])
     ?(policy_no_vendor_device = false) ?(live_patching_disabled = false)
-    ?(uefi_certificates = "") ?(repository = Ref.null) () =
+    ?(uefi_certificates = "") () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -288,7 +288,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~allowed_operations ~restrictions ~other_config ~ha_cluster_stack
     ~guest_agent_config ~cpu_info ~policy_no_vendor_device
     ~live_patching_disabled ~uefi_certificates ~is_psr_pending:false
-    ~tls_verification_enabled:false ~repository ;
+    ~tls_verification_enabled:false ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -276,7 +276,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(ha_cluster_stack = !Xapi_globs.cluster_stack_default)
     ?(guest_agent_config = []) ?(cpu_info = [])
     ?(policy_no_vendor_device = false) ?(live_patching_disabled = false)
-    ?(uefi_certificates = "") () =
+    ?(uefi_certificates = "") ?(repositories = []) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -288,7 +288,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~allowed_operations ~restrictions ~other_config ~ha_cluster_stack
     ~guest_agent_config ~cpu_info ~policy_no_vendor_device
     ~live_patching_disabled ~uefi_certificates ~is_psr_pending:false
-    ~tls_verification_enabled:false ;
+    ~tls_verification_enabled:false ~repositories ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/tests/test_repository.ml
+++ b/ocaml/tests/test_repository.ml
@@ -24,13 +24,15 @@ let test_introduce_duplicate_name () =
   let source_url = "https://source-url.com" in
   let source_url_1 = "https://source-url1.com" in
   let ref =
-    Repository.introduce ~__context ~name_label ~name_description ~binary_url ~source_url
+    Repository.introduce
+      ~__context ~name_label ~name_description ~binary_url ~source_url ~update:true
   in
   Alcotest.check_raises "test_introduce_duplicate_name"
     Api_errors.( Server_error (repository_already_exists, [(Ref.string_of ref)]) )
     (fun () ->
        Repository.introduce ~__context ~name_label
-         ~name_description:name_description_1 ~binary_url:binary_url_1 ~source_url:source_url_1
+         ~name_description:name_description_1 ~binary_url:binary_url_1
+         ~source_url:source_url_1 ~update:true
        |> ignore)
 
 let test_introduce_duplicate_binary_url () =
@@ -43,13 +45,15 @@ let test_introduce_duplicate_binary_url () =
   let source_url = "https://source-url.com" in
   let source_url_1 = "https://source-url1.com" in
   let ref =
-    Repository.introduce ~__context ~name_label ~name_description ~binary_url ~source_url
+    Repository.introduce
+      ~__context ~name_label ~name_description ~binary_url ~source_url ~update:true
   in
   Alcotest.check_raises "test_introduce_duplicate_name"
     Api_errors.( Server_error (repository_already_exists, [(Ref.string_of ref)]) )
     (fun () ->
        Repository.introduce ~__context ~binary_url:binary_url
-         ~name_label:name_label_1 ~name_description:name_description_1 ~source_url:source_url_1
+         ~name_label:name_label_1 ~name_description:name_description_1
+         ~source_url:source_url_1 ~update:false
        |> ignore)
 
 let test =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3158,7 +3158,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
       } )
   ; ( "repository-introduce"
     , {
-        reqd= ["name-label"; "binary-url"; "source-url"]
+        reqd= ["name-label"; "binary-url"; "source-url"; "update"]
       ; optn= ["name-description"]
       ; help= "Add the configuration for a new repository."
       ; implementation= No_fd Cli_operations.Repository.introduce

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1207,6 +1207,7 @@ let gen_cmds rpc session_id =
           ; "name-description"
           ; "binary-url"
           ; "source-url"
+          ; "update"
           ; "hash"
           ; "up-to-date"
           ]
@@ -7381,8 +7382,9 @@ module Repository = struct
     in
     let binary_url = List.assoc "binary-url" params in
     let source_url = List.assoc "source-url" params in
+    let update = get_bool_param params "update" in
     let ref = Client.Repository.introduce ~rpc ~session_id
-        ~name_label ~name_description ~binary_url ~source_url
+        ~name_label ~name_description ~binary_url ~source_url ~update
     in
     let uuid = Client.Repository.get_uuid ~rpc ~session_id ~self:ref in
     printer (Cli_printer.PList [uuid])

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -145,8 +145,8 @@ let pool_operation_to_string = function
       "cluster_create"
   | `designate_new_master ->
       "designate_new_master"
-  | `set_repository ->
-      "set_repository"
+  | `configure_repositories ->
+      "configure_repositories"
   | `sync_updates ->
       "sync_updates"
   | `get_updates ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -4382,6 +4382,9 @@ let repository_record rpc session_id repository =
       ; make_field ~name:"source-url"
           ~get:(fun () -> (x ()).API.repository_source_url)
           ()
+      ; make_field ~name:"update"
+          ~get:(fun () -> string_of_bool (x ()).API.repository_update)
+          ()
       ; make_field ~name:"hash"
           ~get:(fun () -> (x ()).API.repository_hash)
           ()

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1204,7 +1204,7 @@ let designate_new_master_in_progress = "DESIGNATE_NEW_MASTER_IN_PROGRESS"
 
 let pool_secret_rotation_pending = "POOL_SECRET_ROTATION_PENDING"
 
-let set_repository_in_progress = "SET_REPOSITORY_IN_PROGRESS"
+let configure_repositories_in_progress = "CONFIGURE_REPOSITORIES_IN_PROGRESS"
 
 let invalid_base_url = "INVALID_BASE_URL"
 
@@ -1217,6 +1217,8 @@ let reposync_in_progress = "REPOSYNC_IN_PROGRESS"
 let repository_cleanup_failed = "REPOSITORY_CLEANUP_FAILED"
 
 let no_repository_enabled = "NO_REPOSITORY_ENABLED"
+
+let multiple_update_repositories_enabled = "MULTIPLE_UPDATE_REPOSITORIES_ENABLED"
 
 let sync_updates_in_progress = "SYNC_UPDATES_IN_PROGRESS"
 

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -43,7 +43,7 @@ let create_pool_record ~__context =
       ~ha_cluster_stack:"xhad" ~guest_agent_config:[] ~cpu_info:[]
       ~policy_no_vendor_device:false ~live_patching_disabled:false
       ~uefi_certificates:"" ~is_psr_pending:false
-      ~tls_verification_enabled:false ~repository:Ref.null
+      ~tls_verification_enabled:false
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -43,7 +43,7 @@ let create_pool_record ~__context =
       ~ha_cluster_stack:"xhad" ~guest_agent_config:[] ~cpu_info:[]
       ~policy_no_vendor_device:false ~live_patching_disabled:false
       ~uefi_certificates:"" ~is_psr_pending:false
-      ~tls_verification_enabled:false
+      ~tls_verification_enabled:false ~repositories:[]
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -5727,11 +5727,13 @@ functor
     module Certificate = struct end
 
     module Repository = struct
-      let introduce ~__context ~name_label ~name_description ~binary_url ~source_url =
+      let introduce ~__context ~name_label ~name_description ~binary_url ~source_url ~update =
         info "Repository.introduce: \
-              name = '%s'; name_description = '%s'; binary_url = '%s'; source_url = '%s'"
-          name_label name_description binary_url source_url;
-        Local.Repository.introduce ~__context ~name_label ~name_description ~binary_url ~source_url
+              name = '%s'; name_description = '%s'; binary_url = '%s'; source_url = '%s'; \
+              update = '%s'"
+          name_label name_description binary_url source_url (string_of_bool update) ;
+        Local.Repository.introduce
+          ~__context ~name_label ~name_description ~binary_url ~source_url ~update
 
       let forget ~__context ~self =
         info "Repository.forget: self = '%s'" (repository_uuid ~__context self);

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -940,13 +940,24 @@ functor
                do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
                    Client.Pool.enable_tls_verification rpc session_id))
 
-      let set_repository ~__context ~self ~value =
-        info "Pool.set_repository : pool = '%s'; value = %s"
-          (pool_uuid ~__context self) (repository_uuid ~__context value);
-        Local.Pool.set_repository ~__context ~self ~value
+      let set_repositories ~__context ~self ~value =
+        info "Pool.set_repositories : pool = '%s'; value = [ %s ]"
+          (pool_uuid ~__context self)
+          (String.concat "; " (List.map (repository_uuid ~__context) value)) ;
+        Local.Pool.set_repositories ~__context ~self ~value
+
+      let add_repository ~__context ~self ~value =
+        info "Pool.add_repository : pool = '%s'; repo_uuid = %s"
+          (pool_uuid ~__context self) (repository_uuid ~__context value) ;
+        Local.Pool.add_repository ~__context ~self ~value
+
+      let remove_repository ~__context ~self ~value =
+        info "Pool.remove_repository : pool = '%s'; repo_uuid = %s"
+          (pool_uuid ~__context self) (repository_uuid ~__context value) ;
+        Local.Pool.remove_repository ~__context ~self ~value
 
       let sync_updates ~__context ~self ~force =
-        info "Pool.sync_updates: pool = '%s'; false = %s"
+        info "Pool.sync_updates: pool = '%s'; force = %s"
           (pool_uuid ~__context self) (string_of_bool force);
         Local.Pool.sync_updates ~__context ~self ~force
     end

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -25,7 +25,7 @@ module UpdateIdSet = Set.Make (String)
 let capacity_in_parallel = 16
 let reposync_mutex = Mutex.create ()
 
-let introduce ~__context ~name_label ~name_description ~binary_url ~source_url =
+let introduce ~__context ~name_label ~name_description ~binary_url ~source_url ~update =
   assert_url_is_valid ~url:binary_url;
   assert_url_is_valid ~url:source_url;
   Db.Repository.get_all ~__context
@@ -34,7 +34,7 @@ let introduce ~__context ~name_label ~name_description ~binary_url ~source_url =
       || binary_url = Db.Repository.get_binary_url ~__context ~self:ref then
         raise Api_errors.( Server_error (repository_already_exists, [(Ref.string_of ref)]) ));
   create_repository_record
-    ~__context ~name_label ~name_description ~binary_url ~source_url
+    ~__context ~name_label ~name_description ~binary_url ~source_url ~update
 
 let forget ~__context ~self =
   let pool = Helpers.get_pool ~__context in

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -47,7 +47,7 @@ val sync:
 val create_pool_repository :
      __context:Context.t
   -> self:[`Repository] API.Ref.t
-  -> string
+  -> unit
 
 val get_repository_handler :
      Http.Request.t
@@ -81,3 +81,7 @@ val apply_immediate_guidances :
   -> host:[`host] API.Ref.t
   -> guidances:Repository_helpers.Guidance.t list
   -> unit
+
+val set_available_updates :
+     __context:Context.t
+  -> string

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -26,10 +26,6 @@ val forget :
   -> self:[`Repository] API.Ref.t
   -> unit
 
-val get_enabled_repository :
-     __context:Context.t
-  -> [`Repository] API.Ref.t
-
 val cleanup_all_pool_repositories : unit -> unit
 
 val cleanup_pool_repo  :

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -18,6 +18,7 @@ val introduce :
   -> name_description:string
   -> binary_url:string
   -> source_url:string
+  -> update:bool
   -> [`Repository] API.Ref.t
 
 val forget :

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -29,7 +29,12 @@ val get_enabled_repository :
      __context:Context.t
   -> [`Repository] API.Ref.t
 
-val cleanup_pool_repo  : unit -> unit
+val cleanup_all_pool_repositories : unit -> unit
+
+val cleanup_pool_repo  :
+    __context:Context.t
+  -> self:[`Repository] API.Ref.t
+  -> unit
 
 val with_reposync_lock : (unit -> 'a) -> 'a
 

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -535,7 +535,8 @@ module UpdateInfo = struct
       raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
 end
 
-let create_repository_record ~__context ~name_label ~name_description ~binary_url ~source_url =
+let create_repository_record
+    ~__context ~name_label ~name_description ~binary_url ~source_url =
   let ref = Ref.make () in
   let uuid = Uuidm.to_string (Uuidm.create `V4) in
   Db.Repository.create
@@ -574,7 +575,7 @@ let assert_url_is_valid ~url =
     error "Invalid url %s: %s" url (ExnHelper.string_of_exn e);
     raise Api_errors.(Server_error (invalid_base_url, [url]))
 
-let with_pool_repository f =
+let with_pool_repositories f =
   Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () ->
         Mutex.lock exposing_pool_repo_mutex;
@@ -683,6 +684,13 @@ let get_cachedir repo_name =
       | _ ->
         let msg = Printf.sprintf "Not found cachedir for repository %s" repo_name in
         raise Api_errors.(Server_error (internal_error, [msg])))
+
+let get_remote_repository_name ~__context ~self =
+    !Xapi_globs.remote_repository_prefix ^ (Db.Repository.get_name_label ~__context ~self)
+
+let get_enabled_repositories ~__context =
+  let pool = Helpers.get_pool ~__context in
+  Db.Pool.get_repositories ~__context ~self:pool
 
 let with_local_repository ~__context f =
   let master_addr =

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -702,11 +702,14 @@ let get_enabled_repositories ~__context =
   let pool = Helpers.get_pool ~__context in
   Db.Pool.get_repositories ~__context ~self:pool
 
+let get_repository_name ~__context ~self =
+  Db.Repository.get_uuid ~__context ~self
+
 let get_remote_repository_name ~__context ~self =
-    !Xapi_globs.remote_repository_prefix ^ "-" ^ (Db.Repository.get_name_label ~__context ~self)
+    !Xapi_globs.remote_repository_prefix ^ "-" ^ (get_repository_name ~__context ~self)
 
 let get_local_repository_name ~__context ~self =
-    !Xapi_globs.local_repository_prefix ^ "-" ^ (Db.Repository.get_name_label ~__context ~self)
+    !Xapi_globs.local_repository_prefix ^ "-" ^ (get_repository_name ~__context ~self)
 
 let with_local_repositories ~__context f =
   let master_addr =

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -536,7 +536,7 @@ module UpdateInfo = struct
 end
 
 let create_repository_record
-    ~__context ~name_label ~name_description ~binary_url ~source_url =
+    ~__context ~name_label ~name_description ~binary_url ~source_url ~update =
   let ref = Ref.make () in
   let uuid = Uuidm.to_string (Uuidm.create `V4) in
   Db.Repository.create
@@ -547,6 +547,7 @@ let create_repository_record
     ~name_description
     ~binary_url
     ~source_url
+    ~update
     ~hash:""
     ~up_to_date:false;
   ref

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -870,8 +870,6 @@ let pool_repo_name = ref "remote"
 
 let remote_repository_prefix = ref "remote"
 
-let local_repo_name = ref "local"
-
 let local_repository_prefix = ref "local"
 
 let yum_config_manager_cmd = ref "/usr/bin/yum-config-manager"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -866,8 +866,6 @@ let yum_cmd = ref "/usr/bin/yum"
 
 let yum_repos_config_dir  = ref "/etc/yum.repos.d"
 
-let pool_repo_name = ref "remote"
-
 let remote_repository_prefix = ref "remote"
 
 let local_repository_prefix = ref "local"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -868,7 +868,11 @@ let yum_repos_config_dir  = ref "/etc/yum.repos.d"
 
 let pool_repo_name = ref "remote"
 
+let remote_repository_prefix = ref "remote"
+
 let local_repo_name = ref "local"
+
+let local_repository_prefix = ref "local"
 
 let yum_config_manager_cmd = ref "/usr/bin/yum-config-manager"
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2535,9 +2535,6 @@ let apply_updates ~__context ~self ~hash =
     let pool = Helpers.get_pool ~__context in
     if Db.Pool.get_ha_enabled ~__context ~self:pool then
       raise Api_errors.(Server_error (ha_is_enabled, []));
-    let ref = Repository.get_enabled_repository ~__context in
-    if hash = "" || hash <> Db.Repository.get_hash ~__context ~self:ref then
-      raise Api_errors.(Server_error (updateinfo_hash_mismatch, []));
     Xapi_host_helpers.with_host_operation
       ~__context ~self
       ~doc:"Host.apply_updates"

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -332,7 +332,19 @@ val alert_failed_login_attempts : unit -> unit
 
 val enable_tls_verification : __context:Context.t -> unit
 
-val set_repository :
+val set_repositories :
+     __context:Context.t
+  -> self:API.ref_pool
+  -> value:[`Repository] API.Ref.t list
+  -> unit
+
+val add_repository :
+     __context:Context.t
+  -> self:API.ref_pool
+  -> value:[`Repository] API.Ref.t
+  -> unit
+
+val remove_repository :
      __context:Context.t
   -> self:API.ref_pool
   -> value:[`Repository] API.Ref.t

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -30,7 +30,7 @@ let all_operations =
   ; `ha_disable
   ; `cluster_create
   ; `designate_new_master
-  ; `set_repository
+  ; `configure_repositories
   ; `sync_updates
   ; `get_updates
   ; `apply_updates
@@ -57,7 +57,7 @@ let valid_operations ~__context record _ref' =
     ; (`ha_disable, Api_errors.ha_disable_in_progress, [])
     ; (`cluster_create, Api_errors.cluster_create_in_progress, [])
     ; (`designate_new_master, Api_errors.designate_new_master_in_progress, [])
-    ; (`set_repository, Api_errors.set_repository_in_progress, [])
+    ; (`configure_repositories, Api_errors.configure_repositories_in_progress, [])
     ; (`sync_updates, Api_errors.sync_updates_in_progress, [])
     ; (`get_updates, Api_errors.get_updates_in_progress, [])
     ; (`apply_updates, Api_errors.apply_updates_in_progress, [])

--- a/ocaml/xapi/xapi_pool_transition.ml
+++ b/ocaml/xapi/xapi_pool_transition.ml
@@ -206,7 +206,7 @@ let become_another_masters_slave master_address =
     debug "Setting pool.conf to point to %s" master_address ;
     set_role new_role ;
     run_external_scripts false ;
-    Repository.cleanup_pool_repo () ; (* For simplicity, it's safe to cleanup on all slaves *)
+    Repository.cleanup_all_pool_repositories () ; (* For simplicity, it's safe to cleanup on all slaves *)
     Xapi_fuse.light_fuse_and_run ()
   )
 


### PR DESCRIPTION
This series update repository functions to support multiple repositories being enabled at same time. But in these enabled repositories, there should be one and only one update repository.
If a repository is an update repository, XAPI will expect that it has updateinfo.xml and will parse it to get update metadata. A new bool field "update" is added into repository datamodel. If it is true, this repository is an update repository.