### PR TITLE
ci: try to reuse dune cache as much as possible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     name: Ocaml tests
     runs-on: ubuntu-20.04
     env:
-      XAPI_VERSION: "v0.0.0-${{ github.sha }}"
+      XAPI_VERSION: "v0.0.0"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
By adding the commit hash into the configure, the dune cache is invalidated. Use the same dummy version always to try to reuse as much of the cache as possible.

For comparison on a scheduled run, it took 6m to install dependencies, 21s to build xapi, then 26s to test it.

On a PR based on it, it took 4 m to build the dependencies, 2m 30s to build xapi, then 3m 30s to test it.

Hopefully with this change the build and test times can be reduced as well.