### PR TITLE
Add timeout to gpumon client

### DIFF
--- a/ocaml/xapi-idl/gpumon/gpumon_client.ml
+++ b/ocaml/xapi-idl/gpumon/gpumon_client.ml
@@ -16,7 +16,7 @@ let xml_url () = "file:" ^ Gpumon_interface.xml_path
 
 let rpc call =
   if !Xcp_client.use_switch then
-    Xcp_client.json_switch_rpc Gpumon_interface.queue_name call
+    Xcp_client.json_switch_rpc ~timeout:10 Gpumon_interface.queue_name call
   else
     Xcp_client.xml_http_rpc
       ~srcstr:(Xcp_client.get_user_agent ())


### PR DESCRIPTION
It can happens that the message switch queue for gpumon is not available and in this case the RPC is never answered. To avoid waiting forever we add a timeout.

The condition where the RPC is not answered arise when the RRDD gpumon plugin is not started. We observed in this condition and on a host with an Nvidia GPU that the xapi wait forever because it tries to get information about the GPU but we don't see a queue `org.xen.xapi.gpumon`. Adding this timeout allows the RPC to return and xapi continues its initialization. 
We also observed that starting the RRDD gpumon plugin has the effect of creating the `org.xen.xapi.gpumon` queue and so if the plugin is started the timeout is not needed.