### PR TITLE
CP-35523: Block access to the website on port 80

### DIFF
--- a/ocaml/xapi/fileserver.ml
+++ b/ocaml/xapi/fileserver.ml
@@ -85,27 +85,35 @@ let send_file (uri_base : string) (dir : string) (req : Request.t)
   let uri_base_len = String.length uri_base in
   let s = Buf_io.fd_of bio in
   Buf_io.assert_buffer_empty bio ;
-  let uri = req.Request.uri in
-  try
-    let relative_url =
-      String.sub uri uri_base_len (String.length uri - uri_base_len)
-    in
-    (* file_path is the thing which should be served *)
-    let file_path = dir ^ "/" ^ relative_url in
-    (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
-    let file_path = Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot file_path in
-    if not (String.startswith dir file_path) then (
-      debug "Rejecting request for file: %s (outside of directory %s)" file_path
-        dir ;
+  match Context._client_of_rq req with
+  | None when !Xapi_globs.website_https_only ->
+      (* Reject non-TLS requests *)
       Http_svr.response_forbidden ~req s
-    ) else
-      let stat = Unix.stat file_path in
-      (* if a directory, automatically add index.html *)
-      let file_path =
-        if stat.Unix.st_kind = Unix.S_DIR then
-          file_path ^ "/index.html"
-        else
-          file_path
-      in
-      response_file s file_path
-  with _ -> Http_svr.response_missing s (missing uri)
+  | _ -> (
+      let uri = req.Request.uri in
+      try
+        let relative_url =
+          String.sub uri uri_base_len (String.length uri - uri_base_len)
+        in
+        (* file_path is the thing which should be served *)
+        let file_path = dir ^ "/" ^ relative_url in
+        (* remove any dodgy use of "." or ".." NB we don't prevent the use of symlinks *)
+        let file_path =
+          Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot file_path
+        in
+        if not (String.startswith dir file_path) then (
+          debug "Rejecting request for file: %s (outside of directory %s)"
+            file_path dir ;
+          Http_svr.response_forbidden ~req s
+        ) else
+          let stat = Unix.stat file_path in
+          (* if a directory, automatically add index.html *)
+          let file_path =
+            if stat.Unix.st_kind = Unix.S_DIR then
+              file_path ^ "/index.html"
+            else
+              file_path
+          in
+          response_file s file_path
+      with _ -> Http_svr.response_missing s (missing uri)
+    )

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -797,6 +797,8 @@ let sm_dir = ref "/opt/xensource/sm"
 
 let web_dir = ref "/opt/xensource/www"
 
+let website_https_only = ref true
+
 let cluster_stack_root = ref "/usr/libexec/xapi/cluster-stack"
 
 let cluster_stack_default = ref "xhad"
@@ -1143,6 +1145,10 @@ let other_options =
     , Arg.Set allow_host_sched_gran_modification
     , (fun () -> string_of_bool !allow_host_sched_gran_modification)
     , "Allows to modify the host's scheduler granularity" )
+  ; ( "website-https-only"
+    , Arg.Set website_https_only
+    , (fun () -> string_of_bool !website_https_only)
+    , "Allow access to the internal website using HTTPS only (no HTTP)" )
   ]
 
 let all_options = options_of_xapi_globs_spec @ other_options


### PR DESCRIPTION
By default, only HTTPS is allowed, as a small step to improve security.
This only affects the web content on the GET / handler (for the time
being).  There is a config file option to re-enable HTTP access if
required.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>