### PR TITLE
[maintenance]: mark warning 5: ignored partial application as an erro…

### DIFF
--- a/dune
+++ b/dune
@@ -5,7 +5,7 @@
   )
   (dev (flags (:standard -g -w -39)))
   (release
-    (flags (:standard -w -39-6))
+    (flags (:standard -w -39-6@5))
     (env-vars (ALCOTEST_COMPACT 1))
   )
 )


### PR DESCRIPTION
…r in release mode

When introducing new fields all code that creates the object must be updated to pass the new labeled argument. If you forget to do that for the unit test then the unit test will compile and run with a warning, but fail at runtime because the host wasn't actually created.

In dev mode this is already an error, so change release mode to also make it an error to detect the problem earlier, instead of a non-obvious failure in 'Test_pvs_cache_storage'.