### PR TITLE
CA-356506: enable verbose mode for iqn generation script

### DIFF
--- a/scripts/generate-iscsi-iqn
+++ b/scripts/generate-iscsi-iqn
@@ -3,6 +3,8 @@
 # Make an iSCSI IQN for localhost
 
 set -e
+# To debug upgrade failures
+set -x
 
 export FIRSTBOOT_DATA_DIR=/etc/firstboot.d/data
 export XENSOURCE_INVENTORY=/etc/xensource-inventory


### PR DESCRIPTION
On upgrade generate-iscsi-iqn sometimes exits with code 1, but without
logging any error message.

Might be better to integrate this script into XAPI so that we get proper
stacktraces in the long run.
For now just enable verbose mode on this script so that we see exactly
how far it executed and on which line it failed in daemon.log.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>