### PR TITLE
Revert "CP-42787: Ensure correct pool update sequence"

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1957,12 +1957,6 @@ let _ =
   error Api_errors.invalid_update_sync_day ["day"]
     ~doc:"Invalid day of the week chosen for weekly update sync." () ;
 
-  error Api_errors.coordinator_requires_toolstack_restart []
-    ~doc:
-      "A toolstack restart on the coordinator is required before this \
-       operation."
-    () ;
-
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1285,9 +1285,6 @@ let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"
 
 let invalid_update_sync_day = "INVALID_UPDATE_SYNC_DAY"
 
-let coordinator_requires_toolstack_restart =
-  "COORDINATOR_REQUIRES_TOOLSTACK_RESTART"
-
 (* VTPMs *)
 
 let vtpm_max_amount_reached = "VTPM_MAX_AMOUNT_REACHED"

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2983,22 +2983,10 @@ let get_host_updates_handler (req : Http.Request.t) s _ =
       Unixext.really_write_string s json_str |> ignore
   )
 
-let is_toolstack_restart_required ~__context self =
-  Db.Host.get_recommended_guidances ~__context ~self
-  |> List.mem `restart_toolstack
-
-let assert_master_does_not_requires_restart_toolstack ~__context =
-  if Helpers.get_master ~__context |> is_toolstack_restart_required ~__context
-  then
-    raise Api_errors.(Server_error (coordinator_requires_toolstack_restart, []))
-
 let apply_updates ~__context ~self ~hash =
   (* This function runs on master host *)
   Helpers.assert_we_are_master ~__context ;
   Pool_features.assert_enabled ~__context ~f:Features.Updates ;
-  if not (Helpers.is_pool_master ~__context ~host:self) then
-    assert_master_does_not_requires_restart_toolstack ~__context ;
-
   let guidances, warnings =
     Xapi_pool_helpers.with_pool_operation ~__context
       ~self:(Helpers.get_pool ~__context)


### PR DESCRIPTION
This reverts commit d2290d419f0ecdca28d2c35ca2169a4ca1197a61.

Instead of blocking pool member update process, there is a better solution: during xapi's startup on pool member, check the coordinator's xapi version in the "master connection", and block if the coordinator has a lower version.

This revert commit removes the blocking during pool member update, will try to have a fix following the new solution later.