### PR TITLE
Modify Xenctrlext to use its own libxc handle

### DIFF
--- a/ocaml/xenopsd/xc/device.mli
+++ b/ocaml/xenopsd/xc/device.mli
@@ -256,7 +256,7 @@ module PCI : sig
 
   val list : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> (int * address) list
 
-  val dequarantine : Xenctrl.handle -> Xenops_interface.Pci.address -> bool
+  val dequarantine : Xenops_interface.Pci.address -> bool
 end
 
 module Vfs : sig

--- a/ocaml/xenopsd/xc/xenctrlext.ml
+++ b/ocaml/xenopsd/xc/xenctrlext.ml
@@ -12,7 +12,27 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xenctrl
+type handle
+
+type domid = Xenctrl.domid
+
+external interface_open : unit -> handle = "stub_xenctrlext_interface_open"
+
+let handle = ref None
+
+let get_handle () =
+  match !handle with
+  | Some h ->
+      h
+  | None ->
+      let h =
+        try interface_open ()
+        with e ->
+          let msg = Printexc.to_string e in
+          failwith ("failed to open xenctrlext: " ^ msg)
+      in
+      handle := Some h ;
+      h
 
 external get_boot_cpufeatures :
   handle -> int32 * int32 * int32 * int32 * int32 * int32 * int32 * int32

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -12,7 +12,13 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xenctrl
+type handle
+
+type domid = Xenctrl.domid
+
+external interface_open : unit -> handle = "stub_xenctrlext_interface_open"
+
+val get_handle : unit -> handle
 
 external get_boot_cpufeatures :
   handle -> int32 * int32 * int32 * int32 * int32 * int32 * int32 * int32


### PR DESCRIPTION
Xenopsd's _H() in xenctrlext_stubs blindly reaches sideways into the internals of a different libray (specifically, Xenctrl from upstream Xen).  This violates many API/ABI rules.  It also breaks now that upstream Xen has switched Xenctrl to using a Custom block.

Have Xenctrlext open its own libxc handle, to disentangle it from Xenctrl.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>