### PR TITLE
CA-384457: Add special case for End_of_file to sparse_dd_wrapper

### DIFF
--- a/ocaml/xapi/sparse_dd_wrapper.ml
+++ b/ocaml/xapi/sparse_dd_wrapper.ml
@@ -163,6 +163,9 @@ let dd_internal progress_cb base prezeroed verify_cert infile outfile size =
         with
         | Forkhelpers.Success _ ->
             progress_cb (Finished None)
+        | Forkhelpers.Failure (log, End_of_file) ->
+            error "Error while trying to read progress from sparse_dd" ;
+            raise (Api_errors.Server_error (Api_errors.vdi_copy_failed, [log]))
         | Forkhelpers.Failure (log, exn) ->
             error "Failure from sparse_dd: %s raising %s" log
               (Printexc.to_string exn) ;


### PR DESCRIPTION
Example log after the patch

```
Dec  7 11:11:11 xrtuk-15-02 xapi: [error||30997 ||backtrace] Async.VDI.copy R:a1c789606cb2 failed with exception Server_error(VDI_COPY_FAILED, [ Fatal error: exception Dune__exe__Sparse_dd.MyExp\x0A ])
Dec  7 11:11:11 xrtuk-15-02 xapi: [error||30997 ||backtrace] Raised Server_error(VDI_COPY_FAILED, [ Fatal error: exception Dune__exe__Sparse_dd.MyExp\x0A ])
Dec  7 11:11:11 xrtuk-15-02 xapi: [error||30997 ||backtrace] 1/22 xapi Raised at file ocaml/xapi/sparse_dd_wrapper.ml, line 168
Dec  7 11:11:11 xrtuk-15-02 xapi: [error||30997 ||backtrace] 2/22 xapi Called from file ocaml/xapi/sparse_dd_wrapper.ml, line 178
Dec  7 11:11:11 xrtuk-15-02 xapi: [error||30997 ||backtrace] 3/22 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
Dec  7 11:11:11 xrtuk-15-02 xapi: [error||30997 ||backtrace] 4/22 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 38
Dec  7 11:11:11 xrtuk-15-02 xapi: [error||30997 ||backtrace] 5/22 xapi Called from file lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
```
