### PR TITLE
CP-45973 update vhd-tool to python3

### DIFF
--- a/ocaml/vhd-tool/scripts/get_nbd_extents.py
+++ b/ocaml/vhd-tool/scripts/get_nbd_extents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """
 Returns a list of extents with their block statuses for an NBD export.

--- a/ocaml/vhd-tool/scripts/get_nbd_extents.py
+++ b/ocaml/vhd-tool/scripts/get_nbd_extents.py
@@ -15,9 +15,9 @@ import json
 import logging
 import logging.handlers
 
-from python_nbd_client import PythonNbdClient, assert_protocol
 import python_nbd_client
-
+from python_nbd_client import assert_protocol
+from python_nbd_client import PythonNbdClient
 
 LOGGER = logging.getLogger("get_nbd_extents")
 LOGGER.setLevel(logging.DEBUG)
@@ -28,7 +28,7 @@ LOGGER.setLevel(logging.DEBUG)
 # It looks like for qemu 2.12, the length parameter of a NBD_CMD_BLOCK_STATUS
 # request is not limited by the maximum block size supported by the server (as
 # defined by NBD_INFO_BLOCK_SIZE), only by the size of a 32-bit int.
-MAX_REQUEST_LEN = 2 ** 32 - 1
+MAX_REQUEST_LEN = 2**32 - 1
 
 # Make the NBD_CMD_BLOCK_STATUS request aligned to 512 bytes, just in case. But
 # it looks like this is not required for qemu 2.12.
@@ -36,17 +36,14 @@ MAX_REQUEST_LEN = MAX_REQUEST_LEN - (MAX_REQUEST_LEN % 512)
 
 
 def _get_extents(path, exportname, offset, length):
-    with PythonNbdClient(address=path,
-                         exportname=exportname,
-                         unix=True,
-                         use_tls=False,
-                         connect=False) as client:
-
+    with PythonNbdClient(
+        address=path, exportname=exportname, unix=True, use_tls=False, connect=False
+    ) as client:
         client.negotiate_structured_reply()
 
         # Select our metadata context. This context is documented at
         # https://github.com/NetworkBlockDevice/nbd/blob/master/doc/proto.md#baseallocation-metadata-context
-        context = 'base:allocation'
+        context = "base:allocation"
         selected_contexts = client.set_meta_contexts(exportname, [context])
         assert_protocol(len(selected_contexts) == 1)
         (meta_context_id, meta_context_name) = selected_contexts[0]
@@ -56,12 +53,18 @@ def _get_extents(path, exportname, offset, length):
 
         size = client.get_size()
         LOGGER.debug(
-            'Connected to NBD export %s served at path %s of size %d bytes',
-            exportname, path, size)
+            "Connected to NBD export %s served at path %s of size %d bytes",
+            exportname,
+            path,
+            size,
+        )
 
         if (offset < 0) or (length <= 0) or ((offset + length) > size):
-            raise ValueError("Offset={} and length={} out of bounds: "
-                             "export has size {}".format(offset, length, size))
+            raise ValueError(
+                "Offset={} and length={} out of bounds: " "export has size {}".format(
+                    offset, length, size
+                )
+            )
         end = offset + length
         while offset < end:
             request_len = min(MAX_REQUEST_LEN, end - offset)
@@ -75,18 +78,16 @@ def _get_extents(path, exportname, offset, length):
             reply = replies[0]
 
             # First make sure it's a block status reply
-            if python_nbd_client.is_error_chunk(
-                    reply_type=reply['reply_type']):
-                raise Exception('Received error: {}'.format(reply))
-            if reply['reply_type'] != \
-                    python_nbd_client.NBD_REPLY_TYPE_BLOCK_STATUS:
-                raise Exception('Unexpected reply: {}'.format(reply))
+            if python_nbd_client.is_error_chunk(reply_type=reply["reply_type"]):
+                raise Exception("Received error: {}".format(reply))
+            if reply["reply_type"] != python_nbd_client.NBD_REPLY_TYPE_BLOCK_STATUS:
+                raise Exception("Unexpected reply: {}".format(reply))
 
             # Then process the returned block status info
-            assert_protocol(reply['context_id'] == meta_context_id)
+            assert_protocol(reply["context_id"] == meta_context_id)
             # Note: There might be consecutive descriptors with the same status
             # value.
-            descriptors = reply['descriptors']
+            descriptors = reply["descriptors"]
             for i, descriptor in enumerate(descriptors, 1):
                 (extent_length, flags) = descriptor
                 if i == (len(descriptors)):
@@ -94,7 +95,7 @@ def _get_extents(path, exportname, offset, length):
                     # length, but the last extent can exceed the requested
                     # length
                     extent_length = min(extent_length, end - offset)
-                yield {'length': extent_length, 'flags': flags}
+                yield {"length": extent_length, "flags": flags}
                 offset += extent_length
                 assert_protocol(offset <= end)
 
@@ -103,56 +104,63 @@ def _main():
     # Configure the root logger to log into syslog
     # (Specifically, into /var/log/user.log)
     syslog_handler = logging.handlers.SysLogHandler(
-        address='/dev/log',
-        facility=logging.handlers.SysLogHandler.LOG_USER)
+        address="/dev/log", facility=logging.handlers.SysLogHandler.LOG_USER
+    )
     # Ensure the program name is included in the log messages:
-    formatter = logging.Formatter('%(name)s: [%(levelname)s] %(message)s')
+    formatter = logging.Formatter("%(name)s: [%(levelname)s] %(message)s")
     syslog_handler.setFormatter(formatter)
     logging.getLogger().addHandler(syslog_handler)
 
     try:
         parser = argparse.ArgumentParser(
             description="Return a list of extents with their block statuses. "
-                        "The returned extents are consecutive, non-"
-                        "overlapping, in the correct order starting from the "
-                        "specified offset, and exactly cover the requested "
-                        "area. There might be consecutive extents with the "
-                        "same status flags.")
+            "The returned extents are consecutive, non-"
+            "overlapping, in the correct order starting from the "
+            "specified offset, and exactly cover the requested "
+            "area. There might be consecutive extents with the "
+            "same status flags."
+        )
         parser.add_argument(
-            '--path',
+            "--path",
             required=True,
-            help="The path of the Unix domain socket of the NBD server")
+            help="The path of the Unix domain socket of the NBD server",
+        )
         parser.add_argument(
-            '--exportname',
+            "--exportname",
             required=True,
-            help="The export name of the device to connect to")
+            help="The export name of the device to connect to",
+        )
         parser.add_argument(
-            '--offset',
-            required=True,
-            type=int,
-            help="The returned list of extents will be computed "
-                 "starting from this offset")
-        parser.add_argument(
-            '--length',
+            "--offset",
             required=True,
             type=int,
             help="The returned list of extents will be computed "
-                 "for an area of this length starting at the given offset")
+            "starting from this offset",
+        )
+        parser.add_argument(
+            "--length",
+            required=True,
+            type=int,
+            help="The returned list of extents will be computed "
+            "for an area of this length starting at the given offset",
+        )
 
         args = parser.parse_args()
-        LOGGER.debug('Called with args %s', args)
+        LOGGER.debug("Called with args %s", args)
 
         extents = list(
             _get_extents(
                 path=args.path,
                 exportname=args.exportname,
                 offset=args.offset,
-                length=args.length))
-        print json.dumps(extents)
+                length=args.length,
+            )
+        )
+        print(json.dumps(extents))
     except Exception as exc:
         LOGGER.exception(exc)
         raise
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _main()

--- a/ocaml/vhd-tool/scripts/python_nbd_client.py
+++ b/ocaml/vhd-tool/scripts/python_nbd_client.py
@@ -13,7 +13,7 @@
 
 # Original file from
 # https://github.com/cloudius-systems/osv/blob/master/scripts/nbd_client.py ,
-# added support for (non-fixed) newstyle negotation,
+# added support for (non-fixed) newstyle negotiation,
 # then @thomasmck added support for fixed-newstyle negotiation and TLS
 
 """
@@ -26,12 +26,12 @@ Additionally, it supports the BLOCK_STATUS extension:
 for the extension docs, see the same file in the extension-blockstatus branch.
 """
 
-import socket
-import struct
-import ssl
 import logging
+import socket
+import ssl
+import struct
 
-LOGGER = logging.getLogger('python_nbd_client')
+LOGGER = logging.getLogger("python_nbd_client")
 
 # Request types
 NBD_CMD_READ = 0
@@ -42,11 +42,11 @@ NBD_CMD_FLUSH = 3
 NBD_CMD_BLOCK_STATUS = 7
 
 # Transmission flags
-NBD_FLAG_HAS_FLAGS = (1 << 0)
-NBD_FLAG_SEND_FLUSH = (1 << 2)
+NBD_FLAG_HAS_FLAGS = 1 << 0
+NBD_FLAG_SEND_FLUSH = 1 << 2
 
 # Client flags
-NBD_FLAG_C_FIXED_NEWSTYLE = (1 << 0)
+NBD_FLAG_C_FIXED_NEWSTYLE = 1 << 0
 
 # Option types
 NBD_OPT_EXPORT_NAME = 1
@@ -58,28 +58,28 @@ NBD_OPT_LIST_META_CONTEXT = 9
 NBD_OPT_SET_META_CONTEXT = 10
 
 # Option reply types
-NBD_REP_ERROR_BIT = (1 << 31)
+NBD_REP_ERROR_BIT = 1 << 31
 NBD_REP_ACK = 1
 NBD_REP_INFO = 3
 NBD_REP_META_CONTEXT = 4
 
-OPTION_REPLY_MAGIC = 0x3e889045565a9
+OPTION_REPLY_MAGIC = 0x3E889045565A9
 
 NBD_REQUEST_MAGIC = 0x25609513
 NBD_SIMPLE_REPLY_MAGIC = 0x67446698
-NBD_STRUCTURED_REPLY_MAGIC = 0x668e33ef
+NBD_STRUCTURED_REPLY_MAGIC = 0x668E33EF
 
 # Structured reply types
 NBD_REPLY_TYPE_NONE = 0
 NBD_REPLY_TYPE_OFFSET_DATA = 1
 NBD_REPLY_TYPE_OFFSET_HOLE = 2
 NBD_REPLY_TYPE_BLOCK_STATUS = 5
-NBD_REPLY_TYPE_ERROR_BIT = (1 << 15)
-NBD_REPLY_TYPE_ERROR = (1 << 15 + 1)
-NBD_REPLY_TYPE_ERROR_OFFSET = (1 << 15 + 2)
+NBD_REPLY_TYPE_ERROR_BIT = 1 << 15
+NBD_REPLY_TYPE_ERROR = 1 << 15 + 1
+NBD_REPLY_TYPE_ERROR_OFFSET = 1 << 15 + 2
 
 # Structured reply flags
-NBD_REPLY_FLAG_DONE = (1 << 0)
+NBD_REPLY_FLAG_DONE = 1 << 0
 
 # NBD_INFO information types
 NBD_INFO_EXPORT = 0
@@ -93,6 +93,7 @@ class NBDEOFError(EOFError):
     An end of file error happened while reading from the socket, because it has
     been closed.
     """
+
     pass
 
 
@@ -103,9 +104,11 @@ class NBDTransmissionError(Exception):
 
     :attribute error_code: The error code returned by the server.
     """
+
     def __init__(self, error_code):
         super(NBDTransmissionError, self).__init__(
-            "Server returned error during transmission: {}".format(error_code))
+            "Server returned error during transmission: {}".format(error_code)
+        )
         self.error_code = error_code
 
 
@@ -115,11 +118,13 @@ class NBDOptionError(Exception):
 
     :attribute reply: The error reply sent by the server.
     """
+
     def __init__(self, reply):
         error_code = reply - NBD_REP_ERROR_BIT
         super(NBDOptionError, self).__init__(
             "Server returned error during option haggling: "
-            "reply type={}; error code={}".format(reply, error_code))
+            "reply type={}; error code={}".format(reply, error_code)
+        )
         self.reply = reply
 
 
@@ -132,11 +137,12 @@ class NBDUnexpectedOptionResponseError(Exception):
                          it is expecting a response.
     :attribute received: The server's response is a reply to this option.
     """
+
     def __init__(self, expected, received):
         super(NBDUnexpectedOptionResponseError, self).__init__(
             "Received response to unexpected option {}; "
-            "was expecting a response to option {}"
-            .format(received, expected))
+            "was expecting a response to option {}".format(received, expected)
+        )
         self.expected = expected
         self.received = received
 
@@ -148,10 +154,12 @@ class NBDUnexpectedStructuredReplyType(Exception):
 
     :attribute type: The type of the structured chunk message.
     """
+
     def __init__(self, reply_type):
         super(NBDUnexpectedStructuredReplyType, self).__init__(
             "Received a structured reply chunk message "
-            "with an unexpected type: {}".format(reply_type))
+            "with an unexpected type: {}".format(reply_type)
+        )
         self.reply_type = reply_type
 
 
@@ -164,12 +172,13 @@ class NBDUnexpectedReplyHandleError(Exception):
                          is expecting a reply to.
     :attribute received: The server's reply contained this handle.
     """
+
     def __init__(self, expected, received):
         super(NBDUnexpectedReplyHandleError, self).__init__(
             "Received reply with unexpected handle {}; "
             "was expecting a response to the request with "
-            "handle {}"
-            .format(received, expected))
+            "handle {}".format(received, expected)
+        )
         self.expected = expected
         self.received = received
 
@@ -179,6 +188,7 @@ class NBDProtocolError(Exception):
     The NBD server sent an invalid response that is not allowed by the NBD
     protocol.
     """
+
     pass
 
 
@@ -221,19 +231,20 @@ class PythonNbdClient(object):
     extension.
     """
 
-    def __init__(self,
-                 address,
-                 exportname="",
-                 port=10809,
-                 timeout=60,
-                 subject=None,
-                 cert=None,
-                 use_tls=True,
-                 new_style_handshake=True,
-                 unix=False,
-                 connect=True):
-        LOGGER.info("Creating connection to address '%s' and port '%s'",
-                    address, port)
+    def __init__(
+        self,
+        address,
+        exportname="",
+        port=10809,
+        timeout=60,
+        subject=None,
+        cert=None,
+        use_tls=True,
+        new_style_handshake=True,
+        unix=False,
+        connect=True,
+    ):
+        LOGGER.info("Creating connection to address '%s' and port '%s'", address, port)
         self._flushed = True
         self._closed = True
         self._handle = 0
@@ -250,10 +261,7 @@ class PythonNbdClient(object):
         self._s.connect(address)
         self._closed = False
         if new_style_handshake:
-            self._fixed_new_style_handshake(
-                cert=cert,
-                subject=subject,
-                use_tls=use_tls)
+            self._fixed_new_style_handshake(cert=cert, subject=subject, use_tls=use_tls)
             if connect:
                 self.connect(exportname=exportname)
         else:
@@ -294,11 +302,11 @@ class PythonNbdClient(object):
 
     #  Newstyle handshake
 
-    def _send_option(self, option, data=b''):
+    def _send_option(self, option, data=b""):
         LOGGER.debug("NBD sending option header")
         data_length = len(data)
         LOGGER.debug("option='%d' data_length='%d'", option, data_length)
-        self._s.sendall(b'IHAVEOPT')
+        self._s.sendall(b"IHAVEOPT")
         header = struct.pack(">LL", option, data_length)
         self._s.sendall(header + data)
         self._last_sent_option = option
@@ -306,14 +314,18 @@ class PythonNbdClient(object):
     def _parse_option_reply(self):
         LOGGER.debug("NBD parsing option reply")
         reply = self._recvall(8 + 4 + 4 + 4)
-        (magic, option, reply_type, data_length) = struct.unpack(
-            ">QLLL", reply)
-        LOGGER.debug("NBD reply magic='0x%x' option='%d' reply_type='%d'",
-                     magic, option, reply_type)
+        (magic, option, reply_type, data_length) = struct.unpack(">QLLL", reply)
+        LOGGER.debug(
+            "NBD reply magic='0x%x' option='%d' reply_type='%d'",
+            magic,
+            option,
+            reply_type,
+        )
         assert_protocol(magic == OPTION_REPLY_MAGIC)
         if option != self._last_sent_option:
             raise NBDUnexpectedOptionResponseError(
-                expected=self._last_sent_option, received=option)
+                expected=self._last_sent_option, received=option
+            )
         if reply_type & NBD_REP_ERROR_BIT != 0:
             raise NBDOptionError(reply=reply_type)
         data = self._recvall(data_length)
@@ -331,7 +343,7 @@ class PythonNbdClient(object):
             return None
         assert_protocol(reply_type == NBD_REP_META_CONTEXT)
         context_id = struct.unpack(">L", data[:4])[0]
-        name = (data[4:]).decode('utf-8')
+        name = (data[4:]).decode("utf-8")
         return (context_id, name)
 
     def _upgrade_socket_to_tls(self, cert, subject):
@@ -342,14 +354,15 @@ class PythonNbdClient(object):
         context.options &= ~ssl.OP_NO_SSLv2
         context.options &= ~ssl.OP_NO_SSLv3
         context.verify_mode = ssl.CERT_REQUIRED
-        context.check_hostname = (subject is not None)
+        context.check_hostname = subject is not None
         context.load_verify_locations(cadata=cert)
         cleartext_socket = self._s
         self._s = context.wrap_socket(
             cleartext_socket,
             server_side=False,
             do_handshake_on_connect=True,
-            server_hostname=subject)
+            server_hostname=subject,
+        )
 
     def _initiate_tls_upgrade(self):
         # start TLS negotiation
@@ -360,43 +373,42 @@ class PythonNbdClient(object):
 
     def request_info(self, export_name, info_requests):
         """Query information from the server."""
-        data = struct.pack('>L', len(export_name))
-        data += export_name.encode('utf-8')
-        data += struct.pack('>H', len(info_requests))
+        data = struct.pack(">L", len(export_name))
+        data += export_name.encode("utf-8")
+        data += struct.pack(">H", len(info_requests))
         for request in info_requests:
-            data += struct.pack('>H', request)
+            data += struct.pack(">H", request)
         self._send_option(NBD_OPT_INFO, data)
         infos = []
         while True:
             (reply_type, data) = self._parse_option_reply()
             if reply_type == NBD_REP_INFO:
                 info_type = struct.unpack(">H", data[:2])[0]
-                info = {'information_type': info_type}
+                info = {"information_type": info_type}
                 payload = data[2:]
                 if info_type == NBD_INFO_BLOCK_SIZE:
                     assert_protocol(len(data) == 14)
-                    sizes = struct.unpack('>LLL', payload)
-                    (info['minimum_block_size'],
-                     info['preferred_block_size'],
-                     info['maximum_block_size']) = sizes
+                    sizes = struct.unpack(">LLL", payload)
+                    (
+                        info["minimum_block_size"],
+                        info["preferred_block_size"],
+                        info["maximum_block_size"],
+                    ) = sizes
                     infos += [info]
                 elif info_type == NBD_INFO_EXPORT:
                     assert_protocol(len(data) == 12)
-                    export_info = struct.unpack('>QH', payload)
-                    (info['size'],
-                     info['transmission_flags']) = export_info
+                    export_info = struct.unpack(">QH", payload)
+                    (info["size"], info["transmission_flags"]) = export_info
                     infos += [info]
                 else:
                     # The client MUST ignore information replies it does not
                     # understand.
-                    LOGGER.warning('Unsupported info reply type: %d',
-                                   info_type)
+                    LOGGER.warning("Unsupported info reply type: %d", info_type)
             elif reply_type == NBD_REP_ACK:
                 assert_protocol(not data)
                 break
             else:
-                raise NBDProtocolError(
-                    'Unexpected reply type: {}'.format(reply_type))
+                raise NBDProtocolError("Unexpected reply type: {}".format(reply_type))
         return infos
 
     def negotiate_structured_reply(self):
@@ -409,12 +421,12 @@ class PythonNbdClient(object):
         self._structured_reply = True
 
     def _process_meta_context_option(self, option, export_name, queries):
-        data = struct.pack('>L', len(export_name))
-        data += export_name.encode('utf-8')
-        data += struct.pack('>L', len(queries))
+        data = struct.pack(">L", len(export_name))
+        data += export_name.encode("utf-8")
+        data += struct.pack(">L", len(queries))
         for query in queries:
-            data += struct.pack('>L', len(query))
-            data += query.encode('utf-8')
+            data += struct.pack(">L", len(query))
+            data += query.encode("utf-8")
         self._send_option(option, data)
         while True:
             reply = self._parse_meta_context_reply()
@@ -423,8 +435,7 @@ class PythonNbdClient(object):
             yield reply
 
     def _send_meta_context_option(self, option, export_name, queries):
-        return list(self._process_meta_context_option(
-            option, export_name, queries))
+        return list(self._process_meta_context_option(option, export_name, queries))
 
     def set_meta_contexts(self, export_name, queries):
         """
@@ -435,9 +446,8 @@ class PythonNbdClient(object):
         negotiate_structured_reply.
         """
         return self._send_meta_context_option(
-            option=NBD_OPT_SET_META_CONTEXT,
-            export_name=export_name,
-            queries=queries)
+            option=NBD_OPT_SET_META_CONTEXT, export_name=export_name, queries=queries
+        )
 
     def list_meta_contexts(self, export_name, queries):
         """
@@ -448,20 +458,19 @@ class PythonNbdClient(object):
         negotiate_structured_reply.
         """
         return self._send_meta_context_option(
-            option=NBD_OPT_LIST_META_CONTEXT,
-            export_name=export_name,
-            queries=queries)
+            option=NBD_OPT_LIST_META_CONTEXT, export_name=export_name, queries=queries
+        )
 
     def _fixed_new_style_handshake(self, cert, subject, use_tls):
         nbd_magic = self._recvall(len("NBDMAGIC"))
-        assert_protocol(nbd_magic == b'NBDMAGIC')
+        assert_protocol(nbd_magic == b"NBDMAGIC")
         nbd_magic = self._recvall(len("IHAVEOPT"))
-        assert_protocol(nbd_magic == b'IHAVEOPT')
+        assert_protocol(nbd_magic == b"IHAVEOPT")
         buf = self._recvall(2)
         handshake_flags = struct.unpack(">H", buf)[0]
         assert_protocol(handshake_flags & NBD_FLAG_HAS_FLAGS != 0)
         client_flags = NBD_FLAG_C_FIXED_NEWSTYLE
-        client_flags = struct.pack('>L', client_flags)
+        client_flags = struct.pack(">L", client_flags)
         self._s.sendall(client_flags)
 
         if use_tls:
@@ -475,17 +484,19 @@ class PythonNbdClient(object):
         Valid only during the handshake phase. Requests the given
         export and enters the transmission phase.
         """
-        LOGGER.info("Connecting to export '%s' using newstyle negotiation",
-                    exportname)
+        LOGGER.info("Connecting to export '%s' using newstyle negotiation", exportname)
         # request export
-        self._send_option(NBD_OPT_EXPORT_NAME, exportname.encode('utf-8'))
+        self._send_option(NBD_OPT_EXPORT_NAME, exportname.encode("utf-8"))
 
         # non-fixed newstyle negotiation: we get these if the server is willing
         # to allow the export
         buf = self._recvall(10)
         (self._size, self._transmission_flags) = struct.unpack(">QH", buf)
-        LOGGER.debug("NBD got size=%d transmission flags=%d",
-                     self._size, self._transmission_flags)
+        LOGGER.debug(
+            "NBD got size=%d transmission flags=%d",
+            self._size,
+            self._transmission_flags,
+        )
         # ignore the zeroes
         zeroes = self._recvall(124)
         LOGGER.debug("NBD got zeroes: %s", zeroes)
@@ -497,11 +508,9 @@ class PythonNbdClient(object):
     def _old_style_handshake(self):
         LOGGER.info("Connecting to server using oldstyle negotiation")
         nbd_magic = self._recvall(len("NBDMAGIC"))
-        assert_protocol(nbd_magic == b'NBDMAGIC')
+        assert_protocol(nbd_magic == b"NBDMAGIC")
         buf = self._recvall(8 + 8 + 4)
-        (magic,
-         self._size,
-         self._transmission_flags) = struct.unpack(">QQL", buf)
+        (magic, self._size, self._transmission_flags) = struct.unpack(">QQL", buf)
         assert_protocol(magic == 0x00420281861253)
         # ignore trailing zeroes
         self._recvall(124)
@@ -513,21 +522,28 @@ class PythonNbdClient(object):
         LOGGER.debug("NBD request offset=%d length=%d", offset, length)
         command_flags = 0
         self._handle += 1
-        header = struct.pack('>LHHQQL', NBD_REQUEST_MAGIC, command_flags,
-                             request_type, self._handle, offset, length)
+        header = struct.pack(
+            ">LHHQQL",
+            NBD_REQUEST_MAGIC,
+            command_flags,
+            request_type,
+            self._handle,
+            offset,
+            length,
+        )
         self._s.sendall(header)
 
     def _check_handle(self, handle):
         if handle != self._handle:
-            raise NBDUnexpectedReplyHandleError(
-                expected=self._handle, received=handle)
+            raise NBDUnexpectedReplyHandleError(expected=self._handle, received=handle)
 
     def _parse_simple_reply(self, data_length=0):
         LOGGER.debug("NBD parsing simple reply, data_length=%d", data_length)
         reply = self._recvall(4 + 4 + 8)
         (magic, errno, handle) = struct.unpack(">LLQ", reply)
-        LOGGER.debug("NBD simple reply magic='0x%x' errno='%d' handle='%d'",
-                     magic, errno, handle)
+        LOGGER.debug(
+            "NBD simple reply magic='0x%x' errno='%d' handle='%d'", magic, errno, handle
+        )
         assert_protocol(magic == NBD_SIMPLE_REPLY_MAGIC)
         self._check_handle(handle)
         data = self._recvall(length=data_length)
@@ -537,61 +553,66 @@ class PythonNbdClient(object):
         return data
 
     def _handle_block_status_reply(self, fields):
-        data_length = fields['data_length']
+        data_length = fields["data_length"]
         assert_protocol((data_length >= 12) and (data_length % 8 == 4))
         data = self._recvall(data_length)
         view = memoryview(data)
-        fields['context_id'] = struct.unpack(">L", view[:4])[0]
+        fields["context_id"] = struct.unpack(">L", view[:4])[0]
         view = view[4:]
         descriptors = list(_parse_block_status_descriptors(view))
         assert_protocol(descriptors)
-        fields['descriptors'] = descriptors
+        fields["descriptors"] = descriptors
 
     def _handle_data_reply(self, fields):
-        data_length = fields['data_length']
+        data_length = fields["data_length"]
         assert_protocol(data_length >= 9)
         buf = self._recvall(8)
-        fields['offset'] = struct.unpack(">Q", buf)[0]
-        fields['data'] = self._recvall(data_length - 8)
-        assert_protocol(fields['data'])
+        fields["offset"] = struct.unpack(">Q", buf)[0]
+        fields["data"] = self._recvall(data_length - 8)
+        assert_protocol(fields["data"])
 
     def _handle_hole_reply(self, fields):
-        assert_protocol(fields['data_length'] == 12)
+        assert_protocol(fields["data_length"] == 12)
         buf = self._recvall(12)
-        (fields['offset'], fields['hole_size']) = struct.unpack(">QL", buf)
+        (fields["offset"], fields["hole_size"]) = struct.unpack(">QL", buf)
 
     def _handle_structured_reply_error(self, fields):
-        data_length = fields['data_length']
+        data_length = fields["data_length"]
         assert_protocol(data_length >= 6)
         buf = self._recvall(4 + 2)
         (errno, message_length) = struct.unpack(">LH", buf)
-        fields['error'] = errno
+        fields["error"] = errno
         remaining_length = data_length - 6
         # The client MAY continue transmission in case of an unexpected error
         # type, unless message_length does not fit into the length:
         if message_length > remaining_length:
             raise NBDProtocolError(
-                'message_length is too large to fit within data_length bytes')
+                "message_length is too large to fit within data_length bytes"
+            )
         data = self._recvall(remaining_length)
         view = memoryview(data)
-        fields['message'] = view[0:message_length].tobytes().decode('utf-8')
+        fields["message"] = view[0:message_length].tobytes().decode("utf-8")
         view = view[message_length:]
-        if fields['reply_type'] == NBD_REPLY_TYPE_ERROR_OFFSET:
-            fields['offset'] = struct.unpack(">Q", view)[0]
+        if fields["reply_type"] == NBD_REPLY_TYPE_ERROR_OFFSET:
+            fields["offset"] = struct.unpack(">Q", view)[0]
 
     def _parse_structured_reply_chunk(self):
         LOGGER.debug("NBD parsing structured reply chunk")
         reply = self._recvall(4 + 2 + 2 + 8 + 4)
         header = struct.unpack(">LHHQL", reply)
         (magic, flags, reply_type, handle, data_length) = header
-        LOGGER.debug("NBD structured reply magic='%x' flags='%s' "
-                     "reply_type='%d' handle='%d' data_length='%d'",
-                     magic, flags, reply_type, handle, data_length)
+        LOGGER.debug(
+            "NBD structured reply magic='%x' flags='%s' "
+            "reply_type='%d' handle='%d' data_length='%d'",
+            magic,
+            flags,
+            reply_type,
+            handle,
+            data_length,
+        )
         assert_protocol(magic == NBD_STRUCTURED_REPLY_MAGIC)
         self._check_handle(handle)
-        fields = {'flags': flags,
-                  'reply_type': reply_type,
-                  'data_length': data_length}
+        fields = {"flags": flags, "reply_type": reply_type, "data_length": data_length}
         if reply_type == NBD_REPLY_TYPE_BLOCK_STATUS:
             self._handle_block_status_reply(fields)
         elif reply_type == NBD_REPLY_TYPE_NONE:
@@ -611,7 +632,7 @@ class PythonNbdClient(object):
         while True:
             reply = self._parse_structured_reply_chunk()
             yield reply
-            if _is_final_structured_reply_chunk(flags=reply['flags']):
+            if _is_final_structured_reply_chunk(flags=reply["flags"]):
                 return
 
     def write(self, data, offset):

--- a/ocaml/vhd-tool/scripts/python_nbd_client.py
+++ b/ocaml/vhd-tool/scripts/python_nbd_client.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 #
 # Copyright (C) 2013 Nodalink, SARL.
 #
@@ -94,8 +93,6 @@ class NBDEOFError(EOFError):
     been closed.
     """
 
-    pass
-
 
 class NBDTransmissionError(Exception):
     """
@@ -106,7 +103,7 @@ class NBDTransmissionError(Exception):
     """
 
     def __init__(self, error_code):
-        super(NBDTransmissionError, self).__init__(
+        super().__init__(
             "Server returned error during transmission: {}".format(error_code)
         )
         self.error_code = error_code
@@ -121,7 +118,7 @@ class NBDOptionError(Exception):
 
     def __init__(self, reply):
         error_code = reply - NBD_REP_ERROR_BIT
-        super(NBDOptionError, self).__init__(
+        super().__init__(
             "Server returned error during option haggling: "
             "reply type={}; error code={}".format(reply, error_code)
         )
@@ -139,7 +136,7 @@ class NBDUnexpectedOptionResponseError(Exception):
     """
 
     def __init__(self, expected, received):
-        super(NBDUnexpectedOptionResponseError, self).__init__(
+        super().__init__(
             "Received response to unexpected option {}; "
             "was expecting a response to option {}".format(received, expected)
         )
@@ -156,7 +153,7 @@ class NBDUnexpectedStructuredReplyType(Exception):
     """
 
     def __init__(self, reply_type):
-        super(NBDUnexpectedStructuredReplyType, self).__init__(
+        super().__init__(
             "Received a structured reply chunk message "
             "with an unexpected type: {}".format(reply_type)
         )
@@ -174,7 +171,7 @@ class NBDUnexpectedReplyHandleError(Exception):
     """
 
     def __init__(self, expected, received):
-        super(NBDUnexpectedReplyHandleError, self).__init__(
+        super().__init__(
             "Received reply with unexpected handle {}; "
             "was expecting a response to the request with "
             "handle {}".format(received, expected)
@@ -188,8 +185,6 @@ class NBDProtocolError(Exception):
     The NBD server sent an invalid response that is not allowed by the NBD
     protocol.
     """
-
-    pass
 
 
 def assert_protocol(assertion):
@@ -223,7 +218,7 @@ def _parse_block_status_descriptors(data):
         data = data[8:]
 
 
-class PythonNbdClient(object):
+class PythonNbdClient:
     """
     A pure-Python NBD client. Supports both the fixed-newstyle and the oldstyle
     negotiation, and also has support for upgrading the connection to TLS


### PR DESCRIPTION
    Changes for python3 syntax:

    1. format with black
    2. remove redundant arguments in super() https://docs.python.org/3/library/functions.html#super
    3. remove redundant pass statement
    4. since Python 3, all classes inherit from object by default
    5. since PEP 3120, Using UTF-8 as the default source encoding

Test passed with Storage BST，job id: 191563