### PR TITLE
Avoid compiler warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           ERR=$(egrep 'Error |Warning ' -c make-check.log)
           echo ERR=$ERR
-          test 251 -eq  "$ERR"
+          test 240 -eq  "$ERR"
 
       - name: Check all code in release mode
         # This should be removed when the preceding passes succeed

--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -425,7 +425,8 @@ let gen_db_actions highapi =
   List.iter (List.iter print)
     (between [""]
        [
-         ["open API"]
+         [{|[@@@ocaml.warning "-6-27-33"]|}]
+       ; ["open API"]
        ; (* These records have the hidden fields inside.
             This excludes records not stored in the database, which must not
             have hidden fields. *)

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -444,7 +444,8 @@ let gen_module api : O.Module.t =
       ]
     ~preamble:
       [
-        "module D = Debug.Make(struct let name = \"dispatcher\" end)"
+        {|[@@@ocaml.warning "-27"]|}
+      ; "module D = Debug.Make(struct let name = \"dispatcher\" end)"
       ; "module ApiLogRead = Debug.Make(struct let name = \"api_readonly\" end)"
       ; "module ApiLogSideEffect = Debug.Make(struct let name = \"api_effect\" \
          end)"

--- a/ocaml/message-switch/switch/logging.ml
+++ b/ocaml/message-switch/switch/logging.ml
@@ -71,21 +71,15 @@ let ignore_fmt_lwt fmt = Printf.ksprintf (fun _ -> Lwt.return ()) fmt
 (* General system logging *)
 let logger = create 512
 
-type level = Debug | Info | Warn | Error | Null
-
-let log_level = ref Warn
+type level = Info | Warn | Error
 
 let string_of_level = function
-  | Debug ->
-      "debug"
   | Info ->
       "info"
   | Warn ->
       "warn"
   | Error ->
       "error"
-  | Null ->
-      "null"
 
 let log level key (fmt : (_, _, _, _) format4) =
   let level = string_of_level level in

--- a/ocaml/message-switch/unix/protocol_unix.ml
+++ b/ocaml/message-switch/unix/protocol_unix.ml
@@ -28,7 +28,7 @@ let thread_forever f v =
     match f v with
     | (_ : ('a, 'b) result) ->
         assert false
-    | exception e ->
+    | exception _ ->
         Thread.delay 1.0 ; (loop [@tailcall]) ()
   in
   Thread.create loop ()
@@ -546,5 +546,5 @@ module Server = struct
     let (_ : Thread.t) = thread_forever (loop connections) None in
     Ok ()
 
-  let shutdown ~t () = failwith "Shutdown is unimplemented"
+  let shutdown ~t:_ () = failwith "Shutdown is unimplemented"
 end

--- a/ocaml/quicktest/qt.mli
+++ b/ocaml/quicktest/qt.mli
@@ -22,7 +22,7 @@ val cli_cmd : string list -> string
 val localhost_uuid : string
 
 module Test : sig
-  val assert_raises_match : (exn -> bool) -> (unit -> 'a) -> unit
+  val assert_raises_match : (exn -> bool) -> (unit -> unit) -> unit
   (** This test succeeds if an exception is raised for which the given
       exception matching function returns true *)
 end

--- a/ocaml/quicktest/quicktest_async_calls.ml
+++ b/ocaml/quicktest/quicktest_async_calls.ml
@@ -1,6 +1,6 @@
 let rec wait_for_task_complete rpc session_id task =
   Thread.delay 1. ;
-  match Client.Client.Task.get_status rpc session_id task with
+  match Client.Client.Task.get_status ~rpc ~session_id ~self:task with
   | `pending | `cancelling ->
       wait_for_task_complete rpc session_id task
   | _ ->
@@ -20,12 +20,13 @@ let async_test rpc session_id sr_info () =
   print_endline "Async.VDI.copy test" ;
   Qt.VDI.with_new rpc session_id sr (fun newvdi ->
       let task =
-        Client.Client.Async.VDI.copy rpc session_id newvdi sr Ref.null Ref.null
+        Client.Client.Async.VDI.copy ~rpc ~session_id ~vdi:newvdi ~sr
+          ~base_vdi:Ref.null ~into_vdi:Ref.null
       in
       wait_for_task_complete rpc session_id task ;
       Printf.printf "Task completed!\n%!" ;
-      let status = Client.Client.Task.get_status rpc session_id task in
-      let result = Client.Client.Task.get_result rpc session_id task in
+      let status = Client.Client.Task.get_status ~rpc ~session_id ~self:task in
+      let result = Client.Client.Task.get_result ~rpc ~session_id ~self:task in
       print_endline
         (Printf.sprintf "Status: %s  result: %s%!"
            ( match status with
@@ -46,7 +47,7 @@ let async_test rpc session_id sr_info () =
       | `failure ->
           Alcotest.failf "Failure of VDI copy! error_info: %s"
             (String.concat ","
-               (Client.Client.Task.get_error_info rpc session_id task)
+               (Client.Client.Task.get_error_info ~rpc ~session_id ~self:task)
             )
       | `success ->
           let self = result |> extract_ref in

--- a/ocaml/quicktest/quicktest_http.ml
+++ b/ocaml/quicktest/quicktest_http.ml
@@ -11,16 +11,10 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open Xapi_stdext_threads.Threadext
 open Xapi_stdext_pervasives.Pervasiveext
-open Client
 
 module Uds = struct
   (* {{{1 *)
-
-  module D = Debug.Make (struct let name = "quicktest_http:Uds" end)
-
-  open D
 
   exception Parse_error of string
 
@@ -108,10 +102,6 @@ end
 
 module HTML_Escaping = struct
   (* {{{1 *)
-
-  module D = Debug.Make (struct let name = "quicktest_http:HTML_Escaping" end)
-
-  open D
 
   let non_resource_cmd = "GET /foo<>'\"& HTTP/1.0\r\n\r\n"
 

--- a/ocaml/quicktest/quicktest_import_raw_vdi.ml
+++ b/ocaml/quicktest/quicktest_import_raw_vdi.ml
@@ -13,7 +13,6 @@
  *)
 
 open Client
-open Http
 
 let import_raw_vdi ~session_id ~task_id f =
   let req =
@@ -34,9 +33,9 @@ let start rpc session_id () =
       ~description:""
   in
   try
-    import_raw_vdi ~session_id ~task_id (fun fd -> ()) |> ignore ;
+    import_raw_vdi ~session_id ~task_id (fun _ -> ()) |> ignore ;
     Alcotest.fail "No exception was raised by import_raw_vdi"
-  with e ->
+  with _ ->
     let a = Client.Task.get_record ~rpc ~session_id ~self:task_id in
     Client.Task.destroy ~rpc ~session_id ~self:task_id ;
     if a.API.task_status <> `failure then

--- a/ocaml/quicktest/quicktest_max_vdi_size.ml
+++ b/ocaml/quicktest/quicktest_max_vdi_size.ml
@@ -27,7 +27,7 @@ let test_export_import rpc session_id sr_info () =
   (* We only want to export to a sparse VHD, not to a fully-inflated raw file *)
   let format = "vhd" in
   let sR = sr_info.Qt.sr in
-  with_max_vdi rpc session_id sR (fun rpc session_id sr vdi ->
+  with_max_vdi rpc session_id sR (fun rpc session_id _ vdi ->
       let virtual_size =
         Client.Client.VDI.get_virtual_size ~rpc ~session_id ~self:vdi
       in

--- a/ocaml/quicktest/quicktest_vdi_ops_data_integrity.ml
+++ b/ocaml/quicktest/quicktest_vdi_ops_data_integrity.ml
@@ -32,7 +32,7 @@ let write_random_data rpc session_id vdi =
         write_random_block offset length
       in
       let num_extents = Random.int max_writes in
-      for i = 1 to num_extents do
+      for _ = 1 to num_extents do
         write_random_extent ()
       done
   )
@@ -42,10 +42,13 @@ let fill rpc session_id vdi =
     Client.Client.VDI.get_virtual_size ~rpc ~session_id ~self:vdi
     |> Int64.to_int
   in
-  Qt.VDI.with_open rpc session_id vdi `RW (fun fd ->
-      let buf = random_bytes size in
-      Unix.write fd buf 0 size
-  )
+  let (_ : int) =
+    Qt.VDI.with_open rpc session_id vdi `RW (fun fd ->
+        let buf = random_bytes size in
+        Unix.write fd buf 0 size
+    )
+  in
+  ()
 
 let noop _rpc _session_id _vdi = ()
 

--- a/ocaml/quicktest/quicktest_vm_lifecycle.ml
+++ b/ocaml/quicktest/quicktest_vm_lifecycle.ml
@@ -38,23 +38,23 @@ let all_possible_tests =
   ; Internal_op Internal_crash
   ]
 
-let one rpc s vm test =
+let one rpc session_id vm test =
   print_endline ("Running test " ^ string_of_test test) ;
-  if Client.Client.VM.get_power_state rpc s vm = `Halted then
-    Client.Client.VM.start rpc s vm false false ;
+  if Client.Client.VM.get_power_state ~rpc ~session_id ~self:vm = `Halted then
+    Client.Client.VM.start ~rpc ~session_id ~vm ~start_paused:false ~force:false ;
   (* wait for the guest to actually start up *)
   Thread.delay 15. ;
   let call_api = function
     | Clean, Shutdown ->
-        Client.Client.VM.clean_shutdown rpc s vm
+        Client.Client.VM.clean_shutdown ~rpc ~session_id ~vm
     | Hard, Shutdown ->
-        Client.Client.VM.hard_shutdown rpc s vm
+        Client.Client.VM.hard_shutdown ~rpc ~session_id ~vm
     | Clean, Reboot ->
-        Client.Client.VM.clean_reboot rpc s vm
+        Client.Client.VM.clean_reboot ~rpc ~session_id ~vm
     | Hard, Reboot ->
-        Client.Client.VM.hard_reboot rpc s vm
+        Client.Client.VM.hard_reboot ~rpc ~session_id ~vm
   in
-  let domid = Client.Client.VM.get_domid rpc s vm in
+  let domid = Client.Client.VM.get_domid ~rpc ~session_id ~self:vm in
   ( match test with
   | Internal_op internal_op -> (
       (* The Xenctrl module is used in xenopsd *)
@@ -80,7 +80,7 @@ let one rpc s vm test =
     let start = Unix.gettimeofday () in
     let finished = ref false in
     while Unix.gettimeofday () -. start < 300. && not !finished do
-      finished := p (Client.Client.VM.get_domid rpc s vm) ;
+      finished := p (Client.Client.VM.get_domid ~rpc ~session_id ~self:vm) ;
       if not !finished then Thread.delay 1.
     done ;
     if not !finished then failwith "timeout"

--- a/ocaml/tests/binpack_test.ml
+++ b/ocaml/tests/binpack_test.ml
@@ -74,7 +74,7 @@ let prove_plan_is_possible_via_counterexample_search
           (fun _ ->
             let num_failures = Random.int config.num_failures in
             (* choose 'num_failures' elements at random *)
-            let alive, dead =
+            let _, dead =
               List.fold_left
                 (fun (remaining, sofar) _ ->
                   if List.length sofar = num_failures then
@@ -196,7 +196,7 @@ let check_planning_performance filename n' r' i =
   let heuristic = Array.make (n' * r') 0 in
   let get array n r = array.((r' * (n - 1)) + (r - 1)) in
   let set array n r value = array.((r' * (n - 1)) + (r - 1)) <- value in
-  for attempts = 1 to i do
+  for _ = 1 to i do
     for n = 1 to n' do
       for r = 1 to r' do
         if r < n then (

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -141,7 +141,7 @@ let make_vm ~__context ?(name_label = "name_label")
     ?(snapshot_schedule = Ref.null) ?(is_vmss_snapshot = false)
     ?(shutdown_delay = 0L) ?(order = 0L) ?(suspend_SR = Ref.null)
     ?(suspend_VDI = Ref.null) ?(version = 0L) ?(generation_id = "0:0")
-    ?(hardware_platform_version = 0L) ?(has_vendor_device = false)
+    ?(hardware_platform_version = 0L) ?has_vendor_device:_
     ?(has_vendor_device = false) ?(reference_label = "") ?(domain_type = `hvm)
     ?(nVRAM = []) ?(last_booted_record = "") ?(last_boot_CPU_flags = [])
     ?(power_state = `Halted) () =
@@ -476,7 +476,7 @@ let make_pvs_cache_storage ~__context ?(ref = Ref.make ())
 let make_pool_update ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ?(name_label = "") ?(name_description = "") ?(version = "")
     ?(installation_size = 0L) ?(key = "") ?(after_apply_guidance = [])
-    ?(enforce_homogeneity = false) ?(other_config = []) ?(vdi = Ref.null) () =
+    ?(enforce_homogeneity = false) ?other_config:_ ?(vdi = Ref.null) () =
   let update_info =
     Xapi_pool_update.
       {
@@ -552,7 +552,7 @@ let create_vlan_pif ~__context ~host ~vlan ~pif ?(bridge = "xapi0") () =
 
 let create_tunnel_pif ~__context ~host ~pif ?(bridge = "xapi0") () =
   let network = make_network ~__context ~bridge () in
-  let tunnel, access_pif =
+  let _, access_pif =
     make_tunnel ~__context ~transport_PIF:pif ~network ~host
   in
   access_pif

--- a/ocaml/tests/test_bios_strings.ml
+++ b/ocaml/tests/test_bios_strings.ml
@@ -117,7 +117,7 @@ let values_from_string str =
       r.values
   | Ok [] ->
       []
-  | Error msg ->
+  | Error _ ->
       []
 
 let test_parser () =

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -202,7 +202,7 @@ let test_get_network_fails () =
     (Failure ("No cluster_hosts found for cluster " ^ Ref.string_of cluster))
     (fun () -> Xapi_cluster.get_network ~__context ~self:cluster |> ignore) ;
   (* Add two cluster_hosts on different networks *)
-  for i = 0 to 1 do
+  for _ = 0 to 1 do
     make_cluster_host ~__context ~cluster () |> ignore
   done ;
   Alcotest.check_raises "Cluster_hosts on different networks"

--- a/ocaml/tests/test_cluster_host.ml
+++ b/ocaml/tests/test_cluster_host.ml
@@ -72,7 +72,7 @@ let test_fix_prereq () =
     Api_errors.(
       Server_error (pif_has_no_network_configuration, [Ref.string_of pifref])
     )
-    (fun () -> Xapi_cluster_host.fix_pif_prerequisites __context pifref) ;
+    (fun () -> Xapi_cluster_host.fix_pif_prerequisites ~__context pifref) ;
   Db.PIF.set_IP ~__context ~self:pifref ~value:"1.1.1.1" ;
   Xapi_cluster_host.fix_pif_prerequisites ~__context pifref ;
   let pif = Xapi_clustering.pif_of_host ~__context network host in
@@ -205,7 +205,7 @@ let test_forget () =
 let test_forget2 () =
   let __context = Test_common.make_test_database () in
   let host2 = Test_common.make_host ~__context () in
-  let host3 = Test_common.make_host __context () in
+  let host3 = Test_common.make_host ~__context () in
   let cluster, original_cluster_hosts = make ~__context [host2; host3] in
   Xapi_host.destroy ~__context ~self:host3 ;
   let pending = Db.Cluster.get_pending_forget ~__context ~self:cluster in

--- a/ocaml/tests/test_clustering.ml
+++ b/ocaml/tests/test_clustering.ml
@@ -280,12 +280,12 @@ let make_scenario ?(cluster_host = Some true) () =
   let _sm_2 : _ API.Ref.t =
     T.make_sm ~__context ~_type:"lvm" ~required_cluster_stack:[] ()
   in
-  Xapi_clustering.Daemon.enable __context ;
+  Xapi_clustering.Daemon.enable ~__context ;
   (__context, host, cluster, cluster_host)
 
 let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled
     () =
-  let __context, host, cluster, cluster_host = make_scenario () in
+  let __context, host, _, _ = make_scenario () in
   Alcotest.(check unit)
     "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_enabled"
     ()
@@ -295,7 +295,7 @@ let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_hos
 
 let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist
     () =
-  let __context, host, cluster, cluster_host = make_scenario () in
+  let __context, host, _, _ = make_scenario () in
   Alcotest.(check unit)
     "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching_sms_exist"
     ()
@@ -305,7 +305,7 @@ let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_matching
 
 let test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_is_disabled
     () =
-  let __context, host, cluster, cluster_host =
+  let __context, host, _, cluster_host =
     make_scenario ~cluster_host:(Some false) ()
   in
   Alcotest.check_raises
@@ -320,9 +320,7 @@ let test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_cluster_host_i
 
 let test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists
     () =
-  let __context, host, cluster, cluster_host =
-    make_scenario ~cluster_host:None ()
-  in
+  let __context, host, _, _ = make_scenario ~cluster_host:None () in
   Alcotest.check_raises
     "test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_host_exists"
     Api_errors.(Server_error (no_compatible_cluster_host, [Ref.string_of host]))
@@ -333,9 +331,7 @@ let test_assert_cluster_host_is_enabled_for_matching_sms_fails_if_no_cluster_hos
 
 let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed
     () =
-  let __context, host, cluster, cluster_host =
-    make_scenario ~cluster_host:(Some false) ()
-  in
+  let __context, host, _, _ = make_scenario ~cluster_host:(Some false) () in
   Alcotest.(check unit)
     "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_host_is_disabled_and_clustering_is_not_needed"
     ()
@@ -345,9 +341,7 @@ let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_cluster_hos
 
 let test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed
     () =
-  let __context, host, cluster, cluster_host =
-    make_scenario ~cluster_host:None ()
-  in
+  let __context, host, _, _ = make_scenario ~cluster_host:None () in
   Alcotest.(check unit)
     "test_assert_cluster_host_is_enabled_for_matching_sms_succeeds_if_no_cluster_host_exists_and_clustering_is_not_needed \
      should pass"
@@ -538,7 +532,7 @@ let test_disallow_unplug_no_clustering () =
 
 let test_disallow_unplug_with_clustering () =
   let __context = T.make_test_database () in
-  let host, network, pif = make_host_network_pif ~__context in
+  let host, _, pif = make_host_network_pif ~__context in
   check_disallow_unplug false __context pif
     "check_disallow_unplug called by test_disallow_unplug_with_clustering to \
      check default config" ;
@@ -570,7 +564,7 @@ let test_assert_no_clustering_on_pif () =
   in
   assert_no_clustering_on self "assert_no_clustering_on_pif without clustering" ;
   (* Add an enabled cluster_host *)
-  let cluster, cluster_host =
+  let _, cluster_host =
     T.make_cluster_and_cluster_host ~__context ~host ~pIF:self ()
   in
   Alcotest.check_raises "Live cluster_host on PIF"
@@ -677,7 +671,7 @@ let test_choose_cluster_stack_clusters_no_sms () =
   let __context = T.make_test_database () in
   choose_cluster_stack_should_select default ~__context ;
   (* Add two clusters, test choose_cluster_stack's filtering *)
-  for i = 0 to 1 do
+  for _ = 0 to 1 do
     let _ = T.make_cluster_and_cluster_host ~__context () in
     choose_cluster_stack_should_select default_smapiv3 ~__context
   done

--- a/ocaml/tests/test_clustering_allowed_operations.ml
+++ b/ocaml/tests/test_clustering_allowed_operations.ml
@@ -166,7 +166,7 @@ let test_clustering_ops_disallowed_during_rolling_upgrade () =
 let test_cluster_host_ops_without_join () =
   (* Note that joined:true by default so no need to check *)
   let __context = make_test_database () in
-  let cluster, cluster_host =
+  let _, cluster_host =
     make_cluster_and_cluster_host ~__context
       ~host:Helpers.(get_localhost ~__context)
       ()

--- a/ocaml/tests/test_dbsync_master.ml
+++ b/ocaml/tests/test_dbsync_master.ml
@@ -13,7 +13,6 @@
  *)
 
 open Test_highlevel
-open Dbsync_master
 
 module CreateToolsSR = Generic.MakeStateful (struct
   module Io = struct
@@ -66,7 +65,7 @@ module CreateToolsSR = Generic.MakeStateful (struct
     Dbsync_master.create_tools_sr __context name description sr_introduce
       maybe_create_pbd
 
-  let extract_output __context vms =
+  let extract_output __context _ =
     List.fold_left
       (fun acc self ->
         if Db.SR.get_is_tools_sr ~__context ~self then

--- a/ocaml/tests/test_event.ml
+++ b/ocaml/tests/test_event.ml
@@ -20,11 +20,16 @@ let event_setup_common = Test_event_common.event_setup_common
 
 let test_event_from_ev () =
   (* Test that creating an object generates an event for that object *)
-  let __context, session_id = event_setup_common () in
-  let evs = Xapi_event.from __context ["vm"] "" 30.0 |> parse_event_from in
+  let __context, _ = event_setup_common () in
+  let evs =
+    Xapi_event.from ~__context ~classes:["vm"] ~token:"" ~timeout:30.0
+    |> parse_event_from
+  in
   let tok = evs.token in
-  let vm = make_vm __context () in
-  let evs_rpc = Xapi_event.from __context ["vm"] tok 4.0 in
+  let vm = make_vm ~__context () in
+  let evs_rpc =
+    Xapi_event.from ~__context ~classes:["vm"] ~token:tok ~timeout:4.0
+  in
   let evs = evs_rpc |> parse_event_from in
   Printf.printf "evs: %s\n%!" (Jsonrpc.to_string evs_rpc) ;
   let ev = List.filter (fun ev -> ev.ty = "vm") evs.events in
@@ -34,14 +39,17 @@ let test_event_from_ev () =
 
 let test_event_from_ev_rel () =
   (* Test that creating a connector object generates all relevant events *)
-  let __context, session_id = event_setup_common () in
-  let vm = make_vm __context () in
+  let __context, _ = event_setup_common () in
+  let vm = make_vm ~__context () in
   let evs =
-    Xapi_event.from __context ["vm"; "vbd"] "" 30.0 |> parse_event_from
+    Xapi_event.from ~__context ~classes:["vm"; "vbd"] ~token:"" ~timeout:30.0
+    |> parse_event_from
   in
   let tok = evs.token in
   let vbd = make_vbd ~__context ~vM:vm () in
-  let evs_rpc = Xapi_event.from __context ["vm"; "vbd"] tok 4.0 in
+  let evs_rpc =
+    Xapi_event.from ~__context ~classes:["vm"; "vbd"] ~token:tok ~timeout:4.0
+  in
   let evs2 = evs_rpc |> parse_event_from in
   let tok2 = evs2.token in
   let vm_ev = List.filter (fun ev -> ev.ty = "vm") evs2.events in
@@ -51,7 +59,9 @@ let test_event_from_ev_rel () =
   let ev = List.hd vm_ev in
   Alcotest.(check string) "ev.reference" (Ref.string_of vm) ev.reference ;
   Db.VBD.destroy ~__context ~self:vbd ;
-  let evs_rpc = Xapi_event.from __context ["vm"; "vbd"] tok2 4.0 in
+  let evs_rpc =
+    Xapi_event.from ~__context ~classes:["vm"; "vbd"] ~token:tok2 ~timeout:4.0
+  in
   let evs3 = evs_rpc |> parse_event_from in
   let vm_ev = List.filter (fun ev -> ev.ty = "vm") evs3.events in
   let vbd_ev = List.filter (fun ev -> ev.ty = "vbd") evs3.events in
@@ -59,11 +69,17 @@ let test_event_from_ev_rel () =
   Alcotest.(check int) "list length" 1 (List.length vbd_ev)
 
 let test_event_from_timeout () =
-  let __context, session_id = event_setup_common () in
-  let evs = Xapi_event.from __context ["vm"] "" 30.0 |> parse_event_from in
+  let __context, _ = event_setup_common () in
+  let evs =
+    Xapi_event.from ~__context ~classes:["vm"] ~token:"" ~timeout:30.0
+    |> parse_event_from
+  in
   let tok = evs.token in
   let start_time = Unix.gettimeofday () in
-  let _ = Xapi_event.from __context ["vm"] tok 1.0 |> parse_event_from in
+  let _ =
+    Xapi_event.from ~__context ~classes:["vm"] ~token:tok ~timeout:1.0
+    |> parse_event_from
+  in
   let end_time = Unix.gettimeofday () in
   let elapsed = end_time -. start_time in
   Printf.printf "test_event_from_timeout: elapsed=%f\n" elapsed ;
@@ -91,26 +107,28 @@ let event_next_unblock () =
      logout so a little pause in here is probably the best we can do *)
   Thread.delay 0.5 ;
   (* Logout which should cause the background thread to unblock *)
-  Xapi_session.destroy_db_session __context session_id ;
+  Xapi_session.destroy_db_session ~__context ~self:session_id ;
   (* Again we can't tell the difference between a slow and a totally blocked thread
      so set the max wait time 10 times more, but it will ublock as early as possible *)
   let unblocked = not (Delay.wait wait_hdl (0.5 *. 10.)) in
   Alcotest.(check bool) "Unblocked" true unblocked
 
 let event_next_test () =
-  let __context, session_id = event_setup_common () in
+  let __context, _ = event_setup_common () in
   let () = Xapi_event.register ~__context ~classes:["pool"] in
   let wait_hdl = Delay.make () in
   let pool = Db.Pool.get_all ~__context |> List.hd in
   let key = "event_next_test" in
-  (try Db.Pool.remove_from_other_config __context pool key with _ -> ()) ;
+  ( try Db.Pool.remove_from_other_config ~__context ~self:pool ~key
+    with _ -> ()
+  ) ;
   let (_ : Thread.t) =
     Thread.create
       (fun () ->
         let finished = ref false in
         while not !finished do
-          ignore (Xapi_event.next __context) ;
-          let oc = Db.Pool.get_other_config __context pool in
+          ignore (Xapi_event.next ~__context) ;
+          let oc = Db.Pool.get_other_config ~__context ~self:pool in
           if List.mem_assoc key oc && List.assoc key oc = "1" then (
             Printf.printf "got expected event" ;
             finished := true ;
@@ -121,7 +139,7 @@ let event_next_test () =
       ()
   in
   Thread.delay 1. ;
-  Db.Pool.add_to_other_config __context pool key "1" ;
+  Db.Pool.add_to_other_config ~__context ~self:pool ~key ~value:"1" ;
   let unblocked = not (Delay.wait wait_hdl (1.0 *. 10.)) in
   Alcotest.(check bool) "checking other_config" true unblocked
 
@@ -131,19 +149,22 @@ let wait_for_pool_key __context key =
   let pool = Db.Pool.get_all ~__context |> List.hd in
   while not !finished do
     let events =
-      Xapi_event.from __context ["pool"] !token 10. |> parse_event_from
+      Xapi_event.from ~__context ~classes:["pool"] ~token:!token ~timeout:10.
+      |> parse_event_from
     in
     token := events.token ;
-    let oc = Db.Pool.get_other_config __context pool in
+    let oc = Db.Pool.get_other_config ~__context ~self:pool in
     if List.mem_assoc key oc && List.assoc key oc = "1" then finished := true
   done
 
 let event_from_test () =
-  let __context, session_id = event_setup_common () in
+  let __context, _ = event_setup_common () in
   let wait_hdl = Delay.make () in
-  let pool = Db.Pool.get_all __context |> List.hd in
+  let pool = Db.Pool.get_all ~__context |> List.hd in
   let key = "event_from_test" in
-  (try Db.Pool.remove_from_other_config __context pool key with _ -> ()) ;
+  ( try Db.Pool.remove_from_other_config ~__context ~self:pool ~key
+    with _ -> ()
+  ) ;
   let (_ : Thread.t) =
     Thread.create
       (fun () ->
@@ -153,21 +174,25 @@ let event_from_test () =
       ()
   in
   Thread.delay 0.5 ;
-  Db.Pool.add_to_other_config __context pool key "1" ;
+  Db.Pool.add_to_other_config ~__context ~self:pool ~key ~value:"1" ;
   let unblocked = not (Delay.wait wait_hdl (0.5 *. 10.)) in
   Alcotest.(check bool) "event_from_test" true unblocked
 
 let event_from_parallel_test () =
-  let __context, session_id = event_setup_common () in
-  let pool = Db.Pool.get_all __context |> List.hd in
+  let __context, _ = event_setup_common () in
+  let pool = Db.Pool.get_all ~__context |> List.hd in
   let key = "event_next_test" in
-  (try Db.Pool.remove_from_other_config __context pool key with _ -> ()) ;
+  ( try Db.Pool.remove_from_other_config ~__context ~self:pool ~key
+    with _ -> ()
+  ) ;
   let ok = ref true in
   let (i_should_succeed : Thread.t) =
     Thread.create
       (fun () ->
         try
-          let _ = Xapi_event.from __context [] "" 2.0 in
+          let _ =
+            Xapi_event.from ~__context ~classes:[] ~token:"" ~timeout:2.0
+          in
           ()
           (* good *)
         with e ->
@@ -182,14 +207,14 @@ let event_from_parallel_test () =
   in
   Thread.delay 0.5 ;
   (* wait for both threads to block in Event.from *)
-  Db.Pool.add_to_other_config __context pool key "1" ;
+  Db.Pool.add_to_other_config ~__context ~self:pool ~key ~value:"1" ;
   Thread.join interfering_thread ;
   Thread.join i_should_succeed ;
   (* Check that Event.from didn't get cancelled by mistake *)
   Alcotest.(check bool) "event_from_parallel_test" true !ok
 
-let object_level_event_test session_id =
-  let __context, session_id = event_setup_common () in
+let object_level_event_test _session_id =
+  let __context, _ = event_setup_common () in
   let finished = ref false in
   let failure = ref false in
   let wait_hdl = Delay.make () in
@@ -198,8 +223,8 @@ let object_level_event_test session_id =
   Printf.printf "watching %s\n%!" (Ref.string_of vm_a) ;
   Printf.printf "ignoring %s\n%!" (Ref.string_of vm_b) ;
   let key = "object_level_event_next" in
-  (try Db.VM.remove_from_other_config __context vm_a key with _ -> ()) ;
-  (try Db.VM.remove_from_other_config __context vm_b key with _ -> ()) ;
+  (try Db.VM.remove_from_other_config ~__context ~self:vm_a ~key with _ -> ()) ;
+  (try Db.VM.remove_from_other_config ~__context ~self:vm_b ~key with _ -> ()) ;
   let (_ : Thread.t) =
     Thread.create
       (fun () ->
@@ -207,9 +232,9 @@ let object_level_event_test session_id =
         while not !finished do
           Printf.printf "Calling event.from...\n%!" ;
           let events =
-            Xapi_event.from __context
-              [Printf.sprintf "vm/%s" (Ref.string_of vm_a)]
-              !token 10.
+            Xapi_event.from ~__context
+              ~classes:[Printf.sprintf "vm/%s" (Ref.string_of vm_a)]
+              ~token:!token ~timeout:10.
             |> parse_event_from
           in
           Printf.printf "Got %d events\n%!" (List.length events.events) ;
@@ -225,7 +250,7 @@ let object_level_event_test session_id =
             )
             events.events ;
           token := events.token ;
-          let oc = Db.VM.get_other_config __context vm_a in
+          let oc = Db.VM.get_other_config ~__context ~self:vm_a in
           if List.mem_assoc key oc && List.assoc key oc = "1" then (
             Printf.printf "got expected event (new token = %s)\n%!" !token ;
             finished := true
@@ -238,12 +263,12 @@ let object_level_event_test session_id =
   in
   Thread.delay 0.5 ;
   Printf.printf "Adding to vm_b\n%!" ;
-  Db.VM.add_to_other_config __context vm_b key "1" ;
+  Db.VM.add_to_other_config ~__context ~self:vm_b ~key ~value:"1" ;
   Thread.delay 0.5 ;
   Printf.printf "Removing from vm_b\n%!" ;
-  Db.VM.remove_from_other_config __context vm_b key ;
+  Db.VM.remove_from_other_config ~__context ~self:vm_b ~key ;
   Printf.printf "Adding to vm_a. This ought to wake up the event thread\n%!" ;
-  Db.VM.add_to_other_config __context vm_a key "1" ;
+  Db.VM.add_to_other_config ~__context ~self:vm_a ~key ~value:"1" ;
   let blocked = Delay.wait wait_hdl (1.0 *. 10.) in
   if blocked then (
     Printf.printf "FAILURE: Didn't get expected change in event thread\n%!" ;

--- a/ocaml/tests/test_extauth_plugin_ADwinbind.ml
+++ b/ocaml/tests/test_extauth_plugin_ADwinbind.ml
@@ -26,7 +26,7 @@ module ExtractOuConfig = Generic.MakeStateless (struct
       Test_printers.(pair (assoc_list string string) (list string))
   end
 
-  let transform x = Extauth_plugin_ADwinbind.extract_ou_config x
+  let transform x = Extauth_plugin_ADwinbind.extract_ou_config ~config_params:x
 
   let tests =
     `QuickAndAutoDocumented

--- a/ocaml/tests/test_features.ml
+++ b/ocaml/tests/test_features.ml
@@ -23,10 +23,8 @@ module OfAssocList = Generic.MakeStateless (struct
 
     let string_of_input_t = Test_printers.(assoc_list string string)
 
-    let string_of_output_t =
-      Test_printers.(
-        fun features -> String.concat "," (List.map name_of_feature features)
-      )
+    let string_of_output_t features =
+      String.concat "," (List.map name_of_feature features)
   end
 
   let transform = of_assoc_list

--- a/ocaml/tests/test_guest_agent.ml
+++ b/ocaml/tests/test_guest_agent.ml
@@ -59,7 +59,7 @@ module Networks = Generic.MakeStateless (struct
       with Not_found -> []
     )
 
-  let list (T (root, children)) path =
+  let list (T (_root, children)) path =
     let nodes =
       Xapi_stdext_std.Xstringext.String.split_f (fun s -> s = '/') path
     in

--- a/ocaml/tests/test_ha_vm_failover.ml
+++ b/ocaml/tests/test_ha_vm_failover.ml
@@ -55,7 +55,7 @@ type pool = {
   ; cluster: int
 }
 
-let string_of_vm {memory; name_label} =
+let string_of_vm {memory; name_label; _} =
   Printf.sprintf "{memory = %Ld; name_label = %S}" memory name_label
 
 let string_of_host {memory_total; name_label; vms} =
@@ -370,8 +370,6 @@ let string_of_unit_result =
 
 module AssertNewVMPreservesHAPlan = Generic.MakeStateful (struct
   module Io = struct
-    open Xapi_ha_vm_failover
-
     type input_t = pool * vm
 
     type output_t = (unit, exn) result
@@ -385,7 +383,7 @@ module AssertNewVMPreservesHAPlan = Generic.MakeStateful (struct
 
   let load_input __context (pool, _) = setup ~__context pool
 
-  let extract_output __context (pool, vm) =
+  let extract_output __context (_pool, vm) =
     let open Db_filter_types in
     let local_sr =
       Db.SR.get_refs_where ~__context
@@ -510,8 +508,6 @@ end)
 
 module ComputeMaxFailures = Generic.MakeStateful (struct
   module Io = struct
-    open Xapi_ha_vm_failover
-
     type input_t = pool
 
     type output_t = int

--- a/ocaml/tests/test_host.ml
+++ b/ocaml/tests/test_host.ml
@@ -14,10 +14,6 @@
 
 open Test_common
 
-module D = Debug.Make (struct let name = "test_xapi_xenops" end)
-
-open D
-
 let add_host __context name =
   ignore
     (Xapi_host.create ~__context

--- a/ocaml/tests/test_host_helpers.ml
+++ b/ocaml/tests/test_host_helpers.ml
@@ -57,9 +57,7 @@ let setup_test_oc_watcher () =
 
 let test_host1 () =
   (* Test1: update other_config:iscsi_iqn,multipathing on host1, check they appear in the calls list *)
-  let __context, calls, host1, host2, watcher, token =
-    setup_test_oc_watcher ()
-  in
+  let __context, calls, host1, _, watcher, token = setup_test_oc_watcher () in
   Db.Host.set_multipathing ~__context ~self:host1 ~value:false ;
   Db.Host.add_to_other_config ~__context ~self:host1 ~key:"iscsi_iqn"
     ~value:"test1" ;
@@ -73,9 +71,7 @@ let test_host1 () =
 
 let test_host2 () =
   (* Test2: update other_config:iscsi_iqn,multipathing on host2, check they appear in the calls list *)
-  let __context, calls, host1, host2, watcher, token =
-    setup_test_oc_watcher ()
-  in
+  let __context, calls, _, host2, watcher, token = setup_test_oc_watcher () in
   Db.Host.set_multipathing ~__context ~self:host2 ~value:true ;
   Db.Host.add_to_other_config ~__context ~self:host2 ~key:"iscsi_iqn"
     ~value:"test2" ;
@@ -89,9 +85,7 @@ let test_host2 () =
 
 let test_different_keys () =
   (* Test3: verify that setting other other-config keys causes no set *)
-  let __context, calls, host1, host2, watcher, token =
-    setup_test_oc_watcher ()
-  in
+  let __context, calls, host1, _, watcher, token = setup_test_oc_watcher () in
   Db.Host.add_to_other_config ~__context ~self:host1 ~key:"other_key"
     ~value:"test1" ;
   let _token = watcher token in
@@ -100,9 +94,7 @@ let test_different_keys () =
 let test_host_set_iscsi_iqn () =
   (* Test3: verify that sequence of DB calls in Host.set_iscsi_iqn don't cause the
      watcher to invoke further calls *)
-  let __context, calls, host1, host2, watcher, token =
-    setup_test_oc_watcher ()
-  in
+  let __context, calls, host1, _, watcher, token = setup_test_oc_watcher () in
   Db.Host.add_to_other_config ~__context ~self:host1 ~key:"iscsi_iqn"
     ~value:"test1" ;
   let token = watcher token in

--- a/ocaml/tests/test_map_check.ml
+++ b/ocaml/tests/test_map_check.ml
@@ -13,7 +13,6 @@
  *)
 
 open Map_check
-open Test_common
 open Test_highlevel
 
 let string_of_requirement requirement =
@@ -133,7 +132,7 @@ end)
 let string_of_ty = function String -> "String" | _ -> ""
 
 let string_of_ks ks =
-  let field, kss = ks in
+  let _, kss = ks in
   List.map
     (fun (a, b) ->
       let inner_string =
@@ -169,7 +168,7 @@ module AssertAllKeys = Generic.MakeStateless (struct
     let string_of_output_t = Test_printers.(assoc_list string string)
   end
 
-  let transform (ty, ks, value, db) = assert_all_keys ty ks value db
+  let transform (ty, ks, value, db) = assert_all_keys ~ty ~ks ~value ~db
 
   let tests =
     `QuickAndAutoDocumented
@@ -372,7 +371,7 @@ module AssertKeys = Generic.MakeStateless (struct
 
     type output_t = ((string * string) list, exn) result
 
-    let string_of_input_t (ty, ks, value, db) =
+    let string_of_input_t (_, ks, value, db) =
       Printf.sprintf "keys=%s, input_value=%s, db_value=%s" (string_of_ks ks)
         (Test_printers.(assoc_list string string) value)
         (Test_printers.(assoc_list string string) db)
@@ -382,7 +381,7 @@ module AssertKeys = Generic.MakeStateless (struct
   end
 
   let transform (ty, ks, value, db) =
-    try Ok (assert_keys ty ks value db) with e -> Error e
+    try Ok (assert_keys ~ty ~ks ~value ~db) with e -> Error e
 
   let tests =
     `QuickAndAutoDocumented

--- a/ocaml/tests/test_network.ml
+++ b/ocaml/tests/test_network.ml
@@ -13,7 +13,7 @@ let with_test f =
   f network add_purpose remove_purpose get_purpose
 
 let test_add_purpose () =
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ get_purpose ->
       let network1 = network ~purpose:[] in
       let _network2 : _ API.Ref.t = network ~purpose:[] in
       add_purpose ~self:network1 ~value:`nbd ;
@@ -23,7 +23,7 @@ let test_add_purpose () =
         [`nbd]
         (get_purpose ~self:network1)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ get_purpose ->
       let network1 = network ~purpose:[] in
       let _network2 : _ API.Ref.t = network ~purpose:[`nbd] in
       add_purpose ~self:network1 ~value:`nbd ;
@@ -33,7 +33,7 @@ let test_add_purpose () =
         [`nbd]
         (get_purpose ~self:network1)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ get_purpose ->
       let network1 = network ~purpose:[] in
       let _network2 : _ API.Ref.t = network ~purpose:[] in
       add_purpose ~self:network1 ~value:`insecure_nbd ;
@@ -43,7 +43,7 @@ let test_add_purpose () =
         [`insecure_nbd]
         (get_purpose ~self:network1)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ get_purpose ->
       let network1 = network ~purpose:[] in
       let _network2 : _ API.Ref.t = network ~purpose:[`insecure_nbd] in
       add_purpose ~self:network1 ~value:`insecure_nbd ;
@@ -53,7 +53,7 @@ let test_add_purpose () =
         [`insecure_nbd]
         (get_purpose ~self:network1)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ get_purpose ->
       let network1 = network ~purpose:[`nbd] in
       add_purpose ~self:network1 ~value:`nbd ;
       assert_equal
@@ -62,7 +62,7 @@ let test_add_purpose () =
         [`nbd]
         (get_purpose ~self:network1)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ _ ->
       let network1 = network ~purpose:[`nbd] in
       Alcotest.check_raises
         "Should not be allowed to add 'insecure_nbd' to a network that already \
@@ -73,7 +73,7 @@ let test_add_purpose () =
         )
         (fun () -> add_purpose ~self:network1 ~value:`insecure_nbd)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ _ ->
       let network1 = network ~purpose:[] in
       let _network2 : _ API.Ref.t = network ~purpose:[`nbd] in
       Alcotest.check_raises
@@ -84,7 +84,7 @@ let test_add_purpose () =
         )
         (fun () -> add_purpose ~self:network1 ~value:`insecure_nbd)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ _ ->
       let network1 = network ~purpose:[`insecure_nbd] in
       Alcotest.check_raises
         "Should not be allowed to add 'nbd' to a network that already has the \
@@ -94,7 +94,7 @@ let test_add_purpose () =
         )
         (fun () -> add_purpose ~self:network1 ~value:`nbd)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network add_purpose _ _ ->
       let network1 = network ~purpose:[] in
       let _network2 : _ API.Ref.t = network ~purpose:[`insecure_nbd] in
       Alcotest.check_raises
@@ -107,7 +107,7 @@ let test_add_purpose () =
   )
 
 let test_remove_purpose () =
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network _ remove_purpose get_purpose ->
       let network1 = network ~purpose:[`nbd] in
       remove_purpose ~self:network1 ~value:`insecure_nbd ;
       assert_equal
@@ -116,7 +116,7 @@ let test_remove_purpose () =
         [`nbd]
         (get_purpose ~self:network1)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network _ remove_purpose get_purpose ->
       let network1 = network ~purpose:[] in
       remove_purpose ~self:network1 ~value:`nbd ;
       assert_equal
@@ -125,7 +125,7 @@ let test_remove_purpose () =
         []
         (get_purpose ~self:network1)
   ) ;
-  with_test (fun network add_purpose remove_purpose get_purpose ->
+  with_test (fun network _ remove_purpose get_purpose ->
       let network1 = network ~purpose:[`nbd] in
       remove_purpose ~self:network1 ~value:`nbd ;
       assert_equal

--- a/ocaml/tests/test_nm.ml
+++ b/ocaml/tests/test_nm.ml
@@ -1,5 +1,4 @@
 open Test_highlevel
-open Test_common
 
 module MaybeUpdateMasterPifMac = Generic.MakeStateful (struct
   module Io = struct

--- a/ocaml/tests/test_no_migrate.ml
+++ b/ocaml/tests/test_no_migrate.ml
@@ -64,9 +64,9 @@ let run_test (nv, nm, force, permitted) op =
         (Printf.sprintf "nv=%b nm=%b force=%b permitted=%b op=%s" nv nm force
            permitted (op_string op)
         )
-  | Some (x, xs) when not permitted ->
+  | Some _ when not permitted ->
       ()
-  | Some (x, xs) ->
+  | Some (x, _) ->
       Alcotest.fail
         (Printf.sprintf "nv=%b nm=%b force=%b permitted=%b op=%s error was=%s"
            nv nm force permitted (op_string op) x

--- a/ocaml/tests/test_pgpu.ml
+++ b/ocaml/tests/test_pgpu.ml
@@ -24,7 +24,7 @@ let on_host_with_k2 (f : Context.t -> API.ref_PGPU -> 'a) =
 
 let assert_raises_api_error msg expected_error f =
   match f () with
-  | exception Api_errors.(Server_error (actual_error, params)) ->
+  | exception Api_errors.(Server_error (actual_error, _)) ->
       Alcotest.(check string) msg expected_error actual_error
   | _ ->
       Alcotest.fail msg

--- a/ocaml/tests/test_pgpu_helpers.ml
+++ b/ocaml/tests/test_pgpu_helpers.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Test_common
 open Test_highlevel
 open Test_vgpu_common
 open Xapi_vgpu_type

--- a/ocaml/tests/test_pool_apply_edition.ml
+++ b/ocaml/tests/test_pool_apply_edition.ml
@@ -15,13 +15,13 @@
 let apply_edition_succeed ~__context ~host ~edition =
   Db.Host.set_edition ~__context ~self:host ~value:edition
 
-let apply_edition_fail_host_offline ~__context ~host ~edition =
+let apply_edition_fail_host_offline ~__context ~host ~edition:_ =
   raise Api_errors.(Server_error (host_offline, [Ref.string_of host]))
 
 let setup ~host_count ~edition =
   let __context = Test_common.make_test_database () in
   let hosts = ref [] in
-  for n = 2 to host_count do
+  for _ = 2 to host_count do
     (* Already made one in make_test_database *)
     hosts := Test_common.make_host ~__context () :: !hosts
   done ;

--- a/ocaml/tests/test_pool_cpuinfo.ml
+++ b/ocaml/tests/test_pool_cpuinfo.ml
@@ -76,58 +76,105 @@ module PoolCpuinfo = Generic.MakeStateful (struct
   let tests =
     `QuickAndAutoDocumented
       [
-        ( [(cpu_info "Abacus" "1" "1" "0000000a" "0000000a", true)]
-        , cpu_pinfo "Abacus" "1" "1" "0000000a" "0000000a"
-        )
-      ; ( [
-            (cpu_info "Abacus" "2" "4" "0000000a" "0000000a", true)
-          ; (cpu_info "Abacus" "1" "1" "0000000a" "0000000a", true)
-          ]
-        , cpu_pinfo "Abacus" "3" "5" "0000000a" "0000000a"
-        )
-      ; ( [
-            (cpu_info "Abacus" "8" "2" "0000000a" "00000002", true)
-          ; (cpu_info "Abacus" "4" "1" "0000000f" "00000001", true)
-          ]
-        , cpu_pinfo "Abacus" "12" "3" "0000000a" "00000000"
-        )
-      ; ( [
-            ( cpu_info "Abacus" "24" "1" "ffffffff-ffffffff" "ffffffff-ffffffff"
-            , true
-            )
-          ; ( cpu_info "Abacus" "24" "24" "ffffffff-ffffffff" "ffffffff-ffffffff"
+        ( [
+            ( cpu_info ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"1"
+                ~features_hvm:"0000000a" ~features_pv:"0000000a"
             , true
             )
           ]
-        , cpu_pinfo "Abacus" "48" "25" "ffffffff-ffffffff" "ffffffff-ffffffff"
+        , cpu_pinfo ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"1"
+            ~features_hvm:"0000000a" ~features_pv:"0000000a"
         )
       ; ( [
-            ( cpu_info "Abacus" "1" "1" "ffffffff" "ffffffff-ffffffff-ffffffff"
+            ( cpu_info ~vendor:"Abacus" ~cpu_count:"2" ~socket_count:"4"
+                ~features_hvm:"0000000a" ~features_pv:"0000000a"
             , true
             )
-          ; ( cpu_info "Abacus" "1" "1" "ffffffff-ffffffff" "ffffffff-ffffffff"
+          ; ( cpu_info ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"1"
+                ~features_hvm:"0000000a" ~features_pv:"0000000a"
             , true
             )
           ]
-        , cpu_pinfo "Abacus" "2" "2" "ffffffff-00000000"
-            "ffffffff-ffffffff-00000000"
+        , cpu_pinfo ~vendor:"Abacus" ~cpu_count:"3" ~socket_count:"5"
+            ~features_hvm:"0000000a" ~features_pv:"0000000a"
         )
       ; ( [
-            (cpu_info "Abacus" "10" "1" "01230123-5a5a5a5a" "00000002", true)
-          ; (cpu_info "Abacus" "1" "10" "ffff1111-a5a56666" "00004242", true)
+            ( cpu_info ~vendor:"Abacus" ~cpu_count:"8" ~socket_count:"2"
+                ~features_hvm:"0000000a" ~features_pv:"00000002"
+            , true
+            )
+          ; ( cpu_info ~vendor:"Abacus" ~cpu_count:"4" ~socket_count:"1"
+                ~features_hvm:"0000000f" ~features_pv:"00000001"
+            , true
+            )
           ]
-        , cpu_pinfo "Abacus" "11" "11" "01230101-00004242" "00000002"
+        , cpu_pinfo ~vendor:"Abacus" ~cpu_count:"12" ~socket_count:"3"
+            ~features_hvm:"0000000a" ~features_pv:"00000000"
+        )
+      ; ( [
+            ( cpu_info ~vendor:"Abacus" ~cpu_count:"24" ~socket_count:"1"
+                ~features_hvm:"ffffffff-ffffffff"
+                ~features_pv:"ffffffff-ffffffff"
+            , true
+            )
+          ; ( cpu_info ~vendor:"Abacus" ~cpu_count:"24" ~socket_count:"24"
+                ~features_hvm:"ffffffff-ffffffff"
+                ~features_pv:"ffffffff-ffffffff"
+            , true
+            )
+          ]
+        , cpu_pinfo ~vendor:"Abacus" ~cpu_count:"48" ~socket_count:"25"
+            ~features_hvm:"ffffffff-ffffffff" ~features_pv:"ffffffff-ffffffff"
+        )
+      ; ( [
+            ( cpu_info ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"1"
+                ~features_hvm:"ffffffff"
+                ~features_pv:"ffffffff-ffffffff-ffffffff"
+            , true
+            )
+          ; ( cpu_info ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"1"
+                ~features_hvm:"ffffffff-ffffffff"
+                ~features_pv:"ffffffff-ffffffff"
+            , true
+            )
+          ]
+        , cpu_pinfo ~vendor:"Abacus" ~cpu_count:"2" ~socket_count:"2"
+            ~features_hvm:"ffffffff-00000000"
+            ~features_pv:"ffffffff-ffffffff-00000000"
+        )
+      ; ( [
+            ( cpu_info ~vendor:"Abacus" ~cpu_count:"10" ~socket_count:"1"
+                ~features_hvm:"01230123-5a5a5a5a" ~features_pv:"00000002"
+            , true
+            )
+          ; ( cpu_info ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"10"
+                ~features_hvm:"ffff1111-a5a56666" ~features_pv:"00004242"
+            , true
+            )
+          ]
+        , cpu_pinfo ~vendor:"Abacus" ~cpu_count:"11" ~socket_count:"11"
+            ~features_hvm:"01230101-00004242" ~features_pv:"00000002"
         )
       ; (* Include one host that is not HVM-capable *)
         ( [
-            (cpu_info "Abacus" "10" "1" "00000000-00000000" "00000002", false)
-          ; (cpu_info "Abacus" "1" "10" "ffff1111-a5a56666" "00004242", true)
+            ( cpu_info ~vendor:"Abacus" ~cpu_count:"10" ~socket_count:"1"
+                ~features_hvm:"00000000-00000000" ~features_pv:"00000002"
+            , false
+            )
+          ; ( cpu_info ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"10"
+                ~features_hvm:"ffff1111-a5a56666" ~features_pv:"00004242"
+            , true
+            )
           ]
-        , cpu_pinfo "Abacus" "11" "11" "ffff1111-a5a56666" "00000002"
+        , cpu_pinfo ~vendor:"Abacus" ~cpu_count:"11" ~socket_count:"11"
+            ~features_hvm:"ffff1111-a5a56666" ~features_pv:"00000002"
         )
       ; (* Test a Dundee host which has features_hvm, but not features_hvm_host (test for CA-188665 no longer relevant, was for pre-Dundeee) *)
         ( [
-            (cpu_info "Abacus" "1" "1" "01230123-5a5a5a5a" "00000002", true)
+            ( cpu_info ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"1"
+                ~features_hvm:"01230123-5a5a5a5a" ~features_pv:"00000002"
+            , true
+            )
           ; ( [
                 ("cpu_count", "1")
               ; ("features", "ffff1111-a5a56666")
@@ -139,18 +186,25 @@ module PoolCpuinfo = Generic.MakeStateful (struct
             , true
             )
           ]
-        , cpu_pinfo "Abacus" "2" "2" "01230101-00004242" "00000002"
+        , cpu_pinfo ~vendor:"Abacus" ~cpu_count:"2" ~socket_count:"2"
+            ~features_hvm:"01230101-00004242" ~features_pv:"00000002"
         )
       ; (* Test that the new _host fields are used for pool leveling *)
         ( [
-            ( cpu_info_common "Abacus" "1" "1" "deadbeef-deadbeef" "deadbeef"
-                "01230123-5a5a5a5a" "00000002"
+            ( cpu_info_common ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"1"
+                ~features_hvm:"deadbeef-deadbeef" ~features_pv:"deadbeef"
+                ~features_hvm_host:"01230123-5a5a5a5a"
+                ~features_pv_host:"00000002"
             , true
             )
-          ; (cpu_info "Abacus" "1" "1" "01230123-5a5a5a5a" "00000002", true)
+          ; ( cpu_info ~vendor:"Abacus" ~cpu_count:"1" ~socket_count:"1"
+                ~features_hvm:"01230123-5a5a5a5a" ~features_pv:"00000002"
+            , true
+            )
           ]
-        , cpu_info_common "Abacus" "2" "2" "00210023-5a081a4a" "00000002"
-            "01230123-5a5a5a5a" "00000002"
+        , cpu_info_common ~vendor:"Abacus" ~cpu_count:"2" ~socket_count:"2"
+            ~features_hvm:"00210023-5a081a4a" ~features_pv:"00000002"
+            ~features_hvm_host:"01230123-5a5a5a5a" ~features_pv_host:"00000002"
         )
       ]
 end)

--- a/ocaml/tests/test_pool_update.ml
+++ b/ocaml/tests/test_pool_update.ml
@@ -29,16 +29,16 @@ let test_pool_update_refcount () =
   let __context = make_test_database () in
   let vdi = make_vdi ~__context ~virtual_size:4096L () in
   Xapi_pool_update.with_inc_refcount ~__context ~uuid:"a" ~vdi
-    (fun ~__context ~uuid ~vdi -> ()
+    (fun ~__context ~uuid:_ ~vdi:_ -> ()
   ) ;
   Xapi_pool_update.with_inc_refcount ~__context ~uuid:"a" ~vdi
-    (fun ~__context ~uuid ~vdi -> assert_equal 0 1
+    (fun ~__context ~uuid:_ ~vdi:_ -> assert_equal 0 1
   ) ;
   Xapi_pool_update.with_dec_refcount ~__context ~uuid:"a" ~vdi
-    (fun ~__context ~uuid ~vdi -> assert_equal 0 1
+    (fun ~__context ~uuid:_ ~vdi:_ -> assert_equal 0 1
   ) ;
   Xapi_pool_update.with_dec_refcount ~__context ~uuid:"a" ~vdi
-    (fun ~__context ~uuid ~vdi -> ()
+    (fun ~__context ~uuid:_ ~vdi:_ -> ()
   )
 
 let test_assert_space_available () =

--- a/ocaml/tests/test_psr.ml
+++ b/ocaml/tests/test_psr.ml
@@ -110,8 +110,6 @@ module Impl =
 functor
   (Hosts : sig
      val master : master
-
-     val members : member list
    end)
   ->
   struct
@@ -195,12 +193,8 @@ end
 
 (* the test implementation has been defined above,
    and we use this function to access it *)
-let mk_psr master members =
-  let module PSR = Xapi_psr.Make (Impl (struct
-    let master = master
-
-    let members = members
-  end)) in
+let mk_psr master =
+  let module PSR = Xapi_psr.Make (Impl (struct let master = master end)) in
   let module PSR = struct
     include PSR
 
@@ -294,7 +288,7 @@ let almost_all_possible_fists ~num_hosts =
 
 let test_no_fistpoint () =
   let master, members = mk_hosts 6 in
-  let module PSR = (val mk_psr master members) in
+  let module PSR = (val mk_psr master) in
   let r = PSR.start (default_pool_secret, new_pool_secret) ~master ~members in
   check_psr_succeeded r new_pool_secret master members
 
@@ -304,7 +298,7 @@ let test_no_fistpoint () =
 let test_fail_once () =
   let num_hosts = 3 in
   let master, members = mk_hosts num_hosts in
-  let module PSR = (val mk_psr master members) in
+  let module PSR = (val mk_psr master) in
   let hosts = master.member :: members in
   almost_all_possible_fists ~num_hosts
   |> List.iter (fun (fistpoint, host_id, exp_err) ->
@@ -329,7 +323,7 @@ let test_master_fails_during_cleanup () =
   let open Xapi_psr in
   let num_hosts = 6 in
   let master, members = mk_hosts num_hosts in
-  let module PSR = (val mk_psr master members) in
+  let module PSR = (val mk_psr master) in
   let fistpoint = (After, Cleanup) in
   let exp_err = Error (Failed_during_cleanup, 0) in
   master.member.fistpoint <- Some fistpoint ;

--- a/ocaml/tests/test_session.ml
+++ b/ocaml/tests/test_session.ml
@@ -1,4 +1,3 @@
-open Test_common
 module Date = Xapi_stdext_date.Date
 
 let now = Date.of_string "2020-09-22T14:57:11Z"
@@ -14,7 +13,7 @@ let fail_login ~__context ~uname ~originator ~now () =
         else
           raise (Auth_signature.Auth_failure "Auth failure")
     )
-  with e -> ()
+  with _ -> ()
 
 let success_login ~__context ~uname ~originator ~now () =
   Xapi_session._record_login_failure ~__context ~now ~uname ~originator

--- a/ocaml/tests/test_sm_features.ml
+++ b/ocaml/tests/test_sm_features.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Test_common
 open Test_highlevel
 
 type sm_object = {capabilities: string list; features: (string * int64) list}

--- a/ocaml/tests/test_sr_allowed_operations.ml
+++ b/ocaml/tests/test_sr_allowed_operations.ml
@@ -16,7 +16,7 @@ open Test_common
 
 (* Helpers for testing Xapi_sr_operations.assert_operation_valid *)
 
-let setup_test ~__context ?sm_fun ?vdi_fun () =
+let setup_test ~__context ?sm_fun ?vdi_fun:_ () =
   let run f x = match f with Some f -> ignore (f x) | None -> () in
   let _sm_ref = make_sm ~__context () in
   let sr_ref = make_sr ~__context () in
@@ -44,7 +44,7 @@ let check_operation_error f exn =
 let test_operations_restricted_during_rpu =
   let test_check_operation_error () =
     let __context = Mock.make_context_with_new_db "Mock context" in
-    let master = Test_common.make_host __context () in
+    let master = Test_common.make_host ~__context () in
     let pool = Test_common.make_pool ~__context ~master () in
     let sr_ref, _ = setup_test ~__context () in
     (* Artificially put xapi into RPU mode - see Helpers.rolling_upgrade_in_progress *)

--- a/ocaml/tests/test_valid_ref_list.ml
+++ b/ocaml/tests/test_valid_ref_list.ml
@@ -26,7 +26,7 @@ let test_exists =
 
 let test_valid_ref_filter =
   with_vm_list (fun __context -> function
-    | [vm1; vm2; vm3; vm4] as l ->
+    | [vm1; _; _; vm4] as l ->
         let assert_equal l1 l2 =
           let as_strings = List.map Ref.string_of in
           assert_equal (l1 |> as_strings) (l2 |> as_strings)
@@ -77,7 +77,7 @@ let test_flat_map =
 
 let test_filter_map =
   with_vm_list (fun __context -> function
-    | [vm1; vm2; vm3; vm4] as l ->
+    | [_; _; _; _] as l ->
         let f vm =
           let n = Db.VM.get_name_label ~__context ~self:vm in
           if n = "c" then Some n else None

--- a/ocaml/tests/test_vdi_allowed_operations.ml
+++ b/ocaml/tests/test_vdi_allowed_operations.ml
@@ -458,7 +458,7 @@ let test_cbt =
 let test_operations_restricted_during_rpu =
   let test_check_operation_error () =
     let __context = Mock.make_context_with_new_db "Mock context" in
-    let master = Test_common.make_host __context () in
+    let master = Test_common.make_host ~__context () in
     let pool = Test_common.make_pool ~__context ~master () in
     Db.Pool.add_to_other_config ~__context ~self:pool
       ~key:Xapi_globs.rolling_upgrade_in_progress ~value:"x" ;
@@ -478,7 +478,7 @@ let test_operations_restricted_during_rpu =
   in
   let test_update_allowed_operations () =
     let __context = Mock.make_context_with_new_db "Mock context" in
-    let master = Test_common.make_host __context () in
+    let master = Test_common.make_host ~__context () in
     let pool = Test_common.make_pool ~__context ~master () in
     Db.Pool.add_to_other_config ~__context ~self:pool
       ~key:Xapi_globs.rolling_upgrade_in_progress ~value:"x" ;
@@ -532,7 +532,7 @@ let test_null_vm =
 
 let test_update_allowed_operations () =
   let __context = Test_common.make_test_database () in
-  let vdi_ref, vdi_record =
+  let vdi_ref, _ =
     setup_test ~__context
       ~vdi_fun:(fun vdi_ref ->
         let host_ref = Helpers.get_localhost ~__context in

--- a/ocaml/tests/test_vlan.ml
+++ b/ocaml/tests/test_vlan.ml
@@ -89,7 +89,10 @@ let test_create_unmanaged_pif () =
   let tagged_PIF = make_pif ~__context ~network ~host ~managed:false () in
   assert_raises_api_error Api_errors.pif_unmanaged
     ~args:[Ref.string_of tagged_PIF] (fun () ->
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      in
+      ()
   )
 
 let test_create_network_already_connected () =
@@ -100,7 +103,10 @@ let test_create_network_already_connected () =
   let tagged_PIF = make_pif ~__context ~network ~host () in
   assert_raises_api_error Api_errors.network_already_connected
     ~args:[Ref.string_of host; Ref.string_of tagged_PIF] (fun () ->
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network
+      in
+      ()
   )
 
 let test_create_pif_is_bond_slave () =
@@ -115,7 +121,10 @@ let test_create_pif_is_bond_slave () =
   let vlan_network = make_network ~__context ~bridge:"xapi0" () in
   assert_raises_api_error Api_errors.cannot_add_vlan_to_bond_slave
     ~args:[Ref.string_of tagged_PIF] (fun () ->
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      in
+      ()
   )
 
 let test_create_pif_is_vlan_master () =
@@ -129,8 +138,11 @@ let test_create_pif_is_vlan_master () =
   assert_raises_api_error Api_errors.pif_is_vlan
     ~args:[Ref.string_of untagged_PIF] (fun () ->
       let tag = 3201L in
-      Xapi_vlan.create ~__context ~tagged_PIF:untagged_PIF ~tag
-        ~network:vlan_network2
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF:untagged_PIF ~tag
+          ~network:vlan_network2
+      in
+      ()
   )
 
 let test_create_pif_is_vlan_master_on_sriov () =
@@ -145,8 +157,11 @@ let test_create_pif_is_vlan_master_on_sriov () =
   assert_raises_api_error Api_errors.pif_is_vlan
     ~args:[Ref.string_of untagged_PIF] (fun () ->
       let tag = 3201L in
-      Xapi_vlan.create ~__context ~tagged_PIF:untagged_PIF ~tag
-        ~network:vlan_network2
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF:untagged_PIF ~tag
+          ~network:vlan_network2
+      in
+      ()
   )
 
 let test_create_invalid_tag () =
@@ -158,12 +173,19 @@ let test_create_invalid_tag () =
   let tagged_PIF = make_pif ~__context ~network ~host () in
   assert_raises_api_error Api_errors.vlan_tag_invalid
     ~args:[Int64.to_string tag] (fun () ->
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      in
+      ()
   ) ;
   let new_tag = 4095L in
   assert_raises_api_error Api_errors.vlan_tag_invalid
     ~args:[Int64.to_string new_tag] (fun () ->
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag:new_tag ~network:vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag:new_tag
+          ~network:vlan_network
+      in
+      ()
   )
 
 let test_create_vlan_already_exists () =
@@ -180,7 +202,10 @@ let test_create_vlan_already_exists () =
   in
   let new_vlan_network = make_network ~__context ~bridge:"xapi1" () in
   assert_raises_api_error Api_errors.pif_vlan_exists ~args:[device] (fun () ->
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:new_vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:new_vlan_network
+      in
+      ()
   )
 
 let test_create_pif_is_tunnel_access () =
@@ -194,7 +219,10 @@ let test_create_pif_is_tunnel_access () =
   in
   assert_raises_api_error Api_errors.is_tunnel_access_pif
     ~args:[Ref.string_of tagged_PIF] (fun () ->
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      in
+      ()
   )
 
 let test_gc_vlan () =
@@ -238,7 +266,10 @@ let test_create_sriov_vlan_into_non_sriov_vlan_network () =
   assert_raises_api_error Api_errors.network_incompatible_with_vlan_on_sriov
     ~args:[Ref.string_of vlan_network] (fun () ->
       let tag = 3201L in
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      in
+      ()
   )
 
 let test_create_non_sriov_vlan_into_sriov_vlan_network () =
@@ -259,7 +290,10 @@ let test_create_non_sriov_vlan_into_sriov_vlan_network () =
   assert_raises_api_error Api_errors.network_incompatible_with_vlan_on_bridge
     ~args:[Ref.string_of vlan_network] (fun () ->
       let tag = 3201L in
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      in
+      ()
   )
 
 let test_create_sriov_vlan_into_sriov_vlan_network_with_different_type_pci_device
@@ -286,7 +320,10 @@ let test_create_sriov_vlan_into_sriov_vlan_network_with_different_type_pci_devic
   assert_raises_api_error Api_errors.network_has_incompatible_vlan_on_sriov_pifs
     ~args:[Ref.string_of tagged_PIF; Ref.string_of vlan_network] (fun () ->
       let tag = 3201L in
-      Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      let (_ : [`VLAN] Ref.t) =
+        Xapi_vlan.create ~__context ~tagged_PIF ~tag ~network:vlan_network
+      in
+      ()
   )
 
 let test =

--- a/ocaml/tests/test_vm_check_operation_error.ml
+++ b/ocaml/tests/test_vm_check_operation_error.ml
@@ -139,7 +139,7 @@ let test_migration_allowed_when_cbt_enabled_vdis_are_not_moved () =
 
 let test_sxm_allowed_when_rum () =
   with_test_vm (fun __context vm_ref ->
-      let master = Test_common.make_host __context () in
+      let master = Test_common.make_host ~__context () in
       let pool = Test_common.make_pool ~__context ~master () in
       Db.Pool.add_to_other_config ~__context ~self:pool
         ~key:Xapi_globs.rolling_upgrade_in_progress ~value:"x" ;

--- a/ocaml/tests/test_vm_helpers.ml
+++ b/ocaml/tests/test_vm_helpers.ml
@@ -124,7 +124,7 @@ let assert_host_group_coherent g =
   match g with
   | [] ->
       ()
-  | (h, c) :: _ ->
+  | (_, c) :: _ ->
       assert_list_is_set (List.map fst g) ;
       Alcotest.(check bool)
         "Score not same for all hosts in group" true
@@ -197,7 +197,7 @@ let check_expectations ~__context gpu_group visible_hosts vgpu_type
 let test_group_hosts_bf () =
   on_pool_of_k1s
     VGPU_T.(
-      fun __context h h' h'' ->
+      fun __context _ h' h'' ->
         let gpu_group = List.hd (Db.GPU_group.get_all ~__context) in
         Db.GPU_group.set_allocation_algorithm ~__context ~self:gpu_group
           ~value:`breadth_first ;
@@ -206,18 +206,19 @@ let test_group_hosts_bf () =
           @ Db.Host.get_PGPUs ~__context ~self:h''
         with
         | [h'_p; h''_p; h''_p'] ->
-            check_expectations __context gpu_group [h'; h''] k100 [[h'']; [h']] ;
-            check_expectations __context gpu_group [h'; h''] k140q [[h'']; [h']] ;
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h'']; [h']] ;
+            check_expectations ~__context gpu_group [h'; h''] k140q
+              [[h'']; [h']] ;
             ignore (make_vgpu ~__context ~resident_on:h''_p k100) ;
-            check_expectations __context gpu_group [h'; h''] k100 [[h'']; [h']] ;
-            check_expectations __context gpu_group [h'; h''] k140q [[h'; h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h'']; [h']] ;
+            check_expectations ~__context gpu_group [h'; h''] k140q [[h'; h'']] ;
             ignore (make_vgpu ~__context ~resident_on:h''_p' k140q) ;
-            check_expectations __context gpu_group [h'; h''] k100 [[h']; [h'']] ;
-            check_expectations __context gpu_group [h''] k140q [[h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h']; [h'']] ;
+            check_expectations ~__context gpu_group [h''] k140q [[h'']] ;
             ignore (make_vgpu ~__context ~resident_on:h'_p k100) ;
-            check_expectations __context gpu_group [h'; h''] k100 [[h'; h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h'; h'']] ;
             ignore (make_vgpu ~__context ~resident_on:h'_p k100) ;
-            check_expectations __context gpu_group [h'; h''] k100 [[h'']; [h']]
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h'']; [h']]
         | _ ->
             Alcotest.fail
               "Test-failure: Unexpected number of pgpus in test setup"
@@ -226,7 +227,7 @@ let test_group_hosts_bf () =
 let test_group_hosts_df () =
   on_pool_of_k1s
     VGPU_T.(
-      fun __context h h' h'' ->
+      fun __context _ h' h'' ->
         let gpu_group = List.hd (Db.GPU_group.get_all ~__context) in
         Db.GPU_group.set_allocation_algorithm ~__context ~self:gpu_group
           ~value:`depth_first ;
@@ -235,18 +236,19 @@ let test_group_hosts_df () =
           @ Db.Host.get_PGPUs ~__context ~self:h''
         with
         | [h'_p; h''_p; h''_p'] ->
-            check_expectations __context gpu_group [h'; h''] k100 [[h']; [h'']] ;
-            check_expectations __context gpu_group [h'; h''] k140q [[h']; [h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h']; [h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k140q
+              [[h']; [h'']] ;
             ignore (make_vgpu ~__context ~resident_on:h''_p k100) ;
-            check_expectations __context gpu_group [h'; h''] k100 [[h']; [h'']] ;
-            check_expectations __context gpu_group [h'; h''] k140q [[h'; h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h']; [h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k140q [[h'; h'']] ;
             ignore (make_vgpu ~__context ~resident_on:h''_p' k140q) ;
-            check_expectations __context gpu_group [h'; h''] k100 [[h'']; [h']] ;
-            check_expectations __context gpu_group [h''] k140q [[h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h'']; [h']] ;
+            check_expectations ~__context gpu_group [h''] k140q [[h'']] ;
             ignore (make_vgpu ~__context ~resident_on:h'_p k100) ;
-            check_expectations __context gpu_group [h'; h''] k100 [[h'; h'']] ;
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h'; h'']] ;
             ignore (make_vgpu ~__context ~resident_on:h'_p k100) ;
-            check_expectations __context gpu_group [h'; h''] k100 [[h']; [h'']]
+            check_expectations ~__context gpu_group [h'; h''] k100 [[h']; [h'']]
         | _ ->
             Alcotest.fail
               "Test-failure: Unexpected number of pgpus in test setup"
@@ -414,7 +416,7 @@ let assert_grouping_of_sriov ~__context ~network ~expection_groups =
   assert_equivalent expection_groups host_lists
 
 let test_group_hosts_netsriov () =
-  on_pool_of_intel_i350 (fun __context h h' h'' ->
+  on_pool_of_intel_i350 (fun __context _ h' h'' ->
       let sriov_networks =
         List.find_all
           (fun network ->
@@ -442,7 +444,7 @@ let test_group_hosts_netsriov () =
   )
 
 let test_group_hosts_netsriov_unattached () =
-  on_pool_of_intel_i350 (fun __context h h' h'' ->
+  on_pool_of_intel_i350 (fun __context _ h' h'' ->
       let sriov_networks =
         List.find_all
           (fun network ->
@@ -476,7 +478,7 @@ let test_group_hosts_netsriov_unattached () =
   )
 
 let test_group_hosts_netsriov_with_allocated () =
-  on_pool_of_intel_i350 (fun __context h h' h'' ->
+  on_pool_of_intel_i350 (fun __context _ h' h'' ->
       let sriov_networks =
         List.find_all
           (fun network ->
@@ -523,7 +525,7 @@ let test_group_hosts_netsriov_with_allocated () =
   )
 
 let test_get_group_key_vgpu () =
-  on_pool_of_intel_i350 (fun __context _ h' _ ->
+  on_pool_of_intel_i350 (fun __context _ _ _ ->
       let group = List.hd (Db.GPU_group.get_all ~__context) in
       let vm = make_vm_with_vgpu_in_group ~__context VGPU_T.k100 group in
       match Xapi_vm_helpers.get_group_key ~__context ~vm with
@@ -534,7 +536,7 @@ let test_get_group_key_vgpu () =
   )
 
 let test_get_group_key_netsriov () =
-  on_pool_of_intel_i350 (fun __context _ h' _ ->
+  on_pool_of_intel_i350 (fun __context _ _ _ ->
       let sriov_network =
         List.find
           (fun network ->
@@ -551,7 +553,7 @@ let test_get_group_key_netsriov () =
   )
 
 let test_get_group_key_vgpu_and_netsriov () =
-  on_pool_of_intel_i350 (fun __context _ h' _ ->
+  on_pool_of_intel_i350 (fun __context _ _ _ ->
       let group = List.hd (Db.GPU_group.get_all ~__context) in
       let vm = make_vm_with_vgpu_in_group ~__context VGPU_T.k100 group in
       let sriov_network =

--- a/ocaml/tests/test_vm_placement.ml
+++ b/ocaml/tests/test_vm_placement.ml
@@ -631,13 +631,11 @@ module Categorisation = struct
 end
 
 module Selection = struct
-  open Construction
+  let match_no_hosts _ = -1L
 
-  let match_no_hosts host = -1L
+  let match_all_hosts _ = 1L
 
-  let match_all_hosts host = 1L
-
-  let validate_all_hosts host = true
+  let validate_all_hosts _ = true
 
   let select_first_host () = 0.0
 

--- a/ocaml/tests/test_xapi_cmd_result.ml
+++ b/ocaml/tests/test_xapi_cmd_result.ml
@@ -25,7 +25,8 @@ module XapiCmdResult = Generic.MakeStateless (struct
     let string_of_output_t = Test_printers.(option string)
   end
 
-  let transform (sep, key, lines) = Xapi_cmd_result.of_output_opt sep key lines
+  let transform (sep, key, lines) =
+    Xapi_cmd_result.of_output_opt ~sep ~key ~lines
 
   let tests =
     `QuickAndAutoDocumented

--- a/ocaml/tests/test_xapi_xenops.ml
+++ b/ocaml/tests/test_xapi_xenops.ml
@@ -1,5 +1,4 @@
 open Test_common
-open Test_vgpu_common
 
 module D = Debug.Make (struct let name = "test_xapi_xenops" end)
 
@@ -265,7 +264,7 @@ let test_nested_virt_licensing () =
                (string_of_platform platform)
             )
       with
-      | Api_errors.Server_error (e, l)
+      | Api_errors.Server_error (e, _)
       when e = Api_errors.license_restriction
       ->
         if not should_raise then

--- a/ocaml/tests/test_xenopsd_metadata.ml
+++ b/ocaml/tests/test_xenopsd_metadata.ml
@@ -28,7 +28,7 @@ let string_of_vm_config conf =
     (Test_printers.(assoc_list string string) conf.oc)
     (Test_printers.(assoc_list string string) conf.platform)
 
-let string_of_vgpu_type {Xapi_vgpu_type.vendor_name; model_name} =
+let string_of_vgpu_type {Xapi_vgpu_type.vendor_name; model_name; _} =
   Printf.sprintf "vendor_name = %s, model_name = %s" vendor_name model_name
 
 let load_vm_config __context conf =
@@ -71,7 +71,7 @@ module HVMSerial = Generic.MakeStateful (struct
   let extract_output __context _ =
     let metadata = run_create_metadata ~__context in
     match metadata.Metadata.vm.Vm.ty with
-    | Vm.HVM {Vm.serial} ->
+    | Vm.HVM {Vm.serial; _} ->
         serial
     | _ ->
         failwith "expected HVM metadata"
@@ -141,7 +141,7 @@ module VideoMode = Generic.MakeStateful (struct
   let extract_output __context _ =
     let metadata = run_create_metadata ~__context in
     match metadata.Metadata.vm.Vm.ty with
-    | Vm.HVM {Vm.video= video_mode} ->
+    | Vm.HVM {Vm.video= video_mode; _} ->
         video_mode
     | _ ->
         failwith "expected HVM metadata"
@@ -190,7 +190,7 @@ module VideoRam = Generic.MakeStateful (struct
   let extract_output __context _ =
     let metadata = run_create_metadata ~__context in
     match metadata.Metadata.vm.Vm.ty with
-    | Vm.HVM {Vm.video_mib} ->
+    | Vm.HVM {Vm.video_mib; _} ->
         video_mib
     | _ ->
         failwith "expected HVM metadata"

--- a/ocaml/vhd-tool/src/cohttp_unbuffered_io.ml
+++ b/ocaml/vhd-tool/src/cohttp_unbuffered_io.ml
@@ -66,8 +66,6 @@ let read_http_headers c =
     let remaining x = String.length x.marker - x.i
 
     let matched x = x.i = String.length x.marker
-
-    let to_string x = Printf.sprintf "%d" x.i
   end in
   let marker = Scanner.make end_of_headers in
 

--- a/ocaml/vhd-tool/src/image.ml
+++ b/ocaml/vhd-tool/src/image.ml
@@ -8,8 +8,6 @@ let is_nbd_device path =
   let major, _ = get_device_numbers path in
   major = nbd_device_num
 
-module Opt = struct let default d = function None -> d | Some x -> x end
-
 type t = [`Vhd of string | `Raw of string | `Nbd of string * string]
 
 let to_string = function


### PR DESCRIPTION
The PR is better reviewed commit by commit. The warnings removed are mostly unlabeled parameters in Client calls and unused bindings.

For autogenerated code I've opted for ignoring the warnings emitted rather than trying to change the code generated.

The quality gate doesn't change much because I've held off some changes that happen before the ones in the compiled units fixed here. I believe the other changes are more contentious and I want to test more rigorously.

The changes in here should not be contentious as
1. They add parameter labels, which makes it difficult to introduce errors; and
2. Changes in tests surface errors really fast in obvious ways