### PR TITLE
CP-40651 Validate the login username and provide friendly error message

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -177,7 +177,7 @@ let _ =
     () ;
 
   (* Session errors *)
-  error Api_errors.session_authentication_failed []
+  error Api_errors.session_authentication_failed ["username"; "msg"]
     ~doc:
       "The credentials given by the user are incorrect, so access has been \
        denied, and you have not been issued a session handle."

--- a/ocaml/tests/test_session.ml
+++ b/ocaml/tests/test_session.ml
@@ -6,10 +6,17 @@ let future = Date.of_string "2020-09-22T15:03:13Z"
 
 let fail_login ~__context ~uname ~originator ~now () =
   try
+    let user_name = Option.get uname in
     Xapi_session._record_login_failure ~__context ~now ~uname ~originator
       ~record:`log_and_alert (fun () ->
         if Random.bool () then
-          raise Api_errors.(Server_error (session_authentication_failed, [uname, "Authentication failed"]))
+          raise
+            Api_errors.(
+              Server_error
+                ( session_authentication_failed
+                , [user_name; "Authentication failed"]
+                )
+            )
         else
           raise (Auth_signature.Auth_failure "Auth failure")
     )

--- a/ocaml/tests/test_session.ml
+++ b/ocaml/tests/test_session.ml
@@ -9,7 +9,7 @@ let fail_login ~__context ~uname ~originator ~now () =
     Xapi_session._record_login_failure ~__context ~now ~uname ~originator
       ~record:`log_and_alert (fun () ->
         if Random.bool () then
-          raise Api_errors.(Server_error (session_authentication_failed, []))
+          raise Api_errors.(Server_error (session_authentication_failed, [uname, "Authentication failed"]))
         else
           raise (Auth_signature.Auth_failure "Auth failure")
     )

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -261,7 +261,7 @@ let with_context ?(dummy = false) label (req : Request.t) (s : Unix.file_descr)
   with Http.Unauthorised _ as e ->
     let fail __context =
       TaskHelper.failed ~__context
-        (Api_errors.Server_error (Api_errors.session_authentication_failed, []))
+        (Api_errors.Server_error (Api_errors.session_authentication_failed, [uname, "Authentication required to access the resource"]))
     in
     debug
       "No authentication provided to http handler: returning 401 unauthorised" ;

--- a/ocaml/xapi/xapi_http.ml
+++ b/ocaml/xapi/xapi_http.ml
@@ -261,7 +261,11 @@ let with_context ?(dummy = false) label (req : Request.t) (s : Unix.file_descr)
   with Http.Unauthorised _ as e ->
     let fail __context =
       TaskHelper.failed ~__context
-        (Api_errors.Server_error (Api_errors.session_authentication_failed, [uname, "Authentication required to access the resource"]))
+        (Api_errors.Server_error
+           ( Api_errors.session_authentication_failed
+           , [""; "Authentication required to access the resource"]
+           )
+        )
     in
     debug
       "No authentication provided to http handler: returning 401 unauthorised" ;

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -257,6 +257,15 @@ let xapi_internal_originator = "xapi"
 
 let serialize_auth = Mutex.create ()
 
+let assert_username uname = 
+  match uname with
+  | "" ->
+      raise
+        Api_errors.(
+          Server_error
+            (session_authentication_failed, [""; "Username is required to login"])
+        )
+
 let wipe_string_contents str =
   for i = 0 to Bytes.length str - 1 do
     Bytes.set str i '\000'
@@ -766,6 +775,7 @@ let login_with_password ~__context ~uname ~pwd ~version:_ ~originator =
             ~auth_user_sid:"" ~auth_user_name:uname ~rbac_permissions
             ~db_ref:None ~client_certificate:true
       | None -> (
+          let () = assert_username uname in
           let () =
             if Pool_role.is_slave () then
               raise

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -257,14 +257,18 @@ let xapi_internal_originator = "xapi"
 
 let serialize_auth = Mutex.create ()
 
-let assert_username uname = 
+let assert_username uname =
   match uname with
   | "" ->
       raise
         Api_errors.(
           Server_error
-            (session_authentication_failed, [""; "Username is required to login"])
+            ( session_authentication_failed
+            , [""; "Username is required to login"]
+            )
         )
+  | _ ->
+      ()
 
 let wipe_string_contents str =
   for i = 0 to Bytes.length str - 1 do


### PR DESCRIPTION
Add a check for an empty username before performing local or external authentication to prevent passing an empty username to the authentication server.

Signed-off-by: Lunfan Zhang luzhan@tibco.com