### PR TITLE
Toolstack Tracing v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,8 @@ install: build doc sdk doc-json
 # ocaml/rrd2csv
 	scripts/install.sh 755 _build/install/default/bin/rrd2csv $(DESTDIR)$(OPTDIR)/bin/rrd2csv
 	scripts/install.sh 644 ocaml/rrd2csv/man/rrd2csv.1.man $(DESTDIR)$(OPTMANDIR)/rrd2csv.1
+# ocaml/xs-trace
+	scripts/install.sh 755 _build/install/default/bin/xs-trace $(DESTDIR)/usr/bin/xs-trace
 # xcp-rrdd
 	install -D _build/install/default/bin/xcp-rrdd $(DESTDIR)/usr/sbin/xcp-rrdd
 	install -D _build/install/default/bin/rrddump $(DESTDIR)/usr/bin/rrddump

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7732,6 +7732,124 @@ module VUSB = struct
       ~messages:[create; unplug; destroy] ()
 end
 
+module Tracing = struct
+  let lifecycle = []
+
+  let set_status =
+    call ~name:"set_status" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; (Bool, "status", "The status the TracerProvider is to be set to")
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_tags =
+    call ~name:"set_tags" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Map (String, String)
+          , "tags"
+          , "The tags the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_endpoints =
+    call ~name:"set_endpoints" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Set String
+          , "endpoints"
+          , "The endpoints the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_components =
+    call ~name:"set_components" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Set String
+          , "components"
+          , "The components the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_filters =
+    call ~name:"set_filters" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Set String
+          , "filters"
+          , "The filter the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_processors =
+    call ~name:"set_processors" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Set String
+          , "processors"
+          , "The processors the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let t =
+    create_obj ~name:_tracing ~descr:"Describes a TracerProvider"
+      ~doccomments:[] ~gen_constructor_destructor:false ~gen_events:true
+      ~in_db:true ~lifecycle ~persist:PersistEverything ~in_oss_since:None
+      ~messages_default_allowed_roles:_R_POOL_ADMIN
+      ~contents:
+        ([uid _tracing ~lifecycle]
+        @ [
+            field ~qualifier:DynamicRO ~ty:(Set (Ref _host)) ~lifecycle "hosts"
+              "A list of hosts the TracerProvider is to be registered on"
+              ~ignore_foreign_key:true
+          ; field ~qualifier:DynamicRO ~ty:String ~lifecycle "name_label"
+              "A user assinged label for a TracerProvider"
+          ; field ~qualifier:DynamicRO
+              ~ty:(Map (String, String))
+              ~lifecycle "tags"
+              "Tags to be set on spans to provide extra information"
+          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "endpoints"
+              "Endpoints where spans are exported to"
+          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "components"
+              "Componenets the TraverProvider is to be registered on"
+          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "filters"
+              "Filters for operations that spans will be produced for"
+          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "processors"
+              "Processors that will filter/map spans before being exported"
+          ; field ~qualifier:DynamicRO ~ty:Bool ~lifecycle "status"
+              "Processors that will filter/map spans before being exported"
+          ]
+        )
+      ~messages:
+        [
+          set_status
+        ; set_tags
+        ; set_endpoints
+        ; set_components
+        ; set_filters
+        ; set_processors
+        ]
+      ()
+end
 (******************************************************************************************)
 
 (** All the objects in the system in order they will appear in documentation: *)
@@ -7803,6 +7921,7 @@ let all_system =
   ; PUSB.t
   ; USB_group.t
   ; VUSB.t
+  ; Tracing.t
   ; Datamodel_cluster.t
   ; Datamodel_cluster_host.t
   ; Datamodel_certificate.t
@@ -8040,6 +8159,7 @@ let expose_get_all_messages_for =
   ; _certificate
   ; _repository
   ; _vtpm
+  ; _tracing
   ]
 
 let no_task_id_for = [_task; (* _alert; *) _event]

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 760
+let schema_minor_vsn = 761
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -302,6 +302,8 @@ let _certificate = "Certificate"
 let _diagnostics = "Diagnostics"
 
 let _repository = "Repository"
+
+let _tracing = "Tracing"
 
 let update_guidances =
   Enum

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -1,4 +1,6 @@
 let prototyped_of_class = function
+  | "Tracing" ->
+      Some "23.8.0-next"
   | "VTPM" ->
       Some "22.26.0"
   | _ ->
@@ -7,6 +9,24 @@ let prototyped_of_class = function
 let prototyped_of_field = function
   | "Repository", "gpgkey_path" ->
       Some "22.12.0"
+  | "Tracing", "status" ->
+      Some "23.8.0-next"
+  | "Tracing", "processors" ->
+      Some "23.8.0-next"
+  | "Tracing", "filters" ->
+      Some "23.8.0-next"
+  | "Tracing", "components" ->
+      Some "23.8.0-next"
+  | "Tracing", "endpoints" ->
+      Some "23.8.0-next"
+  | "Tracing", "tags" ->
+      Some "23.8.0-next"
+  | "Tracing", "name_label" ->
+      Some "23.8.0-next"
+  | "Tracing", "hosts" ->
+      Some "23.8.0-next"
+  | "Tracing", "uuid" ->
+      Some "23.8.0-next"
   | "VTPM", "contents" ->
       Some "22.26.0"
   | "VTPM", "is_protected" ->
@@ -33,6 +53,18 @@ let prototyped_of_message = function
       Some "22.20.0"
   | "Repository", "set_gpgkey_path" ->
       Some "22.12.0"
+  | "Tracing", "set_processors" ->
+      Some "23.8.0-next"
+  | "Tracing", "set_filters" ->
+      Some "23.8.0-next"
+  | "Tracing", "set_components" ->
+      Some "23.8.0-next"
+  | "Tracing", "set_endpoints" ->
+      Some "23.8.0-next"
+  | "Tracing", "set_tags" ->
+      Some "23.8.0-next"
+  | "Tracing", "set_status" ->
+      Some "23.8.0-next"
   | "message", "destroy_many" ->
       Some "22.19.0"
   | "VTPM", "set_contents" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "021c461d774cbfc67ba65e5616d21f41"
+let last_known_schema_hash = "7ee70fc484a1f9dd3ca373ced3fdd30e"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/libs/http-svr/dune
+++ b/ocaml/libs/http-svr/dune
@@ -27,6 +27,7 @@
     xapi-stdext-threads
     xapi-stdext-unix
     xml-light2
+    tracing
   )
 )
 

--- a/ocaml/libs/http-svr/http.ml
+++ b/ocaml/libs/http-svr/http.ml
@@ -124,6 +124,8 @@ module Hdr = struct
   let accept = "accept"
 
   let location = "location"
+
+  let traceparent = "traceparent"
 end
 
 let output_http fd headers =
@@ -554,6 +556,7 @@ module Request = struct
     ; mutable close: bool
     ; additional_headers: (string * string) list
     ; body: string option
+    ; traceparent: string option
   }
   [@@deriving rpc]
 
@@ -577,11 +580,12 @@ module Request = struct
     ; close= true
     ; additional_headers= []
     ; body= None
+    ; traceparent= None
     }
 
   let make ?(frame = false) ?(version = "1.1") ?(keep_alive = true) ?accept
       ?cookie ?length ?auth ?subtask_of ?body ?(headers = []) ?content_type
-      ?host ?(query = []) ~user_agent meth path =
+      ?host ?(query = []) ?traceparent ~user_agent meth path =
     {
       empty with
       version
@@ -600,6 +604,7 @@ module Request = struct
     ; body
     ; accept
     ; query
+    ; traceparent
     }
 
   let get_version x = x.version
@@ -631,6 +636,7 @@ module Request = struct
             ; close= false
             ; additional_headers= []
             ; body= None
+            ; traceparent= None
             }
         | None ->
             error "Failed to parse: %s" x ;
@@ -646,7 +652,8 @@ module Request = struct
     Printf.sprintf
       "{ frame = %b; method = %s; uri = %s; query = [ %s ]; content_length = [ \
        %s ]; transfer encoding = %s; version = %s; cookie = [ %s ]; task = %s; \
-       subtask_of = %s; content-type = %s; host = %s; user_agent = %s }"
+       subtask_of = %s; content-type = %s; host = %s; user_agent = %s; \
+       traceparent = %s }"
       x.frame (string_of_method_t x.m) x.uri (kvpairs x.query)
       (Option.fold ~none:"" ~some:Int64.to_string x.content_length)
       (Option.value ~default:"" x.transfer_encoding)
@@ -656,6 +663,7 @@ module Request = struct
       (Option.value ~default:"" x.content_type)
       (Option.value ~default:"" x.host)
       (Option.value ~default:"" x.user_agent)
+      (Option.value ~default:"" x.traceparent)
 
   let to_header_list x =
     let kvpairs x =
@@ -705,6 +713,11 @@ module Request = struct
         ~some:(fun x -> [Hdr.user_agent ^ ": " ^ x])
         x.user_agent
     in
+    let traceparent =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Hdr.traceparent ^ ": " ^ x])
+        x.traceparent
+    in
     let close =
       [(Hdr.connection ^ ": " ^ if x.close then "close" else "keep-alive")]
     in
@@ -722,6 +735,7 @@ module Request = struct
     @ content_type
     @ host
     @ user_agent
+    @ traceparent
     @ close
     @ List.map (fun (k, v) -> k ^ ":" ^ v) x.additional_headers
 

--- a/ocaml/libs/http-svr/http.mli
+++ b/ocaml/libs/http-svr/http.mli
@@ -88,6 +88,7 @@ module Request : sig
     ; mutable close: bool
     ; additional_headers: (string * string) list
     ; body: string option
+    ; traceparent: string option
   }
 
   val rpc_of_t : t -> Rpc.t
@@ -110,6 +111,7 @@ module Request : sig
     -> ?content_type:string
     -> ?host:string
     -> ?query:(string * string) list
+    -> ?traceparent:string
     -> user_agent:string
     -> method_t
     -> string
@@ -227,6 +229,8 @@ module Hdr : sig
   val accept : string
 
   val location : string
+
+  val traceparent : string
 end
 
 val output_http : Unix.file_descr -> string list -> unit

--- a/ocaml/libs/http-svr/http_svr.ml
+++ b/ocaml/libs/http-svr/http_svr.ml
@@ -400,6 +400,8 @@ let request_of_bio_exn ~proxy_seen ~read_timeout ~total_timeout ~max_length bio
                        {req with host= Some v}
                    | k when k = Http.Hdr.user_agent ->
                        {req with user_agent= Some v}
+                   | k when k = Http.Hdr.traceparent ->
+                       {req with traceparent= Some v}
                    | k when k = Http.Hdr.connection && lowercase v = "close" ->
                        {req with close= true}
                    | k

--- a/ocaml/libs/http-svr/xmlrpc_client.ml
+++ b/ocaml/libs/http-svr/xmlrpc_client.ml
@@ -54,6 +54,7 @@ let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth
     let open Tracing in
     Option.map
       (fun span ->
+        let _ = Span.set_span_kind span SpanKind.Client in
         Span.get_span_context span |> SpanContext.to_traceparent
       )
       tracing

--- a/ocaml/libs/http-svr/xmlrpc_client.ml
+++ b/ocaml/libs/http-svr/xmlrpc_client.ml
@@ -49,10 +49,20 @@ let connect ?session_id ?task_id ?subtask_of path =
     ?subtask_of Http.Connect path
 
 let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth
-    ?subtask_of ?query ?body path =
+    ?subtask_of ?query ?body ?(tracing = None) path =
+  let traceparent =
+    let open Tracing in
+    Option.map
+      (fun span ->
+        Span.get_span_context span |> SpanContext.to_traceparent
+      )
+      tracing
+  in
+  debug "Setting traceparent header = %s"
+    (Option.value ~default:"None" traceparent) ;
   let headers = Option.map (fun x -> [(Http.Hdr.task_id, x)]) task_id in
   Http.Request.make ~user_agent ?frame ?version ?keep_alive ?cookie ?headers
-    ?length ?auth ?subtask_of ?query ?body Http.Post path
+    ?length ?auth ?subtask_of ?query ?body ?traceparent Http.Post path
 
 (** Thrown when ECONNRESET is caught which suggests the remote crashed or restarted *)
 exception Connection_reset

--- a/ocaml/libs/http-svr/xmlrpc_client.mli
+++ b/ocaml/libs/http-svr/xmlrpc_client.mli
@@ -72,6 +72,7 @@ val xmlrpc :
   -> ?subtask_of:string
   -> ?query:(string * string) list
   -> ?body:string
+  -> ?tracing:Tracing.t
   -> string
   -> Http.Request.t
 (** Returns an HTTP.Request.t representing an XMLRPC request *)

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -1,0 +1,12 @@
+(library
+  (name tracing)
+  (public_name xapi-tracing)
+  (libraries
+    cohttp
+    rpclib.core
+    rpclib.json
+    xapi-idl
+    xapi-stdext-unix
+  )
+  (preprocess (pps ppx_deriving_rpc))
+)

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -1,0 +1,142 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+type config = Undetermined | Disabled | Url of string
+
+let tracing_config = ref Undetermined
+
+let url_file = "/etc/xapi-tracing-url"
+
+module Http = struct
+  module Request = Cohttp.Request.Make (Cohttp_posix_io.Buffered_IO)
+  module Response = Cohttp.Response.Make (Cohttp_posix_io.Buffered_IO)
+
+  let get_user_agent () = Sys.argv.(0)
+
+  let post ~url ~route ~body : (string, exn) result =
+    try
+      let uri = Printf.sprintf "%s%s" url route in
+      let uri' = Uri.of_string uri in
+      Open_uri.with_open_uri uri' (fun fd ->
+          let headers =
+            Cohttp.Header.of_list
+              [
+                ("User-agent", get_user_agent ())
+              ; ("content-type", "application/body")
+              ; ("content-length", string_of_int (String.length body))
+              ]
+          in
+          let request =
+            Cohttp.Request.make ~meth:`POST ~version:`HTTP_1_1 ~headers uri'
+          in
+          let ic = Unix.in_channel_of_descr fd in
+          let oc = Unix.out_channel_of_descr fd in
+          Request.write
+            (fun writer -> Request.write_body writer body)
+            request oc ;
+          match Response.read ic with
+          | `Eof ->
+              Ok ""
+          | `Invalid x ->
+              Error (Failure ("invalid read: " ^ x))
+          | `Ok response ->
+              let body = Buffer.create 16 in
+              let reader = Response.make_body_reader response ic in
+              let rec loop () =
+                match Response.read_body_chunk reader with
+                | Cohttp.Transfer.Chunk x ->
+                    Buffer.add_string body x ; loop ()
+                | Cohttp.Transfer.Final_chunk x ->
+                    Buffer.add_string body x
+                | Cohttp.Transfer.Done ->
+                    ()
+              in
+              loop () ;
+              Ok (Buffer.contents body)
+      )
+    with e -> Error e
+end
+
+type span_context = {
+    uber_trace_id: string [@key "uber-trace-id"]
+  ; traceparent: string [@key "traceparent"]
+}
+[@@deriving rpcty]
+
+type blob = {span_context: span_context; stamp: float; operation_name: string}
+[@@deriving rpcty]
+
+type t = blob option [@@deriving rpcty]
+
+type start_span_body = {operation_name: string; parent: t} [@@deriving rpcty]
+
+let start_span_json ~operation_name ~parent : string =
+  {operation_name; parent}
+  |> Rpcmarshal.marshal start_span_body.Rpc.Types.ty
+  |> Jsonrpc.to_string
+
+let blob_json x : string =
+  Rpcmarshal.marshal blob.Rpc.Types.ty x |> Jsonrpc.to_string
+
+let json_of_t : t -> string option = Option.map blob_json
+
+let string_of_t x : string = Option.value ~default:"(empty)" (json_of_t x)
+
+let t_of_string x : t =
+  x
+  |> Jsonrpc.of_string
+  |> Rpcmarshal.unmarshal blob.Rpc.Types.ty
+  |> Result.to_option
+
+let empty : t = None
+
+let null = function None -> true | Some _ -> false
+
+let start ~name ~parent : (t, exn) result =
+  let call url =
+    let body = start_span_json ~operation_name:name ~parent in
+    match Http.post ~url ~body ~route:"/start-span" with
+    | Ok x ->
+        Ok (t_of_string x)
+    | Error _ as e ->
+        e
+  in
+  match !tracing_config with
+  | Disabled ->
+      Ok None
+  | Undetermined -> (
+    try
+      let url =
+        Xapi_stdext_unix.Unixext.string_of_file url_file |> String.trim
+      in
+      tracing_config := Url url ;
+      call url
+    with e ->
+      tracing_config := Disabled ;
+      Error e
+  )
+  | Url url ->
+      call url
+
+let finish x : (unit, exn) result =
+  match (x, !tracing_config) with
+  | Some blob, Url url -> (
+      let body = blob_json blob in
+      match Http.post ~url ~route:"/finish-span" ~body with
+      | Ok x ->
+          Ok ()
+      | Error _ as e ->
+          e
+    )
+  | _ ->
+      Ok ()

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -11,6 +11,14 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+let url_file = "/etc/xapi-tracing-url"
+
+let trace_log_dir = "/var/log/dt/zipkinv2/json"
+
+module D = Debug.Make (struct let name = "tracing" end)
+
+open D
+
 module Span = struct
   type t = {
       trace_id: string
@@ -58,28 +66,30 @@ module Span = struct
         span.tags <- new_tags
     | orig_tags, new_tags ->
         span.tags <- orig_tags @ new_tags
+end
 
+module Spans = struct
   let lock = Mutex.create ()
 
-  let since spans =
+  let spans = Hashtbl.create 100
+
+  let add_to_spans ~(span : Span.t) =
+    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+        let key = span.trace_id in
+        match Hashtbl.find_opt spans key with
+        | None ->
+            Hashtbl.add spans key [span]
+        | Some span_list ->
+            if List.length span_list < 1000 then
+              Hashtbl.replace spans key (span :: span_list)
+    )
+
+  let since () =
     Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
         let copy = Hashtbl.copy spans in
         Hashtbl.clear spans ; copy
     )
 end
-
-let spans = Hashtbl.create 100
-
-let add_to_spans ~(span : Span.t) =
-  Xapi_stdext_threads.Threadext.Mutex.execute Span.lock (fun () ->
-      let key = span.trace_id in
-      match Hashtbl.find_opt spans key with
-      | None ->
-          Hashtbl.add spans key [span]
-      | Some span_list ->
-          if List.length span_list < 1000 then
-            Hashtbl.replace spans key (span :: span_list)
-  )
 
 type blob = Span.t [@@deriving rpcty]
 
@@ -104,7 +114,7 @@ let null = function None -> true | Some _ -> false
 
 let start ~name ~parent : (t, exn) result =
   let span = Span.start ~name ~parent () in
-  add_to_spans ~span ; Ok (Some span)
+  Spans.add_to_spans ~span ; Ok (Some span)
 
 let finish x : (unit, exn) result =
   match x with None -> Ok () | Some span -> Span.finish ~span () ; Ok ()
@@ -129,8 +139,10 @@ module Export = struct
           }
           [@@deriving rpcty]
 
-          let json_of_t s =
-            Rpcmarshal.marshal t.Rpc.Types.ty s |> Jsonrpc.to_string
+          type t_list = t list [@@deriving rpcty]
+
+          let json_of_t_list s =
+            Rpcmarshal.marshal t_list.Rpc.Types.ty s |> Jsonrpc.to_string
         end
 
         let zipkin_span_of_span : Span.t -> ZipkinSpan.t =
@@ -142,16 +154,150 @@ module Export = struct
           ; name= s.span_name
           ; timestamp= int_of_float (s.span_begin_time *. 1000000.)
           ; duration=
-              (Option.value s.span_end_time ~default:(Unix.gettimeofday () *. 1000000.)
-              -. (s.span_begin_time *. 1000000.)) |> int_of_float
+              Option.value s.span_end_time ~default:(Unix.gettimeofday ())
+              -. s.span_begin_time
+              |> ( *. ) 1000000.
+              |> int_of_float
           ; kind= "SERVER"
           ; localEndpoint= {serviceName= "xapi"}
           ; tags= s.tags
           }
 
-        let content_of (span : Span.t) =
-          ZipkinSpan.json_of_t (zipkin_span_of_span span)
+        let content_of (spans : Span.t list) =
+          List.map zipkin_span_of_span spans |> ZipkinSpan.json_of_t_list
       end
     end
+  end
+
+  module Destination = struct
+    module File = struct
+      let export ~trace_id ~span_json : (string, exn) result =
+        try
+          (* TODO: *)
+          let host_id = "myhostid" in
+          let timestamp = Unix.gettimeofday () |> string_of_float in
+          let microsec = String.sub timestamp 6 (String.length timestamp - 6) in
+          let unix_time = float_of_string timestamp |> Unix.localtime in
+          let date =
+            Printf.sprintf "%d%d%d-%d%d%d-%s" unix_time.tm_year unix_time.tm_mon
+              unix_time.tm_mday unix_time.tm_hour unix_time.tm_min
+              unix_time.tm_sec microsec
+          in
+          let file =
+            String.concat "/" [trace_log_dir; trace_id; "xapi"; host_id; date]
+            ^ ".json"
+          in
+          Xapi_stdext_unix.Unixext.mkdir_rec (Filename.dirname file) 0o700 ;
+          Xapi_stdext_unix.Unixext.write_string_to_file file span_json ;
+          (* TODO: Ensure file is only written when trace is complete *)
+          Ok ""
+        with e -> Error e
+    end
+
+    module Http = struct
+      module Request = Cohttp.Request.Make (Cohttp_posix_io.Buffered_IO)
+      module Response = Cohttp.Response.Make (Cohttp_posix_io.Buffered_IO)
+
+      let export ~span_json ~url : (string, exn) result =
+        try
+          let body = span_json in
+          let uri = Uri.of_string url in
+          let headers =
+            Cohttp.Header.of_list
+              [
+                ("accepts", "application/json")
+              ; ("content-type", "application/json")
+              ; ("content-length", string_of_int (String.length body))
+              ]
+          in
+          Open_uri.with_open_uri uri (fun fd ->
+              let request =
+                Cohttp.Request.make ~meth:`POST ~version:`HTTP_1_1 ~headers uri
+              in
+              let ic = Unix.in_channel_of_descr fd in
+              let oc = Unix.out_channel_of_descr fd in
+              Request.write
+                (fun writer -> Request.write_body writer body)
+                request oc ;
+              match Response.read ic with
+              | `Eof ->
+                  Ok ""
+              | `Invalid x ->
+                  Error (Failure ("invalid read: " ^ x))
+              | `Ok response ->
+                  let body = Buffer.create 128 in
+                  let reader = Response.make_body_reader response ic in
+                  let rec loop () =
+                    match Response.read_body_chunk reader with
+                    | Cohttp.Transfer.Chunk x ->
+                        Buffer.add_string body x ; loop ()
+                    | Cohttp.Transfer.Final_chunk x ->
+                        Buffer.add_string body x
+                    | Cohttp.Transfer.Done ->
+                        ()
+                  in
+                  loop () ;
+                  Ok (Buffer.contents body)
+          )
+        with e -> Error e
+    end
+
+    let export_to_http_server () =
+      debug "Tracing: About to export to http server" ;
+      let url =
+        Xapi_stdext_unix.Unixext.string_of_file url_file |> String.trim
+      in
+      let span_list = Spans.since () in
+      try
+        Hashtbl.iter
+          (fun _ span_list ->
+            let zipkin_spans = Content.Json.Zipkinv2.content_of span_list in
+            match Http.export ~span_json:zipkin_spans ~url with
+            | Ok _ ->
+                ()
+            | Error e ->
+                raise e
+          )
+          span_list ;
+        Ok ()
+      with e -> Error e
+
+    let export_to_logs () =
+      debug "Tracing: About to export to dom0 logs" ;
+      let span_list = Spans.since () in
+      try
+        Hashtbl.iter
+          (fun trace_id span_list ->
+            let zipkin_spans = Content.Json.Zipkinv2.content_of span_list in
+            match File.export ~trace_id ~span_json:zipkin_spans with
+            | Ok _ ->
+                ()
+            | Error e ->
+                raise e
+          )
+          span_list ;
+        Ok ()
+      with e -> Error e
+
+    let _ =
+      Thread.create
+        (fun () ->
+          while true do
+            debug "Tracing: Waiting 30s before exporting spans" ;
+            Thread.delay 30. ;
+            let export_span =
+              Span.start ~name:"export_to_http_server" ~parent:None ()
+            in
+            match export_to_http_server () with
+            | Ok () ->
+                Span.finish ~span:export_span ()
+            | Error e ->
+                debug "Tracing: ERROR %s" (Printexc.to_string e) ;
+                Span.finish ~span:export_span
+                  ~tags:[("exception.message", Printexc.to_string e)]
+                  ()
+          done
+        )
+        ()
   end
 end

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -19,6 +19,10 @@ module D = Debug.Make (struct let name = "tracing" end)
 
 open D
 
+type endpoint = Bugtool | Url of string [@@deriving rpcty]
+
+let endpoint_of_string = function "bugtool" -> Bugtool | url -> Url url
+
 module SpanContext = struct
   type t = {trace_id: string; span_id: string} [@@deriving rpcty]
 
@@ -75,21 +79,6 @@ module Span = struct
         span.tags <- orig_tags @ new_tags
 end
 
-module Tracer = struct
-  type t = string [@@deriving rpcty]
-  (* So the module exists, type will need to be changed*)
-
-  let span_of_span_context span_context span_name : Span.t =
-    {
-      span_context
-    ; span_name
-    ; span_parent= None
-    ; span_begin_time= Unix.gettimeofday ()
-    ; span_end_time= None
-    ; tags= []
-    }
-end
-
 module Spans = struct
   let lock = Mutex.create ()
 
@@ -113,6 +102,155 @@ module Spans = struct
     )
 end
 
+type provider_config_t = {
+    name_label: string
+  ; tags: (string * string) list
+  ; endpoints: endpoint list
+  ; filters: string list
+  ; processors: string list
+  ; enabled: bool
+}
+[@@deriving rpcty]
+
+module Tracer = struct
+  type t = {name: string; provider: provider_config_t ref}
+
+  let create ~name ~provider = {name; provider}
+
+  let span_of_span_context span_context span_name : Span.t =
+    {
+      span_context
+    ; span_name
+    ; span_parent= None
+    ; span_begin_time= Unix.gettimeofday ()
+    ; span_end_time= None
+    ; tags= []
+    }
+
+  let get_empty name =
+    warn "Tracer of name %s was not found" name ;
+    let provider =
+      ref
+        {
+          name_label= ""
+        ; tags= []
+        ; endpoints= []
+        ; filters= []
+        ; processors= []
+        ; enabled= false
+        }
+    in
+    {name= ""; provider}
+
+  let start ~tracer:t ~name ~parent : (Span.t option, exn) result =
+    let provider = !(t.provider) in
+    (* Do not start span if the TracerProvider is diabled*)
+    if not provider.enabled then
+      Ok None
+    else
+      let tags = provider.tags in
+      let span = Span.start ~tags ~name ~parent () in
+      Spans.add_to_spans ~span ; Ok (Some span)
+
+  let finish x : (unit, exn) result =
+    match x with None -> Ok () | Some span -> Span.finish ~span () ; Ok ()
+end
+
+module TracerProvider = struct
+  type t = {tracers: Tracer.t list; config: provider_config_t}
+
+  let find_tracer ~provider:t ~name =
+    match
+      List.filter (fun (tracer : Tracer.t) -> tracer.name = name) t.tracers
+    with
+    | [tracer] ->
+        tracer
+    | _ ->
+        Tracer.get_empty name
+end
+
+module TracerProviders = struct
+  let lock = Mutex.create ()
+
+  let tracer_providers = Hashtbl.create 100
+
+  let find_or_create_tracer ~provider ~name =
+    match
+      List.filter
+        (fun tracer -> tracer.Tracer.name = name)
+        provider.TracerProvider.tracers
+    with
+    | provider :: _ ->
+        provider
+    | _ ->
+        Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+            let label = provider.TracerProvider.config.name_label in
+            let tracer =
+              Tracer.create ~name ~provider:(ref provider.TracerProvider.config)
+            in
+            let provider =
+              {provider with tracers= tracer :: provider.TracerProvider.tracers}
+            in
+            Hashtbl.replace tracer_providers label provider ;
+            tracer
+        )
+
+  let set_default ~tags ~endpoints ~processors ~filters =
+    let endpoints = List.map endpoint_of_string endpoints in
+    let default : TracerProvider.t =
+      {
+        tracers= []
+      ; config=
+          {
+            name_label= "default"
+          ; tags= ("provider", "default") :: tags
+          ; endpoints
+          ; filters
+          ; processors
+          ; enabled= true
+          }
+      }
+    in
+    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+        Hashtbl.replace tracer_providers "default" default
+    )
+
+  let get_default () =
+    try
+      Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+          let provider = Hashtbl.find tracer_providers "default" in
+          Ok provider
+      )
+    with e -> Error e
+
+  let get_default_tracer ~name =
+    let default = get_default () in
+    match default with
+    | Ok provider ->
+        find_or_create_tracer ~provider ~name
+    | Error e ->
+        if
+          name <> "server_init"
+          (* Expected behavior for no default to be initialised on startup *)
+        then
+          warn "Error fetching default provider: %s " (Printexc.to_string e) ;
+        find_or_create_tracer
+          ~provider:
+            {
+              tracers= []
+            ; config=
+                {
+                  name_label= "default"
+                ; tags= [("provider", "temp_" ^ name)]
+                ; endpoints= [Bugtool]
+                ; filters= ["all"]
+                ; processors= []
+                ; enabled= true
+                }
+            }
+          ~name
+end
+
 type blob = Span.t [@@deriving rpcty]
 
 type t = blob option [@@deriving rpcty]
@@ -133,13 +271,6 @@ let t_of_string x : t =
 let empty : t = None
 
 let null = function None -> true | Some _ -> false
-
-let start ~name ~parent : (t, exn) result =
-  let span = Span.start ~name ~parent () in
-  Spans.add_to_spans ~span ; Ok (Some span)
-
-let finish x : (unit, exn) result =
-  match x with None -> Ok () | Some span -> Span.finish ~span () ; Ok ()
 
 module Export = struct
   module Content = struct
@@ -167,8 +298,13 @@ module Export = struct
             Rpcmarshal.marshal t_list.Rpc.Types.ty s |> Jsonrpc.to_string
         end
 
-        let zipkin_span_of_span : Span.t -> ZipkinSpan.t =
-         fun s ->
+        let zipkin_span_of_span (s : Span.t) : ZipkinSpan.t =
+          let tags =
+            List.assoc_opt "host" s.tags
+            |> Option.fold ~none:s.tags ~some:(fun uuid ->
+                   ("instance", uuid) :: s.tags
+               )
+          in
           {
             id= s.span_context.span_id
           ; traceId= s.span_context.trace_id
@@ -183,7 +319,7 @@ module Export = struct
               |> int_of_float
           ; kind= "SERVER"
           ; localEndpoint= {serviceName= "xapi"}
-          ; tags= s.tags
+          ; tags
           }
 
         let content_of (spans : Span.t list) =

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -491,13 +491,19 @@ module Export = struct
         try
           (* TODO: *)
           let host_id = "myhostid" in
-          let timestamp = Unix.gettimeofday () |> string_of_float in
-          let microsec = String.sub timestamp 6 (String.length timestamp - 6) in
-          let unix_time = float_of_string timestamp |> Unix.localtime in
+          let timestamp = Unix.gettimeofday () in
+          let timestamp_ms =
+            timestamp *. 1000000. |> int_of_float |> string_of_int
+          in
+          let microsec =
+            String.sub timestamp_ms 6 (String.length timestamp_ms - 6)
+          in
+          let unix_time = timestamp |> Unix.localtime in
           let date =
-            Printf.sprintf "%d%d%d-%d%d%d-%s" unix_time.tm_year unix_time.tm_mon
-              unix_time.tm_mday unix_time.tm_hour unix_time.tm_min
-              unix_time.tm_sec microsec
+            Printf.sprintf "%d%02d%d-%d%d%d-%s"
+              (Int.rem unix_time.tm_year 100)
+              (unix_time.tm_mon + 1) unix_time.tm_mday unix_time.tm_hour
+              unix_time.tm_min unix_time.tm_sec microsec
           in
           let file =
             String.concat "/" [path; trace_id; "xapi"; host_id; date] ^ ".json"

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -11,79 +11,70 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-type config = Undetermined | Disabled | Url of string
+module Span = struct
+  type t = {
+      trace_id: int
+    ; span_id: int
+    ; span_parent: t option
+    ; span_name: string
+    ; span_begin_time: float
+    ; mutable span_end_time: float option
+    ; mutable tags: (string * string) list
+  }
+  [@@deriving rpcty]
 
-let tracing_config = ref Undetermined
+  let start ?(tags = []) ~name ~parent () =
+    let trace_id =
+      match parent with
+      | None ->
+          Random.int 1073741823
+      | Some span_parent ->
+          span_parent.trace_id
+    in
+    let span_id = Random.int 1073741823 in
+    let span_parent = parent in
+    let span_name = name in
+    let span_begin_time = Unix.time () in
+    let span_end_time = None in
+    {
+      trace_id
+    ; span_id
+    ; span_parent
+    ; span_name
+    ; span_begin_time
+    ; span_end_time
+    ; tags
+    }
 
-let url_file = "/etc/xapi-tracing-url"
-
-module Http = struct
-  module Request = Cohttp.Request.Make (Cohttp_posix_io.Buffered_IO)
-  module Response = Cohttp.Response.Make (Cohttp_posix_io.Buffered_IO)
-
-  let get_user_agent () = Sys.argv.(0)
-
-  let post ~url ~route ~body : (string, exn) result =
-    try
-      let uri = Printf.sprintf "%s%s" url route in
-      let uri' = Uri.of_string uri in
-      Open_uri.with_open_uri uri' (fun fd ->
-          let headers =
-            Cohttp.Header.of_list
-              [
-                ("User-agent", get_user_agent ())
-              ; ("content-type", "application/body")
-              ; ("content-length", string_of_int (String.length body))
-              ]
-          in
-          let request =
-            Cohttp.Request.make ~meth:`POST ~version:`HTTP_1_1 ~headers uri'
-          in
-          let ic = Unix.in_channel_of_descr fd in
-          let oc = Unix.out_channel_of_descr fd in
-          Request.write
-            (fun writer -> Request.write_body writer body)
-            request oc ;
-          match Response.read ic with
-          | `Eof ->
-              Ok ""
-          | `Invalid x ->
-              Error (Failure ("invalid read: " ^ x))
-          | `Ok response ->
-              let body = Buffer.create 16 in
-              let reader = Response.make_body_reader response ic in
-              let rec loop () =
-                match Response.read_body_chunk reader with
-                | Cohttp.Transfer.Chunk x ->
-                    Buffer.add_string body x ; loop ()
-                | Cohttp.Transfer.Final_chunk x ->
-                    Buffer.add_string body x
-                | Cohttp.Transfer.Done ->
-                    ()
-              in
-              loop () ;
-              Ok (Buffer.contents body)
-      )
-    with e -> Error e
+  let finish ?(tags = []) ~span () =
+    span.span_end_time <- Some (Unix.time ()) ;
+    match (span.tags, tags) with
+    | _, [] ->
+        ()
+    | [], new_tags ->
+        span.tags <- new_tags
+    | orig_tags, new_tags ->
+        span.tags <- orig_tags @ new_tags
 end
 
-type span_context = {
-    uber_trace_id: string [@key "uber-trace-id"]
-  ; traceparent: string [@key "traceparent"]
-}
-[@@deriving rpcty]
+let spans = Hashtbl.create 100
 
-type blob = {span_context: span_context; stamp: float; operation_name: string}
-[@@deriving rpcty]
+let m = Mutex.create ()
+
+let add_to_spans ~(span : Span.t) =
+  Xapi_stdext_threads.Threadext.Mutex.execute m (fun () ->
+      let key = span.trace_id in
+      match Hashtbl.find_opt spans key with
+      | None ->
+          Hashtbl.add spans key [span]
+      | Some span_list ->
+          if List.length span_list < 1000 then
+            Hashtbl.replace spans key (span :: span_list)
+  )
+
+type blob = Span.t [@@deriving rpcty]
 
 type t = blob option [@@deriving rpcty]
-
-type start_span_body = {operation_name: string; parent: t} [@@deriving rpcty]
-
-let start_span_json ~operation_name ~parent : string =
-  {operation_name; parent}
-  |> Rpcmarshal.marshal start_span_body.Rpc.Types.ty
-  |> Jsonrpc.to_string
 
 let blob_json x : string =
   Rpcmarshal.marshal blob.Rpc.Types.ty x |> Jsonrpc.to_string
@@ -103,40 +94,8 @@ let empty : t = None
 let null = function None -> true | Some _ -> false
 
 let start ~name ~parent : (t, exn) result =
-  let call url =
-    let body = start_span_json ~operation_name:name ~parent in
-    match Http.post ~url ~body ~route:"/start-span" with
-    | Ok x ->
-        Ok (t_of_string x)
-    | Error _ as e ->
-        e
-  in
-  match !tracing_config with
-  | Disabled ->
-      Ok None
-  | Undetermined -> (
-    try
-      let url =
-        Xapi_stdext_unix.Unixext.string_of_file url_file |> String.trim
-      in
-      tracing_config := Url url ;
-      call url
-    with e ->
-      tracing_config := Disabled ;
-      Error e
-  )
-  | Url url ->
-      call url
+  let span = Span.start ~name ~parent () in
+  add_to_spans ~span ; Ok (Some span)
 
 let finish x : (unit, exn) result =
-  match (x, !tracing_config) with
-  | Some blob, Url url -> (
-      let body = blob_json blob in
-      match Http.post ~url ~route:"/finish-span" ~body with
-      | Ok x ->
-          Ok ()
-      | Error _ as e ->
-          e
-    )
-  | _ ->
-      Ok ()
+  match x with None -> Ok () | Some span -> Span.finish ~span () ; Ok ()

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -458,7 +458,8 @@ module Export = struct
               Request.write
                 (fun writer -> Request.write_body writer body)
                 request oc ;
-              match Response.read ic with
+              Unix.shutdown fd Unix.SHUTDOWN_SEND ;
+              match try Response.read ic with _ -> `Eof with
               | `Eof ->
                   Ok ""
               | `Invalid x ->

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -23,6 +23,22 @@ type endpoint = Bugtool | Url of string [@@deriving rpcty]
 
 let endpoint_of_string = function "bugtool" -> Bugtool | url -> Url url
 
+module SpanKind = struct
+  type t = Server | Consumer | Client | Producer | Internal [@@deriving rpcty]
+
+  let to_string = function
+    | Server ->
+        "SERVER"
+    | Consumer ->
+        "CONSUMER"
+    | Client ->
+        "CLIENT"
+    | Producer ->
+        "PRODUCER"
+    | Internal ->
+        "INTERNAL"
+end
+
 module SpanContext = struct
   type t = {trace_id: string; span_id: string} [@@deriving rpcty]
 
@@ -42,6 +58,7 @@ module Span = struct
       span_context: SpanContext.t
     ; span_parent: t option
     ; span_name: string
+    ; mutable span_kind: SpanKind.t
     ; span_begin_time: float
     ; mutable span_end_time: float option
     ; mutable tags: (string * string) list
@@ -50,9 +67,11 @@ module Span = struct
 
   let get_span_context t = t.span_context
 
+  let set_span_kind span kind = span.span_kind <- kind
+
   let generate_id n = String.init n (fun _ -> "0123456789abcdef".[Random.int 16])
 
-  let start ?(tags = []) ~name ~parent () =
+  let start ?(tags = []) ~name ~parent ~kind () =
     let trace_id =
       match parent with
       | None ->
@@ -64,9 +83,18 @@ module Span = struct
     let span_context : SpanContext.t = {trace_id; span_id} in
     let span_parent = parent in
     let span_name = name in
+    let span_kind = kind in
     let span_begin_time = Unix.gettimeofday () in
     let span_end_time = None in
-    {span_context; span_parent; span_name; span_begin_time; span_end_time; tags}
+    {
+      span_context
+    ; span_parent
+    ; span_name
+    ; span_kind
+    ; span_begin_time
+    ; span_end_time
+    ; tags
+    }
 
   let finish ?(tags = []) ~span () =
     span.span_end_time <- Some (Unix.gettimeofday ()) ;
@@ -194,6 +222,7 @@ module Tracer = struct
       span_context
     ; span_name
     ; span_parent= None
+    ; span_kind= SpanKind.Client (* This will be the span of the client call*)
     ; span_begin_time= Unix.gettimeofday ()
     ; span_end_time= None
     ; tags= []
@@ -214,14 +243,15 @@ module Tracer = struct
     in
     {name= ""; provider}
 
-  let start ~tracer:t ~name ~parent : (Span.t option, exn) result =
+  let start ?(kind = SpanKind.Internal) ~tracer:t ~name ~parent () :
+      (Span.t option, exn) result =
     let provider = !(t.provider) in
     (* Do not start span if the TracerProvider is diabled*)
     if not provider.enabled then
       Ok None
     else
       let tags = provider.tags in
-      let span = Span.start ~tags ~name ~parent () in
+      let span = Span.start ~tags ~name ~parent ~kind () in
       Spans.add_to_spans ~span ; Ok (Some span)
 
   let finish x : (unit, exn) result =
@@ -402,13 +432,19 @@ module Export = struct
             ; name: string
             ; timestamp: int
             ; duration: int
-            ; kind: string
+            ; kind: string option
             ; localEndpoint: localEndpoint
             ; tags: (string * string) list
           }
           [@@deriving rpcty]
 
           type t_list = t list [@@deriving rpcty]
+
+          let kind_to_zipkin_kind = function
+            | SpanKind.Internal ->
+                None
+            | k ->
+                Some k
 
           let json_of_t_list s =
             Rpcmarshal.marshal t_list.Rpc.Types.ty s |> Jsonrpc.to_string
@@ -433,7 +469,9 @@ module Export = struct
               -. s.span_begin_time
               |> ( *. ) 1000000.
               |> int_of_float
-          ; kind= "SERVER"
+          ; kind=
+              Option.map SpanKind.to_string
+                (ZipkinSpan.kind_to_zipkin_kind s.span_kind)
           ; localEndpoint= {serviceName= "xapi"}
           ; tags
           }
@@ -561,7 +599,8 @@ module Export = struct
             debug "Tracing: Waiting 30s before exporting spans" ;
             Thread.delay 30. ;
             let export_span =
-              Span.start ~name:"export_to_http_server" ~parent:None ()
+              Span.start ~name:"export_to_http_server" ~parent:None
+                ~kind:SpanKind.Client ()
             in
             match export_to_http_server () with
             | Ok () ->

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -11,10 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-let url_file = "/etc/xapi-tracing-url"
-
-let trace_log_dir = "/var/log/dt/zipkinv2/json"
-
 module D = Debug.Make (struct let name = "tracing" end)
 
 open D
@@ -275,12 +271,17 @@ module TracerProvider = struct
         tracer
     | _ ->
         Tracer.get_empty name
+
+  let endpoints_of t = t.config.endpoints
 end
 
 module TracerProviders = struct
   let lock = Mutex.create ()
 
   let tracer_providers = Hashtbl.create 100
+
+  let get_tracer_providers () =
+    Hashtbl.fold (fun _ provider acc -> provider :: acc) tracer_providers []
 
   let find_or_create_tracer ~provider ~name =
     match
@@ -484,7 +485,9 @@ module Export = struct
 
   module Destination = struct
     module File = struct
-      let export ~trace_id ~span_json : (string, exn) result =
+      let trace_log_dir = "/var/log/dt/zipkinv2/json"
+
+      let export ~trace_id ~span_json ~path : (string, exn) result =
         try
           (* TODO: *)
           let host_id = "myhostid" in
@@ -497,8 +500,7 @@ module Export = struct
               unix_time.tm_sec microsec
           in
           let file =
-            String.concat "/" [trace_log_dir; trace_id; "xapi"; host_id; date]
-            ^ ".json"
+            String.concat "/" [path; trace_id; "xapi"; host_id; date] ^ ".json"
           in
           Xapi_stdext_unix.Unixext.mkdir_rec (Filename.dirname file) 0o700 ;
           Xapi_stdext_unix.Unixext.write_string_to_file file span_json ;
@@ -555,42 +557,37 @@ module Export = struct
         with e -> Error e
     end
 
-    let export_to_http_server () =
-      debug "Tracing: About to export to http server" ;
-      let url =
-        Xapi_stdext_unix.Unixext.string_of_file url_file |> String.trim
+    let export_to_endpoint endpoint =
+      let export_span =
+        Span.start ~name:"exporting_spans" ~parent:None ~kind:SpanKind.Internal
+          ()
       in
-      let span_list = Spans.since () in
       try
-        Hashtbl.iter
-          (fun _ span_list ->
-            let zipkin_spans = Content.Json.Zipkinv2.content_of span_list in
-            match Http.export ~span_json:zipkin_spans ~url with
-            | Ok _ ->
-                ()
-            | Error e ->
-                raise e
-          )
-          span_list ;
-        Ok ()
-      with e -> Error e
-
-    let export_to_logs () =
-      debug "Tracing: About to export to dom0 logs" ;
-      let span_list = Spans.since () in
-      try
+        debug "Tracing: About to export" ;
+        let span_list = Spans.since () in
         Hashtbl.iter
           (fun trace_id span_list ->
             let zipkin_spans = Content.Json.Zipkinv2.content_of span_list in
-            match File.export ~trace_id ~span_json:zipkin_spans with
+            match
+              match endpoint with
+              | Url url ->
+                  Http.export ~span_json:zipkin_spans ~url
+              | Bugtool ->
+                  File.export ~trace_id ~span_json:zipkin_spans
+                    ~path:File.trace_log_dir
+            with
             | Ok _ ->
                 ()
             | Error e ->
                 raise e
           )
           span_list ;
-        Ok ()
-      with e -> Error e
+        Span.finish ~span:export_span ()
+      with e ->
+        debug "Tracing: ERROR %s" (Printexc.to_string e) ;
+        Span.finish ~span:export_span
+          ~tags:[("exception.message", Printexc.to_string e)]
+          ()
 
     let _ =
       Thread.create
@@ -598,18 +595,10 @@ module Export = struct
           while true do
             debug "Tracing: Waiting 30s before exporting spans" ;
             Thread.delay 30. ;
-            let export_span =
-              Span.start ~name:"export_to_http_server" ~parent:None
-                ~kind:SpanKind.Client ()
-            in
-            match export_to_http_server () with
-            | Ok () ->
-                Span.finish ~span:export_span ()
-            | Error e ->
-                debug "Tracing: ERROR %s" (Printexc.to_string e) ;
-                Span.finish ~span:export_span
-                  ~tags:[("exception.message", Printexc.to_string e)]
-                  ()
+            TracerProviders.get_tracer_providers ()
+            |> List.iter (fun x ->
+                   TracerProvider.endpoints_of x |> List.iter export_to_endpoint
+               )
           done
         )
         ()

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -84,6 +84,8 @@ module Spans = struct
 
   let spans = Hashtbl.create 100
 
+  let finished_spans = Hashtbl.create 100
+
   let add_to_spans ~(span : Span.t) =
     Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
         let key = span.span_context.trace_id in
@@ -95,11 +97,81 @@ module Spans = struct
               Hashtbl.replace spans key (span :: span_list)
     )
 
+  let mark_finished ~(span : Span.t) =
+    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+        let key = span.span_context.trace_id in
+        match Hashtbl.find_opt spans key with
+        | None ->
+            debug "Span does not exist or already finished"
+        | Some span_list -> (
+            List.filter (fun x -> x != span) span_list
+            |> Hashtbl.replace spans key ;
+            match Hashtbl.find_opt finished_spans key with
+            | None ->
+                Hashtbl.add finished_spans key [span]
+            | Some span_list ->
+                if List.length span_list < 1000 then
+                  Hashtbl.replace finished_spans key (span :: span_list)
+          )
+    )
+
+  let assert_finished x =
+    match x with
+    | None ->
+        false
+    | Some (span : Span.t) -> (
+      match Hashtbl.find_opt finished_spans span.span_context.trace_id with
+      | None ->
+          false
+      | Some span_list ->
+          List.exists (fun x -> x == span) span_list
+    )
+
   let since () =
     Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
-        let copy = Hashtbl.copy spans in
-        Hashtbl.clear spans ; copy
+        let copy = Hashtbl.copy finished_spans in
+        Hashtbl.clear finished_spans ;
+        copy
     )
+
+  module GC = struct
+    let span_timeout = ref 86400.
+
+    let span_timeout_thread = ref None
+
+    let gc_inactive_spans () =
+      Hashtbl.iter
+        (fun _ (spanlist : Span.t list) ->
+          List.iter
+            (fun (span : Span.t) ->
+              let elapsed = Unix.gettimeofday () -. span.span_begin_time in
+              if elapsed > !span_timeout *. 1000000. then
+                debug "Tracing: Span %s timed out, forcibly finishing now"
+                  span.span_context.span_id ;
+              Span.finish ~span
+                ~tags:[("gc_inactive_span_timeout", string_of_float elapsed)]
+                () ;
+              mark_finished ~span
+            )
+            spanlist
+        )
+        spans
+
+    let initialise_thread ~timeout =
+      span_timeout := timeout ;
+      span_timeout_thread :=
+        Some
+          (Thread.create
+             (fun () ->
+               while true do
+                 debug "Tracing: Span garbage collector" ;
+                 Thread.delay !span_timeout ;
+                 gc_inactive_spans ()
+               done
+             )
+             ()
+          )
+  end
 end
 
 type provider_config_t = {
@@ -153,7 +225,13 @@ module Tracer = struct
       Spans.add_to_spans ~span ; Ok (Some span)
 
   let finish x : (unit, exn) result =
-    match x with None -> Ok () | Some span -> Span.finish ~span () ; Ok ()
+    match x with
+    | None ->
+        Ok ()
+    | Some span ->
+        Span.finish ~span () ; Spans.mark_finished ~span ; Ok ()
+
+  let assert_finished x = Spans.assert_finished x
 end
 
 module TracerProvider = struct
@@ -272,6 +350,9 @@ let empty : t = None
 
 let null = function None -> true | Some _ -> false
 
+let enable_span_garbage_collector ?(timeout = 86400.) () =
+  Spans.GC.initialise_thread ~timeout
+
 module Export = struct
   module Content = struct
     module Json = struct
@@ -348,7 +429,6 @@ module Export = struct
           in
           Xapi_stdext_unix.Unixext.mkdir_rec (Filename.dirname file) 0o700 ;
           Xapi_stdext_unix.Unixext.write_string_to_file file span_json ;
-          (* TODO: Ensure file is only written when trace is complete *)
           Ok ""
         with e -> Error e
     end

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -14,6 +14,12 @@
 
 (* Basic types *)
 
+module SpanKind : sig
+  type t = Server | Consumer | Client | Producer | Internal
+
+  val to_string : t -> string
+end
+
 module SpanContext : sig
   type t
 
@@ -26,6 +32,8 @@ module Span : sig
   type t
 
   val get_span_context : t -> SpanContext.t
+
+  val set_span_kind : t -> SpanKind.t -> unit
 end
 
 module Tracer : sig
@@ -34,9 +42,11 @@ module Tracer : sig
   val span_of_span_context : SpanContext.t -> string -> Span.t
 
   val start :
-       tracer:t
+       ?kind:SpanKind.t
+    -> tracer:t
     -> name:string
     -> parent:Span.t option
+    -> unit
     -> (Span.t option, exn) result
 
   val finish : Span.t option -> (unit, exn) result

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -14,7 +14,27 @@
 
 (* Basic types *)
 
-type blob
+module SpanContext : sig
+  type t
+
+  val to_traceparent : t -> string
+
+  val of_traceparent : string -> t option
+end
+
+module Span : sig
+  type t
+
+  val get_span_context : t -> SpanContext.t
+end
+
+module Tracer : sig
+  type t
+
+  val span_of_span_context : SpanContext.t -> string -> Span.t
+end
+
+type blob = Span.t
 
 type t = blob option
 

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -1,0 +1,35 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* Basic types *)
+
+type blob
+
+type t = blob option
+
+val empty : t
+
+val null : t -> bool
+
+val t_of_string : string -> t
+
+val string_of_t : t -> string
+
+val json_of_t : t -> string option
+
+(* Create spans *)
+
+val start : name:string -> parent:t -> (t, exn) result
+
+val finish : t -> (unit, exn) result

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -40,6 +40,8 @@ module Tracer : sig
     -> (Span.t option, exn) result
 
   val finish : Span.t option -> (unit, exn) result
+
+  val assert_finished : Span.t option -> bool
 end
 
 module TracerProvider : sig
@@ -78,4 +80,4 @@ val string_of_t : t -> string
 
 val json_of_t : t -> string option
 
-(* Create spans *)
+val enable_span_garbage_collector : ?timeout:float -> unit -> unit

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -32,6 +32,36 @@ module Tracer : sig
   type t
 
   val span_of_span_context : SpanContext.t -> string -> Span.t
+
+  val start :
+       tracer:t
+    -> name:string
+    -> parent:Span.t option
+    -> (Span.t option, exn) result
+
+  val finish : Span.t option -> (unit, exn) result
+end
+
+module TracerProvider : sig
+  type t
+
+  val find_tracer : provider:t -> name:string -> Tracer.t
+end
+
+module TracerProviders : sig
+  val find_or_create_tracer :
+    provider:TracerProvider.t -> name:string -> Tracer.t
+
+  val set_default :
+       tags:(string * string) list
+    -> endpoints:string list
+    -> processors:string list
+    -> filters:string list
+    -> unit
+
+  val get_default : unit -> (TracerProvider.t, exn) result
+
+  val get_default_tracer : name:string -> Tracer.t
 end
 
 type blob = Span.t
@@ -49,7 +79,3 @@ val string_of_t : t -> string
 val json_of_t : t -> string option
 
 (* Create spans *)
-
-val start : name:string -> parent:t -> (t, exn) result
-
-val finish : t -> (unit, exn) result

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -81,3 +81,11 @@ val string_of_t : t -> string
 val json_of_t : t -> string option
 
 val enable_span_garbage_collector : ?timeout:float -> unit -> unit
+
+module Export : sig
+  module Destination : sig
+    module Http : sig
+      val export : span_json:string -> url:string -> (string, exn) result
+    end
+  end
+end

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -61,6 +61,16 @@ module TracerProviders : sig
     -> filters:string list
     -> unit
 
+  val set :
+       ?status:bool
+    -> ?tags:(string * string) list
+    -> ?endpoints:string list
+    -> ?filters:string list
+    -> ?processors:string list
+    -> name_label:string
+    -> unit
+    -> unit
+
   val get_default : unit -> (TracerProvider.t, exn) result
 
   val get_default_tracer : name:string -> Tracer.t

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -42,6 +42,7 @@
     xapi-stdext-threads
     xapi-stdext-unix
     xapi-test-utils
+    xapi-tracing
     xapi-types
     xapi-stdext-pervasives
     xapi-xenopsd
@@ -83,6 +84,7 @@
     xapi-idl.xen
     xapi_internal
     xapi-test-utils
+    xapi-tracing
     xapi-types
     xapi-stdext-threads
     xml-light2

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -46,6 +46,7 @@ let () =
      ; ("Test_storage_migrate_state", Test_storage_migrate_state.test)
      ; ("Test_bios_strings", Test_bios_strings.test)
      ; ("Test_certificates", Test_certificates.test)
+     ; ("Test_tracing", Test_tracing.test)
      ]
     @ Test_guest_agent.tests
     @ Test_nm.tests

--- a/ocaml/tests/test_tracing.ml
+++ b/ocaml/tests/test_tracing.ml
@@ -1,0 +1,54 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+open Tracing
+
+let hashtable_test : bool =
+  enable_span_garbage_collector ~timeout:3. () ;
+  let task_name = "test_task" in
+  let tracer = TracerProviders.get_default_tracer ~name:task_name in
+  let span0 = Tracer.start ~tracer ~name:task_name ~parent:None in
+  let span1 = Tracer.start ~tracer ~name:task_name ~parent:None in
+  let span2 = Tracer.start ~tracer ~name:task_name ~parent:None in
+  let span3 = Tracer.start ~tracer ~name:task_name ~parent:None in
+  try
+    List.iter
+      (fun s ->
+        match s with
+        | Ok span ->
+            if Tracer.assert_finished span then
+              failwith "unfinished span in finished_spans" ;
+            let _ = Tracer.finish span in
+            if not (Tracer.assert_finished span) then
+              failwith "finished span not in finished_spans" ;
+            ()
+        | Error _ ->
+            failwith "span failed"
+      )
+      [span0; span1; span2] ;
+    Unix.sleep 5 ;
+    match span3 with
+    | Ok span ->
+        if not (Tracer.assert_finished span) then
+          failwith "timed-out span not in finished_spans"
+        else
+          true
+    | Error _ ->
+        failwith "span failed"
+  with Failure _ -> false
+
+let test_tracing () =
+  let success = hashtable_test in
+  Alcotest.(check bool) "created spans in the correct hash table" true success
+
+let test = [("test_tracing", `Quick, test_tracing)]

--- a/ocaml/tests/test_tracing.ml
+++ b/ocaml/tests/test_tracing.ml
@@ -17,10 +17,10 @@ let hashtable_test : bool =
   enable_span_garbage_collector ~timeout:3. () ;
   let task_name = "test_task" in
   let tracer = TracerProviders.get_default_tracer ~name:task_name in
-  let span0 = Tracer.start ~tracer ~name:task_name ~parent:None in
-  let span1 = Tracer.start ~tracer ~name:task_name ~parent:None in
-  let span2 = Tracer.start ~tracer ~name:task_name ~parent:None in
-  let span3 = Tracer.start ~tracer ~name:task_name ~parent:None in
+  let span0 = Tracer.start ~tracer ~name:task_name ~parent:None () in
+  let span1 = Tracer.start ~tracer ~name:task_name ~parent:None () in
+  let span2 = Tracer.start ~tracer ~name:task_name ~parent:None () in
+  let span3 = Tracer.start ~tracer ~name:task_name ~parent:None () in
   try
     List.iter
       (fun s ->

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1306,6 +1306,11 @@ let gen_cmds rpc session_id =
           ]
           rpc session_id
       )
+    ; Client.Tracing.(
+        mk get_all_records_where get_by_uuid tracing_record "tracing" []
+          ["uuid"; "name_label"; "endpoints"; "status"]
+          rpc session_id
+      )
     ; Client.VTPM.(
         mk get_all_records_where get_by_uuid vtpm_record "vtpm" []
           ["uuid"; "vm"; "profile"] rpc session_id

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5231,3 +5231,119 @@ let vtpm_record rpc session_id vtpm =
           ()
       ]
   }
+
+let tracing_record rpc session_id tracing =
+  let _ref = ref tracing in
+  let empty_record =
+    ToGet (fun () -> Client.Tracing.get_record ~rpc ~session_id ~self:!_ref)
+  in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  {
+    setref=
+      (fun r ->
+        _ref := r ;
+        record := empty_record
+      )
+  ; setrefrec=
+      (fun (a, b) ->
+        _ref := a ;
+        record := Got b
+      )
+  ; record= x
+  ; getref= (fun () -> !_ref)
+  ; fields=
+      [
+        make_field ~name:"uuid" ~get:(fun () -> (x ()).API.tracing_uuid) ()
+      ; make_field ~name:"hosts"
+          ~get:(fun () ->
+            List.map get_uuid_from_ref (x ()).API.tracing_hosts
+            |> String.concat ","
+            |> fun s -> if s = "" then "all" else ""
+          )
+          ()
+      ; make_field ~name:"name_label"
+          ~get:(fun () -> (x ()).API.tracing_name_label)
+          ()
+      ; make_field ~name:"tags"
+          ~get:(fun () ->
+            List.map
+              (fun (k, v) -> Printf.sprintf "%s : %s" k v)
+              (x ()).API.tracing_tags
+            |> String.concat ","
+            |> fun s -> if s = "" then "none" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s
+            |> List.filter_map (fun kv ->
+                   match String.split_on_char ':' kv with
+                   | [k; _] when List.mem k ["host"; "pool"; "host name"] ->
+                       None (* Reserved Tags*)
+                   | [k; v] ->
+                       Some (k, v)
+                   | _ ->
+                       None
+               )
+            |> fun tags ->
+            Client.Tracing.set_tags ~rpc ~session_id ~self:tracing ~tags
+          )
+          ()
+      ; make_field ~name:"endpoints"
+          ~get:(fun () ->
+            (x ()).API.tracing_endpoints |> String.concat ", " |> fun s ->
+            if s = "" then "none" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s |> List.filter (( <> ) "none")
+            |> fun endpoints ->
+            Client.Tracing.set_endpoints ~rpc ~session_id ~self:tracing
+              ~endpoints
+          )
+          ()
+      ; make_field ~name:"components"
+          ~get:(fun () ->
+            (x ()).API.tracing_components |> String.concat ", " |> fun s ->
+            if s = "" then "all" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s |> List.filter (( <> ) "all")
+            |> fun components ->
+            Client.Tracing.set_components ~rpc ~session_id ~self:tracing
+              ~components
+          )
+          ()
+      ; make_field ~name:"filters"
+          ~get:(fun () ->
+            (x ()).API.tracing_filters |> String.concat ", " |> fun s ->
+            if s = "" then "all" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s |> List.filter (( <> ) "all")
+            |> fun filters ->
+            Client.Tracing.set_filters ~rpc ~session_id ~self:tracing ~filters
+          )
+          ()
+      ; make_field ~name:"processors"
+          ~get:(fun () ->
+            (x ()).API.tracing_processors |> String.concat ", " |> fun s ->
+            if s = "" then "none" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s |> List.filter (( <> ) "none")
+            |> fun processors ->
+            Client.Tracing.set_processors ~rpc ~session_id ~self:tracing
+              ~processors
+          )
+          ()
+      ; make_field ~name:"status"
+          ~get:(fun () ->
+            (x ()).API.tracing_status |> fun b ->
+            if b then "enabled" else "disabled"
+          )
+          ~set:(fun s ->
+            s = "enabled" |> fun status ->
+            Client.Tracing.set_status ~rpc ~session_id ~self:tracing ~status
+          )
+          ()
+      ]
+  }

--- a/ocaml/xapi-idl/lib/task_server.ml
+++ b/ocaml/xapi-idl/lib/task_server.ml
@@ -80,6 +80,7 @@ functor
       ; id: id  (** unique task id *)
       ; ctime: float  (** created timestamp *)
       ; dbg: string  (** token sent by client *)
+      ; mutable tracing: string option
       ; mutable state: Interface.Task.state  (** current completion state *)
       ; mutable subtasks: (string * Interface.Task.state) list
             (** one level of "subtasks" *)
@@ -126,12 +127,22 @@ functor
 
     (* [add dbg f] creates a fresh [t], registers and returns it *)
     let add tasks dbg (f : task_handle -> Interface.Task.async_result option) =
+      let dbg, tracing =
+        match String.index_opt dbg '\n' with
+        | Some i ->
+            ( String.sub dbg 0 i
+            , Some (String.sub dbg (i + 1) (String.length dbg - i - 1))
+            )
+        | None ->
+            (dbg, None)
+      in
       let t =
         {
           tasks
         ; id= next_task_id ()
         ; ctime= Unix.gettimeofday ()
         ; dbg
+        ; tracing
         ; state= Interface.Task.Pending 0.
         ; subtasks= []
         ; f
@@ -317,4 +328,8 @@ functor
             true
       in
       if already_finished then task_finished t
+
+    let tracing t = t.tracing
+
+    let set_tracing t tracing = t.tracing <- tracing
   end

--- a/ocaml/xapi-idl/lib/task_server.mli
+++ b/ocaml/xapi-idl/lib/task_server.mli
@@ -118,4 +118,8 @@ module Task : functor (Interface : INTERFACE) -> sig
      Useful for asynchronous tasks that we don't wait for.
   *)
   val destroy_on_finish : task_handle -> unit
+
+  val tracing : task_handle -> string option
+
+  val set_tracing : task_handle -> string option -> unit
 end

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -128,6 +128,7 @@ module Actions = struct
   module Certificate = Certificates
   module Diagnostics = Xapi_diagnostics
   module Repository = Repository
+  module Tracing = Xapi_tracing
 end
 
 (** Use the server functor to make an XML-RPC dispatcher. *)

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -48,10 +48,22 @@ type t = {
   ; origin: origin
   ; database: Db_ref.t
   ; dbg: string
+  ; mutable tracing: Tracing.t
   ; client: (http_t * Ipaddr.t) option
   ; mutable test_rpc: (Rpc.call -> Rpc.response) option
   ; mutable test_clusterd_rpc: (Rpc.call -> Rpc.response) option
 }
+
+let complete_tracing __context =
+  ( match Tracing.finish __context.tracing with
+  | Ok () ->
+      ()
+  | Error e ->
+      R.warn "Failed to complete tracing: %s" (Printexc.to_string e)
+  ) ;
+  __context.tracing <- Tracing.empty
+
+let tracing_of __context = __context.tracing
 
 let get_session_id x =
   match x.session_id with
@@ -109,6 +121,7 @@ let get_initial () =
   ; origin= Internal
   ; database= default_database ()
   ; dbg= "initial_task"
+  ; tracing= Tracing.empty
   ; client= None
   ; test_rpc= None
   ; test_clusterd_rpc= None
@@ -237,6 +250,17 @@ let from_forwarded_task ?(http_other_config = []) ?session_id
   let dbg = make_dbg http_other_config task_name task_id in
   info "task %s forwarded%s" dbg
     (trackid_of_session ~with_brackets:true ~prefix:" " session_id) ;
+  let tracing =
+    let open Tracing in
+    (* Set parent based on trace context from forwarded call instead! *)
+    let parent = empty in
+    match start ~name:task_name ~parent with
+    | Ok x ->
+        x
+    | Error e ->
+        R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+        None
+  in
   {
     session_id
   ; task_id
@@ -244,6 +268,7 @@ let from_forwarded_task ?(http_other_config = []) ?session_id
   ; origin
   ; database= default_database ()
   ; dbg
+  ; tracing
   ; client
   ; test_rpc= None
   ; test_clusterd_rpc= None
@@ -282,6 +307,18 @@ let make ?(http_other_config = []) ?(quiet = false) ?subtask_of ?session_id
             " by task " ^ make_dbg [] "" subtask_of
         )
   ) ;
+  let tracing =
+    let open Tracing in
+    (* Set parent based on incoming trace context instead! *)
+    let parent = empty in
+    match start ~name:task_name ~parent with
+    | Ok x ->
+        R.debug "Started trace: %s" (string_of_t x) ;
+        x
+    | Error e ->
+        R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+        None
+  in
   {
     session_id
   ; database
@@ -289,6 +326,7 @@ let make ?(http_other_config = []) ?(quiet = false) ?subtask_of ?session_id
   ; origin
   ; forwarded_task= false
   ; dbg
+  ; tracing
   ; client
   ; test_rpc= None
   ; test_clusterd_rpc= None
@@ -298,7 +336,20 @@ let make_subcontext ~__context ?task_in_database task_name =
   let session_id = __context.session_id in
   let subtask_of = __context.task_id in
   let subcontext = make ~subtask_of ?session_id ?task_in_database task_name in
-  {subcontext with client= __context.client}
+  let tracing =
+    let open Tracing in
+    let parent = __context.tracing in
+    if null parent then
+      empty
+    else (* only create a tracing if we're part of a tree *)
+      match Tracing.start ~name:task_name ~parent with
+      | Ok x ->
+          x
+      | Error e ->
+          R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+          None
+  in
+  {subcontext with client= __context.client; tracing}
 
 let get_http_other_config http_req =
   let http_other_config_hdr = "x-http-other-config-" in
@@ -361,3 +412,15 @@ let get_client_ip context =
 
 let get_user_agent context =
   match context.origin with Internal -> None | Http (rq, _) -> rq.user_agent
+
+let with_tracing context name f =
+  let parent = context.tracing in
+  match Tracing.start ~name ~parent with
+  | Ok span_context ->
+      let new_context = {context with tracing= span_context} in
+      let result = f new_context in
+      let _ = Tracing.finish span_context in
+      result
+  | Error e ->
+      R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+      f context

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -148,6 +148,13 @@ let __destroy_task : (__context:t -> API.ref_task -> unit) ref =
 
 let string_of_task __context = __context.dbg
 
+let string_of_task_and_tracing __context =
+  match Tracing.json_of_t __context.tracing with
+  | None ->
+      __context.dbg
+  | Some tracing ->
+      __context.dbg ^ "\n" ^ tracing
+
 let check_for_foreign_database ~__context =
   match __context.session_id with
   | Some sid -> (

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -55,7 +55,7 @@ type t = {
 }
 
 let complete_tracing __context =
-  ( match Tracing.finish __context.tracing with
+  ( match Tracing.Tracer.finish __context.tracing with
   | Ok () ->
       ()
   | Error e ->
@@ -247,7 +247,8 @@ let tracing_of_origin (origin : origin) task_name =
   match origin with
   | Http (req, _) ->
       let traceparent_opt = req.Http.Request.traceparent in
-      R.debug "Received traceparent header (tracing_of_origin) = %s" (Option.value ~default:"None" traceparent_opt);
+      R.debug "Received traceparent header (tracing_of_origin) = %s"
+        (Option.value ~default:"None" traceparent_opt) ;
       let* traceparent = traceparent_opt in
       let* span_context = SpanContext.of_traceparent traceparent in
       let span = Tracer.span_of_span_context span_context task_name in
@@ -274,7 +275,9 @@ let from_forwarded_task ?(http_other_config = []) ?session_id
   let tracing =
     let open Tracing in
     let parent = tracing_of_origin origin task_name in
-    match start ~name:task_name ~parent with
+    let tracer = TracerProviders.get_default_tracer ~name:task_name in
+    let span = Tracer.start ~tracer ~name:task_name ~parent in
+    match span with
     | Ok x ->
         x
     | Error e ->
@@ -330,7 +333,9 @@ let make ?(http_other_config = []) ?(quiet = false) ?subtask_of ?session_id
   let tracing =
     let open Tracing in
     let parent = tracing_of_origin origin task_name in
-    match start ~name:task_name ~parent with
+    let tracer = TracerProviders.get_default_tracer ~name:task_name in
+    let span = Tracer.start ~tracer ~name:task_name ~parent in
+    match span with
     | Ok x ->
         R.debug "Started trace: %s" (string_of_t x) ;
         x
@@ -361,7 +366,9 @@ let make_subcontext ~__context ?task_in_database task_name =
     if null parent then
       empty
     else (* only create a tracing if we're part of a tree *)
-      match Tracing.start ~name:task_name ~parent with
+      let tracer = TracerProviders.get_default_tracer ~name:task_name in
+      let span = Tracer.start ~tracer ~name:task_name ~parent in
+      match span with
       | Ok x ->
           x
       | Error e ->
@@ -433,12 +440,15 @@ let get_user_agent context =
   match context.origin with Internal -> None | Http (rq, _) -> rq.user_agent
 
 let with_tracing context name f =
+  let open Tracing in
   let parent = context.tracing in
-  match Tracing.start ~name ~parent with
+  let tracer = TracerProviders.get_default_tracer ~name in
+  let span = Tracer.start ~tracer ~name ~parent in
+  match span with
   | Ok span_context ->
       let new_context = {context with tracing= span_context} in
       let result = f new_context in
-      let _ = Tracing.finish span_context in
+      let _ = Tracing.Tracer.finish span_context in
       result
   | Error e ->
       R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -241,6 +241,20 @@ let make_dbg http_other_config task_name task_id =
       (if task_name = "" then "" else " ")
       (Ref.really_pretty_and_small task_id)
 
+let tracing_of_origin (origin : origin) task_name =
+  let open Tracing in
+  let ( let* ) = Option.bind in
+  match origin with
+  | Http (req, _) ->
+      let traceparent_opt = req.Http.Request.traceparent in
+      R.debug "Received traceparent header (tracing_of_origin) = %s" (Option.value ~default:"None" traceparent_opt);
+      let* traceparent = traceparent_opt in
+      let* span_context = SpanContext.of_traceparent traceparent in
+      let span = Tracer.span_of_span_context span_context task_name in
+      Some span
+  | _ ->
+      empty
+
 (** constructors *)
 
 let from_forwarded_task ?(http_other_config = []) ?session_id
@@ -259,8 +273,7 @@ let from_forwarded_task ?(http_other_config = []) ?session_id
     (trackid_of_session ~with_brackets:true ~prefix:" " session_id) ;
   let tracing =
     let open Tracing in
-    (* Set parent based on trace context from forwarded call instead! *)
-    let parent = empty in
+    let parent = tracing_of_origin origin task_name in
     match start ~name:task_name ~parent with
     | Ok x ->
         x
@@ -316,8 +329,7 @@ let make ?(http_other_config = []) ?(quiet = false) ?subtask_of ?session_id
   ) ;
   let tracing =
     let open Tracing in
-    (* Set parent based on incoming trace context instead! *)
-    let parent = empty in
+    let parent = tracing_of_origin origin task_name in
     match start ~name:task_name ~parent with
     | Ok x ->
         R.debug "Started trace: %s" (string_of_t x) ;

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -276,7 +276,10 @@ let from_forwarded_task ?(http_other_config = []) ?session_id
     let open Tracing in
     let parent = tracing_of_origin origin task_name in
     let tracer = TracerProviders.get_default_tracer ~name:task_name in
-    let span = Tracer.start ~tracer ~name:task_name ~parent in
+    let kind =
+      match parent with None -> SpanKind.Internal | Some _ -> SpanKind.Server
+    in
+    let span = Tracer.start ~kind ~tracer ~name:task_name ~parent () in
     match span with
     | Ok x ->
         x
@@ -334,7 +337,10 @@ let make ?(http_other_config = []) ?(quiet = false) ?subtask_of ?session_id
     let open Tracing in
     let parent = tracing_of_origin origin task_name in
     let tracer = TracerProviders.get_default_tracer ~name:task_name in
-    let span = Tracer.start ~tracer ~name:task_name ~parent in
+    let kind =
+      match parent with None -> SpanKind.Internal | Some _ -> SpanKind.Server
+    in
+    let span = Tracer.start ~kind ~tracer ~name:task_name ~parent () in
     match span with
     | Ok x ->
         R.debug "Started trace: %s" (string_of_t x) ;
@@ -367,7 +373,7 @@ let make_subcontext ~__context ?task_in_database task_name =
       empty
     else (* only create a tracing if we're part of a tree *)
       let tracer = TracerProviders.get_default_tracer ~name:task_name in
-      let span = Tracer.start ~tracer ~name:task_name ~parent in
+      let span = Tracer.start ~tracer ~name:task_name ~parent () in
       match span with
       | Ok x ->
           x
@@ -443,7 +449,7 @@ let with_tracing context name f =
   let open Tracing in
   let parent = context.tracing in
   let tracer = TracerProviders.get_default_tracer ~name in
-  let span = Tracer.start ~tracer ~name ~parent in
+  let span = Tracer.start ~tracer ~name ~parent () in
   match span with
   | Ok span_context ->
       let new_context = {context with tracing= span_context} in

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -76,6 +76,8 @@ val forwarded_task : t -> bool
 
 val string_of_task : t -> string
 
+val string_of_task_and_tracing : t -> string
+
 val task_in_database : t -> bool
 (** [task_in_database __context] indicates if [get_task_id __context] corresponds to a task stored in database or
     to a dummy task. *)

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -139,3 +139,9 @@ val get_client : t -> string option
 val get_client_ip : t -> string option
 
 val get_user_agent : t -> string option
+
+val complete_tracing : t -> unit
+
+val tracing_of : t -> Tracing.t
+
+val with_tracing : t -> string -> (t -> 'a) -> 'a

--- a/ocaml/xapi/dbsync.ml
+++ b/ocaml/xapi/dbsync.ml
@@ -48,9 +48,9 @@ let create_host_metrics ~__context =
     )
     (Db.Host.get_all ~__context)
 
-let update_env () =
-  Server_helpers.exec_with_new_task "dbsync (update_env)" ~task_in_database:true
-    (fun __context ->
+let update_env ~__context =
+  Server_helpers.exec_with_subtask ~__context "dbsync (update_env)"
+    ~task_in_database:true (fun ~__context ->
       let other_config =
         match Db.Pool.get_all ~__context with
         | [pool] ->
@@ -73,8 +73,8 @@ let update_env () =
       if not (Pool_role.is_master ()) then resync_dom0_config_files ()
   )
 
-let setup () =
-  try update_env ()
+let setup ~__context =
+  try update_env ~__context
   with exn ->
     Backtrace.is_important exn ;
     debug "dbsync caught an exception: %s" (ExnHelper.string_of_exn exn) ;

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -144,6 +144,7 @@
     xapi-stdext-threads
     xapi-stdext-unix
     xapi-stdext-zerocheck
+    xapi-tracing
     xapi-xenopsd
     xenstore_transport.unix
     xml-light2

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -402,10 +402,11 @@ let make_rpc ~__context rpc : Rpc.response =
   in
 
   let traceparent =
+    let open Tracing in
     Option.map
-      (fun context ->
-        Tracing.Span.get_span_context context
-        |> Tracing.SpanContext.to_traceparent
+      (fun span ->
+        let _ = Span.set_span_kind span SpanKind.Client in
+        Span.get_span_context span |> SpanContext.to_traceparent
       )
       (Context.tracing_of __context)
   in

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -388,7 +388,9 @@ let update_pif_addresses ~__context =
 let make_rpc ~__context rpc : Rpc.response =
   let subtask_of = Ref.string_of (Context.get_task_id __context) in
   let open Xmlrpc_client in
-  let http = xmlrpc ~subtask_of ~version:"1.1" "/" in
+  let http =
+    xmlrpc ~subtask_of ~version:"1.1" "/" ~tracing:(Context.tracing_of __context)
+  in
   let transport =
     if Pool_role.is_master () then
       Unix Xapi_globs.unix_domain_socket
@@ -400,19 +402,6 @@ let make_rpc ~__context rpc : Rpc.response =
         , !Constants.https_port
         )
   in
-
-  let traceparent =
-    let open Tracing in
-    Option.map
-      (fun span ->
-        let _ = Span.set_span_kind span SpanKind.Client in
-        Span.get_span_context span |> SpanContext.to_traceparent
-      )
-      (Context.tracing_of __context)
-  in
-  debug "Setting traceparent header (make_rpc) = %s"
-    (Option.value ~default:"None" traceparent) ;
-  let http = {http with traceparent} in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"xapi" ~transport ~http rpc
 
 let make_timeboxed_rpc ~__context timeout rpc : Rpc.response =

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -400,6 +400,17 @@ let make_rpc ~__context rpc : Rpc.response =
         , !Constants.https_port
         )
   in
+
+  let traceparent =
+    Option.map
+      (fun context ->
+        Tracing.Span.get_span_context context
+        |> Tracing.SpanContext.to_traceparent
+      )
+      (Context.tracing_of __context)
+  in
+  debug "Setting traceparent header (make_rpc) = %s" (Option.value ~default:"None" traceparent) ;
+  let http = {http with traceparent} in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"xapi" ~transport ~http rpc
 
 let make_timeboxed_rpc ~__context timeout rpc : Rpc.response =

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -409,7 +409,8 @@ let make_rpc ~__context rpc : Rpc.response =
       )
       (Context.tracing_of __context)
   in
-  debug "Setting traceparent header (make_rpc) = %s" (Option.value ~default:"None" traceparent) ;
+  debug "Setting traceparent header (make_rpc) = %s"
+    (Option.value ~default:"None" traceparent) ;
   let http = {http with traceparent} in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"xapi" ~transport ~http rpc
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -62,10 +62,11 @@ let remote_rpc_no_retry _context hostname (task_opt : API.ref_task option) xml =
     xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.0" "/"
   in
   let traceparent =
+    let open Tracing in
     Option.map
-      (fun context ->
-        Tracing.Span.get_span_context context
-        |> Tracing.SpanContext.to_traceparent
+      (fun span ->
+        let _ = Span.set_span_kind span SpanKind.Client in
+        Span.get_span_context span |> SpanContext.to_traceparent
       )
       (Context.tracing_of _context)
   in
@@ -90,10 +91,11 @@ let remote_rpc_retry _context hostname (task_opt : API.ref_task option) xml =
     xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.1" "/"
   in
   let traceparent =
+    let open Tracing in
     Option.map
-      (fun context ->
-        Tracing.Span.get_span_context context
-        |> Tracing.SpanContext.to_traceparent
+      (fun span ->
+        let _ = Span.set_span_kind span SpanKind.Client in
+        Span.get_span_context span |> SpanContext.to_traceparent
       )
       (Context.tracing_of _context)
   in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -651,6 +651,14 @@ functor
           Ref.string_of repository
       with _ -> "invalid"
 
+    let tracing_uuid ~__context tracing =
+      try
+        if Pool_role.is_master () then
+          Db.Tracing.get_uuid ~__context ~self:tracing
+        else
+          Ref.string_of tracing
+      with _ -> "invalid"
+
     module Session = struct
       include Local.Session
 
@@ -6475,5 +6483,106 @@ functor
             Client.Repository.apply_livepatch ~rpc ~session_id ~host ~component
               ~base_build_id ~base_version ~base_release ~to_version ~to_release
         )
+    end
+
+    module Tracing = struct
+      let do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn =
+        let localhost = Helpers.get_localhost ~__context in
+        if Helpers.is_pool_master ~__context ~host:localhost then (
+          db_fn () ;
+          (* Option.iter
+             (fun status -> Db.Tracing.set_status ~__context ~self ~value:status)
+             status ; *)
+          let hosts =
+            match Db.Tracing.get_hosts ~__context ~self with
+            | [] ->
+                Db.Host.get_all ~__context
+            | hosts ->
+                hosts
+          in
+          let hosts, local = List.partition (( <> ) localhost) hosts in
+          List.iter
+            (fun host -> do_op_on ~__context ~local_fn ~host client_fn)
+            hosts ;
+          List.iter (fun _ -> local_fn ~__context) local
+        ) else
+          local_fn ~__context ;
+        ()
+
+      let set_status ~__context ~self ~status =
+        info "Tracing.set_status: self=%s status=%B"
+          (tracing_uuid ~__context self)
+          status ;
+        let local_fn = Local.Tracing.set_status ~self ~status in
+        let client_fn session_id rpc =
+          Client.Tracing.set_status ~rpc ~session_id ~self ~status
+        in
+        let db_fn () = Db.Tracing.set_status ~__context ~self ~value:status in
+        do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
+
+      let set_tags ~__context ~self ~tags =
+        let pool =
+          Db.Pool.get_uuid ~__context ~self:(Helpers.get_pool ~__context)
+        in
+        let tags = ("pool", pool) :: tags in
+        info "Tracing.set_tags: self=%s tags=%s"
+          (tracing_uuid ~__context self)
+          (List.map (fun (k, v) -> k ^ ":" ^ v) tags |> String.concat ",") ;
+        let local_fn = Local.Tracing.set_tags ~self ~tags in
+        let client_fn session_id rpc =
+          Client.Tracing.set_tags ~rpc ~session_id ~self ~tags
+        in
+        let db_fn () = Db.Tracing.set_tags ~__context ~self ~value:tags in
+        do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
+
+      let set_endpoints ~__context ~self ~endpoints =
+        info "Tracing.set_endpoints: self=%s endpoints=%s"
+          (tracing_uuid ~__context self)
+          (endpoints |> String.concat ",") ;
+        let local_fn = Local.Tracing.set_endpoints ~self ~endpoints in
+        let client_fn session_id rpc =
+          Client.Tracing.set_endpoints ~rpc ~session_id ~self ~endpoints
+        in
+        let db_fn () =
+          Db.Tracing.set_endpoints ~__context ~self ~value:endpoints
+        in
+        do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
+
+      let set_components ~__context ~self ~components =
+        info "Tracing.set_components: self=%s components=%s"
+          (tracing_uuid ~__context self)
+          (components |> String.concat ",") ;
+        let local_fn = Local.Tracing.set_components ~self ~components in
+        let client_fn session_id rpc =
+          Client.Tracing.set_components ~rpc ~session_id ~self ~components
+        in
+        let db_fn () =
+          Db.Tracing.set_components ~__context ~self ~value:components
+        in
+        do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
+
+      let set_filters ~__context ~self ~filters =
+        info "Tracing.set_filters: self=%s filters=%s"
+          (tracing_uuid ~__context self)
+          (filters |> String.concat ",") ;
+        let local_fn = Local.Tracing.set_filters ~self ~filters in
+        let client_fn session_id rpc =
+          Client.Tracing.set_filters ~rpc ~session_id ~self ~filters
+        in
+        let db_fn () = Db.Tracing.set_filters ~__context ~self ~value:filters in
+        do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
+
+      let set_processors ~__context ~self ~processors =
+        info "Tracing.set_processors: self=%s processors=%s"
+          (tracing_uuid ~__context self)
+          (processors |> String.concat ",") ;
+        let local_fn = Local.Tracing.set_processors ~self ~processors in
+        let client_fn session_id rpc =
+          Client.Tracing.set_processors ~rpc ~session_id ~self ~processors
+        in
+        let db_fn () =
+          Db.Tracing.set_processors ~__context ~self ~value:processors
+        in
+        do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
     end
   end

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -59,20 +59,12 @@ let remote_rpc_no_retry _context hostname (task_opt : API.ref_task option) xml =
       )
   in
   let http =
-    xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.0" "/"
+    xmlrpc
+      ?task_id:(Option.map Ref.string_of task_opt)
+      ~version:"1.0"
+      ~tracing:(Context.tracing_of _context)
+      "/"
   in
-  let traceparent =
-    let open Tracing in
-    Option.map
-      (fun span ->
-        let _ = Span.set_span_kind span SpanKind.Client in
-        Span.get_span_context span |> SpanContext.to_traceparent
-      )
-      (Context.tracing_of _context)
-  in
-  debug "Setting traceparent header (remote_rpc_no_retry) = %s"
-    (Option.value ~default:"None" traceparent) ;
-  let http = {http with traceparent} in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
 (* Use HTTP 1.1, use the stunnel cache and pre-verify the connection *)
@@ -88,20 +80,12 @@ let remote_rpc_retry _context hostname (task_opt : API.ref_task option) xml =
       )
   in
   let http =
-    xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.1" "/"
+    xmlrpc
+      ?task_id:(Option.map Ref.string_of task_opt)
+      ~version:"1.1"
+      ~tracing:(Context.tracing_of _context)
+      "/"
   in
-  let traceparent =
-    let open Tracing in
-    Option.map
-      (fun span ->
-        let _ = Span.set_span_kind span SpanKind.Client in
-        Span.get_span_context span |> SpanContext.to_traceparent
-      )
-      (Context.tracing_of _context)
-  in
-  debug "Setting traceparent header (remote_rpc_no_retry) = %s"
-    (Option.value ~default:"None" traceparent) ;
-  let http = {http with traceparent} in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
 let call_slave_with_session remote_rpc_fn __context host

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -61,6 +61,17 @@ let remote_rpc_no_retry _context hostname (task_opt : API.ref_task option) xml =
   let http =
     xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.0" "/"
   in
+  let traceparent =
+    Option.map
+      (fun context ->
+        Tracing.Span.get_span_context context
+        |> Tracing.SpanContext.to_traceparent
+      )
+      (Context.tracing_of _context)
+  in
+  debug "Setting traceparent header (remote_rpc_no_retry) = %s"
+    (Option.value ~default:"None" traceparent) ;
+  let http = {http with traceparent} in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
 (* Use HTTP 1.1, use the stunnel cache and pre-verify the connection *)
@@ -78,6 +89,17 @@ let remote_rpc_retry _context hostname (task_opt : API.ref_task option) xml =
   let http =
     xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.1" "/"
   in
+  let traceparent =
+    Option.map
+      (fun context ->
+        Tracing.Span.get_span_context context
+        |> Tracing.SpanContext.to_traceparent
+      )
+      (Context.tracing_of _context)
+  in
+  debug "Setting traceparent header (remote_rpc_no_retry) = %s"
+    (Option.value ~default:"None" traceparent) ;
+  let http = {http with traceparent} in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
 let call_slave_with_session remote_rpc_fn __context host

--- a/ocaml/xapi/startup.ml
+++ b/ocaml/xapi/startup.ml
@@ -84,18 +84,16 @@ let run ~__context tasks =
             ignore
               (Thread.create
                  (fun tsk_fct ->
-                   Server_helpers.exec_with_new_task
-                     ~subtask_of:(Context.get_task_id __context) tsk_name
-                     (fun __context -> thread_exn_wrapper tsk_name tsk_fct
+                   Server_helpers.exec_with_subtask tsk_name (fun ~__context ->
+                       thread_exn_wrapper tsk_name tsk_fct
                    )
                  )
                  tsk_fct
               )
           ) else (
             debug "task [%s]" tsk_name ;
-            Server_helpers.exec_with_new_task tsk_name
-              ~subtask_of:(Context.get_task_id __context) (fun __context ->
-                tsk_fct ()
+            Server_helpers.exec_with_subtask ~__context tsk_name
+              (fun ~__context -> tsk_fct ()
             )
           )
         )

--- a/ocaml/xapi/startup.ml
+++ b/ocaml/xapi/startup.ml
@@ -84,8 +84,8 @@ let run ~__context tasks =
             ignore
               (Thread.create
                  (fun tsk_fct ->
-                   Server_helpers.exec_with_subtask tsk_name (fun ~__context ->
-                       thread_exn_wrapper tsk_name tsk_fct
+                   Server_helpers.exec_with_subtask ~__context tsk_name
+                     (fun ~__context -> thread_exn_wrapper tsk_name tsk_fct
                    )
                  )
                  tsk_fct

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -370,7 +370,7 @@ let with_tracing ~name ~dbg f =
   in
   let name = "SM." ^ name in
   let tracer = Tracing.TracerProviders.get_default_tracer ~name in
-  let span = Tracing.Tracer.start ~tracer ~name ~parent in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent () in
   match span with
   | Ok span_context ->
       let result = f dbg in

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -369,10 +369,12 @@ let with_tracing ~name ~dbg f =
         (dbg, Tracing.empty)
   in
   let name = "SM." ^ name in
-  match Tracing.start ~name ~parent with
+  let tracer = Tracing.TracerProviders.get_default_tracer ~name in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent in
+  match span with
   | Ok span_context ->
       let result = f dbg in
-      let _ = Tracing.finish span_context in
+      let _ = Tracing.Tracer.finish span_context in
       result
   | Error e ->
       D.warn "Failed to start tracing: %s" (Printexc.to_string e) ;

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -359,6 +359,25 @@ module Everything = struct
     Errors.errors := h.errors
 end
 
+let with_tracing ~name ~dbg f =
+  let dbg, parent =
+    match String.index_opt dbg '\n' with
+    | Some i ->
+        let tracing = String.sub dbg (i + 1) (String.length dbg - i - 1) in
+        (String.sub dbg 0 i, Tracing.t_of_string tracing)
+    | None ->
+        (dbg, Tracing.empty)
+  in
+  let name = "SM." ^ name in
+  match Tracing.start ~name ~parent with
+  | Ok span_context ->
+      let result = f dbg in
+      let _ = Tracing.finish span_context in
+      result
+  | Error e ->
+      D.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+      f dbg
+
 module Wrapper =
 functor
   (Impl : Server_impl)
@@ -453,11 +472,12 @@ functor
         in
         List.fold_left perform_one vdi_t ops
 
-      let perform_nolock context ~dbg ~dp ~sr ~vdi ~vm this_op =
+      let perform_nolock context ~dbg ~name ~dp ~sr ~vdi ~vm this_op =
         match Host.find sr !Host.host with
         | None ->
             raise (Storage_error (Sr_not_attached (s_of_sr sr)))
         | Some sr_t ->
+            with_tracing ~name ~dbg @@ fun dbg ->
             let vdi_t =
               Option.value ~default:(Vdi.empty ()) (Sr.find vdi sr_t)
             in
@@ -524,7 +544,9 @@ functor
                   ignore
                     (List.fold_left
                        (fun _ op ->
-                         perform_nolock context ~dbg ~dp ~sr ~vdi ~vm op
+                         perform_nolock context ~dbg
+                           ~name:"VDI.destroy_datapath_nolock" ~dp ~sr ~vdi ~vm
+                           op
                        )
                        vdi_t ops
                     )
@@ -584,6 +606,7 @@ functor
       let epoch_begin context ~dbg ~sr ~vdi ~vm ~persistent =
         info "VDI.epoch_begin dbg:%s sr:%s vdi:%s vm:%s persistent:%b" dbg
           (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) persistent ;
+        with_tracing ~name:"VDI.epoch_begin" ~dbg @@ fun dbg ->
         with_vdi sr vdi (fun () ->
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
@@ -598,7 +621,8 @@ functor
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
                 let state =
-                  perform_nolock context ~dbg ~dp ~sr ~vdi ~vm
+                  perform_nolock context ~dbg ~name:"VDI.attach3" ~dp ~sr ~vdi
+                    ~vm
                     (Vdi_automaton.Attach
                        ( if read_write then
                            Vdi_automaton.RW
@@ -668,8 +692,8 @@ functor
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
                 ignore
-                  (perform_nolock context ~dbg ~dp ~sr ~vdi ~vm
-                     Vdi_automaton.Activate
+                  (perform_nolock context ~dbg ~dp ~name:"VDI.activate3" ~sr
+                     ~vdi ~vm Vdi_automaton.Activate
                   )
             )
         )
@@ -690,8 +714,8 @@ functor
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
                 ignore
-                  (perform_nolock context ~dbg ~dp ~sr ~vdi ~vm
-                     Vdi_automaton.Deactivate
+                  (perform_nolock context ~dbg ~name:"VDI.deactivate" ~dp ~sr
+                     ~vdi ~vm Vdi_automaton.Deactivate
                   )
             )
         )
@@ -703,8 +727,8 @@ functor
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
                 ignore
-                  (perform_nolock context ~dbg ~dp ~sr ~vdi ~vm
-                     Vdi_automaton.Detach
+                  (perform_nolock context ~dbg ~name:"VDI.detach" ~dp ~sr ~vdi
+                     ~vm Vdi_automaton.Detach
                   )
             )
         )
@@ -712,6 +736,7 @@ functor
       let epoch_end context ~dbg ~sr ~vdi ~vm =
         info "VDI.epoch_end dbg:%s sr:%s vdi:%s vm:%s" dbg (s_of_sr sr)
           (s_of_vdi vdi) (s_of_vm vm) ;
+        with_tracing ~name:"VDI.epoch_end" ~dbg @@ fun dbg ->
         with_vdi sr vdi (fun () ->
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () -> Impl.VDI.epoch_end context ~dbg ~sr ~vdi ~vm
@@ -1019,6 +1044,8 @@ functor
         failure
 
       let destroy' context ~dbg ~dp ~allow_leak =
+        info "DP.destroy dbg:%s dp:%s allow_leak:%b" dbg dp allow_leak ;
+        with_tracing ~name:"DP.destroy" ~dbg @@ fun dbg ->
         let failures =
           Host.list !Host.host
           |> List.filter_map (fun (sr, sr_t) ->

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -184,7 +184,10 @@ let queryable ~__context transport () =
   let traceparent =
     let open Tracing in
     Option.map
-      (fun span -> Span.get_span_context span |> SpanContext.to_traceparent)
+      (fun span ->
+        let _ = Span.set_span_kind span SpanKind.Client in
+        Span.get_span_context span |> SpanContext.to_traceparent
+      )
       (Context.tracing_of __context)
   in
   debug "Setting traceparent header (make_rpc) = %s"

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -180,19 +180,9 @@ let pingable ip () =
 
 let queryable ~__context transport () =
   let open Xmlrpc_client in
-  let http = xmlrpc ~version:"1.0" "/" in
-  let traceparent =
-    let open Tracing in
-    Option.map
-      (fun span ->
-        let _ = Span.set_span_kind span SpanKind.Client in
-        Span.get_span_context span |> SpanContext.to_traceparent
-      )
-      (Context.tracing_of __context)
+  let http =
+    xmlrpc ~version:"1.0" ~tracing:(Context.tracing_of __context) "/"
   in
-  debug "Setting traceparent header (make_rpc) = %s"
-    (Option.value ~default:"None" traceparent) ;
-  let http = {http with traceparent} in
   let rpc =
     XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_smapiv2" ~transport ~http
   in

--- a/ocaml/xapi/taskHelper.ml
+++ b/ocaml/xapi/taskHelper.ml
@@ -178,6 +178,7 @@ let status_is_completed task_status =
   task_status = `success || task_status = `failure || task_status = `cancelled
 
 let complete ~__context result =
+  Context.complete_tracing __context ;
   operate_on_db_task ~__context (fun self ->
       let status = Db_actions.DB_Action.Task.get_status ~__context ~self in
       if status = `pending then (
@@ -224,6 +225,7 @@ let exn_if_cancelling ~__context =
     raise_cancelled ~__context
 
 let cancel_this ~__context ~self =
+  Context.complete_tracing __context ;
   assert_op_valid ~__context self ;
   let status = Db_actions.DB_Action.Task.get_status ~__context ~self in
   if status = `pending then (
@@ -241,6 +243,7 @@ let cancel ~__context =
   operate_on_db_task ~__context (fun self -> cancel_this ~__context ~self)
 
 let failed ~__context exn =
+  Context.complete_tracing __context ;
   let code, params = ExnHelper.error_of_exn exn in
   operate_on_db_task ~__context (fun self ->
       let status = Db_actions.DB_Action.Task.get_status ~__context ~self in

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1420,6 +1420,13 @@ let server_init () =
                 Xapi_host.write_uefi_certificates_to_disk ~__context
                   ~host:(Helpers.get_localhost ~__context)
             )
+          ; ( "Set default TracerProvider intance on host"
+            , [Startup.NoExnRaising]
+            , fun () ->
+                Xapi_tracing.set_default ~__context
+                  ~pool:(Helpers.get_pool ~__context)
+                  ~host:(Helpers.get_localhost ~__context)
+            )
           ] ;
         debug "startup: startup sequence finished"
     ) ;

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -94,7 +94,7 @@ let populate_db backend =
     The db connections must have been parsed from db.conf file and initialised before this fn is called.
     Also this function depends on being able to call API functions through the external interface.
 *)
-let start_database_engine () =
+let start_database_engine ~__context () =
   let t = Db_backend.make () in
   populate_db t ;
   Db_ref.update_database t
@@ -104,7 +104,7 @@ let start_database_engine () =
   debug "Performing initial DB GC" ;
   Db_gc.single_pass () ;
   (* Make sure all 'my' database records exist and are up to date *)
-  Dbsync.setup () ;
+  Dbsync.setup ~__context ;
   ignore (Db_gc.start_db_gc_thread ()) ;
   debug "Finished populating db cache" ;
   Xapi_ha.on_database_engine_ready () ;
@@ -1070,7 +1070,7 @@ let server_init () =
                running etc.) -- see CA-11087 *)
             ( "starting up database engine"
             , [Startup.OnlyMaster]
-            , start_database_engine
+            , start_database_engine ~__context
             )
           ; ( "hi-level database upgrade"
             , [Startup.OnlyMaster]
@@ -1103,7 +1103,7 @@ let server_init () =
             , Remote_requests.handle_requests
             )
           ] ;
-        match Pool_role.get_role () with
+        ( match Pool_role.get_role () with
         | Pool_role.Master ->
             ()
         | Pool_role.Broken ->
@@ -1157,7 +1157,7 @@ let server_init () =
                     , Storage_access.start_smapiv1_servers
                     )
                   ] ;
-                Dbsync.setup ()
+                Dbsync.setup ~__context
               with _ ->
                 debug
                   "Failure in slave dbsync; slave will pause and then restart \
@@ -1169,9 +1169,7 @@ let server_init () =
             Master_connection.restart_on_connection_timeout := true ;
             Master_connection.on_database_connection_established :=
               fun () -> on_master_restart ~__context
-    ) ;
-    Server_helpers.exec_with_new_task "server_init" ~task_in_database:true
-      (fun __context ->
+        ) ;
         Startup.run ~__context
           [
             ("Checking emergency network reset", [], check_network_reset)
@@ -1236,7 +1234,7 @@ let server_init () =
                	 table happens to be right) *)
             ( "Best-effort bring up of physical and sriov NICs"
             , [Startup.NoExnRaising]
-            , Xapi_pif.start_of_day_best_effort_bring_up
+            , Xapi_pif.start_of_day_best_effort_bring_up ~__context
             )
           ; ( "updating the vswitch controller"
             , []

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -924,6 +924,12 @@ let rpm_cmd = ref "/usr/bin/rpm"
 
 let rpm_gpgkey_dir = ref "/etc/pki/rpm-gpg"
 
+let tracing_default_endpoints = ref ["bugtool"]
+
+let tracing_default_filters = ref []
+
+let tracing_default_processors = ref []
+
 let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
@@ -1195,6 +1201,23 @@ let other_options =
       (fun s -> s)
       (fun s -> s)
       disable_dbsync_for
+  ; gen_list_option "tracing-default-endpoints"
+      "space-separated list of endpoints strings for the default tracer \
+       provider"
+      (fun s -> s)
+      (fun s -> s)
+      tracing_default_endpoints
+  ; gen_list_option "tracing-default-filters"
+      "space-separated list of filters strings for the default tracer provider"
+      (fun s -> s)
+      (fun s -> s)
+      tracing_default_filters
+  ; gen_list_option "tracing-default-processors"
+      "space-separated list of processors strings for the default tracer \
+       provider"
+      (fun s -> s)
+      (fun s -> s)
+      tracing_default_processors
   ; ( "xenopsd-queues"
     , Arg.String (fun x -> xenopsd_queues := String.split ',' x)
     , (fun () -> String.concat "," !xenopsd_queues)

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -1092,24 +1092,21 @@ let calculate_pifs_required_at_start_of_day ~__context =
   in
   pifs @ sriov_pifs
 
-let start_of_day_best_effort_bring_up () =
-  Server_helpers.exec_with_new_task
-    "Bringing up managed physical and sriov PIFs" (fun __context ->
-      let dbg = Context.string_of_task __context in
-      debug "Configured network backend: %s"
-        (Network_interface.string_of_kind (Net.Bridge.get_kind dbg ())) ;
-      (* Clear the state of the network daemon, before refreshing it by plugging
-         * the most important PIFs (see above). *)
-      Net.clear_state () ;
-      List.iter
-        (fun (pif, pifr) ->
-          Helpers.log_exn_continue
-            (Printf.sprintf "error trying to bring up pif: %s" pifr.API.pIF_uuid)
-            (fun pif ->
-              debug "Best effort attempt to bring up PIF: %s" pifr.API.pIF_uuid ;
-              plug ~__context ~self:pif
-            )
-            pif
+let start_of_day_best_effort_bring_up ~__context () =
+  let dbg = Context.string_of_task __context in
+  debug "Configured network backend: %s"
+    (Network_interface.string_of_kind (Net.Bridge.get_kind dbg ())) ;
+  (* Clear the state of the network daemon, before refreshing it by plugging
+     * the most important PIFs (see above). *)
+  Net.clear_state () ;
+  List.iter
+    (fun (pif, pifr) ->
+      Helpers.log_exn_continue
+        (Printf.sprintf "error trying to bring up pif: %s" pifr.API.pIF_uuid)
+        (fun pif ->
+          debug "Best effort attempt to bring up PIF: %s" pifr.API.pIF_uuid ;
+          plug ~__context ~self:pif
         )
-        (calculate_pifs_required_at_start_of_day ~__context)
-  )
+        pif
+    )
+    (calculate_pifs_required_at_start_of_day ~__context)

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -262,7 +262,7 @@ val calculate_pifs_required_at_start_of_day :
     interfaces required by storage NICs etc. (these interface are not filtered out at the moment).
 *)
 
-val start_of_day_best_effort_bring_up : unit -> unit
+val start_of_day_best_effort_bring_up : __context:Context.t -> unit -> unit
 (** Attempt to bring up (plug) the required PIFs when the host starts up.
  *  Uses {!calculate_pifs_required_at_start_of_day}. *)
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3283,21 +3283,11 @@ let perform ~local_fn ~__context ~host op =
     let open Xmlrpc_client in
     let verify_cert = Some Stunnel.pool (* verify! *) in
     let task_id = Option.map Ref.string_of task_opt in
-    let http = xmlrpc ?task_id ~version:"1.0" "/" in
+    let http =
+      xmlrpc ?task_id ~version:"1.0" ~tracing:(Context.tracing_of __context) "/"
+    in
     let port = !Constants.https_port in
     let transport = SSL (SSL.make ~verify_cert ?task_id (), hostname, port) in
-    let traceparent =
-      let open Tracing in
-      Option.map
-        (fun span ->
-          let _ = Span.set_span_kind span SpanKind.Client in
-          Span.get_span_context span |> SpanContext.to_traceparent
-        )
-        (Context.tracing_of __context)
-    in
-    debug "Setting traceparent header (pool.perform) = %s"
-      (Option.value ~default:"None" traceparent) ;
-    let http = {http with traceparent} in
     XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
   in
   let open Message_forwarding in

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3289,7 +3289,10 @@ let perform ~local_fn ~__context ~host op =
     let traceparent =
       let open Tracing in
       Option.map
-        (fun span -> Span.get_span_context span |> SpanContext.to_traceparent)
+        (fun span ->
+          let _ = Span.set_span_kind span SpanKind.Client in
+          Span.get_span_context span |> SpanContext.to_traceparent
+        )
         (Context.tracing_of __context)
     in
     debug "Setting traceparent header (pool.perform) = %s"

--- a/ocaml/xapi/xapi_tracing.ml
+++ b/ocaml/xapi/xapi_tracing.ml
@@ -1,0 +1,24 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+let set_default ~__context ~pool ~host =
+  let pool_uuid = Db.Pool.get_uuid ~__context ~self:pool in
+  let host_uuid = Db.Host.get_uuid ~__context ~self:host in
+  let host_label = Db.Host.get_name_label ~__context ~self:host in
+  let tags =
+    [("pool", pool_uuid); ("host", host_uuid); ("host name", host_label)]
+  in
+  let endpoints = !Xapi_globs.tracing_default_endpoints in
+  let processors = !Xapi_globs.tracing_default_processors in
+  let filters = !Xapi_globs.tracing_default_filters in
+  Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters

--- a/ocaml/xapi/xapi_tracing.ml
+++ b/ocaml/xapi/xapi_tracing.ml
@@ -11,7 +11,17 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+let create ~__context ?(hosts = []) ?(tags = []) ?(endpoints = ["bugtool"])
+    ?(components = []) ?(filters = []) ?(processors = []) ?(status = false)
+    ~name_label () : unit =
+  let tracing = Ref.make () in
+  Db.Tracing.create ~__context
+    ~uuid:(Uuidx.to_string (Uuidx.make ()))
+    ~ref:tracing ~hosts ~name_label ~tags ~endpoints ~components ~filters
+    ~processors ~status
+
 let set_default ~__context ~pool ~host =
+  (* Called on each host *)
   let pool_uuid = Db.Pool.get_uuid ~__context ~self:pool in
   let host_uuid = Db.Host.get_uuid ~__context ~self:host in
   let host_label = Db.Host.get_name_label ~__context ~self:host in
@@ -21,4 +31,55 @@ let set_default ~__context ~pool ~host =
   let endpoints = !Xapi_globs.tracing_default_endpoints in
   let processors = !Xapi_globs.tracing_default_processors in
   let filters = !Xapi_globs.tracing_default_filters in
-  Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters
+  let default =
+    List.find_opt
+      (fun self -> Db.Tracing.get_name_label ~__context ~self = "default")
+      (Db.Tracing.get_all ~__context)
+  in
+  let is_master = Helpers.is_pool_master ~__context ~host in
+  match (default, is_master) with
+  | Some self, _ ->
+      let tags =
+        ("host", host_uuid)
+        :: ("host name", host_label)
+        :: Db.Tracing.get_tags ~__context ~self
+      in
+      let endpoints = Db.Tracing.get_endpoints ~__context ~self in
+      let processors = Db.Tracing.get_processors ~__context ~self in
+      let filters = Db.Tracing.get_filters ~__context ~self in
+      Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters
+  | None, false ->
+      Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters
+  | None, true ->
+      create ~__context ~tags:[("pool", pool_uuid)] ~endpoints ~processors
+        ~filters ~status:true ~name_label:"default" () ;
+      Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters
+
+let set_status ~__context ~self ~status =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  Tracing.TracerProviders.set ~name_label ~status ()
+
+let set_tags ~__context ~self ~tags =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  let tags =
+    let host = Helpers.get_localhost ~__context in
+    let host_uuid = Db.Host.get_uuid ~__context ~self:host in
+    let host_label = Db.Host.get_name_label ~__context ~self:host in
+    ("host", host_uuid) :: ("host name", host_label) :: tags
+  in
+  Tracing.TracerProviders.set ~name_label ~tags ()
+
+let set_endpoints ~__context ~self ~endpoints =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  Tracing.TracerProviders.set ~name_label ~endpoints ()
+
+let set_components ~__context ~self:_ ~components:_ = ()
+
+(* Will implement later, this function will set / unset providers on veraious components *)
+let set_filters ~__context ~self ~filters =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  Tracing.TracerProviders.set ~name_label ~filters ()
+
+let set_processors ~__context ~self ~processors =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  Tracing.TracerProviders.set ~name_label ~processors ()

--- a/ocaml/xapi/xapi_tracing.mli
+++ b/ocaml/xapi/xapi_tracing.mli
@@ -1,0 +1,16 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val set_default :
+  __context:Context.t -> pool:API.ref_pool -> host:API.ref_host -> unit

--- a/ocaml/xapi/xapi_tracing.mli
+++ b/ocaml/xapi/xapi_tracing.mli
@@ -14,3 +14,24 @@
 
 val set_default :
   __context:Context.t -> pool:API.ref_pool -> host:API.ref_host -> unit
+
+val set_status :
+  __context:Context.t -> self:API.ref_Tracing -> status:bool -> unit
+
+val set_tags :
+     __context:Context.t
+  -> self:API.ref_Tracing
+  -> tags:(string * string) list
+  -> unit
+
+val set_endpoints :
+  __context:Context.t -> self:API.ref_Tracing -> endpoints:string list -> unit
+
+val set_components :
+  __context:Context.t -> self:API.ref_Tracing -> components:string list -> unit
+
+val set_filters :
+  __context:Context.t -> self:API.ref_Tracing -> filters:string list -> unit
+
+val set_processors :
+  __context:Context.t -> self:API.ref_Tracing -> processors:string list -> unit

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -263,7 +263,7 @@ let firmware_of_vm vm =
       default_firmware
 
 let varstore_rm_with_sandbox ~__context ~vm_uuid f =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let domid = 0 in
   let chroot, socket_path =
     Xenops_sandbox.Varstore_guard.start dbg ~domid ~vm_uuid ~paths:[]
@@ -1394,7 +1394,7 @@ module Guest_agent_features = struct
 end
 
 let apply_guest_agent_config ~__context config =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let features = Guest_agent_features.of_config ~__context config in
   let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
   Client.HOST.update_guest_agent_features dbg features
@@ -1671,7 +1671,7 @@ module Xenopsd_metadata = struct
         let md = create_metadata ~__context ~self in
         let txt = md |> rpc_of Metadata.t |> Jsonrpc.to_string in
         info "xenops: VM.import_metadata %s" txt ;
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self)
                                 : XENOPS
                             )
@@ -1684,7 +1684,7 @@ module Xenopsd_metadata = struct
     )
 
   let delete_nolock ~__context id =
-    let dbg = Context.string_of_task __context in
+    let dbg = Context.string_of_task_and_tracing __context in
     info "xenops: VM.remove %s" id ;
     try
       let module Client = ( val make_client
@@ -1711,7 +1711,7 @@ module Xenopsd_metadata = struct
   let pull ~__context id =
     with_lock metadata_m (fun () ->
         info "xenops: VM.export_metadata %s" id ;
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client
                                     (queue_of_vm ~__context
                                        ~self:(vm_of_id ~__context id)
@@ -1745,7 +1745,7 @@ module Xenopsd_metadata = struct
     let id = id_of_vm ~__context ~self in
     let queue_name = queue_of_vm ~__context ~self in
     with_lock metadata_m (fun () ->
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         if vm_exists_in_xenopsd queue_name dbg id then
           let txt =
             create_metadata ~__context ~self
@@ -1887,7 +1887,7 @@ let update_vm ~__context id =
         debug "xenopsd event: ignoring event for VM (VM %s not resident)" id
       else
         let previous = Xenops_cache.find_vm id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self)
                                 : XENOPS
                             )
@@ -2447,7 +2447,7 @@ let update_vbd ~__context (id : string * string) =
           (fst id)
       else
         let previous = Xenops_cache.find_vbd id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2559,7 +2559,7 @@ let update_vif ~__context id =
           (fst id)
       else
         let previous = Xenops_cache.find_vif id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2606,7 +2606,9 @@ let update_vif ~__context id =
                                  (fst id) (snd id)
                               )
                         | Some device ->
-                            let dbg = Context.string_of_task __context in
+                            let dbg =
+                              Context.string_of_task_and_tracing __context
+                            in
                             let mtu = Net.Interface.get_mtu dbg device in
                             Db.VIF.set_MTU ~__context ~self:vif
                               ~value:(Int64.of_int mtu)
@@ -2673,7 +2675,7 @@ let update_pci ~__context id =
           (fst id)
       else
         let previous = Xenops_cache.find_pci id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2749,7 +2751,7 @@ let update_vgpu ~__context id =
           (fst id)
       else
         let previous = Xenops_cache.find_vgpu id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2821,7 +2823,7 @@ let update_vusb ~__context (id : string * string) =
           (fst id)
       else
         let previous = Xenops_cache.find_vusb id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2883,7 +2885,7 @@ let update_task ~__context queue_name id =
   try
     let self = TaskHelper.id_to_task_exn (TaskHelper.Xenops (queue_name, id)) in
     (* throws Not_found *)
-    let dbg = Context.string_of_task __context in
+    let dbg = Context.string_of_task_and_tracing __context in
     let module Client = (val make_client queue_name : XENOPS) in
     let task_t = Client.TASK.stat dbg id in
     match task_t.Task.state with
@@ -2913,7 +2915,7 @@ let update_task ~__context queue_name id =
       error "xenopsd event: Caught %s while updating task" (string_of_exn e)
 
 let rec events_watch ~__context cancel queue_name from =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   if Xapi_fist.delay_xenopsd_event_threads () then Thread.delay 30.0 ;
   let module Client = (val make_client queue_name : XENOPS) in
   let barriers, events, next = Client.UPDATES.get dbg from None in
@@ -2982,14 +2984,14 @@ let events_from_xenopsd queue_name =
 let refresh_vm ~__context ~self =
   let id = id_of_vm ~__context ~self in
   info "xenops: UPDATES.refresh_vm %s" id ;
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let queue_name = queue_of_vm ~__context ~self in
   let module Client = (val make_client queue_name : XENOPS) in
   Client.UPDATES.refresh_vm dbg id ;
   Events_from_xenopsd.wait queue_name dbg id ()
 
 let resync_resident_on ~__context =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let localhost = Helpers.get_localhost ~__context in
   let domain0 = Helpers.get_domain_zero ~__context in
   (* Get a list of all the ids of VMs that Xapi thinks are resident here
@@ -3527,7 +3529,7 @@ let update_debug_info __context t =
     debug_info
 
 let sync_with_task_result __context ?cancellable queue_name x =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   x
   |> register_task __context ?cancellable queue_name
   |> wait_for_task queue_name dbg
@@ -3538,7 +3540,7 @@ let sync_with_task __context ?cancellable queue_name x =
   sync_with_task_result __context ?cancellable queue_name x |> ignore
 
 let sync __context queue_name x =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   x
   |> wait_for_task queue_name dbg
   |> success_task queue_name (update_debug_info __context) dbg
@@ -3549,7 +3551,7 @@ let pause ~__context ~self =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.pause %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.pause dbg id |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg id () ;
@@ -3562,7 +3564,7 @@ let unpause ~__context ~self =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.unpause %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.unpause dbg id |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg id () ;
@@ -3574,7 +3576,7 @@ let request_rdp ~__context ~self enabled =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.request_rdp %s %b" id enabled ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.request_rdp dbg id enabled
       |> sync_with_task __context queue_name ;
@@ -3586,7 +3588,7 @@ let run_script ~__context ~self script =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.run_script %s %s" id script ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       let r =
         Client.VM.run_script dbg id script
@@ -3602,7 +3604,7 @@ let set_xenstore_data ~__context ~self xsdata =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.set_xenstore_data %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.set_xsdata dbg id xsdata |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg id ()
@@ -3613,7 +3615,7 @@ let set_vcpus ~__context ~self n =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.set_vcpus %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       try
         Client.VM.set_vcpus dbg id (Int64.to_int n)
@@ -3640,7 +3642,7 @@ let set_shadow_multiplier ~__context ~self target =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.set_shadow_multiplier %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       try
         Client.VM.set_shadow_multiplier dbg id target
@@ -3669,7 +3671,7 @@ let set_memory_dynamic_range ~__context ~self min max =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.set_memory_dynamic_range %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.set_memory_dynamic_range dbg id min max
       |> sync_with_task __context queue_name ;
@@ -3677,7 +3679,7 @@ let set_memory_dynamic_range ~__context ~self min max =
   )
 
 let maybe_refresh_vm ~__context ~self =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let queue_name = queue_of_vm ~__context ~self in
   let id = id_of_vm ~__context ~self in
   if vm_exists_in_xenopsd queue_name dbg id then (
@@ -3689,7 +3691,7 @@ let maybe_refresh_vm ~__context ~self =
   )
 
 let start ~__context ~self paused force =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let queue_name = queue_of_vm ~__context ~self in
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       maybe_refresh_vm ~__context ~self ;
@@ -3779,7 +3781,7 @@ let reboot ~__context ~self timeout =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       assert_resident_on ~__context ~self ;
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       maybe_refresh_vm ~__context ~self ;
       (* Ensure we have the latest version of the VM metadata before the reboot *)
       Events_from_xapi.wait ~__context ~self ;
@@ -3801,7 +3803,7 @@ let shutdown ~__context ~self timeout =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       assert_resident_on ~__context ~self ;
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       info "xenops: VM.shutdown %s" id ;
       let module Client = (val make_client queue_name : XENOPS) in
       let () =
@@ -3850,7 +3852,7 @@ let suspend ~__context ~self =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       assert_resident_on ~__context ~self ;
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       let vm_t, _state = Client.VM.stat dbg id in
       (* XXX: this needs to be at boot time *)
@@ -3887,7 +3889,7 @@ let suspend ~__context ~self =
           let d = disk_of_vdi ~__context ~self:vdi |> Option.get in
           Db.VM.set_suspend_VDI ~__context ~self ~value:vdi ;
           try
-            let dbg = Context.string_of_task __context in
+            let dbg = Context.string_of_task_and_tracing __context in
             info "xenops: VM.suspend %s to %s" id
               (d |> rpc_of disk |> Jsonrpc.to_string) ;
             Client.VM.suspend dbg id d
@@ -3930,7 +3932,7 @@ let suspend ~__context ~self =
   )
 
 let resume ~__context ~self ~start_paused ~force:_ =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let queue_name = queue_of_vm ~__context ~self in
   let vm_id = id_of_vm ~__context ~self in
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
@@ -3990,7 +3992,7 @@ let s3suspend ~__context ~self =
   let queue_name = queue_of_vm ~__context ~self in
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       debug "xenops: VM.s3suspend %s" id ;
       Client.VM.s3suspend dbg id |> sync_with_task __context queue_name ;
@@ -4001,7 +4003,7 @@ let s3resume ~__context ~self =
   let queue_name = queue_of_vm ~__context ~self in
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       debug "xenops: VM.s3resume %s" id ;
       Client.VM.s3resume dbg id |> sync_with_task __context queue_name ;
@@ -4027,7 +4029,7 @@ let vbd_plug ~__context ~self =
       Db.VBD.set_currently_attached ~__context ~self ~value:true ;
       Events_from_xapi.wait ~__context ~self:vm ;
       let vbd = md_of_vbd ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Events_from_xenopsd.with_suppressed queue_name dbg vm_id (fun () ->
           info "xenops: VBD.add %s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id) ;
@@ -4054,7 +4056,7 @@ let vbd_unplug ~__context ~self force =
   transform_xenops_exn ~__context ~vm queue_name (fun () ->
       assert_resident_on ~__context ~self:vm ;
       let vbd = md_of_vbd ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       ( try
           info "xenops: VBD.unplug %s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id) ;
@@ -4092,7 +4094,7 @@ let vbd_eject_hvm ~__context ~self =
       assert_resident_on ~__context ~self:vm ;
       let vbd = md_of_vbd ~__context ~self in
       info "xenops: VBD.eject %s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VBD.eject dbg vbd.Vbd.id |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg (fst vbd.Vbd.id) () ;
@@ -4133,7 +4135,7 @@ let vbd_insert_hvm ~__context ~self ~vdi =
       let d = disk_of_vdi ~__context ~self:vdi |> Option.get in
       info "xenops: VBD.insert %s.%s %s" (fst vbd.Vbd.id) (snd vbd.Vbd.id)
         (d |> rpc_of disk |> Jsonrpc.to_string) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VBD.insert dbg vbd.Vbd.id d |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg (fst vbd.Vbd.id) () ;
@@ -4166,7 +4168,7 @@ let vbd_insert_hvm ~__context ~self ~vdi =
   )
 
 let has_qemu ~__context ~vm =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let id = Db.VM.get_uuid ~__context ~self:vm in
   let queue_name = queue_of_vm ~__context ~self:vm in
   let module Client = (val make_client queue_name : XENOPS) in
@@ -4214,7 +4216,7 @@ let vif_plug ~__context ~self =
       Db.VIF.set_currently_attached ~__context ~self ~value:true ;
       Events_from_xapi.wait ~__context ~self:vm ;
       let vif = md_of_vif ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Xapi_network.with_networks_attached_for_vm ~__context ~vm (fun () ->
           Events_from_xenopsd.with_suppressed queue_name dbg vm_id (fun () ->
@@ -4244,7 +4246,7 @@ let vif_set_locking_mode ~__context ~self =
       assert_resident_on ~__context ~self:vm ;
       let vif = md_of_vif ~__context ~self in
       info "xenops: VIF.set_locking_mode %s.%s" (fst vif.Vif.id) (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VIF.set_locking_mode dbg vif.Vif.id vif.Vif.locking_mode
       |> sync_with_task __context queue_name ;
@@ -4259,7 +4261,7 @@ let vif_set_pvs_proxy ~__context ~self creating =
       let vif = md_of_vif ~__context ~self in
       let proxy = if creating then vif.Vif.pvs_proxy else None in
       info "xenops: VIF.set_pvs_proxy %s.%s" (fst vif.Vif.id) (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VIF.set_pvs_proxy dbg vif.Vif.id proxy
       |> sync_with_task __context queue_name ;
@@ -4273,7 +4275,7 @@ let vif_unplug ~__context ~self force =
       assert_resident_on ~__context ~self:vm ;
       let vif = md_of_vif ~__context ~self in
       info "xenops: VIF.unplug %s.%s" (fst vif.Vif.id) (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       try
         Client.VIF.unplug dbg vif.Vif.id force
@@ -4318,7 +4320,7 @@ let vif_move ~__context ~self _network =
                 )
             )
       | _ ->
-          let dbg = Context.string_of_task __context in
+          let dbg = Context.string_of_task_and_tracing __context in
           let module Client = (val make_client queue_name : XENOPS) in
           (* Nb., at this point, the database shows the vif on the new network *)
           Xapi_network.attach_for_vif ~__context ~vif:self () ;
@@ -4346,7 +4348,7 @@ let vif_set_ipv4_configuration ~__context ~self =
       let vif = md_of_vif ~__context ~self in
       info "xenops: VIF.set_ipv4_configuration %s.%s" (fst vif.Vif.id)
         (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VIF.set_ipv4_configuration dbg vif.Vif.id
         vif.Vif.ipv4_configuration
@@ -4362,7 +4364,7 @@ let vif_set_ipv6_configuration ~__context ~self =
       let vif = md_of_vif ~__context ~self in
       info "xenops: VIF.set_ipv6_configuration %s.%s" (fst vif.Vif.id)
         (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VIF.set_ipv6_configuration dbg vif.Vif.id
         vif.Vif.ipv6_configuration
@@ -4374,7 +4376,7 @@ let task_cancel ~__context ~self =
   try
     let queue_name, id = TaskHelper.task_to_id_exn self |> unwrap in
     let module Client = (val make_client queue_name : XENOPS) in
-    let dbg = Context.string_of_task __context in
+    let dbg = Context.string_of_task_and_tracing __context in
     info "xenops: TASK.cancel %s" id ;
     Client.TASK.cancel dbg id |> ignore ;
     (* it might actually have completed, we don't care *)
@@ -4399,7 +4401,7 @@ let vusb_unplug_hvm ~__context ~self =
       assert_resident_on ~__context ~self:vm ;
       let vusb = md_of_vusb ~__context ~self in
       info "xenops: VUSB.unplug %s.%s" (fst vusb.Vusb.id) (snd vusb.Vusb.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VUSB.unplug dbg vusb.Vusb.id |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg (fst vusb.Vusb.id) () ;

--- a/ocaml/xenopsd/lib/dune
+++ b/ocaml/xenopsd/lib/dune
@@ -41,6 +41,7 @@
    xapi-stdext-pervasives
    xapi-stdext-threads
    xapi-stdext-unix
+   xapi-tracing
    xmlm
  )
  (preprocess

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -3782,18 +3782,16 @@ module VM = struct
     Debug.with_thread_associated dbg
       (fun () ->
         let id, md = parse_metadata s in
+        let op = Atomic (VM_import_metadata (id, md)) in
         (* We allow a higher-level toolstack to replace the metadata of a
            running VM. Any changes will take place on next reboot.
            The metadata update will be queued so that ongoing operations
            do not see unexpected state changes. *)
         if DB.exists id then
-          let _ =
-            queue_operation_and_wait dbg id
-              (Atomic (VM_import_metadata (id, md)))
-          in
-          id
+          ignore (queue_operation_and_wait dbg id op)
         else
-          import_metadata id md
+          immediate_operation dbg id op ;
+        id
       )
       ()
 

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -1844,10 +1844,17 @@ let rec perform_atomic ~progress_callback ?subtask:_ ?result (op : atomic)
           (Xenops_task.id_of_handle t)
           (List.length atoms) description
       in
+      let parallel_id_with_tracing =
+        match Xenops_task.tracing t with
+        | Some t ->
+            parallel_id ^ "\n" ^ t
+        | None ->
+            parallel_id
+      in
       debug "begin_%s" parallel_id ;
       let task_list =
         queue_atomics_and_wait ~progress_callback ~max_parallel_atoms:10
-          parallel_id parallel_id atoms
+          parallel_id_with_tracing parallel_id atoms
       in
       debug "end_%s" parallel_id ;
       (* make sure that we destroy all the parallel tasks that finished *)

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -162,6 +162,113 @@ type atomic =
 
 let string_of_atomic x = x |> rpc_of atomic |> Jsonrpc.to_string
 
+let rec name_of_atomic = function
+  | VBD_eject _ ->
+      "VBD_eject"
+  | VIF_plug _ ->
+      "VIF_plug"
+  | VIF_unplug _ ->
+      "VIF_unplug"
+  | VIF_move _ ->
+      "VIF_move"
+  | VIF_set_carrier _ ->
+      "VIF_set_carrier"
+  | VIF_set_locking_mode _ ->
+      "VIF_set_locking_mode"
+  | VIF_set_pvs_proxy _ ->
+      "VIF_set_pvs_proxy"
+  | VIF_set_ipv4_configuration _ ->
+      "VIF_set_ipv4_configuration"
+  | VIF_set_ipv6_configuration _ ->
+      "VIF_set_ipv6_configuration"
+  | VIF_set_active _ ->
+      "VIF_set_active"
+  | VM_hook_script_stable _ ->
+      "VM_hook_script_stable"
+  | VM_hook_script _ ->
+      "VM_hook_script"
+  | VBD_plug _ ->
+      "VBD_plug"
+  | VBD_epoch_begin _ ->
+      "VBD_epoch_begin"
+  | VBD_epoch_end _ ->
+      "VBD_epoch_end"
+  | VBD_set_qos _ ->
+      "VBD_set_qos"
+  | VBD_unplug _ ->
+      "VBD_unplug"
+  | VBD_insert _ ->
+      "VBD_insert"
+  | VBD_set_active _ ->
+      "VBD_set_active"
+  | VM_remove _ ->
+      "VM_remove"
+  | PCI_plug _ ->
+      "PCI_plug"
+  | PCI_unplug _ ->
+      "PCI_unplug"
+  | PCI_dequarantine _ ->
+      "PCI_dequarantine"
+  | VUSB_plug _ ->
+      "VUSB_plug"
+  | VUSB_unplug _ ->
+      "VUSB_unplug"
+  | VGPU_set_active _ ->
+      "VGPU_set_active"
+  | VGPU_start _ ->
+      "VGPU_start"
+  | VM_set_xsdata _ ->
+      "VM_set_xsdata"
+  | VM_set_vcpus _ ->
+      "VM_set_vcpus"
+  | VM_set_shadow_multiplier _ ->
+      "VM_set_shadow_multiplier"
+  | VM_set_memory_dynamic_range _ ->
+      "VM_set_memory_dynamic_range"
+  | VM_pause _ ->
+      "VM_pause"
+  | VM_softreboot _ ->
+      "VM_softreboot"
+  | VM_unpause _ ->
+      "VM_unpause"
+  | VM_request_rdp _ ->
+      "VM_request_rdp"
+  | VM_run_script _ ->
+      "VM_run_script"
+  | VM_set_domain_action_request _ ->
+      "VM_set_domain_action_request"
+  | VM_create_device_model _ ->
+      "VM_create_device_model"
+  | VM_destroy_device_model _ ->
+      "VM_destroy_device_model"
+  | VM_destroy _ ->
+      "VM_destroy"
+  | VM_create _ ->
+      "VM_create"
+  | VM_build _ ->
+      "VM_build"
+  | VM_shutdown_domain _ ->
+      "VM_shutdown_domain"
+  | VM_s3suspend _ ->
+      "VM_s3suspend"
+  | VM_s3resume _ ->
+      "VM_s3resume"
+  | VM_save _ ->
+      "VM_save"
+  | VM_restore _ ->
+      "VM_restore"
+  | VM_delay _ ->
+      "VM_delay"
+  | VM_rename _ ->
+      "VM_rename"
+  | VM_import_metadata _ ->
+      "VM_import_metadata"
+  | Parallel (_, _, atomics) ->
+      Printf.sprintf "Parallel (%s)"
+        (String.concat " | " (List.map name_of_atomic atomics))
+  | Best_effort atomic ->
+      Printf.sprintf "Best_effort (%s)" (name_of_atomic atomic)
+
 type vm_migrate_op = {
     vmm_id: Vm.id
   ; vmm_vdi_map: (string * string) list
@@ -209,6 +316,48 @@ type operation =
 [@@deriving rpcty]
 
 let string_of_operation x = x |> rpc_of operation |> Jsonrpc.to_string
+
+let name_of_operation = function
+  | VM_start _ ->
+      "VM_start"
+  | VM_poweroff _ ->
+      "VM_poweroff"
+  | VM_shutdown _ ->
+      "VM_shutdown"
+  | VM_reboot _ ->
+      "VM_reboot"
+  | VM_suspend _ ->
+      "VM_suspend"
+  | VM_resume _ ->
+      "VM_resume"
+  | VM_restore_vifs _ ->
+      "VM_restore_vifs"
+  | VM_restore_devices _ ->
+      "VM_restore_devices"
+  | VM_migrate _ ->
+      "VM_migrate"
+  | VM_receive_memory _ ->
+      "VM_receive_memory"
+  | VBD_hotplug _ ->
+      "VBD_hotplug"
+  | VBD_hotunplug _ ->
+      "VBD_hotunplug"
+  | VIF_hotplug _ ->
+      "VIF_hotplug"
+  | VIF_hotunplug _ ->
+      "VIF_hotunplug"
+  | VM_check_state _ ->
+      "VM_check_state"
+  | PCI_check_state _ ->
+      "PCI_check_state"
+  | VBD_check_state _ ->
+      "VBD_check_state"
+  | VIF_check_state _ ->
+      "VIF_check_state"
+  | VUSB_check_state _ ->
+      "VUSB_check_state"
+  | Atomic atomic ->
+      Printf.sprintf "Atomic (%s)" (name_of_atomic atomic)
 
 module TASK = struct
   open Xenops_task
@@ -1660,9 +1809,26 @@ let rec atomics_of_operation = function
   | _ ->
       []
 
+let with_tracing ~name ~task f =
+  let name = "xenopsd." ^ name in
+  let context = Xenops_task.tracing task in
+  let parent : Tracing.t = Option.bind context Tracing.t_of_string in
+  match Tracing.start ~name ~parent with
+  | Ok span_context ->
+      let sub_context = Tracing.json_of_t span_context in
+      Xenops_task.set_tracing task sub_context ;
+      let result = f () in
+      let _ = Tracing.finish span_context in
+      Xenops_task.set_tracing task context ;
+      result
+  | Error e ->
+      warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+      f ()
+
 let rec perform_atomic ~progress_callback ?subtask:_ ?result (op : atomic)
     (t : Xenops_task.task_handle) : unit =
   let module B = (val get_backend () : S) in
+  with_tracing ~name:(name_of_atomic op) ~task:t @@ fun () ->
   Xenops_task.check_cancelling t ;
   match op with
   | Best_effort atom -> (
@@ -2337,6 +2503,7 @@ and trigger_cleanup_after_failure_atom op t =
 and perform_exn ?subtask ?result (op : operation) (t : Xenops_task.task_handle)
     : unit =
   let module B = (val get_backend () : S) in
+  with_tracing ~name:(name_of_operation op) ~task:t @@ fun () ->
   let one = function
     | VM_start (id, force) -> (
         debug "VM.start %s (force=%b)" id force ;

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -1814,7 +1814,7 @@ let with_tracing ~name ~task f =
   let context = Xenops_task.tracing task in
   let parent : Tracing.t = Option.bind context Tracing.t_of_string in
   let tracer = Tracing.TracerProviders.get_default_tracer ~name in
-  let span = Tracing.Tracer.start ~tracer ~name ~parent in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent () in
   match span with
   | Ok span ->
       let sub_context = Tracing.json_of_t span in

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -1813,12 +1813,14 @@ let with_tracing ~name ~task f =
   let name = "xenopsd." ^ name in
   let context = Xenops_task.tracing task in
   let parent : Tracing.t = Option.bind context Tracing.t_of_string in
-  match Tracing.start ~name ~parent with
-  | Ok span_context ->
-      let sub_context = Tracing.json_of_t span_context in
+  let tracer = Tracing.TracerProviders.get_default_tracer ~name in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent in
+  match span with
+  | Ok span ->
+      let sub_context = Tracing.json_of_t span in
       Xenops_task.set_tracing task sub_context ;
       let result = f () in
-      let _ = Tracing.finish span_context in
+      let _ = Tracing.Tracer.finish span in
       Xenops_task.set_tracing task context ;
       result
   | Error e ->

--- a/ocaml/xs-trace/dune
+++ b/ocaml/xs-trace/dune
@@ -1,0 +1,10 @@
+(executable
+  (modes byte exe)
+  (name xs_trace)
+  (public_name xs-trace)
+  (package xapi)
+  (libraries
+    tracing
+    xapi-stdext-unix
+  )
+)

--- a/ocaml/xs-trace/test/dune
+++ b/ocaml/xs-trace/test/dune
@@ -1,0 +1,10 @@
+(executable
+ (modes byte exe)
+ (name test_xs_trace)
+ (libraries unix))
+
+(rule
+  (alias runtest)
+  (package xapi)
+  (deps test-xs-trace.sh ../xs_trace.exe test-source.json test_xs_trace.exe)
+  (action (run bash test-xs-trace.sh)))

--- a/ocaml/xs-trace/test/test-source.json
+++ b/ocaml/xs-trace/test/test-source.json
@@ -1,0 +1,12 @@
+[
+    {
+        "tags":{},
+        "localEndpoint":{"serviceName":"xapi"},
+        "kind":"SERVER",
+        "duration":46,
+        "timestamp":1677671549043900,
+        "name":"session_check",
+        "traceId":"9dda2bd691624f9e",
+        "id":"d3ee4b91c27d703a"
+    }
+]

--- a/ocaml/xs-trace/test/test-xs-trace.sh
+++ b/ocaml/xs-trace/test/test-xs-trace.sh
@@ -1,0 +1,17 @@
+set -eux
+
+export PORT=9411
+export HOST="127.0.0.1"
+
+./test_xs_trace.exe &
+
+PID=$!
+
+../xs_trace.exe cp test-source.json http://$HOST:$PORT/api/v2/spans
+
+kill $PID
+
+if [ $(diff test-source.json test-http-server.out | grep "<") ]
+then
+    exit 1
+fi

--- a/ocaml/xs-trace/test/test_xs_trace.ml
+++ b/ocaml/xs-trace/test/test_xs_trace.ml
@@ -1,0 +1,16 @@
+let _ =
+  let inet_addr = Unix.ADDR_INET (Unix.inet_addr_of_string "127.0.0.1", 9411) in
+  let rec read_write_all ic file =
+    match input_line ic with
+    | line ->
+        Printf.fprintf file "\n%s" line ;
+        read_write_all ic file
+    | exception End_of_file ->
+        ()
+  in
+  Unix.establish_server
+    (fun ic _ ->
+      let file = open_out "test-http-server.out" in
+      read_write_all ic file
+    )
+    inet_addr

--- a/ocaml/xs-trace/xs_trace.ml
+++ b/ocaml/xs-trace/xs_trace.ml
@@ -7,15 +7,16 @@ let _ =
   let origin = Sys.argv.(2) in
   let url = Sys.argv.(3) in
   let rec export_file orig =
-    if Sys.is_directory orig then (
+    if Sys.is_directory orig then
       let files = Sys.readdir orig in
       let file_paths = Array.map (fun file -> orig ^ "/" ^ file) files in
-      Array.iter export_file file_paths ;
-    ) else
+      Array.iter export_file file_paths
+    else
       let span_json = Xapi_stdext_unix.Unixext.string_of_file orig in
       let result = Tracing.Export.Destination.Http.export ~span_json ~url in
       match result with
-      | Ok _ -> ()
+      | Ok _ ->
+          ()
       | Error err ->
           Printf.eprintf "Error: %s" (Printexc.to_string err) ;
           exit 1
@@ -29,6 +30,6 @@ let _ =
       Sys.rmdir orig
     ) else
       Sys.remove orig
-    in
+  in
   if action = "mv" then
     remove_all origin

--- a/ocaml/xs-trace/xs_trace.ml
+++ b/ocaml/xs-trace/xs_trace.ml
@@ -1,0 +1,34 @@
+let _ =
+  if Array.length Sys.argv <> 4 then (
+    Printf.eprintf "Usage: %s cp/mv <origin> <destination>\n" Sys.argv.(0) ;
+    exit 1
+  ) ;
+  let action = Sys.argv.(1) in
+  let origin = Sys.argv.(2) in
+  let url = Sys.argv.(3) in
+  let rec export_file orig =
+    if Sys.is_directory orig then (
+      let files = Sys.readdir orig in
+      let file_paths = Array.map (fun file -> orig ^ "/" ^ file) files in
+      Array.iter export_file file_paths ;
+    ) else
+      let span_json = Xapi_stdext_unix.Unixext.string_of_file orig in
+      let result = Tracing.Export.Destination.Http.export ~span_json ~url in
+      match result with
+      | Ok _ -> ()
+      | Error err ->
+          Printf.eprintf "Error: %s" (Printexc.to_string err) ;
+          exit 1
+  in
+  export_file origin ;
+  let rec remove_all orig =
+    if Sys.is_directory orig then (
+      let files = Sys.readdir orig in
+      let file_paths = Array.map (fun file -> orig ^ "/" ^ file) files in
+      Array.iter remove_all file_paths ;
+      Sys.rmdir orig
+    ) else
+      Sys.remove orig
+    in
+  if action = "mv" then
+    remove_all origin

--- a/scripts/bugtool-plugin/xapi/stuff.xml
+++ b/scripts/bugtool-plugin/xapi/stuff.xml
@@ -12,4 +12,5 @@
 <files>@ETCDIR@/stunnel/xapi-stunnel-ca-bundle.pem</files>
 <command label="xapi_cert">cat @ETCXENDIR@/xapi-ssl.pem | @BINDIR@/openssl x509 -text</command>
 <command label="xapi_pool_cert">cat @ETCXENDIR@/xapi-pool-tls.pem | @BINDIR@/openssl x509 -text</command>
+<directory label="tracing">/var/log/dt</directory>
 </collect>

--- a/xapi-tracing.opam
+++ b/xapi-tracing.opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xen.org"
+authors: "xen-api@lists.xen.org"
+homepage: "https://xapi-project.github.io/"
+bug-reports: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build: [[ "dune" "build" "-p" name "-j" jobs ]]
+
+available: [ os = "linux" ]
+depends: [
+  "ocaml"
+  "dune"
+  "cohttp"
+  "rpclib"
+  "xapi-idl"
+  "xapi-stdext-unix"
+]
+synopsis: "Library required by xapi"
+description: """
+These libraries are provided for backwards compatibility only.
+No new code should use these libraries."""
+url {
+  src:
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}


### PR DESCRIPTION
Creating this PR as an early form of Request for Comments, in order to obtain feedback as soon as possible.

PLEASE DO NOT MERGE UNTIL AT LEAST THE FOLLOWING FIXUPS ARE ADDED:
1) tracing starts disabled by default
2) tracing does not add too many lines to debug output

----
This PR contains an initial implementation for xen-api of the distributed tracing concepts in https://opentelemetry.io/docs/reference/specification/trace/api/

It's split in two main parts:

a) ocaml/libs/tracing/tracing.ml: minimal library implementation of the API defined in the link above.
- TracerProvider: configuration for status (enabled/disabled) and endpoints (disk/network)
- Span: abstracts an action with start and finish events
- Export: Content format manipulation and Destination output helpers for files and http endpoints. These helpers pull the finished spans and move them over to the destination endpoints indicated in the TracerProvider. The initial content format present is zipkinv2, which is compatible with a number of different distributed tracing endpoints. It should be possible to produce content also in the OTEL format using a content producer library such as ocaml-opentelemetry. 

b) all the other files: initial xen-api instrumentation using tracing.ml to produce distributed tracing content to the supported destination endpoints.

--
Example usage:

1) install Jaeger using something like:
```
docker run -d --name jaeger   -e COLLECTOR_ZIPKIN_HTTP_PORT=9411   -p 5775:5775/udp   -p 6831:6831/udp   -p 6832:6832/udp   -p 5778:5778   -p 16686:16686   -p 14268:14268   -p 9411:9411   jaegertracing/all-in-one:1.6
```
2) set the destination endpoint to point to (1):
```
   xe tracing-param-set uuid=<tracing-provider-uuid> endpoints=http://<my-jaeger-ip>:9411/api/v2/spans
```
3) enable the tracer provider:
```
   xe tracing-param-set uuid=<tracing-provider-uuid> status=enabled
```
and you should be able to see the spans collected by XAPI in the Jaeger UI at `http://<my-jaeger-ip>:16686/`