### PR TITLE
xapi-idl: Add xcp-rrdd methods for Protocol V3

### DIFF
--- a/ocaml/xapi-idl/rrd/rrd_interface.ml
+++ b/ocaml/xapi-idl/rrd/rrd_interface.ml
@@ -495,6 +495,36 @@ module RPC_API (R : RPC) = struct
           (uid_p @-> returning float_p rrd_err)
     end
 
+    module Metrics = struct
+      let register =
+        let version_p =
+          Param.mk ~name:"version" ~description:["OpenMetrics version"] Types.string
+        in
+        declare "Plugin.Metrics.register"
+          [
+            "[Plugin.Metrics.register uid version] registers a plugin"
+          ; "as a source of metrics using protocol V3. [uid] is a unique"
+          ; "identifier for the plugin, often the name of the plugin."
+          ; "[version] specifies the OpenMetrics version to use in protocol V3."
+          ]
+          (uid_p @-> version_p @-> returning string_p rrd_err)
+
+      let deregister =
+        declare "Plugin.Metrics.deregister"
+          ["Deregisters a plugin by uid"]
+          (uid_p @-> returning unit_p rrd_err)
+      
+      let get_versions =
+        let versions_p =
+          Param.mk ~name:"versions" ~description:["Supported OpenMetrics versions"] string list
+        in
+        declare "Plugin.Metrics.get_versions"
+          [
+            "Get the list of OpenMetrics versions that are supported."
+          ]
+          (unit_p @-> returning versions_p rrd_err)
+    end
+
     let register =
       let freq_p =
         Param.mk ~name:"frequency"


### PR DESCRIPTION
Add `Plugin.Metrics.register`, `Plugin.Metrics.deregister` and `Plugin.Metrics.get_versions` RPC methods to xapi-idl.

`Plugin.Metrics.register`:
Register a protocol v3 plugin (as defined in https://github.com/xapi-project/xapi-project.github.io/pull/278) to xcp-rrdd daemon (or a compatible implementation) using a uid (that is similar to `Plugin.Local.register` uid) and a specific OpenMetrics version to use in protocol v3 payload (e.g "OpenMetrics 1.0.0").
If the xcp-rrdd daemon doesn't support the asked OpenMetrics version, this method is supposed to fail (see `Plugin.Metrics.get_versions`).

`Plugin.Metrics.deregister`:
Basically the same as `Plugin.Local.deregister`, added for consistency.

`Plugin.Metrics.get_versions`:
Get the list of OpenMetrics versions supported by the xcp-rrdd daemon that can be used for `Plugin.Metrics.register`.

Ideally, a plugin should call `Plugin.Metrics.get_versions` first to get the list of supported OpenMetrics versions, and choose one that the plugin supports, or fail otherwise.

Open questions/issues :
- [ ] I haven't found out how to specify a list/array as a RPC parameter in OCaml, which causes syntax issues with `get_versions` `versions_p` parameter.
- [ ] Should OpenMetrics versions be handled as precise versions (e.g `OpenMetrics 1.0.0`) or follow semantic versioning and consider non-breaking changes as the same version (use e.g `OpenMetrics 1.0` for 1.0.0, 1.0.1 and so on) ?
- [ ] Should `Plugin.Metrics.register` be always deregistered using `Plugin.Metrics.deregister` to allow more easily separating protocol v2 code with v3 code ?