### PR TITLE
XenAPI.Session: raise exception on attempted forwarding of python magic methods

### DIFF
--- a/scripts/examples/python/XenAPI/XenAPI.py
+++ b/scripts/examples/python/XenAPI/XenAPI.py
@@ -113,6 +113,9 @@ class UDSTransport(xmlrpclib.Transport):
         for key, value in self._extra_headers:
             connection.putheader(key, value)
 
+def notimplemented(name, *args, **kwargs):
+    raise NotImplementedError("XMLRPC proxies do not support python magic methods", name, *args, **kwargs)
+
 class Session(xmlrpclib.ServerProxy):
     """A server proxy and session manager for communicating with xapi using
     the Xen-API.
@@ -215,6 +218,8 @@ class Session(xmlrpclib.ServerProxy):
             return lambda *params: self._login(name, params)
         elif name == 'logout':
             return _Dispatcher(self.API_version, self.xenapi_request, "logout")
+        elif name.startswith('__') and name.endswith('__'):
+            return lambda *args, **kwargs: notimplemented(name, args, kwargs)
         else:
             return xmlrpclib.ServerProxy.__getattr__(self, name)
 


### PR DESCRIPTION
Python calls magic methods for certain operations, e.g.
`not session` calls `session.__nonzero__`
and `session == foo` calls `session.__eq__`.

In the case of `__nonzero__` the failure is obvious: XAPI will return an RPC error
because it doesn't implement __nonzero__, which will be a dict and not an integer and Python raises a type error.
For a recent example of such a bug, see: https://github.com/xapi-project/sm/pull/562/commits/c52bcdf4e219126cb2b3b7a163902b85912ce4a3

`__eq__` is more problematic because the result is an error, a dict, which can be converted to an always true boolean.

Explicitly check for magic methods (starting with `__`) and reject it as not implemented.
This will give a clear stacktrace and error message, allowing to locate these bugs more easily.
Also prints the method name and arguments, which could help identify the callsite.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>