### PR TITLE
CP-41574: Add telemetry configuration data

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1949,6 +1949,13 @@ let _ =
   error Api_errors.vtpm_max_amount_reached ["amount"]
     ~doc:"The VM cannot be associated with more VTPMs." () ;
 
+  error Api_errors.telemetry_next_collection_too_late ["timestamp"]
+    ~doc:
+      "The next scheduled telemetry data collection is too far into the \
+       future. Pick a timestamp within two telemetry intervals starting from \
+       now."
+    () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -21,6 +21,12 @@ let prototyped_of_field = function
       Some "22.20.0"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
+  | "pool", "telemetry_next_collection" ->
+      Some "23.8.0-next"
+  | "pool", "telemetry_frequency" ->
+      Some "23.8.0-next"
+  | "pool", "telemetry_uuid" ->
+      Some "23.8.0-next"
   | "pool", "coordinator_bias" ->
       Some "22.37.0"
   | "pool", "migration_compression" ->
@@ -45,6 +51,10 @@ let prototyped_of_message = function
       Some "22.26.0"
   | "host", "set_https_only" ->
       Some "22.27.0"
+  | "pool", "reset_telemetry_uuid" ->
+      Some "23.8.0-next"
+  | "pool", "set_telemetry_next_collection" ->
+      Some "23.8.0-next"
   | "pool", "set_https_only" ->
       Some "22.27.0"
   | _ ->

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1350,9 +1350,14 @@ let t =
             ~default_value:(Some (VString "")) "repository_proxy_username"
             "Username for the authentication of the proxy used in syncing with \
              the enabled repositories"
-        ; field ~in_product_since:"21.3.0" ~internal_only:true
-            ~qualifier:DynamicRO ~ty:(Ref _secret)
-            ~default_value:(Some (VRef null_ref)) "repository_proxy_password"
+        ; field ~qualifier:DynamicRO
+            ~lifecycle:
+              [
+                (Published, "21.3.0", "")
+              ; (Changed, rel_next, "Changed internal_only to false")
+              ]
+            ~ty:(Ref _secret) ~default_value:(Some (VRef null_ref))
+            "repository_proxy_password"
             "Password for the authentication of the proxy used in syncing with \
              the enabled repositories"
         ; field ~qualifier:RW ~lifecycle:[] ~ty:Bool

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "021c461d774cbfc67ba65e5616d21f41"
+let last_known_schema_hash = "8de3ec5ab553be646f6ecfa1aa4c207b"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -287,7 +287,9 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(client_certificate_auth_enabled = false)
     ?(client_certificate_auth_name = "") ?(repository_proxy_url = "")
     ?(repository_proxy_username = "") ?(repository_proxy_password = Ref.null)
-    ?(migration_compression = false) ?(coordinator_bias = true) () =
+    ?(migration_compression = false) ?(coordinator_bias = true)
+    ?(telemetry_uuid = Ref.null) ?(telemetry_frequency = `weekly)
+    ?(telemetry_next_collection = API.Date.never) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -302,7 +304,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~tls_verification_enabled:false ~repositories
     ~client_certificate_auth_enabled ~client_certificate_auth_name
     ~repository_proxy_url ~repository_proxy_username ~repository_proxy_password
-    ~migration_compression ~coordinator_bias ;
+    ~migration_compression ~coordinator_bias ~telemetry_uuid
+    ~telemetry_frequency ~telemetry_next_collection ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -514,6 +514,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pool-reset-telemetry-uuid"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Assign a new UUID for the pool's telemetry data."
+      ; implementation= No_fd Cli_operations.pool_reset_telemetry_uuid
+      ; flags= []
+      }
+    )
   ; ( "host-is-in-emergency-mode"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1824,6 +1824,10 @@ let pool_disable_repository_proxy _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   Client.Pool.disable_repository_proxy ~rpc ~session_id ~self:pool
 
+let pool_reset_telemetry_uuid _printer rpc session_id params =
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  Client.Pool.reset_telemetry_uuid ~rpc ~session_id ~self:pool
+
 let vdi_type_of_string = function
   | "system" ->
       `system

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -571,6 +571,14 @@ let protocol_to_string = function
   | `rdp ->
       "RDP"
 
+let telemetry_frequency_to_string = function
+  | `daily ->
+      "daily"
+  | `weekly ->
+      "weekly"
+  | `monthly ->
+      "monthly"
+
 let task_allowed_operations_to_string s =
   match s with `cancel -> "Cancel" | `destroy -> "Destroy"
 

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1460,6 +1460,17 @@ let pool_record rpc session_id pool =
               ~value:(bool_of_string x)
           )
           ()
+      ; make_field ~name:"telemetry-frequency"
+          ~get:(fun () ->
+            (x ()).API.pool_telemetry_frequency
+            |> Record_util.telemetry_frequency_to_string
+          )
+          ()
+      ; make_field ~name:"telemetry-next-collection"
+          ~get:(fun () ->
+            (x ()).API.pool_telemetry_next_collection |> Date.to_string
+          )
+          ()
       ]
   }
 

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1285,3 +1285,6 @@ let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"
 (* VTPMs *)
 
 let vtpm_max_amount_reached = "VTPM_MAX_AMOUNT_REACHED"
+
+(* Telemetry *)
+let telemetry_next_collection_too_late = "TELEMETRY_NEXT_COLLECTION_TOO_LATE"

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -47,7 +47,9 @@ let create_pool_record ~__context =
       ~client_certificate_auth_enabled:false ~client_certificate_auth_name:""
       ~repository_proxy_url:"" ~repository_proxy_username:""
       ~repository_proxy_password:Ref.null ~migration_compression:false
-      ~coordinator_bias:true
+      ~coordinator_bias:true ~telemetry_uuid:Ref.null
+      ~telemetry_frequency:`weekly
+      ~telemetry_next_collection:Xapi_stdext_date.Date.epoch
 
 let set_master_ip ~__context =
   let ip =
@@ -287,6 +289,41 @@ let ensure_vm_metrics_records_exist_noexn __context =
   Helpers.log_exn_continue "ensuring VM_metrics flags exist"
     ensure_vm_metrics_records_exist __context
 
+let setup_telemetry ~__context =
+  let pool = Helpers.get_pool ~__context in
+  let ref = Db.Pool.get_telemetry_uuid ~__context ~self:pool in
+  if ref = Ref.null then
+    Helpers.log_exn_continue "Setting up telemetry"
+      (fun () ->
+        Helpers.call_api_functions ~__context (fun rpc session_id ->
+            Client.Pool.reset_telemetry_uuid ~rpc ~session_id ~self:pool
+        ) ;
+        (* An exception will result in leaving the next collection as default *)
+        let interval_hours =
+          match Db.Pool.get_telemetry_frequency ~__context ~self:pool with
+          | `daily ->
+              1 * 24
+          | `weekly ->
+              7 * 24
+          | `monthly ->
+              30 * 24
+        in
+        let value =
+          let open Ptime in
+          (* A quiescent period (1 day) plus a random hour within a telemetry interval *)
+          Span.of_int_s (3600 * 24)
+          |> Span.add (Span.of_int_s (Random.int (interval_hours * 3600)))
+          |> add_span (Ptime_clock.now ())
+          |> Option.get
+          |> Xapi_stdext_date.Date.of_ptime
+        in
+        Helpers.call_api_functions ~__context (fun rpc session_id ->
+            Client.Pool.set_telemetry_next_collection ~rpc ~session_id
+              ~self:pool ~value
+        )
+      )
+      ()
+
 (* Update the database to reflect current state. Called for both start of day and after
    an agent restart. *)
 let update_env __context =
@@ -297,6 +334,7 @@ let update_env __context =
   set_master_pool_reference ~__context ;
   set_master_ip ~__context ;
   set_master_live ~__context ;
+  setup_telemetry ~__context ;
   (* CA-15449: when we restore from backup we end up with Hosts being forgotten and VMs
      marked as running with dangling resident_on references. We delete the control domains
      and reset the rest to Halted. *)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1090,6 +1090,16 @@ functor
           (pool_uuid ~__context self)
           value ;
         Local.Pool.set_https_only ~__context ~self ~value
+
+      let set_telemetry_next_collection ~__context ~self ~value =
+        info "%s: pool='%s' value='%s'" __FUNCTION__
+          (pool_uuid ~__context self)
+          (Xapi_stdext_date.Date.to_string value) ;
+        Local.Pool.set_telemetry_next_collection ~__context ~self ~value
+
+      let reset_telemetry_uuid ~__context ~self =
+        info "%s: pool='%s'" __FUNCTION__ (pool_uuid ~__context self) ;
+        Local.Pool.reset_telemetry_uuid ~__context ~self
     end
 
     module VM = struct

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -390,3 +390,11 @@ val set_uefi_certificates :
 
 val set_https_only :
   __context:Context.t -> self:API.ref_pool -> value:bool -> unit
+
+val set_telemetry_next_collection :
+     __context:Context.t
+  -> self:API.ref_pool
+  -> value:Xapi_stdext_date.Date.iso8601
+  -> unit
+
+val reset_telemetry_uuid : __context:Context.t -> self:API.ref_pool -> unit


### PR DESCRIPTION
This series add a few pool-wide fields and APIs to facilitate the
telemetry functionality to store and manage pool-wide configurations.