### PR TITLE
XSI-1175 make message limit configurable

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -435,7 +435,7 @@ let hosts_which_are_shutting_down_m = Mutex.create ()
 
 let xha_timeout = "timeout"
 
-let message_limit = 10000
+let message_limit = ref 10000
 
 let xapi_message_script = ref "mail-alarm"
 
@@ -1318,6 +1318,11 @@ let other_options =
     , (fun () -> string_of_int !cert_expiration_days)
     , "Number of days a refreshed certificate will be valid; it defaults to 10 \
        years."
+    )
+  ; ( "messages-limit"
+    , Arg.Set_int message_limit
+    , (fun () -> string_of_int !message_limit)
+    , "Maximum number of messages kept before deleting oldest ones."
     )
   ]
 

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -530,6 +530,7 @@ let destroy ~__context ~self =
 
 (* Gc the messages - leave only the number of messages defined in 'Xapi_globs.message_limit' *)
 let gc ~__context =
+  let message_limit = !Xapi_globs.message_limit in
   if
     try
       Unix.access message_dir [Unix.F_OK] ;
@@ -541,11 +542,11 @@ let gc ~__context =
         (fun msg -> try Some (float_of_string msg, msg) with _ -> None)
         (Array.to_list (Sys.readdir message_dir))
     in
-    if List.length allmsg > Xapi_globs.message_limit then (
-      warn "Messages have reached over the limit %d" Xapi_globs.message_limit ;
+    if List.length allmsg > message_limit then (
+      warn "Messages have reached over the limit %d" message_limit ;
       let sorted = List.sort (fun (t1, _) (t2, _) -> compare t1 t2) allmsg in
       let n = List.length sorted in
-      let to_reap = n - Xapi_globs.message_limit in
+      let to_reap = n - message_limit in
       let rec reap_one i msgs =
         if i = to_reap then
           ()


### PR DESCRIPTION
Messages are usually small but XSI-1175 has shown that mpathalert
messages can reach 200kB per message. This puts stress on the system
because it keeps up to 10000 messages in the database. As an immediate
fix, permit to set a lower limit of messages to keep.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>