### PR TITLE
Add a fallback system for auth files belonging to RPMs

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -846,7 +846,11 @@ let nbd_client_manager_script =
 
 let varstore_rm = ref "/usr/bin/varstore-rm"
 
-let varstore_dir = ref "/usr/share/varstored"
+let varstore_dir = ref "/var/lib/varstored"
+
+let default_auth_dir = ref "/usr/share/varstored"
+
+let override_auths = ref false
 
 let disable_logging_for = ref []
 
@@ -1397,6 +1401,11 @@ let other_options =
     , (fun () -> string_of_bool !ignore_vtpm_unimplemented)
     , "Do not raise errors on use-cases where VTPM codepaths are not finished."
     )
+  ; ( "override_auths"
+    , Arg.Set override_auths
+    , (fun () -> string_of_bool !override_auths)
+    , "Allow to override auth files with default ones when missing"
+    )
   ]
 
 (* The options can be set with the variable xapiflags in /etc/sysconfig/xapi.
@@ -1553,6 +1562,7 @@ module Resources = struct
       , "Executed to clear certain UEFI variables during clone"
       )
     ; ("varstore_dir", varstore_dir, "Path to local varstored directory")
+    ; ("default_auth_dir", default_auth_dir, "Directory for default auth files")
     ; ( "nvidia-sriov-manage"
       , nvidia_sriov_manage_script
       , "Path to NVIDIA sriov-manage script"

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3588,6 +3588,12 @@ let disable_repository_proxy ~__context ~self =
     )
 
 let set_uefi_certificates ~__context ~self ~value =
+  if not !Xapi_globs.override_auths then
+    raise
+      Api_errors.(
+        Server_error (operation_not_allowed, ["Disabled by xapi.conf"])
+      ) ;
+
   Db.Pool.set_uefi_certificates ~__context ~self ~value ;
   Helpers.call_api_functions ~__context (fun rpc session_id ->
       List.iter


### PR DESCRIPTION
This is an implementation of what was proposed in [this comment](https://github.com/xapi-project/xen-api/pull/4689#issuecomment-1103919868) and a rework of [this commit](https://github.com/xapi-project/xen-api/commit/6ad054a4baa39e0356e3c1001e2f557de3a56d50).

- Erase all auth files at XAPI startup, PK and dbx included

- If after the extract of the tarball all auth files are missing: fetch them from a default dir and copy them in the varstore directory

- New XAPI conf entry: `default_auth_dir`: Path for default auth files installed by RPMs

- New XAPI conf entry: `override_auths`: Allow to override the auth files It means that `{Host/Pool}.set_uefi_certificates` will throw a `operation_not_allowed` error if the entry is set to `false` to prevent a user to edit the auth files with its own custom ones

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>