### PR TITLE
CA-384148 enable logging for redo_log_alert

### DIFF
--- a/ocaml/database/db_globs.ml
+++ b/ocaml/database/db_globs.ml
@@ -35,7 +35,7 @@ let redo_log_max_dying_processes = 2
 let redo_log_comms_socket_stem = "sock-blkdev-io"
 
 (** The maximum time, in seconds, for which we are prepared to wait for a response from the block device I/O process before assuming that it has died while initially connecting to it *)
-let redo_log_max_startup_time = ref 10.
+let redo_log_max_startup_time = ref 5.
 
 (** The length, in bytes, of one redo log which constitutes half of the VDI *)
 let redo_log_length_of_half = 60 * 1024 * 1024

--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -123,6 +123,7 @@ let disable log =
 let redo_log_events = Event.new_channel ()
 
 let cannot_connect_fn log =
+  D.debug "%s" __FUNCTION__ ;
   if !(log.currently_accessible) then (
     D.debug "Signalling unable to access redo log" ;
     Event.sync (Event.send redo_log_events (log.name, false)) ;
@@ -131,6 +132,7 @@ let cannot_connect_fn log =
   log.currently_accessible := false
 
 let can_connect_fn log =
+  D.debug "%s" __FUNCTION__ ;
   if not !(log.currently_accessible) then (
     D.debug "Signalling redo log is healthy" ;
     Event.sync (Event.send redo_log_events (log.name, true)) ;
@@ -611,11 +613,13 @@ let shutdown log =
   )
 
 let broken log =
+  D.debug "%s" __FUNCTION__ ;
   set_time_of_last_failure log ;
   shutdown log ;
   cannot_connect_fn log
 
 let healthy log =
+  D.debug "%s" __FUNCTION__ ;
   reset_time_of_last_failure log ;
   can_connect_fn log
 

--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -626,7 +626,6 @@ let healthy log =
 exception TooManyProcesses
 
 let startup log =
-  with_lock log.mutex @@ fun () ->
   if is_enabled log then (
     try
       ( match !(log.pid) with

--- a/ocaml/xapi/redo_log_alert.ml
+++ b/ocaml/xapi/redo_log_alert.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module R = Debug.Make (struct let name = "redo_log" end)
+module R = Debug.Make (struct let name = __MODULE__ end)
 
 open R
 


### PR DESCRIPTION
Logging or redo_log is disable in xapi.conf. By logging under the module name, enable it for this module.