### PR TITLE
xenopsd tests: don't run cancel_utils_test as unit test

### DIFF
--- a/ocaml/xenopsd/xc/dune
+++ b/ocaml/xenopsd/xc/dune
@@ -114,14 +114,12 @@
  )
 )
 
-(test
+(executable
  (name cancel_utils_test)
- (package xapi-xenopsd-xc)
  (modules cancel_utils_test)
  (libraries
   cmdliner
   ezxenstore.core
-  ounit2
   threads.posix
   xapi-idl.xen.interface
   xapi-xenopsd


### PR DESCRIPTION
In practice the watches code was not being exercised by the test in any situation, so transforming it into an executable that doesn't get compiled by default. It is still checked by the CI

@stormi this should fix your failures