### PR TITLE
Choose size of batch VM evacuation

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -356,6 +356,7 @@ let evacuate =
       [
         (Published, rel_miami, "")
       ; (Extended, "1.297.0", "Enable migration network selection.")
+      ; (Extended, "23.27.0", "Choose batch size of VM evacuation.")
       ]
     ~versioned_params:
       [
@@ -372,6 +373,15 @@ let evacuate =
         ; param_doc= "Optional preferred network for migration"
         ; param_release= next_release
         ; param_default= Some (VRef null_ref)
+        }
+      ; {
+          param_type= Int
+        ; param_name= "evacuate_batch_size"
+        ; param_doc=
+            "The maximum number of VMs to be migrated per batch 0 will use the \
+             value `evacuation-batch-size` defined in xapi.conf"
+        ; param_release= next_release
+        ; param_default= Some (VInt 0L)
         }
       ]
     ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -5327,6 +5327,7 @@ let host_evacuate _printer rpc session_id params =
     (do_host_op rpc session_id ~multiple:false
        (fun _ host ->
          Client.Host.evacuate ~rpc ~session_id ~host:(host.getref ()) ~network
+           ~evacuate_batch_size:0L
        )
        params ["network-uuid"]
     )

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3387,14 +3387,14 @@ functor
           (host_uuid ~__context self) ;
         Local.Host.get_vms_which_prevent_evacuation ~__context ~self
 
-      let evacuate ~__context ~host ~network =
+      let evacuate ~__context ~host ~network ~evacuate_batch_size =
         info "Host.evacuate: host = '%s'" (host_uuid ~__context host) ;
         (* Block call if this would break our VM restart plan (because the body of this sets enabled to false) *)
         Xapi_ha_vm_failover.assert_host_disable_preserves_ha_plan ~__context
           host ;
         Xapi_host_helpers.with_host_operation ~__context ~self:host
           ~doc:"Host.evacuate" ~op:`evacuate (fun () ->
-            Local.Host.evacuate ~__context ~host ~network
+            Local.Host.evacuate ~__context ~host ~network ~evacuate_batch_size
         )
 
       let retrieve_wlb_evacuate_recommendations ~__context ~self =

--- a/ocaml/xapi/vm_evacuation.ml
+++ b/ocaml/xapi/vm_evacuation.ml
@@ -63,7 +63,10 @@ let ensure_no_vms ~__context ~rpc ~session_id ~evacuate_timeout =
         estimate_evacuate_timeout ~__context ~host
     in
     let tasks =
-      [Client.Async.Host.evacuate ~rpc ~session_id ~host ~network:Ref.null]
+      [
+        Client.Async.Host.evacuate ~rpc ~session_id ~host ~network:Ref.null
+          ~evacuate_batch_size:0L
+      ]
     in
     if not (Tasks.with_tasks_destroy ~rpc ~session_id ~timeout ~tasks) then
       get_running_domains () |> List.iter cancel_vm_tasks

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -607,7 +607,7 @@ let compute_evacuation_plan ~__context ~host =
            Using original algorithm" ;
         compute_evacuation_plan_no_wlb ~__context ~host ()
 
-let evacuate ~__context ~host ~network =
+let evacuate ~__context ~host ~network ~evacuate_batch_size =
   let plans = compute_evacuation_plan ~__context ~host in
   let plans_length = float (Hashtbl.length plans) in
   (* Check there are no errors in this list *)
@@ -708,8 +708,15 @@ let evacuate ~__context ~host ~network =
     TaskHelper.set_progress ~__context 1.0
   in
 
+  let batch_size =
+    match evacuate_batch_size with
+    | size when size > 0L ->
+        Int64.to_int size
+    | _ ->
+        !Xapi_globs.evacuation_batch_size
+  in
   (* avoid edge cases from meaningless batch sizes *)
-  let batch_size = Int.(max 1 (abs !Xapi_globs.evacuation_batch_size)) in
+  let batch_size = Int.(max 1 (abs batch_size)) in
   info "Host.evacuate: migrating VMs in batches of %d" batch_size ;
 
   (* execute evacuation plan in batches *)

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -64,7 +64,11 @@ val get_vms_which_prevent_evacuation_internal :
   -> (API.ref_VM * string list) list
 
 val evacuate :
-  __context:Context.t -> host:API.ref_host -> network:API.ref_network -> unit
+     __context:Context.t
+  -> host:API.ref_host
+  -> network:API.ref_network
+  -> evacuate_batch_size:int64
+  -> unit
 
 val retrieve_wlb_evacuate_recommendations :
   __context:Context.t -> self:API.ref_host -> (API.ref_VM * string list) list


### PR DESCRIPTION
New optional argument to `Host.evacuate`: `evacuate_batch_size` When provided uses it instead of `xapi.conf`'s `evacuation_batch_size` When not provided uses the `xapi.conf` option

Fixes: https://github.com/xapi-project/xen-api/issues/5202