### PR TITLE
CA-348700: Block VDI.copy if on-boot=reset

### DIFF
--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -179,7 +179,7 @@ let check_operation_error ~__context ?(sr_records=[]) ?(pbd_records=[]) ?(vbd_re
           else None
         | `snapshot when record.Db_actions.vDI_sharable ->
           Some (Api_errors.vdi_is_sharable, [ _ref ])
-        | `snapshot when reset_on_boot ->
+        | `snapshot | `copy when reset_on_boot ->
           Some (Api_errors.vdi_on_boot_mode_incompatible_with_operation, [])
         | `snapshot ->
           if List.exists (fun (_, op) -> op = `copy) current_ops


### PR DESCRIPTION
Performing a VDI copy on a VDI that has reset-on-boot enabled may lead
to the VDI to be wiped completely, rather than reset to a predefined
state, when a VM is started. Storage migrate is blocked for VMs that
have such VDIs, and VDI.copy should have the same constraint.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>
(backport of 0df30b01768a868e00a4003571016bf871e582bb)