### PR TITLE
Add `secureboot-enforce` setting in `xapi.conf`

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -998,6 +998,8 @@ let prefer_nbd_attach = ref false
 (** 1 MiB *)
 let max_observer_file_size = ref (1 lsl 20)
 
+let secureboot_enforce = ref false
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1469,6 +1471,11 @@ let other_options =
     , Arg.Set_int max_observer_file_size
     , (fun () -> string_of_int !max_observer_file_size)
     , "The maximum size of log files for saving spans"
+    )
+  ; ( "secureboot-enforce"
+    , Arg.Set secureboot_enforce
+    , (fun () -> string_of_bool !secureboot_enforce)
+    , "Do not start a VM with no SB certificates if secureboot is set to on"
     )
   ]
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -286,16 +286,23 @@ let assert_memory_constraints ~__context ~vm platformdata =
 *)
 
 let update_platform_secureboot ~__context ~self platform =
-  match List.assoc "secureboot" platform with
-  | exception Not_found ->
-      platform
-  | "auto" ->
-      ( "secureboot"
-      , string_of_bool (Db.Pool.get_uefi_certificates ~__context ~self <> "")
-      )
-      :: List.remove_assoc "secureboot" platform
-  | _ ->
-      platform
+  let platform =
+    match List.assoc "secureboot" platform with
+    | exception Not_found ->
+        platform
+    | "auto" ->
+        ( "secureboot"
+        , string_of_bool (Db.Pool.get_uefi_certificates ~__context ~self <> "")
+        )
+        :: List.remove_assoc "secureboot" platform
+    | _ ->
+        platform
+  in
+  if !Xapi_globs.secureboot_enforce then
+    ("secureboot-enforce", "true")
+    :: List.remove_assoc "secureboot-enforce" platform
+  else
+    platform
 
 let start ~__context ~vm ~start_paused ~force =
   let vmr = Db.VM.get_record ~__context ~self:vm in


### PR DESCRIPTION
This setting will be used by varstored to know
wheter to allow the start of a VM that has no certificates when secureboot is enabled.

Default: false to keep the previous behavior.

See: https://github.com/xapi-project/varstored/pull/19