### PR TITLE
CP-46045 define VTPM feature

### DIFF
--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -63,6 +63,7 @@ type feature =
   | Certificate_verification
   | Updates
   | Internal_repo_access
+  | VTPM
 [@@deriving rpc]
 
 type orientation = Positive | Negative
@@ -130,6 +131,7 @@ let keys_of_features =
   ; ( Internal_repo_access
     , ("restrict_internal_repo_access", Negative, "Internal_repo_access")
     )
+  ; (VTPM, ("restrict_vtpm", Negative, "VTPM"))
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi-types/features.mli
+++ b/ocaml/xapi-types/features.mli
@@ -71,6 +71,7 @@ type feature =
   | Updates  (** Enable host updates from a repository *)
   | Internal_repo_access
       (** Enable restriction on repository access to pool members only *)
+  | VTPM  (** Support VTPM device required by Win11 guests *)
 
 val feature_of_rpc : Rpc.t -> feature
 (** Convert RPC into {!feature}s *)


### PR DESCRIPTION
VTPM is currently marked as an experimental feature; this commit promotes it to a regular feature by defining it. We don't plan on branching on its presence. This is to make the presence of it observable by API clients.

This code needs to be merged before we can update v6 because v6 depends on the xapi-types packges.