### PR TITLE
Do not fetch random SR in empty list

### DIFF
--- a/ocaml/quicktest/qt_filter.ml
+++ b/ocaml/quicktest/qt_filter.ml
@@ -198,8 +198,11 @@ module SR = struct
 
   let random srs () =
     let srs = srs () in
-    let index = Random.int @@ List.length srs in
-    [List.nth srs index]
+    if srs = [] then
+      []
+    else
+      let index = Random.int @@ List.length srs in
+      [List.nth srs index]
 
   let sr_filter f srs () = List.filter f (srs ())
 


### PR DESCRIPTION
When looking for a random SR in an empty list,
quicktest can call `Random.int 0` which will throw. Instead return an empty list.
Instead of throwing, the test won't be passed as there is no compatible SR.

This can happen when calling quickest with the `-sr` on ISO SR.