### PR TITLE
CA-355625 reload Stunnel instead of restart after cert change

### DIFF
--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -222,9 +222,6 @@ end = struct
 
   let regen_bundle () = Helpers.update_ca_bundle ()
 
-  let restart_stunnel ~__context =
-    Xapi_mgmt_iface.reconfigure_stunnel ~__context
-
   let with_log prefix f =
     D.debug "%s: start" prefix ;
     let res = f () in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1474,7 +1474,7 @@ let replace_host_certificate ~__context ~type' ~host
   List.iter (Db_util.remove_cert_by_ref ~__context) old_certs ;
   let task = Context.get_task_id __context in
   Db.Task.set_progress ~__context ~self:task ~value:1.0 ;
-  Xapi_mgmt_iface.reconfigure_stunnel ~__context
+  Helpers.Stunnel.reload ()
 
 let install_server_certificate ~__context ~host ~certificate ~private_key
     ~certificate_chain =


### PR DESCRIPTION
When changing a host's certificate, it is enough to reload Stunnel
rather than restarting it. This keeps existing connections alive. This
requires support in the systemd configuration of stunnel.
