### PR TITLE
CA-379929: move json dump out of the rrdd plugin directory

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -798,8 +798,7 @@ let do_monitor_write xc writers =
       let uuid_domids = List.map (fun (_, u, i) -> (u, i)) domains in
       Rrdd_monitor.update_rrds timestamp stats uuid_domids my_paused_vms ;
 
-      (* Dump to /dev/shm/metrics/host-dss *)
-      Rrdd_server.Plugin.get_path "host-dss"
+      Rrdd_libs.Constants.datasource_dump_file
       |> Rrdd_server.dump_host_dss_to_file
   )
 

--- a/ocaml/xcp-rrdd/lib/rrdd/constants.ml
+++ b/ocaml/xcp-rrdd/lib/rrdd/constants.ml
@@ -13,6 +13,8 @@
  *)
 (* constants which are global across all the tools *)
 
+let ( // ) = Filename.concat
+
 let get_vm_rrd = "vm_rrd"
 
 let get_vm_rrd_uri = "/" ^ get_vm_rrd
@@ -48,6 +50,9 @@ let rrd_location = Filename.concat "/var/lib/xcp" "blobs/rrds"
 
 (* Blob storage location. *)
 let blob_location = Filename.concat "/var/lib/xcp" "blobs"
+
+(* Location of json dump for NRPE to read them *)
+let datasource_dump_file = "/dev/shm" // "host-metrics.json"
 
 let version_major = 1
 

--- a/ocaml/xcp-rrdd/lib/rrdd/constants.ml
+++ b/ocaml/xcp-rrdd/lib/rrdd/constants.ml
@@ -54,8 +54,4 @@ let blob_location = Filename.concat "/var/lib/xcp" "blobs"
 (* Location of json dump for NRPE to read them *)
 let datasource_dump_file = "/dev/shm" // "host-metrics.json"
 
-let version_major = 1
-
-let version_minor = 0
-
-let rrdd_user_agent = Printf.sprintf "rrdd/%d.%d" version_major version_minor
+let rrdd_user_agent = "rrdd" // Xapi_version.version

--- a/ocaml/xcp-rrdd/lib/rrdd/dune
+++ b/ocaml/xcp-rrdd/lib/rrdd/dune
@@ -7,6 +7,7 @@
     threads.posix
     xapi-log
     xapi-stdext-threads
+    xapi_version
   )
 )
 

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -24,6 +24,7 @@ depends: [
   "ezxenstore"
   "uuid"
   "xapi-backtrace"
+  "xapi-consts"
   "xapi-idl"
   "xapi-rrd"
   "xapi-rrd-transport"


### PR DESCRIPTION
It causes logspam to have the file there

Also replaces a hardcoded version in the HTTP requests xcp-rdd sends with the actual version