### PR TITLE
Make reboot equal to shutdown+start for CPUID changes due to a changed domain type

### DIFF
--- a/ocaml/database/dune
+++ b/ocaml/database/dune
@@ -95,3 +95,5 @@
   (action (run %{x} --master db.xml --test))
 )
 
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/gencert/dune
+++ b/ocaml/gencert/dune
@@ -62,3 +62,5 @@
   (action (run %{test} --color=always))
 )
 
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/libs/resources/test/dune
+++ b/ocaml/libs/resources/test/dune
@@ -9,3 +9,5 @@
   )
 )
 
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/networkd/test/dune
+++ b/ocaml/networkd/test/dune
@@ -19,3 +19,6 @@
   )
  )
 )
+
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/squeezed/test/dune
+++ b/ocaml/squeezed/test/dune
@@ -12,3 +12,6 @@
     xapi-idl
   )
 )
+
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/tests/alerts/dune
+++ b/ocaml/tests/alerts/dune
@@ -10,3 +10,5 @@
   (action (run %{test} --color=always))
 )
 
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -49,9 +49,10 @@ let default_cpu_info =
   ; ("model", "")
   ; ("stepping", "")
   ; ("flags", "")
-  ; ("features", "")
   ; ("features_pv", "")
   ; ("features_hvm", "")
+  ; ("features_pv_host", "")
+  ; ("features_hvm_host", "")
   ]
 
 let make_localhost ~__context ?(features = Features.all_features) () =
@@ -85,7 +86,6 @@ let make_localhost ~__context ?(features = Features.all_features) () =
           ; features= [||]
           ; features_pv= [||]
           ; features_hvm= [||]
-          ; features_oldstyle= [||]
           ; features_pv_host= [||]
           ; features_hvm_host= [||]
           }

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -111,7 +111,8 @@ let make_localhost ~__context ?(features = Features.all_features) () =
   Dbsync_master.create_pool_record ~__context ;
   let pool = Helpers.get_pool ~__context in
   Db.Pool.set_restrictions ~__context ~self:pool
-    ~value:(Features.to_assoc_list features)
+    ~value:(Features.to_assoc_list features) ;
+  Db.Pool.set_cpu_info ~__context ~self:pool ~value:default_cpu_info
 
 (** Make a simple in-memory database containing a single host and dom0 VM record. *)
 let make_test_database ?(conn = Mock.Database.conn) ?(reuse = false) ?features

--- a/ocaml/tests/test_cpuid_helpers.ml
+++ b/ocaml/tests/test_cpuid_helpers.ml
@@ -453,7 +453,7 @@ end)
 let domain_type : API.domain_type Test_printers.printer =
   Record_util.domain_type_to_string
 
-module ResetCPUFlags = Generic.MakeStateful (struct
+module NextBootCPUFeatures = Generic.MakeStateful (struct
   module Io = struct
     type input_t = (string * API.domain_type) list
 
@@ -486,21 +486,16 @@ module ResetCPUFlags = Generic.MakeStateful (struct
     Db.Pool.set_cpu_info ~__context
       ~self:(Db.Pool.get_all ~__context |> List.hd)
       ~value:cpu_info ;
-    let vms =
-      List.map
-        (fun (name_label, domain_type) ->
-          Test_common.make_vm ~__context ~name_label ~domain_type ()
-          )
-        cases
-    in
-    List.iter (fun vm -> Cpuid_helpers.reset_cpu_flags ~__context ~vm) vms
+    List.iter
+      (fun (name_label, domain_type) ->
+        ignore (Test_common.make_vm ~__context ~name_label ~domain_type ())
+        )
+      cases
 
   let extract_output __context vms =
     let get_flags (label, _) =
-      let self = List.hd (Db.VM.get_by_name_label ~__context ~label) in
-      let flags = Db.VM.get_last_boot_CPU_flags ~__context ~self in
-      try List.assoc Xapi_globs.cpu_info_features_key flags
-      with Not_found -> ""
+      let vm = List.hd (Db.VM.get_by_name_label ~__context ~label) in
+      Cpuid_helpers.next_boot_cpu_features ~__context ~vm
     in
     List.map get_flags vms
 
@@ -760,6 +755,6 @@ let tests =
     ; ("accessors", Accessors.tests)
     ; ("setters", Setters.tests)
     ; ("modifiers", Modifiers.tests)
-    ; ("reset_cpu_flags", ResetCPUFlags.tests)
+    ; ("next_boot_cpu_features", NextBootCPUFeatures.tests)
     ; ("test_assert_vm_is_compatible", AssertVMIsCompatible.tests)
     ]

--- a/ocaml/tests/xapi-cli-protocol/dune
+++ b/ocaml/tests/xapi-cli-protocol/dune
@@ -7,3 +7,5 @@
   )
 )
 
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/vhd-tool/test/dune
+++ b/ocaml/vhd-tool/test/dune
@@ -17,3 +17,6 @@
   )
   (action (run %{x}))
 )
+
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/xapi-idl/lib_test/dune
+++ b/ocaml/xapi-idl/lib_test/dune
@@ -22,3 +22,6 @@
    xapi-idl.xen
  )
  (preprocess (pps ppx_deriving_rpc)))
+
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/xapi-idl/storage/dune
+++ b/ocaml/xapi-idl/storage/dune
@@ -67,3 +67,6 @@
  )
  (package xapi-idl)
  (deps storage_test.exe))
+
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -468,7 +468,6 @@ module Host = struct
     ; features_hvm: int64 array
     ; features_pv_host: int64 array
     ; features_hvm_host: int64 array
-    ; features_oldstyle: int64 array
   }
   [@@deriving rpcty]
 
@@ -617,15 +616,6 @@ module XenopsAPI (R : RPC) = struct
     let update_guest_agent_features =
       declare "HOST.update_guest_agent_features" []
         (debug_info_p @-> feature_list_p @-> returning unit_p err)
-
-    let upgrade_cpu_features =
-      let is_hvm_p = Param.mk ~name:"is_hvm" Types.bool in
-      declare "HOST.upgrade_cpu_features" []
-        (debug_info_p
-        @-> cpu_features_array_p
-        @-> is_hvm_p
-        @-> returning cpu_features_array_p err
-        )
   end
 
   module VM = struct

--- a/ocaml/xapi-idl/xen/xenops_types.ml
+++ b/ocaml/xapi-idl/xen/xenops_types.ml
@@ -194,6 +194,7 @@ module Vm = struct
     ; nomigrate: bool  (** true means VM must not migrate *)
     ; nested_virt: bool  (** true means VM uses nested virtualisation *)
     ; domain_type: domain_type
+    ; featureset: string
   }
   [@@deriving rpcty, sexp]
 end

--- a/ocaml/xapi-storage/generator/test/dune
+++ b/ocaml/xapi-storage/generator/test/dune
@@ -18,3 +18,5 @@
   (action (run %{x}))
 )
 
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -144,24 +144,6 @@ let upgrade_features ~__context ~vm ~host host_features vm_features =
       (string_of_features upgraded_features) ;
   upgraded_features
 
-let set_flags ~__context self vendor features =
-  let features = features |> snd features_t in
-  let value =
-    [(cpu_info_vendor_key, vendor); (cpu_info_features_key, features)]
-  in
-  debug "VM's CPU features set to: %s" features ;
-  Db.VM.set_last_boot_CPU_flags ~__context ~self ~value
-
-(* Reset last_boot_CPU_flags with the vendor and feature set.
- * On VM.start, the feature set is inherited from the pool level (PV or HVM) *)
-let reset_cpu_flags ~__context ~vm =
-  let pool_vendor, _, pool_features =
-    let pool = Helpers.get_pool ~__context in
-    let pool_cpu_info = Db.Pool.get_cpu_info ~__context ~self:pool in
-    get_flags_for_vm ~__context vm pool_cpu_info
-  in
-  set_flags ~__context vm pool_vendor pool_features
-
 (* Return the featureset to be used for the next boot of the given VM. *)
 let next_boot_cpu_features ~__context ~vm =
   (* On VM.start, the feature set is inherited from the pool level (PV or HVM) *)
@@ -186,28 +168,6 @@ let next_boot_cpu_features ~__context ~vm =
     Map_check.getf ~default features_field_boot pool_cpu_info
   in
   snd features_t pool_features
-
-(* Update last_boot_CPU_flags with the vendor and feature set.
- * On VM.resume or migrate, the field is kept intact, and upgraded if needed. *)
-let update_cpu_flags ~__context ~vm ~host =
-  let current_features =
-    let flags = Db.VM.get_last_boot_CPU_flags ~__context ~self:vm in
-    Map_check.getf ~default:[||] features flags
-  in
-  debug "VM last boot CPU features: %s" (string_of_features current_features) ;
-  try
-    let host_vendor, host_features, _ =
-      let host_cpu_info = Db.Host.get_cpu_info ~__context ~self:host in
-      get_flags_for_vm ~__context vm host_cpu_info
-    in
-    let new_features =
-      upgrade_features ~__context ~vm host_features current_features
-    in
-    if new_features <> current_features then
-      set_flags ~__context vm host_vendor new_features
-  with Not_found ->
-    (* pre-Dundee? *)
-    failwith "Host does not have new leveling feature keys"
 
 let get_host_cpu_info ~__context ~vm ~host ?remote () =
   match remote with

--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -173,6 +173,31 @@ let reset_cpu_flags ~__context ~vm =
   in
   set_flags ~__context vm pool_vendor pool_features
 
+(* Return the featureset to be used for the next boot of the given VM. *)
+let next_boot_cpu_features ~__context ~vm =
+  (* On VM.start, the feature set is inherited from the pool level (PV or HVM) *)
+  let pool = Helpers.get_pool ~__context in
+  let pool_cpu_info = Db.Pool.get_cpu_info ~__context ~self:pool in
+  let features_field, features_field_boot =
+    (* Always use VM.domain_type, even if the VM is running, because we
+       need the features for when the VM starts next. *)
+    let domain_type =
+      Db.VM.get_domain_type ~__context ~self:vm |> Helpers.check_domain_type
+    in
+    match domain_type with
+    | `hvm | `pv_in_pvh ->
+        (features_hvm, features_hvm_host)
+    | `pv ->
+        (features_pv, features_pv_host)
+  in
+  (* The default is for backwards compatibility with versions that do not
+     yet have a features_field_boot (e.g. during RPU). *)
+  let default = Map_check.getf features_field pool_cpu_info in
+  let pool_features =
+    Map_check.getf ~default features_field_boot pool_cpu_info
+  in
+  snd features_t pool_features
+
 (* Update last_boot_CPU_flags with the vendor and feature set.
  * On VM.resume or migrate, the field is kept intact, and upgraded if needed. *)
 let update_cpu_flags ~__context ~vm ~host =

--- a/ocaml/xapi/cpuid_helpers.mli
+++ b/ocaml/xapi/cpuid_helpers.mli
@@ -20,6 +20,8 @@ val features_of_string : string -> int64 array
 
 val reset_cpu_flags : __context:Context.t -> vm:[`VM] API.Ref.t -> unit
 
+val next_boot_cpu_features : __context:Context.t -> vm:[`VM] API.Ref.t -> string
+
 val update_cpu_flags :
   __context:Context.t -> vm:[`VM] API.Ref.t -> host:[`host] API.Ref.t -> unit
 

--- a/ocaml/xapi/cpuid_helpers.mli
+++ b/ocaml/xapi/cpuid_helpers.mli
@@ -18,12 +18,7 @@ val string_of_features : int64 array -> string
 
 val features_of_string : string -> int64 array
 
-val reset_cpu_flags : __context:Context.t -> vm:[`VM] API.Ref.t -> unit
-
 val next_boot_cpu_features : __context:Context.t -> vm:[`VM] API.Ref.t -> string
-
-val update_cpu_flags :
-  __context:Context.t -> vm:[`VM] API.Ref.t -> host:[`host] API.Ref.t -> unit
 
 val assert_vm_is_compatible :
      __context:Context.t

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -614,11 +614,6 @@ let create_host_cpu ~__context host_info =
         ; ("model", cpu_info.model)
         ; ("stepping", cpu_info.stepping)
         ; ("flags", cpu_info.flags)
-        ; (* To support VMs migrated from hosts which do not support CPU levelling v2,
-             		   set the "features" key to what it would be on such hosts. *)
-          ( "features"
-          , Cpuid_helpers.string_of_features cpu_info.features_oldstyle
-          )
         ; ( Xapi_globs.cpu_info_features_pv_key
           , Cpuid_helpers.string_of_features cpu_info.features_pv
           )

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2376,8 +2376,7 @@ functor
         create_vm_message ~__context ~vm ~message_body
           ~message:Api_messages.vm_migrated ;
         update_vbd_operations ~__context ~vm ;
-        update_vif_operations ~__context ~vm ;
-        Cpuid_helpers.update_cpu_flags ~__context ~vm ~host
+        update_vif_operations ~__context ~vm
 
       let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map
           ~vgpu_map ~options =

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -387,7 +387,6 @@ let start ~__context ~vm ~start_paused ~force =
      	 * If/when we introduce another version, we must reassess this. *)
   update_vm_virtual_hardware_platform_version ~__context ~vm ;
   (* Reset CPU feature set, which will be passed to xenopsd *)
-  Cpuid_helpers.reset_cpu_flags ~__context ~vm ;
   (* If the VM has any vGPUs, gpumon must remain stopped until the
      * VM has started. *)
   ( match vmr.API.vM_VGPUs with
@@ -611,7 +610,6 @@ let resume ~__context ~vm ~start_paused ~force =
   if not force then
     Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host () ;
   (* Update CPU feature set, which will be passed to xenopsd *)
-  Cpuid_helpers.update_cpu_flags ~__context ~vm ~host ;
   Xapi_xenops.resume ~__context ~self:vm ~start_paused ~force
 
 let resume_on ~__context ~vm ~host ~start_paused ~force =

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -417,7 +417,6 @@ let pool_migrate_complete ~__context ~vm ~host =
   let queue_name = Xapi_xenops_queue.queue_of_vm ~__context ~self:vm in
   if Xapi_xenops.vm_exists_in_xenopsd queue_name dbg id then (
     remove_stale_pcis ~__context ~vm ;
-    Cpuid_helpers.update_cpu_flags ~__context ~vm ~host ;
     Xapi_xenops.set_resident_on ~__context ~self:vm ;
     Xapi_xenops.add_caches id ;
     Xapi_xenops.refresh_vm ~__context ~self:vm ;

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2028,8 +2028,7 @@ let update_vm ~__context id =
                     | Some x ->
                         Db.VM.set_last_booted_record ~__context ~self ~value:x ;
                         debug "VM %s last_booted_record set to %s"
-                          (Ref.string_of self) x ;
-                        Xenopsd_metadata.delete ~__context id
+                          (Ref.string_of self) x
                 ) ;
                 if power_state = `Halted then
                   !trigger_xenapi_reregister ()

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1218,14 +1218,7 @@ module MD = struct
     let platformdata =
       if not (List.mem_assoc Vm_platform.featureset platformdata) then
         let featureset =
-          if
-            List.mem_assoc Xapi_globs.cpu_info_features_key
-              vm.API.vM_last_boot_CPU_flags
-          then
-            List.assoc Xapi_globs.cpu_info_features_key
-              vm.API.vM_last_boot_CPU_flags
-          else
-            failwith "VM's CPU featureset not initialised"
+          Cpuid_helpers.next_boot_cpu_features ~__context ~vm:vmref
         in
         (Vm_platform.featureset, featureset) :: platformdata
       else

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2339,6 +2339,31 @@ let update_vm ~__context id =
                 error "Caught %s: while updating VM %s HVM_shadow_multiplier"
                   (Printexc.to_string e) id
           ) ;
+          (* Preserve last_boot_CPU_flags when suspending (see current_domain_type) *)
+          if different (fun x -> x.Vm.featureset) && power_state <> `Suspended
+          then
+            Option.iter
+              (fun (_, state) ->
+                try
+                  debug
+                    "xenopsd event: Updating VM %s last_boot_CPU_flags <- %s" id
+                    state.Vm.featureset ;
+                  let vendor =
+                    Db.Host.get_cpu_info ~__context ~self:localhost
+                    |> List.assoc Xapi_globs.cpu_info_vendor_key
+                  in
+                  let value =
+                    [
+                      (Xapi_globs.cpu_info_vendor_key, vendor)
+                    ; (Xapi_globs.cpu_info_features_key, state.Vm.featureset)
+                    ]
+                  in
+                  Db.VM.set_last_boot_CPU_flags ~__context ~self ~value
+                with e ->
+                  error "Caught %s: while updating VM %s last_boot_CPU_flags"
+                    (Printexc.to_string e) id
+                )
+              info ;
           Xenops_cache.update_vm id (Option.map snd info) ;
           if !should_update_allowed_operations then
             Helpers.call_api_functions ~__context (fun rpc session_id ->

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -3128,15 +3128,6 @@ module HOST = struct
         B.HOST.update_guest_agent_features features
         )
       ()
-
-  let upgrade_cpu_features _ dbg features is_hvm =
-    Debug.with_thread_associated dbg
-      (fun () ->
-        debug "HOST.upgrade_cpu_features" ;
-        let module B = (val get_backend () : S) in
-        B.HOST.upgrade_cpu_features features is_hvm
-        )
-      ()
 end
 
 module VM = struct
@@ -3639,7 +3630,6 @@ let _ =
   Server.HOST.send_debug_keys (HOST.send_debug_keys ()) ;
   Server.HOST.set_worker_pool_size (HOST.set_worker_pool_size ()) ;
   Server.HOST.update_guest_agent_features (HOST.update_guest_agent_features ()) ;
-  Server.HOST.upgrade_cpu_features (HOST.upgrade_cpu_features ()) ;
   Server.VM.add (VM.add ()) ;
   Server.VM.remove (VM.remove ()) ;
   Server.VM.migrate (VM.migrate ()) ;

--- a/ocaml/xenopsd/lib/xenops_server_plugin.ml
+++ b/ocaml/xenopsd/lib/xenops_server_plugin.ml
@@ -64,8 +64,6 @@ module type S = sig
     val send_debug_keys : string -> unit
 
     val update_guest_agent_features : Host.guest_agent_feature list -> unit
-
-    val upgrade_cpu_features : int64 array -> bool -> int64 array
   end
 
   module VM : sig

--- a/ocaml/xenopsd/lib/xenops_server_skeleton.ml
+++ b/ocaml/xenopsd/lib/xenops_server_skeleton.ml
@@ -36,7 +36,6 @@ module HOST = struct
         ; features= [||]
         ; features_pv= [||]
         ; features_hvm= [||]
-        ; features_oldstyle= [||]
         ; features_pv_host= [||]
         ; features_hvm_host= [||]
         }
@@ -51,8 +50,6 @@ module HOST = struct
   let send_debug_keys _ = ()
 
   let update_guest_agent_features _ = ()
-
-  let upgrade_cpu_features _ _ = [||]
 end
 
 module VM = struct

--- a/ocaml/xenopsd/lib/xenops_utils.ml
+++ b/ocaml/xenopsd/lib/xenops_utils.ml
@@ -512,6 +512,7 @@ let halted_vm =
   ; nomigrate= false
   ; nested_virt= false
   ; domain_type= Vm.Domain_undefined
+  ; featureset= ""
   }
 
 let unplugged_pci = {Pci.plugged= false}

--- a/ocaml/xenopsd/test/dune
+++ b/ocaml/xenopsd/test/dune
@@ -36,3 +36,6 @@
   )
   (action (run ./check-no-xenctrl.sh %{x}))
 )
+
+(env (_ (env-vars (ALCOTEST_COMPACT 1))))
+

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -1004,7 +1004,6 @@ module HOST = struct
         (* this is Default policy in Xen's terminology, used on boot for new VMs *)
         let features_pv_host = get_cpu_featureset xc Featureset_pv in
         let features_hvm_host = get_cpu_featureset xc Featureset_hvm in
-        let features_oldstyle = oldstyle_featuremask xc in
         (* this is Max policy in Xen's terminology, used for migration checks *)
         let features_hvm =
           get_max_featureset xc "HVM" features_hvm_host
@@ -1035,7 +1034,6 @@ module HOST = struct
             ; features
             ; features_pv
             ; features_hvm
-            ; features_oldstyle
             ; features_hvm_host
             ; features_pv_host
             }
@@ -1098,11 +1096,6 @@ module HOST = struct
                 )
               features
         )
-    )
-
-  let upgrade_cpu_features features is_hvm =
-    with_xc_and_xs (fun xc _ ->
-        Xenctrl.upgrade_oldstyle_featuremask xc features is_hvm
     )
 end
 

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2957,6 +2957,13 @@ module VM = struct
                     x.VmExtra.persistent.VmExtra.nested_virt
                 )
             ; domain_type= get_domain_type ~xs di
+            ; featureset=
+                ( match vme with
+                | None ->
+                    ""
+                | Some x ->
+                    List.assoc "featureset" x.VmExtra.persistent.platformdata
+                )
             }
     )
 


### PR DESCRIPTION
The problem occurs in particular when the domain-type of a running PV VM is changed to PV-in-PVH. The domain-type change is correctly applied when the VM reboots, but the CPUID featureset needs to change along with it, but does not. The result is a crash as soon as the VM reboots.

To fix this, we need to:

- Reset the featureset not just on start, but also on reboot.
- Updated platformdata, which contains the featureset, must be sent to xenopsd immediately and used upon reboot (but not for migrating or resuming!).

Currently in xenopsd, platformdata is stored in:
- `Xenops_interface.VM.t` (persistent)
- `Domain.create_info` (non-persistent)

plaformdata is NOT stored in:
- `VmExtra.persistent_t`

On start:
- xapi pushes `Xenops_interface.VM.t` to xenopsd.
- `Domain.create_info` is recreated in `VM_create` based on `Xenops_interface.VM.t`, and used immediately by low-level code, but not stored.

In xapi:
- `Cpuid_helpers.reset_cpu_flags` is called from VM.start (only) and sets `VM.last_boot_CPU_flags` based on the "pool cpuid level".
- When pushing/updating VM metadata to xenopsd, `Xapi_xenops.MD.of_vm` takes `VM.last_boot_CPU_flags` and puts it into `platformdata:featureset` in the `Xenops_interface.VM.t` record.
  - Other platform keys are taken from `VM.platform`, sanity checked, and included in `platformdata` as well.
  - The events-from-xapi loop regenerates the metadata and sends it to xenopsd, triggered by xapi DB changes, while a VM is running.
  - This includes regular platform keys. The `featureset` won't change, because `VM.last_boot_CPU_flags` never changes.
- `VM.last_boot_CPU_flags` is relied upon for resume to provide the correct featureset.
- For migration, xenopsd pushes `Xenops_interface.VM.t` to the remote xenopsd, which includes `platformdata:featureset`.
  - `VmExtra.persistent_t` is _also_ sent to the remote.

To address the problem, we make the following changes:
- Put the current featureset (in fact, the entire platform map) in `persistent_t` and take it from there for resume and migrate.
- Let `VM.t` be the next-boot config.
- Add featureset to xenopsd's `VM.state` and get it from `persistent_t` if requested by xapi.
- Set `VM.last_boot_CPU_flags` based on the state from xenopsd (only).
- Recompute the feature set "on the fly" when pushing new VM metadata to xenopsd (which is triggered by DB changes), rather than taking it from `VM.last_boot_CPU_flags`.