### PR TITLE
Add pool.set_wlb_enabled permission for client auth

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1159,7 +1159,9 @@ let t =
         ; field ~in_product_since:rel_george ~internal_only:true
             ~qualifier:DynamicRO ~ty:(Ref _secret) "wlb_password"
             "Password for accessing the workload balancing host"
-        ; field ~in_product_since:rel_george ~qualifier:RW ~ty:Bool
+        ; field
+            ~writer_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)
+            ~in_product_since:rel_george ~qualifier:RW ~ty:Bool
             ~default_value:(Some (VBool false)) "wlb_enabled"
             "true if workload balancing is enabled on the pool, false otherwise"
         ; field ~in_product_since:rel_george ~qualifier:RW ~ty:Bool

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "8ae84546b95daaeef2bd0639c734e9e8"
+let last_known_schema_hash = "1c9bfd71d35514942662ad8973443aa1"
 
 let current_schema_hash : string =
   let open Datamodel_types in


### PR DESCRIPTION
Authentication with client certificate requires permission to run
'pool.set_wlb_enabled'. This commit is just for this.

Signed-off-by: Ming Lu <ming.lu@citrix.com>