### PR TITLE
CA-375147: UPDATES_REQUIRE_SYNC when toolstack restarted on coordinator

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1929,8 +1929,6 @@ let _ =
       "The hash of updateinfo doesn't match with current one. There may be \
        newer available updates."
     () ;
-  error Api_errors.updates_require_sync []
-    ~doc:"A call to pool.sync_updates is required before this operation." () ;
   error Api_errors.cannot_restart_device_model ["ref"]
     ~doc:"Cannot restart device models of paused VMs residing on the host." () ;
   error Api_errors.invalid_repository_proxy_url ["url"]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1268,8 +1268,6 @@ let apply_guidance_failed = "APPLY_GUIDANCE_FAILED"
 
 let updateinfo_hash_mismatch = "UPDATEINFO_HASH_MISMATCH"
 
-let updates_require_sync = "UPDATES_REQUIRE_SYNC"
-
 let cannot_restart_device_model = "CANNOT_RESTART_DEVICE_MODEL"
 
 let invalid_repository_proxy_url = "INVALID_REPOSITORY_PROXY_URL"


### PR DESCRIPTION
For repository-based updates, the information of available updates on every host is stored in a cache (in memory) in XAPI process on coordinator. This cache aims to make the HTTP GET /updates requests responded quickly as a fast path. One drawback of this design is that the cache would be flushed when toolstack on coordinator restarted. As part of original design, if this happens, an error 'UPDATES_REQUIRE_SYNC' will be raised to clients so that HTTP-based users would get quick responses in all cases.

This commit aims to fill the cache again (but taking longer time) automatically instead of raising error 'UPDATES_REQUIRE_SYNC' when the cache has been flushed. This will simplify the XAPI call flow from client's perspective.