### PR TITLE
users in pool admin group which contains # can not ssh into dom0

### DIFF
--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -10,8 +10,6 @@
 # Alternatively, the extauth-hook module can be called, which will
 # dispatch to the correct extauth-hook-<type>.py module automatically.
 import abc
-import XenAPIPlugin
-import XenAPI
 import sys
 import subprocess
 import os
@@ -20,6 +18,9 @@ import logging
 import logging.handlers
 from collections import OrderedDict
 from enum import Enum
+import XenAPIPlugin
+import XenAPI
+
 
 # this plugin manage following configuration files for external auth
 # - /etc/nsswitch.conf
@@ -31,7 +32,8 @@ from enum import Enum
 
 
 def setup_logger():
-    logger = logging.getLogger()
+    """Helper function setup logger"""
+    log = logging.getLogger()
     logging.basicConfig(
         format='%(asctime)s %(levelname)s %(name)s %(funcName)s %(message)s', level=logging.DEBUG)
     # Send to syslog local5, which will be redirected to xapi log /var/log/xensource.log
@@ -41,9 +43,9 @@ def setup_logger():
     # Send to authpriv, which will be redirected to /var/log/secure
     auth_log = logging.handlers.SysLogHandler(
         facility="authpriv", address='/dev/log')
-    logger.addHandler(handler)
-    logger.addHandler(std_err)
-    logger.addHandler(auth_log)
+    log.addHandler(handler)
+    log.addHandler(std_err)
+    log.addHandler(auth_log)
 
 
 setup_logger()
@@ -51,60 +53,73 @@ logger = logging.getLogger(__name__)
 
 
 def run_cmd(cmd, log_cmd=True):
+    """Helper function to run command"""
     try:
         result = subprocess.check_output(cmd)
         if log_cmd:
-            logger.debug("{} -> {}".format(cmd, result))
+            msg = "{} -> {}".format(cmd, result)
+            logger.debug(msg)
         return result.strip()
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         logger.exception("Failed to run command %s", cmd)
         return None
 
 
 class ADBackend(Enum):
-    bd_pbis = 0
-    bd_winbind = 1
+    """Enum for AD backend"""
+    BD_PBIS = 0
+    BD_WINBIND = 1
 
 
+# pylint: disable=useless-object-inheritance, too-few-public-methods
 class ADConfig(object):
+    """Base class for AD configuration"""
+    #pylint: disable=too-many-arguments
+
     def __init__(self, path, session, args, ad_enabled=True, load_existing=True, file_mode=0o644):
         self._file_path = path
         self._session = session
         self._args = args
         self._lines = []
-        self._backend = self._get_ad_backend(args)
+        self._backend = self._get_ad_backend()
         self._ad_enabled = ad_enabled
         self._file_mode = file_mode
         if load_existing and os.path.exists(self._file_path):
-            with open(self._file_path, 'r') as f:
-                lines = f.readlines()
+            with open(self._file_path, 'r') as file:
+                lines = file.readlines()
                 self._lines = [l.strip() for l in lines]
 
-    def _get_ad_backend(self, args):
-        if args.get("ad_backend", "winbind") == "pbis":
+    def _get_ad_backend(self):
+        """Get atctive AD backend"""
+        if self._args.get("ad_backend", "winbind") == "pbis":
             logger.debug("pbis is used as AD backend")
-            return ADBackend.bd_pbis
+            return ADBackend.BD_PBIS
 
         logger.debug("winbind is used as AD backend")
-        return ADBackend.bd_winbind
+        return ADBackend.BD_WINBIND
 
     @abc.abstractmethod
     def _apply_to_cache(self):
         pass
 
     def apply(self):
+        """Apply configuration"""
         self._apply_to_cache()
         self._install()
 
     def _install(self):
-        with tempfile.NamedTemporaryFile(prefix="extauth-", delete=False) as f:
-            f.write("\n".join(self._lines).encode())
-            f.flush()
-            os.rename(f.name, self._file_path)
+        """Install configuration"""
+        with tempfile.NamedTemporaryFile(prefix="extauth-", delete=False) as file:
+            file.write("\n".join(self._lines).encode())
+            file.flush()
+            os.rename(file.name, self._file_path)
             os.chmod(self._file_path, self._file_mode)
 
 
-class StaticPam(ADConfig):
+class StaticSSHPam(ADConfig):
+    """
+    Class to manage ssh pam configuration
+    """
     ad_pam_format = """#%PAM-1.0
 auth        required      pam_env.so
 auth        sufficient    pam_unix.so try_first_pass nullok
@@ -133,12 +148,12 @@ session    include      system-auth
 session    required     pam_loginuid.so"""
 
     def __init__(self, session, args, ad_enabled=True):
-        super(StaticPam, self).__init__("/etc/pam.d/sshd", session, args, ad_enabled,
+        super(StaticSSHPam, self).__init__("/etc/pam.d/sshd", session, args, ad_enabled,
                                         load_existing=False)
 
     def _apply_to_cache(self):
         if self._ad_enabled:
-            if self._backend == ADBackend.bd_pbis:
+            if self._backend == ADBackend.BD_PBIS:
                 ad_pam_module = "/lib/security/pam_lsass.so"
             else:
                 ad_pam_module = "pam_winbind.so"
@@ -173,14 +188,13 @@ class DynamicPam(ADConfig):
 
     def _format_item(self, item):
         space_replacement = "+"
-        if space_replacement in item:
-            raise ValueError(
-                "{} is not permitted in subject name".format(space_replacement))
-
         if " " not in item:
             return item
+        if self._backend == ADBackend.BD_PBIS:
+            if space_replacement in item:
+                raise ValueError(
+                    "{} is not permitted in subject name".format(space_replacement))
 
-        if self._backend == ADBackend.bd_pbis:
             # PBIS relace space with "+", eg "ab  cd" -> "ab++cd"
             # PBIS pam module will reverse it back
             return item.replace(" ", space_replacement)
@@ -225,10 +239,13 @@ class KeyValueConfig(ADConfig):
      Otherwise, it will be just copied and un-configurable
      If multiple lines with the same key exists, only the first line will be configured
     """
-    _special_line_prefix = "__key_value_config_sp_line_prefix_"  # Presume normal config does not have such keys
+    # Presume normal config does not have such keys
+    _special_line_prefix = "__key_value_config_sp_line_prefix_"
     _empty_value = ""
 
-    def __init__(self, path, session, args, ad_enabled=True, load_existing=True, file_mode=0o644, sep=": ", comment="#"):
+    #pylint: disable=too-many-arguments
+    def __init__(self, path, session, args, ad_enabled=True, load_existing=True,
+                 file_mode=0o644, sep=": ", comment="#"):
         super(KeyValueConfig, self).__init__(path, session,
                                              args, ad_enabled, load_existing, file_mode)
         self._sep = None if sep.isspace() else sep  # Ignore number/type of spaces
@@ -239,7 +256,8 @@ class KeyValueConfig(ADConfig):
     def _is_comment_line(self, line):
         return line.startswith(self._comment)
 
-    def is_special_line(self, line):
+    def _is_special_line(self, line):
+        """Whether the line is a special line"""
         return line.startswith(self._special_line_prefix)
 
     def _load_values(self):
@@ -251,14 +269,14 @@ class KeyValueConfig(ADConfig):
             elif self._is_comment_line(line):
                 self._values[sp_key] = line
             else:  # Parse the key, value pair
-                kv = line.split(self._sep)
-                if len(kv) != 2:
+                item = line.split(self._sep)
+                if len(item) != 2:
                     # Taken as raw line
                     self._values[sp_key] = line
                 else:
-                    k, v = kv[0].strip(), kv[1].strip()
-                    if k not in self._values:
-                        self._values[k] = v
+                    key, value = item[0].strip(), item[1].strip()
+                    if key not in self._values:
+                        self._values[key] = value
                     else:
                         # Key already exists, Not supported as configurable
                         self._values[sp_key] = line
@@ -267,7 +285,7 @@ class KeyValueConfig(ADConfig):
         self._values[key] = value
 
     def _apply_value(self, key, value):
-        if self.is_special_line(key):
+        if self._is_special_line(key):
             line = value
         else:  # normal line, construct the key value pair
             sep = self._sep if self._sep else " "
@@ -276,17 +294,19 @@ class KeyValueConfig(ADConfig):
 
     def _apply_to_cache(self):
         self._lines = []
-        for k, v in self._values.items():
-            self._apply_value(k, v)
+        for key, value in self._values.items():
+            self._apply_value(key, value)
 
 
 class NssConfig(KeyValueConfig):
+    """Class to manage NSS configuration"""
+
     def __init__(self, session, args, ad_enabled=True):
         super(NssConfig, self).__init__(
             "/etc/nsswitch.conf", session, args, ad_enabled)
         modules = "files sss"
         if ad_enabled:
-            if self._backend == ADBackend.bd_pbis:
+            if self._backend == ADBackend.BD_PBIS:
                 modules = "files sss lsass"
             else:
                 modules = "files hcp winbind"
@@ -296,6 +316,8 @@ class NssConfig(KeyValueConfig):
 
 
 class SshdConfig(KeyValueConfig):
+    """Class to manage sshd configuration"""
+
     def __init__(self, session, args, ad_enabled=True):
         super(SshdConfig, self).__init__("/etc/ssh/sshd_config", session, args, ad_enabled,
                                          sep=" ")
@@ -310,6 +332,8 @@ class SshdConfig(KeyValueConfig):
 
 
 class PamWinbindConfig(KeyValueConfig):
+    """Class to manage winbind pam configuration"""
+
     def __init__(self, session, args, ad_enabled=True):
         super(PamWinbindConfig, self).__init__("/etc/security/pam_winbind.conf", session, args,
                                                ad_enabled, sep=" = ")
@@ -317,17 +341,20 @@ class PamWinbindConfig(KeyValueConfig):
 
 
 class ConfigManager:
+    """Class to manage all the AD configurations"""
+
     def __init__(self, session, args, ad_enabled=True):
         self._build_config(session, args, ad_enabled)
 
     def _build_config(self, session, args, ad_enabled):
         self._nss = NssConfig(session, args, ad_enabled)
         self._sshd = SshdConfig(session, args, ad_enabled)
-        self._static_pam = StaticPam(session, args, ad_enabled)
+        self._static_pam = StaticSSHPam(session, args, ad_enabled)
         self._dynamic_pam = DynamicPam(session, args, ad_enabled)
         self._pam_winbind = PamWinbindConfig(session, args, ad_enabled)
 
     def refresh_all(self):
+        """Update all the configurations"""
         self._nss.apply()
         self._sshd.apply()
         self._dynamic_pam.apply()
@@ -335,56 +362,66 @@ class ConfigManager:
         self._pam_winbind.apply()
 
     def refresh_dynamic_pam(self):
+        """Only refresh the dynanic configurations"""
         self._dynamic_pam.apply()
 
 
 def refresh_all_configurations(session, args, name, ad_enabled=True):
+    """Update all configurations"""
     try:
         logger.info("refresh_all_configurations for %s", name)
         ConfigManager(session, args, ad_enabled).refresh_all()
         return str(True)
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         msg = "Failed to refresh all configurations"
         logger.exception(msg)
         return msg
 
 
 def refresh_dynamic_pam(session, args, name):
+    """Refresh dynamic pam configurations"""
     try:
         logger.info("refresh_dynamic_pam for %s", name)
         ConfigManager(session, args).refresh_dynamic_pam()
         return str(True)
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         msg = "Failed to refresh dynamic pam configuration"
         logger.exception(msg)
         return msg
 
 
 def after_extauth_enable(session, args):
+    """Callback for after enable external auth"""
     return refresh_all_configurations(session, args, "after_extauth_enable")
 
 
 def after_xapi_initialize(session, args):
+    """Callback afer xapi initialize"""
     return refresh_all_configurations(session, args, "after_xapi_initialize")
 
 
 def after_subject_add(session, args):
+    """Callback after add subject"""
     return refresh_dynamic_pam(session, args, "after_subject_add")
 
 
 def after_subject_remove(session, args):
+    """Callbackk after remove subject"""
     return refresh_dynamic_pam(session, args, "after_subject_remove")
 
 
 def after_subject_update(session, args):
+    """Callback after subject update"""
     return refresh_dynamic_pam(session, args, "after_subject_update")
 
 
 def after_roles_update(session, args):
+    """Callback after roles update"""
     return refresh_dynamic_pam(session, args, "after_roles_update")
 
 
 def before_extauth_disable(session, args):
+    """Callback before disable external auth"""
     return refresh_all_configurations(session, args, "before_extauth_disable", False)
 
 

--- a/scripts/plugins/test_extauth_hook_AD.py
+++ b/scripts/plugins/test_extauth_hook_AD.py
@@ -3,6 +3,7 @@ Test module for extauth_hook_ad
 """
 #pylint: disable=invalid-name
 import sys
+import os
 from unittest import TestCase
 from mock import MagicMock, patch
 # mock modules to avoid dependencies
@@ -10,7 +11,7 @@ sys.modules["XenAPIPlugin"] = MagicMock()
 sys.modules["XenAPI"] = MagicMock()
 # pylint: disable=wrong-import-position
 # Import must after mock modules
-from extauth_hook_ad import StaticPam, DynamicPam, NssConfig, SshdConfig
+from extauth_hook_ad import StaticSSHPam, DynamicPam, NssConfig, SshdConfig
 
 
 def line_exists_in_config(lines, line):
@@ -73,46 +74,53 @@ def build_group(domain, name, is_admin):
     }
 
 
+def mock_rename_to_clean(src, dest):
+    """"Some unittest do create temporary files, this mock function remove the temporary files"""
+    os.remove(src)
+
+
 @patch("os.chmod")
 @patch("os.rename")
 class TestStaicPamConfig(TestCase):
     def test_ad_not_enabled(self, mock_rename, mock_chmod):
         # No hcp_users file should be included
-        static = StaticPam(mock_session, args_bd_winbind, ad_enabled=False)
+        mock_rename.side_effect = mock_rename_to_clean
+        static = StaticSSHPam(mock_session, args_bd_winbind, ad_enabled=False)
         static.apply()
         enabled_keyward = "account     include       hcp_users"
         self.assertFalse(line_exists_in_config(static._lines, enabled_keyward))
 
     def test_ad_enabled_with_winbind(self, mock_rename, mock_chmod):
         # pam_winbind should be used
-        static = StaticPam(mock_session, args_bd_winbind)
+        mock_rename.side_effect = mock_rename_to_clean
+        static = StaticSSHPam(mock_session, args_bd_winbind)
         static.apply()
         enabled_keyward = "auth sufficient    pam_winbind.so try_first_pass try_authtok"
         self.assertTrue(line_exists_in_config(static._lines, enabled_keyward))
 
     def test_ad_enabled_with_pbis(self, mock_rename, mock_chmod):
         # pam_lsass should be used
-        static = StaticPam(mock_session, args_bd_pbis)
+        mock_rename.side_effect = mock_rename_to_clean
+        static = StaticSSHPam(mock_session, args_bd_pbis)
         static.apply()
         enabled_keyward = "auth sufficient /lib/security/pam_lsass.so try_first_pass try_authtok"
         self.assertTrue(line_exists_in_config(static._lines, enabled_keyward))
 
 
-@patch("os.chmod")
-@patch("os.rename")
+@patch("extauth_hook_ad.ADConfig._install")
 class TestDynamicPam(TestCase):
     @patch("extauth_hook_ad.open")
     @patch("os.path.exists")
     @patch("os.remove")
-    def test_ad_not_enabled(self, mock_remove, mock_exists, mock_open, mock_rename, mock_chmod):
+    def test_ad_not_enabled(self, mock_remove, mock_exists, mock_open, mock_install):
         # dynamic pam file should be removed
         mock_exists.return_value = True
         dynamic = DynamicPam(mock_session, args_bd_winbind, ad_enabled=False)
         dynamic.apply()
         mock_remove.assert_called()
-        mock_rename.assert_not_called()
+        mock_install.assert_not_called()
 
-    def test_permit_admin_user(self, mock_rename, mock_chmod):
+    def test_permit_admin_user(self, mock_install):
         # Domain user with admin role should be included in config file
         user = build_user("CONNAPP", "radmin", True)
         mock_session.xenapi.subject.get_record.return_value = user
@@ -120,9 +128,9 @@ class TestDynamicPam(TestCase):
         dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertTrue(line_exists_in_config(dynamic._lines, permit_user))
-        mock_rename.assert_called()
+        mock_install.assert_called()
 
-    def test_pbis_permit_admin_user_with_space(self, mock_rename, mock_chmod):
+    def test_pbis_permit_admin_user_with_space(self, mock_install):
         # Domain user name with space should be repalced by "+" with PBIS
         user = build_user("CONNAPP", "radmin  l1", True)
         mock_session.xenapi.subject.get_record.return_value = user
@@ -130,9 +138,9 @@ class TestDynamicPam(TestCase):
         dynamic = DynamicPam(mock_session, args_bd_pbis)
         dynamic.apply()
         self.assertTrue(line_exists_in_config(dynamic._lines, permit_user))
-        mock_rename.assert_called()
+        mock_install.assert_called()
 
-    def test_winbind_permit_admin_user_with_space(self, mock_rename, mock_chmod):
+    def test_winbind_permit_admin_user_with_space(self, mock_install):
         # Domain user name with space should be surrounded by [] with winbind
         user = build_user("CONNAPP", "radmin  l1", True)
         mock_session.xenapi.subject.get_record.return_value = user
@@ -140,9 +148,9 @@ class TestDynamicPam(TestCase):
         dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertTrue(line_exists_in_config(dynamic._lines, permit_user))
-        mock_rename.assert_called()
+        mock_install.assert_called()
 
-    def test_not_permit_non_admin_user(self, mock_rename, mock_chmod):
+    def test_not_permit_non_admin_user(self, mock_install):
         # Domain user without admin role should be included in config file
         user = build_user("CONNAPP", "radmin", False)
         mock_session.xenapi.subject.get_record.return_value = user
@@ -150,9 +158,8 @@ class TestDynamicPam(TestCase):
         dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertFalse(line_exists_in_config(dynamic._lines, permit_user))
-        mock_rename.assert_called()
 
-    def test_permit_admin_group(self, mock_rename, mock_chmod):
+    def test_permit_admin_group(self, mock_install):
         # Domain group with admin role should be included in config file
         group = build_group("CONNAPP", "test_group", True)
         mock_session.xenapi.subject.get_record.return_value = group
@@ -160,9 +167,8 @@ class TestDynamicPam(TestCase):
         dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertTrue(line_exists_in_config(dynamic._lines, permit_group))
-        mock_rename.assert_called()
 
-    def test_not_permit_non_admin_group(self, mock_rename, mock_chmod):
+    def test_not_permit_non_admin_group(self, mock_install):
         # Domain user without admin role should not be included in config file
         group = build_group("CONNAPP", "test_group", False)
         mock_session.xenapi.subject.get_record.return_value = group
@@ -170,24 +176,23 @@ class TestDynamicPam(TestCase):
         dynamic = DynamicPam(mock_session, args_bd_winbind)
         dynamic.apply()
         self.assertFalse(line_exists_in_config(dynamic._lines, permit_group))
-        mock_rename.assert_called()
 
-    def test_not_permit_pool_admin_with_plus_in_name(self, mock_rename, mock_chmod):
+    def test_pbis_not_permit_pool_admin_with_plus_in_name(self, mock_install):
         """
         Domain user name should not contain "+"
         """
-        user = build_user("CONNAPP", "radm+in", True)
+        user = build_user("CONNAPP", "rad m+in", True)
         mock_session.xenapi.subject.get_record.return_value = user
-        permit_user = r"account sufficient pam_succeed_if.so user = CONNAPP\radm+in"
-        dynamic = DynamicPam(mock_session, args_bd_winbind)
+        permit_user = r"account sufficient pam_succeed_if.so user = CONNAPP\ra dm+in"
+        dynamic = DynamicPam(mock_session, args_bd_pbis)
         dynamic.apply()
         self.assertFalse(line_exists_in_config(dynamic._lines, permit_user))
 
-    def test_failed_to_add_one_admin_should_not_affact_others(self, mock_rename, mock_chmod):
+    def test_failed_to_add_one_admin_should_not_affact_others(self, mock_install):
         """
         Failed to add one bad domain users should not affact others
         """
-        bad_user = build_user("CONNAPP", "bad+in", True)
+        bad_user = build_user("CONNAPP", "ba d+in", True)
         good_user = build_user("CONNAPP", "good", True)
 
         mock_session_with_multi_users = MagicMock()
@@ -199,24 +204,23 @@ class TestDynamicPam(TestCase):
             bad_user, good_user]
         mock_session_with_multi_users.xenapi.role.get_by_name_label.return_value = admin_roles
 
-        bad_condition = r"account sufficient pam_succeed_if.so user = CONNAPP\bad+in"
+        bad_condition = r"account sufficient pam_succeed_if.so user = CONNAPP\ba d+in"
         good_condition = r"account sufficient pam_succeed_if.so user = CONNAPP\good"
-        dynamic = DynamicPam(mock_session_with_multi_users, args_bd_winbind)
+        dynamic = DynamicPam(mock_session_with_multi_users, args_bd_pbis)
         dynamic.apply()
         self.assertFalse(line_exists_in_config(dynamic._lines, bad_condition))
         self.assertTrue(line_exists_in_config(dynamic._lines, good_condition))
 
 
-@patch("os.chmod")
-@patch("os.rename")
+@patch("extauth_hook_ad.ADConfig._install")
 class TestNssConfig(TestCase):
-    def test_ad_not_enabled(self, mock_rename, mock_chmod):
+    def test_ad_not_enabled(self, mock_install):
         expected_config = "passwd:  files sss"
         nss = NssConfig(mock_session, args_bd_winbind, False)
         nss.apply()
         self.assertTrue(line_exists_in_config(nss._lines, expected_config))
 
-    def test_ad_enabled(self, mock_rename, mock_chmod):
+    def test_ad_enabled(self, mock_install):
         expected_config = "passwd: files hcp winbind"
         nss = NssConfig(mock_session, args_bd_winbind, True)
         nss.apply()
@@ -224,11 +228,10 @@ class TestNssConfig(TestCase):
 
 
 @patch("extauth_hook_ad.run_cmd")
-@patch("os.chmod")
-@patch("os.rename")
+@patch("extauth_hook_ad.ADConfig._install")
 @patch("extauth_hook_ad.open")
 class TestSshdConfig(TestCase):
-    def test_ad_not_enabled(self, mock_open, mock_rename, mock_chmod, mock_run_cmd):
+    def test_ad_not_enabled(self, mock_open, mock_install, mock_run_cmd):
         expected_config = "ChallengeResponseAuthentication no"
         # mock empty file exists
         mock_open.return_value.__enter__.return_value.readlines.return_value = []
@@ -237,7 +240,7 @@ class TestSshdConfig(TestCase):
         self.assertTrue(line_exists_in_config(sshd._lines, expected_config))
         mock_run_cmd.assert_called()
 
-    def test_ad_enabled(self, mock_open, mock_rename, mock_chmod, mock_run_cmd):
+    def test_ad_enabled(self, mock_open, mock_install, mock_run_cmd):
         expected_config = "ChallengeResponseAuthentication yes"
         # mock empty file exists
         mock_open.return_value.__enter__.return_value.readlines.return_value = []


### PR DESCRIPTION
 CA-355588: users in pool admin group which contains # can not ssh into dom0
    
    Linux PAM take # as comments and there is no way to escape it
    This commit fix the issue by permit users and groups through
    pam_listfile pam module by
    - users, in /etc/security/hcp_ad_users.conf
    - groups, in /etc/security/hcp_ad_groups.conf    
