### PR TITLE
CA-385065 VM import with VTPM, don't block on power state

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -1886,7 +1886,7 @@ module VTPM : HandlerTools = struct
             (lookup vtpm'.vTPM'_VM) state.table
         in
         let self =
-          Xapi_vtpm.create ~__context ~vM:vm ~is_unique:vtpm'.vTPM'_is_unique
+          Xapi_vtpm.import ~__context ~vM:vm ~is_unique:vtpm'.vTPM'_is_unique
         in
         (* there is no API to set the protected field *)
         Db.VTPM.set_is_protected ~__context ~self

--- a/ocaml/xapi/xapi_vtpm.ml
+++ b/ocaml/xapi/xapi_vtpm.ml
@@ -59,14 +59,21 @@ let copy_or_create_contents ~__context ?from () =
   in
   Option.fold ~none:(create ()) ~some:maybe_copy from
 
-let create ~__context ~vM ~is_unique =
+let create' ~import ~__context ~vM ~is_unique =
   let persistence_backend = `xapi in
   assert_not_restricted ~__context ;
   assert_no_vtpm_associated ~__context vM ;
-  Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self:vM
-    ~expected:`Halted ;
+  if not import then
+    Xapi_vm_lifecycle.assert_initial_power_state_is ~__context ~self:vM
+      ~expected:`Halted ;
   let contents = copy_or_create_contents ~__context () in
   introduce ~__context ~vM ~persistence_backend ~contents ~is_unique
+
+let create ~__context ~vM ~is_unique =
+  create' ~import:false ~__context ~vM ~is_unique
+
+let import ~__context ~vM ~is_unique =
+  create' ~import:true ~__context ~vM ~is_unique
 
 let copy ~__context ~vM ref =
   let vtpm = Db.VTPM.get_record ~__context ~self:ref in

--- a/ocaml/xapi/xapi_vtpm.mli
+++ b/ocaml/xapi/xapi_vtpm.mli
@@ -15,6 +15,9 @@
 val create :
   __context:Context.t -> vM:[`VM] API.Ref.t -> is_unique:bool -> [`VTPM] Ref.t
 
+val import :
+  __context:Context.t -> vM:[`VM] API.Ref.t -> is_unique:bool -> [`VTPM] Ref.t
+
 val assert_no_vtpm_associated : __context:Context.t -> [`VM] API.Ref.t -> unit
 
 val copy :


### PR DESCRIPTION
An imported VM can have a power state different from halted. So far we enforced that a VM is halted when creating a VTPM for it. In the case of import we want to relax this because the VM is not actually running.

This might not be the best solution. In essence, when importing a VM we have to ignore its power state when creating a VTPM for it. This is also being tested after some initial testing by me.