### PR TITLE
XenAPI.py: define how to build package in pyproject.toml

### DIFF
--- a/scripts/examples/python/Makefile
+++ b/scripts/examples/python/Makefile
@@ -3,7 +3,7 @@ PROFILE=release
 .PHONY: build clean
 
 build: setup.py
-	python setup.py bdist_wheel
+	pip wheel -w dist --no-deps .
 	python setup.py sdist
 
 setup.py:

--- a/scripts/examples/python/pyproject.toml
+++ b/scripts/examples/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 38.6.0", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
This fixes #4716, #4717

This only changes how the python wheel (distributable package) is generated, it's generated in the same place.
Note that this still needs to invoke `make build` to generate `setup.py`, In general this will need to have an environment where xapi is buildable in order to retrieve the API version.