### PR TITLE
CP-38617: Add module with stubs for xenforeignmemory

### DIFF
--- a/ocaml/xenforeign/dune
+++ b/ocaml/xenforeign/dune
@@ -1,0 +1,4 @@
+(executable
+  (name main)
+  (libraries xenopsd_xc hex)
+  )

--- a/ocaml/xenforeign/main.ml
+++ b/ocaml/xenforeign/main.ml
@@ -1,0 +1,27 @@
+module Xfm = Xenctrlext.Xenforeignmemory
+
+let usage_msg = "foreign-mapper <domid>"
+
+let domid = ref None
+
+let anon_fun param =
+  match !domid with None -> domid := Some (int_of_string param) | _ -> ()
+
+let defer f = Fun.protect ~finally:f
+
+let () =
+  Arg.parse [] anon_fun usage_msg ;
+  let the_domid = Option.get !domid in
+
+  let handle = Xfm.acquire None in
+  defer (fun () -> Xfm.release handle) @@ fun () ->
+  let prot = {Xfm.read= true; write= true; exec= false} in
+  let tpm_addr = 0x110000L in
+  Xfm.with_mapping handle the_domid prot [tpm_addr]
+    ~on_unmap_failure:(Fun.const ())
+  @@ fun mapping ->
+  let readable_region = Bigarray.Array1.(create Char C_layout 1024) in
+  for i = 0 to 1023 do
+    readable_region.{i} <- mapping.{i}
+  done ;
+  Hex.(hexdump (of_bigstring readable_region))

--- a/ocaml/xenopsd/c_stubs/dune
+++ b/ocaml/xenopsd/c_stubs/dune
@@ -16,7 +16,7 @@
  (foreign_stubs
   (language c)
   (names tuntap_stubs xenctrlext_stubs)
-  (flags (-L/lib64 -lxentoollog))
  )
+  (c_library_flags (-L/lib64 -lxentoollog -lxenforeignmemory))
 )
 

--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -19,6 +19,10 @@
 #include <string.h>
 #include <unistd.h>
 #include <xenctrl.h>
+#include <xenforeignmemory.h>
+#include <xentoollog.h>
+
+#include <sys/mman.h>
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -28,12 +32,23 @@
 #include <caml/signals.h>
 #include <caml/callback.h>
 #include <caml/unixsupport.h>
+#include <caml/bigarray.h>
 
 #define _H(__h) ((xc_interface *)(__h))
 #define _D(__d) ((uint32_t)Int_val(__d))
 
 /* From xenctrl_stubs */
 #define ERROR_STRLEN 1024
+
+#define Xtl_val(x)(*((struct xentoollog_logger **) Data_custom_val(x)))
+#define Xfm_val(x)(*((struct xenforeignmemory_handle **) Data_abstract_val(x)))
+#define Addr_val(x)(*((void **) Data_abstract_val(x)))
+
+// Defined in OCaml 4.12: https://github.com/ocaml/ocaml/pull/9734
+#if OCAML_VERSION < 41200
+#define Some_val(v) Field(v, 0)
+#define Is_some(v) Is_block(v)
+#endif
 
 static void raise_unix_errno_msg(int err_code, const char *err_msg)
 {
@@ -392,6 +407,138 @@ CAMLprim value stub_xenctrlext_cputopoinfo(value xch)
         free(cputopo);
 
 	CAMLreturn(result);
+}
+
+CAMLprim value stub_xenforeignmemory_open(value logger, value open_flags)
+{
+        CAMLparam2(logger, open_flags);
+        struct xentoollog_logger *log_handle = NULL;
+        struct xenforeignmemory_handle *fmem;
+        CAMLlocal1(result);
+
+        if(Is_some(logger)) {
+                log_handle = Xtl_val(Some_val(logger));
+        }
+
+        // allocate memory to store the result, if the call to get the xfm
+        // handle fails the ocaml GC will collect this abstract tag
+        result = caml_alloc(1, Abstract_tag);
+
+        fmem = xenforeignmemory_open(log_handle, Int_val(open_flags));
+
+        if(fmem == NULL) {
+                caml_failwith("Error when opening foreign memory handle");
+        }
+
+        Xfm_val(result) = fmem;
+
+        CAMLreturn(result);
+}
+
+CAMLprim value stub_xenforeignmemory_close(value fmem)
+{
+        CAMLparam1(fmem);
+        int retval;
+
+        if(Xfm_val(fmem) == NULL) {
+                caml_invalid_argument(
+                        "Error: cannot close NULL foreign memory handle");
+        }
+
+        retval = xenforeignmemory_close(Xfm_val(fmem));
+
+        if(retval < 0) {
+                caml_failwith("Error when closing foreign memory handle");
+        }
+
+        // Protect against double close
+        Xfm_val(fmem) = NULL;
+
+        CAMLreturn(Val_unit);
+}
+
+CAMLprim value stub_xenforeignmemory_map(value fmem, value dom,
+        value prot_flags, value pages)
+{
+        CAMLparam4(fmem, dom, prot_flags, pages);
+        CAMLlocal2(cell, result);
+        size_t i, pages_length;
+        xen_pfn_t *arr;
+        int prot, the_errno;
+        void *retval;
+
+        if (Field(prot_flags, 0) == Val_false &&
+            Field(prot_flags, 1) == Val_false &&
+            Field(prot_flags, 2) == Val_false) {
+                prot = PROT_NONE;
+        } else {
+                prot = 0;
+                if(Field(prot_flags, 0) == Val_true) {
+                        prot |= PROT_READ;
+                }
+                if(Field(prot_flags, 1) == Val_true) {
+                        prot |= PROT_WRITE;
+                }
+                if(Field(prot_flags, 2) == Val_true) {
+                        prot |= PROT_EXEC;
+                }
+        }
+
+        // traverse list to know the length of the array
+        cell = pages;
+        for(pages_length = 0; cell != Val_emptylist; pages_length++) {
+                cell = Field(cell, 1);
+        }
+
+        // allocate and populate the array
+        arr = malloc(sizeof(xen_pfn_t) * pages_length);
+        if(arr == NULL) {
+                caml_failwith("Error: could not allocate page array before mapping memory");
+        }
+
+        cell = pages;
+        for(i = 0; i < pages_length; i++) {
+                arr[i] = Int64_val(Field(cell, 0));
+                cell = Field(cell, 1);
+        }
+
+        retval = xenforeignmemory_map
+                (Xfm_val(fmem), _D(dom), prot, pages_length, arr, NULL);
+        the_errno = errno;
+
+        free(arr);
+
+        if(retval == NULL) {
+                raise_unix_errno_msg(the_errno,
+                                "Error when trying to map foreign memory");
+        }
+
+        result = caml_ba_alloc_dims(
+                        CAML_BA_CHAR | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL, 1,
+                        retval, (long) 4096 * pages_length);
+
+        CAMLreturn(result);
+}
+
+CAMLprim value stub_xenforeignmemory_unmap(value fmem, value mapping)
+{
+        CAMLparam2(fmem, mapping);
+        size_t pages;
+        int retval, the_errno;
+
+        // convert mapping to pages and addr
+        pages = Caml_ba_array_val(mapping)->dim[0] / 4096;
+
+        retval = xenforeignmemory_unmap(Xfm_val(fmem),
+                        Caml_ba_data_val(mapping), pages);
+        the_errno = errno;
+
+        if(retval < 0) {
+                raise_unix_errno_msg(the_errno,
+                                "Error when trying to unmap foreign memory");
+        }
+
+        CAMLreturn(Val_unit);
 }
 
 /*

--- a/ocaml/xenopsd/xc/dune
+++ b/ocaml/xenopsd/xc/dune
@@ -46,6 +46,7 @@
   xapi-xenopsd.c_stubs
   xapi-xenopsd-xc.c_stubs
   xenctrl
+  xentoollog
   xenstore
   xenstore_transport.unix
  )

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -78,3 +78,30 @@ external vcpu_setaffinity_soft : handle -> domid -> int -> bool array -> unit
 external numainfo : handle -> numainfo = "stub_xenctrlext_numainfo"
 
 external cputopoinfo : handle -> cputopo array = "stub_xenctrlext_cputopoinfo"
+
+module Xenforeignmemory : sig
+  type handle
+
+  type mapping =
+    (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+  type prot = {read: bool; write: bool; exec: bool}
+
+  val acquire : Xentoollog.handle option -> handle
+
+  val release : handle -> unit
+
+  val with_mapping :
+       handle
+    -> domid
+    -> prot
+    -> Int64.t list
+    -> ?on_unmap_failure:(string -> unit)
+    -> (mapping -> unit)
+    -> unit
+  (** [with_mapping handle domid prot pages ~on_unmap_failure f] maps the
+      [pages] in the domain [domid] to the current domain with the flags
+      [prot] and allows to use this memory as a bigarray inside the scope of
+      [f]. [on_memory_failure] may be defined to capture an unmap failure
+      after [f] goes out of scope. This is useful for logging, for example. *)
+end

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=517
+  N=518
   # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
   MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)

--- a/xapi-xenopsd-xc.opam
+++ b/xapi-xenopsd-xc.opam
@@ -46,6 +46,7 @@ depends: [
   "xenctrl"
   "xenstore"
   "xenstore_transport"
+  "xentoollog"
 ]
 synopsis:
   "A xenops plugin which knows how to use xenstore, xenctrl and xenguest to manage"


### PR DESCRIPTION
Adding these here, to xenctrlext instead of upstream allows us to iterate faster to adapt them to new features that we need.

Depends on https://github.com/xapi-project/xs-opam/pull/600 and https://github.com/xapi-project/xenctrl/pull/4