### PR TITLE
CA-357075: Handle error from get_cluster_config call during RPU

### DIFF
--- a/ocaml/xapi/xapi_cluster_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_helpers.ml
@@ -181,6 +181,8 @@ module Pem = struct
           D.debug "Pem.get_existing: found existing pem!" ;
           Some p
     )
+    | exception Api_errors.(Server_error (message_method_unknown, _)) ->
+        None
 
   let maybe_write_new ~__context self =
     let write h =
@@ -220,4 +222,6 @@ module Pem = struct
           D.info "Pem.maybe_write_new: successfully written on cluster '%s'"
             (Ref.short_string_of self)
     )
+    | exception Api_errors.(Server_error (message_method_unknown, _)) ->
+        ()
 end


### PR DESCRIPTION
The Cluster_host.get_cluster_config is new, but during a rolling pool
upgrade it may be called on pool members that have not yet been updated.
We therefore must handle the MESSAGE_METHOD_UNKNOWN error that gets
raised in this case.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>