### PR TITLE
CP-43901: Block pool member startup if it has a higher xapi version

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -720,6 +720,9 @@ let _ =
        the coordinator's database and pointing to the correct coordinator? Are \
        all servers using the same pool secret?"
     () ;
+  error Api_errors.host_xapi_version_higher_than_coordinator
+    ["host_xapi_version"]
+    ~doc:"The host xapi version is higher than the one in the coordinator" () ;
   error Api_errors.host_broken []
     ~doc:
       "This server failed in the middle of an automatic failover operation and \

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -95,6 +95,7 @@ let local_assert_healthy =
       ; Api_errors.license_restriction
       ; Api_errors.license_does_not_support_pooling
       ; Api_errors.ha_should_be_fenced
+      ; Api_errors.host_xapi_version_higher_than_coordinator
       ]
     ~allowed_roles:_R_LOCAL_ROOT_ONLY ()
 

--- a/ocaml/util/xapi_version.ml
+++ b/ocaml/util/xapi_version.ml
@@ -43,3 +43,27 @@ let version, xapi_version_major, xapi_version_minor, git_id =
              version
           )
     )
+
+let compare_version version_a version_b =
+  let maj_a, min_a, _ =
+    try Scanf.sscanf version_a "%d.%d.%s" (fun maj min rest -> (maj, min, rest))
+    with _ ->
+      failwith
+        (Printf.sprintf "Couldn't determine xapi version for version_a: '%s'"
+           version_a
+        )
+  in
+  let maj_b, min_b, _ =
+    try Scanf.sscanf version_b "%d.%d.%s" (fun maj min rest -> (maj, min, rest))
+    with _ ->
+      failwith
+        (Printf.sprintf "Couldn't determine xapi version for version_b: '%s'"
+           version_b
+        )
+  in
+  if maj_a > maj_b || (maj_a = maj_b && min_a > min_b) then
+    1
+  else if maj_a = maj_b && min_a = min_b then
+    0
+  else
+    -1

--- a/ocaml/util/xapi_version.ml
+++ b/ocaml/util/xapi_version.ml
@@ -44,9 +44,5 @@ let version, xapi_version_major, xapi_version_minor, git_id =
 let compare_version version_a version_b =
   let maj_a, min_a, _ = parse_xapi_version version_a in
   let maj_b, min_b, _ = parse_xapi_version version_b in
-  if maj_a > maj_b || (maj_a = maj_b && min_a > min_b) then
-    1
-  else if maj_a = maj_b && min_a = min_b then
-    0
-  else
-    -1
+  let ( <?> ) a b = if a = 0 then b else a in
+  Int.compare maj_a maj_b <?> Int.compare min_a min_b <?> 0

--- a/ocaml/util/xapi_version.ml
+++ b/ocaml/util/xapi_version.ml
@@ -18,11 +18,19 @@ let hostname = "localhost"
 
 let date = Xapi_build_info.date
 
+let parse_xapi_version version =
+  try Scanf.sscanf version "%d.%d.%s" (fun maj min rest -> (maj, min, rest))
+  with _ ->
+    failwith
+      (Printf.sprintf "Couldn't determine xapi version from string: '%s'"
+         version
+      )
+
 let version, xapi_version_major, xapi_version_minor, git_id =
   match Build_info.V1.version () with
   | None ->
       ("0.0.dev", 0, 0, "dev")
-  | Some v -> (
+  | Some v ->
       let str = Build_info.V1.Version.to_string v in
       let version =
         if String.starts_with ~prefix:"v" str then
@@ -30,37 +38,12 @@ let version, xapi_version_major, xapi_version_minor, git_id =
         else
           str
       in
-      try
-        let maj, min, git_id =
-          Scanf.sscanf version "%d.%d.%s" (fun maj min rest -> (maj, min, rest))
-        in
-        (version, maj, min, git_id)
-      with _ ->
-        failwith
-          (Printf.sprintf
-             "Couldn't determine xapi version - got unexpected version from \
-              dune: '%s'"
-             version
-          )
-    )
+      let maj, min, git_id = parse_xapi_version version in
+      (version, maj, min, git_id)
 
 let compare_version version_a version_b =
-  let maj_a, min_a, _ =
-    try Scanf.sscanf version_a "%d.%d.%s" (fun maj min rest -> (maj, min, rest))
-    with _ ->
-      failwith
-        (Printf.sprintf "Couldn't determine xapi version for version_a: '%s'"
-           version_a
-        )
-  in
-  let maj_b, min_b, _ =
-    try Scanf.sscanf version_b "%d.%d.%s" (fun maj min rest -> (maj, min, rest))
-    with _ ->
-      failwith
-        (Printf.sprintf "Couldn't determine xapi version for version_b: '%s'"
-           version_b
-        )
-  in
+  let maj_a, min_a, _ = parse_xapi_version version_a in
+  let maj_b, min_b, _ = parse_xapi_version version_b in
   if maj_a > maj_b || (maj_a = maj_b && min_a > min_b) then
     1
   else if maj_a = maj_b && min_a = min_b then

--- a/ocaml/util/xapi_version.mli
+++ b/ocaml/util/xapi_version.mli
@@ -23,3 +23,5 @@ val git_id : string
 val xapi_version_major : int
 
 val xapi_version_minor : int
+
+val compare_version : string -> string -> int

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -143,6 +143,9 @@ let host_master_cannot_talk_back = "HOST_MASTER_CANNOT_TALK_BACK"
 
 let host_unknown_to_master = "HOST_UNKNOWN_TO_MASTER"
 
+let host_xapi_version_higher_than_coordinator =
+  "HOST_XAPI_VERSION_HIGHER_THAN_COORDINATOR"
+
 (* should be fenced *)
 let host_broken = "HOST_BROKEN"
 

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -355,6 +355,3 @@ let tls_verification_emergency_disabled =
   addMessage "TLS_VERIFICATION_EMERGENCY_DISABLED" 3L
 
 let periodic_update_sync_failed = addMessage "PERIODIC_UPDATE_SYNC_FAILED" 3L
-
-let xapi_startup_blocked_as_version_higher_than_coordinator =
-  addMessage "XAPI_STARTUP_BLOCKED_AS_VERSION_HIGHER_THAN_COORDINATOR" 1L

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -355,3 +355,6 @@ let tls_verification_emergency_disabled =
   addMessage "TLS_VERIFICATION_EMERGENCY_DISABLED" 3L
 
 let periodic_update_sync_failed = addMessage "PERIODIC_UPDATE_SYNC_FAILED" 3L
+
+let xapi_startup_blocked_as_version_higher_than_coordinator =
+  addMessage "XAPI_STARTUP_BLOCKED_AS_VERSION_HIGHER_THAN_COORDINATOR" 1L

--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -355,3 +355,6 @@ let tls_verification_emergency_disabled =
   addMessage "TLS_VERIFICATION_EMERGENCY_DISABLED" 3L
 
 let periodic_update_sync_failed = addMessage "PERIODIC_UPDATE_SYNC_FAILED" 3L
+
+let xapi_startup_blocked_as_version_higher_than_coordinator =
+  addMessage "XAPI_STARTUP_BLOCKED_AS_VERSION_HIGHER_THAN_COORDINATOR" 2L

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -465,11 +465,9 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
                   ~self:(Helpers.get_localhost ~__context)
               in
               let err_msg =
-                "Xapi startup in pool member "
-                ^ name_label
-                ^ " is blocked as its xapi version("
-                ^ Xapi_version.version
-                ^ ") is higher than xapi version in pool coordinator."
+                Printf.sprintf "Xapi startup in pool member %s is blocked as its xapi version \
+                  (%s) is higher than xapi version in pool coordinator."
+                  name_label Xapi_version.version
               in
               if not !xapi_ver_high_alerted then (
                 let name, priority =

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -479,7 +479,6 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
                     Api_messages
                     .xapi_startup_blocked_as_version_higher_than_coordinator
                   in
-                  debug "xapi version NOT ok, send alert" ;
                   ignore
                     (Client.Client.Message.create ~rpc ~session_id ~name
                        ~priority ~cls:`Host ~obj_uuid
@@ -498,7 +497,6 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
             ) else (
               existing_alerts
               |> List.iter (fun (self, _) ->
-                     debug "xapi version ok, remove existing_alerts" ;
                      Client.Client.Message.destroy ~rpc ~session_id ~self
                  ) ;
               None

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -503,7 +503,8 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
       Xapi_host.set_emergency_mode_error code params ;
       Some Temporary
   | exn ->
-      debug "Caught exception: %s in attempt_host_status_check_with_coordinator"
+      debug "Caught exception: %s in %s"
+        (ExnHelper.string_of_exn exn) __FUNCTION__ ;
         (ExnHelper.string_of_exn exn) ;
       Xapi_host.set_emergency_mode_error Api_errors.internal_error
         [ExnHelper.string_of_exn exn] ;

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -449,14 +449,17 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
               [localhost_uuid] ;
             Some Permanent
         | `ok ->
-            let compare_xapi_version_with_coordinator ~__context =
-              Xapi_version.compare_version Xapi_version.version
+            let xapi_version_higher version =
+              version |> Xapi_version.compare_version Xapi_version.version
+              |> fun r -> r > 0
+            in
+            if
+              xapi_version_higher
                 (Db.Host.get_software_version ~__context
                    ~self:(Helpers.get_master ~__context)
                 |> List.assoc "xapi_build"
                 )
-            in
-            if compare_xapi_version_with_coordinator ~__context > 0 then (
+            then (
               if not !xapi_ver_high_alerted then (
                 let name_label =
                   Db.Host.get_name_label ~__context

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -423,70 +423,6 @@ type host_status_check_error =
 
 (* some glitch or other *)
 
-(** Attempt checking host status with pool coordinator:
- *  1. Pool.hello
- *  2. if Pool.hello ok, check xapi version
- *  Return None if ok or Some host_status_check_error otherwise *)
-let attempt_host_status_check_with_coordinator ~__context my_ip =
-  let localhost_uuid = Helpers.get_localhost_uuid () in
-  try
-    Helpers.call_emergency_mode_functions (Pool_role.get_master_address ())
-      (fun rpc session_id ->
-        match
-          Client.Client.Pool.hello ~rpc ~session_id ~host_uuid:localhost_uuid
-            ~host_address:my_ip
-        with
-        | `cannot_talk_back ->
-            error "Master claims he cannot talk back to us on IP: %s" my_ip ;
-            Xapi_host.set_emergency_mode_error
-              Api_errors.host_master_cannot_talk_back [my_ip] ;
-            Some Temporary
-        | `unknown_host ->
-            debug "Master claims he has no record of us being a slave" ;
-            Xapi_host.set_emergency_mode_error Api_errors.host_unknown_to_master
-              [localhost_uuid] ;
-            Some Permanent
-        | `ok ->
-            let compare_xapi_version_with_coordinator ~__context =
-              let coordinator_ref = Helpers.get_master ~__context in
-              let coordinator_xapi_ver =
-                Db.Host.get_software_version ~__context ~self:coordinator_ref
-                |> List.assoc "xapi_build"
-              in
-              Xapi_version.compare_version Xapi_version.version
-                coordinator_xapi_ver
-            in
-            if compare_xapi_version_with_coordinator ~__context > 0 then (
-              error
-                "Xapi version in the host is higher than the one in coordinator" ;
-              Xapi_host.set_emergency_mode_error
-                Api_errors.host_xapi_version_higher_than_coordinator
-                [Xapi_version.version] ;
-              Some Permanent
-            ) else
-              None
-    )
-  with
-  | Api_errors.Server_error (code, _)
-    when code = Api_errors.session_authentication_failed ->
-      debug
-        "Master did not recognise our pool secret: we must be pointing at the \
-         wrong master." ;
-      Xapi_host.set_emergency_mode_error Api_errors.host_unknown_to_master
-        [localhost_uuid] ;
-      Some Permanent
-  | Api_errors.Server_error (code, params) as exn ->
-      debug "Caught exception: %s in attempt_host_status_check_with_coordinator"
-        (ExnHelper.string_of_exn exn) ;
-      Xapi_host.set_emergency_mode_error code params ;
-      Some Temporary
-  | exn ->
-      debug "Caught exception: %s in attempt_host_status_check_with_coordinator"
-        (ExnHelper.string_of_exn exn) ;
-      Xapi_host.set_emergency_mode_error Api_errors.internal_error
-        [ExnHelper.string_of_exn exn] ;
-      Some Temporary
-
 (** Bring up the HA system if configured *)
 let start_ha () =
   try Xapi_ha.on_server_restart ()
@@ -1149,12 +1085,118 @@ let server_init () =
             Helpers.touch_file !Xapi_globs.ready_file ;
             (* Keep trying to log into master *)
             let finished = ref false in
+            let xapi_ver_high_alerted = ref false in
+
             while not !finished do
               (* Grab the management IP address (wait forever for it if necessary) *)
               let ip = wait_for_management_ip_address ~__context in
               debug "Start master_connection watchdog" ;
               ignore (Master_connection.start_master_connection_watchdog ()) ;
               debug "Attempting to communicate with master" ;
+
+              (* Attempt checking host status with pool coordinator:
+               * 1. Pool.hello
+               * 2. if Pool.hello ok, check xapi version
+               * Return None if ok or Some host_status_check_error otherwise *)
+              let attempt_host_status_check_with_coordinator ~__context my_ip =
+                let localhost_uuid = Helpers.get_localhost_uuid () in
+                try
+                  Helpers.call_emergency_mode_functions
+                    (Pool_role.get_master_address ()) (fun rpc session_id ->
+                      match
+                        Client.Client.Pool.hello ~rpc ~session_id
+                          ~host_uuid:localhost_uuid ~host_address:my_ip
+                      with
+                      | `cannot_talk_back ->
+                          error
+                            "Master claims he cannot talk back to us on IP: %s"
+                            my_ip ;
+                          Xapi_host.set_emergency_mode_error
+                            Api_errors.host_master_cannot_talk_back [my_ip] ;
+                          Some Temporary
+                      | `unknown_host ->
+                          debug
+                            "Master claims he has no record of us being a slave" ;
+                          Xapi_host.set_emergency_mode_error
+                            Api_errors.host_unknown_to_master [localhost_uuid] ;
+                          Some Permanent
+                      | `ok ->
+                          let compare_xapi_version_with_coordinator ~__context =
+                            let coordinator_ref =
+                              Helpers.get_master ~__context
+                            in
+                            let coordinator_xapi_ver =
+                              Db.Host.get_software_version ~__context
+                                ~self:coordinator_ref
+                              |> List.assoc "xapi_build"
+                            in
+                            Xapi_version.compare_version Xapi_version.version
+                              coordinator_xapi_ver
+                          in
+                          if
+                            compare_xapi_version_with_coordinator ~__context > 0
+                          then (
+                            if not !xapi_ver_high_alerted then (
+                              let name_label =
+                                Db.Host.get_name_label ~__context
+                                  ~self:(Helpers.get_localhost ~__context)
+                              in
+                              let name, priority =
+                                Api_messages
+                                .xapi_startup_blocked_as_version_higher_than_coordinator
+                              in
+                              ignore
+                                (Client.Client.Message.create ~rpc ~session_id
+                                   ~name ~priority ~cls:`Host
+                                   ~obj_uuid:localhost_uuid
+                                   ~body:
+                                     ("Xapi startup in pool member "
+                                     ^ name_label
+                                     ^ " is blocked as its xapi version("
+                                     ^ Xapi_version.version
+                                     ^ ") is higher than xapi version in pool \
+                                        coordinator."
+                                     )
+                                ) ;
+                              xapi_ver_high_alerted := true
+                            ) ;
+                            error
+                              "Xapi version in the host(%s) is higher than the \
+                               one in coordinator"
+                              Xapi_version.version ;
+                            Xapi_host.set_emergency_mode_error
+                              Api_errors
+                              .host_xapi_version_higher_than_coordinator
+                              [Xapi_version.version] ;
+                            Some Permanent
+                          ) else
+                            None
+                  )
+                with
+                | Api_errors.Server_error (code, _)
+                  when code = Api_errors.session_authentication_failed ->
+                    debug
+                      "Master did not recognise our pool secret: we must be \
+                       pointing at the wrong master." ;
+                    Xapi_host.set_emergency_mode_error
+                      Api_errors.host_unknown_to_master [localhost_uuid] ;
+                    Some Permanent
+                | Api_errors.Server_error (code, params) as exn ->
+                    debug
+                      "Caught exception: %s in \
+                       attempt_host_status_check_with_coordinator"
+                      (ExnHelper.string_of_exn exn) ;
+                    Xapi_host.set_emergency_mode_error code params ;
+                    Some Temporary
+                | exn ->
+                    debug
+                      "Caught exception: %s in \
+                       attempt_host_status_check_with_coordinator"
+                      (ExnHelper.string_of_exn exn) ;
+                    Xapi_host.set_emergency_mode_error Api_errors.internal_error
+                      [ExnHelper.string_of_exn exn] ;
+                    Some Temporary
+              in
               (* Try to check host status with the pool *)
               match
                 attempt_host_status_check_with_coordinator ~__context ip

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -465,8 +465,10 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
                   ~self:(Helpers.get_localhost ~__context)
               in
               let err_msg =
-                Printf.sprintf "Xapi startup in pool member %s is blocked as its xapi version \
-                  (%s) is higher than xapi version in pool coordinator."
+                Printf.sprintf
+                  "Xapi startup in pool member %s is blocked as its xapi \
+                   version (%s) is higher than xapi version in pool \
+                   coordinator."
                   name_label Xapi_version.version
               in
               if not !xapi_ver_high_alerted then (
@@ -499,13 +501,14 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
       Some Permanent
   | Api_errors.Server_error (code, params) as exn ->
       debug "Caught exception: %s in %s"
-        (ExnHelper.string_of_exn exn) __FUNCTION__ ;
+        (ExnHelper.string_of_exn exn)
+        __FUNCTION__ ;
       Xapi_host.set_emergency_mode_error code params ;
       Some Temporary
   | exn ->
       debug "Caught exception: %s in %s"
-        (ExnHelper.string_of_exn exn) __FUNCTION__ ;
-        (ExnHelper.string_of_exn exn) ;
+        (ExnHelper.string_of_exn exn)
+        __FUNCTION__ ;
       Xapi_host.set_emergency_mode_error Api_errors.internal_error
         [ExnHelper.string_of_exn exn] ;
       Some Temporary

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -498,8 +498,8 @@ let attempt_host_status_check_with_coordinator ~__context my_ip =
         [localhost_uuid] ;
       Some Permanent
   | Api_errors.Server_error (code, params) as exn ->
-      debug "Caught exception: %s in attempt_host_status_check_with_coordinator"
-        (ExnHelper.string_of_exn exn) ;
+      debug "Caught exception: %s in %s"
+        (ExnHelper.string_of_exn exn) __FUNCTION__ ;
       Xapi_host.set_emergency_mode_error code params ;
       Some Temporary
   | exn ->


### PR DESCRIPTION
During pool upgrade, it is expected that pool coordinator needs to be updated first, and a new xapi should start on the coordinator before it starts on any other host in the pool. Otherwise it is dangerous and may cause unpredictable problem.

This commit is to block pool member startup if it has a higher xapi version than coordinator until coordinator has a equal or higher version of xapi running.