### PR TITLE
CA-361151: Provide default user details on ldap query fail

### DIFF
--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -719,7 +719,6 @@ let config_winbind_damon ~domain ~workgroup ~netbios_name =
       ; Printf.sprintf "realm = %s" domain
       ; "security = ADS"
       ; "template shell = /bin/bash"
-      ; "winbind offline logon = Yes"
       ; "winbind refresh tickets = Yes"
       ; "winbind enum groups = no"
       ; "winbind enum users = no"


### PR DESCRIPTION
Ldap fails for cross domain if the target domain does not trust
the joined domain
Ldap is used to query user details like whether an account is
disabled, locked out etc, provide default value on failure

Signed-off-by: Lin Liu <lin.liu@citrix.com>