### PR TITLE
CP-42013: Do not apply recommended guidances automatically

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1943,6 +1943,8 @@ let _ =
     ~doc:"The repository proxy username/password is invalid." () ;
   error Api_errors.apply_livepatch_failed ["livepatch"]
     ~doc:"Failed to apply a livepatch." () ;
+  error Api_errors.updates_require_recommended_guidance ["recommended_guidance"]
+    ~doc:"Requires recommended guidance after applying updates." () ;
   error Api_errors.update_guidance_changed ["guidance"]
     ~doc:"Guidance for the update has changed" () ;
 

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1711,7 +1711,10 @@ let apply_updates =
         )
       ]
     ~result:
-      (Set (Set String), "The list of warnings happened in applying updates")
+      ( Set (Set String)
+      , "The list of results after applying updates, including livepatch apply \
+         failures and recommended guidances"
+      )
     ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)
     ()
 
@@ -1741,6 +1744,21 @@ let set_https_only =
         , "value"
         , "true - http port 80 will be blocked, false - http port 80 will be \
            open"
+        )
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
+let apply_recommended_guidances =
+  call ~name:"apply_recommended_guidances"
+    ~doc:
+      "apply all recommended guidances both on the host and on all HVM VMs on \
+       the host after updates are applied on the host"
+    ~lifecycle:[]
+    ~params:
+      [
+        ( Ref _host
+        , "self"
+        , "The host whose recommended guidances will be applied"
         )
       ]
     ~allowed_roles:_R_POOL_OP ()
@@ -1879,6 +1897,7 @@ let t =
       ; apply_updates
       ; copy_primary_host_certs
       ; set_https_only
+      ; apply_recommended_guidances
       ]
     ~contents:
       ([
@@ -2099,6 +2118,9 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
             ~default_value:(Some (VBool false)) "https_only"
             "Reflects whether port 80 is open (false) or not (true)"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
+            "recommended_guidances" ~default_value:(Some (VSet []))
+            "The set of recommended guidances after applying updates"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -15,14 +15,10 @@ let prototyped_of_field = function
       Some "22.26.0"
   | "VTPM", "persistence_backend" ->
       Some "22.26.0"
-  | "host", "recommended_guidances" ->
-      Some "23.3.0-next"
   | "host", "https_only" ->
       Some "22.27.0"
   | "host", "last_software_update" ->
       Some "22.20.0"
-  | "VM", "recommended_guidances" ->
-      Some "23.3.0-next"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
   | "pool", "last_update_sync" ->
@@ -49,8 +45,6 @@ let prototyped_of_message = function
       Some "22.26.0"
   | "VTPM", "create" ->
       Some "22.26.0"
-  | "host", "apply_recommended_guidances" ->
-      Some "23.3.0-next"
   | "host", "set_https_only" ->
       Some "22.27.0"
   | "pool", "set_https_only" ->

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -15,10 +15,14 @@ let prototyped_of_field = function
       Some "22.26.0"
   | "VTPM", "persistence_backend" ->
       Some "22.26.0"
+  | "host", "recommended_guidances" ->
+      Some "23.3.0-next"
   | "host", "https_only" ->
       Some "22.27.0"
   | "host", "last_software_update" ->
       Some "22.20.0"
+  | "VM", "recommended_guidances" ->
+      Some "23.3.0-next"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
   | "pool", "last_update_sync" ->
@@ -45,6 +49,8 @@ let prototyped_of_message = function
       Some "22.26.0"
   | "VTPM", "create" ->
       Some "22.26.0"
+  | "host", "apply_recommended_guidances" ->
+      Some "23.3.0-next"
   | "host", "set_https_only" ->
       Some "22.27.0"
   | "pool", "set_https_only" ->

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2141,6 +2141,9 @@ let t =
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
             "The set of pending guidances after applying updates"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
+            "recommended_guidances" ~default_value:(Some (VSet []))
+            "The set of recommended guidances after applying updates"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "d170625a90c4a15e0d2035b79143dfb5"
+let last_known_schema_hash = "fe154f2e33876f2ca8e7879d245d5494"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -207,7 +207,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled
-    ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref) ;
+    ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
+    ~recommended_guidances:[] ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1027,6 +1027,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Host_selectors]
       }
     )
+  ; ( "host-apply-recommended-guidances"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Apply recommended guidances on a host."
+      ; implementation= No_fd Cli_operations.host_apply_recommended_guidances
+      ; flags= [Host_selectors]
+      }
+    )
   ; ( "patch-upload"
     , {
         reqd= ["file-name"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7638,6 +7638,16 @@ let host_apply_updates _printer rpc session_id params =
        params ["hash"]
     )
 
+let host_apply_recommended_guidances _printer rpc session_id params =
+  ignore
+    (do_host_op rpc session_id ~multiple:false
+       (fun _ host ->
+         let host = host.getref () in
+         Client.Host.apply_recommended_guidances ~rpc ~session_id ~self:host
+       )
+       params []
+    )
+
 module SDN_controller = struct
   let introduce printer rpc session_id params =
     let port =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2565,6 +2565,12 @@ let vm_record rpc session_id vm =
       ; make_field ~name:"vtpms"
           ~get:(fun () -> get_uuids_from_refs (x ()).API.vM_VTPMs)
           ()
+      ; make_field ~name:"recommended-guidances"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.vM_recommended_guidances
+          )
+          ()
       ]
   }
 
@@ -3202,6 +3208,12 @@ let host_record rpc session_id host =
           ()
       ; make_field ~name:"last-software-update"
           ~get:(fun () -> Date.to_string (x ()).API.host_last_software_update)
+          ()
+      ; make_field ~name:"recommended-guidances"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.host_recommended_guidances
+          )
           ()
       ]
   }

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1280,6 +1280,9 @@ let dynamic_memory_control_unavailable = "DYNAMIC_MEMORY_CONTROL_UNAVAILABLE"
 
 let apply_livepatch_failed = "APPLY_LIVEPATCH_FAILED"
 
+let updates_require_recommended_guidance =
+  "UPDATES_REQUIRE_RECOMMENDED_GUIDANCE"
+
 let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"
 
 (* VTPMs *)

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -321,7 +321,7 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info : host_info
     ~version:0L ~generation_id:"" ~hardware_platform_version:0L
     ~has_vendor_device:false ~requires_reboot:false ~reference_label:""
     ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[]
-    ~pending_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[] ;
   ensure_domain_zero_metrics_record ~__context ~domain_zero_ref host_info ;
   Db.Host.set_control_domain ~__context ~self:localhost ~value:domain_zero_ref ;
   Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3977,6 +3977,14 @@ functor
         do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
             Client.Host.set_https_only ~rpc ~session_id ~self ~value
         )
+
+      let apply_recommended_guidances ~__context ~self =
+        let uuid = host_uuid ~__context self in
+        info "Host.apply_recommended_guidance: host = %s" uuid ;
+        let local_fn = Local.Host.apply_recommended_guidances ~self in
+        do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
+            Client.Host.apply_recommended_guidances ~rpc ~session_id ~self
+        )
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -732,7 +732,7 @@ let set_pending_guidances ~__context ~host ~guidances =
        | RestartDeviceModel ->
            set_pending_restart_device_models ~__context ~host
        | g ->
-           warn "Unsupported pending guidance %s, ignore it."
+           warn "Unsupported pending guidance %s, ignoring it."
              (Guidance.to_string g)
        )
 
@@ -749,7 +749,7 @@ let set_recommended_guidances ~__context ~host ~guidances =
        | RestartDeviceModel ->
            set_recommended_restart_device_models ~__context ~host
        | g ->
-           warn "Unsupported recommended guidance %s, ignore it."
+           warn "Unsupported recommended guidance %s, ignoring it."
              (Guidance.to_string g)
        )
 

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -688,23 +688,9 @@ let apply_livepatch ~__context ~host:_ ~component ~base_build_id ~base_version
       error "%s" msg ;
       raise Api_errors.(Server_error (internal_error, [msg]))
 
-let do_with_device_models ~__context ~host ~action_label:_ f =
-  (* Call f with device models of all running HVM VMs on the host *)
-  Db.Host.get_resident_VMs ~__context ~self:host
-  |> List.map (fun self -> (self, Db.VM.get_record ~__context ~self))
-  |> List.filter (fun (_, record) -> not record.API.vM_is_control_domain)
-  |> List.filter_map f
-  |> function
-  | [] ->
-      ()
-  | _ :: _ ->
-      let host' = Ref.string_of host in
-      raise Api_errors.(Server_error (cannot_restart_device_model, [host']))
-
 let set_pending_restart_device_models ~__context ~host =
   (* Set pending restart device models of all running HVM VMs on the host *)
-  do_with_device_models ~__context ~host ~action_label:"set pending restart"
-  @@ fun (ref, record) ->
+  do_with_device_models ~__context ~host @@ fun (ref, record) ->
   match
     (record.API.vM_power_state, Helpers.has_qemu_currently ~__context ~self:ref)
   with
@@ -716,69 +702,19 @@ let set_pending_restart_device_models ~__context ~host =
       (* No device models are running for this VM *)
       None
 
-let restart_device_models ~__context ~host =
-  (* Restart device models of all running HVM VMs on the host by doing
-   * local migrations. *)
-  do_with_device_models ~__context ~host ~action_label:"restart"
-  @@ fun (ref, record) ->
+let set_recommended_restart_device_models ~__context ~host =
+  (* Set recommended restart device models of all running HVM VMs on the host *)
+  do_with_device_models ~__context ~host @@ fun (ref, record) ->
   match
     (record.API.vM_power_state, Helpers.has_qemu_currently ~__context ~self:ref)
   with
-  | `Running, true ->
-      Helpers.call_api_functions ~__context (fun rpc session_id ->
-          Client.Client.VM.pool_migrate ~rpc ~session_id ~vm:ref ~host
-            ~options:[("live", "true")]
-      ) ;
+  | `Running, true | `Paused, true ->
+      Db.VM.add_recommended_guidances ~__context ~self:ref
+        ~value:`restart_device_model ;
       None
-  | `Paused, true ->
-      error "VM 'ref=%s' is paused, can't restart device models for it"
-        (Ref.string_of ref) ;
-      Some ref
   | _ ->
       (* No device models are running for this VM *)
       None
-
-let apply_immediate_guidances ~__context ~host ~guidances =
-  (* This function runs on coordinator host *)
-  try
-    let open Client in
-    Helpers.call_api_functions ~__context (fun rpc session_id ->
-        let open Guidance in
-        match guidances with
-        | [] ->
-            ()
-        | [RebootHost] ->
-            Client.Host.reboot ~rpc ~session_id ~host
-        | [EvacuateHost] ->
-            (* EvacuatHost should be done before applying updates by XAPI users.
-             * Here only the guidances to be applied after applying updates are handled.
-             *)
-            ()
-        | [RestartDeviceModel] ->
-            restart_device_models ~__context ~host
-        | [RestartToolstack] ->
-            Client.Host.restart_agent ~rpc ~session_id ~host
-        | l when GuidanceSet.eq_set1 l ->
-            (* EvacuateHost and RestartToolstack *)
-            Client.Host.restart_agent ~rpc ~session_id ~host
-        | l when GuidanceSet.eq_set2 l ->
-            (* RestartDeviceModel and RestartToolstack *)
-            restart_device_models ~__context ~host ;
-            Client.Host.restart_agent ~rpc ~session_id ~host
-        | l ->
-            let host' = Ref.string_of host in
-            error
-              "Found wrong guidance(s) after applying updates on host \
-               ref='%s': %s"
-              host'
-              (String.concat ";" (List.map Guidance.to_string l)) ;
-            raise Api_errors.(Server_error (apply_guidance_failed, [host']))
-    )
-  with e ->
-    let host' = Ref.string_of host in
-    error "applying immediate guidances on host ref='%s' failed: %s" host'
-      (ExnHelper.string_of_exn e) ;
-    raise Api_errors.(Server_error (apply_guidance_failed, [host']))
 
 let set_pending_guidances ~__context ~host ~guidances =
   let open Guidance in
@@ -797,6 +733,23 @@ let set_pending_guidances ~__context ~host ~guidances =
            set_pending_restart_device_models ~__context ~host
        | g ->
            warn "Unsupported pending guidance %s, ignore it."
+             (Guidance.to_string g)
+       )
+
+let set_recommended_guidances ~__context ~host ~guidances =
+  let open Guidance in
+  guidances
+  |> List.iter (function
+       | RebootHost ->
+           Db.Host.add_recommended_guidances ~__context ~self:host
+             ~value:`reboot_host
+       | RestartToolstack ->
+           Db.Host.add_recommended_guidances ~__context ~self:host
+             ~value:`restart_toolstack
+       | RestartDeviceModel ->
+           set_recommended_restart_device_models ~__context ~host
+       | g ->
+           warn "Unsupported recommended guidance %s, ignore it."
              (Guidance.to_string g)
        )
 
@@ -834,7 +787,7 @@ let apply_livepatches' ~__context ~host ~livepatches =
 let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
     =
   (* This function runs on coordinator host *)
-  let expected_immediate_guidances =
+  let expected_recommended_guidances =
     eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
       ~livepatches ~failed_livepatches:[]
   in
@@ -861,15 +814,15 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
         )
       ]
       ) ;
-  (* Evaluate immediate/pending guidances *)
-  let immediate_guidances, pending_guidances =
-    let immediate_guidances' =
+  (* Evaluate recommended/pending guidances *)
+  let recommended_guidances, pending_guidances =
+    let recommended_guidances' =
       eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
         ~livepatches:successful_livepatches ~failed_livepatches
     in
     let pending_guidances' =
       List.filter
-        (fun g -> not (List.mem g immediate_guidances'))
+        (fun g -> not (List.mem g recommended_guidances'))
         (eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Absolute
            ~livepatches:[] ~failed_livepatches:[]
         )
@@ -879,7 +832,7 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
         (* No livepatch should be applicable now *)
         Db.Host.remove_pending_guidances ~__context ~self:host
           ~value:`reboot_host_on_livepatch_failure ;
-        (immediate_guidances', pending_guidances')
+        (recommended_guidances', pending_guidances')
     | _ :: _ ->
         (* There is(are) livepatch failure(s):
          * the host should not be rebooted, and
@@ -887,17 +840,18 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
          *)
         ( List.filter
             (fun g -> not (g = Guidance.RebootHost))
-            immediate_guidances'
+            recommended_guidances'
         , Guidance.RebootHostOnLivePatchFailure :: pending_guidances'
         )
   in
   List.iter
-    (fun g -> debug "immediate_guidance: %s" (Guidance.to_string g))
-    immediate_guidances ;
+    (fun g -> debug "recommended_guidance: %s" (Guidance.to_string g))
+    recommended_guidances ;
   List.iter
     (fun g -> debug "pending_guidance: %s" (Guidance.to_string g))
     pending_guidances ;
-  GuidanceSet.assert_valid_guidances immediate_guidances ;
+  GuidanceSet.assert_valid_guidances recommended_guidances ;
+  set_recommended_guidances ~__context ~host ~guidances:recommended_guidances ;
   set_pending_guidances ~__context ~host ~guidances:pending_guidances ;
   let warnings =
     List.map
@@ -908,17 +862,19 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
   in
   match
     GuidanceSet.equal
-      (GuidanceSet.of_list expected_immediate_guidances)
-      (GuidanceSet.of_list immediate_guidances)
+      (GuidanceSet.of_list expected_recommended_guidances)
+      (GuidanceSet.of_list recommended_guidances)
   with
   | true ->
-      (immediate_guidances, warnings)
+      (recommended_guidances, warnings)
   | false ->
-      let return_of_immediate_guidances =
-        immediate_guidances |> List.map Guidance.to_string |> String.concat ";"
+      let return_of_recommended_guidances =
+        recommended_guidances
+        |> List.map Guidance.to_string
+        |> String.concat ";"
         |> fun s -> [Api_errors.update_guidance_changed; s]
       in
-      (immediate_guidances, return_of_immediate_guidances :: warnings)
+      (recommended_guidances, return_of_recommended_guidances :: warnings)
 
 let apply_updates ~__context ~host ~hash =
   (* This function runs on coordinator host *)

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -68,12 +68,6 @@ val apply_updates :
   -> hash:string
   -> Updateinfo.Guidance.t list * string list list
 
-val apply_immediate_guidances :
-     __context:Context.t
-  -> host:[`host] API.Ref.t
-  -> guidances:Updateinfo.Guidance.t list
-  -> unit
-
 val set_available_updates : __context:Context.t -> string
 
 val reset_updates_in_cache : unit -> unit

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -1077,17 +1077,9 @@ let prune_updateinfo_for_livepatches livepatches updateinfo =
   in
   {updateinfo with livepatches= lps}
 
-let do_with_device_models ~__context
-    ?(only_vm_with_recommended_guidances = false) ~host f =
+let do_with_device_models ~__context ~host f =
   (* Call f with device models of all running HVM VMs on the host *)
   Db.Host.get_resident_VMs ~__context ~self:host
-  |> List.filter (fun self ->
-         if only_vm_with_recommended_guidances then
-           List.mem `restart_device_model
-             (Db.VM.get_recommended_guidances ~__context ~self)
-         else
-           true
-     )
   |> List.map (fun self -> (self, Db.VM.get_record ~__context ~self))
   |> List.filter (fun (_, record) -> not record.API.vM_is_control_domain)
   |> List.filter_map f

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -1077,12 +1077,12 @@ let prune_updateinfo_for_livepatches livepatches updateinfo =
   in
   {updateinfo with livepatches= lps}
 
-let do_with_device_models ~__context ?(vm_with_recommended_guidances = false)
-    ~host f =
+let do_with_device_models ~__context
+    ?(only_vm_with_recommended_guidances = false) ~host f =
   (* Call f with device models of all running HVM VMs on the host *)
   Db.Host.get_resident_VMs ~__context ~self:host
   |> List.filter (fun self ->
-         if vm_with_recommended_guidances then
+         if only_vm_with_recommended_guidances then
            List.mem `restart_device_model
              (Db.VM.get_recommended_guidances ~__context ~self)
          else

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -1076,3 +1076,24 @@ let prune_updateinfo_for_livepatches livepatches updateinfo =
     List.filter (fun x -> LivePatchSet.mem x livepatches) updateinfo.livepatches
   in
   {updateinfo with livepatches= lps}
+
+let do_with_device_models ~__context ?(vm_with_recommended_guidances = false)
+    ~host f =
+  (* Call f with device models of all running HVM VMs on the host *)
+  Db.Host.get_resident_VMs ~__context ~self:host
+  |> List.filter (fun self ->
+         if vm_with_recommended_guidances then
+           List.mem `restart_device_model
+             (Db.VM.get_recommended_guidances ~__context ~self)
+         else
+           true
+     )
+  |> List.map (fun self -> (self, Db.VM.get_record ~__context ~self))
+  |> List.filter (fun (_, record) -> not record.API.vM_is_control_domain)
+  |> List.filter_map f
+  |> function
+  | [] ->
+      ()
+  | _ :: _ ->
+      let host' = Ref.string_of host in
+      raise Api_errors.(Server_error (cannot_restart_device_model, [host']))

--- a/ocaml/xapi/updateinfo.ml
+++ b/ocaml/xapi/updateinfo.ml
@@ -53,6 +53,16 @@ module Guidance = struct
     | _ ->
         error "Unknown node in <absolute|recommended_guidance>" ;
         raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+
+  let of_update_guidance = function
+    | `reboot_host ->
+        RebootHost
+    | `reboot_host_on_livepatch_failure ->
+        RebootHostOnLivePatchFailure
+    | `restart_toolstack ->
+        RestartToolstack
+    | `restart_device_model ->
+        RestartDeviceModel
 end
 
 module Applicability = struct

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -28,6 +28,13 @@ module Guidance : sig
   val to_string : t -> string
 
   val of_string : string -> t
+
+  val of_update_guidance :
+       [< `reboot_host
+       | `reboot_host_on_livepatch_failure
+       | `restart_device_model
+       | `restart_toolstack ]
+    -> t
 end
 
 (** The applicability of metadata for one update in updateinfo *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2970,20 +2970,7 @@ let apply_recommended_guidances ~__context ~self =
           host'
           (String.concat ";"
              (List.map Guidance.to_string
-                (List.map
-                   (fun ug ->
-                     match ug with
-                     | `reboot_host ->
-                         Guidance.RebootHost
-                     | `reboot_host_on_livepatch_failure ->
-                         Guidance.RebootHostOnLivePatchFailure
-                     | `restart_toolstack ->
-                         Guidance.RestartToolstack
-                     | `restart_device_model ->
-                         Guidance.RestartDeviceModel
-                   )
-                   l
-                )
+                (List.map Guidance.of_update_guidance l)
              )
           ) ;
         raise Api_errors.(Server_error (apply_guidance_failed, [host']))

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2928,7 +2928,7 @@ let restart_device_models_for_recommended_guidances ~__context ~host =
   (* Restart device models of all running HVM VMs on the host by doing
    * local migrations if it is required by recommended guidances. *)
   Repository_helpers.do_with_device_models ~__context ~host
-    ~vm_with_recommended_guidances:true
+    ~only_vm_with_recommended_guidances:true
   @@ fun (ref, record) ->
   match
     (record.API.vM_power_state, Helpers.has_qemu_currently ~__context ~self:ref)

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -546,3 +546,6 @@ val copy_primary_host_certs : __context:Context.t -> host:API.ref_host -> unit
 
 val set_https_only :
   __context:Context.t -> self:API.ref_host -> value:bool -> unit
+
+val apply_recommended_guidances :
+  __context:Context.t -> self:API.ref_host -> unit

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -374,11 +374,15 @@ let consider_enabling_host_nolock ~__context =
     let pool = Helpers.get_pool ~__context in
     Db.Host.remove_pending_guidances ~__context ~self:localhost
       ~value:`restart_toolstack ;
+    Db.Host.remove_recommended_guidances ~__context ~self:localhost
+      ~value:`restart_toolstack ;
     if !Xapi_globs.on_system_boot then (
       debug
         "Host.enabled: system has just restarted: setting localhost to enabled" ;
       Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
       Db.Host.remove_pending_guidances ~__context ~self:localhost
+        ~value:`reboot_host ;
+      Db.Host.remove_recommended_guidances ~__context ~self:localhost
         ~value:`reboot_host ;
       Db.Host.remove_pending_guidances ~__context ~self:localhost
         ~value:`reboot_host_on_livepatch_failure ;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -677,7 +677,7 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~is_vmss_snapshot:false ~appliance ~start_delay ~shutdown_delay ~order
     ~suspend_SR ~version ~generation_id ~hardware_platform_version
     ~has_vendor_device ~requires_reboot:false ~reference_label ~domain_type
-    ~pending_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[] ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -396,7 +396,7 @@ let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~has_vendor_device:all.Db_actions.vM_has_vendor_device
     ~requires_reboot:false ~reference_label:all.Db_actions.vM_reference_label
     ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM
-    ~pending_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[] ;
   (* update the VM's parent field in case of snapshot. Note this must be done after "ref"
      	   has been created, so that its "children" field can be updated by the database layer *)
   ( match disk_op with

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -3510,7 +3510,9 @@ let set_resident_on ~__context ~self =
   !trigger_xenapi_reregister () ;
   (* Any future XenAPI updates will trigger events, but we might have missed one so: *)
   Xenopsd_metadata.update ~__context ~self ;
-  Db.VM.remove_pending_guidances ~__context ~self ~value:`restart_device_model
+  Db.VM.remove_pending_guidances ~__context ~self ~value:`restart_device_model ;
+  Db.VM.remove_recommended_guidances ~__context ~self
+    ~value:`restart_device_model
 
 let update_debug_info __context t =
   let task = Context.get_task_id __context in


### PR DESCRIPTION
1. add a new field "recommended_guidances" in both host and vm datamodel
2. return "recommended_guidances" together with "warnings" as update applying results from host.apply_updates
3. add API host.apply_recommended_guidances
4. refactor "immediate_guidances" to "recommended_guidances"