### PR TITLE
REQ-403 add fist to Cert_distrib.exchange_certificate_among_all_members

### DIFF
--- a/ocaml/xapi/cert_distrib.ml
+++ b/ocaml/xapi/cert_distrib.ml
@@ -364,7 +364,7 @@ let take_and_append n x xs =
   in
   loop 0 [] xs
 
-let exchange_certificates_among_all_members ~__context =
+let exchange_certificates_in_pool ~__context =
   (* here we coordinate the certificate distribution. from a high level
      we do the following:
      a) collect certs from all the members, aggregating them on the master.
@@ -387,7 +387,7 @@ let exchange_certificates_among_all_members ~__context =
      *   - throw an error at a random point
      *   - print out what is going to execute for debugging purposes
      *)
-    match Xapi_fist.exchange_certificates_among_all_members () with
+    match Xapi_fist.exchange_certificates_in_pool () with
     | None ->
         Fun.id
     | Some seed ->
@@ -401,16 +401,13 @@ let exchange_certificates_among_all_members ~__context =
                   Api_errors.(
                     Server_error
                       ( internal_error
-                      , [
-                          "/tmp/fist_exchange_certificates_among_all_members \
-                           FIST!"
-                        ]
+                      , ["/tmp/fist_exchange_certificates_in_pool FIST!"]
                       )
                   )
             )
           in
           let ops' = take_and_append rand_i throw_op ops in
-          D.debug "exchange_certificates_among_all_members: we are about to..." ;
+          D.debug "exchange_certificates_in_pool: we are about to..." ;
           List.iteri (fun i (desc, _) -> D.debug "%d. %s" i desc) ops' ;
           ops'
   in

--- a/ocaml/xapi/cert_distrib.mli
+++ b/ocaml/xapi/cert_distrib.mli
@@ -15,8 +15,8 @@
 val local_exec : __context:Context.t -> command:string -> string
 (** execute a string encoded job, returning a string encoded result *)
 
-val exchange_certificates_among_all_members : __context:Context.t -> unit
-(** [exchange_certificates_among_all_members ~__context] collects internal
+val exchange_certificates_in_pool : __context:Context.t -> unit
+(** [exchange_certificates_in_pool ~__context] collects internal
     certificates from all members in a pool and installed on all of them. On
     success, new bundles will have been generated on the members. *)
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -997,7 +997,7 @@ functor
           ~doc:"Pool.enable_tls_verification" ~self ~op:`tls_verification_enable
           (fun () ->
             debug "Pool.enable_tls_verification start ... (1/2)" ;
-            Cert_distrib.exchange_certificates_among_all_members ~__context ;
+            Cert_distrib.exchange_certificates_in_pool ~__context ;
             while Xapi_fist.pause_after_cert_exchange () do
               debug "Pool.enable_tls_verification sleeping on fistpoint" ;
               Thread.delay 5.0

--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -122,3 +122,32 @@ let hang_psr psr_checkpoint =
       "psr_cleanup"
   )
   |> hang_while
+
+(* extract integer seed from fist file, if it exists.
+ * raises if fist file exists but does not contain an integer *)
+let int_seed name : int option =
+  let ex msg = Api_errors.(Server_error (internal_error, [msg])) in
+  match fistpoint name with
+  | false ->
+      D.debug "fistpoint=%s is not being used" name ;
+      None
+  | true -> (
+    match fistpoint_read name with
+    | None ->
+        Printf.sprintf "fistpoint=%s exists but has no seed" name |> ex |> raise
+    | Some seed -> (
+      try
+        let seed = seed |> String.trim |> int_of_string in
+        D.debug "fistpoint=%s using seed=%i" name seed ;
+        Some seed
+      with _ ->
+        Printf.sprintf "fistpoint=%s exists but seed='%s' is not an integer"
+          name seed
+        |> ex
+        |> raise
+    )
+  )
+
+let exchange_certificates_among_all_members () : int option =
+  let name = "exchange_certificates_among_all_members" in
+  int_seed name

--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -148,6 +148,6 @@ let int_seed name : int option =
     )
   )
 
-let exchange_certificates_among_all_members () : int option =
-  let name = "exchange_certificates_among_all_members" in
+let exchange_certificates_in_pool () : int option =
+  let name = "exchange_certificates_in_pool" in
   int_seed name


### PR DESCRIPTION
The idea here is that a test harness can place `/tmp/fist_exchange_certificates_among_all_members` on the file system of the primary host, and cause subsequent calls to`Pool.enable_tls_verification` to fail during its critical section. This will allow the test harness to mimic network failures, and reliably test their effect on this api call