### PR TITLE
Tracing Instrumentation in Xapi

### DIFF
--- a/ocaml/libs/http-lib/dune
+++ b/ocaml/libs/http-lib/dune
@@ -27,6 +27,7 @@
     xapi-stdext-threads
     xapi-stdext-unix
     xml-light2
+    tracing
   )
 )
 

--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -90,6 +90,7 @@ module Request : sig
     ; mutable close: bool
     ; additional_headers: (string * string) list
     ; body: string option
+    ; traceparent: string option
   }
 
   val rpc_of_t : t -> Rpc.t
@@ -112,6 +113,7 @@ module Request : sig
     -> ?content_type:string
     -> ?host:string
     -> ?query:(string * string) list
+    -> ?traceparent:string
     -> user_agent:string
     -> method_t
     -> string
@@ -229,6 +231,8 @@ module Hdr : sig
   val accept : string
 
   val location : string
+
+  val traceparent : string
 end
 
 val output_http : Unix.file_descr -> string list -> unit

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -399,6 +399,8 @@ let request_of_bio_exn ~proxy_seen ~read_timeout ~total_timeout ~max_length bio
                        {req with host= Some v}
                    | k when k = Http.Hdr.user_agent ->
                        {req with user_agent= Some v}
+                   | k when k = Http.Hdr.traceparent ->
+                       {req with traceparent= Some v}
                    | k when k = Http.Hdr.connection && lowercase v = "close" ->
                        {req with close= true}
                    | k

--- a/ocaml/libs/http-lib/xmlrpc_client.ml
+++ b/ocaml/libs/http-lib/xmlrpc_client.ml
@@ -49,10 +49,16 @@ let connect ?session_id ?task_id ?subtask_of path =
     ?subtask_of Http.Connect path
 
 let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth
-    ?subtask_of ?query ?body path =
+    ?subtask_of ?query ?body ?(tracing = None) path =
+  let traceparent =
+    let open Tracing in
+    Option.map
+      (fun span -> Span.get_context span |> SpanContext.to_traceparent)
+      tracing
+  in
   let headers = Option.map (fun x -> [(Http.Hdr.task_id, x)]) task_id in
   Http.Request.make ~user_agent ?frame ?version ?keep_alive ?cookie ?headers
-    ?length ?auth ?subtask_of ?query ?body Http.Post path
+    ?length ?auth ?subtask_of ?query ?body ?traceparent Http.Post path
 
 (** Thrown when ECONNRESET is caught which suggests the remote crashed or restarted *)
 exception Connection_reset

--- a/ocaml/libs/http-lib/xmlrpc_client.mli
+++ b/ocaml/libs/http-lib/xmlrpc_client.mli
@@ -72,6 +72,7 @@ val xmlrpc :
   -> ?subtask_of:string
   -> ?query:(string * string) list
   -> ?body:string
+  -> ?tracing:Tracing.Span.t option
   -> string
   -> Http.Request.t
 (** Returns an HTTP.Request.t representing an XMLRPC request *)

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -147,3 +147,5 @@ val complete_tracing_with_exn : t -> exn * string -> unit
 val tracing_of : t -> Tracing.Span.t option
 
 val with_tracing : t -> string -> (t -> 'a) -> 'a
+
+val set_client_span : t -> Tracing.Span.t option

--- a/ocaml/xapi/context.mli
+++ b/ocaml/xapi/context.mli
@@ -139,3 +139,11 @@ val get_client : t -> string option
 val get_client_ip : t -> string option
 
 val get_user_agent : t -> string option
+
+val complete_tracing : t -> unit
+
+val complete_tracing_with_exn : t -> exn * string -> unit
+
+val tracing_of : t -> Tracing.Span.t option
+
+val with_tracing : t -> string -> (t -> 'a) -> 'a

--- a/ocaml/xapi/dbsync.ml
+++ b/ocaml/xapi/dbsync.ml
@@ -48,9 +48,9 @@ let create_host_metrics ~__context =
     )
     (Db.Host.get_all ~__context)
 
-let update_env () =
-  Server_helpers.exec_with_new_task "dbsync (update_env)" ~task_in_database:true
-    (fun __context ->
+let update_env ~__context =
+  Server_helpers.exec_with_subtask ~__context "dbsync (update_env)"
+    ~task_in_database:true (fun ~__context ->
       let other_config =
         match Db.Pool.get_all ~__context with
         | [pool] ->
@@ -73,8 +73,8 @@ let update_env () =
       if not (Pool_role.is_master ()) then resync_dom0_config_files ()
   )
 
-let setup () =
-  try update_env ()
+let setup ~__context =
+  try update_env ~__context
   with exn ->
     Backtrace.is_important exn ;
     debug "dbsync caught an exception: %s" (ExnHelper.string_of_exn exn) ;

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -388,7 +388,8 @@ let update_pif_addresses ~__context =
 let make_rpc ~__context rpc : Rpc.response =
   let subtask_of = Ref.string_of (Context.get_task_id __context) in
   let open Xmlrpc_client in
-  let http = xmlrpc ~subtask_of ~version:"1.1" "/" in
+  let tracing = Context.set_client_span __context in
+  let http = xmlrpc ~subtask_of ~version:"1.1" "/" ~tracing in
   let transport =
     if Pool_role.is_master () then
       Unix Xapi_globs.unix_domain_socket
@@ -410,7 +411,8 @@ let make_timeboxed_rpc ~__context timeout rpc : Rpc.response =
        * associated with the task. To avoid conflating the stunnel with any real resources
        * the task has acquired we make a new one specifically for the stunnel pid *)
       let open Xmlrpc_client in
-      let http = xmlrpc ~subtask_of ~version:"1.1" "/" in
+      let tracing = Context.set_client_span __context in
+      let http = xmlrpc ~subtask_of ~version:"1.1" ~tracing "/" in
       let task_id = Context.get_task_id __context in
       let cancel () =
         let resources =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -58,8 +58,11 @@ let remote_rpc_no_retry _context hostname (task_opt : API.ref_task option) xml =
       , !Constants.https_port
       )
   in
+  let tracing = Context.set_client_span _context in
   let http =
-    xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.0" "/"
+    xmlrpc
+      ?task_id:(Option.map Ref.string_of task_opt)
+      ~version:"1.0" ~tracing "/"
   in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
@@ -75,8 +78,11 @@ let remote_rpc_retry _context hostname (task_opt : API.ref_task option) xml =
       , !Constants.https_port
       )
   in
+  let tracing = Context.set_client_span _context in
   let http =
-    xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.1" "/"
+    xmlrpc
+      ?task_id:(Option.map Ref.string_of task_opt)
+      ~version:"1.1" ~tracing "/"
   in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 

--- a/ocaml/xapi/startup.ml
+++ b/ocaml/xapi/startup.ml
@@ -84,18 +84,16 @@ let run ~__context tasks =
             ignore
               (Thread.create
                  (fun tsk_fct ->
-                   Server_helpers.exec_with_new_task
-                     ~subtask_of:(Context.get_task_id __context) tsk_name
-                     (fun __context -> thread_exn_wrapper tsk_name tsk_fct
+                   Server_helpers.exec_with_subtask ~__context tsk_name
+                     (fun ~__context -> thread_exn_wrapper tsk_name tsk_fct
                    )
                  )
                  tsk_fct
               )
           ) else (
             debug "task [%s]" tsk_name ;
-            Server_helpers.exec_with_new_task tsk_name
-              ~subtask_of:(Context.get_task_id __context) (fun __context ->
-                tsk_fct ()
+            Server_helpers.exec_with_subtask ~__context tsk_name
+              (fun ~__context -> tsk_fct ()
             )
           )
         )

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -180,9 +180,10 @@ let pingable ip () =
 
 let queryable ~__context transport () =
   let open Xmlrpc_client in
+  let tracing = Context.set_client_span __context in
+  let http = xmlrpc ~version:"1.0" ~tracing "/" in
   let rpc =
-    XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_smapiv2" ~transport
-      ~http:(xmlrpc ~version:"1.0" "/")
+    XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_smapiv2" ~transport ~http
   in
   let listMethods = Rpc.call "system.listMethods" [] in
   try

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -262,7 +262,7 @@ val calculate_pifs_required_at_start_of_day :
     interfaces required by storage NICs etc. (these interface are not filtered out at the moment).
 *)
 
-val start_of_day_best_effort_bring_up : unit -> unit
+val start_of_day_best_effort_bring_up : __context:Context.t -> unit -> unit
 (** Attempt to bring up (plug) the required PIFs when the host starts up.
  *  Uses {!calculate_pifs_required_at_start_of_day}. *)
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3282,7 +3282,8 @@ let perform ~local_fn ~__context ~host op =
     let open Xmlrpc_client in
     let verify_cert = Some Stunnel.pool (* verify! *) in
     let task_id = Option.map Ref.string_of task_opt in
-    let http = xmlrpc ?task_id ~version:"1.0" "/" in
+    let tracing = Context.set_client_span __context in
+    let http = xmlrpc ?task_id ~version:"1.0" ~tracing "/" in
     let port = !Constants.https_port in
     let transport = SSL (SSL.make ~verify_cert ?task_id (), hostname, port) in
     XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml


### PR DESCRIPTION
Following the Library and Management API, Instrumenting Xapi to create and finish spans while completing tasks. Xapi will also send a `traceparent` header as defined by the W3C context specification. This will allow for spans to be tracked across multiple hosts.

The start up sequence has also be reorganised to link startup tasks into one trace to better identify performance issues surrounding at (Only after networks are up)

This code will include the pr-2 content so only focus on the last 4 commits