### PR TITLE
CA-356325: Could not ssh to a host with a pooladmin user with upper case

### DIFF
--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -176,18 +176,18 @@ class DynamicPam(ADConfig):
         if len(comps) < 2:
             logger.error("subject %s from sid %s is not valid", subject, sid)
             return None, None
-        # CONNAPP\test_user 1  # 1: user, 2: group
-        is_group = True if comps[1].strip() =="2" else False
-        _name = comps[0].strip()
-        # The _name returned name contains uppercase, need to format it from subject details
-        return self._query_subject_name(_name, is_group), is_group
+        # CONNAPP\IUgroup 1  # 1: user, 2: group
+        is_group = comps[1].strip() == "2"
+        real_name = comps[0].strip()
+        # The real_name returned name contains uppercase, need to format it from subject details
+        return self._query_subject_name(real_name, is_group), is_group
 
-    def _query_subject_name(self, _name, is_group):
+    def _query_subject_name(self, real_name, is_group):
         sub_cmd = "--group-info" if is_group else "--user-info"
-        cmd = ["/usr/bin/wbinfo", sub_cmd, _name]
+        cmd = ["/usr/bin/wbinfo", sub_cmd, real_name]
         subject_detail = run_cmd(cmd)
         if not subject_detail:
-           logger.error("Failed to lookup subject details %s", _name)
+           logger.error("Failed to lookup subject details %s", real_name)
            return None
         # CONNAPP\ugroup:x:3000009: --> group details
         # CONNAPP\iugroup:*:3000016:3000000:IUgroup:/home/CONNAPP/iugroup:/bin/bash --> user details

--- a/scripts/plugins/test_extauth_hook_AD.py
+++ b/scripts/plugins/test_extauth_hook_AD.py
@@ -144,7 +144,7 @@ class TestDynamicPam(TestCase):
 
     @patch("extauth_hook_ad.run_cmd")
     def test_query_subject_success(self, mock_cmd, mock_rename, mock_chmod):
-        def cmd_result(cmd):
+        def mock_exec(cmd):
             if "-s" in cmd:
                 return "CONNAPP\\test_group 2\n" # mock "wbinfo -s" to lookup sid
             elif "--group-info" in cmd:
@@ -155,7 +155,7 @@ class TestDynamicPam(TestCase):
                 raise ValueError("Unknown subcommand from wbinfo")
         dynamic = DynamicPam(mock_session, args_bd_wibind)
         sid = "S-1-5-21-3143668282-2591278241-912959342-1174"
-        mock_cmd.side_effect = cmd_result
+        mock_cmd.side_effect = mock_exec
         name, is_group = dynamic._query_subject(sid)
         self.assertEqual(r"CONNAPP\test_group", name)
         self.assertTrue(is_group)


### PR DESCRIPTION
User is permitted to ssh to dom0 by adding their name pam configure files
However, ssh expected the name in lower case other than the real name

This commit fix the issue by lookup name in subject details, which contain
the expected name

Signed-off-by: Lin Liu <lin.liu@citrix.com>