### PR TITLE
python/XenAPI: Replace import six.moves with stdlib imports

### DIFF
--- a/ocaml/tests/test_data/repository_pkg_of_fullname_all
+++ b/ocaml/tests/test_data/repository_pkg_of_fullname_all
@@ -266,7 +266,6 @@ libjpeg-turbo-1.2.90-5.el7.x86_64
 ethtool-4.19-1.xs8.x86_64
 xxhash-libs-0.6.5-1.el7.x86_64
 libcollection-0.7.0-29.el7.x86_64
-python-six-1.9.0-2.el7.noarch
 libarchive-3.1.2-10.el7_2.x86_64
 iptables-1.4.21-24.1.el7_5.x86_64
 newt-0.52.15-4.el7.x86_64

--- a/scripts/examples/python/XenAPI/XenAPI.py
+++ b/scripts/examples/python/XenAPI/XenAPI.py
@@ -55,10 +55,16 @@
 # --------------------------------------------------------------------
 
 import gettext
-import six.moves.xmlrpc_client as xmlrpclib
-import six.moves.http_client as httplib
 import socket
 import sys
+
+if sys.version_info[0] == 2:
+    import httplib as httplib
+    import xmlrpclib as xmlrpclib
+else:
+    import http.client as httplib
+    import xmlrpc.client as xmlrpclib
+
 
 translation = gettext.translation('xen-xm', fallback = True)
 

--- a/scripts/examples/python/XenAPIPlugin.py
+++ b/scripts/examples/python/XenAPIPlugin.py
@@ -5,8 +5,13 @@
 from __future__ import print_function
 
 import sys
-import six.moves.xmlrpc_client as xmlrpclib
+
 import XenAPI
+
+if sys.version_info[0] == 2:
+    import xmlrpclib as xmlrpclib
+else:
+    import xmlrpc.client as xmlrpclib
 
 class Failure(Exception):
     """Provide compatibilty with plugins written against XenServer 5.5 API"""

--- a/scripts/examples/python/setup.cfg
+++ b/scripts/examples/python/setup.cfg
@@ -19,8 +19,6 @@ classifiers =
 
 [options]
 packages = find:
-install_requires =
-  six
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4
 
 [bdist_wheel]


### PR DESCRIPTION
Replace the use of six.moves with directly importing the standard xmlrpc and http libs of Python 2.7 and Python 3.x

Tested by using xenserver-status-report/xen-bugtool with it using on XS 8.3.0 with Python 2.7 and Python 3.6 installed.

Consequently, the Requires: python-six and python3-six can be removed from the xen-api.spec file as well.