### PR TITLE
python/setup.cfg: Fix deprecated dash-separated key

### DIFF
--- a/scripts/examples/python/setup.cfg
+++ b/scripts/examples/python/setup.cfg
@@ -2,7 +2,7 @@
 name = XenAPI
 description = XenAPI SDK, for communication with XenServer.
 long_description = file: README.md
-long-description-content-type = text/markdown; charset=UTF-8
+long_description_content_type = text/markdown; charset=UTF-8
 author = Citrix Systems, Inc.
 author_email = xen-api@lists.xenproject.org
 license = BSD-2-Clause


### PR DESCRIPTION
As pointed out in #4715, `setuptools` now has a warning for dash-separated keys like `long-description-content-type`:
https://github.com/pypa/setuptools/blob/main/setuptools/dist.py#L789

They don't warn when using `pip3 wheel -w dist --no-deps .`, but they warn when using `python setup.py build` etc.

I've checked the setuptools commit history to find about all the details.

We should fix the warning.

Fixes #4715