### PR TITLE
Client-cert auth: use CAfile

### DIFF
--- a/ocaml/xapi/xapi_stunnel_server.ml
+++ b/ocaml/xapi/xapi_stunnel_server.ml
@@ -98,7 +98,7 @@ end = struct
                 Xapi_globs.unix_domain_socket_clientcert
             ; "redirect = 80"
             ; "verifyChain = yes"
-            ; Printf.sprintf "CApath = %s" !Xapi_globs.trusted_certs_dir
+            ; Printf.sprintf "CAfile = %s" !Xapi_globs.stunnel_bundle_path
             ; Printf.sprintf "checkHost = %s" name
             ]
         )


### PR DESCRIPTION
The CApath stunnel config option is currently used, but it turns out
that the necessary pem file symlinks are not always created. This should
be sorted out, but for now the quickest solution is to switch to CAfile
and use the CA bundle.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>