### PR TITLE
Remove hard-coded paths of repository metadata files

### DIFF
--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -724,15 +724,15 @@ module UpdateInfoMetaDataOfXml = Generic.MakeStateless (struct
   module Io = struct
     type input_t = string
 
-    type output_t = (UpdateInfoMetaData.t, exn) result
+    type output_t = (RepoMetaData.t, exn) result
 
     let string_of_input_t x = x
 
     let fields =
       Fmt.Dump.
         [
-          field "checksum" (fun (r : UpdateInfoMetaData.t) -> r.checksum) string
-        ; field "location" (fun (r : UpdateInfoMetaData.t) -> r.location) string
+          field "checksum" (fun (r : RepoMetaData.t) -> r.checksum) string
+        ; field "location" (fun (r : RepoMetaData.t) -> r.location) string
         ]
       
 
@@ -741,7 +741,7 @@ module UpdateInfoMetaDataOfXml = Generic.MakeStateless (struct
   end
 
   let transform input =
-    try Ok (UpdateInfoMetaData.of_xml (Xml.parse_string input))
+    try Ok RepoMetaData.(of_xml (Xml.parse_string input) UpdateInfo)
     with e -> Error e
 
   let tests =
@@ -808,7 +808,7 @@ module UpdateInfoMetaDataOfXml = Generic.MakeStateless (struct
             </repomd>
            |}
         , Ok
-            UpdateInfoMetaData.
+            RepoMetaData.
               {checksum= "123abc"; location= "repodata/123abc.xml.gz"}
             
         )

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -342,10 +342,10 @@ let set_available_updates ~__context =
             |> Filename.concat repo_name
             |> Filename.concat !Xapi_globs.local_pool_repo_dir
           in
-          let md = UpdateInfoMetaData.of_xml_file xml_path in
+          let md = RepoMetaData.(of_xml_file xml_path UpdateInfo) in
           Db.Repository.set_hash ~__context ~self:repository
-            ~value:md.UpdateInfoMetaData.checksum ;
-          Some md.UpdateInfoMetaData.checksum
+            ~value:md.RepoMetaData.checksum ;
+          Some md.RepoMetaData.checksum
         ) else
           None
       )
@@ -369,11 +369,13 @@ let create_pool_repository ~__context ~self =
       if Db.Repository.get_update ~__context ~self then
         let cachedir = get_repo_config repo_name "cachedir" in
         let md =
-          UpdateInfoMetaData.of_xml_file (Filename.concat cachedir "repomd.xml")
+          RepoMetaData.(
+            of_xml_file (Filename.concat cachedir "repomd.xml") UpdateInfo
+          )
         in
         let updateinfo_xml_gz_path =
           Filename.concat repo_dir
-            (md.UpdateInfoMetaData.checksum ^ "-updateinfo.xml.gz")
+            (md.RepoMetaData.checksum ^ "-updateinfo.xml.gz")
         in
         match Sys.file_exists updateinfo_xml_gz_path with
         | true ->
@@ -482,19 +484,19 @@ let parse_updateinfo ~__context ~self =
   let repo_dir = Filename.concat !Xapi_globs.local_pool_repo_dir repo_name in
   let repodata_dir = Filename.concat repo_dir "repodata" in
   let repomd_xml_path = Filename.concat repodata_dir "repomd.xml" in
-  let md = UpdateInfoMetaData.of_xml_file repomd_xml_path in
-  if hash <> md.UpdateInfoMetaData.checksum then (
+  let md = RepoMetaData.(of_xml_file repomd_xml_path UpdateInfo) in
+  if hash <> md.RepoMetaData.checksum then (
     let msg =
       Printf.sprintf
         "Unexpected mismatch between XAPI DB (%s) and YUM DB (%s). Need to do \
          pool.sync-updates again."
-        hash md.UpdateInfoMetaData.checksum
+        hash md.RepoMetaData.checksum
     in
     error "%s: %s" repo_name msg ;
     raise Api_errors.(Server_error (internal_error, [msg]))
   ) ;
   let updateinfo_xml_gz_path =
-    Filename.concat repo_dir md.UpdateInfoMetaData.location
+    Filename.concat repo_dir md.RepoMetaData.location
   in
   match Sys.file_exists updateinfo_xml_gz_path with
   | false ->

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -374,8 +374,7 @@ let create_pool_repository ~__context ~self =
           )
         in
         let updateinfo_xml_gz_path =
-          Filename.concat repo_dir
-            (md.RepoMetaData.checksum ^ "-updateinfo.xml.gz")
+          Filename.concat repo_dir (Filename.basename md.RepoMetaData.location)
         in
         match Sys.file_exists updateinfo_xml_gz_path with
         | true ->

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -566,9 +566,13 @@ end
 module RepoMetaData = struct
   type t = {checksum: string; location: string}
 
-  type datatype = UpdateInfo
+  type datatype = UpdateInfo | Group
 
-  let string_of_datatype = function UpdateInfo -> "updateinfo"
+  let string_of_datatype = function
+    | UpdateInfo ->
+        "updateinfo"
+    | Group ->
+        "group"
 
   let assert_valid = function
     | {checksum= ""; _} | {location= ""; _} ->

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -563,22 +563,28 @@ module Applicability = struct
         raise Invalid_inequality
 end
 
-module UpdateInfoMetaData = struct
+module RepoMetaData = struct
   type t = {checksum: string; location: string}
 
-  let assert_valid_repomd = function
-    | {checksum= ""; _} | {location= ""; _} ->
-        error "Missing 'checksum' or 'location' in updateinfo in repomod.xml" ;
-        raise Api_errors.(Server_error (invalid_repomd_xml, []))
-    | umd ->
-        umd
+  type datatype = UpdateInfo
 
-  let of_xml = function
+  let string_of_datatype = function UpdateInfo -> "updateinfo"
+
+  let assert_valid = function
+    | {checksum= ""; _} | {location= ""; _} ->
+        error "Can't find valid 'checksum' or 'location'" ;
+        raise Api_errors.(Server_error (invalid_repomd_xml, []))
+    | md ->
+        ()
+
+  let of_xml xml data_type =
+    let dt = string_of_datatype data_type in
+    match xml with
     | Xml.Element ("repomd", _, children) -> (
-        let get_updateinfo_node = function
+        let get_node = function
           | Xml.Element ("data", attrs, nodes) -> (
             match List.assoc_opt "type" attrs with
-            | Some "updateinfo" ->
+            | Some data_type' when data_type' = dt ->
                 Some nodes
             | _ ->
                 None
@@ -586,7 +592,7 @@ module UpdateInfoMetaData = struct
           | _ ->
               None
         in
-        match List.filter_map get_updateinfo_node children with
+        match List.filter_map get_node children with
         | [l] ->
             List.fold_left
               (fun md n ->
@@ -596,7 +602,7 @@ module UpdateInfoMetaData = struct
                 | Xml.Element ("location", attrs, _) -> (
                   try {md with location= List.assoc "href" attrs}
                   with _ ->
-                    error "Failed to get location of updateinfo.xml.gz" ;
+                    error "Failed to get 'href' in 'location' of '%s'" dt ;
                     raise Api_errors.(Server_error (invalid_repomd_xml, []))
                 )
                 | _ ->
@@ -604,16 +610,16 @@ module UpdateInfoMetaData = struct
               )
               {checksum= ""; location= ""}
               l
-            |> assert_valid_repomd
+            |> fun md -> assert_valid md ; md
         | _ ->
-            error "Missing or multiple 'updateinfo' node(s)" ;
+            error "Missing or multiple '%s' node(s)" dt ;
             raise Api_errors.(Server_error (invalid_repomd_xml, []))
       )
     | _ ->
         error "Missing 'repomd' node" ;
         raise Api_errors.(Server_error (invalid_repomd_xml, []))
 
-  let of_xml_file xml_path =
+  let of_xml_file xml_path data_type =
     match Sys.file_exists xml_path with
     | false ->
         error "No repomd.xml found: %s" xml_path ;
@@ -621,7 +627,7 @@ module UpdateInfoMetaData = struct
     | true -> (
       match Xml.parse_file xml_path with
       | xml ->
-          of_xml xml
+          of_xml xml data_type
       | exception e ->
           error "Failed to parse repomd.xml: %s" (ExnHelper.string_of_exn e) ;
           raise Api_errors.(Server_error (invalid_repomd_xml, []))


### PR DESCRIPTION
This series remove the hard-coded paths of repository metadata files. 
Instead, in this series, the paths are retrieved from the repomd.xml.