### PR TITLE
CP-39894: move xenopsd's daemon modules from device to service

### DIFF
--- a/ocaml/xenopsd/lib/xenops_utils.ml
+++ b/ocaml/xenopsd/lib/xenops_utils.ml
@@ -44,6 +44,23 @@ module Unix = struct
       }
 end
 
+(** Represent an IPC endpoint *)
+module Socket = struct
+  type t = Unix of string | Port of int
+
+  module Unix = struct
+    let path x = "unix:" ^ x
+
+    let rm x =
+      let dbg = debug "error cleaning unix socket %s: %s" x in
+      try Unix.unlink x with
+      | Unix.Unix_error (Unix.ENOENT, _, _) ->
+          ()
+      | Unix.Unix_error (e, _, _) ->
+          dbg (Unix.error_message e)
+  end
+end
+
 let all = List.fold_left ( && ) true
 
 let any = List.fold_left ( || ) false
@@ -632,6 +649,12 @@ let chunks size lst =
     [] lst
   |> List.map (fun xs -> List.rev xs)
   |> List.rev
+
+let really_kill pid =
+  try Unixext.kill_and_wait pid
+  with Unixext.Process_still_alive ->
+    debug "%d: failed to respond to SIGTERM, sending SIGKILL" pid ;
+    Unixext.kill_and_wait ~signal:Sys.sigkill pid
 
 let best_effort txt f =
   try f ()

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -2207,100 +2207,6 @@ module Dm_Common = struct
     in
     {argv; fd_map= []}
 
-  let vgpu_args_of_nvidia domid vcpus vgpus restore =
-    let open Xenops_interface.Vgpu in
-    let virtual_pci_address_compare vgpu1 vgpu2 =
-      match (vgpu1, vgpu2) with
-      | ( {implementation= Nvidia {virtual_pci_address= pci1; _}; _}
-        , {implementation= Nvidia {virtual_pci_address= pci2; _}; _} ) ->
-          Stdlib.compare pci1.dev pci2.dev
-      | other1, other2 ->
-          Stdlib.compare other1 other2
-    in
-    let device_args =
-      let make addr args =
-        Printf.sprintf "--device=%s"
-          (Xcp_pci.string_of_address addr :: args
-          |> List.filter (fun str -> str <> "")
-          |> String.concat ","
-          )
-      in
-      vgpus
-      |> List.sort virtual_pci_address_compare
-      |> List.map (fun vgpu ->
-             let addr =
-               match vgpu.virtual_pci_address with
-               | Some pci ->
-                   pci (* pass VF in case of SRIOV *)
-               | None ->
-                   vgpu.physical_pci_address
-             in
-             (* pass PF otherwise *)
-             match vgpu.implementation with
-             (* 1. Upgrade case, migrate from a old host with old vGPU having
-                config_path 2. Legency case, run with old Nvidia host driver *)
-             | Nvidia
-                 {
-                   virtual_pci_address
-                 ; config_file= Some config_file
-                 ; extra_args
-                 ; _
-                 } ->
-                 (* The VGPU UUID is not available. Create a fresh one; xapi
-                    will deal with it. *)
-                 let uuid = Uuid.(to_string (make ())) in
-                 debug "NVidia vGPU config: using config file %s and uuid %s"
-                   config_file uuid ;
-                 make addr
-                   [
-                     config_file
-                   ; Xcp_pci.string_of_address virtual_pci_address
-                   ; uuid
-                   ; extra_args
-                   ]
-             | Nvidia
-                 {
-                   virtual_pci_address
-                 ; type_id= Some type_id
-                 ; uuid= Some uuid
-                 ; extra_args
-                 ; _
-                 } ->
-                 debug "NVidia vGPU config: using type id %s and uuid: %s"
-                   type_id uuid ;
-                 make addr
-                   [
-                     type_id
-                   ; Xcp_pci.string_of_address virtual_pci_address
-                   ; uuid
-                   ; extra_args
-                   ]
-             | Nvidia {type_id= None; config_file= None; _} ->
-                 (* No type_id _and_ no config_file: something is wrong *)
-                 raise
-                   (Xenopsd_error
-                      (Internal_error
-                         (Printf.sprintf "NVidia vGPU metadata incomplete (%s)"
-                            __LOC__
-                         )
-                      )
-                   )
-             | _ ->
-                 ""
-         )
-    in
-    let suspend_file = sprintf demu_save_path domid in
-    let base_args =
-      [
-        "--domain=" ^ string_of_int domid
-      ; "--vcpus=" ^ string_of_int vcpus
-      ; "--suspend=" ^ suspend_file
-      ]
-      @ device_args
-    in
-    let fd_arg = if restore then ["--resume"] else [] in
-    List.concat [base_args; fd_arg]
-
   let write_vgpu_data ~xs domid devid keys =
     let path = xenops_vgpu_path domid devid in
     xs.Xs.writev path keys
@@ -2353,17 +2259,6 @@ module Dm_Common = struct
 
   let prepend_wrapper_args domid args =
     string_of_int domid :: "--syslog" :: args
-
-  let pid_alive pid name =
-    match Forkhelpers.waitpid_nohang pid with
-    | 0, Unix.WEXITED 0 ->
-        true
-    | _, Unix.WEXITED n ->
-        error "%s: unexpected exit with code: %d" name n ;
-        false
-    | _, (Unix.WSIGNALED n | Unix.WSTOPPED n) ->
-        error "%s: unexpected signal: %d" name n ;
-        false
 
   let gimtool_m = Mutex.create ()
 
@@ -3775,27 +3670,17 @@ module Dm = struct
     match vgpus with
     | {implementation= Nvidia _; _} :: _ ->
         (* Start DEMU and wait until it has reached the desired state *)
-        let state_path = Printf.sprintf "/local/domain/%d/vgpu/state" domid in
-        let cancel = Cancel_utils.Vgpu domid in
         if not (Service.Vgpu.is_running ~xs domid) then (
           let pcis = List.map (fun x -> x.physical_pci_address) vgpus in
           PCI.bind pcis PCI.Nvidia ;
           let module Q = (val Backend.of_profile profile) in
-          let args = vgpu_args_of_nvidia domid vcpus vgpus restore in
-          let vgpu_pid =
-            Service.Vgpu.start_daemon ~path:!Xc_resources.vgpu ~args ~domid
-              ~fds:[] ()
-          in
-          Service.Vgpu.wait_path ~pidalive:(pid_alive vgpu_pid) ~task
-            ~name:"vgpu" ~domid ~xs ~ready_path:state_path
-            ~timeout:!Xenopsd.vgpu_ready_timeout
-            ~cancel () ;
-          Forkhelpers.dontwaitpid vgpu_pid
+          Service.Vgpu.start ~xs ~vcpus ~vgpus ~restore task domid
         ) else
           info "Daemon %s is already running for domain %d" !Xc_resources.vgpu
             domid ;
         (* Keep waiting until DEMU's state becomes "initialising" or "running",
            or an error occurred. *)
+        let state_path = Service.Vgpu.state_path domid in
         let good_watches =
           [
             Watch.value_to_become state_path "initialising"
@@ -3805,8 +3690,9 @@ module Dm = struct
         in
         let error_watch = Watch.value_to_become state_path "error" in
         if
-          cancellable_watch cancel good_watches [error_watch] task ~xs
-            ~timeout:3600. ()
+          cancellable_watch
+            (Service.Vgpu.cancel_key domid)
+            good_watches [error_watch] task ~xs ~timeout:3600. ()
         then
           info "Daemon vgpu is ready"
         else

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -94,23 +94,6 @@ module Profile = struct
         Qemu_upstream_compat
 end
 
-(** Represent an IPC endpoint *)
-module Socket = struct
-  type t = Unix of string | Port of int
-
-  module Unix = struct
-    let path x = "unix:" ^ x
-
-    let rm x =
-      let dbg = debug "error cleaning unix socket %s: %s" x in
-      try Unix.unlink x with
-      | Unix.Unix_error (Unix.ENOENT, _, _) ->
-          ()
-      | Unix.Unix_error (e, _, _) ->
-          dbg (Unix.error_message e)
-  end
-end
-
 (* keys read by vif udev script (keep in sync with api:scripts/vif) *)
 let vif_udev_keys =
   "promiscuous"
@@ -119,10 +102,6 @@ let vif_udev_keys =
 (****************************************************************************************)
 
 module Generic = struct
-  let vnc_port_path domid = sprintf "/local/domain/%d/console/vnc-port" domid
-
-  let tc_port_path domid = sprintf "/local/domain/%d/console/tc-port" domid
-
   (* Oxenstored's transaction conflict algorithm will cause parallel but
      separate device creation transactions to abort and retry, leading to
      livelock while starting lots of VMs. Work around this by serialising these
@@ -368,11 +347,7 @@ module Generic = struct
       "Device.Generic.hard_shutdown about to blow away backend and error paths" ;
     rm_device_state ~xs x
 
-  let really_kill pid =
-    try Unixext.kill_and_wait pid
-    with Unixext.Process_still_alive ->
-      debug "%d: failed to respond to SIGTERM, sending SIGKILL" pid ;
-      Unixext.kill_and_wait ~signal:Sys.sigkill pid
+  let really_kill = Xenops_utils.really_kill
 
   let best_effort = Xenops_utils.best_effort
 end
@@ -1076,321 +1051,6 @@ module Vcpu_Common = struct
     with Xs_protocol.Enoent _ -> false
 end
 
-module type DAEMONPIDPATH = sig
-  val name : string
-
-  val use_pidfile : bool
-
-  val pid_path : int -> string
-end
-
-module DaemonMgmt (D : DAEMONPIDPATH) = struct
-  module SignalMask = struct
-    module H = Hashtbl
-
-    type t = (int, bool) H.t
-
-    let create () = H.create 16
-
-    let set tbl key = H.replace tbl key true
-
-    let unset tbl key = H.remove tbl key
-
-    let has tbl key = H.mem tbl key
-  end
-
-  let signal_mask = SignalMask.create ()
-
-  let name = D.name
-
-  let pid_path = D.pid_path
-
-  let pid_path_signal domid = pid_path domid ^ "-signal"
-
-  let pidfile_path domid =
-    if D.use_pidfile then
-      Some (sprintf "%s/%s-%d.pid" Device_common.var_run_xen_path D.name domid)
-    else
-      None
-
-  let pid ~xs domid =
-    try
-      match pidfile_path domid with
-      | Some path when Sys.file_exists path ->
-          let pid =
-            path |> Unixext.string_of_file |> String.trim |> int_of_string
-          in
-          Unixext.with_file path [Unix.O_RDONLY] 0 (fun fd ->
-              try
-                Unix.lockf fd Unix.F_TRLOCK 0 ;
-                (* we succeeded taking the lock: original process is dead.
-                 * some other process might've reused its pid *)
-                None
-              with Unix.Unix_error (Unix.EAGAIN, _, _) ->
-                (* cannot obtain lock: process is alive *)
-                Some pid
-          )
-      | _ ->
-          (* backward compatibility during update installation: only has
-             xenstore pid *)
-          let pid = xs.Xs.read (pid_path domid) in
-          Some (int_of_string pid)
-    with _ -> None
-
-  let is_running ~xs domid =
-    match pid ~xs domid with
-    | None ->
-        false
-    | Some p -> (
-      try Unix.kill p 0 ; (* This checks the existence of pid p *)
-                          true
-      with _ -> false
-    )
-
-  let stop ~xs domid =
-    match pid ~xs domid with
-    | None ->
-        ()
-    | Some pid -> (
-        debug "%s: stopping %s with SIGTERM (domid = %d pid = %d)" D.name D.name
-          domid pid ;
-        let open Generic in
-        best_effort (sprintf "killing %s" D.name) (fun () -> really_kill pid) ;
-        let key = pid_path domid in
-        best_effort (sprintf "removing XS key %s" key) (fun () -> xs.Xs.rm key) ;
-        match pidfile_path domid with
-        | None ->
-            ()
-        | Some path ->
-            best_effort (sprintf "removing %s" path) (fun () -> Unix.unlink path)
-      )
-
-  let syslog_key ~domid = Printf.sprintf "%s-%d" D.name domid
-
-  let start ~fds ~syslog_key path args =
-    let syslog_stdout = Forkhelpers.Syslog_WithKey syslog_key in
-    let redirect_stderr_to_stdout = true in
-    let pid =
-      Forkhelpers.safe_close_and_exec None None None fds ~syslog_stdout
-        ~redirect_stderr_to_stdout path args
-    in
-    debug
-      "%s: should be running in the background (stdout -> syslog); (fd,pid) = \
-       %s"
-      D.name
-      (Forkhelpers.string_of_pidty pid) ;
-    pid
-
-  (* Forks a daemon and then returns the pid. *)
-  let start_daemon ~path ~args ~domid ?(fds = []) () =
-    let syslog_key = syslog_key ~domid in
-    debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
-    let pid = start ~fds ~syslog_key path args in
-    debug "Daemon started: %s" syslog_key ;
-    pid
-end
-
-module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
-  (* backward compat: for daemons running during an update *)
-  module Compat = DaemonMgmt (D)
-
-  let pidfile_path = Compat.pidfile_path
-
-  let pid_path = Compat.pid_path
-
-  let of_domid domid =
-    let key = Compat.syslog_key ~domid in
-    if Fe_systemctl.exists ~service:key then
-      Some key
-    else
-      None
-
-  let alive service _ =
-    if Fe_systemctl.is_active ~service then
-      true
-    else
-      let status = Fe_systemctl.show ~service in
-      let open Fe_systemctl in
-      error
-        "%s: unexpected termination \
-         (Result=%s,ExecMainPID=%d,ExecMainStatus=%d,ActiveState=%s)"
-        service status.result status.exec_main_pid status.exec_main_status
-        status.active_state ;
-      false
-
-  let stop ~xs domid =
-    match of_domid domid with
-    | None ->
-        Compat.stop ~xs domid
-    | Some service ->
-        (* xenstore cleanup is done by systemd unit file *)
-        let (_ : Fe_systemctl.status) = Fe_systemctl.stop ~service in
-        ()
-
-  let start_daemon ~path ~args ~domid () =
-    debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
-    let service = Compat.syslog_key ~domid in
-    let pidpath = D.pid_path domid in
-    let properties =
-      ("ExecStopPost", "-/usr/bin/xenstore-rm " ^ pidpath)
-      ::
-      ( match Compat.pidfile_path domid with
-      | None ->
-          []
-      | Some path ->
-          [("ExecStopPost", "-/bin/rm -f " ^ path)]
-      )
-    in
-    Fe_systemctl.start_transient ~properties ~service path args ;
-    debug "Daemon started: %s" service ;
-    service
-end
-
-module Qemu = DaemonMgmt (struct
-  let name = "qemu-dm"
-
-  let use_pidfile = true
-
-  let pid_path domid = sprintf "/local/domain/%d/qemu-pid" domid
-end)
-
-module Vgpu = DaemonMgmt (struct
-  let name = "vgpu"
-
-  let use_pidfile = false
-
-  let pid_path domid = sprintf "/local/domain/%d/vgpu-pid" domid
-end)
-
-module Varstored = SystemdDaemonMgmt (struct
-  let name = "varstored"
-
-  let use_pidfile = true
-
-  let pid_path domid = sprintf "/local/domain/%d/varstored-pid" domid
-end)
-
-module PV_Vnc = struct
-  module D = DaemonMgmt (struct
-    let name = "vncterm"
-
-    let use_pidfile = false
-
-    let pid_path domid = sprintf "/local/domain/%d/vncterm-pid" domid
-  end)
-
-  let vnc_console_path domid = sprintf "/local/domain/%d/console" domid
-
-  let pid ~xs domid = D.pid ~xs domid
-
-  (* Look up the commandline args for the vncterm pid; *)
-  (* Check that they include the vncterm binary path and the xenstore console
-     path for the supplied domid. *)
-  let is_cmdline_valid domid pid =
-    try
-      let cmdline =
-        Printf.sprintf "/proc/%d/cmdline" pid
-        |> Unixext.string_of_file
-        |> Astring.String.cuts ~sep:"\000"
-      in
-      List.mem !Xc_resources.vncterm cmdline
-      && List.mem (vnc_console_path domid) cmdline
-    with _ -> false
-
-  let is_vncterm_running ~xs domid =
-    match pid ~xs domid with
-    | None ->
-        false
-    | Some p ->
-        D.is_running ~xs domid && is_cmdline_valid domid p
-
-  let get_vnc_port ~xs domid =
-    if not (is_vncterm_running ~xs domid) then
-      None
-    else
-      try
-        Some
-          (Socket.Port (int_of_string (xs.Xs.read (Generic.vnc_port_path domid)))
-          )
-      with _ -> None
-
-  let get_tc_port ~xs domid =
-    if not (is_vncterm_running ~xs domid) then
-      None
-    else
-      try Some (int_of_string (xs.Xs.read (Generic.tc_port_path domid)))
-      with _ -> None
-
-  let load_args = function
-    | None ->
-        []
-    | Some filename ->
-        if Sys.file_exists filename then
-          ["-l"; filename]
-        else
-          []
-
-  exception Failed_to_start
-
-  let vncterm_statefile pid =
-    sprintf "/var/xen/vncterm/%d/vncterm.statefile" pid
-
-  let get_statefile ~xs domid =
-    match pid ~xs domid with
-    | None ->
-        None
-    | Some pid ->
-        let filename = vncterm_statefile pid in
-        if Sys.file_exists filename then
-          Some filename
-        else
-          None
-
-  let save ~xs domid =
-    match pid ~xs domid with
-    | Some pid ->
-        Unix.kill pid Sys.sigusr1 ;
-        let filename = vncterm_statefile pid in
-        let delay = 10. in
-        let start_time = Unix.time () in
-        (* wait at most ten seconds *)
-        while
-          (not (Sys.file_exists filename)) || Unix.time () -. start_time > delay
-        do
-          debug "Device.PV_Vnc.save: waiting for %s to appear" filename ;
-          Thread.delay 1.
-        done ;
-        if Unix.time () -. start_time > delay then
-          debug "Device.PV_Vnc.save: timeout while waiting for %s to appear"
-            filename
-        else
-          debug "Device.PV_Vnc.save: %s has appeared" filename
-    | None ->
-        ()
-
-  let start ?statefile ~xs ?ip domid =
-    debug "In PV_Vnc.start" ;
-    let ip = Option.value ~default:"127.0.0.1" ip in
-    let l =
-      [
-        "-x"
-      ; sprintf "/local/domain/%d/console" domid
-      ; "-T"
-      ; (* listen for raw connections *)
-        "-v"
-      ; ip ^ ":1"
-      ]
-      @ load_args statefile
-    in
-    (* Now add the close fds wrapper *)
-    let pid = D.start_daemon ~path:!Xc_resources.vncterm ~args:l ~domid () in
-    let path = D.pid_path domid in
-    xs.Xs.write path (string_of_int (Forkhelpers.getpid pid)) ;
-    Forkhelpers.dontwaitpid pid
-
-  let stop ~xs domid = D.stop ~xs domid
-end
-
 module PCI = struct
   type t = {
       address: Xenops_interface.Pci.address
@@ -1550,7 +1210,7 @@ module PCI = struct
       |> int_of_string
     in
     if hvm && qmp_add then
-      if Qemu.is_running ~xs domid then
+      if Service.Qemu.is_running ~xs domid then
         let id =
           Printf.sprintf "pci-pt-%02x_%02x.%01x" host.bus host.dev host.fn
         in
@@ -2140,7 +1800,7 @@ module Vusb = struct
       {"execute":"qom-list","arguments":{"path":"/machine/peripheral"}} result:
       {"return": [{"name": "usb1", "type": "child<usb-host>"}, {"name":"type",
       "type": "string"}} The usb1 is added. *)
-    if Qemu.is_running ~xs domid then
+    if Service.Qemu.is_running ~xs domid then
       let path = "/machine/peripheral" in
       match qmp_send_cmd domid Qmp.(Qom_list path) with
       | Qmp.(Qom usbs) ->
@@ -2211,13 +1871,13 @@ module Vusb = struct
             speed id ;
           get_bus_from_version ()
     in
-    if Qemu.is_running ~xs domid then (
+    if Service.Qemu.is_running ~xs domid then (
       let bus, prepare_bus = get_bus () in
       prepare_bus () ;
       (* Need to reset USB device before passthrough to vm according to
          CP-24616. Also need to do deprivileged work in usb_reset script if QEMU
          is deprivileged. *)
-      ( match Qemu.pid ~xs domid with
+      ( match Service.Qemu.pid ~xs domid with
       | Some pid ->
           usb_reset_attach ~hostbus ~hostport ~domid ~pid ~privileged
       | _ ->
@@ -2246,7 +1906,7 @@ module Vusb = struct
     debug "vusb_unplug: unplug VUSB device %s" id ;
     finally
       (fun () ->
-        if Qemu.is_running ~xs domid then
+        if Service.Qemu.is_running ~xs domid then
           try qmp_send_cmd domid Qmp.(Device_del id) |> ignore
           with QMP_connection_error _ ->
             raise (Xenopsd_error Device_not_connected)
@@ -2278,7 +1938,7 @@ end = struct
   (** query qemu for the serial console and write it to xenstore. Only write
       path for a real console, not a file or socket path. CA-318579 *)
   let update_xenstore ~xs domid =
-    ( if not @@ Qemu.is_running ~xs domid then
+    ( if not @@ Service.Qemu.is_running ~xs domid then
         let msg = sprintf "Qemu not running for domain %d (%s)" domid __LOC__ in
         raise (Xenopsd_error (Internal_error msg))
     ) ;
@@ -2404,13 +2064,13 @@ module Dm_Common = struct
     Xenops_sandbox.Chroot.Path.of_string ~relative:"efi-vars-save.dat"
 
   let get_vnc_port ~xs domid ~f =
-    match Qemu.is_running ~xs domid with true -> f () | false -> None
+    match Service.Qemu.is_running ~xs domid with true -> f () | false -> None
 
   let get_tc_port ~xs domid =
-    if not (Qemu.is_running ~xs domid) then
+    if not (Service.Qemu.is_running ~xs domid) then
       None
     else
-      try Some (int_of_string (xs.Xs.read (Generic.tc_port_path domid)))
+      try Some (int_of_string (xs.Xs.read (Service.PV_Vnc.tc_port_path domid)))
       with _ -> None
 
   let signal (task : Xenops_task.task_handle) ~xs ~qemu_domid ~domid ?wait_for
@@ -2539,7 +2199,7 @@ module Dm_Common = struct
                )
           |> List.concat
         ; (info.monitor |> function None -> [] | Some x -> ["-monitor"; x])
-        ; (Qemu.pidfile_path domid |> function
+        ; (Service.Qemu.pidfile_path domid |> function
            | None ->
                []
            | Some x ->
@@ -2734,9 +2394,11 @@ module Dm_Common = struct
 
   (* Called by every domain destroy, even non-HVM *)
   let stop ~xs ~qemu_domid domid =
-    let qemu_pid_path = Qemu.pid_path domid in
+    let qemu_pid_path = Service.Qemu.pid_path domid in
+    let vm_uuid = Xenops_helpers.uuid_of_domid ~xs domid |> Uuid.to_string in
+    let dbg = Printf.sprintf "stop domid %d" domid in
     let stop_qemu () =
-      match Qemu.pid ~xs domid with
+      match Service.Qemu.pid ~xs domid with
       | None ->
           () (* nothing to do *)
       | Some qemu_pid -> (
@@ -2744,7 +2406,7 @@ module Dm_Common = struct
           let open Generic in
           best_effort
             "signalling that qemu is ending as expected, mask further signals"
-            (fun () -> Qemu.SignalMask.set Qemu.signal_mask domid
+            (fun () -> Service.Qemu.(SignalMask.set signal_mask domid)
           ) ;
           best_effort "killing qemu-dm" (fun () -> really_kill qemu_pid) ;
           best_effort "removing qemu-pid from xenstore" (fun () ->
@@ -2752,12 +2414,12 @@ module Dm_Common = struct
           ) ;
           best_effort
             "unmasking signals, qemu-pid is already gone from xenstore"
-            (fun () -> Qemu.SignalMask.unset Qemu.signal_mask domid
+            (fun () -> Service.Qemu.(SignalMask.unset signal_mask domid)
           ) ;
           best_effort "removing device model path from xenstore" (fun () ->
               xs.Xs.rm (device_model_path ~qemu_domid domid)
           ) ;
-          match Qemu.pidfile_path domid with
+          match Service.Qemu.pidfile_path domid with
           | None ->
               ()
           | Some path ->
@@ -2766,12 +2428,10 @@ module Dm_Common = struct
               )
         )
     in
-    let stop_vgpu () = Vgpu.stop ~xs domid in
+    let stop_vgpu () = Service.Vgpu.stop ~xs domid in
     let stop_varstored () =
-      let vm_uuid = Xenops_helpers.uuid_of_domid ~xs domid |> Uuid.to_string in
       debug "About to stop varstored for domain %d (%s)" domid vm_uuid ;
-      Varstored.stop ~xs domid ;
-      let dbg = Printf.sprintf "stop domid %d" domid in
+      Service.Varstored.stop ~xs domid ;
       Xenops_sandbox.Varstore_guard.stop dbg ~domid ~vm_uuid
     in
     stop_vgpu () ; stop_varstored () ; stop_qemu ()
@@ -2994,7 +2654,9 @@ module Backend = struct
             try
               Some
                 (Socket.Port
-                   (int_of_string (xs.Xs.read (Generic.vnc_port_path domid)))
+                   (int_of_string
+                      (xs.Xs.read (Service.PV_Vnc.vnc_port_path domid))
+                   )
                 )
             with _ -> None
         )
@@ -3008,7 +2670,7 @@ module Backend = struct
 
       let init_daemon ~task:_ ~path:_ ~args:_ ~domid:_ ~xs:_ ~ready_path:_
           ~timeout:_ ~cancel:_ ?fds:_ _ =
-        raise (Ioemu_failed (Qemu.name, "PV guests have no IO emulator"))
+        raise (Ioemu_failed (Service.Qemu.name, "PV guests have no IO emulator"))
 
       let qemu_args ~xs:_ ~dm:_ _ _ _ = {Dm_Common.argv= []; fd_map= []}
 
@@ -3746,8 +3408,8 @@ module Backend = struct
 
       let init_daemon ~task ~path ~args ~domid ~xs:_ ~ready_path:_ ~timeout
           ~cancel:_ ?(fds = []) _ =
-        let pid = Qemu.start_daemon ~path ~args ~domid ~fds () in
-        wait_event_socket ~task ~name:Qemu.name ~domid ~timeout ;
+        let pid = Service.Qemu.start_daemon ~path ~args ~domid ~fds () in
+        wait_event_socket ~task ~name:Service.Qemu.name ~domid ~timeout ;
         QMP_Event.add domid ;
         pid
 
@@ -4142,7 +3804,6 @@ module Dm = struct
     in
     let backend = nvram.Nvram_uefi_variables.backend in
     let open Fe_argv in
-    let ( >>= ) = bind in
     let argf fmt = ksprintf (fun s -> ["--arg"; s]) fmt in
     let on cond value = if cond then value else return () in
     let chroot, socket_path =
@@ -4167,7 +3828,7 @@ module Dm = struct
         ; Printf.sprintf "socket:%s" socket_path
         ]
       >>= fun () ->
-      (Varstored.pidfile_path domid |> function
+      (Service.Varstored.pidfile_path domid |> function
        | None ->
            return ()
        | Some x ->
@@ -4187,10 +3848,11 @@ module Dm = struct
            (Xenops_sandbox.Chroot.chroot_path_inside efivars_save_path)
     in
     let args = Fe_argv.run args |> snd |> Fe_argv.argv in
-    let service = Varstored.start_daemon ~path ~args ~domid () in
-    let ready_path = Varstored.pid_path domid in
-    wait_path ~pidalive:(Varstored.alive service) ~task ~name ~domid ~xs
-      ~ready_path
+    let service = Service.Varstored.start_daemon ~path ~args ~domid () in
+    let ready_path = Service.Varstored.pid_path domid in
+    wait_path
+      ~pidalive:(Service.Varstored.alive service)
+      ~task ~name ~domid ~xs ~ready_path
       ~timeout:!Xenopsd.varstored_ready_timeout
       ~cancel:(Cancel_utils.Varstored domid) ()
 
@@ -4201,13 +3863,14 @@ module Dm = struct
         (* Start DEMU and wait until it has reached the desired state *)
         let state_path = Printf.sprintf "/local/domain/%d/vgpu/state" domid in
         let cancel = Cancel_utils.Vgpu domid in
-        if not (Vgpu.is_running ~xs domid) then (
+        if not (Service.Vgpu.is_running ~xs domid) then (
           let pcis = List.map (fun x -> x.physical_pci_address) vgpus in
           PCI.bind pcis PCI.Nvidia ;
           let module Q = (val Backend.of_profile profile) in
           let args = vgpu_args_of_nvidia domid vcpus vgpus restore in
           let vgpu_pid =
-            Vgpu.start_daemon ~path:!Xc_resources.vgpu ~args ~domid ~fds:[] ()
+            Service.Vgpu.start_daemon ~path:!Xc_resources.vgpu ~args ~domid
+              ~fds:[] ()
           in
           wait_path ~pidalive:(pid_alive vgpu_pid) ~task ~name:"vgpu" ~domid ~xs
             ~ready_path:state_path
@@ -4357,8 +4020,8 @@ module Dm = struct
                       Printf.sprintf "unknown"
                 )
               in
-              if not (Qemu.SignalMask.has Qemu.signal_mask domid) then
-                match Qemu.pid ~xs domid with
+              if not Service.Qemu.(SignalMask.has signal_mask domid) then
+                match Service.Qemu.pid ~xs domid with
                 | None ->
                     (* after expected qemu stop or domain xs tree destroyed:
                        this event arrived too late, nothing to do *)
@@ -4369,7 +4032,9 @@ module Dm = struct
                 | Some _ ->
                     (* before expected qemu stop: qemu-pid is available in
                        domain xs tree: signal action to take *)
-                    xs.Xs.write (Qemu.pid_path_signal domid) crash_reason
+                    xs.Xs.write
+                      (Service.Qemu.pid_path_signal domid)
+                      crash_reason
             )
         )
 
@@ -4386,7 +4051,7 @@ module Dm = struct
 
   let suspend_varstored (_ : Xenops_task.task_handle) ~xs domid ~vm_uuid =
     debug "Called Dm.suspend_varstored (domid=%d)" domid ;
-    Varstored.stop ~xs domid ;
+    Service.Varstored.stop ~xs domid ;
     Xenops_sandbox.Varstore_guard.read ~domid efivars_save_path ~vm_uuid
 
   let restore_varstored (_ : Xenops_task.task_handle) ~xs ~efivars domid =
@@ -4441,16 +4106,16 @@ let clean_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
 
 let get_vnc_port ~xs ~dm domid =
   (* Check whether a qemu exists for this domain *)
-  let qemu_exists = Qemu.is_running ~xs domid in
+  let qemu_exists = Service.Qemu.is_running ~xs domid in
   if qemu_exists then
     Dm.get_vnc_port ~xs ~dm domid
   else
-    PV_Vnc.get_vnc_port ~xs domid
+    Service.PV_Vnc.get_vnc_port ~xs domid
 
 let get_tc_port ~xs domid =
   (* Check whether a qemu exists for this domain *)
-  let qemu_exists = Qemu.is_running ~xs domid in
+  let qemu_exists = Service.Qemu.is_running ~xs domid in
   if qemu_exists then
     Dm.get_tc_port ~xs domid
   else
-    PV_Vnc.get_tc_port ~xs domid
+    Service.PV_Vnc.get_tc_port ~xs domid

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -347,8 +347,6 @@ module Generic = struct
       "Device.Generic.hard_shutdown about to blow away backend and error paths" ;
     rm_device_state ~xs x
 
-  let really_kill = Xenops_utils.really_kill
-
   let best_effort = Xenops_utils.best_effort
 end
 
@@ -1871,36 +1869,29 @@ module Vusb = struct
             speed id ;
           get_bus_from_version ()
     in
-    if Service.Qemu.is_running ~xs domid then (
-      let bus, prepare_bus = get_bus () in
-      prepare_bus () ;
-      (* Need to reset USB device before passthrough to vm according to
-         CP-24616. Also need to do deprivileged work in usb_reset script if QEMU
-         is deprivileged. *)
-      ( match Service.Qemu.pid ~xs domid with
-      | Some pid ->
-          usb_reset_attach ~hostbus ~hostport ~domid ~pid ~privileged
-      | _ ->
-          raise
-            (Xenopsd_error
-               (Internal_error
-                  (Printf.sprintf "qemu pid does not exist for vm %d" domid)
-               )
-            )
-      ) ;
-      let cmd =
-        Qmp.(
-          Device_add
-            Device.
-              {
-                driver= "usb-host"
-              ; device= USB {USB.id; params= Some USB.{bus; hostbus; hostport}}
-              }
-            
-        )
-      in
-      qmp_send_cmd domid cmd |> ignore
-    )
+    match Service.Qemu.pid ~xs domid with
+    | Some pid ->
+        (* Need to reset USB device before passthrough to vm according to
+           CP-24616. Also need to do deprivileged work in usb_reset script if QEMU
+           is deprivileged. *)
+        let bus, prepare_bus = get_bus () in
+        prepare_bus () ;
+        usb_reset_attach ~hostbus ~hostport ~domid ~pid ~privileged ;
+
+        let cmd =
+          Qmp.(
+            Device_add
+              Device.
+                {
+                  driver= "usb-host"
+                ; device= USB {USB.id; params= Some {bus; hostbus; hostport}}
+                }
+              
+          )
+        in
+        qmp_send_cmd domid cmd |> ignore
+    | None ->
+        ()
 
   let vusb_unplug ~xs ~privileged ~domid ~id ~hostbus ~hostport =
     debug "vusb_unplug: unplug VUSB device %s" id ;
@@ -2197,12 +2188,7 @@ module Dm_Common = struct
                )
           |> List.concat
         ; (info.monitor |> function None -> [] | Some x -> ["-monitor"; x])
-        ; (Service.Qemu.pidfile_path domid |> function
-           | None ->
-               []
-           | Some x ->
-               ["-pidfile"; x]
-          )
+        ; ["-pidfile"; Service.Qemu.pidfile_path domid]
         ]
     in
     {argv; fd_map= []}
@@ -2267,40 +2253,9 @@ module Dm_Common = struct
 
   (* Called by every domain destroy, even non-HVM *)
   let stop ~xs ~qemu_domid domid =
-    let qemu_pid_path = Service.Qemu.pid_path domid in
     let vm_uuid = Xenops_helpers.uuid_of_domid ~xs domid |> Uuid.to_string in
     let dbg = Printf.sprintf "stop domid %d" domid in
-    let stop_qemu () =
-      match Service.Qemu.pid ~xs domid with
-      | None ->
-          () (* nothing to do *)
-      | Some qemu_pid -> (
-          debug "qemu-dm: stopping qemu-dm with SIGTERM (domid = %d)" domid ;
-          let open Generic in
-          best_effort
-            "signalling that qemu is ending as expected, mask further signals"
-            (fun () -> Service.Qemu.(SignalMask.set signal_mask domid)
-          ) ;
-          best_effort "killing qemu-dm" (fun () -> really_kill qemu_pid) ;
-          best_effort "removing qemu-pid from xenstore" (fun () ->
-              xs.Xs.rm qemu_pid_path
-          ) ;
-          best_effort
-            "unmasking signals, qemu-pid is already gone from xenstore"
-            (fun () -> Service.Qemu.(SignalMask.unset signal_mask domid)
-          ) ;
-          best_effort "removing device model path from xenstore" (fun () ->
-              xs.Xs.rm (device_model_path ~qemu_domid domid)
-          ) ;
-          match Service.Qemu.pidfile_path domid with
-          | None ->
-              ()
-          | Some path ->
-              best_effort (sprintf "removing %s" path) (fun () ->
-                  Unix.unlink path
-              )
-        )
-    in
+    let stop_qemu () = Service.Qemu.stop ~xs ~qemu_domid domid in
     let stop_vgpu () = Service.Vgpu.stop ~xs domid in
     let stop_varstored () =
       debug "About to stop varstored for domain %d (%s)" domid vm_uuid ;
@@ -3833,7 +3788,7 @@ module Dm = struct
                     (* before expected qemu stop: qemu-pid is available in
                        domain xs tree: signal action to take *)
                     xs.Xs.write
-                      (Service.Qemu.pid_path_signal domid)
+                      (Service.Qemu.pidxenstore_path_signal domid)
                       crash_reason
             )
         )

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -2057,11 +2057,9 @@ module Dm_Common = struct
 
   let vnc_socket_path = (sprintf "%s/vnc-%d") Device_common.var_run_xen_path
 
-  let efivars_resume_path =
-    Xenops_sandbox.Chroot.Path.of_string ~relative:"efi-vars-resume.dat"
+  let efivars_resume_path = Service.Varstored.efivars_resume_path
 
-  let efivars_save_path =
-    Xenops_sandbox.Chroot.Path.of_string ~relative:"efi-vars-save.dat"
+  let efivars_save_path = Service.Varstored.efivars_save_path
 
   let get_vnc_port ~xs domid ~f =
     match Service.Qemu.is_running ~xs domid with true -> f () | false -> None
@@ -2366,26 +2364,6 @@ module Dm_Common = struct
     | _, (Unix.WSIGNALED n | Unix.WSTOPPED n) ->
         error "%s: unexpected signal: %d" name n ;
         false
-
-  (* Waits for a daemon to signal startup by writing to a xenstore path
-     (optionally with a given value) If this doesn't happen in the timeout then
-     an exception is raised *)
-  let wait_path ~pidalive ~task ~name ~domid ~xs ~ready_path ~timeout ~cancel _
-      =
-    let syslog_key = Printf.sprintf "%s-%d" name domid in
-    let watch = Watch.value_to_appear ready_path |> Watch.map (fun _ -> ()) in
-    Xenops_task.check_cancelling task ;
-    ( try
-        let (_ : bool) =
-          cancellable_watch cancel [watch] [] task ~xs ~timeout ()
-        in
-        ()
-      with Watch.Timeout _ ->
-        if pidalive name then
-          raise (Ioemu_failed (name, "Timeout reached while starting daemon")) ;
-        raise (Ioemu_failed (name, "Daemon exited unexpectedly"))
-    ) ;
-    debug "Daemon initialised: %s" syslog_key
 
   let gimtool_m = Mutex.create ()
 
@@ -3792,70 +3770,6 @@ module Dm = struct
   (* the following functions depend on the functions above that use the qemu
      backend Q *)
 
-  let start_varstored ~xs ~nvram ?(restore = false)
-      (task : Xenops_task.task_handle) domid =
-    let open Xenops_types in
-    debug "Preparing to start varstored for UEFI boot (domid=%d)" domid ;
-    let path = !Xc_resources.varstored in
-    let name = "varstored" in
-    let vm_uuid = Xenops_helpers.uuid_of_domid ~xs domid |> Uuid.to_string in
-    let reset_on_boot =
-      nvram.Nvram_uefi_variables.on_boot = Nvram_uefi_variables.Reset
-    in
-    let backend = nvram.Nvram_uefi_variables.backend in
-    let open Fe_argv in
-    let argf fmt = ksprintf (fun s -> ["--arg"; s]) fmt in
-    let on cond value = if cond then value else return () in
-    let chroot, socket_path =
-      Xenops_sandbox.Varstore_guard.start (Xenops_task.get_dbg task) ~vm_uuid
-        ~domid ~paths:[efivars_save_path]
-    in
-    let args =
-      Add.many
-        [
-          "--domain"
-        ; string_of_int domid
-        ; "--chroot"
-        ; chroot.root
-        ; "--depriv"
-        ; "--uid"
-        ; string_of_int chroot.uid
-        ; "--gid"
-        ; string_of_int chroot.gid
-        ; "--backend"
-        ; backend
-        ; "--arg"
-        ; Printf.sprintf "socket:%s" socket_path
-        ]
-      >>= fun () ->
-      (Service.Varstored.pidfile_path domid |> function
-       | None ->
-           return ()
-       | Some x ->
-           Add.many ["--pidfile"; x]
-      )
-      >>= fun () ->
-      Add.many @@ argf "uuid:%s" vm_uuid >>= fun () ->
-      on reset_on_boot @@ Add.arg "--nonpersistent" >>= fun () ->
-      on restore @@ Add.arg "--resume" >>= fun () ->
-      on restore
-      @@ Add.many
-      @@ argf "resume:%s"
-           (Xenops_sandbox.Chroot.chroot_path_inside efivars_resume_path)
-      >>= fun () ->
-      Add.many
-      @@ argf "save:%s"
-           (Xenops_sandbox.Chroot.chroot_path_inside efivars_save_path)
-    in
-    let args = Fe_argv.run args |> snd |> Fe_argv.argv in
-    let service = Service.Varstored.start_daemon ~path ~args ~domid () in
-    let ready_path = Service.Varstored.pid_path domid in
-    wait_path
-      ~pidalive:(Service.Varstored.alive service)
-      ~task ~name ~domid ~xs ~ready_path
-      ~timeout:!Xenopsd.varstored_ready_timeout
-      ~cancel:(Cancel_utils.Varstored domid) ()
-
   let start_vgpu ~xc:_ ~xs task ?(restore = false) domid vgpus vcpus profile =
     let open Xenops_interface.Vgpu in
     match vgpus with
@@ -3872,8 +3786,8 @@ module Dm = struct
             Service.Vgpu.start_daemon ~path:!Xc_resources.vgpu ~args ~domid
               ~fds:[] ()
           in
-          wait_path ~pidalive:(pid_alive vgpu_pid) ~task ~name:"vgpu" ~domid ~xs
-            ~ready_path:state_path
+          Service.Vgpu.wait_path ~pidalive:(pid_alive vgpu_pid) ~task
+            ~name:"vgpu" ~domid ~xs ~ready_path:state_path
             ~timeout:!Xenopsd.vgpu_ready_timeout
             ~cancel () ;
           Forkhelpers.dontwaitpid vgpu_pid
@@ -3942,8 +3856,8 @@ module Dm = struct
     (* start varstored if appropriate *)
     ( match info.firmware with
     | Uefi nvram_uefi ->
-        start_varstored ~restore:(action = Restore) ~xs ~nvram:nvram_uefi task
-          domid
+        Service.Varstored.start ~restore:(action = Restore) ~xs
+          ~nvram:nvram_uefi task domid
     | Bios ->
         ()
     ) ;

--- a/ocaml/xenopsd/xc/device.mli
+++ b/ocaml/xenopsd/xc/device.mli
@@ -58,11 +58,6 @@ module Profile : sig
       [fallback] if an invalid name is provided. *)
 end
 
-(** Represent an IPC endpoint *)
-module Socket : sig
-  type t = Unix of string | Port of int
-end
-
 module Generic : sig
   val rm_device_state : xs:Xenstore.Xs.xsh -> device -> unit
 
@@ -225,55 +220,6 @@ module Vcpu : sig
   val status : xs:Xenstore.Xs.xsh -> dm:Profile.t -> devid:int -> int -> bool
 end
 
-module PV_Vnc : sig
-  exception Failed_to_start
-
-  val save : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
-
-  val get_statefile : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> string option
-
-  val start :
-       ?statefile:string
-    -> xs:Xenstore.Xs.xsh
-    -> ?ip:string
-    -> Xenctrl.domid
-    -> unit
-
-  val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
-
-  val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Socket.t option
-
-  val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
-end
-
-module Qemu : sig
-  module SignalMask : sig
-    type t
-
-    val create : unit -> t
-
-    val set : t -> int -> unit
-
-    val unset : t -> int -> unit
-
-    val has : t -> int -> bool
-  end
-
-  val signal_mask : SignalMask.t
-
-  val pid_path_signal : Xenctrl.domid -> string
-
-  val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
-
-  val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
-end
-
-module Vgpu : sig
-  val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
-
-  val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
-end
-
 module PCI : sig
   open Xenops_interface.Pci
 
@@ -391,7 +337,10 @@ module Dm : sig
   }
 
   val get_vnc_port :
-    xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> Socket.t option
+       xs:Xenstore.Xs.xsh
+    -> dm:Profile.t
+    -> Xenctrl.domid
+    -> Xenops_utils.Socket.t option
 
   val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 
@@ -527,6 +476,9 @@ module Vusb : sig
 end
 
 val get_vnc_port :
-  xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> Socket.t option
+     xs:Xenstore.Xs.xsh
+  -> dm:Profile.t
+  -> Xenctrl.domid
+  -> Xenops_utils.Socket.t option
 
 val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -695,7 +695,7 @@ let destroy (task : Xenops_task.task_handle) ~xc ~xs ~qemu_domid ~dm domid =
     (fun () -> Device.Dm.stop ~xs ~qemu_domid ~dm domid)
     () ;
   log_exn_continue "Error stoping vncterm, already dead ?"
-    (fun () -> Device.PV_Vnc.stop ~xs domid)
+    (fun () -> Service.PV_Vnc.stop ~xs domid)
     () ;
   (* Forcibly shutdown every backend *)
   List.iter

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -1,3 +1,16 @@
+(* Copyright (C) Citrix Systems Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+*)
+
 module D = Debug.Make (struct let name = "service" end)
 
 open! D

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -96,8 +96,6 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
   let pid_path domid =
     match D.pid_location with Xenstore key | Path_of {key; _} -> key domid
 
-  let pid_path_signal domid = pid_path domid ^ "-signal"
-
   let pidfile_path domid =
     match D.pid_location with
     | Path_of {file; _} ->
@@ -190,13 +188,59 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
     pid
 end
 
-module Qemu = DaemonMgmt (struct
+module Qemu = struct
   let name = "qemu-dm"
 
-  let pid_path domid = Printf.sprintf "/local/domain/%d/qemu-pid" domid
+  let pidfile_path = pidfile_path_tmpfs name
 
-  let pid_location = Pid.Path_of {key= pid_path; file= pidfile_path_tmpfs name}
-end)
+  let pidxenstore_path domid = Printf.sprintf "/local/domain/%d/qemu-pid" domid
+
+  let pidxenstore_path_signal domid = pidxenstore_path domid ^ "-signal"
+
+  module D = DaemonMgmt (struct
+    let name = name
+
+    let pid_location = Pid.Path_of {key= pidxenstore_path; file= pidfile_path}
+  end)
+
+  module SignalMask = D.SignalMask
+
+  let signal_mask = D.signal_mask
+
+  let start_daemon = D.start_daemon
+
+  let pid = D.pid
+
+  let is_running = D.is_running
+
+  let stop ~xs ~qemu_domid domid =
+    match pid ~xs domid with
+    | None ->
+        () (* nothing to do *)
+    | Some pid ->
+        let xenstore_path = pidxenstore_path domid in
+        let best_effort = Xenops_utils.best_effort in
+        let really_kill = Xenops_utils.really_kill in
+        debug "qemu-dm: stopping qemu-dm with SIGTERM (domid = %d)" domid ;
+        best_effort
+          "signalling that qemu is ending as expected, mask further signals"
+          (fun () -> SignalMask.set signal_mask domid
+        ) ;
+        best_effort "killing qemu-dm" (fun () -> really_kill pid) ;
+        best_effort "removing qemu-pid from xenstore" (fun () ->
+            xs.Xs.rm xenstore_path
+        ) ;
+        best_effort "unmasking signals, qemu-pid is already gone from xenstore"
+          (fun () -> SignalMask.unset signal_mask domid
+        ) ;
+        best_effort "removing device model path from xenstore" (fun () ->
+            xs.Xs.rm (Device_common.device_model_path ~qemu_domid domid)
+        ) ;
+        let file_path = pidfile_path domid in
+        best_effort (Printf.sprintf "removing %s" file_path) (fun () ->
+            Unix.unlink file_path
+        )
+end
 
 module Vgpu = struct
   module D = DaemonMgmt (struct

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -23,6 +23,18 @@ module Socket = Xenops_utils.Socket
 
 exception Service_failed of (string * string)
 
+let alive service _ =
+  let is_active = Fe_systemctl.is_active ~service in
+  ( if not is_active then
+      let status = Fe_systemctl.show ~service in
+      error
+        "%s: unexpected termination \
+         (Result=%s,ExecMainPID=%d,ExecMainStatus=%d,ActiveState=%s)"
+        service status.result status.exec_main_pid status.exec_main_status
+        status.active_state
+  ) ;
+  is_active
+
 (* Waits for a daemon to signal startup by writing to a xenstore path
    (optionally with a given value) If this doesn't happen in the timeout then
    an exception is raised *)
@@ -93,16 +105,6 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
 
   let name = D.name
 
-  let pid_path domid =
-    match D.pid_location with Xenstore key | Path_of {key; _} -> key domid
-
-  let pidfile_path domid =
-    match D.pid_location with
-    | Path_of {file; _} ->
-        Some (file domid)
-    | _ ->
-        None
-
   let pid ~xs domid =
     try
       match D.pid_location with
@@ -150,17 +152,22 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
         best_effort (Printf.sprintf "killing %s" D.name) (fun () ->
             really_kill pid
         ) ;
-        let key = pid_path domid in
-        best_effort (Printf.sprintf "removing XS key %s" key) (fun () ->
-            xs.Xs.rm key
-        ) ;
-        match pidfile_path domid with
-        | None ->
-            ()
-        | Some path ->
-            best_effort (Printf.sprintf "removing %s" path) (fun () ->
-                Unix.unlink path
-            )
+        let remove_key key =
+          best_effort (Printf.sprintf "removing XS key %s" key) (fun () ->
+              xs.Xs.rm key
+          )
+        in
+        let remove_file path =
+          best_effort (Printf.sprintf "removing %s" path) (fun () ->
+              Unix.unlink path
+          )
+        in
+        match D.pid_location with
+        | Xenstore key ->
+            remove_key (key domid)
+        | Path_of {key; file} ->
+            remove_key (key domid) ;
+            remove_file (file domid)
       )
 
   let syslog_key ~domid = Printf.sprintf "%s-%d" D.name domid
@@ -370,10 +377,6 @@ module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
   (* backward compat: for daemons running during an update *)
   module Compat = DaemonMgmt (D)
 
-  let pidfile_path = Compat.pidfile_path
-
-  let pid_path = Compat.pid_path
-
   let of_domid domid =
     let key = Compat.syslog_key ~domid in
     if Fe_systemctl.exists ~service:key then
@@ -381,43 +384,41 @@ module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
     else
       None
 
-  let alive service _ =
-    if Fe_systemctl.is_active ~service then
-      true
-    else
-      let status = Fe_systemctl.show ~service in
-      let open Fe_systemctl in
-      error
-        "%s: unexpected termination \
-         (Result=%s,ExecMainPID=%d,ExecMainStatus=%d,ActiveState=%s)"
-        service status.result status.exec_main_pid status.exec_main_status
-        status.active_state ;
-      false
-
-  let stop ~xs domid =
+  let is_running ~xs domid =
     match of_domid domid with
     | None ->
+        Compat.is_running ~xs domid
+    | Some key ->
+        Fe_systemctl.is_active ~service:key
+
+  let stop ~xs domid =
+    match (of_domid domid, is_running ~xs domid) with
+    | None, true ->
         Compat.stop ~xs domid
-    | Some service ->
+    | Some service, true ->
         (* xenstore cleanup is done by systemd unit file *)
         let (_ : Fe_systemctl.status) = Fe_systemctl.stop ~service in
         ()
+    | Some service, false ->
+        info "Not trying to stop %s since it's not running" service
+    | None, false ->
+        info "Not trying to stop %s for domid %i since it's not running" D.name
+          domid
 
   let start_daemon ~path ~args ~domid () =
     debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
     let service = Compat.syslog_key ~domid in
-    let pidpath =
-      match D.pid_location with Xenstore key | Path_of {key; _} -> key domid
-    in
     let properties =
-      ("ExecStopPost", "-/usr/bin/xenstore-rm " ^ pidpath)
-      ::
-      ( match Compat.pidfile_path domid with
-      | None ->
-          []
-      | Some path ->
-          [("ExecStopPost", "-/bin/rm -f " ^ path)]
-      )
+      let remove_key path = ("ExecStopPost", "-/usr/bin/xenstore-rm " ^ path) in
+      let remove_file path = ("ExecStopPost", "-/bin/rm -f " ^ path) in
+      match D.pid_location with
+      | Xenstore get_path ->
+          let key_path = get_path domid in
+          [remove_key key_path]
+      | Path_of {key; file} ->
+          let key_path = key domid in
+          let file_path = file domid in
+          [remove_key key_path; remove_file file_path]
     in
     Fe_systemctl.start_transient ~properties ~service path args ;
     debug "Daemon started: %s" service ;
@@ -425,13 +426,17 @@ module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
 end
 
 module Varstored = struct
+  let name = "varstored"
+
+  let pidxenstore_path domid =
+    Printf.sprintf "/local/domain/%d/varstored-pid" domid
+
+  let pidfile_path = pidfile_path_tmpfs name
+
   module D = SystemdDaemonMgmt (struct
-    let name = "varstored"
+    let name = name
 
-    let pid_path domid = Printf.sprintf "/local/domain/%d/varstored-pid" domid
-
-    let pid_location =
-      Pid.Path_of {key= pid_path; file= pidfile_path_tmpfs name}
+    let pid_location = Pid.Path_of {key= pidxenstore_path; file= pidfile_path}
   end)
 
   let efivars_resume_path =
@@ -444,19 +449,16 @@ module Varstored = struct
     let open Xenops_types in
     debug "Preparing to start varstored for UEFI boot (domid=%d)" domid ;
     let path = !Xc_resources.varstored in
-    let name = "varstored" in
     let vm_uuid = Xenops_helpers.uuid_of_domid ~xs domid |> Uuid.to_string in
-    let reset_on_boot =
-      nvram.Nvram_uefi_variables.on_boot = Nvram_uefi_variables.Reset
-    in
+    let reset_on_boot = Nvram_uefi_variables.(nvram.on_boot = Reset) in
     let backend = nvram.Nvram_uefi_variables.backend in
-    let open Fe_argv in
-    let argf fmt = Printf.ksprintf (fun s -> ["--arg"; s]) fmt in
-    let on cond value = if cond then value else return () in
     let chroot, socket_path =
       Xenops_sandbox.Varstore_guard.start (Xenops_task.get_dbg task) ~vm_uuid
         ~domid ~paths:[efivars_save_path]
     in
+    let open Fe_argv in
+    let argf fmt = Printf.ksprintf (fun s -> ["--arg"; s]) fmt in
+    let on cond value = if cond then value else return () in
     let args =
       Add.many
         [
@@ -473,14 +475,9 @@ module Varstored = struct
         ; backend
         ; "--arg"
         ; Printf.sprintf "socket:%s" socket_path
+        ; "--pidfile"
+        ; pidfile_path domid
         ]
-      >>= fun () ->
-      (D.pidfile_path domid |> function
-       | None ->
-           return ()
-       | Some x ->
-           Add.many ["--pidfile"; x]
-      )
       >>= fun () ->
       Add.many @@ argf "uuid:%s" vm_uuid >>= fun () ->
       on reset_on_boot @@ Add.arg "--nonpersistent" >>= fun () ->
@@ -496,8 +493,8 @@ module Varstored = struct
     in
     let args = Fe_argv.run args |> snd |> Fe_argv.argv in
     let service = D.start_daemon ~path ~args ~domid () in
-    let ready_path = D.pid_path domid in
-    wait_path ~pidalive:(D.alive service) ~task ~name ~domid ~xs ~ready_path
+    let ready_path = pidxenstore_path domid in
+    wait_path ~pidalive:(alive service) ~task ~name ~domid ~xs ~ready_path
       ~timeout:!Xenopsd.varstored_ready_timeout
       ~cancel:(Cancel_utils.Varstored domid) ()
 
@@ -505,12 +502,13 @@ module Varstored = struct
 end
 
 module PV_Vnc = struct
+  let pidxenstore_path domid =
+    Printf.sprintf "/local/domain/%d/vncterm-pid" domid
+
   module D = DaemonMgmt (struct
     let name = "vncterm"
 
-    let pid_path domid = Printf.sprintf "/local/domain/%d/vncterm-pid" domid
-
-    let pid_location = Pid.Xenstore pid_path
+    let pid_location = Pid.Xenstore pidxenstore_path
   end)
 
   let vnc_console_path domid = Printf.sprintf "/local/domain/%d/console" domid
@@ -621,7 +619,7 @@ module PV_Vnc = struct
     in
     (* Now add the close fds wrapper *)
     let pid = D.start_daemon ~path:!Xc_resources.vncterm ~args:l ~domid () in
-    let path = D.pid_path domid in
+    let path = pidxenstore_path domid in
     xs.Xs.write path (string_of_int (Forkhelpers.getpid pid)) ;
     Forkhelpers.dontwaitpid pid
 

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -1,0 +1,337 @@
+module D = Debug.Make (struct let name = "service" end)
+
+open! D
+module Unixext = Xapi_stdext_unix.Unixext
+module Xenops_task = Xenops_task.Xenops_task
+module Chroot = Xenops_sandbox.Chroot
+module Path = Chroot.Path
+module Xs = Xenstore.Xs
+module Socket = Xenops_utils.Socket
+
+module type DAEMONPIDPATH = sig
+  val name : string
+
+  val use_pidfile : bool
+
+  val pid_path : int -> string
+end
+
+module DaemonMgmt (D : DAEMONPIDPATH) = struct
+  module SignalMask = struct
+    module H = Hashtbl
+
+    type t = (int, bool) H.t
+
+    let create () = H.create 16
+
+    let set tbl key = H.replace tbl key true
+
+    let unset tbl key = H.remove tbl key
+
+    let has tbl key = H.mem tbl key
+  end
+
+  let signal_mask = SignalMask.create ()
+
+  let name = D.name
+
+  let pid_path = D.pid_path
+
+  let pid_path_signal domid = pid_path domid ^ "-signal"
+
+  let pidfile_path domid =
+    if D.use_pidfile then
+      Some
+        (Printf.sprintf "%s/%s-%d.pid" Device_common.var_run_xen_path D.name
+           domid
+        )
+    else
+      None
+
+  let pid ~xs domid =
+    try
+      match pidfile_path domid with
+      | Some path when Sys.file_exists path ->
+          let pid =
+            path |> Unixext.string_of_file |> String.trim |> int_of_string
+          in
+          Unixext.with_file path [Unix.O_RDONLY] 0 (fun fd ->
+              try
+                Unix.lockf fd Unix.F_TRLOCK 0 ;
+                (* we succeeded taking the lock: original process is dead.
+                 * some other process might've reused its pid *)
+                None
+              with Unix.Unix_error (Unix.EAGAIN, _, _) ->
+                (* cannot obtain lock: process is alive *)
+                Some pid
+          )
+      | _ ->
+          (* backward compatibility during update installation: only has
+             xenstore pid *)
+          let pid = xs.Xs.read (pid_path domid) in
+          Some (int_of_string pid)
+    with _ -> None
+
+  let is_running ~xs domid =
+    match pid ~xs domid with
+    | None ->
+        false
+    | Some p -> (
+      try Unix.kill p 0 ; (* This checks the existence of pid p *)
+                          true
+      with _ -> false
+    )
+
+  let stop ~xs domid =
+    match pid ~xs domid with
+    | None ->
+        ()
+    | Some pid -> (
+        let best_effort = Xenops_utils.best_effort in
+        let really_kill = Xenops_utils.really_kill in
+        debug "%s: stopping %s with SIGTERM (domid = %d pid = %d)" D.name D.name
+          domid pid ;
+        best_effort (Printf.sprintf "killing %s" D.name) (fun () ->
+            really_kill pid
+        ) ;
+        let key = pid_path domid in
+        best_effort (Printf.sprintf "removing XS key %s" key) (fun () ->
+            xs.Xs.rm key
+        ) ;
+        match pidfile_path domid with
+        | None ->
+            ()
+        | Some path ->
+            best_effort (Printf.sprintf "removing %s" path) (fun () ->
+                Unix.unlink path
+            )
+      )
+
+  let syslog_key ~domid = Printf.sprintf "%s-%d" D.name domid
+
+  let start ~fds ~syslog_key path args =
+    let syslog_stdout = Forkhelpers.Syslog_WithKey syslog_key in
+    let redirect_stderr_to_stdout = true in
+    let pid =
+      Forkhelpers.safe_close_and_exec None None None fds ~syslog_stdout
+        ~redirect_stderr_to_stdout path args
+    in
+    debug
+      "%s: should be running in the background (stdout -> syslog); (fd,pid) = \
+       %s"
+      D.name
+      (Forkhelpers.string_of_pidty pid) ;
+    pid
+
+  (* Forks a daemon and then returns the pid. *)
+  let start_daemon ~path ~args ~domid ?(fds = []) () =
+    let syslog_key = syslog_key ~domid in
+    debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
+    let pid = start ~fds ~syslog_key path args in
+    debug "Daemon started: %s" syslog_key ;
+    pid
+end
+
+module Qemu = DaemonMgmt (struct
+  let name = "qemu-dm"
+
+  let use_pidfile = true
+
+  let pid_path domid = Printf.sprintf "/local/domain/%d/qemu-pid" domid
+end)
+
+module Vgpu = DaemonMgmt (struct
+  let name = "vgpu"
+
+  let use_pidfile = false
+
+  let pid_path domid = Printf.sprintf "/local/domain/%d/vgpu-pid" domid
+end)
+
+module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
+  (* backward compat: for daemons running during an update *)
+  module Compat = DaemonMgmt (D)
+
+  let pidfile_path = Compat.pidfile_path
+
+  let pid_path = Compat.pid_path
+
+  let of_domid domid =
+    let key = Compat.syslog_key ~domid in
+    if Fe_systemctl.exists ~service:key then
+      Some key
+    else
+      None
+
+  let alive service _ =
+    if Fe_systemctl.is_active ~service then
+      true
+    else
+      let status = Fe_systemctl.show ~service in
+      let open Fe_systemctl in
+      error
+        "%s: unexpected termination \
+         (Result=%s,ExecMainPID=%d,ExecMainStatus=%d,ActiveState=%s)"
+        service status.result status.exec_main_pid status.exec_main_status
+        status.active_state ;
+      false
+
+  let stop ~xs domid =
+    match of_domid domid with
+    | None ->
+        Compat.stop ~xs domid
+    | Some service ->
+        (* xenstore cleanup is done by systemd unit file *)
+        let (_ : Fe_systemctl.status) = Fe_systemctl.stop ~service in
+        ()
+
+  let start_daemon ~path ~args ~domid () =
+    debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
+    let service = Compat.syslog_key ~domid in
+    let pidpath = D.pid_path domid in
+    let properties =
+      ("ExecStopPost", "-/usr/bin/xenstore-rm " ^ pidpath)
+      ::
+      ( match Compat.pidfile_path domid with
+      | None ->
+          []
+      | Some path ->
+          [("ExecStopPost", "-/bin/rm -f " ^ path)]
+      )
+    in
+    Fe_systemctl.start_transient ~properties ~service path args ;
+    debug "Daemon started: %s" service ;
+    service
+end
+
+module Varstored = SystemdDaemonMgmt (struct
+  let name = "varstored"
+
+  let use_pidfile = true
+
+  let pid_path domid = Printf.sprintf "/local/domain/%d/varstored-pid" domid
+end)
+
+module PV_Vnc = struct
+  module D = DaemonMgmt (struct
+    let name = "vncterm"
+
+    let use_pidfile = false
+
+    let pid_path domid = Printf.sprintf "/local/domain/%d/vncterm-pid" domid
+  end)
+
+  let vnc_console_path domid = Printf.sprintf "/local/domain/%d/console" domid
+
+  let vnc_port_path domid =
+    Printf.sprintf "/local/domain/%d/console/vnc-port" domid
+
+  let tc_port_path domid =
+    Printf.sprintf "/local/domain/%d/console/tc-port" domid
+
+  let pid ~xs domid = D.pid ~xs domid
+
+  (* Look up the commandline args for the vncterm pid; *)
+  (* Check that they include the vncterm binary path and the xenstore console
+     path for the supplied domid. *)
+  let is_cmdline_valid domid pid =
+    try
+      let cmdline =
+        Printf.sprintf "/proc/%d/cmdline" pid
+        |> Unixext.string_of_file
+        |> Astring.String.cuts ~sep:"\000"
+      in
+      List.mem !Xc_resources.vncterm cmdline
+      && List.mem (vnc_console_path domid) cmdline
+    with _ -> false
+
+  let is_vncterm_running ~xs domid =
+    match pid ~xs domid with
+    | None ->
+        false
+    | Some p ->
+        D.is_running ~xs domid && is_cmdline_valid domid p
+
+  let get_vnc_port ~xs domid =
+    if not (is_vncterm_running ~xs domid) then
+      None
+    else
+      try Some (Socket.Port (int_of_string (xs.Xs.read (vnc_port_path domid))))
+      with _ -> None
+
+  let get_tc_port ~xs domid =
+    if not (is_vncterm_running ~xs domid) then
+      None
+    else
+      try Some (int_of_string (xs.Xs.read (tc_port_path domid)))
+      with _ -> None
+
+  let load_args = function
+    | None ->
+        []
+    | Some filename ->
+        if Sys.file_exists filename then
+          ["-l"; filename]
+        else
+          []
+
+  exception Failed_to_start
+
+  let vncterm_statefile pid =
+    Printf.sprintf "/var/xen/vncterm/%d/vncterm.statefile" pid
+
+  let get_statefile ~xs domid =
+    match pid ~xs domid with
+    | None ->
+        None
+    | Some pid ->
+        let filename = vncterm_statefile pid in
+        if Sys.file_exists filename then
+          Some filename
+        else
+          None
+
+  let save ~xs domid =
+    match pid ~xs domid with
+    | Some pid ->
+        Unix.kill pid Sys.sigusr1 ;
+        let filename = vncterm_statefile pid in
+        let delay = 10. in
+        let start_time = Unix.time () in
+        (* wait at most ten seconds *)
+        while
+          (not (Sys.file_exists filename)) || Unix.time () -. start_time > delay
+        do
+          debug "Device.PV_Vnc.save: waiting for %s to appear" filename ;
+          Thread.delay 1.
+        done ;
+        if Unix.time () -. start_time > delay then
+          debug "Device.PV_Vnc.save: timeout while waiting for %s to appear"
+            filename
+        else
+          debug "Device.PV_Vnc.save: %s has appeared" filename
+    | None ->
+        ()
+
+  let start ?statefile ~xs ?ip domid =
+    debug "In PV_Vnc.start" ;
+    let ip = Option.value ~default:"127.0.0.1" ip in
+    let l =
+      [
+        "-x"
+      ; Printf.sprintf "/local/domain/%d/console" domid
+      ; "-T"
+      ; (* listen for raw connections *)
+        "-v"
+      ; ip ^ ":1"
+      ]
+      @ load_args statefile
+    in
+    (* Now add the close fds wrapper *)
+    let pid = D.start_daemon ~path:!Xc_resources.vncterm ~args:l ~domid () in
+    let path = D.pid_path domid in
+    xs.Xs.write path (string_of_int (Forkhelpers.getpid pid)) ;
+    Forkhelpers.dontwaitpid pid
+
+  let stop ~xs domid = D.stop ~xs domid
+end

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -21,6 +21,27 @@ module Path = Chroot.Path
 module Xs = Xenstore.Xs
 module Socket = Xenops_utils.Socket
 
+exception Service_failed of (string * string)
+
+(* Waits for a daemon to signal startup by writing to a xenstore path
+   (optionally with a given value) If this doesn't happen in the timeout then
+   an exception is raised *)
+let wait_path ~pidalive ~task ~name ~domid ~xs ~ready_path ~timeout ~cancel _ =
+  let syslog_key = Printf.sprintf "%s-%d" name domid in
+  let watch = Watch.value_to_appear ready_path |> Watch.map (fun _ -> ()) in
+  Xenops_task.check_cancelling task ;
+  ( try
+      let (_ : bool) =
+        Cancel_utils.cancellable_watch cancel [watch] [] task ~xs ~timeout ()
+      in
+      ()
+    with Watch.Timeout _ ->
+      if pidalive name then
+        raise (Service_failed (name, "Timeout reached while starting daemon")) ;
+      raise (Service_failed (name, "Daemon exited unexpectedly"))
+  ) ;
+  debug "Daemon initialised: %s" syslog_key
+
 module type DAEMONPIDPATH = sig
   val name : string
 
@@ -153,13 +174,25 @@ module Qemu = DaemonMgmt (struct
   let pid_path domid = Printf.sprintf "/local/domain/%d/qemu-pid" domid
 end)
 
-module Vgpu = DaemonMgmt (struct
-  let name = "vgpu"
+module Vgpu = struct
+  module D = DaemonMgmt (struct
+    let name = "vgpu"
 
-  let use_pidfile = false
+    let use_pidfile = false
 
-  let pid_path domid = Printf.sprintf "/local/domain/%d/vgpu-pid" domid
-end)
+    let pid_path domid = Printf.sprintf "/local/domain/%d/vgpu-pid" domid
+  end)
+
+  let start_daemon = D.start_daemon
+
+  let pid = D.pid
+
+  let is_running = D.is_running
+
+  let stop = D.stop
+
+  let wait_path = wait_path
+end
 
 module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
   (* backward compat: for daemons running during an update *)
@@ -217,13 +250,84 @@ module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
     service
 end
 
-module Varstored = SystemdDaemonMgmt (struct
-  let name = "varstored"
+module Varstored = struct
+  module D = SystemdDaemonMgmt (struct
+    let name = "varstored"
 
-  let use_pidfile = true
+    let use_pidfile = true
 
-  let pid_path domid = Printf.sprintf "/local/domain/%d/varstored-pid" domid
-end)
+    let pid_path domid = Printf.sprintf "/local/domain/%d/varstored-pid" domid
+  end)
+
+  let efivars_resume_path =
+    Xenops_sandbox.Chroot.Path.of_string ~relative:"efi-vars-resume.dat"
+
+  let efivars_save_path =
+    Xenops_sandbox.Chroot.Path.of_string ~relative:"efi-vars-save.dat"
+
+  let start ~xs ~nvram ?(restore = false) task domid =
+    let open Xenops_types in
+    debug "Preparing to start varstored for UEFI boot (domid=%d)" domid ;
+    let path = !Xc_resources.varstored in
+    let name = "varstored" in
+    let vm_uuid = Xenops_helpers.uuid_of_domid ~xs domid |> Uuid.to_string in
+    let reset_on_boot =
+      nvram.Nvram_uefi_variables.on_boot = Nvram_uefi_variables.Reset
+    in
+    let backend = nvram.Nvram_uefi_variables.backend in
+    let open Fe_argv in
+    let argf fmt = Printf.ksprintf (fun s -> ["--arg"; s]) fmt in
+    let on cond value = if cond then value else return () in
+    let chroot, socket_path =
+      Xenops_sandbox.Varstore_guard.start (Xenops_task.get_dbg task) ~vm_uuid
+        ~domid ~paths:[efivars_save_path]
+    in
+    let args =
+      Add.many
+        [
+          "--domain"
+        ; string_of_int domid
+        ; "--chroot"
+        ; chroot.root
+        ; "--depriv"
+        ; "--uid"
+        ; string_of_int chroot.uid
+        ; "--gid"
+        ; string_of_int chroot.gid
+        ; "--backend"
+        ; backend
+        ; "--arg"
+        ; Printf.sprintf "socket:%s" socket_path
+        ]
+      >>= fun () ->
+      (D.pidfile_path domid |> function
+       | None ->
+           return ()
+       | Some x ->
+           Add.many ["--pidfile"; x]
+      )
+      >>= fun () ->
+      Add.many @@ argf "uuid:%s" vm_uuid >>= fun () ->
+      on reset_on_boot @@ Add.arg "--nonpersistent" >>= fun () ->
+      on restore @@ Add.arg "--resume" >>= fun () ->
+      on restore
+      @@ Add.many
+      @@ argf "resume:%s"
+           (Xenops_sandbox.Chroot.chroot_path_inside efivars_resume_path)
+      >>= fun () ->
+      Add.many
+      @@ argf "save:%s"
+           (Xenops_sandbox.Chroot.chroot_path_inside efivars_save_path)
+    in
+    let args = Fe_argv.run args |> snd |> Fe_argv.argv in
+    let service = D.start_daemon ~path ~args ~domid () in
+    let ready_path = D.pid_path domid in
+    wait_path ~pidalive:(D.alive service) ~task ~name ~domid ~xs ~ready_path
+      ~timeout:!Xenopsd.varstored_ready_timeout
+      ~cancel:(Cancel_utils.Varstored domid) ()
+
+  let stop = D.stop
+end
 
 module PV_Vnc = struct
   module D = DaemonMgmt (struct

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -42,6 +42,17 @@ let wait_path ~pidalive ~task ~name ~domid ~xs ~ready_path ~timeout ~cancel _ =
   ) ;
   debug "Daemon initialised: %s" syslog_key
 
+let pid_alive pid name =
+  match Forkhelpers.waitpid_nohang pid with
+  | 0, Unix.WEXITED 0 ->
+      true
+  | _, Unix.WEXITED n ->
+      error "%s: unexpected exit with code: %d" name n ;
+      false
+  | _, (Unix.WSIGNALED n | Unix.WSTOPPED n) ->
+      error "%s: unexpected signal: %d" name n ;
+      false
+
 module type DAEMONPIDPATH = sig
   val name : string
 
@@ -183,15 +194,119 @@ module Vgpu = struct
     let pid_path domid = Printf.sprintf "/local/domain/%d/vgpu-pid" domid
   end)
 
-  let start_daemon = D.start_daemon
+  let vgpu_args_of_nvidia domid vcpus vgpus restore =
+    let open Xenops_interface.Vgpu in
+    let virtual_pci_address_compare vgpu1 vgpu2 =
+      match (vgpu1, vgpu2) with
+      | ( {implementation= Nvidia {virtual_pci_address= pci1; _}; _}
+        , {implementation= Nvidia {virtual_pci_address= pci2; _}; _} ) ->
+          Stdlib.compare pci1.dev pci2.dev
+      | other1, other2 ->
+          Stdlib.compare other1 other2
+    in
+    let device_args =
+      let make addr args =
+        Printf.sprintf "--device=%s"
+          (Xcp_pci.string_of_address addr :: args
+          |> List.filter (fun str -> str <> "")
+          |> String.concat ","
+          )
+      in
+      vgpus
+      |> List.sort virtual_pci_address_compare
+      |> List.map (fun vgpu ->
+             let addr =
+               match vgpu.virtual_pci_address with
+               | Some pci ->
+                   pci (* pass VF in case of SRIOV *)
+               | None ->
+                   vgpu.physical_pci_address
+             in
+             (* pass PF otherwise *)
+             match vgpu.implementation with
+             (* 1. Upgrade case, migrate from a old host with old vGPU having
+                config_path 2. Legency case, run with old Nvidia host driver *)
+             | Nvidia
+                 {
+                   virtual_pci_address
+                 ; config_file= Some config_file
+                 ; extra_args
+                 ; _
+                 } ->
+                 (* The VGPU UUID is not available. Create a fresh one; xapi
+                    will deal with it. *)
+                 let uuid = Uuidm.to_string (Uuidm.create `V4) in
+                 debug "NVidia vGPU config: using config file %s and uuid %s"
+                   config_file uuid ;
+                 make addr
+                   [
+                     config_file
+                   ; Xcp_pci.string_of_address virtual_pci_address
+                   ; uuid
+                   ; extra_args
+                   ]
+             | Nvidia
+                 {
+                   virtual_pci_address
+                 ; type_id= Some type_id
+                 ; uuid= Some uuid
+                 ; extra_args
+                 ; _
+                 } ->
+                 debug "NVidia vGPU config: using type id %s and uuid: %s"
+                   type_id uuid ;
+                 make addr
+                   [
+                     type_id
+                   ; Xcp_pci.string_of_address virtual_pci_address
+                   ; uuid
+                   ; extra_args
+                   ]
+             | Nvidia {type_id= None; config_file= None; _} ->
+                 (* No type_id _and_ no config_file: something is wrong *)
+                 raise
+                   (Xenops_interface.Xenopsd_error
+                      (Internal_error
+                         (Printf.sprintf "NVidia vGPU metadata incomplete (%s)"
+                            __LOC__
+                         )
+                      )
+                   )
+             | _ ->
+                 ""
+         )
+    in
+    let suspend_file = Printf.sprintf Device_common.demu_save_path domid in
+    let base_args =
+      [
+        "--domain=" ^ string_of_int domid
+      ; "--vcpus=" ^ string_of_int vcpus
+      ; "--suspend=" ^ suspend_file
+      ]
+      @ device_args
+    in
+    let fd_arg = if restore then ["--resume"] else [] in
+    List.concat [base_args; fd_arg]
+
+  let state_path domid = Printf.sprintf "/local/domain/%d/vgpu/state" domid
+
+  let cancel_key domid = Cancel_utils.Vgpu domid
+
+  let start ~xs ~vcpus ~vgpus ~restore task domid =
+    let args = vgpu_args_of_nvidia domid vcpus vgpus restore in
+    let cancel = cancel_key domid in
+    let pid = D.start_daemon ~path:!Xc_resources.vgpu ~args ~domid ~fds:[] () in
+    wait_path ~pidalive:(pid_alive pid) ~task ~name:D.name ~domid ~xs
+      ~ready_path:(state_path domid)
+      ~timeout:!Xenopsd.vgpu_ready_timeout
+      ~cancel () ;
+    Forkhelpers.dontwaitpid pid
 
   let pid = D.pid
 
   let is_running = D.is_running
 
   let stop = D.stop
-
-  let wait_path = wait_path
 end
 
 module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -63,6 +63,18 @@ module Vgpu : sig
   val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
 
   val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+
+  val wait_path :
+       pidalive:(string -> bool)
+    -> task:Xenops_task.Xenops_task.task_handle
+    -> name:string
+    -> domid:int
+    -> xs:Xenstore.Xs.xsh
+    -> ready_path:Watch.path
+    -> timeout:float
+    -> cancel:Cancel_utils.key
+    -> 'a
+    -> unit
 end
 
 module PV_Vnc : sig
@@ -92,16 +104,17 @@ module PV_Vnc : sig
 end
 
 module Varstored : sig
-  val pidfile_path : Xenctrl.domid -> string option
-  (** path of file containing the pid value *)
+  val efivars_save_path : Xenops_sandbox.Chroot.Path.t
 
-  val pid_path : Xenctrl.domid -> string
-  (** xenstore key containing the pid value *)
+  val efivars_resume_path : Xenops_sandbox.Chroot.Path.t
 
-  val start_daemon :
-    path:string -> args:string list -> domid:Xenctrl.domid -> unit -> string
-
-  val alive : string -> 'a -> bool
+  val start :
+       xs:Xenstore.Xs.xsh
+    -> nvram:Xenops_types.Nvram_uefi_variables.t
+    -> ?restore:bool
+    -> Xenops_task.Xenops_task.task_handle
+    -> Xenctrl.domid
+    -> unit
 
   val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
 end

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -1,3 +1,16 @@
+(* Copyright (C) Citrix Systems Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+*)
+
 module Qemu : sig
   module SignalMask : sig
     type t

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -1,0 +1,94 @@
+module Qemu : sig
+  module SignalMask : sig
+    type t
+
+    val create : unit -> t
+
+    val set : t -> int -> unit
+
+    val unset : t -> int -> unit
+
+    val has : t -> int -> bool
+  end
+
+  val signal_mask : SignalMask.t
+
+  val name : string
+
+  val pid_path_signal : Xenctrl.domid -> string
+
+  val pidfile_path : Xenctrl.domid -> string option
+  (** path of file containing the pid value *)
+
+  val pid_path : Xenctrl.domid -> string
+  (** xenstore key containing the pid value *)
+
+  val start_daemon :
+       path:string
+    -> args:string list
+    -> domid:Xenctrl.domid
+    -> ?fds:(string * Unix.file_descr) list
+    -> unit
+    -> Forkhelpers.pidty
+
+  val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+
+  val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
+end
+
+module Vgpu : sig
+  val start_daemon :
+       path:string
+    -> args:string list
+    -> domid:Xenctrl.domid
+    -> ?fds:(string * Unix.file_descr) list
+    -> unit
+    -> Forkhelpers.pidty
+
+  val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+
+  val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
+
+  val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+end
+
+module PV_Vnc : sig
+  exception Failed_to_start
+
+  val vnc_port_path : Xenctrl.domid -> string
+
+  val tc_port_path : Xenctrl.domid -> string
+
+  val save : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+
+  val get_statefile : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> string option
+
+  val start :
+       ?statefile:string
+    -> xs:Xenstore.Xs.xsh
+    -> ?ip:string
+    -> Xenctrl.domid
+    -> unit
+
+  val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+
+  val get_vnc_port :
+    xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Xenops_utils.Socket.t option
+
+  val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+end
+
+module Varstored : sig
+  val pidfile_path : Xenctrl.domid -> string option
+  (** path of file containing the pid value *)
+
+  val pid_path : Xenctrl.domid -> string
+  (** xenstore key containing the pid value *)
+
+  val start_daemon :
+    path:string -> args:string list -> domid:Xenctrl.domid -> unit -> string
+
+  val alive : string -> 'a -> bool
+
+  val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+end

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -28,13 +28,10 @@ module Qemu : sig
 
   val name : string
 
-  val pid_path_signal : Xenctrl.domid -> string
+  val pidxenstore_path_signal : Xenctrl.domid -> string
 
-  val pidfile_path : Xenctrl.domid -> string option
+  val pidfile_path : Xenctrl.domid -> string
   (** path of file containing the pid value *)
-
-  val pid_path : Xenctrl.domid -> string
-  (** xenstore key containing the pid value *)
 
   val start_daemon :
        path:string
@@ -47,6 +44,9 @@ module Qemu : sig
   val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 
   val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
+
+  val stop :
+    xs:Xenstore.Xs.xsh -> qemu_domid:Xenctrl.domid -> Xenctrl.domid -> unit
 end
 
 module Vgpu : sig

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -50,31 +50,24 @@ module Qemu : sig
 end
 
 module Vgpu : sig
-  val start_daemon :
-       path:string
-    -> args:string list
-    -> domid:Xenctrl.domid
-    -> ?fds:(string * Unix.file_descr) list
+  val start :
+       xs:Xenstore.Xs.xsh
+    -> vcpus:int
+    -> vgpus:Xenops_interface.Vgpu.t list
+    -> restore:bool
+    -> Xenops_task.Xenops_task.task_handle
+    -> int
     -> unit
-    -> Forkhelpers.pidty
+
+  val cancel_key : Xenctrl.domid -> Cancel_utils.key
+
+  val state_path : Xenctrl.domid -> string
 
   val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 
   val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
 
   val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
-
-  val wait_path :
-       pidalive:(string -> bool)
-    -> task:Xenops_task.Xenops_task.task_handle
-    -> name:string
-    -> domid:int
-    -> xs:Xenstore.Xs.xsh
-    -> ready_path:Watch.path
-    -> timeout:float
-    -> cancel:Cancel_utils.key
-    -> 'a
-    -> unit
 end
 
 module PV_Vnc : sig

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -1681,7 +1681,7 @@ module VM = struct
           (fun () -> Device.Dm.stop ~xs ~qemu_domid ~dm:(dm_of ~vm) domid)
           () ;
         log_exn_continue "Error stoping vncterm, already dead ?"
-          (fun () -> Device.PV_Vnc.stop ~xs domid)
+          (fun () -> Service.PV_Vnc.stop ~xs domid)
           ()
         (* If qemu is in a different domain to storage, detach disks *)
     )
@@ -1738,7 +1738,7 @@ module VM = struct
           (fun () ->
             (* Finally, discard any device caching for the domid destroyed *)
             DeviceCache.discard device_cache di.Xenctrl.domid ;
-            Device.(Qemu.SignalMask.unset Qemu.signal_mask di.Xenctrl.domid)
+            Service.Qemu.(SignalMask.unset signal_mask di.Xenctrl.domid)
           )
     )
 
@@ -2255,7 +2255,7 @@ module VM = struct
       match vm.Vm.ty with
       | Vm.PV {vncterm= true; vncterm_ip= ip; _}
       | Vm.PVinPVH {vncterm= true; vncterm_ip= ip; _} ->
-          Device.PV_Vnc.start ~xs ?ip di.Xenctrl.domid
+          Service.PV_Vnc.start ~xs ?ip di.Xenctrl.domid
       | _ ->
           ()
     with Device.Ioemu_failed (name, msg) ->
@@ -2737,9 +2737,9 @@ module VM = struct
             let vnc =
               Option.map
                 (function
-                  | Device.Socket.Port port ->
+                  | Xenops_utils.Socket.Port port ->
                       {Vm.protocol= Vm.Rfb; port; path= ""}
-                  | Device.Socket.Unix path ->
+                  | Xenops_utils.Socket.Unix path ->
                       {Vm.protocol= Vm.Rfb; port= 0; path}
                   )
                 (Device.get_vnc_port ~xs ~dm:(dm_of ~vm) di.Xenctrl.domid)
@@ -3448,9 +3448,9 @@ module VGPU = struct
         let emulator_pid =
           match vgpu.implementation with
           | Empty | MxGPU _ | GVT_g _ ->
-              Device.Qemu.pid ~xs frontend_domid
+              Service.Qemu.pid ~xs frontend_domid
           | Nvidia _ ->
-              Device.Vgpu.pid ~xs frontend_domid
+              Service.Vgpu.pid ~xs frontend_domid
         in
         match emulator_pid with
         | Some _ ->
@@ -3469,7 +3469,7 @@ module VUSB = struct
   let get_state vm vusb =
     on_frontend
       (fun _ xs frontend_domid _ ->
-        let emulator_pid = Device.Qemu.pid ~xs frontend_domid in
+        let emulator_pid = Service.Qemu.pid ~xs frontend_domid in
         debug "Qom list to get vusb state" ;
         let peripherals = Device.Vusb.qom_list ~xs ~domid:frontend_domid in
         let found = List.mem (snd vusb.Vusb.id) peripherals in
@@ -4883,7 +4883,7 @@ module Actions = struct
     ; sprintf "/local/domain/%d/memory/uncooperative" domid
     ; sprintf "/local/domain/%d/console/vnc-port" domid
     ; sprintf "/local/domain/%d/console/tc-port" domid
-    ; Device.Qemu.pid_path_signal domid
+    ; Service.Qemu.pid_path_signal domid
     ; sprintf "/local/domain/%d/control" domid
     ; sprintf "/local/domain/%d/device" domid
     ; sprintf "/local/domain/%d/rrd" domid
@@ -5060,7 +5060,8 @@ module Actions = struct
         debug "Ignoring qemu-pid-signal watch on shutdown domain %d" d
       else
         let signal =
-          try Some (xs.Xs.read (Device.Qemu.pid_path_signal d)) with _ -> None
+          try Some (xs.Xs.read (Service.Qemu.pid_path_signal d))
+          with _ -> None
         in
         match signal with
         | None ->

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -4883,7 +4883,7 @@ module Actions = struct
     ; sprintf "/local/domain/%d/memory/uncooperative" domid
     ; sprintf "/local/domain/%d/console/vnc-port" domid
     ; sprintf "/local/domain/%d/console/tc-port" domid
-    ; Service.Qemu.pid_path_signal domid
+    ; Service.Qemu.pidxenstore_path_signal domid
     ; sprintf "/local/domain/%d/control" domid
     ; sprintf "/local/domain/%d/device" domid
     ; sprintf "/local/domain/%d/rrd" domid
@@ -5060,7 +5060,7 @@ module Actions = struct
         debug "Ignoring qemu-pid-signal watch on shutdown domain %d" d
       else
         let signal =
-          try Some (xs.Xs.read (Service.Qemu.pid_path_signal d))
+          try Some (xs.Xs.read (Service.Qemu.pidxenstore_path_signal d))
           with _ -> None
         in
         match signal with


### PR DESCRIPTION
This mirrors the changes in https://github.com/xapi-project/xen-api/pull/4720 except the code that is used exclusively by the swtpm daemon, mainly the code introduced by this commit and successive modifications: [`500bbab` (#4720)](https://github.com/xapi-project/xen-api/pull/4720/commits/500bbab1e5e0bac85cf9ac73972cabb1ef8e2bf1), which I cherry picked, the modified to remove the Swtpm module and functions it depends on (because they would have been unused)

It's pretty to notice the differences between this and the swtpm branch are the removal of functions needed by the swtpm daemon; and the removal of File  in the variant `Pid.path`, which would be unused, and consequent change in behaviour in the uses of this variant.

I used `git diff feature/vtpm..private/paus/pidpaths -- ocaml/xenopsd/xc/service.ml`

For device.ml there are more differences, all the ones I found were cause because of the addition of the vtpm parameter and swtpm management as well.

Ring3 BST + BVT SR: 170941 ✅