### PR TITLE
nbd: include the test binary into xapi-nbd package

### DIFF
--- a/ocaml/nbd/lib_test/dune
+++ b/ocaml/nbd/lib_test/dune
@@ -1,5 +1,6 @@
 (test
  (name suite)
+ (package xapi-nbd)
  (libraries
   alcotest
   alcotest-lwt


### PR DESCRIPTION
otherwise it fails to compile as part of the wsproxy package tests

found in https://github.com/psafont/xs-opam/runs/4776218783?check_suite_focus=true#step:10:814