### PR TITLE
CP-42810: Periodic update sync

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 764
+let schema_minor_vsn = 765
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1954,6 +1954,9 @@ let _ =
        now."
     () ;
 
+  error Api_errors.invalid_update_sync_day ["day"]
+    ~doc:"The day when update sync will run is invalid." () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1086,6 +1086,20 @@ let configure_update_sync =
       ]
     ~allowed_roles:_R_POOL_OP ()
 
+let set_update_sync_enabled =
+  call ~name:"set_update_sync_enabled" ~lifecycle:[]
+    ~doc:
+      "enable or disable periodic update synchronization depending on the value"
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( Bool
+        , "value"
+        , "true - enable periodic update synchronization, false - disable it"
+        )
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
 (** A pool class *)
 let t =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:None
@@ -1171,6 +1185,7 @@ let t =
       ; set_telemetry_next_collection
       ; reset_telemetry_uuid
       ; configure_update_sync
+      ; set_update_sync_enabled
       ]
     ~contents:
       ([uid ~in_oss_since:None _pool]

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "255a85e3f423241dd4e7f224a42a3116"
+let last_known_schema_hash = "5730ef2912cf94116294e951518f9257"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -291,7 +291,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(migration_compression = false) ?(coordinator_bias = true)
     ?(telemetry_uuid = Ref.null) ?(telemetry_frequency = `weekly)
     ?(telemetry_next_collection = API.Date.never)
-    ?(last_update_sync = API.Date.epoch) () =
+    ?(last_update_sync = API.Date.epoch) ?(update_sync_frequency = `daily)
+    ?(update_sync_day = 0L) ?(update_sync_enabled = false) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -307,7 +308,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~client_certificate_auth_enabled ~client_certificate_auth_name
     ~repository_proxy_url ~repository_proxy_username ~repository_proxy_password
     ~migration_compression ~coordinator_bias ~telemetry_uuid
-    ~telemetry_frequency ~telemetry_next_collection ~last_update_sync ;
+    ~telemetry_frequency ~telemetry_next_collection ~last_update_sync
+    ~update_sync_frequency ~update_sync_day ~update_sync_enabled ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -6,7 +6,7 @@
       test_cluster_host test_cluster test_pusb test_network_sriov
       test_vm_placement test_vm_helpers test_repository test_repository_helpers
       test_ref
-      test_livepatch test_rpm test_updateinfo test_storage_smapiv1_wrapper test_storage_quicktest))
+      test_livepatch test_rpm test_updateinfo test_storage_smapiv1_wrapper test_storage_quicktest test_pool_helpers))
   (libraries
     alcotest
     angstrom
@@ -57,12 +57,12 @@
 (tests
   (names test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt
     test_clustering test_pusb test_daemon_manager test_repository test_repository_helpers
-    test_livepatch test_rpm test_updateinfo)
+    test_livepatch test_rpm test_updateinfo test_pool_helpers)
   (package xapi)
   (modules test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt
     test_event test_clustering test_cluster_host test_cluster test_pusb
     test_daemon_manager test_repository test_repository_helpers test_livepatch test_rpm
-    test_updateinfo)
+    test_updateinfo test_pool_helpers)
   (libraries
     alcotest
     fmt

--- a/ocaml/tests/test_pool_helpers.ml
+++ b/ocaml/tests/test_pool_helpers.ml
@@ -1,0 +1,354 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Test_highlevel
+open Xapi_pool_helpers
+
+let secs_random_within_a_day = PeriodicUpdateSync.seconds_random_within_a_day ()
+
+module TestUpdateSyncDelay = struct
+  let test_update_sync_delay_for_retry_1 () =
+    let min_delay = 60. *. 60. in
+    let max_delay = 2. *. 60. *. 60. in
+    for _ = 1 to 100 do
+      let delay =
+        PeriodicUpdateSync.update_sync_delay_for_retry
+          ~num_of_retries_for_last_scheduled_update_sync:1
+      in
+      Alcotest.(check bool)
+        "test_update_sync_delay_for_retry_1" true
+        (min_delay <= delay && delay < max_delay)
+    done
+
+  let test_update_sync_delay_for_retry_2 () =
+    let min_delay = 60. *. 60. in
+    let max_delay = 3. *. 60. *. 60. in
+    for _ = 1 to 100 do
+      let delay =
+        PeriodicUpdateSync.update_sync_delay_for_retry
+          ~num_of_retries_for_last_scheduled_update_sync:2
+      in
+      Alcotest.(check bool)
+        "test_update_sync_delay_for_retry_2" true
+        (min_delay <= delay && delay < max_delay)
+    done
+
+  let test_update_sync_delay_for_retry_3 () =
+    let min_delay = 60. *. 60. in
+    let max_delay = 5. *. 60. *. 60. in
+    for _ = 1 to 100 do
+      let delay =
+        PeriodicUpdateSync.update_sync_delay_for_retry
+          ~num_of_retries_for_last_scheduled_update_sync:2
+      in
+      Alcotest.(check bool)
+        "test_update_sync_delay_for_retry_3" true
+        (min_delay <= delay && delay < max_delay)
+    done
+
+  let test_update_sync_delay_for_retry_4 () =
+    Alcotest.check_raises "test_update_sync_delay_for_retry_4"
+      (PeriodicUpdateSync.UpdateSync_RetryNumExceeded 4) (fun () ->
+        ignore
+          (PeriodicUpdateSync.update_sync_delay_for_retry
+             ~num_of_retries_for_last_scheduled_update_sync:4
+          )
+    )
+
+  let test_next_scheduled_datetime_now () =
+    let utc_now = Ptime_clock.now () in
+    let y, m, d, hh, mm, ss =
+      PeriodicUpdateSync.next_scheduled_datetime ~delay:0. ~utc_now
+        ~tz_offset_s:(Ptime_clock.current_tz_offset_s () |> Option.get)
+    in
+    let tm = Unix.localtime (Ptime.to_float_s utc_now) in
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_now year" y (tm.tm_year + 1900) ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_now month" m (tm.tm_mon + 1) ;
+    Alcotest.(check int) "test_next_scheduled_datetime_now day" d tm.tm_mday ;
+    Alcotest.(check int) "test_next_scheduled_datetime_now hour" hh tm.tm_hour ;
+    Alcotest.(check int) "test_next_scheduled_datetime_now mintue" mm tm.tm_min ;
+    Alcotest.(check int) "test_next_scheduled_datetime_now second" ss tm.tm_sec
+
+  let test_next_scheduled_datetime_10_minutes_later () =
+    let utc_now = Ptime_clock.now () in
+    let y, m, d, hh, mm, ss =
+      PeriodicUpdateSync.next_scheduled_datetime ~delay:(10. *. 60.) ~utc_now
+        ~tz_offset_s:(Ptime_clock.current_tz_offset_s () |> Option.get)
+    in
+    let tm = Unix.localtime (Ptime.to_float_s utc_now +. (10. *. 60.)) in
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_10_minutes_later year" y (tm.tm_year + 1900) ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_10_minutes_later month" m (tm.tm_mon + 1) ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_10_minutes_later day" d tm.tm_mday ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_10_minutes_later hour" hh tm.tm_hour ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_10_minutes_later mintue" mm tm.tm_min ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_10_minutes_later second" ss tm.tm_sec
+
+  let test_next_scheduled_datetime_tomorrow () =
+    let utc_now = Ptime_clock.now () in
+    let y, m, d, hh, mm, ss =
+      PeriodicUpdateSync.next_scheduled_datetime
+        ~delay:(24. *. 60. *. 60.)
+        ~utc_now
+        ~tz_offset_s:(Ptime_clock.current_tz_offset_s () |> Option.get)
+    in
+    let tm = Unix.localtime (Ptime.to_float_s utc_now +. (24. *. 60. *. 60.)) in
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_tomorrow year" y (tm.tm_year + 1900) ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_tomorrow month" m (tm.tm_mon + 1) ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_tomorrow day" d tm.tm_mday ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_tomorrow hour" hh tm.tm_hour ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_tomorrow mintue" mm tm.tm_min ;
+    Alcotest.(check int)
+      "test_next_scheduled_datetime_tomorrow second" ss tm.tm_sec
+
+  let test_utc_start_of_next_scheduled_day_1 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 5, 4), ((13, 14, 15), tz_offset_s))
+      |> Option.get
+    in
+    let res =
+      PeriodicUpdateSync.utc_start_of_next_scheduled_day ~utc_now ~tz_offset_s
+        ~frequency:`daily ~day_configed_int:0
+    in
+    let utc_start_of_next_day =
+      Ptime.of_date_time ((2023, 5, 5), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    Alcotest.(check bool)
+      "test_utc_start_of_next_scheduled_day_1, daily" true
+      (Ptime.equal res utc_start_of_next_day)
+
+  let test_utc_start_of_next_scheduled_day_2 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 5, 31), ((13, 14, 15), tz_offset_s))
+      |> Option.get
+    in
+    let res =
+      PeriodicUpdateSync.utc_start_of_next_scheduled_day ~utc_now ~tz_offset_s
+        ~frequency:`daily ~day_configed_int:0
+    in
+    let utc_start_of_next_day =
+      Ptime.of_date_time ((2023, 6, 1), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    Alcotest.(check bool)
+      "test_utc_start_of_next_scheduled_day_2, daily, end of month" true
+      (Ptime.equal res utc_start_of_next_day)
+
+  let test_utc_start_of_next_scheduled_day_3 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 12, 31), ((13, 14, 15), tz_offset_s))
+      |> Option.get
+    in
+    let res =
+      PeriodicUpdateSync.utc_start_of_next_scheduled_day ~utc_now ~tz_offset_s
+        ~frequency:`daily ~day_configed_int:0
+    in
+    let utc_start_of_next_day =
+      Ptime.of_date_time ((2024, 1, 1), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    Alcotest.(check bool)
+      "test_utc_start_of_next_scheduled_day_3, daily, end of year" true
+      (Ptime.equal res utc_start_of_next_day)
+
+  let test_utc_start_of_next_scheduled_day_4 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 5, 4), ((13, 14, 15), tz_offset_s))
+      |> Option.get
+    in
+    let res =
+      PeriodicUpdateSync.utc_start_of_next_scheduled_day ~utc_now ~tz_offset_s
+        ~frequency:`weekly ~day_configed_int:6
+    in
+    let utc_start_of_next_sched_day =
+      Ptime.of_date_time ((2023, 5, 6), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    Alcotest.(check bool)
+      "test_utc_start_of_next_scheduled_day_4, weekly, this week" true
+      (Ptime.equal res utc_start_of_next_sched_day)
+
+  let test_utc_start_of_next_scheduled_day_5 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 5, 4), ((13, 14, 15), tz_offset_s))
+      |> Option.get
+    in
+    let res =
+      PeriodicUpdateSync.utc_start_of_next_scheduled_day ~utc_now ~tz_offset_s
+        ~frequency:`weekly ~day_configed_int:1
+    in
+    let utc_start_of_next_sched_day =
+      Ptime.of_date_time ((2023, 5, 8), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    Alcotest.(check bool)
+      "test_utc_start_of_next_scheduled_day_5, weekly, next week" true
+      (Ptime.equal res utc_start_of_next_sched_day)
+
+  let test_utc_start_of_next_scheduled_day_6 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 5, 4), ((13, 14, 15), tz_offset_s))
+      |> Option.get
+    in
+    let res =
+      PeriodicUpdateSync.utc_start_of_next_scheduled_day ~utc_now ~tz_offset_s
+        ~frequency:`weekly ~day_configed_int:4
+    in
+    let utc_start_of_next_sched_day =
+      Ptime.of_date_time ((2023, 5, 11), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    Alcotest.(check bool)
+      "test_utc_start_of_next_scheduled_day_6, weekly, next week 2" true
+      (Ptime.equal res utc_start_of_next_sched_day)
+
+  let test_update_sync_delay_for_next_schedule_internal_1 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 5, 4), ((0, 0, 1), tz_offset_s)) |> Option.get
+    in
+    let utc_start_of_next_sched_day =
+      Ptime.of_date_time ((2023, 5, 6), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    let seconds_in_a_day = 0. in
+    let delay = (2. *. 24. *. 60. *. 60.) -. 1. in
+    let res =
+      PeriodicUpdateSync.update_sync_delay_for_next_schedule_internal ~utc_now
+        ~utc_start_of_next_sched_day ~seconds_in_a_day
+    in
+    Alcotest.(check (float Float.epsilon))
+      "test_update_sync_delay_for_next_schedule_internal_1, seconds_in_a_day 0"
+      delay res
+
+  let test_update_sync_delay_for_next_schedule_internal_2 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 5, 4), ((0, 0, 1), tz_offset_s)) |> Option.get
+    in
+    let utc_start_of_next_sched_day =
+      Ptime.of_date_time ((2023, 5, 6), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    let seconds_in_a_day = 66. in
+    let delay = (2. *. 24. *. 60. *. 60.) -. 1. +. 66. in
+    let res =
+      PeriodicUpdateSync.update_sync_delay_for_next_schedule_internal ~utc_now
+        ~utc_start_of_next_sched_day ~seconds_in_a_day
+    in
+    Alcotest.(check (float Float.epsilon))
+      "test_update_sync_delay_for_next_schedule_internal_2, seconds_in_a_day \
+       not 0"
+      delay res
+
+  let test_update_sync_delay_for_next_schedule_internal_3 () =
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let utc_now =
+      Ptime.of_date_time ((2023, 4, 29), ((0, 0, 1), tz_offset_s)) |> Option.get
+    in
+    let utc_start_of_next_sched_day =
+      Ptime.of_date_time ((2023, 5, 4), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+    let seconds_in_a_day = 66. in
+    let delay = (5. *. 24. *. 60. *. 60.) -. 1. +. 66. in
+    let res =
+      PeriodicUpdateSync.update_sync_delay_for_next_schedule_internal ~utc_now
+        ~utc_start_of_next_sched_day ~seconds_in_a_day
+    in
+    Alcotest.(check (float Float.epsilon))
+      "test_update_sync_delay_for_next_schedule_internal_3, next month" delay
+      res
+
+  let test =
+    [
+      ( "update_sync_delay_for_retry 1st time"
+      , `Quick
+      , test_update_sync_delay_for_retry_1
+      )
+    ; ( "update_sync_delay_for_retry 2nd time"
+      , `Quick
+      , test_update_sync_delay_for_retry_2
+      )
+    ; ( "update_sync_delay_for_retry 3rd time"
+      , `Quick
+      , test_update_sync_delay_for_retry_3
+      )
+    ; ( "update_sync_delay_for_retry 4th time"
+      , `Quick
+      , test_update_sync_delay_for_retry_4
+      )
+    ; ("next_scheduled_datetime now", `Quick, test_next_scheduled_datetime_now)
+    ; ( "next_scheduled_datetime 10 minutes later"
+      , `Quick
+      , test_next_scheduled_datetime_10_minutes_later
+      )
+    ; ( "next_scheduled_datetime tomorrow"
+      , `Quick
+      , test_next_scheduled_datetime_tomorrow
+      )
+    ; ( "utc_start_of_next_scheduled_day daily"
+      , `Quick
+      , test_utc_start_of_next_scheduled_day_1
+      )
+    ; ( "utc_start_of_next_scheduled_day daily, end of month"
+      , `Quick
+      , test_utc_start_of_next_scheduled_day_2
+      )
+    ; ( "utc_start_of_next_scheduled_day daily, end of year"
+      , `Quick
+      , test_utc_start_of_next_scheduled_day_3
+      )
+    ; ( "utc_start_of_next_scheduled_day weekly, this week"
+      , `Quick
+      , test_utc_start_of_next_scheduled_day_4
+      )
+    ; ( "utc_start_of_next_scheduled_day weekly, next week"
+      , `Quick
+      , test_utc_start_of_next_scheduled_day_5
+      )
+    ; ( "utc_start_of_next_scheduled_day weekly, next week, 2"
+      , `Quick
+      , test_utc_start_of_next_scheduled_day_6
+      )
+    ; ( "update_sync_delay_for_next_schedule_internal, random seconds 0"
+      , `Quick
+      , test_update_sync_delay_for_next_schedule_internal_1
+      )
+    ; ( "update_sync_delay_for_next_schedule_internal, random seconds not 0"
+      , `Quick
+      , test_update_sync_delay_for_next_schedule_internal_2
+      )
+    ; ( "update_sync_delay_for_next_schedule_internal, next month"
+      , `Quick
+      , test_update_sync_delay_for_next_schedule_internal_3
+      )
+    ]
+end
+
+let tests =
+  make_suite "pool_helpers_"
+    [("periodic_update_sync", TestUpdateSyncDelay.test)]
+
+let () = Alcotest.run "Pool Helpers" tests

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3012,6 +3012,17 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pool-set-update-sync-enabled"
+    , {
+        reqd= ["value"]
+      ; optn= []
+      ; help=
+          "Enable or disable periodic update synchronization depending on the \
+           value"
+      ; implementation= No_fd Cli_operations.pool_set_update_sync_enabled
+      ; flags= []
+      }
+    )
   ; ( "host-ha-xapi-healthcheck"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2997,6 +2997,21 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pool-configure-update-sync"
+    , {
+        reqd= ["update-sync-frequency"; "update-sync-day"]
+      ; optn= []
+      ; help=
+          "Configure periodic update synchronization from remote CDN. \
+           'update_sync_frequenc': the frequency at which updates are synced \
+           from remote CDN: daily or weekly. 'update_sync_day': which day of \
+           one period the update sychronization is scheduled. For 'daily' \
+           schedule, it should be 0. For 'weekly' schedule, 0..6, where 0 is \
+           Sunday."
+      ; implementation= No_fd Cli_operations.pool_configure_update_sync
+      ; flags= []
+      }
+    )
   ; ( "host-ha-xapi-healthcheck"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1857,6 +1857,11 @@ let pool_configure_update_sync _printer rpc session_id params =
   Client.Pool.configure_update_sync ~rpc ~session_id ~self:pool
     ~update_sync_frequency:frequency ~update_sync_day:day_int
 
+let pool_set_update_sync_enabled _printer rpc session_id params =
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  let value = get_bool_param params "value" in
+  Client.Pool.set_update_sync_enabled ~rpc ~session_id ~self:pool ~value
+
 let vdi_type_of_string = function
   | "system" ->
       `system

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -1134,3 +1134,18 @@ let mac_from_int_array macs =
 
 (* generate a random mac that is locally administered *)
 let random_mac_local () = mac_from_int_array (Array.make 6 (Random.int 0x100))
+
+let update_sync_frequency_to_string = function
+  | `daily ->
+      "daily"
+  | `weekly ->
+      "weekly"
+
+let update_sync_frequency_of_string s =
+  match String.lowercase_ascii s with
+  | "daily" ->
+      `daily
+  | "weekly" ->
+      `weekly
+  | _ ->
+      raise (Record_failure ("Expected 'daily', 'weekly', got " ^ s))

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1474,6 +1474,18 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"last-update-sync"
           ~get:(fun () -> Date.to_string (x ()).API.pool_last_update_sync)
           ()
+      ; make_field ~name:"update-sync-frequency"
+          ~get:(fun () ->
+            Record_util.update_sync_frequency_to_string
+              (x ()).API.pool_update_sync_frequency
+          )
+          ()
+      ; make_field ~name:"update-sync-day"
+          ~get:(fun () -> Int64.to_string (x ()).API.pool_update_sync_day)
+          ()
+      ; make_field ~name:"update-sync-enabled"
+          ~get:(fun () -> (x ()).API.pool_update_sync_enabled |> string_of_bool)
+          ()
       ]
   }
 

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1283,6 +1283,8 @@ let updates_require_recommended_guidance =
 
 let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"
 
+let invalid_update_sync_day = "INVALID_UPDATE_SYNC_DAY"
+
 (* VTPMs *)
 
 let vtpm_max_amount_reached = "VTPM_MAX_AMOUNT_REACHED"

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -51,6 +51,8 @@ let create_pool_record ~__context =
       ~telemetry_frequency:`weekly
       ~telemetry_next_collection:Xapi_stdext_date.Date.epoch
       ~last_update_sync:Xapi_stdext_date.Date.epoch
+      ~update_sync_frequency:`weekly ~update_sync_day:0L
+      ~update_sync_enabled:false
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1100,6 +1100,17 @@ functor
       let reset_telemetry_uuid ~__context ~self =
         info "%s: pool='%s'" __FUNCTION__ (pool_uuid ~__context self) ;
         Local.Pool.reset_telemetry_uuid ~__context ~self
+
+      let configure_update_sync ~__context ~self ~update_sync_frequency
+          ~update_sync_day =
+        info
+          "Pool.configure_update_sync: pool='%s' update_sync_frequency='%s' \
+           update_sync_day=%Ld"
+          (pool_uuid ~__context self)
+          (Record_util.update_sync_frequency_to_string update_sync_frequency)
+          update_sync_day ;
+        Local.Pool.configure_update_sync ~__context ~self ~update_sync_frequency
+          ~update_sync_day
     end
 
     module VM = struct

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1111,6 +1111,12 @@ functor
           update_sync_day ;
         Local.Pool.configure_update_sync ~__context ~self ~update_sync_frequency
           ~update_sync_day
+
+      let set_update_sync_enabled ~__context ~self ~value =
+        info "Pool.set_update_sync_enabled: pool='%s' value='%B'"
+          (pool_uuid ~__context self)
+          value ;
+        Local.Pool.set_update_sync_enabled ~__context ~self ~value
     end
 
     module VM = struct

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1219,7 +1219,7 @@ let server_init () =
             )
           ; ( "Registering periodic functions"
             , []
-            , Xapi_periodic_scheduler_init.register
+            , fun () -> Xapi_periodic_scheduler_init.register ~__context
             )
           ; ("executing startup scripts", [Startup.NoExnRaising], startup_script)
           ; ( "considering executing on-master-start script"

--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -113,6 +113,9 @@ let pause_after_cert_exchange () = fistpoint "pause_after_cert_exchange"
 let fail_on_error_in_yum_upgrade_dry_run () =
   fistpoint "fail_on_error_in_yum_upgrade_dry_run"
 
+let disable_periodic_update_sync_sec_randomness () =
+  fistpoint "disable_periodic_update_sync_sec_randomness"
+
 let hang_psr psr_checkpoint =
   ( match psr_checkpoint with
   | `backup ->

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -17,7 +17,7 @@ module D = Debug.Make (struct let name = "backgroundscheduler" end)
 
 open D
 
-let register () =
+let register ~__context =
   debug "Registering periodic calls" ;
   let master = Pool_role.is_master () in
   (* blob/message/rrd file syncing - sync once a day *)
@@ -113,4 +113,10 @@ let register () =
         "Period alert if TLS verification emergency disabled" (fun __context ->
           Xapi_host.alert_if_tls_verification_was_emergency_disabled ~__context
       )
-  )
+  ) ;
+  if
+    master
+    && Db.Pool.get_update_sync_enabled ~__context
+         ~self:(Helpers.get_pool ~__context)
+  then
+    Xapi_pool_helpers.PeriodicUpdateSync.set_enabled ~__context ~value:true

--- a/ocaml/xapi/xapi_periodic_scheduler_init.mli
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.mli
@@ -13,5 +13,5 @@
  *)
 (** Schedule common background tasks. *)
 
-val register : unit -> unit
+val register : __context:Context.t -> unit
 (** Register periodic calls, done by {!Xapi} on start-up. *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3686,4 +3686,11 @@ let configure_update_sync ~__context ~self ~update_sync_frequency
   ) ;
   Db.Pool.set_update_sync_frequency ~__context ~self
     ~value:update_sync_frequency ;
-  Db.Pool.set_update_sync_day ~__context ~self ~value:update_sync_day
+  Db.Pool.set_update_sync_day ~__context ~self ~value:update_sync_day ;
+  if Db.Pool.get_update_sync_enabled ~__context ~self then
+    (* re-schedule periodic update sync with new configuration immediately *)
+    Xapi_pool_helpers.PeriodicUpdateSync.set_enabled ~__context ~value:true
+
+let set_update_sync_enabled ~__context ~self ~value =
+  Db.Pool.set_update_sync_enabled ~__context ~self ~value ;
+  Xapi_pool_helpers.PeriodicUpdateSync.set_enabled ~__context ~value

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -398,3 +398,10 @@ val set_telemetry_next_collection :
   -> unit
 
 val reset_telemetry_uuid : __context:Context.t -> self:API.ref_pool -> unit
+
+val configure_update_sync :
+     __context:Context.t
+  -> self:API.ref_pool
+  -> update_sync_frequency:API.update_sync_frequency
+  -> update_sync_day:int64
+  -> unit

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -405,3 +405,6 @@ val configure_update_sync :
   -> update_sync_frequency:API.update_sync_frequency
   -> update_sync_day:int64
   -> unit
+
+val set_update_sync_enabled :
+  __context:Context.t -> self:API.ref_pool -> value:bool -> unit

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -269,3 +269,221 @@ let apply_guest_agent_config ~__context =
         (Printexc.to_string e)
   in
   call_fn_on_slaves_then_master ~__context f
+
+module PeriodicUpdateSync = struct
+  let periodic_update_sync_task_name = "Periodic update synchronization"
+
+  exception UpdateSync_RetryNumExceeded of int
+
+  let seconds_random_within_a_day () =
+    if Xapi_fist.disable_periodic_update_sync_sec_randomness () then
+      0.
+    else
+      let secs_of_a_day = 24. *. 60. *. 60. in
+      let secs_random = Random.float secs_of_a_day in
+      secs_random
+
+  let frequency_to_str ~frequency =
+    match frequency with
+    | `daily ->
+        "daily"
+    | `monthly ->
+        "monthly"
+    | `weekly ->
+        "weekly"
+
+  let weekday_to_int = function
+    | `Sun ->
+        0
+    | `Mon ->
+        1
+    | `Tue ->
+        2
+    | `Wed ->
+        3
+    | `Thu ->
+        4
+    | `Fri ->
+        5
+    | `Sat ->
+        6
+
+  let utc_start_of_next_scheduled_day ~utc_now ~tz_offset_s ~frequency
+      ~day_configed_int =
+    let y, m, d = fst (Ptime.to_date_time ~tz_offset_s utc_now) in
+    let utc_start_of_today =
+      Ptime.of_date_time ((y, m, d), ((0, 0, 0), tz_offset_s)) |> Option.get
+    in
+
+    match frequency with
+    | `daily ->
+        (* schedule in the next day *)
+        let one_day_span = Ptime.Span.of_d_ps (1, 0L) |> Option.get in
+        Ptime.add_span utc_start_of_today one_day_span |> Option.get
+    | `weekly ->
+        let weekday = Ptime.weekday ~tz_offset_s utc_now in
+        let weekday_num = weekday_to_int weekday in
+        let span =
+          match weekday_num < day_configed_int with
+          | true ->
+              (* schedule this week *)
+              Ptime.Span.of_d_ps (day_configed_int - weekday_num, 0L)
+              |> Option.get
+          | false ->
+              (* schedule next week *)
+              Ptime.Span.of_d_ps (day_configed_int + 7 - weekday_num, 0L)
+              |> Option.get
+        in
+        Ptime.add_span utc_start_of_today span |> Option.get
+
+  let next_scheduled_datetime ~delay ~utc_now ~tz_offset_s =
+    let span = Ptime.Span.of_float_s delay |> Option.get in
+    let target = Ptime.add_span utc_now span |> Option.get in
+    let (y, m, d), ((hh, mm, ss), _) = Ptime.to_date_time ~tz_offset_s target in
+    (y, m, d, hh, mm, ss)
+
+  let print_next_schedule ~delay ~utc_now ~tz_offset_s =
+    debug "[PeriodicUpdateSync] delay for next update sync: %f seconds" delay ;
+    let y, m, d, hh, mm, ss =
+      next_scheduled_datetime ~delay ~utc_now ~tz_offset_s
+    in
+    debug
+      "[PeriodicUpdateSync] next update sync scheduled at pool time: %d-%d-%d, \
+       %d:%d:%d "
+      y m d hh mm ss
+
+  let update_sync_delay_for_next_schedule_internal ~utc_now
+      ~utc_start_of_next_sched_day ~seconds_in_a_day =
+    let random_span = Ptime.Span.of_float_s seconds_in_a_day |> Option.get in
+    let utc_next_schedule =
+      Ptime.add_span utc_start_of_next_sched_day random_span |> Option.get
+    in
+    Ptime.diff utc_next_schedule utc_now |> Ptime.Span.to_float_s
+
+  let update_sync_delay_for_next_schedule ~__context =
+    let frequency =
+      Db.Pool.get_update_sync_frequency ~__context
+        ~self:(Helpers.get_pool ~__context)
+    in
+    let day_configed =
+      Db.Pool.get_update_sync_day ~__context ~self:(Helpers.get_pool ~__context)
+    in
+    debug
+      "[PeriodicUpdateSync] update_sync_delay_for_next_schedule, frequency=%s, \
+       day_configed=%Ld"
+      (frequency_to_str ~frequency)
+      day_configed ;
+    let day_configed_int = Int64.to_int day_configed in
+    let utc_now = Ptime_clock.now () in
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    let seconds_in_a_day = seconds_random_within_a_day () in
+    let utc_start_of_next_sched_day =
+      utc_start_of_next_scheduled_day ~utc_now ~tz_offset_s ~frequency
+        ~day_configed_int
+    in
+    let delay =
+      update_sync_delay_for_next_schedule_internal ~utc_now
+        ~utc_start_of_next_sched_day ~seconds_in_a_day
+    in
+    print_next_schedule ~delay ~utc_now ~tz_offset_s ;
+    delay
+
+  let update_sync_delay_for_retry ~num_of_retries_for_last_scheduled_update_sync
+      =
+    let delay =
+      match num_of_retries_for_last_scheduled_update_sync with
+      | 1 ->
+          (* a random time between 1 hour and 2 hours *)
+          let secs_of_an_hour = 60. *. 60. in
+          secs_of_an_hour +. Random.float secs_of_an_hour
+      | 2 ->
+          (* a random time between 1 hour and 3 hours *)
+          let secs_of_an_hour = 60. *. 60. in
+          secs_of_an_hour +. (Random.float 2. *. secs_of_an_hour)
+      | 3 ->
+          (* a random time between 1 hour and 5 hours *)
+          let secs_of_an_hour = 60. *. 60. in
+          secs_of_an_hour +. (Random.float 4. *. secs_of_an_hour)
+      | n ->
+          raise (UpdateSync_RetryNumExceeded n)
+    in
+    let utc_now = Ptime_clock.now () in
+    let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+    print_next_schedule ~delay ~utc_now ~tz_offset_s ;
+    delay
+
+  let rec update_sync ~num_of_retries_for_last_scheduled_update_sync =
+    Server_helpers.exec_with_new_task "periodic_update_sync" (fun __context ->
+        Helpers.call_api_functions ~__context (fun rpc session_id ->
+            if num_of_retries_for_last_scheduled_update_sync > 0 then
+              debug "[PeriodicUpdateSync] number of retries: %d"
+                num_of_retries_for_last_scheduled_update_sync ;
+            try
+              ignore
+                (Client.Pool.sync_updates ~rpc ~session_id
+                   ~self:(Helpers.get_pool ~__context)
+                   ~force:false ~token:"" ~token_id:""
+                ) ;
+              Xapi_periodic_scheduler.add_to_queue
+                periodic_update_sync_task_name Xapi_periodic_scheduler.OneShot
+                (update_sync_delay_for_next_schedule ~__context) (fun () ->
+                  update_sync ~num_of_retries_for_last_scheduled_update_sync:0
+              )
+            with _ ->
+              (* retry at most 3 times for each scheduled update sync *)
+              if num_of_retries_for_last_scheduled_update_sync < 3 then
+                try
+                  let num_str =
+                    match num_of_retries_for_last_scheduled_update_sync + 1 with
+                    | 1 ->
+                        "first"
+                    | 2 ->
+                        "second"
+                    | 3 ->
+                        "third"
+                    | n ->
+                        raise (UpdateSync_RetryNumExceeded n)
+                  in
+                  debug
+                    "[PeriodicUpdateSync] pool.sync_updates failed, will retry \
+                     the %s time"
+                    num_str ;
+
+                  Xapi_periodic_scheduler.add_to_queue
+                    periodic_update_sync_task_name
+                    Xapi_periodic_scheduler.OneShot
+                    (update_sync_delay_for_retry
+                       ~num_of_retries_for_last_scheduled_update_sync:
+                         (num_of_retries_for_last_scheduled_update_sync + 1)
+                    )
+                    (fun () ->
+                      update_sync
+                        ~num_of_retries_for_last_scheduled_update_sync:
+                          (num_of_retries_for_last_scheduled_update_sync + 1)
+                    )
+                with UpdateSync_RetryNumExceeded n ->
+                  error
+                    "number of update sync retries error: %d, only retry 3 \
+                     times"
+                    n
+              else (* stop retrying, schedule update sync in the next period *)
+                Xapi_periodic_scheduler.add_to_queue
+                  periodic_update_sync_task_name Xapi_periodic_scheduler.OneShot
+                  (update_sync_delay_for_next_schedule ~__context) (fun () ->
+                    update_sync ~num_of_retries_for_last_scheduled_update_sync:0
+                )
+        )
+    )
+
+  let set_enabled ~__context ~value =
+    debug "[PeriodicUpdateSync] set_enabled: %B" value ;
+    if value then (
+      Xapi_periodic_scheduler.remove_from_queue periodic_update_sync_task_name ;
+      Xapi_periodic_scheduler.add_to_queue periodic_update_sync_task_name
+        Xapi_periodic_scheduler.OneShot
+        (update_sync_delay_for_next_schedule ~__context) (fun () ->
+          update_sync ~num_of_retries_for_last_scheduled_update_sync:0
+      )
+    ) else
+      Xapi_periodic_scheduler.remove_from_queue periodic_update_sync_task_name
+end

--- a/ocaml/xapi/xapi_pool_helpers.mli
+++ b/ocaml/xapi/xapi_pool_helpers.mli
@@ -62,3 +62,34 @@ val get_master_slaves_list : __context:Context.t -> [`host] Ref.t list
 val get_slaves_list : __context:Context.t -> [`host] Ref.t list
 
 val apply_guest_agent_config : __context:Context.t -> unit
+
+module PeriodicUpdateSync : sig
+  val set_enabled : __context:Context.t -> value:bool -> unit
+
+  (* below for UT only *)
+  val next_scheduled_datetime :
+       delay:float
+    -> utc_now:Ptime.t
+    -> tz_offset_s:int
+    -> int * int * int * int * int * int
+
+  val utc_start_of_next_scheduled_day :
+       utc_now:Ptime.t
+    -> tz_offset_s:int
+    -> frequency:[< `daily | `weekly]
+    -> day_configed_int:int
+    -> Ptime.t
+
+  val update_sync_delay_for_next_schedule_internal :
+       utc_now:Ptime.t
+    -> utc_start_of_next_sched_day:Ptime.t
+    -> seconds_in_a_day:float
+    -> float
+
+  exception UpdateSync_RetryNumExceeded of int
+
+  val seconds_random_within_a_day : unit -> float
+
+  val update_sync_delay_for_retry :
+    num_of_retries_for_last_scheduled_update_sync:int -> float
+end

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -380,6 +380,13 @@ _xe()
                 set_completions "$vdis" "$val"
                 return 0
                 ;;
+
+            update-sync-frequency) # for pool-configure-update-sync
+                IFS=$'\n,'
+                set_completions 'daily,weekly' "$value"
+                return 0
+                ;;
+
             *)
                 snd=`echo ${param} | gawk -F- '{print $NF}'`
                 fst=`echo ${param} | gawk -F- '{printf "%s", $1; for (i=2; i<NF; i++) printf "-%s", $i}'`


### PR DESCRIPTION
Configuration of periodic update sync:    
    1. add new fields: "update_sync_frequency", "update_sync_day",
       "update_sync_enabled" in pool datamodel
    2. add API: pool.configure_update_sync
    3. add xe CLI: pool-configure-update-sync

Implementation of periodic update sync:    
    1. add API pool.set_update_sync_enabled and xe CLI
    pool-set-update-sync-enabled to enable and disable periodic
    update sync.
    2. implement periodic update sync with "daily" and "weekly"
    schedule.
    3. add fist support: disable_periodic_update_sync_sec_randomness.
    4. UT for periodic update sync delay added.