### PR TITLE
CA-359226 add fist point to backdate new certs during testing

### DIFF
--- a/ocaml/gencert/gencert.ml
+++ b/ocaml/gencert/gencert.ml
@@ -41,7 +41,7 @@ let generate_cert_or_fail ~generator ~path =
     exit 1
   )
 
-let main ~dbg ~path ~sni =
+let main ~dbg ~path ~sni () =
   let init_inventory () = Inventory.inventory_filename := inventory in
   init_inventory () ;
   let generator path =
@@ -82,7 +82,7 @@ let () =
   | [|_; path; sni|] -> (
     match SNI.of_string sni with
     | Some sni ->
-        main ~dbg ~path ~sni
+        main ~dbg ~path ~sni ()
     | None ->
         D.error "SNI must be default or xapi:pool, but got '%s'" sni ;
         exit 1

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -1,3 +1,21 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val fist_path : string
+(** Path to a file; if this file exists, newly created certificates will
+be backdated to 2008-07-01 and any [valid_from] ignored *)
+
 val write_certs : string -> string -> (unit, [> Rresult.R.msg]) result
 (** [write_certs path pkcs12] writes [pkcs12] to [path] atomically.
 [pkcs12] should contain a components of a PKCS12 Certificate *)
@@ -6,13 +24,19 @@ val host :
      name:string
   -> dns_names:string list
   -> ips:Cstruct.t list
+  -> ?valid_from:Ptime.t (* default: now *)
   -> string
   -> X509.Certificate.t
 (** [host name dns_names ip path] creates (atomically) a PEM file at
     [path] with [name] as CN, and the following SANs: [dns_names] + [ip] *)
 
-val xapi_pool : uuid:string -> string -> X509.Certificate.t
+val xapi_pool :
+     ?valid_from:Ptime.t (* default: now *)
+  -> uuid:string
+  -> string
+  -> X509.Certificate.t
 (** [xapi_pool uuid path] creates (atomically) a PEM file at [path] with
     [uuid] as CN *)
 
-val xapi_cluster : cn:string -> string
+val xapi_cluster :
+  ?valid_from:Ptime.t (* default: now *) -> cn:string -> unit -> string

--- a/ocaml/xapi/xapi_cluster_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_helpers.ml
@@ -109,7 +109,7 @@ module Pem = struct
   open Cluster_interface
   module Client = Client.Client
 
-  let init' cn = {cn; blobs= [Gencertlib.Selfcert.xapi_cluster ~cn]}
+  let init' cn = {cn; blobs= [Gencertlib.Selfcert.xapi_cluster ~cn ()]}
 
   let init ~__context ~cn =
     if unit_test ~__context then


### PR DESCRIPTION
When creating new certs, we made them valid from the current moment. To
help with testing, we backdate them based if fist point
/tmp/fist_gencert_backdate is present. During testing we change the date
and that introduces the problem to have certificates that are only start
to become valid in the future. Backdating avoids the problem.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>