### PR TITLE
maintenance: explicitely declare direct dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     name: Ocaml tests
     runs-on: ubuntu-20.04
     env:
-      package: "xapi-cli-protocol xapi-client xapi-consts xapi-database xapi-datamodel xapi-types xapi xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-svr pciutil safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd vhd-tool xapi-networkd xapi-squeezed xapi-xenopsd xapi-xenopsd-cli xapi-xenopsd-simulator xapi-xenopsd-xc message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-storage-cli wsproxy xapi-nbd varstored-guard"
+      package: "xapi-cli-protocol xapi-client xapi-consts xapi-database xapi-datamodel xapi-types xapi xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-svr pciutil safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd vhd-tool xapi-networkd xapi-squeezed xapi-xenopsd xapi-xenopsd-cli xapi-xenopsd-simulator xapi-xenopsd-xc message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-storage-cli wsproxy xapi-nbd varstored-guard xapi-log xapi-open-uri"
       XAPI_VERSION: "v0.0.0-${{ github.sha }}"
 
     steps:

--- a/ocaml/alerts/certificate/dune
+++ b/ocaml/alerts/certificate/dune
@@ -18,6 +18,7 @@
   (modules certificate_check_main)
   (libraries
     certificate_check
+    dune-build-info
     http-svr
     xapi-client
     xapi-types

--- a/ocaml/database/dune
+++ b/ocaml/database/dune
@@ -22,12 +22,12 @@
     http-svr
     uuid
     xapi-backtrace
+    xapi-log
     xapi-stdext-encodings
     xapi-stdext-pervasives
     xapi-stdext-std
     xapi-stdext-threads
     xapi-stdext-unix
-    xapi-idl
     xml-light2
     xmlm
   )
@@ -42,8 +42,9 @@
   (package xapi)
   (modules block_device_io)
   (libraries
+    dune-build-info
     xapi-database
-    xapi-idl
+    xapi-log
     xapi-stdext-pervasives
     xapi-stdext-unix
     uuid
@@ -55,10 +56,12 @@
   (name database_server_main)
   (modules database_server_main)
   (libraries
-    xapi-database
-    threads
-    xapi-stdext-threads
+    dune-build-info
     http-svr
+    threads.posix
+    xapi-database
+    xapi-stdext-threads
+    xapi-stdext-unix
   )
 )
 
@@ -68,7 +71,14 @@
   (modules db_cache_test unit_test_marshall)
   (libraries
     alcotest
+    dune-build-info
+    http-svr
+    ppx_sexp_conv.runtime-lib
+    rpclib.xml
+    sexplib
+    sexplib0
     xapi-database
+    xml-light2
   )
 )
 
@@ -81,7 +91,9 @@
   )
   (libraries
     alcotest
+    dune-build-info
     xapi-database
+    xml-light2
   )
 )
 

--- a/ocaml/db_process/dune
+++ b/ocaml/db_process/dune
@@ -4,10 +4,11 @@
   (public_name xapi-db-process)
   (package xapi)
   (libraries
+    dune-build-info
     unix
     xapi-inventory
     xapi-database
-    xapi-idl
+    xapi-log
   )
 )
 

--- a/ocaml/doc/dune
+++ b/ocaml/doc/dune
@@ -2,14 +2,17 @@
   (modes byte exe)
   (name jsapi)
   (libraries
-    xapi-datamodel
+    dune-build-info
+    gzip
+    mustache
+    rpclib.core
+    rpclib.json
+    uuid
     xapi-consts
+    xapi-datamodel
     xapi-stdext-pervasives
     xapi-stdext-std
     xapi-stdext-unix
-    uuid
-    gzip
-    mustache
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/events/dune
+++ b/ocaml/events/dune
@@ -4,6 +4,7 @@
   (public_name event_listen)
   (package xapi)
   (libraries
+    dune-build-info
     http-svr
     xapi-client
     xapi-types

--- a/ocaml/forkexecd/lib/dune
+++ b/ocaml/forkexecd/lib/dune
@@ -2,7 +2,16 @@
  (name forkexec)
  (public_name forkexec)
  (wrapped false)
- (libraries astring fd-send-recv rpclib.json threads uuid xapi-stdext-pervasives
-   xapi-stdext-unix)
+ (libraries
+   astring
+   fd-send-recv
+   rpclib.core
+   rpclib.json
+   uuid
+   xapi-backtrace
+   xapi-log
+   xapi-stdext-pervasives
+   xapi-stdext-unix
+ )
  (preprocess
   (pps ppx_deriving_rpc)))

--- a/ocaml/forkexecd/src/dune
+++ b/ocaml/forkexecd/src/dune
@@ -1,7 +1,15 @@
 (executable
  (modes byte exe)
  (name fe_main)
- (libraries astring forkexec systemd uuid xapi-log xapi-stdext-unix))
+ (libraries
+   astring
+   fd-send-recv
+   forkexec
+   systemd
+   uuid
+   xapi-log
+   xapi-stdext-unix
+  ))
 
 (install
  (package xapi-forkexecd)

--- a/ocaml/forkexecd/test/dune
+++ b/ocaml/forkexecd/test/dune
@@ -1,7 +1,7 @@
 (executable
  (modes byte exe)
  (name fe_test)
- (libraries forkexec xapi-stdext-unix))
+ (libraries forkexec uuid xapi-stdext-unix))
 
 (rule
  (alias runtest)

--- a/ocaml/gencert/dune
+++ b/ocaml/gencert/dune
@@ -15,9 +15,9 @@
     result
     rresult
     x509
-    xapi_aux
+    xapi-backtrace
     xapi-consts
-    xapi-idl
+    xapi-log
     xapi-inventory
     xapi-stdext-unix
   )
@@ -31,9 +31,12 @@
   (modules gencert)
   (libraries
     astring
+    dune-build-info
     gencertlib
+    x509
     xapi-inventory
-    xapi-idl
+    xapi_aux
+    xapi-log
   )
 )
 
@@ -44,11 +47,14 @@
   (libraries
     alcotest
     cstruct
+    dune-build-info
     fmt
     gencertlib
     mirage-crypto
     mirage-crypto-pk
     mirage-crypto-rng.unix
+    ptime
+    result
     rresult
     x509
     xapi-consts

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -29,7 +29,11 @@
   (name datamodel_main)
   (modules datamodel_main dot_backend dtd_backend markdown_backend)
   (libraries
+    dune-build-info
     xapi-datamodel
+    xapi-stdext-std
+    xapi-stdext-pervasives
+    xapi-stdext-unix
   )
 )
 
@@ -37,6 +41,9 @@
   (name schematest)
   (modules schematest)
   (libraries
+    dune-build-info
+    rpclib.core
+    rpclib.json
     xapi_datamodel
   )
   (package xapi-datamodel)
@@ -47,8 +54,9 @@
   (name gen_lifecycle)
   (modules gen_lifecycle)
   (libraries
+    dune-build-info
     xapi-datamodel
-    xapi_version
+    xapi-consts.xapi_version
   )
   (promote (until-clean))
  )

--- a/ocaml/idl/json_backend/dune
+++ b/ocaml/idl/json_backend/dune
@@ -2,6 +2,8 @@
   (modes byte exe)
   (name gen_json)
   (libraries
+    dune-build-info
+    fmt
     xapi-datamodel
     xapi-consts
     xapi-stdext-unix

--- a/ocaml/idl/ocaml_backend/dune
+++ b/ocaml/idl/ocaml_backend/dune
@@ -2,12 +2,12 @@
   (modes byte exe)
   (name gen_api_main)
   (libraries
+    dune-build-info
     sexpr
-    threads
     uuid
     xapi-consts
     xapi-datamodel
-    xapi-idl
+    xapi-log
     xapi-stdext-pervasives
     xapi-stdext-std
   )

--- a/ocaml/libs/gzip/dune
+++ b/ocaml/libs/gzip/dune
@@ -2,7 +2,7 @@
   (name gzip)
   (public_name gzip)
   (libraries
-    xapi-compression
+    (re_export xapi-compression)
   )
 )
 

--- a/ocaml/libs/http-svr/dune
+++ b/ocaml/libs/http-svr/dune
@@ -7,14 +7,19 @@
   (libraries
     astring
     base64
+    mtime
+    mtime.clock.os
     polly
-    rpclib
+    rpclib.core
+    rpclib.json
+    rpclib.xml
+    safe_resources
     sha
     stunnel
     threads.posix
     uuid
+    xapi-backtrace
     xapi-consts.xapi_version
-    xapi-idl
     xapi-idl.updates
     xapi-log
     xapi-stdext-date
@@ -30,16 +35,18 @@
   (name http_test)
   (modules http_test)
   (libraries
+    dune-build-info
     http-svr
-    oUnit
+    ounit2
   )
 )
 
-(executable
-  (modes byte exe)
+(test
   (name radix_tree_test)
   (modules radix_tree_test)
+  (package http-svr)
   (libraries
+    dune-build-info
     http-svr
   )
 )
@@ -49,8 +56,12 @@
   (name test_client)
   (modules test_client)
   (libraries
+    dune-build-info
     http-svr
-    oUnit
+    ounit2
+    safe-resources
+    stunnel
+    threads.posix
     xapi-stdext-pervasives
     xapi-stdext-unix
   )
@@ -61,8 +72,11 @@
   (name test_server)
   (modules test_server)
   (libraries
+    dune-build-info
     http-svr
-    oUnit
+    ounit2
+    safe-resources
+    threads.posix
     xapi-stdext-threads
     xapi-stdext-unix
   )
@@ -75,15 +89,6 @@
     (:x http_test.exe)
   )
   (action (run %{x} -runner sequential -verbose true))
-)
-
-(rule
-  (alias runtest)
-  (package http-svr)
-  (deps
-    (:x radix_tree_test.exe)
-  )
-  (action (run %{x}))
 )
 
 (rule

--- a/ocaml/libs/log/dune
+++ b/ocaml/libs/log/dune
@@ -6,6 +6,9 @@
    (names syslog_stubs))
  (libraries
    astring
+   logs
+   threads.posix
+   xapi-backtrace
    xapi-stdext-pervasives
  )
  (wrapped false)

--- a/ocaml/libs/open-uri/dune
+++ b/ocaml/libs/open-uri/dune
@@ -3,7 +3,10 @@
  (public_name xapi-open-uri)
  (libraries
    cohttp
+   safe-resources
    stunnel
+   uri
+   xapi-backtrace
    xapi-consts
    xapi-log
    xapi-stdext-pervasives

--- a/ocaml/libs/resources/dune
+++ b/ocaml/libs/resources/dune
@@ -5,6 +5,7 @@
     logs
     xapi-backtrace
     fmt
+    threads.posix
     xapi-stdext-pervasives
     xapi-stdext-threads
   )

--- a/ocaml/libs/stunnel/dune
+++ b/ocaml/libs/stunnel/dune
@@ -6,6 +6,7 @@
     astring
     forkexec
     safe-resources
+    threads.posix
     uuid
     xapi-consts
     xapi-inventory

--- a/ocaml/libs/uuid/dune
+++ b/ocaml/libs/uuid/dune
@@ -12,5 +12,5 @@
   (name uuid_test)
   (package uuid)
   (modules uuid_test)
-  (libraries uuid alcotest)
+  (libraries alcotest fmt uuid)
   )

--- a/ocaml/libs/xapi-compression/dune
+++ b/ocaml/libs/xapi-compression/dune
@@ -6,7 +6,7 @@
     forkexec
     threads
     safe-resources
-    xapi-idl
+    xapi-log
     xapi-stdext-pervasives
     xapi-stdext-unix
   )

--- a/ocaml/libs/zstd/dune
+++ b/ocaml/libs/zstd/dune
@@ -2,7 +2,7 @@
   (name zstd)
   (public_name zstd)
   (libraries
-    xapi-compression
+    (re_export xapi-compression)
   )
 )
 

--- a/ocaml/license/dune
+++ b/ocaml/license/dune
@@ -18,6 +18,7 @@
   (modules daily_license_check_main)
   (libraries
     daily_license_check
+    dune-build-info
     http-svr
     xapi-client
     xapi-types

--- a/ocaml/message-switch/async/dune
+++ b/ocaml/message-switch/async/dune
@@ -3,7 +3,12 @@
   (public_name message-switch-async)
   (libraries
     async
+    async_unix
+    async_kernel
+    base
     cohttp-async
+    core
+    core_kernel
     message-switch-core
   )
 )

--- a/ocaml/message-switch/cli/dune
+++ b/ocaml/message-switch/cli/dune
@@ -3,7 +3,11 @@
   (name main)
   (libraries
     cmdliner
+    message-switch-core
     message-switch-unix
+    rpclib.core
+    rpclib.json
+    threads.posix
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/message-switch/core/dune
+++ b/ocaml/message-switch/core/dune
@@ -4,9 +4,11 @@
   (libraries
     astring
     cohttp
-    rpclib
+    rpclib.core
     rpclib.json
     sexplib
+    sexplib0
+    uri
   )
   (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )

--- a/ocaml/message-switch/core_test/async/dune
+++ b/ocaml/message-switch/core_test/async/dune
@@ -5,7 +5,14 @@
     server_async_main
   )
   (libraries
+    async
+    async_kernel
+    async_unix
+    base
+    base.caml
     cohttp-async
+    core
+    core_kernel
     message-switch-async
   )
 )

--- a/ocaml/message-switch/core_test/dune
+++ b/ocaml/message-switch/core_test/dune
@@ -6,6 +6,7 @@
   )
   (libraries
     message-switch-unix
+    threads.posix
   )
 )
 

--- a/ocaml/message-switch/core_test/lwt/dune
+++ b/ocaml/message-switch/core_test/lwt/dune
@@ -6,8 +6,13 @@
     server_main
   )
   (libraries
+    cohttp
     cohttp-lwt-unix
+    lwt
+    lwt.unix
+    message-switch-core
     message-switch-lwt
+    uri
   )
 )
 

--- a/ocaml/message-switch/lwt/dune
+++ b/ocaml/message-switch/lwt/dune
@@ -5,6 +5,7 @@
     cohttp-lwt-unix
     message-switch-core
     lwt
+    lwt.unix
   )
 )
 

--- a/ocaml/message-switch/switch/dune
+++ b/ocaml/message-switch/switch/dune
@@ -3,16 +3,30 @@
   (name switch_main)
   (libraries
     cmdliner
+    cohttp
+    cohttp-lwt
     cohttp-lwt-unix
+    conduit-lwt-unix
+    cstruct
     io-page-unix
+    lwt
+    lwt.unix
     lwt_log
+    message-switch-core
     message-switch-lwt
     message-switch-unix
+    mirage-block
+    mirage-block-unix
+    mirage-time
     mtime
     mtime.clock.os
-    mirage-block-unix
+    result
+    rpclib.core
+    rpclib.json
     shared-block-ring
     sexplib
+    sexplib0
+    uri
   )
   (preprocess (pps ppx_sexp_conv))
 )

--- a/ocaml/message-switch/unix/dune
+++ b/ocaml/message-switch/unix/dune
@@ -6,8 +6,11 @@
     protocol_unix_scheduler
   )
   (libraries
+    cohttp
     message-switch-core
-    threads
+    rpclib.core
+    rpclib.json
+    threads.posix
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/mpathalert/dune
+++ b/ocaml/mpathalert/dune
@@ -4,6 +4,7 @@
   (public_name mpathalert)
   (package xapi)
   (libraries
+    dune-build-info
     http-svr
     threads.posix
     uuid

--- a/ocaml/nbd/lib/dune
+++ b/ocaml/nbd/lib/dune
@@ -11,6 +11,8 @@
   lwt
   lwt_log
   lwt.unix
+  rpclib.core
+  xapi-types
   xen-api-client-lwt
  )
 )

--- a/ocaml/nbd/src/dune
+++ b/ocaml/nbd/src/dune
@@ -4,17 +4,24 @@
  (libraries
   cmdliner
   consts
+  dune-build-info
   local_xapi_session
   lwt
   lwt.unix
+  lwt_log
+  mirage-block
   mirage-block-unix
+  nbd
   nbd-unix
+  rpclib.core
   uri
   uuid
   vbd_store
+  xapi-consts
   xapi-inventory
+  xapi-types
   xen-api-client-lwt
-  xapi-idl)
+  )
 )
 (install
  (package xapi-nbd)

--- a/ocaml/networkd/bin/dune
+++ b/ocaml/networkd/bin/dune
@@ -15,19 +15,31 @@
  (package xapi-networkd)
  (modes byte exe)
  (libraries
+  astring
+  dune-build-info
   forkexec
+  http-svr
+  integers
   netlink
   networklibs
-  rpclib
+  rpclib.core
+  rpclib.json
+  result
+  rresult
   systemd
-  threads
-  xapi_version
+  threads.posix
+  xapi-client
+  xapi-consts
+  xapi-consts.xapi_version
   xapi-stdext-pervasives
+  xapi-stdext-std
   xapi-stdext-threads
   xapi-stdext-unix
   xapi-inventory
   xapi-idl
   xapi-idl.network
+  xapi-log
+  xapi-types
   xen-api-client))
 
 (alias

--- a/ocaml/networkd/bin_db/dune
+++ b/ocaml/networkd/bin_db/dune
@@ -4,7 +4,7 @@
  (package xapi-networkd)
  (modes byte exe)
  (libraries
+  dune-build-info
   networklibs
-  threads
   xapi-idl.network)
 )

--- a/ocaml/networkd/lib/dune
+++ b/ocaml/networkd/lib/dune
@@ -5,13 +5,24 @@
   forkexec
   mtime
   mtime.clock.os
-  rpclib
-  systemd
-  threads
+  re
   re.perl
+  result
+  rpclib.core
+  rpclib.json
+  rresult
+  systemd
+  threads.posix
+  uri
+  xapi-stdext-pervasives
   xapi-stdext-std
+  xapi-stdext-threads
   xapi-stdext-unix
   xapi-inventory
-  xapi-idl.network)
+  xapi-idl.network
+  xapi-log
+  xapi-open-uri
+  yojson
+ )
  (wrapped false)
 )

--- a/ocaml/networkd/test/dune
+++ b/ocaml/networkd/test/dune
@@ -3,7 +3,12 @@
  (libraries
   alcotest
   astring
+  dune-build-info
+  fmt
   networklibs
+  rpclib.core
+  rpclib.json
+  xapi-log
   xapi-test-utils)
 )
 

--- a/ocaml/perftest/dune
+++ b/ocaml/perftest/dune
@@ -4,6 +4,7 @@
   (public_name perftest)
   (package xapi)
   (libraries
+    dune-build-info
     http-svr
     rpclib.core
     threads.posix
@@ -11,7 +12,6 @@
     xapi-cli-protocol
     xapi-client
     xapi-datamodel
-    xapi-idl
     xapi-inventory
     xapi-types
     xapi-stdext-pervasives

--- a/ocaml/quicktest/dune
+++ b/ocaml/quicktest/dune
@@ -6,6 +6,7 @@
   (libraries
     alcotest
     astring
+    dune-build-info
     fmt
     forkexec
     http-svr
@@ -14,13 +15,13 @@
     result
     rresult
     rpclib.core
+    stunnel
     threads.posix
     unix
     uuid
     xapi-client
     xapi-consts
     xapi-datamodel
-    xapi-idl
     xapi_internal
     xapi-types
     xapi-stdext-date

--- a/ocaml/rrd2csv/src/dune
+++ b/ocaml/rrd2csv/src/dune
@@ -4,11 +4,17 @@
   (public_name rrd2csv)
   (package rrd2csv)
   (libraries
-    threads
+    dune-build-info
+    http-svr
+    threads.posix
     xapi-idl.rrd
     xapi-client
+    xapi-rrd
+    xapi-stdext-pervasives
     xapi-stdext-std
     xapi-stdext-threads
+    xapi-types
+    xmlm
   )
 )
 

--- a/ocaml/sdk-gen/c/dune
+++ b/ocaml/sdk-gen/c/dune
@@ -2,9 +2,11 @@
   (modes byte exe)
   (name gen_c_binding)
   (libraries
-    xapi-datamodel
-    CommonFunctions
     astring
+    CommonFunctions
+    dune-build-info
+    mustache
+    xapi-datamodel
   )
 )
 

--- a/ocaml/sdk-gen/common/dune
+++ b/ocaml/sdk-gen/common/dune
@@ -2,6 +2,7 @@
   (name CommonFunctions)
   (wrapped false)
   (libraries
+    astring
     xapi-datamodel
     mustache
   )

--- a/ocaml/sdk-gen/csharp/dune
+++ b/ocaml/sdk-gen/csharp/dune
@@ -3,9 +3,12 @@
   (name gen_csharp_binding)
   (modules Gen_csharp_binding)
   (libraries
-    xapi-datamodel
-    CommonFunctions
     astring
+    CommonFunctions
+    dune-build-info
+    mustache
+    xapi-consts
+    xapi-datamodel
   )
 )
 
@@ -14,8 +17,11 @@
   (name friendly_error_names)
   (modules Friendly_error_names)
   (libraries
-    xapi-datamodel
     CommonFunctions
+    dune-build-info
+    mustache
+    xapi-datamodel
+    xmllight2
   )
 )
 

--- a/ocaml/sdk-gen/java/dune
+++ b/ocaml/sdk-gen/java/dune
@@ -2,10 +2,12 @@
   (modes byte exe)
   (name main)
   (libraries
-    xapi-datamodel
-    str
-    CommonFunctions
     astring
+    CommonFunctions
+    dune-build-info
+    mustache
+    str
+    xapi-datamodel
   )
 )
 

--- a/ocaml/sdk-gen/powershell/dune
+++ b/ocaml/sdk-gen/powershell/dune
@@ -2,9 +2,11 @@
   (modes byte exe)
   (name gen_powershell_binding)
   (libraries
-    xapi-datamodel
-    CommonFunctions
     astring
+    CommonFunctions
+    dune-build-info
+    mustache
+    xapi-datamodel
   )
 )
 

--- a/ocaml/squeezed/lib/dune
+++ b/ocaml/squeezed/lib/dune
@@ -4,7 +4,7 @@
   (libraries
     re
     re.str
-    xapi-idl
+    xapi-log
     threads
   )
   (wrapped false)

--- a/ocaml/squeezed/src/dune
+++ b/ocaml/squeezed/src/dune
@@ -9,7 +9,10 @@
     xapi-stdext-pervasives
     xapi-stdext-unix
     astring
+    dune-build-info
+    rpclib.core
     squeeze
+    threads.posix
     xenctrl
     xenstore
     xenstore.unix
@@ -18,6 +21,8 @@
     rpclib
     xapi-idl
     xapi-idl.memory
+    xapi-log
+    xapi-types
     uuid
     re
     re.str

--- a/ocaml/squeezed/test/dune
+++ b/ocaml/squeezed/test/dune
@@ -9,6 +9,6 @@
     xenctrl
     unix
     squeeze
-    xapi-idl
+    xapi-log
   )
 )

--- a/ocaml/tapctl/dune
+++ b/ocaml/tapctl/dune
@@ -3,9 +3,11 @@
   (wrapped false)
   (preprocess (pps ppx_deriving_rpc))
   (libraries
+    astring
     re
-    rpclib
-    threads
+    rpclib.core
+    rpclib.json
+    threads.posix
     forkexec
     xapi-stdext-unix
     xapi-stdext-threads

--- a/ocaml/tests/alerts/dune
+++ b/ocaml/tests/alerts/dune
@@ -5,7 +5,12 @@
     alcotest
     certificate_check
     daily_license_check
+    dune-build-info
+    fmt
+    xapi-consts
+    xapi-log
     xapi-stdext-date
+    xapi-types
   )
   (action (run %{test} --color=always))
 )

--- a/ocaml/tests/common/dune
+++ b/ocaml/tests/common/dune
@@ -3,8 +3,29 @@
   (modules :standard)
   (wrapped false)
   (libraries
+    alcotest
+    fmt
+    http-svr
+    rpclib.core
+    rpclib.json
+    rpclib.xml
+    threads.posix
+    uuid
+    xapi_aux
+    xapi-consts
+    xapi-database
+    xapi-datamodel
+    xapi-idl
+    xapi-idl.memory
+    xapi-idl.network
+    xapi-idl.xen.interface
     xapi_internal
+    xapi-inventory
+    xapi-log
     xapi-test-utils
+    xapi-types
+    xapi-stdext-date
+    xapi-stdext-unix
   )
 )
 

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -8,16 +8,44 @@
       test_livepatch test_rpm test_updateinfo))
   (libraries
     alcotest
+    angstrom
     astring
+    cstruct
+    dune-build-info
     fmt
+    http-svr
+    ipaddr
+    mirage-crypto
+    pam
+    result
+    rpclib.core
+    rpclib.json
     rresult
+    tapctl
+    tests_common
+    threads.posix
+    uuid
+    xapi-backtrace
+    xapi-client
+    xapi_cli_server
+    xapi-consts
+    xapi-database
+    xapi-datamodel
+    xapi-idl
+    xapi-idl.storage.interface
+    xapi-idl.xen.interface
+    xapi-idl.xen.interface.types
     xapi_internal
+    xapi-log
     xapi-stdext-date
     xapi-stdext-std
     xapi-stdext-threads
     xapi-stdext-unix
     xapi-test-utils
-    tests_common
+    xapi-types
+    xapi-stdext-pervasives
+    xapi-xenopsd
+    xml-light2
   )
   (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
   (deps
@@ -36,8 +64,29 @@
     test_updateinfo)
   (libraries
     alcotest
-    xapi_internal
+    fmt
+    result
+    rpclib.core
+    rpclib.json
+    rresult
     tests_common
+    threads.posix
+    uuid
+    xapi-client
+    xapi_cli_server
+    xapi-consts
+    xapi-database
+    xapi-idl
+    xapi-idl.cluster
+    xapi-idl.storage
+    xapi-idl.storage.interface
+    xapi-idl.xen
+    xapi_internal
+    xapi-test-utils
+    xapi-types
+    xapi-stdext-threads
+    xml-light2
+    yojson
   )
   (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )

--- a/ocaml/vhd-tool/cli/dune
+++ b/ocaml/vhd-tool/cli/dune
@@ -4,10 +4,22 @@
   (package vhd-tool)
   (public_names vhd-tool sparse_dd get_vhd_vsize)
   (libraries
-    cmdliner
+    astring
+    dune-build-info
     local_lib
+    cmdliner
     cstruct
+    forkexec
+    lwt
+    lwt.unix
+    tapctl
+    threads.posix
+    uri
+    vhd-format
+    vhd-format-lwt
     xapi-idl
+    xapi-log
+    xenstore_transport.unix
   )
 )
 

--- a/ocaml/vhd-tool/src/dune
+++ b/ocaml/vhd-tool/src/dune
@@ -6,20 +6,31 @@
   (name local_lib)
   (wrapped false)
   (libraries
+    astring
+    bigarray-compat
+    cohttp
     cohttp-lwt
     cstruct
     io-page.unix
     lwt
+    lwt.unix
+    lwt_ssl
+    nbd
     nbd-unix
     re.str
-    rpclib
+    result
+    rpclib.core
     rpclib.json
     sha
+    ssl
     tar
+    uri
     vhd-format
     vhd-format-lwt
     tapctl
     xapi-stdext-std
+    xapi-stdext-unix
+    xenstore
     xenstore.client
     xenstore.unix
     xenstore_transport

--- a/ocaml/vhd-tool/test/dune
+++ b/ocaml/vhd-tool/test/dune
@@ -3,6 +3,7 @@
   (libraries
     alcotest
     alcotest-lwt
+    lwt
     local_lib
     vhd-format
     vhd-format-lwt

--- a/ocaml/vncproxy/dune
+++ b/ocaml/vncproxy/dune
@@ -4,7 +4,9 @@
   (public_name vncproxy)
   (package xapi)
   (libraries
+    dune-build-info
     http-svr
+    stunnel
     xapi-client
     xapi-consts
     xapi-types

--- a/ocaml/wsproxy/cli/dune
+++ b/ocaml/wsproxy/cli/dune
@@ -9,7 +9,7 @@
    logs.lwt
    lwt
    lwt.unix
-   re.str
+   re
    uuid
    wslib
   )

--- a/ocaml/wsproxy/test/dune
+++ b/ocaml/wsproxy/test/dune
@@ -1,5 +1,5 @@
 (test
   (name wsproxy_tests)
   (package wsproxy)
-  (libraries oUnit qcheck wslib)
+  (libraries ounit2 qcheck-core wslib)
 )

--- a/ocaml/xapi-aux/dune
+++ b/ocaml/xapi-aux/dune
@@ -6,9 +6,11 @@
     forkexec
     ipaddr
     tar
+    threads.posix
     xapi-consts
-    xapi-idl
     xapi-idl.network
+    xapi-inventory
+    xapi-log
     xapi-stdext-threads
     xapi-stdext-unix
     xapi-types

--- a/ocaml/xapi-cli-server/dune
+++ b/ocaml/xapi-cli-server/dune
@@ -10,13 +10,14 @@
     result
     rresult
     sexplib
+    sexplib0
     tar
     threads.posix
     xapi-backtrace
     xapi-consts
     xapi-database
     xapi-datamodel
-    xapi-idl
+    xapi-log
     xapi-types
     xapi-client
     xapi-cli-protocol
@@ -24,6 +25,7 @@
     xapi-stdext-date
     xapi-stdext-pervasives
     xapi-stdext-std
+    xapi-stdext-threads
     xapi-stdext-unix
     xmlm
     xml-light2

--- a/ocaml/xapi-client/dune
+++ b/ocaml/xapi-client/dune
@@ -17,7 +17,7 @@
     mtime.clock.os
     rpclib.core
     xapi-consts
-    xapi-idl
+    xapi-log
     xapi-types
     xapi-stdext-date
     xapi-stdext-pervasives

--- a/ocaml/xapi-guard/src/dune
+++ b/ocaml/xapi-guard/src/dune
@@ -1,14 +1,33 @@
 (executable
  (name main)
  (libraries
-	cmdliner
-	cohttp-lwt 
-	message-switch-lwt
-	rpclib-lwt 
-	xapi-idl 
-	xapi-idl.varstore.deprivileged
-	xapi-idl.varstore.privileged
-	xen-api-client-lwt)
+   cmdliner
+   cohttp
+   cohttp-lwt 
+   cohttp-lwt-unix 
+   conduit-lwt-unix
+   dune-build-info
+   lwt
+   lwt.unix
+   message-switch-lwt
+   result
+   rresult
+   rpclib.core
+   rpclib.json
+   rpclib.xml
+   rpclib-lwt 
+   uri
+   uuidm
+   xapi-backtrace
+   xapi-consts
+   xapi-idl 
+   xapi-idl.varstore.deprivileged
+   xapi-idl.varstore.privileged
+   xapi-idl.xen.interface
+   xapi-idl.xen.interface.types
+   xapi-log
+   xapi-types
+   xen-api-client-lwt)
  (preprocess (pps ppx_deriving_rpc)))
 
 (install

--- a/ocaml/xapi-idl/cluster/dune
+++ b/ocaml/xapi-idl/cluster/dune
@@ -4,9 +4,12 @@
  (public_name xapi-idl.cluster)
  (modules (:standard \ cluster_cli))
  (libraries
+   result
+   rpclib.core
+   rpclib.json
+   rresult
    xapi-idl
    threads
-   rpclib.core
  )
  (wrapped false)
  (preprocess (pps ppx_deriving_rpc)))
@@ -17,7 +20,9 @@
  (libraries
    cmdliner
    rpclib.cmdliner
+   rpclib.core
    rpclib.markdown
+   xapi-idl
    xapi-idl.cluster))
 
 (rule

--- a/ocaml/xapi-idl/example/dune
+++ b/ocaml/xapi-idl/example/dune
@@ -1,9 +1,11 @@
 (executable
  (name example)
  (libraries
+   astring
    rpclib.core
-   xapi-idl
    xapi-consts.xapi_version
+   xapi-idl
+   xapi-log
  )
  (preprocess (pps ppx_deriving_rpc)))
 

--- a/ocaml/xapi-idl/gpumon/dune
+++ b/ocaml/xapi-idl/gpumon/dune
@@ -3,9 +3,12 @@
  (public_name xapi-idl.gpumon)
  (modules (:standard \ gpumon_cli))
  (libraries
+   result
    rpclib.core
+   rresult
    threads
    xapi-idl
+   xapi-log
  )
  (wrapped false)
  (preprocess (pps ppx_deriving_rpc)))
@@ -16,7 +19,9 @@
  (libraries
    cmdliner
    rpclib.cmdliner
+   rpclib.core
    rpclib.markdown
+   xapi-idl
    xapi-idl.gpumon))
 
 (rule

--- a/ocaml/xapi-idl/lib/dune
+++ b/ocaml/xapi-idl/lib/dune
@@ -6,10 +6,11 @@
    astring
    cmdliner
    cohttp
+   (re_export dune-build-info)
    fd-send-recv
    logs
    message-switch-core
-   message-switch-unix 
+   message-switch-unix
    mtime
    mtime.clock.os
    ppx_sexp_conv.runtime-lib
@@ -17,10 +18,14 @@
    rpclib.core
    rpclib.json
    rpclib.xml
+   result
+   rresult
    sexplib
-   threads
+   sexplib0
+   threads.posix
    unix
    uri
+   uuidm
    xapi-backtrace
    xapi-consts
    xapi-log
@@ -37,6 +42,18 @@
  (name xcp_updates)
  (public_name xapi-idl.updates)
  (modules updates task_server scheduler)
- (libraries xapi-idl)
+ (libraries
+   mtime
+   mtime.clock.os
+   rpclib.core
+   rpclib.json
+   sexplib
+   sexplib0
+   threads.posix
+   xapi-backtrace
+   xapi-log
+   xapi-stdext-pervasives
+   xapi-stdext-threads
+ )
  (wrapped false)
  (preprocess (pps ppx_deriving_rpc)))

--- a/ocaml/xapi-idl/lib_test/dune
+++ b/ocaml/xapi-idl/lib_test/dune
@@ -4,9 +4,13 @@
  (deps (source_tree test_data))
  (libraries
    alcotest
+   fmt
+   result
    rpclib.core
+   rpclib.json
    rpclib.markdown
-   threads
+   rpclib.xml
+   threads.posix
    xapi-idl
    xapi-idl.cluster
    xapi-idl.rrd
@@ -15,9 +19,13 @@
    xapi-idl.network
    xapi-idl.gpumon
    xapi-idl.storage
+   xapi-idl.storage.interface
    xapi-idl.varstore.privileged
    xapi-idl.varstore.deprivileged
    xapi-idl.v6
    xapi-idl.xen
+   xapi-idl.xen.interface
+   xapi-idl.xen.interface.types
+   xapi-log
  )
  (preprocess (pps ppx_deriving_rpc)))

--- a/ocaml/xapi-idl/memory/dune
+++ b/ocaml/xapi-idl/memory/dune
@@ -3,9 +3,11 @@
  (public_name xapi-idl.memory)
  (modules (:standard \ memory_cli))
  (libraries
+   result
    rpclib.core
-   threads
+   rresult
    xapi-idl
+   xapi-log
  )
  (wrapped false)
  (preprocess (pps ppx_deriving_rpc)))
@@ -16,7 +18,9 @@
  (libraries
    cmdliner
    rpclib.cmdliner
+   rpclib.core
    rpclib.markdown
+   xapi-idl
    xapi-idl.memory
  ))
 

--- a/ocaml/xapi-idl/misc/dune
+++ b/ocaml/xapi-idl/misc/dune
@@ -5,8 +5,12 @@
  (package xapi-idl)
  (libraries
    cmdliner
+   dune-build-info
    lwt
    lwt.unix
+   rpclib.core
+   rpclib.json
    xapi-idl
+   xapi-log
  )
  (preprocess (pps ppx_deriving_rpc)))

--- a/ocaml/xapi-idl/network/dune
+++ b/ocaml/xapi-idl/network/dune
@@ -3,9 +3,13 @@
  (public_name xapi-idl.network)
  (modules (:standard \ network_cli))
  (libraries
+   result
    rpclib.core
-   threads
+   rpclib.json
+   rresult
+   threads.posix
    xapi-idl
+   xapi-log
  )
  (wrapped false)
  (preprocess (pps ppx_deriving_rpc)))
@@ -15,8 +19,11 @@
  (modules network_cli)
  (libraries
    cmdliner
+   dune-build-info
    rpclib.cmdliner
+   rpclib.core
    rpclib.markdown
+   xapi-idl
    xapi-idl.network
  ))
 

--- a/ocaml/xapi-idl/rrd/dune
+++ b/ocaml/xapi-idl/rrd/dune
@@ -3,8 +3,9 @@
  (public_name xapi-idl.rrd.interface.types)
  (modules data_source)
  (libraries
+   result
    rpclib.core
-   threads
+   rresult
    xapi-idl
    xapi-rrd
  )
@@ -16,8 +17,9 @@
  (public_name xapi-idl.rrd.interface)
  (modules rrd_interface)
  (libraries
+   result
    rpclib.core
-   threads
+   rresult
    xapi-idl
    xapi-idl.rrd.interface.types
    xapi-rrd
@@ -31,9 +33,10 @@
  (modules (:standard \ data_source rrd_interface rrd_cli))
  (libraries
    rpclib.core
-   threads
+   threads.posix
    xapi-idl
-   xapi-idl.rrd.interface
+   (re_export xapi-idl.rrd.interface)
+   (re_export xapi-idl.rrd.interface.types)
    xapi-rrd
  )
  (wrapped false)
@@ -44,8 +47,11 @@
  (modules rrd_cli)
  (libraries
    cmdliner
+   dune-build-info
    rpclib.cmdliner
+   rpclib.core
    rpclib.markdown
+   xapi-idl
    xapi-idl.rrd
  ))
 

--- a/ocaml/xapi-idl/storage/dune
+++ b/ocaml/xapi-idl/storage/dune
@@ -3,7 +3,9 @@
  (public_name xapi-idl.storage.interface.types)
  (modules vdi_automaton)
  (libraries
+   result
    rpclib.core
+   rresult
    threads
    xapi-idl
  )
@@ -16,11 +18,14 @@
  (modules storage_interface)
  (libraries
    astring
+   result
    rpclib.core
-   threads
+   rpclib.json
+   rresult
    xapi-stdext-date
    xapi-idl
    xapi-idl.storage.interface.types
+   xapi-log
  )
  (wrapped false)
  (preprocess (pps ppx_sexp_conv ppx_deriving_rpc)))
@@ -33,7 +38,7 @@
     vdi_automaton_test))
  (libraries
    rpclib.core
-   threads
+   threads.posix
    xapi-idl
    xapi-idl.storage.interface
    xapi-stdext-date
@@ -41,14 +46,16 @@
  (wrapped false)
  (preprocess (pps ppx_sexp_conv ppx_deriving_rpc)))
 
-(executable
+(test
  (name storage_test)
  (modules storage_test)
  (libraries
    alcotest
    cmdliner
+   dune-build-info
    xapi-idl
    xapi-idl.storage
+   xapi-idl.storage.interface
  )
  (preprocess (pps ppx_sexp_conv ppx_deriving_rpc)))
 
@@ -57,6 +64,7 @@
  (modules suite vdi_automaton_test)
  (libraries
    alcotest
+   dune-build-info
    xapi-idl.storage.interface
    xapi-idl.storage.interface.types
  )

--- a/ocaml/xapi-idl/v6/dune
+++ b/ocaml/xapi-idl/v6/dune
@@ -3,9 +3,12 @@
  (public_name xapi-idl.v6)
  (modules (:standard \ v6_cli))
  (libraries
+   result
    rpclib.core
-   threads
+   rresult
+   threads.posix
    xapi-idl
+   xapi-log
  )
  (wrapped false)
  (preprocess (pps ppx_deriving_rpc)))
@@ -15,9 +18,13 @@
  (modules v6_cli)
  (libraries
    cmdliner
+   dune-build-info
    rpclib.cmdliner
+   rpclib.core
    rpclib.markdown
+   xapi-idl
    xapi-idl.v6
+   xapi-log
  ))
 
 (rule

--- a/ocaml/xapi-idl/varstore/deprivileged/dune
+++ b/ocaml/xapi-idl/varstore/deprivileged/dune
@@ -6,6 +6,7 @@
    rpclib.core
    threads
    xapi-idl.xen
+   xapi-idl.xen.interface
    xcp
  )
  (wrapped false)
@@ -16,8 +17,11 @@
  (modules varstore_deprivileged_cli)
  (libraries
    cmdliner
+   dune-build-info
    rpclib.cmdliner
+   rpclib.core
    rpclib.markdown
+   xapi-idl
    xapi-idl.varstore.deprivileged
  ))
 

--- a/ocaml/xapi-idl/varstore/privileged/dune
+++ b/ocaml/xapi-idl/varstore/privileged/dune
@@ -3,8 +3,9 @@
  (public_name xapi-idl.varstore.privileged)
  (modules (:standard \ varstore_privileged_cli))
  (libraries
+   result
    rpclib.core
-   threads
+   rresult
    uuidm
    xcp
  )
@@ -16,8 +17,11 @@
  (modules varstore_privileged_cli)
  (libraries
    cmdliner
+   dune-build-info
    rpclib.cmdliner
+   rpclib.core
    rpclib.markdown
+   xapi-idl
    xapi-idl.varstore.privileged
  ))
 

--- a/ocaml/xapi-idl/xen/dune
+++ b/ocaml/xapi-idl/xen/dune
@@ -3,7 +3,11 @@
  (public_name xapi-idl.xen.interface.types)
  (modules xenops_types device_number)
  (libraries
+   result
    rpclib.core
+   rresult
+   sexplib
+   sexplib0
    threads
    xapi-idl
  )
@@ -15,10 +19,12 @@
  (public_name xapi-idl.xen.interface)
  (modules xenops_interface)
  (libraries
+   result
    rpclib.core
-   threads
+   rresult
    xapi-idl
    xapi-idl.xen.interface.types
+   xapi-log
  )
  (wrapped false)
  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv)))
@@ -28,7 +34,9 @@
  (public_name xapi-idl.xen)
  (modules (:standard \ device_number xenops_interface xenops_types))
  (libraries
+   result
    rpclib.core
+   rpclib.json
    threads
    xapi-idl
    xapi-idl.xen.interface

--- a/ocaml/xapi-storage-cli/dune
+++ b/ocaml/xapi-storage-cli/dune
@@ -1,11 +1,13 @@
 (executable
   (name main)
   (libraries
+    dune-build-info
     xapi-idl
     xapi-idl.storage
+    xapi-idl.storage.interface
     re
     re.str
-    rpclib
+    rpclib.core
     rpclib.json
     cmdliner
     threads

--- a/ocaml/xapi-storage-script/dune
+++ b/ocaml/xapi-storage-script/dune
@@ -1,19 +1,34 @@
 (executable
   (name main)
   (libraries
+    async
     async_inotify
+    async_kernel
+    async_unix
+    base
+    base.caml
+    core
+    core_kernel
+    dune-build-info
     message-switch-async
     message-switch-unix
-    rpclib
+    result
+    rpclib.core
+    rpclib.json
     rpclib-async
     sexplib
-    threads
+    sexplib0
+    uri
+    xapi-backtrace
     xapi-consts.xapi_version
-    xapi-stdext-date
-    xapi-storage
     xapi-idl
     xapi-idl.rrd
     xapi-idl.storage
+    xapi-idl.storage.interface
+    xapi-log
+    xapi-rrd
+    xapi-stdext-date
+    xapi-storage
   )
   (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )

--- a/ocaml/xapi-storage/generator/lib/dune
+++ b/ocaml/xapi-storage/generator/lib/dune
@@ -4,7 +4,9 @@
   (modules apis common control data files plugin task)
   (preprocess (pps ppx_deriving_rpc))
   (libraries
-    rpclib
+    result
+    rpclib.core
+    rresult
   )
 )
 

--- a/ocaml/xapi-storage/generator/src/dune
+++ b/ocaml/xapi-storage/generator/src/dune
@@ -4,6 +4,7 @@
     xapi-storage
     unix
     cmdliner
+    rpclib.core
     rpclib.markdown
   )
 )

--- a/ocaml/xapi-storage/generator/test/dune
+++ b/ocaml/xapi-storage/generator/test/dune
@@ -2,8 +2,11 @@
   (name storage_test)
   (libraries
     alcotest
+    fmt
     lwt
     lwt.unix
+    rpclib.core
+    rpclib.xml
     xapi_storage
   )
 )

--- a/ocaml/xapi-types/dune
+++ b/ocaml/xapi-types/dune
@@ -16,8 +16,9 @@
     astring
     http-svr
     rpclib.core
+    rpclib.json
     rpclib.xml
-    threads
+    uuid
     xapi-consts
     xapi-stdext-date
     xapi-stdext-unix

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -105,6 +105,7 @@
     unixpwd
     uri
     uuid
+    uuidm
     x509
     xapi_aux
     xapi-backtrace
@@ -132,6 +133,8 @@
     xapi-idl.gpumon
     xapi-idl.updates
     xapi-inventory
+    xapi-log
+    xapi-open-uri
     xapi-rrd
     xapi-types
     xapi-stdext-date
@@ -161,6 +164,7 @@
   (libraries
     xapi_internal
     xapi-idl
+    xapi-log
     xapi-stdext-unix
   )
 )

--- a/ocaml/xcp-rrdd/bin/read-blktap-stats/dune
+++ b/ocaml/xcp-rrdd/bin/read-blktap-stats/dune
@@ -4,6 +4,7 @@
   (package rrdd-plugins)
   (public_name xcp-rrdd-read-blktap-stats)
   (libraries
+    cstruct
     rrdd-plugins.libs
     unix
   )

--- a/ocaml/xcp-rrdd/bin/rrdd/dune
+++ b/ocaml/xcp-rrdd/bin/rrdd/dune
@@ -5,23 +5,31 @@
   (libraries
     astring
     dune-build-info
+    ezxenstore
     gzip
     http-svr
     inotify
     mtime
     mtime.clock.os
+    rpclib.core
+    rrd-transport
+    rrd-transport.lib
+    stunnel
     systemd
+    threads.posix
+    uuid
     xapi-backtrace
+    xapi-consts
+    xapi-idl.network
+    xapi-idl.rrd
+    xapi-inventory
+    xapi-log
     xapi-rrd
     xapi-rrd.unix
-    rrd-transport
     xapi-rrdd
     xapi-stdext-threads
     xapi-stdext-unix
-    xapi-consts
-    ezxenstore
-    xapi-idl.network
-    uuid
+    xmlm
   )
   (preprocess (pps ppx_deriving_rpc))
 )
@@ -33,10 +41,36 @@
   (package xapi-rrdd)
   (modules xcp_rrdd)
   (libraries
+    astring
+    dune-build-info
+    ezxenstore.core
+    ezxenstore.watch
+    forkexec
     http-svr
+    inotify
+    rpclib.core
+    rpclib.json
+    rpclib.xml
     rrdd_libs_internal
+    rrd-transport
+    systemd
+    threads.posix
+    uuid
     xapi-backtrace
+    xapi-consts.xapi_version
     xapi-idl
+    xapi-idl.network
+    xapi-idl.rrd
+    xapi-log
+    xapi-rrd
+    xapi-rrdd
+    xapi-stdext-pervasives
+    xapi-stdext-threads
+    xapi-stdext-unix
+    xenctrl
+    xenstore
+    xenstore.unix
+    xenstore_transport.unix
   )
 )
 

--- a/ocaml/xcp-rrdd/bin/rrddump/dune
+++ b/ocaml/xcp-rrdd/bin/rrddump/dune
@@ -3,8 +3,11 @@
   (name rrddump)
   (public_name rrddump)
   (libraries
-    threads
+    dune-build-info
+    rrd-transport
+    xapi-rrd
     xapi-rrd.unix
+    xmlm
   )
   (package rrddump)
 )

--- a/ocaml/xcp-rrdd/bin/rrdp-dummy/dune
+++ b/ocaml/xcp-rrdd/bin/rrdp-dummy/dune
@@ -3,7 +3,10 @@
   (public_name rrdp_dummy)
   (package xapi-rrdd-plugin)
   (libraries
+    dune-build-info
     rrdd-plugin
+    xapi-idl.rrd
+    xapi-rrd
     xenstore.unix
     xenstore_transport.unix
   )

--- a/ocaml/xcp-rrdd/bin/rrdp-iostat/dune
+++ b/ocaml/xcp-rrdd/bin/rrdp-iostat/dune
@@ -4,18 +4,29 @@
   (package rrdd-plugins)
   (public_name xcp-rrdd-iostat)
   (libraries
+    astring
+    cstruct
+    dune-build-info
+    ezxenstore.core
+    inotify
+    mtime
+    mtime.clock.os
     rrdd-plugin
     rrdd-plugins.libs
-    xapi-stdext-std
-    xapi-stdext-unix
     str
-    threads
+    stringext
+    threads.posix
     uuid
-    ezxenstore
+    xapi-idl.rrd
+    xapi-log
+    xapi-rrd
+    xapi-stdext-std
+    xapi-stdext-threads
+    xapi-stdext-unix
     xenctrl
+    xenstore
     xenstore.unix
-    inotify
-    mtime.clock.os
+    xenstore_transport
   )
 )
 

--- a/ocaml/xcp-rrdd/bin/rrdp-squeezed/dune
+++ b/ocaml/xcp-rrdd/bin/rrdp-squeezed/dune
@@ -4,11 +4,19 @@
   (package rrdd-plugins)
   (public_name xcp-rrdd-squeezed)
   (libraries
+    dune-build-info
     rrdd-plugin
     rrdd-plugins.libs
     xapi-stdext-std
-    threads
     ezxenstore
+    ezxenstore.watch
+    xapi-idl.rrd
+    xapi-log
+    xapi-rrd
+    xenctrl
+    xenstore
+    xenstore.unix
+    xenstore_transport
   )
 )
 

--- a/ocaml/xcp-rrdd/bin/rrdp-xenpm/dune
+++ b/ocaml/xcp-rrdd/bin/rrdp-xenpm/dune
@@ -4,10 +4,13 @@
   (package rrdd-plugins)
   (public_name xcp-rrdd-xenpm)
   (libraries
+    dune-build-info
     rrdd-plugin
     rrdd-plugins.libs
     str
-    threads
+    xapi-idl.rrd
+    xapi-log
+    xapi-rrd
     xenctrl
   )
 )

--- a/ocaml/xcp-rrdd/bin/transport-rw/dune
+++ b/ocaml/xcp-rrdd/bin/transport-rw/dune
@@ -5,8 +5,11 @@
   (package xapi-rrd-transport-utils)
   (libraries
     cmdliner
-    threads
+    dune-build-info
     rrd-transport
+    threads.posix
+    xapi-idl.rrd
+    xapi-rrd
   )
 )
 

--- a/ocaml/xcp-rrdd/lib/plugin/dune
+++ b/ocaml/xcp-rrdd/lib/plugin/dune
@@ -11,10 +11,12 @@
     xapi-stdext-std
     xapi-stdext-threads
     xapi-stdext-unix
-    threads
+    threads.posix
     xapi-rrd
     rrd-transport.file
+    rrd-transport.lib
     xapi-idl.rrd
+    xapi-log
     xenstore_transport.unix
     xenstore.unix
   )
@@ -27,7 +29,14 @@
   (wrapped false)
   (modules reporter_local)
   (libraries
-    rrdd_plugin_base
+    rrdd-plugin.base
+    rrd-transport.file
+    rrd-transport.lib
+    threads.posix
+    xapi-idl.rrd
+    xapi-log
+    xapi-stdext-threads
+    xapi-stdext-unix
   )
 )
 
@@ -38,8 +47,13 @@
   (wrapped false)
   (modules reporter_interdomain)
   (libraries
-    rrdd_plugin_base
+    rrdd-plugin.base
+    rrd-transport.lib
     rrd-transport.page
+    threads.posix
+    xapi-idl.rrd.interface
+    xapi-log
+    xenstore_transport.unix
   )
 )
 
@@ -50,9 +64,15 @@
   (wrapped false)
   (modules rrdd_plugin)
   (libraries
-    rrdd_plugin_local
-    rrdd_plugin_interdomain
+    rrdd-plugin.base
+    rrdd-plugin.local
+    rrdd-plugin.interdomain
     rrd-transport
+    threads.posix
+    xapi-idl.rrd
+    xapi-idl.rrd.interface.types
+    xapi-log
+    xapi-rrd
   )
 )
 

--- a/ocaml/xcp-rrdd/lib/rrdd/dune
+++ b/ocaml/xcp-rrdd/lib/rrdd/dune
@@ -4,8 +4,9 @@
   (modules constants stats)
   (flags (:standard -bin-annot))
   (libraries
-    xapi-idl
-    threads
+    threads.posix
+    xapi-log
+    xapi-stdext-threads
   )
 )
 

--- a/ocaml/xcp-rrdd/lib/transport/base/dune
+++ b/ocaml/xcp-rrdd/lib/transport/base/dune
@@ -7,6 +7,8 @@
     bigarray
     crc
     cstruct
+    rpclib.core
+    rpclib.json
     xapi-rrd
     threads
     xapi-idl.rrd

--- a/ocaml/xcp-rrdd/lib/transport/file/dune
+++ b/ocaml/xcp-rrdd/lib/transport/file/dune
@@ -3,7 +3,10 @@
   (public_name rrd-transport.file)
   (wrapped false)
   (libraries
+    bigarray-compat
+    cstruct
     rrd_transport_lib
+    threads.posix
   )
 )
 

--- a/ocaml/xcp-rrdd/lib/transport/main/dune
+++ b/ocaml/xcp-rrdd/lib/transport/main/dune
@@ -3,8 +3,9 @@
   (public_name rrd-transport)
   (wrapped false)
   (libraries
-    rrd_transport_file
-    rrd_transport_page
+    (re_export rrd_transport_lib)
+    (re_export rrd_transport_file)
+    (re_export rrd_transport_page)
   )
 )
 

--- a/ocaml/xcp-rrdd/lib/transport/page/dune
+++ b/ocaml/xcp-rrdd/lib/transport/page/dune
@@ -3,7 +3,11 @@
   (public_name rrd-transport.page)
   (wrapped false)
   (libraries
+    bigarray-compat
+    cstruct
+    io-page.unix
     rrd_transport_lib
+    threads.posix
     xen-gnt
     xen-gnt-unix
   )

--- a/ocaml/xcp-rrdd/test/rrdd/dune
+++ b/ocaml/xcp-rrdd/test/rrdd/dune
@@ -2,8 +2,11 @@
   (name test_rrdd_monitor)
   (package xapi-rrdd)
   (libraries
-    oUnit
+    dune-build-info
+    ounit2
     rrdd_libs_internal
+    xapi-idl.rrd
+    xapi-rrd
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/xcp-rrdd/test/transport/dune
+++ b/ocaml/xcp-rrdd/test/transport/dune
@@ -2,8 +2,11 @@
   (names test_unit test_scale)
   (package rrd-transport)
   (libraries
-    oUnit
+    dune-build-info
+    ounit2
     rrd-transport
+    xapi-idl.rrd
+    xapi-rrd
   )
 )
 

--- a/ocaml/xe-cli/dune
+++ b/ocaml/xe-cli/dune
@@ -5,6 +5,7 @@
   (package xe)
   (libraries
     astring
+    dune-build-info
     fpath
     safe-resources
     stunnel

--- a/ocaml/xen-api-client/async/dune
+++ b/ocaml/xen-api-client/async/dune
@@ -3,13 +3,18 @@
   (public_name xen-api-client-async)
   (libraries
     async
+    async_kernel
     async_unix
+    base
     cohttp
     core
-    rpclib
+    core_kernel
+    rpclib.core
     rpclib.json
-    threads
+    rpclib.xml
     uri
+    xapi-client
+    xapi-consts
     xen-api-client
     xmlm
   )

--- a/ocaml/xen-api-client/async_examples/dune
+++ b/ocaml/xen-api-client/async_examples/dune
@@ -3,10 +3,15 @@
   (name list_vms)
   (modules list_vms)
   (libraries
-    core
     async
     async_unix
-    threads
+    base
+    base.caml
+    core
+    core_kernel
+    dune-build-info
+    xapi-consts
+    xapi-types
     xen-api-client
     xen-api-client-async
   )
@@ -17,10 +22,18 @@
   (name event_test)
   (modules event_test)
   (libraries
-    core
     async
     async_unix
-    threads
+    base
+    base.caml
+    core
+    core_kernel
+    dune-build-info
+    ppx_sexp_conv.runtime-lib
+    rpclib.json
+    sexplib0
+    xapi-consts
+    xapi-types
     xen-api-client
     xen-api-client-async
   )

--- a/ocaml/xen-api-client/lib_test/dune
+++ b/ocaml/xen-api-client/lib_test/dune
@@ -2,7 +2,12 @@
   (modes byte exe)
   (name xen_api_test)
   (libraries
-    oUnit
+    dune-build-info
+    rpclib.xml
+    ounit2
+    uri
+    xapi-client
+    xapi-types
     xen-api-client
   )
 )

--- a/ocaml/xen-api-client/lwt/dune
+++ b/ocaml/xen-api-client/lwt/dune
@@ -2,16 +2,24 @@
   (name xen_api_client_lwt)
   (public_name xen-api-client-lwt)
   (libraries
+    astring
+    bigarray-compat
     cohttp
     cstruct
     lwt
     lwt_ssl
     lwt.unix
     re.str
-    rpclib
+    rpclib.core
     rpclib.json
+    rpclib.xml
+    ssl
     uri
+    xapi-client
+    xapi-consts
+    xapi-idl.varstore.privileged
     xapi-stdext-std
+    xapi-types
     xen-api-client
     xmlm
   )

--- a/ocaml/xen-api-client/lwt_examples/dune
+++ b/ocaml/xen-api-client/lwt_examples/dune
@@ -3,8 +3,11 @@
   (name list_vms)
   (modules list_vms)
   (libraries
+    dune-build-info
     lwt
     lwt.unix
+    xapi-consts
+    xapi-types
     xen-api-client
     xen-api-client-lwt
   )
@@ -15,8 +18,13 @@
   (name upload_disk)
   (modules upload_disk)
   (libraries
+    cstruct
+    dune-build-info
     lwt
     lwt.unix
+    uri
+    xapi-consts
+    xapi-types
     xen-api-client
     xen-api-client-lwt
   )
@@ -27,9 +35,16 @@
   (name watch_metrics)
   (modules watch_metrics)
   (libraries
+    cohttp
+    cohttp-lwt
     cohttp-lwt-unix
+    dune-build-info
     lwt
     lwt.unix
+    uri
+    xapi-consts
+    xapi-rrd
+    xapi-types
     xen-api-client
     xen-api-client-lwt
   )

--- a/ocaml/xenforeign/dune
+++ b/ocaml/xenforeign/dune
@@ -1,4 +1,4 @@
 (executable
   (name main)
-  (libraries xenopsd_xc hex)
+  (libraries bigarray-compat cstruct dune-build-info xenctrl xenopsd_xc hex)
   )

--- a/ocaml/xenopsd/cli/dune
+++ b/ocaml/xenopsd/cli/dune
@@ -6,7 +6,9 @@
   (public_name xenops-cli)
   (package xapi-xenopsd-cli)
   (libraries
+      astring
       cmdliner
+      dune-build-info
       re
       result
       rpclib.core
@@ -14,10 +16,12 @@
       rresult
       threads
       uuid
+      uuidm
       xapi-idl
       xapi-idl.xen
       xapi-idl.xen.interface
       xapi-idl.xen.interface.types
+      xapi-stdext-pervasives
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/xenopsd/dbgring/dune
+++ b/ocaml/xenopsd/dbgring/dune
@@ -3,8 +3,10 @@
  (public_name dbgring)
  (package xapi-xenopsd-xc)
  (libraries
+   dune-build-info
    xapi-xenopsd
    xenctrl
+   xenctrl.xenmmap
    xenstore
    xenstore.unix
    xenstore_transport
@@ -13,7 +15,7 @@
    xapi-idl.xen
    rpclib.core
    uutf
-   xapi-idl
+   xapi-log
    rpclib.json
    xapi-stdext-pervasives
  )

--- a/ocaml/xenopsd/lib/dune
+++ b/ocaml/xenopsd/lib/dune
@@ -15,10 +15,13 @@
    result
    rpclib.core
    rpclib.json
+   rpclib.xml
    rresult
    sexplib
    sexplib0
+   stunnel
    uri
+   uuid
    uuidm
    uutf
    threads.posix
@@ -32,6 +35,8 @@
    xapi-idl.xen
    xapi-idl.xen.interface
    xapi-idl.xen.interface.types
+   xapi-log
+   xapi-open-uri
    xapi-stdext-date
    xapi-stdext-pervasives
    xapi-stdext-threads

--- a/ocaml/xenopsd/list_domains/dune
+++ b/ocaml/xenopsd/list_domains/dune
@@ -2,5 +2,5 @@
   (name list_domains)
   (public_name list_domains)
   (package xapi-xenopsd-xc)
-  (libraries xenctrl xapi-idl.memory ezxenstore.watch uuid)
+  (libraries dune-build-info xenctrl xapi-idl.memory ezxenstore.watch uuid)
 )

--- a/ocaml/xenopsd/simulator/dune
+++ b/ocaml/xenopsd/simulator/dune
@@ -3,6 +3,7 @@
  (public_name xenopsd-simulator)
  (package xapi-xenopsd-simulator)
  (libraries
+   dune-build-info
    xapi-idl.xen.interface
    xapi-xenopsd
  )

--- a/ocaml/xenopsd/suspend_image_viewer/dune
+++ b/ocaml/xenopsd/suspend_image_viewer/dune
@@ -3,7 +3,11 @@
  (libraries
   cmdliner
   forkexec
+  result
+  uuid
+  xapi-consts.xapi_version
   xapi-idl
+  xapi-log
   xapi-stdext-unix
   xapi-xenopsd
  )

--- a/ocaml/xenopsd/test/dune
+++ b/ocaml/xenopsd/test/dune
@@ -3,6 +3,7 @@
  (package xapi-xenopsd)
  (libraries
   alcotest
+  dune-build-info
   fmt
   result
   rpclib.core
@@ -10,6 +11,7 @@
   xapi-idl
   xapi-idl.xen.interface
   xapi-idl.xen.interface.types
+  xapi-log
   xapi-stdext-pervasives
   xapi-xenopsd
   xenstore_transport.unix

--- a/ocaml/xenopsd/xc/dune
+++ b/ocaml/xenopsd/xc/dune
@@ -8,6 +8,7 @@
           cancel_utils_test)
  (libraries
   astring
+  base64
   ezxenstore.core
   ezxenstore.watch
   fd-send-recv
@@ -26,16 +27,18 @@
   qmp
   threads.posix
   uuid
+  uuidm
   xapi-backtrace
   xapi-idl
   xapi-idl.memory
   xapi-idl.network
   xapi-idl.rrd
-  xapi-idl.rrd.interface
   xapi-idl.storage
   xapi-idl.storage.interface
+  xapi-idl.varstore.privileged
   xapi-idl.xen.interface
   xapi-idl.xen.interface.types
+  xapi-log
   xapi-rrd
   xapi-stdext-date
   xapi-stdext-pervasives
@@ -63,9 +66,10 @@
  (modules xenops_xc_main)
 
  (libraries
+  dune-build-info
   ezxenstore.core
   uuid
-  xapi-idl.varstore.privileged
+  xapi-idl
   xapi-idl.xen.interface
   xapi-inventory
   xapi-stdext-unix
@@ -82,6 +86,7 @@
  (libraries
   astring
   cmdliner
+  dune-build-info
   ezxenstore.core
   uuid
   xapi-idl.memory
@@ -97,6 +102,7 @@
  (name memory_summary)
  (modules memory_summary)
  (libraries
+  dune-build-info
   xapi-stdext-date
   xapi-stdext-unix
   xapi-xenopsd
@@ -119,6 +125,7 @@
  (modules cancel_utils_test)
  (libraries
   cmdliner
+  dune-build-info
   ezxenstore.core
   threads.posix
   xapi-idl.xen.interface

--- a/ocaml/xsh/dune
+++ b/ocaml/xsh/dune
@@ -4,9 +4,9 @@
   (public_name xsh)
   (package xapi)
   (libraries
+    dune-build-info
     stunnel
     safe-resources
-    threads
   )
 )
 

--- a/scripts/examples/python/dune
+++ b/scripts/examples/python/dune
@@ -2,6 +2,7 @@
   (modes byte exe)
   (name setuppy_gen)
   (libraries
+    dune-build-info
     xapi-stdext-unix
     xapi-datamodel
   )


### PR DESCRIPTION
Previously a lot of libraries were used but not declared because a dependent library was declared pulled them.

To enable the explicit mode `(implicit_transitive_deps false)` needs to be added to `dune-project`. I believe enabling it requires a high bar of knowledge around libraries, so it's best to leave it disabled. For example, the error when not importing declaring `dune-build-info` when it's needed is indecipherable:
```
File "ocaml/gencert/.gencert.eobjs/build_info_data.ml-gen", line 1:
Error: Could not find the .cmi file for interface
       ocaml/gencert/.gencert.eobjs/build_info_data.ml-gen.
```

While dune does not warn of unused libraries, I've removed some unused libraries, like xapi-idl (because only xapi-log was being used), or threads, which is not needed anymore as dune assumes `-mt` and forces linking against `threads.posix`anyway. Read https://dune.readthedocs.io/en/stable/dune-files.html?highlight=threads#implicit-transitive-deps-1 and https://dune.readthedocs.io/en/stable/advanced-topics.html?highlight=threads#findlib-integration

For users of the gzip and zstd I've decided to reexport the symbols from the library xapi-compression. I saw little value in forcing users to declare both.