### PR TITLE
CP-32622: avoid using select and instead use epoll

### DIFF
--- a/ocaml/libs/http-svr/buf_io.ml
+++ b/ocaml/libs/http-svr/buf_io.ml
@@ -79,14 +79,17 @@ let is_full ic = ic.cur = 0 && ic.max = Bytes.length ic.buf
 let fill_buf ~buffered ic timeout =
   let buf_size = Bytes.length ic.buf in
   let fill_no_exc timeout len =
-    let l, _, _ = Unix.select [ic.fd] [] [] timeout in
-    if List.length l <> 0 then (
-      let n = Unix.read ic.fd ic.buf ic.max len in
-      ic.max <- n + ic.max ;
-      if n = 0 && len <> 0 then raise Eof ;
-      n
-    ) else
-      -1
+    Unix.setsockopt_float ic.fd Unix.SO_RCVTIMEO timeout ;
+    let result =
+      try
+        let n = Unix.read ic.fd ic.buf ic.max len in
+        ic.max <- n + ic.max ;
+        if n = 0 && len <> 0 then raise Eof ;
+        n
+      with Unix.Unix_error (Unix.EAGAIN, _, _) -> -1
+    in
+    Unix.setsockopt_float ic.fd Unix.SO_RCVTIMEO 0. ;
+    result
   in
   (* If there's no space to read, shift *)
   if ic.max = buf_size then shift ic ;

--- a/ocaml/libs/stunnel/stunnel.ml
+++ b/ocaml/libs/stunnel/stunnel.ml
@@ -394,7 +394,7 @@ let rec retry f = function
     try f ()
     with Stunnel_initialisation_failed ->
       (* Leave a few seconds between each attempt *)
-      ignore (Unix.select [] [] [] 3.) ;
+      Thread.delay 3. ;
       retry f (n - 1)
   )
 

--- a/ocaml/message-switch/unix/dune
+++ b/ocaml/message-switch/unix/dune
@@ -8,6 +8,7 @@
   (libraries
     cohttp
     message-switch-core
+    polly
     rpclib.core
     rpclib.json
     threads.posix

--- a/ocaml/networkd/lib/jsonrpc_client.ml
+++ b/ocaml/networkd/lib/jsonrpc_client.ml
@@ -32,8 +32,6 @@ let json_rpc_write_timeout = ref 60000000000L
 
 (* timeout value in ns when writing RPC request *)
 
-let to_s s = Int64.to_float s *. 1e-9
-
 (* Read the entire contents of the fd, of unknown length *)
 let timeout_read fd timeout =
   let buf = Buffer.create !json_rpc_max_len in
@@ -42,13 +40,6 @@ let timeout_read fd timeout =
     Mtime.Span.to_uint64_ns (Mtime_clock.count read_start)
   in
   let rec inner max_time max_bytes =
-    let ready_to_read, _, _ =
-      try Unix.select [fd] [] [] (to_s max_time)
-      with
-      (* in case the unix.select call fails in situation like interrupt *)
-      | Unix.Unix_error (Unix.EINTR, _, _) ->
-        ([], [], [])
-    in
     (* This is not accurate the calculate time just for the select part.
        However, we think the read time will be minor comparing to the scale of
        tens of seconds. the current style will be much concise in code. *)
@@ -60,27 +51,25 @@ let timeout_read fd timeout =
       debug "Timeout after read %d" (Buffer.length buf) ;
       raise Timeout
     ) ;
-    if List.mem fd ready_to_read then
-      let bytes = Bytes.make 4096 '\000' in
-      match Unix.read fd bytes 0 4096 with
-      | 0 ->
-          Buffer.contents buf (* EOF *)
-      | n ->
-          if n > max_bytes then (
-            debug "exceeding maximum read limit %d, clear buffer"
-              !json_rpc_max_len ;
-            Buffer.clear buf ;
-            raise Read_error
-          ) else (
-            Buffer.add_subbytes buf bytes 0 n ;
-            inner remain_time (max_bytes - n)
-          )
-      | exception
-          Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK | Unix.EINTR), _, _)
-        ->
-          inner remain_time max_bytes
-    else
-      inner remain_time max_bytes
+    ( try Unix.setsockopt_float fd SO_RCVTIMEO (Int64.to_float max_time)
+      with Unix.Unix_error (Unix.ENOTSOCK, _, _) ->
+        (* In the unit tests, the fd comes from a pipe... ignore *)
+        ()
+    ) ;
+    let bytes = Bytes.make 4096 '\000' in
+    match Unix.read fd bytes 0 4096 with
+    | 0 ->
+        Buffer.contents buf (* EOF *)
+    | n when n > max_bytes ->
+        debug "exceeding maximum read limit %d, clear buffer" !json_rpc_max_len ;
+        Buffer.clear buf ;
+        raise Read_error
+    | n ->
+        Buffer.add_subbytes buf bytes 0 n ;
+        inner remain_time (max_bytes - n)
+    | exception
+        Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK | Unix.EINTR), _, _) ->
+        inner remain_time max_bytes
   in
   inner timeout !json_rpc_max_len
 
@@ -95,13 +84,6 @@ let timeout_write filedesc total_length data response_time =
     Mtime.Span.to_uint64_ns (Mtime_clock.count write_start)
   in
   let rec inner_write offset max_time =
-    let _, ready_to_write, _ =
-      try Unix.select [] [filedesc] [] (to_s max_time)
-      with
-      (* in case the unix.select call fails in situation like interrupt *)
-      | Unix.Unix_error (Unix.EINTR, _, _) ->
-        ([], [], [])
-    in
     let remain_time =
       let used_time = get_total_used_time () in
       Int64.sub response_time used_time
@@ -110,32 +92,30 @@ let timeout_write filedesc total_length data response_time =
       debug "Timeout to write %d at offset %d" total_length offset ;
       raise Timeout
     ) ;
-    if List.mem filedesc ready_to_write then
-      let length = total_length - offset in
-      let bytes_written =
-        try Unix.single_write filedesc data offset length
-        with
-        | Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK | Unix.EINTR), _, _)
-        ->
-          0
-      in
-      let new_offset = offset + bytes_written in
+    Unix.setsockopt_float filedesc Unix.SO_SNDTIMEO (Int64.to_float max_time) ;
+    let length = total_length - offset in
+    let bytes_written =
+      try Unix.single_write filedesc data offset length
+      with Unix.Unix_error (Unix.EINTR, _, _) -> 0
+    in
+    let new_offset = offset + bytes_written in
+    try
       if length = bytes_written then
         ()
       else
         inner_write new_offset remain_time
-    else
-      inner_write offset remain_time
+    with Unix.Unix_error (Unix.EAGAIN, _, _) -> inner_write offset remain_time
   in
   inner_write 0 response_time
 
 let with_rpc ?(version = Jsonrpc.V2) ~path ~call () =
   let uri = Uri.of_string (Printf.sprintf "file://%s" path) in
   Open_uri.with_open_uri uri (fun s ->
-      Unix.set_nonblock s ;
       let req = Bytes.of_string (Jsonrpc.string_of_call ~version call) in
       timeout_write s (Bytes.length req) req !json_rpc_write_timeout ;
+      Unix.setsockopt_float s SO_SNDTIMEO 0. ;
       let res = timeout_read s !json_rpc_read_timeout in
+      Unix.setsockopt_float s SO_RCVTIMEO 0. ;
       debug "Response: %s" res ;
       Jsonrpc.response_of_string ~strict:false res
   )

--- a/ocaml/squeezed/src/squeeze_xen.ml
+++ b/ocaml/squeezed/src/squeeze_xen.ml
@@ -572,7 +572,7 @@ let make_host ~verbose ~xc =
       1024L
     <> 0L
   do
-    ignore (Unix.select [] [] [] 0.25)
+    Thread.delay 0.25
   done ;
 
   (* Some VMs are considered by us (but not by xen) to have an
@@ -857,7 +857,7 @@ let io ~xc ~verbose =
       (fun domid kib ->
         execute_action ~xc {Squeeze.action_domid= domid; new_target_kib= kib}
       )
-  ; wait= (fun delay -> ignore (Unix.select [] [] [] delay))
+  ; wait= (fun delay -> Thread.delay delay)
   ; execute_action= (fun action -> execute_action ~xc action)
   ; target_host_free_mem_kib
   ; free_memory_tolerance_kib

--- a/ocaml/xapi-idl/lib/dune
+++ b/ocaml/xapi-idl/lib/dune
@@ -13,6 +13,7 @@
    message-switch-unix
    mtime
    mtime.clock.os
+   polly
    ppx_sexp_conv.runtime-lib
    re
    rpclib.core

--- a/ocaml/xe-cli/dune
+++ b/ocaml/xe-cli/dune
@@ -7,6 +7,7 @@
     astring
     dune-build-info
     fpath
+    polly
     safe-resources
     stunnel
     threads

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -633,7 +633,7 @@ let main_loop ifd ofd permitted_filenames =
           with
           | Unix.Unix_error (_, _, _)
             when !delay <= long_connection_retry_timeout ->
-              ignore (Unix.select [] [] [] !delay) ;
+              Thread.delay !delay ;
               delay := !delay *. 2. ;
               keep_connection ()
           | e ->

--- a/ocaml/xenopsd/cli/dune
+++ b/ocaml/xenopsd/cli/dune
@@ -9,6 +9,7 @@
       astring
       cmdliner
       dune-build-info
+      polly
       re
       result
       rpclib.core

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -1214,7 +1214,7 @@ let raw_console_proxy sockaddr =
         (fun () -> Unix.close s)
     with
     | Unix.Unix_error (_, _, _) when !delay <= long_connection_retry_timeout ->
-        ignore (Unix.select [] [] [] !delay) ;
+        Thread.delay !delay ;
         delay := !delay *. 2. ;
         keep_connection ()
     | e ->

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -1176,27 +1176,38 @@ let raw_console_proxy sockaddr =
       ) else if !final then
         finished := true
       else
-        let r, _, _ = Unix.select [Unix.stdin; fd] [] [] (-1.) in
-        if List.mem Unix.stdin r then (
-          let b =
-            Unix.read Unix.stdin buf_remote !buf_remote_end
-              (block - !buf_remote_end)
-          in
-          let i = ref !buf_remote_end in
-          while
-            !i < !buf_remote_end + b
-            && Char.code (Bytes.get buf_remote !i) <> 0x1d
-          do
-            incr i
-          done ;
-          if !i < !buf_remote_end + b then final := true ;
-          buf_remote_end := !i
-        ) ;
-        if List.mem fd r then
-          let b =
-            Unix.read fd buf_local !buf_local_end (block - !buf_local_end)
-          in
-          buf_local_end := !buf_local_end + b
+        let epoll = Polly.create () in
+        List.iter
+          (fun fd -> Polly.add epoll fd Polly.Events.inp)
+          [Unix.stdin; fd] ;
+        Fun.protect
+          ~finally:(fun () -> Polly.close epoll)
+          (fun () ->
+            ignore
+            @@ Polly.wait epoll 2 (-1) (fun _ file_desc _ ->
+                   if Unix.stdin = file_desc then (
+                     let b =
+                       Unix.read Unix.stdin buf_remote !buf_remote_end
+                         (block - !buf_remote_end)
+                     in
+                     let i = ref !buf_remote_end in
+                     while
+                       !i < !buf_remote_end + b
+                       && Char.code (Bytes.get buf_remote !i) <> 0x1d
+                     do
+                       incr i
+                     done ;
+                     if !i < !buf_remote_end + b then final := true ;
+                     buf_remote_end := !i
+                   ) ;
+                   if fd = file_desc then
+                     let b =
+                       Unix.read fd buf_local !buf_local_end
+                         (block - !buf_local_end)
+                     in
+                     buf_local_end := !buf_local_end + b
+               )
+          )
     done
   in
   let delay = ref 0.1 in

--- a/ocaml/xenopsd/xc/memory_breakdown.ml
+++ b/ocaml/xenopsd/xc/memory_breakdown.ml
@@ -246,7 +246,7 @@ let print_memory_field_values xc xs =
   flush stdout
 
 (** Sleeps for the given time period in seconds. *)
-let sleep time_period_seconds = ignore (Unix.select [] [] [] time_period_seconds)
+let sleep time_period_seconds = Thread.delay time_period_seconds
 
 (** Prints a header line of memory field names, and then periodically prints a
     line of memory field values. *)

--- a/ocaml/xenopsd/xc/memory_summary.ml
+++ b/ocaml/xenopsd/xc/memory_summary.ml
@@ -36,7 +36,7 @@ let _ =
   let finished = ref false in
   while not !finished do
     finished := !delay < 0. ;
-    if !delay > 0. then ignore (Unix.select [] [] [] !delay) ;
+    if !delay > 0. then Thread.delay !delay ;
     flush stdout ;
     let physinfo = Xenctrl.physinfo xc in
     let one_page = 4096L in

--- a/ocaml/xsh/dune
+++ b/ocaml/xsh/dune
@@ -5,6 +5,7 @@
   (package xapi)
   (libraries
     dune-build-info
+    polly
     stunnel
     safe-resources
     xapi-consts


### PR DESCRIPTION
To avoid xapi from running out of file descriptors, replace select with epoll in most cases