### PR TITLE
CP-36750: Block enabling TLS verification on pool ops

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 702
+let schema_minor_vsn = 703
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -8,6 +8,7 @@ open Datamodel_types
             "ha_disable", "Indicates this pool is in the process of disabling HA";
             "cluster_create", "Indicates this pool is in the process of creating a cluster";
             "designate_new_master", "Indicates this pool is in the process of changing master";
+            "tls_verification_enable", "Indicates this pool is in the process of enabling TLS verification";
           ])
 
   let enable_ha = call

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "0ab12bc6f78eeae82a987239b4b100a7"
+let last_known_schema_hash = "aa2bb241740310988f3f16b236392066"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -153,6 +153,8 @@ let pool_operation_to_string = function
       "cluster_create"
   | `designate_new_master ->
       "designate_new_master"
+  | `tls_verification_enable ->
+      "tls_verification_enable"
 
 let host_operation_to_string = function
   | `provision ->

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1203,3 +1203,5 @@ let vcpu_max_not_cores_per_socket_multiple =
 let designate_new_master_in_progress = "DESIGNATE_NEW_MASTER_IN_PROGRESS"
 
 let pool_secret_rotation_pending = "POOL_SECRET_ROTATION_PENDING"
+
+let tls_verification_enable_in_progress = "TLS_VERIFICATION_ENABLE_IN_PROGRESS"


### PR DESCRIPTION
It must not be run concurrently with other pool operations as it might
disrupt the certificate distribution. It must not be run when HA is
enabled as it might fence hosts and change the master while the
operation is in progress.

Confirm it works when HA is enabled:
```
# xe pool-param-get uuid=6991f2ea-9674-5997-fce7-a26122ad838a param-name=ha-enabled 
true
# xe pool-enable-tls-verification 
The operation could not be performed because HA is enabled on the Pool
```