### PR TITLE
Use file type for is_raw_image()

### DIFF
--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2379,9 +2379,16 @@ module VM = struct
         with e -> debug "Caught %s" (Printexc.to_string e)
       )
 
+  (* A raw image is a file or device in contrast to a directory where
+     would need to open a file *)
   let is_raw_image path =
-    Unixext.with_file path [Unix.O_RDONLY] 0o400 @@ fun fd ->
-    Result.is_ok (Suspend_image.read_save_signature fd)
+    match Unix.((stat path).st_kind) with
+    | Unix.S_REG | Unix.S_BLK ->
+        true
+    | _ ->
+        false
+    | exception _ ->
+        false
 
   let fsync fd =
     try Unixext.fsync fd


### PR DESCRIPTION
When resuming a VM, xenopsd branches based on where the suspend image is
stored. So far it tries to open the image and read the header. This
either succeeds, in which case it concludes this is a raw image, or
fails. It then open the image again to read it. This patch simplifies
this logic by using the file type to make that decision. If the header
later can't be read this still would lead to a failure - so we are not
skipping the header check.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>