### PR TITLE
CA-359214: Only restart stunnel if the config file has changed

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -183,7 +183,7 @@ let run ~__context ?mgmt_enabled () =
   Mutex.execute management_m (fun () ->
       Client_certificate_auth_server.update ~__context ~mgmt_enabled ;
       next_server_mode ~mgmt_enabled |> Server.update ~__context ;
-      Xapi_stunnel_server.restart ~__context (Server.is_ipv6_enabled ())
+      Xapi_stunnel_server.sync ~__context (Server.is_ipv6_enabled ())
   )
 
 let reconfigure_himn ~__context ~addr =

--- a/ocaml/xapi/xapi_stunnel_server.mli
+++ b/ocaml/xapi/xapi_stunnel_server.mli
@@ -16,8 +16,8 @@
     There exist scripts (e.g. xe-toolstack-restart) which also manipulate
     the stunnel daemon but they do this directly (not via ocaml). *)
 
-val restart : __context:Context.t -> bool -> unit
-(** restart stunnel, possibly changing the config file *)
+val sync : __context:Context.t -> bool -> unit
+(** update config file and (re)start stunnel, if needed *)
 
 val reload : ?wait:float -> unit -> unit
 (** reload (potentially updated) configuration *)


### PR DESCRIPTION
This avoids unnecessarily breaking connections.

This addresses a regression introduced in d1fea38, which caused stunnel
to be restarted no matter whether a new management server was started.

The patch renames Xapi_stunnel_server.restart to .sync to reflect that
the function no longer always restarts stunnel. Also the logging is
improved.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>