### PR TITLE
stunnel/gencert services: use Wants rather than Requires

### DIFF
--- a/scripts/11-stunnel-gencert.conf
+++ b/scripts/11-stunnel-gencert.conf
@@ -1,3 +1,3 @@
 [Unit]
-Requires=gencert.service
+Wants=gencert.service
 After=gencert.service

--- a/scripts/gencert.service
+++ b/scripts/gencert.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Generate TLS certificates for xapi
-Requires=forkexecd.service
+Wants=forkexecd.service
 After=forkexecd.service
 
 [Service]


### PR DESCRIPTION
This avoids stunnel to go down if forkexecd is restarted.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>