### PR TITLE
CA-369446 

### DIFF
--- a/ocaml/xenopsd/scripts/setup-vif-rules
+++ b/ocaml/xenopsd/scripts/setup-vif-rules
@@ -23,7 +23,7 @@ import sys
 import syslog
 import time
 import common
-from common import send_to_syslog, doexec
+from common import ON_ERROR_FAIL, send_to_syslog, doexec, run
 
 path = "/sbin:/usr/sbin:/bin:/usr/bin"
 
@@ -203,7 +203,7 @@ def make_vswitch_external_ids(vif):
 def add_vswitch_port(bridge_name, vif):
     args = [vsctl, "--timeout=30", "add-port", bridge_name, vif.vif_name]
     args += make_vswitch_external_ids(vif)
-    doexec(args)
+    run(ON_ERROR_FAIL, args)
     set_xs_ofport_path(vif)
     setup_pvs_proxy_rules(vif, "add")
 


### PR DESCRIPTION
Change the use of doexec in add_vswitch_port to run using the ON_ERROR_FAIL handler. This will prevent the VM from starting in the case of ovs-vsctl failing.

Signed-off-by: jameshensmancitrix <james.hensman@citrix.com>