### PR TITLE
CP-37500: Support multiple Domain controller in domain

### DIFF
--- a/ocaml/tests/test_extauth_plugin_ADwinbind.ml
+++ b/ocaml/tests/test_extauth_plugin_ADwinbind.ml
@@ -336,8 +336,8 @@ msDS-SupportedEncryptionTypes: 0|}
       , Ok
           {
             upn= "ladmin@conappada.local"
-          ; name="ladmin"
-          ; display_name="ladmin"
+          ; name= "ladmin"
+          ; display_name= "ladmin"
           ; account_disabled= false
           ; account_expired= false
           ; account_locked= false
@@ -348,7 +348,7 @@ msDS-SupportedEncryptionTypes: 0|}
           {
             upn= "locked@conappada.local"
           ; name= "locked"
-          ; display_name = "locked"
+          ; display_name= "locked"
           ; account_disabled= false
           ; account_expired= false
           ; account_locked= true
@@ -365,17 +365,17 @@ msDS-SupportedEncryptionTypes: 0|}
           ; account_locked= false
           ; password_expired= false
           } )
-    ; (stdout_krbtgt
+    ; ( stdout_krbtgt
       , Ok
           {
-             upn= ""
-          ;  display_name= ""
-          ;  name= "krbtgt"
-          ;  password_expired= false
-          ;  account_locked= false
-          ;  account_expired= false
-          ;  account_disabled= true
-          })
+            upn= ""
+          ; display_name= ""
+          ; name= "krbtgt"
+          ; password_expired= false
+          ; account_locked= false
+          ; account_expired= false
+          ; account_disabled= true
+          } )
     ; ("Got 0 replies", Error "ldap parsing failed ': got 0 replies'")
     ; ( "complete garbage"
       , Error "ldap parsing failed 'unexpected header: string'" )

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -911,11 +911,15 @@ let ntlm_auth_cmd = ref "/usr/bin/ntlm_auth"
 
 let winbind_debug_level = ref 2
 
-let winbind_cache_time = ref 300
+let winbind_cache_time = ref 60
+
+let winbind_machine_pwd_timeout = ref (7 * 24 * 3600)
 
 let tdb_tool = ref "/usr/bin/tdbtool"
 
 let sqlite3 = ref "/usr/bin/sqlite3"
+
+let samba_dir = "/var/lib/samba"
 
 let xapi_globs_spec =
   [
@@ -986,6 +990,7 @@ let xapi_globs_spec =
   ; ("max_active_sr_scans", Int max_active_sr_scans)
   ; ("winbind_debug_level", Int winbind_debug_level)
   ; ("winbind_cache_time", Int winbind_cache_time)
+  ; ("winbind_machine_pwd_timeout", Int winbind_machine_pwd_timeout)
   ]
 
 let options_of_xapi_globs_spec =

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -158,7 +158,7 @@ class DynamicPam(ADConfig):
             condition = "ingroup" if is_group else "="
             self._lines.append("account sufficient pam_succeed_if.so user {} {}".format(condition, name))
         except Exception:
-            logger.warning("Failed to check subject %s for dynamic pam", sid)
+            logger.warning("Failed to check subject %s for dynamic pam", subject_rec)
 
     def _install(self):
         if self._ad_enabled:


### PR DESCRIPTION
User information is queried through ldap
When joining domain, a machine account and pasword is created in
the joined domain controller, and such info is used to by ldap
query for authentication.

However, if the domain have multiple domain controller,
the joined domain needs time to sync the data to other controllers.
Before the syncing is finished, if one lday query goes to other
domain controller, then it will failed as auth error.

This commit fix the issue by providing winbind krb5.conf to ldap query
This will guides ldap query goes to the right domain controller

Signed-off-by: Lin Liu <lin.liu@citrix.com>