### PR TITLE
CA-384936 attach static VDIs for redo-log

### DIFF
--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -41,7 +41,7 @@ let get_static_device reason =
       (Static_vdis_list.list ())
   in
   (* Return the path to the first attached VDI which matches the reason *)
-  R.debug "Found %d VDIs matching [%s]" (List.length vdis) reason ;
+  D.debug "Found %d VDIs matching [%s]" (List.length vdis) reason ;
   match vdis with [] -> None | hd :: _ -> hd.Static_vdis_list.path
 
 let mib megabytes =

--- a/ocaml/xapi/static_vdis.ml
+++ b/ocaml/xapi/static_vdis.ml
@@ -113,6 +113,7 @@ let gc () =
 (** If we just rebooted and failed to attach our static VDIs then this can be called to reattempt the attach:
     	this is necessary for HA to start. *)
 let reattempt_on_boot_attach () =
+  debug "%s" __FUNCTION__ ;
   let script = "attach-static-vdis" in
   try ignore (Helpers.call_script "/sbin/service" [script; "start"])
   with e ->

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -531,6 +531,7 @@ let start_redo_log () =
       && not (bool_of_string (Localdb.get Constants.ha_armed))
     then (
       debug "Redo log was enabled when shutting down, so restarting it" ;
+      Static_vdis.reattempt_on_boot_attach () ;
       (* enable the use of the redo log *)
       Redo_log.enable_existing Xapi_ha.ha_redo_log
         Xapi_globs.gen_metadata_vdi_reason ;


### PR DESCRIPTION
The redo-log without HA is missing to attach the static VDIs that
 actually contain the redo log. Call the same code that we are using in
 the HA case.
