### PR TITLE
Add "xe host-updates-show-available" CLI and update "xe host-apply-updates"

### DIFF
--- a/ocaml/xapi-cli-protocol/cli_protocol.ml
+++ b/ocaml/xapi-cli-protocol/cli_protocol.ml
@@ -35,6 +35,7 @@ type command =
   | Load of string (* filename *)
   | HttpGet of string * string (* filename * path *)
   | PrintHttpGetJson of string (* path *)
+  | PrintUpdateGuidance of string (* path *)
   | HttpPut of string * string (* filename * path *)
   | HttpConnect of string (* path *)
   | Prompt (* request the user enter some text *)
@@ -69,6 +70,8 @@ let string_of_command = function
       "HttpGet " ^ path ^ " -> " ^ filename
   | PrintHttpGetJson path ->
       "PrintHttpGetJson " ^ path ^ " -> stdout"
+  | PrintUpdateGuidance path ->
+      "PrintUpdateGuidance " ^ path ^ " -> stdout"
   | HttpPut (filename, path) ->
       "HttpPut " ^ path ^ " -> " ^ filename
   | HttpConnect path ->
@@ -158,7 +161,7 @@ let unmarshal_list pos f =
 (*****************************************************************************)
 (* Marshal/Unmarshal higher-level messages                                   *)
 
-(* Highest command id: 18 *)
+(* Highest command id: 19 *)
 
 let marshal_command = function
   | Print x ->
@@ -171,6 +174,8 @@ let marshal_command = function
       marshal_int 12 ^ marshal_string a ^ marshal_string b
   | PrintHttpGetJson a ->
       marshal_int 18 ^ marshal_string a
+  | PrintUpdateGuidance a ->
+      marshal_int 19 ^ marshal_string a
   | HttpPut (a, b) ->
       marshal_int 13 ^ marshal_string a ^ marshal_string b
   | HttpConnect a ->
@@ -224,6 +229,9 @@ let unmarshal_command pos =
   | 18 ->
       let a, pos = unmarshal_string pos in
       (PrintHttpGetJson a, pos)
+  | 19 ->
+      let a, pos = unmarshal_string pos in
+      (PrintUpdateGuidance a, pos)
   | n ->
       raise (Unknown_tag ("command", n))
 

--- a/ocaml/xapi-cli-protocol/cli_protocol.ml
+++ b/ocaml/xapi-cli-protocol/cli_protocol.ml
@@ -34,6 +34,7 @@ type command =
   | Debug of string (* debug message to optionally display *)
   | Load of string (* filename *)
   | HttpGet of string * string (* filename * path *)
+  | PrintHttpGetJson of string (* path *)
   | HttpPut of string * string (* filename * path *)
   | HttpConnect of string (* path *)
   | Prompt (* request the user enter some text *)
@@ -66,6 +67,8 @@ let string_of_command = function
       "Load " ^ x
   | HttpGet (filename, path) ->
       "HttpGet " ^ path ^ " -> " ^ filename
+  | PrintHttpGetJson path ->
+      "PrintHttpGetJson " ^ path ^ " -> stdout"
   | HttpPut (filename, path) ->
       "HttpPut " ^ path ^ " -> " ^ filename
   | HttpConnect path ->
@@ -155,7 +158,7 @@ let unmarshal_list pos f =
 (*****************************************************************************)
 (* Marshal/Unmarshal higher-level messages                                   *)
 
-(* Highest command id: 17 *)
+(* Highest command id: 18 *)
 
 let marshal_command = function
   | Print x ->
@@ -166,6 +169,8 @@ let marshal_command = function
       marshal_int 1 ^ marshal_string x
   | HttpGet (a, b) ->
       marshal_int 12 ^ marshal_string a ^ marshal_string b
+  | PrintHttpGetJson a ->
+      marshal_int 18 ^ marshal_string a
   | HttpPut (a, b) ->
       marshal_int 13 ^ marshal_string a ^ marshal_string b
   | HttpConnect a ->
@@ -216,6 +221,9 @@ let unmarshal_command pos =
   | 16 ->
       let body, pos = unmarshal_string pos in
       (PrintStderr body, pos)
+  | 18 ->
+      let a, pos = unmarshal_string pos in
+      (PrintHttpGetJson a, pos)
   | n ->
       raise (Unknown_tag ("command", n))
 

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1032,7 +1032,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
         reqd= ["hash"]
       ; optn= []
       ; help= "Apply updates from enabled repository on specified host."
-      ; implementation= No_fd Cli_operations.host_apply_updates
+      ; implementation= With_fd Cli_operations.host_apply_updates
       ; flags= [Host_selectors]
       }
     )

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1047,6 +1047,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Neverforward]
       }
     )
+  ; ( "host-updates-show-available"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Show available updates for a specified host."
+      ; implementation= With_fd Cli_operations.host_updates_show_available
+      ; flags= [Host_selectors]
+      }
+    )
   ; ( "patch-upload"
     , {
         reqd= ["file-name"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -5500,12 +5500,10 @@ let download_file rpc session_id task fd filename uri label =
     response := unmarshal fd
   done ;
   let ok =
-    match (!response, filename <> "") with
-    | Response OK, true ->
+    match !response with
+    | Response OK ->
         true
-    | Response OK, false ->
-        false
-    | Response Failed, _ ->
+    | Response Failed ->
         (* Need to check whether the thin cli managed to contact the server
            				   or not. If not, we need to mark the task as failed *)
         if Client.Task.get_progress ~rpc ~session_id ~self:task < 0.0 then
@@ -5517,7 +5515,8 @@ let download_file rpc session_id task fd filename uri label =
   wait_for_task_complete rpc session_id task ;
   (* Check the server status -- even if the client thinks it's ok, we need
      	   to check that the server does too. *)
-  check_task_status ~rpc ~session_id ~task ~fd ~label ~ok ()
+  let quiet_on_success = if filename = "" then true else false in
+  check_task_status ~rpc ~session_id ~task ~fd ~label ~ok ~quiet_on_success ()
 
 let download_file_with_task fd rpc session_id filename uri query label task_name
     =

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -5681,24 +5681,17 @@ let vm_import fd _printer rpc session_id params =
     in
     marshal fd (Command (Print (String.concat "," uuids)))
 
-let blob_get fd _printer rpc session_id params =
-  let blob_uuid = List.assoc "uuid" params in
-  let blob_ref = Client.Blob.get_by_uuid ~rpc ~session_id ~uuid:blob_uuid in
-  let filename = List.assoc "filename" params in
-  let blobtask =
+let command_in_task ~rpc ~session_id ~fd ~obj ~label ~quiet_on_success f =
+  let task =
     Client.Task.create ~rpc ~session_id
-      ~label:(Printf.sprintf "Obtaining blob, ref=%s" (Ref.string_of blob_ref))
+      ~label:(Printf.sprintf "%s (ref=%s)" label (Ref.string_of obj))
       ~description:""
   in
-  Client.Task.set_progress ~rpc ~session_id ~self:blobtask ~value:(-1.0) ;
-  let bloburi =
-    Printf.sprintf "%s?session_id=%s&task_id=%s&ref=%s" Constants.blob_uri
-      (Ref.string_of session_id) (Ref.string_of blobtask)
-      (Ref.string_of blob_ref)
-  in
+  Client.Task.set_progress ~rpc ~session_id ~self:task ~value:(-1.0) ;
+  let command = f session_id task obj in
   finally
     (fun () ->
-      marshal fd (Command (HttpGet (filename, bloburi))) ;
+      marshal fd (Command command) ;
       let response = ref (Response Wait) in
       while !response = Response Wait do
         response := unmarshal fd
@@ -5708,61 +5701,48 @@ let blob_get fd _printer rpc session_id params =
         | Response OK ->
             true
         | Response Failed ->
-            if Client.Task.get_progress ~rpc ~session_id ~self:blobtask < 0.0
-            then
-              Client.Task.set_status ~rpc ~session_id ~self:blobtask
-                ~value:`failure ;
+            (* Need to check whether the thin cli managed to contact the server
+             * or not. If not, we need to mark the task as failed.
+             *)
+            if Client.Task.get_progress ~rpc ~session_id ~self:task < 0.0 then
+              Client.Task.set_status ~rpc ~session_id ~self:task ~value:`failure ;
             false
         | _ ->
             false
       in
-      wait_for_task_complete rpc session_id blobtask ;
-      check_task_status ~rpc ~session_id ~task:blobtask ~fd ~label:"Blob get"
-        ~ok ()
+      wait_for_task_complete rpc session_id task ;
+      check_task_status ~rpc ~session_id ~task ~fd ~label ~ok ~quiet_on_success
+        ()
     )
-    (fun () -> Client.Task.destroy ~rpc ~session_id ~self:blobtask)
+    (fun () -> Client.Task.destroy ~rpc ~session_id ~self:task)
+
+let blob_uri ~session_id ~task ~blob =
+  let query =
+    [
+      ("session_id", [Ref.string_of session_id])
+    ; ("task_id", [Ref.string_of task])
+    ; ("ref", [Ref.string_of blob])
+    ]
+  in
+  Uri.make ~path:Constants.blob_uri ~query () |> Uri.to_string
+
+let blob_get fd _printer rpc session_id params =
+  let blob_uuid = List.assoc "uuid" params in
+  let blob_ref = Client.Blob.get_by_uuid ~rpc ~session_id ~uuid:blob_uuid in
+  let filename = List.assoc "filename" params in
+  command_in_task ~rpc ~session_id ~fd ~obj:blob_ref ~label:"GET blob"
+    ~quiet_on_success:false (fun session_id task blob ->
+      HttpGet (filename, blob_uri ~session_id ~task ~blob)
+  )
 
 let blob_put fd _printer rpc session_id params =
   let blob_uuid = List.assoc "uuid" params in
   let blob_ref = Client.Blob.get_by_uuid ~rpc ~session_id ~uuid:blob_uuid in
   let filename = List.assoc "filename" params in
-  let blobtask =
-    Client.Task.create ~rpc ~session_id
-      ~label:(Printf.sprintf "Blob PUT, ref=%s" (Ref.string_of blob_ref))
-      ~description:""
-  in
-  Client.Task.set_progress ~rpc ~session_id ~self:blobtask ~value:(-1.0) ;
-  let bloburi =
-    Printf.sprintf "%s?session_id=%s&task_id=%s&ref=%s" Constants.blob_uri
-      (Ref.string_of session_id) (Ref.string_of blobtask)
-      (Ref.string_of blob_ref)
-  in
-  finally
-    (fun () ->
-      marshal fd (Command (HttpPut (filename, bloburi))) ;
-      let response = ref (Response Wait) in
-      while !response = Response Wait do
-        response := unmarshal fd
-      done ;
-      let ok =
-        match !response with
-        | Response OK ->
-            true
-        | Response Failed ->
-            if Client.Task.get_progress ~rpc ~session_id ~self:blobtask < 0.0
-            then
-              Client.Task.set_status ~rpc ~session_id ~self:blobtask
-                ~value:`failure ;
-            false
-        | _ ->
-            false
-      in
-      wait_for_task_complete rpc session_id blobtask ;
-      (* if the client thinks it's ok, check that the server does too *)
-      check_task_status ~rpc ~session_id ~task:blobtask ~fd ~label:"Blob put"
-        ~ok ()
-    )
-    (fun () -> Client.Task.destroy ~rpc ~session_id ~self:blobtask)
+  command_in_task ~rpc ~session_id ~fd ~obj:blob_ref ~label:"PUT blob"
+    ~quiet_on_success:false (fun session_id task blob ->
+      HttpPut (filename, blob_uri ~session_id ~task ~blob)
+  )
 
 let blob_create printer rpc session_id params =
   let name = List.assoc "name" params in
@@ -7655,49 +7635,16 @@ let get_avail_updates_uri ~session_id ~task ~host =
   in
   Uri.make ~path:Constants.get_updates_uri ~query () |> Uri.to_string
 
-let command_in_task ~rpc ~session_id ~fd ~host ~label f =
-  let task =
-    Client.Task.create ~rpc ~session_id
-      ~label:(Printf.sprintf "%s for host (ref=%s)" label (Ref.string_of host))
-      ~description:""
-  in
-  Client.Task.set_progress ~rpc ~session_id ~self:task ~value:(-1.0) ;
-  let command = f session_id task host in
-  finally
-    (fun () ->
-      marshal fd (Command command) ;
-      let response = ref (Response Wait) in
-      while !response = Response Wait do
-        response := unmarshal fd
-      done ;
-      let ok =
-        match !response with
-        | Response OK ->
-            true
-        | Response Failed ->
-            (* Need to check whether the thin cli managed to contact the server
-             * or not. If not, we need to mark the task as failed.
-             *)
-            if Client.Task.get_progress ~rpc ~session_id ~self:task < 0.0 then
-              Client.Task.set_status ~rpc ~session_id ~self:task ~value:`failure ;
-            false
-        | _ ->
-            false
-      in
-      wait_for_task_complete rpc session_id task ;
-      check_task_status ~rpc ~session_id ~task ~fd ~label ~ok
-        ~quiet_on_success:true ()
-    )
-    (fun () -> Client.Task.destroy ~rpc ~session_id ~self:task)
-
 let print_avail_updates ~rpc ~session_id ~fd ~host =
-  command_in_task ~rpc ~session_id ~fd ~host ~label:"Print available updates"
+  command_in_task ~rpc ~session_id ~fd ~obj:host
+    ~label:"Print available updates for host" ~quiet_on_success:true
     (fun session_id task host ->
       PrintHttpGetJson (get_avail_updates_uri ~session_id ~task ~host)
   )
 
 let print_update_guidance ~rpc ~session_id ~fd ~host =
-  command_in_task ~rpc ~session_id ~fd ~host ~label:"Print update guidance"
+  command_in_task ~rpc ~session_id ~fd ~obj:host
+    ~label:"Print update guidance for host" ~quiet_on_success:true
     (fun session_id task host ->
       PrintUpdateGuidance (get_avail_updates_uri ~session_id ~task ~host)
   )

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -5462,40 +5462,17 @@ let wait_for_task_complete rpc session_id task_id =
     Thread.delay 1.0
   done
 
-let download_file rpc session_id task fd filename uri label =
-  marshal fd (Command (HttpGet (filename, uri))) ;
-  let response = ref (Response Wait) in
-  while !response = Response Wait do
-    response := unmarshal fd
-  done ;
-  let ok =
-    match !response with
-    | Response OK ->
-        true
-    | Response Failed ->
-        (* Need to check whether the thin cli managed to contact the server
-           				   or not. If not, we need to mark the task as failed *)
-        if Client.Task.get_progress ~rpc ~session_id ~self:task < 0.0 then
-          Client.Task.set_status ~rpc ~session_id ~self:task ~value:`failure ;
-        false
-    | _ ->
-        false
-  in
-  wait_for_task_complete rpc session_id task ;
-  (* Check the server status -- even if the client thinks it's ok, we need
-     	   to check that the server does too. *)
+let check_task_status ~rpc ~session_id ~task ~fd ~label ~ok =
+  (* if the client thinks it's ok, check that the server does too *)
   match Client.Task.get_status ~rpc ~session_id ~self:task with
+  | `success when ok ->
+      marshal fd (Command (Print (Printf.sprintf "%s succeeded" label)))
   | `success ->
-      if ok then (
-        if filename <> "" then
-          marshal fd (Command (Print (Printf.sprintf "%s succeeded" label)))
-      ) else (
-        marshal fd
-          (Command
-             (PrintStderr (Printf.sprintf "%s failed, unknown error.\n" label))
-          ) ;
-        raise (ExitWithError 1)
-      )
+      marshal fd
+        (Command
+           (PrintStderr (Printf.sprintf "%s failed, unknown error.\n" label))
+        ) ;
+      raise (ExitWithError 1)
   | `failure ->
       let result = Client.Task.get_error_info ~rpc ~session_id ~self:task in
       if result = [] then
@@ -5512,6 +5489,32 @@ let download_file rpc session_id task fd filename uri label =
       marshal fd (Command (PrintStderr "Internal error\n")) ;
       (* should never happen *)
       raise (ExitWithError 1)
+
+let download_file rpc session_id task fd filename uri label =
+  marshal fd (Command (HttpGet (filename, uri))) ;
+  let response = ref (Response Wait) in
+  while !response = Response Wait do
+    response := unmarshal fd
+  done ;
+  let ok =
+    match (!response, filename <> "") with
+    | Response OK, true ->
+        true
+    | Response OK, false ->
+        false
+    | Response Failed, _ ->
+        (* Need to check whether the thin cli managed to contact the server
+           				   or not. If not, we need to mark the task as failed *)
+        if Client.Task.get_progress ~rpc ~session_id ~self:task < 0.0 then
+          Client.Task.set_status ~rpc ~session_id ~self:task ~value:`failure ;
+        false
+    | _ ->
+        false
+  in
+  wait_for_task_complete rpc session_id task ;
+  (* Check the server status -- even if the client thinks it's ok, we need
+     	   to check that the server does too. *)
+  check_task_status ~rpc ~session_id ~task ~fd ~label ~ok
 
 let download_file_with_task fd rpc session_id filename uri query label task_name
     =
@@ -5711,31 +5714,8 @@ let blob_get fd _printer rpc session_id params =
             false
       in
       wait_for_task_complete rpc session_id blobtask ;
-      (* if the client thinks it's ok, check that the server does too *)
-      match Client.Task.get_status ~rpc ~session_id ~self:blobtask with
-      | `success ->
-          if ok then
-            marshal fd (Command (Print "Blob get succeeded"))
-          else (
-            marshal fd
-              (Command (PrintStderr "Blob get failed, unknown error.\n")) ;
-            raise (ExitWithError 1)
-          )
-      | `failure ->
-          let result =
-            Client.Task.get_error_info ~rpc ~session_id ~self:blobtask
-          in
-          if result = [] then
-            marshal fd (Command (PrintStderr "Blob get failed, unknown error\n"))
-          else
-            raise (Api_errors.Server_error (List.hd result, List.tl result))
-      | `cancelled ->
-          marshal fd (Command (PrintStderr "Blob get cancelled\n")) ;
-          raise (ExitWithError 1)
-      | _ ->
-          marshal fd (Command (PrintStderr "Internal error\n")) ;
-          (* should never happen *)
-          raise (ExitWithError 1)
+      check_task_status ~rpc ~session_id ~task:blobtask ~fd ~label:"Blob get"
+        ~ok
     )
     (fun () -> Client.Task.destroy ~rpc ~session_id ~self:blobtask)
 
@@ -5776,30 +5756,8 @@ let blob_put fd _printer rpc session_id params =
       in
       wait_for_task_complete rpc session_id blobtask ;
       (* if the client thinks it's ok, check that the server does too *)
-      match Client.Task.get_status ~rpc ~session_id ~self:blobtask with
-      | `success ->
-          if ok then
-            marshal fd (Command (Print "Blob put succeeded"))
-          else (
-            marshal fd
-              (Command (PrintStderr "Blob put failed, unknown error.\n")) ;
-            raise (ExitWithError 1)
-          )
-      | `failure ->
-          let result =
-            Client.Task.get_error_info ~rpc ~session_id ~self:blobtask
-          in
-          if result = [] then
-            marshal fd (Command (PrintStderr "Blob put failed, unknown error\n"))
-          else
-            raise (Api_errors.Server_error (List.hd result, List.tl result))
-      | `cancelled ->
-          marshal fd (Command (PrintStderr "Blob put cancelled\n")) ;
-          raise (ExitWithError 1)
-      | _ ->
-          marshal fd (Command (PrintStderr "Internal error\n")) ;
-          (* should never happen *)
-          raise (ExitWithError 1)
+      check_task_status ~rpc ~session_id ~task:blobtask ~fd ~label:"Blob put"
+        ~ok
     )
     (fun () -> Client.Task.destroy ~rpc ~session_id ~self:blobtask)
 

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -435,6 +435,38 @@ let assert_filename_permitted ?(permit_cwd = false) permitted_filenames filename
   | _ ->
       ()
 
+let do_http_get ofd url exit_code f =
+  try
+    let rec doit url =
+      let server, path = parse_url url in
+      debug "Opening connection to server '%s' path '%s'\n%!" server path ;
+      with_open_tcp server @@ fun (ic, oc) ->
+      Printf.fprintf oc "GET %s HTTP/1.0\r\n\r\n" path ;
+      flush oc ;
+      (* Get the result header immediately *)
+      let resultline = input_line ic in
+      debug "Got %s\n%!" resultline ;
+      match http_response_code resultline with
+      | 200 ->
+          f ic ; marshal ofd (Response OK)
+      | 302 ->
+          let headers = read_rest_of_headers ic in
+          let newloc = List.assoc "location" headers in
+          (* see above about Unixfd.with_connection *)
+          close_in_noerr ic ; close_out_noerr oc ; doit newloc
+      | _ ->
+          failwith "Unhandled response code"
+    in
+    doit url
+  with
+  | ClientSideError msg ->
+      marshal ofd (Response Failed) ;
+      Printf.fprintf stderr "Operation failed. Error: %s\n" msg ;
+      exit_code := Some 1
+  | e ->
+      debug "HTTP GET failure: %s\n%!" (Printexc.to_string e) ;
+      marshal ofd (Response Failed)
+
 let main_loop ifd ofd permitted_filenames =
   (* Intially exchange version information *)
   let major', minor' =
@@ -709,64 +741,28 @@ let main_loop ifd ofd permitted_filenames =
                the normal communication channel *)
             marshal ofd (Response Failed)
       )
-    | Command (HttpGet (filename, url)) -> (
-      try
-        let rec doit url =
-          let server, path = parse_url url in
-          debug "Opening connection to server '%s' path '%s'\n%!" server path ;
-          with_open_tcp server @@ fun (ic, oc) ->
-          Printf.fprintf oc "GET %s HTTP/1.0\r\n\r\n" path ;
-          flush oc ;
-          (* Get the result header immediately *)
-          let resultline = input_line ic in
-          debug "Got %s\n%!" resultline ;
-          match http_response_code resultline with
-          | 200 ->
-              let file_ch =
-                if filename = "" then
-                  Unix.out_channel_of_descr (Unix.dup Unix.stdout)
-                else (
-                  assert_filename_permitted ~permit_cwd:true permitted_filenames
-                    filename ;
-                  try
-                    open_out_gen
-                      [Open_wronly; Open_creat; Open_excl]
-                      0o600 filename
-                  with e -> raise (ClientSideError (Printexc.to_string e))
-                )
-              in
-              while input_line ic <> "\r" do
-                ()
-              done ;
-              Pervasiveext.finally
-                (fun () ->
-                  copy_with_heartbeat ic file_ch heartbeat_fun ;
-                  marshal ofd (Response OK)
-                )
-                (fun () -> try close_out file_ch with _ -> ())
-          | 302 ->
-              let headers = read_rest_of_headers ic in
-              let newloc = List.assoc "location" headers in
-              (* see above about Unixfd.with_connection *)
-              close_in_noerr ic ; close_out_noerr oc ; doit newloc
-          | _ ->
-              failwith "Unhandled response code"
-        in
-        doit url
-      with
-      | ClientSideError msg ->
-          marshal ofd (Response Failed) ;
-          Printf.fprintf stderr "Operation failed. Error: %s\n" msg ;
-          exit_code := Some 1
-      | e -> (
-        match e with
-        | Filename_not_permitted _ ->
-            raise e
-        | _ ->
-            debug "HttpGet failure: %s\n%!" (Printexc.to_string e) ;
-            marshal ofd (Response Failed)
-      )
-    )
+    | Command (HttpGet (filename, url)) ->
+        do_http_get ofd url exit_code (fun ic ->
+            let file_ch =
+              if filename = "" then
+                Unix.out_channel_of_descr (Unix.dup Unix.stdout)
+              else (
+                assert_filename_permitted ~permit_cwd:true permitted_filenames
+                  filename ;
+                try
+                  open_out_gen
+                    [Open_wronly; Open_creat; Open_excl]
+                    0o600 filename
+                with e -> raise (ClientSideError (Printexc.to_string e))
+              )
+            in
+            while input_line ic <> "\r" do
+              ()
+            done ;
+            Pervasiveext.finally
+              (fun () -> copy_with_heartbeat ic file_ch heartbeat_fun)
+              (fun () -> try close_out file_ch with _ -> ())
+        )
     | Command Prompt ->
         let data = input_line stdin in
         marshal ofd (Blob (Chunk (Int32.of_int (String.length data)))) ;

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -763,6 +763,16 @@ let main_loop ifd ofd permitted_filenames =
               (fun () -> copy_with_heartbeat ic file_ch heartbeat_fun)
               (fun () -> try close_out file_ch with _ -> ())
         )
+    | Command (PrintHttpGetJson url) ->
+        do_http_get ofd url exit_code (fun ic ->
+            while input_line ic <> "\r" do
+              ()
+            done ;
+            Yojson.Basic.from_channel ic
+            |> Yojson.Basic.pretty_to_string
+            |> print_endline ;
+            flush stdout
+        )
     | Command Prompt ->
         let data = input_line stdin in
         marshal ofd (Blob (Chunk (Int32.of_int (String.length data)))) ;

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,7 +3,7 @@
 set -e
 
 list-hd () {
-  N=317
+  N=315
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD List.hd usages"


### PR DESCRIPTION
To facilitate the users who use XE CLI to perform update, a new XE CLI "xe host-show-updates" is added in this series to show the available updates on a host. Prior to this change, the information can be get from XAPI HTTP /updates endpoint. In addition, the available updates will be printed out in existing "xe host-apply-updates".