### PR TITLE
CP-42019: Update wording for expiry message

### DIFF
--- a/ocaml/alerts/certificate/certificate_check.ml
+++ b/ocaml/alerts/certificate/certificate_check.ml
@@ -25,11 +25,11 @@ let get_certificates rpc session_id =
 
 let certificate_description = function
   | Host _ ->
-      "TLS server certificate"
+      "The TLS server certificate"
   | Internal _ ->
-      "internal TLS server certificate"
+      "The internal TLS server certificate"
   | CA _ ->
-      "CA pool certificate"
+      "The CA pool certificate"
 
 let alert_conditions = function
   | Host _ ->

--- a/ocaml/alerts/expiry_alert.ml
+++ b/ocaml/alerts/expiry_alert.ml
@@ -52,9 +52,9 @@ let message_body msg expiry =
   Printf.sprintf "<body><message>%s</message><date>%s</date></body>" msg
     (Date.to_string expiry)
 
-let expired_message obj = Printf.sprintf "The %s has expired." obj
+let expired_message obj = Printf.sprintf "%s has expired." obj
 
-let expiring_message obj = Printf.sprintf "The %s is expiring soon." obj
+let expiring_message obj = Printf.sprintf "%s is expiring soon." obj
 
 let maybe_generate_alert now obj_description alert_conditions expiry =
   let remaining_days =


### PR DESCRIPTION
As the suggested wording from Katherine are:
"Your Customer Success Services (CSS) agreement is expiring soon."
and "Your Customer Success Services (CSS) agreement has expired.",
remove the leading "The".