### PR TITLE
CA-366309: ignore HA when checking update readiness

### DIFF
--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -54,6 +54,15 @@ val assert_can_evacuate : __context:Context.t -> host:API.ref_host -> unit
 val get_vms_which_prevent_evacuation :
   __context:Context.t -> self:API.ref_host -> (API.ref_VM * string list) list
 
+(* Similar to the (API) call `host.get_vms_which_prevent_evacuation`, but with an
+   additional `ignore_ha` argument. The makes the evacuation planner behave the
+   same no matter whether HA is enabled or not. *)
+val get_vms_which_prevent_evacuation_internal :
+     __context:Context.t
+  -> self:API.ref_host
+  -> ignore_ha:bool
+  -> (API.ref_VM * string list) list
+
 val evacuate :
   __context:Context.t -> host:API.ref_host -> network:API.ref_network -> unit
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3440,7 +3440,8 @@ let check_update_readiness ~__context ~self:_ ~requires_reboot =
     if not alive then
       [[Api_errors.host_offline; Ref.string_of host]]
     else if requires_reboot then
-      Xapi_host.get_vms_which_prevent_evacuation ~__context ~self:host
+      Xapi_host.get_vms_which_prevent_evacuation_internal ~__context ~self:host
+        ~ignore_ha:true
       |> List.map (fun (_, error) -> error)
     else
       [[]]


### PR DESCRIPTION
In particular, the evacuation plan is computed in a different way when
HA is enabled. We want the update readiness to check things as if HA is
disabled, because before updates are applied, HA will be disabled anyway.