### PR TITLE
CP-40528 VTPM snapshot, revert, clone

### DIFF
--- a/ocaml/message-switch/switch/q.ml
+++ b/ocaml/message-switch/switch/q.ml
@@ -238,7 +238,7 @@ module Op = struct
         * string
         * int64
         * Message_switch_core.Protocol.Message.t
-      (* origin * queue * id * body *)
+  (* origin * queue * id * body *)
   [@@deriving sexp]
 
   let of_cstruct x =

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -56,11 +56,11 @@
 
 (tests
   (names test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt
-    test_clustering test_pusb test_daemon_manager test_repository test_repository_helpers
+    test_pusb test_daemon_manager test_repository test_repository_helpers
     test_livepatch test_rpm test_updateinfo)
   (package xapi)
   (modules test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt
-    test_event test_clustering test_cluster_host test_cluster test_pusb
+    test_event test_cluster_host test_cluster test_pusb
     test_daemon_manager test_repository test_repository_helpers test_livepatch test_rpm
     test_updateinfo)
   (libraries

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5215,6 +5215,12 @@ let vtpm_record rpc session_id vtpm =
   in
   let record = ref empty_record in
   let x () = lzy_get record in
+  let secret () =
+    let str = Client.VTPM.get_contents ~rpc ~session_id ~self:!_ref in
+    Printf.sprintf "MD5=%s size=%d bytes"
+      Digest.(string str |> to_hex)
+      (String.length str)
+  in
   {
     setref=
       (fun r ->
@@ -5237,6 +5243,7 @@ let vtpm_record rpc session_id vtpm =
       ; make_field ~name:"vm-name-label"
           ~get:(fun () -> get_name_from_ref (x ()).API.vTPM_VM)
           ()
+      ; make_field ~name:"secret" ~get:secret ()
       ; make_field ~name:"is_unique"
           ~get:(fun () -> string_of_bool (x ()).API.vTPM_is_unique)
           ()

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -397,6 +397,7 @@ let do_not_copy =
   ; "VIFs"
   ; "VGPUs"
   ; "VUSBs"
+  ; "VTPMs"
   ; (* Stateful fields that will be reset anyway *)
     "power_state"
   ; (* Attached PCIs should not revert from snapshot *)
@@ -478,6 +479,35 @@ let revert_vm_fields ~__context ~snapshot ~vm =
     ~overrides ;
   TaskHelper.set_progress ~__context 0.1
 
+(* See CP-40528. A snapshot is a VM record that contains the record of
+   the VM at snapshot time in snapshot_metadata, including its VTPM.
+   Most data is restored from snapshot_metadata. At the time the
+   snapshot is taken, a copy of the VTPM is taken and this is part of
+   the VM record. We want to use a copy of this VTPM. We need to make a
+   copy because a snapshot can be restored multiple times and we have to
+   ensure the VTPM of the snapshot remains unaltered. *)
+
+let update_vtpm ~__context ~snapshot ~vm =
+  debug "%s for VM %s (1/2)" __FUNCTION__ (Ref.string_of vm) ;
+  let vtpms = Db.VM.get_VTPMs ~__context ~self:vm in
+  (* destroy current VTPM, but don't fail if it doesn't exist *)
+  List.iter
+    (fun vtpm ->
+      if Db.is_valid_ref __context vtpm then
+        Xapi_vtpm.destroy ~__context ~self:vtpm
+    )
+    vtpms ;
+  (* assign copy of snapshot VTPM to VM *)
+  let _vtpms =
+    Db.VM.get_VTPMs ~__context ~self:snapshot
+    |> List.map (fun vtpm -> Xapi_vtpm.copy ~__context ~vM:vm vtpm)
+  in
+  (* A restored VTPM has a different UUID than the one that took the
+     snapshot from. But there is no easy way to maintain it. In
+     particular, the current VM could have a different number of VTPMs
+     than the snapshot. So code can't rely on this anyway. *)
+  debug "%s for VM %s (2/2)" __FUNCTION__ (Ref.string_of vm)
+
 let revert ~__context ~snapshot ~vm =
   debug "Reverting %s to %s" (Ref.string_of vm) (Ref.string_of snapshot) ;
   (* This is destructive and relatively fast. There's no point advertising cancel since it
@@ -489,6 +519,7 @@ let revert ~__context ~snapshot ~vm =
     update_guest_metrics ~__context ~snapshot ~vm ;
     update_metrics ~__context ~snapshot ~vm ;
     update_parent ~__context ~snapshot ~vm ;
+    update_vtpm ~__context ~snapshot ~vm ;
     TaskHelper.set_progress ~__context 1. ;
     Xapi_vm_lifecycle.force_state_reset ~__context ~self:vm ~value:power_state ;
     debug "VM.revert done"

--- a/ocaml/xapi/xapi_vtpm.ml
+++ b/ocaml/xapi/xapi_vtpm.ml
@@ -12,6 +12,10 @@
    GNU Lesser General Public License for more details.
  *)
 
+module D = Debug.Make (struct let name = __MODULE__ end)
+
+open D
+
 (** Don't allow unless VTPM is enabled as an experimental feature *)
 let assert_not_restricted ~__context =
   let pool = Helpers.get_pool ~__context in
@@ -82,6 +86,7 @@ let copy ~__context ~vM ref =
   let vtpm = Db.VTPM.get_record ~__context ~self:ref in
   let persistence_backend = vtpm.vTPM_persistence_backend in
   let is_unique = vtpm.vTPM_is_unique in
+  debug "%s VTPM %s is_unique=%b" __FUNCTION__ (Ref.string_of ref) is_unique ;
   let contents = copy_or_create_contents ~__context ~from:ref () in
   introduce ~__context ~vM ~persistence_backend ~contents ~is_unique
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -669,9 +669,8 @@ module MD = struct
     in
     let backend_kind_keys = other_config_keys Xapi_globs.vbd_backend_key in
     let poll_duration_keys =
-      in_range ~min:0 ~max:max_int
-        ~fallback:0
-          (* if user provides invalid integer, use 0 = disable polling *)
+      in_range ~min:0 ~max:max_int ~fallback:0
+        (* if user provides invalid integer, use 0 = disable polling *)
         (other_config_keys Xapi_globs.vbd_polling_duration_key
            ~default:
              (Some (string_of_int !Xapi_globs.default_vbd3_polling_duration))


### PR DESCRIPTION
Implement VM snapshot/revert and VM clone for VMs that have VTPMs.

A VM snapshot is a VM record with an additional field snapshot_metadata
that contains all metadata of the VM we are taking a snapshot of. This
metadata includes a reference to the VTPM the VM is/was using. In
addition, a new VTPM as a copy of the existing one is created and referred
to by the VM record that represents the snapshot. So a snapshot references
two VTPM: one directly (A) and one via snapshot_metadata (B).

Since the VM that took the snapshot is in continued use, it will continue
to update B but A is stable.

When reverting the snapshot we create a new VM from the VM record that
represents the snapshot. This can happen again and again.  Unlike a clone,
reverting a snapshot does not consume it.

As a consequence, the VM we are creating can't use VTPM A (and modify
it) but we create a copy of A and use that. This currently means that
the UUID of the VTPM changes - this is fixed in a later commit.

To help development, this patch extends the fields listed in "xe
vtpm-list" by showing the size and MD5 hash of the content. Otherwise
tracking this is difficult because the content is not stored in the VTPM
object but it refers to another object of class secret that holds the
actual content.

When we revert a VM snapshot, we:

* delete the VMs current VTPM * make a copy of the snapshot VTPM *
assign the copy to the VM

The copy (of the VTPM) has a UUID that is different from the UUID before
the revert. But we can maintain the same UUID because the VTPM before
the revert operation is removed. So we remember that UUID and assign it
to the copy we just created.
