### PR TITLE
CP-46909: Update error returned from HTTP endpoint /updates

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1913,6 +1913,8 @@ let _ =
     ~doc:"Failed to get available updates from a host." () ;
   error Api_errors.get_updates_failed []
     ~doc:"Failed to get available updates from the pool." () ;
+  error Api_errors.invalid_host_ref_specified ["parameter"]
+    ~doc:"The specified parameter contained invalid host reference." () ;
   error Api_errors.get_updates_in_progress []
     ~doc:
       "The operation could not be performed because getting updates is in \

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1261,6 +1261,8 @@ let invalid_repomd_xml = "INVALID_REPOMD_XML"
 
 let get_updates_failed = "GET_UPDATES_FAILED"
 
+let invalid_host_ref_specified = "INVALID_HOST_REF_SPECIFIED"
+
 let get_updates_in_progress = "GET_UPDATES_IN_PROGRESS"
 
 let apply_updates_in_progress = "APPLY_UPDATES_IN_PROGRESS"

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3500,26 +3500,13 @@ let get_updates_handler (req : Http.Request.t) s _ =
       in
       match hs with
       | _ :: _ as hosts ->
-          let failures_of_404 =
-            [
-              Api_errors.no_repository_enabled
-            ; Api_errors.invalid_repomd_xml
-            ; Api_errors.invalid_updateinfo_xml
-            ]
-          in
           Xapi_pool_helpers.with_pool_operation ~__context
             ~self:(Helpers.get_pool ~__context)
             ~doc:"pool.get_updates" ~op:`get_updates (fun () ->
               try
                 http_res (Repository.get_pool_updates_in_json ~__context ~hosts)
               with
-              | Api_errors.(Server_error (failure, _)) as e
-                when List.mem failure failures_of_404 ->
-                  error "404: can't get updates for pool: %s"
-                    (ExnHelper.string_of_exn e) ;
-                  http_err failure []
-              | Api_errors.(Server_error (failure, _)) as e
-                when not (List.mem failure failures_of_404) ->
+              | Api_errors.(Server_error (failure, _)) as e ->
                   error "getting updates for pool failed: %s"
                     (ExnHelper.string_of_exn e) ;
                   http_err failure []


### PR DESCRIPTION
The error was designed as HTTP error code only. This is not friendly to clients like XenCenter, i.e. XenCenter can't get more information from the error. The improvement is to return a JSON format data like:
{
    "error": {
        "code": 1,
        "data": ["<data1>", "<data2>", ...],
        "message": "<XAPI error code>"
    }
}.
The data list are the parameters of the error defined in datamodel_error, and the HTTP response code will be 200 always.