### PR TITLE
CA-355964: Hostname change will affect the authentication

### DIFF
--- a/ocaml/tests/test_extauth_plugin_ADwinbind.ml
+++ b/ocaml/tests/test_extauth_plugin_ADwinbind.ml
@@ -84,6 +84,7 @@ module ParseValueFromPbis = Generic.MakeStateless (struct
       [
         ( "X'58005200540055004B002D00300032002D003000330024000000'"
         , "XRTUK-02-03" )
+      ; ("X'4C004F00430041004C0048004F0053005400320024000000'", "LOCALHOST2")
       ]
 end)
 

--- a/ocaml/tests/test_extauth_plugin_ADwinbind.ml
+++ b/ocaml/tests/test_extauth_plugin_ADwinbind.ml
@@ -41,6 +41,50 @@ module ExtractOuConfig = Generic.MakeStateless (struct
       ]
 end)
 
+module Range = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = int * int * int
+
+    type output_t = int list
+
+    let string_of_input_t (x, y, z) = Printf.sprintf "%d , %d, %d" x y z
+
+    let string_of_output_t = Test_printers.(list int)
+  end
+
+  let transform (s, e, step) = Extauth_plugin_ADwinbind.range s e step
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        ((0, 10, 1), [0; 1; 2; 3; 4; 5; 6; 7; 8; 9])
+      ; ((0, 1, 1), [0])
+      ; ((0, 0, 1), [])
+      ; ((1, 0, 1), [])
+      ]
+end)
+
+module ParseValueFromPbis = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = string
+
+    type output_t = string
+
+    let string_of_input_t = Test_printers.(string)
+
+    let string_of_output_t = Test_printers.(string)
+  end
+
+  let transform s = Extauth_plugin_ADwinbind.parse_value_from_pbis s
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        ( "X'58005200540055004B002D00300032002D003000330024000000'"
+        , "XRTUK-02-03" )
+      ]
+end)
+
 let test_domainify_uname =
   let open Extauth_plugin_ADwinbind in
   let check uname exp () =
@@ -349,6 +393,8 @@ let test_wbinfo_exception_of_stderr =
 let tests =
   [
     ("ADwinbind:extract_ou_config", ExtractOuConfig.tests)
+  ; ("ADwinbind:test_range", Range.tests)
+  ; ("ADwinbind:test_parse_value_from_pbis", ParseValueFromPbis.tests)
   ; ("ADwinbind:test_domainify_uname", test_domainify_uname)
   ; ("ADwinbind:test_parse_wbinfo_uid_info", test_parse_wbinfo_uid_info)
   ; ("ADwinbind:test_parse_ldap_stdout", test_parse_ldap_stdout)

--- a/ocaml/tests/test_extauth_plugin_ADwinbind.ml
+++ b/ocaml/tests/test_extauth_plugin_ADwinbind.ml
@@ -52,7 +52,8 @@ module Range = Generic.MakeStateless (struct
     let string_of_output_t = Test_printers.(list int)
   end
 
-  let transform (s, e, step) = Extauth_plugin_ADwinbind.range s e step
+  let transform (s, e, step) =
+    Extauth_plugin_ADwinbind.Migrate_from_pbis.range s e step
 
   let tests =
     `QuickAndAutoDocumented
@@ -75,7 +76,8 @@ module ParseValueFromPbis = Generic.MakeStateless (struct
     let string_of_output_t = Test_printers.(string)
   end
 
-  let transform s = Extauth_plugin_ADwinbind.parse_value_from_pbis s
+  let transform s =
+    Extauth_plugin_ADwinbind.Migrate_from_pbis.parse_value_from_pbis s
 
   let tests =
     `QuickAndAutoDocumented

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -58,7 +58,7 @@ let wb_cmd = !Xapi_globs.wb_cmd
 
 let tdb_tool = !Xapi_globs.tdb_tool
 
-let debug_level = !Xapi_globs.winbind_debug_level |> string_of_int
+let debug_level () = !Xapi_globs.winbind_debug_level |> string_of_int
 
 let ntlm_auth uname passwd : (unit, exn) result =
   try
@@ -181,7 +181,7 @@ module Ldap = struct
 
   let net_ads (sid : string) : (string, exn) result =
     try
-      let args = ["ads"; "sid"; "-d"; debug_level; "--machine-pass"; sid] in
+      let args = ["ads"; "sid"; "-d"; debug_level (); "--machine-pass"; sid] in
       let stdout =
         Helpers.call_script ~log_output:On_failure !Xapi_globs.net_cmd args
       in
@@ -191,7 +191,9 @@ module Ldap = struct
   let query_user sid =
     let* stdout =
       try
-        let args = ["ads"; "sid"; "-d"; debug_level; "--machine-pass"; sid] in
+        let args =
+          ["ads"; "sid"; "-d"; debug_level (); "--machine-pass"; sid]
+        in
         let stdout =
           Helpers.call_script ~log_output:On_failure !Xapi_globs.net_cmd args
         in
@@ -459,7 +461,7 @@ let query_domain_workgroup ~domain ~db_workgroup =
       try
         let kdc =
           Helpers.call_script ~log_output:On_failure net_cmd
-            ["lookup"; "kdc"; domain; "-d"; debug_level]
+            ["lookup"; "kdc"; domain; "-d"; debug_level ()]
           (* Result like 10.71.212.25:88\n10.62.1.25:88\n*)
           |> String.split_on_char '\n'
           |> hd "lookup kdc return invalid result"
@@ -469,7 +471,7 @@ let query_domain_workgroup ~domain ~db_workgroup =
 
         let lines =
           Helpers.call_script ~log_output:On_failure net_cmd
-            ["ads"; "lookup"; "-S"; kdc; "-d"; debug_level]
+            ["ads"; "lookup"; "-S"; kdc; "-d"; debug_level ()]
         in
         match Xapi_cmd_result.of_output_opt ~sep:':' ~key ~lines with
         | Some v ->
@@ -501,7 +503,7 @@ let config_winbind_damon ~domain ~workgroup ~netbios_name =
       ; "idmap config * : range = 3000000-3999999"
       ; Printf.sprintf "idmap config %s: backend = rid" domain
       ; Printf.sprintf "idmap config %s: range = 2000000-2999999" domain
-      ; Printf.sprintf "log level = %s" debug_level
+      ; Printf.sprintf "log level = %s" (debug_level ())
       ; "idmap config * : backend = tdb"
       ; "" (* Empty line at the end *)
       ]
@@ -578,7 +580,7 @@ let disable_machine_account ~service_name = function
       (* Disable machine account in DC *)
       let env = [|Printf.sprintf "PASSWD=%s" p|] in
       let args =
-        ["ads"; "leave"; "-U"; u; "--keep-account"; "-d"; debug_level]
+        ["ads"; "leave"; "-U"; u; "--keep-account"; "-d"; debug_level ()]
       in
       try
         Helpers.call_script ~env net_cmd args |> ignore ;
@@ -914,7 +916,7 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
       ; "-n"
       ; netbios_name
       ; "-d"
-      ; debug_level
+      ; debug_level ()
       ; "--no-dns-updates"
       ]
       @ ou_param

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -643,7 +643,9 @@ module Winbind = struct
   let migrate_netbios_name ~__context =
     (* Migrate netbios_name from PBIS db and persist to xapi db *)
     let self = Helpers.get_localhost ~__context in
-    let hostname = Db.Host.get_hostname ~__context ~self in
+    let hostname =
+      Db.Host.get_hostname ~__context ~self |> String.uppercase_ascii
+    in
     let netbios_name = Migrate_from_pbis.netbios_name ~default:hostname in
     (* Persist migrated netbios_name *)
     let key = "netbios_name" in
@@ -693,6 +695,31 @@ module Winbind = struct
       in
       error "Service not ready error: %s" msg ;
       raise (Auth_service_error (E_GENERIC, msg))
+
+  let random_string len =
+    let upper_char_start = 65 in
+    let upper_char_len = 26 in
+    let rec aux n acc =
+      if n > 0 then
+        aux (n - 1)
+          ((upper_char_start + Random.int upper_char_len |> char_of_int) :: acc)
+      else
+        acc
+    in
+    aux len [] |> List.to_seq |> String.of_seq
+
+  let build_netbios_name hostname =
+    (* Winbind follow https://docs.microsoft.com/en-US/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou#domain-names to limit netbios length to 15
+     * Compress the hostname if exceed the length *)
+    let max_length = 15 in
+    if String.length hostname > max_length then
+      (* format hostname to prefix-random each with 7 chars *)
+      let len = 7 in
+      let prefix = String.sub hostname 0 len in
+      let suffix = random_string len in
+      Printf.sprintf "%s-%s" prefix suffix
+    else
+      hostname
 end
 
 module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
@@ -862,7 +889,7 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
       from_config ~name:"pass" ~err_msg:"enable requires password"
         ~config_params
     in
-    let netbios_name = get_localhost_name () in
+    let netbios_name = get_localhost_name () |> Winbind.build_netbios_name in
 
     assert_hostname_valid ~hostname:netbios_name ;
 
@@ -892,7 +919,8 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
       ]
       @ ou_param
     in
-    debug "Joining domain %s with user %s" service_name user ;
+    debug "Joining domain %s with user %s netbios_name %s" service_name user
+      netbios_name ;
     let env = [|Printf.sprintf "PASSWD=%s" pass|] in
     try
       Helpers.call_script ~env net_cmd args |> ignore ;

--- a/ocaml/xapi/extauth_plugin_ADwinbind.mli
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.mli
@@ -37,6 +37,10 @@ val extract_ou_config :
 
 val domainify_uname : domain:string -> string -> string
 
+val range : int -> int -> int -> int list
+
+val parse_value_from_pbis : string -> string
+
 module Wbinfo : sig
   type uid_info = {user_name: string; uid: int; gid: int; gecos: string}
 

--- a/ocaml/xapi/extauth_plugin_ADwinbind.mli
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.mli
@@ -37,10 +37,6 @@ val extract_ou_config :
 
 val domainify_uname : domain:string -> string -> string
 
-val range : int -> int -> int -> int list
-
-val parse_value_from_pbis : string -> string
-
 module Wbinfo : sig
   type uid_info = {user_name: string; uid: int; gid: int; gecos: string}
 
@@ -63,4 +59,12 @@ module Ldap : sig
   val string_of_user : user -> string
 
   val parse_user : string -> (user, string) result
+end
+
+module Migrate_from_pbis : sig
+  val range : int -> int -> int -> int list
+
+  val parse_value_from_pbis : string -> string
+
+  val from_key : string -> string
 end

--- a/ocaml/xapi/extauth_plugin_ADwinbind.mli
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.mli
@@ -65,6 +65,4 @@ module Migrate_from_pbis : sig
   val range : int -> int -> int -> int list
 
   val parse_value_from_pbis : string -> string
-
-  val from_key : string -> string
 end

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -392,6 +392,9 @@ let set_iSCSI_initiator_script =
  * or the host is joining or leaving AD *)
 let domain_join_cli_cmd = ref "/opt/pbis/bin/domainjoin-cli"
 
+(* sqlite3 database PBIS used to store domain information *)
+let pbis_db_path = "/var/lib/pbis/db/registry.db"
+
 (* When set to true indicates that the host has still booted so we're initialising everything
    from scratch e.g. shared storage, sampling boot free mem etc *)
 let on_system_boot = ref false

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -910,6 +910,8 @@ let winbind_debug_level = ref 2
 
 let tdb_tool = ref "/usr/bin/tdbtool"
 
+let sqlite3 = ref "/usr/bin/sqlite3"
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1421,6 +1423,9 @@ module Resources = struct
       , "Executed to manage Samba Database" )
     ; ("winbind query tool", wb_cmd, "Query information from winbind daemon")
     ; ("ntlm auth utility", ntlm_auth_cmd, "Used to authenticate AD users")
+    ; ( "SQLite database  management tool"
+      , sqlite3
+      , "Executed to manage SQlite Database, like PBIS database" )
     ]
 
   let essential_files =

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -166,12 +166,15 @@ class DynamicPam(ADConfig):
 
 
 class KeyValueConfig(ADConfig):
-    _empty_line_prefix = "__key_value_config_empty_line_prefix_" # Presume normal config does not have such keys
+    # Only support configure files with key value in each line, seperated by sep
+    # Otherwise, it will be just copied and un-configurable
+    # If multiple lines with the same key exists, only the first line will be configured
+    _special_line_prefix = "__key_value_config_sp_line_prefix_" # Presume normal config does not have such keys
     _empty_value = ""
 
     def __init__(self, path, session, args, ad_enabled=True, load_existing=True, file_mode=0o644, sep=": ", comment="#"):
         super(KeyValueConfig, self).__init__(path, session, args, ad_enabled, load_existing, file_mode)
-        self._sep = sep
+        self._sep = None if sep.isspace() else sep  # Ignore number/type of spaces
         self._comment = comment
         self._values = OrderedDict()
         self._load_values()
@@ -179,34 +182,38 @@ class KeyValueConfig(ADConfig):
     def _is_comment_line(self, line):
         return line.startswith(self._comment)
 
-    def _is_empty_line(self, line):
-        return line.startswith(self._empty_line_prefix)
+    def is_special_line(self, line):
+        return line.startswith(self._special_line_prefix)
 
     def _load_values(self):
         for idx, line in enumerate(self._lines):
+            sp_key = "{}{}".format(self._special_line_prefix, str(idx)) # Generate a unique key to store multiple special lines
             if line == "": # Empty line
-                key = "{}{}".format(self._empty_line_prefix, str(idx)) # Generate a unique key to store multiple empty lines
-                self._values[key] = self._empty_value
+                self._values[sp_key] = self._empty_value
             elif self._is_comment_line(line):
-                self._values[line] = self._empty_value # Store the comment as key, Presume comments are unique
+                self._values[sp_key] = line
             else: # Parse the key, value pair
                 kv = line.split(self._sep)
-                if len(kv) < 2:
-                    logger.warning("'%s' does not has valid key value pair with sep '%s'", line, self._sep)
-                    continue
-                k , v = kv[0].strip(), kv[1].strip()
-                self._values[k] = v
+                if len(kv) != 2:
+                    logger.warning("'%s' is taken as raw line with sep '%s'", line, self._sep)
+                    self._values[sp_key] = line
+                else:
+                    k , v = kv[0].strip(), kv[1].strip()
+                    if k not in self._values:
+                        self._values[k] = v
+                    else:
+                        logger.info("%s already exists, line %d is not configurable", k, idx)
+                        self._values[sp_key] = line
 
     def _update_key_value(self, key, value):
         self._values[key] = value
 
     def _apply_value(self, key, value):
-        if self._is_comment_line(key):
-            line = key
-        elif self._is_empty_line(key):
-            line = self._empty_value
+        if self.is_special_line(key):
+            line = value
         else: # normal line, construct the key value pair
-            line = "{}{}{}".format(key, self._sep, value)
+            sep = self._sep if self._sep else  " "
+            line = "{}{}{}".format(key, sep, value)
         self._lines.append(line)
 
     def _apply_to_cache(self):

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -13,6 +13,7 @@ import abc
 import XenAPIPlugin
 import XenAPI
 import sys
+import subprocess
 import os
 import tempfile
 import logging
@@ -47,6 +48,17 @@ logger = logging.getLogger(__name__)
 class ADBackend(Enum):
     bd_pbis = 0
     bd_winbind = 1
+
+
+def run_cmd(cmd, log_cmd=True):
+    try:
+        result = subprocess.check_output(cmd)
+        if log_cmd:
+            logger.debug("{} -> {}".format(cmd, result))
+        return result.strip()
+    except Exception:
+        logger.exception("Failed to run command %s", cmd)
+        return None
 
 
 class ADConfig(object):
@@ -146,12 +158,27 @@ class DynamicPam(ADConfig):
         # Add each subject which contains the admin role
         for opaque_ref in subjects:
             subject_rec = self._session.xenapi.subject.get_record(opaque_ref)
-            sid = subject_rec['subject_identifier']
-            name = subject_rec["other_config"]["subject-name"]
-            is_group = subject_rec["other_config"]["subject-is-group"] == "true"
             if admin_role in subject_rec['roles']:
-                logger.debug("Permit %s with sid %s is_group as %s", name, sid, is_group)
-                self._add_subject(name, is_group)
+                sid = subject_rec['subject_identifier']
+                name, is_group = self._query_subject(sid)
+                if name:
+                    logger.debug("Permit %s with sid %s is_group as %s", name, sid, is_group)
+                    self._add_subject(name, is_group)
+
+    def _query_subject(self, sid):
+        # xapi support add subject with sid only, thus leave subject-name and subject-is-group empty
+        # This function query such info by wbinfo command
+        # Returns: (subject-name, subject-is-group)
+        subject = run_cmd(["/usr/bin/wbinfo", "-s", sid])
+        if not subject:
+            return None, None
+        comps = subject.split()
+        if len(comps) < 2:
+            logger.error("subject %s from sid %s is not valid", subject, sid)
+            return None, None
+        # CONNAPP\test_user 1  # 1: user, 2: group
+        name, category = comps[0].strip(), comps[1].strip()
+        return name, True if category == "2" else False
 
     def _add_subject(self, name, is_group):
         condition = "ingroup" if is_group else "="
@@ -195,14 +222,13 @@ class KeyValueConfig(ADConfig):
             else: # Parse the key, value pair
                 kv = line.split(self._sep)
                 if len(kv) != 2:
-                    logger.warning("'%s' is taken as raw line with sep '%s'", line, self._sep)
+                    # Not in key value format, take it as special raw line
                     self._values[sp_key] = line
                 else:
                     k , v = kv[0].strip(), kv[1].strip()
                     if k not in self._values:
                         self._values[k] = v
                     else:
-                        logger.info("%s already exists, line %d is not configurable", k, idx)
                         self._values[sp_key] = line
 
     def _update_key_value(self, key, value):


### PR DESCRIPTION
Winbind just use the hostname as the netbios_name to talk to DC
if hostname is changed after join domain, the auth will failed
This commit fix the issue by

* Store the netbios_name in xapi db during join domain
* Configure netbios_name to winbind daemon during xapi bootup
* Migrate netbios_name from PBIS db if domain joined but xapi
database does not have the value, to support update/upgrade

Signed-off-by: Lin Liu <lin.liu@citrix.com>