### PR TITLE
Xenctrl: drop interface_close

### DIFF
--- a/ocaml/xenopsd/dbgring/dbgring.ml
+++ b/ocaml/xenopsd/dbgring/dbgring.ml
@@ -24,10 +24,8 @@ let open_ring0 () =
   Unix.close fd ; intf
 
 let open_ringU domid mfn =
-  let xc = Xenctrl.interface_open () in
-  Xapi_stdext_pervasives.Pervasiveext.finally
-    (fun () -> Xenctrl.map_foreign_range xc domid (Xenmmap.getpagesize ()) mfn)
-    (fun () -> Xenctrl.interface_close xc)
+  Xenctrl.with_intf @@ fun xc ->
+  Xenctrl.map_foreign_range xc domid (Xenmmap.getpagesize ()) mfn
 
 let open_ring domid mfn =
   if domid = 0 then

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -5196,10 +5196,7 @@ let look_for_xen () =
       exit 1
 
 let look_for_xenctrl () =
-  try
-    let xc = Xenctrl.interface_open () in
-    debug "xenctrl interface is available" ;
-    Xenctrl.interface_close xc
+  try Xenctrl.with_intf @@ fun _xc -> debug "xenctrl interface is available"
   with e ->
     error "I failed to open the low-level xen control interface (xenctrl)" ;
     error "The raw error was: %s" (Printexc.to_string e) ;


### PR DESCRIPTION
This got removed from Xen 4.18. We only use a global, so switch to using Xenctrl.with_intf.

(We can't use a single global 'xc' value, because that might cause some unit tests to fail since initializing xenctrl outside of a Xen system is not possible, so delaying initialization is still needed).

Signed-off-by: Edwin Török <edvin.torok@citrix.com>