### PR TITLE
CP-43387: Fix VDI delta copy with NBD datapath connection

### DIFF
--- a/ocaml/tapctl/tapctl.ml
+++ b/ocaml/tapctl/tapctl.ml
@@ -532,3 +532,10 @@ let of_device ctx path =
       t
   | _ ->
       raise Not_found
+
+let find ctx ~pid ~minor =
+  match list ~t:{minor; tapdisk_pid= pid} ctx with
+  | [t] ->
+      t
+  | _ ->
+      raise Not_found

--- a/ocaml/tapctl/tapctl.mli
+++ b/ocaml/tapctl/tapctl.mli
@@ -91,3 +91,6 @@ exception Not_a_device
 
 val of_device : context -> string -> t
 (** Given a path to a device, return the corresponding tap information *)
+
+val find : context -> pid:int -> minor:int -> t
+(** Find tap given a tapdisk pid and a minor number *)


### PR DESCRIPTION
For disks that are backed by NBD rather than a blktap2 device, an update to sparse_dd is needed to be able to send a VHD difference disk when copying a VDI with respect to a base VDI. This will also be required for storage migration.

It is not feasible (efficient) to look at just the NBD exports of the two VDIs to determine the differences. The proper way to do this is to add functionality to the SMAPI to obtain the differences between two VDIs. We will look at this for SMAPIv3 a little later.

In the short term, we'll get sparse_dd to look at the VHD files behind the scenes. This is how it currently works for the blktap2 devices as well, where sparse_dd finds the VHD file from the minor number of the kernel block device.

The NBD server path exposed by tapdisk has its pid and the minor number encoded in it. This can be extracted and used to find the VHD file as above.