### PR TITLE
Offload VM CPU Policy checks to Xen

### DIFF
--- a/ocaml/xenopsd/xc/xenctrlext.ml
+++ b/ocaml/xenopsd/xc/xenctrlext.ml
@@ -103,6 +103,12 @@ external numainfo : handle -> numainfo = "stub_xenctrlext_numainfo"
 
 external cputopoinfo : handle -> cputopo array = "stub_xenctrlext_cputopoinfo"
 
+external combine_cpu_policies : int64 array -> int64 array -> int64 array
+  = "stub_xenctrlext_combine_cpu_featuresets"
+
+external policy_is_compatible : int64 array -> int64 array -> string option
+  = "stub_xenctrlext_featuresets_are_compatible"
+
 module Xenforeignmemory = struct
   type handle
 

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -85,6 +85,12 @@ external numainfo : handle -> numainfo = "stub_xenctrlext_numainfo"
 
 external cputopoinfo : handle -> cputopo array = "stub_xenctrlext_cputopoinfo"
 
+external combine_cpu_policies : int64 array -> int64 array -> int64 array
+  = "stub_xenctrlext_combine_cpu_featuresets"
+
+external policy_is_compatible : int64 array -> int64 array -> string option
+  = "stub_xenctrlext_featuresets_are_compatible"
+
 module Xenforeignmemory : sig
   type handle
 


### PR DESCRIPTION
In order to support MSR_ARCH_CAPS, combining policlies becomes more complicated than a simple intersection.  More generally, it is more conviencient to have all levelling/compatibility logic in a single codebase to avoid needing linked changes in Xapi.

Where possible, offload the decisions into Xen.