### PR TITLE
utf8_recode: use Uutf.{Buffer.add_utf_8,String.fold_utf_8} instead of Uutf.{encoder,decoder}

### DIFF
--- a/ocaml/xenopsd/lib/xenops_utils.ml
+++ b/ocaml/xenopsd/lib/xenops_utils.ml
@@ -122,7 +122,15 @@ let utf8_add_if_valid buf _ next =
   Uutf.Buffer.add_utf_8 buf uchar;
   buf
 
+let is_valid prev _ = function
+  | `Malformed _ -> false
+  | `Uchar _ -> prev
+
 let utf8_recode str =
+  (* optimistic assumption that the string contains only valid utf8,
+     avoids allocations *)
+  if Uutf.String.fold_utf_8 is_valid true str then str
+  else
   let b = Buffer.create (String.length str) in
   Uutf.String.fold_utf_8 utf8_add_if_valid b str
   |> Buffer.contents


### PR DESCRIPTION
Uutf.encoder allocates a 64k buffer internally (in addition to our 1k buffer).
Use Uutf.Buffer to write utf8 chars directly into our buffer instead.
Also size the buffer based on initial string size (it can grow if needed).

This should reduce allocation rate.

Thanks to a hint from https://discuss.ocaml.org/t/decoding-many-unicode-strings-with-uutf/8910/2

