### PR TITLE
Update datamodel_lifecycle.ml only when changed

### DIFF
--- a/update-dm-lifecycle
+++ b/update-dm-lifecycle
@@ -1,4 +1,12 @@
 #!/bin/sh
 
-XAPI_VERSION=${XAPI_VERSION:-0.0.0} dune exec --profile=${PROFILE:-release} ocaml/idl/gen_lifecycle.exe -- $* > datamodel_lifecycle.ml
-[ -s datamodel_lifecycle.ml ] && mv datamodel_lifecycle.ml ocaml/idl/datamodel_lifecycle.ml
+PREFIX=ocaml/idl
+ML=datamodel_lifecycle.ml
+
+export XAPI_VERSION=${XAPI_VERSION:-0.0.0}
+dune exec --profile=${PROFILE:-release} $PREFIX/gen_lifecycle.exe -- $* > "$ML"
+if /usr/bin/cmp "$ML" "$PREFIX/$ML"; then
+  echo "$ML is unchanged"
+else
+  test -s "$ML" && mv "$ML" "$PREFIX/$ML" && echo "$ML updated"
+fi


### PR DESCRIPTION
To avoid recompiliation when nothing changed, check for atual changes in
the the update-dm-lifecycle script.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>