### PR TITLE
maintenance: prepare code for newer versions of libraries

### DIFF
--- a/ocaml/quicktest/quicktest_vdi_copy.ml
+++ b/ocaml/quicktest/quicktest_vdi_copy.ml
@@ -61,8 +61,11 @@ let read_from_vdi ~session_id ~vdi f =
    using sleep instead of the event system. *)
 let wait_for_no_vbds_then_destroy ~rpc ~session_id self =
   let wait_for_no_vbds () =
-    let start = Mtime_clock.counter () in
-    let over () = Mtime_clock.count start |> Mtime.Span.to_s > 4.0 in
+    let from_start = Mtime_clock.counter () in
+    let over () =
+      let elapsed = Mtime_clock.(count from_start) in
+      Mtime.Span.(compare elapsed (4 * s) > 0)
+    in
     while (not (over ())) && Client.VDI.get_VBDs ~rpc ~session_id ~self <> [] do
       Unix.sleepf 0.1
     done

--- a/ocaml/tests/test_vdi_cbt.ml
+++ b/ocaml/tests/test_vdi_cbt.ml
@@ -566,7 +566,7 @@ let test_data_destroy =
       let destroy_vbd () = Db.VBD.destroy ~__context ~self:vbd in
       let data_destroy ~timeout =
         (* It could return earlier normally, but this is the longest we'd wait in case of extreme situation *)
-        let timebox_timeout = timeout +. (1.0 *. 10.) in
+        let timebox_timeout = Float.of_int (timeout + 10) in
         let wait_hdl = Delay.make () in
         let raisedexn = ref None in
         ignore
@@ -600,7 +600,7 @@ let test_data_destroy =
             destroy_vbd ()
         )
       in
-      data_destroy ~timeout:1.0 ; Thread.join t
+      data_destroy ~timeout:1 ; Thread.join t
     in
     let test_data_destroy_succeeds_when_vbd_is_being_unplugged () =
       let _vdi, start_vbd_unplug, finish_vbd_unplug, destroy_vbd, data_destroy =
@@ -615,7 +615,7 @@ let test_data_destroy =
             destroy_vbd ()
         )
       in
-      Thread.delay 0.1 ; data_destroy ~timeout:1.0 ; Thread.join t
+      Thread.delay 0.1 ; data_destroy ~timeout:1 ; Thread.join t
     in
     let test_data_destroy_succeeds_when_vbd_is_being_destroyed () =
       let _vdi, start_vbd_unplug, finish_vbd_unplug, destroy_vbd, data_destroy =
@@ -629,7 +629,7 @@ let test_data_destroy =
             destroy_vbd ()
         )
       in
-      Thread.delay 0.1 ; data_destroy ~timeout:1.0 ; Thread.join t
+      Thread.delay 0.1 ; data_destroy ~timeout:1 ; Thread.join t
     in
     let test_data_destroy_times_out_when_vbd_does_not_get_unplugged_in_time () =
       let vDI, start_vbd_unplug, _, _, data_destroy = setup_test () in
@@ -643,7 +643,7 @@ let test_data_destroy =
         Api_errors.(
           Server_error (vdi_in_use, [Ref.string_of vDI; "data_destroy"])
         )
-        (fun () -> data_destroy ~timeout:1.0) ;
+        (fun () -> data_destroy ~timeout:1) ;
       Thread.join t
     in
     let test_data_destroy_times_out_when_vbd_does_not_get_destroyed_in_time () =
@@ -662,7 +662,7 @@ let test_data_destroy =
         Api_errors.(
           Server_error (vdi_in_use, [Ref.string_of vDI; "data_destroy"])
         )
-        (fun () -> data_destroy ~timeout:1.0) ;
+        (fun () -> data_destroy ~timeout:1) ;
       Thread.join t
     in
     [

--- a/ocaml/xapi-idl/lib/scheduler.ml
+++ b/ocaml/xapi-idl/lib/scheduler.ml
@@ -80,7 +80,10 @@ type time = Delta of int
 
 (*type t = int64 * int [@@deriving rpc]*)
 
-let time_of_span span = span |> Mtime.Span.to_s |> ceil |> Int64.of_float
+let span_to_s span =
+  Mtime.Span.to_uint64_ns span |> Int64.to_float |> fun ns -> ns /. 1e9
+
+let time_of_span span = span_to_s span |> ceil |> Int64.of_float
 
 let mtime_sub time now = Mtime.Span.abs_diff time now |> time_of_span
 
@@ -160,7 +163,7 @@ let rec main_loop s =
     if Mtime.Span.compare sleep_until this > 0 then
       (* be careful that this is absolute difference,
          it is never negative! *)
-      Mtime.Span.(abs_diff sleep_until this |> to_s)
+      Mtime.Span.abs_diff sleep_until this |> span_to_s
     else
       0.
   in

--- a/ocaml/xapi-idl/lib/scheduler.mli
+++ b/ocaml/xapi-idl/lib/scheduler.mli
@@ -62,3 +62,9 @@ module PipeDelay : sig
   val signal : t -> unit
   (** Signal anyone currently waiting with the PipeDelay.t *)
 end
+
+val span_to_s : Mtime.Span.t -> float
+(** [span_to_s span] converts a time span into seconds, represented by a float.
+    When the span is longer than ~54 years it becomes unprecise, avoid whenever
+    possible, this is unavoidable when using Thread.wait functions and related.
+    *)

--- a/ocaml/xapi/xapi_periodic_scheduler.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler.ml
@@ -85,7 +85,7 @@ let loop () =
           let sleep =
             Mtime.(span next.Ipq.time now)
             |> Mtime.Span.add (Clock.span 0.001)
-            |> Mtime.Span.to_s
+            |> Scheduler.span_to_s
           in
           try ignore (Delay.wait delay sleep)
           with e ->

--- a/ocaml/xapi/xapi_udhcpd.ml
+++ b/ocaml/xapi/xapi_udhcpd.ml
@@ -203,9 +203,11 @@ let restart_nolock () =
       ["udhcpd"; !Xapi_globs.udhcpd_conf]
   in
   let start = Mtime_clock.counter () in
+  let timeout = Mtime.Span.(30 * s) in
   let rec wait_for_pid n =
-    let now = Mtime_clock.count start in
-    if Mtime.Span.to_s now > 30.0 then failwith "Failed to start udhcpd" ;
+    let elapsed = Mtime_clock.count start in
+    if Mtime.Span.compare elapsed timeout > 0 then
+      failwith "Failed to start udhcpd" ;
     let pid =
       try Unixext.pidfile_read !Xapi_globs.udhcpd_pidfile with _ -> None
     in

--- a/ocaml/xapi/xapi_vdi.mli
+++ b/ocaml/xapi/xapi_vdi.mli
@@ -157,7 +157,7 @@ val destroy : __context:Context.t -> self:[`VDI] API.Ref.t -> unit
 val data_destroy : __context:Context.t -> self:[`VDI] API.Ref.t -> unit
 
 val _data_destroy :
-  __context:Context.t -> self:[`VDI] API.Ref.t -> timeout:float -> unit
+  __context:Context.t -> self:[`VDI] API.Ref.t -> timeout:int -> unit
 (** This version of {!data_destroy} is for unit testing purposes: the timeout
     for waiting for the VDI's VBDs to disappear is configurable to enable faster
     unit tests. *)

--- a/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
@@ -413,7 +413,8 @@ let exec_tap_ctl () =
            Some "performing map initialization"
        | Some c ->
            let span_since_last_update = Mtime_clock.count c in
-           if Mtime.Span.to_min span_since_last_update > 5. then
+           let five_minutes = Mtime.Span.(5 * min) in
+           if Mtime.Span.compare span_since_last_update five_minutes > 0 then
              Some "map was last updated over 5 minutes ago"
            else
              None

--- a/ocaml/xen-api-client/lib_test/dune
+++ b/ocaml/xen-api-client/lib_test/dune
@@ -1,6 +1,6 @@
-(executable
-  (modes exe)
+(test
   (name xen_api_test)
+  (package xen-api-client)
   (libraries
     dune-build-info
     rpclib.xml
@@ -11,13 +11,3 @@
     xen-api-client
   )
 )
-
-(rule
-  (alias runtest)
-  (deps
-    (:x xen_api_test.exe)
-  )
-  (package xen-api-client)
-  (action (run %{x}))
-)
-

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -37,7 +37,7 @@ let vgpu_ready_timeout = ref 30.
 
 let varstored_ready_timeout = ref 30.
 
-let swtpm_ready_timeout = ref 60.
+let swtpm_ready_timeout = ref 60
 
 let use_upstream_qemu = ref false
 

--- a/ocaml/xxhash/stubs/dune
+++ b/ocaml/xxhash/stubs/dune
@@ -12,6 +12,7 @@
   (name xxhash_bindings)
   (libraries
     ctypes
+    ctypes.stubs
     integers
   )
   (modules xxhash_bindings)

--- a/rrd-transport.opam
+++ b/rrd-transport.opam
@@ -17,7 +17,7 @@ depends: [
   "yojson"
   "xapi-idl" {>= "1.0.0"}
   "xapi-rrd" {>= "1.0.0"}
-  "ounit" {with-test}
+  "ounit2" {with-test}
 ]
 synopsis: "Shared-memory protocols for exposing performance counters"
 description: """

--- a/wsproxy.opam
+++ b/wsproxy.opam
@@ -19,7 +19,7 @@ depends: [
   "lwt" {>= "3.0.0"}
   "re"
   "uuid"
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "qcheck" {with-test}
 ]
 tags: [ "org:xapi-project" ]

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -18,7 +18,6 @@ depends: [
   "inotify"
   "io-page"
   "mtime"
-  "ounit" {with-test}
   "ppx_deriving_rpc"
   "rpclib"
   "systemd"

--- a/xapi-storage.opam
+++ b/xapi-storage.opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml"
   "dune"
   "conf-python-3"
-  "ounit" {with-test}
   "alcotest" {with-test}
   "lwt" {with-test}
   "rpclib" {with-test}

--- a/xapi-xenopsd-xc.opam
+++ b/xapi-xenopsd-xc.opam
@@ -13,7 +13,6 @@ build: [
 depends: [
   "ocaml"
   "dune"
-  "ounit2" {with-test}
   "astring"
   "base-threads"
   "base-unix"

--- a/xen-api-client-async.opam
+++ b/xen-api-client-async.opam
@@ -24,7 +24,6 @@ depends: [
   "uri"
   "xen-api-client"
   "xmlm"
-  "ounit" {with-test}
 ]
 synopsis:
   "Xen-API client library for remotely-controlling a xapi host"

--- a/xen-api-client-lwt.opam
+++ b/xen-api-client-lwt.opam
@@ -25,7 +25,6 @@ depends: [
   "uri"
   "xen-api-client"
   "xmlm"
-  "ounit" {with-test}
 ]
 synopsis:
   "Xen-API client library for remotely-controlling a xapi host"

--- a/xen-api-client.opam
+++ b/xen-api-client.opam
@@ -25,7 +25,7 @@ depends: [
   "xapi-client"
   "xapi-types"
   "xmlm"
-  "ounit" {with-test}
+  "ounit2" {with-test}
 ]
 synopsis:
   "Xen-API client library for remotely-controlling a xapi host"


### PR DESCRIPTION
In particular:
- add dependency to ctypes.stubs to use its new dune-compiled version
- replace ounit with ounit2
- remove usages of Mtime.Span.to_s: avoid conversion to float if possible by comparing timespans, or use manual conversion to seconds in floats, taking care to remove as little precision as possible (floats become imprecise for periods longer than 54 years). The latter is needed when there are interfaces using the float seconds, which are difficult to change because they are outside our control, or they introduce backwards-compatibility headaches.

I've been working on a bigger code change for adopting monotonic timers across the board, but I'd like to get some functions upstreamed to Mtime before that to make the comparisons easier to understand.