### PR TITLE
CP-39850: Copy VTPM on clone

### DIFF
--- a/ocaml/xapi/xapi_secret.ml
+++ b/ocaml/xapi/xapi_secret.ml
@@ -45,6 +45,13 @@ let clean_out_passwds ~__context strmap =
   let secrets = List.map snd (List.filter check_key strmap) in
   List.iter delete_secret secrets
 
+let copy ~__context ~secret =
+  let uuid = Uuid.(to_string (make ())) in
+  let value = Db.Secret.get_value ~__context ~self:secret in
+  let other_config = Db.Secret.get_other_config ~__context ~self:secret in
+  let ref = introduce ~__context ~uuid ~value ~other_config in
+  ref
+
 (* Modify a ((string * string) list) by duplicating all the passwords found in
  * it *)
 let duplicate_passwds ~__context strmap =

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -1096,15 +1096,15 @@ let clone ~__context ~vdi ~driver_params =
         in
         try
           (* Remove the vdi_clone from the SR's current operations, this prevents the whole
-             	  SR being locked for the duration of the slow copy *)
+             SR being locked for the duration of the slow copy *)
           let task_id = Ref.string_of (Context.get_task_id __context) in
           Db.SR.remove_from_current_operations ~__context
             ~self:a.Db_actions.vDI_SR ~key:task_id ;
           Xapi_sr_operations.update_allowed_operations ~__context
             ~self:a.Db_actions.vDI_SR ;
           (* Remove the clone from the VDI's current operations since the dom0 block-attach
-             	  will protect the VDI anyway. There's no point refreshing the VDI's allowed operations
-             	  because they're going to change when the VBD.plug happens. *)
+             will protect the VDI anyway. There's no point refreshing the VDI's allowed operations
+             because they're going to change when the VBD.plug happens. *)
           Db.VDI.remove_from_current_operations ~__context ~self:vdi
             ~key:task_id ;
           Sm_fs_ops.copy_vdi ~__context vdi newvdi ;
@@ -1125,11 +1125,11 @@ let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
   let src = Db.VDI.get_record ~__context ~self:vdi in
 
   (* If 'into' is a valid VDI then we will write into that.
-     	   Otherwise we'll create a fresh VDI in 'sr'. *)
+     Otherwise we'll create a fresh VDI in 'sr'. *)
 
   (* Note that we should destroy 'dst' on failure IFF we created it
-     	   here. We really ought to have a persistent log of cleanup actions,
-     	   since this will get lost over process restart. *)
+     here. We really ought to have a persistent log of cleanup actions,
+     since this will get lost over process restart. *)
   let vdi_to_cleanup = ref None in
   try
     let dst =
@@ -1137,8 +1137,8 @@ let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
         into_vdi
       else
         (* When creating a new VDI, clone as many properties of the
-           				   original as we can. If we're not cloning a property, please
-           				   explain why in a comment. *)
+           original as we can. If we're not cloning a property, please
+           explain why in a comment. *)
         Helpers.call_api_functions ~__context (fun rpc session_id ->
             let new_vdi =
               Client.VDI.create ~rpc ~session_id

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -419,6 +419,7 @@ let clone ?snapshot_info_record ?(ignore_vdis = []) disk_op ~__context ~vm
       let vbds = Db.VM.get_VBDs ~__context ~self:vm in
       let vifs = Db.VM.get_VIFs ~__context ~self:vm in
       let vgpus = Db.VM.get_VGPUs ~__context ~self:vm in
+      let vtpms = Db.VM.get_VTPMs ~__context ~self:vm in
       let power_state = Db.VM.get_power_state ~__context ~self:vm in
       (* If a VM is snapshotted, then the new VM must remain halted.
          Otherwise, we keep the same power-state as the initial VM *)
@@ -501,6 +502,10 @@ let clone ?snapshot_info_record ?(ignore_vdis = []) disk_op ~__context ~vm
           (* copy VGPUs *)
           let (_ : [`VGPU] Ref.t list) =
             List.map (fun vgpu -> Xapi_vgpu.copy ~__context ~vm:ref vgpu) vgpus
+          in
+          (* copy vTPMs *)
+          let (_ : [`VTPM] Ref.t list) =
+            List.map (fun vtpm -> Xapi_vtpm.copy ~__context ~vM:ref vtpm) vtpms
           in
           (* copy the suspended VDI if needed *)
           let suspend_VDI =

--- a/ocaml/xapi/xapi_vtpm.mli
+++ b/ocaml/xapi/xapi_vtpm.mli
@@ -15,6 +15,9 @@
 val create :
   __context:Context.t -> vM:[`VM] API.Ref.t -> is_unique:bool -> [`VTPM] Ref.t
 
+val copy :
+  __context:Context.t -> vM:[`VM] Ref.t -> [`VTPM] Ref.t -> [`VTPM] Ref.t
+
 val destroy : __context:Context.t -> self:[`VTPM] Ref.t -> unit
 
 val get_contents : __context:Context.t -> self:[`VTPM] Ref.t -> string


### PR DESCRIPTION
On the non-unique mode (default) it copies the VTPM, this allows bitlocker to continue functioning in the clone without re-keying.  On unique mode it creates a new VTPM with the same profile.

This PR is not enough to make snapshots work, this is because it's not easy to notify xapi about the new vtpm contents while the VM is running because xenopsd is not involved. Instead it blocks this operation showing that the functionality is not implemented to avoid loss of data.

I've manually tested the clone with both values of unique and the live snapshot with vtpms associated