### PR TITLE
CP-41730: Limit ldap query timeout for subject information

### DIFF
--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -307,7 +307,8 @@ module Ldap = struct
     let domain_krb5_cfg = krb5_conf_path ~domain_netbios in
     [|Printf.sprintf "KRB5_CONFIG=%s" domain_krb5_cfg|]
 
-  let query_user ?(log_output = Helpers.On_failure) sid domain_netbios kdc =
+  let query_user ?(log_output = Helpers.On_failure) ?timeout sid domain_netbios
+      kdc =
     let env = env_of_krb5 domain_netbios in
     (* msDS-UserPasswordExpiryTimeComputed not in the default attrs list, define it explictly here *)
     let attrs =
@@ -340,7 +341,7 @@ module Ldap = struct
           @ attrs
         in
         let stdout =
-          Helpers.call_script ~env ~log_output !Xapi_globs.net_cmd args
+          Helpers.call_script ~env ~log_output !Xapi_globs.net_cmd ?timeout args
         in
         Ok stdout
       with _ -> Error (generic_ex "ldap query user info from sid failed")
@@ -1360,7 +1361,8 @@ module AuthADWinbind : Auth_signature.AUTH_MODULE = struct
       match ClosestKdc.from_db domain with
       | Some _ -> (
           let closest_kdc = closest_kdc_of_domain domain in
-          match Ldap.query_user sid domain_netbios closest_kdc with
+          let timeout = !Xapi_globs.winbind_ldap_query_subject_timeout in
+          match Ldap.query_user sid domain_netbios closest_kdc ~timeout with
           | Ok user ->
               Ok user
           | _ ->

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -951,6 +951,8 @@ let winbind_allow_kerberos_auth_fallback = ref false
 
 let winbind_keep_configuration = ref false
 
+let winbind_ldap_query_subject_timeout = ref 20.
+
 let tdb_tool = ref "/usr/bin/tdbtool"
 
 let sqlite3 = ref "/usr/bin/sqlite3"
@@ -1334,6 +1336,11 @@ let other_options =
     , (fun () -> string_of_bool !winbind_keep_configuration)
     , "Whether to clear winbind configuration when join domain failed or leave \
        domain"
+    )
+  ; ( "winbind_ldap_query_subject_timeout"
+    , Arg.Set_float winbind_ldap_query_subject_timeout
+    , (fun () -> string_of_float !winbind_ldap_query_subject_timeout)
+    , "Timeout to perform ldap query for subject information"
     )
   ; ( "website-https-only"
     , Arg.Set website_https_only


### PR DESCRIPTION
During login, subject information is queried to verify detailed info. Default value is used in case of ldap query failed.

This commit set a configurable timeout for ldap query. For a busy system with lots of login request with remote Domain Controller, Admin can set a smaller timeout to accelerate the login process