### PR TITLE
fe_systemctl: fix quoting and add a quicktest

### DIFF
--- a/ocaml/forkexecd/lib/fe_systemctl.ml
+++ b/ocaml/forkexecd/lib/fe_systemctl.ml
@@ -18,6 +18,10 @@ type status = {
   ; active_state: string
 }
 
+module StringMap = Map.Make (String)
+
+type 'a string_map = 'a StringMap.t
+
 let systemctl = "/usr/bin/systemctl"
 
 let action ~service action =
@@ -26,41 +30,78 @@ let action ~service action =
   in
   ()
 
-let default_env = ["PATH=" ^ String.concat ":" Forkhelpers.default_path]
+let default_env =
+  StringMap.singleton "PATH" @@ String.concat ":" Forkhelpers.default_path
 
 let run_path = "/run/systemd/system/"
 
-let start_transient ?(env = Array.of_list default_env) ?(properties = [])
-    ~service cmd args =
+(* see https://www.freedesktop.org/software/systemd/man/systemd.syntax.html#Quoting
+   Neither [Filename.quote] or [String.escaped] would produce correct results
+*)
+let systemd_quote s =
+  let b = Buffer.create (String.length s) in
+  Buffer.add_char b '\'' ;
+  let () =
+    s
+    |> String.iter @@ function
+       | '\\' ->
+           Buffer.add_string b {|\\|}
+       | '\'' ->
+           (* these hex escapes work regardless what outer quotes are used *)
+           Buffer.add_string b {|\x27|}
+       | '"' ->
+           Buffer.add_string b {|\x22|}
+       | c when Astring.Char.Ascii.is_print c ->
+           Buffer.add_char b c
+       | _ ->
+           invalid_arg ("Values can only contain printable characters: " ^ s)
+  in
+  Buffer.add_char b '\'' ; Buffer.contents b
+
+let env_pair (k, v) = Printf.sprintf "%s=%s" k v
+
+let environment env =
+  env
+  |> StringMap.bindings
+  |> List.map env_pair
+  |> List.map (fun v -> ("Environment", [v]))
+(* we could build just a single environment line, but might be too long and
+   difficult to debug *)
+
+let build_properties env base properties =
+  "[Service]"
+  :: (List.concat [environment env; base; properties]
+     |> List.map (fun (k, v) ->
+            String.concat ""
+              [k; "="; List.map systemd_quote v |> String.concat " "]
+        )
+     )
+
+let start_transient ?(env = default_env) ?(properties = []) ~service cmd args =
   let syslog_key = service in
   let service = syslog_key ^ ".service" in
   let destination = Filename.concat run_path service in
-  properties
-  |> List.append
-       [
-         ( "Environment"
-         , env |> Array.to_list |> List.map Filename.quote |> String.concat " "
-         )
-       ; ("SyslogIdentifier", syslog_key)
-       ; ("SyslogLevel", "debug")
-       ; ("StandardOutput", "syslog")
-       ; ("StandardError", "inherit")
-       ; ("StartLimitInterval", "0") (* no rate-limit, for bootstorms *)
-       ; ("ExecStart", String.concat " " (cmd :: List.map Filename.quote args))
-       ; ("Type", "simple")
-         (* our systemd is too old, and doesn't support 'exec' *)
-       ; ("Restart", "no")
-         (* can't restart the device-model, it would've lost all state already *)
-       ; ("Slice", "system.slice")
-       ; ("TimeoutStopSec", "10")
-       ]
-  |> List.map (fun (k, v) -> k ^ "=" ^ v)
+  build_properties env
+    [
+      ("SyslogIdentifier", [syslog_key])
+    ; ("SyslogLevel", ["debug"])
+    ; ("StandardOutput", ["syslog"])
+    ; ("StandardError", ["inherit"])
+    ; ("StartLimitInterval", ["0"]) (* no rate-limit, for bootstorms *)
+    ; ("ExecStart", cmd :: args)
+    ; ("Type", ["simple"])
+      (* our systemd is too old, and doesn't support 'exec' *)
+    ; ("Restart", ["no"])
+      (* can't restart the device-model, it would've lost all state already *)
+    ; ("Slice", ["system.slice"])
+    ; ("TimeoutStopSec", ["10"])
+    ]
+    properties
   |> List.append
        [
          "[Unit]"
        ; "Description=transient unit for " ^ syslog_key
        ; "DefaultDependencies=no" (* lifecycle tied to domain, not systemd *)
-       ; "[Service]"
        ]
   |> String.concat "\n"
   |> Xapi_stdext_unix.Unixext.write_string_to_file destination ;

--- a/ocaml/forkexecd/lib/fe_systemctl.mli
+++ b/ocaml/forkexecd/lib/fe_systemctl.mli
@@ -11,6 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+(** systemd service status *)
 type status = {
     result: string
   ; exec_main_pid: int
@@ -18,9 +19,12 @@ type status = {
   ; active_state: string
 }
 
+(** key -> value map *)
+type 'a string_map = 'a Map.Make(String).t
+
 val start_transient :
-     ?env:string array
-  -> ?properties:(string * string) list
+     ?env:string string_map
+  -> ?properties:(string * string list) list
   -> service:string
   -> string
   -> string list

--- a/ocaml/forkexecd/lib/fe_systemctl.mli
+++ b/ocaml/forkexecd/lib/fe_systemctl.mli
@@ -22,6 +22,35 @@ type status = {
 (** key -> value map *)
 type 'a string_map = 'a Map.Make(String).t
 
+val set_properties :
+     ?env:string string_map
+  -> ?properties:(string * string list) list
+  -> service:string
+  -> unit
+  -> unit
+(** [set_properties ?env ?properties ~service ()] sets properties on systemd
+      [service].
+
+  @param env Environment variables to set
+
+  @param properties systemd service properties to override.
+    [Some value] overrides the property.
+    [None] removes any override for the property, setting back to default
+
+  @param service the systemd service to change. Changes take effect on next
+  restart.
+
+*)
+
+val start_templated : template:string -> instance:string -> unit
+(** [start_templated ~template ~instance] starts [template@instance.service]
+  instance of the [template@.service] systemd template unit.
+  The service is expected to exist already.
+
+  @param template the [template@.service] name
+  @param instance parameter for template, available as %i and %I for substitution
+*)
+
 val start_transient :
      ?env:string string_map
   -> ?properties:(string * string list) list
@@ -30,13 +59,13 @@ val start_transient :
   -> string list
   -> unit
 (** [start_transient ?env ?properties ~service cmd args] generates and starts a transient systemd
- * [service] that will execute [cmd args].
- * stdout/stderr from the service is redirected to syslog with [service] as syslog key.
- * Additional [properties] can be specified that are written into the systemd unit file's [Service]
- * section.
- * By default the service is not auto-restarted when it fails, and there is a 10s timeout between
- * SIGTERM and SIGKILL on stop.
- * On failure it raises [Spawn_internal_error(stderr, stdout, Unix.process_status)] *)
+  [service] that will execute [cmd args].
+  stdout/stderr from the service is redirected to syslog with [service] as syslog key.
+  Additional [properties] can be specified that are written into the systemd unit file's [Service]
+  section.
+  By default the service is not auto-restarted when it fails, and there is a 10s timeout between
+  SIGTERM and SIGKILL on stop.
+  On failure it raises [Spawn_internal_error(stderr, stdout, Unix.process_status)] *)
 
 val is_active : service:string -> bool
 (** [is_active ~service] checks whether the [service] is still running *)
@@ -46,10 +75,16 @@ val show : service:string -> status
 
 val stop : service:string -> status
 (** [stop ~service] stops the specified systemd unit (usually a transient service created above).
-  * On failure of the command it raises [Spawn_internal_error(stderr, stdout, Unix.process_status)].
-  * Returns the service's status, and unloads the unit.
-  * *)
+  On failure of the command it raises [Spawn_internal_error(stderr, stdout, Unix.process_status)].
+  Returns the service's status, and unloads/deletes the unit if it was a transient service.
+  (the deletion is a no-op for regular services since they won't be found in
+  the transient path)
+ *)
 
 val exists : service:string -> bool
 (** [exists ~service] checks whether [service] still exists in systemd.
- * Note: stopped transient services get cleaned up and this will return false *)
+  Note: stopped transient services get cleaned up and this will return false *)
+
+(**/**)
+
+val set_test : unit -> unit

--- a/ocaml/forkexecd/lib/forkhelpers.mli
+++ b/ocaml/forkexecd/lib/forkhelpers.mli
@@ -14,7 +14,7 @@
 
 (** Functions to execute processes, pass file descriptors around and return results *)
 
-(** The low-level Unix.fork(), Unix.exec*() functions and friends are not safe to 
+(** The low-level Unix.fork(), Unix.exec*() functions and friends are not safe to
     call in multithreaded programs for two reasons:
     + parallel threads opening new file descriptors will have these descriptors captured
       by a fork(). This leads to annoying glitches like (for example) attempts to 'umount'
@@ -25,7 +25,7 @@
 
     Additionally Unix.fork(), Unix.exec*() are very low-level primitives. When we call
     these functions what we actually want to do is run some separate process with certain
-    file-descriptors, optionally returning results. 
+    file-descriptors, optionally returning results.
 
     	The interface in this module
     + is higher-level than Unix.fork(), Unix.exec*()
@@ -49,7 +49,7 @@ val execute_command_get_output :
   -> string list
   -> string * string
 (** [execute_command_get_output cmd args] runs [cmd args] and returns (stdout, stderr)
-    	on success (exit 0). On failure this raises 
+    	on success (exit 0). On failure this raises
     [Spawn_internal_error(stderr, stdout, Unix.process_status)] *)
 
 val execute_command_get_output_send_stdin :
@@ -61,7 +61,7 @@ val execute_command_get_output_send_stdin :
   -> string
   -> string * string
 (** [execute_command_get_output cmd args stdin] runs [cmd args], passes in the string [stdin] and returns (stdout, stderr)
-    	on success (exit 0). On failure this raises 
+    	on success (exit 0). On failure this raises
     [Spawn_internal_error(stderr, stdout, Unix.process_status)] *)
 
 (** Thrown by [execute_command_get_output] if the subprocess exits with a non-zero exit code *)
@@ -115,8 +115,8 @@ val dontwaitpid : pidty -> unit
     	process will not persist as a zombie. *)
 
 val waitpid_fail_if_bad_exit : pidty -> unit
-(** [waitpid_fail_if_bad_exit p] calls waitpid on [p] and throws [Subprocess_failed x] if the 
-    	process exits with non-zero code x and [Subprocess_killed x] if the process is killed by a 
+(** [waitpid_fail_if_bad_exit p] calls waitpid on [p] and throws [Subprocess_failed x] if the
+    	process exits with non-zero code x and [Subprocess_killed x] if the process is killed by a
     	signal and exits with non-zero code x. *)
 
 (** Result returned by {!with_logfile_fd}. *)

--- a/ocaml/forkexecd/test/fe_test.sh
+++ b/ocaml/forkexecd/test/fe_test.sh
@@ -13,7 +13,7 @@ cleanup () {
     kill $MAIN
 }
 trap cleanup EXIT
-for _ in $(seq 1 10); do
-    test -S ${SOCKET} || sleep 1
+for _ in $(seq 1 100); do
+    test -S ${SOCKET} || sleep 0.1
 done
 echo "" | ./fe_test.exe 16

--- a/ocaml/quicktest/dune
+++ b/ocaml/quicktest/dune
@@ -40,3 +40,9 @@
  (alias runtest)
  (action (run ./quicktest.exe -skip-xapi -- list))
 )
+
+(rule
+ (alias runtest-systemd-user)
+ (deps ./quicktest.exe ../forkexecd/src/fe_main.exe)
+ (action (run ./systemd_user_test.sh))
+)

--- a/ocaml/quicktest/dune
+++ b/ocaml/quicktest/dune
@@ -35,3 +35,8 @@
   (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
 
+
+(rule
+ (alias runtest)
+ (action (run ./quicktest.exe -skip-xapi -- list))
+)

--- a/ocaml/quicktest/qt.ml
+++ b/ocaml/quicktest/qt.ml
@@ -58,7 +58,11 @@ let inventory_lookup k =
   Xapi_inventory.inventory_filename := "/etc/xensource-inventory" ;
   Xapi_inventory.lookup k
 
-let localhost_uuid = inventory_lookup Xapi_inventory._installation_uuid
+let localhost_uuid =
+  if Unix.geteuid () = 0 then
+    inventory_lookup Xapi_inventory._installation_uuid
+  else
+    Uuidm.nil |> Uuidm.to_string
 
 module Test = struct
   let assert_raises_match exception_match fn =

--- a/ocaml/quicktest/qt_filter.ml
+++ b/ocaml/quicktest/qt_filter.ml
@@ -58,10 +58,20 @@ let cleanup () =
   Client.Client.Session.logout ~rpc:!A.rpc ~session_id:!session_id
 
 let wrap f =
-  init () ;
-  Xapi_stdext_pervasives.Pervasiveext.finally
-    (fun () -> f () ; finish ())
-    cleanup
+  if !Quicktest_args.skip_xapi then
+    f ()
+  else (
+    init () ;
+    Xapi_stdext_pervasives.Pervasiveext.finally
+      (fun () -> f () ; finish ())
+      cleanup
+  )
+
+let with_xapi_query f =
+  if !Quicktest_args.skip_xapi then
+    []
+  else
+    f ()
 
 let conn tcs =
   for_each
@@ -283,7 +293,7 @@ module SR = struct
     let test = test sr_info in
     (name, speed, test)
 
-  let list_srs srs = srs ()
+  let list_srs srs = with_xapi_query srs
 
   let f srs tcs =
     for_each
@@ -295,6 +305,7 @@ let sr = SR.f
 
 let vm_template template_name =
   for_each (fun (name, speed, test) ->
+      with_xapi_query @@ fun () ->
       match Qt.VM.Template.find !A.rpc !session_id template_name with
       | None ->
           []

--- a/ocaml/quicktest/qt_filter.mli
+++ b/ocaml/quicktest/qt_filter.mli
@@ -20,6 +20,10 @@
 val wrap : (unit -> unit) -> unit
 (** This has to wrap the quicktest run *)
 
+val with_xapi_query : (unit -> 'a list) -> 'a list
+(** [with_xapi_query get_list] calls [get_list ()] unless [-skip-xapi] CLI
+    argument was used. *)
+
 (** A slightly different definition of Alcotest.test_case, to ensure we can
     reason about the entire type of the test function *)
 type 'a test_case = string * Alcotest.speed_level * 'a

--- a/ocaml/quicktest/quicktest.ml
+++ b/ocaml/quicktest/quicktest.ml
@@ -20,6 +20,7 @@ let () =
       let suite =
         [
           ("Quicktest_example", Quicktest_example.tests ())
+        ; ("Quicktest_fe_systemctl", Quicktest_fe_systemctl.tests ())
         ; ("cbt", Quicktest_cbt.tests ())
         ; ("event", Quicktest_event.tests ())
         ; ("import_raw_vdi", Quicktest_import_raw_vdi.tests ())

--- a/ocaml/quicktest/quicktest_args.ml
+++ b/ocaml/quicktest/quicktest_args.ml
@@ -33,6 +33,12 @@ let rpc_unix_domain xml =
 
 let rpc = ref rpc_unix_domain
 
+let alcotest_args = ref [||]
+
+let set_alcotest_args l = alcotest_args := Array.of_list l
+
+let skip_xapi = ref false
+
 (** Parse the legacy quicktest command line args. This is used instead of
     invoking Alcotest directly, for backwards-compatibility with clients who
     run the quicktest binary. *)
@@ -48,6 +54,8 @@ let parse () =
       , "Only run SR tests on the pool's default SR"
       )
     ; ("-nocolour", Arg.Clear use_colour, "Don't use colour in the output")
+    ; ("-skip-xapi", Arg.Set skip_xapi, "SKIP tests that require XAPI")
+    ; ("--", Arg.Rest_all set_alcotest_args, "Supply alcotest arguments")
     ]
     (fun x ->
       match (!host, !username, !password) with
@@ -72,4 +80,4 @@ let parse () =
 let get_alcotest_args () =
   let name = [|Sys.argv.(0)|] in
   let colour = if not !use_colour then [|"--color=never"|] else [||] in
-  Array.concat [name; colour]
+  Array.concat [name; colour; !alcotest_args]

--- a/ocaml/quicktest/quicktest_fe_systemctl.ml
+++ b/ocaml/quicktest/quicktest_fe_systemctl.ml
@@ -1,0 +1,88 @@
+(*
+ * Copyright (C) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+let home = Sys.getenv_opt "HOME" |> Option.value ~default:"/root"
+
+let dest = home ^ "/.config/systemd/user/xapi-envtest@.service"
+
+let get_temp_file prefix suffix =
+  (* /tmp visible to systemd may not match /tmp visible to test
+     when running tests inside containers.
+     Use a path in the current dir instead for testing.
+  *)
+  let name = Filename.temp_file ~temp_dir:(Sys.getcwd ()) prefix suffix in
+  at_exit (fun () -> Xapi_stdext_unix.Unixext.unlink_safe name) ;
+  name
+
+let envout = get_temp_file "envout" "txt"
+
+let unit =
+  Printf.sprintf
+    {|
+  [Unit]
+  Description=env test
+
+  [Service]
+  Type=simple
+  ExecStart=/usr/bin/env
+  StandardOutput=file:%s
+|}
+    envout
+
+let init () =
+  Fe_systemctl.set_test () ;
+  let parent = Filename.dirname dest in
+  Xapi_stdext_unix.Unixext.mkdir_rec parent 0o700 ;
+  Xapi_stdext_unix.Unixext.write_string_to_file dest unit ;
+  at_exit @@ fun () -> Xapi_stdext_unix.Unixext.unlink_safe dest
+
+module StringMap = Map.Make (String)
+
+let printable =
+  Array.init 127 Char.chr
+  |> Array.to_seq
+  |> Seq.filter Astring.Char.Ascii.is_print
+  |> String.of_seq
+
+let test_systemctl () =
+  init () ;
+  let instance = Unix.gettimeofday () |> string_of_float in
+  let service = "xapi-envtest@" ^ instance in
+  let prefix = "XAPI_QUICKTEST" in
+  let env =
+    [
+      (prefix ^ "FOO", "bar")
+    ; (prefix ^ "FOO2", "bar2")
+    ; (prefix ^ "PRINTABLE", printable)
+    ]
+    |> List.to_seq
+    |> StringMap.of_seq
+  in
+  Fe_systemctl.set_properties ~env ~service () ;
+  Fe_systemctl.start_templated ~template:"xapi-envtest" ~instance ;
+  let (_ : Fe_systemctl.status) = Fe_systemctl.stop ~service in
+  let actual_envs =
+    envout
+    |> Xapi_stdext_unix.Unixext.string_of_file
+    |> String.split_on_char '\n'
+    |> List.filter_map (Astring.String.cut ~sep:"=")
+    |> List.filter (fun (k, _) -> String.starts_with ~prefix k)
+  in
+  if actual_envs = [] then
+    Alcotest.failf "Environment cannot be empty" ;
+  let cmp (k1, _) (k2, _) = String.compare k1 k2 in
+  Alcotest.(check @@ slist (pair string string) cmp)
+    "environment should match" (StringMap.bindings env) actual_envs
+
+let tests () = [("systemctl", `Quick, test_systemctl)]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -5804,13 +5804,6 @@ let export_common fd _printer rpc session_id params filename num ?task_uuid
   in
   let vm_metadata_only = get_bool_param params "metadata" in
   let vm_record = vm.record () in
-  (* disallow exports and cross-pool migrations of VMs with VTPMs *)
-  ( if vm_record.API.vM_VTPMs <> [] then
-      let message = "Exporting VM metadata with VTPMs attached" in
-      (* Helpers.maybe_raise_vtpm_unimplemented cannot be used due to the
-         xapi_globs dependence *)
-      raise Api_errors.(Server_error (not_implemented, [message]))
-  ) ;
   let exporttask, task_destroy_fn =
     match task_uuid with
     | None ->

--- a/ocaml/xapi/export.ml
+++ b/ocaml/xapi/export.ml
@@ -117,6 +117,10 @@ let rec update_table ~__context ~include_snapshots ~preserve_power_state
              add proxy.API.pVS_proxy_site
            )
        ) ;
+    (* add VTPMs that belong to this VM *)
+    vm.API.vM_VTPMs
+    |> List.iter (fun ref -> if Db.is_valid_ref __context ref then add ref) ;
+
     (* If we need to include snapshots, update the table for VMs in the 'snapshots' field *)
     if include_snapshots then
       List.iter
@@ -211,11 +215,6 @@ let make_vm ?(with_snapshot_metadata = false) ~preserve_power_state table
     __context self =
   let vm = Db.VM.get_record ~__context ~self in
   let vM_VTPMs = filter table (List.map Ref.string_of vm.API.vM_VTPMs) in
-  (* disallow exports and cross-pool migrations of VMs with VTPMs *)
-  ( if vM_VTPMs <> [] then
-      let message = "Exporting VM metadata with VTPMs attached" in
-      Helpers.maybe_raise_vtpm_unimplemented __FUNCTION__ message
-  ) ;
   let vm =
     {
       vm with
@@ -467,6 +466,28 @@ let make_pvs_sites table __context self =
   ; snapshot= API.rpc_of_pVS_site_t site
   }
 
+let make_vtpm table __context self =
+  debug "exporting vtpm %s" (Ref.string_of self) ;
+  let lookup' ref = lookup table (Ref.string_of ref) in
+  let vtpm = Db.VTPM.get_record ~__context ~self in
+  let secret = Xapi_vtpm.get_contents ~__context ~self in
+  (* we are using a hand-crafted record that we serialise. The default
+     API type does not include the value of the VTPM *)
+  let vtpm' =
+    {
+      vTPM'_VM= lookup' vtpm.vTPM_VM
+    ; vTPM'_uuid= vtpm.vTPM_uuid
+    ; vTPM'_is_unique= vtpm.vTPM_is_unique
+    ; vTPM'_is_protected= vtpm.vTPM_is_protected
+    ; vTPM'_content= secret
+    }
+  in
+  {
+    cls= Datamodel_common._vtpm
+  ; id= Ref.string_of (lookup' self)
+  ; snapshot= rpc_of_vtpm' vtpm'
+  }
+
 let make_all ~with_snapshot_metadata ~preserve_power_state table __context =
   let filter table rs =
     List.filter (fun x -> lookup table (Ref.string_of x) <> Ref.null) rs
@@ -532,6 +553,11 @@ let make_all ~with_snapshot_metadata ~preserve_power_state table __context =
       (make_pvs_sites table __context)
       (filter table (Db.PVS_site.get_all ~__context))
   in
+  let vtpms =
+    List.map
+      (make_vtpm table __context)
+      (filter table (Db.VTPM.get_all ~__context))
+  in
   List.concat
     [
       hosts
@@ -547,6 +573,7 @@ let make_all ~with_snapshot_metadata ~preserve_power_state table __context =
     ; gpu_groups
     ; pvs_proxies
     ; pvs_sites
+    ; vtpms
     ]
 
 (* on normal export, do not include snapshot metadata;

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -46,6 +46,20 @@ let rpc_of_version x =
     ; (_export_vsn, Rpc.Int (Int64.of_int Xapi_globs.export_vsn))
     ]
 
+(* manually define a type for VTPM that includes its content. We
+   deliberately only capture the essence to facilitate moving to a
+   different backend at a later point rather than preserving the entire
+   structure. *)
+
+type vtpm' = {
+    vTPM'_VM: API.ref_VM
+  ; vTPM'_uuid: string
+  ; vTPM'_is_unique: bool
+  ; vTPM'_is_protected: bool
+  ; vTPM'_content: string
+}
+[@@deriving rpc]
+
 exception Failure of string
 
 let find kvpairs where x =

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -566,8 +566,8 @@ module SystemdDaemonMgmt (D : DAEMONPIDPATH) = struct
     debug "Starting daemon: %s with args [%s]" path (String.concat "; " args) ;
     let service = Compat.syslog_key ~domid in
     let properties =
-      let remove_key path = ("ExecStopPost", "-/usr/bin/xenstore-rm " ^ path) in
-      let remove_file path = ("ExecStopPost", "-/bin/rm -f " ^ path) in
+      let remove_key path = ("ExecStopPost", ["-/usr/bin/xenstore-rm"; path]) in
+      let remove_file path = ("ExecStopPost", ["-/bin/rm"; "-f"; path]) in
       match D.pid_location with
       | Xenstore get_path ->
           let key_path = get_path domid in

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -58,7 +58,7 @@ structural-equality () {
 }
 
 vtpm-unimplemented () {
-  N=8
+  N=6
   VTPM=$(git grep -r --count 'maybe_raise_vtpm_unimplemented' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$VTPM" -eq "$N" ]; then
     echo "OK found $VTPM usages of vtpm unimplemented errors"
@@ -68,8 +68,24 @@ vtpm-unimplemented () {
   fi
 }
 
+vtpm-fields () {
+  A=$(git grep -hc "vTPM'_.*:" ocaml/xapi/importexport.ml)
+  B=$(git grep -hc '; field' ocaml/idl/datamodel_vtpm.ml)
+  case "$A/$B" in
+    5/6)
+      echo "OK found $A/$B VTPM fields in importexport.ml datamodel_vtpm.ml"
+      ;;
+    *)
+      echo "ERROR have VTPM fields changed? Check importexport.ml" 1>&2
+      exit 1
+      ;;
+  esac
+}
+
 list-hd
 verify-cert
 mli-files
 structural-equality
 vtpm-unimplemented
+vtpm-fields
+


### PR DESCRIPTION
This is in preparation of running etcd as a (templated/transient) systemd service.

The test here launches 'env' through fe_systemctl and sets an environment variable containing all printable characters as values to check that quoting is done properly.
In particular systemd's quoting doesn't match either `Filename.quote` or `String.escaped` and needs a hand-written escaper. The syntax is [documented here](https://www.freedesktop.org/software/systemd/man/systemd.syntax.html#Quoting), notice how Filename.quote would produce the wrong results when escaping the single quote character (`'\''`) and String.escaped would not quote it at all.
Quote single and double quotes using hex escape sequences (this makes it independent to the kind of quote used to wrap items).

The test is not suitable for a unit test because it depends on external tools (systemd), which may not be available in all build environments (in particular won't be available in the RPM build environment, not even in --user mode).
Quicktests are tests that run in Dom0, so it is a suitable place to run this test automatically without having to add a lot of extra machinery to run the test.

However it is still useful to run this test in a development environment (provided you have 'systemctl --user' working there, which most Linux distros or containers would), so add some flags to quicktest to be able to run without XAPI, which can be used like this:
`dune exec ./quicktest.exe -- -skip-xapi`.
When the argument is passed the XAPI session is not initialized and any queries to XAPI to list VMs/SRs will return the empty list (thus these tests won't run at all). Reading the XAPI inventory for localhost UUID is also skipped when UID is not  
 root (0), otherwise you'd get a permission denied error trying to create it.

If you want to pass additional arguments to alcotest (e.g. to 'list' or run just  a particular test with 'test')  then you can now do:
`dune exec ./quicktest.exe -- -skip-xapi -- list` (the first '--' is interpreted by 'dune' itself to pass through the arguments to the underlying command without trying to interpret them as dune arguments, and the second '--' is parsed by the new code in quicktest).

Also adds a start_templated convenience wrapper that starts a templated 'foo@instance' parametrized systemd template and a 'set_properties' that can be used to override certain settings via systemd drop-in (e.g. Environment variables).
We do not use 'systemctl set-property' because that only supports setting runtime changeable properties (mostly cgroup) properties, and not settings that require a service restart like Environment.
Although we could use entirely transient systemd services to always set the environment, it might be useful to be able to use a templated systemd service with the environment customized per instance, so that the customization survives a reboot and the service is started up even if XAPI would have difficulty starting on next boot (this will be useful to keep the quorum alive with services like 'etcd').

PR to feature branch, since this is likely to evolve as part of its use in etcd and the quicktest changes still need testing in XenRT.