### PR TITLE
CP-40155 Parallelize Host.evacuate

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -926,6 +926,8 @@ let repository_gpgcheck = ref true
 
 let migration_compression = ref false
 
+let evacuation_batch_size = ref 10
+
 type xapi_globs_spec_ty = Float of float ref | Int of int ref
 
 let extauth_ad_backend = ref "winbind"
@@ -1354,6 +1356,11 @@ let other_options =
     , Arg.Set migration_compression
     , (fun () -> string_of_bool !migration_compression)
     , "Use compression during VM migration when no API option provided."
+    )
+  ; ( "evacuation-batch-size"
+    , Arg.Set_int evacuation_batch_size
+    , (fun () -> string_of_int !evacuation_batch_size)
+    , "The number of VMs evacauted from a host in parallel."
     )
   ]
 

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -375,6 +375,9 @@ sm-plugins=ext nfs iscsi lvmoiscsi dummy file hba rawhba udev iso lvm lvmohba lv
 # migration-compression = true
 # if not requested otherwise, use stream compression during migration of a VM
 
+# evacuation-batch-size = 10
+# number of VMs migrated in parallel in Host.evacuate
+
 # The file to check if host reboot required
 reboot_required_hfxs = /run/reboot-required.hfxs
 


### PR DESCRIPTION
Host.evacuate migrates all VMs from a host to another in preparation of
a host update. This is currently done sequentially, one VM after
another. We want to migrate VMs in parallel to reduce total elapsed
time.

Because a host can host hundreds of VMs, we want to limit
parallelization such that at most n migrations are active at the same
time. We implement this using batching: a fixed number of VMs is
migrated off in parallel before the next batch is started. This is
controlled by a new parameter evacuation-batch-size in xapi.conf.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>

I suspect that this is leaking tasks but I don't understand why this is happening
and would like to ask reviewers to have an eye towards that. Otherwise the
code works well in the tests that I have run where I continuously evacuate hosts in a pool.