### PR TITLE
xapi-types/ref: optimize of_string for real references 

### DIFF
--- a/ocaml/xapi-types/ref.ml
+++ b/ocaml/xapi-types/ref.ml
@@ -135,3 +135,5 @@ let really_pretty_and_small x =
       "O:" ^ Astring.String.with_range ~len:12 x
   | Null ->
       "NULL"
+
+let pp ppf x = Format.fprintf ppf "%s" (string_of x)

--- a/ocaml/xapi-types/ref.mli
+++ b/ocaml/xapi-types/ref.mli
@@ -43,3 +43,5 @@ val is_dummy : 'a t -> bool
 val name_of_dummy : 'a t -> string
 
 val really_pretty_and_small : 'a t -> string
+
+val pp : Format.formatter -> 'a t -> unit


### PR DESCRIPTION
Estimated testing time 20s (2 benchmarks x 10s). Change using '-quota'.
```
┌────────┬──────────┬─────────┬────────────┐
│ Name   │ Time/Run │ mWd/Run │ Percentage │
├────────┼──────────┼─────────┼────────────┤
│ master │  63.58ns │  28.00w │    100.00% │
│ pr     │  37.84ns │  14.00w │     59.51% │
└────────┴──────────┴─────────┴────────────┘
```