### PR TITLE
Add datamodel option to log Db.X.destroy calls

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4155,6 +4155,7 @@ module Event = struct
       obj_allowed_roles=_R_POOL_ADMIN;
       obj_implicit_msg_allowed_roles=_R_ALL;
       obj_doc_tags=[];
+      db_logging=None;
     }
 end
 
@@ -4447,6 +4448,7 @@ module PCI = struct
       ~messages_default_allowed_roles:_R_POOL_OP
       ~persist:PersistEverything
       ~in_oss_since:None
+      ~db_logging:Log_destroy
       ~contents:[
         uid _pci ~lifecycle:[Published, rel_boston, ""];
         field ~qualifier:StaticRO ~ty:String ~lifecycle:[] "class_id" "PCI class ID" ~default_value:(Some (VString "")) ~internal_only:true;

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -535,6 +535,7 @@ let create_obj ?lifecycle ~in_oss_since ?in_product_since ?(internal_deprecated_
     ?force_custom_actions:(force_custom_actions=None) (* None,Some(RW),Some(StaticRO) *)
     ~messages_default_allowed_roles ?(doc_tags=[])(* used in constructor, destructor and explicit obj msgs *)
     ?(msg_lifecycles = [])(* To specify lifecycle for automatic messages (e.g. constructor) when different to object lifecycle. *)
+    ?db_logging
     () =
   let contents_default_writer_roles = if contents_default_writer_roles=None then messages_default_allowed_roles else contents_default_writer_roles in
   let get_field_reader_roles = function None->contents_default_reader_roles|r->r in
@@ -576,4 +577,5 @@ let create_obj ?lifecycle ~in_oss_since ?in_product_since ?(internal_deprecated_
     persist = persist; gen_events = gen_events; obj_release = release;
     in_database=in_db; obj_allowed_roles = messages_default_allowed_roles; obj_implicit_msg_allowed_roles = implicit_messages_allowed_roles;
     obj_doc_tags = doc_tags;
+    db_logging;
   }

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -490,6 +490,8 @@ type persist_option = PersistNothing | PersistEverything [@@deriving rpc]
 (* PersistEverything - all creates/writes persisted;
    PersistNothing - no creates/writes to this table persisted *)
 
+type db_logging = Log_destroy [@@deriving rpc]
+
 (** An object (or entity) is represented by one of these: *)
 type obj = {
   name : string;
@@ -508,6 +510,7 @@ type obj = {
   obj_release: release;
   in_database: bool; (* If the object is in the database *)
   obj_doc_tags: doc_tag list;
+  db_logging: db_logging option
 } [@@deriving rpc]
 
 (* val rpc_of_obj : obj -> Rpc.t *)

--- a/ocaml/idl/ocaml_backend/gen_db_actions.ml
+++ b/ocaml/idl/ocaml_backend/gen_db_actions.ml
@@ -445,7 +445,16 @@ let db_action api : O.Module.t =
       | FromField ((Add | Remove), _) ->
           failwith "Cannot generate db add/remove for non sets and maps"
       | FromObject Delete ->
-          Printf.sprintf "DB.delete_row __t \"%s\" %s"
+          let log_prefix =
+            match obj.db_logging with
+            | None ->
+                ""
+            | Some Log_destroy ->
+                Printf.sprintf
+                  {|D.debug "deleting row from %s table: ref=%s" self ; |}
+                  obj.name "%s"
+          in
+          Printf.sprintf "%sDB.delete_row __t \"%s\" %s" log_prefix
             (Escaping.escape_obj obj.DT.name)
             Client._self
       | FromObject Make ->


### PR DESCRIPTION
The motivation for change is to make it easier to figure out, from a bugtool, what happened in the xapi database

To see what this PR does, it's easiest to see the diff of the auto-generated file, db_actions.ml:

```
     and destroy ~__context ~self =
       let self = DM_to_String.ref_PCI self in
       let __t = Context.database_of __context in
       let module DB = (val (Db_cache.get __t) : Db_interface.DB_ACCESS) in
-      DB.delete_row __t "PCI" self
+      D.debug "deleting row from PCI table: ref=%s" self ; DB.delete_row __t "PCI" self
     (**  *)
```

Some ways we might want to extend the change:
 - add logging to other tables, apart from PCI
 - write to a file other than xensource.log
 - log other db calls, such as 'create'