### PR TITLE
Leave the API version for Yangtze/hotfixes as 2.15

### DIFF
--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -279,7 +279,7 @@ let release_order_full = [{
    }; {
      code_name     = Some rel_yangtze_https;
      version_major = 2;
-     version_minor = 16;
+     version_minor = 15;
      branding      = "Citrix Hypervisor 8.2 CU1 Hotfix";
      release_date  = None;
    }


### PR DESCRIPTION
The API version of the 8.2/Stockholm release was 2.15. Any updates to it should keep the same API version, to avoid compatibility problems with clients.