### PR TITLE
Enable formatting for ocaml code and format the code

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,3 @@
 (lang dune 2.0)
 
-(allow_approximate_merlin)
-
-(formatting disabled)
+(formatting (enabled_for ocaml))

--- a/ocaml/tapctl/tapctl.ml
+++ b/ocaml/tapctl/tapctl.ml
@@ -98,8 +98,7 @@ module Dummy = struct
   let get_dummy_tapdisk_list ctx =
     let filename = get_dummy_tapdisk_list_filename ctx in
     try
-      dummy_tap_list_of_rpc
-        (Jsonrpc.of_string (Unixext.string_of_file filename))
+      dummy_tap_list_of_rpc (Jsonrpc.of_string (Unixext.string_of_file filename))
     with _ -> []
 
   let write_dummy_tapdisk_list ctx list =
@@ -112,8 +111,7 @@ module Dummy = struct
     let numbers = IntSet.of_list list in
     let next n = n + 1 in
     let next_unused n = not (IntSet.mem (next n) numbers) in
-    IntSet.find_first_opt next_unused numbers
-    |> Option.fold ~none:0 ~some:next
+    IntSet.find_first_opt next_unused numbers |> Option.fold ~none:0 ~some:next
 
   let find_next_unused_minor list =
     let minors = List.filter_map (fun t -> t.d_minor) list in
@@ -143,7 +141,8 @@ module Dummy = struct
         Unixext.unlink_safe dummy_device ;
         Unixext.touch_file dummy_device ;
         write_dummy_tapdisk_list ctx (entry :: list) ;
-        minor)
+        minor
+    )
 
   let spawn ctx =
     Mutex.execute d_lock (fun () ->
@@ -153,15 +152,16 @@ module Dummy = struct
           {d_minor= None; d_pid= Some pid; d_state= None; d_args= None}
         in
         write_dummy_tapdisk_list ctx (entry :: list) ;
-        pid)
+        pid
+    )
 
   let attach ctx pid minor =
     Mutex.execute d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
-        ( (* sanity check *)
-        match
-          (get_entry_from_pid pid list, get_entry_from_minor minor list)
-        with
+        (* sanity check *)
+        ( match
+            (get_entry_from_pid pid list, get_entry_from_minor minor list)
+          with
         | Some e1, Some e2 ->
             if e1.d_minor <> None then failwith "pid already attached!" ;
             if e2.d_pid <> None then failwith "minor already in use!"
@@ -186,7 +186,8 @@ module Dummy = struct
             list
         in
         write_dummy_tapdisk_list ctx (new_entry :: list) ;
-        {tapdisk_pid= pid; minor})
+        {tapdisk_pid= pid; minor}
+    )
 
   let _open ctx t leaf_path driver =
     let args = Printf.sprintf "%s:%s" (string_of_driver driver) leaf_path in
@@ -198,10 +199,12 @@ module Dummy = struct
               if e.d_pid = Some t.tapdisk_pid && e.d_minor = Some t.minor then
                 {e with d_state= Some "0"; d_args= Some args}
               else
-                e)
+                e
+              )
             list
         in
-        write_dummy_tapdisk_list ctx list)
+        write_dummy_tapdisk_list ctx list
+    )
 
   let close ctx t =
     Mutex.execute d_lock (fun () ->
@@ -212,10 +215,12 @@ module Dummy = struct
               if e.d_pid = Some t.tapdisk_pid && e.d_minor = Some t.minor then
                 {e with d_state= Some "0x2"; d_args= None}
               else
-                e)
+                e
+              )
             list
         in
-        write_dummy_tapdisk_list ctx list)
+        write_dummy_tapdisk_list ctx list
+    )
 
   let pause ctx t =
     Mutex.execute d_lock (fun () ->
@@ -226,10 +231,12 @@ module Dummy = struct
               if e.d_pid = Some t.tapdisk_pid && e.d_minor = Some t.minor then
                 {e with d_state= Some "0x2a"}
               else
-                e)
+                e
+              )
             list
         in
-        write_dummy_tapdisk_list ctx list)
+        write_dummy_tapdisk_list ctx list
+    )
 
   let unpause ctx t leaf_path driver =
     let args = Printf.sprintf "%s:%s" (string_of_driver driver) leaf_path in
@@ -241,17 +248,20 @@ module Dummy = struct
               if e.d_pid = Some t.tapdisk_pid && e.d_minor = Some t.minor then
                 {e with d_state= Some "0"; d_args= Some args}
               else
-                e)
+                e
+              )
             list
         in
-        write_dummy_tapdisk_list ctx list)
+        write_dummy_tapdisk_list ctx list
+    )
 
   let detach ctx t =
     Mutex.execute d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let a, b =
           ( get_entry_from_pid t.tapdisk_pid list
-          , get_entry_from_minor t.minor list )
+          , get_entry_from_minor t.minor list
+          )
         in
         if a <> None && a <> b then failwith "Not attached" ;
         let list =
@@ -261,21 +271,23 @@ module Dummy = struct
           {d_minor= Some t.minor; d_pid= None; d_state= None; d_args= None}
           :: list
         in
-        write_dummy_tapdisk_list ctx list)
+        write_dummy_tapdisk_list ctx list
+    )
 
   let free ctx minor =
     Mutex.execute d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let entry = get_entry_from_minor minor list in
-        ( (* sanity check *)
-        match entry with
+        (* sanity check *)
+        ( match entry with
         | Some e ->
             if e.d_pid <> None then failwith "Can't free an attached minor"
         | None ->
             failwith "Unknown minor"
         ) ;
         let list = List.filter (fun e -> e.d_minor <> Some minor) list in
-        write_dummy_tapdisk_list ctx list)
+        write_dummy_tapdisk_list ctx list
+    )
 
   let list ?t ctx =
     Mutex.execute d_lock (fun () ->
@@ -298,8 +310,10 @@ module Dummy = struct
                 else
                   None
             | _ ->
-                None)
-          list)
+                None
+            )
+          list
+    )
 
   let stats t =
     let open Stats in
@@ -336,7 +350,8 @@ let canonicalise x =
               else
                 None
           | _ ->
-              found)
+              found
+          )
         None (xen_paths @ paths)
     in
     match first_hit with None -> x | Some hit -> hit
@@ -394,7 +409,8 @@ let _open ctx t leaf_path driver =
       (invoke_tap_ctl ctx "open"
          (args t
          @ ["-a"; Printf.sprintf "%s:%s" (string_of_driver driver) leaf_path]
-         ))
+         )
+      )
 
 let close ctx t =
   if ctx.dummy then
@@ -416,7 +432,8 @@ let unpause ctx t leaf_path driver =
       (invoke_tap_ctl ctx "unpause"
          (args t
          @ ["-a"; Printf.sprintf "%s:%s" (string_of_driver driver) leaf_path]
-         ))
+         )
+      )
 
 let detach ctx t =
   if ctx.dummy then
@@ -458,7 +475,8 @@ let list ?t ctx =
             let args = Astring.String.cut ~sep:":" args in
             Some ({tapdisk_pid; minor}, state, args)
         | _ ->
-            None)
+            None
+        )
       lines
 
 let is_paused ctx t =
@@ -493,7 +511,9 @@ let read_proc_devices () : (int * string) list =
     (List.map Option.to_list
        (Unixext.file_lines_fold
           (fun acc x -> parse_line x :: acc)
-          [] "/proc/devices"))
+          [] "/proc/devices"
+       )
+    )
 
 let driver_of_major major = List.assoc major (read_proc_devices ())
 

--- a/ocaml/vhd-tool/cli/main.ml
+++ b/ocaml/vhd-tool/cli/main.ml
@@ -71,7 +71,8 @@ let get_cmd =
     Arg.(value & pos 1 (some string) None & info [] ~doc)
   in
   ( Term.(ret (pure Impl.get $ common_options_t $ filename $ key))
-  , Term.info "get" ~sdocs:_common_options ~doc ~man )
+  , Term.info "get" ~sdocs:_common_options ~doc ~man
+  )
 
 let filename =
   let doc = Printf.sprintf "Path to the vhd file." in
@@ -90,7 +91,8 @@ let info_cmd =
     @ help
   in
   ( Term.(ret (pure Impl.info $ common_options_t $ filename))
-  , Term.info "info" ~sdocs:_common_options ~doc ~man )
+  , Term.info "info" ~sdocs:_common_options ~doc ~man
+  )
 
 let contents_cmd =
   let doc = "display the contents of the vhd" in
@@ -105,7 +107,8 @@ let contents_cmd =
     @ help
   in
   ( Term.(ret (pure Impl.contents $ common_options_t $ filename))
-  , Term.info "contents" ~sdocs:_common_options ~doc ~man )
+  , Term.info "contents" ~sdocs:_common_options ~doc ~man
+  )
 
 let create_cmd =
   let doc = "create a dynamic vhd" in
@@ -131,7 +134,8 @@ let create_cmd =
     Arg.(value & opt (some file) None & info ["parent"] ~doc)
   in
   ( Term.(ret (pure Impl.create $ common_options_t $ filename $ size $ parent))
-  , Term.info "create" ~sdocs:_common_options ~doc ~man )
+  , Term.info "create" ~sdocs:_common_options ~doc ~man
+  )
 
 let check_cmd =
   let doc = "check the structure of a vhd file" in
@@ -149,7 +153,8 @@ let check_cmd =
     Arg.(value & pos 0 (some file) None & info [] ~doc)
   in
   ( Term.(ret (pure Impl.check $ common_options_t $ filename))
-  , Term.info "check" ~sdocs:_common_options ~doc ~man )
+  , Term.info "check" ~sdocs:_common_options ~doc ~man
+  )
 
 let source =
   let doc = Printf.sprintf "The source disk" in
@@ -247,8 +252,10 @@ let serve_cmd =
         $ machine
         $ tar_filename_prefix
         $ ignore_checksums
-        ))
-  , Term.info "serve" ~sdocs:_common_options ~doc ~man )
+        )
+    )
+  , Term.info "serve" ~sdocs:_common_options ~doc ~man
+  )
 
 let stream_cmd =
   let doc = "stream the contents of a vhd disk" in
@@ -356,16 +363,19 @@ let stream_cmd =
       $ progress
       $ machine
       $ tar_filename_prefix
-      $ good_ciphersuites)
+      $ good_ciphersuites
+    )
   in
   ( Term.(ret (pure Impl.stream $ common_options_t $ stream_args_t))
-  , Term.info "stream" ~sdocs:_common_options ~doc ~man )
+  , Term.info "stream" ~sdocs:_common_options ~doc ~man
+  )
 
 let default_cmd =
   let doc = "manipulate virtual disks stored in vhd files" in
   let man = help in
   ( Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ common_options_t))
-  , Term.info "vhd-tool" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man )
+  , Term.info "vhd-tool" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
+  )
 
 let cmds =
   [

--- a/ocaml/vhd-tool/cli/sparse_dd.ml
+++ b/ocaml/vhd-tool/cli/sparse_dd.ml
@@ -33,7 +33,8 @@ let encryption_mode_of_string = function
   | x ->
       failwith
         (Printf.sprintf "Unknown encryption mode %s. Use always, never or user."
-           x)
+           x
+        )
 
 let encryption_mode = ref User
 
@@ -75,17 +76,20 @@ let options =
     ( name
     , Arg.String (fun x -> var_ref := Some x)
     , (fun () -> string_opt !var_ref)
-    , description )
+    , description
+    )
   in
   [
     ( "unbuffered"
     , Arg.Bool (fun b -> Vhd_format_lwt.File.use_unbuffered := b)
     , (fun () -> string_of_bool !Vhd_format_lwt.File.use_unbuffered)
-    , "use unbuffered I/O via O_DIRECT" )
+    , "use unbuffered I/O via O_DIRECT"
+    )
   ; ( "encryption-mode"
     , Arg.String (fun x -> encryption_mode := encryption_mode_of_string x)
     , (fun () -> string_of_encryption_mode !encryption_mode)
-    , "how to use encryption" )
+    , "how to use encryption"
+    )
   ; (* Want to ignore bad values for "nice" etc. so not using Arg.Int *)
     str_option "nice" nice
       "If supplied, the scheduling priority will be set using this value as \
@@ -99,47 +103,58 @@ let options =
   ; ( "experimental-reads-bypass-tapdisk"
     , Arg.Set experimental_reads_bypass_tapdisk
     , (fun () -> string_of_bool !experimental_reads_bypass_tapdisk)
-    , "bypass tapdisk and read directly from the underlying vhd file" )
+    , "bypass tapdisk and read directly from the underlying vhd file"
+    )
   ; ( "experimental-writes-bypass-tapdisk"
     , Arg.Set experimental_writes_bypass_tapdisk
     , (fun () -> string_of_bool !experimental_writes_bypass_tapdisk)
-    , "bypass tapdisk and write directly to the underlying vhd file" )
+    , "bypass tapdisk and write directly to the underlying vhd file"
+    )
   ; ( "base"
     , Arg.String (fun x -> base := Some x)
     , (fun () -> string_opt !base)
-    , "base disk to search for differences from" )
+    , "base disk to search for differences from"
+    )
   ; ( "src"
     , Arg.String (fun x -> src := Some x)
     , (fun () -> string_opt !src)
-    , "source disk" )
+    , "source disk"
+    )
   ; ( "dest"
     , Arg.String (fun x -> dest := Some x)
     , (fun () -> string_opt !dest)
-    , "destination disk" )
+    , "destination disk"
+    )
   ; ( "size"
     , Arg.String (fun x -> size := Int64.of_string x)
     , (fun () -> Int64.to_string !size)
-    , "number of bytes to copy" )
+    , "number of bytes to copy"
+    )
   ; ( "prezeroed"
     , Arg.Set prezeroed
     , (fun () -> string_of_bool !prezeroed)
-    , "assume the destination disk has been prezeroed" )
+    , "assume the destination disk has been prezeroed"
+    )
   ; ( "machine"
     , Arg.Set machine_readable_progress
     , (fun () -> string_of_bool !machine_readable_progress)
-    , "emit machine-readable output" )
+    , "emit machine-readable output"
+    )
   ; ( "ssl-legacy"
     , Arg.Set ssl_legacy
     , (fun () -> string_of_bool !ssl_legacy)
-    , " for TLS, allow all protocol versions instead of just TLSv1.2" )
+    , " for TLS, allow all protocol versions instead of just TLSv1.2"
+    )
   ; ( "good-ciphersuites"
     , Arg.String (fun x -> good_ciphersuites := Some x)
     , (fun () -> string_opt !good_ciphersuites)
-    , " the list of ciphersuites to allow for TLS" )
+    , " the list of ciphersuites to allow for TLS"
+    )
   ; ( "legacy-ciphersuites"
     , Arg.String (fun x -> legacy_ciphersuites := Some x)
     , (fun () -> string_opt !legacy_ciphersuites)
-    , " additional TLS ciphersuites allowed only if ssl-legacy is set" )
+    , " additional TLS ciphersuites allowed only if ssl-legacy is set"
+    )
   ]
 
 let ( +* ) = Int64.add
@@ -223,7 +238,8 @@ let find_backend_device path =
                 assert (self = bedomid) ;
                 Some params
             | _ ->
-                raise Not_found)
+                raise Not_found
+        )
     | _ ->
         raise Not_found
   with _ -> None
@@ -237,7 +253,8 @@ let with_paused_tapdisk path f =
       Tapctl.pause context tapdev ;
       after f (fun () ->
           debug "unpausing tapdisk for %s" path ;
-          Tapctl.unpause context tapdev path Tapctl.Vhd)
+          Tapctl.unpause context tapdev path Tapctl.Vhd
+      )
   | _, _, _ ->
       failwith (Printf.sprintf "Failed to pause tapdisk for %s" path)
 
@@ -358,7 +375,8 @@ let _ =
        )
        | _ ->
            error "Cannot use ionice due to invalid class value: %d" c
-     )) ;
+     )
+  ) ;
   debug "src = %s; dest = %s; base = %s; size = %Ld" src dest
     (Opt.default "None" base) size ;
   let src_image = Image.of_device src in
@@ -427,7 +445,8 @@ let _ =
       , src_image
       , !experimental_writes_bypass_tapdisk
       , dest
-      , dest_image )
+      , dest_image
+      )
     with
     | true, _, Some (`Vhd vhd), true, _, Some (`Vhd vhd') ->
         prezeroed := false ;

--- a/ocaml/vhd-tool/src/channels.ml
+++ b/ocaml/vhd-tool/src/channels.ml
@@ -30,9 +30,7 @@ let with_handle from_fd to_fd f =
   let unix_from_fd = Lwt_unix.unix_file_descr from_fd in
   let unix_to_fd = Lwt_unix.unix_file_descr to_fd in
   let handle = _init unix_from_fd unix_to_fd in
-  Lwt.finalize
-    (fun () -> f handle)
-    (fun () -> _cleanup handle ; Lwt.return_unit)
+  Lwt.finalize (fun () -> f handle) (fun () -> _cleanup handle ; Lwt.return_unit)
 
 let _direct_copy handle _from_fd _to_fd len =
   (* Atlhough the FD is set to blocking mode (by [with_blocking_fd]),
@@ -68,10 +66,12 @@ let direct_copy from_fd to_fd len =
               (fun () ->
                 f fd >>= fun r ->
                 Lwt_unix.set_blocking fd false ;
-                return r)
+                return r
+                )
               (fun e ->
                 Lwt_unix.set_blocking fd false ;
-                fail e)
+                fail e
+                )
       )
   in
 
@@ -103,7 +103,10 @@ let direct_copy from_fd to_fd len =
                 else
                   return ()
               in
-              loop len)))
+              loop len
+          )
+      )
+  )
 
 type t = {
     really_read: Cstruct.t -> unit Lwt.t

--- a/ocaml/vhd-tool/src/cohttp_unbuffered_io.ml
+++ b/ocaml/vhd-tool/src/cohttp_unbuffered_io.ml
@@ -122,8 +122,7 @@ let read_exactly ic len =
 
 let read ic n =
   let buf = Bytes.make n '\000' in
-  really_read_into ic.c buf 0 n >>= fun () ->
-  return (Bytes.unsafe_to_string buf)
+  really_read_into ic.c buf 0 n >>= fun () -> return (Bytes.unsafe_to_string buf)
 
 let write oc x =
   let buf = Cstruct.create (String.length x) in

--- a/ocaml/vhd-tool/src/common.ml
+++ b/ocaml/vhd-tool/src/common.ml
@@ -127,7 +127,8 @@ module Progress_bar (T : Floatable) = struct
       T.(
         to_float value
         /. to_float t.max_value
-        *. float_of_int (t.width - prefix - suffix))
+        *. float_of_int (t.width - prefix - suffix)
+      )
 
   let eta t =
     let time_so_far = Unix.gettimeofday () -. t.start_time in
@@ -191,7 +192,9 @@ let print_table header rows =
       (snd
          (List.fold_left
             (fun (i, acc) _ -> (i + 1, width_of_column i :: acc))
-            (0, []) header))
+            (0, []) header
+         )
+      )
   in
   let print_row row =
     List.iter

--- a/ocaml/vhd-tool/src/impl.ml
+++ b/ocaml/vhd-tool/src/impl.ml
@@ -76,7 +76,8 @@ let get _common filename key =
       `Error
         ( true
         , Printf.sprintf "Unknown key. Known keys are: %s"
-            (String.concat ", " Vhd_format.F.Vhd.Field.list) )
+            (String.concat ", " Vhd_format.F.Vhd.Field.list)
+        )
 
 let info _common filename =
   try
@@ -90,7 +91,8 @@ let info _common filename =
             | Some v ->
                 [f; v]
             | None ->
-                [f; "<missing field>"])
+                [f; "<missing field>"]
+            )
           Vhd_format.F.Vhd.Field.list
       in
       print_table ["field"; "value"] all ;
@@ -154,7 +156,8 @@ let create common filename size parent =
          Lwt_main.run t
      | Some _parent, Some _size ->
          failwith
-           "Overriding the size in a child node not currently implemented") ;
+           "Overriding the size in a child node not currently implemented"
+    ) ;
     `Ok ()
   with Failure x -> `Error (true, x)
 
@@ -211,7 +214,8 @@ let[@warning "-27"] stream_human _common _ s _ _ ?(progress = no_progress_bar)
       Printf.printf "%s: %s\n"
         (padto ' ' decimal_digits (Int64.to_string sector))
         (Vhd_format.Element.to_string x) ;
-      return (Int64.add sector (Vhd_format.Element.len x)))
+      return (Int64.add sector (Vhd_format.Element.len x))
+      )
     0L s.elements
   >>= fun _ ->
   Printf.printf "# end of stream\n" ;
@@ -236,7 +240,8 @@ let stream_nbd _common c s prezeroed _ ?(progress = no_progress_bar) () =
     Int64.(
       add
         (add s.size.metadata s.size.copy)
-        (if prezeroed then 0L else s.size.empty))
+        (if prezeroed then 0L else s.size.empty)
+    )
   in
   let p = progress total_work in
 
@@ -260,13 +265,16 @@ let stream_nbd _common c s prezeroed _ ?(progress = no_progress_bar) () =
           fail
             (Failure
                (Printf.sprintf "unexpected stream element: %s"
-                  (Vhd_format.Element.to_string x)))
+                  (Vhd_format.Element.to_string x)
+               )
+            )
       )
       >>= fun work ->
       let sector = Int64.add sector (Vhd_format.Element.len x) in
       let work_done = Int64.add work_done work in
       p work_done ;
-      return (sector, work_done))
+      return (sector, work_done)
+      )
     (0L, 0L) s.elements
   >>= fun _ ->
   p total_work ;
@@ -281,7 +289,8 @@ let stream_chunked _common c s prezeroed _ ?(progress = no_progress_bar) () =
     Int64.(
       add
         (add s.size.metadata s.size.copy)
-        (if prezeroed then 0L else s.size.empty))
+        (if prezeroed then 0L else s.size.empty)
+    )
   in
   let p = progress total_work in
 
@@ -305,13 +314,16 @@ let stream_chunked _common c s prezeroed _ ?(progress = no_progress_bar) () =
           fail
             (Failure
                (Printf.sprintf "unexpected stream element: %s"
-                  (Vhd_format.Element.to_string x)))
+                  (Vhd_format.Element.to_string x)
+               )
+            )
       )
       >>= fun work ->
       let sector = Int64.add sector (Vhd_format.Element.len x) in
       let work_done = Int64.add work_done work in
       p work_done ;
-      return (sector, work_done))
+      return (sector, work_done)
+      )
     (0L, 0L) s.elements
   >>= fun _ ->
   p total_work ;
@@ -328,7 +340,8 @@ let stream_raw _common c s prezeroed _ ?(progress = no_progress_bar) () =
     Int64.(
       add
         (add s.size.metadata s.size.copy)
-        (if prezeroed then 0L else s.size.empty))
+        (if prezeroed then 0L else s.size.empty)
+    )
   in
   let p = progress total_work in
 
@@ -354,7 +367,8 @@ let stream_raw _common c s prezeroed _ ?(progress = no_progress_bar) () =
       )
       >>= fun work ->
       let work_done = Int64.add work_done work in
-      p work_done ; return work_done)
+      p work_done ; return work_done
+      )
     0L s.elements
   >>= fun _ ->
   p total_work ;
@@ -526,13 +540,16 @@ let stream_tar _common c s _ prefix ?(progress = no_progress_bar) () =
           fail
             (Failure
                (Printf.sprintf "unexpected stream element: %s"
-                  (Vhd_format.Element.to_string x)))
+                  (Vhd_format.Element.to_string x)
+               )
+            )
       )
       >>= fun state ->
       let work = Int64.mul (E.len x) 512L in
       let work_done = Int64.add state.work_done work in
       p work_done ;
-      return {state with work_done})
+      return {state with work_done}
+      )
     (initial s.size.Vhd_format.F.total)
     s.elements
   >>= fun _ ->
@@ -632,7 +649,9 @@ let serve_tar_to_raw total_size c dest prezeroed progress expected_prefix
                 fail
                   (Failure
                      (Printf.sprintf "expected filename prefix %s, got %s" p
-                        hdr.Tar.Header.file_name))
+                        hdr.Tar.Header.file_name
+                     )
+                  )
               else
                 let p_len = String.length p in
                 let file_name_len = String.length hdr.Tar.Header.file_name in
@@ -665,7 +684,9 @@ let serve_tar_to_raw total_size c dest prezeroed progress expected_prefix
                 fail
                   (Failure
                      (Printf.sprintf "Unexpected checksum in block %s"
-                        hdr.Tar.Header.file_name))
+                        hdr.Tar.Header.file_name
+                     )
+                  )
               ) else
                 loop {t with ctx= Sha1.init ()}
           else
@@ -680,8 +701,8 @@ let serve_tar_to_raw total_size c dest prezeroed progress expected_prefix
               with _ ->
                 fail
                   (Failure
-                     (Printf.sprintf "Expected sequence number, got %s"
-                        filename))
+                     (Printf.sprintf "Expected sequence number, got %s" filename)
+                  )
             )
             >>= fun sequence_number ->
             let skipped_blocks = sequence_number - t.last_sequence_number - 1 in
@@ -741,7 +762,8 @@ let endpoint_of_string = function
                |> int_of_string
                |> file_descr_of_int
                |> Lwt_unix.of_unix_file_descr
-               ))
+               )
+            )
       | Some "tcp", _ ->
           let host =
             match Uri.host uri' with
@@ -798,7 +820,8 @@ let retry common retries f =
               "warning: caught %s; will retry %d more time%s...\n%!"
               (Printexc.to_string exn) n
               (if n = 1 then "" else "s") ;
-          Lwt_unix.sleep 1. >>= fun () -> aux (n - 1))
+          Lwt_unix.sleep 1. >>= fun () -> aux (n - 1)
+      )
   in
   aux retries
 
@@ -821,7 +844,9 @@ let make_stream common source relative_to source_format destination_format =
              (Printf.sprintf
                 "Failed to parse nbdhybrid source: %s (expecting \
                  <raw_disk>:<nbd_server>:<export_name>:<size>"
-                source))
+                source
+             )
+          )
   )
   | "hybrid", "raw" -> (
     (* expect source to be block_device:vhd *)
@@ -844,7 +869,9 @@ let make_stream common source relative_to source_format destination_format =
           (Failure
              (Printf.sprintf
                 "Failed to parse hybrid source: %s (expected raw_disk|vhd_disk)"
-                source))
+                source
+             )
+          )
   )
   | "hybrid", "vhd" -> (
     (* expect source to be block_device:vhd *)
@@ -867,7 +894,9 @@ let make_stream common source relative_to source_format destination_format =
           (Failure
              (Printf.sprintf
                 "Failed to parse hybrid source: %s (expected raw_disk|vhd_disk)"
-                source))
+                source
+             )
+          )
   )
   | "vhd", "vhd" ->
       let path = common.path @ [Filename.dirname source] in
@@ -1010,7 +1039,8 @@ let write_stream common s destination _source_protocol destination_protocol
               let headers =
                 List.map
                   (fun (x, y) ->
-                    (String.lowercase_ascii x, String.lowercase_ascii y))
+                    (String.lowercase_ascii x, String.lowercase_ascii y)
+                    )
                   headers
               in
               let te = "transfer-encoding" in
@@ -1038,8 +1068,9 @@ let write_stream common s destination _source_protocol destination_protocol
     fail
       (Failure
          (Printf.sprintf "this destination only supports protocols: [ %s ]"
-            (String.concat "; "
-               (List.map string_of_protocol possible_protocols))))
+            (String.concat "; " (List.map string_of_protocol possible_protocols))
+         )
+      )
   else
     let start = Unix.gettimeofday () in
     ( match destination_protocol with
@@ -1153,7 +1184,8 @@ let serve_nbd_to_raw common size c dest _ _ _ _ =
             inblocks
               (fun offset subblock ->
                 c.Channels.really_read subblock >>= fun () ->
-                Vhd_format_lwt.IO.really_write dest offset subblock)
+                Vhd_format_lwt.IO.really_write dest offset subblock
+                )
               request
             >>= fun () ->
             Reply.marshal rep
@@ -1166,7 +1198,8 @@ let serve_nbd_to_raw common size c dest _ _ _ _ =
             inblocks
               (fun offset subblock ->
                 Vhd_format_lwt.IO.really_read dest offset subblock >>= fun () ->
-                c.Channels.really_write subblock)
+                c.Channels.really_write subblock
+                )
               request
         | _ ->
             Reply.marshal rep
@@ -1258,13 +1291,13 @@ let serve common_options source source_fd source_format source_protocol
       failwith (Printf.sprintf "%s is not a supported format" source_format) ;
     let supported_formats = ["raw"] in
     if not (List.mem destination_format supported_formats) then
-      failwith
-        (Printf.sprintf "%s is not a supported format" destination_format) ;
+      failwith (Printf.sprintf "%s is not a supported format" destination_format) ;
     let supported_protocols = [NoProtocol; Chunked; Nbd; Tar] in
     if not (List.mem source_protocol supported_protocols) then
       failwith
         (Printf.sprintf "%s is not a supported source protocol"
-           (string_of_protocol source_protocol)) ;
+           (string_of_protocol source_protocol)
+        ) ;
 
     let destination =
       match destination_fd with
@@ -1334,13 +1367,15 @@ let serve common_options source source_fd source_format source_protocol
               (Failure
                  "Non-zero size required (either a pre-existing destination \
                   file or specified via --destination-size on the command \
-                  line)")
+                  line)"
+              )
           else
             return (fd, size)
       | _ ->
           failwith
             (Printf.sprintf "Not implemented: writing to destination %s"
-               destination)
+               destination
+            )
       )
       >>= fun (destination_fd, size) ->
       let fn =
@@ -1360,14 +1395,14 @@ let serve common_options source source_fd source_format source_protocol
               (Printf.sprintf
                  "Not implemented: receiving format %s via protocol %s"
                  source_format
-                 (StreamCommon.string_of_protocol source_protocol))
+                 (StreamCommon.string_of_protocol source_protocol)
+              )
       in
       fn source_sock destination_fd prezeroed progress_bar expected_prefix
         ignore_checksums
       >>= fun () ->
       let fd =
-        Lwt_unix.unix_file_descr
-          (Vhd_format_lwt.IO.to_file_descr destination_fd)
+        Lwt_unix.unix_file_descr (Vhd_format_lwt.IO.to_file_descr destination_fd)
       in
       try
         Vhd_format_lwt.File.fsync fd ;

--- a/ocaml/vhd-tool/src/nbd_input.ml
+++ b/ocaml/vhd-tool/src/nbd_input.ml
@@ -34,7 +34,8 @@ let get_extents_json ~extent_reader ~server ~export_name ~offset ~length =
        ; Int64.to_string offset
        ; "--length"
        ; Int64.to_string length
-      |] )
+      |]
+    )
 
 let raw ?(extent_reader = "/opt/xensource/libexec/get_nbd_extents.py") raw
     server export_name size =
@@ -71,7 +72,8 @@ let raw ?(extent_reader = "/opt/xensource/libexec/get_nbd_extents.py") raw
           (Printf.sprintf
              "Nbd_input.raw: extents returned for offset=%Ld & length=%Ld \
               finished at incorrect offset %Ld,"
-             offset length final_offset)
+             offset length final_offset
+          )
     else
       Lwt.return_unit
     )
@@ -85,7 +87,8 @@ let raw ?(extent_reader = "/opt/xensource/libexec/get_nbd_extents.py") raw
             Lwt.fail_with
               (Printf.sprintf
                  "Nbd_input.raw finished with offset=%Ld <> size=%Ld" offset
-                 size)
+                 size
+              )
         else
           Lwt.return_unit
         )

--- a/ocaml/vhd-tool/src/xenstore.ml
+++ b/ocaml/vhd-tool/src/xenstore.ml
@@ -89,7 +89,8 @@ module Xs = struct
     ; write= Client.write h
     ; writev=
         (fun base_path ->
-          List.iter (fun (k, v) -> Client.write h (base_path ^ "/" ^ k) v))
+          List.iter (fun (k, v) -> Client.write h (base_path ^ "/" ^ k) v)
+          )
     ; mkdir= Client.mkdir h
     ; rm= (fun path -> try Client.rm h path with Xs_protocol.Enoent _ -> ())
     ; setperms= Client.setperms h


### PR DESCRIPTION
This was missed during the update to dune 2.0