### PR TITLE
ci: build the sdk when running the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,12 @@ jobs:
       - name: Run tests
         run: opam exec -- make test
 
+      - name: Build SDK
+        run: |
+          mkdir -p /opt/xensource/sm
+          wget -O /opt/xensource/sm/XE_SR_ERRORCODES.xml https://raw.githubusercontent.com/xapi-project/sm/master/drivers/XE_SR_ERRORCODES.xml
+          opam exec -- make sdk
+
       - name: Uninstall unversioned packages and remove pins
         # This should purge them from the cache, unversioned package have
         # 'master' as its version

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ scripts/examples/python/setup.py
 scripts/examples/python/XenAPI.egg-info/
 scripts/examples/python/build/
 scripts/examples/python/dist/
+
+# ignore file needed for building the SDK
+ocaml/sdk-gen/csharp/XE_SR_ERRORCODES.xml


### PR DESCRIPTION
The xml file is fetched straight from the SM master branch and it's placed where the makefile expects it