### PR TITLE
CP-37898: change default back to PBIS

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -901,7 +901,7 @@ let repository_gpgcheck = ref true
 
 type xapi_globs_spec_ty = Float of float ref | Int of int ref
 
-let extauth_ad_backend = ref "winbind"
+let extauth_ad_backend = ref "pbis"
 
 let net_cmd = ref "/usr/bin/net"
 

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -76,7 +76,7 @@ class ADConfig(object):
                 self._lines = [l.strip() for l in lines]
 
     def _get_ad_backend(self, args):
-        if  args.get("ad_backend", "winbind") == "pbis":
+        if  args.get("ad_backend", "pbis") == "pbis":
             logger.debug("pbis is used as AD backend")
             return ADBackend.bd_pbis
 


### PR DESCRIPTION
There are some outstanding changes needed before we can switch to
winbind by default.
Since the code still supports both PBIS and winbind lets change the
default to PBIS to unblock testing.

