### PR TITLE
add experimental PVH support

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 760
+let schema_minor_vsn = 761
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1647,6 +1647,7 @@ let domain_type =
         ("hvm", "HVM; Fully Virtualised")
       ; ("pv", "PV: Paravirtualised")
       ; ("pv_in_pvh", "PV inside a PVH container")
+      ; ("pvh", "PVH")
       ; ("unspecified", "Not specified or unknown domain type")
       ]
     )

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,8 @@
 let hash x = Digest.string x |> Digest.to_hex
 
-(* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "021c461d774cbfc67ba65e5616d21f41"
+(* BEWARE: if this changes, check that schema has been bumped accordingly in
+   ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
+let last_known_schema_hash = "c994671e607237e92f89814b3b640dd3"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/test_cpuid_helpers.ml
+++ b/ocaml/tests/test_cpuid_helpers.ml
@@ -506,6 +506,7 @@ module NextBootCPUFeatures = Generic.MakeStateful (struct
         ([("a", `hvm)], [features_hvm])
       ; ([("a", `pv)], [features_pv])
       ; ([("a", `pv_in_pvh)], [features_hvm])
+      ; ([("a", `pvh)], [features_hvm])
       ; ( [("a", `hvm); ("b", `pv); ("c", `pv_in_pvh)]
         , [features_hvm; features_pv; features_hvm]
         )

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -987,6 +987,8 @@ let domain_type_to_string = function
       "pv"
   | `pv_in_pvh ->
       "pv-in-pvh"
+  | `pvh ->
+      "pvh"
   | `unspecified ->
       "unspecified"
 
@@ -998,6 +1000,8 @@ let domain_type_of_string x =
       `pv
   | "pv-in-pvh" ->
       `pv_in_pvh
+  | "pvh" ->
+      `pvh
   | s ->
       raise (Record_failure ("Invalid domain type. Got " ^ s))
 

--- a/ocaml/xapi-idl/xen/xenops_types.ml
+++ b/ocaml/xapi-idl/xen/xenops_types.ml
@@ -129,7 +129,11 @@ module Vm = struct
   }
   [@@deriving rpcty, sexp]
 
-  type builder_info = HVM of hvm_info | PV of pv_info | PVinPVH of pv_info
+  type builder_info =
+    | HVM of hvm_info
+    | PV of pv_info
+    | PVinPVH of pv_info
+    | PVH of pv_info
   [@@deriving rpcty, sexp]
 
   type id = string [@@deriving rpcty, sexp]
@@ -179,6 +183,7 @@ module Vm = struct
     | Domain_HVM
     | Domain_PV
     | Domain_PVinPVH
+    | Domain_PVH
     | Domain_undefined
   [@@deriving rpcty, sexp]
 

--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -111,7 +111,7 @@ let vendor = Map_check.(field "vendor" string)
 let get_flags_for_vm ~__context vm cpu_info =
   let features_field, features_field_boot =
     match Helpers.domain_type ~__context ~self:vm with
-    | `hvm | `pv_in_pvh ->
+    | `hvm | `pv_in_pvh | `pvh ->
         (features_hvm, features_hvm_host)
     | `pv ->
         (features_pv, features_pv_host)
@@ -156,7 +156,7 @@ let next_boot_cpu_features ~__context ~vm =
       Db.VM.get_domain_type ~__context ~self:vm |> Helpers.check_domain_type
     in
     match domain_type with
-    | `hvm | `pv_in_pvh ->
+    | `hvm | `pv_in_pvh | `pvh ->
         (features_hvm, features_hvm_host)
     | `pv ->
         (features_pv, features_pv_host)

--- a/ocaml/xapi/memory_check.ml
+++ b/ocaml/xapi/memory_check.ml
@@ -33,6 +33,8 @@ let vm_compute_required_memory vm_record guest_memory_kib =
         (vm_record.API.vM_HVM_shadow_multiplier, Memory.HVM.full_config)
     | `pv_in_pvh ->
         (vm_record.API.vM_HVM_shadow_multiplier, Memory.PVinPVH.full_config)
+    | `pvh ->
+        (vm_record.API.vM_HVM_shadow_multiplier, Memory.HVM.full_config)
     | `pv ->
         (Memory.Linux.shadow_multiplier_default, Memory.Linux.full_config)
   in
@@ -255,7 +257,7 @@ let vm_compute_memory_overhead ~vm_record =
   let vcpu_count = Int64.to_int vm_record.API.vM_VCPUs_max in
   let model =
     match Helpers.check_domain_type vm_record.API.vM_domain_type with
-    | `hvm ->
+    | `hvm | `pvh ->
         Memory.HVM.overhead_mib
     | `pv_in_pvh ->
         Memory.PVinPVH.overhead_mib

--- a/ocaml/xapi/vm_platform.ml
+++ b/ocaml/xapi/vm_platform.ml
@@ -162,7 +162,7 @@ let sanity_check ~platformdata ~firmware ~vcpu_max ~vcpu_at_startup:_
   in
   (* Sanity check for HVM or PV-in-PVH domains with invalid VCPU configuration*)
   let check_cores_per_socket =
-    match domain_type with `hvm | `pv_in_pvh -> true | `pv -> false
+    match domain_type with `hvm | `pv_in_pvh | `pvh -> true | `pv -> false
   in
   ( match (List.assoc device_model platformdata, firmware) with
   | "qemu-trad", Xenops_types.Vm.Uefi _ ->

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -206,7 +206,7 @@ let compute_evacuation_plan ~__context total_hosts remaining_hosts
           match Helpers.check_domain_type snapshot.API.vM_domain_type with
           | `hvm | `pv ->
               Memory_check.Dynamic_min
-          | `pv_in_pvh ->
+          | `pv_in_pvh | `pvh ->
               Memory_check.Static_max
         in
         (vm, total_memory_of_vm ~__context policy snapshot)

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -118,7 +118,7 @@ let valid_operations ~__context record _ref' : table =
     match Helpers.domain_type ~__context ~self:vm with
     | `hvm ->
         true
-    | `pv_in_pvh | `pv ->
+    | `pv_in_pvh | `pv | `pvh ->
         false
   in
   ( if power_state = `Running && needs_driver_check () then

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -317,7 +317,7 @@ let validate_actions_after_crash ~__context ~self ~value =
   let fld = "VM.actions_after_crash" in
   let hvm_cannot_coredump v =
     match Helpers.domain_type ~__context ~self with
-    | `hvm | `pv_in_pvh ->
+    | `hvm | `pv_in_pvh | `pvh ->
         value_not_supported fld v
           "cannot invoke a coredump of an HVM or PV-in-PVH domain"
     | `pv ->
@@ -638,7 +638,7 @@ let assert_enough_memory_available ~__context ~self ~host ~snapshot =
   in
   let policy =
     match Helpers.check_domain_type snapshot.API.vM_domain_type with
-    | `hvm | `pv ->
+    | `hvm | `pv | `pvh ->
         Memory_check.Dynamic_min
     | `pv_in_pvh ->
         Memory_check.Static_max
@@ -752,7 +752,7 @@ let assert_can_boot_here ~__context ~self ~host ~snapshot ~do_cpuid_check
   assert_usbs_available ~__context ~self ~host ;
   assert_netsriov_available ~__context ~self ~host ;
   ( match Helpers.domain_type ~__context ~self with
-  | `hvm | `pv_in_pvh ->
+  | `hvm | `pv_in_pvh | `pvh ->
       assert_host_supports_hvm ~__context ~self ~host
   | `pv ->
       ()

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -159,7 +159,7 @@ let has_definitely_booted_pv ~vmmr =
     match r.Db_actions.vM_metrics_current_domain_type with
     | `hvm | `unspecified ->
         false
-    | `pv | `pv_in_pvh ->
+    | `pv | `pv_in_pvh | `pvh ->
         true
   )
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -339,12 +339,17 @@ let rtc_timeoffset_of_vm ~__context (vm, vm_t) vbds =
 
 (* /boot/ contains potentially sensitive files like xen-initrd, so we will only*)
 (* allow directly booting guests from the subfolder /boot/guest/ *)
-let allowed_dom0_directory_for_boot_files = "/boot/guest/"
+let allowed_dom0_directories_for_boot_files =
+  ["/boot/guest/"; "/var/lib/xcp/guest"]
 
 let is_boot_file_whitelisted filename =
   let safe_str str = not (String.has_substr str "..") in
   (* make sure the script prefix is the allowed dom0 directory *)
-  String.startswith allowed_dom0_directory_for_boot_files filename
+  List.exists
+    (fun allowed_dom0_directory_for_boot_files ->
+      String.startswith allowed_dom0_directory_for_boot_files filename
+    )
+    allowed_dom0_directories_for_boot_files
   (* avoid ..-style attacks and other weird things *)
   && safe_str filename
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -547,6 +547,10 @@ let builder_of_vm ~__context (vmref, vm) timeoffset pci_passthrough vgpu =
       PVinPVH (make_direct_boot_record options)
   | `pv_in_pvh, Helpers.Indirect options ->
       PVinPVH (make_indirect_boot_record options)
+  | `pvh, Helpers.Direct options ->
+      PVH (make_direct_boot_record options)
+  | `pvh, Helpers.Indirect options ->
+      PVH (make_indirect_boot_record options)
   | _ ->
       raise
         Api_errors.(
@@ -572,7 +576,7 @@ module MD = struct
       match vm.API.vM_domain_type with
       | `hvm ->
           true
-      | `pv_in_pvh | `pv | `unspecified ->
+      | `pv_in_pvh | `pv | `pvh | `unspecified ->
           false
     in
     let device_number = Device_number.of_string hvm vbd.API.vBD_userdevice in
@@ -2047,6 +2051,8 @@ let update_vm ~__context id =
                     update `pv
                 | Domain_PVinPVH ->
                     update `pv_in_pvh
+                | Domain_PVH ->
+                    update `pvh
                 | Domain_undefined ->
                     if power_state <> `Halted then
                       debug

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -432,7 +432,7 @@ let print_vm id =
     )
     | HVM {boot_order= b; _} ->
         [(_builder, quote "hvm"); (_boot, quote b)]
-    | PVinPVH _ ->
+    | PVinPVH _ | PVH _ ->
         failwith "unimplemented"
   in
   let name = [(_name, quote vm_t.name)] in

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -1178,6 +1178,24 @@ let export_metadata vdi_map vif_map vgpu_pci_map id =
                         }
                   )
               }
+        | Vm.PVH pv_info ->
+            Vm.PVH
+              {
+                pv_info with
+                Vm.boot=
+                  ( match pv_info.Vm.boot with
+                  | Vm.Direct _ ->
+                      pv_info.Vm.boot
+                  | Vm.Indirect pv_indirect_boot ->
+                      Vm.Indirect
+                        {
+                          pv_indirect_boot with
+                          Vm.devices=
+                            List.map (remap_vdi vdi_map)
+                              pv_indirect_boot.Vm.devices
+                        }
+                  )
+              }
         )
     }
   in
@@ -1258,7 +1276,7 @@ let import_metadata id md =
       let fs =
         let stat = B.HOST.stat () in
         ( match md.Metadata.vm.Vm.ty with
-        | HVM _ | PVinPVH _ ->
+        | HVM _ | PVinPVH _ | PVH _ ->
             Host.(stat.cpu_info.features_hvm)
         | PV _ ->
             Host.(stat.cpu_info.features_pv)

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -59,6 +59,8 @@ let feature_flags_path = ref "/etc/xenserver/features.d"
 
 let pvinpvh_xen_cmdline = ref "pv-shim console=xen"
 
+let pvh_ovmf_cmdline = ref ""
+
 let numa_placement = ref false
 
 (* This is for debugging only *)
@@ -241,6 +243,11 @@ let options =
     , Arg.Set_string pvinpvh_xen_cmdline
     , (fun () -> !pvinpvh_xen_cmdline)
     , "Command line for the inner-xen for PV-in-PVH guests"
+    )
+  ; ( "pvh-ovmf-cmdline"
+    , Arg.Set_string pvh_ovmf_cmdline
+    , (fun () -> !pvh_ovmf_cmdline)
+    , "Command line for OVMF for PVH guests"
     )
   ; ( "numa-placement"
     , Arg.Bool (fun x -> numa_placement := x)

--- a/ocaml/xenopsd/test/test.ml
+++ b/ocaml/xenopsd/test/test.ml
@@ -334,11 +334,11 @@ let vm_assert_equal vm vm' =
   assert_equal ~msg:"has_vendor_device" ~printer:string_of_bool
     vm.has_vendor_device vm'.has_vendor_device ;
   let is_hvm vm =
-    match vm.ty with HVM _ -> true | PV _ | PVinPVH _ -> false
+    match vm.ty with HVM _ -> true | PV _ | PVinPVH _ | PVH _ -> false
   in
   assert_equal ~msg:"HVM-ness" ~printer:string_of_bool (is_hvm vm) (is_hvm vm') ;
   match (vm.ty, vm'.ty) with
-  | HVM _, (PV _ | PVinPVH _) | (PV _ | PVinPVH _), HVM _ ->
+  | HVM _, (PV _ | PVinPVH _ | PVH _) | (PV _ | PVinPVH _ | PVH _), HVM _ ->
       failwith "HVM-ness"
   | HVM h, HVM h' ->
       assert_equal ~msg:"HAP" ~printer:string_of_bool h.hap h'.hap ;
@@ -371,7 +371,7 @@ let vm_assert_equal vm vm' =
         h.boot_order h'.boot_order ;
       assert_equal ~msg:"qemu_disk_cmdline" ~printer:string_of_bool
         h.qemu_disk_cmdline h'.qemu_disk_cmdline
-  | (PV p | PVinPVH p), (PV p' | PVinPVH p') -> (
+  | (PV p | PVinPVH p | PVH p), (PV p' | PVinPVH p' | PVH p') -> (
       assert_equal ~msg:"framebuffer" ~printer:string_of_bool p.framebuffer
         p'.framebuffer ;
       assert_equal ~msg:"vncterm" ~printer:string_of_bool p.vncterm p'.vncterm ;


### PR DESCRIPTION
This enables testing and developing PVH support in OVMF, XTF and mirage unikernels.

Tested an earlier version of this with a Mirage Solo5 unikernel (it might be useful for writing xenstore fuzzers/tests too).

/cc @andyhhp 