### PR TITLE
ci: stop ssh-agent to allow for a second upload

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,9 @@ jobs:
           allow_empty_commit: false
           enable_jekyll: true # do not create .nojekyll file
 
+      - name: Clean SSH state for next upload
+        run: ssh-agent -k || true
+
       - name: Generate xapi docs
         run: |
           opam exec -- ./configure


### PR DESCRIPTION
Seems like the github action is not prepared for multiple uploads and does not clean up the state immediately. Stop ssh-agent in a best-effort mode so the SSh setup on the second upload succeeds

Unfortunately this step cannot be tested on my fork as it SSH setup is skipped because the action detects it's done in a fork:
```
Run ssh-agent -k || true
SSH_AGENT_PID not set, cannot kill agent
```