### PR TITLE
maintenance: run uuid tests as part of that package

### DIFF
--- a/ocaml/libs/uuid/dune
+++ b/ocaml/libs/uuid/dune
@@ -9,6 +9,7 @@
 
 (test
   (name uuid_test)
+  (package uuid)
   (modules uuid_test)
   (libraries uuid alcotest)
   )

--- a/ocaml/message-switch/switch/time.ml
+++ b/ocaml/message-switch/switch/time.ml
@@ -14,5 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let sleep_ns nanoseconds =
-  Lwt_unix.sleep (Int64.to_float nanoseconds *. Mtime.ns_to_s)
+let sleep_ns nanoseconds = Lwt_unix.sleep (Int64.to_float nanoseconds *. 1e-9)

--- a/ocaml/xapi-client/tasks.ml
+++ b/ocaml/xapi-client/tasks.ml
@@ -30,7 +30,7 @@ let wait_for_all_inner ~rpc ~session_id ~all_timeout ~tasks =
   let timeout_span =
     match all_timeout with
     | Some t ->
-        Some (t *. Mtime.s_to_ns |> Int64.of_float |> Mtime.Span.of_uint64_ns)
+        Some (t *. 1e9 |> Int64.of_float |> Mtime.Span.of_uint64_ns)
     | None ->
         None
   in

--- a/ocaml/xapi-idl/lib/scheduler.ml
+++ b/ocaml/xapi-idl/lib/scheduler.ml
@@ -103,7 +103,7 @@ module Dump = struct
 end
 
 let mtime_add x t =
-  let dt = Mtime.(x *. Mtime.s_to_ns |> Int64.of_float |> Span.of_uint64_ns) in
+  let dt = x *. 1e9 |> Int64.of_float |> Mtime.Span.of_uint64_ns in
   Mtime.Span.add dt t
 
 let one_shot_f s dt (name : string) f =

--- a/ocaml/xapi/xapi_periodic_scheduler.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler.ml
@@ -29,7 +29,7 @@ let lock = Mutex.create ()
 
 module Clock = struct
   (** time span of s seconds *)
-  let span s = Mtime.(Span.of_uint64_ns (Int64.of_float (s *. s_to_ns)))
+  let span s = Mtime.Span.of_uint64_ns (Int64.of_float (s *. 1e9))
 
   let add_span clock secs =
     match Mtime.add_span clock (span secs) with

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -908,9 +908,7 @@ let wait_for_vbds_to_be_unplugged_and_destroyed ~__context ~self ~timeout =
   let start = Mtime_clock.now () in
   let finish =
     let maybe_finish =
-      let timeout =
-        Mtime.(Span.of_uint64_ns (Int64.of_float (timeout *. s_to_ns)))
-      in
+      let timeout = Mtime.Span.of_uint64_ns (Int64.of_float (timeout *. 1e9)) in
       Mtime.(add_span start timeout)
     in
     (* It is safe to unbox this because the timeout should not cause an overflow *)

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -3707,7 +3707,7 @@ module Backend = struct
          is ready. *)
       let wait_event_socket ~task ~name ~domid ~timeout =
         let finished = ref false in
-        let timeout_ns = Int64.of_float (timeout *. Mtime.s_to_ns) in
+        let timeout_ns = Int64.of_float (timeout *. 1e9) in
         let now = Mtime_clock.now () in
         let target =
           match Mtime.(add_span now (Span.of_uint64_ns timeout_ns)) with

--- a/uuid.opam
+++ b/uuid.opam
@@ -4,12 +4,16 @@ authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api.git"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"
-build: [[ "dune" "build" "-p" name "-j" jobs ]]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
 
 available: [ os = "linux" ]
 depends: [
   "ocaml"
   "dune"
+  "alcotest" {with-test}
 ]
 synopsis: "Library required by xapi"
 description: """


### PR DESCRIPTION
This causes a failure when compiling wsproxy in an opam environment as the test binary is built for all the opam packages in the repo and wsproxy lacks the alcotest dependency when testing.