### PR TITLE
CP-27910: expose json flag for /vm_rrd in the datamodel

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8257,7 +8257,7 @@ let http_actions =
     , ( Get
       , Constants.get_vm_rrd_uri
       , true
-      , [String_query_arg "uuid"]
+      , [String_query_arg "uuid"; Bool_query_arg "json"]
       , _R_READ_ONLY
       , []
       )


### PR DESCRIPTION


This is needed for the SDK to generate functions that allow setting the json
flag by clients. (Xencenter, for example)