### PR TITLE
CA-365059: Clear messages in source pool after migrating VM

### DIFF
--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -817,13 +817,15 @@ let handler (req : Http.Request.t) fd _ =
           (ExnHelper.string_of_exn e)
   )
 
-(* Export messages and send to another host/pool over http. *)
-let send_messages ~__context ~cls ~obj_uuid ~session_id ~remote_address =
-  let msgs = get ~__context ~cls ~obj_uuid ~since:(Date.of_float 0.0) in
-  let body = export_xml msgs in
+(* Export and send messages stored on the current host to another host/pool over http. *)
+let send_messages ~__context ~cls ~obj_uuid ~session_id ~remote_address
+    ~messages =
+  let body = export_xml messages in
   let query =
     [
-      ("session_id", Ref.string_of session_id); ("cls", "VM"); ("uuid", obj_uuid)
+      ("session_id", Ref.string_of session_id)
+    ; ("cls", Record_util.class_to_string cls)
+    ; ("uuid", obj_uuid)
     ]
   in
   let subtask_of = Context.string_of_task __context in

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1603,8 +1603,15 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
         XenAPI.VM.set_ha_always_run ~rpc:remote.rpc ~session_id:remote.session
           ~self:new_vm ~value:true ;
       (* Send non-database metadata *)
-      Xapi_message.send_messages ~__context ~cls:`VM ~obj_uuid:vm_uuid
+      let messages =
+        Xapi_message.get ~__context ~cls:`VM ~obj_uuid:vm_uuid
+          ~since:(Date.of_float 0.0)
+      in
+      Xapi_message.send_messages ~__context ~cls:`VM ~obj_uuid:vm_uuid ~messages
         ~session_id:remote.session ~remote_address:remote.remote_master_ip ;
+      (* CA-365059: Remove messages since they've already been copied to the destination pool *)
+      let message_refs = List.rev_map fst messages in
+      Xapi_message.destroy_many ~__context ~messages:message_refs ;
       Xapi_blob.migrate_push ~__context ~rpc:remote.rpc
         ~remote_address:remote.remote_master_ip ~session_id:remote.session
         ~old_vm:vm ~new_vm


### PR DESCRIPTION
please be nit picky! 😁

tested using migration of w10 VM between 2 standalone hosts.
______

So while making this change I noticed we only move (and now clear) messages connected to the VM.

We are **not** doing the same for messages connected to other objects (such as VDIs). Is this something we should add?