### PR TITLE
Update to mtime 1.4 interface

### DIFF
--- a/ocaml/database/db_globs.ml
+++ b/ocaml/database/db_globs.ml
@@ -58,14 +58,14 @@ let idempotent_map = ref false
 
 let permanent_master_failure_retry_interval = ref 60.
 
-let master_connection_reset_timeout = ref 120.
+let master_connection_reset_timeout = ref 120
 
 (* amount of time to retry master_connection before (if
    restart_on_connection_timeout is set) restarting xapi; -ve means don't
    timeout: *)
-let master_connection_retry_timeout = ref (-1.)
+let master_connection_retry_timeout = ref (-1)
 
-let master_connection_default_timeout = ref 10.
+let master_connection_default_timeout = ref 10
 
 let pool_secret = ref (Db_secret_string.of_string "")
 

--- a/ocaml/message-switch/switch/time.ml
+++ b/ocaml/message-switch/switch/time.ml
@@ -14,5 +14,4 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let sleep_ns nanoseconds =
-  Lwt_unix.sleep (Int64.to_float nanoseconds *. Mtime.ns_to_s)
+let sleep_ns nanoseconds = Lwt_unix.sleep (Int64.to_float nanoseconds *. 1e-9)

--- a/ocaml/tests/common/test_event_common.ml
+++ b/ocaml/tests/common/test_event_common.ml
@@ -4,11 +4,13 @@ let scheduler_mutex = Mutex.create ()
 
 let start_periodic_scheduler () =
   Mutex.lock scheduler_mutex ;
-  if !ps_start then
-    ()
-  else (
+  ( if !ps_start then
+      ()
+  else
+    let period = Mtime.Span.(1 * min) in
+    let start = Mtime.Span.zero in
     Xapi_periodic_scheduler.add_to_queue "dummy"
-      (Xapi_periodic_scheduler.Periodic 60.0) 0.0 (fun () -> ()
+      (Xapi_periodic_scheduler.Periodic period) start (fun () -> ()
     ) ;
     Xapi_event.register_hooks () ;
     ignore (Thread.create Xapi_periodic_scheduler.loop ()) ;

--- a/ocaml/tests/test_vdi_cbt.ml
+++ b/ocaml/tests/test_vdi_cbt.ml
@@ -568,7 +568,7 @@ let test_data_destroy =
       let destroy_vbd () = Db.VBD.destroy ~__context ~self:vbd in
       let data_destroy ~timeout =
         (* It could return earlier normally, but this is the longest we'd wait in case of extreme situation *)
-        let timebox_timeout = timeout +. (1.0 *. 10.) in
+        let timebox_timeout = Mtime.Span.(add timeout (10 * s)) in
         let wait_hdl = Threadext.Delay.make () in
         let raisedexn = ref None in
         ignore
@@ -579,9 +579,9 @@ let test_data_destroy =
                Threadext.Delay.signal wait_hdl
            )
           ) ;
-        if Threadext.Delay.wait wait_hdl timebox_timeout then
+        if Threadext.Delay.wait wait_hdl (Mtime.Span.to_s timebox_timeout) then
           Alcotest.fail
-            (Printf.sprintf "data_destroy did not return in %f seconds"
+            (Format.asprintf "data_destroy did not return in %a" Mtime.Span.pp
                timebox_timeout
             ) ;
         match !raisedexn with None -> () | Some e -> raise e
@@ -602,7 +602,8 @@ let test_data_destroy =
             destroy_vbd ()
         )
       in
-      data_destroy ~timeout:1.0 ; Thread.join t
+      data_destroy ~timeout:Mtime.Span.(1 * s) ;
+      Thread.join t
     in
     let test_data_destroy_succeeds_when_vbd_is_being_unplugged () =
       let _vdi, start_vbd_unplug, finish_vbd_unplug, destroy_vbd, data_destroy =
@@ -617,7 +618,9 @@ let test_data_destroy =
             destroy_vbd ()
         )
       in
-      Thread.delay 0.1 ; data_destroy ~timeout:1.0 ; Thread.join t
+      Thread.delay 0.1 ;
+      data_destroy ~timeout:Mtime.Span.(1 * s) ;
+      Thread.join t
     in
     let test_data_destroy_succeeds_when_vbd_is_being_destroyed () =
       let _vdi, start_vbd_unplug, finish_vbd_unplug, destroy_vbd, data_destroy =
@@ -631,7 +634,9 @@ let test_data_destroy =
             destroy_vbd ()
         )
       in
-      Thread.delay 0.1 ; data_destroy ~timeout:1.0 ; Thread.join t
+      Thread.delay 0.1 ;
+      data_destroy ~timeout:Mtime.Span.(1 * s) ;
+      Thread.join t
     in
     let test_data_destroy_times_out_when_vbd_does_not_get_unplugged_in_time () =
       let vDI, start_vbd_unplug, _, _, data_destroy = setup_test () in
@@ -645,7 +650,7 @@ let test_data_destroy =
         Api_errors.(
           Server_error (vdi_in_use, [Ref.string_of vDI; "data_destroy"])
         )
-        (fun () -> data_destroy ~timeout:1.0) ;
+        (fun () -> data_destroy ~timeout:Mtime.Span.(1 * s)) ;
       Thread.join t
     in
     let test_data_destroy_times_out_when_vbd_does_not_get_destroyed_in_time () =
@@ -664,7 +669,7 @@ let test_data_destroy =
         Api_errors.(
           Server_error (vdi_in_use, [Ref.string_of vDI; "data_destroy"])
         )
-        (fun () -> data_destroy ~timeout:1.0) ;
+        (fun () -> data_destroy ~timeout:Mtime.Span.(1 * s)) ;
       Thread.join t
     in
     [

--- a/ocaml/xapi-client/tasks.ml
+++ b/ocaml/xapi-client/tasks.ml
@@ -30,7 +30,7 @@ let wait_for_all_inner ~rpc ~session_id ~all_timeout ~tasks =
   let timeout_span =
     match all_timeout with
     | Some t ->
-        Some (t *. Mtime.s_to_ns |> Int64.of_float |> Mtime.Span.of_uint64_ns)
+        Some Mtime.Span.(Float.to_int (t *. 1e9) * ns)
     | None ->
         None
   in

--- a/ocaml/xapi/ipq.ml
+++ b/ocaml/xapi/ipq.ml
@@ -13,7 +13,7 @@
  *)
 (* Imperative priority queue *)
 
-type 'a event = {ev: 'a; time: Mtime.t}
+type 'a event = {ev: 'a; time: Mtime.Span.t}
 
 type 'a t = {mutable size: int; mutable data: 'a event array}
 
@@ -49,7 +49,7 @@ let add h x =
   (* moving [x] up in the heap *)
   let rec moveup i =
     let fi = (i - 1) / 2 in
-    if i > 0 && Mtime.is_later d.(fi).time ~than:x.time then (
+    if i > 0 && Mtime.Span.compare d.(fi).time x.time > 0 then (
       d.(i) <- d.(fi) ;
       moveup fi
     ) else
@@ -76,7 +76,7 @@ let remove h s =
         let j' = j + 1 in
         if j' < n && d.(j').time < d.(j).time then j' else j
       in
-      if Mtime.is_earlier d.(j).time ~than:x.time then (
+      if Mtime.Span.compare d.(j).time x.time < 0 then (
         d.(i) <- d.(j) ;
         movedown j
       ) else

--- a/ocaml/xapi/network_event_loop.ml
+++ b/ocaml/xapi/network_event_loop.ml
@@ -24,10 +24,7 @@ let _watch_networks_for_nbd_changes __context ~update_firewall
      to allow NBD traffic on them. At startup, we don't know on which
      interfaces NBD is allowed, and we always update the firewall. *)
   let allowed_interfaces = None in
-  let api_timeout = 60. in
-  let timeout =
-    30. +. api_timeout +. !Db_globs.master_connection_reset_timeout
-  in
+  let timeout = Float.of_int (90 + !Db_globs.master_connection_reset_timeout) in
   let wait_for_network_change ~token =
     let from =
       Helpers.call_api_functions ~__context (fun rpc session_id ->

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -878,7 +878,7 @@ let server_init () =
   (* Record the initial value of Master_connection.connection_timeout and set it to 'never'. When we are a slave who
      has just started up we want to wait forever for the master to appear. (See CA-25481) *)
   let initial_connection_timeout = !Master_connection.connection_timeout in
-  Master_connection.connection_timeout := -1. ;
+  Master_connection.connection_timeout := -1 ;
   (* never timeout *)
   let call_extauth_hook_script_after_xapi_initialize ~__context =
     (* CP-709 *)
@@ -1137,7 +1137,7 @@ let server_init () =
                 (* We can't tolerate an exception in db synchronization so fall back into emergency mode
                    if this happens and try again later.. *)
                 Master_connection.restart_on_connection_timeout := false ;
-                Master_connection.connection_timeout := 10. ;
+                Master_connection.connection_timeout := 10 ;
                 (* give up retrying after 10s *)
                 Db_cache_impl.initialise () ;
                 Sm.register () ;

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -656,7 +656,7 @@ let pif_reconfigure_ip_timeout = ref 300.
 let pool_db_sync_interval = ref 300.
 
 (* blob/message/rrd file syncing - sync once a day *)
-let pool_data_sync_interval = ref 86400.
+let pool_data_sync_interval = ref 86400
 
 let domain_shutdown_total_timeout = ref 1200.
 
@@ -681,13 +681,13 @@ let ha_xapi_restart_timeout = ref 300
    logrotate when it exceeds the threshold *)
 let logrotate_check_interval = ref 300.
 
-let rrd_backup_interval = ref 86400.
+let rrd_backup_interval = ref 86400
 
 (* CP-703: Periodic revalidation of externally-authenticated sessions *)
-let session_revalidation_interval = ref 300. (* every 5 minutes *)
+let session_revalidation_interval = ref 300 (* every 5 minutes *)
 
 (* CP-820: other-config field in subjects should be periodically refreshed *)
-let update_all_subjects_interval = ref 900. (* every 15 minutes *)
+let update_all_subjects_interval = ref 900 (* every 15 minutes *)
 
 (* The default upper bound on the length of time to wait for a running VM to
    reach its current memory target. *)
@@ -936,9 +936,10 @@ let winbind_debug_level = ref 2
 
 let winbind_cache_time = ref 60
 
-let winbind_machine_pwd_timeout = ref (2. *. 7. *. 24. *. 3600.)
+let winbind_machine_pwd_timeout = ref (2 * 7 * 24 * 3600)
+(* every 2 weeks *)
 
-let winbind_update_closest_kdc_interval = ref (3600. *. 22.)
+let winbind_update_closest_kdc_interval = ref (3600 * 22)
 (* every 22 hours *)
 
 let winbind_kerberos_encryption_type = ref Kerberos_encryption_types.Winbind.All
@@ -956,19 +957,19 @@ let samba_dir = "/var/lib/samba"
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
-    , Float Db_globs.master_connection_reset_timeout
+    , Int Db_globs.master_connection_reset_timeout
     )
   ; ( "master_connection_retry_timeout"
-    , Float Db_globs.master_connection_retry_timeout
+    , Int Db_globs.master_connection_retry_timeout
     )
   ; ( "master_connection_default_timeout"
-    , Float Db_globs.master_connection_default_timeout
+    , Int Db_globs.master_connection_default_timeout
     )
   ; ("qemu_dm_ready_timeout", Float qemu_dm_ready_timeout)
   ; ("hotplug_timeout", Float hotplug_timeout)
   ; ("pif_reconfigure_ip_timeout", Float pif_reconfigure_ip_timeout)
   ; ("pool_db_sync_interval", Float pool_db_sync_interval)
-  ; ("pool_data_sync_interval", Float pool_data_sync_interval)
+  ; ("pool_data_sync_interval", Int pool_data_sync_interval)
   ; ("domain_shutdown_total_timeout", Float domain_shutdown_total_timeout)
   ; ("emergency_reboot_delay_base", Float emergency_reboot_delay_base)
   ; ("emergency_reboot_delay_extra", Float emergency_reboot_delay_extra)
@@ -977,9 +978,9 @@ let xapi_globs_spec =
   ; ("ha_xapi_restart_attempts", Int ha_xapi_restart_attempts)
   ; ("ha_xapi_restart_timeout", Int ha_xapi_restart_timeout)
   ; ("logrotate_check_interval", Float logrotate_check_interval)
-  ; ("rrd_backup_interval", Float rrd_backup_interval)
-  ; ("session_revalidation_interval", Float session_revalidation_interval)
-  ; ("update_all_subjects_interval", Float update_all_subjects_interval)
+  ; ("rrd_backup_interval", Int rrd_backup_interval)
+  ; ("session_revalidation_interval", Int session_revalidation_interval)
+  ; ("update_all_subjects_interval", Int update_all_subjects_interval)
   ; ("wait_memory_target_timeout", Float wait_memory_target_timeout)
   ; ("snapshot_with_quiesce_timeout", Float snapshot_with_quiesce_timeout)
   ; ("host_heartbeat_interval", Float host_heartbeat_interval)
@@ -1022,9 +1023,9 @@ let xapi_globs_spec =
   ; ("max_active_sr_scans", Int max_active_sr_scans)
   ; ("winbind_debug_level", Int winbind_debug_level)
   ; ("winbind_cache_time", Int winbind_cache_time)
-  ; ("winbind_machine_pwd_timeout", Float winbind_machine_pwd_timeout)
+  ; ("winbind_machine_pwd_timeout", Int winbind_machine_pwd_timeout)
   ; ( "winbind_update_closest_kdc_interval"
-    , Float winbind_update_closest_kdc_interval
+    , Int winbind_update_closest_kdc_interval
     )
   ]
 

--- a/ocaml/xapi/xapi_periodic_scheduler.mli
+++ b/ocaml/xapi/xapi_periodic_scheduler.mli
@@ -16,10 +16,10 @@
 (** Timer type. *)
 type func_ty =
   | OneShot  (** Fire just once *)
-  | Periodic of float  (** Fire periodically with a given period in seconds *)
+  | Periodic of Mtime.Span.t  (** Fire periodically with a given period *)
 
 val add_to_queue :
-  ?signal:bool -> string -> func_ty -> float -> (unit -> unit) -> unit
+  ?signal:bool -> string -> func_ty -> Mtime.Span.t -> (unit -> unit) -> unit
 (** Start a new timer. *)
 
 val remove_from_queue : string -> unit

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -23,25 +23,29 @@ let register () =
   (* blob/message/rrd file syncing - sync once a day *)
   let sync_timer =
     if Xapi_fist.reduce_blob_sync_interval () then
-      60.0 *. 5.0
+      Mtime.Span.(5 * min)
     else
-      !Xapi_globs.pool_data_sync_interval
+      Mtime.Span.(!Xapi_globs.pool_data_sync_interval * s)
   in
   let sync_func () = Xapi_sync.do_sync () in
   let sync_delay =
     (* 10 mins if fist point there - to ensure rrd sync happens first *)
-    if Xapi_fist.reduce_blob_sync_interval () then 60.0 *. 10.0 else 7200.
+    if Xapi_fist.reduce_blob_sync_interval () then
+      Mtime.Span.(10 * min)
+    else
+      Mtime.Span.(2 * hour)
   in
   (* Heartbeat to show the queue is still running - will be more useful when there's less logging! *)
-  let hb_timer = 3600.0 in
-  (* one hour *)
+  let hb_timer = Mtime.Span.(1 * hour) in
+  let hb_delay = Mtime.Span.(4 * min) in
   let hb_func () = debug "Periodic scheduler heartbeat" in
+
   (* Periodic backup of RRDs *)
   let rrdbackup_timer =
     if Xapi_fist.reduce_rrd_backup_interval () then
-      60.0 *. 5.0
+      Mtime.Span.(5 * min)
     else
-      !Xapi_globs.rrd_backup_interval
+      Mtime.Span.(!Xapi_globs.rrd_backup_interval * s)
   in
   let rrdbackup_func () =
     Server_helpers.exec_with_new_task "rrdbackup_func" (fun __context ->
@@ -59,22 +63,42 @@ let register () =
     )
   in
   let rrdbackup_delay =
-    if Xapi_fist.reduce_rrd_backup_interval () then 60.0 *. 6.0 else 3600.0
+    if Xapi_fist.reduce_rrd_backup_interval () then
+      Mtime.Span.(6 * min)
+    else
+      Mtime.Span.(1 * hour)
   in
   let session_revalidation_func () =
     Server_helpers.exec_with_new_task "session_revalidation_func"
       (fun __context -> Xapi_session.revalidate_all_sessions ~__context
     )
   in
-  let session_revalidation_delay = 60.0 *. 5.0 in
-  (* initial delay = 5 minutes *)
+  let session_revalidation_interval =
+    Mtime.Span.(!Xapi_globs.session_revalidation_interval * s)
+  in
+  let session_revalidation_delay = Mtime.Span.(5 * min) in
   let update_all_subjects_func () =
     Server_helpers.exec_with_new_task "update_all_subjects_func"
       (fun __context -> Xapi_subject.update_all_subjects ~__context
     )
   in
-  let update_all_subjects_delay = 10.0 in
-  (* initial delay = 10 seconds *)
+  let update_all_subjects_interval =
+    Mtime.Span.(!Xapi_globs.update_all_subjects_interval * s)
+  in
+  let update_all_subjects_delay = Mtime.Span.(10 * s) in
+
+  let monitor_master_period = Mtime.Span.(1 * hour) in
+  let monitor_master_delay = Mtime.Span.(1 * hour) in
+
+  let tls_enabled_period = Mtime.Span.(10 * min) in
+  let tls_enabled_delay = Mtime.Span.(10 * min) in
+  let tls_enabled_check () =
+    Server_helpers.exec_with_new_task
+      "Period alert if TLS verification emergency disabled" (fun __context ->
+        Xapi_host.alert_if_tls_verification_was_emergency_disabled ~__context
+    )
+  in
+
   if master then
     Xapi_periodic_scheduler.add_to_queue "Synchronising RRDs/messages"
       (Xapi_periodic_scheduler.Periodic sync_timer) sync_delay sync_func ;
@@ -85,22 +109,21 @@ let register () =
   if master then
     Xapi_periodic_scheduler.add_to_queue
       "Revalidating externally-authenticated sessions"
-      (Xapi_periodic_scheduler.Periodic
-         !Xapi_globs.session_revalidation_interval
-      ) session_revalidation_delay session_revalidation_func ;
+      (Xapi_periodic_scheduler.Periodic session_revalidation_interval)
+      session_revalidation_delay session_revalidation_func ;
   if master then
     Xapi_periodic_scheduler.add_to_queue
       "Trying to update subjects' info using external directory service (if \
        any)"
-      (Xapi_periodic_scheduler.Periodic !Xapi_globs.update_all_subjects_interval)
+      (Xapi_periodic_scheduler.Periodic update_all_subjects_interval)
       update_all_subjects_delay update_all_subjects_func ;
   Xapi_periodic_scheduler.add_to_queue "Periodic scheduler heartbeat"
-    (Xapi_periodic_scheduler.Periodic hb_timer) 240.0 hb_func ;
+    (Xapi_periodic_scheduler.Periodic hb_timer) hb_delay hb_func ;
   Xapi_periodic_scheduler.add_to_queue "Update monitor configuration"
-    (Xapi_periodic_scheduler.Periodic 3600.0) 3600.0
-    Monitor_master.update_configuration_from_master ;
+    (Xapi_periodic_scheduler.Periodic monitor_master_period)
+    monitor_master_delay Monitor_master.update_configuration_from_master ;
   ( if master then
-      let freq = !Xapi_globs.failed_login_alert_freq |> float_of_int in
+      let freq = Mtime.Span.(!Xapi_globs.failed_login_alert_freq * s) in
       Xapi_periodic_scheduler.add_to_queue
         "Periodic alert failed login attempts"
         (Xapi_periodic_scheduler.Periodic freq) freq
@@ -108,9 +131,5 @@ let register () =
   ) ;
   Xapi_periodic_scheduler.add_to_queue
     "Period alert if TLS verification emergency disabled"
-    (Xapi_periodic_scheduler.Periodic 600.) 600. (fun () ->
-      Server_helpers.exec_with_new_task
-        "Period alert if TLS verification emergency disabled" (fun __context ->
-          Xapi_host.alert_if_tls_verification_was_emergency_disabled ~__context
-      )
-  )
+    (Xapi_periodic_scheduler.Periodic tls_enabled_period) tls_enabled_delay
+    tls_enabled_check

--- a/ocaml/xapi/xapi_pool_transition.ml
+++ b/ocaml/xapi/xapi_pool_transition.ml
@@ -164,7 +164,7 @@ let attempt_two_phase_commit_of_new_master ~__context (manual : bool)
       "Phase 2.2: setting flag to make us restart when the connection to the \
        master dies" ;
     Master_connection.restart_on_connection_timeout := true ;
-    Master_connection.connection_timeout := 0.
+    Master_connection.connection_timeout := 0
   ) ;
   if !hosts_which_failed <> [] then (
     error

--- a/ocaml/xapi/xapi_vdi.mli
+++ b/ocaml/xapi/xapi_vdi.mli
@@ -157,7 +157,7 @@ val destroy : __context:Context.t -> self:[`VDI] API.Ref.t -> unit
 val data_destroy : __context:Context.t -> self:[`VDI] API.Ref.t -> unit
 
 val _data_destroy :
-  __context:Context.t -> self:[`VDI] API.Ref.t -> timeout:float -> unit
+  __context:Context.t -> self:[`VDI] API.Ref.t -> timeout:Mtime.Span.t -> unit
 (** This version of {!data_destroy} is for unit testing purposes: the timeout
     for waiting for the VDI's VBDs to disappear is configurable to enable faster
     unit tests. *)


### PR DESCRIPTION
Mtime 1.4 deprecates the constant to convert from seconds to nanoseconds and viceverse.

I've used to opportunity to use the new interface for defining spans and remove quite a few periods defined in seconds, now they should be easier to recognized in the timeouts that happen.

Most of the code uses Mtime and counters to set the point of reference. For AD this is not possible as the state is persisted, so Ptime is used.

I wanted to gather some comments while I test: for example I don't know if changing the xapi globals to ints from floats breaks compatibility or whether I missed some shared frame of reference which would cause failures.

The part I like the least is the use of compare which is not instant to recognize what it means.

The CI will fail until Mtime is updated in xs-opam (and once it's updated it will make the CI fail xen-api until this PR or similar is merged)