### PR TITLE
Trace Export functions to monitor performance 

### DIFF
--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -134,6 +134,8 @@ module Export : sig
   end
 end
 
+val set_observe : bool -> unit
+
 val validate_attribute : string * string -> bool
 
 val main : unit -> Thread.t

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -66,6 +66,7 @@ module Tracer : sig
 
   val start :
        tracer:t
+    -> ?attributes:(string * string) list
     -> ?span_kind:SpanKind.t
     -> name:string
     -> parent:Span.t option

--- a/ocaml/tests/test_observer.ml
+++ b/ocaml/tests/test_observer.ml
@@ -26,7 +26,8 @@ let trace_log_dir ?(test_name = "") () =
 
 let () =
   Export.Destination.File.set_trace_log_dir (trace_log_dir ()) ;
-  Export.set_service_name "unit_tests"
+  Export.set_service_name "unit_tests" ;
+  set_observe false
 
 module Xapi_DB = struct
   let assert_num_observers ~__context x =


### PR DESCRIPTION
Given concerns that exporting over http was being slow, this pull request will create spans that measure how performant the Export functions are.