### PR TITLE
CA-361988 execute cluster host_resync always locally

### DIFF
--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -121,6 +121,18 @@ let join_internal ~__context ~self =
 (* Enable cluster_host in client layer via clusterd *)
 let resync_host ~__context ~host =
   match find_cluster_host ~__context ~host with
+  | _ when host <> Helpers.get_localhost ~__context ->
+      raise
+        Api_errors.(
+          Server_error
+            ( internal_error
+            , [
+                "resync_host called with remote host"
+              ; Ref.string_of host
+              ; __LOC__
+              ]
+            )
+        )
   | None ->
       () (* no clusters exist *)
   | Some self ->


### PR DESCRIPTION
Host_resync() must be executed on each host locally. For this, iterate
on the master (in message_forwarding) and call via RPC pool_resync,
which then calls host_resync().

This commit splits the code from pool_resync() between
message_forwarding) and pool_resync().

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>