### PR TITLE
Python's XenAPI: Update metadata

### DIFF
--- a/scripts/examples/python/setup.cfg
+++ b/scripts/examples/python/setup.cfg
@@ -3,10 +3,10 @@ name = XenAPI
 description = XenAPI SDK, for communication with XenServer.
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8
-author = Citrix Systems, Inc.
+author = Xapi project developers and maintainers
 author_email = xen-api@lists.xenproject.org
 license = BSD-2-Clause
-url = https://www.citrix.com/community/citrix-developer/citrix-hypervisor-developer/
+url = https://xapi-project.github.io/
 project_urls =
     Bug Tracker = https://github.com/xapi-project/xen-api/issues
     Source Code = https://github.com/xapi-project/xen-api


### PR DESCRIPTION
Both the URL and the author were out of date, changed them both top reference the xapi project

Note: the pypi releases are broken as github stopped allowing to do secure releases on tags (yet). The fix has been promised to arrive next month