### PR TITLE
CA-354436: pool.is_slave took a long time to respond

### DIFF
--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -319,7 +319,8 @@ let do_db_xml_rpc_persistent_with_reopen ~host:_ ~path (req : string) :
           !backoff_delay ;
         let timed_out = Scheduler.PipeDelay.wait delay !backoff_delay in
         if not timed_out then
-          debug "%s: Wake up and retry connecting" __FUNCTION__ ;
+          debug "%s: Sleep interrupted, retrying master connection now"
+            __FUNCTION__ ;
         update_backoff_delay () ;
         try open_secure_connection () with _ -> ()
         (* oh well, maybe nextime... *)

--- a/ocaml/xapi-idl/lib/scheduler.mli
+++ b/ocaml/xapi-idl/lib/scheduler.mli
@@ -47,3 +47,18 @@ val one_shot : t -> time -> string -> (unit -> unit) -> handle
 
 val cancel : t -> handle -> unit
 (** Cancel an item *)
+
+(** The PipeDelay module here implements simple cancellable delays. *)
+module PipeDelay : sig
+  type t
+
+  val make : unit -> t
+  (** Makes a PipeDelay.t *)
+
+  val wait : t -> float -> bool
+  (** Wait for the specified amount of time. Returns true if we waited the full
+      length of time, false if we were woken *)
+
+  val signal : t -> unit
+  (** Signal anyone currently waiting with the PipeDelay.t *)
+end

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2120,6 +2120,7 @@ let is_slave ~__context ~host:_ =
   debug
     "About to kick the database connection to make sure it's still working..." ;
   let (_ : bool) =
+    Scheduler.PipeDelay.signal Master_connection.delay ;
     Db.is_valid_ref __context
       (Ref.of_string
          "Pool.is_slave checking to see if the database connection is up"


### PR DESCRIPTION
This commit is to fix an issue which may be hit when the pool coordinator is rebooting or its XAPI is restarting.

In either of the cases, other pool members keep trying to connect to the coordinator for DB connections. This connecting holds the DB lock until a timer expired. And the timer uses exponential backoff to avoid overload the coordinator. The maximum of the timer is 256 seconds.

Meanwhile in starting up, the XAPI in coordinator will issue XAPI call pool.is_slave to every pool member. This call on every pool member will try to acquire the DB lock as well and hence be blocked by the re-connecting mentioned above. In the worst case, the start-up of XAPI would be delayed up to more than 4 minutes (256 seconds).

The idea of this commit is that since the pool.is_slave is issued from the coordinator, it is reasonable to abort the waiting for the timer expiry and try connecting again.