### PR TITLE
maintenance: avoid using deprecated functions

### DIFF
--- a/ocaml/message-switch/switch/q.ml
+++ b/ocaml/message-switch/switch/q.ml
@@ -247,7 +247,7 @@ module Op = struct
   let to_cstruct t =
     let s = sexp_of_t t |> Sexplib.Sexp.to_string in
     let c = Cstruct.create (String.length s) in
-    Cstruct.blit_from_string s 0 c 0 (Cstruct.len c) ;
+    Cstruct.blit_from_string s 0 c 0 (Cstruct.length c) ;
     c
 end
 

--- a/ocaml/vhd-tool/src/channels.ml
+++ b/ocaml/vhd-tool/src/channels.ml
@@ -123,12 +123,12 @@ let of_raw_fd fd =
   let offset = ref 0L in
   let really_read buf =
     IO.complete "read" (Some !offset) Lwt_bytes.read fd buf >>= fun () ->
-    (offset := Int64.(add !offset (of_int (Cstruct.len buf)))) ;
+    (offset := Int64.(add !offset (of_int (Cstruct.length buf)))) ;
     return ()
   in
   let really_write buf =
     IO.complete "write" (Some !offset) Lwt_bytes.write fd buf >>= fun () ->
-    (offset := Int64.(add !offset (of_int (Cstruct.len buf)))) ;
+    (offset := Int64.(add !offset (of_int (Cstruct.length buf)))) ;
     return ()
   in
   let skip _ = fail Impossible_to_seek in
@@ -169,13 +169,13 @@ let of_ssl_fd fd good_ciphersuites =
   let offset = ref 0L in
   let really_read buf =
     IO.complete "read" (Some !offset) Lwt_ssl.read_bytes sock buf >>= fun () ->
-    (offset := Int64.(add !offset (of_int (Cstruct.len buf)))) ;
+    (offset := Int64.(add !offset (of_int (Cstruct.length buf)))) ;
     return ()
   in
   let really_write buf =
     IO.complete "write" (Some !offset) Lwt_ssl.write_bytes sock buf
     >>= fun () ->
-    (offset := Int64.(add !offset (of_int (Cstruct.len buf)))) ;
+    (offset := Int64.(add !offset (of_int (Cstruct.length buf)))) ;
     return ()
   in
   let skip _ = fail Impossible_to_seek in

--- a/ocaml/vhd-tool/src/chunked.ml
+++ b/ocaml/vhd-tool/src/chunked.ml
@@ -23,7 +23,7 @@ type t = {
 
 let marshal (buf : Cstruct.t) t =
   set_t_offset buf t.offset ;
-  set_t_len buf (Int32.of_int (Cstruct.len t.data))
+  set_t_len buf (Int32.of_int (Cstruct.length t.data))
 
 let is_last_chunk (buf : Cstruct.t) =
   get_t_offset buf = 0L && get_t_len buf = 0l

--- a/ocaml/vhd-tool/src/iO.ml
+++ b/ocaml/vhd-tool/src/iO.ml
@@ -21,7 +21,7 @@ let complete name offset op fd buffer =
   if !debug_io then
     Printf.fprintf stderr "%s offset=%s length=%d\n%!" name
       (match offset with Some x -> Int64.to_string x | None -> "None")
-      (Cstruct.len buffer) ;
+      (Cstruct.length buffer) ;
   let open Lwt in
   let ofs = buffer.Cstruct.off in
   let len = buffer.Cstruct.len in

--- a/ocaml/vhd-tool/src/impl.ml
+++ b/ocaml/vhd-tool/src/impl.ml
@@ -32,7 +32,7 @@ module Channel_In = Vhd_format.F.From_input (struct
         return ()
       else
         let this =
-          Int64.(to_int (min (of_int (Cstruct.len scratch)) remaining))
+          Int64.(to_int (min (of_int (Cstruct.length scratch)) remaining))
         in
         let frag = Cstruct.sub scratch 0 this in
         read c frag >>= fun () -> drop Int64.(sub remaining (of_int this))
@@ -122,7 +122,8 @@ let contents _common filename =
             | Fragment.Batmap _x ->
                 Printf.printf "batmap\n"
             | Fragment.Block (offset, buffer) ->
-                Printf.printf "Block %Ld (len %d)\n" offset (Cstruct.len buffer)
+                Printf.printf "Block %Ld (len %d)\n" offset
+                  (Cstruct.length buffer)
             ) ;
             tl () >>= fun x -> loop x
       in
@@ -253,7 +254,7 @@ let stream_nbd _common c s prezeroed _ ?(progress = no_progress_bar) () =
       | `Sectors data -> (
           Client.write server (Int64.mul sector 512L) [data] >>= function
           | Ok () ->
-              return Int64.(of_int (Cstruct.len data))
+              return Int64.(of_int (Cstruct.length data))
           | Error _e ->
               fail (Failure "Got error from NBD library")
         )
@@ -305,7 +306,7 @@ let stream_chunked _common c s prezeroed _ ?(progress = no_progress_bar) () =
           Chunked.marshal header t ;
           c.Channels.really_write header >>= fun () ->
           c.Channels.really_write data >>= fun () ->
-          return Int64.(of_int (Cstruct.len data))
+          return Int64.(of_int (Cstruct.length data))
       | `Empty _n ->
           (* must be prezeroed *)
           assert prezeroed ;
@@ -358,7 +359,7 @@ let stream_raw _common c s prezeroed _ ?(progress = no_progress_bar) () =
           c.Channels.copy_from fd (Int64.mul 512L sector_len)
       | `Sectors data ->
           c.Channels.really_write data >>= fun () ->
-          return Int64.(of_int (Cstruct.len data))
+          return Int64.(of_int (Cstruct.length data))
       | `Empty n ->
           (* must be prezeroed *)
           c.Channels.skip Int64.(mul n 512L) >>= fun () ->
@@ -429,7 +430,7 @@ let stream_tar _common c s _ prefix ?(progress = no_progress_bar) () =
   let block_size = 1024 * 1024 in
   let header = IO.alloc Tar.Header.length in
   let zeroes = IO.alloc block_size in
-  for i = 0 to Cstruct.len zeroes - 1 do
+  for i = 0 to Cstruct.length zeroes - 1 do
     Cstruct.set_uint8 zeroes i 0
   done ;
   (* This undercounts by missing the tar headers and occasional empty sector *)
@@ -443,7 +444,7 @@ let stream_tar _common c s _ prefix ?(progress = no_progress_bar) () =
   (* Write [data] to the tar-format stream currnetly in [state] *)
   let rec input state data =
     (* Write as much as we can into the current file *)
-    let len = Cstruct.len data in
+    let len = Cstruct.length data in
     let this_block_len = min len state.nr_bytes_remaining in
     let this_block = Cstruct.sub data 0 this_block_len in
     sha1_update_cstruct state.ctx this_block ;
@@ -479,7 +480,7 @@ let stream_tar _common c s _ prefix ?(progress = no_progress_bar) () =
     )
     >>= fun state ->
     (* If we have unwritten data then output the next header *)
-    ( if nr_bytes_remaining = 0 && Cstruct.len rest > 0 then (
+    ( if nr_bytes_remaining = 0 && Cstruct.length rest > 0 then (
         (* XXX the last block might be smaller than block_size *)
         let hdr = make_tar_header prefix state.next_counter "" block_size in
         Tar.Header.marshal header hdr ;
@@ -495,7 +496,7 @@ let stream_tar _common c s _ prefix ?(progress = no_progress_bar) () =
         return {state with nr_bytes_remaining}
     )
     >>= fun state ->
-    if Cstruct.len rest > 0 then
+    if Cstruct.length rest > 0 then
       input state rest
     else
       return state
@@ -503,7 +504,7 @@ let stream_tar _common c s _ prefix ?(progress = no_progress_bar) () =
 
   let rec empty state bytes =
     let write state bytes =
-      let this = Int64.(to_int (min bytes (of_int (Cstruct.len zeroes)))) in
+      let this = Int64.(to_int (min bytes (of_int (Cstruct.length zeroes)))) in
       input state (Cstruct.sub zeroes 0 this) >>= fun state ->
       empty state Int64.(sub bytes (of_int this))
     in
@@ -711,7 +712,7 @@ let serve_tar_to_raw total_size c dest prezeroed progress expected_prefix
             (* XXX: prezeroed? *)
             let rec copy offset remaining =
               let this =
-                Int64.(to_int (min remaining (of_int (Cstruct.len buffer))))
+                Int64.(to_int (min remaining (of_int (Cstruct.length buffer))))
               in
               let block = Cstruct.sub buffer 0 this in
               c.Channels.really_read block >>= fun () ->
@@ -1251,7 +1252,7 @@ let serve_raw_to_raw common size c dest _ progress _ _ =
   let buffer = IO.alloc twomib in
   let p = progress size in
   let rec loop offset remaining =
-    let n = Int64.(to_int (min remaining (of_int (Cstruct.len buffer)))) in
+    let n = Int64.(to_int (min remaining (of_int (Cstruct.length buffer)))) in
     let rounded_n = round_up_to_sector common.unbuffered n in
     (* Create a buffer of the rounded-up size *)
     let block = Cstruct.sub buffer 0 rounded_n in

--- a/ocaml/vhd-tool/src/input.ml
+++ b/ocaml/vhd-tool/src/input.ml
@@ -30,7 +30,7 @@ let of_fd fd =
 
 let read fd buf =
   IO.complete "read" (Some fd.offset) Lwt_bytes.read fd.fd buf >>= fun () ->
-  fd.offset <- Int64.(add fd.offset (of_int (Cstruct.len buf))) ;
+  fd.offset <- Int64.(add fd.offset (of_int (Cstruct.length buf))) ;
   return ()
 
 let skip_to fd n =
@@ -39,7 +39,7 @@ let skip_to fd n =
     if remaining = 0L then
       return ()
     else
-      let this = Int64.(to_int (min remaining (of_int (Cstruct.len buf)))) in
+      let this = Int64.(to_int (min remaining (of_int (Cstruct.length buf)))) in
       let frag = Cstruct.sub buf 0 this in
       IO.complete "read" (Some fd.offset) Lwt_bytes.read fd.fd frag
       >>= fun () ->

--- a/ocaml/xapi-aux/tar_helpers.ml
+++ b/ocaml/xapi-aux/tar_helpers.ml
@@ -35,9 +35,9 @@ let rec _really_input fd buf off = function
 let really_input = with_restart _really_input
 
 let really_read ifd buffer =
-  let s = Bytes.create (Cstruct.len buffer) in
-  really_input ifd s 0 (Cstruct.len buffer) ;
-  Cstruct.blit_from_bytes s 0 buffer 0 (Cstruct.len buffer)
+  let s = Bytes.create (Cstruct.length buffer) in
+  really_input ifd s 0 (Cstruct.length buffer) ;
+  Cstruct.blit_from_bytes s 0 buffer 0 (Cstruct.length buffer)
 
 let skip ifd n =
   let buffer = Cstruct.create 4096 in
@@ -45,7 +45,7 @@ let skip ifd n =
     if n <= 0 then
       ()
     else
-      let amount = min n (Cstruct.len buffer) in
+      let amount = min n (Cstruct.length buffer) in
       really_read ifd (Cstruct.sub buffer 0 amount) ;
       loop (n - amount)
   in

--- a/ocaml/xapi-guard/src/varstored_interface.ml
+++ b/ocaml/xapi-guard/src/varstored_interface.ml
@@ -156,7 +156,7 @@ let with_xapi f =
  * Try actually connecting: the file could be present but nobody listening on the other side.
  * *)
 let rec wait_for_file_to_appear path =
-  Lwt_unix.yield () >>= fun () ->
+  Lwt.pause () >>= fun () ->
   Lwt.try_bind
     (fun () ->
       Conduit_lwt_unix.connect ~ctx:Conduit_lwt_unix.default_ctx

--- a/ocaml/xcp-rrdd/lib/transport/base/rrd_reader_functor.ml
+++ b/ocaml/xcp-rrdd/lib/transport/base/rrd_reader_functor.ml
@@ -42,7 +42,7 @@ module Make (T : TRANSPORT) = struct
     let read_payload () =
       if !is_open then
         let cs =
-          if Cstruct.len (T.expose !state) <= 0 then
+          if Cstruct.length (T.expose !state) <= 0 then
             state := T.init id ;
           T.expose !state
         in

--- a/ocaml/xcp-rrdd/lib/transport/file/rrd_file_writer.ml
+++ b/ocaml/xcp-rrdd/lib/transport/file/rrd_file_writer.ml
@@ -43,7 +43,7 @@ module File = struct
   (** This assumes there's no limit to the size of file which can be used. *)
   let get_allocator cstruct =
     let alloc_cstruct size =
-      if size > Cstruct.len cstruct then
+      if size > Cstruct.length cstruct then
         failwith "not enough memory" ;
       cstruct
     in

--- a/ocaml/xcp-rrdd/lib/transport/page/rrd_page_writer.ml
+++ b/ocaml/xcp-rrdd/lib/transport/page/rrd_page_writer.ml
@@ -43,7 +43,7 @@ module Page = struct
   let get_allocator share =
     let alloc_cstruct size =
       let c = Io_page.to_cstruct share.Gntshr.mapping in
-      if size > Cstruct.len c then
+      if size > Cstruct.length c then
         failwith "not enough memory" ;
       c
     in

--- a/ocaml/xen-api-client/lwt/data_channel.ml
+++ b/ocaml/xen-api-client/lwt/data_channel.ml
@@ -54,7 +54,7 @@ let of_unseekable_fd fd =
     complete "write" (Some !really_write_offset) Lwt_bytes.write fd buf
     >>= fun () ->
     (really_write_offset :=
-       Int64.(add !really_write_offset (of_int (Cstruct.len buf)))
+       Int64.(add !really_write_offset (of_int (Cstruct.length buf)))
     ) ;
     return ()
   in
@@ -86,7 +86,7 @@ let of_ssl_fd fd =
     complete "write" (Some !really_write_offset) Lwt_ssl.write_bytes sock buf
     >>= fun () ->
     (really_write_offset :=
-       Int64.(add !really_write_offset (of_int (Cstruct.len buf)))
+       Int64.(add !really_write_offset (of_int (Cstruct.length buf)))
     ) ;
     return ()
   in

--- a/ocaml/xen-api-client/lwt_examples/upload_disk.ml
+++ b/ocaml/xen-api-client/lwt_examples/upload_disk.ml
@@ -62,7 +62,7 @@ let main filename =
               in
               ic.Data_channel.really_read block >>= fun () ->
               oc.Data_channel.really_write block >>= fun () ->
-              copy Int64.(sub remaining (of_int (Cstruct.len block)))
+              copy Int64.(sub remaining (of_int (Cstruct.length block)))
           in
           copy virtual_size >>= fun () ->
           oc.Data_channel.close () >>= fun () -> ic.Data_channel.close ()


### PR DESCRIPTION
These were introduced by the xs-opam update:
- Cstruct.len : just rename the function to Cstruct.len
- Lwt_unix.yield : the platform-independent Lwt.pause should be used instead