### PR TITLE
Simplify scanning /sys/block/<dev>/ stats for iostat

### DIFF
--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,7 +3,7 @@
 set -e
 
 list-hd () {
-  N=320
+  N=318
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD List.hd usages"


### PR DESCRIPTION
Use scanf to to read the stats provided by the /sys file system. This rest of the code is still quite convoluted. In case of an error we are returning 0 values - not sure this is a good choice.