### PR TITLE
CP-36866: Distribute trusted appliance certificates on join

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -567,6 +567,8 @@ let _ =
     ~doc:"The host joining the pool must have the same API version as the pool master." ();
   error Api_errors.pool_joining_host_must_have_same_db_schema ["host_db_schema";"master_db_schema"]
     ~doc:"The host joining the pool must have the same database schema as the pool master." ();
+  error Api_errors.pool_joining_host_ca_certificates_conflict []
+    ~doc:"The host joining the pool has different ca certificates from the pool master while using the same name, uninstall them and try again." ();
 
   (* External directory service *)
   error Api_errors.subject_cannot_be_resolved []
@@ -1053,7 +1055,7 @@ let _ =
 
   error Api_errors.server_certificate_invalid []
     ~doc:"The provided certificate is not in a PEM-encoded X509." ();
-    error Api_errors.server_certificate_key_mismatch []
+  error Api_errors.server_certificate_key_mismatch []
     ~doc:"The provided key does not match the provided certificate's public key." ();
   error Api_errors.server_certificate_not_valid_yet ["now"; "not_before"]
     ~doc:"The provided certificate is not valid yet." ();

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -80,7 +80,7 @@ open Datamodel_types
       ()
 
   (* This is a map of uuid -> cert_blob *)
-  let pool_certs = Map (String, String)
+  let certs = Map (String, String)
 
   let exchange_certificates_on_join = call
       ~name:"exchange_certificates_on_join"
@@ -89,8 +89,22 @@ open Datamodel_types
       ~params:[String, "uuid", "The uuid of the joining host";
                String, "certificate", "The contents of the joiner's certificate";
               ]
-      ~result:(pool_certs, "The contents of the pool's certificates")
+      ~result:(certs, "The contents of the pool's certificates")
       ~doc:"Install the pool certificate of a joiner and return the pool's certificates"
+      ~hide_from_docs:true
+      ~allowed_roles:_R_POOL_OP
+      ()
+
+  let exchange_ca_certificates_on_join = call
+      ~name:"exchange_ca_certificates_on_join"
+      ~in_oss_since:None
+      ~in_product_since:rel_next
+      ~params:[certs, "import", "The CA certificates that are to be installed";
+               Set (Ref _certificate), "export", "The CA certificates that will be returned, \
+                                                  ready to be installed";
+              ]
+      ~result:(certs, "The contents of the CA certificates requested")
+      ~doc:"Install the CA certificates of a joiner and return the requested CA certificates"
       ~hide_from_docs:true
       ~allowed_roles:_R_POOL_OP
       ()
@@ -769,6 +783,7 @@ open Datamodel_types
         ; eject
         ; initial_auth
         ; exchange_certificates_on_join
+        ; exchange_ca_certificates_on_join
         ; transition_to_master
         ; slave_reset_master
         ; recover_slaves

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -701,6 +701,9 @@ let pool_joining_host_has_network_sriovs =
 let pool_joining_host_tls_verification_mismatch =
   "POOL_JOINING_HOST_TLS_VERIFICATION_MISMATCH"
 
+let pool_joining_host_ca_certificates_conflict =
+  "POOL_JOINING_HOST_CA_CERTIFICATES_CONFLICT"
+
 (*workload balancing*)
 let wlb_not_initialized = "WLB_NOT_INITIALIZED"
 

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -4,8 +4,6 @@ module D = Debug.Make (struct let name = "cert_distrib" end)
 
 module XenAPI = Client.Client
 
-type existing_cert_strategy = Erase_old | Merge [@@deriving sexp]
-
 type 'a remote_call =
   API.ref_host -> (Rpc.call -> Rpc.response) -> API.ref_session -> 'a
 
@@ -13,18 +11,36 @@ module WireProtocol = struct
   module Sexp = Sexplib.Sexp
   open Sexplib0.Sexp_conv
 
-  type cert_blob = string [@@deriving sexp]
+  (** [conflict_resolution] is used to determine how to treat existing
+      certs in /etc/stunnel/certs-pool
+      Erase_old => existing certs in the trusted certs dir will be removed
+      Merge     => merge incoming certs with certs in the trusted certs dir,
+                   resolving conflicts by taking the incoming cert *)
+  type conflict_resolution = Erase_old | Merge [@@deriving sexp]
 
-  type cert = {uuid: string; blob: cert_blob} [@@deriving sexp]
+  type certificate = HostPoolCertificate | ApplianceCertificate
+  [@@deriving sexp]
+
+  type certificate_file = {filename: string; content: string} [@@deriving sexp]
 
   type command =
-    | Collect
-    | Write of (existing_cert_strategy * cert list)
+    | CollectOne of certificate * string
+    | CollectMany of certificate * string list
+    | Write of (certificate * conflict_resolution * certificate_file list)
     | GenBundle
   [@@deriving sexp]
 
-  type result = CollectResult of cert_blob | WriteResult | GenBundleResult
+  type result =
+    | CollectOneResult of certificate_file
+    | CollectManyResult of certificate_file list
+    | WriteResult
+    | GenBundleResult
   [@@deriving sexp]
+
+  let string_of_conflict_resolution x =
+    x |> sexp_of_conflict_resolution |> Sexp.to_string
+
+  let string_of_certificate x = x |> sexp_of_certificate |> Sexp.to_string
 
   let string_of_command x = x |> sexp_of_command |> Sexp.to_string
 
@@ -32,12 +48,14 @@ module WireProtocol = struct
     try Some (x |> Sexp.of_string |> command_of_sexp) with _ -> None
 
   let dbg_of_command = function
-    | Collect ->
-        "Collect"
-    | Write (Erase_old, _) ->
-        "Write (Erase_old)"
-    | Write (Merge, _) ->
-        "Write (Merge)"
+    | CollectOne (typ, _) ->
+        Printf.sprintf "CollectOne (%s)" (string_of_certificate typ)
+    | CollectMany (typ, _) ->
+        Printf.sprintf "CollectMany (%s)" (string_of_certificate typ)
+    | Write (typ, resolution, _) ->
+        Printf.sprintf "Write (%s, %s)"
+          (string_of_certificate typ)
+          (string_of_conflict_resolution resolution)
     | GenBundle ->
         "GenBundle"
 
@@ -47,12 +65,18 @@ module WireProtocol = struct
     try Some (x |> Sexp.of_string |> result_of_sexp) with _ -> None
 
   let dbg_of_result = function
-    | CollectResult _ ->
+    | CollectOneResult _ ->
         "CollectResult"
+    | CollectManyResult _ ->
+        "CollectManyResult"
     | WriteResult ->
         "WriteResult"
     | GenBundleResult ->
         "GenBundleResult"
+
+  let pair_of_certificate_file {filename; content} = (filename, content)
+
+  let certificate_file_of_pair (filename, content) = {filename; content}
 end
 
 let raise_internal ?e ?details msg : 'a =
@@ -65,48 +89,109 @@ let raise_internal ?e ?details msg : 'a =
   [msg; details; e] |> String.concat ". " |> D.error "%s" ;
   raise Api_errors.(Server_error (internal_error, [msg]))
 
+module type CertificateProvider = sig
+  val store_path : string
+
+  val certificate_of_id_content :
+    string -> string -> WireProtocol.certificate_file
+
+  val read_certificate : string -> WireProtocol.certificate_file
+end
+
+module HostPoolProvider = struct
+  let certificate_path = !Xapi_globs.server_cert_internal_path
+
+  let store_path = !Xapi_globs.trusted_pool_certs_dir
+
+  let certificate_of_id_content uuid content =
+    WireProtocol.{filename= uuid ^ ".pem"; content}
+
+  let read_certificate uuid =
+    let open Gencertlib.Pem in
+    match parse_file certificate_path with
+    | Error reason ->
+        raise_internal
+          ~details:(Printf.sprintf "reason: %s" reason)
+          (Printf.sprintf "failed to parse %s" certificate_path)
+    | Ok {host_cert; _} ->
+        certificate_of_id_content uuid host_cert
+end
+
+module ApplianceProvider = struct
+  let store_path = !Xapi_globs.trusted_certs_dir
+
+  let certificate_of_id_content filename content =
+    WireProtocol.{filename; content}
+
+  let read_certificate filename =
+    let content =
+      Unixext.read_lines (Filename.concat store_path filename)
+      |> String.concat "\n"
+    in
+    certificate_of_id_content filename content
+end
+
+let provider_of_certificate (typ : WireProtocol.certificate) :
+    (module CertificateProvider) =
+  match typ with
+  | HostPoolCertificate ->
+      (module HostPoolProvider : CertificateProvider)
+  | ApplianceCertificate ->
+      (module ApplianceProvider : CertificateProvider)
+
 (* eventually the remote calls should probably become API calls in the datamodel
    but they remain here for quick development *)
 module Worker : sig
   val local_exec : __context:Context.t -> command:string -> string
 
-  val remote_collect_cert : WireProtocol.cert_blob remote_call
+  val remote_collect_cert :
+       WireProtocol.certificate
+    -> string
+    -> WireProtocol.certificate_file remote_call
+
+  val remote_collect_certs :
+       WireProtocol.certificate
+    -> string list
+    -> WireProtocol.certificate_file list remote_call
 
   val remote_write_certs_fs :
-    existing_cert_strategy -> WireProtocol.cert list -> unit remote_call
+       WireProtocol.certificate
+    -> WireProtocol.conflict_resolution
+    -> WireProtocol.certificate_file list
+    -> unit remote_call
 
   val remote_regen_bundle : unit remote_call
 
+  val local_collect_certs :
+       __context:Context.t
+    -> WireProtocol.certificate
+    -> string list
+    -> WireProtocol.certificate_file list
+
   val local_write_cert_fs :
        __context:Context.t
-    -> existing_cert_strategy
-    -> WireProtocol.cert list
+    -> WireProtocol.certificate
+    -> WireProtocol.conflict_resolution
+    -> WireProtocol.certificate_file list
     -> unit
 
   val local_regen_bundle : __context:Context.t -> unit
 end = struct
   open WireProtocol
 
-  let my_cert = !Xapi_globs.server_cert_internal_path
+  let read_cert typ id =
+    let module P = (val provider_of_certificate typ : CertificateProvider) in
+    P.read_certificate id
 
-  let pool_certs = !Xapi_globs.trusted_pool_certs_dir
-
-  let pool_certs_bk = Printf.sprintf "%s.bk" pool_certs
-
-  let get_my_cert () : cert_blob =
-    let open Gencertlib.Pem in
-    match parse_file my_cert with
-    | Error reason ->
-        raise_internal
-          ~details:(Printf.sprintf "reason: %s" reason)
-          (Printf.sprintf "failed to parse %s" my_cert)
-    | Ok {host_cert; _} ->
-        host_cert
-
-  let write_certs_fs strategy certs =
+  let write_certs_fs typ strategy certs =
     let open Helpers.FileSys in
+    let module P = (val provider_of_certificate typ : CertificateProvider) in
+    let pool_certs = P.store_path in
+    let pool_certs_bk = Printf.sprintf "%s.bk" pool_certs in
     let mv_or_cp = match strategy with Erase_old -> mv | Merge -> cpr in
-    ( try mv_or_cp ~src:pool_certs ~dest:pool_certs_bk
+    ( try
+        Unixext.mkdir_rec pool_certs_bk 0o700 ;
+        mv_or_cp ~src:pool_certs ~dest:pool_certs_bk
       with e ->
         D.debug
           "write_certs_fs: ignoring failure, mv_or_cp %s to %s. exception: %s"
@@ -115,9 +200,9 @@ end = struct
     ( try
         Unixext.mkdir_rec pool_certs 0o700 ;
         certs
-        |> List.iter (fun {uuid; blob} ->
-               let fname = Printf.sprintf "%s/%s.pem" pool_certs uuid in
-               redirect blob ~fname)
+        |> List.iter (function {filename; content} ->
+               let fname = Filename.concat P.store_path filename in
+               redirect content ~fname)
       with e ->
         (* on fail, try reset to previous cert state *)
         ( try mv ~src:pool_certs_bk ~dest:pool_certs
@@ -161,11 +246,12 @@ end = struct
     D.debug "Worker.local_exec: command is '%s'" (dbg_of_command p) ;
     let r =
       match p with
-      | Collect ->
-          let cert = get_my_cert () in
-          CollectResult cert
-      | Write (strategy, certs) ->
-          write_certs_fs strategy certs ;
+      | CollectOne (typ, id) ->
+          CollectOneResult (read_cert typ id)
+      | CollectMany (typ, ids) ->
+          CollectManyResult (List.map (read_cert typ) ids)
+      | Write (typ, strategy, certs) ->
+          write_certs_fs typ strategy certs ;
           WriteResult
       | GenBundle ->
           regen_bundle () ; GenBundleResult
@@ -191,15 +277,23 @@ end = struct
       ~details:(Printf.sprintf "r = %s" (dbg_of_result r))
       (Printf.sprintf "%s: unexpected result" name)
 
-  let remote_collect_cert host rpc session_id =
-    remote_call_sync host Collect rpc session_id |> function
-    | CollectResult cert ->
+  let remote_collect_cert typ id host rpc session_id =
+    remote_call_sync host (CollectOne (typ, id)) rpc session_id |> function
+    | CollectOneResult cert ->
         cert
     | r ->
         unexpected_result "remote_collect_cert" r
 
-  let remote_write_certs_fs strategy certs host rpc session_id =
-    remote_call_sync host (Write (strategy, certs)) rpc session_id |> function
+  let remote_collect_certs typ ids host rpc session_id =
+    remote_call_sync host (CollectMany (typ, ids)) rpc session_id |> function
+    | CollectManyResult certs ->
+        certs
+    | r ->
+        unexpected_result "remote_collect_certs" r
+
+  let remote_write_certs_fs typ strategy certs host rpc session_id =
+    remote_call_sync host (Write (typ, strategy, certs)) rpc session_id
+    |> function
     | WriteResult ->
         ()
     | r ->
@@ -212,8 +306,16 @@ end = struct
     | r ->
         unexpected_result "remote_regen_bundle" r
 
-  let local_write_cert_fs ~__context strategy certs =
-    let command = WireProtocol.string_of_command (Write (strategy, certs)) in
+  let local_collect_certs ~__context typ ids =
+    let command = string_of_command (CollectMany (typ, ids)) in
+    match result_or_fail (local_exec ~__context ~command) with
+    | CollectManyResult certs ->
+        certs
+    | r ->
+        unexpected_result "local_collect_certs" r
+
+  let local_write_cert_fs ~__context typ strategy certs =
+    let command = string_of_command (Write (typ, strategy, certs)) in
     match result_or_fail (local_exec ~__context ~command) with
     | WriteResult ->
         ()
@@ -221,7 +323,7 @@ end = struct
         unexpected_result "local_write_certs_fs" r
 
   let local_regen_bundle ~__context =
-    let command = WireProtocol.string_of_command GenBundle in
+    let command = string_of_command GenBundle in
     match result_or_fail (local_exec ~__context ~command) with
     | GenBundleResult ->
         ()
@@ -235,8 +337,11 @@ let collect_pool_certs ~__context ~rpc ~session_id ~map ~from_hosts =
   from_hosts
   |> List.map (fun host ->
          let uuid = Db.Host.get_uuid ~__context ~self:host in
-         let blob = Worker.remote_collect_cert host rpc session_id in
-         map WireProtocol.{uuid; blob})
+         let cert =
+           Worker.remote_collect_cert HostPoolCertificate uuid host rpc
+             session_id
+         in
+         map cert)
 
 let exchange_certificates_among_all_members ~__context =
   (* here we coordinate the certificate distribution. from a high level
@@ -245,7 +350,7 @@ let exchange_certificates_among_all_members ~__context =
         the cert collected will be [Worker.my_cert]
      b) tell all hosts to write the certs collected in (a) to [Worker.pool_certs]).
         the original contents of [Worker.pool_certs] will either be removed or
-        simply added to, depending on [existing_cert_strategy].
+        simply added to, depending on [conflict_resolution].
      c) tell all_hosts to regenerate their trust bundles. the old bundle is
         removed completely. see 'update-ca-bundle.sh'. only at this point would we
         expect 'things to go wrong', e.g. new connections fail, if the certs have not
@@ -264,19 +369,22 @@ let exchange_certificates_among_all_members ~__context =
   in
   List.iter
     (fun host ->
-      Worker.remote_write_certs_fs Erase_old certs host rpc session_id)
+      Worker.remote_write_certs_fs HostPoolCertificate Erase_old certs host rpc
+        session_id)
     all_hosts ;
   List.iter
     (fun host -> Worker.remote_regen_bundle host rpc session_id)
     all_hosts
 
 let import_joiner ~__context ~uuid ~certificate ~to_hosts =
-  let joiner_certificate = WireProtocol.{uuid; blob= certificate} in
+  let joiner_certificate =
+    HostPoolProvider.certificate_of_id_content uuid certificate
+  in
   Helpers.call_api_functions ~__context @@ fun rpc session_id ->
   List.iter
     (fun host ->
-      Worker.remote_write_certs_fs Merge [joiner_certificate] host rpc
-        session_id)
+      Worker.remote_write_certs_fs HostPoolCertificate Merge
+        [joiner_certificate] host rpc session_id)
     to_hosts ;
   List.iter
     (fun host -> Worker.remote_regen_bundle host rpc session_id)
@@ -288,12 +396,10 @@ let exchange_certificates_with_joiner ~__context ~uuid ~certificate =
   import_joiner ~__context ~uuid ~certificate ~to_hosts:all_hosts ;
   Helpers.call_api_functions ~__context @@ fun rpc session_id ->
   collect_pool_certs ~__context ~rpc ~session_id ~from_hosts:all_hosts
-    ~map:(fun WireProtocol.{uuid; blob} -> (uuid, blob))
+    ~map:WireProtocol.pair_of_certificate_file
 
 (* This function is called on the host that is joining a pool *)
 let import_joining_pool_certs ~__context ~pool_certs =
-  let pool_certs =
-    List.map (fun (uuid, blob) -> WireProtocol.{uuid; blob}) pool_certs
-  in
-  Worker.local_write_cert_fs ~__context Merge pool_certs ;
+  let pool_certs = List.map WireProtocol.certificate_file_of_pair pool_certs in
+  Worker.local_write_cert_fs ~__context HostPoolCertificate Merge pool_certs ;
   Worker.local_regen_bundle ~__context

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -9,14 +9,10 @@ type existing_cert_strategy = Erase_old | Merge
 val local_exec : __context:Context.t -> command:string -> string
 (** execute a string encoded job, returning a string encoded result *)
 
-val go :
-     __context:Context.t
-  -> from_hosts:API.ref_host list
-  -> to_hosts:API.ref_host list
-  -> existing_cert_strategy:existing_cert_strategy
-  -> unit
-(** Certificates are collected from [from_hosts] and installed on [to_hosts].
-    On success, new bundles will have been generated on all [to_hosts] *)
+val exchange_certificates_among_all_members : __context:Context.t -> unit
+(** [exchange_certificates_among_all_members ~__context] collects internal
+    certificates from all members in a pool and installed on all of them. On
+    success, new bundles will have been generated on the members. *)
 
 val exchange_certificates_with_joiner :
      __context:Context.t

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -25,3 +25,28 @@ val import_joining_pool_certs :
     This parameter must be a result of [exchange_certificates_with_joiner].
     This functions was designed as part of pool join and is unlikely to be
     useful elsewhere. *)
+
+val collect_ca_certs :
+  __context:Context.t -> names:string list -> (string * string) list
+(** [collect_ca_certs ~__context ~names] returns the ca certificates present
+    in the filesystem with the filenames [names], ready to export. *)
+
+val exchange_ca_certificates_with_joiner :
+     __context:Context.t
+  -> import:(string * string) list
+  -> export:string list
+  -> (string * string) list
+(** [exchange_ca_certificates_with_joiner ~__context ~import ~export]
+    distributes [import] certificates to all hosts in a pool and makes the
+    pool trust them by installing them as ca certificates into
+    the filesystem. Returns the list of ca certificates with names
+    [export]. This function was designed as part of pool join and is
+    unlikely to be useful elsewhere. *)
+
+val import_joining_pool_ca_certificates :
+  __context:Context.t -> ca_certs:(string * string) list -> unit
+(** [import_joining_pool_ca_certificates ~__context ~ca_certs]
+    Installs [ca_certs] into the filesystem as ca certificates.
+    This parameter must be the result of
+    [exchange_ca_certificates_with_joiner]. This function was designed
+    as part of pool join and is unlikely to be useful elsewhere. *)

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -1,11 +1,3 @@
-type existing_cert_strategy = Erase_old | Merge
-
-(** [existing_cert_strategy] is used to determine how to treat existing
-    certs in /etc/stunnel/certs-pool
-    Erase_old => existing certs in the trusted certs dir will be removed
-    Merge     => merge incoming certs with certs in the trusted certs dir,
-                 resolving conflicts by taking the incoming cert *)
-
 val local_exec : __context:Context.t -> command:string -> string
 (** execute a string encoded job, returning a string encoded result *)
 
@@ -22,7 +14,8 @@ val exchange_certificates_with_joiner :
 (** [exchange_certificates_with_joiner ~__context ~uuid ~certificate]
     distributes [certificate] to all hosts in a pool and makes the pool trust
     it by installing it as the pool certificate for the host with [uuid] into
-    the filesystem. This function was designed as part of pool join and is
+    the filesystem. Returns a list of internal certificates of all hosts in
+    the pool. This function was designed as part of pool join and is
     unlikely to be useful elsewhere. *)
 
 val import_joining_pool_certs :

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -955,9 +955,7 @@ functor
         Xapi_pool_helpers.with_pool_operation ~__context
           ~doc:"Pool.enable_tls_verification" ~self ~op:`tls_verification_enable
           (fun () ->
-            Cert_distrib.(
-              go ~__context ~existing_cert_strategy:Erase_old
-                ~from_hosts:all_hosts ~to_hosts:all_hosts) ;
+            Cert_distrib.exchange_certificates_among_all_members ~__context ;
             all_hosts
             |> List.iter (fun host ->
                    do_op_on ~local_fn ~__context ~host (fun session_id rpc ->

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -105,6 +105,12 @@ val exchange_certificates_on_join :
   -> certificate:string
   -> API.string_to_string_map
 
+val exchange_ca_certificates_on_join :
+     __context:Context.t
+  -> import:API.string_to_string_map
+  -> export:API.ref_Certificate list
+  -> API.string_to_string_map
+
 val emergency_transition_to_master : __context:'a -> unit
 
 val emergency_reset_master : __context:'a -> master_address:string -> unit


### PR DESCRIPTION
The cert_distrib module can now be used to gather more than one type of certificate. This is used in the pool join to retrieve the 'CA' certificates from a pool and install them in the joining host.

The joining host calculates which certificates it's missing and which certificates the pool is missing and distributes only those. Additionally it detect if there are certificates with conflicting names before doing this and stops the join in this case.