### PR TITLE
CP-35846: Restrict access to internal yum repo server (members only)

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8350,7 +8350,7 @@ let http_actions =
     , (Get, Constants.get_pool_update_download_uri, false, [], _R_READ_ONLY, [])
     )
   ; ( "get_repository"
-    , (Get, Constants.get_repository_uri, false, [], _R_READ_ONLY, [])
+    , (Get, Constants.get_repository_uri, false, [], _R_LOCAL_ROOT_ONLY, [])
     )
   ; ( "get_host_updates"
     , ( Get
@@ -8394,7 +8394,6 @@ let public_http_actions_with_no_rbac_check =
   ; "post_jsonrpc"
   ; "post_jsonrpc_options"
   ; "get_pool_update_download"
-  ; "get_repository"
   ]
 
 (* permissions not associated with any object message or field *)

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -1042,6 +1042,10 @@ let with_local_repositories ~__context f =
               [
                 "--save"
               ; Printf.sprintf "--setopt=%s.sslverify=false" repo_name
+                (* certificate verification is handled by the stunnel proxy *)
+              ; Printf.sprintf "--setopt=%s.ptoken=true" repo_name
+                (* makes yum include the pool secret as a cookie in all requests
+                   (only to access the repo mirror in the coordinator!) *)
               ; repo_name
               ]
             in
@@ -1215,6 +1219,7 @@ let get_updates_from_repoquery repositories =
   let params =
     [
       "-a"
+    ; "--plugins"
     ; "--disablerepo=*"
     ; Printf.sprintf "--enablerepo=%s" (String.concat "," repositories)
     ; "--pkgnarrow=updates"

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -175,6 +175,8 @@ install:
 # YUM plugins
 	$(IPROG) yum-plugins/accesstoken.py $(DESTDIR)$(YUMPLUGINDIR)
 	$(IDATA) yum-plugins/accesstoken.conf $(DESTDIR)$(YUMPLUGINCONFDIR)
+	$(IPROG) yum-plugins/ptoken.py $(DESTDIR)$(YUMPLUGINDIR)
+	$(IDATA) yum-plugins/ptoken.conf $(DESTDIR)$(YUMPLUGINCONFDIR)
 # maillanguages
 	mkdir -p $(DESTDIR)/etc/xapi.d/mail-languages
 	$(IDATA) mail-languages/en-US.json $(DESTDIR)/etc/xapi.d/mail-languages

--- a/scripts/yum-plugins/accesstoken.py
+++ b/scripts/yum-plugins/accesstoken.py
@@ -6,7 +6,7 @@
 #   enabled=1
 #
 # Configure it by:
-# yum-config-manager --setopt=centaurus.accesstoken=file://<token-file-path> --save
+# yum-config-manager --setopt=<repo-name>.accesstoken=file://<token-file-path> --save
 
 # The content of the file referred by the <token-file-path> looks like:
 # { 'token': '...', 'token_id': '...' }

--- a/scripts/yum-plugins/ptoken.conf
+++ b/scripts/yum-plugins/ptoken.conf
@@ -1,0 +1,3 @@
+[main]
+enabled=1
+

--- a/scripts/yum-plugins/ptoken.py
+++ b/scripts/yum-plugins/ptoken.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+
+# Drop this file into /usr/lib/yum-plugins/
+# Enable it by creating conf file /etc/yum/pluginconf.d/ptoken.conf:
+#   [main]
+#   enabled=1
+#
+# Configure it by:
+# yum-config-manager --setopt=<repo-name>.ptoken=file://<token-file-path> --save
+
+from yum import config
+from yum.plugins import TYPE_CORE
+
+requires_api_version = '2.5'
+plugin_type = (TYPE_CORE,)
+
+def config_hook(conduit):
+    config.RepoConf.ptoken = config.BoolOption(False)
+
+def init_hook(conduit):
+    with open('/etc/xensource/ptoken') as f:
+        ptoken = f.read().strip()
+
+    repos = conduit.getRepos()
+    for name in repos.repos:
+        repo = repos.repos[name]
+        # Only include the ptoken for repos with a localhost URL, for added safety.
+        # These may be proxied to the coordinator through stunnel, set up by xapi.
+        if len(repo.baseurl) > 0 and repo.baseurl[0].startswith("http://127.0.0.1") \
+            and repo.getConfigOption('ptoken'):
+            repo.http_headers['cookie'] = "pool_secret=" + ptoken


### PR DESCRIPTION
This restricts the /repository endpoint to local-root only. This
endpoint is exposed only on the coordinator, and used by other pool
members to access the pool's yum repo mirror.

Yum calls to this endpoint now require a pool secret to be used in a
cookie, which is implemented through a yum plugin.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>