### PR TITLE
CP-36097 xapi should talk to cluster daemons using hostnames as well as IPs

### DIFF
--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -172,9 +172,13 @@ let t =
           ~ty:(Set (Ref _cluster_host)) "cluster_hosts"
           "A list of the cluster_host objects associated with the Cluster"
 
-      ; field ~qualifier:DynamicRO ~lifecycle:[ Prototyped, rel_lima, "" ]
+      ; field ~qualifier:DynamicRO
+          ~lifecycle:[ Prototyped, rel_lima, "" ; Changed, rel_next, "allow encoding of IP_with_hostname" ]
+          (* this column stores addresses
+           * the old encoding is to store the IP directly as a string
+           * the new encoding is to store rpc string rep of the address *)
           ~ty:(Set String) "pending_forget" ~default_value:(Some (VSet []))
-          "Internal field used by Host.destroy to store the IP of cluster members \
+          "Internal field used by Host.destroy to store the address of cluster members \
            marked as permanently dead but not yet removed"
 
       ; field   ~qualifier:StaticRO ~lifecycle

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "aa2bb241740310988f3f16b236392066"
+let last_known_schema_hash = "9cd231613de78338d83df8075bcbca9f"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -26,8 +26,13 @@ let test_clusterd_rpc ~__context call =
       Rpc.{success= true; contents= Rpc.Null; is_notification= false}
   | "diagnostics", _ ->
       let open Cluster_interface in
-      let id = 1l in
-      let me = {addr= IPv4 "192.0.2.1"; id} in
+      let host = Helpers.get_localhost ~__context in
+      let me =
+        {
+          addr= Xapi_clustering.Addr.of_ip_host ~__context ~host ~ip:"192.0.2.1"
+        ; id= 1l
+        }
+      in
       let cluster_config =
         {
           cluster_name= "xapi-clusterd"

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -950,6 +950,13 @@ functor
             Cert_distrib.(
               go ~__context ~existing_cert_strategy:Erase_old
                 ~from_hosts:all_hosts ~to_hosts:all_hosts) ;
+
+            (* check clusterds are set up correctly *)
+            Db.Cluster.get_all ~__context
+            |> List.iter (fun self ->
+                   Xapi_clustering.enable_tls_verification_prechecks ~__context
+                     ~self) ;
+
             all_hosts
             |> List.iter (fun host ->
                    do_op_on ~local_fn ~__context ~host (fun session_id rpc ->

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -48,14 +48,14 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
       let host = Helpers.get_master ~__context in
       let pifrec = Db.PIF.get_record ~__context ~self:pIF in
       assert_pif_prerequisites (pIF, pifrec) ;
-      let ip = ip_of_pif (pIF, pifrec) in
+      let addr = Addr.of_pif_host ~__context ~host (pIF, pifrec) in
       let token_timeout_ms = Int64.of_float (token_timeout *. 1000.0) in
       let token_timeout_coefficient_ms =
         Int64.of_float (token_timeout_coefficient *. 1000.0)
       in
       let init_config =
         {
-          Cluster_interface.local_ip= ip
+          Cluster_interface.local_ip= addr
         ; token_timeout_ms= Some token_timeout_ms
         ; token_coefficient_ms= Some token_timeout_coefficient_ms
         ; name= None


### PR DESCRIPTION
- replaces usages of `IPv4` with `IP_with_hostname`
- when enabling tls verification, run clusterd prechecks