### PR TITLE
CP-36097 REQ-403 ferry cluster pems

### DIFF
--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -14,3 +14,5 @@ val host :
 val xapi_pool : uuid:string -> string -> unit
 (** [xapi_pool uuid path] creates (atomically) a PEM file at [path] with
     [uuid] as CN *)
+
+val xapi_cluster : cn:string -> string

--- a/ocaml/idl/datamodel_cluster_host.ml
+++ b/ocaml/idl/datamodel_cluster_host.ml
@@ -91,6 +91,20 @@ let forget = call
   ~hide_from_docs:true
   ()
 
+let get_cluster_config = call
+  ~name:"get_cluster_config"
+  ~doc:"Get the cluster config from a cluster host"
+  ~params:
+    [ Ref _cluster_host, "self", "the cluster_host to contact"
+    ]
+  ~result:(SecretString, "")
+  ~lifecycle:[Published, rel_next, ""]
+  ~allowed_roles:_R_POOL_OP
+  ~errs:Api_errors.([cluster_stack_in_use
+                    ])
+  ~hide_from_docs:true
+  ()
+
 let t =
   create_obj
     ~name: _cluster_host
@@ -142,5 +156,6 @@ let t =
       ; force_destroy
       ; forget
       ; disable
+      ; get_cluster_config
       ]
     ()

--- a/ocaml/idl/datamodel_cluster_host.ml
+++ b/ocaml/idl/datamodel_cluster_host.ml
@@ -105,6 +105,20 @@ let get_cluster_config = call
   ~hide_from_docs:true
   ()
 
+let write_pems = call
+  ~name:"write_pems"
+  ~doc:"Introduces pems into the cluster host's cluster"
+  ~params:
+    [ Ref _cluster_host, "self", "the cluster_host to contact"
+    ; SecretString, "pems", "encoded pem"
+    ]
+  ~lifecycle:[Published, rel_next, ""]
+  ~allowed_roles:_R_POOL_OP
+  ~errs:Api_errors.([cluster_stack_in_use
+                    ])
+  ~hide_from_docs:true
+  ()
+
 let t =
   create_obj
     ~name: _cluster_host
@@ -157,5 +171,6 @@ let t =
       ; forget
       ; disable
       ; get_cluster_config
+      ; write_pems
       ]
     ()

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -37,6 +37,7 @@ let test_clusterd_rpc ~__context call =
         ; config_version= 1L
         ; cluster_token_timeout_ms= 20000L
         ; cluster_token_coefficient_ms= 1000L
+        ; pems= None
         }
       in
       let diag =
@@ -72,6 +73,8 @@ let test_rpc ~__context call =
   | "Cluster.destroy", [_session; self] ->
       let open API in
       Xapi_cluster.destroy ~__context ~self:(ref_Cluster_of_rpc self) ;
+      Rpc.{success= true; contents= Rpc.String ""; is_notification= false}
+  | "Cluster_host.get_cluster_config", _ ->
       Rpc.{success= true; contents= Rpc.String ""; is_notification= false}
   | name, params ->
       Alcotest.failf "Unexpected RPC: %s(%s)" name

--- a/ocaml/xapi-types/secretString.ml
+++ b/ocaml/xapi-types/secretString.ml
@@ -16,6 +16,8 @@ type t = string [@@deriving rpc]
 
 let of_string s = s
 
+let json_rpc_of_t s = Jsonrpc.of_string ~strict:true s
+
 let _pool_secret = "pool_secret"
 
 let with_cookie t request =

--- a/ocaml/xapi-types/secretString.mli
+++ b/ocaml/xapi-types/secretString.mli
@@ -25,6 +25,8 @@ val of_string : string -> t
 
 val equal : t -> t -> bool
 
+val json_rpc_of_t : t -> Rpc.t
+
 val t_of_rpc : Rpc.t -> t
 
 val rpc_of_t : t -> Rpc.t

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -34,6 +34,8 @@ module D = Debug.Make (struct let name = "helpers" end)
 open D
 module StringSet = Set.Make (String)
 
+let ( let* ) = Result.bind
+
 let log_exn_continue msg f x =
   try f x
   with e ->
@@ -2100,3 +2102,12 @@ let update_ca_bundle =
              "/opt/xensource/bin/update-ca-bundle.sh" []
           )
     )
+
+let unit_test ~__context : bool =
+  Pool_role.is_unit_test ()
+  ||
+  match Context.get_test_clusterd_rpc __context with
+  | Some _ ->
+      true
+  | None ->
+      false

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1002,6 +1002,8 @@ functor
               debug "Pool.enable_tls_verification sleeping on fistpoint" ;
               Thread.delay 5.0
             done ;
+            Db.Cluster.get_all ~__context
+            |> List.iter (Xapi_cluster_helpers.Pem.maybe_write_new ~__context) ;
             all_hosts
             |> List.iter (fun host ->
                    do_op_on ~local_fn ~__context ~host (fun session_id rpc ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6311,6 +6311,14 @@ functor
         do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
             Client.Cluster_host.get_cluster_config rpc session_id self
         )
+
+      let write_pems ~__context ~self ~pems =
+        info "Cluster_host.write_pems:%s" (Ref.string_of self) ;
+        let host = Db.Cluster_host.get_host ~__context ~self in
+        let local_fn = Local.Cluster_host.write_pems ~self ~pems in
+        do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
+            Client.Cluster_host.write_pems rpc session_id self pems
+        )
     end
 
     module Certificate = struct end

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6303,6 +6303,14 @@ functor
           )
         in
         find_first_live other_hosts
+
+      let get_cluster_config ~__context ~self =
+        info "Cluster_host.get_cluster_config:%s" (Ref.string_of self) ;
+        let host = Db.Cluster_host.get_host ~__context ~self in
+        let local_fn = Local.Cluster_host.get_cluster_config ~self in
+        do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
+            Client.Cluster_host.get_cluster_config rpc session_id self
+        )
     end
 
     module Certificate = struct end

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -16,6 +16,7 @@ open Xapi_clustering
 
 module D = Debug.Make (struct let name = "xapi_cluster" end)
 
+module Gencert = Gencertlib.Selfcert
 open D
 
 (* TODO: update allowed_operations on boot/toolstack-restart *)
@@ -53,12 +54,14 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
       let token_timeout_coefficient_ms =
         Int64.of_float (token_timeout_coefficient *. 1000.0)
       in
+      let pems = Xapi_cluster_helpers.Pem.init ~__context ~cn:cluster_uuid in
       let init_config =
         {
           Cluster_interface.local_ip= ip
         ; token_timeout_ms= Some token_timeout_ms
         ; token_coefficient_ms= Some token_timeout_coefficient_ms
         ; name= None
+        ; pems
         }
       in
       Xapi_clustering.Daemon.enable ~__context ;

--- a/ocaml/xapi/xapi_cluster_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_helpers.ml
@@ -103,3 +103,82 @@ let with_cluster_operation ~__context ~(self : [`Cluster] API.Ref.t) ~doc ~op
           (Datamodel_common._cluster, Ref.string_of self)
       with _ -> ()
   )
+
+module Pem = struct
+  open Helpers
+  open Cluster_interface
+  module Client = Client.Client
+
+  let init' cn = {cn; blobs= [Gencertlib.Selfcert.xapi_cluster ~cn]}
+
+  let init ~__context ~cn =
+    if unit_test ~__context then
+      None
+    else
+      Some (init' cn)
+
+  let get_existing' ~__context self =
+    let cc_of_cluster_host h =
+      call_api_functions ~__context @@ fun rpc session_id ->
+      Client.Cluster_host.get_cluster_config rpc session_id h
+      |> SecretString.json_rpc_of_t
+      |> Rpcmarshal.unmarshal cluster_config.Rpc.Types.ty
+      |> function
+      | Ok x ->
+          x
+      | Error e ->
+          raise
+            Api_errors.(
+              Server_error (internal_error, ["bad response from cluster host"])
+            )
+    in
+    if unit_test ~__context then
+      `unittest
+    else
+      let hs = Db.Cluster.get_cluster_hosts ~__context ~self in
+      let enabled_hs =
+        List.filter
+          (fun self -> Db.Cluster_host.get_enabled ~__context ~self)
+          hs
+      in
+      match (hs, enabled_hs) with
+      | [], _ ->
+          `no_cluster_hosts
+      | _, [] ->
+          `all_disabled
+      | _, h :: _ ->
+          if enabled_hs = hs then
+            `all_enabled (h, cc_of_cluster_host h)
+          else
+            `not_all_enabled (h, cc_of_cluster_host h)
+
+  let get_existing ~__context self =
+    (* try to get existing pem, though this might not be possible for example if
+     * every cluster host has been disabled
+     *
+     * create a new pem if we are the first cluster host *)
+    let gen () =
+      D.debug "Pem.get_existing: generating new" ;
+      let cn = Db.Cluster.get_uuid ~__context ~self in
+      Some (init' cn)
+    in
+    match get_existing' ~__context self with
+    | `unittest ->
+        None
+    | `all_disabled ->
+        D.debug "Pem.get_existing: all existing cluster hosts disabled" ;
+        gen ()
+    | `no_cluster_hosts ->
+        D.debug "Pem.get_existing: there are no existing cluster hosts" ;
+        gen ()
+    | `all_enabled (_, cc) | `not_all_enabled (_, cc) -> (
+      match cc.pems with
+      | None ->
+          (* this is not a problem unless tls verification is enabled! *)
+          D.debug "Pem.get_existing: existing cluster does not have a pem" ;
+          None
+      | Some p ->
+          D.debug "Pem.get_existing: found existing pem!" ;
+          Some p
+    )
+end

--- a/ocaml/xapi/xapi_cluster_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_helpers.ml
@@ -181,4 +181,43 @@ module Pem = struct
           D.debug "Pem.get_existing: found existing pem!" ;
           Some p
     )
+
+  let maybe_write_new ~__context self =
+    let write h =
+      let cn = Db.Cluster.get_uuid ~__context ~self in
+      let p = init' cn in
+      let p_encoded =
+        Rpcmarshal.marshal pems.Rpc.Types.ty p
+        |> Jsonrpc.to_string
+        |> SecretString.of_string
+      in
+      call_api_functions ~__context @@ fun rpc session_id ->
+      Client.Cluster_host.write_pems rpc session_id h p_encoded
+    in
+    match get_existing' ~__context self with
+    | `unittest ->
+        ()
+    | `all_disabled | `not_all_enabled _ ->
+        D.error "Pem.maybe_write_new: all cluster hosts must be enabled" ;
+        raise
+          Api_errors.(
+            Server_error (internal_error, ["all cluster hosts must be enabled"])
+          )
+    | `no_cluster_hosts ->
+        D.info
+          "Pem.maybe_write_new: nothing to do because there are no cluster \
+           hosts"
+    | `all_enabled (h, cc) -> (
+      match cc.pems with
+      | Some _ ->
+          D.info "Pem.maybe_write_new: pem already exists, so not overwriting"
+      | None ->
+          D.info
+            "Pem.maybe_write_new: cluster '%s' has no existing pem, attempting \
+             to write a new one"
+            (Ref.short_string_of self) ;
+          write h ;
+          D.info "Pem.maybe_write_new: successfully written on cluster '%s'"
+            (Ref.short_string_of self)
+    )
 end

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -90,3 +90,6 @@ val forget : __context:Context.t -> self:API.ref_Cluster_host -> unit
     from the cluster. This will only succeed if the rest of the hosts are online,
     so in the case of failure the cluster's pending_forget list will be updated.
     If you declare all your dead hosts as dead one by one the last one should succeed *)
+
+val get_cluster_config :
+  __context:Context.t -> self:API.ref_Cluster_host -> SecretString.t

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -99,3 +99,5 @@ val write_pems :
   -> self:API.ref_Cluster_host
   -> pems:SecretString.t
   -> unit
+
+val is_local_cluster_host_using_xapis_pem : __context:Context.t -> bool

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -93,3 +93,9 @@ val forget : __context:Context.t -> self:API.ref_Cluster_host -> unit
 
 val get_cluster_config :
   __context:Context.t -> self:API.ref_Cluster_host -> SecretString.t
+
+val write_pems :
+     __context:Context.t
+  -> self:API.ref_Cluster_host
+  -> pems:SecretString.t
+  -> unit

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -292,6 +292,11 @@ module Daemon = struct
       !Xapi_globs.firewall_port_config_script
       ["close"; port] ;
     debug "Cluster daemon: disabled & stopped"
+
+  let restart ~__context =
+    debug "Attempting to restart the clustering daemon" ;
+    maybe_call_script ~__context !Xapi_globs.systemctl ["restart"; service] ;
+    debug "Cluster daemon: restarted"
 end
 
 (* xapi-clusterd only listens on message-switch,

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3271,6 +3271,10 @@ let ping_with_tls_verification ~__context host =
 let enable_tls_verification ~__context =
   let hosts = Db.Host.get_all ~__context in
   List.iter (ping_with_tls_verification ~__context) hosts ;
+  Xapi_clustering.(
+    if !Daemon.enabled then
+      Daemon.restart ~__context
+  ) ;
   Stunnel_client.set_verify_by_default true ;
   Helpers.touch_file Xapi_globs.verify_certificates_path
 


### PR DESCRIPTION
Xapi will generate a pem when it creates a cluster. This cert goes in the cluster database. New cluster hosts will get a copy of the cluster pem when they join (such that they can trust the cluster they are joining)

We also provide a mechanism such that we can introduce pems to an existing cluster. This may be necessary before enabling TLS verification