### PR TITLE
CP-42011: Config scheduled job to synchronize updates

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1947,6 +1947,10 @@ let _ =
     ~doc:"Requires recommended guidance after applying updates." () ;
   error Api_errors.update_guidance_changed ["guidance"]
     ~doc:"Guidance for the update has changed" () ;
+  error Api_errors.invalid_update_sync_day ["day"]
+    ~doc:"The day when update sync will run is invalid." () ;
+  error Api_errors.invalid_update_sync_hour ["hour"]
+    ~doc:"The hour when update sync will run is invalid." () ;
 
   error Api_errors.vtpm_max_amount_reached ["amount"]
     ~doc:"The VM cannot be associated with more VTPMs." () ;

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1046,16 +1046,16 @@ let configure_update_sync =
         (Ref _pool, "self", "The pool")
       ; ( update_sync_frequency
         , "update_sync_frequency"
-        , "of type Enum ('daily', 'weekly', 'monthly') to record the frequency \
-           of the scheduled update synchronization"
+        , "The frequency at which updates are synced from remote CDN: daily, \
+           weekly, or monthly."
         )
       ; ( Int
         , "update_sync_day"
-        , "which day of one period the update sychronization is scheduled"
+        , "Which day of one period the update sychronization is scheduled"
         )
       ; ( Int
         , "update_sync_hour"
-        , "which hour of day the update sychronization is scheduled"
+        , "Which hour of day the update sychronization is scheduled"
         )
       ]
     ~allowed_roles:_R_POOL_OP ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1024,6 +1024,42 @@ let set_uefi_certificates =
       ]
     ~allowed_roles:_R_POOL_ADMIN ()
 
+let update_sync_frequency =
+  Enum
+    ( "update_sync_frequency"
+    , [
+        ("daily", "Indicates the pool update synchronization is scheduled daily")
+      ; ( "weekly"
+        , "Indicates the pool update synchronization is scheduled weekly"
+        )
+      ; ( "monthly"
+        , "Indicates the pool update synchronization is scheduled monthly"
+        )
+      ]
+    )
+
+let configure_update_sync =
+  call ~name:"configure_update_sync"
+    ~doc:"config scheduled job to sync update from remote CDN" ~lifecycle:[]
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( update_sync_frequency
+        , "update_sync_frequency"
+        , "of type Enum ('daily', 'weekly', 'monthly') to record the frequency \
+           of the scheduled update synchronization"
+        )
+      ; ( Int
+        , "update_sync_day"
+        , "which day of one period the update sychronization is scheduled"
+        )
+      ; ( Int
+        , "update_sync_hour"
+        , "which hour of day the update sychronization is scheduled"
+        )
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
 (** A pool class *)
 let t =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:None
@@ -1106,6 +1142,7 @@ let t =
       ; disable_repository_proxy
       ; set_uefi_certificates
       ; set_https_only
+      ; configure_update_sync
       ]
     ~contents:
       ([uid ~in_oss_since:None _pool]
@@ -1334,6 +1371,18 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
             ~default_value:(Some (VDateTime Date.epoch)) "last_update_sync"
             "time of the last update sychronization"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:update_sync_frequency
+            ~default_value:(Some (VEnum "daily")) "update_sync_frequency"
+            "frequency of the scheduled update synchronization"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "update_sync_day"
+            ~default_value:(Some (VInt 1L))
+            "which day of one period the update sychronization is scheduled"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "update_sync_hour"
+            ~default_value:(Some (VInt 0L))
+            "which hour of day the update sychronization is scheduled"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
+            ~default_value:(Some (VBool false)) "update_sync_enabled"
+            "if scheduled update sychronization is enabled or not"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1040,7 +1040,7 @@ let update_sync_frequency =
 
 let configure_update_sync =
   call ~name:"configure_update_sync"
-    ~doc:"config scheduled job to sync update from remote CDN" ~lifecycle:[]
+    ~doc:"Config scheduled job to sync update from remote CDN" ~lifecycle:[]
     ~params:
       [
         (Ref _pool, "self", "The pool")
@@ -1051,11 +1051,15 @@ let configure_update_sync =
         )
       ; ( Int
         , "update_sync_day"
-        , "Which day of one period the update sychronization is scheduled"
+        , "Which day of one period the update sychronization is scheduled. For \
+           'daily' schedule, it should be 1. For 'weekly' schedule, -7..-1 and \
+           1..7, where 1 and -7 is Sunday. For 'monthly' schedule, -28..-1 and \
+           1..28, this ensure that the day exist in every month. For negative \
+           number, it means the day count down from the end of the period."
         )
       ; ( Int
         , "update_sync_hour"
-        , "Which hour of day the update sychronization is scheduled"
+        , "Which hour of day the update sychronization is scheduled, 0..23"
         )
       ]
     ~allowed_roles:_R_POOL_OP ()
@@ -1373,16 +1377,17 @@ let t =
             "time of the last update sychronization"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:update_sync_frequency
             ~default_value:(Some (VEnum "daily")) "update_sync_frequency"
-            "frequency of the scheduled update synchronization"
+            "The frequency at which updates are synced from remote CDN: daily, \
+             weekly, or monthly."
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "update_sync_day"
             ~default_value:(Some (VInt 1L))
-            "which day of one period the update sychronization is scheduled"
+            "Which day of one period the update sychronization is scheduled"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "update_sync_hour"
             ~default_value:(Some (VInt 0L))
-            "which hour of day the update sychronization is scheduled"
+            "Which hour of day the update sychronization is scheduled"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
             ~default_value:(Some (VBool false)) "update_sync_enabled"
-            "if scheduled update sychronization is enabled or not"
+            "If scheduled update sychronization is enabled or not"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "9ebc7e426e5e40455ef56edb38576c27"
+let last_known_schema_hash = "4c64949949d7f6fba87cbb9b9ac4ff40"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "fe154f2e33876f2ca8e7879d245d5494"
+let last_known_schema_hash = "9ebc7e426e5e40455ef56edb38576c27"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -289,7 +289,9 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(client_certificate_auth_name = "") ?(repository_proxy_url = "")
     ?(repository_proxy_username = "") ?(repository_proxy_password = Ref.null)
     ?(migration_compression = false) ?(coordinator_bias = true)
-    ?(last_update_sync = API.Date.epoch) () =
+    ?(last_update_sync = API.Date.epoch) ?(update_sync_frequency = `daily)
+    ?(update_sync_day = 1L) ?(update_sync_hour = 0L)
+    ?(update_sync_enabled = false) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -304,7 +306,9 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~tls_verification_enabled:false ~repositories
     ~client_certificate_auth_enabled ~client_certificate_auth_name
     ~repository_proxy_url ~repository_proxy_username ~repository_proxy_password
-    ~migration_compression ~coordinator_bias ~last_update_sync ;
+    ~migration_compression ~coordinator_bias ~last_update_sync
+    ~update_sync_frequency ~update_sync_day ~update_sync_hour
+    ~update_sync_enabled ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2988,6 +2988,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pool-configure-update-sync"
+    , {
+        reqd= ["update-sync-frequency"; "update-sync-day"; "update-sync-hour"]
+      ; optn= []
+      ; help= "Configure the scheduled update synchronization from remote CDN"
+      ; implementation= No_fd Cli_operations.pool_configure_update_sync
+      ; flags= []
+      }
+    )
   ; ( "host-ha-xapi-healthcheck"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1844,16 +1844,16 @@ let pool_configure_update_sync _printer rpc session_id params =
       failwith
         "Failed to parse parameter 'update-sync-hour': expecting an integer"
   in
-  ( match frequency with
-  | `daily when day_int <> 1L ->
+  ( match (frequency, day_int) with
+  | `daily, d when d <> 1L ->
       failwith
         "For daily schedule, cannot set the day when update sync will run to \
          an integer other than 1.\n"
-  | `weekly when day_int < -7L || day_int = 0L || day_int > 7L ->
+  | `weekly, d when d < -7L || d = 0L || d > 7L ->
       failwith
         "For weekly schedule, cannot set the day when update sync will run to \
          an integer out of range: -7 ~ -1, 1 ~ 7.\n"
-  | `monthly when day_int < -28L || day_int = 0L || day_int > 28L ->
+  | `monthly, d when d < -28L || d = 0L || d > 28L ->
       failwith
         "For monthly schedule, cannot set the day when update sync will run to \
          an integer out of range: -28 ~ -1, 1 ~ 28.\n"

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1824,6 +1824,51 @@ let pool_disable_repository_proxy _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   Client.Pool.disable_repository_proxy ~rpc ~session_id ~self:pool
 
+let pool_configure_update_sync _printer rpc session_id params =
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  let frequency =
+    Record_util.update_sync_frequency_of_string
+      (List.assoc "update-sync-frequency" params)
+  in
+  let day = List.assoc "update-sync-day" params in
+  let day_int =
+    try Int64.of_string day
+    with _ ->
+      failwith
+        "Failed to parse parameter 'update-sync-day': expecting an integer"
+  in
+  let hour = List.assoc "update-sync-hour" params in
+  let hour_int =
+    try Int64.of_string hour
+    with _ ->
+      failwith
+        "Failed to parse parameter 'update-sync-hour': expecting an integer"
+  in
+  ( match frequency with
+  | `daily when day_int <> 1L ->
+      failwith
+        "For daily schedule, cannot set the day when update sync will run to \
+         an integer other than 1.\n"
+  | `weekly when day_int < -7L || day_int = 0L || day_int > 7L ->
+      failwith
+        "For weekly schedule, cannot set the day when update sync will run to \
+         an integer out of range: -7 ~ -1, 1 ~ 7.\n"
+  | `monthly when day_int < -28L || day_int = 0L || day_int > 28L ->
+      failwith
+        "For monthly schedule, cannot set the day when update sync will run to \
+         an integer out of range: -28 ~ -1, 1 ~ 28.\n"
+  | _ ->
+      ()
+  ) ;
+  if hour_int < 0L || hour_int > 23L then
+    failwith
+      "Cannot set the hour when update sync will run to an integer out of \
+       range: 0 ~ 23.\n"
+  else
+    Client.Pool.configure_update_sync ~rpc ~session_id ~self:pool
+      ~update_sync_frequency:frequency ~update_sync_day:day_int
+      ~update_sync_hour:hour_int
+
 let vdi_type_of_string = function
   | "system" ->
       `system

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -1118,3 +1118,22 @@ let mac_from_int_array macs =
 
 (* generate a random mac that is locally administered *)
 let random_mac_local () = mac_from_int_array (Array.make 6 (Random.int 0x100))
+
+let update_sync_frequency_to_string = function
+  | `daily ->
+      "daily"
+  | `weekly ->
+      "weekly"
+  | `monthly ->
+      "monthly"
+
+let update_sync_frequency_of_string s =
+  match String.lowercase_ascii s with
+  | "daily" ->
+      `daily
+  | "weekly" ->
+      `weekly
+  | "monthly" ->
+      `monthly
+  | _ ->
+      raise (Record_failure ("Expected 'daily', 'weekly', 'monthly', got " ^ s))

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1463,6 +1463,21 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"last-update-sync"
           ~get:(fun () -> Date.to_string (x ()).API.pool_last_update_sync)
           ()
+      ; make_field ~name:"update-sync-frequency"
+          ~get:(fun () ->
+            Record_util.update_sync_frequency_to_string
+              (x ()).API.pool_update_sync_frequency
+          )
+          ()
+      ; make_field ~name:"update-sync-day"
+          ~get:(fun () -> Int64.to_string (x ()).API.pool_update_sync_day)
+          ()
+      ; make_field ~name:"update-sync-hour"
+          ~get:(fun () -> Int64.to_string (x ()).API.pool_update_sync_hour)
+          ()
+      ; make_field ~name:"update-sync-enabled"
+          ~get:(fun () -> (x ()).API.pool_update_sync_enabled |> string_of_bool)
+          ()
       ]
   }
 

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1285,6 +1285,10 @@ let updates_require_recommended_guidance =
 
 let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"
 
+let invalid_update_sync_day = "INVALID_UPDATE_SYNC_DAY"
+
+let invalid_update_sync_hour = "INVALID_UPDATE_SYNC_HOUR"
+
 (* VTPMs *)
 
 let vtpm_max_amount_reached = "VTPM_MAX_AMOUNT_REACHED"

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -48,6 +48,8 @@ let create_pool_record ~__context =
       ~repository_proxy_url:"" ~repository_proxy_username:""
       ~repository_proxy_password:Ref.null ~migration_compression:false
       ~coordinator_bias:true ~last_update_sync:Xapi_stdext_date.Date.epoch
+      ~update_sync_frequency:`daily ~update_sync_day:1L ~update_sync_hour:0L
+      ~update_sync_enabled:false
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1090,6 +1090,17 @@ functor
           (pool_uuid ~__context self)
           value ;
         Local.Pool.set_https_only ~__context ~self ~value
+
+      let configure_update_sync ~__context ~self ~update_sync_frequency
+          ~update_sync_day ~update_sync_hour =
+        info
+          "Pool.configure_update_sync: pool='%s' update_sync_frequency='%s' \
+           update_sync_day=%Ld update_sync_hour=%Ld"
+          (pool_uuid ~__context self)
+          (Record_util.update_sync_frequency_to_string update_sync_frequency)
+          update_sync_day update_sync_hour ;
+        Local.Pool.configure_update_sync ~__context ~self ~update_sync_frequency
+          ~update_sync_day ~update_sync_hour
     end
 
     module VM = struct

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3612,8 +3612,8 @@ let set_https_only ~__context ~self:_ ~value =
 
 let configure_update_sync ~__context ~self ~update_sync_frequency
     ~update_sync_day ~update_sync_hour =
-  ( match update_sync_frequency with
-  | `daily when update_sync_day <> 1L ->
+  ( match (update_sync_frequency, update_sync_day) with
+  | `daily, d when d <> 1L ->
       error
         "For daily schedule, cannot set the day when update sync will run to \
          an integer other than 1" ;
@@ -3622,9 +3622,7 @@ let configure_update_sync ~__context ~self ~update_sync_frequency
           Server_error
             (invalid_update_sync_day, [Int64.to_string update_sync_day])
         )
-  | `weekly
-    when update_sync_day < -7L || update_sync_day = 0L || update_sync_day > 7L
-    ->
+  | `weekly, d when d < -7L || d = 0L || d > 7L ->
       error
         "For weekly schedule, cannot set the day when update sync will run to \
          an integer out of range: -7 ~ -1, 1 ~ 7" ;
@@ -3633,9 +3631,7 @@ let configure_update_sync ~__context ~self ~update_sync_frequency
           Server_error
             (invalid_update_sync_day, [Int64.to_string update_sync_day])
         )
-  | `monthly
-    when update_sync_day < -28L || update_sync_day = 0L || update_sync_day > 28L
-    ->
+  | `monthly, d when d < -28L || d = 0L || d > 28L ->
       error
         "For monthly schedule, cannot set the day when update sync will run to \
          an integer out of range: -28 ~ -1, 1 ~ 28" ;

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -390,3 +390,11 @@ val set_uefi_certificates :
 
 val set_https_only :
   __context:Context.t -> self:API.ref_pool -> value:bool -> unit
+
+val configure_update_sync :
+     __context:Context.t
+  -> self:API.ref_pool
+  -> update_sync_frequency:API.update_sync_frequency
+  -> update_sync_day:int64
+  -> update_sync_hour:int64
+  -> unit

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -380,6 +380,13 @@ _xe()
                 set_completions "$vdis" "$val"
                 return 0
                 ;;
+
+            update-sync-frequency) # for pool-configure-update-sync
+                IFS=$'\n,'
+                set_completions 'daily,weekly,monthly' "$value"
+                return 0
+                ;;
+
             *)
                 snd=`echo ${param} | gawk -F- '{print $NF}'`
                 fst=`echo ${param} | gawk -F- '{printf "%s", $1; for (i=2; i<NF; i++) printf "-%s", $i}'`


### PR DESCRIPTION
1. add new fields: "update_sync_frequency", "update_sync_day", "update_sync_hour", "update_sync_enabled" in pool datamodel
2. add API: pool.configure_update_sync
3. add xe CLI: pool-configure-update-sync