### PR TITLE
CP-38626:Allow manipulation of VTPM contents

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8025,6 +8025,7 @@ let expose_get_all_messages_for =
   ; _cluster_host
   ; _certificate
   ; _repository
+  ; _vtpm
   ]
 
 let no_task_id_for = [_task; (* _alert; *) _event]

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5012,23 +5012,6 @@ module Role = struct
       ()
 end
 
-module VTPM = struct
-  let t =
-    create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303
-      ~internal_deprecated_since:None ~persist:PersistEverything
-      ~gen_constructor_destructor:true ~name:_vtpm ~descr:"A virtual TPM device"
-      ~gen_events:false ~doccomments:[]
-      ~messages_default_allowed_roles:_R_VM_ADMIN ~messages:[]
-      ~contents:
-        [
-          uid _vtpm
-        ; field ~qualifier:StaticRO ~ty:(Ref _vm) "VM" "the virtual machine"
-        ; field ~qualifier:StaticRO ~ty:(Ref _vm) "backend"
-            "the domain where the backend is located"
-        ]
-      ()
-end
-
 module Console = struct
   (** Console protocols *)
   let protocol =
@@ -7783,7 +7766,7 @@ let all_system =
   ; PBD.t
   ; Crashdump.t
   ; (* misc *)
-    VTPM.t
+    Datamodel_vtpm.t
   ; Console.t
   ; (* filesystem; *)
     User.t

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -9,7 +9,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 711
+let schema_minor_vsn = 712
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2113,6 +2113,11 @@ let t =
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
             "The set of pending guidances after applying updates"
+        ; field ~qualifier:StaticRO ~in_product_since:rel_next
+            ~ty:(Map (String, String))
+            ~default_value:(Some (VMap [])) "default_vtpm_profile"
+            "The security properties that will be used by default when \
+             creating a TPMs attached to the VM / template"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -16,17 +16,47 @@ open Datamodel_types
 open Datamodel_common
 open Datamodel_roles
 
+let get_contents =
+  call ~name:"get_contents" ~in_product_since:"rel_next"
+    ~doc:"Obtain the contents of the TPM" ~secret:true
+    ~params:[(Ref _vtpm, "self", "The VTPM reference")]
+    ~result:(String, "The contents") ~hide_from_docs:true
+    ~allowed_roles:_R_LOCAL_ROOT_ONLY ()
+
+let set_contents =
+  call ~name:"set_contents" ~in_product_since:"rel_next"
+    ~doc:"Introduce new contents for the TPM" ~secret:true
+    ~params:
+      [
+        (Ref _vtpm, "self", "The VTPM reference")
+      ; (String, "contents", "The new contents")
+      ]
+    ~hide_from_docs:true ~allowed_roles:_R_LOCAL_ROOT_ONLY ()
+
 let t =
   create_obj ~in_db:true ~in_oss_since:oss_since_303 ~persist:PersistEverything
-    ~lifecycle:[(Published, rel_rio, "Added VTPM stub")]
+    ~lifecycle:
+      [
+        (Published, rel_rio, "Added VTPM stub")
+      ; (Extended, rel_next, "Added ability to manipulate contents")
+      ; (Extended, rel_next, "Added VTPM profiles")
+      ; (Changed, rel_next, "Removed backend field")
+      ]
     ~gen_constructor_destructor:true ~name:_vtpm ~descr:"A virtual TPM device"
     ~gen_events:false ~doccomments:[]
-    ~messages_default_allowed_roles:_R_VM_ADMIN ~messages:[]
+    ~messages_default_allowed_roles:_R_POOL_ADMIN
     ~contents:
       [
         uid _vtpm
-      ; field ~qualifier:StaticRO ~ty:(Ref _vm) "VM" "the virtual machine"
-      ; field ~qualifier:StaticRO ~ty:(Ref _vm) "backend"
-          "the domain where the backend is located"
+      ; field ~qualifier:StaticRO ~ty:(Ref _vm) "VM"
+          "The virtual machine the TPM is attached to"
+      ; field ~qualifier:DynamicRO
+          ~ty:(Map (String, String))
+          ~lifecycle:[(Published, rel_next, "Added VTPM profiles")]
+          "profile" "The security properties that define how the TPM is handled"
+      ; field ~qualifier:DynamicRO ~ty:(Ref _secret) ~internal_only:true
+          ~lifecycle:[(Published, rel_next, "Added VTPM contents")]
+          "contents" "The contents of the TPM"
       ]
+    ~messages:[get_contents; set_contents]
     ()

--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -1,0 +1,32 @@
+(*
+   Copyright (C) Citrix Systems Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+open Datamodel_types
+open Datamodel_common
+open Datamodel_roles
+
+let t =
+  create_obj ~in_db:true ~in_oss_since:oss_since_303 ~persist:PersistEverything
+    ~lifecycle:[(Published, rel_rio, "Added VTPM stub")]
+    ~gen_constructor_destructor:true ~name:_vtpm ~descr:"A virtual TPM device"
+    ~gen_events:false ~doccomments:[]
+    ~messages_default_allowed_roles:_R_VM_ADMIN ~messages:[]
+    ~contents:
+      [
+        uid _vtpm
+      ; field ~qualifier:StaticRO ~ty:(Ref _vm) "VM" "the virtual machine"
+      ; field ~qualifier:StaticRO ~ty:(Ref _vm) "backend"
+          "the domain where the backend is located"
+      ]
+    ()

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -5,7 +5,8 @@
     datamodel_errors datamodel_roles datamodel_vm datamodel_host
     datamodel_pool datamodel_cluster datamodel_cluster_host dm_api escaping
     datamodel_values datamodel_schema datamodel_certificate
-    datamodel_diagnostics datamodel_repository datamodel_lifecycle)
+    datamodel_diagnostics datamodel_repository datamodel_lifecycle
+    datamodel_vtpm)
   (flags (:standard -warn-error +a-3-4-6-9-27-28-29))
   (libraries
     ppx_sexp_conv.runtime-lib

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "8ae84546b95daaeef2bd0639c734e9e8"
+let last_known_schema_hash = "86da35f0d2370c16c866b116f241a6f0"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -144,7 +144,7 @@ let make_vm ~__context ?(name_label = "name_label")
     ?(hardware_platform_version = 0L) ?(has_vendor_device = false)
     ?(has_vendor_device = false) ?(reference_label = "") ?(domain_type = `hvm)
     ?(nVRAM = []) ?(last_booted_record = "") ?(last_boot_CPU_flags = [])
-    ?(power_state = `Halted) () =
+    ?(power_state = `Halted) ?(default_vtpm_profile = []) () =
   Xapi_vm.create ~__context ~name_label ~name_description ~user_version
     ~is_a_template ~affinity ~memory_target ~memory_static_max
     ~memory_dynamic_max ~memory_dynamic_min ~memory_static_min ~vCPUs_params
@@ -157,7 +157,7 @@ let make_vm ~__context ?(name_label = "name_label")
     ~start_delay ~shutdown_delay ~order ~suspend_SR ~suspend_VDI
     ~snapshot_schedule ~is_vmss_snapshot ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~reference_label ~domain_type
-    ~last_booted_record ~last_boot_CPU_flags ~power_state
+    ~last_booted_record ~last_boot_CPU_flags ~default_vtpm_profile ~power_state
 
 let make_host ~__context ?(uuid = make_uuid ()) ?(name_label = "host")
     ?(name_description = "description") ?(hostname = "localhost")

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1297,6 +1297,10 @@ let gen_cmds rpc session_id =
           ]
           rpc session_id
       )
+    ; Client.VTPM.(
+        mk () get_all_records_where get_by_uuid vtpm_record "vtpm" []
+          ["uuid"; "vm"; "profile"] rpc session_id
+      )
     ]
 
 let message_create printer rpc session_id params =

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -2660,7 +2660,7 @@ let vm_create printer rpc session_id params =
       ~suspend_VDI:Ref.null ~version:0L ~generation_id:""
       ~hardware_platform_version:0L ~has_vendor_device:false ~reference_label:""
       ~domain_type:`unspecified ~nVRAM:[] ~last_booted_record:""
-      ~last_boot_CPU_flags:[] ~power_state:`Halted
+      ~last_boot_CPU_flags:[] ~default_vtpm_profile:[] ~power_state:`Halted
   in
   let uuid = Client.VM.get_uuid rpc session_id vm in
   printer (Cli_printer.PList [uuid])

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2431,6 +2431,14 @@ let vm_record rpc session_id vm =
               (x ()).API.vM_pending_guidances
           )
           ()
+      ; make_field ~name:"vtpm"
+          ~get:(fun () -> get_uuids_from_refs (x ()).API.vM_VTPMs)
+          ()
+      ; make_field ~name:"default_vtpm_profile"
+          ~get:(fun () ->
+            Record_util.s2sm_to_string "; " (x ()).API.vM_default_vtpm_profile
+          )
+          ()
       ]
   }
 
@@ -4973,6 +4981,40 @@ let repository_record rpc session_id repository =
       ; make_field ~name:"hash" ~get:(fun () -> (x ()).API.repository_hash) ()
       ; make_field ~name:"up-to-date"
           ~get:(fun () -> string_of_bool (x ()).API.repository_up_to_date)
+          ()
+      ]
+  }
+
+let vtpm_record rpc session_id vtpm =
+  let _ref = ref vtpm in
+  let empty_record =
+    ToGet (fun () -> Client.VTPM.get_record rpc session_id !_ref)
+  in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  {
+    setref=
+      (fun r ->
+        _ref := r ;
+        record := empty_record
+      )
+  ; setrefrec=
+      (fun (a, b) ->
+        _ref := a ;
+        record := Got b
+      )
+  ; record= x
+  ; getref= (fun () -> !_ref)
+  ; fields=
+      [
+        make_field ~name:"uuid" ~get:(fun () -> (x ()).API.vTPM_uuid) ()
+      ; make_field ~name:"vm"
+          ~get:(fun () -> get_uuid_from_ref (x ()).API.vTPM_VM)
+          ()
+      ; make_field ~name:"profile"
+          ~get:(fun () ->
+            Record_util.s2sm_to_string "; " (x ()).API.vTPM_profile
+          )
           ()
       ]
   }

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -80,14 +80,10 @@ module Actions = struct
 
   module Data_source = struct end
 
+  module VTPM = Xapi_vtpm
+
   let not_implemented x =
     raise (Api_errors.Server_error (Api_errors.not_implemented, [x]))
-
-  module VTPM = struct
-    let create ~__context ~vM ~backend = not_implemented "VTPM.create"
-
-    let destroy ~__context ~self = not_implemented "VTPM.destroy"
-  end
 
   module Console = struct
     let create ~__context ~other_config = not_implemented "Console.create"

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -329,7 +329,7 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info : host_info
     ~version:0L ~generation_id:"" ~hardware_platform_version:0L
     ~has_vendor_device:false ~requires_reboot:false ~reference_label:""
     ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[]
-    ~pending_guidances:[] ;
+    ~pending_guidances:[] ~default_vtpm_profile:[] ;
   ensure_domain_zero_metrics_record ~__context ~domain_zero_ref host_info ;
   Db.Host.set_control_domain ~__context ~self:localhost ~value:domain_zero_ref ;
   Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -632,7 +632,7 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~is_snapshot_from_vmpp ~snapshot_schedule ~is_vmss_snapshot ~appliance
     ~start_delay ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~reference_label ~domain_type
-    ~nVRAM : API.ref_VM =
+    ~nVRAM ~default_vtpm_profile : API.ref_VM =
   if has_vendor_device then
     Pool_features.assert_enabled ~__context
       ~f:Features.PCI_device_for_auto_update ;
@@ -713,7 +713,7 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~snapshot_schedule:Ref.null ~is_vmss_snapshot:false ~appliance ~start_delay
     ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~requires_reboot:false
-    ~reference_label ~domain_type ~pending_guidances:[] ;
+    ~reference_label ~domain_type ~pending_guidances:[] ~default_vtpm_profile ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -203,6 +203,7 @@ val create :
   -> reference_label:string
   -> domain_type:API.domain_type
   -> nVRAM:(string * string) list
+  -> default_vtpm_profile:(string * string) list
   -> API.ref_VM
 
 val destroy : __context:Context.t -> self:[`VM] Ref.t -> unit

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -392,7 +392,8 @@ let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~has_vendor_device:all.Db_actions.vM_has_vendor_device
     ~requires_reboot:false ~reference_label:all.Db_actions.vM_reference_label
     ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM
-    ~pending_guidances:[] ;
+    ~pending_guidances:[]
+    ~default_vtpm_profile:all.Db_actions.vM_default_vtpm_profile ;
   (* update the VM's parent field in case of snapshot. Note this must be done after "ref"
      	   has been created, so that its "children" field can be updated by the database layer *)
   ( match disk_op with

--- a/ocaml/xapi/xapi_vtpm.ml
+++ b/ocaml/xapi/xapi_vtpm.ml
@@ -1,0 +1,41 @@
+(*
+   Copyright (C) Citrix Systems Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+let introduce ~__context ~uuid ~vM ~profile ~contents =
+  let ref = Ref.make () in
+  Db.VTPM.create ~__context ~ref ~uuid ~vM ~profile ~contents ;
+  ref
+
+let create ~__context ~vM =
+  let uuid = Uuid.(to_string (make_uuid ())) in
+  let profile = Db.VM.get_default_vtpm_profile ~__context ~self:vM in
+  let contents = Xapi_secret.create ~__context ~value:"" ~other_config:[] in
+  let ref = introduce ~__context ~uuid ~vM ~profile ~contents in
+  ref
+
+let destroy ~__context ~self =
+  let secret = Db.VTPM.get_contents ~__context ~self in
+  Db.Secret.destroy ~__context ~self:secret ;
+  Db.VTPM.destroy ~__context ~self
+
+let get_contents ~__context ~self =
+  let secret = Db.VTPM.get_contents ~__context ~self in
+  Base64.decode_exn (Db.Secret.get_value ~__context ~self:secret)
+
+let set_contents ~__context ~self ~contents =
+  let previous_secret = Db.VTPM.get_contents ~__context ~self in
+  let encoded = Base64.encode_exn contents in
+  let secret = Xapi_secret.create ~__context ~value:encoded ~other_config:[] in
+  Db.VTPM.set_contents ~__context ~self ~value:secret ;
+  Db.Secret.destroy ~__context ~self:previous_secret

--- a/ocaml/xapi/xapi_vtpm.mli
+++ b/ocaml/xapi/xapi_vtpm.mli
@@ -1,0 +1,22 @@
+(*
+   Copyright (C) Citrix Systems Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+val create : __context:Context.t -> vM:[`VM] API.Ref.t -> [`VTPM] Ref.t
+
+val destroy : __context:Context.t -> self:[`VTPM] Ref.t -> unit
+
+val get_contents : __context:Context.t -> self:[`VTPM] Ref.t -> string
+
+val set_contents :
+  __context:Context.t -> self:[`VTPM] Ref.t -> contents:string -> unit

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=518
+  N=519
   # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
   MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)


### PR DESCRIPTION
This is restricted to local access only, through the UNIX socket.

This allows the software TPM daemon to retrieve and push the contents of
the TPM from and to the xapi database.

Any remote accesses to the contents are forbidden