### PR TITLE
CP-41796 enable HTTPS migration by default

### DIFF
--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1288,3 +1288,6 @@ let vtpm_max_amount_reached = "VTPM_MAX_AMOUNT_REACHED"
 
 (* Telemetry *)
 let telemetry_next_collection_too_late = "TELEMETRY_NEXT_COLLECTION_TOO_LATE"
+
+(* FIPS/CC_PREPARATIONS *)
+let illegal_in_fips_mode = "ILLEGAL_IN_FIPS_MODE"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -817,7 +817,7 @@ let web_dir = ref "/opt/xensource/www"
 
 let website_https_only = ref true
 
-let migration_https_only = ref false
+let migration_https_only = ref true
 
 let cluster_stack_root = ref "/usr/libexec/xapi/cluster-stack"
 


### PR DESCRIPTION
Flip the default for HTTPS migration to ON. This is another step to have no unencrypted communication.