### PR TITLE
Updating README with step-by-step build instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,18 +53,18 @@ To build xen-api from source, we recommend using [opam](https://opam.ocaml.org/d
     opam repo add xs-opam https://github.com/xapi-project/xs-opam.git
     # Remove the default, because how it handles version conflicts is different:
     opam repo remove default
-    # Have opam now figure out what versions of each package to use:
+    # (NOT needed with opam>=2.1.0) Have opam now figure out what versions of each package to use:
     opam pin --yes add . --no-action
     ```
 
 6) Install all the Packages.
 
     ```bash
-    PACKAGES="xapi-cli-protocol xapi-client xapi-consts xapi-database xapi-datamodel xapi-types xapi xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-svr pciutil safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd vhd-tool"
+    PACKAGES="xapi-cli-protocol xapi-client xapi-consts xapi-database xapi-datamodel xapi-types xapi xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-svr pciutil safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd vhd-tool xs-toolstack"
 
-    ## Install all the dependances (Including OS):
+    # NOT needed with opam>=2.1.0) Install all the dependances (Including OS):
     opam --yes depext --yes -u $PACKAGES # The first '--yes' is to install depext itself
-    ## Install the Packages finally:
+    # Install the Packages finally:
     opam install $PACKAGES --yes --deps-only --with-test -v
     # update the current switch. (You're already on the correct one, just refresh it).
     eval $(opam env)


### PR DESCRIPTION
These instructions are tested on Ubuntu Desktop 20.04

Of note, I couldn't get `xe` to run after these, since I couldn't figure out how to start the services. Is there an easy way to start them that I could add to the README? Or is starting them too different between OS's to support something like that?