### PR TITLE
REQ-403 concurrency fixes part 3

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1467,6 +1467,19 @@ let host_query_ha = call ~flags:[`Session]
     ~allowed_roles:_R_POOL_ADMIN
     ()
 
+  let copy_primary_host_certs = call
+    ~name:"copy_primary_host_certs"
+    ~in_oss_since:None
+    ~in_product_since:rel_next
+    ~doc:"useful for secondary hosts that are missing some certs"
+    ~params:[
+      Ref _host, "host", "this host receives a copy of the primary host's trusted certificates";
+    ]
+    ~allowed_roles:_R_POOL_ADMIN
+    ~hide_from_docs:true
+    ~pool_internal:true
+    ()
+
   (** Hosts *)
   let t =
     create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303 ~internal_deprecated_since:None ~persist:PersistEverything ~gen_constructor_destructor:false ~name:_host ~descr:"A physical host" ~gen_events:true
@@ -1596,6 +1609,7 @@ let host_query_ha = call ~flags:[`Session]
         emergency_reenable_tls_verification;
         cert_distrib_atom;
         apply_updates;
+        copy_primary_host_certs;
       ]
       ~contents:
         ([ uid _host;

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -1,4 +1,5 @@
 module Unixext = Xapi_stdext_unix.Unixext
+module StringSet = Set.Make (String)
 
 module D = Debug.Make (struct let name = "cert_distrib" end)
 
@@ -103,8 +104,10 @@ module HostPoolProvider = struct
 
   let store_path = !Xapi_globs.trusted_pool_certs_dir
 
+  let cert_fname_of_host_uuid uuid = uuid ^ ".pem"
+
   let certificate_of_id_content uuid content =
-    WireProtocol.{filename= uuid ^ ".pem"; content}
+    WireProtocol.{filename= cert_fname_of_host_uuid uuid; content}
 
   let read_certificate uuid =
     let open Gencertlib.Pem in
@@ -117,6 +120,8 @@ module HostPoolProvider = struct
         certificate_of_id_content uuid host_cert
 end
 
+let string_of_file path = Unixext.read_lines path |> String.concat "\n"
+
 module ApplianceProvider = struct
   let store_path = !Xapi_globs.trusted_certs_dir
 
@@ -124,10 +129,7 @@ module ApplianceProvider = struct
     WireProtocol.{filename; content}
 
   let read_certificate filename =
-    let content =
-      Unixext.read_lines (Filename.concat store_path filename)
-      |> String.concat "\n"
-    in
+    let content = string_of_file (Filename.concat store_path filename) in
     certificate_of_id_content filename content
 end
 
@@ -394,6 +396,81 @@ let exchange_certificates_among_all_members ~__context =
   List.iter
     (fun host -> Worker.remote_regen_bundle host rpc session_id)
     all_hosts
+
+let ( (get_local_ca_certs : unit -> WireProtocol.certificate_file list)
+    , (get_local_pool_certs : unit -> WireProtocol.certificate_file list) ) =
+  let g path () =
+    (* collects all certs in [path] ending in "pem". this is equivalent to the
+     * certs that would be put in a bundle, if update-ca-bundle.sh were to be
+     * executed on [path] *)
+    Sys.readdir path
+    |> Array.to_list
+    |> List.filter (Fun.flip Filename.check_suffix "pem")
+    |> List.map (fun filename ->
+           let path = Filename.concat path filename in
+           let content = string_of_file path in
+           WireProtocol.{filename; content}
+       )
+  in
+  (g ApplianceProvider.store_path, g HostPoolProvider.store_path)
+
+let am_i_missing_certs ~__context : bool =
+  (* compare what's in the database with what's on my filesystem *)
+  let f exp_fnames ac_dir () =
+    let exp = exp_fnames ~__context |> StringSet.of_list in
+    let ac = Sys.readdir ac_dir |> Array.to_seq |> StringSet.of_seq in
+    let diff = StringSet.diff exp ac in
+    if StringSet.is_empty diff then
+      false
+    else (
+      D.warn
+        "am_i_missing_certs: expected to see the following certs in %s but did \
+         not: [ %s ]"
+        ac_dir
+        (diff |> StringSet.elements |> String.concat "; ") ;
+      true
+    )
+  in
+  let missing_pool_certs =
+    f
+      (fun ~__context ->
+        Db.Host.get_all ~__context
+        |> List.map (fun self -> Db.Host.get_uuid ~__context ~self)
+        |> List.map HostPoolProvider.cert_fname_of_host_uuid
+        )
+      HostPoolProvider.store_path
+  in
+  let missing_ca_certs =
+    f
+      (fun ~__context ->
+        Db.Certificate.get_all ~__context
+        |> List.filter_map (fun self ->
+               match Db.Certificate.get_type ~__context ~self with
+               | `ca ->
+                   Some (Db.Certificate.get_name ~__context ~self)
+               | _ ->
+                   None
+           )
+        )
+      ApplianceProvider.store_path
+  in
+  missing_pool_certs () || missing_ca_certs ()
+
+let copy_certs_to_host ~__context ~host =
+  lock @@ fun () ->
+  D.debug "copy_certs_to_host: sending my certs to host %s"
+    (Ref.short_string_of host) ;
+  if am_i_missing_certs ~__context then
+    D.error
+      "i have been asked to copy my certs to %s but i myself am missing \
+       certs... this is bad, but continuing anyway"
+      (Ref.short_string_of host) ;
+  Helpers.call_api_functions ~__context @@ fun rpc session_id ->
+  Worker.remote_write_certs_fs HostPoolCertificate Erase_old
+    (get_local_pool_certs ()) host rpc session_id ;
+  Worker.remote_write_certs_fs ApplianceCertificate Erase_old
+    (get_local_ca_certs ()) host rpc session_id ;
+  Worker.remote_regen_bundle host rpc session_id
 
 let import_joiner ~__context ~uuid ~certificate ~to_hosts =
   let joiner_certificate =

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -6,6 +6,12 @@ val exchange_certificates_among_all_members : __context:Context.t -> unit
     certificates from all members in a pool and installed on all of them. On
     success, new bundles will have been generated on the members. *)
 
+val am_i_missing_certs : __context:Context.t -> bool
+
+val copy_certs_to_host : __context:Context.t -> host:API.ref_host -> unit
+(** [copy_certs_to_host ~__context ~host] collects all local certificates and
+    installs them on [host] *)
+
 val exchange_certificates_with_joiner :
      __context:Context.t
   -> uuid:string

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3663,6 +3663,10 @@ functor
             Client.Host.cert_distrib_atom ~rpc ~session_id ~host ~command
         )
 
+      let copy_primary_host_certs ~__context ~host =
+        info "Host.copy_primary_host_certs host = '%s'" (Ref.string_of host) ;
+        Local.Host.copy_primary_host_certs ~__context ~host
+
       let attach_static_vdis ~__context ~host ~vdi_reason_map =
         info "Host.attach_static_vdis: host = '%s'; vdi/reason pairs = [ %s ]"
           (host_uuid ~__context host)

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -279,23 +279,47 @@ let on_master_restart ~__context =
   debug
     "attempting to set Host_metrics.live to true immediately (unless I'm in \
      the middle of shutting myself down)" ;
-  try
-    let host = Helpers.get_localhost ~__context in
-    let metrics = Db.Host.get_metrics ~__context ~self:host in
-    let shutting_down =
-      Mutex.execute Xapi_globs.hosts_which_are_shutting_down_m (fun () ->
-          List.exists
-            (fun x -> x = host)
-            !Xapi_globs.hosts_which_are_shutting_down
+  ( try
+      let host = Helpers.get_localhost ~__context in
+      let metrics = Db.Host.get_metrics ~__context ~self:host in
+      let shutting_down =
+        Mutex.execute Xapi_globs.hosts_which_are_shutting_down_m (fun () ->
+            List.exists
+              (fun x -> x = host)
+              !Xapi_globs.hosts_which_are_shutting_down
+        )
+      in
+      if not shutting_down then
+        Db.Host_metrics.set_live ~__context ~self:metrics ~value:true
+    with e ->
+      debug
+        "failed to set Host_metrics.live to true immediately; will have to \
+         wait for regular heartbeat to arrive: %s"
+        (ExnHelper.string_of_exn e)
+  ) ;
+  let am_i_missing_certs () =
+    let open Helpers in
+    let module Client = Client.Client in
+    try
+      if
+        Db.Pool.get_tls_verification_enabled ~__context
+          ~self:(get_pool ~__context)
+        && Cert_distrib.am_i_missing_certs ~__context
+      then (
+        D.debug
+          "am_i_missing_certs: i am missing certs! asking primary host to send \
+           us its certs" ;
+        let host = get_localhost ~__context in
+        call_api_functions ~__context @@ fun rpc session_id ->
+        Client.Host.copy_primary_host_certs ~rpc ~session_id ~host ;
+        D.debug
+          "am_i_missing_certs: successfully copied certs from primary host!"
       )
-    in
-    if not shutting_down then
-      Db.Host_metrics.set_live ~__context ~self:metrics ~value:true
-  with e ->
-    debug
-      "failed to set Host_metrics.live to true immediately; will have to wait \
-       for regular heartbeat to arrive: %s"
-      (ExnHelper.string_of_exn e)
+    with e ->
+      D.error "am_i_missing_certs: exception (ignoring): %s"
+        (Printexc.to_string e)
+  in
+  am_i_missing_certs ()
 
 (* Make sure the local database can be read *)
 let init_local_database () =
@@ -844,29 +868,6 @@ let init_tls_verification () =
       info "TLS verification is enabled: %s" file ;
       Stunnel_client.set_verify_by_default true
 
-let am_i_missing_certs_loop ~__context () =
-  let open Helpers in
-  let module Client = Client.Client in
-  let delay = 10.0 in
-  let inner () =
-    try
-      if
-        Db.Pool.get_tls_verification_enabled ~__context
-          ~self:(get_pool ~__context)
-        && Cert_distrib.am_i_missing_certs ~__context
-      then (
-        D.debug "am_i_missing_certs_loop: i am missing certs!" ;
-        let host = get_localhost ~__context in
-        call_api_functions ~__context @@ fun rpc session_id ->
-        Client.Host.copy_primary_host_certs ~rpc ~session_id ~host
-      )
-    with e ->
-      D.error "am_i_missing_certs_loop: exception (ignoring and continuing): %s"
-        (Printexc.to_string e)
-  in
-  let rec loop () = inner () ; Thread.delay delay ; (loop [@tailcall]) () in
-  loop ()
-
 let server_init () =
   let print_server_starting_message () =
     debug "(Re)starting xapi" ;
@@ -1162,10 +1163,6 @@ let server_init () =
         Startup.run ~__context
           [
             ("Checking emergency network reset", [], check_network_reset)
-          ; ( "am i missing certs thread"
-            , [Startup.OnlySlave; Startup.OnThread]
-            , am_i_missing_certs_loop ~__context
-            )
           ; ( "Upgrade bonds to Boston"
             , [Startup.NoExnRaising]
             , Sync_networking.fix_bonds ~__context

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2673,6 +2673,8 @@ let alert_if_tls_verification_was_emergency_disabled ~__context =
 let cert_distrib_atom ~__context ~host ~command =
   Cert_distrib.local_exec ~__context ~command
 
+let copy_primary_host_certs = Cert_distrib.copy_certs_to_host
+
 let get_host_updates_handler (req : Http.Request.t) s _ =
   let uuid = Helpers.get_localhost_uuid () in
   debug

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -528,3 +528,5 @@ val get_host_updates_handler : Http.Request.t -> Unix.file_descr -> 'a -> unit
 
 val apply_updates :
   __context:Context.t -> self:API.ref_host -> hash:string -> unit
+
+val copy_primary_host_certs : __context:Context.t -> host:API.ref_host -> unit


### PR DESCRIPTION
This fixes parallel pool joins

The idea is that the joiners only exchanges certs with the primary host during Pool.join. The secondary hosts will get joiners' certificates because of `am_i_missing_certs_loop`