### PR TITLE
CA-365112: Permit pool admin username with space to ssh login

### DIFF
--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -172,20 +172,21 @@ class DynamicPam(ADConfig):
                 self._add_subject(subject_rec)
 
     def _format_item(self, item):
-        # CA-363207: Pam cannot handle space, put it inside []
         space_replacement = "+"
         if space_replacement in item:
             raise ValueError(
                 "{} is not permitted in subject name".format(space_replacement))
 
-        if " " in item:
-            if self._backend == ADBackend.bd_pbis:
-                # PBIS relace space with "+", eg "ab  cd" -> "ab++cd"
-                # PBIS pam module will reverse it back
-                return item.replace(" ", space_replacement)
-            # winbind put name with space within "[]"
-            return "[{}]".format(item)
-        return item
+        if " " not in item:
+            return item
+
+        if self._backend == ADBackend.bd_pbis:
+            # PBIS relace space with "+", eg "ab  cd" -> "ab++cd"
+            # PBIS pam module will reverse it back
+            return item.replace(" ", space_replacement)
+
+        # winbind put name with space within "[]"
+        return "[{}]".format(item)
 
     def _add_subject(self, subject_rec):
         try:

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -27,16 +27,20 @@ from enum import Enum
 # - /etc/pam.d/hcp_users
 # - /etc/ssh/ssh_config
 
-#pylint: disable=super-with-arguments
+# pylint: disable=super-with-arguments
+
 
 def setup_logger():
     logger = logging.getLogger()
-    logging.basicConfig(format='%(asctime)s %(levelname)s %(name)s %(funcName)s %(message)s', level=logging.DEBUG)
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)s %(name)s %(funcName)s %(message)s', level=logging.DEBUG)
     # Send to syslog local5, which will be redirected to xapi log /var/log/xensource.log
-    handler = logging.handlers.SysLogHandler(facility='local5', address='/dev/log')
+    handler = logging.handlers.SysLogHandler(
+        facility='local5', address='/dev/log')
     std_err = logging.StreamHandler(sys.stderr)
     # Send to authpriv, which will be redirected to /var/log/secure
-    auth_log = logging.handlers.SysLogHandler(facility="authpriv", address='/dev/log')
+    auth_log = logging.handlers.SysLogHandler(
+        facility="authpriv", address='/dev/log')
     logger.addHandler(handler)
     logger.addHandler(std_err)
     logger.addHandler(auth_log)
@@ -77,7 +81,7 @@ class ADConfig(object):
                 self._lines = [l.strip() for l in lines]
 
     def _get_ad_backend(self, args):
-        if  args.get("ad_backend", "winbind") == "pbis":
+        if args.get("ad_backend", "winbind") == "pbis":
             logger.debug("pbis is used as AD backend")
             return ADBackend.bd_pbis
 
@@ -143,9 +147,11 @@ session    required     pam_loginuid.so"""
             content = self.no_ad_pam
         self._lines = content.split("\n")
 
+
 class DynamicPam(ADConfig):
     #pylint: disable=too-few-public-methods
     """Class manage /etc/pam.d/hcp_users which permit pool admin ssh"""
+
     def __init__(self, session, arg, ad_enabled=True):
         super(DynamicPam, self).__init__("/etc/pam.d/hcp_users", session, arg, ad_enabled,
                                          load_existing=False)
@@ -157,7 +163,8 @@ class DynamicPam(ADConfig):
         # Rewrite the PAM SSH config using the latest info from Active Directory
         # and the list of subjects from xapi
         subjects = self._session.xenapi.subject.get_all()
-        admin_role = self._session.xenapi.role.get_by_name_label('pool-admin')[0]
+        admin_role = self._session.xenapi.role.get_by_name_label(
+            'pool-admin')[0]
         # Add each subject which contains the admin role
         for opaque_ref in subjects:
             subject_rec = self._session.xenapi.subject.get_record(opaque_ref)
@@ -168,13 +175,14 @@ class DynamicPam(ADConfig):
         # CA-363207: Pam cannot handle space, put it inside []
         space_replacement = "+"
         if space_replacement in item:
-            raise ValueError("{} is not permitted in subject name".format(space_replacement))
+            raise ValueError(
+                "{} is not permitted in subject name".format(space_replacement))
 
         if " " in item:
             if self._backend == ADBackend.bd_pbis:
                 # PBIS relace space with "+", eg "ab  cd" -> "ab++cd"
                 # PBIS pam module will reverse it back
-                return item.replace(" " , space_replacement)
+                return item.replace(" ", space_replacement)
             # winbind put name with space within "[]"
             return "[{}]".format(item)
         return item
@@ -182,21 +190,25 @@ class DynamicPam(ADConfig):
     def _add_subject(self, subject_rec):
         try:
             sid = subject_rec['subject_identifier']
-            name = self._format_item(subject_rec["other_config"]["subject-name"])
+            name = self._format_item(
+                subject_rec["other_config"]["subject-name"])
             is_group = subject_rec["other_config"]["subject-is-group"] == "true"
-            logger.debug("Permit %s with sid %s is_group as %s", name, sid, is_group)
+            logger.debug("Permit %s with sid %s is_group as %s",
+                         name, sid, is_group)
             condition = "ingroup" if is_group else "="
             self._lines.append("account sufficient pam_succeed_if.so user {} {}".format(
                 condition, name))
             # If ssh key is permittd in authorized_keys,
             # UPN cannot match by SAM, put UPN format explictly
             if not is_group:
-                subject_upn = self._format_item(subject_rec["other_config"]["subject-upn"])
+                subject_upn = self._format_item(
+                    subject_rec["other_config"]["subject-upn"])
                 self._lines.append("account sufficient pam_succeed_if.so user {} {}".format(
                     condition, subject_upn))
-        #pylint: disable=broad-except
+        # pylint: disable=broad-except
         except Exception as exp:
-            logger.warning("Failed to add subject %s for dynamic pam: %s", subject_rec, str(exp))
+            logger.warning(
+                "Failed to add subject %s for dynamic pam: %s", subject_rec, str(exp))
 
     def _install(self):
         if self._ad_enabled:
@@ -212,11 +224,12 @@ class KeyValueConfig(ADConfig):
      Otherwise, it will be just copied and un-configurable
      If multiple lines with the same key exists, only the first line will be configured
     """
-    _special_line_prefix = "__key_value_config_sp_line_prefix_" # Presume normal config does not have such keys
+    _special_line_prefix = "__key_value_config_sp_line_prefix_"  # Presume normal config does not have such keys
     _empty_value = ""
 
     def __init__(self, path, session, args, ad_enabled=True, load_existing=True, file_mode=0o644, sep=": ", comment="#"):
-        super(KeyValueConfig, self).__init__(path, session, args, ad_enabled, load_existing, file_mode)
+        super(KeyValueConfig, self).__init__(path, session,
+                                             args, ad_enabled, load_existing, file_mode)
         self._sep = None if sep.isspace() else sep  # Ignore number/type of spaces
         self._comment = comment
         self._values = OrderedDict()
@@ -230,18 +243,19 @@ class KeyValueConfig(ADConfig):
 
     def _load_values(self):
         for idx, line in enumerate(self._lines):
-            sp_key = "{}{}".format(self._special_line_prefix, str(idx)) # Generate a unique key to store multiple special lines
-            if line == "": # Empty line
+            # Generate a unique key to store multiple special lines
+            sp_key = "{}{}".format(self._special_line_prefix, str(idx))
+            if line == "":  # Empty line
                 self._values[sp_key] = self._empty_value
             elif self._is_comment_line(line):
                 self._values[sp_key] = line
-            else: # Parse the key, value pair
+            else:  # Parse the key, value pair
                 kv = line.split(self._sep)
                 if len(kv) != 2:
                     # Taken as raw line
                     self._values[sp_key] = line
                 else:
-                    k , v = kv[0].strip(), kv[1].strip()
+                    k, v = kv[0].strip(), kv[1].strip()
                     if k not in self._values:
                         self._values[k] = v
                     else:
@@ -254,8 +268,8 @@ class KeyValueConfig(ADConfig):
     def _apply_value(self, key, value):
         if self.is_special_line(key):
             line = value
-        else: # normal line, construct the key value pair
-            sep = self._sep if self._sep else  " "
+        else:  # normal line, construct the key value pair
+            sep = self._sep if self._sep else " "
             line = "{}{}{}".format(key, sep, value)
         self._lines.append(line)
 
@@ -267,7 +281,8 @@ class KeyValueConfig(ADConfig):
 
 class NssConfig(KeyValueConfig):
     def __init__(self, session, args, ad_enabled=True):
-        super(NssConfig, self).__init__("/etc/nsswitch.conf", session, args, ad_enabled)
+        super(NssConfig, self).__init__(
+            "/etc/nsswitch.conf", session, args, ad_enabled)
         modules = "files sss"
         if ad_enabled:
             if self._backend == ADBackend.bd_pbis:
@@ -375,12 +390,12 @@ def before_extauth_disable(session, args):
 # The dispatcher
 if __name__ == "__main__":
     dispatch_tbl = {
-        "after-extauth-enable":  after_extauth_enable,
-        "after-xapi-initialize": after_xapi_initialize,
-        "after-subject-add":     after_subject_add,
-        "after-subject-update":  after_subject_update,
-        "after-subject-remove":  after_subject_remove,
-        "after-roles-update":    after_roles_update,
-        "before-extauth-disable":before_extauth_disable,
+        "after-extauth-enable":   after_extauth_enable,
+        "after-xapi-initialize":  after_xapi_initialize,
+        "after-subject-add":      after_subject_add,
+        "after-subject-update":   after_subject_update,
+        "after-subject-remove":   after_subject_remove,
+        "after-roles-update":     after_roles_update,
+        "before-extauth-disable": before_extauth_disable,
     }
     XenAPIPlugin.dispatch(dispatch_tbl)

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -27,6 +27,7 @@ from enum import Enum
 # - /etc/pam.d/hcp_users
 # - /etc/ssh/ssh_config
 
+#pylint: disable=super-with-arguments
 
 def setup_logger():
     logger = logging.getLogger()
@@ -143,6 +144,8 @@ session    required     pam_loginuid.so"""
         self._lines = content.split("\n")
 
 class DynamicPam(ADConfig):
+    #pylint: disable=too-few-public-methods
+    """Class manage /etc/pam.d/hcp_users which permit pool admin ssh"""
     def __init__(self, session, arg, ad_enabled=True):
         super(DynamicPam, self).__init__("/etc/pam.d/hcp_users", session, arg, ad_enabled,
                                          load_existing=False)
@@ -163,7 +166,16 @@ class DynamicPam(ADConfig):
 
     def _format_item(self, item):
         # CA-363207: Pam cannot handle space, put it inside []
+        space_replacement = "+"
+        if space_replacement in item:
+            raise ValueError("{} is not permitted in subject name".format(space_replacement))
+
         if " " in item:
+            if self._backend == ADBackend.bd_pbis:
+                # PBIS relace space with "+", eg "ab  cd" -> "ab++cd"
+                # PBIS pam module will reverse it back
+                return item.replace(" " , space_replacement)
+            # winbind put name with space within "[]"
             return "[{}]".format(item)
         return item
 
@@ -174,15 +186,17 @@ class DynamicPam(ADConfig):
             is_group = subject_rec["other_config"]["subject-is-group"] == "true"
             logger.debug("Permit %s with sid %s is_group as %s", name, sid, is_group)
             condition = "ingroup" if is_group else "="
-            self._lines.append("account sufficient pam_succeed_if.so user {} {}".format(condition, name))
-            sid = subject_rec['subject_identifier']
+            self._lines.append("account sufficient pam_succeed_if.so user {} {}".format(
+                condition, name))
             # If ssh key is permittd in authorized_keys,
             # UPN cannot match by SAM, put UPN format explictly
             if not is_group:
                 subject_upn = self._format_item(subject_rec["other_config"]["subject-upn"])
-                self._lines.append("account sufficient pam_succeed_if.so user {} {}".format(condition, subject_upn))
-        except Exception:
-            logger.warning("Failed to check subject %s for dynamic pam", subject_rec)
+                self._lines.append("account sufficient pam_succeed_if.so user {} {}".format(
+                    condition, subject_upn))
+        #pylint: disable=broad-except
+        except Exception as exp:
+            logger.warning("Failed to add subject %s for dynamic pam: %s", subject_rec, str(exp))
 
     def _install(self):
         if self._ad_enabled:
@@ -193,9 +207,11 @@ class DynamicPam(ADConfig):
 
 
 class KeyValueConfig(ADConfig):
-    # Only support configure files with key value in each line, seperated by sep
-    # Otherwise, it will be just copied and un-configurable
-    # If multiple lines with the same key exists, only the first line will be configured
+    """
+     Only support configure files with key value in each line, seperated by sep
+     Otherwise, it will be just copied and un-configurable
+     If multiple lines with the same key exists, only the first line will be configured
+    """
     _special_line_prefix = "__key_value_config_sp_line_prefix_" # Presume normal config does not have such keys
     _empty_value = ""
 

--- a/scripts/plugins/test_extauth_hook_AD.py
+++ b/scripts/plugins/test_extauth_hook_AD.py
@@ -12,7 +12,7 @@ def line_exists_in_config(lines, line):
     return any(line.split() == l.split() for l in lines)
 
 domain = "conappada.local"
-args_bd_wibind = {'auth_type': 'AD', 'service_name': domain, 'ad_backend': 'winbind'}
+args_bd_winbind = {'auth_type': 'AD', 'service_name': domain, 'ad_backend': 'winbind'}
 args_bd_pbis = {'auth_type': 'AD', 'service_name': domain, 'ad_backend': 'pbis'}
 mock_session = MagicMock()
 
@@ -22,6 +22,8 @@ admin_role = 'OpaqueRef:0165f154-ba3e-034e-6b27-5d271af109ba'
 admin_roles = [admin_role]
 mock_session.xenapi.role.get_by_name_label.return_value = admin_roles
 
+#pylint: disable=unused-argument, protected-access, redefined-outer-name, missing-function-docstring
+#pylint: disable=too-many-arguments, missing-class-docstring, no-self-use
 
 def build_user(domain, name, is_admin=True):
     return {
@@ -64,19 +66,19 @@ def build_group(domain, name, is_admin):
 class TestStaicPamConfig(TestCase):
     def test_ad_not_enabled(self, mock_rename, mock_chmod):
         # No hcp_users file should be included
-        static = StaticPam(mock_session, args_bd_wibind, ad_enabled = False)
+        static = StaticPam(mock_session, args_bd_winbind, ad_enabled = False)
         static.apply()
         enabled_keyward = "account     include       hcp_users"
         self.assertFalse(line_exists_in_config(static._lines, enabled_keyward))
 
     def test_ad_enabled_with_winbind(self, mock_rename, mock_chmod):
         # pam_winbind should be used
-        static = StaticPam(mock_session, args_bd_wibind)
+        static = StaticPam(mock_session, args_bd_winbind)
         static.apply()
         enabled_keyward = "auth sufficient    pam_winbind.so try_first_pass try_authtok"
         self.assertTrue(line_exists_in_config(static._lines, enabled_keyward))
 
-    def test_ad_enabled_with_winbind(self, mock_rename, mock_chmod):
+    def test_ad_enabled_with_pbis(self, mock_rename, mock_chmod):
         # pam_lsass should be used
         static = StaticPam(mock_session, args_bd_pbis)
         static.apply()
@@ -93,7 +95,7 @@ class TestDynamicPam(TestCase):
     def test_ad_not_enabled(self, mock_remove, mock_exists, mock_open, mock_rename, mock_chmod):
         # dynamic pam file should be removed
         mock_exists.return_value = True
-        dynamic = DynamicPam(mock_session, args_bd_wibind, ad_enabled = False)
+        dynamic = DynamicPam(mock_session, args_bd_winbind, ad_enabled = False)
         dynamic.apply()
         mock_remove.assert_called()
         mock_rename.assert_not_called()
@@ -103,7 +105,27 @@ class TestDynamicPam(TestCase):
         user = build_user("CONNAPP", "radmin", True)
         mock_session.xenapi.subject.get_record.return_value = user
         permit_user = r"account sufficient pam_succeed_if.so user = CONNAPP\radmin"
-        dynamic = DynamicPam(mock_session, args_bd_wibind)
+        dynamic = DynamicPam(mock_session, args_bd_winbind)
+        dynamic.apply()
+        self.assertTrue(line_exists_in_config(dynamic._lines, permit_user))
+        mock_rename.assert_called()
+
+    def test_pbis_permit_admin_user_with_space(self, mock_rename, mock_chmod):
+        # Domain user name with space should be repalced by "+" with PBIS
+        user = build_user("CONNAPP", "radmin  l1", True)
+        mock_session.xenapi.subject.get_record.return_value = user
+        permit_user = r"account sufficient pam_succeed_if.so user = CONNAPP\radmin++l1"
+        dynamic = DynamicPam(mock_session, args_bd_pbis)
+        dynamic.apply()
+        self.assertTrue(line_exists_in_config(dynamic._lines, permit_user))
+        mock_rename.assert_called()
+
+    def test_winbind_permit_admin_user_with_space(self, mock_rename, mock_chmod):
+        # Domain user name with space should be surrounded by [] with winbind
+        user = build_user("CONNAPP", "radmin  l1", True)
+        mock_session.xenapi.subject.get_record.return_value = user
+        permit_user = r"account sufficient pam_succeed_if.so user = [CONNAPP\radmin  l1]"
+        dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertTrue(line_exists_in_config(dynamic._lines, permit_user))
         mock_rename.assert_called()
@@ -113,7 +135,7 @@ class TestDynamicPam(TestCase):
         user = build_user("CONNAPP", "radmin", False)
         mock_session.xenapi.subject.get_record.return_value = user
         permit_user = r"account sufficient pam_succeed_if.so user = CONNAPP\radmin"
-        dynamic = DynamicPam(mock_session, args_bd_wibind)
+        dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertFalse(line_exists_in_config(dynamic._lines, permit_user))
         mock_rename.assert_called()
@@ -123,20 +145,53 @@ class TestDynamicPam(TestCase):
         group = build_group("CONNAPP", "test_group", True)
         mock_session.xenapi.subject.get_record.return_value = group
         permit_group = r"account sufficient pam_succeed_if.so user ingroup CONNAPP\test_group"
-        dynamic = DynamicPam(mock_session, args_bd_wibind)
+        dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertTrue(line_exists_in_config(dynamic._lines, permit_group))
         mock_rename.assert_called()
 
     def test_not_permit_non_admin_group(self, mock_rename, mock_chmod):
-        # Domain user with admin role should be included in config file
+        # Domain user without admin role should not be included in config file
         group = build_group("CONNAPP", "test_group", False)
         mock_session.xenapi.subject.get_record.return_value = group
         permit_group = r"account sufficient pam_succeed_if.so user ingroup CONNAPP\test_group"
-        dynamic = DynamicPam(mock_session, args_bd_wibind)
+        dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertFalse(line_exists_in_config(dynamic._lines, permit_group))
         mock_rename.assert_called()
+
+    def test_not_permit_pool_admin_with_plus_in_name(self, mock_rename, mock_chmod):
+        """
+        Domain user name should not contain "+"
+        """
+        user = build_user("CONNAPP", "radm+in", True)
+        mock_session.xenapi.subject.get_record.return_value = user
+        permit_user = r"account sufficient pam_succeed_if.so user = CONNAPP\radm+in"
+        dynamic = DynamicPam(mock_session, args_bd_winbind)
+        dynamic.apply()
+        self.assertFalse(line_exists_in_config(dynamic._lines, permit_user))
+
+    def test_failed_to_add_one_admin_should_not_affact_others(self, mock_rename, mock_chmod):
+        """
+        Failed to add one bad domain users should not affact others
+        """
+        bad_user = build_user("CONNAPP", "bad+in", True)
+        good_user = build_user("CONNAPP", "good", True)
+
+        mock_session_with_multi_users  = MagicMock()
+
+        subjects = ['OpaqueRef:96ae4be5-8815-4de8-a40f-d5e5c531dda9',
+                    'OpaqueRef:96ae4be5-8815-4de8-a40f-d5e5c531dda1']
+        mock_session_with_multi_users.xenapi.subject.get_all.return_value = subjects
+        mock_session_with_multi_users.xenapi.subject.get_record.side_effect= [bad_user, good_user]
+        mock_session_with_multi_users.xenapi.role.get_by_name_label.return_value = admin_roles
+
+        bad_condition = r"account sufficient pam_succeed_if.so user = CONNAPP\bad+in"
+        good_condition = r"account sufficient pam_succeed_if.so user = CONNAPP\good"
+        dynamic = DynamicPam(mock_session_with_multi_users, args_bd_winbind)
+        dynamic.apply()
+        self.assertFalse(line_exists_in_config(dynamic._lines, bad_condition))
+        self.assertTrue(line_exists_in_config(dynamic._lines, good_condition))
 
 
 @patch("os.chmod")
@@ -144,13 +199,13 @@ class TestDynamicPam(TestCase):
 class TestNssConfig(TestCase):
     def test_ad_not_enabled(self, mock_rename, mock_chmod):
         expected_config = "passwd:  files sss"
-        nss = NssConfig(mock_session, args_bd_wibind, False)
+        nss = NssConfig(mock_session, args_bd_winbind, False)
         nss.apply()
         self.assertTrue(line_exists_in_config(nss._lines, expected_config))
 
     def test_ad_enabled(self, mock_rename, mock_chmod):
         expected_config = "passwd: files hcp winbind"
-        nss = NssConfig(mock_session, args_bd_wibind, True)
+        nss = NssConfig(mock_session, args_bd_winbind, True)
         nss.apply()
         self.assertTrue(line_exists_in_config(nss._lines, expected_config))
 
@@ -163,7 +218,7 @@ class TestSshdConfig(TestCase):
         expected_config = "ChallengeResponseAuthentication no"
         # mock empty file exists
         mock_open.return_value.__enter__.return_value.readlines.return_value = []
-        sshd = SshdConfig(mock_session, args_bd_wibind, False)
+        sshd = SshdConfig(mock_session, args_bd_winbind, False)
         sshd.apply()
         self.assertTrue(line_exists_in_config(sshd._lines, expected_config))
         mock_run_cmd.assert_called()
@@ -172,7 +227,7 @@ class TestSshdConfig(TestCase):
         expected_config = "ChallengeResponseAuthentication yes"
         # mock empty file exists
         mock_open.return_value.__enter__.return_value.readlines.return_value = []
-        sshd = SshdConfig(mock_session, args_bd_wibind, True)
+        sshd = SshdConfig(mock_session, args_bd_winbind, True)
         sshd.apply()
         self.assertTrue(line_exists_in_config(sshd._lines, expected_config))
         mock_run_cmd.assert_called()


### PR DESCRIPTION
CA-363207 complains pool admin group name with space cannot login,
that issue is fixed by surround group name with [], which works both
for pbis and winbind.
However, the fix does not work PBIS username with space.
This commit take pbis and winbind seperately
* for pbis, relace space with +, which is the original pbis solution
* for winbind, surround name with []

Signed-off-by: Lin Liu <lin.liu@citrix.com>