### PR TITLE
XSI-1246/CA-367232: Daily license re-apply fails is HA is enabled

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1850,7 +1850,10 @@ let apply_edition_internal ~__context ~host ~edition ~additional =
 let apply_edition ~__context ~host ~edition ~force =
   (* if HA is enabled do not allow the edition to be changed *)
   let pool = Helpers.get_pool ~__context in
-  if Db.Pool.get_ha_enabled ~__context ~self:pool then
+  if
+    Db.Pool.get_ha_enabled ~__context ~self:pool
+    && edition <> Db.Host.get_edition ~__context ~self:host
+  then
     raise (Api_errors.Server_error (Api_errors.ha_is_enabled, []))
   else
     let additional = if force then [("force", "true")] else [] in


### PR DESCRIPTION
A CH host is meant to re-apply it's license once a day, in order to
correctly handle expiry and to pick up any new licenses. This is some by
setting a timer in a thread in v6d, which triggers a host.apply_edition
call to xapi after 24 hours. The problem is that this call is rejected
if HA is enabled, which breaks the mechanism.

We'll fix this by allowing a host.apply_edition call if the edition is
not being changed. This is still consistent with the original intention
of the restriction (as evidenced by the code comment).

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>
(cherry-picked from commit 894e8821a50020e31383591c5640a71598c3aef3)