### PR TITLE
Enable to set a `Task`'s `resident_on` field.

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -266,6 +266,16 @@ module Task = struct
       ~allowed_roles:_R_READ_ONLY (* POOL_OP can set error_info for any tasks, others can set error_info only for owned tasks *)
       ()
 
+  let set_resident_on = call ~flags:[`Session]
+      ~in_oss_since:None
+      ~in_product_since:rel_next
+      ~name:"set_resident_on"
+      ~doc:"Set the resident on field"
+      ~params:[Ref _task, "self", "Reference to the task object";
+               Ref _host, "value", "Resident on to be set"]
+      ~allowed_roles:_R_READ_ONLY (* POOL_OP can set resident_on for any tasks, others can set error_info only for owned tasks *)
+      ()
+
   (* this permission allows to destroy any task, instead of only the owned ones *)
   let extra_permission_task_destroy_any = "task.destroy/any"
 

--- a/ocaml/xapi/xapi_task.ml
+++ b/ocaml/xapi/xapi_task.ml
@@ -76,3 +76,7 @@ let set_result ~__context ~self ~value =
 let set_error_info ~__context ~self ~value =
   TaskHelper.assert_op_valid ~__context self ;
   Db.Task.set_error_info ~__context ~self ~value
+
+let set_resident_on ~__context ~self ~value =
+  TaskHelper.assert_op_valid ~__context self ;
+  Db.Task.set_resident_on ~__context ~self ~value


### PR DESCRIPTION
This is a continuation of https://github.com/xapi-project/xen-api/pull/4543.
When creating a Task that is not linked to another XAPI call, a user needs to set on which host this task is running.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>