### PR TITLE
ci: publish XenAPI releases to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,8 @@ on:
       - 'v*'
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
     env:
       XAPI_VERSION: ${{ github.ref_name }}
 
@@ -33,17 +30,48 @@ jobs:
           ./configure --xapi-version=${{ github.ref_name }}
           make python
 
+      - name: Store python distribution artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: XenAPI
+          path: scripts/examples/python/dist/
+
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Retrieve python distribution artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: XenAPI
+          path: dist/
+
       - name: Draft Release ${{ github.ref_name }}
         run: gh release create ${{ github.ref_name }} --draft --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        run: gh release upload ${{ github.ref_name }} scripts/examples/python/dist/*
+        run: gh release upload ${{ github.ref_name }} dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  publish:
+    runs-on: ubuntu-latest
+    needs: release
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve python distribution artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: XenAPI
+          path: dist/
+
       - name: Publish the Python release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: scripts/examples/python/dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     env:
       XAPI_VERSION: ${{ github.ref_name }}
 
@@ -34,8 +37,13 @@ jobs:
         run: gh release create ${{ github.ref_name }} --draft --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
       - name: Upload artifacts
-        run: gh release upload ${{ github.ref_name }} scripts/examples/python/dist/* 
+        run: gh release upload ${{ github.ref_name }} scripts/examples/python/dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish the Python release to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: scripts/examples/python/dist/


### PR DESCRIPTION
This uses the new token-less authentication method added to PyPI, which
restricts the conditions around the github workflow allowed to publish

Workflow tested here: https://github.com/psafont/xen-api/actions/runs/4786024146
it only fails on upload to pypi because it lacks permissions, otherwise it works as expected, including the creation of github release and the contents of the artifact match with what's expected, with a tarball and a python wheel