### PR TITLE
CP-39894: Move most of the daemon management code to the service module and make pid locations explicit

### DIFF
--- a/ocaml/xenopsd/lib/xenops_sandbox.ml
+++ b/ocaml/xenopsd/lib/xenops_sandbox.ml
@@ -120,8 +120,6 @@ end
 module type SANDBOX = sig
   val create : domid:int -> vm_uuid:string -> Chroot.Path.t -> string
 
-  val chroot : domid:int -> vm_uuid:string -> Chroot.t
-
   val start :
        string
     -> vm_uuid:string

--- a/ocaml/xenopsd/lib/xenops_sandbox.mli
+++ b/ocaml/xenopsd/lib/xenops_sandbox.mli
@@ -48,11 +48,6 @@ module type SANDBOX = sig
       [domid] inside the chroot for [domid] and returns the absolute path to it
       outside the chroot *)
 
-  val chroot : domid:int -> vm_uuid:string -> Chroot.t
-  (** [chroot ~domid ~vm_uuid] returns the chroot for [domid] and [vm_uuid].
-      The chroot may not necessarily exist yet.
-  *)
-
   val start :
        string
     -> vm_uuid:string

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -1294,12 +1294,11 @@ module Swtpm = struct
     ) else
       debug "vTPM state for domid %d is empty: not restoring" domid
 
-  let start_daemon dbg ~xs ~path ~args ~domid ~vm_uuid ~vtpm_uuid ~index () =
+  let start_daemon dbg ~xs ~chroot ~path ~args ~domid ~vm_uuid ~vtpm_uuid ~index () =
     let state =
       Varstore_privileged_client.Client.vtpm_get_contents dbg vtpm_uuid
       |> Base64.decode_exn
     in
-    let chroot = Xenops_sandbox.Swtpm_guard.chroot ~domid ~vm_uuid in
     let abs_path =
       Xenops_sandbox.Chroot.absolute_path_outside chroot state_path
     in
@@ -4236,7 +4235,7 @@ module Dm = struct
     let args = Fe_argv.run args |> snd |> Fe_argv.argv in
     let timeout_seconds = !Xenopsd.swtpm_ready_timeout in
     let dbg = Xenops_task.get_dbg task in
-    let execute = Swtpm.start_daemon dbg ~xs ~vtpm_uuid ~vm_uuid ~index in
+    let execute = Swtpm.start_daemon dbg ~xs ~chroot ~vtpm_uuid ~vm_uuid ~index in
     let service =
       {Service.name; domid; exec_path; chroot; args; execute; timeout_seconds}
     in

--- a/ocaml/xenopsd/xc/device.mli
+++ b/ocaml/xenopsd/xc/device.mli
@@ -58,11 +58,6 @@ module Profile : sig
       [fallback] if an invalid name is provided. *)
 end
 
-(** Represent an IPC endpoint *)
-module Socket : sig
-  type t = Unix of string | Port of int
-end
-
 module Generic : sig
   val rm_device_state : xs:Xenstore.Xs.xsh -> device -> unit
 
@@ -225,55 +220,6 @@ module Vcpu : sig
   val status : xs:Xenstore.Xs.xsh -> dm:Profile.t -> devid:int -> int -> bool
 end
 
-module PV_Vnc : sig
-  exception Failed_to_start
-
-  val save : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
-
-  val get_statefile : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> string option
-
-  val start :
-       ?statefile:string
-    -> xs:Xenstore.Xs.xsh
-    -> ?ip:string
-    -> Xenctrl.domid
-    -> unit
-
-  val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
-
-  val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Socket.t option
-
-  val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
-end
-
-module Qemu : sig
-  module SignalMask : sig
-    type t
-
-    val create : unit -> t
-
-    val set : t -> int -> unit
-
-    val unset : t -> int -> unit
-
-    val has : t -> int -> bool
-  end
-
-  val signal_mask : SignalMask.t
-
-  val pid_path_signal : Xenctrl.domid -> string
-
-  val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
-
-  val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
-end
-
-module Vgpu : sig
-  val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
-
-  val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
-end
-
 module PCI : sig
   open Xenops_interface.Pci
 
@@ -392,7 +338,10 @@ module Dm : sig
   }
 
   val get_vnc_port :
-    xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> Socket.t option
+       xs:Xenstore.Xs.xsh
+    -> dm:Profile.t
+    -> Xenctrl.domid
+    -> Xenops_utils.Socket.t option
 
   val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 
@@ -549,6 +498,9 @@ module Vusb : sig
 end
 
 val get_vnc_port :
-  xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> Socket.t option
+     xs:Xenstore.Xs.xsh
+  -> dm:Profile.t
+  -> Xenctrl.domid
+  -> Xenops_utils.Socket.t option
 
 val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -694,7 +694,7 @@ let destroy (task : Xenops_task.task_handle) ~xc ~xs ~qemu_domid ~vtpm ~dm domid
     (fun () -> Device.Dm.stop ~xs ~qemu_domid ~vtpm ~dm domid)
     () ;
   log_exn_continue "Error stoping vncterm, already dead ?"
-    (fun () -> Device.PV_Vnc.stop ~xs domid)
+    (fun () -> Service.PV_Vnc.stop ~xs domid)
     () ;
   (* Forcibly shutdown every backend *)
   List.iter

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -5,6 +5,8 @@ module Unixext = Xapi_stdext_unix.Unixext
 module Xenops_task = Xenops_task.Xenops_task
 module Chroot = Xenops_sandbox.Chroot
 module Path = Chroot.Path
+module Xs = Xenstore.Xs
+module Socket = Xenops_utils.Socket
 
 let defer f g = Xapi_stdext_pervasives.Pervasiveext.finally g f
 
@@ -164,3 +166,407 @@ let start_and_wait_for_readyness ~task ~service =
     (wait ~for_s:service.timeout_seconds ~service_name:syslog_key) ;
 
   debug "Service %s initialized" syslog_key
+
+module type DAEMONPIDPATH = sig
+  val name : string
+
+  val use_pidfile : bool
+
+  val pid_path : int -> string
+end
+
+module DaemonMgmt (D : DAEMONPIDPATH) = struct
+  module SignalMask = struct
+    module H = Hashtbl
+
+    type t = (int, bool) H.t
+
+    let create () = H.create 16
+
+    let set tbl key = H.replace tbl key true
+
+    let unset tbl key = H.remove tbl key
+
+    let has tbl key = H.mem tbl key
+  end
+
+  let signal_mask = SignalMask.create ()
+
+  let name = D.name
+
+  let pid_path = D.pid_path
+
+  let pid_path_signal domid = pid_path domid ^ "-signal"
+
+  let pidfile_path domid =
+    if D.use_pidfile then
+      Some
+        (Printf.sprintf "%s/%s-%d.pid" Device_common.var_run_xen_path D.name
+           domid
+        )
+    else
+      None
+
+  let pid ~xs domid =
+    try
+      match pidfile_path domid with
+      | Some path when Sys.file_exists path ->
+          let pid =
+            path |> Unixext.string_of_file |> String.trim |> int_of_string
+          in
+          Unixext.with_file path [Unix.O_RDONLY] 0 (fun fd ->
+              try
+                Unix.lockf fd Unix.F_TRLOCK 0 ;
+                (* we succeeded taking the lock: original process is dead.
+                 * some other process might've reused its pid *)
+                None
+              with Unix.Unix_error (Unix.EAGAIN, _, _) ->
+                (* cannot obtain lock: process is alive *)
+                Some pid
+          )
+      | _ ->
+          (* backward compatibility during update installation: only has
+             xenstore pid *)
+          let pid = xs.Xs.read (pid_path domid) in
+          Some (int_of_string pid)
+    with _ -> None
+
+  let is_running ~xs domid =
+    match pid ~xs domid with
+    | None ->
+        false
+    | Some p -> (
+      try Unix.kill p 0 ; (* This checks the existence of pid p *)
+                          true
+      with _ -> false
+    )
+
+  let stop ~xs domid =
+    match pid ~xs domid with
+    | None ->
+        ()
+    | Some pid -> (
+        let best_effort = Xenops_utils.best_effort in
+        let really_kill = Xenops_utils.really_kill in
+        debug "%s: stopping %s with SIGTERM (domid = %d pid = %d)" D.name D.name
+          domid pid ;
+        best_effort (Printf.sprintf "killing %s" D.name) (fun () ->
+            really_kill pid
+        ) ;
+        let key = pid_path domid in
+        best_effort (Printf.sprintf "removing XS key %s" key) (fun () ->
+            xs.Xs.rm key
+        ) ;
+        match pidfile_path domid with
+        | None ->
+            ()
+        | Some path ->
+            best_effort (Printf.sprintf "removing %s" path) (fun () ->
+                Unix.unlink path
+            )
+      )
+
+  let syslog_key ~domid = Printf.sprintf "%s-%d" D.name domid
+
+  let start ~fds ~syslog_key path args =
+    let syslog_stdout = Forkhelpers.Syslog_WithKey syslog_key in
+    let redirect_stderr_to_stdout = true in
+    let pid =
+      Forkhelpers.safe_close_and_exec None None None fds ~syslog_stdout
+        ~redirect_stderr_to_stdout path args
+    in
+    debug
+      "%s: should be running in the background (stdout -> syslog); (fd,pid) = \
+       %s"
+      D.name
+      (Forkhelpers.string_of_pidty pid) ;
+    pid
+
+  (* Forks a daemon and then returns the pid. *)
+  let start_daemon ~path ~args ~domid ?(fds = []) () =
+    let syslog_key = syslog_key ~domid in
+    debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
+    let pid = start ~fds ~syslog_key path args in
+    debug "Daemon started: %s" syslog_key ;
+    pid
+end
+
+module Qemu = DaemonMgmt (struct
+  let name = "qemu-dm"
+
+  let use_pidfile = true
+
+  let pid_path domid = Printf.sprintf "/local/domain/%d/qemu-pid" domid
+end)
+
+module Vgpu = DaemonMgmt (struct
+  let name = "vgpu"
+
+  let use_pidfile = false
+
+  let pid_path domid = Printf.sprintf "/local/domain/%d/vgpu-pid" domid
+end)
+
+module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
+  (* backward compat: for daemons running during an update *)
+  module Compat = DaemonMgmt (D)
+
+  let pidfile_path = Compat.pidfile_path
+
+  let pid_path = Compat.pid_path
+
+  let of_domid domid =
+    let key = Compat.syslog_key ~domid in
+    if Fe_systemctl.exists ~service:key then
+      Some key
+    else
+      None
+
+  let is_running ~xs domid =
+    match of_domid domid with
+    | None ->
+        Compat.is_running ~xs domid
+    | Some key ->
+        Fe_systemctl.is_active ~service:key
+
+  let alive service _ =
+    if Fe_systemctl.is_active ~service then
+      true
+    else
+      let status = Fe_systemctl.show ~service in
+      let open Fe_systemctl in
+      error
+        "%s: unexpected termination \
+         (Result=%s,ExecMainPID=%d,ExecMainStatus=%d,ActiveState=%s)"
+        service status.result status.exec_main_pid status.exec_main_status
+        status.active_state ;
+      false
+
+  let stop ~xs domid =
+    match of_domid domid with
+    | None ->
+        Compat.stop ~xs domid
+    | Some service ->
+        (* xenstore cleanup is done by systemd unit file *)
+        let (_ : Fe_systemctl.status) = Fe_systemctl.stop ~service in
+        ()
+
+  let start_daemon ~path ~args ~domid () =
+    debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
+    let service = Compat.syslog_key ~domid in
+    let pidpath = D.pid_path domid in
+    let properties =
+      ("ExecStopPost", "-/usr/bin/xenstore-rm " ^ pidpath)
+      ::
+      ( match Compat.pidfile_path domid with
+      | None ->
+          []
+      | Some path ->
+          [("ExecStopPost", "-/bin/rm -f " ^ path)]
+      )
+    in
+    Fe_systemctl.start_transient ~properties ~service path args ;
+    debug "Daemon started: %s" service ;
+    service
+end
+
+module Varstored = SystemdDaemonMgmt (struct
+  let name = "varstored"
+
+  let use_pidfile = true
+
+  let pid_path domid = Printf.sprintf "/local/domain/%d/varstored-pid" domid
+end)
+
+(* TODO: struct and include and uri to uri mapper, etc.
+   also xapi needs default backend set
+*)
+module Swtpm = struct
+  module D = SystemdDaemonMgmt (struct
+    let name = "swtpm-wrapper"
+
+    let use_pidfile = false
+
+    let pid_path domid = Printf.sprintf "/local/domain/%d/varstored-pid" domid
+  end)
+
+  let xs_path ~domid = Device_common.get_private_path domid ^ "/vtpm"
+
+  let state_path =
+    (* for easier compat with dir:// mode, but can be anything.
+       If we implement VDI state storage this could be a block device
+    *)
+    Xenops_sandbox.Chroot.Path.of_string ~relative:"tpm2-00.permall"
+
+  let restore ~domid ~vm_uuid state =
+    if String.length state > 0 then (
+      let path = Xenops_sandbox.Swtpm_guard.create ~domid ~vm_uuid state_path in
+      debug "Restored vTPM for domid %d: %d bytes, digest %s" domid
+        (String.length state)
+        (state |> Digest.string |> Digest.to_hex) ;
+      Unixext.write_string_to_file path state
+    ) else
+      debug "vTPM state for domid %d is empty: not restoring" domid
+
+  let start_daemon dbg ~xs ~chroot ~path ~args ~domid ~vm_uuid ~vtpm_uuid ~index
+      () =
+    let state =
+      Varstore_privileged_client.Client.vtpm_get_contents dbg vtpm_uuid
+      |> Base64.decode_exn
+    in
+    let abs_path =
+      Xenops_sandbox.Chroot.absolute_path_outside chroot state_path
+    in
+    if Sys.file_exists abs_path then
+      debug "Not restoring vTPM: %s already exists" abs_path
+    else
+      restore ~domid ~vm_uuid state ;
+    let vtpm_path = xs_path ~domid in
+    xs.Xs.write
+      (Filename.concat vtpm_path @@ string_of_int index)
+      (Uuidm.to_string vtpm_uuid) ;
+    D.start_daemon ~path ~args ~domid ()
+
+  let suspend ~xs ~domid ~vm_uuid =
+    D.stop ~xs domid ;
+    Xenops_sandbox.Swtpm_guard.read ~domid ~vm_uuid state_path
+
+  let stop dbg ~xs ~domid ~vm_uuid ~vtpm_uuid =
+    debug "About to stop vTPM (%s) for domain %d (%s)"
+      (Uuidm.to_string vtpm_uuid)
+      domid vm_uuid ;
+    let contents = suspend ~xs ~domid ~vm_uuid in
+    let length = String.length contents in
+    if length > 0 then (
+      debug "Storing vTPM state of %d bytes" length ;
+      Varstore_privileged_client.Client.vtpm_set_contents dbg vtpm_uuid
+        (Base64.encode_string contents)
+    ) else
+      debug "vTPM state is empty: not storing" ;
+    (* needed to save contents before wiping the chroot *)
+    Xenops_sandbox.Swtpm_guard.stop dbg ~domid ~vm_uuid
+end
+
+module PV_Vnc = struct
+  module D = DaemonMgmt (struct
+    let name = "vncterm"
+
+    let use_pidfile = false
+
+    let pid_path domid = Printf.sprintf "/local/domain/%d/vncterm-pid" domid
+  end)
+
+  let vnc_console_path domid = Printf.sprintf "/local/domain/%d/console" domid
+
+  let vnc_port_path domid =
+    Printf.sprintf "/local/domain/%d/console/vnc-port" domid
+
+  let tc_port_path domid =
+    Printf.sprintf "/local/domain/%d/console/tc-port" domid
+
+  let pid ~xs domid = D.pid ~xs domid
+
+  (* Look up the commandline args for the vncterm pid; *)
+  (* Check that they include the vncterm binary path and the xenstore console
+     path for the supplied domid. *)
+  let is_cmdline_valid domid pid =
+    try
+      let cmdline =
+        Printf.sprintf "/proc/%d/cmdline" pid
+        |> Unixext.string_of_file
+        |> Astring.String.cuts ~sep:"\000"
+      in
+      List.mem !Xc_resources.vncterm cmdline
+      && List.mem (vnc_console_path domid) cmdline
+    with _ -> false
+
+  let is_vncterm_running ~xs domid =
+    match pid ~xs domid with
+    | None ->
+        false
+    | Some p ->
+        D.is_running ~xs domid && is_cmdline_valid domid p
+
+  let get_vnc_port ~xs domid =
+    if not (is_vncterm_running ~xs domid) then
+      None
+    else
+      try Some (Socket.Port (int_of_string (xs.Xs.read (vnc_port_path domid))))
+      with _ -> None
+
+  let get_tc_port ~xs domid =
+    if not (is_vncterm_running ~xs domid) then
+      None
+    else
+      try Some (int_of_string (xs.Xs.read (tc_port_path domid)))
+      with _ -> None
+
+  let load_args = function
+    | None ->
+        []
+    | Some filename ->
+        if Sys.file_exists filename then
+          ["-l"; filename]
+        else
+          []
+
+  exception Failed_to_start
+
+  let vncterm_statefile pid =
+    Printf.sprintf "/var/xen/vncterm/%d/vncterm.statefile" pid
+
+  let get_statefile ~xs domid =
+    match pid ~xs domid with
+    | None ->
+        None
+    | Some pid ->
+        let filename = vncterm_statefile pid in
+        if Sys.file_exists filename then
+          Some filename
+        else
+          None
+
+  let save ~xs domid =
+    match pid ~xs domid with
+    | Some pid ->
+        Unix.kill pid Sys.sigusr1 ;
+        let filename = vncterm_statefile pid in
+        let delay = 10. in
+        let start_time = Unix.time () in
+        (* wait at most ten seconds *)
+        while
+          (not (Sys.file_exists filename)) || Unix.time () -. start_time > delay
+        do
+          debug "Device.PV_Vnc.save: waiting for %s to appear" filename ;
+          Thread.delay 1.
+        done ;
+        if Unix.time () -. start_time > delay then
+          debug "Device.PV_Vnc.save: timeout while waiting for %s to appear"
+            filename
+        else
+          debug "Device.PV_Vnc.save: %s has appeared" filename
+    | None ->
+        ()
+
+  let start ?statefile ~xs ?ip domid =
+    debug "In PV_Vnc.start" ;
+    let ip = Option.value ~default:"127.0.0.1" ip in
+    let l =
+      [
+        "-x"
+      ; Printf.sprintf "/local/domain/%d/console" domid
+      ; "-T"
+      ; (* listen for raw connections *)
+        "-v"
+      ; ip ^ ":1"
+      ]
+      @ load_args statefile
+    in
+    (* Now add the close fds wrapper *)
+    let pid = D.start_daemon ~path:!Xc_resources.vncterm ~args:l ~domid () in
+    let path = D.pid_path domid in
+    xs.Xs.write path (string_of_int (Forkhelpers.getpid pid)) ;
+    Forkhelpers.dontwaitpid pid
+
+  let stop ~xs domid = D.stop ~xs domid
+end

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -1,3 +1,16 @@
+(* Copyright (C) Citrix Systems Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
 module D = Debug.Make (struct let name = "service" end)
 
 open! D

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -199,6 +199,17 @@ let wait_path ~pidalive ~task ~name ~domid ~xs ~ready_path ~timeout ~cancel _ =
   ) ;
   debug "Daemon initialised: %s" syslog_key
 
+let pid_alive pid name =
+  match Forkhelpers.waitpid_nohang pid with
+  | 0, Unix.WEXITED 0 ->
+      true
+  | _, Unix.WEXITED n ->
+      error "%s: unexpected exit with code: %d" name n ;
+      false
+  | _, (Unix.WSIGNALED n | Unix.WSTOPPED n) ->
+      error "%s: unexpected signal: %d" name n ;
+      false
+
 module type DAEMONPIDPATH = sig
   val name : string
 
@@ -340,15 +351,119 @@ module Vgpu = struct
     let pid_path domid = Printf.sprintf "/local/domain/%d/vgpu-pid" domid
   end)
 
-  let start_daemon = D.start_daemon
+  let vgpu_args_of_nvidia domid vcpus vgpus restore =
+    let open Xenops_interface.Vgpu in
+    let virtual_pci_address_compare vgpu1 vgpu2 =
+      match (vgpu1, vgpu2) with
+      | ( {implementation= Nvidia {virtual_pci_address= pci1; _}; _}
+        , {implementation= Nvidia {virtual_pci_address= pci2; _}; _} ) ->
+          Stdlib.compare pci1.dev pci2.dev
+      | other1, other2 ->
+          Stdlib.compare other1 other2
+    in
+    let device_args =
+      let make addr args =
+        Printf.sprintf "--device=%s"
+          (Xcp_pci.string_of_address addr :: args
+          |> List.filter (fun str -> str <> "")
+          |> String.concat ","
+          )
+      in
+      vgpus
+      |> List.sort virtual_pci_address_compare
+      |> List.map (fun vgpu ->
+             let addr =
+               match vgpu.virtual_pci_address with
+               | Some pci ->
+                   pci (* pass VF in case of SRIOV *)
+               | None ->
+                   vgpu.physical_pci_address
+             in
+             (* pass PF otherwise *)
+             match vgpu.implementation with
+             (* 1. Upgrade case, migrate from a old host with old vGPU having
+                config_path 2. Legency case, run with old Nvidia host driver *)
+             | Nvidia
+                 {
+                   virtual_pci_address
+                 ; config_file= Some config_file
+                 ; extra_args
+                 ; _
+                 } ->
+                 (* The VGPU UUID is not available. Create a fresh one; xapi
+                    will deal with it. *)
+                 let uuid = Uuidm.to_string (Uuidm.create `V4) in
+                 debug "NVidia vGPU config: using config file %s and uuid %s"
+                   config_file uuid ;
+                 make addr
+                   [
+                     config_file
+                   ; Xcp_pci.string_of_address virtual_pci_address
+                   ; uuid
+                   ; extra_args
+                   ]
+             | Nvidia
+                 {
+                   virtual_pci_address
+                 ; type_id= Some type_id
+                 ; uuid= Some uuid
+                 ; extra_args
+                 ; _
+                 } ->
+                 debug "NVidia vGPU config: using type id %s and uuid: %s"
+                   type_id uuid ;
+                 make addr
+                   [
+                     type_id
+                   ; Xcp_pci.string_of_address virtual_pci_address
+                   ; uuid
+                   ; extra_args
+                   ]
+             | Nvidia {type_id= None; config_file= None; _} ->
+                 (* No type_id _and_ no config_file: something is wrong *)
+                 raise
+                   (Xenops_interface.Xenopsd_error
+                      (Internal_error
+                         (Printf.sprintf "NVidia vGPU metadata incomplete (%s)"
+                            __LOC__
+                         )
+                      )
+                   )
+             | _ ->
+                 ""
+         )
+    in
+    let suspend_file = Printf.sprintf Device_common.demu_save_path domid in
+    let base_args =
+      [
+        "--domain=" ^ string_of_int domid
+      ; "--vcpus=" ^ string_of_int vcpus
+      ; "--suspend=" ^ suspend_file
+      ]
+      @ device_args
+    in
+    let fd_arg = if restore then ["--resume"] else [] in
+    List.concat [base_args; fd_arg]
+
+  let state_path domid = Printf.sprintf "/local/domain/%d/vgpu/state" domid
+
+  let cancel_key domid = Cancel_utils.Vgpu domid
+
+  let start ~xs ~vcpus ~vgpus ~restore task domid =
+    let args = vgpu_args_of_nvidia domid vcpus vgpus restore in
+    let cancel = cancel_key domid in
+    let pid = D.start_daemon ~path:!Xc_resources.vgpu ~args ~domid ~fds:[] () in
+    wait_path ~pidalive:(pid_alive pid) ~task ~name:D.name ~domid ~xs
+      ~ready_path:(state_path domid)
+      ~timeout:!Xenopsd.vgpu_ready_timeout
+      ~cancel () ;
+    Forkhelpers.dontwaitpid pid
 
   let pid = D.pid
 
   let is_running = D.is_running
 
   let stop = D.stop
-
-  let wait_path = wait_path
 end
 
 module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -255,9 +255,8 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
       match D.pid_location with
       | (File file | Path_of {file; _}) when Sys.file_exists (file domid) ->
           let path = file domid in
-          let pid =
-            path |> Unixext.string_of_file |> String.trim |> int_of_string
-          in
+          let ( let* ) = Option.bind in
+          let* pid = Unixext.pidfile_read path in
           Unixext.with_file path [Unix.O_RDONLY] 0 (fun fd ->
               try
                 Unix.lockf fd Unix.F_TRLOCK 0 ;
@@ -370,9 +369,10 @@ module Qemu = struct
   let is_running = D.is_running
 
   let stop ~xs ~qemu_domid domid =
+    let file_path = pidfile_path domid in
     match pid ~xs domid with
     | None ->
-        () (* nothing to do *)
+        Unixext.unlink_safe file_path
     | Some pid ->
         let xenstore_path = pidxenstore_path domid in
         let best_effort = Xenops_utils.best_effort in
@@ -392,7 +392,6 @@ module Qemu = struct
         best_effort "removing device model path from xenstore" (fun () ->
             xs.Xs.rm (Device_common.device_model_path ~qemu_domid domid)
         ) ;
-        let file_path = pidfile_path domid in
         best_effort (Printf.sprintf "removing %s" file_path) (fun () ->
             Unix.unlink file_path
         )

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -210,12 +210,25 @@ let pid_alive pid name =
       error "%s: unexpected signal: %d" name n ;
       false
 
+let pidfile_path root daemon_name domid =
+  Printf.sprintf "%s/%s-%d.pid" root daemon_name domid
+
+let pidfile_path_tmpfs daemon_name domid =
+  pidfile_path Device_common.var_run_xen_path daemon_name domid
+
+module Pid = struct
+  type both = {key: int -> string; file: int -> string}
+
+  type path =
+    | Xenstore of (int -> string)
+    (* | File of (int -> string) *)
+    | Path_of of both
+end
+
 module type DAEMONPIDPATH = sig
   val name : string
 
-  val use_pidfile : bool
-
-  val pid_path : int -> string
+  val pid_location : Pid.path
 end
 
 module DaemonMgmt (D : DAEMONPIDPATH) = struct
@@ -237,23 +250,23 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
 
   let name = D.name
 
-  let pid_path = D.pid_path
+  let pid_path domid =
+    match D.pid_location with Xenstore key | Path_of {key; _} -> key domid
 
   let pid_path_signal domid = pid_path domid ^ "-signal"
 
   let pidfile_path domid =
-    if D.use_pidfile then
-      Some
-        (Printf.sprintf "%s/%s-%d.pid" Device_common.var_run_xen_path D.name
-           domid
-        )
-    else
-      None
+    match D.pid_location with
+    | Path_of {file; _} ->
+        Some (file domid)
+    | _ ->
+        None
 
   let pid ~xs domid =
     try
-      match pidfile_path domid with
-      | Some path when Sys.file_exists path ->
+      match D.pid_location with
+      | Path_of {file; _} when Sys.file_exists (file domid) ->
+          let path = file domid in
           let pid =
             path |> Unixext.string_of_file |> String.trim |> int_of_string
           in
@@ -267,10 +280,10 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
                 (* cannot obtain lock: process is alive *)
                 Some pid
           )
-      | _ ->
+      | Xenstore key | Path_of {key; _} ->
           (* backward compatibility during update installation: only has
-             xenstore pid *)
-          let pid = xs.Xs.read (pid_path domid) in
+             xenstore pid available *)
+          let pid = xs.Xs.read (key domid) in
           Some (int_of_string pid)
     with _ -> None
 
@@ -337,18 +350,18 @@ end
 module Qemu = DaemonMgmt (struct
   let name = "qemu-dm"
 
-  let use_pidfile = true
-
   let pid_path domid = Printf.sprintf "/local/domain/%d/qemu-pid" domid
+
+  let pid_location = Pid.Path_of {key= pid_path; file= pidfile_path_tmpfs name}
 end)
 
 module Vgpu = struct
   module D = DaemonMgmt (struct
     let name = "vgpu"
 
-    let use_pidfile = false
-
     let pid_path domid = Printf.sprintf "/local/domain/%d/vgpu-pid" domid
+
+    let pid_location = Pid.Xenstore pid_path
   end)
 
   let vgpu_args_of_nvidia domid vcpus vgpus restore =
@@ -513,7 +526,9 @@ module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
   let start_daemon ~path ~args ~domid () =
     debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
     let service = Compat.syslog_key ~domid in
-    let pidpath = D.pid_path domid in
+    let pidpath =
+      match D.pid_location with Xenstore key | Path_of {key; _} -> key domid
+    in
     let properties =
       ("ExecStopPost", "-/usr/bin/xenstore-rm " ^ pidpath)
       ::
@@ -533,9 +548,10 @@ module Varstored = struct
   module D = SystemdDaemonMgmt (struct
     let name = "varstored"
 
-    let use_pidfile = true
-
     let pid_path domid = Printf.sprintf "/local/domain/%d/varstored-pid" domid
+
+    let pid_location =
+      Pid.Path_of {key= pid_path; file= pidfile_path_tmpfs name}
   end)
 
   let efivars_resume_path =
@@ -615,9 +631,10 @@ module Swtpm = struct
   module D = SystemdDaemonMgmt (struct
     let name = "swtpm-wrapper"
 
-    let use_pidfile = false
-
     let pid_path domid = Printf.sprintf "/local/domain/%d/varstored-pid" domid
+
+    (* XXX: the xenstore key is not used, the daemon should define the pidfile *)
+    let pid_location = Pid.Xenstore pid_path
   end)
 
   let xs_path ~domid = Device_common.get_private_path domid ^ "/vtpm"
@@ -716,9 +733,9 @@ module PV_Vnc = struct
   module D = DaemonMgmt (struct
     let name = "vncterm"
 
-    let use_pidfile = false
-
     let pid_path domid = Printf.sprintf "/local/domain/%d/vncterm-pid" domid
+
+    let pid_location = Pid.Xenstore pid_path
   end)
 
   let vnc_console_path domid = Printf.sprintf "/local/domain/%d/console" domid

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -13,3 +13,127 @@ type t = {
 
 val start_and_wait_for_readyness :
   task:Xenops_task.Xenops_task.task_handle -> service:t -> unit
+
+module Qemu : sig
+  module SignalMask : sig
+    type t
+
+    val create : unit -> t
+
+    val set : t -> int -> unit
+
+    val unset : t -> int -> unit
+
+    val has : t -> int -> bool
+  end
+
+  val signal_mask : SignalMask.t
+
+  val name : string
+
+  val pid_path_signal : Xenctrl.domid -> string
+
+  val pidfile_path : Xenctrl.domid -> string option
+  (** path of file containing the pid value *)
+
+  val pid_path : Xenctrl.domid -> string
+  (** xenstore key containing the pid value *)
+
+  val start_daemon :
+       path:string
+    -> args:string list
+    -> domid:Xenctrl.domid
+    -> ?fds:(string * Unix.file_descr) list
+    -> unit
+    -> Forkhelpers.pidty
+
+  val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+
+  val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
+end
+
+module Vgpu : sig
+  val start_daemon :
+       path:string
+    -> args:string list
+    -> domid:Xenctrl.domid
+    -> ?fds:(string * Unix.file_descr) list
+    -> unit
+    -> Forkhelpers.pidty
+
+  val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+
+  val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
+
+  val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+end
+
+module PV_Vnc : sig
+  exception Failed_to_start
+
+  val vnc_port_path : Xenctrl.domid -> string
+
+  val tc_port_path : Xenctrl.domid -> string
+
+  val save : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+
+  val get_statefile : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> string option
+
+  val start :
+       ?statefile:string
+    -> xs:Xenstore.Xs.xsh
+    -> ?ip:string
+    -> Xenctrl.domid
+    -> unit
+
+  val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+
+  val get_vnc_port :
+    xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Xenops_utils.Socket.t option
+
+  val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+end
+
+module Varstored : sig
+  val pidfile_path : Xenctrl.domid -> string option
+  (** path of file containing the pid value *)
+
+  val pid_path : Xenctrl.domid -> string
+  (** xenstore key containing the pid value *)
+
+  val start_daemon :
+    path:string -> args:string list -> domid:Xenctrl.domid -> unit -> string
+
+  val alive : string -> 'a -> bool
+
+  val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+end
+
+module Swtpm : sig
+  val state_path : Xenops_sandbox.Chroot.Path.t
+
+  val start_daemon :
+       string
+    -> xs:Xenstore.Xs.xsh
+    -> chroot:Xenops_sandbox.Chroot.t
+    -> path:string
+    -> args:string list
+    -> domid:Xenctrl.domid
+    -> vm_uuid:string
+    -> vtpm_uuid:Varstore_privileged_interface.Uuidm.t
+    -> index:int
+    -> unit
+    -> string
+
+  val restore : domid:int -> vm_uuid:string -> string -> unit
+
+  val suspend : xs:Xenstore.Xs.xsh -> domid:int -> vm_uuid:string -> string
+
+  val stop :
+       string
+    -> xs:Xenstore.Xs.xsh
+    -> domid:int
+    -> vm_uuid:string
+    -> vtpm_uuid:Varstore_privileged_interface.Uuidm.t
+    -> unit
+end

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -52,6 +52,18 @@ module Vgpu : sig
   val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
 
   val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+
+  val wait_path :
+       pidalive:(string -> bool)
+    -> task:Xenops_task.Xenops_task.task_handle
+    -> name:string
+    -> domid:int
+    -> xs:Xenstore.Xs.xsh
+    -> ready_path:Watch.path
+    -> timeout:float
+    -> cancel:Cancel_utils.key
+    -> 'a
+    -> unit
 end
 
 module PV_Vnc : sig
@@ -81,16 +93,17 @@ module PV_Vnc : sig
 end
 
 module Varstored : sig
-  val pidfile_path : Xenctrl.domid -> string option
-  (** path of file containing the pid value *)
+  val efivars_save_path : Xenops_sandbox.Chroot.Path.t
 
-  val pid_path : Xenctrl.domid -> string
-  (** xenstore key containing the pid value *)
+  val efivars_resume_path : Xenops_sandbox.Chroot.Path.t
 
-  val start_daemon :
-    path:string -> args:string list -> domid:Xenctrl.domid -> unit -> string
-
-  val alive : string -> 'a -> bool
+  val start :
+       xs:Xenstore.Xs.xsh
+    -> nvram:Xenops_types.Nvram_uefi_variables.t
+    -> ?restore:bool
+    -> Xenops_task.Xenops_task.task_handle
+    -> Xenctrl.domid
+    -> unit
 
   val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
 end

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -1,19 +1,5 @@
 exception Service_failed of (string * string)
 
-type t = {
-    name: string
-  ; domid: Xenctrl.domid
-  ; exec_path: string
-  ; chroot: Xenops_sandbox.Chroot.t
-  ; timeout_seconds: float
-  ; args: string list
-  ; execute:
-      path:string -> args:string list -> domid:Xenctrl.domid -> unit -> string
-}
-
-val start_and_wait_for_readyness :
-  task:Xenops_task.Xenops_task.task_handle -> service:t -> unit
-
 module Qemu : sig
   module SignalMask : sig
     type t
@@ -110,19 +96,12 @@ module Varstored : sig
 end
 
 module Swtpm : sig
-  val state_path : Xenops_sandbox.Chroot.Path.t
-
-  val start_daemon :
-       string
-    -> xs:Xenstore.Xs.xsh
-    -> chroot:Xenops_sandbox.Chroot.t
-    -> path:string
-    -> args:string list
-    -> domid:Xenctrl.domid
-    -> vm_uuid:string
+  val start :
+       xs:Xenstore.Xs.xsh
     -> vtpm_uuid:Varstore_privileged_interface.Uuidm.t
     -> index:int
-    -> unit
+    -> Xenops_task.Xenops_task.task_handle
+    -> Xenctrl.domid
     -> string
 
   val restore : domid:int -> vm_uuid:string -> string -> unit

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -39,31 +39,24 @@ module Qemu : sig
 end
 
 module Vgpu : sig
-  val start_daemon :
-       path:string
-    -> args:string list
-    -> domid:Xenctrl.domid
-    -> ?fds:(string * Unix.file_descr) list
+  val start :
+       xs:Xenstore.Xs.xsh
+    -> vcpus:int
+    -> vgpus:Xenops_interface.Vgpu.t list
+    -> restore:bool
+    -> Xenops_task.Xenops_task.task_handle
+    -> int
     -> unit
-    -> Forkhelpers.pidty
+
+  val cancel_key : Xenctrl.domid -> Cancel_utils.key
+
+  val state_path : Xenctrl.domid -> string
 
   val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 
   val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
 
   val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
-
-  val wait_path :
-       pidalive:(string -> bool)
-    -> task:Xenops_task.Xenops_task.task_handle
-    -> name:string
-    -> domid:int
-    -> xs:Xenstore.Xs.xsh
-    -> ready_path:Watch.path
-    -> timeout:float
-    -> cancel:Cancel_utils.key
-    -> 'a
-    -> unit
 end
 
 module PV_Vnc : sig

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -17,13 +17,10 @@ module Qemu : sig
 
   val name : string
 
-  val pid_path_signal : Xenctrl.domid -> string
+  val pidxenstore_path_signal : Xenctrl.domid -> string
 
-  val pidfile_path : Xenctrl.domid -> string option
+  val pidfile_path : Xenctrl.domid -> string
   (** path of file containing the pid value *)
-
-  val pid_path : Xenctrl.domid -> string
-  (** xenstore key containing the pid value *)
 
   val start_daemon :
        path:string
@@ -36,6 +33,9 @@ module Qemu : sig
   val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 
   val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
+
+  val stop :
+    xs:Xenstore.Xs.xsh -> qemu_domid:Xenctrl.domid -> Xenctrl.domid -> unit
 end
 
 module Vgpu : sig

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -4877,7 +4877,7 @@ module Actions = struct
     ; sprintf "/local/domain/%d/memory/uncooperative" domid
     ; sprintf "/local/domain/%d/console/vnc-port" domid
     ; sprintf "/local/domain/%d/console/tc-port" domid
-    ; Service.Qemu.pid_path_signal domid
+    ; Service.Qemu.pidxenstore_path_signal domid
     ; sprintf "/local/domain/%d/control" domid
     ; sprintf "/local/domain/%d/device" domid
     ; sprintf "/local/domain/%d/rrd" domid
@@ -5054,7 +5054,7 @@ module Actions = struct
         debug "Ignoring qemu-pid-signal watch on shutdown domain %d" d
       else
         let signal =
-          try Some (xs.Xs.read (Service.Qemu.pid_path_signal d))
+          try Some (xs.Xs.read (Service.Qemu.pidxenstore_path_signal d))
           with _ -> None
         in
         match signal with


### PR DESCRIPTION
The PR is better reviewed commit-by-commit. The biggest change (https://github.com/xapi-project/xen-api/pull/4720/commits/10c0291ec1f085e66684d3f445727df7a6f8924a) should only move around the code and only modify the callers' side.

Xenops and the daemons until now have used 2 ways of communicating the pid to the former: a xenstore key and optionally a file. We want to move to a model where we can use only a pidfile for some daemons (SWTPM, mainly).

Previously the path pidfile was implicit and the code to fetch it was shared among all the daemons meaning that even if the daemon always provided a pidfile, their clients always had to take into account the case where there was no file to process.

These changes force all the damon modules to declare the locations where the pidfile is expected to be, and only expose the pidfile in the way the daemon actually uses it.

Having all this logic in a separate module also help us to maintain an interface and not allow clients to access all the internal workings, facilitating future refactors (on how to wait for a daemon, for example)

vTPM suite: SR 170394 green
ring3 BVT+BST: SR170395 green