### PR TITLE
CA-355588: Users in groups contains # can not ssh into dom0

### DIFF
--- a/ocaml/xapi/extauth.ml
+++ b/ocaml/xapi/extauth.ml
@@ -93,6 +93,8 @@ let get_event_params ~__context host =
     ("auth_type", auth_type)
   ; ("service_name", service_name)
   ; ("ad_backend", !Xapi_globs.extauth_ad_backend)
+  ; ("list_sep", !Xapi_globs.extauth_pam_access_list_sep)
+  ; ("field_sep", !Xapi_globs.extauth_pam_access_field_sep)
   ]
 
 (* allows extauth hook script to be called only under specific conditions *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -919,6 +919,10 @@ type xapi_globs_spec_ty = Float of float ref | Int of int ref
 
 let extauth_ad_backend = ref "winbind"
 
+let extauth_pam_access_list_sep = ref ";"
+
+let extauth_pam_access_field_sep = ref ","
+
 let net_cmd = ref "/usr/bin/net"
 
 let wb_cmd = ref "/usr/bin/wbinfo"
@@ -1275,6 +1279,16 @@ let other_options =
     , Arg.Set_string extauth_ad_backend
     , (fun () -> !extauth_ad_backend)
     , "Which AD backend used to talk to DC"
+    )
+  ; ( "extauth_pam_access_list_sep"
+    , Arg.Set_string extauth_pam_access_list_sep
+    , (fun () -> !extauth_pam_access_list_sep)
+    , "Special char pam_access used to seperate list items"
+    )
+  ; ( "extauth_pam_access_field_sep"
+    , Arg.Set_string extauth_pam_access_field_sep
+    , (fun () -> !extauth_pam_access_field_sep)
+    , "Special char pam_access used to seperate fields"
     )
   ; ( "winbind_kerberos_encryption_type"
     , Arg.String


### PR DESCRIPTION
Linux PAM take # as comments and there is no way to escape it.
This commit permit access to dom0 by pam_access instead of pam_succeed_if
/etc/security/hcp_access.conf (pam_access config) is used to permit users
and groups instead of /etc/pam.d/hcp_users (linux pam config)

Signed-off-by: Lin Liu <lin.liu@citrix.com>