### PR TITLE
CP-43518: tap-ctl stats: treat `tap` key as optional in returned object

### DIFF
--- a/ocaml/tapctl/tapctl.ml
+++ b/ocaml/tapctl/tapctl.ml
@@ -45,7 +45,7 @@ module Stats = struct
       name: string
     ; secs: int64 * int64
     ; images: Image.t list
-    ; tap: Tap.t
+    ; tap: Tap.t option
     ; nbd_mirror_failed: int
     ; reqs_outstanding: int
   }
@@ -318,13 +318,13 @@ module Dummy = struct
           list
     )
 
-  let stats t =
+  let stats _t =
     let open Stats in
     {
       name= "none"
     ; secs= (0L, 0L)
     ; images= []
-    ; tap= {Tap.minor= t.minor; reqs= (0L, 0L); kicks= (0L, 0L)}
+    ; tap= None
     ; nbd_mirror_failed= 0
     ; reqs_outstanding= 0
     }

--- a/ocaml/tapctl/tapctl.mli
+++ b/ocaml/tapctl/tapctl.mli
@@ -23,7 +23,7 @@ module Stats : sig
       name: string
     ; secs: int64 * int64
     ; images: Image.t list
-    ; tap: Tap.t
+    ; tap: Tap.t option
     ; nbd_mirror_failed: int
     ; reqs_outstanding: int
   }


### PR DESCRIPTION
The `tap-ctl stats` command returns a JSON object with a number of keys in it, of which xapi uses just one (`nbd_mirror_failed`). One of the other keys, `tap`, will no longer be there ones the tapdev devices are gone. Just treat it as optional.