### PR TITLE
CA-379112 make PBD.plug wait for scan results 

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -5778,7 +5778,7 @@ functor
                 Xapi_sr.maybe_push_sr_rrds ~__context ~sr ;
                 Xapi_sr.update ~__context ~sr
               in
-              Xapi_sr.scan_one ~__context ~callback:sr_scan_callback sr
+              sr_scan_callback ()
           )
 
       let unplug ~__context ~self =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -5760,8 +5760,10 @@ functor
         ) ;
         (* We always plug the master PBD first and unplug it last. If this is the
          * first PBD plugged for this SR (proxy: the PBD being plugged is for the
-         * master) then we should perform an initial SR scan and perform some
-         * asynchronous start-of-day operations in the callback.
+         * master) then we should perform an initial SR scan. CA-379112
+         * changed the scan from asynchronous to synchronous as
+         * otherwise on return the xapi DB does not have the correct
+         * information.
          * Note the current context contains a completed real task and we should
          * not reuse it for what is effectively another call. *)
         if is_master_pbd then

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -591,7 +591,11 @@ let update ~__context ~sr =
       Db.SR.set_physical_size ~__context ~self:sr ~value:sr_info.total_space ;
       Db.SR.set_physical_utilisation ~__context ~self:sr
         ~value:(Int64.sub sr_info.total_space sr_info.free_space) ;
-      Db.SR.set_clustered ~__context ~self:sr ~value:sr_info.clustered
+      Db.SR.set_clustered ~__context ~self:sr ~value:sr_info.clustered ;
+      info "%s: updated xapi DB for SR %s" __FUNCTION__
+        (Option.fold ~some:Fun.id ~none:sr_info.name_label
+           sr_info.Storage_interface.sr_uuid
+        )
   )
 
 let get_supported_types ~__context = Sm.supported_drivers ()


### PR DESCRIPTION

We have a race condition: PDB.plug updates the xapi database in a separate thread. This means the information there is accurate only after PBD.plug returns. In this case, the information about available space could be misleading before it is silently corrected. To avoid this, make this update synchronous.

