### PR TITLE
Use port 443 for client certificate auth (again)

### DIFF
--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -291,8 +291,6 @@ let http_port = default_cleartext_port
 
 let https_port = ref default_ssl_port
 
-let https_port_clientcert = 8443
-
 (** Type 11 strings that are always included *)
 let standard_type11_strings =
   [

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -131,15 +131,6 @@ module Client_certificate_auth_server = struct
     && Pool_role.is_master ()
     && Db.Pool.get_client_certificate_auth_enabled ~__context ~self:pool
 
-  let configure_port cmd =
-    let cmd' = if cmd then "open" else "close" in
-    let _ =
-      Helpers.call_script
-        !Xapi_globs.firewall_port_config_script
-        [cmd'; string_of_int Constants.https_port_clientcert]
-    in
-    ()
-
   let start () =
     if !management_server = None then (
       let sock_path = Xapi_globs.unix_domain_socket_clientcert in
@@ -147,13 +138,11 @@ module Client_certificate_auth_server = struct
       Unixext.unlink_safe sock_path ;
       let domain_sock = Xapi_http.bind (Unix.ADDR_UNIX sock_path) in
       Http_svr.start Xapi_http.server domain_sock ;
-      configure_port true ;
       management_server := Some domain_sock
     )
 
   let stop () =
     Option.iter Http_svr.stop !management_server ;
-    configure_port false ;
     management_server := None
 
   let update ~__context ~mgmt_enabled =


### PR DESCRIPTION
Partial revert of 6d4537904a49984827cbe88b290ba1e52f4b9c00.

This relies on the "redirect" option of stunnel. We found earlier that
this option was incompatible with the "protocol" option that xapi needs.
However, this was fixed in stunnel v5.60.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>