### PR TITLE
CP-43916: Merge only required and clean commits from feature/stream-updates into master

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 763
+let schema_minor_vsn = 764
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1954,6 +1954,9 @@ let _ =
        now."
     () ;
 
+  error Api_errors.invalid_update_sync_day ["day"]
+    ~doc:"Invalid day of the week chosen for weekly update sync." () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1941,6 +1941,8 @@ let _ =
     ~doc:"The repository proxy username/password is invalid." () ;
   error Api_errors.apply_livepatch_failed ["livepatch"]
     ~doc:"Failed to apply a livepatch." () ;
+  error Api_errors.updates_require_recommended_guidance ["recommended_guidance"]
+    ~doc:"Requires recommended guidance after applying updates." () ;
   error Api_errors.update_guidance_changed ["guidance"]
     ~doc:"Guidance for the update has changed" () ;
 

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1931,8 +1931,6 @@ let _ =
       "The hash of updateinfo doesn't match with current one. There may be \
        newer available updates."
     () ;
-  error Api_errors.updates_require_sync []
-    ~doc:"A call to pool.sync_updates is required before this operation." () ;
   error Api_errors.cannot_restart_device_model ["ref"]
     ~doc:"Cannot restart device models of paused VMs residing on the host." () ;
   error Api_errors.invalid_repository_proxy_url ["url"]

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1761,6 +1761,24 @@ let apply_recommended_guidances =
       ]
     ~allowed_roles:_R_POOL_OP ()
 
+let latest_synced_updates_applied_state =
+  Enum
+    ( "latest_synced_updates_applied_state"
+    , [
+        ( "yes"
+        , "The host is up to date with the latest updates synced from remote \
+           CDN"
+        )
+      ; ( "no"
+        , "The host is outdated with the latest updates synced from remote CDN"
+        )
+      ; ( "unknown"
+        , "If the host is up to date with the latest updates synced from \
+           remote CDN is unknown"
+        )
+      ]
+    )
+
 (** Hosts *)
 let t =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303
@@ -2120,6 +2138,12 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "recommended_guidances" ~default_value:(Some (VSet []))
             "The set of recommended guidances after applying updates"
+        ; field ~qualifier:DynamicRO ~lifecycle:[]
+            ~ty:latest_synced_updates_applied_state
+            "latest_synced_updates_applied"
+            ~default_value:(Some (VEnum "unknown"))
+            "Default as 'unknown', 'yes' if the host is up to date with \
+             updates synced from remote CDN, otherwise 'no'"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1709,7 +1709,10 @@ let apply_updates =
         )
       ]
     ~result:
-      (Set (Set String), "The list of warnings happened in applying updates")
+      ( Set (Set String)
+      , "The list of results after applying updates, including livepatch apply \
+         failures and recommended guidances"
+      )
     ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)
     ()
 
@@ -1739,6 +1742,21 @@ let set_https_only =
         , "value"
         , "true - http port 80 will be blocked, false - http port 80 will be \
            open"
+        )
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
+let apply_recommended_guidances =
+  call ~name:"apply_recommended_guidances"
+    ~doc:
+      "apply all recommended guidances both on the host and on all HVM VMs on \
+       the host after updates are applied on the host"
+    ~lifecycle:[]
+    ~params:
+      [
+        ( Ref _host
+        , "self"
+        , "The host whose recommended guidances will be applied"
         )
       ]
     ~allowed_roles:_R_POOL_OP ()
@@ -1877,6 +1895,7 @@ let t =
       ; apply_updates
       ; copy_primary_host_certs
       ; set_https_only
+      ; apply_recommended_guidances
       ]
     ~contents:
       ([
@@ -2098,6 +2117,9 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
             ~default_value:(Some (VBool false)) "https_only"
             "Reflects whether port 80 is open (false) or not (true)"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
+            "recommended_guidances" ~default_value:(Some (VSet []))
+            "The set of recommended guidances after applying updates"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -29,12 +29,26 @@ let prototyped_of_field = function
       Some "22.26.0"
   | "VTPM", "persistence_backend" ->
       Some "22.26.0"
+  | "host", "latest_synced_updates_applied" ->
+      Some "23.16.2-next"
+  | "host", "recommended_guidances" ->
+      Some "23.16.2-next"
   | "host", "https_only" ->
       Some "22.27.0"
   | "host", "last_software_update" ->
       Some "22.20.0"
+  | "VM", "recommended_guidances" ->
+      Some "23.16.2-next"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
+  | "pool", "update_sync_enabled" ->
+      Some "23.16.2-next"
+  | "pool", "update_sync_day" ->
+      Some "23.16.2-next"
+  | "pool", "update_sync_frequency" ->
+      Some "23.16.2-next"
+  | "pool", "last_update_sync" ->
+      Some "23.16.2-next"
   | "pool", "telemetry_next_collection" ->
       Some "23.9.0"
   | "pool", "telemetry_frequency" ->
@@ -77,8 +91,14 @@ let prototyped_of_message = function
       Some "22.26.0"
   | "VTPM", "create" ->
       Some "22.26.0"
+  | "host", "apply_recommended_guidances" ->
+      Some "23.16.2-next"
   | "host", "set_https_only" ->
       Some "22.27.0"
+  | "pool", "set_update_sync_enabled" ->
+      Some "23.16.2-next"
+  | "pool", "configure_update_sync" ->
+      Some "23.16.2-next"
   | "pool", "reset_telemetry_uuid" ->
       Some "23.9.0"
   | "pool", "set_telemetry_next_collection" ->

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1380,6 +1380,9 @@ let t =
             "telemetry_next_collection"
             "The earliest timestamp (in UTC) when the next round of telemetry \
              collection can be carried out"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
+            ~default_value:(Some (VDateTime Date.epoch)) "last_update_sync"
+            "time of the last update sychronization"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1055,6 +1055,54 @@ let reset_telemetry_uuid =
     ~params:[(Ref _pool, "self", "The pool")]
     ~allowed_roles:_R_POOL_ADMIN ()
 
+let update_sync_frequency =
+  Enum
+    ( "update_sync_frequency"
+    , [
+        ("daily", "The update synchronizations happen every day")
+      ; ( "weekly"
+        , "The update synchronizations happen every week on the chosen day"
+        )
+      ]
+    )
+
+let configure_update_sync =
+  call ~name:"configure_update_sync"
+    ~doc:
+      "Configure periodic update synchronization to sync updates from a remote \
+       CDN"
+    ~lifecycle:[]
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( update_sync_frequency
+        , "update_sync_frequency"
+        , "The frequency at which updates are synchronized from a remote CDN: \
+           daily or weekly."
+        )
+      ; ( Int
+        , "update_sync_day"
+        , "The day of the week the update synchronization will happen, based \
+           on pool's local timezone. Valid values are 0 to 6, 0 being Sunday. \
+           For 'daily' schedule, the value is ignored."
+        )
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
+let set_update_sync_enabled =
+  call ~name:"set_update_sync_enabled" ~lifecycle:[]
+    ~doc:
+      "enable or disable periodic update synchronization depending on the value"
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( Bool
+        , "value"
+        , "true - enable periodic update synchronization, false - disable it"
+        )
+      ]
+    ~allowed_roles:_R_POOL_OP ()
+
 (** A pool class *)
 let t =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:None
@@ -1139,6 +1187,8 @@ let t =
       ; set_https_only
       ; set_telemetry_next_collection
       ; reset_telemetry_uuid
+      ; configure_update_sync
+      ; set_update_sync_enabled
       ]
     ~contents:
       ([uid ~in_oss_since:None _pool]
@@ -1383,6 +1433,18 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
             ~default_value:(Some (VDateTime Date.epoch)) "last_update_sync"
             "time of the last update sychronization"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:update_sync_frequency
+            ~default_value:(Some (VEnum "weekly")) "update_sync_frequency"
+            "The frequency at which updates are synchronized from a remote \
+             CDN: daily or weekly."
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "update_sync_day"
+            ~default_value:(Some (VInt 0L))
+            "The day of the week the update synchronizations will be \
+             scheduled, based on pool's local timezone. Ignored when \
+             update_sync_frequency is daily"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
+            ~default_value:(Some (VBool false)) "update_sync_enabled"
+            "Whether periodic update synchronization is enabled or not"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_repository.ml
+++ b/ocaml/idl/datamodel_repository.ml
@@ -173,7 +173,15 @@ let t =
           "SHA256 checksum of latest updateinfo.xml.gz in this repository if \
            its 'update' is true"
       ; field ~qualifier:DynamicRO
-          ~lifecycle:[(Published, "1.301.0", "")]
+          ~lifecycle:
+            [
+              (Published, "1.301.0", "")
+            ; (Deprecated, "23.12.0-next", "Dummy transition")
+            ; ( Removed
+              , "23.12.0-next"
+              , "The up_to_date field of repository was removed"
+              )
+            ]
           ~ty:Bool ~default_value:(Some (VBool false)) "up_to_date"
           "True if all hosts in pool is up to date with this repository"
       ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:String

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2141,6 +2141,9 @@ let t =
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
             "The set of pending guidances after applying updates"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
+            "recommended_guidances" ~default_value:(Some (VSet []))
+            "The set of recommended guidances after applying updates"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "f6016430c783ed9269de300359b926cd"
+let last_known_schema_hash = "3efd34e77e3d098653f4f0e1c89bae1d"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "52dba8fb7b9be91d45f8b3d96ae87f1d"
+let last_known_schema_hash = "f6016430c783ed9269de300359b926cd"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "6e38b31df3f16f18608bf5eaf74ae5d2"
+let last_known_schema_hash = "37049c34c08a2494d23606ec9585328f"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "37049c34c08a2494d23606ec9585328f"
+let last_known_schema_hash = "52dba8fb7b9be91d45f8b3d96ae87f1d"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -293,7 +293,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(migration_compression = false) ?(coordinator_bias = true)
     ?(telemetry_uuid = Ref.null) ?(telemetry_frequency = `weekly)
     ?(telemetry_next_collection = API.Date.never)
-    ?(last_update_sync = API.Date.epoch) () =
+    ?(last_update_sync = API.Date.epoch) ?(update_sync_frequency = `daily)
+    ?(update_sync_day = 0L) ?(update_sync_enabled = false) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -309,7 +310,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~client_certificate_auth_enabled ~client_certificate_auth_name
     ~repository_proxy_url ~repository_proxy_username ~repository_proxy_password
     ~migration_compression ~coordinator_bias ~telemetry_uuid
-    ~telemetry_frequency ~telemetry_next_collection ~last_update_sync ;
+    ~telemetry_frequency ~telemetry_next_collection ~last_update_sync
+    ~update_sync_frequency ~update_sync_day ~update_sync_enabled ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -209,7 +209,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled
-    ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref) ;
+    ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
+    ~recommended_guidances:[] ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -291,7 +291,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(repository_proxy_username = "") ?(repository_proxy_password = Ref.null)
     ?(migration_compression = false) ?(coordinator_bias = true)
     ?(telemetry_uuid = Ref.null) ?(telemetry_frequency = `weekly)
-    ?(telemetry_next_collection = API.Date.never) () =
+    ?(telemetry_next_collection = API.Date.never)
+    ?(last_update_sync = API.Date.epoch) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -307,7 +308,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~client_certificate_auth_enabled ~client_certificate_auth_name
     ~repository_proxy_url ~repository_proxy_username ~repository_proxy_password
     ~migration_compression ~coordinator_bias ~telemetry_uuid
-    ~telemetry_frequency ~telemetry_next_collection ;
+    ~telemetry_frequency ~telemetry_next_collection ~last_update_sync ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -210,7 +210,7 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
-    ~recommended_guidances:[] ;
+    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -7,7 +7,8 @@
       test_cluster_host test_cluster test_pusb test_network_sriov
       test_vm_placement test_vm_helpers test_repository test_repository_helpers
       test_ref
-      test_livepatch test_rpm test_updateinfo test_storage_smapiv1_wrapper test_storage_quicktest test_observer))
+      test_livepatch test_rpm test_updateinfo test_storage_smapiv1_wrapper test_storage_quicktest test_observer
+      test_pool_periodic_update_sync))
   (libraries
     alcotest
     angstrom
@@ -59,13 +60,13 @@
 (tests
   (names test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt
     test_clustering test_pusb test_daemon_manager test_repository test_repository_helpers
-    test_livepatch test_rpm test_updateinfo)
+    test_livepatch test_rpm test_updateinfo test_pool_periodic_update_sync)
   (package xapi)
   (modes exe)
   (modules test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt
     test_event test_clustering test_cluster_host test_cluster test_pusb
     test_daemon_manager test_repository test_repository_helpers test_livepatch test_rpm
-    test_updateinfo)
+    test_updateinfo test_pool_periodic_update_sync)
   (libraries
     alcotest
     fmt

--- a/ocaml/tests/test_pool_periodic_update_sync.ml
+++ b/ocaml/tests/test_pool_periodic_update_sync.ml
@@ -1,0 +1,159 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Test_highlevel
+open Pool_periodic_update_sync
+
+type time_without_tz = int * int * int
+
+let timezones = [(0, "UTC"); (8 * 60 * 60, "UTC +8"); (-1 * 60 * 60, "UTC -1")]
+
+let of_date_time_tz d t tz_s = Ptime.of_date_time (d, (t, tz_s)) |> Option.get
+
+module TestDayOfNextSync = struct
+  let ptime = Alcotest.testable Ptime.pp Ptime.equal
+
+  type test_case = {
+      description: string
+    ; now: Ptime.date * time_without_tz
+    ; frequency: frequency
+    ; expected: Ptime.date * time_without_tz
+  }
+
+  let test_cases =
+    [
+      {
+        description= "daily"
+      ; now= ((2023, 5, 4), (13, 14, 15))
+      ; frequency= Daily
+      ; expected= ((2023, 5, 5), (0, 0, 0))
+      }
+    ; {
+        description= "daily, end of month"
+      ; now= ((2023, 5, 31), (13, 14, 15))
+      ; frequency= Daily
+      ; expected= ((2023, 6, 1), (0, 0, 0))
+      }
+    ; {
+        description= "daily, end of year"
+      ; now= ((2023, 12, 31), (13, 14, 15))
+      ; frequency= Daily
+      ; expected= ((2024, 1, 1), (0, 0, 0))
+      }
+    ; {
+        description= "weekly, this week"
+      ; now= ((2023, 5, 4), (13, 14, 15))
+      ; frequency= Weekly 6
+      ; expected= ((2023, 5, 6), (0, 0, 0))
+      }
+    ; {
+        description= "weekly, different day of next week"
+      ; now= ((2023, 5, 4), (13, 14, 15))
+      ; frequency= Weekly 1
+      ; expected= ((2023, 5, 8), (0, 0, 0))
+      }
+    ; {
+        description= "weekly, same day of next week"
+      ; now= ((2023, 5, 4), (13, 14, 15))
+      ; frequency= Weekly 4
+      ; expected= ((2023, 5, 11), (0, 0, 0))
+      }
+    ]
+
+  let test {description; now= d_a, t_a; frequency; expected= d_b, t_b}
+      tz_offset_s () =
+    let expected = of_date_time_tz d_b t_b tz_offset_s in
+    let now = of_date_time_tz d_a t_a tz_offset_s in
+    let actual = day_of_next_sync ~now ~tz_offset_s ~frequency in
+    Alcotest.check ptime description expected actual
+
+  let tests_for_each_tz_from_test_case ({description; _} as test_case) =
+    let test_from_tz (tz, tz_name) =
+      let description = Printf.sprintf "%s, %s" description tz_name in
+      (description, `Quick, test {test_case with description} tz)
+    in
+    List.map test_from_tz timezones
+
+  let tests = List.concat_map tests_for_each_tz_from_test_case test_cases
+end
+
+module TestTimeUntilNextSync = struct
+  let ptime_span = Alcotest.testable Ptime.Span.pp Ptime.Span.equal
+
+  type test_case = {
+      description: string
+    ; now: Ptime.date * time_without_tz
+    ; next_sync: Ptime.date * time_without_tz
+    ; expected: int
+  }
+
+  let test_cases =
+    [
+      {
+        description= "same month, more than 2 hours"
+      ; now= ((2023, 5, 4), (0, 0, 1))
+      ; next_sync= ((2023, 5, 6), (0, 0, 0))
+      ; expected= (2 * 24 * 60 * 60) - 1
+      }
+    ; {
+        description= "different month, more than 2 hours"
+      ; now= ((2023, 4, 29), (0, 0, 1))
+      ; next_sync= ((2023, 5, 4), (0, 1, 6))
+      ; expected= (5 * 24 * 60 * 60) - 1 + 60 + 6
+      }
+    ; {
+        description= "2 hours and 1 second"
+      ; now= ((2023, 5, 4), (23, 0, 1))
+      ; next_sync= ((2023, 5, 5), (1, 0, 2))
+      ; expected= (2 * 60 * 60) + 1
+      }
+    ; {
+        description= "2 hours"
+      ; now= ((2023, 5, 4), (23, 0, 1))
+      ; next_sync= ((2023, 5, 5), (1, 0, 1))
+      ; expected= 2 * 60 * 60
+      }
+    ; {
+        description= "1 hour and 59 second"
+      ; now= ((2023, 5, 4), (23, 0, 1))
+      ; next_sync= ((2023, 5, 5), (1, 0, 0))
+      ; expected= 2 * 60 * 60
+      }
+    ]
+
+  let test {description; now= d_a, t_a; next_sync= d_b, t_b; expected}
+      tz_offset_s () =
+    let next_sync = of_date_time_tz d_b t_b tz_offset_s in
+    let now = of_date_time_tz d_a t_a tz_offset_s in
+    let actual = time_until_next_sync ~now ~next_sync in
+    Alcotest.check ptime_span description (Ptime.Span.of_int_s expected) actual
+
+  let tests_for_each_tz_from_test_case ({description; _} as test_case) =
+    let test_from_tz (tz, tz_name) =
+      let description = Printf.sprintf "%s, %s" description tz_name in
+      (description, `Quick, test {test_case with description} tz)
+    in
+    List.map test_from_tz timezones
+
+  let tests = List.concat_map tests_for_each_tz_from_test_case test_cases
+end
+
+let tests =
+  make_suite "pool_periodic_update_sync-"
+    [
+      ("day_of_next_sync", TestDayOfNextSync.tests)
+    ; ("time_until_next_sync", TestTimeUntilNextSync.tests)
+    ]
+
+let () = Alcotest.run "Pool Periodic Update Sync" tests

--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -602,6 +602,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -618,6 +620,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -659,6 +663,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -699,6 +705,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -715,6 +723,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -755,6 +765,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -784,6 +796,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -824,6 +838,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -864,6 +880,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -904,6 +922,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -933,6 +953,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -973,6 +995,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1001,6 +1025,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1041,6 +1067,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1081,6 +1109,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1143,6 +1173,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "10.23.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1195,6 +1227,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "10.23.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1249,6 +1283,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1277,6 +1313,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.22.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1329,6 +1367,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1367,6 +1407,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.22.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1419,6 +1461,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1435,6 +1479,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1487,6 +1533,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1503,6 +1551,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; update_type= "security"
                     ; livepatch_guidance= None
                     ; livepatches= []
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1565,6 +1615,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.21.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ; ( "UPDATE-0001"
@@ -1593,6 +1645,8 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                             ; to_release= "8.0.22.xs8"
                             }
                         ]
+                    ; issued= Xapi_stdext_date.Date.epoch
+                    ; severity= Severity.None
                     }
                 )
               ]
@@ -1934,6 +1988,8 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
       ; update_type= "security"
       ; livepatch_guidance= None
       ; livepatches= []
+      ; issued= Xapi_stdext_date.Date.epoch
+      ; severity= Severity.None
       }
 
   let updates_info =
@@ -3072,6 +3128,8 @@ module PruneUpdateInfoForLivepatches = Generic.MakeStateless (struct
       ; update_type= "UPDATE_TYPE"
       ; livepatch_guidance= None
       ; livepatches= []
+      ; issued= Xapi_stdext_date.Date.epoch
+      ; severity= Severity.None
       }
 
   let tests =

--- a/ocaml/tests/test_updateinfo.ml
+++ b/ocaml/tests/test_updateinfo.ml
@@ -448,6 +448,12 @@ let fields_of_updateinfo =
             r.livepatches
         )
         (list string)
+    ; field "issued"
+        (fun (r : UpdateInfo.t) -> Xapi_stdext_date.Date.to_string r.issued)
+        string
+    ; field "severity"
+        (fun (r : UpdateInfo.t) -> Severity.to_string r.severity)
+        string
     ]
 
 module UpdateInfoOfXml = Generic.MakeStateless (struct
@@ -563,6 +569,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
                   }
               )
             ]
@@ -603,6 +611,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
               </update>
             </updates>
           |}
@@ -622,6 +632,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= Severity.High
                   }
               )
             ]
@@ -637,6 +650,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
               </update>
               <update type="security">
                 <id>UPDATE-0001</id>
@@ -646,6 +661,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
+                <issued date="2023-05-12 08:37:50"/>
+                <severity>None</severity>
               </update>
             </updates>
           |}
@@ -665,6 +682,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= Severity.High
                   }
               )
             ; ( "UPDATE-0001"
@@ -681,6 +701,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:50Z"
+                  ; severity= Severity.None
                   }
               )
             ]
@@ -715,6 +738,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     <arch>x86_64</arch>
                   </applicability>
                 </guidance_applicabilities>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
               </update>
             </updates>
           |}
@@ -754,6 +779,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= None
                   ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= Severity.High
                   }
               )
             ]
@@ -774,6 +802,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   <livepatch component="kernel" base="4.19.19-8.0.19.xs8" to="4.19.19-8.0.21.xs8" base-buildid="8346194f2e98a228f5a595b13ecabd43a99fada0"/>
                   <livepatch component="kernel" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
                 </livepatches>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
               </update>
             </updates>
           |}
@@ -815,6 +845,9 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                           ; to_release= "8.0.21.xs8"
                           }
                       ]
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= Severity.High
                   }
               )
             ]
@@ -852,6 +885,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= Some Guidance.RestartDeviceModel
                   ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
                   }
               )
             ]
@@ -903,6 +938,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                           ; to_release= "8.0.21.xs8"
                           }
                       ]
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
                   }
               )
             ]
@@ -942,6 +979,8 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; update_type= "security"
                   ; livepatch_guidance= Some Guidance.RestartToolstack
                   ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
                   }
               )
             ]

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2997,6 +2997,32 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pool-configure-update-sync"
+    , {
+        reqd= ["update-sync-frequency"; "update-sync-day"]
+      ; optn= []
+      ; help=
+          "Configure periodic update synchronization from a remote CDN. \
+           'update_sync_frequency': the frequency the synchronizations happen \
+           from a remote CDN: daily or weekly. 'update_sync_day': which day of \
+           the week the synchronizations will be scheduled in. For 'daily' \
+           schedule, the value is ignored. For 'weekly' schedule, valid values \
+           are 0 to 6, where 0 is Sunday."
+      ; implementation= No_fd Cli_operations.pool_configure_update_sync
+      ; flags= []
+      }
+    )
+  ; ( "pool-set-update-sync-enabled"
+    , {
+        reqd= ["value"]
+      ; optn= []
+      ; help=
+          "Enable or disable periodic update synchronization depending on the \
+           value"
+      ; implementation= No_fd Cli_operations.pool_set_update_sync_enabled
+      ; flags= []
+      }
+    )
   ; ( "host-ha-xapi-healthcheck"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1036,6 +1036,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Host_selectors]
       }
     )
+  ; ( "host-apply-recommended-guidances"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Apply recommended guidances on a host."
+      ; implementation= No_fd Cli_operations.host_apply_recommended_guidances
+      ; flags= [Host_selectors]
+      }
+    )
   ; ( "patch-upload"
     , {
         reqd= ["file-name"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7648,6 +7648,16 @@ let host_apply_updates _printer rpc session_id params =
        params ["hash"]
     )
 
+let host_apply_recommended_guidances _printer rpc session_id params =
+  ignore
+    (do_host_op rpc session_id ~multiple:false
+       (fun _ host ->
+         let host = host.getref () in
+         Client.Host.apply_recommended_guidances ~rpc ~session_id ~self:host
+       )
+       params []
+    )
+
 module SDN_controller = struct
   let introduce printer rpc session_id params =
     let port =

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1841,6 +1841,38 @@ let pool_reset_telemetry_uuid _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   Client.Pool.reset_telemetry_uuid ~rpc ~session_id ~self:pool
 
+let pool_configure_update_sync _printer rpc session_id params =
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  let update_sync_frequency =
+    Record_util.update_sync_frequency_of_string
+      (List.assoc "update-sync-frequency" params)
+  in
+  let day = List.assoc_opt "update-sync-day" params in
+  let update_sync_day =
+    match (update_sync_frequency, day) with
+    | `daily, _ ->
+        0L
+    | `weekly, d ->
+        let invalid_day_msg =
+          "Invalid value for day picked, must be an integer from 0 to 6"
+        in
+        let day_int =
+          try Option.(map Int64.of_string d |> get)
+          with _ -> failwith invalid_day_msg
+        in
+        if day_int < 0L || day_int > 6L then
+          failwith invalid_day_msg
+        else
+          day_int
+  in
+  Client.Pool.configure_update_sync ~rpc ~session_id ~self:pool
+    ~update_sync_frequency ~update_sync_day
+
+let pool_set_update_sync_enabled _printer rpc session_id params =
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  let value = get_bool_param params "value" in
+  Client.Pool.set_update_sync_enabled ~rpc ~session_id ~self:pool ~value
+
 let vdi_type_of_string = function
   | "system" ->
       `system

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -1134,3 +1134,18 @@ let mac_from_int_array macs =
 
 (* generate a random mac that is locally administered *)
 let random_mac_local () = mac_from_int_array (Array.make 6 (Random.int 0x100))
+
+let update_sync_frequency_to_string = function
+  | `daily ->
+      "daily"
+  | `weekly ->
+      "weekly"
+
+let update_sync_frequency_of_string s =
+  match String.lowercase_ascii s with
+  | "daily" ->
+      `daily
+  | "weekly" ->
+      `weekly
+  | _ ->
+      raise (Record_failure ("Expected 'daily', 'weekly', got " ^ s))

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -208,6 +208,14 @@ let update_guidance_to_string = function
   | `restart_device_model ->
       "restart_device_model"
 
+let latest_synced_updates_applied_state_to_string = function
+  | `yes ->
+      "yes"
+  | `no ->
+      "no"
+  | `unknown ->
+      "unknown"
+
 let vdi_operation_to_string : API.vdi_operations -> string = function
   | `clone ->
       "clone"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1474,6 +1474,18 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"last-update-sync"
           ~get:(fun () -> Date.to_string (x ()).API.pool_last_update_sync)
           ()
+      ; make_field ~name:"update-sync-frequency"
+          ~get:(fun () ->
+            Record_util.update_sync_frequency_to_string
+              (x ()).API.pool_update_sync_frequency
+          )
+          ()
+      ; make_field ~name:"update-sync-day"
+          ~get:(fun () -> Int64.to_string (x ()).API.pool_update_sync_day)
+          ()
+      ; make_field ~name:"update-sync-enabled"
+          ~get:(fun () -> (x ()).API.pool_update_sync_enabled |> string_of_bool)
+          ()
       ]
   }
 

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1471,6 +1471,9 @@ let pool_record rpc session_id pool =
             (x ()).API.pool_telemetry_next_collection |> Date.to_string
           )
           ()
+      ; make_field ~name:"last-update-sync"
+          ~get:(fun () -> Date.to_string (x ()).API.pool_last_update_sync)
+          ()
       ]
   }
 

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2576,6 +2576,12 @@ let vm_record rpc session_id vm =
       ; make_field ~name:"vtpms"
           ~get:(fun () -> get_uuids_from_refs (x ()).API.vM_VTPMs)
           ()
+      ; make_field ~name:"recommended-guidances"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.vM_recommended_guidances
+          )
+          ()
       ]
   }
 
@@ -3213,6 +3219,12 @@ let host_record rpc session_id host =
           ()
       ; make_field ~name:"last-software-update"
           ~get:(fun () -> Date.to_string (x ()).API.host_last_software_update)
+          ()
+      ; make_field ~name:"recommended-guidances"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.host_recommended_guidances
+          )
           ()
       ]
   }

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3238,6 +3238,12 @@ let host_record rpc session_id host =
               (x ()).API.host_recommended_guidances
           )
           ()
+      ; make_field ~name:"latest-synced-updates-applied"
+          ~get:(fun () ->
+            Record_util.latest_synced_updates_applied_state_to_string
+              (x ()).API.host_latest_synced_updates_applied
+          )
+          ()
       ]
   }
 
@@ -5222,9 +5228,6 @@ let repository_record rpc session_id repository =
           ~get:(fun () -> string_of_bool (x ()).API.repository_update)
           ()
       ; make_field ~name:"hash" ~get:(fun () -> (x ()).API.repository_hash) ()
-      ; make_field ~name:"up-to-date"
-          ~get:(fun () -> string_of_bool (x ()).API.repository_up_to_date)
-          ()
       ; make_field ~name:"gpgkey-path"
           ~get:(fun () -> (x ()).API.repository_gpgkey_path)
           ~set:(fun x ->

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1283,6 +1283,8 @@ let updates_require_recommended_guidance =
 
 let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"
 
+let invalid_update_sync_day = "INVALID_UPDATE_SYNC_DAY"
+
 (* VTPMs *)
 
 let vtpm_max_amount_reached = "VTPM_MAX_AMOUNT_REACHED"

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1280,6 +1280,9 @@ let invalid_repository_proxy_credential = "INVALID_REPOSITORY_PROXY_CREDENTIAL"
 
 let apply_livepatch_failed = "APPLY_LIVEPATCH_FAILED"
 
+let updates_require_recommended_guidance =
+  "UPDATES_REQUIRE_RECOMMENDED_GUIDANCE"
+
 let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"
 
 (* VTPMs *)

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1270,8 +1270,6 @@ let apply_guidance_failed = "APPLY_GUIDANCE_FAILED"
 
 let updateinfo_hash_mismatch = "UPDATEINFO_HASH_MISMATCH"
 
-let updates_require_sync = "UPDATES_REQUIRE_SYNC"
-
 let cannot_restart_device_model = "CANNOT_RESTART_DEVICE_MODEL"
 
 let invalid_repository_proxy_url = "INVALID_REPOSITORY_PROXY_URL"

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -353,3 +353,5 @@ let failed_login_attempts = addMessage "FAILED_LOGIN_ATTEMPTS" 3L
 
 let tls_verification_emergency_disabled =
   addMessage "TLS_VERIFICATION_EMERGENCY_DISABLED" 3L
+
+let periodic_update_sync_failed = addMessage "PERIODIC_UPDATE_SYNC_FAILED" 3L

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -321,7 +321,7 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info : host_info
     ~version:0L ~generation_id:"" ~hardware_platform_version:0L
     ~has_vendor_device:false ~requires_reboot:false ~reference_label:""
     ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[]
-    ~pending_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[] ;
   ensure_domain_zero_metrics_record ~__context ~domain_zero_ref host_info ;
   Db.Host.set_control_domain ~__context ~self:localhost ~value:domain_zero_ref ;
   Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -51,6 +51,8 @@ let create_pool_record ~__context =
       ~telemetry_frequency:`weekly
       ~telemetry_next_collection:Xapi_stdext_date.Date.epoch
       ~last_update_sync:Xapi_stdext_date.Date.epoch
+      ~update_sync_frequency:`weekly ~update_sync_day:0L
+      ~update_sync_enabled:false
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -50,6 +50,7 @@ let create_pool_record ~__context =
       ~coordinator_bias:true ~telemetry_uuid:Ref.null
       ~telemetry_frequency:`weekly
       ~telemetry_next_collection:Xapi_stdext_date.Date.epoch
+      ~last_update_sync:Xapi_stdext_date.Date.epoch
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -823,6 +823,13 @@ let is_pool_master ~__context ~host =
   let master_id = Db.Host.get_uuid ~__context ~self:master in
   host_id = master_id
 
+let assert_we_are_master ~__context =
+  if not (is_pool_master ~__context ~host:(get_localhost ~__context)) then
+    raise
+      Api_errors.(
+        Server_error (host_is_slave, [Pool_role.get_master_address ()])
+      )
+
 (* Host version compare helpers *)
 let compare_int_lists : int list -> int list -> int =
  fun a b ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3999,6 +3999,14 @@ functor
         do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
             Client.Host.set_https_only ~rpc ~session_id ~self ~value
         )
+
+      let apply_recommended_guidances ~__context ~self =
+        let uuid = host_uuid ~__context self in
+        info "Host.apply_recommended_guidance: host = %s" uuid ;
+        let local_fn = Local.Host.apply_recommended_guidances ~self in
+        do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
+            Client.Host.apply_recommended_guidances ~rpc ~session_id ~self
+        )
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4002,11 +4002,8 @@ functor
 
       let apply_recommended_guidances ~__context ~self =
         let uuid = host_uuid ~__context self in
-        info "Host.apply_recommended_guidance: host = %s" uuid ;
-        let local_fn = Local.Host.apply_recommended_guidances ~self in
-        do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
-            Client.Host.apply_recommended_guidances ~rpc ~session_id ~self
-        )
+        info "Host.apply_recommended_guidances: host = %s" uuid ;
+        Local.Host.apply_recommended_guidances ~__context ~self
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1114,6 +1114,22 @@ functor
       let reset_telemetry_uuid ~__context ~self =
         info "%s: pool='%s'" __FUNCTION__ (pool_uuid ~__context self) ;
         Local.Pool.reset_telemetry_uuid ~__context ~self
+
+      let configure_update_sync ~__context ~self ~update_sync_frequency
+          ~update_sync_day =
+        info "%s: pool='%s' update_sync_frequency='%s' update_sync_day=%Ld"
+          __FUNCTION__
+          (pool_uuid ~__context self)
+          (Record_util.update_sync_frequency_to_string update_sync_frequency)
+          update_sync_day ;
+        Local.Pool.configure_update_sync ~__context ~self ~update_sync_frequency
+          ~update_sync_day
+
+      let set_update_sync_enabled ~__context ~self ~value =
+        info "%s: pool='%s' value='%B'" __FUNCTION__
+          (pool_uuid ~__context self)
+          value ;
+        Local.Pool.set_update_sync_enabled ~__context ~self ~value
     end
 
     module VM = struct

--- a/ocaml/xapi/pool_periodic_update_sync.ml
+++ b/ocaml/xapi/pool_periodic_update_sync.ml
@@ -1,0 +1,173 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = __MODULE__ end)
+
+open D
+open Client
+
+type frequency = Daily | Weekly of int
+
+let frequency_of_freq_and_day freq day =
+  match (freq, Int64.to_int day) with
+  | `daily, _ ->
+      Daily
+  | `weekly, d ->
+      Weekly d
+
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
+
+let periodic_update_sync_task_name = "Periodic update synchronization"
+
+let secs_per_hour = 60 * 60
+
+let update_sync_minimum_interval = Ptime.Span.of_int_s (2 * secs_per_hour)
+
+let secs_per_day = 24 * secs_per_hour
+
+let random_delay () =
+  if Xapi_fist.disable_periodic_update_sync_sec_randomness () then
+    Ptime.Span.zero
+  else
+    Ptime.Span.of_int_s (Random.int secs_per_day)
+
+let frequency_to_str ~frequency =
+  match frequency with `daily -> "daily" | `weekly -> "weekly"
+
+let weekday_to_int = function
+  | `Sun ->
+      0
+  | `Mon ->
+      1
+  | `Tue ->
+      2
+  | `Wed ->
+      3
+  | `Thu ->
+      4
+  | `Fri ->
+      5
+  | `Sat ->
+      6
+
+let day_of_next_sync ~now ~tz_offset_s ~frequency =
+  let y, m, d = fst (Ptime.to_date_time ~tz_offset_s now) in
+  let beginning_of_day =
+    Ptime.of_date_time ((y, m, d), ((0, 0, 0), tz_offset_s)) |> Option.get
+  in
+  let delay_of d = Ptime.Span.of_d_ps (d, 0L) |> Option.get in
+
+  let days =
+    match frequency with
+    | Daily ->
+        1
+    | Weekly configured_day ->
+        let today = Ptime.weekday ~tz_offset_s now |> weekday_to_int in
+        if today < configured_day then
+          configured_day - today (* 1 to 6 days *)
+        else
+          configured_day - today + 7 (* 1 to 7 days *)
+  in
+  Ptime.add_span beginning_of_day (delay_of days) |> Option.get
+
+let time_until_next_sync_internal ~now ~next_sync =
+  let delay = Ptime.diff next_sync now in
+  if Xapi_fist.disable_periodic_update_sync_sec_randomness () then
+    delay
+  else if Ptime.Span.compare delay update_sync_minimum_interval > 0 then
+    delay
+  else (* Enforce a minimum of 2 hours between schedules *)
+    update_sync_minimum_interval
+
+let time_until_next_sync ~now ~next_sync =
+  match Xapi_fist.set_periodic_update_sync_delay () with
+  | None ->
+      time_until_next_sync_internal ~now ~next_sync
+  | Some delay -> (
+    try
+      let seconds = int_of_string (String.trim delay) in
+      Ptime.Span.of_int_s seconds
+    with _ ->
+      debug
+        "[PeriodicUpdateSync] failed to interpret periodic update sync delay: \
+         \"%s\""
+        delay ;
+      time_until_next_sync_internal ~now ~next_sync
+  )
+
+let seconds_until_next_schedule ~__context =
+  let frequency =
+    Db.Pool.get_update_sync_frequency ~__context
+      ~self:(Helpers.get_pool ~__context)
+  in
+  let day_of_week =
+    Db.Pool.get_update_sync_day ~__context ~self:(Helpers.get_pool ~__context)
+  in
+  debug
+    "[PeriodicUpdateSync] seconds_until_next_schedule, frequency=%s, \
+     day_configed=%Ld"
+    (frequency_to_str ~frequency)
+    day_of_week ;
+  let frequency = frequency_of_freq_and_day frequency day_of_week in
+  let now = Ptime_clock.now () in
+  let tz_offset_s = Ptime_clock.current_tz_offset_s () |> Option.get in
+  let delay = random_delay () in
+  let next_day = day_of_next_sync ~now ~tz_offset_s ~frequency in
+  let next_sync = Ptime.add_span next_day delay |> Option.get in
+  let delay = time_until_next_sync ~now ~next_sync |> Ptime.Span.to_float_s in
+  debug "[PeriodicUpdateSync] delay for next update sync: %f seconds" delay ;
+  delay
+
+let rec update_sync () =
+  debug "[PeriodicUpdateSync] periodic update synchronization start..." ;
+  Server_helpers.exec_with_new_task "periodic_update_sync" (fun __context ->
+      finally
+        (fun () ->
+          Helpers.call_api_functions ~__context (fun rpc session_id ->
+              try
+                ignore
+                  (Client.Pool.sync_updates ~rpc ~session_id
+                     ~self:(Helpers.get_pool ~__context)
+                     ~force:false ~token:"" ~token_id:""
+                  )
+              with e ->
+                let exc = Printexc.to_string e in
+                warn "Periodic update sync failed with exception %s" exc ;
+                let now = Xapi_stdext_date.Date.(now () |> to_string) in
+                let body =
+                  Printf.sprintf
+                    "<body><message>Periodic update sync \
+                     failed.</message><exception>%s</exception><date>%s</date></body>"
+                    exc now
+                in
+                let obj_uuid =
+                  Db.Pool.get_uuid ~__context ~self:(Helpers.get_pool ~__context)
+                in
+                Xapi_alert.add ~msg:Api_messages.periodic_update_sync_failed
+                  ~cls:`Pool ~obj_uuid ~body
+          )
+        )
+        (add_to_queue ~__context)
+  )
+
+and add_to_queue ~__context () =
+  let open Xapi_periodic_scheduler in
+  add_to_queue periodic_update_sync_task_name OneShot
+    (seconds_until_next_schedule ~__context)
+    update_sync
+
+let set_enabled ~__context ~value =
+  Xapi_periodic_scheduler.remove_from_queue periodic_update_sync_task_name ;
+  if value then
+    add_to_queue ~__context ()

--- a/ocaml/xapi/pool_periodic_update_sync.mli
+++ b/ocaml/xapi/pool_periodic_update_sync.mli
@@ -11,7 +11,16 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-(** Schedule common background tasks. *)
 
-val register : __context:Context.t -> unit
-(** Register periodic calls, done by {!Xapi} on start-up. *)
+val set_enabled : __context:Context.t -> value:bool -> unit
+
+(* Below exposed only for ease of testing *)
+
+type frequency = Daily | Weekly of int
+
+val day_of_next_sync :
+  now:Ptime.t -> tz_offset_s:int -> frequency:frequency -> Ptime.t
+
+val time_until_next_sync : now:Ptime.t -> next_sync:Ptime.t -> Ptime.span
+
+val random_delay : unit -> Ptime.span

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -188,6 +188,7 @@ let sync ~__context ~self ~token ~token_id =
           ; "--download-metadata"
           ; "--delete"
           ; "--plugins"
+          ; "--newest-only"
           ; Printf.sprintf "--repoid=%s" repo_name
           ]
         in

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -641,12 +641,12 @@ let set_restart_device_models ~__context ~host ~kind =
   | `Running, true | `Paused, true -> (
     match kind with
     | Guidance.Absolute ->
-        Db.VM.add_pending_guidances ~__context ~self:ref
-          ~value:`restart_device_model ;
+        Db.VM.set_pending_guidances ~__context ~self:ref
+          ~value:[`restart_device_model] ;
         None
     | Guidance.Recommended ->
-        Db.VM.add_recommended_guidances ~__context ~self:ref
-          ~value:`restart_device_model ;
+        Db.VM.set_recommended_guidances ~__context ~self:ref
+          ~value:[`restart_device_model] ;
         None
   )
   | _ ->
@@ -656,39 +656,46 @@ let set_restart_device_models ~__context ~host ~kind =
 let set_pending_guidances ~__context ~host ~guidances =
   let open Guidance in
   guidances
-  |> List.iter (function
-       | RebootHost ->
-           Db.Host.add_pending_guidances ~__context ~self:host
-             ~value:`reboot_host
-       | RebootHostOnLivePatchFailure ->
-           Db.Host.add_pending_guidances ~__context ~self:host
-             ~value:`reboot_host_on_livepatch_failure
-       | RestartToolstack ->
-           Db.Host.add_pending_guidances ~__context ~self:host
-             ~value:`restart_toolstack
-       | RestartDeviceModel ->
-           set_restart_device_models ~__context ~host ~kind:Absolute
-       | g ->
-           warn "Unsupported pending guidance %s, ignoring it."
-             (Guidance.to_string g)
+  |> List.fold_left
+       (fun acc g ->
+         match g with
+         | RebootHost ->
+             `reboot_host :: acc
+         | RebootHostOnLivePatchFailure ->
+             `reboot_host_on_livepatch_failure :: acc
+         | RestartToolstack ->
+             `restart_toolstack :: acc
+         | RestartDeviceModel ->
+             set_restart_device_models ~__context ~host ~kind:Absolute ;
+             acc
+         | g ->
+             warn "Unsupported pending guidance %s, ignoring it."
+               (Guidance.to_string g) ;
+             acc
        )
+       []
+  |> fun gs -> Db.Host.set_pending_guidances ~__context ~self:host ~value:gs
 
 let set_recommended_guidances ~__context ~host ~guidances =
   let open Guidance in
   guidances
-  |> List.iter (function
-       | RebootHost ->
-           Db.Host.add_recommended_guidances ~__context ~self:host
-             ~value:`reboot_host
-       | RestartToolstack ->
-           Db.Host.add_recommended_guidances ~__context ~self:host
-             ~value:`restart_toolstack
-       | RestartDeviceModel ->
-           set_restart_device_models ~__context ~host ~kind:Recommended
-       | g ->
-           warn "Unsupported recommended guidance %s, ignoring it."
-             (Guidance.to_string g)
+  |> List.fold_left
+       (fun acc g ->
+         match g with
+         | RebootHost ->
+             `reboot_host :: acc
+         | RestartToolstack ->
+             `restart_toolstack :: acc
+         | RestartDeviceModel ->
+             set_restart_device_models ~__context ~host ~kind:Absolute ;
+             acc
+         | g ->
+             warn "Unsupported recommended guidance %s, ignoring it."
+               (Guidance.to_string g) ;
+             acc
        )
+       []
+  |> fun gs -> Db.Host.set_recommended_guidances ~__context ~self:host ~value:gs
 
 let apply_livepatches' ~__context ~host ~livepatches =
   List.partition_map
@@ -749,18 +756,27 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
       ) ;
   (* Evaluate recommended/pending guidances *)
   let recommended_guidances, pending_guidances =
-    let recommended_guidances' =
+    let new_recommended_gs =
       (* EvacuateHost will be applied before applying updates *)
       eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
         ~livepatches:successful_livepatches ~failed_livepatches
       |> List.filter (fun g -> g <> Guidance.EvacuateHost)
     in
+    let recommended_guidances' =
+      merge_with_unapplied_guidances ~__context ~host ~kind:Recommended
+        ~guidances:new_recommended_gs
+    in
 
-    let pending_guidances' =
+    let new_pending_gs =
       eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Absolute
         ~livepatches:[] ~failed_livepatches:[]
       |> List.filter (fun g -> not (List.mem g recommended_guidances'))
     in
+    let pending_guidances' =
+      merge_with_unapplied_guidances ~__context ~host ~kind:Absolute
+        ~guidances:new_pending_gs
+    in
+
     match failed_livepatches with
     | [] ->
         (* No livepatch should be applicable now *)

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -703,97 +703,26 @@ let apply_livepatch ~__context ~host:_ ~component ~base_build_id ~base_version
       error "%s" msg ;
       raise Api_errors.(Server_error (internal_error, [msg]))
 
-let do_with_device_models ~__context ~host ~action_label:_ f =
-  (* Call f with device models of all running HVM VMs on the host *)
-  Db.Host.get_resident_VMs ~__context ~self:host
-  |> List.map (fun self -> (self, Db.VM.get_record ~__context ~self))
-  |> List.filter (fun (_, record) -> not record.API.vM_is_control_domain)
-  |> List.filter_map f
-  |> function
-  | [] ->
-      ()
-  | _ :: _ ->
-      let host' = Ref.string_of host in
-      raise Api_errors.(Server_error (cannot_restart_device_model, [host']))
-
-let set_pending_restart_device_models ~__context ~host =
+let set_restart_device_models ~__context ~host ~kind =
   (* Set pending restart device models of all running HVM VMs on the host *)
-  do_with_device_models ~__context ~host ~action_label:"set pending restart"
-  @@ fun (ref, record) ->
+  do_with_device_models ~__context ~host @@ fun (ref, record) ->
   match
     (record.API.vM_power_state, Helpers.has_qemu_currently ~__context ~self:ref)
   with
-  | `Running, true | `Paused, true ->
-      Db.VM.add_pending_guidances ~__context ~self:ref
-        ~value:`restart_device_model ;
-      None
+  | `Running, true | `Paused, true -> (
+    match kind with
+    | Guidance.Absolute ->
+        Db.VM.add_pending_guidances ~__context ~self:ref
+          ~value:`restart_device_model ;
+        None
+    | Guidance.Recommended ->
+        Db.VM.add_recommended_guidances ~__context ~self:ref
+          ~value:`restart_device_model ;
+        None
+  )
   | _ ->
       (* No device models are running for this VM *)
       None
-
-let restart_device_models ~__context ~host =
-  (* Restart device models of all running HVM VMs on the host by doing
-   * local migrations. *)
-  do_with_device_models ~__context ~host ~action_label:"restart"
-  @@ fun (ref, record) ->
-  match
-    (record.API.vM_power_state, Helpers.has_qemu_currently ~__context ~self:ref)
-  with
-  | `Running, true ->
-      Helpers.call_api_functions ~__context (fun rpc session_id ->
-          Client.Client.VM.pool_migrate ~rpc ~session_id ~vm:ref ~host
-            ~options:[("live", "true")]
-      ) ;
-      None
-  | `Paused, true ->
-      error "VM 'ref=%s' is paused, can't restart device models for it"
-        (Ref.string_of ref) ;
-      Some ref
-  | _ ->
-      (* No device models are running for this VM *)
-      None
-
-let apply_immediate_guidances ~__context ~host ~guidances =
-  (* This function runs on coordinator host *)
-  try
-    let open Client in
-    Helpers.call_api_functions ~__context (fun rpc session_id ->
-        let open Guidance in
-        match guidances with
-        | [] ->
-            ()
-        | [RebootHost] ->
-            Client.Host.reboot ~rpc ~session_id ~host
-        | [EvacuateHost] ->
-            (* EvacuatHost should be done before applying updates by XAPI users.
-             * Here only the guidances to be applied after applying updates are handled.
-             *)
-            ()
-        | [RestartDeviceModel] ->
-            restart_device_models ~__context ~host
-        | [RestartToolstack] ->
-            Client.Host.restart_agent ~rpc ~session_id ~host
-        | l when GuidanceSet.eq_set1 l ->
-            (* EvacuateHost and RestartToolstack *)
-            Client.Host.restart_agent ~rpc ~session_id ~host
-        | l when GuidanceSet.eq_set2 l ->
-            (* RestartDeviceModel and RestartToolstack *)
-            restart_device_models ~__context ~host ;
-            Client.Host.restart_agent ~rpc ~session_id ~host
-        | l ->
-            let host' = Ref.string_of host in
-            error
-              "Found wrong guidance(s) after applying updates on host \
-               ref='%s': %s"
-              host'
-              (String.concat ";" (List.map Guidance.to_string l)) ;
-            raise Api_errors.(Server_error (apply_guidance_failed, [host']))
-    )
-  with e ->
-    let host' = Ref.string_of host in
-    error "applying immediate guidances on host ref='%s' failed: %s" host'
-      (ExnHelper.string_of_exn e) ;
-    raise Api_errors.(Server_error (apply_guidance_failed, [host']))
 
 let set_pending_guidances ~__context ~host ~guidances =
   let open Guidance in
@@ -809,9 +738,26 @@ let set_pending_guidances ~__context ~host ~guidances =
            Db.Host.add_pending_guidances ~__context ~self:host
              ~value:`restart_toolstack
        | RestartDeviceModel ->
-           set_pending_restart_device_models ~__context ~host
+           set_restart_device_models ~__context ~host ~kind:Absolute
        | g ->
-           warn "Unsupported pending guidance %s, ignore it."
+           warn "Unsupported pending guidance %s, ignoring it."
+             (Guidance.to_string g)
+       )
+
+let set_recommended_guidances ~__context ~host ~guidances =
+  let open Guidance in
+  guidances
+  |> List.iter (function
+       | RebootHost ->
+           Db.Host.add_recommended_guidances ~__context ~self:host
+             ~value:`reboot_host
+       | RestartToolstack ->
+           Db.Host.add_recommended_guidances ~__context ~self:host
+             ~value:`restart_toolstack
+       | RestartDeviceModel ->
+           set_restart_device_models ~__context ~host ~kind:Recommended
+       | g ->
+           warn "Unsupported recommended guidance %s, ignoring it."
              (Guidance.to_string g)
        )
 
@@ -849,10 +795,6 @@ let apply_livepatches' ~__context ~host ~livepatches =
 let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
     =
   (* This function runs on coordinator host *)
-  let expected_immediate_guidances =
-    eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
-      ~livepatches ~failed_livepatches:[]
-  in
   (* Install RPM updates firstly *)
   Helpers.call_api_functions ~__context (fun rpc session_id ->
       Client.Client.Repository.apply ~rpc ~session_id ~host
@@ -876,15 +818,15 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
         )
       ]
       ) ;
-  (* Evaluate immediate/pending guidances *)
-  let immediate_guidances, pending_guidances =
-    let immediate_guidances' =
+  (* Evaluate recommended/pending guidances *)
+  let recommended_guidances, pending_guidances =
+    let recommended_guidances' =
       eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Recommended
         ~livepatches:successful_livepatches ~failed_livepatches
     in
     let pending_guidances' =
       List.filter
-        (fun g -> not (List.mem g immediate_guidances'))
+        (fun g -> not (List.mem g recommended_guidances'))
         (eval_guidances ~updates_info ~updates:acc_rpm_updates ~kind:Absolute
            ~livepatches:[] ~failed_livepatches:[]
         )
@@ -894,7 +836,7 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
         (* No livepatch should be applicable now *)
         Db.Host.remove_pending_guidances ~__context ~self:host
           ~value:`reboot_host_on_livepatch_failure ;
-        (immediate_guidances', pending_guidances')
+        (recommended_guidances', pending_guidances')
     | _ :: _ ->
         (* There is(are) livepatch failure(s):
          * the host should not be rebooted, and
@@ -902,38 +844,26 @@ let apply_updates' ~__context ~host ~updates_info ~livepatches ~acc_rpm_updates
          *)
         ( List.filter
             (fun g -> not (g = Guidance.RebootHost))
-            immediate_guidances'
+            recommended_guidances'
         , Guidance.RebootHostOnLivePatchFailure :: pending_guidances'
         )
   in
   List.iter
-    (fun g -> debug "immediate_guidance: %s" (Guidance.to_string g))
-    immediate_guidances ;
+    (fun g -> debug "recommended_guidance: %s" (Guidance.to_string g))
+    recommended_guidances ;
   List.iter
     (fun g -> debug "pending_guidance: %s" (Guidance.to_string g))
     pending_guidances ;
-  GuidanceSet.assert_valid_guidances immediate_guidances ;
+  GuidanceSet.assert_valid_guidances recommended_guidances ;
+  set_recommended_guidances ~__context ~host ~guidances:recommended_guidances ;
   set_pending_guidances ~__context ~host ~guidances:pending_guidances ;
-  let warnings =
-    List.map
+  ( recommended_guidances
+  , List.map
       (fun (lp, _) ->
         [Api_errors.apply_livepatch_failed; LivePatch.to_string lp]
       )
       failed_livepatches
-  in
-  match
-    GuidanceSet.equal
-      (GuidanceSet.of_list expected_immediate_guidances)
-      (GuidanceSet.of_list immediate_guidances)
-  with
-  | true ->
-      (immediate_guidances, warnings)
-  | false ->
-      let return_of_immediate_guidances =
-        immediate_guidances |> List.map Guidance.to_string |> String.concat ";"
-        |> fun s -> [Api_errors.update_guidance_changed; s]
-      in
-      (immediate_guidances, return_of_immediate_guidances :: warnings)
+  )
 
 let apply_updates ~__context ~host ~hash =
   (* This function runs on coordinator host *)

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -250,47 +250,6 @@ let http_get_host_updates_in_json ~__context ~host ~installed =
     )
     (fun () -> Xapi_session.destroy_db_session ~__context ~self:host_session_id)
 
-let group_host_updates_by_repository ~__context enabled host updates_of_host =
-  (* Return updates grouped by repository. Example:
-   * [ ("repo-00", [u0, u1]);
-   *   ("repo-01", [u3, u4]);
-   *   ... ...
-   * ]
-   *)
-  match Yojson.Basic.Util.member "updates" updates_of_host with
-  | `List updates ->
-      List.fold_left
-        (fun acc update ->
-          let upd = Update.of_json update in
-          match
-            Db.Repository.get_by_uuid ~__context ~uuid:upd.Update.repository
-          with
-          | repository when List.mem repository enabled ->
-              append_by_key acc repository upd
-          | repository when not (List.mem repository enabled) ->
-              let msg =
-                Printf.sprintf "Found update (%s) from a disabled repository"
-                  (Update.to_string upd)
-              in
-              raise Api_errors.(Server_error (internal_error, [msg]))
-          | _ | (exception _) ->
-              let msg =
-                Printf.sprintf "Found update (%s) from an unmanaged repository"
-                  (Update.to_string upd)
-              in
-              raise Api_errors.(Server_error (internal_error, [msg]))
-        )
-        [] updates
-  | _ ->
-      let host' = Ref.string_of host in
-      error "Invalid updates from host ref='%s': No 'updates'" host' ;
-      raise Api_errors.(Server_error (get_host_updates_failed, [host']))
-  | exception e ->
-      let host' = Ref.string_of host in
-      error "Invalid updates from host ref='%s': %s" host'
-        (ExnHelper.string_of_exn e) ;
-      raise Api_errors.(Server_error (get_host_updates_failed, [host']))
-
 let parse_updateinfo ~__context ~self ~check =
   let repo_name = get_remote_repository_name ~__context ~self in
   let repo_dir = Filename.concat !Xapi_globs.local_pool_repo_dir repo_name in
@@ -333,92 +292,62 @@ let get_hosts_updates ~__context =
       Helpers.run_in_parallel ~funs ~capacity:capacity_in_parallel
   )
 
-let get_applied_livepatches_of_hosts hosts_updates =
-  List.map
-    (fun (h, updates_of_host) ->
-      let applied_livepatches =
-        get_list_from_updates_of_host "applied_livepatches" updates_of_host
-        |> List.map Livepatch.of_json
-      in
-      (h, applied_livepatches)
-    )
-    hosts_updates
+let get_applied_livepatches_of_host updates_of_host =
+  get_list_from_updates_of_host "applied_livepatches" updates_of_host
+  |> List.map Livepatch.of_json
 
-(* Group updates by repository for each host *)
-let get_updates_of_hosts ~__context enabled_repositories hosts_updates =
-  List.map
-    (fun (h, updates_of_host) ->
-      group_host_updates_by_repository ~__context enabled_repositories h
-        updates_of_host
-    )
-    hosts_updates
-
-let is_livepatchable ~__context repository applied_livepatches_of_hosts =
+let is_livepatchable ~__context repository applied_livepatches_of_host =
   let updates_info =
     parse_updateinfo ~__context ~self:repository ~check:false
   in
   List.exists
-    (fun (_, applied_livepatches) ->
-      List.exists
-        (fun lp ->
-          get_accumulative_livepatches ~since:lp ~updates_info |> function
-          | [] ->
-              false
-          | _ ->
-              true
-        )
-        applied_livepatches
+    (fun lp ->
+      get_accumulative_livepatches ~since:lp ~updates_info |> function
+      | [] ->
+          false
+      | _ ->
+          true
     )
-    applied_livepatches_of_hosts
+    applied_livepatches_of_host
 
 let set_available_updates ~__context =
   ignore (get_single_enabled_update_repository ~__context) ;
   let enabled = get_enabled_repositories ~__context in
   let hosts_updates = get_hosts_updates ~__context in
-  let applied_livepatches_of_hosts =
-    get_applied_livepatches_of_hosts hosts_updates
-  in
-  let updates_of_hosts =
-    get_updates_of_hosts ~__context enabled hosts_updates
-  in
-  (* Group updates by repository for all hosts *)
-  let updates_by_repository =
-    List.fold_left
-      (fun acc l ->
-        List.fold_left (fun acc' (x, y) -> append_by_key acc' x y) acc l
-      )
-      [] updates_of_hosts
-  in
+  List.iter
+    (fun (h, updates_of_host) ->
+      let latest_synced_updates_applied =
+        match get_list_from_updates_of_host "updates" updates_of_host with
+        | [] -> (
+            (* No RPM packages to be updated.
+             * Find out if there are available livepatches from a update repo
+             *)
+            let update_repo =
+              get_singleton
+                (List.filter
+                   (fun repo -> Db.Repository.get_update ~__context ~self:repo)
+                   enabled
+                )
+            in
+            let livepatchable =
+              is_livepatchable ~__context update_repo
+                (get_applied_livepatches_of_host updates_of_host)
+            in
+            match livepatchable with true -> `no | false -> `yes
+          )
+        | _ ->
+            `no
+      in
+      Db.Host.set_latest_synced_updates_applied ~__context ~self:h
+        ~value:latest_synced_updates_applied
+    )
+    hosts_updates ;
   let checksums =
     List.filter_map
       (fun repository ->
-        let pkg_updates_available =
-          match List.assoc_opt repository updates_by_repository with
-          | Some (_ :: _) ->
-              true
-          | _ ->
-              false
-        in
         let is_update_repo =
           Db.Repository.get_update ~__context ~self:repository
         in
-        let up_to_date =
-          match (pkg_updates_available, is_update_repo) with
-          | true, _ ->
-              false
-          | false, false ->
-              true
-          | false, true ->
-              (* No RPM packages to be updated.
-               * Find out if there are available livepatches from a update repo
-               *)
-              not
-                (is_livepatchable ~__context repository
-                   applied_livepatches_of_hosts
-                )
-        in
-        Db.Repository.set_up_to_date ~__context ~self:repository
-          ~value:up_to_date ;
         if is_update_repo then (
           let repo_name =
             get_remote_repository_name ~__context ~self:repository

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -68,12 +68,6 @@ val apply_updates :
   -> hash:string
   -> Updateinfo.Guidance.t list * string list list
 
-val apply_immediate_guidances :
-     __context:Context.t
-  -> host:[`host] API.Ref.t
-  -> guidances:Updateinfo.Guidance.t list
-  -> unit
-
 val set_available_updates : __context:Context.t -> string
 
 val reset_updates_in_cache : unit -> unit

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -650,6 +650,20 @@ let eval_guidances ~updates_info ~updates ~kind ~livepatches ~failed_livepatches
   |> GuidanceSet.resort_guidances ~kind
   |> GuidanceSet.elements
 
+let merge_with_unapplied_guidances ~__context ~host ~kind ~guidances =
+  let open GuidanceSet in
+  ( match kind with
+  | Guidance.Absolute ->
+      Db.Host.get_pending_guidances ~__context ~self:host
+  | Guidance.Recommended ->
+      Db.Host.get_recommended_guidances ~__context ~self:host
+  )
+  |> List.map (fun g -> Guidance.of_update_guidance g)
+  |> of_list
+  |> union (of_list guidances)
+  |> resort_guidances ~kind
+  |> elements
+
 let repoquery_sep = ":|"
 
 let get_repoquery_fmt () =

--- a/ocaml/xapi/updateinfo.ml
+++ b/ocaml/xapi/updateinfo.ml
@@ -53,6 +53,16 @@ module Guidance = struct
     | _ ->
         error "Unknown node in <absolute|recommended_guidance>" ;
         raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+
+  let of_update_guidance = function
+    | `reboot_host ->
+        RebootHost
+    | `reboot_host_on_livepatch_failure ->
+        RebootHostOnLivePatchFailure
+    | `restart_toolstack ->
+        RestartToolstack
+    | `restart_device_model ->
+        RestartDeviceModel
 end
 
 module Applicability = struct

--- a/ocaml/xapi/updateinfo.ml
+++ b/ocaml/xapi/updateinfo.ml
@@ -405,6 +405,21 @@ module LivePatch = struct
          )
 end
 
+module Severity = struct
+  type t = None | High
+
+  let to_string = function None -> "None" | High -> "High"
+
+  let of_string = function
+    | "None" ->
+        None
+    | "High" ->
+        High
+    | _ ->
+        error "Unknown severity in updateinfo" ;
+        raise Api_errors.(Server_error (invalid_updateinfo_xml, []))
+end
+
 module UpdateInfo = struct
   type t = {
       id: string
@@ -418,6 +433,8 @@ module UpdateInfo = struct
     ; update_type: string
     ; livepatch_guidance: Guidance.t option
     ; livepatches: LivePatch.t list
+    ; issued: Xapi_stdext_date.Date.t
+    ; severity: Severity.t
   }
 
   let guidance_to_string o =
@@ -434,6 +451,8 @@ module UpdateInfo = struct
       ; ("type", `String ui.update_type)
       ; ("recommended-guidance", `String (guidance_to_string ui.rec_guidance))
       ; ("absolute-guidance", `String (guidance_to_string ui.abs_guidance))
+      ; ("issued", `String (Xapi_stdext_date.Date.to_string ui.issued))
+      ; ("severity", `String (Severity.to_string ui.severity))
       ]
     in
     match ui.livepatches with
@@ -477,6 +496,8 @@ module UpdateInfo = struct
     ; update_type= ""
     ; livepatch_guidance= None
     ; livepatches= []
+    ; issued= Xapi_stdext_date.Date.epoch
+    ; severity= Severity.None
     }
 
   let assert_valid_updateinfo = function
@@ -558,6 +579,37 @@ module UpdateInfo = struct
                           }
                       | Xml.Element ("livepatches", _, livepatches) ->
                           {acc with livepatches= LivePatch.of_xml livepatches}
+                      | Xml.Element ("issued", attr, _) ->
+                          let issued =
+                            match List.assoc_opt "date" attr with
+                            | Some date -> (
+                              try
+                                Xapi_stdext_date.Date.of_string
+                                  (Scanf.sscanf date
+                                     "%04d-%02d-%02d %02d:%02d:%02d"
+                                     (fun y mon d h m s ->
+                                       Printf.sprintf
+                                         "%04i%02i%02iT%02i:%02i:%02iZ" y mon d
+                                         h m s
+                                   )
+                                  )
+                              with e ->
+                                (* The error should not block update. Ingore it
+                                   and set "issued" as epoch. *)
+                                warn "%s" (ExnHelper.string_of_exn e) ;
+                                Xapi_stdext_date.Date.epoch
+                            )
+                            | None ->
+                                Xapi_stdext_date.Date.epoch
+                          in
+                          {acc with issued}
+                      | Xml.Element ("severity", _, [Xml.PCData v]) -> (
+                        try {acc with severity= Severity.of_string v}
+                        with e ->
+                          (* The error should not block update. Ingore it. *)
+                          warn "%s" (ExnHelper.string_of_exn e) ;
+                          acc
+                      )
                       | _ ->
                           acc
                     )

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -27,6 +27,7 @@ module Guidance : sig
 
   val to_string : t -> string
 
+  (* may fail *)
   val of_string : string -> t
 
   val of_update_guidance :
@@ -97,6 +98,15 @@ module LivePatch : sig
   val of_xml : Xml.xml list -> t list
 end
 
+module Severity : sig
+  type t = None | High
+
+  val to_string : t -> string
+
+  (* may fail *)
+  val of_string : string -> t
+end
+
 (** The metadata of one update in updateinfo *)
 module UpdateInfo : sig
   type t = {
@@ -111,6 +121,8 @@ module UpdateInfo : sig
     ; update_type: string
     ; livepatch_guidance: Guidance.t option
     ; livepatches: LivePatch.t list
+    ; issued: Xapi_stdext_date.Date.t
+    ; severity: Severity.t
   }
 
   val to_json : t -> Yojson.Basic.t

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -28,6 +28,13 @@ module Guidance : sig
   val to_string : t -> string
 
   val of_string : string -> t
+
+  val of_update_guidance :
+       [< `reboot_host
+       | `reboot_host_on_livepatch_failure
+       | `restart_device_model
+       | `restart_toolstack ]
+    -> t
 end
 
 (** The applicability of metadata for one update in updateinfo *)

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1218,7 +1218,7 @@ let server_init () =
             )
           ; ( "Registering periodic functions"
             , []
-            , Xapi_periodic_scheduler_init.register
+            , fun () -> Xapi_periodic_scheduler_init.register ~__context
             )
           ; ("executing startup scripts", [Startup.NoExnRaising], startup_script)
           ; ( "considering executing on-master-start script"

--- a/ocaml/xapi/xapi_fist.ml
+++ b/ocaml/xapi/xapi_fist.ml
@@ -113,6 +113,12 @@ let pause_after_cert_exchange () = fistpoint "pause_after_cert_exchange"
 let fail_on_error_in_yum_upgrade_dry_run () =
   fistpoint "fail_on_error_in_yum_upgrade_dry_run"
 
+let disable_periodic_update_sync_sec_randomness () =
+  fistpoint "disable_periodic_update_sync_sec_randomness"
+
+let set_periodic_update_sync_delay () =
+  fistpoint_read "set_periodic_update_sync_delay"
+
 let hang_psr psr_checkpoint =
   ( match psr_checkpoint with
   | `backup ->

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1047,7 +1047,8 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
       )
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
-    ~tls_verification_enabled ~last_software_update:Date.never ;
+    ~tls_verification_enabled ~last_software_update:Date.never
+    ~recommended_guidances:[] ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;
@@ -2999,11 +3000,15 @@ let apply_updates ~__context ~self ~hash =
   in
   Db.Host.set_last_software_update ~__context ~self
     ~value:(get_servertime ~__context ~host:self) ;
-  Repository.apply_immediate_guidances ~__context ~host:self ~guidances ;
-  (* The warnings may not be returned to async caller if this happens
-   * on the coordinator host and the 'restartToolstack' is required.
-   *)
-  warnings
+  List.map
+    (fun g ->
+      [
+        Api_errors.updates_require_recommended_guidance
+      ; Updateinfo.Guidance.to_string g
+      ]
+    )
+    guidances
+  @ warnings
 
 let cc_prep () =
   let cc = "CC_PREPARATIONS" in
@@ -3032,3 +3037,59 @@ let set_https_only ~__context ~self ~value =
   | true ->
       (* it is illegal changing the firewall/https config in CC/FIPS mode *)
       raise (Api_errors.Server_error (Api_errors.illegal_in_fips_mode, []))
+
+let try_restart_device_models_for_recommended_guidances ~__context ~host =
+  (* Restart device models of all running HVM VMs on the host by doing
+   * local migrations if it is required by recommended guidances. *)
+  Repository_helpers.do_with_device_models ~__context ~host
+  @@ fun (ref, record) ->
+  match
+    ( List.mem `restart_device_model
+        (Db.VM.get_recommended_guidances ~__context ~self:ref)
+    , record.API.vM_power_state
+    , Helpers.has_qemu_currently ~__context ~self:ref
+    )
+  with
+  | true, `Running, true ->
+      Xapi_vm_migrate.pool_migrate ~__context ~vm:ref ~host
+        ~options:[("live", "true")] ;
+      None
+  | true, `Paused, true ->
+      error "VM 'ref=%s' is paused, can't restart device models for it"
+        (Ref.string_of ref) ;
+      Some ref
+  | _ ->
+      (* No `restart_device_model as recommended guidance for this VM or no
+       * device models are running for this VM *)
+      None
+
+let apply_recommended_guidances ~__context ~self =
+  try
+    let open Updateinfo in
+    Db.Host.get_recommended_guidances ~__context ~self |> function
+    | [] ->
+        try_restart_device_models_for_recommended_guidances ~__context
+          ~host:self
+    | [`reboot_host] ->
+        reboot ~__context ~host:self
+    | [`restart_toolstack] ->
+        try_restart_device_models_for_recommended_guidances ~__context
+          ~host:self ;
+        restart_agent ~__context ~host:self
+    | l ->
+        let host' = Ref.string_of self in
+        error
+          "Found wrong guidance(s) when applying recommended guidances on host \
+           ref='%s': %s"
+          host'
+          (String.concat ";"
+             (List.map Guidance.to_string
+                (List.map Guidance.of_update_guidance l)
+             )
+          ) ;
+        raise Api_errors.(Server_error (apply_guidance_failed, [host']))
+  with e ->
+    let host' = Ref.string_of self in
+    error "applying recommended guidances on host ref='%s' failed: %s" host'
+      (ExnHelper.string_of_exn e) ;
+    raise Api_errors.(Server_error (apply_guidance_failed, [host']))

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1048,7 +1048,7 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled ~last_software_update:Date.never
-    ~recommended_guidances:[] ;
+    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;
@@ -3001,6 +3001,7 @@ let apply_updates ~__context ~self ~hash =
   in
   Db.Host.set_last_software_update ~__context ~self
     ~value:(get_servertime ~__context ~host:self) ;
+  Db.Host.set_latest_synced_updates_applied ~__context ~self ~value:`yes ;
   List.map
     (fun g ->
       [

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -546,3 +546,6 @@ val copy_primary_host_certs : __context:Context.t -> host:API.ref_host -> unit
 
 val set_https_only :
   __context:Context.t -> self:API.ref_host -> value:bool -> unit
+
+val apply_recommended_guidances :
+  __context:Context.t -> self:API.ref_host -> unit

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -374,11 +374,15 @@ let consider_enabling_host_nolock ~__context =
     let pool = Helpers.get_pool ~__context in
     Db.Host.remove_pending_guidances ~__context ~self:localhost
       ~value:`restart_toolstack ;
+    Db.Host.remove_recommended_guidances ~__context ~self:localhost
+      ~value:`restart_toolstack ;
     if !Xapi_globs.on_system_boot then (
       debug
         "Host.enabled: system has just restarted: setting localhost to enabled" ;
       Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
       Db.Host.remove_pending_guidances ~__context ~self:localhost
+        ~value:`reboot_host ;
+      Db.Host.remove_recommended_guidances ~__context ~self:localhost
         ~value:`reboot_host ;
       Db.Host.remove_pending_guidances ~__context ~self:localhost
         ~value:`reboot_host_on_livepatch_failure ;

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -17,7 +17,7 @@ module D = Debug.Make (struct let name = "backgroundscheduler" end)
 
 open D
 
-let register () =
+let register ~__context =
   debug "Registering periodic calls" ;
   let master = Pool_role.is_master () in
   (* blob/message/rrd file syncing - sync once a day *)
@@ -113,4 +113,10 @@ let register () =
         "Period alert if TLS verification emergency disabled" (fun __context ->
           Xapi_host.alert_if_tls_verification_was_emergency_disabled ~__context
       )
-  )
+  ) ;
+  if
+    master
+    && Db.Pool.get_update_sync_enabled ~__context
+         ~self:(Helpers.get_pool ~__context)
+  then
+    Pool_periodic_update_sync.set_enabled ~__context ~value:true

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1564,6 +1564,8 @@ let join_common ~__context ~master_address ~master_username ~master_password
             "Unable to set the write the new pool certificates to the disk : %s"
             (ExnHelper.string_of_exn e)
       ) ;
+      Db.Host.set_latest_synced_updates_applied ~__context ~self:me
+        ~value:`unknown ;
       (* this is where we try and sync up as much state as we can
          with the master. This is "best effort" rather than
          critical; if we fail part way through this then we carry
@@ -3349,7 +3351,6 @@ let set_repositories ~__context ~self ~value =
     (fun x ->
       if not (List.mem x existings) then (
         Db.Repository.set_hash ~__context ~self:x ~value:"" ;
-        Db.Repository.set_up_to_date ~__context ~self:x ~value:false ;
         Repository.reset_updates_in_cache ()
       )
     )
@@ -3365,7 +3366,6 @@ let add_repository ~__context ~self ~value =
   if not (List.mem value existings) then (
     Db.Pool.add_repositories ~__context ~self ~value ;
     Db.Repository.set_hash ~__context ~self:value ~value:"" ;
-    Db.Repository.set_up_to_date ~__context ~self:value ~value:false ;
     Repository.reset_updates_in_cache ()
   )
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3664,3 +3664,36 @@ let reset_telemetry_uuid ~__context ~self =
   Xapi_stdext_pervasives.Pervasiveext.ignore_exn (fun _ ->
       Db.Secret.destroy ~__context ~self:old_ref
   )
+
+let configure_update_sync ~__context ~self ~update_sync_frequency
+    ~update_sync_day =
+  let day =
+    match (update_sync_frequency, update_sync_day) with
+    | `weekly, d when d < 0L || d > 6L ->
+        error
+          "For weekly schedule, cannot set the day when update sync will run \
+           to an integer out of range: 0 ~ 6" ;
+        raise
+          Api_errors.(
+            Server_error
+              (invalid_update_sync_day, [Int64.to_string update_sync_day])
+          )
+    | `daily, d ->
+        if d <> 0L then
+          warn
+            "For 'daily' schedule, the value of update_sync_day is ignored, \
+             update_sync_day of the pool will be set to the default value 0." ;
+        0L
+    | `weekly, d ->
+        d
+  in
+  Db.Pool.set_update_sync_frequency ~__context ~self
+    ~value:update_sync_frequency ;
+  Db.Pool.set_update_sync_day ~__context ~self ~value:day ;
+  if Db.Pool.get_update_sync_enabled ~__context ~self then
+    (* re-schedule periodic update sync with new configuration immediately *)
+    Pool_periodic_update_sync.set_enabled ~__context ~value:true
+
+let set_update_sync_enabled ~__context ~self ~value =
+  Pool_periodic_update_sync.set_enabled ~__context ~value ;
+  Db.Pool.set_update_sync_enabled ~__context ~self ~value

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2031,6 +2031,7 @@ let designate_new_master ~__context ~host:_ =
     let pool = Helpers.get_pool ~__context in
     if Db.Pool.get_ha_enabled ~__context ~self:pool then
       raise (Api_errors.Server_error (Api_errors.ha_is_enabled, [])) ;
+    Db.Pool.set_last_update_sync ~__context ~self:pool ~value:Date.epoch ;
     (* Only the master can sync the *current* database; only the master
        knows the current generation count etc. *)
     Helpers.call_api_functions ~__context (fun rpc session_id ->

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3413,7 +3413,9 @@ let sync_updates ~__context ~self ~force ~token ~token_id =
              sync ~__context ~self:x ~token ~token_id ;
              create_pool_repository ~__context ~self:x
          ) ;
-      set_available_updates ~__context
+      let checksum = set_available_updates ~__context in
+      Db.Pool.set_last_update_sync ~__context ~self ~value:(Date.now ()) ;
+      checksum
   | false ->
       with_reposync_lock @@ fun () ->
       enabled |> List.iter (fun x -> sync ~__context ~self:x ~token ~token_id) ;
@@ -3421,7 +3423,9 @@ let sync_updates ~__context ~self ~force ~token ~token_id =
         ~doc:"pool.sync_updates" ~op:`sync_updates
       @@ fun () ->
       List.iter (fun x -> create_pool_repository ~__context ~self:x) enabled ;
-      set_available_updates ~__context
+      let checksum = set_available_updates ~__context in
+      Db.Pool.set_last_update_sync ~__context ~self ~value:(Date.now ()) ;
+      checksum
 
 let check_update_readiness ~__context ~self:_ ~requires_reboot =
   (* Pool license check *)

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -398,3 +398,13 @@ val set_telemetry_next_collection :
   -> unit
 
 val reset_telemetry_uuid : __context:Context.t -> self:API.ref_pool -> unit
+
+val configure_update_sync :
+     __context:Context.t
+  -> self:API.ref_pool
+  -> update_sync_frequency:API.update_sync_frequency
+  -> update_sync_day:int64
+  -> unit
+
+val set_update_sync_enabled :
+  __context:Context.t -> self:API.ref_pool -> value:bool -> unit

--- a/ocaml/xapi/xapi_psr.ml
+++ b/ocaml/xapi/xapi_psr.ml
@@ -527,18 +527,6 @@ let start =
       if is_ha_enabled then
         raise Api_errors.(Server_error (ha_is_enabled, []))
     in
-    let assert_we_are_master () =
-      if
-        not
-          (Helpers.is_pool_master ~__context
-             ~host:(Helpers.get_localhost ~__context)
-          )
-      then
-        raise
-          Api_errors.(
-            Server_error (host_is_slave, [Pool_role.get_master_address ()])
-          )
-    in
     let assert_all_hosts_alive () =
       let live_hosts = Helpers.get_live_hosts ~__context |> HostSet.of_list in
       let all_hosts_list =
@@ -564,7 +552,7 @@ let start =
           set_up_psr_pending_flag (fun () ->
               Pool_features.assert_enabled ~__context
                 ~f:Features.Pool_secret_rotation ;
-              assert_we_are_master () ;
+              Helpers.assert_we_are_master ~__context ;
               Assert.master_state_valid () ;
               let[@warning "-8"] (master :: members) =
                 assert_all_hosts_alive ()

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -675,7 +675,7 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~is_vmss_snapshot:false ~appliance ~start_delay ~shutdown_delay ~order
     ~suspend_SR ~version ~generation_id ~hardware_platform_version
     ~has_vendor_device ~requires_reboot:false ~reference_label ~domain_type
-    ~pending_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[] ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -397,7 +397,7 @@ let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~has_vendor_device:all.Db_actions.vM_has_vendor_device
     ~requires_reboot:false ~reference_label:all.Db_actions.vM_reference_label
     ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM
-    ~pending_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[] ;
   (* update the VM's parent field in case of snapshot. Note this must be done after "ref"
      	   has been created, so that its "children" field can be updated by the database layer *)
   ( match disk_op with

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -3498,7 +3498,9 @@ let set_resident_on ~__context ~self =
   !trigger_xenapi_reregister () ;
   (* Any future XenAPI updates will trigger events, but we might have missed one so: *)
   Xenopsd_metadata.update ~__context ~self ;
-  Db.VM.remove_pending_guidances ~__context ~self ~value:`restart_device_model
+  Db.VM.remove_pending_guidances ~__context ~self ~value:`restart_device_model ;
+  Db.VM.remove_recommended_guidances ~__context ~self
+    ~value:`restart_device_model
 
 let update_debug_info __context t =
   let task = Context.get_task_id __context in

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -380,6 +380,13 @@ _xe()
                 set_completions "$vdis" "$val"
                 return 0
                 ;;
+
+            update-sync-frequency) # for pool-configure-update-sync
+                IFS=$'\n,'
+                set_completions 'daily,weekly' "$value"
+                return 0
+                ;;
+
             *)
                 snd=`echo ${param} | gawk -F- '{print $NF}'`
                 fst=`echo ${param} | gawk -F- '{printf "%s", $1; for (i=2; i<NF; i++) printf "-%s", $i}'`


### PR DESCRIPTION
12 commits, each has passed the test, and the code of last commit is the same as current feature branch:
```
[gangj@xenrt1015818053 scm]$ git log -1 feature/stream-updates
commit eb7171741dca671c327ccaf3240efbb8c78c0f25 (origin/private/gangj/stream-updates.m, github/feature/stream-updates, private/gangj/stream-updates.m, feature/stream-updates.m, feature/stream-updates)
Author: gangj <62988402+gangj@users.noreply.github.com>
Date:   Tue Jul 18 04:09:04 2023 +0000

    CA-380043: VM recommended guidances is not set correctly
    
    This fixes an issue introduced in 47bfe89e:
    CA-378778: Calculate host guidance correctly
    where the "recommended_guidances" was set into "pending_guidances" by mistake.
    
    ---------
    
    Signed-off-by: Gang Ji <gang.ji@citrix.com>

------

[gangj@xenrt1015818053 scm]$ git log -1 private/gangj/CP-43916
commit cb8cd3d5c4a47b19548bba2661f8b1ac433e2e65 (HEAD -> private/gangj/CP-43916.newBase.step-cc, my_github/private/gangj/CP-43916, private/gangj/CP-43916)
Author: gangj <62988402+gangj@users.noreply.github.com>
Date:   Tue Jul 18 04:09:04 2023 +0000

    CA-380043: VM recommended guidances is not set correctly
    
    This fixes an issue introduced in fd3958a8:
    CA-378778: Calculate host guidance correctly
    where the "recommended_guidances" was set into "pending_guidances" by mistake.
    
    Signed-off-by: Gang Ji <gang.ji@citrix.com>

[gangj@xenrt1015818053 scm]$

-----

[gangj@xenrt1015818053 scm]$ git diff cb8cd3d5 eb717174
[gangj@xenrt1015818053 scm]$

```
New added XenRT cases for "CDN on-prem update" are all passed, the last commit to update `datamodel_lifecycle` and `schema_minor_vsn` added.

Below are the 12 commits:

CP-42016: Add parameter "--newest-only" to "reposync" command
Download only the latest version of each RPM when mirroring down from the hosted yum repository

CP-42014: Add last_update_sync to pool datamodel
Add a new field "last_update_sync" of type DateTime to record when the last update synchronization occurred.

CP-42013: Do not apply recommended guidances automatically
1 add a new field "recommended_guidances" in both host and vm datamodel
2 return "recommended_guidances" together with "warnings" as update applying results from host.apply_updates
3 add API host.apply_recommended_guidances
4 rename "immediate_guidances" to "recommended_guidances"

CA-376144: handle host.apply_recommended_guidances first on pool coordinator
Instead of proxying the request directly to pool member, first handler the
request on pool coordinator, only proxy "VM.pool_migrate", "Host.reboot",
"Host.restart_agent" to pool member.
This resolves issue introduced in 0ac9dd7:
CP-42013: Do not apply recommended guidances automatically

CA-375147: UPDATES_REQUIRE_SYNC when toolstack restarted on coordinator
For repository-based updates, the information of available updates on
every host is stored in a cache (in memory) in XAPI process on
coordinator. This cache aims to make the HTTP GET /updates requests
responded quickly as a fast path. One drawback of this design is that
the cache would be flushed when toolstack on coordinator restarted. As
part of original design, if this happens, an error
'UPDATES_REQUIRE_SYNC' will be raised to clients so that HTTP-based
users would get quick responses in all cases.
This commit aims to fill the cache again (but taking longer time)
automatically instead of raising error 'UPDATES_REQUIRE_SYNC' when the
cache has been flushed. This will simplify the XAPI call flow from
client's perspective.

CP-42810: Periodic update sync
1 add API pool.set_update_sync_enabled and xe CLI pool-set-update-sync-enabled to enable and disable periodic update sync.
2 implement periodic update sync with "daily" and "weekly" schedule.
3 add fist support: disable_periodic_update_sync_sec_randomness.
4 add fist support: set_periodic_update_sync_delay.
5 UT for periodic update sync delay added.

CP-40204, CA-366396: Add "host.latest_synced_updates_applied", remove "repository.up_to_date"
This commit deprecates the "repository.up_to_date" and adds "host.latest_synced_updates_applied".
In this way, the "up to date" status is tracked per host, instead of per repository.

CA-376145: Reset pool.last_update_sync on pool coordinator change

CA-378757: remove "EvacuateHost" from recommended guidance
In the update applying process, "EvacuateHost" will be applied before applying updates.

CP-43545: expose `issued` and `severity` from updateinfo
Expose the `issued` and `severity` fields from updateinfo on host http endpoint: /updates.

CA-378778: Calculate host guidance correctly
When there remains 'recommended_guidances' or 'pending_guidances' from previous update not applied for a host, the 'recommended_guidances' and 'pending_guidances' are not calculated correctly: the previous guidance should be taken into account to calculate the new 'recommended_guidances' and 'pending_guidances'.

CA-380043: VM recommended guidances is not set correctly
This fixes an issue introduced in fd3958a8:
CA-378778: Calculate host guidance correctly
where the "recommended_guidances" was set into "pending_guidances" by mistake.