### PR TITLE
CA-378317 fix EBADF in waitpid_nohang (v2)

### DIFF
--- a/ocaml/forkexecd/lib/forkhelpers.mli
+++ b/ocaml/forkexecd/lib/forkhelpers.mli
@@ -110,9 +110,13 @@ val safe_close_and_exec :
 val waitpid : pidty -> int * Unix.process_status
 (** [waitpid p] returns the (pid, Unix.process_status) *)
 
-val waitpid_nohang : pidty -> int * Unix.process_status
-(** [waitpid_nohang p] returns the (pid, Unix.process_status) if the process has already
-    	quit or (0, Unix.WEXITTED 0) if the process is still running. *)
+val waitpid_nohang : ?close:bool -> pidty -> int * Unix.process_status
+(** [waitpid_nohang p] returns the (pid, Unix.process_status) if the
+    process has already quit or (PID, Unix.WEXITTED 0) if the process is
+    still running.  If the process is finished, the socket is closed by
+    default and not otherwise. The [close] option can be used to never
+    close the socket such that this is left to the caller, which is a
+    cleaner protocol. *)
 
 val dontwaitpid : pidty -> unit
 (** [dontwaitpid p]: signals the caller's desire to never call waitpid. Note that the final

--- a/ocaml/libs/stunnel/stunnel.ml
+++ b/ocaml/libs/stunnel/stunnel.ml
@@ -257,7 +257,7 @@ let disconnect_with_pid ?(wait = true) ?(force = false) pid =
           ( if wait then
               Forkhelpers.waitpid
             else
-              Forkhelpers.waitpid_nohang
+              Forkhelpers.waitpid_nohang ~close:true
           )
             fpid
         )


### PR DESCRIPTION
waitpid_nohang closes the socket by calling waitpid and then calls clear_nonblock on that socket, which fails.

waitpid_nohang's policy around closing the socket is not obvious enough. Make it more explicit by not calling waitpid but inlining this code and lookign at the different cases. Also provide an option to never close the socket such that this resided with the caller - which is a cleaner protocol. The default behaviour is to still close the socket when the child process has terminated and not otherwise.