### PR TITLE
xenopsd/xc: Print all information in Service_failed exceptions 

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -16,7 +16,7 @@ let prototyped_of_field = function
   | "VTPM", "persistence_backend" ->
       Some "22.26.0"
   | "host", "https_only" ->
-      Some "22.26.0-next"
+      Some "22.27.0"
   | "host", "last_software_update" ->
       Some "22.20.0"
   | _ ->
@@ -38,8 +38,8 @@ let prototyped_of_message = function
   | "VTPM", "create" ->
       Some "22.26.0"
   | "host", "set_https_only" ->
-      Some "22.26.0-next"
+      Some "22.27.0"
   | "pool", "set_https_only" ->
-      Some "22.26.0-next"
+      Some "22.27.0"
   | _ ->
       None

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -25,6 +25,15 @@ let defer f g = Xapi_stdext_pervasives.Pervasiveext.finally g f
 
 exception Service_failed of (string * string)
 
+let () =
+  Printexc.register_printer (function
+    | Service_failed (service, reason) ->
+        Some
+          (Printf.sprintf "Service_failed(service=%s,reason=%s)" service reason)
+    | _ ->
+        None
+    )
+
 type t = {
     name: string
   ; domid: Xenctrl.domid


### PR DESCRIPTION
This means that now xensource.log will contain the reason that produced
these exceptions

Reported by @xennifer 