### PR TITLE
CA-378323: prevent find writing to stderr if /var/log/dt not present

### DIFF
--- a/scripts/xapi-tracing-log-trim.sh
+++ b/scripts/xapi-tracing-log-trim.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 
+DTPATH=/var/log/dt
+
+# nothing to do if DT directory not present
+test ! -d "${DTPATH}" && exit 0
+
 # find the oldest trace files beyond MAX_MB size and delete
-find /var/log/dt -mindepth 1 -type f -printf '%T@ %k %p\n' | sort -nr | awk -v max_mb=${MAX_MB:=100} 'BEGIN{size=0}{size+=$2; if (size>1000*max_mb) {$1=""; $2=""; print $0}}' | xargs -r rm
+find "${DTPATH}" -mindepth 1 -type f -printf '%T@ %k %p\n' | sort -nr | awk -v max_mb=${MAX_MB:=100} 'BEGIN{size=0}{size+=$2; if (size>1000*max_mb) {$1=""; $2=""; print $0}}' | xargs -r rm
 
 # delete any remaining files that are older than MAX_DAYS days
-find /var/log/dt -mindepth 1 -mtime ${MAX_DAYS:=+30} -delete
+find "${DTPATH}" -mindepth 1 -mtime ${MAX_DAYS:=+30} -delete
 
 # clean up any empty directories
-find /var/log/dt -mindepth 1 -type d -empty -delete
+find "${DTPATH}" -mindepth 1 -type d -empty -delete


### PR DESCRIPTION
When no observer is enabled, by default /var/log/dt is not present. In this situation, when cron runs xapi-tracing-log-trim.sh, the find commands will write to stderr ending up in dead.letter files:

find: ‘/var/log/dt’: No such file or directory

After this patch, the script will:
- skip the find operations using /var/log/dt if this path is not present,
- and use an internal DTPATH var to refer to this path instead of repeating it across many places.

Behaviour when /var/log/dt is present was maintained.