### PR TITLE
Sync varstore certificates in XAPI with those on disks

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1588,9 +1588,21 @@ let set_multipathing =
       ]
     ~allowed_roles:_R_POOL_OP ()
 
+let write_uefi_certificates_to_disk =
+  call ~name:"write_uefi_certificates_to_disk"
+    ~lifecycle:[(Published, rel_next, "")]
+    ~doc:"Writes the UEFI certificates to a host disk"
+    ~params:[(Ref _host, "host", "The host")]
+    ~allowed_roles:_R_LOCAL_ROOT_ONLY ~pool_internal:true ~hide_from_docs:true
+    ()
+
 let set_uefi_certificates =
   call ~name:"set_uefi_certificates"
-    ~lifecycle:[(Published, rel_quebec, "")]
+    ~lifecycle:
+      [
+        (Published, rel_quebec, "")
+      ; (Deprecated, rel_next, "Use Pool.set_uefi_certificates instead")
+      ]
     ~doc:"Sets the UEFI certificates on a host"
     ~params:
       [
@@ -1834,6 +1846,7 @@ let t =
       ; allocate_resources_for_vm
       ; set_iscsi_iqn
       ; set_multipathing
+      ; write_uefi_certificates_to_disk
       ; set_uefi_certificates
       ; notify_accept_new_pool_secret
       ; notify_send_new_pool_secret
@@ -2036,7 +2049,11 @@ let t =
             ~default_value:(Some (VBool false)) ~ty:Bool "multipathing"
             "Specifies whether multipathing is enabled"
         ; field ~qualifier:StaticRO
-            ~lifecycle:[(Published, rel_quebec, "")]
+            ~lifecycle:
+              [
+                (Published, rel_quebec, "")
+              ; (Deprecated, rel_next, "Use Pool.uefi_certificates instead")
+              ]
             ~default_value:(Some (VString "")) ~ty:String "uefi_certificates"
             "The UEFI certificates allowing Secure Boot"
         ; field ~qualifier:DynamicRO

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -995,6 +995,17 @@ let disable_repository_proxy =
     ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)
     ()
 
+let set_uefi_certificates =
+  call ~name:"set_uefi_certificates"
+    ~lifecycle:[(Published, rel_next, "")]
+    ~doc:"Sets the UEFI certificates for a pool and all its hosts"
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; (String, "value", "The certificates to apply to the pool and its hosts")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
 (** A pool class *)
 let t =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:None
@@ -1075,6 +1086,7 @@ let t =
       ; disable_client_certificate_auth
       ; configure_repository_proxy
       ; disable_repository_proxy
+      ; set_uefi_certificates
       ]
     ~contents:
       ([uid ~in_oss_since:None _pool]
@@ -1242,7 +1254,14 @@ let t =
         ; field ~in_product_since:rel_inverness ~qualifier:DynamicRO ~ty:Bool
             ~default_value:(Some (VBool false)) "igmp_snooping_enabled"
             "true if IGMP snooping is enabled in the pool, false otherwise."
-        ; field ~in_product_since:rel_quebec ~qualifier:RW ~ty:String
+        ; field ~in_product_since:rel_quebec ~qualifier:StaticRO ~ty:String
+            ~lifecycle:
+              [
+                ( Changed
+                , rel_next
+                , "Became StaticRO to be editable through new method"
+                )
+              ]
             ~default_value:(Some (VString "")) "uefi_certificates"
             "The UEFI certificates allowing Secure Boot"
         ; field ~in_product_since:rel_stockholm_psr ~qualifier:RW ~ty:Bool

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "5248cdbe333dd64ad01b9f94eb51baba"
+let last_known_schema_hash = "f3fc2d5938bf9f1046d9103fd7c95c33"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1343,6 +1343,9 @@ let pool_record rpc session_id pool =
           ()
       ; make_field ~name:"uefi-certificates" ~hidden:true
           ~get:(fun () -> (x ()).API.pool_uefi_certificates)
+          ~set:(fun value ->
+            Client.Pool.set_uefi_certificates rpc session_id pool value
+          )
           ()
       ; make_field ~name:"tls-verification-enabled"
           ~get:(fun () ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1082,6 +1082,12 @@ functor
         info "Pool.disable_repository_proxy: pool = '%s'"
           (pool_uuid ~__context self) ;
         Local.Pool.disable_repository_proxy ~__context ~self
+
+      let set_uefi_certificates ~__context ~self ~value =
+        info "Pool.set_uefi_certificates: pool='%s' value='%s'"
+          (pool_uuid ~__context self)
+          value ;
+        Local.Pool.set_uefi_certificates ~__context ~self ~value
     end
 
     module VM = struct
@@ -3875,6 +3881,14 @@ functor
         let local_fn = Local.Host.set_multipathing ~host ~value in
         do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
             Client.Host.set_multipathing ~rpc ~session_id ~host ~value
+        )
+
+      let write_uefi_certificates_to_disk ~__context ~host =
+        info "Host.write_uefi_certificates_to_disk: host='%s' "
+          (host_uuid ~__context host) ;
+        let local_fn = Local.Host.write_uefi_certificates_to_disk ~host in
+        do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
+            Client.Host.write_uefi_certificates_to_disk ~rpc ~session_id ~host
         )
 
       let set_uefi_certificates ~__context ~host ~value =

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1421,6 +1421,14 @@ let server_init () =
                       (Helpers.get_localhost ~__context)
                 )
             )
+          ; ( "Sync UEFI certificates on host with XAPI db"
+            , [Startup.NoExnRaising]
+            , fun () ->
+                Helpers.call_api_functions ~__context (fun rpc session_id ->
+                    Xapi_host.write_uefi_certificates_to_disk __context
+                      (Helpers.get_localhost ~__context)
+                )
+            )
           ] ;
         debug "startup: startup sequence finished"
     ) ;

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -479,6 +479,9 @@ val nvidia_vf_setup :
 val allocate_resources_for_vm :
   __context:Context.t -> self:API.ref_host -> vm:API.ref_VM -> live:bool -> unit
 
+val write_uefi_certificates_to_disk :
+  __context:Context.t -> host:API.ref_host -> unit
+
 val set_uefi_certificates :
   __context:Context.t -> host:API.ref_host -> value:string -> unit
 

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -384,3 +384,6 @@ val configure_repository_proxy :
   -> unit
 
 val disable_repository_proxy : __context:Context.t -> self:API.ref_pool -> unit
+
+val set_uefi_certificates :
+  __context:Context.t -> self:API.ref_pool -> value:string -> unit

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -296,46 +296,6 @@ let update_platform_secureboot ~__context ~self platform =
   | _ ->
       platform
 
-let extract_certificate_file name =
-  if String.contains name '/' then
-    (* Internal error: tarfile not created correctly *)
-    failwith ("Invalid path in certificate tarball: " ^ name) ;
-  let path = Filename.concat !Xapi_globs.varstore_dir name in
-  Helpers.touch_file path ; path
-
-let with_temp_file_contents ~contents f =
-  let filename, out = Filename.open_temp_file "xapi_uefi_certificates" "tar" in
-  Xapi_stdext_pervasives.Pervasiveext.finally
-    (fun () ->
-      Xapi_stdext_pervasives.Pervasiveext.finally
-        (fun () -> output_string out contents)
-        (fun () -> close_out out) ;
-      Unixext.with_file filename [Unix.O_RDONLY] 0 f
-    )
-    (fun () -> Sys.remove filename)
-
-let save_uefi_certificates_to_dir ~__context ~pool ~vm =
-  let uefi_key = Filename.concat !Xapi_globs.varstore_dir "KEK.auth" in
-  if not (Sys.file_exists uefi_key) then
-    if
-      Sys.file_exists !Xapi_globs.varstore_dir
-      && Sys.is_directory !Xapi_globs.varstore_dir
-    then
-      match
-        Base64.decode (Db.Pool.get_uefi_certificates ~__context ~self:pool)
-      with
-      | Ok contents when contents <> "" ->
-          with_temp_file_contents ~contents
-            (Tar_unix.Archive.extract extract_certificate_file) ;
-          debug "UEFI tar file extracted to varstore directory"
-      | Ok _ ->
-          ()
-      (* no UEFI tar file *)
-      | Error _ ->
-          debug
-            "UEFI tar file was not extracted: it was not base64-encoded \
-             correctly"
-
 let start ~__context ~vm ~start_paused ~force =
   let vmr = Db.VM.get_record ~__context ~self:vm in
   if vmr.API.vM_ha_restart_priority = Constants.ha_restart then (
@@ -349,7 +309,6 @@ let start ~__context ~vm ~start_paused ~force =
     | Bios ->
         Vm_platform.fallback_device_model_default_value
     | Uefi _ ->
-        save_uefi_certificates_to_dir ~__context ~pool ~vm ;
         Vm_platform.fallback_device_model_default_value_uefi
   in
   let platform =


### PR DESCRIPTION
- `Pool.set_uefi_certificates` is implemented and calls `Host.set_uefi_certificates` on all hosts
- `Host.set_uefi_certificates` writes certificates on disks
- On XAPI startup certificates stored in XAPI's `Host.uefi_certificates` are written on disks
- When a host joins the pool `Host.set_uefi_certificates` is called with the certificates stored in XAPI's `Pool.uefi_certificates`

This means:
- At every XAPI startup the certificates in host disks are synced with XAPI's `Host.uefi_certificates`
- When `Pool.set_uefi_certificates` is called all hosts are synced in XAPi and disks with XAPI's `Pool.uefi_certificates`
- When `Host.set_uefi_certificates` is called the host certificates on disk are synced with XAPI's `Host.uefi_certificates`

Also: `Host.set_uefi_certificates` no longer calls `Pool.set_uefi_certificates`, this requires changes
in external libs (varstored, uefistored, etc) to set the pool's certificates: call `Pool.set_uefi_certificates`.

See: https://github.com/xapi-project/xen-api/issues/4647

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>