### PR TITLE
xapi_pool_helpers: refactor call_fn_on_hosts; exclude tests from interface quality gate

### DIFF
--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,33 +3,37 @@
 set -e
 
 list-hd () {
+  N=295
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
-  if [ "$LIST_HD" -eq 296 ]; then
+  if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD usages"
   else
-    echo "ERROR expected 296 List.hd usages, got $LIST_HD" 1>&2
+    echo "ERROR expected $N List.hd usages, got $LIST_HD" 1>&2
     exit 1
   fi
 }
 
 verify-cert () {
+  N=7
   NONE=$(git grep -r --count 'verify_cert:None' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
-  if [ "$NONE" -eq 7 ]; then
+  if [ "$NONE" -eq "$N" ]; then
     echo "OK counted $NONE usages of verify_cert:None"
   else
-    echo "ERROR expected 7 verify_cert:None usages, got $NONE" 1>&2
+    echo "ERROR expected $N verify_cert:None usages, got $NONE" 1>&2
     exit 1
   fi
 }
 
 mli-files () {
-  MLIS=$(git ls-files -- '**/*.mli' | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
-  MLS=$(git  ls-files -- '**/*.ml'  | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
+  N=275
+  # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
+  MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
+  MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   num_mls_without_mlis=$(comm -23 <(sort <<<"$MLS") <(sort <<<"$MLIS") | wc -l)
-  if [ "$num_mls_without_mlis" -eq 394 ]; then
+  if [ "$num_mls_without_mlis" -eq "$N" ]; then
     echo "OK counted $num_mls_without_mlis .ml files without an .mli"
   else
-    echo "ERROR expected 394 .ml files without .mlis, got $num_mls_without_mlis."\
+    echo "ERROR expected $N .ml files without .mlis, got $num_mls_without_mlis."\
          "If you created some .ml files, they are probably missing corresponding .mli's" 1>&2
     exit 1
   fi


### PR DESCRIPTION
Print the first exception raised, not the last one, this is done by
replacing the fold_left with the filter_map to store exception in the
same order as they're raised.
Avoid using List.length and List.hd.

Avoid repeating numbers in quality_gate, do not count ml files in the test directory