### PR TITLE
Use TMPDIR when testing if possible in tests to get round the opam sandbox

### DIFF
--- a/forkexec.opam
+++ b/forkexec.opam
@@ -10,7 +10,7 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "base-threads"
   "fd-send-recv"
   "ppx_deriving_rpc"

--- a/gzip.opam
+++ b/gzip.opam
@@ -9,10 +9,10 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "xapi-compression"
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""

--- a/http-svr.opam
+++ b/http-svr.opam
@@ -11,7 +11,7 @@ build: [
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "astring"
   "base64" {>= "3.1.0"}
   "rpclib"
@@ -24,7 +24,7 @@ depends: [
   "xml-light2"
   "ounit" {with-test & >= "2.0.0"}
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""

--- a/ocaml/message-switch/core_test/basic-rpc-test.sh
+++ b/ocaml/message-switch/core_test/basic-rpc-test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-SPATH=/tmp/sock
-SWITCHPATH=/tmp/switch
+SPATH=${TMPDIR:-/tmp}/sock
+SWITCHPATH=${TMPDIR:-/tmp}/switch
 
 
 rm -rf ${SWITCHPATH} && mkdir -p ${SWITCHPATH}

--- a/ocaml/message-switch/core_test/interop-test.sh
+++ b/ocaml/message-switch/core_test/interop-test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -ex
 
-LINKPATH=/tmp/link_test
+LINKPATH="${TMPDIR:-/tmp}/link_test"
 
 rm -rf ${LINKPATH} && mkdir -p ${LINKPATH}
 

--- a/ocaml/message-switch/core_test/lwt/link_test_main.ml
+++ b/ocaml/message-switch/core_test/lwt/link_test_main.ml
@@ -17,7 +17,7 @@
 open Lwt
 open Message_switch_core.Protocol
 
-let basedir = ref "/tmp/link_test"
+let basedir = ref Filename.(concat (get_temp_dir_name ()) "link_test")
 
 let rpc_req = {Message.payload= "hello"; kind= Message.Request "reply to"}
 

--- a/ocaml/message-switch/core_test/message_switch_test.py
+++ b/ocaml/message-switch/core_test/message_switch_test.py
@@ -14,14 +14,19 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+import unittest, os
 from message_switch import *
 
-basedir = "/tmp/link_test"
+try:
+    tmpdir = os.environ["TMPDIR"]
+except KeyError:
+    tmpdir = "/tmp"
+
+basedir = os.path.join(tmpdir, "link_test")
 
 rpc_req = Message("hello", 1L, "reply_to")
 rpc_res = Message("hello", 1L)
 
-import unittest, os
 class Internal_invariants(unittest.TestCase):
     def test_Message_save_load(self):
         for m in [rpc_req, rpc_res]:

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -15,10 +15,7 @@
 open API
 
 (* A directory to use for temporary files. *)
-let working_area = "/tmp/xapi-test"
-
-(** Utility functions *)
-let id (x : 'a) : 'a = x
+let working_area = Filename.(concat (get_temp_dir_name ()) "xapi-test")
 
 let make_uuid () = Uuid.string_of_uuid (Uuid.make_uuid ())
 

--- a/ocaml/tests/test_xapi_db_upgrade.ml
+++ b/ocaml/tests/test_xapi_db_upgrade.ml
@@ -58,7 +58,9 @@ let upgrade_vm_memory_for_dmc () =
     (r.API.vM_memory_static_min <= r.API.vM_memory_static_max)
 
 let upgrade_bios () =
-  let tmp_filename = "/tmp/previousInventory" in
+  let tmp_filename =
+    Filename.(concat (get_temp_dir_name ()) "previousInventory")
+  in
   let check inventory bios_strings =
     Xapi_stdext_unix.Unixext.write_string_to_file tmp_filename inventory ;
     let __context = T.make_test_database () in

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -303,7 +303,9 @@ let upgrade_bios_strings =
         let oem_manufacturer =
           let test_path =
             Option.map
-              (fun _ -> "/tmp/previousInventory")
+              (fun _ ->
+                Filename.(concat (get_temp_dir_name ()) "previousInventory")
+                )
               (Sys.getenv_opt "XAPI_TEST")
           in
           let inventory_path =

--- a/pciutil.opam
+++ b/pciutil.opam
@@ -9,10 +9,10 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "xapi-stdext-unix"
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""

--- a/rrd2csv.opam
+++ b/rrd2csv.opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 name: "rrd2csv"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [ "Guillem Rieu" ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "base-threads"
   "xapi-client"
   "xapi-idl"

--- a/rrdd-plugins.opam
+++ b/rrdd-plugins.opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 name: "rrdd-plugins"
 maintainer: "xs-devel@lists.xenserver.org"
 authors: [ "xs-devel@lists.xenserver.org" ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git://github.com/xapi-project/xen-api"
@@ -10,7 +10,7 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 synopsis: "Plugins registering to the RRD daemon and exposing various metrics"
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "base-threads"
   "base-unix"
   "cstruct-unix"
@@ -24,3 +24,6 @@ depends: [
   "xenstore"
   "mtime"
 ]
+url {
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}

--- a/rrddump.opam
+++ b/rrddump.opam
@@ -9,3 +9,6 @@ bug-reports: "https://github.com/xapi-project/xen-api/issues"
 depends: ["xapi-rrd" "xmlm"]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+url {
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}

--- a/safe-resources.opam
+++ b/safe-resources.opam
@@ -11,7 +11,7 @@ build: [
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "fmt"
   "logs"
   "xapi-backtrace"

--- a/sexpr.opam
+++ b/sexpr.opam
@@ -9,11 +9,11 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "astring"
   "xapi-stdext-threads"
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""

--- a/stunnel.opam
+++ b/stunnel.opam
@@ -9,7 +9,7 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "astring"
   "forkexec"
   "safe-resources"
@@ -20,7 +20,7 @@ depends: [
   "xapi-stdext-threads"
   "xapi-stdext-unix"
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""

--- a/uuid.opam
+++ b/uuid.opam
@@ -9,9 +9,9 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""

--- a/vhd-tool.opam
+++ b/vhd-tool.opam
@@ -35,5 +35,5 @@ depends: [
 ]
 synopsis: ".vhd file manipulation"
 url {
-  src: "https://github.com/xapi-project/vhd-tool/archive/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/wsproxy.opam
+++ b/wsproxy.opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 name: "wsproxy"
 maintainer: "xen-api@lists.xen.org"
-authors: [ "xen-api@lists.xen.org" ]
-license: "LGPL-2.0 with OCaml linking exception"
+authors: [ "Jon Ludlam" "Marcello Seri" ]
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "base64" {>= "3.1.0"}
   "fmt"
   "logs"
@@ -25,5 +25,5 @@ depends: [
 tags: [ "org:xapi-project" ]
 synopsis: "Websockets proxy for VNC traffic"
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-cli-protocol.opam
+++ b/xapi-cli-protocol.opam
@@ -23,5 +23,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-client.opam
+++ b/xapi-client.opam
@@ -29,5 +29,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-compression.opam
+++ b/xapi-compression.opam
@@ -9,13 +9,13 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "forkexec"
   "safe-resources"
   "xapi-stdext-pervasives"
   "xapi-stdext-unix"
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""

--- a/xapi-consts.opam
+++ b/xapi-consts.opam
@@ -19,5 +19,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -34,5 +34,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-datamodel.opam
+++ b/xapi-datamodel.opam
@@ -28,5 +28,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-forkexecd.opam
+++ b/xapi-forkexecd.opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "astring"
   "forkexec"
   "systemd" {>= "1.2"}

--- a/xapi-idl.opam
+++ b/xapi-idl.opam
@@ -9,7 +9,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "alcotest" {with-test}
   "fmt" {with-test}
   "astring"

--- a/xapi-nbd.opam
+++ b/xapi-nbd.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: ["dave.scott@citrix.com"]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git+https://github.com/xapi-project/xapi-nbd.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
@@ -27,5 +27,5 @@ tags: [ "org:mirage" "org:xapi-project" ]
 synopsis: "Expose XenServer disks conveniently over NBD"
 url {
   src:
-    "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-networkd.opam
+++ b/xapi-networkd.opam
@@ -30,5 +30,5 @@ depends: [
 synopsis: "The XCP networking daemon"
 url {
   src:
-    "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build}
+  "dune"
   "dune-build-info"
   "astring"
   "gzip"

--- a/xapi-squeezed.opam
+++ b/xapi-squeezed.opam
@@ -1,16 +1,16 @@
 opam-version: "2.0"
 author: "dave.scott@eu.citrix.com"
 maintainer: "xen-api@lists.xen.org"
-homepage: "https://github.com/xapi-project/squeezed"
-bug-reports: "https://github.com/xapi-project/squeezed/issues"
-dev-repo: "git://github.com/xapi-project/squeezed.git"
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "git://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "uuidm"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
@@ -30,5 +30,5 @@ The squeezed daemon shares host memory among running VMs using the
 balloon drivers to move memory."""
 url {
   src:
-    "https://github.com/xapi-project/squeezed/archive/master/master.tar.gz"
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-storage-cli.opam
+++ b/xapi-storage-cli.opam
@@ -2,14 +2,14 @@ opam-version: "2.0"
 name: "xapi-storage-cli"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "base-threads"
   "re"
   "rpclib"
@@ -22,5 +22,5 @@ description: """
 The CLI allows you to directly manipulate virtual disk images, without
 them being attached to VMs."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-storage-script.opam
+++ b/xapi-storage-script.opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 name: "xapi-storage-script"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git://github.com/xapi-project/xen-api"
@@ -10,7 +10,8 @@ tags: [ "org:xapi-project" ]
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
+  "conf-python-2-7" {with-test}
   "xapi-idl" {>= "0.10.0"}
   "xapi-storage"
   "async" {>= "v0.9.0"}
@@ -25,11 +26,15 @@ depends: [
   "ppx_sexp_conv"
   "xapi-stdext-date"
 ]
+# python 2.7 is not enough to ensure the availability of 'python' in these
+depexts: [
+  ["python"] {os-family = "debian" & with-test}
+]
 synopsis: "A directory full of scripts can be a Xapi storage implementation"
 description: """
 This daemon watches a directory for subdirectories, and when a subdir
 is created a storage service is registered."""
 url {
   src:
-    "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-storage.opam
+++ b/xapi-storage.opam
@@ -10,7 +10,8 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
+  "conf-python-2-7"
   "ounit" {with-test}
   "alcotest" {with-test}
   "lwt" {with-test}
@@ -20,9 +21,11 @@ depends: [
   "xmlm"
   "cmdliner"
 ]
+# python 2.7 is not enough to ensure the availability of 'python' in these
 depexts: [
-  ["python"] {os-distribution = "centos"}
-  ["python"] {os-distribution = "debian"}
-  ["python"] {os-distribution = "ubuntu"}
+  ["python"] {os-family = "debian"}
 ]
 synopsis: "Code and documentation generator for the Xapi storage interface"
+url {
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}

--- a/xapi-types.opam
+++ b/xapi-types.opam
@@ -35,5 +35,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-xenopsd-cli.opam
+++ b/xapi-xenopsd-cli.opam
@@ -1,16 +1,16 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
-homepage: "https://github.com/xapi-project/xenopsd"
-bug-reports: "https://github.com/xapi-project/xenopsd/issues"
-dev-repo: "git+https://github.com/xapi-project/xenopsd.git"
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "base-threads"
   "cmdliner"
   "re"
@@ -25,5 +25,5 @@ description: """
 A simple command-line tool for interacting with xenopsd
 """
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-xenopsd-simulator.opam
+++ b/xapi-xenopsd-simulator.opam
@@ -2,21 +2,21 @@ opam-version: "2.0"
 name: "xapi-xenopsd-simulator"
 maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
-homepage: "https://github.com/xapi-project/xenopsd"
-dev-repo: "git+https://github.com/xapi-project/xenopsd.git"
-bug-reports: "https://github.com/xapi-project/xenopsd/issues"
+homepage: "https://github.com/xapi-project/xen-api"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
 build: [
   ["./configure"]
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "base-unix"
   "xapi-xenopsd"
 ]
 synopsis:
   "Simulation backend allowing testing of the higher-level xenops logic"
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-xenopsd-xc.opam
+++ b/xapi-xenopsd-xc.opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 name: "xapi-xenopsd-xc"
 maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
-homepage: "https://github.com/xapi-project/xenopsd"
-dev-repo: "git+https://github.com/xapi-project/xenopsd.git"
-bug-reports: "https://github.com/xapi-project/xenopsd/issues"
+homepage: "https://github.com/xapi-project/xen-api"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
 build: [
   ["./configure"]
   [ "dune" "build" "-p" name "-j" jobs ]
@@ -12,11 +12,12 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "ounit2" {with-test}
   "astring"
   "base-threads"
   "base-unix"
+  "conf-xen"
   "ezxenstore"
   "fd-send-recv"
   "fmt"
@@ -50,5 +51,5 @@ synopsis:
   "A xenops plugin which knows how to use xenstore, xenctrl and xenguest to manage"
 description: "VMs on a xen host."
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-xenopsd.opam
+++ b/xapi-xenopsd.opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 name: "xapi-xenopsd"
 maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
-homepage: "https://github.com/xapi-project/xenopsd"
-dev-repo: "git+https://github.com/xapi-project/xenopsd.git"
-bug-reports: "https://github.com/xapi-project/xenopsd/issues"
+homepage: "https://github.com/xapi-project/xen-api"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
 build: [
   ["./configure"]
   ["dune" "build" "-p" name "-j" jobs]
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "base-threads"
   "alcotest" {with-test}
   "astring"
@@ -48,5 +48,5 @@ via a simple API. The API has been tailored to suit the needs of xapi,
 which manages clusters of hosts running Xen, but it can also be used
 standalone."""
 url {
-  src: "https://github.com/xapi-project/xenopsd/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi.opam
+++ b/xapi.opam
@@ -77,5 +77,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xe.opam
+++ b/xe.opam
@@ -27,5 +27,5 @@ description: """
 This daemon exposes the XenAPI and is used by clients such as 'xe'
 and 'XenCenter' to manage clusters of Xen-enabled hosts."""
 url {
-  src: "https://github.com/xapi-project/xen-api/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xen-api-client-async.opam
+++ b/xen-api-client-async.opam
@@ -1,10 +1,13 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
-authors: [ "xen-api@lists.xen.org" ]
-license: "LGPL"
+authors: [ "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg" ]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
+tags: [
+  "org:xapi-project"
+]
 build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
@@ -12,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build & >= "1.4"}
+  "dune"
   "async" {>= "v0.9.0"}
   "async_unix"
   "base-threads"
@@ -26,3 +29,6 @@ depends: [
 ]
 synopsis:
   "Xen-API client library for remotely-controlling a xapi host"
+url {
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}

--- a/xen-api-client-lwt.opam
+++ b/xen-api-client-lwt.opam
@@ -1,10 +1,13 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
-authors: [ "xen-api@lists.xen.org" ]
-license: "LGPL"
+authors: [ "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg" ]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
+tags: [
+  "org:xapi-project"
+]
 build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
@@ -12,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build & >= "1.4"}
+  "dune" {>= "1.4"}
   "cohttp" {>= "0.22.0"}
   "cohttp-lwt-unix"
   "cstruct" {>= "1.0.1"}
@@ -27,3 +30,6 @@ depends: [
 ]
 synopsis:
   "Xen-API client library for remotely-controlling a xapi host"
+url {
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}

--- a/xen-api-client.opam
+++ b/xen-api-client.opam
@@ -1,10 +1,13 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
-authors: [ "xen-api@lists.xen.org" ]
-license: "LGPL"
+authors: [ "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg" ]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
+tags: [
+  "org:xapi-project"
+]
 build-env: [[ XAPI_VERSION = "v0.0.0" ]]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
@@ -12,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {build & >= "1.4"}
+  "dune" {"1.4"}
   "astring"
   "cohttp" {>= "0.22.0"}
   "re"
@@ -27,3 +30,6 @@ depends: [
 ]
 synopsis:
   "Xen-API client library for remotely-controlling a xapi host"
+url {
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}

--- a/xen-api-sdk.opam
+++ b/xen-api-sdk.opam
@@ -4,16 +4,16 @@ synopsis: "Xen API SDK generation code."
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 license: "BSD 2-Clause"
-homepage: "https://github.com/xapi-project/xen-api-sdk"
-bug-reports: "https://github.com/xapi-project/xen-api-sdk/issues"
-dev-repo: "git+https://github.com/xapi-project/xen-api-sdk.git"
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 url {
-  src: "https://github.com/xapi-project/xen-api-sdk/archive/master.tar.gz"
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }
 tags: [ "org:xapi-project" ]
 build: [[ "dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "dune" {build}
+  "dune"
   "xapi-datamodel"
   "mustache"
   "astring"

--- a/xml-light2.opam
+++ b/xml-light2.opam
@@ -9,10 +9,10 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "xmlm"
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""

--- a/zstd.opam
+++ b/zstd.opam
@@ -9,10 +9,10 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune"
   "xapi-compression"
 ]
-synopsis: "Further transitional libraries required by xapi"
+synopsis: "Library required by xapi"
 description: """
 These libraries are provided for backwards compatibility only.
 No new code should use these libraries."""


### PR DESCRIPTION
for xapi_db_upgrade this means having to select one of three directories

This changes are needed for opam's 2.1.0 sanbox, which doesn't allow writing to /tmp