### PR TITLE
CP-41213: swtpm-wrapper should not fiddle with cgroups

### DIFF
--- a/ocaml/xenopsd/scripts/swtpm-wrapper
+++ b/ocaml/xenopsd/scripts/swtpm-wrapper
@@ -32,15 +32,6 @@ CLONE_NEWIPC = 0x08000000 # IPC namespace
 
 SWTPM_NVSTORE_LINEAR_MAGIC = 0x737774706d6c696e
 
-# Set cgroup_slice to the name of the cgroup slice the swtpm process
-# should live in.
-#  - None means leave in the same slice as the parent process.
-#  - '' means move it into the default slice.
-#  - 'system.slice' means move it into the system slice, etc.
-# If the nominated slice does not already exist, the process will be
-# left in its parent's slice.
-cgroup_slice = ''
-
 def unshare(flags):
     libc = ctypes.CDLL(ctypes.util.find_library('c'), use_errno=True)
     unshare_prototype = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_int, use_errno=True)
@@ -61,19 +52,6 @@ def enable_core_dumps():
 
 def prepare_exec():
     """Set up the execution environment for SWTPM."""
-
-    if cgroup_slice is not None:
-        # Move to nominated cgroup slice
-        print("Moving to cgroup slice '%s'" % cgroup_slice)
-        try:
-            # Note the default slice uses /sys/fs/cgroup/cpu/tasks but
-            # other.slice uses /sys/fs/cgroup/cpu/other.slice/tasks.
-            g = open("/sys/fs/cgroup/cpu/%s/tasks" % cgroup_slice, 'w')
-            g.write(str(os.getpid()))
-            g.close()
-        except IOError as e:
-            print("Warning: writing pid to '%s' tasks file: %s" \
-                % (cgroup_slice, e))
 
     core_dump_limit = enable_core_dumps()
     print("core dump limit: %d" % core_dump_limit)


### PR DESCRIPTION
There is code in swtpm-wrapper for changing cgroups that sholud not be there.  This is all looked after by systemd now.