### PR TITLE
VTPM: rework datamodel, fix nits needed by clients / detected by QA

### DIFF
--- a/ocaml/database/database_test.ml
+++ b/ocaml/database/database_test.ml
@@ -84,6 +84,15 @@ functor
       ->
         ()
 
+    let expect_missing_default name f =
+      try f ()
+      with
+      | Db_exn.DBCache_NotFound
+          ("missing default value in datamodel for new field", name', _)
+      when name' = name
+      ->
+        ()
+
     let expect_missing_field name f =
       try f ()
       with
@@ -515,7 +524,7 @@ functor
       ) ;
       Printf.printf
         "create_row <unique ref> <unique uuid> <missing required field>\n" ;
-      expect_missing_field name_label (fun () ->
+      expect_missing_default name_label (fun () ->
           let broken_vm =
             List.filter
               (fun (k, _) -> k <> name_label)

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -171,7 +171,12 @@ module Row = struct
               add g c.Schema.Column.name default t
           | None ->
               raise
-                (DBCache_NotFound ("missing field", c.Schema.Column.name, ""))
+                (DBCache_NotFound
+                   ( "missing default value in datamodel for new field"
+                   , c.Schema.Column.name
+                   , ""
+                   )
+                )
         else
           t
       )

--- a/ocaml/database/db_upgrade.ml
+++ b/ocaml/database/db_upgrade.ml
@@ -12,9 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module D = Debug.Make (struct
-  let name = "xapi" (* this is set to 'xapi' deliberately! :) *)
-end)
+module D = Debug.Make (struct let name = __MODULE__ end)
 
 open D
 open Db_cache_types

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -9,7 +9,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 753
+let schema_minor_vsn = 754
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -9,7 +9,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 754
+let schema_minor_vsn = 755
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2118,11 +2118,6 @@ let t =
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
             "The set of pending guidances after applying updates"
-        ; field ~qualifier:StaticRO ~in_product_since:rel_next
-            ~ty:(Map (String, String))
-            ~default_value:(Some (VMap [])) "default_vtpm_profile"
-            "The security properties that will be used by default when \
-             creating a TPMs attached to the VM / template"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -26,11 +26,15 @@ let create =
         (Published, rel_rio, "")
       ; ( Changed
         , rel_next
-        , "Require only a VM reference to create a VTPM instance"
+        , "Require only a VM reference and uniqueness to create a VTPM instance"
         )
       ]
     ~doc:"Create a new VTPM instance, and return its handle."
-    ~params:[(Ref _vm, "vM", "The VM reference the VTPM will be attached to")]
+    ~params:
+      [
+        (Ref _vm, "vM", "The VM reference the VTPM will be attached to")
+      ; (Bool, "is_unique", "Whether the VTPM must be unique")
+      ]
     ~result:(Ref _vtpm, "The reference of the newly created VTPM")
     ~allowed_roles:_R_VM_ADMIN ()
 
@@ -63,7 +67,7 @@ let t =
       [
         (Published, rel_rio, "Added VTPM stub")
       ; (Extended, rel_next, "Added ability to manipulate contents")
-      ; (Extended, rel_next, "Added VTPM profiles")
+      ; (Extended, rel_next, "Added VTPM unique and protected properties")
       ; (Extended, rel_next, "Added Persistence backed")
       ]
     ~gen_constructor_destructor:false ~name:_vtpm ~descr:"A virtual TPM device"
@@ -80,10 +84,13 @@ let t =
       ; field ~qualifier:DynamicRO ~ty:persistence_backend
           ~default_value:(Some (VEnum "xapi")) ~lifecycle:[]
           "persistence_backend" "The backend where the vTPM is persisted"
-      ; field ~qualifier:DynamicRO
-          ~ty:(Map (String, String))
-          ~lifecycle:[(Published, rel_next, "Added VTPM profiles")]
-          "profile" "The security properties that define how the TPM is handled"
+      ; field ~qualifier:StaticRO ~ty:Bool ~default_value:(Some (VBool false))
+          ~lifecycle:[] "is_unique"
+          "Whether the contents are never copied, satisfying the TPM spec"
+      ; field ~qualifier:DynamicRO ~ty:Bool ~default_value:(Some (VBool false))
+          ~lifecycle:[] "is_protected"
+          "Whether the contents of the VTPM are secured according to the TPM \
+           spec"
       ; field ~qualifier:DynamicRO ~ty:(Ref _secret) ~internal_only:true
           ~lifecycle:[(Published, rel_next, "Added VTPM contents")]
           "contents" "The contents of the TPM"

--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -92,8 +92,7 @@ let t =
           "Whether the contents of the VTPM are secured according to the TPM \
            spec"
       ; field ~qualifier:DynamicRO ~ty:(Ref _secret) ~internal_only:true
-          ~lifecycle:[(Published, rel_next, "Added VTPM contents")]
-          "contents" "The contents of the TPM"
+          ~lifecycle:[] "contents" "The contents of the TPM"
       ]
     ~messages:[create; destroy; get_contents; set_contents]
     ()

--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -16,6 +16,27 @@ open Datamodel_types
 open Datamodel_common
 open Datamodel_roles
 
+let create =
+  call ~name:"create"
+    ~lifecycle:
+      [
+        (Published, rel_rio, "")
+      ; ( Changed
+        , rel_next
+        , "Require only a VM reference to create a VTPM instance"
+        )
+      ]
+    ~doc:"Create a new VTPM instance, and return its handle."
+    ~params:[(Ref _vm, "vM", "The VM reference the VTPM will be attached to")]
+    ~result:(Ref _vtpm, "The reference of the newly created VTPM")
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let destroy =
+  call ~name:"destroy" ~lifecycle:[(Published, rel_rio, "")]
+    ~doc:"Destroy the specified VTPM instance, along with its state."
+    ~params:[(Ref _vtpm, "self", "The reference to the VTPM object")]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
 let get_contents =
   call ~name:"get_contents" ~in_product_since:"rel_next"
     ~doc:"Obtain the contents of the TPM" ~secret:true
@@ -42,7 +63,7 @@ let t =
       ; (Extended, rel_next, "Added VTPM profiles")
       ; (Changed, rel_next, "Removed backend field")
       ]
-    ~gen_constructor_destructor:true ~name:_vtpm ~descr:"A virtual TPM device"
+    ~gen_constructor_destructor:false ~name:_vtpm ~descr:"A virtual TPM device"
     ~gen_events:false ~doccomments:[]
     ~messages_default_allowed_roles:_R_POOL_ADMIN
     ~contents:
@@ -58,5 +79,5 @@ let t =
           ~lifecycle:[(Published, rel_next, "Added VTPM contents")]
           "contents" "The contents of the TPM"
       ]
-    ~messages:[get_contents; set_contents]
+    ~messages:[create; destroy; get_contents; set_contents]
     ()

--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -16,6 +16,9 @@ open Datamodel_types
 open Datamodel_common
 open Datamodel_roles
 
+let persistence_backend =
+  Enum ("persistence_backend", [("xapi", "This VTPM is persisted in XAPI's DB")])
+
 let create =
   call ~name:"create"
     ~lifecycle:
@@ -61,7 +64,7 @@ let t =
         (Published, rel_rio, "Added VTPM stub")
       ; (Extended, rel_next, "Added ability to manipulate contents")
       ; (Extended, rel_next, "Added VTPM profiles")
-      ; (Changed, rel_next, "Removed backend field")
+      ; (Extended, rel_next, "Added Persistence backed")
       ]
     ~gen_constructor_destructor:false ~name:_vtpm ~descr:"A virtual TPM device"
     ~gen_events:false ~doccomments:[]
@@ -71,6 +74,12 @@ let t =
         uid _vtpm
       ; field ~qualifier:StaticRO ~ty:(Ref _vm) "VM"
           "The virtual machine the TPM is attached to"
+      ; field ~qualifier:DynamicRO ~ty:(Ref _vm) "backend"
+          ~default_value:(Some (VRef null_ref))
+          "The domain where the backend is located (unused)"
+      ; field ~qualifier:DynamicRO ~ty:persistence_backend
+          ~default_value:(Some (VEnum "xapi")) ~lifecycle:[]
+          "persistence_backend" "The backend where the vTPM is persisted"
       ; field ~qualifier:DynamicRO
           ~ty:(Map (String, String))
           ~lifecycle:[(Published, rel_next, "Added VTPM profiles")]

--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -29,13 +29,13 @@ let create =
     ~doc:"Create a new VTPM instance, and return its handle."
     ~params:[(Ref _vm, "vM", "The VM reference the VTPM will be attached to")]
     ~result:(Ref _vtpm, "The reference of the newly created VTPM")
-    ~allowed_roles:_R_POOL_ADMIN ()
+    ~allowed_roles:_R_VM_ADMIN ()
 
 let destroy =
   call ~name:"destroy" ~lifecycle:[(Published, rel_rio, "")]
     ~doc:"Destroy the specified VTPM instance, along with its state."
     ~params:[(Ref _vtpm, "self", "The reference to the VTPM object")]
-    ~allowed_roles:_R_POOL_ADMIN ()
+    ~allowed_roles:_R_VM_ADMIN ()
 
 let get_contents =
   call ~name:"get_contents" ~in_product_since:"rel_next"

--- a/ocaml/idl/datamodel_vtpm.ml
+++ b/ocaml/idl/datamodel_vtpm.ml
@@ -67,7 +67,7 @@ let t =
       ; (Extended, rel_next, "Added Persistence backed")
       ]
     ~gen_constructor_destructor:false ~name:_vtpm ~descr:"A virtual TPM device"
-    ~gen_events:false ~doccomments:[]
+    ~gen_events:true ~doccomments:[]
     ~messages_default_allowed_roles:_R_POOL_ADMIN
     ~contents:
       [

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "611368f97e9312aaf62e8918c0936142"
+let last_known_schema_hash = "7959564ea47f1bad8ab6935ccbaa1f6c"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "eefd4e2daeb4acdb9945a3a3689cab1a"
+let last_known_schema_hash = "31528dd0d66fa1dc6cbea5a25c44e79c"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "31528dd0d66fa1dc6cbea5a25c44e79c"
+let last_known_schema_hash = "611368f97e9312aaf62e8918c0936142"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -144,7 +144,7 @@ let make_vm ~__context ?(name_label = "name_label")
     ?(hardware_platform_version = 0L) ?has_vendor_device:_
     ?(has_vendor_device = false) ?(reference_label = "") ?(domain_type = `hvm)
     ?(nVRAM = []) ?(last_booted_record = "") ?(last_boot_CPU_flags = [])
-    ?(power_state = `Halted) ?(default_vtpm_profile = []) () =
+    ?(power_state = `Halted) () =
   Xapi_vm.create ~__context ~name_label ~name_description ~user_version
     ~is_a_template ~affinity ~memory_target ~memory_static_max
     ~memory_dynamic_max ~memory_dynamic_min ~memory_static_min ~vCPUs_params
@@ -157,7 +157,7 @@ let make_vm ~__context ?(name_label = "name_label")
     ~start_delay ~shutdown_delay ~order ~suspend_SR ~suspend_VDI
     ~snapshot_schedule ~is_vmss_snapshot ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~reference_label ~domain_type
-    ~last_booted_record ~last_boot_CPU_flags ~default_vtpm_profile ~power_state
+    ~last_booted_record ~last_boot_CPU_flags ~power_state
 
 let make_host ~__context ?(uuid = make_uuid ()) ?(name_label = "host")
     ?(name_description = "description") ?(hostname = "localhost")

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -2744,7 +2744,7 @@ let vm_create printer rpc session_id params =
       ~suspend_VDI:Ref.null ~version:0L ~generation_id:""
       ~hardware_platform_version:0L ~has_vendor_device:false ~reference_label:""
       ~domain_type:`unspecified ~nVRAM:[] ~last_booted_record:""
-      ~last_boot_CPU_flags:[] ~default_vtpm_profile:[] ~power_state:`Halted
+      ~last_boot_CPU_flags:[] ~power_state:`Halted
   in
   let uuid = Client.VM.get_uuid ~rpc ~session_id ~self:vm in
   printer (Cli_printer.PList [uuid])
@@ -7845,7 +7845,14 @@ module VTPM = struct
   let create printer rpc session_id params =
     let vm_uuid = List.assoc "vm-uuid" params in
     let vM = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
-    let ref = Client.VTPM.create ~rpc ~session_id ~vM in
+    let is_unique =
+      match List.assoc_opt "is_unique" params with
+      | Some value ->
+          bool_of_string "is_unique" value
+      | None ->
+          false
+    in
+    let ref = Client.VTPM.create ~rpc ~session_id ~vM ~is_unique in
     let uuid = Client.VTPM.get_uuid ~rpc ~session_id ~self:ref in
     printer (Cli_printer.PList [uuid])
 

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2522,11 +2522,6 @@ let vm_record rpc session_id vm =
       ; make_field ~name:"vtpm"
           ~get:(fun () -> get_uuids_from_refs (x ()).API.vM_VTPMs)
           ()
-      ; make_field ~name:"default_vtpm_profile"
-          ~get:(fun () ->
-            Record_util.s2sm_to_string "; " (x ()).API.vM_default_vtpm_profile
-          )
-          ()
       ]
   }
 
@@ -5181,10 +5176,11 @@ let vtpm_record rpc session_id vtpm =
       ; make_field ~name:"vm"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vTPM_VM)
           ()
-      ; make_field ~name:"profile"
-          ~get:(fun () ->
-            Record_util.s2sm_to_string "; " (x ()).API.vTPM_profile
-          )
+      ; make_field ~name:"unique"
+          ~get:(fun () -> string_of_bool (x ()).API.vTPM_is_unique)
+          ()
+      ; make_field ~name:"protected"
+          ~get:(fun () -> string_of_bool (x ()).API.vTPM_is_protected)
           ()
       ]
   }

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -320,7 +320,7 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info : host_info
     ~version:0L ~generation_id:"" ~hardware_platform_version:0L
     ~has_vendor_device:false ~requires_reboot:false ~reference_label:""
     ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[]
-    ~pending_guidances:[] ~default_vtpm_profile:[] ;
+    ~pending_guidances:[] ;
   ensure_domain_zero_metrics_record ~__context ~domain_zero_ref host_info ;
   Db.Host.set_control_domain ~__context ~self:localhost ~value:domain_zero_ref ;
   Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -594,7 +594,7 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~is_snapshot_from_vmpp:_ ~snapshot_schedule:_ ~is_vmss_snapshot:_ ~appliance
     ~start_delay ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~reference_label ~domain_type
-    ~nVRAM ~default_vtpm_profile : API.ref_VM =
+    ~nVRAM : API.ref_VM =
   if has_vendor_device then
     Pool_features.assert_enabled ~__context
       ~f:Features.PCI_device_for_auto_update ;
@@ -674,7 +674,7 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~snapshot_schedule:Ref.null ~is_vmss_snapshot:false ~appliance ~start_delay
     ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~requires_reboot:false
-    ~reference_label ~domain_type ~pending_guidances:[] ~default_vtpm_profile ;
+    ~reference_label ~domain_type ~pending_guidances:[] ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -203,7 +203,6 @@ val create :
   -> reference_label:string
   -> domain_type:API.domain_type
   -> nVRAM:(string * string) list
-  -> default_vtpm_profile:(string * string) list
   -> API.ref_VM
 
 val destroy : __context:Context.t -> self:[`VM] Ref.t -> unit

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -395,8 +395,7 @@ let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~has_vendor_device:all.Db_actions.vM_has_vendor_device
     ~requires_reboot:false ~reference_label:all.Db_actions.vM_reference_label
     ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM
-    ~pending_guidances:[]
-    ~default_vtpm_profile:all.Db_actions.vM_default_vtpm_profile ;
+    ~pending_guidances:[] ;
   (* update the VM's parent field in case of snapshot. Note this must be done after "ref"
      	   has been created, so that its "children" field can be updated by the database layer *)
   ( match disk_op with

--- a/ocaml/xapi/xapi_vtpm.mli
+++ b/ocaml/xapi/xapi_vtpm.mli
@@ -12,7 +12,8 @@
    GNU Lesser General Public License for more details.
  *)
 
-val create : __context:Context.t -> vM:[`VM] API.Ref.t -> [`VTPM] Ref.t
+val create :
+  __context:Context.t -> vM:[`VM] API.Ref.t -> is_unique:bool -> [`VTPM] Ref.t
 
 val destroy : __context:Context.t -> self:[`VTPM] Ref.t -> unit
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -405,7 +405,7 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough vgpu =
                 ~value:"" ~other_config ;
               let vtpm_uuid = uuid () in
               Db.VTPM.create ~__context ~ref:(ref ()) ~uuid:vtpm_uuid ~vM:vmref
-                ~profile ~contents ;
+                ~profile ~backend:Ref.null ~persistence_backend:`xapi ~contents ;
               Some vtpm_uuid
             ) else
               None


### PR DESCRIPTION
Replace the profile with single fields, which as of now cannot be changed. Unique can be made configured later on.

This means deleting the default_vtpm_profile from the VM objects. The way the design is going it looks like "empty" or otherwise vtpms associated will replace this parameter, which contain this information and more.

vtpm.create's role has been changed and it's now similat to other classes like vgpu so it uses individual fields as parameters instead of whole records. This is because VTPM records cannot be easily created by clients. (for comparison VM _does_ have a create method, but it has big warnings against using it and the default way to create VMs is by cloning templates, both in Xencenter and Xen Orchestra)

VTPM.backend has been reintroduced for internal purposes only

The contents of the VTPM are now only encoded once for serialization purposes. There's still a second encoding, but it's used for verification purposes and the result is discarded.

New builds are in progress