### PR TITLE
CP-37549: Address subject-add performance issue

### DIFF
--- a/ocaml/tests/test_extauth_plugin_ADwinbind.ml
+++ b/ocaml/tests/test_extauth_plugin_ADwinbind.ml
@@ -37,7 +37,8 @@ module ExtractOuConfig = Generic.MakeStateless (struct
           ; ("service-name", "conappada.local")
           ; ("ou", "TOU")
           ]
-        , ([("ou", "TOU")], ["createcomputer=TOU"]) )
+        , ([("ou", "TOU")], ["createcomputer=TOU"])
+        )
       ]
 end)
 
@@ -83,7 +84,8 @@ module ParseValueFromPbis = Generic.MakeStateless (struct
     `QuickAndAutoDocumented
       [
         ( "X'58005200540055004B002D00300032002D003000330024000000'"
-        , "XRTUK-02-03" )
+        , "XRTUK-02-03"
+        )
       ; ("X'4C004F00430041004C0048004F0053005400320024000000'", "LOCALHOST2")
       ]
 end)
@@ -135,7 +137,8 @@ let test_parse_wbinfo_uid_info =
           ; uid= 3000003
           ; gid= 3000174
           ; gecos= {|ladmin|}
-          } )
+          }
+      )
     ; ( {|CONNAPP\locked:*:3000004:3000174::/home/CONNAPP/locked:/bin/bash|}
       , Ok
           {user_name= {|CONNAPP\locked|}; uid= 3000004; gid= 3000174; gecos= ""}
@@ -342,7 +345,8 @@ msDS-SupportedEncryptionTypes: 0|}
           ; account_expired= false
           ; account_locked= false
           ; password_expired= false
-          } )
+          }
+      )
     ; ( stdout_locked
       , Ok
           {
@@ -353,7 +357,8 @@ msDS-SupportedEncryptionTypes: 0|}
           ; account_expired= false
           ; account_locked= true
           ; password_expired= false
-          } )
+          }
+      )
     ; ( stdout_expired
       , Ok
           {
@@ -364,7 +369,8 @@ msDS-SupportedEncryptionTypes: 0|}
           ; account_expired= true
           ; account_locked= false
           ; password_expired= false
-          } )
+          }
+      )
     ; ( stdout_krbtgt
       , Ok
           {
@@ -375,10 +381,12 @@ msDS-SupportedEncryptionTypes: 0|}
           ; account_locked= false
           ; account_expired= false
           ; account_disabled= true
-          } )
+          }
+      )
     ; ("Got 0 replies", Error "ldap parsing failed ': got 0 replies'")
     ; ( "complete garbage"
-      , Error "ldap parsing failed 'unexpected header: string'" )
+      , Error "ldap parsing failed 'unexpected header: string'"
+      )
     ]
   in
   matrix |> List.map @@ fun (inp, exp) -> ("<omit inp>", `Quick, check inp exp)
@@ -403,7 +411,8 @@ let test_wbinfo_exception_of_stderr =
     [
       ( "failed to call wbcLookupName: WBC_ERR_DOMAIN_NOT_FOUND\x0ACould not \
          lookup name ladmin@mydomain.net\x0A"
-      , Some (Auth_service_error (E_GENERIC, "WBC_ERR_DOMAIN_NOT_FOUND")) )
+      , Some (Auth_service_error (E_GENERIC, "WBC_ERR_DOMAIN_NOT_FOUND"))
+      )
     ; ("garbage", None)
     ]
   in
@@ -418,5 +427,6 @@ let tests =
   ; ("ADwinbind:test_parse_wbinfo_uid_info", test_parse_wbinfo_uid_info)
   ; ("ADwinbind:test_parse_ldap_stdout", test_parse_ldap_stdout)
   ; ( "ADwinbind:test_wbinfo_exception_of_stderr"
-    , test_wbinfo_exception_of_stderr )
+    , test_wbinfo_exception_of_stderr
+    )
   ]

--- a/ocaml/tests/test_xapi_cmd_result.ml
+++ b/ocaml/tests/test_xapi_cmd_result.ml
@@ -31,7 +31,8 @@ module XapiCmdResult = Generic.MakeStateless (struct
     `QuickAndAutoDocumented
       [
         ( (':', "Pre-Win2k Domain", "Pre-Win2k Domain: CONNAPP\nsome:other")
-        , Some "CONNAPP" )
+        , Some "CONNAPP"
+        )
       ; ((':', "Pre-Win2k Domain", "Not import msg"), None)
       ]
 end)

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7088,15 +7088,10 @@ let subject_add printer rpc session_id params =
   let subject_identifier =
     Client.Auth.get_subject_identifier ~rpc ~session_id ~subject_name
   in
-  (* obtains a list of name-value pairs with info about the subject from the external directory *)
-  let subject_info =
-    Client.Auth.get_subject_information_from_identifier ~rpc ~session_id
-      ~subject_identifier
-  in
-  (* now we've got enough information to create our new subject in the pool *)
+  (* now we've got enough information to create our new subject in the pool
+   * Subject.create will query subject information basing on the subject identifier *)
   let subject_ref =
-    Client.Subject.create ~rpc ~session_id ~subject_identifier
-      ~other_config:subject_info
+    Client.Subject.create ~rpc ~session_id ~subject_identifier ~other_config:[]
   in
   let subject_uuid = Client.Subject.get_uuid rpc session_id subject_ref in
   printer (Cli_printer.PList [subject_uuid])

--- a/ocaml/xapi/extauth.ml
+++ b/ocaml/xapi/extauth.ml
@@ -47,7 +47,7 @@ module Ext_auth = struct
     (* the external authentication plugin *)
     | "AD" ->
         (*windows active directory*)
-        Extauth_ad.methods()
+        Extauth_ad.methods ()
     (* if no other auth_type fits, then we don't know what to do *)
     | _ as uat ->
         (*error*)
@@ -87,7 +87,11 @@ let get_event_params ~__context host =
   let service_name =
     Db.Host.get_external_auth_service_name ~__context ~self:host
   in
-  [("auth_type", auth_type); ("service_name", service_name); ("ad_backend", !Xapi_globs.extauth_ad_backend)]
+  [
+    ("auth_type", auth_type)
+  ; ("service_name", service_name)
+  ; ("ad_backend", !Xapi_globs.extauth_ad_backend)
+  ]
 
 (* allows extauth hook script to be called only under specific conditions *)
 let can_execute_extauth_hook_script ~__context host event_name =

--- a/ocaml/xapi/extauth_ad.ml
+++ b/ocaml/xapi/extauth_ad.ml
@@ -69,7 +69,7 @@ let init_service ~__context =
   |> AD_type.of_string
   |> AD.init_service ~__context
 
-let methods() =
+let methods () =
   match !Xapi_globs.extauth_ad_backend |> AD_type.of_string with
   | Pbis ->
       Extauth_plugin_ADpbis.AuthADlw.methods

--- a/ocaml/xapi/extauth_plugin_ADpbis.ml
+++ b/ocaml/xapi/extauth_plugin_ADpbis.ml
@@ -27,7 +27,8 @@ let lwsmd_service = "lwsmd"
 module Lwsmd = struct
   let is_ad_enabled ~__context =
     ( Helpers.get_localhost ~__context |> fun self ->
-      Db.Host.get_external_auth_type ~__context ~self )
+      Db.Host.get_external_auth_type ~__context ~self
+    )
     |> fun x -> x = Xapi_globs.auth_type_AD
 
   let enable_nsswitch () =
@@ -119,7 +120,9 @@ let start_damon () =
     raise
       (Auth_signature.Auth_service_error
          ( Auth_signature.E_GENERIC
-         , Printf.sprintf "Failed to start %s" lwsmd_service ))
+         , Printf.sprintf "Failed to start %s" lwsmd_service
+         )
+      )
 
 module AuthADlw : Auth_signature.AUTH_MODULE = struct
   (*

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -228,7 +228,7 @@ module Ldap = struct
     parse_user stdout <!> generic_ex "%s"
 end
 
-type domain_name_type = | Name | NetbiosName
+type domain_name_type = Name | NetbiosName
 
 module Wbinfo = struct
   let exception_of_stderr =
@@ -236,7 +236,8 @@ module Wbinfo = struct
     let regex = Re.Perl.(compile (re {|.*(WBC_ERR_[A-Z_]*).*|})) in
     let get_regex_match x =
       Option.bind (Re.exec_opt regex x) (fun g ->
-          match Re.Group.all g with [|_; code|] -> Some code | _ -> None)
+          match Re.Group.all g with [|_; code|] -> Some code | _ -> None
+      )
     in
     fun stderr ->
       get_regex_match stderr
@@ -261,7 +262,8 @@ module Wbinfo = struct
                  Not_found
              | _ ->
                  Auth_service_error
-                   (E_GENERIC, Printf.sprintf "unknown error code: %s" code))
+                   (E_GENERIC, Printf.sprintf "unknown error code: %s" code)
+         )
 
   let call_wbinfo (args : string list) : (string, exn) result =
     let generic_err () =
@@ -315,29 +317,31 @@ module Wbinfo = struct
      * *)
     let args = ["--domain-info"; from_name] in
     let* stdout = call_wbinfo args in
-    let key = match target_name_type with
-    | Name -> "Alt_Name"
-    | NetbiosName -> "Name" in
-    try
-      Ok(Xapi_cmd_result.of_output ~sep:':' ~key stdout)
+    let key =
+      match target_name_type with Name -> "Alt_Name" | NetbiosName -> "Name"
+    in
+    try Ok (Xapi_cmd_result.of_output ~sep:':' ~key stdout)
     with _ -> Error (parsing_ex args)
 
   let is_domain_netbios_valid domain_netbios =
     let min_valid_domain_length = 1 in
     match domain_name_of ~target_name_type:Name ~from_name:domain_netbios with
-    | Ok name -> String.length name >= min_valid_domain_length
-    | Error _ -> false
+    | Ok name ->
+        String.length name >= min_valid_domain_length
+    | Error _ ->
+        false
 
   let domain_of_uname uname =
     match String.split_on_char '\\' uname with
     | [domain_netbios; _] ->
-      let* domain_name = domain_name_of ~target_name_type:Name ~from_name:domain_netbios in
-      Ok (domain_netbios, domain_name)
+        let* domain_name =
+          domain_name_of ~target_name_type:Name ~from_name:domain_netbios
+        in
+        Ok (domain_netbios, domain_name)
     | _ ->
         Error (generic_ex "Invalid domain user name %s" uname)
 
-
-  let all_domain_netbios() =
+  let all_domain_netbios () =
     (*
      * List all domains (trusted and own domain)
      * wbinfo --all-domains
@@ -355,8 +359,10 @@ module Wbinfo = struct
      * *)
     let args = ["--all-domains"] in
     let* stdout = call_wbinfo args in
-    Ok(String.split_on_char '\n' stdout
-      |> List.filter (fun x -> is_domain_netbios_valid x))
+    Ok
+      (String.split_on_char '\n' stdout
+      |> List.filter (fun x -> is_domain_netbios_valid x)
+      )
 
   type name = User of string | Other of string
 
@@ -378,7 +384,8 @@ module Wbinfo = struct
           | [|_; name; _|] ->
               Some (Other name)
           | _ ->
-              None)
+              None
+      )
     in
     fun sid ->
       let args = ["--sid-to-name"; sid] in
@@ -465,7 +472,8 @@ module Migrate_from_pbis = struct
     if String.length value <= min_valid_pbis_value_length then
       raise
         (Auth_service_error
-           (E_GENERIC, Printf.sprintf "No value for %s in %s" key db))
+           (E_GENERIC, Printf.sprintf "No value for %s in %s" key db)
+        )
     else
       value
 
@@ -479,7 +487,8 @@ module Migrate_from_pbis = struct
     | _ ->
         raise
           (Auth_service_error
-             (E_GENERIC, Printf.sprintf "Failed to extract %s from %s" reg input))
+             (E_GENERIC, Printf.sprintf "Failed to extract %s from %s" reg input)
+          )
 
   let parse_value_from_pbis raw_value =
     debug "parsing raw_value from pbis %s" raw_value ;
@@ -535,7 +544,8 @@ let get_domain_info_from_db () =
       Db.Host.get_external_auth_configuration ~__context ~self:host |> fun l ->
       (List.assoc_opt "workgroup" l, List.assoc_opt "netbios_name" l)
     in
-    {service_name; workgroup; netbios_name})
+    {service_name; workgroup; netbios_name}
+    )
   |> Server_helpers.exec_with_new_task
        "retrieving external auth domain workgroup"
 
@@ -546,8 +556,14 @@ let kdcs_of_domain domain =
     (* Result like 10.71.212.25:88\n10.62.1.25:88\n*)
     |> String.split_on_char '\n'
     |> List.filter (fun x -> String.trim x <> "") (* Remove empty lines *)
-    |> List.map (fun r -> String.split_on_char ':' r |> hd (Printf.sprintf "Invalid kdc %s" r))
-  with _ -> raise (Auth_service_error (E_LOOKUP, (Printf.sprintf "Failed to lookup kdcs of domain %s" domain)))
+    |> List.map (fun r ->
+           String.split_on_char ':' r |> hd (Printf.sprintf "Invalid kdc %s" r)
+       )
+  with _ ->
+    raise
+      (Auth_service_error
+         (E_LOOKUP, Printf.sprintf "Failed to lookup kdcs of domain %s" domain)
+      )
 
 let query_domain_workgroup ~domain ~db_workgroup =
   (* If workgroup found in pool database just use it, otherwise, query DC *)
@@ -561,8 +577,7 @@ let query_domain_workgroup ~domain ~db_workgroup =
       in
       try
         let kdc =
-          kdcs_of_domain domain
-          |> hd "lookup kdc return invalid result"
+          kdcs_of_domain domain |> hd "lookup kdc return invalid result"
         in
 
         let lines =
@@ -594,7 +609,8 @@ let config_winbind_damon ~domain ~workgroup ~netbios_name =
       ; "winbind enum groups = no"
       ; "winbind enum users = no"
       ; Printf.sprintf "winbind cache time = %d" !Xapi_globs.winbind_cache_time
-      ; Printf.sprintf "machine password timeout = %d" !Xapi_globs.winbind_machine_pwd_timeout
+      ; Printf.sprintf "machine password timeout = %d"
+          !Xapi_globs.winbind_machine_pwd_timeout
       ; "kerberos encryption types = strong"
       ; Printf.sprintf "workgroup = %s" workgroup
       ; Printf.sprintf "netbios name = %s" netbios_name
@@ -609,7 +625,8 @@ let config_winbind_damon ~domain ~workgroup ~netbios_name =
   let len = String.length conf_contents in
   Unixext.atomic_write_to_file smb_config 0o0644 (fun fd ->
       let (_ : int) = Unix.single_write_substring fd conf_contents 0 len in
-      Unix.fsync fd)
+      Unix.fsync fd
+  )
 
 let from_config ~name ~err_msg ~config_params =
   match List.assoc_opt name config_params with
@@ -623,7 +640,8 @@ let all_number_re = Re.Perl.re {|^\d+$|} |> Re.Perl.compile
 let get_localhost_name () =
   (fun __context ->
     Helpers.get_localhost ~__context |> fun host ->
-    Db.Host.get_hostname ~__context ~self:host)
+    Db.Host.get_hostname ~__context ~self:host
+    )
   |> Server_helpers.exec_with_new_task "retrieving hostname"
 
 let assert_hostname_valid ~hostname =
@@ -633,7 +651,8 @@ let assert_hostname_valid ~hostname =
       (Auth_service_error
          ( E_GENERIC
          , Printf.sprintf "hostname '%s' cannot contain only digits." hostname
-         ))
+         )
+      )
 
 let assert_domain_equal_service_name ~service_name ~config_params =
   (* For legeacy support, if domain exist in config_params, it must be equal to service_name *)
@@ -642,7 +661,8 @@ let assert_domain_equal_service_name ~service_name ~config_params =
   | Some domain when domain <> service_name ->
       raise
         (Auth_service_error
-           (E_GENERIC, "if present, config:domain must match service-name."))
+           (E_GENERIC, "if present, config:domain must match service-name.")
+        )
   | _ ->
       ()
 
@@ -670,7 +690,8 @@ let persist_extauth_config ~domain ~user ~ou_conf ~workgroup ~netbios_name =
     Helpers.get_localhost ~__context |> fun self ->
     Db.Host.set_external_auth_configuration ~__context ~self ~value ;
     Db.Host.get_name_label ~__context ~self
-    |> debug "update external_auth_configuration for host %s")
+    |> debug "update external_auth_configuration for host %s"
+    )
   |> Server_helpers.exec_with_new_task "update external_auth_configuration"
 
 let disable_machine_account ~service_name = function
@@ -728,7 +749,8 @@ module Winbind = struct
 
   let is_ad_enabled ~__context =
     ( Helpers.get_localhost ~__context |> fun self ->
-      Db.Host.get_external_auth_type ~__context ~self )
+      Db.Host.get_external_auth_type ~__context ~self
+    )
     |> fun x -> x = Xapi_globs.auth_type_AD
 
   let start ~timeout ~wait_until_success =
@@ -784,7 +806,7 @@ module Winbind = struct
       raise (Auth_service_error (E_GENERIC, msg))
 
   let random_string len =
-    let upper_char_start = Char.code('A') in
+    let upper_char_start = Char.code 'A' in
     let upper_char_len = 26 in
     let random_char () =
       upper_char_start + Random.int upper_char_len |> char_of_int
@@ -807,48 +829,68 @@ end
 
 module ClosestKdc = struct
   let periodic_update_task_name = "Update closest kdc"
+
   let startup_delay = 5.
 
   let mtime_this ~name ~f =
-    let start = Mtime_clock.counter() in
-    match f() with
-    | Ok _ -> Ok(name, Mtime_clock.count start)
-    | Error e -> Error e
+    let start = Mtime_clock.counter () in
+    match f () with
+    | Ok _ ->
+        Ok (name, Mtime_clock.count start)
+    | Error e ->
+        Error e
 
   let update_db ~domain ~kdc =
-  (fun __context ->
-     let self = Helpers.get_localhost ~__context in
-     Db.Host.get_external_auth_configuration ~__context ~self|> fun value ->
-     (domain, kdc) :: List.remove_assoc domain value |> fun value ->
-     Db.Host.set_external_auth_configuration ~__context ~self ~value)
-  |> Server_helpers.exec_with_new_task "update domain closest kdc"
+    (fun __context ->
+      let self = Helpers.get_localhost ~__context in
+      Db.Host.get_external_auth_configuration ~__context ~self |> fun value ->
+      (domain, kdc) :: List.remove_assoc domain value |> fun value ->
+      Db.Host.set_external_auth_configuration ~__context ~self ~value
+      )
+    |> Server_helpers.exec_with_new_task "update domain closest kdc"
 
   let from_db domain =
     (fun __context ->
-     let self = Helpers.get_localhost ~__context in
-     Db.Host.get_external_auth_configuration ~__context ~self|> List.assoc_opt domain)
-  |> Server_helpers.exec_with_new_task "query domain closest kdc"
+      let self = Helpers.get_localhost ~__context in
+      Db.Host.get_external_auth_configuration ~__context ~self
+      |> List.assoc_opt domain
+      )
+    |> Server_helpers.exec_with_new_task "query domain closest kdc"
 
   let lookup domain =
     try
-      let* krbtgt_sid = Wbinfo.sid_of_name (Printf.sprintf "%s@%s" krbtgt domain) in
-      let* domain_netbios_name = Wbinfo.domain_name_of ~target_name_type:NetbiosName ~from_name: domain in
+      let* krbtgt_sid =
+        Wbinfo.sid_of_name (Printf.sprintf "%s@%s" krbtgt domain)
+      in
+      let* domain_netbios_name =
+        Wbinfo.domain_name_of ~target_name_type:NetbiosName ~from_name:domain
+      in
 
       kdcs_of_domain domain
-      |> List.map (fun kdc -> debug "Got domain '%s' kdc '%s'" domain kdc; kdc)
-      |> List.map (fun kdc -> mtime_this ~name:kdc ~f:(fun() -> Ldap.query_user krbtgt_sid domain_netbios_name kdc))
+      |> List.map (fun kdc ->
+             debug "Got domain '%s' kdc '%s'" domain kdc ;
+             kdc
+         )
+      |> List.map (fun kdc ->
+             mtime_this ~name:kdc ~f:(fun () ->
+                 Ldap.query_user krbtgt_sid domain_netbios_name kdc
+             )
+         )
       |> List.filter_map Result.to_option
       |> List.sort (fun (_, s1) (_, s2) -> Mtime.Span.compare s1 s2)
       |> hd (Printf.sprintf "domain %s does not has valid kdc" domain)
-      |> fun x -> Ok(domain, fst x)
+      |> fun x -> Ok (domain, fst x)
     with e ->
-      debug "Failed to lookup domain %s closest kdc" domain;
+      debug "Failed to lookup domain %s closest kdc" domain ;
       Error e
 
-  let update() =
+  let update () =
     try
-      Wbinfo.all_domain_netbios() |> maybe_raise
-      |> List.map (fun netbios -> Wbinfo.domain_name_of ~target_name_type:Name ~from_name:netbios)
+      Wbinfo.all_domain_netbios ()
+      |> maybe_raise
+      |> List.map (fun netbios ->
+             Wbinfo.domain_name_of ~target_name_type:Name ~from_name:netbios
+         )
       |> List.filter_map Result.to_option
       |> List.map (fun domain -> lookup domain)
       |> List.filter_map Result.to_option
@@ -856,13 +898,15 @@ module ClosestKdc = struct
     with e -> error "Failed to update domain kdc %s" (Printexc.to_string e)
 
   let trigger_update ~start =
-    if Pool_role.is_master() then
+    if Pool_role.is_master () then
       Xapi_periodic_scheduler.add_to_queue periodic_update_task_name
-        (Xapi_periodic_scheduler.Periodic !Xapi_globs.winbind_update_closest_kdc_interval)
+        (Xapi_periodic_scheduler.Periodic
+           !Xapi_globs.winbind_update_closest_kdc_interval
+        )
         start update
 
-  let stop_update() =
-    if Pool_role.is_master() then
+  let stop_update () =
+    if Pool_role.is_master () then
       Xapi_periodic_scheduler.remove_from_queue periodic_update_task_name
 end
 
@@ -911,8 +955,7 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
        | Auth_service_error (E_GENERIC, msg) ->
            Auth_failure msg
        | e ->
-           D.error "authenticate_username_password:ex: %s"
-             (Printexc.to_string e) ;
+           D.error "authenticate_username_password:ex: %s" (Printexc.to_string e) ;
            Auth_failure
              (Printf.sprintf "couldn't get SID from username='%s'" uname)
      in
@@ -950,11 +993,15 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
   let query_subject_information_user (uid : int) (sid : string) =
     let* {user_name; gecos; gid} = Wbinfo.uid_info_of_uid uid in
     let* domain_netbios, domain = Wbinfo.domain_of_uname user_name in
-    let closest_kdc = match ClosestKdc.from_db domain with
-      | Some kdc -> kdc
+    let closest_kdc =
+      match ClosestKdc.from_db domain with
+      | Some kdc ->
+          kdc
       | None ->
-        (* Just pick the first KDC in the list *)
-        kdcs_of_domain domain |> hd (Printf.sprintf "Failed to lookup kdc of domain %s" domain) in
+          (* Just pick the first KDC in the list *)
+          kdcs_of_domain domain
+          |> hd (Printf.sprintf "Failed to lookup kdc of domain %s" domain)
+    in
     let* {
            name
          ; upn
@@ -976,11 +1023,13 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
           else if gecos <> "" && gecos <> "<null>" then
             gecos
           else
-            user_name )
+            user_name
+        )
       ; ("subject-uid", string_of_int uid)
       ; ("subject-gid", string_of_int gid)
       ; ( "subject-upn"
-        , if upn <> "" then upn else Printf.sprintf "%s@%s" name domain )
+        , if upn <> "" then upn else Printf.sprintf "%s@%s" name domain
+        )
       ; ("subject-account-disabled", string_of_bool account_disabled)
       ; ("subject-account-locked", string_of_bool account_locked)
       ; ("subject-account-expired", string_of_bool account_expired)
@@ -1084,7 +1133,8 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
       Winbind.check_ready_to_serve ~timeout:300. ;
       persist_extauth_config ~domain:service_name ~user ~ou_conf ~workgroup
         ~netbios_name ;
-      ClosestKdc.trigger_update ~start:0.; (* Trigger right now *)
+      ClosestKdc.trigger_update ~start:0. ;
+      (* Trigger right now *)
       debug "Succeed to join domain %s" service_name
     with
     | Forkhelpers.Spawn_internal_error (_, stdout, _) ->
@@ -1124,7 +1174,7 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
     (* Clean extauth config *)
     persist_extauth_config ~domain:"" ~user:"" ~ou_conf:[] ~workgroup:""
       ~netbios_name:"" ;
-    ClosestKdc.stop_update() ;
+    ClosestKdc.stop_update () ;
     debug "Succeed to disable external auth for %s" service_name
 
   (* unit on_xapi_initialize(bool system_boot)
@@ -1134,7 +1184,7 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
   *)
   let on_xapi_initialize _system_boot =
     Winbind.start ~timeout:5. ~wait_until_success:true ;
-    ClosestKdc.trigger_update ~start:ClosestKdc.startup_delay;
+    ClosestKdc.trigger_update ~start:ClosestKdc.startup_delay ;
     Winbind.check_ready_to_serve ~timeout:300.
 
   (* unit on_xapi_exit()

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1390,7 +1390,8 @@ let server_init () =
             )
           ; ( "Initializing AD external auth service"
             , [Startup.NoExnRaising]
-            , fun () -> Extauth_ad.init_service ~__context )
+            , fun () -> Extauth_ad.init_service ~__context
+            )
           ; ( "Calling on_xapi_initialize event hook in the external \
                authentication plugin"
             , [Startup.NoExnRaising; Startup.OnThread]

--- a/ocaml/xapi/xapi_cmd_result.mli
+++ b/ocaml/xapi/xapi_cmd_result.mli
@@ -30,4 +30,4 @@ val find : string -> t -> string option
 val of_output_opt : sep:char -> key:string -> lines:string -> string option
 
 (* find result from the whole result lines *)
-val of_output: sep:char -> key:string -> string -> string
+val of_output : sep:char -> key:string -> string -> string

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -993,7 +993,9 @@ let xapi_globs_spec =
   ; ("winbind_debug_level", Int winbind_debug_level)
   ; ("winbind_cache_time", Int winbind_cache_time)
   ; ("winbind_machine_pwd_timeout", Int winbind_machine_pwd_timeout)
-  ; ("winbind_update_closest_kdc_interval", Float winbind_update_closest_kdc_interval)
+  ; ( "winbind_update_closest_kdc_interval"
+    , Float winbind_update_closest_kdc_interval
+    )
   ]
 
 let options_of_xapi_globs_spec =
@@ -1244,11 +1246,13 @@ let other_options =
   ; ( "allow-host-sched-gran-modification"
     , Arg.Set allow_host_sched_gran_modification
     , (fun () -> string_of_bool !allow_host_sched_gran_modification)
-    , "Allows to modify the host's scheduler granularity" )
+    , "Allows to modify the host's scheduler granularity"
+    )
   ; ( "extauth_ad_backend"
     , Arg.Set_string extauth_ad_backend
     , (fun () -> !extauth_ad_backend)
-    , "Which AD backend used to talk to DC" )
+    , "Which AD backend used to talk to DC"
+    )
   ; ( "website-https-only"
     , Arg.Set website_https_only
     , (fun () -> string_of_bool !website_https_only)
@@ -1428,18 +1432,22 @@ module Resources = struct
       )
     ; ( "gen_pool_secret_script"
       , gen_pool_secret_script
-      , "Generates new pool secrets" )
+      , "Generates new pool secrets"
+      )
     ; ( "samba administration tool"
       , net_cmd
-      , "Executed to manage external auth with AD like join and leave domain" )
+      , "Executed to manage external auth with AD like join and leave domain"
+      )
     ; ( "Samba TDB (Trivial Database) management tool"
       , tdb_tool
-      , "Executed to manage Samba Database" )
+      , "Executed to manage Samba Database"
+      )
     ; ("winbind query tool", wb_cmd, "Query information from winbind daemon")
     ; ("ntlm auth utility", ntlm_auth_cmd, "Used to authenticate AD users")
     ; ( "SQLite database  management tool"
       , sqlite3
-      , "Executed to manage SQlite Database, like PBIS database" )
+      , "Executed to manage SQlite Database, like PBIS database"
+      )
     ]
 
   let essential_files =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -915,6 +915,8 @@ let winbind_cache_time = ref 60
 
 let winbind_machine_pwd_timeout = ref (7 * 24 * 3600)
 
+let winbind_update_closest_kdc_interval = ref (3600. *. 24.) (* every day *)
+
 let tdb_tool = ref "/usr/bin/tdbtool"
 
 let sqlite3 = ref "/usr/bin/sqlite3"
@@ -991,6 +993,7 @@ let xapi_globs_spec =
   ; ("winbind_debug_level", Int winbind_debug_level)
   ; ("winbind_cache_time", Int winbind_cache_time)
   ; ("winbind_machine_pwd_timeout", Int winbind_machine_pwd_timeout)
+  ; ("winbind_update_closest_kdc_interval", Float winbind_update_closest_kdc_interval)
   ]
 
 let options_of_xapi_globs_spec =

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -340,11 +340,12 @@ let get_permissions ~__context ~subject_membership =
   permission_membership
 
 (* CP-827: finds out if the subject was suspended (ie. disabled,expired,locked-out) *)
-let is_subject_suspended  ~__context ~cache subject_identifier =
+let is_subject_suspended ~__context ~cache subject_identifier =
   (* obtains the subject's info containing suspension information *)
   let info =
     try
-      Xapi_subject.get_subject_information_from_identifier ~__context ~cache subject_identifier
+      Xapi_subject.get_subject_information_from_identifier ~__context ~cache
+        subject_identifier
     with Auth_signature.Subject_cannot_be_resolved | Not_found ->
       (* user was not found in external directory in order to obtain info *)
       debug "Subject %s not found in external directory while re-obtaining info"
@@ -462,8 +463,17 @@ let revalidate_external_session ~__context ~session =
           (* 2a. revalidate external authentication *)
 
           (* CP-827: if the user was suspended (disabled,expired,locked-out), then we must destroy the session *)
-          let suspended, _ = is_subject_suspended ~__context ~cache:true authenticated_user_sid in
-          let suspended = if suspended then is_subject_suspended ~__context ~cache:false authenticated_user_sid |> fst else suspended in
+          let suspended, _ =
+            is_subject_suspended ~__context ~cache:true authenticated_user_sid
+          in
+          let suspended =
+            if suspended then
+              is_subject_suspended ~__context ~cache:false
+                authenticated_user_sid
+              |> fst
+            else
+              suspended
+          in
           if suspended then (
             debug
               "Subject (identifier %s) has been suspended, destroying session \
@@ -842,8 +852,15 @@ let login_with_password ~__context ~uname ~pwd ~version ~originator =
                 (* subject info caching problems in likewise) and closes the user's session *)
                 let subject_suspended, subject_name =
                   try
-                    let suspended, name = is_subject_suspended ~__context ~cache:true subject_identifier in
-                    if suspended then is_subject_suspended ~__context ~cache:false subject_identifier else suspended, name
+                    let suspended, name =
+                      is_subject_suspended ~__context ~cache:true
+                        subject_identifier
+                    in
+                    if suspended then
+                      is_subject_suspended ~__context ~cache:false
+                        subject_identifier
+                    else
+                      (suspended, name)
                   with Auth_signature.Auth_service_error (errtag, msg) ->
                     debug
                       "Failed to find if user %s (subject_id %s, from %s) is \

--- a/ocaml/xapi/xapi_subject.ml
+++ b/ocaml/xapi/xapi_subject.ml
@@ -29,7 +29,10 @@ let run_hook_script_after_subject_add () =
         (Server_helpers.exec_with_new_task "run_hook_script_after_subject_add"
            (fun __context ->
              Extauth.call_extauth_hook_script_in_pool ~__context
-               Extauth.event_name_after_subject_add)))
+               Extauth.event_name_after_subject_add
+         )
+        )
+  )
 
 let asynchronously_run_hook_script_after_subject_add =
   At_least_once_more.make "running after-subject-add hook script"
@@ -51,7 +54,8 @@ let create ~__context ~subject_identifier ~other_config =
         (* visits each subject in the table o(n) *)
         let subject_id_in_db = record.API.subject_subject_identifier in
         subject_identifier = subject_id_in_db
-        (* is it the subject we are looking for? *))
+        (* is it the subject we are looking for? *)
+        )
       subjects
   then (
     (* we found an already existing user with the same subject identifier. *)
@@ -104,7 +108,10 @@ let run_hook_script_after_subject_remove () =
         (Server_helpers.exec_with_new_task
            "run_hook_script_after_subject_remove" (fun __context ->
              Extauth.call_extauth_hook_script_in_pool ~__context
-               Extauth.event_name_after_subject_remove)))
+               Extauth.event_name_after_subject_remove
+         )
+        )
+  )
 
 let asynchronously_run_hook_script_after_subject_remove =
   At_least_once_more.make "running after-subject-remove hook script"
@@ -148,7 +155,8 @@ let update_all_subjects ~__context =
           debug "Error trying to update subject %s: %s"
             (Db.Subject.get_subject_identifier ~__context ~self:subj)
             (ExnHelper.string_of_exn e)
-        (* ignore this exception e, do not raise it again *))
+        (* ignore this exception e, do not raise it again *)
+        )
       subjects
 
 (* This function returns all permissions associated with a subject *)
@@ -162,9 +170,11 @@ let get_permissions_name_label ~__context ~self =
        (fun accu role ->
          List.rev_append
            (Xapi_role.get_permissions_name_label ~__context ~self:role)
-           accu)
+           accu
+         )
        []
-       (Db.Subject.get_roles ~__context ~self))
+       (Db.Subject.get_roles ~__context ~self)
+    )
 
 let run_hook_script_after_subject_roles_update () =
   (* CP-825: Serialize execution of pool-enable-extauth and pool-disable-extauth *)
@@ -176,7 +186,10 @@ let run_hook_script_after_subject_roles_update () =
         (Server_helpers.exec_with_new_task
            "run_hook_script_after_subject_roles_update" (fun __context ->
              Extauth.call_extauth_hook_script_in_pool ~__context
-               Extauth.event_name_after_roles_update)))
+               Extauth.event_name_after_roles_update
+         )
+        )
+  )
 
 let asynchronously_run_hook_script_after_subject_roles_update =
   At_least_once_more.make "running after-subject-roles-update hook script"
@@ -225,7 +238,9 @@ let query_subject_information_from_db ~__context identifier =
       ~expr:
         (Db_filter_types.Eq
            ( Db_filter_types.Field "subject_identifier"
-           , Db_filter_types.Literal identifier ))
+           , Db_filter_types.Literal identifier
+           )
+        )
   with
   | [] ->
       raise Auth_signature.Subject_cannot_be_resolved
@@ -235,4 +250,7 @@ let query_subject_information_from_db ~__context identifier =
 
 let get_subject_information_from_identifier ~__context ~cache identifier =
   let open Extauth in
-  if cache then query_subject_information_from_db ~__context identifier else (Ext_auth.d ()).query_subject_information identifier
+  if cache then
+    query_subject_information_from_db ~__context identifier
+  else
+    (Ext_auth.d ()).query_subject_information identifier

--- a/ocaml/xapi/xapi_systemctl.ml
+++ b/ocaml/xapi/xapi_systemctl.ml
@@ -37,7 +37,8 @@ let perform ~wait_until_success ~service ~timeout op =
     debug "%s %s" op_str service ;
     ignore
       (Forkhelpers.execute_command_get_output !Xapi_globs.systemctl
-         [op_str; service]) ;
+         [op_str; service]
+      ) ;
     if wait_until_success then (
       if op = Restart then Thread.delay 0.1 ;
       let is_active = Fe_systemctl.is_active service in


### PR DESCRIPTION
subject-add needs to perform ldap query for subject information like subject-name
lockout, disabled, etc. This takes long time for subject add

This commit address the issue by
1. Only query subject information from sid once
2. Query and cache closest KDC and update regularly

Signed-off-by: Lin Liu <lin.liu@citrix.com>