### PR TITLE
Add temporary feature 'Internal_repo_access' to allow update in mix mode

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8394,6 +8394,7 @@ let public_http_actions_with_no_rbac_check =
   ; "post_jsonrpc"
   ; "post_jsonrpc_options"
   ; "get_pool_update_download"
+  ; "get_repository"
   ]
 
 (* permissions not associated with any object message or field *)

--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -62,6 +62,7 @@ type feature =
   | Pool_secret_rotation
   | Certificate_verification
   | Updates
+  | Internal_repo_access
 [@@deriving rpc]
 
 type orientation = Positive | Negative
@@ -126,6 +127,9 @@ let keys_of_features =
     , ("restrict_certificate_verification", Negative, "Certificate_verification")
     )
   ; (Updates, ("restrict_updates", Negative, "Upd"))
+  ; ( Internal_repo_access
+    , ("restrict_internal_repo_access", Negative, "Internal_repo_access")
+    )
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi-types/features.mli
+++ b/ocaml/xapi-types/features.mli
@@ -69,6 +69,8 @@ type feature =
   | Pool_secret_rotation  (** Enable Pool Secret Rotation *)
   | Certificate_verification  (** Used by XenCenter *)
   | Updates  (** Enable host updates from a repository *)
+  | Internal_repo_access
+      (** Enable restriction on repository access to pool members only *)
 
 val feature_of_rpc : Rpc.t -> feature
 (** Convert RPC into {!feature}s *)


### PR DESCRIPTION
In commit d951478f3, a new function was added to restrict the repository
access to pool members only. With this funciton, the pool members need
to use pool_secret in access requests to the mirrorred repositories on
the pool coordinator for authentication.

But in updating, this would cause the pool members can't access the
mirrored repositories as at that time the pool coordinator has been
updated to check the pool_secret while the pool members have not been
udpated to use pool_secret.

Per suggestion from Rob Hoes, this commit adds a temporary feature flag
to make the pool coordinator be able to distinguish the case in the
mixed mode in updating.

Signed-off-by: Ming Lu <ming.lu@citrix.com>