### PR TITLE
CP-41444 Added actions_after_softreboot field and passed to Xenopsd

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 758
+let schema_minor_vsn = 759
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -19,6 +19,8 @@ let prototyped_of_field = function
       Some "22.27.0"
   | "host", "last_software_update" ->
       Some "22.20.0"
+  | "VM", "actions__after_softreboot" ->
+      Some "22.34.0-next"
   | "pool", "coordinator_bias" ->
       Some "22.34.0-next"
   | "pool", "migration_compression" ->

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -98,6 +98,17 @@ let on_crash_behaviour =
       ]
     )
 
+let on_softreboot_behavior =
+  Enum
+    ( "on_softreboot_behavior"
+    , [
+        ("soft_reboot", "perform soft-reboot")
+      ; ("destroy", "destroy the VM state")
+      ; ("restart", "restart the VM")
+      ; ("preserve", "leave the VM paused")
+      ]
+    )
+
 let on_normal_exit_behaviour =
   Enum
     ( "on_normal_exit"
@@ -118,8 +129,13 @@ let vcpus =
 let actions =
   let crash = field ~qualifier:StaticRO ~ty:on_crash_behaviour in
   let normal = field ~ty:on_normal_exit_behaviour in
+  let soft =
+    field ~qualifier:RW ~lifecycle:[] ~ty:on_softreboot_behavior
+      ~default_value:(Some (VEnum "soft_reboot"))
+  in
   [
-    normal "after_shutdown" "action to take after the guest has shutdown itself"
+    soft "after_softreboot" "action to take after soft reboot"
+  ; normal "after_shutdown" "action to take after the guest has shutdown itself"
   ; normal "after_reboot" "action to take after the guest has rebooted itself"
   ; crash "after_crash" "action to take if the guest crashes"
   ]

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "e7329cee96ae9a638cd62ca4fad6f413"
+let last_known_schema_hash = "24ec58d6f7fb24a2a6c48aa4973521ed"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -128,6 +128,7 @@ let make_vm ~__context ?(name_label = "name_label")
     ?(memory_static_max = 1000L) ?(memory_dynamic_max = 500L)
     ?(memory_dynamic_min = 500L) ?(memory_static_min = 0L) ?(vCPUs_params = [])
     ?(vCPUs_max = 1L) ?(vCPUs_at_startup = 1L)
+    ?(actions_after_softreboot = `soft_reboot)
     ?(actions_after_shutdown = `destroy) ?(actions_after_reboot = `restart)
     ?(actions_after_crash = `destroy) ?(pV_bootloader = "") ?(pV_kernel = "")
     ?(pV_ramdisk = "") ?(pV_args = "") ?(pV_bootloader_args = "")
@@ -147,16 +148,17 @@ let make_vm ~__context ?(name_label = "name_label")
   Xapi_vm.create ~__context ~name_label ~name_description ~user_version
     ~is_a_template ~affinity ~memory_target ~memory_static_max
     ~memory_dynamic_max ~memory_dynamic_min ~memory_static_min ~vCPUs_params
-    ~vCPUs_max ~vCPUs_at_startup ~actions_after_shutdown ~actions_after_reboot
-    ~actions_after_crash ~pV_bootloader ~pV_kernel ~pV_ramdisk ~pV_args
-    ~pV_bootloader_args ~pV_legacy_args ~hVM_boot_policy ~hVM_boot_params
-    ~hVM_shadow_multiplier ~platform ~nVRAM ~pCI_bus ~other_config
-    ~xenstore_data ~recommendations ~ha_always_run ~ha_restart_priority ~tags
-    ~blocked_operations ~protection_policy ~appliance ~start_delay
-    ~shutdown_delay ~order ~suspend_SR ~suspend_VDI ~snapshot_schedule
-    ~is_vmss_snapshot ~version ~generation_id ~hardware_platform_version
-    ~has_vendor_device ~reference_label ~domain_type ~last_booted_record
-    ~last_boot_CPU_flags ~power_state
+    ~vCPUs_max ~vCPUs_at_startup ~actions_after_softreboot
+    ~actions_after_shutdown ~actions_after_reboot ~actions_after_crash
+    ~pV_bootloader ~pV_kernel ~pV_ramdisk ~pV_args ~pV_bootloader_args
+    ~pV_legacy_args ~hVM_boot_policy ~hVM_boot_params ~hVM_shadow_multiplier
+    ~platform ~nVRAM ~pCI_bus ~other_config ~xenstore_data ~recommendations
+    ~ha_always_run ~ha_restart_priority ~tags ~blocked_operations
+    ~protection_policy ~appliance ~start_delay ~shutdown_delay ~order
+    ~suspend_SR ~suspend_VDI ~snapshot_schedule ~is_vmss_snapshot ~version
+    ~generation_id ~hardware_platform_version ~has_vendor_device
+    ~reference_label ~domain_type ~last_booted_record ~last_boot_CPU_flags
+    ~power_state
 
 let make_host ~__context ?(uuid = make_uuid ()) ?(name_label = "host")
     ?(name_description = "description") ?(hostname = "localhost")

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -2747,13 +2747,13 @@ let vm_create printer rpc session_id params =
       ~affinity:Ref.null ~memory_target:memory_max ~memory_static_max:memory_max
       ~memory_dynamic_max:memory_max ~memory_dynamic_min:memory_min
       ~memory_static_min:memory_min ~vCPUs_params:[] ~vCPUs_max:1L
-      ~vCPUs_at_startup:1L ~actions_after_shutdown:`destroy
-      ~actions_after_reboot:`restart ~actions_after_crash:`destroy
-      ~pV_bootloader:"" ~pV_kernel:"" ~pV_ramdisk:"" ~pV_args:""
-      ~pV_bootloader_args:"" ~pV_legacy_args:"" ~hVM_boot_policy:""
-      ~hVM_boot_params:[] ~hVM_shadow_multiplier:1. ~platform:[] ~pCI_bus:""
-      ~other_config:[] ~xenstore_data:[] ~recommendations:""
-      ~ha_always_run:false ~ha_restart_priority:"" ~tags:[]
+      ~vCPUs_at_startup:1L ~actions_after_softreboot:`soft_reboot
+      ~actions_after_shutdown:`destroy ~actions_after_reboot:`restart
+      ~actions_after_crash:`destroy ~pV_bootloader:"" ~pV_kernel:""
+      ~pV_ramdisk:"" ~pV_args:"" ~pV_bootloader_args:"" ~pV_legacy_args:""
+      ~hVM_boot_policy:"" ~hVM_boot_params:[] ~hVM_shadow_multiplier:1.
+      ~platform:[] ~pCI_bus:"" ~other_config:[] ~xenstore_data:[]
+      ~recommendations:"" ~ha_always_run:false ~ha_restart_priority:"" ~tags:[]
       ~protection_policy:Ref.null ~snapshot_schedule:Ref.null
       ~is_vmss_snapshot:false ~appliance:Ref.null ~start_delay:0L
       ~shutdown_delay:0L ~order:0L ~suspend_SR:Ref.null ~suspend_VDI:Ref.null
@@ -2762,6 +2762,7 @@ let vm_create printer rpc session_id params =
       ~nVRAM:[] ~last_booted_record:"" ~last_boot_CPU_flags:[]
       ~power_state:`Halted
   in
+
   let uuid = Client.VM.get_uuid ~rpc ~session_id ~self:vm in
   printer (Cli_printer.PList [uuid])
 

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -628,6 +628,37 @@ let string_to_on_crash_behaviour s =
            )
         )
 
+let on_softreboot_behaviour_to_string x =
+  match x with
+  | `destroy ->
+      "Destroy"
+  | `restart ->
+      "Restart"
+  | `preserve ->
+      "Preserve"
+  | `soft_reboot ->
+      "Soft reboot"
+
+let string_to_on_softreboot_behaviour s =
+  match String.lowercase_ascii s with
+  | "destroy" ->
+      `destroy
+  | "restart" ->
+      `restart
+  | "preserve" ->
+      `preserve
+  | "soft_reboot" ->
+      `soft_reboot
+  | _ ->
+      raise
+        (Record_failure
+           ("Expected 'destroy', 'coredump_and_destroy',"
+           ^ "'restart', 'coredump_and_restart', 'preserve', 'soft_reboot' or \
+              'rename_restart', got "
+           ^ s
+           )
+        )
+
 let host_display_to_string h =
   match h with
   | `enabled ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1963,6 +1963,16 @@ let vm_record rpc session_id vm =
               ~value:(Record_util.string_to_on_normal_exit x)
           )
           ()
+      ; make_field ~name:"actions-after-softreboot"
+          ~get:(fun () ->
+            Record_util.on_softreboot_behaviour_to_string
+              (x ()).API.vM_actions_after_softreboot
+          )
+          ~set:(fun x ->
+            Client.VM.set_actions_after_softreboot ~rpc ~session_id ~self:vm
+              ~value:(Record_util.string_to_on_softreboot_behaviour x)
+          )
+          ()
       ; make_field ~name:"actions-after-reboot"
           ~get:(fun () ->
             Record_util.on_normal_exit_to_string

--- a/ocaml/xapi-idl/lib_test/xen_test.ml
+++ b/ocaml/xapi-idl/lib_test/xen_test.ml
@@ -22,9 +22,9 @@ let old_vm_t =
    \"memory_static_max\": 268435456, \"memory_dynamic_max\": 268435456, \
    \"memory_dynamic_min\": 134217728, \"vcpu_max\": 1, \"vcpus\": 1, \
    \"scheduler_params\": {\"priority\": [256, 0], \"affinity\": []}, \
-   \"on_crash\": [\"Shutdown\"], \"on_shutdown\": [\"Shutdown\"], \
-   \"on_reboot\": [\"Start\"], \"pci_msitranslate\": true, \"pci_power_mgmt\": \
-   false}"
+   \"on_softreboot\": [\"Shutdown\"], \"on_crash\": [\"Shutdown\"], \
+   \"on_shutdown\": [\"Shutdown\"], \"on_reboot\": [\"Start\"], \
+   \"pci_msitranslate\": true, \"pci_power_mgmt\": false}"
 
 let test_upgrade_rules () =
   let old_json = old_vm_t in

--- a/ocaml/xapi-idl/xen/xenops_types.ml
+++ b/ocaml/xapi-idl/xen/xenops_types.ml
@@ -134,7 +134,8 @@ module Vm = struct
 
   type id = string [@@deriving rpcty, sexp]
 
-  type action = Coredump | Shutdown | Start | Pause [@@deriving rpcty, sexp]
+  type action = Coredump | Shutdown | Start | Pause | Softreboot
+  [@@deriving rpcty, sexp]
 
   type scheduler_params = {
       priority: (int * int) option  (** weight, cap *)
@@ -161,6 +162,7 @@ module Vm = struct
     ; on_crash: action list
     ; on_shutdown: action list
     ; on_reboot: action list
+    ; on_softreboot: action list [@default [Softreboot]]
     ; pci_msitranslate: bool
     ; pci_power_mgmt: bool
     ; has_vendor_device: bool [@default false]

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -295,17 +295,18 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info : host_info
     ~hVM_boot_policy:"" ~hVM_boot_params:[] ~hVM_shadow_multiplier:1.
     ~platform:[] ~pCI_bus:"" ~pV_args:"" ~pV_ramdisk:"" ~pV_kernel:""
     ~pV_bootloader:"" ~pV_bootloader_args:"" ~pV_legacy_args:""
-    ~actions_after_crash:`destroy ~actions_after_reboot:`destroy
-    ~actions_after_shutdown:`destroy ~allowed_operations:[]
-    ~current_operations:[] ~blocked_operations:[] ~power_state:`Running
-    ~vCPUs_max:(Int64.of_int vcpus) ~vCPUs_at_startup:(Int64.of_int vcpus)
-    ~vCPUs_params:[] ~memory_overhead:0L ~memory_static_min:memory.static_min
-    ~memory_dynamic_min:memory.dynamic_min ~memory_target:memory.target
-    ~memory_static_max:memory.static_max ~memory_dynamic_max:memory.dynamic_max
-    ~resident_on:localhost ~scheduled_to_be_resident_on:Ref.null
-    ~affinity:localhost ~suspend_VDI:Ref.null ~domid:0L ~domarch
-    ~is_control_domain:true ~is_a_template:false ~is_default_template:false
-    ~is_a_snapshot:false ~snapshot_time:Date.never ~snapshot_of:Ref.null
+    ~actions_after_softreboot:`soft_reboot ~actions_after_crash:`destroy
+    ~actions_after_reboot:`destroy ~actions_after_shutdown:`destroy
+    ~allowed_operations:[] ~current_operations:[] ~blocked_operations:[]
+    ~power_state:`Running ~vCPUs_max:(Int64.of_int vcpus)
+    ~vCPUs_at_startup:(Int64.of_int vcpus) ~vCPUs_params:[] ~memory_overhead:0L
+    ~memory_static_min:memory.static_min ~memory_dynamic_min:memory.dynamic_min
+    ~memory_target:memory.target ~memory_static_max:memory.static_max
+    ~memory_dynamic_max:memory.dynamic_max ~resident_on:localhost
+    ~scheduled_to_be_resident_on:Ref.null ~affinity:localhost
+    ~suspend_VDI:Ref.null ~domid:0L ~domarch ~is_control_domain:true
+    ~is_a_template:false ~is_default_template:false ~is_a_snapshot:false
+    ~snapshot_time:Date.never ~snapshot_of:Ref.null
     ~transportable_snapshot_id:"" ~snapshot_info:[] ~snapshot_metadata:""
     ~parent:Ref.null ~other_config:[] ~blobs:[] ~xenstore_data:[] ~tags:[]
     ~user_version:1L ~ha_restart_priority:"" ~ha_always_run:false

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -585,16 +585,16 @@ let resume_on ~__context ~vm ~host ~start_paused ~force =
 let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~is_a_template ~suspend_VDI ~affinity ~memory_target ~memory_static_max
     ~memory_dynamic_max ~memory_dynamic_min ~memory_static_min ~vCPUs_params
-    ~vCPUs_max ~vCPUs_at_startup ~actions_after_shutdown ~actions_after_reboot
-    ~actions_after_crash ~pV_bootloader ~pV_kernel ~pV_ramdisk ~pV_args
-    ~pV_bootloader_args ~pV_legacy_args ~hVM_boot_policy ~hVM_boot_params
-    ~hVM_shadow_multiplier ~platform ~pCI_bus ~other_config ~last_boot_CPU_flags
-    ~last_booted_record ~recommendations ~xenstore_data ~ha_always_run
-    ~ha_restart_priority ~tags ~blocked_operations:_ ~protection_policy:_
-    ~snapshot_schedule:_ ~is_vmss_snapshot:_ ~appliance ~start_delay
-    ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
-    ~hardware_platform_version ~has_vendor_device ~reference_label ~domain_type
-    ~nVRAM : API.ref_VM =
+    ~vCPUs_max ~vCPUs_at_startup ~actions_after_softreboot
+    ~actions_after_shutdown ~actions_after_reboot ~actions_after_crash
+    ~pV_bootloader ~pV_kernel ~pV_ramdisk ~pV_args ~pV_bootloader_args
+    ~pV_legacy_args ~hVM_boot_policy ~hVM_boot_params ~hVM_shadow_multiplier
+    ~platform ~pCI_bus ~other_config ~last_boot_CPU_flags ~last_booted_record
+    ~recommendations ~xenstore_data ~ha_always_run ~ha_restart_priority ~tags
+    ~blocked_operations:_ ~protection_policy:_ ~snapshot_schedule:_
+    ~is_vmss_snapshot:_ ~appliance ~start_delay ~shutdown_delay ~order
+    ~suspend_SR ~version ~generation_id ~hardware_platform_version
+    ~has_vendor_device ~reference_label ~domain_type ~nVRAM : API.ref_VM =
   if has_vendor_device then
     Pool_features.assert_enabled ~__context
       ~f:Features.PCI_device_for_auto_update ;
@@ -662,19 +662,19 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~scheduled_to_be_resident_on ~affinity ~memory_overhead:0L
     ~memory_static_max ~memory_dynamic_max ~memory_target ~memory_dynamic_min
     ~memory_static_min ~vCPUs_params ~vCPUs_at_startup ~vCPUs_max
-    ~actions_after_shutdown ~actions_after_reboot ~actions_after_crash
-    ~hVM_boot_policy ~hVM_boot_params ~hVM_shadow_multiplier
-    ~suspend_VDI:_suspend_VDI ~platform ~nVRAM ~pV_kernel ~pV_ramdisk ~pV_args
-    ~pV_bootloader ~pV_bootloader_args ~pV_legacy_args ~pCI_bus ~other_config
-    ~domid:(-1L) ~domarch:"" ~last_boot_CPU_flags:_last_boot_CPU_flags
-    ~is_control_domain:false ~metrics ~guest_metrics:Ref.null
-    ~last_booted_record:_last_booted_record ~xenstore_data ~recommendations
-    ~blobs:[] ~ha_restart_priority ~ha_always_run ~tags ~bios_strings:[]
-    ~protection_policy:Ref.null ~snapshot_schedule:Ref.null
-    ~is_vmss_snapshot:false ~appliance ~start_delay ~shutdown_delay ~order
-    ~suspend_SR ~version ~generation_id ~hardware_platform_version
-    ~has_vendor_device ~requires_reboot:false ~reference_label ~domain_type
-    ~pending_guidances:[] ;
+    ~actions_after_softreboot ~actions_after_shutdown ~actions_after_reboot
+    ~actions_after_crash ~hVM_boot_policy ~hVM_boot_params
+    ~hVM_shadow_multiplier ~suspend_VDI:_suspend_VDI ~platform ~nVRAM ~pV_kernel
+    ~pV_ramdisk ~pV_args ~pV_bootloader ~pV_bootloader_args ~pV_legacy_args
+    ~pCI_bus ~other_config ~domid:(-1L) ~domarch:""
+    ~last_boot_CPU_flags:_last_boot_CPU_flags ~is_control_domain:false ~metrics
+    ~guest_metrics:Ref.null ~last_booted_record:_last_booted_record
+    ~xenstore_data ~recommendations ~blobs:[] ~ha_restart_priority
+    ~ha_always_run ~tags ~bios_strings:[] ~protection_policy:Ref.null
+    ~snapshot_schedule:Ref.null ~is_vmss_snapshot:false ~appliance ~start_delay
+    ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
+    ~hardware_platform_version ~has_vendor_device ~requires_reboot:false
+    ~reference_label ~domain_type ~pending_guidances:[] ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -158,6 +158,7 @@ val create :
   -> vCPUs_params:(string * string) list
   -> vCPUs_max:int64
   -> vCPUs_at_startup:int64
+  -> actions_after_softreboot:[< `soft_reboot | `destroy | `preserve | `restart]
   -> actions_after_shutdown:[< `destroy | `restart]
   -> actions_after_reboot:[< `destroy | `restart]
   -> actions_after_crash:

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -367,6 +367,7 @@ let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~vCPUs_max:all.Db_actions.vM_VCPUs_max
     ~vCPUs_at_startup:all.Db_actions.vM_VCPUs_at_startup
     ~vCPUs_params:all.Db_actions.vM_VCPUs_params
+    ~actions_after_softreboot:all.Db_actions.vM_actions_after_softreboot
     ~actions_after_shutdown:all.Db_actions.vM_actions_after_shutdown
     ~actions_after_reboot:all.Db_actions.vM_actions_after_reboot
     ~actions_after_crash:all.Db_actions.vM_actions_after_crash

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1120,7 +1120,7 @@ module MD = struct
     |> List.map (fun pusb -> of_vusb ~__context ~vm ~pusb)
 
   let of_vm ~__context (vmref, vm) vbds pci_passthrough vgpu =
-    let on_crash_behaviour = function
+    let on_action_behaviour = function
       | `preserve ->
           [Vm.Pause]
       | `coredump_and_restart ->
@@ -1131,13 +1131,10 @@ module MD = struct
           [Vm.Start]
       | `destroy ->
           [Vm.Shutdown]
+      | `soft_reboot ->
+          [Vm.Softreboot]
     in
-    let on_normal_exit_behaviour = function
-      | `restart ->
-          [Vm.Start]
-      | `destroy ->
-          [Vm.Shutdown]
-    in
+
     let open Vm in
     let scheduler_params =
       (* vcpu <-> pcpu affinity settings are stored here.
@@ -1321,9 +1318,10 @@ module MD = struct
     ; vcpu_max= Int64.to_int vm.API.vM_VCPUs_max
     ; vcpus= Int64.to_int vm.API.vM_VCPUs_at_startup
     ; scheduler_params
-    ; on_crash= on_crash_behaviour vm.API.vM_actions_after_crash
-    ; on_shutdown= on_normal_exit_behaviour vm.API.vM_actions_after_shutdown
-    ; on_reboot= on_normal_exit_behaviour vm.API.vM_actions_after_reboot
+    ; on_crash= on_action_behaviour vm.API.vM_actions_after_crash
+    ; on_shutdown= on_action_behaviour vm.API.vM_actions_after_shutdown
+    ; on_reboot= on_action_behaviour vm.API.vM_actions_after_reboot
+    ; on_softreboot= on_action_behaviour vm.API.vM_actions_after_softreboot
     ; pci_msitranslate
     ; pci_power_mgmt= false
     ; has_vendor_device= vm.API.vM_has_vendor_device

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -671,6 +671,7 @@ let add' _copts x () =
             ; on_crash= [Vm.Shutdown]
             ; on_shutdown= [Vm.Shutdown]
             ; on_reboot= [Vm.Start]
+            ; on_softreboot= [Vm.Softreboot]
             ; pci_msitranslate
             ; pci_power_mgmt
             ; has_vendor_device

--- a/ocaml/xenopsd/test/test.ml
+++ b/ocaml/xenopsd/test/test.ml
@@ -253,6 +253,7 @@ let create_vm vmid =
   ; on_crash= [Vm.Shutdown]
   ; on_shutdown= [Vm.Shutdown]
   ; on_reboot= [Vm.Start]
+  ; on_softreboot= [Vm.Softreboot]
   ; pci_msitranslate= true
   ; pci_power_mgmt= false
   ; has_vendor_device= false
@@ -973,7 +974,7 @@ let barrier_ordering () =
 let test_ca351823 () =
   let open Suspend_image.Xenops_record in
   let s =
-    {|((time 20210219T17:16:27Z)(word_size 64)(vm_str "((id 434d1235-c58b-99f4-f652-c79d57e50719)(name vm-generic-linux)(ssidref 0)(xsdata((vm-data \"\")))(platformdata((featureset 17cbfbff-f7fa3223-2d93fbff-00000023-00000001-000007ab-00000000-00000000-00001000-9c000400)(generation-id \"\")(timeoffset 0)(usb true)(usb_tablet true)(device-model qemu-upstream-compat)(acpi 1)(apic true)(pae true)(hpet true)(vga std)(videoram 8)(nx true)(viridian false)(device_id 0001)))(bios_strings((bios-vendor Xen)(bios-version \"\")(system-manufacturer Xen)(system-product-name \"HVM domU\")(system-version \"\")(system-serial-number \"\")(hp-rombios \"\")(oem-1 Xen)(oem-2 MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d)))(ty(HVM((hap true)(shadow_multiplier 1)(timeoffset 0)(video_mib 8)(video Standard_VGA)(acpi true)(serial(pty))(keymap())(vnc_ip())(pci_emulations())(pci_passthrough false)(boot_order c)(qemu_disk_cmdline false)(qemu_stubdom false))))(suppress_spurious_page_faults false)(machine_address_size())(memory_static_max 4294967296)(memory_dynamic_max 4294967296)(memory_dynamic_min 4294967296)(vcpu_max 2)(vcpus 2)(scheduler_params((priority((256 0)))(affinity())))(on_crash(Pause))(on_shutdown(Shutdown))(on_reboot(Start))(pci_msitranslate true)(pci_power_mgmt false)(has_vendor_device false))")(xs_subtree()))|}
+    {|((time 20210219T17:16:27Z)(word_size 64)(vm_str "((id 434d1235-c58b-99f4-f652-c79d57e50719)(name vm-generic-linux)(ssidref 0)(xsdata((vm-data \"\")))(platformdata((featureset 17cbfbff-f7fa3223-2d93fbff-00000023-00000001-000007ab-00000000-00000000-00001000-9c000400)(generation-id \"\")(timeoffset 0)(usb true)(usb_tablet true)(device-model qemu-upstream-compat)(acpi 1)(apic true)(pae true)(hpet true)(vga std)(videoram 8)(nx true)(viridian false)(device_id 0001)))(bios_strings((bios-vendor Xen)(bios-version \"\")(system-manufacturer Xen)(system-product-name \"HVM domU\")(system-version \"\")(system-serial-number \"\")(hp-rombios \"\")(oem-1 Xen)(oem-2 MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d)))(ty(HVM((hap true)(shadow_multiplier 1)(timeoffset 0)(video_mib 8)(video Standard_VGA)(acpi true)(serial(pty))(keymap())(vnc_ip())(pci_emulations())(pci_passthrough false)(boot_order c)(qemu_disk_cmdline false)(qemu_stubdom false))))(suppress_spurious_page_faults false)(machine_address_size())(memory_static_max 4294967296)(memory_dynamic_max 4294967296)(memory_dynamic_min 4294967296)(vcpu_max 2)(vcpus 2)(scheduler_params((priority((256 0)))(affinity())))(on_softreboot(Pause))(on_crash(Pause))(on_shutdown(Shutdown))(on_reboot(Start))(pci_msitranslate true)(pci_power_mgmt false)(has_vendor_device false))")(xs_subtree()))|}
   in
   match of_string s with
   | Ok _ ->


### PR DESCRIPTION
- An added field in actions namespace: `after_softreboot` to VM
- Contains all actions in `after_crash` and `soft_reboot`
- Updated Xenopsd VM with field and new `Vm.Softreboot` Handler which triggers the previous `B.VM.soft_reset`

Signed-off-by: jameshensmancitrix <james.hensman@citrix.com>