### PR TITLE
Publish new Hugo-based docs

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,37 @@
+name: Generate and upload Hugo docs
+
+on:
+  push:
+    branches: master
+
+jobs:
+  ocaml:
+    name: Docs
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.119.0'
+
+      - name: Build
+        run: |
+          cd doc
+          hugo --minify
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DOCS_DEPLOY_KEY }}
+          publish_dir: ./doc/public
+          user_name: 'Github action on xapi-project/xen-api'
+          user_email: 'github-actions-xapi-project-xen-api[bot]@users.noreply.github.com'
+          external_repository: xapi-project/xapi-project.github.io
+          publish_branch: master
+          destination_dir: new-docs # temporary staging branch
+          allow_empty_commit: false
+          enable_jekyll: true # do not create .nojekyll file

--- a/doc/go.mod
+++ b/doc/go.mod
@@ -1,5 +1,5 @@
 module xapi-project.github.io
 
-go 1.21.1
+go 1.20
 
 require github.com/McShelby/hugo-theme-relearn v0.0.0-20230905210935-196188b7f3bd // indirect

--- a/doc/hugo.toml
+++ b/doc/hugo.toml
@@ -1,3 +1,4 @@
+baseURL = "https://xapi-project.github.io/new-docs/"
 languageCode = 'en-us'
 title = 'XAPI Toolstack Developer Documentation'
 disablePathToLower = true


### PR DESCRIPTION
This Github Action publishes the new Hugo-based docs from /doc to a temporary staging area at https://xapi-project.github.io/new-docs/. Eventually, this will replace the old docs on https://xapi-project.github.io. However, we are still transferring docs to the new world, which we do incrementally so that it all can be updated and reviewed again.