### PR TITLE
CA-355571: Include accumulative updates for updates description and guidances

### DIFF
--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -347,8 +347,27 @@ module GuidanceSetAssertValidGuidanceTest = Generic.MakeStateless (struct
       ; ([EvacuateHost], Ok ())
       ; ([EvacuateHost; RestartToolstack], Ok ())
       ; ([RestartDeviceModel; RestartToolstack], Ok ())
-      ; ([RestartDeviceModel; EvacuateHost], Ok ())
-      ; ([EvacuateHost; RestartToolstack; RestartDeviceModel], Ok ())
+      ; ( [RestartDeviceModel; EvacuateHost]
+        , Error
+            Api_errors.(
+              Server_error
+                ( internal_error
+                , [GuidanceSet.error_msg [RestartDeviceModel; EvacuateHost]]
+                )
+            )
+        )
+      ; ( [EvacuateHost; RestartToolstack; RestartDeviceModel]
+        , Error
+            Api_errors.(
+              Server_error
+                ( internal_error
+                , [
+                    GuidanceSet.error_msg
+                      [EvacuateHost; RestartToolstack; RestartDeviceModel]
+                  ]
+                )
+            )
+        )
       ; ( [RebootHost; RestartToolstack]
         , Error
             Api_errors.(

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -537,7 +537,6 @@ let restart_device_models ~__context ~host =
 let apply_immediate_guidances ~__context ~host ~guidances =
   (* This function runs on master host *)
   try
-    let num_of_hosts = List.length (Db.Host.get_all ~__context) in
     let open Client in
     Helpers.call_api_functions ~__context (fun rpc session_id ->
         let open Guidance in
@@ -561,16 +560,6 @@ let apply_immediate_guidances ~__context ~host ~guidances =
         | l when GuidanceSet.eq_set2 l ->
             (* RestartDeviceModel and RestartToolstack *)
             restart_device_models ~__context ~host ;
-            Client.Host.restart_agent ~rpc ~session_id ~host
-        | l when GuidanceSet.eq_set3 l ->
-            (* RestartDeviceModel and EvacuateHost *)
-            (* Evacuating host restarted device models already *)
-            if num_of_hosts = 1 then restart_device_models ~__context ~host ;
-            ()
-        | l when GuidanceSet.eq_set4 l ->
-            (* EvacuateHost, RestartToolstack and RestartDeviceModel *)
-            (* Evacuating host restarted device models already *)
-            if num_of_hosts = 1 then restart_device_models ~__context ~host ;
             Client.Host.restart_agent ~rpc ~session_id ~host
         | l ->
             let host' = Ref.string_of host in

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -68,7 +68,7 @@ module Pkg = struct
     let open Rresult.R.Infix in
     ( ( match Astring.String.cuts ~sep:":" epoch_ver_rel with
       | [e; vr] -> (
-        try Ok (Epoch.of_string e, vr) with _ -> Result.Error "Invalid epoch"
+        try Ok (Epoch.of_string e, vr) with _ -> Error "Invalid epoch"
       )
       | [vr] ->
           Ok (None, vr)


### PR DESCRIPTION
CA-355571: Include accumulative updates for updates description and guidances

When applying updates on a host, there are 2 parts would be considered:
1. Latest updates, which include binary RPM packages to be installed.
The 'yum list updates' will get these RPM packages;
2. Accumulative updates. Some of these updates may be overrided by the
latest updates. These can be get from 'yum updateinfo list updates'.

E.g. pkg-a-1.0.0-r1.x86_64 has been installed on a host. There is an
update pkg-a-1.0.1-r1.x86_64 which is included in update-1. But this
update-1 has not been applied by user. Now there is another update-2
with pkg-a-1.0.2-r1.x86_64. In this case, the latest update is update-2
(pkg-a-1.0.2-r1.x86_64), the accumulative updates are update-1 and
update-2.

With this commit, the metadata (summary, description) of all
accumulative updates are included in overall update information; and
guidances of all accumulative updates are evaluated as well.
But the RPM packages to be installed are still from latest updates.


CA-355571: Refine precedence between guidances

This commit aims to refine the precedence between guidances as:
RestartToolstack < RebootHost
EvacuateHost < RebootHost
RestartDeviceModel < RebootHost
RestartDeviceModel < EvacuateHost

This implies following as well:
EvacauteHost and RestartToolstack can be presented together;
RestartDeviceModel and RestartToolstack can be presented together.