### PR TITLE
Make Xapi_compression.compress more polymorphic

### DIFF
--- a/ocaml/libs/gzip/gzip.mli
+++ b/ocaml/libs/gzip/gzip.mli
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-val compress : Unix.file_descr -> (Unix.file_descr -> unit) -> unit
+val compress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 (** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
     and whose output is 'ofd' *)
 

--- a/ocaml/libs/xapi-compression/xapi_compression.mli
+++ b/ocaml/libs/xapi-compression/xapi_compression.mli
@@ -6,7 +6,7 @@ module Make : functor (Algorithm : ALGORITHM) -> sig
   val available : unit -> bool
   (** Returns whether this compression algorithm is available *)
 
-  val compress : Unix.file_descr -> (Unix.file_descr -> unit) -> unit
+  val compress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
   (** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
       and whose output is 'ofd' *)
 

--- a/ocaml/libs/zstd/zstd.mli
+++ b/ocaml/libs/zstd/zstd.mli
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-val compress : Unix.file_descr -> (Unix.file_descr -> unit) -> unit
+val compress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 (** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
     and whose output is 'ofd' *)
 


### PR DESCRIPTION
There is no good reason to limit the return type of the compression
function.  This makes it work with functions that return a (monadic)
error code.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>