### PR TITLE
CA-386457: fix environment variable loading of `$PERFMON_FLAGS` in perfmon.service

### DIFF
--- a/scripts/sysconfig-perfmon
+++ b/scripts/sysconfig-perfmon
@@ -3,26 +3,22 @@
 # /etc/init.d/perfmon and used to construct the command line
 # arguments to pass to @OPTDIR@/bin/perfmon.
 
-# uncomment lines to enable options.
-
-PERFMON_FLAGS=""
-
 # send lots of debug to /var/log/messages
-#PERFMON_FLAGS="$PERFMON_FLAGS --debug"
+#PERFMON_FLAGS=" --debug"
 
 # change loop time from default of 5 minutes to 1 minute
-#PERFMON_FLAGS="$PERFMON_FLAGS --interval=60"
+#PERFMON_FLAGS=" --interval=60"
 
 # Tell perfmon to request "5 second averages" from XAPI.  By default
 # it requests "60 second averages" from XAPI.  The only valid options
 # are 5 or 60.
-#PERFMON_FLAGS="$PERFMON_FLAGS --rrdstep=5"
+#PERFMON_FLAGS=" --rrdstep=5"
 
 #####################################################################
 # Advanced
 
 # run only 10 loops then exit
-#PERFMON_FLAGS="$PERFMON_FLAGS --numloops=10"
+#PERFMON_FLAGS=" --numloops=10"
 
 # Re-read the perfmon configuration for the host and all VMs
 # every 10 minutes, instead of the default of every 1/2 hour.
@@ -30,9 +26,20 @@ PERFMON_FLAGS=""
 #
 # (Note: XenCenter also "pushes" config changes so this is only a 
 # failsafe!)
-#PERFMON_FLAGS="$PERFMON_FLAGS --config_update_period=600"
+#PERFMON_FLAGS=" --config_update_period=600"
 
 # Change the dither on each loop period from the default of 5% to 10%.
 # This is purely to prevent slaves becoming synchronised and
 # making requests to the master at the same time.
-#PERFMON_FLAGS="$PERFMON_FLAGS --interval_percent_dither=10"
+#PERFMON_FLAGS=" --interval_percent_dither=10"
+
+#####################################################################
+# Caution
+
+# Variable expansion is not performed inside the strings
+# and the "$" character has no special meaning in the EnvironmentFile of service. 
+# So we couldn't use `PERFMON_FLAGS="$PERFMON_FLAGS Options"` here,
+# we must put desired options in a line, for example:
+# PERFMON_FLAGS="--debug --interval=60 --rrdstep=5 --numloops=10 --config_update_period=600"
+
+PERFMON_FLAGS=""


### PR DESCRIPTION
For example, we set the `$PERFMON_FLAGS` in scripts/sysconfig-perfmon:
```bash
PERFMON_FLAGS=""
PERFMON_FLAGS="$PERFMON_FLAGS --debug"
PERFMON_FLAGS="$PERFMON_FLAGS --interval=60"
PERFMON_FLAGS="$PERFMON_FLAGS --rrdstep=5"
```
What we ultimately want the value of `PERFMON_FLAGS` is `--debug --interval=60 --rrdstep=5`, then pass `PERFMON_FLAGS` to @OPTDIR@/bin/perfmon.

But there are some limits in EnvironmentFile of service in the [document of systemd](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Environment):
> Variable expansion is not performed inside the strings and the "$" character has no special meaning.
>
> Settings from these files override settings made with Environment=. If the same variable is set twice from these files, the files will be read in the order they are specified and the later setting will override the earlier setting.

So if we configure the EnvironmentFile in perfmon.service, what we will only get is `$PERFMON_FLAGS --rrdstep=5` in fact.