### PR TITLE
ci: work around outdated ubuntu repositories on all workflows

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -55,6 +55,9 @@ jobs:
           # invalidate cache every week, gets built using a scheduled job
           key: ${{ steps.cache-key.outputs.date }}-1.249
 
+      - name: Update Ubuntu repositories
+        run: sudo apt-get update
+
       - name: Use ocaml
         uses: avsm/setup-ocaml@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   ocaml:
     name: Docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       XAPI_VERSION: "v0.0.0-${{ github.sha }}"
       STORAGE_DOCDIR: .gh-pages-xapi-storage
@@ -23,6 +23,9 @@ jobs:
       - name: Load environment file
         id: dotenv
         uses: falti/dotenv-action@v1
+
+      - name: Update Ubuntu repositories
+        run: sudo apt-get update
 
       - name: Use ocaml
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ocaml-format:
     name: Ocaml files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -22,7 +22,10 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v1.0.2
+        uses: falti/dotenv-action@v1.0.4
+
+      - name: Update Ubuntu repositories
+        run: sudo apt-get update
 
       - name: Use ocaml
         uses: ocaml/setup-ocaml@v2
@@ -31,11 +34,10 @@ jobs:
           opam-repositories: |
             xs-opam: ${{ steps.dotenv.outputs.repository }}
           dune-cache: true
+          opam-pin: false
 
       - name: Install ocamlformat
-        run: |
-          opam update
-          opam install ocamlformat
+        run: opam install ocamlformat
 
       - name: Check whether `make format` was run
         run: opam exec -- dune build @fmt


### PR DESCRIPTION
The documentation push failed because the ubuntu repos are not up-to-date in the ubuntu image used in the CI, work around this on all the remaining workflows.

Also update base image and actions, use the latest available. There's no need to pin any packages when checking the format, so skip that step