### PR TITLE
XSI-1017

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1136,7 +1136,7 @@ module Xenopsd_metadata = struct
                maybe_persist_md ~__context ~self txt;
                Xapi_cache.update_nolock id (Some txt);
                let module Client = (val make_client queue_name : XENOPS) in
-               let (_ : Task.id) = Client.VM.import_metadata_async dbg txt in
+               let (_: Vm.id) = Client.VM.import_metadata dbg txt in
                ()
            end
       )


### PR DESCRIPTION
The patches that change the behaviour of importing VM metadata in xenopsd have made a certain race condition in device hotplug more likely. Revert these, hopefully temporarily, while we fix the hotplug issue.