### PR TITLE
CA-352073: Ensure all serialized calls can pass rbac checks 

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -50,13 +50,8 @@ let debug msg args =
     ""
 
 let has_default_args args =
-  let arg_has_default arg =
-    match arg.DT.param_default with None -> false | Some _ -> true
-  in
-  let any_defaults =
-    List.fold_left (fun e x -> e || x) false (List.map arg_has_default args)
-  in
-  any_defaults
+  let has_default arg = Option.is_some arg.DT.param_default in
+  List.exists has_default args
 
 (* ------------------------------------------------------------------------------------------
     Code to generate a single operation in server dispatcher
@@ -76,11 +71,8 @@ let count_mandatory_message_parameters (msg : message) =
 
 let operation (obj : obj) (x : message) =
   let msg_params = x.DT.msg_params in
-  let msg_params_with_default_values =
-    List.filter (fun p -> p.DT.param_default <> None) msg_params
-  in
-  let msg_params_without_default_values =
-    List.filter (fun p -> p.DT.param_default = None) msg_params
+  let msg_params_with_default_values, msg_params_without_default_values =
+    List.partition (fun p -> p.DT.param_default <> None) msg_params
   in
   let msg_without_default_values =
     {x with DT.msg_params= msg_params_without_default_values}
@@ -141,19 +133,19 @@ let operation (obj : obj) (x : message) =
     let of_field f =
       let binding = O.string_of_param (Client.param_of_field f) in
       let converter = Printf.sprintf "%s_of_rpc" (OU.alias_of_ty f.DT.ty) in
+      let wire_name = Printf.sprintf {|"%s"|} (DU.wire_name_of_field f) in
       let lookup_expr =
         match f.DT.default_value with
         | None ->
-            Printf.sprintf "(my_assoc \"%s\" __structure)"
-              (DU.wire_name_of_field f)
+            Printf.sprintf "(my_assoc %s __structure)" wire_name
         | Some default ->
             Printf.sprintf
-              "(if (List.mem_assoc \"%s\" __structure) then (my_assoc \"%s\" \
-               __structure) else %s)"
-              (DU.wire_name_of_field f) (DU.wire_name_of_field f)
+              "((List.assoc_opt %s __structure) |> Option.value ~default:(%s))"
+              wire_name
               (Datamodel_values.to_ocaml_string default)
       in
-      Printf.sprintf "        let %s = %s %s in" binding converter lookup_expr
+      Printf.sprintf "            let %s = %s %s in" binding converter
+        lookup_expr
     in
     String.concat "\n"
       ("let __structure = match __structure_rpc with Dict d -> d | _ -> \
@@ -197,9 +189,6 @@ let operation (obj : obj) (x : message) =
       ]
   in
   (* Generate the unmarshalling code *)
-  let rec add_counts i l =
-    match l with [] -> [] | x :: xs -> (i, x) :: add_counts (i + 1) xs
-  in
   let has_session_arg =
     if is_ctor then
       is_session_arg Client.session
@@ -252,14 +241,14 @@ let operation (obj : obj) (x : message) =
         args_without_default_values
     )
     (* and for every default value we try to get this from default_args or default it *)
-    @ List.map
-        (fun (param_count, default_param) ->
+    @ List.mapi
+        (fun param_count default_param ->
           let param_name =
             OU.ocaml_of_record_name default_param.DT.param_name
           in
           let param_type = OU.alias_of_ty default_param.DT.param_type in
           let try_and_get_default =
-            Printf.sprintf "Server_helpers.nth %d default_args" param_count
+            Printf.sprintf "List.nth default_args %d" param_count
           in
           let default_value =
             match default_param.DT.param_default with
@@ -271,7 +260,7 @@ let operation (obj : obj) (x : message) =
           Printf.sprintf "let %s = %s_of_rpc (try %s with _ -> %s) in"
             param_name param_type try_and_get_default default_value
         )
-        (add_counts 1 msg_params_with_default_values)
+        msg_params_with_default_values
   in
   let may_be_side_effecting msg =
     match msg.msg_tag with
@@ -477,12 +466,10 @@ let gen_module api : O.Module.t =
                    http_req.Http.Request.subtask_of in"
                 ; "let http_other_config = Context.get_http_other_config \
                    http_req in"
-                ; "let may f = function | None -> None | Some x -> Some (f x) \
-                   in"
                 ; "Server_helpers.exec_with_new_task \
                    (\"dispatch:\"^__call^\"\") ~http_other_config \
-                   ?subtask_of:(may Ref.of_string subtask_of) (fun __context \
-                   ->"
+                   ?subtask_of:(Option.map Ref.of_string subtask_of) (fun \
+                   __context ->"
                 ; "Server_helpers.dispatch_exn_wrapper (fun () -> (match \
                    __call with "
                 ]

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -117,15 +117,14 @@ let operation (obj : obj) (x : message) =
   let is_non_constructor_with_defaults =
     (not is_ctor) && has_default_args x.DT.msg_params
   in
-  let arg_pattern = String.concat "::" string_args in
   let arg_pattern =
     if is_non_constructor_with_defaults then
-      arg_pattern ^ "::default_args"
+      String.concat " :: " (string_args @ ["default_args"])
     else
-      arg_pattern ^ "::[]"
+      Printf.sprintf "[%s]" (String.concat "; " string_args)
   in
   let name_pattern_match =
-    Printf.sprintf "| \"%s\" | \"%s\" -> " wire_name alternative_wire_name
+    Printf.sprintf {|| "%s" | "%s" -> |} wire_name alternative_wire_name
   in
   (* Lookup the various fields from the constructor record *)
   let from_ctor_record =
@@ -197,33 +196,29 @@ let operation (obj : obj) (x : message) =
   in
   let rbac_check_begin =
     if has_session_arg then
+      let serialize_list lst =
+        String.concat "; " lst |> Printf.sprintf "[%s]"
+      in
+      let serialize_name_list lst =
+        List.map (Printf.sprintf {|"%s"|}) lst |> serialize_list
+      in
+      let default_arg_name_params =
+        if is_non_constructor_with_defaults then
+          List.map (fun dp -> dp.DT.param_name) msg_params_with_default_values
+        else
+          []
+      in
+      let arg_names = orig_string_args @ default_arg_name_params in
+      let key_names = List.map fst x.msg_map_keys_roles in
       [
-        "let arg_names = "
-        ^ List.fold_right
-            (fun arg args -> "\"" ^ arg ^ "\"::" ^ args)
-            orig_string_args
-            ( if is_non_constructor_with_defaults then
-                List.fold_right
-                  (fun dp ss -> "\"" ^ dp.DT.param_name ^ "\"::" ^ ss)
-                  msg_params_with_default_values ""
-                ^ "[]"
-            else
-              "[]"
-            )
-        ^ " in"
-      ; "let key_names = "
-        ^ List.fold_right
-            (fun arg args -> "\"" ^ arg ^ "\"::" ^ args)
-            (List.map (fun (k, _) -> k) x.msg_map_keys_roles)
-            "[]"
-        ^ " in"
+        Printf.sprintf "let arg_names = %s in" (serialize_name_list arg_names)
+      ; Printf.sprintf "let key_names = %s in" (serialize_name_list key_names)
       ; "let rbac __context fn = Rbac.check session_id __call \
          ~args:(arg_names,__params) ~keys:key_names ~__context ~fn in"
       ]
     else
-      ["let rbac __context fn = fn() in"]
+      ["let rbac __context fn = fn () in"]
   in
-  let rbac_check_end = if has_session_arg then [] else [] in
   let unmarshall_code =
     (* If we are forwarding the call then we don't want to emit a warning
        because we know we don't need the arguments *)
@@ -293,7 +288,7 @@ let operation (obj : obj) (x : message) =
           "let host = ref_host_of_rpc host_rpc in"
         ; "let call_string = Jsonrpc.string_of_call {call with name=__call} in"
         ; "let marshaller = (fun x -> x) in"
-        ; "let local_op = fun ~__context ->(rbac __context \
+        ; "let local_op = fun ~__context -> (rbac __context \
            (fun()->(Custom.Host.call_extension \
            ~__context:(Context.check_for_foreign_database ~__context) ~host \
            ~call:call_string))) in"
@@ -389,7 +384,6 @@ let operation (obj : obj) (x : message) =
         @ session_check_exp
         @ rbac_check_begin
         @ gen_body ()
-        @ rbac_check_end
       else
         comments
         @ ["let session_id = ref_session_of_rpc session_id_rpc in"]
@@ -505,15 +499,15 @@ let gen_module api : O.Module.t =
                  ; "    then "
                    ^ debug "This is not a built-in rpc \"%s\"" ["__call"]
                  ; "    begin match __params with"
-                 ; "    | session_id_rpc::_->"
+                 ; "    | session_id_rpc :: _->"
                  ; "      let session_id = ref_session_of_rpc session_id_rpc in"
                  ; "      Session_check.check ~intra_pool_only:false \
                     ~session_id;"
                  ; "      (* based on the Host.call_extension call *)"
-                 ; "      let arg_names = \"session_id\"::__call::[] in"
+                 ; "      let arg_names = [\"session_id\"; __call] in"
                  ; "      let key_names = [] in"
                  ; "      let rbac __context fn = Rbac.check session_id \
-                    \"Host.call_extension\" ~args:(arg_names,__params) \
+                    \"Host.call_extension\" ~args:(arg_names, __params) \
                     ~keys:key_names ~__context ~fn in"
                  ; "      Server_helpers.forward_extension ~__context rbac { \
                     call with Rpc.name = __call }"

--- a/ocaml/idl/ocaml_backend/ocaml_syntax.ml
+++ b/ocaml/idl/ocaml_backend/ocaml_syntax.ml
@@ -79,18 +79,25 @@ module Let = struct
       | Named (name, _) ->
           "~" ^ name
     in
-    [
-      Line ("(** " ^ x.doc ^ " *)")
-    ; Line
-        (prefix
-        ^ " "
-        ^ x.name
-        ^ " "
-        ^ String.concat " " (List.map param x.params)
-        ^ " ="
-        )
-    ; Indent (List.map (fun x -> Line x) x.body)
-    ]
+    let doclines =
+      if x.doc <> "" then
+        [Line ("(** " ^ x.doc ^ " *)")]
+      else
+        []
+    in
+
+    doclines
+    @ [
+        Line
+          (prefix
+          ^ " "
+          ^ x.name
+          ^ " "
+          ^ String.concat " " (List.map param x.params)
+          ^ " ="
+          )
+      ; Indent (List.map (fun x -> Line x) x.body)
+      ]
 end
 
 module Type = struct

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -22,15 +22,6 @@ let my_assoc fld assoc_list =
   try List.assoc fld assoc_list
   with Not_found -> raise (Dispatcher_FieldNotFound fld)
 
-exception Nth (* should never be thrown externally *)
-
-let rec nth n l =
-  match l with
-  | [] ->
-      raise Nth
-  | x :: xs ->
-      if n = 1 then x else nth (n - 1) xs
-
 let async_wire_name = "Async."
 
 let async_length = String.length async_wire_name

--- a/ocaml/xapi/server_helpers.mli
+++ b/ocaml/xapi/server_helpers.mli
@@ -42,8 +42,6 @@ val exec_with_subtask :
 (* used by auto-generated code in server.ml *)
 val my_assoc : string -> (string * 'a) list -> 'a
 
-val nth : int -> 'a list -> 'a
-
 val sync_ty_and_maybe_remove_prefix :
   string -> [> `Async | `InternalAsync | `Sync] * string
 


### PR DESCRIPTION
Explicitly define a list of tuples with names and values so the rbac checks can never fail at runtime on differing lengths for these. Instead now the check happens at build time, by list construction.

Calls with defaults allowed the values list to be shorter as they never bothered to contain the default values. Now the default values are collected to match all the names of the parameters.

To help with this, I've removed some custom functions with default ones, and changed how lists are generated to stop using cons, as it doesn't lend itself to determine a particular number of elements in a list.

- [x] Ring3 BST + BVT internal test run: 175912 (all tests green except one because of an unrelated testing issue)

To give an idea on how these changes impact the code generated here are a couple of examples:

Call without defaults before:
```ocaml
    | "subject.get_record" | "subject_get_record" -> 
        begin match __params with
        | session_id_rpc::self_rpc::[] -> 
            (* has no side-effect; should be handled by DB action *) 
            (* has no asynchronous mode *)
            let session_id = ref_session_of_rpc session_id_rpc in
            let self = ref_subject_of_rpc self_rpc in
            Session_check.check ~intra_pool_only:false ~session_id;
            let arg_names = "session_id"::"self"::[] in
            let key_names = [] in
            let rbac __context fn = Rbac.check session_id __call ~args:(arg_names,__params) ~keys:key_names ~__context ~fn in
```
after:
```ocaml
    | "subject.get_record" | "subject_get_record" -> 
        begin match __params with
        | [session_id_rpc; self_rpc] -> 
            (* has no side-effect; should be handled by DB action *) 
            (* has no asynchronous mode *)
            let session_id = ref_session_of_rpc session_id_rpc in
            let self = ref_subject_of_rpc self_rpc in
            Session_check.check ~intra_pool_only:false ~session_id;
            let arg_names_values = [("session_id", session_id_rpc); ("self", self_rpc)] in
            let arg_names, arg_values = List.split arg_names_values in
            let key_names = [] in
            let rbac __context fn = Rbac.check session_id __call ~args:(arg_names, arg_values) ~keys:key_names ~__context ~fn in
```
Call with defaults before:
```ocaml
    | "GPU_group.create" | "GPU_group_create" -> 
        begin match __params with
        | session_id_rpc::default_args -> 
            (* has side-effect (with locks and no automatic DB action) *)
            (* has asynchronous mode *)
            let session_id = ref_session_of_rpc session_id_rpc in
            let name_label = string_of_rpc (try Server_helpers.nth 1 default_args with _ -> Rpc.String "") in
            let name_description = string_of_rpc (try Server_helpers.nth 2 default_args with _ -> Rpc.String "") in
            let other_config = string_to_string_map_of_rpc (try Server_helpers.nth 3 default_args with _ -> Rpc.Dict []) in
            Session_check.check ~intra_pool_only:false ~session_id;
            let arg_names = "session_id"::"name_label"::"name_description"::"other_config"::[] in
            let key_names = [] in
            let rbac __context fn = Rbac.check session_id __call ~args:(arg_names,__params) ~keys:key_names ~__context ~fn in
```
after:
```ocaml
    | "GPU_group.create" | "GPU_group_create" -> 
        begin match __params with
        | session_id_rpc :: default_args -> 
            (* has side-effect (with locks and no automatic DB action) *)
            (* has asynchronous mode *)
            let name_label_rpc = try List.nth default_args 0 with _ -> Rpc.String "" in
            let name_description_rpc = try List.nth default_args 1 with _ -> Rpc.String "" in
            let other_config_rpc = try List.nth default_args 2 with _ -> Rpc.Dict [] in
            let session_id = ref_session_of_rpc session_id_rpc in
            let name_label = string_of_rpc name_label_rpc in
            let name_description = string_of_rpc name_description_rpc in
            let other_config = string_to_string_map_of_rpc other_config_rpc in
            Session_check.check ~intra_pool_only:false ~session_id;
            let arg_names_values = [("session_id", session_id_rpc); ("name_label", name_label_rpc); ("name_description", name_description_rpc); ("other_config", other_config_rpc)] in
            let arg_names, arg_values = List.split arg_names_values in
            let key_names = [] in
            let rbac __context fn = Rbac.check session_id __call ~args:(arg_names, arg_values) ~keys:key_names ~__context ~fn in
```

This not only gets rids of the rbac_audit spurious warnings, but the RBAC code spends a copious amount of time at time ensuring that `~args` contains 2 lists of the same length, this is because this doesn't happen just once, but pervasively in the code. This is an identified bottleneck when there are many calls happening at the same. While this PR doesn't fix this bottleneck, I've experimented with removing all these check and will open a PR once the code is cleaned up: https://github.com/xapi-project/xen-api/compare/master...psafont:xen-api:private/paus/rbacuum