### PR TITLE
CP-38554: Start up and stop SWTPM and guard for every domain

### DIFF
--- a/ocaml/xenopsd/lib/xenops_sandbox.ml
+++ b/ocaml/xenopsd/lib/xenops_sandbox.ml
@@ -118,7 +118,7 @@ end = struct
 end
 
 module type SANDBOX = sig
-  val prepare : domid:int -> vm_uuid:string -> Chroot.Path.t -> string
+  val create : domid:int -> vm_uuid:string -> Chroot.Path.t -> string
 
   val start :
        string

--- a/ocaml/xenopsd/lib/xenops_sandbox.ml
+++ b/ocaml/xenopsd/lib/xenops_sandbox.ml
@@ -208,4 +208,19 @@ module Varstored : GUARD = struct
     Varstore_privileged_client.Client.destroy dbg domid path
 end
 
+module Swtpm : GUARD = struct
+  let daemon_name = "swtpm"
+
+  (* swtpm cannot run on /var/run because it's mounted using nodev and access
+     is needed to /dev/urandom *)
+  let base_directory = "/var/lib/xcp/run"
+
+  let create dbg ~vm_uuid ~domid ~path =
+    Varstore_privileged_client.Client.create dbg vm_uuid domid path
+
+  let destroy dbg ~domid ~path =
+    Varstore_privileged_client.Client.destroy dbg domid path
+end
+
 module Varstore_guard = Guard (Varstored)
+module Swtpm_guard = Guard (Swtpm)

--- a/ocaml/xenopsd/lib/xenops_sandbox.mli
+++ b/ocaml/xenopsd/lib/xenops_sandbox.mli
@@ -64,3 +64,5 @@ module type SANDBOX = sig
 end
 
 module Varstore_guard : SANDBOX
+
+module Swtpm_guard : SANDBOX

--- a/ocaml/xenopsd/lib/xenops_sandbox.mli
+++ b/ocaml/xenopsd/lib/xenops_sandbox.mli
@@ -1,0 +1,66 @@
+module Chroot : sig
+  type t = private {root: string; uid: int; gid: int}
+
+  module Path : sig
+    type t
+
+    val root : t
+
+    val of_string : relative:string -> t
+
+    val concat : t -> string -> t
+  end
+
+  val absolute_path_outside : t -> Path.t -> string
+  (** [absolute_path_outside chroot path] returns the absolute path outside the
+      chroot *)
+
+  val chroot_path_inside : Path.t -> string
+  (** [chroot_path_inside path] returns the path when inside the chroot *)
+
+  val create_dir : within:t -> int -> Path.t -> unit
+  (** [create_dir ~within perm path] Creates the directory with path [path] inside
+      the chroot [within] with its owner and group ids and permissions [perm]*)
+
+  val of_domid :
+    base:string -> daemon:string -> domid:int -> vm_uuid:string -> t
+  (** [of_domid ~base ~daemon ~domid ~vm_uuid] describes a chroot for specified
+     daemon and domain *)
+
+  val create :
+       base:string
+    -> daemon:string
+    -> domid:int
+    -> vm_uuid:string
+    -> Path.t list
+    -> t
+  (** [create ~base ~daemon ~domid paths] Creates the specified chroot with
+      appropriate permissions on directory [base], and ensures that all [paths]
+      are owned by the chrooted daemon and rw- *)
+
+  val destroy : t -> unit
+  (** [destroy chroot] Deletes the chroot *)
+end
+
+module type SANDBOX = sig
+  val prepare : domid:int -> vm_uuid:string -> Chroot.Path.t -> string
+  (** [prepare ~domid ~vm_uuid path] creates an empty [path] file owned by
+      [domid] inside the chroot for [domid] and returns the absolute path to it
+      outside the chroot *)
+
+  val start :
+       string
+    -> vm_uuid:string
+    -> domid:int
+    -> paths:Chroot.Path.t list
+    -> Chroot.t * string
+  (** [start dbg ~vm_uuid ~domid ~paths] prepares a chroot for [domid], and asks
+      the guard to create a socket restricted to [vm_uuid]. Also creates
+      empty files specified in [path] owned by [domid] user. *)
+
+  val read : domid:int -> Chroot.Path.t -> vm_uuid:string -> string
+
+  val stop : string -> domid:int -> vm_uuid:string -> unit
+end
+
+module Varstore_guard : SANDBOX

--- a/ocaml/xenopsd/lib/xenops_sandbox.mli
+++ b/ocaml/xenopsd/lib/xenops_sandbox.mli
@@ -43,8 +43,8 @@ module Chroot : sig
 end
 
 module type SANDBOX = sig
-  val prepare : domid:int -> vm_uuid:string -> Chroot.Path.t -> string
-  (** [prepare ~domid ~vm_uuid path] creates an empty [path] file owned by
+  val create : domid:int -> vm_uuid:string -> Chroot.Path.t -> string
+  (** [create ~domid ~vm_uuid path] creates an empty [path] file owned by
       [domid] inside the chroot for [domid] and returns the absolute path to it
       outside the chroot *)
 

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -41,6 +41,8 @@ let vgpu_ready_timeout = ref 30.
 
 let varstored_ready_timeout = ref 30.
 
+let swtpm_ready_timeout = ref 30.
+
 let use_upstream_qemu = ref false
 
 let pci_quarantine = ref true

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -4510,7 +4510,7 @@ module Dm = struct
   let restore_varstored (task : Xenops_task.task_handle) ~xs ~efivars domid =
     debug "Called Dm.restore_varstored (domid=%d)" domid ;
     let path =
-      Xenops_sandbox.Varstore_guard.prepare ~domid
+      Xenops_sandbox.Varstore_guard.create ~domid
         ~vm_uuid:(Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid))
         efivars_resume_path
     in

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -28,7 +28,7 @@ exception Device_not_found
 
 exception Cdrom
 
-module D = Debug.Make (struct let name = "xenops" end)
+module D = Debug.Make (struct let name = "device" end)
 
 open D
 
@@ -66,11 +66,7 @@ module Profile = struct
   let wrapper_of = function
     | Qemu_none | Qemu_trad ->
         "/bin/false"
-    | Qemu_upstream_compat ->
-        !Resources.upstream_compat_qemu_dm_wrapper
-    | Qemu_upstream ->
-        !Resources.upstream_compat_qemu_dm_wrapper
-    | Qemu_upstream_uefi ->
+    | Qemu_upstream_compat | Qemu_upstream | Qemu_upstream_uefi ->
         !Resources.upstream_compat_qemu_dm_wrapper
 
   let of_string = function
@@ -4212,7 +4208,6 @@ module Dm = struct
     in
     let backend = nvram.Nvram_uefi_variables.backend in
     let open Fe_argv in
-    let ( >>= ) = bind in
     let argf fmt = ksprintf (fun s -> ["--arg"; s]) fmt in
     let on cond value = if cond then value else return () in
     let chroot, socket_path =

--- a/ocaml/xenopsd/xc/dune
+++ b/ocaml/xenopsd/xc/dune
@@ -13,6 +13,7 @@
   fd-send-recv
   fmt
   forkexec
+  inotify
   mtime
   mtime.clock.os
   polly

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -1,0 +1,166 @@
+module D = Debug.Make (struct let name = "service" end)
+
+open! D
+module Unixext = Xapi_stdext_unix.Unixext
+module Xenops_task = Xenops_task.Xenops_task
+module Chroot = Xenops_sandbox.Chroot
+module Path = Chroot.Path
+
+let defer f g = Xapi_stdext_pervasives.Pervasiveext.finally g f
+
+exception Service_failed of (string * string)
+
+type t = {
+    name: string
+  ; domid: Xenctrl.domid
+  ; exec_path: string
+  ; chroot: Chroot.t
+  ; timeout_seconds: float
+  ; args: string list
+  ; execute:
+      path:string -> args:string list -> domid:Xenctrl.domid -> unit -> string
+}
+
+let alive service =
+  let is_active = Fe_systemctl.is_active ~service in
+  ( if not is_active then
+      let status = Fe_systemctl.show ~service in
+      error
+        "%s: unexpected termination \
+         (Result=%s,ExecMainPID=%d,ExecMainStatus=%d,ActiveState=%s)"
+        service status.result status.exec_main_pid status.exec_main_status
+        status.active_state
+  ) ;
+  is_active
+
+type watch_trigger = Created | Cancelled | Waiting
+
+let fold_events ~init f events =
+  events
+  |> List.to_seq
+  |> Seq.flat_map (fun (_, events, _, fnameopt) ->
+         List.to_seq events |> Seq.map (fun event -> (event, fnameopt))
+     )
+  |> Seq.fold_left f init
+
+exception ECancelled of Xenops_task.task_handle
+
+let raise_e = function
+  | ECancelled t ->
+      Xenops_task.raise_cancelled t
+  | e ->
+      raise e
+
+let with_inotify f =
+  let fd = Inotify.create () in
+  defer (fun () -> Unix.close fd) (fun () -> f fd)
+
+let with_watch notifd dir f =
+  let open Inotify in
+  let flags = [S_Create; S_Delete; S_Delete_self; S_Onlydir] in
+  let watch = Inotify.add_watch notifd dir flags in
+  defer (fun () -> Inotify.rm_watch notifd watch) (fun () -> f watch)
+
+let with_monitor watch_fd f =
+  let fd = Polly.create () in
+  Polly.add fd watch_fd Polly.Events.inp ;
+  defer (fun () -> Polly.del fd watch_fd ; Polly.close fd) (fun () -> f fd)
+
+let start_and_wait_for_readyness ~task ~service =
+  let sandbox_path p =
+    Chroot.absolute_path_outside service.chroot (Path.of_string ~relative:p)
+  in
+
+  let pid_name = Printf.sprintf "%s-%d.pid" service.name service.domid in
+  let cancel_name =
+    Printf.sprintf "%s-%s.cancel" service.name (Xenops_task.get_dbg task)
+  in
+
+  let cancel_path = sandbox_path cancel_name in
+
+  let cancel () =
+    (* create an empty file to trigger the watch and delete it
+       immediately *)
+    Unixext.touch_file cancel_path ;
+    Unixext.unlink_safe cancel_path
+  in
+  (* create watches for pidfile and task cancellation *)
+  with_inotify @@ fun notifd ->
+  with_watch notifd service.chroot.root @@ fun _ ->
+  with_monitor notifd @@ fun pollfd ->
+  let wait ~for_s ~service_name =
+    let start_time = Mtime_clock.elapsed () in
+    let poll_period_ms = 1000 in
+    let collect_watches acc (event, file) =
+      match (acc, event, file) with
+      (* treat deleted directory or pidfile as cancelling *)
+      | Cancelled, _, _ | _, (Inotify.Ignored | Inotify.Delete_self), _ ->
+          Cancelled
+      | _, Inotify.Delete, Some name when name = pid_name ->
+          Cancelled
+      | _, Inotify.Create, Some name when name = cancel_name ->
+          Cancelled
+      | _, Inotify.Create, Some name when name = pid_name ->
+          Created
+      | _, _, _ ->
+          acc
+    in
+
+    let cancellable_watch () =
+      let event = ref Waiting in
+      let rec poll_loop () =
+        try
+          ignore
+          @@ Polly.wait pollfd 1 poll_period_ms (fun _ fd events ->
+                 if Polly.Events.(test events inp) then
+                   event :=
+                     fold_events ~init:!event collect_watches (Inotify.read fd)
+             ) ;
+
+          let current_time = Mtime_clock.elapsed () in
+          let elapsed_time =
+            Mtime.Span.(to_s (abs_diff start_time current_time))
+          in
+
+          match !event with
+          | Waiting when elapsed_time < for_s ->
+              poll_loop ()
+          | Created ->
+              Ok ()
+          | Cancelled ->
+              Error (ECancelled task)
+          | Waiting ->
+              let err_msg =
+                if alive service_name then
+                  "Timeout reached while starting service"
+                else
+                  "Service exited unexpectedly"
+              in
+              Error (Service_failed (service_name, err_msg))
+        with e ->
+          let err_msg =
+            Printf.sprintf
+              "Exception while waiting for service %s to be ready: %s"
+              service_name (Printexc.to_string e)
+          in
+          Error (Service_failed (service_name, err_msg))
+      in
+
+      Xenops_task.with_cancel task cancel poll_loop
+    in
+    cancellable_watch ()
+  in
+
+  (* start systemd service *)
+  let syslog_key =
+    service.execute ~path:service.exec_path ~args:service.args
+      ~domid:service.domid ()
+  in
+
+  Xenops_task.check_cancelling task ;
+
+  (* wait for pidfile to appear *)
+  Result.iter_error raise_e
+    (wait ~for_s:service.timeout_seconds ~service_name:syslog_key) ;
+
+  debug "Service %s initialized" syslog_key

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -1,0 +1,15 @@
+exception Service_failed of (string * string)
+
+type t = {
+    name: string
+  ; domid: Xenctrl.domid
+  ; exec_path: string
+  ; chroot: Xenops_sandbox.Chroot.t
+  ; timeout_seconds: float
+  ; args: string list
+  ; execute:
+      path:string -> args:string list -> domid:Xenctrl.domid -> unit -> string
+}
+
+val start_and_wait_for_readyness :
+  task:Xenops_task.Xenops_task.task_handle -> service:t -> unit

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=518
+  N=517
   # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
   MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)


### PR DESCRIPTION
Xenopsd manages several services that sustain the lifecycle of each
domain. To launch a service, xenopsd usually starts up a daemon and it
waits for this daemon to write its pid on xenstore to signal the service
is ready to attend requests.

While this method is convenient in order to be able to cancel the wait
using xenstore watches, it's unfortunate as it makes the daemons depend
on xenstore even if it isn't needed to supply the service.

This change implements an alternative way to set up a cancellable wait
on the service readiness using inotify and epoll by setting up
filesystem watches instead of xenstore ones.

The polling loop wakes up every second to have a direct method to deal
with timeouts as well as unrelated events that happened in the
filesystem.

For every domain now xenopsd creates a chroot (which starts up a guard
daemon instance), launches an SWTPM instance, then waits on its pidfile
to be created.
On domain destruction is shuts down both instances: first SWTPM, then
the guard.

TODO:
- [x] Communicate swtpm socket path from inside the chroot to the qemu invocation