### PR TITLE
CA-371529 XSI-1329 remove license check for has-vendor-device

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1374,13 +1374,16 @@ let t =
             ~default_value:(Some (VMap []))
             ~ty:(Map (String, String))
             "cpu_info" "Details about the physical CPUs on the pool"
-        ; field ~qualifier:RW ~in_product_since:rel_dundee
-            ~default_value:(Some (VBool false)) ~ty:Bool
+        ; field ~qualifier:RW ~default_value:(Some (VBool false)) ~ty:Bool
+            ~lifecycle:
+              [
+                (Published, rel_dundee, "")
+              ; (Deprecated, "24.14.0", "No longer considered by VM.create")
+              ]
             "policy_no_vendor_device"
-            "The pool-wide policy for clients on whether to use the vendor \
-             device or not on newly created VMs. This field will also be \
-             consulted if the 'has_vendor_device' field is not specified in \
-             the VM.create call."
+            "This field was consulted when VM.create did not specify a value \
+             for 'has_vendor_device'; VM.create now uses a simple default and \
+             no longer consults this value."
         ; field ~qualifier:RW ~in_product_since:rel_ely
             ~default_value:(Some (VBool false)) ~ty:Bool
             "live_patching_disabled"

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -423,7 +423,6 @@ type api_value =
   | VMap of (api_value * api_value) list
   | VSet of api_value list
   | VRef of string
-  | VCustom of string * api_value
 [@@deriving rpc]
 
 (* For convenience, we use the same value here as is defined in the Ref module in
@@ -766,7 +765,5 @@ let rec type_checks v t =
       all_true (List.map (fun v -> type_checks v t) vl)
   | VRef _, Ref _ ->
       true
-  | VCustom _, _ ->
-      true (* Type checks defered to phase-2 compile time *)
   | _, _ ->
       false

--- a/ocaml/idl/datamodel_types.mli
+++ b/ocaml/idl/datamodel_types.mli
@@ -120,7 +120,6 @@ type api_value =
   | VMap of (api_value * api_value) list
   | VSet of api_value list
   | VRef of string
-  | VCustom of string * api_value
 
 val rpc_of_api_value : api_value -> Rpc.t
 

--- a/ocaml/idl/datamodel_values.ml
+++ b/ocaml/idl/datamodel_values.ml
@@ -49,12 +49,10 @@ let rec to_rpc v =
       Rpc.Enum (List.map (fun v -> to_rpc v) vl)
   | VRef r ->
       Rpc.String r
-  | VCustom (_, _) ->
-      failwith "Can't RPC up a custom value"
 
 open Printf
 
-let to_ocaml_string ?(v2 = false) v =
+let to_ocaml_string v =
   let rec aux = function
     | Rpc.Null ->
         "Rpc.Null"
@@ -80,18 +78,7 @@ let to_ocaml_string ?(v2 = false) v =
     | Rpc.Base64 t ->
         sprintf "Rpc.Base64 %s" t
   in
-  match v with
-  | VCustom (s, v') ->
-      if v2 then
-        (* s can contain stringified body of ocaml functions, and will break
-         * the aPI.ml code, we need to use the v' in that case. The version
-         * switch allows us to use this other version in gen_api.ml without
-         * having to duplicate lots of code *)
-        aux (to_rpc v')
-      else
-        s
-  | _ ->
-      aux (to_rpc v)
+  aux (to_rpc v)
 
 let rec to_db v =
   let open Schema.Value in
@@ -116,8 +103,6 @@ let rec to_db v =
       Set (List.map to_string vl)
   | VRef r ->
       String r
-  | VCustom (_, y) ->
-      to_db y
 
 (* Generate suitable "empty" database value of specified type *)
 let gen_empty_db_val t =

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2093,34 +2093,8 @@ let t =
             "The host virtual hardware platform version the VM can run on"
         ; field ~qualifier:StaticRO
             ~lifecycle:[(Published, rel_dundee, "")]
-            ~doc_tags:[Windows]
-            ~default_value:
-              (Some
-                 (VCustom
-                    ( String.concat "\n"
-                        [
-                          "(try Rpc.Bool ("
-                        ; "let pool = List.hd \
-                           (Db_actions.DB_Action.Pool.get_all ~__context) in"
-                        ; "let restrictions = \
-                           Db_actions.DB_Action.Pool.get_restrictions \
-                           ~__context ~self:pool in "
-                        ; "let vendor_device_allowed = try List.assoc \
-                           \"restrict_pci_device_for_auto_update\" \
-                           restrictions = \"false\" with _ -> false in"
-                        ; "let policy_says_its_ok = not \
-                           (Db_actions.DB_Action.Pool.get_policy_no_vendor_device \
-                           ~__context ~self:pool) in"
-                        ; "vendor_device_allowed && policy_says_its_ok) with e \
-                           -> D.error \"Failure when defaulting \
-                           has_vendor_device field: %s\" (Printexc.to_string \
-                           e); Rpc.Bool false)"
-                        ]
-                    , VBool false
-                    )
-                 )
-              )
-            ~ty:Bool "has_vendor_device"
+            ~doc_tags:[Windows] ~default_value:(Some (VBool true)) ~ty:Bool
+            "has_vendor_device"
             "When an HVM guest starts, this controls the presence of the \
              emulated C000 PCI device which triggers Windows Update to fetch \
              or update PV drivers."

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2092,7 +2092,14 @@ let t =
             "hardware_platform_version"
             "The host virtual hardware platform version the VM can run on"
         ; field ~qualifier:StaticRO
-            ~lifecycle:[(Published, rel_dundee, "")]
+            ~lifecycle:
+              [
+                (Published, rel_dundee, "")
+              ; ( Changed
+                , "24.14.0"
+                , "New default and not consulting Pool.policy_no_vendor_device"
+                )
+              ]
             ~doc_tags:[Windows] ~default_value:(Some (VBool true)) ~ty:Bool
             "has_vendor_device"
             "When an HVM guest starts, this controls the presence of the \

--- a/ocaml/idl/json_backend/gen_json.ml
+++ b/ocaml/idl/json_backend/gen_json.ml
@@ -107,8 +107,6 @@ end = struct
         Printf.sprintf "{%s}" (String.concat ", " (List.map string_of_default x))
     | VRef x ->
         if x = "" then "Null" else x
-    | VCustom (_, y) ->
-        string_of_default y
 
   let of_lifecycle lc =
     `Assoc

--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -188,8 +188,7 @@ let gen_record_type ~with_module highapi tys =
           | None ->
               "None"
           | Some default ->
-              sprintf "(Some (%s))"
-                (Datamodel_values.to_ocaml_string ~v2:true default)
+              sprintf "(Some (%s))" (Datamodel_values.to_ocaml_string default)
         in
         let make_to_field fld =
           let rpc_field = rpc_field fld in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "8a03b539f1c318023775f345faef4d5b"
+let last_known_schema_hash = "8c3cb4546e7dc9e8d9d05c8194d8a3d6"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "7db36ba4b150b06a5098ff9bed87b191"
+let last_known_schema_hash = "8a03b539f1c318023775f345faef4d5b"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -1240,8 +1240,6 @@ and get_default_value_opt field =
         List.map (fun x -> String.concat ", " (get_default_value x)) y
     | VRef y ->
         if y = "" then ["Helper.NullOpaqueRef"] else [sprintf "\"%s\"" y]
-    | VCustom (_, y) ->
-        get_default_value y
   in
   match field.default_value with
   | Some y ->

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3993,6 +3993,7 @@ let vm_install_real printer rpc session_id template name description params =
         Client.VM.set_has_vendor_device ~rpc ~session_id ~self:new_vm
           ~value:want_dev
       with e when e = licerr ->
+        (* No longer licensed, this should not happen. CA-371529 *)
         let msg =
           Printf.sprintf
             "Note: the VM template recommends setting has-vendor-device=true \

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -629,17 +629,15 @@ module VM : HandlerTools = struct
               ~domain_type:vm_record.API.vM_domain_type
               ~is_a_template:vm_record.API.vM_is_a_template
               vm_record.API.vM_platform
+        ; API.vM_suspend_VDI= Ref.null
+        ; API.vM_power_state= `Halted
         }
       in
       let vm =
         log_reraise
           ("failed to create VM with name-label " ^ vm_record.API.vM_name_label)
           (fun value ->
-            let vm =
-              Xapi_vm_helpers
-              .create_from_record_without_checking_licence_feature_for_vendor_device
-                ~__context rpc session_id value
-            in
+            let vm = Client.VM.create_from_record ~rpc ~session_id ~value in
             if config.full_restore then
               Db.VM.set_uuid ~__context ~self:vm ~value:value.API.vM_uuid ;
             vm

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -592,9 +592,6 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~shutdown_delay ~order ~suspend_SR ~version ~generation_id
     ~hardware_platform_version ~has_vendor_device ~reference_label ~domain_type
     ~nVRAM : API.ref_VM =
-  if has_vendor_device then
-    Pool_features.assert_enabled ~__context
-      ~f:Features.PCI_device_for_auto_update ;
   (* Add random mac_seed if there isn't one specified already *)
   let other_config =
     let gen_mac_seed () = Uuidx.to_string (Uuidx.make ()) in
@@ -1571,19 +1568,9 @@ let import ~__context ~url ~sr ~full_restore ~force =
 let query_services ~__context ~self:_ =
   raise Api_errors.(Server_error (not_implemented, ["query_services"]))
 
-let assert_can_set_has_vendor_device ~__context ~self ~value =
-  if
-    value
-    (* Do the check even for templates, because snapshots are templates and
-       	 * we allow restoration of a VM from a snapshot. *)
-  then
-    Pool_features.assert_enabled ~__context
-      ~f:Features.PCI_device_for_auto_update ;
-  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self
-    ~expected:`Halted
-
 let set_has_vendor_device ~__context ~self ~value =
-  assert_can_set_has_vendor_device ~__context ~self ~value ;
+  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self
+    ~expected:`Halted ;
   Db.VM.set_has_vendor_device ~__context ~self ~value ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:self
 

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -401,9 +401,6 @@ val call_plugin :
 val set_has_vendor_device :
   __context:Context.t -> self:API.ref_VM -> value:bool -> unit
 
-val assert_can_set_has_vendor_device :
-  __context:Context.t -> self:API.ref_VM -> value:bool -> unit
-
 val import :
      __context:Context.t
   -> url:string

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -244,10 +244,8 @@ let snapshot_metadata ~__context ~vm ~is_a_snapshot =
   else
     ""
 
-(* return a new VM record, in appropriate power state and having the good metrics. *)
-(* N.B. always check VM.has_vendor_device and Features.PCI_device_for_auto_update before calling this,
- * as is done before the single existing call to this function.
- * If ever we need to expose this function in the .mli file then we should do the check in the function. *)
+(* return a new VM record, in appropriate power state and having the
+   good metrics.  *)
 let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~new_power_state () =
   let all = Db.VM.get_record_internal ~__context ~self:vm in
@@ -448,13 +446,6 @@ let clone ?snapshot_info_record ?(ignore_vdis = []) disk_op ~__context ~vm
           vbds
       in
 
-      (* Check licence permission before copying disks, since the copy can take
-         a long time. We always allow snapshotting a VM, but check before
-         clone/copy of an existing snapshot or template. *)
-      if Db.VM.get_has_vendor_device ~__context ~self:vm && not is_a_snapshot
-      then
-        Pool_features.assert_enabled ~__context
-          ~f:Features.PCI_device_for_auto_update ;
       (* driver params to be passed to storage backend clone operations. *)
       let driver_params = make_driver_params () in
       (* backend cloning operations first *)

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -245,7 +245,7 @@ let snapshot_metadata ~__context ~vm ~is_a_snapshot =
     ""
 
 (* return a new VM record, in appropriate power state and having the
-   good metrics.  *)
+   good metrics. *)
 let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~new_power_state () =
   let all = Db.VM.get_record_internal ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -71,9 +71,6 @@ let set_actions_after_crash ~__context ~self ~value =
 let set_is_a_template ~__context ~self ~value =
   (* We define a 'set_is_a_template false' as 'install time' *)
   info "VM.set_is_a_template('%b')" value ;
-  if Db.VM.get_has_vendor_device ~__context ~self then
-    Pool_features.assert_enabled ~__context
-      ~f:Features.PCI_device_for_auto_update ;
   let m = Db.VM.get_metrics ~__context ~self in
   ( if not value then
       try
@@ -154,18 +151,13 @@ let update_vm_virtual_hardware_platform_version ~__context ~vm =
 
 let create_from_record_without_checking_licence_feature_for_vendor_device
     ~__context rpc session_id vm_record =
+  (* vendor device is no longer licensed *)
   let mk_vm r =
     Client.Client.VM.create_from_record ~rpc ~session_id
       ~value:{r with API.vM_suspend_VDI= Ref.null; API.vM_power_state= `Halted}
   in
   let has_vendor_device = vm_record.API.vM_has_vendor_device in
-  if
-    has_vendor_device
-    && not
-         (Pool_features.is_enabled ~__context
-            Features.PCI_device_for_auto_update
-         )
-  then (
+  if has_vendor_device then (
     (* Avoid the licence feature check which is enforced in VM.create (and create_from_record). *)
     let vm = mk_vm {vm_record with API.vM_has_vendor_device= false} in
     Db.VM.set_has_vendor_device ~__context ~self:vm ~value:true ;

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -149,23 +149,6 @@ let update_vm_virtual_hardware_platform_version ~__context ~vm =
     Db.VM.set_hardware_platform_version ~__context ~self:vm
       ~value:visibly_required_version
 
-let create_from_record_without_checking_licence_feature_for_vendor_device
-    ~__context rpc session_id vm_record =
-  (* vendor device is no longer licensed *)
-  let mk_vm r =
-    Client.Client.VM.create_from_record ~rpc ~session_id
-      ~value:{r with API.vM_suspend_VDI= Ref.null; API.vM_power_state= `Halted}
-  in
-  let has_vendor_device = vm_record.API.vM_has_vendor_device in
-  if has_vendor_device then (
-    (* Avoid the licence feature check which is enforced in VM.create (and create_from_record). *)
-    let vm = mk_vm {vm_record with API.vM_has_vendor_device= false} in
-    Db.VM.set_has_vendor_device ~__context ~self:vm ~value:true ;
-    update_vm_virtual_hardware_platform_version ~__context ~vm ;
-    vm
-  ) else
-    mk_vm vm_record
-
 let destroy ~__context ~self =
   (* Used to be a call to hard shutdown here, but this will be redundant *)
   (* given the call to 'assert_operation_valid' *)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1720,9 +1720,6 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
     try bool_of_string (List.assoc "force" options) with _ -> false
   in
   let copy = try bool_of_string (List.assoc "copy" options) with _ -> false in
-  if copy && Db.VM.get_has_vendor_device ~__context ~self:vm then
-    Pool_features.assert_enabled ~__context
-      ~f:Features.PCI_device_for_auto_update ;
   let source_host_ref =
     let host = Db.VM.get_resident_on ~__context ~self:vm in
     if host <> Ref.null then

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -553,11 +553,16 @@ let create_vm_from_snapshot ~__context ~snapshot =
     let snap_metadata = Helpers.vm_string_to_assoc snap_metadata in
     let vm_uuid = List.assoc Db_names.uuid snap_metadata in
     let snap_record = Db.VM.get_record ~__context ~self:snapshot in
+    let snap_record =
+      {
+        snap_record with
+        API.vM_suspend_VDI= Ref.null
+      ; API.vM_power_state= `Halted
+      }
+    in
     Helpers.call_api_functions ~__context (fun rpc session_id ->
         let new_vm =
-          Xapi_vm_helpers
-          .create_from_record_without_checking_licence_feature_for_vendor_device
-            ~__context rpc session_id snap_record
+          Client.VM.create_from_record ~rpc ~session_id ~value:snap_record
         in
         try
           Db.VM.set_uuid ~__context ~self:new_vm ~value:vm_uuid ;

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,7 +3,7 @@
 set -e
 
 list-hd () {
-  N=315
+  N=314
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD List.hd usages"


### PR DESCRIPTION
The API call VM.set-has-vendor-device used to be a lincensed feature but it no longer is. As a first step to simplify when Windows VMs automatically or not update device drivers, remove the license checks in the code. The feature flag still remains in place.