### PR TITLE
CA-371780: Reduce overheads in update_rrdds

### DIFF
--- a/ocaml/xcp-rrdd/test/rrdd/dune
+++ b/ocaml/xcp-rrdd/test/rrdd/dune
@@ -2,8 +2,8 @@
   (name test_rrdd_monitor)
   (package xapi-rrdd)
   (libraries
+    alcotest
     dune-build-info
-    ounit2
     rrdd_libs_internal
     xapi-idl.rrd
     xapi-rrd

--- a/ocaml/xcp-rrdd/test/rrdd/test_rrdd_monitor.ml
+++ b/ocaml/xcp-rrdd/test/rrdd/test_rrdd_monitor.ml
@@ -31,8 +31,10 @@ let dss_of_rrds rrds =
 
 let check_datasources kind rdds expected_dss =
   match rdds with
-  | None ->
+  | None when expected_dss <> [] ->
       Alcotest.fail (Printf.sprintf "%s RRD must be created" kind)
+  | None ->
+      ()
   | Some actual_rdds ->
       let actual_dss = dss_of_rrds actual_rdds in
       let expected_dss = List.fast_sort Stdlib.compare expected_dss in

--- a/ocaml/xcp-rrdd/test/rrdd/test_rrdd_monitor.ml
+++ b/ocaml/xcp-rrdd/test/rrdd/test_rrdd_monitor.ml
@@ -1,7 +1,3 @@
-open OUnit2
-
-let assert_equal_int = assert_equal ~printer:string_of_int
-
 let ds_a =
   Ds.ds_make ~name:"ds_a" ~units:"(fraction)" ~description:"datasource a"
     ~value:(Rrd.VT_Float 1.0) ~ty:Rrd.Gauge ~default:true ()
@@ -10,94 +6,113 @@ let ds_b =
   Ds.ds_make ~name:"ds_b" ~units:"(fraction)" ~description:"datasource b"
     ~value:(Rrd.VT_Float 2.0) ~ty:Rrd.Gauge ~default:true ()
 
-let reset_rrdd_shared_state _ctxt =
+let reset_rrdd_shared_state () =
   Hashtbl.clear Rrdd_shared.vm_rrds ;
   Rrdd_shared.host_rrd := None
 
-let dump_dss = List.map (fun ds -> ds.Ds.ds_name)
+let pp_ds =
+  Fmt.(
+    Dump.record
+      [
+        Dump.field "ds_name" (fun t -> t.Ds.ds_name) string
+      ; Dump.field "ds_description" (fun t -> t.Ds.ds_description) string
+      ; Dump.field "ds_default" (fun t -> t.Ds.ds_default) bool
+      ; Dump.field "ds_min" (fun t -> t.Ds.ds_min) float
+      ; Dump.field "ds_max" (fun t -> t.Ds.ds_max) float
+      ; Dump.field "ds_units" (fun t -> t.Ds.ds_units) string
+      ]
+  )
 
-let dump_rrd_hash hash =
-  Hashtbl.fold (fun k v acc -> (k, dump_dss v.Rrdd_shared.dss) :: acc) hash []
+let ds = Alcotest.testable pp_ds (fun a b -> String.equal a.ds_name b.ds_name)
 
-let string_of_rrd_dump dump =
-  let rrds =
-    List.map
-      (fun (k, v) -> Printf.sprintf "(%s, [%s])" k (String.concat "; " v))
-      dump
-  in
-  Printf.sprintf "[%s]" (String.concat "; " rrds)
+let dss_of_rrds rrds =
+  Hashtbl.fold (fun k v acc -> (k, v.Rrdd_shared.dss) :: acc) rrds []
+  |> List.fast_sort Stdlib.compare
 
-let check_rrd_hash actual_rrds expected_rrds =
-  assert_equal ~printer:string_of_rrd_dump
-    (List.sort compare expected_rrds)
-    (List.sort compare (dump_rrd_hash actual_rrds))
-
-let check_host_dss expected_dss =
-  match !Rrdd_shared.host_rrd with
+let check_datasources kind rdds expected_dss =
+  match rdds with
   | None ->
-      assert_failure "host_rrd should have been created"
-  | Some info ->
-      assert_equal ~printer:(String.concat "; ")
-        (List.sort compare expected_dss)
-        (List.sort compare (dump_dss info.Rrdd_shared.dss))
+      Alcotest.fail (Printf.sprintf "%s RRD must be created" kind)
+  | Some actual_rdds ->
+      let actual_dss = dss_of_rrds actual_rdds in
+      let expected_dss = List.fast_sort Stdlib.compare expected_dss in
+      Alcotest.(check @@ list @@ pair string (list ds))
+        (Printf.sprintf "%s rrds are not expected" kind)
+        actual_dss expected_dss
+
+let host_rrds rrd_info =
+  Option.bind rrd_info @@ fun rrd_info ->
+  let h = Hashtbl.create 1 in
+  if rrd_info.Rrdd_shared.dss <> [] then
+    Hashtbl.add h "host" rrd_info ;
+  Some h
 
 let update_rrds_test ~dss ~uuid_domids ~paused_vms ~expected_vm_rrds
-    ~expected_sr_rrds ~expected_host_dss ctxt =
-  OUnit2.bracket reset_rrdd_shared_state (fun () -> ignore) ctxt ;
-  Rrdd_monitor.update_rrds 12345.0 dss uuid_domids paused_vms ;
-  check_rrd_hash Rrdd_shared.vm_rrds expected_vm_rrds ;
-  check_rrd_hash Rrdd_shared.sr_rrds expected_sr_rrds ;
-  check_host_dss expected_host_dss
+    ~expected_sr_rrds ~expected_host_dss =
+  let test () =
+    reset_rrdd_shared_state () ;
+    Rrdd_monitor.update_rrds 12345.0 dss uuid_domids paused_vms ;
+    check_datasources "VM" (Some Rrdd_shared.vm_rrds) expected_vm_rrds ;
+    check_datasources "SR" (Some Rrdd_shared.sr_rrds) expected_sr_rrds ;
+    check_datasources "Host" (host_rrds !Rrdd_shared.host_rrd) expected_host_dss
+  in
+  [("", `Quick, test)]
 
 let update_rrds =
-  "update_rrds"
-  >:::
   let open Rrd in
   [
-    "Null update"
-    >:: update_rrds_test ~dss:[] ~uuid_domids:[] ~paused_vms:[]
-          ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Single host update"
-    >:: update_rrds_test ~dss:[(Host, ds_a)] ~uuid_domids:[] ~paused_vms:[]
-          ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:["ds_a"]
-  ; "Multiple host updates"
-    >:: update_rrds_test
-          ~dss:[(Host, ds_a); (Host, ds_a)]
-          ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[]
-          ~expected_sr_rrds:[] ~expected_host_dss:["ds_a"; "ds_a"]
-  ; "Single non-resident VM update"
-    >:: update_rrds_test ~dss:[(VM "a", ds_a)] ~uuid_domids:[] ~paused_vms:[]
-          ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Multiple non-resident VM updates"
-    >:: update_rrds_test
-          ~dss:[(VM "a", ds_a); (VM "b", ds_a)]
-          ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[]
-          ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Single resident VM update"
-    >:: update_rrds_test ~dss:[(VM "a", ds_a)] ~uuid_domids:[("a", 1)]
-          ~paused_vms:[]
-          ~expected_vm_rrds:[("a", ["ds_a"])]
-          ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Multiple resident VM updates"
-    >:: update_rrds_test
-          ~dss:[(VM "a", ds_a); (VM "b", ds_a); (VM "b", ds_b)]
-          ~uuid_domids:[("a", 1); ("b", 1)] ~paused_vms:[]
-          ~expected_vm_rrds:[("a", ["ds_a"]); ("b", ["ds_a"; "ds_b"])]
-          ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Multiple resident and non-resident VM updates"
-    >:: update_rrds_test
-          ~dss:[(VM "a", ds_a); (VM "b", ds_a); (VM "c", ds_a)]
-          ~uuid_domids:[("a", 1); ("b", 1)] ~paused_vms:[]
-          ~expected_vm_rrds:[("a", ["ds_a"]); ("b", ["ds_a"])]
-          ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Multiple SR updates"
-    >:: update_rrds_test
-          ~dss:[(SR "a", ds_a); (SR "b", ds_a); (SR "b", ds_b)]
-          ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[]
-          ~expected_sr_rrds:[("a", ["ds_a"]); ("b", ["ds_a"; "ds_b"])]
-          ~expected_host_dss:[]
+    ( "Null update"
+    , update_rrds_test ~dss:[] ~uuid_domids:[] ~paused_vms:[]
+        ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Single host update"
+    , update_rrds_test ~dss:[(Host, ds_a)] ~uuid_domids:[] ~paused_vms:[]
+        ~expected_vm_rrds:[] ~expected_sr_rrds:[]
+        ~expected_host_dss:[("host", [ds_a])]
+    )
+  ; ( "Multiple host updates"
+    , update_rrds_test
+        ~dss:[(Host, ds_a); (Host, ds_b)]
+        ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[] ~expected_sr_rrds:[]
+        ~expected_host_dss:[("host", [ds_a; ds_b])]
+    )
+  ; ( "Single non-resident VM update"
+    , update_rrds_test ~dss:[(VM "a", ds_a)] ~uuid_domids:[] ~paused_vms:[]
+        ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Multiple non-resident VM updates"
+    , update_rrds_test
+        ~dss:[(VM "a", ds_a); (VM "b", ds_a)]
+        ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[] ~expected_sr_rrds:[]
+        ~expected_host_dss:[]
+    )
+  ; ( "Single resident VM update"
+    , update_rrds_test ~dss:[(VM "a", ds_a)] ~uuid_domids:[("a", 1)]
+        ~paused_vms:[]
+        ~expected_vm_rrds:[("a", [ds_a])]
+        ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Multiple resident VM updates"
+    , update_rrds_test
+        ~dss:[(VM "a", ds_a); (VM "b", ds_a); (VM "b", ds_b)]
+        ~uuid_domids:[("a", 1); ("b", 1)] ~paused_vms:[]
+        ~expected_vm_rrds:[("a", [ds_a]); ("b", [ds_a; ds_b])]
+        ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Multiple resident and non-resident VM updates"
+    , update_rrds_test
+        ~dss:[(VM "a", ds_a); (VM "b", ds_a); (VM "c", ds_a)]
+        ~uuid_domids:[("a", 1); ("b", 1)] ~paused_vms:[]
+        ~expected_vm_rrds:[("a", [ds_a]); ("b", [ds_a])]
+        ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Multiple SR updates"
+    , update_rrds_test
+        ~dss:[(SR "a", ds_a); (SR "b", ds_a); (SR "b", ds_b)]
+        ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[]
+        ~expected_sr_rrds:[("a", [ds_a]); ("b", [ds_a; ds_b])]
+        ~expected_host_dss:[]
+    )
   ]
 
-let suite = "rrdd monitor test" >::: [update_rrds]
-
-let () = run_test_tt_main suite
+let () = Alcotest.run "RRD daemon monitor test" update_rrds


### PR DESCRIPTION
This function had quadratic costs with all the lists it was using. On
top of that all three types of owned datasources were processed in a
different way, especially the VMs, which where map from a list of active
VMs instead of the owned data sources

Further work is needed move collect the datasources into the appropriate
datastructure instead of in this function, and extend the datastructures
into the used functions isntead of converting them to lists

Additionally I've ported the unit tests to alcotests, which allowed to uncover a minor difference in behaviour: previously the host record was always created, not it only is created when there are host sources. This is irrelevant in the grand scheme of things as host sources are fed every time to the function.

I've manually tested updating a host with this change, the overhead from this function has gone down substantially looking at the flamegraphs, and CHC keeps showing stats correctly, both new one and previous ones.

I don't think this change should be backported

Marked as draft as a couple of todos need to be handled

![image](https://user-images.githubusercontent.com/5189409/199774934-13eca8de-8330-438e-8c26-2d30831bb691.png)