### PR TITLE
CP-39996: Generate and push docs to xapi-storage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Generate and upload docs
+
+on:
+  push:
+    branches: master
+
+jobs:
+  ocaml:
+    name: Docs
+    runs-on: ubuntu-20.04
+    env:
+      XAPI_VERSION: "v0.0.0-${{ github.sha }}"
+      STORAGE_DOCDIR: .gh-pages-xapi-storage
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Pull configuration from xs-opam
+        run: |
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+
+      - name: Load environment file
+        id: dotenv
+        uses: falti/dotenv-action@v0.2.8
+
+      - name: Use ocaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
+          dune-cache: true
+
+      - name: Install dependencies
+        run: |
+          opam install . --deps-only --with-doc -v
+
+      - name: Generate xapi-storage docs
+        run: |
+          mkdir $STORAGE_DOCDIR
+          opam exec -- dune exec ocaml/xapi-storage/generator/src/main.exe -- gen_markdown --path=$STORAGE_DOCDIR
+
+      - name: Deploy xapi-storage docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_STORAGE_DEPLOY_KEY }}
+          publish_dir: ${{ env.STORAGE_DOCDIR }}
+          user_name: 'Github action on xapi-project/xen-api'
+          user_email: 'github-actions-xapi-project-xen-api[bot]@users.noreply.github.com'
+          external_repository: xapi-project/xapi-storage
+          publish_branch: slate
+          destination_dir: source/includes/
+          allow_empty_commit: false
+          enable_jekyll: true # do not create .nojekyll file


### PR DESCRIPTION
Xapi-storage still hosts the documentation for SMAPIv3, so to keep it up-to-date this repository needs to push the changes to xapi-project/xapi-storage.

Tested manually that this correctly updates the correct branch. The first commit will create a `.nojekyll` file once this is merged to master. This is expected as the documentation files have not changed since the last commit and the file is specific to github's pages to avoid its internal jekyll deployment.  Currently the deploy action avoids pushing empty commits, so only changes will create documentation pushes.

I believe there might be a step missing to actually publish to github pages but that can be dealt with a github action in xapi-storage.
