### PR TITLE
CA-353309: Create correct filters for uninstalling ca certs

### DIFF
--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -223,7 +223,7 @@ end = struct
     let expr =
       let open Db_filter_types in
       let type' = Eq (Field "type", Literal "ca") in
-      let name' = Eq (Field "type", Literal name) in
+      let name' = Eq (Field "name", Literal name) in
       And (type', name')
     in
     let self =


### PR DESCRIPTION
It would be nice to make these kind of expressions typed.

Example of fixed code running:
```
[root@xxx ~]# xe pool-certificate-install filename=/etc/xensource/xapi-ssl.pem
[root@xxx ~]# xe certificate-list type=ca
uuid ( RO)           : 69cdbef6-8c2b-2fcc-4a50-d554d2507b75
           type ( RO): ca
           name ( RO): xapi-ssl.pem
           host ( RO): <not in database>
     not-before ( RO): 20210423T11:32:48Z
      not-after ( RO): 20310421T11:32:48Z
    fingerprint ( RO): 8D:C1:29:D4:A8:86:43:B4:15:AF:4B:F7:6E:69:7D:A7:A9:49:E0:9D:E3:8C:0E:51:DC:BF:F0:0C:F2:DD:5A:9D


[root@xxx ~]# xe pool-certificate-uninstall name=xapi-ssl.pem
[root@xxx ~]# xe certificate-list type=ca
[root@xxx ~]# logout
Connection to xxx closed.

```