### PR TITLE
CA-376145: Reset pool.last_update_sync on pool coordinator change

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2029,6 +2029,7 @@ let designate_new_master ~__context ~host:_ =
     let pool = Helpers.get_pool ~__context in
     if Db.Pool.get_ha_enabled ~__context ~self:pool then
       raise (Api_errors.Server_error (Api_errors.ha_is_enabled, [])) ;
+    Db.Pool.set_last_update_sync ~__context ~self:pool ~value:Date.epoch ;
     (* Only the master can sync the *current* database; only the master
        knows the current generation count etc. *)
     Helpers.call_api_functions ~__context (fun rpc session_id ->


### PR DESCRIPTION
When the coordinator in a pool changes the package metadata cache is not transferred from the previous coordinator to the new one. This means the field pool.last_update_sync becomes out of sync with the new state.

Fix this by resetting the field on pool coordinator change