### PR TITLE
CP-43728: Store in DB: if Toolstack restart is required after update

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2144,6 +2144,12 @@ let t =
             ~default_value:(Some (VEnum "unknown"))
             "Default as 'unknown', 'yes' if the host is up to date with \
              updates synced from remote CDN, otherwise 'no'"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
+            "toolstack_restart_required_after_update"
+            ~default_value:(Some (VBool false))
+            "True if this host has applied an update with RestartToolstack as \
+             one of its recommended guidance, set to False after Toolstack is \
+             restarted"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "3efd34e77e3d098653f4f0e1c89bae1d"
+let last_known_schema_hash = "c2f56456af7c1e9d3c45f5db9e16d06a"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -208,7 +208,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
-    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown ;
+    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
+    ~toolstack_restart_required_after_update:false ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1048,7 +1048,8 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled ~last_software_update:Date.never
-    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown ;
+    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
+    ~toolstack_restart_required_after_update:false ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;
@@ -2984,8 +2985,7 @@ let get_host_updates_handler (req : Http.Request.t) s _ =
   )
 
 let is_toolstack_restart_required ~__context self =
-  Db.Host.get_recommended_guidances ~__context ~self
-  |> List.mem `restart_toolstack
+  Db.Host.get_toolstack_restart_required_after_update ~__context ~self
 
 let assert_master_does_not_requires_restart_toolstack ~__context =
   if Helpers.get_master ~__context |> is_toolstack_restart_required ~__context

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -376,6 +376,8 @@ let consider_enabling_host_nolock ~__context =
       ~value:`restart_toolstack ;
     Db.Host.remove_recommended_guidances ~__context ~self:localhost
       ~value:`restart_toolstack ;
+    Db.Host.set_toolstack_restart_required_after_update ~__context
+      ~self:localhost ~value:false ;
     if !Xapi_globs.on_system_boot then (
       debug
         "Host.enabled: system has just restarted: setting localhost to enabled" ;


### PR DESCRIPTION
Add field "toolstack_restart_required_after_update" to Host objects to
record if Toolstack restart is required after update.

This commit is a fixup for d2290d419f0ecdca28d2c35ca2169a4ca1197a61 
CP-42787: Ensure correct pool update sequence:

 let is_toolstack_restart_required ~__context self =
 \-  Db.Host.get_recommended_guidances ~__context ~self
 \-  |> List.mem `restart_toolstack
 \+  Db.Host.get_toolstack_restart_required_after_update ~__context ~self

As `restart_toolstack will be removed from recommended_guidances
if `reboot_host also exists in recommended_guidances.