### PR TITLE
Fix SDK build

### DIFF
--- a/ocaml/sdk-gen/c/gen_c_binding.ml
+++ b/ocaml/sdk-gen/c/gen_c_binding.ml
@@ -1339,6 +1339,10 @@ and c_type_of_ty needed record = function
   | Set String ->
       needed := StringSet.add "string_set" !needed ;
       "struct xen_string_set *"
+  | Set (Set String) ->
+      (* TODO: implement this new type correctly *)
+      needed := StringSet.add "string_set" !needed ;
+      "struct xen_string_set *"
   | Set (Record n) ->
       needed := StringSet.add (n ^ "_decl") !needed ;
       sprintf "struct %s_set *" (record_typename n)

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -1255,6 +1255,9 @@ and exposed_type = function
       "long[]"
   | Set String ->
       "string[]"
+  | Set (Set String) ->
+      (* TODO: implement this new type correctly *)
+      "string[]"
   | Enum (name, _) as x ->
       enums := TypeSet.add x !enums ;
       name
@@ -1415,6 +1418,9 @@ and simple_convert_from_proxy thing ty =
   | SecretString | String ->
       thing
   | Set String ->
+      sprintf "(string [])%s" thing
+  | Set (Set String) ->
+      (* TODO: implement this new type correctly *)
       sprintf "(string [])%s" thing
   | Set (Ref name) ->
       sprintf "XenRef<%s>.Create(%s)" (exposed_class_name name) thing

--- a/ocaml/sdk-gen/powershell/common_functions.ml
+++ b/ocaml/sdk-gen/powershell/common_functions.ml
@@ -167,6 +167,9 @@ and exposed_type = function
       "long[]"
   | Set String ->
       "string[]"
+  | Set (Set String) ->
+      (* TODO: implement this new type correctly *)
+      "string[]"
   | Enum (name, _) ->
       name
   | Map (u, v) ->


### PR DESCRIPTION
Commit 63cbb1d8 introduced a function in the datamodel that has a
return type `Set (Set String)`, which is a valid datamodel type, but
it is not yet recognised by the API bindings (SDK).

This patch just adds match cases to the code generators, such that
`make sdk` does not fail. This will need a follow-up patch to correctly
handle unmarshalling for the type.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>