### PR TITLE
xapi_blob: don't verify connection when sending between pools

### DIFF
--- a/ocaml/xapi/xapi_blob.ml
+++ b/ocaml/xapi/xapi_blob.ml
@@ -68,7 +68,7 @@ let send_blobs ~__context ~remote_address ~session_id uuid_map =
         let open Xmlrpc_client in
         let transport =
           SSL
-            ( SSL.make ~verify_cert:(Stunnel_client.pool ()) ()
+            ( SSL.make ~verify_cert:None ()
             , remote_address
             , !Constants.https_port
             )

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -14,7 +14,7 @@ list-hd () {
 }
 
 verify-cert () {
-  N=13
+  N=14
   NONE=$(git grep -r --count 'verify_cert:None' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$NONE" -eq "$N" ]; then
     echo "OK counted $NONE usages of verify_cert:None"


### PR DESCRIPTION
The other host's certificates are not trusted and the connection will fail

Verifying the certificate will be part of the work to enable checking for cross-pool migration

I couldn't find any reference to set_blobs, so all this code has been unused for years, if not decades. I think design-wise the team moved away from having generic blobs and instead giving them semantic meaning, like the vtpm contents or the uefi vars, I doubt this was ever used, but now it's a bit difficult to get rid of