### PR TITLE
CP-45568: Do not enable host if its mandatory host guidance is pending

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1963,6 +1963,12 @@ let _ =
   error Api_errors.no_repositories_configured []
     ~doc:"No update repositories have been configured." () ;
 
+  error Api_errors.host_pending_mandatory_guidances_not_empty ["host"]
+    ~doc:
+      "The specified server is disabled and cannot be re-enabled until all of \
+       its pending mandatory guidances got applied."
+    () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1290,6 +1290,9 @@ let invalid_update_sync_day = "INVALID_UPDATE_SYNC_DAY"
 
 let no_repositories_configured = "NO_REPOSITORIES_CONFIGURED"
 
+let host_pending_mandatory_guidances_not_empty =
+  "HOST_PENDING_MANDATORY_GUIDANCE_NOT_EMPTY"
+
 (* VTPMs *)
 
 let vtpm_max_amount_reached = "VTPM_MAX_AMOUNT_REACHED"

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -78,13 +78,17 @@ let assert_safe_to_reenable ~__context ~self =
   let host_pending_mandatory_guidances =
     Db.Host.get_pending_guidances ~__context ~self
   in
-  if host_pending_mandatory_guidances <> [] then
+  if host_pending_mandatory_guidances <> [] then (
+    info "%s: %d mandatory guidances are pending for host %s" __FUNCTION__
+      (List.length host_pending_mandatory_guidances)
+      (Ref.string_of self) ;
     raise
       (Api_errors.Server_error
          ( Api_errors.host_pending_mandatory_guidances_not_empty
          , [Ref.string_of self]
          )
-      ) ;
+      )
+  ) ;
   let host_disabled_until_reboot =
     try bool_of_string (Localdb.get Constants.host_disabled_until_reboot)
     with _ -> false

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -79,7 +79,8 @@ let assert_safe_to_reenable ~__context ~self =
     Db.Host.get_pending_guidances ~__context ~self
   in
   if host_pending_mandatory_guidances <> [] then (
-    info "%s: %d mandatory guidances are pending for host %s: [%s]" __FUNCTION__
+    error "%s: %d mandatory guidances are pending for host %s: [%s]"
+      __FUNCTION__
       (List.length host_pending_mandatory_guidances)
       (Ref.string_of self)
       (String.concat ";"

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -67,19 +67,33 @@ let set_power_on_mode ~__context ~self ~power_on_mode ~power_on_config =
   Xapi_host_helpers.update_allowed_operations ~__context ~self
 
 (** Before we re-enable this host we make sure it's safe to do so. It isn't if:
-    	+ we're in the middle of an HA shutdown/reboot and have our fencing temporarily disabled.
-    	+ xapi hasn't properly started up yet.
-    	+ HA is enabled and this host has broken storage or networking which would cause protected VMs
-    	to become non-agile
+        + there are pending mandatory guidances on the host
+        + we're in the middle of an HA shutdown/reboot and have our fencing temporarily disabled.
+        + xapi hasn't properly started up yet.
+        + HA is enabled and this host has broken storage or networking which would cause protected VMs
+        to become non-agile
 *)
 let assert_safe_to_reenable ~__context ~self =
   assert_startup_complete () ;
+  let host_pending_mandatory_guidances =
+    Db.Host.get_pending_guidances ~__context ~self
+  in
+  if host_pending_mandatory_guidances <> [] then
+    raise
+      (Api_errors.Server_error
+         ( Api_errors.host_pending_mandatory_guidances_not_empty
+         , [Ref.string_of self]
+         )
+      ) ;
   let host_disabled_until_reboot =
     try bool_of_string (Localdb.get Constants.host_disabled_until_reboot)
     with _ -> false
   in
   if host_disabled_until_reboot then
-    raise (Api_errors.Server_error (Api_errors.host_disabled_until_reboot, [])) ;
+    raise
+      (Api_errors.Server_error
+         (Api_errors.host_disabled_until_reboot, [Ref.string_of self])
+      ) ;
   if Db.Pool.get_ha_enabled ~__context ~self:(Helpers.get_pool ~__context) then (
     let pbds = Db.Host.get_PBDs ~__context ~self in
     let unplugged_pbds =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -79,9 +79,16 @@ let assert_safe_to_reenable ~__context ~self =
     Db.Host.get_pending_guidances ~__context ~self
   in
   if host_pending_mandatory_guidances <> [] then (
-    info "%s: %d mandatory guidances are pending for host %s" __FUNCTION__
+    info "%s: %d mandatory guidances are pending for host %s: [%s]" __FUNCTION__
       (List.length host_pending_mandatory_guidances)
-      (Ref.string_of self) ;
+      (Ref.string_of self)
+      (String.concat ";"
+         (List.map Updateinfo.Guidance.to_string
+            (List.map Updateinfo.Guidance.of_update_guidance
+               host_pending_mandatory_guidances
+            )
+         )
+      ) ;
     raise
       (Api_errors.Server_error
          ( Api_errors.host_pending_mandatory_guidances_not_empty

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -367,8 +367,17 @@ let consider_enabling_host_nolock ~__context =
   in
   if host_pending_mandatory_guidances <> [] then
     debug
-      "Host.enabled: host has mandatory guidances pending to be applied. \
-       Leaving host disabled"
+      "Host.enabled: host(%s) has %d mandatory guidances pending to be \
+       applied: [%s]. Leaving host disabled"
+      (Ref.string_of localhost)
+      (List.length host_pending_mandatory_guidances)
+      (String.concat ";"
+         (List.map Updateinfo.Guidance.to_string
+            (List.map Updateinfo.Guidance.of_update_guidance
+               host_pending_mandatory_guidances
+            )
+         )
+      )
   else if
     (not !user_requested_host_disable)
     && ((not ha_enabled) || all_pbds_ok)

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -367,7 +367,7 @@ let consider_enabling_host_nolock ~__context =
   in
   if host_pending_mandatory_guidances <> [] then
     debug
-      "Host.enabled: host remains pending mandatory guidances not applied. \
+      "Host.enabled: host has mandatory guidances pending to be applied. \
        Leaving host disabled"
   else if
     (not !user_requested_host_disable)

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -362,7 +362,14 @@ let consider_enabling_host_nolock ~__context =
          pbds
       )
   in
-  if
+  let host_pending_mandatory_guidances =
+    Db.Host.get_pending_guidances ~__context ~self:localhost
+  in
+  if host_pending_mandatory_guidances <> [] then
+    debug
+      "Host.enabled: host remains pending mandatory guidances not applied. \
+       Leaving host disabled"
+  else if
     (not !user_requested_host_disable)
     && ((not ha_enabled) || all_pbds_ok)
     && is_xen_compatible ()

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -374,64 +374,16 @@ let consider_enabling_host_nolock ~__context =
     let pool = Helpers.get_pool ~__context in
     Db.Host.remove_pending_guidances ~__context ~self:localhost
       ~value:`restart_toolstack ;
-    ( if !Xapi_globs.on_system_boot then (
-        debug
-          "Host.enabled: system has just restarted: remove livepatch failure \
-           guidances" ;
-        Db.Host.remove_pending_guidances ~__context ~self:localhost
-          ~value:`reboot_host ;
-        Db.Host.remove_pending_guidances ~__context ~self:localhost
-          ~value:`reboot_host_on_livepatch_failure ;
-        Db.Host.remove_pending_guidances_recommended ~__context ~self:localhost
-          ~value:`reboot_host_on_kernel_livepatch_failure ;
-        Db.Host.remove_pending_guidances_recommended ~__context ~self:localhost
-          ~value:`reboot_host_on_xen_livepatch_failure ;
-
-        let host_pending_mandatory_guidances =
-          Db.Host.get_pending_guidances ~__context ~self:localhost
-        in
-        if host_pending_mandatory_guidances <> [] then
-          debug
-            "Host.enabled: system has just restarted but host(%s) has %d \
-             mandatory guidances pending to be applied: [%s]. Leaving host \
-             disabled"
-            (Ref.string_of localhost)
-            (List.length host_pending_mandatory_guidances)
-            (String.concat ";"
-               (List.map Updateinfo.Guidance.to_string
-                  (List.map Updateinfo.Guidance.of_update_guidance
-                     host_pending_mandatory_guidances
-                  )
-               )
-            )
-        else (
-          debug
-            "Host.enabled: system has just restarted and no pending mandatory \
-             guidances: setting localhost to enabled" ;
-          Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
-          update_allowed_operations ~__context ~self:localhost ;
-          Localdb.put Constants.host_disabled_until_reboot "false" ;
-          (* Start processing pending VM powercycle events *)
-          Local_work_queue.start_vm_lifecycle_queue ()
-        )
-      ) else if
-        try bool_of_string (Localdb.get Constants.host_disabled_until_reboot)
-        with _ -> false
-      then
-        debug
-          "Host.enabled: system not just rebooted but \
-           host_disabled_until_reboot still set. Leaving host disabled"
-    else
+    let if_no_pending_guidances f =
       let host_pending_mandatory_guidances =
         Db.Host.get_pending_guidances ~__context ~self:localhost
       in
       if host_pending_mandatory_guidances <> [] then
         debug
-          "Host.enabled: system not just rebooted && \
-           host_disabled_until_reboot not set but host(%s) has %d mandatory \
-           guidances pending to be applied: [%s]. Leaving host disabled"
-          (Ref.string_of localhost)
+          "Host.enabled: there are %d pending mandatory guidances on host \
+           (%s): [%s]. Leave host disabled."
           (List.length host_pending_mandatory_guidances)
+          (Ref.string_of localhost)
           (String.concat ";"
              (List.map Updateinfo.Guidance.to_string
                 (List.map Updateinfo.Guidance.of_update_guidance
@@ -439,16 +391,51 @@ let consider_enabling_host_nolock ~__context =
                 )
              )
           )
-      else (
-        debug
-          "Host.enabled: system not just rebooted && \
-           host_disabled_until_reboot not set and no pending mandatory \
-           guidances: setting localhost to enabled" ;
-        Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
-        update_allowed_operations ~__context ~self:localhost ;
-        (* Start processing pending VM powercycle events *)
-        Local_work_queue.start_vm_lifecycle_queue ()
-      )
+      else
+        f ()
+    in
+    if !Xapi_globs.on_system_boot then (
+      debug
+        "Host.enabled: system has just restarted: remove livepatch failure \
+         guidances" ;
+      Db.Host.remove_pending_guidances ~__context ~self:localhost
+        ~value:`reboot_host ;
+      Db.Host.remove_pending_guidances ~__context ~self:localhost
+        ~value:`reboot_host_on_livepatch_failure ;
+      Db.Host.remove_pending_guidances_recommended ~__context ~self:localhost
+        ~value:`reboot_host_on_kernel_livepatch_failure ;
+      Db.Host.remove_pending_guidances_recommended ~__context ~self:localhost
+        ~value:`reboot_host_on_xen_livepatch_failure ;
+
+      if_no_pending_guidances @@ fun () ->
+      debug
+        "Host.enabled: system has just restarted and no pending mandatory \
+         guidances: setting localhost to enabled" ;
+      Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
+      update_allowed_operations ~__context ~self:localhost ;
+      Localdb.put Constants.host_disabled_until_reboot "false" ;
+      (* Start processing pending VM powercycle events *)
+      Local_work_queue.start_vm_lifecycle_queue ()
+    ) else if
+        try bool_of_string (Localdb.get Constants.host_disabled_until_reboot)
+        with _ -> false
+      then
+      debug
+        "Host.enabled: system not just rebooted but host_disabled_until_reboot \
+         still set. Leaving host disabled"
+    else (
+      debug
+        "Host.enabled: system not just rebooted && host_disabled_until_reboot \
+         not set" ;
+      if_no_pending_guidances @@ fun () ->
+      debug
+        "Host.enabled: system not just rebooted && host_disabled_until_reboot \
+         not set and no pending mandatory guidances: setting localhost to \
+         enabled" ;
+      Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
+      update_allowed_operations ~__context ~self:localhost ;
+      (* Start processing pending VM powercycle events *)
+      Local_work_queue.start_vm_lifecycle_queue ()
     ) ;
     (* If Host has been enabled and HA is also enabled then tell the master to recompute its plan *)
     if

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -362,23 +362,7 @@ let consider_enabling_host_nolock ~__context =
          pbds
       )
   in
-  let host_pending_mandatory_guidances =
-    Db.Host.get_pending_guidances ~__context ~self:localhost
-  in
-  if host_pending_mandatory_guidances <> [] then
-    debug
-      "Host.enabled: host(%s) has %d mandatory guidances pending to be \
-       applied: [%s]. Leaving host disabled"
-      (Ref.string_of localhost)
-      (List.length host_pending_mandatory_guidances)
-      (String.concat ";"
-         (List.map Updateinfo.Guidance.to_string
-            (List.map Updateinfo.Guidance.of_update_guidance
-               host_pending_mandatory_guidances
-            )
-         )
-      )
-  else if
+  if
     (not !user_requested_host_disable)
     && ((not ha_enabled) || all_pbds_ok)
     && is_xen_compatible ()
@@ -392,8 +376,8 @@ let consider_enabling_host_nolock ~__context =
       ~value:`restart_toolstack ;
     if !Xapi_globs.on_system_boot then (
       debug
-        "Host.enabled: system has just restarted: setting localhost to enabled" ;
-      Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
+        "Host.enabled: system has just restarted: remove livepatch failure \
+         guidances" ;
       Db.Host.remove_pending_guidances ~__context ~self:localhost
         ~value:`reboot_host ;
       Db.Host.remove_pending_guidances ~__context ~self:localhost
@@ -402,10 +386,34 @@ let consider_enabling_host_nolock ~__context =
         ~value:`reboot_host_on_kernel_livepatch_failure ;
       Db.Host.remove_pending_guidances_recommended ~__context ~self:localhost
         ~value:`reboot_host_on_xen_livepatch_failure ;
-      update_allowed_operations ~__context ~self:localhost ;
-      Localdb.put Constants.host_disabled_until_reboot "false" ;
-      (* Start processing pending VM powercycle events *)
-      Local_work_queue.start_vm_lifecycle_queue ()
+
+      let host_pending_mandatory_guidances =
+        Db.Host.get_pending_guidances ~__context ~self:localhost
+      in
+      if host_pending_mandatory_guidances <> [] then
+        debug
+          "Host.enabled: system has just restarted but host(%s) has %d \
+           mandatory guidances pending to be applied: [%s]. Leaving host \
+           disabled"
+          (Ref.string_of localhost)
+          (List.length host_pending_mandatory_guidances)
+          (String.concat ";"
+             (List.map Updateinfo.Guidance.to_string
+                (List.map Updateinfo.Guidance.of_update_guidance
+                   host_pending_mandatory_guidances
+                )
+             )
+          )
+      else (
+        debug
+          "Host.enabled: system has just restarted and no pending mandatory \
+           guidances: setting localhost to enabled" ;
+        Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
+        update_allowed_operations ~__context ~self:localhost ;
+        Localdb.put Constants.host_disabled_until_reboot "false" ;
+        (* Start processing pending VM powercycle events *)
+        Local_work_queue.start_vm_lifecycle_queue ()
+      )
     ) else if
         try bool_of_string (Localdb.get Constants.host_disabled_until_reboot)
         with _ -> false
@@ -414,13 +422,33 @@ let consider_enabling_host_nolock ~__context =
         "Host.enabled: system not just rebooted but host_disabled_until_reboot \
          still set. Leaving host disabled"
     else (
-      debug
-        "Host.enabled: system not just rebooted && host_disabled_until_reboot \
-         not set: setting localhost to enabled" ;
-      Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
-      update_allowed_operations ~__context ~self:localhost ;
-      (* Start processing pending VM powercycle events *)
-      Local_work_queue.start_vm_lifecycle_queue ()
+      let host_pending_mandatory_guidances =
+        Db.Host.get_pending_guidances ~__context ~self:localhost
+      in
+      if host_pending_mandatory_guidances <> [] then
+        debug
+          "Host.enabled: system not just rebooted && \
+           host_disabled_until_reboot not set but host(%s) has %d mandatory \
+           guidances pending to be applied: [%s]. Leaving host disabled"
+          (Ref.string_of localhost)
+          (List.length host_pending_mandatory_guidances)
+          (String.concat ";"
+             (List.map Updateinfo.Guidance.to_string
+                (List.map Updateinfo.Guidance.of_update_guidance
+                   host_pending_mandatory_guidances
+                )
+             )
+          )
+      else (
+        debug
+          "Host.enabled: system not just rebooted && \
+           host_disabled_until_reboot not set and no pending mandatory \
+           guidances: setting localhost to enabled" ;
+        Db.Host.set_enabled ~__context ~self:localhost ~value:true ;
+        update_allowed_operations ~__context ~self:localhost ;
+        (* Start processing pending VM powercycle events *)
+        Local_work_queue.start_vm_lifecycle_queue ()
+      )
     ) ;
     (* If Host has been enabled and HA is also enabled then tell the master to recompute its plan *)
     if


### PR DESCRIPTION
As mandatory host guidance must be applied after applying updates, otherwise there may be e.g. VM failures, it is safe not to enable a host when its mandatory host guidance is pending:

1. do not enable host on xapi startup if there is pending mandatory gudiance in the host.
2. raise error: host_pending_mandatory_guidances_not_empty for API host.enable if there is pending mandatory gudiance in the host.