### PR TITLE
maintenance: relax message-switch's bounds on mtime

### DIFF
--- a/message-switch.opam
+++ b/message-switch.opam
@@ -24,7 +24,7 @@ depends: [
   "message-switch-lwt"
   "message-switch-unix"
   "mirage-block-unix" {>= "2.4.0"}
-  "mtime" {>= "1.0.0" & < "2.0.0"}
+  "mtime" {>= "1.0.0"}
   "ppx_deriving_rpc" {with-test}
   "ppx_sexp_conv"
   "sexplib"


### PR DESCRIPTION
Currently it's also compatible with mtime 2.x