### PR TITLE
xapi: avoid spawning processes to touch files

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1219,16 +1219,13 @@ let local_storage_exists () =
     true
   with _ -> false
 
-let touch_file fname =
-  try
-    if fname <> "" then
-      match Unixext.spawnvp "touch" [|"touch"; fname|] with
-      | Unix.WEXITED 0 ->
-          ()
-      | _ ->
-          warn "Unable to touch ready file '%s': touch exited abnormally" fname
-  with e ->
-    warn "Unable to touch ready file '%s': %s" fname (Printexc.to_string e)
+(** Stdlib's Arg module doesn't support string option ref, instead the empty
+    string is used for expressing the null value *)
+let touch_file cmd_arg =
+  if cmd_arg <> "" then
+    try Unixext.touch_file cmd_arg
+    with e ->
+      warn "Unable to touch file '%s': %s" cmd_arg (Printexc.to_string e)
 
 let vm_to_string __context vm =
   let str = Ref.string_of vm in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1108,8 +1108,12 @@ let syslog_reconfigure ~__context ~host:_ =
   let flag =
     match destination with "" -> "--noremote" | _ -> "--remote=" ^ destination
   in
-  let args = [|!Xapi_globs.xe_syslog_reconfigure; flag|] in
-  ignore (Unixext.spawnvp args.(0) args)
+  let (_ : string * string) =
+    Forkhelpers.execute_command_get_output
+      !Xapi_globs.xe_syslog_reconfigure
+      [flag]
+  in
+  ()
 
 let get_management_interface ~__context ~host =
   let pifs =


### PR DESCRIPTION
The check against an empty string needs to be kept as some of the
variables use an empty string as an alternative to None, meaning not to
create the file at all.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>