### PR TITLE
Stunnel.reload: wait 5s by default

### DIFF
--- a/ocaml/xapi/cert_refresh.ml
+++ b/ocaml/xapi/cert_refresh.ml
@@ -97,8 +97,11 @@ let host ~__context ~type' =
         Certificates.Db_util.add_cert ~__context ~type':(`host_internal host)
           cert
   in
-  (* start using new cert *)
-  Helpers.Stunnel.reload () ; ref
+  (* We might have a slow client that connects using the old cert and
+     has not picked up the new cert. To avoid that the connection fails,
+     continue using the old cert for a small time before serving the new
+     cert *)
+  Thread.delay 5.0 ; Helpers.Stunnel.reload () ; ref
 
 (* The stunnel clients trust the old and the new [host] server cert.  On
 the local host, rename the old cert and re-create the cert bundle

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1826,8 +1826,8 @@ module Stunnel : sig
   val restart : __context:Context.t -> accept:string -> unit
   (** restart stunnel, possibly changing the config file *)
 
-  val reload : unit -> unit
-  (** reload (potentially updated) configuration *)
+  val reload : ?wait:float -> unit -> unit
+  (** reload (potentially updated) configuration and wait 5s *)
 end = struct
   let cert = !Xapi_globs.server_cert_path
 
@@ -1914,7 +1914,10 @@ end = struct
 
   let systemctl_ cmd = systemctl cmd |> ignore
 
-  let reload () = systemctl_ "reload-or-restart"
+  let reload ?(wait = 5.0) () =
+    systemctl_ "reload-or-restart" ;
+    (* We can't be sure that the reload is finished, so wait a moment *)
+    Thread.delay wait
 
   let is_enabled () =
     let is_enabled_stdout =


### PR DESCRIPTION
The stunnel reload is initiated via systemd, which in turn sends a
signal to stunnel. This is an asynchronous call and we can't know for
sure that stunnel has reloaded its configuration when the call returns.
This can create a race condition in that we try using the new
configuration when indeed it is not yet ready. To avoid this, wait 5
seconds. There is no good mechanism to make this synchronous.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>