### PR TITLE
CP-36690 at startup, sync host certs with DB

### DIFF
--- a/ocaml/xapi/certificates_sync.ml
+++ b/ocaml/xapi/certificates_sync.ml
@@ -20,11 +20,9 @@ let uninstall ~__context cert =
 
 (** add a certificate to the database. The certificate is already in the
   file system. This creates a new entry in the database. *)
-let install ~__context ~host cert =
+let install ~__context ~host ~type' cert =
   try
-    let ref =
-      Certificates.Db_util.add_cert ~__context ~type':(`host host) cert
-    in
+    let ref = Certificates.Db_util.add_cert ~__context ~type' cert in
     info "Adding host certificicate %s to database" (Ref.string_of ref) ;
     R.ok ()
   with e ->
@@ -41,10 +39,10 @@ let is_unchanged ~__context cert_ref cert =
   in
   cert_hash = ref_hash
 
-(** [get_server_cert] loads xapi-ssl.pem from the file system and
+(** [get_server_cert] loads [path] from the file system and
   returns it decoded *)
-let get_server_cert () =
-  match G.Pem.parse_file !Xapi_globs.server_cert_path with
+let get_server_cert path =
+  match G.Pem.parse_file path with
   | Error msg ->
       Error (`Msg (msg, []))
   | Ok cert ->
@@ -58,15 +56,24 @@ let get_server_cert () =
       in
       Ok host_cert
 
-let update ~__context =
+let sync ~__context ~type' =
   let host = Helpers.get_localhost ~__context in
   let host_uuid = Helpers.get_localhost_uuid () in
-  let cert_refs = Db.Host.get_certificates ~__context ~self:host in
-  let* cert = get_server_cert () in
-  match cert_refs with
+  let refs = Certificates.Db_util.get_host_certs ~__context ~type' ~host in
+  let type', path =
+    (* this shadows type'. We have two tags here: with and without an
+       argument and we need the one with host as an argument below *)
+    match type' with
+    | `host ->
+        (`host host, !Xapi_globs.server_cert_path)
+    | `host_internal ->
+        (`host_internal host, !Xapi_globs.server_cert_internal_path)
+  in
+  let* cert = get_server_cert path in
+  match refs with
   | [] ->
       info "Host %s has no active server certificate" host_uuid ;
-      install ~__context ~host cert
+      install ~__context ~host ~type' cert
   | [cert_ref] ->
       let unchanged = is_unchanged ~__context cert_ref cert in
       if unchanged then (
@@ -74,7 +81,7 @@ let update ~__context =
         Ok ()
       ) else (
         info "Server certificate for host %s changed - updating" host_uuid ;
-        let* () = install ~__context ~host cert in
+        let* () = install ~__context ~host ~type' cert in
         uninstall ~__context cert_ref ;
         Ok ()
       )
@@ -82,6 +89,11 @@ let update ~__context =
       warn "The host has more than one certificate: %s"
         (String.concat ", " (List.map Ref.string_of cert_refs)) ;
       info "Server certificate for host %s changed - updating" host_uuid ;
-      let* () = install ~__context ~host cert in
+      let* () = install ~__context ~host ~type' cert in
       List.iter (uninstall ~__context) cert_refs ;
       Ok ()
+
+let update ~__context =
+  let* () = sync ~__context ~type':`host in
+  let* () = sync ~__context ~type':`host_internal in
+  Ok ()

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -330,16 +330,6 @@ let server_run_in_emergency_mode () =
   in
   wait_to_die () ; exit 0
 
-let update_certificates ~__context () =
-  info "syncing certificates on xapi start" ;
-  match Certificates_sync.update ~__context with
-  | Ok () ->
-      info "successfully synced certificates"
-  | Error (`Msg (msg, _)) ->
-      error "Failed to update host certificates: %s" msg
-  | exception e ->
-      error "Failed to update host certificates: %s" (Printexc.to_string e)
-
 let bring_up_management_if ~__context () =
   try
     let management_if =
@@ -361,7 +351,6 @@ let bring_up_management_if ~__context () =
       | Some ip ->
           debug "Management IP address is: %s" ip ;
           (* Make sure everyone is up to speed *)
-          update_certificates ~__context () ;
           ignore
             (Thread.create
                (fun () ->


### PR DESCRIPTION
    CP-36690 at startup, sync host certs with DB
    
    Each host has two server certificates that identifies it, one for
    internal and external communication each and both are tracked in the
    Xapi database. At Xapi startup, the database entries for them need to be
    kept in sync with the certificates in the file system. This was done so
    far for only one of them (xapi-ssl.pem) but needs to be done for both.
    This commit generalizes the code to do that.
    
