### PR TITLE
CA-357417 REQ-403 ensure valid cert alerts are not deleted

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4205,6 +4205,7 @@ module Message = struct
                    "VMSS", "VMSS";
                    "PVS_proxy","PVS_proxy";
                    "VDI","VDI";
+                   "Certificate","Certificate";
                  ])
 
   let create = call
@@ -4301,7 +4302,7 @@ module Message = struct
       [ uid _message;
         field ~qualifier:DynamicRO ~ty:String "name" "The name of the message";
         field ~qualifier:DynamicRO ~ty:Int "priority" "The message priority, 0 being low priority";
-        field ~qualifier:DynamicRO ~ty:cls "cls" "The class of the object this message is associated with";
+        field ~qualifier:DynamicRO ~ty:cls ~lifecycle:[(Extended, rel_next, "Added Certificate class")] "cls" "The class of the object this message is associated with";
         field ~qualifier:DynamicRO ~ty:String "obj_uuid" "The uuid of the object this message is associated with";
         field ~qualifier:DynamicRO ~ty:DateTime "timestamp" "The time at which the message was created";
         field ~qualifier:DynamicRO ~ty:String "body" "The body of the message"; ]

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -8,7 +8,7 @@ open Datamodel_roles
               When introducing a new release, bump the schema minor version to the next hundred
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
-let schema_minor_vsn = 705
+let schema_minor_vsn = 706
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "9f182f350692d61e8c78286dcef11ce3"
+let last_known_schema_hash = "60310e095b88648560ef9f69f9ea7331"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -43,6 +43,8 @@ let class_to_string cls =
       "PVS_proxy"
   | `VDI ->
       "VDI"
+  | `Certificate ->
+      "Certificate"
   | _ ->
       "unknown"
 
@@ -64,6 +66,8 @@ let string_to_class str =
       `PVS_proxy
   | "VDI" ->
       `VDI
+  | "Certificate" ->
+      `Certificate
   | _ ->
       failwith "Bad type"
 

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -240,6 +240,8 @@ let check_uuid ~__context ~cls ~uuid =
         ignore (Db.PVS_proxy.get_by_uuid ~__context ~uuid)
     | `VDI ->
         ignore (Db.VDI.get_by_uuid ~__context ~uuid)
+    | `Certificate ->
+        ignore (Db.Certificate.get_by_uuid ~__context ~uuid)
     ) ;
     true
   with _ -> false


### PR DESCRIPTION
By associating CA certs to the pool object, we had no way to
distinguish alerts from multiple CA certs (without examining the
contents of the message). This was leading a bug, characterised by the
following:

```bash
openssl req -x509 -newkey rsa:2048 -keyout 14key.pem -out 14cert.pem -days 14 -nodes -subj '/CN=localhost'
openssl req -x509 -newkey rsa:2048 -keyout 7key.pem -out 7cert.pem -days 7 -nodes -subj '/CN=localhost'

xe pool-install-ca-certificate filename=7cert.pem
/etc/cron.daily/certificate-check
xe message-list # alert appears as expected

xe pool-install-ca-certificate filename=14cert.pem
/etc/cron.daily/certificate-check
xe message-list # an alert about 14cert.pem appears,
                # but the 7cert.pem alert has gone
```

This patch ensures the above script will retain both alerts.

NB. with this change if you uninstall a pool certificate, then
any associated alerts are not removed, even after executing
the certificate check binary.