### PR TITLE
Add new fields to SpanContext

### DIFF
--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -91,6 +91,7 @@ module Request : sig
     ; additional_headers: (string * string) list
     ; body: string option
     ; traceparent: string option
+    ; tracestate: string option
   }
 
   val rpc_of_t : t -> Rpc.t
@@ -114,6 +115,7 @@ module Request : sig
     -> ?host:string
     -> ?query:(string * string) list
     -> ?traceparent:string
+    -> ?tracestate:string
     -> user_agent:string
     -> method_t
     -> string
@@ -233,6 +235,8 @@ module Hdr : sig
   val location : string
 
   val traceparent : string
+
+  val tracestate : string
 end
 
 val output_http : Unix.file_descr -> string list -> unit

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -401,6 +401,8 @@ let request_of_bio_exn ~proxy_seen ~read_timeout ~total_timeout ~max_length bio
                        {req with user_agent= Some v}
                    | k when k = Http.Hdr.traceparent ->
                        {req with traceparent= Some v}
+                   | k when k = Http.Hdr.tracestate ->
+                       {req with tracestate= Some v}
                    | k when k = Http.Hdr.connection && lowercase v = "close" ->
                        {req with close= true}
                    | k

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -9,6 +9,7 @@
     rpclib.json
     xapi-idl
     xapi-stdext-unix
+    hex
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -130,6 +130,18 @@ module SpanContext = struct
     | tracestate ->
         Some tracestate
 
+  let tracestate_get key t = List.assoc_opt key t.tracestate
+
+  let tracestate_delete key t =
+    let tracestate = List.filter (fun (k, _) -> k <> key) t.tracestate in
+    {t with tracestate}
+
+  let tracestate_replace key value t =
+    let tracestate =
+      (key, value) :: List.filter (fun (k, _) -> k <> key) t.tracestate
+    in
+    {t with tracestate}
+
   let of_traceparent ?tracestate traceparent =
     let tracestate =
       Option.fold ~none:[]

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -78,15 +78,77 @@ module SpanEvent = struct
 end
 
 module SpanContext = struct
-  type t = {trace_id: string; span_id: string} [@@deriving rpcty]
+  type t = {
+      trace_id: string
+    ; span_id: string
+    ; trace_flags: char
+    ; tracestate: (string * string) list
+    ; is_remote: bool
+  }
 
-  let to_traceparent t = Printf.sprintf "00-%s-%s-00" t.trace_id t.span_id
+  let char_to_octet c =
+    Hex.of_char c |> fun (a, b) -> String.of_seq Seq.(cons a (return b))
 
-  let of_traceparent traceparent =
+  let char_of_octet f =
+    try "0x" ^ f |> int_of_string |> char_of_int with _ -> '\x00'
+
+  let is_valid t =
+    String.exists (( <> ) '0') t.span_id
+    && String.exists (( <> ) '0') t.trace_id
+
+  let generate_id n = String.init n (fun _ -> "0123456789abcdef".[Random.int 16])
+
+  let rec create sampled parent =
+    let span_id = generate_id 8 in
+    let trace_flags = if sampled then '\x01' else '\x00' in
+    match parent with
+    | None ->
+        let trace_id = generate_id 16 in
+        let t =
+          {trace_id; span_id; trace_flags; tracestate= []; is_remote= false}
+        in
+        if is_valid t then t else create sampled None
+    | Some parent ->
+        let trace_id = parent.trace_id in
+        let tracestate = parent.tracestate in
+        let is_remote = false in
+        let t = {trace_id; span_id; trace_flags; tracestate; is_remote} in
+        if is_valid t then t else create sampled (Some parent)
+
+  let to_traceparent t =
+    Printf.sprintf "00-%s-%s-%s" t.trace_id t.span_id
+      (char_to_octet t.trace_flags)
+
+  let to_tracestate t =
+    match
+      t.tracestate |> List.map (fun (k, v) -> k ^ "=" ^ v) |> String.concat ","
+    with
+    | "" ->
+        None
+    | tracestate ->
+        Some tracestate
+
+  let of_traceparent ?tracestate traceparent =
+    let tracestate =
+      Option.fold ~none:[]
+        ~some:(fun s ->
+          String.split_on_char ',' s
+          |> List.filter_map (fun kv ->
+                 match String.split_on_char '=' kv with
+                 | [k; v] ->
+                     Some (k, v)
+                 | _ ->
+                     None
+             )
+        )
+        tracestate
+    in
     let elements = String.split_on_char '-' traceparent in
     match elements with
-    | ["00"; trace_id; span_id; "00"] ->
-        Some {trace_id; span_id}
+    | ["00"; trace_id; span_id; flags] ->
+        let trace_flags = char_of_octet flags in
+        let is_remote = true in
+        Some {trace_id; span_id; trace_flags; tracestate; is_remote}
     | _ ->
         None
 end
@@ -100,7 +162,7 @@ module Span = struct
       context: SpanContext.t
     ; span_kind: SpanKind.t
     ; status: Status.t
-    ; parent: t option
+    ; parent: SpanContext.t option
     ; name: string
     ; begin_time: float
     ; end_time: float option
@@ -118,18 +180,15 @@ module Span = struct
 
   let get_context t = t.context
 
-  let generate_id n = String.init n (fun _ -> "0123456789abcdef".[Random.int 16])
-
   let start ?(attributes = Attributes.empty) ~name ~parent ~span_kind () =
-    let trace_id =
-      match parent with
-      | None ->
-          generate_id 32
-      | Some span_parent ->
-          span_parent.context.trace_id
-    in
-    let span_id = generate_id 16 in
-    let context : SpanContext.t = {trace_id; span_id} in
+    let parent = Option.map (fun s -> s.context) parent in
+    Option.iter
+      (fun parent ->
+        if not (SpanContext.is_valid parent) then
+          failwith "Tracing: parent span has invalid context. Not starting"
+      )
+      parent ;
+    let context = SpanContext.create true parent in
     (* Using gettimeofday over Mtime as it is better for sharing timestamps between the systems *)
     let begin_time = Unix.gettimeofday () in
     let end_time = None in
@@ -596,9 +655,9 @@ module Export = struct
               s.events
           in
           {
-            id= s.context.span_id
-          ; traceId= s.context.trace_id
-          ; parentId= Option.map (fun x -> x.Span.context.span_id) s.parent
+            id= s.Span.context.span_id
+          ; traceId= s.Span.context.trace_id
+          ; parentId= Option.map (fun x -> x.SpanContext.span_id) s.parent
           ; name= s.name
           ; timestamp= int_of_float (s.begin_time *. 1000000.)
           ; duration=

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -98,6 +98,8 @@ module SpanContext = struct
 
   let generate_id n = String.init n (fun _ -> "0123456789abcdef".[Random.int 16])
 
+  let is_sampled t = Char.code t.trace_flags mod 2 <> 1
+
   let rec create sampled parent =
     let span_id = generate_id 8 in
     let trace_flags = if sampled then '\x01' else '\x00' in
@@ -180,7 +182,8 @@ module Span = struct
 
   let get_context t = t.context
 
-  let start ?(attributes = Attributes.empty) ~name ~parent ~span_kind () =
+  let start ?(sampled = true) ?(attributes = Attributes.empty) ~name ~parent
+      ~span_kind () =
     let parent = Option.map (fun s -> s.context) parent in
     Option.iter
       (fun parent ->
@@ -188,7 +191,7 @@ module Span = struct
           failwith "Tracing: parent span has invalid context. Not starting"
       )
       parent ;
-    let context = SpanContext.create true parent in
+    let context = SpanContext.create sampled parent in
     (* Using gettimeofday over Mtime as it is better for sharing timestamps between the systems *)
     let begin_time = Unix.gettimeofday () in
     let end_time = None in
@@ -322,15 +325,18 @@ module Spans = struct
 
   let add_to_finished span =
     let key = span.Span.context.trace_id in
-    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
-        match Hashtbl.find_opt finished_spans key with
-        | None ->
-            if Hashtbl.length finished_spans < !max_traces then
-              Hashtbl.add finished_spans key [span]
-        | Some span_list ->
-            if List.length span_list < !max_spans then
-              Hashtbl.replace finished_spans key (span :: span_list)
-    )
+    if SpanContext.is_sampled span.Span.context then
+      ()
+    else
+      Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+          match Hashtbl.find_opt finished_spans key with
+          | None ->
+              if Hashtbl.length finished_spans < !max_traces then
+                Hashtbl.add finished_spans key [span]
+          | Some span_list ->
+              if List.length span_list < !max_spans then
+                Hashtbl.replace finished_spans key (span :: span_list)
+      )
 
   let mark_finished span = Option.iter add_to_finished (remove_from_spans span)
 
@@ -349,9 +355,18 @@ module Spans = struct
   (** since copies the existing finished spans and then clears the existing spans as to only export them once  *)
   let since () =
     Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
-        let copy = Hashtbl.copy finished_spans in
-        Hashtbl.clear finished_spans ;
-        copy
+        let finished_traces = Hashtbl.create 100 in
+        Hashtbl.filter_map_inplace
+          (fun trace_id spans ->
+            match spans with
+            | root :: _ when root.Span.parent = None ->
+                Hashtbl.add finished_traces trace_id spans ;
+                None
+            | _ ->
+                Some spans
+          )
+          finished_spans ;
+        finished_traces
     )
 
   let dump () = Hashtbl.(copy spans, Hashtbl.copy finished_spans)

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -36,6 +36,12 @@ module SpanContext : sig
   val of_traceparent : ?tracestate:string -> string -> t option
 
   val to_tracestate : t -> string option
+
+  val tracestate_get : string -> t -> string option
+
+  val tracestate_delete : string -> t -> t
+
+  val tracestate_replace : string -> string -> t -> t
 end
 
 module Span : sig

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -29,9 +29,13 @@ end
 module SpanContext : sig
   type t
 
+  val is_valid : t -> bool
+
   val to_traceparent : t -> string
 
-  val of_traceparent : string -> t option
+  val of_traceparent : ?tracestate:string -> string -> t option
+
+  val to_tracestate : t -> string option
 end
 
 module Span : sig

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -279,11 +279,21 @@ let tracing_of_origin (origin : origin) task_name =
   let ( let* ) = Option.bind in
   let parent =
     match origin with
-    | Http (req, _) ->
-        let* traceparent = req.Http.Request.traceparent in
-        let* span_context = SpanContext.of_traceparent traceparent in
-        let span = Tracer.span_of_span_context span_context task_name in
-        Some span
+    | Http (req, _) -> (
+        let tracestate = req.Http.Request.traceparent in
+        let traceparent = req.Http.Request.traceparent in
+        match (traceparent, tracestate) with
+        | None, _ ->
+            None
+        | Some traceparent, None ->
+            let* span_context = SpanContext.of_traceparent traceparent in
+            Some (Tracer.span_of_span_context span_context task_name)
+        | Some traceparent, Some tracestate ->
+            let* span_context =
+              SpanContext.of_traceparent ~tracestate traceparent
+            in
+            Some (Tracer.span_of_span_context span_context task_name)
+      )
     | _ ->
         None
   in


### PR DESCRIPTION
Based off the OpenTelemetry specification **[here](https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext)**, add more methods and fields to the SpanContext. This also includes adding `tracestate` as a header to `http_svr` and using sampling based off the new flags field.  