### PR TITLE
CA-359076: avoid DB calls when starting management server

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -127,10 +127,11 @@ module Client_certificate_auth_server = struct
   let management_server = ref None
 
   let must_be_running ~__context ~mgmt_enabled =
-    let pool = Helpers.get_pool ~__context in
+    (* Note: no DB calls can be made here, except on the coordinator *)
     mgmt_enabled
     && Pool_role.is_master ()
-    && Db.Pool.get_client_certificate_auth_enabled ~__context ~self:pool
+    && Db.Pool.get_client_certificate_auth_enabled ~__context
+         ~self:(Helpers.get_pool ~__context)
 
   let start () =
     if !management_server = None then (


### PR DESCRIPTION
This postpones the DB calls in `must_be_running` until after the pool-
role check. On the coordinator, DB calls are allowed at this time.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>