### PR TITLE
CA-375396: Ignore removed fields when redoing writes

### DIFF
--- a/ocaml/database/db_cache.ml
+++ b/ocaml/database/db_cache.ml
@@ -51,13 +51,19 @@ let apply_delta_to_cache entry db_ref =
       debug "Redoing delete_row %s (%s)" tblname objref ;
       DB.delete_row db_ref tblname objref
   | Redo_log.WriteField (tblname, objref, fldname, newval) ->
-      debug "Redoing write_field %s (%s) [%s -> %s]" tblname objref fldname
-        newval ;
       let removed =
         try lifecycle_state_of ~obj:tblname fldname = Removed_s
         with Not_found ->
-          D.warn "no lifetime information about %s.%s, ignoring" tblname fldname ;
+          warn "no lifetime information about %s.%s, ignoring write_field"
+            tblname fldname ;
           true
       in
-      if not removed then
+      if not removed then (
+        debug "Redoing write_field %s (%s) [%s -> %s]" tblname objref fldname
+          newval ;
         DB.write_field db_ref tblname objref fldname newval
+      ) else
+        info
+          "Field has been removed from the datamodel, ignoring write_field %s \
+           (%s) [%s -> %s]"
+          tblname objref fldname newval


### PR DESCRIPTION
When loading a database from disk in XML, fields that are marked in the datamodel as removed are ignored and not written to the in-memory database. Because some fields that have been marked as removed are still written to, like host metrics' free memory, they might still be tried to be replayed and they fail because the row does not exist in the database.

The plan is to change the generation of code from the datamodel which will make the writes impossible. In the meantime follow the same strategy of the xml loading: do not replay the writes if the field has been marked as removed

I've rerun the test that was failing 6 times to verify the issue is not happening anymore. I'm looking at the reason some other tests in the suite failed to see if the change was the cause