### PR TITLE
CP-37898: Make winbind encryption types configurable

### DIFF
--- a/ocaml/xapi-aux/kerberos_encryption_types.ml
+++ b/ocaml/xapi-aux/kerberos_encryption_types.ml
@@ -1,0 +1,40 @@
+(*
+ * Copyright (C) 2006-2009 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* Kerberos support several different encrytion types
+ * winbind support it as strong, legacy and all
+ * details, https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html
+ * *)
+
+module Winbind = struct
+  type t = Strong | Legacy | All
+
+  let to_string = function
+    | Strong ->
+        "strong"
+    | Legacy ->
+        "legacy"
+    | All ->
+        "all"
+
+  let of_string = function
+    | "all" ->
+        Some All
+    | "legacy" ->
+        Some Legacy
+    | "strong" ->
+        Some Strong
+    | _ ->
+        None
+end

--- a/ocaml/xapi-aux/kerberos_encryption_types.mli
+++ b/ocaml/xapi-aux/kerberos_encryption_types.mli
@@ -1,0 +1,21 @@
+(*
+ * Copyright (C) 2006-2009 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module Winbind : sig
+  type t = Strong | Legacy | All
+
+  val to_string : t -> string
+
+  val of_string : string -> t option
+end

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -691,7 +691,10 @@ let config_winbind_damon ~domain ~workgroup ~netbios_name =
       ; Printf.sprintf "winbind cache time = %d" !Xapi_globs.winbind_cache_time
       ; Printf.sprintf "machine password timeout = %d"
           !Xapi_globs.winbind_machine_pwd_timeout
-      ; "kerberos encryption types = strong"
+      ; Printf.sprintf "kerberos encryption types = %s"
+          (Kerberos_encryption_types.Winbind.to_string
+             !Xapi_globs.winbind_kerberos_encryption_type
+          )
       ; Printf.sprintf "workgroup = %s" workgroup
       ; Printf.sprintf "netbios name = %s" netbios_name
       ; "idmap config * : range = 3000000-3999999"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -917,6 +917,9 @@ let winbind_machine_pwd_timeout = ref (7 * 24 * 3600)
 
 let winbind_update_closest_kdc_interval = ref (3600. *. 24.) (* every day *)
 
+let winbind_kerberos_encryption_type =
+  ref Kerberos_encryption_types.Winbind.Strong
+
 let tdb_tool = ref "/usr/bin/tdbtool"
 
 let sqlite3 = ref "/usr/bin/sqlite3"
@@ -1254,6 +1257,20 @@ let other_options =
     , Arg.Set_string extauth_ad_backend
     , (fun () -> !extauth_ad_backend)
     , "Which AD backend used to talk to DC"
+    )
+  ; ( "winbind_kerberos_encryption_type"
+    , Arg.String
+        (fun s ->
+          Option.iter
+            (fun k -> winbind_kerberos_encryption_type := k)
+            (Kerberos_encryption_types.Winbind.of_string s)
+          )
+    , (fun () ->
+        Kerberos_encryption_types.Winbind.to_string
+          !winbind_kerberos_encryption_type
+        )
+    , "Encryption types to use when operating as Kerberos client \
+       [strong|legacy|all]"
     )
   ; ( "website-https-only"
     , Arg.Set website_https_only


### PR DESCRIPTION
Trunk limit the encryption methods to `strong` to improve securirty.
However, There may be some existing environment with legacy encryption
like RC4-HMAC. Limit the `strong` encryption may break LCM customers.

This commit set encryption type to `strong` as default
and will configure it to `all` during back port

Details: https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html

Signed-off-by: Lin Liu <lin.liu@citrix.com>