### PR TITLE
CA-372785 make with-vdi more robust

### DIFF
--- a/scripts/with-vdi
+++ b/scripts/with-vdi
@@ -44,7 +44,12 @@ else
 fi
 VBD=$(xe vbd-create vm-uuid=${CONTROL_DOMAIN_UUID} vdi-uuid=${VDI} \
   device=autodetect mode=${MODE} unpluggable=true)
-xe vbd-plug uuid="${VBD}"
+
+xe vbd-plug uuid="${VBD}" && RC="$?" || RC="$?"
+if [ "$RC" != 0 ]; then
+  xe vbd-destroy uuid="${VBD}"
+  exit "$RC"
+fi
 DEVICE=$(xe vbd-param-get uuid="${VBD}" param-name=device)
 export DEVICE
 if [ -z "$COMMAND" ]; then


### PR DESCRIPTION
The vbd-plug call in with-vdi may fail after a VBD was already created. The errexit option would cause the script to fail before the VBD would be destroyed. So make sure we destroy the VBD if vbd-plug fails.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>