### PR TITLE
CP-40950: Make bias against scheduling vms on pool master configurable

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -21,6 +21,8 @@ let prototyped_of_field = function
       Some "22.20.0"
   | "pool", "migration_compression" ->
       Some "22.33.0"
+  | "pool", "coordinator_bias" ->
+      Some "22.34.0-next"
   | _ ->
       None
 

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1327,6 +1327,10 @@ let t =
             ~default_value:(Some (VBool false)) "migration_compression"
             "Default behaviour during migration, True if stream compression \
              should be used"
+        ; field ~qualifier:RW ~ty:Bool ~default_value:(Some (VBool true))
+            "coordinator_bias"
+            "true if bias against pool master when scheduling vms is enabled, \
+             false otherwise"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "91175adc3dd18f9a75cde195ca76148e"
+let last_known_schema_hash = "e7329cee96ae9a638cd62ca4fad6f413"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -284,7 +284,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(client_certificate_auth_enabled = false)
     ?(client_certificate_auth_name = "") ?(repository_proxy_url = "")
     ?(repository_proxy_username = "") ?(repository_proxy_password = Ref.null)
-    ?(migration_compression = false) () =
+    ?(migration_compression = false) ?(coordinator_bias = true) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -299,7 +299,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~tls_verification_enabled:false ~repositories
     ~client_certificate_auth_enabled ~client_certificate_auth_name
     ~repository_proxy_url ~repository_proxy_username ~repository_proxy_password
-    ~migration_compression ;
+    ~migration_compression ~coordinator_bias ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/tests/test_vm_placement.ml
+++ b/ocaml/tests/test_vm_placement.ml
@@ -435,7 +435,7 @@ module Categorisation = struct
         Alcotest.(check int64)
           "same ints"
           (Int64.of_int expected_result)
-          (Vm_placement.definite_host_category
+          (Vm_placement.definite_host_category ~master_bias:true
              (mock_slave a s_min d_min d_max s_max)
           )
       )
@@ -466,7 +466,7 @@ module Categorisation = struct
         Alcotest.(check int64)
           "same ints"
           (Int64.of_int expected_result)
-          (Vm_placement.definite_host_category
+          (Vm_placement.definite_host_category ~master_bias:true
              (mock_master a s_min d_min d_max s_max)
           )
       )
@@ -497,7 +497,7 @@ module Categorisation = struct
         Alcotest.(check int64)
           "same ints"
           (Int64.of_int expected_result)
-          (Vm_placement.probable_host_category
+          (Vm_placement.probable_host_category ~master_bias:true
              (mock_slave a s_min d_min d_max s_max)
           )
       )
@@ -528,7 +528,7 @@ module Categorisation = struct
         Alcotest.(check int64)
           "same ints"
           (Int64.of_int expected_result)
-          (Vm_placement.probable_host_category
+          (Vm_placement.probable_host_category ~master_bias:true
              (mock_master a s_min d_min d_max s_max)
           )
       )

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1453,6 +1453,13 @@ let pool_record rpc session_id pool =
               ~value:(bool_of_string x)
           )
           ()
+      ; make_field ~name:"coordinator-bias"
+          ~get:(fun () -> (x ()).API.pool_coordinator_bias |> string_of_bool)
+          ~set:(fun x ->
+            Client.Pool.set_coordinator_bias ~rpc ~session_id ~self:pool
+              ~value:(bool_of_string x)
+          )
+          ()
       ]
   }
 

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -47,6 +47,7 @@ let create_pool_record ~__context =
       ~client_certificate_auth_enabled:false ~client_certificate_auth_name:""
       ~repository_proxy_url:"" ~repository_proxy_username:""
       ~repository_proxy_password:Ref.null ~migration_compression:false
+      ~coordinator_bias:true
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/xapi_vm_placement.ml
+++ b/ocaml/xapi/xapi_vm_placement.ml
@@ -93,9 +93,11 @@ let select_host __context guest validate_host hosts =
   let validate_host uuid =
     validate_host (Db.Host.get_by_uuid ~__context ~uuid)
   in
+  let pool = Helpers.get_pool ~__context in
+  let master_bias = Db.Pool.get_coordinator_bias ~__context ~self:pool in
   let host =
     select_host_from_summary pool_summary affinity_host_ids validate_host
-      random_fn
+      master_bias random_fn
   in
   match host with
   | Some host ->


### PR DESCRIPTION
By design, the pool master has a bias against scheduling VMs on it, preferring other member hosts.
An option to toggle this bias has been added, which can be used to improve performance, for example when the non-master hosts get overloaded.