### PR TITLE
CP-45974-port examples folder under /xen-api/scripts/examples to python3.

### DIFF
--- a/scripts/examples/python/XenAPIPlugin.py
+++ b/scripts/examples/python/XenAPIPlugin.py
@@ -9,7 +9,7 @@ import sys
 import XenAPI
 
 if sys.version_info[0] == 2:
-    import xmlrpclib as xmlrpclib
+    import xmlrpclib
 else:
     import xmlrpc.client as xmlrpclib
 

--- a/scripts/examples/python/XenAPIPlugin.py
+++ b/scripts/examples/python/XenAPIPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # XenAPI python plugin boilerplate code
 

--- a/scripts/examples/python/exportimport.py
+++ b/scripts/examples/python/exportimport.py
@@ -20,7 +20,7 @@
 #  - connect an export to an import to copy a raw disk image
 
 from __future__ import print_function
-import sys, os, socket, urllib2, urlparse, XenAPI, traceback, ssl, time
+import sys, os, socket, urllib.request, urllib.error, urllib.parse, XenAPI, traceback, ssl, time
 
 def exportimport(url, xapi, session, src_vdi, dst_vdi):
   # If an HTTP operation fails then it will record the error on the task
@@ -35,12 +35,12 @@ def exportimport(url, xapi, session, src_vdi, dst_vdi):
     put_url = "/import_raw_vdi?session_id=%s&vdi=%s&task_id=%s" % (session, dst_vdi, import_task)
 
     # 'data' is the stream of raw data:
-    data = urllib2.urlopen(url + get_url)
+    data = urllib.request.urlopen(url + get_url)
 
     # python's builtin library doesn't support HTTP PUT very well
     # so we do it manually. Note xapi doesn't support Transfer-encoding:
     # chunked so we must send the data raw.
-    url = urlparse.urlparse(url)
+    url = urllib.parse.urlparse(url)
     host = url.netloc.split(":")[0] # assume port 443
     if url.scheme != "https":
       print("Sorry, this example only supports HTTPS (not HTTP)", file=sys.stderr)

--- a/scripts/examples/python/exportimport.py
+++ b/scripts/examples/python/exportimport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2014 Citrix, Inc.
 #

--- a/scripts/examples/python/lvhd-api-test.py
+++ b/scripts/examples/python/lvhd-api-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import XenAPI, sys

--- a/scripts/examples/python/mini-xenrt.py
+++ b/scripts/examples/python/mini-xenrt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Receive multiple VMs
 # Issue parallel loops of: reboot, suspend/resume, migrate

--- a/scripts/examples/python/mini-xenrt.py
+++ b/scripts/examples/python/mini-xenrt.py
@@ -15,9 +15,9 @@ stop = False
 
 class Operation:
     def __init__(self):
-        raise "this is supposed to be abstract, dummy"
+        raise Exception("this is supposed to be abstract, dummy")
     def execute(self, server, session_id):
-        raise "this is supposed to be abstract, dummy"
+        raise Exception("this is supposed to be abstract, dummy")
 
 class Reboot(Operation):
     def __init__(self, vm):
@@ -120,7 +120,7 @@ if __name__ == "__main__":
             allowed_ops = vms[vm]["allowed_operations"]
             for op in [ "clean_reboot", "suspend", "pool_migrate" ]:
                 if op not in allowed_ops:
-                    raise "VM %s is not in a state where it can %s" % (vms[vm]["name_label"], op)
+                    raise Exception("VM %s is not in a state where it can %s" % (vms[vm]["name_label"], op))
             workers.append(Worker(x, session, make_operation_list(vm)))
     for w in workers:
         w.start()

--- a/scripts/examples/python/mini-xenrt.py
+++ b/scripts/examples/python/mini-xenrt.py
@@ -4,7 +4,7 @@
 # Issue parallel loops of: reboot, suspend/resume, migrate
 
 from __future__ import print_function
-import xmlrpclib
+import xmlrpc.client
 from threading import Thread
 import time, sys
 
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         print("  -- performs parallel operations on VMs with the specified other-config key")
         sys.exit(1)
     
-    x = xmlrpclib.Server(sys.argv[1])
+    x = xmlrpc.client.server(sys.argv[1])
     key = sys.argv[2]
     session = x.session.login_with_password("root", "xenroot", "1.0", "xen-api-scripts-minixenrt.py")["Value"]
     vms = x.VM.get_all_records(session)["Value"]

--- a/scripts/examples/python/mini-xenrt.py
+++ b/scripts/examples/python/mini-xenrt.py
@@ -138,5 +138,4 @@ if __name__ == "__main__":
         sys.exit(0)
     else:
         print("FAIL")
-        sys.exit(1)
-        
+        sys.exit(1)  

--- a/scripts/examples/python/monitor-unwanted-domains.py
+++ b/scripts/examples/python/monitor-unwanted-domains.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os, subprocess, XenAPI, inventory, time, sys

--- a/scripts/examples/python/provision.py
+++ b/scripts/examples/python/provision.py
@@ -65,7 +65,7 @@ def parseProvisionSpec(txt):
     doc = xml.dom.minidom.parseString(txt)
     all = doc.getElementsByTagName("provision")
     if len(all) != 1:
-        raise "Expected to find exactly one <provision> element"
+        raise Exception("Expected to find exactly one <provision> element")
     ps = ProvisionSpec()
     disks = all[0].getElementsByTagName("disk")
     for disk in disks:
@@ -107,5 +107,5 @@ if __name__ == "__main__":
     txt2 = printProvisionSpec(ps)
     print(txt2)
     if txt != txt2:
-        raise "Sanity-check failed: print(parse(print(x))) <> print(x)"
+        raise Exception("Sanity-check failed: print(parse(print(x))) <> print(x)")
     print("* OK: print(parse(print(x))) == print(x)")

--- a/scripts/examples/python/provision.py
+++ b/scripts/examples/python/provision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2007 XenSource, Inc.
 #
 # Permission to use, copy, modify, and distribute this software for any

--- a/scripts/examples/python/renameif.py
+++ b/scripts/examples/python/renameif.py
@@ -165,5 +165,3 @@ if __name__ == "__main__":
         renameif(session)
     finally:
         session.logout()
-        
-

--- a/scripts/examples/python/renameif.py
+++ b/scripts/examples/python/renameif.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2008 XenSource, Inc.
 #
 # Permission to use, copy, modify, and distribute this software for any

--- a/scripts/examples/python/shell.py
+++ b/scripts/examples/python/shell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2006-2008 Citrix Systems.
 #
 # Permission to use, copy, modify, and distribute this software for any

--- a/scripts/examples/python/xva.py
+++ b/scripts/examples/python/xva.py
@@ -3,7 +3,7 @@
 # Rewrite the VDI.sm_config:SCSIid fields in XVA metadata
 
 from __future__ import print_function
-import tarfile, xmlrpclib, optparse, StringIO, sys
+import tarfile, xmlrpc.client, optparse, io, sys
 
 class Object(object):
     """Represents an XVA metadata object, for example a VM, VBD, VDI, SR, VIF or Network.
@@ -50,7 +50,7 @@ class XVA(object):
 
     def save(self, fileobj):
         # Reconstruct the ova.xml from Objects
-        ova_txt = xmlrpclib.dumps(({"version": self._version, "objects": map(lambda x:x.marshal(), self._objects)}, ))
+        ova_txt = xmlrpc.client.dumps(({"version": self._version, "objects": map(lambda x:x.marshal(), self._objects)}, ))
         prefix="<params>\n<param>\n"
         suffix="</param>\n</params>\n"
         if not(ova_txt.startswith(prefix)) or not(ova_txt.endswith(suffix)):
@@ -61,7 +61,7 @@ class XVA(object):
         output = tarfile.TarFile(mode='w', fileobj=fileobj)
         tarinfo = tarfile.TarInfo("ova.xml")
         tarinfo.size = len(ova_txt)
-        output.addfile(tarinfo, StringIO.StringIO(ova_txt))
+        output.addfile(tarinfo, io.StringIO(ova_txt))
         # Stream the contents of the input, copying to the output
         for name in self._input.getnames():
             if name == "ova.xml":
@@ -73,7 +73,7 @@ class XVA(object):
 def open_xva(name):
     t = tarfile.open(name = name)
     ova_txt = t.extractfile("ova.xml").read()
-    ova = xmlrpclib.loads("<params><param>" + ova_txt + "</param></params>")[0][0]
+    ova = xmlrpc.client.loads("<params><param>" + ova_txt + "</param></params>")[0][0]
     return XVA(t, ova)
 
 if __name__ == "__main__":

--- a/scripts/examples/python/xva.py
+++ b/scripts/examples/python/xva.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Rewrite the VDI.sm_config:SCSIid fields in XVA metadata
 

--- a/scripts/examples/smapiv2.py
+++ b/scripts/examples/smapiv2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os, sys, time, socket, traceback

--- a/scripts/examples/smapiv2.py
+++ b/scripts/examples/smapiv2.py
@@ -246,7 +246,7 @@ def daemonize():
     os.dup2(devnull.fileno(), sys.stdout.fileno())
     os.dup2(devnull.fileno(), sys.stderr.fileno())
 
-from SimpleXMLRPCServer import SimpleXMLRPCServer, SimpleXMLRPCRequestHandler
+from xmlrpc.server import SimpleXMLRPCServer, SimpleXMLRPCRequestHandler
 
 # Server XMLRPC from any HTTP POST path #####################################
 
@@ -266,13 +266,13 @@ class Server(SimpleXMLRPCServer):
 # BaseHTTPServer (and its subclasses) make.
 # See: http://bugs.python.org/issue6085
 # See: http://www.answermysearches.com/xmlrpc-server-slow-in-python-how-to-fix/2140/
-import BaseHTTPServer
+import http.server
 
 def _bare_address_string(self):
     host, port = self.client_address[:2]
     return '%s' % host
 
-BaseHTTPServer.BaseHTTPRequestHandler.address_string = \
+http.server.BaseHTTPRequestHandler.address_string = \
         _bare_address_string
 
 # Given an implementation, serve requests forever ###########################

--- a/scripts/examples/smapiv2.py
+++ b/scripts/examples/smapiv2.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 from __future__ import print_function
-import os, sys, time, socket, traceback
+import os, sys, io, time, socket, traceback
 
-log_f = os.fdopen(os.dup(sys.stdout.fileno()), "aw")
+log_f = io.open(os.dup(sys.stdout.fileno()), "w")
 pid = None
 
 def reopenlog(log_file):
@@ -11,9 +11,12 @@ def reopenlog(log_file):
     if log_f:
         log_f.close()
     if log_file:
-        log_f = open(log_file, "aw")
+        try:
+            log_f = io.open(log_file, "a")
+        except FilenotFoundError:
+            log_f = io.open(log_file, "w")
     else:
-        log_f = os.fdopen(os.dup(sys.stdout.fileno()), "aw")
+        log_f = io.open(os.dup(sys.stdout.fileno()), "a")
 
 def log(txt):
     global log_f, pid

--- a/scripts/examples/storage.py
+++ b/scripts/examples/storage.py
@@ -19,7 +19,7 @@
 # WARNING: this API is considered to be unstable and may be changed at-will
 
 from __future__ import print_function
-import os, sys, commands, json
+import os, sys, subprocess, json
 
 import smapiv2
 from smapiv2 import log, start, BackendError, Vdi_does_not_exist
@@ -29,7 +29,7 @@ root = "/sr/"
 # [run task cmd] executes [cmd], throwing a BackendError if exits with
 # a non-zero exit code.
 def run(task, cmd):
-    code, output = commands.getstatusoutput(cmd)
+    code, output = subprocess.getstatusoutput(cmd)
     if code != 0:
         log("%s: %s exitted with code %d: %s" % (task, cmd, code, output))
         raise BackendError

--- a/scripts/examples/storage.py
+++ b/scripts/examples/storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) Citrix Inc
 #


### PR DESCRIPTION
PR contains below changes  to support python3,

1. Shebang has been changed to  #!/usr/bin/env python3
2. Certain modules required update to make it compatible with python3 .
3. Used Generic  exception to fix "Python 3 does not support string exceptions"
4. Fixed extra line issues when making changes.
5. smapiv2 throws "ValueError: must have exactly one of create/read/write/append mode" made necessary changes to the code to make it compatible with python3.

Signed-off-by: Ashwinh <ashwin.h@cloud.com>