### PR TITLE
CP-33338: write physical-device-path to xenstore for nbd devices

### DIFF
--- a/ocaml/xenopsd/scripts/block
+++ b/ocaml/xenopsd/scripts/block
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 TYPE=`echo ${XENBUS_PATH} | cut -f 2 -d '/'`
 DOMID=`echo ${XENBUS_PATH} | cut -f 3 -d '/'`
@@ -25,12 +25,23 @@ add)
 
 		# Write physical-device field only for real block devices.
 		if [ "$TYPE" != "9pfs" ]; then
-			physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
-			syslog "${XENBUS_PATH}: physical-device=${physical_device}"
-			xenstore-exists "${XENBUS_PATH}/physical-device"
-			if [ $? -eq 1 ]; then
-				syslog "${XENBUS_PATH}: writing physical-device=${physical_device}"
-				xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
+			if [[ $params =~ nbd:unix:([^:]*) ]]
+			then
+				physical_device_path=$(readlink -f ${BASH_REMATCH[1]})
+				syslog "${XENBUS_PATH}: physical-device-path=${physical_device_path}"
+				xenstore-exists "${XENBUS_PATH}/physical-device-path"
+				if [ $? -eq 1 ]; then
+					syslog "${XENBUS_PATH}: writing physical-device-path=${physical_device_path}"
+					xenstore-write "${XENBUS_PATH}/physical-device-path" "${physical_device_path}"
+				fi
+			else
+				physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
+				syslog "${XENBUS_PATH}: physical-device=${physical_device}"
+				xenstore-exists "${XENBUS_PATH}/physical-device"
+				if [ $? -eq 1 ]; then
+					syslog "${XENBUS_PATH}: writing physical-device=${physical_device}"
+					xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
+				fi
 			fi
 		fi
 	fi


### PR DESCRIPTION
When the VDI datapath is attached with an NBD export the backend expects the details to be present in physical-device-path.

Signed-off-by: Mark Syms <mark.syms@citrix.com>