### PR TITLE
CA-376879: VLAN PIF created in pool.join is shown as disconnected

### DIFF
--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -34,8 +34,9 @@ let pool_introduce ~__context ~tagged_PIF ~untagged_PIF ~tag ~other_config =
   let tagged_pif_metrics = Db.PIF.get_metrics ~__context ~self:tagged_PIF in
   if untagged_pif_metrics <> tagged_pif_metrics then (
     debug
-      "Set PIF_metrics (%s) of VLAN untagged PIF (%s) to the one (%s) of VLAN \
-       tagged PIF (%s)"
+      "%s: Set PIF_metrics (%s) of VLAN untagged PIF (%s) to the one (%s) of \
+       VLAN tagged PIF (%s)"
+      __FUNCTION__
       (Ref.string_of untagged_pif_metrics)
       (Ref.string_of untagged_PIF)
       (Ref.string_of tagged_pif_metrics)

--- a/ocaml/xapi/xapi_vlan.ml
+++ b/ocaml/xapi/xapi_vlan.ml
@@ -30,19 +30,19 @@ let pool_introduce ~__context ~tagged_PIF ~untagged_PIF ~tag ~other_config =
   (* Ensure that the untagged PIF shares PIF_metrics of tagged PIF.
    * This is useful for the VLANs created in pool.join for management network.
    *)
-  let metrics = Db.PIF.get_metrics ~__context ~self:untagged_PIF in
-  let metrics_of_tagged_pif = Db.PIF.get_metrics ~__context ~self:tagged_PIF in
-  if metrics <> metrics_of_tagged_pif then (
+  let untagged_pif_metrics = Db.PIF.get_metrics ~__context ~self:untagged_PIF in
+  let tagged_pif_metrics = Db.PIF.get_metrics ~__context ~self:tagged_PIF in
+  if untagged_pif_metrics <> tagged_pif_metrics then (
     debug
       "Set PIF_metrics (%s) of VLAN untagged PIF (%s) to the one (%s) of VLAN \
        tagged PIF (%s)"
-      (Ref.string_of metrics)
+      (Ref.string_of untagged_pif_metrics)
       (Ref.string_of untagged_PIF)
-      (Ref.string_of metrics_of_tagged_pif)
+      (Ref.string_of tagged_pif_metrics)
       (Ref.string_of tagged_PIF) ;
-    Db.PIF.set_metrics ~__context ~self:untagged_PIF
-      ~value:metrics_of_tagged_pif ;
-    if metrics <> Ref.null then Db.PIF_metrics.destroy ~__context ~self:metrics
+    Db.PIF.set_metrics ~__context ~self:untagged_PIF ~value:tagged_pif_metrics ;
+    if untagged_pif_metrics <> Ref.null then
+      Db.PIF_metrics.destroy ~__context ~self:untagged_pif_metrics
   ) ;
   vlan
 


### PR DESCRIPTION
The issue to be fixed in this commit is that when a host joins a pool in which the management network is on a VLAN network, the new untagged PIF of the joined host shows disconnected always.

Normally, the VLAN untagged PIF should share PIF_metrics with the tagged PIF so that the PIF_metrics could be updated correctly. This sharing is ensured by 'Xapi_vlan.create'. While in pool.join, the untagged PIF is created by 'Xapi_pif.pool_introduce', in which the 'metrics' of the new untagged PIF doesn't share with the tagged PIF. This causes the 'carrier' of 'metrics' of the new untagged PIF be 'false' forever. And consequenctly the management network shows disconnected always.

Can't switch to use 'Xapi_vlan.create' simply to fix this issue as the call can't set the "management" field of the untagged PIF correctly. The 'Xapi_pif.pool_introduce' can do this, but can't set the sharing of PIF_metrics correctly. What's more, from engineering's perspective, it is not worth to change these two API calls for this minor issue.

So the fix is as simple as to reset the PIF_metrics of untagged PIF to the one used by tagged PIF when creating the VLAN object in pool.join. In this case, the only drawback is an unused PIF_metrics is created and then destroyed in pool.join.