### PR TITLE
Instrument named mutexes with distributed tracing

### DIFF
--- a/ocaml/libs/http-lib/xmlrpc_client.mli
+++ b/ocaml/libs/http-lib/xmlrpc_client.mli
@@ -138,14 +138,9 @@ end
 module Internal : sig
   (** Internal functions should not be used by clients directly *)
 
-  val set_stunnelpid_callback : (string option -> int -> unit) option ref
-  (** When invoking an XMLRPC call over HTTPS via stunnel, this callback
-      		is called to allow us to store the association between a task and an
-      		stunnel pid *)
-
-  val unset_stunnelpid_callback : (string option -> int -> unit) option ref
-  (** After invoking an XMLRPC call over HTTPS via stunnel, this callback
-      		is called to allow us to forget the association between a task and an
+  val set_stunnelpid_callback : (string option -> int -> unit -> unit) -> unit
+  (** When invoking an XMLRPC call over HTTPS via stunnel, these callback
+      		are called to allow us to store and forget the association between a task and an
       		stunnel pid *)
 
   val destination_is_ok : (string -> bool) option ref

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -416,21 +416,19 @@ module Tracer = struct
       Spans.add_to_spans ~span ; Ok (Some span)
 
   let finish ?error span =
-    Ok
-      (Option.map
-         (fun span ->
-           let span =
-             match error with
-             | Some exn_t ->
-                 Span.set_error span exn_t
-             | None ->
-                 Span.set_ok span
-           in
-           let span = Span.finish ~span () in
-           Spans.mark_finished span ; span
-         )
-         span
-      )
+    match span with
+    | None ->
+        None
+    | Some span ->
+        let span =
+          match error with
+          | Some exn_t ->
+              Span.set_error span exn_t
+          | None ->
+              Span.set_ok span
+        in
+        let span = Span.finish ~span () in
+        Spans.mark_finished span ; Some span
 
   let span_is_finished x = Spans.span_is_finished x
 

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -73,8 +73,7 @@ module Tracer : sig
     -> unit
     -> (Span.t option, exn) result
 
-  val finish :
-    ?error:exn * string -> Span.t option -> (Span.t option, exn) result
+  val finish : ?error:exn * string -> Span.t option -> Span.t option
 
   val span_is_finished : Span.t option -> bool
 

--- a/ocaml/tests/bench/bechamel_simple_cli.ml
+++ b/ocaml/tests/bench/bechamel_simple_cli.ml
@@ -1,0 +1,49 @@
+(* based on bechamel example code *)
+open Bechamel
+open Toolkit
+
+let instances = Instance.[monotonic_clock; minor_allocated; major_allocated]
+
+let benchmark tests =
+  (* stabilize:true would be the default but it measures GC stabilization time as part of the function
+     runtime, leading to about 10x as much time measured than without.
+     It is also confusing for flamegraphs because the GC will show up much more frequently than in reality
+     due to the thousands of repeated calls.
+  *)
+  let cfg =
+    Benchmark.cfg
+      ~quota:Time.(second 5.0)
+      ~start:10 ~stabilize:false ~compaction:false ()
+  in
+  Benchmark.all cfg instances tests
+
+let analyze raw_results =
+  let ols =
+    Analyze.ols ~r_square:true ~bootstrap:0 ~predictors:[|Measure.run|]
+  in
+  let results =
+    List.map (fun instance -> Analyze.all ols instance raw_results) instances
+  in
+  (Analyze.merge ols instances results, raw_results)
+
+let () =
+  List.iter (fun i -> Bechamel_notty.Unit.add i (Measure.unit i)) instances
+
+let img (window, results) =
+  Bechamel_notty.Multiple.image_of_ols_results ~rect:window
+    ~predictor:Measure.run results
+
+open Notty_unix
+
+let cli tests =
+  Format.printf "@,Running benchmarks@." ;
+  let results, _ = tests |> benchmark |> analyze in
+
+  let window =
+    match winsize Unix.stdout with
+    | Some (w, h) ->
+        {Bechamel_notty.w; h}
+    | None ->
+        {Bechamel_notty.w= 80; h= 1}
+  in
+  img (window, results) |> eol |> output_image

--- a/ocaml/tests/bench/bench_named_mutex.ml
+++ b/ocaml/tests/bench/bench_named_mutex.ml
@@ -1,0 +1,50 @@
+open Bechamel
+
+let bench_tracing = true
+
+let test name allocate execute =
+  let test_mutex m = execute m ignore in
+  Test.make_with_resource ~name
+    Test.multiple (* TODO: Test.uniq segfaults here, bechamel bug *)
+    ~allocate ~free:ignore (Staged.stage test_mutex)
+
+let mutex_lock_unlock m f = Mutex.lock m ; f () ; Mutex.unlock m
+
+let tracing_benchmarks () =
+  let () = Suite_init.harness_init () in
+  let __context = Test_common.make_test_database () in
+  let observer =
+    Xapi_observer.create ~__context ~name_label:"test" ~name_description:""
+      ~hosts:[] ~attributes:[] ~endpoints:["bugtool"] ~components:["xapi"]
+      ~enabled:true
+  in
+  let host = !Xapi_globs.localhost_ref in
+  let () = Xapi_observer.register ~__context ~self:observer ~host in
+  let open Locking_helpers in
+  let named_trace_execute m f =
+    Context.with_tracing __context "bench" @@ fun __context ->
+    Named_mutex.execute m f
+  in
+  test "NamedMutex.execute (tracing)"
+    (fun () -> Named_mutex.create "test")
+    named_trace_execute
+
+let benchmarks =
+  let open Locking_helpers in
+  let named_execute m f = Named_mutex.execute m f in
+  Test.make_grouped ~name:"Mutex"
+    ([
+       test "Mutex.lock/unlock" Mutex.create mutex_lock_unlock
+     ; test "Mutex.execute" Mutex.create
+         Xapi_stdext_threads.Threadext.Mutex.execute
+     ; test "NamedMutex.execute"
+         (fun () -> Named_mutex.create "test")
+         named_execute
+     ]
+    @ if bench_tracing then [tracing_benchmarks ()] else []
+    )
+
+let () =
+  Gc.compact () ;
+  Memtrace.trace_if_requested () ;
+  Bechamel_simple_cli.cli benchmarks

--- a/ocaml/tests/bench/dune
+++ b/ocaml/tests/bench/dune
@@ -1,0 +1,6 @@
+(executable
+ (name bench_named_mutex)
+ (modes exe)
+ (optional)
+ (libraries bechamel xapi_internal bechamel-notty notty.unix xapi-stdext-threads tests_common memtrace)
+)

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -8,6 +8,7 @@
       test_vm_placement test_vm_helpers test_repository test_repository_helpers
       test_ref
       test_livepatch test_rpm test_updateinfo test_storage_smapiv1_wrapper test_storage_quicktest test_observer
+      test_locking_helpers
       test_pool_periodic_update_sync))
   (libraries
     alcotest
@@ -122,6 +123,13 @@
 (package xapi)
 (modules test_observer)
 (libraries alcotest tracing xapi_internal tests_common yojson))
+
+(test
+(name test_locking_helpers)
+(package xapi)
+(modules test_locking_helpers)
+(libraries alcotest tracing xapi_internal tests_common)
+)
 
 (rule
   (alias runtest)

--- a/ocaml/tests/test_locking_helpers.ml
+++ b/ocaml/tests/test_locking_helpers.ml
@@ -1,0 +1,280 @@
+open Locking_helpers
+
+let test_kill_resource () =
+  (* no-op *)
+  kill_resource (lock "foo") ;
+
+  Alcotest.check_raises "non-existent pid"
+    (Unix.Unix_error (Unix.ESRCH, "kill", ""))
+    (fun () ->
+      (* non-existent pid, we cannot use max_int here as that will result in a negative overflow when converted to a C int *)
+      kill_resource (process ("foo", 0x7FFF_FFFF))
+    )
+
+let test_is_process =
+  [
+    (lock "stunnel", false)
+  ; (process ("stunnel", 100), true)
+  ; (process ("other", 100), false)
+  ]
+  |> List.map @@ fun (resource, expected) ->
+     let test () =
+       Alcotest.(
+         check' ~msg:"is_process" bool ~expected
+           ~actual:(is_process "stunnel" resource)
+       )
+     in
+     Alcotest.(test_case (string_of_resource resource) `Quick test)
+
+let resource = Alcotest.testable (Fmt.of_to_string string_of_resource) ( = )
+
+let main = Thread.id (Thread.self ())
+
+let test_acquired_resources () =
+  let r = lock "locktest" in
+  let waiting = Thread_state.waiting_for r in
+  let acquired = Thread_state.acquired r waiting in
+
+  let lst = Thread_state.get_all_acquired_resources () in
+  Alcotest.(
+    check' (list resource) ~msg:"acquired resources" ~expected:[r] ~actual:lst
+  ) ;
+
+  let str = Thread_state.to_graphviz () in
+  ( if Thread.id (Thread.self ()) = main then
+      let expected =
+        {|digraph Resources {
+node [shape=Mrecord];
+t0 [label="{} | {NULL} | {Lock(locktest) | 0}"];
+node [shape=record];
+r0 [style=filled label="{lock} | {locktest}"];
+r0 -> t0
+rankdir=LR
+overlap=false
+label="Threads and resources"
+fontsize=12
+}|}
+      in
+      Alcotest.(check' string ~msg:"graphviz" ~expected ~actual:str)
+  ) ;
+
+  Thread_state.released r acquired ;
+  let lst = Thread_state.get_all_acquired_resources () in
+  Alcotest.(
+    check' (list resource) ~msg:"acquired resources (released)" ~expected:[]
+      ~actual:lst
+  )
+
+let test_single_task () =
+  (* cannot create it within the test since it'll be considered a leak *)
+  let __context = Test_common.make_test_database () in
+
+  let rpc, session_id = Test_common.make_client_params ~__context in
+  let self =
+    Client.Client.Task.create ~rpc ~session_id ~label:"task_label"
+      ~description:"task_description"
+  in
+  let r = lock "bar" in
+  Thread_state.with_named_thread "myname" self (fun () ->
+      let waiting = Thread_state.waiting_for r in
+      let acquired = Thread_state.acquired r waiting in
+
+      let lst = Thread_state.get_acquired_resources_by_task self in
+      Alcotest.(
+        check' (list resource) ~msg:"acquired resources" ~expected:[r]
+          ~actual:lst
+      ) ;
+
+      Thread_state.released r acquired ;
+      let lst = Thread_state.get_acquired_resources_by_task self in
+      Alcotest.(
+        check' (list resource) ~msg:"acquired resources (0)" ~expected:[]
+          ~actual:lst
+      )
+  ) ;
+  Client.Client.Task.destroy ~rpc ~session_id ~self ;
+  Db_gc.single_pass ()
+
+let test_named_mutex_simple () =
+  let name = "mytestmutex" in
+  let r = lock name in
+  let m = Named_mutex.create name in
+  Named_mutex.execute m (fun () ->
+      let lst = Thread_state.get_all_acquired_resources () in
+      Alcotest.(
+        check' (list resource) ~msg:"acquired resources (mutex)" ~expected:[r]
+          ~actual:lst
+      )
+  ) ;
+  let lst = Thread_state.get_all_acquired_resources () in
+  Alcotest.(
+    check' (list resource) ~msg:"acquired resources (mutex)" ~expected:[]
+      ~actual:lst
+  )
+
+let test_named_mutex_finally () =
+  let name = "mytestmutex2" in
+  let r = lock name in
+  let m = Named_mutex.create name in
+  Alcotest.check_raises "exit" Exit (fun () ->
+      Named_mutex.execute m (fun () ->
+          let lst = Thread_state.get_all_acquired_resources () in
+          Alcotest.(
+            check' (list resource) ~msg:"acquired resources (mutex)"
+              ~expected:[r] ~actual:lst
+          ) ;
+          raise Exit
+      )
+  ) ;
+  let lst = Thread_state.get_all_acquired_resources () in
+  Alcotest.(
+    check' (list resource) ~msg:"acquired resources (mutex)" ~expected:[]
+      ~actual:lst
+  ) ;
+  (* check that mutex got released, no deadlock *)
+  Named_mutex.execute m ignore
+
+module ThreadWrap = struct
+  type t = {
+      thread: Thread.t
+    ; failure: (Printexc.raw_backtrace * exn) option Atomic.t
+  }
+
+  let create f arg =
+    let failure = Atomic.make None in
+    let wrap f =
+      try f arg
+      with e ->
+        let bt = Printexc.get_raw_backtrace () in
+        Atomic.set failure (Some (bt, e))
+    in
+    {thread= Thread.create wrap f; failure}
+
+  let join t =
+    Thread.join t.thread ;
+    match Atomic.get t.failure with
+    | None ->
+        ()
+    | Some (bt, e) ->
+        Printexc.raise_with_backtrace e bt
+end
+
+let other_thread f () =
+  let thr = ThreadWrap.create f () in
+  ThreadWrap.join thr
+
+let full_gc () =
+  (* see comment in Gc module: finalisers may allocate and need a 2nd run *)
+  Gc.full_major () ; Gc.compact ()
+
+let no_table_leak f () =
+  (* could run 2 full_major, look at live words, but that is difficult to get working reliably across runtime versions
+     (sometimes the allocated memory goes negative, e.g. if some global gets freed)
+  *)
+  full_gc () ;
+  let before = Thread_state.known_threads () in
+  f () ;
+  full_gc () ;
+  let after = Thread_state.known_threads () in
+  Alcotest.(
+    check' int ~msg:"leaked thread table entry" ~expected:before ~actual:after
+  )
+
+let test_named_mutex_many i =
+  let name = "mytestmutex" ^ string_of_int i in
+  let r = lock name in
+  let m = Named_mutex.create name in
+  Named_mutex.execute m (fun () ->
+      let lst =
+        Thread_state.get_all_acquired_resources () |> List.filter (( = ) r)
+      in
+      Alcotest.(
+        check' (list resource) ~msg:"acquired resources (mutex)" ~expected:[r]
+          ~actual:lst
+      )
+  ) ;
+  let lst =
+    Thread_state.get_all_acquired_resources () |> List.filter (( = ) r)
+  in
+  Alcotest.(
+    check' (list resource) ~msg:"acquired resources (mutex)" ~expected:[]
+      ~actual:lst
+  )
+
+let shared_mutex = Named_mutex.create "shared"
+
+let shared_owner = Atomic.make (-1)
+
+let holders = Atomic.make 0
+
+let test_named_mutex_many_same j =
+  for i = 1 to 1000 do
+    Named_mutex.execute shared_mutex (fun () ->
+        let old_holders = Atomic.fetch_and_add holders 1 in
+        let actual = Atomic.exchange shared_owner j in
+        if actual <> -1 then
+          Fmt.failwith
+            "Shared owner already set to: %d (I am %d). Old holders = %d" actual
+            j old_holders ;
+
+        if i mod 10 = 0 then Thread.yield () ;
+
+        (* try to introduce more race conditions while holding the lock *)
+        if not (Atomic.compare_and_set shared_owner j (-1)) then
+          Fmt.failwith "Failed to restore shared owner" ;
+        Atomic.decr holders ;
+
+        if old_holders <> 0 then
+          Fmt.failwith
+            "Only one thread should be able to acquire the mutex at a time: %d"
+            old_holders
+    )
+  done
+
+let many_threads f () =
+  let waiting = Atomic.make 0 in
+  let n = 64 in
+  let test_thread i =
+    (* wait for all threads to start, to maximize race conditions *)
+    Atomic.incr waiting ;
+    while Atomic.get waiting <> n do
+      Thread.yield ()
+    done ;
+
+    f i
+  in
+
+  let threads = Array.init n @@ ThreadWrap.create test_thread in
+  Array.iter ThreadWrap.join threads
+
+let () =
+  Suite_init.harness_init () ;
+  Alcotest.(
+    run "Locking_helpers"
+      [
+        ("is_process", test_is_process)
+      ; ("kill_resource", [test_case "kill_resource" `Quick test_kill_resource])
+      ; ( "acquired resources"
+        , [
+            test_case "single thread" `Quick
+            @@ no_table_leak test_acquired_resources
+          ; test_case "single task" `Quick @@ no_table_leak test_single_task
+          ; test_case "single thread (other)" `Quick
+              (no_table_leak @@ other_thread test_acquired_resources)
+          ; test_case "single task (other)" `Quick
+              (no_table_leak @@ other_thread test_single_task)
+          ]
+        )
+      ; ( "named mutex"
+        , [
+            test_case "without tracing" `Quick
+            @@ no_table_leak test_named_mutex_simple
+          ; test_case "finally" `Quick @@ no_table_leak test_named_mutex_finally
+          ; test_case "race (64 threads)" `Slow
+              (no_table_leak @@ many_threads test_named_mutex_many)
+          ; test_case "race same (64 threads)" `Slow
+              (no_table_leak @@ many_threads test_named_mutex_many_same)
+          ]
+        )
+      ]
+  )

--- a/ocaml/tests/test_locking_helpers.ml
+++ b/ocaml/tests/test_locking_helpers.ml
@@ -274,6 +274,8 @@ let () =
               (no_table_leak @@ many_threads test_named_mutex_many)
           ; test_case "race same (64 threads)" `Slow
               (no_table_leak @@ many_threads test_named_mutex_many_same)
+          ; test_case "GC finalizer" `Quick
+              (no_table_leak @@ Locking_helpers.Named_mutex.Private.test_locking)
           ]
         )
       ]

--- a/ocaml/tests/test_observer.ml
+++ b/ocaml/tests/test_observer.ml
@@ -445,7 +445,7 @@ let test_tracing_exn_backtraces () =
       let stacktrace = Printexc.get_backtrace () in
       let x = Tracer.finish ~error:(e, stacktrace) x in
       match x with
-      | Ok (Some span) ->
+      | Some span ->
           let span_stacktrace = Span.get_tag span "exception.stacktrace" in
           debug "STACKTRACE: %s" span_stacktrace ;
           List.iter
@@ -457,10 +457,8 @@ let test_tracing_exn_backtraces () =
                 true function_match
             )
             ["raise_exn"; "test_b"; "test_a"]
-      | Ok None ->
+      | None ->
           Alcotest.failf "Span finish failed"
-      | Error _ ->
-          Alcotest.failf "Failed to fetch exception stacktrace"
     )
   )
   | Error e ->

--- a/ocaml/xapi/cert_refresh.ml
+++ b/ocaml/xapi/cert_refresh.ml
@@ -53,7 +53,7 @@ let unreachable_hosts ~__context =
 
 let maybe_update_clustering_tls_config ~__context =
   let open Xapi_clustering in
-  with_clustering_lock __LOC__ @@ fun () ->
+  with_clustering_lock ~__context __LOC__ @@ fun () ->
   let host = Helpers.get_localhost ~__context in
   match Xapi_clustering.find_cluster_host ~__context ~host with
   | None ->

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -55,21 +55,13 @@ type t = {
 }
 
 let complete_tracing __context =
-  ( match Tracing.Tracer.finish __context.tracing with
-  | Ok _ ->
-      ()
-  | Error e ->
-      R.warn "Failed to complete tracing: %s" (Printexc.to_string e)
-  ) ;
+  let (_ : Tracing.Span.t option) = Tracing.Tracer.finish __context.tracing in
   __context.tracing <- None
 
 let complete_tracing_with_exn __context error =
-  ( match Tracing.Tracer.finish ~error __context.tracing with
-  | Ok _ ->
-      ()
-  | Error e ->
-      R.warn "Failed to complete tracing: %s" (Printexc.to_string e)
-  ) ;
+  let (_ : Tracing.Span.t option) =
+    Tracing.Tracer.finish ~error __context.tracing
+  in
   __context.tracing <- None
 
 let tracing_of __context = __context.tracing

--- a/ocaml/xapi/local_work_queue.ml
+++ b/ocaml/xapi/local_work_queue.ml
@@ -64,7 +64,7 @@ let wait_in_line q description f =
   let state = ref `Pending in
   let waiting =
     Locking_helpers.Thread_state.waiting_for
-      (Locking_helpers.Lock q.Thread_queue.name)
+      (Locking_helpers.lock q.Thread_queue.name)
   in
   let ok =
     q.Thread_queue.push_fn description (fun () ->
@@ -91,11 +91,13 @@ let wait_in_line q description f =
   ) ;
   let acquired =
     Locking_helpers.Thread_state.acquired
-      (Locking_helpers.Lock q.Thread_queue.name) waiting
+      (Locking_helpers.lock q.Thread_queue.name)
+      waiting
   in
   finally f (fun () ->
       Locking_helpers.Thread_state.released
-        (Locking_helpers.Lock q.Thread_queue.name) acquired ;
+        (Locking_helpers.lock q.Thread_queue.name)
+        acquired ;
       with_lock m (fun () ->
           state := `Finished ;
           Condition.signal c

--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -11,7 +11,93 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
+module IntMap = Map.Make (Int)
+
+module Thread_local_storage = struct
+  module Thread_key : sig
+    type t = private int
+
+    val of_thread : Thread.t -> t
+
+    val hash : t -> int
+
+    val equal : t -> t -> bool
+  end = struct
+    type t = int
+
+    let of_thread = Thread.id
+
+    let hash x = x
+
+    let equal = Int.equal
+  end
+
+  module LiveThreads = Hashtbl.Make (Thread_key)
+
+  (* While a thread is alive we keep some per-thread data,
+     after the thread dies the data will be GC-ed.
+     Ephemerons would allocate some internal options on each lookup,
+     so we cannot use them here. Instead we add a finaliser on the Thread.t.
+  *)
+  type 'a t = {lock: Mutex.t; tbl: 'a LiveThreads.t; init: unit -> 'a}
+
+  let with_lock t f arg =
+    Mutex.lock t.lock ;
+    match f t arg with
+    | result ->
+        Mutex.unlock t.lock ; result
+    | exception e ->
+        let bt = Printexc.get_raw_backtrace () in
+        Mutex.unlock t.lock ;
+        Printexc.raise_with_backtrace e bt
+
+  let on_thread_gc t thread_id () =
+    Mutex.lock t.lock ;
+    LiveThreads.remove t.tbl thread_id ;
+    Mutex.unlock t.lock
+
+  let find_or_create_unlocked t self =
+    (* try/with avoids allocation on fast-path *)
+    let id = Thread_key.of_thread self in
+    try LiveThreads.find t.tbl id
+    with Not_found ->
+      (* slow-path: first time use on current thread *)
+      let v = t.init () in
+      LiveThreads.replace t.tbl id v ;
+      (* do not use a closure here, it might keep 'self' alive forver *)
+      Gc.finalise_last (on_thread_gc t id) self ;
+      v
+
+  let get t =
+    let self = Thread.self () in
+    with_lock t find_or_create_unlocked self
+
+  let make init : 'a t =
+    let lock = Mutex.create () in
+    let tbl = LiveThreads.create 47 in
+    let t = {lock; tbl; init} in
+    (* preallocate storage for current thread *)
+    let (_ : 'a) = get t in
+    t
+
+  let set_unlocked t v =
+    let self = Thread.self () in
+    LiveThreads.replace t.tbl (Thread_key.of_thread self) v
+
+  let set t v = with_lock t set_unlocked v
+
+  let snapshot_unlocked t () =
+    LiveThreads.fold
+      (fun thr v acc -> IntMap.add (thr :> int) v acc)
+      t.tbl IntMap.empty
+
+  let snapshot t = with_lock t snapshot_unlocked ()
+
+  let count_unlocked t () = LiveThreads.length t.tbl
+
+  let count t = with_lock t count_unlocked ()
+end
 
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
@@ -79,45 +165,29 @@ module Thread_state = struct
   let empty =
     {acquired_resources= []; task= Ref.null; name= ""; waiting_for= None}
 
-  let m = Mutex.create ()
+  let make_empty () = empty
 
-  module IntMap = Map.Make (struct
-    type t = int
+  let thread_states = Thread_local_storage.make make_empty
 
-    let compare = compare
-  end)
-
-  let thread_states = ref IntMap.empty
+  (* to be able to debug locking problems we need a consistent snapshot:
+     if we're waiting for a lock, who's holding it currently and what locks are they holding or waiting for?
+  *)
 
   let get_acquired_resources_by_task task =
-    let snapshot = with_lock m (fun () -> !thread_states) in
+    let snapshot = Thread_local_storage.snapshot thread_states in
     let all, _ = IntMap.partition (fun _ ts -> ts.task = task) snapshot in
     List.map fst
       (IntMap.fold (fun _ ts acc -> ts.acquired_resources @ acc) all [])
 
   let get_all_acquired_resources () =
-    let snapshot = with_lock m (fun () -> !thread_states) in
+    let snapshot = Thread_local_storage.snapshot thread_states in
     List.map fst
       (IntMap.fold (fun _ ts acc -> ts.acquired_resources @ acc) snapshot [])
 
-  let me () = Thread.id (Thread.self ())
-
   let update f =
-    let id = me () in
-    let snapshot = with_lock m (fun () -> !thread_states) in
-    let ts =
-      if IntMap.mem id snapshot then
-        f (IntMap.find id snapshot)
-      else
-        f empty
-    in
-    with_lock m (fun () ->
-        thread_states :=
-          if ts = empty then
-            IntMap.remove id !thread_states
-          else
-            IntMap.add id ts !thread_states
-    )
+    let old = Thread_local_storage.get thread_states in
+    let ts = f old in
+    Thread_local_storage.set thread_states ts
 
   let with_named_thread name task f =
     update (fun ts -> {ts with name; task}) ;
@@ -182,7 +252,7 @@ module Thread_state = struct
 
   let to_graphviz () =
     let t' = now () in
-    let snapshot = with_lock m (fun () -> !thread_states) in
+    let snapshot = Thread_local_storage.snapshot thread_states in
     (* Map from thread ids -> record rows *)
     let threads =
       IntMap.map
@@ -273,7 +343,7 @@ module Thread_state = struct
     in
     String.concat "\n" all
 
-  let known_threads () = with_lock m (fun () -> IntMap.cardinal !thread_states)
+  let known_threads () = Thread_local_storage.count thread_states
 
   let with_resource resource acquire f release arg =
     let acquired = acquire resource arg in

--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -244,7 +244,7 @@ module Thread_state = struct
       | None ->
           None
       | Some (parent, span) -> (
-          let (_ : (_, _) result) = Tracing.Tracer.finish span in
+          let (_ : Tracing.Span.t option) = Tracing.Tracer.finish span in
           let name = resource.acquired_str in
           let tracer = Tracing.get_tracer ~name in
           match Tracing.Tracer.start ~tracer ~name ~parent () with
@@ -266,7 +266,7 @@ module Thread_state = struct
     span
 
   let released resource span =
-    let (_ : (_, _) result) = Tracing.Tracer.finish span in
+    let (_ : Tracing.Span.t option) = Tracing.Tracer.finish span in
     let ts = get_states () in
     if ts.last_acquired_resource = resource then
       ts.last_acquired_resource <- none

--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -36,6 +36,16 @@ let kill_resource = function
       info "Sending SIGKILL to %s pid %d" name pid ;
       Unix.kill pid Sys.sigkill
 
+let lock name = Lock name
+
+let process (name, pid) = Process (name, pid)
+
+let is_process name = function
+  | Lock _ ->
+      false
+  | Process (name', _) ->
+      String.equal name name'
+
 module Thread_state = struct
   type waiting = (Tracing.Span.t option * Tracing.Span.t option) option
 

--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -262,6 +262,8 @@ module Thread_state = struct
         ]
     in
     String.concat "\n" all
+
+  let known_threads () = with_lock m (fun () -> IntMap.cardinal !thread_states)
 end
 
 module Named_mutex = struct

--- a/ocaml/xapi/locking_helpers.mli
+++ b/ocaml/xapi/locking_helpers.mli
@@ -13,9 +13,16 @@
  *)
 
 (** Represents a type of resource a thread has either allocated or is waiting for. *)
-type resource =
-  | Lock of string  (** e.g. a per-VM lock or a queue *)
-  | Process of string * int  (** e.g. an stunnel process with the given pid *)
+type resource
+
+val lock : string -> resource
+(** [lock name] a per-VM lock or a queue *)
+
+val process : string * int -> resource
+(** [process (name, pid)] e.g a an stunnel process with the given pid *)
+
+val is_process : string -> resource -> bool
+(** [is_process name resource] checks whether [resource] is a process named [name]. *)
 
 val kill_resource : resource -> unit
 (** Best-effort attempt to kill a resource *)

--- a/ocaml/xapi/locking_helpers.mli
+++ b/ocaml/xapi/locking_helpers.mli
@@ -22,16 +22,20 @@ val kill_resource : resource -> unit
 
 (** Records per-thread diagnostic information *)
 module Thread_state : sig
+  type waiting
+
+  type acquired
+
   val with_named_thread : string -> API.ref_task -> (unit -> 'a) -> 'a
   (** Called when a thread becomes associated with a particular task *)
 
-  val waiting_for : resource -> unit
+  val waiting_for : resource -> waiting
   (** Called when a thread is about to block waiting for a resource to be free *)
 
-  val acquired : resource -> unit
+  val acquired : resource -> waiting -> acquired
   (** Called when a thread acquires a resource *)
 
-  val released : resource -> unit
+  val released : resource -> acquired -> unit
   (** Called when a thread releases a resource *)
 
   val get_all_acquired_resources : unit -> resource list

--- a/ocaml/xapi/locking_helpers.mli
+++ b/ocaml/xapi/locking_helpers.mli
@@ -27,6 +27,9 @@ val is_process : string -> resource -> bool
 val kill_resource : resource -> unit
 (** Best-effort attempt to kill a resource *)
 
+val string_of_resource : resource -> string
+(** [string_of_resource resource] a string representation of the resource for debugging *)
+
 (** Records per-thread diagnostic information *)
 module Thread_state : sig
   type waiting
@@ -50,6 +53,8 @@ module Thread_state : sig
   val get_acquired_resources_by_task : API.ref_task -> resource list
 
   val to_graphviz : unit -> string
+
+  val known_threads : unit -> int
 end
 
 module Named_mutex : sig

--- a/ocaml/xapi/locking_helpers.mli
+++ b/ocaml/xapi/locking_helpers.mli
@@ -29,7 +29,7 @@ module Thread_state : sig
   val with_named_thread : string -> API.ref_task -> (unit -> 'a) -> 'a
   (** Called when a thread becomes associated with a particular task *)
 
-  val waiting_for : resource -> waiting
+  val waiting_for : ?parent:Tracing.Span.t -> resource -> waiting
   (** Called when a thread is about to block waiting for a resource to be free *)
 
   val acquired : resource -> waiting -> acquired
@@ -50,5 +50,6 @@ module Named_mutex : sig
 
   val create : string -> t
 
-  val execute : t -> (unit -> 'a) -> 'a
+  val execute :
+    ?__context:Context.t -> ?parent:Tracing.Span.t -> t -> (unit -> 'a) -> 'a
 end

--- a/ocaml/xapi/locking_helpers.mli
+++ b/ocaml/xapi/locking_helpers.mli
@@ -64,4 +64,8 @@ module Named_mutex : sig
 
   val execute :
     ?__context:Context.t -> ?parent:Tracing.Span.t -> t -> (unit -> 'a) -> 'a
+
+  module Private : sig
+    val test_locking : unit -> unit
+  end
 end

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -735,14 +735,7 @@ let bring_pif_up ~__context ?(management_interface = false) (pif : API.ref_PIF)
                   Locking_helpers.Thread_state.get_all_acquired_resources ()
                 in
                 debug "There are %d allocated resources" (List.length all) ;
-                List.filter
-                  (function
-                    | Locking_helpers.Process ("stunnel", _) ->
-                        true
-                    | _ ->
-                        false
-                    )
-                  all
+                List.filter (Locking_helpers.is_process "stunnel") all
               in
               debug "Of which %d are stunnels" (List.length stunnels) ;
               List.iter Locking_helpers.kill_resource stunnels

--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -86,23 +86,24 @@ let sr_delete dconf driver sr =
 let serialize_attach_detach =
   Locking_helpers.Named_mutex.create "sr_attach/detach"
 
-let sr_attach dconf driver sr =
-  Locking_helpers.Named_mutex.execute serialize_attach_detach (fun () ->
+let sr_attach parent dconf driver sr =
+  Locking_helpers.Named_mutex.execute ?parent serialize_attach_detach (fun () ->
       debug "sr_attach" driver (sprintf "sr=%s" (Ref.string_of sr)) ;
       let call = Sm_exec.make_call ~sr_ref:sr dconf "sr_attach" [] in
       Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
   )
 
-let sr_detach dconf driver sr =
-  Locking_helpers.Named_mutex.execute serialize_attach_detach (fun () ->
+let sr_detach parent dconf driver sr =
+  Locking_helpers.Named_mutex.execute ?parent serialize_attach_detach (fun () ->
       debug "sr_detach" driver (sprintf "sr=%s" (Ref.string_of sr)) ;
       let call = Sm_exec.make_call ~sr_ref:sr dconf "sr_detach" [] in
       Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
   )
 
-let sr_probe dconf driver sr_sm_config =
+let sr_probe parent dconf driver sr_sm_config =
   if List.mem_assoc Sr_probe (features_of_driver driver) then
-    Locking_helpers.Named_mutex.execute serialize_attach_detach (fun () ->
+    Locking_helpers.Named_mutex.execute ?parent serialize_attach_detach
+      (fun () ->
         debug "sr_probe" driver
           (sprintf "sm_config=[%s]"
              (String.concat "; "

--- a/ocaml/xapi/storage_locks.ml
+++ b/ocaml/xapi/storage_locks.ml
@@ -37,7 +37,7 @@ let with_instance_lock t key f =
     Locking_helpers.Lock
       ("SM/" ^ Ref.really_pretty_and_small (Ref.of_string key))
   in
-  Locking_helpers.Thread_state.waiting_for r ;
+  let waiting = Locking_helpers.Thread_state.waiting_for r in
   with_lock t.m (fun () ->
       (* Wait for the lock to be free (ie the table entry to be removed and the master lock to be released *)
       while Hashtbl.mem t.t key || t.master_lock do
@@ -45,16 +45,16 @@ let with_instance_lock t key f =
       done ;
       Hashtbl.replace t.t key ()
   ) ;
-  Locking_helpers.Thread_state.acquired r ;
+  let acquired = Locking_helpers.Thread_state.acquired r waiting in
   Xapi_stdext_pervasives.Pervasiveext.finally f (fun () ->
       with_lock t.m (fun () -> Hashtbl.remove t.t key ; Condition.broadcast t.c) ;
-      Locking_helpers.Thread_state.released r
+      Locking_helpers.Thread_state.released r acquired
   )
 
 (** Execute the function with the master_lock held and no instance locks held *)
 let with_master_lock t f =
   let r = Locking_helpers.Lock "SM" in
-  Locking_helpers.Thread_state.waiting_for r ;
+  let waiting = Locking_helpers.Thread_state.waiting_for r in
   with_lock t.m (fun () ->
       (* Wait for the master_lock to be released *)
       while t.master_lock do
@@ -67,11 +67,11 @@ let with_master_lock t f =
         Condition.wait t.c t.m
       done
   ) ;
-  Locking_helpers.Thread_state.acquired r ;
+  let acquired = Locking_helpers.Thread_state.acquired r waiting in
   Xapi_stdext_pervasives.Pervasiveext.finally f (fun () ->
       with_lock t.m (fun () ->
           t.master_lock <- false ;
           Condition.broadcast t.c
       ) ;
-      Locking_helpers.Thread_state.released r
+      Locking_helpers.Thread_state.released r acquired
   )

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -194,6 +194,7 @@ module SMAPIv1 : Server_impl = struct
           let task = Context.get_task_id __context in
           Storage_interface.Raw
             (Sm.sr_probe
+               (Context.tracing_of __context)
                (Some task, Sm.sm_master true :: device_config)
                _type sm_config
             )
@@ -271,6 +272,7 @@ module SMAPIv1 : Server_impl = struct
           Sm.call_sm_functions ~__context ~sR:sr (fun _ _type ->
               try
                 Sm.sr_attach
+                  (Context.tracing_of __context)
                   (Some (Context.get_task_id __context), device_config)
                   _type sr
               with
@@ -291,7 +293,11 @@ module SMAPIv1 : Server_impl = struct
               ~uuid:(Storage_interface.Sr.string_of sr)
           in
           Sm.call_sm_functions ~__context ~sR:sr (fun device_config _type ->
-              try Sm.sr_detach device_config _type sr with
+              try
+                Sm.sr_detach
+                  (Context.tracing_of __context)
+                  device_config _type sr
+              with
               | Api_errors.Server_error (code, params) ->
                   raise (Storage_error (Backend_error (code, params)))
               | e ->

--- a/ocaml/xapi/thread_queue.ml
+++ b/ocaml/xapi/thread_queue.ml
@@ -29,7 +29,7 @@ type 'a process_fn = 'a -> unit
 (** The type of the function which pushes new elements into the queue *)
 type 'a push_fn = string -> 'a -> bool
 
-type 'a t = {push_fn: 'a push_fn; name: string}
+type 'a t = {push_fn: 'a push_fn; name: string; lock: Locking_helpers.resource}
 
 (** Given an optional maximum queue length and a function for processing elements (which will be called in a
     single background thread), return a function which pushes items onto the queue. *)
@@ -95,4 +95,4 @@ let make ?max_q_length ?(name = "unknown") (process_fn : 'a process_fn) : 'a t =
             true
     )
   in
-  {push_fn= push; name}
+  {push_fn= push; name; lock= Locking_helpers.lock name}

--- a/ocaml/xapi/workload_balancing.ml
+++ b/ocaml/xapi/workload_balancing.ml
@@ -516,7 +516,7 @@ let init_wlb ~__context ~wlb_url ~wlb_username ~wlb_password ~xenserver_username
             Db.Secret.destroy ~__context ~self:old_secret_ref
         )
   in
-  Locking_helpers.Named_mutex.execute request_mutex
+  Locking_helpers.Named_mutex.execute ~__context request_mutex
     (perform_wlb_request ~enable_log:false ~meth:"AddXenServer" ~params
        ~auth:(encoded_auth wlb_username wlb_password)
        ~url:wlb_url ~handle_response ~__context
@@ -545,7 +545,7 @@ let decon_wlb ~__context =
   else
     let params = pool_uuid_param ~__context in
     try
-      Locking_helpers.Named_mutex.execute request_mutex
+      Locking_helpers.Named_mutex.execute ~__context request_mutex
         (perform_wlb_request ~meth:"RemoveXenServer" ~params ~handle_response
            ~__context
         )

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -165,7 +165,7 @@ let register_callback_fns () =
   in
   Xapi_cli.rpc_fun := Some fake_rpc ;
   let set_stunnelpid _task_opt pid =
-    let resource = Locking_helpers.Process ("stunnel", pid) in
+    let resource = Locking_helpers.process ("stunnel", pid) in
     let waiting = Locking_helpers.Thread_state.waiting_for resource in
     let acquired = Locking_helpers.Thread_state.acquired resource waiting in
     fun () -> Locking_helpers.Thread_state.released resource acquired

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -37,7 +37,7 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
   (* Currently we only support corosync. If we support more cluster stacks, this
    * should be replaced by a general function that checks the given cluster_stack *)
   Pool_features.assert_enabled ~__context ~f:Features.Corosync ;
-  with_clustering_lock __LOC__ (fun () ->
+  with_clustering_lock ~__context __LOC__ (fun () ->
       let dbg = Context.string_of_task __context in
       validate_params ~token_timeout ~token_timeout_coefficient ;
       let cluster_ref = Ref.make () in

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -55,7 +55,7 @@ let call_api_function_with_alert ~__context ~msg ~cls ~obj_uuid ~body
 
 (* Create xapi db object for cluster_host, resync_host calls clusterd *)
 let create_internal ~__context ~cluster ~host ~pIF : API.ref_Cluster_host =
-  with_clustering_lock __LOC__ (fun () ->
+  with_clustering_lock ~__context __LOC__ (fun () ->
       assert_operation_host_target_is_localhost ~__context ~host ;
       assert_pif_attached_to ~host ~pIF ~__context ;
       assert_cluster_host_can_be_created ~__context ~host ;
@@ -104,7 +104,7 @@ let set_tls_config ~__context ~self ~verify =
 
 (* Helper function atomically enables clusterd and joins the cluster_host *)
 let join_internal ~__context ~self =
-  with_clustering_lock __LOC__ (fun () ->
+  with_clustering_lock ~__context __LOC__ (fun () ->
       let pIF = Db.Cluster_host.get_PIF ~__context ~self in
       fix_pif_prerequisites ~__context pIF ;
       let dbg = Context.string_of_task __context in
@@ -206,7 +206,7 @@ let create ~__context ~cluster ~host ~pif =
   cluster_host
 
 let destroy_op ~__context ~self ~force =
-  with_clustering_lock __LOC__ (fun () ->
+  with_clustering_lock ~__context __LOC__ (fun () ->
       let dbg = Context.string_of_task __context in
       let host = Db.Cluster_host.get_host ~__context ~self in
       assert_operation_host_target_is_localhost ~__context ~host ;
@@ -252,7 +252,7 @@ let destroy ~__context ~self =
 let ip_of_str str = Cluster_interface.IPv4 str
 
 let forget ~__context ~self =
-  with_clustering_lock __LOC__ (fun () ->
+  with_clustering_lock ~__context __LOC__ (fun () ->
       let dbg = Context.string_of_task __context in
       let cluster = Db.Cluster_host.get_cluster ~__context ~self in
       let pif = Db.Cluster_host.get_PIF ~__context ~self in
@@ -285,7 +285,7 @@ let forget ~__context ~self =
   )
 
 let enable ~__context ~self =
-  with_clustering_lock __LOC__ (fun () ->
+  with_clustering_lock ~__context __LOC__ (fun () ->
       let dbg = Context.string_of_task __context in
       let host = Db.Cluster_host.get_host ~__context ~self in
       assert_operation_host_target_is_localhost ~__context ~host ;
@@ -325,7 +325,7 @@ let enable ~__context ~self =
   )
 
 let disable ~__context ~self =
-  with_clustering_lock __LOC__ (fun () ->
+  with_clustering_lock ~__context __LOC__ (fun () ->
       let dbg = Context.string_of_task __context in
       let host = Db.Cluster_host.get_host ~__context ~self in
       assert_operation_host_target_is_localhost ~__context ~host ;

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -27,9 +27,9 @@ let set_ha_cluster_stack ~__context =
 (* host-local clustering lock *)
 let clustering_lock_m = Locking_helpers.Named_mutex.create "clustering"
 
-let with_clustering_lock where f =
+let with_clustering_lock ~__context where f =
   debug "Trying to grab host-local clustering lock... (%s)" where ;
-  Locking_helpers.Named_mutex.execute clustering_lock_m (fun () ->
+  Locking_helpers.Named_mutex.execute ~__context clustering_lock_m (fun () ->
       Xapi_stdext_pervasives.Pervasiveext.finally
         (fun () ->
           debug "Grabbed host-local clustering lock; executing function... (%s)"
@@ -155,14 +155,14 @@ let with_clustering_lock_if_needed ~__context ~sr_sm_type where f =
   | [] ->
       f ()
   | _required_cluster_stacks ->
-      with_clustering_lock where f
+      with_clustering_lock ~__context where f
 
 let with_clustering_lock_if_cluster_exists ~__context where f =
   match Db.Cluster.get_all ~__context with
   | [] ->
       f ()
   | _ ->
-      with_clustering_lock where f
+      with_clustering_lock ~__context where f
 
 let find_cluster_host ~__context ~host =
   match

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -742,7 +742,7 @@ let revert ~__context ~snapshot =
 (* thread mess around with that. *)
 let checkpoint ~__context ~vm ~new_name =
   Pool_features.assert_enabled ~__context ~f:Features.Checkpoint ;
-  Local_work_queue.wait_in_line Local_work_queue.long_running_queue
+  Local_work_queue.wait_in_line ~__context Local_work_queue.long_running_queue
     (Printf.sprintf "VM.checkpoint %s" (Context.string_of_task __context))
     (fun () ->
       TaskHelper.set_cancellable ~__context ;

--- a/ocaml/xen-api-client/lib/dune
+++ b/ocaml/xen-api-client/lib/dune
@@ -8,10 +8,10 @@
     cohttp
     re.str
     rpclib
-    xapi-rrd
     uri
     uuid
     xmlm
+    xapi-rrd
     xapi-client
     xapi-types
   )

--- a/xapi-types.opam
+++ b/xapi-types.opam
@@ -13,7 +13,6 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "astring"
-  "ocaml-migrate-parsetree"
   "ppx_deriving_rpc"
   "rpclib"
   "sexpr"


### PR DESCRIPTION
When distributed tracing is enabled this will generate spans:
* 'waiting_for' and 'acquired' are begin/end spans for the 'waiting_for(lockname)' span
* 'acquired' and 'released' are begin/end spans for the 'acquired(lockname)' span

An optional '?parent' argument to 'waiting_for' enables tracing, which is in turn retrieved from `Context.t` and `None` by default, unless an Observer has been created and enabled.
I initially wanted to enforce a strict waiting_for..acquired..released order, but due to how callbacks work in Xmlrpc/stunnel there will always be optional values. Also there is no 'waiting_for' event generated for stunnel, because we only know its PID at the very end once it is already connected (instrumenting that would require digging into stunnel.ml which is out of scope for now). I do enforce strict pairing between acquired/released though.

This adds some minimal parent tracing to 3 SMAPI calls that take named mutexes, but I haven't instrumented the SMAPI further (I'll wait for @robhoes 's changes first).

Also I do not create a new context and do not act as a parent span for functions called while the lock is held, that can be fixed in the future by plumbing a __context through to appropriate places and changing Named_mutex.execute to invoke its 'f' argument with a context or parent span.

TODO: instead of constructing a new string every time we wait for / acquire/ release a lock pre-construct the string and store it in 'type resource', that should reduce the overhead of this instrumentation. Hence the draft in the PR.