### PR TITLE
CP-38688 introduce Message.destroy_many() API/CLI call

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6281,6 +6281,11 @@ module Message = struct
         [(Ref _message, "self", "The reference of the message to destroy")]
       ~flags:[`Session] ~allowed_roles:_R_POOL_OP ()
 
+  let destroy_many =
+    call ~name:"destroy_many" ~in_product_since:rel_next
+      ~params:[(Set (Ref _message), "messages", "Messages to destroy")]
+      ~flags:[`Session] ~allowed_roles:_R_POOL_OP ()
+
   let get_all =
     call ~name:"get_all" ~in_product_since:rel_orlando ~params:[]
       ~flags:[`Session]
@@ -6343,6 +6348,7 @@ module Message = struct
         [
           create
         ; destroy
+        ; destroy_many
         ; get
         ; get_all
         ; get_since

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6282,7 +6282,7 @@ module Message = struct
       ~flags:[`Session] ~allowed_roles:_R_POOL_OP ()
 
   let destroy_many =
-    call ~name:"destroy_many" ~in_product_since:rel_next
+    call ~name:"destroy_many" ~lifecycle:[]
       ~params:[(Set (Ref _message), "messages", "Messages to destroy")]
       ~flags:[`Session] ~allowed_roles:_R_POOL_OP ()
 

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -11,5 +11,7 @@ let prototyped_of_field = function
 let prototyped_of_message = function
   | "Repository", "set_gpgkey_path" ->
       Some "22.12.0"
+  | "message", "destroy_many" ->
+      Some "22.18.0-next"
   | _ ->
       None

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -120,9 +120,9 @@ let rec cmdtable_data : (string * cmd_spec) list =
     )
   ; ( "message-destroy"
     , {
-        reqd= ["uuid"]
-      ; optn= []
-      ; help= "Destroy an existing message."
+        reqd= []
+      ; optn= ["uuid"; "uuids"]
+      ; help= "Destroy one existing message or many"
       ; implementation= No_fd Cli_operations.message_destroy
       ; flags= []
       }

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -528,6 +528,9 @@ let destroy ~__context ~self =
   let basefilename = List.hd (List.rev (String.split_on_char '/' fullpath)) in
   destroy_real __context basefilename
 
+let destroy_many ~__context ~messages =
+  List.iter (fun self -> destroy ~__context ~self) messages
+
 (* Gc the messages - leave only the number of messages defined in 'Xapi_globs.message_limit' *)
 let gc ~__context =
   let message_limit = !Xapi_globs.message_limit in


### PR DESCRIPTION
The RPC overhead when destroying many messages is high. To avoid it,
introcuce a message to destroy several messages in one call. This
introduces a new API call Message.destroy_many. The corresponding CLI
command message-destroy is extended to accept a parameter "uuids" to
accept multiple UUIDs in additio to the existing "uuid" parameter.

I notice that destroyig a message by itself is not cheap because it
parses the XML content of the message being destroyed. In an unlucky
case it also involves scanning a directory on the file system to remove
an alias.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>