### PR TITLE
CA-363700: update xenopsd platformdata if rtc-timeoffset changes

### DIFF
--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -4788,10 +4788,15 @@ module Actions = struct
         (Option.map (function {VmExtra.persistent} as extra ->
              ( match persistent with
              | {VmExtra.ty= Some (Vm.HVM hvm_info)} ->
+                 let platformdata =
+                   ("timeoffset", timeoffset)
+                   :: List.remove_assoc "timeoffset" persistent.platformdata
+                 in
                  let persistent =
                    {
                      persistent with
                      VmExtra.ty= Some (Vm.HVM {hvm_info with Vm.timeoffset})
+                   ; platformdata
                    }
                  in
                  debug "VM = %s; rtc/timeoffset <- %s" vm timeoffset ;


### PR DESCRIPTION
The timeoffset parameter of a VM, which controls its timezone settings,
is present in the VM metadata in two places: in the build spec as well
as in the platformdata. This also drives the fact that the timeoffset is
written to two places in xenstore:

    /vm/<uuid>/rtc/timeoffset
    /local/domain/<domid>/platform/timeoffset

It turns out that the PV tools and/or QEMU in some way rely on both of
these paths.

When a VM starts, its timeoffset platform key is used to set the value
of both bits of metadata that are sent to xenopsd. If the timezone
inside of the VM is changed, then an event is sent back to xapi, which
updates the platform key in its xapi.

If a VM resumes, it is similar to start, but additionally the VM's
runtime metadata is sent to xenopsd as well, so the VM is resumed with
exactly the same state as before it suspended.

Since a recent change, the platformdata has been made part of xenopsd's
runtime VM metadata, and is therefore persisted across a suspend/resume
cycle or live migration. This means that the timeoffset in the
platformdata now comes from this xenopsd-level metadata rather than from
xapi's metadata.

This all would have been fine, if xenopsd were to update the timeoffset
in its persistent platformdata whenever it changes in the VM (besides
sending the event to xapi). Unfortunately, this was not the case, which
meant that, after a suspend/resume cycle, the VM's timezone reverted
back to whatever it was when the VM started, and any changes after that
are forgotten. The situation for live migration is similar.

This commit adds the missing metadata update in xenopsd.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>