### PR TITLE
Toolstack Tracing V1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,8 @@ install: build doc sdk doc-json
 # ocaml/rrd2csv
 	scripts/install.sh 755 _build/install/default/bin/rrd2csv $(DESTDIR)$(OPTDIR)/bin/rrd2csv
 	scripts/install.sh 644 ocaml/rrd2csv/man/rrd2csv.1.man $(DESTDIR)$(OPTMANDIR)/rrd2csv.1
+# ocaml/xs-trace
+	scripts/install.sh 755 _build/install/default/bin/xs-trace $(DESTDIR)/usr/bin/xs-trace
 # xcp-rrdd
 	install -D _build/install/default/bin/xcp-rrdd $(DESTDIR)/usr/sbin/xcp-rrdd
 	install -D _build/install/default/bin/rrddump $(DESTDIR)/usr/bin/rrddump

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7732,6 +7732,124 @@ module VUSB = struct
       ~messages:[create; unplug; destroy] ()
 end
 
+module Tracing = struct
+  let lifecycle = []
+
+  let set_status =
+    call ~name:"set_status" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; (Bool, "status", "The status the TracerProvider is to be set to")
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_tags =
+    call ~name:"set_tags" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Map (String, String)
+          , "tags"
+          , "The tags the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_endpoints =
+    call ~name:"set_endpoints" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Set String
+          , "endpoints"
+          , "The endpoints the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_components =
+    call ~name:"set_components" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Set String
+          , "components"
+          , "The components the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_filters =
+    call ~name:"set_filters" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Set String
+          , "filters"
+          , "The filter the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let set_processors =
+    call ~name:"set_processors" ~in_oss_since:None ~lifecycle
+      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+      ~params:
+        [
+          (Ref _tracing, "self", "The TracerProvider")
+        ; ( Set String
+          , "processors"
+          , "The processors the TracerProvider is to be set to"
+          )
+        ]
+      ~allowed_roles:_R_POOL_ADMIN ()
+
+  let t =
+    create_obj ~name:_tracing ~descr:"Describes a TracerProvider"
+      ~doccomments:[] ~gen_constructor_destructor:false ~gen_events:true
+      ~in_db:true ~lifecycle ~persist:PersistEverything ~in_oss_since:None
+      ~messages_default_allowed_roles:_R_POOL_ADMIN
+      ~contents:
+        ([uid _tracing ~lifecycle]
+        @ [
+            field ~qualifier:DynamicRO ~ty:(Set (Ref _host)) ~lifecycle "hosts"
+              "A list of hosts the TracerProvider is to be registered on"
+              ~ignore_foreign_key:true
+          ; field ~qualifier:DynamicRO ~ty:String ~lifecycle "name_label"
+              "A user-assinged label for a TracerProvider"
+          ; field ~qualifier:DynamicRO
+              ~ty:(Map (String, String))
+              ~lifecycle "tags"
+              "Tags to be set on spans to provide extra information"
+          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "endpoints"
+              "Endpoints where spans are exported to"
+          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "components"
+              "Componenets the TraverProvider is to be registered on"
+          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "filters"
+              "Filters for operations that spans will be produced for"
+          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "processors"
+              "Processors that will filter/map spans before being exported"
+          ; field ~qualifier:DynamicRO ~ty:Bool ~lifecycle "status"
+              "The status of the TracerProvider"
+          ]
+        )
+      ~messages:
+        [
+          set_status
+        ; set_tags
+        ; set_endpoints
+        ; set_components
+        ; set_filters
+        ; set_processors
+        ]
+      ()
+end
 (******************************************************************************************)
 
 (** All the objects in the system in order they will appear in documentation: *)
@@ -7803,6 +7921,7 @@ let all_system =
   ; PUSB.t
   ; USB_group.t
   ; VUSB.t
+  ; Tracing.t
   ; Datamodel_cluster.t
   ; Datamodel_cluster_host.t
   ; Datamodel_certificate.t
@@ -8040,6 +8159,7 @@ let expose_get_all_messages_for =
   ; _certificate
   ; _repository
   ; _vtpm
+  ; _tracing
   ]
 
 let no_task_id_for = [_task; (* _alert; *) _event]

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7732,124 +7732,6 @@ module VUSB = struct
       ~messages:[create; unplug; destroy] ()
 end
 
-module Tracing = struct
-  let lifecycle = []
-
-  let set_status =
-    call ~name:"set_status" ~in_oss_since:None ~lifecycle
-      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
-      ~params:
-        [
-          (Ref _tracing, "self", "The TracerProvider")
-        ; (Bool, "status", "The status the TracerProvider is to be set to")
-        ]
-      ~allowed_roles:_R_POOL_ADMIN ()
-
-  let set_tags =
-    call ~name:"set_tags" ~in_oss_since:None ~lifecycle
-      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
-      ~params:
-        [
-          (Ref _tracing, "self", "The TracerProvider")
-        ; ( Map (String, String)
-          , "tags"
-          , "The tags the TracerProvider is to be set to"
-          )
-        ]
-      ~allowed_roles:_R_POOL_ADMIN ()
-
-  let set_endpoints =
-    call ~name:"set_endpoints" ~in_oss_since:None ~lifecycle
-      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
-      ~params:
-        [
-          (Ref _tracing, "self", "The TracerProvider")
-        ; ( Set String
-          , "endpoints"
-          , "The endpoints the TracerProvider is to be set to"
-          )
-        ]
-      ~allowed_roles:_R_POOL_ADMIN ()
-
-  let set_components =
-    call ~name:"set_components" ~in_oss_since:None ~lifecycle
-      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
-      ~params:
-        [
-          (Ref _tracing, "self", "The TracerProvider")
-        ; ( Set String
-          , "components"
-          , "The components the TracerProvider is to be set to"
-          )
-        ]
-      ~allowed_roles:_R_POOL_ADMIN ()
-
-  let set_filters =
-    call ~name:"set_filters" ~in_oss_since:None ~lifecycle
-      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
-      ~params:
-        [
-          (Ref _tracing, "self", "The TracerProvider")
-        ; ( Set String
-          , "filters"
-          , "The filter the TracerProvider is to be set to"
-          )
-        ]
-      ~allowed_roles:_R_POOL_ADMIN ()
-
-  let set_processors =
-    call ~name:"set_processors" ~in_oss_since:None ~lifecycle
-      ~doc:"Set the fields of a TracerProvider in the Tracing Library"
-      ~params:
-        [
-          (Ref _tracing, "self", "The TracerProvider")
-        ; ( Set String
-          , "processors"
-          , "The processors the TracerProvider is to be set to"
-          )
-        ]
-      ~allowed_roles:_R_POOL_ADMIN ()
-
-  let t =
-    create_obj ~name:_tracing ~descr:"Describes a TracerProvider"
-      ~doccomments:[] ~gen_constructor_destructor:false ~gen_events:true
-      ~in_db:true ~lifecycle ~persist:PersistEverything ~in_oss_since:None
-      ~messages_default_allowed_roles:_R_POOL_ADMIN
-      ~contents:
-        ([uid _tracing ~lifecycle]
-        @ [
-            field ~qualifier:DynamicRO ~ty:(Set (Ref _host)) ~lifecycle "hosts"
-              "A list of hosts the TracerProvider is to be registered on"
-              ~ignore_foreign_key:true
-          ; field ~qualifier:DynamicRO ~ty:String ~lifecycle "name_label"
-              "A user-assinged label for a TracerProvider"
-          ; field ~qualifier:DynamicRO
-              ~ty:(Map (String, String))
-              ~lifecycle "tags"
-              "Tags to be set on spans to provide extra information"
-          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "endpoints"
-              "Endpoints where spans are exported to"
-          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "components"
-              "Componenets the TraverProvider is to be registered on"
-          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "filters"
-              "Filters for operations that spans will be produced for"
-          ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle "processors"
-              "Processors that will filter/map spans before being exported"
-          ; field ~qualifier:DynamicRO ~ty:Bool ~lifecycle "status"
-              "The status of the TracerProvider"
-          ]
-        )
-      ~messages:
-        [
-          set_status
-        ; set_tags
-        ; set_endpoints
-        ; set_components
-        ; set_filters
-        ; set_processors
-        ]
-      ()
-end
 (******************************************************************************************)
 
 (** All the objects in the system in order they will appear in documentation: *)
@@ -7921,7 +7803,7 @@ let all_system =
   ; PUSB.t
   ; USB_group.t
   ; VUSB.t
-  ; Tracing.t
+  ; Datamodel_tracing.t
   ; Datamodel_cluster.t
   ; Datamodel_cluster_host.t
   ; Datamodel_certificate.t

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 762
+let schema_minor_vsn = 763
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -302,6 +302,8 @@ let _certificate = "Certificate"
 let _diagnostics = "Diagnostics"
 
 let _repository = "Repository"
+
+let _tracing = "Tracing"
 
 let update_guidances =
   Enum

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -1,4 +1,6 @@
 let prototyped_of_class = function
+  | "Tracing" ->
+      Some "23.9.0"
   | "VTPM" ->
       Some "22.26.0"
   | _ ->
@@ -7,6 +9,24 @@ let prototyped_of_class = function
 let prototyped_of_field = function
   | "Repository", "gpgkey_path" ->
       Some "22.12.0"
+  | "Tracing", "status" ->
+      Some "23.9.0"
+  | "Tracing", "processors" ->
+      Some "23.9.0"
+  | "Tracing", "filters" ->
+      Some "23.9.0"
+  | "Tracing", "components" ->
+      Some "23.9.0"
+  | "Tracing", "endpoints" ->
+      Some "23.9.0"
+  | "Tracing", "tags" ->
+      Some "23.9.0"
+  | "Tracing", "name_label" ->
+      Some "23.9.0"
+  | "Tracing", "hosts" ->
+      Some "23.9.0"
+  | "Tracing", "uuid" ->
+      Some "23.9.0"
   | "VTPM", "contents" ->
       Some "22.26.0"
   | "VTPM", "is_protected" ->
@@ -39,6 +59,18 @@ let prototyped_of_message = function
       Some "22.20.0"
   | "Repository", "set_gpgkey_path" ->
       Some "22.12.0"
+  | "Tracing", "set_processors" ->
+      Some "23.9.0"
+  | "Tracing", "set_filters" ->
+      Some "23.9.0"
+  | "Tracing", "set_components" ->
+      Some "23.9.0"
+  | "Tracing", "set_endpoints" ->
+      Some "23.9.0"
+  | "Tracing", "set_tags" ->
+      Some "23.9.0"
+  | "Tracing", "set_status" ->
+      Some "23.9.0"
   | "message", "destroy_many" ->
       Some "22.19.0"
   | "VTPM", "set_contents" ->

--- a/ocaml/idl/datamodel_tracing.ml
+++ b/ocaml/idl/datamodel_tracing.ml
@@ -1,0 +1,129 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Datamodel_types
+open Datamodel_common
+open Datamodel_roles
+
+let set_status =
+  call ~name:"set_status" ~in_oss_since:None ~lifecycle:[]
+    ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+    ~params:
+      [
+        (Ref _tracing, "self", "The TracerProvider")
+      ; (Bool, "status", "The status the TracerProvider is to be set to")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_tags =
+  call ~name:"set_tags" ~in_oss_since:None ~lifecycle:[]
+    ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+    ~params:
+      [
+        (Ref _tracing, "self", "The TracerProvider")
+      ; ( Map (String, String)
+        , "tags"
+        , "The tags the TracerProvider is to be set to"
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_endpoints =
+  call ~name:"set_endpoints" ~in_oss_since:None ~lifecycle:[]
+    ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+    ~params:
+      [
+        (Ref _tracing, "self", "The TracerProvider")
+      ; ( Set String
+        , "endpoints"
+        , "The endpoints the TracerProvider is to be set to"
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_components =
+  call ~name:"set_components" ~in_oss_since:None ~lifecycle:[]
+    ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+    ~params:
+      [
+        (Ref _tracing, "self", "The TracerProvider")
+      ; ( Set String
+        , "components"
+        , "The components the TracerProvider is to be set to"
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_filters =
+  call ~name:"set_filters" ~in_oss_since:None ~lifecycle:[]
+    ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+    ~params:
+      [
+        (Ref _tracing, "self", "The TracerProvider")
+      ; (Set String, "filters", "The filter the TracerProvider is to be set to")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_processors =
+  call ~name:"set_processors" ~in_oss_since:None ~lifecycle:[]
+    ~doc:"Set the fields of a TracerProvider in the Tracing Library"
+    ~params:
+      [
+        (Ref _tracing, "self", "The TracerProvider")
+      ; ( Set String
+        , "processors"
+        , "The processors the TracerProvider is to be set to"
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let t =
+  create_obj ~name:_tracing ~descr:"Describes a TracerProvider" ~doccomments:[]
+    ~gen_constructor_destructor:false ~gen_events:true ~in_db:true ~lifecycle:[]
+    ~persist:PersistEverything ~in_oss_since:None
+    ~messages_default_allowed_roles:_R_POOL_ADMIN
+    ~contents:
+      ([uid _tracing ~lifecycle:[]]
+      @ [
+          field ~qualifier:DynamicRO ~ty:(Set (Ref _host)) ~lifecycle:[] "hosts"
+            "A list of hosts the TracerProvider is to be registered on"
+            ~ignore_foreign_key:true
+        ; field ~qualifier:DynamicRO ~ty:String ~lifecycle:[] "name_label"
+            "A user-assinged label for a TracerProvider"
+        ; field ~qualifier:DynamicRO
+            ~ty:(Map (String, String))
+            ~lifecycle:[] "tags"
+            "Tags to be set on spans to provide extra information"
+        ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle:[] "endpoints"
+            "Endpoints where spans are exported to"
+        ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle:[] "components"
+            "Componenets the TraverProvider is to be registered on"
+        ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle:[] "filters"
+            "Filters for operations that spans will be produced for"
+        ; field ~qualifier:DynamicRO ~ty:(Set String) ~lifecycle:[] "processors"
+            "Processors that will filter/map spans before being exported"
+        ; field ~qualifier:DynamicRO ~ty:Bool ~lifecycle:[] "status"
+            "The status of the TracerProvider"
+        ]
+      )
+    ~messages:
+      [
+        set_status
+      ; set_tags
+      ; set_endpoints
+      ; set_components
+      ; set_filters
+      ; set_processors
+      ]
+    ()

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -6,7 +6,7 @@
     datamodel_pool datamodel_cluster datamodel_cluster_host dm_api escaping
     datamodel_values datamodel_schema datamodel_certificate
     datamodel_diagnostics datamodel_repository datamodel_lifecycle
-    datamodel_vtpm)
+    datamodel_vtpm datamodel_tracing)
   (libraries
     ppx_sexp_conv.runtime-lib
     rpclib.core

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "c0f465587c9f59f8c17d1afa3c2998b2"
+let last_known_schema_hash = "29fb7e0b8860ca5a55e70dcfefb11895"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/libs/http-svr/dune
+++ b/ocaml/libs/http-svr/dune
@@ -27,6 +27,7 @@
     xapi-stdext-threads
     xapi-stdext-unix
     xml-light2
+    tracing
   )
 )
 

--- a/ocaml/libs/http-svr/http.ml
+++ b/ocaml/libs/http-svr/http.ml
@@ -124,6 +124,8 @@ module Hdr = struct
   let accept = "accept"
 
   let location = "location"
+
+  let traceparent = "traceparent"
 end
 
 let output_http fd headers =
@@ -554,6 +556,7 @@ module Request = struct
     ; mutable close: bool
     ; additional_headers: (string * string) list
     ; body: string option
+    ; traceparent: string option
   }
   [@@deriving rpc]
 
@@ -577,11 +580,12 @@ module Request = struct
     ; close= true
     ; additional_headers= []
     ; body= None
+    ; traceparent= None
     }
 
   let make ?(frame = false) ?(version = "1.1") ?(keep_alive = true) ?accept
       ?cookie ?length ?auth ?subtask_of ?body ?(headers = []) ?content_type
-      ?host ?(query = []) ~user_agent meth path =
+      ?host ?(query = []) ?traceparent ~user_agent meth path =
     {
       empty with
       version
@@ -600,6 +604,7 @@ module Request = struct
     ; body
     ; accept
     ; query
+    ; traceparent
     }
 
   let get_version x = x.version
@@ -631,6 +636,7 @@ module Request = struct
             ; close= false
             ; additional_headers= []
             ; body= None
+            ; traceparent= None
             }
         | None ->
             error "Failed to parse: %s" x ;
@@ -646,7 +652,8 @@ module Request = struct
     Printf.sprintf
       "{ frame = %b; method = %s; uri = %s; query = [ %s ]; content_length = [ \
        %s ]; transfer encoding = %s; version = %s; cookie = [ %s ]; task = %s; \
-       subtask_of = %s; content-type = %s; host = %s; user_agent = %s }"
+       subtask_of = %s; content-type = %s; host = %s; user_agent = %s; \
+       traceparent = %s }"
       x.frame (string_of_method_t x.m) x.uri (kvpairs x.query)
       (Option.fold ~none:"" ~some:Int64.to_string x.content_length)
       (Option.value ~default:"" x.transfer_encoding)
@@ -656,6 +663,7 @@ module Request = struct
       (Option.value ~default:"" x.content_type)
       (Option.value ~default:"" x.host)
       (Option.value ~default:"" x.user_agent)
+      (Option.value ~default:"" x.traceparent)
 
   let to_header_list x =
     let kvpairs x =
@@ -705,6 +713,11 @@ module Request = struct
         ~some:(fun x -> [Hdr.user_agent ^ ": " ^ x])
         x.user_agent
     in
+    let traceparent =
+      Option.fold ~none:[]
+        ~some:(fun x -> [Hdr.traceparent ^ ": " ^ x])
+        x.traceparent
+    in
     let close =
       [(Hdr.connection ^ ": " ^ if x.close then "close" else "keep-alive")]
     in
@@ -722,6 +735,7 @@ module Request = struct
     @ content_type
     @ host
     @ user_agent
+    @ traceparent
     @ close
     @ List.map (fun (k, v) -> k ^ ":" ^ v) x.additional_headers
 

--- a/ocaml/libs/http-svr/http.mli
+++ b/ocaml/libs/http-svr/http.mli
@@ -88,6 +88,7 @@ module Request : sig
     ; mutable close: bool
     ; additional_headers: (string * string) list
     ; body: string option
+    ; traceparent: string option
   }
 
   val rpc_of_t : t -> Rpc.t
@@ -110,6 +111,7 @@ module Request : sig
     -> ?content_type:string
     -> ?host:string
     -> ?query:(string * string) list
+    -> ?traceparent:string
     -> user_agent:string
     -> method_t
     -> string
@@ -227,6 +229,8 @@ module Hdr : sig
   val accept : string
 
   val location : string
+
+  val traceparent : string
 end
 
 val output_http : Unix.file_descr -> string list -> unit

--- a/ocaml/libs/http-svr/http_svr.ml
+++ b/ocaml/libs/http-svr/http_svr.ml
@@ -400,6 +400,8 @@ let request_of_bio_exn ~proxy_seen ~read_timeout ~total_timeout ~max_length bio
                        {req with host= Some v}
                    | k when k = Http.Hdr.user_agent ->
                        {req with user_agent= Some v}
+                   | k when k = Http.Hdr.traceparent ->
+                       {req with traceparent= Some v}
                    | k when k = Http.Hdr.connection && lowercase v = "close" ->
                        {req with close= true}
                    | k

--- a/ocaml/libs/http-svr/xmlrpc_client.ml
+++ b/ocaml/libs/http-svr/xmlrpc_client.ml
@@ -49,10 +49,18 @@ let connect ?session_id ?task_id ?subtask_of path =
     ?subtask_of Http.Connect path
 
 let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth
-    ?subtask_of ?query ?body path =
+    ?subtask_of ?query ?body ?(tracing = None) path =
+  let traceparent =
+    let open Tracing in
+    Option.map
+      (fun span -> Span.get_span_context span |> SpanContext.to_traceparent)
+      tracing
+  in
+  debug "Setting traceparent header = %s"
+    (Option.value ~default:"None" traceparent) ;
   let headers = Option.map (fun x -> [(Http.Hdr.task_id, x)]) task_id in
   Http.Request.make ~user_agent ?frame ?version ?keep_alive ?cookie ?headers
-    ?length ?auth ?subtask_of ?query ?body Http.Post path
+    ?length ?auth ?subtask_of ?query ?body ?traceparent Http.Post path
 
 (** Thrown when ECONNRESET is caught which suggests the remote crashed or restarted *)
 exception Connection_reset

--- a/ocaml/libs/http-svr/xmlrpc_client.ml
+++ b/ocaml/libs/http-svr/xmlrpc_client.ml
@@ -53,7 +53,10 @@ let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth
   let traceparent =
     let open Tracing in
     Option.map
-      (fun span -> Span.get_span_context span |> SpanContext.to_traceparent)
+      (fun span ->
+        let _ = Span.set_span_kind span SpanKind.Client in
+        Span.get_span_context span |> SpanContext.to_traceparent
+      )
       tracing
   in
   debug "Setting traceparent header = %s"

--- a/ocaml/libs/http-svr/xmlrpc_client.mli
+++ b/ocaml/libs/http-svr/xmlrpc_client.mli
@@ -72,6 +72,7 @@ val xmlrpc :
   -> ?subtask_of:string
   -> ?query:(string * string) list
   -> ?body:string
+  -> ?tracing:Tracing.t
   -> string
   -> Http.Request.t
 (** Returns an HTTP.Request.t representing an XMLRPC request *)

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -1,0 +1,12 @@
+(library
+  (name tracing)
+  (public_name xapi-tracing)
+  (libraries
+    cohttp
+    rpclib.core
+    rpclib.json
+    xapi-idl
+    xapi-stdext-unix
+  )
+  (preprocess (pps ppx_deriving_rpc))
+)

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -485,13 +485,19 @@ module Export = struct
         try
           (* TODO: *)
           let host_id = "myhostid" in
-          let timestamp = Unix.gettimeofday () |> string_of_float in
-          let microsec = String.sub timestamp 6 (String.length timestamp - 6) in
-          let unix_time = float_of_string timestamp |> Unix.localtime in
+          let timestamp = Unix.gettimeofday () in
+          let timestamp_ms =
+            timestamp *. 1000000. |> int_of_float |> string_of_int
+          in
+          let microsec =
+            String.sub timestamp_ms 6 (String.length timestamp_ms - 6)
+          in
+          let unix_time = timestamp |> Unix.localtime in
           let date =
-            Printf.sprintf "%d%d%d-%d%d%d-%s" unix_time.tm_year unix_time.tm_mon
-              unix_time.tm_mday unix_time.tm_hour unix_time.tm_min
-              unix_time.tm_sec microsec
+            Printf.sprintf "%d%02d%d-%d%d%d-%s"
+              (Int.rem unix_time.tm_year 100)
+              (unix_time.tm_mon + 1) unix_time.tm_mday unix_time.tm_hour
+              unix_time.tm_min unix_time.tm_sec microsec
           in
           let file =
             String.concat "/" [path; trace_id; "xapi"; host_id; date] ^ ".json"

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -273,7 +273,7 @@ module TracerProviders = struct
             tracer
         )
 
-  let set_default ~tags ~endpoints ~processors ~filters =
+  let set_default ~tags ~endpoints ~processors ~filters ~enabled =
     let endpoints = List.map endpoint_of_string endpoints in
     let default : TracerProvider.t =
       {
@@ -285,7 +285,7 @@ module TracerProviders = struct
           ; endpoints
           ; filters
           ; processors
-          ; enabled= true
+          ; enabled
           }
       }
     in
@@ -323,6 +323,41 @@ module TracerProviders = struct
                 }
             }
           ~name
+
+  let set ?status ?tags ?endpoints ?filters ?processors ~name_label () =
+    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+        let provider : TracerProvider.t =
+          match Hashtbl.find_opt tracer_providers name_label with
+          | Some provider ->
+              let config = provider.config in
+              let enabled = Option.value ~default:config.enabled status in
+              let tags = Option.value ~default:config.tags tags in
+              let endpoints =
+                Option.fold ~none:config.endpoints
+                  ~some:(List.map endpoint_of_string)
+                  endpoints
+              in
+              let filters = Option.value ~default:config.filters filters in
+              let processors =
+                Option.value ~default:config.processors processors
+              in
+              let config =
+                {config with enabled; tags; endpoints; filters; processors}
+              in
+              let tracers =
+                List.map
+                  (fun tracer : Tracer.t -> {tracer with provider= ref config})
+                  provider.tracers
+              in
+              {config; tracers}
+          | None ->
+              failwith
+                (Printf.sprintf "The TracerProvider : %s does not exist"
+                   name_label
+                )
+        in
+        Hashtbl.replace tracer_providers name_label provider
+    )
 end
 
 type blob = Span.t [@@deriving rpcty]

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -1,0 +1,98 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+module SpanContext = struct
+  type t = {trace_id: string; span_id: string} [@@deriving rpcty]
+end
+
+module Span = struct
+  type t = {
+      span_context: SpanContext.t
+    ; span_parent: t option
+    ; span_name: string
+    ; span_begin_time: float
+    ; mutable span_end_time: float option
+    ; mutable tags: (string * string) list
+  }
+  [@@deriving rpcty]
+
+  let generate_id n = String.init n (fun _ -> "0123456789abcdef".[Random.int 16])
+
+  let start ?(tags = []) ~name ~parent () =
+    let trace_id =
+      match parent with
+      | None ->
+          generate_id 32
+      | Some span_parent ->
+          span_parent.span_context.trace_id
+    in
+    let span_id = generate_id 16 in
+    let span_context : SpanContext.t = {trace_id; span_id} in
+    let span_parent = parent in
+    let span_name = name in
+    let span_begin_time = Unix.gettimeofday () in
+    let span_end_time = None in
+    {span_context; span_parent; span_name; span_begin_time; span_end_time; tags}
+
+  let finish ?(tags = []) ~span () =
+    span.span_end_time <- Some (Unix.gettimeofday ()) ;
+    match (span.tags, tags) with
+    | _, [] ->
+        ()
+    | [], new_tags ->
+        span.tags <- new_tags
+    | orig_tags, new_tags ->
+        span.tags <- orig_tags @ new_tags
+
+  let lock = Mutex.create ()
+
+end
+
+let spans = Hashtbl.create 100
+
+let add_to_spans ~(span : Span.t) =
+  Xapi_stdext_threads.Threadext.Mutex.execute Span.lock (fun () ->
+      let key = span.span_context.trace_id in
+      match Hashtbl.find_opt spans key with
+      | None ->
+          Hashtbl.add spans key [span]
+      | Some span_list ->
+          if List.length span_list < 1000 then
+            Hashtbl.replace spans key (span :: span_list)
+  )
+
+type blob = Span.t [@@deriving rpcty]
+
+type t = blob option [@@deriving rpcty]
+
+let t_to_string_opt =
+  Option.map (fun s ->
+      Rpcmarshal.marshal blob.Rpc.Types.ty s |> Jsonrpc.to_string
+  )
+
+let t_of_string x : t =
+  x
+  |> Jsonrpc.of_string
+  |> Rpcmarshal.unmarshal blob.Rpc.Types.ty
+  |> Result.to_option
+
+let empty : t = None
+
+let is_empty = function None -> true | Some _ -> false
+
+let start ~name ~parent : (t, exn) result =
+  let span = Span.start ~name ~parent () in
+  add_to_spans ~span ; Ok (Some span)
+
+let finish x : (unit, exn) result =
+  match x with None -> Ok () | Some span -> Span.finish ~span () ; Ok ()

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -32,6 +32,36 @@ module Tracer : sig
   type t
 
   val span_of_span_context : SpanContext.t -> string -> Span.t
+
+  val start :
+       tracer:t
+    -> name:string
+    -> parent:Span.t option
+    -> (Span.t option, exn) result
+
+  val finish : Span.t option -> (unit, exn) result
+end
+
+module TracerProvider : sig
+  type t
+
+  val find_tracer : provider:t -> name:string -> Tracer.t
+end
+
+module TracerProviders : sig
+  val find_or_create_tracer :
+    provider:TracerProvider.t -> name:string -> Tracer.t
+
+  val set_default :
+       tags:(string * string) list
+    -> endpoints:string list
+    -> processors:string list
+    -> filters:string list
+    -> unit
+
+  val get_default : unit -> (TracerProvider.t, exn) result
+
+  val get_default_tracer : name:string -> Tracer.t
 end
 
 type blob = Span.t
@@ -47,7 +77,3 @@ val t_of_string : string -> t
 val t_to_string_opt : t -> string option
 
 (* Create spans *)
-
-val start : name:string -> parent:t -> (t, exn) result
-
-val finish : t -> (unit, exn) result

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -59,6 +59,17 @@ module TracerProviders : sig
     -> endpoints:string list
     -> processors:string list
     -> filters:string list
+    -> enabled:bool
+    -> unit
+
+  val set :
+       ?status:bool
+    -> ?tags:(string * string) list
+    -> ?endpoints:string list
+    -> ?filters:string list
+    -> ?processors:string list
+    -> name_label:string
+    -> unit
     -> unit
 
   val get_default : unit -> (TracerProvider.t, exn) result

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -40,6 +40,8 @@ module Tracer : sig
     -> (Span.t option, exn) result
 
   val finish : Span.t option -> (unit, exn) result
+
+  val assert_finished : Span.t option -> bool
 end
 
 module TracerProvider : sig
@@ -76,4 +78,4 @@ val t_of_string : string -> t
 
 val t_to_string_opt : t -> string option
 
-(* Create spans *)
+val enable_span_garbage_collector : ?timeout:float -> unit -> unit

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -14,6 +14,12 @@
 
 (* Basic types *)
 
+module SpanKind : sig
+  type t = Server | Consumer | Client | Producer | Internal
+
+  val to_string : t -> string
+end
+
 module SpanContext : sig
   type t
 
@@ -26,6 +32,8 @@ module Span : sig
   type t
 
   val get_span_context : t -> SpanContext.t
+
+  val set_span_kind : t -> SpanKind.t -> unit
 end
 
 module Tracer : sig
@@ -34,9 +42,11 @@ module Tracer : sig
   val span_of_span_context : SpanContext.t -> string -> Span.t
 
   val start :
-       tracer:t
+       ?kind:SpanKind.t
+    -> tracer:t
     -> name:string
     -> parent:Span.t option
+    -> unit
     -> (Span.t option, exn) result
 
   val finish : Span.t option -> (unit, exn) result

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -14,7 +14,27 @@
 
 (* Basic types *)
 
-type blob
+module SpanContext : sig
+  type t
+
+  val to_traceparent : t -> string
+
+  val of_traceparent : string -> t option
+end
+
+module Span : sig
+  type t
+
+  val get_span_context : t -> SpanContext.t
+end
+
+module Tracer : sig
+  type t
+
+  val span_of_span_context : SpanContext.t -> string -> Span.t
+end
+
+type blob = Span.t
 
 type t = blob option
 

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -79,3 +79,11 @@ val t_of_string : string -> t
 val t_to_string_opt : t -> string option
 
 val enable_span_garbage_collector : ?timeout:float -> unit -> unit
+
+module Export : sig
+  module Destination : sig
+    module Http : sig
+      val export : span_json:string -> url:string -> (string, exn) result
+    end
+  end
+end

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -1,0 +1,33 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* Basic types *)
+
+type blob
+
+type t = blob option
+
+val empty : t
+
+val is_empty : t -> bool
+
+val t_of_string : string -> t
+
+val t_to_string_opt : t -> string option
+
+(* Create spans *)
+
+val start : name:string -> parent:t -> (t, exn) result
+
+val finish : t -> (unit, exn) result

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1306,6 +1306,11 @@ let gen_cmds rpc session_id =
           ]
           rpc session_id
       )
+    ; Client.Tracing.(
+        mk get_all_records_where get_by_uuid tracing_record "tracing" []
+          ["uuid"; "name_label"; "endpoints"; "status"]
+          rpc session_id
+      )
     ; Client.VTPM.(
         mk get_all_records_where get_by_uuid vtpm_record "vtpm" []
           ["uuid"; "vm"; "profile"] rpc session_id

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5242,3 +5242,119 @@ let vtpm_record rpc session_id vtpm =
           ()
       ]
   }
+
+let tracing_record rpc session_id tracing =
+  let _ref = ref tracing in
+  let empty_record =
+    ToGet (fun () -> Client.Tracing.get_record ~rpc ~session_id ~self:!_ref)
+  in
+  let record = ref empty_record in
+  let x () = lzy_get record in
+  {
+    setref=
+      (fun r ->
+        _ref := r ;
+        record := empty_record
+      )
+  ; setrefrec=
+      (fun (a, b) ->
+        _ref := a ;
+        record := Got b
+      )
+  ; record= x
+  ; getref= (fun () -> !_ref)
+  ; fields=
+      [
+        make_field ~name:"uuid" ~get:(fun () -> (x ()).API.tracing_uuid) ()
+      ; make_field ~name:"hosts"
+          ~get:(fun () ->
+            List.map get_uuid_from_ref (x ()).API.tracing_hosts
+            |> String.concat ","
+            |> fun s -> if s = "" then "all" else ""
+          )
+          ()
+      ; make_field ~name:"name_label"
+          ~get:(fun () -> (x ()).API.tracing_name_label)
+          ()
+      ; make_field ~name:"tags"
+          ~get:(fun () ->
+            List.map
+              (fun (k, v) -> Printf.sprintf "%s : %s" k v)
+              (x ()).API.tracing_tags
+            |> String.concat ","
+            |> fun s -> if s = "" then "none" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s
+            |> List.filter_map (fun kv ->
+                   match String.split_on_char ':' kv with
+                   | [k; _] when List.mem k ["host"; "pool"; "host name"] ->
+                       None (* Reserved Tags*)
+                   | [k; v] ->
+                       Some (k, v)
+                   | _ ->
+                       None
+               )
+            |> fun tags ->
+            Client.Tracing.set_tags ~rpc ~session_id ~self:tracing ~tags
+          )
+          ()
+      ; make_field ~name:"endpoints"
+          ~get:(fun () ->
+            (x ()).API.tracing_endpoints |> String.concat ", " |> fun s ->
+            if s = "" then "none" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s |> List.filter (( <> ) "none")
+            |> fun endpoints ->
+            Client.Tracing.set_endpoints ~rpc ~session_id ~self:tracing
+              ~endpoints
+          )
+          ()
+      ; make_field ~name:"components"
+          ~get:(fun () ->
+            (x ()).API.tracing_components |> String.concat ", " |> fun s ->
+            if s = "" then "all" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s |> List.filter (( <> ) "all")
+            |> fun components ->
+            Client.Tracing.set_components ~rpc ~session_id ~self:tracing
+              ~components
+          )
+          ()
+      ; make_field ~name:"filters"
+          ~get:(fun () ->
+            (x ()).API.tracing_filters |> String.concat ", " |> fun s ->
+            if s = "" then "all" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s |> List.filter (( <> ) "all")
+            |> fun filters ->
+            Client.Tracing.set_filters ~rpc ~session_id ~self:tracing ~filters
+          )
+          ()
+      ; make_field ~name:"processors"
+          ~get:(fun () ->
+            (x ()).API.tracing_processors |> String.concat ", " |> fun s ->
+            if s = "" then "none" else s
+          )
+          ~set:(fun s ->
+            String.split_on_char ',' s |> List.filter (( <> ) "none")
+            |> fun processors ->
+            Client.Tracing.set_processors ~rpc ~session_id ~self:tracing
+              ~processors
+          )
+          ()
+      ; make_field ~name:"status"
+          ~get:(fun () ->
+            (x ()).API.tracing_status |> fun b ->
+            if b then "enabled" else "disabled"
+          )
+          ~set:(fun s ->
+            s = "enabled" |> fun status ->
+            Client.Tracing.set_status ~rpc ~session_id ~self:tracing ~status
+          )
+          ()
+      ]
+  }

--- a/ocaml/xapi-idl/lib/task_server.mli
+++ b/ocaml/xapi-idl/lib/task_server.mli
@@ -118,4 +118,8 @@ module Task : functor (Interface : INTERFACE) -> sig
      Useful for asynchronous tasks that we don't wait for.
   *)
   val destroy_on_finish : task_handle -> unit
+
+  val tracing : task_handle -> string option
+
+  val set_tracing : task_handle -> string option -> unit
 end

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -128,6 +128,7 @@ module Actions = struct
   module Certificate = Certificates
   module Diagnostics = Xapi_diagnostics
   module Repository = Repository
+  module Tracing = Xapi_tracing
 end
 
 (** Use the server functor to make an XML-RPC dispatcher. *)

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -148,6 +148,13 @@ let __destroy_task : (__context:t -> API.ref_task -> unit) ref =
 
 let string_of_task __context = __context.dbg
 
+let string_of_task_and_tracing __context =
+  match Tracing.t_to_string_opt __context.tracing with
+  | None ->
+      __context.dbg
+  | Some tracing ->
+      __context.dbg ^ "\x00" ^ tracing
+
 let check_for_foreign_database ~__context =
   match __context.session_id with
   | Some sid -> (

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -48,10 +48,22 @@ type t = {
   ; origin: origin
   ; database: Db_ref.t
   ; dbg: string
+  ; mutable tracing: Tracing.t
   ; client: (http_t * Ipaddr.t) option
   ; mutable test_rpc: (Rpc.call -> Rpc.response) option
   ; mutable test_clusterd_rpc: (Rpc.call -> Rpc.response) option
 }
+
+let complete_tracing __context =
+  ( match Tracing.finish __context.tracing with
+  | Ok () ->
+      ()
+  | Error e ->
+      R.warn "Failed to complete tracing: %s" (Printexc.to_string e)
+  ) ;
+  __context.tracing <- Tracing.empty
+
+let tracing_of __context = __context.tracing
 
 let get_session_id x =
   match x.session_id with
@@ -109,6 +121,7 @@ let get_initial () =
   ; origin= Internal
   ; database= default_database ()
   ; dbg= "initial_task"
+  ; tracing= Tracing.empty
   ; client= None
   ; test_rpc= None
   ; test_clusterd_rpc= None
@@ -237,6 +250,17 @@ let from_forwarded_task ?(http_other_config = []) ?session_id
   let dbg = make_dbg http_other_config task_name task_id in
   info "task %s forwarded%s" dbg
     (trackid_of_session ~with_brackets:true ~prefix:" " session_id) ;
+  let tracing =
+    let open Tracing in
+    (* Set parent based on trace context from forwarded call instead! *)
+    let parent = empty in
+    match start ~name:task_name ~parent with
+    | Ok x ->
+        x
+    | Error e ->
+        R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+        None
+  in
   {
     session_id
   ; task_id
@@ -244,6 +268,7 @@ let from_forwarded_task ?(http_other_config = []) ?session_id
   ; origin
   ; database= default_database ()
   ; dbg
+  ; tracing
   ; client
   ; test_rpc= None
   ; test_clusterd_rpc= None
@@ -282,6 +307,19 @@ let make ?(http_other_config = []) ?(quiet = false) ?subtask_of ?session_id
             " by task " ^ make_dbg [] "" subtask_of
         )
   ) ;
+  let tracing =
+    let open Tracing in
+    (* Set parent based on incoming trace context instead! *)
+    let parent = empty in
+    match start ~name:task_name ~parent with
+    | Ok x ->
+        R.debug "Started trace: %s"
+          (Option.value ~default:"(empty)" (t_to_string_opt x)) ;
+        x
+    | Error e ->
+        R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+        None
+  in
   {
     session_id
   ; database
@@ -289,6 +327,7 @@ let make ?(http_other_config = []) ?(quiet = false) ?subtask_of ?session_id
   ; origin
   ; forwarded_task= false
   ; dbg
+  ; tracing
   ; client
   ; test_rpc= None
   ; test_clusterd_rpc= None
@@ -298,7 +337,20 @@ let make_subcontext ~__context ?task_in_database task_name =
   let session_id = __context.session_id in
   let subtask_of = __context.task_id in
   let subcontext = make ~subtask_of ?session_id ?task_in_database task_name in
-  {subcontext with client= __context.client}
+  let tracing =
+    let open Tracing in
+    let parent = __context.tracing in
+    if is_empty parent then
+      empty
+    else (* only create a tracing if we're part of a tree *)
+      match Tracing.start ~name:task_name ~parent with
+      | Ok x ->
+          x
+      | Error e ->
+          R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+          None
+  in
+  {subcontext with client= __context.client; tracing}
 
 let get_http_other_config http_req =
   let http_other_config_hdr = "x-http-other-config-" in
@@ -361,3 +413,15 @@ let get_client_ip context =
 
 let get_user_agent context =
   match context.origin with Internal -> None | Http (rq, _) -> rq.user_agent
+
+let with_tracing context name f =
+  let parent = context.tracing in
+  match Tracing.start ~name ~parent with
+  | Ok span_context ->
+      let new_context = {context with tracing= span_context} in
+      let result = f new_context in
+      let _ = Tracing.finish span_context in
+      result
+  | Error e ->
+      R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+      f context

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -155,6 +155,14 @@ let string_of_task_and_tracing __context =
   | Some tracing ->
       __context.dbg ^ "\x00" ^ tracing
 
+let tracing_of_dbg dbg =
+  match String.index_opt dbg '\x00' with
+  | Some i ->
+      let tracing = String.sub dbg (i + 1) (String.length dbg - i - 1) in
+      (String.sub dbg 0 i, Tracing.t_of_string tracing)
+  | None ->
+      (dbg, Tracing.empty)
+
 let check_for_foreign_database ~__context =
   match __context.session_id with
   | Some sid -> (

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -76,6 +76,8 @@ val forwarded_task : t -> bool
 
 val string_of_task : t -> string
 
+val string_of_task_and_tracing : t -> string
+
 val task_in_database : t -> bool
 (** [task_in_database __context] indicates if [get_task_id __context] corresponds to a task stored in database or
     to a dummy task. *)

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -139,3 +139,9 @@ val get_client : t -> string option
 val get_client_ip : t -> string option
 
 val get_user_agent : t -> string option
+
+val complete_tracing : t -> unit
+
+val tracing_of : t -> Tracing.t
+
+val with_tracing : t -> string -> (t -> 'a) -> 'a

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -78,6 +78,8 @@ val string_of_task : t -> string
 
 val string_of_task_and_tracing : t -> string
 
+val tracing_of_dbg : string -> string * Tracing.t
+
 val task_in_database : t -> bool
 (** [task_in_database __context] indicates if [get_task_id __context] corresponds to a task stored in database or
     to a dummy task. *)

--- a/ocaml/xapi/dbsync.ml
+++ b/ocaml/xapi/dbsync.ml
@@ -48,9 +48,9 @@ let create_host_metrics ~__context =
     )
     (Db.Host.get_all ~__context)
 
-let update_env () =
-  Server_helpers.exec_with_new_task "dbsync (update_env)" ~task_in_database:true
-    (fun __context ->
+let update_env ~__context =
+  Server_helpers.exec_with_subtask ~__context "dbsync (update_env)"
+    ~task_in_database:true (fun ~__context ->
       let other_config =
         match Db.Pool.get_all ~__context with
         | [pool] ->
@@ -73,8 +73,8 @@ let update_env () =
       if not (Pool_role.is_master ()) then resync_dom0_config_files ()
   )
 
-let setup () =
-  try update_env ()
+let setup ~__context =
+  try update_env ~__context
   with exn ->
     Backtrace.is_important exn ;
     debug "dbsync caught an exception: %s" (ExnHelper.string_of_exn exn) ;

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -144,6 +144,7 @@
     xapi-stdext-threads
     xapi-stdext-unix
     xapi-stdext-zerocheck
+    xapi-tracing
     xapi-xenopsd
     xenstore_transport.unix
     xml-light2

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -388,7 +388,9 @@ let update_pif_addresses ~__context =
 let make_rpc ~__context rpc : Rpc.response =
   let subtask_of = Ref.string_of (Context.get_task_id __context) in
   let open Xmlrpc_client in
-  let http = xmlrpc ~subtask_of ~version:"1.1" "/" in
+  let http =
+    xmlrpc ~subtask_of ~version:"1.1" "/" ~tracing:(Context.tracing_of __context)
+  in
   let transport =
     if Pool_role.is_master () then
       Unix Xapi_globs.unix_domain_socket

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -59,7 +59,11 @@ let remote_rpc_no_retry _context hostname (task_opt : API.ref_task option) xml =
       )
   in
   let http =
-    xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.0" "/"
+    xmlrpc
+      ?task_id:(Option.map Ref.string_of task_opt)
+      ~version:"1.0"
+      ~tracing:(Context.tracing_of _context)
+      "/"
   in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
@@ -76,7 +80,11 @@ let remote_rpc_retry _context hostname (task_opt : API.ref_task option) xml =
       )
   in
   let http =
-    xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.1" "/"
+    xmlrpc
+      ?task_id:(Option.map Ref.string_of task_opt)
+      ~version:"1.1"
+      ~tracing:(Context.tracing_of _context)
+      "/"
   in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6498,9 +6498,6 @@ functor
         let localhost = Helpers.get_localhost ~__context in
         if Helpers.is_pool_master ~__context ~host:localhost then (
           db_fn () ;
-          (* Option.iter
-             (fun status -> Db.Tracing.set_status ~__context ~self ~value:status)
-             status ; *)
           let hosts =
             match Db.Tracing.get_hosts ~__context ~self with
             | [] ->
@@ -6518,7 +6515,7 @@ functor
         ()
 
       let set_status ~__context ~self ~status =
-        info "Tracing.set_status: self=%s status=%B"
+        info "%s: self=%s status=%B" __FUNCTION__
           (tracing_uuid ~__context self)
           status ;
         let local_fn = Local.Tracing.set_status ~self ~status in
@@ -6533,7 +6530,7 @@ functor
           Db.Pool.get_uuid ~__context ~self:(Helpers.get_pool ~__context)
         in
         let tags = ("pool", pool) :: tags in
-        info "Tracing.set_tags: self=%s tags=%s"
+        info "%s: self=%s tags=%s" __FUNCTION__
           (tracing_uuid ~__context self)
           (List.map (fun (k, v) -> k ^ ":" ^ v) tags |> String.concat ",") ;
         let local_fn = Local.Tracing.set_tags ~self ~tags in
@@ -6544,9 +6541,7 @@ functor
         do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
 
       let set_endpoints ~__context ~self ~endpoints =
-        info "Tracing.set_endpoints: self=%s endpoints=%s"
-          (tracing_uuid ~__context self)
-          (endpoints |> String.concat ",") ;
+        info "%s: self=%s" __FUNCTION__ (tracing_uuid ~__context self) ;
         let local_fn = Local.Tracing.set_endpoints ~self ~endpoints in
         let client_fn session_id rpc =
           Client.Tracing.set_endpoints ~rpc ~session_id ~self ~endpoints
@@ -6557,7 +6552,7 @@ functor
         do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
 
       let set_components ~__context ~self ~components =
-        info "Tracing.set_components: self=%s components=%s"
+        info "%s: self=%s components=%s" __FUNCTION__
           (tracing_uuid ~__context self)
           (components |> String.concat ",") ;
         let local_fn = Local.Tracing.set_components ~self ~components in
@@ -6570,7 +6565,7 @@ functor
         do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
 
       let set_filters ~__context ~self ~filters =
-        info "Tracing.set_filters: self=%s filters=%s"
+        info "%s: self=%s filters=%s" __FUNCTION__
           (tracing_uuid ~__context self)
           (filters |> String.concat ",") ;
         let local_fn = Local.Tracing.set_filters ~self ~filters in
@@ -6581,7 +6576,7 @@ functor
         do_trace_op_on ~__context ~self ~local_fn ~client_fn ~db_fn
 
       let set_processors ~__context ~self ~processors =
-        info "Tracing.set_processors: self=%s processors=%s"
+        info "%s: self=%s processors=%s" __FUNCTION__
           (tracing_uuid ~__context self)
           (processors |> String.concat ",") ;
         let local_fn = Local.Tracing.set_processors ~self ~processors in

--- a/ocaml/xapi/startup.ml
+++ b/ocaml/xapi/startup.ml
@@ -84,18 +84,16 @@ let run ~__context tasks =
             ignore
               (Thread.create
                  (fun tsk_fct ->
-                   Server_helpers.exec_with_new_task
-                     ~subtask_of:(Context.get_task_id __context) tsk_name
-                     (fun __context -> thread_exn_wrapper tsk_name tsk_fct
+                   Server_helpers.exec_with_subtask ~__context tsk_name
+                     (fun ~__context -> thread_exn_wrapper tsk_name tsk_fct
                    )
                  )
                  tsk_fct
               )
           ) else (
             debug "task [%s]" tsk_name ;
-            Server_helpers.exec_with_new_task tsk_name
-              ~subtask_of:(Context.get_task_id __context) (fun __context ->
-                tsk_fct ()
+            Server_helpers.exec_with_subtask ~__context tsk_name
+              (fun ~__context -> tsk_fct ()
             )
           )
         )

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -18,6 +18,20 @@ module D = Debug.Make (struct let name = "mux" end)
 
 open D
 
+let with_tracing ~name ~dbg f =
+  let dbg, parent = Context.tracing_of_dbg dbg in
+  let name = "SM." ^ name in
+  let tracer = Tracing.TracerProviders.get_default_tracer ~name in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent () in
+  match span with
+  | Ok span_context ->
+      let result = f dbg in
+      let _ = Tracing.Tracer.finish span_context in
+      result
+  | Error e ->
+      D.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+      f dbg
+
 type processor = Rpc.call -> Rpc.response
 
 let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
@@ -167,6 +181,7 @@ module Mux = struct
           let module C = StorageAPI (Idl.Exn.GenClient (struct
             let rpc = of_sr sr
           end)) in
+          with_tracing ~name:"Query.diagnostics" ~dbg @@ fun dbg ->
           C.Query.diagnostics dbg
       )
   end
@@ -224,12 +239,14 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"DP.destroy2" ~dbg @@ fun dbg ->
       C.DP.destroy2 dbg dp sr vdi vm allow_leak ;
       DP_info.delete dp
 
     let destroy _context ~dbg ~dp ~allow_leak =
       info "DP.destroy dbg:%s dp:%s allow_leak:%b" dbg dp allow_leak ;
       let open DP_info in
+      with_tracing ~name:"DP.destroy" ~dbg @@ fun dbg ->
       match read dp with
       | Some {sr; vdi; vm; _} ->
           destroy2 _context ~dbg ~dp ~sr ~vdi ~vm ~allow_leak
@@ -279,6 +296,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"SR.create" ~dbg @@ fun dbg ->
       C.SR.create dbg sr name_label name_description device_config physical_size
 
     let attach () ~dbg ~sr ~device_config =
@@ -287,6 +305,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"SR.attach" ~dbg @@ fun dbg ->
       C.SR.attach dbg sr device_config
 
     let set_name_label () ~dbg ~sr ~new_name_label =
@@ -295,6 +314,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"SR.set_name_label" ~dbg @@ fun dbg ->
       C.SR.set_name_label dbg sr new_name_label
 
     let set_name_description () ~dbg ~sr ~new_name_description =
@@ -303,6 +323,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"SR.set_name_description" ~dbg @@ fun dbg ->
       C.SR.set_name_description dbg sr new_name_description
 
     let detach () ~dbg ~sr =
@@ -310,28 +331,28 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
-      C.SR.detach dbg sr
+      with_tracing ~name:"SR.detach" ~dbg @@ fun dbg -> C.SR.detach dbg sr
 
     let destroy () ~dbg ~sr =
       info "SR.destroy dbg:%s sr:%s" dbg (s_of_sr sr) ;
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
-      C.SR.destroy dbg sr
+      with_tracing ~name:"SR.destroy" ~dbg @@ fun dbg -> C.SR.destroy dbg sr
 
     let stat () ~dbg ~sr =
       info "SR.stat dbg:%s sr:%s" dbg (s_of_sr sr) ;
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
-      C.SR.stat dbg sr
+      with_tracing ~name:"SR.stat" ~dbg @@ fun dbg -> C.SR.stat dbg sr
 
     let scan () ~dbg ~sr =
       info "SR.scan dbg:%s sr:%s" dbg (s_of_sr sr) ;
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
-      C.SR.scan dbg sr
+      with_tracing ~name:"SR.scan" ~dbg @@ fun dbg -> C.SR.scan dbg sr
 
     module SRSet = Set.Make (struct
       type t = Storage_interface.Sr.t
@@ -354,7 +375,7 @@ module Mux = struct
              let module C = StorageAPI (Idl.Exn.GenClient (struct
                let rpc = of_sr sr
              end)) in
-             C.SR.list dbg
+             with_tracing ~name:"SR.list" ~dbg @@ fun dbg -> C.SR.list dbg
          )
         )
       |> SRSet.elements
@@ -364,7 +385,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
-      C.SR.reset dbg sr
+      with_tracing ~name:"SR.reset" ~dbg @@ fun dbg -> C.SR.reset dbg sr
 
     let update_snapshot_info_src () ~dbg ~sr ~vdi ~url ~dest ~dest_vdi
         ~snapshot_pairs =
@@ -381,6 +402,8 @@ module Mux = struct
         |> String.concat "; "
         |> Printf.sprintf "[%s]"
         ) ;
+      with_tracing ~name:"Storage_migrate.update_snapshot_info_src" ~dbg
+      @@ fun dbg ->
       Storage_migrate.update_snapshot_info_src ~dbg ~sr ~vdi ~url ~dest
         ~dest_vdi ~snapshot_pairs
 
@@ -401,6 +424,7 @@ module Mux = struct
         |> String.concat "; "
         |> Printf.sprintf "[%s]"
         ) ;
+      with_tracing ~name:"SR.update_snapshot_info_dest" ~dbg @@ fun dbg ->
       C.SR.update_snapshot_info_dest dbg sr vdi src_vdi snapshot_pairs
   end
 
@@ -411,6 +435,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.create" ~dbg @@ fun dbg ->
       C.VDI.create dbg sr vdi_info
 
     let set_name_label () ~dbg ~sr ~vdi ~new_name_label =
@@ -419,6 +444,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.set_name_label" ~dbg @@ fun dbg ->
       C.VDI.set_name_label dbg sr vdi new_name_label
 
     let set_name_description () ~dbg ~sr ~vdi ~new_name_description =
@@ -428,6 +454,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.set_name_description" ~dbg @@ fun dbg ->
       C.VDI.set_name_description dbg sr vdi new_name_description
 
     let snapshot () ~dbg ~sr ~vdi_info =
@@ -436,7 +463,9 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
-      try C.VDI.snapshot dbg sr vdi_info
+      try
+        with_tracing ~name:"VDI.snapshot" ~dbg @@ fun dbg ->
+        C.VDI.snapshot dbg sr vdi_info
       with Storage_interface.Storage_error (Activated_on_another_host uuid) ->
         Server_helpers.exec_with_new_task "smapiv2.snapshot.activated"
           ~subtask_of:(Ref.of_string dbg) (fun __context ->
@@ -455,6 +484,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.clone" ~dbg @@ fun dbg ->
       C.VDI.clone dbg sr vdi_info
 
     let resize () ~dbg ~sr ~vdi ~new_size =
@@ -463,6 +493,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.resize" ~dbg @@ fun dbg ->
       C.VDI.resize dbg sr vdi new_size
 
     let destroy () ~dbg ~sr ~vdi =
@@ -470,6 +501,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.destroy" ~dbg @@ fun dbg ->
       C.VDI.destroy dbg sr vdi
 
     let stat () ~dbg ~sr ~vdi =
@@ -477,7 +509,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
-      C.VDI.stat dbg sr vdi
+      with_tracing ~name:"VDI.stat" ~dbg @@ fun dbg -> C.VDI.stat dbg sr vdi
 
     let introduce () ~dbg ~sr ~uuid ~sm_config ~location =
       info "VDI.introduce dbg:%s sr:%s uuid:%s sm_config:%s location:%s" dbg
@@ -487,6 +519,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.introduce" ~dbg @@ fun dbg ->
       C.VDI.introduce dbg sr uuid sm_config location
 
     let set_persistent () ~dbg ~sr ~vdi ~persistent =
@@ -495,6 +528,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.set_persistent" ~dbg @@ fun dbg ->
       C.VDI.set_persistent dbg sr vdi persistent
 
     let epoch_begin () ~dbg ~sr ~vdi ~vm ~persistent =
@@ -503,6 +537,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.epoch_begin" ~dbg @@ fun dbg ->
       C.VDI.epoch_begin dbg sr vdi vm persistent
 
     let attach () ~dbg ~dp ~sr ~vdi ~read_write =
@@ -513,6 +548,7 @@ module Mux = struct
       end)) in
       let vm = Vm.of_string "0" in
       DP_info.write dp DP_info.{sr; vdi; vm; read_write} ;
+      with_tracing ~name:"VDI.attach" ~dbg @@ fun dbg ->
       let backend = C.VDI.attach3 dbg dp sr vdi vm read_write in
       (* VDI.attach2 should be used instead, VDI.attach is only kept for
          backwards-compatibility, because older xapis call Remote.VDI.attach during SXM.
@@ -560,6 +596,7 @@ module Mux = struct
       end)) in
       let vm = Vm.of_string "0" in
       DP_info.write dp DP_info.{sr; vdi; vm; read_write} ;
+      with_tracing ~name:"VDI.attach2" ~dbg @@ fun dbg ->
       C.VDI.attach3 dbg dp sr vdi vm read_write
 
     let attach3 () ~dbg ~dp ~sr ~vdi ~vm ~read_write =
@@ -568,6 +605,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.attach3" ~dbg @@ fun dbg ->
       DP_info.write dp DP_info.{sr; vdi; vm; read_write} ;
       C.VDI.attach3 dbg dp sr vdi vm read_write
 
@@ -577,6 +615,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.activate" ~dbg @@ fun dbg ->
       C.VDI.activate dbg dp sr vdi
 
     let activate3 () ~dbg ~dp ~sr ~vdi ~vm =
@@ -593,6 +632,7 @@ module Mux = struct
         | None ->
             failwith "DP not found"
       in
+      with_tracing ~name:"VDI.activate3" ~dbg @@ fun dbg ->
       if (not read_write) && sr_has_capability sr Smint.Vdi_activate_readonly
       then (
         info "The VDI was attached read-only: calling activate_readonly" ;
@@ -608,6 +648,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.activate_readonly" ~dbg @@ fun dbg ->
       C.VDI.activate_readonly dbg dp sr vdi vm
 
     let deactivate () ~dbg ~dp ~sr ~vdi ~vm =
@@ -616,6 +657,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.deativate" ~dbg @@ fun dbg ->
       C.VDI.deactivate dbg dp sr vdi vm
 
     let detach () ~dbg ~dp ~sr ~vdi ~vm =
@@ -624,6 +666,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.detach" ~dbg @@ fun dbg ->
       C.VDI.detach dbg dp sr vdi vm ;
       DP_info.delete dp
 
@@ -633,6 +676,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.epoch_end" ~dbg @@ fun dbg ->
       C.VDI.epoch_end dbg sr vdi vm
 
     let get_by_name () ~dbg ~sr ~name =
@@ -640,6 +684,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.get_by_name" ~dbg @@ fun dbg ->
       C.VDI.get_by_name dbg sr name
 
     let set_content_id () ~dbg ~sr ~vdi ~content_id =
@@ -648,6 +693,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.set_content_id" ~dbg @@ fun dbg ->
       C.VDI.set_content_id dbg sr vdi content_id
 
     let similar_content () ~dbg ~sr ~vdi =
@@ -656,6 +702,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.similar_content" ~dbg @@ fun dbg ->
       C.VDI.similar_content dbg sr vdi
 
     let compose () ~dbg ~sr ~vdi1 ~vdi2 =
@@ -664,6 +711,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.compose" ~dbg @@ fun dbg ->
       C.VDI.compose dbg sr vdi1 vdi2
 
     let add_to_sm_config () ~dbg ~sr ~vdi ~key ~value =
@@ -672,6 +720,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.add_to_sm_config" ~dbg @@ fun dbg ->
       C.VDI.add_to_sm_config dbg sr vdi key value
 
     let remove_from_sm_config () ~dbg ~sr ~vdi ~key =
@@ -680,6 +729,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.remove_from_sm_config" ~dbg @@ fun dbg ->
       C.VDI.remove_from_sm_config dbg sr vdi key
 
     let get_url () ~dbg ~sr ~vdi =
@@ -687,6 +737,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.get_url" ~dbg @@ fun dbg ->
       C.VDI.get_url dbg sr vdi
 
     let enable_cbt () ~dbg ~sr ~vdi =
@@ -694,6 +745,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.enabled_cbt" ~dbg @@ fun dbg ->
       C.VDI.enable_cbt dbg sr vdi
 
     let disable_cbt () ~dbg ~sr ~vdi =
@@ -701,6 +753,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.disable_cbt" ~dbg @@ fun dbg ->
       C.VDI.disable_cbt dbg sr vdi
 
     let data_destroy () ~dbg ~sr ~vdi =
@@ -708,6 +761,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.data_destroy" ~dbg @@ fun dbg ->
       C.VDI.data_destroy dbg sr vdi
 
     let list_changed_blocks () ~dbg ~sr ~vdi_from ~vdi_to =
@@ -716,6 +770,7 @@ module Mux = struct
       let module C = StorageAPI (Idl.Exn.GenClient (struct
         let rpc = of_sr sr
       end)) in
+      with_tracing ~name:"VDI.list_changed_blocks" ~dbg @@ fun dbg ->
       C.VDI.list_changed_blocks dbg sr vdi_from vdi_to
   end
 
@@ -724,6 +779,7 @@ module Mux = struct
        SR/VDI -- for a particular SR and VDI
        content_id -- for a particular content *)
     let open Xapi_stdext_std.Xstringext in
+    with_tracing ~name:"get_by_name" ~dbg @@ fun dbg ->
     match List.filter (fun x -> x <> "") (String.split ~limit:2 '/' name) with
     | [sr; name] ->
         let sr = Storage_interface.Sr.of_string sr in

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -370,7 +370,7 @@ let with_tracing ~name ~dbg f =
   in
   let name = "SM." ^ name in
   let tracer = Tracing.TracerProviders.get_default_tracer ~name in
-  let span = Tracing.Tracer.start ~tracer ~name ~parent in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent () in
   match span with
   | Ok span_context ->
       let result = f dbg in

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -369,10 +369,12 @@ let with_tracing ~name ~dbg f =
         (dbg, Tracing.empty)
   in
   let name = "SM." ^ name in
-  match Tracing.start ~name ~parent with
+  let tracer = Tracing.TracerProviders.get_default_tracer ~name in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent in
+  match span with
   | Ok span_context ->
       let result = f dbg in
-      let _ = Tracing.finish span_context in
+      let _ = Tracing.Tracer.finish span_context in
       result
   | Error e ->
       D.warn "Failed to start tracing: %s" (Printexc.to_string e) ;

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -359,27 +359,6 @@ module Everything = struct
     Errors.errors := h.errors
 end
 
-let with_tracing ~name ~dbg f =
-  let dbg, parent =
-    match String.index_opt dbg '\x00' with
-    | Some i ->
-        let tracing = String.sub dbg (i + 1) (String.length dbg - i - 1) in
-        (String.sub dbg 0 i, Tracing.t_of_string tracing)
-    | None ->
-        (dbg, Tracing.empty)
-  in
-  let name = "SM." ^ name in
-  let tracer = Tracing.TracerProviders.get_default_tracer ~name in
-  let span = Tracing.Tracer.start ~tracer ~name ~parent () in
-  match span with
-  | Ok span_context ->
-      let result = f dbg in
-      let _ = Tracing.Tracer.finish span_context in
-      result
-  | Error e ->
-      D.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
-      f dbg
-
 module Wrapper =
 functor
   (Impl : Server_impl)
@@ -474,12 +453,11 @@ functor
         in
         List.fold_left perform_one vdi_t ops
 
-      let perform_nolock context ~dbg ~name ~dp ~sr ~vdi ~vm this_op =
+      let perform_nolock context ~dbg ~dp ~sr ~vdi ~vm this_op =
         match Host.find sr !Host.host with
         | None ->
             raise (Storage_error (Sr_not_attached (s_of_sr sr)))
         | Some sr_t ->
-            with_tracing ~name ~dbg @@ fun dbg ->
             let vdi_t =
               Option.value ~default:(Vdi.empty ()) (Sr.find vdi sr_t)
             in
@@ -546,9 +524,7 @@ functor
                   ignore
                     (List.fold_left
                        (fun _ op ->
-                         perform_nolock context ~dbg
-                           ~name:"VDI.destroy_datapath_nolock" ~dp ~sr ~vdi ~vm
-                           op
+                         perform_nolock context ~dbg ~dp ~sr ~vdi ~vm op
                        )
                        vdi_t ops
                     )
@@ -608,7 +584,6 @@ functor
       let epoch_begin context ~dbg ~sr ~vdi ~vm ~persistent =
         info "VDI.epoch_begin dbg:%s sr:%s vdi:%s vm:%s persistent:%b" dbg
           (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) persistent ;
-        with_tracing ~name:"VDI.epoch_begin" ~dbg @@ fun dbg ->
         with_vdi sr vdi (fun () ->
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
@@ -623,8 +598,7 @@ functor
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
                 let state =
-                  perform_nolock context ~dbg ~name:"VDI.attach3" ~dp ~sr ~vdi
-                    ~vm
+                  perform_nolock context ~dbg ~dp ~sr ~vdi ~vm
                     (Vdi_automaton.Attach
                        ( if read_write then
                            Vdi_automaton.RW
@@ -694,8 +668,8 @@ functor
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
                 ignore
-                  (perform_nolock context ~dbg ~dp ~name:"VDI.activate3" ~sr
-                     ~vdi ~vm Vdi_automaton.Activate
+                  (perform_nolock context ~dbg ~dp ~sr ~vdi ~vm
+                     Vdi_automaton.Activate
                   )
             )
         )
@@ -716,8 +690,8 @@ functor
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
                 ignore
-                  (perform_nolock context ~dbg ~name:"VDI.deactivate" ~dp ~sr
-                     ~vdi ~vm Vdi_automaton.Deactivate
+                  (perform_nolock context ~dbg ~dp ~sr ~vdi ~vm
+                     Vdi_automaton.Deactivate
                   )
             )
         )
@@ -729,8 +703,8 @@ functor
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () ->
                 ignore
-                  (perform_nolock context ~dbg ~name:"VDI.detach" ~dp ~sr ~vdi
-                     ~vm Vdi_automaton.Detach
+                  (perform_nolock context ~dbg ~dp ~sr ~vdi ~vm
+                     Vdi_automaton.Detach
                   )
             )
         )
@@ -738,7 +712,6 @@ functor
       let epoch_end context ~dbg ~sr ~vdi ~vm =
         info "VDI.epoch_end dbg:%s sr:%s vdi:%s vm:%s" dbg (s_of_sr sr)
           (s_of_vdi vdi) (s_of_vm vm) ;
-        with_tracing ~name:"VDI.epoch_end" ~dbg @@ fun dbg ->
         with_vdi sr vdi (fun () ->
             remove_datapaths_andthen_nolock context ~dbg ~sr ~vdi ~vm Vdi.leaked
               (fun () -> Impl.VDI.epoch_end context ~dbg ~sr ~vdi ~vm
@@ -1047,7 +1020,6 @@ functor
 
       let destroy' context ~dbg ~dp ~allow_leak =
         info "DP.destroy dbg:%s dp:%s allow_leak:%b" dbg dp allow_leak ;
-        with_tracing ~name:"DP.destroy" ~dbg @@ fun dbg ->
         let failures =
           Host.list !Host.host
           |> List.filter_map (fun (sr, sr_t) ->

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -180,9 +180,11 @@ let pingable ip () =
 
 let queryable ~__context transport () =
   let open Xmlrpc_client in
+  let http =
+    xmlrpc ~version:"1.0" ~tracing:(Context.tracing_of __context) "/"
+  in
   let rpc =
-    XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_smapiv2" ~transport
-      ~http:(xmlrpc ~version:"1.0" "/")
+    XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_smapiv2" ~transport ~http
   in
   let listMethods = Rpc.call "system.listMethods" [] in
   try

--- a/ocaml/xapi/taskHelper.ml
+++ b/ocaml/xapi/taskHelper.ml
@@ -178,6 +178,7 @@ let status_is_completed task_status =
   task_status = `success || task_status = `failure || task_status = `cancelled
 
 let complete ~__context result =
+  Context.complete_tracing __context ;
   operate_on_db_task ~__context (fun self ->
       let status = Db_actions.DB_Action.Task.get_status ~__context ~self in
       if status = `pending then (
@@ -224,6 +225,7 @@ let exn_if_cancelling ~__context =
     raise_cancelled ~__context
 
 let cancel_this ~__context ~self =
+  Context.complete_tracing __context ;
   assert_op_valid ~__context self ;
   let status = Db_actions.DB_Action.Task.get_status ~__context ~self in
   if status = `pending then (
@@ -241,6 +243,7 @@ let cancel ~__context =
   operate_on_db_task ~__context (fun self -> cancel_this ~__context ~self)
 
 let failed ~__context exn =
+  Context.complete_tracing __context ;
   let code, params = ExnHelper.error_of_exn exn in
   operate_on_db_task ~__context (fun self ->
       let status = Db_actions.DB_Action.Task.get_status ~__context ~self in

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1420,6 +1420,13 @@ let server_init () =
                 Xapi_host.write_uefi_certificates_to_disk ~__context
                   ~host:(Helpers.get_localhost ~__context)
             )
+          ; ( "Set default TracerProvider intance on host"
+            , [Startup.NoExnRaising]
+            , fun () ->
+                Xapi_tracing.set_default ~__context
+                  ~pool:(Helpers.get_pool ~__context)
+                  ~host:(Helpers.get_localhost ~__context)
+            )
           ] ;
         debug "startup: startup sequence finished"
     ) ;

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -94,7 +94,7 @@ let populate_db backend =
     The db connections must have been parsed from db.conf file and initialised before this fn is called.
     Also this function depends on being able to call API functions through the external interface.
 *)
-let start_database_engine () =
+let start_database_engine ~__context () =
   let t = Db_backend.make () in
   populate_db t ;
   Db_ref.update_database t
@@ -104,7 +104,7 @@ let start_database_engine () =
   debug "Performing initial DB GC" ;
   Db_gc.single_pass () ;
   (* Make sure all 'my' database records exist and are up to date *)
-  Dbsync.setup () ;
+  Dbsync.setup ~__context ;
   ignore (Db_gc.start_db_gc_thread ()) ;
   debug "Finished populating db cache" ;
   Xapi_ha.on_database_engine_ready () ;
@@ -1070,7 +1070,7 @@ let server_init () =
                running etc.) -- see CA-11087 *)
             ( "starting up database engine"
             , [Startup.OnlyMaster]
-            , start_database_engine
+            , start_database_engine ~__context
             )
           ; ( "hi-level database upgrade"
             , [Startup.OnlyMaster]
@@ -1103,7 +1103,7 @@ let server_init () =
             , Remote_requests.handle_requests
             )
           ] ;
-        match Pool_role.get_role () with
+        ( match Pool_role.get_role () with
         | Pool_role.Master ->
             ()
         | Pool_role.Broken ->
@@ -1157,7 +1157,7 @@ let server_init () =
                     , Storage_access.start_smapiv1_servers
                     )
                   ] ;
-                Dbsync.setup ()
+                Dbsync.setup ~__context
               with _ ->
                 debug
                   "Failure in slave dbsync; slave will pause and then restart \
@@ -1169,9 +1169,7 @@ let server_init () =
             Master_connection.restart_on_connection_timeout := true ;
             Master_connection.on_database_connection_established :=
               fun () -> on_master_restart ~__context
-    ) ;
-    Server_helpers.exec_with_new_task "server_init" ~task_in_database:true
-      (fun __context ->
+        ) ;
         Startup.run ~__context
           [
             ("Checking emergency network reset", [], check_network_reset)
@@ -1236,7 +1234,7 @@ let server_init () =
                	 table happens to be right) *)
             ( "Best-effort bring up of physical and sriov NICs"
             , [Startup.NoExnRaising]
-            , Xapi_pif.start_of_day_best_effort_bring_up
+            , Xapi_pif.start_of_day_best_effort_bring_up ~__context
             )
           ; ( "updating the vswitch controller"
             , []

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1202,18 +1202,17 @@ let other_options =
       (fun s -> s)
       disable_dbsync_for
   ; gen_list_option "tracing-default-endpoints"
-      "space-separated list of endpoints strings for the default tracer \
-       provider"
+      "comma-separated list of endpoint strings for the default tracer provider"
       (fun s -> s)
       (fun s -> s)
       tracing_default_endpoints
   ; gen_list_option "tracing-default-filters"
-      "space-separated list of filters strings for the default tracer provider"
+      "comma-separated list of filter strings for the default tracer provider"
       (fun s -> s)
       (fun s -> s)
       tracing_default_filters
   ; gen_list_option "tracing-default-processors"
-      "space-separated list of processors strings for the default tracer \
+      "comma-separated list of processor strings for the default tracer \
        provider"
       (fun s -> s)
       (fun s -> s)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -924,6 +924,12 @@ let rpm_cmd = ref "/usr/bin/rpm"
 
 let rpm_gpgkey_dir = ref "/etc/pki/rpm-gpg"
 
+let tracing_default_endpoints = ref ["bugtool"]
+
+let tracing_default_filters = ref []
+
+let tracing_default_processors = ref []
+
 let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
@@ -1195,6 +1201,23 @@ let other_options =
       (fun s -> s)
       (fun s -> s)
       disable_dbsync_for
+  ; gen_list_option "tracing-default-endpoints"
+      "space-separated list of endpoints strings for the default tracer \
+       provider"
+      (fun s -> s)
+      (fun s -> s)
+      tracing_default_endpoints
+  ; gen_list_option "tracing-default-filters"
+      "space-separated list of filters strings for the default tracer provider"
+      (fun s -> s)
+      (fun s -> s)
+      tracing_default_filters
+  ; gen_list_option "tracing-default-processors"
+      "space-separated list of processors strings for the default tracer \
+       provider"
+      (fun s -> s)
+      (fun s -> s)
+      tracing_default_processors
   ; ( "xenopsd-queues"
     , Arg.String (fun x -> xenopsd_queues := String.split ',' x)
     , (fun () -> String.concat "," !xenopsd_queues)

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -1092,25 +1092,22 @@ let calculate_pifs_required_at_start_of_day ~__context =
   in
   pifs @ sriov_pifs
 
-let start_of_day_best_effort_bring_up () =
-  Server_helpers.exec_with_new_task
-    "Bringing up managed physical and sriov PIFs" (fun __context ->
-      let dbg = Context.string_of_task __context in
-      debug "Configured network backend: %s"
-        (Network_interface.string_of_kind (Net.Bridge.get_kind dbg ())) ;
-      (* Clear the state of the network daemon, before refreshing it by plugging
-         * the most important PIFs (see above). *)
-      Net.clear_state () ;
-      List.iter
-        (fun (pif, pifr) ->
-          Helpers.log_exn_continue
-            (Printf.sprintf "error trying to bring up pif: %s" pifr.API.pIF_uuid)
-            (fun pif ->
-              debug "Best effort attempt to bring up PIF: %s" pifr.API.pIF_uuid ;
-              plug ~__context ~self:pif
-            )
-            pif
+let start_of_day_best_effort_bring_up ~__context () =
+  let dbg = Context.string_of_task __context in
+  debug "Configured network backend: %s"
+    (Network_interface.string_of_kind (Net.Bridge.get_kind dbg ())) ;
+  (* Clear the state of the network daemon, before refreshing it by plugging
+     * the most important PIFs (see above). *)
+  Net.clear_state () ;
+  List.iter
+    (fun (pif, pifr) ->
+      Helpers.log_exn_continue
+        (Printf.sprintf "error trying to bring up pif: %s" pifr.API.pIF_uuid)
+        (fun pif ->
+          debug "Best effort attempt to bring up PIF: %s" pifr.API.pIF_uuid ;
+          plug ~__context ~self:pif
         )
-        (calculate_pifs_required_at_start_of_day ~__context) ;
-      Net.sync_state ()
-  )
+        pif
+    )
+    (calculate_pifs_required_at_start_of_day ~__context) ;
+  Net.sync_state ()

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -262,7 +262,7 @@ val calculate_pifs_required_at_start_of_day :
     interfaces required by storage NICs etc. (these interface are not filtered out at the moment).
 *)
 
-val start_of_day_best_effort_bring_up : unit -> unit
+val start_of_day_best_effort_bring_up : __context:Context.t -> unit -> unit
 (** Attempt to bring up (plug) the required PIFs when the host starts up.
  *  Uses {!calculate_pifs_required_at_start_of_day}. *)
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3283,7 +3283,9 @@ let perform ~local_fn ~__context ~host op =
     let open Xmlrpc_client in
     let verify_cert = Some Stunnel.pool (* verify! *) in
     let task_id = Option.map Ref.string_of task_opt in
-    let http = xmlrpc ?task_id ~version:"1.0" "/" in
+    let http =
+      xmlrpc ?task_id ~version:"1.0" ~tracing:(Context.tracing_of __context) "/"
+    in
     let port = !Constants.https_port in
     let transport = SSL (SSL.make ~verify_cert ?task_id (), hostname, port) in
     XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml

--- a/ocaml/xapi/xapi_tracing.ml
+++ b/ocaml/xapi/xapi_tracing.ml
@@ -11,14 +11,77 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+let create ~__context ?(hosts = []) ?(tags = []) ?(endpoints = ["bugtool"])
+    ?(components = []) ?(filters = []) ?(processors = []) ?(status = false)
+    ~name_label () : unit =
+  let tracing = Ref.make () in
+  Db.Tracing.create ~__context
+    ~uuid:(Uuidx.to_string (Uuidx.make ()))
+    ~ref:tracing ~hosts ~name_label ~tags ~endpoints ~components ~filters
+    ~processors ~status
+
 let set_default ~__context ~pool ~host =
+  (* Called on each host *)
   let pool_uuid = Db.Pool.get_uuid ~__context ~self:pool in
   let host_uuid = Db.Host.get_uuid ~__context ~self:host in
   let host_label = Db.Host.get_name_label ~__context ~self:host in
-  let tags =
-    [("pool", pool_uuid); ("host", host_uuid); ("host name", host_label)]
+  let default =
+    List.find_opt
+      (fun self -> Db.Tracing.get_name_label ~__context ~self = "default")
+      (Db.Tracing.get_all ~__context)
   in
-  let endpoints = !Xapi_globs.tracing_default_endpoints in
-  let processors = !Xapi_globs.tracing_default_processors in
-  let filters = !Xapi_globs.tracing_default_filters in
-  Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters
+  let is_master = Helpers.is_pool_master ~__context ~host in
+  match default with
+  | Some self ->
+      let tags =
+        ("host", host_uuid)
+        :: ("host name", host_label)
+        :: Db.Tracing.get_tags ~__context ~self
+      in
+      let endpoints = Db.Tracing.get_endpoints ~__context ~self in
+      let processors = Db.Tracing.get_processors ~__context ~self in
+      let filters = Db.Tracing.get_filters ~__context ~self in
+      let enabled = Db.Tracing.get_status ~__context ~self in
+      Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters
+        ~enabled
+  | None ->
+      let tags =
+        [("pool", pool_uuid); ("host", host_uuid); ("host name", host_label)]
+      in
+      let endpoints = !Xapi_globs.tracing_default_endpoints in
+      let processors = !Xapi_globs.tracing_default_processors in
+      let filters = !Xapi_globs.tracing_default_filters in
+      if is_master then
+        create ~__context ~tags:[("pool", pool_uuid)] ~endpoints ~processors
+          ~filters ~status:false ~name_label:"default" () ;
+      Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters
+        ~enabled:false
+
+let set_status ~__context ~self ~status =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  Tracing.TracerProviders.set ~name_label ~status ()
+
+let set_tags ~__context ~self ~tags =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  let tags =
+    let host = Helpers.get_localhost ~__context in
+    let host_uuid = Db.Host.get_uuid ~__context ~self:host in
+    let host_label = Db.Host.get_name_label ~__context ~self:host in
+    ("host", host_uuid) :: ("host name", host_label) :: tags
+  in
+  Tracing.TracerProviders.set ~name_label ~tags ()
+
+let set_endpoints ~__context ~self ~endpoints =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  Tracing.TracerProviders.set ~name_label ~endpoints ()
+
+let set_components ~__context ~self:_ ~components:_ = ()
+
+(* Will implement later, this function will set / unset providers on veraious components *)
+let set_filters ~__context ~self ~filters =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  Tracing.TracerProviders.set ~name_label ~filters ()
+
+let set_processors ~__context ~self ~processors =
+  let name_label = Db.Tracing.get_name_label ~__context ~self in
+  Tracing.TracerProviders.set ~name_label ~processors ()

--- a/ocaml/xapi/xapi_tracing.ml
+++ b/ocaml/xapi/xapi_tracing.ml
@@ -1,0 +1,24 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+let set_default ~__context ~pool ~host =
+  let pool_uuid = Db.Pool.get_uuid ~__context ~self:pool in
+  let host_uuid = Db.Host.get_uuid ~__context ~self:host in
+  let host_label = Db.Host.get_name_label ~__context ~self:host in
+  let tags =
+    [("pool", pool_uuid); ("host", host_uuid); ("host name", host_label)]
+  in
+  let endpoints = !Xapi_globs.tracing_default_endpoints in
+  let processors = !Xapi_globs.tracing_default_processors in
+  let filters = !Xapi_globs.tracing_default_filters in
+  Tracing.TracerProviders.set_default ~tags ~endpoints ~processors ~filters

--- a/ocaml/xapi/xapi_tracing.mli
+++ b/ocaml/xapi/xapi_tracing.mli
@@ -1,0 +1,16 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val set_default :
+  __context:Context.t -> pool:API.ref_pool -> host:API.ref_host -> unit

--- a/ocaml/xapi/xapi_tracing.mli
+++ b/ocaml/xapi/xapi_tracing.mli
@@ -14,3 +14,24 @@
 
 val set_default :
   __context:Context.t -> pool:API.ref_pool -> host:API.ref_host -> unit
+
+val set_status :
+  __context:Context.t -> self:API.ref_Tracing -> status:bool -> unit
+
+val set_tags :
+     __context:Context.t
+  -> self:API.ref_Tracing
+  -> tags:(string * string) list
+  -> unit
+
+val set_endpoints :
+  __context:Context.t -> self:API.ref_Tracing -> endpoints:string list -> unit
+
+val set_components :
+  __context:Context.t -> self:API.ref_Tracing -> components:string list -> unit
+
+val set_filters :
+  __context:Context.t -> self:API.ref_Tracing -> filters:string list -> unit
+
+val set_processors :
+  __context:Context.t -> self:API.ref_Tracing -> processors:string list -> unit

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -263,7 +263,7 @@ let firmware_of_vm vm =
       default_firmware
 
 let varstore_rm_with_sandbox ~__context ~vm_uuid f =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let domid = 0 in
   let chroot, socket_path =
     Xenops_sandbox.Varstore_guard.start dbg ~domid ~vm_uuid ~paths:[]
@@ -1403,7 +1403,7 @@ module Guest_agent_features = struct
 end
 
 let apply_guest_agent_config ~__context config =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let features = Guest_agent_features.of_config ~__context config in
   let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
   Client.HOST.update_guest_agent_features dbg features
@@ -1680,7 +1680,7 @@ module Xenopsd_metadata = struct
         let md = create_metadata ~__context ~self in
         let txt = md |> rpc_of Metadata.t |> Jsonrpc.to_string in
         info "xenops: VM.import_metadata %s" txt ;
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self)
                                 : XENOPS
                             )
@@ -1693,7 +1693,7 @@ module Xenopsd_metadata = struct
     )
 
   let delete_nolock ~__context id =
-    let dbg = Context.string_of_task __context in
+    let dbg = Context.string_of_task_and_tracing __context in
     info "xenops: VM.remove %s" id ;
     try
       let module Client = ( val make_client
@@ -1720,7 +1720,7 @@ module Xenopsd_metadata = struct
   let pull ~__context id =
     with_lock metadata_m (fun () ->
         info "xenops: VM.export_metadata %s" id ;
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client
                                     (queue_of_vm ~__context
                                        ~self:(vm_of_id ~__context id)
@@ -1754,7 +1754,7 @@ module Xenopsd_metadata = struct
     let id = id_of_vm ~__context ~self in
     let queue_name = queue_of_vm ~__context ~self in
     with_lock metadata_m (fun () ->
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         if vm_exists_in_xenopsd queue_name dbg id then
           let txt =
             create_metadata ~__context ~self
@@ -1896,7 +1896,7 @@ let update_vm ~__context id =
         debug "xenopsd event: ignoring event for VM (VM %s not resident)" id
       else
         let previous = Xenops_cache.find_vm id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self)
                                 : XENOPS
                             )
@@ -2458,7 +2458,7 @@ let update_vbd ~__context (id : string * string) =
           (fst id)
       else
         let previous = Xenops_cache.find_vbd id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2570,7 +2570,7 @@ let update_vif ~__context id =
           (fst id)
       else
         let previous = Xenops_cache.find_vif id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2617,7 +2617,9 @@ let update_vif ~__context id =
                                  (fst id) (snd id)
                               )
                         | Some device ->
-                            let dbg = Context.string_of_task __context in
+                            let dbg =
+                              Context.string_of_task_and_tracing __context
+                            in
                             let mtu = Net.Interface.get_mtu dbg device in
                             Db.VIF.set_MTU ~__context ~self:vif
                               ~value:(Int64.of_int mtu)
@@ -2684,7 +2686,7 @@ let update_pci ~__context id =
           (fst id)
       else
         let previous = Xenops_cache.find_pci id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2760,7 +2762,7 @@ let update_vgpu ~__context id =
           (fst id)
       else
         let previous = Xenops_cache.find_vgpu id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2832,7 +2834,7 @@ let update_vusb ~__context (id : string * string) =
           (fst id)
       else
         let previous = Xenops_cache.find_vusb id in
-        let dbg = Context.string_of_task __context in
+        let dbg = Context.string_of_task_and_tracing __context in
         let module Client = ( val make_client (queue_of_vm ~__context ~self:vm)
                                 : XENOPS
                             )
@@ -2894,7 +2896,7 @@ let update_task ~__context queue_name id =
   try
     let self = TaskHelper.id_to_task_exn (TaskHelper.Xenops (queue_name, id)) in
     (* throws Not_found *)
-    let dbg = Context.string_of_task __context in
+    let dbg = Context.string_of_task_and_tracing __context in
     let module Client = (val make_client queue_name : XENOPS) in
     let task_t = Client.TASK.stat dbg id in
     match task_t.Task.state with
@@ -2924,7 +2926,7 @@ let update_task ~__context queue_name id =
       error "xenopsd event: Caught %s while updating task" (string_of_exn e)
 
 let rec events_watch ~__context cancel queue_name from =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   if Xapi_fist.delay_xenopsd_event_threads () then Thread.delay 30.0 ;
   let module Client = (val make_client queue_name : XENOPS) in
   let barriers, events, next = Client.UPDATES.get dbg from None in
@@ -2993,14 +2995,14 @@ let events_from_xenopsd queue_name =
 let refresh_vm ~__context ~self =
   let id = id_of_vm ~__context ~self in
   info "xenops: UPDATES.refresh_vm %s" id ;
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let queue_name = queue_of_vm ~__context ~self in
   let module Client = (val make_client queue_name : XENOPS) in
   Client.UPDATES.refresh_vm dbg id ;
   Events_from_xenopsd.wait queue_name dbg id ()
 
 let resync_resident_on ~__context =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let localhost = Helpers.get_localhost ~__context in
   let domain0 = Helpers.get_domain_zero ~__context in
   (* Get a list of all the ids of VMs that Xapi thinks are resident here
@@ -3538,7 +3540,7 @@ let update_debug_info __context t =
     debug_info
 
 let sync_with_task_result __context ?cancellable queue_name x =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   x
   |> register_task __context ?cancellable queue_name
   |> wait_for_task queue_name dbg
@@ -3549,7 +3551,7 @@ let sync_with_task __context ?cancellable queue_name x =
   sync_with_task_result __context ?cancellable queue_name x |> ignore
 
 let sync __context queue_name x =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   x
   |> wait_for_task queue_name dbg
   |> success_task queue_name (update_debug_info __context) dbg
@@ -3560,7 +3562,7 @@ let pause ~__context ~self =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.pause %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.pause dbg id |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg id () ;
@@ -3573,7 +3575,7 @@ let unpause ~__context ~self =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.unpause %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.unpause dbg id |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg id () ;
@@ -3585,7 +3587,7 @@ let request_rdp ~__context ~self enabled =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.request_rdp %s %b" id enabled ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.request_rdp dbg id enabled
       |> sync_with_task __context queue_name ;
@@ -3597,7 +3599,7 @@ let run_script ~__context ~self script =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.run_script %s %s" id script ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       let r =
         Client.VM.run_script dbg id script
@@ -3613,7 +3615,7 @@ let set_xenstore_data ~__context ~self xsdata =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.set_xenstore_data %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.set_xsdata dbg id xsdata |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg id ()
@@ -3624,7 +3626,7 @@ let set_vcpus ~__context ~self n =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.set_vcpus %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       try
         Client.VM.set_vcpus dbg id (Int64.to_int n)
@@ -3651,7 +3653,7 @@ let set_shadow_multiplier ~__context ~self target =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.set_shadow_multiplier %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       try
         Client.VM.set_shadow_multiplier dbg id target
@@ -3680,7 +3682,7 @@ let set_memory_dynamic_range ~__context ~self min max =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
       debug "xenops: VM.set_memory_dynamic_range %s" id ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VM.set_memory_dynamic_range dbg id min max
       |> sync_with_task __context queue_name ;
@@ -3688,7 +3690,7 @@ let set_memory_dynamic_range ~__context ~self min max =
   )
 
 let maybe_refresh_vm ~__context ~self =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let queue_name = queue_of_vm ~__context ~self in
   let id = id_of_vm ~__context ~self in
   if vm_exists_in_xenopsd queue_name dbg id then (
@@ -3700,7 +3702,7 @@ let maybe_refresh_vm ~__context ~self =
   )
 
 let start ~__context ~self paused force =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let queue_name = queue_of_vm ~__context ~self in
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       maybe_refresh_vm ~__context ~self ;
@@ -3790,7 +3792,7 @@ let reboot ~__context ~self timeout =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       assert_resident_on ~__context ~self ;
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       maybe_refresh_vm ~__context ~self ;
       (* Ensure we have the latest version of the VM metadata before the reboot *)
       Events_from_xapi.wait ~__context ~self ;
@@ -3812,7 +3814,7 @@ let shutdown ~__context ~self timeout =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       assert_resident_on ~__context ~self ;
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       info "xenops: VM.shutdown %s" id ;
       let module Client = (val make_client queue_name : XENOPS) in
       let () =
@@ -3861,7 +3863,7 @@ let suspend ~__context ~self =
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       assert_resident_on ~__context ~self ;
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       let vm_t, _state = Client.VM.stat dbg id in
       (* XXX: this needs to be at boot time *)
@@ -3898,7 +3900,7 @@ let suspend ~__context ~self =
           let d = disk_of_vdi ~__context ~self:vdi |> Option.get in
           Db.VM.set_suspend_VDI ~__context ~self ~value:vdi ;
           try
-            let dbg = Context.string_of_task __context in
+            let dbg = Context.string_of_task_and_tracing __context in
             info "xenops: VM.suspend %s to %s" id
               (d |> rpc_of disk |> Jsonrpc.to_string) ;
             Client.VM.suspend dbg id d
@@ -3941,7 +3943,7 @@ let suspend ~__context ~self =
   )
 
 let resume ~__context ~self ~start_paused ~force:_ =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let queue_name = queue_of_vm ~__context ~self in
   let vm_id = id_of_vm ~__context ~self in
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
@@ -4001,7 +4003,7 @@ let s3suspend ~__context ~self =
   let queue_name = queue_of_vm ~__context ~self in
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       debug "xenops: VM.s3suspend %s" id ;
       Client.VM.s3suspend dbg id |> sync_with_task __context queue_name ;
@@ -4012,7 +4014,7 @@ let s3resume ~__context ~self =
   let queue_name = queue_of_vm ~__context ~self in
   transform_xenops_exn ~__context ~vm:self queue_name (fun () ->
       let id = id_of_vm ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       debug "xenops: VM.s3resume %s" id ;
       Client.VM.s3resume dbg id |> sync_with_task __context queue_name ;
@@ -4038,7 +4040,7 @@ let vbd_plug ~__context ~self =
       Db.VBD.set_currently_attached ~__context ~self ~value:true ;
       Events_from_xapi.wait ~__context ~self:vm ;
       let vbd = md_of_vbd ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Events_from_xenopsd.with_suppressed queue_name dbg vm_id (fun () ->
           info "xenops: VBD.add %s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id) ;
@@ -4065,7 +4067,7 @@ let vbd_unplug ~__context ~self force =
   transform_xenops_exn ~__context ~vm queue_name (fun () ->
       assert_resident_on ~__context ~self:vm ;
       let vbd = md_of_vbd ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       ( try
           info "xenops: VBD.unplug %s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id) ;
@@ -4103,7 +4105,7 @@ let vbd_eject_hvm ~__context ~self =
       assert_resident_on ~__context ~self:vm ;
       let vbd = md_of_vbd ~__context ~self in
       info "xenops: VBD.eject %s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VBD.eject dbg vbd.Vbd.id |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg (fst vbd.Vbd.id) () ;
@@ -4144,7 +4146,7 @@ let vbd_insert_hvm ~__context ~self ~vdi =
       let d = disk_of_vdi ~__context ~self:vdi |> Option.get in
       info "xenops: VBD.insert %s.%s %s" (fst vbd.Vbd.id) (snd vbd.Vbd.id)
         (d |> rpc_of disk |> Jsonrpc.to_string) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VBD.insert dbg vbd.Vbd.id d |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg (fst vbd.Vbd.id) () ;
@@ -4177,7 +4179,7 @@ let vbd_insert_hvm ~__context ~self ~vdi =
   )
 
 let has_qemu ~__context ~vm =
-  let dbg = Context.string_of_task __context in
+  let dbg = Context.string_of_task_and_tracing __context in
   let id = Db.VM.get_uuid ~__context ~self:vm in
   let queue_name = queue_of_vm ~__context ~self:vm in
   let module Client = (val make_client queue_name : XENOPS) in
@@ -4225,7 +4227,7 @@ let vif_plug ~__context ~self =
       Db.VIF.set_currently_attached ~__context ~self ~value:true ;
       Events_from_xapi.wait ~__context ~self:vm ;
       let vif = md_of_vif ~__context ~self in
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Xapi_network.with_networks_attached_for_vm ~__context ~vm (fun () ->
           Events_from_xenopsd.with_suppressed queue_name dbg vm_id (fun () ->
@@ -4255,7 +4257,7 @@ let vif_set_locking_mode ~__context ~self =
       assert_resident_on ~__context ~self:vm ;
       let vif = md_of_vif ~__context ~self in
       info "xenops: VIF.set_locking_mode %s.%s" (fst vif.Vif.id) (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VIF.set_locking_mode dbg vif.Vif.id vif.Vif.locking_mode
       |> sync_with_task __context queue_name ;
@@ -4270,7 +4272,7 @@ let vif_set_pvs_proxy ~__context ~self creating =
       let vif = md_of_vif ~__context ~self in
       let proxy = if creating then vif.Vif.pvs_proxy else None in
       info "xenops: VIF.set_pvs_proxy %s.%s" (fst vif.Vif.id) (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VIF.set_pvs_proxy dbg vif.Vif.id proxy
       |> sync_with_task __context queue_name ;
@@ -4284,7 +4286,7 @@ let vif_unplug ~__context ~self force =
       assert_resident_on ~__context ~self:vm ;
       let vif = md_of_vif ~__context ~self in
       info "xenops: VIF.unplug %s.%s" (fst vif.Vif.id) (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       try
         Client.VIF.unplug dbg vif.Vif.id force
@@ -4329,7 +4331,7 @@ let vif_move ~__context ~self _network =
                 )
             )
       | _ ->
-          let dbg = Context.string_of_task __context in
+          let dbg = Context.string_of_task_and_tracing __context in
           let module Client = (val make_client queue_name : XENOPS) in
           (* Nb., at this point, the database shows the vif on the new network *)
           Xapi_network.attach_for_vif ~__context ~vif:self () ;
@@ -4357,7 +4359,7 @@ let vif_set_ipv4_configuration ~__context ~self =
       let vif = md_of_vif ~__context ~self in
       info "xenops: VIF.set_ipv4_configuration %s.%s" (fst vif.Vif.id)
         (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VIF.set_ipv4_configuration dbg vif.Vif.id
         vif.Vif.ipv4_configuration
@@ -4373,7 +4375,7 @@ let vif_set_ipv6_configuration ~__context ~self =
       let vif = md_of_vif ~__context ~self in
       info "xenops: VIF.set_ipv6_configuration %s.%s" (fst vif.Vif.id)
         (snd vif.Vif.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VIF.set_ipv6_configuration dbg vif.Vif.id
         vif.Vif.ipv6_configuration
@@ -4385,7 +4387,7 @@ let task_cancel ~__context ~self =
   try
     let queue_name, id = TaskHelper.task_to_id_exn self |> unwrap in
     let module Client = (val make_client queue_name : XENOPS) in
-    let dbg = Context.string_of_task __context in
+    let dbg = Context.string_of_task_and_tracing __context in
     info "xenops: TASK.cancel %s" id ;
     Client.TASK.cancel dbg id |> ignore ;
     (* it might actually have completed, we don't care *)
@@ -4410,7 +4412,7 @@ let vusb_unplug_hvm ~__context ~self =
       assert_resident_on ~__context ~self:vm ;
       let vusb = md_of_vusb ~__context ~self in
       info "xenops: VUSB.unplug %s.%s" (fst vusb.Vusb.id) (snd vusb.Vusb.id) ;
-      let dbg = Context.string_of_task __context in
+      let dbg = Context.string_of_task_and_tracing __context in
       let module Client = (val make_client queue_name : XENOPS) in
       Client.VUSB.unplug dbg vusb.Vusb.id |> sync_with_task __context queue_name ;
       Events_from_xenopsd.wait queue_name dbg (fst vusb.Vusb.id) () ;

--- a/ocaml/xenopsd/lib/dune
+++ b/ocaml/xenopsd/lib/dune
@@ -41,6 +41,7 @@
    xapi-stdext-pervasives
    xapi-stdext-threads
    xapi-stdext-unix
+   xapi-tracing
    xmlm
  )
  (preprocess

--- a/ocaml/xenopsd/lib/storage.ml
+++ b/ocaml/xenopsd/lib/storage.ml
@@ -36,16 +36,21 @@ let transform_exception f x =
 (* Used to identify this VBD to the storage layer *)
 let id_of frontend vbd = Printf.sprintf "vbd/%s/%s" frontend (snd vbd)
 
+let get_dbg task =
+  match Xenops_task.tracing task with
+  | None ->
+      Xenops_task.get_dbg task
+  | Some tracing ->
+      Xenops_task.get_dbg task ^ "\x00" ^ tracing
+
 let epoch_begin task sr vdi domid persistent =
   transform_exception
-    (fun () ->
-      Client.VDI.epoch_begin (Xenops_task.get_dbg task) sr vdi domid persistent
-    )
+    (fun () -> Client.VDI.epoch_begin (get_dbg task) sr vdi domid persistent)
     ()
 
 let epoch_end task sr vdi domid =
   transform_exception
-    (fun () -> Client.VDI.epoch_end (Xenops_task.get_dbg task) sr vdi domid)
+    (fun () -> Client.VDI.epoch_end (get_dbg task) sr vdi domid)
     ()
 
 let vm_of_domid vmdomid =
@@ -60,40 +65,36 @@ let vm_of_domid vmdomid =
       Storage_interface.Vm.of_string ""
 
 let attach_and_activate ~task ~_vm ~vmdomid ~dp ~sr ~vdi ~read_write =
+  let dbg = get_dbg task in
   let result =
     Xenops_task.with_subtask task
       (Printf.sprintf "VDI.attach3 %s" dp)
       (transform_exception (fun () ->
-           Client.VDI.attach3 "attach_and_activate_impl" dp sr vdi vmdomid
-             read_write
+           Client.VDI.attach3 dbg dp sr vdi vmdomid read_write
        )
       )
   in
   Xenops_task.with_subtask task
     (Printf.sprintf "VDI.activate3 %s" dp)
-    (transform_exception (fun () ->
-         Client.VDI.activate3 "attach_and_activate_impl" dp sr vdi vmdomid
-     )
-    ) ;
+    (transform_exception (fun () -> Client.VDI.activate3 dbg dp sr vdi vmdomid)) ;
   result
 
 let deactivate task dp sr vdi vmdomid =
   debug "Deactivating disk %s %s" (Sr.string_of sr) (Vdi.string_of vdi) ;
+  let dbg = get_dbg task in
   Xenops_task.with_subtask task
     (Printf.sprintf "VDI.deactivate %s" dp)
-    (transform_exception (fun () ->
-         Client.VDI.deactivate "deactivate" dp sr vdi vmdomid
-     )
-    )
+    (transform_exception (fun () -> Client.VDI.deactivate dbg dp sr vdi vmdomid))
 
 let dp_destroy task dp =
   Xenops_task.with_subtask task
     (Printf.sprintf "DP.destroy %s" dp)
     (transform_exception (fun () ->
+         let dbg = get_dbg task in
          let waiting_for_plugin = ref true in
          while !waiting_for_plugin do
            try
-             Client.DP.destroy "dp_destroy" dp false ;
+             Client.DP.destroy dbg dp false ;
              waiting_for_plugin := false
            with
            | Storage_interface.Storage_error (No_storage_plugin_for_sr _sr) as e

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -1832,7 +1832,7 @@ let with_tracing ~name ~task f =
   let context = Xenops_task.tracing task in
   let parent : Tracing.t = Option.bind context Tracing.t_of_string in
   let tracer = Tracing.TracerProviders.get_default_tracer ~name in
-  let span = Tracing.Tracer.start ~tracer ~name ~parent in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent () in
   match span with
   | Ok span ->
       let sub_context = Tracing.t_to_string_opt span in

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -3794,18 +3794,16 @@ module VM = struct
     Debug.with_thread_associated dbg
       (fun () ->
         let id, md = parse_metadata s in
+        let op = Atomic (VM_import_metadata (id, md)) in
         (* We allow a higher-level toolstack to replace the metadata of a
            running VM. Any changes will take place on next reboot.
            The metadata update will be queued so that ongoing operations
            do not see unexpected state changes. *)
         if DB.exists id then
-          let _ =
-            queue_operation_and_wait dbg id
-              (Atomic (VM_import_metadata (id, md)))
-          in
-          id
+          ignore (queue_operation_and_wait dbg id op)
         else
-          import_metadata id md
+          immediate_operation dbg id op ;
+        id
       )
       ()
 

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -1862,10 +1862,11 @@ let rec perform_atomic ~progress_callback ?subtask:_ ?result (op : atomic)
           (Xenops_task.id_of_handle t)
           (List.length atoms) description
       in
+      let with_tracing = parallel_id_with_tracing parallel_id t in
       debug "begin_%s" parallel_id ;
       let task_list =
         queue_atomics_and_wait ~progress_callback ~max_parallel_atoms:10
-          parallel_id parallel_id atoms
+          with_tracing parallel_id atoms
       in
       debug "end_%s" parallel_id ;
       (* make sure that we destroy all the parallel tasks that finished *)

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -162,6 +162,113 @@ type atomic =
 
 let string_of_atomic x = x |> rpc_of atomic |> Jsonrpc.to_string
 
+let rec name_of_atomic = function
+  | VBD_eject _ ->
+      "VBD_eject"
+  | VIF_plug _ ->
+      "VIF_plug"
+  | VIF_unplug _ ->
+      "VIF_unplug"
+  | VIF_move _ ->
+      "VIF_move"
+  | VIF_set_carrier _ ->
+      "VIF_set_carrier"
+  | VIF_set_locking_mode _ ->
+      "VIF_set_locking_mode"
+  | VIF_set_pvs_proxy _ ->
+      "VIF_set_pvs_proxy"
+  | VIF_set_ipv4_configuration _ ->
+      "VIF_set_ipv4_configuration"
+  | VIF_set_ipv6_configuration _ ->
+      "VIF_set_ipv6_configuration"
+  | VIF_set_active _ ->
+      "VIF_set_active"
+  | VM_hook_script_stable _ ->
+      "VM_hook_script_stable"
+  | VM_hook_script _ ->
+      "VM_hook_script"
+  | VBD_plug _ ->
+      "VBD_plug"
+  | VBD_epoch_begin _ ->
+      "VBD_epoch_begin"
+  | VBD_epoch_end _ ->
+      "VBD_epoch_end"
+  | VBD_set_qos _ ->
+      "VBD_set_qos"
+  | VBD_unplug _ ->
+      "VBD_unplug"
+  | VBD_insert _ ->
+      "VBD_insert"
+  | VBD_set_active _ ->
+      "VBD_set_active"
+  | VM_remove _ ->
+      "VM_remove"
+  | PCI_plug _ ->
+      "PCI_plug"
+  | PCI_unplug _ ->
+      "PCI_unplug"
+  | PCI_dequarantine _ ->
+      "PCI_dequarantine"
+  | VUSB_plug _ ->
+      "VUSB_plug"
+  | VUSB_unplug _ ->
+      "VUSB_unplug"
+  | VGPU_set_active _ ->
+      "VGPU_set_active"
+  | VGPU_start _ ->
+      "VGPU_start"
+  | VM_set_xsdata _ ->
+      "VM_set_xsdata"
+  | VM_set_vcpus _ ->
+      "VM_set_vcpus"
+  | VM_set_shadow_multiplier _ ->
+      "VM_set_shadow_multiplier"
+  | VM_set_memory_dynamic_range _ ->
+      "VM_set_memory_dynamic_range"
+  | VM_pause _ ->
+      "VM_pause"
+  | VM_softreboot _ ->
+      "VM_softreboot"
+  | VM_unpause _ ->
+      "VM_unpause"
+  | VM_request_rdp _ ->
+      "VM_request_rdp"
+  | VM_run_script _ ->
+      "VM_run_script"
+  | VM_set_domain_action_request _ ->
+      "VM_set_domain_action_request"
+  | VM_create_device_model _ ->
+      "VM_create_device_model"
+  | VM_destroy_device_model _ ->
+      "VM_destroy_device_model"
+  | VM_destroy _ ->
+      "VM_destroy"
+  | VM_create _ ->
+      "VM_create"
+  | VM_build _ ->
+      "VM_build"
+  | VM_shutdown_domain _ ->
+      "VM_shutdown_domain"
+  | VM_s3suspend _ ->
+      "VM_s3suspend"
+  | VM_s3resume _ ->
+      "VM_s3resume"
+  | VM_save _ ->
+      "VM_save"
+  | VM_restore _ ->
+      "VM_restore"
+  | VM_delay _ ->
+      "VM_delay"
+  | VM_rename _ ->
+      "VM_rename"
+  | VM_import_metadata _ ->
+      "VM_import_metadata"
+  | Parallel (_, _, atomics) ->
+      Printf.sprintf "Parallel (%s)"
+        (String.concat " | " (List.map name_of_atomic atomics))
+  | Best_effort atomic ->
+      Printf.sprintf "Best_effort (%s)" (name_of_atomic atomic)
+
 type vm_migrate_op = {
     vmm_id: Vm.id
   ; vmm_vdi_map: (string * string) list
@@ -209,6 +316,48 @@ type operation =
 [@@deriving rpcty]
 
 let string_of_operation x = x |> rpc_of operation |> Jsonrpc.to_string
+
+let name_of_operation = function
+  | VM_start _ ->
+      "VM_start"
+  | VM_poweroff _ ->
+      "VM_poweroff"
+  | VM_shutdown _ ->
+      "VM_shutdown"
+  | VM_reboot _ ->
+      "VM_reboot"
+  | VM_suspend _ ->
+      "VM_suspend"
+  | VM_resume _ ->
+      "VM_resume"
+  | VM_restore_vifs _ ->
+      "VM_restore_vifs"
+  | VM_restore_devices _ ->
+      "VM_restore_devices"
+  | VM_migrate _ ->
+      "VM_migrate"
+  | VM_receive_memory _ ->
+      "VM_receive_memory"
+  | VBD_hotplug _ ->
+      "VBD_hotplug"
+  | VBD_hotunplug _ ->
+      "VBD_hotunplug"
+  | VIF_hotplug _ ->
+      "VIF_hotplug"
+  | VIF_hotunplug _ ->
+      "VIF_hotunplug"
+  | VM_check_state _ ->
+      "VM_check_state"
+  | PCI_check_state _ ->
+      "PCI_check_state"
+  | VBD_check_state _ ->
+      "VBD_check_state"
+  | VIF_check_state _ ->
+      "VIF_check_state"
+  | VUSB_check_state _ ->
+      "VUSB_check_state"
+  | Atomic atomic ->
+      Printf.sprintf "Atomic (%s)" (name_of_atomic atomic)
 
 module TASK = struct
   open Xenops_task
@@ -1678,9 +1827,26 @@ let rec atomics_of_operation = function
   | _ ->
       []
 
+let with_tracing ~name ~task f =
+  let name = "xenopsd." ^ name in
+  let context = Xenops_task.tracing task in
+  let parent : Tracing.t = Option.bind context Tracing.t_of_string in
+  match Tracing.start ~name ~parent with
+  | Ok span ->
+      let sub_context = Tracing.t_to_string_opt span in
+      Xenops_task.set_tracing task sub_context ;
+      let result = f () in
+      let _ = Tracing.finish span in
+      Xenops_task.set_tracing task context ;
+      result
+  | Error e ->
+      warn "Failed to start tracing: %s" (Printexc.to_string e) ;
+      f ()
+
 let rec perform_atomic ~progress_callback ?subtask:_ ?result (op : atomic)
     (t : Xenops_task.task_handle) : unit =
   let module B = (val get_backend () : S) in
+  with_tracing ~name:(name_of_atomic op) ~task:t @@ fun () ->
   Xenops_task.check_cancelling t ;
   match op with
   | Best_effort atom -> (
@@ -2355,6 +2521,7 @@ and trigger_cleanup_after_failure_atom op t =
 and perform_exn ?subtask ?result (op : operation) (t : Xenops_task.task_handle)
     : unit =
   let module B = (val get_backend () : S) in
+  with_tracing ~name:(name_of_operation op) ~task:t @@ fun () ->
   let one = function
     | VM_start (id, force) -> (
         debug "VM.start %s (force=%b)" id force ;

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -1831,12 +1831,14 @@ let with_tracing ~name ~task f =
   let name = "xenopsd." ^ name in
   let context = Xenops_task.tracing task in
   let parent : Tracing.t = Option.bind context Tracing.t_of_string in
-  match Tracing.start ~name ~parent with
+  let tracer = Tracing.TracerProviders.get_default_tracer ~name in
+  let span = Tracing.Tracer.start ~tracer ~name ~parent in
+  match span with
   | Ok span ->
       let sub_context = Tracing.t_to_string_opt span in
       Xenops_task.set_tracing task sub_context ;
       let result = f () in
-      let _ = Tracing.finish span in
+      let _ = Tracing.Tracer.finish span in
       Xenops_task.set_tracing task context ;
       result
   | Error e ->

--- a/ocaml/xenopsd/lib/xenops_task.ml
+++ b/ocaml/xenopsd/lib/xenops_task.ml
@@ -69,3 +69,10 @@ let is_task task = function
       Some Xenops_task.(get_state (handle_of_id tasks id))
   | _ ->
       None
+
+let parallel_id_with_tracing parallel_id t =
+  match Xenops_task.tracing t with
+  | Some t ->
+      parallel_id ^ "\x00" ^ t
+  | None ->
+      parallel_id

--- a/ocaml/xs-trace/dune
+++ b/ocaml/xs-trace/dune
@@ -1,0 +1,10 @@
+(executable
+  (modes byte exe)
+  (name xs_trace)
+  (public_name xs-trace)
+  (package xapi)
+  (libraries
+    tracing
+    xapi-stdext-unix
+  )
+)

--- a/ocaml/xs-trace/test/dune
+++ b/ocaml/xs-trace/test/dune
@@ -1,0 +1,10 @@
+(executable
+ (modes byte exe)
+ (name test_xs_trace)
+ (libraries unix))
+
+(rule
+  (alias runtest)
+  (package xapi)
+  (deps test-xs-trace.sh ../xs_trace.exe test-source.json test_xs_trace.exe)
+  (action (run bash test-xs-trace.sh)))

--- a/ocaml/xs-trace/test/test-source.json
+++ b/ocaml/xs-trace/test/test-source.json
@@ -1,0 +1,12 @@
+[
+    {
+        "tags":{},
+        "localEndpoint":{"serviceName":"xapi"},
+        "kind":"SERVER",
+        "duration":46,
+        "timestamp":1677671549043900,
+        "name":"session_check",
+        "traceId":"9dda2bd691624f9e",
+        "id":"d3ee4b91c27d703a"
+    }
+]

--- a/ocaml/xs-trace/test/test-xs-trace.sh
+++ b/ocaml/xs-trace/test/test-xs-trace.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eux
+
+export PORT=9411
+export HOST="127.0.0.1"
+
+./test_xs_trace.exe && ../xs_trace.exe cp test-source.json http://$HOST:$PORT/api/v2/spans
+
+
+if [ $(diff test-source.json test-http-server.out | grep "<") ]
+then
+    exit 1
+fi

--- a/ocaml/xs-trace/test/test_xs_trace.ml
+++ b/ocaml/xs-trace/test/test_xs_trace.ml
@@ -1,0 +1,21 @@
+let _ =
+  let inet_addr = Unix.ADDR_INET (Unix.inet_addr_of_string "127.0.0.1", 9411) in
+  let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Unix.bind sock inet_addr ;
+  Unix.listen sock 1 ;
+  let rec read_write_all ic file =
+    match input_line ic with
+    | line ->
+        Printf.fprintf file "\n%s" line ;
+        read_write_all ic file
+    | exception End_of_file ->
+        ()
+  in
+  match Unix.fork () with
+  | 0 ->
+      let fd, _ = Unix.accept sock in
+      let ic = Unix.in_channel_of_descr fd in
+      let file = open_out "test-http-server.out" in
+      read_write_all ic file
+  | _ ->
+      ()

--- a/ocaml/xs-trace/xs_trace.ml
+++ b/ocaml/xs-trace/xs_trace.ml
@@ -1,0 +1,35 @@
+let _ =
+  if Array.length Sys.argv <> 4 then (
+    Printf.eprintf "Usage: %s cp/mv <origin> <destination>\n" Sys.argv.(0) ;
+    exit 1
+  ) ;
+  let action = Sys.argv.(1) in
+  let origin = Sys.argv.(2) in
+  let url = Sys.argv.(3) in
+  let rec export_file orig =
+    if Sys.is_directory orig then
+      let files = Sys.readdir orig in
+      let file_paths = Array.map (fun file -> orig ^ "/" ^ file) files in
+      Array.iter export_file file_paths
+    else
+      let span_json = Xapi_stdext_unix.Unixext.string_of_file orig in
+      let result = Tracing.Export.Destination.Http.export ~span_json ~url in
+      match result with
+      | Ok _ ->
+          ()
+      | Error err ->
+          Printf.eprintf "Error: %s" (Printexc.to_string err) ;
+          exit 1
+  in
+  export_file origin ;
+  let rec remove_all orig =
+    if Sys.is_directory orig then (
+      let files = Sys.readdir orig in
+      let file_paths = Array.map (Filename.concat orig) files in
+      Array.iter remove_all file_paths ;
+      Sys.rmdir orig
+    ) else
+      Sys.remove orig
+  in
+  if action = "mv" then
+    remove_all origin

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=510
+  N=511
   # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
   MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=509
+  N=510
   # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
   MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)

--- a/scripts/bugtool-plugin/xapi/stuff.xml
+++ b/scripts/bugtool-plugin/xapi/stuff.xml
@@ -12,4 +12,5 @@
 <files>@ETCDIR@/stunnel/xapi-stunnel-ca-bundle.pem</files>
 <command label="xapi_cert">cat @ETCXENDIR@/xapi-ssl.pem | @BINDIR@/openssl x509 -text</command>
 <command label="xapi_pool_cert">cat @ETCXENDIR@/xapi-pool-tls.pem | @BINDIR@/openssl x509 -text</command>
+<directory label="tracing">/var/log/dt</directory>
 </collect>

--- a/xapi-tracing.opam
+++ b/xapi-tracing.opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xen.org"
+authors: "xen-api@lists.xen.org"
+homepage: "https://xapi-project.github.io/"
+bug-reports: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+build: [[ "dune" "build" "-p" name "-j" jobs ]]
+
+available: [ os = "linux" ]
+depends: [
+  "ocaml"
+  "dune"
+  "cohttp"
+  "rpclib"
+  "xapi-idl"
+  "xapi-stdext-unix"
+]
+synopsis: "Library required by xapi"
+description: """
+These libraries are provided for backwards compatibility only.
+No new code should use these libraries."""
+url {
+  src:
+    "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}


### PR DESCRIPTION
This PR contains an initial implementation for xen-api of the distributed tracing concepts in https://opentelemetry.io/docs/reference/specification/trace/api/

It's split in two main parts:

a) ocaml/libs/tracing/tracing.ml: minimal library implementation of the API defined in the link above.

TracerProvider: configuration for status (enabled/disabled) and endpoints (disk/network)
Span: abstracts an action with start and finish events
Export: Content format manipulation and Destination output helpers for files and http endpoints. These helpers pull the finished spans and move them over to the destination endpoints indicated in the TracerProvider. The initial content format present is zipkinv2, which is compatible with a number of different distributed tracing endpoints. It should be possible to produce content also in the OTEL format using a content producer library such as ocaml-opentelemetry.
b) all the other files: initial xen-api instrumentation using tracing.ml to produce distributed tracing content to the supported destination endpoints.

--
Example usage:

install Jaeger using something like:
`docker run -d --name jaeger   -e COLLECTOR_ZIPKIN_HTTP_PORT=9411   -p 5775:5775/udp   -p 6831:6831/udp   -p 6832:6832/udp   -p 5778:5778   -p 16686:16686   -p 14268:14268   -p 9411:9411   jaegertracing/all-in-one:1.6`
set the destination endpoint to point to (1):
`   xe tracing-param-set uuid=<tracing-provider-uuid> endpoints=http://<my-jaeger-ip>:9411/api/v2/spans`
enable the tracer provider:
`   xe tracing-param-set uuid=<tracing-provider-uuid> status=enabled`
and you should be able to see the spans collected by XAPI in the Jaeger UI at http://<my-jaeger-ip>:16686/