### PR TITLE
CA-376448: explicitly validate refs in PVS_cache_storage.create

### DIFF
--- a/ocaml/xapi/xapi_pvs_cache_storage.ml
+++ b/ocaml/xapi/xapi_pvs_cache_storage.ml
@@ -29,6 +29,9 @@ let assert_not_already_present ~__context site host =
     api_error E.pvs_cache_storage_already_present [str site; str host]
 
 let create ~__context ~host ~sR ~site ~size =
+  Helpers.assert_is_valid_ref ~__context ~name:"host" ~ref:host ;
+  Helpers.assert_is_valid_ref ~__context ~name:"SR" ~ref:sR ;
+  Helpers.assert_is_valid_ref ~__context ~name:"site" ~ref:site ;
   assert_not_already_present ~__context site host ;
   let cache_storage = Ref.make () in
   let uuid = Uuidx.(to_string (make ())) in


### PR DESCRIPTION
In particular, if the host parameter is left out from the call, a null ref is used and put into the new PVS_cache_storage object. The DB GC will then destroy the object when it runs next, due to the invalid ref, but it is better to fail the create call immediately.