### PR TITLE
CA-370140: shut down swtpm after qemu

### DIFF
--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -2267,7 +2267,7 @@ module Dm_Common = struct
       Service.Varstored.stop ~xs domid ;
       Xenops_sandbox.Varstore_guard.stop dbg ~domid ~vm_uuid
     in
-    stop_vgpu () ; stop_varstored () ; stop_swptm () ; stop_qemu ()
+    stop_vgpu () ; stop_varstored () ; stop_qemu () ; stop_swptm ()
 
   type disk_type_args = int * string * Media.t -> string list
 


### PR DESCRIPTION
Qemu sends a signal to swtpm to cleanly shut down, this means that Qemu needs to be shut down before SWTPM, and it also means that it's normal behaviour that SWTPM shuts down itself as a consequence of this.

This means that on successful attempts this loglines will be printed when xenopsd tries to shut the service down:
```
Oct  6 14:23:13 x-11-58 xenopsd-xc: [debug||17 |events|service] About to stop vTPM (73a7dbe6-1ea8-b04b-aeea-5b3b524386d1) for domain 1 (9e2bff38-0c30-a9fe-2420-4c7f0fa1f2b4)
Oct  6 14:23:13 x-11-58 xenopsd-xc: [ info||17 |events|service] Not trying to stop swtpm-wrapper-1 since it's not running
Oct  6 14:23:13 x-11-58 xenopsd-xc: [debug||17 |events|service] Storing vTPM state of 6791 bytes
Oct  6 14:23:13 x-11-58 xenopsd-xc: [debug||17 |events|xenops_sandbox] About to stop swtpm for 1 (9e2bff38-0c30-a9fe-2420-4c7f0fa1f2b4) File "ocaml/xenopsd/lib/xenops_sandbox.ml", line 185, characters 69-76
```

Note that trying to shut SWTPM is still needed in case there's an error in this procedure.