### PR TITLE
CP-39806: remove code without a stable formatting

### DIFF
--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -1235,22 +1235,32 @@ let logout_subject_identifier ~__context ~subject_identifier =
   let all_sessions = Db.Session.get_all ~__context in
   let current_session = Context.get_session_id __context in
   (* we filter the sessions to be destroyed *)
+  (* 1. we never allow local_superuser sessions to be forcibly logged out *)
+  let is_not_local_superuser s =
+    not (Db.Session.get_is_local_superuser ~__context ~self:s)
+  in
+  (* 2. we remove the session associated with this function call from the list
+        of all sessions to be destroyed *)
+  let is_not_current_session s =
+    Db.Session.get_uuid ~__context ~self:s
+    <> Db.Session.get_uuid ~__context ~self:current_session
+  in
+  (* 3. we only consider those sessions associated with the specific subject_id
+        received as parameter *)
+  let is_associated_with_user_logging_out s =
+    (* TODO: better to look up the membership closure *)
+    (* 3.1. the sid of the authenticated user or
+       3.2. any sids of the group that authenticated the user *)
+    Db.Session.get_auth_user_sid ~__context ~self:s = subject_identifier
+    || get_group_subject_identifier_from_session ~__context ~session:s
+       = subject_identifier
+  in
   let sessions =
     List.filter
       (fun s ->
-        (* 1. we never allow local_superuser sessions to be forcibly logged out *)
-        (not (Db.Session.get_is_local_superuser ~__context ~self:s))
-        (* 2. we remove the session associated with this function call from the list of all sessions to be destroyed *)
-        && Db.Session.get_uuid ~__context ~self:s
-           <> Db.Session.get_uuid ~__context ~self:current_session
-        && (* 3. we only consider those sessions associated with the specific subject_id received as parameter *)
-        ((* 3.1. the sid of the authenticated user *)
-         Db.Session.get_auth_user_sid ~__context ~self:s = subject_identifier
-        || (* 3.2. any sids of the group that authenticated the user *)
-           (* TODO: better to look up the membership closure *)
-        get_group_subject_identifier_from_session ~__context ~session:s
-        = subject_identifier
-        )
+        is_not_local_superuser s
+        && is_not_current_session s
+        && is_associated_with_user_logging_out s
       )
       all_sessions
   in


### PR DESCRIPTION
newer ocamlformat are unable to reach a stable format for code that
has long comment inside long boolean expressions, change the code so an
ocamlformat version compatible with ocaml 4.14 can be used to format the
code.

See https://github.com/ocaml-ppx/ocamlformat/issues/2057 