### PR TITLE
ocaml/xapi-storage/python/xapi/**.py: modernize -f except,print

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build/
+*.bak
 *.native
 .merlin
 *.install

--- a/ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py
+++ b/ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+from __future__ import print_function
 import os
 import sys
 import urlparse
@@ -127,4 +128,4 @@ if __name__ == "__main__":
     else:
         cmds = ['Datapath.{}'.format(x) for x in dir(cmd) if not x.startswith('_')]
         for name in cmds:
-            print name
+            print(name)

--- a/ocaml/xapi-storage/python/examples/datapath/loop+blkback/plugin.py
+++ b/ocaml/xapi-storage/python/examples/datapath/loop+blkback/plugin.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+from __future__ import print_function
 import os
 import sys
 
@@ -53,4 +54,4 @@ if __name__ == "__main__":
     else:
         cmds = ['Plugin.{}'.format(x) for x in dir(cmd) if not x.startswith('_')]
         for name in cmds:
-            print name
+            print(name)

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/plugin.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/plugin.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+from __future__ import print_function
 import os
 import sys
 
@@ -70,4 +71,4 @@ if __name__ == "__main__":
     else:
         cmds = ['Plugin.{}'.format(x) for x in dir(cmd) if not x.startswith('_')]
         for name in cmds:
-            print name
+            print(name)

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/sr.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/sr.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+from __future__ import print_function
 import os
 import sys
 import urllib
@@ -158,4 +159,4 @@ if __name__ == "__main__":
     else:
         cmds = ['SR.{}'.format(x) for x in dir(cmd) if not x.startswith('_')]
         for name in cmds:
-            print name
+            print(name)

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/volume.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/volume.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+from __future__ import print_function
 import glob
 import json
 import os
@@ -210,4 +211,4 @@ if __name__ == "__main__":
     else:
         cmds = ['Volume.{}'.format(x) for x in dir(cmd) if not x.startswith('_')]
         for name in cmds:
-            print name
+            print(name)

--- a/ocaml/xapi-storage/python/xapi/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/__init__.py
@@ -25,6 +25,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+from __future__ import print_function
 import sys
 import traceback
 import json
@@ -58,7 +59,7 @@ def handle_exception(e, code=None, params=None):
         "params": params,
         "backtrace": backtrace,
     }
-    print >>sys.stdout, json.dumps(results)
+    print(json.dumps(results), file=sys.stdout)
     sys.exit(1)
 
 

--- a/ocaml/xapi-storage/python/xapi/storage/api/datapath.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/datapath.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from xapi import success, Rpc_light_failure, InternalError, UnmarshalException, TypeError, is_long, UnknownMethod
 import xapi
 import sys
@@ -302,8 +303,8 @@ class Datapath_commandline():
             request = self._parse_open()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.open(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -315,8 +316,8 @@ class Datapath_commandline():
             request = self._parse_attach()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.attach(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -328,8 +329,8 @@ class Datapath_commandline():
             request = self._parse_activate()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.activate(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -341,8 +342,8 @@ class Datapath_commandline():
             request = self._parse_deactivate()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.deactivate(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -354,8 +355,8 @@ class Datapath_commandline():
             request = self._parse_detach()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.detach(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -367,8 +368,8 @@ class Datapath_commandline():
             request = self._parse_close()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.close(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -384,7 +385,7 @@ class datapath_server_dispatcher:
             if method.startswith("Datapath") and self.Datapath:
                 return self.Datapath._dispatch(method, params)
             raise UnknownMethod(method)
-        except Exception, e:
+        except Exception as e:
             logging.info("caught %s" % e)
             traceback.print_exc()
             try:

--- a/ocaml/xapi-storage/python/xapi/storage/api/plugin.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/plugin.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from xapi import success, Rpc_light_failure, InternalError, UnmarshalException, TypeError, is_long, UnknownMethod
 import xapi
 import sys
@@ -173,8 +174,8 @@ class Plugin_commandline():
             request = self._parse_query()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.query(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -186,8 +187,8 @@ class Plugin_commandline():
             request = self._parse_ls()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.ls(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -199,8 +200,8 @@ class Plugin_commandline():
             request = self._parse_diagnostics()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.diagnostics(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -216,7 +217,7 @@ class plugin_server_dispatcher:
             if method.startswith("Plugin") and self.Plugin:
                 return self.Plugin._dispatch(method, params)
             raise UnknownMethod(method)
-        except Exception, e:
+        except Exception as e:
             logging.info("caught %s" % e)
             traceback.print_exc()
             try:

--- a/ocaml/xapi-storage/python/xapi/storage/api/volume.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/volume.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from xapi import success, Rpc_light_failure, InternalError, UnmarshalException, TypeError, is_long, UnknownMethod
 import xapi
 import sys
@@ -656,8 +657,8 @@ class Volume_commandline():
             request = self._parse_create()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.create(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -669,8 +670,8 @@ class Volume_commandline():
             request = self._parse_snapshot()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.snapshot(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -682,8 +683,8 @@ class Volume_commandline():
             request = self._parse_clone()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.clone(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -695,8 +696,8 @@ class Volume_commandline():
             request = self._parse_destroy()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.destroy(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -708,8 +709,8 @@ class Volume_commandline():
             request = self._parse_set_name()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.set_name(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -721,8 +722,8 @@ class Volume_commandline():
             request = self._parse_set_description()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.set_description(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -734,8 +735,8 @@ class Volume_commandline():
             request = self._parse_set()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.set(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -747,8 +748,8 @@ class Volume_commandline():
             request = self._parse_unset()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.unset(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -760,8 +761,8 @@ class Volume_commandline():
             request = self._parse_resize()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.resize(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -773,8 +774,8 @@ class Volume_commandline():
             request = self._parse_stat()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.stat(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1267,8 +1268,8 @@ class SR_commandline():
             request = self._parse_probe()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.probe(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1280,8 +1281,8 @@ class SR_commandline():
             request = self._parse_create()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.create(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1293,8 +1294,8 @@ class SR_commandline():
             request = self._parse_attach()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.attach(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1306,8 +1307,8 @@ class SR_commandline():
             request = self._parse_detach()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.detach(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1319,8 +1320,8 @@ class SR_commandline():
             request = self._parse_destroy()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.destroy(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1332,8 +1333,8 @@ class SR_commandline():
             request = self._parse_stat()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.stat(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1345,8 +1346,8 @@ class SR_commandline():
             request = self._parse_set_name()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.set_name(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1358,8 +1359,8 @@ class SR_commandline():
             request = self._parse_set_description()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.set_description(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1371,8 +1372,8 @@ class SR_commandline():
             request = self._parse_ls()
             use_json = 'json' in request and request['json']
             results = self.dispatcher.ls(request)
-            print json.dumps(results)
-        except Exception, e:
+            print(json.dumps(results))
+        except Exception as e:
             if use_json:
                 xapi.handle_exception(e)
             else:
@@ -1391,7 +1392,7 @@ class volume_server_dispatcher:
             elif method.startswith("SR") and self.SR:
                 return self.SR._dispatch(method, params)
             raise UnknownMethod(method)
-        except Exception, e:
+        except Exception as e:
             logging.info("caught %s" % e)
             traceback.print_exc()
             try:

--- a/ocaml/xapi-storage/python/xapi/storage/api/volume.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/volume.py
@@ -6,6 +6,14 @@ import json
 import argparse
 import traceback
 import logging
+
+# pylint: disable=invalid-name,redefined-builtin,undefined-variable
+# pyright: reportUndefinedVariable=false
+if sys.version_info[0] > 2:
+    long = int
+    unicode = str
+    str = bytes
+
 class Sr_not_attached(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Sr_not_attached", [ arg_0 ])
@@ -467,17 +475,17 @@ class Volume_test:
     def create(self, dbg, sr, name, description, size):
         """Operations which operate on volumes (also known as Virtual Disk Images)"""
         result = {}
-        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
+        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": long(0), "physical_utilisation": long(0), "uri": [ "string", "string" ], "keys": { "string": "string" } }
         return result
     def snapshot(self, dbg, sr, key):
         """Operations which operate on volumes (also known as Virtual Disk Images)"""
         result = {}
-        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
+        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": long(0), "physical_utilisation": long(0), "uri": [ "string", "string" ], "keys": { "string": "string" } }
         return result
     def clone(self, dbg, sr, key):
         """Operations which operate on volumes (also known as Virtual Disk Images)"""
         result = {}
-        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
+        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": long(0), "physical_utilisation": long(0), "uri": [ "string", "string" ], "keys": { "string": "string" } }
         return result
     def destroy(self, dbg, sr, key):
         """Operations which operate on volumes (also known as Virtual Disk Images)"""
@@ -506,7 +514,7 @@ class Volume_test:
     def stat(self, dbg, sr, key):
         """Operations which operate on volumes (also known as Virtual Disk Images)"""
         result = {}
-        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
+        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": long(0), "physical_utilisation": long(0), "uri": [ "string", "string" ], "keys": { "string": "string" } }
         return result
 class Volume_commandline():
     """Parse command-line arguments and call an implementation."""
@@ -1107,7 +1115,7 @@ class SR_test:
     def probe(self, dbg, uri):
         """Operations which act on Storage Repositories"""
         result = {}
-        result["result"] = { "srs": [ { "sr": "string", "name": "string", "description": "string", "free_space": 0L, "total_space": 0L, "datasources": [ "string", "string" ], "clustered": True, "health": None }, { "sr": "string", "name": "string", "description": "string", "free_space": 0L, "total_space": 0L, "datasources": [ "string", "string" ], "clustered": True, "health": None } ], "uris": [ "string", "string" ] }
+        result["result"] = { "srs": [ { "sr": "string", "name": "string", "description": "string", "free_space": long(0), "total_space": long(0), "datasources": [ "string", "string" ], "clustered": True, "health": None }, { "sr": "string", "name": "string", "description": "string", "free_space": long(0), "total_space": long(0), "datasources": [ "string", "string" ], "clustered": True, "health": None } ], "uris": [ "string", "string" ] }
         return result
     def create(self, dbg, uri, name, description, configuration):
         """Operations which act on Storage Repositories"""
@@ -1129,7 +1137,7 @@ class SR_test:
     def stat(self, dbg, sr):
         """Operations which act on Storage Repositories"""
         result = {}
-        result["sr"] = { "sr": "string", "name": "string", "description": "string", "free_space": 0L, "total_space": 0L, "datasources": [ "string", "string" ], "clustered": True, "health": None }
+        result["sr"] = { "sr": "string", "name": "string", "description": "string", "free_space": long(0), "total_space": long(0), "datasources": [ "string", "string" ], "clustered": True, "health": None }
         return result
     def set_name(self, dbg, sr, new_name):
         """Operations which act on Storage Repositories"""
@@ -1142,7 +1150,7 @@ class SR_test:
     def ls(self, dbg, sr):
         """Operations which act on Storage Repositories"""
         result = {}
-        result["volumes"] = [ { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }, { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } } ]
+        result["volumes"] = [ { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": long(0), "physical_utilisation": long(0), "uri": [ "string", "string" ], "keys": { "string": "string" } }, { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": long(0), "physical_utilisation": long(0), "uri": [ "string", "string" ], "keys": { "string": "string" } } ]
         return result
 class SR_commandline():
     """Parse command-line arguments and call an implementation."""


### PR DESCRIPTION
Reviewed by me(@bernhardkaindl):

Migrate `xapi-storage` Python code to Python3: __Initial part of step 1__:

In order for a clear and easy review, this commit adds only two fixes:
```ml
modernize -wf except,print $(find ocaml/xapi-storage/xapi -name *.py)
```
This `modernize` makes these changes:
- `except Exception, e` to: `except Exception as e`
- Updates print() with `from __future__ import print_function`, for forcing Python2 to `raise SyntaxError` on Python2 `print` (the import of print_function could be omitted without problem)