### PR TITLE
CA-358904 REQ-403  cross pool migration must not use cert checking

### DIFF
--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -316,8 +316,7 @@ let remote_metadata_export_import ~__context ~rpc ~session_id ~remote_address
                         unlikely to happen in practice because the cache size is large enough.*)
                      with_transport
                        (SSL
-                          ( SSL.make ~verify_cert:(Stunnel_client.pool ())
-                              ~use_stunnel_cache:true ()
+                          ( SSL.make ~verify_cert:None ~use_stunnel_cache:true ()
                           , remote_address
                           , !Constants.https_port
                           )

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -828,11 +828,7 @@ let send_messages ~__context ~cls ~obj_uuid ~session_id ~remote_address =
   in
   let open Xmlrpc_client in
   let transport =
-    SSL
-      ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
-      , remote_address
-      , !Constants.https_port
-      )
+    SSL (SSL.make ~verify_cert:None (), remote_address, !Constants.https_port)
   in
   with_transport transport
     (with_http request (fun (rsp, fd) ->

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -14,7 +14,7 @@ list-hd () {
 }
 
 verify-cert () {
-  N=12
+  N=14
   NONE=$(git grep -r --count 'verify_cert:None' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$NONE" -eq "$N" ]; then
     echo "OK counted $NONE usages of verify_cert:None"


### PR DESCRIPTION
When communicating between two pool, certificate checking can't be used
because this requires a prior key exchange. Add a patch to detect this
case.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>