### PR TITLE
CA-363068: Ensure that stunnel-on-demand shuts down after xapi

### DIFF
--- a/scripts/stunnel-on-demand.socket
+++ b/scripts/stunnel-on-demand.socket
@@ -2,6 +2,7 @@
 Description=Stunnel Socket for Per-Connection XAPI Service
 Requires=gencert.service
 After=gencert.service
+Before=xapi.service
 
 [Socket]
 ListenStream=443

--- a/scripts/stunnel-on-demand@.service
+++ b/scripts/stunnel-on-demand@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Stunnel Per-Connection Server
 After=syslog.target network.target
+Before=xapi.service
 
 [Service]
 ExecStart=/usr/bin/stunnel /etc/stunnel/xapi.conf


### PR DESCRIPTION
Add systemd a ordering dependency on xapi, matching the one that is present on
stunnel@xapi. This ensures that pool members can still communicate with the
pool coordinator (in both directions) until xapi has stopped.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>