### PR TITLE
CA-366430: do not wipe PK.auth/dbx.auth

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2593,7 +2593,7 @@ let write_uefi_certificates_to_disk ~__context ~host =
             let path = Filename.concat !Xapi_globs.varstore_dir name in
             Unixext.unlink_safe path
           )
-          ["PK.auth"; "KEK.auth"; "db.auth"; "dbx.auth"] ;
+          ["KEK.auth"; "db.auth"] ;
         (* No uefi certificates, nothing to do. *)
         if contents <> "" then (
           with_temp_file_contents ~contents


### PR DESCRIPTION
These files are owned by other RPM packages.
Also upgrade would need to be taken into consideration where
uefi-certificates would already be set on a pool, but just with KEK+db
without PK+dbx.
In that case if we order uploading PK/dbx and restart xapi the wrong way
around we may get these files wiped completely from the system.
Wiping just KEK+db should be enough to ensure we don't have stale files
around.

Fixes a regression introduced by 53d656bec66d903425fc7bfe580d1425da5f2745