### PR TITLE
CA-357785: Stop metrics binaries from logging to stdout

### DIFF
--- a/ocaml/xcp-rrdd/lib/plugin/rrdd_plugin.ml
+++ b/ocaml/xcp-rrdd/lib/plugin/rrdd_plugin.ml
@@ -138,7 +138,6 @@ functor
       ) else (
         D.info "Not daemonizing .." ;
         Sys.catch_break true ;
-        Debug.log_to_stdout ()
       ) ;
       if !pidfile <> "" then (
         D.debug "Storing process id into specified file .." ;

--- a/ocaml/xcp-rrdd/lib/plugin/rrdd_plugin.ml
+++ b/ocaml/xcp-rrdd/lib/plugin/rrdd_plugin.ml
@@ -119,31 +119,7 @@ functor
       Debug.set_facility Syslog.Local0 ;
       D.info "installing signal handler for SIGTERM in %s" __LOC__ ;
       Sys.set_signal Sys.sigterm (Sys.Signal_handle on_sigterm) ;
-      let pidfile = ref "" in
-      let daemonize = ref false in
-      Arg.parse
-        (Arg.align
-           [
-             ("-daemon", Arg.Set daemonize, "Create a daemon")
-           ; ( "-pidfile"
-             , Arg.Set_string pidfile
-             , Printf.sprintf "Set the pid file (default \"%s\")" !pidfile
-             )
-           ]
-        )
-        (fun _ -> failwith "Invalid argument")
-        (Printf.sprintf "Usage: %s [-daemon] [-pidfile filename]" N.name) ;
-      if !daemonize then (
-        D.info "Daemonizing .." ; Unixext.daemonize ()
-      ) else (
-        D.info "Not daemonizing .." ;
-        Sys.catch_break true ;
-      ) ;
-      if !pidfile <> "" then (
-        D.debug "Storing process id into specified file .." ;
-        Unixext.mkdir_rec (Filename.dirname !pidfile) 0o755 ;
-        Unixext.pidfile_write !pidfile
-      )
+      Sys.catch_break true
 
     let main_loop ~neg_shift ~target ~protocol ~dss_f =
       Reporter.start (module D) ~uid:N.name ~neg_shift ~target ~protocol ~dss_f


### PR DESCRIPTION
Before systemd these binaries were daemonized when running on a system,
and not daemonized when ran for debugging purposes.
Now systemd launches them without parameters to be daemonized making
this code obsolete and make it log on daemon.log as well.

Remove the logic that allows daemonization and stop logging to stdout

This avoids the logspam in daemon.log which is produced because the ocaml libraries doesn't set a stricted loglevel. the log facility local0 already avoid logging debug-level messages to xcp-rrdd-plugins.log using syslog configuration