### PR TITLE
CP-45570: Clear pending guidance when it got applied

### DIFF
--- a/ocaml/xapi/xapi_host_helpers.mli
+++ b/ocaml/xapi/xapi_host_helpers.mli
@@ -100,6 +100,20 @@ val assert_xen_compatible : unit -> unit
     currently installed xenctrl library and the currently running Xen hypervisor.)
     Raises XEN_INCOMPATIBLE if not, and caches the outcome of the check. *)
 
+val remove_pending_guidance :
+     __context:Context.t
+  -> self:API.ref_host
+  -> value:
+       [ `reboot_host
+       | `reboot_host_on_kernel_livepatch_failure
+       | `reboot_host_on_livepatch_failure
+       | `reboot_host_on_xen_livepatch_failure
+       | `restart_device_model
+       | `restart_toolstack
+       | `restart_vm ]
+  -> unit
+(** Removes update guidance from a host's all pending guidances lists. *)
+
 module Host_requires_reboot : sig
   val set : unit -> unit
   (** [set ()] is used to signal the host needs a reboot. This could be, for

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -479,6 +479,9 @@ let remove_stale_pcis ~__context ~vm =
 let pool_migrate_complete ~__context ~vm ~host:_ =
   let id = Db.VM.get_uuid ~__context ~self:vm in
   debug "VM.pool_migrate_complete %s" id ;
+  (* clear RestartDeviceModel guidance on VM migrate *)
+  Xapi_vm_lifecycle.remove_pending_guidance ~__context ~self:vm
+    ~value:`restart_device_model ;
   let dbg = Context.string_of_task __context in
   let queue_name = Xapi_xenops_queue.queue_of_vm ~__context ~self:vm in
   if Xapi_xenops.vm_exists_in_xenopsd queue_name dbg id then (

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1999,6 +1999,9 @@ let update_vm ~__context id =
             xenapi_of_xenops_power_state
               (Option.map (fun x -> (snd x).Vm.power_state) info)
           in
+          let power_state_before_update =
+            Db.VM.get_power_state ~__context ~self
+          in
           (* We preserve the current_domain_type of suspended VMs like we preserve
              the currently_attached fields for VBDs/VIFs etc - it's important to know
              whether suspended VMs are going to resume into PV or PVinPVH for example.
@@ -2275,13 +2278,28 @@ let update_vm ~__context id =
               try
                 Option.iter
                   (fun (_, state) ->
-                    debug "xenopsd event: Updating VM %s last_start_time <- %s"
-                      id
-                      (Date.to_string (Date.of_float state.Vm.last_start_time)) ;
                     let metrics = Db.VM.get_metrics ~__context ~self in
                     let start_time = Date.of_float state.Vm.last_start_time in
-                    Db.VM_metrics.set_start_time ~__context ~self:metrics
-                      ~value:start_time ;
+                    if
+                      start_time
+                      <> Db.VM_metrics.get_start_time ~__context ~self:metrics
+                    then (
+                      debug
+                        "xenopsd event: Updating VM %s last_start_time <- %s" id
+                        (Date.to_string (Date.of_float state.Vm.last_start_time)) ;
+                      Db.VM_metrics.set_start_time ~__context ~self:metrics
+                        ~value:start_time ;
+                      if
+                        (* VM start and VM reboot *)
+                        power_state = `Running
+                        && power_state_before_update <> `Suspended
+                      then (
+                        Xapi_vm_lifecycle.remove_pending_guidance ~__context
+                          ~self ~value:`restart_device_model ;
+                        Xapi_vm_lifecycle.remove_pending_guidance ~__context
+                          ~self ~value:`restart_vm
+                      )
+                    ) ;
                     create_guest_metrics_if_needed () ;
                     let gm = Db.VM.get_guest_metrics ~__context ~self in
                     let update_time =
@@ -3484,10 +3502,7 @@ let set_resident_on ~__context ~self =
   refresh_vm ~__context ~self ;
   !trigger_xenapi_reregister () ;
   (* Any future XenAPI updates will trigger events, but we might have missed one so: *)
-  Xenopsd_metadata.update ~__context ~self ;
-  Db.VM.remove_pending_guidances ~__context ~self ~value:`restart_device_model ;
-  Db.VM.remove_recommended_guidances ~__context ~self
-    ~value:`restart_device_model
+  Xenopsd_metadata.update ~__context ~self
 
 let update_debug_info __context t =
   let task = Context.get_task_id __context in


### PR DESCRIPTION
This PR fixes issue about clearing RestartToolstack guidance and RestartDeviceModel guidance, and clear RestartVM guidance.

Please refer commit message of each commit for details.