### PR TITLE
Fix extra `/` in https redirection

### DIFF
--- a/ocaml/xapi/fileserver.ml
+++ b/ocaml/xapi/fileserver.ml
@@ -93,8 +93,10 @@ let send_file (uri_base : string) (dir : string) (req : Request.t)
     match req.Request.host with
     | Some host ->
         (* Redirect towards HTTPS *)
-        let path = String.concat "" [uri_base; req.Request.uri] in
-        let dest = Uri.make ~scheme:"https" ~host ~path () |> Uri.to_string in
+        let dest =
+          Uri.make ~scheme:"https" ~host ~path:req.Request.uri ()
+          |> Uri.to_string
+        in
         Http_svr.response_redirect ~req s dest
     | None ->
         Http_svr.response_forbidden ~req s


### PR DESCRIPTION
Do not use `uri_base` when redirecting towards https

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>