### PR TITLE
CA-353388: Control debug level by debug_stunnel env variable

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1736,7 +1736,7 @@ end = struct
             | Some x ->
                 Printf.sprintf "TIMEOUTidle = %s" x
             )
-          ; "debug = authpriv.5"
+          ; Stunnel.debug_conf_of_env ()
           ; "protocol = proxy" (* tells stunnel to include inet address info *)
           ; ""
           ; "[xapi]"


### PR DESCRIPTION
stunnel logs fill up disk partition
This commit set the default debug level to 5 and controlled by
debug_stunnel environment variable

Signed-off-by: Lin Liu <lin.liu@citrix.com>