### PR TITLE
CA-369599: ignore invalid references on eject

### DIFF
--- a/ocaml/xapi-types/ref.ml
+++ b/ocaml/xapi-types/ref.ml
@@ -77,6 +77,8 @@ let of_string x =
           Other x
     )
 
+let to_option = function Null -> None | ref -> Some ref
+
 let name_of_dummy = function
   | Real x | Other x ->
       failwith

--- a/ocaml/xapi-types/ref.mli
+++ b/ocaml/xapi-types/ref.mli
@@ -22,6 +22,10 @@ val null : 'a t
 
 val string_of : 'a t -> string
 
+val to_option : 'a t -> 'a t option
+(** [to_option ref] returns [None] when [ref] is [Ref.Null] or [Some ref]
+    otherwise *)
+
 val short_string_of : 'a t -> string
 
 val of_string : string -> 'a t

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -772,7 +772,7 @@ let get_my_pbds __context =
 (* Return the PBD for specified SR on a specific host *)
 (* Just say an SR is shared if it has more than one PBD *)
 let is_sr_shared ~__context ~self =
-  List.length (Db.SR.get_PBDs ~__context ~self) > 1
+  match Db.SR.get_PBDs ~__context ~self with [] | [_] -> false | _ -> true
 
 let get_main_ip_address ~__context =
   try Pool_role.get_master_address () with _ -> "127.0.0.1"

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -122,6 +122,9 @@ let choose_network_name_for_pif device =
 (* !! FIXME(2) - this code could be shared with the CLI? *)
 let checknull f = try f () with _ -> "<not in database>"
 
+let ignore_invalid_ref f (x : 'a Ref.t) =
+  try Ref.to_option (f x) with Db_exn.DBCache_NotFound _ -> None
+
 let get_pool ~__context = List.hd (Db.Pool.get_all ~__context)
 
 let get_master ~__context =

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1745,29 +1745,41 @@ let eject_self ~__context ~host =
       )
       my_vms_with_records ;
     (* all control domains resident on me should be destroyed once I leave the
-       		pool, therefore pick them out as follows: if they have a valid resident_on,
-       		the latter should be me; if they don't (e.g. they are halted), they should have
-       		disks on my local storage *)
+       pool, therefore pick them out as follows: if they have a valid
+       resident_on, the latter should be me; if they don't (e.g. they are
+       halted), they should have disks on my local storage *)
     let vm_is_resident_on_host vm_rec host =
       Db.is_valid_ref __context vm_rec.API.vM_resident_on
       && vm_rec.API.vM_resident_on = host
     in
-    let vm_has_disks_on_local_sr_of_host vm_ref host =
-      let is_sr_local x = not (Helpers.is_sr_shared ~__context ~self:x) in
+    let vm_has_disks_on_local_sr_of_host vm_rec host =
+      let is_sr_local x =
+        try not (Helpers.is_sr_shared ~__context ~self:x)
+        with Db_exn.DBCache_NotFound _ -> false
+      in
       let host_has_sr x =
         Helpers.check_sr_exists_for_host ~__context ~self:x ~host <> None
       in
-      Db.VM.get_VBDs ~__context ~self:vm_ref
-      |> List.map (fun x -> Db.VBD.get_VDI ~__context ~self:x)
-      |> List.filter (fun x -> x <> Ref.null)
-      (* filter out null ref VDIs (can happen e.g. for CDs) *)
-      |> List.map (fun x -> Db.VDI.get_SR ~__context ~self:x)
+      let ignore_invalid_ref f x =
+        try
+          let ref = f x in
+          if ref <> Ref.null then
+            Some ref
+          else
+            None
+        with Db_exn.DBCache_NotFound _ -> None
+      in
+      vm_rec.API.vM_VBDs
+      |> List.filter_map
+           (ignore_invalid_ref (fun x -> Db.VBD.get_VDI ~__context ~self:x))
+      |> List.filter_map
+           (ignore_invalid_ref (fun x -> Db.VDI.get_SR ~__context ~self:x))
       |> List.exists (fun x -> is_sr_local x && host_has_sr x)
     in
-    let is_obsolete_control_domain (vm_ref, vm_rec) =
+    let is_obsolete_control_domain (_, vm_rec) =
       vm_rec.API.vM_is_control_domain
       && (vm_is_resident_on_host vm_rec host
-         || vm_has_disks_on_local_sr_of_host vm_ref host
+         || vm_has_disks_on_local_sr_of_host vm_rec host
          )
     in
     let control_domains_to_destroy =

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1753,21 +1753,13 @@ let eject_self ~__context ~host =
       && vm_rec.API.vM_resident_on = host
     in
     let vm_has_disks_on_local_sr_of_host vm_rec host =
+      let open! Helpers in
       let is_sr_local x =
-        try not (Helpers.is_sr_shared ~__context ~self:x)
+        try not (is_sr_shared ~__context ~self:x)
         with Db_exn.DBCache_NotFound _ -> false
       in
       let host_has_sr x =
-        Helpers.check_sr_exists_for_host ~__context ~self:x ~host <> None
-      in
-      let ignore_invalid_ref f x =
-        try
-          let ref = f x in
-          if ref <> Ref.null then
-            Some ref
-          else
-            None
-        with Db_exn.DBCache_NotFound _ -> None
+        check_sr_exists_for_host ~__context ~self:x ~host <> None
       in
       vm_rec.API.vM_VBDs
       |> List.filter_map


### PR DESCRIPTION
While ejecting multiple hosts in parallel some references may become
invalid, ignore them as they are from objects pertaining to ejected
hosts.