### PR TITLE
CA-378966: Detect state network interface changes

### DIFF
--- a/ocaml/networkd/bin/network_monitor_thread.ml
+++ b/ocaml/networkd/bin/network_monitor_thread.ml
@@ -379,15 +379,20 @@ let relevant line =
     [
       ("ignore second line of a message", String.starts_with ~prefix:"    ")
     ; ("no link-local addresses", contains "inet6 fe80")
+    ; ( "ignore vif and tap devices"
+      , fun line -> contains " vif" line || contains " tap" line
+      )
     ]
   in
-  let allowed = [("IP changes", contains "inet")] in
+  let allowed =
+    [("IP changes", contains "inet"); ("state changes", contains " state ")]
+  in
   let test (_name, fn) = fn line in
   (not (List.exists test ignored)) && List.exists test allowed
 
 let rec ip_watcher () =
   let cmd = Network_utils.iproute2 in
-  let args = ["monitor"; "address"] in
+  let args = ["monitor"; "address"; "link"] in
   let readme, writeme = Unix.pipe () in
   with_lock watcher_m (fun () ->
       watcher_pid :=

--- a/ocaml/xapi-aux/dune
+++ b/ocaml/xapi-aux/dune
@@ -5,6 +5,7 @@
     cstruct
     forkexec
     ipaddr
+    ipaddr.unix
     tar
     threads.posix
     xapi-consts

--- a/ocaml/xapi-aux/networking_info.ml
+++ b/ocaml/xapi-aux/networking_info.ml
@@ -13,6 +13,8 @@
  *)
 module Net = Network_client.Client
 
+module L = Debug.Make (struct let name = __MODULE__ end)
+
 let get_hostname () = try Unix.gethostname () with _ -> ""
 
 exception Unexpected_address_type of string
@@ -64,10 +66,9 @@ let get_management_ip_addr ~dbg =
         | "ipv6" ->
             Net.Interface.get_ipv6_addr dbg iface
         | s ->
-            raise
-              (Unexpected_address_type
-                 (Printf.sprintf "Expected 'ipv4' or 'ipv6', got %s" s)
-              )
+            let msg = Printf.sprintf "Expected 'ipv4' or 'ipv6', got %s" s in
+            L.error "%s: %s" __FUNCTION__ msg ;
+            raise (Unexpected_address_type msg)
       in
       let addrs =
         addrs

--- a/ocaml/xapi-aux/networking_info.ml
+++ b/ocaml/xapi-aux/networking_info.ml
@@ -40,15 +40,13 @@ let dns_names () =
      )
   |> Astring.String.uniquify
 
-let ip_addr_of_string ip =
-  Ipaddr.of_string ip
-  |> Stdlib.Result.to_option
-  |> Option.map (function
-       | Ipaddr.V4 addr ->
-           Cstruct.of_string (Ipaddr.V4.to_octets addr)
-       | Ipaddr.V6 addr ->
-           Cstruct.of_string (Ipaddr.V6.to_octets addr)
-       )
+let ipaddr_to_cstruct = function
+  | Ipaddr.V4 addr ->
+      Cstruct.of_string (Ipaddr.V4.to_octets addr)
+  | Ipaddr.V6 addr ->
+      Cstruct.of_string (Ipaddr.V6.to_octets addr)
+
+let list_head lst = List.nth_opt lst 0
 
 let get_management_ip_addr ~dbg =
   let iface = Inventory.lookup Inventory._management_interface in
@@ -70,14 +68,10 @@ let get_management_ip_addr ~dbg =
             L.error "%s: %s" __FUNCTION__ msg ;
             raise (Unexpected_address_type msg)
       in
-      let addrs =
-        addrs
-        |> List.map (fun (addr, _) -> Unix.string_of_inet_addr addr)
-        |> (* Filter out link-local addresses *)
-        List.filter (fun addr -> String.sub addr 0 4 <> "fe80")
-        |> List.map (fun str ->
-               Option.map (fun bytes -> (str, bytes)) (ip_addr_of_string str)
-           )
-      in
-      Option.join (List.nth_opt addrs 0)
+      addrs
+      |> List.map (fun (addr, _) -> Ipaddr_unix.of_inet_addr addr)
+      (* Filter out link-local addresses *)
+      |> List.filter (fun addr -> Ipaddr.scope addr <> Ipaddr.Link)
+      |> List.map (fun ip -> (Ipaddr.to_string ip, ipaddr_to_cstruct ip))
+      |> list_head
   with _ -> None

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -719,11 +719,18 @@ let slave_local_login_with_password ~__context ~uname ~pwd =
       Xapi_local_session.create ~__context ~pool:false
   )
 
-(* CP-714: Modify session.login_with_password to first try local super-user login; and then call into external auth plugin if this is enabled *)
-(* 1. If the pool master's Host.external_auth_type field is not none, then the Session.login_with_password XenAPI method will:
-      - try and authenticate locally (checking whether the supplied credentials refer to the local superuser account); and then if this authentication step fails
-      - try and authenticate remotely, passing the supplied username/password to the external auth/directory service. (Note: see below for definition of 'authenticate remotely')
-   2. otherwise, Session.login_with_password will only attempt to authenticate against the local superuser credentials
+(* CP-714: Modify session.login_with_password to first try local super-user
+   login; and then call into external auth plugin if this is enabled
+   1. If the pool master's Host.external_auth_type field is not none, then the
+      Session.login_with_password XenAPI method will:
+      - try and authenticate locally (checking whether the supplied credentials
+        refer to the local superuser account); and then if this authentication
+        step fails
+      - try and authenticate remotely, passing the supplied username/password
+        to the external auth/directory service. (Note: see below for definition
+        of 'authenticate remotely')
+   2. otherwise, Session.login_with_password will only attempt to authenticate
+      against the local superuser credentials
 *)
 let login_with_password ~__context ~uname ~pwd ~version:_ ~originator =
   let pwd = Bytes.of_string pwd in


### PR DESCRIPTION
Currently only address changes are detected, but state changes are needed
because MTU changes make the state of the link to change.

Not detecting this situation makes xapi hang at boot in certain scenarios.