### PR TITLE
scripts/plugins/extauth-hook-AD.py: Skip init logging on import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,18 +14,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        docker-image:  # See https://hub.docker.com/_/python/tags for images
+          - python:2.7.18-alpine3.11
+          - python:3.11.4-alpine3.18
+    container: ${{ matrix.docker-image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Use python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Install python 2 dependencies
-        if: ${{ matrix.python-version == 2.7 }}
+        if: ${{ startsWith(matrix.docker-image, 'python:2.7.18') }}
         run: pip install enum
 
       - name: Install dependencies

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -52,7 +52,8 @@ def setup_logger():
     log.addHandler(auth_log)
 
 
-setup_logger()
+if __name__ == "__main__":
+    setup_logger()
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
- Re-enable Python 2.7 CI using tiny docker containers(very fast)

- [scripts/plugins/extauth-hook-AD.py](https://github.com/xapi-project/xen-api/blob/master/scripts/plugins/extauth-hook-AD.py) has a main function, but it's [setup_logger()](https://github.com/xapi-project/xen-api/blob/master/scripts/plugins/extauth-hook-AD.py#L38) runs during import, which breaks importing it in tests in containers not providing /dev/log. Call setup_logger() only if the module is started as a script.