### PR TITLE
xapi_vtpm: do not reuse name for get_contents

### DIFF
--- a/ocaml/xapi/xapi_vtpm.ml
+++ b/ocaml/xapi/xapi_vtpm.ml
@@ -53,7 +53,7 @@ let introduce ~__context ~vM ~persistence_backend ~contents ~is_unique =
   ref
 
 (** Contents from unique vtpms cannot be copied! *)
-let get_contents ~__context ?from () =
+let copy_or_create_contents ~__context ?from () =
   let create () = Xapi_secret.create ~__context ~value:"" ~other_config:[] in
   let copy ref =
     let contents = Db.VTPM.get_contents ~__context ~self:ref in
@@ -74,14 +74,14 @@ let create ~__context ~vM ~is_unique =
   assert_no_vtpm_associated ~__context vM ;
   Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self:vM
     ~expected:`Halted ;
-  let contents = get_contents ~__context () in
+  let contents = copy_or_create_contents ~__context () in
   introduce ~__context ~vM ~persistence_backend ~contents ~is_unique
 
 let copy ~__context ~vM ref =
   let vtpm = Db.VTPM.get_record ~__context ~self:ref in
   let persistence_backend = vtpm.vTPM_persistence_backend in
   let is_unique = vtpm.vTPM_is_unique in
-  let contents = get_contents ~__context ~from:ref () in
+  let contents = copy_or_create_contents ~__context ~from:ref () in
   introduce ~__context ~vM ~persistence_backend ~contents ~is_unique
 
 let destroy ~__context ~self =


### PR DESCRIPTION
The internal function that's more complex can have another name, rename so it's easier to see which one is being used and the intention behind it.