### PR TITLE
CA-370575: [XSI-1310] Driver disks / supp packs applied at host

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -220,13 +220,14 @@ let with_api_errors f x =
       error "%s" msg ;
       raise (Api_errors.Server_error (Api_errors.invalid_update, [errinfo]))
 
-(* yum confif example
+(* yum config example
    [main]
    keepcache=0
    reposdir=/dev/null
    gpgcheck=$signed
    repo_gpgcheck=$signed
    installonlypkgs=
+   group_command=compat
 
    [$label]
    name=$label
@@ -247,6 +248,7 @@ let create_yum_config ~__context ~self ~url =
     ; Printf.sprintf "gpgcheck=%d" signed_index
     ; Printf.sprintf "repo_gpgcheck=%d" signed_index
     ; "installonlypkgs="
+    ; "group_command=compat"
     ; ""
     ; Printf.sprintf "[%s]" name_label
     ; Printf.sprintf "name=%s" name_label

--- a/scripts/extensions/pool_update.apply
+++ b/scripts/extensions/pool_update.apply
@@ -77,17 +77,6 @@ def execute_apply(session, update_package, yum_conf_file):
             raise ApplyFailure(output)
 
 
-def remove_group(group, yum_conf_file):
-    cmd = ['yum', 'group', 'mark', 'remove', group, '-c', yum_conf_file]
-    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
-    output, _ = p.communicate()
-    xcp.logger.info('pool_update.apply %r returncode=%r output:', cmd, p.returncode)
-    for line in output.split('\n'):
-        xcp.logger.info(line)
-    if p.returncode != 0:
-        raise ApplyFailure(output)
-
-
 if __name__ == '__main__':
     xcp.logger.logToSyslog(level=logging.INFO)
     txt = sys.stdin.read()
@@ -151,7 +140,6 @@ if __name__ == '__main__':
                 file.write("{0}".format(yum_conf))
 
             execute_apply(session, '@update', yum_conf_file)
-            remove_group('update', yum_conf_file)
 
             session.xenapi.pool_update.resync_host(host)
             print(success_message())


### PR DESCRIPTION
install time cannot be updated

When applied at host install time, the yum is configured with `group_command=compat`, thus yum does not have group membership information if `group_command=objects` is set during update.apply

This commit set `group_command=compat` to support Driver disks/ supp packs applied
* at host install time
* manually (install some packages)

Signed-off-by: Lin Liu <lin.liu@citrix.com>