### PR TITLE
Simplify and fix UDSTransport implementation

### DIFF
--- a/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
@@ -75,28 +75,13 @@ class UDSHTTPConnection(httplib.HTTPConnection):
     self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     self.sock.connect(path)
 
-class UDSHTTP(httplib.HTTP):
-  _connection_class = UDSHTTPConnection
-
 class UDSTransport(xmlrpclib.Transport):
-  def __init__(self, use_datetime = 0):
-    self._use_datetime = use_datetime
-    self._extra_headers = []
-
+  # FIXME: is this function actually used anywhere?
   def add_extra_header(self, key, value):
     self._extra_headers += [(key, value)]
 
   def make_connection(self, host):
-    # Python 2.4 compatibility
-    if sys.version_info[0] <= 2 and sys.version_info[1] < 6:
-      return UDSHTTP(host)
-    else:
-      return UDSHTTPConnection(host)
-
-  def send_request(self, connection, handler, request_body):
-    connection.putrequest("POST", handler)
-    for key, value in self._extra_headers:
-      connection.putheader(key, value)
+    return UDSHTTPConnection(host)
 
 class Proxy(xmlrpclib.ServerProxy):
   def __init__(self, uri, transport = None, encoding = None, verbose = 0,

--- a/scripts/examples/python/XenAPI/XenAPI.py
+++ b/scripts/examples/python/XenAPI/XenAPI.py
@@ -92,26 +92,11 @@ class UDSHTTPConnection(httplib.HTTPConnection):
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.sock.connect(path)
 
-class UDSHTTP(httplib.HTTPConnection):
-    _connection_class = UDSHTTPConnection
-
 class UDSTransport(xmlrpclib.Transport):
-    def __init__(self, use_datetime=0):
-        self._use_datetime = use_datetime
-        self._extra_headers=[]
-        self._connection = (None, None)
     def add_extra_header(self, key, value):
         self._extra_headers += [ (key,value) ]
     def make_connection(self, host):
-        # Python 2.4 compatibility
-        if sys.version_info[0] <= 2 and sys.version_info[1] < 7:
-            return UDSHTTP(host)
-        else:
-            return UDSHTTPConnection(host)
-    def send_request(self, connection, handler, request_body):
-        connection.putrequest("POST", handler)
-        for key, value in self._extra_headers:
-            connection.putheader(key, value)
+        return UDSHTTPConnection(host)
 
 def notimplemented(name, *args, **kwargs):
     raise NotImplementedError("XMLRPC proxies do not support python magic methods", name, *args, **kwargs)


### PR DESCRIPTION
The current implementation of UDSTransport in XenAPI.py and rrdd.py has
several issues:
- It redefines xmlrpclib.Transport.send_request, whose signature has changed
  in python 3, so this breaks XenAPI.py's python 3 port.
- The overridden implementation of send_request adds extra headers that are
  already handled by the parent class. As a result, extra headers are sent
  twice.
- Method __init__ is overridden needlessly, which could cause issues in
  the future if the parent class evolves.

This commit fixes the issues by simply deleting the send_request and
__init__ methods from the implementation of UDSTransport.

At the same time, code that was written to retain compatibility with python
< 2.7 is removed.

The add_extra_header method is kept in XenAPI.py, as `sm` apparently uses it
to add a `Subtask-of:` header. Symmetrically, I also kept it in rrdd.py,
but I'm not sure it's used anywhere.

Fixes #4767

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>