### PR TITLE
CA-375427: Make DP.destroy idempotent again

### DIFF
--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -229,15 +229,14 @@ module Mux = struct
 
     let destroy _context ~dbg ~dp ~allow_leak =
       info "DP.destroy dbg:%s dp:%s allow_leak:%b" dbg dp allow_leak ;
-      let sr, vdi, vm =
-        let open DP_info in
-        match read dp with
-        | Some x ->
-            (x.sr, x.vdi, x.vm)
-        | None ->
-            failwith "DP not found"
-      in
-      destroy2 _context ~dbg ~dp ~sr ~vdi ~vm ~allow_leak
+      let open DP_info in
+      match read dp with
+      | Some {sr; vdi; vm; _} ->
+          destroy2 _context ~dbg ~dp ~sr ~vdi ~vm ~allow_leak
+      | None ->
+          info
+            "dp %s is not associated with a locally attached VDI; nothing to do"
+            dp
 
     let diagnostics () = Storage_smapiv1_wrapper.Impl.DP.diagnostics ()
 


### PR DESCRIPTION
Before the recent storage API reorganisation, the DP.destroy call was implemented in storage_impl.ml. This file has been renamed storage_smapiv1_wrapper.ml and was pushed down from being the storage API entry point in xapi to only wrap SMAPIv1 calls, and now sits below the storage mux in the stack. The call in storage_impl.ml simply returns if there is no associated VDI with the given datapath in the local state, and there is nothing to "destroy".

The current entry point for the call in storage_mux.ml does raise an error if the datapath is not known, which leads to unexpected errors. This commits makes the call idempotent again.