### PR TITLE
CP-42642: Support share server certificate file to group users

### DIFF
--- a/ocaml/gencert/lib.ml
+++ b/ocaml/gencert/lib.ml
@@ -125,7 +125,7 @@ let validate_certificate kind pem now private_key =
     )
 
 let install_server_certificate ~pem_chain ~pem_leaf ~pkcs8_private_key
-    ~server_cert_path =
+    ~server_cert_path ~cert_gid =
   let now = Ptime_clock.now () in
   validate_private_key pkcs8_private_key >>= fun priv ->
   validate_certificate Leaf pem_leaf now priv >>= fun cert ->
@@ -139,6 +139,6 @@ let install_server_certificate ~pem_chain ~pem_leaf ~pkcs8_private_key
   >>= fun server_cert_components ->
   server_cert_components
   |> String.concat "\n\n"
-  |> Selfcert.write_certs server_cert_path
+  |> Selfcert.write_certs server_cert_path cert_gid
   |> R.reword_error (function `Msg msg -> `Msg (internal_error, [msg]))
   >>= fun () -> R.ok cert

--- a/ocaml/gencert/lib.mli
+++ b/ocaml/gencert/lib.mli
@@ -17,6 +17,7 @@ val install_server_certificate :
   -> pem_leaf:string
   -> pkcs8_private_key:string
   -> server_cert_path:string
+  -> cert_gid:int
   -> (X509.Certificate.t, [> `Msg of string * string list]) Result.result
 (** [install_server_certificate pem_chain pem_leaf pkcs8_private_key
      server_cert_path] writes a PKCS12 containing [pkcs8_private_key],

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -16,7 +16,7 @@ val fist_path : string
 (** Path to a file; if this file exists, newly created certificates will
 be backdated to 2008-07-01 and any [valid_from] ignored *)
 
-val write_certs : string -> string -> (unit, [> Rresult.R.msg]) result
+val write_certs : string -> int -> string -> (unit, [> Rresult.R.msg]) result
 (** [write_certs path pkcs12] writes [pkcs12] to [path] atomically.
 [pkcs12] should contain a components of a PKCS12 Certificate *)
 
@@ -27,6 +27,7 @@ val host :
   -> ?valid_from:Ptime.t (* default: now *)
   -> valid_for_days:int
   -> string
+  -> int
   -> X509.Certificate.t
 (** [host name dns_names ip path] creates (atomically) a PEM file at
     [path] with [name] as CN, and the following SANs: [dns_names] + [ip] *)
@@ -36,6 +37,7 @@ val xapi_pool :
   -> valid_for_days:int
   -> uuid:string
   -> string
+  -> int
   -> X509.Certificate.t
 (** [xapi_pool uuid path] creates (atomically) a PEM file at [path] with
     [uuid] as CN *)

--- a/ocaml/xapi/cert_refresh.ml
+++ b/ocaml/xapi/cert_refresh.ml
@@ -70,7 +70,7 @@ let host ~__context ~type' =
   let path = new_cert_path type' in
   let valid_for_days = !Xapi_globs.cert_expiration_days in
   let uuid = Inventory.lookup Inventory._installation_uuid in
-  let cert = Gencertlib.Selfcert.xapi_pool ~uuid ~valid_for_days path in
+  let cert = Gencertlib.Selfcert.xapi_pool ~uuid ~valid_for_days path (-1) in
   let bak = backup_cert_path type' in
   let unreachable = unreachable_hosts ~__context in
   if not @@ HostSet.is_empty unreachable then

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -436,6 +436,7 @@ let install_server_certificate ~pem_chain ~pem_leaf ~pkcs8_private_key ~path =
   let installation =
     Gencertlib.Lib.install_server_certificate ~pem_chain ~pem_leaf
       ~pkcs8_private_key ~server_cert_path:path
+      ~cert_gid:!Xapi_globs.server_cert_group_id
   in
   match installation with
   | Ok cert ->

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -749,6 +749,9 @@ let pool_secret_path = ref (Filename.concat "/etc/xensource" "ptoken")
 (* Path to server ssl certificate *)
 let server_cert_path = ref (Filename.concat "/etc/xensource" "xapi-ssl.pem")
 
+(* The group id of server ssl certificate file *)
+let server_cert_group_id = ref (-1)
+
 (* Path to server certificate used for host-to-host TLS connections *)
 let server_cert_internal_path =
   ref (Filename.concat "/etc/xensource" "xapi-pool-tls.pem")
@@ -1404,6 +1407,11 @@ let other_options =
     , (fun () -> string_of_bool !override_uefi_certs)
     , "Enable (true) or Disable (false) overriding location for varstored UEFI \
        certificates"
+    )
+  ; ( "server-cert-group-id"
+    , Arg.Set_int server_cert_group_id
+    , (fun () -> string_of_int !server_cert_group_id)
+    , "The group id of server ssl certificate file."
     )
   ]
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1602,6 +1602,7 @@ let _new_host_cert ~dbg ~path : X509.Certificate.t =
   let ips = [ip] in
   let valid_for_days = !Xapi_globs.cert_expiration_days in
   Gencertlib.Selfcert.host ~name:cn ~dns_names ~ips ~valid_for_days path
+    !Xapi_globs.server_cert_group_id
 
 let reset_server_certificate ~__context ~host =
   let dbg = Context.string_of_task __context in

--- a/scripts/gencert.service
+++ b/scripts/gencert.service
@@ -6,8 +6,8 @@ After=forkexecd.service
 [Service]
 User=root
 Type=oneshot
-ExecStart=/opt/xensource/libexec/gencert /etc/xensource/xapi-pool-tls.pem xapi:pool
-ExecStart=/opt/xensource/libexec/gencert /etc/xensource/xapi-ssl.pem default
+ExecStart=/opt/xensource/libexec/gencert /etc/xensource/xapi-pool-tls.pem -1 xapi:pool
+ExecStart=/opt/xensource/libexec/gencert /etc/xensource/xapi-ssl.pem -1 default
 RemainAfterExit=yes
 
 [Install]

--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -34,6 +34,10 @@ inventory = /etc/xensource-inventory
 # /etc/systemd/system/default.target.wants/xapi-nbd.path
 # server-cert-path = @ETCXENDIR@/xapi-ssl.pem
 
+# The group id of server ssl certificate file.
+# -1 means the default group won't be changed.
+# server-cert-group-id = -1
+
 # Where to cache boot-time CPU info
 # cpu-info-file = @ETCXENDIR@/boot_time_cpus
 


### PR DESCRIPTION
- Currently /etc/xensource/xapi-ssl.pem is user (default root) readonly, to share to other users of one group add the setting "server-cert-group-id".
- gencert.service can not read xapi config file, so feed the goup id in service unit file directly. In future can consider to make "xapi_globs" as common library so that gencert.service can read "server-cert-group-id" directly.
- The group id -1 means the default group won't be changed.