### PR TITLE
`xe pif-list` default params (#5263)

### DIFF
--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -935,7 +935,13 @@ let gen_cmds rpc session_id =
     ; Client.PIF.(
         mk get_all_records_where get_by_uuid pif_record "pif" []
           [
-            "uuid"; "device"; "VLAN"; "mac"; "network-uuid"; "currently-attached"
+            "uuid"
+          ; "device"
+          ; "VLAN"
+          ; "mac"
+          ; "network-uuid"
+          ; "currently-attached"
+          ; "host-uuid"
           ]
           rpc session_id
       )

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -938,7 +938,7 @@ let gen_cmds rpc session_id =
             "uuid"
           ; "device"
           ; "VLAN"
-          ; "mac"
+          ; "MAC"
           ; "network-uuid"
           ; "currently-attached"
           ; "host-uuid"


### PR DESCRIPTION
Adds `host-id` to `pif-list` params printed by default, and fix the "MAC" case discrepancy noticed by @robhoes 