### PR TITLE
CA-380551: bump minimum HA SR size to 4GiB

### DIFF
--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -49,7 +49,7 @@ let mib megabytes =
   Int64.of_int megabytes ** 1024L ** 1024L
 
 (* Make sure we have plenty of room for the database *)
-let minimum_vdi_size, recommended_vdi_size = (mib 256, mib 4096)
+let minimum_vdi_size = mib 4096
 
 let redo_log_sm_config = [("type", "raw")]
 

--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -48,8 +48,17 @@ let mib megabytes =
   let ( ** ) = Int64.mul in
   Int64.of_int megabytes ** 1024L ** 1024L
 
-(* Make sure we have plenty of room for the database *)
-let minimum_vdi_size = mib 4096
+(* Make sure we have plenty of room for the database
+   There is also a 4MiB statefile, so make the sum be 4GB, which is easier to document.
+*)
+let minimum_vdi_size =
+  let ( // ) = Int64.div and ( ** ) = Int64.mul and ( -- ) = Int64.sub in
+  let align = mib 4 in
+  ((4_000_000_000L // align)
+  -- 2L
+     (* -2 because we also need room for a statefile, and an 'empty' SR seems to have a utilization of 4MiB *)
+  )
+  ** align
 
 let redo_log_sm_config = [("type", "raw")]
 

--- a/ocaml/database/redo_log.mli
+++ b/ocaml/database/redo_log.mli
@@ -21,9 +21,6 @@ val get_static_device : string -> string option
 val minimum_vdi_size : int64
 (** Minimum size for redo log VDI *)
 
-val recommended_vdi_size : int64
-(** Recommended size for redo log VDI *)
-
 val redo_log_sm_config : (string * string) list
 (** SM config for redo log VDI *)
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2859,7 +2859,7 @@ let create_redo_log_vdi ~__context ~sr =
       Client.VDI.create ~rpc ~session_id ~name_label:"Metadata redo-log"
         ~name_description:
           "Used when HA is disabled, while extra security is still desired"
-        ~sR:sr ~virtual_size:Redo_log.recommended_vdi_size ~_type:`redo_log
+        ~sR:sr ~virtual_size:Redo_log.minimum_vdi_size ~_type:`redo_log
         ~sharable:true ~read_only:false ~other_config:[] ~xenstore_data:[]
         ~sm_config:Redo_log.redo_log_sm_config ~tags:[]
   )

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -946,7 +946,7 @@ let find_or_create_metadata_vdi ~__context ~sr =
         Helpers.call_api_functions ~__context (fun rpc session_id ->
             Client.VDI.create ~rpc ~session_id ~name_label:"Metadata for DR"
               ~name_description:"Used for disaster recovery" ~sR:sr
-              ~virtual_size:Redo_log.recommended_vdi_size ~_type:`metadata
+              ~virtual_size:Redo_log.minimum_vdi_size ~_type:`metadata
               ~sharable:false ~read_only:false ~other_config:[]
               ~xenstore_data:[] ~sm_config:Redo_log.redo_log_sm_config ~tags:[]
         )

--- a/ocaml/xapi/xha_metadata_vdi.ml
+++ b/ocaml/xapi/xha_metadata_vdi.ml
@@ -24,8 +24,8 @@ let create ~__context ~sr =
   Helpers.call_api_functions ~__context (fun rpc session_id ->
       Client.VDI.create ~rpc ~session_id ~name_label:"Metadata for HA"
         ~name_description:"Used for master failover" ~sR:sr
-        ~virtual_size:Redo_log.recommended_vdi_size ~_type:`redo_log
-        ~sharable:true ~read_only:false ~other_config:[] ~xenstore_data:[]
+        ~virtual_size:Redo_log.minimum_vdi_size ~_type:`redo_log ~sharable:true
+        ~read_only:false ~other_config:[] ~xenstore_data:[]
         ~sm_config:Redo_log.redo_log_sm_config ~tags:[]
   )
 

--- a/ocaml/xapi/xha_statefile.ml
+++ b/ocaml/xapi/xha_statefile.ml
@@ -29,34 +29,42 @@ open Client
 
 (** Return the minimum size of an HA statefile, as of
     XenServer HA state-file description vsn 1.3 *)
-let minimum_size =
+let minimum_statefile_size =
   let ( ** ) = Int64.mul and ( ++ ) = Int64.add in
   let global_section_size = 4096L
   and host_section_size = 4096L
   and maximum_number_of_hosts = 64L in
   global_section_size ++ (maximum_number_of_hosts ** host_section_size)
 
-let ha_fits_sr ~__context ~sr ~typ ~minimum_size =
+let round_to ~align n = Int64.(div (add n @@ sub align 1L) align |> mul align)
+
+(* SM doesn't actually allow us to create VDIs smaller than 4MiB, so we need to round up *)
+let minimum_sr_size =
+  [minimum_statefile_size; Redo_log.minimum_vdi_size]
+  |> List.map @@ round_to ~align:Int64.(shift_left 1L 22)
+  |> List.fold_left Int64.add Int64.zero
+
+let ha_fits_sr ~__context ~what ~sr ~typ ~minimum_size =
   let ha_fits self =
     Db.VDI.get_type ~__context ~self = typ
     && Db.VDI.get_virtual_size ~__context ~self >= minimum_size
   in
   match List.filter ha_fits (Db.SR.get_VDIs ~__context ~self:sr) with
   | x :: _ ->
-      debug "Would re-use existing statefile: %s"
+      debug "Would re-use existing %s: %s" what
         (Db.VDI.get_uuid ~__context ~self:x) ;
       Some x
   | [] ->
-      debug
-        "no suitable existing statefile found; would have to create a fresh one" ;
+      debug "no suitable existing %s found; would have to create a fresh one"
+        what ;
       let self = sr in
       let size = Db.SR.get_physical_size ~__context ~self in
       let utilisation = Db.SR.get_physical_utilisation ~__context ~self in
       let free_space = Int64.sub size utilisation in
-      if free_space < minimum_size then (
+      if free_space < minimum_sr_size then (
         let sr = Ref.string_of sr in
         info "%s: SR %s size=%Ld utilisation=%Ld free=%Ld needed=%Ld"
-          __FUNCTION__ sr size utilisation free_space minimum_size ;
+          __FUNCTION__ sr size utilisation free_space minimum_sr_size ;
         raise
           (Api_errors.Server_error
              (Api_errors.sr_source_space_insufficient, [sr])
@@ -126,11 +134,16 @@ let check_sr_can_host_statefile ~__context ~sr ~cluster_stack =
           (Api_errors.Server_error
              (Api_errors.sr_operation_not_supported, [Ref.string_of sr])
           ) ;
-      ha_fits_sr ~__context ~sr ~minimum_size ~typ:`ha_statefile
+      ha_fits_sr ~__context ~what:"statefile" ~sr
+        ~minimum_size:minimum_statefile_size ~typ:`ha_statefile
 
 let assert_sr_can_host_statefile ~__context ~sr ~cluster_stack =
   let (_ : 'a option) =
     check_sr_can_host_statefile ~__context ~sr ~cluster_stack
+  in
+  let (_ : _ option) =
+    ha_fits_sr ~__context ~what:"redo-log" ~sr
+      ~minimum_size:Redo_log.minimum_vdi_size ~typ:`redo_log
   in
   ()
 
@@ -146,7 +159,7 @@ let list_srs_which_can_host_statefile ~__context ~cluster_stack =
 
 let create ~__context ~sr ~cluster_stack =
   assert_sr_can_host_statefile ~__context ~sr ~cluster_stack ;
-  let size = minimum_size in
+  let size = minimum_statefile_size in
   Helpers.call_api_functions ~__context (fun rpc session_id ->
       Client.VDI.create ~rpc ~session_id ~name_label:"Statefile for HA"
         ~name_description:"Used for storage heartbeating" ~sR:sr


### PR DESCRIPTION
Commit 00cb7f2fa changed the default (recommended) size of the redo log to 4GiB, while keeping the minimum at 256MiB for backwards compatibility with existing VDIs.

However:
* HA must be disabled/re-enabled across updates anyway so backwards compatibility is not needed
* the redo-log on its own is known not to work (bug), keeping backwards compatibility here is not useful
* it makes it more difficult for XenCenter to tell the user when they chose an SR that is too small

If the SR is greater than minimum but below recommended then from the CLI you could still enable HA and create a redo log of the appropriate size, but not from XenCenter (where the size cannot be chosen).

We could expose a new RO pool field with the minimum size and update clients to use that, but that is unnecessary complication for a very rare use case.

Revert the 'recommended_size' introduction, and instead bump the minimum size. The existing 'SR.assert_can_host_statefile' can then report an error when the size is wrong and XenCenter can appropriately grey out the choice for the user with the correct message. (And this method works also for other reasons why we might reject an SR).

Fixes: 00cb7f2fa ("redo-log: bump default size to 4GiB")