### PR TITLE
Fix quicktest's -default-sr parameter

### DIFF
--- a/ocaml/quicktest/qt_filter.ml
+++ b/ocaml/quicktest/qt_filter.ml
@@ -172,15 +172,16 @@ module SR = struct
 
   let all_srs = lazy (list_srs_connected_to_localhost !A.rpc !session_id)
 
-  let all =
+  let all () =
     if !A.use_default_sr then
       let pool = Qt.get_pool !A.rpc !session_id in
       only
         (Client.Client.Pool.get_default_SR ~rpc:!A.rpc ~session_id:!session_id
            ~self:pool
         )
+        ()
     else
-      fun () -> Lazy.force all_srs
+      Lazy.force all_srs
 
   let random srs () =
     let srs = srs () in


### PR DESCRIPTION
The value of `use_default_sr` is evaluated before it can be set to true
if the `-default-sr` parameter is provided to the command line.

Move the if test inside a function so that `use_default_sr` is only
evaluated when appropriate.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>