### PR TITLE
xapi.conf: match the default value for override-uefi-certs

### DIFF
--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -83,7 +83,7 @@ igd-passthru-vendor-whitelist = 8086
 
 # Override the default location of RPM-provided certificates in default_auth_dir (/usr/share/varstored)
 # to force use of customised UEFI certificates in varstore_dir (/var/lib/varstored)
-# override-uefi-certs = true
+# override-uefi-certs = false
 
 # Paths to utilities: ############################################
 


### PR DESCRIPTION
The current commented value suggests that the default value is true, but the default is actually false.