### PR TITLE
CP-35955: Add absolute guidances in pending_guidances

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -198,6 +198,8 @@ let update_guidances =
           "Indicates the updated host should reboot as soon as possible"
         ; "restart_toolstack",
           "Indicates the Toolstack running on the updated host should restart as soon as possible"
+        ; "restart_device_model",
+          "Indicates the device model of a running VM should restart as soon as possible"
         ])
 
 let get_oss_releases in_oss_since =

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -191,6 +191,15 @@ let _certificate = "Certificate"
 let _diagnostics = "Diagnostics"
 let _repository = "Repository"
 
+let update_guidances =
+  Enum ("update_guidances",
+        [
+          "reboot_host",
+          "Indicates the updated host should reboot as soon as possible"
+        ; "restart_toolstack",
+          "Indicates the Toolstack running on the updated host should restart as soon as possible"
+        ])
+
 let get_oss_releases in_oss_since =
   match in_oss_since with
     None -> []

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1245,7 +1245,9 @@ let _ =
   error Api_errors.updateinfo_hash_mismatch []
     ~doc:"The hash of updateinfo doesn't match with current one. There may be newer available updates." ();
   error Api_errors.updates_require_sync []
-    ~doc:"A call to pool.sync_updates is required before this operation." ()
+    ~doc:"A call to pool.sync_updates is required before this operation." ();
+  error Api_errors.cannot_restart_device_model ["ref"]
+    ~doc:"Cannot restart device models of paused VMs residing on the host." ()
 
 
 let _ =

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1646,6 +1646,7 @@ let host_query_ha = call ~flags:[`Session]
            field ~qualifier:StaticRO ~lifecycle:[Published, rel_kolkata, ""] ~default_value:(Some (VBool false)) ~ty:Bool "multipathing" "Specifies whether multipathing is enabled";
            field ~qualifier:StaticRO ~lifecycle:[Published, rel_quebec, ""] ~default_value:(Some (VString "")) ~ty:String "uefi_certificates" "The UEFI certificates allowing Secure Boot";
            field ~qualifier:DynamicRO ~lifecycle:[Published, rel_stockholm, ""] ~ty:(Set (Ref _certificate)) "certificates" "List of certificates installed in the host";
-           field ~qualifier:DynamicRO ~lifecycle:[Published, rel_stockholm, ""] ~default_value:(Some (VSet [])) ~ty:(Set String) "editions" "List of all available product editions"
+           field ~qualifier:DynamicRO ~lifecycle:[Published, rel_stockholm, ""] ~default_value:(Some (VSet [])) ~ty:(Set String) "editions" "List of all available product editions";
+           field ~qualifier:DynamicRO ~in_product_since:rel_next ~ty:(Set update_guidances) "pending_guidances" ~default_value:(Some (VSet [])) "The set of pending guidances after applying updates"
          ])
       ()

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1460,6 +1460,7 @@ let set_NVRAM_EFI_variables = call ~flags:[`Session]
            field ~lifecycle:[Prototyped, rel_naples, ""] ~qualifier:StaticRO ~ty:(Map(String, String)) "NVRAM"
              ~default_value:(Some (VMap []))
              "initial value for guest NVRAM (containing UEFI variables, etc). Cannot be changed while the VM is running";
+           field ~qualifier:DynamicRO ~in_product_since:rel_next ~ty:(Set update_guidances) "pending_guidances" ~default_value:(Some (VSet [])) "The set of pending guidances after applying updates"
          ])
       ()
 

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "b8351551efb478e2cf5ff835b019d567"
+let last_known_schema_hash = "87660671b559cb1cedd8b6f9acbf3b90"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -200,7 +200,7 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~power_on_config:[] ~local_cache_sr ~ssl_legacy ~guest_VCPUs_params:[]
     ~display:`enabled ~virtual_hardware_platform_versions:[]
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
-    ~multipathing:false ~uefi_certificates:"" ~editions:[] ;
+    ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[] ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -185,6 +185,12 @@ let host_operation_to_string = function
   | `apply_updates ->
       "apply_updates"
 
+let update_guidance_to_string = function
+  | `reboot_host ->
+      "reboot_host"
+  | `restart_toolstack ->
+      "restart_toolstack"
+
 let vdi_operation_to_string : API.vdi_operations -> string = function
   | `clone ->
       "clone"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -190,6 +190,8 @@ let update_guidance_to_string = function
       "reboot_host"
   | `restart_toolstack ->
       "restart_toolstack"
+  | `restart_device_model ->
+      "restart_device_model"
 
 let vdi_operation_to_string : API.vdi_operations -> string = function
   | `clone ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2405,6 +2405,12 @@ let vm_record rpc session_id vm =
             Client.VM.set_bios_strings rpc session_id vm x
             )
           ()
+      ; make_field ~name:"pending-guidances"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.vM_pending_guidances
+            )
+          ()
       ]
   }
 

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3005,6 +3005,12 @@ let host_record rpc session_id host =
             Client.Host.set_uefi_certificates ~rpc ~session_id ~host ~value
             )
           ()
+      ; make_field ~name:"pending-guidances"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.host_pending_guidances
+            )
+          ()
       ]
   }
 

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1257,3 +1257,5 @@ let apply_guidance_failed = "APPLY_GUIDANCE_FAILED"
 let updateinfo_hash_mismatch = "UPDATEINFO_HASH_MISMATCH"
 
 let updates_require_sync = "UPDATES_REQUIRE_SYNC"
+
+let cannot_restart_device_model = "CANNOT_RESTART_DEVICE_MODEL"

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -328,7 +328,8 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info : host_info
     ~start_delay:0L ~shutdown_delay:0L ~order:0L ~suspend_SR:Ref.null
     ~version:0L ~generation_id:"" ~hardware_platform_version:0L
     ~has_vendor_device:false ~requires_reboot:false ~reference_label:""
-    ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[] ;
+    ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[]
+    ~pending_guidances:[] ;
   ensure_domain_zero_metrics_record ~__context ~domain_zero_ref host_info ;
   Db.Host.set_control_domain ~__context ~self:localhost ~value:domain_zero_ref ;
   Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -166,10 +166,10 @@ let http_get_host_updates_in_json ~__context ~host ~installed =
         debug "host %s returned updates: %s" host_name json_str ;
         Yojson.Basic.from_string json_str
       with e ->
-        let ref = Ref.string_of host in
-        error "Failed to get updates from host ref='%s': %s" ref
+        let host' = Ref.string_of host in
+        error "Failed to get updates from host ref='%s': %s" host'
           (ExnHelper.string_of_exn e) ;
-        raise Api_errors.(Server_error (get_host_updates_failed, [ref]))
+        raise Api_errors.(Server_error (get_host_updates_failed, [host']))
       )
     (fun () -> Xapi_session.destroy_db_session ~__context ~self:host_session_id)
 
@@ -180,7 +180,6 @@ let group_host_updates_by_repository ~__context enabled host updates_of_host =
    *   ... ...
    * ]
    *)
-  (* TODO: live patches *)
   match Yojson.Basic.Util.member "updates" updates_of_host with
   | `List updates ->
       List.fold_left
@@ -206,14 +205,14 @@ let group_host_updates_by_repository ~__context enabled host updates_of_host =
           )
         [] updates
   | _ ->
-      let ref = Ref.string_of host in
-      error "Invalid updates from host ref='%s': No 'updates'" ref ;
-      raise Api_errors.(Server_error (get_host_updates_failed, [ref]))
+      let host' = Ref.string_of host in
+      error "Invalid updates from host ref='%s': No 'updates'" host' ;
+      raise Api_errors.(Server_error (get_host_updates_failed, [host']))
   | exception e ->
-      let ref = Ref.string_of host in
-      error "Invalid updates from host ref='%s': %s" ref
+      let host' = Ref.string_of host in
+      error "Invalid updates from host ref='%s': %s" host'
         (ExnHelper.string_of_exn e) ;
-      raise Api_errors.(Server_error (get_host_updates_failed, [ref]))
+      raise Api_errors.(Server_error (get_host_updates_failed, [host']))
 
 let set_available_updates ~__context =
   ignore (get_single_enabled_update_repository ~__context) ;
@@ -349,7 +348,6 @@ let get_host_updates_in_json ~__context ~installed =
           |> List.filter_map
                (get_rpm_update_in_json ~rpm2updates ~installed_pkgs)
         in
-        (* TODO: live patches *)
         `Assoc [("updates", `List updates)]
     )
   with
@@ -476,44 +474,61 @@ let apply ~__context ~host =
       in
       try ignore (Helpers.call_script !Xapi_globs.yum_cmd params)
       with e ->
-        let ref = Ref.string_of host in
-        error "Failed to apply updates on host ref='%s': %s" ref
+        let host' = Ref.string_of host in
+        error "Failed to apply updates on host ref='%s': %s" host'
           (ExnHelper.string_of_exn e) ;
-        raise Api_errors.(Server_error (apply_updates_failed, [ref]))
+        raise Api_errors.(Server_error (apply_updates_failed, [host']))
   )
 
-let restart_device_models ~__context host =
-  (* Restart device models of all running HVM VMs on the host by doing
-   * local migrations. *)
+let do_with_device_models ~__context ~host ~action_label f =
+  (* Call f with device models of all running HVM VMs on the host *)
   Db.Host.get_resident_VMs ~__context ~self:host
   |> List.map (fun self -> (self, Db.VM.get_record ~__context ~self))
   |> List.filter (fun (_, record) -> not record.API.vM_is_control_domain)
-  |> List.filter_map (fun (ref, record) ->
-         match
-           ( record.API.vM_power_state
-           , Helpers.has_qemu_currently ~__context ~self:ref
-           )
-         with
-         | `Running, true ->
-             Helpers.call_api_functions ~__context (fun rpc session_id ->
-                 Client.Client.VM.pool_migrate rpc session_id ref host
-                   [("live", "true")]
-             ) ;
-             None
-         | `Paused, true ->
-             error "VM 'ref=%s' is paused, can't restart its device models"
-               (Ref.string_of ref) ;
-             Some ref
-         | _ ->
-             (* No device models are running for this VM *)
-             None
-     )
+  |> List.filter_map f
   |> function
   | [] ->
       ()
   | _ :: _ ->
-      let msg = "Can't restart device models for some VMs" in
-      raise Api_errors.(Server_error (internal_error, [msg]))
+      let host' = Ref.string_of host in
+      raise Api_errors.(Server_error (cannot_restart_device_model, [host']))
+
+let set_pending_restart_device_models ~__context ~host =
+  (* Set pending restart device models of all running HVM VMs on the host *)
+  do_with_device_models ~__context ~host ~action_label:"set pending restart"
+  @@ fun (ref, record) ->
+  match
+    (record.API.vM_power_state, Helpers.has_qemu_currently ~__context ~self:ref)
+  with
+  | `Running, true | `Paused, true ->
+      Db.VM.add_pending_guidances ~__context ~self:ref
+        ~value:`restart_device_model ;
+      None
+  | _ ->
+      (* No device models are running for this VM *)
+      None
+
+let restart_device_models ~__context ~host =
+  (* Restart device models of all running HVM VMs on the host by doing
+   * local migrations. *)
+  do_with_device_models ~__context ~host ~action_label:"restart"
+  @@ fun (ref, record) ->
+  match
+    (record.API.vM_power_state, Helpers.has_qemu_currently ~__context ~self:ref)
+  with
+  | `Running, true ->
+      Helpers.call_api_functions ~__context (fun rpc session_id ->
+          Client.Client.VM.pool_migrate rpc session_id ref host
+            [("live", "true")]
+      ) ;
+      None
+  | `Paused, true ->
+      error "VM 'ref=%s' is paused, can't restart device models for it"
+        (Ref.string_of ref) ;
+      Some ref
+  | _ ->
+      (* No device models are running for this VM *)
+      None
 
 let apply_immediate_guidances ~__context ~host ~guidances =
   (* This function runs on master host *)
@@ -533,40 +548,57 @@ let apply_immediate_guidances ~__context ~host ~guidances =
              *)
             ()
         | [RestartDeviceModel] ->
-            restart_device_models ~__context host
+            restart_device_models ~__context ~host
         | [RestartToolstack] ->
             Client.Host.restart_agent ~rpc ~session_id ~host
-        | l when eq_set1 l ->
+        | l when GuidanceSet.eq_set1 l ->
             (* EvacuateHost and RestartToolstack *)
             Client.Host.restart_agent ~rpc ~session_id ~host
-        | l when eq_set2 l ->
+        | l when GuidanceSet.eq_set2 l ->
             (* RestartDeviceModel and RestartToolstack *)
-            restart_device_models ~__context host ;
+            restart_device_models ~__context ~host ;
             Client.Host.restart_agent ~rpc ~session_id ~host
-        | l when eq_set3 l ->
+        | l when GuidanceSet.eq_set3 l ->
             (* RestartDeviceModel and EvacuateHost *)
             (* Evacuating host restarted device models already *)
-            if num_of_hosts = 1 then restart_device_models ~__context host ;
+            if num_of_hosts = 1 then restart_device_models ~__context ~host ;
             ()
-        | l when eq_set4 l ->
+        | l when GuidanceSet.eq_set4 l ->
             (* EvacuateHost, RestartToolstack and RestartDeviceModel *)
             (* Evacuating host restarted device models already *)
-            if num_of_hosts = 1 then restart_device_models ~__context host ;
+            if num_of_hosts = 1 then restart_device_models ~__context ~host ;
             Client.Host.restart_agent ~rpc ~session_id ~host
         | l ->
-            let ref = Ref.string_of host in
+            let host' = Ref.string_of host in
             error
               "Found wrong guidance(s) after applying updates on host \
                ref='%s': %s"
-              ref
+              host'
               (String.concat ";" (List.map Guidance.to_string l)) ;
-            raise Api_errors.(Server_error (apply_guidance_failed, [ref]))
+            raise Api_errors.(Server_error (apply_guidance_failed, [host']))
     )
   with e ->
-    let ref = Ref.string_of host in
-    error "applying immediate guidances on host ref='%s' failed: %s" ref
+    let host' = Ref.string_of host in
+    error "applying immediate guidances on host ref='%s' failed: %s" host'
       (ExnHelper.string_of_exn e) ;
-    raise Api_errors.(Server_error (apply_guidance_failed, [ref]))
+    raise Api_errors.(Server_error (apply_guidance_failed, [host']))
+
+let set_pending_guidances ~__context ~host ~guidances =
+  let open Guidance in
+  guidances
+  |> List.iter (function
+       | RebootHost ->
+           Db.Host.add_pending_guidances ~__context ~self:host
+             ~value:`reboot_host
+       | RestartToolstack ->
+           Db.Host.add_pending_guidances ~__context ~self:host
+             ~value:`restart_toolstack
+       | RestartDeviceModel ->
+           set_pending_restart_device_models ~__context ~host
+       | g ->
+           warn "Unsupported pending guidance %s, ignore it."
+             (Guidance.to_string g)
+       )
 
 let apply_updates ~__context ~host ~hash =
   (* This function runs on master host *)
@@ -584,8 +616,8 @@ let apply_updates ~__context ~host ~hash =
         in
         match all_updates with
         | [] ->
-            let ref = Ref.string_of host in
-            info "Host ref='%s' is already up to date." ref ;
+            let host' = Ref.string_of host in
+            info "Host ref='%s' is already up to date." host' ;
             []
         | l ->
             let repository_name =
@@ -598,14 +630,18 @@ let apply_updates ~__context ~host ~hash =
             let immediate_guidances =
               eval_guidances ~updates_info ~updates ~kind:Recommended
             in
-            Guidance.assert_valid_guidances immediate_guidances ;
+            let pending_guidances =
+              List.filter
+                (fun g -> not (List.mem g immediate_guidances))
+                (eval_guidances ~updates_info ~updates ~kind:Absolute)
+            in
+            GuidanceSet.assert_valid_guidances immediate_guidances ;
             Helpers.call_api_functions ~__context (fun rpc session_id ->
                 Client.Client.Repository.apply ~rpc ~session_id ~host
             ) ;
-
-            (* TODO: absolute guidances *)
             Hashtbl.replace updates_in_cache host
               (`Assoc [("updates", `List [])]) ;
+            set_pending_guidances ~__context ~host ~guidances:pending_guidances ;
             immediate_guidances
     )
   with
@@ -613,9 +649,9 @@ let apply_updates ~__context ~host ~hash =
     when code <> Api_errors.internal_error ->
       raise e
   | e ->
-      let ref = Ref.string_of host in
-      error "applying updates on host ref='%s' failed: %s" ref
+      let host' = Ref.string_of host in
+      error "applying updates on host ref='%s' failed: %s" host'
         (ExnHelper.string_of_exn e) ;
-      raise Api_errors.(Server_error (apply_updates_failed, [ref]))
+      raise Api_errors.(Server_error (apply_updates_failed, [host']))
 
 let reset_updates_in_cache () = Hashtbl.clear updates_in_cache

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -941,7 +941,7 @@ let create ~__context ~uuid ~name_label ~name_description ~hostname ~address
         [0L]
       )
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
-    ~multipathing:false ~uefi_certificates:"" ~editions:[] ;
+    ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[] ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -381,10 +381,14 @@ let consider_enabling_host_nolock ~__context =
        		   letting a machine with no fencing touch any VMs. Once the host reboots we can safely clear
        		   the flag 'host_disabled_until_reboot' *)
     let pool = Helpers.get_pool ~__context in
+    Db.Host.remove_pending_guidances ~__context ~self:localhost
+      ~value:`restart_toolstack ;
     if !Xapi_globs.on_system_boot then (
       debug
         "Host.enabled: system has just restarted: setting localhost to enabled" ;
       Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
+      Db.Host.remove_pending_guidances ~__context ~self:localhost
+        ~value:`reboot_host ;
       update_allowed_operations ~__context ~self:localhost ;
       Localdb.put Constants.host_disabled_until_reboot "false" ;
       (* Start processing pending VM powercycle events *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -715,7 +715,7 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~snapshot_schedule:Ref.null ~is_vmss_snapshot:false ~appliance ~start_delay
     ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~requires_reboot:false
-    ~reference_label ~domain_type ;
+    ~reference_label ~domain_type ~pending_guidances:[] ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -391,7 +391,8 @@ let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~hardware_platform_version:all.Db_actions.vM_hardware_platform_version
     ~has_vendor_device:all.Db_actions.vM_has_vendor_device
     ~requires_reboot:false ~reference_label:all.Db_actions.vM_reference_label
-    ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM ;
+    ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM
+    ~pending_guidances:[] ;
   (* update the VM's parent field in case of snapshot. Note this must be done after "ref"
      	   has been created, so that its "children" field can be updated by the database layer *)
   ( match disk_op with

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -3413,7 +3413,8 @@ let set_resident_on ~__context ~self =
   refresh_vm ~__context ~self ;
   !trigger_xenapi_reregister () ;
   (* Any future XenAPI updates will trigger events, but we might have missed one so: *)
-  Xenopsd_metadata.update ~__context ~self
+  Xenopsd_metadata.update ~__context ~self ;
+  Db.VM.remove_pending_guidances ~__context ~self ~value:`restart_device_model
 
 let update_debug_info __context t =
   let task = Context.get_task_id __context in


### PR DESCRIPTION
There are two kinds of update guidances designed:
1. Recommended guidances: basically these guidances will be applied by
XAPI automatically after host being updated;
2. Absolute guidances: these guidances requires user to apply manually.

Both kinds of guidances look like: RebootHost, RestartToolstack, and
RestartDeviceModel.

This commit introduces function to add absolute guidances into
host.pending_guidances or VM.pending_guidances. In this way, users can
get to know the pending guidances need to be done by them manually.

Signed-off-by: Ming Lu <ming.lu@citrix.com>