### PR TITLE
gencert: remove unused cert generation code

### DIFF
--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -66,8 +66,6 @@ let expire_in_days ~valid_from days =
   | Some e ->
       R.ok (valid_from, e)
 
-let expire_never ~valid_from () = (valid_from, Ptime.max)
-
 let sans dns_names ips =
   let sans = X509.General_name.(singleton DNS dns_names |> add IP ips) in
   X509.Extension.(singleton Subject_alt_name (false, sans))
@@ -182,21 +180,3 @@ let xapi_pool ?valid_from ~valid_for_days ~uuid pemfile =
     Ok c
   in
   R.failwith_error_msg res
-
-let xapi_cluster ?valid_from ~cn () =
-  let date = valid_from' valid_from in
-  let expiration = expire_never ~valid_from:date () in
-  let key_length = 2048 in
-  let issuer =
-    [
-      X509.Distinguished_name.(
-        Relative_distinguished_name.of_list
-          [CN cn; Serialnumber (serial_stamp ())]
-      )
-    ]
-  in
-  let extensions = X509.Extension.empty in
-  let _, pkcs12 =
-    selfsign' issuer extensions key_length expiration |> R.failwith_error_msg
-  in
-  pkcs12

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -39,6 +39,3 @@ val xapi_pool :
   -> X509.Certificate.t
 (** [xapi_pool uuid path] creates (atomically) a PEM file at [path] with
     [uuid] as CN *)
-
-val xapi_cluster :
-  ?valid_from:Ptime.t (* default: now *) -> cn:string -> unit -> string


### PR DESCRIPTION
clusters don't need their own certificates anymore, remove code that generates them to minimize confusion

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>