### PR TITLE
CP-40032: Expose VTPM creation and destruction both on the CLI and the API

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1940,9 +1940,11 @@ let _ =
   error Api_errors.invalid_repository_proxy_url ["url"]
     ~doc:"The repository proxy URL is invalid." () ;
   error Api_errors.invalid_repository_proxy_credential []
-    ~doc:"The repository proxy username/password is invalid." ()
+    ~doc:"The repository proxy username/password is invalid." () ;
 
-let _ =
+  error Api_errors.vtpm_max_amount_reached ["amount"]
+    ~doc:"The VM cannot be associated with more VTPMs." () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3569,6 +3569,24 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "vtpm-create"
+    , {
+        reqd= ["vm-uuid"]
+      ; optn= []
+      ; help= "Create a VTPM associated with a VM."
+      ; implementation= No_fd Cli_operations.VTPM.create
+      ; flags= []
+      }
+    )
+  ; ( "vtpm-destroy"
+    , {
+        reqd= ["uuid"]
+      ; optn= []
+      ; help= "Destroy a VTPM"
+      ; implementation= No_fd Cli_operations.VTPM.destroy
+      ; flags= []
+      }
+    )
   ]
 
 let cmdtable : (string, cmd_spec) Hashtbl.t = Hashtbl.create 50

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7828,3 +7828,17 @@ module Repository = struct
     Client.Repository.set_gpgkey_path ~rpc ~session_id ~self:ref
       ~value:gpgkey_path
 end
+
+module VTPM = struct
+  let create printer rpc session_id params =
+    let vm_uuid = List.assoc "vm-uuid" params in
+    let vM = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
+    let ref = Client.VTPM.create ~rpc ~session_id ~vM in
+    let uuid = Client.VTPM.get_uuid ~rpc ~session_id ~self:ref in
+    printer (Cli_printer.PList [uuid])
+
+  let destroy _ rpc session_id params =
+    let uuid = List.assoc "uuid" params in
+    let ref = Client.VTPM.get_by_uuid ~rpc ~session_id ~uuid in
+    Client.VTPM.destroy ~rpc ~session_id ~self:ref
+end

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1277,3 +1277,7 @@ let invalid_repository_proxy_url = "INVALID_REPOSITORY_PROXY_URL"
 let invalid_repository_proxy_credential = "INVALID_REPOSITORY_PROXY_CREDENTIAL"
 
 let dynamic_memory_control_unavailable = "DYNAMIC_MEMORY_CONTROL_UNAVAILABLE"
+
+(* VTPMs *)
+
+let vtpm_max_amount_reached = "VTPM_MAX_AMOUNT_REACHED"


### PR DESCRIPTION
For now, only allow a single VTPM to be associated to a VM, and only
allow VTPM creation and destruction on halted VMs to avoid desync of the
DB and the actual running state of the devices.