### PR TITLE
Add space between header name and value

### DIFF
--- a/ocaml/libs/http-lib/http.ml
+++ b/ocaml/libs/http-lib/http.ml
@@ -757,7 +757,7 @@ module Request = struct
     @ user_agent
     @ traceparent
     @ close
-    @ List.map (fun (k, v) -> k ^ ":" ^ v) x.additional_headers
+    @ List.map (fun (k, v) -> k ^ ": " ^ v) x.additional_headers
 
   let to_headers_and_body (x : t) =
     (* If the body is given then compute a content length *)
@@ -856,7 +856,7 @@ module Response = struct
     let task =
       Option.fold ~none:[] ~some:(fun x -> [Hdr.task_id ^ ": " ^ x]) x.task
     in
-    let headers = List.map (fun (k, v) -> k ^ ":" ^ v) x.additional_headers in
+    let headers = List.map (fun (k, v) -> k ^ ": " ^ v) x.additional_headers in
     status :: (content_length @ task @ headers)
 
   let to_headers_and_body (x : t) =


### PR DESCRIPTION
While I can't find a mention of the space this in the HTTP/1.1 spec, some clients cannot parse this correctly (tested with [Insomnia](https://insomnia.rest/)).

Also changing because we already do have this space for other headers, such as `content-length`.