### PR TITLE
Add `vdi_update` filter to some tests

### DIFF
--- a/ocaml/quicktest/quicktest_cbt.ml
+++ b/ocaml/quicktest/quicktest_cbt.ml
@@ -157,6 +157,7 @@ let tests () =
                 ; `vdi_data_destroy
                 ; `vdi_snapshot
                 ]
+           |> has_capabilities [Sr_capabilities.vdi_update]
          )
   ; [("vdi_clone_copy_test", `Slow, vdi_clone_copy_test)]
     |> conn
@@ -165,6 +166,7 @@ let tests () =
            all
            |> allowed_operations
                 [`vdi_create; `vdi_destroy; `vdi_enable_cbt; `vdi_clone]
+           |> has_capabilities [Sr_capabilities.vdi_update]
          )
   ]
   |> List.concat

--- a/ocaml/quicktest/quicktest_vdi.ml
+++ b/ocaml/quicktest/quicktest_vdi.ml
@@ -417,7 +417,8 @@ let tests () =
          )
   ; [("test_vdi_snapshot", `Slow, test_vdi_snapshot)]
     |> conn
-    |> sr SR.(all |> has_capabilities [Sr_capabilities.vdi_snapshot])
+    |> sr
+         SR.(all |> has_capabilities Sr_capabilities.[vdi_snapshot; vdi_update])
   ; [("test_vdi_clone", `Slow, test_vdi_clone)]
     |> conn
     |> sr
@@ -428,7 +429,8 @@ let tests () =
          )
   ; [("vdi_snapshot_in_pool", `Slow, vdi_snapshot_in_pool)]
     |> conn
-    |> sr SR.(all |> has_capabilities [Sr_capabilities.vdi_snapshot])
+    |> sr
+         SR.(all |> has_capabilities Sr_capabilities.[vdi_snapshot; vdi_update])
   ; [
       ( "vdi_create_destroy_plug_checksize"
       , `Slow


### PR DESCRIPTION
These tests call at some point `VDI.update` so
the VDIs not supporting it should be filtered out.