### PR TITLE
Simplify the release and the main workflow releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,15 +42,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-        # The checkout action performs a shallow, this triggers dune to set the
-        # version to <hash>-dirty. Work around this dune behaviour and tag the
-        # commit so a proper version is always picked up
-      - name: Tag current commit
-        run: |
-          git config user.name "Dune workaround"
-          git config user.email "<>"
-          git tag -am "workaround for dune" "$XAPI_VERSION"
-
       - name: Pull configuration from xs-opam
         run: |
           curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  build:
+  build-python:
     runs-on: ubuntu-latest
     env:
       XAPI_VERSION: ${{ github.ref_name }}
@@ -39,28 +39,20 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-python
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
       - name: Retrieve python distribution artifacts
         uses: actions/download-artifact@v3
         with:
           name: XenAPI
           path: dist/
 
-      - name: Draft Release ${{ github.ref_name }}
-        run: gh release create ${{ github.ref_name }} --generate-notes
+      - name: Create release ${{ github.ref_name }}
+        run: gh release create ${{ github.ref_name }} --repo ${{ github.repository }} --generate-notes dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload artifacts
-        run: gh release upload ${{ github.ref_name }} dist/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
+  publish-pypi:
     runs-on: ubuntu-latest
     needs: release
     environment: pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           path: dist/
 
       - name: Draft Release ${{ github.ref_name }}
-        run: gh release create ${{ github.ref_name }} --draft --generate-notes
+        run: gh release create ${{ github.ref_name }} --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   build-python:
     runs-on: ubuntu-latest
-    env:
-      XAPI_VERSION: ${{ github.ref_name }}
 
     steps:
       - name: Checkout code
@@ -27,7 +25,7 @@ jobs:
 
       - name: Generate python package for XenAPI
         run: |
-          ./configure --xapi-version=${{ github.ref_name }}
+          ./configure --xapi_version=${{ github.ref_name }}
           make python
 
       - name: Store python distribution artifacts


### PR DESCRIPTION
I found these while trying to found out a reliable way to push the datamodel changes after a release. Unfortunately doing that seems quite fragile with github actions, so I'm only pushing for these small fixes instead.

These have been tested on my fork to ensure they work as expected