### PR TITLE
Remove most vTPM restrictions

### DIFF
--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -423,13 +423,6 @@ let clone ?snapshot_info_record ?(ignore_vdis = []) disk_op ~__context ~vm
       let vgpus = Db.VM.get_VGPUs ~__context ~self:vm in
       let vtpms = Db.VM.get_VTPMs ~__context ~self:vm in
       let power_state = Db.VM.get_power_state ~__context ~self:vm in
-      ( match (power_state, vtpms) with
-      | `Running, _ :: _ ->
-          let message = "VM.clone of running VM with VTPM" in
-          Helpers.maybe_raise_vtpm_unimplemented __FUNCTION__ message
-      | _ ->
-          ()
-      ) ;
       (* If a VM is snapshotted, then the new VM must remain halted.
          Otherwise, we keep the same power-state as the initial VM *)
       let new_power_state =

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1757,12 +1757,6 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
              )
           ) ;
       let power_state = Db.VM.get_power_state ~__context ~self:vm in
-      (* VTPMs can't be exported currently, which will make the migration fail *)
-      ( if power_state <> `Halted && Db.VM.get_VTPMs ~__context ~self:vm <> []
-      then
-          let message = "Cross-pool VM migration with VTPMs attached" in
-          Helpers.maybe_raise_vtpm_unimplemented __FUNCTION__ message
-      ) ;
       (* Check VDIs are not migrating to or from an SR which doesn't have required_sr_operations *)
       assert_sr_support_operations ~__context ~vdi_map ~remote
         ~ops:required_sr_operations ;

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -73,15 +73,7 @@ let compare_snapid_chunks s1 s2 =
 let checkpoint ~__context ~vm ~new_name =
   Xapi_vmss.show_task_in_xencenter ~__context ~vm ;
   let power_state = Db.VM.get_power_state ~__context ~self:vm in
-  let vtpms = Db.VM.get_VTPMs ~__context ~self:vm in
   let snapshot_info = ref [] in
-  ( match (power_state, vtpms) with
-  | `Running, _ :: _ ->
-      let message = "VM.checkpoint of running VM with VTPM" in
-      Helpers.maybe_raise_vtpm_unimplemented __FUNCTION__ message
-  | _ ->
-      ()
-  ) ;
   (* live-suspend the VM if the VM is running *)
   ( if power_state = `Running then
       try

--- a/ocaml/xapi/xapi_vtpm.ml
+++ b/ocaml/xapi/xapi_vtpm.ml
@@ -27,19 +27,6 @@ let assert_not_restricted ~__context =
   | _ ->
       raise Api_errors.(Server_error (feature_restricted, [feature]))
 
-(** The state in the xapi backend is only up-to-date when the VMs are halted *)
-let assert_no_fencing ~__context ~persistence_backend =
-  let pool = Helpers.get_pool ~__context in
-  let ha_enabled = Db.Pool.get_ha_enabled ~__context ~self:pool in
-  let clustering_enabled = Db.Cluster.get_all ~__context <> [] in
-  let may_fence = ha_enabled || clustering_enabled in
-  match (persistence_backend, may_fence) with
-  | `xapi, true ->
-      let message = "VTPM.create with HA or clustering enabled" in
-      Helpers.maybe_raise_vtpm_unimplemented __FUNCTION__ message
-  | _ ->
-      ()
-
 let assert_no_vtpm_associated ~__context vm =
   match Db.VM.get_VTPMs ~__context ~self:vm with
   | [] ->
@@ -75,7 +62,6 @@ let copy_or_create_contents ~__context ?from () =
 let create ~__context ~vM ~is_unique =
   let persistence_backend = `xapi in
   assert_not_restricted ~__context ;
-  assert_no_fencing ~__context ~persistence_backend ;
   assert_no_vtpm_associated ~__context vM ;
   Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self:vM
     ~expected:`Halted ;

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -58,7 +58,7 @@ structural-equality () {
 }
 
 vtpm-unimplemented () {
-  N=4
+  N=3
   VTPM=$(git grep -r --count 'maybe_raise_vtpm_unimplemented' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$VTPM" -eq "$N" ]; then
     echo "OK found $VTPM usages of vtpm unimplemented errors"

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -58,7 +58,7 @@ structural-equality () {
 }
 
 vtpm-unimplemented () {
-  N=7
+  N=4
   VTPM=$(git grep -r --count 'maybe_raise_vtpm_unimplemented' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$VTPM" -eq "$N" ]; then
     echo "OK found $VTPM usages of vtpm unimplemented errors"


### PR DESCRIPTION
We are moving to a new backend for vTPM state storage that is updated as soon as the swTPM updates it. This permits to remove some restrictions that are in place to prohibit vTPM state being lost.

* cloning of a running VM
* cross-pool migration of a running VM
* checkpointing of a running VM
* creating a vTPM on a VM that is protected by high availability (HA)

One restriction remains in place: we still can't create a vTPM for a VM with a BIOS (in contrast to UEFI).
