### PR TITLE
CP-38850 add xapi.conf option for cert-expiration-days

### DIFF
--- a/ocaml/gencert/gencert.ml
+++ b/ocaml/gencert/gencert.ml
@@ -42,6 +42,7 @@ let generate_cert_or_fail ~generator ~path =
   )
 
 let main ~dbg ~path ~sni () =
+  let valid_for_days = 365 * 10 in
   let init_inventory () = Inventory.inventory_filename := inventory in
   init_inventory () ;
   let generator path =
@@ -58,13 +59,13 @@ let main ~dbg ~path ~sni () =
         let dns_names = Networking_info.dns_names () in
         let ips = [ip] in
         let (_ : X509.Certificate.t) =
-          Gencertlib.Selfcert.host ~name ~dns_names ~ips path
+          Gencertlib.Selfcert.host ~name ~dns_names ~ips ~valid_for_days path
         in
         ()
     | SNI.Xapi_pool ->
         let uuid = Inventory.lookup Inventory._installation_uuid in
         let (_ : X509.Certificate.t) =
-          Gencertlib.Selfcert.xapi_pool ~uuid path
+          Gencertlib.Selfcert.xapi_pool ~valid_for_days ~uuid path
         in
         ()
   in

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -143,10 +143,10 @@ let selfsign issuer extensions key_length expiration certfile =
   let* () = write_certs certfile pkcs12 in
   Ok cert
 
-let host ~name ~dns_names ~ips ?valid_from pemfile =
+let host ~name ~dns_names ~ips ?valid_from ~valid_for_days pemfile =
   let valid_from = valid_from' valid_from in
   let res =
-    let* expiration = expire_in_days ~valid_from (365 * 10) in
+    let* expiration = expire_in_days ~valid_from valid_for_days in
     let key_length = 2048 in
     let issuer =
       [
@@ -162,10 +162,10 @@ let host ~name ~dns_names ~ips ?valid_from pemfile =
 
 let serial_stamp () = Unix.gettimeofday () |> string_of_float
 
-let xapi_pool ?valid_from ~uuid pemfile =
+let xapi_pool ?valid_from ~valid_for_days ~uuid pemfile =
   let valid_from = valid_from' valid_from in
   let res =
-    let* expiration = expire_in_days ~valid_from (365 * 10) in
+    let* expiration = expire_in_days ~valid_from valid_for_days in
     let key_length = 2048 in
     let issuer =
       [

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -25,6 +25,7 @@ val host :
   -> dns_names:string list
   -> ips:Cstruct.t list
   -> ?valid_from:Ptime.t (* default: now *)
+  -> valid_for_days:int
   -> string
   -> X509.Certificate.t
 (** [host name dns_names ip path] creates (atomically) a PEM file at
@@ -32,6 +33,7 @@ val host :
 
 val xapi_pool :
      ?valid_from:Ptime.t (* default: now *)
+  -> valid_for_days:int
   -> uuid:string
   -> string
   -> X509.Certificate.t

--- a/ocaml/xapi/cert_refresh.ml
+++ b/ocaml/xapi/cert_refresh.ml
@@ -68,8 +68,9 @@ let host ~__context ~type' =
   let host = Helpers.get_localhost ~__context in
   let pem = cert_path type' in
   let path = new_cert_path type' in
+  let valid_for_days = !Xapi_globs.cert_expiration_days in
   let uuid = Inventory.lookup Inventory._installation_uuid in
-  let cert = Gencertlib.Selfcert.xapi_pool ~uuid path in
+  let cert = Gencertlib.Selfcert.xapi_pool ~uuid ~valid_for_days path in
   let bak = backup_cert_path type' in
   let unreachable = unreachable_hosts ~__context in
   if not @@ HostSet.is_empty unreachable then

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -559,6 +559,8 @@ let default_wlb_timeout = 30.0
 
 let default_wlb_reports_timeout = 600.0
 
+let cert_expiration_days = ref (365 * 10)
+
 (** {2 Settings relating to dynamic memory control} *)
 
 (** A pool-wide configuration key that specifies for HVM guests a lower bound
@@ -1310,6 +1312,12 @@ let other_options =
     , (fun () -> string_of_int !failed_login_alert_freq)
     , "Frequency at which we alert any failed logins (in seconds; \
        default=3600s)"
+    )
+  ; ( "cert-expiration-days"
+    , Arg.Set_int cert_expiration_days
+    , (fun () -> string_of_int !cert_expiration_days)
+    , "Number of days a refreshed certificate will be valid; it defaults to 10 \
+       years."
     )
   ]
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1514,7 +1514,8 @@ let _new_host_cert ~dbg ~path : X509.Certificate.t =
   let dns_names = Networking_info.dns_names () in
   let cn = match dns_names with [] -> ip_as_string | dns :: _ -> dns in
   let ips = [ip] in
-  Gencertlib.Selfcert.host ~name:cn ~dns_names ~ips path
+  let valid_for_days = !Xapi_globs.cert_expiration_days in
+  Gencertlib.Selfcert.host ~name:cn ~dns_names ~ips ~valid_for_days path
 
 let reset_server_certificate ~__context ~host =
   let dbg = Context.string_of_task __context in


### PR DESCRIPTION
When xapi generates/refreshes a host or pool certificate, the number of
days it will remain valid will be taken from xapi.conf.

Note that initially certficates are generated using a binary 'gencert'
which does not read this value from xapi.conf and will use the current
default of 10 years.

Also note that, for now, certificates used by clusterd have an unlimited
lifetime but this could be changed to also use the value specified in
xapi.conf.

To generate new certificates with a lifetime as in xapi.conf:

* edit xapi.conf
* restart xapi to make it read xapi.conf: service xapi restart
* xe host-reset-server-certificate
* xe host-refresh-server-certificate host=<hostname>

To verify SSL certficate lifetimes:

* openssl s_client -showcerts -connect localhost:443  2> /dev/null < /dev/null
    | openssl x509 -noout -dates

* openssl s_client -showcerts -connect localhost:443
    -servername pool 2> /dev/null < /dev/null | openssl x509 -noout -dates

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>