### PR TITLE
ci: fix testing of xapi-xenstored in newer opam's sandboxes

### DIFF
--- a/ocaml/forkexecd/test/fe_test.sh
+++ b/ocaml/forkexecd/test/fe_test.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # Use user-writable directories
-export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp}
+export TMPDIR=${TMPDIR:-/tmp}
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-$TMPDIR}
 export FE_TEST=1
 
 SOCKET=${XDG_RUNTIME_DIR}/xapi/forker/main


### PR DESCRIPTION
xs-opam's CI is the only environment where /tmp is not writable and
XDG_RUNTIME_DIR is not set. Using TMPDIR with /tmp as a backup will mean
the socket is writeable in all environments

xs-opam's CI successfuly passes with this branch: https://github.com/psafont/xs-opam/runs/6075835428?check_suite_focus=true