### PR TITLE
CA-360997: Don't reject imports if the host's major version is larger

### DIFF
--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -107,15 +107,15 @@ let this_version __context =
     This will get complicated over time... *)
 let assert_compatible ~__context other_version =
   let this_version = this_version __context in
-  (* error if major versions differ; also error if this host has a
-     lower minor vsn than the import *)
+  (* error if this host has a lower vsn than the import *)
   if
-    this_version.xapi_vsn_major <> other_version.xapi_vsn_major
-    || this_version.xapi_vsn_minor < other_version.xapi_vsn_minor
+    this_version.xapi_vsn_major < other_version.xapi_vsn_major
+    || this_version.xapi_vsn_major = other_version.xapi_vsn_major
+       && this_version.xapi_vsn_minor < other_version.xapi_vsn_minor
   then (
     error
       "Import version is incompatible - this_version=(%d,%d), \
-       other_version=(%d, %d)"
+       other_version=(%d,%d)"
       this_version.xapi_vsn_major this_version.xapi_vsn_minor
       other_version.xapi_vsn_major other_version.xapi_vsn_minor ;
     raise (Api_errors.Server_error (Api_errors.import_incompatible_version, []))


### PR DESCRIPTION
The current code always rejects imports of the major version of the
running xapi and the one in the import metadata are not equal. This
change makes it less strict by only rejecting imports from strictly
newer versions of xapi.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>