### PR TITLE
CA-358816: Updated subject name in DC does not get updated in pam

### DIFF
--- a/ocaml/xapi/extauth.ml
+++ b/ocaml/xapi/extauth.ml
@@ -74,6 +74,8 @@ let event_name_after_subject_add = "after-subject-add"
 
 let event_name_after_subject_remove = "after-subject-remove"
 
+let event_name_after_subject_update = "after-subject-update"
+
 let event_name_after_xapi_initialize = "after-xapi-initialize"
 
 let event_name_before_extauth_disable = "before-extauth-disable"

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -73,8 +73,8 @@ let register () =
       (fun __context -> Xapi_subject.update_all_subjects ~__context
     )
   in
-  let update_all_subjects_delay = 60.0 *. 15.0 in
-  (* initial delay = 15 minutes *)
+  let update_all_subjects_delay = 10.0 in
+  (* initial delay = 10 seconds *)
   if master then
     Xapi_periodic_scheduler.add_to_queue "Synchronising RRDs/messages"
       (Xapi_periodic_scheduler.Periodic sync_timer) sync_delay sync_func ;

--- a/ocaml/xapi/xapi_subject.ml
+++ b/ocaml/xapi/xapi_subject.ml
@@ -133,8 +133,12 @@ let update ~__context ~self =
     Xapi_auth.get_subject_information_from_identifier ~__context
       ~subject_identifier
   in
-  (* update locally the fresh information received from external directory service *)
-  Db.Subject.set_other_config ~__context ~self ~value:subject_info
+  if Db.Subject.get_other_config ~__context ~self <> subject_info then (
+    (* update locally the fresh information received from external directory service *)
+    Db.Subject.set_other_config ~__context ~self ~value:subject_info ;
+    true
+  ) else
+    false
 
 let update_all_subjects ~__context =
   (* checks if external authentication is enabled, otherwise it's useless to try to do the update *)
@@ -146,18 +150,28 @@ let update_all_subjects ~__context =
   else (* external authentication is enabled *)
     let subjects = Db.Subject.get_all ~__context in
     (* visits each subject in the table o(n) *)
-    List.iter
-      (fun subj ->
-        (* uses a best-effort attempt to update the subject information *)
-        (* therefore, if an exception was raised, just ignore it *)
-        try update ~__context ~self:subj
-        with e ->
-          debug "Error trying to update subject %s: %s"
-            (Db.Subject.get_subject_identifier ~__context ~self:subj)
-            (ExnHelper.string_of_exn e)
-        (* ignore this exception e, do not raise it again *)
-        )
-      subjects
+    let need_update_config =
+      List.fold_left
+        (fun updated subj ->
+          (* uses a best-effort attempt to update the subject information *)
+          (* therefore, if an exception was raised, just ignore it *)
+          try update ~__context ~self:subj || updated
+          with e ->
+            debug "Error trying to update subject %s: %s"
+              (Db.Subject.get_subject_identifier ~__context ~self:subj)
+              (ExnHelper.string_of_exn e) ;
+            (* ignore this exception e, do not raise it again *)
+            updated
+          )
+        false subjects
+    in
+    if need_update_config then
+      Xapi_stdext_threads.Threadext.Mutex.execute
+        Xapi_globs.serialize_pool_enable_disable_extauth (fun () ->
+          Extauth.call_extauth_hook_script_in_pool ~__context
+            Extauth.event_name_after_subject_update
+          |> ignore
+      )
 
 (* This function returns all permissions associated with a subject *)
 let get_permissions_name_label ~__context ~self =

--- a/scripts/plugins/extauth-hook
+++ b/scripts/plugins/extauth-hook
@@ -37,6 +37,12 @@ def after_subject_remove(session, args):
         return hdlr.after_subject_remove(session, args)
     return str(True)
 
+def after_subject_update(session, args):
+    hdlr = get_extauth_handler(args)
+    if hdlr:
+        return hdlr.after_subject_update(session, args)
+    return str(True)
+
 def after_roles_update(session, args):
     hdlr = get_extauth_handler(args)
     if hdlr:
@@ -54,10 +60,11 @@ def before_extauth_disable(session, args):
 if __name__ == "__main__":
     dispatch_tbl = {
         "after-extauth-enable":  after_extauth_enable,
-        "after-xapi-initialize": after_xapi_initialize, 
-        "after-subject-add":     after_subject_add, 
-        "after-subject-remove":  after_subject_remove, 
-        "after-roles-update":    after_roles_update, 
+        "after-xapi-initialize": after_xapi_initialize,
+        "after-subject-add":     after_subject_add,
+        "after-subject-remove":  after_subject_remove,
+        "after-subject-update":  after_subject_update,
+        "after-roles-update":    after_roles_update,
         "before-extauth-disable":before_extauth_disable,
     }
     XenAPIPlugin.dispatch(dispatch_tbl)

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -323,6 +323,10 @@ def after_subject_remove(session, args):
     return refresh_dynamic_pam(session, args, "after_subject_remove")
 
 
+def after_subject_update(session, args):
+    return refresh_dynamic_pam(session, args, "after_subject_update")
+
+
 def after_roles_update(session, args):
     return refresh_dynamic_pam(session, args, "after_roles_update")
 
@@ -337,6 +341,7 @@ if __name__ == "__main__":
         "after-extauth-enable":  after_extauth_enable,
         "after-xapi-initialize": after_xapi_initialize,
         "after-subject-add":     after_subject_add,
+        "after-subject-update":  after_subject_update,
         "after-subject-remove":  after_subject_remove,
         "after-roles-update":    after_roles_update,
         "before-extauth-disable":before_extauth_disable,


### PR DESCRIPTION
The permitted user subject name is configured in pam configuration
file /etc/pam.d/hcp_users
however, it is only updated as event callback like add subject
This commit fix this by update the pam configuration if subject
updated in domain controller

Signed-off-by: Lin Liu <lin.liu@citrix.com>