### PR TITLE
CA-391658: toolstack restart when HA is enabled is not safe

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -9,7 +9,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 756
+let schema_minor_vsn = 757
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1959,6 +1959,9 @@ let t =
             ~in_product_since:rel_orlando ~ty:(Set String)
             ~default_value:(Some (VSet [])) "ha_network_peers"
             "The set of hosts visible via the network from this host"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
+            ~internal_only:true ~default_value:(Some (VDateTime Date.never))
+            "ha_healthcheck_timestamp" "Timestamp of last HA health check"
         ; field ~qualifier:DynamicRO ~in_product_since:rel_orlando
             ~ty:(Map (String, Ref _blob))
             ~default_value:(Some (VMap [])) "blobs"

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "39db2a6a38076fdb59070df945072b81"
+let last_known_schema_hash = "81680b1a0f58b95efeb27939544c1e39"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -204,7 +204,7 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~display:`enabled ~virtual_hardware_platform_versions:[]
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
-    ~tls_verification_enabled
+    ~tls_verification_enabled ~ha_healthcheck_timestamp:Date.never
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref) ;
   ref
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -766,6 +766,9 @@ let restart_agent ~__context ~host:_ =
 
 let shutdown_agent ~__context =
   debug "Host.restart_agent: Host agent will shutdown in 1s!!!!" ;
+  if Pool_role.is_master () &&
+    try Localdb.get Constants.ha_armed = "true" with _ -> false then
+    raise (Api_errors.Server_error (Api_errors.ha_is_enabled, [])) ;
   Xapi_fuse.light_fuse_and_dont_restart ~fuse_length:1. ()
 
 let disable ~__context ~host =

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -140,7 +140,7 @@ val ha_release_resources : __context:Context.t -> host:'a -> unit
 
 val ha_wait_for_shutdown_via_statefile : __context:'a -> host:'b -> unit
 
-val ha_xapi_healthcheck : __context:'a -> bool
+val ha_xapi_healthcheck : __context:Context.t -> bool
 
 val preconfigure_ha :
      __context:Context.t

--- a/scripts/xe-toolstack-restart
+++ b/scripts/xe-toolstack-restart
@@ -49,15 +49,13 @@ for svc in $SERVICES ; do
 
 	if [ $? -eq 0 ] ; then
 		TO_RESTART="$svc $TO_RESTART"
-		systemctl stop $svc
 	fi
 done
+systemctl stop ${TO_RESTART}
 
 set -e
 
-for svc in $TO_RESTART ; do
-	systemctl start $svc
-done
+systemctl start ${TO_RESTART}
 
 rm -f $LOCKFILE
 echo "done."


### PR DESCRIPTION
Try to reduce toolstack downtime on toolstack restart by stopping and starting all the services at once: then any timeouts will be handled in parallel instead of sequently (i.e. ~1m30s, after which systemd will SIGKILL, instead of ~32m).

Reject toolstack restart through the API (e.g. from XenCenter) when HA is enabled, requiring you to disable HA first with `xe host-emergency-ha-disable --force` as documented.

We should also tune the default HA xapi check timeouts though, the default 60s for XHA Is wrong (larger than 1m30s in toolstack restart), and even the 120s for SMAPIv3 is dangerously close.

Alternatively toolstack restart could do the emergency HA disable itself, but actions like that are probably best if the user is aware of them, at least when done through the UI. Perhaps the toolstack restart script should either check and reject if HA is enabled or emergency disable it itself to prevent the undesired host fencing.

There are probably more improvements we can do here, hence a draft, because HA doesn't actually detect a stuck XAPI (xapi responds to healthchecks, but you can't start/stop VMs due to a stuck SR for example)