### PR TITLE
CP-36100: format code around rrdd commands

### DIFF
--- a/ocaml/xapi-aux/pool_role.ml
+++ b/ocaml/xapi-aux/pool_role.ml
@@ -107,3 +107,6 @@ let get_master_address () =
       raise This_host_is_a_master
   | Broken ->
       raise This_host_is_broken
+
+let get_master_address_opt () =
+  match get_role () with Slave ip -> Some ip | Master | Broken -> None

--- a/ocaml/xapi-aux/pool_role.mli
+++ b/ocaml/xapi-aux/pool_role.mli
@@ -42,3 +42,7 @@ exception This_host_is_broken
 
 val get_master_address : unit -> string
 (** If this node is a slave, returns the IP address of its master *)
+
+val get_master_address_opt : unit -> string option
+(** [get_master_address_opt ()] returns None if the current host is the master
+    or it's broken, and Some (address of the pool master) otherwise *)

--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -237,8 +237,8 @@ let push_rrd ~__context ~(vm_uuid : string) : unit =
     let domid = vm_uuid_to_domid ~__context ~uuid:vm_uuid in
     log_and_ignore_exn (fun () -> Rrdd.push_rrd_local vm_uuid domid)
   else
-    let remote_address = Db.Host.get_address ~__context ~self:vm_host in
-    log_and_ignore_exn (fun () -> Rrdd.push_rrd_remote vm_uuid remote_address)
+    let member_address = Db.Host.get_address ~__context ~self:vm_host in
+    log_and_ignore_exn (fun () -> Rrdd.push_rrd_remote vm_uuid member_address)
 
 let migrate_rrd ~__context ?remote_address ?session_id ~vm_uuid ~host_uuid () =
   let remote_address =
@@ -259,9 +259,7 @@ module Deprecated = struct
     with _ -> 0
 
   let load_rrd ~__context ~uuid =
-    let master_address =
-      try Some (Pool_role.get_master_address ()) with _ -> None
-    in
+    let master_address = Pool_role.get_master_address_opt () in
     let timescale = get_timescale ~__context in
     log_and_ignore_exn (fun () ->
         Rrdd.Deprecated.load_rrd uuid timescale master_address)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1307,10 +1307,8 @@ let sync_data ~__context ~host = Xapi_sync.sync_host __context host
 let backup_rrds ~__context ~host ~delay =
   Xapi_periodic_scheduler.add_to_queue "RRD backup"
     Xapi_periodic_scheduler.OneShot delay (fun _ ->
-      let remote_address =
-        try Some (Pool_role.get_master_address ()) with _ -> None
-      in
-      log_and_ignore_exn (Rrdd.backup_rrds remote_address) ;
+      let master_address = Pool_role.get_master_address_opt () in
+      log_and_ignore_exn (Rrdd.backup_rrds master_address) ;
       log_and_ignore_exn (fun () ->
           List.iter
             (fun sr -> Xapi_sr.maybe_copy_sr_rrds ~__context ~sr)

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -49,8 +49,8 @@ let register () =
         Helpers.call_api_functions ~__context (fun rpc session_id ->
             ignore
               (List.fold_left
-                 (fun delay host ->
-                   Client.Client.Host.backup_rrds rpc session_id host delay ;
+                 (fun delay member ->
+                   Client.Client.Host.backup_rrds rpc session_id member delay ;
                    delay +. 60.0)
                  0.0 hosts)))
   in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -582,10 +582,8 @@ let suspend ~__context ~vm =
   Xapi_gpumon.update_vgpu_metadata ~__context ~vm ;
   Xapi_xenops.suspend ~__context ~self:vm ;
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
-  let remote_address =
-    try Some (Pool_role.get_master_address ()) with _ -> None
-  in
-  log_and_ignore_exn (fun () -> Rrdd.archive_rrd vm_uuid remote_address)
+  let master_address = Pool_role.get_master_address_opt () in
+  log_and_ignore_exn (fun () -> Rrdd.archive_rrd vm_uuid master_address)
 
 let resume ~__context ~vm ~start_paused ~force =
   if Db.VM.get_ha_restart_priority ~__context ~self:vm = Constants.ha_restart

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -841,11 +841,8 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
   update_allowed_operations ~__context ~self ;
   if state = `Halted then (* archive the rrd for this vm *)
     let vm_uuid = Db.VM.get_uuid ~__context ~self in
-    log_and_ignore_exn (fun () ->
-        Rrdd.archive_rrd vm_uuid
-          (* remote address *)
-          ( try Some (Pool_role.get_master_address ()) with _ -> None
-          ))
+    let master_address = Pool_role.get_master_address_opt () in
+    log_and_ignore_exn (fun () -> Rrdd.archive_rrd vm_uuid master_address)
 
 (** Called on new VMs (clones, imports) and on server start to manually refresh
     the power state, allowed_operations field etc.  Clean current-operations


### PR DESCRIPTION
This change makes it easy to see that backup_rrds and archive_rrds are
exclusively used with the pool's members ip addresses or None.

This allows the code in xcp-rrdd to assume these calls to trust the pool's internal certificates when establishing connections.