### PR TITLE
backport! CA-349123: Fix metadata race in VBD/VIF plug

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -3753,6 +3753,11 @@ let vbd_plug ~__context ~self =
   transform_xenops_exn ~__context ~vm queue_name (fun () ->
       assert_resident_on ~__context ~self:vm ;
       Events_from_xapi.wait ~__context ~self:vm ;
+      (* Set currently_attached to true before calling VBD.add, so that any
+         following metadata push would not rip out the new VBD metadata again.
+         Not a great design, but it follows what `start` does. We have plans
+         to improve this more generally. *)
+      Db.VBD.set_currently_attached ~__context ~self ~value:true ;
       let vbd = md_of_vbd ~__context ~self in
       let dbg = Context.string_of_task __context in
       let module Client = (val make_client queue_name : XENOPS) in
@@ -3913,6 +3918,11 @@ let vif_plug ~__context ~self =
   transform_xenops_exn ~__context ~vm queue_name (fun () ->
       assert_resident_on ~__context ~self:vm ;
       Events_from_xapi.wait ~__context ~self:vm ;
+      (* Set currently_attached to true before calling VIF.add, so that any
+         following metadata push would not rip out the new VIF metadata again.
+         Not a great design, but it follows what `start` does. We have plans
+         to improve this more generally. *)
+      Db.VIF.set_currently_attached ~__context ~self ~value:true ;
       let vif = md_of_vif ~__context ~self in
       let dbg = Context.string_of_task __context in
       let module Client = (val make_client queue_name : XENOPS) in


### PR DESCRIPTION
Set currently_attached to true before calling {VIF;VBD}.add, so that any
following metadata push would not rip out the new device's metadata again.
Not a great design, but it follows what `start` does. We have plans
to improve this more generally.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>
(cherry picked from commit 4d7ff096738c48e94d88772b6f1565f3a602b204)