### PR TITLE
CA-375280: xe-toolstack-restart: stop and start all services at once

### DIFF
--- a/scripts/xe-toolstack-restart
+++ b/scripts/xe-toolstack-restart
@@ -49,15 +49,13 @@ for svc in $SERVICES ; do
 
 	if [ $? -eq 0 ] ; then
 		TO_RESTART="$svc $TO_RESTART"
-		systemctl stop $svc
 	fi
 done
+systemctl stop ${TO_RESTART}
 
 set -e
 
-for svc in $TO_RESTART ; do
-	systemctl start $svc
-done
+systemctl start ${TO_RESTART}
 
 rm -f $LOCKFILE
 echo "done."


### PR DESCRIPTION
Starting all services at once is what happens on boot, so this should work.

We currently stop services one at a time, and if they get stuck (e.g. due to waiting on a network filesystem that is stuck) then each has to hit the 1m30s timeout in systemd before they get killed, which is a minimum of ~32m before the toolstack is stopped.

Which is a lot higher than the default 2 minute HA timeout, and even if the XAPI watcher would attempt recovery by restarting XAPI (or the toolstack), it would be stuck waiting for this 30m process to complete first.

Stop all services at once and then start all needed ones at once. (Don't attempt to restart all in a single command since that might result in some services restarting and immediately seeing another service being restarted, interrupting communication and potentially leading to errors).

Systemd can then use existing service dependencies to order the restarts.

Tested with a BST.