### PR TITLE
General improvements for Tracing

### DIFF
--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -91,7 +91,6 @@ module Span = struct
     ; events: SpanEvent.t list
     ; attributes: (string * string) list
   }
-  [@@deriving rpcty]
 
   let compare span1 span2 =
     SpanContext.(
@@ -191,13 +190,6 @@ module Span = struct
         {span with status= {status_code; description}}
     | _ ->
         span
-
-  let to_string s = Rpcmarshal.marshal t.Rpc.Types.ty s |> Jsonrpc.to_string
-
-  let of_string s =
-    Jsonrpc.of_string s
-    |> Rpcmarshal.unmarshal t.Rpc.Types.ty
-    |> Result.to_option
 end
 
 module Spans = struct

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -143,6 +143,7 @@ module Span = struct
             ("exception.message", msg)
           ; ("exception.stacktrace", stacktrace)
           ; ("exception.type", exn_type)
+          ; ("error", "true")
           ]
         in
         match span.status.status_code with

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -54,6 +54,11 @@ module Status = struct
   [@@deriving rpcty]
 end
 
+module SpanEvent = struct
+  type t = {name: string; time: float; attributes: (string * string) list}
+  [@@deriving rpcty]
+end
+
 module SpanContext = struct
   type t = {trace_id: string; span_id: string} [@@deriving rpcty]
 
@@ -83,6 +88,7 @@ module Span = struct
     ; begin_time: float
     ; end_time: float option
     ; links: SpanLink.t list
+    ; events: SpanEvent.t list
     ; attributes: (string * string) list
   }
   [@@deriving rpcty]
@@ -113,6 +119,7 @@ module Span = struct
     let end_time = None in
     let status : Status.t = {status_code= Status.Unset; description= None} in
     let links = [] in
+    let events = [] in
     {
       context
     ; span_kind
@@ -122,6 +129,7 @@ module Span = struct
     ; begin_time
     ; end_time
     ; links
+    ; events
     ; attributes
     }
 
@@ -139,6 +147,10 @@ module Span = struct
   let add_link span context attributes =
     let link : SpanLink.t = {context; attributes} in
     {span with links= link :: span.links}
+
+  let add_event span name attributes =
+    let event : SpanEvent.t = {name; time= Unix.gettimeofday (); attributes} in
+    {span with events= event :: span.events}
 
   let set_error span exn_t =
     match exn_t with
@@ -362,6 +374,7 @@ module Tracer = struct
     ; begin_time= Unix.gettimeofday ()
     ; end_time= None
     ; links= []
+    ; events= []
     ; attributes= []
     }
 

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -60,7 +60,7 @@ end
 module Tracer : sig
   type t
 
-  val span_of_span_context : t -> SpanContext.t -> string -> Span.t
+  val span_of_span_context : SpanContext.t -> string -> Span.t
 
   val start :
        tracer:t
@@ -94,7 +94,6 @@ val create :
      enabled:bool
   -> attributes:(string * string) list
   -> endpoints:string list
-  -> service_name:string
   -> name_label:string
   -> uuid:string
   -> unit
@@ -106,11 +105,13 @@ val get_tracer : name:string -> Tracer.t
 module Export : sig
   val set_export_interval : float -> unit
 
+  val set_host_id : string -> unit
+
+  val set_service_name : string -> unit
+
   module Destination : sig
     module File : sig
       val set_trace_log_dir : string -> unit
-
-      val set_host_id : string -> unit
     end
   end
 end

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -45,6 +45,8 @@ module Span : sig
 
   val add_link : t -> SpanContext.t -> (string * string) list -> t
 
+  val add_event : t -> string -> (string * string) list -> t
+
   val set_span_kind : t -> SpanKind.t -> t
 
   val get_tag : t -> string -> string

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -84,20 +84,16 @@ end
 
 val set :
      ?enabled:bool
-  -> ?tags:(string * string) list
+  -> ?attributes:(string * string) list
   -> ?endpoints:string list
-  -> ?filters:string list
-  -> ?processors:string list
   -> uuid:string
   -> unit
   -> unit
 
 val create :
      enabled:bool
-  -> tags:(string * string) list
+  -> attributes:(string * string) list
   -> endpoints:string list
-  -> filters:string list
-  -> processors:string list
   -> service_name:string
   -> name_label:string
   -> uuid:string

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -39,10 +39,6 @@ module Span : sig
 
   val get_context : t -> SpanContext.t
 
-  val of_string : string -> t option
-
-  val to_string : t -> string
-
   val add_link : t -> SpanContext.t -> (string * string) list -> t
 
   val add_event : t -> string -> (string * string) list -> t

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -43,6 +43,8 @@ module Span : sig
 
   val to_string : t -> string
 
+  val add_link : t -> SpanContext.t -> (string * string) list -> t
+
   val set_span_kind : t -> SpanKind.t -> t
 
   val get_tag : t -> string -> string

--- a/ocaml/tests/test_tracing.ml
+++ b/ocaml/tests/test_tracing.ml
@@ -20,8 +20,8 @@ open D
 let () = Printexc.record_backtrace true
 
 let _ =
-  create ~enabled:false ~name_label:"default" ~uuid:"123" ~tags:[]
-    ~endpoints:["bugtool"] ~processors:[] ~filters:[] ~service_name:"xapi" ;
+  create ~enabled:false ~name_label:"default" ~uuid:"123" ~attributes:[]
+    ~endpoints:["bugtool"] ~service_name:"xapi" ;
   main ()
 
 let start_test_span () =

--- a/ocaml/tests/test_tracing.ml
+++ b/ocaml/tests/test_tracing.ml
@@ -21,7 +21,7 @@ let () = Printexc.record_backtrace true
 
 let _ =
   create ~enabled:false ~name_label:"default" ~uuid:"123" ~attributes:[]
-    ~endpoints:["bugtool"] ~service_name:"xapi" ;
+    ~endpoints:["bugtool"] ;
   main ()
 
 let start_test_span () =

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -267,7 +267,7 @@ let make_dbg http_other_config task_name task_id =
       (if task_name = "" then "" else " ")
       (Ref.really_pretty_and_small task_id)
 
-let tracing_of_origin tracer (origin : origin) task_name =
+let tracing_of_origin (origin : origin) task_name =
   let open Tracing in
   let ( let* ) = Option.bind in
   let parent =
@@ -275,7 +275,7 @@ let tracing_of_origin tracer (origin : origin) task_name =
     | Http (req, _) ->
         let* traceparent = req.Http.Request.traceparent in
         let* span_context = SpanContext.of_traceparent traceparent in
-        let span = Tracer.span_of_span_context tracer span_context task_name in
+        let span = Tracer.span_of_span_context span_context task_name in
         Some span
     | _ ->
         None
@@ -304,7 +304,7 @@ let from_forwarded_task ?(http_other_config = []) ?session_id
   let tracing =
     let open Tracing in
     let tracer = get_tracer ~name:task_name in
-    let parent, span_kind = tracing_of_origin tracer origin task_name in
+    let parent, span_kind = tracing_of_origin origin task_name in
     match Tracer.start ~span_kind ~tracer ~name:task_name ~parent () with
     | Ok x ->
         x
@@ -361,7 +361,7 @@ let make ?(http_other_config = []) ?(quiet = false) ?subtask_of ?session_id
   let tracing =
     let open Tracing in
     let tracer = get_tracer ~name:task_name in
-    let parent, span_kind = tracing_of_origin tracer origin task_name in
+    let parent, span_kind = tracing_of_origin origin task_name in
     match Tracer.start ~span_kind ~tracer ~name:task_name ~parent () with
     | Ok x ->
         x

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -473,12 +473,13 @@ let make_remote_rpc_of_url ~verify_cert ~srcstr ~dststr (url, pool_secret) call
   XMLRPC_protocol.rpc ~transport ~srcstr ~dststr ~http call
 
 (* This one uses rpc-light *)
-let make_remote_rpc ?(verify_cert = Stunnel_client.pool ()) remote_address xml =
+let make_remote_rpc ?(verify_cert = Stunnel_client.pool ()) ~__context remote_address xml =
   let open Xmlrpc_client in
   let transport =
     SSL (SSL.make ~verify_cert (), remote_address, !Constants.https_port)
   in
-  let http = xmlrpc ~version:"1.0" "/" in
+  let tracing = Context.tracing_of __context in
+  let http = xmlrpc ~version:"1.0" ~tracing "/" in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_xapi" ~transport ~http xml
 
 (* Helper type for an object which may or may not be in the local database. *)

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -473,7 +473,8 @@ let make_remote_rpc_of_url ~verify_cert ~srcstr ~dststr (url, pool_secret) call
   XMLRPC_protocol.rpc ~transport ~srcstr ~dststr ~http call
 
 (* This one uses rpc-light *)
-let make_remote_rpc ?(verify_cert = Stunnel_client.pool ()) ~__context remote_address xml =
+let make_remote_rpc ?(verify_cert = Stunnel_client.pool ()) ~__context
+    remote_address xml =
   let open Xmlrpc_client in
   let transport =
     SSL (SSL.make ~verify_cert (), remote_address, !Constants.https_port)

--- a/ocaml/xapi/xapi_observer.ml
+++ b/ocaml/xapi/xapi_observer.ml
@@ -56,7 +56,6 @@ module Observer : ObserverInterface = struct
   let create ~__context ~uuid ~name_label ~attributes ~endpoints ~enabled =
     debug "Observer.create %s" uuid ;
     Tracing.create ~uuid ~name_label ~attributes ~endpoints ~enabled
-      ~service_name:"xapi"
 
   let destroy ~__context ~uuid =
     debug "Observer.destroy %s" uuid ;
@@ -96,7 +95,7 @@ module Observer : ObserverInterface = struct
 
   let set_host_id ~__context ~host_id =
     debug "Observer.set_host_id" ;
-    Tracing.Export.Destination.File.set_host_id host_id
+    Tracing.Export.set_host_id host_id
 end
 
 let supported_components = ["xapi"; "xenopsd"]
@@ -298,13 +297,14 @@ let load ~__context =
     all
 
 let initialise ~__context =
-  init ~__context ;
   load ~__context ;
   set_trace_log_dir ~__context !Xapi_globs.trace_log_dir ;
   set_export_interval ~__context !Xapi_globs.export_interval ;
   set_max_spans ~__context !Xapi_globs.max_spans ;
   set_max_traces ~__context !Xapi_globs.max_traces ;
-  set_host_id ~__context (Helpers.get_localhost_uuid ())
+  set_host_id ~__context (Helpers.get_localhost_uuid ()) ;
+  Tracing.Export.set_service_name "xapi" ;
+  init ~__context
 
 let set_hosts ~__context ~self ~value =
   assert_valid_hosts ~__context value ;

--- a/ocaml/xapi/xapi_observer.ml
+++ b/ocaml/xapi/xapi_observer.ml
@@ -153,8 +153,17 @@ let assert_valid_endpoints endpoints =
         true
     | url -> (
       try
-        let _ = Uri.of_string url in
-        true
+        let uri = Uri.of_string url in
+        let scheme = Uri.scheme uri in
+        let host = Uri.host uri in
+        (scheme = Some "http" || scheme = Some "https")
+        &&
+        match host with
+        | Some host ->
+            Result.is_ok (Ipaddr.of_string host)
+            || Result.is_ok (Domain_name.of_string host)
+        | _ ->
+            false
       with _ -> false
     )
   in

--- a/ocaml/xapi/xapi_observer.ml
+++ b/ocaml/xapi/xapi_observer.ml
@@ -55,8 +55,8 @@ end
 module Observer : ObserverInterface = struct
   let create ~__context ~uuid ~name_label ~attributes ~endpoints ~enabled =
     debug "Observer.create %s" uuid ;
-    Tracing.create ~uuid ~name_label ~tags:attributes ~endpoints ~processors:[]
-      ~filters:[] ~enabled ~service_name:"xapi"
+    Tracing.create ~uuid ~name_label ~attributes ~endpoints ~enabled
+      ~service_name:"xapi"
 
   let destroy ~__context ~uuid =
     debug "Observer.destroy %s" uuid ;
@@ -68,7 +68,7 @@ module Observer : ObserverInterface = struct
 
   let set_attributes ~__context ~uuid ~attributes =
     debug "Observer.set_attributes %s" uuid ;
-    Tracing.set ~uuid ~tags:attributes ()
+    Tracing.set ~uuid ~attributes ()
 
   let set_endpoints ~__context ~uuid ~endpoints =
     debug "Observer.set_endpoints %s" uuid ;

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -36,8 +36,8 @@ let no_exn f x =
   try ignore (f x)
   with exn -> debug "Ignoring exception: %s" (ExnHelper.string_of_exn exn)
 
-let rpc ~verify_cert host_address xml =
-  try Helpers.make_remote_rpc ~verify_cert host_address xml
+let rpc ~__context ~verify_cert host_address xml =
+  try Helpers.make_remote_rpc ~__context ~verify_cert host_address xml
   with Xmlrpc_client.Connection_reset ->
     raise
       (Api_errors.Server_error
@@ -1417,7 +1417,7 @@ let join_common ~__context ~master_address ~master_username ~master_password
     ~force =
   assert_pooling_licensed ~__context ;
   let new_pool_secret = ref (SecretString.of_string "") in
-  let unverified_rpc = rpc ~verify_cert:None master_address in
+  let unverified_rpc = rpc ~__context ~verify_cert:None master_address in
   let me = Helpers.get_localhost ~__context in
   let session_id =
     try
@@ -1456,7 +1456,7 @@ let join_common ~__context ~master_address ~master_username ~master_password
 
   (* Certificate exchange done, we must switch to verified pool connections as
      soon as possible *)
-  let rpc = rpc ~verify_cert:(Stunnel_client.pool ()) master_address in
+  let rpc = rpc ~__context ~verify_cert:(Stunnel_client.pool ()) master_address in
   let session_id =
     try
       Client.Session.login_with_password ~rpc ~uname:master_username

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1456,7 +1456,9 @@ let join_common ~__context ~master_address ~master_username ~master_password
 
   (* Certificate exchange done, we must switch to verified pool connections as
      soon as possible *)
-  let rpc = rpc ~__context ~verify_cert:(Stunnel_client.pool ()) master_address in
+  let rpc =
+    rpc ~__context ~verify_cert:(Stunnel_client.pool ()) master_address
+  in
   let session_id =
     try
       Client.Session.login_with_password ~rpc ~uname:master_username

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -111,10 +111,10 @@ let remote_of_dest ~__context dest =
   let rpc =
     match Db.Host.get_uuid ~__context ~self:dest_host with
     | _ ->
-        Helpers.make_remote_rpc remote_master_ip
+        Helpers.make_remote_rpc ~__context remote_master_ip
     | exception _ ->
         (* host unknown - this is a cross-pool migration *)
-        Helpers.make_remote_rpc ~verify_cert:None remote_master_ip
+        Helpers.make_remote_rpc ~__context ~verify_cert:None remote_master_ip
   in
   let sm_url =
     let url = List.assoc _sm dest in

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -4042,8 +4042,8 @@ module Observer = struct
     debug "Observer.create : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
       (fun () ->
-        Tracing.create ~uuid ~name_label ~tags:attributes ~filters:[]
-          ~processors:[] ~endpoints ~enabled ~service_name:"xenopsd"
+        Tracing.create ~uuid ~name_label ~attributes ~endpoints ~enabled
+          ~service_name:"xenopsd"
       )
       ()
 
@@ -4060,7 +4060,7 @@ module Observer = struct
   let set_attributes _ dbg uuid attributes =
     debug "Observer.set_attributes : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
-      (fun () -> Tracing.set ~uuid ~tags:attributes ())
+      (fun () -> Tracing.set ~uuid ~attributes ())
       ()
 
   let set_endpoints _ dbg uuid endpoints =

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -4043,7 +4043,6 @@ module Observer = struct
     Debug.with_thread_associated dbg
       (fun () ->
         Tracing.create ~uuid ~name_label ~attributes ~endpoints ~enabled
-          ~service_name:"xenopsd"
       )
       ()
 
@@ -4100,7 +4099,7 @@ module Observer = struct
   let set_host_id _ dbg host_id =
     debug "Observer.set_host_id : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
-      (fun () -> Tracing.Export.Destination.File.set_host_id host_id)
+      (fun () -> Tracing.Export.set_host_id host_id)
       ()
 end
 

--- a/ocaml/xenopsd/lib/xenops_task.ml
+++ b/ocaml/xenopsd/lib/xenops_task.ml
@@ -77,29 +77,13 @@ let parallel_id_with_tracing parallel_id t =
   | None ->
       parallel_id
 
-let traceparent_of_task t =
-  let ( let* ) = Option.bind in
-  let* tracing = Xenops_task.tracing t in
-  let* span = Tracing.Span.of_string tracing in
-  Tracing.Span.get_context span
-  |> Tracing.SpanContext.to_traceparent
-  |> Option.some
-
 let dbg_with_traceparent_of_task t =
   Option.fold ~none:(Xenops_task.get_dbg t)
     ~some:(fun traceparent -> Xenops_task.get_dbg t ^ "\x00" ^ traceparent)
-    (traceparent_of_task t)
+    (Xenops_task.tracing t)
 
 let traceparent_header_of_task t =
   Option.map
     (fun traceparent -> ("traceparent", traceparent))
-    (traceparent_of_task t)
+    (Xenops_task.tracing t)
   |> Option.to_list
-
-let tracing_of_traceparent name traceparent =
-  let open Tracing in
-  match Tracing.SpanContext.of_traceparent traceparent with
-  | None ->
-      None
-  | Some context ->
-      Some (Tracing.Tracer.span_of_span_context context name |> Span.to_string)

--- a/ocaml/xenopsd/lib/xenops_task.ml
+++ b/ocaml/xenopsd/lib/xenops_task.ml
@@ -98,12 +98,8 @@ let traceparent_header_of_task t =
 
 let tracing_of_traceparent name traceparent =
   let open Tracing in
-  let tracer = get_tracer ~name in
   match Tracing.SpanContext.of_traceparent traceparent with
   | None ->
       None
   | Some context ->
-      Some
-        (Tracing.Tracer.span_of_span_context tracer context name
-        |> Span.to_string
-        )
+      Some (Tracing.Tracer.span_of_span_context context name |> Span.to_string)

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -434,6 +434,8 @@ let log_uncaught_exception e bt =
 let main backend =
   Printexc.record_backtrace true ;
   Printexc.set_uncaught_exception_handler log_uncaught_exception ;
+  (* Set service name for Tracing *)
+  Tracing.Export.set_service_name "xenopsd" ;
   (* Listen for transferred file descriptors *)
   let forwarded_server =
     Xcp_service.make_socket_server (forwarded_path ()) handle_received_fd


### PR DESCRIPTION
General improvements to the library and instrumentation to improve performance, functionality and closeness to OTEL specification

1. Add error attribute to identify to UIs like jaeger that a span has an error contained
2. Ensure all uri endpoints passed to the API have a valid scheme and host
3. The `make_remote_rpc` in helpers.ml is given `__context` to it can send tracing information
4. Remove unneeded fields from tracer providers
5. Move `service_name` from `TracerProvider` into a library wide constant for a component
6.  Add SpanLink
7.  Add SpanEvent
8. Use w3c Format for sending tracing to Xenopsd

Commit messages need to be cleaned