### PR TITLE
CA-343683 Atomising Networkd pif plugging on Xapi startup

### DIFF
--- a/ocaml/networkd/bin/networkd.ml
+++ b/ocaml/networkd/bin/networkd.ml
@@ -174,6 +174,7 @@ let bind () =
   let open Network_server in
   S.clear_state clear_state ;
   S.reset_state reset_state ;
+  S.sync_state sync_state ;
   S.set_gateway_interface set_gateway_interface ;
   S.set_dns_interface set_dns_interface ;
   S.Interface.get_all Interface.get_all ;

--- a/ocaml/xapi-idl/network/network_interface.ml
+++ b/ocaml/xapi-idl/network/network_interface.ml
@@ -336,12 +336,17 @@ module Interface_API (R : RPC) = struct
 
   let clear_state =
     declare "clear_state"
-      ["Clear configuration state"]
+      ["Clear configuration state then lock the writing of the state to disk"]
       (unit_p @-> returning unit_p err)
 
   let reset_state =
     declare "reset_state"
       ["Reset configuration state"]
+      (unit_p @-> returning unit_p err)
+
+  let sync_state =
+    declare "sync_state"
+      ["Allow for the config state to be written to disk then perform a write"]
       (unit_p @-> returning unit_p err)
 
   let set_gateway_interface =

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -1111,5 +1111,6 @@ let start_of_day_best_effort_bring_up () =
             )
             pif
         )
-        (calculate_pifs_required_at_start_of_day ~__context)
+        (calculate_pifs_required_at_start_of_day ~__context) ;
+      Net.sync_state ()
   )


### PR DESCRIPTION
network config will not write to disk when network state is being refreshed when starting up

- 	added `config_writable` flag. config will write on if true but will remain in memory otherwise.

- 	`config_writable` is set to false when the state is cleared

- 	added `sync_state` function to enable disk writing then write to disk: synchronising memory and disk.

This will prevent the chance of incomplete config in `networkd.db` which can cause network issues on reboot.

Signed-off-by: jameshensmancitrix <james.hensman@citrix.com>