### PR TITLE
CP-47153 add task list to bugtool

### DIFF
--- a/scripts/bugtool-plugin/xapi/stuff.xml
+++ b/scripts/bugtool-plugin/xapi/stuff.xml
@@ -13,4 +13,5 @@
 <command label="xapi_cert">cat @ETCXENDIR@/xapi-ssl.pem | @BINDIR@/openssl x509 -text</command>
 <command label="xapi_pool_cert">cat @ETCXENDIR@/xapi-pool-tls.pem | @BINDIR@/openssl x509 -text</command>
 <command label="save_rrd">rrd-cli save_rrds</command>
+<command label="task_list">@OPTDIR@/bin/xe task-list params=all</command>
 </collect>


### PR DESCRIPTION
The xapi database holds task but this table is not persisted. In conjuction with XSI-1559 it would be useful to have the currently active tasks. Add the output of "xe task-list" to the bugtool.

This was manually tested. In the typical case the task list is empty. So this adds no weight to the bugtool.