### PR TITLE
CP-33973 disable DMC: adjust unit test to disable DMC feature 

### DIFF
--- a/ocaml/tests/test_xapi_db_upgrade.ml
+++ b/ocaml/tests/test_xapi_db_upgrade.ml
@@ -17,7 +17,9 @@ module X = Xapi_db_upgrade
 module Date = Xapi_stdext_date.Date
 
 let upgrade_vm_memory_for_dmc () =
-  let __context = T.make_test_database () in
+  (* disable DMC for unit tests *)
+  let features = Features.(List.filter (( <> ) DMC) all_features) in
+  let __context = T.make_test_database ~features () in
   let self = List.hd (Db.VM.get_all ~__context) in
   (* Set control domain's dynamic_min <> dynamic_max <> target *)
   Db.VM.set_memory_dynamic_min ~__context ~self ~value:1L ;


### PR DESCRIPTION
The handling of DMC is guarded by a corresponding license feature flag. But this is not true for the database upgrade rule that is triggered during a version upgrade - it unconditionally disables DMC on all halted VMs. Change this to respect the feature flag as well. This makes backporting this code to the LTSR easier where DMC is still supported.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>