### PR TITLE
CP-33044 define attach/detach IDL calls for gpumon

### DIFF
--- a/ocaml/xapi-idl/gpumon/dune
+++ b/ocaml/xapi-idl/gpumon/dune
@@ -15,6 +15,8 @@
 
 (executable
  (name gpumon_cli)
+ (public_name gpumon-cli)
+ (package xapi-idl)
  (modules gpumon_cli)
  (libraries
    cmdliner

--- a/ocaml/xapi-idl/gpumon/gpumon_interface.ml
+++ b/ocaml/xapi-idl/gpumon/gpumon_interface.ml
@@ -130,6 +130,10 @@ module RPC_API (R : RPC) = struct
   module Nvidia = struct
     (** common API call parameters *)
 
+    let unit_p = param Rpc.Types.unit
+
+    let bool_p = param Rpc.Types.bool
+
     let debug_info_p =
       param ~description:["Uninterpreted string used for debugging."] debug_info
 
@@ -217,5 +221,22 @@ module RPC_API (R : RPC) = struct
         @-> nvidia_vgpu_metadata_list_p
         @-> returning compatibility_p gpu_err
         )
+
+    let nvml_attach =
+      declare "nvml_attach"
+        [
+          "Attach nVidia cards to Gpumon for metrics and compatibility checking."
+        ]
+        (debug_info_p @-> returning unit_p gpu_err)
+
+    let nvml_detach =
+      declare "nvml_detach"
+        ["Detach nVidia cards from Gpumon"]
+        (debug_info_p @-> returning unit_p gpu_err)
+
+    let nvml_is_attached =
+      declare "nvml_is_attached"
+        ["Return true if nVidia cards are currently attached."]
+        (debug_info_p @-> returning bool_p gpu_err)
   end
 end

--- a/ocaml/xcp-rrdd/lib/plugin/reporter.ml
+++ b/ocaml/xcp-rrdd/lib/plugin/reporter.ml
@@ -92,6 +92,11 @@ let wait_until_next_reading (module D : Debug.DEBUG) ~neg_shift ~uid ~protocol
   )
 
 let loop (module D : Debug.DEBUG) ~reporter ~report ~cleanup =
+  let log_backtrace e =
+    let trace = Printexc.(get_raw_backtrace () |> raw_backtrace_to_string) in
+    D.error "%s: %s" (Printexc.to_string e) trace
+  in
+
   let running = ref true in
   ( match reporter with
   | Some reporter ->
@@ -127,9 +132,10 @@ let loop (module D : Debug.DEBUG) ~reporter ~report ~cleanup =
         cleanup () ;
         running := false
     | e ->
+        log_backtrace e ;
         D.error "Unexpected error %s, sleeping for 10 seconds..."
           (Printexc.to_string e) ;
-        D.log_backtrace () ;
+
         Thread.delay 10.0
   done ;
   D.info "leaving main loop"


### PR DESCRIPTION
We want to tell gpumon to attach and detach its NVML library. Extend the RPC interface defined for gpumon with new calls. Futhermore, generate the gpumon-cli to exercise these operations from the command line. This requires a change in xapi.spec:

  %files -n message-switch
  %{_unitdir}/message-switch.service
  %{_sbindir}/message-switch
  %{_sbindir}/message-cli
  /usr/bin/gpumon-cli
  %config(noreplace) /etc/message-switch.conf
  /etc/xensource/bugtool/message-switch/stuff.xml
  /etc/xensource/bugtool/message-switch.xml

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>