### PR TITLE
Enable to choose a migration network in `VM.pool_migrate` and `Host.evacuate`:

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -336,7 +336,14 @@ let host_query_ha = call ~flags:[`Session]
       ~in_product_since:rel_miami
       ~name:"evacuate"
       ~doc:"Migrate all VMs off of this host, where possible."
-      ~params:[Ref _host, "host", "The host to evacuate"]
+      ~lifecycle:[
+        Published, rel_miami, "";
+        Extended, rel_next, "Enable migration network selection."
+      ]
+      ~versioned_params:[
+        {param_type=Ref _host; param_name="host"; param_doc="The host to evacuate"; param_release=miami_release; param_default=None};
+        {param_type=Ref _network; param_name="network"; param_doc="Optional preferred network for migration"; param_release=next_release; param_default=(Some (VRef null_ref))}
+      ]
       ~allowed_roles:_R_POOL_OP
       ()
 

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2430,7 +2430,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "host-evacuate"
     , {
         reqd= []
-      ; optn= []
+      ; optn= ["network-uuid"]
       ; help= "Migrate all VMs off a host."
       ; implementation= No_fd Cli_operations.host_evacuate
       ; flags= [Host_selectors]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -4767,10 +4767,16 @@ let host_all_editions printer rpc session_id params =
   printer (Cli_printer.PList editions)
 
 let host_evacuate printer rpc session_id params =
+  let network =
+    List.assoc_opt "network-uuid" params
+    |> Option.fold ~none:Ref.null ~some:(fun uuid ->
+           Client.Network.get_by_uuid rpc session_id uuid)
+  in
   ignore
     (do_host_op rpc session_id ~multiple:false
-       (fun _ host -> Client.Host.evacuate rpc session_id (host.getref ()))
-       params [])
+       (fun _ host ->
+         Client.Host.evacuate rpc session_id (host.getref ()) network)
+       params ["network-uuid"])
 
 let host_get_vms_which_prevent_evacuation printer rpc session_id params =
   let uuid = List.assoc "uuid" params in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2987,13 +2987,14 @@ functor
           (host_uuid ~__context self) ;
         Local.Host.get_vms_which_prevent_evacuation ~__context ~self
 
-      let evacuate ~__context ~host =
+      let evacuate ~__context ~host ~network =
         info "Host.evacuate: host = '%s'" (host_uuid ~__context host) ;
         (* Block call if this would break our VM restart plan (because the body of this sets enabled to false) *)
         Xapi_ha_vm_failover.assert_host_disable_preserves_ha_plan ~__context
           host ;
         with_host_operation ~__context ~self:host ~doc:"Host.evacuate"
-          ~op:`evacuate (fun () -> Local.Host.evacuate ~__context ~host)
+          ~op:`evacuate (fun () ->
+            Local.Host.evacuate ~__context ~host ~network)
 
       let retrieve_wlb_evacuate_recommendations ~__context ~self =
         info "Host.retrieve_wlb_evacuate_recommendations: host = '%s'"

--- a/ocaml/xapi/vm_evacuation.ml
+++ b/ocaml/xapi/vm_evacuation.ml
@@ -60,7 +60,9 @@ let ensure_no_vms ~__context ~rpc ~session_id ~evacuate_timeout =
       else
         estimate_evacuate_timeout ~__context ~host
     in
-    let tasks = [Client.Async.Host.evacuate ~rpc ~session_id ~host] in
+    let tasks =
+      [Client.Async.Host.evacuate ~rpc ~session_id ~host ~network:Ref.null]
+    in
     if not (Tasks.with_tasks_destroy ~rpc ~session_id ~timeout ~tasks) then
       get_running_domains () |> List.iter cancel_vm_tasks
   in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -548,7 +548,7 @@ let compute_evacuation_plan ~__context ~host =
            Using original algorithm" ;
         compute_evacuation_plan_no_wlb ~__context ~host
 
-let evacuate ~__context ~host =
+let evacuate ~__context ~host ~network =
   let task = Context.get_task_id __context in
   let plans = compute_evacuation_plan ~__context ~host in
   (* Check there are no errors in this list *)
@@ -566,9 +566,26 @@ let evacuate ~__context ~host =
     match plan with
     | Migrate host ->
         ( try
+            ( if network <> Ref.null then
+                let hosts = Db.Host.get_all ~__context in
+                List.iter
+                  (fun host ->
+                    ignore
+                    @@ Xapi_network_attach_helpers
+                       .assert_valid_ip_configuration_on_network_for_host
+                         ~__context ~self:network ~host)
+                  hosts
+            ) ;
+            let with_network_option =
+              if network <> Ref.null then
+                [("network", Ref.string_of network)]
+              else
+                []
+            in
+            let options = ("live", "true") :: with_network_option in
             Helpers.call_api_functions ~__context (fun rpc session_id ->
                 Client.Client.VM.pool_migrate ~rpc ~session_id ~vm ~host
-                  ~options:[("live", "true")])
+                  ~options)
           with
         | Api_errors.Server_error (code, params)
           when code = Api_errors.vm_bad_power_state ->

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -54,7 +54,8 @@ val assert_can_evacuate : __context:Context.t -> host:API.ref_host -> unit
 val get_vms_which_prevent_evacuation :
   __context:Context.t -> self:API.ref_host -> (API.ref_VM * string list) list
 
-val evacuate : __context:Context.t -> host:API.ref_host -> unit
+val evacuate :
+  __context:Context.t -> host:API.ref_host -> network:API.ref_network -> unit
 
 val retrieve_wlb_evacuate_recommendations :
   __context:Context.t -> self:API.ref_host -> (API.ref_VM * string list) list

--- a/ocaml/xapi/xapi_network_attach_helpers.mli
+++ b/ocaml/xapi/xapi_network_attach_helpers.mli
@@ -44,3 +44,6 @@ val assert_can_see_named_networks :
 val assert_can_attach_network_on_host :
   __context:Context.t -> self:[`network] Ref.t -> host:[`host] Ref.t -> unit
 (** Raises an exception if the network cannot be attached. *)
+
+val assert_valid_ip_configuration_on_network_for_host :
+  __context:Context.t -> self:[`network] Ref.t -> host:[`host] Ref.t -> string

--- a/ocaml/xapi/xapi_pif_helpers.ml
+++ b/ocaml/xapi/xapi_pif_helpers.ml
@@ -242,3 +242,11 @@ let is_device_underneath_same_type ~__context pif1 pif2 =
     (pci_rec.Db_actions.pCI_vendor_id, pci_rec.Db_actions.pCI_device_id)
   in
   get_device_info pif1 = get_device_info pif2
+
+let get_primary_address ~__context ~pif =
+  match Db.PIF.get_primary_address_type ~__context ~self:pif with
+  | `IPv4 -> (
+    match Db.PIF.get_IP ~__context ~self:pif with "" -> None | ip -> Some ip
+  )
+  | `IPv6 ->
+      List.nth_opt (Db.PIF.get_IPv6 ~__context ~self:pif) 0


### PR DESCRIPTION
- Add `network` key in `options` expecting a network ref to try to migrate on
- If not possible, fallback on management address

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>