### PR TITLE
CA-367236 replace Ezjsonm with Yojson

### DIFF
--- a/ocaml/xcp-rrdd/lib/transport/base/dune
+++ b/ocaml/xcp-rrdd/lib/transport/base/dune
@@ -10,7 +10,7 @@
     xapi-rrd
     threads
     xapi-idl.rrd
-    ezjsonm
+    yojson
   )
 )
 

--- a/ocaml/xcp-rrdd/lib/transport/base/rrd_json.ml
+++ b/ocaml/xcp-rrdd/lib/transport/base/rrd_json.ml
@@ -48,7 +48,7 @@ let bool b = string "%b" b (* Should use `Bool b *)
 
 let float x = string "%.2f" x
 
-let record xs = `O xs
+let record xs = `Assoc xs
 
 let description = function
   | "" ->
@@ -82,22 +82,18 @@ let dss_to_json ~header timestamp dss =
       ; ("datasources", record @@ List.map ds_to_json dss)
       ]
   in
-  let buf = Buffer.create 2048 in
   let out = Buffer.create 2048 in
-  let () = Ezjsonm.to_buffer buf payload in
-  let json = Buffer.contents buf in
+  let json = Yojson.to_string payload in
   let digest = Digest.string json |> Digest.to_hex in
   Buffer.add_string out
-  @@ Printf.sprintf "%s%08x\n%s\n" header (Buffer.length buf) digest ;
+  @@ Printf.sprintf "%s%08x\n%s\n" header (String.length json) digest ;
   Buffer.add_string out json ;
   Buffer.add_char out '\n' ;
   Buffer.contents out
 
 let metadata_to_json (dss : (Rrd.ds_owner * Ds.ds) list) =
   let json = record [("datasources", record @@ List.map ds_to_json dss)] in
-  let buf = Buffer.create 2048 in
-  let () = Ezjsonm.to_buffer buf json in
-  Buffer.contents buf
+  Yojson.to_string json
 
 let json_of_dss = dss_to_json
 

--- a/ocaml/xcp-rrdd/lib/transport/base/rrd_protocol_v1.ml
+++ b/ocaml/xcp-rrdd/lib/transport/base/rrd_protocol_v1.ml
@@ -94,7 +94,9 @@ let parse_payload ~(json : string) : payload =
   try
     let rpc = Jsonrpc.of_string json in
     let kvs = Rrd_rpc.dict_of_rpc ~rpc in
-    let timestamp = Rpc.int64_of_rpc (List.assoc "timestamp" kvs) in
+    let timestamp =
+      Rpc.float_of_rpc (List.assoc "timestamp" kvs) |> Int64.of_float
+    in
     let datasource_rpcs =
       Rrd_rpc.dict_of_rpc ~rpc:(List.assoc "datasources" kvs)
     in

--- a/rrd-transport.opam
+++ b/rrd-transport.opam
@@ -14,7 +14,7 @@ depends: [
   "cstruct"
   "crc"
   "astring"
-  "ezjsonm"
+  "yojson"
   "xapi-idl" {>= "1.0.0"}
   "xapi-rrd" {>= "1.0.0"}
   "xen-gnt" {>= "3.0.0"}


### PR DESCRIPTION
We would like to use just one library for creating and consuming JSON;
so replace Ezjsonm with Yojson.

The serialisation of timestamps in the V1 transport appears to change:
they are now serialised as floats; to avoid errors in the parse, we need
to change the reader for the V1 transport.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>