### PR TITLE
Install suspend_image_viewer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ install: build doc sdk doc-json
 	scripts/install.sh 755 _build/install/default/bin/vncproxy $(DESTDIR)$(OPTDIR)/debug/vncproxy
 # ocaml/perftest
 	scripts/install.sh 755 _build/install/default/bin/perftest $(DESTDIR)$(OPTDIR)/debug/perftest
-# ocaml/suspend_image_viewer
-	scripts/install.sh 755 _build/install/default/bin/perftest $(DESTDIR)$(OPTDIR)/debug/suspend_image_viewer
+# ocaml/suspend-image-viewer
+	scripts/install.sh 755 _build/install/default/bin/perftest $(DESTDIR)$(OPTDIR)/debug/suspend-image-viewer
 # ocaml/mpathalert
 	scripts/install.sh 755 _build/install/default/bin/mpathalert $(DESTDIR)$(OPTDIR)/bin/mpathalert
 # ocaml/license

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ install: build doc sdk doc-json
 	scripts/install.sh 755 _build/install/default/bin/vncproxy $(DESTDIR)$(OPTDIR)/debug/vncproxy
 # ocaml/perftest
 	scripts/install.sh 755 _build/install/default/bin/perftest $(DESTDIR)$(OPTDIR)/debug/perftest
+# ocaml/suspend_image_viewer
+	scripts/install.sh 755 _build/install/default/bin/perftest $(DESTDIR)$(OPTDIR)/debug/suspend_image_viewer
 # ocaml/mpathalert
 	scripts/install.sh 755 _build/install/default/bin/mpathalert $(DESTDIR)$(OPTDIR)/bin/mpathalert
 # ocaml/license

--- a/ocaml/xenopsd/suspend_image_viewer/dune
+++ b/ocaml/xenopsd/suspend_image_viewer/dune
@@ -1,5 +1,6 @@
 (executable
- (public_name suspend_image_viewer)
+ (public_name suspend-image-viewer)
+ (name suspend_image_viewer)
  (package xapi-xenopsd-xc)
  (libraries
   cmdliner

--- a/ocaml/xenopsd/suspend_image_viewer/dune
+++ b/ocaml/xenopsd/suspend_image_viewer/dune
@@ -1,5 +1,6 @@
 (executable
- (name suspend_image_viewer)
+ (public_name suspend_image_viewer)
+ (package xapi-xenopsd-xc)
  (libraries
   cmdliner
   forkexec

--- a/ocaml/xenopsd/suspend_image_viewer/view.sh
+++ b/ocaml/xenopsd/suspend_image_viewer/view.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Usage: copy this script and suspend_image_viewer executable to a box
+# Usage: copy this script and suspend-image-viewer executable to a box
 # Given a snapshot called `snap-mem` view its suspend image VDI:
 # /opt/xensource/debug/with-vdi $(xe snapshot-list name-label=uefi-mem params=suspend-VDI-uuid --minimal) ./view.sh
-./suspend_image_viewer --config /etc/xenopsd.conf --path /dev/$DEVICE
+./suspend-image-viewer --config /etc/xenopsd.conf --path /dev/$DEVICE


### PR DESCRIPTION
This is useful for debugging. It cannot be easily run out of Dom0 due to its dependency on verify-stream-v2 provided by Xen.
Also if it is not installed in Dom0 then it is bitrotting and not being tested, so when we need it then we realise it is broken.

Note that `verify-stream-v2` is currently bitrotted and its shebang needs to be edited to python2 to make it work.

Can be used like this:

```
/opt/xensource/debug/with-vdi de9bd384-b866-42b6-a8a0-b4f03a23c0fe
./suspend_image_viewer.exe --path /dev/$DEVICE --verify-stream-v2=/usr/libexec/xen/bin/verify-stream-v2
```

(This will require a specfile update when merged)