### PR TITLE
Add [post|put]_services_xenops to client auth permission list

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8081,10 +8081,22 @@ let http_actions =
     , (Get, Constants.xenops_uri, false, [], _R_VM_POWER_ADMIN, [])
     )
   ; ( "post_services_xenops"
-    , (Post, Constants.xenops_uri, false, [], _R_VM_POWER_ADMIN, [])
+    , ( Post
+      , Constants.xenops_uri
+      , false
+      , []
+      , _R_VM_POWER_ADMIN ++ _R_CLIENT_CERT
+      , []
+      )
     )
   ; ( "put_services_xenops"
-    , (Put, Constants.xenops_uri, false, [], _R_VM_POWER_ADMIN, [])
+    , ( Put
+      , Constants.xenops_uri
+      , false
+      , []
+      , _R_VM_POWER_ADMIN ++ _R_CLIENT_CERT
+      , []
+      )
     )
   ; ( "get_services_sm"
     , (Get, Constants.sm_uri, false, [], _R_VM_POWER_ADMIN, [])


### PR DESCRIPTION
These two methods are used when performing VM.pool_migrate to
migrate VMs from member hosts to coordinator host.

The clients authenticated with certificates require permission to use
these methods. This commit extends the permission list of client auth
with these two methods.

Signed-off-by: Ming Lu <ming.lu@citrix.com>