### PR TITLE
backport CA-352073, CA-342527, CA-372128: reduce overhead in xapi database and rbac checks

### DIFF
--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -28,7 +28,7 @@ module StringMap = struct
   include Map.Make (struct
     type t = string
 
-    let compare = Stdlib.compare
+    let compare = String.compare
   end)
 
   let update key default f t =
@@ -242,7 +242,16 @@ module KeyMap = struct
   include Map.Make (struct
     type t = common_key
 
-    let compare = Stdlib.compare
+    let compare a b =
+      match (a, b) with
+      | Ref x, Ref y ->
+          String.compare x y
+      | Uuid x, Uuid y ->
+          String.compare x y
+      | Ref _, Uuid _ ->
+          -1
+      | Uuid _, Ref _ ->
+          1
   end)
 
   let add_unique tblname fldname k v t =

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -431,11 +431,7 @@ module Database = struct
 
   let table_of_ref rf db = fst (KeyMap.find (Ref rf) db.keymap)
 
-  let lookup_key key db =
-    if KeyMap.mem (Ref key) db.keymap then
-      Some (KeyMap.find (Ref key) db.keymap)
-    else
-      None
+  let lookup_key key db = KeyMap.find_opt (Ref key) db.keymap
 
   let make schema =
     {

--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -30,10 +30,6 @@ module StringMap = struct
 
     let compare = String.compare
   end)
-
-  let update key default f t =
-    let v = try find key t with Not_found -> default in
-    add key (f v) t
 end
 
 module type VAL = sig
@@ -95,26 +91,25 @@ functor
 
     let touch generation key default row =
       let default = {stat= Stat.make generation; v= default} in
-      StringMap.update key default
-        (fun x -> {x with stat= {x.stat with Stat.modified= generation}})
+      StringMap.update key
+        (function
+          | Some x ->
+              Some {x with stat= {x.stat with Stat.modified= generation}}
+          | None ->
+              Some default
+          )
         row
 
     let update generation key default f row =
       let default = {stat= Stat.make generation; v= default} in
-      let updatefn () =
-        StringMap.update key default
-          (fun x -> {stat= {x.stat with Stat.modified= generation}; v= f x.v})
-          row
-      in
-      if mem key row then
-        let old = find key row in
-        let newv = f old in
-        if newv == old then
-          row
-        else
-          updatefn ()
-      else
-        updatefn ()
+      StringMap.update key
+        (function
+          | Some x ->
+              Some {stat= {x.stat with Stat.modified= generation}; v= f x.v}
+          | None ->
+              Some default
+          )
+        row
 
     let fold_over_recent since f t initial =
       StringMap.fold

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -262,11 +262,9 @@ let operation (obj : obj) (x : message) =
       let key_names = List.map fst x.msg_map_keys_roles in
       [
         Printf.sprintf "let arg_names_values = %s in" (serialize_args args)
-      ; (* This incurs a runtime cost *)
-        "let arg_names, arg_values = List.split arg_names_values in"
       ; Printf.sprintf "let key_names = %s in" (serialize_name_list key_names)
       ; "let rbac __context fn = Rbac.check session_id __call \
-         ~args:(arg_names, arg_values) ~keys:key_names ~__context ~fn in"
+         ~args:arg_names_values ~keys:key_names ~__context ~fn in"
       ]
     else
       ["let rbac __context fn = fn () in"]
@@ -542,14 +540,13 @@ let gen_module api : O.Module.t =
                  ; "      Session_check.check false session_id;"
                  ; "      (* based on the Host.call_extension call *)"
                  ; "      let call_rpc = Rpc.String __call in "
-                 ; "      let arg_names, arg_values ="
+                 ; "      let arg_names_values ="
                  ; "        [(\"session_id\", session_id_rpc); (__call, \
                     call_rpc)]"
-                 ; "        |> List.split"
                  ; "      in"
                  ; "      let key_names = [] in"
                  ; "      let rbac __context fn = Rbac.check session_id \
-                    \"Host.call_extension\" ~args:(arg_names, arg_values) \
+                    \"Host.call_extension\" ~args:arg_names_values \
                     ~keys:key_names ~__context ~fn in"
                  ; "      Server_helpers.forward_extension ~__context rbac { \
                     call with Rpc.name = __call }"

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -197,11 +197,12 @@ let operation (obj : obj) (x : message) =
     else
       List.exists (fun a -> is_session_arg a) args_without_default_values
   in
-  let unmarshall_default_params =
+  let name_default_params, unmarshall_default_params =
     List.mapi
       (fun param_count default_param ->
         let param_name = OU.ocaml_of_record_name default_param.DT.param_name in
         let param_type = OU.alias_of_ty default_param.DT.param_type in
+        let param_rpc = to_rpc_name param_name in
         let try_and_get_default =
           Printf.sprintf "List.nth default_args %d" param_count
         in
@@ -212,10 +213,14 @@ let operation (obj : obj) (x : message) =
           | Some default ->
               Datamodel_values.to_ocaml_string default
         in
-        Printf.sprintf "let %s = %s_of_rpc (try %s with _ -> %s) in" param_name
-          param_type try_and_get_default default_value
+        ( Printf.sprintf "let %s = try %s with _ -> %s in" param_rpc
+            try_and_get_default default_value
+        , Printf.sprintf "let %s = %s_of_rpc %s in" param_name param_type
+            param_rpc
+        )
       )
       msg_params_with_default_values
+    |> List.split
   in
   let rbac_check_begin =
     if has_session_arg then
@@ -225,6 +230,10 @@ let operation (obj : obj) (x : message) =
       let serialize_name_list lst =
         List.map (Printf.sprintf {|"%s"|}) lst |> serialize_list
       in
+      let serialize_args args =
+        List.map (fun (n, v) -> Printf.sprintf {|("%s", %s)|} n v) args
+        |> serialize_list
+      in
       let default_arg_name_params =
         if is_non_constructor_with_defaults then
           List.map (fun dp -> dp.DT.param_name) msg_params_with_default_values
@@ -232,12 +241,32 @@ let operation (obj : obj) (x : message) =
           []
       in
       let arg_names = orig_string_args @ default_arg_name_params in
+      let default_arg_values =
+        List.map
+          (fun dp -> to_rpc_name (OU.ocaml_of_record_name dp.DT.param_name))
+          msg_params_with_default_values
+      in
+      let arg_values = string_args @ default_arg_values in
+      let args =
+        try List.combine arg_names arg_values
+        with Invalid_argument _ ->
+          let msg =
+            Printf.sprintf
+              "Cannot serialize call %s.%s: number of arguments doesn't match \
+               with the number of names for it; in %s"
+              (OU.ocaml_of_obj_name obj.DT.name)
+              x.msg_name __LOC__
+          in
+          failwith msg
+      in
       let key_names = List.map fst x.msg_map_keys_roles in
       [
-        Printf.sprintf "let arg_names = %s in" (serialize_name_list arg_names)
+        Printf.sprintf "let arg_names_values = %s in" (serialize_args args)
+      ; (* This incurs a runtime cost *)
+        "let arg_names, arg_values = List.split arg_names_values in"
       ; Printf.sprintf "let key_names = %s in" (serialize_name_list key_names)
       ; "let rbac __context fn = Rbac.check session_id __call \
-         ~args:(arg_names,__params) ~keys:key_names ~__context ~fn in"
+         ~args:(arg_names, arg_values) ~keys:key_names ~__context ~fn in"
       ]
     else
       ["let rbac __context fn = fn () in"]
@@ -385,6 +414,7 @@ let operation (obj : obj) (x : message) =
     let all_list =
       if not (DU.has_been_removed x.DT.msg_lifecycle) then
         comments
+        @ name_default_params
         @ unmarshall_code
         @ session_check_exp
         @ rbac_check_begin
@@ -511,10 +541,15 @@ let gen_module api : O.Module.t =
                  ; "      let session_id = ref_session_of_rpc session_id_rpc in"
                  ; "      Session_check.check false session_id;"
                  ; "      (* based on the Host.call_extension call *)"
-                 ; "      let arg_names = [\"session_id\"; __call] in"
+                 ; "      let call_rpc = Rpc.String __call in "
+                 ; "      let arg_names, arg_values ="
+                 ; "        [(\"session_id\", session_id_rpc); (__call, \
+                    call_rpc)]"
+                 ; "        |> List.split"
+                 ; "      in"
                  ; "      let key_names = [] in"
                  ; "      let rbac __context fn = Rbac.check session_id \
-                    \"Host.call_extension\" ~args:(arg_names, __params) \
+                    \"Host.call_extension\" ~args:(arg_names, arg_values) \
                     ~keys:key_names ~__context ~fn in"
                  ; "      Server_helpers.forward_extension ~__context rbac { \
                     call with Rpc.name = __call }"

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -115,9 +115,8 @@ let operation (obj : obj) (x : message) =
     else
       List.map O.string_of_param args_without_default_values
   in
-  let string_args =
-    List.map (fun s -> Printf.sprintf "%s_rpc" s) orig_string_args
-  in
+  let to_rpc_name s = Printf.sprintf "%s_rpc" s in
+  let string_args = List.map to_rpc_name orig_string_args in
   let is_non_constructor_with_defaults =
     (not is_ctor) && has_default_args x.DT.msg_params
   in
@@ -198,6 +197,26 @@ let operation (obj : obj) (x : message) =
     else
       List.exists (fun a -> is_session_arg a) args_without_default_values
   in
+  let unmarshall_default_params =
+    List.mapi
+      (fun param_count default_param ->
+        let param_name = OU.ocaml_of_record_name default_param.DT.param_name in
+        let param_type = OU.alias_of_ty default_param.DT.param_type in
+        let try_and_get_default =
+          Printf.sprintf "List.nth default_args %d" param_count
+        in
+        let default_value =
+          match default_param.DT.param_default with
+          | None ->
+              "** EXPECTED DEFAULT VALUE IN THIS PARAM **"
+          | Some default ->
+              Datamodel_values.to_ocaml_string default
+        in
+        Printf.sprintf "let %s = %s_of_rpc (try %s with _ -> %s) in" param_name
+          param_type try_and_get_default default_value
+      )
+      msg_params_with_default_values
+  in
   let rbac_check_begin =
     if has_session_arg then
       let serialize_list lst =
@@ -240,26 +259,7 @@ let operation (obj : obj) (x : message) =
         args_without_default_values
     )
     (* and for every default value we try to get this from default_args or default it *)
-    @ List.mapi
-        (fun param_count default_param ->
-          let param_name =
-            OU.ocaml_of_record_name default_param.DT.param_name
-          in
-          let param_type = OU.alias_of_ty default_param.DT.param_type in
-          let try_and_get_default =
-            Printf.sprintf "List.nth default_args %d" param_count
-          in
-          let default_value =
-            match default_param.DT.param_default with
-            | None ->
-                "** EXPECTED DEFAULT VALUE IN THIS PARAM **"
-            | Some default ->
-                Datamodel_values.to_ocaml_string default
-          in
-          Printf.sprintf "let %s = %s_of_rpc (try %s with _ -> %s) in"
-            param_name param_type try_and_get_default default_value
-        )
-        msg_params_with_default_values
+    @ unmarshall_default_params
   in
   let may_be_side_effecting msg =
     match msg.msg_tag with

--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -12,8 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Stdext.Listext
-
 module D = Debug.Make (struct let name = "rbac" end)
 
 open D
@@ -127,10 +125,10 @@ let permission_of_action ?args ~keys _action =
           let key_name =
             List.find
               (fun key_name ->
-                if String.ends_with ~suffix:"*" key_name then
+                if Astring.String.is_suffix ~affix:"*" key_name then
                   (* resolve wildcards at the end *)
-                  String.starts_with
-                    ~prefix:(String.sub key_name 0 (String.length key_name - 1))
+                  Astring.String.is_prefix
+                    ~affix:(String.sub key_name 0 (String.length key_name - 1))
                     key_name_in_args
                 else (* no wildcards to resolve *)
                   key_name = key_name_in_args

--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -107,7 +107,7 @@ let get_keyERR_permission_name permission err = permission ^ "/keyERR:" ^ err
 let permission_of_action ?args ~keys _action =
   (* all permissions are in lowercase, see gen_rbac.writer_ *)
   let action = String.lowercase_ascii _action in
-  if List.length keys < 1 then
+  if keys = [] then
     (* most actions do not use rbac-guarded map keys in the arguments *)
     action
   else (* only actions with rbac-guarded map keys fall here *)
@@ -116,66 +116,40 @@ let permission_of_action ?args ~keys _action =
         (* this should never happen *)
         debug "DENYING access: no args for keyed-action %s" action ;
         get_keyERR_permission_name action "DENY_NOARGS" (* will always deny *)
-    | Some (arg_keys, arg_values) ->
-        if List.length arg_keys <> List.length arg_values then (
+    | Some keys_values -> (
+      match List.assoc_opt "key" keys_values with
+      | None ->
+          (* this should never happen *)
+          debug "DENYING access: no 'key' argument in the action %s" action ;
+          get_keyERR_permission_name action "DENY_NOKEY"
+      | Some (Rpc.String key_name_in_args) -> (
+        try
+          let key_name =
+            List.find
+              (fun key_name ->
+                if String.ends_with ~suffix:"*" key_name then
+                  (* resolve wildcards at the end *)
+                  String.starts_with
+                    ~prefix:(String.sub key_name 0 (String.length key_name - 1))
+                    key_name_in_args
+                else (* no wildcards to resolve *)
+                  key_name = key_name_in_args
+              )
+              keys
+          in
+          get_key_permission_name action (String.lowercase_ascii key_name)
+        with Not_found ->
+          (* expected, key_in_args is not rbac-protected *)
+          action
+      )
+      | Some value ->
           (* this should never happen *)
           debug
-            "DENYING access: arg_keys and arg_values lengths don't match: \
-             arg_keys=[%s], arg_values=[%s]"
-            (List.fold_left (fun ss s -> ss ^ s ^ ",") "" arg_keys)
-            (List.fold_left
-               (fun ss s -> ss ^ Rpc.to_string s ^ ",")
-               "" arg_values
-            ) ;
-          get_keyERR_permission_name action "DENY_WRGLEN" (* will always deny *)
-        ) else (* keys and values have the same length *)
-          let rec get_permission_name_of_keys arg_keys arg_values =
-            match (arg_keys, arg_values) with
-            | [], [] | _, [] | [], _ ->
-                (* this should never happen *)
-                debug "DENYING access: no 'key' argument in the action %s"
-                  action ;
-                get_keyERR_permission_name action "DENY_NOKEY"
-                (* deny by default *)
-            | k :: ks, v :: vs -> (
-                if k <> "key" (* "key" is defined in datamodel_utils.ml *) then
-                  get_permission_name_of_keys ks vs
-                else (* found "key" in args *)
-                  match v with
-                  | Rpc.String key_name_in_args -> (
-                    try
-                      (*debug "key_name_in_args=%s, keys=[%s]" key_name_in_args ((List.fold_left (fun ss s->ss^s^",") "" keys)) ;*)
-                      let key_name =
-                        List.find
-                          (fun key_name ->
-                            if Stdext.Xstringext.String.endswith "*" key_name
-                            then (* resolve wildcards at the end *)
-                              Stdext.Xstringext.String.startswith
-                                (String.sub key_name 0
-                                   (String.length key_name - 1)
-                                )
-                                key_name_in_args
-                            else (* no wildcards to resolve *)
-                              key_name = key_name_in_args
-                          )
-                          keys
-                      in
-                      get_key_permission_name action
-                        (String.lowercase_ascii key_name)
-                    with Not_found ->
-                      (* expected, key_in_args is not rbac-protected *)
-                      action
-                  )
-                  | _ ->
-                      (* this should never happen *)
-                      debug
-                        "DENYING access: wrong XML value [%s] in the 'key' \
-                         argument of action %s"
-                        (Rpc.to_string v) action ;
-                      get_keyERR_permission_name action "DENY_NOVALUE"
-              )
-          in
-          get_permission_name_of_keys arg_keys arg_values
+            "DENYING access: wrong XML value [%s] in the 'key' argument of \
+             action %s"
+            (Rpc.to_string value) action ;
+          get_keyERR_permission_name action "DENY_NOVALUE"
+    )
 
 let is_permission_in_session ~session_id ~permission ~session =
   let find_linear elem set = List.exists (fun e -> e = elem) set in

--- a/ocaml/xapi/rbac_audit.ml
+++ b/ocaml/xapi/rbac_audit.ml
@@ -344,11 +344,11 @@ let get_db_namevalue __context name action _ref =
 *)
 let rec sexpr_args_of __context name rpc_value action =
   let is_selected_action_param action_params =
-    if List.mem_assoc action action_params then
-      let params = List.assoc action action_params in
-      List.mem name params
-    else
-      false
+    match List.assoc_opt action action_params with
+    | Some params ->
+        List.mem name params
+    | None ->
+        false
   in
   (* heuristic 1: print descriptive arguments in the xapi call *)
   if
@@ -384,7 +384,7 @@ let rec sexpr_args_of __context name rpc_value action =
              ; SExpr.Node
                  (sexpr_of_parameters __context
                     (action ^ "." ^ name)
-                    (Some (["__structure"], [rpc_value]))
+                    (Some [("__structure", rpc_value)])
                  )
              ; SExpr.String ""
              ; SExpr.String ""
@@ -430,52 +430,30 @@ let rec sexpr_args_of __context name rpc_value action =
 and
     (* Given an action and its parameters, *)
     (* return the marshalled uuid params and corresponding names *)
-    (*let rec*) sexpr_of_parameters __context action args : SExpr.t list =
+    sexpr_of_parameters __context action args : SExpr.t list =
   match args with
   | None ->
       []
-  | Some (str_names, rpc_values) ->
-      if List.length str_names <> List.length rpc_values then (
-        (* debug mode *)
-        D.warn
-          "cannot marshall arguments for the action %s: name and value list \
-           lengths don't match. str_names=[%s], xml_values=[%s]"
-          action
-          (List.fold_left (fun ss s -> ss ^ s ^ ",") "" str_names)
-          (List.fold_left (fun ss s -> ss ^ Rpc.to_string s ^ ",") "" rpc_values) ;
-        []
-      ) else
-        List.fold_right2
-          (fun str_name rpc_value (params : SExpr.t list) ->
-            if str_name = "session_id" then
+  | Some names_rpc_values ->
+      List.fold_right
+        (fun (str_name, rpc_value) (params : SExpr.t list) ->
+          match (str_name, rpc_value) with
+          | "session_id", _ ->
               params (* ignore session_id param *)
-            else if
+          | "__structure", Rpc.Dict d ->
               (* if it is a constructor structure, need to rewrap params *)
-              str_name = "__structure"
-            then
-              match rpc_value with
-              | Rpc.Dict d ->
-                  let names = List.map fst d in
-                  let values = List.map snd d in
-                  let myparam =
-                    sexpr_of_parameters __context action (Some (names, values))
-                  in
-                  myparam @ params
-              | rpc_value -> (
-                match sexpr_args_of __context str_name rpc_value action with
-                | None ->
-                    params
-                | Some p ->
-                    p :: params
-              )
-            else (* the expected list of xml arguments *)
-              match sexpr_args_of __context str_name rpc_value action with
-              | None ->
-                  params
-              | Some p ->
-                  p :: params
+              let myparam = sexpr_of_parameters __context action (Some d) in
+              myparam @ params
+          | _ -> (
+            (* the expected list of xml arguments *)
+            match sexpr_args_of __context str_name rpc_value action with
+            | None ->
+                params
+            | Some p ->
+                p :: params
           )
-          str_names rpc_values []
+        )
+        names_rpc_values []
 
 let has_to_audit action =
   let has_side_effect action =
@@ -517,37 +495,28 @@ let add_dummy_args __context action args =
   match args with
   | None ->
       args
-  | Some (str_names, rpc_values) -> (
-      let rec find_self str_names rpc_values =
-        match (str_names, rpc_values) with
-        | "self" :: _, rpc :: _ ->
-            rpc
-        | _ :: str_names', _ :: rpc_values' ->
-            find_self str_names' rpc_values'
-        | _, _ ->
-            raise Not_found
-      in
-      match action with
-      (* Add VDI info for VBD.destroy *)
-      | "VBD.destroy" -> (
-        try
-          let vbd = API.ref_VBD_of_rpc (find_self str_names rpc_values) in
-          let vdi = DB_Action.VBD.get_VDI __context vbd in
-          Some (str_names @ ["VDI"], rpc_values @ [API.rpc_of_ref_VDI vdi])
-        with e ->
-          D.debug "couldn't get VDI ref for VBD: %s" (ExnHelper.string_of_exn e) ;
-          args
-      )
-      | _ ->
-          args
+  | Some names_rpc -> (
+    match action with
+    (* Add VDI info for VBD.destroy *)
+    | "VBD.destroy" -> (
+      try
+        let vbd = API.ref_VBD_of_rpc (List.assoc "self" names_rpc) in
+        let vdi = DB_Action.VBD.get_VDI ~__context ~self:vbd in
+        let params = names_rpc @ [("VDI", API.rpc_of_ref_VDI vdi)] in
+        Some params
+      with e ->
+        D.debug "couldn't get VDI ref for VBD: %s" (ExnHelper.string_of_exn e) ;
+        args
     )
+    | _ ->
+        args
+  )
 
 let sexpr_of __context session_id allowed_denied ok_error result_error ?args
     ?sexpr_of_args action permission =
   let result_error =
     if result_error = "" then result_error else ":" ^ result_error
   in
-  (*let (params:SExpr.t list) = (string_of_parameters action args) in*)
   SExpr.Node
     [
       SExpr.String (trackid session_id)
@@ -556,8 +525,7 @@ let sexpr_of __context session_id allowed_denied ok_error result_error ?args
     ; SExpr.String allowed_denied
     ; SExpr.String (ok_error ^ result_error)
     ; SExpr.String (call_type_of action)
-    ; (*SExpr.String (Helper_hostname.get_hostname ())::*)
-      SExpr.String action
+    ; SExpr.String action
     ; SExpr.Node
         ( match sexpr_of_args with
         | None ->

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -27,15 +27,6 @@ let my_assoc fld assoc_list =
   try List.assoc fld assoc_list
   with Not_found -> raise (Dispatcher_FieldNotFound fld)
 
-exception Nth (* should never be thrown externally *)
-
-let rec nth n l =
-  match l with
-  | [] ->
-      raise Nth
-  | x :: xs ->
-      if n = 1 then x else nth (n - 1) xs
-
 let async_wire_name = "Async."
 
 let async_length = String.length async_wire_name

--- a/ocaml/xapi/server_helpers.mli
+++ b/ocaml/xapi/server_helpers.mli
@@ -42,8 +42,6 @@ val exec_with_subtask :
 (* used by auto-generated code in server.ml *)
 val my_assoc : string -> (string * 'a) list -> 'a
 
-val nth : int -> 'a list -> 'a
-
 val sync_ty_and_maybe_remove_prefix :
   string -> [> `Async | `InternalAsync | `Sync] * string
 

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -77,10 +77,8 @@ let append_to_master_audit_log __context action line =
       )
 
 let rbac_audit_params_of (req : Request.t) =
-  let all = req.Request.cookie @ req.Request.query in
-  List.fold_right
-    (fun (n, v) (acc_n, acc_v) -> (n :: acc_n, Rpc.String v :: acc_v))
-    all ([], [])
+  req.Request.cookie @ req.Request.query
+  |> List.map (fun (n, v) -> (n, Rpc.String v))
 
 let assert_credentials_ok realm ?(http_action = realm) ?(fn = Rbac.nofn)
     (req : Request.t) ic =


### PR DESCRIPTION
Backport of https://github.com/xapi-project/xen-api/pull/4835

- [x] ring3 BST + BVT SR 178982  (includes https://github.com/xapi-project/xcp-rrd/pull/53 and https://github.com/xapi-project/xcp-rrdd/pull/127)


Results on 12-core machines:

creating 512 VMs (unikernels), pausing, then shutting them down:

unpatched:

```
$ time ./minion-storm.bash
real	23m7.819s
user	0m4.063s
sys 	0m18.154s
```
```
$ time xe vm-list > /dev/null

real	0m0.733s
user	0m0.012s
sys 	0m0.015s
```

patched:
```
$ time ./minion-storm.bash
real	16m29.273s
user	0m5.737s
sys 	0m25.089s
```
```
$ time xe vm-list > /dev/null

real	0m0.449s
user	0m0.009s
sys 	0m0.032s
```