### PR TITLE
fix CI, opam: sync with latest metadata; use ocaml setup v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,18 +36,6 @@ jobs:
     name: Ocaml tests
     runs-on: ubuntu-20.04
     env:
-      package: 'xapi-cli-protocol xapi-client xapi-consts xapi-datamodel xapi-types xapi
-        xe xen-api-sdk xen-api-client xen-api-client-lwt xen-api-client-async
-        xapi-rrdd xapi-rrdd-plugin xapi-rrd-transport xapi-rrd-transport-utils
-        rrd-transport rrdd-plugin rrdd-plugins rrddump gzip http-lib pciutil
-        safe-resources sexpr stunnel uuid xapi-compression xml-light2 zstd
-        vhd-tool xapi-networkd xapi-squeezed xapi-xenopsd xapi-xenopsd-cli
-        xapi-xenopsd-simulator xapi-xenopsd-xc message-switch
-        message-switch-async message-switch-cli message-switch-core
-        message-switch-lwt message-switch-unix xapi-idl forkexec xapi-forkexecd
-        xapi-storage xapi-storage-script xapi-storage-cli wsproxy xapi-nbd
-        varstored-guard xapi-log xapi-open-uri vhd-format vhd-format-lwt
-        xapi-tracing xapi-expiry-alerts ezxenstore'
       XAPI_VERSION: "v0.0.0-${{ github.sha }}"
 
     steps:
@@ -69,34 +57,18 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v1.0.2
-
-      - name: Retrieve date for cache key
-        id: cache-key
-        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Restore opam cache
-        id: opam-cache
-        uses: actions/cache@v3
-        with:
-          path: "~/.opam"
-          # invalidate cache daily, gets built daily using a scheduled job
-          key: ${{ steps.cache-key.outputs.date }}
+        uses: falti/dotenv-action@v1.0.4
 
       - name: Use ocaml
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
-          opam-repository: ${{ steps.dotenv.outputs.repository }}
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
+          dune-cache: true
 
       - name: Install dependencies
-        run: |
-          opam update
-          opam pin add . --no-action
-          opam depext -u ${{ env.package }}
-          opam upgrade
-          opam install ${{ env.package }} --deps-only --with-test -v
+        run: opam install . --deps-only --with-test -v
 
       - name: Configure
         run: opam exec -- ./configure --xapi_version="$XAPI_VERSION"

--- a/forkexec.opam
+++ b/forkexec.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 
 build: [[ "dune" "build" "-p" name "-j" jobs ]]

--- a/http-lib.opam
+++ b/http-lib.opam
@@ -26,6 +26,7 @@ depends: [
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
+  "xapi-tracing"
   "xml-light2"
   "ounit2" {with-test & >= "2.0.0"}
 ]

--- a/message-switch-async.opam
+++ b/message-switch-async.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch-cli.opam
+++ b/message-switch-cli.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch-core.opam
+++ b/message-switch-core.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch-lwt.opam
+++ b/message-switch-lwt.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch-unix.opam
+++ b/message-switch-unix.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch.opam
+++ b/message-switch.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/rrd2csv.opam
+++ b/rrd2csv.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml"
   "dune"
-  "base-threads"
+  "http-lib"
   "xapi-client"
   "xapi-idl"
   "xapi-rrd"

--- a/rrdd-plugin.opam
+++ b/rrdd-plugin.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api.git"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/rrdd-plugins.opam
+++ b/rrdd-plugins.opam
@@ -5,7 +5,7 @@ authors: [ "xs-devel@lists.xenserver.org" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 synopsis: "Plugins registering to the RRD daemon and exposing various metrics"
 depends: [

--- a/xapi-forkexecd.opam
+++ b/xapi-forkexecd.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 
 build: [

--- a/xapi-idl.opam
+++ b/xapi-idl.opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 authors: "Dave Scott"
 homepage: "https://github.com/xapi-project/xcp-idl"
 bug-reports: "https://github.com/xapi-project/xcp-idl/issues"
-dev-repo: "git://github.com/xapi-project/xcp-idl"
+dev-repo: "https://github.com/xapi-project/xcp-idl.git"
 maintainer: "xen-api@lists.xen.org"
 tags: [ "org:xapi-project" ]
 build: [["dune" "build" "-p" name "-j" jobs]]
@@ -34,6 +34,7 @@ depends: [
   "xapi-stdext-date"
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
+  "xapi-tracing"
   "xapi-inventory"
   "xmlm"
 ]

--- a/xapi-nbd.opam
+++ b/xapi-nbd.opam
@@ -21,6 +21,7 @@ depends: [
   "uri"
   "uuid"
   "xapi-inventory"
+  "xapi-tracing"
   "xen-api-client-lwt"
 ]
 tags: [ "org:mirage" "org:xapi-project" ]

--- a/xapi-networkd.opam
+++ b/xapi-networkd.opam
@@ -13,6 +13,7 @@ depends: [
   "alcotest" {with-test}
   "base-threads"
   "forkexec"
+  "http-lib"
   "mtime"
   "netlink"
   "re"

--- a/xapi-open-uri.opam
+++ b/xapi-open-uri.opam
@@ -11,8 +11,10 @@ build: [
 available: [ os = "linux" | os = "macos" ]
 depends: [
   "ocaml"
+  "cohttp"
   "dune"
   "stunnel"
+  "uri"
   "xapi-stdext-pervasives"
 ]
 synopsis: "Library required by xapi"

--- a/xapi-rrdd-plugin.opam
+++ b/xapi-rrdd-plugin.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api.git"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 depends: ["ocaml" "rrdd-plugin"]
 synopsis: "A plugin library for the xapi performance monitoring daemon"
 description: """

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -14,6 +14,7 @@ depends: [
   "dune-build-info"
   "astring"
   "gzip"
+  "http-lib"
   "inotify"
   "io-page"
   "mtime"

--- a/xapi-squeezed.opam
+++ b/xapi-squeezed.opam
@@ -3,7 +3,7 @@ author: "dave.scott@eu.citrix.com"
 maintainer: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api.git"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}

--- a/xapi-storage-script.opam
+++ b/xapi-storage-script.opam
@@ -5,13 +5,13 @@ authors: [ "xen-api@lists.xen.org" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"
   "dune"
-  "conf-python-2-7" {with-test}
+  "conf-python-3" {with-test}
   "xapi-idl" {>= "0.10.0"}
   "xapi-storage"
   "async" {>= "v0.9.0"}

--- a/xapi-storage.opam
+++ b/xapi-storage.opam
@@ -4,14 +4,14 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "git://github.com/xapi-project/xen-api.git"
+dev-repo: "https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "ocaml"
   "dune"
-  "conf-python-2-7"
+  "conf-python-3"
   "ounit" {with-test}
   "alcotest" {with-test}
   "lwt" {with-test}
@@ -20,10 +20,6 @@ depends: [
   "rpclib"
   "xmlm"
   "cmdliner"
-]
-# python 2.7 is not enough to ensure the availability of 'python' in these
-depexts: [
-  ["python"] {os-family = "debian"}
 ]
 synopsis: "Code and documentation generator for the Xapi storage interface"
 url {

--- a/xapi-tracing.opam
+++ b/xapi-tracing.opam
@@ -9,10 +9,13 @@ build: [[ "dune" "build" "-p" name "-j" jobs ]]
 available: [ os = "linux" ]
 depends: [
   "ocaml"
+  "cohttp-posix"
   "dune"
   "cohttp"
   "rpclib"
-  "xapi-idl"
+  "xapi-log"
+  "xapi-open-uri"
+  "xapi-stdext-threads"
   "xapi-stdext-unix"
 ]
 synopsis: "Library required by xapi"

--- a/xapi-xenopsd.opam
+++ b/xapi-xenopsd.opam
@@ -37,6 +37,7 @@ depends: [
   "xapi-stdext-pervasives"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
+  "xapi-tracing"
   "xenstore_transport" {with-test}
   "xmlm"
   "zstd"

--- a/xapi.opam
+++ b/xapi.opam
@@ -51,6 +51,7 @@ depends: [
   "xapi-cli-protocol"
   "xapi-consts"
   "xapi-datamodel"
+  "xapi-expiry-alerts"
   "xapi-stdext-date"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"
@@ -58,6 +59,7 @@ depends: [
   "xapi-stdext-unix"
   "xapi-stdext-zerocheck"
   "xapi-test-utils" {with-test}
+  "xapi-tracing"
   "xapi-types"
   "xapi-xenopsd"
   "xapi-idl"

--- a/xen-api-client.opam
+++ b/xen-api-client.opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {"1.4"}
+  "dune" {>= "2.0"}
   "astring"
   "cohttp" {>= "0.22.0"}
   "re"

--- a/xen-api-sdk.opam
+++ b/xen-api-sdk.opam
@@ -3,7 +3,7 @@ name: "xen-api-sdk"
 synopsis: "Xen API SDK generation code"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
-license: "BSD 2-Clause"
+license: "BSD-2-Clause"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 dev-repo: "git+https://github.com/xapi-project/xen-api.git"


### PR DESCRIPTION
Changes some download links to stop using the git protocol, updates some dependencies on new libraries and changes the conf-python dependency to depend on python 3

Also changes the ocaml setup action to v2, as this is the one that's maintained and should give less problems than the v1 that's in use currently