### PR TITLE
Use make check to show all warnings while hiding them from make

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,12 @@ jobs:
       - name: Run tests
         run: opam exec -- make test
 
+      - name: Check all code in release mode
+        # This should be removed when the following pass succeeds
+        run: opam exec -- make check-release
+
       - name: Check all code
+        continue-on-error: true
         run: opam exec -- make check
 
       - name: Run stress tests

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ build:
 
 # Quickly verify that the code compiles, without actually building it
 check:
+	XAPI_VERSION=$(XAPI_VERSION) dune build @check -j $(JOBS)
+
+check-release:
 	XAPI_VERSION=$(XAPI_VERSION) dune build @check -j $(JOBS) --profile=$(PROFILE)
 
 clean:

--- a/dune
+++ b/dune
@@ -4,7 +4,7 @@
     (flags (:standard -w -39))
   )
   (dev (flags (:standard -g -w -39)))
-  (release (flags (:standard -w -39)))
+  (release (flags (:standard -w -39-6)))
 )
 
 (executable

--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -21,8 +21,8 @@ let days_until_expiry epoch expiry =
   | false ->
       Float.(to_int (ceil days))
 
-let get_certificate_attributes rpc session =
-  XenAPI.Certificate.get_all_records rpc session
+let get_certificate_attributes rpc session_id =
+  XenAPI.Certificate.get_all_records ~rpc ~session_id
   |> List.map @@ fun (cert_ref, certificate) ->
      match certificate.API.certificate_type with
      | `host ->
@@ -105,7 +105,7 @@ let generate_alert epoch cert =
       , Some (body expiring, Api_messages.host_internal_certificate_expiring_30)
       )
 
-let execute rpc session existing_messages (cert, alert) =
+let execute rpc session_id existing_messages (cert, alert) =
   (* CA-342551: messages need to be deleted if the pending alert regard the
      same host and has newer, updated information.
      If the pending alert has the same metadata as the existing host message
@@ -114,50 +114,53 @@ let execute rpc session existing_messages (cert, alert) =
      In the case there are alerts regarding the host but no alert is pending
      they are not destroyed since no alert is automatically dismissed. *)
   match alert with
-  | Some (message, (alert, priority)) -> (
+  | Some (body, (alert, priority)) -> (
     try
-      let cls, uuid =
+      let cls, obj_uuid =
         match cert with
         | Host (host, _) | Internal (host, _) ->
-            (`Host, XenAPI.Host.get_uuid rpc session host)
+            (`Host, XenAPI.Host.get_uuid ~rpc ~session_id ~self:host)
         | CA (cert, _) ->
-            (`Certificate, XenAPI.Certificate.get_uuid rpc session cert)
+            ( `Certificate
+            , XenAPI.Certificate.get_uuid ~rpc ~session_id ~self:cert
+            )
       in
       let messages_in_host =
         List.filter
-          (fun (_, record) -> record.API.message_obj_uuid = uuid)
+          (fun (_, record) -> record.API.message_obj_uuid = obj_uuid)
           existing_messages
       in
-      let is_outdated (ref, record) =
-        record.API.message_body <> message
+      let is_outdated (_ref, record) =
+        record.API.message_body <> body
         || record.API.message_name <> alert
         || record.API.message_priority <> priority
       in
       let outdated, current = List.partition is_outdated messages_in_host in
 
       List.iter
-        (fun (self, _) -> XenAPI.Message.destroy rpc session self)
+        (fun (self, _) -> XenAPI.Message.destroy ~rpc ~session_id ~self)
         outdated ;
       if current = [] then
         let (_ : [> `message] API.Ref.t) =
-          XenAPI.Message.create rpc session alert priority cls uuid message
+          XenAPI.Message.create ~rpc ~session_id ~name:alert ~priority ~cls
+            ~obj_uuid ~body
         in
         ()
-    with Api_errors.(Server_error (handle_invalid, _)) ->
+    with Api_errors.(Server_error (_handle_invalid, _)) ->
       (* this happens when the host reference is invalid *)
       ()
   )
   | None ->
       ()
 
-let alert rpc session =
+let alert rpc session_id =
   let now = Unix.time () in
   (* Message starting with
      [\{host_server_certificate,pool_ca_certificate\}_\{expiring,expired\}]
      may need to be refreshed, gather them just once *)
   let previous_messages =
-    XenAPI.Message.get_all_records rpc session
-    |> List.filter (fun (ref, record) ->
+    XenAPI.Message.get_all_records ~rpc ~session_id
+    |> List.filter (fun (_ref, record) ->
            let expiring_or_expired name =
              let matching affix = Astring.String.is_prefix ~affix name in
              matching Api_messages.host_server_certificate_expiring
@@ -171,6 +174,6 @@ let alert rpc session =
        )
   in
   let send_alert_maybe attributes =
-    attributes |> generate_alert now |> execute rpc session previous_messages
+    attributes |> generate_alert now |> execute rpc session_id previous_messages
   in
-  get_certificate_attributes rpc session |> List.iter send_alert_maybe
+  get_certificate_attributes rpc session_id |> List.iter send_alert_maybe

--- a/ocaml/alerts/certificate/certificate_check_main.ml
+++ b/ocaml/alerts/certificate/certificate_check_main.ml
@@ -8,10 +8,10 @@ let rpc xml =
     xml
 
 let _ =
-  let session =
+  let session_id =
     XenAPI.Session.login_with_password ~rpc ~uname:"" ~pwd:"" ~version:"1.0"
       ~originator:"certificate-check"
   in
   Xapi_stdext_pervasives.Pervasiveext.finally
-    (fun () -> Certificate_check.alert rpc session)
-    (fun () -> XenAPI.Session.logout rpc session)
+    (fun () -> Certificate_check.alert rpc session_id)
+    (fun () -> XenAPI.Session.logout ~rpc ~session_id)

--- a/ocaml/doc/jsapi.ml
+++ b/ocaml/doc/jsapi.ml
@@ -59,7 +59,7 @@ let generate_files api_dir =
         List.filter
           (fun (_transition, release, _doc) ->
             release = code_name_of_release rel
-            )
+          )
           obj.obj_lifecycle
       in
       let obj_changes : changes_t =

--- a/ocaml/doc/jsapi.ml
+++ b/ocaml/doc/jsapi.ml
@@ -15,7 +15,6 @@
 open Xapi_stdext_std.Xstringext
 open Xapi_stdext_pervasives.Pervasiveext
 module Unixext = Xapi_stdext_unix.Unixext
-open Datamodel
 open Datamodel_types
 
 type change_t = lifecycle_change * string * string
@@ -58,12 +57,14 @@ let generate_files api_dir =
     let search_obj obj =
       let changes =
         List.filter
-          (fun (transition, release, doc) -> release = code_name_of_release rel)
+          (fun (_transition, release, _doc) ->
+            release = code_name_of_release rel
+            )
           obj.obj_lifecycle
       in
       let obj_changes : changes_t =
         List.map
-          (fun (transition, release, doc) ->
+          (fun (transition, _release, doc) ->
             ( transition
             , obj.name
             , if doc = "" && transition = Published then
@@ -77,13 +78,13 @@ let generate_files api_dir =
       let changes_for_msg m =
         let changes =
           List.filter
-            (fun (transition, release, doc) ->
+            (fun (_transition, release, _doc) ->
               release = code_name_of_release rel
             )
             m.msg_lifecycle
         in
         List.map
-          (fun (transition, release, doc) ->
+          (fun (transition, _release, doc) ->
             ( transition
             , m.msg_name
             , if doc = "" && transition = Published then m.msg_doc else doc
@@ -98,14 +99,14 @@ let generate_files api_dir =
       let changes_for_field f =
         let changes =
           List.filter
-            (fun (transition, release, doc) ->
+            (fun (_transition, release, _doc) ->
               release = code_name_of_release rel
             )
             f.lifecycle
         in
         let field_name = String.concat "_" f.full_name in
         List.map
-          (fun (transition, release, doc) ->
+          (fun (transition, _release, doc) ->
             ( transition
             , field_name
             , if doc = "" && transition = Published then
@@ -121,7 +122,7 @@ let generate_files api_dir =
           (fun l -> function
             | Field f ->
                 f :: l
-            | Namespace (name, contents) ->
+            | Namespace (_name, contents) ->
                 flatten_contents contents @ l
           )
           [] contents

--- a/ocaml/events/event_listen.ml
+++ b/ocaml/events/event_listen.ml
@@ -30,7 +30,6 @@ let rpc xml =
     ~http xml
 
 open Client
-open Printf
 open Event_types
 
 let _ =

--- a/ocaml/gencert/pem.ml
+++ b/ocaml/gencert/pem.ml
@@ -28,11 +28,7 @@ let is_whitespace = function
   | _ ->
       false
 
-let is_newline = function '\n' -> true | '\r' -> true | _ -> false
-
 let is_data = function '-' -> false | _ -> true
-
-let newline = take_while1 is_newline
 
 let ws = take_while is_whitespace
 

--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -168,9 +168,7 @@ let pool_resync =
       "Resynchronise the cluster_host objects across the pool. Creates them \
        where they need creating and then plugs them"
     ~params:[(Ref _cluster, "self", "The cluster to resync")]
-    ~lifecycle ~allowed_roles:_R_POOL_OP
-    ~errs:Api_errors.[]
-    ()
+    ~lifecycle ~allowed_roles:_R_POOL_OP ~errs:[] ()
 
 let t =
   create_obj ~name:_cluster ~descr:"Cluster-wide Cluster metadata"

--- a/ocaml/idl/datamodel_main.ml
+++ b/ocaml/idl/datamodel_main.ml
@@ -75,7 +75,7 @@ let _ =
   (* Add all implicit messages to the API directly *)
   let api = DU.add_implicit_messages ~document_order:!markdown_mode api in
   (* Only show those visible to the client *)
-  let api = filter (fun _ -> true) (fun field -> true) DU.on_client_side api in
+  let api = filter (fun _ -> true) (Fun.const true) DU.on_client_side api in
   (* And only messages marked as not hidden from the docs, and non-internal fields *)
   let api =
     filter

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -402,6 +402,8 @@ type ty =
   | Option of ty
 [@@deriving rpc]
 
+[@@@ocaml.warning "-33"]
+
 type api_value =
   | VString of string
   | VInt of int64

--- a/ocaml/idl/dot_backend.ml
+++ b/ocaml/idl/dot_backend.ml
@@ -13,7 +13,6 @@
  *)
 open Printf
 open Datamodel_types
-open Datamodel
 open Datamodel_utils
 open Dm_api
 
@@ -46,7 +45,7 @@ let of_objs api =
          (fun (obj : obj) ->
            (* First consider the edges defined as relational *)
            let relational =
-             List.filter (fun ((a, _), (b, _)) -> a = obj.name) relations
+             List.filter (fun ((a, _), _) -> a = obj.name) relations
            in
            let edges =
              List.map

--- a/ocaml/idl/dtd_backend.ml
+++ b/ocaml/idl/dtd_backend.ml
@@ -13,8 +13,6 @@
  *)
 
 open Printf
-open Datamodel
-open Datamodel_utils
 open Datamodel_types
 open Dm_api
 
@@ -141,14 +139,14 @@ let rec dtd_element_of_contents known_els parent_name accu = function
         (List.fold_left (dtd_element_of_contents known_els name) [] xs)
         []
       :: accu
-  | Field {field_name= name; ty} -> (
+  | Field {field_name= name; ty; _} -> (
     match ty with
     | Set (Int | Ref _) | Int | Float | DateTime | Bool ->
         add_attribute known_els parent_name name [] None ;
         accu
     | Set _ ->
         element known_els name [] [] :: accu
-    | Ref n ->
+    | Ref _ ->
         add_attribute known_els parent_name name [] (Some "") ;
         accu
     | Enum (_, vals) ->

--- a/ocaml/idl/json_backend/gen_json.ml
+++ b/ocaml/idl/json_backend/gen_json.ml
@@ -452,7 +452,7 @@ let releases objs =
         List.filter
           (fun (_transition, release, _doc) ->
             release = code_name_of_release rel
-            )
+          )
           obj.obj_lifecycle
       in
       let obj_changes =

--- a/ocaml/idl/json_backend/gen_json.ml
+++ b/ocaml/idl/json_backend/gen_json.ml
@@ -185,7 +185,7 @@ let fields_of_obj_with_enums obj =
       (fun l -> function
         | Field f ->
             f :: l
-        | Namespace (name, contents) ->
+        | Namespace (_name, contents) ->
             flatten_contents contents @ l
       )
       [] contents
@@ -290,7 +290,7 @@ let messages_of_obj_with_enums obj =
         if msg.msg_tag = FromObject Make then
           let ctor_fields =
             List.filter
-              (function {qualifier= StaticRO | RW} -> true | _ -> false)
+              (function {qualifier= StaticRO | RW; _} -> true | _ -> false)
               (fields_of_obj obj)
             |> List.map (fun f ->
                    String.concat "_" f.full_name
@@ -450,12 +450,14 @@ let releases objs =
     let search_obj obj =
       let changes =
         List.filter
-          (fun (transition, release, doc) -> release = code_name_of_release rel)
+          (fun (_transition, release, _doc) ->
+            release = code_name_of_release rel
+            )
           obj.obj_lifecycle
       in
       let obj_changes =
         List.map
-          (fun (transition, release, doc) ->
+          (fun (transition, _release, doc) ->
             ( transition
             , obj.name
             , ( if doc = "" && transition = Published then
@@ -471,13 +473,13 @@ let releases objs =
       let changes_for_msg m =
         let changes =
           List.filter
-            (fun (transition, release, doc) ->
+            (fun (_transition, release, _doc) ->
               release = code_name_of_release rel
             )
             m.msg_lifecycle
         in
         List.map
-          (fun (transition, release, doc) ->
+          (fun (transition, _release, doc) ->
             ( transition
             , obj.name ^ "." ^ m.msg_name
             , (if doc = "" && transition = Published then m.msg_doc else doc)
@@ -494,14 +496,14 @@ let releases objs =
       let changes_for_field f =
         let changes =
           List.filter
-            (fun (transition, release, doc) ->
+            (fun (_transition, release, _doc) ->
               release = code_name_of_release rel
             )
             f.lifecycle
         in
         let field_name = String.concat "_" f.full_name in
         List.map
-          (fun (transition, release, doc) ->
+          (fun (transition, _release, doc) ->
             ( transition
             , obj.name ^ "." ^ field_name
             , ( if doc = "" && transition = Published then
@@ -519,7 +521,7 @@ let releases objs =
           (fun l -> function
             | Field f ->
                 f :: l
-            | Namespace (name, contents) ->
+            | Namespace (_name, contents) ->
                 flatten_contents contents @ l
           )
           [] contents
@@ -584,9 +586,9 @@ let _ =
     (Filename.concat data_dir "release_info.json")
     (string_of_json 0 release_info) ;
   let release_yaml = function
-    | {release_date= None} ->
+    | {release_date= None; _} ->
         ""
-    | {code_name= Some x; version_major; version_minor; branding= y} ->
+    | {code_name= Some x; branding= y; _} ->
         Printf.sprintf "%s: %s\n" x y
     | _ ->
         ""
@@ -599,15 +601,9 @@ let _ =
   let class_md_dir = Filename.concat destdir "xen-api/classes" in
   Xapi_stdext_unix.Unixext.mkdir_rec class_md_dir 0o755 ;
   let release_md = function
-    | {release_date= None} ->
+    | {release_date= None; _} ->
         ()
-    | {
-        code_name= Some x
-      ; version_major
-      ; version_minor
-      ; branding
-      ; release_date= y
-      } ->
+    | {code_name= Some x; release_date= y; _} ->
         [
           "---"
         ; "layout: xenapi-release"

--- a/ocaml/idl/markdown_backend.ml
+++ b/ocaml/idl/markdown_backend.ml
@@ -13,7 +13,6 @@
  *)
 open Printf
 open Datamodel_types
-open Datamodel
 open Datamodel_utils
 open Dm_api
 open Xapi_stdext_pervasives.Pervasiveext
@@ -98,7 +97,7 @@ let rec of_ty_verbatim = function
       "bool"
   | DateTime ->
       "datetime"
-  | Enum (name, things) ->
+  | Enum (name, _) ->
       name
   | Set x ->
       sprintf "%s set" (of_ty_verbatim x)
@@ -122,7 +121,7 @@ let rec of_ty = function
       "bool"
   | DateTime ->
       "datetime"
-  | Enum (name, things) ->
+  | Enum (name, _) ->
       escape name
   | Set x ->
       of_ty x ^ " set"
@@ -263,7 +262,7 @@ let print_field_table_of_obj printer ~is_class_deprecated ~is_class_removed x =
     printer
       "|:-------------------|:-------------------|:--------------|:---------------------------------------|" ;
     let print_field_content printer
-        ({release; qualifier; ty; field_description= description} as y) =
+        ({qualifier; ty; field_description= description; _} as y) =
       let wired_name = Datamodel_utils.wire_name_of_field y in
       let descr =
         ( if List.exists is_removal_marker y.lifecycle || is_class_removed then

--- a/ocaml/license/daily_license_check_main.ml
+++ b/ocaml/license/daily_license_check_main.ml
@@ -8,7 +8,7 @@ let rpc xml =
     xml
 
 let _ =
-  let session =
+  let session_id =
     XenAPI.Session.login_with_password ~rpc ~uname:"" ~pwd:"" ~version:"1.0"
       ~originator:"daily-license-check"
   in
@@ -16,12 +16,12 @@ let _ =
     (fun () ->
       let now = Unix.time () in
       let pool, pool_license_state, all_license_params =
-        Daily_license_check.get_info_from_db rpc session
+        Daily_license_check.get_info_from_db rpc session_id
       in
       let result =
         Daily_license_check.check_license now pool_license_state
           all_license_params
       in
-      Daily_license_check.execute rpc session pool result
+      Daily_license_check.execute rpc session_id pool result
     )
-    (fun () -> XenAPI.Session.logout rpc session)
+    (fun () -> XenAPI.Session.logout ~rpc ~session_id)

--- a/ocaml/perftest/createpool.ml
+++ b/ocaml/perftest/createpool.ml
@@ -35,12 +35,14 @@ let get_network_num_from_interface pool i =
     LVHD won't work so we can't use LVM over iSCSI or FC. It's probably easiest
     to include a whitelist here rather than find an EQL array to test this. *)
 let sr_is_suitable session_id sr =
-  let t = String.lowercase_ascii (Client.SR.get_type rpc session_id sr) in
+  let t =
+    String.lowercase_ascii (Client.SR.get_type ~rpc ~session_id ~self:sr)
+  in
   t = "ext" || t = "nfs"
 
 let default_sr_must_be_suitable session_id =
-  let realpool = List.hd (Client.Pool.get_all rpc session_id) in
-  let defaultsr = Client.Pool.get_default_SR rpc session_id realpool in
+  let realpool = List.hd (Client.Pool.get_all ~rpc ~session_id) in
+  let defaultsr = Client.Pool.get_default_SR ~rpc ~session_id ~self:realpool in
   if not (sr_is_suitable session_id defaultsr) then
     failwith
       "Pool's default SR is unsuitable for the local storage on the template"
@@ -72,8 +74,8 @@ let initialise session_id template pool =
   (* Create a disk for local storage *)
   debug "Creating a disk for local storage on the template" ;
   default_sr_must_be_suitable session_id ;
-  let realpool = List.hd (Client.Pool.get_all rpc session_id) in
-  let defaultsr = Client.Pool.get_default_SR rpc session_id realpool in
+  let realpool = List.hd (Client.Pool.get_all ~rpc ~session_id) in
+  let defaultsr = Client.Pool.get_default_SR ~rpc ~session_id ~self:realpool in
   let newdisk =
     Client.VDI.create ~rpc ~session_id ~name_label:"SDK storage"
       ~name_description:"" ~sR:defaultsr ~virtual_size:sr_disk_size ~_type:`user
@@ -94,7 +96,7 @@ let initialise session_id template pool =
   Client.VM.add_to_xenstore_data ~rpc ~session_id ~self:template
     ~key:"vm-data/provision/interfaces/0/admin" ~value:"true" ;
   Array.iteri
-    (fun i net ->
+    (fun i _ ->
       Client.VM.add_to_xenstore_data ~rpc ~session_id ~self:template
         ~key:(Printf.sprintf "vm-data/provision/interfaces/%d/mode" i)
         ~value:"static" ;
@@ -104,90 +106,112 @@ let initialise session_id template pool =
     )
     interfaces ;
   debug "Setting memory to 128 Megs" ;
-  Client.VM.set_memory_static_min rpc session_id template
-    (Int64.mul 128L 1048576L) ;
-  Client.VM.set_memory_dynamic_min rpc session_id template
-    (Int64.mul 128L 1048576L) ;
-  Client.VM.set_memory_dynamic_max rpc session_id template
-    (Int64.mul 128L 1048576L) ;
-  Client.VM.set_memory_static_max rpc session_id template
-    (Int64.mul 128L 1048576L) ;
-  Client.VM.remove_from_other_config rpc session_id template oc_key ;
-  Client.VM.add_to_other_config rpc session_id template oc_key pool.key ;
+  Client.VM.set_memory_static_min ~rpc ~session_id ~self:template
+    ~value:(Int64.mul 128L 1048576L) ;
+  Client.VM.set_memory_dynamic_min ~rpc ~session_id ~self:template
+    ~value:(Int64.mul 128L 1048576L) ;
+  Client.VM.set_memory_dynamic_max ~rpc ~session_id ~self:template
+    ~value:(Int64.mul 128L 1048576L) ;
+  Client.VM.set_memory_static_max ~rpc ~session_id ~self:template
+    ~value:(Int64.mul 128L 1048576L) ;
+  Client.VM.remove_from_other_config ~rpc ~session_id ~self:template ~key:oc_key ;
+  Client.VM.add_to_other_config ~rpc ~session_id ~self:template ~key:oc_key
+    ~value:pool.key ;
   interfaces
 
 let reset_template session_id template =
   (* Destroy template's VIFs *)
   debug "Resetting template to factory settings" ;
-  let vifs = Client.VM.get_VIFs rpc session_id template in
+  let vifs = Client.VM.get_VIFs ~rpc ~session_id ~self:template in
   List.iter
     (fun vif ->
       try
-        if List.mem_assoc oc_key (Client.VIF.get_other_config rpc session_id vif)
+        if
+          List.mem_assoc oc_key
+            (Client.VIF.get_other_config ~rpc ~session_id ~self:vif)
         then
-          Client.VIF.destroy rpc session_id vif
+          Client.VIF.destroy ~rpc ~session_id ~self:vif
       with _ -> ()
     )
     vifs ;
   (* Destroy template's sr disk *)
-  let vbds = Client.VM.get_VBDs rpc session_id template in
+  let vbds = Client.VM.get_VBDs ~rpc ~session_id ~self:template in
   List.iter
     (fun vbd ->
-      if List.mem_assoc oc_key (Client.VBD.get_other_config rpc session_id vbd)
+      if
+        List.mem_assoc oc_key
+          (Client.VBD.get_other_config ~rpc ~session_id ~self:vbd)
       then (
-        let vdi = Client.VBD.get_VDI rpc session_id vbd in
+        let vdi = Client.VBD.get_VDI ~rpc ~session_id ~self:vbd in
         assert (
-          List.mem_assoc oc_key (Client.VDI.get_other_config rpc session_id vdi)
+          List.mem_assoc oc_key
+            (Client.VDI.get_other_config ~rpc ~session_id ~self:vdi)
         ) ;
-        Client.VDI.destroy rpc session_id vdi ;
-        try Client.VBD.destroy rpc session_id vbd with _ -> ()
+        Client.VDI.destroy ~rpc ~session_id ~self:vdi ;
+        try Client.VBD.destroy ~rpc ~session_id ~self:vbd with _ -> ()
       )
     )
     vbds ;
   (* Remove xenstore keys *)
-  Client.VM.set_xenstore_data rpc session_id template [] ;
-  Client.VM.set_PV_args rpc session_id template "" ;
-  try Client.VM.remove_from_other_config rpc session_id template oc_key
+  Client.VM.set_xenstore_data ~rpc ~session_id ~self:template ~value:[] ;
+  Client.VM.set_PV_args ~rpc ~session_id ~self:template ~value:"" ;
+  try
+    Client.VM.remove_from_other_config ~rpc ~session_id ~self:template
+      ~key:oc_key
   with _ -> ()
 
-let uninitialise session_id template key =
+let uninitialise session_id _template key =
   (* Shut down and uninstall any VMs *)
   debug "Shutting down and uninstalling any VMs" ;
-  let vms = Client.VM.get_all rpc session_id in
+  let vms = Client.VM.get_all ~rpc ~session_id in
   List.iter
     (fun vm ->
-      let is_a_template = Client.VM.get_is_a_template rpc session_id vm in
+      let is_a_template =
+        Client.VM.get_is_a_template ~rpc ~session_id ~self:vm
+      in
       let is_control_domain =
-        Client.VM.get_is_control_domain rpc session_id vm
+        Client.VM.get_is_control_domain ~rpc ~session_id ~self:vm
       in
       let is_managed =
         try
-          List.assoc oc_key (Client.VM.get_other_config rpc session_id vm) = key
+          List.assoc oc_key
+            (Client.VM.get_other_config ~rpc ~session_id ~self:vm)
+          = key
         with _ -> false
       in
-      let running = Client.VM.get_power_state rpc session_id vm = `Running in
+      let running =
+        Client.VM.get_power_state ~rpc ~session_id ~self:vm = `Running
+      in
       if (not is_a_template) && (not is_control_domain) && is_managed then (
-        if running then Client.VM.hard_shutdown rpc session_id vm ;
-        let vbds = Client.VM.get_VBDs rpc session_id vm in
+        if running then Client.VM.hard_shutdown ~rpc ~session_id ~vm ;
+        let vbds = Client.VM.get_VBDs ~rpc ~session_id ~self:vm in
         let vdis =
-          List.map (fun vbd -> Client.VBD.get_VDI rpc session_id vbd) vbds
+          List.map
+            (fun vbd -> Client.VBD.get_VDI ~rpc ~session_id ~self:vbd)
+            vbds
         in
         List.iter
-          (fun vdi -> try Client.VDI.destroy rpc session_id vdi with _ -> ())
+          (fun vdi ->
+            try Client.VDI.destroy ~rpc ~session_id ~self:vdi with _ -> ()
+          )
           vdis ;
         List.iter
-          (fun vbd -> try Client.VBD.destroy rpc session_id vbd with _ -> ())
+          (fun vbd ->
+            try Client.VBD.destroy ~rpc ~session_id ~self:vbd with _ -> ()
+          )
           vbds ;
         List.iter
-          (fun vif -> try Client.VIF.destroy rpc session_id vif with _ -> ())
-          (Client.VM.get_VIFs rpc session_id vm) ;
-        Client.VM.destroy rpc session_id vm
+          (fun vif ->
+            try Client.VIF.destroy ~rpc ~session_id ~self:vif with _ -> ()
+          )
+          (Client.VM.get_VIFs ~rpc ~session_id ~self:vm) ;
+        Client.VM.destroy ~rpc ~session_id ~self:vm
       )
     )
     vms ;
   (* Destroy networks *)
   debug "Destroying networks" ;
-  let nets = Client.Network.get_all_records rpc session_id in
+  let nets = Client.Network.get_all_records ~rpc ~session_id in
   let mynets =
     List.filter
       (fun (_, r) ->
@@ -196,8 +220,10 @@ let uninitialise session_id template key =
       )
       nets
   in
-  List.iter (fun (net, _) -> Client.Network.destroy rpc session_id net) mynets ;
-  let nets = Client.Network.get_all_records rpc session_id in
+  List.iter
+    (fun (net, _) -> Client.Network.destroy ~rpc ~session_id ~self:net)
+    mynets ;
+  let nets = Client.Network.get_all_records ~rpc ~session_id in
   debug "Destroying any bridges" ;
   let ic =
     Unix.open_process_in "ifconfig -a | grep \"^xapi\" | awk '{print $1}'"
@@ -223,7 +249,9 @@ let uninitialise session_id template key =
     netdevs
 
 let destroy_sdk_pool session_id sdkname key =
-  let template = List.hd (Client.VM.get_by_name_label rpc session_id sdkname) in
+  let template =
+    List.hd (Client.VM.get_by_name_label ~rpc ~session_id ~label:sdkname)
+  in
   uninitialise session_id template key
 
 let describe_pool template_name pool_name key =
@@ -245,12 +273,12 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
   let pool = List.find (fun p -> p.id = pool_name) pools in
   let pool = {pool with key; ipbase} in
   let template =
-    try List.hd (Client.VM.get_by_name_label rpc session_id sdkname)
+    try List.hd (Client.VM.get_by_name_label ~rpc ~session_id ~label:sdkname)
     with _ ->
       debug ~out:stderr "template '%s' not found" sdkname ;
       exit 1
   in
-  let uuid = Client.VM.get_uuid rpc session_id template in
+  let uuid = Client.VM.get_uuid ~rpc ~session_id ~self:template in
   debug "Creating test pool '%s' using SDK template uuid=%s" pool.id uuid ;
   (* Clear up any leftover state on the template *)
   reset_template session_id template ;
@@ -258,23 +286,23 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
   Printf.printf "Creating iSCSI target VM serving %d LUNs\n%!" pool.iscsi_luns ;
   let (_ : API.ref_VM option) =
     CreateVM.make_iscsi session_id pool
-      (Client.VIF.get_network rpc session_id interfaces.(2))
+      (Client.VIF.get_network ~rpc ~session_id ~self:interfaces.(2))
   in
   debug "Creating %d SDK VMs" pool.hosts ;
   let hosts =
     Array.init pool.hosts (fun i ->
         let n = i + 1 in
         let vm =
-          Client.VM.clone rpc session_id template
-            (Printf.sprintf "perftestpool%d" n)
+          Client.VM.clone ~rpc ~session_id ~vm:template
+            ~new_name:(Printf.sprintf "perftestpool%d" n)
         in
-        Client.VM.provision rpc session_id vm ;
+        Client.VM.provision ~rpc ~session_id ~vm ;
         Array.iteri
           (fun i _ ->
             ignore
-              (Client.VM.add_to_xenstore_data rpc session_id vm
-                 (Printf.sprintf "vm-data/provision/interfaces/%d/ip" i)
-                 (Printf.sprintf "192.168.%d.%d" (i + pool.ipbase) n)
+              (Client.VM.add_to_xenstore_data ~rpc ~session_id ~self:vm
+                 ~key:(Printf.sprintf "vm-data/provision/interfaces/%d/ip" i)
+                 ~value:(Printf.sprintf "192.168.%d.%d" (i + pool.ipbase) n)
               )
           )
           interfaces ;
@@ -282,31 +310,33 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
     )
   in
   debug "Setting memory on master to be 256 Megs" ;
-  Client.VM.set_memory_static_max rpc session_id hosts.(0)
-    (Int64.mul 256L 1048576L) ;
-  Client.VM.set_memory_static_min rpc session_id hosts.(0)
-    (Int64.mul 256L 1048576L) ;
-  Client.VM.set_memory_dynamic_max rpc session_id hosts.(0)
-    (Int64.mul 256L 1048576L) ;
-  Client.VM.set_memory_dynamic_min rpc session_id hosts.(0)
-    (Int64.mul 256L 1048576L) ;
-  Client.VM.add_to_other_config rpc session_id hosts.(0) master_of_pool pool.key ;
-  Client.VM.add_to_other_config rpc session_id hosts.(0) management_ip
-    (Printf.sprintf "192.168.%d.1" pool.ipbase) ;
+  Client.VM.set_memory_static_max ~rpc ~session_id ~self:hosts.(0)
+    ~value:(Int64.mul 256L 1048576L) ;
+  Client.VM.set_memory_static_min ~rpc ~session_id ~self:hosts.(0)
+    ~value:(Int64.mul 256L 1048576L) ;
+  Client.VM.set_memory_dynamic_max ~rpc ~session_id ~self:hosts.(0)
+    ~value:(Int64.mul 256L 1048576L) ;
+  Client.VM.set_memory_dynamic_min ~rpc ~session_id ~self:hosts.(0)
+    ~value:(Int64.mul 256L 1048576L) ;
+  Client.VM.add_to_other_config ~rpc ~session_id ~self:hosts.(0)
+    ~key:master_of_pool ~value:pool.key ;
+  Client.VM.add_to_other_config ~rpc ~session_id ~self:hosts.(0)
+    ~key:management_ip
+    ~value:(Printf.sprintf "192.168.%d.1" pool.ipbase) ;
   let localhost_uuid = Inventory.lookup "INSTALLATION_UUID" in
   Array.iteri
     (fun i host ->
       debug "Starting VM %d" i ;
-      Client.VM.start_on rpc session_id host
-        (Client.Host.get_by_uuid rpc session_id localhost_uuid)
-        false false
+      Client.VM.start_on ~rpc ~session_id ~vm:host
+        ~host:(Client.Host.get_by_uuid ~rpc ~session_id ~uuid:localhost_uuid)
+        ~start_paused:false ~force:false
     )
     hosts ;
   ignore
     (Sys.command
        (Printf.sprintf "ifconfig %s 192.168.%d.200 up"
-          (Client.Network.get_bridge rpc session_id
-             (Client.VIF.get_network rpc session_id interfaces.(0))
+          (Client.Network.get_bridge ~rpc ~session_id
+             ~self:(Client.VIF.get_network ~rpc ~session_id ~self:interfaces.(0))
           )
           pool.ipbase
        )
@@ -335,7 +365,7 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
          )
       )
   in
-  let has_guest_booted i vm =
+  let has_guest_booted i _vm =
     let ip = Printf.sprintf "192.168.%d.%d" pool.ipbase (i + 1) in
     let is_pingable () =
       if pingable.(i) then
@@ -357,15 +387,17 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
       else
         let rpc = remoterpc ip in
         try
-          let s =
-            Client.Session.login_with_password rpc "root" "xensource" "1.1"
-              "perftest"
+          let session_id =
+            Client.Session.login_with_password ~rpc ~uname:"root"
+              ~pwd:"xensource" ~version:"1.1" ~originator:"perftest"
           in
           Xapi_stdext_pervasives.Pervasiveext.finally
             (fun () ->
-              let host = List.hd (Client.Host.get_all rpc s) in
+              let host = List.hd (Client.Host.get_all ~rpc ~session_id) in
               (* only one host because it hasn't joined the pool yet *)
-              let other_config = Client.Host.get_other_config rpc s host in
+              let other_config =
+                Client.Host.get_other_config ~rpc ~session_id ~self:host
+              in
               let key = "firstboot-complete" in
               (* Since these are 'fresh' hosts which have never booted, the key goes from missing -> present *)
               if List.mem_assoc key other_config then (
@@ -375,7 +407,7 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
               ) else
                 false
             )
-            (fun () -> Client.Session.logout rpc s)
+            (fun () -> Client.Session.logout ~rpc ~session_id)
         with _ -> false
     in
     is_pingable () && firstbooted ()
@@ -396,22 +428,23 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
   debug "Guests have booted; issuing Pool.joins." ;
   let host_uuids =
     Array.mapi
-      (fun i vm ->
+      (fun i _ ->
         let n = i + 1 in
         let rpc = remoterpc (Printf.sprintf "192.168.%d.%d" pool.ipbase n) in
-        let s =
-          Client.Session.login_with_password rpc "root" "xensource" "1.1"
-            "perftest"
+        let session_id =
+          Client.Session.login_with_password ~rpc ~uname:"root" ~pwd:"xensource"
+            ~version:"1.1" ~originator:"perftest"
         in
-        let h = List.hd (Client.Host.get_all rpc s) in
-        let u = Client.Host.get_uuid rpc s h in
+        let h = List.hd (Client.Host.get_all ~rpc ~session_id) in
+        let u = Client.Host.get_uuid ~rpc ~session_id ~self:h in
         debug "Setting name of host %d" n ;
-        Client.Host.set_name_label rpc s h (Printf.sprintf "perftest host %d" i) ;
+        Client.Host.set_name_label ~rpc ~session_id ~self:h
+          ~value:(Printf.sprintf "perftest host %d" i) ;
         if i <> 0 then (
           debug "Joining to pool" ;
-          Client.Pool.join rpc s
-            (Printf.sprintf "192.168.%d.1" pool.ipbase)
-            "root" "xensource"
+          Client.Pool.join ~rpc ~session_id
+            ~master_address:(Printf.sprintf "192.168.%d.1" pool.ipbase)
+            ~master_username:"root" ~master_password:"xensource"
         ) ;
         u
       )
@@ -419,13 +452,16 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
   in
   let poolrpc = remoterpc (Printf.sprintf "192.168.%d.1" pool.ipbase) in
   let poolses =
-    Client.Session.login_with_password poolrpc "root" "xensource" "1.1"
-      "perftest"
+    Client.Session.login_with_password ~rpc:poolrpc ~uname:"root"
+      ~pwd:"xensource" ~version:"1.1" ~originator:"perftest"
   in
-  let vpool = List.hd (Client.Pool.get_all poolrpc poolses) in
-  Client.Pool.add_to_other_config poolrpc poolses vpool "scenario" pool_name ;
+  let vpool = List.hd (Client.Pool.get_all ~rpc:poolrpc ~session_id:poolses) in
+  Client.Pool.add_to_other_config ~rpc:poolrpc ~session_id:poolses ~self:vpool
+    ~key:"scenario" ~value:pool_name ;
   debug "Waiting for all hosts to become live and enabled" ;
-  let hosts = Array.of_list (Client.Host.get_all poolrpc poolses) in
+  let hosts =
+    Array.of_list (Client.Host.get_all ~rpc:poolrpc ~session_id:poolses)
+  in
   let live = Array.make (Array.length hosts) false in
   let enabled = Array.make (Array.length hosts) false in
   let string_of_status () =
@@ -453,9 +489,11 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
       if live.(i) && enabled.(i) then
         true
       else
-        let metrics = Client.Host.get_metrics rpc session_id host in
-        let live' = Client.Host_metrics.get_live rpc session_id metrics in
-        let enabled' = Client.Host.get_enabled rpc session_id host in
+        let metrics = Client.Host.get_metrics ~rpc ~session_id ~self:host in
+        let live' =
+          Client.Host_metrics.get_live ~rpc ~session_id ~self:metrics
+        in
+        let enabled' = Client.Host.get_enabled ~rpc ~session_id ~self:host in
         if live.(i) <> live' || enabled.(i) <> enabled' then
           debug "Individual host status: %s" (string_of_status ()) ;
         live.(i) <- live' ;
@@ -471,15 +509,17 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
         (Array.to_list (Array.mapi (has_host_booted poolrpc poolses) hosts))
   done ;
   debug "All hosts are ready." ;
-  let mypool = List.hd (Client.Pool.get_all poolrpc poolses) in
-  let master = Client.Pool.get_master poolrpc poolses mypool in
+  let mypool = List.hd (Client.Pool.get_all ~rpc:poolrpc ~session_id:poolses) in
+  let master =
+    Client.Pool.get_master ~rpc:poolrpc ~session_id:poolses ~self:mypool
+  in
   let iscsi_vm_ip = CreateVM.make_iscsi_ip pool in
   let xml =
     try
       Client.SR.probe ~rpc:poolrpc ~session_id:poolses ~host:master
         ~device_config:[("target", iscsi_vm_ip)] ~sm_config:[]
         ~_type:"lvmoiscsi"
-    with Api_errors.Server_error ("SR_BACKEND_FAILURE_96", [a; b; xml]) -> xml
+    with Api_errors.Server_error ("SR_BACKEND_FAILURE_96", [xml; _]) -> xml
   in
   let iqns = parse_sr_probe_for_iqn xml in
   if iqns = [] then
@@ -490,8 +530,7 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
       Client.SR.probe ~rpc:poolrpc ~session_id:poolses ~host:master
         ~device_config:[("target", iscsi_vm_ip); ("targetIQN", iqn)]
         ~sm_config:[] ~_type:"lvmoiscsi"
-    with Api_errors.Server_error ("SR_BACKEND_FAILURE_107", [a; b; xml]) ->
-      xml
+    with Api_errors.Server_error ("SR_BACKEND_FAILURE_107", [xml; _]) -> xml
   in
   (* Create an SR for each LUN found *)
   Printf.printf "Creating LVMoISCSI SRs (one for each of %d LUNs)\n%!"
@@ -507,49 +546,73 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
     Array.init pool.iscsi_luns (fun i ->
         Printf.printf " - Creating shared LVMoISCSI SR %d...\n%!" i ;
         let name_label = Printf.sprintf "LVMoISCSI-%d" i in
-        Client.SR.create poolrpc poolses master
-          [("target", iscsi_vm_ip); ("targetIQN", iqn); ("SCSIid", scsiids.(i))]
-          0L name_label "" "lvmoiscsi" "" true []
+        Client.SR.create ~rpc:poolrpc ~session_id:poolses ~host:master
+          ~device_config:
+            [
+              ("target", iscsi_vm_ip)
+            ; ("targetIQN", iqn)
+            ; ("SCSIid", scsiids.(i))
+            ]
+          ~physical_size:0L ~name_label ~name_description:"" ~_type:"lvmoiscsi"
+          ~content_type:"" ~shared:true ~sm_config:[]
     )
   in
   let local_srs =
     Array.mapi
       (fun i host_uuid ->
-        let h = Client.Host.get_by_uuid poolrpc poolses host_uuid in
+        let h =
+          Client.Host.get_by_uuid ~rpc:poolrpc ~session_id:poolses
+            ~uuid:host_uuid
+        in
         let name_label = Printf.sprintf "Local LVM on host %d" i in
-        Client.SR.create poolrpc poolses h
-          [("device", "/dev/" ^ sr_disk_device)]
-          0L name_label "" "lvm" "" false []
+        Client.SR.create ~rpc:poolrpc ~session_id:poolses ~host:h
+          ~device_config:[("device", "/dev/" ^ sr_disk_device)]
+          ~physical_size:0L ~name_label ~name_description:"" ~_type:"lvm"
+          ~content_type:"" ~shared:false ~sm_config:[]
       )
       host_uuids
   in
-  let pifs = Client.PIF.get_all poolrpc poolses in
+  let pifs = Client.PIF.get_all ~rpc:poolrpc ~session_id:poolses in
   let bondednets =
     Array.init pool.bonds (fun i ->
-        Client.Network.create poolrpc poolses
-          (Printf.sprintf "Network associated with bond%d" i)
-          "" 1500L [] "" true []
+        Client.Network.create ~rpc:poolrpc ~session_id:poolses
+          ~name_label:(Printf.sprintf "Network associated with bond%d" i)
+          ~name_description:"" ~mTU:1500L ~other_config:[] ~bridge:""
+          ~managed:true ~tags:[]
     )
   in
   let unused_nets =
     ref
       (Listext.List.setify
-         (List.map (fun pif -> Client.PIF.get_network poolrpc poolses pif) pifs)
+         (List.map
+            (fun pif ->
+              Client.PIF.get_network ~rpc:poolrpc ~session_id:poolses ~self:pif
+            )
+            pifs
+         )
       )
   in
   (* Reconfigure the master's networking last as this will be the most destructive *)
-  let master_uuid = Client.Host.get_uuid poolrpc poolses master in
+  let master_uuid =
+    Client.Host.get_uuid ~rpc:poolrpc ~session_id:poolses ~self:master
+  in
   let slave_uuids =
     List.filter (fun x -> x <> master_uuid) (Array.to_list host_uuids)
   in
   let host_uuids = Array.of_list (slave_uuids @ [master_uuid]) in
   let (_ : API.ref_Bond array array) =
-    Array.mapi
-      (fun i host_uuid ->
-        let host_ref = Client.Host.get_by_uuid poolrpc poolses host_uuid in
+    Array.map
+      (fun host_uuid ->
+        let host_ref =
+          Client.Host.get_by_uuid ~rpc:poolrpc ~session_id:poolses
+            ~uuid:host_uuid
+        in
         let pifs =
           List.filter
-            (fun pif -> Client.PIF.get_host poolrpc poolses pif = host_ref)
+            (fun pif ->
+              Client.PIF.get_host ~rpc:poolrpc ~session_id:poolses ~self:pif
+              = host_ref
+            )
             pifs
         in
         Array.init pool.bonds (fun bnum ->
@@ -557,35 +620,57 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
             let device2 = Printf.sprintf "eth%d" ((bnum * 2) + 1) in
             let master =
               List.find
-                (fun pif -> Client.PIF.get_device poolrpc poolses pif = device)
+                (fun pif ->
+                  Client.PIF.get_device ~rpc:poolrpc ~session_id:poolses
+                    ~self:pif
+                  = device
+                )
                 pifs
             in
             let pifs =
               List.filter
                 (fun pif ->
-                  let d = Client.PIF.get_device poolrpc poolses pif in
+                  let d =
+                    Client.PIF.get_device ~rpc:poolrpc ~session_id:poolses
+                      ~self:pif
+                  in
                   d = device || d = device2
                 )
                 pifs
             in
             let nets =
               List.map
-                (fun pif -> Client.PIF.get_network poolrpc poolses pif)
+                (fun pif ->
+                  Client.PIF.get_network ~rpc:poolrpc ~session_id:poolses
+                    ~self:pif
+                )
                 pifs
             in
             unused_nets :=
               List.filter (fun net -> not (List.mem net nets)) !unused_nets ;
-            let mac = Client.PIF.get_MAC poolrpc poolses master in
-            let bond =
-              Client.Bond.create poolrpc poolses bondednets.(bnum) pifs mac
-                `balanceslb []
+            let mac =
+              Client.PIF.get_MAC ~rpc:poolrpc ~session_id:poolses ~self:master
             in
-            let bondpif = Client.Bond.get_master poolrpc poolses bond in
-            Client.PIF.reconfigure_ip poolrpc poolses bondpif `Static
-              (Client.PIF.get_IP poolrpc poolses master)
-              "255.255.255.0" "" "" ;
-            if Client.PIF.get_management poolrpc poolses master then (
-              ( try Client.Host.management_reconfigure poolrpc poolses bondpif
+            let bond =
+              Client.Bond.create ~rpc:poolrpc ~session_id:poolses
+                ~network:bondednets.(bnum) ~members:pifs ~mAC:mac
+                ~mode:`balanceslb ~properties:[]
+            in
+            let bondpif =
+              Client.Bond.get_master ~rpc:poolrpc ~session_id:poolses ~self:bond
+            in
+            Client.PIF.reconfigure_ip ~rpc:poolrpc ~session_id:poolses
+              ~self:bondpif ~mode:`Static
+              ~iP:
+                (Client.PIF.get_IP ~rpc:poolrpc ~session_id:poolses ~self:master)
+              ~netmask:"255.255.255.0" ~gateway:"" ~dNS:"" ;
+            if
+              Client.PIF.get_management ~rpc:poolrpc ~session_id:poolses
+                ~self:master
+            then (
+              ( try
+                  Client.Host.management_reconfigure ~rpc:poolrpc
+                    ~session_id:poolses ~pif:bondpif
                 with _ -> ()
               ) ;
               debug "Reconfigured management interface to be on the bond." ;
@@ -605,7 +690,10 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
   debug "Nets for VMs: %s"
     (String.concat ","
        (List.map
-          (fun net -> Client.Network.get_name_label poolrpc poolses net)
+          (fun net ->
+            Client.Network.get_name_label ~rpc:poolrpc ~session_id:poolses
+              ~self:net
+          )
           nets_for_vms
        )
     ) ;
@@ -620,7 +708,7 @@ let create_sdk_pool session_id sdkname pool_name key ipbase =
     )
     pool.vms
 
-let create_pool session_id sdkname pool_name key ipbase =
+let create_pool session_id _ pool_name key _ =
   iscsi_vm_iso_must_exist session_id ;
   default_sr_must_be_suitable session_id ;
   let pool = Scenario.get pool_name in

--- a/ocaml/perftest/cumulative_time.ml
+++ b/ocaml/perftest/cumulative_time.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Perfdebug
 open Graphutil
 
 let _ =
@@ -83,7 +82,7 @@ let _ =
       let ls =
         List.flatten
           (List.mapi
-             (fun i ((info, floats), output) ->
+             (fun i ((info, _floats), output) ->
                let graph_one_label =
                  Printf.sprintf "Cumulative time, SR %d (left axis)" (i + 1)
                in

--- a/ocaml/perftest/histogram.ml
+++ b/ocaml/perftest/histogram.ml
@@ -173,7 +173,7 @@ let _ =
         all ;
       let ls =
         List.map
-          (fun ((info, floats), output) ->
+          (fun ((info, _floats), output) ->
             {
               Gnuplot.filename= output
             ; title= short_info_to_title info

--- a/ocaml/perftest/perfutil.ml
+++ b/ocaml/perftest/perfutil.ml
@@ -50,13 +50,14 @@ let rewrite_provisioning_xml rpc session_id new_vm sr_uuid =
     | x ->
         x
   in
-  let other_config = Client.VM.get_other_config rpc session_id new_vm in
+  let other_config = Client.VM.get_other_config ~rpc ~session_id ~self:new_vm in
   if List.mem_assoc "disks" other_config then (
     let xml = Xml.parse_string (List.assoc "disks" other_config) in
-    Client.VM.remove_from_other_config rpc session_id new_vm "disks" ;
+    Client.VM.remove_from_other_config ~rpc ~session_id ~self:new_vm
+      ~key:"disks" ;
     let newdisks = rewrite_xml xml sr_uuid in
-    Client.VM.add_to_other_config rpc session_id new_vm "disks"
-      (Xml.to_string newdisks)
+    Client.VM.add_to_other_config ~rpc ~session_id ~self:new_vm ~key:"disks"
+      ~value:(Xml.to_string newdisks)
   )
 
 let parse_sr_probe_for_iqn (xml : string) : string list =

--- a/ocaml/perftest/statistics.ml
+++ b/ocaml/perftest/statistics.ml
@@ -109,7 +109,7 @@ module Hist = struct
       fold x
         (fun bin_start bin_end height acc ->
           match acc with
-          | Some x ->
+          | Some _ ->
               acc (* got it already *)
           | None ->
               if height > y then

--- a/ocaml/wsproxy/test/test_helpers.ml
+++ b/ocaml/wsproxy/test/test_helpers.ml
@@ -15,7 +15,7 @@
 open OUnit
 open Wslib
 
-let gen_nums n generator = QCheck.Gen.generate n generator
+let gen_nums n generator = QCheck.Gen.generate ~n generator
 
 let test_split () =
   let a, b = Helpers.split "helper" 2 in

--- a/ocaml/wsproxy/test/test_iteratees.ml
+++ b/ocaml/wsproxy/test/test_iteratees.ml
@@ -16,7 +16,6 @@ open OUnit
 open Wslib
 module I = Iteratees.Iteratee (Test.StringMonad)
 module TestWsIteratee = Websockets.Wsprotocol (Test.StringMonad)
-open TestWsIteratee
 open I
 
 let get_data = function IE_done x -> Some x | IE_cont _ -> None

--- a/ocaml/xapi-aux/helper_process.ml
+++ b/ocaml/xapi-aux/helper_process.ml
@@ -13,7 +13,7 @@
  *)
 (* Hopefully, this handler will be able to look at the return codes of the cmds, and produce *)
 (* a reasonable error. For now, just return the error code! *)
-let generic_handler cmd n =
+let generic_handler _ n =
   raise (Api_errors.Server_error (Api_errors.internal_error, [string_of_int n]))
 
 exception Process_output_error of string
@@ -23,7 +23,7 @@ let get_process_output ?(handler = generic_handler) cmd =
   try
     fst (Forkhelpers.execute_command_get_output (List.hd args) (List.tl args))
   with
-  | Forkhelpers.Spawn_internal_error (err, out, Unix.WEXITED n) ->
+  | Forkhelpers.Spawn_internal_error (_, _, Unix.WEXITED n) ->
       handler cmd n
   | _ ->
       raise (Process_output_error cmd)

--- a/ocaml/xapi-client/dune
+++ b/ocaml/xapi-client/dune
@@ -11,6 +11,7 @@
 (library
   (name xapi_client)
   (public_name xapi-client)
+  (flags (:standard -w -50))
   (libraries
     mtime
     mtime.clock.os

--- a/ocaml/xapi-storage-cli/main.ml
+++ b/ocaml/xapi-storage-cli/main.ml
@@ -312,7 +312,7 @@ let on_vdi' f common_opts sr vdi =
     (fun sr vdi ->
       let () = f sr vdi in
       `Ok ()
-      )
+    )
     common_opts sr vdi
 
 let mirror_start common_opts sr vdi dp url dest =

--- a/ocaml/xapi-storage-cli/main.ml
+++ b/ocaml/xapi-storage-cli/main.ml
@@ -30,9 +30,9 @@ let string_of_mirror id {Mirror.source_vdi; dest_vdi; state; failed} =
           (function
             | Storage_interface.Mirror.Receiving ->
                 "Receiving"
-            | Sending ->
+            | Storage_interface.Mirror.Sending ->
                 "Sending"
-            | Copying ->
+            | Storage_interface.Mirror.Copying ->
                 "Copying"
             )
           state
@@ -102,9 +102,9 @@ let help =
 
 (* Commands *)
 
-let wrap common_opts f =
+let wrap_exn common_opts f =
   Storage_interface.default_path := common_opts.Common.socket ;
-  try f () ; `Ok () with
+  try f () with
   | Unix.Unix_error ((Unix.ECONNREFUSED | Unix.ENOENT), "connect", _) as e ->
       Printf.fprintf stderr "Failed to connect to %s: %s\n%!"
         common_opts.Common.socket (Printexc.to_string e) ;
@@ -121,6 +121,11 @@ let wrap common_opts f =
       Printf.fprintf stderr "Error from storage backend:\n" ;
       Printf.fprintf stderr "%s: [ %s ]\n" code (String.concat "; " params) ;
       exit 1
+
+let wrap common_opts f =
+  wrap_exn common_opts @@ fun () ->
+  let () = f () in
+  `Ok ()
 
 let query common_opts =
   wrap common_opts (fun () ->
@@ -300,10 +305,18 @@ let on_vdi f common_opts sr vdi =
       `Error (true, "must supply VDI")
   | Some sr, Some vdi ->
       let sr, vdi = Storage_interface.(Sr.of_string sr, Vdi.of_string vdi) in
-      wrap common_opts (fun () -> f sr vdi)
+      wrap_exn common_opts (fun () -> f sr vdi)
+
+let on_vdi' f common_opts sr vdi =
+  on_vdi
+    (fun sr vdi ->
+      let () = f sr vdi in
+      `Ok ()
+      )
+    common_opts sr vdi
 
 let mirror_start common_opts sr vdi dp url dest =
-  on_vdi
+  on_vdi'
     (fun sr vdi ->
       let get_opt x err = match x with Some y -> y | None -> failwith err in
       let dp = get_opt dp "Need a local data path" in
@@ -367,27 +380,31 @@ let vdi_resize common_opts sr vdi new_size =
     common_opts sr vdi
 
 let vdi_destroy common_opts sr vdi =
-  on_vdi (fun sr vdi -> Client.VDI.destroy dbg sr vdi) common_opts sr vdi
+  on_vdi' (fun sr vdi -> Client.VDI.destroy dbg sr vdi) common_opts sr vdi
 
 let vdi_attach common_opts sr vdi =
-  on_vdi
+  on_vdi'
     (fun sr vdi ->
       let info = Client.VDI.attach dbg dbg sr vdi true in
       Printf.printf "%s\n" (Jsonrpc.to_string (rpc_of attach_info info))
     )
     common_opts sr vdi
 
-let vdi_detach common_opts sr vdi =
-  on_vdi (fun sr vdi -> Client.VDI.detach dbg dbg sr vdi) common_opts sr vdi
+let vdi_detach common_opts sr vdi vm =
+  let vm = Vm.of_string vm in
+  on_vdi' (fun sr vdi -> Client.VDI.detach dbg dbg sr vdi vm) common_opts sr vdi
 
 let vdi_activate common_opts sr vdi =
-  on_vdi (fun sr vdi -> Client.VDI.activate dbg dbg sr vdi) common_opts sr vdi
+  on_vdi' (fun sr vdi -> Client.VDI.activate dbg dbg sr vdi) common_opts sr vdi
 
-let vdi_deactivate common_opts sr vdi =
-  on_vdi (fun sr vdi -> Client.VDI.deactivate dbg dbg sr vdi) common_opts sr vdi
+let vdi_deactivate common_opts sr vdi vm =
+  let vm = Vm.of_string vm in
+  on_vdi'
+    (fun sr vdi -> Client.VDI.deactivate dbg dbg sr vdi vm)
+    common_opts sr vdi
 
 let vdi_similar_content common_opts sr vdi =
-  on_vdi
+  on_vdi'
     (fun sr vdi ->
       let vdis = Client.VDI.similar_content dbg sr vdi in
       List.iter
@@ -400,7 +417,7 @@ let vdi_similar_content common_opts sr vdi =
     common_opts sr vdi
 
 let vdi_compose common_opts sr vdi1 vdi2 =
-  on_vdi
+  on_vdi'
     (fun sr vdi1 ->
       match vdi2 with
       | None ->
@@ -412,16 +429,16 @@ let vdi_compose common_opts sr vdi1 vdi2 =
     common_opts sr vdi1
 
 let vdi_enable_cbt common_opts sr vdi =
-  on_vdi (fun sr vdi -> Client.VDI.enable_cbt dbg sr vdi) common_opts sr vdi
+  on_vdi' (fun sr vdi -> Client.VDI.enable_cbt dbg sr vdi) common_opts sr vdi
 
 let vdi_disable_cbt common_opts sr vdi =
-  on_vdi (fun sr vdi -> Client.VDI.disable_cbt dbg sr vdi) common_opts sr vdi
+  on_vdi' (fun sr vdi -> Client.VDI.disable_cbt dbg sr vdi) common_opts sr vdi
 
 let vdi_data_destroy common_opts sr vdi =
-  on_vdi (fun sr vdi -> Client.VDI.data_destroy dbg sr vdi) common_opts sr vdi
+  on_vdi' (fun sr vdi -> Client.VDI.data_destroy dbg sr vdi) common_opts sr vdi
 
 let vdi_list_changed_blocks common_opts sr vdi_from vdi_to =
-  on_vdi
+  on_vdi'
     (fun sr vdi_from ->
       match vdi_to with
       | None ->
@@ -459,6 +476,10 @@ let sr_arg =
 let vdi_arg =
   let doc = "unique identifier for this VDI within this storage repository" in
   Arg.(value & pos 1 (some string) None & info [] ~docv:"VDI" ~doc)
+
+let vm_arg =
+  let doc = "unique identifier for a VM" in
+  Arg.(required & pos 2 (some string) None & info [] ~docv:"VM" ~doc)
 
 let vdi2_arg ~docv ~doc =
   Arg.(value & pos 2 (some string) None & info [] ~docv ~doc)
@@ -775,7 +796,7 @@ let vdi_detach_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_detach $ common_options_t $ sr_arg $ vdi_arg))
+  ( Term.(ret (pure vdi_detach $ common_options_t $ sr_arg $ vdi_arg $ vm_arg))
   , Term.info "vdi-detach" ~sdocs:_common_options ~doc ~man
   )
 
@@ -806,7 +827,9 @@ let vdi_deactivate_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_deactivate $ common_options_t $ sr_arg $ vdi_arg))
+  ( Term.(
+      ret (pure vdi_deactivate $ common_options_t $ sr_arg $ vdi_arg $ vm_arg)
+    )
   , Term.info "vdi-deactivate" ~sdocs:_common_options ~doc ~man
   )
 

--- a/ocaml/xapi-types/dune
+++ b/ocaml/xapi-types/dune
@@ -11,7 +11,7 @@
 (library
   (name xapi_types)
   (public_name xapi-types)
-  (flags (:standard))
+  (flags (:standard -w -33))
   (libraries
     astring
     http-svr


### PR DESCRIPTION
I've silenced some warning that are difficult to silence, because they are produced by rpclib or are produced by generated code but are harmless. This allows for `make check` to use the debug profile and actually show a lot of warnings, some of them which look like they should be addressed, like when the result type is ignored.

Once build passes, I'll push another commit where `make check` is changed and shows all the issues in CI.