### PR TITLE
CP-37866 add Host.tls_verification_enabled field

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 704
+let schema_minor_vsn = 705
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1670,6 +1670,8 @@ let host_query_ha = call ~flags:[`Session]
            field ~qualifier:StaticRO ~lifecycle:[Published, rel_quebec, ""] ~default_value:(Some (VString "")) ~ty:String "uefi_certificates" "The UEFI certificates allowing Secure Boot";
            field ~qualifier:DynamicRO ~lifecycle:[Published, rel_stockholm, ""] ~ty:(Set (Ref _certificate)) "certificates" "List of certificates installed in the host";
            field ~qualifier:DynamicRO ~lifecycle:[Published, rel_stockholm, ""] ~default_value:(Some (VSet [])) ~ty:(Set String) "editions" "List of all available product editions";
-           field ~qualifier:DynamicRO ~in_product_since:rel_next ~ty:(Set update_guidances) "pending_guidances" ~default_value:(Some (VSet [])) "The set of pending guidances after applying updates"
+           field ~qualifier:DynamicRO ~in_product_since:rel_next ~ty:(Set update_guidances) "pending_guidances" ~default_value:(Some (VSet [])) "The set of pending guidances after applying updates";
+           field ~qualifier:DynamicRO ~in_product_since:rel_next ~ty:Bool "tls_verification_enabled" ~default_value:(Some (VBool false)) "True if this host has TLS verifcation enabled"
+
          ])
       ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "946d2318ed40d9cbb68267dc3295e79a"
+let last_known_schema_hash = "9f182f350692d61e8c78286dcef11ce3"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -183,6 +183,10 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ?(external_auth_configuration = []) ?(license_params = [])
     ?(edition = "free") ?(license_server = []) ?(local_cache_sr = Ref.null)
     ?(chipset_info = []) ?(ssl_legacy = false) () =
+  let pool = Helpers.get_pool ~__context in
+  let tls_verification_enabled =
+    Db.Pool.get_tls_verification_enabled ~__context ~self:pool
+  in
   Db.Host.create ~__context ~ref ~current_operations:[] ~allowed_operations:[]
     ~software_version:(Xapi_globs.software_version ())
     ~enabled:false ~aPI_version_major:Datamodel_common.api_version_major
@@ -200,7 +204,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~power_on_config:[] ~local_cache_sr ~ssl_legacy ~guest_VCPUs_params:[]
     ~display:`enabled ~virtual_hardware_platform_versions:[]
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
-    ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[] ;
+    ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
+    ~tls_verification_enabled ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3017,6 +3017,11 @@ let host_record rpc session_id host =
               (x ()).API.host_pending_guidances
             )
           ()
+      ; make_field ~name:"tls-verification-enabled"
+          ~get:(fun () ->
+            (x ()).API.host_tls_verification_enabled |> string_of_bool
+            )
+          ()
       ]
   }
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -868,6 +868,11 @@ let init_tls_verification () =
       info "TLS verification is enabled: %s" file ;
       Stunnel_client.set_verify_by_default true
 
+let report_tls_verification ~__context =
+  let self = Helpers.get_localhost ~__context in
+  let value = Stunnel_client.get_verify_by_default () in
+  Db.Host.set_tls_verification_enabled ~__context ~self ~value
+
 let server_init () =
   let print_server_starting_message () =
     debug "(Re)starting xapi" ;
@@ -1085,6 +1090,10 @@ let server_init () =
             , [Startup.OnlyMaster]
             , fun () ->
                 Xapi_host_helpers.Configuration.start_watcher_thread ~__context
+            )
+          ; ( "Update database state of TLS verification"
+            , []
+            , fun () -> report_tls_verification ~__context
             )
           ; ( "Remote requests"
             , [Startup.OnThread]

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -514,12 +514,12 @@ val set_sched_gran :
 val get_sched_gran :
   __context:Context.t -> self:API.ref_host -> API.host_sched_gran
 
-val emergency_disable_tls_verification : __context:'a -> unit
+val emergency_disable_tls_verification : __context:Context.t -> unit
 
 val alert_if_tls_verification_was_emergency_disabled :
   __context:Context.t -> unit
 
-val emergency_reenable_tls_verification : __context:'a -> unit
+val emergency_reenable_tls_verification : __context:Context.t -> unit
 
 val cert_distrib_atom :
   __context:Context.t -> host:API.ref_host -> command:string -> string

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3281,6 +3281,7 @@ let ping_with_tls_verification ~__context host =
   |> ignore
 
 let enable_tls_verification ~__context =
+  let self = Helpers.get_localhost ~__context in
   let hosts = Db.Host.get_all ~__context in
   List.iter (ping_with_tls_verification ~__context) hosts ;
   Xapi_clustering.(
@@ -3288,6 +3289,7 @@ let enable_tls_verification ~__context =
       Daemon.restart ~__context
   ) ;
   Stunnel_client.set_verify_by_default true ;
+  Db.Host.set_tls_verification_enabled ~__context ~self ~value:true ;
   Helpers.touch_file Xapi_globs.verify_certificates_path
 
 let set_repositories ~__context ~self ~value =


### PR DESCRIPTION
TLS verification is enabled on the pool level but can be disabled
locally (in an emergency) for a host. To provide visibility if this has
happened, this adds field Host.tls_verification_enabled for XenCenter to
use it.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>