### PR TITLE
CA-378757: remove "EvacuateHost" from recommended guidance

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -750,8 +750,12 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
   (* Evaluate recommended/pending guidances *)
   let recommended_guidances, pending_guidances =
     let recommended_guidances' =
-      eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
-        ~livepatches:successful_livepatches ~failed_livepatches
+      (* EvacuateHost will be applied before applying updates *)
+      List.filter
+        (fun g -> not (g = Guidance.EvacuateHost))
+        (eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
+           ~livepatches:successful_livepatches ~failed_livepatches
+        )
     in
     let pending_guidances' =
       List.filter

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -751,18 +751,15 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
   let recommended_guidances, pending_guidances =
     let recommended_guidances' =
       (* EvacuateHost will be applied before applying updates *)
-      List.filter
-        (fun g -> g <> Guidance.EvacuateHost)
-        (eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
-           ~livepatches:successful_livepatches ~failed_livepatches
-        )
+      eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
+        ~livepatches:successful_livepatches ~failed_livepatches
+      |> List.filter (fun g -> g <> Guidance.EvacuateHost)
     in
+
     let pending_guidances' =
-      List.filter
-        (fun g -> not (List.mem g recommended_guidances'))
-        (eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Absolute
-           ~livepatches:[] ~failed_livepatches:[]
-        )
+      eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Absolute
+        ~livepatches:[] ~failed_livepatches:[]
+      |> List.filter (fun g -> not (List.mem g recommended_guidances'))
     in
     match failed_livepatches with
     | [] ->

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -752,7 +752,7 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
     let recommended_guidances' =
       (* EvacuateHost will be applied before applying updates *)
       List.filter
-        (fun g -> not (g = Guidance.EvacuateHost))
+        (fun g -> g <> Guidance.EvacuateHost)
         (eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
            ~livepatches:successful_livepatches ~failed_livepatches
         )
@@ -775,9 +775,7 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
          * the host should not be rebooted, and
          * an extra pending guidance 'RebootHostOnLivePatchFailure' should be set.
          *)
-        ( List.filter
-            (fun g -> not (g = Guidance.RebootHost))
-            recommended_guidances'
+        ( List.filter (fun g -> g <> Guidance.RebootHost) recommended_guidances'
         , Guidance.RebootHostOnLivePatchFailure :: pending_guidances'
         )
   in


### PR DESCRIPTION
In the update applying process, "EvacuateHost" will be applied before applying updates.