### PR TITLE
CP-40214: **/*.py: raise (AnyException()): Remove optional parentheses

### DIFF
--- a/ocaml/message-switch/python/message_switch.py
+++ b/ocaml/message-switch/python/message_switch.py
@@ -210,7 +210,7 @@ def link_send(sock, m):
 def link_recv(reader):
     status = reader.readline()
     if not(status.startswith("HTTP/1.1 200 OK")):
-        raise (Bad_status(status))
+        raise Bad_status(status)
     content_length = None
     eoh = False
     while not eoh:

--- a/ocaml/xapi-idl/designs/interprocesscomms.md
+++ b/ocaml/xapi-idl/designs/interprocesscomms.md
@@ -540,20 +540,20 @@ response:
 		def start(self, args):
 			"""type-check inputs, call implementation, type-check outputs and return"""
 			if type(args) <> type({}):
-				raise (UnmarshalException('arguments', 'dict', repr(args)))
+				raise UnmarshalException('arguments', 'dict', repr(args))
 			if not(args.has_key('dbg')):
 				raise UnmarshalException('argument missing', 'dbg', '')
 			dbg = args["dbg"]
 			if type(dbg) <> type(""):
-				raise (TypeError("string", repr(dbg)))
+				raise TypeError("string", repr(dbg))
 			if not(args.has_key('id')):
 				raise UnmarshalException('argument missing', 'id', '')
 			id = args["id"]
 			if type(id) <> type(""):
-				raise (TypeError("string", repr(id)))
+				raise TypeError("string", repr(id))
 			results = self._impl.start(dbg, id)
 			if type(results) <> type(""):
-				raise (TypeError("string", repr(results)))
+				raise TypeError("string", repr(results))
 			return results
 		def _dispatch(self, method, params):
 			"""type check inputs, call implementation, type check outputs and return"""

--- a/ocaml/xapi-storage/python/xapi/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/__init__.py
@@ -67,9 +67,9 @@ class XenAPIException(Exception):
     def __init__(self, code, params):
         Exception.__init__(self)
         if not isinstance(code, str) and not isinstance(code, unicode):
-            raise (TypeError("string", repr(code)))
+            raise TypeError("string", repr(code))
         if not isinstance(params, list):
-            raise (TypeError("list", repr(params)))
+            raise TypeError("list", repr(params))
         self.code = code
         self.params = params
 

--- a/ocaml/xapi-storage/python/xapi/storage/api/datapath.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/datapath.py
@@ -9,7 +9,7 @@ class Unimplemented(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
         if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
-            raise (TypeError("string", repr(arg_0)))
+            raise TypeError("string", repr(arg_0))
         self.arg_0 = arg_0
 class Datapath_server_dispatcher:
     """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
@@ -19,133 +19,133 @@ class Datapath_server_dispatcher:
     def open(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         if not('persistent' in args):
             raise UnmarshalException('argument missing', 'persistent', '')
         persistent = args["persistent"]
         if not isinstance(persistent, bool):
-            raise (TypeError("bool", repr(persistent)))
+            raise TypeError("bool", repr(persistent))
         results = self._impl.open(dbg, uri, persistent)
         return results
     def attach(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         if not('domain' in args):
             raise UnmarshalException('argument missing', 'domain', '')
         domain = args["domain"]
         if not isinstance(domain, str) and not isinstance(domain, unicode):
-            raise (TypeError("string", repr(domain)))
+            raise TypeError("string", repr(domain))
         results = self._impl.attach(dbg, uri, domain)
         if not isinstance(results['domain_uuid'], str) and not isinstance(results['domain_uuid'], unicode):
-            raise (TypeError("string", repr(results['domain_uuid'])))
+            raise TypeError("string", repr(results['domain_uuid']))
         if results['implementation'][0] == 'Blkback':
             if not isinstance(results['implementation'][1], str) and not isinstance(results['implementation'][1], unicode):
-                raise (TypeError("string", repr(results['implementation'][1])))
+                raise TypeError("string", repr(results['implementation'][1]))
         elif results['implementation'][0] == 'Tapdisk3':
             if not isinstance(results['implementation'][1], str) and not isinstance(results['implementation'][1], unicode):
-                raise (TypeError("string", repr(results['implementation'][1])))
+                raise TypeError("string", repr(results['implementation'][1]))
         elif results['implementation'][0] == 'Qdisk':
             if not isinstance(results['implementation'][1], str) and not isinstance(results['implementation'][1], unicode):
-                raise (TypeError("string", repr(results['implementation'][1])))
+                raise TypeError("string", repr(results['implementation'][1]))
         return results
     def activate(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         if not('domain' in args):
             raise UnmarshalException('argument missing', 'domain', '')
         domain = args["domain"]
         if not isinstance(domain, str) and not isinstance(domain, unicode):
-            raise (TypeError("string", repr(domain)))
+            raise TypeError("string", repr(domain))
         results = self._impl.activate(dbg, uri, domain)
         return results
     def deactivate(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         if not('domain' in args):
             raise UnmarshalException('argument missing', 'domain', '')
         domain = args["domain"]
         if not isinstance(domain, str) and not isinstance(domain, unicode):
-            raise (TypeError("string", repr(domain)))
+            raise TypeError("string", repr(domain))
         results = self._impl.deactivate(dbg, uri, domain)
         return results
     def detach(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         if not('domain' in args):
             raise UnmarshalException('argument missing', 'domain', '')
         domain = args["domain"]
         if not isinstance(domain, str) and not isinstance(domain, unicode):
-            raise (TypeError("string", repr(domain)))
+            raise TypeError("string", repr(domain))
         results = self._impl.detach(dbg, uri, domain)
         return results
     def close(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         results = self._impl.close(dbg, uri)
         return results
     def _dispatch(self, method, params):

--- a/ocaml/xapi-storage/python/xapi/storage/api/plugin.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/plugin.py
@@ -9,7 +9,7 @@ class Unimplemented(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
         if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
-            raise (TypeError("string", repr(arg_0)))
+            raise TypeError("string", repr(arg_0))
         self.arg_0 = arg_0
 class Plugin_server_dispatcher:
     """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
@@ -19,74 +19,74 @@ class Plugin_server_dispatcher:
     def query(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         results = self._impl.query(dbg)
         if not isinstance(results['plugin'], str) and not isinstance(results['plugin'], unicode):
-            raise (TypeError("string", repr(results['plugin'])))
+            raise TypeError("string", repr(results['plugin']))
         if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
-            raise (TypeError("string", repr(results['name'])))
+            raise TypeError("string", repr(results['name']))
         if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
-            raise (TypeError("string", repr(results['description'])))
+            raise TypeError("string", repr(results['description']))
         if not isinstance(results['vendor'], str) and not isinstance(results['vendor'], unicode):
-            raise (TypeError("string", repr(results['vendor'])))
+            raise TypeError("string", repr(results['vendor']))
         if not isinstance(results['copyright'], str) and not isinstance(results['copyright'], unicode):
-            raise (TypeError("string", repr(results['copyright'])))
+            raise TypeError("string", repr(results['copyright']))
         if not isinstance(results['version'], str) and not isinstance(results['version'], unicode):
-            raise (TypeError("string", repr(results['version'])))
+            raise TypeError("string", repr(results['version']))
         if not isinstance(results['required_api_version'], str) and not isinstance(results['required_api_version'], unicode):
-            raise (TypeError("string", repr(results['required_api_version'])))
+            raise TypeError("string", repr(results['required_api_version']))
         if not isinstance(results['features'], list):
-            raise (TypeError("string list", repr(results['features'])))
+            raise TypeError("string list", repr(results['features']))
         for tmp_1 in results['features']:
             if not isinstance(tmp_1, str) and not isinstance(tmp_1, unicode):
-                raise (TypeError("string", repr(tmp_1)))
+                raise TypeError("string", repr(tmp_1))
         if not isinstance(results['configuration'], dict):
-            raise (TypeError("(string * string) list", repr(results['configuration'])))
+            raise TypeError("(string * string) list", repr(results['configuration']))
         for tmp_2 in results['configuration'].keys():
             if not isinstance(tmp_2, str) and not isinstance(tmp_2, unicode):
-                raise (TypeError("string", repr(tmp_2)))
+                raise TypeError("string", repr(tmp_2))
         for tmp_2 in results['configuration'].values():
             if not isinstance(tmp_2, str) and not isinstance(tmp_2, unicode):
-                raise (TypeError("string", repr(tmp_2)))
+                raise TypeError("string", repr(tmp_2))
         if not isinstance(results['required_cluster_stack'], list):
-            raise (TypeError("string list", repr(results['required_cluster_stack'])))
+            raise TypeError("string list", repr(results['required_cluster_stack']))
         for tmp_3 in results['required_cluster_stack']:
             if not isinstance(tmp_3, str) and not isinstance(tmp_3, unicode):
-                raise (TypeError("string", repr(tmp_3)))
+                raise TypeError("string", repr(tmp_3))
         return results
     def ls(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         results = self._impl.ls(dbg)
         if not isinstance(results, list):
-            raise (TypeError("string list", repr(results)))
+            raise TypeError("string list", repr(results))
         for tmp_4 in results:
             if not isinstance(tmp_4, str) and not isinstance(tmp_4, unicode):
-                raise (TypeError("string", repr(tmp_4)))
+                raise TypeError("string", repr(tmp_4))
         return results
     def diagnostics(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         results = self._impl.diagnostics(dbg)
         if not isinstance(results, str) and not isinstance(results, unicode):
-            raise (TypeError("string", repr(results)))
+            raise TypeError("string", repr(results))
         return results
     def _dispatch(self, method, params):
         """type check inputs, call implementation, type check outputs and return"""

--- a/ocaml/xapi-storage/python/xapi/storage/api/volume.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/volume.py
@@ -9,31 +9,31 @@ class Sr_not_attached(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Sr_not_attached", [ arg_0 ])
         if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
-            raise (TypeError("string", repr(arg_0)))
+            raise TypeError("string", repr(arg_0))
         self.arg_0 = arg_0
 class SR_does_not_exist(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "SR_does_not_exist", [ arg_0 ])
         if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
-            raise (TypeError("string", repr(arg_0)))
+            raise TypeError("string", repr(arg_0))
         self.arg_0 = arg_0
 class Volume_does_not_exist(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Volume_does_not_exist", [ arg_0 ])
         if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
-            raise (TypeError("string", repr(arg_0)))
+            raise TypeError("string", repr(arg_0))
         self.arg_0 = arg_0
 class Unimplemented(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
         if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
-            raise (TypeError("string", repr(arg_0)))
+            raise TypeError("string", repr(arg_0))
         self.arg_0 = arg_0
 class Cancelled(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Cancelled", [ arg_0 ])
         if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
-            raise (TypeError("string", repr(arg_0)))
+            raise TypeError("string", repr(arg_0))
         self.arg_0 = arg_0
 class Volume_server_dispatcher:
     """Operations which operate on volumes (also known as Virtual Disk Images)"""
@@ -43,364 +43,364 @@ class Volume_server_dispatcher:
     def create(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('name' in args):
             raise UnmarshalException('argument missing', 'name', '')
         name = args["name"]
         if not isinstance(name, str) and not isinstance(name, unicode):
-            raise (TypeError("string", repr(name)))
+            raise TypeError("string", repr(name))
         if not('description' in args):
             raise UnmarshalException('argument missing', 'description', '')
         description = args["description"]
         if not isinstance(description, str) and not isinstance(description, unicode):
-            raise (TypeError("string", repr(description)))
+            raise TypeError("string", repr(description))
         if not('size' in args):
             raise UnmarshalException('argument missing', 'size', '')
         size = args["size"]
         if not(is_long(size)):
-            raise (TypeError("int64", repr(size)))
+            raise TypeError("int64", repr(size))
         results = self._impl.create(dbg, sr, name, description, size)
         if not isinstance(results['key'], str) and not isinstance(results['key'], unicode):
-            raise (TypeError("string", repr(results['key'])))
+            raise TypeError("string", repr(results['key']))
         if results['uuid'] is not None:
             if not isinstance(results['uuid'], str) and not isinstance(results['uuid'], unicode):
-                raise (TypeError("string", repr(results['uuid'])))
+                raise TypeError("string", repr(results['uuid']))
         if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
-            raise (TypeError("string", repr(results['name'])))
+            raise TypeError("string", repr(results['name']))
         if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
-            raise (TypeError("string", repr(results['description'])))
+            raise TypeError("string", repr(results['description']))
         if not isinstance(results['read_write'], bool):
-            raise (TypeError("bool", repr(results['read_write'])))
+            raise TypeError("bool", repr(results['read_write']))
         if not(is_long(results['virtual_size'])):
-            raise (TypeError("int64", repr(results['virtual_size'])))
+            raise TypeError("int64", repr(results['virtual_size']))
         if not(is_long(results['physical_utilisation'])):
-            raise (TypeError("int64", repr(results['physical_utilisation'])))
+            raise TypeError("int64", repr(results['physical_utilisation']))
         if not isinstance(results['uri'], list):
-            raise (TypeError("string list", repr(results['uri'])))
+            raise TypeError("string list", repr(results['uri']))
         for tmp_5 in results['uri']:
             if not isinstance(tmp_5, str) and not isinstance(tmp_5, unicode):
-                raise (TypeError("string", repr(tmp_5)))
+                raise TypeError("string", repr(tmp_5))
         if not isinstance(results['keys'], dict):
-            raise (TypeError("(string * string) list", repr(results['keys'])))
+            raise TypeError("(string * string) list", repr(results['keys']))
         for tmp_6 in results['keys'].keys():
             if not isinstance(tmp_6, str) and not isinstance(tmp_6, unicode):
-                raise (TypeError("string", repr(tmp_6)))
+                raise TypeError("string", repr(tmp_6))
         for tmp_6 in results['keys'].values():
             if not isinstance(tmp_6, str) and not isinstance(tmp_6, unicode):
-                raise (TypeError("string", repr(tmp_6)))
+                raise TypeError("string", repr(tmp_6))
         return results
     def snapshot(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         results = self._impl.snapshot(dbg, sr, key)
         if not isinstance(results['key'], str) and not isinstance(results['key'], unicode):
-            raise (TypeError("string", repr(results['key'])))
+            raise TypeError("string", repr(results['key']))
         if results['uuid'] is not None:
             if not isinstance(results['uuid'], str) and not isinstance(results['uuid'], unicode):
-                raise (TypeError("string", repr(results['uuid'])))
+                raise TypeError("string", repr(results['uuid']))
         if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
-            raise (TypeError("string", repr(results['name'])))
+            raise TypeError("string", repr(results['name']))
         if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
-            raise (TypeError("string", repr(results['description'])))
+            raise TypeError("string", repr(results['description']))
         if not isinstance(results['read_write'], bool):
-            raise (TypeError("bool", repr(results['read_write'])))
+            raise TypeError("bool", repr(results['read_write']))
         if not(is_long(results['virtual_size'])):
-            raise (TypeError("int64", repr(results['virtual_size'])))
+            raise TypeError("int64", repr(results['virtual_size']))
         if not(is_long(results['physical_utilisation'])):
-            raise (TypeError("int64", repr(results['physical_utilisation'])))
+            raise TypeError("int64", repr(results['physical_utilisation']))
         if not isinstance(results['uri'], list):
-            raise (TypeError("string list", repr(results['uri'])))
+            raise TypeError("string list", repr(results['uri']))
         for tmp_7 in results['uri']:
             if not isinstance(tmp_7, str) and not isinstance(tmp_7, unicode):
-                raise (TypeError("string", repr(tmp_7)))
+                raise TypeError("string", repr(tmp_7))
         if not isinstance(results['keys'], dict):
-            raise (TypeError("(string * string) list", repr(results['keys'])))
+            raise TypeError("(string * string) list", repr(results['keys']))
         for tmp_8 in results['keys'].keys():
             if not isinstance(tmp_8, str) and not isinstance(tmp_8, unicode):
-                raise (TypeError("string", repr(tmp_8)))
+                raise TypeError("string", repr(tmp_8))
         for tmp_8 in results['keys'].values():
             if not isinstance(tmp_8, str) and not isinstance(tmp_8, unicode):
-                raise (TypeError("string", repr(tmp_8)))
+                raise TypeError("string", repr(tmp_8))
         return results
     def clone(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         results = self._impl.clone(dbg, sr, key)
         if not isinstance(results['key'], str) and not isinstance(results['key'], unicode):
-            raise (TypeError("string", repr(results['key'])))
+            raise TypeError("string", repr(results['key']))
         if results['uuid'] is not None:
             if not isinstance(results['uuid'], str) and not isinstance(results['uuid'], unicode):
-                raise (TypeError("string", repr(results['uuid'])))
+                raise TypeError("string", repr(results['uuid']))
         if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
-            raise (TypeError("string", repr(results['name'])))
+            raise TypeError("string", repr(results['name']))
         if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
-            raise (TypeError("string", repr(results['description'])))
+            raise TypeError("string", repr(results['description']))
         if not isinstance(results['read_write'], bool):
-            raise (TypeError("bool", repr(results['read_write'])))
+            raise TypeError("bool", repr(results['read_write']))
         if not(is_long(results['virtual_size'])):
-            raise (TypeError("int64", repr(results['virtual_size'])))
+            raise TypeError("int64", repr(results['virtual_size']))
         if not(is_long(results['physical_utilisation'])):
-            raise (TypeError("int64", repr(results['physical_utilisation'])))
+            raise TypeError("int64", repr(results['physical_utilisation']))
         if not isinstance(results['uri'], list):
-            raise (TypeError("string list", repr(results['uri'])))
+            raise TypeError("string list", repr(results['uri']))
         for tmp_9 in results['uri']:
             if not isinstance(tmp_9, str) and not isinstance(tmp_9, unicode):
-                raise (TypeError("string", repr(tmp_9)))
+                raise TypeError("string", repr(tmp_9))
         if not isinstance(results['keys'], dict):
-            raise (TypeError("(string * string) list", repr(results['keys'])))
+            raise TypeError("(string * string) list", repr(results['keys']))
         for tmp_10 in results['keys'].keys():
             if not isinstance(tmp_10, str) and not isinstance(tmp_10, unicode):
-                raise (TypeError("string", repr(tmp_10)))
+                raise TypeError("string", repr(tmp_10))
         for tmp_10 in results['keys'].values():
             if not isinstance(tmp_10, str) and not isinstance(tmp_10, unicode):
-                raise (TypeError("string", repr(tmp_10)))
+                raise TypeError("string", repr(tmp_10))
         return results
     def destroy(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         results = self._impl.destroy(dbg, sr, key)
         return results
     def set_name(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         if not('new_name' in args):
             raise UnmarshalException('argument missing', 'new_name', '')
         new_name = args["new_name"]
         if not isinstance(new_name, str) and not isinstance(new_name, unicode):
-            raise (TypeError("string", repr(new_name)))
+            raise TypeError("string", repr(new_name))
         results = self._impl.set_name(dbg, sr, key, new_name)
         return results
     def set_description(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         if not('new_description' in args):
             raise UnmarshalException('argument missing', 'new_description', '')
         new_description = args["new_description"]
         if not isinstance(new_description, str) and not isinstance(new_description, unicode):
-            raise (TypeError("string", repr(new_description)))
+            raise TypeError("string", repr(new_description))
         results = self._impl.set_description(dbg, sr, key, new_description)
         return results
     def set(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         if not('k' in args):
             raise UnmarshalException('argument missing', 'k', '')
         k = args["k"]
         if not isinstance(k, str) and not isinstance(k, unicode):
-            raise (TypeError("string", repr(k)))
+            raise TypeError("string", repr(k))
         if not('v' in args):
             raise UnmarshalException('argument missing', 'v', '')
         v = args["v"]
         if not isinstance(v, str) and not isinstance(v, unicode):
-            raise (TypeError("string", repr(v)))
+            raise TypeError("string", repr(v))
         results = self._impl.set(dbg, sr, key, k, v)
         return results
     def unset(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         if not('k' in args):
             raise UnmarshalException('argument missing', 'k', '')
         k = args["k"]
         if not isinstance(k, str) and not isinstance(k, unicode):
-            raise (TypeError("string", repr(k)))
+            raise TypeError("string", repr(k))
         results = self._impl.unset(dbg, sr, key, k)
         return results
     def resize(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         if not('new_size' in args):
             raise UnmarshalException('argument missing', 'new_size', '')
         new_size = args["new_size"]
         if not(is_long(new_size)):
-            raise (TypeError("int64", repr(new_size)))
+            raise TypeError("int64", repr(new_size))
         results = self._impl.resize(dbg, sr, key, new_size)
         return results
     def stat(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
         if not isinstance(key, str) and not isinstance(key, unicode):
-            raise (TypeError("string", repr(key)))
+            raise TypeError("string", repr(key))
         results = self._impl.stat(dbg, sr, key)
         if not isinstance(results['key'], str) and not isinstance(results['key'], unicode):
-            raise (TypeError("string", repr(results['key'])))
+            raise TypeError("string", repr(results['key']))
         if results['uuid'] is not None:
             if not isinstance(results['uuid'], str) and not isinstance(results['uuid'], unicode):
-                raise (TypeError("string", repr(results['uuid'])))
+                raise TypeError("string", repr(results['uuid']))
         if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
-            raise (TypeError("string", repr(results['name'])))
+            raise TypeError("string", repr(results['name']))
         if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
-            raise (TypeError("string", repr(results['description'])))
+            raise TypeError("string", repr(results['description']))
         if not isinstance(results['read_write'], bool):
-            raise (TypeError("bool", repr(results['read_write'])))
+            raise TypeError("bool", repr(results['read_write']))
         if not(is_long(results['virtual_size'])):
-            raise (TypeError("int64", repr(results['virtual_size'])))
+            raise TypeError("int64", repr(results['virtual_size']))
         if not(is_long(results['physical_utilisation'])):
-            raise (TypeError("int64", repr(results['physical_utilisation'])))
+            raise TypeError("int64", repr(results['physical_utilisation']))
         if not isinstance(results['uri'], list):
-            raise (TypeError("string list", repr(results['uri'])))
+            raise TypeError("string list", repr(results['uri']))
         for tmp_11 in results['uri']:
             if not isinstance(tmp_11, str) and not isinstance(tmp_11, unicode):
-                raise (TypeError("string", repr(tmp_11)))
+                raise TypeError("string", repr(tmp_11))
         if not isinstance(results['keys'], dict):
-            raise (TypeError("(string * string) list", repr(results['keys'])))
+            raise TypeError("(string * string) list", repr(results['keys']))
         for tmp_12 in results['keys'].keys():
             if not isinstance(tmp_12, str) and not isinstance(tmp_12, unicode):
-                raise (TypeError("string", repr(tmp_12)))
+                raise TypeError("string", repr(tmp_12))
         for tmp_12 in results['keys'].values():
             if not isinstance(tmp_12, str) and not isinstance(tmp_12, unicode):
-                raise (TypeError("string", repr(tmp_12)))
+                raise TypeError("string", repr(tmp_12))
         return results
     def _dispatch(self, method, params):
         """type check inputs, call implementation, type check outputs and return"""
@@ -788,264 +788,264 @@ class SR_server_dispatcher:
     def probe(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         results = self._impl.probe(dbg, uri)
         if not isinstance(results['srs'], list):
-            raise (TypeError("7 list", repr(results['srs'])))
+            raise TypeError("7 list", repr(results['srs']))
         for tmp_13 in results['srs']:
             if not isinstance(tmp_13['sr'], str) and not isinstance(tmp_13['sr'], unicode):
-                raise (TypeError("string", repr(tmp_13['sr'])))
+                raise TypeError("string", repr(tmp_13['sr']))
             if not isinstance(tmp_13['name'], str) and not isinstance(tmp_13['name'], unicode):
-                raise (TypeError("string", repr(tmp_13['name'])))
+                raise TypeError("string", repr(tmp_13['name']))
             if not isinstance(tmp_13['description'], str) and not isinstance(tmp_13['description'], unicode):
-                raise (TypeError("string", repr(tmp_13['description'])))
+                raise TypeError("string", repr(tmp_13['description']))
             if not(is_long(tmp_13['free_space'])):
-                raise (TypeError("int64", repr(tmp_13['free_space'])))
+                raise TypeError("int64", repr(tmp_13['free_space']))
             if not(is_long(tmp_13['total_space'])):
-                raise (TypeError("int64", repr(tmp_13['total_space'])))
+                raise TypeError("int64", repr(tmp_13['total_space']))
             if not isinstance(tmp_13['datasources'], list):
-                raise (TypeError("string list", repr(tmp_13['datasources'])))
+                raise TypeError("string list", repr(tmp_13['datasources']))
             for tmp_14 in tmp_13['datasources']:
                 if not isinstance(tmp_14, str) and not isinstance(tmp_14, unicode):
-                    raise (TypeError("string", repr(tmp_14)))
+                    raise TypeError("string", repr(tmp_14))
             if not isinstance(tmp_13['clustered'], bool):
-                raise (TypeError("bool", repr(tmp_13['clustered'])))
+                raise TypeError("bool", repr(tmp_13['clustered']))
             if tmp_13['health'][0] == 'Healthy':
                 if not isinstance(tmp_13['health'][1], str) and not isinstance(tmp_13['health'][1], unicode):
-                    raise (TypeError("string", repr(tmp_13['health'][1])))
+                    raise TypeError("string", repr(tmp_13['health'][1]))
             elif tmp_13['health'][0] == 'Recovering':
                 if not isinstance(tmp_13['health'][1], str) and not isinstance(tmp_13['health'][1], unicode):
-                    raise (TypeError("string", repr(tmp_13['health'][1])))
+                    raise TypeError("string", repr(tmp_13['health'][1]))
         if not isinstance(results['uris'], list):
-            raise (TypeError("string list", repr(results['uris'])))
+            raise TypeError("string list", repr(results['uris']))
         for tmp_15 in results['uris']:
             if not isinstance(tmp_15, str) and not isinstance(tmp_15, unicode):
-                raise (TypeError("string", repr(tmp_15)))
+                raise TypeError("string", repr(tmp_15))
         return results
     def create(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         if not('name' in args):
             raise UnmarshalException('argument missing', 'name', '')
         name = args["name"]
         if not isinstance(name, str) and not isinstance(name, unicode):
-            raise (TypeError("string", repr(name)))
+            raise TypeError("string", repr(name))
         if not('description' in args):
             raise UnmarshalException('argument missing', 'description', '')
         description = args["description"]
         if not isinstance(description, str) and not isinstance(description, unicode):
-            raise (TypeError("string", repr(description)))
+            raise TypeError("string", repr(description))
         if not('configuration' in args):
             raise UnmarshalException('argument missing', 'configuration', '')
         configuration = args["configuration"]
         if not isinstance(configuration, dict):
-            raise (TypeError("(string * string) list", repr(configuration)))
+            raise TypeError("(string * string) list", repr(configuration))
         for tmp_16 in configuration.keys():
             if not isinstance(tmp_16, str) and not isinstance(tmp_16, unicode):
-                raise (TypeError("string", repr(tmp_16)))
+                raise TypeError("string", repr(tmp_16))
         for tmp_16 in configuration.values():
             if not isinstance(tmp_16, str) and not isinstance(tmp_16, unicode):
-                raise (TypeError("string", repr(tmp_16)))
+                raise TypeError("string", repr(tmp_16))
         results = self._impl.create(dbg, uri, name, description, configuration)
         return results
     def attach(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
         if not isinstance(uri, str) and not isinstance(uri, unicode):
-            raise (TypeError("string", repr(uri)))
+            raise TypeError("string", repr(uri))
         results = self._impl.attach(dbg, uri)
         if not isinstance(results, str) and not isinstance(results, unicode):
-            raise (TypeError("string", repr(results)))
+            raise TypeError("string", repr(results))
         return results
     def detach(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         results = self._impl.detach(dbg, sr)
         return results
     def destroy(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         results = self._impl.destroy(dbg, sr)
         return results
     def stat(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         results = self._impl.stat(dbg, sr)
         if not isinstance(results['sr'], str) and not isinstance(results['sr'], unicode):
-            raise (TypeError("string", repr(results['sr'])))
+            raise TypeError("string", repr(results['sr']))
         if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
-            raise (TypeError("string", repr(results['name'])))
+            raise TypeError("string", repr(results['name']))
         if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
-            raise (TypeError("string", repr(results['description'])))
+            raise TypeError("string", repr(results['description']))
         if not(is_long(results['free_space'])):
-            raise (TypeError("int64", repr(results['free_space'])))
+            raise TypeError("int64", repr(results['free_space']))
         if not(is_long(results['total_space'])):
-            raise (TypeError("int64", repr(results['total_space'])))
+            raise TypeError("int64", repr(results['total_space']))
         if not isinstance(results['datasources'], list):
-            raise (TypeError("string list", repr(results['datasources'])))
+            raise TypeError("string list", repr(results['datasources']))
         for tmp_17 in results['datasources']:
             if not isinstance(tmp_17, str) and not isinstance(tmp_17, unicode):
-                raise (TypeError("string", repr(tmp_17)))
+                raise TypeError("string", repr(tmp_17))
         if not isinstance(results['clustered'], bool):
-            raise (TypeError("bool", repr(results['clustered'])))
+            raise TypeError("bool", repr(results['clustered']))
         if results['health'][0] == 'Healthy':
             if not isinstance(results['health'][1], str) and not isinstance(results['health'][1], unicode):
-                raise (TypeError("string", repr(results['health'][1])))
+                raise TypeError("string", repr(results['health'][1]))
         elif results['health'][0] == 'Recovering':
             if not isinstance(results['health'][1], str) and not isinstance(results['health'][1], unicode):
-                raise (TypeError("string", repr(results['health'][1])))
+                raise TypeError("string", repr(results['health'][1]))
         return results
     def set_name(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('new_name' in args):
             raise UnmarshalException('argument missing', 'new_name', '')
         new_name = args["new_name"]
         if not isinstance(new_name, str) and not isinstance(new_name, unicode):
-            raise (TypeError("string", repr(new_name)))
+            raise TypeError("string", repr(new_name))
         results = self._impl.set_name(dbg, sr, new_name)
         return results
     def set_description(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         if not('new_description' in args):
             raise UnmarshalException('argument missing', 'new_description', '')
         new_description = args["new_description"]
         if not isinstance(new_description, str) and not isinstance(new_description, unicode):
-            raise (TypeError("string", repr(new_description)))
+            raise TypeError("string", repr(new_description))
         results = self._impl.set_description(dbg, sr, new_description)
         return results
     def ls(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
         if not isinstance(args, dict):
-            raise (UnmarshalException('arguments', 'dict', repr(args)))
+            raise UnmarshalException('arguments', 'dict', repr(args))
         if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
         if not isinstance(dbg, str) and not isinstance(dbg, unicode):
-            raise (TypeError("string", repr(dbg)))
+            raise TypeError("string", repr(dbg))
         if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
         if not isinstance(sr, str) and not isinstance(sr, unicode):
-            raise (TypeError("string", repr(sr)))
+            raise TypeError("string", repr(sr))
         results = self._impl.ls(dbg, sr)
         if not isinstance(results, list):
-            raise (TypeError("8 list", repr(results)))
+            raise TypeError("8 list", repr(results))
         for tmp_18 in results:
             if not isinstance(tmp_18['key'], str) and not isinstance(tmp_18['key'], unicode):
-                raise (TypeError("string", repr(tmp_18['key'])))
+                raise TypeError("string", repr(tmp_18['key']))
             if tmp_18['uuid'] is not None:
                 if not isinstance(tmp_18['uuid'], str) and not isinstance(tmp_18['uuid'], unicode):
-                    raise (TypeError("string", repr(tmp_18['uuid'])))
+                    raise TypeError("string", repr(tmp_18['uuid']))
             if not isinstance(tmp_18['name'], str) and not isinstance(tmp_18['name'], unicode):
-                raise (TypeError("string", repr(tmp_18['name'])))
+                raise TypeError("string", repr(tmp_18['name']))
             if not isinstance(tmp_18['description'], str) and not isinstance(tmp_18['description'], unicode):
-                raise (TypeError("string", repr(tmp_18['description'])))
+                raise TypeError("string", repr(tmp_18['description']))
             if not isinstance(tmp_18['read_write'], bool):
-                raise (TypeError("bool", repr(tmp_18['read_write'])))
+                raise TypeError("bool", repr(tmp_18['read_write']))
             if not(is_long(tmp_18['virtual_size'])):
-                raise (TypeError("int64", repr(tmp_18['virtual_size'])))
+                raise TypeError("int64", repr(tmp_18['virtual_size']))
             if not(is_long(tmp_18['physical_utilisation'])):
-                raise (TypeError("int64", repr(tmp_18['physical_utilisation'])))
+                raise TypeError("int64", repr(tmp_18['physical_utilisation']))
             if not isinstance(tmp_18['uri'], list):
-                raise (TypeError("string list", repr(tmp_18['uri'])))
+                raise TypeError("string list", repr(tmp_18['uri']))
             for tmp_19 in tmp_18['uri']:
                 if not isinstance(tmp_19, str) and not isinstance(tmp_19, unicode):
-                    raise (TypeError("string", repr(tmp_19)))
+                    raise TypeError("string", repr(tmp_19))
             if not isinstance(tmp_18['keys'], dict):
-                raise (TypeError("(string * string) list", repr(tmp_18['keys'])))
+                raise TypeError("(string * string) list", repr(tmp_18['keys']))
             for tmp_20 in tmp_18['keys'].keys():
                 if not isinstance(tmp_20, str) and not isinstance(tmp_20, unicode):
-                    raise (TypeError("string", repr(tmp_20)))
+                    raise TypeError("string", repr(tmp_20))
             for tmp_20 in tmp_18['keys'].values():
                 if not isinstance(tmp_20, str) and not isinstance(tmp_20, unicode):
-                    raise (TypeError("string", repr(tmp_20)))
+                    raise TypeError("string", repr(tmp_20))
         return results
     def _dispatch(self, method, params):
         """type check inputs, call implementation, type check outputs and return"""


### PR DESCRIPTION
- Remove optional parentheses for "raise (...AnyException..)))":
  ```ml
  sed -i '/raise (/s/)$//  ;  s/raise (/raise /' $(find ocaml -name *.py
  ```
  Also updates these in with the same change:
  - ocaml/message-switch/python/message_switch.py
  - ocaml/xapi-idl/designs/interprocesscomms.md