### PR TITLE
CA-356017: fix migration failures

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2447,35 +2447,31 @@ functor
               forward_migrate_send ()
           )
         in
-        let message_body =
-          match migration_type with
-          | `Live_interpool ->
-              let source_host = Db.VM.get_resident_on ~__context ~self:vm in
-              Printf.sprintf
-                "VM '%s' (uuid: %s) migrated from host '%s' (uuid: %s) to \
-                 another pool"
-                (Db.VM.get_name_label ~__context ~self:vm)
-                (Db.VM.get_uuid ~__context ~self:vm)
-                (Db.Host.get_name_label ~__context ~self:source_host)
-                (Db.Host.get_uuid ~__context ~self:source_host)
-          | `Non_live ->
-              Printf.sprintf "VM '%s' (uuid: %s) migrated non live"
-                (Db.VM.get_name_label ~__context ~self:vm)
-                (Db.VM.get_uuid ~__context ~self:vm)
-          | `Live_intrapool host ->
-              let source_host = Db.VM.get_resident_on ~__context ~self:vm in
-              Printf.sprintf
-                "VM '%s' (uuid: %s) migrated from host '%s' (uuid: %s) to host \
-                 '%s' (uuid: %s)"
-                (Db.VM.get_name_label ~__context ~self:vm)
-                (Db.VM.get_uuid ~__context ~self:vm)
-                (Db.Host.get_name_label ~__context ~self:source_host)
-                (Db.Host.get_uuid ~__context ~self:source_host)
-                (Db.Host.get_name_label ~__context ~self:host)
-                (Db.Host.get_uuid ~__context ~self:host)
-        in
-        create_vm_message ~__context ~vm ~message_body
-          ~message:Api_messages.vm_migrated ;
+        ( if Db.is_valid_ref __context vm then
+            let message_body =
+              match migration_type with
+              | `Live_interpool ->
+                  (* after interpool migration completes the original VM object will be gone *)
+                  "VM migrated to another pool"
+              | `Non_live ->
+                  Printf.sprintf "VM '%s' (uuid: %s) migrated non live"
+                    (Db.VM.get_name_label ~__context ~self:vm)
+                    (Db.VM.get_uuid ~__context ~self:vm)
+              | `Live_intrapool host ->
+                  let source_host = Db.VM.get_resident_on ~__context ~self:vm in
+                  Printf.sprintf
+                    "VM '%s' (uuid: %s) migrated from host '%s' (uuid: %s) to \
+                     host '%s' (uuid: %s)"
+                    (Db.VM.get_name_label ~__context ~self:vm)
+                    (Db.VM.get_uuid ~__context ~self:vm)
+                    (Db.Host.get_name_label ~__context ~self:source_host)
+                    (Db.Host.get_uuid ~__context ~self:source_host)
+                    (Db.Host.get_name_label ~__context ~self:host)
+                    (Db.Host.get_uuid ~__context ~self:host)
+            in
+            create_vm_message ~__context ~vm ~message_body
+              ~message:Api_messages.vm_migrated
+        ) ;
         result
 
       let send_trigger ~__context ~vm ~trigger =


### PR DESCRIPTION
CrossPool migrations were failing:

```
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] Raised Db_exn.DBCache_NotFound("missing row", "VM", "OpaqueRef:24fa7464-93f7-475f-9389-b66955c430ec")
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 1/11 xapi Raised at file ocaml/database/db_cache_impl.ml, line 52
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 2/11 xapi Called from file ocaml/database/db_cache_impl.ml, line 57
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 3/11 xapi Called from file ocaml/xapi/db_actions.ml, line 4939
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 4/11 xapi Called from file ocaml/xapi/message_forwarding.ml, line 2453
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 5/11 xapi Called from file ocaml/xapi/rbac.ml, line 225
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 6/11 xapi Called from file ocaml/xapi/rbac.ml, line 234
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 7/11 xapi Called from file ocaml/xapi/server_helpers.ml, line 100
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 8/11 xapi Called from file ocaml/xapi/server_helpers.ml, line 118
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 9/11 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 10/11 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 38
Jun 25 10:15:54 xrtuk-13-01 xapi: [error||3390 ||backtrace] 11/11 xapi Called from file lib/debug.ml, line 230
```

After the migration finishes the VM will be truly gone, so we can't
query any more fields, have to do any queries prior to the migration.

This means that we can't log messages for cross-pool migrations on the
source, add a Db.is_valid_ref check because we currently don't
differentiate between non-live intra and inter-pool.

Fixes: 37c9778685b47b7414c65fa039f5ece7aaa15947
Signed-off-by: Edwin Török <edvin.torok@citrix.com>