### PR TITLE
CP-42559: Add RBAC info to C#, Java, and C SDK method comments

### DIFF
--- a/ocaml/idl/datamodel_roles.ml
+++ b/ocaml/idl/datamodel_roles.ml
@@ -64,7 +64,23 @@ let roles_all = List.map role_name ordered
 
 let role_description = List.map role_name_with_description ordered
 
-let role_is_internal = List.map role_name_with_internal ordered
+let role_is_internal_map = List.map role_name_with_internal ordered
+
+(** Returns true if role_name_label matches that of an internal role.
+@param role_name_label the string representation of the role we're checking.
+@raise Failure if there is no matching field or the field doesn't have a is_internal value.
+*)
+let role_is_internal role_name_label =
+  match List.assoc_opt role_name_label role_is_internal_map with
+  | Some is_internal ->
+      is_internal
+  | None ->
+      failwith
+        (Printf.sprintf
+           "Check Datamodel_roles.role_is_internal: there's no is_internal \
+            field set for role %s"
+           role_name_label
+        )
 
 (* obtain all roles with at least the specified role privileges *)
 let roles_gte role =

--- a/ocaml/idl/ocaml_backend/gen_rbac.ml
+++ b/ocaml/idl/ocaml_backend/gen_rbac.ml
@@ -134,16 +134,7 @@ let writer_role name nroles =
         )
   in
   let role_is_internal =
-    try
-      List.assoc role_name_label Datamodel_roles.role_is_internal
-      |> string_of_bool
-    with Not_found ->
-      failwith
-        (Printf.sprintf
-           "Check Datamodel_roles.role_is_internal: there's no is_internal \
-            field set for role %s"
-           role_name_label
-        )
+    Datamodel_roles.role_is_internal role_name_label |> string_of_bool
   in
   Printf.sprintf "let %s = \n  { (* %s *)\n" (role_label name) role_number
   (*^(Printf.sprintf "  role_ref = \"%s\";\n" role_ref)*)

--- a/ocaml/sdk-gen/c/gen_c_binding.ml
+++ b/ocaml/sdk-gen/c/gen_c_binding.ml
@@ -349,7 +349,12 @@ and get_message_comment message =
   let full_stop =
     if Astring.String.is_suffix ~affix:"." message.msg_doc then "" else "."
   in
-  Helper.comment true (sprintf "%s%s" message.msg_doc full_stop)
+  let minimum_allowed_role = get_minimum_allowed_role message in
+  let content =
+    sprintf "%s%s\nMinimum allowed role: %s." message.msg_doc full_stop
+      minimum_allowed_role
+  in
+  Helper.comment true content
 
 and impl_messages needed classname messages =
   joined "\n\n" (impl_message needed classname) messages

--- a/ocaml/sdk-gen/common/CommonFunctions.ml
+++ b/ocaml/sdk-gen/common/CommonFunctions.ml
@@ -197,6 +197,16 @@ let gen_param_groups message params =
        (if expRelease = "" then overloadGroups else [params])
     )
 
+and get_minimum_allowed_role msg =
+  let get_last_role roles =
+    match List.rev roles with [] -> "Not Applicable" | last :: _ -> last
+  in
+  match msg.msg_allowed_roles with
+  | None ->
+      "Not Applicable"
+  | Some roles ->
+      get_last_role roles
+
 (*** XML documentation ***)
 
 and get_published_info_message message cls =

--- a/ocaml/sdk-gen/common/CommonFunctions.ml
+++ b/ocaml/sdk-gen/common/CommonFunctions.ml
@@ -198,8 +198,19 @@ let gen_param_groups message params =
     )
 
 and get_minimum_allowed_role msg =
-  let get_last_role roles =
-    match List.rev roles with [] -> "Not Applicable" | last :: _ -> last
+  let get_last_role recroles =
+    let reversed_role_list = List.rev recroles in
+    let rec get_role reversed_list =
+      match reversed_list with
+      | [] ->
+          "Not Applicable"
+      | last :: rest ->
+          if not (Datamodel_roles.role_is_internal last) then
+            last
+          else
+            get_role rest
+    in
+    get_role reversed_role_list
   in
   match msg.msg_allowed_roles with
   | None ->

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -553,6 +553,7 @@ and gen_overloads generator message =
 
 and gen_exposed_method cls msg curParams =
   let classname = cls.name in
+  let minimum_allowed_role = get_minimum_allowed_role msg in
   let proxyMsgName = proxy_msg_name classname msg in
   let exposed_ret_type = exposed_type_opt msg.msg_result in
   let paramSignature = exposed_params msg classname curParams in
@@ -573,14 +574,17 @@ and gen_exposed_method cls msg curParams =
       \        /// <summary>\n\
       \        /// %s%s%s\n\
       \        /// </summary>%s%s\n\
+      \        /// <remarks>\n\
+      \        /// Minimum allowed role: %s\n\
+      \        /// </remarks>\n\
       \        public static %s %s(%s)\n\
       \        {\n\
       \            %s;\n\
       \        }\n"
       msg.msg_doc
       (if publishInfo = "" then "" else "\n        /// " ^ publishInfo)
-      deprecatedInfoString paramsDoc deprecatedAttributeString exposed_ret_type
-      msg.msg_name paramSignature
+      deprecatedInfoString paramsDoc deprecatedAttributeString
+      minimum_allowed_role exposed_ret_type msg.msg_name paramSignature
       (json_return_opt
          (sprintf "session.JsonRpcClient.%s(%s)" proxyMsgName jsonCallParams)
          msg.msg_result
@@ -593,14 +597,18 @@ and gen_exposed_method cls msg curParams =
         \        /// <summary>\n\
         \        /// %s%s%s\n\
         \        /// </summary>%s%s\n\
+        \        /// <remarks>\n\
+        \        /// Minimum allowed role: %s\n\
+        \        /// </remarks>\n\
         \        public static XenRef<Task> async_%s(%s)\n\
         \        {\n\
         \          return session.JsonRpcClient.async_%s(%s);\n\
         \        }\n"
         msg.msg_doc
         (if publishInfo = "" then "" else "\n        /// " ^ publishInfo)
-        deprecatedInfoString paramsDoc deprecatedAttributeString msg.msg_name
-        paramSignature proxyMsgName jsonCallParams
+        deprecatedInfoString paramsDoc deprecatedAttributeString
+        minimum_allowed_role msg.msg_name paramSignature proxyMsgName
+        jsonCallParams
     else
       ""
   in

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -288,6 +288,8 @@ let gen_method file cls message params async_version =
 
   fprintf file "    /**\n" ;
   fprintf file "     * %s\n" (escape_xml message.msg_doc) ;
+  fprintf file "     * Minimum allowed role: %s\n"
+    (get_minimum_allowed_role message) ;
   if not (publishInfo = "") then fprintf file "     * %s\n" publishInfo ;
   if get_method_deprecated message then fprintf file "     * @deprecated\n" ;
   fprintf file "     *\n" ;


### PR DESCRIPTION
The PowerShell SDK needs more work as we'd need to generate a valid `dll-Help.xml` file to properly comment cmdlets: https://learn.microsoft.com/en-us/powershell/scripting/developer/help/how-to-create-the-cmdlet-help-file?view=powershell-7.3


Comment based support for `Get-Help` is only available for modules written directly in PowerShell.


Bit out of scope for this, worth opening a separate ticket.


Example of the new docs:

C#

```csharp
/// <summary>
/// Create a new VTPM instance, and return its handle.
 /// Experimental. First published in 22.26.0.
/// </summary>
/// <param name="session">The session</param>
/// <param name="_vm">The VM reference the VTPM will be attached to</param>
/// <param name="_is_unique">Whether the VTPM must be unique</param>
/// <remarks>
/// Minimum allowed role: vm-admin
/// </remarks>
public static XenRef<VTPM> create(Session session, string _vm, bool _is_unique)
{
    return session.JsonRpcClient.vtpm_create(session.opaque_ref, _vm, _is_unique);
}
```

C
```c
/**
 * Create a new VTPM instance, and return its handle.
 * Minimum allowed role: vm-admin.
 */
extern bool
xen_vtpm_create(xen_session *session, xen_vtpm *result, xen_vm vm, bool is_unique);
```

Java

```java
/**
   * Create a new VTPM instance, and return its handle.
   * Minimum allowed role: vm-admin
   * Experimental. First published in 22.26.0.
   *
   * @param c The connection the call is made on
   * @param vM The VM reference the VTPM will be attached to
   * @param isUnique Whether the VTPM must be unique
   * @return The reference of the newly created VTPM
   * @throws BadServerResponse Thrown if the response from the server contains an invalid status.
   * @throws XenAPIException Thrown if the call failed.
   * @throws XmlRpcException Thrown if the result of an asynchronous call could not be parsed.
   */
public static VTPM create(Connection c, VM vM, Boolean isUnique) throws BadServerResponse, XenAPIException, XmlRpcException 
{
    String method_call = "VTPM.create";
    String session = c.getSessionReference();
    Object[] method_params = {Marshalling.toXMLRPC(session), Marshalling.toXMLRPC(vM), Marshalling.toXMLRPC(isUnique)};
    Map response = c.dispatch(method_call, method_params);
    Object result = response.get("Value");
    return Types.toVTPM(result);
}
```