### PR TITLE
Add a fallback system for auth files belonging to RPMs

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -846,6 +846,8 @@ let varstore_rm = ref "/usr/bin/varstore-rm"
 
 let varstore_dir = ref "/usr/share/varstored"
 
+let fallback_auth_dir = ref "/var/lib/varstored"
+
 let disable_logging_for = ref []
 
 let nvidia_whitelist = ref "/usr/share/nvidia/vgpu/vgpuConfig.xml"
@@ -1501,6 +1503,7 @@ module Resources = struct
       , "Executed to clear certain UEFI variables during clone"
       )
     ; ("varstore_dir", varstore_dir, "Path to local varstored directory")
+    ; ("fallback_auth_dir", fallback_auth_dir, "Fallback path for auth files")
     ; ( "nvidia-sriov-manage"
       , nvidia_sriov_manage_script
       , "Path to NVIDIA sriov-manage script"


### PR DESCRIPTION
This is an implementation in what was proposed in [this comment](https://github.com/xapi-project/xen-api/pull/4689#issuecomment-1103919868).

- Erase all auth files at XAPI startup, `PK` and `dbx` included

- If after the extract of the tarball mandatory auth files are missing:
fetch them from a fallback dir and copy them in the varstore directory

- New XAPI conf entry: `fallback_auth_dir`: Fallback path for auth files installed by RPMs

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>