### PR TITLE
CA-353553 add API error for when NVidia GPU is misconfigured

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -292,7 +292,8 @@ let _ =
     ~doc:"Nvidia tools error. Please ensure that the latest Nvidia tools are installed" ();
   error Api_errors.vm_pci_bus_full ["VM"]
     ~doc:"The VM does not have any free PCI slots" ();
-
+  error Api_errors.nvidia_sriov_misconfigured ["host"; "device_name"]
+    ~doc:"The NVidia GPU is not configured for SR-IOV as expected" ();
 
   error Api_errors.openvswitch_not_active []
     ~doc:"This operation needs the OpenVSwitch networking backend to be enabled on all hosts in the pool." ();

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -613,6 +613,8 @@ let vgpu_guest_driver_limit = "VGPU_GUEST_DRIVER_LIMIT"
 
 let nvidia_tools_error = "NVIDIA_TOOLS_ERROR"
 
+let nvidia_sriov_misconfigured = "NVIDIA_SRIOV_MISCONFIGURED"
+
 let vm_pci_bus_full = "VM_PCI_BUS_FULL"
 
 let import_error_generic = "IMPORT_ERROR"

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -450,8 +450,13 @@ let nvidia_vf_setup ~__context ~pf ~enable =
   let activate_vfs pci =
     match num_vfs pci with
     | None ->
-        let msg = sprintf "Can't determine number of VFs for PCI %s" pci in
-        raise (fail msg)
+        let host = Db.PCI.get_host ~__context ~self:pf in
+        let device = Db.PCI.get_device_name ~__context ~self:pf in
+        error "Can't determine number of VFs for PCI %s" pci ;
+        raise
+          Api_errors.(
+            Server_error
+              (nvidia_sriov_misconfigured, [Ref.string_of host; device]))
     | Some 0 when Sys.file_exists script ->
         debug "PCI %s has 0 VFs - calling %s" pci script ;
         let out, _ =


### PR DESCRIPTION
Backport of 32eee1f3c

Xapi sets up GPU types based on an XML configuration that tells it
whether a card is SR-IOV capable. When we actually use the card and
enable virtual functions and find the card is not correctly configured
for SR-IOV, we raised so far an internal error. This patch adds a new
API error to report the case more clearly.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>