### PR TITLE
Check if user if root before continuing with test

### DIFF
--- a/ocaml/libs/ezxenstore/lib_test/main.ml
+++ b/ocaml/libs/ezxenstore/lib_test/main.ml
@@ -7,15 +7,18 @@ let set_socket_path path = Xs_transport.xenstored_socket := path
 let test socket =
   set_socket_path socket ;
   let open Xenstore in
-  try
-    let result = with_xs (fun xs -> xs.write "/foo" "bar" ; xs.read "/foo") in
-    if result = "bar" then
-      `Ok 0
-    else
-      `Error (false, "argh")
-  with Xs_transport.Could_not_find_xenstore ->
-    (* Do not fail on systems that don't have xenstore running *)
+  if Unix.geteuid () <> 0 then (* non-root won't have access to xenstore *)
     `Ok 0
+  else
+    try
+      let result = with_xs (fun xs -> xs.write "/foo" "bar" ; xs.read "/foo") in
+      if result = "bar" then
+        `Ok 0
+      else
+        `Error (false, "argh")
+    with Xs_transport.Could_not_find_xenstore ->
+      (* Do not fail on systems that don't have xenstore running *)
+      `Ok 0
 
 let socket =
   let doc = "Set the path to the xenstored socket" in


### PR DESCRIPTION
When developing on a Xen environment test fails when not running on root, this change circumvents the test when the user does not have access to Xenstore.