### PR TITLE
CP-40204, CA-366396: Add "host.up_to_date", remove "repository.up_to_date"

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1761,6 +1761,24 @@ let apply_recommended_guidances =
       ]
     ~allowed_roles:_R_POOL_OP ()
 
+let up_to_date_state =
+  Enum
+    ( "up_to_date_state"
+    , [
+        ( "yes"
+        , "The host is up to date with the latest updates synced from remote \
+           CDN"
+        )
+      ; ( "no"
+        , "The host is outdated with the latest updates synced from remote CDN"
+        )
+      ; ( "unknown"
+        , "If the host is up to date with the latest updates synced from \
+           remote CDN is unknown"
+        )
+      ]
+    )
+
 (** Hosts *)
 let t =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303
@@ -2120,6 +2138,10 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "recommended_guidances" ~default_value:(Some (VSet []))
             "The set of recommended guidances after applying updates"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:up_to_date_state
+            "up_to_date" ~default_value:(Some (VEnum "unknown"))
+            "Default as 'unknown', 'yes' if the host is up to date with \
+             updates synced from remote CDN, otherwise 'no'"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1761,9 +1761,9 @@ let apply_recommended_guidances =
       ]
     ~allowed_roles:_R_POOL_OP ()
 
-let up_to_date_state =
+let latest_synced_updates_applied_state =
   Enum
-    ( "up_to_date_state"
+    ( "latest_synced_updates_applied_state"
     , [
         ( "yes"
         , "The host is up to date with the latest updates synced from remote \
@@ -2138,8 +2138,10 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "recommended_guidances" ~default_value:(Some (VSet []))
             "The set of recommended guidances after applying updates"
-        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:up_to_date_state
-            "up_to_date" ~default_value:(Some (VEnum "unknown"))
+        ; field ~qualifier:DynamicRO ~lifecycle:[]
+            ~ty:latest_synced_updates_applied_state
+            "latest_synced_updates_applied"
+            ~default_value:(Some (VEnum "unknown"))
             "Default as 'unknown', 'yes' if the host is up to date with \
              updates synced from remote CDN, otherwise 'no'"
         ]

--- a/ocaml/idl/datamodel_repository.ml
+++ b/ocaml/idl/datamodel_repository.ml
@@ -173,7 +173,15 @@ let t =
           "SHA256 checksum of latest updateinfo.xml.gz in this repository if \
            its 'update' is true"
       ; field ~qualifier:DynamicRO
-          ~lifecycle:[(Published, "1.301.0", "")]
+          ~lifecycle:
+            [
+              (Published, "1.301.0", "")
+            ; (Deprecated, "23.12.0-next", "Dummy transition")
+            ; ( Removed
+              , "23.12.0-next"
+              , "The up_to_date field of repository was removed"
+              )
+            ]
           ~ty:Bool ~default_value:(Some (VBool false)) "up_to_date"
           "True if all hosts in pool is up to date with this repository"
       ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:String

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "5c33f8540b222e679c1330c47b9a71d6"
+let last_known_schema_hash = "38e60e8505eb7dc40f83351a2f57cd44"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "38e60e8505eb7dc40f83351a2f57cd44"
+let last_known_schema_hash = "e4b05b704ead950588fa07cd9123837c"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -208,7 +208,7 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
-    ~recommended_guidances:[] ;
+    ~recommended_guidances:[] ~up_to_date:`unknown ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -208,7 +208,7 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
-    ~recommended_guidances:[] ~up_to_date:`unknown ;
+    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -208,6 +208,14 @@ let update_guidance_to_string = function
   | `restart_device_model ->
       "restart_device_model"
 
+let up_to_date_state_to_string = function
+  | `yes ->
+      "yes"
+  | `no ->
+      "no"
+  | `unknown ->
+      "unknown"
+
 let vdi_operation_to_string : API.vdi_operations -> string = function
   | `clone ->
       "clone"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -208,7 +208,7 @@ let update_guidance_to_string = function
   | `restart_device_model ->
       "restart_device_model"
 
-let up_to_date_state_to_string = function
+let latest_synced_updates_applied_state_to_string = function
   | `yes ->
       "yes"
   | `no ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3238,6 +3238,11 @@ let host_record rpc session_id host =
               (x ()).API.host_recommended_guidances
           )
           ()
+      ; make_field ~name:"up-to-date"
+          ~get:(fun () ->
+            Record_util.up_to_date_state_to_string (x ()).API.host_up_to_date
+          )
+          ()
       ]
   }
 
@@ -5222,9 +5227,6 @@ let repository_record rpc session_id repository =
           ~get:(fun () -> string_of_bool (x ()).API.repository_update)
           ()
       ; make_field ~name:"hash" ~get:(fun () -> (x ()).API.repository_hash) ()
-      ; make_field ~name:"up-to-date"
-          ~get:(fun () -> string_of_bool (x ()).API.repository_up_to_date)
-          ()
       ; make_field ~name:"gpgkey-path"
           ~get:(fun () -> (x ()).API.repository_gpgkey_path)
           ~set:(fun x ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3238,9 +3238,10 @@ let host_record rpc session_id host =
               (x ()).API.host_recommended_guidances
           )
           ()
-      ; make_field ~name:"up-to-date"
+      ; make_field ~name:"latest-synced-updates-applied"
           ~get:(fun () ->
-            Record_util.up_to_date_state_to_string (x ()).API.host_up_to_date
+            Record_util.latest_synced_updates_applied_state_to_string
+              (x ()).API.host_latest_synced_updates_applied
           )
           ()
       ]

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1039,7 +1039,7 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled ~last_software_update:Date.never
-    ~recommended_guidances:[] ;
+    ~recommended_guidances:[] ~up_to_date:`unknown ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;
@@ -2992,6 +2992,7 @@ let apply_updates ~__context ~self ~hash =
   in
   Db.Host.set_last_software_update ~__context ~self
     ~value:(get_servertime ~__context ~host:self) ;
+  Db.Host.set_up_to_date ~__context ~self ~value:`yes ;
   List.map
     (fun g ->
       [

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1039,7 +1039,7 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled ~last_software_update:Date.never
-    ~recommended_guidances:[] ~up_to_date:`unknown ;
+    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;
@@ -2992,7 +2992,7 @@ let apply_updates ~__context ~self ~hash =
   in
   Db.Host.set_last_software_update ~__context ~self
     ~value:(get_servertime ~__context ~host:self) ;
-  Db.Host.set_up_to_date ~__context ~self ~value:`yes ;
+  Db.Host.set_latest_synced_updates_applied ~__context ~self ~value:`yes ;
   List.map
     (fun g ->
       [

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1562,6 +1562,7 @@ let join_common ~__context ~master_address ~master_username ~master_password
             "Unable to set the write the new pool certificates to the disk : %s"
             (ExnHelper.string_of_exn e)
       ) ;
+      Db.Host.set_up_to_date ~__context ~self:me ~value:`unknown ;
       (* this is where we try and sync up as much state as we can
          with the master. This is "best effort" rather than
          critical; if we fail part way through this then we carry
@@ -3344,7 +3345,6 @@ let set_repositories ~__context ~self ~value =
     (fun x ->
       if not (List.mem x existings) then (
         Db.Repository.set_hash ~__context ~self:x ~value:"" ;
-        Db.Repository.set_up_to_date ~__context ~self:x ~value:false ;
         Repository.reset_updates_in_cache ()
       )
     )
@@ -3360,7 +3360,6 @@ let add_repository ~__context ~self ~value =
   if not (List.mem value existings) then (
     Db.Pool.add_repositories ~__context ~self ~value ;
     Db.Repository.set_hash ~__context ~self:value ~value:"" ;
-    Db.Repository.set_up_to_date ~__context ~self:value ~value:false ;
     Repository.reset_updates_in_cache ()
   )
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1562,7 +1562,8 @@ let join_common ~__context ~master_address ~master_username ~master_password
             "Unable to set the write the new pool certificates to the disk : %s"
             (ExnHelper.string_of_exn e)
       ) ;
-      Db.Host.set_up_to_date ~__context ~self:me ~value:`unknown ;
+      Db.Host.set_latest_synced_updates_applied ~__context ~self:me
+        ~value:`unknown ;
       (* this is where we try and sync up as much state as we can
          with the master. This is "best effort" rather than
          critical; if we fail part way through this then we carry


### PR DESCRIPTION
In repository-based continuous update, XAPI users/clients would like to know if the versions of software installed on individual hosts are consistent in a CH pool.

The consistency was defined as "a host is running same versions of everything as the coordinator" in hotfix-based discrete update.

Now the consistency is defined as "a host is running same versions of everything as the latest ones known in last pool.sync_updates".

Therefore, a new boolean filed "host.up_to_date" should be added as the indicator.

This field should be set in:

    pool.sync_updates, and
    host.apply_updates