### PR TITLE
CA-370084: Print PEMs containing DOS endlines in yangtze

### DIFF
--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -275,7 +275,7 @@ let pool_uninstall kind ~__context ~name =
 
 let rec trim_cert = function
   | x :: xs ->
-      if x = pem_certificate_header then
+      if String.trim x = pem_certificate_header then
         trim_cert' [x] xs
       else
         trim_cert xs
@@ -284,7 +284,7 @@ let rec trim_cert = function
 
 and trim_cert' acc = function
   | x :: xs ->
-      if x = pem_certificate_footer then
+      if String.trim x = pem_certificate_footer then
         List.rev (x :: acc)
       else
         trim_cert' (x :: acc) xs


### PR DESCRIPTION
The check to find the header and the footer were too strict, trim the lines before comparing.