### PR TITLE
Add certificate checking to sparse-dd

### DIFF
--- a/ocaml/vhd-tool/cli/main.ml
+++ b/ocaml/vhd-tool/cli/main.ml
@@ -210,6 +210,18 @@ let good_ciphersuites =
   let doc = "The list of ciphersuites to allow for TLS" in
   Arg.(value & opt (some string) None & info ["good-ciphersuites"] ~doc)
 
+let verify_dest =
+  let doc = "Verify the TLS certificate of the remote host." in
+  Arg.(value & flag & info ["verify-dest"] ~doc)
+
+let sni =
+  let doc = "The SNI hostname if connecting to the remote over TLS" in
+  Arg.(value & opt (some string) None & info ["sni"] ~doc)
+
+let cert_bundle_path =
+  let doc = "Path to a CA certificate bundle" in
+  Arg.(value & opt (some string) None & info ["cert-bundle-path"] ~doc)
+
 let serve_cmd =
   let doc = "serve the contents of a disk" in
   let man =
@@ -364,6 +376,9 @@ let stream_cmd =
       $ machine
       $ tar_filename_prefix
       $ good_ciphersuites
+      $ verify_dest
+      $ sni
+      $ cert_bundle_path
     )
   in
   ( Term.(ret (const Impl.stream $ common_options_t $ stream_args_t))

--- a/ocaml/vhd-tool/cli/sparse_dd.ml
+++ b/ocaml/vhd-tool/cli/sparse_dd.ml
@@ -61,11 +61,7 @@ let experimental_reads_bypass_tapdisk = ref false
 
 let experimental_writes_bypass_tapdisk = ref false
 
-let ssl_legacy = ref false
-
 let good_ciphersuites = ref None
-
-let legacy_ciphersuites = ref None
 
 let string_opt = function None -> "None" | Some x -> x
 
@@ -140,20 +136,10 @@ let options =
     , (fun () -> string_of_bool !machine_readable_progress)
     , "emit machine-readable output"
     )
-  ; ( "ssl-legacy"
-    , Arg.Set ssl_legacy
-    , (fun () -> string_of_bool !ssl_legacy)
-    , " for TLS, allow all protocol versions instead of just TLSv1.2"
-    )
   ; ( "good-ciphersuites"
     , Arg.String (fun x -> good_ciphersuites := Some x)
     , (fun () -> string_opt !good_ciphersuites)
     , " the list of ciphersuites to allow for TLS"
-    )
-  ; ( "legacy-ciphersuites"
-    , Arg.String (fun x -> legacy_ciphersuites := Some x)
-    , (fun () -> string_opt !legacy_ciphersuites)
-    , " additional TLS ciphersuites allowed only if ssl-legacy is set"
     )
   ]
 

--- a/ocaml/vhd-tool/src/impl.ml
+++ b/ocaml/vhd-tool/src/impl.ml
@@ -944,7 +944,7 @@ let make_stream common source relative_to source_format destination_format =
       assert false
 
 let write_stream common s destination _source_protocol destination_protocol
-    prezeroed progress tar_filename_prefix good_ciphersuites =
+    prezeroed progress tar_filename_prefix good_ciphersuites verify_cert =
   endpoint_of_string destination >>= fun endpoint ->
   let use_ssl = match endpoint with Https _ -> true | _ -> false in
   ( match endpoint with
@@ -997,7 +997,7 @@ let write_stream common s destination _source_protocol destination_protocol
       >>= fun () ->
       let open Cohttp in
       ( if use_ssl then
-          Channels.of_ssl_fd sock good_ciphersuites
+          Channels.of_ssl_fd sock good_ciphersuites verify_cert
       else
         Channels.of_raw_fd sock
       )
@@ -1131,7 +1131,7 @@ let stream_t common args ?(progress = no_progress_bar) () =
   write_stream common s args.StreamCommon.destination
     args.StreamCommon.source_protocol args.StreamCommon.destination_protocol
     args.StreamCommon.prezeroed progress args.StreamCommon.tar_filename_prefix
-    args.StreamCommon.good_ciphersuites
+    args.StreamCommon.good_ciphersuites args.StreamCommon.verify_cert
 
 let stream common args =
   try

--- a/ocaml/xapi/sm_fs_ops.ml
+++ b/ocaml/xapi/sm_fs_ops.ml
@@ -141,8 +141,8 @@ let copy_vdi ~__context ?base vdi_src vdi_dst =
               if local_copy then
                 with_block_attached_device __context rpc session_id vdi_dst `RW
                   (fun device_dst ->
-                    Sparse_dd_wrapper.dd ~progress_cb ?base sparse device_src
-                      device_dst size
+                    Sparse_dd_wrapper.dd ~progress_cb ?base ~verify_cert:None
+                      sparse device_src device_dst size
                 )
               else
                 (* Create a new subtask for the inter-host sparse_dd. Without
@@ -163,8 +163,8 @@ let copy_vdi ~__context ?base vdi_src vdi_dst =
                     in
                     debug "remote_uri = %s" remote_uri ;
                     try
-                      Sparse_dd_wrapper.dd ~progress_cb ?base sparse device_src
-                        remote_uri size ;
+                      Sparse_dd_wrapper.dd ~progress_cb ~verify_cert:None ?base
+                        sparse device_src remote_uri size ;
                       Tasks.wait_for_all ~rpc ~session_id
                         ~tasks:[import_task_id] ;
                       match

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -537,8 +537,8 @@ let copy' ~task ~dbg ~sr ~vdi ~url ~dest ~dest_vdi =
                 let dd =
                   Sparse_dd_wrapper.start
                     ~progress_cb:(progress_callback 0.05 0.9 task)
-                    ?base:base_path true (Option.get src) dest_vdi_url
-                    remote_vdi.virtual_size
+                    ~verify_cert:None ?base:base_path true (Option.get src)
+                    dest_vdi_url remote_vdi.virtual_size
                 in
                 Storage_task.with_cancel task
                   (fun () -> Sparse_dd_wrapper.cancel dd)

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -14,7 +14,7 @@ list-hd () {
 }
 
 verify-cert () {
-  N=12
+  N=15
   NONE=$(git grep -r --count 'verify_cert:None' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$NONE" -eq "$N" ]; then
     echo "OK counted $NONE usages of verify_cert:None"


### PR DESCRIPTION
This is required to be able to fully support storage migration over HTTPS. This is still off by default.