### PR TITLE
XSI-1120 CA-288411: make the cache work after a toolstack restart

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2079,6 +2079,12 @@ let resync_resident_on ~__context =
       Db.VM.set_resident_on ~__context ~self:vm ~value:localhost)
       xapi_thinks_are_nowhere;
 
+  List.iter (fun ((id, state), _queue_name) ->
+      match xenapi_of_xenops_power_state (Some state.Vm.power_state) with
+      | `Running | `Paused -> add_caches id;
+      | _ -> ()
+  ) xenopsd_vms_in_xapi;
+
   (* Sync VM state in Xapi for VMs not running on this host *)
   List.iter (fun (id, vm) ->
       info "VM %s was marked as resident here in the DB but isn't known to xenopsd. Resetting in DB" id;


### PR DESCRIPTION
Backport of 55fd33ece4cf4db2cc6a5dfdbb074811aa03fb52

This fixes a regression introduced in the fix for XOP-830,
where `add_caches` got dropped from the startup resynchronization logic.

This resulted in periodic writes to the database, which are especially
bad with redo log (or implicitly with HA) turned on.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>
Signed-off-by: Christian Lindig <christian.lindig@citrix.com>