### PR TITLE
CA-378778: Calculate host guidance correctly

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -766,22 +766,27 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
       ) ;
   (* Evaluate recommended/pending guidances *)
   let recommended_guidances, pending_guidances =
-    let recommended_guidances' =
+    let new_recommended_gs =
       (* EvacuateHost will be applied before applying updates *)
       eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
         ~livepatches:successful_livepatches ~failed_livepatches
-        ~unapplied_guidances:
-          (Db.Host.get_recommended_guidances ~__context ~self:host)
       |> List.filter (fun g -> g <> Guidance.EvacuateHost)
     in
+    let recommended_guidances' =
+      merge_with_unapplied_guidances ~__context ~host ~kind:Recommended
+        ~guidances:new_recommended_gs
+    in
 
-    let pending_guidances' =
+    let new_pending_gs =
       eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Absolute
         ~livepatches:[] ~failed_livepatches:[]
-        ~unapplied_guidances:
-          (Db.Host.get_pending_guidances ~__context ~self:host)
       |> List.filter (fun g -> not (List.mem g recommended_guidances'))
     in
+    let pending_guidances' =
+      merge_with_unapplied_guidances ~__context ~host ~kind:Absolute
+        ~guidances:new_pending_gs
+    in
+
     match failed_livepatches with
     | [] ->
         (* No livepatch should be applicable now *)

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -765,7 +765,7 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
       (* EvacuateHost will be applied before applying updates *)
       eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
         ~livepatches:successful_livepatches ~failed_livepatches
-        ~previous_guidances:
+        ~unapplied_guidances:
           (Db.Host.get_recommended_guidances ~__context ~self:host)
       |> List.filter (fun g -> g <> Guidance.EvacuateHost)
     in
@@ -773,7 +773,8 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
     let pending_guidances' =
       eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Absolute
         ~livepatches:[] ~failed_livepatches:[]
-        ~previous_guidances:(Db.Host.get_pending_guidances ~__context ~self:host)
+        ~unapplied_guidances:
+          (Db.Host.get_pending_guidances ~__context ~self:host)
       |> List.filter (fun g -> not (List.mem g recommended_guidances'))
     in
     match failed_livepatches with

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -641,12 +641,12 @@ let set_restart_device_models ~__context ~host ~kind =
   | `Running, true | `Paused, true -> (
     match kind with
     | Guidance.Absolute ->
-        Db.VM.add_pending_guidances ~__context ~self:ref
-          ~value:`restart_device_model ;
+        Db.VM.set_pending_guidances ~__context ~self:ref
+          ~value:[`restart_device_model] ;
         None
     | Guidance.Recommended ->
-        Db.VM.add_recommended_guidances ~__context ~self:ref
-          ~value:`restart_device_model ;
+        Db.VM.set_recommended_guidances ~__context ~self:ref
+          ~value:[`restart_device_model] ;
         None
   )
   | _ ->

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -622,7 +622,7 @@ let append_livepatch_guidances ~updates_info ~upd_ids_of_livepatches guidances =
     upd_ids_of_livepatches guidances
 
 let eval_guidances ~updates_info ~updates ~kind ~livepatches ~failed_livepatches
-    ~previous_guidances =
+    ~unapplied_guidances =
   let extract_upd_ids lps =
     List.fold_left
       (fun acc (_, lps) ->
@@ -637,7 +637,7 @@ let eval_guidances ~updates_info ~updates ~kind ~livepatches ~failed_livepatches
   let initial_gs =
     List.fold_left
       (fun acc g -> GuidanceSet.add (Guidance.of_update_guidance g) acc)
-      GuidanceSet.empty previous_guidances
+      GuidanceSet.empty unapplied_guidances
   in
   List.fold_left
     (fun acc u ->
@@ -1240,11 +1240,11 @@ let consolidate_updates_of_host ~repository_name ~updates_info host
   in
   let rec_guidances =
     eval_guidances ~updates_info ~updates ~kind:Recommended ~livepatches
-      ~failed_livepatches:[] ~previous_guidances:[]
+      ~failed_livepatches:[] ~unapplied_guidances:[]
   in
   let abs_guidances =
     eval_guidances ~updates_info ~updates ~kind:Absolute ~livepatches:[]
-      ~failed_livepatches:[] ~previous_guidances:[]
+      ~failed_livepatches:[] ~unapplied_guidances:[]
     |> List.filter (fun g -> not (List.mem g rec_guidances))
   in
   let upd_ids_of_livepatches, lps =


### PR DESCRIPTION
When there remains 'recommended_guidances' or 'pending_guidances' from previous update not applied for a host, the 'recommended_guidances' and 'pending_guidances' are not calculated correctly: the previous guidance should be taken into account to calculate the new 'recommended_guidances' and 'pending_guidances'.