### PR TITLE
CP-38064: update for rpclib 7 compatibility

### DIFF
--- a/ocaml/idl/datamodel_values.ml
+++ b/ocaml/idl/datamodel_values.ml
@@ -48,7 +48,8 @@ let to_ocaml_string ?(v2=false) v =
     | Rpc.Bool b -> sprintf "Rpc.Bool %b" b
     | Rpc.Dict d -> sprintf "Rpc.Dict [%s]" (String.concat ";" (List.map (fun (n,v) -> sprintf "(\"%s\",%s)" n (aux v)) d))
     | Rpc.Enum l -> sprintf "Rpc.Enum [%s]" (String.concat ";" (List.map aux l))
-    | Rpc.DateTime t -> sprintf "Rpc.DateTime %s" t in
+    | Rpc.DateTime t -> sprintf "Rpc.DateTime %s" t
+    | Rpc.Base64 t -> sprintf "Rpc.Base64 %s" t in
   match v with
   | VCustom (s,v') ->
     if v2 then

--- a/ocaml/tests/mock_rpc.ml
+++ b/ocaml/tests/mock_rpc.ml
@@ -26,19 +26,20 @@ let rpc __context call =
         {
           success= true
         ; contents= contents |> Xmlrpc.to_string |> Xmlrpc.of_string
+        ; notif= false
         }
   | "VM.update_allowed_operations", [session_id_rpc; self_rpc] ->
       let open API in
       let _session_id = ref_session_of_rpc session_id_rpc in
       let self = ref_VM_of_rpc self_rpc in
       Xapi_vm_lifecycle.update_allowed_operations ~__context ~self ;
-      Rpc.{success= true; contents= Rpc.String ""}
+      Rpc.{success= true; contents= Rpc.String ""; notif= false}
   | "VM.atomic_set_resident_on", [session_id_rpc; vm_rpc; host_rpc] ->
       let open API in
       let _session_id = ref_session_of_rpc session_id_rpc in
       let vm = ref_VM_of_rpc vm_rpc in
       let host = ref_host_of_rpc host_rpc in
       Db.VM.set_resident_on ~__context ~self:vm ~value:host ;
-      Rpc.{success= true; contents= Rpc.String ""}
+      Rpc.{success= true; contents= Rpc.String ""; notif= false}
   | _ ->
       failwith "Unexpected RPC"

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -20,9 +20,9 @@ let test_clusterd_rpc ~__context call =
   let test_token = "test_token" in
   match (call.Rpc.name, call.Rpc.params) with
   | "create", _ ->
-      Rpc.{success= true; contents= Rpc.String test_token}
+      Rpc.{success= true; contents= Rpc.String test_token; notif= false}
   | ("enable" | "disable" | "destroy" | "leave"), _ ->
-      Rpc.{success= true; contents= Rpc.Null}
+      Rpc.{success= true; contents= Rpc.Null; notif= false}
   | "diagnostics", _ ->
       let open Cluster_interface in
       let id = 1l in
@@ -56,7 +56,7 @@ let test_clusterd_rpc ~__context call =
       let contents =
         Rpcmarshal.marshal Cluster_interface.diagnostics.Rpc.Types.ty diag
       in
-      Rpc.{success= true; contents}
+      Rpc.{success= true; contents; notif= false}
   | name, params ->
       Alcotest.failf "Unexpected RPC: %s(%s)" name
         (String.concat " " (List.map Rpc.to_string params))
@@ -66,11 +66,11 @@ let test_rpc ~__context call =
   | "Cluster_host.destroy", [self] ->
       let open API in
       Xapi_cluster_host.destroy ~__context ~self:(ref_Cluster_host_of_rpc self) ;
-      Rpc.{success= true; contents= Rpc.String ""}
+      Rpc.{success= true; contents= Rpc.String ""; notif= false}
   | "Cluster.destroy", [_session; self] ->
       let open API in
       Xapi_cluster.destroy ~__context ~self:(ref_Cluster_of_rpc self) ;
-      Rpc.{success= true; contents= Rpc.String ""}
+      Rpc.{success= true; contents= Rpc.String ""; notif= false}
   | name, params ->
       Alcotest.failf "Unexpected RPC: %s(%s)" name
         (String.concat " " (List.map Rpc.to_string params))
@@ -137,9 +137,10 @@ let test_create_cleanup () =
           ; contents=
               Rpcmarshal.marshal Cluster_interface.error.Rpc.Types.ty
                 Cluster_interface.(InternalError "Cluster.create failed")
+          ; notif= false
           }
     | _, _ ->
-        Rpc.{success= true; contents= Rpc.Null}
+        Rpc.{success= true; contents= Rpc.Null; notif= false}
   in
   try
     create_cluster ~__context ~test_clusterd_rpc () |> ignore ;

--- a/ocaml/tests/test_cluster_host.ml
+++ b/ocaml/tests/test_cluster_host.ml
@@ -50,7 +50,7 @@ let pif_plug_rpc __context call =
       let _session_id = ref_session_of_rpc session_id_rpc in
       let self = ref_PIF_of_rpc self_rpc in
       Db.PIF.set_currently_attached ~__context ~self ~value:true ;
-      Rpc.{success= true; contents= Rpc.String ""}
+      Rpc.{success= true; contents= Rpc.String ""; notif= false}
   | "Cluster_host.create", [session_id_rpc; cluster_rpc; host_rpc; pif_rpc] ->
       let open API in
       let _session_id = ref_session_of_rpc session_id_rpc in
@@ -58,7 +58,7 @@ let pif_plug_rpc __context call =
       let host = ref_host_of_rpc host_rpc in
       let pIF = ref_PIF_of_rpc pif_rpc in
       ignore (Test_common.make_cluster_host ~__context ~cluster ~host ~pIF ()) ;
-      Rpc.{success= true; contents= Rpc.String ""}
+      Rpc.{success= true; contents= Rpc.String ""; notif= false}
   | _ ->
       failwith "Unexpected RPC"
 
@@ -150,7 +150,7 @@ let test_clusterd_rpc ~__context call =
       let nall = List.length all in
       Printf.printf "dead_members: %d, all: %d\n" ndead nall ;
       if ndead = nall - 1 then
-        Rpc.{success= true; contents= Rpc.rpc_of_unit ()}
+        Rpc.{success= true; contents= Rpc.rpc_of_unit (); notif= false}
       else
         let err =
           Cluster_interface.InternalError "Remaining hosts are not all alive"
@@ -168,9 +168,9 @@ let test_rpc ~__context call =
   | "Cluster_host.forget", [_session; self] ->
       let open API in
       Xapi_cluster_host.forget ~__context ~self:(ref_Cluster_host_of_rpc self) ;
-      Rpc.{success= true; contents= Rpc.String ""}
+      Rpc.{success= true; contents= Rpc.String ""; notif= false}
   | "host.apply_guest_agent_config", _ ->
-      Rpc.{success= true; contents= Rpc.rpc_of_unit ()}
+      Rpc.{success= true; contents= Rpc.rpc_of_unit (); notif= false}
   | name, params ->
       failwith
         (Printf.sprintf "Unexpected RPC: %s(%s)" name

--- a/ocaml/tests/test_host_helpers.ml
+++ b/ocaml/tests/test_host_helpers.ml
@@ -36,13 +36,13 @@ let setup_test_oc_watcher () =
         let v = API.string_of_rpc value_rpc in
         Db.Host.set_iscsi_iqn ~__context ~self:host ~value:v ;
         calls := (host, `set_iscsi_iqn v) :: !calls ;
-        Rpc.{success= true; contents= Rpc.String ""}
+        Rpc.{success= true; contents= Rpc.String ""; notif= false}
     | "host.set_multipathing", [_session_id_rpc; host_rpc; value_rpc] ->
         let host = API.ref_host_of_rpc host_rpc in
         let v = API.bool_of_rpc value_rpc in
         Db.Host.set_multipathing ~__context ~self:host ~value:v ;
         calls := (host, `set_multipathing v) :: !calls ;
-        Rpc.{success= true; contents= Rpc.String ""}
+        Rpc.{success= true; contents= Rpc.String ""; notif= false}
     | _ ->
         Mock_rpc.rpc __context call
   in


### PR DESCRIPTION
cherry-pick of 0cd0a294f73790d1365e6c06d5de7a0725a6b5eb

This is needed for the ppxlib update for yangtze

1.249.10-lcm is now the branch for Stockholm