### PR TITLE
REQ-403 concurrency fixes pt 4

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -8,12 +8,17 @@ open Datamodel_types
             "ha_disable", "Indicates this pool is in the process of disabling HA";
             "cluster_create", "Indicates this pool is in the process of creating a cluster";
             "designate_new_master", "Indicates this pool is in the process of changing master";
-            "tls_verification_enable", "Indicates this pool is in the process of enabling TLS verification";
             "configure_repositories", "Indicates this pool is in the process of configuring repositories";
             "sync_updates", "Indicates this pool is in the process of syncing updates";
             "get_updates", "Indicates this pool is in the process of getting updates";
             "apply_updates", "Indicates this pool is in the process of applying updates";
+            (* ops involving cert distribution; these do not necessarily correspond to 'Pool.x' commands,
+             * but they do require a pool-wide lock *)
+            "tls_verification_enable", "Indicates this pool is in the process of enabling TLS verification";
             "cert_refresh", "A certificate refresh and distribution is in progress";
+            "exchange_certificates_on_join", "Indicates this pool is exchanging internal certificates with a new joiner";
+            "exchange_ca_certificates_on_join", "Indicates this pool is exchanging ca certificates with a new joiner";
+            "copy_primary_host_certs", "Indicates the primary host is sending its certificates to another host";
           ])
 
   let enable_ha = call

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "632046e456380e732bb9faadde0ecb9e"
+let last_known_schema_hash = "946d2318ed40d9cbb68267dc3295e79a"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -166,6 +166,12 @@ let pool_operation_to_string = function
       "apply_updates"
   | `cert_refresh ->
       "cert_refresh"
+  | `exchange_certificates_on_join ->
+      "exchange_certificates_on_join"
+  | `exchange_ca_certificates_on_join ->
+      "exchange_ca_certificates_on_join"
+  | `copy_primary_host_certs ->
+      "copy_primary_host_certs"
 
 let host_operation_to_string = function
   | `provision ->

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -342,13 +342,6 @@ let collect_pool_certs ~__context ~rpc ~session_id ~map ~from_hosts =
 
 let _distrib_m = Mutex.create ()
 
-(* where possible, the master host should control the certificate
- * distributions.  this allows us to coordinate multiple parties that are
- * trying to modify /etc/stunnel at the same time with [lock]!
- *
- * we apply this lock to all top level distribution calls, with the exception of
- * the pool join functions that execute on the joiner.
- *)
 let lock (f : unit -> 'a) : 'a =
   D.debug "cert_distrib.ml: locking..." ;
   Mutex.lock _distrib_m ;

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -1,3 +1,17 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
 module Unixext = Xapi_stdext_unix.Unixext
 module StringSet = Set.Make (String)
 

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -513,7 +513,6 @@ let collect_ca_certs ~__context ~names =
 
 (* This function is called on the pool that is incorporating a new host *)
 let exchange_ca_certificates_with_joiner ~__context ~import ~export =
-  lock @@ fun () ->
   let appliance_certs = List.map WireProtocol.certificate_file_of_pair import in
   Worker.local_write_cert_fs ~__context ApplianceCertificate Merge
     appliance_certs ;

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -354,25 +354,6 @@ let collect_pool_certs ~__context ~rpc ~session_id ~map ~from_hosts =
          map cert
      )
 
-let _distrib_m = Mutex.create ()
-
-(* where possible, the master host should control the certificate
- * distributions.  this allows us to coordinate multiple parties that are
- * trying to modify /etc/stunnel at the same time with [lock]!
- *
- * we apply this lock to all top level distribution calls, with the exception of
- * the pool join functions that execute on the joiner.
- *)
-let lock (f : unit -> 'a) : 'a =
-  D.debug "cert_distrib.ml: locking..." ;
-  Mutex.lock _distrib_m ;
-  Fun.protect
-    ~finally:(fun () ->
-      D.debug "cert_distrib.ml: unlocking..." ;
-      Mutex.unlock _distrib_m
-      )
-    f
-
 let exchange_certificates_among_all_members ~__context =
   (* here we coordinate the certificate distribution. from a high level
      we do the following:

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -448,7 +448,6 @@ let am_i_missing_certs ~__context : bool =
   missing_pool_certs () || missing_ca_certs ()
 
 let copy_certs_to_host ~__context ~host =
-  lock @@ fun () ->
   D.debug "copy_certs_to_host: sending my certs to host %s"
     (Ref.short_string_of host) ;
   if am_i_missing_certs ~__context then

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -372,7 +372,6 @@ let exchange_certificates_among_all_members ~__context =
          we do not guarantee 'atomicity', so if regenerating the bundle on one host
          fails, then state across the pool will most likely become inconsistent, and
          manual intervention may be required *)
-  lock @@ fun () ->
   let all_hosts = Xapi_pool_helpers.get_master_slaves_list ~__context in
   Helpers.call_api_functions ~__context @@ fun rpc session_id ->
   let certs =

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -466,7 +466,6 @@ let copy_certs_to_host ~__context ~host =
 
 (* This function is called on the pool that is incorporating a new host *)
 let exchange_certificates_with_joiner ~__context ~uuid ~certificate =
-  lock @@ fun () ->
   let joiner_certificate =
     HostPoolProvider.certificate_of_id_content uuid certificate
   in

--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -342,6 +342,13 @@ let collect_pool_certs ~__context ~rpc ~session_id ~map ~from_hosts =
 
 let _distrib_m = Mutex.create ()
 
+(* where possible, the master host should control the certificate
+ * distributions.  this allows us to coordinate multiple parties that are
+ * trying to modify /etc/stunnel at the same time with [lock]!
+ *
+ * we apply this lock to all top level distribution calls, with the exception of
+ * the pool join functions that execute on the joiner.
+ *)
 let lock (f : unit -> 'a) : 'a =
   D.debug "cert_distrib.ml: locking..." ;
   Mutex.lock _distrib_m ;

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -1,3 +1,12 @@
+val lock : (unit -> 'a) -> 'a
+(** where possible, the master host should control the certificate
+  * distributions. this allows us to coordinate multiple parties that are
+  * trying to modify /etc/stunnel at the same time with [lock]!
+  *
+  * we apply this lock to all top level distribution calls, with the exception of
+  * the pool join functions that execute on the joiner.
+  *)
+
 val local_exec : __context:Context.t -> command:string -> string
 (** execute a string encoded job, returning a string encoded result *)
 

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -1,3 +1,17 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
 val local_exec : __context:Context.t -> command:string -> string
 (** execute a string encoded job, returning a string encoded result *)
 

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -1,12 +1,3 @@
-val lock : (unit -> 'a) -> 'a
-(** where possible, the master host should control the certificate
-  * distributions. this allows us to coordinate multiple parties that are
-  * trying to modify /etc/stunnel at the same time with [lock]!
-  *
-  * we apply this lock to all top level distribution calls, with the exception of
-  * the pool join functions that execute on the joiner.
-  *)
-
 val local_exec : __context:Context.t -> command:string -> string
 (** execute a string encoded job, returning a string encoded result *)
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3585,25 +3585,29 @@ functor
       let refresh_server_certificate ~__context ~host =
         info "Host.refresh_server_certificate: host = '%s'"
           (host_uuid ~__context host) ;
-        let pool = Helpers.get_pool ~__context in
-        let local_fn = Local.Host.refresh_server_certificate ~host in
-        let other =
-          Db.Host.get_all ~__context |> List.filter (fun h -> h <> host)
-        in
-        Xapi_pool_helpers.with_pool_operation ~__context
-          ~doc:"Host.refresh_server_certificate" ~self:pool ~op:`cert_refresh
-        @@ fun () ->
-        (* let host refresh its certificates first *)
-        do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
-            Client.Host.refresh_server_certificate rpc session_id host
-        ) ;
-        (* update all other hosts in the pool *)
-        other
-        |> List.iter (fun h ->
-               do_op_on ~local_fn ~__context ~host:h (fun session_id rpc ->
-                   Client.Host.refresh_server_certificate rpc session_id host
+        Cert_distrib.lock (fun () ->
+            let pool = Helpers.get_pool ~__context in
+            let local_fn = Local.Host.refresh_server_certificate ~host in
+            let other =
+              Db.Host.get_all ~__context |> List.filter (fun h -> h <> host)
+            in
+            Xapi_pool_helpers.with_pool_operation ~__context
+              ~doc:"Host.refresh_server_certificate" ~self:pool
+              ~op:`cert_refresh
+            @@ fun () ->
+            (* let host refresh its certificates first *)
+            do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
+                Client.Host.refresh_server_certificate rpc session_id host
+            ) ;
+            (* update all other hosts in the pool *)
+            other
+            |> List.iter (fun h ->
+                   do_op_on ~local_fn ~__context ~host:h (fun session_id rpc ->
+                       Client.Host.refresh_server_certificate rpc session_id
+                         host
+                   )
                )
-           )
+        )
 
       let _success ~__context () =
         let task = Context.get_task_id __context in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3585,29 +3585,25 @@ functor
       let refresh_server_certificate ~__context ~host =
         info "Host.refresh_server_certificate: host = '%s'"
           (host_uuid ~__context host) ;
-        Cert_distrib.lock (fun () ->
-            let pool = Helpers.get_pool ~__context in
-            let local_fn = Local.Host.refresh_server_certificate ~host in
-            let other =
-              Db.Host.get_all ~__context |> List.filter (fun h -> h <> host)
-            in
-            Xapi_pool_helpers.with_pool_operation ~__context
-              ~doc:"Host.refresh_server_certificate" ~self:pool
-              ~op:`cert_refresh
-            @@ fun () ->
-            (* let host refresh its certificates first *)
-            do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
-                Client.Host.refresh_server_certificate rpc session_id host
-            ) ;
-            (* update all other hosts in the pool *)
-            other
-            |> List.iter (fun h ->
-                   do_op_on ~local_fn ~__context ~host:h (fun session_id rpc ->
-                       Client.Host.refresh_server_certificate rpc session_id
-                         host
-                   )
+        let pool = Helpers.get_pool ~__context in
+        let local_fn = Local.Host.refresh_server_certificate ~host in
+        let other =
+          Db.Host.get_all ~__context |> List.filter (fun h -> h <> host)
+        in
+        Xapi_pool_helpers.with_pool_operation ~__context
+          ~doc:"Host.refresh_server_certificate" ~self:pool ~op:`cert_refresh
+        @@ fun () ->
+        (* let host refresh its certificates first *)
+        do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
+            Client.Host.refresh_server_certificate rpc session_id host
+        ) ;
+        (* update all other hosts in the pool *)
+        other
+        |> List.iter (fun h ->
+               do_op_on ~local_fn ~__context ~host:h (fun session_id rpc ->
+                   Client.Host.refresh_server_certificate rpc session_id host
                )
-        )
+           )
 
       let _success ~__context () =
         let task = Context.get_task_id __context in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3667,7 +3667,10 @@ functor
 
       let copy_primary_host_certs ~__context ~host =
         info "Host.copy_primary_host_certs host = '%s'" (Ref.string_of host) ;
-        Local.Host.copy_primary_host_certs ~__context ~host
+        Xapi_pool_helpers.with_pool_operation ~__context
+          ~op:`copy_primary_host_certs ~doc:"Host.copy_primary_host_certs"
+          ~self:(Helpers.get_pool ~__context)
+        @@ fun () -> Local.Host.copy_primary_host_certs ~__context ~host
 
       let attach_static_vdis ~__context ~host ~vdi_reason_map =
         info "Host.attach_static_vdis: host = '%s'; vdi/reason pairs = [ %s ]"

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1606,6 +1606,10 @@ let join_force ~__context ~master_address ~master_username ~master_password =
 
 let exchange_certificates_on_join ~__context ~uuid ~certificate :
     API.string_to_string_map =
+  Xapi_pool_helpers.with_pool_operation ~__context
+    ~op:`exchange_certificates_on_join ~doc:"Pool.exchange_certificates_on_join"
+    ~self:(Helpers.get_pool ~__context)
+  @@ fun () ->
   Cert_distrib.exchange_certificates_with_joiner ~__context ~uuid ~certificate
 
 let exchange_ca_certificates_on_join ~__context ~import ~export :

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1614,6 +1614,11 @@ let exchange_certificates_on_join ~__context ~uuid ~certificate :
 
 let exchange_ca_certificates_on_join ~__context ~import ~export :
     API.string_to_string_map =
+  Xapi_pool_helpers.with_pool_operation ~__context
+    ~op:`exchange_ca_certificates_on_join
+    ~doc:"Pool.exchange_ca_certificates_on_join"
+    ~self:(Helpers.get_pool ~__context)
+  @@ fun () ->
   let export =
     List.map (fun self -> Db.Certificate.get_name ~__context ~self) export
   in


### PR DESCRIPTION
Put cert refresh under the cert distrib lock.

The main aim of this is to mutually exclude both
'copy_primary_host_certs' and cert refresh (tls verification enable is
already excluded via the refresh cert pool op).

It is handy to have both locks, since the pool op excludes pool refresh
with things like HA enable/disable.