### PR TITLE
CP-45981: Update xenopsd from python2 to python3

### DIFF
--- a/ocaml/xenopsd/scripts/common.py
+++ b/ocaml/xenopsd/scripts/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2011-2013 Citrix Systems, Inc.
 #
@@ -38,7 +38,8 @@ def send_to_syslog(msg):
 def doexec(args):
     """Execute a subprocess, then return its return code, stdout and stderr"""
     send_to_syslog(args)
-    proc = subprocess.Popen([ "/usr/bin/env", "PATH=%s" % path ] + args,stdin=None,stdout=subprocess.PIPE,stderr=subprocess.PIPE,close_fds=True)
+    proc = subprocess.Popen([ "/usr/bin/env", "PATH=%s" % path ] + args, stdin=None, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, close_fds=True, universal_newlines=True)
     rc = proc.wait()
     stdout = proc.stdout
     stderr = proc.stderr
@@ -101,7 +102,7 @@ def add_to_bridge(mode, dev, bridge, address, external_ids):
         cmd = ["ovs-vsctl", "--timeout=30", "--", "--if-exists", "del-port", dev, "--", "add-port", bridge, dev]
         for (key, value) in external_ids:
              cmd = cmd + ["--", "set", "interface", dev, 'external-ids:"%s"="%s"' % (key, value) ]
-	run(ON_ERROR_LOG, cmd)
+        run(ON_ERROR_LOG, cmd)
 
 def remove_from_bridge(mode, dev, bridge):
     if mode == MODE_BRIDGE:
@@ -203,14 +204,13 @@ class VIF:
             "ipv4_allowed": [],
             "ipv6_allowed": []
         }
-        private = self.json["extra_private_keys"]
         if "locking_mode" in self.json:
             if type(self.json["locking_mode"]) is list:
-		# Must be type=locked here
+                # Must be type=locked here
                 results["locking_mode"] = self.json["locking_mode"][0].lower()
-		locked_params=self.json["locking_mode"][1]
-		results["ipv4_allowed"] = locked_params["ipv4"]
-		results["ipv6_allowed"] = locked_params["ipv6"]
+                locked_params=self.json["locking_mode"][1]
+                results["ipv4_allowed"] = locked_params["ipv4"]
+                results["ipv6_allowed"] = locked_params["ipv6"]
             else:
                 results["locking_mode"] = self.json["locking_mode"].lower()
         send_to_syslog("Got locking config: %s" % (repr(results)))

--- a/ocaml/xenopsd/scripts/igmp_query_injector.py
+++ b/ocaml/xenopsd/scripts/igmp_query_injector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import threading
 import logging
@@ -106,7 +106,7 @@ class IGMPQueryInjector(object):
         t.join(self.vif_connected_timeout)
         if watcher.watches:
             log.warning('Wait vif state change timeout')
-            for vif in watcher.watches.itervalues():
+            for vif in watcher.watches.values():
                 log.warning("Vif:%s state did not change to '%s', don't inject IGMP query to mac: %s" %
                             (vif, VIF_CONNECTED_STATE, get_vif_mac(vif)))
 
@@ -142,11 +142,11 @@ def get_vif_state_path(vif):
 
 
 def get_parent_bridge(bridge):
-    return subprocess.check_output(['/usr/bin/ovs-vsctl', 'br-to-parent', bridge]).strip()
+    return subprocess.check_output(['/usr/bin/ovs-vsctl', 'br-to-parent', bridge], universal_newlines=True).strip()
 
 
 def network_backend_is_openvswitch():
-    bridge_type = subprocess.check_output(['/opt/xensource/bin/xe-get-network-backend']).strip()
+    bridge_type = subprocess.check_output(['/opt/xensource/bin/xe-get-network-backend'], universal_newlines=True).strip()
     return bridge_type == 'openvswitch'
 
 
@@ -161,7 +161,7 @@ def memodict(f):
 
 @memodict
 def igmp_snooping_is_enabled_on_bridge(bridge):
-    vlan = subprocess.check_output(['/usr/bin/ovs-vsctl', 'br-to-vlan', bridge]).strip()
+    vlan = subprocess.check_output(['/usr/bin/ovs-vsctl', 'br-to-vlan', bridge], universal_newlines=True).strip()
     if vlan != '0':
         # this br is a fake br, should get its parent
         bridge = get_parent_bridge(bridge)
@@ -170,12 +170,12 @@ def igmp_snooping_is_enabled_on_bridge(bridge):
 
 @memodict
 def _igmp_snooping_is_enabled_on_bridge(bridge):
-    enabled = subprocess.check_output(['/usr/bin/ovs-vsctl', 'get', 'bridge', bridge, 'mcast_snooping_enable']).strip()
+    enabled = subprocess.check_output(['/usr/bin/ovs-vsctl', 'get', 'bridge', bridge, 'mcast_snooping_enable'], universal_newlines=True).strip()
     return enabled == 'true'
 
 
 def igmp_snooping_is_enabled_on_bridge_of_vif(vif):
-    bridge = subprocess.check_output(['/usr/bin/ovs-vsctl', 'iface-to-br', vif]).strip()
+    bridge = subprocess.check_output(['/usr/bin/ovs-vsctl', 'iface-to-br', vif], universal_newlines=True).strip()
     return igmp_snooping_is_enabled_on_bridge(bridge)
 
 

--- a/ocaml/xenopsd/scripts/pygrub-wrapper
+++ b/ocaml/xenopsd/scripts/pygrub-wrapper
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python3
 #
 # Copyright (C) 2023 Cloud Software Group
 #
@@ -12,13 +12,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
 
-from __future__ import print_function
+
 import pwd, subprocess, sys
 
 cmd = ["pygrub"]
 
 # Get the usage string. We can't use check_output() because the exit status isn't 0
-pygrub_usage = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[1]
+pygrub_usage = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()[1]
 
 for arg in sys.argv[1:]:
     # Catch the synthetic --domid argument and turn it into --runas

--- a/ocaml/xenopsd/scripts/qemu-vif-script
+++ b/ocaml/xenopsd/scripts/qemu-vif-script
@@ -1,7 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
+
 from common import *
+import sys
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:

--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python3
 #
 # Copyright (C) 2016 Citrix Systems R&D Ltd.
 #
@@ -12,9 +12,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
 
-from __future__ import print_function
 import os
-import re
 import sys
 import socket
 import tempfile
@@ -266,6 +264,7 @@ def main(argv):
                 incoming_fd = os.open(loadvm_path, os.O_RDONLY)
             qemu_args[n] = "-incoming"
             qemu_args[n+1] = "fd:%d" % incoming_fd
+            open_fds.append(incoming_fd)
 
         n += 1
 
@@ -310,7 +309,7 @@ def main(argv):
 
     clipboardd = '/opt/xensource/libexec/xs-clipboardd'
     subprocess.call([clipboardd, "-d", str(domid), "-s", str(s2.fileno())],
-                    preexec_fn=close_fds)
+                    pass_fds=[s2.fileno()])
 
     s2.close()
 
@@ -327,7 +326,7 @@ def main(argv):
 
     qemu = subprocess.Popen(qemu_args, executable=qemu_dm, env=qemu_env,
                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                            preexec_fn=prepare_exec)
+                            preexec_fn=prepare_exec, pass_fds=open_fds)
 
     xenstore_write("/local/domain/%d/qemu-pid" % domid, "%d" % qemu.pid)
     xenstore_write("/local/domain/%d/image/device-model-pid" % domid, "%d" % qemu.pid)

--- a/ocaml/xenopsd/scripts/setup-vif-rules
+++ b/ocaml/xenopsd/scripts/setup-vif-rules
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 #
@@ -13,14 +13,11 @@
 # GNU Lesser General Public License for more details.
 #
 
-from __future__ import print_function
+
 import fcntl
 import os
 import os.path
-import string
-import subprocess
 import sys
-import syslog
 import time
 import common
 from common import ON_ERROR_FAIL, send_to_syslog, doexec, run
@@ -92,7 +89,9 @@ def remove_bridge_port(vif_name):
 def get_chain_name(vif_name):
     return ("FORWARD_%s" % vif_name)
 
-def do_chain_action(executable, action, chain_name, args=[]):
+def do_chain_action(executable, action, chain_name, args=None):
+    if args is None:
+        args = []
     return doexec([executable, action, chain_name] + args)
 
 def chain_exists(executable, chain_name):


### PR DESCRIPTION
1. Update xenopsd to python3
2. Fix some tab and space inconsistency
3. Remove unused import modules

Test:
3879814 auto cert kit (network and VM related test)
3879823 vCPUPinning (qemu-related test)
191817 Ring 0 BST 
191818 ToolStack Input 


