### PR TITLE
CP-44637: Update data model of Tunnel for cross-server-private-network

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2214,6 +2214,16 @@ module Tunnel = struct
           ; param_release= next_release
           ; param_default= Some (VEnum "gre")
           }
+        ; {
+            param_type= Bool
+          ; param_name= "cross_server"
+          ; param_doc=
+              "Cross_server used to indicate what scenario is the tunnel used \
+               in: cross_server is true for a cross-server private network, \
+               false for XCP-ng"
+          ; param_release= next_release
+          ; param_default= Some (VBool false)
+          }
         ]
       ~result:(Ref _tunnel, "The reference of the created tunnel object")
       ~lifecycle:[(Published, rel_cowley, "Create a tunnel")]
@@ -2274,6 +2284,23 @@ module Tunnel = struct
         ; field ~ty:tunnel_protocol ~default_value:(Some (VEnum "gre"))
             ~lifecycle:[(Published, "1.250.0", "Add protocol field to tunnel")]
             "protocol" "The protocol used for tunneling (either GRE or VxLAN)"
+        ; field ~qualifier:StaticRO ~ty:Int ~default_value:(Some (VInt 0L))
+            ~lifecycle:
+              [(Published, rel_next, "VXLAN network identifier of tunnel")]
+            "tunnel_id"
+            "VXLAN network identifier of tunnel used in a cross-server private \
+             network"
+        ; field ~qualifier:StaticRO ~ty:Bool ~default_value:(Some (VBool false))
+            ~lifecycle:
+              [
+                ( Published
+                , rel_next
+                , "Indicate what scenario is the tunnel used in (cross-server \
+                   private network or XCP-ng)"
+                )
+              ]
+            "cross_server"
+            "True for a cross-server private network, false for XCP-ng"
         ]
       ()
 end

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "96da2c136aa13d4f8e71dd40fe2b84af"
+let last_known_schema_hash = "7139afaa328802993f5950594f68bef2"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/test_tunnel.ml
+++ b/ocaml/tests/test_tunnel.ml
@@ -60,6 +60,7 @@ let test_create_on_unmanaged_pif () =
     Api_errors.(Server_error (pif_unmanaged, [Ref.string_of transport_PIF]))
     (fun () ->
       Xapi_tunnel.create ~__context ~transport_PIF ~network ~protocol:`gre
+        ~cross_server:false
       |> ignore
     )
 
@@ -79,6 +80,7 @@ let test_create_network_already_connected () =
     )
     (fun () ->
       Xapi_tunnel.create ~__context ~transport_PIF ~network ~protocol:`gre
+        ~cross_server:false
       |> ignore
     )
 
@@ -98,6 +100,7 @@ let test_create_on_bond_slave () =
     )
     (fun () ->
       Xapi_tunnel.create ~__context ~transport_PIF ~network ~protocol:`gre
+        ~cross_server:false
       |> ignore
     )
 
@@ -111,7 +114,7 @@ let test_create_on_tunnel_access () =
     Api_errors.(Server_error (is_tunnel_access_pif, [Ref.string_of access_PIF]))
     (fun () ->
       Xapi_tunnel.create ~__context ~transport_PIF:access_PIF ~network
-        ~protocol:`gre
+        ~protocol:`gre ~cross_server:false
       |> ignore
     )
 
@@ -128,7 +131,7 @@ let test_create_on_sriov_logical () =
     )
     (fun () ->
       Xapi_tunnel.create ~__context ~transport_PIF:sriov_logical_PIF ~network
-        ~protocol:`gre
+        ~protocol:`gre ~cross_server:false
       |> ignore
     )
 
@@ -150,6 +153,7 @@ let test_create_on_vlan_on_sriov_logical () =
     )
     (fun () ->
       Xapi_tunnel.create ~__context ~transport_PIF ~network ~protocol:`gre
+        ~cross_server:false
       |> ignore
     )
 
@@ -174,7 +178,7 @@ let test_create_tunnel_into_sriov_network () =
     )
     (fun () ->
       Xapi_tunnel.create ~__context ~transport_PIF:pif ~network:sriov_network
-        ~protocol:`gre
+        ~protocol:`gre ~cross_server:false
       |> ignore
     )
 
@@ -202,7 +206,7 @@ let test_create_tunnel_into_sriov_vlan_network () =
     )
     (fun () ->
       Xapi_tunnel.create ~__context ~transport_PIF:pif
-        ~network:sriov_vlan_network ~protocol:`gre
+        ~network:sriov_vlan_network ~protocol:`gre ~cross_server:false
       |> ignore
     )
 

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1899,7 +1899,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "tunnel-create"
     , {
         reqd= ["pif-uuid"; "network-uuid"]
-      ; optn= ["protocol"]
+      ; optn= ["protocol"; "cross_server"]
       ; help= "Create a new tunnel on a host."
       ; implementation= No_fd Cli_operations.tunnel_create
       ; flags= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -6178,8 +6178,10 @@ let tunnel_create printer rpc session_id params =
     Record_util.tunnel_protocol_of_string
       (List.assoc_opt "protocol" params |> Option.value ~default:"gre")
   in
+  let cross_server = get_bool_param params "cross_server" in
   let tunnel =
     Client.Tunnel.create ~rpc ~session_id ~transport_PIF:pif ~network ~protocol
+      ~cross_server
   in
   let pif' = Client.Tunnel.get_access_PIF ~rpc ~session_id ~self:tunnel in
   let uuid = Client.PIF.get_uuid ~rpc ~session_id ~self:pif' in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4447,14 +4447,16 @@ functor
     end
 
     module Tunnel = struct
-      let create ~__context ~transport_PIF ~network ~protocol =
+      let create ~__context ~transport_PIF ~network ~protocol ~cross_server =
         info "Tunnel.create: network = '%s'" (network_uuid ~__context network) ;
-        let local_fn = Local.Tunnel.create ~transport_PIF ~network ~protocol in
+        let local_fn =
+          Local.Tunnel.create ~transport_PIF ~network ~protocol ~cross_server
+        in
         do_op_on ~local_fn ~__context
           ~host:(Db.PIF.get_host ~__context ~self:transport_PIF)
           (fun session_id rpc ->
             Client.Tunnel.create ~rpc ~session_id ~transport_PIF ~network
-              ~protocol
+              ~protocol ~cross_server
         )
 
       let destroy ~__context ~self =

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -831,12 +831,21 @@ let bring_pif_down ~__context ?(force = false) (pif : API.ref_PIF) =
           (* If last tunnel with VxLAN protocol is unplugged, close VxLAN UDP port *)
           let maybe_close_port () =
             let host = rc.API.pIF_host in
+            let cross_server =
+              Db.Tunnel.get_cross_server ~__context ~self:tunnel_ref
+            in
             match Db.Tunnel.get_protocol ~__context ~self:tunnel_ref with
             | `vxlan ->
                 let expr =
-                  Eq
-                    ( Field "protocol"
-                    , Literal (Record_util.tunnel_protocol_to_string `vxlan)
+                  And
+                    ( Eq
+                        ( Field "protocol"
+                        , Literal (Record_util.tunnel_protocol_to_string `vxlan)
+                        )
+                    , Eq
+                        ( Field "cross_server"
+                        , Literal (string_of_bool cross_server)
+                        )
                     )
                 in
                 let tunnels = Db.Tunnel.get_records_where ~__context ~expr in

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -410,7 +410,11 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
   in
   (* Allow pool-join if host does not have any tunnels *)
   let assert_no_tunnels_on_me () =
-    if Db.Tunnel.get_all ~__context <> [] then (
+    let tunnels =
+      Db.Tunnel.get_refs_where ~__context
+        ~expr:(Eq (Field "cross_server", Literal "false"))
+    in
+    if tunnels <> [] then (
       error "The current host has tunnels: it cannot join a new pool" ;
       raise
         (Api_errors.Server_error (Api_errors.pool_joining_host_has_tunnels, []))

--- a/ocaml/xapi/xapi_tunnel.mli
+++ b/ocaml/xapi/xapi_tunnel.mli
@@ -20,6 +20,7 @@ val create :
   -> transport_PIF:[`PIF] Ref.t
   -> network:[`network] Ref.t
   -> protocol:API.tunnel_protocol
+  -> cross_server:bool
   -> [`tunnel] Ref.t
 (** Create a tunnel for a given transport PIF and network *)
 


### PR DESCRIPTION
1. a new field tunnel_id of type int to record the id for all the tunnels in this "cross-server-private-network"
2. a new boolean field called cross_server to indicate whether tunnels to the remote server are set up automatically