### PR TITLE
CP-40123: encode the dumped JSON in rrdd as utf-8

### DIFF
--- a/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
@@ -305,7 +305,7 @@ class API(object):
             combined.update(ds.metadata)
 
         metadata = {"datasources": combined}
-        metadata_json = json.dumps(metadata, sort_keys=True)
+        metadata_json = json.dumps(metadata, sort_keys=True).encode('utf-8')
         metadata_checksum = crc32(metadata_json) & 0xffffffff
 
         self.dest.seek(0)
@@ -320,7 +320,7 @@ class API(object):
             self.dest.write(val)
 
         self.dest.write(pack(">L", len(metadata_json)))
-        self.dest.write(metadata_json.encode())
+        self.dest.write(metadata_json)
         self.dest.flush()
         self.datasources = []
         time.sleep(


### PR DESCRIPTION
Python3 wants the input to crc32 to be byteslike, the content of the metadata should be essentially ascii anyway so encoding as utf-8 should not make any functional difference. Test with python2 as well and the results for a given input are the same with or without the encode.