### PR TITLE
CP-34198: Start membership naming for pool hosts

### DIFF
--- a/ocaml/database/database_server_main.ml
+++ b/ocaml/database/database_server_main.ml
@@ -2,9 +2,9 @@ open Xapi_stdext_unix
 open Xapi_stdext_threads.Threadext
 
 type mode =
-  | Slave of string
-  (* master IP *)
-  | Master of string
+  | Supporter of string
+  (* IP of coordinator *)
+  | Coordinator of string
 
 (* database filename *)
 
@@ -45,12 +45,12 @@ let _ =
   Arg.parse
     [
       ( "--slave-of"
-      , Arg.String (fun master -> mode := Some (Slave master))
-      , "run as a slave of a remote db"
+      , Arg.String (fun coordinator -> mode := Some (Supporter coordinator))
+      , "run as a supporter of a remote db"
       )
     ; ( "--master"
-      , Arg.String (fun db -> mode := Some (Master db))
-      , "run as a master from the given db filename"
+      , Arg.String (fun db -> mode := Some (Coordinator db))
+      , "run as a coordinator from the given db filename"
       )
     ; ( "--listen-on"
       , Arg.Set_string listen_path
@@ -65,9 +65,9 @@ let _ =
       failwith "Requires either --slave-of or --master arguments"
   | Some mode -> (
     match mode with
-    | Slave _ ->
+    | Supporter _ ->
         failwith "unimplemented"
-    | Master db_filename ->
+    | Coordinator db_filename ->
         Printf.printf "Database path: %s\n%!" db_filename ;
         let db = Parse_db_conf.make db_filename in
         Db_conn_store.initialise_db_connections [db] ;

--- a/ocaml/database/db_cache.ml
+++ b/ocaml/database/db_cache.ml
@@ -24,10 +24,10 @@ module Local_db : DB_ACCESS = Db_cache_impl
 (** Slaves will use this to call the master by XMLRPC *)
 module Remote_db : DB_ACCESS = Db_rpc_client_v1.Make (struct
   let initialise () =
-    ignore (Master_connection.start_master_connection_watchdog ()) ;
-    ignore (Master_connection.open_secure_connection ())
+    ignore (Coordinator_connection.start_coordinator_connection_watchdog ()) ;
+    ignore (Coordinator_connection.open_secure_connection ())
 
-  let rpc request = Master_connection.execute_remote_fn request
+  let rpc request = Coordinator_connection.execute_remote_fn request
 end)
 
 let get = function

--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -300,11 +300,10 @@ let process_structured_field_locked t (key, value) tblname fld objref
       | AddMap | AddMapLegacy -> (
         try
           (* We use the idempotent map add if we're using the non-legacy
-             process function, or if the global field 'idempotent_map' has
-             been set. By default, the Db calls on the master use the
-             legacy functions, but those on the slave use the new one.
-             This means xapi code should always assume idempotent_map is
-             true *)
+             process function, or if the global field 'idempotent_map' has been
+             set. By default, the Db calls on the coordinator use the legacy
+             functions, but those on the supporter use the new one. This means
+             xapi code should always assume idempotent_map is true *)
           let idempotent =
             proc_fn_selector = AddMap || !Db_globs.idempotent_map
           in

--- a/ocaml/database/db_lock.ml
+++ b/ocaml/database/db_lock.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-(* Lock shared between client/slave implementations *)
+(* Lock shared between client/supporter implementations *)
 
 open Xapi_stdext_threads.Threadext
 open Xapi_stdext_pervasives.Pervasiveext

--- a/ocaml/database/db_rpc_common_v2.ml
+++ b/ocaml/database/db_rpc_common_v2.ml
@@ -38,7 +38,7 @@ module Request = struct
         * Db_cache_types.structured_op_t
   [@@deriving rpc]
 
-  (* Make sure the slave only ever uses the idempotent version *)
+  (* Make sure supporters only ever use the idempotent version *)
   let rpc_of_t t =
     let t' =
       match t with

--- a/ocaml/database/ref_index.ml
+++ b/ocaml/database/ref_index.ml
@@ -11,9 +11,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-(* This data is accessible only on the pool master, since the data all lives there.
-   Unlike the "first-class" db calls, these are not marshalled over the wire if called
-   on a slave -- so don't ever call them on slaves! :) *)
+(* This data is accessible only on the coordinator, since the data all lives
+   there. Unlike the "first-class" db calls, these are not marshalled over the
+   wire if called on a supporter -- so don't ever call these on supporters! *)
 
 open Db_cache_types
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -67,7 +67,8 @@ module Session = struct
           ; param_default= Some (VString "")
           }
         ]
-      ~errs:[Api_errors.session_authentication_failed; Api_errors.host_is_slave]
+      ~errs:
+        [Api_errors.session_authentication_failed; Api_errors.host_is_supporter]
       ~secret:true
       ~allowed_roles:_R_ALL (*any static role can try to create a user session*)
       ()

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -697,7 +697,7 @@ let _ =
        disabled."
     () ;
 
-  error Api_errors.host_its_own_slave []
+  error Api_errors.host_its_own_supporter []
     ~doc:
       "The host is its own supporter. Please use \
        pool-emergency-transition-to-master or pool-emergency-reset-master."
@@ -716,7 +716,7 @@ let _ =
       "The coordinator reports that it cannot talk back to the supporter on \
        the supplied management IP address."
     () ;
-  error Api_errors.host_unknown_to_master ["host"]
+  error Api_errors.host_unknown_to_coordinator ["host"]
     ~doc:
       "The coordinator says the server is not known to it. Is the server in \
        the coordinator's database and pointing to the correct coordinator? Are \
@@ -1499,7 +1499,8 @@ let _ =
     () ;
 
   (* Pool errors *)
-  error Api_errors.host_is_slave ["Master IP address"]
+  error Api_errors.host_is_supporter
+    ["Coordinator's IP address"]
     ~doc:
       "You cannot make regular API calls directly on a supporter. Please pass \
        API calls via the coordinator host."
@@ -1974,7 +1975,7 @@ let _ =
     (fst Api_messages.vcpu_qos_failed)
     ~doc:"Applying QoS to VCPU failed." () ;
   message
-    (fst Api_messages.pool_master_transition)
+    (fst Api_messages.pool_coordinator_transition)
     ~doc:"Host has become the new Pool coordinator." () ;
   message
     (fst Api_messages.pbd_plug_failed_on_server_start)

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -90,7 +90,7 @@ let local_assert_healthy =
         Api_errors.host_still_booting
       ; Api_errors.host_has_no_management_ip
       ; Api_errors.host_master_cannot_talk_back
-      ; Api_errors.host_unknown_to_master
+      ; Api_errors.host_unknown_to_coordinator
       ; Api_errors.host_broken
       ; Api_errors.license_restriction
       ; Api_errors.license_does_not_support_pooling
@@ -146,7 +146,7 @@ let request_backup =
     ~params:
       [
         (Ref _host, "host", "The Host to send the request to")
-      ; (Int, "generation", "The generation count of the master's database")
+      ; (Int, "generation", "The generation count of the coordinator's database")
       ; ( Bool
         , "force"
         , "If this is true then the client _has_ to take a backup, otherwise \
@@ -162,7 +162,10 @@ let request_config_file_sync =
     ~params:
       [
         (Ref _host, "host", "The Host to send the request to")
-      ; (String, "hash", "The hash of the master's dom0 config files package")
+      ; ( String
+        , "hash"
+        , "The hash of the coordinator's dom0 config files package"
+        )
       ]
     ~pool_internal:true ~hide_from_docs:true ~allowed_roles:_R_LOCAL_ROOT_ONLY
     ()
@@ -973,7 +976,8 @@ let tickle_heartbeat =
         , "Anything else we want to let the master know"
         )
       ]
-    ~result:(Map (String, String), "Anything the master wants to tell the slave")
+    ~result:
+      (Map (String, String), "Anything the master wants to tell the supporter")
     ~doc:
       "Needs to be called every 30 seconds for the master to believe the host \
        is alive"
@@ -1715,12 +1719,12 @@ let apply_updates =
 let copy_primary_host_certs =
   call ~name:"copy_primary_host_certs" ~in_oss_since:None
     ~in_product_since:"1.307.0"
-    ~doc:"useful for secondary hosts that are missing some certs"
+    ~doc:"useful for supporters that are missing some certs"
     ~params:
       [
         ( Ref _host
         , "host"
-        , "this host receives a copy of the primary host's trusted certificates"
+        , "this host receives a copy of the coordinator's trusted certificates"
         )
       ]
     ~allowed_roles:_R_POOL_ADMIN ~hide_from_docs:true ~pool_internal:true ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -842,7 +842,7 @@ let rotate_secret =
     ~errs:
       [
         Api_errors.internal_error
-      ; Api_errors.host_is_slave
+      ; Api_errors.host_is_supporter
       ; Api_errors.cannot_contact_host
       ; Api_errors.ha_is_enabled
       ; Api_errors.not_supported_during_upgrade

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -869,8 +869,8 @@ let stateReset =
   call ~in_product_since:rel_rio ~name:"power_state_reset"
     ~doc:
       "Reset the power-state of the VM to halted in the database only. (Used \
-       to recover from slave failures in pooling scenarios by resetting the \
-       power-states of VMs running on dead slaves to halted.) This is a \
+       to recover from supporter failures in pooling scenarios by resetting \
+       the power-states of VMs running on dead slaves to halted.) This is a \
        potentially dangerous operation; use with care."
     ~params:[(Ref _vm, "vm", "The VM to reset")]
     ~errs:[] ~allowed_roles:_R_POOL_OP ()

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -93,7 +93,7 @@ let make_localhost ~__context ?(features = Features.all_features) () =
     ; chipset_info= None
     }
   in
-  Dbsync_slave.create_localhost ~__context host_info ;
+  Dbsync_supporter.create_localhost ~__context host_info ;
   (* We'd like to be able to call refresh_localhost_info, but
      	   create_misc is giving me too many headaches right now. Do the
      	   simple thing first and just set localhost_ref instead. *)
@@ -108,7 +108,7 @@ let make_localhost ~__context ?(features = Features.all_features) () =
     ~value:Network_interface.(string_of_kind Openvswitch) ;
   Create_misc.ensure_domain_zero_records ~__context
     ~host:!Xapi_globs.localhost_ref host_info ;
-  Dbsync_master.create_pool_record ~__context ;
+  Dbsync_coordinator.create_pool_record ~__context ;
   let pool = Helpers.get_pool ~__context in
   Db.Pool.set_restrictions ~__context ~self:pool
     ~value:(Features.to_assoc_list features) ;

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -63,7 +63,7 @@ let () =
     @ Test_vm.tests
     @ Test_cpuid_helpers.tests
     @ Test_pool_cpuinfo.tests
-    @ Test_dbsync_master.tests
+    @ Test_dbsync_coordinator.tests
     @ Test_pvs_cache_storage.tests
     @ Test_extauth_plugin_ADpbis.tests
     @ Test_helpers.tests

--- a/ocaml/tests/test_dbsync_coordinator.ml
+++ b/ocaml/tests/test_dbsync_coordinator.ml
@@ -62,7 +62,7 @@ module CreateToolsSR = Generic.MakeStateful (struct
           )
       )
       srs ;
-    Dbsync_master.create_tools_sr __context name description sr_introduce
+    Dbsync_coordinator.create_tools_sr __context name description sr_introduce
       maybe_create_pbd
 
   let extract_output __context _ =

--- a/ocaml/tests/test_pool_restore_database.ml
+++ b/ocaml/tests/test_pool_restore_database.ml
@@ -22,7 +22,7 @@ let run_test vm =
   Db.VM.set_is_control_domain ~__context ~self:vm ~value:isControlDomain ;
   Db.VM.set_power_state ~__context ~self:vm ~value:powerState ;
   Db.VM.set_resident_on ~__context ~self:vm ~value:Ref.null ;
-  Dbsync_master.reset_vms_running_on_missing_hosts ~__context ;
+  Dbsync_coordinator.reset_vms_running_on_missing_hosts ~__context ;
   Alcotest.check alco_power_state
     (Printf.sprintf "The VM %s is not halted" nameLabel)
     (Db.VM.get_power_state ~__context ~self:vm)

--- a/ocaml/tests/test_psr.ml
+++ b/ocaml/tests/test_psr.ml
@@ -56,7 +56,7 @@ let () =
 
 type host_id = int
 
-type member = {
+type supporter = {
     id: host_id
   ; mutable current_pool_secret: string
   ; mutable staged_pool_secret: string option
@@ -69,10 +69,10 @@ type psr_state = {
 }
 
 (* in the real implementation, the checkpoint and pool secret backups
-   are stored on the master, so we model that here *)
-type master = {member: member; psr_state: psr_state}
+   are stored on the coordinator, so we model that here *)
+type coordinator = {member: supporter; psr_state: psr_state}
 
-type host_t = Master of master | Member of member
+type host_t = Coordinator of coordinator | Supporter of supporter
 
 let map_r f = Rresult.R.reword_error (fun (failure, e) -> (failure, f e))
 
@@ -100,16 +100,16 @@ let mk_hosts num =
     ; fistpoint= None
     }
   in
-  let master =
+  let coordinator =
     {member; psr_state= {checkpoint= None; pool_secret_backups= None}}
   in
-  let members = List.init (num - 1) (fun id -> {member with id= id + 1}) in
-  (master, members)
+  let supporter = List.init (num - 1) (fun id -> {member with id= id + 1}) in
+  (coordinator, supporter)
 
 module Impl =
 functor
   (Hosts : sig
-     val master : master
+     val coordinator : coordinator
    end)
   ->
   struct
@@ -121,16 +121,20 @@ functor
 
     type host = host_t
 
-    let save_checkpoint x = master.psr_state.checkpoint <- Some x
+    let save_checkpoint x = coordinator.psr_state.checkpoint <- Some x
 
-    let retrieve_checkpoint () = master.psr_state.checkpoint
+    let retrieve_checkpoint () = coordinator.psr_state.checkpoint
 
     let backup pool_secrets =
-      master.psr_state.pool_secret_backups <- Some pool_secrets
+      coordinator.psr_state.pool_secret_backups <- Some pool_secrets
 
-    let retrieve () = Option.get master.psr_state.pool_secret_backups
+    let retrieve () = Option.get coordinator.psr_state.pool_secret_backups
 
-    let iter_host f = function Member m -> f m | Master m -> f m.member
+    let iter_host f = function
+      | Supporter m ->
+          f m
+      | Coordinator m ->
+          f m.member
 
     let tell_accept_new_pool_secret (_, staged_pool_secret) =
       iter_host (fun h ->
@@ -168,13 +172,13 @@ functor
               f ()
       )
 
-    let cleanup_master _ =
+    let cleanup_coordinator _ =
       let f () =
-        master.member.staged_pool_secret <- None ;
-        master.psr_state.checkpoint <- None ;
-        master.psr_state.pool_secret_backups <- None
+        coordinator.member.staged_pool_secret <- None ;
+        coordinator.psr_state.checkpoint <- None ;
+        coordinator.psr_state.pool_secret_backups <- None
       in
-      match master.member.fistpoint with
+      match coordinator.member.fistpoint with
       | Some ((Before, Cleanup) as fp) ->
           raise (Fistpoint fp)
       | Some ((After, Cleanup) as fp) ->
@@ -186,29 +190,31 @@ functor
 module type PSR = sig
   val start :
        string * string
-    -> master:master
-    -> members:member list
+    -> coordinator:coordinator
+    -> supporters:supporter list
     -> host_id Xapi_psr.r
 end
 
 (* the test implementation has been defined above,
    and we use this function to access it *)
-let mk_psr master =
-  let module PSR = Xapi_psr.Make (Impl (struct let master = master end)) in
+let mk_psr coordinator =
+  let module PSR = Xapi_psr.Make (Impl (struct
+    let coordinator = coordinator
+  end)) in
   let module PSR = struct
     include PSR
 
-    let start pool_secrets ~master ~members =
-      start pool_secrets ~master:(Master master)
-        ~members:(List.map (fun m -> Member m) members)
-      |> map_r (function Member m -> m.id | Master m -> m.member.id)
+    let start pool_secrets ~coordinator ~supporters =
+      start pool_secrets ~coordinator:(Coordinator coordinator)
+        ~supporters:(List.map (fun m -> Supporter m) supporters)
+      |> map_r (function Supporter m -> m.id | Coordinator m -> m.member.id)
   end in
   (module PSR : PSR)
 
 let r' = Alcotest.testable (Fmt.of_to_string string_of_r) ( = )
 
-let check_psr_succeeded r exp_pool_secret master members =
-  let hosts = master.member :: members in
+let check_psr_succeeded r exp_pool_secret coordinator members =
+  let hosts = coordinator.member :: members in
   Alcotest.check r' "PSR should be successful" (Ok ()) r ;
   List.iter
     (fun h ->
@@ -226,7 +232,7 @@ let check_psr_succeeded r exp_pool_secret master members =
       )
     )
     hosts ;
-  let psr_state = master.psr_state in
+  let psr_state = coordinator.psr_state in
   Alcotest.(
     check (option string) "checkpoint was cleaned up" None psr_state.checkpoint
   ) ;
@@ -237,7 +243,7 @@ let check_psr_succeeded r exp_pool_secret master members =
   )
 
 (* we test almost all combinations of hosts and fistpoints. the only
-   case we don't test is one case of master cleanup failure,
+   case we don't test is one case of coordinator cleanup failure,
    since it is slightly different - it has its own unit test (see below).
 *)
 let almost_all_possible_fists ~num_hosts =
@@ -258,7 +264,7 @@ let almost_all_possible_fists ~num_hosts =
   in
   let range = List.init num_hosts Fun.id in
   let open Xapi_psr in
-  let master_fistpoints =
+  let coordinator_fistpoints =
     multiply [Before; After]
       [
         ( Accept_new_pool_secret
@@ -284,22 +290,24 @@ let almost_all_possible_fists ~num_hosts =
       ]
       (List.tl range)
   in
-  List.append member_fistpoints master_fistpoints
+  List.append member_fistpoints coordinator_fistpoints
 
 let test_no_fistpoint () =
-  let master, members = mk_hosts 6 in
-  let module PSR = (val mk_psr master) in
-  let r = PSR.start (default_pool_secret, new_pool_secret) ~master ~members in
-  check_psr_succeeded r new_pool_secret master members
+  let coordinator, supporters = mk_hosts 6 in
+  let module PSR = (val mk_psr coordinator) in
+  let r =
+    PSR.start (default_pool_secret, new_pool_secret) ~coordinator ~supporters
+  in
+  check_psr_succeeded r new_pool_secret coordinator supporters
 
 (* try PSR with a fistpoint primed, check that it
    fails; then retry without any fistpoints and
    check that it succeeds. *)
 let test_fail_once () =
   let num_hosts = 3 in
-  let master, members = mk_hosts num_hosts in
-  let module PSR = (val mk_psr master) in
-  let hosts = master.member :: members in
+  let coordinator, supporters = mk_hosts num_hosts in
+  let module PSR = (val mk_psr coordinator) in
+  let hosts = coordinator.member :: supporters in
   almost_all_possible_fists ~num_hosts
   |> List.iter (fun (fistpoint, host_id, exp_err) ->
          let new_pool_secret =
@@ -309,33 +317,41 @@ let test_fail_once () =
          let faulty_host = List.nth hosts host_id in
          faulty_host.fistpoint <- Some fistpoint ;
          let r =
-           PSR.start (default_pool_secret, new_pool_secret) ~master ~members
+           PSR.start
+             (default_pool_secret, new_pool_secret)
+             ~coordinator ~supporters
          in
          Alcotest.check r'
            (Printf.sprintf "PSR should fail with %s" (string_of_r exp_err))
            exp_err r ;
          faulty_host.fistpoint <- None ;
-         let r = PSR.start (default_pool_secret, "not_used") ~master ~members in
-         check_psr_succeeded r new_pool_secret master members
+         let r =
+           PSR.start (default_pool_secret, "not_used") ~coordinator ~supporters
+         in
+         check_psr_succeeded r new_pool_secret coordinator supporters
      )
 
-let test_master_fails_during_cleanup () =
+let test_coordinator_fails_during_cleanup () =
   let open Xapi_psr in
   let num_hosts = 6 in
-  let master, members = mk_hosts num_hosts in
-  let module PSR = (val mk_psr master) in
+  let coordinator, supporters = mk_hosts num_hosts in
+  let module PSR = (val mk_psr coordinator) in
   let fistpoint = (After, Cleanup) in
   let exp_err = Error (Failed_during_cleanup, 0) in
-  master.member.fistpoint <- Some fistpoint ;
-  let r = PSR.start (default_pool_secret, new_pool_secret) ~master ~members in
+  coordinator.member.fistpoint <- Some fistpoint ;
+  let r =
+    PSR.start (default_pool_secret, new_pool_secret) ~coordinator ~supporters
+  in
   Alcotest.check r'
     (Printf.sprintf "PSR should fail with %s" (string_of_r exp_err))
     exp_err r ;
-  master.member.fistpoint <- None ;
+  coordinator.member.fistpoint <- None ;
   let r =
-    PSR.start (default_pool_secret, "this_ps_gets_used") ~master ~members
+    PSR.start
+      (default_pool_secret, "this_ps_gets_used")
+      ~coordinator ~supporters
   in
-  check_psr_succeeded r "this_ps_gets_used" master members
+  check_psr_succeeded r "this_ps_gets_used" coordinator supporters
 
 let tests =
   [
@@ -343,9 +359,9 @@ let tests =
     , [
         ("test_no_fistpoint", `Quick, test_no_fistpoint)
       ; ("test_fail_once", `Quick, test_fail_once)
-      ; ( "test_master_fails_during_cleanup"
+      ; ( "test_coordinator_fails_during_cleanup"
         , `Quick
-        , test_master_fails_during_cleanup
+        , test_coordinator_fails_during_cleanup
         )
       ]
     )

--- a/ocaml/tests/test_vm_placement.ml
+++ b/ocaml/tests/test_vm_placement.ml
@@ -302,23 +302,23 @@ module Construction = struct
     ; memory_static_max= Int64.of_int memory_static_max
     }
 
-  let host_snapshot id is_pool_master guests_resident guests_scheduled
+  let host_snapshot id is_coordinator guests_resident guests_scheduled
       memory_overhead memory_total =
     {
       Vm_placement.HS.id
-    ; is_pool_master
+    ; is_coordinator
     ; guests_resident
     ; guests_scheduled
     ; memory_overhead= Int64.of_int memory_overhead
     ; memory_total= Int64.of_int memory_total
     }
 
-  let host_snapshot_summary id is_pool_master memory_available_sum
+  let host_snapshot_summary id is_coordinator memory_available_sum
       memory_static_min_sum memory_dynamic_min_sum memory_dynamic_max_sum
       memory_static_max_sum =
     {
       Vm_placement.HSS.id
-    ; is_pool_master
+    ; is_coordinator
     ; memory_available_sum= Int64.of_int memory_available_sum
     ; memory_static_min_sum= Int64.of_int memory_static_min_sum
     ; memory_dynamic_min_sum= Int64.of_int memory_dynamic_min_sum
@@ -334,15 +334,15 @@ module Summarisation = struct
   let rec summarise_host_snapshot_input_output_data =
     [
       (*
-	(---------------------------------------------------), (-------------)
-	(                     INPUT:                        ), (   OUTPUT:   )
-	(---------------------------------------------------), (-------------)
-	(                 host snapshot                     ), (   host      )
-	([-------------],[-------------],[-------------]    ), (   snapshot  )
-	([  guests     ],[  guests     ],[  guests     ]    ), (   summary   )
-	([  resident   ],[  scheduled  ],[  extra      ]    ), (             )
-	([-------------],[-------------],[-------------]    ), (-------------)
-	([ xpqrs; xpqrs],[ xpqrs; xpqrs],[ xpqrs; xpqrs],x,t), (A, P, Q, R, S)*)
+    (---------------------------------------------------), (-------------)
+    (                     INPUT:                        ), (   OUTPUT:   )
+    (---------------------------------------------------), (-------------)
+    (                 host snapshot                     ), (   host      )
+    ([-------------],[-------------],[-------------]    ), (   snapshot  )
+    ([  guests     ],[  guests     ],[  guests     ]    ), (   summary   )
+    ([  resident   ],[  scheduled  ],[  extra      ]    ), (             )
+    ([-------------],[-------------],[-------------]    ), (-------------)
+    ([ xpqrs; xpqrs],[ xpqrs; xpqrs],[ xpqrs; xpqrs],x,t), (A, P, Q, R, S)*)
       (([], [], [], 0, 0), (0, 0, 0, 0, 0))
     ; (([], [], [], 0, 8), (8, 0, 0, 0, 0))
     ; (([], [], [], 1, 8), (7, 0, 0, 0, 0))

--- a/ocaml/xapi-aux/pool_role.mli
+++ b/ocaml/xapi-aux/pool_role.mli
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type t = Master | Slave of string  (** IP address *) | Broken
+type t = Coordinator | Supporter of string  (** IP address *) | Broken
 
 val with_pool_role_lock : (unit -> unit) -> unit
 
@@ -22,11 +22,11 @@ val string_of : t -> string
 val get_role : unit -> t
 (** Returns the role of this node *)
 
-val is_master : unit -> bool
-(** Returns true if this node is a master *)
+val is_coordinator : unit -> bool
+(** [is_coordinator ()] returns true if this node is the pool coordinator *)
 
-val is_slave : unit -> bool
-(** Returns true if this node is a slave *)
+val is_supporter : unit -> bool
+(** [is_supporter ()] returns true if this node is a supporter *)
 
 val is_broken : unit -> bool
 (** Returns true if this node is broken *)
@@ -36,13 +36,15 @@ val is_unit_test : unit -> bool
 
 val set_pool_role_for_test : unit -> unit
 
-exception This_host_is_a_master
+exception This_host_is_coordinator
 
 exception This_host_is_broken
 
-val get_master_address : unit -> string
-(** If this node is a slave, returns the IP address of its master *)
+val get_address_of_coordinator_exn : unit -> string
+(** [get_address_of_coordinator_exn ()] returns the IP of the pool coordinator
+    if this node is a supporter, otherwise fails *)
 
-val get_master_address_opt : unit -> string option
-(** [get_master_address_opt ()] returns None if the current host is the master
-    or it's broken, and Some (address of the pool master) otherwise *)
+val get_address_of_coordinator : unit -> string option
+(** [get_address_of_coordinator ()] returns None if the current host the pool
+    coordinator or the host is broken, and Some (address of the pool's
+    coordinator) otherwise *)

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1602,7 +1602,7 @@ let pool_emergency_reset_master printer rpc session_id params =
 
 let pool_emergency_transition_to_master printer rpc session_id params =
   let force = get_bool_param params "force" in
-  if (not (Pool_role.is_master ())) || force then (
+  if (not (Pool_role.is_coordinator ())) || force then (
     Client.Pool.emergency_transition_to_master ~rpc ~session_id ;
     printer
       (Cli_printer.PList

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -119,7 +119,7 @@ let host_offline = "HOST_OFFLINE"
 
 let host_cannot_destroy_self = "HOST_CANNOT_DESTROY_SELF"
 
-let host_is_slave = "HOST_IS_SLAVE"
+let host_is_supporter = "HOST_IS_SLAVE"
 
 let host_name_invalid = "HOST_NAME_INVALID"
 
@@ -132,7 +132,7 @@ let hosts_failed_to_disable_caching = "HOSTS_FAILED_TO_DISABLE_CACHING"
 let host_cannot_see_SR = "HOST_CANNOT_SEE_SR"
 
 (* Host errors which explain why the host is in emergency mode *)
-let host_its_own_slave = "HOST_ITS_OWN_SLAVE"
+let host_its_own_supporter = "HOST_ITS_OWN_SLAVE"
 
 let host_still_booting = "HOST_STILL_BOOTING"
 
@@ -141,7 +141,7 @@ let host_has_no_management_ip = "HOST_HAS_NO_MANAGEMENT_IP"
 
 let host_master_cannot_talk_back = "HOST_MASTER_CANNOT_TALK_BACK"
 
-let host_unknown_to_master = "HOST_UNKNOWN_TO_MASTER"
+let host_unknown_to_coordinator = "HOST_UNKNOWN_TO_MASTER"
 
 (* should be fenced *)
 let host_broken = "HOST_BROKEN"

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -122,7 +122,7 @@ let host_clock_went_backwards = addMessage "HOST_CLOCK_WENT_BACKWARDS" 1L
 
 (* Unused in xen-api *)
 
-let pool_master_transition = addMessage "POOL_MASTER_TRANSITION" 4L
+let pool_coordinator_transition = addMessage "POOL_MASTER_TRANSITION" 4L
 
 let pbd_plug_failed_on_server_start =
   addMessage "PBD_PLUG_FAILED_ON_SERVER_START" 3L

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -200,15 +200,15 @@ let default_smapiv3_cluster_stack = "corosync"
 (* Note: default without clustering is in !Xapi_globs.default_cluster_stack *)
 let supported_smapiv3_cluster_stacks = ["corosync"]
 
-(* Set in the local db to cause us to emit an alert when we come up as a master after
-   a transition or HA failover *)
-let this_node_just_became_master = "this_node_just_became_master"
+(* Set in the local db to cause us to emit an alert when we come up as a
+   coordinator after a transition or HA failover *)
+let this_node_just_became_coordinator = "this_node_just_became_master"
 
 (* Environment variables used to communicate with HA reconfigure script *)
 let ha_peers = "ha_peers"
 
-(* Stores whether we've executed the master scripts *)
-let master_scripts = "master_scripts"
+(* Stores whether we've executed the coordinator scripts *)
+let coordinator_scripts = "master_scripts"
 
 (* This flag is set when we commit to rebooting or shutting down the host when HA is enabled.
    This will prevent anyone from re-enabling the host and starting VMs on it during shutdown. *)

--- a/ocaml/xapi/cert_refresh.ml
+++ b/ocaml/xapi/cert_refresh.ml
@@ -48,7 +48,7 @@ end)
 
 let unreachable_hosts ~__context =
   let live = Helpers.get_live_hosts ~__context in
-  let pool = Xapi_pool_helpers.get_master_slaves_list ~__context in
+  let pool = Xapi_pool_helpers.get_members_coordinator_first ~__context in
   HostSet.(diff (of_list pool) (of_list live))
 
 let maybe_update_clustering_tls_config ~__context =

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -81,7 +81,7 @@ let is_unix_socket s =
       false
 
 let default_database () =
-  if Pool_role.is_master () then
+  if Pool_role.is_coordinator () then
     Db_backend.make ()
   else
     Db_ref.Remote

--- a/ocaml/xapi/dbsync_coordinator.ml
+++ b/ocaml/xapi/dbsync_coordinator.ml
@@ -15,7 +15,7 @@
  * @group Main Loop and Start-up
 *)
 
-module D = Debug.Make (struct let name = "dbsync" end)
+module D = Debug.Make (struct let name = __MODULE__ end)
 
 open D
 open Client

--- a/ocaml/xapi/dbsync_supporter.ml
+++ b/ocaml/xapi/dbsync_supporter.ml
@@ -24,7 +24,7 @@ open Create_misc
 open Client
 open Network
 
-module D = Debug.Make (struct let name = "dbsync" end)
+module D = Debug.Make (struct let name = __MODULE__ end)
 
 open D
 
@@ -176,23 +176,6 @@ let record_host_memory_properties ~__context info =
               (obvious_overhead_memory_bytes ++ nonobvious_overhead_memory_bytes)
         )
         boot_memory_bytes
-
-(* -- used this for testing uniqueness constraints executed on slave do not kill connection.
-   Committing commented out vsn of this because it might be useful again..
-   let test_uniqueness_doesnt_kill_us ~__context =
-   let duplicate_uuid = Uuid.to_string (Uuid.make_uuid()) in
-    Db.Network.create ~__context ~ref:(Ref.make()) ~uuid:duplicate_uuid
-      ~current_operations:[] ~allowed_operations:[]
-      ~name_label:"Test uniqueness constraint"
-      ~name_description:"Testing"
-      ~bridge:"bridge" ~other_config:[] ~purpose:[];
-    Db.Network.create ~__context ~ref:(Ref.make()) ~uuid:duplicate_uuid
-      ~current_operations:[] ~allowed_operations:[]
-      ~name_label:"Test uniqueness constraint"
-      ~name_description:"Testing"
-      ~bridge:"bridge" ~other_config:[] ~purpose:[];
-    ()
-*)
 
 (* CA-23803:
  * As well as marking the management interface as attached, mark any other important

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -1075,17 +1075,16 @@ module ClosestKdc = struct
     with e -> error "Failed to update domain kdc %s" (Printexc.to_string e)
 
   let trigger_update ~start =
-    if Pool_role.is_master () then (
+    if Pool_role.is_coordinator () then
       debug "Trigger task: %s" periodic_update_task_name ;
-      Xapi_periodic_scheduler.add_to_queue periodic_update_task_name
-        (Xapi_periodic_scheduler.Periodic
-           !Xapi_globs.winbind_update_closest_kdc_interval
-        )
-        start update
-    )
+    Xapi_periodic_scheduler.add_to_queue periodic_update_task_name
+      (Xapi_periodic_scheduler.Periodic
+         !Xapi_globs.winbind_update_closest_kdc_interval
+      )
+      start update
 
   let stop_update () =
-    if Pool_role.is_master () then
+    if Pool_role.is_coordinator () then
       Xapi_periodic_scheduler.remove_from_queue periodic_update_task_name
 end
 

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -191,11 +191,11 @@ let check_sr_availability ~__context sr =
   let localhost = Helpers.get_localhost ~__context in
   check_sr_availability_host ~__context sr localhost
 
-let find_host_for_sr ~__context ?(prefer_slaves = false) sr =
+let find_host_for_sr ~__context ?(prefer_supporters = false) sr =
   let choose_fn ~host =
     Xapi_vm_helpers.assert_can_see_specified_SRs ~__context ~reqd_srs:[sr] ~host
   in
-  Xapi_vm_helpers.choose_host ~__context ~choose_fn ~prefer_slaves ()
+  Xapi_vm_helpers.choose_host ~__context ~choose_fn ~prefer_supporters ()
 
 let check_vm_host_SRs ~__context vm host =
   try

--- a/ocaml/xapi/localdb.ml
+++ b/ocaml/xapi/localdb.ml
@@ -11,8 +11,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-(* Store and retrieve some host-specific data as key-value pairs. This can
-   be used in emergency mode since every slave has its own copy. *)
+(* Store and retrieve some host-specific data as key-value pairs. This can be
+   used in emergency mode since every supporter has its own copy. *)
 
 open Xapi_stdext_threads.Threadext
 open Xapi_stdext_pervasives.Pervasiveext

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -237,22 +237,22 @@ let choose_pbds_for_sr ~consider_unplugged_pbds ~__context ~self () =
   let pbds = PBDSet.of_list pbds_to_consider in
   let pbd_candidates =
     if Helpers.is_sr_shared ~__context ~self then
-      let master = Helpers.get_master ~__context in
-      let master_pbds =
-        PBDSet.of_list (Db.Host.get_PBDs ~__context ~self:master)
+      let coordinator = Helpers.get_coordinator ~__context in
+      let coordinator_pbds =
+        PBDSet.of_list (Db.Host.get_PBDs ~__context ~self:coordinator)
       in
       (* Operation run on shared SRs depend on the first pbd of the list to be
          on the master. *)
-      let sr_master_pbds, rest_pbds =
-        PBDSet.partition (fun pbd -> PBDSet.mem pbd master_pbds) pbds
+      let sr_coordinator_pbds, supporters_pbds =
+        PBDSet.partition (fun pbd -> PBDSet.mem pbd coordinator_pbds) pbds
       in
-      if PBDSet.is_empty sr_master_pbds then
+      if PBDSet.is_empty sr_coordinator_pbds then
         Error `Sr_no_pbds
       else
         Ok
           (List.rev_append
-             (PBDSet.elements sr_master_pbds)
-             (PBDSet.elements rest_pbds)
+             (PBDSet.elements sr_coordinator_pbds)
+             (PBDSet.elements supporters_pbds)
           )
     else
       Ok pbds_to_consider
@@ -360,7 +360,7 @@ functor
 
     let pool_uuid ~__context pool =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           let name = Db.Pool.get_name_label ~__context ~self:pool in
           Printf.sprintf "%s%s"
             (Db.Pool.get_uuid ~__context ~self:pool)
@@ -370,7 +370,7 @@ functor
       with _ -> "invalid"
 
     let current_pool_uuid ~__context =
-      if Pool_role.is_master () then
+      if Pool_role.is_coordinator () then
         let _, pool = List.hd (Db.Pool.get_all_records ~__context) in
         Printf.sprintf "%s%s" pool.API.pool_uuid
           (add_brackets pool.API.pool_name_label)
@@ -379,7 +379,7 @@ functor
 
     let host_uuid ~__context host =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           let name = Db.Host.get_name_label ~__context ~self:host in
           Printf.sprintf "%s%s"
             (Db.Host.get_uuid ~__context ~self:host)
@@ -390,7 +390,7 @@ functor
 
     let vm_uuid ~__context vm =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           let name = Db.VM.get_name_label ~__context ~self:vm in
           Printf.sprintf "%s%s"
             (Db.VM.get_uuid ~__context ~self:vm)
@@ -401,7 +401,7 @@ functor
 
     let vm_appliance_uuid ~__context vm_appliance =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           let name =
             Db.VM_appliance.get_name_label ~__context ~self:vm_appliance
           in
@@ -414,7 +414,7 @@ functor
 
     let sr_uuid ~__context sr =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           let name = Db.SR.get_name_label ~__context ~self:sr in
           Printf.sprintf "%s%s"
             (Db.SR.get_uuid ~__context ~self:sr)
@@ -425,7 +425,7 @@ functor
 
     let vdi_uuid ~__context vdi =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.VDI.get_uuid ~__context ~self:vdi
         else
           Ref.string_of vdi
@@ -433,7 +433,7 @@ functor
 
     let vif_uuid ~__context vif =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.VIF.get_uuid ~__context ~self:vif
         else
           Ref.string_of vif
@@ -441,7 +441,7 @@ functor
 
     let vlan_uuid ~__context vlan =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.VLAN.get_uuid ~__context ~self:vlan
         else
           Ref.string_of vlan
@@ -449,7 +449,7 @@ functor
 
     let tunnel_uuid ~__context tunnel =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Tunnel.get_uuid ~__context ~self:tunnel
         else
           Ref.string_of tunnel
@@ -457,7 +457,7 @@ functor
 
     let bond_uuid ~__context bond =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Bond.get_uuid ~__context ~self:bond
         else
           Ref.string_of bond
@@ -465,7 +465,7 @@ functor
 
     let network_sriov_uuid ~__context sriov =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Network_sriov.get_uuid ~__context ~self:sriov
         else
           Ref.string_of sriov
@@ -473,7 +473,7 @@ functor
 
     let pif_uuid ~__context pif =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.PIF.get_uuid ~__context ~self:pif
         else
           Ref.string_of pif
@@ -481,7 +481,7 @@ functor
 
     let vbd_uuid ~__context vbd =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.VBD.get_uuid ~__context ~self:vbd
         else
           Ref.string_of vbd
@@ -489,7 +489,7 @@ functor
 
     let pbd_uuid ~__context pbd =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.PBD.get_uuid ~__context ~self:pbd
         else
           Ref.string_of pbd
@@ -497,7 +497,7 @@ functor
 
     let task_uuid ~__context task =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Task.get_uuid ~__context ~self:task
         else
           Ref.string_of task
@@ -505,7 +505,7 @@ functor
 
     let crashdump_uuid ~__context cd =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Crashdump.get_uuid ~__context ~self:cd
         else
           Ref.string_of cd
@@ -513,7 +513,7 @@ functor
 
     let host_crashdump_uuid ~__context hcd =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Host_crashdump.get_uuid ~__context ~self:hcd
         else
           Ref.string_of hcd
@@ -521,7 +521,7 @@ functor
 
     let network_uuid ~__context network =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Network.get_uuid ~__context ~self:network
         else
           Ref.string_of network
@@ -529,7 +529,7 @@ functor
 
     let host_patch_uuid ~__context patch =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Host_patch.get_uuid ~__context ~self:patch
         else
           Ref.string_of patch
@@ -537,7 +537,7 @@ functor
 
     let pool_patch_uuid ~__context patch =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Pool_patch.get_uuid ~__context ~self:patch
         else
           Ref.string_of patch
@@ -545,7 +545,7 @@ functor
 
     let pool_update_uuid ~__context update =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Pool_update.get_uuid ~__context ~self:update
         else
           Ref.string_of update
@@ -553,7 +553,7 @@ functor
 
     let pci_uuid ~__context pci =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.PCI.get_uuid ~__context ~self:pci
         else
           Ref.string_of pci
@@ -561,7 +561,7 @@ functor
 
     let pgpu_uuid ~__context pgpu =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.PGPU.get_uuid ~__context ~self:pgpu
         else
           Ref.string_of pgpu
@@ -569,7 +569,7 @@ functor
 
     let gpu_group_uuid ~__context gpu_group =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.GPU_group.get_uuid ~__context ~self:gpu_group
         else
           Ref.string_of gpu_group
@@ -577,7 +577,7 @@ functor
 
     let vgpu_uuid ~__context vgpu =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.VGPU.get_uuid ~__context ~self:vgpu
         else
           Ref.string_of vgpu
@@ -585,7 +585,7 @@ functor
 
     let vgpu_type_uuid ~__context vgpu_type =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.VGPU_type.get_uuid ~__context ~self:vgpu_type
         else
           Ref.string_of vgpu_type
@@ -593,7 +593,7 @@ functor
 
     let sdn_controller_uuid ~__context sdn_controller =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.SDN_controller.get_uuid ~__context ~self:sdn_controller
         else
           Ref.string_of sdn_controller
@@ -601,7 +601,7 @@ functor
 
     let pusb_uuid ~__context pusb =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.PUSB.get_uuid ~__context ~self:pusb
         else
           Ref.string_of pusb
@@ -609,7 +609,7 @@ functor
 
     let usb_group_uuid ~__context usb_group =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.USB_group.get_uuid ~__context ~self:usb_group
         else
           Ref.string_of usb_group
@@ -617,7 +617,7 @@ functor
 
     let vusb_uuid ~__context vusb =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.VUSB.get_uuid ~__context ~self:vusb
         else
           Ref.string_of vusb
@@ -625,7 +625,7 @@ functor
 
     let repository_uuid ~__context repository =
       try
-        if Pool_role.is_master () then
+        if Pool_role.is_coordinator () then
           Db.Repository.get_uuid ~__context ~self:repository
         else
           Ref.string_of repository
@@ -776,7 +776,7 @@ functor
         info "Pool.eject: pool = '%s'; host = '%s'"
           (current_pool_uuid ~__context)
           (host_uuid ~__context host) ;
-        let master = Helpers.get_master ~__context in
+        let master = Helpers.get_coordinator ~__context in
         let local_fn = Local.Pool.eject ~host in
         let other =
           Db.Host.get_all ~__context
@@ -995,7 +995,9 @@ functor
           (current_pool_uuid ~__context) ;
         let self = Helpers.get_pool ~__context in
         let local_fn = Local.Pool.enable_tls_verification in
-        let all_hosts = Xapi_pool_helpers.get_master_slaves_list ~__context in
+        let all_hosts =
+          Xapi_pool_helpers.get_members_coordinator_first ~__context
+        in
 
         Xapi_pool_helpers.with_pool_operation ~__context
           ~doc:"Pool.enable_tls_verification" ~self ~op:`tls_verification_enable
@@ -4691,14 +4693,15 @@ functor
         Not_found exception will be raised.
         WARNING: this may forward the call to a host that is NOT the SR master. *)
       let forward_sr_multiple_op ~local_fn ~__context ~srs
-          ?(prefer_slaves = false) op =
+          ?(prefer_supporters = false) op =
         let choose_fn ~host =
           Xapi_vm_helpers.assert_can_see_specified_SRs ~__context ~reqd_srs:srs
             ~host
         in
         let host =
           try
-            Xapi_vm_helpers.choose_host ~__context ~choose_fn ~prefer_slaves ()
+            Xapi_vm_helpers.choose_host ~__context ~choose_fn ~prefer_supporters
+              ()
           with _ -> raise Not_found
         in
         do_op_on ~local_fn ~__context ~host op
@@ -5270,10 +5273,10 @@ functor
           (fun () ->
             try
               SR.forward_sr_multiple_op ~local_fn ~__context ~srs:[src_sr; sr]
-                ~prefer_slaves:true op
+                ~prefer_supporters:true op
             with Not_found ->
               SR.forward_sr_multiple_op ~local_fn ~__context ~srs:[src_sr]
-                ~prefer_slaves:true op
+                ~prefer_supporters:true op
           )
 
       let pool_migrate ~__context ~vdi ~sr ~options =
@@ -6203,7 +6206,7 @@ functor
         let host =
           match Db.Cluster_host.get_all ~__context with
           | [] ->
-              Helpers.get_master ~__context
+              Helpers.get_coordinator ~__context
           | cluster_hosts when List.exists is_local_cluster_host cluster_hosts
             ->
               localhost
@@ -6263,7 +6266,9 @@ functor
       let pool_resync ~__context ~self =
         (* iterates Cluster_host.enable and Cluster_host where necessary*)
         info "Cluster.pool_resync cluster: %s" (Ref.string_of self) ;
-        let hosts = Xapi_pool_helpers.get_master_slaves_list ~__context in
+        let hosts =
+          Xapi_pool_helpers.get_members_coordinator_first ~__context
+        in
         let local_fn = Local.Cluster.pool_resync ~self in
         hosts
         |> List.iter (fun host ->

--- a/ocaml/xapi/monitor_coordinator.ml
+++ b/ocaml/xapi/monitor_coordinator.ml
@@ -18,13 +18,12 @@ open Monitor_types
 open Db_filter_types
 open Network
 
-module D = Debug.Make (struct let name = "monitor_master" end)
+module D = Debug.Make (struct let name = __MODULE__ end)
 
 open D
 
-let update_configuration_from_master () =
-  Server_helpers.exec_with_new_task "update_configuration_from_master"
-    (fun __context ->
+let update_configuration_from_coordinator () =
+  Server_helpers.exec_with_new_task __FUNCTION__ (fun __context ->
       let oc =
         Db.Pool.get_other_config ~__context ~self:(Helpers.get_pool ~__context)
       in
@@ -73,8 +72,8 @@ let set_pif_metrics ~__context ~self ~vendor ~device ~carrier ~speed ~duplex
   Db.PIF_metrics.set_last_updated ~__context ~self
     ~value:(Date.of_float (Unix.gettimeofday ()))
 
-(* Note that the following function is actually called on the slave most of the
- * time now but only when the PIF information changes. *)
+(* Note that the following function is actually called on supporters most of
+   the time now but only when the PIF information changes. *)
 let update_pifs ~__context host pifs =
   match List.length pifs with
   | 0 ->

--- a/ocaml/xapi/monitor_coordinator.mli
+++ b/ocaml/xapi/monitor_coordinator.mli
@@ -17,12 +17,12 @@
 *)
 
 (** This module implements the saving of properties for various objects (e.g.
- * VIFs, CPUs) into xapi's database. It is also used to regularly update
- * some simple configuration from the master. *)
+    VIFs, CPUs) into xapi's database. It is also used to regularly update
+    some simple configuration from the coordinator. *)
 
-val update_configuration_from_master : unit -> unit
+val update_configuration_from_coordinator : unit -> unit
 (** Used on a regular interval to update rrdd's use_min_max and xenops'
- * pass_through_pif_carrier. *)
+    pass_through_pif_carrier. *)
 
 val update_pifs :
   __context:Context.t -> 'a Ref.t -> Monitor_types.pif list -> unit

--- a/ocaml/xapi/monitor_dbcalls.ml
+++ b/ocaml/xapi/monitor_dbcalls.ml
@@ -106,7 +106,7 @@ let pifs_update_fn () =
         bond_changes ;
       set_bond_changes ~except:!keeps () ;
       ( try
-          Monitor_master.update_pifs ~__context host pif_changes ;
+          Monitor_coordinator.update_pifs ~__context host pif_changes ;
           set_pif_changes ()
         with e -> issues := e :: !issues
       ) ;

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -725,8 +725,8 @@ let bring_pif_up ~__context ?(management_interface = false) (pif : API.ref_PIF)
             warn "About to kill idle client stunnels" ;
             (* The master_connection would otherwise try to take a broken stunnel from the cache *)
             Stunnel_cache.flush () ;
-            warn "About to forcibly reset the master connection" ;
-            Master_connection.force_connection_reset ()
+            warn "About to forcibly reset the primary connection" ;
+            Coordinator_connection.force_connection_reset ()
           ) ;
           if rc.API.pIF_currently_attached = false || management_interface then (
             if management_interface then (

--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -79,7 +79,7 @@ let permission_set permission_list =
 
 let create_session_permissions_tbl ~session_id ~rbac_permissions =
   if
-    use_efficient_permission_set && Pool_role.is_master ()
+    use_efficient_permission_set && Pool_role.is_coordinator ()
     (* Create this structure on the master only, *)
     (* so as to avoid heap-leaking on the slaves *)
   then (

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -364,9 +364,9 @@ let get_local_repository_name ~__context ~self =
 
 let with_local_repositories ~__context f =
   let master_addr =
-    try Pool_role.get_master_address ()
-    with Pool_role.This_host_is_a_master ->
-      Option.get (Helpers.get_management_ip_addr ~__context)
+    Option.value
+      ~default:(Option.get (Helpers.get_management_ip_addr ~__context))
+      (Pool_role.get_address_of_coordinator ())
   in
   Stunnel.with_client_proxy ~verify_cert:(Stunnel_client.pool ())
     ~remote_host:master_addr ~remote_port:Constants.default_ssl_port

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -66,14 +66,15 @@ let exec_with_context ~__context ~need_complete ?marshaller ?f_forward
   (* Execute fn f in specified __context, marshalling result with "marshaller" *)
   let exec () =
     (* NB:
-       1. If we are a slave we process the call locally assuming the locks have
-       already been taken by the master
-       2. If we are the master, locks are only necessary for the potentially-forwarded
-       (ie side-effecting) operations and not things like the database layer *)
+       1. If we are a supporter we process the call locally assuming the locks
+       have already been taken by the coordinator
+       2. If we are the coordinator, locks are only necessary for the
+       potentially-forwarded (ie side-effecting) operations and not things like
+       the database layer *)
     try
       let result =
-        if not (Pool_role.is_master ()) then
-          f ~__context (* slaves process everything locally *)
+        if not (Pool_role.is_coordinator ()) then
+          f ~__context (* supporters process everything locally *)
         else
           match f_forward with
           | None ->

--- a/ocaml/xapi/startup.ml
+++ b/ocaml/xapi/startup.ml
@@ -19,7 +19,7 @@ module D = Debug.Make (struct let name = "startup" end)
 
 open D
 
-type flag = OnlyMaster | OnlySlave | NoExnRaising | OnThread
+type flag = OnlyCoordinator | OnlySupporter | NoExnRaising | OnThread
 
 let thread_exn_wrapper thread_name f =
   ( try f ()
@@ -31,47 +31,47 @@ let thread_exn_wrapper thread_name f =
   warn "thread [%s] died" thread_name ;
   ()
 
-(* run all list of tasks sequentially. every function is wrapped in a try with handler with
- * the possibility to specify to run only on master or slave, and that the exception should
- * not be raised *)
+(* run all list of tasks sequentially. every function is wrapped in a try with
+   handler with the possibility to specify to run only on coordinator or
+   supporters, and that the exception should not be raised *)
 let run ~__context tasks =
   let task_id = Context.get_task_id __context in
   let dummy_task = Ref.is_dummy task_id in
   let get_flags_of_list flags =
-    let only_master = ref false
-    and only_slave = ref false
+    let only_coordinator = ref false
+    and only_supporter = ref false
     and exnraise = ref true
     and onthread = ref false in
     List.iter
       (fun flag ->
         match flag with
-        | OnlyMaster ->
-            only_master := true
-        | OnlySlave ->
-            only_slave := true
+        | OnlyCoordinator ->
+            only_coordinator := true
+        | OnlySupporter ->
+            only_supporter := true
         | NoExnRaising ->
             exnraise := false
         | OnThread ->
             onthread := true
       )
       flags ;
-    (!only_master, !only_slave, !exnraise, !onthread)
+    (!only_coordinator, !only_supporter, !exnraise, !onthread)
   in
   (* get pool role status *)
-  let is_master = Pool_role.is_master () in
+  let is_coordinator = Pool_role.is_coordinator () in
   (* iterate tasks *)
   List.iter
     (fun (tsk_name, tsk_flags, tsk_fct) ->
       (* Wrap the function with a timer *)
       let tsk_fct () = Stats.time_this tsk_name tsk_fct in
-      let only_master, only_slave, exnraise, onthread =
+      let only_coordinator, only_supporter, exnraise, onthread =
         get_flags_of_list tsk_flags
       in
       try
         if
-          (only_master && is_master)
-          || (only_slave && not is_master)
-          || ((not only_slave) && not only_master)
+          (only_coordinator && is_coordinator)
+          || (only_supporter && not is_coordinator)
+          || ((not only_supporter) && not only_coordinator)
         then (
           if not dummy_task then (
             Db.Task.remove_from_other_config ~__context ~self:task_id

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -131,7 +131,10 @@ let vdi_info_of_vdi_rec __context vdi_rec =
   }
 
 let redirect _sr =
-  raise (Storage_error (Redirect (Some (Pool_role.get_master_address ()))))
+  raise
+    (Storage_error
+       (Redirect (Some (Pool_role.get_address_of_coordinator_exn ())))
+    )
 
 module SMAPIv1 = struct
   (** xapi's builtin ability to call local SM plugins using the existing

--- a/ocaml/xapi/sync_networking.mli
+++ b/ocaml/xapi/sync_networking.mli
@@ -17,10 +17,10 @@
 
 val fix_bonds : __context:Context.t -> unit -> unit
 
-val copy_bonds_from_master : __context:Context.t -> unit -> unit
+val copy_bonds_from_coordinator : __context:Context.t -> unit -> unit
 
-val copy_vlans_from_master : __context:Context.t -> unit -> unit
+val copy_vlans_from_coordinator : __context:Context.t -> unit -> unit
 
-val copy_tunnels_from_master : __context:Context.t -> unit -> unit
+val copy_tunnels_from_coordinator : __context:Context.t -> unit -> unit
 
-val copy_network_sriovs_from_master : __context:Context.t -> unit -> unit
+val copy_network_sriovs_from_coordinator : __context:Context.t -> unit -> unit

--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -207,9 +207,9 @@ let add_vgpus_to_vm ~__context host vm vgpus =
 (* The two functions below are the main entry points of this module *)
 
 (* Note that this function is called from Message_forwarding.allocate_vm_to_host,
- * only on the pool master, and with the global lock held. We therefore do not
- * need any further locking in any of the functions above, where resources are
- * reserved. *)
+   only on the coordinator, and with the global lock held. We therefore do not
+   need any further locking in any of the functions above, where resources are
+   reserved. *)
 let create_vgpus ~__context host (vm, vm_r) hvm =
   let vgpus = vgpus_of_vm ~__context vm_r in
   if vgpus <> [] && not hvm then
@@ -221,7 +221,8 @@ let create_vgpus ~__context host (vm, vm_r) hvm =
       ) ;
   add_vgpus_to_vm ~__context host vm vgpus
 
-(* This function is called from Xapi_xenops, after forwarding, so possibly on a slave. *)
+(* This function is called from Xapi_xenops, after forwarding, so possibly on a
+   supporter. *)
 let list_pcis_for_passthrough ~__context ~vm :
     (int * (int * int * int * int)) list =
   let pcis_of_vgpu = function

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -478,7 +478,7 @@ let init_wlb ~__context ~wlb_url ~wlb_username ~wlb_password ~xenserver_username
     ~xenserver_password =
   assert_wlb_licensed ~__context ;
   let pool = Helpers.get_pool ~__context in
-  let master = Db.Pool.get_master ~__context ~self:pool in
+  let coordinator = Db.Pool.get_master ~__context ~self:pool in
   let params =
     sprintf "%s\n%s\n%s\n%s\n"
       (generate_safe_param "Password" xenserver_password)
@@ -491,12 +491,14 @@ let init_wlb ~__context ~wlb_url ~wlb_username ~wlb_password ~xenserver_username
                  ~default:"ipv4"
               )
           in
-          let master_address = Db.Host.get_address ~__context ~self:master in
+          let coordinator_address =
+            Db.Host.get_address ~__context ~self:coordinator
+          in
           if address_type = `IPv4 then
-            sprintf "http://%s:80/" master_address
+            sprintf "http://%s:80/" coordinator_address
           else
             (*This is an ipv6 address, put [] around the address so that WLB can properly parse the url*)
-            sprintf "http://[%s]:80/" master_address
+            sprintf "http://[%s]:80/" coordinator_address
          )
       )
   in

--- a/ocaml/xapi/xapi_alert.ml
+++ b/ocaml/xapi/xapi_alert.ml
@@ -50,7 +50,7 @@ let alert_queue_push =
 (** Function which guarantees not to block and creates the message on a 'best-effort' basis *)
 let add ~msg:(name, priority) ~cls ~obj_uuid ~body =
   let sent =
-    if Pool_role.is_master () then
+    if Pool_role.is_coordinator () then
       Server_helpers.exec_with_new_task "Sending an alert"
         ~task_in_database:false (fun __context ->
           let (_ : 'a Ref.t) =

--- a/ocaml/xapi/xapi_dr_task.ml
+++ b/ocaml/xapi/xapi_dr_task.ml
@@ -78,7 +78,7 @@ let try_create_sr_from_record ~__context ~_type ~device_config ~dr_task
       in
       try
         (* Create and plug PBDs. *)
-        Xapi_pool_helpers.call_fn_on_master_then_slaves ~__context
+        Xapi_pool_helpers.call_fn_on_members_coordinator_first ~__context
           (fun ~rpc ~session_id ~host ->
             debug "Attaching SR %s to host %s" sr_record.uuid
               (Db.Host.get_name_label ~__context ~self:host) ;
@@ -119,7 +119,7 @@ let create ~__context ~_type ~device_config ~whitelist =
          )
       ) ;
   (* Probe the specified device for SRs. *)
-  let master = Helpers.get_master ~__context in
+  let master = Helpers.get_coordinator ~__context in
   let probe_result =
     Helpers.call_api_functions ~__context (fun rpc session_id ->
         Client.SR.probe ~rpc ~session_id ~host:master ~device_config ~_type

--- a/ocaml/xapi/xapi_fuse.ml
+++ b/ocaml/xapi/xapi_fuse.ml
@@ -64,7 +64,10 @@ let light_fuse_and_run ?(fuse_length = !Constants.fuse_time) () =
          try
            let dbconn = Db_connections.preferred_write_db () in
            let lock_db =
-             if Pool_role.is_master () then Db_lock.with_lock else fun f -> f ()
+             if Pool_role.is_coordinator () then
+               Db_lock.with_lock
+             else
+               fun f -> f ()
            in
            lock_db (fun () ->
                Db_cache_impl.flush_and_exit dbconn
@@ -119,7 +122,10 @@ let light_fuse_and_dont_restart ?(fuse_length = !Constants.fuse_time) () =
          log_and_ignore_exn (Rrdd.backup_rrds None) ;
          Thread.delay fuse_length ;
          let lock_db =
-           if Pool_role.is_master () then Db_lock.with_lock else fun f -> f ()
+           if Pool_role.is_coordinator () then
+             Db_lock.with_lock
+           else
+             fun f -> f ()
          in
          lock_db (fun () ->
              Db_cache_impl.flush_and_exit

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -87,8 +87,9 @@ let storage_unix_domain_socket = Filename.concat "/var/lib/xcp" "storage"
 
 let local_database = Filename.concat "/var/lib/xcp" "local.db"
 
-(* if a slave in emergency "cannot see master mode" then this flag is set *)
-let slave_emergency_mode = ref false
+(* if a supporter is in emergency "cannot see coordinator mode" then this flag
+   is set *)
+let supporter_emergency_mode = ref false
 
 (** Whenever in emergency mode we stash an error here so the user can determine what's wrong
     without trawling through logfiles *)
@@ -302,9 +303,9 @@ let max_sessions_per_user_name = 500
 (* Place where database XML backups are kept *)
 let backup_db_xml = Filename.concat "/var/lib/xcp" "state-backup.xml"
 
-(* Directory containing scripts which are executed when a node becomes master
-   and when a node gives up the master role *)
-let master_scripts_dir = ref (Filename.concat "/etc/xensource" "master.d")
+(* Directory containing scripts which are executed when a node becomes coordinator
+   and when a node gives up the coordinator role *)
+let coordinator_scripts_dir = ref (Filename.concat "/etc/xensource" "master.d")
 
 (* Indicates whether we should allow clones of suspended VMs via VM.clone *)
 let pool_allow_clone_suspended_vm = "allow_clone_suspended_vm"
@@ -335,7 +336,7 @@ let sync_switch_off = "nosync"
 
 (* Set the following keys to this value to disable the dbsync operation *)
 
-(* dbsync_slave *)
+(* dbsync_supporter *)
 let sync_local_vdi_activations = "sync_local_vdi_activations"
 
 let sync_create_localhost = "sync_create_localhost"
@@ -375,7 +376,7 @@ let disable_dbsync_for = ref []
 (* create_storage *)
 let sync_create_pbds = "sync_create_pbds"
 
-(* sync VLANs on slave with master *)
+(* sync VLANs on supporter host with coordinator *)
 let sync_vlans = "sync_vlans"
 
 (* Set on the Pool.other_config to signal that the pool is currently in a mixed-mode
@@ -1576,7 +1577,7 @@ module Resources = struct
   let nonessential_dirs =
     [
       ( "master-scripts-dir"
-      , master_scripts_dir
+      , coordinator_scripts_dir
       , "Scripts to execute when transitioning pool role"
       )
     ; ("packs-dir", packs_dir, "Directory containing supplemental pack data")

--- a/ocaml/xapi/xapi_ha.mli
+++ b/ocaml/xapi/xapi_ha.mli
@@ -37,16 +37,17 @@ val on_server_restart : unit -> unit
 (** Called when xapi restarts: server may be in emergency mode at this point.
     We need to inspect the local configuration and if HA is supposed to be armed
     we need to set everything up.
-    Note that the master shouldn't be able to activate HA while we are offline
-    since that would cause us to come up with a broken configuration (the
-    enable-HA stage has the critical task of synchronising the HA configuration
-    on all the hosts). So really we only want to notice if the Pool has had
-    HA disabled while we were offline. *)
+    Note that the coordinator shouldn't be able to activate HA while we are
+    offline since that would cause us to come up with a broken configuration
+    (the enable-HA stage has the critical task of synchronising the HA
+    configuration on all the hosts). So really we only want to notice if the
+    Pool has had HA disabled while we were offline. *)
 
 val on_database_engine_ready : unit -> unit
-(** Called in the master xapi startup when the database is ready. We set all
-    hosts (including this one) to disabled, then signal the monitor thread to look.
-    It can then wait for slaves to turn up before trying to restart VMs. *)
+(** Called in the coordinator xapi startup when the database is ready. We set
+    all hosts (including this one) to disabled, then signal the monitor thread
+    to look. It can then wait for supporters to turn up before trying to
+    restart VMs. *)
 
 (******************************************************************************)
 (** {2 Internal API calls to configure individual hosts} *)
@@ -90,13 +91,14 @@ val preconfigure_host :
 
 val join_liveset : 'a -> 'b Ref.t -> unit
 
-val propose_new_master : __context:'a -> address:string -> manual:'b -> unit
-(** First phase of a two-phase commit of a new master *)
+val propose_new_coordinator :
+  __context:'a -> address:string -> manual:'b -> unit
+(** First phase of a two-phase commit of a new coordinator *)
 
-val commit_new_master : __context:Context.t -> address:string -> unit
-(** Second phase of a two-phase commit of a new master *)
+val commit_new_coordinator : __context:Context.t -> address:string -> unit
+(** Second phase of a two-phase commit of a new coordinator *)
 
-val abort_new_master : __context:'a -> address:string -> unit
+val abort_new_coordinator : __context:'a -> address:string -> unit
 
 (******************************************************************************)
 (** {2 External API calls} *)

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -35,12 +35,12 @@ let inet_rpc xml =
      is disabled. *)
   let open Xmlrpc_client in
   let transport =
-    if Pool_role.is_master () then
+    if Pool_role.is_coordinator () then
       TCP ("127.0.0.1", http)
     else
       SSL
         ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
-        , Pool_role.get_master_address ()
+        , Pool_role.get_address_of_coordinator_exn ()
         , https
         )
   in
@@ -74,7 +74,7 @@ let append_to_master_audit_log __context action line =
   if
     Astring.String.is_prefix ~affix:Datamodel.rbac_http_permission_prefix action
   then
-    if Pool_role.is_slave () then
+    if Pool_role.is_supporter () then
       Helpers.call_api_functions ~__context (fun rpc session_id ->
           Client.Pool.audit_log_append ~rpc ~session_id ~line
       )

--- a/ocaml/xapi/xapi_local_session.ml
+++ b/ocaml/xapi/xapi_local_session.ml
@@ -11,8 +11,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-(** Code to handle local sessions, used so that slaves can communicate even when
-    the master is down. *)
+(** Code to handle local sessions, used so that supporters can communicate
+    even when the coordinator is down. *)
 
 type t = {
     r: API.ref_session

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -421,9 +421,10 @@ let create ~__context ~name ~priority ~cls ~obj_uuid ~body =
   let _ref = Ref.make () in
   let uuid = Uuid.to_string (Uuid.make ()) in
   let timestamp = Mutex.execute event_mutex (fun () -> Unix.gettimeofday ()) in
-  (* During rolling upgrade, upgraded master might have a alerts grading
-     	   system different from the not yet upgraded slaves, during that process we
-     	   transform the priority of received messages as a special case. *)
+  (* During rolling upgrade, upgraded coordinator might have a alerts grading
+     system different from the not yet upgraded supporters, during that
+     process we transform the priority of received messages as a special case.
+  *)
   let priority =
     if
       Helpers.rolling_upgrade_in_progress ~__context
@@ -778,11 +779,11 @@ let handler (req : Http.Request.t) fd _ =
     (fun __context ->
       try
         (* Redirect if we're not master *)
-        if not (Pool_role.is_master ()) then
+        if not (Pool_role.is_coordinator ()) then
           let url =
             Printf.sprintf "https://%s%s?%s"
               (Http.Url.maybe_wrap_IPv6_literal
-                 (Pool_role.get_master_address ())
+                 (Pool_role.get_address_of_coordinator_exn ())
               )
               req.Http.Request.uri
               (String.concat "&" (List.map (fun (a, b) -> a ^ "=" ^ b) query))

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -243,7 +243,7 @@ let assert_not_management_pif ~__context ~self =
 let assert_not_slave_management_pif ~__context ~self =
   if
     true
-    && Pool_role.is_slave ()
+    && Pool_role.is_supporter ()
     && Db.PIF.get_currently_attached ~__context ~self
     && Db.PIF.get_management ~__context ~self
   then

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -205,28 +205,21 @@ let assert_no_pool_ops ~__context =
       in
       raise Api_errors.(Server_error (internal_error, [err]))
 
-let get_master_slaves_list_with_fn ~__context fn =
-  let _unsorted_hosts = Db.Host.get_all ~__context in
-  let master = Helpers.get_master ~__context in
-  let slaves = List.filter (fun h -> h <> master) _unsorted_hosts in
-  (* anything not a master *)
-  debug "MASTER=%s, SLAVES=%s"
-    (Db.Host.get_name_label ~__context ~self:master)
-    (List.fold_left
-       (fun str h -> str ^ "," ^ Db.Host.get_name_label ~__context ~self:h)
-       "" slaves
-    ) ;
-  fn master slaves
+let get_members ~__context =
+  let all_hosts = Db.Host.get_all ~__context in
+  let coordinator = Helpers.get_coordinator ~__context in
+  let supporters = List.filter (fun h -> h <> coordinator) all_hosts in
+  let pp_host self = Db.Host.get_name_label ~__context ~self in
+  debug "COORDINATOR=%s, SUPPORTERS=%s" (pp_host coordinator)
+    (String.concat "; " (List.map pp_host supporters)) ;
+  (coordinator, supporters)
 
-(* returns the list of hosts in the pool, with the master being the first element of the list *)
-let get_master_slaves_list ~__context =
-  get_master_slaves_list_with_fn ~__context (fun master slaves ->
-      master :: slaves
-  )
+let get_members_coordinator_first ~__context =
+  let coordinator, supporters = get_members ~__context in
+  coordinator :: supporters
 
-(* returns the list of slaves in the pool *)
-let get_slaves_list ~__context =
-  get_master_slaves_list_with_fn ~__context (fun _ slaves -> slaves)
+let get_members_coordinator_last ~__context =
+  List.rev (get_members_coordinator_first ~__context)
 
 let call_fn_on_hosts ~__context hosts f =
   Helpers.call_api_functions ~__context (fun rpc session_id ->
@@ -247,17 +240,15 @@ let call_fn_on_hosts ~__context hosts f =
       match errs with [] -> () | (_, first_exn) :: _ -> raise first_exn
   )
 
-let call_fn_on_master_then_slaves ~__context f =
-  let hosts = get_master_slaves_list ~__context in
+let call_fn_on_members_coordinator_first ~__context f =
+  let hosts = get_members_coordinator_first ~__context in
   call_fn_on_hosts ~__context hosts f
 
-(* Note: fn exposed in .mli *)
-
-(** Call the function on the slaves first. When those calls have all
- *  returned, call the function on the master. *)
-let call_fn_on_slaves_then_master ~__context f =
-  (* Get list with master as LAST element: important for ssl_legacy calls *)
-  let hosts = List.rev (get_master_slaves_list ~__context) in
+(** Call the function on the secondary hosts first. When those calls have all
+    returned, call the function on the coordinator. *)
+let call_fn_on_members_coordinator_last ~__context f =
+  (* Get coordinator as LAST element: important for ssl_legacy calls *)
+  let hosts = get_members_coordinator_last ~__context in
   call_fn_on_hosts ~__context hosts f
 
 let apply_guest_agent_config ~__context =
@@ -268,4 +259,4 @@ let apply_guest_agent_config ~__context =
         (Db.Host.get_uuid ~__context ~self:host)
         (Printexc.to_string e)
   in
-  call_fn_on_slaves_then_master ~__context f
+  call_fn_on_members_coordinator_last ~__context f

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -32,7 +32,7 @@ val ha_enable_in_progress : __context:Context.t -> bool
    that no pool operations are running. *)
 val assert_no_pool_ops : __context:Context.t -> unit
 
-val call_fn_on_master_then_slaves :
+val call_fn_on_members_coordinator_first :
      __context:Context.t
   -> (   rpc:(Rpc.call -> Rpc.response)
       -> session_id:API.ref_session
@@ -40,10 +40,11 @@ val call_fn_on_master_then_slaves :
       -> unit
      )
   -> unit
-(** Call the function on the master, then on each of the slaves in turn. Useful
-    when attaching an SR to all hosts in the pool. *)
+(** [call_fn_on_members_coordinator_first] Executes a [Client.Client.Host] operation
+    on all members in the pool. The operation is done first on the coordinator.
+    Useful when attaching an SR to all hosts in the pool. *)
 
-val call_fn_on_slaves_then_master :
+val call_fn_on_members_coordinator_last :
      __context:Context.t
   -> (   rpc:(Rpc.call -> Rpc.response)
       -> session_id:API.ref_session
@@ -51,14 +52,18 @@ val call_fn_on_slaves_then_master :
       -> unit
      )
   -> unit
-(** Call the function on the slaves first. When those calls have all
- *  returned, call the function on the master. *)
+(** [call_fn_on_members_coordinator_first] Executes a [Client.Client.Host] operation
+    on all members in the pool. The operation is done last on the coordinator. *)
 
-val get_master_slaves_list_with_fn :
-  __context:Context.t -> ([`host] Ref.t -> [`host] Ref.t list -> unit) -> unit
+val get_members : __context:Context.t -> [`host] Ref.t * [`host] Ref.t list
+(** [get_members] returns the coordinator and the list of supporters. *)
 
-val get_master_slaves_list : __context:Context.t -> [`host] Ref.t list
+val get_members_coordinator_first : __context:Context.t -> [`host] Ref.t list
+(** [get_members_coordinator_first] returns a list of pool members, with the
+    head of the list being the coordinator. *)
 
-val get_slaves_list : __context:Context.t -> [`host] Ref.t list
+val get_members_coordinator_last : __context:Context.t -> [`host] Ref.t list
+(** [get_members_coordinator_last] returns a list of pool members, with the
+    last element being the coordinator. *)
 
 val apply_guest_agent_config : __context:Context.t -> unit

--- a/ocaml/xapi/xapi_pool_transition.ml
+++ b/ocaml/xapi/xapi_pool_transition.ml
@@ -29,31 +29,31 @@ let set_role r =
   with_pool_role_lock (fun () ->
       Unixext.write_string_to_file !Constants.pool_config_file (string_of r)
   ) ;
-  Localdb.put Constants.this_node_just_became_master
-    (string_of_bool (old_role <> Master && r = Master))
+  Localdb.put Constants.this_node_just_became_coordinator
+    (string_of_bool (old_role <> Coordinator && r = Coordinator))
 
-(** Execute scripts in the "master-scripts" dir when changing role from master
-    to slave or back again. Remember whether the scripts have been run using
-    state in the local database. *)
-let run_external_scripts becoming_master =
+(** Execute scripts in the "master-scripts" dir when changing role from coordinator
+    to supporter or back again. Remember whether the scripts have been run
+    using state in the local database. *)
+let run_external_scripts becoming_coordinator =
   let call_scripts () =
-    let arg = if becoming_master then "start" else "stop" in
+    let arg = if becoming_coordinator then "start" else "stop" in
     debug "Calling scripts in %s with argument %s"
-      !Xapi_globs.master_scripts_dir
+      !Xapi_globs.coordinator_scripts_dir
       arg ;
     let all =
-      try Array.to_list (Sys.readdir !Xapi_globs.master_scripts_dir)
+      try Array.to_list (Sys.readdir !Xapi_globs.coordinator_scripts_dir)
       with _ -> []
     in
     let order =
       List.sort
-        (fun a b -> if becoming_master then compare a b else -compare a b)
+        (fun a b -> if becoming_coordinator then compare a b else -compare a b)
         all
     in
     List.iter
       (fun filename ->
         try
-          let filename = !Xapi_globs.master_scripts_dir ^ "/" ^ filename in
+          let filename = !Xapi_globs.coordinator_scripts_dir ^ "/" ^ filename in
           debug "Executing %s %s" filename arg ;
           ignore (Forkhelpers.execute_command_get_output filename [arg])
         with Forkhelpers.Spawn_internal_error (_, _, Unix.WEXITED n) ->
@@ -62,36 +62,38 @@ let run_external_scripts becoming_master =
       order
   in
   let already_run =
-    try bool_of_string (Localdb.get Constants.master_scripts) with _ -> false
+    try bool_of_string (Localdb.get Constants.coordinator_scripts)
+    with _ -> false
   in
   (* Only do anything if we're switching mode *)
-  if already_run <> becoming_master then (
+  if already_run <> becoming_coordinator then (
     call_scripts () ;
-    Localdb.put Constants.master_scripts (string_of_bool becoming_master)
+    Localdb.put Constants.coordinator_scripts
+      (string_of_bool becoming_coordinator)
   )
 
-(** Switch into master mode using the backup database *)
-let become_master () =
-  set_role Pool_role.Master ;
-  (* picked up as master on next boot *)
-  (* Since we're becoming the master (and in the HA case the old master is dead) we
-     save ourselves some trouble by saving the stats locally. *)
+(** Switch into coordinator mode using the backup database *)
+let become_coordinator () =
+  set_role Pool_role.Coordinator ;
+  (* Picked up as coordinator on next boot. Since we're becoming the coordinator (and
+     in the HA case the old coordinator is dead) we save ourselves some trouble by
+     saving the stats locally. *)
   Xapi_fuse.light_fuse_and_run ()
 
-(** Ask all the hosts to commit to the new master in a two-phase commit.
+(** Ask all the hosts to commit to the new coordinator in a two-phase commit.
     Code will be used both by the HA layer and by the Pool.designate_new_master
     call; must be careful not to rely on the database layer and to use only
-    slave_local logins.
-    This code runs on the new master. *)
-let attempt_two_phase_commit_of_new_master ~__context (manual : bool)
+    supporter_local logins.
+    This code runs on the new coordinator. *)
+let attempt_two_phase_commit_of_new_coordinator ~__context (manual : bool)
     (peer_addresses : string list) (my_address : string) =
   debug
-    "attempting %s two-phase commit of new master. My address = %s; peer \
+    "attempting %s two-phase commit of new coordinator. My address = %s; peer \
      addresses = [ %s ]"
     (if manual then "manual" else "automatic")
     my_address
     (String.concat "; " peer_addresses) ;
-  (* Always send the calls to old master first and myself last *)
+  (* Always send the calls to old coordinator first and myself last *)
   let all_addresses = peer_addresses @ [my_address] in
   let done_so_far = ref [] in
   let abort () =
@@ -111,11 +113,12 @@ let attempt_two_phase_commit_of_new_master ~__context (manual : bool)
       )
       !done_so_far
   in
-  debug "Phase 1: proposing myself as new master" ;
+  debug "Phase 1: proposing myself as new coordinator" ;
   ( try
       List.iter
         (fun address ->
-          debug "Proposing myself as a new master to host address: %s" address ;
+          debug "Proposing myself as the new coordinator to host address: %s"
+            address ;
           Helpers.call_emergency_mode_functions address (fun rpc session_id ->
               Client.Host.propose_new_master ~rpc ~session_id
                 ~address:my_address ~manual
@@ -130,7 +133,7 @@ let attempt_two_phase_commit_of_new_master ~__context (manual : bool)
   ) ;
   (* Uncomment this to check that timeout of phase 1 request works *)
   (* abort (); raise (Api_errors.Server_error (Api_errors.ha_abort_new_master, [ "debug" ])); *)
-  let am_master_already = Pool_role.get_role () = Pool_role.Master in
+  let am_coordinator_already = Pool_role.is_coordinator () in
   debug
     "No-one objected to the proposal. Any errors from here on will result in \
      this node entering the 'broken' state" ;
@@ -145,26 +148,26 @@ let attempt_two_phase_commit_of_new_master ~__context (manual : bool)
           Client.Host.commit_new_master ~rpc ~session_id ~address:my_address
       )
     with e ->
-      debug "Caught exception %s while telling host to commit new master"
+      debug "Caught exception %s while telling host to commit new coordinator"
         (ExnHelper.string_of_exn e) ;
       hosts_which_failed := address :: !hosts_which_failed
   in
   debug "Phase 2.1: telling everyone but me to commit" ;
   List.iter tell_host_to_commit peer_addresses ;
-  if !hosts_which_failed = [] then set_role Pool_role.Master ;
+  if !hosts_which_failed = [] then set_role Pool_role.Coordinator ;
 
-  (* picked up as master on next boot *)
+  (* picked up as coordinator on next boot *)
 
-  (* If in manual mode then there is an existing master: we must wait for our connection
-     to this master to disappear before restarting, otherwise we might come up, detect
-     the other master and become broken. *)
+  (* If in manual mode then there is an existing coordinator: we must wait for our
+     connection to this coordinator to disappear before restarting, otherwise we
+     might come up, detect the other coordinator and become broken. *)
   if manual then (
     (* Make sure we quickly exit on error *)
     debug
       "Phase 2.2: setting flag to make us restart when the connection to the \
-       master dies" ;
-    Master_connection.restart_on_connection_timeout := true ;
-    Master_connection.connection_timeout := 0.
+       coordinator dies" ;
+    Coordinator_connection.restart_on_connection_timeout := true ;
+    Coordinator_connection.connection_timeout := 0.
   ) ;
   if !hosts_which_failed <> [] then (
     error
@@ -176,17 +179,19 @@ let attempt_two_phase_commit_of_new_master ~__context (manual : bool)
       (Db_connections.preferred_write_db ())
       Xapi_globs.restart_return_code
   ) ;
-  (* If this is an automatic transition then there is no other master to clash with and so
-     we can restart immediately. NB if we are the master (and this code is being used to assert
-     our authoritah on some slaves then we shouldn't restart otherwise we'll get into a restart loop. *)
+  (* If this is an automatic transition then there is no other coordinator to clash
+     with and so we can restart immediately. NB if we are the coordinator (and this
+     code is being used to assert our authoritah on some supporters then we
+     shouldn't restart otherwise we'll get into a restart loop. *)
   if not manual then
-    if am_master_already then
-      info "Not restarting since we are the master already"
+    if am_coordinator_already then
+      info "Not restarting since we are the coordinator already"
     else
       Db_cache_impl.flush_and_exit
         (Db_connections.preferred_write_db ())
         Xapi_globs.restart_return_code ;
-  (* If manual, periodicly access to the database to check whether the old master has restarted. *)
+  (* If manual, periodicly access to the database to check whether the old
+     coordinator has restarted. *)
   if manual then
     let (_ : Thread.t) =
       Thread.create
@@ -197,41 +202,46 @@ let attempt_two_phase_commit_of_new_master ~__context (manual : bool)
               let (_ : API.ref_pool list) = Db.Pool.get_all ~__context in
               let n = 3. in
               debug
-                "The old master has not restarted yet. Sleep for %.0f seconds" n ;
+                "The old coordinator has not restarted yet. Sleep for %.0f \
+                 seconds"
+                n ;
               Thread.delay n
             done
           with _ ->
             debug
-              "The old master has restarted as slave; I am the only master now."
+              "The old coordinator has restarted as supporter; I am the only \
+               coordinator now."
         )
         ()
     in
     ()
 
-(** Point ourselves at another master *)
-let become_another_masters_slave master_address =
-  let new_role = Pool_role.Slave master_address in
+(** Point ourselves at a coordinator *)
+let become_supporter_to coordinator_address =
+  let new_role = Pool_role.Supporter coordinator_address in
   if Pool_role.get_role () = new_role then
-    debug "We are already a slave of %s; nothing to do" master_address
+    debug "We are already a supporter to %s; nothing to do" coordinator_address
   else (
-    debug "Setting pool.conf to point to %s" master_address ;
+    debug "Setting pool.conf to point to %s" coordinator_address ;
     set_role new_role ;
     run_external_scripts false ;
     Repository.cleanup_all_pool_repositories () ;
-    (* For simplicity, it's safe to cleanup on all slaves *)
+    (* For simplicity, it's safe to cleanup on all supporters *)
     Xapi_fuse.light_fuse_and_run ()
   )
 
-(** If we just transitioned slave -> master (as indicated by the localdb flag) then generate a single alert *)
+(** If we just transitioned from supporter to coordinator (as indicated by the
+    localdb flag) then generate a single alert *)
 let consider_sending_alert __context () =
   if
-    try bool_of_string (Localdb.get Constants.this_node_just_became_master)
+    try bool_of_string (Localdb.get Constants.this_node_just_became_coordinator)
     with _ -> false
   then
     let obj_uuid = Helpers.get_localhost_uuid () in
-    let name, priority = Api_messages.pool_master_transition in
+    let name, priority = Api_messages.pool_coordinator_transition in
     let (_ : 'a Ref.t) =
       Xapi_message.create ~__context ~name ~priority ~cls:`Host ~obj_uuid
         ~body:""
     in
-    Localdb.put Constants.this_node_just_became_master (string_of_bool false)
+    Localdb.put Constants.this_node_just_became_coordinator
+      (string_of_bool false)

--- a/ocaml/xapi/xapi_psr.ml
+++ b/ocaml/xapi/xapi_psr.ml
@@ -13,8 +13,8 @@
  *)
 
 (** important invariants:
-  * given a list of hosts containing both the master and
-    the members, the master will always be at the head *)
+  * given a list of hosts containing both the coordinator and
+    supporters, the coordinator will always be at the head *)
 
 module D = Debug.Make (struct let name = "xapi_psr" end)
 
@@ -68,7 +68,7 @@ module type Impl = sig
 
   val tell_cleanup_old_pool_secret : pool_secrets -> host -> unit
 
-  val cleanup_master : pool_secrets -> unit
+  val cleanup_coordinator : pool_secrets -> unit
 end
 
 module Make =
@@ -107,15 +107,16 @@ functor
       | x :: xs ->
           f x >>= fun _ -> (iter_break [@tailcall]) f xs
 
-    let rec go pool_secrets master members = function
+    let rec go pool_secrets coordinator supporters = function
       | No_checkpoint ->
           (* if we fail to backup the pool secrets, it doesn't really matter,
              you can simply restart the rotation *)
           Impl.backup pool_secrets ;
-          (go [@tailcall]) pool_secrets master members Accept_new_pool_secret
+          (go [@tailcall]) pool_secrets coordinator supporters
+            Accept_new_pool_secret
       | Accept_new_pool_secret ->
           Impl.save_checkpoint (string_of_checkpoint Accept_new_pool_secret) ;
-          master :: members
+          coordinator :: supporters
           |> iter_break (fun host ->
                  try
                    Impl.tell_accept_new_pool_secret pool_secrets host ;
@@ -128,10 +129,11 @@ functor
                    Error (Failed_during_accept_new_pool_secret, host)
              )
           >>= fun () ->
-          (go [@tailcall]) pool_secrets master members Send_new_pool_secret
+          (go [@tailcall]) pool_secrets coordinator supporters
+            Send_new_pool_secret
       | Send_new_pool_secret ->
           Impl.save_checkpoint (string_of_checkpoint Send_new_pool_secret) ;
-          master :: members
+          coordinator :: supporters
           |> iter_break (fun host ->
                  try
                    Impl.tell_send_new_pool_secret pool_secrets host ;
@@ -144,10 +146,10 @@ functor
                    Error (Failed_during_send_new_pool_secret, host)
              )
           >>= fun () ->
-          (go [@tailcall]) pool_secrets master members Cleanup_members
+          (go [@tailcall]) pool_secrets coordinator supporters Cleanup_members
       | Cleanup_members ->
           Impl.save_checkpoint (string_of_checkpoint Cleanup_members) ;
-          members
+          supporters
           |> iter_break (fun member ->
                  try
                    Impl.tell_cleanup_old_pool_secret pool_secrets member ;
@@ -158,27 +160,27 @@ functor
                    Error (Failed_during_cleanup, member)
              )
           >>= fun () ->
-          (go [@tailcall]) pool_secrets master members Cleanup_master
+          (go [@tailcall]) pool_secrets coordinator supporters Cleanup_master
       | Cleanup_master -> (
           Impl.save_checkpoint (string_of_checkpoint Cleanup_master) ;
           try
-            Impl.cleanup_master pool_secrets ;
+            Impl.cleanup_coordinator pool_secrets ;
             Ok ()
           with e ->
-            D.error "failed to cleanup the master. error= %s"
+            D.error "failed to cleanup the coordinator. error= %s"
               (Printexc.to_string e) ;
-            Error (Failed_during_cleanup, master)
+            Error (Failed_during_cleanup, coordinator)
         )
 
-    let start pool_secrets ~master ~members =
+    let start pool_secrets ~coordinator ~supporters =
       try
         match
           Impl.retrieve_checkpoint () |> Option.map checkpoint_of_string
         with
         | None | Some No_checkpoint ->
-            go pool_secrets master members No_checkpoint
+            go pool_secrets coordinator supporters No_checkpoint
         | Some checkpoint ->
-            go (Impl.retrieve ()) master members checkpoint
+            go (Impl.retrieve ()) coordinator supporters checkpoint
       with e ->
         (* _in theory_ save_checkpoint or backup could fail, so
            catch that here. however we don't expect this to happen *)
@@ -192,15 +194,15 @@ functor
 let perm = 0o640
 
 (* we include some sanity checks for the following invariants:
-     - only the master should have a checkpoint
-     - either (a) all the master psr state exists (=> resuming a failed psr)
+     - only the coordinator should have a checkpoint
+     - either (a) all the coordinator psr state exists (=> resuming a failed psr)
        or     (b) none of the state exists (=> starting a new psr)
      - existing pool secret backups are consistent with requested pool secret
        changes
      - the runtime state, i.e. Xapi_globs.pool_secrets (although this check
        is not done here, but at each stage separately)
-   these invariants could be broken if for example a psr fails, the master
-   changes, and then a new psr starts on the new master
+   these invariants could be broken if for example a psr fails, the coordinator
+   changes, and then a new psr starts on the new coordinator
 *)
 module Assert : sig
   val backups_match : old_ps:SecretString.t -> new_ps:SecretString.t -> unit
@@ -209,7 +211,7 @@ module Assert : sig
 
   val no_checkpoint : unit -> unit
 
-  val master_state_valid : unit -> unit
+  val coordinator_state_valid : unit -> unit
 end = struct
   let do_backups_exist () =
     let does_old_backup_exist = Sys.file_exists old_pool_secret_backup_path in
@@ -245,15 +247,14 @@ end = struct
         )
 
   let no_checkpoint () =
-    (* we expect a checkpoint on the master, but not slaves *)
-    if Pool_role.is_slave () && does_checkpoint_exist () then
+    (* we expect a checkpoint on the coordinator, but not supporters *)
+    if Pool_role.is_supporter () && does_checkpoint_exist () then
       raise
         Api_errors.(
-          Server_error
-            (internal_error, ["pool member should not have a checkpoint"])
+          Server_error (internal_error, ["supporter must not have a checkpoint"])
         )
 
-  let master_state_valid () =
+  let coordinator_state_valid () =
     match (do_backups_exist (), does_checkpoint_exist ()) with
     | false, false | true, true ->
         ()
@@ -261,7 +262,9 @@ end = struct
         raise
           Api_errors.(
             Server_error
-              (internal_error, ["master pool secret rotation state is invalid"])
+              ( internal_error
+              , ["coordinator pool secret rotation state is invalid"]
+              )
           )
 end
 
@@ -269,7 +272,7 @@ let cleanup_internal ~additional_files_to_remove ~old_ps ~new_ps =
   match !Xapi_globs.pool_secrets with
   | [ps] when ps = new_ps ->
       Assert.no_backups () ;
-      D.info "xapi_psr.ml:cleanup_internal: already cleaned up"
+      D.info "%s: already cleaned up" __FUNCTION__
   | [_] ->
       raise
         Api_errors.(
@@ -384,7 +387,7 @@ functor
           Client.Host.cleanup_pool_secret ~rpc ~session_id ~host ~old_ps ~new_ps
       )
 
-    let cleanup_master (old_ps, new_ps) =
+    let cleanup_coordinator (old_ps, new_ps) =
       Xapi_fist.hang_psr `cleanup ;
       cleanup_internal ~additional_files_to_remove:[checkpoint_path] ~old_ps
         ~new_ps
@@ -410,7 +413,7 @@ let notify_new ~__context ~old_ps ~new_ps =
               )
           )
   | [priority_1_ps] when SecretString.equal priority_1_ps old_ps ->
-      if Pool_role.is_slave () then Assert.no_backups () ;
+      if Pool_role.is_supporter () then Assert.no_backups () ;
       SecretString.write_to_file old_pool_secret_backup_path old_ps ;
       SecretString.write_to_file new_pool_secret_backup_path new_ps ;
       Xapi_globs.pool_secrets := [old_ps; new_ps]
@@ -527,22 +530,23 @@ let start =
       if is_ha_enabled then
         raise Api_errors.(Server_error (ha_is_enabled, []))
     in
-    let assert_we_are_master () =
+    let assert_we_are_coordinator () =
       if
         not
-          (Helpers.is_pool_master ~__context
+          (Helpers.is_coordinator ~__context
              ~host:(Helpers.get_localhost ~__context)
           )
       then
         raise
           Api_errors.(
-            Server_error (host_is_slave, [Pool_role.get_master_address ()])
+            Server_error
+              (host_is_supporter, [Pool_role.get_address_of_coordinator_exn ()])
           )
     in
     let assert_all_hosts_alive () =
       let live_hosts = Helpers.get_live_hosts ~__context |> HostSet.of_list in
       let all_hosts_list =
-        Xapi_pool_helpers.get_master_slaves_list ~__context
+        Xapi_pool_helpers.get_members_coordinator_first ~__context
       in
       let all_hosts = all_hosts_list |> HostSet.of_list in
       let offline_hosts = HostSet.diff all_hosts live_hosts in
@@ -560,26 +564,26 @@ let start =
         raise Api_errors.(Server_error (not_supported_during_upgrade, []))
     in
     with_lock (fun () ->
-        let master, members =
+        let coordinator, supporters =
           set_up_psr_pending_flag (fun () ->
               Pool_features.assert_enabled ~__context
                 ~f:Features.Pool_secret_rotation ;
-              assert_we_are_master () ;
-              Assert.master_state_valid () ;
-              let[@warning "-8"] (master :: members) =
+              assert_we_are_coordinator () ;
+              Assert.coordinator_state_valid () ;
+              let[@warning "-8"] (coordinator :: supporters) =
                 assert_all_hosts_alive ()
               in
               assert_no_ha () ;
               assert_no_rpu () ;
               Xapi_pool_helpers.assert_no_pool_ops ~__context ;
-              (master, members)
+              (coordinator, supporters)
           )
         in
         let module PSR = Make (Impl (struct let __context = __context end)) in
         let r =
           PSR.start
             (Xapi_globs.pool_secret (), Helpers.PoolSecret.make ())
-            ~master ~members
+            ~coordinator ~supporters
         in
         match r with
         | Ok () ->

--- a/ocaml/xapi/xapi_psr.mli
+++ b/ocaml/xapi/xapi_psr.mli
@@ -70,8 +70,8 @@ module type Impl = sig
 
   val tell_cleanup_old_pool_secret : pool_secrets -> host -> unit
 
-  (* cleanup master _after_ the members *)
-  val cleanup_master : pool_secrets -> unit
+  (* cleanup coordinator _after_ the supporters *)
+  val cleanup_coordinator : pool_secrets -> unit
 end
 
 module Make : functor (Impl : Impl) -> sig
@@ -79,5 +79,5 @@ module Make : functor (Impl : Impl) -> sig
 
   (* we model a pool as a list of hosts.
      we accept pool_secrets as a parameter to avoid non-determinism *)
-  val start : pool_secrets -> master:host -> members:host list -> host r
+  val start : pool_secrets -> coordinator:host -> supporters:host list -> host r
 end

--- a/ocaml/xapi/xapi_session.mli
+++ b/ocaml/xapi/xapi_session.mli
@@ -15,8 +15,6 @@
  * @group XenAPI functions
 *)
 
-(** {2 (Fill in Title!)} *)
-
 (* TODO: consider updating sm_exec.ml and removing login_no_password from this mli *)
 val login_no_password :
      __context:Context.t

--- a/ocaml/xapi/xapi_stunnel_server.ml
+++ b/ocaml/xapi/xapi_stunnel_server.ml
@@ -205,7 +205,7 @@ let sync ~__context ipv6_enabled =
     let client_auth_name =
       let pool = Helpers.get_pool ~__context in
       if
-        Pool_role.is_master ()
+        Pool_role.is_coordinator ()
         && Db.Pool.get_client_certificate_auth_enabled ~__context ~self:pool
       then
         Some (Db.Pool.get_client_certificate_auth_name ~__context ~self:pool)

--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -58,9 +58,9 @@ let metadata_replication :
     (API.ref_VDI, API.ref_VBD * Redo_log.redo_log) Hashtbl.t =
   Hashtbl.create Xapi_globs.redo_log_max_instances
 
-let get_master_dom0 ~__context =
-  let master = Helpers.get_master ~__context in
-  Db.Host.get_control_domain ~__context ~self:master
+let get_coordinator_dom0 ~__context =
+  let coordinator = Helpers.get_coordinator ~__context in
+  Db.Host.get_control_domain ~__context ~self:coordinator
 
 (* Unplug and destroy any existing VBDs owned by the VDI. *)
 let destroy_all_vbds ~__context ~vdi =
@@ -105,7 +105,7 @@ let enable_database_replication ~__context ~get_vdi_callback =
         debug "Metadata is already being replicated to VDI %s" vdi_uuid
       else (
         debug "Attempting to enable metadata replication to VDI %s" vdi_uuid ;
-        let dom0 = get_master_dom0 ~__context in
+        let dom0 = get_coordinator_dom0 ~__context in
         (* We've established that metadata is not being replicated to this VDI, so it should be safe to do this. *)
         destroy_all_vbds ~__context ~vdi ;
         (* Create and plug vbd *)

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -864,18 +864,18 @@ let possible_hosts ~__context ?vm ~choose_fn () =
     argument is present, then this function additionally prints a debug message
     that includes the names of the given VM and the subset of all hosts that
     satisfy the given function [choose_fn]. *)
-let choose_host ~__context ?vm ~choose_fn ?(prefer_slaves = false) () =
+let choose_host ~__context ?vm ~choose_fn ?(prefer_supporters = false) () =
   let choices = possible_hosts ~__context ?vm ~choose_fn () in
   match choices with
   | [] ->
-      raise (Api_errors.Server_error (Api_errors.no_hosts_available, []))
+      raise Api_errors.(Server_error (no_hosts_available, []))
   | [h] ->
       h
   | _ ->
       let choices =
-        if prefer_slaves then
-          let master = Helpers.get_master ~__context in
-          List.filter (( <> ) master) choices
+        if prefer_supporters then
+          let coordinator = Helpers.get_coordinator ~__context in
+          List.filter (( <> ) coordinator) choices
         else
           choices
       in

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -885,8 +885,8 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
   update_allowed_operations ~__context ~self ;
   if state = `Halted then (* archive the rrd for this vm *)
     let vm_uuid = Db.VM.get_uuid ~__context ~self in
-    let master_address = Pool_role.get_master_address_opt () in
-    log_and_ignore_exn (fun () -> Rrdd.archive_rrd vm_uuid master_address)
+    let coordinator_address = Pool_role.get_address_of_coordinator () in
+    log_and_ignore_exn (fun () -> Rrdd.archive_rrd vm_uuid coordinator_address)
 
 (** Called on new VMs (clones, imports) and on server start to manually refresh
     the power state, allowed_operations field etc.  Clean current-operations

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1626,7 +1626,7 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
     if host <> Ref.null then
       host
     else
-      Helpers.get_master ~__context
+      Helpers.get_coordinator ~__context
   in
   (* Check that all VDIs are mapped. *)
   let vbds = Db.VM.get_VBDs ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm_placement.ml
+++ b/ocaml/xapi/xapi_vm_placement.ml
@@ -47,7 +47,7 @@ let create_host_snapshot __context host =
   in
   {
     HS.id= host_id
-  ; HS.is_pool_master= Helpers.is_pool_master ~__context ~host
+  ; HS.is_coordinator= Helpers.is_coordinator ~__context ~host
   ; HS.guests_resident= guest_snapshots "resident_on"
   ; HS.guests_scheduled= guest_snapshots "scheduled_to_be_resident_on"
   ; HS.memory_overhead

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -169,7 +169,7 @@ let checkpoint ~__context ~vm ~new_name =
 
 (* The following code have to run on the master as it manipulates the DB cache directly. *)
 let copy_vm_fields ~__context ~metadata ~dst ~do_not_copy ~overrides =
-  if not (Pool_role.is_master ()) then
+  if not (Pool_role.is_coordinator ()) then
     raise
       Api_errors.(
         Server_error

--- a/ocaml/xapi/xha_scripts.ml
+++ b/ocaml/xapi/xha_scripts.ml
@@ -28,7 +28,7 @@ let ha_stop_daemon = "ha_stop_daemon"
 
 let ha_query_liveset = "ha_query_liveset"
 
-let ha_propose_master = "ha_propose_master"
+let ha_propose_coordinator = "ha_propose_master"
 
 let ha_disarm_fencing = "ha_disarm_fencing"
 

--- a/ocaml/xapi/xha_statefile.ml
+++ b/ocaml/xapi/xha_statefile.ml
@@ -120,11 +120,11 @@ let create ~__context ~sr ~cluster_stack =
         ~tags:[]
   )
 
-(** Return a reference to a valid statefile VDI in the given SR.
-    This function prefers to reuse existing VDIs to avoid confusing the heartbeat component:
-    it expects to see a poisoned VDI but not necessarily a stale or corrupted one. Consider that
-    when using LVM-based SRs the VDI could be deleted on the master but the slaves would still
-    have access to stale data. *)
+(** Return a reference to a valid statefile VDI in the given SR. This function
+    prefers to reuse existing VDIs to avoid confusing the heartbeat component:
+    it expects to see a poisoned VDI but not necessarily a stale or corrupted
+    one. Consider that when using LVM-based SRs the VDI could be deleted on the
+    coordinator but the supporters would still have access to stale data. *)
 let find_or_create ~__context ~sr ~cluster_stack =
   assert_sr_can_host_statefile ~__context ~sr ~cluster_stack ;
   let size = minimum_size in


### PR DESCRIPTION
Pool hosts are now called 'members', with one of them being the master
host.

There's no consensus on what to do with the term master, but this naming
scheme allows us to stop using the term slave.

Citrix's writing guides is not very self-explanatory,it would be interesting if people would propose alternatives to "master" in any case.
 https://brand.citrix.com/application-guides/writing/unbiased-language/#section_10