### PR TITLE
CA-378837 log results from Host.get_vms_which_prevent_evacuation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.11"]
+        python-version: ["3.11"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -448,7 +448,16 @@ let get_vms_which_prevent_evacuation_internal ~__context ~self ~ignore_ha =
 
 (* New Orlando style function which returns a Map *)
 let get_vms_which_prevent_evacuation ~__context ~self =
-  get_vms_which_prevent_evacuation_internal ~__context ~self ~ignore_ha:false
+  let vms =
+    get_vms_which_prevent_evacuation_internal ~__context ~self ~ignore_ha:false
+  in
+
+  let log (vm, reasons) =
+    debug "%s: VM %s preventing evacuation of host %s: %s" __FUNCTION__
+      (Ref.string_of vm) (Ref.string_of self)
+      (String.concat "; " reasons)
+  in
+  List.iter log vms ; vms
 
 let compute_evacuation_plan_wlb ~__context ~self =
   (* We treat xapi as primary when it comes to "hard" errors, i.e. those that aren't down to memory constraints.  These are things like

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -451,10 +451,10 @@ let get_vms_which_prevent_evacuation ~__context ~self =
   let vms =
     get_vms_which_prevent_evacuation_internal ~__context ~self ~ignore_ha:false
   in
-
   let log (vm, reasons) =
     debug "%s: VM %s preventing evacuation of host %s: %s" __FUNCTION__
-      (Ref.string_of vm) (Ref.string_of self)
+      (Db.VM.get_uuid ~__context ~self:vm)
+      (Db.Host.get_uuid ~__context ~self)
       (String.concat "; " reasons)
   in
   List.iter log vms ; vms


### PR DESCRIPTION
Host.get_vms_which_prevent_evacuation is used by XenCenter as part of a rolling pool upgrade. But when it fails we are missing information in the logs about VMs that block evacuation of a host. Add logging.