### PR TITLE
Change type of observer components to use variant

### DIFF
--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -153,7 +153,7 @@
     yojson
     zstd
   )
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
+  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv ppx_deriving.ord))
 )
 
 (executable

--- a/ocaml/xapi/xapi_observer.mli
+++ b/ocaml/xapi/xapi_observer.mli
@@ -12,6 +12,14 @@
  * GNU Lesser General Public License for more details.
  *)
 
+module Component : sig
+  type t
+
+  val to_string : t -> string
+
+  val of_string : string -> t
+end
+
 val observed_hosts_of :
   __context:Context.t -> API.ref_host list -> API.ref_host list
 

--- a/xapi.opam
+++ b/xapi.opam
@@ -34,6 +34,7 @@ depends: [
   "pciutil"
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
+  "ppx_deriving"
   "rpclib"
   "rrdd-plugin"
   "rresult"


### PR DESCRIPTION
Note that we keep the interface defined in `xapi_observer.mli` the same, i.e. the `create` and `set_components` functions continue to accept string as parameters, but internally we use ocaml's variant type.