### PR TITLE
Maintenance: remove warnings

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
@@ -354,7 +354,7 @@ let refresh_phypath_to_sr_vdi () =
 
 let exec_tap_ctl () =
   let tap_ctl = "/usr/sbin/tap-ctl list" in
-  let extract_vdis pid minor state kind phypath =
+  let extract_vdis pid minor _state kind phypath =
     if not (kind = "vhd" || kind = "aio") then raise (Failure "Unknown type") ;
     (* Look up SR and VDI uuids from the physical path *)
     if not (Hashtbl.mem phypath_to_sr_vdi phypath) then

--- a/ocaml/xcp-rrdd/lib/plugin/rrdd_plugin.ml
+++ b/ocaml/xcp-rrdd/lib/plugin/rrdd_plugin.ml
@@ -12,8 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_unix
-
 let signal_name signum =
   let signals =
     let t = Hashtbl.create 30 in


### PR DESCRIPTION
Honor warnings by the compiler and fix them.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>