### PR TITLE
CP-43875: Record the repository hash on the host object when updating

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2176,6 +2176,10 @@ let t =
              user should follow to make some updates, e.g. specific hardware \
              drivers or CPU features, fully effective, but the 'average user' \
              doesn't need to"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:String
+            ~default_value:(Some (VString "")) "last_update_hash"
+            "The SHA256 checksum of updateinfo of the most recently applied \
+             update on the host"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -2,7 +2,7 @@ let hash x = Digest.string x |> Digest.to_hex
 
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
-let last_known_schema_hash = "9c650ad57273c375b9f82f26f82aa75f"
+let last_known_schema_hash = "a2378b3ff9c452cb61f0cab7d9f84a46"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -211,7 +211,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~tls_verification_enabled
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
     ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
-    ~pending_guidances_recommended:[] ~pending_guidances_full:[] ;
+    ~pending_guidances_recommended:[] ~pending_guidances_full:[]
+    ~last_update_hash:"" ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3256,6 +3256,9 @@ let host_record rpc session_id host =
               (x ()).API.host_pending_guidances_full
           )
           ()
+      ; make_field ~name:"last-update-hash"
+          ~get:(fun () -> (x ()).API.host_last_update_hash)
+          ()
       ]
   }
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1062,7 +1062,7 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled ~last_software_update ~recommended_guidances:[]
     ~latest_synced_updates_applied:`unknown ~pending_guidances_recommended:[]
-    ~pending_guidances_full:[] ;
+    ~pending_guidances_full:[] ~last_update_hash:"" ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics
     ~value:(Date.of_float (Unix.gettimeofday ())) ;
@@ -3018,6 +3018,7 @@ let apply_updates ~__context ~self ~hash =
   Db.Host.set_last_software_update ~__context ~self
     ~value:(get_servertime ~__context ~host:self) ;
   Db.Host.set_latest_synced_updates_applied ~__context ~self ~value:`yes ;
+  Db.Host.set_last_update_hash ~__context ~self ~value:hash ;
   warnings
 
 let cc_prep () =


### PR DESCRIPTION
Add field "last_update_hash" on host object to record the SHA256 checksum of updateinfo of the most recently applied update on the host.