### PR TITLE
CP-36658 remove certs of ejected host

### DIFF
--- a/ocaml/xapi/certificates_sync.ml
+++ b/ocaml/xapi/certificates_sync.ml
@@ -97,3 +97,44 @@ let update ~__context =
   let* () = sync ~__context ~type':`host in
   let* () = sync ~__context ~type':`host_internal in
   Ok ()
+
+let internal_error fmt =
+  fmt
+  |> Printf.kprintf @@ fun msg ->
+     error "%s" msg ;
+     raise Api_errors.(Server_error (internal_error, [msg]))
+
+let remove_from_db ~__context cert =
+  try
+    Db.Certificate.destroy ~__context ~self:cert ;
+    info "removed host certificate %s from db" (Ref.string_of cert)
+  with e ->
+    internal_error "failed to remove cert %s: %s" (Ref.string_of cert)
+      (Printexc.to_string e)
+
+let path host_uuid =
+  let prefix = !Xapi_globs.trusted_pool_certs_dir in
+  Filename.concat prefix (Printf.sprintf "%s.pem" host_uuid)
+
+let host_certs_of ~__context host =
+  List.concat
+    [
+      Certificates.Db_util.get_host_certs ~__context ~host ~type':`host
+    ; Certificates.Db_util.get_host_certs ~__context ~host ~type':`host_internal
+    ]
+
+let eject_certs_from_db ~__context certs =
+  certs |> List.iter (remove_from_db ~__context)
+
+let eject_certs_from_fs_for ~__context host =
+  (* the cert is not identified by its UUID in the file system but
+     by the UUID of the host it belongs to *)
+  let host_uuid = Db.Host.get_uuid ~__context ~self:host in
+  let file = path host_uuid in
+  try
+    Sys.remove file ;
+    Certificates.update_ca_bundle () ;
+    info "removed host certificate %s" file
+  with e ->
+    internal_error "failed to remove cert %s on pool eject" file
+      (Printexc.to_string e)

--- a/ocaml/xapi/certificates_sync.mli
+++ b/ocaml/xapi/certificates_sync.mli
@@ -3,3 +3,16 @@ val update :
 (** inspect the host's certificate in /etx/xensource/xapi_ssl.pem
 (default) and update it's database entry in case it has changed. In
 effect this creates a new entry and removes the stale entry. *)
+
+val host_certs_of :
+  __context:Context.t -> API.ref_host -> API.ref_Certificate list
+
+val eject_certs_from_db :
+  __context:Context.t -> API.ref_Certificate list -> unit
+(** remove a cert from the database. A cert has public and private parts,
+   which are covered by the same entry in the database *)
+
+val eject_certs_from_fs_for : __context:Context.t -> API.ref_host -> unit
+(** remove the public (distributed) part of a certficate from the file
+   system. This is the public part of certificate from another host that
+   is stored in the filesystem of the host where this code is eexecuted.  *)


### PR DESCRIPTION
When a host leaves a pool, the remaining hosts in the pool must no
longer trust it. This is implemented by removing the leaving host's
certificates from the database and file system.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>