### PR TITLE
CA-374872: error when `BOND_MEMBERS` is not in `management.conf`

### DIFF
--- a/ocaml/networkd/lib/network_config.ml
+++ b/ocaml/networkd/lib/network_config.ml
@@ -61,7 +61,11 @@ let read_management_conf () =
       Option.value ~default:"" (List.assoc_opt "BOND_MODE" args)
     in
     let bond_members =
-      String.split_on_char ',' (List.assoc "BOND_MEMBERS" args)
+      match List.assoc_opt "BOND_MEMBERS" args with
+      | None ->
+          []
+      | Some x ->
+          String.split_on_char ',' x
     in
     let device =
       (* Take 1st member of bond *)


### PR DESCRIPTION
It is an optional field, handle its abscence gracefully. Following up: https://github.com/xapi-project/xen-api/pull/4333 (commit: e8dbc1d981ee9cb1f8090da996cd794b0ca1141c)

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>