### PR TITLE
CP-45703: jemalloc: avoid bottlenecks with C threads

### DIFF
--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -20,7 +20,7 @@ Conflicts=shutdown.target
 [Service]
 User=root
 Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
-Environment="MALLOC_CONF=narenas:1,tcache:false,lg_dirty_mult:22"
+Environment="MALLOC_CONF=narenas:1,tcache:true,lg_dirty_mult:22"
 Type=simple
 Restart=on-failure
 ExecStart=@LIBEXECDIR@/xapi-init start


### PR DESCRIPTION
Current default jemalloc settings:
```
╭──────────────────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                  │  minor-allocated          │  monotonic clock/op       │
├──────────────────────────────────────┼───────────────────────────┼───────────────────────────┤
│  concurrent semaphore + sleep fix:1  │            14.4615 mnw/run│          40.7085 ms/op/run│
│  concurrent semaphore + sleep fix:8  │            76.0000 mnw/run│          39.6229 ms/op/run│
╰──────────────────────────────────────┴───────────────────────────┴───────────────────────────╯
```

A flamegraph shows that 'sha512_crypt_r' spends >90% of time in jemalloc and not on hashing.

With 'tcache:true'
```
╭──────────────────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                  │  minor-allocated          │  monotonic clock/op       │
├──────────────────────────────────────┼───────────────────────────┼───────────────────────────┤
│  concurrent semaphore + sleep fix:1  │            10.1538 mnw/run│           1.6766 ms/op/run│
│  concurrent semaphore + sleep fix:8  │            67.3600 mnw/run│           0.4431 ms/op/run│
╰──────────────────────────────────────┴───────────────────────────┴───────────────────────────╯
```

Without jemalloc:
```
╭──────────────────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                  │  minor-allocated          │  monotonic clock/op       │
├──────────────────────────────────────┼───────────────────────────┼───────────────────────────┤
│  concurrent semaphore + sleep fix:1  │            10.0488 mnw/run│           1.5649 ms/op/run│
│  concurrent semaphore + sleep fix:8  │            67.1111 mnw/run│           0.3858 ms/op/run│
╰──────────────────────────────────────┴───────────────────────────┴───────────────────────────╯
```

Draft PR, need to measure impact on memory usage (and add a ticket number).