### PR TITLE
CA-368912 CP-38583 set Host.last_software_update on upgrade

### DIFF
--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -868,6 +868,18 @@ let remove_legacy_ssl_support =
       )
   }
 
+let upgrade_last_updated_field =
+  {
+    description= "update Host.last_software_update field"
+  ; version= (fun _ -> true)
+  ; fn=
+      (fun ~__context ->
+        let host = Helpers.get_localhost ~__context in
+        Db.Host.set_last_software_update ~__context ~self:host
+          ~value:(Xapi_host.get_servertime ~__context ~host)
+      )
+  }
+
 let rules =
   [
     upgrade_domain_type
@@ -896,6 +908,7 @@ let rules =
   ; upgrade_cluster_timeouts
   ; upgrade_secrets
   ; remove_legacy_ssl_support
+  ; upgrade_last_updated_field
   ]
 
 (* Maybe upgrade most recent db *)

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -871,7 +871,7 @@ let remove_legacy_ssl_support =
 let upgrade_last_updated_field =
   {
     description= "update Host.last_software_update field"
-  ; version= (fun _ -> true)
+  ; version= (fun version -> version <= yangtze)
   ; fn=
       (fun ~__context ->
         let host = Helpers.get_localhost ~__context in


### PR DESCRIPTION
Host.last_software_update is a new field in the host record that
reflects the last time a host was updated. This field has a default of
Date.never, which is misleading after an upgarde. Use the DB upgrade
mechanism to set it to the current date.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>