### PR TITLE
CP-37370 refresh pool-internal certs using cron

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -142,6 +142,7 @@ install:
 	mkdir -p $(DESTDIR)/etc/cron.daily
 	$(IPROG) license-check $(DESTDIR)/etc/cron.daily/
 	$(IPROG) certificate-check $(DESTDIR)/etc/cron.daily/
+	$(IPROG) certificate-refresh $(DESTDIR)/etc/cron.daily/
 	mkdir -p $(DESTDIR)/etc/cron.d
 	$(IDATA) xapi-logrotate.cron $(DESTDIR)/etc/cron.d/xapi-logrotate.cron
 	mkdir -p $(DESTDIR)/opt/xensource/gpg

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -140,9 +140,10 @@ install:
 	$(IPROG) hfx_filename $(DESTDIR)$(BINDIR)
 	$(IPROG) pv2hvm $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)/etc/cron.daily
+	mkdir -p $(DESTDIR)/etc/cron.hourly
 	$(IPROG) license-check $(DESTDIR)/etc/cron.daily/
 	$(IPROG) certificate-check $(DESTDIR)/etc/cron.daily/
-	$(IPROG) certificate-refresh $(DESTDIR)/etc/cron.daily/
+	$(IPROG) certificate-refresh $(DESTDIR)/etc/cron.hourly/
 	mkdir -p $(DESTDIR)/etc/cron.d
 	$(IDATA) xapi-logrotate.cron $(DESTDIR)/etc/cron.d/xapi-logrotate.cron
 	mkdir -p $(DESTDIR)/opt/xensource/gpg

--- a/scripts/certificate-refresh
+++ b/scripts/certificate-refresh
@@ -1,0 +1,11 @@
+#! /bin/bash
+# wait randomly up to 10m (600s) and refresh the pool-internal
+# host certificate of this host
+
+set -e
+
+source /etc/xensource-inventory
+host="$INSTALLATION_UUID"
+/usr/bin/sleep $((RANDOM % 600))
+/opt/xensource/bin/xe host-refresh-server-certificate host="$host"
+exit 0


### PR DESCRIPTION

Call `xe host-refresh-server-certificate` from cron. Do it hourly before release for increased testing but revert to doing it daily before release. This requires a corresponding change in `xapi.spec` for packaging.