### PR TITLE
update print-custom-templates to python3

### DIFF
--- a/scripts/print-custom-templates
+++ b/scripts/print-custom-templates
@@ -1,42 +1,40 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # Print out custom template UUIDs in CLI comma-separated minimal format
 # (c) Anil Madhavapeddy, Citrix Systems Inc, 2008
 
 import atexit
-import XenAPI
-import os, sys, time
+import contextlib
+import sys
 
-def logout():
-    try:
+import XenAPI
+
+
+def logout(session):
+    with contextlib.suppress(Exception):
         session.xenapi.session.logout()
-    except:
-        pass
-atexit.register(logout)
 
 def main(argv):
     try:
         session = XenAPI.xapi_local()
         session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-custom-template")
+        atexit.register(logout, session)
 
         templates = session.xenapi.VM.get_all_records_where('field "is_a_template" = "true" and field "is_a_snapshot" = "false"' )
     except:
-        print >> sys.stderr, "Error retrieving template list"
+        print("Error retrieving template list", file=sys.stderr)
         sys.exit(1)
 
     output=[]
-    for tmplref in templates.keys():
+    for tmplref in templates:
         tmplrec = templates[tmplref]
         try:
-            if not tmplrec['other_config'].has_key('default_template'):
-                output.append(tmplrec['uuid'])
-            elif tmplrec['other_config']['default_template'] != true:
-                output.append(tmplrec['uuid'])
-        except:
+            if "default_template" not in tmplrec["other_config"] or tmplrec["other_config"]["default_template"] != 'true':
+                output.append(tmplrec["uuid"])
+        except KeyError:
             pass
-    print(str.join(',', output))
+
+    print(str.join(",", output))
     session.xenapi.logout()
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-
-


### PR DESCRIPTION
- format with `2to3`
- In Python 2, it was possible to compare strings without using quotes, but python3 not
- fix invalid `logout` function 

Tested manually on host
