### PR TITLE
CA-363633: Always take the generation-id directly from xapi

### DIFF
--- a/ocaml/xapi-idl/xen/xenops_types.ml
+++ b/ocaml/xapi-idl/xen/xenops_types.ml
@@ -160,6 +160,7 @@ module Vm = struct
     ; pci_msitranslate: bool
     ; pci_power_mgmt: bool
     ; has_vendor_device: bool [@default false]
+    ; generation_id: string option
   }
   [@@deriving rpcty, sexp]
 

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -533,7 +533,7 @@ module Applicability = struct
                 (* The error should not block update. Ingore it. *)
                 warn "Unknown node in <applicability>" ;
                 a
-            )
+          )
           default children
         |> assert_valid
     | _ ->

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -109,8 +109,6 @@ let filtered_flags =
 (* Other keys we might want to write to the platform map. *)
 let timeoffset = "timeoffset"
 
-let generation_id = "generation-id"
-
 (* Helper functions. *)
 (* [is_valid key platformdata] returns true if:
    1. The key is _not_ in platformdata (absence of key is valid) or

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1204,15 +1204,12 @@ module MD = struct
            (fun (key, _) -> key <> Vm_platform.timeoffset)
            platformdata
     in
-    let platformdata =
-      let genid =
-        match vm.API.vM_generation_id with
-        | "0:0" ->
-            Xapi_vm_helpers.vm_fresh_genid ~__context ~self:vmref
-        | _ ->
-            vm.API.vM_generation_id
-      in
-      (Vm_platform.generation_id, genid) :: platformdata
+    let generation_id =
+      match vm.API.vM_generation_id with
+      | "0:0" ->
+          Some (Xapi_vm_helpers.vm_fresh_genid ~__context ~self:vmref)
+      | _ ->
+          Some vm.API.vM_generation_id
     in
     (* Add the CPUID feature set for the VM's next boot to the platform data. *)
     let platformdata =
@@ -1289,6 +1286,7 @@ module MD = struct
     ; pci_msitranslate
     ; pci_power_mgmt= false
     ; has_vendor_device= vm.API.vM_has_vendor_device
+    ; generation_id
     }
 end
 

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -669,6 +669,7 @@ let add' _copts x () =
             ; pci_msitranslate
             ; pci_power_mgmt
             ; has_vendor_device
+            ; generation_id= None
             }
           in
           let (id : Vm.id) = Client.VM.add dbg vm in

--- a/ocaml/xenopsd/test/test.ml
+++ b/ocaml/xenopsd/test/test.ml
@@ -255,6 +255,7 @@ let create_vm vmid =
   ; pci_msitranslate= true
   ; pci_power_mgmt= false
   ; has_vendor_device= false
+  ; generation_id= None
   }
 
 let sl x =

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -1332,11 +1332,20 @@ module VM = struct
       @ affinity
       @ weight
     in
+    let set_generation_id platformdata =
+      let key = "generation-id" in
+      match vm.generation_id with
+      | Some genid ->
+          (key, genid) :: List.remove_assoc key platformdata
+      | None ->
+          platformdata
+    in
     let default k v p = if List.mem_assoc k p then p else (k, v) :: p in
     let platformdata =
-      persistent.VmExtra.platformdata
+      persistent.VmExtra.platformdata @ vcpus
       |> default "acpi_s3" "0"
       |> default "acpi_s4" "0"
+      |> set_generation_id
     in
     let is_uefi =
       match ty with HVM {firmware= Uefi _; _} -> true | _ -> false
@@ -1356,7 +1365,7 @@ module VM = struct
     ; hap= hvm
     ; name= vm.name
     ; xsdata= vm.xsdata
-    ; platformdata= platformdata @ vcpus
+    ; platformdata
     ; bios_strings= vm.bios_strings
     ; has_vendor_device= vm.has_vendor_device
     ; is_uefi


### PR DESCRIPTION
The generation-id of a VM is made up by xapi - specifically for Windows
VMs - and xapi changes it or leaves it the same depending on the use
case. One such use case is revert-from-checkpoint, where the reverted VM
is expected to get a new generation-id.

The generation-id is put into the plaformdata by xapi and xenopsd
just writes it to xenstore when creating a domain. Because of a recent
change, the platformdata is now persisted by xenopsd across
suspend/resume and migration, and will therefore not take any new values
that set by xapi in the VM metadata.

Since a checkpoint is essentially a suspended VM, and a
revert-from-checkpoint results in a VM that can subsequently be resumed,
the VM now does not get a refreshed generation-id after this operation,
which is a bug.

To address this, the generation_id is given a dedicated field in the VM
metadata for xenopsd, so that it behaves as before. Xenopsd itself then
puts it into the platformdata when creating a domain.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>