### PR TITLE
CP-43400: Expose ServerCertificateValidationCallback in the Session. Also, deprecated some of the Session constructors.

### DIFF
--- a/ocaml/sdk-gen/csharp/autogen/src/JsonRpc.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/JsonRpc.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Security;
 using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -179,6 +180,7 @@ namespace XenAPI
         public bool AllowAutoRedirect { get; set; }
         public bool PreAuthenticate { get; set; }
         public CookieContainer Cookies { get; set; }
+        public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
 
         public string Url { get; private set; }
 
@@ -212,6 +214,7 @@ namespace XenAPI
             webRequest.PreAuthenticate = PreAuthenticate;
             webRequest.AllowWriteStreamBuffering = true;
             webRequest.CookieContainer = Cookies ?? webRequest.CookieContainer ?? new CookieContainer();
+            webRequest.ServerCertificateValidationCallback = ServerCertificateValidationCallback ?? ServicePointManager.ServerCertificateValidationCallback;
 
             // for performance reasons it's preferable to deserialize directly
             // from the Stream rather than allocating strings inbetween

--- a/ocaml/sdk-gen/csharp/autogen/src/Session.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Session.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Security;
 using Newtonsoft.Json;
 
 
@@ -121,7 +122,8 @@ namespace XenAPI
                     Expect100Continue = session.JsonRpcClient.Expect100Continue,
                     AllowAutoRedirect = session.JsonRpcClient.AllowAutoRedirect,
                     PreAuthenticate = session.JsonRpcClient.PreAuthenticate,
-                    Cookies = session.JsonRpcClient.Cookies
+                    Cookies = session.JsonRpcClient.Cookies,
+                    ServerCertificateValidationCallback = session.JsonRpcClient.ServerCertificateValidationCallback
                 };
             }
             CopyADFromSession(session);
@@ -239,6 +241,12 @@ namespace XenAPI
         {
             get => JsonRpcClient?.ConnectionGroupName;
             set => JsonRpcClient.ConnectionGroupName = value;
+        }
+
+        public RemoteCertificateValidationCallback ServerCertificateValidationCallback
+        {
+            get => JsonRpcClient?.ServerCertificateValidationCallback;
+            set => JsonRpcClient.ServerCertificateValidationCallback = value;
         }
 
         public ICredentials Credentials => JsonRpcClient?.WebProxy?.Credentials;

--- a/ocaml/sdk-gen/csharp/autogen/src/Session.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Session.cs
@@ -62,7 +62,6 @@ namespace XenAPI
         {
             JsonRpcClient = new JsonRpcClient(url)
             {
-                ConnectionGroupName = ConnectionGroupName,
                 Timeout = timeout,
                 KeepAlive = true,
                 UserAgent = UserAgent,
@@ -114,10 +113,10 @@ namespace XenAPI
                 JsonRpcClient = new JsonRpcClient(session.Url)
                 {
                     JsonRpcVersion = session.JsonRpcClient.JsonRpcVersion,
-                    Timeout = timeout,
-                    KeepAlive = session.JsonRpcClient.KeepAlive,
                     UserAgent = session.JsonRpcClient.UserAgent,
+                    KeepAlive = session.JsonRpcClient.KeepAlive,
                     WebProxy = session.JsonRpcClient.WebProxy,
+                    Timeout = timeout,
                     ProtocolVersion = session.JsonRpcClient.ProtocolVersion,
                     Expect100Continue = session.JsonRpcClient.Expect100Continue,
                     AllowAutoRedirect = session.JsonRpcClient.AllowAutoRedirect,


### PR DESCRIPTION
Please review each commit separately.

Regarding the 3rd commit: .NET has a global property which allows specifying a certificate validation handler for use with the server requests. Because this is a client wide setting, it does not allow for much flexibility if the client wants to connect to various types of hypervisors and implement different certificate validation logic for each one, therefore this PR exposes it in the SDK so the client can customize the global setting for XenServer sessions.

Regarding the 4th commit: Since the beginning of the C# SDK's life, we have exposed a few properties of the web requests at the Session class level so the implementing client can override the defaults. Timeout was the very first one, but at the time it had not been exposed as a Property but as a constructor parameter instead. Since the others are Properties, and since the Properties allow for more flexibility (i.e. they can be set at any time without having to construct a new Session instance), I exposed Timeout as a Property too and deprecated the constructor overloads that have it in their parameter set.