### PR TITLE
CA-355179: Support epoch in RPM;CA-355180: Improve parsing output of 'yum list updates'

### DIFF
--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -68,25 +68,24 @@ module Pkg = struct
     let open Rresult.R.Infix in
     ( ( match Astring.String.cuts ~sep:":" epoch_ver_rel with
       | [e; vr] -> (
-        try Result.Ok (Epoch.of_string e, vr)
-        with _ -> Result.Error "Invalid epoch"
+        try Ok (Epoch.of_string e, vr) with _ -> Result.Error "Invalid epoch"
       )
       | [vr] ->
-          Result.Ok (None, vr)
+          Ok (None, vr)
       | _ ->
-          Result.Error "Invalid epoch:version-release"
+          Error "Invalid epoch:version-release"
       )
     >>= fun (e, vr) ->
       match Astring.String.cuts ~sep:"-" vr with
       | [v; r] ->
-          Result.Ok (e, v, r)
+          Ok (e, v, r)
       | _ ->
-          Result.Error "Invalid version-release"
+          Error "Invalid version-release"
     )
     |> function
-    | Result.Ok (e, v, r) ->
+    | Ok (e, v, r) ->
         (e, v, r)
-    | Result.Error msg ->
+    | Error msg ->
         let msg = error_msg epoch_ver_rel in
         error "%s" msg ;
         raise Api_errors.(Server_error (internal_error, [msg]))
@@ -207,20 +206,14 @@ module Update = struct
   let to_string u =
     Printf.sprintf "%s.%s %s:%s-%s -> %s:%s-%s from %s:%s" u.name u.arch
       ( match u.old_epoch with
-      | Some e -> (
-        match e with Some i -> string_of_int i | None -> Epoch.epoch_none
-      )
+      | Some e ->
+          Epoch.to_string e
       | None ->
           Epoch.epoch_none
       )
       (Option.value u.old_version ~default:"unknown")
       (Option.value u.old_release ~default:"unknown")
-      ( match u.new_epoch with
-      | Some i ->
-          string_of_int i
-      | None ->
-          Epoch.epoch_none
-      )
+      (Epoch.to_string u.new_epoch)
       u.new_version u.new_release
       (Option.value u.update_id ~default:"unknown")
       u.repository


### PR DESCRIPTION
    CA-355179: Support epoch in RPM

    This commit adds logic to support epoch in RPM packages.

    From https://rpm-packaging-guide.github.io/,  "the Epoch version would
    win out over the traditional Name-Version-Release marker that signifies
    versioning for RPM Packages."

    CA-355180: Improve parsing output of 'yum list updates'

    This commit improves the logic of parsing output of "yum list updates".
    Usually each line of the output would look like:
    "qemu-dp.x86_64                             2:2.12.0-2.0.11.xs8 local"
    But for some reason, it could be:
    "qemu-dp.x86_64
                                 2:2.12.0-2.0.11.xs8 local".
    This means one line can be separated by newline as well. This commit
    aims to handle these cases.