### PR TITLE
CP-36863: Expose local YUM repository only on TLS interface

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -373,7 +373,9 @@ let get_repository_handler (req : Http.Request.t) s _ =
   let open Xapi_stdext_std.Xstringext in
   debug "Repository.get_repository_handler URL %s" req.Request.uri ;
   req.Request.close <- true ;
-  if is_local_pool_repo_enabled () then (
+  if Fileserver.access_forbidden req s then
+    Http_svr.response_forbidden ~req s
+  else if is_local_pool_repo_enabled () then (
     try
       let len = String.length Constants.get_repository_uri in
       match String.sub_to_end req.Request.uri len with


### PR DESCRIPTION
In one update of continuous update model, a local YUM repository is
enalbed on the pool master host. The pool slaves can access this YUM
repository for updating.

This commit restricts the service port of the local YUM repository on
the pool master to TLS interface only.

Signed-off-by: Ming Lu <ming.lu@citrix.com>