### PR TITLE
xapi-cli: Have a consistent interface for vtpms's vm

### DIFF
--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1308,7 +1308,8 @@ let gen_cmds rpc session_id =
       )
     ; Client.VTPM.(
         mk get_all_records_where get_by_uuid vtpm_record "vtpm" []
-          ["uuid"; "vm"; "profile"] rpc session_id
+          ["uuid"; "vm-uuid"; "profile"]
+          rpc session_id
       )
     ]
 

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5231,8 +5231,11 @@ let vtpm_record rpc session_id vtpm =
   ; fields=
       [
         make_field ~name:"uuid" ~get:(fun () -> (x ()).API.vTPM_uuid) ()
-      ; make_field ~name:"vm"
+      ; make_field ~name:"vm-uuid"
           ~get:(fun () -> get_uuid_from_ref (x ()).API.vTPM_VM)
+          ()
+      ; make_field ~name:"vm-name-label"
+          ~get:(fun () -> get_name_from_ref (x ()).API.vTPM_VM)
           ()
       ; make_field ~name:"is_unique"
           ~get:(fun () -> string_of_bool (x ()).API.vTPM_is_unique)


### PR DESCRIPTION
Use vm-uuid for vtpm-list and expose vtpm name-label as well for it, like other fields