### PR TITLE
CP-44477 Add Typescript bindings for XenAPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ JOBS = $(shell getconf _NPROCESSORS_ONLN)
 PROFILE=release
 OPTMANDIR ?= $(OPTDIR)/man/man1/
 
-.PHONY: build clean test doc python format install uninstall
+.PHONY: build clean test doc python typescript format install uninstall
 
 # if we have XAPI_VERSION set then set it in dune-project so we use that version number instead of the one obtained from git
 # this is typically used when we're not building from a git repo
@@ -71,16 +71,18 @@ sdk:
 	mkdir -p $(XAPISDK)/java
 	mkdir -p $(XAPISDK)/powershell
 	mkdir -p $(XAPISDK)/python
+	mkdir -p $(XAPISDK)/typescript
 	cp -r _build/default/ocaml/sdk-gen/c/autogen/* $(XAPISDK)/c
 	cp -r _build/default/ocaml/sdk-gen/csharp/autogen/* $(XAPISDK)/csharp
 	cp -r _build/default/ocaml/sdk-gen/java/autogen/* $(XAPISDK)/java
 	cp -r _build/default/ocaml/sdk-gen/powershell/autogen/* $(XAPISDK)/powershell
 	cp scripts/examples/python/XenAPI/XenAPI.py $(XAPISDK)/python
+	cp scripts/examples/typescript/src/XenAPI.ts $(XAPISDK)/typescript
 	sh ocaml/sdk-gen/windows-line-endings.sh $(XAPISDK)/csharp
 	sh ocaml/sdk-gen/windows-line-endings.sh $(XAPISDK)/powershell
 
-python:
-	$(MAKE) -C scripts/examples/python build
+python typescript:
+	$(MAKE) -C scripts/examples/$@ build
 
 doc-json:
 	dune exec --profile=$(PROFILE) -- ocaml/idl/json_backend/gen_json.exe -destdir $(XAPIDOC)/jekyll

--- a/scripts/examples/typescript/.gitignore
+++ b/scripts/examples/typescript/.gitignore
@@ -1,0 +1,4 @@
+**/.env
+**/node_modules
+package-lock.json
+dist/

--- a/scripts/examples/typescript/Makefile
+++ b/scripts/examples/typescript/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build clean
+
+build:
+	sed -i '/version/s/1.0.0/'"$(XAPI_VERSION)"'/' package.json
+	npm install
+	npm run build
+
+publish:
+	npm publish
+
+clean:
+	rm -rf dist/ node-modules/ package-local.json

--- a/scripts/examples/typescript/README.md
+++ b/scripts/examples/typescript/README.md
@@ -1,0 +1,33 @@
+## Typescript for XenAPI Usage
+
+### Examples
+Install lib from npm repository
+```
+$ npm install xen-api-ts
+```
+
+The usage of Typescript XenAPI is almost identical to the [Python XenAPI](https://xapi-project.github.io/xen-api/usage.html), except it's asynchronous and requires async/await.
+```
+import { xapi_client } from "xen-api-ts"
+async function main() {
+    const session = xapi_client(process.env.HOST_URL)
+    try:
+        await session.login_with_password(process.env.USERNAME, process.env.PASSWORD)
+        const hosts = await session.xenapi.host.get_all()
+    finally:
+        await session.xenapi.session.logout()
+}
+main()
+```
+
+For more example usage, we can run as follows.
+```
+$ cd <examples/typescript dir>
+$ npm install
+$ echo "HOST_URL=xxx" >> .env
+$ echo "USERNAME=xxx" >> .env
+$ echo "PASSWORD=xxx" >> .env
+$ npm test tests/getXapiVersion.ts
+```
+
+## Packaging

--- a/scripts/examples/typescript/package.json
+++ b/scripts/examples/typescript/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "xen-api-ts",
+  "version": "1.0.0",
+  "description": "A typescript library for Xen API",
+  "main": "dist/XenAPI.js",
+  "types": "dist/XenAPI.d.ts",
+  "files": [
+      "/dist"
+  ],
+  "scripts": {
+    "test": "node -r ts-node/register -r dotenv/config ",
+    "build": "tsc"
+  },
+  "keywords": [
+    "xenserve",
+    "xen-api",
+    "typescript"
+  ],
+  "author": "Su Fei <fei.su@cloud.com>",
+  "license": "GPLv2",
+  "devDependencies": {
+    "@types/node": "^20.8.9",
+    "ts-node": "^10.9.1",
+    "dotenv": "^16.3.1",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "json-rpc-2.0": "^1.6.0"
+  }
+}

--- a/scripts/examples/typescript/src/XenAPI.ts
+++ b/scripts/examples/typescript/src/XenAPI.ts
@@ -1,0 +1,52 @@
+import { JSONRPCClient } from "json-rpc-2.0";
+
+class XapiSession {
+    private client: JSONRPCClient;
+    private session_id: string | undefined;
+
+    constructor(hostUrl: string | undefined) {
+        this.client = new JSONRPCClient(async (request) => {
+            const response = await fetch(`${hostUrl}/jsonrpc`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify(request),
+            });
+            if (response.status === 200) {
+                const json = await response.json();
+                return this.client.receive(json);
+            } else if (request.id !== undefined) {
+                return Promise.reject(new Error(response.statusText));
+            }
+        });
+    }
+
+    async login(method: string, args: any[] = []) {
+        this.session_id = await this.client.request(`session.${method}`, [...args])
+        return this.session_id
+    }
+
+    async xapi_request(method: string, args: any[] = []) {
+        return await this.client.request(`${method}`, [this.session_id, ...args])
+    }
+}
+
+function xapi_proxy(obj: XapiSession, path: any[] = []): any {
+    return new Proxy(() => {}, {
+        get (target, property) {
+            return xapi_proxy(obj, path.concat(property))
+        },
+        apply (target, self, args) {
+            if (path.length > 0){
+                if(path[path.length-1].startsWith("login")) {
+                    return obj.login(path[path.length-1], args)
+                } else if (path[0].toLowerCase() == 'xenapi') {
+                    return obj.xapi_request(path.slice(1).join('.'), args)
+                }
+            }
+        }
+    })
+}
+
+export function xapi_client(url: string|undefined) {
+    return xapi_proxy(new XapiSession(url))
+}

--- a/scripts/examples/typescript/tests/getXapiVersion.ts
+++ b/scripts/examples/typescript/tests/getXapiVersion.ts
@@ -1,0 +1,29 @@
+import { xapi_client } from "../src/XenAPI"
+
+// Ref https://xapi-project.github.io/xen-api/
+async function get_api_version(session: any) {
+    const pool = await session.xenapi.pool.get_all()
+    const host = await session.xenapi.pool.get_master(pool[0])
+    const major = await session.xenapi.host.get_API_version_major(host)
+    const minor = await session.xenapi.host.get_API_version_minor(host)
+    return `${major}.${minor}`
+}
+
+async function main() {
+    console.log(`Login ${process.env.HOST_URL} with ${process.env.USERNAME}`)
+    const session = xapi_client(process.env.HOST_URL)
+    //const session = xapi_proxy(new XapiSession(process.env.HOST_URL))
+    const sid = await session.login_with_password(process.env.USERNAME, process.env.PASSWORD)
+    console.log(`Login successfully with ${sid}`)
+
+    const ver = await get_api_version(session)
+    console.log(`\nCurrent XAPI Version: ${ver}`)
+
+    const hosts = await session.xenapi.host.get_all()
+    console.log(`\nGet Host list:\n${hosts.join("\n")}`)
+
+    await session.xenapi.session.logout()
+    console.log(`\nSession Logout.`)
+}
+
+main()

--- a/scripts/examples/typescript/tsconfig.json
+++ b/scripts/examples/typescript/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  /* select which files the compiler processes. */
+  "include": [
+      "src/**/*"
+  ],
+  "exclude": [
+      "node_modules"
+  ]
+}


### PR DESCRIPTION
In this PR, I implemented the Typescript bindings for XenAPI whose usage is almost identical to the [Python XenAPI](https://xapi-project.github.io/xen-api/usage.html), except it's asynchronous and requires async/await.

Meanwhile, publish Typescript distribution for XenAPI automatically to npmjs by github action. Repo Admin need to create a `NPM_TOKEN` variable in repository secrets.