### PR TITLE
 CA-364138 XSI-1217: fix FD leak, Unix.EMFILE

### DIFF
--- a/ocaml/xapi-guard/src/varstored_interface.ml
+++ b/ocaml/xapi-guard/src/varstored_interface.ml
@@ -162,10 +162,9 @@ let rec wait_for_file_to_appear path =
       Conduit_lwt_unix.connect ~ctx:Conduit_lwt_unix.default_ctx
         (`Unix_domain_socket (`File path))
     )
-    (fun (_, ic, _oc) ->
+    (fun (_, ic, oc) ->
       D.debug "Socket at %s works" path ;
-      (* do not close both channels, or we get an EBADF *)
-      Lwt_io.close ic
+      Lwt_io.close oc >>= fun () -> Lwt_io.close ic
     )
     (fun e ->
       D.debug "Waiting for file %s to appear (%s)" path (Printexc.to_string e) ;


### PR DESCRIPTION

* Fix file descriptor leak
* Log the number of file descriptors in use when serving a new VM - this is optional but helps to verify the fix
* Currently testing this (after having removed the debugging code that I used to find the leak)