### PR TITLE
CA-373074 Fix Fingerprint not writing on boot 

### DIFF
--- a/scripts/gencert.service
+++ b/scripts/gencert.service
@@ -8,6 +8,8 @@ User=root
 Type=oneshot
 ExecStart=/opt/xensource/libexec/gencert /etc/xensource/xapi-pool-tls.pem -1 xapi:pool
 ExecStart=/opt/xensource/libexec/gencert /etc/xensource/xapi-ssl.pem -1 default
+ExecStartPost=/sbin/update-issue
+ExecStartPost=/usr/bin/killall -q -HUP -r .*getty
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
An internal test case flags that the host fingerprint is not being found by the testcase. 

The update is done by the script `update_getty`, however if the certificate is not generated then this process will not run properly. This change runs this script at the end of gencert starting.