### PR TITLE
Revert "Add a fallback system for auth files belonging to RPMs"

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -846,8 +846,6 @@ let varstore_rm = ref "/usr/bin/varstore-rm"
 
 let varstore_dir = ref "/usr/share/varstored"
 
-let fallback_auth_dir = ref "/var/lib/varstored"
-
 let disable_logging_for = ref []
 
 let nvidia_whitelist = ref "/usr/share/nvidia/vgpu/vgpuConfig.xml"
@@ -1517,7 +1515,6 @@ module Resources = struct
       , "Executed to clear certain UEFI variables during clone"
       )
     ; ("varstore_dir", varstore_dir, "Path to local varstored directory")
-    ; ("fallback_auth_dir", fallback_auth_dir, "Fallback path for auth files")
     ; ( "nvidia-sriov-manage"
       , nvidia_sriov_manage_script
       , "Path to NVIDIA sriov-manage script"

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2686,34 +2686,13 @@ let write_uefi_certificates_to_disk ~__context ~host:_ =
             let path = Filename.concat !Xapi_globs.varstore_dir name in
             Unixext.unlink_safe path
           )
-          ["PK.auth"; "KEK.auth"; "db.auth"; "dbx.auth"] ;
+          ["KEK.auth"; "db.auth"] ;
         (* No uefi certificates, nothing to do. *)
         if contents <> "" then (
           with_temp_file_contents ~contents
             (Tar_unix.Archive.extract extract_certificate_file) ;
           debug "UEFI tar file extracted to temporary directory"
-        ) ;
-        (* If some mandatory auth files are missing, fetch them from a fallback dir *)
-        List.iter
-          (fun name ->
-            let path = Filename.concat !Xapi_globs.varstore_dir name in
-            let fallback_path =
-              Filename.concat !Xapi_globs.fallback_auth_dir name
-            in
-            if (not (Sys.file_exists path)) && Sys.file_exists fallback_path
-            then (
-              debug "Copy fallback auth %s to varstore dir" name ;
-              let ifd = Unix.openfile fallback_path [Unix.O_RDONLY] 0o0 in
-              let ofd =
-                Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT] 0o640
-              in
-              ignore
-              @@ Xapi_stdext_pervasives.Pervasiveext.finally
-                   (fun () -> Unixext.copy_file ifd ofd)
-                   (fun () -> Unix.close ifd ; Unix.close ofd)
-            )
-          )
-          ["PK.auth"; "dbx.auth"]
+        )
     (* No UEFI tar file. *)
     | Error _ ->
         debug


### PR DESCRIPTION
This reverts commit 5ad054a4baa39e0356e3c1001e2f557de3a56d50.

This commit caused xapi to delete dbx.auth from /usr/share/varstored.

Currently there's no way to recover this file once it's been deleted as it only gets written on first boot.

There is a plan to make varstored read the certificates from /var/lib/ and make xapi write and delete the files there. While that is implemented revert to the old behaviour to be able to brand shippable versions.

Sorry @benjamreis !