### PR TITLE
fix (http-svr): allow : in passwords when using basic auth

### DIFF
--- a/ocaml/libs/http-svr/http.ml
+++ b/ocaml/libs/http-svr/http.ml
@@ -214,8 +214,8 @@ let authorization_of_string x =
     let end_of_string s from = String.sub s from (String.length s - from) in
     match Base64.decode (end_of_string x (String.length basic)) with
     | Result.Ok userpass -> (
-      match Astring.String.cuts ~sep:":" userpass with
-      | [username; password] ->
+      match Astring.String.cut ~sep:":" userpass with
+      | Some (username, password) ->
           Basic (username, password)
       | _ ->
           UnknownAuth x

--- a/ocaml/libs/http-svr/http.ml
+++ b/ocaml/libs/http-svr/http.ml
@@ -211,8 +211,7 @@ type authorization = Basic of string * string | UnknownAuth of string
 let authorization_of_string x =
   let basic = "Basic " in
   if Astring.String.is_prefix ~affix:basic x then
-    let end_of_string s from = String.sub s from (String.length s - from) in
-    match Base64.decode (end_of_string x (String.length basic)) with
+    match Base64.decode ~off:(String.length basic) x with
     | Result.Ok userpass -> (
       match Astring.String.cut ~sep:":" userpass with
       | Some (username, password) ->


### PR DESCRIPTION
Fixes #4593

Previously:
```
# let x = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==";;
val x : string = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="

# Http.authorization_of_string x;;
- : Http.authorization = Http.Basic ("Aladdin", "open sesame")

# let to_basic x = "Basic " ^ Base64.encode_exn x;;
val to_basic : string -> string = <fun>

# Http.authorization_of_string (to_basic "Aladdin:");;
- : Http.authorization = Http.Basic ("Aladdin", "")

# Http.authorization_of_string (to_basic ":password");;
- : Http.authorization = Http.Basic ("", "password"

# Http.authorization_of_string (to_basic "Aladdin:the: password");;
- : Http.authorization = Http.UnknownAuth "Basic QWxhZGRpbjp0aGU6IHBhc3N3b3Jk"

utop # Http.authorization_of_string (to_basic ":password:");;
- : Http.authorization = Http.UnknownAuth "Basic OnBhc3N3b3JkOg=="
```

now:
```
# let x = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==";;
val x : string = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="

# Http.authorization_of_string x;;
- : Http.authorization = Http.Basic ("Aladdin", "open sesame")

 # let to_basic x = "Basic " ^ Base64.encode_exn x;;
val to_basic : string -> string = <fun>

# Http.authorization_of_string (to_basic "Aladdin:");;
- : Http.authorization = Http.Basic ("Aladdin", "")

# Http.authorization_of_string (to_basic ":password:");;
- : Http.authorization = Http.Basic ("", "password:")

# Http.authorization_of_string (to_basic "Aladdin:the: password");;
- : Http.authorization = Http.Basic ("Aladdin", "the: password")

# Http.authorization_of_string (to_basic ":password:");;
- : Http.authorization = Http.Basic ("", "password:")
```

This bug present in Havana as well