### PR TITLE
maintenance: update opam metadata from xs-opam

### DIFF
--- a/ezxenstore.opam
+++ b/ezxenstore.opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "jonathan.ludlam@citrix.com"
-authors: ["xen-api@lists.xensource.com"]
+maintainer: "xapi project maintainers"
+authors: ["Jonathan Ludlam"]
 license: "ISC"
-homepage: "https://github.com/xapi-project/ezxenstore"
-bug-reports: "https://github.com/xapi-project/ezxenstore/issues"
-dev-repo: "git+https://github.com/xapi-project/ezxenstore.git"
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml"

--- a/forkexec.opam
+++ b/forkexec.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 
 build: [[ "dune" "build" "-p" name "-j" jobs ]]

--- a/message-switch-async.opam
+++ b/message-switch-async.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch-cli.opam
+++ b/message-switch-cli.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch-core.opam
+++ b/message-switch-core.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch-lwt.opam
+++ b/message-switch-lwt.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch-unix.opam
+++ b/message-switch-unix.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/message-switch.opam
+++ b/message-switch.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [
   ["./configure" "--prefix" "%{prefix}%"]

--- a/rrdd-plugin.opam
+++ b/rrdd-plugin.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/rrdd-plugins.opam
+++ b/rrdd-plugins.opam
@@ -5,7 +5,7 @@ authors: [ "xs-devel@lists.xenserver.org" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 synopsis: "Plugins registering to the RRD daemon and exposing various metrics"
 depends: [

--- a/vhd-tool.opam
+++ b/vhd-tool.opam
@@ -21,7 +21,6 @@ depends: [
   "io-page"
   "lwt"
   "nbd-unix"
-  "ocaml-migrate-parsetree"
   "ppx_cstruct"
   "ppx_deriving_rpc"
   "re"

--- a/xapi-datamodel.opam
+++ b/xapi-datamodel.opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "mustache"
-  "ocaml-migrate-parsetree"
   "ppx_deriving_rpc"
   "rpclib"
   "base-threads"

--- a/xapi-expiry-alerts.opam
+++ b/xapi-expiry-alerts.opam
@@ -1,18 +1,18 @@
 opam-version: "2.0"
+name: "xapi-expiry-alerts"
+synopsis: "A library to send expiration-related alerts and removing outdated ones"
+description: """\
+The interface of this library is 'alert', upon calling this API, any
+existing outdated messages will be removed first, and a new message
+will be created only if it does not exist in Xapi.Message records
+yet."""
 maintainer: "xen-api@lists.xen.org"
 authors: [ "Pau Ruiz Safont" "Gang Ji" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
-dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-tags: [
-  "org:xapi-project"
-]
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
 depends: [
+  "alcotest" {with-test}
   "ocaml"
   "dune"
   "astring"
@@ -20,10 +20,12 @@ depends: [
   "xapi-consts"
   "xapi-types"
   "xapi-stdext-date"
-  "alcotest" {with-test}
 ]
-synopsis:
-  "Xen-API client library for sending expiry alerts and removing outdated ones"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 url {
   src: "https://github.com/xapi-project/xen-api/archive/master.tar.gz"
 }

--- a/xapi-forkexecd.opam
+++ b/xapi-forkexecd.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 
 build: [

--- a/xapi-idl.opam
+++ b/xapi-idl.opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
 authors: "Dave Scott"
-homepage: "https://github.com/xapi-project/xcp-idl"
-bug-reports: "https://github.com/xapi-project/xcp-idl/issues"
-dev-repo: "https://github.com/xapi-project/xcp-idl.git"
-maintainer: "xen-api@lists.xen.org"
+homepage: "https://github.com/xapi-project/xen-api"
+bug-reports: "https://github.com/xapi-project/xen-api/issues"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
+maintainer: "xapi project maintainers"
 tags: [ "org:xapi-project" ]
 build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
@@ -22,7 +22,6 @@ depends: [
   "message-switch-core"
   "message-switch-unix"
   "mtime"
-  "ocaml-migrate-parsetree"
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "re"

--- a/xapi-rrdd-plugin.opam
+++ b/xapi-rrdd-plugin.opam
@@ -3,7 +3,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 depends: ["ocaml" "rrdd-plugin"]
 synopsis: "A plugin library for the xapi performance monitoring daemon"
 description: """

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -24,7 +24,6 @@ depends: [
   "ezxenstore"
   "uuid"
   "xapi-backtrace"
-  "xapi-consts"
   "xapi-idl"
   "xapi-rrd"
   "xapi-rrd-transport"

--- a/xapi-squeezed.opam
+++ b/xapi-squeezed.opam
@@ -3,7 +3,7 @@ author: "dave.scott@eu.citrix.com"
 maintainer: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}

--- a/xapi-storage-script.opam
+++ b/xapi-storage-script.opam
@@ -5,7 +5,7 @@ authors: [ "xen-api@lists.xen.org" ]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xen-api"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 tags: [ "org:xapi-project" ]
 build: [[ "dune" "build" "-p" name "-j" jobs ]]
 depends: [

--- a/xapi-storage.opam
+++ b/xapi-storage.opam
@@ -4,7 +4,7 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
-dev-repo: "https://github.com/xapi-project/xen-api.git"
+dev-repo: "git+https://github.com/xapi-project/xen-api.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/xapi-tracing.opam
+++ b/xapi-tracing.opam
@@ -17,6 +17,7 @@ depends: [
   "xapi-open-uri"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
+  "zstd"
 ]
 synopsis: "Library required by xapi"
 description: """

--- a/xapi-types.opam
+++ b/xapi-types.opam
@@ -13,7 +13,6 @@ depends: [
   "ocaml"
   "dune" {build & >= "1.4"}
   "astring"
-  "ocaml-migrate-parsetree"
   "ppx_deriving_rpc"
   "rpclib"
   "sexpr"

--- a/xapi.opam
+++ b/xapi.opam
@@ -29,7 +29,6 @@ depends: [
   "mirage-crypto-rng" {with-test}
   "message-switch-unix"
   "mtime"
-  "ocaml-migrate-parsetree"
   "opentelemetry-client-ocurl"
   "pci"
   "pciutil"


### PR DESCRIPTION
In particular fixes a lot of errors caused by the incorrect format of the 'dev' pseudo-urls