### PR TITLE
CP-42014: Add last_update_sync to pool datamodel

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 760
+let schema_minor_vsn = 761
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -21,6 +21,8 @@ let prototyped_of_field = function
       Some "22.20.0"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
+  | "pool", "last_update_sync" ->
+      Some "23.3.0-next"
   | "pool", "coordinator_bias" ->
       Some "22.37.0"
   | "pool", "migration_compression" ->

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1331,6 +1331,9 @@ let t =
             "coordinator_bias"
             "true if bias against pool master when scheduling vms is enabled, \
              false otherwise"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
+            ~default_value:(Some (VDateTime Date.epoch)) "last_update_sync"
+            "time of the last update sychronization"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "021c461d774cbfc67ba65e5616d21f41"
+let last_known_schema_hash = "d170625a90c4a15e0d2035b79143dfb5"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -287,7 +287,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(client_certificate_auth_enabled = false)
     ?(client_certificate_auth_name = "") ?(repository_proxy_url = "")
     ?(repository_proxy_username = "") ?(repository_proxy_password = Ref.null)
-    ?(migration_compression = false) ?(coordinator_bias = true) () =
+    ?(migration_compression = false) ?(coordinator_bias = true)
+    ?(last_update_sync = API.Date.epoch) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -302,7 +303,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~tls_verification_enabled:false ~repositories
     ~client_certificate_auth_enabled ~client_certificate_auth_name
     ~repository_proxy_url ~repository_proxy_username ~repository_proxy_password
-    ~migration_compression ~coordinator_bias ;
+    ~migration_compression ~coordinator_bias ~last_update_sync ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1460,6 +1460,9 @@ let pool_record rpc session_id pool =
               ~value:(bool_of_string x)
           )
           ()
+      ; make_field ~name:"last-update-sync"
+          ~get:(fun () -> Date.to_string (x ()).API.pool_last_update_sync)
+          ()
       ]
   }
 

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -47,7 +47,7 @@ let create_pool_record ~__context =
       ~client_certificate_auth_enabled:false ~client_certificate_auth_name:""
       ~repository_proxy_url:"" ~repository_proxy_username:""
       ~repository_proxy_password:Ref.null ~migration_compression:false
-      ~coordinator_bias:true
+      ~coordinator_bias:true ~last_update_sync:Xapi_stdext_date.Date.epoch
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3397,7 +3397,6 @@ let sync_updates ~__context ~self ~force ~token ~token_id =
    * But the 'configure_repositories' and 'sync_updates' may do the change.
    *)
   let enabled = Repository_helpers.get_enabled_repositories ~__context in
-  let pool = Helpers.get_pool ~__context in
   match force with
   | true ->
       Xapi_pool_helpers.with_pool_operation ~__context ~self
@@ -3410,17 +3409,19 @@ let sync_updates ~__context ~self ~force ~token ~token_id =
              sync ~__context ~self:x ~token ~token_id ;
              create_pool_repository ~__context ~self:x
          ) ;
-      Db.Pool.set_last_update_sync ~__context ~self:pool ~value:(Date.now ()) ;
-      set_available_updates ~__context
+      let checksum = set_available_updates ~__context in
+      Db.Pool.set_last_update_sync ~__context ~self ~value:(Date.now ()) ;
+      checksum
   | false ->
       with_reposync_lock @@ fun () ->
       enabled |> List.iter (fun x -> sync ~__context ~self:x ~token ~token_id) ;
-      Db.Pool.set_last_update_sync ~__context ~self:pool ~value:(Date.now ()) ;
       Xapi_pool_helpers.with_pool_operation ~__context ~self
         ~doc:"pool.sync_updates" ~op:`sync_updates
       @@ fun () ->
       List.iter (fun x -> create_pool_repository ~__context ~self:x) enabled ;
-      set_available_updates ~__context
+      let checksum = set_available_updates ~__context in
+      Db.Pool.set_last_update_sync ~__context ~self ~value:(Date.now ()) ;
+      checksum
 
 let check_update_readiness ~__context ~self:_ ~requires_reboot =
   (* Pool license check *)


### PR DESCRIPTION
Add a new field "last_update_sync" of type DateTime to record when the last
update synchronization occurred.