### PR TITLE
CP-40284, CP-39874: Gate VTPM creation behind an experimental feature and Prevent VTPMs and HA from coexisting

### DIFF
--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5176,10 +5176,10 @@ let vtpm_record rpc session_id vtpm =
       ; make_field ~name:"vm"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vTPM_VM)
           ()
-      ; make_field ~name:"unique"
+      ; make_field ~name:"is_unique"
           ~get:(fun () -> string_of_bool (x ()).API.vTPM_is_unique)
           ()
-      ; make_field ~name:"protected"
+      ; make_field ~name:"is_protected"
           ~get:(fun () -> string_of_bool (x ()).API.vTPM_is_protected)
           ()
       ]

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -888,6 +888,13 @@ let is_platform_version_same_on_master ~__context ~host =
       (LocalObject host)
     = 0
 
+let assert_ha_vtpms_compatible ~__context =
+  let on_db = {|field "persistence_backend"="xapi"|} in
+  let vtpms_on_db = Db.VTPM.get_all_records_where ~__context ~expr:on_db in
+  if vtpms_on_db <> [] then
+    let message = "VTPM persistence when HA or clustering is enabled" in
+    raise Api_errors.(Server_error (not_implemented, [message]))
+
 let assert_platform_version_is_same_on_master ~__context ~host ~self =
   if not (is_platform_version_same_on_master ~__context ~host) then
     raise

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -34,6 +34,7 @@ let validate_params ~token_timeout ~token_timeout_coefficient =
 let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
     ~token_timeout_coefficient =
   assert_cluster_stack_valid ~cluster_stack ;
+  Helpers.assert_ha_vtpms_compatible ~__context ;
   (* Currently we only support corosync. If we support more cluster stacks, this
    * should be replaced by a general function that checks the given cluster_stack *)
   Pool_features.assert_enabled ~__context ~f:Features.Corosync ;

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2338,12 +2338,13 @@ let create_VLAN_from_PIF ~__context ~pif ~network ~vLAN =
 let enable_disable_m = Mutex.create ()
 
 let enable_ha ~__context ~heartbeat_srs ~configuration =
+  Helpers.assert_ha_vtpms_compatible ~__context ;
   if not (Helpers.pool_has_different_host_platform_versions ~__context) then
     with_lock enable_disable_m (fun () ->
         Xapi_ha.enable __context heartbeat_srs configuration
     )
   else
-    raise (Api_errors.Server_error (Api_errors.not_supported_during_upgrade, []))
+    raise Api_errors.(Server_error (not_supported_during_upgrade, []))
 
 let disable_ha ~__context =
   with_lock enable_disable_m (fun () -> Xapi_ha.disable __context)


### PR DESCRIPTION
This also blocks creation of VMs from templates with vtpm in the platform data.

Tested manually both cases for feature flag, and 4 cases for fencing + vtpm (try to create vtpm with ha, clustering on + try to enable ha, cluster when a vtpm is present)