### PR TITLE
CA-378317: fix EBADF in waitpid_nohang (v1)

### DIFF
--- a/ocaml/forkexecd/lib/forkhelpers.ml
+++ b/ocaml/forkexecd/lib/forkhelpers.ml
@@ -62,12 +62,9 @@ let waitpid (sock, pid) =
 
 let waitpid_nohang ((sock, _) as x) =
   Unix.set_nonblock sock ;
-  let r =
-    try waitpid x
-    with Unix.(Unix_error ((EAGAIN | EWOULDBLOCK), _, _)) ->
-      (0, Unix.WEXITED 0)
-  in
-  Unix.clear_nonblock sock ; r
+  try waitpid x
+  with Unix.(Unix_error ((EAGAIN | EWOULDBLOCK), _, _)) ->
+    Unix.clear_nonblock sock ; (0, Unix.WEXITED 0)
 
 let dontwaitpid (sock, _pid) =
   ( try


### PR DESCRIPTION
'waitpid' will close the socket when succesful,
so move the 'clear_nonblock' to the EAGAIN|EWOULDBLOCK case where the socket should still be open.

Fixes: 291c5002f ("CA-341921: avoid EINVAL errors for >1024 FDs")