### PR TITLE
CP-36098 introduce host-refresh-server-certificates

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1029,6 +1029,14 @@ let host_query_ha = call ~flags:[`Session]
       ~allowed_roles:_R_READ_ONLY
       ()
 
+  let refresh_server_certificates = call
+      ~lifecycle:[Published, rel_next, ""]
+      ~name:"refresh_server_certificates"
+      ~doc:"Replace the self-signed certficates for the host with new ones."
+      ~params:[Ref _host, "host", "The host"]
+      ~allowed_roles:_R_POOL_ADMIN
+      ()
+
   let display =
     Enum ("host_display", [
         "enabled", "This host is outputting its console to a physical display device";
@@ -1544,6 +1552,7 @@ let host_query_ha = call ~flags:[`Session]
         crl_list;
         certificate_sync;
         get_server_certificate;
+        refresh_server_certificates;
         install_server_certificate;
         emergency_reset_server_certificate;
         reset_server_certificate;

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3071,6 +3071,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Host_selectors]
       }
     )
+  ; ( "host-refresh-server-certificates"
+    , {
+        reqd= []
+      ; optn= ["host-uuid"]
+      ; help= "Refresh server certificate on host with local host as default"
+      ; implementation= No_fd Cli_operations.host_refresh_server_certificates
+      ; flags= [Host_selectors]
+      }
+    )
   ; ( "host-server-certificate-install"
     , {
         reqd= ["certificate"; "private-key"]

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3074,7 +3074,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "host-refresh-server-certificates"
     , {
         reqd= []
-      ; optn= ["host-uuid"]
+      ; optn= []
       ; help= "Refresh server certificate on host with local host as default"
       ; implementation= No_fd Cli_operations.host_refresh_server_certificates
       ; flags= [Host_selectors]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3504,6 +3504,16 @@ let host_get_server_certificate printer rpc session_id params =
        params []
     )
 
+let host_refresh_server_certificates printer rpc session_id params =
+  ignore
+    (do_host_op rpc session_id ~multiple:false
+       (fun _ host ->
+         let host = host.getref () in
+         Client.Host.refresh_server_certificates rpc session_id host
+         )
+       params []
+    )
+
 let host_install_server_certificate fd printer rpc session_id params =
   let certificate =
     List.assoc "certificate" params |> get_file_or_fail fd "certificate"

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -438,11 +438,10 @@ let hostnames_of_pem_cert pem =
   >>| X509.Certificate.hostnames
 
 let install_server_certificate ?(pem_chain = None) ~pem_leaf ~pkcs8_private_key
-    =
-  let server_cert_path = !Xapi_globs.server_cert_path in
+    ~path =
   let installation =
     Gencertlib.Lib.install_server_certificate ~pem_chain ~pem_leaf
-      ~pkcs8_private_key ~server_cert_path
+      ~pkcs8_private_key ~server_cert_path:path
   in
   match installation with
   | Ok cert ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3540,6 +3540,25 @@ functor
             Client.Host.get_server_certificate rpc session_id host
         )
 
+      let refresh_server_certificates ~__context ~host =
+        info "Host.refresh_server_certificates: host = '%s'"
+          (host_uuid ~__context host) ;
+        let local_fn = Local.Host.refresh_server_certificates ~host in
+        let other =
+          Db.Host.get_all ~__context |> List.filter (fun h -> h <> host)
+        in
+        (* let host refresh its certificates first *)
+        do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
+            Client.Host.refresh_server_certificates rpc session_id host
+        ) ;
+        (* update all other hosts in the pool *)
+        other
+        |> List.iter (fun h ->
+               do_op_on ~local_fn ~__context ~host:h (fun session_id rpc ->
+                   Client.Host.refresh_server_certificates rpc session_id host
+               )
+           )
+
       let _success ~__context () =
         let task = Context.get_task_id __context in
         let progress = Db.Task.get_progress ~__context ~self:task in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1448,6 +1448,18 @@ let certificate_sync ~__context ~host = Certificates.local_sync ()
 let get_server_certificate ~__context ~host =
   Certificates.get_server_certificate ()
 
+let refresh_server_certificates ~__context ~host =
+  (* we need to do different things depending on whether we
+     refresh the certificates on this host or whether they were
+     refreshed on another host in the pool *)
+  let localhost = Helpers.get_localhost ~__context in
+  match host with
+  | host when host = localhost ->
+      debug "Host.refresh_server_certificates - refresh this host"
+  | host ->
+      debug "Host.refresh_server_certificates - other host %s was refrehsed"
+        (Ref.string_of host)
+
 let with_cert_lock : (unit -> 'a) -> 'a =
   let cert_m = Mutex.create () in
   Mutex.execute cert_m

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1528,7 +1528,7 @@ let refresh_my_cert ~__context ~type' =
   in
   let dbg = Context.string_of_task __context in
   let write_cert_fs () = _new_host_cert ~dbg ~path in
-  replace_host_certificate ~__context ~type':`host ~host write_cert_fs
+  replace_host_certificate ~__context ~type' ~host write_cert_fs
 
 let refresh_server_certificates ~__context ~host =
   (* we need to do different things depending on whether we

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1488,17 +1488,17 @@ let install_server_certificate ~__context ~host ~certificate ~private_key
     ~certificate_chain =
   if Db.Pool.get_ha_enabled ~__context ~self:(Helpers.get_pool ~__context) then
     raise Api_errors.(Server_error (ha_is_enabled, [])) ;
+  let path = !Xapi_globs.server_cert_path in
   let write_cert_fs () =
     let pem_chain =
       match certificate_chain with "" -> None | pem_chain -> Some pem_chain
     in
     Certificates.install_server_certificate ~pem_leaf:certificate
-      ~pkcs8_private_key:private_key ~pem_chain
+      ~pkcs8_private_key:private_key ~pem_chain ~path
   in
   replace_host_certificate ~__context ~type':`host ~host write_cert_fs
 
-let _new_host_cert ~dbg : X509.Certificate.t =
-  let xapi_ssl_pem = !Xapi_globs.server_cert_path in
+let _new_host_cert ~dbg ~path : X509.Certificate.t =
   let name, ip =
     match Networking_info.get_management_ip_addr ~dbg with
     | None ->
@@ -1510,16 +1510,18 @@ let _new_host_cert ~dbg : X509.Certificate.t =
   in
   let dns_names = Networking_info.dns_names () in
   let ips = [ip] in
-  Gencertlib.Selfcert.host ~name ~dns_names ~ips xapi_ssl_pem
+  Gencertlib.Selfcert.host ~name ~dns_names ~ips path
 
 let reset_server_certificate ~__context ~host =
   let dbg = Context.string_of_task __context in
-  let write_cert_fs () = _new_host_cert ~dbg in
+  let path = !Xapi_globs.server_cert_path in
+  let write_cert_fs () = _new_host_cert ~dbg ~path in
   replace_host_certificate ~__context ~type':`host ~host write_cert_fs
 
 let emergency_reset_server_certificate ~(__context : 'a) =
+  let path = !Xapi_globs.server_cert_path in
   let (_ : X509.Certificate.t) =
-    _new_host_cert ~dbg:"emergency_reset_certificate"
+    _new_host_cert ~dbg:"emergency_reset_certificate" ~path
   in
   ()
 

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -291,6 +291,9 @@ val certificate_sync : __context:'a -> host:'b -> unit
 
 val get_server_certificate : __context:'a -> host:'b -> string
 
+val refresh_server_certificates :
+  __context:Context.t -> host:[`host] Ref.t -> unit
+
 val install_server_certificate :
      __context:Context.t
   -> host:[`host] Ref.t


### PR DESCRIPTION
Some initial scaffolding and code to refresh a host certificate. I believe the current approach can't work because we can't atomically update a server certificate and make all pool members trust it.
