### PR TITLE
Factor out Throttle module

### DIFF
--- a/ocaml/xapi-aux/throttle.ml
+++ b/ocaml/xapi-aux/throttle.ml
@@ -1,0 +1,39 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module type SIZE = sig
+  val n : int
+end
+
+module Make (Size : SIZE) = struct
+  module Semaphore = Xapi_stdext_threads.Semaphore
+
+  let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
+  let semaphore = ref None
+
+  let m = Mutex.create ()
+
+  let get_semaphore () =
+    with_lock m @@ fun () ->
+    match !semaphore with
+    | None ->
+        let result = Semaphore.create Size.n in
+        semaphore := Some result ;
+        result
+    | Some s ->
+        s
+
+  let execute f = Semaphore.execute (get_semaphore ()) f
+end

--- a/ocaml/xapi-aux/throttle.ml
+++ b/ocaml/xapi-aux/throttle.ml
@@ -13,7 +13,7 @@
  *)
 
 module type SIZE = sig
-  val n : int
+  val n : unit -> int
 end
 
 module Make (Size : SIZE) = struct
@@ -29,7 +29,7 @@ module Make (Size : SIZE) = struct
     with_lock m @@ fun () ->
     match !semaphore with
     | None ->
-        let result = Semaphore.create Size.n in
+        let result = Semaphore.create (Size.n ()) in
         semaphore := Some result ;
         result
     | Some s ->

--- a/ocaml/xapi-aux/throttle.mli
+++ b/ocaml/xapi-aux/throttle.mli
@@ -1,0 +1,23 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module type SIZE = sig
+  val n : int
+end
+
+module Make (Size : SIZE) : sig
+  (** [execute f] up to [Size.n] in parallel. *)
+
+  val execute : (unit -> 'a) -> 'a
+end

--- a/ocaml/xapi-aux/throttle.mli
+++ b/ocaml/xapi-aux/throttle.mli
@@ -13,11 +13,12 @@
  *)
 
 module type SIZE = sig
-  val n : int
+  val n : unit -> int
+  (** evaluated on first [execute] *)
 end
 
 module Make (Size : SIZE) : sig
-  (** [execute f] up to [Size.n] in parallel. *)
+  (** [execute f] up to [Size.n ()] in parallel. *)
 
   val execute : (unit -> 'a) -> 'a
 end

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -61,7 +61,7 @@ let scan_finished sr =
       Condition.broadcast scans_in_progress_c
   )
 
-module Size = struct let n = !Xapi_globs.max_active_sr_scans end
+module Size = struct let n () = !Xapi_globs.max_active_sr_scans end
 
 module AutoScanThrottle = Throttle.Make (Size)
 module SRScanThrottle = Throttle.Make (Size)

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -61,30 +61,10 @@ let scan_finished sr =
       Condition.broadcast scans_in_progress_c
   )
 
-module Throttle () = struct
-  let semaphore = ref None
+module Size = struct let n = !Xapi_globs.max_active_sr_scans end
 
-  let m = Mutex.create ()
-
-  let get_semaphore () =
-    with_lock m (fun () ->
-        (* overridable on startup from config file, have
-         * to delay initialization *)
-        match !semaphore with
-        | None ->
-            let result = Semaphore.create !Xapi_globs.max_active_sr_scans in
-            semaphore := Some result ;
-            result
-        | Some s ->
-            s
-    )
-
-  let execute f = Semaphore.execute (get_semaphore ()) f
-end
-
-module AutoScanThrottle = Throttle ()
-
-module SRScanThrottle = Throttle ()
+module AutoScanThrottle = Throttle.Make (Size)
+module SRScanThrottle = Throttle.Make (Size)
 
 (* Perform a single scan of an SR in a background thread. Limit to one thread per SR *)
 (* If a callback is supplied, call it once the scan is complete. *)


### PR DESCRIPTION
We use the Throttle module to execute a function multiple times in
parallel up to a configured number. This generalises the existing module
and makes it accessible in other contexts.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>