### PR TITLE
CA-333441, CA-377454 create /var/lock/sm/iscsiadm

### DIFF
--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -415,6 +415,8 @@ module Configuration = struct
 
   let set_initiator_name iqn =
     let hostname = Unix.gethostname () in
+    (* CA-377454 - robustness, create dir if necessary *)
+    Unixext.mkdir_rec "/var/lock/sm/iscsiadm" 0o700 ;
     let args = make_set_initiator_args iqn hostname in
     ignore (Helpers.call_script !Xapi_globs.set_iSCSI_initiator_script args)
 


### PR DESCRIPTION
Backport f0dea47058d366de3cde84e9cf4a95d7a40e71e1

The SM code is supposed to create /var/lock/sm/iscsiadm but it can fail to do that before we call /opt/xensource/libexec/set-iscsi-initiator. To reduce the dependency on the SM change, create this directory if necessary. This facilitates bacporting this change by reducing the dependency on SM backports to fix this.