### PR TITLE
OCaml C stub bugfixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# See ./CODING_STYLE
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+charset = utf-8
+max_line_length = 79
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Makefiles must use tabs, otherwise they don't work
+[Makefile]
+indent_style = tabs
+
+[*.{c,h}]
+indent_size = 4
+
+[*.{ml,mli}]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ _build/
 .merlin
 *.install
 *.swp
+compile_flags.txt
 
 # tests
 xapi-db.xml

--- a/Makefile
+++ b/Makefile
@@ -213,3 +213,10 @@ uninstall:
 		message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt \
 		message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-log \
 		xapi-open-uri
+
+compile_flags.txt: Makefile
+	(ocamlc -config-var ocamlc_cflags;\
+	ocamlc -config-var ocamlc_cppflags;\
+	echo -I$(shell ocamlc -where);\
+	echo -Wall -Wextra -Wstrict-prototypes -D_FORTIFY_SOURCE=2\
+	) | xargs -n1 echo >$@

--- a/ocaml/auth/xa_auth_stubs.c
+++ b/ocaml/auth/xa_auth_stubs.c
@@ -32,19 +32,18 @@ CAMLprim value stub_XA_mh_authorize(value username, value password){
     CAMLparam2(username, password);
     CAMLlocal1(ret);
     ret = Val_unit;
-    
+
     char *c_username = strdup(String_val(username));
     char *c_password = strdup(String_val(password));
     const char *error = NULL;
     int rc;
-    
+
     caml_enter_blocking_section();
     rc = XA_mh_authorize(c_username, c_password, &error);
-    caml_leave_blocking_section();
-    
     free(c_username);
     free(c_password);
-    
+    caml_leave_blocking_section();
+
     if (rc != XA_SUCCESS)
         caml_failwith(error ? error : "Unknown error");
     CAMLreturn(ret);
@@ -54,19 +53,18 @@ CAMLprim value stub_XA_mh_chpasswd(value username, value new_password){
     CAMLparam2(username, new_password);
     CAMLlocal1(ret);
     ret = Val_unit;
-    
+
     char *c_username = strdup(String_val(username));
     char *c_new_password = strdup(String_val(new_password));
     const char *error = NULL;
     int rc;
-    
+
     caml_enter_blocking_section();
     rc = XA_mh_chpasswd (c_username, c_new_password, &error);
-    caml_leave_blocking_section();
-    
     free(c_username);
     free(c_new_password);
-    
+    caml_leave_blocking_section();
+
     if (rc != XA_SUCCESS)
         caml_failwith(error ? error : "Unknown error");
     CAMLreturn(ret);

--- a/ocaml/libs/log/syslog_stubs.c
+++ b/ocaml/libs/log/syslog_stubs.c
@@ -59,9 +59,9 @@ value stub_syslog(value facility, value level, value msg)
 
 	caml_enter_blocking_section();
 	syslog(c_facility, "%s", c_msg);
-	caml_leave_blocking_section();
-	
 	free(c_msg);
+	caml_leave_blocking_section();
+
 	CAMLreturn(Val_unit);
 }
 

--- a/ocaml/vhd-tool/src/direct_copy_stubs.c
+++ b/ocaml/vhd-tool/src/direct_copy_stubs.c
@@ -83,7 +83,7 @@ CAMLprim value stub_init(value in_fd, value out_fd)
      we might get on setting the flag.
   */
   flags = fcntl(c_out_fd, F_GETFL, NULL);
-  if (flags > 0 && !(flags & O_DIRECT))
+  if (flags >= 0 && !(flags & O_DIRECT))
     fcntl(c_out_fd, F_SETFL, flags | O_DIRECT);
 #endif
 
@@ -138,7 +138,7 @@ CAMLprim value stub_direct_copy(value handle, value len){
 
   rc = TRIED_AND_FAILED;
   bytes = 0;
-  
+
   remaining = c_len;
   while (remaining > 0) {
     ssize_t bread;

--- a/ocaml/vhd-tool/src/direct_copy_stubs.c
+++ b/ocaml/vhd-tool/src/direct_copy_stubs.c
@@ -32,10 +32,7 @@
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
-
-/* ocaml/ocaml/unixsupport.c */
-extern void uerror(char *cmdname, value cmdarg);
-#define Nothing ((value) 0)
+#include <caml/unixsupport.h>
 
 enum direct_copy_rc {
   OK                   = 0,

--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -79,24 +79,14 @@ static void raise_unix_errno_msg(int err_code, const char *err_msg)
 
 static void failwith_xc(xc_interface *xch)
 {
-        static char error_str[XC_MAX_ERROR_MSG_LEN + 6];
-        int real_errno = -1;
-        if (xch) {
-                const xc_error *error = xc_get_last_error(xch);
-                if (error->code == XC_ERROR_NONE) {
-                        real_errno = errno;
-                        snprintf(error_str, sizeof(error_str), "%d: %s", errno, strerror(errno));
-                } else {
-                        real_errno = error->code;
-                        snprintf(error_str, sizeof(error_str), "%d: %s: %s",
-                                 error->code,
-                                 xc_error_code_to_desc(error->code),
-                                 error->message);
-                }
-        } else {
-                snprintf(error_str, sizeof(error_str), "Unable to open XC interface");
-        }
-        raise_unix_errno_msg(real_errno, error_str);
+    static char error_str[XC_MAX_ERROR_MSG_LEN + 6];
+    int real_errno = errno;
+    if (xch) {
+        snprintf(error_str, sizeof(error_str), "%d: %s", errno, strerror(errno));
+    } else {
+        snprintf(error_str, sizeof(error_str), "Unable to open XC interface");
+    }
+    raise_unix_errno_msg(real_errno, error_str);
 }
 
 CAMLprim value stub_xenctrlext_interface_open(value unused)

--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -33,8 +33,12 @@
 #include <caml/unixsupport.h>
 #include <caml/bigarray.h>
 
-#define _H(__h) (*((xc_interface **)Data_custom_val(__h)))
-#define _D(__d) ((uint32_t)Int_val(__d))
+static inline xc_interface *xch_of_val(value v)
+{
+	xc_interface *xch = *(xc_interface **)Data_custom_val(v);
+
+	return xch;
+}
 
 /* From xenctrl_stubs */
 #define ERROR_STRLEN 1024
@@ -50,7 +54,7 @@
 
 static void stub_xenctrlext_finalize(value v)
 {
-	xc_interface_close(_H(v));
+	xc_interface_close(xch_of_val(v));
 }
 
 static struct custom_operations xenctrlext_ops = {
@@ -109,22 +113,23 @@ CAMLprim value stub_xenctrlext_interface_open(value unused)
 		failwith_xc(xch);
 
 	result = caml_alloc_custom(&xenctrlext_ops, sizeof(xch), 0, 1);
-	_H(result) = xch;
+	*(xc_interface **)Data_custom_val(result) = xch;
 
 	CAMLreturn(result);
 }
 
-CAMLprim value stub_xenctrlext_get_runstate_info(value xch, value domid)
+CAMLprim value stub_xenctrlext_get_runstate_info(value xch_val, value domid)
 {
-	CAMLparam2(xch, domid);
+	CAMLparam2(xch_val, domid);
 #if defined(XENCTRL_HAS_GET_RUNSTATE_INFO)
 	CAMLlocal1(result);
 	xc_runstate_info_t info;
 	int retval;
+	xc_interface *xch = xch_of_val(xch_val);
 
-	retval = xc_get_runstate_info(_H(xch), _D(domid), &info);
+	retval = xc_get_runstate_info(xch, Int_val(domid), &info);
 	if (retval < 0)
-		failwith_xc(_H(xch));
+		failwith_xc(xch);
 
 	/* Store
 	   0 : state (int32)
@@ -149,17 +154,18 @@ CAMLprim value stub_xenctrlext_get_runstate_info(value xch, value domid)
 #endif
 }
 
-CAMLprim value stub_xenctrlext_get_boot_cpufeatures(value xch)
+CAMLprim value stub_xenctrlext_get_boot_cpufeatures(value xch_val)
 {
-	CAMLparam1(xch);
+	CAMLparam1(xch_val);
 #if defined(XENCTRL_HAS_GET_CPUFEATURES)
 	CAMLlocal1(v);
 	uint32_t a, b, c, d, e, f, g, h;
 	int ret;
+	xc_interface *xch = xch_of_val(xch_val);
 
-	ret = xc_get_boot_cpufeatures(_H(xch), &a, &b, &c, &d, &e, &f, &g, &h);
+	ret = xc_get_boot_cpufeatures(xch, &a, &b, &c, &d, &e, &f, &g, &h);
 	if (ret < 0)
-	  failwith_xc(_H(xch));
+	  failwith_xc(xch);
 
 	v = caml_alloc_tuple(8);
 	Store_field(v, 0, caml_copy_int32(a));
@@ -188,99 +194,108 @@ static int xcext_domain_set_timer_mode(xc_interface *xch, unsigned int domid, in
                             HVM_PARAM_TIMER_MODE, (unsigned long) mode);
 }
 
-CAMLprim value stub_xenctrlext_domain_get_acpi_s_state(value xch, value domid)
+CAMLprim value stub_xenctrlext_domain_get_acpi_s_state(value xch_val, value domid)
 {
-	CAMLparam2(xch, domid);
+	CAMLparam2(xch_val, domid);
 	unsigned long v;
 	int ret;
+	xc_interface* xch = xch_of_val(xch_val);
 
-	ret = xc_get_hvm_param(_H(xch), _D(domid), HVM_PARAM_ACPI_S_STATE, &v);
+	ret = xc_get_hvm_param(xch, Int_val(domid), HVM_PARAM_ACPI_S_STATE, &v);
 	if (ret != 0)
-		failwith_xc(_H(xch));
+		failwith_xc(xch);
 
 	CAMLreturn(Val_int(v));
 }
 
-CAMLprim value stub_xenctrlext_domain_send_s3resume(value xch, value domid)
+CAMLprim value stub_xenctrlext_domain_send_s3resume(value xch_val, value domid)
 {
-	CAMLparam2(xch, domid);
-	xcext_domain_send_s3resume(_H(xch), _D(domid));
+	CAMLparam2(xch_val, domid);
+	xc_interface *xch = xch_of_val(xch_val);
+
+	xcext_domain_send_s3resume(xch, Int_val(domid));
 	CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_xenctrlext_domain_set_timer_mode(value xch, value id, value mode)
+CAMLprim value stub_xenctrlext_domain_set_timer_mode(value xch_val, value id, value mode)
 {
-	CAMLparam3(xch, id, mode);
+	CAMLparam3(xch_val, id, mode);
 	int ret;
+	xc_interface* xch = xch_of_val(xch_val);
 
-	ret = xcext_domain_set_timer_mode(_H(xch), _D(id), Int_val(mode));
+	ret = xcext_domain_set_timer_mode(xch, Int_val(id), Int_val(mode));
 	if (ret < 0)
-		failwith_xc(_H(xch));
+		failwith_xc(xch);
 	CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_xenctrlext_get_max_nr_cpus(value xch)
+CAMLprim value stub_xenctrlext_get_max_nr_cpus(value xch_val)
 {
-	CAMLparam1(xch);
+	CAMLparam1(xch_val);
 	xc_physinfo_t c_physinfo;
+    xc_interface *xch = xch_of_val(xch_val);
 	int r;
 
 	caml_enter_blocking_section();
-	r = xc_physinfo(_H(xch), &c_physinfo);
+	r = xc_physinfo(xch, &c_physinfo);
 	caml_leave_blocking_section();
 
 	if (r)
-		failwith_xc(_H(xch));
+		failwith_xc(xch);
 
 	CAMLreturn(Val_int(c_physinfo.max_cpu_id + 1));
 }
 
-CAMLprim value stub_xenctrlext_domain_set_target(value xch,
+CAMLprim value stub_xenctrlext_domain_set_target(value xch_val,
 					 value domid,
 					 value target)
 {
-	CAMLparam3(xch, domid, target);
+	CAMLparam3(xch_val, domid, target);
+	xc_interface* xch = xch_of_val(xch_val);
 
-	int retval = xc_domain_set_target(_H(xch), _D(domid), _D(target));
+	int retval = xc_domain_set_target(xch, Int_val(domid), Int_val(target));
 	if (retval)
-		failwith_xc(_H(xch));
+		failwith_xc(xch);
 	CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_xenctrlext_physdev_map_pirq(value xch,
+CAMLprim value stub_xenctrlext_physdev_map_pirq(value xch_val,
         value domid,
         value irq)
 {
-    CAMLparam3(xch, domid, irq);
+    CAMLparam3(xch_val, domid, irq);
+    xc_interface *xch = xch_of_val(xch_val);
     int pirq = Int_val(irq);
     caml_enter_blocking_section();
-    int retval = xc_physdev_map_pirq(_H(xch), _D(domid), pirq, &pirq);
+    int retval = xc_physdev_map_pirq(xch, Int_val(domid), pirq, &pirq);
     caml_leave_blocking_section();
     if (retval)
-        failwith_xc(_H(xch));
+        failwith_xc(xch);
     CAMLreturn(Val_int(pirq));
 } /* ocaml here would be int -> int */
 
-CAMLprim value stub_xenctrlext_assign_device(value xch, value domid,
+CAMLprim value stub_xenctrlext_assign_device(value xch_val, value domid,
         value machine_sbdf, value flag)
 {
-    CAMLparam4(xch, domid, machine_sbdf, flag);
+    CAMLparam4(xch_val, domid, machine_sbdf, flag);
+    xc_interface *xch = xch_of_val(xch_val);
     caml_enter_blocking_section();
-    int retval = xc_assign_device(_H(xch), _D(domid), Int_val(machine_sbdf), Int_val(flag));
+    int retval = xc_assign_device(xch, Int_val(domid), Int_val(machine_sbdf), Int_val(flag));
     caml_leave_blocking_section();
     if (retval)
-        failwith_xc(_H(xch));
+        failwith_xc(xch);
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_xenctrlext_deassign_device(value xch, value domid, value machine_sbdf)
+CAMLprim value stub_xenctrlext_deassign_device(value xch_val, value domid, value machine_sbdf)
 {
-    CAMLparam3(xch, domid, machine_sbdf);
+    CAMLparam3(xch_val, domid, machine_sbdf);
+    xc_interface *xc = xch_of_val(xch_val);
     caml_enter_blocking_section();
-    int retval = xc_deassign_device(_H(xch), _D(domid), Int_val(machine_sbdf));
+    int retval = xc_deassign_device(xc, Int_val(domid), Int_val(machine_sbdf));
     caml_leave_blocking_section();
     if (retval)
-        failwith_xc(_H(xch));
+        failwith_xc(xc);
     CAMLreturn(Val_unit);
 }
 
@@ -290,80 +305,85 @@ CAMLprim value stub_xenctrlext_domid_quarantine(value unit)
     CAMLreturn(Val_int(DOMID_IO));
 }
 
-CAMLprim value stub_xenctrlext_domain_soft_reset(value xch, value domid)
+CAMLprim value stub_xenctrlext_domain_soft_reset(value xch_val, value domid)
 {
-    CAMLparam2(xch, domid);
+    CAMLparam2(xch_val, domid);
+    xc_interface *xc = xch_of_val(xch_val);
     caml_enter_blocking_section();
-    int retval = xc_domain_soft_reset(_H(xch), _D(domid));
+    int retval = xc_domain_soft_reset(xc, Int_val(domid));
     caml_leave_blocking_section();
     if (retval)
-        failwith_xc(_H(xch));
+        failwith_xc(xc);
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_xenctrlext_domain_update_channels(value xch, value domid,
+CAMLprim value stub_xenctrlext_domain_update_channels(value xch_val, value domid,
         value store_port, value console_port)
 {
-    CAMLparam4(xch, domid, store_port, console_port);
+    CAMLparam4(xch_val, domid, store_port, console_port);
+    xc_interface *xc = xch_of_val(xch_val);
     caml_enter_blocking_section();
-    int retval = xc_set_hvm_param(_H(xch), _D(domid), HVM_PARAM_STORE_EVTCHN, Int_val(store_port));
+    int retval = xc_set_hvm_param(xc, Int_val(domid), HVM_PARAM_STORE_EVTCHN, Int_val(store_port));
     if (!retval)
-        retval = xc_set_hvm_param(_H(xch), _D(domid), HVM_PARAM_CONSOLE_EVTCHN, Int_val(console_port));
+        retval = xc_set_hvm_param(xc, Int_val(domid), HVM_PARAM_CONSOLE_EVTCHN, Int_val(console_port));
     caml_leave_blocking_section();
     if (retval)
-        failwith_xc(_H(xch));
+        failwith_xc(xc);
     CAMLreturn(Val_unit);
 }
 
 /* based on xenctrl_stubs.c */
-static int get_cpumap_len(value xch, value cpumap)
+static int get_cpumap_len(value xch_val, value cpumap)
 {
+	xc_interface* xch = xch_of_val(xch_val);
 	int ml_len = Wosize_val(cpumap);
-	int xc_len = xc_get_max_cpus(_H(xch));
+	int xc_len = xc_get_max_cpus(xch);
 
 	return (ml_len < xc_len ? ml_len : xc_len);
 }
 
-CAMLprim value stub_xenctrlext_vcpu_setaffinity_soft(value xch, value domid,
+CAMLprim value stub_xenctrlext_vcpu_setaffinity_soft(value xch_val, value domid,
                                                      value vcpu, value cpumap)
 {
-	CAMLparam4(xch, domid, vcpu, cpumap);
-	int i, len = get_cpumap_len(xch, cpumap);
+	CAMLparam4(xch_val, domid, vcpu, cpumap);
+	int i, len = get_cpumap_len(xch_val, cpumap);
 	xc_cpumap_t c_cpumap;
 	int retval;
+	xc_interface* xch = xch_of_val(xch_val);
 
-	c_cpumap = xc_cpumap_alloc(_H(xch));
+	c_cpumap = xc_cpumap_alloc(xch);
 	if (c_cpumap == NULL)
-		failwith_xc(_H(xch));
+		failwith_xc(xch);
 
 	for (i=0; i<len; i++) {
 		if (Bool_val(Field(cpumap, i)))
 			c_cpumap[i/8] |= 1 << (i&7);
 	}
-	retval = xc_vcpu_setaffinity(_H(xch), _D(domid),
+	retval = xc_vcpu_setaffinity(xch, Int_val(domid),
 				     Int_val(vcpu),
 				     NULL, c_cpumap,
 				     XEN_VCPUAFFINITY_SOFT);
 	free(c_cpumap);
 
 	if (retval < 0)
-		failwith_xc(_H(xch));
+		failwith_xc(xch);
 	CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_xenctrlext_numainfo(value xch)
+CAMLprim value stub_xenctrlext_numainfo(value xch_val)
 {
-	CAMLparam1(xch);
+	CAMLparam1(xch_val);
 	CAMLlocal5(meminfos, distances, result, info, row);
         unsigned max_nodes = 0;
         xc_meminfo_t *meminfo = NULL;
         uint32_t* distance = NULL;
         unsigned i, j;
         int retval;
+        xc_interface* xch = xch_of_val(xch_val);
 
-        retval = xc_numainfo(_H(xch), &max_nodes, NULL, NULL);
+        retval = xc_numainfo(xch, &max_nodes, NULL, NULL);
         if (retval < 0)
-            failwith_xc(_H(xch));
+            failwith_xc(xch);
 
         meminfo = calloc(max_nodes, sizeof(*meminfo));
         distance = calloc(max_nodes * max_nodes, sizeof(*distance));
@@ -373,11 +393,11 @@ CAMLprim value stub_xenctrlext_numainfo(value xch)
             caml_raise_out_of_memory();
         }
 
-        retval = xc_numainfo(_H(xch), &max_nodes, meminfo, distance);
+        retval = xc_numainfo(xch, &max_nodes, meminfo, distance);
         if (retval < 0) {
             free(meminfo);
             free(distance);
-            failwith_xc(_H(xch));
+            failwith_xc(xch);
         }
 
         meminfos = caml_alloc_tuple(max_nodes);
@@ -406,26 +426,27 @@ CAMLprim value stub_xenctrlext_numainfo(value xch)
 	CAMLreturn(result);
 }
 
-CAMLprim value stub_xenctrlext_cputopoinfo(value xch)
+CAMLprim value stub_xenctrlext_cputopoinfo(value xch_val)
 {
-	CAMLparam1(xch);
+	CAMLparam1(xch_val);
 	CAMLlocal2(topo, result);
         xc_cputopo_t *cputopo = NULL;
         unsigned max_cpus, i;
         int retval;
+        xc_interface* xch = xch_of_val(xch_val);
 
-        retval = xc_cputopoinfo(_H(xch), &max_cpus, NULL);
+        retval = xc_cputopoinfo(xch, &max_cpus, NULL);
         if (retval < 0)
-            failwith_xc(_H(xch));
+            failwith_xc(xch);
 
         cputopo = calloc(max_cpus, sizeof(*cputopo));
         if (!cputopo)
             caml_raise_out_of_memory();
 
-        retval = xc_cputopoinfo(_H(xch), &max_cpus, cputopo);
+        retval = xc_cputopoinfo(xch, &max_cpus, cputopo);
         if (retval < 0) {
             free(cputopo);
-            failwith_xc(_H(xch));
+            failwith_xc(xch);
         }
 
         result = caml_alloc_tuple(max_cpus);
@@ -494,6 +515,7 @@ CAMLprim value stub_xenforeignmemory_map(value fmem, value dom,
         xen_pfn_t *arr;
         int prot, the_errno;
         void *retval;
+        xenforeignmemory_handle *handle = Xfm_val(fmem);
 
         if (Field(prot_flags, 0) == Val_false &&
             Field(prot_flags, 1) == Val_false &&
@@ -531,7 +553,7 @@ CAMLprim value stub_xenforeignmemory_map(value fmem, value dom,
         }
 
         retval = xenforeignmemory_map
-                (Xfm_val(fmem), _D(dom), prot, pages_length, arr, NULL);
+                (handle, Int_val(dom), prot, pages_length, arr, NULL);
         the_errno = errno;
 
         free(arr);

--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -95,9 +95,9 @@ static void failwith_xc(xc_interface *xch)
         raise_unix_errno_msg(real_errno, error_str);
 }
 
-CAMLprim value stub_xenctrlext_interface_open(void)
+CAMLprim value stub_xenctrlext_interface_open(value unused)
 {
-	CAMLparam0();
+	CAMLparam1(unused);
 	CAMLlocal1(result);
 	xc_interface *xch;
 

--- a/unixpwd/c/unixpwd_stubs.c
+++ b/unixpwd/c/unixpwd_stubs.c
@@ -121,9 +121,9 @@ caml_unixpwd_setspw(value caml_user, value caml_password)
 }
 
 CAMLprim        value
-caml_unixpwd_unshadow(void)
+caml_unixpwd_unshadow(value unused)
 {
-    CAMLparam0();
+    CAMLparam1(unused);
     char           *passwords;
     CAMLlocal1(str);
 


### PR DESCRIPTION
Fixes a race condition introduced in 40b755b6d, but also some other long standing bugs (wrong number of arguments to C stubs, incorrect O_DIRECT setting).
It also prepares the C stubs for OCaml 5.0 compatibility by removing some global state (although I don't claim this to be fully OCaml 5.0 ready yet).
There are some '[maintenance]' commits as well to make debugging better by preserving errno in a Unix_error instead of losing it with 'failwith', and better editor integration for C stubs (write out a compile_flags.txt with paths to headers/etc. so that `clang` can act as a language server, just like ocaml-lsp would for OCaml file).

There is also a static analyzer to check that these particular race conditions got fixed everywhere, but that depends on a newer version of GCC, and will come in a separate PR.