### PR TITLE
Some SDK fixes

### DIFF
--- a/ocaml/sdk-gen/csharp/autogen/src/Session.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Session.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 
 using CookComputing.XmlRpc;
@@ -404,11 +405,12 @@ namespace XenAPI
         private void SetAPIVersion()
         {
             Dictionary<XenRef<Pool>, Pool> pools = Pool.get_all_records(this);
-            foreach (Pool pool in pools.Values)
+
+            if (pools.Values.Count > 0)
             {
+                var pool = pools.Values.First();
                 Host host = Host.get_record(this, pool.master);
                 APIVersion = Helper.GetAPIVersion(host.API_version_major, host.API_version_minor);
-                break;
             }
         }
 

--- a/ocaml/sdk-gen/csharp/autogen/src/XenObject.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/XenObject.cs
@@ -40,10 +40,10 @@ namespace XenAPI
     public abstract partial class XenObject<S> : IXenObject where S : XenObject<S>
     {
         /// <summary>
-        /// Copies properties from 'update' into this object. It uses property setters so that
+        /// Copies properties from a given object into this object. It uses property setters so that
         /// event handlers are triggered if the value is changing.
         /// </summary>
-        public abstract void UpdateFrom(S update);
+        public abstract void UpdateFrom(S record);
 
         /// <summary>
         /// Save any changed fields to the server.

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -43,16 +43,13 @@ module TypeSet = Set.Make (struct
   let compare = compare
 end)
 
-let get_deprecated_attribute_string version =
+let get_deprecated_attribute message =
+  let version = message.msg_release.internal_deprecated_since in
   match version with
   | None ->
       ""
   | Some versionString ->
-      "[Deprecated(\"" ^ get_release_name versionString ^ "\")]"
-
-let get_deprecated_attribute message =
-  let version = message.msg_release.internal_deprecated_since in
-  get_deprecated_attribute_string version
+      "[Deprecated(\"" ^ get_release_branding versionString ^ "\")]"
 
 let destdir = "autogen/src"
 
@@ -288,7 +285,7 @@ and gen_class out_chan cls =
   let exposed_class_name = exposed_class_name cls.name in
   let messages =
     List.filter
-      (fun msg -> String.compare msg.msg_name "get_all_records_where" != 0)
+      (fun msg -> String.compare msg.msg_name "get_all_records_where" <> 0)
       cls.messages
   in
   let contents = cls.contents in
@@ -617,12 +614,11 @@ and gen_to_proxy_line out_chan content =
       List.iter (gen_to_proxy_line out_chan) c
 
 and gen_overloads generator message =
-  let methodParams = get_method_params_list message in
-  match methodParams with
+  match message.msg_params with
   | [] ->
       [generator []]
   | _ ->
-      let paramGroups = gen_param_groups message methodParams in
+      let paramGroups = gen_param_groups message message.msg_params in
       List.map generator paramGroups
 
 and gen_exposed_method cls msg curParams =

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -433,16 +433,15 @@ let gen_method file cls message params async_version =
 (*Some methods have an almost identical asynchronous counterpart, which returns*)
 (* a Task reference rather than its usual return value*)
 let gen_method_and_asynchronous_counterpart file cls message =
-  let methodParams = get_method_params_list message in
   let generator x =
     if message.msg_async then gen_method file cls message x true ;
     gen_method file cls message x false
   in
-  match methodParams with
+  match message.msg_params with
   | [] ->
       generator []
   | _ ->
-      let paramGroups = gen_param_groups message methodParams in
+      let paramGroups = gen_param_groups message message.msg_params in
       List.iter generator paramGroups
 
 (* Generate the record *)

--- a/ocaml/sdk-gen/powershell/common_functions.ml
+++ b/ocaml/sdk-gen/powershell/common_functions.ml
@@ -58,10 +58,8 @@ let rec pascal_case_ s =
 and pascal_case s =
   let str = pascal_case_ s in
   if
-    String.length str > 3
-    && (String.lowercase_ascii (String.sub str 0 3) = "set"
-       || String.lowercase_ascii (String.sub str 0 3) = "get"
-       )
+    String.starts_with ~prefix:"set" (String.lowercase_ascii str)
+    || String.starts_with ~prefix:"get" (String.lowercase_ascii str)
   then
     String.sub str 3 (String.length str - 3)
   else

--- a/ocaml/sdk-gen/powershell/common_functions.ml
+++ b/ocaml/sdk-gen/powershell/common_functions.ml
@@ -31,6 +31,7 @@
 open Printf
 open Datamodel
 open Datamodel_types
+open CommonFunctions
 module DU = Datamodel_utils
 
 let rec pascal_case_ s =
@@ -203,27 +204,6 @@ and is_invoke message =
   && (not (is_remover message))
   && (not (is_constructor message))
   && not (is_destructor message)
-
-and is_setter message =
-  String.length message.msg_name >= 3 && String.sub message.msg_name 0 3 = "set"
-
-and is_getter message =
-  String.length message.msg_name >= 3 && String.sub message.msg_name 0 3 = "get"
-
-and is_adder message =
-  String.length message.msg_name >= 3 && String.sub message.msg_name 0 3 = "add"
-
-and is_remover message =
-  String.length message.msg_name >= 6
-  && String.sub message.msg_name 0 6 = "remove"
-
-and is_constructor message =
-  message.msg_tag = FromObject Make || message.msg_name = "create"
-
-and is_real_constructor message = message.msg_tag = FromObject Make
-
-and is_destructor message =
-  message.msg_tag = FromObject Delete || message.msg_name = "destroy"
 
 (* Some adders/removers are just prefixed by Add or RemoveFrom
    and some are prefixed by AddTo or RemoveFrom *)


### PR DESCRIPTION
The following commits have already been reviewed within XenCenter, so they can be ignored:

- CP-37091: Do not use a loop for only one iteration. https://github.com/xenserver/xenadmin/pull/2985
- CA-365905 (XSI-1215): Create a temporary file in the target download folder instead of the user's temp folder if the latter is in a different drive from the target folder. https://github.com/xenserver/xenadmin/pull/2993

These are new changes:

- Renamed parameter of abstract method to match the parameter name in the method's implementations.
- CA-355432: Fixed generation of method overloads.

The last commit, apart from the bug referenced, it also contains the SDK counterpart of CP-38610.