### PR TITLE
CP-38309 make TLS more explicit in clusterd interface

### DIFF
--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -37,7 +37,7 @@ let test_clusterd_rpc ~__context call =
         ; config_version= 1L
         ; cluster_token_timeout_ms= 20000L
         ; cluster_token_coefficient_ms= 1000L
-        ; pems= None
+        ; tls_config= tls_config_empty
         }
       in
       let diag =

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -54,14 +54,16 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
       let token_timeout_coefficient_ms =
         Int64.of_float (token_timeout_coefficient *. 1000.0)
       in
-      let pems = Xapi_cluster_helpers.Pem.init ~__context ~cn:cluster_uuid in
+      let tls_config =
+        Xapi_cluster_helpers.Pem.init ~__context ~cn:cluster_uuid
+      in
       let init_config =
         {
           Cluster_interface.local_ip= ip
         ; token_timeout_ms= Some token_timeout_ms
         ; token_coefficient_ms= Some token_timeout_coefficient_ms
         ; name= None
-        ; pems
+        ; tls_config
         }
       in
       Xapi_clustering.Daemon.enable ~__context ;


### PR DESCRIPTION
We want to move to a more explicit interface with xapi clusterd. In
particular, when certificate checking is enabled and what certificates
it is using should be more obvious.

This leaves certificate checking still *off* by default. Expect the CI to tail because this depends on changes in https://github.com/xapi-project/message-switch/pull/74

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>