### PR TITLE
Write bugtool exports in batches

### DIFF
--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -574,29 +574,75 @@ module Export = struct
     module File = struct
       let trace_log_dir = ref "/var/log/dt/zipkinv2/json"
 
+      let max_file_size = ref (1 lsl 20)
+
       let set_trace_log_dir dir = trace_log_dir := dir
 
-      let export ~trace_id ~span_json ~path : (string, exn) result =
-        try
-          let date = Ptime_clock.now () |> Ptime.to_rfc3339 ~frac_s:6 in
-          let file =
-            path
-            ^ String.concat "-" [trace_id; "xapi"; !host_id; date]
-            ^ ".json"
-          in
-          Xapi_stdext_unix.Unixext.mkdir_rec (Filename.dirname file) 0o700 ;
-          Xapi_stdext_unix.Unixext.write_string_to_file file span_json ;
-          Ok ""
-        with e -> Error e
+      let set_max_file_size size = max_file_size := size
+
+      let file_name = ref None
+
+      let file_stream = ref None
+
+      let lock = Mutex.create ()
+
+      let new_file_name () =
+        let date = Ptime_clock.now () |> Ptime.to_rfc3339 ~frac_s:6 in
+        let ( // ) = Filename.concat in
+        let name =
+          !trace_log_dir
+          // String.concat "-" [get_service_name (); !host_id; date]
+          ^ ".json"
+        in
+        file_name := Some name ;
+        name
+
+      let open_stream file_name =
+        Xapi_stdext_unix.Unixext.mkdir_rec (Filename.dirname file_name) 0o700 ;
+        file_stream :=
+          Some (Unix.openfile file_name [O_WRONLY; O_CREAT; O_APPEND] 0o700)
+
+      let close_stream () =
+        Option.iter (fun stream -> Unix.close stream) !file_stream ;
+        file_stream := None
+
+      let check () =
+        match (!file_stream, !file_name) with
+        | Some file_stream, _
+          when (Unix.fstat file_stream).st_size >= !max_file_size ->
+            close_stream () ;
+            new_file_name () |> open_stream
+        | None, None ->
+            new_file_name () |> open_stream
+        | None, Some file_name ->
+            open_stream file_name
+        | _ ->
+            (* We have an open fd which points to a file under the limit*)
+            ()
+
+      let write str =
+        Option.iter
+          (fun stream ->
+            let content = Bytes.of_string (str ^ "\n") in
+            ignore @@ Unix.write stream content 0 (Bytes.length content)
+          )
+          !file_stream
+
+      let export json = try check () ; write json ; Ok () with e -> Error e
+
+      let with_stream f =
+        Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+            f export ; close_stream ()
+        )
     end
 
     module Http = struct
       module Request = Cohttp.Request.Make (Cohttp_posix_io.Buffered_IO)
       module Response = Cohttp.Response.Make (Cohttp_posix_io.Buffered_IO)
 
-      let export ~span_json ~url : (string, exn) result =
+      let export ~url json =
         try
-          let body = span_json in
+          let body = json in
           let headers =
             Cohttp.Header.of_list
               [
@@ -617,7 +663,7 @@ module Export = struct
               Unix.shutdown fd Unix.SHUTDOWN_SEND ;
               match try Response.read ic with _ -> `Eof with
               | `Eof ->
-                  Ok ""
+                  Ok ()
               | `Invalid x ->
                   Error (Failure ("invalid read: " ^ x))
               | `Ok response ->
@@ -632,33 +678,34 @@ module Export = struct
                     | Cohttp.Transfer.Done ->
                         ()
                   in
-                  loop () ;
-                  Ok (Buffer.contents body)
+                  loop () ; Ok ()
           )
         with e -> Error e
     end
 
-    let export_to_endpoint span_list endpoint =
+    let export_to_endpoint traces endpoint =
+      debug "Tracing: About to export" ;
       try
-        debug "Tracing: About to export" ;
-        Hashtbl.iter
-          (fun trace_id span_list ->
-            let zipkin_spans = Content.Json.Zipkinv2.content_of span_list in
-            match
+        File.with_stream (fun file_export ->
+            let export =
               match endpoint with
               | Url url ->
-                  Http.export ~span_json:zipkin_spans ~url
+                  Http.export ~url
               | Bugtool ->
-                  File.export ~trace_id ~span_json:zipkin_spans
-                    ~path:!File.trace_log_dir
-            with
-            | Ok _ ->
-                ()
-            | Error e ->
-                raise e
-          )
-          span_list
-      with e -> debug "Tracing: ERROR %s" (Printexc.to_string e)
+                  file_export
+            in
+            Ok ()
+            |> Hashtbl.fold
+                 (fun _ spans result ->
+                   Content.Json.Zipkinv2.content_of spans
+                   |> export
+                   |> Result.fold ~ok:(fun () -> result) ~error:Result.error
+                 )
+                 traces
+            |> Result.iter_error raise
+        )
+      with exn ->
+        debug "Tracing : unable to export span : %s" (Printexc.to_string exn)
 
     let main () =
       enable_span_garbage_collector () ;

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -111,6 +111,8 @@ module Export : sig
 
   module Destination : sig
     module File : sig
+      val set_max_file_size : int -> unit
+
       val set_trace_log_dir : string -> unit
     end
   end

--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -1167,5 +1167,9 @@ module XenopsAPI (R : RPC) = struct
     let set_max_spans =
       declare "Observer.set_max_spans" []
         (debug_info_p @-> int_p @-> returning unit_p err)
+
+    let set_max_file_size =
+      declare "Observer.set_max_file_size" []
+        (debug_info_p @-> int_p @-> returning unit_p err)
   end
 end

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -993,6 +993,9 @@ let max_traces = ref 10000
 
 let prefer_nbd_attach = ref false
 
+(** 1 MiB *)
+let max_observer_file_size = ref (1 lsl 20)
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1075,6 +1078,7 @@ let xapi_globs_spec =
   ; ("export_interval", Float export_interval)
   ; ("max_spans", Int max_spans)
   ; ("max_traces", Int max_traces)
+  ; ("max_observer_file_size", Int max_observer_file_size)
   ]
 
 let options_of_xapi_globs_spec =
@@ -1452,6 +1456,11 @@ let other_options =
     , Arg.Set prefer_nbd_attach
     , (fun () -> string_of_bool !prefer_nbd_attach)
     , "Use NBD to attach disks to the control domain."
+    )
+  ; ( "observer-max-file-size"
+    , Arg.Set_int max_observer_file_size
+    , (fun () -> string_of_int !max_observer_file_size)
+    , "The maximum size of log files for saving spans"
     )
   ]
 

--- a/ocaml/xapi/xapi_observer.ml
+++ b/ocaml/xapi/xapi_observer.ml
@@ -49,6 +49,8 @@ module type ObserverInterface = sig
 
   val set_max_traces : __context:Context.t -> traces:int -> unit
 
+  val set_max_file_size : __context:Context.t -> file_size:int -> unit
+
   val set_host_id : __context:Context.t -> host_id:string -> unit
 end
 
@@ -92,6 +94,10 @@ module Observer : ObserverInterface = struct
   let set_max_traces ~__context ~traces =
     debug "Observer.set_max_traces" ;
     Tracing.Spans.set_max_traces traces
+
+  let set_max_file_size ~__context ~file_size =
+    debug "Observer.set_max_file_size" ;
+    Tracing.Export.Destination.File.set_max_file_size file_size
 
   let set_host_id ~__context ~host_id =
     debug "Observer.set_host_id" ;
@@ -269,6 +275,14 @@ let set_max_traces ~__context traces =
     )
     supported_components
 
+let set_max_file_size ~__context file_size =
+  List.iter
+    (fun c ->
+      let module Forwarder = (val get_forwarder c : ObserverInterface) in
+      Forwarder.set_max_file_size ~__context ~file_size
+    )
+    supported_components
+
 let set_host_id ~__context host_id =
   List.iter
     (fun c ->
@@ -302,6 +316,7 @@ let initialise ~__context =
   set_export_interval ~__context !Xapi_globs.export_interval ;
   set_max_spans ~__context !Xapi_globs.max_spans ;
   set_max_traces ~__context !Xapi_globs.max_traces ;
+  set_max_file_size ~__context !Xapi_globs.max_observer_file_size ;
   set_host_id ~__context (Helpers.get_localhost_uuid ()) ;
   Tracing.Export.set_service_name "xapi" ;
   init ~__context

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -4474,6 +4474,11 @@ module Observer = struct
     let dbg = Context.string_of_task __context in
     Client.Observer.set_max_traces dbg traces
 
+  let set_max_file_size ~__context ~file_size =
+    let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
+    let dbg = Context.string_of_task __context in
+    Client.Observer.set_max_file_size dbg file_size
+
   let set_host_id ~__context ~host_id =
     let module Client = (val make_client (default_xenopsd ()) : XENOPS) in
     let dbg = Context.string_of_task __context in

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -4103,6 +4103,12 @@ module Observer = struct
       (fun () -> Tracing.Spans.set_max_traces traces)
       ()
 
+  let set_max_file_size _ dbg file_size =
+    debug "Observer.set_max_file_size : dbg=%s" dbg ;
+    Debug.with_thread_associated dbg
+      (fun () -> Tracing.Export.Destination.File.set_max_file_size file_size)
+      ()
+
   let set_host_id _ dbg host_id =
     debug "Observer.set_host_id : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
@@ -4211,4 +4217,5 @@ let _ =
   Server.Observer.set_export_interval (Observer.set_export_interval ()) ;
   Server.Observer.set_max_spans (Observer.set_max_spans ()) ;
   Server.Observer.set_max_traces (Observer.set_max_traces ()) ;
+  Server.Observer.set_max_file_size (Observer.set_max_file_size ()) ;
   Server.Observer.set_host_id (Observer.set_host_id ())


### PR DESCRIPTION
Instead of writing a new file for every trace we export, write into files split into 1mb batches. This will save disk space as the number of files will be drastically reduced.