### PR TITLE
CA-363207: SSH access failing when using AD groups with spaces in name (Backport)

### DIFF
--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -165,6 +165,9 @@ class DynamicPam(ADConfig):
         try:
             sid = subject_rec['subject_identifier']
             name = subject_rec["other_config"]["subject-name"]
+            # CA-363207: Pam cannot handle space, put it inside []
+            if " " in name:
+                name = "[{}]".format(name)
             is_group = subject_rec["other_config"]["subject-is-group"] == "true"
             logger.debug("Permit %s with sid %s is_group as %s", name, sid, is_group)
             condition = "ingroup" if is_group else "="


### PR DESCRIPTION
pam module cannot handle subject name with space, the subject is split
by space, put it into [] to handle it

Signed-off-by: Lin Liu <lin.liu@citrix.com>
(cherry picked from commit 1e5ab3728e34588de1bde833f73bc8b382975c65)