### PR TITLE
CP-34469 on pool eject, remove host certificates

### DIFF
--- a/scripts/reset-and-reboot
+++ b/scripts/reset-and-reboot
@@ -26,4 +26,13 @@ fi
 
 echo "Resetting state and rebooting"
 rm -f /var/lib/misc/ran-*
+echo "Removing host certificates in /etc/xensource and /etc/stunnel"
+# remove pool-internal certs
+rm -f  /etc/xensource/xapi-pool-tls.pem
+rm -f  /etc/stunnel/xapi-pool-ca-bundle.pem
+rm -fr /etc/stunnel/certs-pool
+# keep potentially user-installed certs (as in CH 8.2)
+# rm -f  /etc/xensource/xapi-ssl.pem
+# rm -f  /etc/stunnel/xapi-stunnel-ca-bundle.pem
+# rm -fr /etc/stunnel/certs
 /sbin/reboot


### PR DESCRIPTION
A host that leaves a pool goes trough a reboot. At boot, it will create
new host certificates if none are present. To trigger this, remove the
existing ones (private and public keys). This includes removing
(public) certificates of other hosts that were part of the pool.

We only remove certs for pool-internal communication. The user may have
updated the host certficate and installed additional CA certificates. We
keep these as this was the behaviour in CH 8.2.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>