### PR TITLE
xapi-storage{,-script}: explicitely use python2 instead of python

### DIFF
--- a/ocaml/xapi-storage-script/examples/datapath/block/Datapath.activate
+++ b/ocaml/xapi-storage-script/examples/datapath/block/Datapath.activate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 sys.path.append("/home/vagrant/djs55/dbus-test/python")

--- a/ocaml/xapi-storage-script/examples/datapath/block/Datapath.attach
+++ b/ocaml/xapi-storage-script/examples/datapath/block/Datapath.attach
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 sys.path.append("/home/vagrant/djs55/dbus-test/python")

--- a/ocaml/xapi-storage-script/examples/datapath/block/Datapath.deactivate
+++ b/ocaml/xapi-storage-script/examples/datapath/block/Datapath.deactivate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 sys.path.append("/home/vagrant/djs55/dbus-test/python")

--- a/ocaml/xapi-storage-script/examples/datapath/block/Datapath.detach
+++ b/ocaml/xapi-storage-script/examples/datapath/block/Datapath.detach
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 sys.path.append("/home/vagrant/djs55/dbus-test/python")

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/plugin.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/plugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
  Copyright (C) Citrix Systems, Inc.

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/sr.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/sr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
  Copyright (C) Citrix Systems, Inc.

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/volume.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/volume.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
  Copyright (C) Citrix Systems, Inc.

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/plugin.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/plugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
  Copyright (C) Citrix Systems, Inc.

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/sr.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/sr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
  Copyright (C) Citrix Systems, Inc.

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
  Copyright (C) Citrix Systems, Inc.

--- a/ocaml/xapi-storage/python/Makefile
+++ b/ocaml/xapi-storage/python/Makefile
@@ -1,5 +1,5 @@
 PREFIX?=/usr
-PYTHON?=python
+PYTHON?=python2
 
 .PHONY: build release clean install uninstall
 

--- a/ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py
+++ b/ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (C) Citrix Systems Inc.
 #

--- a/ocaml/xapi-storage/python/examples/datapath/loop+blkback/plugin.py
+++ b/ocaml/xapi-storage/python/examples/datapath/loop+blkback/plugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (C) Citrix Systems Inc.
 #

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/plugin.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/plugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (C) Citrix Systems Inc.
 #

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/sr.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/sr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (C) Citrix Systems Inc.
 #

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/volume.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/volume.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (C) Citrix Systems Inc.
 #

--- a/ocaml/xapi-storage/python/xapi/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Copyright (c) 2013-2018, Citrix Inc.

--- a/ocaml/xapi-storage/python/xapi/storage/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/storage/__init__.py
@@ -1,1 +1,1 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2

--- a/ocaml/xapi-storage/python/xapi/storage/api/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/__init__.py
@@ -1,1 +1,1 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2

--- a/ocaml/xapi-storage/python/xapi/storage/api/v5/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/v5/__init__.py
@@ -1,1 +1,1 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2

--- a/ocaml/xapi-storage/python/xapi/storage/common.py
+++ b/ocaml/xapi-storage/python/xapi/storage/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from xapi.storage import log
 import xapi

--- a/xapi-database.opam
+++ b/xapi-database.opam
@@ -19,6 +19,7 @@ depends: [
   "rpclib"
   "base-threads"
   "uuid"
+  "xapi-datamodel"
   "xapi-schema"
   "xapi-stdext-encodings"
   "xapi-stdext-pervasives"

--- a/xapi-datamodel.opam
+++ b/xapi-datamodel.opam
@@ -17,7 +17,7 @@ depends: [
   "rpclib"
   "base-threads"
   "xapi-consts"
-  "xapi-database"
+  "xapi-schema"
   "xapi-stdext-date"
   "xapi-stdext-std"
   "xapi-stdext-unix"

--- a/xapi-schema.opam
+++ b/xapi-schema.opam
@@ -13,6 +13,7 @@ depends: [
   "dune"
   "ppx_sexp_conv"
   "sexpr"
+  "xapi-log"
   "xapi-stdext-encodings"
 ]
 synopsis: "The xapi toolstack daemon which implements the XenAPI"

--- a/xapi-storage-script.opam
+++ b/xapi-storage-script.opam
@@ -26,10 +26,6 @@ depends: [
   "ppx_sexp_conv"
   "xapi-stdext-date"
 ]
-# python 2.7 is not enough to ensure the availability of 'python' in these
-depexts: [
-  ["python"] {os-family = "debian" & with-test}
-]
 synopsis: "A directory full of scripts can be a Xapi storage implementation"
 description: """
 This daemon watches a directory for subdirectories, and when a subdir

--- a/xapi-storage.opam
+++ b/xapi-storage.opam
@@ -21,10 +21,6 @@ depends: [
   "xmlm"
   "cmdliner"
 ]
-# python 2.7 is not enough to ensure the availability of 'python' in these
-depexts: [
-  ["python"] {os-family = "debian"}
-]
 synopsis: "Code and documentation generator for the Xapi storage interface"
 url {
   src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"


### PR DESCRIPTION
Other distributions other than Xenserver are used for testing the
installation of packages, and they have removed python as an alias for
python2. Being explicit doesn't break compatibility on Xenserver, and
allows us to keep newer versions of Ubuntu for testing in github.

It also has the benefit of reducing confusion when updating to python3 as the change cannot be done implicitly by switching the python binary.

This is a try to fix the latest error in the nightly CI for the docs: https://github.com/xapi-project/xapi-project.github.io/actions/runs/3700548098/jobs/6275403367

- [x] Confirm that xapi-storage-script tests aren't using `python`. (when it's an alias for python3 they fail)
- [x] Pass ring3 BVT and BST, and storage BST  with the changes