### PR TITLE
CP-46378: Propagate `dbg` to `Sm_exec.exec_xmlrpc`

### DIFF
--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -295,13 +295,15 @@ let vdi_resize ~dbg dconf driver sr vdi newsize =
   in
   Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
-let vdi_generate_config dconf driver sr vdi =
+let vdi_generate_config ~dbg dconf driver sr vdi =
+  with_dbg ~dbg ~name:"vdi_generate_config" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_generate_config" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   let call =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_generate_config" []
   in
-  Sm_exec.parse_string (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_string (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_compose ~dbg dconf driver sr vdi1 vdi2 =
   with_dbg ~dbg ~name:"vdi_compose" @@ fun di ->

--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -137,7 +137,8 @@ let sr_update dconf driver sr =
 let vdi_create ~dbg dconf driver sr sm_config vdi_type size name_label
     name_description metadata_of_pool is_a_snapshot snapshot_time snapshot_of
     read_only =
-  with_dbg ~dbg ~name:"vdi_create" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_create" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_create" driver
     (sprintf "sr=%s sm_config=[%s] type=[%s] size=%Ld" (Ref.string_of sr)
        (String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) sm_config))
@@ -158,17 +159,19 @@ let vdi_create ~dbg dconf driver sr sm_config vdi_type size name_label
       ; string_of_bool read_only
       ]
   in
-  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_update ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_update" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_update" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_update" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_update" [] in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_introduce ~dbg dconf driver sr new_uuid sm_config location =
-  with_dbg ~dbg ~name:"vdi_introduce" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_introduce" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_introduce" driver
     (sprintf "sr=%s new_uuid=%s sm_config=[%s] location=%s" (Ref.string_of sr)
        new_uuid
@@ -179,18 +182,20 @@ let vdi_introduce ~dbg dconf driver sr new_uuid sm_config location =
     Sm_exec.make_call ~sr_ref:sr ~vdi_location:location ~vdi_sm_config:sm_config
       ~new_uuid dconf "vdi_introduce" []
   in
-  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_delete ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_delete" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_delete" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_delete" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   srmaster_only dconf ;
   let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_delete" [] in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_attach ~dbg dconf driver sr vdi writable =
-  with_dbg ~dbg ~name:"vdi_attach" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_attach" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_attach" driver
     (sprintf "sr=%s vdi=%s writable=%b" (Ref.string_of sr) (Ref.string_of vdi)
        writable
@@ -199,37 +204,41 @@ let vdi_attach ~dbg dconf driver sr vdi writable =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_attach"
       [sprintf "%b" writable]
   in
-  let result = Sm_exec.exec_xmlrpc (driver_filename driver) call in
+  let result = Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call in
   Sm_exec.parse_attach_result result
 
 let vdi_detach ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_detach" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_detach" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_detach" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   let call = Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_detach" [] in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_activate ~dbg dconf driver sr vdi writable =
-  with_dbg ~dbg ~name:"vdi_activate" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_activate" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_activate" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   let call =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_activate"
       [sprintf "%b" writable]
   in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_deactivate ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_deactivate" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_deactivate" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_deactivate" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   let call =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_deactivate" []
   in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_snapshot ~dbg dconf driver driver_params sr vdi =
-  with_dbg ~dbg ~name:"vdi_snapshot" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_snapshot" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_snapshot" driver
     (sprintf "sr=%s vdi=%s driver_params=[%s]" (Ref.string_of sr)
        (Ref.string_of vdi)
@@ -240,10 +249,11 @@ let vdi_snapshot ~dbg dconf driver driver_params sr vdi =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi ~driver_params dconf
       "vdi_snapshot" []
   in
-  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_clone ~dbg dconf driver driver_params sr vdi =
-  with_dbg ~dbg ~name:"vdi_clone" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_clone" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_clone" driver
     (sprintf "sr=%s vdi=%s driver_params=[%s]" (Ref.string_of sr)
        (Ref.string_of vdi)
@@ -254,10 +264,11 @@ let vdi_clone ~dbg dconf driver driver_params sr vdi =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi ~driver_params dconf "vdi_clone"
       []
   in
-  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_resize ~dbg dconf driver sr vdi newsize =
-  with_dbg ~dbg ~name:"vdi_resize" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_resize" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_resize" driver
     (sprintf "sr=%s vdi=%s newsize=%Ld" (Ref.string_of sr) (Ref.string_of vdi)
        newsize
@@ -267,7 +278,7 @@ let vdi_resize ~dbg dconf driver sr vdi newsize =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_resize"
       [sprintf "%Lu" newsize]
   in
-  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_generate_config dconf driver sr vdi =
   debug "vdi_generate_config" driver
@@ -278,7 +289,8 @@ let vdi_generate_config dconf driver sr vdi =
   Sm_exec.parse_string (Sm_exec.exec_xmlrpc (driver_filename driver) call)
 
 let vdi_compose ~dbg dconf driver sr vdi1 vdi2 =
-  with_dbg ~dbg ~name:"vdi_compose" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_compose" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_compose" driver
     (sprintf "sr=%s vdi1=%s vdi2=%s" (Ref.string_of sr) (Ref.string_of vdi1)
        (Ref.string_of vdi2)
@@ -288,58 +300,64 @@ let vdi_compose ~dbg dconf driver sr vdi1 vdi2 =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi2 dconf "vdi_compose"
       [Ref.string_of vdi1]
   in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_epoch_begin ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_epoch_begin" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_epoch_begin" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_epoch_begin" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   let call =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_epoch_begin" []
   in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_epoch_end ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_epoch_end" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_epoch_end" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_epoch_end" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   let call =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_epoch_end" []
   in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_enable_cbt ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_enable_cbt" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_enable_cbt" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_enable_cbt" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   srmaster_only dconf ;
   let call =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_enable_cbt" []
   in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_disable_cbt ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_disable_cbt" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_disable_cbt" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_disable_cbt" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   srmaster_only dconf ;
   let call =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_disable_cbt" []
   in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_data_destroy ~dbg dconf driver sr vdi =
-  with_dbg ~dbg ~name:"vdi_data_destroy" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_data_destroy" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_data_destroy" driver
     (sprintf "sr=%s vdi=%s" (Ref.string_of sr) (Ref.string_of vdi)) ;
   srmaster_only dconf ;
   let call =
     Sm_exec.make_call ~sr_ref:sr ~vdi_ref:vdi dconf "vdi_data_destroy" []
   in
-  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let vdi_list_changed_blocks ~dbg dconf driver sr ~vdi_from ~vdi_to =
-  with_dbg ~dbg ~name:"vdi_list_changed_blocks" @@ fun _ ->
+  with_dbg ~dbg ~name:"vdi_list_changed_blocks" @@ fun di ->
+  let dbg = Debuginfo.to_string di in
   debug "vdi_list_changed_blocks" driver
     (sprintf "sr=%s vdi_from=%s vdi_to=%s" (Ref.string_of sr)
        (Ref.string_of vdi_from) (Ref.string_of vdi_to)
@@ -350,7 +368,7 @@ let vdi_list_changed_blocks ~dbg dconf driver sr ~vdi_from ~vdi_to =
       "vdi_list_changed_blocks"
       [Ref.string_of vdi_to]
   in
-  Sm_exec.parse_string (Sm_exec.exec_xmlrpc (driver_filename driver) call)
+  Sm_exec.parse_string (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
 let session_has_internal_sr_access ~__context ~sr =
   let session_id = Context.get_session_id __context in

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -196,7 +196,7 @@ module SMAPIv1 : Server_impl = struct
         ~subtask_of:(Ref.of_string dbg) (fun __context ->
           let task = Context.get_task_id __context in
           Storage_interface.Raw
-            (Sm.sr_probe
+            (Sm.sr_probe ~dbg
                (Some task, Sm.sm_master true :: device_config)
                _type sm_config
             )
@@ -216,7 +216,9 @@ module SMAPIv1 : Server_impl = struct
           let device_config = Sm.sm_master true :: device_config in
           Sm.call_sm_functions ~__context ~sR:sr (fun _ _type ->
               try
-                Sm.sr_create (subtask_of, device_config) _type sr physical_size
+                Sm.sr_create ~dbg
+                  (subtask_of, device_config)
+                  _type sr physical_size
               with
               | Smint.Not_implemented_in_backend ->
                   error "SR.create failed SR:%s Not_implemented_in_backend"
@@ -273,7 +275,7 @@ module SMAPIv1 : Server_impl = struct
           let device_config = Sm.sm_master srmaster :: device_config in
           Sm.call_sm_functions ~__context ~sR:sr (fun _ _type ->
               try
-                Sm.sr_attach
+                Sm.sr_attach ~dbg
                   (Some (Context.get_task_id __context), device_config)
                   _type sr
               with
@@ -294,7 +296,7 @@ module SMAPIv1 : Server_impl = struct
               ~uuid:(Storage_interface.Sr.string_of sr)
           in
           Sm.call_sm_functions ~__context ~sR:sr (fun device_config _type ->
-              try Sm.sr_detach device_config _type sr with
+              try Sm.sr_detach ~dbg device_config _type sr with
               | Api_errors.Server_error (code, params) ->
                   raise (Storage_error (Backend_error (code, params)))
               | e ->
@@ -314,7 +316,7 @@ module SMAPIv1 : Server_impl = struct
               ~uuid:(Storage_interface.Sr.string_of sr)
           in
           Sm.call_sm_functions ~__context ~sR:sr (fun device_config _type ->
-              try Sm.sr_delete device_config _type sr with
+              try Sm.sr_delete ~dbg device_config _type sr with
               | Smint.Not_implemented_in_backend ->
                   raise
                     (Storage_interface.Storage_error
@@ -342,7 +344,7 @@ module SMAPIv1 : Server_impl = struct
           in
           Sm.call_sm_functions ~__context ~sR:sr (fun device_config _type ->
               try
-                Sm.sr_update device_config _type sr ;
+                Sm.sr_update ~dbg device_config _type sr ;
                 let r = Db.SR.get_record ~__context ~self:sr in
                 let sr_uuid = Some r.API.sR_uuid in
                 let name_label = r.API.sR_name_label in
@@ -392,7 +394,7 @@ module SMAPIv1 : Server_impl = struct
           let sr = Db.SR.get_by_uuid ~__context ~uuid:(s_of_sr sr') in
           Sm.call_sm_functions ~__context ~sR:sr (fun device_config _type ->
               try
-                Sm.sr_scan device_config _type sr ;
+                Sm.sr_scan ~dbg device_config _type sr ;
                 let open Db_filter_types in
                 let vdis =
                   Db.VDI.get_records_where ~__context

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1086,7 +1086,10 @@ let server_init () =
           ; ("Initialising random number generator", [], random_setup)
           ; ("Initialise TLS verification", [], init_tls_verification)
           ; ("Running startup check", [], startup_check)
-          ; ("Registering SMAPIv1 plugins", [Startup.OnlyMaster], Sm.register)
+          ; ( "Registering SMAPIv1 plugins"
+            , [Startup.OnlyMaster]
+            , Sm.register ~__context
+            )
           ; ( "Initialising SMAPIv1 state"
             , []
             , Storage_smapiv1_wrapper.initialise
@@ -1211,7 +1214,7 @@ let server_init () =
                 Master_connection.connection_timeout := 10. ;
                 (* give up retrying after 10s *)
                 Db_cache_impl.initialise () ;
-                Sm.register () ;
+                Sm.register ~__context () ;
                 Startup.run ~__context
                   [
                     ( "Starting SMAPIv1 proxies"

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -1067,7 +1067,8 @@ let generate_config ~__context ~host:_ ~vdi =
   Sm.assert_pbd_is_plugged ~__context ~sr:(Db.VDI.get_SR ~__context ~self:vdi) ;
   Xapi_vdi_helpers.assert_managed ~__context ~vdi ;
   Sm.call_sm_vdi_functions ~__context ~vdi (fun srconf srtype sr ->
-      Sm.vdi_generate_config srconf srtype sr vdi
+      let dbg = Context.string_of_task_and_tracing __context in
+      Sm.vdi_generate_config ~dbg srconf srtype sr vdi
   )
 
 let clone ~__context ~vdi ~driver_params =


### PR DESCRIPTION
The `traceparent` was not propagated from the `sm.ml` functions. This commit solve this by propagating `dbg` into `Sm_exec.exec_xmlrpc` as an optional argument.
When `dbg` is passed, `Sm_exec.exec_xmlrps` now creates a span around the call.