### PR TITLE
Make NBD disconnect robust to the device being gone

### DIFF
--- a/scripts/nbd_client_manager.py
+++ b/scripts/nbd_client_manager.py
@@ -208,11 +208,16 @@ def disconnect_nbd_device(nbd_device):
     This function is idempotent: calling it on an already disconnected device
     does nothing.
     """
-    if _is_nbd_device_connected(nbd_device=nbd_device):
-        _remove_persistent_connect_info(nbd_device)
-        cmd = ['nbd-client', '-disconnect', nbd_device]
-        _call(cmd)
-        _wait_for_nbd_device(nbd_device=nbd_device, connected=False)
+    try:
+        if _is_nbd_device_connected(nbd_device=nbd_device):
+            _remove_persistent_connect_info(nbd_device)
+            cmd = ['nbd-client', '-disconnect', nbd_device]
+            _call(cmd)
+            _wait_for_nbd_device(nbd_device=nbd_device, connected=False)
+    except NbdDeviceNotFound:
+        # Device gone, no-op
+        pass
+
 
 
 def _connect_cli(args):


### PR DESCRIPTION
Noticed this in a test which had failed for other reasons and then wouldn't unplug the datapath. If the device is not found there is nothing to disconnect.