### PR TITLE
CA-380581: Remove lock on downloading updates from remote repos

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1890,8 +1890,6 @@ let _ =
   error Api_errors.repository_already_exists ["ref"]
     ~doc:"The repository already exists." () ;
   error Api_errors.repository_is_in_use [] ~doc:"The repository is in use." () ;
-  error Api_errors.reposync_in_progress []
-    ~doc:"The pool is syncing with the enabled remote YUM repository." () ;
   error Api_errors.repository_cleanup_failed []
     ~doc:"Failed to clean up local repository on coordinator." () ;
   error Api_errors.no_repository_enabled []

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1237,8 +1237,6 @@ let repository_already_exists = "REPOSITORY_ALREADY_EXISTS"
 
 let repository_is_in_use = "REPOSITORY_IS_IN_USE"
 
-let reposync_in_progress = "REPOSYNC_IN_PROGRESS"
-
 let repository_cleanup_failed = "REPOSITORY_CLEANUP_FAILED"
 
 let no_repository_enabled = "NO_REPOSITORY_ENABLED"

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -29,8 +29,6 @@ val cleanup_all_pool_repositories : unit -> unit
 val cleanup_pool_repo :
   __context:Context.t -> self:[`Repository] API.Ref.t -> unit
 
-val with_reposync_lock : (unit -> 'a) -> 'a
-
 val sync :
      __context:Context.t
   -> self:[`Repository] API.Ref.t


### PR DESCRIPTION
The 'reposync_mutex' was designed for cases in which a pool is downloading updates from remote repos, but another XAPI call is being carried on to apply updates simultaneously. The assumption of this design is that the downloading may take long time. During this period, it would be nice to allow other operations, e.g get_updates, or apply_updates, etc.

The issue to be fixed in this commit is that the locked status of 'reposync_mutex' can't be populated to clients since the status of the lock is not recorded in XAPI DB.

Additionally, with 80c8153860, only the minimum set of update packages will be downloaded. The assumption above now doesn't hold anymore in most cases.

The 'pool.allowed_operations' now can take the chance to replace 'reposync_mutex' to protect consistency among repo updates related operations. As a result, this will populate the locked status to clients since it is recorded in XAPI DB.

Note: a data change in XAPI DB can be sent/retrieved to/by clients through API calls.