### PR TITLE
CP-36744: Allow users to reenable tls cert checking

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5625,6 +5625,7 @@ let emergency_calls =
     (Datamodel_host.t,Datamodel_host.shutdown_agent);
     (Datamodel_host.t,Datamodel_host.emergency_reset_server_certificate);
     (Datamodel_host.t,Datamodel_host.emergency_disable_tls_verification);
+    (Datamodel_host.t,Datamodel_host.emergency_reenable_tls_verification);
   ]
 
 (** Whitelist of calls that will not get forwarded from the slave to master via the unix domain socket *)

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1428,6 +1428,17 @@ let host_query_ha = call ~flags:[`Session]
       ~allowed_roles:_R_LOCAL_ROOT_ONLY
       ()
 
+  let emergency_reenable_tls_verification = call
+      ~flags:[`Session]
+      ~name:"emergency_reenable_tls_verification"
+      ~lifecycle:[Published, rel_next, ""]
+      ~in_oss_since:None
+      ~in_product_since:rel_next
+      ~params:[]
+      ~doc:"Reenable TLS verification for this host only"
+      ~allowed_roles:_R_LOCAL_ROOT_ONLY
+      ()
+
   (** Hosts *)
   let t =
     create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_host ~descr:"A physical host" ~gen_events:true
@@ -1553,6 +1564,7 @@ let host_query_ha = call ~flags:[`Session]
         set_sched_gran;
         get_sched_gran;
         emergency_disable_tls_verification;
+        emergency_reenable_tls_verification;
         cert_distrib_atom;
       ]
       ~contents:

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -713,6 +713,16 @@ let rec cmdtable_data : (string * cmd_spec) list =
             Cli_operations.host_emergency_disable_tls_verification
       ; flags= [Neverforward]
       } )
+  ; ( "host-emergency-reenable-tls-verification"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Reenable TLS verification for this host only"
+      ; implementation=
+          No_fd_local_session
+            Cli_operations.host_emergency_reenable_tls_verification
+      ; flags= [Neverforward]
+      } )
   ; ( "host-reset-server-certificate"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -6617,6 +6617,9 @@ let host_emergency_reset_server_certificate printer rpc session_id params =
 let host_emergency_disable_tls_verification printer rpc session_id _params =
   Client.Host.emergency_disable_tls_verification ~rpc ~session_id
 
+let host_emergency_reenable_tls_verification printer rpc session_id _params =
+  Client.Host.emergency_reenable_tls_verification ~rpc ~session_id
+
 let host_reset_server_certificate printer rpc session_id params =
   ignore
     (do_host_op rpc session_id ~multiple:false

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3514,6 +3514,10 @@ functor
       let emergency_disable_tls_verification ~__context =
         info "Host.emergency_disable_tls_verification" ;
         Local.Host.emergency_disable_tls_verification ~__context
+
+      let emergency_reenable_tls_verification ~__context =
+        info "Host.emergency_reenable_tls_verification" ;
+        Local.Host.emergency_reenable_tls_verification ~__context
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2469,6 +2469,13 @@ let emergency_disable_tls_verification ~__context =
   Stunnel_client.set_verify_by_default false ;
   Unixext.unlink_safe Xapi_globs.verify_certificates_path
 
+let emergency_reenable_tls_verification ~__context =
+  (* NB: Should only be used after running emergency_disable_tls_verification.
+     Xapi_pool.enable_tls_verification is not used because it introduces a
+     dependency cycle. *)
+  Stunnel_client.set_verify_by_default true ;
+  Helpers.touch_file Xapi_globs.verify_certificates_path
+
 let alert_if_tls_verification_was_emergency_disabled ~__context =
   let tls_verification_enabled_locally =
     Stunnel_client.get_verify_by_default ()

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -515,5 +515,7 @@ val emergency_disable_tls_verification : __context:'a -> unit
 val alert_if_tls_verification_was_emergency_disabled :
   __context:Context.t -> unit
 
+val emergency_reenable_tls_verification : __context:'a -> unit
+
 val cert_distrib_atom :
   __context:Context.t -> host:API.ref_host -> command:string -> string


### PR DESCRIPTION
This is only allowed in emergency mode, like the call for disabling it

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>