### PR TITLE
REQ-403: Display expiry for certificates on the cli

### DIFF
--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1196,7 +1196,15 @@ let gen_cmds rpc session_id =
     ; Client.Certificate.(
         mk get_all get_all_records_where get_by_uuid certificate_record
           "certificate" []
-          ["uuid"; "type"; "name"; "host"; "fingerprint"]
+          [
+            "uuid"
+          ; "type"
+          ; "name"
+          ; "host"
+          ; "not-before"
+          ; "not-after"
+          ; "fingerprint"
+          ]
           rpc session_id)
     ]
 


### PR DESCRIPTION
The expiry period is important enough to show it when listing certificates.