### PR TITLE
CP-45741 VCS support, adjust args for qemu, demu

### DIFF
--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -2091,10 +2091,11 @@ module Dm_Common = struct
   let cmdline_of_disp ?domid info =
     let vga_type_opts x =
       let open Xenops_interface.Vgpu in
+      (* We can match on the implementation details to detect the VCS
+         case. Don't pass -vgpu for a compute vGPU. *)
       match x with
-      | Vgpu [{implementation= Nvidia _; _}] ->
-          ["-vgpu"]
-      | Vgpu ({implementation= Nvidia _; _} :: _) ->
+      | Vgpu ({implementation= Nvidia {vclass; _}; _} :: _)
+        when vclass <> Some "Compute" ->
           ["-vgpu"]
       | Vgpu [{implementation= GVT_g gvt_g; _}] ->
           let base_opts =

--- a/ocaml/xenopsd/xc/device.ml
+++ b/ocaml/xenopsd/xc/device.ml
@@ -2094,8 +2094,9 @@ module Dm_Common = struct
       (* We can match on the implementation details to detect the VCS
          case. Don't pass -vgpu for a compute vGPU. *)
       match x with
-      | Vgpu ({implementation= Nvidia {vclass; _}; _} :: _)
-        when vclass <> Some "Compute" ->
+      | Vgpu ({implementation= Nvidia {vclass= Some "Compute"; _}; _} :: _) ->
+          [] (* don't pass flags for VCS (compute) vGPU *)
+      | Vgpu ({implementation= Nvidia _; _} :: _) ->
           ["-vgpu"]
       | Vgpu [{implementation= GVT_g gvt_g; _}] ->
           let base_opts =

--- a/ocaml/xenopsd/xc/service.ml
+++ b/ocaml/xenopsd/xc/service.ml
@@ -516,7 +516,7 @@ module Vgpu = struct
     let fd_arg = if restore then ["--resume"] else [] in
     (* support for NVidia VCS (compute) vGPUs *)
     let no_console =
-      match List.exists is_compute_vgpu vgpus with
+      match List.for_all is_compute_vgpu vgpus with
       | true ->
           ["--noconsole"]
       | false ->


### PR DESCRIPTION
Part of CP-44317, CP-44320 suporting NVidia VCS. Adjust args when we are running a VCS (compute) vGPU when starting qemu and demu:

* don't pass -vgpu to qemu
* pass --noconsole to demu

Remove a redundant match in cmdline_of_disp.