### PR TITLE
CA-385315: document the certificates' fingerprints hash algorithm

### DIFF
--- a/ocaml/idl/datamodel_certificate.ml
+++ b/ocaml/idl/datamodel_certificate.ml
@@ -65,6 +65,6 @@ let t =
           "Date before which the certificate is valid"
       ; field ~qualifier:StaticRO ~lifecycle ~ty:String "fingerprint"
           ~default_value:(Some (VString ""))
-          "The certificate's fingerprint / hash"
+          "The certificate's SHA256 fingerprint / hash"
       ]
     ~messages:[] ()

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 767
+let schema_minor_vsn = 768
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "95077aed35b715c362c7cf98902de578"
+let last_known_schema_hash = "8ff8c73b261e332b889583c8b2df5ecc"
 
 let current_schema_hash : string =
   let open Datamodel_types in


### PR DESCRIPTION
The hashes in the database always use SHA256