### PR TITLE
Allow to use a CIDR for VIFs IPv4 and IPv6 allowed IPs

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1102,6 +1102,10 @@ let assert_is_valid_cidr kind field cidr =
   if parse_cidr kind cidr = None then
     raise Api_errors.(Server_error (invalid_cidr_address_specified, [field]))
 
+let assert_is_valid_ip_addr kind field address =
+  if (not (is_valid_ip kind address)) && parse_cidr kind address = None then
+    raise Api_errors.(Server_error (invalid_ip_address_specified, [field]))
+
 (** Return true if the MAC is in the right format XX:XX:XX:XX:XX:XX *)
 let is_valid_MAC mac =
   let l = String.split_on_char ':' mac in

--- a/ocaml/xapi/xapi_vif.ml
+++ b/ocaml/xapi/xapi_vif.ml
@@ -118,16 +118,16 @@ let set_locking_mode ~__context ~self ~value =
     (fun () -> Db.VIF.set_locking_mode ~__context ~self ~value)
 
 let set_ipv4_allowed ~__context ~self ~value =
-  let setified_value = Listext.setify value in
-  change_locking_config ~__context ~self ~licence_check:(setified_value <> [])
+  let addr_set = Listext.setify value in
+  change_locking_config ~__context ~self ~licence_check:(addr_set <> [])
     (fun () ->
-      List.iter (Helpers.assert_is_valid_ip `ipv4 "ipv4_allowed") setified_value ;
-      Db.VIF.set_ipv4_allowed ~__context ~self ~value:setified_value
+      List.iter (Helpers.assert_is_valid_ip_addr `ipv4 "ipv4_allowed") addr_set ;
+      Db.VIF.set_ipv4_allowed ~__context ~self ~value:addr_set
   )
 
 let add_ipv4_allowed ~__context ~self ~value =
   change_locking_config ~__context ~self ~licence_check:true (fun () ->
-      Helpers.assert_is_valid_ip `ipv4 "ipv4_allowed" value ;
+      Helpers.assert_is_valid_ip_addr `ipv4 "ipv4_allowed" value ;
       Db.VIF.add_ipv4_allowed ~__context ~self ~value
   )
 
@@ -137,16 +137,16 @@ let remove_ipv4_allowed ~__context ~self ~value =
   )
 
 let set_ipv6_allowed ~__context ~self ~value =
-  let setified_value = Listext.setify value in
-  change_locking_config ~__context ~self ~licence_check:(setified_value <> [])
+  let addr_set = Listext.setify value in
+  change_locking_config ~__context ~self ~licence_check:(addr_set <> [])
     (fun () ->
-      List.iter (Helpers.assert_is_valid_ip `ipv6 "ipv6_allowed") setified_value ;
-      Db.VIF.set_ipv6_allowed ~__context ~self ~value:setified_value
+      List.iter (Helpers.assert_is_valid_ip_addr `ipv6 "ipv6_allowed") addr_set ;
+      Db.VIF.set_ipv6_allowed ~__context ~self ~value:addr_set
   )
 
 let add_ipv6_allowed ~__context ~self ~value =
   change_locking_config ~__context ~self ~licence_check:true (fun () ->
-      Helpers.assert_is_valid_ip `ipv6 "ipv6_allowed" value ;
+      Helpers.assert_is_valid_ip_addr `ipv6 "ipv6_allowed" value ;
       Db.VIF.add_ipv6_allowed ~__context ~self ~value
   )
 


### PR DESCRIPTION
- New `Helpers` method: `assert_is_valid_ip_addr`
- Use the new methoid in the setters and adders of a VIF's allowed IPs

Solves https://github.com/xapi-project/xen-api/issues/4694

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>