### PR TITLE
CP-42739: Bump `maven-javadoc-plugin` version used and skip building docs

### DIFF
--- a/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
+++ b/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
@@ -124,9 +124,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
+                        <!-- Skipping until the JSZip version used in the docs is bumped to 3.8.0 and above -->
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>


### PR DESCRIPTION
Skipping the docs until the `JSZip` version used in the docs is bumped to `v3.8.0`.

The latest available version of the plugin (`3.5.0`) uses `JSZip v3.7.1`.