### PR TITLE
Switch from Xenctrl.hvm_check_pvdriver to Xenctrl.hvm_param_get

### DIFF
--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -600,7 +600,7 @@ let shutdown_wait_for_ack (t : Xenops_task.task_handle) ~timeout ~xc ~xs domid
     | true, `pvh ->
         true (* PVH guests are also always enlightened *)
     | true, `hvm ->
-        Xenctrl.hvm_check_pvdriver xc domid (* checks for HVM_CALLBACK_IRQ *)
+        Xenctrl.hvm_param_get xc domid HVM_PARAM_CALLBACK_IRQ <> 0L
     | true, `pv ->
         failwith "Internal error, should never happen"
   in


### PR DESCRIPTION
The former is technical debt in the hypervisor patchqueue, while the latter is an upstream binding.

No functional change.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>