### PR TITLE
CP-45565: Add new guidance fields to API and CLI

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 768
+let schema_minor_vsn = 769
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -316,6 +316,14 @@ let update_guidances =
         , "Indicates the updated host should reboot as soon as possible since \
            one or more livepatch(es) failed to be applied."
         )
+      ; ( "reboot_host_on_kernel_livepatch_failure"
+        , "Indicates the updated host should reboot as soon as possible since \
+           one or more kernel livepatch(es) failed to be applied."
+        )
+      ; ( "reboot_host_on_xen_livepatch_failure"
+        , "Indicates the updated host should reboot as soon as possible since \
+           one or more xen livepatch(es) failed to be applied."
+        )
       ; ( "restart_toolstack"
         , "Indicates the Toolstack running on the updated host should restart \
            as soon as possible"
@@ -324,6 +332,7 @@ let update_guidances =
         , "Indicates the device model of a running VM should restart as soon \
            as possible"
         )
+      ; ("restart_vm", "Indicates the VM should restart as soon as possible")
       ]
     )
 

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2142,7 +2142,7 @@ let t =
         ; field ~qualifier:DynamicRO ~in_product_since:"1.303.0"
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
-            "The set of pending guidances after applying updates"
+            "The set of pending mandatory guidances after applying updates"
         ; field ~qualifier:DynamicRO ~in_product_since:"1.313.0" ~ty:Bool
             "tls_verification_enabled" ~default_value:(Some (VBool false))
             "True if this host has TLS verifcation enabled"
@@ -2164,6 +2164,12 @@ let t =
             ~default_value:(Some (VEnum "unknown"))
             "Default as 'unknown', 'yes' if the host is up to date with \
              updates synced from remote CDN, otherwise 'no'"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
+            "pending_guidances_recommended" ~default_value:(Some (VSet []))
+            "The set of pending recommended guidances after applying updates"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
+            "pending_guidances_full" ~default_value:(Some (VSet []))
+            "The set of pending full guidances after applying updates"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2168,13 +2168,14 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "pending_guidances_recommended" ~default_value:(Some (VSet []))
             "The set of pending recommended guidances after applying updates, \
-             which we suggest that most users should follow, but if not \
-             followed, will not cause a failure"
+             which most users should follow to make the updates effective, but \
+             if not followed, will not cause a failure"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "pending_guidances_full" ~default_value:(Some (VSet []))
             "The set of pending full guidances after applying updates, which a \
-             user should follow if they want to make the update fully \
-             effective, but the 'average user' doesn't need to"
+             user should follow to make some updates, e.g. specific hardware \
+             drivers or CPU features, fully effective, but the 'average user' \
+             doesn't need to"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2142,7 +2142,8 @@ let t =
         ; field ~qualifier:DynamicRO ~in_product_since:"1.303.0"
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
-            "The set of pending mandatory guidances after applying updates"
+            "The set of pending mandatory guidances after applying updates, \
+             which must be applied, as otherwise there may be e.g. VM failures"
         ; field ~qualifier:DynamicRO ~in_product_since:"1.313.0" ~ty:Bool
             "tls_verification_enabled" ~default_value:(Some (VBool false))
             "True if this host has TLS verifcation enabled"
@@ -2166,10 +2167,14 @@ let t =
              updates synced from remote CDN, otherwise 'no'"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "pending_guidances_recommended" ~default_value:(Some (VSet []))
-            "The set of pending recommended guidances after applying updates"
+            "The set of pending recommended guidances after applying updates, \
+             which we suggest that most users should follow, but if not \
+             followed, will not cause a failure"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "pending_guidances_full" ~default_value:(Some (VSet []))
-            "The set of pending full guidances after applying updates"
+            "The set of pending full guidances after applying updates, which a \
+             user should follow if they want to make the update fully \
+             effective, but the 'average user' doesn't need to"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2161,6 +2161,12 @@ let t =
             ~ty:(Set update_guidances) "recommended_guidances"
             ~default_value:(Some (VSet []))
             "The set of recommended guidances after applying updates"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
+            "pending_guidances_recommended" ~default_value:(Some (VSet []))
+            "The set of pending recommended guidances after applying updates"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
+            "pending_guidances_full" ~default_value:(Some (VSet []))
+            "The set of pending full guidances after applying updates"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2155,7 +2155,8 @@ let t =
         ; field ~qualifier:DynamicRO ~in_product_since:"1.303.0"
             ~ty:(Set update_guidances) "pending_guidances"
             ~default_value:(Some (VSet []))
-            "The set of pending guidances after applying updates"
+            "The set of pending mandatory guidances after applying updates, \
+             which must be applied, as otherwise there may be e.g. VM failures"
         ; field ~qualifier:DynamicRO ~internal_only:true
             ~lifecycle:[(Prototyped, "23.18.0", ""); (Removed, "23.24.0", "")]
             ~ty:(Set update_guidances) "recommended_guidances"
@@ -2163,10 +2164,15 @@ let t =
             "The set of recommended guidances after applying updates"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "pending_guidances_recommended" ~default_value:(Some (VSet []))
-            "The set of pending recommended guidances after applying updates"
+            "The set of pending recommended guidances after applying updates, \
+             which most users should follow to make the updates effective, but \
+             if not followed, will not cause a failure"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:(Set update_guidances)
             "pending_guidances_full" ~default_value:(Some (VSet []))
-            "The set of pending full guidances after applying updates"
+            "The set of pending full guidances after applying updates, which a \
+             user should follow to make some updates, e.g. specific hardware \
+             drivers or CPU features, fully effective, but the 'average user' \
+             doesn't need to"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "f6d7765803645c3e44140c239269ea2c"
+let last_known_schema_hash = "9c650ad57273c375b9f82f26f82aa75f"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "050803716d5d4e3bffa7240e1d1ec840"
+let last_known_schema_hash = "f6d7765803645c3e44140c239269ea2c"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "8ff8c73b261e332b889583c8b2df5ecc"
+let last_known_schema_hash = "050803716d5d4e3bffa7240e1d1ec840"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -211,7 +211,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
-    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown ;
+    ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
+    ~pending_guidances_recommended:[] ~pending_guidances_full:[] ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -203,10 +203,16 @@ let update_guidance_to_string = function
       "reboot_host"
   | `reboot_host_on_livepatch_failure ->
       "reboot_host_on_livepatch_failure"
+  | `reboot_host_on_kernel_livepatch_failure ->
+      "reboot_host_on_kernel_livepatch_failure"
+  | `reboot_host_on_xen_livepatch_failure ->
+      "reboot_host_on_xen_livepatch_failure"
   | `restart_toolstack ->
       "restart_toolstack"
   | `restart_device_model ->
       "restart_device_model"
+  | `restart_vm ->
+      "restart_vm"
 
 let latest_synced_updates_applied_state_to_string = function
   | `yes ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2588,6 +2588,18 @@ let vm_record rpc session_id vm =
       ; make_field ~name:"vtpms"
           ~get:(fun () -> get_uuids_from_refs (x ()).API.vM_VTPMs)
           ()
+      ; make_field ~name:"pending-guidances-recommended"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.vM_pending_guidances_recommended
+          )
+          ()
+      ; make_field ~name:"pending-guidances-full"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.vM_pending_guidances_full
+          )
+          ()
       ]
   }
 
@@ -3230,6 +3242,18 @@ let host_record rpc session_id host =
           ~get:(fun () ->
             Record_util.latest_synced_updates_applied_state_to_string
               (x ()).API.host_latest_synced_updates_applied
+          )
+          ()
+      ; make_field ~name:"pending-guidances-recommended"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.host_pending_guidances_recommended
+          )
+          ()
+      ; make_field ~name:"pending-guidances-full"
+          ~get:(fun () ->
+            map_and_concat Record_util.update_guidance_to_string
+              (x ()).API.host_pending_guidances_full
           )
           ()
       ]

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -321,7 +321,8 @@ and create_domain_zero_record ~__context ~domain_zero_ref (host_info : host_info
     ~version:0L ~generation_id:"" ~hardware_platform_version:0L
     ~has_vendor_device:false ~requires_reboot:false ~reference_label:""
     ~domain_type:Xapi_globs.domain_zero_domain_type ~nVRAM:[]
-    ~pending_guidances:[] ~recommended_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[]
+    ~pending_guidances_recommended:[] ~pending_guidances_full:[] ;
   ensure_domain_zero_metrics_record ~__context ~domain_zero_ref host_info ;
   Db.Host.set_control_domain ~__context ~self:localhost ~value:domain_zero_ref ;
   Xapi_vm_helpers.update_memory_overhead ~__context ~vm:domain_zero_ref

--- a/ocaml/xapi/updateinfo.ml
+++ b/ocaml/xapi/updateinfo.ml
@@ -24,6 +24,9 @@ module Guidance = struct
     | EvacuateHost
     | RestartDeviceModel
     | RebootHostOnLivePatchFailure
+    | RebootHostOnKernelLivePatchFailure
+    | RebootHostOnXenLivePatchFailure
+    | RestartVM
 
   type guidance_kind = Absolute | Recommended
 
@@ -40,6 +43,12 @@ module Guidance = struct
         "RestartDeviceModel"
     | RebootHostOnLivePatchFailure ->
         "RebootHostOnLivePatchFailure"
+    | RebootHostOnKernelLivePatchFailure ->
+        "RebootHostOnKernelLivePatchFailure"
+    | RebootHostOnXenLivePatchFailure ->
+        "RebootHostOnXenLivePatchFailure"
+    | RestartVM ->
+        "RestartVM"
 
   let of_string = function
     | "RebootHost" ->
@@ -50,6 +59,8 @@ module Guidance = struct
         EvacuateHost
     | "RestartDeviceModel" ->
         RestartDeviceModel
+    | "RestartVM" ->
+        RestartVM
     | g ->
         warn
           "Un-recognized guidance in \
@@ -63,10 +74,16 @@ module Guidance = struct
         RebootHost
     | `reboot_host_on_livepatch_failure ->
         RebootHostOnLivePatchFailure
+    | `reboot_host_on_kernel_livepatch_failure ->
+        RebootHostOnKernelLivePatchFailure
+    | `reboot_host_on_xen_livepatch_failure ->
+        RebootHostOnXenLivePatchFailure
     | `restart_toolstack ->
         RestartToolstack
     | `restart_device_model ->
         RestartDeviceModel
+    | `restart_vm ->
+        RestartVM
 end
 
 module Applicability = struct

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -20,6 +20,9 @@ module Guidance : sig
     | EvacuateHost
     | RestartDeviceModel
     | RebootHostOnLivePatchFailure
+    | RebootHostOnKernelLivePatchFailure
+    | RebootHostOnXenLivePatchFailure
+    | RestartVM
 
   type guidance_kind = Absolute | Recommended
 
@@ -33,8 +36,11 @@ module Guidance : sig
   val of_update_guidance :
        [< `reboot_host
        | `reboot_host_on_livepatch_failure
+       | `reboot_host_on_kernel_livepatch_failure
+       | `reboot_host_on_xen_livepatch_failure
        | `restart_device_model
-       | `restart_toolstack ]
+       | `restart_toolstack
+       | `restart_vm ]
     -> t
 end
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1055,7 +1055,8 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~control_domain:Ref.null ~updates_requiring_reboot:[] ~iscsi_iqn:""
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled ~last_software_update ~recommended_guidances:[]
-    ~latest_synced_updates_applied:`unknown ;
+    ~latest_synced_updates_applied:`unknown ~pending_guidances_recommended:[]
+    ~pending_guidances_full:[] ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -382,6 +382,10 @@ let consider_enabling_host_nolock ~__context =
         ~value:`reboot_host ;
       Db.Host.remove_pending_guidances ~__context ~self:localhost
         ~value:`reboot_host_on_livepatch_failure ;
+      Db.Host.remove_pending_guidances_recommended ~__context ~self:localhost
+        ~value:`reboot_host_on_kernel_livepatch_failure ;
+      Db.Host.remove_pending_guidances_recommended ~__context ~self:localhost
+        ~value:`reboot_host_on_xen_livepatch_failure ;
       update_allowed_operations ~__context ~self:localhost ;
       Localdb.put Constants.host_disabled_until_reboot "false" ;
       (* Start processing pending VM powercycle events *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -675,7 +675,8 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
     ~is_vmss_snapshot:false ~appliance ~start_delay ~shutdown_delay ~order
     ~suspend_SR ~version ~generation_id ~hardware_platform_version
     ~has_vendor_device ~requires_reboot:false ~reference_label ~domain_type
-    ~pending_guidances:[] ~recommended_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[]
+    ~pending_guidances_recommended:[] ~pending_guidances_full:[] ;
   Xapi_vm_lifecycle.update_allowed_operations ~__context ~self:vm_ref ;
   update_memory_overhead ~__context ~vm:vm_ref ;
   update_vm_virtual_hardware_platform_version ~__context ~vm:vm_ref ;

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -397,7 +397,8 @@ let copy_vm_record ?snapshot_info_record ~__context ~vm ~disk_op ~new_name
     ~has_vendor_device:all.Db_actions.vM_has_vendor_device
     ~requires_reboot:false ~reference_label:all.Db_actions.vM_reference_label
     ~domain_type:all.Db_actions.vM_domain_type ~nVRAM:all.Db_actions.vM_NVRAM
-    ~pending_guidances:[] ~recommended_guidances:[] ;
+    ~pending_guidances:[] ~recommended_guidances:[]
+    ~pending_guidances_recommended:[] ~pending_guidances_full:[] ;
   (* update the VM's parent field in case of snapshot. Note this must be done after "ref"
      	   has been created, so that its "children" field can be updated by the database layer *)
   ( match disk_op with


### PR DESCRIPTION
    This is the initial commit for the update guidance improvement:
    
    1. Update comments for re-purposing host.pending_guidances.
    2. Add new pending-guidance fields: host.pending_guidances_recommended,
       host.pending_guidances_full, vm.pending_guidances_recommended and
       vm.pending_guidances_full.
    3. Add definition for new guidance: RestartVM,
       reboot_host_on_kernel_livepatch_failure and
       reboot_host_on_xen_livepatch_failure
    4. Add DB upgrade rule: replace reboot_host_on_livepatch_failure in
       "host.pending_guidances" with both
       reboot_host_on_kernel_livepatch_failure and
       reboot_host_on_xen_livepatch_failure in
       "host.pending_guidances_recommended”
    5. Clear reboot_host_on_kernel_livepatch_failure and
       reboot_host_on_xen_livepatch_failure on reboot
    6. CLI: expose those new added pending guidance fields
