### PR TITLE
Short-circuit auth of HTTP requests without auth header

### DIFF
--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -93,7 +93,7 @@ let create_session_for_client_cert req s =
       Xapi_session.login_with_password ~__context ~uname:"" ~pwd:""
         ~version:Datamodel_common.api_version_string
         ~originator:Constants.xapi_user_agent
-  | _ ->
+  | Some `root | None ->
       raise (Http.Unauthorised "")
 
 let assert_credentials_ok realm ?(http_action = realm) ?(fn = Rbac.nofn)


### PR DESCRIPTION
A HTTP request to XAPI will be authenticated by:
1. session in header,
2. pool secret in header,
3. username and password in header, or
4. client certificate

Therefore, if there is no auth header (1, 2, or 3 above) in the HTTP
request, it should be confirmed that if the request has been
authenticated by client certificate.

The 'Xapi_session.login_with_password' is re-used in
'create_session_for_client_cert' for this purpose. Meanwhile, this
funciton will perform RBAC checking as well.

Prior to this commit, a HTTP request without auth header would be checked
by 'create_session_for_client_cert'. But the 'login_with_password' called
in it would have a long journey since 'create_session_for_client_cert'
feeds empty 'uname' and 'pwd' to 'login_with_password'. This long journey
includes local auth and external auth if it is enabled. Especially the
external auth would take long duration which may block successive
authentications.

The fix is to short-circuit the authentication in this case as it is
already known that if the HTTP request has been authenticated by client
certificate. If it is, only RBAC checking will be required to be done by
'login_with_password'. Otherwise it is not necessary to perform
authentication further.

Signed-off-by: Ming Lu <ming.lu@citrix.com>