### PR TITLE
xenopsd/xc: do not log error when querying for migrability

### DIFF
--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -3345,7 +3345,7 @@ module Backend = struct
       let path = Dm_Common.cant_suspend_reason_path domid in
       (* This will raise QMP_Error if it can't do it, we catch it and update
          xenstore. *)
-      match qmp_send_cmd domid Qmp.Query_migratable with
+      match qmp_send_cmd ~may_fail:true domid Qmp.Query_migratable with
       | Qmp.Unit ->
           debug "query-migratable precheck passed (domid=%d)" domid ;
           Generic.safe_rm ~xs path

--- a/ocaml/xenopsd/xc/device_common.mli
+++ b/ocaml/xenopsd/xc/device_common.mli
@@ -149,7 +149,8 @@ val xenops_vgpu_path : Xenctrl.domid -> devid -> string
 val is_upstream_qemu : Xenctrl.domid -> bool
 
 val qmp_send_cmd :
-     ?send_fd:Unix.file_descr (* send this fd ahead of command *)
+     ?send_fd:Unix.file_descr (** send this fd ahead of command *)
+  -> ?may_fail:bool (** wether QMP returning an error is an expected response *)
   -> Xenctrl.domid
   -> Qmp.command
   -> Qmp.result


### PR DESCRIPTION
QMP usually returns an error because nvmes are not migratable, but this
is expected, it doesn't make sense to log  this as an error.