### PR TITLE
Bugfix and improvement for repository GPG key

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1883,6 +1883,8 @@ let _ =
     () ;
   error Api_errors.invalid_base_url ["url"]
     ~doc:"The base url in the repository is invalid." () ;
+  error Api_errors.invalid_gpgkey_path ["gpgkey_path"]
+    ~doc:"The GPG public key file name in the repository is invalid." () ;
   error Api_errors.repository_already_exists ["ref"]
     ~doc:"The repository already exists." () ;
   error Api_errors.repository_is_in_use [] ~doc:"The repository is in use." () ;

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -3,9 +3,13 @@ let prototyped_of_class = function
       None
 
 let prototyped_of_field = function
+  | "Repository", "gpgkey_path" ->
+      Some "22.10.0-next"
   | _ ->
       None
 
 let prototyped_of_message = function
+  | "Repository", "set_gpgkey_path" ->
+      Some "22.10.0-next"
   | _ ->
       None

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "1c9bfd71d35514942662ad8973443aa1"
+let last_known_schema_hash = "5248cdbe333dd64ad01b9f94eb51baba"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/test_repository.ml
+++ b/ocaml/tests/test_repository.ml
@@ -19,10 +19,10 @@ let test_introduce_duplicate_name () =
   let name_label = "name" in
   let name_description = "description" in
   let name_description_1 = "description1" in
-  let binary_url = "https://binary-url.com" in
-  let binary_url_1 = "https://binary-url1.com" in
-  let source_url = "https://source-url.com" in
-  let source_url_1 = "https://source-url1.com" in
+  let binary_url = "https://repo.example.com" in
+  let binary_url_1 = "https://repo1.example.com" in
+  let source_url = "https://repo-src.example.com" in
+  let source_url_1 = "https://repo-src1.example.com" in
   let gpgkey_path = "" in
   let ref =
     Repository.introduce ~__context ~name_label ~name_description ~binary_url
@@ -43,9 +43,9 @@ let test_introduce_duplicate_binary_url () =
   let name_label_1 = "name1" in
   let name_description = "description" in
   let name_description_1 = "description1" in
-  let binary_url = "https://binary-url.com" in
-  let source_url = "https://source-url.com" in
-  let source_url_1 = "https://source-url1.com" in
+  let binary_url = "https://repo.example.com" in
+  let source_url = "https://repo-src.example.com" in
+  let source_url_1 = "https://repo-src1.example.com" in
   let gpgkey_path = "" in
   let ref =
     Repository.introduce ~__context ~name_label ~name_description ~binary_url
@@ -60,12 +60,39 @@ let test_introduce_duplicate_binary_url () =
       |> ignore
     )
 
+let test_introduce_invalid_gpgkey_path () =
+  let __context = T.make_test_database () in
+  let name_label = "name" in
+  let name_description = "description" in
+  let binary_url = "https://repo.example.com" in
+  let source_url = "https://repo-src.example.com" in
+  let gpgkey_path_1 = "../some-file" in
+  Alcotest.check_raises "test_introduce_invalid_gpgkey_path_1"
+    Api_errors.(Server_error (Api_errors.invalid_gpgkey_path, [gpgkey_path_1]))
+    (fun () ->
+      Repository.introduce ~__context ~binary_url ~name_label ~name_description
+        ~source_url ~update:false ~gpgkey_path:gpgkey_path_1
+      |> ignore
+    ) ;
+  let gpgkey_path_2 = "some.file" in
+  Alcotest.check_raises "test_introduce_invalid_gpgkey_path_2"
+    Api_errors.(Server_error (Api_errors.invalid_gpgkey_path, [gpgkey_path_2]))
+    (fun () ->
+      Repository.introduce ~__context ~binary_url ~name_label ~name_description
+        ~source_url ~update:false ~gpgkey_path:gpgkey_path_2
+      |> ignore
+    )
+
 let test =
   [
     ("test_introduce_duplicate_name", `Quick, test_introduce_duplicate_name)
   ; ( "test_introduce_duplicate_binary_url"
     , `Quick
     , test_introduce_duplicate_binary_url
+    )
+  ; ( "test_introduce_invalid_gpgkey_path"
+    , `Quick
+    , test_introduce_invalid_gpgkey_path
     )
   ]
 

--- a/ocaml/tests/test_repository.ml
+++ b/ocaml/tests/test_repository.ml
@@ -23,16 +23,17 @@ let test_introduce_duplicate_name () =
   let binary_url_1 = "https://binary-url1.com" in
   let source_url = "https://source-url.com" in
   let source_url_1 = "https://source-url1.com" in
+  let gpgkey_path = "" in
   let ref =
     Repository.introduce ~__context ~name_label ~name_description ~binary_url
-      ~source_url ~update:true
+      ~source_url ~update:true ~gpgkey_path
   in
   Alcotest.check_raises "test_introduce_duplicate_name"
     Api_errors.(Server_error (repository_already_exists, [Ref.string_of ref]))
     (fun () ->
       Repository.introduce ~__context ~name_label
         ~name_description:name_description_1 ~binary_url:binary_url_1
-        ~source_url:source_url_1 ~update:true
+        ~source_url:source_url_1 ~update:true ~gpgkey_path
       |> ignore
     )
 
@@ -45,16 +46,17 @@ let test_introduce_duplicate_binary_url () =
   let binary_url = "https://binary-url.com" in
   let source_url = "https://source-url.com" in
   let source_url_1 = "https://source-url1.com" in
+  let gpgkey_path = "" in
   let ref =
     Repository.introduce ~__context ~name_label ~name_description ~binary_url
-      ~source_url ~update:true
+      ~source_url ~update:true ~gpgkey_path
   in
   Alcotest.check_raises "test_introduce_duplicate_name"
     Api_errors.(Server_error (repository_already_exists, [Ref.string_of ref]))
     (fun () ->
       Repository.introduce ~__context ~binary_url ~name_label:name_label_1
         ~name_description:name_description_1 ~source_url:source_url_1
-        ~update:false
+        ~update:false ~gpgkey_path
       |> ignore
     )
 

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3546,7 +3546,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "repository-introduce"
     , {
         reqd= ["name-label"; "binary-url"; "source-url"; "update"]
-      ; optn= ["name-description"]
+      ; optn= ["name-description"; "gpgkey-path"]
       ; help= "Add the configuration for a new repository."
       ; implementation= No_fd Cli_operations.Repository.introduce
       ; flags= []
@@ -3558,6 +3558,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= []
       ; help= "Remove the repository record from the database."
       ; implementation= No_fd Cli_operations.Repository.forget
+      ; flags= []
+      }
+    )
+  ; ( "repository-set-gpgkey-path"
+    , {
+        reqd= ["uuid"; "gpgkey-path"]
+      ; optn= []
+      ; help= "Set the file name of the GPG public key."
+      ; implementation= No_fd Cli_operations.Repository.set_gpgkey_path
       ; flags= []
       }
     )

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1294,6 +1294,7 @@ let gen_cmds rpc session_id =
           ; "update"
           ; "hash"
           ; "up-to-date"
+          ; "gpgkey-path"
           ]
           rpc session_id
       )
@@ -7555,9 +7556,10 @@ module Repository = struct
     let binary_url = List.assoc "binary-url" params in
     let source_url = List.assoc "source-url" params in
     let update = get_bool_param params "update" in
+    let gpgkey_path = get_param params "gpgkey-path" ~default:"" in
     let ref =
       Client.Repository.introduce ~rpc ~session_id ~name_label ~name_description
-        ~binary_url ~source_url ~update
+        ~binary_url ~source_url ~update ~gpgkey_path
     in
     let uuid = Client.Repository.get_uuid ~rpc ~session_id ~self:ref in
     printer (Cli_printer.PList [uuid])
@@ -7567,4 +7569,12 @@ module Repository = struct
       Client.Repository.get_by_uuid rpc session_id (List.assoc "uuid" params)
     in
     Client.Repository.forget ~rpc ~session_id ~self:ref
+
+  let set_gpgkey_path printer rpc session_id params =
+    let ref =
+      Client.Repository.get_by_uuid rpc session_id (List.assoc "uuid" params)
+    in
+    let gpgkey_path = List.assoc "gpgkey-path" params in
+    Client.Repository.set_gpgkey_path ~rpc ~session_id ~self:ref
+      ~value:gpgkey_path
 end

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -4974,5 +4974,11 @@ let repository_record rpc session_id repository =
       ; make_field ~name:"up-to-date"
           ~get:(fun () -> string_of_bool (x ()).API.repository_up_to_date)
           ()
+      ; make_field ~name:"gpgkey-path"
+          ~get:(fun () -> (x ()).API.repository_gpgkey_path)
+          ~set:(fun x ->
+            Client.Repository.set_gpgkey_path rpc session_id repository x
+          )
+          ()
       ]
   }

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1227,6 +1227,8 @@ let configure_repositories_in_progress = "CONFIGURE_REPOSITORIES_IN_PROGRESS"
 
 let invalid_base_url = "INVALID_BASE_URL"
 
+let invalid_gpgkey_path = "INVALID_GPGKEY_PATH"
+
 let repository_already_exists = "REPOSITORY_ALREADY_EXISTS"
 
 let repository_is_in_use = "REPOSITORY_IS_IN_USE"

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6393,14 +6393,15 @@ functor
 
     module Repository = struct
       let introduce ~__context ~name_label ~name_description ~binary_url
-          ~source_url ~update =
+          ~source_url ~update ~gpgkey_path =
         info
           "Repository.introduce: name = '%s'; name_description = '%s'; \
-           binary_url = '%s'; source_url = '%s'; update = '%s'"
+           binary_url = '%s'; source_url = '%s'; update = '%s'; gpgkey_path = \
+           '%s'"
           name_label name_description binary_url source_url
-          (string_of_bool update) ;
+          (string_of_bool update) gpgkey_path ;
         Local.Repository.introduce ~__context ~name_label ~name_description
-          ~binary_url ~source_url ~update
+          ~binary_url ~source_url ~update ~gpgkey_path
 
       let forget ~__context ~self =
         info "Repository.forget: self = '%s'" (repository_uuid ~__context self) ;
@@ -6412,5 +6413,11 @@ functor
         do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
             Client.Repository.apply ~rpc ~session_id ~host
         )
+
+      let set_gpgkey_path ~__context ~self ~value =
+        info "Repository.set_gpgkey_path : repository='%s' value='%s'"
+          (repository_uuid ~__context self)
+          value ;
+        Local.Repository.set_gpgkey_path ~__context ~self ~value
     end
   end

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -362,7 +362,11 @@ let create_pool_repository ~__context ~self =
   match Sys.file_exists repo_dir with
   | true -> (
     try
-      ignore (Helpers.call_script !Xapi_globs.createrepo_cmd [repo_dir]) ;
+      let comps_file = Filename.concat repo_dir "comps.xml" in
+      ignore
+        (Helpers.call_script !Xapi_globs.createrepo_cmd
+           ["-g"; comps_file; repo_dir]
+        ) ;
       if Db.Repository.get_update ~__context ~self then
         let cachedir = get_repo_config repo_name "cachedir" in
         let md =

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -19,6 +19,7 @@ val introduce :
   -> binary_url:string
   -> source_url:string
   -> update:bool
+  -> gpgkey_path:string
   -> [`Repository] API.Ref.t
 
 val forget : __context:Context.t -> self:[`Repository] API.Ref.t -> unit
@@ -65,3 +66,6 @@ val apply_immediate_guidances :
 val set_available_updates : __context:Context.t -> string
 
 val reset_updates_in_cache : unit -> unit
+
+val set_gpgkey_path :
+  __context:Context.t -> self:[`Repository] API.Ref.t -> value:string -> unit

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1319,8 +1319,8 @@ let other_options =
   ; ( "repository-gpgkey-name"
     , Arg.Set_string repository_gpgkey_name
     , (fun () -> !repository_gpgkey_name)
-    , "The name of gpg key used by RPM to verify metadata and packages in \
-       repository"
+    , "The default name of gpg key file used by YUM and RPM to verify metadata \
+       and packages in repository"
     )
   ; ( "failed-login-alert-freq"
     , Arg.Set_int failed_login_alert_freq


### PR DESCRIPTION
CA-364450: Fix YUM repo config for repo metadata checking

The '--setopt' of yum-config-manager requires specifying the repo name.
The bug fixed in this commit is '--setopt=repo_gpgcheck=1' should be
'--setopt=<repo-name>.repo_gpgcheck=1' in parameter of
'yum-config-manager'.

In this commit, additionally the `repo_gpgcheck` is moved to the initial
repo configuration file content which contains static configurations
usually.

CP-39209: Add new field 'gpgkey_name' in repository object

Prior to this series, the GPG key file name is coded as a global
configuration of XAPI. This will get the GPG key rotation difficult in
future.

This commit changes the configuration into XAPI repository object so
that it could be changed through XAPI API.

CP-39209: Use GPG key file path from repository object

Given the gpgkey name has been stored in repository object, this commit
retrieves the gpgkey name from the repository object rather than a
global XAPI configuration.

The global XAPI configuration now is a default one for backward
compatibility