### PR TITLE
CA-352073, CA-371780,  CA-372128: reduce overhead in xapi database and rbac checks; and in xcp-rrdd

### DIFF
--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -42,7 +42,7 @@ module StringMap = struct
   include Map.Make (struct
     type t = string
 
-    let compare = Stdlib.compare
+    let compare = String.compare
   end)
 
   let add key v t = add (share key) v t
@@ -274,7 +274,16 @@ module KeyMap = struct
   include Map.Make (struct
     type t = common_key
 
-    let compare = Stdlib.compare
+    let compare a b =
+      match (a, b) with
+      | Ref x, Ref y ->
+          String.compare x y
+      | Uuid x, Uuid y ->
+          String.compare x y
+      | Ref _, Uuid _ ->
+          -1
+      | Uuid _, Ref _ ->
+          1
   end)
 
   let add_unique tblname fldname k v t =

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -463,11 +463,7 @@ module Database = struct
 
   let table_of_ref rf db = fst (KeyMap.find (Ref rf) db.keymap)
 
-  let lookup_key key db =
-    if KeyMap.mem (Ref key) db.keymap then
-      Some (KeyMap.find (Ref key) db.keymap)
-    else
-      None
+  let lookup_key key db = KeyMap.find_opt (Ref key) db.keymap
 
   let make schema =
     {

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -258,11 +258,9 @@ let operation (obj : obj) (x : message) =
       let key_names = List.map fst x.msg_map_keys_roles in
       [
         Printf.sprintf "let arg_names_values = %s in" (serialize_args args)
-      ; (* This incurs a runtime cost *)
-        "let arg_names, arg_values = List.split arg_names_values in"
       ; Printf.sprintf "let key_names = %s in" (serialize_name_list key_names)
       ; "let rbac __context fn = Rbac.check session_id __call \
-         ~args:(arg_names, arg_values) ~keys:key_names ~__context ~fn in"
+         ~args:arg_names_values ~keys:key_names ~__context ~fn in"
       ]
     else
       ["let rbac __context fn = fn () in"]
@@ -535,14 +533,13 @@ let gen_module api : O.Module.t =
                     ~session_id;"
                  ; "      (* based on the Host.call_extension call *)"
                  ; "      let call_rpc = Rpc.String __call in "
-                 ; "      let arg_names, arg_values ="
+                 ; "      let arg_names_values ="
                  ; "        [(\"session_id\", session_id_rpc); (__call, \
                     call_rpc)]"
-                 ; "        |> List.split"
                  ; "      in"
                  ; "      let key_names = [] in"
                  ; "      let rbac __context fn = Rbac.check session_id \
-                    \"Host.call_extension\" ~args:(arg_names, arg_values) \
+                    \"Host.call_extension\" ~args:arg_names_values \
                     ~keys:key_names ~__context ~fn in"
                  ; "      Server_helpers.forward_extension ~__context rbac { \
                     call with Rpc.name = __call }"

--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -105,7 +105,7 @@ let get_keyERR_permission_name permission err = permission ^ "/keyERR:" ^ err
 let permission_of_action ?args ~keys _action =
   (* all permissions are in lowercase, see gen_rbac.writer_ *)
   let action = String.lowercase_ascii _action in
-  if List.length keys < 1 then
+  if keys = [] then
     (* most actions do not use rbac-guarded map keys in the arguments *)
     action
   else (* only actions with rbac-guarded map keys fall here *)
@@ -114,67 +114,40 @@ let permission_of_action ?args ~keys _action =
         (* this should never happen *)
         debug "DENYING access: no args for keyed-action %s" action ;
         get_keyERR_permission_name action "DENY_NOARGS" (* will always deny *)
-    | Some (arg_keys, arg_values) ->
-        if List.length arg_keys <> List.length arg_values then (
+    | Some keys_values -> (
+      match List.assoc_opt "key" keys_values with
+      | None ->
+          (* this should never happen *)
+          debug "DENYING access: no 'key' argument in the action %s" action ;
+          get_keyERR_permission_name action "DENY_NOKEY"
+      | Some (Rpc.String key_name_in_args) -> (
+        try
+          let key_name =
+            List.find
+              (fun key_name ->
+                if String.ends_with ~suffix:"*" key_name then
+                  (* resolve wildcards at the end *)
+                  String.starts_with
+                    ~prefix:(String.sub key_name 0 (String.length key_name - 1))
+                    key_name_in_args
+                else (* no wildcards to resolve *)
+                  key_name = key_name_in_args
+              )
+              keys
+          in
+          get_key_permission_name action (String.lowercase_ascii key_name)
+        with Not_found ->
+          (* expected, key_in_args is not rbac-protected *)
+          action
+      )
+      | Some value ->
           (* this should never happen *)
           debug
-            "DENYING access: arg_keys and arg_values lengths don't match: \
-             arg_keys=[%s], arg_values=[%s]"
-            (List.fold_left (fun ss s -> ss ^ s ^ ",") "" arg_keys)
-            (List.fold_left
-               (fun ss s -> ss ^ Rpc.to_string s ^ ",")
-               "" arg_values
-            ) ;
-          get_keyERR_permission_name action "DENY_WRGLEN" (* will always deny *)
-        ) else (* keys and values have the same length *)
-          let rec get_permission_name_of_keys arg_keys arg_values =
-            match (arg_keys, arg_values) with
-            | [], [] | _, [] | [], _ ->
-                (* this should never happen *)
-                debug "DENYING access: no 'key' argument in the action %s"
-                  action ;
-                get_keyERR_permission_name action "DENY_NOKEY"
-                (* deny by default *)
-            | k :: ks, v :: vs -> (
-                if k <> "key" (* "key" is defined in datamodel_utils.ml *) then
-                  get_permission_name_of_keys ks vs
-                else (* found "key" in args *)
-                  match v with
-                  | Rpc.String key_name_in_args -> (
-                    try
-                      (*debug "key_name_in_args=%s, keys=[%s]" key_name_in_args ((List.fold_left (fun ss s->ss^s^",") "" keys)) ;*)
-                      let key_name =
-                        List.find
-                          (fun key_name ->
-                            if Astring.String.is_suffix ~affix:"*" key_name then
-                              (* resolve wildcards at the end *)
-                              Astring.String.is_prefix
-                                ~affix:
-                                  (String.sub key_name 0
-                                     (String.length key_name - 1)
-                                  )
-                                key_name_in_args
-                            else (* no wildcards to resolve *)
-                              key_name = key_name_in_args
-                          )
-                          keys
-                      in
-                      get_key_permission_name action
-                        (String.lowercase_ascii key_name)
-                    with Not_found ->
-                      (* expected, key_in_args is not rbac-protected *)
-                      action
-                  )
-                  | _ ->
-                      (* this should never happen *)
-                      debug
-                        "DENYING access: wrong XML value [%s] in the 'key' \
-                         argument of action %s"
-                        (Rpc.to_string v) action ;
-                      get_keyERR_permission_name action "DENY_NOVALUE"
-              )
-          in
-          get_permission_name_of_keys arg_keys arg_values
+            "DENYING access: wrong XML value [%s] in the 'key' argument of \
+             action %s"
+            (Rpc.to_string value) action ;
+          get_keyERR_permission_name action "DENY_NOVALUE"
+    )
 
 let is_permission_in_session ~session_id ~permission ~session =
   let find_linear elem set = List.exists (fun e -> e = elem) set in

--- a/ocaml/xapi/rbac_audit.ml
+++ b/ocaml/xapi/rbac_audit.ml
@@ -434,6 +434,8 @@ let has_to_audit action =
           ; (* spam *)
             "http/get_rrd_updates"
           ; (* spam *)
+            "http/rrd_updates"
+          ; (* spam *)
             "http/post_remote_db_access"
           ; (* spam *)
             "host.tickle_heartbeat"

--- a/ocaml/xapi/rbac_audit.ml
+++ b/ocaml/xapi/rbac_audit.ml
@@ -305,11 +305,11 @@ let get_db_namevalue __context name action _ref =
 *)
 let rec sexpr_args_of __context name rpc_value action =
   let is_selected_action_param action_params =
-    if List.mem_assoc action action_params then
-      let params = List.assoc action action_params in
-      List.mem name params
-    else
-      false
+    match List.assoc_opt action action_params with
+    | Some params ->
+        List.mem name params
+    | None ->
+        false
   in
   (* heuristic 1: print descriptive arguments in the xapi call *)
   if
@@ -337,7 +337,7 @@ let rec sexpr_args_of __context name rpc_value action =
              ; SExpr.Node
                  (sexpr_of_parameters __context
                     (action ^ "." ^ name)
-                    (Some (["__structure"], [rpc_value]))
+                    (Some [("__structure", rpc_value)])
                  )
              ; SExpr.String ""
              ; SExpr.String ""
@@ -383,52 +383,30 @@ let rec sexpr_args_of __context name rpc_value action =
 and
     (* Given an action and its parameters, *)
     (* return the marshalled uuid params and corresponding names *)
-    (*let rec*) sexpr_of_parameters __context action args : SExpr.t list =
+    sexpr_of_parameters __context action args : SExpr.t list =
   match args with
   | None ->
       []
-  | Some (str_names, rpc_values) ->
-      if List.length str_names <> List.length rpc_values then (
-        (* debug mode *)
-        D.warn
-          "cannot marshall arguments for the action %s: name and value list \
-           lengths don't match. str_names=[%s], xml_values=[%s]"
-          action
-          (List.fold_left (fun ss s -> ss ^ s ^ ",") "" str_names)
-          (List.fold_left (fun ss s -> ss ^ Rpc.to_string s ^ ",") "" rpc_values) ;
-        []
-      ) else
-        List.fold_right2
-          (fun str_name rpc_value (params : SExpr.t list) ->
-            if str_name = "session_id" then
+  | Some names_rpc_values ->
+      List.fold_right
+        (fun (str_name, rpc_value) (params : SExpr.t list) ->
+          match (str_name, rpc_value) with
+          | "session_id", _ ->
               params (* ignore session_id param *)
-            else if
+          | "__structure", Rpc.Dict d ->
               (* if it is a constructor structure, need to rewrap params *)
-              str_name = "__structure"
-            then
-              match rpc_value with
-              | Rpc.Dict d ->
-                  let names = List.map fst d in
-                  let values = List.map snd d in
-                  let myparam =
-                    sexpr_of_parameters __context action (Some (names, values))
-                  in
-                  myparam @ params
-              | rpc_value -> (
-                match sexpr_args_of __context str_name rpc_value action with
-                | None ->
-                    params
-                | Some p ->
-                    p :: params
-              )
-            else (* the expected list of xml arguments *)
-              match sexpr_args_of __context str_name rpc_value action with
-              | None ->
-                  params
-              | Some p ->
-                  p :: params
+              let myparam = sexpr_of_parameters __context action (Some d) in
+              myparam @ params
+          | _ -> (
+            (* the expected list of xml arguments *)
+            match sexpr_args_of __context str_name rpc_value action with
+            | None ->
+                params
+            | Some p ->
+                p :: params
           )
-          str_names rpc_values []
+        )
+        names_rpc_values []
 
 let has_to_audit action =
   let has_side_effect action =
@@ -475,37 +453,28 @@ let add_dummy_args __context action args =
   match args with
   | None ->
       args
-  | Some (str_names, rpc_values) -> (
-      let rec find_self str_names rpc_values =
-        match (str_names, rpc_values) with
-        | "self" :: _, rpc :: _ ->
-            rpc
-        | _ :: str_names', _ :: rpc_values' ->
-            find_self str_names' rpc_values'
-        | _, _ ->
-            raise Not_found
-      in
-      match action with
-      (* Add VDI info for VBD.destroy *)
-      | "VBD.destroy" -> (
-        try
-          let vbd = API.ref_VBD_of_rpc (find_self str_names rpc_values) in
-          let vdi = DB_Action.VBD.get_VDI ~__context ~self:vbd in
-          Some (str_names @ ["VDI"], rpc_values @ [API.rpc_of_ref_VDI vdi])
-        with e ->
-          D.debug "couldn't get VDI ref for VBD: %s" (ExnHelper.string_of_exn e) ;
-          args
-      )
-      | _ ->
-          args
+  | Some names_rpc -> (
+    match action with
+    (* Add VDI info for VBD.destroy *)
+    | "VBD.destroy" -> (
+      try
+        let vbd = API.ref_VBD_of_rpc (List.assoc "self" names_rpc) in
+        let vdi = DB_Action.VBD.get_VDI ~__context ~self:vbd in
+        let params = names_rpc @ [("VDI", API.rpc_of_ref_VDI vdi)] in
+        Some params
+      with e ->
+        D.debug "couldn't get VDI ref for VBD: %s" (ExnHelper.string_of_exn e) ;
+        args
     )
+    | _ ->
+        args
+  )
 
 let sexpr_of __context session_id allowed_denied ok_error result_error ?args
     ?sexpr_of_args action _permission =
   let result_error =
     if result_error = "" then result_error else ":" ^ result_error
   in
-  (*let (params:SExpr.t list) = (string_of_parameters action args) in*)
   SExpr.Node
     [
       SExpr.String (trackid session_id)
@@ -514,8 +483,7 @@ let sexpr_of __context session_id allowed_denied ok_error result_error ?args
     ; SExpr.String allowed_denied
     ; SExpr.String (ok_error ^ result_error)
     ; SExpr.String (call_type_of ~action)
-    ; (*SExpr.String (Helper_hostname.get_hostname ())::*)
-      SExpr.String action
+    ; SExpr.String action
     ; SExpr.Node
         ( match sexpr_of_args with
         | None ->

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -80,10 +80,8 @@ let append_to_master_audit_log __context action line =
       )
 
 let rbac_audit_params_of (req : Request.t) =
-  let all = req.Request.cookie @ req.Request.query in
-  List.fold_right
-    (fun (n, v) (acc_n, acc_v) -> (n :: acc_n, Rpc.String v :: acc_v))
-    all ([], [])
+  req.Request.cookie @ req.Request.query
+  |> List.map (fun (n, v) -> (n, Rpc.String v))
 
 let create_session_for_client_cert req s =
   let __context = Context.make ~origin:(Http (req, s)) "client_cert" in

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_monitor.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_monitor.ml
@@ -50,9 +50,11 @@ let create_fresh_rrd use_min_max dss =
 let merge_new_dss rrd dss =
   let should_enable_ds ds = !Rrdd_shared.enable_all_dss || ds.ds_default in
   let enabled_dss = List.filter should_enable_ds dss in
-  let current_dss = Rrd.ds_names rrd in
+  let current_dss = Rrd.ds_names rrd |> StringSet.of_list in
   let new_dss =
-    List.filter (fun ds -> not (List.mem ds.ds_name current_dss)) enabled_dss
+    List.filter
+      (fun ds -> not (StringSet.mem ds.ds_name current_dss))
+      enabled_dss
   in
   let now = Unix.gettimeofday () in
   List.fold_left


### PR DESCRIPTION
Continuation of https://github.com/xapi-project/xen-api/pull/4829

RBAC checks have complicated list traversals, quite a few of them can be avoidable changing the datastructure to a list of tuples. There were also some database lookups that were unnecessary and have been folded together, there is also some refactoring in rbac_audit that tries to reduce the cognitive complexity of the code, hopefully it's easier to analyse.

Db_cacche_types spent an unreasonable amount of time in map.update. This is because it tried to avoid running update on unchanged values. This incurred a terrible amount of cost. Currently we can use the standard library implementation of map.update which avoids this while being efficient, cutting the cpu runtime of xapi under certain conditions by half.

Additionally I've also changes an n^2 operation in xcp-rrdd that was taking almost 20% of its cpu time, the change seems very effective, I cannot see it anymore in the flamegraphs and the rest of the functions take wider chunk :)