### PR TITLE
Fix missing xenopsd diagnostics from bugtools

### DIFF
--- a/scripts/xn_diagnostics
+++ b/scripts/xn_diagnostics
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo Querying all xenopsd queues:
-for queue in $(message-cli list | grep org.xen.xcp.xenops); do
+for queue in $(message-cli list | grep org.xen.xapi.xenops); do
   echo xenops-cli list --queue $queue
   xenops-cli list --queue $queue
   echo xenops-cli list --verbose --queue $queue


### PR DESCRIPTION
It is called `xapi`, not `xcp`:
```
xenopsd-xc:4239
xenops-cli:40364
org.xen.xapi.xenops.classic
```

With this change `xn_diagnostics` prints the state of xenopsd queues
again.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>