### PR TITLE
CP-40767 CP-40429 Migration Compression - define Zstd.Fast

### DIFF
--- a/ocaml/libs/zstd/zstd.ml
+++ b/ocaml/libs/zstd/zstd.ml
@@ -20,3 +20,33 @@ module Default = Xapi_compression.Make (struct
 
   let decompress_options = ["--decompress"; "--stdout"]
 end)
+
+module Adaptive = Xapi_compression.Make (struct
+  (** Path to the zstd binary *)
+  let executable = "/usr/bin/zstd"
+
+  (* default compression level is 3 on a scale 1..19 with lower=faster
+     and higher=more compression. By default 1 thread is used *)
+  let compress_options = ["--adapt=min=1,max=4"; "--threads=1"]
+
+  let decompress_options = ["--decompress"; "--stdout"]
+end)
+
+module Fast = Xapi_compression.Make (struct
+  (** Path to the zstd binary *)
+  let executable = "/usr/bin/zstd"
+
+  (** --threads=2 doesn't improve speed *)
+  let compress_options = ["--fast"]
+
+  let decompress_options = ["--decompress"; "--stdout"]
+end)
+
+module Null = Xapi_compression.Make (struct
+  (** Path to the zstd binary *)
+  let executable = "/usr/bin/cat"
+
+  let compress_options = []
+
+  let decompress_options = []
+end)

--- a/ocaml/libs/zstd/zstd.mli
+++ b/ocaml/libs/zstd/zstd.mli
@@ -13,3 +13,9 @@
  *)
 
 module Default : Xapi_compression.COMPRESSOR
+
+module Adaptive : Xapi_compression.COMPRESSOR
+
+module Fast : Xapi_compression.COMPRESSOR
+
+module Null : Xapi_compression.COMPRESSOR

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -2393,7 +2393,7 @@ and perform_exn ?subtask ?result (op : operation) (t : Xenops_task.task_handle)
         let compress =
           match compress_memory with
           | true ->
-              Zstd.Default.compress
+              Zstd.Fast.compress
           | false ->
               fun fd fn -> fn fd
           (* do nothing *)
@@ -2614,7 +2614,7 @@ and perform_exn ?subtask ?result (op : operation) (t : Xenops_task.task_handle)
         let decompress =
           match vmr_compressed with
           | true ->
-              Zstd.Default.decompress_passive
+              Zstd.Fast.decompress_passive
           | false ->
               fun fd fn -> fn fd
         in


### PR DESCRIPTION
Testing of vCPU/vGPU compression reveals that it does not offer a benefit on 10+ GBit/s networks because we can't saturate the network. So compression causes a slowdown compared to uncompressed migration.

So far:

* We are spawning a zstd process for compression with default parameters
* The default compression level is 3, on a scale 1 to 19, so 1 would be fast/low-compression and 19 slow/high-compression.

Define and use a new compression profile Zstd.Fast that uses less CPU; it causes less slowdown in the case of fast networks. The benefit on slow networks needs to be re-evaluated but this appears to be a better trade off.

TRUNK

evacuating xrtmia-04-21 without compression
real    3m44.421s
real    3m39.811s

evacuating xrtmia-04-24 with compression Zstd.Default
real    4m42.191s
real    4m58.360s

ZSTD.ADAPTIVE

evacuating xrtmia-04-21 (in batches of 20) without compression
real    3m48.964s
real    3m47.949s

evacuating xrtmia-04-24 (in batches of 20) with compression Zstd.Adaptive
real    5m59.555s
real    6m15.327s

This is clearly worse than what we have on Trunk.

ZSTD.FAST

evacuating xrtmia-04-21 (in batches of 20) without compression
real    3m39.868s
real    3m44.444s

evacuating xrtmia-04-24 (in batches of 20) with compression Zstd.Fast
real    4m8.825s
real    4m5.427s

This is substantially better than what we have on Trunk. There is still a slowdwown against uncompressed migration but it is much smaller.

Trunk:          4:42 / 3:44 = 1.26 (26% slowdown)
Zstd.Adaptive:  5:59 / 3:48 = 1.57 (57% slowdown)
Zstd.Fast:      4:08 / 3:39 = 1.13 (13% slowdown)

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>