### PR TITLE
CA-385323: fix xapi-guard reconnection on toolstack restart

### DIFF
--- a/ocaml/xapi-guard/src/main.ml
+++ b/ocaml/xapi-guard/src/main.ml
@@ -114,7 +114,6 @@ let listen_for_vm {Persistent.vm_uuid; path; gid; typ} =
   ) else (
     D.debug "%s: listening for %s on socket %s for VM %s" __FUNCTION__
       (ty_to_string typ) path vm_uuid_str ;
-    let* () = safe_unlink path in
     let* stop_server = make_server ~cache path vm_uuid_str in
     let* () = log_fds () in
     Hashtbl.add sockets path (stop_server, (vm_uuid, gid, typ)) ;

--- a/ocaml/xapi-idl/guard/privileged/interface.ml
+++ b/ocaml/xapi-idl/guard/privileged/interface.ml
@@ -72,6 +72,11 @@ module RPC_API (R : RPC) = struct
   (** each VM gets its own group id = qemu_base + domid *)
   let gid_p = Param.mk ~name:"gid" ~description:["socket group id"] Types.int
 
+  let reconnect =
+    declare "reconnect"
+      ["Tell xapi-guard to reconnect to XAPI, which is now up"]
+      (debug_info_p @-> returning unit_p err)
+
   let varstore_create =
     let vm_uuid_p = Param.mk ~name:"vm_uuid" ~description:["VM UUID"] vm_uuid in
     declare "varstore_create"

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1486,6 +1486,11 @@ let server_init () =
                 Xapi_host.write_uefi_certificates_to_disk ~__context
                   ~host:(Helpers.get_localhost ~__context)
             )
+          ; ( "Reconnect xapi-guard"
+            , [Startup.OnThread]
+            , fun () ->
+                Xapi_idl_guard_privileged.Client.reconnect "XAPI startup"
+            )
           ; ( "writing init complete"
             , []
             , fun () -> Helpers.touch_file !Xapi_globs.init_complete


### PR DESCRIPTION
On startup xapi-guard will attempt to listen on 'xapi-depriv-socket' for previously running VMs. It first unlinks the socket, then attempts to connect to XAPI to fetch the VM UUID for each socket, and then call 'bind'. If this fails then the socket will be gone and swtpm/varstored cannot serve those VMs until xapi-guard is restarted again.

This is fine when xapi-guard is restarted on its own (XAPI is up), but it fails during toolstack restart where XAPI may not have completed initializiation by the time xapi-guard attempts to start.

We could fix this by adding a dependency on xapi-init-complete in varstored-guard.service, but debugging that if it goes wrong is more difficult. Instead define a new 'reconnect' API which XAPI will call on startup, which gets explicitly logged, and is easier to trace if it goes wrong.