### PR TITLE
ci: avoid github API deprecation warnings

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -15,7 +15,7 @@ jobs:
         test: ["", "-3"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: '1.249-lcm'
 
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: '1.249-lcm'
 
@@ -40,16 +40,16 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@v1.0.2
 
       - name: Retrieve date for cache key (year-week)
         id: cache-key
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%W")"
+        run: echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Restore opam cache
         id: opam-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "~/.opam"
           # invalidate cache every week, gets built using a scheduled job

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.8
+        uses: falti/dotenv-action@v1.0.2
 
       - name: Use ocaml
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.8
+        uses: falti/dotenv-action@v1.0.2
 
       - name: Use python 
         uses: actions/setup-python@v4
@@ -35,7 +35,7 @@ jobs:
 
       - name: Restore opam cache
         id: opam-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "~/.opam"
           # invalidate cache daily, gets built daily using a scheduled job

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Pull configuration from xs-opam
         run: |
@@ -22,13 +22,15 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@v1.0.2
 
       - name: Use ocaml
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
-          opam-repository: ${{ steps.dotenv.outputs.repository }}
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
+          dune-cache: true
 
       - name: Install ocamlformat
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         test: ["", "-3"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run python tests
         run: bash ./.github/python-nosetests${{ matrix.test }}.sh
 
@@ -47,16 +47,16 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@v1.0.2
 
       - name: Retrieve date for cache key
         id: cache-key
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Restore opam cache
         id: opam-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "~/.opam"
           # invalidate cache daily, gets built daily using a scheduled job
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Generate empty configuration for make to be happy
         run: touch config.mk


### PR DESCRIPTION
This is done both by changing how the output fro the action is set and by updating the versions of the actions

These warning will become errors on the last day of May 2023, so better do it now rather than later

The new versions for the actions work, and I've manually verified that the set-output action for generating the cache key works