### PR TITLE
CP-39136: Reintroduce backend to vtpms 

### DIFF
--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -16,6 +16,9 @@ open Datamodel_types
 open Datamodel_common
 open Datamodel_roles
 
+let persistence_backend =
+  Enum ("persistence_backend", [("xapi", "This VTPM is persisted in XAPI's DB")])
+
 let get_contents =
   call ~name:"get_contents" ~in_product_since:"rel_next"
     ~doc:"Obtain the contents of the TPM" ~secret:true
@@ -40,7 +43,10 @@ let t =
         (Published, rel_rio, "Added VTPM stub")
       ; (Extended, rel_next, "Added ability to manipulate contents")
       ; (Extended, rel_next, "Added VTPM profiles")
-      ; (Changed, rel_next, "Removed backend field")
+      ; ( Changed
+        , rel_next
+        , "Changed the backend field to signify the persistence method"
+        )
       ]
     ~gen_constructor_destructor:true ~name:_vtpm ~descr:"A virtual TPM device"
     ~gen_events:false ~doccomments:[]
@@ -50,6 +56,8 @@ let t =
         uid _vtpm
       ; field ~qualifier:StaticRO ~ty:(Ref _vm) "VM"
           "The virtual machine the TPM is attached to"
+      ; field ~qualifier:DynamicRO ~ty:persistence_backend "backend"
+          "The backend where the vTPM is persisted"
       ; field ~qualifier:DynamicRO
           ~ty:(Map (String, String))
           ~lifecycle:[(Published, rel_next, "Added VTPM profiles")]

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "0d9764a8419d320a9f2a3928be59ee64"
+let last_known_schema_hash = "0ceb87a4c9870a6d320cc2f4708f5ddc"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi/xapi_vtpm.ml
+++ b/ocaml/xapi/xapi_vtpm.ml
@@ -12,16 +12,17 @@
    GNU Lesser General Public License for more details.
  *)
 
-let introduce ~__context ~uuid ~vM ~profile ~contents =
+let introduce ~__context ~uuid ~vM ~backend ~profile ~contents =
   let ref = Ref.make () in
-  Db.VTPM.create ~__context ~ref ~uuid ~vM ~profile ~contents ;
+  Db.VTPM.create ~__context ~ref ~uuid ~vM ~backend ~profile ~contents ;
   ref
 
 let create ~__context ~vM =
   let uuid = Uuid.(to_string (make_uuid ())) in
   let profile = Db.VM.get_default_vtpm_profile ~__context ~self:vM in
+  let backend = `xapi in
   let contents = Xapi_secret.create ~__context ~value:"" ~other_config:[] in
-  let ref = introduce ~__context ~uuid ~vM ~profile ~contents in
+  let ref = introduce ~__context ~uuid ~vM ~backend ~profile ~contents in
   ref
 
 let destroy ~__context ~self =


### PR DESCRIPTION
This type it's for signifying what persistence backend it's being used.
This means its type from a vm ref to an enum, for now with a single
possible value. There's no way to change yet backend, I would be wary of
adding them, as this is intended to permit several persistence backends
at the same time only for the benefit of developers.