### PR TITLE
Yangtze: enable HTTPS migration by default, prevent changes in CC_PREPARATIONS

### DIFF
--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1201,3 +1201,6 @@ let xen_incompatible = "XEN_INCOMPATIBLE"
 let designate_new_master_in_progress = "DESIGNATE_NEW_MASTER_IN_PROGRESS"
 
 let pool_secret_rotation_pending = "POOL_SECRET_ROTATION_PENDING"
+
+(* FIPS/CC_PREPARATIONS *)
+let illegal_in_fips_mode = "ILLEGAL_IN_FIPS_MODE"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -781,7 +781,7 @@ let web_dir = ref "/opt/xensource/www"
 
 let website_https_only = ref true
 
-let migration_https_only = ref false
+let migration_https_only = ref true
 
 let cluster_stack_root = ref "/usr/libexec/xapi/cluster-stack"
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2516,8 +2516,30 @@ let notify_send_new_pool_secret ~__context ~host ~old_ps ~new_ps =
 let cleanup_pool_secret ~__context ~host ~old_ps ~new_ps =
   Xapi_psr.cleanup ~__context ~old_ps ~new_ps
 
+let cc_prep () =
+  let cc = "CC_PREPARATIONS" in
+  Xapi_inventory.lookup ~default:"false" cc |> String.lowercase_ascii
+  |> function
+  | "true" ->
+      true
+  | "false" ->
+      false
+  | other ->
+      D.warn "%s: %s=%s (assuming true)" __MODULE__ cc other ;
+      true
+
 let set_https_only ~__context ~self ~value =
   let state = match value with true -> "close" | false -> "open" in
-  ignore
-  @@ Helpers.call_script !Xapi_globs.firewall_port_config_script [state; "80"] ;
-  Db.Host.set_https_only ~__context ~self ~value
+  match cc_prep () with
+  | false ->
+      ignore
+      @@ Helpers.call_script
+           !Xapi_globs.firewall_port_config_script
+           [state; "80"] ;
+      Db.Host.set_https_only ~__context ~self ~value
+  | true when value = Db.Host.get_https_only ~__context ~self ->
+      (* the new value is the same as the old value *)
+      ()
+  | true ->
+      (* it is illegal changing the firewall/https config in CC/FIPS mode *)
+      raise (Api_errors.Server_error (Api_errors.illegal_in_fips_mode, []))


### PR DESCRIPTION
Backports of

* b490291cd 2023-03-24 CP-41796 prevent changes to https_only in CC_PREPARATIO..
* 4679475d1 2023-03-23 CP-41796 enable HTTPS migration by default               
