### PR TITLE
CP-36409: fix storage driver domain race conditions on startup

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -1406,6 +1406,9 @@ let bind ~__context ~pbd =
       error "Caught VM_BAD_POWER_STATE [ %s ]" (String.concat "; " params)
     (* ignore for now *)
   ) ;
+  if not (Helpers.is_domain_zero ~__context driver) then
+    (* Return the IP of the driver domain, and wait until it responds on this IP *)
+    info "Storage driver domain is up on IP %s" (System_domains.ip_of ~__context driver);
   let uuid = Db.VM.get_uuid ~__context ~self:driver in
   let sr = Db.PBD.get_SR ~__context ~self:pbd in
   let ty = Db.SR.get_type ~__context ~self:sr in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -3041,6 +3041,17 @@ let resync_resident_on ~__context =
           ()
       )
     xenopsd_vms_in_xapi ;
+  (* Reset Dom0 plugged VBDs *)
+  if !Xapi_globs.on_system_boot then begin
+    (* mark all VBDs that were plugged into Dom0 as disconnected *)
+    Helpers.get_domain_zero ~__context
+    |> fun self -> Db.VM.get_VBDs ~__context ~self
+    |> List.iter (fun vbd ->
+        Db.VBD.set_currently_attached ~__context ~self:vbd ~value:false ;
+        Db.VBD.set_reserved ~__context ~self:vbd ~value:false ;
+        Xapi_vbd_helpers.clear_current_operations ~__context ~self:vbd
+    )
+  end;
   (* Sync VM state in Xapi for VMs not running on this host *)
   List.iter
     (fun (id, vm) ->


### PR DESCRIPTION
On startup XAPI still thought that the storage driver domain was running at the time it tried to plug a PBD using a storage driver domain (during XAPI startup we first create storage and then reset power state).
Also plugging a PBD triggers a boot of the storage driver domain, but then XAPI immediately attempts to plug in the PBD, and the (SMAPIv3) plugin might fail to communicate with the driver domain since it hasn't finished booting.

There was already code to wait for a driver domain to boot up, fix it up to use a simpler /HEALTHCHECK GET request instead of xmlrpc to poll for startup completion and call it.