### PR TITLE
CP-45888: Replace XML-RPC client in Java SDK with JSON-RPC

### DIFF
--- a/ocaml/sdk-gen/c/gen_c_binding.ml
+++ b/ocaml/sdk-gen/c/gen_c_binding.ml
@@ -1412,14 +1412,9 @@ and internal_decl_filename name =
 
 and impl_filename name = sprintf "xen_%s.c" (String.lowercase_ascii name)
 
-and internal_impl_filename name =
-  sprintf "xen_%s_internal.c" (String.lowercase_ascii name)
-
 and protector classname = sprintf "XEN_%s_H" (String.uppercase_ascii classname)
 
 and typename classname = sprintf "xen_%s" (String.lowercase_ascii classname)
-
-and variablename classname = sprintf "%s" (String.lowercase_ascii classname)
 
 and record_typename classname = sprintf "%s_record" (typename classname)
 

--- a/ocaml/sdk-gen/c/gen_c_binding.mli
+++ b/ocaml/sdk-gen/c/gen_c_binding.mli
@@ -1,0 +1,1 @@
+(* Empty .mli to ensure unused functions are picked up during check*)

--- a/ocaml/sdk-gen/c/helper.mli
+++ b/ocaml/sdk-gen/c/helper.mli
@@ -1,0 +1,13 @@
+val formatted_wrap : Format.formatter -> string -> unit
+(** Recursively formats the input string
+    based on spaces and newlines, ensuring proper indentation.
+
+    @param formatter The formatter to output the formatted string.
+    @param s The input string to be formatted. *)
+
+val comment : bool -> ?indent:int -> string -> string
+(** Formats a comment block with optional indentation.
+    @param indent Optional indentation level.
+    @param doc Include an extra '*' for documentation.
+    @param s String content of the comment.
+    @return Formatted comment block. *)

--- a/ocaml/sdk-gen/c/helper.mli
+++ b/ocaml/sdk-gen/c/helper.mli
@@ -1,6 +1,6 @@
 val formatted_wrap : Format.formatter -> string -> unit
 (** Recursively formats the input string
-    based on spaces and newlines, ensuring proper indentation.
+    based on spaces and new lines, ensuring proper indentation.
 
     @param formatter The formatter to output the formatted string.
     @param s The input string to be formatted. *)

--- a/ocaml/sdk-gen/common/CommonFunctions.ml
+++ b/ocaml/sdk-gen/common/CommonFunctions.ml
@@ -122,6 +122,9 @@ let get_prototyped_release lifecycle =
 let get_published_release lifecycle =
   lifecycle_matcher Lifecycle.Published lifecycle
 
+let get_deprecated_release lifecycle =
+  lifecycle_matcher Lifecycle.Published lifecycle
+
 let get_release_branding codename =
   try
     let found =

--- a/ocaml/sdk-gen/common/CommonFunctions.ml
+++ b/ocaml/sdk-gen/common/CommonFunctions.ml
@@ -40,9 +40,6 @@ let with_output filename f =
   let io = open_out filename in
   finally (fun () -> f io) ~always:(fun () -> close_out io)
 
-let joined sep f l =
-  l |> List.map f |> List.filter (fun x -> x <> "") |> String.concat sep
-
 let escape_xml s =
   s
   |> Astring.String.cuts ~sep:"<" ~empty:true

--- a/ocaml/sdk-gen/common/CommonFunctions.mli
+++ b/ocaml/sdk-gen/common/CommonFunctions.mli
@@ -14,11 +14,6 @@ val is_setter : Datamodel_types.message -> bool
     @param message Message to check.
     @return [true] if the message is a setter, [false] otherwise. *)
 
-val finally : (unit -> 'a) -> always:(unit -> unit) -> 'a
-(** [finally f ~always] Executes [f] and then [always] regardless of success or failure.
-    @param f Function to execute.
-    @param always Function to execute always. *)
-
 val is_getter : Datamodel_types.message -> bool
 (** [is_getter message] Checks if a message is a getter based on its name.
     @param message Message to check.

--- a/ocaml/sdk-gen/common/CommonFunctions.mli
+++ b/ocaml/sdk-gen/common/CommonFunctions.mli
@@ -58,6 +58,13 @@ val is_remover : Datamodel_types.message -> bool
     @param message Message to check.
     @return [true] if the message is a remover, [false] otherwise. *)
 
+val get_minimum_allowed_role : Datamodel_types.message -> string
+(** [msg message] Get the minimum RBAC role required to run the procedure of the input message.
+    This function ignores internal roles.
+    If no matching role is found, the string "Not Applicable" is returned
+    @param message Input message.
+    @return string the name of the RBAC role if a matching one is found, "Not Applicable" otherwise. *)
+
 val gen_param_groups :
      Datamodel_types.message
   -> Datamodel_types.param list

--- a/ocaml/sdk-gen/common/CommonFunctions.mli
+++ b/ocaml/sdk-gen/common/CommonFunctions.mli
@@ -4,6 +4,12 @@ exception Unknown_wire_protocol
 (** Type representing supported protocols. *)
 type wireProtocol = XmlRpc | JsonRpc
 
+val get_deprecated_release :
+  (Datamodel_types.Lifecycle.change * string * 'a) list -> string
+(** [get_deprecated_release codename] Gets the non-branded release name for a lifecycle if it's deprecated
+    @param lifecycle The lifecycle transitions to check.
+    @return The non-branded release name for a lifecycle if it's deprecated, empty if not deprecated *)
+
 val get_release_branding : string -> string
 (** [get_release_branding codename] Gets the branding for a release codename.
     @param codename Release codename to lookup.

--- a/ocaml/sdk-gen/common/CommonFunctions.mli
+++ b/ocaml/sdk-gen/common/CommonFunctions.mli
@@ -119,12 +119,5 @@ val render_file : string * string -> Mustache.Json.t -> string -> string -> unit
     @param templates_dir Directory containing templates.
     @param dest_dir Directory for the rendered output. *)
 
-val json_releases :
-  [> `O of
-     ( string
-     * [> `A of
-          [> `O of (string * [> `Float of float | `String of string]) list] list
-       | `Float of float ]
-     )
-     list ]
+val json_releases : Mustache.Json.t
 (** JSON structure representing release information. *)

--- a/ocaml/sdk-gen/common/CommonFunctions.mli
+++ b/ocaml/sdk-gen/common/CommonFunctions.mli
@@ -1,0 +1,130 @@
+(** Exception for unknown wire protocol. *)
+exception Unknown_wire_protocol
+
+(** Type representing supported protocols. *)
+type wireProtocol = XmlRpc | JsonRpc
+
+val get_release_branding : string -> string
+(** [get_release_branding codename] Gets the branding for a release codename.
+    @param codename Release codename to lookup.
+    @return Branding for the release codename, or the original codename if not found. *)
+
+val is_setter : Datamodel_types.message -> bool
+(** [is_setter message] Checks if a message is a setter based on its name.
+    @param message Message to check.
+    @return [true] if the message is a setter, [false] otherwise. *)
+
+val finally : (unit -> 'a) -> always:(unit -> unit) -> 'a
+(** [finally f ~always] Executes [f] and then [always] regardless of success or failure.
+    @param f Function to execute.
+    @param always Function to execute always. *)
+
+val is_getter : Datamodel_types.message -> bool
+(** [is_getter message] Checks if a message is a getter based on its name.
+    @param message Message to check.
+    @return [true] if the message is a getter, [false] otherwise. *)
+
+val get_deprecated_info_message : Datamodel_types.message -> string
+(** [get_deprecated_info_message message] Returns a deprecated information message
+    based on the internal_deprecated_since version in the input message.
+    @param message Message containing version information.
+    @return Deprecated information message or an empty string if not deprecated. *)
+
+val is_adder : Datamodel_types.message -> bool
+(** [is_adder message] Checks if a message is an adder based on its name.
+    @param message Message to check.
+    @return [true] if the message is an adder, [false] otherwise. *)
+
+val get_published_info_class : Datamodel_types.obj -> string
+(** [get_published_info_class cls] Returns information about the first publication
+    of a class based on its lifecycle transitions.
+    @param cls Class to retrieve publication information for.
+    @return Information string with the first published version. *)
+
+val is_method_static : Datamodel_types.message -> bool
+(** [is_method_static message] Checks if a method is static based on its parameters.
+    @param message Message to check.
+    @return [true] if the method is static, [false] otherwise. *)
+
+val escape_xml : string -> string
+(** [escape_xml s] Escapes XML special characters in a string.
+    @param s String to escape.
+    @return String with XML special characters escaped. *)
+
+val get_published_info_message :
+  Datamodel_types.message -> Datamodel_types.obj -> string
+(** Gets information about the publication status of a message.
+    @param message - Message to check.
+    @param cls - Class containing the message.
+    @return Information about the publication status. *)
+
+val is_remover : Datamodel_types.message -> bool
+(** [is_remover message] Checks if a message is a remover based on its name.
+    @param message Message to check.
+    @return [true] if the message is a remover, [false] otherwise. *)
+
+val gen_param_groups :
+     Datamodel_types.message
+  -> Datamodel_types.param list
+  -> Datamodel_types.param list list
+(** Generates parameter groups based on a message and its parameters.
+    @param message - Message containing the parameters.
+    @param params - List of parameters.
+    @return List of parameter groups. *)
+
+val get_published_info_param :
+  Datamodel_types.message -> Datamodel_types.param -> string
+(** Gets information about the publication status of a parameter.
+    @param message - Message containing the parameter.
+    @param param - Parameter to check.
+    @return Information about the publication status. *)
+
+val get_published_info_field :
+  Datamodel_types.field -> Datamodel_types.obj -> string
+(** Gets information about the publication status of a field within a class.
+    @param field - Field to check.
+    @param cls - Class containing the field.
+    @return Information about the publication status. *)
+
+val string_of_file : string -> string
+(** [string_of_file filename] Reads the content of a file into a string.
+    @param filename Name of the file to read.
+    @return String containing the file content. *)
+
+val is_constructor : Datamodel_types.message -> bool
+(** [is_constructor message] Checks if a message is a constructor.
+    @param message Message to check.
+    @return [true] if the message is a constructor, [false] otherwise. *)
+
+val with_output : string -> (out_channel -> 'a) -> 'a
+(** [with_output filename f] Opens a file for writing and executes a function with the output channel.
+    @param filename Name of the file to open.
+    @param f Function to execute with the output channel. *)
+
+val is_destructor : Datamodel_types.message -> bool
+(** [is_destructor message] Checks if a message is a destructor.
+    @param message Message to check.
+    @return [true] if the message is a destructor, [false] otherwise. *)
+
+val is_real_constructor : Datamodel_types.message -> bool
+(** [is_real_constructor message] Checks if a message is a real constructor.
+    @param message Message to check.
+    @return [true] if the message is a real constructor, [false] otherwise. *)
+
+val render_file : string * string -> Mustache.Json.t -> string -> string -> unit
+(** [render_file (infile, outfile) json templates_dir dest_dir] Renders a file using a JSON data model and templates.
+    @param infile Input file name.
+    @param outfile Output file name.
+    @param json JSON data model.
+    @param templates_dir Directory containing templates.
+    @param dest_dir Directory for the rendered output. *)
+
+val json_releases :
+  [> `O of
+     ( string
+     * [> `A of
+          [> `O of (string * [> `Float of float | `String of string]) list] list
+       | `Float of float ]
+     )
+     list ]
+(** JSON structure representing release information. *)

--- a/ocaml/sdk-gen/common/dune
+++ b/ocaml/sdk-gen/common/dune
@@ -6,5 +6,6 @@
     xapi-datamodel
     mustache
   )
+  (modules_without_implementation license)
 )
 

--- a/ocaml/sdk-gen/common/license.mli
+++ b/ocaml/sdk-gen/common/license.mli
@@ -1,0 +1,2 @@
+(* Conent of BSD 2 License *)
+val bsd_two_clause : string

--- a/ocaml/sdk-gen/common/license.mli
+++ b/ocaml/sdk-gen/common/license.mli
@@ -1,2 +1,2 @@
-(* Conent of BSD 2 License *)
+(* Content of BSD 2 License *)
 val bsd_two_clause : string

--- a/ocaml/sdk-gen/csharp/friendly_error_names.mli
+++ b/ocaml/sdk-gen/csharp/friendly_error_names.mli
@@ -1,0 +1,1 @@
+(* Empty .mli to ensure unused functions are picked up during check*)

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -240,9 +240,9 @@ and gen_class_file cls =
   let out_chan =
     open_out (Filename.concat destdir (exposed_class_name cls.name) ^ ".cs")
   in
-  finally
+  Fun.protect
     (fun () -> gen_class out_chan cls)
-    ~always:(fun () -> close_out out_chan)
+    ~finally:(fun () -> close_out out_chan)
 
 and gen_class out_chan cls =
   let print format = fprintf out_chan format in
@@ -842,7 +842,9 @@ and gen_enum' name contents =
 (* ------------------- category: maps *)
 and gen_maps () =
   let out_chan = open_out (Filename.concat destdir "Maps.cs") in
-  finally (fun () -> gen_maps' out_chan) ~always:(fun () -> close_out out_chan)
+  Fun.protect
+    (fun () -> gen_maps' out_chan)
+    ~finally:(fun () -> close_out out_chan)
 
 and gen_maps' out_chan =
   let print format = fprintf out_chan format in

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.mli
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.mli
@@ -1,0 +1,1 @@
+(* Empty .mli to ensure unused functions are picked up during check*)

--- a/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
+++ b/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
@@ -53,29 +53,14 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.apache.xmlrpc</groupId>
-            <artifactId>xmlrpc-client</artifactId>
-            <version>3.1.3</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.xmlrpc</groupId>
-            <artifactId>xmlrpc-common</artifactId>
-            <version>3.1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.ws.commons.util</groupId>
-            <artifactId>ws-commons-util</artifactId>
-            <version>1.0.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
+++ b/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
@@ -55,12 +55,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.1</version>
+            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.2.1</version>
+            <version>5.3</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
@@ -222,7 +222,8 @@ public class Connection {
         return apiVersion;
     }
 
-    private void setAPIVersion(Session session) throws IOException {
+    private void setAPIVersion() throws IOException {
+        apiVersion = APIVersion.UNKNOWN;
         try {
             var pools = Pool.getAllRecords(this);
             var pool = pools.values().stream().findFirst();
@@ -231,7 +232,7 @@ public class Connection {
                 apiVersion = APIVersion.fromMajorMinor(host.APIVersionMajor, host.APIVersionMinor);
             }
         } catch (BadServerResponse exn) {
-            apiVersion = APIVersion.UNKNOWN;
+            // ignore, we default to UNKNOWN
         }
     }
 
@@ -264,7 +265,7 @@ public class Connection {
         if (methodCall.equals("session.login_with_password")) {
             var session = ((Session) result.result);
             sessionReference = session.ref;
-            setAPIVersion(session);
+            setAPIVersion();
         } else if (methodCall.equals("session.slave_local_login_with_password")) {
             var session = ((Session) result.result);
             sessionReference = session.ref;

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
@@ -199,7 +199,7 @@ public class Connection {
      * @param methodCall            the JSON-RPC xapi method call. e.g.: session.login_with_password
      * @param methodParameters      the methodParameters of the method call
      * @param responseTypeReference the type of the response, wrapped with a TypeReference
-     * @param <T>                   The type of the response's payload. For instance, an array of VMs is expected when calling VM.get_all_records
+     * @param <T>                   The type of the response's payload. For instance, a map of opaque references to VM objects is expected when calling VM.get_all_records
      * @return The result of the call with the type specified under T.
      * @throws XenAPIException         if the call failed.
      * @throws IOException             if an I/O error occurs when sending or receiving, includes cases when the request's payload or the response's payload cannot be written or read as valid JSON.

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
@@ -29,7 +29,6 @@
 
 package com.xensource.xenapi;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.xensource.xenapi.Types.BadServerResponse;
 import com.xensource.xenapi.Types.XenAPIException;
@@ -203,10 +202,9 @@ public class Connection {
      * @param <T>                   The type of the response's payload. For instance, an array of VMs is expected when calling VM.get_all_records
      * @return The result of the call with the type specified under T.
      * @throws XenAPIException         if the call failed.
-     * @throws JsonProcessingException if the request's payload or the response's payload cannot be written or read as valid JSON
-     * @throws IOException             if an I/O error occurs when sending or receiving
+     * @throws IOException             if an I/O error occurs when sending or receiving, includes cases when the request's payload or the response's payload cannot be written or read as valid JSON.
      */
-    public <T> T dispatch(String methodCall, Object[] methodParameters, TypeReference<T> responseTypeReference) throws XenAPIException, JsonProcessingException, IOException {
+    public <T> T dispatch(String methodCall, Object[] methodParameters, TypeReference<T> responseTypeReference) throws XenAPIException, IOException {
         var result = client.sendRequest(methodCall, methodParameters, responseTypeReference);
         if (result.error != null) {
             throw new XenAPIException(String.valueOf(result.error));
@@ -231,10 +229,9 @@ public class Connection {
      * @param methodCall       the JSON-RPC xapi method call. e.g.: session.login_with_password
      * @param methodParameters the methodParameters of the method call
      * @throws XenAPIException         if the call failed.
-     * @throws JsonProcessingException if the request's payload or the response's payload cannot be written or read as valid JSON
-     * @throws IOException             if an I/O error occurs when sending or receiving
+     * @throws IOException             if an I/O error occurs when sending or receiving, includes cases when the request's payload or the response's payload cannot be written or read as valid JSON.
      */
-    public <T> void dispatch(String methodCall, Object[] methodParameters) throws XenAPIException, JsonProcessingException, IOException {
+    public <T> void dispatch(String methodCall, Object[] methodParameters) throws XenAPIException, IOException {
         var typeReference = new TypeReference<T>() {
         };
         this.dispatch(methodCall, methodParameters, typeReference);

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/CustomDateDeserializer.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/CustomDateDeserializer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.xensource.xenapi;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * {@link CustomDateDeserializer} is a Jackson JSON deserializer for parsing {@link Date} objects
+ * from custom date formats used in Xen-API responses.
+ */
+public class CustomDateDeserializer extends StdDeserializer<Date> {
+
+    /**
+     * Array of {@link SimpleDateFormat} objects representing the custom date formats
+     * used in XenServer API responses.
+     */
+    private final SimpleDateFormat[] dateFormatters
+            = new SimpleDateFormat[]{
+            new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss'Z'"),
+            new SimpleDateFormat("ss.SSS")
+    };
+
+    /**
+     * Constructs a {@link CustomDateDeserializer} instance.
+     */
+    public CustomDateDeserializer() {
+        this(null);
+    }
+
+    /**
+     * Constructs a {@link CustomDateDeserializer} instance with the specified value type.
+     *
+     * @param t The value type to handle (can be null, handled by superclass)
+     */
+    public CustomDateDeserializer(Class t) {
+        super(t);
+    }
+
+    /**
+     * Deserializes a {@link Date} object from the given JSON parser.
+     *
+     * @param jsonParser             The JSON parser containing the date value to deserialize
+     * @param deserializationContext The deserialization context
+     * @return The deserialized {@link Date} object
+     * @throws IOException if an I/O error occurs during deserialization
+     */
+    @Override
+    public Date deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+
+        for (SimpleDateFormat formatter : dateFormatters) {
+            try {
+                return formatter.parse(jsonParser.getText());
+            } catch (ParseException e) {
+                // ignore
+            }
+        }
+
+        throw new IOException("Failed to deserialize a Date value.");
+    }
+}

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/EventBatch.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/EventBatch.java
@@ -30,6 +30,7 @@
 package com.xensource.xenapi;
 
 import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Class used to map the output of Event.from().
@@ -46,6 +47,7 @@ public class EventBatch
     /**
      * The number of valid objects of all types in the database.
      */
+    @JsonProperty("valid_ref_counts")
     public Object validRefCounts;
 
     /**

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
@@ -32,6 +32,7 @@ package com.xensource.xenapi;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -45,7 +46,7 @@ import org.apache.hc.core5.util.Timeout;
 
 import java.io.IOException;
 import java.net.URL;
-import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -209,7 +210,9 @@ public class JsonRpcClient {
      * Helper method to initialize jackson's ObjectMapper.
      */
     private void initializeObjectMapperConfiguration() {
-        this.objectMapper.setDateFormat(new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss'Z'"));
+        var dateHandlerModule = new SimpleModule("DateHandler");
+        dateHandlerModule.addDeserializer(Date.class, new CustomDateDeserializer());
+        this.objectMapper.registerModule(dateHandlerModule);
     }
 
     /**

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
@@ -143,7 +143,7 @@ public class JsonRpcClient {
      * @param methodCall            the JSON-RPC xapi method call. e.g.: session.login_with_password
      * @param methodParameters      the parameters of the method call
      * @param responseTypeReference the type of the response, wrapped with a TypeReference
-     * @param <T>                   The type of the response's payload. For instance, an array of VMs is expected when calling VM.get_all_records
+     * @param <T>                   The type of the response's payload. For instance, a map of opaque references to VM objects is expected when calling VM.get_all_records
      * @return a JsonRpcResponse object. If its error field is empty, the response was successful.
      * @throws JsonProcessingException if the request's payload or the response's payload cannot be written or read as valid JSON
      * @throws IOException             if an I/O error occurs when sending or receiving

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.xensource.xenapi;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.text.SimpleDateFormat;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provides a JSON-RPC v2.0 client for making remote procedure calls to xapi's backend URL.
+ * <br />
+ * This class enables the communication to the JSON-RPC backend. The client utilizes the HttpClient class for
+ * sending HTTP POST requests with JSON payloads and the ObjectMapper class from the Jackson library for
+ * serialization and deserialization of JSON data.
+ * <br />
+ * The client can be customised by passing it as a parameter to corresponding constructor, enabling custom
+ * handling of requests.
+ * <br />
+ * By default, the timeout for requests is set to 10 minutes (600 seconds). The default timeout for connecting to the
+ * JSON-RPC backend is set to 5 seconds.
+ *
+ * @see HttpClient HttpClient is used to make requests and connect to the backend
+ * @see ObjectMapper ObjectMapper is used to marshall requests and responses
+ */
+public class JsonRpcClient {
+    private static final int DEFAULT_REQUEST_TIMEOUT = 600;
+    private static final int DEFAULT_CONNECTION_TIMEOUT = 5;
+
+    protected static final int MAX_CONCURRENT_CONNECTIONS = 10;
+
+    protected static final String JSON_BACKEND_PATH = "/jsonrpc";
+
+    protected final CloseableHttpClient httpClient;
+    protected final String jsonRpcBackendUrl;
+    protected final ObjectMapper objectMapper;
+    protected final int requestTimeout;
+
+    private final RequestConfig defaultRequestConfig = RequestConfig.custom()
+            .setCookieSpec(StandardCookieSpec.IGNORE)
+            .build();
+
+    /**
+     * Create a JsonRpcClient with default settings.
+     *
+     * @param jsonRpcBackendUrl the URL of the JSON-RPC backend. Usually of the form https://&lt;address&gt;.
+     * @see JsonRpcClient JsonRpcClient for more info on using this class
+     */
+    public JsonRpcClient(URL jsonRpcBackendUrl) {
+        this(jsonRpcBackendUrl, DEFAULT_REQUEST_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
+    }
+
+    /**
+     * Create a JsonRpcClient with the option to define the request and connection timeout values.
+     *
+     * @param jsonRpcBackendUrl the URL of the JSON-RPC backend. Usually of the form https://&lt;address&gt;.
+     * @param requestTimeout    the timeout value for requests.
+     * @param connectionTimeout the timeout value for the initial connection to the host.
+     * @see JsonRpcClient JsonRpcClient for more info on using this class
+     */
+    public JsonRpcClient(URL jsonRpcBackendUrl, int requestTimeout, int connectionTimeout) {
+        var connectionConfig = ConnectionConfig
+                .custom()
+                .setConnectTimeout(connectionTimeout, TimeUnit.SECONDS)
+                .build();
+
+        var connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setDefaultConnectionConfig(connectionConfig);
+        connectionManager.setMaxTotal(MAX_CONCURRENT_CONNECTIONS);
+
+        this.httpClient = HttpClients
+                .custom()
+                .setConnectionManager(connectionManager)
+                .build();
+        this.jsonRpcBackendUrl = formatBackendUrl(jsonRpcBackendUrl);
+        this.requestTimeout = requestTimeout;
+        this.objectMapper = new ObjectMapper();
+        initializeObjectMapperConfiguration();
+    }
+
+    /**
+     * Initialize a JsonRpcClient using a custom HttpClient instance.
+     *
+     * @param client            the custom HttpClient to use for all requests
+     * @param jsonRpcBackendUrl the URL of the JSON-RPC backend. Usually of the form https://&lt;address&gt;.
+     * @param requestTimeout    the timeout value for requests.
+     * @see HttpClient
+     * @see JsonRpcClient JsonRpcClient for more info on using this class
+     */
+    public JsonRpcClient(CloseableHttpClient client, URL jsonRpcBackendUrl, int requestTimeout) {
+        httpClient = client;
+
+        this.requestTimeout = requestTimeout;
+        this.jsonRpcBackendUrl = formatBackendUrl(jsonRpcBackendUrl);
+
+        this.objectMapper = new ObjectMapper();
+        initializeObjectMapperConfiguration();
+    }
+
+    /**
+     * Send a method call to xapi's backend. You need to provide the type of the data returned by a successful response.
+     *
+     * @param methodCall            the JSON-RPC xapi method call. e.g.: session.login_with_password
+     * @param methodParameters      the parameters of the method call
+     * @param responseTypeReference the type of the response, wrapped with a TypeReference
+     * @param <T>                   The type of the response's payload. For instance, an array of VMs is expected when calling VM.get_all_records
+     * @return a JsonRpcResponse object. If its error field is empty, the response was successful.
+     * @throws JsonProcessingException if the request's payload or the response's payload cannot be written or read as valid JSON
+     * @throws IOException             if an I/O error occurs when sending or receiving
+     */
+    public <T> JsonRpcResponse<T> sendRequest(String methodCall, Object[] methodParameters, TypeReference<T> responseTypeReference) throws IOException {
+        var requestBody = objectMapper
+                .writeValueAsString(new JsonRpcRequest(methodCall, methodParameters));
+
+        var requestEntity = new StringEntity(requestBody, ContentType.APPLICATION_JSON);
+
+        var requestConfig = RequestConfig.copy(defaultRequestConfig)
+                .setConnectionRequestTimeout(this.requestTimeout, TimeUnit.SECONDS)
+                .build();
+
+        var request = new HttpPost(this.jsonRpcBackendUrl);
+        request.setConfig(requestConfig);
+        request.setEntity(requestEntity);
+
+        return httpClient.execute(request, response -> {
+            try (response) {
+                var typeFactory = objectMapper.getTypeFactory();
+                var responseObjectType = typeFactory.constructType(responseTypeReference.getType());
+                var type = typeFactory.constructParametricType(JsonRpcResponse.class, responseObjectType);
+
+                var responseContent = response.getEntity().getContent();
+                return objectMapper.readValue(responseContent, type);
+            }
+        });
+    }
+
+    /**
+     * Helper method to initialize jackson's ObjectMapper.
+     */
+    private void initializeObjectMapperConfiguration() {
+        this.objectMapper.setDateFormat(new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss'Z'"));
+    }
+
+    /**
+     * Format input URL to the form protocol://host/jsonrpc
+     *
+     * @param url the input URL to format
+     * @return a string version of a valid xen-api backend URL
+     */
+    private String formatBackendUrl(URL url) {
+        // We only replace it when it's empty.
+        // If the user purposely set the path
+        // we use the given value even if incorrect
+        if (!url.getPath().isEmpty()) {
+            return url.getProtocol() + "://" + url.getHost() + JSON_BACKEND_PATH;
+        }
+        return url.toString();
+    }
+}

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
@@ -44,7 +44,6 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 
 import java.io.IOException;
 import java.net.URL;
-import java.net.http.HttpClient;
 import java.text.SimpleDateFormat;
 import java.util.concurrent.TimeUnit;
 
@@ -61,7 +60,7 @@ import java.util.concurrent.TimeUnit;
  * By default, the timeout for requests is set to 10 minutes (600 seconds). The default timeout for connecting to the
  * JSON-RPC backend is set to 5 seconds.
  *
- * @see HttpClient HttpClient is used to make requests and connect to the backend
+ * @see CloseableHttpClient CloseableHttpClient is used to make requests and connect to the backend
  * @see ObjectMapper ObjectMapper is used to marshall requests and responses
  */
 public class JsonRpcClient {
@@ -120,12 +119,12 @@ public class JsonRpcClient {
     }
 
     /**
-     * Initialize a JsonRpcClient using a custom HttpClient instance.
+     * Initialize a JsonRpcClient using a custom CloseableHttpClient instance.
      *
      * @param client            the custom HttpClient to use for all requests
      * @param jsonRpcBackendUrl the URL of the JSON-RPC backend. Usually of the form https://&lt;address&gt;.
      * @param requestTimeout    the timeout value for requests.
-     * @see HttpClient
+     * @see CloseableHttpClient CloseableHttpClient the client that will be used for dispatching requests
      * @see JsonRpcClient JsonRpcClient for more info on using this class
      */
     public JsonRpcClient(CloseableHttpClient client, URL jsonRpcBackendUrl, int requestTimeout) {

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
@@ -222,7 +222,7 @@ public class JsonRpcClient {
         // We only replace it when it's empty.
         // If the user purposely set the path
         // we use the given value even if incorrect
-        if (!url.getPath().isEmpty()) {
+        if (url.getPath().isEmpty()) {
             return url.getProtocol() + "://" + url.getHost() + JSON_BACKEND_PATH;
         }
         return url.toString();

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcRequest.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcRequest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.xensource.xenapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Represents the payload of a request sent to a
+ * JSON-RPC v2.0 backend.
+ */
+public class JsonRpcRequest {
+    @JsonProperty("jsonrpc")
+    public String jsonRpc;
+    public int id;
+    public String method;
+    @JsonProperty("params")
+    public Object[] parameters;
+
+    public JsonRpcRequest(String method, Object[] parameters) {
+        this.method = method;
+        this.parameters = parameters;
+        this.jsonRpc = "2.0";
+        this.id = 1;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            var mapper = new ObjectMapper();
+            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException ex) {
+            return "Error while processing object. Could not serialize as JSON.";
+        }
+    }
+}

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcResponse.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcResponse.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) Cloud Software Group, Inc.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -29,48 +29,31 @@
 
 package com.xensource.xenapi;
 
-import java.util.*;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
- * Marshalls Java types onto the wire.
- * Does not cope with records.  Use individual record.toMap()
+ * Represents the payload of responses returned from a
+ * JSON-RPC v2.0 backend.
+ * @param <T> The type of the response's result
  */
-public final class Marshalling {
-    /**
-     * Converts Integers to Strings
-     * and Sets to Lists recursively.
-     */
-    public static Object toXMLRPC(Object o) {
-        if (o instanceof String ||
-            o instanceof Boolean ||
-            o instanceof Double ||
-            o instanceof Date) {
-            return o;
-	} else if (o instanceof Long) {
-	    return o.toString();
-        } else if (o instanceof Map) {
-            Map<Object, Object> result = new HashMap<Object, Object>();
-            Map m = (Map)o;
-            for (Object k : m.keySet())
-            {
-                result.put(toXMLRPC(k), toXMLRPC(m.get(k)));
-            }
-            return result;
-        } else if (o instanceof Set) {
-            List<Object> result = new ArrayList<Object>();
-            for (Object e : ((Set)o))
-            {
-                result.add(toXMLRPC(e));
-            }
-            return result;
-	} else if (o instanceof XenAPIObject) {
-	    return ((XenAPIObject) o).toWireString();
-	} else if (o instanceof Enum) {
-	    return o.toString();
-	}else if (o == null){
-	    return "";
-        } else {
-		throw new RuntimeException ("=============don't know how to marshall:({[" + o + "]})");
+public class JsonRpcResponse<T> {
+    @JsonProperty("jsonrpc")
+    public String jsonRpc;
+    public int id;
+    public T result;
+    public JsonRpcResponseError error;
+
+    @Override
+    public String toString() {
+        try {
+            var mapper = new ObjectMapper();
+            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException ex) {
+            return "Error while processing object. Could not serialize as JSON";
         }
     }
 }

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcResponseError.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcResponseError.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.xensource.xenapi;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Represents the structure of an error returned by a
+ * JSON-RPC v2.0 backend. Does not apply to JSON-RPC v1.0.
+ */
+public class JsonRpcResponseError {
+    public int code;
+    public String message;
+    public String[] data;
+
+    public String toString() {
+        try {
+            var mapper = new ObjectMapper();
+            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException ex) {
+            return "Error while processing object. Could not serialize as JSON.";
+        }
+    }
+}

--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/resources/README.txt
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/resources/README.txt
@@ -39,5 +39,6 @@ https://discussions.citrix.com/forum/101-hypervisor-formerly-xenserver/
 Dependencies
 ------------
 
-XenServerJava is dependent upon Apache XML-RPC by the Apache Software Foundation,
-licensed under the Apache Software License 2.0.
+XenServerJava is dependent upon:
+- The jackson-databind (https://github.com/FasterXML/jackson-databind) package by the Jackson Project (https://github.com/FasterXML/jackson), licensed under the Apache Software License 2.0.
+- The Apache HttpClient (https://hc.apache.org/httpcomponents-client/) package by the Apache Software Foundation (https://www.apache.org/), licensed under the Apache Software License 2.0.

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -233,11 +233,11 @@ let gen_method file cls message params async_version =
       , "Thrown if the response from the server contains an invalid status."
       )
     ; ("XenAPIException", "if the call failed.")
-    ; ( "JsonProcessingException"
-      , "if the request's payload or the response's payload cannot be written \
-         or read as valid JSON."
+    ; ( "IOException"
+      , "if an I/O error occurs when sending or receiving, includes cases when \
+         the request's payload or the response's payload cannot be written or \
+         read as valid JSON."
       )
-    ; ("IOException", "if an I/O error occurs when sending or receiving.")
     ]
   in
   let publishInfo = get_published_info_message message cls in
@@ -522,7 +522,6 @@ let gen_class cls folder =
   fprintf file
     {|package com.xensource.xenapi;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.xensource.xenapi.Types.BadServerResponse;
 import com.xensource.xenapi.Types.XenAPIException;

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -234,9 +234,8 @@ let gen_method file cls message params async_version =
       )
     ; ("XenAPIException", "if the call failed.")
     ; ( "IOException"
-      , "if an I/O error occurs when sending or receiving, includes cases when \
-         the request's payload or the response's payload cannot be written or \
-         read as valid JSON."
+      , "if an error occurs during a send or receive. This includes cases \
+         where a payload is invalid JSON."
       )
     ]
   in
@@ -420,7 +419,7 @@ and gen_record_tostring_contents file prefix = function
 
 let field_default = function
   | SecretString | String ->
-      "\"\""
+      {|""|}
   | Int ->
       "0"
   | Float ->
@@ -438,7 +437,7 @@ let field_default = function
   | Map (t1, t2) ->
       sprintf "new HashMap<%s, %s>()" (get_java_type t1) (get_java_type t2)
   | Ref ty ->
-      sprintf "new %s(\"OpaqueRef:NULL\")" (class_case ty)
+      sprintf {|new %s("OpaqueRef:NULL")|} (class_case ty)
   | Record _ ->
       assert false
   | Option _ ->
@@ -611,15 +610,12 @@ let gen_enum file name ls =
       global_replace (regexp_string "\n") "\n         * " escaped_description
     in
     let comment =
-      "        /**\n"
-      ^ "         * "
-      ^ final_description
-      ^ "\n"
-      ^ "         */\n"
+      String.concat "\n"
+        ["        /**"; "         * " ^ final_description; "         */"]
     in
     let json_property =
       if name != "UNRECOGNIZED" then
-        "@JsonProperty(\"" ^ name ^ "\")"
+        {|@JsonProperty("|} ^ name ^ {|"|}
       else
         "@JsonEnumDefaultValue"
     in

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -520,16 +520,18 @@ let gen_class cls folder =
   let publishInfo = get_published_info_class cls in
   print_license file ;
   fprintf file
-    "package com.xensource.xenapi;\n\n\
-     import com.fasterxml.jackson.annotation.JsonProperty;\n\
-     import com.fasterxml.jackson.core.JsonProcessingException;\n\
-     import com.fasterxml.jackson.core.type.TypeReference;\n\
-     import com.xensource.xenapi.Types.BadServerResponse;\n\
-     import com.xensource.xenapi.Types.XenAPIException;\n\n\
-     import java.io.PrintWriter;\n\
-     import java.io.StringWriter;\n\
-     import java.util.*;\n\
-     import java.io.IOException;\n\n" ;
+    {|package com.xensource.xenapi;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.xensource.xenapi.Types.BadServerResponse;
+import com.xensource.xenapi.Types.XenAPIException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.*;
+import java.io.IOException;
+
+|} ;
   fprintf file "/**\n" ;
   fprintf file " * %s\n" cls.description ;
   if not (publishInfo = "") then fprintf file " * %s\n" publishInfo ;
@@ -684,122 +686,123 @@ let gen_method_error_throw file name error =
       )
   in
 
-  fprintf file "            if (errorName.equals(\"%s\"))\n" name ;
-  fprintf file "            {\n" ;
+  fprintf file "       if (errorName.equals(\"%s\")){\n" name ;
 
   (* Prepare the parameters to the Exception constructor *)
   List.iter
     (fun i ->
       fprintf file
-        "                String p%i = errorData.length > %i ? errorData[%i] : \
-         \"\";\n"
+        "           String p%i = errorData.length > %i ? errorData[%i] : \"\";\n"
         i i i
     )
     (range (List.length error.err_params)) ;
 
-  fprintf file "                throw new Types.%s(%s);\n" class_name paramsStr ;
-  fprintf file "            }\n"
+  fprintf file "           throw new Types.%s(%s);\n" class_name paramsStr ;
+  fprintf file "       }\n"
 
 let gen_types_class folder =
   let class_name = "Types" in
   let file = open_out (Filename.concat folder class_name ^ ".java") in
   print_license file ;
   fprintf file
-    "package com.xensource.xenapi;\n\n\
-     import java.util.Map;\n\n\
-     import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;\n\
-     import com.fasterxml.jackson.annotation.JsonProperty;\n\
-     import java.io.IOException;\n\n\
-     /**\n\
-    \ * This class holds enum types and exceptions.\n\
-    \ */\n\
-     public class Types\n\
-     {\n\
-    \    /**\n\
-    \     * Interface for all Record classes\n\
-    \     */\n\
-    \    public interface Record\n\
-    \    {\n\
-    \        /**\n\
-    \         * Convert a Record to a Map\n\
-    \         */\n\
-    \        Map<String, Object> toMap();\n\
-    \    }\n\n\
-    \    /**\n\
-    \     * Base class for all XenAPI Exceptions\n\
-    \     */\n\
-    \    public static class XenAPIException extends IOException {\n\
-    \        public final String shortDescription;\n\
-    \        public final String[] errorDescription;\n\n\
-    \        XenAPIException(String shortDescription)\n\
-    \        {\n\
-    \            this.shortDescription = shortDescription;\n\
-    \            this.errorDescription = null;\n\
-    \        }\n\n\
-    \        XenAPIException(String[] errorDescription)\n\
-    \        {\n\
-    \            this.errorDescription = errorDescription;\n\n\
-    \            if (errorDescription.length > 0)\n\
-    \            {\n\
-    \                shortDescription = errorDescription[0];\n\
-    \            } else\n\
-    \            {\n\
-    \                shortDescription = \"\";\n\
-    \            }\n\
-    \        }\n\n\
-    \        public String toString()\n\
-    \        {\n\
-    \            if (errorDescription == null)\n\
-    \            {\n\
-    \                return shortDescription;\n\
-    \            } else if (errorDescription.length == 0)\n\
-    \            {\n\
-    \                return \"\";\n\
-    \            }\n\
-    \            StringBuilder sb = new StringBuilder();\n\
-    \            for (int i = 0; i < errorDescription.length - 1; i++)\n\
-    \            {\n\
-    \                sb.append(errorDescription[i]);\n\
-    \            }\n\
-    \            sb.append(errorDescription[errorDescription.length - 1]);\n\n\
-    \            return sb.toString();\n\
-    \        }\n\
-    \    }\n\
-    \    /**\n\
-    \     * Thrown if the response from the server contains an invalid status.\n\
-    \     */\n\
-    \    public static class BadServerResponse extends XenAPIException\n\
-    \    {\n\
-    \        public BadServerResponse(JsonRpcResponseError responseError)\n\
-    \        {\n\
-    \            super(String.valueOf(responseError));\n\
-    \        }\n\
-    \    }\n\n\
-    \  " ;
+    {|package com.xensource.xenapi;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.IOException;
+
+/**
+ * This class holds enum types and exceptions.
+ */
+public class Types
+{
+   /**
+    * Interface for all Record classes
+    */
+   public interface Record
+   {
+       /**
+        * Convert a Record to a Map
+        */
+       Map<String, Object> toMap();
+   }
+   /**
+    * Base class for all XenAPI Exceptions
+    */
+   public static class XenAPIException extends IOException {
+       public final String shortDescription;
+       public final String[] errorDescription;
+       XenAPIException(String shortDescription)
+       {
+           this.shortDescription = shortDescription;
+           this.errorDescription = null;
+       }
+       XenAPIException(String[] errorDescription)
+       {
+           this.errorDescription = errorDescription;
+           if (errorDescription.length > 0)
+           {
+               shortDescription = errorDescription[0];
+           } else
+           {
+               shortDescription = "";
+           }
+       }
+       public String toString()
+       {
+           if (errorDescription == null)
+           {
+               return shortDescription;
+           } else if (errorDescription.length == 0)
+           {
+               return "";
+           }
+           StringBuilder sb = new StringBuilder();
+           for (int i = 0; i < errorDescription.length - 1; i++)
+           {
+               sb.append(errorDescription[i]);
+           }
+           sb.append(errorDescription[errorDescription.length - 1]);
+           return sb.toString();
+       }
+   }
+   /**
+    * Thrown if the response from the server contains an invalid status.
+    */
+   public static class BadServerResponse extends XenAPIException
+   {
+       public BadServerResponse(JsonRpcResponseError responseError)
+       {
+           super(String.valueOf(responseError));
+       }
+   }
+|} ;
 
   fprintf file
-    "    /**\n\
-    \     * Checks the provided server response was successful. If the call \
-     failed, throws a XenAPIException. If the server\n\
-    \     * returned an invalid response, throws a BadServerResponse. \
-     Otherwise, returns the server response as passed in.\n\
-    \     */\n\
-    \    public static void checkError(JsonRpcResponseError response) throws \
-     XenAPIException, BadServerResponse\n\
-    \    {\n\
-    \        var errorData = response.data;\n\
-    \            if(errorData.length == 0){\n\
-    \                throw new BadServerResponse(response);\n\
-    \            }\n\
-    \            var errorName = errorData[0];\n\n" ;
+    {|   /**
+   * Checks the provided server response was successful. If the call
+   * failed, throws a XenAPIException. If the server
+   * returned an invalid response, throws a BadServerResponse.
+   * Otherwise, returns the server response as passed in.
+   */
+   public static void checkError(JsonRpcResponseError response) throws XenAPIException, BadServerResponse
+   {
+       var errorData = response.data;
+       if(errorData.length == 0){
+           throw new BadServerResponse(response);
+       }
+       var errorName = errorData[0];
+|} ;
 
   Hashtbl.iter (gen_method_error_throw file) Datamodel.errors ;
 
   fprintf file
-    "\n\
-    \        // An unknown error occurred\n\
-    \        throw new Types.XenAPIException(errorData);\n\
-    \     }\n\n" ;
+    {|
+    // An unknown error occurred
+    throw new Types.XenAPIException(errorData);
+}
+
+|} ;
 
   gen_enums file ;
   fprintf file "\n" ;

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -336,8 +336,7 @@ let gen_method file cls message params async_version =
       get_method_params_for_xml message params
   in
 
-  output_string file
-    (String.concat ", " (List.map (fun s -> sprintf "%s" s) methodParamsList)) ;
+  output_string file (String.concat ", " methodParamsList) ;
 
   fprintf file "};\n" ;
 

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -691,8 +691,8 @@ let gen_method_error_throw file name error =
   List.iter
     (fun i ->
       fprintf file
-        "                String p%i = errorData.length > %i ? \
-        errorData[%i] : \"\";\n"
+        "                String p%i = errorData.length > %i ? errorData[%i] : \
+         \"\";\n"
         i i i
     )
     (range (List.length error.err_params)) ;
@@ -706,10 +706,10 @@ let gen_types_class folder =
   print_license file ;
   fprintf file
     "package com.xensource.xenapi;\n\n\
-    import java.util.Map;\n\n\
-    import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;\n\
-    import com.fasterxml.jackson.annotation.JsonProperty;\n\
-    import java.io.IOException;\n\n\
+     import java.util.Map;\n\n\
+     import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;\n\
+     import com.fasterxml.jackson.annotation.JsonProperty;\n\
+     import java.io.IOException;\n\n\
      /**\n\
     \ * This class holds enum types and exceptions.\n\
     \ */\n\
@@ -784,14 +784,14 @@ let gen_types_class folder =
     \     * returned an invalid response, throws a BadServerResponse. \
      Otherwise, returns the server response as passed in.\n\
     \     */\n\
-    \    public static void checkError(JsonRpcResponseError response) throws XenAPIException, \
-     BadServerResponse\n\
+    \    public static void checkError(JsonRpcResponseError response) throws \
+     XenAPIException, BadServerResponse\n\
     \    {\n\
-    \        var errorData = response.data;
-    \        if(errorData.length == 0){
-    \            throw new BadServerResponse(response);
-    \        }
-    \        var errorName = errorData[0];\n\n" ;
+    \        var errorData = response.data;\n\
+    \            if(errorData.length == 0){\n\
+    \                throw new BadServerResponse(response);\n\
+    \            }\n\
+    \            var errorName = errorData[0];\n\n" ;
 
   Hashtbl.iter (gen_method_error_throw file) Datamodel.errors ;
 

--- a/ocaml/sdk-gen/java/main.mli
+++ b/ocaml/sdk-gen/java/main.mli
@@ -1,0 +1,1 @@
+(* Empty .mli to ensure unused functions are picked up during check*)

--- a/ocaml/sdk-gen/powershell/common_functions.ml
+++ b/ocaml/sdk-gen/powershell/common_functions.ml
@@ -197,7 +197,6 @@ and cut_msg_name message_name fn_type =
   else
     message_name
 
-(* True if an object has a uuid (and therefore should have a get_by_uuid message *)
 and has_uuid x =
   let all_fields = DU.fields_of_obj x in
   List.filter (fun fld -> fld.full_name = ["uuid"]) all_fields <> []

--- a/ocaml/sdk-gen/powershell/common_functions.ml
+++ b/ocaml/sdk-gen/powershell/common_functions.ml
@@ -144,7 +144,7 @@ and is_invoke message =
   && (not (is_constructor message))
   && not (is_destructor message)
 
-(* Some adders/removers are just prefixed by Add or RemoveFrom
+(* Some adders/removers are just prefixed by Add or Remove
    and some are prefixed by AddTo or RemoveFrom *)
 and cut_msg_name message_name fn_type =
   let name_len = String.length message_name in

--- a/ocaml/sdk-gen/powershell/common_functions.ml
+++ b/ocaml/sdk-gen/powershell/common_functions.ml
@@ -8,7 +8,7 @@ open Datamodel_types
 open CommonFunctions
 module DU = Datamodel_utils
 
-let rec pascal_case_ s =
+let rec pascal_case_rec s =
   let ss =
     Astring.String.cuts ~sep:"_" ~empty:true s
     |> List.map String.capitalize_ascii
@@ -30,7 +30,7 @@ let rec pascal_case_ s =
       h' ^ String.concat "" tl
 
 and pascal_case s =
-  let str = pascal_case_ s in
+  let str = pascal_case_rec s in
   if
     String.starts_with ~prefix:"set" (String.lowercase_ascii str)
     || String.starts_with ~prefix:"get" (String.lowercase_ascii str)
@@ -197,7 +197,7 @@ and get_http_action_stem name =
   let parts = Astring.String.cuts ~sep:"_" name in
   let filtered = List.filter trim_http_action_stem parts in
   let trimmed = String.concat "_" filtered in
-  match trimmed with "" -> pascal_case_ "vm" | _ -> pascal_case_ trimmed
+  match trimmed with "" -> pascal_case_rec "vm" | _ -> pascal_case_rec trimmed
 
 and trim_http_action_stem x =
   match x with

--- a/ocaml/sdk-gen/powershell/common_functions.ml
+++ b/ocaml/sdk-gen/powershell/common_functions.ml
@@ -59,9 +59,6 @@ and ocaml_class_to_csharp_local_var classname =
   else
     String.lowercase_ascii (exposed_class_name classname)
 
-and ocaml_field_to_csharp_local_var field =
-  String.lowercase_ascii (full_name field)
-
 and ocaml_field_to_csharp_property field =
   ocaml_class_to_csharp_property (full_name field)
 
@@ -86,38 +83,9 @@ and exposed_class_name classname =
 
 and qualified_class_name classname = "XenAPI." ^ exposed_class_name classname
 
-and type_default ty =
-  match ty with
-  | Int ->
-      ""
-  | SecretString | String ->
-      ""
-  | Float ->
-      ""
-  | Bool ->
-      ""
-  | Enum _ ->
-      ""
-  | Record _ ->
-      ""
-  | Ref _ ->
-      ""
-  | Map (_, _) ->
-      " = new Hashtable()"
-  | Set String ->
-      " = new string[0]"
-  | _ ->
-      sprintf " = new %s()" (exposed_type ty)
-
 and escaped = function "params" -> "paramz" | s -> s
 
 and full_name field = escaped (String.concat "_" field.full_name)
-
-and exposed_type_opt = function
-  | Some (typ, _) ->
-      exposed_type typ
-  | None ->
-      "void"
 
 and exposed_type = function
   | SecretString | String ->

--- a/ocaml/sdk-gen/powershell/common_functions.mli
+++ b/ocaml/sdk-gen/powershell/common_functions.mli
@@ -14,7 +14,7 @@ val get_common_verb_category : string -> string
     @param verb - HTTP action verb.
     @return Common verb category. *)
 
-val pascal_case_ : string -> string
+val pascal_case_rec : string -> string
 (** Recursively converts a string to PascalCase.
     @param s - String to convert.
     @return PascalCase formatted string. *)

--- a/ocaml/sdk-gen/powershell/common_functions.mli
+++ b/ocaml/sdk-gen/powershell/common_functions.mli
@@ -86,13 +86,13 @@ val exposed_class_name : string -> string
 
 val cut_msg_name : string -> string -> string
 (** Extracts the base name from an OCaml message name by removing the specified prefix.
-   Some adders/removers are just prefixed by Add or RemoveFrom
-      and some are prefixed by AddTo or RemoveFrom
-      @param message_name - OCaml message name.
-      @param fn_type - Prefix to remove ("Add" or "Remove").
-      @return Base name after removing the specified prefix. *)
+    Some adders/removers are just prefixed by Add or Remove and some are prefixed by
+    AddTo or RemoveFrom.
+    @param message_name - OCaml message name.
+    @param fn_type - Prefix to remove ("Add" or "Remove").
+    @return Base name after removing the specified prefix. *)
 
 val lower_and_underscore_first : string -> string
 (** Converts a string to lowercase and adds an underscore at the beginning.
-   @param s - Input string.
-   @return String in lowercase with an underscore at the beginning. *)
+    @param s - Input string.
+    @return String in lowercase with an underscore at the beginning. *)

--- a/ocaml/sdk-gen/powershell/common_functions.mli
+++ b/ocaml/sdk-gen/powershell/common_functions.mli
@@ -1,0 +1,98 @@
+val get_http_action_stem : string -> string
+(** Gets the HTTP action stem based on the name.
+    @param name - Name to analyze.
+    @return HTTP action stem. *)
+
+val get_http_action_verb : string -> Datamodel.http_meth -> string
+(** Gets the HTTP action verb based on the name and method.
+    @param name - Name to analyze.
+    @param meth - HTTP method.
+    @return HTTP action verb. *)
+
+val get_common_verb_category : string -> string
+(** Gets the common verb category based on the HTTP action verb.
+    @param verb - HTTP action verb.
+    @return Common verb category. *)
+
+val pascal_case_ : string -> string
+(** Recursively converts a string to PascalCase.
+    @param s - String to convert.
+    @return PascalCase formatted string. *)
+
+val qualified_class_name : string -> string
+(** Gets the qualified class name by prepending "XenAPI." to the exposed class name.
+    @param classname - Class name.
+    @return Qualified class name. *)
+
+val ocaml_class_to_csharp_local_var : string -> string
+(** Converts an OCaml class name to a C# local variable.
+    @param classname - OCaml class name.
+    @return C# local variable name. *)
+
+val ocaml_class_to_csharp_property : string -> string
+(** Converts an OCaml class name to a C# property name.
+    @param classname - OCaml class name.
+    @return C# property name. *)
+
+val ocaml_class_to_csharp_class : string -> string
+(** Converts an OCaml class name to a C# class name.
+    @param classname - OCaml class name.
+    @return C# class name. *)
+
+val is_invoke : Datamodel_types.message -> bool
+(** Checks if a message is an invoke operation.
+    @param message - Message to check.
+    @return true if it's an invoke operation, false otherwise. *)
+
+val has_uuid : Datamodel_types.obj -> bool
+(** Checks if an object has a UUID field, and therefore should have a get_by_uuid message.
+    @param x - Object to check.
+    @return true if the object has a UUID field, false otherwise. *)
+
+val has_name : Datamodel_types.obj -> bool
+(** Checks if an object has a name field.
+    @param x - Object to check.
+    @return true if the object has a name field, false otherwise. *)
+
+val full_name : Datamodel_types.field -> string
+(** Gets the full name of a field as a single string with underscores escaped.
+    @param field - Field to extract the full name from.
+    @return Full name with underscores escaped. *)
+
+val obj_internal_type : Datamodel_types.ty -> string
+(** Gets the internal type representation of an object.
+    @param x - Object to determine the internal type for.
+    @return Internal type representation as a string. *)
+
+val ocaml_field_to_csharp_property : Datamodel_types.field -> string
+(** Converts an OCaml field to its corresponding C# property name.
+    @param field - OCaml field.
+    @return C# property name. *)
+
+val exposed_type : Datamodel_types.ty -> string
+(** Converts an exposed type from OCaml to its corresponding C# type.
+    @param ty - OCaml type.
+    @return Corresponding C# type. *)
+
+val pascal_case : string -> string
+(** Converts a string to PascalCase.
+    @param s - Input string.
+    @return PascalCase formatted string. *)
+
+val exposed_class_name : string -> string
+(** Converts an OCaml class name to a corresponding exposed class name in C#.
+    @param classname - OCaml class name.
+    @return Exposed class name in C#. *)
+
+val cut_msg_name : string -> string -> string
+(** Extracts the base name from an OCaml message name by removing the specified prefix.
+   Some adders/removers are just prefixed by Add or RemoveFrom
+      and some are prefixed by AddTo or RemoveFrom
+      @param message_name - OCaml message name.
+      @param fn_type - Prefix to remove ("Add" or "Remove").
+      @return Base name after removing the specified prefix. *)
+
+val lower_and_underscore_first : string -> string
+(** Converts a string to lowercase and adds an underscore at the beginning.
+   @param s - Input string.
+   @return String in lowercase with an underscore at the beginning. *)

--- a/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
+++ b/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
@@ -171,14 +171,14 @@ and gen_arg_param = function
           else
             ""
         )
-        (pascal_case_ x)
+        (pascal_case_rec x)
   | Int64_query_arg x ->
       sprintf "\n        [Parameter]\n        public long? %s { get; set; }\n"
-        (pascal_case_ x)
+        (pascal_case_rec x)
   | Bool_query_arg x ->
       let y = if x = "host" then "is_host" else x in
       sprintf "\n        [Parameter]\n        public bool? %s { get; set; }\n"
-        (pascal_case_ y)
+        (pascal_case_rec y)
   | Varargs_query_arg ->
       sprintf
         "\n\
@@ -214,12 +214,12 @@ and gen_call_arg_params args =
 
 and gen_call_arg_param = function
   | String_query_arg x ->
-      sprintf ", %s" (pascal_case_ x)
+      sprintf ", %s" (pascal_case_rec x)
   | Int64_query_arg x ->
-      sprintf ", %s" (pascal_case_ x)
+      sprintf ", %s" (pascal_case_rec x)
   | Bool_query_arg x ->
       let y = if x = "host" then "is_host" else x in
-      sprintf ", %s" (pascal_case_ y)
+      sprintf ", %s" (pascal_case_rec y)
   | Varargs_query_arg ->
       sprintf ", Args"
 

--- a/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
+++ b/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
@@ -19,8 +19,6 @@ end)
 
 let destdir = "autogen/src"
 
-let templdir = "templates"
-
 type cmdlet = {filename: string; content: string}
 
 let api =

--- a/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
+++ b/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
@@ -552,15 +552,6 @@ and print_methods_constructor message obj classname =
     (gen_shouldprocess "New" message classname)
     (gen_csharp_api_call message classname "New" "passthru")
 
-and create_param_parse param paramName =
-  match param.param_type with
-  | Ref _ ->
-      sprintf "\n            string %s = %s.opaque_ref;\n"
-        (String.lowercase_ascii param.param_name)
-        paramName
-  | _ ->
-      ""
-
 and gen_make_record obj classname =
   sprintf
     "\n\
@@ -1144,37 +1135,6 @@ and print_cmdlet_methods_dynamic classname messages enum commonVerb =
         (ocaml_class_to_csharp_class classname)
         enum (cut_message_name hd) (cut_message_name hd) localVar
         (print_cmdlet_methods_dynamic classname tl enum commonVerb)
-
-and print_async_param_getter classname asyncMessages =
-  let properties =
-    List.map
-      (fun x ->
-        sprintf "                    case Xen%sProperty.%s:"
-          (ocaml_class_to_csharp_class classname)
-          x
-      )
-      asyncMessages
-  in
-  match asyncMessages with
-  | [] ->
-      ""
-  | _ ->
-      sprintf
-        "\n\
-        \        protected override bool GenerateAsyncParam\n\
-        \        {\n\
-        \            get\n\
-        \            {\n\
-        \                switch (XenProperty)\n\
-        \                {\n\
-         %s\n\
-        \                        return true;\n\
-        \                    default:\n\
-        \                        return false;\n\
-        \                }\n\
-        \            }\n\
-        \        }\n"
-        (String.concat "\n" properties)
 
 (**************************************)
 (* Common to more than one generators *)

--- a/ocaml/sdk-gen/powershell/gen_powershell_binding.mli
+++ b/ocaml/sdk-gen/powershell/gen_powershell_binding.mli
@@ -1,0 +1,1 @@
+(* Empty .mli to ensure unused functions are picked up during check*)

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=530
+  N=522
   # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
   MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)


### PR DESCRIPTION
I suggest reviewing commits one at a time.

I also suggest you check out and run the output, I have built it against my SDK tag, feel free to ask for info.

As discussed this makes use of Apache's client since the Java stdlib one was having issues with the connection pool.

I am however not exposing request configuration (except timeouts). This would be trivial-ish but I didn't want to add bloat.

I have only implemented sync calls for the HTTP client. We could add the option to pass callbacks to calls and make it fully async but it's out of scope and I didn't want to make reviews even longer. 

Other notable changes:
- Now using `HashSet` instead of the generic `Set` for relevant types
- Marshalling in `Types.java` and other places has mostly been replaced by type handling from Jackson's `ObjectMapper`. This makes the source much smaller and arguably easier to understand. I have tried to start remote calls without a lot of issues. The only change needed was setting the date format to ISO 8601 Zulu instead of simple ISO 8601. Haven't encountered issues though there's the chance that xapi will send back dates with a different format. In that case I'd argue we should fix xapi, instead.
- As part of this PR I have added the options for SDK consumers to pass their own `ConsumableHttpClient` with their preferred configuration, which should suffice for most advanced usage. We had a similar PR raised against the C# SDK so I thought it'd be a nice addition.
- I have set the max no. of concurrent connections per host connection to `10`. In XenCenter we do 3(?) but I didn't want to limit the SDK. I could also leave them unlimited so feel free to weigh in.
- As part of the review requests, I have added `mli` files to ensure we don't miss unused functions.  I have only added definitions for functions that are actually consumed outside the files, so `mli` definitions for the files that end up as generation binaries are excluded.