### PR TITLE
ci: stop trying to push docs on every commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,6 @@ jobs:
     env:
       XAPI_VERSION: "v0.0.0-${{ github.sha }}"
       STORAGE_DOCDIR: .gh-pages-xapi-storage
-      JEKYLL_DOCDIR: _build/install/default/xapi/doc/jekyll
 
     steps:
       - name: Checkout code
@@ -52,26 +51,5 @@ jobs:
           external_repository: xapi-project/xapi-storage
           publish_branch: slate
           destination_dir: source/includes/
-          allow_empty_commit: false
-          enable_jekyll: true # do not create .nojekyll file
-
-      - name: Clean SSH state for next upload
-        run: ssh-agent -k || true
-
-      - name: Generate xapi docs
-        run: |
-          opam exec -- ./configure
-          opam exec -- make doc-json
-
-      - name: Deploy xapi docs
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          deploy_key: ${{ secrets.ACTIONS_JENKINS_DEPLOY_KEY }}
-          user_name: 'Github action on xapi-project/xen-api'
-          user_email: 'github-actions-xapi-project-xen-api[bot]@users.noreply.github.com'
-          external_repository: xapi-project/xapi-project.github.io
-          publish_dir: ${{ env.JEKYLL_DOCDIR }}
-          publish_branch: master
-          keep_files: true
           allow_empty_commit: false
           enable_jekyll: true # do not create .nojekyll file


### PR DESCRIPTION
Seems like github workflow infrastructure is flakey there and makes the CI to fail.

We have other options, maybe using other actions, or even use pull-based, nightly method from the other repositories.

This reverts the changes in .github/workflows/docs.yml from:
bc38b245df68e63e7ed1c80e4dc1846b685da0ef
fdc2afd47bd1e6f39e0498c70bb7617a093b7e83
bed94e97b57aaa99f5c6c0565e0294f1d741ed6e
2e766873311cd165281f4b3558369beff444403a