### PR TITLE
Build the doc-json target as part of the install target. Also:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ python:
 
 doc-json:
 	dune build --profile=$(PROFILE) ocaml/idl/json_backend/gen_json.exe
-	dune exec --profile=$(PROFILE) -- ocaml/idl/json_backend/gen_json.exe -destdir _build/install/default/jekyll
+	dune exec --profile=$(PROFILE) -- ocaml/idl/json_backend/gen_json.exe -destdir $(XAPIDOC)/jekyll
 
 format:
 	dune build @fmt --auto-promote
@@ -73,7 +73,7 @@ format:
 quality-gate:
 	./quality-gate.sh
 
-install: build doc sdk
+install: build doc sdk doc-json
 	mkdir -p $(DESTDIR)$(SBINDIR)
 	mkdir -p $(DESTDIR)$(OPTDIR)/bin
 	mkdir -p $(DESTDIR)$(MANDIR)
@@ -121,6 +121,7 @@ install: build doc sdk
 		xapi-client xapi-database xapi-consts xapi-cli-protocol xapi-datamodel xapi-types
 # docs
 	mkdir -p $(DESTDIR)$(DOCDIR)
+	cp -r $(XAPIDOC)/jekyll $(DESTDIR)$(DOCDIR)
 	cp -r $(XAPIDOC)/html $(DESTDIR)$(DOCDIR)
 	cp -r $(XAPIDOC)/markdown $(DESTDIR)$(DOCDIR)
 	cp $(XAPIDOC)/*.dot $(XAPIDOC)/doc-convert.sh $(DESTDIR)$(DOCDIR)

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -55,7 +55,6 @@ let rel_indigo = "indigo"
 let rel_dundee = "dundee"
 let rel_ely = "ely"
 let rel_falcon = "falcon"
-let rel_honolulu = "honolulu"
 let rel_inverness = "inverness"
 let rel_jura = "jura"
 let rel_kolkata = "kolkata"
@@ -210,12 +209,6 @@ let release_order_full = [{
      version_minor = 6;
      branding      = "XenServer 7.1";
      release_date  = Some "February 2017";
-   }; {
-     code_name     = Some rel_honolulu;
-     version_major = 2;
-     version_minor = 6;
-     branding      = "XenServer 7.1 CU1";
-     release_date  = Some "September 2017";
    }; {
      code_name     = Some rel_falcon;
      version_major = 2;

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -76,7 +76,7 @@ type api_release = {
 }
 
 (* When you add a new release, use the version number of the latest release, "Unreleased"
-   for the branding and None for the release date, until the actual values are finalised. *)
+   for the branding, and Some "" for the release date, until the actual values are finalised. *)
 
 let release_order_full = [{
     code_name     = Some rel_rio;
@@ -275,17 +275,17 @@ let release_order_full = [{
      version_major = 2;
      version_minor = 15;
      branding      = "Citrix Hypervisor 8.2 Hotfix 2";
-     release_date  = None;
+     release_date  = Some "November 2020";
    }; {
      code_name     = Some rel_next;
      version_major = 2;
      version_minor = 16;
      branding      = "Unreleased";
-     release_date  = None;
+     release_date  = Some ""; (* unknown date *)
    }
   ]
 (* When you add a new release, use the version number of the latest release, "Unreleased"
-   for the branding and None for the release date, until the actual values are finalised. *)
+   for the branding, and Some "" for the release date, until the actual values are finalised. *)
 
 let release_order =
   List.filter (fun x -> x.code_name <> None) release_order_full

--- a/ocaml/idl/json_backend/gen_json.ml
+++ b/ocaml/idl/json_backend/gen_json.ml
@@ -565,6 +565,8 @@ let _ =
   parse_args () ;
   let destdir = !destdir' in
   Xapi_stdext_unix.Unixext.mkdir_rec destdir 0o755 ;
+  let data_dir = Filename.concat destdir "_data" in
+  Xapi_stdext_unix.Unixext.mkdir_rec data_dir 0o755 ;
   let api = Datamodel.all_api in
   (* Add all implicit messages *)
   let api = add_implicit_messages api in
@@ -580,11 +582,11 @@ let _ =
   in
   let objs = objects_of_api api in
   Xapi_stdext_unix.Unixext.write_string_to_file
-    (Filename.concat destdir "xenapi.json")
+    (Filename.concat data_dir "xenapi.json")
     (objs |> json_of_objs |> string_of_json 0) ;
   let release_info = releases objs in
   Xapi_stdext_unix.Unixext.write_string_to_file
-    (Filename.concat destdir "release_info.json")
+    (Filename.concat data_dir "release_info.json")
     (string_of_json 0 release_info) ;
   let release_yaml = function
     | {release_date= None} ->
@@ -595,11 +597,11 @@ let _ =
         ""
   in
   Xapi_stdext_unix.Unixext.write_string_to_file
-    (Filename.concat destdir "releases.yml")
+    (Filename.concat data_dir "releases.yml")
     (release_order_full |> List.map release_yaml |> String.concat "") ;
-  let release_md_dir = Filename.concat destdir "releases" in
+  let release_md_dir = Filename.concat destdir "xen-api/releases" in
   Xapi_stdext_unix.Unixext.mkdir_rec release_md_dir 0o755 ;
-  let class_md_dir = Filename.concat destdir "classes" in
+  let class_md_dir = Filename.concat destdir "xen-api/classes" in
   Xapi_stdext_unix.Unixext.mkdir_rec class_md_dir 0o755 ;
   let release_md = function
     | {release_date= None} ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "87660671b559cb1cedd8b6f9acbf3b90"
+let last_known_schema_hash = "633a99b46dda090677598aad3a830f76"
 
 let current_schema_hash : string =
   let open Datamodel_types in


### PR DESCRIPTION
Restructured output so it's easier to drop it into xapi-project.github.io.
Added missing release date (or the release is not generated by gen-json.exe).