### PR TITLE
Call resume fast if an exception occurs during migration

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -827,6 +827,22 @@ let unpause =
       ]
     ~allowed_roles:_R_VM_OP ()
 
+(* VM.ResumeFast *)
+
+let resumeFast =
+  call ~in_product_since:rel_rio ~name:"resume_fast"
+    ~doc:
+      "Resume the specified VM cooperatively. This can only be called when the \
+       specified VM is in the Suspended state."
+    ~params:[(Ref _vm, "vm", "The VM to resume fast")]
+    ~errs:
+      [
+        Api_errors.vm_bad_power_state
+      ; Api_errors.operation_not_allowed
+      ; Api_errors.vm_is_template
+      ]
+    ~allowed_roles:_R_VM_OP ()
+
 (* VM.CleanShutdown *)
 
 let cleanShutdown =

--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -737,6 +737,10 @@ module XenopsAPI (R : RPC) = struct
       declare "VM.unpause" []
         (debug_info_p @-> vm_id_p @-> returning task_id_p err)
 
+    let resume_fast =
+      declare "VM.resume_fast" []
+        (debug_info_p @-> vm_id_p @-> returning task_id_p err)
+
     let request_rdp =
       let enabled_p = Param.mk ~name:"enabled" Types.bool in
       declare "VM.request_rdp" []

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -197,6 +197,7 @@ let callback1 ?(json_rpc_version = Jsonrpc.V1) is_json req fd call =
   (* if we're a master or slave and whether the call came in on the unix domain socket or the tcp socket *)
   (* If we're a slave, and the call is from the unix domain socket or from the HIMN, and the call *isn't* *)
   (* in the whitelist, then forward *)
+  let _ = D.info "call.Rpc.name is %s" call.Rpc.name in
   let whitelisted = List.mem call.Rpc.name whitelist in
   let emergency_call = List.mem call.Rpc.name emergency_call_list in
   let is_slave = not (Pool_role.is_master ()) in

--- a/ocaml/xenopsd/lib/xenops_server_plugin.ml
+++ b/ocaml/xenopsd/lib/xenops_server_plugin.ml
@@ -118,6 +118,8 @@ module type S = sig
 
     val unpause : Xenops_task.task_handle -> Vm.t -> unit
 
+    val resume_fast : Xenops_task.task_handle -> Vm.t -> unit
+
     val set_xsdata :
       Xenops_task.task_handle -> Vm.t -> (string * string) list -> unit
 

--- a/ocaml/xenopsd/lib/xenops_server_skeleton.ml
+++ b/ocaml/xenopsd/lib/xenops_server_skeleton.ml
@@ -77,6 +77,8 @@ module VM = struct
 
   let unpause _ _ = unimplemented "VM.unpause"
 
+  let resume_fast _ _ = unimplemented "VM.resume_fast"
+
   let set_xsdata _ _ _ = unimplemented "VM.set_xsdata"
 
   let set_vcpus _ _ _ = unimplemented "VM.set_vcpus"

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -770,6 +770,11 @@ let pause ~xc domid = Xenctrl.domain_pause xc domid
 
 let unpause ~xc domid = Xenctrl.domain_unpause xc domid
 
+let resume_fast ~xc domid =
+  let uuid = get_uuid ~xc domid in
+  debug "VM = %s; domid = %d; calling resume fast" (Uuidx.to_string uuid) domid ;
+  Xenctrl.domain_resume_fast xc domid
+
 let set_action_request ~xs domid x =
   let path = xs.Xs.getdomainpath domid ^ "/action-request" in
   match x with None -> xs.Xs.rm path | Some v -> xs.Xs.write path v

--- a/ocaml/xenopsd/xc/domain.mli
+++ b/ocaml/xenopsd/xc/domain.mli
@@ -209,6 +209,9 @@ val pause : xc:Xenctrl.handle -> domid -> unit
 val unpause : xc:Xenctrl.handle -> domid -> unit
 (** Unpause a domain *)
 
+val resume_fast : xc:Xenctrl.handle -> domid -> unit
+(** Resume fast a domain *)
+
 val set_action_request : xs:Xenstore.Xs.xsh -> domid -> string option -> unit
 (** [set_action_request xs domid None] declares this domain is fully intact. Any
     other string is a hint to the toolstack that the domain is still broken. *)

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -1786,6 +1786,15 @@ module VM = struct
         Domain.unpause ~xc di.Xenctrl.domid
     )
 
+  (** To be able to call resume fast the domain should have been suspended so we
+      need to ensure that it is the case. Fast resume is calling resume cooperative.
+      This can only be used for guests which can handle the special return code. *)
+  let resume_fast t vm =
+    on_domain t vm (fun xc _ _ _ di ->
+        (* TODO: check if we can get info in xenstore that the VM supports fast resume *)
+        Domain.resume_fast ~xc di.Xenctrl.domid
+    )
+
   let set_xsdata task vm xsdata =
     on_domain task vm (fun _ xs _ _ di ->
         Domain.set_xsdata ~xs di.Xenctrl.domid xsdata


### PR DESCRIPTION
Hello,

I have a look to use domain resume fast. So if an exception is raised when performing the migration of a VM we call resume fast to resume the VM on the original host if the VM is in suspended state. Based on some previous work done in #4746 I started to write this piece of code. I have some issue for testing it. I tried to introduce an error in the handshake during the migration but unfortunately the VM resume on the original host without the need to trigger the resume fast. To be more accurate I just replace the success arm of the match of the [point 4 of the synchronisation](https://github.com/xapi-project/xen-api/blob/master/ocaml/xenopsd/lib/xenops_server.ml#L2723) to also raise an exception. The migration failed as expected but the VM was just still running on the original host without calling fast resume. I guess that it is not the right way to test it and I just de-synchronized both hosts...

Any comments about the patch is welcome but also a way for testing it will be welcome :)