### PR TITLE
squeezed: fix link to architectural drawing

### DIFF
--- a/ocaml/squeezed/doc/architecture/README.md
+++ b/ocaml/squeezed/doc/architecture/README.md
@@ -6,7 +6,7 @@ Squeezed is responsible for managing the memory on a single host. Squeezed
 
 The following diagram shows the internals of Squeezed:
 
-![Internals of squeezed](http://xapi-project.github.io/squeezed/doc/architecture/squeezed.png)
+![Internals of squeezed](http://xapi-project.github.io/squeezed/architecture/squeezed.png)
 
 At the center of squeezed is an abstract model of a Xen host. The model includes
 - the amount of already-used host memory (used by fixed overheads such as Xen


### PR DESCRIPTION
This fixes the link from the github repo to the actual drawing.

What's unclear to me is that the contents of http://xapi-project.github.io/squeezed/architecture/architecture.html do look like they were generated from the docs in the same directory, except that
- it is not the case for this image
- the link to the image is the correct one there

The fact that the formatting of that doc does not parse/format the itemized list like github does is also annoying, and I mention it here in the case there would be a single thing to do to fix all those issues.