### PR TITLE
REQ-403 verification after pool eject

### DIFF
--- a/scripts/network-init
+++ b/scripts/network-init
@@ -108,6 +108,12 @@ rename_network_label() {
     done
 }
 
+maybe-enable-tls-verification() {
+  verification_enabled="$(${XE} pool-list params=tls-verification-enabled --minimal)"
+  if [ "$FIRSTBOOT_ENABLE_TLS_VERIFICATION" == "true" ] && [ "$verification_enabled" != "true" ] ; then
+      ${XE} pool-enable-tls-verification
+  fi
+}
 
 if [ "$UPGRADE" = "true" ]; then
     rename_network_label
@@ -116,6 +122,7 @@ else
     rename_network_label
     # Ensure changes are synced to disk
     xe pool-sync-database
+    maybe-enable-tls-verification
 fi
 
 touch /var/lib/misc/ran-network-init

--- a/scripts/reset-and-reboot
+++ b/scripts/reset-and-reboot
@@ -6,6 +6,7 @@
 # reboot.
 
 export FIRSTBOOT_DATA_DIR=/etc/firstboot.d/data
+export XENSOURCE_INVENTORY=/etc/xensource-inventory
 
 grep -sv '^UPGRADE=' ${FIRSTBOOT_DATA_DIR}/host.conf >/tmp/host.conf.$$
 rm -f ${FIRSTBOOT_DATA_DIR}/host.conf
@@ -38,5 +39,12 @@ rm -f  /etc/stunnel/xapi-stunnel-ca-bundle.pem
 rm -fr /etc/stunnel/certs
 
 # do not remove /etc/xensource/xapi-ssl.pem
+
+# ensure TLS verification is enabled when we come back
+rm -f /var/xapi/verify-certificates
+tmp="$(mktemp /tmp/xensource-inventory.XXXXXX)"
+grep -v FIRSTBOOT_ENABLE_TLS_VERIFICATION "$XENSOURCE_INVENTORY" > "$tmp"
+echo "FIRSTBOOT_ENABLE_TLS_VERIFICATION='true'" >> "$tmp"
+mv "$tmp" "$XENSOURCE_INVENTORY"
 
 /sbin/reboot

--- a/scripts/reset-and-reboot
+++ b/scripts/reset-and-reboot
@@ -40,11 +40,11 @@ rm -fr /etc/stunnel/certs
 
 # do not remove /etc/xensource/xapi-ssl.pem
 
-# ensure TLS verification is enabled when we come back
+# ensure TLS verification is disabled when we come back
 rm -f /var/xapi/verify-certificates
 tmp="$(mktemp /tmp/xensource-inventory.XXXXXX)"
 grep -v FIRSTBOOT_ENABLE_TLS_VERIFICATION "$XENSOURCE_INVENTORY" > "$tmp"
-echo "FIRSTBOOT_ENABLE_TLS_VERIFICATION='true'" >> "$tmp"
+echo "FIRSTBOOT_ENABLE_TLS_VERIFICATION='false'" >> "$tmp"
 mv "$tmp" "$XENSOURCE_INVENTORY"
 
 /sbin/reboot


### PR DESCRIPTION
This PR achieves two objectives:
 - fixes a bug where /var/xapi/verify-certificates was lingering around after pool eject (causing mismatch between db tls verification state + actual state)
 - when we want to 'switch on' the feature by default, reverting f47c98d will ensure that ejected hosts 'come back' with verification enabled

In the future, for new installs, we can also add `FIRSTBOOT_ENABLE_TLS_VERIFICATION='true'` to /etc/xensource-inventory to get verification by default