### PR TITLE
CP-46677: Create correct span names associated with tasks.

### DIFF
--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -5868,9 +5868,8 @@ let export_common fd _printer rpc session_id params filename num ?task_uuid
     | None ->
         (* manage task internally *)
         let exporttask =
-          Client.Task.create ~rpc ~session_id
-            ~label:(Printf.sprintf "Export of VM: %s" vm_record.API.vM_uuid)
-            ~description:""
+          Client.Task.create ~rpc ~session_id ~label:"Export of VM"
+            ~description:vm_record.API.vM_uuid
         in
         ( exporttask
         , fun () -> Client.Task.destroy ~rpc ~session_id ~self:exporttask

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -237,12 +237,14 @@ let parent_of_origin (origin : origin) span_name =
 let start_tracing_helper parent_fn task_name =
   let open Tracing in
   let span_details_from_task_name task_name =
-    match String.split_on_char ':' task_name with
-    | [x; y; uuid] when x = "dispatch" && y = "system.isAlive" ->
-        let span_name = x ^ ":" ^ y in
-        (span_name, [("xs.xapi.rpc.msg.uuid", uuid)])
-    | _ ->
-        (task_name, [])
+    let uuid_length = 36 in
+    let dispatch_system_is_alive = "dispatch:system.isAlive:" in
+    let open String in
+    if starts_with ~prefix:dispatch_system_is_alive task_name then
+      let uuid = sub task_name (length dispatch_system_is_alive) uuid_length in
+      ("dispatch:system.isAlive", [("xs.span.arg.vm.uuid", uuid)])
+    else
+      (task_name, [])
   in
   let span_name, span_attributes = span_details_from_task_name task_name in
   let parent = parent_fn span_name in


### PR DESCRIPTION
Some tasks have the name "Export of VM" concatenated with the corresponding uuid. These creates thousands of different span names for the same task. This change prevents that and slightly refactors the code to remove duplicated code when creating the span for different types of tasks.