### PR TITLE
CP-35955: Add absolute guidances in pending_guidances

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1275,6 +1275,13 @@ let set_NVRAM_EFI_variables = call ~flags:[`Session]
   ~allowed_roles:_R_LOCAL_ROOT_ONLY
   ()
 
+let pending_guidances =
+  Enum ("vm_pending_guidances",
+        [
+          "RestartDeviceModel",
+          "Indicates the device model of this running VM should restart as soon as possible"
+        ])
+
   (** VM (or 'guest') configuration: *)
   let t =
     create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:true ~name:_vm ~descr:"A virtual machine (or 'guest')."
@@ -1460,6 +1467,7 @@ let set_NVRAM_EFI_variables = call ~flags:[`Session]
            field ~lifecycle:[Prototyped, rel_naples, ""] ~qualifier:StaticRO ~ty:(Map(String, String)) "NVRAM"
              ~default_value:(Some (VMap []))
              "initial value for guest NVRAM (containing UEFI variables, etc). Cannot be changed while the VM is running";
+           field ~qualifier:DynamicRO ~in_product_since:rel_next ~ty:(Set pending_guidances) "pending_guidances" ~default_value:(Some (VSet [])) "The set of pending guidances after applying updates"
          ])
       ()
 

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "b8351551efb478e2cf5ff835b019d567"
+let last_known_schema_hash = "fdc1e9009e25e6aa0f6da8bc6adffbe1"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -200,7 +200,7 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~power_on_config:[] ~local_cache_sr ~ssl_legacy ~guest_VCPUs_params:[]
     ~display:`enabled ~virtual_hardware_platform_versions:[]
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
-    ~multipathing:false ~uefi_certificates:"" ~editions:[] ;
+    ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[] ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -400,6 +400,10 @@ let vm_appliance_operation_to_string = function
   | `shutdown ->
       "shutdown"
 
+let vm_pending_guidances_to_string = function
+  | `RestartDeviceModel ->
+      "RestartDeviceModel"
+
 let cpu_feature_to_string f =
   match f with
   | `FPU ->

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -184,6 +184,12 @@ let host_operation_to_string = function
   | `apply_updates ->
       "apply_updates"
 
+let host_pending_guidances_to_string = function
+  | `RebootHost ->
+      "RebootHost"
+  | `RestartToolstack ->
+      "RestartToolstack"
+
 let vdi_operation_to_string : API.vdi_operations -> string = function
   | `clone ->
       "clone"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2116,6 +2116,11 @@ let vm_record rpc session_id vm =
               x ;
             Client.VM.set_bios_strings rpc session_id vm x)
           ()
+      ; make_field ~name:"pending-guidances"
+          ~get:(fun () ->
+            map_and_concat Record_util.vm_pending_guidances_to_string
+              (x ()).API.vM_pending_guidances)
+          ()
       ]
   }
 

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2662,6 +2662,11 @@ let host_record rpc session_id host =
           ~set:(fun value ->
             Client.Host.set_uefi_certificates ~rpc ~session_id ~host ~value)
           ()
+      ; make_field ~name:"pending-guidances"
+          ~get:(fun () ->
+            map_and_concat Record_util.host_pending_guidances_to_string
+              (x ()).API.host_pending_guidances)
+          ()
       ]
   }
 

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -326,7 +326,7 @@ and create_domain_zero_record ~__context ~domain_zero_ref
     ~start_delay:0L ~shutdown_delay:0L ~order:0L ~suspend_SR:Ref.null
     ~version:0L ~generation_id:"" ~hardware_platform_version:0L
     ~has_vendor_device:false ~requires_reboot:false ~reference_label:""
-    ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[] ;
+    ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[] ~pending_guidances:[] ;
   ensure_domain_zero_metrics_record ~__context ~domain_zero_ref host_info ;
   Db.Host.set_control_domain ~__context ~self:localhost ~value:domain_zero_ref ;
   Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3516,6 +3516,11 @@ functor
         let uuid = host_uuid ~__context self in
         info "Host.apply_updates: host = '%s'; hash = '%s'" uuid hash;
         Local.Host.apply_updates ~__context ~self ~hash
+
+      let remove_pending_guidance ~__context ~self ~value =
+        info "Host.remove_pending_guidance: host = '%s'; guidance = %s"
+          (host_uuid ~__context self) (Record_util.host_pending_guidances_to_string value) ;
+        Local.Host.remove_pending_guidance ~__context ~self ~value
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1278,6 +1278,12 @@ let server_init () =
                 Helpers.call_api_functions ~__context (fun rpc session_id ->
                     Xapi_pool_update.resync_host __context
                       (Helpers.get_localhost ~__context)) )
+          ; ( "Cleanup pending RestartToolstack guidance"
+            , [Startup.NoExnRaising]
+            , fun () ->
+                Helpers.call_api_functions ~__context (fun rpc session_id ->
+                    Xapi_host.remove_pending_guidance __context
+                      (Helpers.get_localhost ~__context) `RestartToolstack) )
           ] ;
         debug "startup: startup sequence finished") ;
     wait_to_die ()

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -895,7 +895,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address
         [0L]
       )
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
-    ~multipathing:false ~uefi_certificates:"" ~editions:[] ;
+    ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[] ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;
@@ -2555,3 +2555,6 @@ let apply_updates ~__context ~self ~hash =
     Repository.apply_updates ~__context ~host:self ~hash
   in
   Repository.apply_immediate_guidances ~__context ~host:self ~guidances
+
+let remove_pending_guidance ~__context ~self ~value =
+  Db.Host.remove_pending_guidances ~__context ~self ~value

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -530,3 +530,9 @@ val apply_updates :
   -> self:API.ref_host
   -> hash:string
   -> unit
+
+val remove_pending_guidance :
+     __context:Context.t
+  -> self:API.ref_host
+  -> value:API.host_pending_guidances
+  -> unit

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -377,6 +377,7 @@ let consider_enabling_host_nolock ~__context =
       debug
         "Host.enabled: system has just restarted: setting localhost to enabled" ;
       Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
+      Db.Host.remove_pending_guidances ~__context ~self:localhost ~value:`RebootHost ;
       update_allowed_operations ~__context ~self:localhost ;
       Localdb.put Constants.host_disabled_until_reboot "false" ;
       (* Start processing pending VM powercycle events *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -698,7 +698,7 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~snapshot_schedule:Ref.null ~is_vmss_snapshot:false ~appliance ~start_delay
     ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~requires_reboot:false
-    ~reference_label ~domain_type ;
+    ~reference_label ~domain_type ~pending_guidances:[] ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -380,7 +380,8 @@ let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~hardware_platform_version:all.Db_actions.vM_hardware_platform_version
     ~has_vendor_device:all.Db_actions.vM_has_vendor_device
     ~requires_reboot:false ~reference_label:all.Db_actions.vM_reference_label
-    ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM ;
+    ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM
+    ~pending_guidances:[] ;
   (* update the VM's parent field in case of snapshot. Note this must be done after "ref"
      	   has been created, so that its "children" field can be updated by the database layer *)
   ( match disk_op with

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -3294,7 +3294,8 @@ let set_resident_on ~__context ~self =
   refresh_vm ~__context ~self ;
   !trigger_xenapi_reregister () ;
   (* Any future XenAPI updates will trigger events, but we might have missed one so: *)
-  Xenopsd_metadata.update ~__context ~self
+  Xenopsd_metadata.update ~__context ~self ;
+  Db.VM.remove_pending_guidances ~__context ~self ~value:`RestartDeviceModel
 
 let update_debug_info __context t =
   let task = Context.get_task_id __context in


### PR DESCRIPTION
There are two kinds of update guidances designed:
1. Recommended guidances: basically these guidances will be applied by
XAPI automatically after host being updated;
2. Absolute guidances: these guidances requires user to apply manually.

Both kinds of guidances look like: RebootHost, RestartToolstack, and
RestartDeviceModel.

This commit introduces function to add absolute guidances into
host.pending_guidances or VM.pending_guidances. In this way, users can
get to know the pending guidances need to be done by them manually.

Signed-off-by: Ming Lu <ming.lu@citrix.com>