### PR TITLE
CP-36090: Xapi tell plugin extauth_ad_backend type

### DIFF
--- a/ocaml/xapi/extauth.ml
+++ b/ocaml/xapi/extauth.ml
@@ -87,7 +87,7 @@ let get_event_params ~__context host =
   let service_name =
     Db.Host.get_external_auth_service_name ~__context ~self:host
   in
-  [("auth_type", auth_type); ("service_name", service_name)]
+  [("auth_type", auth_type); ("service_name", service_name); ("ad_backend", !Xapi_globs.extauth_ad_backend)]
 
 (* allows extauth hook script to be called only under specific conditions *)
 let can_execute_extauth_hook_script ~__context host event_name =


### PR DESCRIPTION
extauth_ad_backend is configurable and can be one of following
* pbis, older ad backend needs to be replaced
* winbind, samba solution to manage linux box with domain

Signed-off-by: Lin Liu <lin.liu@citrix.com>