### PR TITLE
CA-386582: Always create exporting thread for observers

### DIFF
--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -193,7 +193,7 @@ let resync_host ~__context ~host =
             (* Note that join_internal and enable both use the clustering lock *)
             Client.Client.Cluster_host.enable ~rpc ~session_id ~self
           ) ;
-          Xapi_observer.initialise_component ~__context
+          Xapi_observer.initialise_observer ~__context
             Xapi_observer.Component.Xapi_clusterd ;
           let verify = Stunnel_client.get_verify_by_default () in
           set_tls_config ~__context ~self ~verify
@@ -302,7 +302,7 @@ let enable ~__context ~self =
           "Cluster_host.enable: xapi-clusterd not running - attempting to start" ;
         Xapi_clustering.Daemon.enable ~__context
       ) ;
-      Xapi_observer.initialise_component ~__context
+      Xapi_observer.initialise_observer ~__context
         Xapi_observer.Component.Xapi_clusterd ;
       let verify = Stunnel_client.get_verify_by_default () in
       set_tls_config ~__context ~self ~verify ;

--- a/ocaml/xapi/xapi_observer.mli
+++ b/ocaml/xapi/xapi_observer.mli
@@ -25,7 +25,7 @@ val observed_hosts_of :
 
 val initialise : __context:Context.t -> unit
 
-val initialise_component : __context:Context.t -> Component.t -> unit
+val initialise_observer : __context:Context.t -> Component.t -> unit
 
 val create :
      __context:Context.t


### PR DESCRIPTION
create observer exporting thread regardless of whether we have observers in database. 