### PR TITLE
Fix suspend-image-viewer binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ install: build doc sdk doc-json
 # ocaml/perftest
 	scripts/install.sh 755 _build/install/default/bin/perftest $(DESTDIR)$(OPTDIR)/debug/perftest
 # ocaml/suspend-image-viewer
-	scripts/install.sh 755 _build/install/default/bin/perftest $(DESTDIR)$(OPTDIR)/debug/suspend-image-viewer
+	scripts/install.sh 755 _build/install/default/bin/suspend-image-viewer $(DESTDIR)$(OPTDIR)/debug/suspend-image-viewer
 # ocaml/mpathalert
 	scripts/install.sh 755 _build/install/default/bin/mpathalert $(DESTDIR)$(OPTDIR)/bin/mpathalert
 # ocaml/license


### PR DESCRIPTION
Fixes: a5e99ec2f ("Install suspend_image_viewer")

I tried to use 'suspend-image-viewer' from the new XAPI package, but it was something completely different.
Apparently I made a copy+paste error in the install rules and installed `perftest` under the name `suspend-image-viewer`. We should really use dune to install all these, but fixing that is for another time, for now fix just the copy+paste error.