### PR TITLE
Remove RPM gpgcheck in reposync

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -185,7 +185,6 @@ let sync ~__context ~self ~token ~token_id =
           ; !Xapi_globs.local_pool_repo_dir
           ; "--downloadcomps"
           ; "--download-metadata"
-          ; (if !Xapi_globs.repository_gpgcheck then "--gpgcheck" else "")
           ; "--delete"
           ; "--plugins"
           ; Printf.sprintf "--repoid=%s" repo_name


### PR DESCRIPTION
Prior to this commit, the assumption is the RPM GPG key will be imported
before running 'reposync'. This results in un-necessary dependency and
un-necessary RPM packages signature checking since this will be done by
'yum upgrade' later as well.

In this commit, the '--gpgcheck' paramter is removed. Thereafter,
'reposync' will only check repository metadata. It will not require the
RPM GPG key being imported anymore. And later in 'yum upgrade', the GPG
key will be imported automatically and used for RPM packages signature
checking.

Signed-off-by: Ming Lu <ming.lu@citrix.com>