### PR TITLE
Revert `uuidx` rename in `gen_powershell_binding.ml`

### DIFF
--- a/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
+++ b/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
@@ -460,7 +460,7 @@ and print_methods_class classname has_uuid has_name =
           \            else if (Uuid != Guid.Empty)\n\
           \            {\n\
           \                foreach (var record in records)\n\
-          \                    if (Uuidx.ToString() == record.Value.uuid)\n\
+          \                    if (Uuid.ToString() == record.Value.uuid)\n\
           \                    {\n\
           \                        results.Add(record.Value);\n\
           \                        break;\n\
@@ -1590,7 +1590,7 @@ and print_parse_xenobject_private_method obj classname includeUuidAndName =
           \            else if (Uuid != Guid.Empty)\n\
           \            {\n\
           \                var xenRef = %s.get_by_uuid(session, \
-           Uuidx.ToString());\n\
+           Uuid.ToString());\n\
           \                if (xenRef != null)\n\
           \                    %s = xenRef.opaque_ref;\n\
           \            }"


### PR DESCRIPTION
Breaks PS SDK generation as the mentions were referring to C# code

Issue introduced in 0e924451d54674b36251d4993e5f397408dd4e86