### PR TITLE
CA-364194: Allow creation of statefiles to time out 

### DIFF
--- a/ocaml/xapi/static_vdis.ml
+++ b/ocaml/xapi/static_vdis.ml
@@ -36,7 +36,7 @@ let permanent_vdi_attach ~__context ~vdi ~reason =
       )
   ) ;
   ignore
-    (Helpers.call_script !Xapi_globs.static_vdis
+    (Helpers.call_script ~timeout:60.0 !Xapi_globs.static_vdis
        ["add"; Db.VDI.get_uuid ~__context ~self:vdi; reason]
     ) ;
   (* VDI will be attached on next boot; attach it now too *)

--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -20,6 +20,8 @@ def call_volume_plugin(name, command, args):
              + command), "static-vdis"]
     if args:
         cmd_args.extend(args)
+    # on Python >= 3.3 a timout can be set, not on 2.7
+    # when porting please add a timeout
     output = subprocess.check_output(cmd_args)
     return json.loads(output)
 


### PR DESCRIPTION
Currently enabling HA can stall because the GFS2 calls when adding the
HA statefile might stall indefinitely when there are connection issues

Now xapi waits a minute before failing, signalling the user that
something has gone awry

Unfortunately using Python 2.7 blocks us from having a timeout in static-vdis, added a comment so it has more chances of getting added when porting to python 3.5+

Xapi helpers now will also print when a script is called without a callback so it's easier to spot similar situations

I've also converted this infrastructure to [mtime](https://github.com/xapi-project/xen-api/compare/master...psafont:xen-api:private/paus/its-about-mtime?expand=1), but it got big and it's better that this goes in independently