### PR TITLE
CP-43977: Fallback un-recognized guidance as RebootHost

### DIFF
--- a/ocaml/tests/test_updateinfo.ml
+++ b/ocaml/tests/test_updateinfo.ml
@@ -786,6 +786,84 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
               )
             ]
         )
+      ; (* Single update with new guidances *)
+        ( {|
+            <updates>
+              <update type="security">
+                <id>UPDATE-0000</id>
+                <title>title</title>
+                <summary>summary</summary>
+                <description>description</description>
+                <special_info>special information</special_info>
+                <url>https://update.details.info</url>
+                <recommended_guidance>NewGuidance</recommended_guidance>
+                <absolute_guidance>NewGuidance</absolute_guidance>
+                <guidance_applicabilities>
+                  <applicability>
+                    <name>xsconsole</name>
+                    <inequality>gte</inequality>
+                    <epoch>None</epoch>
+                    <version>10.1.0</version>
+                    <release>25</release>
+                    <arch>x86_64</arch>
+                  </applicability>
+                  <applicability>
+                    <name>xsconsole</name>
+                    <inequality>lt</inequality>
+                    <epoch>None</epoch>
+                    <version>10.1.0</version>
+                    <release>25</release>
+                    <arch>x86_64</arch>
+                  </applicability>
+                </guidance_applicabilities>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
+              </update>
+            </updates>
+          |}
+        , Ok
+            [
+              ( "UPDATE-0000"
+              , UpdateInfo.
+                  {
+                    id= "UPDATE-0000"
+                  ; summary= "summary"
+                  ; description= "description"
+                  ; rec_guidance= Some Guidance.RebootHost
+                  ; abs_guidance= Some Guidance.RebootHost
+                  ; guidance_applicabilities=
+                      [
+                        Applicability.
+                          {
+                            name= "xsconsole"
+                          ; arch= "x86_64"
+                          ; inequality= Some Gte
+                          ; epoch= None
+                          ; version= "10.1.0"
+                          ; release= "25"
+                          }
+                      ; Applicability.
+                          {
+                            name= "xsconsole"
+                          ; arch= "x86_64"
+                          ; inequality= Some Lt
+                          ; epoch= None
+                          ; version= "10.1.0"
+                          ; release= "25"
+                          }
+                      ]
+                  ; spec_info= "special information"
+                  ; url= "https://update.details.info"
+                  ; update_type= "security"
+                  ; livepatch_guidance= None
+                  ; livepatches= []
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= Severity.High
+                  }
+              )
+            ]
+        )
       ; (* Single update with livepatches and livepatch_guidance *)
         ( {|
             <updates>
@@ -822,6 +900,72 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; url= "https://update.details.info"
                   ; update_type= "security"
                   ; livepatch_guidance= Some Guidance.RestartToolstack
+                  ; livepatches=
+                      [
+                        LivePatch.
+                          {
+                            component= Kernel
+                          ; base_build_id=
+                              "8346194f2e98a228f5a595b13ecabd43a99fada0"
+                          ; base_version= "4.19.19"
+                          ; base_release= "8.0.19.xs8"
+                          ; to_version= "4.19.19"
+                          ; to_release= "8.0.21.xs8"
+                          }
+                      ; LivePatch.
+                          {
+                            component= Kernel
+                          ; base_build_id=
+                              "9346194f2e98a228f5a595b13ecabd43a99fada0"
+                          ; base_version= "4.19.19"
+                          ; base_release= "8.0.20.xs8"
+                          ; to_version= "4.19.19"
+                          ; to_release= "8.0.21.xs8"
+                          }
+                      ]
+                  ; issued=
+                      Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
+                  ; severity= Severity.High
+                  }
+              )
+            ]
+        )
+      ; (* Single update with livepatches and new livepatch_guidance *)
+        ( {|
+            <updates>
+              <update type="security">
+                <id>UPDATE-0000</id>
+                <title>title</title>
+                <summary>summary</summary>
+                <description>description</description>
+                <special_info>special information</special_info>
+                <url>https://update.details.info</url>
+                <guidance_applicabilities/>
+                <livepatch_guidance>NewGuidance</livepatch_guidance>
+                <livepatches>
+                  <livepatch component="kernel" base="4.19.19-8.0.19.xs8" to="4.19.19-8.0.21.xs8" base-buildid="8346194f2e98a228f5a595b13ecabd43a99fada0"/>
+                  <livepatch component="kernel" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
+                </livepatches>
+                <issued date="2023-05-12 08:37:49"/>
+                <severity>High</severity>
+              </update>
+            </updates>
+          |}
+        , Ok
+            [
+              ( "UPDATE-0000"
+              , UpdateInfo.
+                  {
+                    id= "UPDATE-0000"
+                  ; summary= "summary"
+                  ; description= "description"
+                  ; rec_guidance= None
+                  ; abs_guidance= None
+                  ; guidance_applicabilities= []
+                  ; spec_info= "special information"
+                  ; url= "https://update.details.info"
+                  ; update_type= "security"
+                  ; livepatch_guidance= Some Guidance.RebootHost
                   ; livepatches=
                       [
                         LivePatch.


### PR DESCRIPTION
In this way, future new added guidance can be covered by the max
guidance: RebootHost.