### PR TITLE
CP-47012: change pending guidance in old xapi to recommended ones in new xapi

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,9 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 774
+(* This comment is a reminder to update the version in upgrade_update_guidance if schema_minor_vsn
+   changed when the update guidance improvement feature branch got merged into master branch *)
+let schema_minor_vsn = 775
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,8 +10,6 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-(* This comment is a reminder to update the version in upgrade_update_guidance if schema_minor_vsn
-   changed when the update guidance improvement feature branch got merged into master branch *)
 let schema_minor_vsn = 775
 
 (* Historical schema versions just in case this is useful later *)
@@ -135,6 +133,10 @@ let stockholm_release_schema_minor_vsn = 601
 let yangtze_release_schema_major_vsn = 5
 
 let yangtze_release_schema_minor_vsn = 602
+
+let nile_release_schema_major_vsn = 5
+
+let nile_release_schema_minor_vsn = 775
 
 (* List of tech-preview releases. Fields in these releases are not guaranteed to be retained when
  * upgrading to a full release. *)

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -866,6 +866,9 @@ let empty_pool_uefi_certificates =
  * 2. Move the rest guidances in \
  *    host.pending_guidances into host.pending_guidances_recommended *)
 let upgrade_update_guidance =
+  (* This is an intended build error to remind changing below schema version *)
+  (* To build feature branch, you need to remove this line temporarily *)
+  let change_version_to_the_latest_schema_version = () in
   {
     description=
       "Upgrade pending update gudiances"

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -871,7 +871,12 @@ let upgrade_update_guidance =
       "Upgrade pending update gudiances"
       (* TODO: update below schema version to which the feature branch got merged with *)
   ; version=
-      (fun x -> x < (5, 775))
+      (fun x ->
+        x
+        < ( Datamodel_common.nile_release_schema_major_vsn
+          , Datamodel_common.nile_release_schema_minor_vsn
+          )
+      )
       (* the version where update guidance improvement is made *)
   ; fn=
       (fun ~__context ->

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -859,14 +859,16 @@ let empty_pool_uefi_certificates =
       )
   }
 
-let update_livepatch_guidance =
+(* 1. Replace reboot_host_on_livepatch_failure in host.pending_guidances \
+ *    with reboot_host_on_kernel_livepatch_failure and \
+ *    reboot_host_on_xen_livepatch_failure in \
+ *    host.pending_guidances_recommended.
+ * 2. Move the rest guidances in \
+ *    host.pending_guidances into host.pending_guidances_recommended *)
+let upgrade_update_guidance =
   {
     description=
-      "1. Replace reboot_host_on_livepatch_failure in host.pending_guidances \
-       with reboot_host_on_kernel_livepatch_failure and \
-       reboot_host_on_xen_livepatch_failure in \
-       host.pending_guidances_recommended. 2. Move the rest guidances in \
-       host.pending_guidances into host.pending_guidances_recommended"
+      "Upgrade pending update gudiances"
       (* TODO: update below schema version to which the feature branch got merged with *)
   ; version= (fun x -> x < (5, 769))
   ; fn=
@@ -923,7 +925,7 @@ let rules =
   ; upgrade_secrets
   ; remove_legacy_ssl_support
   ; empty_pool_uefi_certificates
-  ; update_livepatch_guidance
+  ; upgrade_update_guidance
   ]
 
 (* Maybe upgrade most recent db *)

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -867,7 +867,8 @@ let update_livepatch_guidance =
        reboot_host_on_xen_livepatch_failure in \
        host.pending_guidances_recommended. 2. Move the rest guidances in \
        host.pending_guidances into host.pending_guidances_recommended"
-  ; version= (fun _ -> true)
+      (* TODO: update below schema version to which the feature branch got merged with *)
+  ; version= (fun x -> x < (5, 769))
   ; fn=
       (fun ~__context ->
         Db.Host.get_all ~__context

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -862,10 +862,11 @@ let empty_pool_uefi_certificates =
 let update_livepatch_guidance =
   {
     description=
-      "Replace reboot_host_on_livepatch_failure in host.pending_guidances with \
-       reboot_host_on_kernel_livepatch_failure and \
+      "1. Replace reboot_host_on_livepatch_failure in host.pending_guidances \
+       with reboot_host_on_kernel_livepatch_failure and \
        reboot_host_on_xen_livepatch_failure in \
-       host.pending_guidances_recommended"
+       host.pending_guidances_recommended. 2. Move the rest guidances in \
+       host.pending_guidances into host.pending_guidances_recommended"
   ; version= (fun _ -> true)
   ; fn=
       (fun ~__context ->
@@ -881,7 +882,14 @@ let update_livepatch_guidance =
                    ~value:`reboot_host_on_xen_livepatch_failure ;
                  Db.Host.remove_pending_guidances ~__context ~self
                    ~value:`reboot_host_on_livepatch_failure
-               )
+               ) ;
+               List.iter
+                 (fun g ->
+                   Db.Host.add_pending_guidances_recommended ~__context ~self
+                     ~value:g
+                 )
+                 (Db.Host.get_pending_guidances ~__context ~self) ;
+               Db.Host.set_pending_guidances ~__context ~self ~value:[]
            )
       )
   }

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -866,14 +866,13 @@ let empty_pool_uefi_certificates =
  * 2. Move the rest guidances in \
  *    host.pending_guidances into host.pending_guidances_recommended *)
 let upgrade_update_guidance =
-  (* This is an intended build error to remind changing below schema version *)
-  (* To build feature branch, you need to remove this line temporarily *)
-  let change_version_to_the_latest_schema_version = () in
   {
     description=
       "Upgrade pending update gudiances"
       (* TODO: update below schema version to which the feature branch got merged with *)
-  ; version= (fun x -> x < (5, 769))
+  ; version=
+      (fun x -> x < (5, 775))
+      (* the version where update guidance improvement is made *)
   ; fn=
       (fun ~__context ->
         Db.Host.get_all ~__context


### PR DESCRIPTION
Add update guidance DB upgrade rule: except reboot_host_on_livepatch_failure, move any guidance in
"host.pending_guidances" into "host.pending_guidances_recommended".