### PR TITLE
Fix bugs in merge of guidances and livepatch failures

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -316,6 +316,14 @@ let update_guidances =
         , "Indicates the updated host should reboot as soon as possible since \
            one or more livepatch(es) failed to be applied."
         )
+      ; ( "reboot_host_on_xen_livepatch_failure"
+        , "Indicates the updated host should reboot as soon as possible since \
+           one or more Xen livepatch(es) failed to be applied."
+        )
+      ; ( "reboot_host_on_kernel_livepatch_failure"
+        , "Indicates the updated host should reboot as soon as possible since \
+           one or more Linux Kernel livepatch(es) failed to be applied."
+        )
       ; ( "restart_toolstack"
         , "Indicates the Toolstack running on the updated host should restart \
            as soon as possible"

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "f4d0ee4f27d7fc0377add334197f6cd8"
+let last_known_schema_hash = "a1268fd3ea5824c4e05abbc9742675c0"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -203,6 +203,10 @@ let update_guidance_to_string = function
       "reboot_host"
   | `reboot_host_on_livepatch_failure ->
       "reboot_host_on_livepatch_failure"
+  | `reboot_host_on_kernel_livepatch_failure ->
+      "reboot_host_on_kernel_livepatch_failure"
+  | `reboot_host_on_xen_livepatch_failure ->
+      "reboot_host_on_xen_livepatch_failure"
   | `restart_toolstack ->
       "restart_toolstack"
   | `restart_device_model ->

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -64,7 +64,7 @@ val apply_updates :
      __context:Context.t
   -> host:[`host] API.Ref.t
   -> hash:string
-  -> Updateinfo.Guidance.t list * string list list
+  -> string list list
 
 val set_available_updates : __context:Context.t -> string
 

--- a/ocaml/xapi/updateinfo.ml
+++ b/ocaml/xapi/updateinfo.ml
@@ -24,6 +24,8 @@ module Guidance = struct
     | EvacuateHost
     | RestartDeviceModel
     | RebootHostOnLivePatchFailure
+    | RebootHostOnXenLivePatchFailure
+    | RebootHostOnKernelLivePatchFailure
 
   type guidance_kind = Absolute | Recommended
 
@@ -40,6 +42,10 @@ module Guidance = struct
         "RestartDeviceModel"
     | RebootHostOnLivePatchFailure ->
         "RebootHostOnLivePatchFailure"
+    | RebootHostOnKernelLivePatchFailure ->
+        "RebootHostOnKernelLivePatchFailure"
+    | RebootHostOnXenLivePatchFailure ->
+        "RebootHostOnXenLivePatchFailure"
 
   let of_string = function
     | "RebootHost" ->
@@ -58,15 +64,35 @@ module Guidance = struct
           g ;
         RebootHost
 
-  let of_update_guidance = function
+  let of_pending_guidance = function
     | `reboot_host ->
         RebootHost
     | `reboot_host_on_livepatch_failure ->
         RebootHostOnLivePatchFailure
+    | `reboot_host_on_kernel_livepatch_failure ->
+        RebootHostOnKernelLivePatchFailure
+    | `reboot_host_on_xen_livepatch_failure ->
+        RebootHostOnXenLivePatchFailure
     | `restart_toolstack ->
         RestartToolstack
     | `restart_device_model ->
         RestartDeviceModel
+
+  let to_pending_guidance = function
+    | RebootHost ->
+        Some `reboot_host
+    | RebootHostOnLivePatchFailure ->
+        Some `reboot_host_on_livepatch_failure
+    | RebootHostOnKernelLivePatchFailure ->
+        Some `reboot_host_on_kernel_livepatch_failure
+    | RebootHostOnXenLivePatchFailure ->
+        Some `reboot_host_on_xen_livepatch_failure
+    | RestartToolstack ->
+        Some `restart_toolstack
+    | RestartDeviceModel ->
+        Some `restart_device_model
+    | EvacuateHost ->
+        None
 end
 
 module Applicability = struct

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -20,6 +20,8 @@ module Guidance : sig
     | EvacuateHost
     | RestartDeviceModel
     | RebootHostOnLivePatchFailure
+    | RebootHostOnXenLivePatchFailure
+    | RebootHostOnKernelLivePatchFailure
 
   type guidance_kind = Absolute | Recommended
 
@@ -30,12 +32,24 @@ module Guidance : sig
   (* may fail *)
   val of_string : string -> t
 
-  val of_update_guidance :
+  val of_pending_guidance :
        [< `reboot_host
        | `reboot_host_on_livepatch_failure
        | `restart_device_model
-       | `restart_toolstack ]
+       | `restart_toolstack
+       | `reboot_host_on_xen_livepatch_failure
+       | `reboot_host_on_kernel_livepatch_failure ]
     -> t
+
+  val to_pending_guidance :
+       t
+    -> [> `reboot_host
+       | `reboot_host_on_livepatch_failure
+       | `restart_device_model
+       | `restart_toolstack
+       | `reboot_host_on_xen_livepatch_failure
+       | `reboot_host_on_kernel_livepatch_failure ]
+       option
 end
 
 (** The applicability of metadata for one update in updateinfo *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2987,7 +2987,7 @@ let apply_updates ~__context ~self ~hash =
   (* This function runs on master host *)
   Helpers.assert_we_are_master ~__context ;
   Pool_features.assert_enabled ~__context ~f:Features.Updates ;
-  let guidances, warnings =
+  let warnings =
     Xapi_pool_helpers.with_pool_operation ~__context
       ~self:(Helpers.get_pool ~__context)
       ~doc:"Host.apply_updates" ~op:`apply_updates
@@ -3002,15 +3002,7 @@ let apply_updates ~__context ~self ~hash =
   Db.Host.set_last_software_update ~__context ~self
     ~value:(get_servertime ~__context ~host:self) ;
   Db.Host.set_latest_synced_updates_applied ~__context ~self ~value:`yes ;
-  List.map
-    (fun g ->
-      [
-        Api_errors.updates_require_recommended_guidance
-      ; Updateinfo.Guidance.to_string g
-      ]
-    )
-    guidances
-  @ warnings
+  warnings
 
 let cc_prep () =
   let cc = "CC_PREPARATIONS" in

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -382,6 +382,10 @@ let consider_enabling_host_nolock ~__context =
         ~value:`reboot_host ;
       Db.Host.remove_pending_guidances ~__context ~self:localhost
         ~value:`reboot_host_on_livepatch_failure ;
+      Db.Host.remove_pending_guidances ~__context ~self:localhost
+        ~value:`reboot_host_on_xen_livepatch_failure ;
+      Db.Host.remove_pending_guidances ~__context ~self:localhost
+        ~value:`reboot_host_on_kernel_livepatch_failure ;
       update_allowed_operations ~__context ~self:localhost ;
       Localdb.put Constants.host_disabled_until_reboot "false" ;
       (* Start processing pending VM powercycle events *)


### PR DESCRIPTION
This commit aims to fix bugs in merging guidances. Following changes are included in this commit:
1. merge_with_unapplied_guidances: merge host|VM.pending_guidances with the guidances calculated from the latest update.
2. merge_livepatch_failures: merge livepatch failures in host.pending_guidances with the failures in the latest update.
3. Remove the merged guidances from the return of `host.apply_updates` as they have been set in host|VM.pending_guidances.
4. Add RebootHostOnXenLivepatchFailure and RebootHostOnKernelLivepatchFailure to deprecate RebootHostOnlLivepatchFailure
5. Add exhaustive unit tests for this part.