### PR TITLE
Update CI badges in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 Xapi Project's XenAPI Management Toolstack
 ==========================================
 
-[![Build Status](https://travis-ci.org/xapi-project/xen-api.svg?branch=master)](https://travis-ci.org/xapi-project/xen-api)
+![Build](https://github.com/xapi-project/xen-api/actions/workflows/main.yml/badge.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/xapi-project/xen-api/badge.svg?branch=master)](https://coveralls.io/github/xapi-project/xen-api?branch=master)
 [![Lines of Code](https://tokei.rs/b1/github/xapi-project/xen-api)](https://github.com/xapi-project/xen-api)
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,6 @@ Xapi Project's XenAPI Management Toolstack
 ==========================================
 
 ![Build](https://github.com/xapi-project/xen-api/actions/workflows/main.yml/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/xapi-project/xen-api/badge.svg?branch=master)](https://coveralls.io/github/xapi-project/xen-api?branch=master)
 
 Xen API (or xapi) is a management stack that configures and controls
 Xen-enabled hosts and resource pools, and co-ordinates resources

--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,6 @@ Xapi Project's XenAPI Management Toolstack
 
 ![Build](https://github.com/xapi-project/xen-api/actions/workflows/main.yml/badge.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/xapi-project/xen-api/badge.svg?branch=master)](https://coveralls.io/github/xapi-project/xen-api?branch=master)
-[![Lines of Code](https://tokei.rs/b1/github/xapi-project/xen-api)](https://github.com/xapi-project/xen-api)
 
 Xen API (or xapi) is a management stack that configures and controls
 Xen-enabled hosts and resource pools, and co-ordinates resources


### PR DESCRIPTION
We moved to the GitHub CI - so use them to reflect the build status. Also removed the LoC badges because it appeared unreliable to me.