### PR TITLE
Enable HTTPS for storage migration on the source host

### DIFF
--- a/ocaml/libs/http-svr/http.ml
+++ b/ocaml/libs/http-svr/http.ml
@@ -992,4 +992,6 @@ module Url = struct
 
   let auth_of (scheme, _) =
     match scheme with File _ -> None | Http {auth; _} -> auth
+
+  let set_ssl ssl = function Http h, d -> (Http {h with ssl}, d) | x -> x
 end

--- a/ocaml/libs/http-svr/http.mli
+++ b/ocaml/libs/http-svr/http.mli
@@ -269,4 +269,6 @@ module Url : sig
   val get_query : t -> string
 
   val auth_of : t -> authorization option
+
+  val set_ssl : bool -> t -> t
 end

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2552,7 +2552,10 @@ let migrate_receive ~__context ~host ~network ~options:_ =
                (Api_errors.interface_has_no_ip, [Ref.string_of pif])
             )
   ) ;
-  let scheme = if !Xapi_globs.migration_https_only then "https" else "http" in
+  (* Set the scheme to HTTP and let the migration source host decide whether to
+     switch to HTTPS instead, to avoid problems with source hosts that are not
+     able to do HTTPS migrations yet. *)
+  let scheme = "http" in
   let sm_url =
     Printf.sprintf "%s://%s/services/SM?session_id=%s" scheme
       (Http.Url.maybe_wrap_IPv6_literal ip)


### PR DESCRIPTION
This is currently set on the destination, in host.migrate_receive. However, all recent changes to make HTTPS migration work were on the source host. Migration is allowed from older to newer software versions, so it is possible that the destination is HTTPS capable, while the source is not. This may result in the source receiving HTTPS URLs, which is cannot handle, breaking this upgrade case.

Instead, let the source decide whether to switch to HTTPS or not, depending on the config key (to be made the default later).

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>