### PR TITLE
CA-379472 log more block_device_io messages to info

### DIFF
--- a/ocaml/database/db_globs.ml
+++ b/ocaml/database/db_globs.ml
@@ -35,7 +35,7 @@ let redo_log_max_dying_processes = 2
 let redo_log_comms_socket_stem = "sock-blkdev-io"
 
 (** The maximum time, in seconds, for which we are prepared to wait for a response from the block device I/O process before assuming that it has died while initially connecting to it *)
-let redo_log_max_startup_time = ref 5.
+let redo_log_max_startup_time = ref 10.
 
 (** The length, in bytes, of one redo log which constitutes half of the VDI *)
 let redo_log_length_of_half = 60 * 1024 * 1024

--- a/ocaml/xapi/xha_statefile.ml
+++ b/ocaml/xapi/xha_statefile.ml
@@ -112,17 +112,17 @@ let check_sr_can_host_statefile ~__context ~sr ~cluster_stack =
           debug
             "no suitable existing statefile found; would have to create a \
              fresh one" ;
-          let free_space =
-            Int64.sub
-              (Db.SR.get_physical_size ~__context ~self:sr)
-              (Db.SR.get_physical_utilisation ~__context ~self:sr)
-          in
+          let self = sr in
+          let size = Db.SR.get_physical_size ~__context ~self in
+          let utilisation = Db.SR.get_physical_utilisation ~__context ~self in
+          let free_space = Int64.sub size utilisation in
           if free_space < minimum_size then (
-            info "SR %s has %Ld free space, needed %Ld" (Ref.string_of sr)
-              free_space minimum_size ;
+            let sr = Ref.string_of sr in
+            info "%s: SR %s size=%Ld utilisation=%Ld free=%Ld needed=%Ld"
+              __FUNCTION__ sr size utilisation free_space minimum_size ;
             raise
               (Api_errors.Server_error
-                 (Api_errors.sr_source_space_insufficient, [Ref.string_of sr])
+                 (Api_errors.sr_source_space_insufficient, [sr])
               )
           ) else
             None


### PR DESCRIPTION
The debug log level is disabled by default. Since we are strugglign to understand why this process is slow to startup or other reasons why xapi fails to connect to its socket, let's elevate more logging to the info level. We want to avoid logging the regular case where data is transferred but are interested in the setup and teardown case.