### PR TITLE
CP-36579: Add cache in memory for available updates

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1240,7 +1240,9 @@ let _ =
   error Api_errors.apply_guidance_failed ["ref"]
     ~doc:"Failed to apply guidance on a host after updating." ();
   error Api_errors.updateinfo_hash_mismatch []
-    ~doc:"The hash of updateinfo doesn't match with current one. There may be newer available updates." ()
+    ~doc:"The hash of updateinfo doesn't match with current one. There may be newer available updates." ();
+  error Api_errors.updates_require_sync []
+    ~doc:"A call to pool.sync_updates is required before this operation." ()
 
 
 let _ =

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1243,3 +1243,5 @@ let apply_updates_failed = "APPLY_UPDATES_FAILED"
 let apply_guidance_failed = "APPLY_GUIDANCE_FAILED"
 
 let updateinfo_hash_mismatch = "UPDATEINFO_HASH_MISMATCH"
+
+let updates_require_sync = "UPDATES_REQUIRE_SYNC"

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -24,6 +24,7 @@ module UpdateIdSet = Set.Make (String)
 
 let capacity_in_parallel = 16
 let reposync_mutex = Mutex.create ()
+let updates_in_cache = ref None
 
 let introduce ~__context ~name_label ~name_description ~binary_url ~source_url ~update =
   assert_url_is_valid ~url:binary_url;
@@ -146,16 +147,15 @@ let http_get_host_updates_in_json ~__context ~host ~installed =
         raise Api_errors.(Server_error (get_host_updates_failed, [ref])))
     (fun () -> Xapi_session.destroy_db_session ~__context ~self:host_session_id)
 
-let get_host_updates_by_repository ~__context enabled host () =
+let group_host_updates_by_repository ~__context enabled host updates_of_host =
   (* Return updates grouped by repository. Example:
    * [ ("repo-00", [u0, u1]);
    *   ("repo-01", [u3, u4]);
    *   ... ...
    * ]
    *)
-  let json = http_get_host_updates_in_json ~__context ~host ~installed:false in
   (* TODO: live patches *)
-  match Yojson.Basic.Util.member "updates" json with
+  match Yojson.Basic.Util.member "updates" updates_of_host with
   | `List updates ->
     List.fold_left
       (fun acc update ->
@@ -191,21 +191,29 @@ let get_host_updates_by_repository ~__context enabled host () =
     raise Api_errors.(Server_error (get_host_updates_failed, [ref]))
 
 let set_available_updates ~__context =
-  with_pool_repositories @@ fun () ->
   ignore (get_single_enabled_update_repository ~__context) ;
   let hosts = Db.Host.get_all ~__context in
-  let enabled = get_enabled_repositories ~__context in
   let funs =
-    List.map
-      (fun h -> get_host_updates_by_repository ~__context enabled h)
-      hosts
+    List.map (fun host ->
+        fun () ->
+          ( host, (http_get_host_updates_in_json ~__context ~host ~installed:true) )
+      ) hosts
   in
-  let rets_of_hosts = Helpers.run_in_parallel funs capacity_in_parallel in
+  let rets = with_pool_repositories (fun () ->
+      Helpers.run_in_parallel funs capacity_in_parallel)
+  in
+  updates_in_cache := Some rets ;
+  let enabled = get_enabled_repositories ~__context in
+  (* Group updates by repository for each host *)
+  let updates_of_hosts =
+    List.map (fun (h, updates_of_host) ->
+        group_host_updates_by_repository ~__context enabled h updates_of_host) rets
+  in
   (* Group updates by repository for all hosts *)
   let updates_by_repository =
     List.fold_left
       (fun acc l -> List.fold_left (fun acc' (x, y) -> append_by_key acc' x y) acc l)
-      [] rets_of_hosts
+      [] updates_of_hosts
   in
   let checksums =
     List.filter_map
@@ -360,34 +368,29 @@ let parse_updateinfo ~__context ~self =
 let get_pool_updates_in_json ~__context ~hosts =
   try
     let repository = get_single_enabled_update_repository ~__context in
-    let funs =
-      List.map (fun host ->
-          fun () ->
-            ( (Ref.string_of host),
-              (http_get_host_updates_in_json ~__context ~host ~installed:true) )
-        ) hosts
-    in
-    let rets =
-      with_pool_repositories (fun () ->
-          Helpers.run_in_parallel funs capacity_in_parallel)
-    in
-    let repository_name = get_repository_name  ~__context ~self:repository in
-    let updates_info = parse_updateinfo ~__context ~self:repository in
-    let updates_of_hosts, ids_of_updates =
-      rets
-      |> List.fold_left (fun (acc1, acc2) (host, ret_of_host) ->
-          let json_of_host, uids =
-            consolidate_updates_of_host ~repository_name ~updates_info host ret_of_host
-          in
-          ( (json_of_host :: acc1), (UpdateIdSet.union uids acc2) )
-        ) ([], UpdateIdSet.empty)
-    in
-    `Assoc [
-      ("hosts", `List updates_of_hosts);
-      ("updates", `List (UpdateIdSet.elements ids_of_updates
-                         |> List.map (fun uid  ->
-                             UpdateInfo.to_json (List.assoc uid updates_info))));
-      ("hash", `String (Db.Repository.get_hash ~__context ~self:repository))]
+    (match !updates_in_cache with
+     | None ->
+         raise Api_errors.(Server_error (updates_require_sync, []))
+     | Some updates ->
+         let repository_name = get_repository_name  ~__context ~self:repository in
+         let updates_info = parse_updateinfo ~__context ~self:repository in
+         let updates_of_hosts, ids_of_updates =
+           updates
+           |> List.filter (fun (h, _) -> List.mem h hosts)
+           |> List.fold_left (fun (acc1, acc2) (host, updates_of_host) ->
+               let json_of_host, uids =
+                 consolidate_updates_of_host ~repository_name ~updates_info
+                   (Ref.string_of host) updates_of_host
+               in
+               ( (json_of_host :: acc1), (UpdateIdSet.union uids acc2) )
+             ) ([], UpdateIdSet.empty)
+         in
+         `Assoc [
+           ("hosts", `List updates_of_hosts);
+           ("updates", `List (UpdateIdSet.elements ids_of_updates
+                              |> List.map (fun uid  ->
+                                  UpdateInfo.to_json (List.assoc uid updates_info))));
+           ("hash", `String (Db.Repository.get_hash ~__context ~self:repository))])
   with
   | Api_errors.(Server_error (code, _)) as e when code <> Api_errors.internal_error ->
     raise e
@@ -517,6 +520,13 @@ let apply_updates ~__context ~host ~hash =
           Helpers.call_api_functions ~__context (fun rpc session_id ->
               Client.Client.Repository.apply ~rpc ~session_id ~host);
           (* TODO: absolute guidances *)
+          updates_in_cache :=
+            (match !updates_in_cache with
+             | Some updates ->
+                 Some ( (host,
+                         `Assoc [("updates", `List [])]) :: (List.remove_assoc host updates) ) ;
+             | None ->
+                 None) ;
           immediate_guidances)
   with
   | Api_errors.(Server_error (code, _)) as e when code <> Api_errors.internal_error ->
@@ -525,3 +535,6 @@ let apply_updates ~__context ~host ~hash =
     let ref = Ref.string_of host in
     error "applying updates on host ref='%s' failed: %s" ref (ExnHelper.string_of_exn e);
     raise Api_errors.(Server_error (apply_updates_failed, [ref]))
+
+let reset_updates_in_cache () =
+  updates_in_cache := None

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -24,6 +24,7 @@ module UpdateIdSet = Set.Make (String)
 
 let capacity_in_parallel = 16
 let reposync_mutex = Mutex.create ()
+(* The cache below is protected by pool's current_operations locking mechanism *)
 let updates_in_cache = ref None
 
 let introduce ~__context ~name_label ~name_description ~binary_url ~source_url ~update =

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -81,3 +81,5 @@ val apply_immediate_guidances :
 val set_available_updates :
      __context:Context.t
   -> string
+
+val reset_updates_in_cache : unit -> unit


### PR DESCRIPTION
This commit aims to improve the HTTP endpoint `/updates`.

Prior to this commit, HTTP endpoint `/updates` handler will always get
the available updates from all hosts in the pool. This will take quite
long duration.

With this commit, the result of available updates will be stored in a
cache in memory which is established in `pool.sync_updates`. With this
cache, HTTP endpoint `/updates` will return the result from cache
immediately.

Meanwhile, there are a few changes for management of the cache as well.

Signed-off-by: Ming Lu <ming.lu@citrix.com>