### PR TITLE
CA-378455: Ensure TPM contents are base64-encoded on migration recieve

### DIFF
--- a/ocaml/xenopsd/lib/suspend_image.ml
+++ b/ocaml/xenopsd/lib/suspend_image.ml
@@ -42,7 +42,7 @@ module Xenops_record = struct
   [@@deriving sexp]
 
   let make ?vm_str ?xs_subtree () =
-    let time = Xapi_stdext_date.Date.(to_string (of_float (Unix.time ()))) in
+    let time = Xapi_stdext_date.Date.(to_string (now ())) in
     let word_size = Sys.word_size in
     {word_size; time; vm_str; xs_subtree}
 
@@ -62,6 +62,7 @@ type header_type =
   | Qemu_xen
   | Demu
   | Varstored
+  | Swtpm0
   | Swtpm
   | End_of_image
 
@@ -85,6 +86,8 @@ let header_type_of_int64 = function
   | 0x0f11L ->
       Ok Varstored
   | 0x0f12L ->
+      Ok Swtpm0
+  | 0x0f13L ->
       Ok Swtpm
   | 0xffffL ->
       Ok End_of_image
@@ -108,8 +111,10 @@ let int64_of_header_type = function
       0x0f10L
   | Varstored ->
       0x0f11L
-  | Swtpm ->
+  | Swtpm0 ->
       0x0f12L
+  | Swtpm ->
+      0x0f13L
   | End_of_image ->
       0xffffL
 
@@ -134,6 +139,8 @@ let string_of_header h =
       s "vGPU save record (record length=%Ld)" len
   | Varstored, len ->
       s "varstored save record (record length=%Ld)" len
+  | Swtpm0, len ->
+      s "swtpm0 save record (record length=%Ld)" len
   | Swtpm, len ->
       s "swtpm save record (record length=%Ld)" len
   | End_of_image, _ ->

--- a/ocaml/xenopsd/lib/suspend_image.mli
+++ b/ocaml/xenopsd/lib/suspend_image.mli
@@ -40,7 +40,8 @@ type header_type =
   | Qemu_xen
   | Demu
   | Varstored
-  | Swtpm
+  | Swtpm0 (* binary stream *)
+  | Swtpm (* base64 with space separators stream *)
   | End_of_image
 
 type format = Structured | Legacy

--- a/ocaml/xenopsd/suspend_image_viewer/suspend_image_viewer.ml
+++ b/ocaml/xenopsd/suspend_image_viewer/suspend_image_viewer.ml
@@ -69,6 +69,9 @@ let parse_layout fd =
         | Varstored, len ->
             Io.read fd (Io.int_of_int64_exn len) |> ignore ;
             aux (h :: acc)
+        | Swtpm0, len ->
+            Io.read fd (Io.int_of_int64_exn len) |> ignore ;
+            aux (h :: acc)
         | Swtpm, len ->
             Io.read fd (Io.int_of_int64_exn len) |> ignore ;
             aux (h :: acc)

--- a/ocaml/xenopsd/suspend_image_viewer/suspend_image_viewer.ml
+++ b/ocaml/xenopsd/suspend_image_viewer/suspend_image_viewer.ml
@@ -57,21 +57,13 @@ let parse_layout fd =
         debug "Read header <%s>" (string_of_header h) ;
         debug "Dummy-processing record..." ;
         match h with
-        | Xenops, len ->
-            Io.read fd (Io.int_of_int64_exn len) |> ignore ;
-            aux (h :: acc)
         | Libxc, _ ->
             verify_libxc_v2_record fd ;
             aux (h :: acc)
-        | Qemu_trad, len ->
-            Io.read fd (Io.int_of_int64_exn len) |> ignore ;
-            aux (h :: acc)
-        | Varstored, len ->
-            Io.read fd (Io.int_of_int64_exn len) |> ignore ;
-            aux (h :: acc)
-        | Swtpm0, len ->
-            Io.read fd (Io.int_of_int64_exn len) |> ignore ;
-            aux (h :: acc)
+        | Xenops, len
+        | Qemu_trad, len
+        | Varstored, len
+        | Swtpm0, len
         | Swtpm, len ->
             Io.read fd (Io.int_of_int64_exn len) |> ignore ;
             aux (h :: acc)

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -1393,6 +1393,14 @@ let restore_common (task : Xenops_task.task_handle) ~xc ~xs
                 debug "Read varstored record contents (domid=%d)" domid ;
                 Device.Dm.restore_varstored task ~xs ~efivars domid ;
                 process_header fd res
+            | Swtpm0, len ->
+                debug "Read swtpm0 record header (domid=%d length=%Ld)" domid
+                  len ;
+                let raw_contents = Io.read fd (Io.int_of_int64_exn len) in
+                let contents = Base64.encode_string raw_contents in
+                debug "Read swtpm0 record contents (domid=%d)" domid ;
+                Device.Dm.restore_vtpm task ~xs ~contents ~vtpm domid ;
+                process_header fd res
             | Swtpm, len ->
                 debug "Read swtpm record header (domid=%d length=%Ld)" domid len ;
                 let contents = Io.read fd (Io.int_of_int64_exn len) in


### PR DESCRIPTION
When migrating from earlier xapi releases, the migration block was not base64-encoded while newer versions assume the migration block is. Introduce a new migration block so from this version can tell when to base64-encode the contents for migration contents and when to leave the contents alone.

Drafting until the fix is manually verified