### PR TITLE
CP-39551: avoid warnings in xapi-cli-server and xenopsd/xc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           ERR=$(egrep 'Error |Warning ' -c make-check.log)
           echo ERR=$ERR
-          test 240 -eq  "$ERR"
+          test 5 -eq  "$ERR"
 
       - name: Check all code in release mode
         # This should be removed when the preceding passes succeed

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -19,7 +19,6 @@
    XE-CLI Front End
    ---------------------------------------------------------------------- *)
 
-open Cli_util
 open Cli_cmdtable
 
 module D = Debug.Make (struct let name = "cli" end)
@@ -3758,11 +3757,11 @@ let rio_help printer minimal cmd =
       Hashtbl.fold (fun name cmd list -> (name, cmd) :: list) cmdtable []
     in
     let cmds =
-      List.filter (fun (name, cmd) -> not (List.mem Hidden cmd.flags)) cmds
+      List.filter (fun (_, cmd) -> not (List.mem Hidden cmd.flags)) cmds
     in
     (* Filter hidden commands from help *)
     let cmds =
-      List.sort (fun (name1, cmd1) (name2, cmd2) -> compare name1 name2) cmds
+      List.sort (fun (name1, _) (name2, _) -> compare name1 name2) cmds
     in
     if List.mem_assoc "all" cmd.params && List.assoc "all" cmd.params = "true"
     then
@@ -3799,7 +3798,7 @@ let rio_help printer minimal cmd =
       )
     else
       let cmds =
-        List.filter (fun (name, cmd) -> List.mem Standard cmd.flags) cmds
+        List.filter (fun (_, cmd) -> List.mem Standard cmd.flags) cmds
       in
       let cmds = List.map fst cmds in
       let h =

--- a/ocaml/xapi-cli-server/cli_printer.ml
+++ b/ocaml/xapi-cli-server/cli_printer.ml
@@ -15,7 +15,6 @@
  * @group Command-Line Interface (CLI)
 *)
 
-open Cli_util
 open Cli_protocol
 
 type record = (string * string) list
@@ -38,7 +37,7 @@ let pad_rhs s len =
 
 let rec multi_line_record r =
   let maxlen =
-    4 + List.fold_left max 0 (List.map (fun (a, b) -> String.length a) r)
+    4 + List.fold_left max 0 (List.map (fun (a, _) -> String.length a) r)
   in
   let indent fs = List.map (fun (f, v) -> (pad_string f maxlen, v)) fs in
   let r =

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -1084,5 +1084,4 @@ let mac_from_int_array macs =
     macs.(3) macs.(4) macs.(5)
 
 (* generate a random mac that is locally administered *)
-let random_mac_local () =
-  mac_from_int_array (Array.init 6 (fun _ -> Random.int 0x100))
+let random_mac_local () = mac_from_int_array (Array.make 6 (Random.int 0x100))

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -185,7 +185,7 @@ let get_uuids_from_refs rs = map_and_concat get_uuid_from_ref rs
 let get_pbds_host rpc session_id pbds =
   match pbds with
   | [pbd] ->
-      Client.PBD.get_host rpc session_id pbd
+      Client.PBD.get_host ~rpc ~session_id ~self:pbd
   | _ ->
       Ref.null
 
@@ -197,7 +197,7 @@ let get_sr_host rpc session_id record =
 let bond_record rpc session_id bond =
   let _ref = ref bond in
   let empty_record =
-    ToGet (fun () -> Client.Bond.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Bond.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -231,8 +231,8 @@ let bond_record rpc session_id bond =
             Record_util.s2sm_to_string "; " (x ()).API.bond_properties
           )
           ~get_map:(fun () -> (x ()).API.bond_properties)
-          ~set_in_map:(fun k v ->
-            Client.Bond.set_property rpc session_id bond k v
+          ~set_in_map:(fun name value ->
+            Client.Bond.set_property ~rpc ~session_id ~self:bond ~name ~value
           )
           ()
       ; make_field ~name:"primary-slave"
@@ -250,7 +250,7 @@ let bond_record rpc session_id bond =
 let vlan_record rpc session_id vlan =
   let _ref = ref vlan in
   let empty_record =
-    ToGet (fun () -> Client.VLAN.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VLAN.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -285,7 +285,7 @@ let vlan_record rpc session_id vlan =
 let tunnel_record rpc session_id tunnel =
   let _ref = ref tunnel in
   let empty_record =
-    ToGet (fun () -> Client.Tunnel.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Tunnel.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -320,11 +320,13 @@ let tunnel_record rpc session_id tunnel =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.tunnel_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Tunnel.add_to_other_config rpc session_id tunnel k v
+          ~add_to_map:(fun key value ->
+            Client.Tunnel.add_to_other_config ~rpc ~session_id ~self:tunnel ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Tunnel.remove_from_other_config rpc session_id tunnel k
+          ~remove_from_map:(fun key ->
+            Client.Tunnel.remove_from_other_config ~rpc ~session_id ~self:tunnel
+              ~key
           )
           ~get_map:(fun () -> (x ()).API.tunnel_other_config)
           ()
@@ -339,7 +341,7 @@ let tunnel_record rpc session_id tunnel =
 let message_record rpc session_id message =
   let _ref = ref message in
   let empty_record =
-    ToGet (fun () -> Client.Message.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Message.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -379,7 +381,8 @@ let message_record rpc session_id message =
 let network_sriov_record rpc session_id network_sriov =
   let _ref = ref network_sriov in
   let empty_record =
-    ToGet (fun () -> Client.Network_sriov.get_record rpc session_id !_ref)
+    ToGet
+      (fun () -> Client.Network_sriov.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -416,8 +419,8 @@ let network_sriov_record rpc session_id network_sriov =
           ~get:(fun () ->
             try
               Int64.to_string
-                (Client.Network_sriov.get_remaining_capacity rpc session_id
-                   network_sriov
+                (Client.Network_sriov.get_remaining_capacity ~rpc ~session_id
+                   ~self:network_sriov
                 )
             with _ -> "<unknown>"
           )
@@ -428,7 +431,7 @@ let network_sriov_record rpc session_id network_sriov =
 let pif_record rpc session_id pif =
   let _ref = ref pif in
   let empty_record =
-    ToGet (fun () -> Client.PIF.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.PIF.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -438,8 +441,8 @@ let pif_record rpc session_id pif =
          (fun () ->
            try
              Some
-               (Client.PIF_metrics.get_record rpc session_id
-                  (x ()).API.pIF_metrics
+               (Client.PIF_metrics.get_record ~rpc ~session_id
+                  ~self:(x ()).API.pIF_metrics
                )
            with _ -> None
          )
@@ -569,7 +572,9 @@ let pif_record rpc session_id pif =
             Record_util.s2sm_to_string "; " (x ()).API.pIF_properties
           )
           ~get_map:(fun () -> (x ()).API.pIF_properties)
-          ~set_in_map:(fun k v -> Client.PIF.set_property rpc session_id pif k v)
+          ~set_in_map:(fun name value ->
+            Client.PIF.set_property ~rpc ~session_id ~self:pif ~name ~value
+          )
           ()
       ; make_field ~name:"capabilities"
           ~get:(fun () -> concat_with_semi (x ()).API.pIF_capabilities)
@@ -581,7 +586,8 @@ let pif_record rpc session_id pif =
               let host = (x ()).API.pIF_host in
               let name = Printf.sprintf "pif_%s_rx" (x ()).API.pIF_device in
               let value =
-                Client.Host.query_data_source rpc session_id host name
+                Client.Host.query_data_source ~rpc ~session_id ~host
+                  ~data_source:name
               in
               string_of_float (value /. 1024.0)
             with _ -> "<unknown>"
@@ -593,7 +599,8 @@ let pif_record rpc session_id pif =
               let host = (x ()).API.pIF_host in
               let name = Printf.sprintf "pif_%s_tx" (x ()).API.pIF_device in
               let value =
-                Client.Host.query_data_source rpc session_id host name
+                Client.Host.query_data_source ~rpc ~session_id ~host
+                  ~data_source:name
               in
               string_of_float (value /. 1024.0)
             with _ -> "<unknown>"
@@ -660,8 +667,8 @@ let pif_record rpc session_id pif =
       ; make_field ~name:"disallow-unplug"
           ~get:(fun () -> string_of_bool (x ()).API.pIF_disallow_unplug)
           ~set:(fun disallow_unplug ->
-            Client.PIF.set_disallow_unplug rpc session_id pif
-              (safe_bool_of_string "disallow-unplug" disallow_unplug)
+            Client.PIF.set_disallow_unplug ~rpc ~session_id ~self:pif
+              ~value:(safe_bool_of_string "disallow-unplug" disallow_unplug)
           )
           ()
       ; make_field ~name:"pci-bus-path"
@@ -675,11 +682,12 @@ let pif_record rpc session_id pif =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.pIF_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.PIF.add_to_other_config rpc session_id pif k v
+          ~add_to_map:(fun key value ->
+            Client.PIF.add_to_other_config ~rpc ~session_id ~self:pif ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.PIF.remove_from_other_config rpc session_id pif k
+          ~remove_from_map:(fun key ->
+            Client.PIF.remove_from_other_config ~rpc ~session_id ~self:pif ~key
           )
           ~get_map:(fun () -> (x ()).API.pIF_other_config)
           ()
@@ -695,7 +703,7 @@ let pif_record rpc session_id pif =
 let task_record rpc session_id task =
   let _ref = ref task in
   let empty_record =
-    ToGet (fun () -> Client.Task.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Task.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -766,11 +774,13 @@ let task_record rpc session_id task =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.task_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Task.add_to_other_config rpc session_id task k v
+          ~add_to_map:(fun key value ->
+            Client.Task.add_to_other_config ~rpc ~session_id ~self:task ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Task.remove_from_other_config rpc session_id task k
+          ~remove_from_map:(fun key ->
+            Client.Task.remove_from_other_config ~rpc ~session_id ~self:task
+              ~key
           )
           ~get_map:(fun () -> (x ()).API.task_other_config)
           ()
@@ -780,7 +790,7 @@ let task_record rpc session_id task =
 let vif_record rpc session_id vif =
   let _ref = ref vif in
   let empty_record =
-    ToGet (fun () -> Client.VIF.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VIF.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -843,19 +853,21 @@ let vif_record rpc session_id vif =
           ()
       ; make_field ~name:"qos_algorithm_type"
           ~get:(fun () -> (x ()).API.vIF_qos_algorithm_type)
-          ~set:(fun qat ->
-            Client.VIF.set_qos_algorithm_type rpc session_id vif qat
+          ~set:(fun value ->
+            Client.VIF.set_qos_algorithm_type ~rpc ~session_id ~self:vif ~value
           )
           ()
       ; make_field ~name:"qos_algorithm_params"
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vIF_qos_algorithm_params
           )
-          ~add_to_map:(fun k v ->
-            Client.VIF.add_to_qos_algorithm_params rpc session_id vif k v
+          ~add_to_map:(fun key value ->
+            Client.VIF.add_to_qos_algorithm_params ~rpc ~session_id ~self:vif
+              ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VIF.remove_from_qos_algorithm_params rpc session_id vif k
+          ~remove_from_map:(fun key ->
+            Client.VIF.remove_from_qos_algorithm_params ~rpc ~session_id
+              ~self:vif ~key
           )
           ~get_map:(fun () -> (x ()).API.vIF_qos_algorithm_params)
           ()
@@ -869,11 +881,12 @@ let vif_record rpc session_id vif =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vIF_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.VIF.add_to_other_config rpc session_id vif k v
+          ~add_to_map:(fun key value ->
+            Client.VIF.add_to_other_config ~rpc ~session_id ~self:vif ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VIF.remove_from_other_config rpc session_id vif k
+          ~remove_from_map:(fun key ->
+            Client.VIF.remove_from_other_config ~rpc ~session_id ~self:vif ~key
           )
           ~get_map:(fun () -> (x ()).API.vIF_other_config)
           ()
@@ -888,8 +901,8 @@ let vif_record rpc session_id vif =
             try
               let name = Printf.sprintf "vif_%s_rx" (x ()).API.vIF_device in
               string_of_float
-                (Client.VM.query_data_source rpc session_id (x ()).API.vIF_VM
-                   name
+                (Client.VM.query_data_source ~rpc ~session_id
+                   ~self:(x ()).API.vIF_VM ~data_source:name
                 /. 1024.0
                 )
             with _ -> "<unknown>"
@@ -900,8 +913,8 @@ let vif_record rpc session_id vif =
             try
               let name = Printf.sprintf "vif_%s_tx" (x ()).API.vIF_device in
               string_of_float
-                (Client.VM.query_data_source rpc session_id (x ()).API.vIF_VM
-                   name
+                (Client.VM.query_data_source ~rpc ~session_id
+                   ~self:(x ()).API.vIF_VM ~data_source:name
                 /. 1024.0
                 )
             with _ -> "<unknown>"
@@ -912,34 +925,36 @@ let vif_record rpc session_id vif =
             Record_util.vif_locking_mode_to_string (x ()).API.vIF_locking_mode
           )
           ~set:(fun value ->
-            Client.VIF.set_locking_mode rpc session_id vif
-              (Record_util.string_to_vif_locking_mode value)
+            Client.VIF.set_locking_mode ~rpc ~session_id ~self:vif
+              ~value:(Record_util.string_to_vif_locking_mode value)
           )
           ()
       ; make_field ~name:"ipv4-allowed"
           ~get:(fun () -> concat_with_semi (x ()).API.vIF_ipv4_allowed)
           ~get_set:(fun () -> (x ()).API.vIF_ipv4_allowed)
           ~add_to_set:(fun value ->
-            Client.VIF.add_ipv4_allowed rpc session_id vif value
+            Client.VIF.add_ipv4_allowed ~rpc ~session_id ~self:vif ~value
           )
           ~remove_from_set:(fun value ->
-            Client.VIF.remove_ipv4_allowed rpc session_id vif value
+            Client.VIF.remove_ipv4_allowed ~rpc ~session_id ~self:vif ~value
           )
           ~set:(fun value ->
-            Client.VIF.set_ipv4_allowed rpc session_id vif (get_words ',' value)
+            Client.VIF.set_ipv4_allowed ~rpc ~session_id ~self:vif
+              ~value:(get_words ',' value)
           )
           ()
       ; make_field ~name:"ipv6-allowed"
           ~get:(fun () -> concat_with_semi (x ()).API.vIF_ipv6_allowed)
           ~get_set:(fun () -> (x ()).API.vIF_ipv6_allowed)
           ~add_to_set:(fun value ->
-            Client.VIF.add_ipv6_allowed rpc session_id vif value
+            Client.VIF.add_ipv6_allowed ~rpc ~session_id ~self:vif ~value
           )
           ~remove_from_set:(fun value ->
-            Client.VIF.remove_ipv6_allowed rpc session_id vif value
+            Client.VIF.remove_ipv6_allowed ~rpc ~session_id ~self:vif ~value
           )
           ~set:(fun value ->
-            Client.VIF.set_ipv6_allowed rpc session_id vif (get_words ',' value)
+            Client.VIF.set_ipv6_allowed ~rpc ~session_id ~self:vif
+              ~value:(get_words ',' value)
           )
           ()
       ; make_field ~name:"ipv4-configuration-mode"
@@ -972,7 +987,7 @@ let vif_record rpc session_id vif =
 let net_record rpc session_id net =
   let _ref = ref net in
   let empty_record =
-    ToGet (fun () -> Client.Network.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Network.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -994,12 +1009,15 @@ let net_record rpc session_id net =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.network_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.network_name_label)
-          ~set:(fun x -> Client.Network.set_name_label rpc session_id net x)
+          ~set:(fun value ->
+            Client.Network.set_name_label ~rpc ~session_id ~self:net ~value
+          )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.network_name_description)
-          ~set:(fun x ->
-            Client.Network.set_name_description rpc session_id net x
+          ~set:(fun value ->
+            Client.Network.set_name_description ~rpc ~session_id ~self:net
+              ~value
           )
           ()
       ; make_field ~name:"VIF-uuids"
@@ -1017,7 +1035,8 @@ let net_record rpc session_id net =
       ; make_field ~name:"MTU"
           ~get:(fun () -> Int64.to_string (x ()).API.network_MTU)
           ~set:(fun x ->
-            Client.Network.set_MTU rpc session_id net (Int64.of_string x)
+            Client.Network.set_MTU ~rpc ~session_id ~self:net
+              ~value:(Int64.of_string x)
           )
           ()
       ; make_field ~name:"bridge" ~get:(fun () -> (x ()).API.network_bridge) ()
@@ -1028,11 +1047,13 @@ let net_record rpc session_id net =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.network_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Network.add_to_other_config rpc session_id net k v
+          ~add_to_map:(fun key value ->
+            Client.Network.add_to_other_config ~rpc ~session_id ~self:net ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Network.remove_from_other_config rpc session_id net k
+          ~remove_from_map:(fun key ->
+            Client.Network.remove_from_other_config ~rpc ~session_id ~self:net
+              ~key
           )
           ~get_map:(fun () -> (x ()).API.network_other_config)
           ()
@@ -1045,9 +1066,11 @@ let net_record rpc session_id net =
       ; make_field ~name:"tags"
           ~get:(fun () -> concat_with_comma (x ()).API.network_tags)
           ~get_set:(fun () -> (x ()).API.network_tags)
-          ~add_to_set:(fun tag -> Client.Network.add_tags rpc session_id net tag)
-          ~remove_from_set:(fun tag ->
-            Client.Network.remove_tags rpc session_id net tag
+          ~add_to_set:(fun value ->
+            Client.Network.add_tags ~rpc ~session_id ~self:net ~value
+          )
+          ~remove_from_set:(fun value ->
+            Client.Network.remove_tags ~rpc ~session_id ~self:net ~value
           )
           ()
       ; make_field ~name:"default-locking-mode"
@@ -1056,8 +1079,9 @@ let net_record rpc session_id net =
               (x ()).API.network_default_locking_mode
           )
           ~set:(fun value ->
-            Client.Network.set_default_locking_mode rpc session_id net
-              (Record_util.string_to_network_default_locking_mode value)
+            Client.Network.set_default_locking_mode ~rpc ~session_id
+              ~network:net
+              ~value:(Record_util.string_to_network_default_locking_mode value)
           )
           ()
       ; make_field ~name:"purpose"
@@ -1070,12 +1094,12 @@ let net_record rpc session_id net =
             |> List.map Record_util.network_purpose_to_string
           )
           ~add_to_set:(fun s ->
-            Client.Network.add_purpose rpc session_id net
-              (Record_util.string_to_network_purpose s)
+            Client.Network.add_purpose ~rpc ~session_id ~self:net
+              ~value:(Record_util.string_to_network_purpose s)
           )
           ~remove_from_set:(fun s ->
-            Client.Network.remove_purpose rpc session_id net
-              (Record_util.string_to_network_purpose s)
+            Client.Network.remove_purpose ~rpc ~session_id ~self:net
+              ~value:(Record_util.string_to_network_purpose s)
           )
           ()
       ]
@@ -1084,7 +1108,7 @@ let net_record rpc session_id net =
 let pool_record rpc session_id pool =
   let _ref = ref pool in
   let empty_record =
-    ToGet (fun () -> Client.Pool.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Pool.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -1106,11 +1130,15 @@ let pool_record rpc session_id pool =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.pool_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.pool_name_label)
-          ~set:(fun x -> Client.Pool.set_name_label rpc session_id pool x)
+          ~set:(fun value ->
+            Client.Pool.set_name_label ~rpc ~session_id ~self:pool ~value
+          )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.pool_name_description)
-          ~set:(fun x -> Client.Pool.set_name_description rpc session_id pool x)
+          ~set:(fun value ->
+            Client.Pool.set_name_description ~rpc ~session_id ~self:pool ~value
+          )
           ()
       ; make_field ~name:"master"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.pool_master)
@@ -1122,9 +1150,9 @@ let pool_record rpc session_id pool =
               if x = "" then
                 Ref.null
               else
-                Client.SR.get_by_uuid rpc session_id x
+                Client.SR.get_by_uuid ~rpc ~session_id ~uuid:x
             in
-            Client.Pool.set_default_SR rpc session_id pool sr_ref
+            Client.Pool.set_default_SR ~rpc ~session_id ~self:pool ~value:sr_ref
           )
           ()
       ; make_field ~name:"crash-dump-SR"
@@ -1134,9 +1162,10 @@ let pool_record rpc session_id pool =
               if x = "" then
                 Ref.null
               else
-                Client.SR.get_by_uuid rpc session_id x
+                Client.SR.get_by_uuid ~rpc ~session_id ~uuid:x
             in
-            Client.Pool.set_crash_dump_SR rpc session_id pool sr_ref
+            Client.Pool.set_crash_dump_SR ~rpc ~session_id ~self:pool
+              ~value:sr_ref
           )
           ()
       ; make_field ~name:"suspend-image-SR"
@@ -1146,25 +1175,28 @@ let pool_record rpc session_id pool =
               if x = "" then
                 Ref.null
               else
-                Client.SR.get_by_uuid rpc session_id x
+                Client.SR.get_by_uuid ~rpc ~session_id ~uuid:x
             in
-            Client.Pool.set_suspend_image_SR rpc session_id pool sr_ref
+            Client.Pool.set_suspend_image_SR ~rpc ~session_id ~self:pool
+              ~value:sr_ref
           )
           ()
       ; make_field ~name:"supported-sr-types"
           ~get:(fun () ->
-            concat_with_semi (Client.SR.get_supported_types rpc session_id)
+            concat_with_semi (Client.SR.get_supported_types ~rpc ~session_id)
           )
           ~expensive:true ()
       ; make_field ~name:"other-config"
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.pool_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Pool.add_to_other_config rpc session_id pool k v
+          ~add_to_map:(fun key value ->
+            Client.Pool.add_to_other_config ~rpc ~session_id ~self:pool ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Pool.remove_from_other_config rpc session_id pool k
+          ~remove_from_map:(fun key ->
+            Client.Pool.remove_from_other_config ~rpc ~session_id ~self:pool
+              ~key
           )
           ~get_map:(fun () -> (x ()).API.pool_other_config)
           ()
@@ -1210,8 +1242,8 @@ let pool_record rpc session_id pool =
             Int64.to_string (x ()).API.pool_ha_host_failures_to_tolerate
           )
           ~set:(fun x ->
-            Client.Pool.set_ha_host_failures_to_tolerate rpc session_id pool
-              (Int64.of_string x)
+            Client.Pool.set_ha_host_failures_to_tolerate ~rpc ~session_id
+              ~self:pool ~value:(Int64.of_string x)
           )
           ()
       ; make_field ~name:"ha-plan-exists-for"
@@ -1220,8 +1252,8 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"ha-allow-overcommit"
           ~get:(fun () -> string_of_bool (x ()).API.pool_ha_allow_overcommit)
           ~set:(fun x ->
-            Client.Pool.set_ha_allow_overcommit rpc session_id pool
-              (bool_of_string x)
+            Client.Pool.set_ha_allow_overcommit ~rpc ~session_id ~self:pool
+              ~value:(bool_of_string x)
           )
           ()
       ; make_field ~name:"ha-overcommitted"
@@ -1240,32 +1272,34 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"wlb-enabled"
           ~get:(fun () -> string_of_bool (x ()).API.pool_wlb_enabled)
           ~set:(fun x ->
-            Client.Pool.set_wlb_enabled rpc session_id pool (bool_of_string x)
+            Client.Pool.set_wlb_enabled ~rpc ~session_id ~self:pool
+              ~value:(bool_of_string x)
           )
           ()
       ; make_field ~name:"wlb-verify-cert"
           ~get:(fun () -> string_of_bool (x ()).API.pool_wlb_verify_cert)
           ~set:(fun x ->
-            Client.Pool.set_wlb_verify_cert rpc session_id pool
-              (bool_of_string x)
+            Client.Pool.set_wlb_verify_cert ~rpc ~session_id ~self:pool
+              ~value:(bool_of_string x)
           )
           ()
       ; make_field ~name:"igmp-snooping-enabled"
           ~get:(fun () -> string_of_bool (x ()).API.pool_igmp_snooping_enabled)
           ~set:(fun x ->
-            Client.Pool.set_igmp_snooping_enabled rpc session_id pool
-              (bool_of_string x)
+            Client.Pool.set_igmp_snooping_enabled ~rpc ~session_id ~self:pool
+              ~value:(bool_of_string x)
           )
           ()
       ; make_field ~name:"gui-config"
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.pool_gui_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Pool.add_to_gui_config rpc session_id pool k v
+          ~add_to_map:(fun key value ->
+            Client.Pool.add_to_gui_config ~rpc ~session_id ~self:pool ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Pool.remove_from_gui_config rpc session_id pool k
+          ~remove_from_map:(fun key ->
+            Client.Pool.remove_from_gui_config ~rpc ~session_id ~self:pool ~key
           )
           ~get_map:(fun () -> (x ()).API.pool_gui_config)
           ()
@@ -1273,11 +1307,13 @@ let pool_record rpc session_id pool =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.pool_health_check_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Pool.add_to_health_check_config rpc session_id pool k v
+          ~add_to_map:(fun key value ->
+            Client.Pool.add_to_health_check_config ~rpc ~session_id ~self:pool
+              ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Pool.remove_from_health_check_config rpc session_id pool k
+          ~remove_from_map:(fun key ->
+            Client.Pool.remove_from_health_check_config ~rpc ~session_id
+              ~self:pool ~key
           )
           ~get_map:(fun () -> (x ()).API.pool_health_check_config)
           ()
@@ -1295,15 +1331,17 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"tags"
           ~get:(fun () -> concat_with_comma (x ()).API.pool_tags)
           ~get_set:(fun () -> (x ()).API.pool_tags)
-          ~add_to_set:(fun tag -> Client.Pool.add_tags rpc session_id pool tag)
-          ~remove_from_set:(fun tag ->
-            Client.Pool.remove_tags rpc session_id pool tag
+          ~add_to_set:(fun value ->
+            Client.Pool.add_tags ~rpc ~session_id ~self:pool ~value
+          )
+          ~remove_from_set:(fun value ->
+            Client.Pool.remove_tags ~rpc ~session_id ~self:pool ~value
           )
           ()
       ; make_field ~name:"license-state"
           ~get:(fun () ->
             Record_util.s2sm_to_string "; "
-              (Client.Pool.get_license_state rpc session_id pool)
+              (Client.Pool.get_license_state ~rpc ~session_id ~self:pool)
           )
           ()
       ; make_field ~name:"ha-cluster-stack"
@@ -1313,11 +1351,13 @@ let pool_record rpc session_id pool =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.pool_guest_agent_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Pool.add_to_guest_agent_config rpc session_id pool k v
+          ~add_to_map:(fun key value ->
+            Client.Pool.add_to_guest_agent_config ~rpc ~session_id ~self:pool
+              ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Pool.remove_from_guest_agent_config rpc session_id pool k
+          ~remove_from_map:(fun key ->
+            Client.Pool.remove_from_guest_agent_config ~rpc ~session_id
+              ~self:pool ~key
           )
           ~get_map:(fun () -> (x ()).API.pool_guest_agent_config)
           ()
@@ -1330,15 +1370,15 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"policy-no-vendor-device"
           ~get:(fun () -> string_of_bool (x ()).API.pool_policy_no_vendor_device)
           ~set:(fun s ->
-            Client.Pool.set_policy_no_vendor_device rpc session_id pool
-              (safe_bool_of_string "policy-no-vendor-device" s)
+            Client.Pool.set_policy_no_vendor_device ~rpc ~session_id ~self:pool
+              ~value:(safe_bool_of_string "policy-no-vendor-device" s)
           )
           ()
       ; make_field ~name:"live-patching-disabled"
           ~get:(fun () -> string_of_bool (x ()).API.pool_live_patching_disabled)
           ~set:(fun s ->
-            Client.Pool.set_live_patching_disabled rpc session_id pool
-              (safe_bool_of_string "live-patching-disabled" s)
+            Client.Pool.set_live_patching_disabled ~rpc ~session_id ~self:pool
+              ~value:(safe_bool_of_string "live-patching-disabled" s)
           )
           ()
       ; make_field ~name:"uefi-certificates" ~hidden:true
@@ -1363,19 +1403,22 @@ let pool_record rpc session_id pool =
             List.map get_uuid_from_ref (x ()).API.pool_repositories
           )
           ~set:(fun uuids ->
-            Client.Pool.set_repositories rpc session_id pool
-              (List.map
-                 (fun uuid -> Client.Repository.get_by_uuid rpc session_id uuid)
-                 (get_words ',' uuids)
-              )
+            Client.Pool.set_repositories ~rpc ~session_id ~self:pool
+              ~value:
+                (List.map
+                   (fun uuid ->
+                     Client.Repository.get_by_uuid ~rpc ~session_id ~uuid
+                   )
+                   (get_words ',' uuids)
+                )
           )
           ~add_to_set:(fun uuid ->
-            Client.Pool.add_repository rpc session_id pool
-              (Client.Repository.get_by_uuid rpc session_id uuid)
+            Client.Pool.add_repository ~rpc ~session_id ~self:pool
+              ~value:(Client.Repository.get_by_uuid ~rpc ~session_id ~uuid)
           )
           ~remove_from_set:(fun uuid ->
-            Client.Pool.remove_repository rpc session_id pool
-              (Client.Repository.get_by_uuid rpc session_id uuid)
+            Client.Pool.remove_repository ~rpc ~session_id ~self:pool
+              ~value:(Client.Repository.get_by_uuid ~rpc ~session_id ~uuid)
           )
           ()
       ; make_field ~name:"repository-proxy-url"
@@ -1390,7 +1433,7 @@ let pool_record rpc session_id pool =
 let vmss_record rpc session_id vmss =
   let _ref = ref vmss in
   let empty_record =
-    ToGet (fun () -> Client.VMSS.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VMSS.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -1412,24 +1455,28 @@ let vmss_record rpc session_id vmss =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.vMSS_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.vMSS_name_label)
-          ~set:(fun x -> Client.VMSS.set_name_label rpc session_id vmss x)
+          ~set:(fun value ->
+            Client.VMSS.set_name_label ~rpc ~session_id ~self:vmss ~value
+          )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.vMSS_name_description)
-          ~set:(fun x -> Client.VMSS.set_name_description rpc session_id vmss x)
+          ~set:(fun value ->
+            Client.VMSS.set_name_description ~rpc ~session_id ~self:vmss ~value
+          )
           ()
       ; make_field ~name:"enabled"
           ~get:(fun () -> string_of_bool (x ()).API.vMSS_enabled)
           ~set:(fun x ->
-            Client.VMSS.set_enabled rpc session_id vmss
-              (safe_bool_of_string "enabled" x)
+            Client.VMSS.set_enabled ~rpc ~session_id ~self:vmss
+              ~value:(safe_bool_of_string "enabled" x)
           )
           ()
       ; make_field ~name:"type"
           ~get:(fun () -> Record_util.vmss_type_to_string (x ()).API.vMSS_type)
           ~set:(fun x ->
-            Client.VMSS.set_type rpc session_id vmss
-              (Record_util.string_to_vmss_type x)
+            Client.VMSS.set_type ~rpc ~session_id ~self:vmss
+              ~value:(Record_util.string_to_vmss_type x)
           )
           ()
       ; make_field ~name:"retained-snapshots"
@@ -1437,8 +1484,8 @@ let vmss_record rpc session_id vmss =
             string_of_int (Int64.to_int (x ()).API.vMSS_retained_snapshots)
           )
           ~set:(fun x ->
-            Client.VMSS.set_retained_snapshots rpc session_id vmss
-              (safe_i64_of_string "retained-snapshots" x)
+            Client.VMSS.set_retained_snapshots ~rpc ~session_id ~self:vmss
+              ~value:(safe_i64_of_string "retained-snapshots" x)
           )
           ()
       ; make_field ~name:"frequency"
@@ -1446,8 +1493,8 @@ let vmss_record rpc session_id vmss =
             Record_util.vmss_frequency_to_string (x ()).API.vMSS_frequency
           )
           ~set:(fun x ->
-            Client.VMSS.set_frequency rpc session_id vmss
-              (Record_util.string_to_vmss_frequency x)
+            Client.VMSS.set_frequency ~rpc ~session_id ~self:vmss
+              ~value:(Record_util.string_to_vmss_frequency x)
           )
           ()
       ; make_field ~name:"schedule"
@@ -1455,11 +1502,11 @@ let vmss_record rpc session_id vmss =
             Record_util.s2sm_to_string "; " (x ()).API.vMSS_schedule
           )
           ~get_map:(fun () -> (x ()).API.vMSS_schedule)
-          ~add_to_map:(fun k v ->
-            Client.VMSS.add_to_schedule rpc session_id vmss k v
+          ~add_to_map:(fun key value ->
+            Client.VMSS.add_to_schedule ~rpc ~session_id ~self:vmss ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VMSS.remove_from_schedule rpc session_id vmss k
+          ~remove_from_map:(fun key ->
+            Client.VMSS.remove_from_schedule ~rpc ~session_id ~self:vmss ~key
           )
           ()
       ; make_field ~name:"last-run-time"
@@ -1470,9 +1517,9 @@ let vmss_record rpc session_id vmss =
             try
               map_and_concat
                 (fun self ->
-                  try Client.VM.get_uuid rpc session_id self with _ -> nid
+                  try Client.VM.get_uuid ~rpc ~session_id ~self with _ -> nid
                 )
-                (Client.VMSS.get_VMs rpc session_id vmss)
+                (Client.VMSS.get_VMs ~rpc ~session_id ~self:vmss)
             with _ -> ""
           )
           ~expensive:false
@@ -1480,9 +1527,9 @@ let vmss_record rpc session_id vmss =
             try
               List.map
                 (fun self ->
-                  try Client.VM.get_uuid rpc session_id self with _ -> nid
+                  try Client.VM.get_uuid ~rpc ~session_id ~self with _ -> nid
                 )
-                (Client.VMSS.get_VMs rpc session_id vmss)
+                (Client.VMSS.get_VMs ~rpc ~session_id ~self:vmss)
             with _ -> []
           )
           ()
@@ -1492,7 +1539,7 @@ let vmss_record rpc session_id vmss =
 let subject_record rpc session_id subject =
   let _ref = ref subject in
   let empty_record =
-    ToGet (fun () -> Client.Subject.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Subject.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -1526,10 +1573,10 @@ let subject_record rpc session_id subject =
             try
               map_and_concat
                 (fun self ->
-                  try Client.Role.get_name_label rpc session_id self
+                  try Client.Role.get_name_label ~rpc ~session_id ~self
                   with _ -> nid
                 )
-                (Client.Subject.get_roles rpc session_id subject)
+                (Client.Subject.get_roles ~rpc ~session_id ~self:subject)
             with _ -> ""
           )
           ~expensive:false
@@ -1537,10 +1584,10 @@ let subject_record rpc session_id subject =
             try
               List.map
                 (fun self ->
-                  try Client.Role.get_name_label rpc session_id self
+                  try Client.Role.get_name_label ~rpc ~session_id ~self
                   with _ -> nid
                 )
-                (Client.Subject.get_roles rpc session_id subject)
+                (Client.Subject.get_roles ~rpc ~session_id ~self:subject)
             with _ -> []
           )
           ()
@@ -1550,7 +1597,7 @@ let subject_record rpc session_id subject =
 let role_record rpc session_id role =
   let _ref = ref role in
   let empty_record =
-    ToGet (fun () -> Client.Role.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Role.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -1580,7 +1627,7 @@ let role_record rpc session_id role =
 let console_record rpc session_id console =
   let _ref = ref console in
   let empty_record =
-    ToGet (fun () -> Client.Console.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Console.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -1618,11 +1665,13 @@ let console_record rpc session_id console =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.console_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Console.add_to_other_config rpc session_id console k v
+          ~add_to_map:(fun key value ->
+            Client.Console.add_to_other_config ~rpc ~session_id ~self:console
+              ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Console.remove_from_other_config rpc session_id console k
+          ~remove_from_map:(fun key ->
+            Client.Console.remove_from_other_config ~rpc ~session_id
+              ~self:console ~key
           )
           ~get_map:(fun () -> (x ()).API.console_other_config)
           ()
@@ -1632,7 +1681,7 @@ let console_record rpc session_id console =
 let vm_record rpc session_id vm =
   let _ref = ref vm in
   let empty_record =
-    ToGet (fun () -> Client.VM.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VM.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -1641,7 +1690,9 @@ let vm_record rpc session_id vm =
       (fun () ->
         try
           Some
-            (Client.VM_metrics.get_record rpc session_id (x ()).API.vM_metrics)
+            (Client.VM_metrics.get_record ~rpc ~session_id
+               ~self:(x ()).API.vM_metrics
+            )
         with _ -> None
       )
   in
@@ -1652,8 +1703,8 @@ let vm_record rpc session_id vm =
       (fun () ->
         try
           Some
-            (Client.VM_guest_metrics.get_record rpc session_id
-               (x ()).API.vM_guest_metrics
+            (Client.VM_guest_metrics.get_record ~rpc ~session_id
+               ~self:(x ()).API.vM_guest_metrics
             )
         with _ -> None
       )
@@ -1671,8 +1722,8 @@ let vm_record rpc session_id vm =
       else
         ( string_of_int n
         , string_of_float
-            (Client.VM.query_data_source rpc session_id !_ref
-               (Printf.sprintf "cpu%d" n)
+            (Client.VM.query_data_source ~rpc ~session_id ~self:!_ref
+               ~data_source:(Printf.sprintf "cpu%d" n)
             )
         )
         :: inner (n + 1)
@@ -1684,7 +1735,9 @@ let vm_record rpc session_id vm =
       Int64.to_string
         ( try
             Int64.of_float
-              (Client.VM.query_data_source rpc session_id !_ref "memory_target")
+              (Client.VM.query_data_source ~rpc ~session_id ~self:!_ref
+                 ~data_source:"memory_target"
+              )
           with
           | Api_errors.Server_error (code, _)
           when code = Api_errors.vm_bad_power_state
@@ -1712,31 +1765,35 @@ let vm_record rpc session_id vm =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.vM_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.vM_name_label)
-          ~set:(fun x -> Client.VM.set_name_label rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_name_label ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.vM_name_description)
-          ~set:(fun x -> Client.VM.set_name_description rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_name_description ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"user-version"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_user_version)
           ~set:(fun x ->
-            Client.VM.set_user_version rpc session_id vm
-              (safe_i64_of_string "user-version" x)
+            Client.VM.set_user_version ~rpc ~session_id ~self:vm
+              ~value:(safe_i64_of_string "user-version" x)
           )
           ()
       ; make_field ~name:"is-a-template"
           ~get:(fun () -> string_of_bool (x ()).API.vM_is_a_template)
           ~set:(fun x ->
-            Client.VM.set_is_a_template rpc session_id vm
-              (safe_bool_of_string "is-a-template" x)
+            Client.VM.set_is_a_template ~rpc ~session_id ~self:vm
+              ~value:(safe_bool_of_string "is-a-template" x)
           )
           ()
       ; make_field ~name:"is-default-template"
           ~get:(fun () -> string_of_bool (x ()).API.vM_is_default_template)
           ~set:(fun x ->
-            Client.VM.set_is_default_template rpc session_id vm
-              (safe_bool_of_string "is-default-template" x)
+            Client.VM.set_is_default_template ~rpc ~session_id ~vm
+              ~value:(safe_bool_of_string "is-default-template" x)
           )
           ()
       ; make_field ~name:"is-a-snapshot"
@@ -1787,79 +1844,80 @@ let vm_record rpc session_id vm =
       ; make_field ~name:"memory-static-max"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_memory_static_max)
           ~set:(fun x ->
-            Client.VM.set_memory_static_max rpc session_id vm
-              (Record_util.bytes_of_string "memory-static-max" x)
+            Client.VM.set_memory_static_max ~rpc ~session_id ~self:vm
+              ~value:(Record_util.bytes_of_string "memory-static-max" x)
           )
           ()
       ; make_field ~name:"memory-dynamic-max"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_memory_dynamic_max)
           ~set:(fun x ->
-            Client.VM.set_memory_dynamic_max rpc session_id vm
-              (Record_util.bytes_of_string "memory-dynamic-max" x)
+            Client.VM.set_memory_dynamic_max ~rpc ~session_id ~self:vm
+              ~value:(Record_util.bytes_of_string "memory-dynamic-max" x)
           )
           ()
       ; make_field ~name:"memory-dynamic-min"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_memory_dynamic_min)
           ~set:(fun x ->
-            Client.VM.set_memory_dynamic_min rpc session_id vm
-              (Record_util.bytes_of_string "memory-dynamic-min" x)
+            Client.VM.set_memory_dynamic_min ~rpc ~session_id ~self:vm
+              ~value:(Record_util.bytes_of_string "memory-dynamic-min" x)
           )
           ()
       ; make_field ~name:"memory-static-min"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_memory_static_min)
           ~set:(fun x ->
-            Client.VM.set_memory_static_min rpc session_id vm
-              (Record_util.bytes_of_string "memory-static-min" x)
+            Client.VM.set_memory_static_min ~rpc ~session_id ~self:vm
+              ~value:(Record_util.bytes_of_string "memory-static-min" x)
           )
           ()
       ; make_field ~name:"suspend-VDI-uuid"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vM_suspend_VDI)
           ~set:(fun x ->
-            Client.VM.set_suspend_VDI rpc session_id vm
-              (Client.VDI.get_by_uuid rpc session_id x)
+            Client.VM.set_suspend_VDI ~rpc ~session_id ~self:vm
+              ~value:(Client.VDI.get_by_uuid ~rpc ~session_id ~uuid:x)
           )
           ()
       ; make_field ~name:"suspend-SR-uuid"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vM_suspend_SR)
           ~set:(fun x ->
-            Client.VM.set_suspend_SR rpc session_id vm
-              (Client.SR.get_by_uuid rpc session_id x)
+            Client.VM.set_suspend_SR ~rpc ~session_id ~self:vm
+              ~value:(Client.SR.get_by_uuid ~rpc ~session_id ~uuid:x)
           )
           ()
       ; make_field ~name:"VCPUs-params"
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vM_VCPUs_params
           )
-          ~add_to_map:(fun k v ->
-            match k with
+          ~add_to_map:(fun key value ->
+            match key with
             | "weight" | "cap" | "mask" ->
-                Client.VM.add_to_VCPUs_params rpc session_id vm k v
+                Client.VM.add_to_VCPUs_params ~rpc ~session_id ~self:vm ~key
+                  ~value
             | _ ->
                 raise
                   (Record_util.Record_failure
                      ("Failed to add parameter '"
-                     ^ k
+                     ^ key
                      ^ "': expecting 'weight','cap' or 'mask'"
                      )
                   )
           )
-          ~remove_from_map:(fun k ->
-            Client.VM.remove_from_VCPUs_params rpc session_id vm k
+          ~remove_from_map:(fun key ->
+            Client.VM.remove_from_VCPUs_params ~rpc ~session_id ~self:vm ~key
           )
           ~get_map:(fun () -> (x ()).API.vM_VCPUs_params)
           ()
       ; make_field ~name:"VCPUs-max"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_VCPUs_max)
           ~set:(fun x ->
-            Client.VM.set_VCPUs_max rpc session_id vm
-              (safe_i64_of_string "VCPUs-max" x)
+            Client.VM.set_VCPUs_max ~rpc ~session_id ~self:vm
+              ~value:(safe_i64_of_string "VCPUs-max" x)
           )
           ()
       ; make_field ~name:"VCPUs-at-startup"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_VCPUs_at_startup)
           ~set:(fun x ->
-            Client.VM.set_VCPUs_at_startup rpc session_id vm
-              (safe_i64_of_string "VCPUs-at-startup" x)
+            Client.VM.set_VCPUs_at_startup ~rpc ~session_id ~self:vm
+              ~value:(safe_i64_of_string "VCPUs-at-startup" x)
           )
           ()
       ; make_field ~name:"actions-after-shutdown"
@@ -1868,8 +1926,8 @@ let vm_record rpc session_id vm =
               (x ()).API.vM_actions_after_shutdown
           )
           ~set:(fun x ->
-            Client.VM.set_actions_after_shutdown rpc session_id vm
-              (Record_util.string_to_on_normal_exit x)
+            Client.VM.set_actions_after_shutdown ~rpc ~session_id ~self:vm
+              ~value:(Record_util.string_to_on_normal_exit x)
           )
           ()
       ; make_field ~name:"actions-after-reboot"
@@ -1878,8 +1936,8 @@ let vm_record rpc session_id vm =
               (x ()).API.vM_actions_after_reboot
           )
           ~set:(fun x ->
-            Client.VM.set_actions_after_reboot rpc session_id vm
-              (Record_util.string_to_on_normal_exit x)
+            Client.VM.set_actions_after_reboot ~rpc ~session_id ~self:vm
+              ~value:(Record_util.string_to_on_normal_exit x)
           )
           ()
       ; make_field ~name:"actions-after-crash"
@@ -1888,8 +1946,8 @@ let vm_record rpc session_id vm =
               (x ()).API.vM_actions_after_crash
           )
           ~set:(fun x ->
-            Client.VM.set_actions_after_crash rpc session_id vm
-              (Record_util.string_to_on_crash_behaviour x)
+            Client.VM.set_actions_after_crash ~rpc ~session_id ~self:vm
+              ~value:(Record_util.string_to_on_crash_behaviour x)
           )
           ()
       ; make_field ~name:"console-uuids"
@@ -1919,11 +1977,11 @@ let vm_record rpc session_id vm =
           ()
       ; make_field ~name:"platform"
           ~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.vM_platform)
-          ~add_to_map:(fun k v ->
-            Client.VM.add_to_platform rpc session_id vm k v
+          ~add_to_map:(fun key value ->
+            Client.VM.add_to_platform ~rpc ~session_id ~self:vm ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VM.remove_from_platform rpc session_id vm k
+          ~remove_from_map:(fun key ->
+            Client.VM.remove_from_platform ~rpc ~session_id ~self:vm ~key
           )
           ~get_map:(fun () -> (x ()).API.vM_platform)
           ()
@@ -1957,14 +2015,14 @@ let vm_record rpc session_id vm =
                  (x ()).API.vM_blocked_operations
               )
           )
-          ~add_to_map:(fun k v ->
-            Client.VM.add_to_blocked_operations rpc session_id vm
-              (Record_util.string_to_vm_operation k)
-              v
+          ~add_to_map:(fun k value ->
+            Client.VM.add_to_blocked_operations ~rpc ~session_id ~self:vm
+              ~key:(Record_util.string_to_vm_operation k)
+              ~value
           )
           ~remove_from_map:(fun k ->
-            Client.VM.remove_from_blocked_operations rpc session_id vm
-              (Record_util.string_to_vm_operation k)
+            Client.VM.remove_from_blocked_operations ~rpc ~session_id ~self:vm
+              ~key:(Record_util.string_to_vm_operation k)
           )
           ~get_map:(fun () ->
             List.map
@@ -1976,32 +2034,33 @@ let vm_record rpc session_id vm =
         make_field ~name:"allowed-VBD-devices"
           ~get:(fun () ->
             concat_with_semi
-              ( try Client.VM.get_allowed_VBD_devices rpc session_id vm
+              ( try Client.VM.get_allowed_VBD_devices ~rpc ~session_id ~vm
                 with _ -> []
               )
           )
           ~expensive:true
           ~get_set:(fun () ->
-            try Client.VM.get_allowed_VBD_devices rpc session_id vm
+            try Client.VM.get_allowed_VBD_devices ~rpc ~session_id ~vm
             with _ -> []
           )
           ()
       ; make_field ~name:"allowed-VIF-devices"
           ~get:(fun () ->
             concat_with_semi
-              ( try Client.VM.get_allowed_VIF_devices rpc session_id vm
+              ( try Client.VM.get_allowed_VIF_devices ~rpc ~session_id ~vm
                 with _ -> []
               )
           )
           ~expensive:true
           ~get_set:(fun () ->
-            try Client.VM.get_allowed_VIF_devices rpc session_id vm
+            try Client.VM.get_allowed_VIF_devices ~rpc ~session_id ~vm
             with _ -> []
           )
           ()
       ; make_field ~name:"possible-hosts"
           ~get:(fun () ->
-            get_uuids_from_refs (Client.VM.get_possible_hosts rpc session_id vm)
+            get_uuids_from_refs
+              (Client.VM.get_possible_hosts ~rpc ~session_id ~vm)
           )
           ~expensive:true ()
       ; make_field ~name:"domain-type"
@@ -2009,8 +2068,8 @@ let vm_record rpc session_id vm =
             Record_util.domain_type_to_string (x ()).API.vM_domain_type
           )
           ~set:(fun x ->
-            Client.VM.set_domain_type rpc session_id vm
-              (Record_util.domain_type_of_string x)
+            Client.VM.set_domain_type ~rpc ~session_id ~self:vm
+              ~value:(Record_util.domain_type_of_string x)
           )
           ()
       ; make_field ~name:"current-domain-type"
@@ -2025,58 +2084,75 @@ let vm_record rpc session_id vm =
           ()
       ; make_field ~name:"HVM-boot-policy"
           ~get:(fun () -> (x ()).API.vM_HVM_boot_policy)
-          ~set:(fun x -> Client.VM.set_HVM_boot_policy rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_HVM_boot_policy ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"HVM-boot-params"
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vM_HVM_boot_params
           )
-          ~add_to_map:(fun k v ->
-            Client.VM.add_to_HVM_boot_params rpc session_id vm k v
+          ~add_to_map:(fun key value ->
+            Client.VM.add_to_HVM_boot_params ~rpc ~session_id ~self:vm ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VM.remove_from_HVM_boot_params rpc session_id vm k
+          ~remove_from_map:(fun key ->
+            Client.VM.remove_from_HVM_boot_params ~rpc ~session_id ~self:vm ~key
           )
           ~get_map:(fun () -> (x ()).API.vM_HVM_boot_params)
           ()
       ; make_field ~name:"HVM-shadow-multiplier"
           ~get:(fun () -> string_of_float (x ()).API.vM_HVM_shadow_multiplier)
           ~set:(fun x ->
-            Client.VM.set_HVM_shadow_multiplier rpc session_id vm
-              (float_of_string x)
+            Client.VM.set_HVM_shadow_multiplier ~rpc ~session_id ~self:vm
+              ~value:(float_of_string x)
           )
           ()
       ; make_field ~name:"NVRAM" ~hidden:true
           ~get:(fun () -> Record_util.s2sm_to_string "; " (x ()).API.vM_NVRAM)
-          ~add_to_map:(fun k v -> Client.VM.add_to_NVRAM rpc session_id vm k v)
-          ~remove_from_map:(fun k ->
-            Client.VM.remove_from_NVRAM rpc session_id vm k
+          ~add_to_map:(fun key value ->
+            Client.VM.add_to_NVRAM ~rpc ~session_id ~self:vm ~key ~value
+          )
+          ~remove_from_map:(fun key ->
+            Client.VM.remove_from_NVRAM ~rpc ~session_id ~self:vm ~key
           )
           ~get_map:(fun () -> (x ()).API.vM_NVRAM)
           ()
       ; make_field ~name:"PV-kernel"
           ~get:(fun () -> (x ()).API.vM_PV_kernel)
-          ~set:(fun x -> Client.VM.set_PV_kernel rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_PV_kernel ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"PV-ramdisk"
           ~get:(fun () -> (x ()).API.vM_PV_ramdisk)
-          ~set:(fun x -> Client.VM.set_PV_ramdisk rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_PV_ramdisk ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"PV-args"
           ~get:(fun () -> (x ()).API.vM_PV_args)
-          ~set:(fun x -> Client.VM.set_PV_args rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_PV_args ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"PV-legacy-args"
           ~get:(fun () -> (x ()).API.vM_PV_legacy_args)
-          ~set:(fun x -> Client.VM.set_PV_legacy_args rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_PV_legacy_args ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"PV-bootloader"
           ~get:(fun () -> (x ()).API.vM_PV_bootloader)
-          ~set:(fun x -> Client.VM.set_PV_bootloader rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_PV_bootloader ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"PV-bootloader-args"
           ~get:(fun () -> (x ()).API.vM_PV_bootloader_args)
-          ~set:(fun x -> Client.VM.set_PV_bootloader_args rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_PV_bootloader_args ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"last-boot-CPU-flags"
           ~get:(fun () ->
@@ -2093,21 +2169,21 @@ let vm_record rpc session_id vm =
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vM_affinity)
           ~set:(fun x ->
             if x = "" then
-              Client.VM.set_affinity rpc session_id vm Ref.null
+              Client.VM.set_affinity ~rpc ~session_id ~self:vm ~value:Ref.null
             else
-              Client.VM.set_affinity rpc session_id vm
-                (Client.Host.get_by_uuid rpc session_id x)
+              Client.VM.set_affinity ~rpc ~session_id ~self:vm
+                ~value:(Client.Host.get_by_uuid ~rpc ~session_id ~uuid:x)
           )
           ()
       ; make_field ~name:"other-config"
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vM_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.VM.add_to_other_config rpc session_id vm k v
+          ~add_to_map:(fun key value ->
+            Client.VM.add_to_other_config ~rpc ~session_id ~self:vm ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VM.remove_from_other_config rpc session_id vm k
+          ~remove_from_map:(fun key ->
+            Client.VM.remove_from_other_config ~rpc ~session_id ~self:vm ~key
           )
           ~get_map:(fun () -> (x ()).API.vM_other_config)
           ()
@@ -2121,26 +2197,29 @@ let vm_record rpc session_id vm =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vM_xenstore_data
           )
-          ~add_to_map:(fun k v ->
-            Client.VM.add_to_xenstore_data rpc session_id vm k v
+          ~add_to_map:(fun key value ->
+            Client.VM.add_to_xenstore_data ~rpc ~session_id ~self:vm ~key ~value
           )
           ~clear_map:(fun () ->
             Client.VM.set_xenstore_data ~rpc ~session_id ~self:vm ~value:[]
           )
-          ~remove_from_map:(fun k ->
-            Client.VM.remove_from_xenstore_data rpc session_id vm k
+          ~remove_from_map:(fun key ->
+            Client.VM.remove_from_xenstore_data ~rpc ~session_id ~self:vm ~key
           )
           ~get_map:(fun () -> (x ()).API.vM_xenstore_data)
           ()
       ; make_field ~name:"ha-always-run" ~deprecated:true
           ~get:(fun () -> string_of_bool (x ()).API.vM_ha_always_run)
           ~set:(fun x ->
-            Client.VM.set_ha_always_run rpc session_id vm (bool_of_string x)
+            Client.VM.set_ha_always_run ~rpc ~session_id ~self:vm
+              ~value:(bool_of_string x)
           )
           ()
       ; make_field ~name:"ha-restart-priority"
           ~get:(fun () -> (x ()).API.vM_ha_restart_priority)
-          ~set:(fun x -> Client.VM.set_ha_restart_priority rpc session_id vm x)
+          ~set:(fun value ->
+            Client.VM.set_ha_restart_priority ~rpc ~session_id ~self:vm ~value
+          )
           ()
       ; make_field ~name:"blobs"
           ~get:(fun () ->
@@ -2324,35 +2403,40 @@ let vm_record rpc session_id vm =
       ; make_field ~name:"cooperative" (* NB this can receive VM_IS_SNAPSHOT *)
           ~get:(fun () ->
             string_of_bool
-              (try Client.VM.get_cooperative rpc session_id vm with _ -> true)
+              ( try Client.VM.get_cooperative ~rpc ~session_id ~self:vm
+                with _ -> true
+              )
           )
           ~expensive:true ~deprecated:true ()
       ; make_field ~name:"tags"
           ~get:(fun () -> concat_with_comma (x ()).API.vM_tags)
           ~get_set:(fun () -> (x ()).API.vM_tags)
-          ~add_to_set:(fun tag -> Client.VM.add_tags rpc session_id vm tag)
-          ~remove_from_set:(fun tag ->
-            Client.VM.remove_tags rpc session_id vm tag
+          ~add_to_set:(fun value ->
+            Client.VM.add_tags ~rpc ~session_id ~self:vm ~value
+          )
+          ~remove_from_set:(fun value ->
+            Client.VM.remove_tags ~rpc ~session_id ~self:vm ~value
           )
           ()
       ; make_field ~name:"appliance"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vM_appliance)
           ~set:(fun x ->
             if x = "" then
-              Client.VM.set_appliance rpc session_id vm Ref.null
+              Client.VM.set_appliance ~rpc ~session_id ~self:vm ~value:Ref.null
             else
-              Client.VM.set_appliance rpc session_id vm
-                (Client.VM_appliance.get_by_uuid rpc session_id x)
+              Client.VM.set_appliance ~rpc ~session_id ~self:vm
+                ~value:(Client.VM_appliance.get_by_uuid ~rpc ~session_id ~uuid:x)
           )
           ()
       ; make_field ~name:"snapshot-schedule"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vM_snapshot_schedule)
           ~set:(fun x ->
             if x = "" then
-              Client.VM.set_snapshot_schedule rpc session_id vm Ref.null
+              Client.VM.set_snapshot_schedule ~rpc ~session_id ~self:vm
+                ~value:Ref.null
             else
-              Client.VM.set_snapshot_schedule rpc session_id vm
-                (Client.VMSS.get_by_uuid rpc session_id x)
+              Client.VM.set_snapshot_schedule ~rpc ~session_id ~self:vm
+                ~value:(Client.VMSS.get_by_uuid ~rpc ~session_id ~uuid:x)
           )
           ()
       ; make_field ~name:"is-vmss-snapshot"
@@ -2361,21 +2445,22 @@ let vm_record rpc session_id vm =
       ; make_field ~name:"start-delay"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_start_delay)
           ~set:(fun x ->
-            Client.VM.set_start_delay rpc session_id vm
-              (safe_i64_of_string "start-delay" x)
+            Client.VM.set_start_delay ~rpc ~session_id ~self:vm
+              ~value:(safe_i64_of_string "start-delay" x)
           )
           ()
       ; make_field ~name:"shutdown-delay"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_shutdown_delay)
           ~set:(fun x ->
-            Client.VM.set_shutdown_delay rpc session_id vm
-              (safe_i64_of_string "shutdown-delay" x)
+            Client.VM.set_shutdown_delay ~rpc ~session_id ~self:vm
+              ~value:(safe_i64_of_string "shutdown-delay" x)
           )
           ()
       ; make_field ~name:"order"
           ~get:(fun () -> Int64.to_string (x ()).API.vM_order)
           ~set:(fun x ->
-            Client.VM.set_order rpc session_id vm (safe_i64_of_string "order" x)
+            Client.VM.set_order ~rpc ~session_id ~self:vm
+              ~value:(safe_i64_of_string "order" x)
           )
           ()
       ; make_field ~name:"version"
@@ -2392,8 +2477,8 @@ let vm_record rpc session_id vm =
       ; make_field ~name:"has-vendor-device"
           ~get:(fun () -> string_of_bool (x ()).API.vM_has_vendor_device)
           ~set:(fun x ->
-            Client.VM.set_has_vendor_device rpc session_id vm
-              (safe_bool_of_string "has-vendor-device" x)
+            Client.VM.set_has_vendor_device ~rpc ~session_id ~self:vm
+              ~value:(safe_bool_of_string "has-vendor-device" x)
           )
           ()
       ; make_field ~name:"requires-reboot"
@@ -2422,7 +2507,7 @@ let vm_record rpc session_id vm =
                     )
               )
               x ;
-            Client.VM.set_bios_strings rpc session_id vm x
+            Client.VM.set_bios_strings ~rpc ~session_id ~self:vm ~value:x
           )
           ()
       ; make_field ~name:"pending-guidances"
@@ -2437,7 +2522,8 @@ let vm_record rpc session_id vm =
 let host_crashdump_record rpc session_id host =
   let _ref = ref host in
   let empty_record =
-    ToGet (fun () -> Client.Host_crashdump.get_record rpc session_id !_ref)
+    ToGet
+      (fun () -> Client.Host_crashdump.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -2474,7 +2560,7 @@ let host_crashdump_record rpc session_id host =
 let pool_patch_record rpc session_id patch =
   let _ref = ref patch in
   let empty_record =
-    ToGet (fun () -> Client.Pool_patch.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Pool_patch.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -2549,7 +2635,7 @@ let pool_patch_record rpc session_id patch =
 let pool_update_record rpc session_id update =
   let _ref = ref update in
   let empty_record =
-    ToGet (fun () -> Client.Pool_update.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Pool_update.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -2626,7 +2712,7 @@ let pool_update_record rpc session_id update =
 let host_cpu_record rpc session_id host_cpu =
   let _ref = ref host_cpu in
   let empty_record =
-    ToGet (fun () -> Client.Host_cpu.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Host_cpu.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -2673,9 +2759,10 @@ let host_cpu_record rpc session_id host_cpu =
           ~get:(fun () ->
             try
               string_of_float
-                (Client.Host.query_data_source rpc session_id
-                   (x ()).API.host_cpu_host
-                   (Printf.sprintf "cpu%Ld" (x ()).API.host_cpu_number)
+                (Client.Host.query_data_source ~rpc ~session_id
+                   ~host:(x ()).API.host_cpu_host
+                   ~data_source:
+                     (Printf.sprintf "cpu%Ld" (x ()).API.host_cpu_number)
                 )
             with _ -> "<unknown>"
           )
@@ -2686,7 +2773,7 @@ let host_cpu_record rpc session_id host_cpu =
 let host_record rpc session_id host =
   let _ref = ref host in
   let empty_record =
-    ToGet (fun () -> Client.Host.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Host.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -2696,8 +2783,8 @@ let host_record rpc session_id host =
          (fun () ->
            try
              Some
-               (Client.Host_metrics.get_record rpc session_id
-                  (x ()).API.host_metrics
+               (Client.Host_metrics.get_record ~rpc ~session_id
+                  ~self:(x ()).API.host_metrics
                )
            with _ -> None
          )
@@ -2745,11 +2832,15 @@ let host_record rpc session_id host =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.host_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.host_name_label)
-          ~set:(fun s -> Client.Host.set_name_label rpc session_id host s)
+          ~set:(fun value ->
+            Client.Host.set_name_label ~rpc ~session_id ~self:host ~value
+          )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.host_name_description)
-          ~set:(fun s -> Client.Host.set_name_description rpc session_id host s)
+          ~set:(fun value ->
+            Client.Host.set_name_description ~rpc ~session_id ~self:host ~value
+          )
           ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () ->
@@ -2801,34 +2892,36 @@ let host_record rpc session_id host =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.host_logging
           )
-          ~add_to_map:(fun k v ->
-            Client.Host.add_to_logging rpc session_id host k v
+          ~add_to_map:(fun key value ->
+            Client.Host.add_to_logging ~rpc ~session_id ~self:host ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Host.remove_from_logging rpc session_id host k
+          ~remove_from_map:(fun key ->
+            Client.Host.remove_from_logging ~rpc ~session_id ~self:host ~key
           )
           ~get_map:(fun () -> (x ()).API.host_logging)
           ()
       ; make_field ~name:"suspend-image-sr-uuid"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.host_suspend_image_sr)
           ~set:(fun s ->
-            Client.Host.set_suspend_image_sr rpc session_id host
-              ( if s = "" then
-                  Ref.null
-              else
-                Client.SR.get_by_uuid rpc session_id s
-              )
+            Client.Host.set_suspend_image_sr ~rpc ~session_id ~self:host
+              ~value:
+                ( if s = "" then
+                    Ref.null
+                else
+                  Client.SR.get_by_uuid ~rpc ~session_id ~uuid:s
+                )
           )
           ()
       ; make_field ~name:"crash-dump-sr-uuid"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.host_crash_dump_sr)
           ~set:(fun s ->
-            Client.Host.set_crash_dump_sr rpc session_id host
-              ( if s = "" then
-                  Ref.null
-              else
-                Client.SR.get_by_uuid rpc session_id s
-              )
+            Client.Host.set_crash_dump_sr ~rpc ~session_id ~self:host
+              ~value:
+                ( if s = "" then
+                    Ref.null
+                else
+                  Client.SR.get_by_uuid ~rpc ~session_id ~uuid:s
+                )
           )
           ()
       ; make_field ~name:"software-version"
@@ -2845,11 +2938,13 @@ let host_record rpc session_id host =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.host_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.Host.add_to_other_config rpc session_id host k v
+          ~add_to_map:(fun key value ->
+            Client.Host.add_to_other_config ~rpc ~session_id ~self:host ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Host.remove_from_other_config rpc session_id host k
+          ~remove_from_map:(fun key ->
+            Client.Host.remove_from_other_config ~rpc ~session_id ~self:host
+              ~key
           )
           ~get_map:(fun () -> (x ()).API.host_other_config)
           ()
@@ -2896,7 +2991,8 @@ let host_record rpc session_id host =
           ()
       ; make_field ~name:"memory-free-computed" ~expensive:true
           ~get:(fun () ->
-            Int64.to_string (Client.Host.compute_free_memory rpc session_id host)
+            Int64.to_string
+              (Client.Host.compute_free_memory ~rpc ~session_id ~host)
           )
           ()
       ; make_field ~name:"host-metrics-live"
@@ -2957,16 +3053,18 @@ let host_record rpc session_id host =
       ; make_field ~name:"tags"
           ~get:(fun () -> concat_with_comma (x ()).API.host_tags)
           ~get_set:(fun () -> (x ()).API.host_tags)
-          ~add_to_set:(fun tag -> Client.Host.add_tags rpc session_id host tag)
-          ~remove_from_set:(fun tag ->
-            Client.Host.remove_tags rpc session_id host tag
+          ~add_to_set:(fun value ->
+            Client.Host.add_tags ~rpc ~session_id ~self:host ~value
+          )
+          ~remove_from_set:(fun value ->
+            Client.Host.remove_tags ~rpc ~session_id ~self:host ~value
           )
           ()
       ; make_field ~name:"ssl-legacy"
           ~get:(fun () -> string_of_bool (x ()).API.host_ssl_legacy)
           ~set:(fun s ->
-            Client.Host.set_ssl_legacy rpc session_id host
-              (safe_bool_of_string "ssl-legacy" s)
+            Client.Host.set_ssl_legacy ~rpc ~session_id ~self:host
+              ~value:(safe_bool_of_string "ssl-legacy" s)
           )
           ()
       ; make_field ~name:"guest_VCPUs_params"
@@ -2974,11 +3072,13 @@ let host_record rpc session_id host =
             Record_util.s2sm_to_string "; " (x ()).API.host_guest_VCPUs_params
           )
           ~get_map:(fun () -> (x ()).API.host_guest_VCPUs_params)
-          ~add_to_map:(fun k v ->
-            Client.Host.add_to_guest_VCPUs_params rpc session_id host k v
+          ~add_to_map:(fun key value ->
+            Client.Host.add_to_guest_VCPUs_params ~rpc ~session_id ~self:host
+              ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Host.remove_from_guest_VCPUs_params rpc session_id host k
+          ~remove_from_map:(fun key ->
+            Client.Host.remove_from_guest_VCPUs_params ~rpc ~session_id
+              ~self:host ~key
           )
           ()
       ; make_field ~name:"virtual-hardware-platform-versions"
@@ -3016,13 +3116,15 @@ let host_record rpc session_id host =
           ()
       ; make_field ~name:"iscsi_iqn"
           ~get:(fun () -> (x ()).API.host_iscsi_iqn)
-          ~set:(fun s -> Client.Host.set_iscsi_iqn rpc session_id host s)
+          ~set:(fun value ->
+            Client.Host.set_iscsi_iqn ~rpc ~session_id ~host ~value
+          )
           ()
       ; make_field ~name:"multipathing"
           ~get:(fun () -> string_of_bool (x ()).API.host_multipathing)
           ~set:(fun s ->
-            Client.Host.set_multipathing rpc session_id host
-              (safe_bool_of_string "multipathing" s)
+            Client.Host.set_multipathing ~rpc ~session_id ~host
+              ~value:(safe_bool_of_string "multipathing" s)
           )
           ()
       ; make_field ~name:"uefi-certificates" ~hidden:true
@@ -3048,7 +3150,7 @@ let host_record rpc session_id host =
 let vdi_record rpc session_id vdi =
   let _ref = ref vdi in
   let empty_record =
-    ToGet (fun () -> Client.VDI.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VDI.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -3070,12 +3172,14 @@ let vdi_record rpc session_id vdi =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.vDI_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.vDI_name_label)
-          ~set:(fun label -> Client.VDI.set_name_label rpc session_id vdi label)
+          ~set:(fun value ->
+            Client.VDI.set_name_label ~rpc ~session_id ~self:vdi ~value
+          )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.vDI_name_description)
-          ~set:(fun desc ->
-            Client.VDI.set_name_description rpc session_id vdi desc
+          ~set:(fun value ->
+            Client.VDI.set_name_description ~rpc ~session_id ~self:vdi ~value
           )
           ()
       ; make_field ~name:"is-a-snapshot"
@@ -3163,11 +3267,12 @@ let vdi_record rpc session_id vdi =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vDI_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.VDI.add_to_other_config rpc session_id vdi k v
+          ~add_to_map:(fun key value ->
+            Client.VDI.add_to_other_config ~rpc ~session_id ~self:vdi ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VDI.remove_from_other_config rpc session_id vdi k
+          ~remove_from_map:(fun key ->
+            Client.VDI.remove_from_other_config ~rpc ~session_id ~self:vdi ~key
           )
           ~get_map:(fun () -> (x ()).API.vDI_other_config)
           ()
@@ -3189,14 +3294,15 @@ let vdi_record rpc session_id vdi =
       ; make_field ~name:"on-boot"
           ~get:(fun () -> Record_util.on_boot_to_string (x ()).API.vDI_on_boot)
           ~set:(fun onboot ->
-            Client.VDI.set_on_boot rpc session_id vdi
-              (Record_util.string_to_vdi_onboot onboot)
+            Client.VDI.set_on_boot ~rpc ~session_id ~self:vdi
+              ~value:(Record_util.string_to_vdi_onboot onboot)
           )
           ()
       ; make_field ~name:"allow-caching"
           ~get:(fun () -> string_of_bool (x ()).API.vDI_allow_caching)
           ~set:(fun b ->
-            Client.VDI.set_allow_caching rpc session_id vdi (bool_of_string b)
+            Client.VDI.set_allow_caching ~rpc ~session_id ~self:vdi
+              ~value:(bool_of_string b)
           )
           ()
       ; make_field ~name:"metadata-latest"
@@ -3221,9 +3327,11 @@ let vdi_record rpc session_id vdi =
       ; make_field ~name:"tags"
           ~get:(fun () -> concat_with_comma (x ()).API.vDI_tags)
           ~get_set:(fun () -> (x ()).API.vDI_tags)
-          ~add_to_set:(fun tag -> Client.VDI.add_tags rpc session_id vdi tag)
-          ~remove_from_set:(fun tag ->
-            Client.VDI.remove_tags rpc session_id vdi tag
+          ~add_to_set:(fun value ->
+            Client.VDI.add_tags ~rpc ~session_id ~self:vdi ~value
+          )
+          ~remove_from_set:(fun value ->
+            Client.VDI.remove_tags ~rpc ~session_id ~self:vdi ~value
           )
           ()
       ; make_field ~name:"cbt-enabled"
@@ -3235,7 +3343,7 @@ let vdi_record rpc session_id vdi =
 let vbd_record rpc session_id vbd =
   let _ref = ref vbd in
   let empty_record =
-    ToGet (fun () -> Client.VBD.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VBD.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -3300,13 +3408,15 @@ let vbd_record rpc session_id vbd =
       ; make_field ~name:"device" ~get:(fun () -> (x ()).API.vBD_device) ()
       ; make_field ~name:"userdevice"
           ~get:(fun () -> (x ()).API.vBD_userdevice)
-          ~set:(fun dev -> Client.VBD.set_userdevice rpc session_id vbd dev)
+          ~set:(fun value ->
+            Client.VBD.set_userdevice ~rpc ~session_id ~self:vbd ~value
+          )
           ()
       ; make_field ~name:"bootable"
           ~get:(fun () -> string_of_bool (x ()).API.vBD_bootable)
           ~set:(fun boot ->
-            Client.VBD.set_bootable rpc session_id vbd
-              (safe_bool_of_string "bootable" boot)
+            Client.VBD.set_bootable ~rpc ~session_id ~self:vbd
+              ~value:(safe_bool_of_string "bootable" boot)
           )
           ()
       ; make_field ~name:"mode"
@@ -3314,8 +3424,8 @@ let vbd_record rpc session_id vbd =
             match (x ()).API.vBD_mode with `RO -> "RO" | `RW -> "RW"
           )
           ~set:(fun mode ->
-            Client.VBD.set_mode rpc session_id vbd
-              (Record_util.string_to_vbd_mode mode)
+            Client.VBD.set_mode ~rpc ~session_id ~self:vbd
+              ~value:(Record_util.string_to_vbd_mode mode)
           )
           ()
       ; make_field ~name:"type"
@@ -3329,15 +3439,15 @@ let vbd_record rpc session_id vbd =
                 "Floppy"
           )
           ~set:(fun ty ->
-            Client.VBD.set_type rpc session_id vbd
-              (Record_util.string_to_vbd_type ty)
+            Client.VBD.set_type ~rpc ~session_id ~self:vbd
+              ~value:(Record_util.string_to_vbd_type ty)
           )
           ()
       ; make_field ~name:"unpluggable"
           ~get:(fun () -> string_of_bool (x ()).API.vBD_unpluggable)
           ~set:(fun unpluggable ->
-            Client.VBD.set_unpluggable rpc session_id vbd
-              (safe_bool_of_string "unpluggable" unpluggable)
+            Client.VBD.set_unpluggable ~rpc ~session_id ~self:vbd
+              ~value:(safe_bool_of_string "unpluggable" unpluggable)
           )
           ()
       ; make_field ~name:"currently-attached"
@@ -3346,7 +3456,7 @@ let vbd_record rpc session_id vbd =
       ; make_field ~name:"attachable"
           ~get:(fun () ->
             try
-              Client.VBD.assert_attachable rpc session_id vbd ;
+              Client.VBD.assert_attachable ~rpc ~session_id ~self:vbd ;
               "true"
             with e -> Printf.sprintf "false (error: %s)" (Printexc.to_string e)
           )
@@ -3362,8 +3472,8 @@ let vbd_record rpc session_id vbd =
           ()
       ; make_field ~name:"qos_algorithm_type"
           ~get:(fun () -> (x ()).API.vBD_qos_algorithm_type)
-          ~set:(fun qat ->
-            Client.VBD.set_qos_algorithm_type rpc session_id vbd qat
+          ~set:(fun value ->
+            Client.VBD.set_qos_algorithm_type ~rpc ~session_id ~self:vbd ~value
           )
           ()
       ; make_field ~name:"qos_algorithm_params"
@@ -3371,11 +3481,13 @@ let vbd_record rpc session_id vbd =
             Record_util.s2sm_to_string "; " (x ()).API.vBD_qos_algorithm_params
           )
           ~get_map:(fun () -> (x ()).API.vBD_qos_algorithm_params)
-          ~add_to_map:(fun k v ->
-            Client.VBD.add_to_qos_algorithm_params rpc session_id vbd k v
+          ~add_to_map:(fun key value ->
+            Client.VBD.add_to_qos_algorithm_params ~rpc ~session_id ~self:vbd
+              ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VBD.remove_from_qos_algorithm_params rpc session_id vbd k
+          ~remove_from_map:(fun key ->
+            Client.VBD.remove_from_qos_algorithm_params ~rpc ~session_id
+              ~self:vbd ~key
           )
           ()
       ; make_field ~name:"qos_supported_algorithms"
@@ -3388,11 +3500,12 @@ let vbd_record rpc session_id vbd =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vBD_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.VBD.add_to_other_config rpc session_id vbd k v
+          ~add_to_map:(fun key value ->
+            Client.VBD.add_to_other_config ~rpc ~session_id ~self:vbd ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VBD.remove_from_other_config rpc session_id vbd k
+          ~remove_from_map:(fun key ->
+            Client.VBD.remove_from_other_config ~rpc ~session_id ~self:vbd ~key
           )
           ~get_map:(fun () -> (x ()).API.vBD_other_config)
           ()
@@ -3401,8 +3514,8 @@ let vbd_record rpc session_id vbd =
             try
               let name = Printf.sprintf "vbd_%s_read" (x ()).API.vBD_device in
               string_of_float
-                (Client.VM.query_data_source rpc session_id (x ()).API.vBD_VM
-                   name
+                (Client.VM.query_data_source ~rpc ~session_id
+                   ~self:(x ()).API.vBD_VM ~data_source:name
                 /. 1024.0
                 )
             with _ -> "<unknown>"
@@ -3413,8 +3526,8 @@ let vbd_record rpc session_id vbd =
             try
               let name = Printf.sprintf "vbd_%s_write" (x ()).API.vBD_device in
               string_of_float
-                (Client.VM.query_data_source rpc session_id (x ()).API.vBD_VM
-                   name
+                (Client.VM.query_data_source ~rpc ~session_id
+                   ~self:(x ()).API.vBD_VM ~data_source:name
                 /. 1024.0
                 )
             with _ -> "<unknown>"
@@ -3426,7 +3539,7 @@ let vbd_record rpc session_id vbd =
 let crashdump_record rpc session_id crashdump =
   let _ref = ref crashdump in
   let empty_record =
-    ToGet (fun () -> Client.Crashdump.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Crashdump.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -3461,7 +3574,7 @@ let crashdump_record rpc session_id crashdump =
 let sm_record rpc session_id sm =
   let _ref = ref sm in
   let empty_record =
-    ToGet (fun () -> Client.SM.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.SM.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -3521,7 +3634,7 @@ let sm_record rpc session_id sm =
 let sr_record rpc session_id sr =
   let _ref = ref sr in
   let empty_record =
-    ToGet (fun () -> Client.SR.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.SR.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -3543,11 +3656,15 @@ let sr_record rpc session_id sr =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.sR_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.sR_name_label)
-          ~set:(fun x -> Client.SR.set_name_label rpc session_id sr x)
+          ~set:(fun value ->
+            Client.SR.set_name_label ~rpc ~session_id ~sr ~value
+          )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.sR_name_description)
-          ~set:(fun x -> Client.SR.set_name_description rpc session_id sr x)
+          ~set:(fun value ->
+            Client.SR.set_name_description ~rpc ~session_id ~sr ~value
+          )
           ()
       ; make_field ~name:"host"
           ~get:(fun () ->
@@ -3605,8 +3722,8 @@ let sr_record rpc session_id sr =
       ; make_field ~name:"shared"
           ~get:(fun () -> string_of_bool (x ()).API.sR_shared)
           ~set:(fun x ->
-            Client.SR.set_shared rpc session_id sr
-              (safe_bool_of_string "shared" x)
+            Client.SR.set_shared ~rpc ~session_id ~sr
+              ~value:(safe_bool_of_string "shared" x)
           )
           ()
       ; make_field ~name:"introduced-by"
@@ -3619,11 +3736,11 @@ let sr_record rpc session_id sr =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.sR_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.SR.add_to_other_config rpc session_id sr k v
+          ~add_to_map:(fun key value ->
+            Client.SR.add_to_other_config ~rpc ~session_id ~self:sr ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.SR.remove_from_other_config rpc session_id sr k
+          ~remove_from_map:(fun key ->
+            Client.SR.remove_from_other_config ~rpc ~session_id ~self:sr ~key
           )
           ~get_map:(fun () -> (x ()).API.sR_other_config)
           ()
@@ -3645,9 +3762,11 @@ let sr_record rpc session_id sr =
       ; make_field ~name:"tags"
           ~get:(fun () -> concat_with_comma (x ()).API.sR_tags)
           ~get_set:(fun () -> (x ()).API.sR_tags)
-          ~add_to_set:(fun tag -> Client.SR.add_tags rpc session_id sr tag)
-          ~remove_from_set:(fun tag ->
-            Client.SR.remove_tags rpc session_id sr tag
+          ~add_to_set:(fun value ->
+            Client.SR.add_tags ~rpc ~session_id ~self:sr ~value
+          )
+          ~remove_from_set:(fun value ->
+            Client.SR.remove_tags ~rpc ~session_id ~self:sr ~value
           )
           ()
       ; make_field ~name:"clustered"
@@ -3659,7 +3778,7 @@ let sr_record rpc session_id sr =
 let pbd_record rpc session_id pbd =
   let _ref = ref pbd in
   let empty_record =
-    ToGet (fun () -> Client.PBD.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.PBD.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -3707,11 +3826,12 @@ let pbd_record rpc session_id pbd =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.pBD_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.PBD.add_to_other_config rpc session_id pbd k v
+          ~add_to_map:(fun key value ->
+            Client.PBD.add_to_other_config ~rpc ~session_id ~self:pbd ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.PBD.remove_from_other_config rpc session_id pbd k
+          ~remove_from_map:(fun key ->
+            Client.PBD.remove_from_other_config ~rpc ~session_id ~self:pbd ~key
           )
           ~get_map:(fun () -> (x ()).API.pBD_other_config)
           ()
@@ -3775,14 +3895,16 @@ let vm_appliance_record rpc session_id vm_appliance =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.vM_appliance_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.vM_appliance_name_label)
-          ~set:(fun x ->
-            Client.VM_appliance.set_name_label rpc session_id !_ref x
+          ~set:(fun value ->
+            Client.VM_appliance.set_name_label ~rpc ~session_id ~self:!_ref
+              ~value
           )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.vM_appliance_name_description)
-          ~set:(fun x ->
-            Client.VM_appliance.set_name_description rpc session_id !_ref x
+          ~set:(fun value ->
+            Client.VM_appliance.set_name_description ~rpc ~session_id
+              ~self:!_ref ~value
           )
           ()
       ; make_field ~name:"VMs"
@@ -3848,12 +3970,12 @@ let dr_task_record rpc session_id dr_task =
 let pgpu_record rpc session_id pgpu =
   let _ref = ref pgpu in
   let empty_record =
-    ToGet (fun () -> Client.PGPU.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.PGPU.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
   let pci_record p =
-    ref (ToGet (fun () -> Client.PCI.get_record rpc session_id p))
+    ref (ToGet (fun () -> Client.PCI.get_record ~rpc ~session_id ~self:p))
   in
   let xp0 p = lzy_get (pci_record p) in
   let xp () = xp0 (x ()).API.pGPU_PCI in
@@ -3893,11 +4015,12 @@ let pgpu_record rpc session_id pgpu =
           ~get:(fun () ->
             try get_uuid_from_ref (x ()).API.pGPU_GPU_group with _ -> nid
           )
-          ~set:(fun gpu_group_uuid ->
+          ~set:(fun uuid ->
             let gpu_group =
-              Client.GPU_group.get_by_uuid rpc session_id gpu_group_uuid
+              Client.GPU_group.get_by_uuid ~rpc ~session_id ~uuid
             in
-            Client.PGPU.set_GPU_group rpc session_id pgpu gpu_group
+            Client.PGPU.set_GPU_group ~rpc ~session_id ~self:pgpu
+              ~value:gpu_group
           )
           ()
       ; make_field ~name:"gpu-group-name-label"
@@ -3934,11 +4057,13 @@ let pgpu_record rpc session_id pgpu =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.pGPU_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.PGPU.add_to_other_config rpc session_id pgpu k v
+          ~add_to_map:(fun key value ->
+            Client.PGPU.add_to_other_config ~rpc ~session_id ~self:pgpu ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.PGPU.remove_from_other_config rpc session_id pgpu k
+          ~remove_from_map:(fun key ->
+            Client.PGPU.remove_from_other_config ~rpc ~session_id ~self:pgpu
+              ~key
           )
           ~get_map:(fun () -> (x ()).API.pGPU_other_config)
           ()
@@ -3954,22 +4079,23 @@ let pgpu_record rpc session_id pgpu =
               (fun vgpu_type -> get_uuid_from_ref vgpu_type)
               (x ()).API.pGPU_enabled_VGPU_types
           )
-          ~add_to_set:(fun vgpu_type_uuid ->
-            Client.PGPU.add_enabled_VGPU_types rpc session_id pgpu
-              (Client.VGPU_type.get_by_uuid rpc session_id vgpu_type_uuid)
+          ~add_to_set:(fun uuid ->
+            Client.PGPU.add_enabled_VGPU_types ~rpc ~session_id ~self:pgpu
+              ~value:(Client.VGPU_type.get_by_uuid ~rpc ~session_id ~uuid)
           )
-          ~remove_from_set:(fun vgpu_type_uuid ->
-            Client.PGPU.remove_enabled_VGPU_types rpc session_id pgpu
-              (Client.VGPU_type.get_by_uuid rpc session_id vgpu_type_uuid)
+          ~remove_from_set:(fun uuid ->
+            Client.PGPU.remove_enabled_VGPU_types ~rpc ~session_id ~self:pgpu
+              ~value:(Client.VGPU_type.get_by_uuid ~rpc ~session_id ~uuid)
           )
           ~set:(fun vgpu_type_uuids ->
-            Client.PGPU.set_enabled_VGPU_types rpc session_id pgpu
-              (List.map
-                 (fun vgpu_type_uuid ->
-                   Client.VGPU_type.get_by_uuid rpc session_id vgpu_type_uuid
-                 )
-                 (get_words ',' vgpu_type_uuids)
-              )
+            Client.PGPU.set_enabled_VGPU_types ~rpc ~session_id ~self:pgpu
+              ~value:
+                (List.map
+                   (fun uuid ->
+                     Client.VGPU_type.get_by_uuid ~rpc ~session_id ~uuid
+                   )
+                   (get_words ',' vgpu_type_uuids)
+                )
           )
           ()
       ; make_field ~name:"resident-VGPUs"
@@ -3981,7 +4107,7 @@ let pgpu_record rpc session_id pgpu =
 let gpu_group_record rpc session_id gpu_group =
   let _ref = ref gpu_group in
   let empty_record =
-    ToGet (fun () -> Client.GPU_group.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.GPU_group.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4003,14 +4129,16 @@ let gpu_group_record rpc session_id gpu_group =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.gPU_group_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.gPU_group_name_label)
-          ~set:(fun x ->
-            Client.GPU_group.set_name_label rpc session_id gpu_group x
+          ~set:(fun value ->
+            Client.GPU_group.set_name_label ~rpc ~session_id ~self:gpu_group
+              ~value
           )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.gPU_group_name_description)
-          ~set:(fun x ->
-            Client.GPU_group.set_name_description rpc session_id gpu_group x
+          ~set:(fun value ->
+            Client.GPU_group.set_name_description ~rpc ~session_id
+              ~self:gpu_group ~value
           )
           ()
       ; make_field ~name:"VGPU-uuids"
@@ -4033,25 +4161,29 @@ let gpu_group_record rpc session_id gpu_group =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.gPU_group_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.GPU_group.add_to_other_config rpc session_id gpu_group k v
+          ~add_to_map:(fun key value ->
+            Client.GPU_group.add_to_other_config ~rpc ~session_id
+              ~self:gpu_group ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.GPU_group.remove_from_other_config rpc session_id gpu_group k
+          ~remove_from_map:(fun key ->
+            Client.GPU_group.remove_from_other_config ~rpc ~session_id
+              ~self:gpu_group ~key
           )
           ~get_map:(fun () -> (x ()).API.gPU_group_other_config)
           ()
       ; make_field ~name:"enabled-VGPU-types"
           ~get:(fun () ->
             get_uuids_from_refs
-              (Client.GPU_group.get_enabled_VGPU_types rpc session_id gpu_group)
+              (Client.GPU_group.get_enabled_VGPU_types ~rpc ~session_id
+                 ~self:gpu_group
+              )
           )
           ()
       ; make_field ~name:"supported-VGPU-types"
           ~get:(fun () ->
             get_uuids_from_refs
-              (Client.GPU_group.get_supported_VGPU_types rpc session_id
-                 gpu_group
+              (Client.GPU_group.get_supported_VGPU_types ~rpc ~session_id
+                 ~self:gpu_group
               )
           )
           ()
@@ -4061,8 +4193,9 @@ let gpu_group_record rpc session_id gpu_group =
               (x ()).API.gPU_group_allocation_algorithm
           )
           ~set:(fun ty ->
-            Client.GPU_group.set_allocation_algorithm rpc session_id gpu_group
-              (Record_util.allocation_algorithm_of_string ty)
+            Client.GPU_group.set_allocation_algorithm ~rpc ~session_id
+              ~self:gpu_group
+              ~value:(Record_util.allocation_algorithm_of_string ty)
           )
           ()
       ]
@@ -4071,12 +4204,12 @@ let gpu_group_record rpc session_id gpu_group =
 let vgpu_record rpc session_id vgpu =
   let _ref = ref vgpu in
   let empty_record =
-    ToGet (fun () -> Client.VGPU.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VGPU.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
   let pci_record p =
-    ref (ToGet (fun () -> Client.PCI.get_record rpc session_id p))
+    ref (ToGet (fun () -> Client.PCI.get_record ~rpc ~session_id ~self:p))
   in
   let xp () = lzy_get (pci_record (x ()).API.vGPU_PCI) in
   {
@@ -4119,11 +4252,13 @@ let vgpu_record rpc session_id vgpu =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vGPU_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.VGPU.add_to_other_config rpc session_id vgpu k v
+          ~add_to_map:(fun key value ->
+            Client.VGPU.add_to_other_config ~rpc ~session_id ~self:vgpu ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VGPU.remove_from_other_config rpc session_id vgpu k
+          ~remove_from_map:(fun key ->
+            Client.VGPU.remove_from_other_config ~rpc ~session_id ~self:vgpu
+              ~key
           )
           ~get_map:(fun () -> (x ()).API.vGPU_other_config)
           ()
@@ -4133,8 +4268,8 @@ let vgpu_record rpc session_id vgpu =
       ; make_field ~name:"type-model-name"
           ~get:(fun () ->
             try
-              Client.VGPU_type.get_model_name rpc session_id
-                (x ()).API.vGPU_type
+              Client.VGPU_type.get_model_name ~rpc ~session_id
+                ~self:(x ()).API.vGPU_type
             with _ -> nid
           )
           ()
@@ -4152,7 +4287,9 @@ let vgpu_record rpc session_id vgpu =
           ()
       ; make_field ~name:"extra_args"
           ~get:(fun () -> (x ()).API.vGPU_extra_args)
-          ~set:(fun v -> Client.VGPU.set_extra_args rpc session_id vgpu v)
+          ~set:(fun value ->
+            Client.VGPU.set_extra_args ~rpc ~session_id ~self:vgpu ~value
+          )
           ()
       ; make_field ~name:"pci"
           ~get:(fun () -> try (xp ()).API.pCI_pci_id with _ -> nid)
@@ -4163,7 +4300,7 @@ let vgpu_record rpc session_id vgpu =
 let vgpu_type_record rpc session_id vgpu_type =
   let _ref = ref vgpu_type in
   let empty_record =
-    ToGet (fun () -> Client.VGPU_type.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VGPU_type.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4243,7 +4380,7 @@ let vgpu_type_record rpc session_id vgpu_type =
 let pvs_site_record rpc session_id pvs_site =
   let _ref = ref pvs_site in
   let empty_record =
-    ToGet (fun () -> Client.PVS_site.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.PVS_site.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4265,17 +4402,22 @@ let pvs_site_record rpc session_id pvs_site =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.pVS_site_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.pVS_site_name_label)
-          ~set:(fun x -> Client.PVS_site.set_name_label rpc session_id !_ref x)
+          ~set:(fun value ->
+            Client.PVS_site.set_name_label ~rpc ~session_id ~self:!_ref ~value
+          )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.pVS_site_name_description)
-          ~set:(fun x ->
-            Client.PVS_site.set_name_description rpc session_id !_ref x
+          ~set:(fun value ->
+            Client.PVS_site.set_name_description ~rpc ~session_id ~self:!_ref
+              ~value
           )
           ()
       ; make_field ~name:"pvs-uuid"
           ~get:(fun () -> (x ()).API.pVS_site_PVS_uuid)
-          ~set:(fun x -> Client.PVS_site.set_PVS_uuid rpc session_id !_ref x)
+          ~set:(fun value ->
+            Client.PVS_site.set_PVS_uuid ~rpc ~session_id ~self:!_ref ~value
+          )
           ()
       ; make_field ~name:"pvs-cache-storage-uuids"
           ~get:(fun () -> get_uuids_from_refs (x ()).API.pVS_site_cache_storage)
@@ -4301,7 +4443,7 @@ let pvs_site_record rpc session_id pvs_site =
 let pvs_server_record rpc session_id pvs_site =
   let _ref = ref pvs_site in
   let empty_record =
-    ToGet (fun () -> Client.PVS_server.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.PVS_server.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4340,7 +4482,7 @@ let pvs_server_record rpc session_id pvs_site =
 let pvs_proxy_record rpc session_id pvs_site =
   let _ref = ref pvs_site in
   let empty_record =
-    ToGet (fun () -> Client.PVS_proxy.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.PVS_proxy.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4383,7 +4525,10 @@ let pvs_proxy_record rpc session_id pvs_site =
 let pvs_cache_storage_record rpc session_id pvs_site =
   let _ref = ref pvs_site in
   let empty_record =
-    ToGet (fun () -> Client.PVS_cache_storage.get_record rpc session_id !_ref)
+    ToGet
+      (fun () ->
+        Client.PVS_cache_storage.get_record ~rpc ~session_id ~self:!_ref
+      )
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4426,7 +4571,7 @@ let pvs_cache_storage_record rpc session_id pvs_site =
 let feature_record rpc session_id feature =
   let _ref = ref feature in
   let empty_record =
-    ToGet (fun () -> Client.Feature.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Feature.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4470,7 +4615,8 @@ let feature_record rpc session_id feature =
 let sdn_controller_record rpc session_id sdn_controller =
   let _ref = ref sdn_controller in
   let empty_record =
-    ToGet (fun () -> Client.SDN_controller.get_record rpc session_id !_ref)
+    ToGet
+      (fun () -> Client.SDN_controller.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4510,7 +4656,7 @@ let sdn_controller_record rpc session_id sdn_controller =
 let pusb_record rpc session_id pusb =
   let _ref = ref pusb in
   let empty_record =
-    ToGet (fun () -> Client.PUSB.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.PUSB.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4567,8 +4713,9 @@ let pusb_record rpc session_id pusb =
       ; make_field ~name:"passthrough-enabled"
           ~get:(fun () -> string_of_bool (x ()).API.pUSB_passthrough_enabled)
           ~set:(fun passthrough_enabled ->
-            Client.PUSB.set_passthrough_enabled rpc session_id pusb
-              (safe_bool_of_string "passthrough-enabled" passthrough_enabled)
+            Client.PUSB.set_passthrough_enabled ~rpc ~session_id ~self:pusb
+              ~value:
+                (safe_bool_of_string "passthrough-enabled" passthrough_enabled)
           )
           ()
       ]
@@ -4577,7 +4724,7 @@ let pusb_record rpc session_id pusb =
 let usb_group_record rpc session_id usb_group =
   let _ref = ref usb_group in
   let empty_record =
-    ToGet (fun () -> Client.USB_group.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.USB_group.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4599,14 +4746,16 @@ let usb_group_record rpc session_id usb_group =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.uSB_group_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.uSB_group_name_label)
-          ~set:(fun x ->
-            Client.USB_group.set_name_label rpc session_id usb_group x
+          ~set:(fun value ->
+            Client.USB_group.set_name_label ~rpc ~session_id ~self:usb_group
+              ~value
           )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.uSB_group_name_description)
-          ~set:(fun x ->
-            Client.USB_group.set_name_description rpc session_id usb_group x
+          ~set:(fun value ->
+            Client.USB_group.set_name_description ~rpc ~session_id
+              ~self:usb_group ~value
           )
           ()
       ; make_field ~name:"VUSB-uuids"
@@ -4629,11 +4778,13 @@ let usb_group_record rpc session_id usb_group =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.uSB_group_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.USB_group.add_to_other_config rpc session_id usb_group k v
+          ~add_to_map:(fun key value ->
+            Client.USB_group.add_to_other_config ~rpc ~session_id
+              ~self:usb_group ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.USB_group.remove_from_other_config rpc session_id usb_group k
+          ~remove_from_map:(fun key ->
+            Client.USB_group.remove_from_other_config ~rpc ~session_id
+              ~self:usb_group ~key
           )
           ~get_map:(fun () -> (x ()).API.uSB_group_other_config)
           ()
@@ -4643,7 +4794,7 @@ let usb_group_record rpc session_id usb_group =
 let vusb_record rpc session_id vusb =
   let _ref = ref vusb in
   let empty_record =
-    ToGet (fun () -> Client.VUSB.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.VUSB.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4683,11 +4834,13 @@ let vusb_record rpc session_id vusb =
           ~get:(fun () ->
             Record_util.s2sm_to_string "; " (x ()).API.vUSB_other_config
           )
-          ~add_to_map:(fun k v ->
-            Client.VUSB.add_to_other_config rpc session_id vusb k v
+          ~add_to_map:(fun key value ->
+            Client.VUSB.add_to_other_config ~rpc ~session_id ~self:vusb ~key
+              ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.VUSB.remove_from_other_config rpc session_id vusb k
+          ~remove_from_map:(fun key ->
+            Client.VUSB.remove_from_other_config ~rpc ~session_id ~self:vusb
+              ~key
           )
           ~get_map:(fun () -> (x ()).API.vUSB_other_config)
           ()
@@ -4722,7 +4875,7 @@ let vusb_record rpc session_id vusb =
 let cluster_record rpc session_id cluster =
   let _ref = ref cluster in
   let empty_record =
-    ToGet (fun () -> Client.Cluster.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Cluster.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4802,11 +4955,13 @@ let cluster_record rpc session_id cluster =
             Record_util.s2sm_to_string "; " (x ()).API.cluster_other_config
           )
           ~get_map:(fun () -> (x ()).API.cluster_other_config)
-          ~add_to_map:(fun k v ->
-            Client.Cluster.add_to_other_config rpc session_id cluster k v
+          ~add_to_map:(fun key value ->
+            Client.Cluster.add_to_other_config ~rpc ~session_id ~self:cluster
+              ~key ~value
           )
-          ~remove_from_map:(fun k ->
-            Client.Cluster.remove_from_other_config rpc session_id cluster k
+          ~remove_from_map:(fun key ->
+            Client.Cluster.remove_from_other_config ~rpc ~session_id
+              ~self:cluster ~key
           )
           ()
       ]
@@ -4815,7 +4970,7 @@ let cluster_record rpc session_id cluster =
 let cluster_host_record rpc session_id cluster_host =
   let _ref = ref cluster_host in
   let empty_record =
-    ToGet (fun () -> Client.Cluster_host.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Cluster_host.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4884,7 +5039,7 @@ let cluster_host_record rpc session_id cluster_host =
 let certificate_record rpc session_id certificate =
   let _ref = ref certificate in
   let empty_record =
-    ToGet (fun () -> Client.Certificate.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Certificate.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4929,7 +5084,7 @@ let certificate_record rpc session_id certificate =
 let repository_record rpc session_id repository =
   let _ref = ref repository in
   let empty_record =
-    ToGet (fun () -> Client.Repository.get_record rpc session_id !_ref)
+    ToGet (fun () -> Client.Repository.get_record ~rpc ~session_id ~self:!_ref)
   in
   let record = ref empty_record in
   let x () = lzy_get record in
@@ -4951,14 +5106,16 @@ let repository_record rpc session_id repository =
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.repository_uuid) ()
       ; make_field ~name:"name-label"
           ~get:(fun () -> (x ()).API.repository_name_label)
-          ~set:(fun x ->
-            Client.Repository.set_name_label rpc session_id repository x
+          ~set:(fun value ->
+            Client.Repository.set_name_label ~rpc ~session_id ~self:repository
+              ~value
           )
           ()
       ; make_field ~name:"name-description"
           ~get:(fun () -> (x ()).API.repository_name_description)
-          ~set:(fun x ->
-            Client.Repository.set_name_description rpc session_id repository x
+          ~set:(fun value ->
+            Client.Repository.set_name_description ~rpc ~session_id
+              ~self:repository ~value
           )
           ()
       ; make_field ~name:"binary-url"
@@ -4977,7 +5134,8 @@ let repository_record rpc session_id repository =
       ; make_field ~name:"gpgkey-path"
           ~get:(fun () -> (x ()).API.repository_gpgkey_path)
           ~set:(fun x ->
-            Client.Repository.set_gpgkey_path rpc session_id repository x
+            Client.Repository.set_gpgkey_path ~rpc ~session_id ~self:repository
+              ~value:x
           )
           ()
       ]

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -121,7 +121,7 @@ let with_session ~local rpc u p session f =
     (fun () -> f session)
     (fun () -> do_logout ())
 
-let do_rpcs req s username password minimal cmd session args =
+let do_rpcs _req s username password minimal cmd session args =
   let cmdname = get_cmdname cmd in
   let cspec =
     try Hashtbl.find cmdtable cmdname
@@ -326,7 +326,7 @@ let exception_handler s e =
         s
   | Failure str ->
       Cli_util.server_error Api_errors.internal_error ["Failure: " ^ str] s
-  | Unix.Unix_error (a, b, c) ->
+  | Unix.Unix_error (a, _, _) ->
       Cli_util.server_error Api_errors.internal_error
         ["Unix_error: " ^ Unix.error_message a]
         s
@@ -343,7 +343,7 @@ let handler (req : Http.Request.t) (bio : Buf_io.t) _ =
   (* Tell the client the server version *)
   marshal_protocol s ;
   (* Read the client's protocol version *)
-  let major', minor' = unmarshal_protocol s in
+  let major', _ = unmarshal_protocol s in
   if major' <> major then (
     debug "Rejecting request from client" ;
     failwith "Version mismatch"

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -86,6 +86,8 @@ module Profile = struct
         |> fun s -> Xenopsd_error (Internal_error s) |> raise
     | x when x = Name.qemu_upstream_uefi ->
         Qemu_upstream_uefi
+    | x when x = Name.qemu_none ->
+        Qemu_none
     | x ->
         debug "unknown device-model profile %s: defaulting to %s" x
           Name.qemu_upstream_compat ;
@@ -222,11 +224,6 @@ module Generic = struct
       true
     with Xs_protocol.Enoent _ -> false
 
-  let assert_exists_t ~xs t (x : device) =
-    let backend_stub = backend_path_of_device ~xs x in
-    try ignore_string (t.Xst.read backend_stub)
-    with Xs_protocol.Enoent _ -> raise Device_not_found
-
   (** When hot-unplugging a device we ask nicely *)
   let clean_shutdown_async ~xs (x : device) =
     let backend_path = backend_path_of_device ~xs x in
@@ -245,7 +242,7 @@ module Generic = struct
         )
     )
 
-  let unplug_watch ~xs (x : device) =
+  let unplug_watch ~xs:_ (x : device) =
     Hotplug.path_written_by_hotplug_scripts x |> Watch.key_to_disappear
 
   let error_watch ~xs (x : device) =
@@ -413,13 +410,8 @@ module Vbd_Common = struct
         ReadOnly
     | "w" ->
         ReadWrite
-    | s ->
+    | _ ->
         invalid_arg "mode_of_string"
-
-  type lock = string
-
-  (** The format understood by blocktap *)
-  let string_of_lock lock mode = lock ^ ":" ^ string_of_mode mode
 
   type physty = File | Phys | Qcow | Vhd | Aio
 
@@ -975,7 +967,7 @@ end
 
 (** Network SR-IOV VFs: *)
 module NetSriovVf = struct
-  let add ~xs ~devid ~mac ?mtu ?(rate = None) ?(backend_domid = 0)
+  let add ~xs ~devid ~mac ?mtu:_ ?(rate = None) ?(backend_domid = 0)
       ?(other_config = []) ~pci ~vlan ~carrier ?(extra_private_keys = [])
       ?(extra_xenserver_keys = []) (task : Xenops_task.task_handle) domid =
     let vlan_str =
@@ -1202,13 +1194,6 @@ module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
       Some key
     else
       None
-
-  let is_running ~xs domid =
-    match of_domid domid with
-    | None ->
-        Compat.is_running ~xs domid
-    | Some key ->
-        Fe_systemctl.is_active ~service:key
 
   let alive service _ =
     if Fe_systemctl.is_active ~service then
@@ -1613,7 +1598,7 @@ module PCI = struct
       _xen_domctl_dev_rdm_relaxed
 
   let add ~xc ~xs ~hvm pcidevs domid =
-    let host_addr {host; guest= _} = host in
+    let host_addr {host; guest= _; _} = host in
     try
       if !Xenopsd.use_old_pci_add || not hvm then (
         List.iter (fun x -> ignore (quarantine xc (host_addr x))) pcidevs ;
@@ -1621,7 +1606,7 @@ module PCI = struct
       ) else
         List.iter (_pci_add ~xc ~xs ~hvm domid) pcidevs ;
       List.iter
-        (fun {host= pcidev; guest= dev, _} ->
+        (fun {host= pcidev; guest= dev, _; _} ->
           xs.Xs.write
             (Printf.sprintf "%s/dev-%d"
                (device_model_pci_device_path xs 0 domid)
@@ -1953,89 +1938,26 @@ module PCI = struct
          [] (Array.to_list devs)
       )
 
-  let reset ~xs address =
+  let reset ~xs:_ address =
     let devstr = Xenops_interface.Pci.string_of_address address in
     debug "Device.Pci.reset %s" devstr ;
     do_flr devstr
 
-  let clean_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
+  let clean_shutdown (_ : Xenops_task.task_handle) ~xs (x : device) =
     debug "Device.Pci.clean_shutdown %s" (string_of_device x) ;
     let devs = enumerate_devs ~xs x in
-    Xenctrl.with_intf (fun xc ->
-        try release devs x.frontend.domid with _ -> ()
-    ) ;
-    ()
+    try release devs x.frontend.domid with _ -> ()
 
   let hard_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
     debug "Device.Pci.hard_shutdown %s" (string_of_device x) ;
     clean_shutdown task ~xs x
 
-  (* This is the global location where PCI device add/remove status is put. We
-     should aim to use a per-device location to support parallel requests in
-     future *)
-  let device_model_state_path xs be_domid fe_domid =
-    Printf.sprintf "%s/device-model/%d/state"
-      (xs.Xs.getdomainpath be_domid)
-      fe_domid
-
-  let signal_device_model ~xs domid cmd parameter =
-    debug "Device.Pci.signal_device_model domid=%d cmd=%s param=%s" domid cmd
-      parameter ;
-    let be_domid = 0 in
-    (* XXX: assume device model is in domain 0 *)
-    let be_path = xs.Xs.getdomainpath be_domid in
-    (* Currently responses go in this global place. Blank it to prevent
-       request/response/request confusion *)
-    xs.Xs.rm (device_model_state_path xs be_domid domid) ;
-    Xs.transaction xs (fun t ->
-        t.Xst.writev be_path
-          [
-            (Printf.sprintf "device-model/%d/command" domid, cmd)
-          ; (Printf.sprintf "device-model/%d/parameter" domid, parameter)
-          ]
-    )
-
   (* Return a list of PCI devices *)
   let list = read_pcidir
-
-  (* We explicitly add a device frontend in the hotplug case so the device watch
-     code can find the backend and monitor it. *)
-  let ensure_device_frontend_exists ~xs backend_domid frontend_domid =
-    let frontend_path =
-      Printf.sprintf "/local/domain/%d/device/pci/0" frontend_domid
-    in
-    let backend_path =
-      Printf.sprintf "/local/domain/%d/backend/pci/%d/0" backend_domid
-        frontend_domid
-    in
-    debug "adding PCI frontend: frontend_domid = %d; backend_domid = %d"
-      frontend_domid backend_domid ;
-    Xs.transaction xs (fun t ->
-        (* If the frontend already exists, no work to do *)
-        if
-          try
-            ignore (t.Xst.read (frontend_path ^ "/backend")) ;
-            true
-          with _ -> false
-        then
-          debug "PCI frontend already exists: no work to do"
-        else (
-          t.Xst.mkdirperms frontend_path
-            Xs_protocol.ACL.
-              {owner= frontend_domid; other= NONE; acl= [(backend_domid, READ)]}
-             ;
-          t.Xst.writev frontend_path
-            [
-              ("backend", backend_path)
-            ; ("backend-id", string_of_int backend_domid)
-            ; ("state", "1")
-            ]
-        )
-    )
 end
 
 module Vfs = struct
-  let add ~xc ~xs ?(backend_domid = 0) domid =
+  let add ~xc:_ ~xs ?(backend_domid = 0) domid =
     debug "Device.Vfs.add domid=%d" domid ;
     let frontend = {domid; kind= Vfs; devid= 0} in
     let backend = {domid= backend_domid; kind= Vfs; devid= 0} in
@@ -2073,17 +1995,17 @@ module Vfs = struct
     ) ;
     ()
 
-  let hard_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
+  let hard_shutdown (_ : Xenops_task.task_handle) ~xs:_ (x : device) =
     debug "Device.Vfs.hard_shutdown %s" (string_of_device x) ;
     ()
 
-  let clean_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
+  let clean_shutdown (_ : Xenops_task.task_handle) ~xs:_ (x : device) =
     debug "Device.Vfs.clean_shutdown %s" (string_of_device x) ;
     ()
 end
 
 module Vfb = struct
-  let add ~xc ~xs ?(backend_domid = 0) ?(protocol = Protocol_Native) domid =
+  let add ~xc:_ ~xs ?(backend_domid = 0) ?(protocol = Protocol_Native) domid =
     debug "Device.Vfb.add %d" domid ;
     let frontend = {domid; kind= Vfb; devid= 0} in
     let backend = {domid= backend_domid; kind= Vfb; devid= 0} in
@@ -2105,17 +2027,17 @@ module Vfb = struct
     Generic.add_device ~xs device back front [] [] ;
     ()
 
-  let hard_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
+  let hard_shutdown (_ : Xenops_task.task_handle) ~xs:_ (x : device) =
     debug "Device.Vfb.hard_shutdown %s" (string_of_device x) ;
     ()
 
-  let clean_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
+  let clean_shutdown (_ : Xenops_task.task_handle) ~xs:_ (x : device) =
     debug "Device.Vfb.clean_shutdown %s" (string_of_device x) ;
     ()
 end
 
 module Vkbd = struct
-  let add ~xc ~xs ?(backend_domid = 0) ?(protocol = Protocol_Native) domid =
+  let add ~xc:_ ~xs ?(backend_domid = 0) ?(protocol = Protocol_Native) domid =
     debug "Device.Vkbd.add %d" domid ;
     let frontend = {domid; kind= Vkbd; devid= 0} in
     let backend = {domid= backend_domid; kind= Vkbd; devid= 0} in
@@ -2137,11 +2059,11 @@ module Vkbd = struct
     Generic.add_device ~xs device back front [] [] ;
     ()
 
-  let hard_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
+  let hard_shutdown (_ : Xenops_task.task_handle) ~xs:_ (x : device) =
     debug "Device.Vkbd.hard_shutdown %s" (string_of_device x) ;
     ()
 
-  let clean_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
+  let clean_shutdown (_ : Xenops_task.task_handle) ~xs:_ (x : device) =
     debug "Device.Vkbd.clean_shutdown %s" (string_of_device x) ;
     ()
 end
@@ -2213,7 +2135,7 @@ module Vusb = struct
       match qmp_send_cmd domid Qmp.(Qom_list path) with
       | Qmp.(Qom usbs) ->
           List.map (fun p -> p.Qmp.name) usbs
-      | other ->
+      | _other ->
           debug "%s unexpected QMP result for domid %d Qom_list" __LOC__ domid ;
           []
       | exception QMP_connection_error _ ->
@@ -2339,7 +2261,7 @@ end = struct
     match qmp_send_cmd domid Qmp.Query_chardev with
     | Qmp.(Char_devices devices) ->
         List.find_opt is_serial0 devices
-    | other ->
+    | _other ->
         warn "Unexpected QMP result for domid %d query-chardev" domid ;
         None
 
@@ -2370,9 +2292,6 @@ module Dm_Common = struct
      -usb -usbdevice tablet -domain-name bee94ac1-8f97-42e0-bf77-5cb7a6b664ee
      -net nic,vlan=1,macaddr=00:16:3E:76:CE:44,model=rtl8139 -net
      tap,vlan=1,bridge=xenbr0 -vnc 39 -k en-us -vnclisten 127.0.0.1] *)
-
-  (** Should be <= the hardcoded maximum number of emulated NICs *)
-  let max_emulated_nics = 8
 
   type usb_opt = Enabled of (string * int) list | Disabled
 
@@ -2515,11 +2434,11 @@ module Dm_Common = struct
     let vga_type_opts x =
       let open Xenops_interface.Vgpu in
       match x with
-      | Vgpu [{implementation= Nvidia _}] ->
+      | Vgpu [{implementation= Nvidia _; _}] ->
           ["-vgpu"]
-      | Vgpu ({implementation= Nvidia _} :: _) ->
+      | Vgpu ({implementation= Nvidia _; _} :: _) ->
           ["-vgpu"]
-      | Vgpu [{implementation= GVT_g gvt_g}] ->
+      | Vgpu [{implementation= GVT_g gvt_g; _}] ->
           let base_opts =
             [
               "-xengt"
@@ -2532,7 +2451,7 @@ module Dm_Common = struct
             ]
           and priv_opt = ["-priv"] in
           List.flatten [base_opts; priv_opt]
-      | Vgpu [{implementation= MxGPU mxgpu}] ->
+      | Vgpu [{implementation= MxGPU _; _}] ->
           []
       | Vgpu _ ->
           failwith "Unsupported vGPU configuration"
@@ -2574,7 +2493,7 @@ module Dm_Common = struct
       match info.disp with
       | NONE ->
           ([], false)
-      | SDL (opts, x11name) ->
+      | SDL (_, _) ->
           ([], false)
       | VNC (disp_intf, ip_addr_opt, auto, port, keymap) ->
           let vga_type_opts = vga_type_opts disp_intf in
@@ -2583,9 +2502,9 @@ module Dm_Common = struct
     in
     (disp_options, wait_for_port)
 
-  let qemu_args ~xs ~dm info restore ?(domid_for_vnc = false) domid =
+  let qemu_args ~xs:_ ~dm:_ info restore ?(domid_for_vnc = false) domid =
     let restorefile = sprintf qemu_restore_path domid in
-    let disp_options, wait_for_port =
+    let disp_options, _ =
       if domid_for_vnc then
         cmdline_of_disp info ~domid
       else
@@ -2657,6 +2576,7 @@ module Dm_Common = struct
                    virtual_pci_address
                  ; config_file= Some config_file
                  ; extra_args
+                 ; _
                  } ->
                  (* The VGPU UUID is not available. Create a fresh one; xapi
                     will deal with it. *)
@@ -2676,6 +2596,7 @@ module Dm_Common = struct
                  ; type_id= Some type_id
                  ; uuid= Some uuid
                  ; extra_args
+                 ; _
                  } ->
                  debug "NVidia vGPU config: using type id %s and uuid: %s"
                    type_id uuid ;
@@ -2686,7 +2607,7 @@ module Dm_Common = struct
                    ; uuid
                    ; extra_args
                    ]
-             | Nvidia {type_id= None; config_file= None} ->
+             | Nvidia {type_id= None; config_file= None; _} ->
                  (* No type_id _and_ no config_file: something is wrong *)
                  raise
                    (Xenopsd_error
@@ -2907,7 +2828,7 @@ module Dm_Common = struct
         ]
     ]
 
-  let xen_platform ~trad_compat ~xs ~domid ~info =
+  let xen_platform ~trad_compat ~xs:_ ~domid:_ ~info =
     [
       "-device"
     ; String.concat ","
@@ -3068,23 +2989,22 @@ module Backend = struct
             with _ -> None
         )
 
-      let assert_can_suspend ~xs _ = ()
+      let assert_can_suspend ~xs:_ _ = ()
 
       let suspend (task : Xenops_task.task_handle) ~xs ~qemu_domid domid =
         Dm_Common.signal task ~xs ~qemu_domid ~domid "save" ~wait_for:"paused"
 
-      let stop ~xs ~qemu_domid domid = ()
+      let stop ~xs:_ ~qemu_domid:_ _ = ()
 
-      let init_daemon ~task ~path ~args ~domid ~xs ~ready_path ~timeout ~cancel
-          ?(fds = []) _ =
+      let init_daemon ~task:_ ~path:_ ~args:_ ~domid:_ ~xs:_ ~ready_path:_
+          ~timeout:_ ~cancel:_ ?fds:_ _ =
         raise (Ioemu_failed (Qemu.name, "PV guests have no IO emulator"))
 
-      let qemu_args ~xs ~dm info restore domid =
-        {Dm_Common.argv= []; fd_map= []}
+      let qemu_args ~xs:_ ~dm:_ _ _ _ = {Dm_Common.argv= []; fd_map= []}
 
-      let after_suspend_image ~xs ~qemu_domid domid = ()
+      let after_suspend_image ~xs:_ ~qemu_domid:_ _ = ()
 
-      let pci_assign_guest ~xs ~index ~host = None
+      let pci_assign_guest ~xs:_ ~index:_ ~host:_ = None
     end
 
     (* Backend.Qemu_none.Dm *)
@@ -3160,7 +3080,7 @@ module Backend = struct
 
       let base_addr = 4
 
-      let addr ~devid ~index = devid + base_addr
+      let addr ~devid ~index:_ = devid + base_addr
 
       let extra_flags = []
     end
@@ -3216,16 +3136,16 @@ module Backend = struct
               first_gap n xs
           | x :: xs when x = n ->
               first_gap (n + 1) xs
-          | x :: xs ->
+          | _ ->
               n
         in
         let has_nvidia_vgpu =
           let open Xenops_interface.Vgpu in
           let open Dm_Common in
           match info.disp with
-          | VNC (Vgpu [{implementation= Nvidia _}], _, _, _, _) ->
+          | VNC (Vgpu [{implementation= Nvidia _; _}], _, _, _, _) ->
               true
-          | SDL (Vgpu [{implementation= Nvidia _}], _) ->
+          | SDL (Vgpu [{implementation= Nvidia _; _}], _) ->
               true
           | _ ->
               false
@@ -3244,7 +3164,7 @@ module Backend = struct
 
     module PCI = struct
       (* compat: let qemu deal with it as before *)
-      let assign_guest ~xs ~index ~host = None
+      let assign_guest ~xs:_ ~index:_ ~host:_ = None
     end
 
     let name = Profile.Name.qemu_upstream_compat
@@ -3287,7 +3207,7 @@ module Backend = struct
 
       let default = "e1000"
 
-      let addr ~devid ~index = 4 + index
+      let addr ~devid:_ ~index = 4 + index
 
       let extra_flags = ["rombar=0"]
     end
@@ -3307,7 +3227,7 @@ module Backend = struct
       let extra_args = ["-device"; "nvme,serial=nvme0,id=nvme0,addr=7"]
     end
 
-    module XenPV = struct let addr ~xs ~domid _ ~nics = 6 end
+    module XenPV = struct let addr ~xs:_ ~domid:_ _ ~nics:_ = 6 end
 
     module VGPU = struct let device ~index = Some (8 + index) end
 
@@ -3322,7 +3242,7 @@ module Backend = struct
     end
 
     module PCI = struct
-      let assign_guest ~xs ~index ~host =
+      let assign_guest ~xs:_ ~index ~host:_ =
         (* domain here refers to PCI segment from SBDF, and not a Xen domain *)
         Some {Pci.domain= 0; bus= 0; dev= 8 + index; fn= 0}
     end
@@ -3501,7 +3421,7 @@ module Backend = struct
         with _ -> None
       in
       let add_domain id =
-        try add id with e -> error "Adding QMP socket for domain %d failed" id
+        try add id with _ -> error "Adding QMP socket for domain %d failed" id
       in
       ( try
           debug "Starting QMP_Event thread using Polly" ;
@@ -3518,7 +3438,7 @@ module Backend = struct
       while true do
         try
           ignore
-          @@ Polly.wait m 10 forever (fun m fd events ->
+          @@ Polly.wait m 10 forever (fun _ fd events ->
                  Lookup.domid_of fd >>= fun domid ->
                  Lookup.channel_of domid >>= fun c ->
                  let qmp = Qmp_protocol.to_fd c in
@@ -3691,15 +3611,15 @@ module Backend = struct
               | Qmp.Hotpluggable_cpus x -> (
                   x
                   |> List.filter
-                       (fun Qmp.Device.VCPU.{qom_path; props= {socket_id}} ->
+                       (fun Qmp.Device.VCPU.{props= {socket_id; _}; _} ->
                          socket_id = devid
                      )
                   |> function
                   | [] ->
                       err (sprintf "No QEMU CPU found with devid %d" devid)
-                  | Qmp.Device.VCPU.{qom_path= None} :: _ ->
+                  | Qmp.Device.VCPU.{qom_path= None; _} :: _ ->
                       err (sprintf "No qom_path for QEMU CPU devid %d" devid)
-                  | Qmp.Device.VCPU.{qom_path= Some p} :: _ ->
+                  | Qmp.Device.VCPU.{qom_path= Some p; _} :: _ ->
                       p
                 )
               | other ->
@@ -3736,13 +3656,13 @@ module Backend = struct
                     , msg
                     )
                  )
-        | exception e ->
+        | exception _ ->
             debug "assert_can_suspend: OK (domid=%d)" domid ;
             ()
 
       (* key not present *)
 
-      let suspend (task : Xenops_task.task_handle) ~xs ~qemu_domid domid =
+      let suspend (_ : Xenops_task.task_handle) ~xs:_ ~qemu_domid:_ domid =
         let as_msg cmd = Qmp.(Success (Some __LOC__, cmd)) in
         let perms = [Unix.O_WRONLY; Unix.O_CREAT] in
         let save_file = sprintf qemu_save_path domid in
@@ -3814,8 +3734,8 @@ module Backend = struct
         if not !finished then
           raise (Ioemu_failed (name, "Timeout reached while starting daemon"))
 
-      let init_daemon ~task ~path ~args ~domid ~xs ~ready_path ~timeout ~cancel
-          ?(fds = []) _ =
+      let init_daemon ~task ~path ~args ~domid ~xs:_ ~ready_path:_ ~timeout
+          ~cancel:_ ?(fds = []) _ =
         let pid = Qemu.start_daemon ~path ~args ~domid ~fds () in
         wait_event_socket ~task ~name:Qemu.name ~domid ~timeout ;
         QMP_Event.add domid ;
@@ -4034,7 +3954,7 @@ module Backend = struct
         (* add_nic is used in a fold: it adds fd and command line args for a nic
            to the existing fds and arguments (fds, argv) *)
         let none = ["-net"; "none"] in
-        let add_nic (index, fds, argv) (mac, bridge, devid) =
+        let add_nic (index, fds, argv) (mac, _bridge, devid) =
           let ifname = sprintf "tap%d.%d" domid devid in
           let ((uuid, _) as tap) = tap_open ifname in
           let args =
@@ -4264,10 +4184,10 @@ module Dm = struct
       ~timeout:!Xenopsd.varstored_ready_timeout
       ~cancel:(Cancel_utils.Varstored domid) ()
 
-  let start_vgpu ~xc ~xs task ?(restore = false) domid vgpus vcpus profile =
+  let start_vgpu ~xc:_ ~xs task ?(restore = false) domid vgpus vcpus profile =
     let open Xenops_interface.Vgpu in
     match vgpus with
-    | {physical_pci_address= pci; implementation= Nvidia vgpu} :: _ ->
+    | {implementation= Nvidia _; _} :: _ ->
         (* Start DEMU and wait until it has reached the desired state *)
         let state_path = Printf.sprintf "/local/domain/%d/vgpu/state" domid in
         let cancel = Cancel_utils.Vgpu domid in
@@ -4314,9 +4234,9 @@ module Dm = struct
                , Printf.sprintf "Daemon vgpu returned error: %s" error_code
                )
             )
-    | [{physical_pci_address= pci; implementation= GVT_g vgpu}] ->
+    | [{physical_pci_address= pci; implementation= GVT_g _; _}] ->
         PCI.bind [pci] PCI.I915
-    | [{physical_pci_address= pci; implementation= MxGPU vgpu}] ->
+    | [{physical_pci_address= pci; implementation= MxGPU vgpu; _}] ->
         Mutex.execute gimtool_m (fun () ->
             configure_gim ~xs pci vgpu.vgpus_per_pgpu vgpu.framebufferbytes ;
             let keys = [("pf", Xenops_interface.Pci.string_of_address pci)] in
@@ -4454,12 +4374,12 @@ module Dm = struct
     debug "Called Dm.restore_vgpu" ;
     start_vgpu ~xc ~xs task ~restore:true domid vgpus vcpus profile
 
-  let suspend_varstored (task : Xenops_task.task_handle) ~xs domid ~vm_uuid =
+  let suspend_varstored (_ : Xenops_task.task_handle) ~xs domid ~vm_uuid =
     debug "Called Dm.suspend_varstored (domid=%d)" domid ;
     Varstored.stop ~xs domid ;
     Xenops_sandbox.Varstore_guard.read ~domid efivars_save_path ~vm_uuid
 
-  let restore_varstored (task : Xenops_task.task_handle) ~xs ~efivars domid =
+  let restore_varstored (_ : Xenops_task.task_handle) ~xs ~efivars domid =
     debug "Called Dm.restore_varstored (domid=%d)" domid ;
     let path =
       Xenops_sandbox.Varstore_guard.prepare ~domid

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -237,7 +237,7 @@ let uuid_of_vm vm = uuid_of_string vm.Vm.id
 
 let uuid_of_di di = Ez_xenctrl_uuid.uuid_of_handle di.Xenctrl.handle
 
-let di_of_uuid ~xc ~xs uuid =
+let di_of_uuid ~xc uuid =
   let open Xenctrl in
   let uuid' = Uuidm.to_string uuid in
   let all = domain_getinfolist xc 0 in
@@ -264,7 +264,7 @@ let di_of_uuid ~xc ~xs uuid =
            )
         )
 
-let domid_of_uuid ~xc ~xs uuid =
+let domid_of_uuid ~xs uuid =
   (* We don't fully control the domain lifecycle because libxenguest will
      actually destroy a domain on suspend. Therefore we only rely on state in
      xenstore *)
@@ -288,7 +288,7 @@ let domid_of_uuid ~xc ~xs uuid =
                 )
              )
           )
-  with e ->
+  with _ ->
     error "Failed to read %s: has this domain already been cleaned up?" dir ;
     None
 
@@ -346,7 +346,7 @@ let params_of_backend backend =
 let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
   let frontend_vm_id = get_uuid ~xc frontend_domid |> Uuidm.to_string in
   let backend_vm_id = get_uuid ~xc vdi.domid |> Uuidm.to_string in
-  match domid_of_uuid ~xc ~xs (uuid_of_string backend_vm_id) with
+  match domid_of_uuid ~xs (uuid_of_string backend_vm_id) with
   | None ->
       error
         "VM = %s; domid = %d; Failed to determine domid of backend VM id: %s"
@@ -404,7 +404,7 @@ let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
       in
       Device device
 
-let destroy_vbd_frontend ~xc ~xs task disk =
+let destroy_vbd_frontend ~xc:_ ~xs task disk =
   match disk with
   | Empty | Name _ | Nbd _ ->
       ()
@@ -431,8 +431,8 @@ module Storage = struct
   let vm_of_domid = vm_of_domid
 
   (* We need to deal with driver domains here: *)
-  let attach_and_activate ~xc ~xs task vm dp sr vdi read_write =
-    let vmdomid = vm_of_domid (domid_of_uuid ~xc ~xs (uuid_of_string vm)) in
+  let attach_and_activate ~xc:_ ~xs task vm dp sr vdi read_write =
+    let vmdomid = vm_of_domid (domid_of_uuid ~xs (uuid_of_string vm)) in
     let result =
       attach_and_activate ~task ~_vm:vm ~vmdomid ~dp ~sr ~vdi ~read_write
     in
@@ -446,7 +446,7 @@ module Storage = struct
          )
         )
     in
-    match domid_of_uuid ~xc ~xs (uuid_of_string backend) with
+    match domid_of_uuid ~xs (uuid_of_string backend) with
     | None ->
         failwith (Printf.sprintf "Driver domain disapppeared: %s" backend)
     | Some domid ->
@@ -479,7 +479,7 @@ let print_fork_error f =
 
 let run_command cmd args =
   debug "running %s %s" cmd (String.concat " " args) ;
-  let stdout, stderr =
+  let stdout, _ =
     print_fork_error (fun () -> Forkhelpers.execute_command_get_output cmd args)
   in
   stdout
@@ -803,7 +803,7 @@ module DeviceCache = struct
         try PerVMCache.find domid_cache (Some key)
         with _ ->
           let keys =
-            try PerVMCache.fold (fun k v acc -> k :: acc) domid_cache []
+            try PerVMCache.fold (fun k _ acc -> k :: acc) domid_cache []
             with _ -> []
           in
           raise (NotFoundIn keys)
@@ -812,8 +812,8 @@ end
 
 let device_cache = DeviceCache.create 256
 
-let device_by_id xc xs vm kind id =
-  match vm |> uuid_of_string |> domid_of_uuid ~xc ~xs with
+let device_by_id _xc xs vm kind id =
+  match vm |> uuid_of_string |> domid_of_uuid ~xs with
   | None ->
       debug "VM = %s; does not exist in domain list" vm ;
       raise (Xenopsd_error (Does_not_exist ("domain", vm)))
@@ -921,7 +921,7 @@ module Featureset = struct
     to_string ~sep:":"
 end
 
-let debug_featuresets xc name featureset featureset_max index_max =
+let debug_featuresets name featureset featureset_max =
   debug "%s Max featureset = %a" name Featureset.pp featureset_max ;
   debug "%s Dynamic set = %a" name Featureset.pp featureset ;
 
@@ -947,7 +947,7 @@ let get_max_featureset xc name featureset index_max =
   (* The migration-safety policy of max CPUID we can accept *)
   let featureset_max = Xenctrl.get_cpu_featureset xc index_max in
 
-  debug_featuresets xc name featureset featureset_max index_max ;
+  debug_featuresets name featureset featureset_max ;
 
   debug "%s MigrationMax = %a" name Featureset.pp featureset_max ;
   featureset_max
@@ -984,7 +984,7 @@ module HOST = struct
                 String.sub s (i + 2) (String.length s - i - 2)
             in
             Hashtbl.add tbl k v
-          with e -> info "cpuinfo: skipping line [%s]" s
+          with _ -> info "cpuinfo: skipping line [%s]" s
         ) ;
         if s <> "" then get_lines ()
       in
@@ -1008,7 +1008,7 @@ module HOST = struct
     let vendor, modelname, speed, flags, stepping, model, family =
       get_cpuinfo ()
     in
-    with_xc_and_xs (fun xc xs ->
+    with_xc (fun xc ->
         let open Xenctrl in
         let p = physinfo xc in
         let cpu_count = p.nr_cpus in
@@ -1068,18 +1068,18 @@ module HOST = struct
         s
 
   let get_console_data () =
-    with_xc_and_xs (fun xc xs ->
+    with_xc (fun xc ->
         (* There may be invalid XML characters in the buffer, so remove them *)
         let is_printable chr =
           let x = int_of_char chr in
           x = 13 || x = 10 || (x >= 0x20 && x <= 0x7e)
         in
         Xenctrl.readconsolering xc
-        |> String.mapi (fun i c -> if not (is_printable c) then ' ' else c)
+        |> String.map (fun c -> if not (is_printable c) then ' ' else c)
     )
 
   let get_total_memory_mib () =
-    with_xc_and_xs (fun xc xs ->
+    with_xc (fun xc ->
         let pages_per_mib = 256L in
         Int64.(
           div
@@ -1088,8 +1088,7 @@ module HOST = struct
         )
     )
 
-  let send_debug_keys keys =
-    with_xc_and_xs (fun xc xs -> Xenctrl.send_debug_keys xc keys)
+  let send_debug_keys keys = with_xc (fun xc -> Xenctrl.send_debug_keys xc keys)
 
   let update_guest_agent_features features =
     let root = "/guest_agent_features" in
@@ -1241,12 +1240,12 @@ module VM = struct
               Domain.shadow_multiplier= hvm_info.shadow_multiplier
             ; video_mib= hvm_info.video_mib
             }
-      | PV {boot= Direct direct} ->
+      | PV {boot= Direct direct; _} ->
           Domain.BuildPV
             {Domain.cmdline= direct.cmdline; ramdisk= direct.ramdisk}
-      | PV {boot= Indirect {devices= []}} ->
+      | PV {boot= Indirect {devices= []; _}; _} ->
           raise (Xenopsd_error No_bootable_device)
-      | PV {boot= Indirect {devices= d :: _}} ->
+      | PV {boot= Indirect {devices= _ :: _; _}; _} ->
           Domain.BuildPV {Domain.cmdline= ""; ramdisk= None}
       | PVinPVH _ ->
           failwith "This domain type did not exist pre-xenopsd"
@@ -1277,7 +1276,7 @@ module VM = struct
 
   let mkints n = List.init n Fun.id
 
-  let generate_create_info ~xc ~xs vm persistent =
+  let generate_create_info ~xc ~xs:_ vm persistent =
     let ty = match persistent.VmExtra.ty with Some ty -> ty | None -> vm.ty in
     let hvm = match ty with HVM _ | PVinPVH _ -> true | PV _ -> false in
     (* XXX add per-vcpu information to the platform data *)
@@ -1351,9 +1350,9 @@ module VM = struct
     in
     let pci_passthrough =
       match vm.ty with
-      | HVM {pci_passthrough= true} ->
+      | HVM {pci_passthrough= true; _} ->
           true
-      | PV {pci_passthrough= true} ->
+      | PV {pci_passthrough= true; _} ->
           true
       | _ ->
           false
@@ -1452,7 +1451,7 @@ module VM = struct
               in
               let shadow_multiplier =
                 match vm.Vm.ty with
-                | Vm.HVM {Vm.shadow_multiplier= sm} ->
+                | Vm.HVM {Vm.shadow_multiplier= sm; _} ->
                     sm
                 | _ ->
                     1.
@@ -1567,7 +1566,7 @@ module VM = struct
   let on_domain f (task : Xenops_task.task_handle) vm =
     let uuid = uuid_of_vm vm in
     with_xc_and_xs (fun xc xs ->
-        match di_of_uuid ~xc ~xs uuid with
+        match di_of_uuid ~xc uuid with
         | None ->
             raise (Xenopsd_error (Does_not_exist ("domain", vm.Vm.id)))
         | Some di ->
@@ -1581,7 +1580,7 @@ module VM = struct
 
   let add vm =
     with_xc_and_xs (fun xc xs ->
-        match di_of_uuid ~xc ~xs (uuid_of_vm vm) with
+        match di_of_uuid ~xc (uuid_of_vm vm) with
         | None ->
             () (* Domain doesn't exist so no setup required *)
         | Some di ->
@@ -1658,10 +1657,10 @@ module VM = struct
       Domain.move_xstree ~xs di.Xenctrl.domid old_name new_name ;
       DB.rename old_name new_name
     in
-    Option.iter rename_domain (di_of_uuid ~xc ~xs (uuid_of_string old_name))
+    Option.iter rename_domain (di_of_uuid ~xc (uuid_of_string old_name))
 
   let remove vm =
-    with_xc_and_xs (fun xc xs -> safe_rm xs (Printf.sprintf "/vm/%s" vm.Vm.id)) ;
+    with_xs (fun xs -> safe_rm xs (Printf.sprintf "/vm/%s" vm.Vm.id)) ;
     (* Best-effort attempt to remove metadata - if VM has been powered off then
        it will have already been deleted by VM.destroy *)
     try DB.remove vm.Vm.id
@@ -1673,7 +1672,7 @@ module VM = struct
       debug "Safely ignoring exception: %s while %s" (Printexc.to_string e) msg
 
   let destroy_device_model =
-    on_domain_if_exists (fun xc xs task vm di ->
+    on_domain_if_exists (fun _ xs _task vm di ->
         let domid = di.Xenctrl.domid in
         let qemu_domid = this_domid ~xs in
         log_exn_continue "Error stoping device-model, already dead ?"
@@ -1742,14 +1741,14 @@ module VM = struct
     )
 
   let pause =
-    on_domain (fun xc xs _ _ di ->
+    on_domain (fun xc _ _ _ di ->
         if di.Xenctrl.total_memory_pages = 0n then
           raise (Xenopsd_error Domain_not_built) ;
         Domain.pause ~xc di.Xenctrl.domid
     )
 
   let unpause =
-    on_domain (fun xc xs _ _ di ->
+    on_domain (fun xc _ _ _ di ->
         if di.Xenctrl.total_memory_pages = 0n then
           raise (Xenopsd_error Domain_not_built) ;
         Domain.unpause ~xc di.Xenctrl.domid
@@ -1757,12 +1756,12 @@ module VM = struct
 
   let set_xsdata task vm xsdata =
     on_domain
-      (fun xc xs _ _ di -> Domain.set_xsdata ~xs di.Xenctrl.domid xsdata)
+      (fun _ xs _ _ di -> Domain.set_xsdata ~xs di.Xenctrl.domid xsdata)
       task vm
 
   let set_vcpus task vm target =
     on_domain
-      (fun xc xs _ _ di ->
+      (fun _ xs _ _ di ->
         let domid = di.Xenctrl.domid in
         (* Returns the instantaneous CPU number from xenstore *)
         let current =
@@ -1849,21 +1848,22 @@ module VM = struct
 
   (* NB: the arguments which affect the qemu configuration must be saved and
      restored with the VM. *)
-  let create_device_model_config vm vmextra vbds vifs vgpus vusbs =
+  let create_device_model_config vm vmextra vbds vifs vgpus _vusbs =
     match vmextra.VmExtra.persistent with
-    | {VmExtra.build_info= None} | {VmExtra.ty= None} ->
+    | {VmExtra.build_info= None; _} | {VmExtra.ty= None; _} ->
         raise (Xenopsd_error Domain_not_built)
     | {
       VmExtra.build_info= Some build_info
     ; ty= Some ty
     ; VmExtra.qemu_vbds
     ; xen_platform
+    ; _
     } -> (
         let make ?(boot_order = "cd") ?(firmware = default_firmware)
             ?(serial = "pty") ?(monitor = "null") ?(nics = []) ?(disks = [])
             ?(vgpus = []) ?(pci_emulations = []) ?(usb = Device.Dm.Disabled)
             ?(parallel = None) ?(acpi = true) ?(video = Cirrus) ?keymap ?vnc_ip
-            ?(pci_passthrough = false) ?(hvm = true) ?(video_mib = 4) () =
+            ?(pci_passthrough = false) ?(video_mib = 4) () =
           let video =
             match (video, vgpus) with
             | Cirrus, [] ->
@@ -1927,13 +1927,13 @@ module VM = struct
             vifs
         in
         match ty with
-        | PV {framebuffer= false} ->
+        | PV {framebuffer= false; _} ->
             None
         | PV {framebuffer= true; _} | PVinPVH {framebuffer= true; _} ->
             debug
               "Ignoring request for a PV VNC console (would require qemu-trad)" ;
             None
-        | PVinPVH {framebuffer= false} ->
+        | PVinPVH {framebuffer= false; _} ->
             None
         | HVM hvm_info ->
             let disks =
@@ -2002,7 +2002,8 @@ module VM = struct
          manually remove it"
         domid
 
-  let build_domain_exn xc xs domid task vm vbds vifs vgpus vusbs extras force =
+  let build_domain_exn xc xs domid task vm _vbds _vifs vgpus _vusbs extras force
+      =
     let open Memory in
     let initial_target = get_initial_target ~xs domid in
     let static_max_kib = vm.memory_static_max /// 1024L in
@@ -2056,15 +2057,15 @@ module VM = struct
               ( make_build_info !Resources.hvmloader builder_spec_info
               , hvm_info.timeoffset
               )
-          | PV {boot= Direct direct} ->
+          | PV {boot= Direct direct; _} ->
               let builder_spec_info =
                 Domain.BuildPV
                   {Domain.cmdline= direct.cmdline; ramdisk= direct.ramdisk}
               in
               (make_build_info direct.kernel builder_spec_info, "")
-          | PV {boot= Indirect {devices= []}} ->
+          | PV {boot= Indirect {devices= []; _}; _} ->
               raise (Xenopsd_error No_bootable_device)
-          | PV {boot= Indirect ({devices= d :: _} as i)} ->
+          | PV {boot= Indirect ({devices= d :: _; _} as i); _} ->
               with_disk ~xc ~xs task d false (fun dev ->
                   let b =
                     Bootloader.extract task ~bootloader:i.bootloader
@@ -2084,7 +2085,7 @@ module VM = struct
                   , ""
                   )
               )
-          | PVinPVH {boot= Direct direct} ->
+          | PVinPVH {boot= Direct direct; _} ->
               debug "Checking xen cmdline" ;
               let builder_spec_info =
                 Domain.BuildPVH
@@ -2107,9 +2108,9 @@ module VM = struct
               in
 
               (make_build_info !Resources.pvinpvh_xen builder_spec_info, "")
-          | PVinPVH {boot= Indirect {devices= []}} ->
+          | PVinPVH {boot= Indirect {devices= []; _}; _} ->
               raise (Xenopsd_error No_bootable_device)
-          | PVinPVH {boot= Indirect ({devices= d :: _} as i)} ->
+          | PVinPVH {boot= Indirect ({devices= d :: _; _} as i); _} ->
               with_disk ~xc ~xs task d false (fun dev ->
                   let b =
                     Bootloader.extract task ~bootloader:i.bootloader
@@ -2224,7 +2225,7 @@ module VM = struct
       )
       (fun () -> clean_memory_reservation task di.Xenctrl.domid)
 
-  let build ?restore_fd task vm vbds vifs vgpus vusbs extras force =
+  let build ?restore_fd:_ task vm vbds vifs vgpus vusbs extras force =
     on_domain (build_domain vm vbds vifs vgpus vusbs extras force) task vm
 
   let create_device_model_exn vbds vifs vgpus vusbs saved_state vmextra xc xs
@@ -2237,7 +2238,7 @@ module VM = struct
       Option.iter
         (fun info ->
           match vm.Vm.ty with
-          | Vm.HVM {Vm.qemu_stubdom} ->
+          | Vm.HVM {Vm.qemu_stubdom; _} ->
               if qemu_stubdom then
                 warn
                   "QEMU stub domains are no longer implemented;QEMU will be \
@@ -2250,8 +2251,8 @@ module VM = struct
         )
         (create_device_model_config vm vmextra vbds vifs vgpus vusbs) ;
       match vm.Vm.ty with
-      | Vm.PV {vncterm= true; vncterm_ip= ip}
-      | Vm.PVinPVH {vncterm= true; vncterm_ip= ip} ->
+      | Vm.PV {vncterm= true; vncterm_ip= ip; _}
+      | Vm.PVinPVH {vncterm= true; vncterm_ip= ip; _} ->
           Device.PV_Vnc.start ~xs ?ip di.Xenctrl.domid
       | _ ->
           ()
@@ -2291,7 +2292,7 @@ module VM = struct
   let request_shutdown task vm reason ack_delay =
     let reason = shutdown_reason reason in
     on_domain
-      (fun xc xs task vm di ->
+      (fun xc xs task _vm di ->
         let domain_type =
           match get_domain_type ~xs di with
           | Vm.Domain_HVM ->
@@ -2313,11 +2314,11 @@ module VM = struct
       )
       task vm
 
-  let wait_shutdown task vm reason timeout =
+  let wait_shutdown task vm _reason timeout =
     event_wait internal_updates task timeout (function
       | Dynamic.Vm id when id = vm.Vm.id ->
           debug "EVENT on our VM: %s" id ;
-          on_domain (fun xc xs _ vm di -> di.Xenctrl.shutdown) task vm
+          on_domain (fun _ _ _ _ di -> di.Xenctrl.shutdown) task vm
       | Dynamic.Vm id ->
           debug "EVENT on other VM: %s" id ;
           false
@@ -2405,7 +2406,7 @@ module VM = struct
 
   let wait_ballooning task vm =
     on_domain
-      (fun xc xs _ _ di ->
+      (fun _ xs _ _ di ->
         let domid = di.Xenctrl.domid in
         let balloon_active_path =
           xs.Xs.getdomainpath domid ^ "/control/balloon-active"
@@ -2441,9 +2442,9 @@ module VM = struct
       task vm
 
   let assert_can_save vm =
-    with_xc_and_xs (fun xc xs ->
+    with_xs (fun xs ->
         let uuid = uuid_of_vm vm in
-        match domid_of_uuid ~xc ~xs uuid with
+        match domid_of_uuid ~xs uuid with
         | None ->
             failwith (Printf.sprintf "VM %s disappeared" (Uuidm.to_string uuid))
         | Some domid ->
@@ -2478,7 +2479,7 @@ module VM = struct
                   Some vgpu_fd
               | Some disk when disk = data ->
                   Some fd (* Don't open the file twice *)
-              | Some other_disk ->
+              | Some _other_disk ->
                   None (* We don't support this *)
               | None ->
                   None
@@ -2595,7 +2596,7 @@ module VM = struct
     in
     Forkhelpers.dontwaitpid pid
 
-  let restore task progress_callback vm vbds vifs data vgpu_data extras =
+  let restore task _progress_callback vm _vbds vifs data vgpu_data extras =
     on_domain
       (fun xc xs task vm di ->
         finally
@@ -2606,11 +2607,11 @@ module VM = struct
             let vmextra = DB.read_exn k in
             let build_info, timeoffset =
               match vmextra.VmExtra.persistent with
-              | {VmExtra.build_info= None} ->
+              | {VmExtra.build_info= None; _} ->
                   error "VM = %s; No stored build_info: cannot safely restore"
                     vm.Vm.id ;
                   raise (Xenopsd_error (Does_not_exist ("build_info", vm.Vm.id)))
-              | {VmExtra.build_info= Some x; VmExtra.ty} ->
+              | {VmExtra.build_info= Some x; VmExtra.ty; _} ->
                   let initial_target = get_initial_target ~xs domid in
                   let timeoffset =
                     match ty with
@@ -2635,7 +2636,7 @@ module VM = struct
                           Some vgpu_fd
                       | Some disk when disk = data ->
                           Some fd (* Don't open the file twice *)
-                      | Some other_disk ->
+                      | Some _other_disk ->
                           None (* We don't support this *)
                       | None ->
                           None
@@ -2664,7 +2665,7 @@ module VM = struct
                         vm.Vm.id di.Xenctrl.domid ;
                       Domain.destroy task ~xc ~xs ~qemu_domid ~dm:(dm_of ~vm)
                         di.Xenctrl.domid
-                    with e ->
+                    with _ ->
                       debug "Domain.destroy failed. Re-raising original error."
                 ) ;
                 raise e
@@ -2685,16 +2686,18 @@ module VM = struct
 
   let s3suspend =
     (* XXX: TODO: monitor the guest's response; track the s3 state *)
-    on_domain (fun xc xs task vm di ->
+    on_domain (fun xc xs _task _vm di ->
         Domain.shutdown ~xc ~xs di.Xenctrl.domid Domain.S3Suspend
     )
 
   let s3resume =
     (* XXX: TODO: monitor the guest's response; track the s3 state *)
-    on_domain (fun xc xs task vm di -> Domain.send_s3resume ~xc di.Xenctrl.domid)
+    on_domain (fun xc _xs _task _vm di ->
+        Domain.send_s3resume ~xc di.Xenctrl.domid
+    )
 
   let soft_reset =
-    on_domain (fun xc xs task vm di ->
+    on_domain (fun xc xs _task _vm di ->
         Domain.soft_reset ~xc ~xs di.Xenctrl.domid
     )
 
@@ -2704,7 +2707,7 @@ module VM = struct
     (* may not exist *)
     let map_tr f l = List.rev_map f l |> List.rev in
     with_xc_and_xs (fun xc xs ->
-        match di_of_uuid ~xc ~xs uuid with
+        match di_of_uuid ~xc uuid with
         | None -> (
           (* XXX: we need to store (eg) guest agent info *)
           match vme with
@@ -2982,7 +2985,7 @@ module VM = struct
   let request_rdp vm enabled =
     let uuid = uuid_of_vm vm in
     with_xc_and_xs (fun xc xs ->
-        match di_of_uuid ~xc ~xs uuid with
+        match di_of_uuid ~xc uuid with
         | None ->
             raise (Xenopsd_error (Does_not_exist ("domain", vm.Vm.id)))
         | Some di ->
@@ -2996,7 +2999,7 @@ module VM = struct
     let uuid = uuid_of_vm vm in
     let domid, path =
       with_xc_and_xs (fun xc xs ->
-          match di_of_uuid ~xc ~xs uuid with
+          match di_of_uuid ~xc uuid with
           | None ->
               raise (Xenopsd_error (Does_not_exist ("domain", vm.Vm.id)))
           | Some di ->
@@ -3016,7 +3019,7 @@ module VM = struct
       )
     in
     let () =
-      with_xc_and_xs (fun xc xs ->
+      with_xs (fun xs ->
           let state = try xs.Xs.read (path ^ "/state") with _ -> "" in
           match state with
           | "" ->
@@ -3100,7 +3103,7 @@ module VM = struct
   let set_domain_action_request vm request =
     let uuid = uuid_of_vm vm in
     with_xc_and_xs (fun xc xs ->
-        match di_of_uuid ~xc ~xs uuid with
+        match di_of_uuid ~xc uuid with
         | None ->
             raise (Xenopsd_error (Does_not_exist ("domain", vm.Vm.id)))
         | Some di ->
@@ -3124,7 +3127,7 @@ module VM = struct
   let get_domain_action_request vm =
     let uuid = uuid_of_vm vm in
     with_xc_and_xs (fun xc xs ->
-        match di_of_uuid ~xc ~xs uuid with
+        match di_of_uuid ~xc uuid with
         | None ->
             Some Needs_poweroff
         | Some d -> (
@@ -3166,15 +3169,15 @@ module VM = struct
   (* Some hook scripts need to know the domid to avoid confusion when migrating
      vms, now that the behaviour concerning uuids has changed *)
   let get_hook_args vm_uuid =
-    with_xc_and_xs (fun xc xs ->
-        match domid_of_uuid ~xc ~xs (uuid_of_string vm_uuid) with
+    with_xs (fun xs ->
+        match domid_of_uuid ~xs (uuid_of_string vm_uuid) with
         | None ->
             []
         | Some domid ->
             [Xenops_hooks.arg__vmdomid; string_of_int domid]
     )
 
-  let get_internal_state vdi_map vif_map vm =
+  let get_internal_state _vdi_map _vif_map vm =
     let state = DB.read_exn vm.Vm.id in
     state.VmExtra.persistent |> rpc_of VmExtra.persistent_t |> Jsonrpc.to_string
 
@@ -3224,7 +3227,7 @@ module VM = struct
        one from [vm] which came straight from the platform keys. *)
     let persistent =
       match vm.ty with
-      | HVM {timeoffset} -> (
+      | HVM {timeoffset; _} -> (
         match persistent.VmExtra.ty with
         | Some (HVM hvm_info) ->
             {persistent with VmExtra.ty= Some (HVM {hvm_info with timeoffset})}
@@ -3280,7 +3283,7 @@ end
 let on_frontend f frontend =
   with_xc_and_xs (fun xc xs ->
       let frontend_di =
-        match frontend |> uuid_of_string |> di_of_uuid ~xc ~xs with
+        match frontend |> uuid_of_string |> di_of_uuid ~xc with
         | None ->
             raise (Xenopsd_error (Does_not_exist ("domain", frontend)))
         | Some x ->
@@ -3295,9 +3298,9 @@ module PCI = struct
   let id_of pci = snd pci.id
 
   let get_state' vm pci_addr =
-    with_xc_and_xs (fun xc xs ->
+    with_xs (fun xs ->
         let all =
-          match domid_of_uuid ~xc ~xs (uuid_of_string vm) with
+          match domid_of_uuid ~xs (uuid_of_string vm) with
           | Some domid ->
               Device.PCI.list ~xs domid |> List.map snd
           | None ->
@@ -3322,7 +3325,7 @@ module PCI = struct
   (* [plug] a [pci] device and advertise it to QEMU when [advertise] is [true].
      With [advertise=false], the device is not advertised to QEMU. This is
      currently only the case for NVIDIA SR-IOV vGPUs *)
-  let plug task vm pci advertise =
+  let plug _task vm pci advertise =
     on_frontend
       (fun xc xs frontend_domid domain_type ->
         (* Make sure the backend defaults are set *)
@@ -3359,7 +3362,7 @@ module PCI = struct
       )
       vm
 
-  let unplug task vm pci =
+  let unplug _task _vm _pci =
     (* We don't currently need to do anything here. Any necessary cleanup
        happens in Domain.destroy. *)
     ()
@@ -3389,16 +3392,16 @@ module VGPU = struct
 
   let id_of vgpu = snd vgpu.id
 
-  let start task vm vgpus saved_state =
+  let start task vm vgpus _saved_state =
     on_frontend
       (fun xc xs frontend_domid _ ->
         let vmextra = DB.read_exn vm in
         let vcpus =
           match vmextra.VmExtra.persistent with
-          | {VmExtra.build_info= None} ->
+          | {VmExtra.build_info= None; _} ->
               error "VM = %s; No stored build_info: cannot safely restore" vm ;
               raise (Xenopsd_error (Does_not_exist ("build_info", vm)))
-          | {VmExtra.build_info= Some build_info} ->
+          | {VmExtra.build_info= Some build_info; _} ->
               build_info.Domain.vcpus
         in
         let profile =
@@ -3415,7 +3418,7 @@ module VGPU = struct
   let active_path vm vgpu =
     Printf.sprintf "/vm/%s/devices/vgpu/%s" vm (snd vgpu.Vgpu.id)
 
-  let set_active task vm vgpu active =
+  let set_active _task vm vgpu active =
     try set_active_device (active_path vm vgpu) active
     with e ->
       debug "VGPU.set_active %s.%s <- %b failed: %s" (fst vgpu.Vgpu.id)
@@ -3436,7 +3439,7 @@ module VGPU = struct
               Device.Vgpu.pid ~xs frontend_domid
         in
         match emulator_pid with
-        | Some pid ->
+        | Some _ ->
             {Vgpu.active= true; plugged= true; emulator_pid}
         | None ->
             {Vgpu.active= get_active vm vgpu; plugged= false; emulator_pid}
@@ -3457,7 +3460,7 @@ module VUSB = struct
         let peripherals = Device.Vusb.qom_list ~xs ~domid:frontend_domid in
         let found = List.mem (snd vusb.Vusb.id) peripherals in
         match (emulator_pid, found) with
-        | Some pid, true ->
+        | Some _, true ->
             {plugged= true}
         | _, _ ->
             {plugged= false}
@@ -3475,14 +3478,14 @@ module VUSB = struct
     let vmextra = DB.read_exn vm in
     (* When pci_passthrough is true, the qemu will be privileged mode*)
     match vmextra.VmExtra.persistent with
-    | {VmExtra.build_info= Some build_info; ty= Some (HVM hvm_info)} ->
+    | {VmExtra.build_info= Some _; ty= Some (HVM hvm_info); _} ->
         hvm_info.pci_passthrough
     | _ ->
         false
 
-  let plug task vm vusb =
+  let plug _task vm vusb =
     on_frontend
-      (fun xc xs frontend_domid domain_type ->
+      (fun _xc xs frontend_domid domain_type ->
         if domain_type <> Vm.Domain_HVM then
           info "VM = %s; USB passthrough is only supported for HVM guests" vm
         else
@@ -3494,10 +3497,10 @@ module VUSB = struct
       )
       vm
 
-  let unplug task vm vusb =
+  let unplug _task vm vusb =
     try
       on_frontend
-        (fun xc xs frontend_domid hvm ->
+        (fun _xc xs frontend_domid _hvm ->
           let privileged = is_privileged vm in
           Device.Vusb.vusb_unplug ~xs ~privileged ~domid:frontend_domid
             ~id:(snd vusb.Vusb.id) ~hostbus:vusb.Vusb.hostbus
@@ -3574,7 +3577,7 @@ module VBD = struct
   let active_path vm vbd =
     Printf.sprintf "/vm/%s/devices/vbd/%s" vm (snd vbd.Vbd.id)
 
-  let set_active task vm vbd active =
+  let set_active _task vm vbd active =
     try set_active_device (active_path vm vbd) active
     with e ->
       debug "set_active %s.%s <- %b failed: %s" (fst vbd.Vbd.id)
@@ -3585,15 +3588,12 @@ module VBD = struct
     with _ -> false
 
   let epoch_begin task vm disk persistent =
-    with_xc_and_xs (fun xc xs ->
+    with_xs (fun xs ->
         match disk with
         | VDI path ->
             let sr, vdi = Storage.get_disk_by_name task path in
             let storage_vm =
-              vm
-              |> uuid_of_string
-              |> domid_of_uuid ~xc ~xs
-              |> Storage.vm_of_domid
+              vm |> uuid_of_string |> domid_of_uuid ~xs |> Storage.vm_of_domid
             in
             Storage.epoch_begin task sr vdi storage_vm persistent
         | _ ->
@@ -3601,15 +3601,12 @@ module VBD = struct
     )
 
   let epoch_end task vm disk =
-    with_xc_and_xs (fun xc xs ->
+    with_xs (fun xs ->
         match disk with
         | VDI path ->
             let sr, vdi = Storage.get_disk_by_name task path in
             let storage_vm =
-              vm
-              |> uuid_of_string
-              |> domid_of_uuid ~xc ~xs
-              |> Storage.vm_of_domid
+              vm |> uuid_of_string |> domid_of_uuid ~xs |> Storage.vm_of_domid
             in
             Storage.epoch_end task sr vdi storage_vm
         | _ ->
@@ -3816,7 +3813,7 @@ module VBD = struct
 
              3. if the device shutdown is rejected then we should leave the DP
              alone and rely on the event thread calling us again later. *)
-          let domid = domid_of_uuid ~xc ~xs (uuid_of_string vm) in
+          let domid = domid_of_uuid ~xs (uuid_of_string vm) in
           (* If the device is gone then we don't need to shut it down but we do
              need to free any storage resources. *)
           let dev =
@@ -3952,7 +3949,7 @@ module VBD = struct
 
   let eject task vm vbd =
     on_frontend
-      (fun xc xs frontend_domid _ ->
+      (fun xc xs _ _ ->
         let (device : Device_common.device) =
           device_by_id xc xs vm (device_kind_of ~xs vbd) (id_of vbd)
         in
@@ -3971,7 +3968,7 @@ module VBD = struct
     try run !Xc_resources.ionice (Ionice.set_args qos pid) |> ignore_string
     with e -> error "Ionice failed on pid %d: %s" pid (Printexc.to_string e)
 
-  let set_qos task vm vbd =
+  let set_qos _task vm vbd =
     with_xc_and_xs (fun xc xs ->
         Option.iter
           (function
@@ -3995,7 +3992,7 @@ module VBD = struct
           vbd.Vbd.qos
     )
 
-  let get_qos xc xs vm vbd device =
+  let get_qos _xc xs _vm _vbd device =
     try
       match Device_common.kthread_pid_paths_of_device ~xs device with
       | path :: _ ->
@@ -4098,12 +4095,12 @@ module VIF = struct
 
   let id_of vif = snd vif.id
 
-  let backend_domid_of xc xs vif =
+  let backend_domid_of _ xs vif =
     match vif.backend with
     | Network.Local _ | Network.Sriov _ ->
         this_domid ~xs
     | Network.Remote (vm, _) -> (
-      match vm |> uuid_of_string |> domid_of_uuid ~xc ~xs with
+      match vm |> uuid_of_string |> domid_of_uuid ~xs with
       | None ->
           raise (Xenopsd_error (Does_not_exist ("domain", vm)))
       | Some x ->
@@ -4231,7 +4228,7 @@ module VIF = struct
   let active_path vm vif =
     Printf.sprintf "/vm/%s/devices/vif/%s" vm (snd vif.Vif.id)
 
-  let set_active task vm vif active =
+  let set_active _task vm vif active =
     try set_active_device (active_path vm vif) active
     with e ->
       debug "set_active %s.%s <- %b failed: %s" (fst vif.Vif.id)
@@ -4411,7 +4408,7 @@ module VIF = struct
     ) ;
     ()
 
-  let move task vm vif network =
+  let move _task vm vif network =
     (* Verify that there is metadata present for the VM *)
     let _ = DB.read_exn vm in
     with_xc_and_xs (fun xc xs ->
@@ -4463,7 +4460,7 @@ module VIF = struct
     ) ;
     ()
 
-  let set_carrier task vm vif carrier =
+  let set_carrier _task vm vif carrier =
     with_xc_and_xs (fun xc xs ->
         (* If the device is gone then this is ok *)
         try
@@ -4483,7 +4480,7 @@ module VIF = struct
             debug "VM = %s; Ignoring missing device" (id_of vif)
     )
 
-  let set_locking_mode task vm vif mode =
+  let set_locking_mode _task vm vif mode =
     with_xc_and_xs (fun xc xs ->
         match vif.backend with
         | Network.Sriov _ ->
@@ -4563,7 +4560,7 @@ module VIF = struct
             t.Xst.write ip_setting_gateway value
     )
 
-  let set_ipv4_configuration task vm vif ipv4_configuration =
+  let set_ipv4_configuration _task vm vif ipv4_configuration =
     with_xc_and_xs (fun xc xs ->
         let device = device_by_id xc xs vm (device_kind_of vif) (id_of vif) in
         let xenstore_path =
@@ -4586,7 +4583,7 @@ module VIF = struct
               )
     )
 
-  let set_ipv6_configuration task vm vif ipv6_configuration =
+  let set_ipv6_configuration _task vm vif ipv6_configuration =
     with_xc_and_xs (fun xc xs ->
         let device = device_by_id xc xs vm (device_kind_of vif) (id_of vif) in
         let xenstore_path =
@@ -4609,7 +4606,7 @@ module VIF = struct
               )
     )
 
-  let set_pvs_proxy task vm vif proxy =
+  let set_pvs_proxy _task vm vif proxy =
     with_xc_and_xs (fun xc xs ->
         match vif.backend with
         | Network.Sriov _ ->
@@ -4772,7 +4769,7 @@ module Actions = struct
       DB.update vm
         (Option.map (function {VmExtra.persistent} as extra ->
              ( match persistent with
-             | {VmExtra.ty= Some (Vm.HVM hvm_info)} ->
+             | {VmExtra.ty= Some (Vm.HVM hvm_info); _} ->
                  let platformdata =
                    ("timeoffset", timeoffset)
                    :: List.remove_assoc "timeoffset" persistent.platformdata
@@ -5237,8 +5234,8 @@ module DEBUG = struct
     match (cmd, args) with
     | "reboot", [k] ->
         let uuid = uuid_of_string k in
-        with_xc_and_xs (fun xc xs ->
-            match di_of_uuid ~xc ~xs uuid with
+        with_xc (fun xc ->
+            match di_of_uuid ~xc uuid with
             | None ->
                 raise (Xenopsd_error (Does_not_exist ("domain", k)))
             | Some di ->

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,7 +3,7 @@
 set -e
 
 list-hd () {
-  N=331
+  N=330
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD usages"


### PR DESCRIPTION
Please review both commits separately, in particular:
- the xenopsd drops code that was surprisingly unused around PCI devices, should it be used somewhere?
- Most of the (huge!) churn in xapi-cli-server is around adding named parameter to api calls and removing unused parameters / bindings

I ran a suite run 167355 with BST and BVT with the changed and it turned out green, do we want to run some more tests to be safe around the cli server? 