### PR TITLE
Allow VBD.plug to dom0 again

### DIFF
--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -144,34 +144,20 @@ let make_vm ~__context ?(name_label = "name_label")
     ?(hardware_platform_version = 0L) ?has_vendor_device:_
     ?(has_vendor_device = false) ?(reference_label = "") ?(domain_type = `hvm)
     ?(nVRAM = []) ?(last_booted_record = "") ?(last_boot_CPU_flags = [])
-    ?(power_state = `Halted) ?resident_on () =
-  let vm =
-    Xapi_vm.create ~__context ~name_label ~name_description ~user_version
-      ~is_a_template ~affinity ~memory_target ~memory_static_max
-      ~memory_dynamic_max ~memory_dynamic_min ~memory_static_min ~vCPUs_params
-      ~vCPUs_max ~vCPUs_at_startup ~actions_after_shutdown ~actions_after_reboot
-      ~actions_after_crash ~pV_bootloader ~pV_kernel ~pV_ramdisk ~pV_args
-      ~pV_bootloader_args ~pV_legacy_args ~hVM_boot_policy ~hVM_boot_params
-      ~hVM_shadow_multiplier ~platform ~nVRAM ~pCI_bus ~other_config
-      ~xenstore_data ~recommendations ~ha_always_run ~ha_restart_priority ~tags
-      ~blocked_operations ~protection_policy ~is_snapshot_from_vmpp ~appliance
-      ~start_delay ~shutdown_delay ~order ~suspend_SR ~suspend_VDI
-      ~snapshot_schedule ~is_vmss_snapshot ~version ~generation_id
-      ~hardware_platform_version ~has_vendor_device ~reference_label
-      ~domain_type ~last_booted_record ~last_boot_CPU_flags ~power_state
-  in
-  match power_state with
-  | `Running | `Paused ->
-      Db.VM.set_power_state ~__context ~self:vm ~value:power_state ;
-      Option.iter
-        (fun host -> Db.VM.set_resident_on ~__context ~self:vm ~value:host)
-        resident_on ;
-      let vmm = Db.VM.get_metrics ~__context ~self:vm in
-      Db.VM_metrics.set_current_domain_type ~__context ~self:vmm
-        ~value:domain_type ;
-      vm
-  | _ ->
-      vm
+    ?(power_state = `Halted) () =
+  Xapi_vm.create ~__context ~name_label ~name_description ~user_version
+    ~is_a_template ~affinity ~memory_target ~memory_static_max
+    ~memory_dynamic_max ~memory_dynamic_min ~memory_static_min ~vCPUs_params
+    ~vCPUs_max ~vCPUs_at_startup ~actions_after_shutdown ~actions_after_reboot
+    ~actions_after_crash ~pV_bootloader ~pV_kernel ~pV_ramdisk ~pV_args
+    ~pV_bootloader_args ~pV_legacy_args ~hVM_boot_policy ~hVM_boot_params
+    ~hVM_shadow_multiplier ~platform ~nVRAM ~pCI_bus ~other_config
+    ~xenstore_data ~recommendations ~ha_always_run ~ha_restart_priority ~tags
+    ~blocked_operations ~protection_policy ~is_snapshot_from_vmpp ~appliance
+    ~start_delay ~shutdown_delay ~order ~suspend_SR ~suspend_VDI
+    ~snapshot_schedule ~is_vmss_snapshot ~version ~generation_id
+    ~hardware_platform_version ~has_vendor_device ~reference_label ~domain_type
+    ~last_booted_record ~last_boot_CPU_flags ~power_state
 
 let make_host ~__context ?(uuid = make_uuid ()) ?(name_label = "host")
     ?(name_description = "description") ?(hostname = "localhost")

--- a/ocaml/tests/test_vdi_allowed_operations.ml
+++ b/ocaml/tests/test_vdi_allowed_operations.ml
@@ -135,10 +135,7 @@ let test_ca125187 () =
     setup_test ~__context
       ~vdi_fun:(fun vdi_ref ->
         let host_ref = Helpers.get_localhost ~__context in
-        let vm_ref =
-          Test_common.make_vm ~__context ~domain_type:`pv ~power_state:`Running
-            ~resident_on:host_ref ()
-        in
+        let vm_ref = Db.Host.get_control_domain ~__context ~self:host_ref in
         let vbd_ref = Ref.make () in
         let (_ : API.ref_VBD) =
           make_vbd ~__context ~ref:vbd_ref ~vDI:vdi_ref ~vM:vm_ref

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -95,11 +95,6 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
     set_errors Api_errors.other_operation_in_progress
       ["VBD"; _ref; vbd_operation_to_string (List.hd current_ops)]
       [`unpause] ;
-  (* No hotplug on dom0 *)
-  if Helpers.is_domain_zero ~__context vm then
-    set_errors Api_errors.operation_not_allowed
-      ["Control domain does not support hotplug"]
-      [`plug] ;
   (* Drives marked as not unpluggable cannot be unplugged *)
   if not record.Db_actions.vBD_unpluggable then
     set_errors Api_errors.vbd_not_unpluggable [_ref] [`unplug; `unplug_force] ;


### PR DESCRIPTION
Partially revert eb6eca2. VIF.plug to dom0 was needed, but VBD.plug must
be allowed, and does work.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>