### PR TITLE
CA-359978: Flush IP addresses when switching from static to DHCP

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -316,6 +316,8 @@ module Interface = struct
                 ~some:(fun n -> [`dns n])
                 !config.dns_interface
             in
+            if not (Dhclient.is_running name) then (* Remove any static IPs *)
+              Ip.flush_ip_addr name ;
             let options = gateway @ dns in
             Dhclient.ensure_running name options
         | Static4 addrs ->


### PR DESCRIPTION
Switching to DHCP does not simply replace existing IP addresses, but
may add one in addition.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>