### PR TITLE
CP-38688 make Message.destroy_many() async, too

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6284,7 +6284,7 @@ module Message = struct
   let destroy_many =
     call ~name:"destroy_many" ~lifecycle:[]
       ~params:[(Set (Ref _message), "messages", "Messages to destroy")]
-      ~flags:[`Session] ~allowed_roles:_R_POOL_OP ()
+      ~allowed_roles:_R_POOL_OP ()
 
   let get_all =
     call ~name:"get_all" ~in_product_since:rel_orlando ~params:[]


### PR DESCRIPTION
Update the definition of Message.destroy_many to use the default flags,
which inlcudes the Async flag that ensures an async version of this API
call is provided. This should further improve user experiences since we
expect this call to be slow when many messages are removed.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>