### PR TITLE
CP-38583 add Host.last_software_update field with data/time

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -9,7 +9,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 751
+let schema_minor_vsn = 752
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2071,6 +2071,10 @@ let t =
         ; field ~qualifier:DynamicRO ~in_product_since:"1.313.0" ~ty:Bool
             "tls_verification_enabled" ~default_value:(Some (VBool false))
             "True if this host has TLS verifcation enabled"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
+            "last_software_update"
+            ~default_value:(Some (VDateTime (Date.of_float 0.0)))
+            "Date and time when the last software update was applied"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -5,6 +5,8 @@ let prototyped_of_class = function
 let prototyped_of_field = function
   | "Repository", "gpgkey_path" ->
       Some "22.12.0"
+  | "host", "last_software_update" ->
+      Some "22.19.0-next"
   | _ ->
       None
 
@@ -12,6 +14,6 @@ let prototyped_of_message = function
   | "Repository", "set_gpgkey_path" ->
       Some "22.12.0"
   | "message", "destroy_many" ->
-      Some "22.18.0-next"
+      Some "22.19.0"
   | _ ->
       None

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "cf920686e616eb3b610aab4626716480"
+let last_known_schema_hash = "38766d4fd742a81e2c2e95cffb0c5010"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -203,7 +203,7 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~display:`enabled ~virtual_hardware_platform_versions:[]
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
-    ~tls_verification_enabled ;
+    ~tls_verification_enabled ~last_software_update:(Date.localtime ()) ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3147,6 +3147,9 @@ let host_record rpc session_id host =
             (x ()).API.host_tls_verification_enabled |> string_of_bool
           )
           ()
+      ; make_field ~name:"last-software-update"
+          ~get:(fun () -> Date.to_string (x ()).API.host_last_software_update)
+          ()
       ]
   }
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -950,7 +950,7 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
       )
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
-    ~tls_verification_enabled ;
+    ~tls_verification_enabled ~last_software_update:(Date.localtime ()) ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;
@@ -2810,4 +2810,5 @@ let apply_updates ~__context ~self ~hash =
       ~doc:"Host.apply_updates" ~op:`apply_updates
     @@ fun () -> Repository.apply_updates ~__context ~host:self ~hash
   in
+  Db.Host.set_last_software_update ~__context ~self ~value:(Date.localtime ()) ;
   Repository.apply_immediate_guidances ~__context ~host:self ~guidances


### PR DESCRIPTION
Add a new field that reflects the last time Host.apply_software_updates
was run (or the time of the first installation).

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>