### PR TITLE
CP-40754 Update host.https_only field in dbsync based on firewall state

### DIFF
--- a/scripts/plugins/firewall-port
+++ b/scripts/plugins/firewall-port
@@ -47,10 +47,19 @@ case "${OP}" in
             service iptables save
         fi
         ;;
+    check) 
+        if [[ -z `iptables -S $CHAIN | grep " $PORT "` ]]
+        then
+            echo "Port $PORT open: true"
+        else
+            echo "Port $PORT open: false"
+        fi
+        ;;
     *)
-        echo $"Usage: $0 {open|close} {port} {protocol}" 1>&2
+        echo $"Usage: $0 {open|close|check} {port} {protocol}" 1>&2
         exit 1
         ;;
 esac
+
 exit 0
 


### PR DESCRIPTION
The firewall-port script returns true if port 80 is blocked … and false if it is closed, this is captured in set_https_only to update the DB based on the state of the network, not the requested setting should there be a failure

Signed-off-by: jameshensmancitrix <james.hensman@citrix.com>