### PR TITLE
CA-341715: fix control-domain-params-init

### DIFF
--- a/scripts/control-domain-params-init
+++ b/scripts/control-domain-params-init
@@ -2,6 +2,10 @@
 
 set -eu
 
+FIRSTBOOT_DATA_DIR=/etc/firstboot.d/data
+UPGRADE="false"
+[ -r ${FIRSTBOOT_DATA_DIR}/host.conf ] && . ${FIRSTBOOT_DATA_DIR}/host.conf
+
 . /etc/xensource-inventory
 
 if [ -z "$CONTROL_DOMAIN_UUID" ]; then


### PR DESCRIPTION
Fix a014ba9 has code missing to set the UPGRADE variable.  On upgrade, this key
is found in /etc/firstboot.d/data/host.conf, but on firstboot, this file does
not exist.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>