### PR TITLE
Revert "Cross-pool live migration: move CPU check to the target host"

### DIFF
--- a/ocaml/xapi/cpuid_helpers.mli
+++ b/ocaml/xapi/cpuid_helpers.mli
@@ -16,12 +16,11 @@ val next_boot_cpu_features : __context:Context.t -> vm:[`VM] API.Ref.t -> string
 
 val assert_vm_is_compatible :
      __context:Context.t
-  -> vm:[`db of [`VM] API.Ref.t | `import of API.vM_t * API.domain_type]
+  -> vm:[`VM] API.Ref.t
   -> host:[`host] API.Ref.t
+  -> ?remote:(Rpc.call -> Rpc.response Client.Id.t) * [< `session] Ref.t
   -> unit
-(** Checks whether the CPU vendor and features used by the VM are compatible
-    with the given host. The VM can be one that is currently in the DB, or a record
-    coming from a metadata import as used for cross-pool migration. *)
+  -> unit
 
 val vendor : string Map_check.field
 
@@ -41,6 +40,7 @@ val features_hvm_host : [`host] Xenops_interface.CPU_policy.t Map_check.field
 
 val get_host_cpu_info :
      __context:Context.t
+  -> vm:[`VM] API.Ref.t
   -> host:[`host] API.Ref.t
   -> ?remote:(Rpc.call -> Rpc.response Client.Id.t) * [< `session] Ref.t
   -> unit

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -719,15 +719,6 @@ module VM : HandlerTools = struct
         Db.VM.set_suspend_SR ~__context ~self:vm ~value:Ref.null ;
       Db.VM.set_parent ~__context ~self:vm ~value:vm_record.API.vM_parent ;
       ( try
-          let vmm = lookup vm_record.API.vM_metrics state.table in
-          (* We have VM_metrics in the imported metadata, so use it, and destroy
-             the record created by VM.create_from_record above. *)
-          let replaced_vmm = Db.VM.get_metrics ~__context ~self:vm in
-          Db.VM.set_metrics ~__context ~self:vm ~value:vmm ;
-          Db.VM_metrics.destroy ~__context ~self:replaced_vmm
-        with _ -> ()
-      ) ;
-      ( try
           let gm = lookup vm_record.API.vM_guest_metrics state.table in
           Db.VM.set_guest_metrics ~__context ~self:vm ~value:gm
         with _ -> ()
@@ -799,40 +790,6 @@ module GuestMetrics : HandlerTools = struct
       ~can_use_hotplug_vbd:gm_record.API.vM_guest_metrics_can_use_hotplug_vbd
       ~can_use_hotplug_vif:gm_record.API.vM_guest_metrics_can_use_hotplug_vif ;
     state.table <- (x.cls, x.id, Ref.string_of gm) :: state.table
-end
-
-(** Create the VM metrics *)
-module Metrics : HandlerTools = struct
-  type precheck_t = OK
-
-  let precheck __context _config _rpc _session_id _state _x = OK
-
-  let handle_dry_run __context _config _rpc _session_id state x _precheck_result
-      =
-    let dummy_gm = Ref.make () in
-    state.table <- (x.cls, x.id, Ref.string_of dummy_gm) :: state.table
-
-  let handle __context _config _rpc _session_id state x _precheck_result =
-    let vmm_record = API.vM_metrics_t_of_rpc x.snapshot in
-    let vmm = Ref.make () in
-    Db.VM_metrics.create ~__context ~ref:vmm
-      ~uuid:(Uuidx.to_string (Uuidx.make ()))
-      ~memory_actual:vmm_record.API.vM_metrics_memory_actual
-      ~vCPUs_number:vmm_record.API.vM_metrics_VCPUs_number
-      ~vCPUs_utilisation:vmm_record.API.vM_metrics_VCPUs_utilisation
-      ~vCPUs_CPU:vmm_record.API.vM_metrics_VCPUs_CPU
-      ~vCPUs_params:vmm_record.API.vM_metrics_VCPUs_params
-      ~vCPUs_flags:vmm_record.API.vM_metrics_VCPUs_flags
-      ~state:vmm_record.API.vM_metrics_state
-      ~start_time:vmm_record.API.vM_metrics_start_time
-      ~install_time:vmm_record.API.vM_metrics_install_time
-      ~last_updated:vmm_record.API.vM_metrics_last_updated
-      ~other_config:vmm_record.API.vM_metrics_other_config
-      ~hvm:vmm_record.API.vM_metrics_hvm
-      ~nested_virt:vmm_record.API.vM_metrics_nested_virt
-      ~nomigrate:vmm_record.API.vM_metrics_nomigrate
-      ~current_domain_type:vmm_record.API.vM_metrics_current_domain_type ;
-    state.table <- (x.cls, x.id, Ref.string_of vmm) :: state.table
 end
 
 (** If we're restoring VM metadata only then lookup the SR by uuid. If we can't find
@@ -1940,7 +1897,6 @@ module HostHandler = MakeHandler (Host)
 module SRHandler = MakeHandler (SR)
 module VDIHandler = MakeHandler (VDI)
 module GuestMetricsHandler = MakeHandler (GuestMetrics)
-module MetricsHandler = MakeHandler (Metrics)
 module VMHandler = MakeHandler (VM)
 module NetworkHandler = MakeHandler (Net)
 module GPUGroupHandler = MakeHandler (GPUGroup)
@@ -1959,7 +1915,6 @@ let handlers =
   ; (Datamodel_common._sr, SRHandler.handle)
   ; (Datamodel_common._vdi, VDIHandler.handle)
   ; (Datamodel_common._vm_guest_metrics, GuestMetricsHandler.handle)
-  ; (Datamodel_common._vm_metrics, MetricsHandler.handle)
   ; (Datamodel_common._vm, VMHandler.handle)
   ; (Datamodel_common._network, NetworkHandler.handle)
   ; (Datamodel_common._gpu_group, GPUGroupHandler.handle)

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -249,7 +249,6 @@ type vm_export_import = {
   ; dry_run: bool
   ; live: bool
   ; send_snapshots: bool
-  ; check_cpu: bool
 }
 
 (* Copy VM metadata to a remote pool *)
@@ -270,12 +269,11 @@ let remote_metadata_export_import ~__context ~rpc ~session_id ~remote_address
       match which with
       | `All ->
           []
-      | `Only {live; dry_run; send_snapshots; check_cpu; _} ->
+      | `Only {live; dry_run; send_snapshots; _} ->
           [
             Printf.sprintf "live=%b" live
           ; Printf.sprintf "dry_run=%b" dry_run
           ; Printf.sprintf "export_snapshots=%b" send_snapshots
-          ; Printf.sprintf "check_cpu=%b" check_cpu
           ]
     in
     let params = Printf.sprintf "restore=%b" restore :: params in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2398,7 +2398,7 @@ functor
           try bool_of_string (List.assoc "force" options) with _ -> false
         in
         if not force then
-          Cpuid_helpers.assert_vm_is_compatible ~__context ~vm:(`db vm) ~host ;
+          Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host () ;
         let source_host = Db.VM.get_resident_on ~__context ~self:vm in
         with_vm_operation ~__context ~self:vm ~doc:"VM.pool_migrate"
           ~op:`pool_migrate ~strict:(not force) (fun () ->

--- a/ocaml/xapi/xapi_dr.ml
+++ b/ocaml/xapi/xapi_dr.ml
@@ -282,7 +282,6 @@ let recover_vms ~__context ~vms ~session_to ~force =
     {
       Import.dry_run= false
     ; Import.live= false
-    ; check_cpu= false
     ; vdi_map= [] (* we expect the VDI metadata to be present *)
     }
   in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -568,7 +568,7 @@ let resume ~__context ~vm ~start_paused ~force =
   ) ;
   let host = Helpers.get_localhost ~__context in
   if not force then
-    Cpuid_helpers.assert_vm_is_compatible ~__context ~vm:(`db vm) ~host ;
+    Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host () ;
   (* Update CPU feature set, which will be passed to xenopsd *)
   Xapi_xenops.resume ~__context ~self:vm ~start_paused ~force
 

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -647,7 +647,7 @@ let assert_matches_control_domain_affinity ~__context ~self ~host =
 let assert_enough_pcpus ~__context ~self ~host ?remote () =
   let vcpus = Db.VM.get_VCPUs_max ~__context ~self in
   let pcpus =
-    Cpuid_helpers.get_host_cpu_info ~__context ~host ?remote ()
+    Cpuid_helpers.get_host_cpu_info ~__context ~vm:self ~host ?remote ()
     |> Map_check.getf Cpuid_helpers.cpu_count
     |> Int64.of_int
   in
@@ -718,7 +718,7 @@ let assert_can_boot_here ~__context ~self ~host ~snapshot ~do_cpuid_check
   assert_hardware_platform_support ~__context ~vm:self
     ~host:(Helpers.LocalObject host) ;
   if do_cpuid_check then
-    Cpuid_helpers.assert_vm_is_compatible ~__context ~vm:(`db self) ~host ;
+    Cpuid_helpers.assert_vm_is_compatible ~__context ~vm:self ~host () ;
   if do_sr_check then
     assert_can_see_SRs ~__context ~self ~host ;
   assert_can_see_networks ~__context ~self ~host ;

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1182,7 +1182,6 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
      We look at the VDIs of the VM, the VDIs of all of the snapshots, and any
      suspend-image VDIs. *)
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
-  let power_state = Db.VM.get_power_state ~__context ~self:vm in
   let vbds = Db.VM.get_VBDs ~__context ~self:vm in
   let vifs = Db.VM.get_VIFs ~__context ~self:vm in
   let snapshots = Db.VM.get_snapshots ~__context ~self:vm in
@@ -1457,7 +1456,7 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
             in
             inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map
               ~vif_map ~vgpu_map ~dry_run:false ~live:true ~copy
-              ~check_cpu:((not force) && power_state <> `Halted)
+              ~check_cpu:(not force)
           in
           let vm = List.hd vms in
           let () =
@@ -1834,7 +1833,7 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
           not
             (inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map
                ~vif_map ~vgpu_map ~dry_run:true ~live:true ~copy
-               ~check_cpu:((not force) && power_state <> `Halted)
+               ~check_cpu:(not force)
             = []
             )
         then

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -569,7 +569,7 @@ let intra_pool_vdi_remap ~__context vm vdi_map =
     vdis_and_callbacks
 
 let inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map
-    ~vgpu_map ~dry_run ~live ~copy ~check_cpu =
+    ~vgpu_map ~dry_run ~live ~copy =
   List.iter
     (fun vdi_record ->
       let vdi = vdi_record.local_vdi_reference in
@@ -605,7 +605,7 @@ let inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map ~vif_map
     )
     vgpu_map ;
   let vm_export_import =
-    {Importexport.vm; dry_run; live; send_snapshots= not copy; check_cpu}
+    {Importexport.vm; dry_run; live; send_snapshots= not copy}
   in
   finally
     (fun () ->
@@ -1164,9 +1164,6 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
   let remote = remote_of_dest ~__context dest in
   (* Copy mode means we don't destroy the VM on the source host. We also don't
      	   copy over the RRDs/messages *)
-  let force =
-    try bool_of_string (List.assoc "force" options) with _ -> false
-  in
   let copy = try bool_of_string (List.assoc "copy" options) with _ -> false in
   let compress =
     use_compression ~__context options localhost remote.dest_host
@@ -1456,7 +1453,6 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
             in
             inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map
               ~vif_map ~vgpu_map ~dry_run:false ~live:true ~copy
-              ~check_cpu:(not force)
           in
           let vm = List.hd vms in
           let () =
@@ -1791,6 +1787,12 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
           (Api_errors.Server_error
              (Api_errors.host_disabled, [Ref.string_of remote.dest_host])
           ) ;
+      (* Check that the VM's required CPU features are available on the host *)
+      if not force then
+        Cpuid_helpers.assert_vm_is_compatible ~__context ~vm
+          ~host:remote.dest_host
+          ~remote:(remote.rpc, remote.session)
+          () ;
       (* Check that the destination has enough pCPUs *)
       Xapi_vm_helpers.assert_enough_pcpus ~__context ~self:vm
         ~host:remote.dest_host
@@ -1833,7 +1835,6 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
           not
             (inter_pool_metadata_transfer ~__context ~remote ~vm ~vdi_map
                ~vif_map ~vgpu_map ~dry_run:true ~live:true ~copy
-               ~check_cpu:(not force)
             = []
             )
         then


### PR DESCRIPTION
We see some errors in the context of snapshots that we need to investigate.