### PR TITLE
CP-42173: xenctrlext: stop using xentoolog bindings

### DIFF
--- a/ocaml/xenforeign/main.ml
+++ b/ocaml/xenforeign/main.ml
@@ -13,7 +13,7 @@ let () =
   Arg.parse [] anon_fun usage_msg ;
   let the_domid = Option.get !domid in
 
-  let handle = Xfm.acquire None in
+  let handle = Xfm.acquire () in
   defer (fun () -> Xfm.release handle) @@ fun () ->
   let prot = {Xfm.read= true; write= true; exec= false} in
   let tpm_addr = 0x110000L in

--- a/ocaml/xenopsd/c_stubs/dune
+++ b/ocaml/xenopsd/c_stubs/dune
@@ -17,6 +17,6 @@
   (language c)
   (names tuntap_stubs xenctrlext_stubs)
  )
-  (c_library_flags (-L/lib64 -lxentoollog -lxenforeignmemory))
+  (c_library_flags (-L/lib64 -lxenforeignmemory))
 )
 

--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -20,7 +20,6 @@
 #include <unistd.h>
 #include <xenctrl.h>
 #include <xenforeignmemory.h>
-#include <xentoollog.h>
 
 #include <sys/mman.h>
 
@@ -40,7 +39,6 @@
 /* From xenctrl_stubs */
 #define ERROR_STRLEN 1024
 
-#define Xtl_val(x)(*((struct xentoollog_logger **) Data_custom_val(x)))
 #define Xfm_val(x)(*((struct xenforeignmemory_handle **) Data_abstract_val(x)))
 #define Addr_val(x)(*((void **) Data_abstract_val(x)))
 
@@ -443,22 +441,18 @@ CAMLprim value stub_xenctrlext_cputopoinfo(value xch)
 	CAMLreturn(result);
 }
 
-CAMLprim value stub_xenforeignmemory_open(value logger)
+CAMLprim value stub_xenforeignmemory_open(value unit)
 {
-        CAMLparam1(logger);
-        struct xentoollog_logger *log_handle = NULL;
+        CAMLparam1(unit);
         struct xenforeignmemory_handle *fmem;
         CAMLlocal1(result);
-
-        if(Is_some(logger)) {
-                log_handle = Xtl_val(Some_val(logger));
-        }
 
         // allocate memory to store the result, if the call to get the xfm
         // handle fails the ocaml GC will collect this abstract tag
         result = caml_alloc(1, Abstract_tag);
 
-        fmem = xenforeignmemory_open(log_handle, 0);
+        // use NULL instead of a xentoollog handle as those bindings are flawed
+        fmem = xenforeignmemory_open(NULL, 0);
 
         if(fmem == NULL) {
                 caml_failwith("Error when opening foreign memory handle");

--- a/ocaml/xenopsd/xc/dune
+++ b/ocaml/xenopsd/xc/dune
@@ -49,7 +49,6 @@
   xapi-xenopsd.c_stubs
   xapi-xenopsd-xc.c_stubs
   xenctrl
-  xentoollog
   xenstore
   xenstore_transport.unix
  )

--- a/ocaml/xenopsd/xc/xenctrlext.ml
+++ b/ocaml/xenopsd/xc/xenctrlext.ml
@@ -112,8 +112,7 @@ module Xenforeignmemory = struct
 
   type prot = {read: bool; write: bool; exec: bool}
 
-  external acquire : Xentoollog.handle option -> handle
-    = "stub_xenforeignmemory_open"
+  external acquire : unit -> handle = "stub_xenforeignmemory_open"
 
   external release : handle -> unit = "stub_xenforeignmemory_close"
 

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -93,7 +93,7 @@ module Xenforeignmemory : sig
 
   type prot = {read: bool; write: bool; exec: bool}
 
-  val acquire : Xentoollog.handle option -> handle
+  val acquire : unit -> handle
 
   val release : handle -> unit
 

--- a/xapi-xenopsd-xc.opam
+++ b/xapi-xenopsd-xc.opam
@@ -45,7 +45,6 @@ depends: [
   "xenctrl"
   "xenstore"
   "xenstore_transport"
-  "xentoollog"
 ]
 synopsis:
   "A xenops plugin which knows how to use xenstore, xenctrl and xenguest to manage"


### PR DESCRIPTION
These are known to be problematic and cause segfaults on shutdown, the call can be done by passing around NULL to let xen create a handle that can be ignored.

This needs testing with a special build of xen without the bindings from @andyhhp 