### PR TITLE
Hide credentials in repository configuration from log

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -144,7 +144,11 @@ let sync ~__context ~self ~token ~token_id =
       ; repo_name
       ]
     in
-    ignore (Helpers.call_script !Xapi_globs.yum_config_manager_cmd config_params) ;
+    ignore
+      (Helpers.call_script ~log_output:Helpers.On_failure
+         !Xapi_globs.yum_config_manager_cmd
+         config_params
+      ) ;
     (* sync with remote repository *)
     let sync_params =
       [


### PR DESCRIPTION
CA-362704: Hide proxy_username and proxy_password for repo proxy

This commit aims to hide the proxy_username and proxy_password of
repository from log file.

CA-362704: Remove credential related info from remote repository conf file

This commit removes credential related info from the remote repository
conf file as there might be proxy credentials (proxy_username and
proxy_password) and the temporary token file path in it.