### PR TITLE
xapi-cli-server: change vm record to show "vtpms"

### DIFF
--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2519,7 +2519,7 @@ let vm_record rpc session_id vm =
               (x ()).API.vM_pending_guidances
           )
           ()
-      ; make_field ~name:"vtpm"
+      ; make_field ~name:"vtpms"
           ~get:(fun () -> get_uuids_from_refs (x ()).API.vM_VTPMs)
           ()
       ]


### PR DESCRIPTION
This matches the API name, and matches the fact that it's displaying a list, even if currently it will show one at most

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>