### PR TITLE
Minimal swtpm REST API

### DIFF
--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -37,11 +37,12 @@ let get_static_device reason =
   R.debug "Found %d VDIs matching [%s]" (List.length vdis) reason ;
   match vdis with [] -> None | hd :: _ -> hd.Static_vdis_list.path
 
-(* Make sure we have plenty of room for the database *)
-let minimum_vdi_size =
+let mib megabytes =
   let ( ** ) = Int64.mul in
-  let mib = 1024L ** 1024L in
-  256L ** mib
+  Int64.of_int megabytes ** 1024L ** 1024L
+
+(* Make sure we have plenty of room for the database *)
+let minimum_vdi_size, recommended_vdi_size = (mib 256, mib 4096)
 
 let redo_log_sm_config = [("type", "raw")]
 

--- a/ocaml/database/redo_log.mli
+++ b/ocaml/database/redo_log.mli
@@ -21,6 +21,9 @@ val get_static_device : string -> string option
 val minimum_vdi_size : int64
 (** Minimum size for redo log VDI *)
 
+val recommended_vdi_size : int64
+(** Recommended size for redo log VDI *)
+
 val redo_log_sm_config : (string * string) list
 (** SM config for redo log VDI *)
 

--- a/ocaml/xapi-guard/lib/varstored_interface.ml
+++ b/ocaml/xapi-guard/lib/varstored_interface.ml
@@ -27,8 +27,6 @@ type nvram = (string * string) list [@@deriving rpcty]
 
 let originator = "varstored-guard"
 
-let version = "0.1"
-
 type session = [`session] Ref.t
 
 type rpc = call -> response Lwt.t

--- a/ocaml/xapi-guard/lib/varstored_interface.ml
+++ b/ocaml/xapi-guard/lib/varstored_interface.ml
@@ -99,6 +99,95 @@ let serve_forever_lwt_callback rpc_fn path _ req body =
       in
       Cohttp_lwt_unix.Server.respond_string ~status:`Method_not_allowed ~body ()
 
+(* The TPM has 3 kinds of states *)
+type state = {
+    permall: string  (** permanent storage *)
+  ; savestate: string  (** for ACPI S3 *)
+  ; volatilestate: string  (** for snapshot/migration/etc. *)
+}
+
+let split_char = ' '
+
+let join_string = String.make 1 split_char
+
+let deserialize t =
+  match String.split_on_char split_char t with
+  | [permall] ->
+      (* backwards compat with reading tpm2-00.permall *)
+      {permall; savestate= ""; volatilestate= ""}
+  | [permall; savestate; volatilestate] ->
+      {permall; savestate; volatilestate}
+  | splits ->
+      Fmt.failwith "Invalid state: too many splits %d" (List.length splits)
+
+let serialize t =
+  (* it is assumed that swtpm has already base64 encoded this *)
+  String.concat join_string [t.permall; t.savestate; t.volatilestate]
+
+let lookup_key key t =
+  match key with
+  | "/tpm2-00.permall" ->
+      t.permall
+  | "/tpm2-00.savestate" ->
+      t.savestate
+  | "/tpm2-00.volatilestate" ->
+      t.volatilestate
+  | s ->
+      Fmt.invalid_arg "Unknown TPM state key: %s" s
+
+let update_key key state t =
+  if String.contains state split_char then
+    Fmt.invalid_arg
+      "State to be stored (%d bytes) contained forbidden separator: %c"
+      (String.length state) split_char ;
+  match key with
+  | "/tpm2-00.permall" ->
+      {t with permall= state}
+  | "/tpm2-00.savestate" ->
+      {t with savestate= state}
+  | "/tpm2-00.volatilestate" ->
+      {t with volatilestate= state}
+  | s ->
+      Fmt.invalid_arg "Unknown TPM state key: %s" s
+
+let empty = ""
+
+let serve_forever_lwt_callback_vtpm ~cache mutex vtpm _path _ req body =
+  let uri = Cohttp.Request.uri req in
+  (* in case the connection is interrupted/etc. we may still have pending operations,
+     so use a per vTPM mutex to ensure we really only have 1 pending operation at a time for a vTPM
+  *)
+  Lwt_mutex.with_lock mutex @@ fun () ->
+  (* TODO: some logging *)
+  match (Cohttp.Request.meth req, Uri.path uri) with
+  | `GET, key when key <> "/" ->
+      let* contents = with_xapi ~cache @@ VTPM.get_contents ~self:vtpm in
+      let body = contents |> deserialize |> lookup_key key in
+      let headers =
+        Cohttp.Header.of_list [("Content-Type", "application/octet-stream")]
+      in
+      Cohttp_lwt_unix.Server.respond_string ~headers ~status:`OK ~body ()
+  | `PUT, key when key <> "/" ->
+      let* body = Cohttp_lwt.Body.to_string body in
+      let* contents = with_xapi ~cache @@ VTPM.get_contents ~self:vtpm in
+      let contents =
+        contents |> deserialize |> update_key key body |> serialize
+      in
+      let* () = with_xapi ~cache @@ VTPM.set_contents ~self:vtpm ~contents in
+      Cohttp_lwt_unix.Server.respond ~status:`No_content
+        ~body:Cohttp_lwt.Body.empty ()
+  | `DELETE, key when key <> "/" ->
+      let* contents = with_xapi ~cache @@ VTPM.get_contents ~self:vtpm in
+      let contents =
+        contents |> deserialize |> update_key key empty |> serialize
+      in
+      let* () = with_xapi ~cache @@ VTPM.set_contents ~self:vtpm ~contents in
+      Cohttp_lwt_unix.Server.respond ~status:`No_content
+        ~body:Cohttp_lwt.Body.empty ()
+  | _, _ ->
+      let body = "Not allowed" in
+      Cohttp_lwt_unix.Server.respond_string ~status:`Method_not_allowed ~body ()
+
 (* Create a restricted RPC function and socket for a specific VM *)
 let make_server_rpcfn ~cache path vm_uuid =
   let module Server =
@@ -132,4 +221,13 @@ let make_server_rpcfn ~cache path vm_uuid =
   Server.session_logout dummy_logout ;
   Server.get_by_uuid get_by_uuid ;
   serve_forever_lwt_callback (Rpc_lwt.server Server.implementation) path
+  |> serve_forever_lwt path
+
+(* TODO: spawn this through the varstore interface *)
+let make_server_vtpm_rest ~cache path vtpm_uuid =
+  let* vtpm =
+    with_xapi ~cache @@ VTPM.get_by_uuid ~uuid:(Uuidm.to_string vtpm_uuid)
+  in
+  let mutex = Lwt_mutex.create () in
+  serve_forever_lwt_callback_vtpm ~cache mutex vtpm path
   |> serve_forever_lwt path

--- a/ocaml/xapi-guard/lib/varstored_interface.ml
+++ b/ocaml/xapi-guard/lib/varstored_interface.ml
@@ -53,36 +53,11 @@ let () =
 let with_xapi ~cache f =
   Lwt_unix.with_timeout 120. (fun () -> SessionCache.with_session cache f)
 
-let serve_forever_lwt rpc_fn path =
+let serve_forever_lwt path callback =
   let conn_closed _ = () in
   let on_exn e =
     log_backtrace () ;
     warn "Exception: %s" (Printexc.to_string e)
-  in
-  let callback _ req body =
-    let uri = Cohttp.Request.uri req in
-    match (Cohttp.Request.meth req, Uri.path uri) with
-    | `POST, _ ->
-        let* body = Cohttp_lwt.Body.to_string body in
-        let* response =
-          Dorpc.wrap_rpc err (fun () ->
-              let call = Xmlrpc.call_of_string body in
-              (* Do not log the request, it will contain NVRAM *)
-              D.debug "Received request on %s, method %s" path call.Rpc.name ;
-              rpc_fn call
-          )
-        in
-        let body = response |> Xmlrpc.string_of_response in
-        Cohttp_lwt_unix.Server.respond_string ~status:`OK ~body ()
-    | _, _ ->
-        let body =
-          "Not allowed"
-          |> Rpc.rpc_of_string
-          |> Rpc.failure
-          |> Xmlrpc.string_of_response
-        in
-        Cohttp_lwt_unix.Server.respond_string ~status:`Method_not_allowed ~body
-          ()
   in
   let stop, do_stop = Lwt.task () in
   let server = Cohttp_lwt_unix.Server.make ~callback ~conn_closed () in
@@ -99,6 +74,30 @@ let serve_forever_lwt rpc_fn path =
   in
   Lwt_switch.add_hook (Some shutdown) cleanup ;
   Lwt.return cleanup
+
+let serve_forever_lwt_callback rpc_fn path _ req body =
+  let uri = Cohttp.Request.uri req in
+  match (Cohttp.Request.meth req, Uri.path uri) with
+  | `POST, _ ->
+      let* body = Cohttp_lwt.Body.to_string body in
+      let* response =
+        Dorpc.wrap_rpc err (fun () ->
+            let call = Xmlrpc.call_of_string body in
+            (* Do not log the request, it will contain NVRAM *)
+            D.debug "Received request on %s, method %s" path call.Rpc.name ;
+            rpc_fn call
+        )
+      in
+      let body = response |> Xmlrpc.string_of_response in
+      Cohttp_lwt_unix.Server.respond_string ~status:`OK ~body ()
+  | _, _ ->
+      let body =
+        "Not allowed"
+        |> Rpc.rpc_of_string
+        |> Rpc.failure
+        |> Xmlrpc.string_of_response
+      in
+      Cohttp_lwt_unix.Server.respond_string ~status:`Method_not_allowed ~body ()
 
 (* Create a restricted RPC function and socket for a specific VM *)
 let make_server_rpcfn ~cache path vm_uuid =
@@ -132,4 +131,5 @@ let make_server_rpcfn ~cache path vm_uuid =
   Server.session_login dummy_login ;
   Server.session_logout dummy_logout ;
   Server.get_by_uuid get_by_uuid ;
-  serve_forever_lwt (Rpc_lwt.server Server.implementation) path
+  serve_forever_lwt_callback (Rpc_lwt.server Server.implementation) path
+  |> serve_forever_lwt path

--- a/ocaml/xapi-guard/src/dune
+++ b/ocaml/xapi-guard/src/dune
@@ -1,6 +1,7 @@
 (executable
  (name main)
  (libraries
+   astring
    cmdliner
    dune-build-info
    lwt

--- a/ocaml/xapi-guard/src/main.ml
+++ b/ocaml/xapi-guard/src/main.ml
@@ -211,6 +211,7 @@ let make_message_switch_server () =
 let main log_level =
   Debug.set_level log_level ;
   Debug.set_facility Syslog.Local5 ;
+  Debug.init_logs () ;
 
   let old_hook = !Lwt.async_exception_hook in
   (Lwt.async_exception_hook :=

--- a/ocaml/xapi-guard/src/main.ml
+++ b/ocaml/xapi-guard/src/main.ml
@@ -21,7 +21,9 @@ module D = Debug.Make (struct let name = "varstored-guard" end)
 
 let ret v = Lwt.bind v Lwt.return_ok |> Rpc_lwt.T.put
 
-let sockets = Hashtbl.create 127
+type ty = Varstored | Swtpm [@@deriving rpcty]
+
+let ty_to_string = function Varstored -> "Varstored" | Swtpm -> "Swtpm"
 
 let log_fds () =
   let count stream = Lwt_stream.fold (fun _ n -> n + 1) stream 0 in
@@ -38,6 +40,7 @@ module Persistent = struct
       vm_uuid: Varstore_privileged_interface.Uuidm.t
     ; path: string
     ; gid: int
+    ; typ: ty
   }
   [@@deriving rpcty]
 
@@ -62,12 +65,17 @@ module Persistent = struct
       Lwt.return_nil
 end
 
+let sockets = Hashtbl.create 127
+
 let recover_path = "/run/nonpersistent/varstored-guard-active.json"
 
 let store_args sockets =
-  Hashtbl.fold
-    (fun path (_, (vm_uuid, gid)) acc -> {Persistent.vm_uuid; path; gid} :: acc)
-    sockets []
+  sockets
+  |> Hashtbl.to_seq
+  |> Seq.map (fun (path, (_, (vm_uuid, gid, typ))) ->
+         Persistent.{vm_uuid; path; gid; typ}
+     )
+  |> List.of_seq
   |> Persistent.saveto recover_path
 
 let safe_unlink path =
@@ -90,23 +98,31 @@ let () =
       Xen_api_lwt_unix.SessionCache.destroy cache
   )
 
-let listen_for_vm {Persistent.vm_uuid; path; gid} =
+let listen_for_vm {Persistent.vm_uuid; path; gid; typ} =
+  let make_server =
+    match typ with
+    | Varstored ->
+        make_server_varstored
+    | Swtpm ->
+        make_server_vtpm_rest
+  in
   let vm_uuid_str = Uuidm.to_string vm_uuid in
-  D.debug "resume: listening on socket %s for VM %s" path vm_uuid_str ;
+  D.debug "%s: listening for %s on socket %s for VM %s" __FUNCTION__
+    (ty_to_string typ) path vm_uuid_str ;
   let* () = safe_unlink path in
-  let* stop_server = make_server_rpcfn ~cache path vm_uuid_str in
+  let* stop_server = make_server ~cache path vm_uuid_str in
   let* () = log_fds () in
-  Hashtbl.add sockets path (stop_server, (vm_uuid, gid)) ;
+  Hashtbl.add sockets path (stop_server, (vm_uuid, gid, typ)) ;
   let* () = Lwt_unix.chmod path 0o660 in
   Lwt_unix.chown path 0 gid
 
 let resume () =
   let* vms = Persistent.loadfrom recover_path in
   let+ () = Lwt_list.iter_p listen_for_vm vms in
-  D.debug "resume completed"
+  D.debug "%s: completed" __FUNCTION__
 
 (* caller here is trusted (xenopsd through message-switch *)
-let depriv_create dbg vm_uuid gid path =
+let depriv_varstored_create dbg vm_uuid gid path =
   if Hashtbl.mem sockets path then
     Lwt.return_error
       (Varstore_privileged_interface.InternalError
@@ -118,11 +134,11 @@ let depriv_create dbg vm_uuid gid path =
     @@
     ( D.debug "[%s] creating deprivileged socket at %s, owned by group %d" dbg
         path gid ;
-      let* () = listen_for_vm {Persistent.path; vm_uuid; gid} in
+      let* () = listen_for_vm {Persistent.path; vm_uuid; gid; typ= Varstored} in
       store_args sockets
     )
 
-let depriv_destroy dbg gid path =
+let depriv_varstored_destroy dbg gid path =
   D.debug "[%s] stopping server for gid %d and path %s" dbg gid path ;
   ret
   @@
@@ -139,6 +155,48 @@ let depriv_destroy dbg gid path =
       let* () = Lwt.finalize stop_server finally in
       D.debug "[%s] stopped server for gid %d and removed socket" dbg gid ;
       Lwt.return_unit
+
+let depriv_swtpm_create dbg vm_uuid gid path =
+  if Hashtbl.mem sockets path then
+    Lwt.return_error
+      (Varstore_privileged_interface.InternalError
+         (Printf.sprintf "Path %s is already in use" path)
+      )
+    |> Rpc_lwt.T.put
+  else
+    ret
+    @@
+    ( D.debug "[%s] creating deprivileged socket at %s, owned by group %d" dbg
+        path gid ;
+      let* () = listen_for_vm {Persistent.path; vm_uuid; gid; typ= Swtpm} in
+      store_args sockets
+    )
+
+let depriv_swtpm_destroy dbg gid path =
+  D.debug "[%s] stopping server for gid %d and path %s" dbg gid path ;
+  ret
+  @@
+  match Hashtbl.find_opt sockets path with
+  | None ->
+      D.warn "[%s] asked to swtpm stop server for path %s, but it doesn't exist"
+        dbg path ;
+      Lwt.return_unit
+  | Some (stop_server, (_, _, Swtpm)) ->
+      let finally () =
+        let+ () = safe_unlink path in
+        Hashtbl.remove sockets path
+      in
+      let* () = Lwt.finalize stop_server finally in
+      D.debug "[%s] stopped swtpm server for gid %d and removed socket" dbg gid ;
+      Lwt.return_unit
+  | Some _ ->
+      D.warn
+        "[%s] asked to stop swtpm server for path %s, but it's not an swtpm \
+         server"
+        dbg path ;
+      Lwt.return_unit
+
+(* TODO: these 2 APIs need to be updated to go through the generic interface *)
 
 let vtpm_set_contents dbg vtpm_uuid contents =
   let open Xen_api_lwt_unix in
@@ -164,8 +222,10 @@ let vtpm_get_contents _dbg vtpm_uuid =
 let rpc_fn =
   let module Server = Varstore_privileged_interface.RPC_API (Rpc_lwt.GenServer ()) in
   (* bind APIs *)
-  Server.create depriv_create ;
-  Server.destroy depriv_destroy ;
+  Server.varstore_create depriv_varstored_create ;
+  Server.varstore_destroy depriv_varstored_destroy ;
+  Server.vtpm_create depriv_swtpm_create ;
+  Server.vtpm_destroy depriv_swtpm_destroy ;
   Server.vtpm_set_contents vtpm_set_contents ;
   Server.vtpm_get_contents vtpm_get_contents ;
   Rpc_lwt.server Server.implementation

--- a/ocaml/xapi-guard/src/main.ml
+++ b/ocaml/xapi-guard/src/main.ml
@@ -80,8 +80,7 @@ let safe_unlink path =
 let cache =
   Xen_api_lwt_unix.(
     SessionCache.create_uri ~switch:Varstored_interface.shutdown
-      ~target:uri_local_json ~uname:"root" ~pwd:""
-      ~version:Varstored_interface.version
+      ~target:uri_local_json ~uname:"root" ~pwd:"" ~version:Xapi_version.version
       ~originator:Varstored_interface.originator ()
   )
 

--- a/ocaml/xapi-guard/test/xapi_guard_test.ml
+++ b/ocaml/xapi-guard/test/xapi_guard_test.ml
@@ -88,8 +88,8 @@ let with_rpc f switch () =
     (fun () ->
       (* not strictly necessary to login/logout here - since we only get dummy sessions *)
       let* session_id =
-        Session.login_with_password ~rpc ~uname:"root" ~pwd:"" ~version:"0.0"
-          ~originator:"test"
+        Session.login_with_password ~rpc ~uname:"root" ~pwd:""
+          ~version:Xapi_version.version ~originator:"test"
       in
       let logout () = Session.logout ~rpc ~session_id in
       Lwt.finalize logout @@ f ~rpc ~session_id

--- a/ocaml/xapi-guard/test/xapi_guard_test.ml
+++ b/ocaml/xapi-guard/test/xapi_guard_test.ml
@@ -78,9 +78,9 @@ let with_rpc f switch () =
   in
   (Lwt_switch.add_hook (Some switch) @@ fun () -> SessionCache.destroy cache) ;
   let path = Filename.concat tmp "socket" in
-  (* Create an internal server on 'path', the socket that varstored/swtpm would connect to *)
-  let* stop_server = make_server_rpcfn ~cache path vm_uuid in
-  (* rpc simulates what varstored/swtpm would do *)
+  (* Create an internal server on 'path', the socket that varstored would connect to *)
+  let* stop_server = make_server_varstored ~cache path vm_uuid in
+  (* rpc simulates what varstored would do *)
   let uri = Uri.make ~scheme:"file" ~path () |> Uri.to_string in
   D.debug "Connecting to %s" uri ;
   let rpc = Xen_api_lwt_unix.make uri in

--- a/ocaml/xapi-idl/varstore/privileged/dune
+++ b/ocaml/xapi-idl/varstore/privileged/dune
@@ -1,7 +1,7 @@
 (library
  (name xapi_idl_varstore_privileged)
  (public_name xapi-idl.varstore.privileged)
- (modules (:standard \ varstore_privileged_cli))
+ (modules (:standard \ xapiguard_cli))
  (libraries
    result
    rpclib.core
@@ -13,9 +13,10 @@
  (preprocess (pps ppx_deriving_rpc)))
 
 (executable
- (name varstore_privileged_cli)
+ (public_name xapiguard_cli)
  (modes exe)
- (modules varstore_privileged_cli)
+ (modules xapiguard_cli)
+ (package varstored-guard)
  (libraries
    cmdliner
    dune-build-info
@@ -28,6 +29,6 @@
 
 (rule
  (alias runtest)
- (deps varstore_privileged_cli.exe)
+ (deps xapiguard_cli.exe)
  (package xapi-idl)
  (action (run %{deps} --help=plain)))

--- a/ocaml/xapi-idl/varstore/privileged/varstore_privileged_interface.ml
+++ b/ocaml/xapi-idl/varstore/privileged/varstore_privileged_interface.ml
@@ -48,10 +48,7 @@ module RPC_API (R : RPC) = struct
         name= "Depriv"
       ; namespace= None
       ; description=
-          [
-            "Interface for creating a deprivileged XAPI socket for a specific \
-             VM."
-          ]
+          ["Interface for creating deprivileged sockets for a specific VM."]
       ; version= (1, 0, 0)
       }
 
@@ -75,18 +72,32 @@ module RPC_API (R : RPC) = struct
   (** each VM gets its own group id = qemu_base + domid *)
   let gid_p = Param.mk ~name:"gid" ~description:["socket group id"] Types.int
 
-  let create =
+  let varstore_create =
     let vm_uuid_p = Param.mk ~name:"vm_uuid" ~description:["VM UUID"] vm_uuid in
-    declare "create"
+    declare "varstore_create"
       [
-        "Create a deprivileged socket that only accepts API calls for a"
+        "Create a deprivileged varstore socket that only accepts API calls for a"
       ; "specific VM. The socket will be writable only to the specified group."
       ]
       (debug_info_p @-> vm_uuid_p @-> gid_p @-> path_p @-> returning unit_p err)
 
-  let destroy =
-    declare "destroy"
-      ["Stop listening on sockets for the specified group"]
+  let varstore_destroy =
+    declare "varstore_destroy"
+      ["Stop listening on varstore sockets for the specified group"]
+      (debug_info_p @-> gid_p @-> path_p @-> returning unit_p err)
+
+  let vtpm_create =
+    let vm_uuid_p = Param.mk ~name:"vm_uuid" ~description:["VM UUID"] vm_uuid in
+    declare "vtpm_create"
+      [
+        "Create a deprivileged vtpm socket that only accepts API calls for a"
+      ; "specific VM. The socket will be writable only to the specified group."
+      ]
+      (debug_info_p @-> vm_uuid_p @-> gid_p @-> path_p @-> returning unit_p err)
+
+  let vtpm_destroy =
+    declare "vtpm_destroy"
+      ["Stop listening on vtpm sockets for the specified group"]
       (debug_info_p @-> gid_p @-> path_p @-> returning unit_p err)
 
   let vtpm_uuid_p =

--- a/ocaml/xapi-idl/varstore/privileged/xapiguard_cli.ml
+++ b/ocaml/xapi-idl/varstore/privileged/xapiguard_cli.ml
@@ -20,7 +20,7 @@ let doc =
   String.concat " "
     [
       "A CLI for the deprivileged socket spawning API."
-    ; "This allows scripting of the varstored deprivileging daemon"
+    ; "This allows scripting of the xapi-guard deprivileging daemon"
     ; "for testing and debugging. This tool is not intended to be used"
     ; "as an end user tool"
     ]
@@ -29,7 +29,7 @@ let cmdline_gen () =
   List.map (fun t -> t Varstore_privileged_client.rpc) (Cmds.implementation ())
 
 let cli =
-  Xcp_service.cli ~name:"varstore_cli" ~doc ~version:Cmds.description.version
+  Xcp_service.cli ~name:"xapiguard_cli" ~doc ~version:Cmds.description.version
     ~cmdline_gen
 
 let () = Xcp_service.eval_cmdline cli

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2853,7 +2853,7 @@ let create_redo_log_vdi ~__context ~sr =
       Client.VDI.create ~rpc ~session_id ~name_label:"Metadata redo-log"
         ~name_description:
           "Used when HA is disabled, while extra security is still desired"
-        ~sR:sr ~virtual_size:Redo_log.minimum_vdi_size ~_type:`redo_log
+        ~sR:sr ~virtual_size:Redo_log.recommended_vdi_size ~_type:`redo_log
         ~sharable:true ~read_only:false ~other_config:[] ~xenstore_data:[]
         ~sm_config:Redo_log.redo_log_sm_config ~tags:[]
   )

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -942,7 +942,7 @@ let find_or_create_metadata_vdi ~__context ~sr =
         Helpers.call_api_functions ~__context (fun rpc session_id ->
             Client.VDI.create ~rpc ~session_id ~name_label:"Metadata for DR"
               ~name_description:"Used for disaster recovery" ~sR:sr
-              ~virtual_size:Redo_log.minimum_vdi_size ~_type:`metadata
+              ~virtual_size:Redo_log.recommended_vdi_size ~_type:`metadata
               ~sharable:false ~read_only:false ~other_config:[]
               ~xenstore_data:[] ~sm_config:Redo_log.redo_log_sm_config ~tags:[]
         )

--- a/ocaml/xapi/xha_metadata_vdi.ml
+++ b/ocaml/xapi/xha_metadata_vdi.ml
@@ -24,8 +24,8 @@ let create ~__context ~sr =
   Helpers.call_api_functions ~__context (fun rpc session_id ->
       Client.VDI.create ~rpc ~session_id ~name_label:"Metadata for HA"
         ~name_description:"Used for master failover" ~sR:sr
-        ~virtual_size:Redo_log.minimum_vdi_size ~_type:`redo_log ~sharable:true
-        ~read_only:false ~other_config:[] ~xenstore_data:[]
+        ~virtual_size:Redo_log.recommended_vdi_size ~_type:`redo_log
+        ~sharable:true ~read_only:false ~other_config:[] ~xenstore_data:[]
         ~sm_config:Redo_log.redo_log_sm_config ~tags:[]
   )
 

--- a/ocaml/xenopsd/lib/xenops_sandbox.ml
+++ b/ocaml/xenopsd/lib/xenops_sandbox.ml
@@ -202,10 +202,10 @@ module Varstored : GUARD = struct
   let base_directory = "/var/run/xen"
 
   let create dbg ~vm_uuid ~domid ~path =
-    Varstore_privileged_client.Client.create dbg vm_uuid domid path
+    Varstore_privileged_client.Client.varstore_create dbg vm_uuid domid path
 
   let destroy dbg ~domid ~path =
-    Varstore_privileged_client.Client.destroy dbg domid path
+    Varstore_privileged_client.Client.varstore_destroy dbg domid path
 end
 
 module Swtpm : GUARD = struct
@@ -216,10 +216,10 @@ module Swtpm : GUARD = struct
   let base_directory = "/var/lib/xcp/run"
 
   let create dbg ~vm_uuid ~domid ~path =
-    Varstore_privileged_client.Client.create dbg vm_uuid domid path
+    Varstore_privileged_client.Client.vtpm_create dbg vm_uuid domid path
 
   let destroy dbg ~domid ~path =
-    Varstore_privileged_client.Client.destroy dbg domid path
+    Varstore_privileged_client.Client.vtpm_destroy dbg domid path
 end
 
 module Varstore_guard = Guard (Varstored)

--- a/ocaml/xenopsd/lib/xenops_sandbox.mli
+++ b/ocaml/xenopsd/lib/xenops_sandbox.mli
@@ -23,18 +23,26 @@ module Chroot : sig
       the chroot [within] with its owner and group ids and permissions [perm]*)
 
   val of_domid :
-    base:string -> daemon:string -> domid:int -> vm_uuid:string -> t
-  (** [of_domid ~base ~daemon ~domid ~vm_uuid] describes a chroot for specified
+       base:string
+    -> base_uid:(unit -> int)
+    -> base_gid:(unit -> int)
+    -> daemon:string
+    -> domid:int
+    -> vm_uuid:string
+    -> t
+  (** [of_domid ~base ~base_uid ~base_gid ~daemon ~domid ~vm_uuid] describes a chroot for specified
      daemon and domain *)
 
   val create :
        base:string
+    -> base_uid:(unit -> int)
+    -> base_gid:(unit -> int)
     -> daemon:string
     -> domid:int
     -> vm_uuid:string
     -> Path.t list
     -> t
-  (** [create ~base ~daemon ~domid paths] Creates the specified chroot with
+  (** [create ~base ~base_uid ~base_gid ~daemon ~domid paths] Creates the specified chroot with
       appropriate permissions on directory [base], and ensures that all [paths]
       are owned by the chrooted daemon and rw- *)
 

--- a/ocaml/xenopsd/scripts/swtpm-wrapper
+++ b/ocaml/xenopsd/scripts/swtpm-wrapper
@@ -67,6 +67,7 @@ def prepare_exec():
 def make_socket(fname):
 
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    print("Binding socket to %s" % fname)
     sock.bind(fname)
     sock.listen(1)
 
@@ -145,7 +146,7 @@ def main(argv):
             sys.exit("Unsupported scheme for TPM initialization: %s" % tpm_state_scheme)
         print('Initial manufacture')
         tpm_exe = '/usr/bin/swtpm_setup'
-        tpm_args = ["swtpm_setup", "--tpm2", "--tpm-state", tpm_state, "--createek", "--create-ek-cert", "--create-platform-cert", "--lock-nvram", "--not-overwrite"]
+        tpm_args = ["swtpm_setup", "--tpm2", "--tpm-state", tpm_dir, "--createek", "--create-ek-cert", "--create-platform-cert", "--lock-nvram", "--not-overwrite"]
         print('Running %s' % tpm_args)
         prepare_exec()
         os.execve(tpm_exe, tpm_args, tpm_env)

--- a/ocaml/xenopsd/scripts/swtpm-wrapper
+++ b/ocaml/xenopsd/scripts/swtpm-wrapper
@@ -95,16 +95,17 @@ def check_state_needs_init(fname):
 def main(argv):
     print("Arguments: %s" % " ".join(argv[1:]))
 
-    if len(argv) < 4:
+    if len(argv) < 5:
         sys.exit("Not enough arguments.")
 
     domid = int(argv[1])
     tpm_dir = argv[2]
     tpm_state = argv[3]
+    needs_init = argv[4] == "true"
     tpm_path = tpm_dir
     depriv = True
 
-    for arg in argv[4:]:
+    for arg in argv[5:]:
         if arg == "--priv":
             depriv = False
         else:
@@ -114,26 +115,34 @@ def main(argv):
     tpm_state_scheme = parsed.scheme
     tpm_state_file = parsed.path.lstrip('/')
     tpm_file = os.path.join(tpm_dir, tpm_state_file)
+    tpm_args = []
+
+    # ensure that paths work regardless of whether we are in the chroot or not:
+    # we'll only use relative paths
+    os.chdir(tpm_dir)
 
     if (tpm_state_scheme == "dir"):
-        tpm_uri = tpm_dir
+        tpm_state_file = "tpm2-00.permall"
+        tpm_file = os.path.join(tpm_dir, tpm_state_file)
+        pass
     elif (tpm_state_scheme == "file"):
-        tpm_uri = tpm_state_scheme + "://" + tpm_file
+        pass
     else:
         sys.exit("Unknown state scheme  %s\n" % tpm_state_scheme)
 
     tpm_env = dict(os.environ)
     tpm_env["LD_LIBRARY_PATH"] = "/usr/lib:"
 
-    if check_state_needs_init(tpm_file):
-        # Initial manufacture
+    if needs_init or check_state_needs_init(tpm_state_file):
+        print('Initial manufacture')
         tpm_exe = '/usr/bin/swtpm_setup'
-        tpm_args = ["swtpm_setup", "--tpm2", "--tpm-state", tpm_uri, "--createek", "--create-ek-cert", "--create-platform-cert", "--lock-nvram", "--not-overwrite"]
-        subprocess.check_call(tpm_args, executable=tpm_exe, env=tpm_env)
+        tpm_args = ["swtpm_setup", "--tpm2", "--tpm-state", tpm_state, "--createek", "--create-ek-cert", "--create-platform-cert", "--lock-nvram", "--not-overwrite"]
+        print('Running %s' % tpm_args)
+        prepare_exec()
+        os.execve(tpm_exe, tpm_args, tpm_env)
 
     tpm_exe = '/usr/bin/swtpm'
     uid = pwd.getpwnam('swtpm_base').pw_uid + domid
-    tpm_args = []
 
     swtpm_pid_full = os.path.join(tpm_dir, "swtpm-%d.pid" % domid)
     open(swtpm_pid_full, 'wb').close()
@@ -166,7 +175,6 @@ def main(argv):
             return
 
         tpm_path = '/'
-        tpm_uri = tpm_state
 
     swtpm_sock = os.path.join(tpm_dir, "swtpm-sock")
     swtpm_pid = os.path.join(tpm_path, "swtpm-%d.pid" % domid)
@@ -176,7 +184,7 @@ def main(argv):
     if (tpm_state_scheme == "dir"):
         state_param = "dir=%s" % tpm_path
     else:
-        state_param = "backend-uri=%s" % tpm_uri
+        state_param = "backend-uri=%s" % tpm_state
 
     tpm_args = ["swtpm-%d" % domid, "socket",
                "--tpm2",

--- a/ocaml/xenopsd/scripts/swtpm-wrapper
+++ b/ocaml/xenopsd/scripts/swtpm-wrapper
@@ -73,6 +73,9 @@ def make_socket(fname):
     return sock
 
 def check_state_needs_init(fname):
+    if fname is None:
+        return False
+    print("Checking TPM state %s" % fname)
 
     if not os.path.exists(fname):
         return True
@@ -127,6 +130,10 @@ def main(argv):
         pass
     elif (tpm_state_scheme == "file"):
         pass
+    elif (tpm_state_scheme == "http" or tpm_state_scheme == "unix+http"):
+        tpm_state_file = None
+        tpm_args = ["--seccomp","action=none"] # TODO: due to curl syscalls
+        tpm_file = None
     else:
         sys.exit("Unknown state scheme  %s\n" % tpm_state_scheme)
 
@@ -134,6 +141,8 @@ def main(argv):
     tpm_env["LD_LIBRARY_PATH"] = "/usr/lib:"
 
     if needs_init or check_state_needs_init(tpm_state_file):
+        if tpm_file is None:
+            sys.exit("Unsupported scheme for TPM initialization: %s" % tpm_state_scheme)
         print('Initial manufacture')
         tpm_exe = '/usr/bin/swtpm_setup'
         tpm_args = ["swtpm_setup", "--tpm2", "--tpm-state", tpm_state, "--createek", "--create-ek-cert", "--create-platform-cert", "--lock-nvram", "--not-overwrite"]
@@ -162,7 +171,8 @@ def main(argv):
 
             if os.path.exists(os.path.join(tpm_dir, ".lock")):
                 os.chown(os.path.join(tpm_dir, ".lock"), uid, uid)
-            os.chown(tpm_file, uid, uid)
+            if tpm_file:
+                os.chown(tpm_file, uid, uid)
 
             if (tpm_state_scheme != "file"):
                 os.chown(tpm_dir, uid, uid)

--- a/ocaml/xenopsd/scripts/swtpm-wrapper
+++ b/ocaml/xenopsd/scripts/swtpm-wrapper
@@ -186,21 +186,12 @@ def main(argv):
                "--pid", "file=%s" % swtpm_pid,
                "-t"] + tpm_args
 
-    swtpm = subprocess.Popen(tpm_args,executable=tpm_exe, preexec_fn=prepare_exec(),
-                             pass_fds=(sock.fileno(),), env=tpm_env,
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
     print("Exec: %s %s" % (tpm_exe, " ".join(tpm_args)))
-
-    sys.stdout.flush()
-    sys.stderr.flush()
-    sock.close()
-
-    # Redirect output from SWTPM to logger
-    os.dup2(swtpm.stdout.fileno(), 0)
-    swtpm.stdout.close()
-
-    os.execvp('logger', ['logger', '-p', 'daemon.info', '-t',
-                         'swtpm-%d[%d]' % (domid, swtpm.pid)])
+    # by default sockets are CLOEXEC
+    os.set_inheritable(sock.fileno(), True)
+    prepare_exec()
+    os.execve(tpm_exe, tpm_args, tpm_env)
 
 if __name__ == '__main__':
     raise SystemExit(main(sys.argv))

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -3855,22 +3855,21 @@ module Dm = struct
 
   let suspend_vtpm (task : Xenops_task.task_handle) ~xs domid ~vtpm =
     debug "Called Dm.suspend_vtpm (domid=%d)" domid ;
-    let vm_uuid = Uuidx.to_string (Xenops_helpers.uuid_of_domid ~xs domid) in
     let dbg = Xenops_task.get_dbg task in
     Option.map
       (fun (Xenops_interface.Vm.Vtpm vtpm_uuid) ->
-        Service.Swtpm.suspend dbg ~xs ~domid ~vm_uuid ~vtpm_uuid
+        Service.Swtpm.suspend dbg ~xs ~domid ~vtpm_uuid
       )
       vtpm
     |> Option.to_list
 
-  let restore_vtpm (task : Xenops_task.task_handle) ~xs ~contents ~vtpm domid =
+  let restore_vtpm (task : Xenops_task.task_handle) ~xs:_ ~contents ~vtpm domid
+      =
     debug "Called Dm.restore_vtpm (domid=%d)" domid ;
-    let vm_uuid = Uuidx.to_string (Xenops_helpers.uuid_of_domid ~xs domid) in
     let dbg = Xenops_task.get_dbg task in
     Option.iter
       (fun (Xenops_interface.Vm.Vtpm vtpm_uuid) ->
-        Service.Swtpm.restore dbg ~domid ~vm_uuid ~vtpm_uuid contents
+        Service.Swtpm.restore dbg ~domid ~vtpm_uuid contents
       )
       vtpm
 end

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -3853,20 +3853,26 @@ module Dm = struct
     Unixext.write_string_to_file path efivars ;
     debug "Wrote EFI variables to %s (domid=%d)" path domid
 
-  let suspend_vtpms (_task : Xenops_task.task_handle) ~xs domid ~vm_uuid ~vtpm =
-    debug "Called Dm.suspend_vtpms (domid=%d)" domid ;
+  let suspend_vtpm (task : Xenops_task.task_handle) ~xs domid ~vtpm =
+    debug "Called Dm.suspend_vtpm (domid=%d)" domid ;
+    let vm_uuid = Uuidx.to_string (Xenops_helpers.uuid_of_domid ~xs domid) in
+    let dbg = Xenops_task.get_dbg task in
     Option.map
-      (fun (Xenops_interface.Vm.Vtpm _vtpm_uuid) ->
-        Service.Swtpm.suspend ~xs ~domid ~vm_uuid
+      (fun (Xenops_interface.Vm.Vtpm vtpm_uuid) ->
+        Service.Swtpm.suspend dbg ~xs ~domid ~vm_uuid ~vtpm_uuid
       )
       vtpm
     |> Option.to_list
 
-  let restore_vtpm (_task : Xenops_task.task_handle) ~xs ~contents domid =
-    debug "Called Dm.restore_vtpms (domid=%d)" domid ;
+  let restore_vtpm (task : Xenops_task.task_handle) ~xs ~contents ~vtpm domid =
+    debug "Called Dm.restore_vtpm (domid=%d)" domid ;
     let vm_uuid = Uuidx.to_string (Xenops_helpers.uuid_of_domid ~xs domid) in
-    (* TODO: multiple vTPM support? *)
-    Service.Swtpm.restore ~domid ~vm_uuid contents
+    let dbg = Xenops_task.get_dbg task in
+    Option.iter
+      (fun (Xenops_interface.Vm.Vtpm vtpm_uuid) ->
+        Service.Swtpm.restore dbg ~domid ~vm_uuid ~vtpm_uuid contents
+      )
+      vtpm
 end
 
 (* Dm *)

--- a/ocaml/xenopsd/xc/device.mli
+++ b/ocaml/xenopsd/xc/device.mli
@@ -434,11 +434,10 @@ module Dm : sig
     -> Xenctrl.domid
     -> unit
 
-  val suspend_vtpms :
+  val suspend_vtpm :
        Xenops_task.task_handle
     -> xs:Xenstore.Xs.xsh
     -> Xenctrl.domid
-    -> vm_uuid:string
     -> vtpm:Xenops_interface.Vm.tpm option
     -> string list
 
@@ -446,6 +445,7 @@ module Dm : sig
        Xenops_task.task_handle
     -> xs:Xenstore.Xs.xsh
     -> contents:string
+    -> vtpm:Xenops_interface.Vm.tpm option
     -> Xenctrl.domid
     -> unit
 

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -1271,7 +1271,7 @@ let consume_qemu_record fd limit domid uuid =
 let restore_common (task : Xenops_task.task_handle) ~xc ~xs
     ~(dm : Device.Profile.t) ~domain_type ~store_port ~store_domid:_
     ~console_port ~console_domid:_ ~no_incr_generationid:_ ~vcpus:_ ~extras
-    manager_path domid main_fd vgpu_fd =
+    ~vtpm manager_path domid main_fd vgpu_fd =
   let module DD = Debug.Make (struct let name = "mig64" end) in
   let open DD in
   let uuid = get_uuid ~xc domid in
@@ -1397,7 +1397,7 @@ let restore_common (task : Xenops_task.task_handle) ~xc ~xs
                 debug "Read swtpm record header (domid=%d length=%Ld)" domid len ;
                 let contents = Io.read fd (Io.int_of_int64_exn len) in
                 debug "Read swtpm record contents (domid=%d)" domid ;
-                Device.Dm.restore_vtpm task ~xs ~contents domid ;
+                Device.Dm.restore_vtpm task ~xs ~contents ~vtpm domid ;
                 process_header fd res
             | End_of_image, _ ->
                 debug "Read suspend image footer" ;
@@ -1531,7 +1531,7 @@ let restore_common (task : Xenops_task.task_handle) ~xc ~xs
 
 let restore (task : Xenops_task.task_handle) ~xc ~xs ~dm ~store_domid
     ~console_domid ~no_incr_generationid ~timeoffset ~extras info ~manager_path
-    domid fd vgpu_fd =
+    ~vtpm domid fd vgpu_fd =
   let static_max_kib = info.memory_max in
   let target_kib = info.memory_target in
   let vcpus = info.vcpus in
@@ -1578,7 +1578,7 @@ let restore (task : Xenops_task.task_handle) ~xc ~xs ~dm ~store_domid
   in
   let store_mfn, console_mfn =
     restore_common task ~xc ~xs ~dm ~domain_type ~store_port ~store_domid
-      ~console_port ~console_domid ~no_incr_generationid ~vcpus ~extras
+      ~console_port ~console_domid ~no_incr_generationid ~vcpus ~extras ~vtpm
       manager_path domid fd vgpu_fd
   in
   let local_stuff = console_keys console_port console_mfn in
@@ -1672,7 +1672,7 @@ let suspend_emu_manager ~(task : Xenops_task.task_handle) ~xc:_ ~xs ~domain_type
                   Device.Dm.suspend_varstored task ~xs domid ~vm_uuid
                 in
                 let (_ : string list) =
-                  Device.Dm.suspend_vtpms task ~xs domid ~vm_uuid ~vtpm
+                  Device.Dm.suspend_vtpm task ~xs domid ~vtpm
                 in
                 ()
             ) ;
@@ -1754,12 +1754,10 @@ let forall f l =
   let open Suspend_image.M in
   fold (fun x () -> f x) l ()
 
-let write_vtpms_record task ~xs ~vtpm domid main_fd =
+let write_vtpm_record task ~xs ~vtpm domid main_fd =
   let open Suspend_image in
   let open Suspend_image.M in
-  Device.Dm.suspend_vtpms task ~xs domid
-    ~vm_uuid:(Uuidx.to_string (Xenops_helpers.uuid_of_domid ~xs domid))
-    ~vtpm
+  Device.Dm.suspend_vtpm task ~xs domid ~vtpm
   |> forall @@ fun swtpm_record ->
      let swtpm_rec_len = String.length swtpm_record in
      debug "Writing swtpm record (domid=%d length=%d)" domid swtpm_rec_len ;
@@ -1804,7 +1802,7 @@ let suspend (task : Xenops_task.task_handle) ~xc ~xs ~domain_type ~is_uefi ~dm
     >>= fun () ->
     ( if is_uefi then
         write_varstored_record task ~xs domid main_fd >>= fun () ->
-        write_vtpms_record task ~xs ~vtpm domid main_fd
+        write_vtpm_record task ~xs ~vtpm domid main_fd
     else
       return ()
     )

--- a/ocaml/xenopsd/xc/domain.mli
+++ b/ocaml/xenopsd/xc/domain.mli
@@ -243,6 +243,7 @@ val restore :
   -> extras:string list
   -> build_info
   -> manager_path:string
+  -> vtpm:Xenops_interface.Vm.tpm option
   -> domid
   -> Unix.file_descr
   -> Unix.file_descr option

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -681,7 +681,7 @@ module Swtpm = struct
     *)
     Xenops_sandbox.Chroot.Path.of_string ~relative:"tpm2-00.permall"
 
-  let restore ~domid ~vm_uuid state =
+  let restore _dbg ~domid ~vm_uuid ~vtpm_uuid:_ state =
     if String.length state > 0 then (
       let path = Xenops_sandbox.Swtpm_guard.create ~domid ~vm_uuid state_path in
       debug "Restored vTPM for domid %d: %d bytes, digest %s" domid
@@ -744,7 +744,7 @@ module Swtpm = struct
     if Sys.file_exists abs_path then
       debug "Not restoring vTPM: %s already exists" abs_path
     else
-      restore ~domid ~vm_uuid state ;
+      restore dbg ~domid ~vm_uuid ~vtpm_uuid state ;
     let vtpm_path = xs_path ~domid in
 
     xs.Xs.write
@@ -757,7 +757,7 @@ module Swtpm = struct
       absolute_path_outside chroot (Path.of_string ~relative:"swtpm-sock")
     )
 
-  let suspend ~xs ~domid ~vm_uuid =
+  let suspend _dbg ~xs ~domid ~vm_uuid ~vtpm_uuid:_ =
     D.stop ~xs domid ;
     Xenops_sandbox.Swtpm_guard.read ~domid ~vm_uuid state_path
 
@@ -765,7 +765,7 @@ module Swtpm = struct
     debug "About to stop vTPM (%s) for domain %d (%s)"
       (Uuidm.to_string vtpm_uuid)
       domid vm_uuid ;
-    let contents = suspend ~xs ~domid ~vm_uuid in
+    let contents = suspend dbg ~xs ~domid ~vm_uuid ~vtpm_uuid in
     let length = String.length contents in
     if length > 0 then (
       debug "Storing vTPM state of %d bytes" length ;

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -123,9 +123,21 @@ module Swtpm : sig
     -> Xenctrl.domid
     -> string
 
-  val restore : domid:int -> vm_uuid:string -> string -> unit
+  val restore :
+       string
+    -> domid:int
+    -> vm_uuid:string
+    -> vtpm_uuid:Varstore_privileged_interface.Uuidm.t
+    -> string
+    -> unit
 
-  val suspend : xs:Xenstore.Xs.xsh -> domid:int -> vm_uuid:string -> string
+  val suspend :
+       string
+    -> xs:Xenstore.Xs.xsh
+    -> domid:int
+    -> vm_uuid:string
+    -> vtpm_uuid:Varstore_privileged_interface.Uuidm.t
+    -> string
 
   val stop :
        string

--- a/ocaml/xenopsd/xc/service.mli
+++ b/ocaml/xenopsd/xc/service.mli
@@ -126,7 +126,6 @@ module Swtpm : sig
   val restore :
        string
     -> domid:int
-    -> vm_uuid:string
     -> vtpm_uuid:Varstore_privileged_interface.Uuidm.t
     -> string
     -> unit
@@ -135,7 +134,6 @@ module Swtpm : sig
        string
     -> xs:Xenstore.Xs.xsh
     -> domid:int
-    -> vm_uuid:string
     -> vtpm_uuid:Varstore_privileged_interface.Uuidm.t
     -> string
 

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2718,8 +2718,8 @@ module VM = struct
                     Domain.restore task ~xc ~xs ~dm:(dm_of ~vm) ~store_domid
                       ~console_domid
                       ~no_incr_generationid (* XXX progress_callback *)
-                      ~timeoffset ~extras build_info ~manager_path domid fd
-                      vgpu_fd
+                      ~timeoffset ~extras build_info ~manager_path
+                      ~vtpm:(vtpm_of ~vm) domid fd vgpu_fd
                 )
               with e ->
                 error "VM %s: restore failed: %s" vm.Vm.id (Printexc.to_string e) ;

--- a/scripts/vtpm_smoke_test.sh
+++ b/scripts/vtpm_smoke_test.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -eu
+WRAPPER=/usr/lib64/xen/bin/swtpm-wrapper
+
+tpm()
+{
+    swtpm_ioctl --unix "${DIR}/swtpm-sock" "$@"
+}
+
+smoketest_cmds()
+{
+    tpm -c
+    tpm -i
+    tpm -e
+    tpm -h foobar
+    tpm -g
+    tpm -v
+    tpm --info 3
+
+    echo "About to save all vTPM states"
+    # volatilestate must be first, 'tpm -v' must be previous command, see manpage
+    for state in volatile permanent savestate; do
+        tpm --save "${state}" test."${state}"
+    done
+
+    # must be run before load, note that shutdown != stop
+    echo "Stopping vTPM"
+    tpm --stop
+    echo "Loading all vTPM state"
+    for state in volatile permanent savestate; do
+        tpm --load "${state}" test."${state}"
+    done
+    echo "(Re)initializing vTPM from loaded state"
+    tpm -i
+
+    echo "Stopping vTPM emulator"
+    tpm -s
+}
+
+DOMID=100000
+GID=$(( $(id swtpm_base -u) + ${DOMID} ))
+
+smoketest_wrapper()
+{
+    URL="$1"
+    echo
+    echo "=== TESTING state backend ${URL} ==="
+    echo
+    echo "Initializing vTPM state in ${DIR}"
+    "${WRAPPER}" "${DOMID}" "${DIR}" dir://. true
+
+    inotifywait --exclude '.*.pid' -e create "${DIR}"&
+    INOTIFY_PID=$!
+
+    echo "Starting vTPM emulator in ${DIR}"
+    "${WRAPPER}" "${DOMID}" "${DIR}" "${URL}" false&
+    WRAPPER_PID=$!
+
+    echo "Waiting for socket"
+    # wait for socket
+    wait "${INOTIFY_PID}"
+    echo "Got socket, running vTPM commands"
+
+    smoketest_cmds
+
+    echo "Waiting for vTPM emulator to finish"
+    wait "${WRAPPER_PID}"
+
+    echo
+    echo "=== OK ${URL} ==="
+    echo
+}
+
+
+smoketest_url()
+{
+    DIR=$(mktemp -d)
+    trap "rm -rf '${DIR}'" EXIT
+
+    smoketest_wrapper "$1"
+}
+
+smoketest_guard()
+{
+    echo
+    echo "=== TESTING xapi-guard<->swtpm communication ==="
+    echo
+    VM=$(xe vm-create --minimal name-label="vtpm test")
+    trap 'xe vm-destroy uuid="${VM}"' EXIT
+    xe vtpm-create vm-uuid="${VM}"
+
+    # TODO: change to new API with Pau's branch
+    # domid picked here is beyond max, so shouldn't clash
+    DIR="/var/lib/xcp/run/swtpm-root-${DOMID}/"
+
+    # cleanup from previous test potentially
+    xapiguard_cli vtpm_destroy smoketest "${DOMID}" "${DIR}/xapidepriv"
+    rm -rf "${DIR}"
+
+    mkdir -p "${DIR}"
+    trap 'rm -rf "${DIR}"' EXIT
+    echo "GID: ${GID}"
+    xapiguard_cli vtpm_create smoketest "\"${VM}\"" "${GID}" "${DIR}/xapidepriv"
+    trap 'xapiguard_cli vtpm_destroy smoketest "${GID}" "${DIR}/xapidepriv"' EXIT
+
+    smoketest_wrapper "unix+http://xapidepriv"
+
+    echo
+    echo "=== OK xapi-guard<->swtpm communication ==="
+    echo
+}
+smoketest_xapi()
+{
+    echo
+    echo "=== TESTING xapi vtpm creation on paused VM ==="
+    echo
+    VM=$(xe vm-create --minimal name-label="vtpm test")
+    trap 'xe vm-destroy uuid="${VM}"' EXIT
+    xe vm-param-set uuid="${VM}" HVM-boot-params:firmware=uefi
+    xe vm-param-set uuid="${VM}" domain-type=hvm
+
+    xe vtpm-create vm-uuid="${VM}"
+
+    xe vm-start uuid="${VM}" paused=true
+    #DOMID=$(xe vm-param-get uuid="${VM}" param-name=dom-id)
+    #DIR="/var/lib/xcp/run/swtpm-root-${DOMID}/"
+    # we can't attach swtpm_ioctl because qemu is already attached
+
+    SNAP=$(xe vm-snapshot uuid="${VM}" new-name-label=vtpm-snapshot)
+    xe snapshot-destroy uuid="${SNAP}"
+    CHECKPOINT=$(xe vm-checkpoint uuid="${VM}" new-name-label=vtpm-checkpoint)
+    xe snapshot-revert snapshot-uuid="${CHECKPOINT}"
+    xe snapshot-destroy uuid="${CHECKPOINT}"
+
+    # no need, revert already did this: xe vm-shutdown uuid="${VM}" --force
+    echo
+    echo "=== OK xapi vtpm ==="
+    echo
+}
+
+smoketest_url "dir://."
+
+smoketest_guard
+# TODO: start small HTTP server that supports GET/PUT/DELETE and use an http
+# url
+
+smoketest_xapi


### PR DESCRIPTION
TODO:
* plumb creation of new socket through to 'make_server_vtpm_rest'
* add new enum for new storage backend in addition to xapi (maybe call it xapi2?), the serialization is different and incompatible (unless swtpm would implement a linear op instead of the current per-entry ops, but per-entry seems more robust)
* bring back the tests, but this time just test basic operations/scalability, not correctness in a distributed system (we won't have a distributed system anymore, we'll rely on shared storage to solve that problem)