### PR TITLE
CP-45175: Enable the OVMF debugging port by default

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -280,7 +280,7 @@ def main(argv):
     qemu_args += ["-vnc-clipboard-socket-fd", str(s1.fileno())]
     #qemu_args += ["-trace", "events=/root/trace"]
     #qemu_args += ["-monitor", "tcp:127.0.0.1:7777,server,nowait"]
-    #qemu_args += ["-chardev", "stdio,id=ovmf", "-device", "isa-debugcon,chardev=ovmf,iobase=0x402"]
+    qemu_args += ["-chardev", "stdio,id=ovmf", "-device", "isa-debugcon,chardev=ovmf,iobase=0x402"]
 
     if depriv:
         root_dir = "/var/xen/qemu/root-{}".format(domid)


### PR DESCRIPTION
Currently, getting debug messages out of OVMF requires (amongst other things) editing the qemu-wrapper script to enable the debug port. This is inconvenient. Fix this by simply always enabling it. With the current OVMF, this results in no change in the default behaviour since the release build of OVMF does not log anything though that is expected to change in the near future.