### PR TITLE
Fix date representations for CH Center

### DIFF
--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -203,7 +203,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~display:`enabled ~virtual_hardware_platform_versions:[]
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
-    ~tls_verification_enabled ~last_software_update:(Date.localtime ()) ;
+    ~tls_verification_enabled
+    ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref) ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/util/gen_build_info_ml.sh
+++ b/ocaml/util/gen_build_info_ml.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-DATE=$(date "+%Y-%m-%d")
+DATE=$(date -u "+%Y%m%dT%H:%M:%SZ")
 
 if [[ -z "$XAPI_VERSION" ]]; then
   printf "XAPI_VERSION not set" 1>&2


### PR DESCRIPTION
Citrix Hypervisor center receives dates via XMLRPC and JSON RPC. Recently introduced dates don't conform to the XMLRPC date format - so fix these. The format itself is a somewhat questionable interpretation for ISO8601 because it mixes no punctuation for the the date with punctuation for the time but this is the format provided in examples by http://xmlrpc.com/spec.md. See the commit messages for details.

