### PR TITLE
CP-39031 keep more xapi version details for Host.software_versions

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -569,6 +569,7 @@ let make_software_version ~__context host_info =
   @ v6_version
   @ [
       ("xapi", get_xapi_verstring ())
+    ; ("xapi_build", Build_info.version)
     ; ("xen", Option.value ~default:"(unknown)" host_info.xen_verstring)
     ; ("linux", host_info.linux_verstring)
     ; ("xencenter_min", Xapi_globs.xencenter_min_verstring)


### PR DESCRIPTION
Keep more details about the version of xapi as it is recorded in the
"sofware-versions" field of a host. This is most useful on a host where
a new version has been installed but not yet started. We want to know,
what version is currently running.

To make this useful, we will have to pass a more detailed XAPI_VERSION 
during builds into the environment from where it is picked up. That 
requires changes in the SPEC file - so let's do this first.

