### PR TITLE
CA-364049: Tell external auth plugins to use python3

### DIFF
--- a/scripts/plugins/extauth-hook
+++ b/scripts/plugins/extauth-hook
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Plugin called by xapi whenever an external_auth_type is enabled or disabled as an 
 # Also when a subject is added or removed.

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # extauth-hook-AD.py
 #


### PR DESCRIPTION
 External auth pluins needs to import Enum, which is removed as
    secureboot-certificate does not Requires it any more.
    
    To resovle this issue there are two options:
    * Requires python2-enum34 in xapi.spec in re-introduce the package
    * Update the plugins to use python3
    
    Given python2 are going to be updated to puthon3, this commit fix
    the issue by telling plugins to use python3 explictly