### PR TITLE
REQ-403: failed_login_alert_freq

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1043,6 +1043,8 @@ type nvidia_t4_sriov = Nvidia_T4_SRIOV | Nvidia_LEGACY | Nvidia_DEFAULT
 
 let nvidia_t4_sriov = ref Nvidia_DEFAULT
 
+let failed_login_alert_freq = ref 3600
+
 let other_options =
   [
     gen_list_option "sm-plugins"
@@ -1237,6 +1239,12 @@ let other_options =
     , (fun () -> !repository_gpgkey_name)
     , "The name of gpg key used by RPM to verify metadata and packages in \
        repository"
+    )
+  ; ( "failed-login-alert-freq"
+    , Arg.Set_int failed_login_alert_freq
+    , (fun () -> string_of_int !failed_login_alert_freq)
+    , "Frequency at which we alert any failed logins (in seconds; \
+       default=3600s)"
     )
   ]
 

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -99,10 +99,13 @@ let register () =
   Xapi_periodic_scheduler.add_to_queue "Update monitor configuration"
     (Xapi_periodic_scheduler.Periodic 3600.0) 3600.0
     Monitor_master.update_configuration_from_master ;
-  if master then
-    Xapi_periodic_scheduler.add_to_queue "Periodic alert failed login attempts"
-      (Xapi_periodic_scheduler.Periodic 3600.0) 3600.0
-      Xapi_pool.alert_failed_login_attempts ;
+  ( if master then
+      let freq = !Xapi_globs.failed_login_alert_freq |> float_of_int in
+      Xapi_periodic_scheduler.add_to_queue
+        "Periodic alert failed login attempts"
+        (Xapi_periodic_scheduler.Periodic freq) freq
+        Xapi_pool.alert_failed_login_attempts
+  ) ;
   Xapi_periodic_scheduler.add_to_queue
     "Period alert if TLS verification emergency disabled"
     (Xapi_periodic_scheduler.Periodic 600.) 600. (fun () ->


### PR DESCRIPTION
Mostly for testing purposes, it is useful to be able to configure how
often we check to see if there were any failed logins.

See c27e7fd5597c48e93d46ddb469ea4b6a50ff5b67 for the associated
implementation