### PR TITLE
CA-387033: Update xapi error document

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1961,8 +1961,8 @@ let _ =
 
   error Api_errors.host_pending_mandatory_guidances_not_empty ["host"]
     ~doc:
-      "The specified server is disabled and cannot be re-enabled until all of \
-       its pending mandatory guidances got applied."
+      "Operation could not be performed on the host because there is pending \
+       mandatory update guidance on it."
     () ;
 
   error Api_errors.host_evacuation_is_required ["host"]

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -1622,12 +1622,10 @@ let assert_no_host_pending_mandatory_guidance ~__context ~host =
       __FUNCTION__
       (List.length host_pending_mandatory_guidances)
       (Ref.string_of host)
-      (String.concat ";"
-         (List.map Updateinfo.Guidance.to_string
-            (List.map Updateinfo.Guidance.of_pending_guidance
-               host_pending_mandatory_guidances
-            )
-         )
+      (host_pending_mandatory_guidances
+      |> List.map Updateinfo.Guidance.of_pending_guidance
+      |> List.map Updateinfo.Guidance.to_string
+      |> String.concat ";"
       ) ;
     raise
       Api_errors.(

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -75,28 +75,8 @@ let set_power_on_mode ~__context ~self ~power_on_mode ~power_on_config =
 *)
 let assert_safe_to_reenable ~__context ~self =
   assert_startup_complete () ;
-  let host_pending_mandatory_guidances =
-    Db.Host.get_pending_guidances ~__context ~self
-  in
-  if host_pending_mandatory_guidances <> [] then (
-    error "%s: %d mandatory guidances are pending for host %s: [%s]"
-      __FUNCTION__
-      (List.length host_pending_mandatory_guidances)
-      (Ref.string_of self)
-      (String.concat ";"
-         (List.map Updateinfo.Guidance.to_string
-            (List.map Updateinfo.Guidance.of_pending_guidance
-               host_pending_mandatory_guidances
-            )
-         )
-      ) ;
-    raise
-      (Api_errors.Server_error
-         ( Api_errors.host_pending_mandatory_guidances_not_empty
-         , [Ref.string_of self]
-         )
-      )
-  ) ;
+  Repository_helpers.assert_no_host_pending_mandatory_guidance ~__context
+    ~host:self ;
   let host_disabled_until_reboot =
     try bool_of_string (Localdb.get Constants.host_disabled_until_reboot)
     with _ -> false


### PR DESCRIPTION
Update document for error: "host_pending_mandatory_guidances_not_empty" as it is used not only when enabling host.