### PR TITLE
CP-39884 generalise interface to gzip/zstd-like tools

### DIFF
--- a/ocaml/database/backend_xml.ml
+++ b/ocaml/database/backend_xml.ml
@@ -26,7 +26,7 @@ let unmarshall schema dbconn =
     Xapi_stdext_pervasives.Pervasiveext.finally
       (fun () ->
         let result = ref None in
-        Gzip.decompress_passive compressed (fun uncompressed ->
+        Gzip.Default.decompress_passive compressed (fun uncompressed ->
             result :=
               Some
                 (Db_xml.From.channel schema
@@ -58,7 +58,9 @@ let flush dbconn db =
         if not dbconn.Parse_db_conf.compress then
           Db_xml.To.fd fd db
         else
-          Gzip.compress fd (fun uncompressed -> Db_xml.To.fd uncompressed db)
+          Gzip.Default.compress fd (fun uncompressed ->
+              Db_xml.To.fd uncompressed db
+          )
     )
   in
   let do_flush_gen db filename =

--- a/ocaml/libs/gzip/gzip.ml
+++ b/ocaml/libs/gzip/gzip.ml
@@ -12,9 +12,11 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Gzip = Xapi_compression.Make (struct
+module Default = Xapi_compression.Make (struct
   (** Path to the gzip binary *)
   let executable = "/bin/gzip"
-end)
 
-include Gzip
+  let compress_options = []
+
+  let decompress_options = ["--decompress"; "--stdout"]
+end)

--- a/ocaml/libs/gzip/gzip.mli
+++ b/ocaml/libs/gzip/gzip.mli
@@ -12,13 +12,4 @@
  * GNU Lesser General Public License for more details.
  *)
 
-val compress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
-(** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
-    and whose output is 'ofd' *)
-
-val decompress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
-(** Runs a decompression process which is fed from a pipe whose entrance is passed to 'f'
-    and whose output is 'ofd' *)
-
-(* Experimental decompressor which is fed from an fd and writes to a pipe *)
-val decompress_passive : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
+module Default : Xapi_compression.COMPRESSOR

--- a/ocaml/libs/xapi-compression/xapi_compression.ml
+++ b/ocaml/libs/xapi-compression/xapi_compression.ml
@@ -1,5 +1,25 @@
 module type ALGORITHM = sig
   val executable : string
+
+  val compress_options : string list
+
+  val decompress_options : string list
+end
+
+module type COMPRESSOR = sig
+  val available : unit -> bool
+  (** Returns whether this compression algorithm is available *)
+
+  val compress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
+  (** Runs a compression process which is fed from a pipe whose entrance
+  is passed to 'f' and whose output is 'ofd' *)
+
+  val decompress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
+  (** Runs a decompression process which is fed from a pipe whose
+  entrance is passed to 'f' and whose output is 'ofd' *)
+
+  (* Experimental decompressor which is fed from an fd and writes to a pipe *)
+  val decompress_passive : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 end
 
 module D = Debug.Make (struct let name = "xapi_compression" end)
@@ -46,9 +66,9 @@ module Make (Algorithm : ALGORITHM) = struct
     let args =
       match mode with
       | Compress ->
-          []
+          Algorithm.compress_options
       | Decompress ->
-          ["--decompress"; "--stdout"]
+          Algorithm.decompress_options
     in
     let stdin, stdout, close_now, close_later =
       match input with

--- a/ocaml/libs/xapi-compression/xapi_compression.mli
+++ b/ocaml/libs/xapi-compression/xapi_compression.mli
@@ -1,19 +1,25 @@
 module type ALGORITHM = sig
   val executable : string
+
+  val compress_options : string list
+
+  val decompress_options : string list
 end
 
-module Make : functor (Algorithm : ALGORITHM) -> sig
+module type COMPRESSOR = sig
   val available : unit -> bool
   (** Returns whether this compression algorithm is available *)
 
   val compress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
-  (** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
-      and whose output is 'ofd' *)
+  (** Runs a compression process which is fed from a pipe whose entrance
+  is passed to 'f' and whose output is 'ofd' *)
 
   val decompress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
-  (** Runs a decompression process which is fed from a pipe whose entrance is passed to 'f'
-      and whose output is 'ofd' *)
+  (** Runs a decompression process which is fed from a pipe whose
+  entrance is passed to 'f' and whose output is 'ofd' *)
 
   (* Experimental decompressor which is fed from an fd and writes to a pipe *)
   val decompress_passive : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
 end
+
+module Make : functor (Algorithm : ALGORITHM) -> COMPRESSOR

--- a/ocaml/libs/xapi-compression/xapi_gzip.ml
+++ b/ocaml/libs/xapi-compression/xapi_gzip.ml
@@ -18,7 +18,13 @@
 
 module C = Cmdliner
 
-module Gzip = Xapi_compression.Make (struct let executable = "/bin/gzip" end)
+module Gzip = Xapi_compression.Make (struct
+  let executable = "/bin/gzip"
+
+  let compress_options = []
+
+  let decompress_options = ["--decompress"; "--stdout"]
+end)
 
 let help =
   [

--- a/ocaml/libs/zstd/zstd.ml
+++ b/ocaml/libs/zstd/zstd.ml
@@ -12,9 +12,11 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Zstd = Xapi_compression.Make (struct
+module Default = Xapi_compression.Make (struct
   (** Path to the zstd binary *)
   let executable = "/usr/bin/zstd"
-end)
 
-include Zstd
+  let compress_options = []
+
+  let decompress_options = ["--decompress"; "--stdout"]
+end)

--- a/ocaml/libs/zstd/zstd.mli
+++ b/ocaml/libs/zstd/zstd.mli
@@ -12,13 +12,4 @@
  * GNU Lesser General Public License for more details.
  *)
 
-val compress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
-(** Runs a compression process which is fed from a pipe whose entrance is passed to 'f'
-    and whose output is 'ofd' *)
-
-val decompress : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
-(** Runs a decompression process which is fed from a pipe whose entrance is passed to 'f'
-    and whose output is 'ofd' *)
-
-(* Experimental decompressor which is fed from an fd and writes to a pipe *)
-val decompress_passive : Unix.file_descr -> (Unix.file_descr -> 'a) -> 'a
+module Default : Xapi_compression.COMPRESSOR

--- a/ocaml/xapi/audit_log.ml
+++ b/ocaml/xapi/audit_log.ml
@@ -59,7 +59,7 @@ let transfer_audit_file _path compression fd_out ?filter since : unit =
             path
         else if compression = "gz" then
           Unixext.with_file path [Unix.O_RDONLY] 0o0 (fun gz_fd_in ->
-              Gzip.decompress_passive gz_fd_in (fun fd_in ->
+              Gzip.Default.decompress_passive gz_fd_in (fun fd_in ->
                   (*fd_in is closed by gzip module*)
                   let cin = Unix.in_channel_of_descr fd_in in
                   try

--- a/ocaml/xapi/export.ml
+++ b/ocaml/xapi/export.ml
@@ -922,9 +922,9 @@ let handler (req : Request.t) s _ =
                     in
                     match compression_algorithm with
                     | Some Gzip ->
-                        Gzip.compress s go
+                        Gzip.Default.compress s go
                     | Some Zstd ->
-                        Zstd.compress s go
+                        Zstd.Default.compress s go
                     | None ->
                         go s
                 )

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1980,10 +1980,10 @@ let with_open_archive fd ?length f =
       in
       if zstd then (
         debug "Failed to directly open the archive; trying zstd" ;
-        Zstd.decompress
+        Zstd.Default.decompress
       ) else (
         debug "Failed to directly open the archive; trying gzip" ;
-        Gzip.decompress
+        Gzip.Default.decompress
       )
     in
     let feeder pipe_in =

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -229,7 +229,7 @@ let with_updateinfo_xml gz_path f =
         (fun () ->
           try
             Unixext.with_file gz_path [Unix.O_RDONLY] 0o0 @@ fun gz_fd_in ->
-            Gzip.decompress_passive gz_fd_in @@ fun fd_in ->
+            Gzip.Default.decompress_passive gz_fd_in @@ fun fd_in ->
             let ic = Unix.in_channel_of_descr fd_in in
             try
               while true do

--- a/ocaml/xapi/stream_vdi.ml
+++ b/ocaml/xapi/stream_vdi.ml
@@ -573,7 +573,7 @@ let recv_all_zurich refresh_session ifd (__context : Context.t) rpc session_id
                   raise (Failure "Invalid XVA file")
                 ) ;
                 debug "Decompressing %Ld bytes from %s\n" length file_name ;
-                Gzip.decompress ofd (fun zcat_in ->
+                Gzip.Default.decompress ofd (fun zcat_in ->
                     Tar_helpers.copy_n ifd zcat_in length
                 ) ;
                 Tar_helpers.skip ifd

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_shared.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_shared.ml
@@ -101,7 +101,7 @@ let rrd_of_gzip path =
   in
   if gz_exists then
     Xapi_stdext_unix.Unixext.with_file gz_path [Unix.O_RDONLY] 0o0 (fun fd ->
-        Gzip.decompress_passive fd rrd_of_fd
+        Gzip.Default.decompress_passive fd rrd_of_fd
     )
   else (* If this fails, let the exception propagate *)
     Xapi_stdext_unix.Unixext.with_file path [Unix.O_RDONLY] 0 rrd_of_fd
@@ -153,7 +153,7 @@ let archive_rrd_internal ?(transport = None) ~uuid ~rrd () =
             0o755 ;
           let base_filename = Rrdd_libs.Constants.rrd_location ^ "/" ^ uuid in
           Xapi_stdext_unix.Unixext.atomic_write_to_file (base_filename ^ ".gz")
-            0o644 (fun fd -> Gzip.compress fd (Rrd_unix.to_fd rrd)
+            0o644 (fun fd -> Gzip.Default.compress fd (Rrd_unix.to_fd rrd)
           ) ;
           (* If there's an uncompressed one hanging around, remove it. *)
           Xapi_stdext_unix.Unixext.unlink_safe base_filename


### PR DESCRIPTION
The existing interface to compressions tools assumes that all tools
receive the exact same command-line arguments. This patch removes this
limitiation while keeping the existing comamnd-line arguments as
defaults. No client code needs to be changed.

The xapi_compression.mli interace is extended by accepting additional
(and optional) flags (or other arguments) that are passed to the
compression binary. For example, the compression level could be passed
in addition.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>