### PR TITLE
CP-35348 cover alerts for internal and CA certificates

### DIFF
--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -1,7 +1,17 @@
 module XenAPI = Client.Client
 module Date = Xapi_stdext_date.Date
 
+type cert =
+  | CA of API.ref_pool * API.datetime
+  | Host of API.ref_host * API.datetime
+  | Internal of API.ref_host * API.datetime
+
 let seconds_per_day = 3600. *. 24.
+
+let internal_error fmt =
+  fmt
+  |> Printf.kprintf @@ fun msg ->
+     raise Api_errors.(Server_error (internal_error, [msg]))
 
 let days_until_expiry epoch expiry =
   let days = (expiry /. seconds_per_day) -. (epoch /. seconds_per_day) in
@@ -13,41 +23,94 @@ let days_until_expiry epoch expiry =
 
 let get_certificate_attributes rpc session =
   XenAPI.Certificate.get_all_records rpc session
-  |> List.filter_map (fun (_, certificate) ->
-         (* don't create alerts for `host_internal or `ca
-          * certificates *)
-         match certificate.API.certificate_type with
-         | `host ->
-             Some
-               ( certificate.API.certificate_host
-               , certificate.API.certificate_not_after )
-         | `ca | `host_internal ->
-             None)
+  |> List.map @@ fun (_, certificate) ->
+     match certificate.API.certificate_type with
+     | `host ->
+         Host
+           ( certificate.API.certificate_host
+           , certificate.API.certificate_not_after )
+     | `host_internal ->
+         Internal
+           ( certificate.API.certificate_host
+           , certificate.API.certificate_not_after )
+     | `ca ->
+         let pool =
+           match XenAPI.Pool.get_all rpc session with
+           | p :: _ ->
+               p
+           | [] ->
+               internal_error "can't indentify pool at %s" __LOC__
+         in
+         CA (pool, certificate.API.certificate_not_after)
 
-let generate_alert epoch (host, expiry) =
+let expired_message = function
+  | Host _ ->
+      "The TLS server certificate has expired."
+  | Internal _ ->
+      "The internal TLS server certificate has expired."
+  | CA _ ->
+      "The CA pool certificate has expired"
+
+let expiring_message = function
+  | Host _ ->
+      "The TLS server certificate is expiring soon."
+  | Internal _ ->
+      "The internal TLS server certificate is expiring soon."
+  | CA _ ->
+      "The CA pool certificate is expiring soon"
+
+let generate_alert epoch cert =
+  let expiry =
+    match cert with Host (_, exp) | Internal (_, exp) | CA (_, exp) -> exp
+  in
   let days = days_until_expiry epoch (Date.to_float expiry) in
-  if days > 30 then
-    (host, None)
-  else
-    let expiring_message = "The TLS server certificate is expiring soon." in
-    let expired_message = "The TLS server certificate has expired." in
-    let body msg =
-      Printf.sprintf "<body><message>%s</message><date>%s</date></body>" msg
-        (Date.to_string expiry)
-    in
-    let message, alert =
-      if days < 0 then
-        (body expired_message, Api_messages.host_server_certificate_expired)
-      else if days < 8 then
-        (body expiring_message, Api_messages.host_server_certificate_expiring_07)
-      else if days < 15 then
-        (body expiring_message, Api_messages.host_server_certificate_expiring_14)
-      else
-        (body expiring_message, Api_messages.host_server_certificate_expiring_30)
-    in
-    (host, Some (message, alert))
+  let expiring = expiring_message cert in
+  let expired = expired_message cert in
+  let body msg =
+    Printf.sprintf "<body><message>%s</message><date>%s</date></body>" msg
+      (Date.to_string expiry)
+  in
+  match (days, cert) with
+  | days, _ when days > 30 ->
+      (cert, None)
+  | days, Host _ when days < 0 ->
+      (cert, Some (body expired, Api_messages.host_server_certificate_expired))
+  | days, Host _ when days < 8 ->
+      ( cert
+      , Some (body expiring, Api_messages.host_server_certificate_expiring_07)
+      )
+  | days, Host _ when days < 15 ->
+      ( cert
+      , Some (body expiring, Api_messages.host_server_certificate_expiring_14)
+      )
+  | _, Host _ ->
+      ( cert
+      , Some (body expiring, Api_messages.host_server_certificate_expiring_30)
+      )
+  | days, CA _ when days < 0 ->
+      (cert, Some (body expired, Api_messages.pool_ca_certificate_expired))
+  | days, CA _ when days < 8 ->
+      (cert, Some (body expiring, Api_messages.pool_ca_certificate_expiring_07))
+  | days, CA _ when days < 15 ->
+      (cert, Some (body expiring, Api_messages.pool_ca_certificate_expiring_14))
+  | _, CA _ ->
+      (cert, Some (body expiring, Api_messages.pool_ca_certificate_expiring_30))
+  | days, Internal _ when days < 0 ->
+      (cert, Some (body expired, Api_messages.host_internal_certificate_expired))
+  | days, Internal _ when days < 8 ->
+      ( cert
+      , Some (body expiring, Api_messages.host_internal_certificate_expiring_07)
+      )
+  | days, Internal _ when days < 15 ->
+      ( cert
+      , Some (body expiring, Api_messages.host_internal_certificate_expiring_14)
+      )
+  | _, Internal _ ->
+      ( cert
+      , Some (body expiring, Api_messages.host_internal_certificate_expiring_30)
+      )
 
-let execute rpc session existing_messages (host, alert) =
+let execute rpc session existing_messages (cert, alert) =
   (* CA-342551: messages need to be deleted if the pending alert regard the
      same host and has newer, updated information.
      If the pending alert has the same metadata as the existing host message
@@ -58,10 +121,16 @@ let execute rpc session existing_messages (host, alert) =
   match alert with
   | Some (message, (alert, priority)) -> (
     try
-      let host_uuid = XenAPI.Host.get_uuid rpc session host in
+      let cls, uuid =
+        match cert with
+        | Host (host, _) | Internal (host, _) ->
+            (`Host, XenAPI.Host.get_uuid rpc session host)
+        | CA (pool, _) ->
+            (`Pool, XenAPI.Pool.get_uuid rpc session pool)
+      in
       let messages_in_host =
         List.filter
-          (fun (_, record) -> record.API.message_obj_uuid = host_uuid)
+          (fun (_, record) -> record.API.message_obj_uuid = uuid)
           existing_messages
       in
       let is_outdated (ref, record) =
@@ -76,8 +145,7 @@ let execute rpc session existing_messages (host, alert) =
         outdated ;
       if current = [] then
         let (_ : [> `message] API.Ref.t) =
-          XenAPI.Message.create rpc session alert priority `Host host_uuid
-            message
+          XenAPI.Message.create rpc session alert priority cls uuid message
         in
         ()
     with Api_errors.(Server_error (handle_invalid, _)) ->
@@ -89,16 +157,20 @@ let execute rpc session existing_messages (host, alert) =
 
 let alert rpc session =
   let now = Unix.time () in
-  (* Message starting with [host_server_certificate_\{expiring,expired\}] may
-     need to be refreshed, gather them just once *)
+  (* Message starting with
+     [\{host_server_certificate,pool_ca_certificate\}_\{expiring,expired\}]
+     may need to be refreshed, gather them just once *)
   let previous_messages =
     XenAPI.Message.get_all_records rpc session
     |> List.filter (fun (ref, record) ->
            let expiring_or_expired name =
-             let expiring = Api_messages.host_server_certificate_expiring in
-             let expired = fst Api_messages.host_server_certificate_expired in
-             let open Astring.String in
-             is_prefix ~affix:expiring name || is_prefix ~affix:expired name
+             let matching affix = Astring.String.is_prefix ~affix name in
+             matching Api_messages.host_server_certificate_expiring
+             || matching (fst Api_messages.host_server_certificate_expired)
+             || matching Api_messages.pool_ca_certificate_expiring
+             || matching (fst Api_messages.pool_ca_certificate_expired)
+             || matching Api_messages.host_internal_certificate_expiring
+             || matching (fst Api_messages.host_internal_certificate_expired)
            in
            expiring_or_expired record.API.message_name)
   in

--- a/ocaml/tests/alerts/test_alert_certificate_check.ml
+++ b/ocaml/tests/alerts/test_alert_certificate_check.ml
@@ -57,12 +57,25 @@ let format_expired datestring =
   _format (datestring, ppf, Api_messages.host_server_certificate_expired)
 
 let certificate_samples =
-  List.map format_good good_samples
-  @ List.map format_expiring expiring_samples
-  @ List.map format_expired expired_samples
+  List.concat
+    [
+      List.map format_good good_samples
+    ; List.map format_expiring expiring_samples
+    ; List.map format_expired expired_samples
+    ]
+
+let gen check_time (host, datetime) =
+  let cert = Host (Ref.null, datetime) in
+  match generate_alert check_time cert with
+  | CA _, x ->
+      ("pool", x)
+  | Host _, x ->
+      ("host", x)
+  | Internal _, x ->
+      ("internal", x)
 
 let test_alerts (server_certificates, expected) () =
-  let result = generate_alert check_time server_certificates in
+  let result = gen check_time server_certificates in
   Alcotest.(check @@ pair string @@ option @@ pair string @@ pair string int64)
     "certificate_expiry" expected result
 

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -295,17 +295,47 @@ let cluster_host_fencing = addMessage "CLUSTER_HOST_FENCING" 2L
 (* Certificate expiration messages *)
 let host_server_certificate_expiring = "HOST_SERVER_CERTIFICATE_EXPIRING"
 
-let host_server_certificate_expiring_30 =
-  addMessage (host_server_certificate_expiring ^ "_30") 3L
+let pool_ca_certificate_expiring = "POOL_CA_CERTIFICATE_EXPIRING"
 
-let host_server_certificate_expiring_14 =
-  addMessage (host_server_certificate_expiring ^ "_14") 2L
-
-let host_server_certificate_expiring_07 =
-  addMessage (host_server_certificate_expiring ^ "_07") 1L
+let host_internal_certificate_expiring = "HOST_INTERNAL_CERTIFICATE_EXPIRING"
 
 let host_server_certificate_expired =
   addMessage "HOST_SERVER_CERTIFICATE_EXPIRED" 1L
+
+let host_internal_certificate_expired =
+  addMessage "HOST_INTERNAL_CERTIFICATE_EXPIRED" 1L
+
+let pool_ca_certificate_expired = addMessage "POOL_CA_CERTIFICATE_EXPIRED" 1L
+
+let certificate_expiring base days prio =
+  addMessage (Printf.sprintf "%s_%02d" base days) prio
+
+let host_server_certificate_expiring_30 =
+  certificate_expiring host_server_certificate_expiring 30 3L
+
+let host_server_certificate_expiring_14 =
+  certificate_expiring host_server_certificate_expiring 14 2L
+
+let host_server_certificate_expiring_07 =
+  certificate_expiring host_server_certificate_expiring 7 1L
+
+let pool_ca_certificate_expiring_30 =
+  certificate_expiring pool_ca_certificate_expiring 30 3L
+
+let pool_ca_certificate_expiring_14 =
+  certificate_expiring pool_ca_certificate_expiring 14 2L
+
+let pool_ca_certificate_expiring_07 =
+  certificate_expiring pool_ca_certificate_expiring 7 1L
+
+let host_internal_certificate_expiring_30 =
+  certificate_expiring host_internal_certificate_expiring 30 3L
+
+let host_internal_certificate_expiring_14 =
+  certificate_expiring host_internal_certificate_expiring 14 2L
+
+let host_internal_certificate_expiring_07 =
+  certificate_expiring host_internal_certificate_expiring 7 1L
 
 let failed_login_attempts = addMessage "FAILED_LOGIN_ATTEMPTS" 3L
 


### PR DESCRIPTION
Extend the alert mechansim for pool-internal and CA certificates.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>