### PR TITLE
xapiguard_cli: run its tests as part of varstored package

### DIFF
--- a/ocaml/xapi-idl/varstore/privileged/dune
+++ b/ocaml/xapi-idl/varstore/privileged/dune
@@ -30,5 +30,5 @@
 (rule
  (alias runtest)
  (deps xapiguard_cli.exe)
- (package xapi-idl)
+ (package varstored-guard)
  (action (run %{deps} --help=plain)))


### PR DESCRIPTION
Otherwise dune not find the executable when only xapi-idl is tested

This fixes xs-opam-repo's CI