### PR TITLE
CA-359975: set the IP in /etc/issue on first boot

### DIFF
--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -119,6 +119,7 @@ let start ~__context ?addr () =
        		   database this can fail... this is ok because the database will be synchronised later *)
     Server_helpers.exec_with_new_task "refreshing consoles" (fun __context ->
         Dbsync_master.set_master_ip ~__context ;
+        Helpers.update_getty () ;
         Dbsync_master.refresh_console_urls ~__context)
 
 let change interface primary_address_type =


### PR DESCRIPTION
On first boot Host.address is set here which means the code that
previously-triggered code in `on_dom0_networking_change` is not run at
that point.

Cherry-pick of ab5971569ae37e41bf72d2923afd0881c20f1545

I've manually verified that be behaviour has changed on hosts set up by the internal citrix testing system.
On a previous build we get this output when logging in through ssh:

```
# cat /etc/issue
Citrix Hypervisor Host 8.2.1

System Booted: 2021-10-28 13:13

Your Citrix Hypervisor Host has now finished booting.
To manage this server please use the Citrix XenCenter application.
You can install XenCenter for Windows from https://www.citrix.com/downloads/citrix-hypervisor.

You can connect to this system using one of the following network
addresses:

IP address not configured
```

With this patch:
```
# cat /etc/issue
Citrix Hypervisor Host 8.2.1

System Booted: 2021-10-28 12:48

Your Citrix Hypervisor Host has now finished booting.
To manage this server please use the Citrix XenCenter application.
You can install XenCenter for Windows from https://www.citrix.com/downloads/citrix-hypervisor.

You can connect to this system using one of the following network
addresses:

10.10.10.1

Citrix Hypervisor Host SSL certificate fingerprint:
91:AF:75:73:21:15:81:7C:26:D7:DE:0F:D7:4E:D0:0B:93:D0:CD:E3
```