### PR TITLE
CP-41796 Close Port 80 (Encrypt Data Transfer During VM Migrations)

### DIFF
--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -322,7 +322,9 @@ let rpc ~srcstr ~dststr (url, pool_secret) =
     let open Http.Url in
     match url with
     | Http h, d ->
-        ((Http {h with host= ip}, d), pool_secret)
+        ( (Http {h with host= ip; ssl= !Xapi_globs.migration_https_only}, d)
+        , pool_secret
+        )
     | _ ->
         remote_url ip
   in
@@ -724,7 +726,7 @@ let start' ~task ~dbg ~sr ~vdi ~dp ~url ~dest =
       | Some tapdev ->
           let pid = Tapctl.get_tapdisk_pid tapdev in
           let path = Printf.sprintf "/var/run/blktap-control/nbdclient%d" pid in
-          with_transport transport
+          with_transport ~stunnel_wait_disconnect:false transport
             (with_http request (fun (response, s) ->
                  let control_fd = Unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
                  finally

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -781,6 +781,8 @@ let web_dir = ref "/opt/xensource/www"
 
 let website_https_only = ref true
 
+let migration_https_only = ref false
+
 let cluster_stack_root = ref "/usr/libexec/xapi/cluster-stack"
 
 let cluster_stack_default = ref "xhad"
@@ -1093,6 +1095,11 @@ let other_options =
     , (fun () -> string_of_bool !relax_xsm_sr_check)
     , "allow storage migration when SRs have been mirrored out-of-band (and \
        have matching SR uuids)"
+    )
+  ; ( "migration-https-only"
+    , Arg.Set migration_https_only
+    , (fun () -> string_of_bool !migration_https_only)
+    , "Exclusively use HTTPS for VM migration"
     )
   ; gen_list_option "disable-logging-for"
       "space-separated list of modules to suppress logging from"

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2376,18 +2376,24 @@ let migrate_receive ~__context ~host ~network ~options =
       | _ ->
           failwith "No IP address on PIF"
   ) ;
+  (* Set the scheme to HTTP and let the migration source host decide whether to
+     switch to HTTPS instead, to avoid problems with source hosts that are not
+     able to do HTTPS migrations yet. *)
+  let scheme = "http" in
+
   let sm_url =
-    Printf.sprintf "http://%s/services/SM?session_id=%s" ip new_session_id
+    Printf.sprintf "%s://%s/services/SM?session_id=%s" scheme ip new_session_id
   in
   let xenops_url =
-    Printf.sprintf "http://%s/services/xenops?session_id=%s" ip new_session_id
+    Printf.sprintf "%s://%s/services/xenops?session_id=%s" scheme ip
+      new_session_id
   in
   let master_address =
     try Pool_role.get_master_address ()
     with Pool_role.This_host_is_a_master ->
       Option.get (Helpers.get_management_ip_addr ~__context)
   in
-  let master_url = Printf.sprintf "http://%s/" master_address in
+  let master_url = Printf.sprintf "%s://%s/" scheme master_address in
   [
     (Xapi_vm_migrate._sm, sm_url)
   ; (Xapi_vm_migrate._host, Ref.string_of host)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -30,6 +30,53 @@ open D
 
 exception InvalidOperation of string
 
+(* This code is usually in xcp-idl but we introduced a local copy here
+   to support https, which has a dependency on stunnel and would create
+   a circular dependency. *)
+
+let with_open_uri' uri f =
+  let finally = Xapi_stdext_pervasives.Pervasiveext.finally in
+  match Uri.scheme uri with
+  | Some "http" -> (
+    match (Uri.host uri, Uri.port uri) with
+    | Some host, Some port ->
+        Open_uri.open_tcp f host port
+    | Some host, None ->
+        Open_uri.open_tcp f host 80
+    | _, _ ->
+        failwith
+          (Printf.sprintf "Failed to parse host and port from URI: %s"
+             (Uri.to_string uri)
+          )
+  )
+  | Some "https" -> (
+    match (Uri.host uri, Uri.port uri) with
+    | Some host, Some port ->
+        Stunnel.with_connect host port (fun s ->
+            f Safe_resources.Unixfd.(!(s.Stunnel.fd))
+        )
+    | Some host, None ->
+        Stunnel.with_connect host !Constants.https_port (fun s ->
+            f Safe_resources.Unixfd.(!(s.Stunnel.fd))
+        )
+    | _, _ ->
+        failwith
+          (Printf.sprintf "Failed to parse host and port from URI: %s"
+             (Uri.to_string uri)
+          )
+  )
+  | Some "file" ->
+      let filename = Uri.path_and_query uri in
+      let sockaddr = Unix.ADDR_UNIX filename in
+      let s = Unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+      finally
+        (fun () -> Unix.connect s sockaddr ; Open_uri.handle_socket f s)
+        (fun () -> Unix.close s)
+  | Some x ->
+      failwith (Printf.sprintf "Unsupported URI scheme: %s" x)
+  | None ->
+      failwith (Printf.sprintf "Failed to parse URI: %s" (Uri.to_string uri))
+
 let assert_operation_valid =
   Xapi_vm_lifecycle.assert_operation_valid ~strict:true
 
@@ -1520,7 +1567,7 @@ let rec import_inner n ~__context ~url ~sr ~full_restore ~force =
   else
     let uri = Uri.of_string url in
     try
-      Open_uri.with_open_uri uri (fun fd ->
+      with_open_uri' uri (fun fd ->
           let module Request =
             Cohttp.Request.Make (Cohttp_posix_io.Unbuffered_IO) in
           let module Response =

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -65,16 +65,29 @@ let get_ip_from_url url =
   | _, _ ->
       failwith (Printf.sprintf "Cannot extract foreign IP address from: %s" url)
 
-let remote_of_dest dest =
-  let master_url = List.assoc _master dest in
-  let xenops_url = List.assoc _xenops dest in
+let remote_of_dest ~__context dest =
+  let maybe_set_https url =
+    if !Xapi_globs.migration_https_only then
+      Http.Url.(url |> of_string |> set_ssl true |> to_string)
+    else
+      url
+  in
+  let master_url = List.assoc _master dest |> maybe_set_https in
+  let xenops_url = List.assoc _xenops dest |> maybe_set_https in
   let session_id = Ref.of_string (List.assoc _session_id dest) in
   let remote_ip = get_ip_from_url xenops_url in
   let remote_master_ip = get_ip_from_url master_url in
   let dest_host_string = List.assoc _host dest in
   let dest_host = Ref.of_string dest_host_string in
   let rpc = Helpers.make_remote_rpc remote_master_ip in
-  let sm_url = List.assoc _sm dest in
+  let sm_url =
+    let url = List.assoc _sm dest in
+    (* Never use HTTPS for local SM calls *)
+    if not (Helpers.this_is_my_address ~__context remote_ip) then
+      maybe_set_https url
+    else
+      url
+  in
   {
     rpc
   ; session= session_id
@@ -321,8 +334,10 @@ let pool_migrate ~__context ~vm ~host ~options =
   let ip =
     Http.Url.maybe_wrap_IPv6_literal (Db.Host.get_address ~__context ~self:host)
   in
+  let scheme = if !Xapi_globs.migration_https_only then "https" else "http" in
+
   let xenops_url =
-    Printf.sprintf "http://%s/services/xenops?session_id=%s" ip session_id
+    Printf.sprintf "%s://%s/services/xenops?session_id=%s" scheme ip session_id
   in
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
   let xenops_vgpu_map = infer_vgpu_map ~__context vm in
@@ -1051,7 +1066,7 @@ let migrate_send' ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~vgpu_map
     (Db.VM.get_uuid ~__context ~self:vm) ;
   let open Xapi_xenops in
   let localhost = Helpers.get_localhost ~__context in
-  let remote = remote_of_dest dest in
+  let remote = remote_of_dest ~__context dest in
   (* Copy mode means we don't destroy the VM on the source host. We also don't
      	   copy over the RRDs/messages *)
   let copy = try bool_of_string (List.assoc "copy" options) with _ -> false in
@@ -1561,7 +1576,7 @@ let migration_type ~__context ~remote =
 let assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options
     ~vgpu_map =
   assert_licensed_storage_motion ~__context ;
-  let remote = remote_of_dest dest in
+  let remote = remote_of_dest ~__context dest in
   let force =
     try bool_of_string (List.assoc "force" options) with _ -> false
   in
@@ -1733,7 +1748,7 @@ let assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map ~vif_map ~options
 let assert_can_migrate_sender ~__context ~vm ~dest ~live ~vdi_map ~vif_map
     ~vgpu_map ~options =
   (* Check that the destination host has compatible pGPUs -- if needed *)
-  let remote = remote_of_dest dest in
+  let remote = remote_of_dest ~__context dest in
   let remote_for_migration_type =
     match migration_type ~__context ~remote with
     | `intra_pool ->


### PR DESCRIPTION
This is a backport of several commits; we omit those that in the original code deal with certificate checking as this is not present in this code base.

The original code is in xen-api.git but in the backport is split into xe-api.git, xenopsd.git, and xen-api-libs-transitional.git.

  5977845    Add HTTPS support to open-uri
  34e0b3b    Move Open_uri from xapi-idl to its own package
  d9f2d36    Move logging lib from xapi-idl to its own package
  140651b    Move good_ciphersuites from Xcp_consts to Constants
  0e92445    Rename Uuid module to Uuidx
  65f95bd    Do not wait for stunnel disconnect
  da27653    Use HTTP for local storage calls
  698f6e7    Use HTTPS when redirecting storage calls
  c30fc13    Switch host.migrate_receive over to HTTPS
  3910474    Switch VM.pool_migrate over to HTTPS

Becasue the actual change is not large, I am keeping all changes in a single commit.

The original code was authored by Rob Hoes <rob.hoes@citrix.com>. Almost all code had to be ported manually.

This switches the xenopsd-to-xenopsd connection over to HTTPS, if enabled in the config file (currently off by default).

Socket keepalives do not work when stunnel is used, as the given fd is the local connection to stunnel, and are not set in HTTPS mode. This is fine, because the stunnel client is already set up with keepalives.

The host.migrate_receive call returns URLs for the sending host to use in its VM.migrate_send call. HTTPS URLs are returned based on the value of the config option.

The function in question redirects a local storage call to another host if the current host does not have access to the SR. This involves rewriting a localhost HTTP URL to a remote URL, which must be an HTTPS URL if storage migration is configured to use HTTPS.

Storage calls that are handled by the local host should always use HTTP, and not set up a connecting through stunnel. The SM URL that is passed to VM.migrate_send in the `dest` parameter, which comes from the return value of a call to host.migrate_receive, may be an HTTPS URL to the localhost, which needs to be rewritten upon receiving it.

When starting a mirroring process for a disk as part of a storage migration, xapi establishes the connection to the destination, but hands it over to tapdisk to do the actual mirroring over NBD. It is crucial that xapi just hands over the file descriptor and then continues with other business, without waiting for the connection to finish. This is how it works for TCP connections now.

When switching to TLS connections, xapi starts an stunnel process as part of the connection setup, and hands over the stunnel fd to tapdisk. By default, this functionality then waits for stunnel to finish after the connection is eventually broken, thus introducing the unwanted blocking. We fix this by telling stunnel to disconnect, but not wait for this to actually happen.

This is currently set on the destination, in host.migrate_receive. However, all recent changes to make HTTPS migration work were on the source host. Migration is allowed from older to newer software versions, so it is possible that the destination is HTTPS capable, while the source is not. This may result in the source receiving HTTPS URLs, which is cannot handle, breaking this upgrade case.

Instead, let the source decide whether to switch to HTTPS or not, depending on the config key (to be made the default later).