### PR TITLE
CA-357025 enable TLS cert checking for pool and WLB together

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1013,6 +1013,8 @@ functor
                      (Ref.string_of host)
                ) ;
             Db.Pool.set_tls_verification_enabled ~__context ~self ~value:true ;
+            debug "Enabling TLS verification for Work Load Balancing (WLB)" ;
+            Db.Pool.set_wlb_verify_cert ~__context ~self ~value:true ;
             debug "Pool.enable_tls_verification completed (2/2)"
         )
 


### PR DESCRIPTION
When enabling TLS certificate verification for a pool, also enable it
for a Work Load Balancing (WLB). Note that currently TLS certificate
checking can be disabled per host in an emergency but not for WLB.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>