### PR TITLE
CA-380715: Hit unspecified domain_type of snapshots in VM migration

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -516,12 +516,18 @@ module VM : HandlerTools = struct
                 |> API.vM_metrics_t_of_rpc
               in
               let host = Helpers.get_localhost ~__context in
-              Cpuid_helpers.assert_vm_is_compatible ~__context
-                ~vm:
-                  (`import
-                    (vm_record, vmm_record.API.vM_metrics_current_domain_type)
-                    )
-                ~host
+              match
+                ( vm_record.API.vM_is_a_snapshot
+                , vmm_record.API.vM_metrics_current_domain_type
+                )
+              with
+              | true, `unspecified ->
+                  (* A snapshot which was taken from a shutdown VM. *)
+                  ()
+              | _, dt ->
+                  Cpuid_helpers.assert_vm_is_compatible ~__context
+                    ~vm:(`import (vm_record, dt))
+                    ~host
           ) ;
           import_action
       | _ ->


### PR DESCRIPTION
In live migration of a VM with snapshots, the "current_domain_type" of a snapshot may be "unspecified" if the snapshot was taken when the VM was in shutdown state. This will fail the CPU checking in migration as the checking has to know the domain type.

On the other hand, it is not necessary to check CPU for a snapshot if its domain type is unknown ('unspecified'). The potential problem might be the snapshot couldn't be reverted and started up in migration destination. But this can't be avoided anyway. For example, a new created VM which never started would hit same issue after migration (not live).

This commit skips the CPU checking on such snapshots.