### PR TITLE
CP-36100-2 Use explicit config for TLS Stunnel verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,3 +96,6 @@ jobs:
 
       - name: Number of List.hd usages has not changed
         run: make list-hd
+
+      - name: Number of verify_cert:None usages has not changed
+        run: make verify-cert

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,12 @@ list-hd:
 	echo counted $$LIST_HD usages ;\
 	test $$LIST_HD -eq 300
 
-quality-gate: list-hd ;
+verify-cert:
+	@NONE=$$( git grep -r --count 'verify_cert:None' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc) ;\
+	echo "counted $$NONE usages of verify_cert:None" ;\
+	test $$NONE -eq 6
+
+quality-gate: list-hd verify-cert ;
 
 install: build doc sdk
 	mkdir -p $(DESTDIR)$(SBINDIR)

--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -76,8 +76,9 @@ let force_connection_reset () =
       | Some () ->
           purge_stunnels verify_cert
     in
-    purge_stunnels true ;
-    purge_stunnels false ;
+    purge_stunnels None ;
+    purge_stunnels (Some Stunnel.pool) ;
+    purge_stunnels (Some Stunnel.appliance) ;
     info
       "force_connection_reset: all cached connections to the master have been \
        purged"
@@ -157,9 +158,10 @@ let on_database_connection_established = ref (fun () -> ())
 let open_secure_connection () =
   let host = !get_master_address () in
   let port = !Db_globs.https_port in
+  let verify_cert = Stunnel_client.pool () in
   Stunnel.with_connect ~use_fork_exec_helper:true ~extended_diagnosis:true
     ~write_to_log:(fun x -> debug "stunnel: %s\n" x)
-    host port
+    ~verify_cert host port
   @@ fun st_proc ->
   let fd_closed = Thread.wait_timed_read Unixfd.(!(st_proc.Stunnel.fd)) 5. in
   let proc_quit =

--- a/ocaml/perftest/perfutil.ml
+++ b/ocaml/perftest/perfutil.ml
@@ -25,7 +25,7 @@ let rpc xml =
 let remoterpc host xml =
   let open Xmlrpc_client in
   XMLRPC_protocol.rpc ~srcstr:"perftest" ~dststr:"remotexapi"
-    ~transport:(SSL (SSL.make (), host, 443))
+    ~transport:(SSL (SSL.make ~verify_cert:None (), host, 443))
     ~http:(xmlrpc ~version:"1.1" "/")
     xml
 

--- a/ocaml/quicktest/qt.ml
+++ b/ocaml/quicktest/qt.ml
@@ -24,7 +24,11 @@ let http request f =
     if !Quicktest_args.using_unix_domain_socket then
       Unix Xapi_globs.unix_domain_socket
     else
-      SSL (SSL.make ~use_fork_exec_helper:false (), !Quicktest_args.host, 443)
+      SSL
+        ( SSL.make ~use_fork_exec_helper:false
+            ~verify_cert:(Stunnel_client.pool ()) ()
+        , !Quicktest_args.host
+        , 443 )
   in
   with_transport transport (with_http request f)
 

--- a/ocaml/quicktest/quicktest_args.ml
+++ b/ocaml/quicktest/quicktest_args.ml
@@ -18,7 +18,11 @@ let http = Xmlrpc_client.xmlrpc ~version:"1.1" "/"
 
 let rpc_remote xml =
   Xmlrpc_client.XMLRPC_protocol.rpc ~srcstr:"quicktest" ~dststr:"xapi"
-    ~transport:(SSL (Xmlrpc_client.SSL.make (), !host, 443))
+    ~transport:
+      (SSL
+         ( Xmlrpc_client.SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
+         , !host
+         , 443 ))
     ~http xml
 
 let rpc_unix_domain xml =

--- a/ocaml/vncproxy/vncproxy.ml
+++ b/ocaml/vncproxy/vncproxy.ml
@@ -73,7 +73,11 @@ let _ =
           ~http xml
     | host ->
         XMLRPC_protocol.rpc ~srcstr:"vncproxy" ~dststr:"xapi"
-          ~transport:(SSL (SSL.make ~use_fork_exec_helper:false (), host, 443))
+          ~transport:
+            (SSL
+               ( SSL.make ~verify_cert:None ~use_fork_exec_helper:false ()
+               , host
+               , 443 ))
           ~http xml
   in
   let find_vm rpc session_id vm =
@@ -94,7 +98,11 @@ let _ =
           (Printf.sprintf "%s?ref=%s" Constants.console_uri (Ref.string_of vm))
       in
       let transport =
-        SSL (SSL.make ~use_fork_exec_helper:false (), address, 443)
+        SSL
+          ( SSL.make ~verify_cert:(Stunnel_client.pool ())
+              ~use_fork_exec_helper:false ()
+          , address
+          , 443 )
       in
       with_transport transport
         (with_http http (fun (response, fd) ->

--- a/ocaml/vncproxy/vncproxy.ml
+++ b/ocaml/vncproxy/vncproxy.ml
@@ -75,7 +75,8 @@ let _ =
         XMLRPC_protocol.rpc ~srcstr:"vncproxy" ~dststr:"xapi"
           ~transport:
             (SSL
-               ( SSL.make ~verify_cert:None ~use_fork_exec_helper:false ()
+               ( SSL.make ~verify_cert:(Stunnel_client.pool ())
+                   ~use_fork_exec_helper:false ()
                , host
                , 443 ))
           ~http xml

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -4082,7 +4082,9 @@ let vm_migrate printer rpc session_id params =
       let open Xmlrpc_client in
       let http = xmlrpc ~version:"1.0" "/" in
       XMLRPC_protocol.rpc ~srcstr:"cli" ~dststr:"dst_xapi"
-        ~transport:(SSL (SSL.make ~use_fork_exec_helper:false (), ip, 443))
+        ~transport:
+          (SSL
+             (SSL.make ~verify_cert:None ~use_fork_exec_helper:false (), ip, 443))
         ~http xml
     in
     let username = List.assoc "remote-username" params in
@@ -5181,7 +5183,7 @@ let vm_import fd printer rpc session_id params =
               let open Xmlrpc_client in
               let transport =
                 SSL
-                  ( SSL.make ~use_stunnel_cache:true
+                  ( SSL.make ~use_stunnel_cache:true ~verify_cert:None
                       ~task_id:(Ref.string_of importtask) ()
                   , address
                   , !Constants.https_port )

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -59,7 +59,10 @@ let forward args s session =
          (Api_errors.host_is_slave, [Pool_role.get_master_address ()])) ;
   let open Xmlrpc_client in
   let transport =
-    SSL (SSL.make (), Pool_role.get_master_address (), !Constants.https_port)
+    SSL
+      ( SSL.make ~verify_cert:None ()
+      , Pool_role.get_master_address ()
+      , !Constants.https_port )
   in
   let body =
     let args =

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -149,7 +149,7 @@ let forward req call is_json =
   let open Xmlrpc_client in
   let transport =
     SSL
-      ( SSL.make ~use_stunnel_cache:true ()
+      ( SSL.make ~use_stunnel_cache:true ~verify_cert:(Stunnel_client.pool ()) ()
       , Pool_role.get_master_address ()
       , !Constants.https_port )
   in

--- a/ocaml/xapi/config_file_sync.ml
+++ b/ocaml/xapi/config_file_sync.ml
@@ -100,7 +100,10 @@ let fetch_config_files_internal ~master_address ~pool_secret =
           in
           let open Xmlrpc_client in
           let transport =
-            SSL (SSL.make (), master_address, !Constants.https_port)
+            SSL
+              ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
+              , master_address
+              , !Constants.https_port )
           in
           with_transport transport
             (with_http request (fun (response, fd) ->

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -305,7 +305,8 @@ let remote_metadata_export_import ~__context ~rpc ~session_id ~remote_address
                         unlikely to happen in practice because the cache size is large enough.*)
                      with_transport
                        (SSL
-                          ( SSL.make ~use_stunnel_cache:true ()
+                          ( SSL.make ~verify_cert:(Stunnel_client.pool ())
+                              ~use_stunnel_cache:true ()
                           , remote_address
                           , !Constants.https_port ))
                        (with_http put (fun (_, ofd) ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -55,7 +55,9 @@ let remote_rpc_no_retry context hostname (task_opt : API.ref_task option) xml =
   let open Xmlrpc_client in
   let transport =
     SSL
-      ( SSL.make ?task_id:(Option.map Ref.string_of task_opt) ()
+      ( SSL.make ~verify_cert:(Stunnel_client.pool ())
+          ?task_id:(Option.map Ref.string_of task_opt)
+          ()
       , hostname
       , !Constants.https_port )
   in
@@ -69,7 +71,7 @@ let remote_rpc_retry context hostname (task_opt : API.ref_task option) xml =
   let open Xmlrpc_client in
   let transport =
     SSL
-      ( SSL.make ~use_stunnel_cache:true
+      ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ~use_stunnel_cache:true
           ?task_id:(Option.map Ref.string_of task_opt)
           ()
       , hostname

--- a/ocaml/xapi/pool_db_backup.ml
+++ b/ocaml/xapi/pool_db_backup.ml
@@ -257,7 +257,12 @@ let http_fetch_db ~master_address ~pool_secret =
     |> SecretString.with_cookie pool_secret
   in
   let open Xmlrpc_client in
-  let transport = SSL (SSL.make (), master_address, !Constants.https_port) in
+  let transport =
+    SSL
+      ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
+      , master_address
+      , !Constants.https_port )
+  in
   with_transport transport
     (with_http request (fun (response, fd) ->
          (* no content length since it's streaming *)

--- a/ocaml/xapi/remote_requests.ml
+++ b/ocaml/xapi/remote_requests.ml
@@ -46,7 +46,7 @@ type response = Success | Exception of exn | NoResponse
 
 type queued_request = {
     task: API.ref_task
-  ; verify_cert: Stunnel.config option
+  ; verify_cert: Stunnel.verification_config option
   ; host: string
   ; port: int
   ; request: Http.Request.t

--- a/ocaml/xapi/remote_requests.ml
+++ b/ocaml/xapi/remote_requests.ml
@@ -46,7 +46,7 @@ type response = Success | Exception of exn | NoResponse
 
 type queued_request = {
     task: API.ref_task
-  ; verify_cert: bool
+  ; verify_cert: Stunnel.config option
   ; host: string
   ; port: int
   ; request: Http.Request.t
@@ -188,11 +188,12 @@ let read_response result response s =
 let send_test_post ~__context ~host ~port ~body =
   try
     let result = ref "" in
+    let verify_cert = Stunnel_client.pool () in
     let request =
       Xapi_http.http_request ~keep_alive:false ~body ~headers:[("Host", host)]
         Http.Post "/"
     in
-    perform_request ~__context ~timeout:30.0 ~verify_cert:true ~host
+    perform_request ~__context ~timeout:30.0 ~verify_cert ~host
       ~port:(Int64.to_int port) ~request ~handler:(read_response result)
       ~enable_log:true ;
     !result

--- a/ocaml/xapi/vpx.ml
+++ b/ocaml/xapi/vpx.ml
@@ -323,6 +323,8 @@ let array_of_jobInstances_of_rpc lr =
 
 let vpxrpc ip call =
   let open Xmlrpc_client in
-  let transport = SSL (SSL.make (), ip, 443) in
+  let transport =
+    SSL (SSL.make ~verify_cert:(Stunnel_client.pool ()) (), ip, 443)
+  in
   (*	debug "call = %s" (Xmlrpc.string_of_call call); *)
   XMLRPC_protocol.rpc ~transport ~http:(xmlrpc ~version:"1.0" "/") call

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -295,7 +295,13 @@ let wlb_request ~__context ~host ~port ~auth ~meth ~params ~handler ~enable_log
   let body = wlb_body meth params in
   let request = wlb_request host meth body auth in
   let pool = Helpers.get_pool ~__context in
-  let verify_cert = Db.Pool.get_wlb_verify_cert ~__context ~self:pool in
+  let verify_cert =
+    match Db.Pool.get_wlb_verify_cert ~__context ~self:pool with
+    | true ->
+        Some Stunnel.appliance
+    | false ->
+        None
+  in
   let pool_other_config = Db.Pool.get_other_config ~__context ~self:pool in
   let timeout =
     try

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -783,6 +783,13 @@ let set_stunnel_timeout () =
     Stunnel.timeoutidle := Some timeout
   with _ -> debug "Using default stunnel timeout (usually 43200)"
 
+let init_tls_verification ~__context () =
+  (* set global flag based on database entry *)
+  let pool = Helpers.get_pool ~__context in
+  let default = Db.Pool.get_tls_verification_enabled ~__context ~self:pool in
+  info "TLS verification by default is %b" default ;
+  Stunnel_client.set_verify_by_default default
+
 let server_init () =
   let print_server_starting_message () =
     debug "(Re)starting xapi" ;
@@ -973,6 +980,7 @@ let server_init () =
           ; ( "bringing up management interface"
             , []
             , bring_up_management_if ~__context )
+          ; ("Initialise TLS verification", [], init_tls_verification ~__context)
           ; ( "Starting periodic scheduler"
             , [Startup.OnThread]
             , Xapi_periodic_scheduler.loop )

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -783,12 +783,15 @@ let set_stunnel_timeout () =
     Stunnel.timeoutidle := Some timeout
   with _ -> debug "Using default stunnel timeout (usually 43200)"
 
-let init_tls_verification ~__context () =
-  (* set global flag based on database entry *)
-  let pool = Helpers.get_pool ~__context in
-  let default = Db.Pool.get_tls_verification_enabled ~__context ~self:pool in
-  info "TLS verification by default is %b" default ;
-  Stunnel_client.set_verify_by_default default
+let init_tls_verification () =
+  let file = Xapi_globs.verify_certificates_path in
+  match Sys.file_exists file with
+  | false ->
+      warn "TLS verification is disabled on this host: %s" file ;
+      Stunnel_client.set_verify_by_default false
+  | true ->
+      info "TLS verification is enabled: %s" file ;
+      Stunnel_client.set_verify_by_default true
 
 let server_init () =
   let print_server_starting_message () =
@@ -939,6 +942,7 @@ let server_init () =
           ; ("Logging xapi version info", [], Xapi_config.dump_config)
           ; ("Setting signal handlers", [], signals_handling)
           ; ("Initialising random number generator", [], random_setup)
+          ; ("Initialise TLS verification", [], init_tls_verification)
           ; ("Running startup check", [], startup_check)
           ; ("Registering SMAPIv1 plugins", [Startup.OnlyMaster], Sm.register)
           ; ( "Starting SMAPIv1 proxies"
@@ -980,7 +984,6 @@ let server_init () =
           ; ( "bringing up management interface"
             , []
             , bring_up_management_if ~__context )
-          ; ("Initialise TLS verification", [], init_tls_verification ~__context)
           ; ( "Starting periodic scheduler"
             , [Startup.OnThread]
             , Xapi_periodic_scheduler.loop )

--- a/ocaml/xapi/xapi_blob.ml
+++ b/ocaml/xapi/xapi_blob.ml
@@ -65,7 +65,10 @@ let send_blobs ~__context ~remote_address ~session_id uuid_map =
         in
         let open Xmlrpc_client in
         let transport =
-          SSL (SSL.make (), remote_address, !Constants.https_port)
+          SSL
+            ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
+            , remote_address
+            , !Constants.https_port )
         in
         with_transport transport
           (with_http request (fun (response, put_fd) ->

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -739,6 +739,8 @@ let stunnel_cert_path = ref "/etc/stunnel/xapi-stunnel-ca-bundle.pem"
 
 let stunnel_conf = ref "/etc/stunnel/xapi.conf"
 
+let verify_certificates_path = "/var/xapi/verify-certificates"
+
 let udhcpd_conf = ref (Filename.concat "/etc/xensource" "udhcpd.conf")
 
 let udhcpd_skel = ref (Filename.concat "/etc/xensource" "udhcpd.skel")

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2468,11 +2468,11 @@ let get_sched_gran ~__context ~self =
 
 let emergency_disable_tls_verification ~__context =
   (* NB: the tls-verification state on this host will no longer agree with state.db *)
-  Helpers.StunnelClient.set_verify_by_default false
+  Stunnel_client.set_verify_by_default false
 
 let alert_if_tls_verification_was_emergency_disabled ~__context =
   let tls_verification_enabled_locally =
-    Helpers.StunnelClient.get_verify_by_default ()
+    Stunnel_client.get_verify_by_default ()
   in
   let tls_verification_enabled_pool_wide =
     Db.Pool.get_tls_verification_enabled ~__context

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2468,7 +2468,8 @@ let get_sched_gran ~__context ~self =
 
 let emergency_disable_tls_verification ~__context =
   (* NB: the tls-verification state on this host will no longer agree with state.db *)
-  Stunnel_client.set_verify_by_default false
+  Stunnel_client.set_verify_by_default false ;
+  Unixext.unlink_safe Xapi_globs.verify_certificates_path
 
 let alert_if_tls_verification_was_emergency_disabled ~__context =
   let tls_verification_enabled_locally =

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -38,7 +38,10 @@ let inet_rpc xml =
     if Pool_role.is_master () then
       TCP ("127.0.0.1", http)
     else
-      SSL (SSL.make (), Pool_role.get_master_address (), https)
+      SSL
+        ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
+        , Pool_role.get_master_address ()
+        , https )
   in
   let http = xmlrpc ~version path in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"xapi" ~transport ~http xml

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -801,7 +801,12 @@ let send_messages ~__context ~cls ~obj_uuid ~session_id ~remote_address =
       Constants.message_put_uri
   in
   let open Xmlrpc_client in
-  let transport = SSL (SSL.make (), remote_address, !Constants.https_port) in
+  let transport =
+    SSL
+      ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
+      , remote_address
+      , !Constants.https_port )
+  in
   with_transport transport
     (with_http request (fun (rsp, fd) ->
          if rsp.Http.Response.code <> "200" then

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2849,4 +2849,5 @@ let alert_failed_login_attempts () =
             ~body:stats)
 
 let enable_tls_verification ~__context =
-  Stunnel_client.set_verify_by_default true
+  Stunnel_client.set_verify_by_default true ;
+  Helpers.touch_file Xapi_globs.verify_certificates_path

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2849,4 +2849,4 @@ let alert_failed_login_attempts () =
             ~body:stats)
 
 let enable_tls_verification ~__context =
-  Helpers.StunnelClient.set_verify_by_default true
+  Stunnel_client.set_verify_by_default true

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -746,7 +746,10 @@ let proxy_request req s host_uuid =
       match host with
       | Some host ->
           let ip = Db.Host.get_address ~__context ~self:host in
-          let transport = Xmlrpc_client.(SSL (SSL.make (), ip, 443)) in
+          let transport =
+            Xmlrpc_client.(
+              SSL (SSL.make ~verify_cert:(Stunnel_client.pool ()) (), ip, 443))
+          in
           Xmlrpc_client.with_transport transport (fun fd ->
               Unixext.really_write_string fd (Http.Request.to_wire_string req) ;
               Unixext.proxy (Unix.dup s) (Unix.dup fd))

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -305,12 +305,14 @@ let exit_status = ref 1
 
 let with_open_tcp_ssl server f =
   let port = get_xapiport true in
+  let verify_cert = None in
+  (* CL *)
   debug "Connecting via stunnel to [%s] port [%d]\n%!" server port ;
   (* We don't bother closing fds since this requires our close_and_exec wrapper *)
   let open Safe_resources in
   Stunnel.with_connect ~use_fork_exec_helper:false
     ~write_to_log:(fun x -> debug "stunnel: %s\n%!" x)
-    ~extended_diagnosis:(!debug_file <> None) server port
+    ~verify_cert ~extended_diagnosis:(!debug_file <> None) server port
   @@ fun x ->
   let x = Stunnel.move_out_exn x in
   let ic = Unix.in_channel_of_descr (Unix.dup Unixfd.(!(x.Stunnel.fd))) in

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -305,14 +305,12 @@ let exit_status = ref 1
 
 let with_open_tcp_ssl server f =
   let port = get_xapiport true in
-  let verify_cert = None in
-  (* CL *)
   debug "Connecting via stunnel to [%s] port [%d]\n%!" server port ;
   (* We don't bother closing fds since this requires our close_and_exec wrapper *)
   let open Safe_resources in
   Stunnel.with_connect ~use_fork_exec_helper:false
     ~write_to_log:(fun x -> debug "stunnel: %s\n%!" x)
-    ~verify_cert ~extended_diagnosis:(!debug_file <> None) server port
+    ~verify_cert:None ~extended_diagnosis:(!debug_file <> None) server port
   @@ fun x ->
   let x = Stunnel.move_out_exn x in
   let ic = Unix.in_channel_of_descr (Unix.dup Unixfd.(!(x.Stunnel.fd))) in

--- a/ocaml/xsh/xsh.ml
+++ b/ocaml/xsh/xsh.ml
@@ -73,11 +73,12 @@ let proxy (ain : Unix.file_descr) (aout : Unix.file_descr)
 
 let with_open_tcp_ssl server f =
   let port = 443 in
+  let verify_cert = None (* CL *) in
   (* We don't bother closing fds since this requires our close_and_exec wrapper *)
   let open Safe_resources in
   Stunnel.with_connect ~use_fork_exec_helper:false
     ~write_to_log:(fun _ -> ())
-    server port
+    ~verify_cert server port
   @@ fun x -> f Unixfd.(!(x.Stunnel.fd))
 
 let _ =

--- a/ocaml/xsh/xsh.ml
+++ b/ocaml/xsh/xsh.ml
@@ -73,12 +73,11 @@ let proxy (ain : Unix.file_descr) (aout : Unix.file_descr)
 
 let with_open_tcp_ssl server f =
   let port = 443 in
-  let verify_cert = None (* CL *) in
   (* We don't bother closing fds since this requires our close_and_exec wrapper *)
   let open Safe_resources in
   Stunnel.with_connect ~use_fork_exec_helper:false
     ~write_to_log:(fun _ -> ())
-    ~verify_cert server port
+    ~verify_cert:None server port
   @@ fun x -> f Unixfd.(!(x.Stunnel.fd))
 
 let _ =


### PR DESCRIPTION
When Stunnel creates a conncetion as a client it can verify this
connection using certificates. We have intra pool connections and
connections opened to appliances, which use different verification
methods. This needs to be reflected beyond yes/no. This patch makes
(more) explicit the configuration to use for verifcation.

Some call sites still use no certificate checking (passing None to
SSL.make) and this will need to be adressed.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>