### PR TITLE
CP-43556 Enhance features in SpanContext

### DIFF
--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -91,6 +91,7 @@ module Request : sig
     ; additional_headers: (string * string) list
     ; body: string option
     ; traceparent: string option
+    ; tracestate: string option
   }
 
   val rpc_of_t : t -> Rpc.t
@@ -114,6 +115,7 @@ module Request : sig
     -> ?host:string
     -> ?query:(string * string) list
     -> ?traceparent:string
+    -> ?tracestate:string
     -> user_agent:string
     -> method_t
     -> string
@@ -233,6 +235,8 @@ module Hdr : sig
   val location : string
 
   val traceparent : string
+
+  val tracestate : string
 end
 
 val output_http : Unix.file_descr -> string list -> unit

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -401,6 +401,8 @@ let request_of_bio_exn ~proxy_seen ~read_timeout ~total_timeout ~max_length bio
                        {req with user_agent= Some v}
                    | k when k = Http.Hdr.traceparent ->
                        {req with traceparent= Some v}
+                   | k when k = Http.Hdr.tracestate ->
+                       {req with tracestate= Some v}
                    | k when k = Http.Hdr.connection && lowercase v = "close" ->
                        {req with close= true}
                    | k

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -9,6 +9,7 @@
     rpclib.json
     xapi-idl
     xapi-stdext-unix
+    hex
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -132,6 +132,18 @@ module SpanContext = struct
     | tracestate ->
         Some tracestate
 
+  let tracestate_get key t = List.assoc_opt key t.tracestate
+
+  let tracestate_delete key t =
+    let tracestate = List.filter (fun (k, _) -> k <> key) t.tracestate in
+    {t with tracestate}
+
+  let tracestate_replace key value t =
+    let tracestate =
+      (key, value) :: List.filter (fun (k, _) -> k <> key) t.tracestate
+    in
+    {t with tracestate}
+
   let of_traceparent ?tracestate traceparent =
     let tracestate =
       Option.fold ~none:[]

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -78,15 +78,79 @@ module SpanEvent = struct
 end
 
 module SpanContext = struct
-  type t = {trace_id: string; span_id: string} [@@deriving rpcty]
+  type t = {
+      trace_id: string
+    ; span_id: string
+    ; trace_flags: char
+    ; tracestate: (string * string) list
+    ; is_remote: bool
+  }
 
-  let to_traceparent t = Printf.sprintf "00-%s-%s-00" t.trace_id t.span_id
+  let char_to_octet c =
+    Hex.of_char c |> fun (a, b) -> String.of_seq Seq.(cons a (return b))
 
-  let of_traceparent traceparent =
+  let char_of_octet f =
+    try "0x" ^ f |> int_of_string |> char_of_int with _ -> '\x00'
+
+  let is_valid t =
+    String.exists (( <> ) '0') t.span_id
+    && String.exists (( <> ) '0') t.trace_id
+
+  let generate_span_id () = Printf.sprintf "%016Lx" (Random.bits64 ())
+
+  let generate_trace_id () = generate_span_id () ^ generate_span_id ()
+
+  let rec create sampled parent =
+    let span_id = generate_span_id () in
+    let trace_flags = if sampled then '\x01' else '\x00' in
+    match parent with
+    | None ->
+        let trace_id = generate_trace_id () in
+        let t =
+          {trace_id; span_id; trace_flags; tracestate= []; is_remote= false}
+        in
+        if is_valid t then t else create sampled None
+    | Some parent ->
+        let trace_id = parent.trace_id in
+        let tracestate = parent.tracestate in
+        let is_remote = false in
+        let t = {trace_id; span_id; trace_flags; tracestate; is_remote} in
+        if is_valid t then t else create sampled (Some parent)
+
+  let to_traceparent t =
+    Printf.sprintf "00-%s-%s-%s" t.trace_id t.span_id
+      (char_to_octet t.trace_flags)
+
+  let to_tracestate t =
+    match
+      t.tracestate |> List.map (fun (k, v) -> k ^ "=" ^ v) |> String.concat ","
+    with
+    | "" ->
+        None
+    | tracestate ->
+        Some tracestate
+
+  let of_traceparent ?tracestate traceparent =
+    let tracestate =
+      Option.fold ~none:[]
+        ~some:(fun s ->
+          String.split_on_char ',' s
+          |> List.filter_map (fun kv ->
+                 match String.split_on_char '=' kv with
+                 | [k; v] ->
+                     Some (k, v)
+                 | _ ->
+                     None
+             )
+        )
+        tracestate
+    in
     let elements = String.split_on_char '-' traceparent in
     match elements with
-    | ["00"; trace_id; span_id; "00"] ->
-        Some {trace_id; span_id}
+    | ["00"; trace_id; span_id; flags] ->
+        let trace_flags = char_of_octet flags in
+        let is_remote = true in
+        Some {trace_id; span_id; trace_flags; tracestate; is_remote}
     | _ ->
         None
 end
@@ -100,7 +164,7 @@ module Span = struct
       context: SpanContext.t
     ; span_kind: SpanKind.t
     ; status: Status.t
-    ; parent: t option
+    ; parent: SpanContext.t option
     ; name: string
     ; begin_time: float
     ; end_time: float option
@@ -118,18 +182,9 @@ module Span = struct
 
   let get_context t = t.context
 
-  let generate_id n = String.init n (fun _ -> "0123456789abcdef".[Random.int 16])
-
   let start ?(attributes = Attributes.empty) ~name ~parent ~span_kind () =
-    let trace_id =
-      match parent with
-      | None ->
-          generate_id 32
-      | Some span_parent ->
-          span_parent.context.trace_id
-    in
-    let span_id = generate_id 16 in
-    let context : SpanContext.t = {trace_id; span_id} in
+    let parent = Option.map (fun s -> s.context) parent in
+    let context = SpanContext.create true parent in
     (* Using gettimeofday over Mtime as it is better for sharing timestamps between the systems *)
     let begin_time = Unix.gettimeofday () in
     let end_time = None in
@@ -402,9 +457,15 @@ module Tracer = struct
 
   let start ~tracer:t ?(attributes = []) ?(span_kind = SpanKind.Internal) ~name
       ~parent () : (Span.t option, exn) result =
+    let valid =
+      Option.map (fun parent -> SpanContext.is_valid parent.Span.context) parent
+      |> Option.value ~default:true
+    in
     (* Do not start span if the TracerProvider is diabled*)
     if not t.provider.enabled then
       ok_none
+    else if not valid then
+      Error (Failure "Invalid Span Parent")
     else
       let attributes = Attributes.of_list attributes in
       let attributes =
@@ -596,9 +657,9 @@ module Export = struct
               s.events
           in
           {
-            id= s.context.span_id
-          ; traceId= s.context.trace_id
-          ; parentId= Option.map (fun x -> x.Span.context.span_id) s.parent
+            id= s.Span.context.span_id
+          ; traceId= s.Span.context.trace_id
+          ; parentId= Option.map (fun x -> x.SpanContext.span_id) s.parent
           ; name= s.name
           ; timestamp= int_of_float (s.begin_time *. 1000000.)
           ; duration=

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -36,6 +36,12 @@ module SpanContext : sig
   val of_traceparent : ?tracestate:string -> string -> t option
 
   val to_tracestate : t -> string option
+
+  val tracestate_get : string -> t -> string option
+
+  val tracestate_delete : string -> t -> t
+
+  val tracestate_replace : string -> string -> t -> t
 end
 
 module Span : sig

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -29,9 +29,13 @@ end
 module SpanContext : sig
   type t
 
+  val is_valid : t -> bool
+
   val to_traceparent : t -> string
 
-  val of_traceparent : string -> t option
+  val of_traceparent : ?tracestate:string -> string -> t option
+
+  val to_tracestate : t -> string option
 end
 
 module Span : sig


### PR DESCRIPTION
Currently the SpanContext only holds 2 values and the [OpenTelemetry Specification](https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext) has 5 and a number of methods. The concept of Sampling, while always set to true is introduced here.    