### PR TITLE
Fix issue #4491: USB device reset for Privileged VMs

### DIFF
--- a/scripts/usb_reset.py
+++ b/scripts/usb_reset.py
@@ -66,7 +66,7 @@ def parse_arg():
                         help="specify the domid of the VM")
     attach.add_argument("-p", dest="pid", type=int, required=True,
                         help="the process id of QEMU")
-    attach.add_argument("-r", dest="reset_only", type=int,
+    attach.add_argument("-r", dest="reset_only", action="store_true",
                         help="reset device only, for privileged mode")
 
     detach = subparsers.add_parser("detach", help="detach a USB device")


### PR DESCRIPTION
When a VM has PCI devices attached, xenopsd will call a usb reset with parameter "-r" for USB passthrough devices to indicate a privileged VM.
xen-api doesn't parse option "-r" properly and is wrongly expecting an integer. This PR fixes this.