### PR TITLE
CA-368069: Got wrong kernel base build_id

### DIFF
--- a/ocaml/xapi/livepatch.ml
+++ b/ocaml/xapi/livepatch.ml
@@ -82,7 +82,7 @@ let get_latest_livepatch lps =
 module BuildId = struct
   let one_byte =
     let open Angstrom in
-    any_uint8 >>= fun c -> return (Printf.sprintf "%0x" c)
+    any_uint8 >>= fun c -> return (Printf.sprintf "%02x" c)
 
   let all_bytes = Angstrom.many one_byte
 end


### PR DESCRIPTION
The bug is the build id should be presented as hexadecimal with width 2.

Signed-off-by: Ming Lu <ming.lu@citrix.com>