### PR TITLE
CP-34467: Exchange certificate when a hosts joins a pool

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -75,6 +75,21 @@ open Datamodel_types
       ~allowed_roles:_R_POOL_OP
       ()
 
+  (* This is a map of uuid -> cert_blob *)
+  let pool_certs = Map (String, String)
+
+  let exchange_certificates_on_join = call
+      ~name:"exchange_certificates_on_join"
+      ~in_oss_since:None
+      ~in_product_since:rel_next
+      ~params:[String, "uuid", "The uuid of the joining host";
+               String, "certificate", "The contents of the joiner's certificate";
+              ]
+      ~result:(pool_certs, "The contents of the pool's certificates")
+      ~doc:"Install the pool certificate of a joiner and return the pool's certificates"
+      ~hide_from_docs:true
+      ~allowed_roles:_R_POOL_OP
+      ()
 
   let slave_reset_master = call ~flags:[`Session]
       ~name:"emergency_reset_master"
@@ -704,6 +719,7 @@ open Datamodel_types
         ; join_force
         ; eject
         ; initial_auth
+        ; exchange_certificates_on_join
         ; transition_to_master
         ; slave_reset_master
         ; recover_slaves

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -1,10 +1,10 @@
 type existing_cert_strategy = Erase_old | Merge
 
 (** [existing_cert_strategy] is used to determine how to treat existing
- *  certs in /etc/stunnel/certs-pool
- *  Erase_old => existing certs in the trusted certs dir will be removed
- *  Merge     => merge incoming certs with certs in the trusted certs dir,
- *               resolving conflicts by taking the incoming cert *)
+    certs in /etc/stunnel/certs-pool
+    Erase_old => existing certs in the trusted certs dir will be removed
+    Merge     => merge incoming certs with certs in the trusted certs dir,
+                 resolving conflicts by taking the incoming cert *)
 
 val local_exec : __context:Context.t -> command:string -> string
 (** execute a string encoded job, returning a string encoded result *)
@@ -16,4 +16,23 @@ val go :
   -> existing_cert_strategy:existing_cert_strategy
   -> unit
 (** Certificates are collected from [from_hosts] and installed on [to_hosts].
- *  On success, new bundles will have been generated on all [to_hosts] *)
+    On success, new bundles will have been generated on all [to_hosts] *)
+
+val exchange_certificates_with_joiner :
+     __context:Context.t
+  -> uuid:string
+  -> certificate:string
+  -> (string * string) list
+(** [exchange_certificates_with_joiner ~__context ~uuid ~certificate]
+    distributes [certificate] to all hosts in a pool and makes the pool trust
+    it by installing it as the pool certificate for the host with [uuid] into
+    the filesystem. This function was designed as part of pool join and is
+    unlikely to be useful elsewhere. *)
+
+val import_joining_pool_certs :
+  __context:Context.t -> pool_certs:(string * string) list -> unit
+(** [import_joining_pool_certs ~__context ~pool_certs] Installs the
+    [pool_certs] into the filesystem as certificates of hosts in the pool.
+    This parameter must be a result of [exchange_certificates_with_joiner].
+    This functions was designed as part of pool join and is unlikely to be
+    useful elsewhere. *)

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -396,17 +396,22 @@ let pool_uninstall kind ~__context ~name =
 
 (* Extracts the server certificate from the server certificate pem file.
    It strips the private key as well as the rest of the certificate chain. *)
-let get_server_certificate () =
-  match Gencertlib.Pem.parse_file !Xapi_globs.server_cert_path with
+let read_public_certficate_from_pkcs12 path =
+  match Gencertlib.Pem.parse_file path with
   | Ok Gencertlib.Pem.{host_cert; _} ->
       host_cert
   | Error e ->
-      warn "Error parsing %s: %s" !Xapi_globs.server_cert_path e ;
+      warn "Error parsing %s: %s" path e ;
       raise_library_corrupt ()
   | exception e ->
-      warn "Exception reading server certificate: %s"
-        (ExnHelper.string_of_exn e) ;
+      warn "Exception reading PKCS #12: %s" (ExnHelper.string_of_exn e) ;
       raise_library_corrupt ()
+
+let get_server_certificate () =
+  read_public_certficate_from_pkcs12 !Xapi_globs.server_cert_path
+
+let get_internal_server_certificate () =
+  read_public_certficate_from_pkcs12 !Xapi_globs.server_cert_internal_path
 
 open Rresult
 

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -393,13 +393,10 @@ let make_remote_rpc_of_url ~srcstr ~dststr (url, pool_secret) call =
     call
 
 (* This one uses rpc-light *)
-let make_remote_rpc remote_address xml =
+let make_remote_rpc ?(verify_cert = Stunnel_client.pool ()) remote_address xml =
   let open Xmlrpc_client in
   let transport =
-    SSL
-      ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
-      , remote_address
-      , !Constants.https_port )
+    SSL (SSL.make ~verify_cert (), remote_address, !Constants.https_port)
   in
   let http = xmlrpc ~version:"1.0" "/" in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_xapi" ~transport ~http xml

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -17,8 +17,6 @@
 
 (** {2 (Fill in Title!)} *)
 
-val rpc : string -> Rpc.call -> Rpc.response
-
 val get_master :
   rpc:(Rpc.call -> Rpc.response) -> session_id:API.ref_session -> API.ref_host
 
@@ -100,6 +98,12 @@ val join_force :
   -> master_username:string
   -> master_password:string
   -> unit
+
+val exchange_certificates_on_join :
+     __context:Context.t
+  -> uuid:string
+  -> certificate:string
+  -> API.string_to_string_map
 
 val emergency_transition_to_master : __context:'a -> unit
 

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -14,10 +14,10 @@ list-hd () {
 
 verify-cert () {
   NONE=$(git grep -r --count 'verify_cert:None' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
-  if [ "$NONE" -eq 6 ]; then
+  if [ "$NONE" -eq 7 ]; then
     echo "OK counted $NONE usages of verify_cert:None"
   else
-    echo "ERROR expected 6 verify_cert:None usages, got $NONE" 1>&2
+    echo "ERROR expected 7 verify_cert:None usages, got $NONE" 1>&2
     exit 1
   fi
 }


### PR DESCRIPTION
After passing the pre-join checks the joiner and the pool exchange
certificates and place them in the filesystem, ready to be used. The
database is not modified for any of the two sides. When rebooting xapi's
startup code in the joining host will detect its internal certificate is
not in the database and will add it.

Current code does not try to merge the trusted certificates that exist
in the joining host and the pool.

I've tested it manually successfully, I'll try to throw automated testing to make sure it's robust