### PR TITLE
CA-381047: Add observer capability to bugtool

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -33,10 +33,13 @@ install:
 	$(IPROG) nbd_client_manager.py $(DESTDIR)$(LIBEXECDIR)
 	mkdir -p $(DESTDIR)$(ETCXENDIR)/bugtool/xapi
 	mkdir -p $(DESTDIR)$(ETCXENDIR)/bugtool/xenopsd
+	mkdir -p $(DESTDIR)$(ETCXENDIR)/bugtool/observer
 	$(IDATA) bugtool-plugin/xapi.xml $(DESTDIR)$(ETCXENDIR)/bugtool
 	$(IDATA) bugtool-plugin/xapi/stuff.xml $(DESTDIR)$(ETCXENDIR)/bugtool/xapi
 	$(IDATA) bugtool-plugin/xenopsd.xml $(DESTDIR)$(ETCXENDIR)/bugtool
 	$(IDATA) bugtool-plugin/xenopsd/stuff.xml $(DESTDIR)$(ETCXENDIR)/bugtool/xenopsd
+	$(IDATA) bugtool-plugin/observer.xml $(DESTDIR)$(ETCXENDIR)/bugtool
+	$(IDATA) bugtool-plugin/observer/stuff.xml $(DESTDIR)$(ETCXENDIR)/bugtool/observer
 	$(IPROG) fence $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) xha-lc $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) xapi-health-check $(DESTDIR)$(LIBEXECDIR)

--- a/scripts/bugtool-plugin/observer.xml
+++ b/scripts/bugtool-plugin/observer.xml
@@ -1,0 +1,1 @@
+<capability pii="maybe" max_size="104857600" max_time="60" mime="text/plain" checked="true"/>

--- a/scripts/bugtool-plugin/observer/stuff.xml
+++ b/scripts/bugtool-plugin/observer/stuff.xml
@@ -1,0 +1,3 @@
+<collect>
+<directory label="tracing">/var/log/dt</directory>
+</collect>

--- a/scripts/bugtool-plugin/xapi/stuff.xml
+++ b/scripts/bugtool-plugin/xapi/stuff.xml
@@ -12,6 +12,5 @@
 <files>@ETCDIR@/stunnel/xapi-stunnel-ca-bundle.pem</files>
 <command label="xapi_cert">cat @ETCXENDIR@/xapi-ssl.pem | @BINDIR@/openssl x509 -text</command>
 <command label="xapi_pool_cert">cat @ETCXENDIR@/xapi-pool-tls.pem | @BINDIR@/openssl x509 -text</command>
-<directory label="tracing">/var/log/dt</directory>
 <command label="save_rrd">rrd-cli save_rrds</command>
 </collect>


### PR DESCRIPTION
Move the tracing log output to its own capability as it spans more than just xapi. This also allows the max size to be increased without increasing it for all of xapi.