### PR TITLE
ezxenstore: make tests exclusive to it

### DIFF
--- a/ocaml/libs/ezxenstore/lib_test/dune
+++ b/ocaml/libs/ezxenstore/lib_test/dune
@@ -1,5 +1,6 @@
 (test
   (name main)
+  (package ezxenstore)
   (deps main.exe)
   (libraries ezxenstore)
 )


### PR DESCRIPTION
This prevents opam from trying to compile the tests when testing other packages