### PR TITLE
CP-39806: avoid opening Threadext modules

### DIFF
--- a/ocaml/database/database_server_main.ml
+++ b/ocaml/database/database_server_main.ml
@@ -1,5 +1,4 @@
 open Xapi_stdext_unix
-open Xapi_stdext_threads.Threadext
 
 type mode =
   | Slave of string
@@ -91,7 +90,7 @@ let _ =
           finished := true
         ) ;
         (* Wait for either completion *)
-        Mutex.execute m (fun () ->
+        Xapi_stdext_threads.Threadext.Mutex.execute m (fun () ->
             while not !finished do
               Condition.wait c m
             done

--- a/ocaml/database/db_backend.ml
+++ b/ocaml/database/db_backend.ml
@@ -83,27 +83,27 @@ let db_registration_mutex = Mutex.create ()
 
 let foreign_databases : (string, Db_ref.t) Hashtbl.t = Hashtbl.create 5
 
-open Xapi_stdext_threads.Threadext
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 let create_registered_session create_session db_ref =
-  Mutex.execute db_registration_mutex (fun () ->
+  with_lock db_registration_mutex (fun () ->
       let session = create_session () in
       Hashtbl.replace foreign_databases session db_ref ;
       session
   )
 
 let unregister_session session =
-  Mutex.execute db_registration_mutex (fun () ->
+  with_lock db_registration_mutex (fun () ->
       Hashtbl.remove foreign_databases session
   )
 
 let is_session_registered session =
-  Mutex.execute db_registration_mutex (fun () ->
+  with_lock db_registration_mutex (fun () ->
       Hashtbl.mem foreign_databases session
   )
 
 let get_registered_database session =
-  Mutex.execute db_registration_mutex (fun () ->
+  with_lock db_registration_mutex (fun () ->
       if Hashtbl.mem foreign_databases session then
         Some (Hashtbl.find foreign_databases session)
       else

--- a/ocaml/database/db_connections.ml
+++ b/ocaml/database/db_connections.ml
@@ -62,19 +62,19 @@ let preferred_write_db () = List.hd (Db_conn_store.read_db_connections ())
 let exit_on_next_flush = ref false
 
 (* db flushing thread refcount: the last thread out of the door does the exit(0) when flush_on_exit is true *)
-open Xapi_stdext_threads
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 let db_flush_thread_refcount_m = Mutex.create ()
 
 let db_flush_thread_refcount = ref 0
 
 let inc_db_flush_thread_refcount () =
-  Threadext.Mutex.execute db_flush_thread_refcount_m (fun () ->
+  with_lock db_flush_thread_refcount_m (fun () ->
       db_flush_thread_refcount := !db_flush_thread_refcount + 1
   )
 
 let dec_and_read_db_flush_thread_refcount () =
-  Threadext.Mutex.execute db_flush_thread_refcount_m (fun () ->
+  with_lock db_flush_thread_refcount_m (fun () ->
       db_flush_thread_refcount := !db_flush_thread_refcount - 1 ;
       !db_flush_thread_refcount
   )

--- a/ocaml/database/db_lock.ml
+++ b/ocaml/database/db_lock.ml
@@ -13,7 +13,6 @@
  *)
 (* Lock shared between client/slave implementations *)
 
-open Xapi_stdext_threads.Threadext
 open Xapi_stdext_pervasives.Pervasiveext
 
 (* Withlock takes dbcache_mutex, and ref-counts to allow the same thread to re-enter without blocking as many times

--- a/ocaml/database/db_remote_cache_access_v1.ml
+++ b/ocaml/database/db_remote_cache_access_v1.ml
@@ -1,5 +1,3 @@
-open Xapi_stdext_threads.Threadext
-
 module DBCacheRemoteListener = struct
   open Db_rpc_common_v1
   open Db_exn
@@ -36,7 +34,8 @@ module DBCacheRemoteListener = struct
       		Note that, although the messages still contain the pool_secret for historical reasons,
       		access has already been applied by the RBAC code in Xapi_http.add_handler. *)
   let process_xmlrpc xml =
-    Mutex.execute ctr_mutex (fun () -> calls_processed := !calls_processed + 1) ;
+    let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute in
+    with_lock ctr_mutex (fun () -> calls_processed := !calls_processed + 1) ;
     let fn_name, args =
       match XMLRPC.From.array (fun x -> x) xml with
       | [fn_name; _; args] ->

--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -18,7 +18,6 @@
    restarts in emergency mode.
 *)
 
-open Xapi_stdext_threads.Threadext
 open Safe_resources
 
 type db_record = (string * string) list * (string * string list) list
@@ -119,7 +118,7 @@ let watchdog_start_mutex = Mutex.create ()
 let my_watchdog : Thread.t option ref = ref None
 
 let start_master_connection_watchdog () =
-  Mutex.execute watchdog_start_mutex (fun () ->
+  Xapi_stdext_threads.Threadext.Mutex.execute watchdog_start_mutex (fun () ->
       match !my_watchdog with
       | None ->
           my_watchdog :=

--- a/ocaml/database/stats.ml
+++ b/ocaml/database/stats.ml
@@ -47,8 +47,9 @@ end
 module D = Debug.Make (struct let name = "stats" end)
 
 open D
-open Xapi_stdext_threads.Threadext
 open Xapi_stdext_pervasives.Pervasiveext
+
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 let timings : (string, Normal_population.t) Hashtbl.t = Hashtbl.create 10
 
@@ -74,7 +75,7 @@ let string_of (p : Normal_population.t) =
 let sample (name : string) (x : float) : unit =
   (* Use the lognormal distribution: *)
   let x' = log x in
-  Mutex.execute timings_m (fun () ->
+  with_lock timings_m (fun () ->
       let p =
         if Hashtbl.mem timings name then
           Hashtbl.find timings name
@@ -105,6 +106,6 @@ let time_this (name : string) f =
   )
 
 let summarise () =
-  Mutex.execute timings_m (fun () ->
+  with_lock timings_m (fun () ->
       Hashtbl.fold (fun k v acc -> (k, string_of v) :: acc) timings []
   )

--- a/ocaml/libs/http-svr/http_proxy.ml
+++ b/ocaml/libs/http-svr/http_proxy.ml
@@ -16,7 +16,6 @@ module D = Debug.Make (struct let name = "http_proxy" end)
 
 open D
 open Xmlrpc_client
-open Xapi_stdext_threads.Threadext
 
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
@@ -75,7 +74,7 @@ let http_proxy src_ip src_port transport =
   try
     let addr = Unix.inet_addr_of_string src_ip in
     let sockaddr = Unix.ADDR_INET (addr, src_port) in
-    Mutex.execute m (fun () ->
+    Xapi_stdext_threads.Threadext.Mutex.execute m (fun () ->
         (* shutdown any server which currently exists *)
         Option.iter (fun server -> server.Server_io.shutdown ()) !server ;
         (* Make sure we don't try to double-close the server *)

--- a/ocaml/libs/http-svr/http_svr.ml
+++ b/ocaml/libs/http-svr/http_svr.ml
@@ -30,7 +30,6 @@
  *)
 
 open Http
-module Mutex = Xapi_stdext_threads.Threadext.Mutex
 module Unixext = Xapi_stdext_unix.Unixext
 
 (* This resolves the lowercase deprecation for all compiler versions *)
@@ -54,7 +53,7 @@ module Stats = struct
   let empty () = {n_requests= 0; n_connections= 0; n_framed= 0}
 
   let update (x : t) (m : Mutex.t) req =
-    Mutex.execute m (fun () ->
+    Xapi_stdext_threads.Threadext.Mutex.execute m (fun () ->
         x.n_requests <- x.n_requests + 1 ;
         if req.Http.Request.close then x.n_connections <- x.n_connections + 1 ;
         if req.Http.Request.frame then x.n_framed <- x.n_framed + 1

--- a/ocaml/libs/http-svr/test_server.ml
+++ b/ocaml/libs/http-svr/test_server.ml
@@ -1,4 +1,5 @@
-open Xapi_stdext_threads.Threadext
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
 open Xapi_stdext_unix
 
 let finished = ref false
@@ -25,7 +26,7 @@ let _ =
        (fun _ s _ ->
          let r = Http.Response.to_wire_string (Http.Response.make "200" "OK") in
          Unixext.really_write_string s r ;
-         Mutex.execute finished_m (fun () ->
+         with_lock finished_m (fun () ->
              finished := true ;
              Condition.signal finished_c
          )
@@ -74,7 +75,7 @@ let _ =
   let socket = Http_svr.bind ~listen_backlog:5 addr "server" in
   start server socket ;
   Printf.printf "Server started on %s:%d\n" ip !port ;
-  Mutex.execute finished_m (fun () ->
+  with_lock finished_m (fun () ->
       while not !finished do
         Condition.wait finished_c finished_m
       done

--- a/ocaml/libs/http-svr/xmlrpc_client.ml
+++ b/ocaml/libs/http-svr/xmlrpc_client.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Mutex = Xapi_stdext_threads.Threadext.Mutex
 module Unixext = Xapi_stdext_unix.Unixext
 
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
@@ -118,9 +117,10 @@ let check_reusable_inner (x : Unixfd.t) =
 exception Stunnel_connection_failed
 
 let get_new_stunnel_id =
+  let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute in
   let counter = ref 0 in
   let m = Mutex.create () in
-  fun () -> Mutex.execute m (fun () -> incr counter ; !counter)
+  fun () -> with_lock m (fun () -> incr counter ; !counter)
 
 let watchdog_scheduler = Scheduler.make ()
 

--- a/ocaml/libs/resources/table.ml
+++ b/ocaml/libs/resources/table.ml
@@ -8,26 +8,26 @@ module Make (V : sig
   val with_moved_exn : t -> (t -> 'd) -> 'd
 end) =
 struct
-  open Xapi_stdext_threads.Threadext
+  let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
   type 'a t = ('a, V.t) Hashtbl.t * Mutex.t
 
   let create n : 'a t = (Hashtbl.create n, Mutex.create ())
 
   let release (t, m) =
-    Mutex.execute m (fun () -> Hashtbl.iter (fun _ v -> V.safe_release v) t)
+    with_lock m (fun () -> Hashtbl.iter (fun _ v -> V.safe_release v) t)
 
   let reset (t, m) =
     release (t, m) ;
     Hashtbl.reset t
 
-  let copy (t, m) = (Mutex.execute m (fun () -> Hashtbl.copy t), Mutex.create ())
+  let copy (t, m) = (with_lock m (fun () -> Hashtbl.copy t), Mutex.create ())
 
-  let length (t, m) = Mutex.execute m (fun () -> Hashtbl.length t)
+  let length (t, m) = with_lock m (fun () -> Hashtbl.length t)
 
   let move_into (t, m) k v =
     let v = V.move_out_exn v in
-    Mutex.execute m (fun () ->
+    with_lock m (fun () ->
         match Hashtbl.find_opt t k with
         | None ->
             Hashtbl.add t k v
@@ -36,23 +36,23 @@ struct
     )
 
   let remove (t, m) k =
-    Mutex.execute m (fun () ->
+    with_lock m (fun () ->
         Option.iter V.safe_release (Hashtbl.find_opt t k) ;
         Hashtbl.remove t k
     )
 
-  let find (t, m) k = Mutex.execute m (fun () -> Hashtbl.find t k)
+  let find (t, m) k = with_lock m (fun () -> Hashtbl.find t k)
 
   let with_find_moved_exn (t, m) k =
     let v =
-      Mutex.execute m (fun () ->
+      with_lock m (fun () ->
           let r = Hashtbl.find t k in
           Hashtbl.remove t k ; r
       )
     in
     V.with_moved_exn v
 
-  let fold (t, m) f init = Mutex.execute m (fun () -> Hashtbl.fold f t init)
+  let fold (t, m) f init = with_lock m (fun () -> Hashtbl.fold f t init)
 
-  let iter (t, m) f = Mutex.execute m (fun () -> Hashtbl.iter f t)
+  let iter (t, m) f = with_lock m (fun () -> Hashtbl.iter f t)
 end

--- a/ocaml/mpathalert/mpathalert.ml
+++ b/ocaml/mpathalert/mpathalert.ml
@@ -11,11 +11,12 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module Mutex = Xapi_stdext_threads.Threadext.Mutex
 module Xstringext = Xapi_stdext_std.Xstringext
 module Listext = Xapi_stdext_std.Listext
 open Client
 open Event_types
+
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 let print_debug = ref false
 
@@ -23,7 +24,7 @@ let delay = ref 120.
 
 let lock = Mutex.create ()
 
-let with_global_lock (f : unit -> unit) = Mutex.execute lock f
+let with_global_lock (f : unit -> unit) = with_lock lock f
 
 let time_of_float x =
   let time = Unix.gmtime x in
@@ -35,7 +36,7 @@ let stdout_m = Mutex.create ()
 
 let debug (fmt : ('a, unit, string, unit) format4) =
   if !print_debug then
-    Mutex.execute stdout_m (fun () ->
+    with_lock stdout_m (fun () ->
         Printf.kprintf
           (fun s ->
             Printf.printf "%s [%d] %s\n"

--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -1193,7 +1193,7 @@ module Ovs = struct
 
     val appctl : ?log:bool -> string list -> string
   end = struct
-    open Xapi_stdext_threads
+    module Semaphore = Xapi_stdext_threads.Semaphore
 
     let s = Semaphore.create 5
 

--- a/ocaml/perftest/perfdebug.ml
+++ b/ocaml/perftest/perfdebug.ml
@@ -11,12 +11,10 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-module Mutex = Xapi_stdext_threads.Threadext.Mutex
-
 let stdout_m = Mutex.create ()
 
 let debug ?(out = stdout) (fmt : ('a, unit, string, unit) format4) =
-  Mutex.execute stdout_m (fun () ->
+  Xapi_stdext_threads.Threadext.Mutex.execute stdout_m (fun () ->
       Printf.kprintf
         (fun s ->
           Printf.fprintf out "%s\n" s ;

--- a/ocaml/quicktest/quicktest_http.ml
+++ b/ocaml/quicktest/quicktest_http.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open Xapi_stdext_pervasives.Pervasiveext
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 module Uds = struct
   (* {{{1 *)

--- a/ocaml/rrd2csv/src/rrd2csv.ml
+++ b/ocaml/rrd2csv/src/rrd2csv.ml
@@ -13,7 +13,6 @@
  *)
 
 module Xstringext = Xapi_stdext_std.Xstringext
-module Mutex = Xapi_stdext_threads.Threadext.Mutex
 open Rrd
 
 let version = "0.1.3"
@@ -37,7 +36,7 @@ module Stdout = struct
 
   let debug (fmt : ('a, unit, string, unit) format4) =
     if !print_debug then
-      Mutex.execute stdout_m (fun () ->
+      Xapi_stdext_threads.Threadext.Mutex.execute stdout_m (fun () ->
           Printf.kprintf
             (fun s ->
               Printf.printf "%s [%d] %s\n"

--- a/ocaml/tapctl/tapctl.ml
+++ b/ocaml/tapctl/tapctl.ml
@@ -1,7 +1,8 @@
 open Forkhelpers
 open Xapi_stdext_unix
-open Xapi_stdext_threads.Threadext
 module IntSet = Set.Make (Int)
+
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 (* Tapdisk stats *)
 module Stats = struct
@@ -130,7 +131,7 @@ module Dummy = struct
     with _ -> None
 
   let allocate ctx =
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let minor = find_next_unused_minor list in
         let entry =
@@ -145,7 +146,7 @@ module Dummy = struct
     )
 
   let spawn ctx =
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let pid = find_next_unused_pid list in
         let entry =
@@ -156,7 +157,7 @@ module Dummy = struct
     )
 
   let attach ctx pid minor =
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         (* sanity check *)
         ( match
@@ -191,7 +192,7 @@ module Dummy = struct
 
   let _open ctx t leaf_path driver =
     let args = Printf.sprintf "%s:%s" (string_of_driver driver) leaf_path in
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let list =
           List.map
@@ -207,7 +208,7 @@ module Dummy = struct
     )
 
   let close ctx t =
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let list =
           List.map
@@ -223,7 +224,7 @@ module Dummy = struct
     )
 
   let pause ctx t =
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let list =
           List.map
@@ -240,7 +241,7 @@ module Dummy = struct
 
   let unpause ctx t leaf_path driver =
     let args = Printf.sprintf "%s:%s" (string_of_driver driver) leaf_path in
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let list =
           List.map
@@ -256,7 +257,7 @@ module Dummy = struct
     )
 
   let detach ctx t =
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let a, b =
           ( get_entry_from_pid t.tapdisk_pid list
@@ -275,7 +276,7 @@ module Dummy = struct
     )
 
   let free ctx minor =
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         let entry = get_entry_from_minor minor list in
         (* sanity check *)
@@ -290,7 +291,7 @@ module Dummy = struct
     )
 
   let list ?t ctx =
-    Mutex.execute d_lock (fun () ->
+    with_lock d_lock (fun () ->
         let list = get_dummy_tapdisk_list ctx in
         List.filter_map
           (fun e ->

--- a/ocaml/tests/test_event.ml
+++ b/ocaml/tests/test_event.ml
@@ -14,7 +14,7 @@
 
 open Test_common
 open Event_types
-open Xapi_stdext_threads.Threadext
+module Delay = Xapi_stdext_threads.Threadext.Delay
 
 let event_setup_common = Test_event_common.event_setup_common
 

--- a/ocaml/tests/test_vdi_cbt.ml
+++ b/ocaml/tests/test_vdi_cbt.ml
@@ -12,7 +12,7 @@
 -  GNU Lesser General Public License for more details.
   *)
 
-module Threadext = Xapi_stdext_threads.Threadext
+module Delay = Xapi_stdext_threads.Threadext.Delay
 
 let register_smapiv2_server (module S : Storage_interface.Server_impl) sr_ref =
   let module S = Storage_interface.Server (S) () in
@@ -569,17 +569,17 @@ let test_data_destroy =
       let data_destroy ~timeout =
         (* It could return earlier normally, but this is the longest we'd wait in case of extreme situation *)
         let timebox_timeout = timeout +. (1.0 *. 10.) in
-        let wait_hdl = Threadext.Delay.make () in
+        let wait_hdl = Delay.make () in
         let raisedexn = ref None in
         ignore
           (bg (fun () ->
                ( try Xapi_vdi._data_destroy ~__context ~self:vDI ~timeout
                  with e -> raisedexn := Some e
                ) ;
-               Threadext.Delay.signal wait_hdl
+               Delay.signal wait_hdl
            )
           ) ;
-        if Threadext.Delay.wait wait_hdl timebox_timeout then
+        if Delay.wait wait_hdl timebox_timeout then
           Alcotest.fail
             (Printf.sprintf "data_destroy did not return in %f seconds"
                timebox_timeout

--- a/ocaml/xapi-aux/pool_role.ml
+++ b/ocaml/xapi-aux/pool_role.ml
@@ -15,7 +15,6 @@
  * @group Pool Management
 *)
 
-module Mutex = Xapi_stdext_threads.Threadext.Mutex
 module Unixext = Xapi_stdext_unix.Unixext
 
 module D = Debug.Make (struct let name = "pool_role" end)
@@ -35,7 +34,7 @@ let role_unit_tests = ref false
 
 let role_m = Mutex.create ()
 
-let with_pool_role_lock f = Mutex.execute role_m f
+let with_pool_role_lock f = Xapi_stdext_threads.Threadext.Mutex.execute role_m f
 
 let set_pool_role_for_test () =
   with_pool_role_lock (fun _ ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -15,8 +15,6 @@
  * @group API Messaging
 *)
 
-open Xapi_stdext_threads.Threadext
-
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 open Client

--- a/ocaml/xapi/monitor_dbcalls.ml
+++ b/ocaml/xapi/monitor_dbcalls.ml
@@ -15,7 +15,8 @@
 open Db_filter_types
 open Monitor_types
 open Monitor_dbcalls_cache
-open Xapi_stdext_threads.Threadext
+
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 module D = Debug.Make (struct let name = "monitor_dbcalls" end)
 
@@ -55,12 +56,12 @@ let get_pif_and_bond_changes () =
   (pif_changes, bond_changes)
 
 let set_pif_changes ?except () =
-  Mutex.execute pifs_cached_m (fun _ ->
+  with_lock pifs_cached_m (fun _ ->
       transfer_map ?except ~source:pifs_tmp ~target:pifs_cached ()
   )
 
 let set_bond_changes ?except () =
-  Mutex.execute bonds_links_up_cached_m (fun _ ->
+  with_lock bonds_links_up_cached_m (fun _ ->
       transfer_map ?except ~source:bonds_links_up_tmp
         ~target:bonds_links_up_cached ()
   )

--- a/ocaml/xapi/monitor_dbcalls_cache.ml
+++ b/ocaml/xapi/monitor_dbcalls_cache.ml
@@ -12,7 +12,8 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_threads.Threadext
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
 module StringSet = Set.Make (String)
 
 (* A cache mapping PIF names to PIF structures. *)
@@ -56,7 +57,7 @@ let ignore_errors = ref StringSet.empty
 (** [clear_cache_for_pif] removes any current cache for PIF with [pif_name],
  * which forces fresh properties for the PIF into xapi's database. *)
 let clear_cache_for_pif ~pif_name =
-  Mutex.execute pifs_cached_m (fun _ ->
+  with_lock pifs_cached_m (fun _ ->
       Hashtbl.remove pifs_cached pif_name ;
       Hashtbl.remove pifs_tmp pif_name
   )
@@ -64,14 +65,14 @@ let clear_cache_for_pif ~pif_name =
 (** [clear_cache_for_vm] removes any current cache for VM with [vm_uuid],
  * which forces fresh properties for the VM into xapi's database. *)
 let clear_cache_for_vm ~vm_uuid =
-  Mutex.execute vm_memory_cached_m (fun _ ->
+  with_lock vm_memory_cached_m (fun _ ->
       Hashtbl.remove vm_memory_cached vm_uuid ;
       Hashtbl.remove vm_memory_tmp vm_uuid
   )
 
 (** [clear_pvs_status_cache] removes the cache entry for [vm_uuid] *)
 let clear_pvs_status_cache ~vm_uuid =
-  Mutex.execute pvs_proxy_cached_m (fun _ ->
+  with_lock pvs_proxy_cached_m (fun _ ->
       Hashtbl.remove pvs_proxy_cached vm_uuid ;
       Hashtbl.remove pvs_proxy_tmp vm_uuid
   )
@@ -80,13 +81,13 @@ let clear_pvs_status_cache ~vm_uuid =
  * xapi's database. *)
 let clear_cache () =
   let safe_clear ~cache ~tmp ~lock =
-    Mutex.execute lock (fun _ -> Hashtbl.clear cache ; Hashtbl.clear tmp)
+    with_lock lock (fun _ -> Hashtbl.clear cache ; Hashtbl.clear tmp)
   in
   safe_clear ~cache:pifs_cached ~tmp:pifs_tmp ~lock:pifs_cached_m ;
   safe_clear ~cache:bonds_links_up_cached ~tmp:bonds_links_up_tmp
     ~lock:bonds_links_up_cached_m ;
   safe_clear ~cache:vm_memory_cached ~tmp:vm_memory_tmp ~lock:vm_memory_cached_m ;
-  Mutex.execute host_memory_m (fun _ ->
+  with_lock host_memory_m (fun _ ->
       host_memory_free_cached := Int64.zero ;
       host_memory_total_cached := Int64.zero
   )

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -16,7 +16,6 @@ module D = Debug.Make (struct let name = "nm" end)
 open D
 open Xapi_stdext_std.Xstringext
 module Listext = Xapi_stdext_std.Listext.List
-open Xapi_stdext_threads.Threadext
 open Db_filter_types
 open Network
 open Network_interface
@@ -24,7 +23,7 @@ open Network_interface
 (* Protect a bunch of local operations with a mutex *)
 let local_m = Mutex.create ()
 
-let with_local_lock f = Mutex.execute local_m f
+let with_local_lock f = Xapi_stdext_threads.Threadext.Mutex.execute local_m f
 
 let is_dom0_interface pif_r =
   pif_r.API.pIF_ip_configuration_mode <> `None

--- a/ocaml/xapi/pciops.ml
+++ b/ocaml/xapi/pciops.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_threads.Threadext
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 let m = Mutex.create ()
 
@@ -100,7 +100,7 @@ let _is_pci_hidden ~__context pci =
 
 (** Check whether a PCI device will be hidden from the dom0 kernel on boot. *)
 let is_pci_hidden ~__context pci =
-  Mutex.execute m (fun () -> _is_pci_hidden ~__context pci)
+  with_lock m (fun () -> _is_pci_hidden ~__context pci)
 
 let _hide_pci ~__context pci =
   if not (_is_pci_hidden ~__context pci) then
@@ -117,8 +117,7 @@ let _hide_pci ~__context pci =
     ()
 
 (** Hide a PCI device from the dom0 kernel. (Takes effect after next boot.) *)
-let hide_pci ~__context pci =
-  Mutex.execute m (fun () -> _hide_pci ~__context pci)
+let hide_pci ~__context pci = with_lock m (fun () -> _hide_pci ~__context pci)
 
 let _unhide_pci ~__context pci =
   if _is_pci_hidden ~__context pci then
@@ -145,7 +144,7 @@ let _unhide_pci ~__context pci =
 
 (** Unhide a PCI device from the dom0 kernel. (Takes effect after next boot.) *)
 let unhide_pci ~__context pci =
-  Mutex.execute m (fun () -> _unhide_pci ~__context pci)
+  with_lock m (fun () -> _unhide_pci ~__context pci)
 
 (** Return the id of a PCI device *)
 let id_of (id, _) = id

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -20,7 +20,6 @@ module SMPERF = Debug.Make (struct let name = "SMPERF" end)
 
 module Listext = Xapi_stdext_std.Listext
 open Xapi_stdext_pervasives.Pervasiveext
-open Xapi_stdext_threads.Threadext
 module Unixext = Xapi_stdext_unix.Unixext
 open Xmlrpc_client
 open Storage_interface
@@ -227,7 +226,7 @@ module State = struct
     save_one (Copy_table active_copy)
 
   let access_table ~save_after f table =
-    Mutex.execute mutex (fun () ->
+    Xapi_stdext_threads.Threadext.Mutex.execute mutex (fun () ->
         if not !loaded then load () ;
         let result = f table in
         if save_after then save () ;

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -15,7 +15,7 @@
  * @group Helper functions for handling system domains
 *)
 
-open Xapi_stdext_threads.Threadext
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 module D = Debug.Make (struct let name = "system_domains" end)
 
@@ -246,21 +246,21 @@ let service_to_queue = Hashtbl.create 10
 let service_to_queue_m = Mutex.create ()
 
 let register_service service queue =
-  Mutex.execute service_to_queue_m (fun () ->
+  with_lock service_to_queue_m (fun () ->
       Hashtbl.replace service_to_queue service queue
   )
 
 let unregister_service service =
-  Mutex.execute service_to_queue_m (fun () ->
+  with_lock service_to_queue_m (fun () ->
       Hashtbl.remove service_to_queue service
   )
 
 let get_service service =
-  Mutex.execute service_to_queue_m (fun () ->
+  with_lock service_to_queue_m (fun () ->
       try Some (Hashtbl.find service_to_queue service) with Not_found -> None
   )
 
 let list_services () =
-  Mutex.execute service_to_queue_m (fun () ->
+  with_lock service_to_queue_m (fun () ->
       Hashtbl.fold (fun service _ acc -> service :: acc) service_to_queue []
   )

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -14,7 +14,6 @@
 module D = Debug.Make (struct let name = "xapi_bond" end)
 
 open D
-module Mutex = Xapi_stdext_threads.Threadext.Mutex
 open Db_filter_types
 
 (* Returns the name of a new bond device, which is the string "bond" followed
@@ -272,7 +271,7 @@ let fix_bond ~__context ~bond =
 (* Protect a bunch of local operations with a mutex *)
 let local_m = Mutex.create ()
 
-let with_local_lock f = Mutex.execute local_m f
+let with_local_lock f = Xapi_stdext_threads.Threadext.Mutex.execute local_m f
 
 let requirements_of_mode = function
   | `lacp ->

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -20,7 +20,6 @@ module L = Debug.Make (struct let name = "license" end)
 open Db_filter_types
 module Listext = Xapi_stdext_std.Listext.List
 open Xapi_stdext_std.Xstringext
-open Xapi_stdext_threads.Threadext
 module Date = Xapi_stdext_date.Date
 open Network
 
@@ -670,7 +669,7 @@ let scan ~__context ~host =
       ([], [])
     )
   in
-  Mutex.execute scan_m (fun () ->
+  Xapi_stdext_threads.Threadext.Mutex.execute scan_m (fun () ->
       let t = make_tables ~__context ~host in
       let devices_not_yet_represented_by_pifs =
         Listext.set_difference

--- a/ocaml/xapi/xapi_pusb.ml
+++ b/ocaml/xapi/xapi_pusb.ml
@@ -12,7 +12,8 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_threads.Threadext
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
 open Xapi_pusb_helpers
 
 module D = Debug.Make (struct let name = "xapi_pusb" end)
@@ -101,7 +102,7 @@ let start_thread f =
     (Thread.create
        (fun () ->
          while true do
-           Mutex.execute mutex (fun () ->
+           with_lock mutex (fun () ->
                while not !scan_required do
                  Condition.wait cond mutex
                done ;
@@ -120,7 +121,7 @@ let start_thread f =
 
 let scan ~__context ~host:_ =
   (* notify that scan is required. *)
-  Mutex.execute mutex (fun () ->
+  with_lock mutex (fun () ->
       scan_required := true ;
       Condition.broadcast cond
   )
@@ -140,7 +141,7 @@ let get_sm_usb_path ~__context vdi =
   with _ -> ""
 
 let set_passthrough_enabled ~__context ~self ~value =
-  Mutex.execute mutex (fun () ->
+  with_lock mutex (fun () ->
       match value with
       | true ->
           (* Remove the vdi records which 'usb_path' in sm-config has the

--- a/ocaml/xapi/xapi_sm.ml
+++ b/ocaml/xapi/xapi_sm.ml
@@ -18,8 +18,6 @@
 (* The SMAPIv1 plugins are a static set in the filesystem.
    The SMAPIv2 plugins are a dynamic set hosted in driver domains. *)
 
-open Xapi_stdext_threads.Threadext
-
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 (* We treat versions as '.'-separated integer lists under the usual
@@ -96,7 +94,7 @@ let _serialize_reg =
         (* inside a nested layer where the lock is held by myself *)
         f ()
     | _ ->
-        Mutex.execute lock (fun () ->
+        Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
             holder := Some (Thread.self ()) ;
             finally f (fun () -> holder := None)
         )

--- a/ocaml/xapi/xapi_stats.ml
+++ b/ocaml/xapi/xapi_stats.ml
@@ -14,6 +14,8 @@
 
 module D = Debug.Make (struct let name = "xapi_stats" end)
 
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
 let generate_master_stats ~__context =
   let session_count =
     Db.Session.get_all ~__context |> List.length |> Int64.of_int
@@ -138,7 +140,7 @@ let shared_page_count = 1
 let start () =
   let __context = Context.make "xapi_stats" in
   let master = Pool_role.is_master () in
-  Xapi_stdext_threads.Threadext.Mutex.execute reporter_m (fun () ->
+  with_lock reporter_m (fun () ->
       match !reporter_cache with
       | Some _ ->
           ()
@@ -162,7 +164,7 @@ let start () =
   )
 
 let stop () =
-  Xapi_stdext_threads.Threadext.Mutex.execute reporter_m (fun () ->
+  with_lock reporter_m (fun () ->
       match !reporter_cache with
       | None ->
           ()

--- a/ocaml/xapi/xapi_stunnel_server.ml
+++ b/ocaml/xapi/xapi_stunnel_server.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_threads.Threadext
 module Unixext = Xapi_stdext_unix.Unixext
 
 module D = Debug.Make (struct let name = "xapi_stunnel_server" end)
@@ -123,7 +122,7 @@ end = struct
     )
 
   let update ~accept ~client_auth_name =
-    Mutex.execute m (fun () ->
+    Xapi_stdext_threads.Threadext.Mutex.execute m (fun () ->
         match (!current_accept, !current_client_auth_name) with
         | Some current_accept, Some current_client_auth_name
           when current_accept = accept

--- a/ocaml/xapi/xapi_sync.ml
+++ b/ocaml/xapi/xapi_sync.ml
@@ -16,12 +16,11 @@
 module D = Debug.Make (struct let name = "sync" end)
 
 open D
-open Xapi_stdext_threads.Threadext
 
 let sync_lock = Mutex.create ()
 
 let sync_host ~__context host =
-  Mutex.execute sync_lock (fun () ->
+  Xapi_stdext_threads.Threadext.Mutex.execute sync_lock (fun () ->
       try
         let localhost = host = !Xapi_globs.localhost_ref
         and host_has_storage =

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -17,7 +17,6 @@
 
 open Xapi_vbd_helpers
 open Vbdops
-open Xapi_stdext_threads.Threadext
 module Date = Xapi_stdext_date.Date
 open D
 
@@ -238,7 +237,7 @@ let create ~__context ~vM ~vDI ~device ~userdevice ~bootable ~mode ~_type
            )
         )
   | _ ->
-      Mutex.execute autodetect_mutex (fun () ->
+      Xapi_stdext_threads.Threadext.Mutex.execute autodetect_mutex (fun () ->
           let possibilities =
             match
               Xapi_vm_helpers.allowed_VBD_devices ~__context ~vm:vM ~_type

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -26,6 +26,8 @@ module D = Debug.Make (struct let name = "xapi_vm" end)
 
 open D
 
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
 exception InvalidOperation of string
 
 let assert_operation_valid =
@@ -1102,7 +1104,7 @@ let call_plugin_latest_m = Mutex.create ()
 
 let record_call_plugin_latest vm =
   let interval = Int64.of_float (!Xapi_globs.vm_call_plugin_interval *. 1e9) in
-  Xapi_stdext_threads.Threadext.Mutex.execute call_plugin_latest_m (fun () ->
+  with_lock call_plugin_latest_m (fun () ->
       let now = Mtime.to_uint64_ns (Mtime_clock.now ()) in
       (* First do a round of GC *)
       let to_gc = ref [] in
@@ -1608,7 +1610,7 @@ let set_HVM_boot_policy ~__context ~self ~value =
 let nvram = Mutex.create ()
 
 let set_NVRAM_EFI_variables ~__context ~self ~value =
-  Xapi_stdext_threads.Threadext.Mutex.execute nvram (fun () ->
+  with_lock nvram (fun () ->
       (* do not use remove_from_NVRAM: we do not want to
          * temporarily end up with an empty NVRAM in HA *)
       let key = "EFI-variables" in

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -20,7 +20,7 @@
     co-ordinate tapdisk locking. We have not got code for this.
 *)
 
-open Xapi_stdext_threads.Threadext
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
@@ -97,13 +97,13 @@ let number = ref 0
 let nmutex = Mutex.create ()
 
 let with_migrate f =
-  Mutex.execute nmutex (fun () ->
+  with_lock nmutex (fun () ->
       if !number = 3 then
         raise
           (Api_errors.Server_error (Api_errors.too_many_storage_migrates, ["3"])) ;
       incr number
   ) ;
-  finally f (fun () -> Mutex.execute nmutex (fun () -> decr number))
+  finally f (fun () -> with_lock nmutex (fun () -> decr number))
 
 module XenAPI = Client
 

--- a/ocaml/xapi/xapi_vusb.ml
+++ b/ocaml/xapi/xapi_vusb.ml
@@ -12,8 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_threads.Threadext
-
 module D = Debug.Make (struct let name = "xapi_vusb" end)
 
 open D
@@ -24,7 +22,7 @@ let create ~__context ~vM ~uSB_group ~other_config =
   let vusb = Ref.make () in
   let uuid = Uuid.to_string (Uuid.make ()) in
   Pool_features.assert_enabled ~__context ~f:Features.USB_passthrough ;
-  Mutex.execute m (fun () ->
+  Xapi_stdext_threads.Threadext.Mutex.execute m (fun () ->
       let attached_vusbs = Db.VM.get_VUSBs ~__context ~self:vM in
       (* At most 6 VUSBS can be attached to one vm *)
       if List.length attached_vusbs > 5 then

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_monitor.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_monitor.ml
@@ -73,8 +73,7 @@ let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
   (* Here we do the synchronising between the dom0 view of the world and our
      Hashtbl. By the end of this execute block, the Hashtbl correctly represents
      the world *)
-  let execute = Xapi_stdext_threads.Threadext.Mutex.execute in
-  execute mutex (fun _ ->
+  Xapi_stdext_threads.Threadext.Mutex.execute mutex (fun _ ->
       let out_of_date, by_how_much =
         match !host_rrd with
         | None ->

--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -121,8 +121,7 @@ let start (xmlrpc_path, http_fwd_path) process =
 
 (* Monitoring code --- START. *)
 
-module Mutex = Xapi_stdext_threads.Threadext.Mutex
-module Thread = Xapi_stdext_threads.Threadext.Thread
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 (*****************************************************)
 (* xenstore related code                             *)
@@ -530,7 +529,7 @@ let dss_mem_vms doms =
       in
       let memory_target_opt =
         try
-          Mutex.execute Rrdd_shared.memory_targets_m (fun _ ->
+          with_lock Rrdd_shared.memory_targets_m (fun _ ->
               Some (Hashtbl.find Rrdd_shared.memory_targets domid)
           )
         with Not_found -> None
@@ -591,7 +590,7 @@ let tapdisk_cache_stats : string =
 
 let dss_cache timestamp =
   let cache_sr_opt =
-    Mutex.execute Rrdd_shared.cache_sr_lock (fun _ -> !Rrdd_shared.cache_sr_uuid)
+    with_lock Rrdd_shared.cache_sr_lock (fun _ -> !Rrdd_shared.cache_sr_uuid)
   in
   let do_read cache_sr =
     debug "do_read: %s %s" tapdisk_cache_stats cache_sr ;
@@ -774,7 +773,7 @@ let monitor_write_loop writers =
           while true do
             try
               do_monitor_write xc writers ;
-              Mutex.execute Rrdd_shared.last_loop_end_time_m (fun _ ->
+              with_lock Rrdd_shared.last_loop_end_time_m (fun _ ->
                   Rrdd_shared.last_loop_end_time := Unix.gettimeofday ()
               ) ;
               Thread.delay !Rrdd_shared.timeslice
@@ -792,7 +791,7 @@ let monitor_write_loop writers =
 (* Monitoring code --- END. *)
 
 module type GCLOG = sig
-  val start : unit -> Xapi_stdext_threads.Threadext.Thread.t
+  val start : unit -> Thread.t
 end
 
 module GCLog : GCLOG = struct
@@ -829,7 +828,7 @@ end
    gives a plugin the possibility to use an atomic rename(2) call. *)
 
 module type DISCOVER = sig
-  val start : string list -> Xapi_stdext_threads.Threadext.Thread.t
+  val start : string list -> Thread.t
 end
 
 module Discover : DISCOVER = struct

--- a/ocaml/xcp-rrdd/lib/plugin/reporter_interdomain.ml
+++ b/ocaml/xcp-rrdd/lib/plugin/reporter_interdomain.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_threads.Threadext
 open Reporter
 
 let start_interdomain (module D : Debug.DEBUG) ~reporter ~uid ~backend_domid

--- a/ocaml/xcp-rrdd/lib/plugin/reporter_local.ml
+++ b/ocaml/xcp-rrdd/lib/plugin/reporter_local.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_stdext_threads.Threadext
 open Xapi_stdext_unix
 open Reporter
 
@@ -44,7 +43,7 @@ let start_local (module D : Debug.DEBUG) ~reporter ~uid ~neg_shift ~page_count
   with exn -> (
     match reporter with
     | Some reporter ->
-        Mutex.execute reporter.lock (fun () ->
+        Xapi_stdext_threads.Threadext.Mutex.execute reporter.lock (fun () ->
             reporter.state <- Stopped (`Failed exn)
         )
     | None ->

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -27,6 +27,8 @@ open D
 
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
 type xen_arm_arch_domainconfig = Xenctrl.xen_arm_arch_domainconfig = {
     gic_version: int
   ; nr_spis: int
@@ -830,7 +832,7 @@ let numa_placement domid ~vcpus ~memory =
   let open Xenctrlext in
   let open Topology in
   let hint =
-    Mutex.execute numa_mutex (fun () ->
+    with_lock numa_mutex (fun () ->
         let host = Lazy.force numa_hierarchy in
         let numa_meminfo =
           Xenctrlext.(with_xc numainfo).memory |> Array.to_list
@@ -1345,11 +1347,11 @@ let restore_common (task : Xenops_task.task_handle) ~xc ~xs
                do here is block until this has happened before sending the next
                request to emu-manager. *)
             let wakeup = Event.new_channel () in
-            Mutex.execute thread_requests_m (fun () ->
+            with_lock thread_requests_m (fun () ->
                 thread_requests := (emu, wakeup) :: !thread_requests
             ) ;
             wrap (fun () ->
-                Mutex.execute emu_manager_send_m (fun () -> send_restore cnx emu)
+                with_lock emu_manager_send_m (fun () -> send_restore cnx emu)
             )
             >>= fun () ->
             debug "Sent restore:%s to emu-manager. Waiting for result..."
@@ -1357,7 +1359,7 @@ let restore_common (task : Xenops_task.task_handle) ~xc ~xs
             (* Block until woken up by the main thread once the result has been
                received. *)
             Event.receive wakeup |> Event.sync ;
-            Mutex.execute thread_requests_m (fun () ->
+            with_lock thread_requests_m (fun () ->
                 thread_requests := List.remove_assoc emu !thread_requests
             ) ;
             return ()


### PR DESCRIPTION
This allows us to sidestep most of the code in Threadext and use only
Mutex.execute, Delay, thread_iter_all_exns and thread_iter

This matters because Stdlib's Thread module is changing in ocaml 4.14
in advance of multicore, [dropping](https://github.com/xapi-project/stdext/commit/ef59ce7eb1042eb44f86235172db8672cb2e9f5c) the code from stdext will allow it to
compile in 4.14.

Since the uses of execute have to be changed in any case, I've opted to
use the name with_lock as I find it more self-explanatory than just
"execute".

On a ring3 BVT + BST I ran some time ago all the tests passed, is there any particular tests we want run?
The main modification for the Threadext module was to add a schedule policy, which was unused.