### PR TITLE
CP-42999: Return new "preview" in return of v6 "get_version"

### DIFF
--- a/ocaml/xapi-idl/lib_test/test_data/v6/responses/get_version.response.0
+++ b/ocaml/xapi-idl/lib_test/test_data/v6/responses/get_version.response.0
@@ -13,14 +13,8 @@
             <value>
               <struct>
                 <member>
-                  <name>dbv</name>
-                  <value>dbv</value>
-                </member>
-                <member>
-                  <name>preview</name>
-                  <value>
-                    <boolean>1</boolean>
-                  </value>
+                  <name>string_pair_lst</name>
+                  <value>string_pair_lst</value>
                 </member>
               </struct>
             </value>

--- a/ocaml/xapi-idl/lib_test/test_data/v6/responses/get_version.response.0
+++ b/ocaml/xapi-idl/lib_test/test_data/v6/responses/get_version.response.0
@@ -1,1 +1,32 @@
-<?xml version="1.0"?><methodResponse><params><param><value><struct><member><name>Status</name><value>Success</value></member><member><name>Value</name><value>string</value></member></struct></value></param></params></methodResponse>
+<?xml version="1.0"?>
+<methodResponse>
+  <params>
+    <param>
+      <value>
+        <struct>
+          <member>
+            <name>Status</name>
+            <value>Success</value>
+          </member>
+          <member>
+            <name>Value</name>
+            <value>
+              <struct>
+                <member>
+                  <name>dbv</name>
+                  <value>dbv</value>
+                </member>
+                <member>
+                  <name>preview</name>
+                  <value>
+                    <boolean>1</boolean>
+                  </value>
+                </member>
+              </struct>
+            </value>
+          </member>
+        </struct>
+      </value>
+    </param>
+  </params>
+</methodResponse>

--- a/ocaml/xapi-idl/v6/v6_interface.ml
+++ b/ocaml/xapi-idl/v6/v6_interface.ml
@@ -51,16 +51,6 @@ type edition = {
 }
 [@@deriving rpcty]
 
-(** Record representing version *)
-type version = {
-    dbv: string  (** Date-Based Version *)
-  ; preview: bool  (** In preview phase or not *)
-}
-[@@deriving rpcty]
-
-let assoc_list_of_version version =
-  [("dbv", version.dbv); ("preview", string_of_bool version.preview)]
-
 (** List of edition records *)
 type edition_list = edition list [@@deriving rpcty]
 
@@ -190,9 +180,11 @@ module RPC_API (R : RPC) = struct
 
   let get_version =
     let result_p =
-      Param.mk ~description:["Version record information"] version
+      Param.mk
+        ~description:["List of version-related string pairs"]
+        string_pair_lst
     in
     declare "get_version"
-      ["Returns version record information"]
+      ["Gets list of version-related string pairs"]
       (debug_info_p @-> returning result_p err)
 end

--- a/ocaml/xapi-idl/v6/v6_interface.ml
+++ b/ocaml/xapi-idl/v6/v6_interface.ml
@@ -51,6 +51,16 @@ type edition = {
 }
 [@@deriving rpcty]
 
+(** Record representing version *)
+type version = {
+    dbv: string  (** Date-Based Version *)
+  ; preview: bool  (** In preview phase or not *)
+}
+[@@deriving rpcty]
+
+let assoc_list_of_version version =
+  [("dbv", version.dbv); ("preview", string_of_bool version.preview)]
+
 (** List of edition records *)
 type edition_list = edition list [@@deriving rpcty]
 
@@ -179,7 +189,10 @@ module RPC_API (R : RPC) = struct
       (debug_info_p @-> returning edition_list_p err)
 
   let get_version =
-    let result_p = Param.mk ~description:["String of version."] Types.string in
-    declare "get_version" ["Returns version"]
+    let result_p =
+      Param.mk ~description:["Version record information"] version
+    in
+    declare "get_version"
+      ["Returns version record information"]
       (debug_info_p @-> returning result_p err)
 end

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -545,15 +545,12 @@ let make_software_version ~__context host_info =
   let option_to_list k o = match o with None -> [] | Some x -> [(k, x)] in
   let v6_version =
     (* Best-effort attempt to read the date-based version from v6d *)
-    try
-      match V6_client.get_version "make_software_version" with
-      | "" ->
-          []
-      | dbv ->
-          [("dbv", dbv)]
-    with
-    | Api_errors.Server_error (code, []) when code = Api_errors.v6d_failure ->
-      []
+    match V6_client.get_version "make_software_version" with
+    | v ->
+        V6_interface.assoc_list_of_version v
+    | exception Api_errors.Server_error (code, [])
+      when code = Api_errors.v6d_failure ->
+        []
   in
   Xapi_globs.software_version ()
   @ v6_version

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -546,8 +546,8 @@ let make_software_version ~__context host_info =
   let v6_version =
     (* Best-effort attempt to read the date-based version from v6d *)
     match V6_client.get_version "make_software_version" with
-    | v ->
-        V6_interface.assoc_list_of_version v
+    | l ->
+        l
     | exception Api_errors.Server_error (code, [])
       when code = Api_errors.v6d_failure ->
         []


### PR DESCRIPTION
This commit adds a new field "preview" in return of v6 interface "get_version".

To achieve this, the change has to extend the return type of "get_version" interface so that more version related information could be supported.