### PR TITLE
CP-39805: Adapt code to cmdliner 1.1.0

### DIFF
--- a/ocaml/libs/xapi-compression/xapi_gzip.ml
+++ b/ocaml/libs/xapi-compression/xapi_gzip.ml
@@ -68,6 +68,8 @@ let decompress =
 
 let main =
   let doc = "Test compression and uncompression" in
-  C.Term.(const compress $ decompress, info "xapi-gzip" ~doc ~man:help)
+  C.Cmd.v
+    C.Cmd.(info "xapi-gzip" ~doc ~man:help)
+    C.Term.(const compress $ decompress)
 
-let () = if !Sys.interactive then () else C.Term.(exit @@ eval main)
+let () = if !Sys.interactive then () else exit @@ C.Cmd.eval main

--- a/ocaml/message-switch/switch/switch_main.ml
+++ b/ocaml/message-switch/switch/switch_main.ml
@@ -68,7 +68,7 @@ module Config = struct
       let doc = "Directory containing state files" in
       Arg.(value & opt (some string) default.statedir & info ["statedir"] ~doc)
     in
-    Term.(pure make $ path $ pidfile $ configfile $ statedir)
+    Term.(const make $ path $ pidfile $ configfile $ statedir)
 end
 
 module Lwt_result = struct
@@ -361,8 +361,8 @@ let cmd =
          using simple HTTP requests."
     ]
   in
-  ( Term.(ret (pure main $ Config.term $ Traceext.term))
-  , Term.info "main" ~doc ~man
-  )
+  Cmd.v
+    (Cmd.info "main" ~doc ~man)
+    Term.(ret (const main $ Config.term $ Traceext.term))
 
-let _ = match Term.eval cmd with `Error _ -> exit 1 | _ -> exit 0
+let () = exit (Cmd.eval cmd)

--- a/ocaml/message-switch/switch/traceext.ml
+++ b/ocaml/message-switch/switch/traceext.ml
@@ -143,7 +143,7 @@ let term =
     in
     Arg.(value & opt int 256 & info ["trace-truncate"] ~doc)
   in
-  Term.(pure config $ trace_entries $ trace_truncate)
+  Term.(const config $ trace_entries $ trace_truncate)
 
 let init config =
   CompactMessage.truncate_at := config.trace_truncate ;

--- a/ocaml/nbd/src/main.ml
+++ b/ocaml/nbd/src/main.ml
@@ -238,9 +238,9 @@ let cmd =
     let doc = "Local port to listen for connections on" in
     Arg.(value & opt int Consts.standard_nbd_port & info ["port"] ~doc)
   in
-  ( Term.(ret (pure main $ port $ certfile $ ciphersuites))
-  , Term.info "xapi-nbd" ~version:"1.0.0" ~doc ~man ~sdocs:_common_options
-  )
+  Cmd.v
+    (Cmd.info "xapi-nbd" ~version:"1.0.0" ~doc ~man ~sdocs:_common_options)
+    Term.(ret (const main $ port $ certfile $ ciphersuites))
 
 let setup_logging () =
   Lwt_log.default := Lwt_log.syslog ~facility:`Daemon () ;
@@ -255,4 +255,4 @@ let () =
      in the failed state, and a backtrace will show up in the logs. *)
   Cleanup.Runtime.register_signal_handler () ;
   setup_logging () ;
-  match Term.eval cmd with `Error _ -> exit 1 | _ -> exit 0
+  exit (Cmd.eval cmd)

--- a/ocaml/networkd/bin/networkd.ml
+++ b/ocaml/networkd/bin/networkd.ml
@@ -212,17 +212,9 @@ let bind () =
   S.Sriov.disable Sriov.disable ;
   S.Sriov.make_vf_config Sriov.make_vf_config
 
-let _ =
-  ( match
-      Xcp_service.configure2 ~name:Sys.argv.(0) ~version:Build_info.version ~doc
-        ~options ~resources ()
-    with
-  | `Ok () ->
-      ()
-  | `Error m ->
-      Printf.fprintf stderr "%s\n" m ;
-      exit 1
-  ) ;
+let () =
+  Xcp_service.configure2 ~name:Sys.argv.(0) ~version:Build_info.version ~doc
+    ~options ~resources () ;
   bind () ;
   let server =
     Xcp_service.make

--- a/ocaml/xapi-guard/src/main.ml
+++ b/ocaml/xapi-guard/src/main.ml
@@ -171,30 +171,28 @@ let main log_level =
   let () = Lwt_main.run @@ make_message_switch_server () in
   D.debug "Exiting varstored-guard"
 
+open! Cmdliner
+
 let cmd =
-  Cmdliner.(
-    let info = Term.info "varstored-guard" ~exits:Term.default_exits in
-    let log_level =
-      let doc = "Syslog level. E.g. debug, info etc." in
-      let level_conv =
-        let parse s =
-          try `Ok (Syslog.level_of_string s)
-          with _ -> `Error (Format.sprintf "Unknown level: %s" s)
-        in
-        let print ppf level =
-          Format.pp_print_string ppf (Syslog.string_of_level level)
-        in
-        (parse, print)
+  let info = Cmd.info "varstored-guard" in
+  let log_level =
+    let doc = "Syslog level. E.g. debug, info etc." in
+    let level_conv =
+      let parse s =
+        try `Ok (Syslog.level_of_string s)
+        with _ -> `Error (Format.sprintf "Unknown level: %s" s)
       in
-      Arg.(
-        value
-        & opt level_conv Syslog.Info
-        & info ["log-level"] ~docv:"LEVEL" ~doc
-      )
+      let print ppf level =
+        Format.pp_print_string ppf (Syslog.string_of_level level)
+      in
+      (parse, print)
     in
+    Arg.(
+      value & opt level_conv Syslog.Info & info ["log-level"] ~docv:"LEVEL" ~doc
+    )
+  in
 
-    let program = Term.(const main $ log_level) in
-    (program, info)
-  )
+  let program = Term.(const main $ log_level) in
+  Cmd.v info program
 
-let () = Cmdliner.Term.(exit @@ eval cmd)
+let () = exit (Cmdliner.Cmd.eval cmd)

--- a/ocaml/xapi-idl/cluster/cluster_cli.ml
+++ b/ocaml/xapi-idl/cluster/cluster_cli.ml
@@ -4,33 +4,20 @@ open Cluster_interface
 
 module Cmds = LocalAPI (Cmdlinergen.Gen ())
 
-let version_str description =
-  let maj, min, mic = description.Idl.Interface.version in
-  Printf.sprintf "%d.%d.%d" maj min mic
+let doc =
+  String.concat ""
+    [
+      "A CLI for the cluster API. This tool is not intended to be used as "
+    ; "an end user tool"
+    ]
 
-open! Cmdliner
-
-let cmds =
+let cmdline_gen () =
   List.map
-    (fun gen ->
-      let t, i = gen (Cluster_client.rpc_internal Cluster_client.json_url) in
-      Cmd.v i t
-    )
+    (fun t -> t (Cluster_client.rpc_internal Cluster_client.json_url))
     (Cmds.implementation ())
 
-let cli () =
-  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
-  let info =
-    let doc =
-      String.concat ""
-        [
-          "A CLI for the cluster API. This tool is not intended to be used as "
-        ; "an end user tool"
-        ]
-    in
-    Cmd.info "cluster_cli" ~version:(version_str Cmds.description) ~doc
-  in
-  let cmd = Cmd.group ~default info cmds in
-  Cmd.eval_value cmd
+let cli =
+  Xcp_service.cli ~name:"cluster_cli" ~doc ~version:Cmds.description.version
+    ~cmdline_gen
 
-let () = match cli () with Ok (`Ok f) -> f () | _ -> ()
+let () = Xcp_service.eval_cmdline cli

--- a/ocaml/xapi-idl/cluster/cluster_cli.ml
+++ b/ocaml/xapi-idl/cluster/cluster_cli.ml
@@ -8,23 +8,29 @@ let version_str description =
   let maj, min, mic = description.Idl.Interface.version in
   Printf.sprintf "%d.%d.%d" maj min mic
 
-let default_cmd =
-  let doc =
-    String.concat ""
-      [
-        "A CLI for the cluster API. This tool is not intended to be used as an "
-      ; "end user tool"
-      ]
-  in
-  ( Cmdliner.Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ()))
-  , Cmdliner.Term.info "cluster_cli"
-      ~version:(version_str Cmds.description)
-      ~doc
-  )
+open! Cmdliner
+
+let cmds =
+  List.map
+    (fun gen ->
+      let t, i = gen (Cluster_client.rpc_internal Cluster_client.json_url) in
+      Cmd.v i t
+    )
+    (Cmds.implementation ())
 
 let cli () =
-  let rpc = Cluster_client.rpc_internal Cluster_client.json_url in
-  Cmdliner.Term.eval_choice default_cmd
-    (List.map (fun t -> t rpc) (Cmds.implementation ()))
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let info =
+    let doc =
+      String.concat ""
+        [
+          "A CLI for the cluster API. This tool is not intended to be used as "
+        ; "an end user tool"
+        ]
+    in
+    Cmd.info "cluster_cli" ~version:(version_str Cmds.description) ~doc
+  in
+  let cmd = Cmd.group ~default info cmds in
+  Cmd.eval_value cmd
 
-let _ = cli ()
+let () = match cli () with Ok (`Ok f) -> f () | _ -> ()

--- a/ocaml/xapi-idl/example/example.ml
+++ b/ocaml/xapi-idl/example/example.ml
@@ -74,15 +74,8 @@ let options =
 
 let _ =
   Debug.log_to_stdout () ;
-  match
-    configure2 ~name:"Example-service" ~version:"1.0"
-      ~doc:
-        "This is an example service which demonstrates the configuration \
-         mechanism."
-      ~options ~resources ()
-  with
-  | `Ok () ->
-      exit 0
-  | `Error m ->
-      Printf.fprintf stderr "Error: %s\n%!" m ;
-      exit 1
+  configure2 ~name:"Example-service" ~version:"1.0"
+    ~doc:
+      "This is an example service which demonstrates the configuration \
+       mechanism."
+    ~options ~resources ()

--- a/ocaml/xapi-idl/gpumon/gpumon_cli.ml
+++ b/ocaml/xapi-idl/gpumon/gpumon_cli.ml
@@ -2,34 +2,19 @@
 
 module Cmds = Gpumon_interface.RPC_API (Cmdlinergen.Gen ())
 
-let version_str description =
-  let maj, min, mic = description.Idl.Interface.version in
-  Printf.sprintf "%d.%d.%d" maj min mic
+let doc =
+  String.concat ""
+    [
+      "A CLI for the GPU monitoring API. This allows scripting of the "
+    ; "gpumon daemon for testing and debugging. This tool is not intended "
+    ; "to be used as an end user tool"
+    ]
 
-open! Cmdliner
+let cmdline_gen () =
+  List.map (fun t -> t Gpumon_client.rpc) (Cmds.implementation ())
 
-let cmds =
-  List.map
-    (fun t ->
-      let t, i = t Gpumon_client.rpc in
-      Cmd.v i t
-    )
-    (Cmds.implementation ())
+let cli =
+  Xcp_service.cli ~name:"gpumon_cli" ~doc ~version:Cmds.description.version
+    ~cmdline_gen
 
-let cli () =
-  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
-  let info =
-    let doc =
-      String.concat ""
-        [
-          "A CLI for the GPU monitoring API. This allows scripting of the "
-        ; "gpumon daemon for testing and debugging. This tool is not intended "
-        ; "to be used as an end user tool"
-        ]
-    in
-    Cmd.info "gpumon_cli" ~version:(version_str Cmds.description) ~doc
-  in
-  let cmd = Cmd.group ~default info cmds in
-  Cmd.eval_value cmd
-
-let () = match cli () with Ok (`Ok f) -> f () | _ -> ()
+let () = Xcp_service.eval_cmdline cli

--- a/ocaml/xapi-idl/gpumon/gpumon_cli.ml
+++ b/ocaml/xapi-idl/gpumon/gpumon_cli.ml
@@ -6,23 +6,30 @@ let version_str description =
   let maj, min, mic = description.Idl.Interface.version in
   Printf.sprintf "%d.%d.%d" maj min mic
 
-let default_cmd =
-  let doc =
-    String.concat ""
-      [
-        "A CLI for the GPU monitoring API. This allows scripting of the gpumon \
-         daemon "
-      ; "for testing and debugging. This tool is not intended to be used as an "
-      ; "end user tool"
-      ]
-  in
-  ( Cmdliner.Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ()))
-  , Cmdliner.Term.info "gpumon_cli" ~version:(version_str Cmds.description) ~doc
-  )
+open! Cmdliner
+
+let cmds =
+  List.map
+    (fun t ->
+      let t, i = t Gpumon_client.rpc in
+      Cmd.v i t
+    )
+    (Cmds.implementation ())
 
 let cli () =
-  let rpc = Gpumon_client.rpc in
-  Cmdliner.Term.eval_choice default_cmd
-    (List.map (fun t -> t rpc) (Cmds.implementation ()))
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let info =
+    let doc =
+      String.concat ""
+        [
+          "A CLI for the GPU monitoring API. This allows scripting of the "
+        ; "gpumon daemon for testing and debugging. This tool is not intended "
+        ; "to be used as an end user tool"
+        ]
+    in
+    Cmd.info "gpumon_cli" ~version:(version_str Cmds.description) ~doc
+  in
+  let cmd = Cmd.group ~default info cmds in
+  Cmd.eval_value cmd
 
-let _ = match cli () with `Ok f -> f () | _ -> ()
+let () = match cli () with Ok (`Ok f) -> f () | _ -> ()

--- a/ocaml/xapi-idl/lib/xcp_service.ml
+++ b/ocaml/xapi-idl/lib/xcp_service.ml
@@ -691,4 +691,14 @@ let cli ~name ~doc ~version ~cmdline_gen =
   Cmd.group ~default info cmds
 
 let eval_cmdline cmdline =
-  match Cmd.eval_value cmdline with Ok (`Ok f) -> f () | _ -> ()
+  match Cmd.eval_value cmdline with
+  | Ok (`Ok f) ->
+      f ()
+  | Ok _ ->
+      ()
+  | Error (`Parse | `Term) ->
+      error "Error when parsing command line" ;
+      exit Cmd.Exit.cli_error
+  | Error `Exn ->
+      error "Error: uncaught exception" ;
+      exit Cmd.Exit.internal_error

--- a/ocaml/xapi-idl/lib/xcp_service.ml
+++ b/ocaml/xapi-idl/lib/xcp_service.ml
@@ -679,3 +679,16 @@ let maybe_daemonize ?start_fn () =
     daemonize ?start_fn ()
   else
     Option.iter (fun fn -> fn ()) start_fn
+
+let cli ~name ~doc ~version ~cmdline_gen =
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let version =
+    let maj, min, mic = version in
+    Printf.sprintf "%d.%d.%d" maj min mic
+  in
+  let info = Cmd.info name ~version ~doc in
+  let cmds = List.map (fun (t, i) -> Cmd.v i t) (cmdline_gen ()) in
+  Cmd.group ~default info cmds
+
+let eval_cmdline cmdline =
+  match Cmd.eval_value cmdline with Ok (`Ok f) -> f () | _ -> ()

--- a/ocaml/xapi-idl/lib/xcp_service.ml
+++ b/ocaml/xapi-idl/lib/xcp_service.ml
@@ -250,12 +250,13 @@ let common_options =
 let loglevel () = !log_level
 
 module Term = Cmdliner.Term
+module Cmd = Cmdliner.Cmd
 
 let rec list = function
   | [] ->
-      Term.pure []
+      Term.const []
   | x :: xs ->
-      Term.app (Term.app (Term.pure (fun x y -> x :: y)) x) (list xs)
+      Term.app (Term.app (Term.const (fun x y -> x :: y)) x) (list xs)
 
 let command_of ?(name = Sys.argv.(0)) ?(version = "unknown")
     ?(doc = "Please describe this command.") xs =
@@ -265,14 +266,14 @@ let command_of ?(name = Sys.argv.(0)) ?(version = "unknown")
     | Arg.Unit f ->
         let t = Cmdliner.Arg.(value & flag & info [key] ~doc) in
         let make = function true -> f () | false -> () in
-        Term.(pure make $ t)
+        Term.(const make $ t)
     | Arg.Bool f ->
         let t =
           Cmdliner.Arg.(
             value & opt bool (bool_of_string default) & info [key] ~doc
           )
         in
-        Term.(pure f $ t)
+        Term.(const f $ t)
     | Arg.Set b ->
         let t =
           Cmdliner.Arg.(
@@ -280,7 +281,7 @@ let command_of ?(name = Sys.argv.(0)) ?(version = "unknown")
           )
         in
         let make v = b := v in
-        Term.(pure make $ t)
+        Term.(const make $ t)
     | Arg.Clear b ->
         let t =
           Cmdliner.Arg.(
@@ -288,21 +289,21 @@ let command_of ?(name = Sys.argv.(0)) ?(version = "unknown")
           )
         in
         let make v = b := not v in
-        Term.(pure make $ t)
+        Term.(const make $ t)
     | Arg.String f ->
         let t = Cmdliner.Arg.(value & opt string default & info [key] ~doc) in
-        Term.(pure f $ t)
+        Term.(const f $ t)
     | Arg.Set_string s ->
         let t = Cmdliner.Arg.(value & opt string default & info [key] ~doc) in
         let make v = s := v in
-        Term.(pure make $ t)
+        Term.(const make $ t)
     | Arg.Int f ->
         let t =
           Cmdliner.Arg.(
             value & opt int (int_of_string default) & info [key] ~doc
           )
         in
-        Term.(pure f $ t)
+        Term.(const f $ t)
     | Arg.Set_int s ->
         let t =
           Cmdliner.Arg.(
@@ -310,14 +311,14 @@ let command_of ?(name = Sys.argv.(0)) ?(version = "unknown")
           )
         in
         let make v = s := v in
-        Term.(pure make $ t)
+        Term.(const make $ t)
     | Arg.Float f ->
         let t =
           Cmdliner.Arg.(
             value & opt float (float_of_string default) & info [key] ~doc
           )
         in
-        Term.(pure f $ t)
+        Term.(const f $ t)
     | Arg.Set_float s ->
         let t =
           Cmdliner.Arg.(
@@ -325,11 +326,11 @@ let command_of ?(name = Sys.argv.(0)) ?(version = "unknown")
           )
         in
         let make v = s := v in
-        Term.(pure make $ t)
+        Term.(const make $ t)
     | _ ->
         let t = Cmdliner.Arg.(value & opt string default & info [key] ~doc) in
         let make v = Config_file.apply v arg in
-        Term.(pure make $ t)
+        Term.(const make $ t)
   in
   let terms = List.map term_of_option xs in
   let _common_options = "COMMON OPTIONS" in
@@ -343,9 +344,9 @@ let command_of ?(name = Sys.argv.(0)) ?(version = "unknown")
     ; `P "Check bug reports at http://github.com/xapi-project/xcp-idl"
     ]
   in
-  ( Term.(ret (pure (fun (_ : unit list) -> `Ok ()) $ list terms))
-  , Term.info name ~version ~sdocs:_common_options ~man
-  )
+  Cmd.v
+    (Cmd.info name ~version ~sdocs:_common_options ~man)
+    Term.(ret (const (fun (_ : unit list) -> `Ok ()) $ list terms))
 
 let arg_spec = List.map (fun (a, b, _, c) -> ("-" ^ a, b, c))
 
@@ -473,22 +474,9 @@ let configure ?(options = []) ?(resources = []) () =
     )
   with Failure _ -> exit 1
 
-type ('a, 'b) error = [`Ok of 'a | `Error of 'b]
-
 let configure2 ~name ~version ~doc ?(options = []) ?(resources = []) () =
-  try
-    configure_common ~options ~resources (fun config_spec ->
-        match Term.eval (command_of ~name ~version ~doc config_spec) with
-        | `Ok () ->
-            ()
-        | `Error _ ->
-            failwith "Failed to parse command-line arguments"
-        | _ ->
-            exit 0
-        (* --help *)
-    ) ;
-    `Ok ()
-  with Failure m -> `Error m
+  configure_common ~options ~resources @@ fun config_spec ->
+  Cmd.eval ~catch:true (command_of ~name ~version ~doc config_spec)
 
 let http_handler call_of_string string_of_response process s =
   let ic = Unix.in_channel_of_descr s in

--- a/ocaml/xapi-idl/lib/xcp_service.mli
+++ b/ocaml/xapi-idl/lib/xcp_service.mli
@@ -30,8 +30,6 @@ type res = {
 
 val configure : ?options:opt list -> ?resources:res list -> unit -> unit
 
-type ('a, 'b) error = [`Ok of 'a | `Error of 'b]
-
 val configure2 :
      name:string
   -> version:string
@@ -39,7 +37,7 @@ val configure2 :
   -> ?options:opt list
   -> ?resources:res list
   -> unit
-  -> (unit, string) error
+  -> unit
 (** More advanced service configuration with manpage generation *)
 
 type server

--- a/ocaml/xapi-idl/lib/xcp_service.mli
+++ b/ocaml/xapi-idl/lib/xcp_service.mli
@@ -61,3 +61,17 @@ val loglevel : unit -> Syslog.level
 val daemonize : ?start_fn:(unit -> unit) -> unit -> unit
 
 val maybe_daemonize : ?start_fn:(unit -> unit) -> unit -> unit
+
+val cli :
+     name:string
+  -> doc:string
+  -> version:Rpc.Version.t
+  -> cmdline_gen:(unit -> ('a Cmdliner.Term.t * Cmdliner.Cmd.info) list)
+  -> 'a Cmdliner.Cmd.t
+(** [cli ~name ~doc ~version ~cmdline_gen] creates a [Cmdliner] cli parser with
+    the subcommands defined by [cmdline_gen] which by default prints the
+    manpage. The resulting parser needs to be evaluated for the current args *)
+
+val eval_cmdline : (unit -> unit) Cmdliner.Cmd.t -> unit
+(** [eval_cmdline cli] evaluates the cli parser [cli] for the parsers usually
+    generated using [cli] with the [rpclib] cli generator *)

--- a/ocaml/xapi-idl/memory/memory_cli.ml
+++ b/ocaml/xapi-idl/memory/memory_cli.ml
@@ -4,34 +4,19 @@ open Memory_interface
 
 module Cmds = API (Cmdlinergen.Gen ())
 
-let version_str description =
-  let maj, min, mic = description.Idl.Interface.version in
-  Printf.sprintf "%d.%d.%d" maj min mic
+let doc =
+  String.concat ""
+    [
+      "A CLI for the memory API. This allows scripting of the squeeze "
+    ; "daemon for testing and debugging. This tool is not intended to be "
+    ; "used as an end user tool"
+    ]
 
-open! Cmdliner
+let cmdline_gen () =
+  List.map (fun t -> t Memory_client.rpc) (Cmds.implementation ())
 
-let cmds =
-  List.map
-    (fun t ->
-      let t, i = t Memory_client.rpc in
-      Cmd.v i t
-    )
-    (Cmds.implementation ())
+let cli =
+  Xcp_service.cli ~name:"memory_cli" ~doc ~version:Cmds.description.version
+    ~cmdline_gen
 
-let cli () =
-  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
-  let info =
-    let doc =
-      String.concat ""
-        [
-          "A CLI for the memory API. This allows scripting of the squeeze "
-        ; "daemon for testing and debugging. This tool is not intended to be "
-        ; "used as an end user tool"
-        ]
-    in
-    Cmd.info "memory_cli" ~version:(version_str Cmds.description) ~doc
-  in
-  let cmd = Cmd.group ~default info cmds in
-  Cmd.eval_value cmd
-
-let () = match cli () with Ok (`Ok f) -> f () | _ -> ()
+let () = Xcp_service.eval_cmdline cli

--- a/ocaml/xapi-idl/memory/memory_cli.ml
+++ b/ocaml/xapi-idl/memory/memory_cli.ml
@@ -8,28 +8,30 @@ let version_str description =
   let maj, min, mic = description.Idl.Interface.version in
   Printf.sprintf "%d.%d.%d" maj min mic
 
-let default_cmd =
-  let doc =
-    String.concat ""
-      [
-        "A CLI for the memory API. This allows scripting of the squeeze daemon "
-      ; "for testing and debugging. This tool is not intended to be used as an "
-      ; "end user tool"
-      ]
-  in
-  ( Cmdliner.Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ()))
-  , Cmdliner.Term.info "memory_cli" ~version:(version_str Cmds.description) ~doc
-  )
+open! Cmdliner
+
+let cmds =
+  List.map
+    (fun t ->
+      let t, i = t Memory_client.rpc in
+      Cmd.v i t
+    )
+    (Cmds.implementation ())
 
 let cli () =
-  let rpc = Memory_client.rpc in
-  match
-    Cmdliner.Term.eval_choice default_cmd
-      (List.map (fun t -> t rpc) (Cmds.implementation ()))
-  with
-  | `Ok f ->
-      f ()
-  | _ ->
-      ()
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let info =
+    let doc =
+      String.concat ""
+        [
+          "A CLI for the memory API. This allows scripting of the squeeze "
+        ; "daemon for testing and debugging. This tool is not intended to be "
+        ; "used as an end user tool"
+        ]
+    in
+    Cmd.info "memory_cli" ~version:(version_str Cmds.description) ~doc
+  in
+  let cmd = Cmd.group ~default info cmds in
+  Cmd.eval_value cmd
 
-let _ = cli ()
+let () = match cli () with Ok (`Ok f) -> f () | _ -> ()

--- a/ocaml/xapi-idl/network/network_cli.ml
+++ b/ocaml/xapi-idl/network/network_cli.ml
@@ -8,25 +8,30 @@ let version_str description =
   let maj, min, mic = description.Idl.Interface.version in
   Printf.sprintf "%d.%d.%d" maj min mic
 
-let default_cmd =
-  let doc =
-    String.concat ""
-      [
-        "A CLI for the network API. This allows scripting of the xcp-networkd \
-         daemon "
-      ; "for testing and debugging. This tool is not intended to be used as an "
-      ; "end user tool"
-      ]
-  in
-  ( Cmdliner.Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ()))
-  , Cmdliner.Term.info "network_cli"
-      ~version:(version_str Cmds.description)
-      ~doc
-  )
+let doc =
+  String.concat ""
+    [
+      "A CLI for the network API. This allows scripting of the xcp-networkd "
+    ; "daemon for testing and debugging. This tool is not intended to be used "
+    ; "as an end user tool"
+    ]
+
+open! Cmdliner
+
+let cmds =
+  List.map
+    (fun t ->
+      let term, inf = t Network_client.rpc in
+      Cmd.v inf term
+    )
+    (Cmds.implementation ())
 
 let cli () =
-  let rpc = Network_client.rpc in
-  Cmdliner.Term.eval_choice default_cmd
-    (List.map (fun t -> t rpc) (Cmds.implementation ()))
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let info =
+    Cmd.info "network_cli" ~version:(version_str Cmds.description) ~doc
+  in
+  let cmd = Cmd.group ~default info cmds in
+  Cmd.eval_value cmd
 
-let _ = match cli () with `Ok f -> f () | _ -> ()
+let () = match cli () with Ok (`Ok f) -> f () | _ -> ()

--- a/ocaml/xapi-idl/rrd/rrd_cli.ml
+++ b/ocaml/xapi-idl/rrd/rrd_cli.ml
@@ -2,34 +2,19 @@
 
 module Cmds = Rrd_interface.RPC_API (Cmdlinergen.Gen ())
 
-let version_str description =
-  let maj, min, mic = description.Idl.Interface.version in
-  Printf.sprintf "%d.%d.%d" maj min mic
+let doc =
+  String.concat ""
+    [
+      "A CLI for the Db monitoring API. This allows scripting of the Rrd "
+    ; "daemon for testing and debugging. This tool is not intended to be "
+    ; "used as an end user tool"
+    ]
 
-open! Cmdliner
+let cmdline_gen () =
+  List.map (fun t -> t Rrd_client.rpc) (Cmds.implementation ())
 
-let cmds =
-  List.map
-    (fun t ->
-      let t, i = t Rrd_client.rpc in
-      Cmd.v i t
-    )
-    (Cmds.implementation ())
+let cli =
+  Xcp_service.cli ~name:"rrd_cli" ~doc ~version:Cmds.description.version
+    ~cmdline_gen
 
-let cli () =
-  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
-  let info =
-    let doc =
-      String.concat ""
-        [
-          "A CLI for the Db monitoring API. This allows scripting of the Rrd "
-        ; "daemon for testing and debugging. This tool is not intended to be "
-        ; "used as an end user tool"
-        ]
-    in
-    Cmd.info "rrd_cli" ~version:(version_str Cmds.description) ~doc
-  in
-  let cmd = Cmd.group ~default info cmds in
-  Cmd.eval_value cmd
-
-let () = match cli () with Ok (`Ok f) -> f () | _ -> ()
+let () = Xcp_service.eval_cmdline cli

--- a/ocaml/xapi-idl/rrd/rrd_cli.ml
+++ b/ocaml/xapi-idl/rrd/rrd_cli.ml
@@ -6,23 +6,30 @@ let version_str description =
   let maj, min, mic = description.Idl.Interface.version in
   Printf.sprintf "%d.%d.%d" maj min mic
 
-let default_cmd =
-  let doc =
-    String.concat ""
-      [
-        "A CLI for the Db monitoring API. This allows scripting of the Rrd \
-         daemon "
-      ; "for testing and debugging. This tool is not intended to be used as an "
-      ; "end user tool"
-      ]
-  in
-  ( Cmdliner.Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ()))
-  , Cmdliner.Term.info "rrd_cli" ~version:(version_str Cmds.description) ~doc
-  )
+open! Cmdliner
+
+let cmds =
+  List.map
+    (fun t ->
+      let t, i = t Rrd_client.rpc in
+      Cmd.v i t
+    )
+    (Cmds.implementation ())
 
 let cli () =
-  let rpc = Rrd_client.rpc in
-  Cmdliner.Term.eval_choice default_cmd
-    (List.map (fun t -> t rpc) (Cmds.implementation ()))
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let info =
+    let doc =
+      String.concat ""
+        [
+          "A CLI for the Db monitoring API. This allows scripting of the Rrd "
+        ; "daemon for testing and debugging. This tool is not intended to be "
+        ; "used as an end user tool"
+        ]
+    in
+    Cmd.info "rrd_cli" ~version:(version_str Cmds.description) ~doc
+  in
+  let cmd = Cmd.group ~default info cmds in
+  Cmd.eval_value cmd
 
-let _ = cli ()
+let () = match cli () with Ok (`Ok f) -> f () | _ -> ()

--- a/ocaml/xapi-idl/storage/storage_test.ml
+++ b/ocaml/xapi-idl/storage/storage_test.ml
@@ -280,6 +280,6 @@ let cmd =
     let doc = "The attached SR." in
     Arg.(value & pos 1 (some sr_t) None & info [] ~doc)
   in
-  (Term.(const start $ verbose $ queue $ sr), Term.info "test" ~doc ~man)
+  Cmd.v (Cmd.info "test" ~doc ~man) Term.(const start $ verbose $ queue $ sr)
 
-let () = Term.exit @@ Term.eval ~catch:true cmd
+let () = exit @@ Cmd.eval ~catch:true cmd

--- a/ocaml/xapi-idl/v6/v6_cli.ml
+++ b/ocaml/xapi-idl/v6/v6_cli.ml
@@ -2,34 +2,18 @@
 
 module Cmds = V6_interface.RPC_API (Cmdlinergen.Gen ())
 
-let version_str description =
-  let maj, min, mic = description.Idl.Interface.version in
-  Printf.sprintf "%d.%d.%d" maj min mic
+let doc =
+  String.concat ""
+    [
+      "A CLI for the V6d API. This allows scripting of the licensing daemon "
+    ; "for testing and debugging. This tool is not intended to be used as "
+    ; "an end user tool"
+    ]
 
-open! Cmdliner
+let cmdline_gen () = List.map (fun t -> t V6_client.rpc) (Cmds.implementation ())
 
-let cmds =
-  List.map
-    (fun t ->
-      let t, i = t V6_client.rpc in
-      Cmd.v i t
-    )
-    (Cmds.implementation ())
+let cli =
+  Xcp_service.cli ~name:"licensing_cli" ~doc ~version:Cmds.description.version
+    ~cmdline_gen
 
-let cli () =
-  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
-  let info =
-    let doc =
-      String.concat ""
-        [
-          "A CLI for the V6d API. This allows scripting of the licensing daemon "
-        ; "for testing and debugging. This tool is not intended to be used as "
-        ; "an end user tool"
-        ]
-    in
-    Cmd.info "licensing_cli" ~version:(version_str Cmds.description) ~doc
-  in
-  let cmd = Cmd.group ~default info cmds in
-  Cmd.eval_value cmd
-
-let () = match cli () with Ok (`Ok f) -> f () | _ -> ()
+let () = Xcp_service.eval_cmdline cli

--- a/ocaml/xapi-idl/v6/v6_cli.ml
+++ b/ocaml/xapi-idl/v6/v6_cli.ml
@@ -6,24 +6,30 @@ let version_str description =
   let maj, min, mic = description.Idl.Interface.version in
   Printf.sprintf "%d.%d.%d" maj min mic
 
-let default_cmd =
-  let doc =
-    String.concat ""
-      [
-        "A CLI for the V6d API. This allows scripting of the licensing daemon "
-      ; "for testing and debugging. This tool is not intended to be used as an "
-      ; "end user tool"
-      ]
-  in
-  ( Cmdliner.Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ()))
-  , Cmdliner.Term.info "licensing_cli"
-      ~version:(version_str Cmds.description)
-      ~doc
-  )
+open! Cmdliner
+
+let cmds =
+  List.map
+    (fun t ->
+      let t, i = t V6_client.rpc in
+      Cmd.v i t
+    )
+    (Cmds.implementation ())
 
 let cli () =
-  let rpc = V6_client.rpc in
-  Cmdliner.Term.eval_choice default_cmd
-    (List.map (fun t -> t rpc) (Cmds.implementation ()))
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let info =
+    let doc =
+      String.concat ""
+        [
+          "A CLI for the V6d API. This allows scripting of the licensing daemon "
+        ; "for testing and debugging. This tool is not intended to be used as "
+        ; "an end user tool"
+        ]
+    in
+    Cmd.info "licensing_cli" ~version:(version_str Cmds.description) ~doc
+  in
+  let cmd = Cmd.group ~default info cmds in
+  Cmd.eval_value cmd
 
-let _ = match cli () with `Ok f -> f () | _ -> ()
+let () = match cli () with Ok (`Ok f) -> f () | _ -> ()

--- a/ocaml/xapi-idl/varstore/deprivileged/varstore_deprivileged_cli.ml
+++ b/ocaml/xapi-idl/varstore/deprivileged/varstore_deprivileged_cli.ml
@@ -14,10 +14,6 @@
 
 module Cmds = Varstore_deprivileged_interface.RPC_API (Cmdlinergen.Gen ())
 
-let version_str description =
-  let maj, min, mic = description.Idl.Interface.version in
-  Printf.sprintf "%d.%d.%d" maj min mic
-
 open! Cmdliner
 
 let cli () =
@@ -33,24 +29,19 @@ let cli () =
     uri := "file://" ^ file ;
     next
   in
-  let doc = "Path to deprivileged socket in /var/run/xen" in
   let path =
+    let doc = "Path to deprivileged socket in /var/run/xen" in
     Arg.(required & opt (some file) None & info ["socket"] ~doc ~docv:"SOCKET")
   in
-  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
-  let info =
-    Cmd.info "varstored_cli"
-      ~version:(version_str Cmds.description)
-      ~doc:"debug CLI"
-  in
-  let cmds =
+  let cmdline_gen () =
     List.map
       (fun t ->
         let term, info = t rpc in
-        Cmd.v info Term.(const wrapper $ path $ term $ const ())
+        (Term.(const wrapper $ path $ term $ const ()), info)
       )
       (Cmds.implementation ())
   in
-  Cmd.eval (Cmd.group ~default info cmds)
+  Xcp_service.cli ~name:"varstored_cli" ~doc:"debug CLI"
+    ~version:Cmds.description.version ~cmdline_gen
 
-let () = exit (cli ())
+let () = exit (Cmd.eval @@ cli ())

--- a/ocaml/xapi-idl/varstore/privileged/varstore_privileged_cli.ml
+++ b/ocaml/xapi-idl/varstore/privileged/varstore_privileged_cli.ml
@@ -20,33 +20,31 @@ let version_str description =
   let maj, min, mic = description.Idl.Interface.version in
   Printf.sprintf "%d.%d.%d" maj min mic
 
-let default_cmd =
-  let doc =
-    String.concat " "
-      [
-        "A CLI for the deprivileged socket spawning API."
-      ; "This allows scripting of the varstored deprivileging daemon"
-      ; "for testing and debugging. This tool is not intended to be used"
-      ; "as an end user tool"
-      ]
-  in
-  ( Cmdliner.Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ()))
-  , Cmdliner.Term.info "varstore_cli"
-      ~version:(version_str Cmds.description)
-      ~doc
-  )
+open! Cmdliner
 
 let cli () =
-  match
-    Cmdliner.Term.eval_choice default_cmd
-      (List.map
-         (fun t -> t Varstore_privileged_client.rpc)
-         (Cmds.implementation ())
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let info =
+    let doc =
+      String.concat " "
+        [
+          "A CLI for the deprivileged socket spawning API."
+        ; "This allows scripting of the varstored deprivileging daemon"
+        ; "for testing and debugging. This tool is not intended to be used"
+        ; "as an end user tool"
+        ]
+    in
+    Cmd.info "varstore_cli" ~version:(version_str Cmds.description) ~doc
+  in
+  let cmds =
+    List.map
+      (fun t ->
+        let t, i = t Varstore_privileged_client.rpc in
+        Cmd.v i t
       )
-  with
-  | `Ok f ->
-      f ()
-  | _ ->
-      ()
+      (Cmds.implementation ())
+  in
+  let cmd = Cmd.group ~default info cmds in
+  Cmd.eval_value cmd
 
-let _ = cli ()
+let () = match cli () with Ok (`Ok f) -> f () | _ -> ()

--- a/ocaml/xapi-storage-cli/main.ml
+++ b/ocaml/xapi-storage-cli/main.ml
@@ -86,7 +86,7 @@ let common_options_t =
     let doc = Printf.sprintf "Specify queue name in message switch." in
     Arg.(value & opt (some string) None & info ["queue"] ~docs ~doc)
   in
-  Term.(pure Common.make $ debug $ verb $ socket $ queue)
+  Term.(const Common.make $ debug $ verb $ socket $ queue)
 
 (* Help sections common to all commands *)
 let help =
@@ -463,8 +463,8 @@ let query_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure query $ common_options_t))
-  , Term.info "query" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const query $ common_options_t))
+  , Cmd.info "query" ~sdocs:_common_options ~doc ~man
   )
 
 let sr_arg =
@@ -495,8 +495,8 @@ let mirror_list_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure mirror_list $ common_options_t))
-  , Term.info "mirror-list" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const mirror_list $ common_options_t))
+  , Cmd.info "mirror-list" ~sdocs:_common_options ~doc ~man
   )
 
 let mirror_start_cmd =
@@ -525,7 +525,7 @@ let mirror_start_cmd =
   in
   ( Term.(
       ret
-        (pure mirror_start
+        (const mirror_start
         $ common_options_t
         $ sr_arg
         $ vdi_arg
@@ -534,7 +534,7 @@ let mirror_start_cmd =
         $ dest
         )
     )
-  , Term.info "mirror-start" ~sdocs:_common_options ~doc ~man
+  , Cmd.info "mirror-start" ~sdocs:_common_options ~doc ~man
   )
 
 let mirror_stop_cmd =
@@ -544,8 +544,8 @@ let mirror_stop_cmd =
     let doc = "ID of the mirror" in
     Arg.(value & pos 0 (some string) None & info [] ~docv:"ID" ~doc)
   in
-  ( Term.(ret (pure mirror_stop $ common_options_t $ id))
-  , Term.info "mirror-stop" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const mirror_stop $ common_options_t $ id))
+  , Cmd.info "mirror-stop" ~sdocs:_common_options ~doc ~man
   )
 
 let sr_attach_cmd =
@@ -575,8 +575,8 @@ let sr_attach_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure sr_attach $ common_options_t $ sr_arg $ device_config))
-  , Term.info "sr-attach" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const sr_attach $ common_options_t $ sr_arg $ device_config))
+  , Cmd.info "sr-attach" ~sdocs:_common_options ~doc ~man
   )
 
 let sr_detach_cmd =
@@ -591,8 +591,8 @@ let sr_detach_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure sr_detach $ common_options_t $ sr_arg))
-  , Term.info "sr-detach" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const sr_detach $ common_options_t $ sr_arg))
+  , Cmd.info "sr-detach" ~sdocs:_common_options ~doc ~man
   )
 
 let sr_stat_cmd =
@@ -607,8 +607,8 @@ let sr_stat_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure sr_stat $ common_options_t $ sr_arg))
-  , Term.info "sr-stat" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const sr_stat $ common_options_t $ sr_arg))
+  , Cmd.info "sr-stat" ~sdocs:_common_options ~doc ~man
   )
 
 let sr_scan_cmd =
@@ -622,8 +622,8 @@ let sr_scan_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure sr_scan $ common_options_t $ sr_arg))
-  , Term.info "sr-scan" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const sr_scan $ common_options_t $ sr_arg))
+  , Cmd.info "sr-scan" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_create_cmd =
@@ -666,7 +666,7 @@ let vdi_create_cmd =
   in
   ( Term.(
       ret
-        (pure vdi_create
+        (const vdi_create
         $ common_options_t
         $ sr_arg
         $ name_arg
@@ -676,7 +676,7 @@ let vdi_create_cmd =
         $ format_arg
         )
     )
-  , Term.info "vdi-create" ~sdocs:_common_options ~doc ~man
+  , Cmd.info "vdi-create" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_clone_cmd =
@@ -705,7 +705,7 @@ let vdi_clone_cmd =
   in
   ( Term.(
       ret
-        (pure vdi_clone
+        (const vdi_clone
         $ common_options_t
         $ sr_arg
         $ vdi_arg
@@ -713,7 +713,7 @@ let vdi_clone_cmd =
         $ descr_arg
         )
     )
-  , Term.info "vdi-clone" ~sdocs:_common_options ~doc ~man
+  , Cmd.info "vdi-clone" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_resize_cmd =
@@ -733,9 +733,9 @@ let vdi_resize_cmd =
     @ help
   in
   ( Term.(
-      ret (pure vdi_resize $ common_options_t $ sr_arg $ vdi_arg $ new_size_arg)
+      ret (const vdi_resize $ common_options_t $ sr_arg $ vdi_arg $ new_size_arg)
     )
-  , Term.info "vdi-resize" ~sdocs:_common_options ~doc ~man
+  , Cmd.info "vdi-resize" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_compose_cmd =
@@ -751,9 +751,9 @@ let vdi_compose_cmd =
       ~doc:"unique identifier for the VDI whose contents should be applied"
   in
   ( Term.(
-      ret (pure vdi_compose $ common_options_t $ sr_arg $ vdi_arg $ vdi2_arg)
+      ret (const vdi_compose $ common_options_t $ sr_arg $ vdi_arg $ vdi2_arg)
     )
-  , Term.info "vdi-compose" ~sdocs:_common_options ~doc ~man
+  , Cmd.info "vdi-compose" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_destroy_cmd =
@@ -765,8 +765,8 @@ let vdi_destroy_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_destroy $ common_options_t $ sr_arg $ vdi_arg))
-  , Term.info "vdi-destroy" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const vdi_destroy $ common_options_t $ sr_arg $ vdi_arg))
+  , Cmd.info "vdi-destroy" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_attach_cmd =
@@ -781,8 +781,8 @@ let vdi_attach_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_attach $ common_options_t $ sr_arg $ vdi_arg))
-  , Term.info "vdi-attach" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const vdi_attach $ common_options_t $ sr_arg $ vdi_arg))
+  , Cmd.info "vdi-attach" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_detach_cmd =
@@ -796,8 +796,8 @@ let vdi_detach_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_detach $ common_options_t $ sr_arg $ vdi_arg $ vm_arg))
-  , Term.info "vdi-detach" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const vdi_detach $ common_options_t $ sr_arg $ vdi_arg $ vm_arg))
+  , Cmd.info "vdi-detach" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_activate_cmd =
@@ -811,8 +811,8 @@ let vdi_activate_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_activate $ common_options_t $ sr_arg $ vdi_arg))
-  , Term.info "vdi-activate" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const vdi_activate $ common_options_t $ sr_arg $ vdi_arg))
+  , Cmd.info "vdi-activate" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_deactivate_cmd =
@@ -828,9 +828,9 @@ let vdi_deactivate_cmd =
     @ help
   in
   ( Term.(
-      ret (pure vdi_deactivate $ common_options_t $ sr_arg $ vdi_arg $ vm_arg)
+      ret (const vdi_deactivate $ common_options_t $ sr_arg $ vdi_arg $ vm_arg)
     )
-  , Term.info "vdi-deactivate" ~sdocs:_common_options ~doc ~man
+  , Cmd.info "vdi-deactivate" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_similar_content_cmd =
@@ -846,8 +846,8 @@ let vdi_similar_content_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_similar_content $ common_options_t $ sr_arg $ vdi_arg))
-  , Term.info "vdi-similar-content" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const vdi_similar_content $ common_options_t $ sr_arg $ vdi_arg))
+  , Cmd.info "vdi-similar-content" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_enable_cbt_cmd =
@@ -859,8 +859,8 @@ let vdi_enable_cbt_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_enable_cbt $ common_options_t $ sr_arg $ vdi_arg))
-  , Term.info "vdi-enable-cbt" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const vdi_enable_cbt $ common_options_t $ sr_arg $ vdi_arg))
+  , Cmd.info "vdi-enable-cbt" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_disable_cbt_cmd =
@@ -872,8 +872,8 @@ let vdi_disable_cbt_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_disable_cbt $ common_options_t $ sr_arg $ vdi_arg))
-  , Term.info "vdi-disable-cbt" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const vdi_disable_cbt $ common_options_t $ sr_arg $ vdi_arg))
+  , Cmd.info "vdi-disable-cbt" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_data_destroy_cmd =
@@ -890,8 +890,8 @@ let vdi_data_destroy_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure vdi_data_destroy $ common_options_t $ sr_arg $ vdi_arg))
-  , Term.info "vdi-data-destroy" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const vdi_data_destroy $ common_options_t $ sr_arg $ vdi_arg))
+  , Cmd.info "vdi-data-destroy" ~sdocs:_common_options ~doc ~man
   )
 
 let vdi_list_changed_blocks_cmd =
@@ -910,21 +910,14 @@ let vdi_list_changed_blocks_cmd =
   in
   ( Term.(
       ret
-        (pure vdi_list_changed_blocks
+        (const vdi_list_changed_blocks
         $ common_options_t
         $ sr_arg
         $ vdi_arg
         $ vdi2_arg
         )
     )
-  , Term.info "vdi-list-changed-blocks" ~sdocs:_common_options ~doc ~man
-  )
-
-let default_cmd =
-  let doc = "interact with an XCP storage management service" in
-  let man = help in
-  ( Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ common_options_t))
-  , Term.info "sm-cli" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
+  , Cmd.info "vdi-list-changed-blocks" ~sdocs:_common_options ~doc ~man
   )
 
 let cmds =
@@ -952,10 +945,15 @@ let cmds =
   ; mirror_start_cmd
   ; mirror_stop_cmd
   ]
+  |> List.map (fun (t, i) -> Cmd.v i t)
 
 let () =
-  match Term.eval_choice default_cmd cmds with
-  | `Error _ ->
-      exit 1
-  | _ ->
-      exit 0
+  let default =
+    Term.(ret (const (fun _ -> `Help (`Pager, None)) $ common_options_t))
+  in
+  let doc = "interact with an XCP storage management service" in
+  let info =
+    Cmd.info "sm-cli" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man:help
+  in
+  let cmd = Cmd.group ~default info cmds in
+  exit (Cmd.eval cmd)

--- a/ocaml/xapi-storage-script/examples/volume/org.xen.xcp.storage.plainlvm/common.ml
+++ b/ocaml/xapi-storage-script/examples/volume/org.xen.xcp.storage.plainlvm/common.ml
@@ -256,7 +256,7 @@ let common_options_t =
     let doc = "Expect json on stdin, print json on stdout." in
     Arg.(value & flag & info ["json"] ~docs ~doc)
   in
-  Term.(pure make $ debug $ verb $ test $ json)
+  Term.(const make $ debug $ verb $ test $ json)
 
 let help =
   [
@@ -318,7 +318,7 @@ module Make (C : Command) (T : Test) = struct
   let cmd =
     let doc = C.CommandLine.doc in
     let man = help in
-    ( Term.(ret (pure wrap $ common_options_t $ C.CommandLine.t))
+    ( Term.(ret (const wrap $ common_options_t $ C.CommandLine.t))
     , Term.info Sys.argv.(0) ~version ~sdocs:_common_options ~doc ~man
     )
 

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1797,15 +1797,8 @@ let _ =
       )
     ]
   in
-  ( match
-      configure2 ~name:"xapi-script-storage" ~version:Version.version
-        ~doc:description ~resources ~options ()
-    with
-  | `Ok () ->
-      ()
-  | `Error x ->
-      error "Error: %s\n%!" x ; Stdlib.exit 1
-  ) ;
+  configure2 ~name:"xapi-script-storage" ~version:Version.version
+    ~doc:description ~resources ~options () ;
   if !Xcp_service.daemon then (
     Xcp_service.maybe_daemonize () ;
     use_syslog := true ;

--- a/ocaml/xapi-storage/generator/src/main.ml
+++ b/ocaml/xapi-storage/generator/src/main.ml
@@ -1,4 +1,4 @@
-open Cmdliner
+open! Cmdliner
 
 let gen_markdown path =
   let open Xapi_storage in
@@ -53,9 +53,7 @@ let gen_python_cmd =
       & info ["p"; "path"] ~doc ~docv:"PATH"
     )
   in
-  ( Term.(ret (const gen_python $ path))
-  , Term.info "gen_python" ~doc ~exits:Term.default_exits
-  )
+  Cmd.v (Cmd.info "gen_python" ~doc) Term.(ret (const gen_python $ path))
 
 let gen_markdown_cmd =
   let doc = "Generate documentation files in markdown format" in
@@ -63,15 +61,10 @@ let gen_markdown_cmd =
     let doc = "Generate the files in the path specified" in
     Arg.(value & opt string "." & info ["p"; "path"] ~doc ~docv:"PATH")
   in
-  ( Term.(ret (const gen_markdown $ path))
-  , Term.info "gen_markdown" ~doc ~exits:Term.default_exits
-  )
+  Cmd.v (Cmd.info "gen_markdown" ~doc) Term.(ret (const gen_markdown $ path))
 
-let default_cmd =
-  let doc = "SMAPI code/documentation generation tool" in
-  ( Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ()))
-  , Term.info "main" ~doc ~exits:Term.default_exits
-  )
-
-let _ =
-  Term.(exit @@ eval_choice default_cmd [gen_python_cmd; gen_markdown_cmd])
+let () =
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let info = Cmd.info "main" ~doc:"SMAPI code/documentation generation tool" in
+  let cmd = Cmd.group ~default info [gen_python_cmd; gen_markdown_cmd] in
+  exit @@ Cmd.eval cmd

--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -987,16 +987,8 @@ let _ =
   Debug.set_facility Syslog.Local5 ;
   (* Read configuration file. *)
   debug "Reading configuration file .." ;
-  ( match
-      Xcp_service.configure2 ~name:Sys.argv.(0) ~version:Version.version ~doc
-        ~options ()
-    with
-  | `Ok () ->
-      ()
-  | `Error m ->
-      Printf.fprintf stderr "%s\n" m ;
-      exit 1
-  ) ;
+  Xcp_service.configure2 ~name:Sys.argv.(0) ~version:Version.version ~doc
+    ~options () ;
   Xcp_service.maybe_daemonize () ;
   debug "Starting the HTTP server .." ;
   (* Eventually we should switch over to xcp_service to declare our services,

--- a/ocaml/xcp-rrdd/bin/transport-rw/writer.ml
+++ b/ocaml/xcp-rrdd/bin/transport-rw/writer.ml
@@ -21,13 +21,6 @@ let help_secs =
   ; `Noblank
   ]
 
-let default_cmd =
-  let doc = "RRD protocol writer" in
-  let man = help_secs in
-  ( Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ pure ()))
-  , Term.info "writer" ~version:"0.1" ~doc ~man
-  )
-
 let write_file_cmd =
   let path =
     let doc = "The path of the file to write" in
@@ -45,9 +38,9 @@ let write_file_cmd =
     ]
     @ help_secs
   in
-  ( Term.(pure Writer_commands.write_file $ path $ protocol)
-  , Term.info "file" ~doc ~man
-  )
+  Cmd.v
+    (Cmd.info "file" ~doc ~man)
+    Term.(const Writer_commands.write_file $ path $ protocol)
 
 let write_page_cmd =
   let domid =
@@ -66,15 +59,15 @@ let write_page_cmd =
     ]
     @ help_secs
   in
-  ( Term.(pure Writer_commands.write_page $ domid $ protocol)
-  , Term.info "page" ~doc ~man
-  )
+  Cmd.v
+    (Cmd.info "page" ~doc ~man)
+    Term.(const Writer_commands.write_page $ domid $ protocol)
 
 let cmds = [write_file_cmd; write_page_cmd]
 
 let () =
-  match Term.eval_choice default_cmd cmds with
-  | `Error _ ->
-      exit 1
-  | _ ->
-      exit 0
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  let doc = "RRD protocol writer" in
+  let info = Cmd.info "writer" ~version:"0.1" ~doc ~man:help_secs in
+  let cmd = Cmd.group ~default info cmds in
+  exit (Cmd.eval cmd)

--- a/ocaml/xenopsd/cli/dune
+++ b/ocaml/xenopsd/cli/dune
@@ -30,9 +30,10 @@
 )
 
 (rule
- (targets xenops-cli.1.gz)
+ (target xenops-cli.1.gz)
+ (deps (:man xenops-cli.1))
  (action
-  (run gzip %{dep:xenops-cli.1}))
+  (with-stdout-to %{target} (with-stdin-from %{man} (run gzip))))
 )
 
 (install

--- a/ocaml/xenopsd/cli/main.ml
+++ b/ocaml/xenopsd/cli/main.ml
@@ -56,7 +56,7 @@ let common_options_t =
     let doc = Printf.sprintf "Specify queue name in message switch." in
     Arg.(value & opt (some string) default & info ["queue"] ~docs ~doc)
   in
-  Term.(pure Common.make $ debug $ verb $ socket $ queue)
+  Term.(const Common.make $ debug $ verb $ socket $ queue)
 
 (* Commands *)
 
@@ -71,8 +71,8 @@ let events_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.events $ common_options_t))
-  , Term.info "events" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.events $ common_options_t))
+  , Cmd.info "events" ~sdocs:_common_options ~doc ~man
   )
 
 let create_cmd =
@@ -93,8 +93,8 @@ let create_cmd =
     let doc = "Connect to the VM's console." in
     Arg.(value & flag & info ["console"] ~doc)
   in
-  ( Term.(ret (pure Xn.create $ common_options_t $ filename $ console))
-  , Term.info "create" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.create $ common_options_t $ filename $ console))
+  , Cmd.info "create" ~sdocs:_common_options ~doc ~man
   )
 
 let add_cmd =
@@ -106,8 +106,8 @@ let add_cmd =
     let doc = Printf.sprintf "Path to the VM metadata to be registered." in
     Arg.(value & pos 0 (some file) None & info [] ~doc)
   in
-  ( Term.(ret (pure Xn.add $ common_options_t $ filename))
-  , Term.info "add" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.add $ common_options_t $ filename))
+  , Cmd.info "add" ~sdocs:_common_options ~doc ~man
   )
 
 let list_cmd =
@@ -125,8 +125,8 @@ let list_cmd =
     ]
     @ help
   in
-  ( Term.(pure Xn.list $ common_options_t)
-  , Term.info "list" ~sdocs:_common_options ~doc ~man
+  ( Term.(const Xn.list $ common_options_t)
+  , Cmd.info "list" ~sdocs:_common_options ~doc ~man
   )
 
 let vm_arg verb =
@@ -158,8 +158,8 @@ let remove_cmd =
     ; `P "Something about power state exceptions"
     ]
   in
-  ( Term.(ret (pure Xn.remove $ common_options_t $ vm))
-  , Term.info "remove" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.remove $ common_options_t $ vm))
+  , Cmd.info "remove" ~sdocs:_common_options ~doc ~man
   )
 
 let start_cmd =
@@ -189,8 +189,8 @@ let start_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.start $ common_options_t $ paused $ console $ vm))
-  , Term.info "start" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.start $ common_options_t $ paused $ console $ vm))
+  , Cmd.info "start" ~sdocs:_common_options ~doc ~man
   )
 
 let console_cmd =
@@ -210,8 +210,8 @@ let console_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.console_connect $ common_options_t $ vm))
-  , Term.info "console" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.console_connect $ common_options_t $ vm))
+  , Cmd.info "console" ~sdocs:_common_options ~doc ~man
   )
 
 let shutdown_cmd =
@@ -238,8 +238,8 @@ let shutdown_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.shutdown $ common_options_t $ timeout $ vm))
-  , Term.info "shutdown" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.shutdown $ common_options_t $ timeout $ vm))
+  , Cmd.info "shutdown" ~sdocs:_common_options ~doc ~man
   )
 
 let reboot_cmd =
@@ -267,8 +267,8 @@ let reboot_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.reboot $ common_options_t $ timeout $ vm))
-  , Term.info "reboot" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.reboot $ common_options_t $ timeout $ vm))
+  , Cmd.info "reboot" ~sdocs:_common_options ~doc ~man
   )
 
 let suspend_cmd =
@@ -290,8 +290,8 @@ let suspend_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.suspend $ common_options_t $ device $ vm))
-  , Term.info "suspend" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.suspend $ common_options_t $ device $ vm))
+  , Cmd.info "suspend" ~sdocs:_common_options ~doc ~man
   )
 
 let resume_cmd =
@@ -313,8 +313,8 @@ let resume_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.resume $ common_options_t $ device $ vm))
-  , Term.info "resume" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.resume $ common_options_t $ device $ vm))
+  , Cmd.info "resume" ~sdocs:_common_options ~doc ~man
   )
 
 let pause_cmd =
@@ -333,8 +333,8 @@ let pause_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.pause $ common_options_t $ vm))
-  , Term.info "pause" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.pause $ common_options_t $ vm))
+  , Cmd.info "pause" ~sdocs:_common_options ~doc ~man
   )
 
 let unpause_cmd =
@@ -352,8 +352,8 @@ let unpause_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.unpause $ common_options_t $ vm))
-  , Term.info "unpause" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.unpause $ common_options_t $ vm))
+  , Cmd.info "unpause" ~sdocs:_common_options ~doc ~man
   )
 
 let import_cmd =
@@ -380,8 +380,8 @@ let import_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.import $ common_options_t $ metadata $ filename))
-  , Term.info "import" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.import $ common_options_t $ metadata $ filename))
+  , Cmd.info "import" ~sdocs:_common_options ~doc ~man
   )
 
 let export_cmd =
@@ -410,9 +410,9 @@ let export_cmd =
     @ help
   in
   ( Term.(
-      ret (pure Xn.export $ common_options_t $ metadata $ xm $ filename $ vm)
+      ret (const Xn.export $ common_options_t $ metadata $ xm $ filename $ vm)
     )
-  , Term.info "export" ~sdocs:_common_options ~doc ~man
+  , Cmd.info "export" ~sdocs:_common_options ~doc ~man
   )
 
 let diagnostics_cmd =
@@ -424,8 +424,8 @@ let diagnostics_cmd =
     ]
     @ help
   in
-  ( Term.(ret (pure Xn.diagnostics $ common_options_t))
-  , Term.info "diagnostics" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.diagnostics $ common_options_t))
+  , Cmd.info "diagnostics" ~sdocs:_common_options ~doc ~man
   )
 
 let tasks_cmd =
@@ -433,8 +433,8 @@ let tasks_cmd =
   let man =
     [`S "DESCRIPTION"; `P "Describe the set of in-progress tasks."] @ help
   in
-  ( Term.(ret (pure Xn.task_list $ common_options_t))
-  , Term.info "tasks" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.task_list $ common_options_t))
+  , Cmd.info "tasks" ~sdocs:_common_options ~doc ~man
   )
 
 let task_cancel_cmd =
@@ -452,8 +452,8 @@ let task_cancel_cmd =
     let doc = "Task id to cancel" in
     Arg.(value & pos 0 (some string) None & info [] ~doc)
   in
-  ( Term.(ret (pure Xn.task_cancel $ common_options_t $ task))
-  , Term.info "task-cancel" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.task_cancel $ common_options_t $ task))
+  , Cmd.info "task-cancel" ~sdocs:_common_options ~doc ~man
   )
 
 let cd_eject_cmd =
@@ -463,8 +463,8 @@ let cd_eject_cmd =
     let doc = "VBD id" in
     Arg.(value & pos 0 (some string) None & info [] ~doc)
   in
-  ( Term.(ret (pure Xn.cd_eject $ common_options_t $ vbd))
-  , Term.info "cd-eject" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.cd_eject $ common_options_t $ vbd))
+  , Cmd.info "cd-eject" ~sdocs:_common_options ~doc ~man
   )
 
 let stat_vm_cmd =
@@ -476,15 +476,8 @@ let stat_vm_cmd =
     let doc = "The uuid of the VM to stat." in
     Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"uuid")
   in
-  ( Term.(ret (pure Xn.stat_vm $ common_options_t $ vm))
-  , Term.info "vm-stat" ~sdocs:_common_options ~doc ~man
-  )
-
-let default_cmd =
-  let doc = "interact with the XCP xenopsd VM management service" in
-  let man = help in
-  ( Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ common_options_t))
-  , Term.info "xenops-cli" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
+  ( Term.(ret (const Xn.stat_vm $ common_options_t $ vm))
+  , Cmd.info "vm-stat" ~sdocs:_common_options ~doc ~man
   )
 
 let cmds =
@@ -510,11 +503,17 @@ let cmds =
   ; cd_eject_cmd
   ; stat_vm_cmd
   ]
+  |> List.map (fun (t, i) -> Cmd.v i t)
 
-let _ =
+let default =
+  Term.(ret (const (fun _ -> `Help (`Pager, None)) $ common_options_t))
+
+let info =
+  let doc = "interact with the XCP xenopsd VM management service" in
+  let man = help in
+  Cmd.info "xenops-cli" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
+
+let () =
   Xcp_client.use_switch := false ;
-  match Term.eval_choice default_cmd cmds with
-  | `Error _ ->
-      exit 1
-  | _ ->
-      exit 0
+  let cmd = Cmd.group ~default info cmds in
+  exit (Cmd.eval cmd)

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -399,15 +399,9 @@ let configure ?(specific_options = []) ?(specific_essential_paths = [])
       ~essentials:(Resources.essentials @ specific_essential_paths)
       ~nonessentials:(Resources.nonessentials @ specific_nonessential_paths)
   in
-  match
-    Xcp_service.configure2
-      ~name:(Filename.basename Sys.argv.(0))
-      ~version:Build_info.version ~doc ~options ~resources ()
-  with
-  | `Ok () ->
-      ()
-  | `Error m ->
-      error "%s" m ; exit 1
+  Xcp_service.configure2
+    ~name:(Filename.basename Sys.argv.(0))
+    ~version:Build_info.version ~doc ~options ~resources ()
 
 let main backend =
   Printexc.record_backtrace true ;

--- a/ocaml/xenopsd/simulator/dune
+++ b/ocaml/xenopsd/simulator/dune
@@ -16,9 +16,10 @@
 )
 
 (rule
- (targets xenopsd-simulator.1.gz)
+ (target xenopsd-simulator.1.gz)
+ (deps (:man xenopsd-simulator.1))
  (action
-  (run gzip %{dep:xenopsd-simulator.1}))
+  (with-stdout-to %{target} (with-stdin-from %{man} (run gzip))))
 )
 
 (install

--- a/ocaml/xenopsd/suspend_image_viewer/suspend_image_viewer.ml
+++ b/ocaml/xenopsd/suspend_image_viewer/suspend_image_viewer.ml
@@ -139,11 +139,6 @@ let () =
       )
     ]
   in
-  match
-    Xcp_service.configure2 ~name:"suspend-image-viewer"
-      ~version:Build_info.version ~resources ~doc ~options ()
-  with
-  | `Ok () ->
-      print_image !path
-  | `Error m ->
-      error "%s" m ; exit 1
+  Xcp_service.configure2 ~name:"suspend-image-viewer"
+    ~version:Build_info.version ~resources ~doc ~options () ;
+  print_image !path

--- a/ocaml/xenopsd/tools/set_domain_uuid.ml
+++ b/ocaml/xenopsd/tools/set_domain_uuid.ml
@@ -22,7 +22,7 @@ open Cmdliner
 let info =
   let doc = "Utility to set a domain's uuid" in
   let man = [] in
-  Term.info "set_domain_uuid" ~version:"1.0" ~doc ~man
+  Cmd.info "set_domain_uuid" ~version:"1.0" ~doc ~man
 
 let uuid =
   let doc = "Uuid of the domain" in
@@ -32,6 +32,6 @@ let domid =
   let doc = "Id of the domain" in
   Arg.(required & pos 1 (some int) None & info [] ~docv:"DOMID" ~doc)
 
-let cmd = Term.(ret (pure set $ domid $ uuid))
+let cmd = Term.(ret (const set $ domid $ uuid))
 
-let () = match Term.eval (cmd, info) with `Error _ -> exit 1 | _ -> exit 0
+let () = exit (Cmd.eval (Cmd.v info cmd))

--- a/ocaml/xenopsd/xc/dune
+++ b/ocaml/xenopsd/xc/dune
@@ -137,9 +137,10 @@
 )
 
 (rule
- (targets xenopsd-xc.1.gz)
+ (target xenopsd-xc.1.gz)
+ (deps (:man xenopsd-xc.1))
  (action
-  (run gzip %{dep:xenopsd-xc.1}))
+   (with-stdout-to %{target} (with-stdin-from %{man} (run gzip))))
 )
 
 (install


### PR DESCRIPTION
This introduces quite a bit of churn, but it fixes several inconsistencies on how the xcp-idl  binaries handle error codes and simplifies how Xcp_service.configure2 works: now it exists when an error happens, and returns a unit, so no actions from the caller are needed.

This PR depends on rpclib 9.0.0, which forces a bit of complication to process the result of the cmdline generator, but aside from the boilerplate it should be fine.

Marked as draft as it needs changes in xs-opam.

TODO: 
- [x] change `Xcp_service.eval_cmdline` to print errors on failure
- [x] support changes introduced by rpclib 8.1.2