### PR TITLE
Upgrade VM runtime state when xenopsd restarts

### DIFF
--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -3574,6 +3574,17 @@ let register_objects () =
     )
     (VM_DB.ids ())
 
+let upgrade_internal_state_of_running_vms () =
+  (* B.VM.set_internal_state contains upgrade code, needed for the case that
+     the type of the backend's internal state is extended in a xenopsd update. *)
+  let module B = (val get_backend () : S) in
+  List.iter
+    (fun vm ->
+      let vm_t = VM_DB.read_exn vm in
+      B.VM.get_internal_state [] [] vm_t |> B.VM.set_internal_state vm_t
+    )
+    (VM_DB.ids ())
+
 type rpc_t = Rpc.t
 
 let typ_of_rpc_t =

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -440,6 +440,7 @@ let main backend =
     ) ;
   Xenops_server.register_objects () ;
   Xenops_server.set_backend (Some backend) ;
+  Xenops_server.upgrade_internal_state_of_running_vms () ;
   Debug.with_thread_associated "main"
     (fun () ->
       let (_ : Thread.t) =


### PR DESCRIPTION
This is needed for the case that the type of the backend's internal
state is extended in a xenopsd update, such that any running VMs have
the current runtime metadata. Case in point is the recent addition of
the platformdata key, where the default value (an empty map) is not
sufficient.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>