### PR TITLE
REQ-403 change type of cert generated during cert refresh

### DIFF
--- a/ocaml/gencert/gencert.ml
+++ b/ocaml/gencert/gencert.ml
@@ -63,7 +63,10 @@ let main ~dbg ~path ~sni =
         ()
     | SNI.Xapi_pool ->
         let uuid = Inventory.lookup Inventory._installation_uuid in
-        Gencertlib.Selfcert.xapi_pool ~uuid path
+        let (_ : X509.Certificate.t) =
+          Gencertlib.Selfcert.xapi_pool ~uuid path
+        in
+        ()
   in
   generate_cert_or_fail ~generator ~path
 

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -147,10 +147,10 @@ let xapi_pool ~uuid pemfile =
       ]
     in
     let extensions = X509.Extension.empty in
-    let* (_ : X509.Certificate.t) =
+    let* (c : X509.Certificate.t) =
       selfsign issuer extensions key_length expiration pemfile
     in
-    Ok ()
+    Ok c
   in
   R.failwith_error_msg res
 

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -11,7 +11,7 @@ val host :
 (** [host name dns_names ip path] creates (atomically) a PEM file at
     [path] with [name] as CN, and the following SANs: [dns_names] + [ip] *)
 
-val xapi_pool : uuid:string -> string -> unit
+val xapi_pool : uuid:string -> string -> X509.Certificate.t
 (** [xapi_pool uuid path] creates (atomically) a PEM file at [path] with
     [uuid] as CN *)
 

--- a/ocaml/xapi/cert_refresh.ml
+++ b/ocaml/xapi/cert_refresh.ml
@@ -40,22 +40,6 @@ let new_cert_path type' = replace_extension (cert_path type') ~ext:"new"
 
 let backup_cert_path type' = replace_extension (cert_path type') ~ext:"bak"
 
-(* Create a new host cert in the file system and return its contents
-also as a data structure *)
-let new_host_cert ~dbg ~path : X509.Certificate.t =
-  let name, ip =
-    match Networking_info.get_management_ip_addr ~dbg with
-    | None ->
-        let msg = Printf.sprintf "%s: failed to get management IP" __LOC__ in
-        D.error "%s" msg ;
-        raise Api_errors.(Server_error (internal_error, [msg]))
-    | Some ip ->
-        ip
-  in
-  let dns_names = Networking_info.dns_names () in
-  let ips = [ip] in
-  Gencertlib.Selfcert.host ~name ~dns_names ~ips path
-
 module HostSet = Set.Make (struct
   type t = API.ref_host
 
@@ -82,10 +66,10 @@ let maybe_restart_cluster_daemon ~__context =
 distribute it in the pool *)
 let host ~__context ~type' =
   let host = Helpers.get_localhost ~__context in
-  let dbg = Context.string_of_task __context in
   let pem = cert_path type' in
   let path = new_cert_path type' in
-  let cert = new_host_cert ~dbg ~path in
+  let uuid = Inventory.lookup Inventory._installation_uuid in
+  let cert = Gencertlib.Selfcert.xapi_pool ~uuid path in
   let bak = backup_cert_path type' in
   let unreachable = unreachable_hosts ~__context in
   if not @@ HostSet.is_empty unreachable then


### PR DESCRIPTION
We should be creating a cert with CN=$uuid, rather than with CN=$ip
