### PR TITLE
CP-36510 REQ-403 distribute certs during Pool.enable_tls_verification

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -999,6 +999,19 @@ let host_query_ha = call ~flags:[`Session]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
+  (* this internal call is used to process values of type [Cert_distrib.Wire.command] *)
+  let cert_distrib_atom = call
+      ~pool_internal:true
+      ~hide_from_docs:true
+      ~lifecycle:[Published, rel_next, ""]
+      ~name:"cert_distrib_atom"
+      ~doc:""
+      ~params:[Ref _host, "host", "The host";
+               String, "command", "The string encoded command"]
+      ~result:(String, "The string encoded result")
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ()
+
   let get_server_certificate = call
       ~in_oss_since:None
       ~lifecycle:[Published, rel_george, ""; Changed, rel_inverness, "Now available to all RBAC roles."]
@@ -1540,6 +1553,7 @@ let host_query_ha = call ~flags:[`Session]
         set_sched_gran;
         get_sched_gran;
         emergency_disable_tls_verification;
+        cert_distrib_atom;
       ]
       ~contents:
         ([ uid _host;

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -1,0 +1,247 @@
+module Unixext = Xapi_stdext_unix.Unixext
+
+module D = Debug.Make (struct let name = "cert_distrib" end)
+
+module XenAPI = Client.Client
+
+type existing_cert_strategy = Erase_old | Merge [@@deriving sexp]
+
+type 'a remote_call =
+  API.ref_host -> (Rpc.call -> Rpc.response) -> API.ref_session -> 'a
+
+module WireProtocol = struct
+  module Sexp = Sexplib.Sexp
+  open Sexplib0.Sexp_conv
+
+  type cert_blob = string [@@deriving sexp]
+
+  type cert = {uuid: string; blob: cert_blob} [@@deriving sexp]
+
+  type command =
+    | Collect
+    | Write of (existing_cert_strategy * cert list)
+    | GenBundle
+  [@@deriving sexp]
+
+  type result = CollectResult of cert_blob | WriteResult | GenBundleResult
+  [@@deriving sexp]
+
+  let string_of_command x = x |> sexp_of_command |> Sexp.to_string
+
+  let command_of_string x =
+    try Some (x |> Sexp.of_string |> command_of_sexp) with _ -> None
+
+  let dbg_of_command = function
+    | Collect ->
+        "Collect"
+    | Write (Erase_old, _) ->
+        "Write (Erase_old)"
+    | Write (Merge, _) ->
+        "Write (Merge)"
+    | GenBundle ->
+        "GenBundle"
+
+  let string_of_result x = x |> sexp_of_result |> Sexp.to_string
+
+  let result_of_string x =
+    try Some (x |> Sexp.of_string |> result_of_sexp) with _ -> None
+
+  let dbg_of_result = function
+    | CollectResult _ ->
+        "CollectResult"
+    | WriteResult ->
+        "WriteResult"
+    | GenBundleResult ->
+        "GenBundleResult"
+end
+
+let raise_internal ?e ?details msg : 'a =
+  let e =
+    Option.fold ~none:""
+      ~some:(fun e -> e |> Printexc.to_string |> Printf.sprintf "exception: %s")
+      e
+  in
+  let details = Option.value ~default:"" details in
+  [msg; details; e] |> String.concat ". " |> D.error "%s" ;
+  raise Api_errors.(Server_error (internal_error, [msg]))
+
+(* eventually the remote calls should probably become API calls in the datamodel
+ * but they remain here for quick development *)
+module Worker : sig
+  val local_exec : __context:Context.t -> command:string -> string
+
+  val remote_collect_cert : WireProtocol.cert_blob remote_call
+
+  val remote_write_certs_fs :
+    existing_cert_strategy -> WireProtocol.cert list -> unit remote_call
+
+  val remote_regen_bundle : unit remote_call
+end = struct
+  open WireProtocol
+
+  let my_cert = !Xapi_globs.server_cert_internal_path
+
+  let pool_certs = !Xapi_globs.trusted_pool_certs_dir
+
+  let pool_certs_bk = Printf.sprintf "%s.bk" pool_certs
+
+  let get_my_cert () : cert_blob =
+    let open Gencertlib.Pem in
+    match parse_file my_cert with
+    | Error reason ->
+        raise_internal
+          ~details:(Printf.sprintf "reason: %s" reason)
+          (Printf.sprintf "failed to parse %s" my_cert)
+    | Ok {host_cert; _} ->
+        host_cert
+
+  let write_certs_fs strategy certs =
+    let open Helpers.FileSys in
+    let mv_or_cp = match strategy with Erase_old -> mv | Merge -> cpr in
+    ( try mv_or_cp ~src:pool_certs ~dest:pool_certs_bk
+      with e ->
+        D.debug
+          "write_certs_fs: ignoring failure, mv_or_cp %s to %s. exception: %s"
+          pool_certs pool_certs_bk (Printexc.to_string e)
+    ) ;
+    ( try
+        Unixext.mkdir_rec pool_certs 0o700 ;
+        certs
+        |> List.iter (fun {uuid; blob} ->
+               let fname = Printf.sprintf "%s/%s.pem" pool_certs uuid in
+               redirect blob ~fname)
+      with e ->
+        (* on fail, try reset to previous cert state *)
+        ( try mv ~src:pool_certs_bk ~dest:pool_certs
+          with e ->
+            D.debug
+              "write_certs_fs: ignoring failure when trying to restore cert \
+               state, mv %s to %s. exception: %s"
+              pool_certs_bk pool_certs (Printexc.to_string e)
+        ) ;
+        raise_internal ~e "write_certs_fs: failed to write certs"
+    ) ;
+    try rmrf pool_certs_bk
+    with e ->
+      D.debug "write_certs_fs: ignoring failed to remove %s. exception: %s"
+        pool_certs_bk (Printexc.to_string e)
+
+  let regen_bundle () =
+    ignore
+      (Forkhelpers.execute_command_get_output
+         "/opt/xensource/bin/update-ca-bundle.sh" [])
+
+  let restart_stunnel ~__context =
+    Xapi_mgmt_iface.reconfigure_stunnel ~__context
+
+  let with_log prefix f =
+    D.debug "%s: start" prefix ;
+    let res = f () in
+    D.debug "%s: end" prefix ; res
+
+  let local_exec ~__context ~command =
+    with_log "Worker.local_exec" @@ fun () ->
+    let p =
+      match command_of_string command with
+      | None ->
+          raise_internal
+            ~details:(Printf.sprintf "command string: %s" command)
+            "local_exec: failed to parse command"
+      | Some x ->
+          x
+    in
+    D.debug "Worker.local_exec: command is '%s'" (dbg_of_command p) ;
+    let r =
+      match p with
+      | Collect ->
+          let cert = get_my_cert () in
+          CollectResult cert
+      | Write (strategy, certs) ->
+          write_certs_fs strategy certs ;
+          WriteResult
+      | GenBundle ->
+          regen_bundle () ; GenBundleResult
+    in
+    string_of_result r
+
+  let result_or_fail x =
+    result_of_string x |> function
+    | Some x ->
+        x
+    | None ->
+        raise_internal
+          ~details:(Printf.sprintf "result string: %s" x)
+          "result_or_fail: failed to parse result"
+
+  let remote_call_sync host command rpc session_id =
+    XenAPI.Host.cert_distrib_atom rpc session_id host
+      (string_of_command command)
+    |> result_or_fail
+
+  let unexpected_result name r =
+    raise_internal
+      ~details:(Printf.sprintf "r = %s" (dbg_of_result r))
+      (Printf.sprintf "%s: unexpected result" name)
+
+  let remote_collect_cert host rpc session_id =
+    remote_call_sync host Collect rpc session_id |> function
+    | CollectResult cert ->
+        cert
+    | r ->
+        unexpected_result "remote_collect_cert" r
+
+  let remote_write_certs_fs strategy certs host rpc session_id =
+    remote_call_sync host (Write (strategy, certs)) rpc session_id |> function
+    | WriteResult ->
+        ()
+    | r ->
+        unexpected_result "remove_write_certs_fs" r
+
+  let remote_regen_bundle host rpc session_id =
+    remote_call_sync host GenBundle rpc session_id |> function
+    | GenBundleResult ->
+        ()
+    | r ->
+        unexpected_result "remote_regen_bundle" r
+end
+
+let local_exec = Worker.local_exec
+
+let go ~__context ~from_hosts ~to_hosts ~existing_cert_strategy =
+  (* here we coordinate the certificate distribution. from a high level
+   * we do the following:
+   * a) collect certs from [from_hosts], aggregating them on the master.
+   *    the cert collected will be [Worker.my_cert]
+   * b) tell [to_hosts] to write the certs collected in (a) to [Worker.pool_certs]).
+   *    the original contents of [Worker.pool_certs] will either be removed or
+   *    simply added to, depending on [existing_cert_strategy]
+   * c) tell [to_hosts] to regenerate their trust bundles. the old bundle is
+   *    removed completely. see 'update-ca-bundle.sh'. only at this point would we
+   *    expect 'things to go wrong', e.g. new connections fail, if the certs have not
+   *    been set up correctly
+   * NB: if any individual call fails, then we don't continue with the distribution.
+   *     for example: suppose that the master is unable to obtain the cert from a host,
+   *     then we are guaranteed not to modify the trusted certs on any hosts. however
+   *     we do not guarantee 'atomicity', so if regenerating the bundle on one host
+   *     fails, then state across the pool will most likely become inconsistent, and
+   *     manual intervention may be required *)
+  let uuid host = Db.Host.get_uuid ~__context ~self:host in
+
+  Helpers.call_api_functions ~__context @@ fun rpc session_id ->
+  let blobs =
+    List.map
+      (fun host -> Worker.remote_collect_cert host rpc session_id)
+      from_hosts
+  in
+  let certs =
+    List.combine blobs from_hosts
+    |> List.map (fun (blob, host) -> WireProtocol.{uuid= uuid host; blob})
+  in
+  List.iter
+    (fun host ->
+      Worker.remote_write_certs_fs existing_cert_strategy certs host rpc
+        session_id)
+    to_hosts ;
+  List.iter
+    (fun host -> Worker.remote_regen_bundle host rpc session_id)
+    to_hosts

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -1,0 +1,19 @@
+type existing_cert_strategy = Erase_old | Merge
+
+(** [existing_cert_strategy] is used to determine how to treat existing
+ *  certs in /etc/stunnel/certs-pool
+ *  Erase_old => existing certs in the trusted certs dir will be removed
+ *  Merge     => merge incoming certs with certs in the trusted certs dir,
+ *               resolving conflicts by taking the incoming cert *)
+
+val local_exec : __context:Context.t -> command:string -> string
+(** execute a string encoded job, returning a string encoded result *)
+
+val go :
+     __context:Context.t
+  -> from_hosts:API.ref_host list
+  -> to_hosts:API.ref_host list
+  -> existing_cert_strategy:existing_cert_strategy
+  -> unit
+(** Certificates are collected from [from_hosts] and installed on [to_hosts].
+ *  On success, new bundles will have been generated on all [to_hosts] *)

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -75,6 +75,7 @@
    rrdd-plugin.base
    rrdd-plugin.local
    sexplib
+   sexplib0
    sexpr
    sha
    stunnel
@@ -130,7 +131,7 @@
    yojson
    zstd
   )
-  (preprocess (pps ppx_deriving_rpc))
+  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
 
 (executable

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1895,3 +1895,58 @@ end = struct
     SecretString.write_to_file !Xapi_globs.pool_secret_path ps ;
     Xapi_psr_util.load_psr_pool_secrets ()
 end
+
+module FileSys : sig
+  (* bash-like interface for manipulating files *)
+  type path = string
+
+  val rmrf : path -> unit
+
+  val mv : src:path -> dest:path -> unit
+
+  val cpr : src:path -> dest:path -> unit
+
+  val redirect : string -> fname:path -> unit
+end = struct
+  type path = string
+
+  let rmrf path =
+    let ( // ) = Filename.concat in
+    let rec rm path =
+      let st = Unix.lstat path in
+      match st.Unix.st_kind with
+      | Unix.S_DIR ->
+          Sys.readdir path |> Array.iter (fun file -> rm (path // file)) ;
+          Unix.rmdir path
+      | _ ->
+          Unix.unlink path
+    in
+    try rm path
+    with e ->
+      error "failed to remove %s" path ;
+      raise e
+
+  let mv ~src ~dest =
+    try Sys.rename src dest
+    with e ->
+      error "mv: failed to mv %s to %s" src dest ;
+      raise e
+
+  let cpr ~src ~dest =
+    (* todo: implement in ocaml *)
+    try
+      let (_ : string) =
+        get_process_output (Printf.sprintf {|/bin/cp -r "%s" "%s"|} src dest)
+      in
+      ()
+    with e ->
+      error "cpr: failed to copy %s to %s" src dest ;
+      raise e
+
+  let redirect blob ~fname =
+    (try Sys.remove fname with _ -> ()) ;
+    try Unixext.write_string_to_file fname blob
+    with e ->
+      error "redirect: failed to write to %s" fname ;
+      raise e
+end

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -735,7 +735,13 @@ let server_cert_path = ref (Filename.concat "/etc/xensource" "xapi-ssl.pem")
 let server_cert_internal_path =
   ref (Filename.concat "/etc/xensource" "xapi-pool-tls.pem")
 
-let stunnel_cert_path = ref "/etc/stunnel/xapi-stunnel-ca-bundle.pem"
+let trusted_certs_dir = ref "/etc/stunnel/certs"
+
+let trusted_pool_certs_dir = ref "/etc/stunnel/certs-pool"
+
+let stunnel_bundle_path = ref "/etc/stunnel/xapi-stunnel-ca-bundle.pem"
+
+let pool_bundle_path = ref "/etc/stunnel/xapi-pool-ca-bundle.pem"
 
 let stunnel_conf = ref "/etc/stunnel/xapi.conf"
 
@@ -1287,7 +1293,10 @@ module Resources = struct
     ; ( "server-cert-internal-path"
       , server_cert_internal_path
       , "Path to server certificate used for host-to-host TLS connections" )
-    ; ("stunnel-cert-path", stunnel_cert_path, "Path to CA ssl certificate")
+    ; ( "stunnel-bundle-path"
+      , stunnel_bundle_path
+      , "Path to stunnel trust bundle" )
+    ; ("pool-bundle-path", pool_bundle_path, "Path to pool trust bundle")
     ; ( "iscsi_initiatorname"
       , iscsi_initiator_config_file
       , "Path to the initiatorname.iscsi file" )
@@ -1324,6 +1333,12 @@ module Resources = struct
       , Db_globs.static_vdis_dir
       , "Optional directory for configuring static VDIs" )
     ; ("tools-sr-dir", tools_sr_dir, "Directory containing tools ISO")
+    ; ( "trusted-pool-certs-dir"
+      , trusted_pool_certs_dir
+      , "Directory containing certs of trusted hosts" )
+    ; ( "trusted-certs-dir"
+      , trusted_certs_dir
+      , "Directory containing certs of other trusted entities" )
     ]
 
   let xcp_resources =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2498,3 +2498,6 @@ let alert_if_tls_verification_was_emergency_disabled ~__context =
         ~cls:`Host
         ~obj_uuid:(Db.Host.get_uuid ~__context ~self)
         ~body
+
+let cert_distrib_atom ~__context ~host ~command =
+  Cert_distrib.local_exec ~__context ~command

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -514,3 +514,6 @@ val emergency_disable_tls_verification : __context:'a -> unit
 
 val alert_if_tls_verification_was_emergency_disabled :
   __context:Context.t -> unit
+
+val cert_distrib_atom :
+  __context:Context.t -> host:API.ref_host -> command:string -> string

--- a/scripts/update-ca-bundle.sh
+++ b/scripts/update-ca-bundle.sh
@@ -5,12 +5,24 @@
 
 set -e
 
-ST="/etc/stunnel"
+regen_bundle () {
+  CERTS_DIR="$1"
+  BUNDLE="$2"
 
-mkdir -p ${ST}/certs
-find ${ST}/certs -name '*.pem' | xargs cat > ${ST}/xapi-stunnel-ca-bundle.tmp
-mv ${ST}/xapi-stunnel-ca-bundle.tmp ${ST}/xapi-stunnel-ca-bundle.pem
+  mkdir -p "$CERTS_DIR"
+  CERTS=$(find "$CERTS_DIR" -name '*.pem')
 
-mkdir -p ${ST}/certs-pool
-find ${ST}/certs-pool -name '*.pem' | xargs cat > ${ST}/xapi-pool-ca-bundle.tmp
-mv ${ST}/xapi-pool-ca-bundle.tmp ${ST}/xapi-pool-ca-bundle.pem
+  if [ -z "$CERTS" ]; then
+    echo "skipping $BUNDLE, no certs in $CERTS_DIR" 1>&2
+  else
+    rm -f "$BUNDLE.tmp"
+    for CERT in $CERTS; do
+      cat "$CERT" >> "$BUNDLE.tmp"
+      echo ""     >> "$BUNDLE.tmp"
+    done
+    mv "$BUNDLE.tmp" "$BUNDLE"
+  fi
+}
+
+regen_bundle "/etc/stunnel/certs"      "/etc/stunnel/xapi-stunnel-ca-bundle.pem"
+regen_bundle "/etc/stunnel/certs-pool" "/etc/stunnel/xapi-pool-ca-bundle.pem"


### PR DESCRIPTION
You can now execute `xe pool-enable-tls-verification` and it 'just works' (without having to manually set up the bundles)

It works as expected in the usual case, where no hosts go offline, nothing bad happens, etc. It has not been tested in failure cases.

From a high level, `cert_distrib.go` is supposed to distribute certs
between hosts. More specifically, it does the following:

 - aggregates a collection of host certs on the master
 - instructs hosts to save this collection
 - instructs hosts to regenerate their bundles, using said collection