### PR TITLE
CA-369690: Prioritize loglines when backing up RRDs, remove loglines about stunnel

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_monitor.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_monitor.ml
@@ -103,8 +103,6 @@ let update_rrds timestamp dss uuid_domids paused_vms =
       | None ->
           Some (add_ds_to StringMap.empty)
       | Some dss ->
-          warn {|%s: found duplicate datasource with key "%s" in owner "%a"|}
-            __FUNCTION__ ds.ds_name owner_to_string owner ;
           Some (add_ds_to dss)
     in
     OwnerMap.update owner merge all


### PR DESCRIPTION
By default xcp-rrdd does not log debug lines, elevate two messages so
it's easier to know when this operation starts happening and when it
fails.

Two loglines per call removed: one is not really useful since the first
logline already contains the most important information about the
stunnel configuration and the one about the cache is not important as
the code is known to work as intended.

The main logline about stunnel has been changed to make it obvious there
has been a change in the are about logging when looking at logs

