### PR TITLE
CA-358904 REQ-403  cross pool migration must not use cert checking

### DIFF
--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -14,7 +14,7 @@ list-hd () {
 }
 
 verify-cert () {
-  N=8
+  N=9
   NONE=$(git grep -r --count 'verify_cert:None' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$NONE" -eq "$N" ]; then
     echo "OK counted $NONE usages of verify_cert:None"


### PR DESCRIPTION
When communicating between two pool, certificate checking can't be used
because this requires a prior key exchange. Add a patch to detect this
case.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>

Still testing this - so that's why it's a draft.