### PR TITLE
CA-365486: repository-domain-name-allowlist could accept a full hostname

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1938,6 +1938,8 @@ let _ =
     ~doc:"The repository proxy URL is invalid." () ;
   error Api_errors.invalid_repository_proxy_credential []
     ~doc:"The repository proxy username/password is invalid." () ;
+  error Api_errors.invalid_repository_domain_allowlist ["domains"]
+    ~doc:"The repository domain allowlist has some invalid domains." () ;
   error Api_errors.apply_livepatch_failed ["livepatch"]
     ~doc:"Failed to apply a livepatch." () ;
   error Api_errors.updates_require_recommended_guidance ["recommended_guidance"]

--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -326,12 +326,32 @@ module AssertUrlIsValid = Generic.MakeStateless (struct
         )
       ; (("https://a.b.c", []), Ok ())
       ; (("http://a.b.c", []), Ok ())
+      ; (("http://192.168.0.2", []), Ok ())
+      ; (("https://192.168.0.2", []), Ok ())
+      ; (("http://192.168.0.2", ["192.168.0.2"]), Ok ())
+      ; (("https://192.168.0.2", ["192.168.0.2"]), Ok ())
+      ; ( ("http://192.168.0.256", ["192.168.0.256"])
+        , Error
+            Api_errors.(
+              Server_error (invalid_base_url, ["http://192.168.0.256"])
+            )
+        )
+      ; (("http://c.com", ["c.com"]), Ok ())
+      ; ( ("http://c.com", ["c.com"; "d.."; ".e.."])
+        , Error
+            Api_errors.(
+              Server_error (invalid_repository_domain_allowlist, ["d.."; ".e.."])
+            )
+        )
       ; (("http://a.b.c.com", ["c.com"; "d.com"]), Ok ())
       ; ( ("http://a.b.c.comm", ["c.com"; "d.com"])
         , Error
             Api_errors.(Server_error (invalid_base_url, ["http://a.b.c.comm"]))
         )
-      ; (("http://a.b...c.com", ["c.com"; "d.com"]), Ok ())
+      ; ( ("http://a.b...c.com", ["c.com"; "d.com"])
+        , Error
+            Api_errors.(Server_error (invalid_base_url, ["http://a.b...c.com"]))
+        )
       ; ( ("http://a.b.cc.com", ["c.com"; "d.com"])
         , Error
             Api_errors.(Server_error (invalid_base_url, ["http://a.b.cc.com"]))

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1277,6 +1277,8 @@ let invalid_repository_proxy_url = "INVALID_REPOSITORY_PROXY_URL"
 
 let invalid_repository_proxy_credential = "INVALID_REPOSITORY_PROXY_CREDENTIAL"
 
+let invalid_repository_domain_allowlist = "INVALID_REPOSITORY_DOMAIN_ALLOWLIST"
+
 let apply_livepatch_failed = "APPLY_LIVEPATCH_FAILED"
 
 let updates_require_recommended_guidance =


### PR DESCRIPTION
For the check of function `assert_url_is_valid`, repository-domain-name-allowlist doesn't work if you use the full FQDN for a server.

The `assert_url_is_valid` only allows if the host ends with .<entry in `repository-domain-name-allowlist`>. Now it is extended to allow if the hosts matches the entry in the list too.