### PR TITLE
Don't use --force in gzip decompress

### DIFF
--- a/ocaml/libs/xapi-compression/xapi_compression.ml
+++ b/ocaml/libs/xapi-compression/xapi_compression.ml
@@ -44,7 +44,11 @@ module Make (Algorithm : ALGORITHM) = struct
     let open Safe_resources in
     Unixfd.with_pipe ~loc:__LOC__ () @@ fun zcat_out zcat_in ->
     let args =
-      if mode = Compress then [] else ["--decompress"] @ ["--stdout"; "--force"]
+      match mode with
+      | Compress ->
+          []
+      | Decompress ->
+          ["--decompress"; "--stdout"]
     in
     let stdin, stdout, close_now, close_later =
       match input with


### PR DESCRIPTION
Normally gzip stops reading input when it has reached its own end-of
input marker even when that is before the end of input. This is
overridden by --force for decompression and it is creating a problem for
us because suspend images on disk are represented as devices that are
larger than the actual content - so --force kept reading beyond the
actual input and this in turn was not accepted by the code taking the
uncompressed output.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>