### PR TITLE
CA-378931: usb_reset: Fix mount call parameters

### DIFF
--- a/scripts/usb_reset.py
+++ b/scripts/usb_reset.py
@@ -231,7 +231,7 @@ def setup_cgroup(domid, pid):
 
 def mount(source, target, fs, flags=0):
     if ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True
-                   ).mount(source, target, fs, flags) < 0:
+                   ).mount(source, target, fs, flags, None) < 0:
         log.error("Failed to mount {} ({}) to {} with flags {}: {}".
                   format(source, fs, target, flags,
                          os.strerror(ctypes.get_errno())))


### PR DESCRIPTION
The mount system call takes a fifth "data" parameter but the code doesn't pass anything so the kernel gets garbage. Newer kernels are more strict than older ones and it causes the call to fail with EINVAL so pass None for the data parameter.