### PR TITLE
CP-45571: Add VM.restart_device_model function (API/CLI)

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1033,6 +1033,7 @@ let pool_migrate =
       ; Api_errors.other_operation_in_progress
       ; Api_errors.vm_is_template
       ; Api_errors.operation_not_allowed
+      ; Api_errors.vm_bad_power_state
       ]
     ~allowed_roles:(_R_VM_POWER_ADMIN ++ _R_CLIENT_CERT)
     ()
@@ -1694,6 +1695,7 @@ let restart_device_models =
       ; Api_errors.other_operation_in_progress
       ; Api_errors.vm_is_template
       ; Api_errors.operation_not_allowed
+      ; Api_errors.vm_bad_power_state
       ]
     ~allowed_roles:(_R_VM_POWER_ADMIN ++ _R_CLIENT_CERT)
     ()

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1033,7 +1033,6 @@ let pool_migrate =
       ; Api_errors.other_operation_in_progress
       ; Api_errors.vm_is_template
       ; Api_errors.operation_not_allowed
-      ; Api_errors.vm_migrate_failed
       ]
     ~allowed_roles:(_R_VM_POWER_ADMIN ++ _R_CLIENT_CERT)
     ()
@@ -1686,6 +1685,19 @@ let set_NVRAM_EFI_variables =
     ~params:[(Ref _vm, "self", "The VM"); (String, "value", "The value")]
     ~hide_from_docs:true ~allowed_roles:_R_LOCAL_ROOT_ONLY ()
 
+let restart_device_models =
+  call ~flags:[`Session] ~name:"restart_device_models" ~lifecycle:[]
+    ~params:[(Ref _vm, "self", "The VM")]
+    ~errs:
+      [
+        Api_errors.vm_bad_power_state
+      ; Api_errors.other_operation_in_progress
+      ; Api_errors.vm_is_template
+      ; Api_errors.operation_not_allowed
+      ]
+    ~allowed_roles:(_R_VM_POWER_ADMIN ++ _R_CLIENT_CERT)
+    ()
+
 (** VM (or 'guest') configuration: *)
 let t =
   create_obj ~in_db:true ~in_product_since:rel_rio ~in_oss_since:oss_since_303
@@ -1819,6 +1831,7 @@ let t =
       ; set_domain_type
       ; set_HVM_boot_policy
       ; set_NVRAM_EFI_variables
+      ; restart_device_models
       ]
     ~contents:
       ([uid _vm]

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1570,6 +1570,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Standard; Vm_selectors]
       }
     )
+  ; ( "vm-restart-device-models"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Restart device models of a VM."
+      ; implementation= No_fd Cli_operations.vm_restart_device_models
+      ; flags= [Standard; Vm_selectors]
+      }
+    )
   ; ( "vm-pause"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3815,6 +3815,15 @@ let vm_resume printer rpc session_id params =
        params ["on"; "progress"]
     )
 
+let vm_restart_device_models printer rpc session_id params =
+  ignore
+    (do_vm_op printer rpc session_id
+       (fun vm ->
+         Client.VM.restart_device_models ~rpc ~session_id ~self:(vm.getref ())
+       )
+       params []
+    )
+
 let vm_pause printer rpc session_id params =
   ignore
     (do_vm_op printer rpc session_id

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3023,6 +3023,10 @@ functor
         (* called by varstored, bypasses VM powerstate check *)
         info "VM.set_NVRAM_EFI_variables: self = '%s'" (vm_uuid ~__context self) ;
         Local.VM.set_NVRAM_EFI_variables ~__context ~self ~value
+
+      let restart_device_models ~__context ~self =
+        info "VM.restart_device_models: self = '%s'" (vm_uuid ~__context self) ;
+        Local.VM.restart_device_models ~__context ~self
     end
 
     module VM_metrics = struct end

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1611,3 +1611,13 @@ let set_NVRAM_EFI_variables ~__context ~self ~value =
       let value = (key, value) :: List.remove_assoc key nvram in
       Db.VM.set_NVRAM ~__context ~self ~value
   )
+
+let restart_device_models ~__context ~self =
+  let host = Db.VM.get_resident_on ~__context ~self in
+  (* As it is implemented as a localhost migration, just reuse message
+   * forwarding of "pool_migrate" to handle "allowed operation" and "message
+   * routing" *)
+  Helpers.call_api_functions ~__context (fun rpc session_id ->
+      Client.VM.pool_migrate ~rpc ~session_id ~vm:self ~host
+        ~options:[("live", "true")]
+  )

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -420,3 +420,5 @@ val set_HVM_boot_policy :
 
 val set_NVRAM_EFI_variables :
   __context:Context.t -> self:API.ref_VM -> value:string -> unit
+
+val restart_device_models : __context:Context.t -> self:API.ref_VM -> unit


### PR DESCRIPTION
Implemented as a localhost migration, can be made more efficient in future.
As it is simply a "pool_migrate", just reuse message forwarding of "pool_migrate" to handle "allowed operation" and "message routing".