### PR TITLE
CA-367979: Bugfixes to support livepatches

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1942,7 +1942,9 @@ let _ =
   error Api_errors.invalid_repository_proxy_credential []
     ~doc:"The repository proxy username/password is invalid." () ;
   error Api_errors.apply_livepatch_failed ["livepatch"]
-    ~doc:"Failed to apply a livepatch." ()
+    ~doc:"Failed to apply a livepatch." () ;
+  error Api_errors.update_guidance_changed ["guidance"]
+    ~doc:"Guidance for the update has changed" ()
 
 let _ =
   message

--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -502,7 +502,8 @@ end)
 
 module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
   module Io = struct
-    type input_t = ((string * UpdateInfo.t) list * Update.t) * string list
+    type input_t =
+      ((string * UpdateInfo.t) list * Update.t) * (string list * string list)
 
     type output_t = Guidance.t option
 
@@ -515,7 +516,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                  (list (pair string (record @@ fields_of_updateinfo)))
                  (record @@ fields_of_update)
               )
-              (list string)
+              (pair (list string) (list string))
           )
       )
 
@@ -523,10 +524,15 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
       Fmt.(str "%a" Dump.(string)) (UpdateInfo.guidance_to_string g)
   end
 
-  let transform ((updates_info, update), upd_ids_of_livepatches) =
+  let transform
+      ( (updates_info, update)
+      , (upd_ids_of_livepatches, upd_ids_of_failed_livepatches)
+      ) =
     eval_guidance_for_one_update ~updates_info ~update
       ~kind:Guidance.Recommended
       ~upd_ids_of_livepatches:(UpdateIdSet.of_list upd_ids_of_livepatches)
+      ~upd_ids_of_failed_livepatches:
+        (UpdateIdSet.of_list upd_ids_of_failed_livepatches)
 
   let tests =
     `QuickAndAutoDocumented
@@ -549,7 +555,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , None
         )
@@ -606,7 +612,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , None
         )
@@ -645,7 +651,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , None
         )
@@ -701,7 +707,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , Some Guidance.RebootHost
         )
@@ -771,7 +777,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , Some Guidance.RestartDeviceModel
         )
@@ -853,7 +859,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , Some Guidance.RestartDeviceModel
         )
@@ -923,7 +929,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , None
         )
@@ -992,7 +998,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , None
         )
@@ -1074,7 +1080,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , []
+          , ([], [])
           )
         , Some Guidance.RestartDeviceModel
         )
@@ -1137,7 +1143,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , ["UPDATE-0000"]
+          , (["UPDATE-0000"], [])
           )
         , Some Guidance.RestartDeviceModel
         )
@@ -1189,7 +1195,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , ["UPDATE-0000"]
+          , (["UPDATE-0000"], [])
           )
         , None
         )
@@ -1273,7 +1279,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , ["UPDATE-0000"]
+          , (["UPDATE-0000"], [])
           )
         , Some Guidance.RebootHost
         )
@@ -1366,7 +1372,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , ["UPDATE-0001"]
+          , (["UPDATE-0001"], [])
           )
         , Some Guidance.RestartToolstack
         )
@@ -1435,7 +1441,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , ["UPDATE-0000"]
+          , (["UPDATE-0000"], [])
           )
         , None
         )
@@ -1504,7 +1510,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 }
               
             )
-          , ["UPDATE-0000"]
+          , (["UPDATE-0000"], [])
           )
         , Some Guidance.RebootHost
         )

--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -1514,6 +1514,99 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
           )
         , Some Guidance.RebootHost
         )
+      ; (* livepatch_guidance: failure of applying livepatch *)
+        ( ( ( [
+                ( "UPDATE-0000"
+                , UpdateInfo.
+                    {
+                      id= "UPDATE-0000"
+                    ; summary= "summary"
+                    ; description= "description"
+                    ; rec_guidance= Some Guidance.RebootHost
+                    ; abs_guidance= None
+                    ; guidance_applicabilities= [] (* No applicabilities *)
+                    ; spec_info= "special info"
+                    ; url= "https://update.details.info"
+                    ; update_type= "security"
+                    ; livepatch_guidance= Some Guidance.RestartToolstack
+                    ; livepatches=
+                        [
+                          LivePatch.
+                            {
+                              component= Livepatch.Xen
+                            ; base_build_id=
+                                "9346194f2e98a228f5a595b13ecabd43a99fada0"
+                            ; base_version= "4.13.4"
+                            ; base_release= "10.24.xs8"
+                            ; to_version= "4.13.4"
+                            ; to_release= "10.25.xs8"
+                            }
+                          
+                        ; LivePatch.
+                            {
+                              component= Livepatch.Kernel
+                            ; base_build_id=
+                                "8346194f2e98a228f5a595b13ecabd43a99fada0"
+                            ; base_version= "4.19.19"
+                            ; base_release= "8.0.20.xs8"
+                            ; to_version= "4.19.19"
+                            ; to_release= "8.0.21.xs8"
+                            }
+                          
+                        ]
+                    }
+                  
+                )
+              ; ( "UPDATE-0001"
+                , UpdateInfo.
+                    {
+                      id= "UPDATE-0001"
+                    ; summary= "summary"
+                    ; description= "description"
+                    ; rec_guidance= Some Guidance.RebootHost
+                    ; abs_guidance= None
+                    ; guidance_applicabilities= [] (* No applicabilities *)
+                    ; spec_info= "special info"
+                    ; url= "https://update.details.info"
+                    ; update_type= "security"
+                    ; livepatch_guidance= None
+                    ; livepatches=
+                        [
+                          LivePatch.
+                            {
+                              component= Livepatch.Kernel
+                            ; base_build_id=
+                                "8346194f2e98a228f5a595b13ecabd43a99fada0"
+                            ; base_version= "4.19.19"
+                            ; base_release= "8.0.20.xs8"
+                            ; to_version= "4.19.19"
+                            ; to_release= "8.0.22.xs8"
+                            }
+                          
+                        ]
+                    }
+                  
+                )
+              ]
+            , Update.
+                {
+                  name= "kernel"
+                ; arch= "x86_64"
+                ; old_epoch= Some None
+                ; old_version= Some "4.19.19"
+                ; old_release= Some "10.20.xs8"
+                ; new_epoch= None
+                ; new_version= "4.19.19"
+                ; new_release= "8.0.22.xs8"
+                ; update_id= Some "UPDATE-0001"
+                ; repository= "regular"
+                }
+              
+            )
+          , (["UPDATE-0000"], ["UPDATE-0001"])
+          )
+        , None
+        )
       ]
 end)
 

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1279,3 +1279,5 @@ let invalid_repository_proxy_credential = "INVALID_REPOSITORY_PROXY_CREDENTIAL"
 let dynamic_memory_control_unavailable = "DYNAMIC_MEMORY_CONTROL_UNAVAILABLE"
 
 let apply_livepatch_failed = "APPLY_LIVEPATCH_FAILED"
+
+let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -871,6 +871,9 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
     in
     match failed_livepatches with
     | [] ->
+        (* No livepatch should be applicable now *)
+        Db.Host.remove_pending_guidances ~__context ~self:host
+          ~value:`reboot_host_on_livepatch_failure ;
         (immediate_guidances', pending_guidances')
     | _ :: _ ->
         (* There is(are) livepatch failure(s):

--- a/ocaml/xapi/updateinfo.ml
+++ b/ocaml/xapi/updateinfo.ml
@@ -286,8 +286,11 @@ module LivePatch = struct
     `Assoc
       [
         ("component", `String (Livepatch.string_of_component lp.component))
-      ; ("base", `String (lp.base_version ^ "-" ^ lp.base_release))
-      ; ("to", `String (lp.to_version ^ "-" ^ lp.to_release))
+      ; ("base_build_id", `String lp.base_build_id)
+      ; ("base_version", `String lp.base_version)
+      ; ("base_release", `String lp.base_release)
+      ; ("to_version", `String lp.to_version)
+      ; ("to_release", `String lp.to_release)
       ]
 
   let to_string lp = Yojson.Basic.pretty_to_string (to_json lp)
@@ -429,9 +432,7 @@ module UpdateInfo = struct
           ( "livepatch-guidance"
           , `String (guidance_to_string ui.livepatch_guidance)
           )
-          :: ( "livepatches"
-             , `List (List.map (fun x -> `String (LivePatch.to_string x)) lps)
-             )
+          :: ("livepatches", `List (List.map (fun x -> LivePatch.to_json x) lps))
           :: l
         in
         `Assoc l'


### PR DESCRIPTION
This series contains a few bug fixes to support livepatch function:

1. Bugfix - Remove RebootHostOnLivePatchFailure after a completion of update
2. Return changed guidance from host.apply_updates
3. Bugfix - Add new unit test for livepatch failure case
4. Bugfix - Add RebootHost guidance wrongly when a livepatch failed
5. Bugfix - Wrong format of livepatch in returned updateinfo