### PR TITLE
CP-43551: Dump host_rrd latest data to /dev/shm/metrics/host-dss

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
@@ -456,6 +456,41 @@ let query_host_ds (ds_name : string) : float =
           query ds_name rrdi
   )
 
+(** Dump all latest data of host dss to file in json format so that any client
+    can read even if it's non-privileged user, such as NRPE. 
+    Especially, nan, infinity and neg_infinity will be converted to strings 
+    "NaN", "infinity" and "-infinity", the client needs to handle by itself.
+    *)
+let dump_host_dss_to_file (file : string) : unit =
+  let convert_value x =
+    match classify_float x with
+    | FP_nan ->
+        `String "NaN"
+    | FP_infinite ->
+        `String (if x > 0.0 then "infinity" else "-infinity")
+    | _ ->
+        `Float x
+  in
+  let json =
+    with_lock mutex (fun () ->
+        match !host_rrd with
+        | None ->
+            `Assoc []
+        | Some rrdi ->
+            `Assoc
+              (Rrd.ds_names rrdi.rrd
+              |> List.map (fun ds_name ->
+                     (ds_name, convert_value (query ds_name rrdi))
+                 )
+              )
+    )
+  in
+  Xapi_stdext_unix.Unixext.atomic_write_to_file file 0o644 (fun fd ->
+      let oc = Unix.out_channel_of_descr fd in
+      Yojson.Basic.to_channel ~std:true oc json ;
+      flush oc
+  )
+
 (** {add_vm_ds vm_uuid domid ds_name} enables collection of the data produced by
     the data sourced with name {ds_name} for the VM {vm_uuid} into a time series
     (rrd). Throws an exception if there are no time series related to {vm_uuid}

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.mli
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.mli
@@ -28,6 +28,8 @@ val query_possible_host_dss : unit -> Data_source.t list
 
 val query_host_ds : string -> float
 
+val dump_host_dss_to_file : string -> unit
+
 val add_vm_ds : string -> int -> string -> unit
 
 val forget_vm_ds : string -> string -> unit

--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -762,7 +762,11 @@ let do_monitor_write xc writers =
       let stats = List.rev_append plugins_stats dom0_stats in
       Rrdd_stats.print_snapshot () ;
       let uuid_domids = List.map (fun (_, u, i) -> (u, i)) domains in
-      Rrdd_monitor.update_rrds timestamp stats uuid_domids my_paused_vms
+      Rrdd_monitor.update_rrds timestamp stats uuid_domids my_paused_vms ;
+
+      (* Dump to /dev/shm/metrics/host-dss *)
+      Rrdd_server.Plugin.get_path "host-dss"
+      |> Rrdd_server.dump_host_dss_to_file
   )
 
 let monitor_write_loop writers =


### PR DESCRIPTION
- Dump all latest data of host dss to file in json format so that any client can read even if it's non-privileged user, such as NRPE.

Test passed, see CP-43551 to get details.