### PR TITLE
CP-41067: Drop eliloader bootloader: obsolete and not needed on any s…

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -189,10 +189,7 @@ let software_version () =
 
 let pygrub_path = "/usr/bin/pygrub"
 
-let eliloader_path = "/usr/bin/eliloader"
-
-let supported_bootloaders =
-  [("pygrub", pygrub_path); ("eliloader", eliloader_path)]
+let supported_bootloaders = [("pygrub", pygrub_path)]
 
 (* Deprecated: *)
 let is_guest_installer_network = "is_guest_installer_network"

--- a/ocaml/xenopsd/doc/walk-throughs/VM.start.md
+++ b/ocaml/xenopsd/doc/walk-throughs/VM.start.md
@@ -249,7 +249,7 @@ from the host in the "build" phase via functions in *libxenguest*. The
 [VM.build_domain_exn](https://github.com/xapi-project/xenopsd/blob/b33bab13080cea91e2fd59d5088622cd68152339/xc/xenops_server_xen.ml#L994)
 function must
 
-1. run pygrub (or eliloader) to extract the kernel and initrd, if necessary
+1. run pygrub to extract the kernel and initrd, if necessary
 2. invoke the *xenguest* binary to interact with libxenguest.
 3. apply the ```cpuid``` configuration
 4. store the current domain configuration on disk -- it's important to know

--- a/ocaml/xenopsd/lib/bootloader.mli
+++ b/ocaml/xenopsd/lib/bootloader.mli
@@ -37,7 +37,6 @@ val extract :
   -> ?legacy_args:string
   -> ?extra_args:string
   -> ?pv_bootloader_args:string
-  -> vm:string
   -> unit
   -> t
 (** Extract the default kernel from the disk *)

--- a/ocaml/xenopsd/lib/resources.ml
+++ b/ocaml/xenopsd/lib/resources.ml
@@ -30,8 +30,6 @@ let hvmloader = ref "hvmloader"
 
 let pygrub = ref "pygrub"
 
-let eliloader = ref "eliloader"
-
 let legacy_conv_tool = ref "convert-legacy-stream"
 
 let verify_libxc_v2 = ref "verify-stream-v2"
@@ -58,10 +56,7 @@ let hvm_guests =
   ]
 
 let pv_guests =
-  [
-    (X_OK, "pygrub", pygrub, "path to the pygrub bootloader binary")
-  ; (X_OK, "eliloader", eliloader, "path to the eliloader bootloader binary")
-  ]
+  [(X_OK, "pygrub", pygrub, "path to the pygrub bootloader binary")]
 
 let pvinpvh_guests =
   [

--- a/ocaml/xenopsd/scripts/make-custom-xenopsd.conf
+++ b/ocaml/xenopsd/scripts/make-custom-xenopsd.conf
@@ -28,7 +28,6 @@ cat >> ${DESTDIR}/${ETCDIR}/xenopsd.conf <<EOT
 # on $(date)
 search-path=${LIBEXECDIR}:${myxen}/boot:${myxen}/bin
 inventory=${ETCDIR}/xcp/inventory
-eliloader=eliloader
 pygrub=pygrub
 qemu-system-i386=qemu-system-i386
 vncterm=${LIBEXECDIR}/vncterm-wrapper

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2075,8 +2075,7 @@ module VM = struct
                   let b =
                     Bootloader.extract task ~bootloader:i.bootloader
                       ~legacy_args:i.legacy_args ~extra_args:i.extra_args
-                      ~pv_bootloader_args:i.bootloader_args ~disk:dev
-                      ~vm:vm.Vm.id ()
+                      ~pv_bootloader_args:i.bootloader_args ~disk:dev ()
                   in
                   kernel_to_cleanup := Some b ;
                   let builder_spec_info =
@@ -2120,8 +2119,7 @@ module VM = struct
                   let b =
                     Bootloader.extract task ~bootloader:i.bootloader
                       ~legacy_args:i.legacy_args ~extra_args:i.extra_args
-                      ~pv_bootloader_args:i.bootloader_args ~disk:dev
-                      ~vm:vm.Vm.id ()
+                      ~pv_bootloader_args:i.bootloader_args ~disk:dev ()
                   in
                   kernel_to_cleanup := Some b ;
                   let builder_spec_info =

--- a/ocaml/xenopsd/xenopsd.conf
+++ b/ocaml/xenopsd/xenopsd.conf
@@ -40,9 +40,6 @@ disable-logging-for=http
 # Path to pygrub
 # pygrub=/usr/lib/xen-4.1/bin/pygrub
 
-# Path to eliloader
-# eliloader=/usr/bin/eliloader
-
 # Path to the network backend switch
 # network_conf="/etc/xcp/network.conf"
 


### PR DESCRIPTION
…upported guest

Eliloader used to supply a patched kernel/initrd needed to boot EL4.x-6.x and Ubuntu 11.04 PV kernels.
All those guests are EOL, and guests nowadays include the required drivers to boot under Xen.

eliloader is being removed from the product:
last update was in 2019 when adding EL6.10 support, and CentOS 6.x is EOL now. Drop it from the supported bootloaders list.

Pygrub is still there, even if booting PV guests isn't strictly supported right now, since it might be useful for PVH guests again, although PVH can also use OVMF to boot.
(Pygrub would extract the kernel to boot from the guest disk prior to booting it)

Also drop function arguments that are now unused (the vm argument).

Signed-off-by: Edwin Török <edvin.torok@citrix.com>