### PR TITLE
CA-358326 log cron job for cert refresh in syslog

### DIFF
--- a/scripts/certificate-refresh
+++ b/scripts/certificate-refresh
@@ -6,6 +6,10 @@ set -e
 
 source /etc/xensource-inventory
 host="$INSTALLATION_UUID"
+prio="local5.error"
+tag="$0"
+xe=/opt/xensource/bin/xe
+
 /usr/bin/sleep $((RANDOM % 600))
-/opt/xensource/bin/xe host-refresh-server-certificate host="$host"
+$xe host-refresh-server-certificate host="$host" 2>&1 | logger -p "$prio" -t "$tag"
 exit 0


### PR DESCRIPTION
When xapi is not available, for example early at system startup, a cron
job for cert rotation calling "xe host-refresh-server-certificate" may
fail because xe can't connect to xapi. Log these errors using syslog.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>