### PR TITLE
Clean up after unit test: don't leave gigabytes of files in /tmp

### DIFF
--- a/ocaml/libs/vhd/vhd_format_lwt_test/parse_test.ml
+++ b/ocaml/libs/vhd/vhd_format_lwt_test/parse_test.ml
@@ -298,12 +298,6 @@ let all_program_tests =
     programs
 
 let _ =
-  let verbose = ref false in
-  Arg.parse
-    [("-verbose", Arg.Unit (fun _ -> verbose := true), "Run in verbose mode")]
-    (fun x -> Printf.fprintf stderr "Ignoring argument: %s" x)
-    "Test vhd parser" ;
-
   let check_empty_disk size =
     Printf.sprintf "check_empty_disk_%Ld" size >:: fun () ->
     Lwt_main.run (check_empty_disk size)
@@ -344,4 +338,4 @@ let _ =
          @ List.map check_empty_snapshot sizes
          @ all_program_tests
   in
-  run_test_tt ~verbose:!verbose suite
+  run_test_tt_main suite

--- a/ocaml/libs/vhd/vhd_format_lwt_test/parse_test.ml
+++ b/ocaml/libs/vhd/vhd_format_lwt_test/parse_test.ml
@@ -40,7 +40,11 @@ let make_new_filename =
   fun () ->
     let this = !counter in
     incr counter ;
-    disk_name_stem ^ string_of_int this ^ disk_suffix
+    let name = disk_name_stem ^ string_of_int this ^ disk_suffix in
+    at_exit (fun () ->
+        try Unix.unlink name with Unix.Unix_error (_, _, _) -> ()
+    ) ;
+    name
 
 let fill_sector_with pattern =
   let b = Io_page.(to_cstruct (get 1)) in

--- a/ocaml/libs/vhd/vhd_format_lwt_test/patterns_lwt.ml
+++ b/ocaml/libs/vhd/vhd_format_lwt_test/patterns_lwt.ml
@@ -38,7 +38,11 @@ let make_new_filename =
   fun () ->
     let this = !counter in
     incr counter ;
-    disk_name_stem ^ string_of_int this ^ disk_suffix
+    let name = disk_name_stem ^ string_of_int this ^ disk_suffix in
+    at_exit (fun () ->
+        try Unix.unlink name with Unix.Unix_error (_, _, _) -> ()
+    ) ;
+    name
 
 let _fill_sector_with pattern =
   let b = Memory.alloc 512 in


### PR DESCRIPTION
`du -csh /tmp/*.vhd` has shown about 1.3GB of files, and this also caused the readonly unit test to fail:
```
[pid 1698168] openat(AT_FDCWD, "/tmp/parse_test.1.vhd", O_RDWR|O_CREAT|O_TRUNC, 0644) = -1 EACCES (Permission denied)

(* Check we respect RO-ness *)
let check_readonly () =
  let filename = make_new_filename () in
  Vhd_IO.create_dynamic ~filename ~size:0L () >>= fun vhd ->
  Vhd_IO.close vhd >>= fun () ->
  Unix.chmod filename 0o444 ;
  Vhd_IO.openchain filename false >>= fun vhd -> Vhd_IO.close vhd
```