### PR TITLE
CP-37014 verify TLS-based RPC before enabling it

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -988,14 +988,22 @@ functor
         Xapi_pool_helpers.with_pool_operation ~__context
           ~doc:"Pool.enable_tls_verification" ~self ~op:`tls_verification_enable
           (fun () ->
+            debug "Pool.enable_tls_verification start ... (1/2)" ;
             Cert_distrib.exchange_certificates_among_all_members ~__context ;
+            while Xapi_fist.pause_after_cert_exchange () do
+              debug "Pool.enable_tls_verification sleeping on fistpoint" ;
+              Thread.delay 5.0
+            done ;
             all_hosts
             |> List.iter (fun host ->
                    do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
                        Client.Pool.enable_tls_verification rpc session_id
-                   )
+                   ) ;
+                   debug "Pool.enable_tls_verification enabling on host %s"
+                     (Ref.string_of host)
                ) ;
-            Db.Pool.set_tls_verification_enabled ~__context ~self ~value:true
+            Db.Pool.set_tls_verification_enabled ~__context ~self ~value:true ;
+            debug "Pool.enable_tls_verification completed (2/2)"
         )
 
       let set_repositories ~__context ~self ~value =

--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -108,6 +108,8 @@ let storage_motion_keep_vdi () = fistpoint "storage_motion_keep_vdi"
 
 let delay_xenopsd_event_threads () = fistpoint "delay_xenopsd_event_threads"
 
+let pause_after_cert_exchange () = fistpoint "pause_after_cert_exchange"
+
 let hang_psr psr_checkpoint =
   ( match psr_checkpoint with
   | `backup ->

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3240,7 +3240,41 @@ let alert_failed_login_attempts () =
             ~body:stats
       )
 
+let perform ~local_fn ~__context ~host op =
+  let rpc' context hostname (task_opt : API.ref_task option) xml =
+    let open Xmlrpc_client in
+    let verify_cert = Some Stunnel.pool (* verify! *) in
+    let task_id = Option.map Ref.string_of task_opt in
+    let http = xmlrpc ?task_id ~version:"1.0" "/" in
+    let port = !Constants.https_port in
+    let transport = SSL (SSL.make ~verify_cert ?task_id (), hostname, port) in
+    XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
+  in
+  let open Message_forwarding in
+  do_op_on_common ~local_fn ~__context ~host op (call_slave_with_session rpc')
+
+(** [ping_with_tls_verification host] calls [Pool.is_slave] using a TLS
+connection that uses certficate checking. We ignore the result but are
+interested in any failures that would indicate connection problems,
+which would raise an exception. We can't use the standard
+[Message_forwarding.do_op_on_common] because certificate checking is not
+yet enabled. *)
+
+let ping_with_tls_verification ~__context host =
+  let local_fn = is_slave ~host in
+  let this_uuid = Helpers.get_localhost_uuid () in
+  let remote_uuid = Db.Host.get_uuid __context host in
+  info "pinging host before enabling TLS: %s -> %s" this_uuid remote_uuid ;
+  Server_helpers.exec_with_subtask ~__context "pool.ping" (fun ~__context ->
+      perform ~local_fn ~__context ~host (fun session_id rpc ->
+          Client.Pool.is_slave rpc session_id host
+      )
+  )
+  |> ignore
+
 let enable_tls_verification ~__context =
+  let hosts = Db.Host.get_all ~__context in
+  List.iter (ping_with_tls_verification ~__context) hosts ;
   Stunnel_client.set_verify_by_default true ;
   Helpers.touch_file Xapi_globs.verify_certificates_path
 

--- a/scripts/update-ca-bundle.sh
+++ b/scripts/update-ca-bundle.sh
@@ -12,16 +12,13 @@ regen_bundle () {
   mkdir -p "$CERTS_DIR"
   CERTS=$(find "$CERTS_DIR" -name '*.pem')
 
-  if [ -z "$CERTS" ]; then
-    echo "skipping $BUNDLE, no certs in $CERTS_DIR" 1>&2
-  else
-    rm -f "$BUNDLE.tmp"
-    for CERT in $CERTS; do
-      cat "$CERT" >> "$BUNDLE.tmp"
-      echo ""     >> "$BUNDLE.tmp"
-    done
-    mv "$BUNDLE.tmp" "$BUNDLE"
-  fi
+  rm -f "$BUNDLE.tmp"
+  touch "$BUNDLE.tmp"
+  for CERT in $CERTS; do
+    cat "$CERT" >> "$BUNDLE.tmp"
+    echo ""     >> "$BUNDLE.tmp"
+  done
+  mv "$BUNDLE.tmp" "$BUNDLE"
 }
 
 regen_bundle "/etc/stunnel/certs"      "/etc/stunnel/xapi-stunnel-ca-bundle.pem"


### PR DESCRIPTION
Before enabling certificate checking, check that all hosts can
communicate when using it. This is implemented in a ping call that uses
certificate checking before it is enabled by default. A host pings all
pool members and all hosts do this based on code in message_forwarding.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>