### PR TITLE
Add xapi-expiry-alerts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,18 @@ jobs:
     name: Ocaml tests
     runs-on: ubuntu-20.04
     env:
-      package: "xapi-cli-protocol xapi-client xapi-consts xapi-datamodel xapi-types xapi xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-lib pciutil safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd vhd-tool xapi-networkd xapi-squeezed xapi-xenopsd xapi-xenopsd-cli xapi-xenopsd-simulator xapi-xenopsd-xc message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-storage-cli wsproxy xapi-nbd varstored-guard xapi-log xapi-open-uri vhd-format vhd-format-lwt xapi-tracing xapi-expiry-alerts ezxenstore"
+      package: 'xapi-cli-protocol xapi-client xapi-consts xapi-datamodel xapi-types xapi
+        xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async
+        xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils
+        rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-lib pciutil
+        safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd
+        vhd-tool xapi-networkd xapi-squeezed xapi-xenopsd xapi-xenopsd-cli
+        xapi-xenopsd-simulator xapi-xenopsd-xc message-switch
+        message-switch-async message-switch-cli message-switch-core
+        message-switch-lwt message-switch-unix xapi-idl forkexec xapi-forkexecd
+        xapi-storage xapi-storage-script xapi-storage-cli wsproxy xapi-nbd
+        varstored-guard xapi-log xapi-open-uri vhd-format vhd-format-lwt
+        xapi-tracing xapi-expiry-alerts ezxenstore'
       XAPI_VERSION: "v0.0.0-${{ github.sha }}"
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
     name: Ocaml tests
     runs-on: ubuntu-20.04
     env:
-      package: "xapi-cli-protocol xapi-client xapi-consts xapi-datamodel xapi-types xapi xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-lib pciutil safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd vhd-tool xapi-networkd xapi-squeezed xapi-xenopsd xapi-xenopsd-cli xapi-xenopsd-simulator xapi-xenopsd-xc message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-storage-cli wsproxy xapi-nbd varstored-guard xapi-log xapi-open-uri vhd-format vhd-format-lwt xapi-tracing"
+      package: "xapi-cli-protocol xapi-client xapi-consts xapi-datamodel xapi-types xapi xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-lib pciutil safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd vhd-tool xapi-networkd xapi-squeezed xapi-xenopsd xapi-xenopsd-cli xapi-xenopsd-simulator xapi-xenopsd-xc message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-storage-cli wsproxy xapi-nbd varstored-guard xapi-log xapi-open-uri vhd-format vhd-format-lwt xapi-tracing xapi-expiry-alerts ezxenstore"
       XAPI_VERSION: "v0.0.0-${{ github.sha }}"
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ install: build doc sdk doc-json
 		gzip http-lib pciutil sexpr stunnel uuid xml-light2 zstd xapi-compression safe-resources \
 		message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt \
 		message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-storage-cli \
-		xapi-nbd varstored-guard xapi-log xapi-open-uri xapi-tracing
+		xapi-nbd varstored-guard xapi-log xapi-open-uri xapi-tracing xapi-expiry-alerts
 	make -C _build/default/ocaml/xapi-storage/python
 	make -C _build/default/ocaml/xapi-storage/python install DESTDIR=$(DESTDIR)
 # docs
@@ -219,7 +219,7 @@ uninstall:
 		gzip http-lib pciutil sexpr stunnel uuid xml-light2 zstd xapi-compression safe-resources \
 		message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt \
 		message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-log \
-		xapi-open-uri xapi-tracing
+		xapi-open-uri xapi-tracing xapi-expiry-alerts
 
 compile_flags.txt: Makefile
 	(ocamlc -config-var ocamlc_cflags;\

--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -6,22 +6,7 @@ type cert =
   | Host of API.ref_host * API.datetime
   | Internal of API.ref_host * API.datetime
 
-let seconds_per_day = 3600. *. 24.
-
-let internal_error fmt =
-  fmt
-  |> Printf.kprintf @@ fun msg ->
-     raise Api_errors.(Server_error (internal_error, [msg]))
-
-let days_until_expiry epoch expiry =
-  let days = (expiry /. seconds_per_day) -. (epoch /. seconds_per_day) in
-  match Float.sign_bit days with
-  | true ->
-      -1
-  | false ->
-      Float.(to_int (ceil days))
-
-let get_certificate_attributes rpc session_id =
+let get_certificates rpc session_id =
   XenAPI.Certificate.get_all_records ~rpc ~session_id
   |> List.map @@ fun (cert_ref, certificate) ->
      match certificate.API.certificate_type with
@@ -38,142 +23,59 @@ let get_certificate_attributes rpc session_id =
      | `ca ->
          CA (cert_ref, certificate.API.certificate_not_after)
 
-let expired_message = function
+let certificate_description = function
   | Host _ ->
-      "The TLS server certificate has expired."
+      "TLS server certificate"
   | Internal _ ->
-      "The internal TLS server certificate has expired."
+      "internal TLS server certificate"
   | CA _ ->
-      "The CA pool certificate has expired"
+      "CA pool certificate"
 
-let expiring_message = function
+let alert_conditions = function
   | Host _ ->
-      "The TLS server certificate is expiring soon."
+      [
+        (0, Api_messages.host_server_certificate_expired)
+      ; (7, Api_messages.host_server_certificate_expiring_07)
+      ; (14, Api_messages.host_server_certificate_expiring_14)
+      ; (30, Api_messages.host_server_certificate_expiring_30)
+      ]
   | Internal _ ->
-      "The internal TLS server certificate is expiring soon."
+      [
+        (0, Api_messages.host_internal_certificate_expired)
+      ; (7, Api_messages.host_internal_certificate_expiring_07)
+      ; (14, Api_messages.host_internal_certificate_expiring_14)
+      ; (30, Api_messages.host_internal_certificate_expiring_30)
+      ]
   | CA _ ->
-      "The CA pool certificate is expiring soon"
+      [
+        (0, Api_messages.pool_ca_certificate_expired)
+      ; (7, Api_messages.pool_ca_certificate_expiring_07)
+      ; (14, Api_messages.pool_ca_certificate_expiring_14)
+      ; (30, Api_messages.pool_ca_certificate_expiring_30)
+      ]
 
-let generate_alert epoch cert =
-  let expiry =
-    match cert with Host (_, exp) | Internal (_, exp) | CA (_, exp) -> exp
-  in
-  let days = days_until_expiry epoch (Date.to_float expiry) in
-  let expiring = expiring_message cert in
-  let expired = expired_message cert in
-  let body msg =
-    Printf.sprintf "<body><message>%s</message><date>%s</date></body>" msg
-      (Date.to_string expiry)
-  in
-  match (days, cert) with
-  | days, _ when days > 30 ->
-      (cert, None)
-  | days, Host _ when days < 0 ->
-      (cert, Some (body expired, Api_messages.host_server_certificate_expired))
-  | days, Host _ when days < 8 ->
-      ( cert
-      , Some (body expiring, Api_messages.host_server_certificate_expiring_07)
-      )
-  | days, Host _ when days < 15 ->
-      ( cert
-      , Some (body expiring, Api_messages.host_server_certificate_expiring_14)
-      )
-  | _, Host _ ->
-      ( cert
-      , Some (body expiring, Api_messages.host_server_certificate_expiring_30)
-      )
-  | days, CA _ when days < 0 ->
-      (cert, Some (body expired, Api_messages.pool_ca_certificate_expired))
-  | days, CA _ when days < 8 ->
-      (cert, Some (body expiring, Api_messages.pool_ca_certificate_expiring_07))
-  | days, CA _ when days < 15 ->
-      (cert, Some (body expiring, Api_messages.pool_ca_certificate_expiring_14))
-  | _, CA _ ->
-      (cert, Some (body expiring, Api_messages.pool_ca_certificate_expiring_30))
-  | days, Internal _ when days < 0 ->
-      (cert, Some (body expired, Api_messages.host_internal_certificate_expired))
-  | days, Internal _ when days < 8 ->
-      ( cert
-      , Some (body expiring, Api_messages.host_internal_certificate_expiring_07)
-      )
-  | days, Internal _ when days < 15 ->
-      ( cert
-      , Some (body expiring, Api_messages.host_internal_certificate_expiring_14)
-      )
-  | _, Internal _ ->
-      ( cert
-      , Some (body expiring, Api_messages.host_internal_certificate_expiring_30)
-      )
+let alert_message_cls_and_obj_uuid rpc session_id cert =
+  match cert with
+  | Host (host, _) | Internal (host, _) ->
+      (`Host, XenAPI.Host.get_uuid ~rpc ~session_id ~self:host)
+  | CA (cert, _) ->
+      (`Certificate, XenAPI.Certificate.get_uuid ~rpc ~session_id ~self:cert)
 
-let execute rpc session_id existing_messages (cert, alert) =
-  (* CA-342551: messages need to be deleted if the pending alert regard the
-     same host and has newer, updated information.
-     If the pending alert has the same metadata as the existing host message
-     it must not be emmited and the existing message must be retained, this
-     prevents changing the message UUID.
-     In the case there are alerts regarding the host but no alert is pending
-     they are not destroyed since no alert is automatically dismissed. *)
-  match alert with
-  | Some (body, (alert, priority)) -> (
-    try
-      let cls, obj_uuid =
-        match cert with
-        | Host (host, _) | Internal (host, _) ->
-            (`Host, XenAPI.Host.get_uuid ~rpc ~session_id ~self:host)
-        | CA (cert, _) ->
-            ( `Certificate
-            , XenAPI.Certificate.get_uuid ~rpc ~session_id ~self:cert
-            )
-      in
-      let messages_in_host =
-        List.filter
-          (fun (_, record) -> record.API.message_obj_uuid = obj_uuid)
-          existing_messages
-      in
-      let is_outdated (_ref, record) =
-        record.API.message_body <> body
-        || record.API.message_name <> alert
-        || record.API.message_priority <> priority
-      in
-      let outdated, current = List.partition is_outdated messages_in_host in
-
-      List.iter
-        (fun (self, _) -> XenAPI.Message.destroy ~rpc ~session_id ~self)
-        outdated ;
-      if current = [] then
-        let (_ : [> `message] API.Ref.t) =
-          XenAPI.Message.create ~rpc ~session_id ~name:alert ~priority ~cls
-            ~obj_uuid ~body
-        in
-        ()
-    with Api_errors.(Server_error (_handle_invalid, _)) ->
-      (* this happens when the host reference is invalid *)
-      ()
-  )
-  | None ->
-      ()
+let get_expiry = function
+  | Host (_, exp) | Internal (_, exp) | CA (_, exp) ->
+      exp
 
 let alert rpc session_id =
-  let now = Unix.time () in
-  (* Message starting with
-     [\{host_server_certificate,pool_ca_certificate\}_\{expiring,expired\}]
-     may need to be refreshed, gather them just once *)
-  let previous_messages =
-    XenAPI.Message.get_all_records ~rpc ~session_id
-    |> List.filter (fun (_ref, record) ->
-           let expiring_or_expired name =
-             let matching affix = Astring.String.is_prefix ~affix name in
-             matching Api_messages.host_server_certificate_expiring
-             || matching (fst Api_messages.host_server_certificate_expired)
-             || matching Api_messages.pool_ca_certificate_expiring
-             || matching (fst Api_messages.pool_ca_certificate_expired)
-             || matching Api_messages.host_internal_certificate_expiring
-             || matching (fst Api_messages.host_internal_certificate_expired)
-           in
-           expiring_or_expired record.API.message_name
-       )
-  in
-  let send_alert_maybe attributes =
-    attributes |> generate_alert now |> execute rpc session_id previous_messages
-  in
-  get_certificate_attributes rpc session_id |> List.iter send_alert_maybe
+  get_certificates rpc session_id
+  |> List.map (fun cert ->
+         let cls, obj_uuid =
+           alert_message_cls_and_obj_uuid rpc session_id cert
+         in
+         let obj_description = certificate_description cert in
+         let alert_conditions = alert_conditions cert in
+         let expiry = get_expiry cert in
+         Expiry_alert.{cls; obj_uuid; obj_description; alert_conditions; expiry}
+     )
+  |> Expiry_alert.alert ~rpc ~session_id
+
+let maybe_generate_alert = Expiry_alert.maybe_generate_alert

--- a/ocaml/alerts/certificate/certificate_check.mli
+++ b/ocaml/alerts/certificate/certificate_check.mli
@@ -1,0 +1,35 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val alert : (Rpc.call -> Rpc.response) -> [< `session] Ref.t -> unit
+
+(* Below exposed only for ease of testing *)
+
+type cert =
+  | CA of API.ref_Certificate * API.datetime
+  | Host of API.ref_host * API.datetime
+  | Internal of API.ref_host * API.datetime
+
+val certificate_description : cert -> string
+
+val alert_conditions : cert -> (int * (string * int64)) list
+
+val get_expiry : cert -> Xapi_stdext_date.Date.t
+
+val maybe_generate_alert :
+     Xapi_stdext_date.Date.t
+  -> string
+  -> (int * (string * int64)) list
+  -> Xapi_stdext_date.Date.t
+  -> (string * (string * int64)) option

--- a/ocaml/alerts/certificate/dune
+++ b/ocaml/alerts/certificate/dune
@@ -3,6 +3,7 @@
   (modules certificate_check)
   (libraries
     astring
+    xapi-expiry-alerts
     xapi-client
     xapi-consts
     xapi-types

--- a/ocaml/alerts/dune
+++ b/ocaml/alerts/dune
@@ -1,0 +1,11 @@
+(library
+  (name expiry_alert)
+  (public_name xapi-expiry-alerts)
+  (libraries
+    astring
+    xapi-client
+    xapi-consts
+    xapi-types
+    xapi-stdext-date
+  )
+)

--- a/ocaml/alerts/expiry_alert.ml
+++ b/ocaml/alerts/expiry_alert.ml
@@ -1,0 +1,112 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module XenAPI = Client.Client
+module Date = Xapi_stdext_date.Date
+
+type message_name = string
+
+type message_priority = int64
+
+type message_id = message_name * message_priority
+
+type remaining_days = int
+
+type raw_alert = {
+    cls:
+      [ `Certificate
+      | `Host
+      | `PVS_proxy
+      | `Pool
+      | `SR
+      | `VDI
+      | `VM
+      | `VMPP
+      | `VMSS ]
+  ; obj_uuid: string
+  ; obj_description: string
+  ; alert_conditions: (remaining_days * message_id) list
+  ; expiry: Xapi_stdext_date.Date.t (* when the obj will expire *)
+}
+
+let seconds_per_day = 3600. *. 24.
+
+let days_until_expiry epoch expiry =
+  (expiry /. seconds_per_day) -. (epoch /. seconds_per_day)
+
+let all_messages rpc session_id =
+  XenAPI.Message.get_all_records ~rpc ~session_id
+
+let message_body msg expiry =
+  Printf.sprintf "<body><message>%s</message><date>%s</date></body>" msg
+    (Date.to_string expiry)
+
+let expired_message obj = Printf.sprintf "The %s has expired." obj
+
+let expiring_message obj = Printf.sprintf "The %s is expiring soon." obj
+
+let maybe_generate_alert now obj_description alert_conditions expiry =
+  let remaining_days =
+    days_until_expiry (Date.to_float now) (Date.to_float expiry)
+  in
+  alert_conditions
+  |> List.sort (fun (a, _) (b, _) -> compare a b)
+  |> List.find_opt (fun (days, _) -> remaining_days < float_of_int days)
+  |> function
+  | None ->
+      None
+  | Some (days, expired_message_id) when days <= 0 ->
+      let expired = expired_message obj_description in
+      Some (message_body expired expiry, expired_message_id)
+  | Some (_, expiring_message_id) ->
+      let expiring = expiring_message obj_description in
+      Some (message_body expiring expiry, expiring_message_id)
+
+let filter_messages msg_name_list msg_obj_uuid alert all_msgs =
+  let msg_body, (msg_name, msg_prio) = alert in
+  all_msgs
+  |> List.filter (fun (_ref, record) ->
+         record.API.message_obj_uuid = msg_obj_uuid
+         && List.mem record.API.message_name msg_name_list
+     )
+  |> List.partition (fun (_ref, record) ->
+         record.API.message_body <> msg_body
+         || record.API.message_name <> msg_name
+         || record.API.message_priority <> msg_prio
+     )
+
+let alert ~rpc ~session_id raw_alerts =
+  let now = Date.now () in
+  let all_msgs = all_messages rpc session_id in
+  List.iter
+    (fun {cls; obj_uuid; obj_description; alert_conditions; expiry} ->
+      maybe_generate_alert now obj_description alert_conditions expiry
+      |> Option.map (fun alert ->
+             let msg_name_list =
+               List.map (fun (_, (msg_name, _)) -> msg_name) alert_conditions
+             in
+             all_msgs |> filter_messages msg_name_list obj_uuid alert
+             |> fun (outdated, current) ->
+             List.iter
+               (fun (self, _) -> XenAPI.Message.destroy ~rpc ~session_id ~self)
+               outdated ;
+             if current = [] then
+               let body, (name, priority) = alert in
+               XenAPI.Message.create ~rpc ~session_id ~name ~priority ~cls
+                 ~obj_uuid ~body
+               |> ignore
+         )
+      |> ignore
+    )
+    raw_alerts

--- a/ocaml/alerts/expiry_alert.mli
+++ b/ocaml/alerts/expiry_alert.mli
@@ -1,0 +1,98 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type message_name = string
+
+type message_priority = int64
+
+(* message_id is the type of mesage defined in Api_messages *)
+type message_id = message_name * message_priority
+
+type remaining_days = int
+
+type raw_alert = {
+    cls:
+      [ `Certificate
+      | `Host
+      | `PVS_proxy
+      | `Pool
+      | `SR
+      | `VDI
+      | `VM
+      | `VMPP
+      | `VMSS ]
+        (* parameter "cls" of XenAPI.Message.create *)
+  ; obj_uuid: string (* parameter "obj_uuid" of XenAPI.Message.create *)
+  ; obj_description: string
+        (* description of the obj which would expire, which will be used in the body of
+         * generated message, take host server certificate for example: "TLS server
+         * certificate"
+         *)
+  ; alert_conditions: (remaining_days * message_id) list
+        (* for example:
+         *   [
+         *     (0, Api_messages.host_server_certificate_expired)
+         *   ; (7, Api_messages.host_server_certificate_expiring_07)
+         *   ; (14, Api_messages.host_server_certificate_expiring_14)
+         *   ; (30, Api_messages.host_server_certificate_expiring_30)
+         *   ]
+         * this means when the remaining days before it will expired is less than 30
+         * days, message "host_server_certificate_expiring_30" should be sent, when
+         * the remaining days is less than 14 days, message
+         * "host_server_certificate_expiring_14" should be sent, when the remaining days
+         * is less than 7 days, message "host_server_certificate_expiring_07" should be
+         * sent, and when it has expired, message "host_server_certificate_expired"
+         * should be sent.
+         *)
+  ; expiry: Xapi_stdext_date.Date.t
+        (* the last second when the obj is valid, it will expire in the next second *)
+}
+
+val alert :
+     rpc:(Rpc.call -> Rpc.response)
+  -> session_id:[< `session] Ref.t
+  -> raw_alert list
+  -> unit
+(** Update XenAPI messages as expiry alert: remove outdated messages and send a message
+    when it has not been sent yet *)
+
+(* Below exposed only for ease of testing *)
+
+val message_body : string -> Xapi_stdext_date.Date.t -> string
+
+val expired_message : string -> string
+
+val expiring_message : string -> string
+
+val maybe_generate_alert :
+     Xapi_stdext_date.Date.t
+  -> string
+  -> (remaining_days * message_id) list
+  -> Xapi_stdext_date.Date.t
+  -> (string * message_id) option
+(** An inner function exposed only for ease of testing, it returns None if there is no
+    need for an expiry alert as it is not expiring or expired yet, otherwise an "alert"
+    is returned in the form of (message_body, message_id) *)
+
+val filter_messages :
+     string list
+  -> string
+  -> string * (string * int64)
+  -> ('c * API.message_t) list
+  -> ('c * API.message_t) list * ('c * API.message_t) list
+(** An inner function exposed only for ease of testing, it filters all of the existing
+    XenAPI messages and returns the filtered messages in the form: (outdated, current),
+    where "outdated" is a list of outdated XenAPI messages which need to be removed,
+    "current" is a list of one element which is an XenAPI message exactly the same as
+    the alert needs to be sent *)

--- a/ocaml/tests/alerts/test_alert_certificate_check.ml
+++ b/ocaml/tests/alerts/test_alert_certificate_check.ml
@@ -16,30 +16,33 @@ open Certificate_check
 
 let date_of = Xapi_stdext_date.Date.of_string
 
-let check_time = Xapi_stdext_date.Date.to_float (date_of "20200201T02:00:00Z")
+let check_time = date_of "20200201T02:00:00Z"
 
 let good_samples =
   [
     "20210202T02:00:00Z" (* +1 year*)
   ; "20200302T02:00:01Z" (* +30 days, +1 second *)
+  ; "20200302T02:00:00Z" (* +30 days *)
   ]
 
 let expiring_samples =
   [
-    ("20200302T02:00:00Z", Api_messages.host_server_certificate_expiring_30)
+    ("20200302T01:59:59Z", Api_messages.host_server_certificate_expiring_30)
   ; ("20200301T02:00:00Z", Api_messages.host_server_certificate_expiring_30)
-  ; ("20200215T02:00:00Z", Api_messages.host_server_certificate_expiring_14)
-  ; ("20200208T02:00:00Z", Api_messages.host_server_certificate_expiring_07)
+  ; ("20200215T02:00:00Z", Api_messages.host_server_certificate_expiring_30)
+  ; ("20200215T01:59:59Z", Api_messages.host_server_certificate_expiring_14)
+  ; ("20200208T02:00:00Z", Api_messages.host_server_certificate_expiring_14)
+  ; ("20200208T01:59:59Z", Api_messages.host_server_certificate_expiring_07)
   ; ("20200201T02:00:00Z", Api_messages.host_server_certificate_expiring_07)
   ]
 
 let expired_samples = ["20200102T02:00:00Z"; "20200201T01:59:59Z"]
 
-let format_good datestring = (date_of datestring, ("host", None))
+let format_good datestring = (date_of datestring, None)
 
 let _format (datestring, ppf, alert) =
   let fmt = Scanf.format_from_string ppf "%s" in
-  (date_of datestring, ("host", Some (Printf.sprintf fmt datestring, alert)))
+  (date_of datestring, Some (Printf.sprintf fmt datestring, alert))
 
 let format_expiring (datestring, alert) =
   let ppf =
@@ -65,17 +68,14 @@ let certificate_samples =
 
 let gen check_time datetime =
   let cert = Host (Ref.null, datetime) in
-  match generate_alert check_time cert with
-  | CA _, x ->
-      ("pool", x)
-  | Host _, x ->
-      ("host", x)
-  | Internal _, x ->
-      ("internal", x)
+  let obj_des = certificate_description cert in
+  let alert_conditions = alert_conditions cert in
+  let expiry = get_expiry cert in
+  maybe_generate_alert check_time obj_des alert_conditions expiry
 
-let test_alerts (server_certificates, expected) () =
-  let result = gen check_time server_certificates in
-  Alcotest.(check @@ pair string @@ option @@ pair string @@ pair string int64)
+let test_alerts (datetime, expected) () =
+  let result = gen check_time datetime in
+  Alcotest.(check @@ option @@ pair string @@ pair string int64)
     "certificate_expiry" expected result
 
 let test =

--- a/ocaml/tests/alerts/test_expiry_alert.ml
+++ b/ocaml/tests/alerts/test_expiry_alert.ml
@@ -1,0 +1,392 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Expiry_alert
+
+let date_of = Xapi_stdext_date.Date.of_string
+
+let test_expired = ("TEST_EXPIRED", 1L)
+
+let test_expiring_07 = ("TEST_EXPIRING_07", 2L)
+
+let test_expiring_14 = ("TEST_EXPIRING_14", 3L)
+
+let test_expiring_30 = ("TEST_EXPIRING_30", 4L)
+
+let alert_conditions =
+  [
+    (7, test_expiring_07)
+  ; (0, test_expired)
+  ; (30, test_expiring_30)
+  ; (14, test_expiring_14)
+  ]
+
+module TestGenerateAlert = struct
+  type test_case = {
+      description: string
+    ; check_time: string
+    ; expire_time: string
+    ; alert_conditions: (remaining_days * message_id) list
+    ; obj_description: string
+    ; expected:
+        (string -> Xapi_stdext_date.Date.t -> (string * (string * int64)) option)
+        option
+  }
+
+  let expired_result expired_message_id obj_description expiry =
+    let expired = expired_message obj_description in
+    Some (message_body expired expiry, expired_message_id)
+
+  let expiring_result expiring_message_id obj_description expiry =
+    let expiring = expiring_message obj_description in
+    Some (message_body expiring expiry, expiring_message_id)
+
+  let test_cases =
+    [
+      {
+        description= "no alert, 31 days left"
+      ; check_time= "20230612T17:00:00Z"
+      ; expire_time= "20230713T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= None
+      }
+    ; {
+        description= "no alert, 30 days and 1 second left"
+      ; check_time= "20230612T17:00:00Z"
+      ; expire_time= "20230712T17:00:01Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= None
+      }
+    ; {
+        description= "no alert, 30 days left"
+      ; check_time= "20230612T17:00:00Z"
+      ; expire_time= "20230712T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= None
+      }
+    ; {
+        description= "expiring alert, 1 second less than 30 days left"
+      ; check_time= "20230612T17:00:01Z"
+      ; expire_time= "20230712T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expiring_result test_expiring_30)
+      }
+    ; {
+        description= "expiring alert, 14 days left"
+      ; check_time= "20230612T17:00:00Z"
+      ; expire_time= "20230626T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expiring_result test_expiring_30)
+      }
+    ; {
+        description= "expiring alert, 1 second less than 14 days left"
+      ; check_time= "20230612T17:00:01Z"
+      ; expire_time= "20230626T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expiring_result test_expiring_14)
+      }
+    ; {
+        description= "expiring alert, 7 days left"
+      ; check_time= "20230612T17:00:00Z"
+      ; expire_time= "20230619T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expiring_result test_expiring_14)
+      }
+    ; {
+        description= "expiring alert, 1 second less than 7 days left"
+      ; check_time= "20230612T17:00:01Z"
+      ; expire_time= "20230619T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expiring_result test_expiring_07)
+      }
+    ; {
+        description= "expiring alert, 1 second left"
+      ; check_time= "20230612T17:00:00Z"
+      ; expire_time= "20230612T17:00:01Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expiring_result test_expiring_07)
+      }
+    ; {
+        description= "expiring alert, 0 second left"
+      ; check_time= "20230612T17:00:00Z"
+      ; expire_time= "20230612T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expiring_result test_expiring_07)
+      }
+    ; {
+        description= "expired alert, 1 second passed"
+      ; check_time= "20230612T17:00:01Z"
+      ; expire_time= "20230612T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expired_result test_expired)
+      }
+    ; {
+        description= "expired alert, 1 day passed"
+      ; check_time= "20230612T17:00:00Z"
+      ; expire_time= "20230611T17:00:00Z"
+      ; alert_conditions
+      ; obj_description= "TLS server certificate"
+      ; expected= Some (expired_result test_expired)
+      }
+    ]
+
+  let verify description expected actual =
+    Alcotest.(check @@ option @@ pair string @@ pair string int64)
+      description expected actual
+
+  let testing
+      {
+        description
+      ; check_time
+      ; expire_time
+      ; alert_conditions
+      ; obj_description
+      ; expected
+      } () =
+    let now = date_of check_time in
+    let expiry = date_of expire_time in
+    let actual =
+      maybe_generate_alert now obj_description alert_conditions expiry
+    in
+    let expected_res =
+      match expected with
+      | None ->
+          None
+      | Some func ->
+          func obj_description expiry
+    in
+    verify description expected_res actual
+
+  let test_from_test_case ({description; _} as test_case) =
+    (description, `Quick, testing test_case)
+
+  let tests = List.map test_from_test_case test_cases
+end
+
+module TestUpdateMessageInternal = struct
+  type message_ref = string
+
+  type test_case = {
+      description: string
+    ; alert_conditions: (int * (string * int64)) list
+    ; msg_obj_uuid: string
+    ; alert: string * (string * int64)
+    ; all_msgs_properties:
+        (message_ref * (string * string * int64 * string)) list
+    ; expected_outdated_msg_refs: message_ref list
+    ; expected_current_msg_refs: message_ref list
+  }
+
+  let test_cases =
+    [
+      {
+        description= "no existing messages"
+      ; alert_conditions
+      ; msg_obj_uuid= "uuid1"
+      ; alert= ("msg_body", (fst test_expiring_30, 3L))
+      ; all_msgs_properties= []
+      ; expected_outdated_msg_refs= []
+      ; expected_current_msg_refs= []
+      }
+    ; {
+        description=
+          "no related messages: both message_name and message_obj_uuid do not \
+           match"
+      ; alert_conditions
+      ; msg_obj_uuid= "msg_obj_uuid"
+      ; alert= ("msg_body", test_expiring_30)
+      ; all_msgs_properties=
+          [
+            ( "msg_ref1"
+            , ("other_msg_name1", "other_msg_body1", 3L, "other_msg_obj_uuid1")
+            )
+          ; ( "msg_ref2"
+            , ("other_msg_name2", "other_msg_body2", 3L, "other_msg_obj_uuid2")
+            )
+          ]
+      ; expected_outdated_msg_refs= []
+      ; expected_current_msg_refs= []
+      }
+    ; {
+        description=
+          "no related messages: message_name match, message_obj_uuid different"
+      ; alert_conditions
+      ; msg_obj_uuid= "uuid1"
+      ; alert= ("msg_body", test_expiring_30)
+      ; all_msgs_properties=
+          [
+            ( "msg_ref1"
+            , ("other_msg_name1", "other_msg_body1", 3L, "other_msg_obj_uuid1")
+            )
+          ; ( "msg_ref2"
+            , ( fst test_expired
+              , "other_msg_body2"
+              , snd test_expired
+              , "other_msg_obj_uuid2"
+              )
+            )
+          ]
+      ; expected_outdated_msg_refs= []
+      ; expected_current_msg_refs= []
+      }
+    ; {
+        description=
+          "no related messages: message_name do not match, message_obj_uuid \
+           equal"
+      ; alert_conditions
+      ; msg_obj_uuid= "msg_obj_uuid"
+      ; alert= ("msg_body", test_expiring_30)
+      ; all_msgs_properties=
+          [
+            ( "msg_ref1"
+            , ("other_msg_name1", "other_msg_body1", 3L, "msg_obj_uuid")
+            )
+          ; ( "msg_ref2"
+            , ("other_msg_name2", "other_msg_body2", 3L, "msg_obj_uuid")
+            )
+          ]
+      ; expected_outdated_msg_refs= []
+      ; expected_current_msg_refs= []
+      }
+    ; {
+        description= "have outdated message"
+      ; alert_conditions
+      ; msg_obj_uuid= "msg_obj_uuid"
+      ; alert= ("msg_body", test_expiring_14)
+      ; all_msgs_properties=
+          [
+            ( "msg_ref1"
+            , ("other_msg_name1", "other_msg_body1", 3L, "msg_obj_uuid")
+            )
+          ; ( "msg_ref2"
+            , ( fst test_expiring_30
+              , "other_msg_body2"
+              , snd test_expiring_30
+              , "msg_obj_uuid"
+              )
+            )
+          ]
+      ; expected_outdated_msg_refs= ["msg_ref2"]
+      ; expected_current_msg_refs= []
+      }
+    ; {
+        description= "already have the required message"
+      ; alert_conditions
+      ; msg_obj_uuid= "msg_obj_uuid"
+      ; alert= ("msg_body", test_expiring_14)
+      ; all_msgs_properties=
+          [
+            ( "msg_ref1"
+            , ("other_msg_name1", "other_msg_body1", 3L, "msg_obj_uuid")
+            )
+          ; ( "msg_ref2"
+            , ( fst test_expiring_14
+              , "msg_body"
+              , snd test_expiring_14
+              , "msg_obj_uuid"
+              )
+            )
+          ]
+      ; expected_outdated_msg_refs= []
+      ; expected_current_msg_refs= ["msg_ref2"]
+      }
+    ]
+
+  let eq_api_message (a_ref, _a_record) (b_ref, _b_record) = a_ref = b_ref
+
+  let string_of_message (ref, record) =
+    Printf.sprintf
+      "Message Ref: %s, message_name: %s, message_priority: %Ld, message_body: \
+       %s, message_obj_uuid: %s"
+      ref record.API.message_name record.API.message_priority
+      record.API.message_body record.API.message_obj_uuid
+
+  let pp_api_message = Fmt.of_to_string string_of_message
+
+  let api_message = Alcotest.testable pp_api_message eq_api_message
+
+  let verify description expected actual =
+    Alcotest.(check @@ pair (list api_message) (list api_message))
+      description expected actual
+
+  let testing
+      {
+        description
+      ; alert_conditions
+      ; msg_obj_uuid
+      ; alert
+      ; all_msgs_properties
+      ; expected_outdated_msg_refs
+      ; expected_current_msg_refs
+      } () =
+    let all_msgs =
+      List.map
+        (fun (ref, (name, body, prio, obj_uuid)) ->
+          ( ref
+          , {
+              API.message_name= name
+            ; API.message_priority= prio
+            ; API.message_obj_uuid= obj_uuid
+            ; API.message_body= body
+            ; API.message_uuid= Uuidx.to_string (Uuidx.make ()) (*not used*)
+            ; API.message_cls= `Host (*not used*)
+            ; API.message_timestamp= Xapi_stdext_date.Date.epoch (*not used*)
+            }
+          )
+        )
+        all_msgs_properties
+    in
+    let msg_name_list =
+      List.map (fun (_, (msg_name, _)) -> msg_name) alert_conditions
+    in
+    let actual = filter_messages msg_name_list msg_obj_uuid alert all_msgs in
+    let refs_to_msgs refs =
+      List.map
+        (fun ref ->
+          ( ref
+          , {
+              API.message_name= "name" (*not used*)
+            ; API.message_priority= 1L (*not used*)
+            ; API.message_obj_uuid= "obj_uuid" (*not used*)
+            ; API.message_body= "body" (*not used*)
+            ; API.message_uuid= Uuidx.to_string (Uuidx.make ()) (*not used*)
+            ; API.message_cls= `Host (*not used*)
+            ; API.message_timestamp= Xapi_stdext_date.Date.epoch (*not used*)
+            }
+          )
+        )
+        refs
+    in
+    let expected_outdated_msgs = refs_to_msgs expected_outdated_msg_refs in
+    let expected_current_msgs = refs_to_msgs expected_current_msg_refs in
+    verify description (expected_outdated_msgs, expected_current_msgs) actual
+
+  let test_from_test_case ({description; _} as test_case) =
+    (description, `Quick, testing test_case)
+
+  let tests = List.map test_from_test_case test_cases
+end
+
+let test = TestGenerateAlert.tests @ TestUpdateMessageInternal.tests

--- a/ocaml/tests/alerts/test_suite.ml
+++ b/ocaml/tests/alerts/test_suite.ml
@@ -5,5 +5,6 @@ let () =
   Alcotest.run "Alerts"
     [
       ("Test_daily_license_check", Test_daily_license_check.test)
+    ; ("Test_expiry_alert", Test_expiry_alert.test)
     ; ("Test_alert_certificate_check", Test_alert_certificate_check.test)
     ]

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=520
+  N=519
   # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
   MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)

--- a/xapi-expiry-alerts.opam
+++ b/xapi-expiry-alerts.opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "Pau Ruiz Safont" "Gang Ji" ]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/xen-api"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune"
+  "astring"
+  "xapi-client"
+  "xapi-consts"
+  "xapi-types"
+  "xapi-stdext-date"
+  "alcotest" {with-test}
+]
+synopsis:
+  "Xen-API client library for sending expiry alerts and removing outdated ones"
+url {
+  src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
+}


### PR DESCRIPTION
This PR follows @psafont 's advise: https://github.com/xapi-project/xs-opam/pull/647#issuecomment-1618430105, after these "xapi-expiry-alerts" related changes merged into master, we can then merge https://github.com/xapi-project/xs-opam/pull/647 and use the library in proprietary daemons

The first 2 commits are cherry-picked from branch: [xapi-project:feature/stream-updates](https://github.com/xapi-project/xen-api/tree/feature/stream-updates), related PRs: https://github.com/xapi-project/xen-api/pull/5060 and https://github.com/xapi-project/xen-api/pull/5085