### PR TITLE
ci: fix lcm workflow

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -36,11 +36,11 @@ jobs:
 
       - name: Pull configuration from xs-opam
         run: |
-          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/release/stockholm/lcm/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/release/yangtze/lcm/tools/xs-opam-ci.env | cut -f2 -d " " > .env
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.4
+        uses: falti/dotenv-action@v0.2.7
 
       - name: Retrieve date for cache key (year-week)
         id: cache-key

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.4
+        uses: falti/dotenv-action@v0.2.7
 
       - name: Use ocaml
         uses: avsm/setup-ocaml@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.4
+        uses: falti/dotenv-action@v0.2.7
 
       - name: Retrieve date for cache key
         id: cache-key


### PR DESCRIPTION
1.249-lcm nows follow yangtze branches instead of stockholm ones, change
the source of the .env file to accommodate this

Update the dotenv action to use the latest one. Unfortunately there
isn't a tag that's reused and that forces us to update the workflows
to follow the latest, secured version

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>