### PR TITLE
CA-349946: Fix startup race conditions with storage driver domains

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -1406,6 +1406,9 @@ let bind ~__context ~pbd =
       error "Caught VM_BAD_POWER_STATE [ %s ]" (String.concat "; " params)
     (* ignore for now *)
   ) ;
+  if not (Helpers.is_domain_zero ~__context driver) then
+    (* Return the IP of the driver domain, and wait until it responds on this IP *)
+    info "Storage driver domain is up on IP %s" (System_domains.ip_of ~__context driver);
   let uuid = Db.VM.get_uuid ~__context ~self:driver in
   let sr = Db.PBD.get_SR ~__context ~self:pbd in
   let ty = Db.SR.get_type ~__context ~self:sr in

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -187,14 +187,19 @@ let pingable ip () =
 
 let queryable ~__context transport () =
   let open Xmlrpc_client in
-  let rpc =
-    XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_smapiv2" ~transport
-      ~http:(xmlrpc ~version:"1.0" "/")
+  let host = match transport with
+  | Unix _ -> None
+  | TCP (host, _) | SSL(_, host, _) -> Some host
   in
-  let listMethods = Rpc.call "system.listMethods" [] in
+  let rpc path =
+    let req = Http.Request.make ?host ~user_agent:Constants.xapi_user_agent Http.Get path in
+    Xmlrpc_client.with_transport transport @@ fun fd ->
+    Http_client.rpc fd req @@ fun resp _resp_fd ->
+    debug "%s/%s replied: %s" (string_of_transport transport) path (Http.Response.to_string resp)
+  in
   try
-    let _ = rpc listMethods in
-    info "XMLRPC service found at %s" (string_of_transport transport) ;
+    let () = rpc "/HEALTHCHECK" in
+    info "Storage service healthcheck succeeded on %s" (string_of_transport transport);
     true
   with e ->
     debug "Temporary failure querying storage service on %s: %s"

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -151,13 +151,17 @@ let is_in_use ~__context ~self =
   else
     false
 
-(* [wait_for ?timeout f] returns true if [f()] (called at 1Hz) returns true within
-   the [timeout] period and false otherwise *)
-let wait_for ?(timeout = 120.) f =
+(* [wait_for ~__context ?timeout taskname f] returns true if [f()] (called at 1Hz) returns true within
+   the [timeout] period and false otherwise.
+   Creates a [taskname] subtask in [__context].
+   *)
+let wait_for ~__context ?(timeout = 600.) taskname f =
   let start = Unix.gettimeofday () in
   let finished = ref false in
   let success = ref false in
+  Server_helpers.exec_with_subtask ~__context taskname ~task_in_database:true @@ fun ~__context ->
   while not !finished do
+    TaskHelper.exn_if_cancelling ~__context;
     let remaining = timeout -. (Unix.gettimeofday () -. start) in
     if remaining < 0. then
       finished := true
@@ -227,12 +231,12 @@ let ip_of ~__context driver =
           )
   in
   info "driver domain uuid:%s ip:%s" (Db.VM.get_uuid ~__context ~self:driver) ip ;
-  if not (wait_for (pingable ip)) then
+  if not (wait_for ~__context "ping driver domain" (pingable ip)) then
     failwith
       (Printf.sprintf "driver domain %s is not responding to IP ping"
          (Ref.string_of driver)
       ) ;
-  if not (wait_for (queryable ~__context (Xmlrpc_client.TCP (ip, 80)))) then
+  if not (wait_for ~__context "query driver domain" (queryable ~__context (Xmlrpc_client.TCP (ip, 80)))) then
     failwith
       (Printf.sprintf "driver domain %s is not responding to XMLRPC query"
          (Ref.string_of driver)

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -3041,6 +3041,16 @@ let resync_resident_on ~__context =
           ()
       )
     xenopsd_vms_in_xapi ;
+  let dom0 = Helpers.get_domain_zero ~__context in
+  (* Reset Dom0 plugged virtual devices *)
+  if !Xapi_globs.on_system_boot then begin
+    (* Dom0 went through Halted->Running state: reflect this and
+       trigger appropiate actions to reset state of VBDs, etc. *)
+    debug "Dom0 just got rebooted: doing Halted->Running transition";
+    Xapi_vm_lifecycle.force_state_reset ~__context ~self:dom0 ~value:`Halted ;
+  end;
+  (* Ensure Dom0 will be in running state even if XAPI startup is interrupted *)
+  Xapi_vm_lifecycle.force_state_reset ~__context ~self:dom0 ~value:`Running ;
   (* Sync VM state in Xapi for VMs not running on this host *)
   List.iter
     (fun (id, vm) ->


### PR DESCRIPTION
When plugging PBDs on startup have to ensure that:
- we wait for the driver domain to boot up and respond before calling the SMAPIv3 plugin to attach it
- ensure we don't deadlock by having cancelable timeouts on driver domain bootup wait, and doing the PBD plug after the xenops event queue is up

Also clean up after failed or missing VBD unplugs: when the system reboots explicitly transition Dom0 VM through Halted and Running power states to trigger the usual cleanups (detach virtual devices). Although take care not to reset other fields like resident on, etc.