### PR TITLE
CA-354834 log ref, uuid when adding CA cert

### DIFF
--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -258,8 +258,7 @@ end = struct
                 )
             )
     in
-
-    Db.Certificate.destroy ~__context ~self
+    remove_cert_by_ref ~__context self
 end
 
 let local_list kind =


### PR DESCRIPTION
To track addition and removal of CA certificates, log the uuid and ref
under which it is added to the database.

This makes sure deletion by name is logged as well. It was missed in a previous patch.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>