### PR TITLE
CP-42016: Add parameter "--newest-only" to "reposync" command

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -188,6 +188,7 @@ let sync ~__context ~self ~token ~token_id =
           ; "--download-metadata"
           ; "--delete"
           ; "--plugins"
+          ; "--newest-only"
           ; Printf.sprintf "--repoid=%s" repo_name
           ]
         in


### PR DESCRIPTION
Download only the latest version of each RPM when mirroring down from the
hosted yum repository

Signed-off-by: Gang Ji <gang.ji@citrix.com>