### PR TITLE
CA-359975: set the IP in /etc/issue on first boot

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -89,6 +89,7 @@ end = struct
          database this can fail... this is ok because the database will be synchronised later *)
       Server_helpers.exec_with_new_task "refreshing consoles" (fun __context ->
           Dbsync_master.set_master_ip ~__context ;
+          Helpers.update_getty () ;
           Dbsync_master.refresh_console_urls ~__context
       )
 


### PR DESCRIPTION
On first boot Host.address is set here which means the code that
previously-triggered code in `on_dom0_networking_change` is not run at
that point.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>