### PR TITLE
CP-41818: Branding and copyright updates for the SDK

### DIFF
--- a/ocaml/sdk-gen/LICENSE
+++ b/ocaml/sdk-gen/LICENSE
@@ -1,5 +1,4 @@
-Copyright (c) Citrix Systems, Inc.
-All rights reserved.
+Copyright (c) Cloud Software Group, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/ocaml/sdk-gen/README.md
+++ b/ocaml/sdk-gen/README.md
@@ -16,7 +16,7 @@ README files. The (patched) third party libraries required for the compilation
 of the C# and PowerShell source code can be obtained from
 [xenserver/dotnet-packages](https://github.com/xenserver/dotnet-packages)
 
-The repository [xenserver-samples](https://github.com/xenserver/xenserver-samples)
+The repository [xenserver/xenserver-samples](https://github.com/xenserver/xenserver-samples)
 contains a number of examples for each of the five programming languages to help
 you get started with the SDK.
 

--- a/ocaml/sdk-gen/c/README.dist
+++ b/ocaml/sdk-gen/c/README.dist
@@ -1,8 +1,10 @@
 libxenserver
 ============
 
-libxenserver is a complete SDK for Citrix Hypervisor exposing the Citrix
-Hypervisor API to C developers.
+Copyright (c) 2007-2023 Cloud Software Group, Inc. All Rights Reserved.
+
+libxenserver is a complete SDK for XenServer exposing the XenServer API to
+C developers.
 
 libxenserver includes a C function call for each API call, so API
 documentation and examples written for for other languages can be easily
@@ -12,16 +14,15 @@ for developers wishing to use libxenserver.
 libxenserver is free software. You can redistribute and modify it under the
 terms of the BSD 2-Clause license. See COPYING for details.
 
-
 Reference
 ---------
 
-For Citrix Hypervisor documentation see https://docs.citrix.com/en-us/citrix-hypervisor/
+For XenServer documentation see https://docs.citrix.com/en-us/citrix-hypervisor/
 
-The Citrix Hypervisor Management API Reference is available at
+The XenServer Management API Reference is available at
 https://developer-docs.citrix.com/projects/citrix-hypervisor-management-api/en/latest/
 
-The Citrix Hypervisor Software Development Kit Guide is available at
+The XenServer Software Development Kit Guide is available at
 https://developer-docs.citrix.com/projects/citrix-hypervisor-sdk/en/latest/
 
 A number of examples to help you get started with the SDK is available at
@@ -30,7 +31,7 @@ https://github.com/xenserver/xenserver-samples
 For community content, blogs, and downloads, visit
 https://www.citrix.com/community/citrix-developer/
 
-To network with other developers using Citrix Hypervisor visit
+To network with other developers using XenServer visit
 https://discussions.citrix.com/forum/101-hypervisor-formerly-xenserver/
 
 

--- a/ocaml/sdk-gen/c/autogen/include/xen/api/xen_common.h
+++ b/ocaml/sdk-gen/c/autogen/include/xen/api/xen_common.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/include/xen/api/xen_event_batch.h
+++ b/ocaml/sdk-gen/c/autogen/include/xen/api/xen_event_batch.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/include/xen/api/xen_int_set.h
+++ b/ocaml/sdk-gen/c/autogen/include/xen/api/xen_int_set.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/include/xen/api/xen_string_set.h
+++ b/ocaml/sdk-gen/c/autogen/include/xen/api/xen_string_set.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/include/xen/api/xen_string_set_set.h
+++ b/ocaml/sdk-gen/c/autogen/include/xen/api/xen_string_set_set.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/src/xen_common.c
+++ b/ocaml/sdk-gen/c/autogen/src/xen_common.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/src/xen_event_batch.c
+++ b/ocaml/sdk-gen/c/autogen/src/xen_event_batch.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/src/xen_int_set.c
+++ b/ocaml/sdk-gen/c/autogen/src/xen_int_set.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/src/xen_string_set.c
+++ b/ocaml/sdk-gen/c/autogen/src/xen_string_set.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/autogen/src/xen_string_set_set.c
+++ b/ocaml/sdk-gen/c/autogen/src/xen_string_set_set.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/gen_c_binding.ml
+++ b/ocaml/sdk-gen/c/gen_c_binding.ml
@@ -1,31 +1,5 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 (* Generator of C bindings from the datamodel *)

--- a/ocaml/sdk-gen/c/helper.ml
+++ b/ocaml/sdk-gen/c/helper.ml
@@ -1,31 +1,5 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 let rec formatted_wrap formatter s =

--- a/ocaml/sdk-gen/c/templates/Makefile.mustache
+++ b/ocaml/sdk-gen/c/templates/Makefile.mustache
@@ -1,6 +1,5 @@
 #
-# Copyright (c) Citrix Systems, Inc.
-# All rights reserved.
+# Copyright (c) Cloud Software Group, Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/templates/xen_all.h.mustache
+++ b/ocaml/sdk-gen/c/templates/xen_all.h.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/templates/xen_api_version.c.mustache
+++ b/ocaml/sdk-gen/c/templates/xen_api_version.c.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/templates/xen_api_version.h.mustache
+++ b/ocaml/sdk-gen/c/templates/xen_api_version.h.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/c/templates/xen_internal.mustache
+++ b/ocaml/sdk-gen/c/templates/xen_internal.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/common/CommonFunctions.ml
+++ b/ocaml/sdk-gen/common/CommonFunctions.ml
@@ -1,31 +1,5 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 open Printf

--- a/ocaml/sdk-gen/common/licence.ml
+++ b/ocaml/sdk-gen/common/licence.ml
@@ -1,37 +1,10 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 let bsd_two_clause =
   "/*\n\
-  \ * Copyright (c) Citrix Systems, Inc.\n\
-  \ * All rights reserved.\n\
+  \ * Copyright (c) Cloud Software Group, Inc.\n\
   \ *\n\
   \ * Redistribution and use in source and binary forms, with or without\n\
   \ * modification, are permitted provided that the following conditions\n\

--- a/ocaml/sdk-gen/csharp/README-NuGet.dist
+++ b/ocaml/sdk-gen/csharp/README-NuGet.dist
@@ -1,6 +1,8 @@
 XenServer.NET
 =============
 
+Copyright (c) 2007-2023 Cloud Software Group, Inc. All Rights Reserved.
+
 XenServer.NET is a complete SDK for XenServer, exposing the XenServer
 API as .NET classes. It is written in C#.
 

--- a/ocaml/sdk-gen/csharp/README.dist
+++ b/ocaml/sdk-gen/csharp/README.dist
@@ -1,6 +1,8 @@
 XenServer.NET
 =============
 
+Copyright (c) 2007-2023 Cloud Software Group, Inc. All Rights Reserved.
+
 XenServer.NET is a complete SDK for XenServer, exposing the XenServer
 API as .NET classes. It is written in C#.
 

--- a/ocaml/sdk-gen/csharp/autogen/src/Converters.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Converters.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/DeprecatedAttribute.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/DeprecatedAttribute.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/Event.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Event.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/Failure.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Failure.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/HTTP.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/HTTP.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/Helper.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Helper.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/IMockWebProxy.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/IMockWebProxy.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/IXenObject.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/IXenObject.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/JsonRpc.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/JsonRpc.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/Marshalling.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Marshalling.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/Response.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Response.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/Session.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Session.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/Subject2.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Subject2.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/UserDetails.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/UserDetails.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/XenObject.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/XenObject.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/autogen/src/XenRef.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/XenRef.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/friendly_error_names.ml
+++ b/ocaml/sdk-gen/csharp/friendly_error_names.ml
@@ -1,31 +1,5 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 open CommonFunctions

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -1,31 +1,5 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 open Printf

--- a/ocaml/sdk-gen/csharp/templates/ApiVersion.mustache
+++ b/ocaml/sdk-gen/csharp/templates/ApiVersion.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/templates/Enum.mustache
+++ b/ocaml/sdk-gen/csharp/templates/Enum.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/templates/JsonRpcClient.mustache
+++ b/ocaml/sdk-gen/csharp/templates/JsonRpcClient.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/templates/Message2.mustache
+++ b/ocaml/sdk-gen/csharp/templates/Message2.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/csharp/templates/XenServer.csproj.mustache
+++ b/ocaml/sdk-gen/csharp/templates/XenServer.csproj.mustache
@@ -7,11 +7,11 @@
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>XenServer.NET</Title>
-    <Authors>Citrix Systems, Inc.</Authors>
+    <Authors>Cloud Software Group, Inc.</Authors>
     <PackageId>$(AssemblyName).NET</PackageId>
     <Product>$(AssemblyName).NET</Product>
     <Description>.NET wrapper for the XenServer API</Description>
-    <Copyright>Copyright (c) Citrix Systems, Inc. All rights reserved.</Copyright>
+    <Copyright>Copyright (c) 2007-2023 Cloud Software Group, Inc. All Rights Reserved.</Copyright>
     <PackageTags>citrix hypervisor virtualization sdk jsonrpc .net c# xen xenserver</PackageTags>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/xapi-project/xen-api</RepositoryUrl>

--- a/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
+++ b/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
@@ -2,16 +2,16 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.citrix.hypervisor</groupId>
+    <groupId>com.xenserver</groupId>
     <artifactId>xen-api</artifactId>
     <version>${revision}</version>
     <packaging>jar</packaging>
-    <name>Citrix Hypervisor Java SDK</name>
-    <description>Mavenized build of the Citrix Hypervisor SDK for Java.</description>
+    <name>XenServer Java SDK</name>
+    <description>Mavenized build of the XenServer SDK for Java.</description>
     <url>https://www.citrix.com/community/citrix-developer/citrix-hypervisor-developer</url>
     <organization>
-        <name>Citrix Systems, Inc.</name>
-        <url>https://www.citrix.com</url>
+        <name>Cloud Software Group, Inc.</name>
+        <url>https://www.cloud.com</url>
     </organization>
     <licenses>
         <license>
@@ -39,7 +39,7 @@
     </mailingLists>
     <developers>
         <developer>
-            <name>Citrix Systems, Inc.</name>
+            <name>Cloud Software Group, Inc.</name>
             <email>xen-api@lists.xenproject.org</email>
         </developer>
     </developers>

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/EventBatch.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/EventBatch.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +34,7 @@ import java.util.Set;
 /**
  * Class used to map the output of Event.from().
  *
- * @author Citrix Systems, Inc.
+ * @author Cloud Software Group, Inc.
  */
 public class EventBatch
 {

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Marshalling.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Marshalling.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/XenAPIObject.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/XenAPIObject.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/resources/README.txt
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/resources/README.txt
@@ -1,8 +1,10 @@
 XenServerJava
 =============
 
-XenServerJava is a complete SDK for Citrix Hypervisor, exposing the Citrix
-Hypervisor API as Java classes.
+Copyright (c) 2007-2023 Cloud Software Group, Inc. All Rights Reserved.
+
+XenServerJava is a complete SDK for XenServer, exposing the XenServer API as
+Java classes.
 
 XenServerJava includes a class for every API class, and a method for each API
 call, so API documentation and examples written for other languages will apply
@@ -16,12 +18,12 @@ terms of the BSD 2-Clause license. See LICENSE for details.
 Reference
 ---------
 
-For Citrix Hypervisor documentation see https://docs.citrix.com/en-us/citrix-hypervisor/
+For XenServer documentation see https://docs.citrix.com/en-us/citrix-hypervisor/
 
-The Citrix Hypervisor Management API Reference is available at
+The XenServer Management API Reference is available at
 https://developer-docs.citrix.com/projects/citrix-hypervisor-management-api/en/latest/
 
-The Citrix Hypervisor Software Development Kit Guide is available at
+The XenServer Software Development Kit Guide is available at
 https://developer-docs.citrix.com/projects/citrix-hypervisor-sdk/en/latest/
 
 A number of examples to help you get started with the SDK is available at
@@ -30,7 +32,7 @@ https://github.com/xenserver/xenserver-samples
 For community content, blogs, and downloads, visit
 https://www.citrix.com/community/citrix-developer/
 
-To network with other developers using Citrix Hypervisor visit
+To network with other developers using XenServer visit
 https://discussions.citrix.com/forum/101-hypervisor-formerly-xenserver/
 
 

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -1,31 +1,5 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 open Printf
@@ -609,7 +583,7 @@ let gen_class cls folder =
   fprintf file " * %s\n" cls.description ;
   if not (publishInfo = "") then fprintf file " * %s\n" publishInfo ;
   fprintf file " *\n" ;
-  fprintf file " * @author Citrix Systems, Inc.\n" ;
+  fprintf file " * @author Cloud Software Group, Inc.\n" ;
   fprintf file " */\n" ;
   fprintf file "public class %s extends XenAPIObject {\n\n" class_name ;
 
@@ -946,7 +920,7 @@ let gen_types_class folder =
      /**\n\
     \ * This class holds vital marshalling functions, enum types and exceptions.\n\
     \ *\n\
-    \ * @author Citrix Systems, Inc.\n\
+    \ * @author Cloud Software Group, Inc.\n\
     \ */\n\
      public class Types\n\
      {\n\

--- a/ocaml/sdk-gen/java/templates/APIVersion.mustache
+++ b/ocaml/sdk-gen/java/templates/APIVersion.mustache
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/README.dist
+++ b/ocaml/sdk-gen/powershell/README.dist
@@ -1,5 +1,7 @@
 XenServer PowerShell Module
-===================================
+===========================
+
+Copyright (c) 2013-2023 Cloud Software Group, Inc. All Rights Reserved.
 
 The XenServer PowerShell Module is a complete SDK for XenServer,
 exposing the XenServer API as Windows PowerShell cmdlets.
@@ -50,7 +52,7 @@ The XenServer PowerShell Module is dependent upon the following libraries:
   for details. A patched version of the library (Newtonsoft.Json.CH.dll) is
   shipped with the XenServer PowerShell Module.
 
-- XenServer.NET by Citrix Systems, Inc.
+- XenServer.NET by Cloud Software Group, Inc.
   XenServer.NET is a complete SDK for XenServer, exposing the XenServer
   API as .NET classes. It is written in C#. 
 

--- a/ocaml/sdk-gen/powershell/autogen/Initialize-Environment.ps1
+++ b/ocaml/sdk-gen/powershell/autogen/Initialize-Environment.ps1
@@ -1,6 +1,5 @@
 #
-# Copyright (c) Citrix Systems, Inc.
-# All rights reserved.
+# Copyright (c) Cloud Software Group, Inc.
 # 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/XenServer.format.ps1xml
+++ b/ocaml/sdk-gen/powershell/autogen/XenServer.format.ps1xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <!--
-  Copyright (c) Citrix Systems, Inc.
-  All rights reserved.
+  Copyright (c) Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/XenServer.types.ps1xml
+++ b/ocaml/sdk-gen/powershell/autogen/XenServer.types.ps1xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-  Copyright (c) Citrix Systems, Inc.
-  All rights reserved.
+  Copyright (c) Cloud Software Group, Inc.
   
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/XenServerPSModule.psd1
+++ b/ocaml/sdk-gen/powershell/autogen/XenServerPSModule.psd1
@@ -1,6 +1,5 @@
 #
-# Copyright (c) Citrix Systems, Inc.
-# All rights reserved.
+# Copyright (c) Cloud Software Group, Inc.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,8 +36,8 @@ GUID = 'D695A8B9-039A-443C-99A4-0D48D7C6AD76'
 
 #Copyright
 Author = ''
-CompanyName = 'Citrix Systems, Inc'
-Copyright = 'Copyright (c) Citrix Systems, Inc. All rights reserved.'
+CompanyName = 'Cloud Software Group, Inc'
+Copyright = 'Copyright (c) 2013-2023 Cloud Software Group, Inc. All rights reserved.'
 
 # Requirements
 PowerShellVersion = '7.2'

--- a/ocaml/sdk-gen/powershell/autogen/src/CommonCmdletFunctions.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/CommonCmdletFunctions.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/src/Connect-XenServer.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/Connect-XenServer.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/src/Disconnect-XenServer.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/Disconnect-XenServer.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/src/Get-XenSession.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/Get-XenSession.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/src/Receive-XenPoolPatch.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/Receive-XenPoolPatch.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/src/Send-XenOemPatchStream.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/Send-XenOemPatchStream.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/src/Wait-XenTask.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/Wait-XenTask.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/src/XenServerCmdlet.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/XenServerCmdlet.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/autogen/src/XenServerHttpCmdlet.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/XenServerHttpCmdlet.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
+ * Copyright (c) Cloud Software Group, Inc.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/ocaml/sdk-gen/powershell/common_functions.ml
+++ b/ocaml/sdk-gen/powershell/common_functions.ml
@@ -1,31 +1,5 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 open Printf

--- a/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
+++ b/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
@@ -1,31 +1,5 @@
 (*
- * Copyright (c) Citrix Systems, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   1) Redistributions of source code must retain the above copyright
- *      notice, this list of conditions and the following disclaimer.
- *
- *   2) Redistributions in binary form must reproduce the above
- *      copyright notice, this list of conditions and the following
- *      disclaimer in the documentation and/or other materials
- *      provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * Copyright (c) Cloud Software Group, Inc.
  *)
 
 open Printf

--- a/ocaml/sdk-gen/windows-line-endings.sh
+++ b/ocaml/sdk-gen/windows-line-endings.sh
@@ -1,6 +1,5 @@
 #
-# Copyright (c) Citrix Systems, Inc.
-# All rights reserved.
+# Copyright (c) Cloud Software Group, Inc.
 # 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions


### PR DESCRIPTION
Summary of changes
Licence:
- Removed BSD2 licence from Ocaml generation files as I think they should match the LGPLv2 licence of the rest of the Ocaml code in this repo (as also stated in the Readme of the sdk-gen repo).

Copyright:
- Added `<yearRange> <vendor>` to SDK sources and Ocaml generation code
- Added `<yearRange> <vendor> All rights reserved.` to Readmes and metadata files shipped with the binary deliverables.
I've used the same yearRange for both of the above cases. Practically speaking I don't think it's incorrect to do so, plus that from past experience I doubt we'll be remembering to update it every time for each individual file, while using the same makes it easier to change in one go.