### PR TITLE
CA-377169 block VM.checkpoint of running VM with VTPM

### DIFF
--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -73,7 +73,15 @@ let compare_snapid_chunks s1 s2 =
 let checkpoint ~__context ~vm ~new_name =
   Xapi_vmss.show_task_in_xencenter ~__context ~vm ;
   let power_state = Db.VM.get_power_state ~__context ~self:vm in
+  let vtpms = Db.VM.get_VTPMs ~__context ~self:vm in
   let snapshot_info = ref [] in
+  ( match (power_state, vtpms) with
+  | `Running, _ :: _ ->
+      let message = "VM.checkpoint of running VM with VTPM" in
+      Helpers.maybe_raise_vtpm_unimplemented __FUNCTION__ message
+  | _ ->
+      ()
+  ) ;
   (* live-suspend the VM if the VM is running *)
   ( if power_state = `Running then
       try

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -58,7 +58,7 @@ structural-equality () {
 }
 
 vtpm-unimplemented () {
-  N=6
+  N=7
   VTPM=$(git grep -r --count 'maybe_raise_vtpm_unimplemented' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$VTPM" -eq "$N" ]; then
     echo "OK found $VTPM usages of vtpm unimplemented errors"


### PR DESCRIPTION
The current VTPM implementation saves the TPM content only when the VM halts. THus, taking a checkpoint while the VM is running would not save the corrent TPM state. Block this.