### PR TITLE
CP-43545: expose `issued` and `severity` from updateinfo

### DIFF
--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -603,7 +603,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -621,7 +621,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -664,7 +664,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -706,7 +706,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -724,7 +724,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -766,7 +766,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -797,7 +797,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -839,7 +839,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -881,7 +881,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -923,7 +923,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -954,7 +954,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -996,7 +996,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1026,7 +1026,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1068,7 +1068,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1110,7 +1110,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1174,7 +1174,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1228,7 +1228,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1284,7 +1284,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1314,7 +1314,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1368,7 +1368,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1408,7 +1408,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1462,7 +1462,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1480,7 +1480,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1534,7 +1534,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1552,7 +1552,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1616,7 +1616,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1646,7 +1646,7 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             }
                         ]
                     ; issued= Xapi_stdext_date.Date.epoch
-                    ; severity= "None"
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1989,7 +1989,7 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
       ; livepatch_guidance= None
       ; livepatches= []
       ; issued= Xapi_stdext_date.Date.epoch
-      ; severity= "None"
+      ; severity= Severity.None
       }
 
   let updates_info =
@@ -3129,7 +3129,7 @@ module PruneUpdateInfoForLivepatches = Generic.MakeStateless (struct
       ; livepatch_guidance= None
       ; livepatches= []
       ; issued= Xapi_stdext_date.Date.epoch
-      ; severity= "None"
+      ; severity= Severity.None
       }
 
   let tests =

--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -602,6 +602,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -618,6 +620,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -659,6 +663,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -699,6 +705,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -715,6 +723,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -755,6 +765,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -784,6 +796,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -824,6 +838,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -864,6 +880,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -904,6 +922,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -933,6 +953,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -973,6 +995,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1001,6 +1025,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1041,6 +1067,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1081,6 +1109,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1143,6 +1173,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "10.23.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1195,6 +1227,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "10.23.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1249,6 +1283,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1277,6 +1313,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.22.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1329,6 +1367,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1367,6 +1407,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.22.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1419,6 +1461,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1435,6 +1479,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1487,6 +1533,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1503,6 +1551,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1565,6 +1615,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1593,6 +1645,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.22.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= "None"
                     }
                 )
               ]
@@ -1934,6 +1988,8 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
       ; update_type= "security"
       ; livepatch_guidance= None
       ; livepatches= []
+      ; issued= Xapi_stdext_date.Date.epoch
+      ; severity= "None"
       }
 
   let updates_info =
@@ -3072,6 +3128,8 @@ module PruneUpdateInfoForLivepatches = Generic.MakeStateless (struct
       ; update_type= "UPDATE_TYPE"
       ; livepatch_guidance= None
       ; livepatches= []
+      ; issued= Xapi_stdext_date.Date.epoch
+      ; severity= "None"
       }
 
   let tests =

--- a/ocaml/tests/test_updateinfo.ml
+++ b/ocaml/tests/test_updateinfo.ml
@@ -451,7 +451,9 @@ let fields_of_updateinfo =
     ; field "issued"
         (fun (r : UpdateInfo.t) -> Xapi_stdext_date.Date.to_string r.issued)
         string
-    ; field "severity" (fun (r : UpdateInfo.t) -> r.severity) string
+    ; field "severity"
+        (fun (r : UpdateInfo.t) -> Severity.to_string r.severity)
+        string
     ]
 
 module UpdateInfoOfXml = Generic.MakeStateless (struct
@@ -568,7 +570,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; livepatch_guidance= None
                   ; livepatches= []
                   ; issued= Xapi_stdext_date.Date.epoch
-                  ; severity= ""
+                  ; severity= Severity.None
                   }
               )
             ]
@@ -632,7 +634,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
-                  ; severity= "High"
+                  ; severity= Severity.High
                   }
               )
             ]
@@ -682,7 +684,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
-                  ; severity= "High"
+                  ; severity= Severity.High
                   }
               )
             ; ( "UPDATE-0001"
@@ -701,7 +703,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:50Z"
-                  ; severity= "None"
+                  ; severity= Severity.None
                   }
               )
             ]
@@ -779,7 +781,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
-                  ; severity= "High"
+                  ; severity= Severity.High
                   }
               )
             ]
@@ -845,7 +847,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                       ]
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
-                  ; severity= "High"
+                  ; severity= Severity.High
                   }
               )
             ]
@@ -884,7 +886,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; livepatch_guidance= Some Guidance.RestartDeviceModel
                   ; livepatches= []
                   ; issued= Xapi_stdext_date.Date.epoch
-                  ; severity= ""
+                  ; severity= Severity.None
                   }
               )
             ]
@@ -937,7 +939,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                           }
                       ]
                   ; issued= Xapi_stdext_date.Date.epoch
-                  ; severity= ""
+                  ; severity= Severity.None
                   }
               )
             ]
@@ -978,7 +980,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; livepatch_guidance= Some Guidance.RestartToolstack
                   ; livepatches= []
                   ; issued= Xapi_stdext_date.Date.epoch
-                  ; severity= ""
+                  ; severity= Severity.None
                   }
               )
             ]

--- a/ocaml/tests/test_updateinfo.ml
+++ b/ocaml/tests/test_updateinfo.ml
@@ -448,6 +448,10 @@ let fields_of_updateinfo =
             r.livepatches
         )
         (list string)
+    ; field "issued"
+        (fun (r : UpdateInfo.t) -> Xapi_stdext_date.Date.to_string r.issued)
+        string
+    ; field "severity" (fun (r : UpdateInfo.t) -> r.severity) string
     ]
 
 module UpdateInfoOfXml = Generic.MakeStateless (struct
@@ -563,6 +567,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= ""
                   }
               )
             ]
@@ -603,6 +609,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
               </update>
             </updates>
           |}
@@ -622,6 +630,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= "High"
                   }
               )
             ]
@@ -637,6 +648,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
               </update>
               <update type="security">
                 <id>UPDATE-0001</id>
@@ -646,6 +659,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
+                <issued date="2023-05-12 08:37:50"/>
+                <severity>None</severity>
               </update>
             </updates>
           |}
@@ -665,6 +680,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= "High"
                   }
               )
             ; ( "UPDATE-0001"
@@ -681,6 +699,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:50Z"
+                  ; severity= "None"
                   }
               )
             ]
@@ -715,6 +736,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     <arch>x86_64</arch>
                   </applicability>
                 </guidance_applicabilities>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
               </update>
             </updates>
           |}
@@ -754,6 +777,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= "High"
                   }
               )
             ]
@@ -774,6 +800,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   <livepatch component="kernel" base="4.19.19-8.0.19.xs8" to="4.19.19-8.0.21.xs8" base-buildid="8346194f2e98a228f5a595b13ecabd43a99fada0"/>
                   <livepatch component="kernel" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
                 </livepatches>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
               </update>
             </updates>
           |}
@@ -815,6 +843,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                           ; to_release= "8.0.21.xs8"
                           }
                       ]
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= "High"
                   }
               )
             ]
@@ -852,6 +883,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= Some Guidance.RestartDeviceModel
                   ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= ""
                   }
               )
             ]
@@ -903,6 +936,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                           ; to_release= "8.0.21.xs8"
                           }
                       ]
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= ""
                   }
               )
             ]
@@ -942,6 +977,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= Some Guidance.RestartToolstack
                   ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= ""
                   }
               )
             ]

--- a/ocaml/xapi/updateinfo.ml
+++ b/ocaml/xapi/updateinfo.ml
@@ -603,8 +603,13 @@ module UpdateInfo = struct
                                 Xapi_stdext_date.Date.epoch
                           in
                           {acc with issued}
-                      | Xml.Element ("severity", _, [Xml.PCData v]) ->
-                          {acc with severity= Severity.of_string v}
+                      | Xml.Element ("severity", _, [Xml.PCData v]) -> (
+                        try {acc with severity= Severity.of_string v}
+                        with e ->
+                          (* The error should not block update. Ingore it. *)
+                          warn "%s" (ExnHelper.string_of_exn e) ;
+                          acc
+                      )
                       | _ ->
                           acc
                     )

--- a/ocaml/xapi/updateinfo.ml
+++ b/ocaml/xapi/updateinfo.ml
@@ -578,7 +578,11 @@ module UpdateInfo = struct
                                          h m s
                                    )
                                   )
-                              with _ -> Xapi_stdext_date.Date.epoch
+                              with e ->
+                                (* The error should not block update. Ingore it
+                                   and set "issued" as epoch. *)
+                                warn "%s" (ExnHelper.string_of_exn e) ;
+                                Xapi_stdext_date.Date.epoch
                             )
                             | None ->
                                 Xapi_stdext_date.Date.epoch

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -97,6 +97,14 @@ module LivePatch : sig
   val of_xml : Xml.xml list -> t list
 end
 
+module Severity : sig
+  type t = None | High
+
+  val to_string : t -> string
+
+  val of_string : string -> t
+end
+
 (** The metadata of one update in updateinfo *)
 module UpdateInfo : sig
   type t = {
@@ -112,7 +120,7 @@ module UpdateInfo : sig
     ; livepatch_guidance: Guidance.t option
     ; livepatches: LivePatch.t list
     ; issued: Xapi_stdext_date.Date.t
-    ; severity: string
+    ; severity: Severity.t
   }
 
   val to_json : t -> Yojson.Basic.t

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -111,6 +111,8 @@ module UpdateInfo : sig
     ; update_type: string
     ; livepatch_guidance: Guidance.t option
     ; livepatches: LivePatch.t list
+    ; issued: Xapi_stdext_date.Date.t
+    ; severity: string
   }
 
   val to_json : t -> Yojson.Basic.t

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -27,6 +27,7 @@ module Guidance : sig
 
   val to_string : t -> string
 
+  (* may fail *)
   val of_string : string -> t
 
   val of_update_guidance :
@@ -102,6 +103,7 @@ module Severity : sig
 
   val to_string : t -> string
 
+  (* may fail *)
   val of_string : string -> t
 end
 


### PR DESCRIPTION
Expose the `issued` and `severity` fields from updateinfo on host http endpoint: /updates.