### PR TITLE
REQ-403 concurrency fixes part 2

### DIFF
--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -220,11 +220,7 @@ end = struct
       D.debug "write_certs_fs: ignoring failed to remove %s. exception: %s"
         pool_certs_bk (Printexc.to_string e)
 
-  let regen_bundle () =
-    ignore
-      (Forkhelpers.execute_command_get_output
-         "/opt/xensource/bin/update-ca-bundle.sh" []
-      )
+  let regen_bundle () = Helpers.update_ca_bundle ()
 
   let restart_stunnel ~__context =
     Xapi_mgmt_iface.reconfigure_stunnel ~__context

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -69,11 +69,7 @@ let rehash () =
   rehash' (library_path CA_Certificate) ;
   rehash' (library_path CRL)
 
-let update_ca_bundle () =
-  ignore
-    (Forkhelpers.execute_command_get_output
-       "/opt/xensource/bin/update-ca-bundle.sh" []
-    )
+let update_ca_bundle () = Helpers.update_ca_bundle ()
 
 let to_string = function CA_Certificate -> "CA certificate" | CRL -> "CRL"
 

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -2080,3 +2080,18 @@ end = struct
       error "redirect: failed to write to %s" fname ;
       raise e
 end
+
+let update_ca_bundle =
+  (* it is not safe for multiple instances of this bash script to be
+   * running at the same time, so we must lock it.
+   *
+   * NB: we choose not to implement the lock inside the bash script
+   * itself *)
+  let m = Mutex.create () in
+  fun () ->
+    Mutex.execute m (fun () ->
+        ignore
+          (Forkhelpers.execute_command_get_output
+             "/opt/xensource/bin/update-ca-bundle.sh" []
+          )
+    )


### PR DESCRIPTION
update_ca_bundle.sh is not thread safe because it manipulates files in
/etc/stunnel. We only allow one instance to be running at once.