### PR TITLE
CP-42012: Periodic update sync

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1052,12 +1052,12 @@ let configure_update_sync =
       ; ( Int
         , "update_sync_day"
         , "Which day of one period the update sychronization is scheduled. For \
-           'daily' schedule, it should be 1. For 'weekly' schedule, -7..-1 and \
-           1..7, where 1 or -7 is Sunday. For 'monthly' schedule, -28..-1 and \
-           1..28, this ensures that the day exists in every month. For \
-           negative number, it means counting down from the end of the period, \
-           which follows Python style. For example, -1 with 'monthly' schedule \
-           means the last day of each month."
+           'daily' schedule, it should be 1. For 'weekly' schedule, 1..7, \
+           where 1 is Sunday. For 'monthly' schedule, -28..-1 and 1..28, this \
+           ensures that the day exists in every month. For negative number, it \
+           means counting down from the end of the month, which follows Python \
+           style. For example, -1 with 'monthly' schedule means the last day \
+           of each month."
         )
       ; ( Int
         , "update_sync_hour"

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1393,7 +1393,7 @@ let t =
             ~default_value:(Some (VDateTime Date.epoch)) "last_update_sync"
             "time of the last update sychronization"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:update_sync_frequency
-            ~default_value:(Some (VEnum "daily")) "update_sync_frequency"
+            ~default_value:(Some (VEnum "weekly")) "update_sync_frequency"
             "The frequency at which updates are synced from remote CDN: daily, \
              weekly, or monthly."
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "update_sync_day"

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1040,7 +1040,7 @@ let update_sync_frequency =
 
 let configure_update_sync =
   call ~name:"configure_update_sync"
-    ~doc:"Config scheduled job to sync update from remote CDN" ~lifecycle:[]
+    ~doc:"Config periodic update synchronizaiton from remote CDN" ~lifecycle:[]
     ~params:
       [
         (Ref _pool, "self", "The pool")
@@ -1053,13 +1053,29 @@ let configure_update_sync =
         , "update_sync_day"
         , "Which day of one period the update sychronization is scheduled. For \
            'daily' schedule, it should be 1. For 'weekly' schedule, -7..-1 and \
-           1..7, where 1 and -7 is Sunday. For 'monthly' schedule, -28..-1 and \
-           1..28, this ensure that the day exist in every month. For negative \
-           number, it means the day count down from the end of the period."
+           1..7, where 1 or -7 is Sunday. For 'monthly' schedule, -28..-1 and \
+           1..28, this ensures that the day exists in every month. For \
+           negative number, it means counting down from the end of the period, \
+           which follows Python style. For example, -1 with 'monthly' schedule \
+           means the last day of each month."
         )
       ; ( Int
         , "update_sync_hour"
         , "Which hour of day the update sychronization is scheduled, 0..23"
+        )
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
+let set_update_sync_enabled =
+  call ~name:"set_update_sync_enabled" ~lifecycle:[]
+    ~doc:
+      "enable or disable periodic update synchronization depending on the value"
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( Bool
+        , "value"
+        , "true - enable periodic update synchronization, false - disable it"
         )
       ]
     ~allowed_roles:_R_POOL_OP ()
@@ -1147,6 +1163,7 @@ let t =
       ; set_uefi_certificates
       ; set_https_only
       ; configure_update_sync
+      ; set_update_sync_enabled
       ]
     ~contents:
       ([uid ~in_oss_since:None _pool]

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -1,7 +1,7 @@
 let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly *)
-let last_known_schema_hash = "4c64949949d7f6fba87cbb9b9ac4ff40"
+let last_known_schema_hash = "a2ad57503f2e274d3a1ca17201072394"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -5,7 +5,8 @@
     (:standard \ test_daemon_manager test_vdi_cbt test_event test_clustering
       test_cluster_host test_cluster test_pusb test_network_sriov
       test_vm_placement test_vm_helpers test_repository test_repository_helpers
-      test_livepatch test_rpm test_updateinfo test_storage_impl test_storage_quicktest))
+      test_livepatch test_rpm test_updateinfo test_storage_impl test_storage_quicktest
+      test_pool_helpers))
   (libraries
     alcotest
     angstrom
@@ -56,12 +57,12 @@
 (tests
   (names test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt
     test_clustering test_pusb test_daemon_manager test_repository test_repository_helpers
-    test_livepatch test_rpm test_updateinfo)
+    test_livepatch test_rpm test_updateinfo test_pool_helpers)
   (package xapi)
   (modules test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt
     test_event test_clustering test_cluster_host test_cluster test_pusb
     test_daemon_manager test_repository test_repository_helpers test_livepatch test_rpm
-    test_updateinfo)
+    test_updateinfo test_pool_helpers)
   (libraries
     alcotest
     fmt

--- a/ocaml/tests/test_pool_helpers.ml
+++ b/ocaml/tests/test_pool_helpers.ml
@@ -1,0 +1,833 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Test_highlevel
+open Xapi_pool_helpers
+
+let secs_random_within_an_hour =
+  PeriodicUpdateSync.seconds_random_within_an_hour ()
+
+module TestDailyUpdateSyncDelay = struct
+  let hour_configed_int = 1
+
+  let test_not_first_run_1_sec_earlier () =
+    let open Unix in
+    let tm_now_1_sec_earlier =
+      {
+        tm_year= 123
+      ; tm_mon= 0
+      ; tm_mday= 1
+      ; tm_hour= hour_configed_int - 1
+      ; tm_min= 59
+      ; tm_sec= 59
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = 1 + (24 * 60 * 60) + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.daily_update_sync_delay ~first_run:false
+        ~tm_now:tm_now_1_sec_earlier ~hour_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "daily_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_not_first_run_on_time () =
+    let open Unix in
+    let tm_on_time =
+      {
+        tm_year= 123
+      ; tm_mon= 0
+      ; tm_mday= 1
+      ; tm_hour= hour_configed_int
+      ; tm_min= 0
+      ; tm_sec= 0
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = (24 * 60 * 60) + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.daily_update_sync_delay ~first_run:false
+        ~tm_now:tm_on_time ~hour_configed_int ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "daily_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_1_sec_earlier () =
+    let open Unix in
+    let tm_1_sec_earlier =
+      {
+        tm_year= 123
+      ; tm_mon= 0
+      ; tm_mday= 1
+      ; tm_hour= hour_configed_int - 1
+      ; tm_min= 59
+      ; tm_sec= 59
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = 1 + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.daily_update_sync_delay ~first_run:true
+        ~tm_now:tm_1_sec_earlier ~hour_configed_int ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "daily_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_on_time () =
+    let open Unix in
+    let tm_on_time =
+      {
+        tm_year= 123
+      ; tm_mon= 0
+      ; tm_mday= 1
+      ; tm_hour= hour_configed_int
+      ; tm_min= 0
+      ; tm_sec= 0
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = (24 * 60 * 60) + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.daily_update_sync_delay ~first_run:true
+        ~tm_now:tm_on_time ~hour_configed_int ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "daily_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_later () =
+    let open Unix in
+    let hours_later = 2 in
+    let min_now = 2 in
+    let sec_now = 3 in
+    let tm_now_later =
+      {
+        tm_year= 123
+      ; tm_mon= 0
+      ; tm_mday= 1
+      ; tm_hour= hour_configed_int + hours_later
+      ; tm_min= min_now
+      ; tm_sec= sec_now
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run =
+      (24 * 60 * 60)
+      - (hours_later * 60 * 60)
+      - (min_now * 60)
+      - sec_now
+      + secs_random_within_an_hour
+    in
+    let res =
+      PeriodicUpdateSync.daily_update_sync_delay ~first_run:true
+        ~tm_now:tm_now_later ~hour_configed_int ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "daily_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test =
+    [
+      ( "not first run, 1 second earlier"
+      , `Quick
+      , test_not_first_run_1_sec_earlier
+      )
+    ; ("not first run, on time", `Quick, test_not_first_run_on_time)
+    ; ("first run, 1 second earlier", `Quick, test_first_run_1_sec_earlier)
+    ; ("first_run, on time", `Quick, test_first_run_on_time)
+    ; ("first_run, later", `Quick, test_first_run_later)
+    ]
+end
+
+module TestWeeklyUpdateSyncDelay = struct
+  let year_run_test = 2023 - 1900
+
+  (* April *)
+  let month_run_test = 3
+
+  let mday_run_test = 6
+
+  (* April 6th 2023 is Thursday *)
+  let wday_run_test = 4
+
+  (* Unix.tm_wday: 0..6, while day_configed_int: 1..7 *)
+  let day_configed_int = wday_run_test + 1
+
+  let day_configed_int_minus = wday_run_test - 7
+
+  let hour_configed_int = 1
+
+  let test_not_first_run_1_sec_earlier () =
+    let open Unix in
+    let tm_1_sec_earlier =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_configed_int - 1
+      ; tm_min= 59
+      ; tm_sec= 59
+      ; tm_wday= wday_run_test
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = 1 + (7 * 24 * 60 * 60) + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.weekly_update_sync_delay ~first_run:false
+        ~tm_now:tm_1_sec_earlier ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "weekly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_not_first_run_on_time () =
+    let open Unix in
+    let tm_on_time =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_configed_int
+      ; tm_min= 0
+      ; tm_sec= 0
+      ; tm_wday= wday_run_test
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = (7 * 24 * 60 * 60) + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.weekly_update_sync_delay ~first_run:false
+        ~tm_now:tm_on_time ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "weekly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_1_sec_earlier () =
+    let open Unix in
+    let tm_1_sec_earlier =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_configed_int - 1
+      ; tm_min= 59
+      ; tm_sec= 59
+      ; tm_wday= wday_run_test
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = 1 + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.weekly_update_sync_delay ~first_run:true
+        ~tm_now:tm_1_sec_earlier ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "weekly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_1_day_earlier () =
+    let open Unix in
+    let tm_1_day_earlier =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test - 1
+      ; tm_hour= hour_configed_int
+      ; tm_min= 0
+      ; tm_sec= 0
+      ; tm_wday= wday_run_test - 1
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = (24 * 60 * 60) + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.weekly_update_sync_delay ~first_run:true
+        ~tm_now:tm_1_day_earlier ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "weekly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_on_time () =
+    let open Unix in
+    let tm_on_time =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_configed_int
+      ; tm_min= 0
+      ; tm_sec= 0
+      ; tm_wday= wday_run_test
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run = (7 * 24 * 60 * 60) + secs_random_within_an_hour in
+    let res =
+      PeriodicUpdateSync.weekly_update_sync_delay ~first_run:true
+        ~tm_now:tm_on_time ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "weekly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_1_hour_later () =
+    let open Unix in
+    let tm_1_hour_later =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_configed_int + 1
+      ; tm_min= 0
+      ; tm_sec= 0
+      ; tm_wday= wday_run_test
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run =
+      (7 * 24 * 60 * 60) - (60 * 60) + secs_random_within_an_hour
+    in
+    let res =
+      PeriodicUpdateSync.weekly_update_sync_delay ~first_run:true
+        ~tm_now:tm_1_hour_later ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "weekly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_1_day_later () =
+    let open Unix in
+    let tm_1_day_later =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test + 1
+      ; tm_hour= hour_configed_int
+      ; tm_min= 0
+      ; tm_sec= 0
+      ; tm_wday= wday_run_test + 1
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let delay_next_run =
+      (7 * 24 * 60 * 60) - (24 * 60 * 60) + secs_random_within_an_hour
+    in
+    let res =
+      PeriodicUpdateSync.weekly_update_sync_delay ~first_run:true
+        ~tm_now:tm_1_day_later ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "weekly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test =
+    [
+      ( "not first run, 1 second earlier"
+      , `Quick
+      , test_not_first_run_1_sec_earlier
+      )
+    ; ("not first run, on time", `Quick, test_not_first_run_on_time)
+    ; ("first run, 1 second earlier", `Quick, test_first_run_1_sec_earlier)
+    ; ("first run, 1 day earlier", `Quick, test_first_run_1_day_earlier)
+    ; ("first run, on time", `Quick, test_first_run_on_time)
+    ; ("first run, 1 hour later", `Quick, test_first_run_1_hour_later)
+    ; ("first run, 1 day later", `Quick, test_first_run_1_day_later)
+    ]
+end
+
+module TestMonthlyUpdateSyncDelay = struct
+  let test_not_first_run_1_sec_earlier () =
+    let year_run_test = 2023 - 1900 in
+    (* April *)
+    let month_run_test = 3 in
+    let mday_run_test = 7 in
+    let day_configed_int = mday_run_test in
+    let hour_configed_int = 1 in
+    let num_of_days_of_april = 30 in
+    let delay_next_run =
+      1 + (num_of_days_of_april * 24 * 60 * 60) + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_1_sec_earlier =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_configed_int - 1
+      ; tm_min= 59
+      ; tm_sec= 59
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:false
+        ~tm_now:tm_1_sec_earlier ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_not_first_run_on_time () =
+    let year_run_test = 2023 - 1900 in
+    (* April *)
+    let month_run_test = 3 in
+    let mday_run_test = 7 in
+    let day_configed_int = mday_run_test in
+    let hour_configed_int = 1 in
+    let num_of_days_of_april = 30 in
+    let delay_next_run =
+      (num_of_days_of_april * 24 * 60 * 60) + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_on_time =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_configed_int
+      ; tm_min= 0
+      ; tm_sec= 0
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:false
+        ~tm_now:tm_on_time ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_trigger_next_month () =
+    let year_run_test = 2023 - 1900 in
+    (* April *)
+    let month_run_test = 3 in
+    let mday_run_test = 7 in
+    let hour_run_test = 11 in
+    let min_run_test = 30 in
+    let sec_run_test = 6 in
+    let day_configed_int = 1 in
+    let hour_configed_int = 1 in
+    let num_of_days_of_april = 30 in
+    let delay_next_run =
+      ((num_of_days_of_april - mday_run_test + 1) * 24 * 60 * 60)
+      - (hour_run_test * 60 * 60)
+      - (min_run_test * 60)
+      - sec_run_test
+      + ((day_configed_int - 1) * 24 * 60 * 60)
+      + (hour_configed_int * 60 * 60)
+      + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_run =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_run_test
+      ; tm_min= min_run_test
+      ; tm_sec= sec_run_test
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:true
+        ~tm_now:tm_run ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_leap_month_trigger_next_month () =
+    let year_run_test = 2024 - 1900 in
+    (* Feb *)
+    let month_run_test = 1 in
+    let mday_run_test = 7 in
+    let hour_run_test = 11 in
+    let min_run_test = 30 in
+    let sec_run_test = 6 in
+    let day_configed_int = 1 in
+    let hour_configed_int = 1 in
+    let num_of_days_of_leap_feb = 29 in
+    let delay_next_run =
+      ((num_of_days_of_leap_feb - mday_run_test + 1) * 24 * 60 * 60)
+      - (hour_run_test * 60 * 60)
+      - (min_run_test * 60)
+      - sec_run_test
+      + ((day_configed_int - 1) * 24 * 60 * 60)
+      + (hour_configed_int * 60 * 60)
+      + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_run =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_run_test
+      ; tm_min= min_run_test
+      ; tm_sec= sec_run_test
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:true
+        ~tm_now:tm_run ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_leap_month_minus_day_trigger_this_month () =
+    let year_run_test = 2024 - 1900 in
+    (* Feb *)
+    let month_run_test = 1 in
+    let mday_run_test = 7 in
+    let hour_run_test = 11 in
+    let min_run_test = 30 in
+    let sec_run_test = 6 in
+    let day_configed_int = -1 in
+    let hour_configed_int = 1 in
+    let num_of_days_of_leap_feb = 29 in
+    let delay_next_run =
+      ((num_of_days_of_leap_feb - mday_run_test + 1) * 24 * 60 * 60)
+      - (hour_run_test * 60 * 60)
+      - (min_run_test * 60)
+      - sec_run_test
+      + (day_configed_int * 24 * 60 * 60)
+      + (hour_configed_int * 60 * 60)
+      + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_run =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_run_test
+      ; tm_min= min_run_test
+      ; tm_sec= sec_run_test
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:true
+        ~tm_now:tm_run ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_trigger_this_month () =
+    let year_run_test = 2023 - 1900 in
+    (* April *)
+    let month_run_test = 3 in
+    let mday_run_test = 7 in
+    let hour_run_test = 11 in
+    let min_run_test = 30 in
+    let sec_run_test = 6 in
+    let day_configed_int = 7 in
+    let hour_configed_int = 12 in
+    let delay_next_run =
+      ((day_configed_int - mday_run_test) * 24 * 60 * 60)
+      + ((hour_configed_int - hour_run_test) * 60 * 60)
+      - (min_run_test * 60)
+      - sec_run_test
+      + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_run =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_run_test
+      ; tm_min= min_run_test
+      ; tm_sec= sec_run_test
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:true
+        ~tm_now:tm_run ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_minus_day_trigger_this_month () =
+    let year_run_test = 2023 - 1900 in
+    (* April *)
+    let month_run_test = 3 in
+    let mday_run_test = 7 in
+    let hour_run_test = 11 in
+    let min_run_test = 30 in
+    let sec_run_test = 6 in
+    let day_configed_int = -1 in
+    let hour_configed_int = 1 in
+    let num_of_days_of_april = 30 in
+    let delay_next_run =
+      ((num_of_days_of_april - mday_run_test + 1) * 24 * 60 * 60)
+      - (hour_run_test * 60 * 60)
+      - (min_run_test * 60)
+      - sec_run_test
+      + (day_configed_int * 24 * 60 * 60)
+      + (hour_configed_int * 60 * 60)
+      + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_run =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_run_test
+      ; tm_min= min_run_test
+      ; tm_sec= sec_run_test
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:true
+        ~tm_now:tm_run ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_minus_day_trigger_next_month () =
+    let year_run_test = 2023 - 1900 in
+    (* April *)
+    let month_run_test = 3 in
+    let mday_run_test = 30 in
+    let hour_run_test = 11 in
+    let min_run_test = 30 in
+    let sec_run_test = 6 in
+    let day_configed_int = -1 in
+    let hour_configed_int = 1 in
+    let num_of_days_of_april = 30 in
+    let num_of_days_of_may = 31 in
+    let delay_next_run =
+      ((num_of_days_of_april - mday_run_test + 1) * 24 * 60 * 60)
+      - (hour_run_test * 60 * 60)
+      - (min_run_test * 60)
+      - sec_run_test
+      + ((num_of_days_of_may + day_configed_int) * 24 * 60 * 60)
+      + (hour_configed_int * 60 * 60)
+      + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_run =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_run_test
+      ; tm_min= min_run_test
+      ; tm_sec= sec_run_test
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:true
+        ~tm_now:tm_run ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_trigger_next_year () =
+    let year_run_test = 2023 - 1900 in
+    let month_run_test = 11 in
+    (* Dec *)
+    let mday_run_test = 7 in
+    let hour_run_test = 11 in
+    let min_run_test = 30 in
+    let sec_run_test = 6 in
+    let day_configed_int = 1 in
+    let hour_configed_int = 1 in
+    let num_of_days_of_dec = 31 in
+    let delay_next_run =
+      ((num_of_days_of_dec - mday_run_test + 1) * 24 * 60 * 60)
+      - (hour_run_test * 60 * 60)
+      - (min_run_test * 60)
+      - sec_run_test
+      + ((day_configed_int - 1) * 24 * 60 * 60)
+      + (hour_configed_int * 60 * 60)
+      + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_run =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_run_test
+      ; tm_min= min_run_test
+      ; tm_sec= sec_run_test
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:true
+        ~tm_now:tm_run ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test_first_run_minus_day_trigger_next_year () =
+    let year_run_test = 2023 - 1900 in
+    let month_run_test = 11 in
+    (* Dec *)
+    let mday_run_test = 30 in
+    let hour_run_test = 11 in
+    let min_run_test = 30 in
+    let sec_run_test = 6 in
+    let day_configed_int = -2 in
+    let hour_configed_int = 1 in
+    let num_of_days_of_dec = 31 in
+    let num_of_days_of_jan = 31 in
+    let delay_next_run =
+      ((num_of_days_of_dec - mday_run_test + 1) * 24 * 60 * 60)
+      - (hour_run_test * 60 * 60)
+      - (min_run_test * 60)
+      - sec_run_test
+      + ((num_of_days_of_jan + day_configed_int) * 24 * 60 * 60)
+      + (hour_configed_int * 60 * 60)
+      + secs_random_within_an_hour
+    in
+
+    let open Unix in
+    let tm_run =
+      {
+        tm_year= year_run_test
+      ; tm_mon= month_run_test
+      ; tm_mday= mday_run_test
+      ; tm_hour= hour_run_test
+      ; tm_min= min_run_test
+      ; tm_sec= sec_run_test
+      ; tm_wday= 0
+      ; tm_yday= 0
+      ; tm_isdst= false
+      }
+    in
+    let res =
+      PeriodicUpdateSync.monthly_update_sync_delay ~first_run:true
+        ~tm_now:tm_run ~hour_configed_int ~day_configed_int
+        ~secs_random_within_an_hour
+    in
+    Alcotest.(check int)
+      "monthly_update_sync_delay" delay_next_run (Float.to_int res)
+
+  let test =
+    [
+      ( "not first run, 1 second earlier"
+      , `Quick
+      , test_not_first_run_1_sec_earlier
+      )
+    ; ("not first run, on time", `Quick, test_not_first_run_on_time)
+    ; ( "first run, first trigger next month"
+      , `Quick
+      , test_first_run_trigger_next_month
+      )
+    ; ( "first run on leap month, first trigger next month"
+      , `Quick
+      , test_first_run_leap_month_trigger_next_month
+      )
+    ; ( "first run on leap month, minus day, first trigger this month"
+      , `Quick
+      , test_first_run_leap_month_minus_day_trigger_this_month
+      )
+    ; ( "first run, first trigger this month"
+      , `Quick
+      , test_first_run_trigger_this_month
+      )
+    ; ( "first run, minus day, first trigger this month"
+      , `Quick
+      , test_first_run_minus_day_trigger_this_month
+      )
+    ; ( "first run, minus day, first trigger next month"
+      , `Quick
+      , test_first_run_minus_day_trigger_next_month
+      )
+    ; ( "first run on Dec, first trigger next Jan"
+      , `Quick
+      , test_first_run_trigger_next_year
+      )
+    ; ( "first run on Dec, minus day, first trigger next Jan"
+      , `Quick
+      , test_first_run_minus_day_trigger_next_year
+      )
+    ]
+end
+
+let tests =
+  make_suite "pool_helpers_"
+    [
+      ("daily_update_sync_delay", TestDailyUpdateSyncDelay.test)
+    ; ("weekly_update_sync_delay", TestWeeklyUpdateSyncDelay.test)
+    ; ("monthly_update_sync_delay", TestMonthlyUpdateSyncDelay.test)
+    ]
+
+let () = Alcotest.run "Pool Helpers" tests

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2992,8 +2992,30 @@ let rec cmdtable_data : (string * cmd_spec) list =
     , {
         reqd= ["update-sync-frequency"; "update-sync-day"; "update-sync-hour"]
       ; optn= []
-      ; help= "Configure the scheduled update synchronization from remote CDN"
+      ; help=
+          "Configure periodic update synchronization from remote CDN. \
+           'update_sync_frequenc': the frequency at which updates are synced \
+           from remote CDN: daily, weekly, or monthly. 'update_sync_day': \
+           which day of one period the update sychronization is scheduled. For \
+           'daily' schedule, it should be 1. For 'weekly' schedule, -7..-1 and \
+           1..7, where 1 or -7 is Sunday. For 'monthly' schedule, -28..-1 and \
+           1..28, this ensures that the day exists in every month. For \
+           negative number, it means counting down from the end of the period, \
+           which follows Python style. For example, -1 with 'monthly' schedule \
+           means the last day of each month. 'update_sync_hour': which hour of \
+           day the update sychronization is scheduled, 0..23"
       ; implementation= No_fd Cli_operations.pool_configure_update_sync
+      ; flags= []
+      }
+    )
+  ; ( "pool-set-update-sync-enabled"
+    , {
+        reqd= ["value"]
+      ; optn= []
+      ; help=
+          "Enable or disable periodic update synchronization depending on the \
+           value"
+      ; implementation= No_fd Cli_operations.pool_set_update_sync_enabled
       ; flags= []
       }
     )

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2997,13 +2997,13 @@ let rec cmdtable_data : (string * cmd_spec) list =
            'update_sync_frequenc': the frequency at which updates are synced \
            from remote CDN: daily, weekly, or monthly. 'update_sync_day': \
            which day of one period the update sychronization is scheduled. For \
-           'daily' schedule, it should be 1. For 'weekly' schedule, -7..-1 and \
-           1..7, where 1 or -7 is Sunday. For 'monthly' schedule, -28..-1 and \
-           1..28, this ensures that the day exists in every month. For \
-           negative number, it means counting down from the end of the period, \
-           which follows Python style. For example, -1 with 'monthly' schedule \
-           means the last day of each month. 'update_sync_hour': which hour of \
-           day the update sychronization is scheduled, 0..23"
+           'daily' schedule, it should be 1. For 'weekly' schedule, 1..7, \
+           where 1 is Sunday. For 'monthly' schedule, -28..-1 and 1..28, this \
+           ensures that the day exists in every month. For negative number, it \
+           means counting down from the end of the month, which follows Python \
+           style. For example, -1 with 'monthly' schedule means the last day \
+           of each month. 'update_sync_hour': which hour of day the update \
+           sychronization is scheduled, 0..23"
       ; implementation= No_fd Cli_operations.pool_configure_update_sync
       ; flags= []
       }

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1869,6 +1869,11 @@ let pool_configure_update_sync _printer rpc session_id params =
       ~update_sync_frequency:frequency ~update_sync_day:day_int
       ~update_sync_hour:hour_int
 
+let pool_set_update_sync_enabled _printer rpc session_id params =
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  let value = get_bool_param params "value" in
+  Client.Pool.set_update_sync_enabled ~rpc ~session_id ~self:pool ~value
+
 let vdi_type_of_string = function
   | "system" ->
       `system

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1849,10 +1849,10 @@ let pool_configure_update_sync _printer rpc session_id params =
       failwith
         "For daily schedule, cannot set the day when update sync will run to \
          an integer other than 1.\n"
-  | `weekly, d when d < -7L || d = 0L || d > 7L ->
+  | `weekly, d when d < 1L || d > 7L ->
       failwith
         "For weekly schedule, cannot set the day when update sync will run to \
-         an integer out of range: -7 ~ -1, 1 ~ 7.\n"
+         an integer out of range: 1 ~ 7.\n"
   | `monthly, d when d < -28L || d = 0L || d > 28L ->
       failwith
         "For monthly schedule, cannot set the day when update sync will run to \

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1101,6 +1101,12 @@ functor
           update_sync_day update_sync_hour ;
         Local.Pool.configure_update_sync ~__context ~self ~update_sync_frequency
           ~update_sync_day ~update_sync_hour
+
+      let set_update_sync_enabled ~__context ~self ~value =
+        info "Pool.set_update_sync_enabled: pool='%s' value='%B'"
+          (pool_uuid ~__context self)
+          value ;
+        Local.Pool.set_update_sync_enabled ~__context ~self ~value
     end
 
     module VM = struct

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1216,7 +1216,7 @@ let server_init () =
             )
           ; ( "Registering periodic functions"
             , []
-            , Xapi_periodic_scheduler_init.register
+            , fun () -> Xapi_periodic_scheduler_init.register ~__context
             )
           ; ("executing startup scripts", [Startup.NoExnRaising], startup_script)
           ; ( "considering executing on-master-start script"

--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -110,6 +110,8 @@ let delay_xenopsd_event_threads () = fistpoint "delay_xenopsd_event_threads"
 
 let pause_after_cert_exchange () = fistpoint "pause_after_cert_exchange"
 
+let update_sync_every_ten_minutes () = fistpoint "update_sync_every_ten_minutes"
+
 let hang_psr psr_checkpoint =
   ( match psr_checkpoint with
   | `backup ->

--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -110,7 +110,8 @@ let delay_xenopsd_event_threads () = fistpoint "delay_xenopsd_event_threads"
 
 let pause_after_cert_exchange () = fistpoint "pause_after_cert_exchange"
 
-let update_sync_every_ten_minutes () = fistpoint "update_sync_every_ten_minutes"
+let disable_periodic_update_sync_sec_randomness () =
+  fistpoint "disable_periodic_update_sync_sec_randomness"
 
 let hang_psr psr_checkpoint =
   ( match psr_checkpoint with

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -17,7 +17,7 @@ module D = Debug.Make (struct let name = "backgroundscheduler" end)
 
 open D
 
-let register () =
+let register ~__context =
   debug "Registering periodic calls" ;
   let master = Pool_role.is_master () in
   (* blob/message/rrd file syncing - sync once a day *)
@@ -113,4 +113,10 @@ let register () =
         "Period alert if TLS verification emergency disabled" (fun __context ->
           Xapi_host.alert_if_tls_verification_was_emergency_disabled ~__context
       )
-  )
+  ) ;
+  if
+    master
+    && Db.Pool.get_update_sync_enabled ~__context
+         ~self:(Helpers.get_pool ~__context)
+  then
+    Xapi_pool_helpers.PeriodicUpdateSync.set_enabled ~__context ~value:true

--- a/ocaml/xapi/xapi_periodic_scheduler_init.mli
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.mli
@@ -13,5 +13,5 @@
  *)
 (** Schedule common background tasks. *)
 
-val register : unit -> unit
+val register : __context:Context.t -> unit
 (** Register periodic calls, done by {!Xapi} on start-up. *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3622,10 +3622,10 @@ let configure_update_sync ~__context ~self ~update_sync_frequency
           Server_error
             (invalid_update_sync_day, [Int64.to_string update_sync_day])
         )
-  | `weekly, d when d < -7L || d = 0L || d > 7L ->
+  | `weekly, d when d < 1L || d > 7L ->
       error
         "For weekly schedule, cannot set the day when update sync will run to \
-         an integer out of range: -7 ~ -1, 1 ~ 7" ;
+         an integer out of range: 1 ~ 7" ;
       raise
         Api_errors.(
           Server_error

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3656,4 +3656,13 @@ let configure_update_sync ~__context ~self ~update_sync_frequency
   Db.Pool.set_update_sync_frequency ~__context ~self
     ~value:update_sync_frequency ;
   Db.Pool.set_update_sync_day ~__context ~self ~value:update_sync_day ;
-  Db.Pool.set_update_sync_hour ~__context ~self ~value:update_sync_hour
+  Db.Pool.set_update_sync_hour ~__context ~self ~value:update_sync_hour ;
+  if Db.Pool.get_update_sync_enabled ~__context ~self then (
+    (* re-schedule periodic update sync with new configuration immediately *)
+    Xapi_pool_helpers.PeriodicUpdateSync.set_enabled ~__context ~value:false ;
+    Xapi_pool_helpers.PeriodicUpdateSync.set_enabled ~__context ~value:true
+  )
+
+let set_update_sync_enabled ~__context ~self ~value =
+  Db.Pool.set_update_sync_enabled ~__context ~self ~value ;
+  Xapi_pool_helpers.PeriodicUpdateSync.set_enabled ~__context ~value

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -398,3 +398,6 @@ val configure_update_sync :
   -> update_sync_day:int64
   -> update_sync_hour:int64
   -> unit
+
+val set_update_sync_enabled :
+  __context:Context.t -> self:API.ref_pool -> value:bool -> unit

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -340,14 +340,9 @@ module PeriodicUpdateSync = struct
 
   let weekly_update_sync_delay ~first_run ~tm_now ~hour_configed_int
       ~day_configed_int ~secs_random_within_an_hour =
-    (* day_configed_int: -7..-1, 1..7 -> weekday_configed: 0..6, to align
+    (* day_configed_int: 1..7 -> weekday_configed: 0..6, to align
        with tm_now.Unix.tm_wday, where Sunday is 0 *)
-    let weekday_configed =
-      if day_configed_int > 0 then
-        day_configed_int - 1
-      else
-        7 + day_configed_int
-    in
+    let weekday_configed = day_configed_int - 1 in
 
     let execute_next_week =
       if not first_run then

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -62,3 +62,7 @@ val get_master_slaves_list : __context:Context.t -> [`host] Ref.t list
 val get_slaves_list : __context:Context.t -> [`host] Ref.t list
 
 val apply_guest_agent_config : __context:Context.t -> unit
+
+module PeriodicUpdateSync : sig
+  val set_enabled : __context:Context.t -> value:bool -> unit
+end

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -65,4 +65,30 @@ val apply_guest_agent_config : __context:Context.t -> unit
 
 module PeriodicUpdateSync : sig
   val set_enabled : __context:Context.t -> value:bool -> unit
+
+  (* below for UT only *)
+  val seconds_random_within_an_hour : unit -> int
+
+  val daily_update_sync_delay :
+       first_run:bool
+    -> tm_now:Unix.tm
+    -> hour_configed_int:int
+    -> secs_random_within_an_hour:int
+    -> float
+
+  val weekly_update_sync_delay :
+       first_run:bool
+    -> tm_now:Unix.tm
+    -> hour_configed_int:int
+    -> day_configed_int:int
+    -> secs_random_within_an_hour:int
+    -> float
+
+  val monthly_update_sync_delay :
+       first_run:bool
+    -> tm_now:Unix.tm
+    -> hour_configed_int:int
+    -> day_configed_int:int
+    -> secs_random_within_an_hour:int
+    -> float
 end


### PR DESCRIPTION
1. add API pool.set_update_sync_enabled and xe CLI
   pool-set-update-sync-enabled to enable and disable periodic
   update sync.
2. scheduling at random seconds within next hour.
3. support negative number for "weekly" and "monthly" periodic
   update sync.
4. retry 3 times for pool.sync_updates in one trigger.
5. add fist support: update_sync_every_ten_minutes.