### PR TITLE
Set PIF's IPv6 Gateway when in DHCP/Autconf

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -445,6 +445,24 @@ module Interface = struct
       )
       ()
 
+  let get_ipv6_gateway dbg name =
+    Debug.with_thread_associated dbg
+      (fun () ->
+        let output = Ip.route_show ~version:Ip.V6 name in
+        try
+          let line =
+            List.find
+              (fun s -> Astring.String.is_prefix ~affix:"default via" s)
+              (Astring.String.cuts ~empty:false ~sep:"\n" output)
+          in
+          let addr =
+            List.nth (Astring.String.cuts ~empty:false ~sep:" " line) 2
+          in
+          Some (Unix.inet_addr_of_string addr)
+        with Not_found -> None
+      )
+      ()
+
   let set_ipv6_gateway _ dbg ~name ~address =
     Debug.with_thread_associated dbg
       (fun () ->

--- a/ocaml/networkd/bin/networkd.ml
+++ b/ocaml/networkd/bin/networkd.ml
@@ -185,6 +185,7 @@ let bind () =
   S.Interface.set_ipv4_conf Interface.set_ipv4_conf ;
   S.Interface.get_ipv4_gateway Interface.get_ipv4_gateway ;
   S.Interface.get_ipv6_addr Interface.get_ipv6_addr ;
+  S.Interface.get_ipv6_gateway Interface.get_ipv6_gateway ;
   S.Interface.get_dns Interface.get_dns ;
   S.Interface.get_mtu Interface.get_mtu ;
   S.Interface.get_capabilities Interface.get_capabilities ;

--- a/ocaml/xapi-idl/network/network_interface.ml
+++ b/ocaml/xapi-idl/network/network_interface.ml
@@ -433,6 +433,16 @@ module Interface_API (R : RPC) = struct
       declare "Interface.get_ipv6_addr" ["Get IPv6 address"]
         (debug_info_p @-> iface_name_p @-> returning result err)
 
+    let get_ipv6_gateway =
+      let module T = struct
+        type _inet_addr_opt_t = Unix.inet_addr option [@@deriving rpcty]
+      end in
+      let result =
+        Param.mk ~description:["gateway address if exists"] T._inet_addr_opt_t
+      in
+      declare "Interface.get_ipv6_gateway" ["Get IPv6 gateway"]
+        (debug_info_p @-> iface_name_p @-> returning result err)
+
     let get_dns =
       let module T = struct
         type _dns_info_t = Unix.inet_addr list * string list [@@deriving rpcty]

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -331,13 +331,21 @@ let update_getty () =
 let set_gateway ~__context ~pif ~bridge =
   let dbg = Context.string_of_task __context in
   try
-    if Net.Interface.exists dbg bridge then
-      match Net.Interface.get_ipv4_gateway dbg bridge with
+    if Net.Interface.exists dbg bridge then (
+      ( match Net.Interface.get_ipv4_gateway dbg bridge with
       | Some addr ->
           Db.PIF.set_gateway ~__context ~self:pif
             ~value:(Unix.string_of_inet_addr addr)
       | None ->
           ()
+      ) ;
+      match Net.Interface.get_ipv6_gateway dbg bridge with
+      | Some addr ->
+          Db.PIF.set_ipv6_gateway ~__context ~self:pif
+            ~value:(Unix.string_of_inet_addr addr)
+      | None ->
+          ()
+    )
   with _ ->
     warn "Unable to get the gateway of PIF %s (%s)" (Ref.string_of pif) bridge
 


### PR DESCRIPTION
Read the default route for IPv6 and set it in the PIF