### PR TITLE
Compression of migration streams

### DIFF
--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1539,6 +1539,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
           ; "remote-network"
           ; "force"
           ; "copy"
+          ; "compress"
           ; "vif:"
           ; "vdi:"
           ]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -4434,7 +4434,10 @@ let vm_migrate printer rpc session_id params =
   let options =
     Listext.map_assoc_with_key
       (comp2 string_of_bool bool_of_string)
-      (Listext.restrict_with_default "false" ["force"; "live"; "copy"] params)
+      (Listext.restrict_with_default "false"
+         ["force"; "live"; "copy"; "compress"]
+         params
+      )
   in
   (* We assume the user wants to do Storage XenMotion if they supply any of the
      SXM-specific parameters, and then we use the new codepath. *)
@@ -4660,6 +4663,7 @@ let vm_migrate printer rpc session_id params =
                   :: "live"
                   :: "force"
                   :: "copy"
+                  :: "compress"
                   :: vm_migrate_sxm_params
                   )
               in
@@ -4773,7 +4777,7 @@ let vm_migrate printer rpc session_id params =
              ~options
          )
          params
-         ["host"; "host-uuid"; "host-name"; "live"]
+         ["host"; "host-uuid"; "host-name"; "live"; "compress"]
       )
   )
 

--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -660,6 +660,11 @@ module XenopsAPI (R : RPC) = struct
           ~description:["URL on which the remote xenopsd can be contacted"]
           Types.string
       in
+      let compress =
+        Param.mk ~name:"compress"
+          ~description:["when true, use stream compression"]
+          Types.bool
+      in
       declare "VM.migrate" []
         (debug_info_p
         @-> vm_id_p
@@ -667,6 +672,7 @@ module XenopsAPI (R : RPC) = struct
         @-> vifmap
         @-> pcimap
         @-> xenops_url
+        @-> compress
         @-> returning task_id_p err
         )
 

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -116,6 +116,20 @@ end))
 
 open Storage_interface
 
+let get_bool_option ~default key values =
+  match List.assoc_opt key values with
+  | Some word -> (
+    match String.lowercase_ascii word with
+    | "true" | "on" | "1" ->
+        true
+    | "false" | "off" | "0" ->
+        false
+    | _ ->
+        default
+  )
+  | None ->
+      default
+
 let assert_sr_support_operations ~__context ~vdi_map ~remote ~ops =
   let op_supported_on_source_sr vdi ops =
     (* Check VDIs must not be present on SR which doesn't have required capability *)
@@ -203,7 +217,7 @@ let assert_licensed_storage_motion ~__context =
   Pool_features.assert_enabled ~__context ~f:Features.Storage_motion
 
 let rec migrate_with_retries ~__context queue_name max try_no dbg vm_uuid
-    xenops_vdi_map xenops_vif_map xenops_vgpu_map xenops =
+    xenops_vdi_map xenops_vif_map xenops_vgpu_map xenops compress =
   let open Xapi_xenops_queue in
   let module Client = (val make_client queue_name : XENOPS) in
   let progress = ref "(none yet)" in
@@ -211,7 +225,7 @@ let rec migrate_with_retries ~__context queue_name max try_no dbg vm_uuid
     progress := "Client.VM.migrate" ;
     let t1 =
       Client.VM.migrate dbg vm_uuid xenops_vdi_map xenops_vif_map
-        xenops_vgpu_map xenops
+        xenops_vgpu_map xenops compress
     in
     progress := "sync_with_task" ;
     ignore (Xapi_xenops.sync_with_task __context queue_name t1)
@@ -237,7 +251,7 @@ let rec migrate_with_retries ~__context queue_name max try_no dbg vm_uuid
           "xenops: will retry migration: caught %s from %s in attempt %d of %d."
           (Printexc.to_string e) !progress try_no max ;
         migrate_with_retries ~__context queue_name max (try_no + 1) dbg vm_uuid
-          xenops_vdi_map xenops_vif_map xenops_vgpu_map xenops
+          xenops_vdi_map xenops_vif_map xenops_vgpu_map xenops compress
     (* Something else went wrong *)
     | e ->
         debug
@@ -344,6 +358,12 @@ let pool_migrate ~__context ~vm ~host ~options =
         .assert_valid_ip_configuration_on_network_for_host ~__context
           ~self:network ~host
   in
+  let compress =
+    (* don't use compression for localhost migration *)
+    let is_local = host = Helpers.get_localhost ~__context in
+    get_bool_option ~default:false "compress" options && not is_local
+  in
+  debug "%s using stream compression=%b" __FUNCTION__ compress ;
   let ip = Http.Url.maybe_wrap_IPv6_literal address in
   let xenops_url =
     Printf.sprintf "http://%s/services/xenops?session_id=%s" ip session_id
@@ -370,7 +390,7 @@ let pool_migrate ~__context ~vm ~host ~options =
             Xapi_xenops.transform_xenops_exn ~__context ~vm queue_name
               (fun () ->
                 migrate_with_retry ~__context queue_name dbg vm_uuid [] []
-                  xenops_vgpu_map xenops_url ;
+                  xenops_vgpu_map xenops_url compress ;
                 (* Delete all record of this VM locally (including caches) *)
                 Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid
             )
@@ -1104,6 +1124,8 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
   (* Copy mode means we don't destroy the VM on the source host. We also don't
      	   copy over the RRDs/messages *)
   let copy = try bool_of_string (List.assoc "copy" options) with _ -> false in
+  let compress = get_bool_option ~default:false "compress" options in
+  debug "%s using stream compression=%b" __FUNCTION__ compress ;
 
   (* The first thing to do is to create mirrors of all the disks on the remote.
      We look through the VM's VBDs and all of those of the snapshots. We then
@@ -1460,7 +1482,8 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
                 infer_vgpu_map ~__context ~remote new_vm
               in
               migrate_with_retry ~__context queue_name dbg vm_uuid
-                xenops_vdi_map xenops_vif_map xenops_vgpu_map remote.xenops_url ;
+                xenops_vdi_map xenops_vif_map xenops_vgpu_map remote.xenops_url
+                compress ;
               Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid
           )
         with

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -359,9 +359,8 @@ let pool_migrate ~__context ~vm ~host ~options =
           ~self:network ~host
   in
   let compress =
-    (* don't use compression for localhost migration *)
     let is_local = host = Helpers.get_localhost ~__context in
-    get_bool_option ~default:false "compress" options && not is_local
+    not is_local
   in
   debug "%s using stream compression=%b" __FUNCTION__ compress ;
   let ip = Http.Url.maybe_wrap_IPv6_literal address in

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -1004,10 +1004,17 @@ let resume _copts disk x =
 
 let resume copts disk x = diagnose_error (need_vm (resume copts disk) x)
 
-let migrate x url =
+let migrate x url compress =
   let open Vm in
   let vm, _ = find_by_name x in
-  Client.VM.migrate dbg vm.id [] [] [] url |> wait_for_task dbg
+  let compress =
+    match String.lowercase_ascii compress with
+    | "t" | "true" | "on" | "1" ->
+        true
+    | _ ->
+        false
+  in
+  Client.VM.migrate dbg vm.id [] [] [] url compress |> wait_for_task dbg
 
 let trim limit str =
   let l = String.length str in
@@ -1525,7 +1532,9 @@ let old_main () =
   | ["help"] | [] ->
       usage () ; exit 0
   | ["migrate"; id; url] ->
-      migrate id url |> task
+      migrate id url "false" |> task
+  | ["migrate"; id; url; compress] ->
+      migrate id url compress |> task
   | ["vbd-list"; id] ->
       vbd_list id
   | ["pci-add"; id; idx; bdf] ->

--- a/ocaml/xenopsd/lib/dune
+++ b/ocaml/xenopsd/lib/dune
@@ -10,6 +10,8 @@
    fmt
    forkexec
    re
+   gzip
+   zstd
    result
    rpclib.core
    rpclib.json

--- a/ocaml/xenopsd/lib/xenops_migrate.ml
+++ b/ocaml/xenopsd/lib/xenops_migrate.ml
@@ -42,7 +42,7 @@ module Handshake = struct
     if n < len then really_read fd buf (ofs + n) (len - n)
 
   (** Receive a 'result' from the remote *)
-  let recv ?(verbose = false) (s : Unix.file_descr) : result =
+  let recv ?(verbose = true) (s : Unix.file_descr) : result =
     let buf = Bytes.make 2 '\000' in
     if verbose then
       debug "Handshake.recv: about to read result code from remote." ;
@@ -78,7 +78,7 @@ module Handshake = struct
         raise (Remote_failed ("error from remote: " ^ x))
 
   (** Transmit a 'result' to the remote *)
-  let send ?(verbose = false) (s : Unix.file_descr) (r : result) =
+  let send ?(verbose = true) (s : Unix.file_descr) (r : result) =
     let len = match r with Success -> 0 | Error msg -> String.length msg in
     let buf = Bytes.make (2 + len) '\000' in
     Bytes.set buf 0 @@ char_of_int ((len lsr 8) land 0xff) ;


### PR DESCRIPTION

Using Zstd to compress the memory stream during migration. This is beneficial when network capacity is limited, especially when migrating multiple VMs.