### PR TITLE
CP-45566: Support guidance data in new format in updateinfo.xml

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1942,10 +1942,6 @@ let _ =
     ~doc:"The repository domain allowlist has some invalid domains." () ;
   error Api_errors.apply_livepatch_failed ["livepatch"]
     ~doc:"Failed to apply a livepatch." () ;
-  error Api_errors.updates_require_recommended_guidance ["recommended_guidance"]
-    ~doc:"Requires recommended guidance after applying updates." () ;
-  error Api_errors.update_guidance_changed ["guidance"]
-    ~doc:"Guidance for the update has changed" () ;
 
   error Api_errors.vtpm_max_amount_reached ["amount"]
     ~doc:"The VM cannot be associated with more VTPMs." () ;

--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -187,118 +187,6 @@ module UpdateOfJsonTest = Generic.MakeStateless (struct
       ]
 end)
 
-module GuidanceSetAssertValidGuidanceTest = Generic.MakeStateless (struct
-  module Io = struct
-    type input_t = Guidance.t list
-
-    type output_t = (unit, exn) result
-
-    let string_of_input_t l =
-      Fmt.(str "%a" Dump.(list string)) (List.map Guidance.to_string l)
-
-    let string_of_output_t =
-      Fmt.(str "%a" Dump.(result ~ok:(any "()") ~error:exn))
-  end
-
-  let transform input =
-    try Ok (GuidanceSet.assert_valid_guidances input) with e -> Error e
-
-  let tests =
-    let open Guidance in
-    `QuickAndAutoDocumented
-      [
-        ([], Ok ())
-      ; ([RebootHost], Ok ())
-      ; ([RestartToolstack], Ok ())
-      ; ([RestartDeviceModel], Ok ())
-      ; ([EvacuateHost], Ok ())
-      ; ([EvacuateHost; RestartToolstack], Ok ())
-      ; ([RestartDeviceModel; RestartToolstack], Ok ())
-      ; ( [RestartDeviceModel; EvacuateHost]
-        , Error
-            Api_errors.(
-              Server_error
-                ( internal_error
-                , [GuidanceSet.error_msg [RestartDeviceModel; EvacuateHost]]
-                )
-            )
-        )
-      ; ( [EvacuateHost; RestartToolstack; RestartDeviceModel]
-        , Error
-            Api_errors.(
-              Server_error
-                ( internal_error
-                , [
-                    GuidanceSet.error_msg
-                      [EvacuateHost; RestartToolstack; RestartDeviceModel]
-                  ]
-                )
-            )
-        )
-      ; ( [RebootHost; RestartToolstack]
-        , Error
-            Api_errors.(
-              Server_error
-                ( internal_error
-                , [GuidanceSet.error_msg [RebootHost; RestartToolstack]]
-                )
-            )
-        )
-      ; ( [RebootHost; RestartDeviceModel]
-        , Error
-            Api_errors.(
-              Server_error
-                ( internal_error
-                , [GuidanceSet.error_msg [RebootHost; RestartDeviceModel]]
-                )
-            )
-        )
-      ; ( [RebootHost; EvacuateHost]
-        , Error
-            Api_errors.(
-              Server_error
-                ( internal_error
-                , [GuidanceSet.error_msg [RebootHost; EvacuateHost]]
-                )
-            )
-        )
-      ]
-end)
-
-let fields_of_updateinfo =
-  Fmt.Dump.
-    [
-      field "id" (fun (r : UpdateInfo.t) -> r.id) string
-    ; field "summary" (fun (r : UpdateInfo.t) -> r.summary) string
-    ; field "description" (fun (r : UpdateInfo.t) -> r.description) string
-    ; field "rec_guidance"
-        (fun (r : UpdateInfo.t) -> UpdateInfo.guidance_to_string r.rec_guidance)
-        string
-    ; field "abs_guidance"
-        (fun (r : UpdateInfo.t) -> UpdateInfo.guidance_to_string r.abs_guidance)
-        string
-    ; field "guidance_applicabilities"
-        (fun (r : UpdateInfo.t) ->
-          List.map Applicability.to_string r.guidance_applicabilities
-        )
-        (list string)
-    ; field "spec_info" (fun (r : UpdateInfo.t) -> r.spec_info) string
-    ; field "url" (fun (r : UpdateInfo.t) -> r.url) string
-    ; field "update_type" (fun (r : UpdateInfo.t) -> r.update_type) string
-    ; field "livepatch_guidance"
-        (fun (r : UpdateInfo.t) ->
-          UpdateInfo.guidance_to_string r.livepatch_guidance
-        )
-        string
-    ; field "livepatches"
-        (fun (r : UpdateInfo.t) ->
-          List.map
-            (fun x -> x |> LivePatch.to_json |> Yojson.Basic.pretty_to_string)
-            r.livepatches
-        )
-        (list string)
-    ]
-
 module AssertUrlIsValid = Generic.MakeStateless (struct
   module Io = struct
     type input_t = string * string list
@@ -520,10 +408,10 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
         updates_info: (string * UpdateInfo.t) list
       ; update: Update.t
       ; upd_ids_of_livepatches: string list
-      ; upd_ids_of_failed_livepatches: string list
+      ; kind: Guidance.kind
     }
 
-    type output_t = Guidance.t option
+    type output_t = Guidance.t list
 
     let fields_of_input =
       Fmt.Dump.
@@ -548,37 +436,24 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
               |> Printf.sprintf "[%s]"
             )
             string
-        ; field "upd_ids_of_failed_livepatches"
-            (fun (r : input_t) ->
-              r.upd_ids_of_failed_livepatches
-              |> String.concat ";"
-              |> Printf.sprintf "[%s]"
-            )
+        ; field "kind"
+            (fun (r : input_t) -> Guidance.kind_to_string r.kind)
             string
         ]
 
     let string_of_input_t = Fmt.(str "%a" Dump.(record @@ fields_of_input))
 
-    let string_of_output_t g =
-      Fmt.(str "%a" Dump.(string)) (UpdateInfo.guidance_to_string g)
+    let string_of_output_t l =
+      Fmt.(str "%a" Dump.(list string)) (List.map Guidance.to_string l)
   end
 
-  let transform
-      Io.
-        {
-          updates_info
-        ; update
-        ; upd_ids_of_livepatches
-        ; upd_ids_of_failed_livepatches
-        } =
-    eval_guidance_for_one_update ~updates_info ~update
-      ~kind:Guidance.Recommended
+  let transform Io.{updates_info; update; upd_ids_of_livepatches; kind} =
+    eval_guidance_for_one_update ~updates_info ~update ~kind
       ~upd_ids_of_livepatches:(UpdateIdSet.of_list upd_ids_of_livepatches)
-      ~upd_ids_of_failed_livepatches:
-        (UpdateIdSet.of_list upd_ids_of_failed_livepatches)
 
   let tests =
     let open Io in
+    let open Guidance in
     `QuickAndAutoDocumented
       [
         (* Update ID in update can't be found in updateinfo list *)
@@ -600,9 +475,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Mandatory
           }
-        , None
+        , []
         )
       ; (* Update ID in update can't be found in updateinfo list *)
         ( {
@@ -614,13 +489,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.EvacuateHost
-                    ; abs_guidance= Some Guidance.RebootHost
+                    ; guidance=
+                        [
+                          (Mandatory, [EvacuateHost])
+                        ; (Recommended, [])
+                        ; (Full, [RebootHost])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -632,13 +511,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.EvacuateHost
-                    ; abs_guidance= Some Guidance.RebootHost
+                    ; guidance=
+                        [
+                          (Mandatory, [EvacuateHost])
+                        ; (Recommended, [])
+                        ; (Full, [RebootHost])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -661,9 +544,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Mandatory
           }
-        , None
+        , []
         )
       ; (* No update ID in update *)
         ( {
@@ -675,13 +558,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.EvacuateHost
-                    ; abs_guidance= Some Guidance.RebootHost
+                    ; guidance=
+                        [
+                          (Mandatory, [EvacuateHost])
+                        ; (Recommended, [])
+                        ; (Full, [RebootHost])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -703,9 +590,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , None
+        , []
         )
       ; (* Empty applicabilities *)
         ( {
@@ -717,13 +604,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= None
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -735,13 +626,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RebootHost])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -763,9 +658,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , Some Guidance.RebootHost
+        , [RebootHost]
         )
       ; (* Matched applicability *)
         ( {
@@ -777,13 +672,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= None
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -795,8 +694,13 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RestartDeviceModel
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [RestartDeviceModel])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities=
                         [
                           Applicability.
@@ -814,7 +718,6 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -836,9 +739,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Mandatory
           }
-        , Some Guidance.RestartDeviceModel
+        , [RestartDeviceModel]
         )
       ; (* Matched in multiple applicabilities *)
         ( {
@@ -850,13 +753,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= None
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -868,8 +775,13 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RestartDeviceModel
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [EvacuateHost])
+                        ; (Recommended, [RestartDeviceModel])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities=
                         [
                           Applicability.
@@ -898,7 +810,6 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -920,9 +831,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , Some Guidance.RestartDeviceModel
+        , [RestartDeviceModel]
         )
       ; (* No matched applicability *)
         ( {
@@ -934,13 +845,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= None
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -952,8 +867,13 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RestartDeviceModel
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [RestartDeviceModel])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities=
                         [
                           Applicability.
@@ -971,7 +891,6 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -993,9 +912,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Mandatory
           }
-        , None
+        , []
         )
       ; (* Unmatched arch *)
         ( {
@@ -1007,13 +926,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= None
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -1025,8 +948,13 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RestartDeviceModel
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [RestartDeviceModel])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities=
                         [
                           Applicability.
@@ -1043,7 +971,6 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -1065,9 +992,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Mandatory
           }
-        , None
+        , []
         )
       ; (* Matched in multiple applicabilities with epoch *)
         ( {
@@ -1079,13 +1006,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= None
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= []
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -1097,8 +1028,13 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RestartDeviceModel
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RestartDeviceModel; RestartToolstack])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities=
                         [
                           Applicability.
@@ -1127,7 +1063,6 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -1149,11 +1084,11 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= []
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , Some Guidance.RestartDeviceModel
+        , [RestartDeviceModel; RestartToolstack]
         )
-      ; (* livepatch_guidance: Some _ *)
+      ; (* livepatch_guidance *)
         ( {
             updates_info=
               [
@@ -1163,13 +1098,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RebootHost])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartDeviceModel; RestartToolstack])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= Some Guidance.RestartDeviceModel
                     ; livepatches=
                         [
                           LivePatch.
@@ -1213,11 +1152,11 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= ["UPDATE-0000"]
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , Some Guidance.RestartDeviceModel
+        , [RestartDeviceModel; RestartToolstack]
         )
-      ; (* livepatch_guidance - None *)
+      ; (* livepatch_guidance - empty *)
         ( {
             updates_info=
               [
@@ -1227,13 +1166,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RebootHost])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches=
                         [
                           LivePatch.
@@ -1267,9 +1210,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= ["UPDATE-0000"]
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , None
+        , []
         )
       ; (* livepatch_guidance: livepatch does not come from RPM update UPDATE-0001.
          * And the RPM update UPDATE-0001 requires RebootHost.
@@ -1283,13 +1226,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= None
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartDeviceModel])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= Some Guidance.RestartDeviceModel
                     ; livepatches=
                         [
                           LivePatch.
@@ -1313,13 +1260,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RebootHost])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartToolstack])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= Some Guidance.RestartToolstack
                     ; livepatches=
                         [
                           LivePatch.
@@ -1353,9 +1304,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= ["UPDATE-0000"]
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , Some Guidance.RebootHost
+        , [RebootHost]
         )
       ; (* livepatch_guidance: livepatch comes from the RPM update UPDATE-001 *)
         ( {
@@ -1367,13 +1318,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RebootHost])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartDeviceModel])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= Some Guidance.RestartDeviceModel
                     ; livepatches=
                         [
                           LivePatch.
@@ -1397,13 +1352,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RebootHost])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartToolstack])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= Some Guidance.RestartToolstack
                     ; livepatches=
                         [
                           LivePatch.
@@ -1447,11 +1406,11 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= ["UPDATE-0001"]
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , Some Guidance.RestartToolstack
+        , [RestartToolstack]
         )
-      ; (* livepatch_guidance: latest update doesn't have livepatch and recommendedGuidance is None *)
+      ; (* livepatch_guidance: latest update doesn't have livepatch and recommended is empty *)
         ( {
             updates_info=
               [
@@ -1461,13 +1420,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartDeviceModel])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches=
                         [
                           LivePatch.
@@ -1491,13 +1454,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= None
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RestartToolstack])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -1519,11 +1486,11 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= ["UPDATE-0000"]
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , None
+        , [RestartToolstack]
         )
-      ; (* livepatch_guidance: latest update doesn't have livepatch and recommendedGuidance is RebootHost *)
+      ; (* livepatch_guidance: latest update doesn't have livepatch but recommended is RebootHost *)
         ( {
             updates_info=
               [
@@ -1533,13 +1500,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartToolstack])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches=
                         [
                           LivePatch.
@@ -1563,13 +1534,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RebootHost])
+                        ; (Full, [])
+                        ; (Livepatch, [])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches= []
                     ; issued= Xapi_stdext_date.Date.epoch
                     ; severity= Severity.None
@@ -1591,11 +1566,11 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= ["UPDATE-0000"]
-          ; upd_ids_of_failed_livepatches= []
+          ; kind= Recommended
           }
-        , Some Guidance.RebootHost
+        , [RebootHost]
         )
-      ; (* livepatch_guidance: failure of applying livepatch *)
+      ; (* livepatch_guidance: is overwhelmed by aother update *)
         ( {
             updates_info=
               [
@@ -1605,13 +1580,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0000"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RestartVM])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartVM])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= Some Guidance.RestartToolstack
                     ; livepatches=
                         [
                           LivePatch.
@@ -1645,13 +1624,17 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                       id= "UPDATE-0001"
                     ; summary= "summary"
                     ; description= "description"
-                    ; rec_guidance= Some Guidance.RebootHost
-                    ; abs_guidance= None
+                    ; guidance=
+                        [
+                          (Mandatory, [])
+                        ; (Recommended, [RebootHost])
+                        ; (Full, [])
+                        ; (Livepatch, [RestartDeviceModel])
+                        ]
                     ; guidance_applicabilities= [] (* No applicabilities *)
                     ; spec_info= "special info"
                     ; url= "https://update.details.info"
                     ; update_type= "security"
-                    ; livepatch_guidance= None
                     ; livepatches=
                         [
                           LivePatch.
@@ -1685,9 +1668,9 @@ module EvalGuidanceForOneUpdate = Generic.MakeStateless (struct
                 ; repository= "regular"
                 }
           ; upd_ids_of_livepatches= ["UPDATE-0000"]
-          ; upd_ids_of_failed_livepatches= ["UPDATE-0001"]
+          ; kind= Recommended
           }
-        , None
+        , [RebootHost]
         )
       ]
 end)
@@ -2000,46 +1983,70 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
         id= ""
       ; summary= "summary"
       ; description= "description"
-      ; rec_guidance= None
-      ; abs_guidance= None
+      ; guidance=
+          [(Mandatory, []); (Recommended, []); (Full, []); (Livepatch, [])]
       ; guidance_applicabilities= []
       ; spec_info= "special info"
       ; url= "https://update.details.info"
       ; update_type= "security"
-      ; livepatch_guidance= None
       ; livepatches= []
       ; issued= Xapi_stdext_date.Date.epoch
       ; severity= Severity.None
       }
 
   let updates_info =
+    let open Guidance in
     [
       ( "UPDATE-0000"
       , {
           updateinfo with
           id= "UPDATE-0000"
-        ; rec_guidance= Some Guidance.EvacuateHost
+        ; guidance=
+            [
+              (Mandatory, [EvacuateHost])
+            ; (Recommended, [])
+            ; (Full, [])
+            ; (Livepatch, [])
+            ]
         }
       )
     ; ( "UPDATE-0001"
       , {
           updateinfo with
           id= "UPDATE-0001"
-        ; rec_guidance= Some Guidance.RebootHost
+        ; guidance=
+            [
+              (Mandatory, [RebootHost])
+            ; (Recommended, [])
+            ; (Full, [])
+            ; (Livepatch, [])
+            ]
         }
       )
     ; ( "UPDATE-0002"
       , {
           updateinfo with
           id= "UPDATE-0002"
-        ; rec_guidance= Some Guidance.RestartDeviceModel
+        ; guidance=
+            [
+              (Mandatory, [RestartDeviceModel])
+            ; (Recommended, [])
+            ; (Full, [])
+            ; (Livepatch, [])
+            ]
         }
       )
     ; ( "UPDATE-0003"
       , {
           updateinfo with
           id= "UPDATE-0003"
-        ; rec_guidance= Some Guidance.EvacuateHost
+        ; guidance=
+            [
+              (Mandatory, [EvacuateHost])
+            ; (Recommended, [])
+            ; (Full, [])
+            ; (Livepatch, [])
+            ]
         }
       )
     ]
@@ -2064,8 +2071,14 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
         , ( `Assoc
               [
                 ("ref", `String host)
-              ; ("recommended-guidance", `List [])
-              ; ("absolute-guidance", `List [])
+              ; ( "guidance"
+                , `Assoc
+                    [
+                      ("mandatory", `List [])
+                    ; ("recommended", `List [])
+                    ; ("full", `List [])
+                    ]
+                )
               ; ("RPMS", `List [])
               ; ("updates", `List [])
               ; ("livepatches", `List [])
@@ -2144,8 +2157,14 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
         , ( `Assoc
               [
                 ("ref", `String host)
-              ; ("recommended-guidance", `List [`String "RebootHost"])
-              ; ("absolute-guidance", `List [])
+              ; ( "guidance"
+                , `Assoc
+                    [
+                      ("mandatory", `List [`String "RebootHost"])
+                    ; ("recommended", `List [])
+                    ; ("full", `List [])
+                    ]
+                )
               ; ( "RPMS"
                 , `List
                     [
@@ -2201,8 +2220,14 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
         , ( `Assoc
               [
                 ("ref", `String host)
-              ; ("recommended-guidance", `List [`String "RebootHost"])
-              ; ("absolute-guidance", `List [])
+              ; ( "guidance"
+                , `Assoc
+                    [
+                      ("mandatory", `List [`String "RebootHost"])
+                    ; ("recommended", `List [])
+                    ; ("full", `List [])
+                    ]
+                )
               ; ("RPMS", `List [`String "libpath-utils-0.2.2-9.el7.noarch.rpm"])
               ; ("updates", `List [`String "UPDATE-0001"])
               ; ("livepatches", `List [])
@@ -2252,8 +2277,14 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
         , ( `Assoc
               [
                 ("ref", `String host)
-              ; ("recommended-guidance", `List [`String "EvacuateHost"])
-              ; ("absolute-guidance", `List [])
+              ; ( "guidance"
+                , `Assoc
+                    [
+                      ("mandatory", `List [`String "EvacuateHost"])
+                    ; ("recommended", `List [])
+                    ; ("full", `List [])
+                    ]
+                )
               ; ("RPMS", `List [`String "libpath-utils-0.2.2-9.el7.noarch.rpm"])
               ; ("updates", `List [`String "UPDATE-0003"])
               ; ("livepatches", `List [])
@@ -2330,8 +2361,14 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
         , ( `Assoc
               [
                 ("ref", `String host)
-              ; ("recommended-guidance", `List [`String "RebootHost"])
-              ; ("absolute-guidance", `List [])
+              ; ( "guidance"
+                , `Assoc
+                    [
+                      ("mandatory", `List [`String "RebootHost"])
+                    ; ("recommended", `List [])
+                    ; ("full", `List [])
+                    ]
+                )
               ; ( "RPMS"
                 , `List
                     [
@@ -2414,8 +2451,14 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
         , ( `Assoc
               [
                 ("ref", `String host)
-              ; ("recommended-guidance", `List [`String "RebootHost"])
-              ; ("absolute-guidance", `List [])
+              ; ( "guidance"
+                , `Assoc
+                    [
+                      ("mandatory", `List [`String "RebootHost"])
+                    ; ("recommended", `List [])
+                    ; ("full", `List [])
+                    ]
+                )
               ; ( "RPMS"
                 , `List
                     [
@@ -2530,8 +2573,14 @@ module ConsolidateUpdatesOfHost = Generic.MakeStateless (struct
         , ( `Assoc
               [
                 ("ref", `String host)
-              ; ("recommended-guidance", `List [`String "RebootHost"])
-              ; ("absolute-guidance", `List [])
+              ; ( "guidance"
+                , `Assoc
+                    [
+                      ("mandatory", `List [`String "RebootHost"])
+                    ; ("recommended", `List [])
+                    ; ("full", `List [])
+                    ]
+                )
               ; ( "RPMS"
                 , `List
                     [
@@ -2750,52 +2799,725 @@ module ParseUpdateInfoList = Generic.MakeStateless (struct
       ]
 end)
 
-module GuidanceSetResortGuidancesTest = Generic.MakeStateless (struct
+module GuidanceSetResortTest = Generic.MakeStateless (struct
   module Io = struct
-    type input_t = Guidance.guidance_kind * Guidance.t list
+    type input_t = Guidance.t list
 
     type output_t = Guidance.t list
 
-    let string_of_input_t (kind, l) =
-      let kind' =
-        match kind with
-        | Guidance.Recommended ->
-            "Recommended"
-        | Guidance.Absolute ->
-            "Absolute"
-      in
-      kind'
-      ^ ", "
-      ^ Fmt.(str "%a" Dump.(list string)) (List.map Guidance.to_string l)
+    let string_of_input_t l =
+      Fmt.(str "%a" Dump.(list string)) (List.map Guidance.to_string l)
+
+    let string_of_output_t = string_of_input_t
+  end
+
+  let transform guidances =
+    guidances
+    |> GuidanceSet.of_list
+    |> GuidanceSet.resort
+    |> GuidanceSet.elements
+
+  let tests =
+    let open Guidance in
+    `QuickAndAutoDocumented
+      [
+        ([], [])
+      ; ([EvacuateHost], [EvacuateHost])
+      ; ([EvacuateHost; RestartDeviceModel], [EvacuateHost])
+      ; ( [EvacuateHost; RestartDeviceModel; RestartToolstack]
+        , [RestartToolstack; EvacuateHost]
+        )
+      ; ( [EvacuateHost; RestartDeviceModel; RestartToolstack; RebootHost]
+        , [RebootHost]
+        )
+      ; ([EvacuateHost; RestartDeviceModel; RebootHost], [RebootHost])
+      ; ([EvacuateHost; RestartToolstack], [RestartToolstack; EvacuateHost])
+      ; ([EvacuateHost; RestartToolstack; RebootHost], [RebootHost])
+      ; ([EvacuateHost; RebootHost], [RebootHost])
+      ; ([RestartDeviceModel], [RestartDeviceModel])
+      ; ( [RestartDeviceModel; RestartToolstack]
+        , [RestartToolstack; RestartDeviceModel]
+        )
+      ; ([RestartDeviceModel; RestartToolstack; RebootHost], [RebootHost])
+      ; ([RestartDeviceModel; RebootHost], [RebootHost])
+      ; ([RestartToolstack], [RestartToolstack])
+      ; ([RestartToolstack; RebootHost], [RebootHost])
+      ; ([RebootHost], [RebootHost])
+      ; ([RestartVM], [RestartVM])
+      ; ([RestartVM; EvacuateHost], [EvacuateHost; RestartVM])
+      ; ( [RestartVM; EvacuateHost; RestartDeviceModel]
+        , [EvacuateHost; RestartVM]
+        )
+      ; ( [RestartVM; EvacuateHost; RestartDeviceModel; RestartToolstack]
+        , [RestartToolstack; EvacuateHost; RestartVM]
+        )
+      ; ( [
+            RestartVM
+          ; EvacuateHost
+          ; RestartDeviceModel
+          ; RestartToolstack
+          ; RebootHost
+          ]
+        , [RebootHost; RestartVM]
+        )
+      ; ( [RestartVM; EvacuateHost; RestartDeviceModel; RebootHost]
+        , [RebootHost; RestartVM]
+        )
+      ; ( [RestartVM; EvacuateHost; RestartToolstack]
+        , [RestartToolstack; EvacuateHost; RestartVM]
+        )
+      ; ( [RestartVM; EvacuateHost; RestartToolstack; RebootHost]
+        , [RebootHost; RestartVM]
+        )
+      ; ([RestartVM; EvacuateHost; RebootHost], [RebootHost; RestartVM])
+      ; ([RestartVM; RestartDeviceModel], [RestartVM])
+      ; ( [RestartVM; RestartDeviceModel; RestartToolstack]
+        , [RestartToolstack; RestartVM]
+        )
+      ; ( [RestartVM; RestartDeviceModel; RestartToolstack; RebootHost]
+        , [RebootHost; RestartVM]
+        )
+      ; ([RestartVM; RestartDeviceModel; RebootHost], [RebootHost; RestartVM])
+      ; ([RestartVM; RestartToolstack], [RestartToolstack; RestartVM])
+      ; ([RestartVM; RestartToolstack; RebootHost], [RebootHost; RestartVM])
+      ; ([RestartVM; RebootHost], [RebootHost; RestartVM])
+      ]
+end)
+
+module GuidanceSetReduceTest = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = Guidance.t list * Guidance.t list
+
+    type output_t = Guidance.t list
+
+    let string_of_input_t (l1, l2) =
+      Fmt.(
+        str "%a + %a"
+          Dump.(list string)
+          (List.map Guidance.to_string l1)
+          Dump.(list string)
+          (List.map Guidance.to_string l2)
+      )
 
     let string_of_output_t l =
       Fmt.(str "%a" Dump.(list string)) (List.map Guidance.to_string l)
   end
 
-  let transform (kind, guidances) =
-    guidances
-    |> GuidanceSet.of_list
-    |> GuidanceSet.resort_guidances
-         ~remove_evacuations:(kind = Guidance.Absolute)
-    |> GuidanceSet.elements
+  let transform (l1, l2) =
+    let open GuidanceSet in
+    reduce (of_list l1) (of_list l2) |> elements
 
   let tests =
+    let open Guidance in
     `QuickAndAutoDocumented
       [
-        ((Guidance.Recommended, [Guidance.RebootHost]), [Guidance.RebootHost])
-      ; ( (Guidance.Recommended, [Guidance.RebootHost; Guidance.RebootHost])
-        , [Guidance.RebootHost]
+        (([], []), [])
+      ; (([], [EvacuateHost]), [EvacuateHost])
+      ; (([], [RebootHost]), [RebootHost])
+      ; (([], [RestartDeviceModel]), [RestartDeviceModel])
+      ; ( ([], [RestartToolstack; EvacuateHost])
+        , [RestartToolstack; EvacuateHost]
         )
-      ; ( ( Guidance.Recommended
-          , [Guidance.RebootHost; Guidance.RestartDeviceModel]
-          )
-        , [Guidance.RebootHost]
+      ; ( ([], [RestartToolstack; RestartDeviceModel])
+        , [RestartToolstack; RestartDeviceModel]
         )
-      ; ((Guidance.Absolute, [Guidance.EvacuateHost]), [])
-      ; ( ( Guidance.Recommended
-          , [Guidance.EvacuateHost; Guidance.RestartDeviceModel]
+      ; (([], [RestartToolstack]), [RestartToolstack])
+      ; (([EvacuateHost], [EvacuateHost]), [])
+      ; (([EvacuateHost], [RebootHost]), [RebootHost])
+      ; (([EvacuateHost], [RestartDeviceModel]), [])
+      ; (([EvacuateHost], [RestartToolstack; EvacuateHost]), [RestartToolstack])
+      ; ( ([EvacuateHost], [RestartToolstack; RestartDeviceModel])
+        , [RestartToolstack]
+        )
+      ; (([EvacuateHost], [RestartToolstack]), [RestartToolstack])
+      ; (([EvacuateHost], []), [])
+      ; (([RebootHost], [EvacuateHost]), [])
+      ; (([RebootHost], [RebootHost]), [])
+      ; (([RebootHost], [RestartDeviceModel]), [])
+      ; (([RebootHost], [RestartToolstack; EvacuateHost]), [])
+      ; (([RebootHost], [RestartToolstack; RestartDeviceModel]), [])
+      ; (([RebootHost], [RestartToolstack]), [])
+      ; (([RebootHost], []), [])
+      ; (([RestartDeviceModel], [EvacuateHost]), [EvacuateHost])
+      ; (([RestartDeviceModel], [RebootHost]), [RebootHost])
+      ; (([RestartDeviceModel], [RestartDeviceModel]), [])
+      ; ( ([RestartDeviceModel], [RestartToolstack; EvacuateHost])
+        , [RestartToolstack; EvacuateHost]
+        )
+      ; ( ([RestartDeviceModel], [RestartToolstack; RestartDeviceModel])
+        , [RestartToolstack]
+        )
+      ; (([RestartDeviceModel], [RestartToolstack]), [RestartToolstack])
+      ; (([RestartDeviceModel], []), [])
+      ; (([RestartToolstack; EvacuateHost], [EvacuateHost]), [])
+      ; (([RestartToolstack; EvacuateHost], [RebootHost]), [RebootHost])
+      ; (([RestartToolstack; EvacuateHost], [RestartDeviceModel]), [])
+      ; ( ([RestartToolstack; EvacuateHost], [RestartToolstack; EvacuateHost])
+        , []
+        )
+      ; ( ( [RestartToolstack; EvacuateHost]
+          , [RestartToolstack; RestartDeviceModel]
           )
-        , [Guidance.EvacuateHost]
+        , []
+        )
+      ; (([RestartToolstack; EvacuateHost], [RestartToolstack]), [])
+      ; (([RestartToolstack; EvacuateHost], []), [])
+      ; ( ([RestartToolstack; RestartDeviceModel], [EvacuateHost])
+        , [EvacuateHost]
+        )
+      ; (([RestartToolstack; RestartDeviceModel], [RebootHost]), [RebootHost])
+      ; (([RestartToolstack; RestartDeviceModel], [RestartDeviceModel]), [])
+      ; ( ( [RestartToolstack; RestartDeviceModel]
+          , [RestartToolstack; EvacuateHost]
+          )
+        , [EvacuateHost]
+        )
+      ; ( ( [RestartToolstack; RestartDeviceModel]
+          , [RestartToolstack; RestartDeviceModel]
+          )
+        , []
+        )
+      ; (([RestartToolstack; RestartDeviceModel], [RestartToolstack]), [])
+      ; (([RestartToolstack; RestartDeviceModel], []), [])
+      ; (([RestartToolstack], [EvacuateHost]), [EvacuateHost])
+      ; (([RestartToolstack], [RebootHost]), [RebootHost])
+      ; (([RestartToolstack], [RestartDeviceModel]), [RestartDeviceModel])
+      ; (([RestartToolstack], [RestartToolstack; EvacuateHost]), [EvacuateHost])
+      ; ( ([RestartToolstack], [RestartToolstack; RestartDeviceModel])
+        , [RestartDeviceModel]
+        )
+      ; (([RestartToolstack], [RestartToolstack]), [])
+      ; (([RestartToolstack], []), [])
+      ; (([RestartVM; EvacuateHost], [EvacuateHost]), [])
+      ; (([RestartVM; EvacuateHost], [RebootHost; RestartVM]), [RebootHost])
+      ; (([RestartVM; EvacuateHost], [RebootHost]), [RebootHost])
+      ; (([RestartVM; EvacuateHost], [RestartDeviceModel]), [])
+      ; ( ([RestartVM; EvacuateHost], [RestartToolstack; EvacuateHost])
+        , [RestartToolstack]
+        )
+      ; ( ([RestartVM; EvacuateHost], [RestartToolstack; RestartDeviceModel])
+        , [RestartToolstack]
+        )
+      ; (([RestartVM; EvacuateHost], [RestartToolstack]), [RestartToolstack])
+      ; (([RestartVM; EvacuateHost], [RestartVM; EvacuateHost]), [])
+      ; ( ( [RestartVM; EvacuateHost]
+          , [RestartVM; RestartToolstack; EvacuateHost]
+          )
+        , [RestartToolstack]
+        )
+      ; ( ([RestartVM; EvacuateHost], [RestartVM; RestartToolstack])
+        , [RestartToolstack]
+        )
+      ; (([RestartVM; EvacuateHost], [RestartVM]), [])
+      ; (([RestartVM; EvacuateHost], []), [])
+      ; (([RestartVM; RestartToolstack; EvacuateHost], [EvacuateHost]), [])
+      ; ( ([RestartVM; RestartToolstack; EvacuateHost], [RebootHost; RestartVM])
+        , [RebootHost]
+        )
+      ; ( ([RestartVM; RestartToolstack; EvacuateHost], [RebootHost])
+        , [RebootHost]
+        )
+      ; (([RestartVM; RestartToolstack; EvacuateHost], [RestartDeviceModel]), [])
+      ; ( ( [RestartVM; RestartToolstack; EvacuateHost]
+          , [RestartToolstack; EvacuateHost]
+          )
+        , []
+        )
+      ; ( ( [RestartVM; RestartToolstack; EvacuateHost]
+          , [RestartToolstack; RestartDeviceModel]
+          )
+        , []
+        )
+      ; (([RestartVM; RestartToolstack; EvacuateHost], [RestartToolstack]), [])
+      ; ( ( [RestartVM; RestartToolstack; EvacuateHost]
+          , [RestartVM; EvacuateHost]
+          )
+        , []
+        )
+      ; ( ( [RestartVM; RestartToolstack; EvacuateHost]
+          , [RestartVM; RestartToolstack; EvacuateHost]
+          )
+        , []
+        )
+      ; ( ( [RestartVM; RestartToolstack; EvacuateHost]
+          , [RestartVM; RestartToolstack]
+          )
+        , []
+        )
+      ; (([RestartVM; RestartToolstack; EvacuateHost], [RestartVM]), [])
+      ; (([RestartVM; RestartToolstack; EvacuateHost], []), [])
+      ; (([RestartVM; RestartToolstack], [EvacuateHost]), [EvacuateHost])
+      ; (([RestartVM; RestartToolstack], [RebootHost; RestartVM]), [RebootHost])
+      ; (([RestartVM; RestartToolstack], [RebootHost]), [RebootHost])
+      ; (([RestartVM; RestartToolstack], [RestartDeviceModel]), [])
+      ; ( ([RestartVM; RestartToolstack], [RestartToolstack; EvacuateHost])
+        , [EvacuateHost]
+        )
+      ; ( ([RestartVM; RestartToolstack], [RestartToolstack; RestartDeviceModel])
+        , []
+        )
+      ; (([RestartVM; RestartToolstack], [RestartToolstack]), [])
+      ; ( ([RestartVM; RestartToolstack], [RestartVM; EvacuateHost])
+        , [EvacuateHost]
+        )
+      ; ( ( [RestartVM; RestartToolstack]
+          , [RestartVM; RestartToolstack; EvacuateHost]
+          )
+        , [EvacuateHost]
+        )
+      ; (([RestartVM; RestartToolstack], [RestartVM; RestartToolstack]), [])
+      ; (([RestartVM; RestartToolstack], [RestartVM]), [])
+      ; (([RestartVM; RestartToolstack], []), [])
+      ; (([RestartVM], [EvacuateHost]), [EvacuateHost])
+      ; (([RestartVM], [RebootHost; RestartVM]), [RebootHost])
+      ; (([RestartVM], [RebootHost]), [RebootHost])
+      ; (([RestartVM], [RestartDeviceModel]), [])
+      ; ( ([RestartVM], [RestartToolstack; EvacuateHost])
+        , [RestartToolstack; EvacuateHost]
+        )
+      ; ( ([RestartVM], [RestartToolstack; RestartDeviceModel])
+        , [RestartToolstack]
+        )
+      ; (([RestartVM], [RestartToolstack]), [RestartToolstack])
+      ; (([RestartVM], [RestartVM; EvacuateHost]), [EvacuateHost])
+      ; ( ([RestartVM], [RestartVM; RestartToolstack; EvacuateHost])
+        , [RestartToolstack; EvacuateHost]
+        )
+      ; (([RestartVM], [RestartVM; RestartToolstack]), [RestartToolstack])
+      ; (([RestartVM], [RestartVM]), [])
+      ; (([RestartVM], []), [])
+      ; (([], [RestartVM; EvacuateHost]), [EvacuateHost; RestartVM])
+      ; ( ([], [RestartVM; RestartToolstack; EvacuateHost])
+        , [RestartToolstack; EvacuateHost; RestartVM]
+        )
+      ; (([], [RestartVM; RestartToolstack]), [RestartToolstack; RestartVM])
+      ; (([], [RestartVM]), [RestartVM])
+      ]
+end)
+
+module GuidanceSetReduceCascadedListTest = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = (Guidance.kind * Guidance.t list) list
+
+    type output_t = input_t
+
+    let string_of_input_t l =
+      let string_of_kind_guidances (kind, gs) =
+        Fmt.(
+          str "%a: %a"
+            Dump.(string)
+            (Guidance.kind_to_string kind)
+            Dump.(list string)
+            (List.map Guidance.to_string gs)
+        )
+      in
+      Fmt.(str "%a" Dump.(list string)) (List.map string_of_kind_guidances l)
+
+    let string_of_output_t = string_of_input_t
+  end
+
+  let transform l =
+    l
+    |> List.map (fun (k, l') -> (k, GuidanceSet.of_list l'))
+    |> GuidanceSet.reduce_cascaded_list
+    |> List.map (fun (k, s') -> (k, GuidanceSet.elements s'))
+
+  let tests =
+    let open Guidance in
+    `QuickAndAutoDocumented
+      [
+        ([], [])
+      ; ( [(Mandatory, []); (Recommended, []); (Full, [])]
+        , [(Mandatory, []); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [])
+          ; (Recommended, [])
+          ; (Full, [RestartToolstack; RestartDeviceModel])
+          ]
+        , [
+            (Mandatory, [])
+          ; (Recommended, [])
+          ; (Full, [RestartToolstack; RestartDeviceModel])
+          ]
+        )
+      ; ( [
+            (Mandatory, [])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RestartDeviceModel])
+          ]
+        , [
+            (Mandatory, [])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RestartDeviceModel])
+          ]
+        )
+      ; ( [
+            (Mandatory, [])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [])
+          ; (Recommended, [RestartToolstack; RestartDeviceModel])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [])
+          ; (Recommended, [RestartToolstack; RestartDeviceModel])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [(Mandatory, [RestartToolstack]); (Recommended, []); (Full, [])]
+        , [(Mandatory, [RestartToolstack]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [])
+          ; (Full, [RestartToolstack])
+          ]
+        , [(Mandatory, [RestartToolstack]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack; RestartDeviceModel])
+          ; (Recommended, [])
+          ; (Full, [])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; RestartDeviceModel])
+          ; (Recommended, [])
+          ; (Full, [])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack; RestartDeviceModel])
+          ; (Recommended, [])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; RestartDeviceModel])
+          ; (Recommended, [])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [RestartDeviceModel])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [RestartDeviceModel])
+          ; (Full, [RestartToolstack])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [(Mandatory, [RebootHost]); (Recommended, []); (Full, [])]
+        , [(Mandatory, [RebootHost]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [])
+          ; (Full, [RestartToolstack; RestartDeviceModel])
+          ]
+        , [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [])
+          ; (Full, [RestartToolstack])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RebootHost])
+          ; (Recommended, [])
+          ; (Full, [RestartToolstack; RestartDeviceModel])
+          ]
+        , [(Mandatory, [RebootHost]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RebootHost])
+          ; (Recommended, [RestartDeviceModel])
+          ; (Full, [RestartToolstack])
+          ]
+        , [(Mandatory, [RebootHost]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [RestartDeviceModel])
+          ]
+        , [(Mandatory, [EvacuateHost]); (Recommended, []); (Full, [])]
+        )
+      ; ( [(Mandatory, [EvacuateHost]); (Recommended, []); (Full, [RebootHost])]
+        , [(Mandatory, [EvacuateHost]); (Recommended, []); (Full, [RebootHost])]
+        )
+      ; ( [
+            (Mandatory, [RebootHost; RestartVM])
+          ; (Recommended, [])
+          ; (Full, [RestartVM])
+          ]
+        , [(Mandatory, [RebootHost; RestartVM]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RebootHost; RestartVM])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        , [(Mandatory, [RebootHost; RestartVM]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RebootHost])
+          ; (Recommended, [RestartVM; EvacuateHost])
+          ; (Full, [RebootHost])
+          ]
+        , [(Mandatory, [RebootHost]); (Recommended, [RestartVM]); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RebootHost])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RestartVM])
+          ]
+        , [(Mandatory, [RebootHost]); (Recommended, []); (Full, [RestartVM])]
+        )
+      ; ( [
+            (Mandatory, [RebootHost; RestartVM])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        , [(Mandatory, [RebootHost; RestartVM]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RestartVM])
+          ]
+        , [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RestartVM])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartVM; RestartToolstack])
+          ; (Recommended, [])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; RestartVM])
+          ; (Recommended, [])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [RestartVM])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [RestartVM])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RebootHost; RestartVM])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RebootHost])
+          ]
+        , [(Mandatory, [RebootHost; RestartVM]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RestartVM; RestartToolstack])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; RestartVM])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [RestartVM])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [RestartVM])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartVM])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        , [
+            (Mandatory, [RestartVM])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RebootHost])
+          ; (Recommended, [])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        , [(Mandatory, [RebootHost]); (Recommended, []); (Full, [RestartVM])]
+        )
+      ; ( [
+            (Mandatory, [RebootHost])
+          ; (Recommended, [RestartDeviceModel])
+          ; (Full, [RestartVM])
+          ]
+        , [(Mandatory, [RebootHost]); (Recommended, []); (Full, [RestartVM])]
+        )
+      ; ( [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RestartVM])
+          ]
+        , [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [RestartToolstack])
+          ; (Full, [RestartVM])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [RestartVM; EvacuateHost])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [EvacuateHost; RestartVM])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RebootHost])
+          ; (Recommended, [RestartToolstack; EvacuateHost])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        , [(Mandatory, [RebootHost]); (Recommended, []); (Full, [RestartVM])]
+        )
+      ; ( [
+            (Mandatory, [RestartVM])
+          ; (Recommended, [RestartDeviceModel])
+          ; (Full, [RestartVM])
+          ]
+        , [(Mandatory, [RestartVM]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RestartVM; RestartToolstack])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; RestartVM])
+          ; (Recommended, [EvacuateHost])
+          ; (Full, [RebootHost])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [RebootHost])
+          ; (Full, [RestartVM])
+          ]
+        , [
+            (Mandatory, [RestartDeviceModel])
+          ; (Recommended, [RebootHost])
+          ; (Full, [RestartVM])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RebootHost; RestartVM])
+          ; (Recommended, [RestartToolstack; RestartDeviceModel])
+          ; (Full, [RebootHost; RestartVM])
+          ]
+        , [(Mandatory, [RebootHost; RestartVM]); (Recommended, []); (Full, [])]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [RestartDeviceModel])
+          ; (Full, [RestartVM])
+          ]
+        , [
+            (Mandatory, [RestartToolstack; EvacuateHost])
+          ; (Recommended, [])
+          ; (Full, [RestartVM])
+          ]
+        )
+      ; ( [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [RestartVM])
+          ; (Full, [RebootHost])
+          ]
+        , [
+            (Mandatory, [RestartToolstack])
+          ; (Recommended, [RestartVM])
+          ; (Full, [RebootHost])
+          ]
         )
       ]
 end)
@@ -3141,13 +3863,12 @@ module PruneUpdateInfoForLivepatches = Generic.MakeStateless (struct
         id= "UPDATE-00"
       ; summary= "SUMMARY"
       ; description= "DESCRIPTION"
-      ; rec_guidance= None
-      ; abs_guidance= None
+      ; guidance=
+          [(Mandatory, []); (Recommended, []); (Full, []); (Livepatch, [])]
       ; guidance_applicabilities= []
       ; spec_info= "SPEC_INFO"
       ; url= "URL"
       ; update_type= "UPDATE_TYPE"
-      ; livepatch_guidance= None
       ; livepatches= []
       ; issued= Xapi_stdext_date.Date.epoch
       ; severity= Severity.None
@@ -3628,18 +4349,253 @@ module GetLatestUpdatesFromRedundancy = Generic.MakeStateless (struct
       ]
 end)
 
+module SetPendingGuidance = Generic.MakeStateless (struct
+  module Io = struct
+    (* ([host pending guidance list], [VMs pending guidance lists]), [coming guidance list] *)
+    type input_t =
+      (Guidance.t list * (string * Guidance.t list) list) * Guidance.t list
+
+    (* ([host pending guidance list], [VMs pending guidance lists]) *)
+    type output_t = Guidance.t list * (string * Guidance.t list) list
+
+    let string_of_pending (host_pending, vms_pending) =
+      Fmt.(
+        str "Host: %a; VMs: %a"
+          Dump.(list string)
+          (List.map Guidance.to_string host_pending)
+          Dump.(list (pair string (list string)))
+          (List.map
+             (fun (vm, l) -> (vm, List.map Guidance.to_string l))
+             vms_pending
+          )
+      )
+
+    let string_of_input_t (pending, coming) =
+      Fmt.(
+        str "Pending: %s. Coming: %a"
+          (string_of_pending pending)
+          Dump.(list string)
+          (List.map Guidance.to_string coming)
+      )
+
+    let string_of_output_t = string_of_pending
+  end
+
+  let transform ((host_pending, vms_pending), coming) =
+    (* Use two hash tables to simulate the host's pending list and the VMs' pending lists *)
+    let host_tbl :
+        ( string
+        , [ `reboot_host
+          | `restart_toolstack
+          | `reboot_host_on_livepatch_failure
+          | `reboot_host_on_xen_livepatch_failure
+          | `reboot_host_on_kernel_livepatch_failure ]
+          list
+        )
+        Hashtbl.t =
+      Hashtbl.create 1
+    in
+    let vms_tbl : (string, [`restart_device_model | `restart_vm] list) Hashtbl.t
+        =
+      Hashtbl.create 3
+    in
+    (* Only one host in the table *)
+    let host_ref = "host_ref" in
+    let open Guidance in
+    let host_to_pending = function
+      | RebootHost ->
+          Some `reboot_host
+      | RebootHostOnLivePatchFailure ->
+          Some `reboot_host_on_livepatch_failure
+      | RebootHostOnXenLivePatchFailure ->
+          Some `reboot_host_on_xen_livepatch_failure
+      | RebootHostOnKernelLivePatchFailure ->
+          Some `reboot_host_on_kernel_livepatch_failure
+      | RestartToolstack ->
+          Some `restart_toolstack
+      | _ ->
+          None
+    in
+    let vm_to_pending = function
+      | RestartDeviceModel ->
+          Some `restart_device_model
+      | RestartVM ->
+          Some `restart_vm
+      | _ ->
+          None
+    in
+    let to_guidance = Guidance.of_pending_guidance in
+    Hashtbl.add host_tbl host_ref (List.filter_map host_to_pending host_pending) ;
+    let vm_mapper (vm_ref, l) = (vm_ref, List.filter_map vm_to_pending l) in
+    Hashtbl.add_seq vms_tbl (List.to_seq (List.map vm_mapper vms_pending)) ;
+    let ops =
+      let host_get () =
+        Hashtbl.find host_tbl host_ref |> List.map to_guidance
+      in
+      let host_add value =
+        Hashtbl.find host_tbl host_ref
+        |> List.cons value
+        |> Hashtbl.replace host_tbl host_ref
+      in
+      let host_remove value =
+        Hashtbl.find host_tbl host_ref
+        |> List.filter (fun g -> g <> value)
+        |> Hashtbl.replace host_tbl host_ref
+      in
+      let vms_get () =
+        Hashtbl.to_seq vms_tbl
+        |> List.of_seq
+        |> List.map (fun (vm_ref, l) -> (vm_ref, List.map to_guidance l))
+      in
+      let vm_add vm_ref value =
+        Hashtbl.find vms_tbl vm_ref
+        |> List.cons value
+        |> Hashtbl.replace vms_tbl vm_ref
+      in
+      let vm_remove vm_ref value =
+        Hashtbl.find vms_tbl vm_ref
+        |> List.filter (fun g -> g <> value)
+        |> Hashtbl.replace vms_tbl vm_ref
+      in
+      {host_get; host_add; host_remove; vms_get; vm_add; vm_remove}
+    in
+    (* transform *)
+    set_pending_guidances ~ops ~coming ;
+    (* return result *)
+    ( ops.host_get ()
+      |> List.sort (fun g1 g2 -> String.compare (to_string g1) (to_string g2))
+    , ops.vms_get () |> List.sort (fun (k1, _) (k2, _) -> String.compare k1 k2)
+    )
+
+  let tests =
+    let open Guidance in
+    `QuickAndAutoDocumented
+      [
+        ((([], []), []), ([], []))
+      ; ((([], []), [RebootHost]), ([RebootHost], []))
+      ; ( (([], [("vm1", [RestartDeviceModel]); ("vm2", [])]), [RebootHost])
+        , ([RebootHost], [("vm1", [RestartDeviceModel]); ("vm2", [])])
+        )
+      ; ((([], []), [RestartDeviceModel]), ([], []))
+      ; ( (([RebootHost], [("vm1", []); ("vm2", [])]), [RebootHost])
+        , ([RebootHost], [("vm1", []); ("vm2", [])])
+        )
+      ; ( (([RestartToolstack], [("vm1", []); ("vm2", [])]), [RebootHost])
+        , ([RebootHost; RestartToolstack], [("vm1", []); ("vm2", [])])
+        )
+      ; ( ( ([RestartToolstack], [("vm1", [RestartDeviceModel]); ("vm2", [])])
+          , [RebootHost]
+          )
+        , ( [RebootHost; RestartToolstack]
+          , [("vm1", [RestartDeviceModel]); ("vm2", [])]
+          )
+        )
+      ; ( ( ([RestartToolstack], [("vm1", [RestartDeviceModel]); ("vm2", [])])
+          , [RestartDeviceModel]
+          )
+        , ( [RestartToolstack]
+          , [("vm1", [RestartDeviceModel]); ("vm2", [RestartDeviceModel])]
+          )
+        )
+      ; ( (([RebootHostOnLivePatchFailure], [("vm1", [])]), [RebootHost])
+        , ([RebootHost; RebootHostOnLivePatchFailure], [("vm1", [])])
+        )
+      ; ( (([RebootHost], [("vm1", [])]), [RebootHostOnLivePatchFailure])
+        , ([RebootHost; RebootHostOnLivePatchFailure], [("vm1", [])])
+        )
+      ; ( ( ( []
+            , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+            )
+          , [RebootHost]
+          )
+        , ( [RebootHost]
+          , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+          )
+        )
+      ; ( ( ( [RestartToolstack]
+            , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+            )
+          , [RebootHost]
+          )
+        , ( [RebootHost; RestartToolstack]
+          , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+          )
+        )
+      ; ( ( ( [RestartToolstack]
+            , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+            )
+          , [RestartToolstack]
+          )
+        , ( [RestartToolstack]
+          , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+          )
+        )
+      ; ( ( ( [RestartToolstack]
+            , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+            )
+          , [RestartDeviceModel]
+          )
+        , ( [RestartToolstack]
+          , [
+              ("vm1", [RestartDeviceModel])
+            ; ("vm2", [RestartDeviceModel])
+            ; ("vm3", [RestartDeviceModel; RestartVM])
+            ]
+          )
+        )
+      ; ( ( ( [RestartToolstack]
+            , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+            )
+          , [RestartVM]
+          )
+        , ( [RestartToolstack]
+          , [
+              ("vm1", [RestartVM])
+            ; ("vm2", [RestartVM; RestartDeviceModel])
+            ; ("vm3", [RestartVM])
+            ]
+          )
+        )
+      ; ( ( ( [RestartToolstack; RebootHostOnXenLivePatchFailure]
+            , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+            )
+          , [RestartToolstack]
+          )
+        , ( [RebootHostOnXenLivePatchFailure; RestartToolstack]
+          , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+          )
+        )
+      ; ( ( ( [RebootHost; RebootHostOnKernelLivePatchFailure]
+            , [("vm1", []); ("vm2", [RestartDeviceModel]); ("vm3", [RestartVM])]
+            )
+          , [RestartToolstack; RestartVM]
+          )
+        , ( [RebootHost; RebootHostOnKernelLivePatchFailure; RestartToolstack]
+          , [
+              ("vm1", [RestartVM])
+            ; ("vm2", [RestartVM; RestartDeviceModel])
+            ; ("vm3", [RestartVM])
+            ]
+          )
+        )
+      ]
+end)
+
 let tests =
   make_suite "repository_helpers_"
     [
       ("update_of_json", UpdateOfJsonTest.tests)
-    ; ("assert_valid_guidances", GuidanceSetAssertValidGuidanceTest.tests)
     ; ("assert_url_is_valid", AssertUrlIsValid.tests)
     ; ("write_yum_config", WriteYumConfig.tests)
     ; ("eval_guidance_for_one_update", EvalGuidanceForOneUpdate.tests)
     ; ("get_update_in_json", GetUpdateInJson.tests)
     ; ("consolidate_updates_of_host", ConsolidateUpdatesOfHost.tests)
     ; ("parse_updateinfo_list", ParseUpdateInfoList.tests)
-    ; ("resort_guidances", GuidanceSetResortGuidancesTest.tests)
+    ; ("guidance_set_resort", GuidanceSetResortTest.tests)
+    ; ("guidance_set_reduce", GuidanceSetReduceTest.tests)
+    ; ( "guidance_set_reduce_cascaded_list"
+      , GuidanceSetReduceCascadedListTest.tests
+      )
     ; ("prune_accumulative_updates", PruneAccumulativeUpdates.tests)
     ; ("prune_updateinfo_for_livepatches", PruneUpdateInfoForLivepatches.tests)
     ; ( "parse_output_of_yum_upgrade_dry_run"
@@ -3648,6 +4604,7 @@ let tests =
     ; ( "get_latest_updates_from_redundancy"
       , GetLatestUpdatesFromRedundancy.tests
       )
+    ; ("set_pending_guidances", SetPendingGuidance.tests)
     ]
 
 let () = Alcotest.run "Repository Helpers" tests

--- a/ocaml/tests/test_updateinfo.ml
+++ b/ocaml/tests/test_updateinfo.ml
@@ -422,11 +422,8 @@ let fields_of_updateinfo =
       field "id" (fun (r : UpdateInfo.t) -> r.id) string
     ; field "summary" (fun (r : UpdateInfo.t) -> r.summary) string
     ; field "description" (fun (r : UpdateInfo.t) -> r.description) string
-    ; field "rec_guidance"
-        (fun (r : UpdateInfo.t) -> UpdateInfo.guidance_to_string r.rec_guidance)
-        string
-    ; field "abs_guidance"
-        (fun (r : UpdateInfo.t) -> UpdateInfo.guidance_to_string r.abs_guidance)
+    ; field "guidance"
+        (fun (r : UpdateInfo.t) -> GuidanceInUpdateInfo.to_string r.guidance)
         string
     ; field "guidance_applicabilities"
         (fun (r : UpdateInfo.t) ->
@@ -436,11 +433,6 @@ let fields_of_updateinfo =
     ; field "spec_info" (fun (r : UpdateInfo.t) -> r.spec_info) string
     ; field "url" (fun (r : UpdateInfo.t) -> r.url) string
     ; field "update_type" (fun (r : UpdateInfo.t) -> r.update_type) string
-    ; field "livepatch_guidance"
-        (fun (r : UpdateInfo.t) ->
-          UpdateInfo.guidance_to_string r.livepatch_guidance
-        )
-        string
     ; field "livepatches"
         (fun (r : UpdateInfo.t) ->
           List.map
@@ -479,6 +471,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
     try Ok (UpdateInfo.of_xml (Xml.parse_string input)) with e -> Error e
 
   let tests =
+    let open Guidance in
     `QuickAndAutoDocumented
       [
         (* No "updates" node *)
@@ -561,13 +554,17 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= ""
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ; (Livepatch, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= None
                   ; livepatches= []
                   ; issued= Xapi_stdext_date.Date.epoch
                   ; severity= Severity.None
@@ -624,13 +621,17 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ; (Livepatch, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= None
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
@@ -674,13 +675,17 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ; (Livepatch, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= None
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
@@ -693,13 +698,17 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0001"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ; (Livepatch, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= None
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:50Z"
@@ -708,7 +717,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
               )
             ]
         )
-      ; (* Single update with guidances *)
+      ; (* Single update with deprecated guidances only *)
         ( {|
             <updates>
               <update type="security">
@@ -751,8 +760,13 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= Some Guidance.RestartDeviceModel
-                  ; abs_guidance= Some Guidance.RebootHost
+                  ; guidance=
+                      [
+                        (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ; (Livepatch, [])
+                      ]
                   ; guidance_applicabilities=
                       [
                         Applicability.
@@ -777,7 +791,6 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= None
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
@@ -786,7 +799,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
               )
             ]
         )
-      ; (* Single update with new guidances *)
+      ; (* Single update with unknown guidance *)
         ( {|
             <updates>
               <update type="security">
@@ -798,6 +811,18 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <url>https://update.details.info</url>
                 <recommended_guidance>NewGuidance</recommended_guidance>
                 <absolute_guidance>NewGuidance</absolute_guidance>
+                <guidance>
+                  <mandatory>
+                    <value>NewGuidance</value>
+                  </mandatory>
+                  <full>
+                    <value>NewGuidance</value>
+                    <value>RestartVM</value>
+                  </full>
+                  <recommended>
+                    <value>NewGuidance</value>
+                  </recommended>
+                </guidance>
                 <guidance_applicabilities>
                   <applicability>
                     <name>xsconsole</name>
@@ -829,8 +854,13 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= Some Guidance.RebootHost
-                  ; abs_guidance= Some Guidance.RebootHost
+                  ; guidance=
+                      [
+                        (Recommended, [RebootHost])
+                      ; (Full, [RebootHost; RestartVM])
+                      ; (Mandatory, [RebootHost])
+                      ; (Livepatch, [])
+                      ]
                   ; guidance_applicabilities=
                       [
                         Applicability.
@@ -855,7 +885,6 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= None
                   ; livepatches= []
                   ; issued=
                       Xapi_stdext_date.Date.of_string "2023-05-12T08:37:49Z"
@@ -864,7 +893,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
               )
             ]
         )
-      ; (* Single update with livepatches and livepatch_guidance *)
+      ; (* Single update with livepatches and livepatch guidance *)
         ( {|
             <updates>
               <update type="security">
@@ -874,6 +903,11 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <description>description</description>
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
+                <guidance>
+                  <livepatch>
+                    <value>RestartToolstack</value>
+                  </livepatch>
+                </guidance>
                 <guidance_applicabilities/>
                 <livepatch_guidance>RestartToolstack</livepatch_guidance>
                 <livepatches>
@@ -893,13 +927,17 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Livepatch, [RestartToolstack])
+                      ; (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= Some Guidance.RestartToolstack
                   ; livepatches=
                       [
                         LivePatch.
@@ -930,7 +968,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
               )
             ]
         )
-      ; (* Single update with livepatches and new livepatch_guidance *)
+      ; (* Single update with livepatches and unknown livepatch guidance *)
         ( {|
             <updates>
               <update type="security">
@@ -941,6 +979,11 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
+                <guidance>
+                  <livepatch>
+                    <value>NewGuidance</value>
+                  </livepatch>
+                </guidance>
                 <livepatch_guidance>NewGuidance</livepatch_guidance>
                 <livepatches>
                   <livepatch component="kernel" base="4.19.19-8.0.19.xs8" to="4.19.19-8.0.21.xs8" base-buildid="8346194f2e98a228f5a595b13ecabd43a99fada0"/>
@@ -959,13 +1002,17 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Livepatch, [RebootHost])
+                      ; (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= Some Guidance.RebootHost
                   ; livepatches=
                       [
                         LivePatch.
@@ -996,7 +1043,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
               )
             ]
         )
-      ; (* Single update with livepatch_guidance but empty livepatches *)
+      ; (* Single update with livepatch guidance but empty livepatch *)
         ( {|
             <updates>
               <update type="security">
@@ -1005,6 +1052,11 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <summary>summary</summary>
                 <description>description</description>
                 <special_info>special information</special_info>
+                <guidance>
+                  <livepatch>
+                    <value>RestartDeviceModel</value>
+                  </livepatch>
+                </guidance>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
                 <livepatch_guidance>RestartDeviceModel</livepatch_guidance>
@@ -1021,13 +1073,17 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Livepatch, [RestartDeviceModel])
+                      ; (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= Some Guidance.RestartDeviceModel
                   ; livepatches= []
                   ; issued= Xapi_stdext_date.Date.epoch
                   ; severity= Severity.None
@@ -1035,7 +1091,7 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
               )
             ]
         )
-      ; (* Single update with invalid livepatches *)
+      ; (* Single update with valid livepatches *)
         ( {|
             <updates>
               <update type="security">
@@ -1043,6 +1099,11 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <title>title</title>
                 <summary>summary</summary>
                 <description>description</description>
+                <guidance>
+                  <livepatch>
+                    <value>RestartToolstack</value>
+                  </livepatch>
+                </guidance>
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
@@ -1062,13 +1123,17 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Livepatch, [RestartToolstack])
+                      ; (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= Some Guidance.RestartToolstack
                   ; livepatches=
                       [
                         LivePatch.
@@ -1096,6 +1161,11 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                 <title>title</title>
                 <summary>summary</summary>
                 <description>description</description>
+                <guidance>
+                  <livepatch>
+                    <value>RestartToolstack</value>
+                  </livepatch>
+                </guidance>
                 <special_info>special information</special_info>
                 <url>https://update.details.info</url>
                 <guidance_applicabilities/>
@@ -1115,13 +1185,340 @@ module UpdateInfoOfXml = Generic.MakeStateless (struct
                     id= "UPDATE-0000"
                   ; summary= "summary"
                   ; description= "description"
-                  ; rec_guidance= None
-                  ; abs_guidance= None
+                  ; guidance=
+                      [
+                        (Livepatch, [RestartToolstack])
+                      ; (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ]
                   ; guidance_applicabilities= []
                   ; spec_info= "special information"
                   ; url= "https://update.details.info"
                   ; update_type= "security"
-                  ; livepatch_guidance= Some Guidance.RestartToolstack
+                  ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
+                  }
+              )
+            ]
+        )
+      ; (* guidance in new format: empty guidance *)
+        ( {|
+            <updates>
+              <update type="security">
+                <id>UPDATE-0000</id>
+                <title>title</title>
+                <summary>summary</summary>
+                <description>empty guidance</description>
+                <special_info>special information</special_info>
+                <url>https://update.details.info</url>
+                <recommended_guidance>EvacuateHost</recommended_guidance>
+                <absolute_guidance>RebootHost</absolute_guidance>
+                <guidance_applicabilities/>
+                <guidance/>
+                <livepatch_guidance>RestartDeviceModel</livepatch_guidance>
+                <livepatches>
+                  <livepatch component="xen" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid=""/>
+                  <livepatch component="kernel" base="4.19.19-8.0.20.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
+                </livepatches>
+              </update>
+            </updates>
+          |}
+        , Ok
+            [
+              ( "UPDATE-0000"
+              , UpdateInfo.
+                  {
+                    id= "UPDATE-0000"
+                  ; summary= "summary"
+                  ; description= "empty guidance"
+                  ; guidance=
+                      [
+                        (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ; (Livepatch, [])
+                      ]
+                  ; guidance_applicabilities= []
+                  ; spec_info= "special information"
+                  ; url= "https://update.details.info"
+                  ; update_type= "security"
+                  ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
+                  }
+              )
+            ]
+        )
+      ; (* guidance in new format only: empty guidance *)
+        ( {|
+            <updates>
+              <update type="security">
+                <id>UPDATE-0000</id>
+                <title>title</title>
+                <summary>summary</summary>
+                <description>guidance in new format only: empty guidance</description>
+                <special_info>special information</special_info>
+                <url>https://update.details.info</url>
+                <guidance_applicabilities/>
+                <guidance/>
+                <livepatches>
+                  <livepatch component="xen" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid=""/>
+                  <livepatch component="kernel" base="4.19.19-8.0.20.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
+                </livepatches>
+              </update>
+            </updates>
+          |}
+        , Ok
+            [
+              ( "UPDATE-0000"
+              , UpdateInfo.
+                  {
+                    id= "UPDATE-0000"
+                  ; summary= "summary"
+                  ; description= "guidance in new format only: empty guidance"
+                  ; guidance=
+                      [
+                        (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ; (Livepatch, [])
+                      ]
+                  ; guidance_applicabilities= []
+                  ; spec_info= "special information"
+                  ; url= "https://update.details.info"
+                  ; update_type= "security"
+                  ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
+                  }
+              )
+            ]
+        )
+      ; (* guidance in new format: empty mandatory and full *)
+        ( {|
+            <updates>
+              <update type="security">
+                <id>UPDATE-0000</id>
+                <title>title</title>
+                <summary>summary</summary>
+                <description>empty mandatory and full</description>
+                <special_info>special information</special_info>
+                <url>https://update.details.info</url>
+                <recommended_guidance>EvacuateHost</recommended_guidance>
+                <absolute_guidance>RebootHost</absolute_guidance>
+                <guidance_applicabilities/>
+                <guidance>
+                  <mandatory/>
+                  <full>
+                  </full>
+                </guidance>
+                <livepatch_guidance>RestartDeviceModel</livepatch_guidance>
+                <livepatches>
+                  <livepatch component="xen" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid=""/>
+                  <livepatch component="kernel" base="4.19.19-8.0.20.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
+                </livepatches>
+              </update>
+            </updates>
+          |}
+        , Ok
+            [
+              ( "UPDATE-0000"
+              , UpdateInfo.
+                  {
+                    id= "UPDATE-0000"
+                  ; summary= "summary"
+                  ; description= "empty mandatory and full"
+                  ; guidance=
+                      [
+                        (Full, [])
+                      ; (Mandatory, [])
+                      ; (Recommended, [])
+                      ; (Livepatch, [])
+                      ]
+                  ; guidance_applicabilities= []
+                  ; spec_info= "special information"
+                  ; url= "https://update.details.info"
+                  ; update_type= "security"
+                  ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
+                  }
+              )
+            ]
+        )
+      ; (* guidance in new format: mandatory only *)
+        ( {|
+            <updates>
+              <update type="security">
+                <id>UPDATE-0000</id>
+                <title>title</title>
+                <summary>summary</summary>
+                <description>mandatory only</description>
+                <special_info>special information</special_info>
+                <url>https://update.details.info</url>
+                <recommended_guidance>EvacuateHost</recommended_guidance>
+                <absolute_guidance>RebootHost</absolute_guidance>
+                <guidance_applicabilities/>
+                <guidance>
+                  <mandatory>
+                    <value>RestartDeviceModel</value>
+                    <value>EvacuateHost</value>
+                    <value>RestartToolstack</value>
+                  </mandatory>
+                </guidance>
+                <livepatch_guidance>RestartDeviceModel</livepatch_guidance>
+                <livepatches>
+                  <livepatch component="xen" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid=""/>
+                  <livepatch component="kernel" base="4.19.19-8.0.20.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
+                </livepatches>
+              </update>
+            </updates>
+          |}
+        , Ok
+            [
+              ( "UPDATE-0000"
+              , UpdateInfo.
+                  {
+                    id= "UPDATE-0000"
+                  ; summary= "summary"
+                  ; description= "mandatory only"
+                  ; guidance=
+                      [
+                        ( Mandatory
+                        , [RestartDeviceModel; EvacuateHost; RestartToolstack]
+                        )
+                      ; (Recommended, [])
+                      ; (Full, [])
+                      ; (Livepatch, [])
+                      ]
+                  ; guidance_applicabilities= []
+                  ; spec_info= "special information"
+                  ; url= "https://update.details.info"
+                  ; update_type= "security"
+                  ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
+                  }
+              )
+            ]
+        )
+      ; (* guidance in new format: mandatory, recommended, full and livepatch *)
+        ( {|
+            <updates>
+              <update type="security">
+                <id>UPDATE-0000</id>
+                <title>title</title>
+                <summary>summary</summary>
+                <description>mandatory, recommended, full and livepatch</description>
+                <special_info>special information</special_info>
+                <url>https://update.details.info</url>
+                <recommended_guidance>EvacuateHost</recommended_guidance>
+                <absolute_guidance>RebootHost</absolute_guidance>
+                <guidance_applicabilities/>
+                <guidance>
+                  <mandatory>
+                    <value>RestartToolstack</value>
+                  </mandatory>
+                  <recommended>
+                    <value>EvacuateHost</value>
+                  </recommended>
+                  <livepatch>
+                    <value>RestartDeviceModel</value>
+                  </livepatch>
+                  <full>
+                    <value>RebootHost</value>
+                  </full>
+                </guidance>
+                <livepatch_guidance>RestartDeviceModel</livepatch_guidance>
+                <livepatches>
+                  <livepatch component="xen" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid=""/>
+                  <livepatch component="kernel" base="4.19.19-8.0.20.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
+                </livepatches>
+              </update>
+            </updates>
+          |}
+        , Ok
+            [
+              ( "UPDATE-0000"
+              , UpdateInfo.
+                  {
+                    id= "UPDATE-0000"
+                  ; summary= "summary"
+                  ; description= "mandatory, recommended, full and livepatch"
+                  ; guidance=
+                      [
+                        (Full, [RebootHost])
+                      ; (Livepatch, [RestartDeviceModel])
+                      ; (Recommended, [EvacuateHost])
+                      ; (Mandatory, [RestartToolstack])
+                      ]
+                  ; guidance_applicabilities= []
+                  ; spec_info= "special information"
+                  ; url= "https://update.details.info"
+                  ; update_type= "security"
+                  ; livepatches= []
+                  ; issued= Xapi_stdext_date.Date.epoch
+                  ; severity= Severity.None
+                  }
+              )
+            ]
+        )
+      ; (* guidance in new format: mandatory, recommended, full and livepatch *)
+        ( {|
+            <updates>
+              <update type="security">
+                <id>UPDATE-0000</id>
+                <title>title</title>
+                <summary>summary</summary>
+                <description>RestartVM in mandatory</description>
+                <special_info>special information</special_info>
+                <url>https://update.details.info</url>
+                <recommended_guidance>EvacuateHost</recommended_guidance>
+                <absolute_guidance>RebootHost</absolute_guidance>
+                <guidance_applicabilities/>
+                <guidance>
+                  <mandatory>
+                    <value>RestartVM</value>
+                  </mandatory>
+                  <recommended>
+                    <value>EvacuateHost</value>
+                  </recommended>
+                  <livepatch>
+                    <value>RestartDeviceModel</value>
+                  </livepatch>
+                  <full>
+                    <value>RebootHost</value>
+                  </full>
+                </guidance>
+                <livepatch_guidance>RestartDeviceModel</livepatch_guidance>
+                <livepatches>
+                  <livepatch component="xen" base="4.19.19-8.0.20.xs8" to="4.19.19-8.0.21.xs8" base-buildid=""/>
+                  <livepatch component="kernel" base="4.19.19-8.0.20.xs8" base-buildid="9346194f2e98a228f5a595b13ecabd43a99fada0"/>
+                </livepatches>
+              </update>
+            </updates>
+          |}
+        , Ok
+            [
+              ( "UPDATE-0000"
+              , UpdateInfo.
+                  {
+                    id= "UPDATE-0000"
+                  ; summary= "summary"
+                  ; description= "RestartVM in mandatory"
+                  ; guidance=
+                      [
+                        (Full, [RebootHost])
+                      ; (Livepatch, [RestartDeviceModel])
+                      ; (Recommended, [EvacuateHost])
+                      ; (Mandatory, [RestartVM])
+                      ]
+                  ; guidance_applicabilities= []
+                  ; spec_info= "special information"
+                  ; url= "https://update.details.info"
+                  ; update_type= "security"
                   ; livepatches= []
                   ; issued= Xapi_stdext_date.Date.epoch
                   ; severity= Severity.None

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1281,11 +1281,6 @@ let invalid_repository_domain_allowlist = "INVALID_REPOSITORY_DOMAIN_ALLOWLIST"
 
 let apply_livepatch_failed = "APPLY_LIVEPATCH_FAILED"
 
-let updates_require_recommended_guidance =
-  "UPDATES_REQUIRE_RECOMMENDED_GUIDANCE"
-
-let update_guidance_changed = "UPDATE_GUIDANCE_CHANGED"
-
 let invalid_update_sync_day = "INVALID_UPDATE_SYNC_DAY"
 
 let no_repositories_configured = "NO_REPOSITORIES_CONFIGURED"

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -64,7 +64,7 @@ val apply_updates :
      __context:Context.t
   -> host:[`host] API.Ref.t
   -> hash:string
-  -> Updateinfo.Guidance.t list * string list list
+  -> string list list
 
 val set_available_updates : __context:Context.t -> string
 

--- a/ocaml/xapi/updateinfo.mli
+++ b/ocaml/xapi/updateinfo.mli
@@ -37,7 +37,7 @@ module Guidance : sig
   (* may fail *)
   val of_string : string -> t
 
-  val of_update_guidance :
+  val of_pending_guidance :
        [< `reboot_host
        | `reboot_host_on_livepatch_failure
        | `reboot_host_on_kernel_livepatch_failure
@@ -46,6 +46,17 @@ module Guidance : sig
        | `restart_toolstack
        | `restart_vm ]
     -> t
+
+  val to_pending_guidance :
+       t
+    -> [> `reboot_host
+       | `reboot_host_on_livepatch_failure
+       | `reboot_host_on_kernel_livepatch_failure
+       | `reboot_host_on_xen_livepatch_failure
+       | `restart_device_model
+       | `restart_toolstack
+       | `restart_vm ]
+       option
 end
 
 (** The applicability of metadata for one update in updateinfo *)
@@ -160,8 +171,7 @@ end
 module HostUpdates : sig
   type t = {
       host: string
-    ; rec_guidances: Guidance.t list
-    ; abs_guidances: Guidance.t list
+    ; guidance: GuidanceInUpdateInfo.t
     ; rpms: Rpm.Pkg.t list
     ; update_ids: string list
     ; livepatches: LivePatch.t list

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -3021,7 +3021,7 @@ let apply_updates ~__context ~self ~hash =
   (* This function runs on master host *)
   Helpers.assert_we_are_master ~__context ;
   Pool_features.assert_enabled ~__context ~f:Features.Updates ;
-  let guidances, warnings =
+  let warnings =
     Xapi_pool_helpers.with_pool_operation ~__context
       ~self:(Helpers.get_pool ~__context)
       ~doc:"Host.apply_updates" ~op:`apply_updates
@@ -3036,15 +3036,7 @@ let apply_updates ~__context ~self ~hash =
   Db.Host.set_last_software_update ~__context ~self
     ~value:(get_servertime ~__context ~host:self) ;
   Db.Host.set_latest_synced_updates_applied ~__context ~self ~value:`yes ;
-  List.map
-    (fun g ->
-      [
-        Api_errors.updates_require_recommended_guidance
-      ; Updateinfo.Guidance.to_string g
-      ]
-    )
-    guidances
-  @ warnings
+  warnings
 
 let cc_prep () =
   let cc = "CC_PREPARATIONS" in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -85,7 +85,7 @@ let assert_safe_to_reenable ~__context ~self =
       (Ref.string_of self)
       (String.concat ";"
          (List.map Updateinfo.Guidance.to_string
-            (List.map Updateinfo.Guidance.of_update_guidance
+            (List.map Updateinfo.Guidance.of_pending_guidance
                host_pending_mandatory_guidances
             )
          )

--- a/ocaml/xapi/xapi_host_helpers.ml
+++ b/ocaml/xapi/xapi_host_helpers.ml
@@ -386,7 +386,7 @@ let consider_enabling_host_nolock ~__context =
           (Ref.string_of localhost)
           (String.concat ";"
              (List.map Updateinfo.Guidance.to_string
-                (List.map Updateinfo.Guidance.of_update_guidance
+                (List.map Updateinfo.Guidance.of_pending_guidance
                    host_pending_mandatory_guidances
                 )
              )


### PR DESCRIPTION
This PR includes changes to support guidance data in new format in updateinfo.xml. The XAPI will support guidance data in updateinfo.xml in either old or new format for sake of backwards compatibility. Then XAPI will convert the guidance data and expose to XAPI clients through interfaces like HTTP /updates and pending guidance lists. But for simplicity, XAPI will not support backwards compatibility on these XAPI interfaces. This means a new XenCenter is required to co-work with the XAPI changes in this PR.