### PR TITLE
CA-380789: Not get power_state from snapshots with suspend VDIs

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1241,7 +1241,7 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
   let suspends_vdis =
     List.fold_left
       (fun acc vm ->
-        if power_state = `Suspended then
+        if Db.VM.get_power_state ~__context ~self:vm = `Suspended then
           let vdi = Db.VM.get_suspend_VDI ~__context ~self:vm in
           let sr = Db.VDI.get_SR ~__context ~self:vdi in
           if


### PR DESCRIPTION
This commit is to fix an issue which was introduced by 3d039f3. In VM migration, the suspend_vdis will be get from snapshots the power_state of which is `Suspended. The individual snapshots are represented as VM records in XAPI as well. They are different with the base VM record.

This commit reverts this part to the logic prior to 3d039f3.