### PR TITLE
maintenance: ignore formatting of datamodel_lifecycle.ml

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,0 +1,1 @@
+ocaml/idl/datamodel_lifecycle.ml

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -1,5 +1,11 @@
-let prototyped_of_class = function _ -> None
+let prototyped_of_class = function
+  | _ ->
+      None
 
-let prototyped_of_field = function _ -> None
+let prototyped_of_field = function
+  | _ ->
+      None
 
-let prototyped_of_message = function _ -> None
+let prototyped_of_message = function
+  | _ ->
+      None


### PR DESCRIPTION
The format of the generated file datamodel_lifecycle.ml and the one enforced by ocamlformat are different, this means when running `make` and `make format` consecutively the format of the file changes.

Make ocamlformat ignore the file altogether to avoid the conflict