### PR TITLE
Tracing: bump database schema

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 762
+let schema_minor_vsn = 763
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5


### PR DESCRIPTION
This is needed to fix a XAPI startup error after the database schema has been changed.

Fixes: 604cfbd58 ("CP-41842 Created Observer class with IDL functions to manage Open Telemetry providers")