### PR TITLE
CP-40027 VM migration introduce /services/xenops/migrate-mem

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -988,7 +988,12 @@ let pool_migrate =
       [
         (Ref _vm, "vm", "The VM to migrate")
       ; (Ref _host, "host", "The target host")
-      ; (Map (String, String), "options", "Extra configuration operations")
+      ; ( Map (String, String)
+        , "options"
+        , "Extra configuration operations: force, live, copy, compress. Each \
+           is a boolean option, taking 'true' or 'false' as a value. Option \
+           'compress' controls the use of stream compression during migration."
+        )
       ]
     ~errs:
       [

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1539,6 +1539,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
           ; "remote-network"
           ; "force"
           ; "copy"
+          ; "compress"
           ; "vif:"
           ; "vdi:"
           ]

--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -660,6 +660,11 @@ module XenopsAPI (R : RPC) = struct
           ~description:["URL on which the remote xenopsd can be contacted"]
           Types.string
       in
+      let compress =
+        Param.mk ~name:"compress"
+          ~description:["when true, use stream compression"]
+          Types.bool
+      in
       declare "VM.migrate" []
         (debug_info_p
         @-> vm_id_p
@@ -667,6 +672,7 @@ module XenopsAPI (R : RPC) = struct
         @-> vifmap
         @-> pcimap
         @-> xenops_url
+        @-> compress
         @-> returning task_id_p err
         )
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -924,6 +924,8 @@ let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
 
+let migration_compression = ref false
+
 type xapi_globs_spec_ty = Float of float ref | Int of int ref
 
 let extauth_ad_backend = ref "winbind"
@@ -1347,6 +1349,11 @@ let other_options =
     , Arg.Set_int message_limit
     , (fun () -> string_of_int !message_limit)
     , "Maximum number of messages kept before deleting oldest ones."
+    )
+  ; ( "migration-compression"
+    , Arg.Set migration_compression
+    , (fun () -> string_of_bool !migration_compression)
+    , "Use compression during VM migration when no API option provided."
     )
   ]
 

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -1004,10 +1004,17 @@ let resume _copts disk x =
 
 let resume copts disk x = diagnose_error (need_vm (resume copts disk) x)
 
-let migrate x url =
+let migrate x url compress =
   let open Vm in
   let vm, _ = find_by_name x in
-  Client.VM.migrate dbg vm.id [] [] [] url |> wait_for_task dbg
+  let compress =
+    match String.lowercase_ascii compress with
+    | "t" | "true" | "on" | "1" ->
+        true
+    | _ ->
+        false
+  in
+  Client.VM.migrate dbg vm.id [] [] [] url compress |> wait_for_task dbg
 
 let trim limit str =
   let l = String.length str in
@@ -1525,7 +1532,9 @@ let old_main () =
   | ["help"] | [] ->
       usage () ; exit 0
   | ["migrate"; id; url] ->
-      migrate id url |> task
+      migrate id url "false" |> task
+  | ["migrate"; id; url; compress] ->
+      migrate id url compress |> task
   | ["vbd-list"; id] ->
       vbd_list id
   | ["pci-add"; id; idx; bdf] ->

--- a/ocaml/xenopsd/lib/dune
+++ b/ocaml/xenopsd/lib/dune
@@ -10,6 +10,8 @@
    fmt
    forkexec
    re
+   gzip
+   zstd
    result
    rpclib.core
    rpclib.json

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -347,7 +347,12 @@ let handle_received_fd this_connection =
       let common_prefix = "/services/xenops/" in
       let memory_prefix = common_prefix ^ "memory/" in
       let migrate_vgpu_prefix = common_prefix ^ "migrate-vgpu/" in
-      let migrate_mem_prefix = common_prefix ^ "migrate-mem/" in
+      (* below we define new routes used for the new handshake protocol *)
+      let migrate = "/services/xenops/migrate/" in
+      let migrate_vm = migrate ^ "vm" in
+      let migrate_mem = migrate ^ "mem" in
+      let migrate_vgpu = migrate ^ "vgpu" in
+
       let has_prefix str prefix =
         String.length prefix <= String.length str
         && String.sub str 0 (String.length prefix) = prefix
@@ -363,8 +368,13 @@ let handle_received_fd this_connection =
         do_receive Xenops_server.VM.receive_memory
       else if has_prefix uri migrate_vgpu_prefix then
         do_receive Xenops_server.VM.receive_vgpu
-      else if has_prefix uri migrate_mem_prefix then
+      (* new routes but using same handlers *)
+      else if has_prefix uri migrate_vm then
+        do_receive Xenops_server.VM.receive_memory
+      else if has_prefix uri migrate_mem then
         do_receive Xenops_server.VM.receive_mem
+      else if has_prefix uri migrate_vgpu then
+        do_receive Xenops_server.VM.receive_vgpu
       else (
         error "Expected URI prefix %s or %s, got %s" memory_prefix
           migrate_vgpu_prefix uri ;

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -347,6 +347,7 @@ let handle_received_fd this_connection =
       let common_prefix = "/services/xenops/" in
       let memory_prefix = common_prefix ^ "memory/" in
       let migrate_vgpu_prefix = common_prefix ^ "migrate-vgpu/" in
+      let migrate_mem_prefix = common_prefix ^ "migrate-mem/" in
       let has_prefix str prefix =
         String.length prefix <= String.length str
         && String.sub str 0 (String.length prefix) = prefix
@@ -362,6 +363,8 @@ let handle_received_fd this_connection =
         do_receive Xenops_server.VM.receive_memory
       else if has_prefix uri migrate_vgpu_prefix then
         do_receive Xenops_server.VM.receive_vgpu
+      else if has_prefix uri migrate_mem_prefix then
+        do_receive Xenops_server.VM.receive_mem
       else (
         error "Expected URI prefix %s or %s, got %s" memory_prefix
           migrate_vgpu_prefix uri ;

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -372,6 +372,9 @@ sm-plugins=ext nfs iscsi lvmoiscsi dummy file hba rawhba udev iso lvm lvmohba lv
 # Path for the firewall-port-config script
 # firewall_port_config_script = /etc/xapi.d/plugins/firewall-port
 
+# migration-compression = true
+# if not requested otherwise, use stream compression during migration of a VM
+
 # The file to check if host reboot required
 reboot_required_hfxs = /run/reboot-required.hfxs
 


### PR DESCRIPTION
* Migrating a VM works currently like this: The source xenopsd opens a
  HTTP connection to the destination xenopsd services/xenops/memory. This
  connection is used as a socket, i.e. in both direction. The handler on
  the destination puts the socket connection into VM_receive_memory. The
  source is using this connection for two purposes: sending the memory
  stream but also a handshake protocol that syncs up source and
  destination. There are more details about the GPU migration stream that
  I'm not touching upon.

* This patch introduces an additional route and handler ..../migrate-mem
  that will be used only for the VM memory stream and leave almost all
  signaling to the two purposes: sending VM memory and keep signaling to
  the original first connection. The motivation is to enable compression
  of the memory stream, which is incompatible with signaling because it
  would introduce latencies.

* All file descriptors (FDs) needed for the migration of a VM end up in
  the VM_migrate and VM_receive_memory operations. On the destination
  the new handler receive_mem stores the FD in a hash table from where
  it is retrieved by the VM_receive_memory implementation and passed on.

* The destination must stay compatible with the old protocol because it
  will receive VMs during a rolling pool upgrade from hosts running
  older software. We signal the use of the new protocol by using a
  cookie mem_migration and the reveiver use its presence to branch on
  the protocol it uses.

* Several changes are administrative: factor out in handlers for the
  error case. Moving parameters of the VM_receive_memory operation into
  a record.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>