### PR TITLE
CP-39640/CP-39157 Add stream compression for VM migration

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -988,7 +988,12 @@ let pool_migrate =
       [
         (Ref _vm, "vm", "The VM to migrate")
       ; (Ref _host, "host", "The target host")
-      ; (Map (String, String), "options", "Extra configuration operations")
+      ; ( Map (String, String)
+        , "options"
+        , "Extra configuration operations: force, live, copy, compress. Each \
+           is a boolean option, taking 'true' or 'false' as a value. Option \
+           'compress' controls the use of stream compression during migration."
+        )
       ]
     ~errs:
       [

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1539,6 +1539,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
           ; "remote-network"
           ; "force"
           ; "copy"
+          ; "compress"
           ; "vif:"
           ; "vdi:"
           ]

--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -660,6 +660,11 @@ module XenopsAPI (R : RPC) = struct
           ~description:["URL on which the remote xenopsd can be contacted"]
           Types.string
       in
+      let compress =
+        Param.mk ~name:"compress"
+          ~description:["when true, use stream compression"]
+          Types.bool
+      in
       declare "VM.migrate" []
         (debug_info_p
         @-> vm_id_p
@@ -667,6 +672,7 @@ module XenopsAPI (R : RPC) = struct
         @-> vifmap
         @-> pcimap
         @-> xenops_url
+        @-> compress
         @-> returning task_id_p err
         )
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -924,7 +924,7 @@ let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
 
-let migration_compression = ref true
+let migration_compression = ref false
 
 type xapi_globs_spec_ty = Float of float ref | Int of int ref
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -924,6 +924,8 @@ let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
 
+let migration_compression = ref true
+
 type xapi_globs_spec_ty = Float of float ref | Int of int ref
 
 let extauth_ad_backend = ref "winbind"
@@ -1347,6 +1349,11 @@ let other_options =
     , Arg.Set_int message_limit
     , (fun () -> string_of_int !message_limit)
     , "Maximum number of messages kept before deleting oldest ones."
+    )
+  ; ( "migration-compression"
+    , Arg.Set migration_compression
+    , (fun () -> string_of_bool !migration_compression)
+    , "Use compression during VM migration when no API option provided."
     )
   ]
 

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -81,6 +81,10 @@ let get_bool_option key values =
 (** Decide whether to use stream compression during migration based on
 options passed to the API, localhost, and destination *)
 let use_compression options src dst =
+  debug "%s: options=%s" __FUNCTION__
+    (String.concat ", "
+       (List.map (fun (k, v) -> Printf.sprintf "%s:%s" k v) options)
+    ) ;
   match (get_bool_option "compress" options, src = dst) with
   | Some b, _ ->
       b (* honour any option given *)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -64,6 +64,31 @@ let get_ip_from_url url =
   | _, _ ->
       failwith (Printf.sprintf "Cannot extract foreign IP address from: %s" url)
 
+let get_bool_option key values =
+  match List.assoc_opt key values with
+  | Some word -> (
+    match String.lowercase_ascii word with
+    | "true" | "on" | "1" ->
+        Some true
+    | "false" | "off" | "0" ->
+        Some false
+    | _ ->
+        None
+  )
+  | None ->
+      None
+
+(** Decide whether to use stream compression during migration based on
+options passed to the API, localhost, and destination *)
+let use_compression options src dst =
+  match (get_bool_option "compress" options, src = dst) with
+  | Some b, _ ->
+      b (* honour any option given *)
+  | None, true ->
+      false (* don't use for local migration *)
+  | None, _ ->
+      !Xapi_globs.migration_compression
+
 let remote_of_dest ~__context dest =
   let master_url = List.assoc _master dest in
   let xenops_url = List.assoc _xenops dest in
@@ -203,7 +228,7 @@ let assert_licensed_storage_motion ~__context =
   Pool_features.assert_enabled ~__context ~f:Features.Storage_motion
 
 let rec migrate_with_retries ~__context queue_name max try_no dbg vm_uuid
-    xenops_vdi_map xenops_vif_map xenops_vgpu_map xenops =
+    xenops_vdi_map xenops_vif_map xenops_vgpu_map xenops compress =
   let open Xapi_xenops_queue in
   let module Client = (val make_client queue_name : XENOPS) in
   let progress = ref "(none yet)" in
@@ -211,7 +236,7 @@ let rec migrate_with_retries ~__context queue_name max try_no dbg vm_uuid
     progress := "Client.VM.migrate" ;
     let t1 =
       Client.VM.migrate dbg vm_uuid xenops_vdi_map xenops_vif_map
-        xenops_vgpu_map xenops
+        xenops_vgpu_map xenops compress
     in
     progress := "sync_with_task" ;
     ignore (Xapi_xenops.sync_with_task __context queue_name t1)
@@ -237,7 +262,7 @@ let rec migrate_with_retries ~__context queue_name max try_no dbg vm_uuid
           "xenops: will retry migration: caught %s from %s in attempt %d of %d."
           (Printexc.to_string e) !progress try_no max ;
         migrate_with_retries ~__context queue_name max (try_no + 1) dbg vm_uuid
-          xenops_vdi_map xenops_vif_map xenops_vgpu_map xenops
+          xenops_vdi_map xenops_vif_map xenops_vgpu_map xenops compress
     (* Something else went wrong *)
     | e ->
         debug
@@ -344,6 +369,10 @@ let pool_migrate ~__context ~vm ~host ~options =
         .assert_valid_ip_configuration_on_network_for_host ~__context
           ~self:network ~host
   in
+  let compress =
+    use_compression options (Helpers.get_localhost ~__context) host
+  in
+  debug "%s using stream compression=%b" __FUNCTION__ compress ;
   let ip = Http.Url.maybe_wrap_IPv6_literal address in
   let xenops_url =
     Printf.sprintf "http://%s/services/xenops?session_id=%s" ip session_id
@@ -370,7 +399,7 @@ let pool_migrate ~__context ~vm ~host ~options =
             Xapi_xenops.transform_xenops_exn ~__context ~vm queue_name
               (fun () ->
                 migrate_with_retry ~__context queue_name dbg vm_uuid [] []
-                  xenops_vgpu_map xenops_url ;
+                  xenops_vgpu_map xenops_url compress ;
                 (* Delete all record of this VM locally (including caches) *)
                 Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid
             )
@@ -1104,6 +1133,8 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
   (* Copy mode means we don't destroy the VM on the source host. We also don't
      	   copy over the RRDs/messages *)
   let copy = try bool_of_string (List.assoc "copy" options) with _ -> false in
+  let compress = use_compression options localhost remote.dest_host in
+  debug "%s using stream compression=%b" __FUNCTION__ compress ;
 
   (* The first thing to do is to create mirrors of all the disks on the remote.
      We look through the VM's VBDs and all of those of the snapshots. We then
@@ -1460,7 +1491,8 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
                 infer_vgpu_map ~__context ~remote new_vm
               in
               migrate_with_retry ~__context queue_name dbg vm_uuid
-                xenops_vdi_map xenops_vif_map xenops_vgpu_map remote.xenops_url ;
+                xenops_vdi_map xenops_vif_map xenops_vgpu_map remote.xenops_url
+                compress ;
               Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid
           )
         with

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -1004,10 +1004,17 @@ let resume _copts disk x =
 
 let resume copts disk x = diagnose_error (need_vm (resume copts disk) x)
 
-let migrate x url =
+let migrate x url compress =
   let open Vm in
   let vm, _ = find_by_name x in
-  Client.VM.migrate dbg vm.id [] [] [] url |> wait_for_task dbg
+  let compress =
+    match String.lowercase_ascii compress with
+    | "t" | "true" | "on" | "1" ->
+        true
+    | _ ->
+        false
+  in
+  Client.VM.migrate dbg vm.id [] [] [] url compress |> wait_for_task dbg
 
 let trim limit str =
   let l = String.length str in
@@ -1525,7 +1532,9 @@ let old_main () =
   | ["help"] | [] ->
       usage () ; exit 0
   | ["migrate"; id; url] ->
-      migrate id url |> task
+      migrate id url "false" |> task
+  | ["migrate"; id; url; compress] ->
+      migrate id url compress |> task
   | ["vbd-list"; id] ->
       vbd_list id
   | ["pci-add"; id; idx; bdf] ->

--- a/ocaml/xenopsd/lib/dune
+++ b/ocaml/xenopsd/lib/dune
@@ -10,6 +10,8 @@
    fmt
    forkexec
    re
+   gzip
+   zstd
    result
    rpclib.core
    rpclib.json

--- a/ocaml/xenopsd/lib/xenops_migrate.ml
+++ b/ocaml/xenopsd/lib/xenops_migrate.ml
@@ -42,7 +42,7 @@ module Handshake = struct
     if n < len then really_read fd buf (ofs + n) (len - n)
 
   (** Receive a 'result' from the remote *)
-  let recv ?(verbose = false) (s : Unix.file_descr) : result =
+  let recv ?(verbose = true) (s : Unix.file_descr) : result =
     let buf = Bytes.make 2 '\000' in
     if verbose then
       debug "Handshake.recv: about to read result code from remote." ;
@@ -78,7 +78,7 @@ module Handshake = struct
         raise (Remote_failed ("error from remote: " ^ x))
 
   (** Transmit a 'result' to the remote *)
-  let send ?(verbose = false) (s : Unix.file_descr) (r : result) =
+  let send ?(verbose = true) (s : Unix.file_descr) (r : result) =
     let len = match r with Success -> 0 | Error msg -> String.length msg in
     let buf = Bytes.make (2 + len) '\000' in
     Bytes.set buf 0 @@ char_of_int ((len lsr 8) land 0xff) ;

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -347,6 +347,7 @@ let handle_received_fd this_connection =
       let common_prefix = "/services/xenops/" in
       let memory_prefix = common_prefix ^ "memory/" in
       let migrate_vgpu_prefix = common_prefix ^ "migrate-vgpu/" in
+      let migrate_mem_prefix = common_prefix ^ "migrate-mem/" in
       let has_prefix str prefix =
         String.length prefix <= String.length str
         && String.sub str 0 (String.length prefix) = prefix
@@ -362,6 +363,8 @@ let handle_received_fd this_connection =
         do_receive Xenops_server.VM.receive_memory
       else if has_prefix uri migrate_vgpu_prefix then
         do_receive Xenops_server.VM.receive_vgpu
+      else if has_prefix uri migrate_mem_prefix then
+        do_receive Xenops_server.VM.receive_mem
       else (
         error "Expected URI prefix %s or %s, got %s" memory_prefix
           migrate_vgpu_prefix uri ;

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -372,6 +372,9 @@ sm-plugins=ext nfs iscsi lvmoiscsi dummy file hba rawhba udev iso lvm lvmohba lv
 # Path for the firewall-port-config script
 # firewall_port_config_script = /etc/xapi.d/plugins/firewall-port
 
+# migration-compression = true
+# if not requested otherwise, use stream compression during migration of a VM
+
 # The file to check if host reboot required
 reboot_required_hfxs = /run/reboot-required.hfxs
 


### PR DESCRIPTION


Optionally compress the memory byte stream that is coming out of
emu-manager as part of a VM migration and extend API and CLI for that
option. The default (when no option is used) is controlled via xapi.conf
and the current default is to use compression for non-local migration.

Compression is implemented by feeding the byte stream through a
compression binary that we spawn with Forkexed. Currently we are using
zstd to achieve high troughput. Compression isbenefical if otherwise the
network connection becomes saturated which often will require multiple
migrations in parallel.

At the API/CLI level compression is enabled by using the option
"compress=true", disabled by "compression=false" and using the default
(controlled via xapi.conf) otherwise.

The sending side signals to the receiving side the use of compression by
using a HTTP cookie key-value pair with "compress=true".

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>

