### PR TITLE
Yangtze Backports

### DIFF
--- a/scripts/bugtool-plugin/xapi/stuff.xml
+++ b/scripts/bugtool-plugin/xapi/stuff.xml
@@ -7,4 +7,5 @@
 <command label="diagnostic_net_stats">@BINDIR@/xe diagnostic-net-stats</command>
 <command label="host_data_source_list">@BINDIR@/xe host-data-source-list host=$(@BINDIR@/xe pool-list params=master --minimal)</command>
 <command label="sr_data_source_list">@BINDIR@/xe sr-list --minimal | tr , '\n' | xargs --verbose -n 1 -I {} @BINDIR@/xe sr-data-source-list uuid={} 2>&amp;1</command>
+<command label="save_rrd">rrd-cli save_rrds</command>
 </collect>


### PR DESCRIPTION
```
* 7b0a03793 2023-09-19 CA-374989: Avoid using get_record on cross-pool migration
* 1950c7367 2023-09-19 CA-376879: VLAN PIF created in pool.join is shown as di..
```

Please remind me if any of this requires changes in spec files - this is easy to miss.