### PR TITLE
Add explicit package to dune tests

### DIFF
--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -56,4 +56,5 @@
   (name schematest)
   (modules schematest)
   (libraries xapi_datamodel)
+  (package xapi-datamodel)
 )

--- a/ocaml/xen-api-client/lib_test/dune
+++ b/ocaml/xen-api-client/lib_test/dune
@@ -18,6 +18,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (alias
   (name runtest)
   (deps (:x xen_api_test.exe))
+  (package xen-api-client)
   (action (run %%{x}))
 )
 |} coverage_rewriter


### PR DESCRIPTION
Prevent dependency errors when building opam packages.
Opam packages build just the parts they need, and if a 'runtest', 'test'
or 'tests' stanza in dune doesn't declare a package it will attempt to
run the tests for another opam package.
However we may be missing dependencies.

Ensure packages only run their own tests (which should also decrease
        testing times of subpackages)

Signed-off-by: Edwin Török <edvin.torok@citrix.com>