### PR TITLE
CP-45979 update host-display to python3

### DIFF
--- a/scripts/host-display
+++ b/scripts/host-display
@@ -8,19 +8,17 @@ n.b. the value returned by the "status" command will be correct as of the next
 boot (assuming that the boot config is not modified further), and is not
 necessarily correct at the time this script is called.
 """
-from __future__ import print_function
 
 import os
-import os.path
 import re
-import subprocess
 import sys
 import syslog
+from pathlib import Path
 
 from xcp.bootloader import Bootloader
+from xcp.cmd import runCmd
 
-COMMAND_NAME = sys.argv[0]
-SHORT_COMMAND_NAME = os.path.basename(COMMAND_NAME)
+SHORT_COMMAND_NAME = Path(__file__).name
 
 XE_SERIAL = "xe-serial"
 XEN_CMDLINE = "/opt/xensource/libexec/xen-cmdline"
@@ -32,32 +30,16 @@ def send_to_syslog(msg):
     syslog.syslog("%s[%d] - %s" % (SHORT_COMMAND_NAME, pid, msg))
 
 
-def doexec(args):
-    """Execute a subprocess, then return its return code, stdout and stderr"""
-    send_to_syslog(args)
-    proc = subprocess.Popen(
-        args,
-        stdin=None,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        close_fds=True,
-        universal_newlines=True)
-    rc = proc.wait()
-    stdout = proc.stdout
-    stderr = proc.stderr
-    return (rc, stdout, stderr)
-
-
 def disable(bootloader):
     """
     Configure the host not to output its console to the physical display on
     next boot.
     """
     if bootloader.default == XE_SERIAL:
-        doexec([XEN_CMDLINE, "--set-xen", "console=%s" % (_get_com_port())])
+        runCmd([XEN_CMDLINE, "--set-xen", "console=%s" % (_get_com_port())])
     else:
-        doexec([XEN_CMDLINE, "--delete-dom0", "console=tty0"])
-        doexec([XEN_CMDLINE, "--delete-xen", "console"])
+        runCmd([XEN_CMDLINE, "--delete-dom0", "console=tty0"])
+        runCmd([XEN_CMDLINE, "--delete-xen", "console"])
 
 
 def enable(bootloader):
@@ -66,10 +48,10 @@ def enable(bootloader):
     next boot.
     """
     if bootloader.default == XE_SERIAL:
-        doexec([XEN_CMDLINE, "--set-xen", "console=%s,vga" % (_get_com_port())])
+        runCmd([XEN_CMDLINE, "--set-xen", "console=%s,vga" % (_get_com_port())])
     else:
-        doexec([XEN_CMDLINE, "--set-xen", "console=vga"])
-        doexec([XEN_CMDLINE, "--set-dom0", "console=hvc0 console=tty0"])
+        runCmd([XEN_CMDLINE, "--set-xen", "console=vga"])
+        runCmd([XEN_CMDLINE, "--set-dom0", "console=hvc0 console=tty0"])
 
 
 def status(_):
@@ -77,8 +59,8 @@ def status(_):
     Determine from the bootloader config whether the host is currently
     configured to output its console to the physical display.
     """
-    (_, stdout, _) = doexec([XEN_CMDLINE, "--get-xen", "console"])
-    if "vga" in stdout.readline().strip():
+    (_, stdout) = runCmd([XEN_CMDLINE, "--get-xen", "console"], with_stdout=True)
+    if "vga" in stdout:
         sys.stdout.write("enabled")
     else:
         sys.stdout.write("disabled")
@@ -91,8 +73,8 @@ def _get_com_port():
     """
     Determine from the current bootloader config which COM port is in use
     """
-    (_, stdout, _) = doexec([XEN_CMDLINE, "--get-xen", "console"])
-    m = re.match(r"console=.*(com\d).*", stdout.readline().strip())
+    (_, stdout) = runCmd([XEN_CMDLINE, "--get-xen", "console"], with_stdout=True)
+    m = re.match(r"console=.*(com\d).*", stdout)
     if m:
         return m.group(1)
     else:
@@ -100,16 +82,15 @@ def _get_com_port():
 
 
 def usage():
-    """ Display a usage string. """
-    command_names = list(COMMANDS.keys())
-    command_names.sort()
+    """Display a usage string."""
+    command_names = sorted(COMMANDS.keys())
     print("Usage:")
-    print("    %s {%s}" % (sys.argv[0], "|".join(command_names)))
+    print("    {} {{{}}}".format(sys.argv[0], "|".join(command_names)))
 
 
 def main():
     """Program entry point."""
-    if len(sys.argv) == 2 and sys.argv[1] in COMMANDS.keys():
+    if len(sys.argv) == 2 and sys.argv[1] in COMMANDS:
         bootloader = Bootloader.loadExisting()
         command = COMMANDS[sys.argv[1]]
         command(bootloader)


### PR DESCRIPTION
- format with black
- use xcp.cmd to replace subprocess.popen

Test passed on Xenrt, job id: 3880432