### PR TITLE
maintenance: allow tests to run in an opam sandbox

### DIFF
--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -50,5 +50,5 @@
 (test
   (name schematest)
   (modules schematest)
-  (libraries xapi_datamodel)
+  (libraries xapi-datamodel)
 )

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -27,3 +27,7 @@
   )
   (action (run ./check-no-xenctrl %{x}))
 )
+
+(env
+  (_ (env-vars (XAPI_TEST 1)))
+)

--- a/ocaml/tests/test_xapi_db_upgrade.ml
+++ b/ocaml/tests/test_xapi_db_upgrade.ml
@@ -58,10 +58,9 @@ let upgrade_vm_memory_for_dmc () =
     (r.API.vM_memory_static_min <= r.API.vM_memory_static_max)
 
 let upgrade_bios () =
+  let tmp_filename = "/tmp/previousInventory" in
   let check inventory bios_strings =
-    Xapi_stdext_unix.Unixext.mkdir_safe "/var/tmp" 0o755 ;
-    Xapi_stdext_unix.Unixext.write_string_to_file "/var/tmp/.previousInventory"
-      inventory ;
+    Xapi_stdext_unix.Unixext.write_string_to_file tmp_filename inventory ;
     let __context = T.make_test_database () in
     X.upgrade_bios_strings.fn ~__context ;
     let _, vm_r = List.hd (Db.VM.get_all_records ~__context) in
@@ -71,7 +70,7 @@ let upgrade_bios () =
   check "OEM_MANUFACTURER=Dell" Constants.old_dell_bios_strings ;
   check "OEM_MANUFACTURER=HP" Constants.old_hp_bios_strings ;
   check "" Constants.generic_bios_strings ;
-  Xapi_stdext_unix.Unixext.unlink_safe "/var/tmp/.previousInventory"
+  Xapi_stdext_unix.Unixext.unlink_safe tmp_filename
 
 let update_snapshots () =
   let __context = T.make_test_database () in

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -281,8 +281,16 @@ let upgrade_bios_strings =
   ; fn=
       (fun ~__context ->
         let oem_manufacturer =
+          let test_path =
+            Option.map
+              (fun _ -> "/tmp/previousInventory")
+              (Sys.getenv_opt "XAPI_TEST")
+          in
+          let inventory_path =
+            Option.value ~default:"/var/tmp/.previousInventory" test_path
+          in
           try
-            let ic = open_in "/var/tmp/.previousInventory" in
+            let ic = open_in inventory_path in
             let rec find_oem_manufacturer () =
               let line = input_line ic in
               match Xapi_inventory.parse_inventory_entry line with


### PR DESCRIPTION
Seems like the opam sandbox also made the tests break while using the container-based workflow for xs-opam. This change fixes them, as it happened with master.

The datamodel tests were also using the private name instead of the public one which broke them.

This change can be tested by creating an opam switch with the 8.2 packages and installing xapi while forcing opam to run its tests:

```
$ opam switch create stockholm 4.08.1
$ eval $(opam env --switch="stockholm" --set-switch)
$ opam repo add xs-opam-stockholm git+https://github.com/xapi-project/xs-opam.git#release/stockholm/lcm
$ opam repo remove default
$ opam pin add xapi . -t
```