### PR TITLE
Fix handling of web-dir parameter

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -778,7 +778,7 @@ let master_only_http_handlers =
   ; ("get_updates", Http_svr.FdIO Xapi_pool.get_updates_handler)
   ]
 
-let common_http_handlers =
+let common_http_handlers () =
   [
     ("get_services_xenops", Http_svr.FdIO Xapi_services.get_handler)
   ; ("put_services_xenops", Http_svr.FdIO Xapi_services.put_handler)
@@ -1040,7 +1040,7 @@ let server_init () =
           ; ("Killing stray sparse_dd processes", [], Sparse_dd_wrapper.killall)
           ; ( "Registering http handlers"
             , []
-            , fun () -> List.iter Xapi_http.add_handler common_http_handlers
+            , fun () -> List.iter Xapi_http.add_handler (common_http_handlers ())
             )
           ; ( "Registering master-only http handlers"
             , [Startup.OnlyMaster]


### PR DESCRIPTION
The web-dir parameter is not taken into account in the definition of
common_http_handlers' get_root handler, because !Xapi_globs.web_dir is
evaluated once and for all when the module loads, before the
configuration file is read.

Turn common_http_handlers into a function so that it is evaluated when
called.

Fixes #4512

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>
Co-authored-by: BenjiReis <benjamin.reis@vates.fr>