### PR TITLE
CP-46323: Expose quorum and cluster membership through the API

### DIFF
--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -194,6 +194,15 @@ let t =
              (Some (VString Constants.default_smapiv3_cluster_stack))
            "Simply the string 'corosync'. No other cluster stacks are \
             currently supported"
+       ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool "is_quorate"
+           ~default_value:(Some (VBool false))
+           "Whether the cluster stack thinks the cluster is quorate"
+       ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "quorum"
+           ~default_value:(Some (VInt 0L))
+           "Number of live hosts in order to be quorate"
+       ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "live_hosts"
+           ~default_value:(Some (VInt 0L))
+           "Current number of live hosts, according to the cluster stack"
        ]
       @ allowed_and_current_operations cluster_operation
       @ [

--- a/ocaml/idl/datamodel_cluster_host.ml
+++ b/ocaml/idl/datamodel_cluster_host.ml
@@ -103,17 +103,24 @@ let t =
            "Reference to the Cluster object"
        ; field ~qualifier:StaticRO ~lifecycle ~ty:(Ref _host) "host"
            ~default_value:(Some (VRef null_ref)) "Reference to the Host object"
-       ; field ~qualifier:StaticRO ~lifecycle ~ty:Bool "enabled"
+       ; field ~qualifier:DynamicRO ~lifecycle ~ty:Bool "enabled"
            ~default_value:(Some (VBool false))
            "Whether the cluster host believes that clustering should be \
-            enabled on this host"
+            enabled on this host. This field can be altered by calling the \
+            enable/disable message on a cluster host. Only enabled members run \
+            the underlying cluster stack. Disabled members are still \
+            considered a member of the cluster (see joined), and can be \
+            re-enabled by the user."
        ; field ~qualifier:StaticRO ~lifecycle ~ty:(Ref _pif) "PIF"
            ~default_value:(Some (VRef null_ref)) "Reference to the PIF object"
-       ; field ~qualifier:StaticRO ~lifecycle ~ty:Bool "joined"
+       ; field ~qualifier:DynamicRO ~lifecycle ~ty:Bool "joined"
            ~default_value:(Some (VBool true))
-           "Whether the cluster host has joined the cluster"
-         (* TODO: add `live` member to represent whether corosync believes that this
-                  cluster host actually is enabled *)
+           "Whether the cluster host has joined the cluster. Contrary to \
+            enabled, a host that is not joined is not considered a member of \
+            the cluster, and hence no operations (e.g. enable/disable) can be \
+            performed on this host. This field can be altered by calling leave \
+            or destroy on a cluster host. It can also be set automatically if \
+            cluster stack believes that this node is not part of the cluster. "
        ]
       @ allowed_and_current_operations cluster_host_operation
       @ [

--- a/ocaml/idl/datamodel_cluster_host.ml
+++ b/ocaml/idl/datamodel_cluster_host.ml
@@ -121,6 +121,15 @@ let t =
             performed on this host. This field can be altered by calling leave \
             or destroy on a cluster host. It can also be set automatically if \
             cluster stack believes that this node is not part of the cluster. "
+       ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool "live"
+           ~default_value:(Some (VBool false))
+           "Whether the underlying cluster stack thinks we are live. This \
+            field is set automatically based on updates from the cluster stack \
+            and cannot be altered by the user."
+       ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
+           "last_update_live" ~default_value:(Some (VDateTime Date.epoch))
+           "Time when the live field was last updated based on information \
+            from the cluster stack"
        ]
       @ allowed_and_current_operations cluster_host_operation
       @ [

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 772
+let schema_minor_vsn = 773
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -21,6 +21,16 @@ let prototyped_of_field = function
       Some "23.14.0"
   | "Repository", "gpgkey_path" ->
       Some "22.12.0"
+  | "Cluster_host", "last_update_live" ->
+      Some "24.2.1-next"
+  | "Cluster_host", "live" ->
+      Some "24.2.1-next"
+  | "Cluster", "live_hosts" ->
+      Some "24.2.1-next"
+  | "Cluster", "quorum" ->
+      Some "24.2.1-next"
+  | "Cluster", "is_quorate" ->
+      Some "24.2.1-next"
   | "VTPM", "contents" ->
       Some "22.26.0"
   | "VTPM", "is_protected" ->

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -30,7 +30,7 @@ let prototyped_of_field = function
   | "VTPM", "persistence_backend" ->
       Some "22.26.0"
   | "host", "numa_affinity_policy" ->
-      Some "23.32.0-next"
+      Some "24.2.1"
   | "host", "latest_synced_updates_applied" ->
       Some "23.18.0"
   | "host", "recommended_guidances" ->
@@ -66,7 +66,7 @@ let prototyped_of_field = function
   | "pool", "migration_compression" ->
       Some "22.33.0"
   | "pool", "custom_uefi_certificates" ->
-      Some "23.32.0-next"
+      Some "24.2.1"
   | _ ->
       None
 
@@ -104,7 +104,7 @@ let prototyped_of_message = function
   | "host", "set_https_only" ->
       Some "22.27.0"
   | "host", "set_numa_affinity_policy" ->
-      Some "23.32.0-next"
+      Some "24.2.1"
   | "VM", "restart_device_models" ->
       Some "23.30.0"
   | "pool", "set_ext_auth_max_threads" ->
@@ -122,6 +122,6 @@ let prototyped_of_message = function
   | "pool", "set_https_only" ->
       Some "22.27.0"
   | "pool", "set_custom_uefi_certificates" ->
-      Some "23.32.0-next"
+      Some "24.2.1"
   | _ ->
       None

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "ab570d662d657ee2055194110d536302"
+let last_known_schema_hash = "f10afca39b85b1c9fd7554b09f749fa5"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "f10afca39b85b1c9fd7554b09f749fa5"
+let last_known_schema_hash = "a3ddab734ad88468120269cf3d0e3bd9"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -620,10 +620,12 @@ let make_vfs_on_pf ~__context ~pf ~num =
 
 let make_cluster_host ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ?(cluster = Ref.null) ?(host = Ref.null) ?(pIF = Ref.null) ?(enabled = true)
-    ?(joined = true) ?(allowed_operations = []) ?(current_operations = [])
-    ?(other_config = []) () =
+    ?(joined = true) ?(live = true) ?(last_update_live = Date.epoch)
+    ?(allowed_operations = []) ?(current_operations = []) ?(other_config = [])
+    () =
   Db.Cluster_host.create ~__context ~ref ~uuid ~cluster ~host ~pIF ~enabled
-    ~allowed_operations ~current_operations ~other_config ~joined ;
+    ~allowed_operations ~current_operations ~other_config ~joined ~live
+    ~last_update_live ;
   ref
 
 let make_cluster_and_cluster_host ~__context ?(ref = Ref.make ())
@@ -633,10 +635,12 @@ let make_cluster_and_cluster_host ~__context ?(ref = Ref.make ())
     ?(pool_auto_join = true)
     ?(token_timeout = Constants.default_token_timeout_s)
     ?(token_timeout_coefficient = Constants.default_token_timeout_coefficient_s)
-    ?(cluster_config = []) ?(other_config = []) ?(host = Ref.null) () =
+    ?(cluster_config = []) ?(other_config = []) ?(host = Ref.null)
+    ?(is_quorate = false) ?(quorum = 0L) ?(live_hosts = 0L) () =
   Db.Cluster.create ~__context ~ref ~uuid ~cluster_token ~pending_forget:[]
     ~cluster_stack ~allowed_operations ~current_operations ~pool_auto_join
-    ~token_timeout ~token_timeout_coefficient ~cluster_config ~other_config ;
+    ~token_timeout ~token_timeout_coefficient ~cluster_config ~other_config
+    ~is_quorate ~quorum ~live_hosts ;
   let cluster_host_ref =
     make_cluster_host ~__context ~cluster:ref ~host ~pIF ()
   in

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -24,6 +24,8 @@ let test_clusterd_rpc ~__context call =
         {success= true; contents= Rpc.String test_token; is_notification= false}
   | ("enable" | "disable" | "destroy" | "leave" | "set-tls-verification"), _ ->
       Rpc.{success= true; contents= Rpc.Null; is_notification= false}
+  | "UPDATES.get", _ ->
+      Rpc.{success= true; contents= Rpc.Null; is_notification= false}
   | ( ( "Observer.create"
       | "Observer.destroy"
       | "Observer.set_enabled"

--- a/ocaml/tests/test_cluster_host.ml
+++ b/ocaml/tests/test_cluster_host.ml
@@ -23,7 +23,8 @@ let create_cluster ~__context pool_auto_join =
     ~token_timeout:Constants.default_token_timeout_s
     ~token_timeout_coefficient:Constants.default_token_timeout_coefficient_s
     ~allowed_operations:[] ~current_operations:[] ~pool_auto_join
-    ~cluster_config:[] ~other_config:[] ~pending_forget:[] ;
+    ~cluster_config:[] ~other_config:[] ~pending_forget:[] ~is_quorate:false
+    ~quorum:0L ~live_hosts:0L ;
   cluster_ref
 
 let check_cluster_option =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5069,6 +5069,15 @@ let cluster_record rpc session_id cluster =
               ~self:cluster ~key
           )
           ()
+      ; make_field ~name:"is-quorate"
+          ~get:(fun () -> Bool.to_string (x ()).API.cluster_is_quorate)
+          ()
+      ; make_field ~name:"quorum"
+          ~get:(fun () -> Int64.to_string (x ()).API.cluster_quorum)
+          ()
+      ; make_field ~name:"live-hosts"
+          ~get:(fun () -> Int64.to_string (x ()).API.cluster_live_hosts)
+          ()
       ]
   }
 
@@ -5109,6 +5118,14 @@ let cluster_host_record rpc session_id cluster_host =
           ()
       ; make_field ~name:"joined"
           ~get:(fun () -> (x ()).API.cluster_host_joined |> string_of_bool)
+          ()
+      ; make_field ~name:"live"
+          ~get:(fun () -> (x ()).API.cluster_host_live |> string_of_bool)
+          ()
+      ; make_field ~name:"last-update-live"
+          ~get:(fun () ->
+            (x ()).API.cluster_host_last_update_live |> Date.to_string
+          )
           ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () ->

--- a/ocaml/xapi-idl/cluster/cluster_interface.ml
+++ b/ocaml/xapi-idl/cluster/cluster_interface.ml
@@ -284,6 +284,21 @@ module LocalAPI (R : RPC) = struct
       @-> returning unit_p err
       )
 
+  module UPDATES = struct
+    open TypeCombinators
+
+    let get =
+      let timeout_p = Param.mk ~name:"timeout" Types.float in
+      let result_p = Param.mk ~name:"updates" (list Types.string) in
+      declare "UPDATES.get"
+        [
+          "Get updates from corosync-notifyd, this blocking call will return \
+           when there is an update from corosync-notifyd or it is timed out \
+           after timeout_p seconds"
+        ]
+        (debug_info_p @-> timeout_p @-> returning result_p err)
+  end
+
   module Observer = struct
     open TypeCombinators
 

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -82,7 +82,9 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
           let verify = Stunnel_client.get_verify_by_default () in
           Xapi_cluster_host.set_tls_config ~__context ~self:cluster_host_ref
             ~verify ;
-
+          (* Create the watcher here in addition to resync_host since pool_create
+             in resync_host only calls cluster_host.create for pool member nodes *)
+          create_cluster_watcher_on_master ~__context ~host ;
           Xapi_cluster_host_helpers.update_allowed_operations ~__context
             ~self:cluster_host_ref ;
           D.debug "Created Cluster: %s and Cluster_host: %s"

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -72,11 +72,12 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
           Db.Cluster.create ~__context ~ref:cluster_ref ~uuid:cluster_uuid
             ~cluster_token ~cluster_stack ~pending_forget:[] ~pool_auto_join
             ~token_timeout ~token_timeout_coefficient ~current_operations:[]
-            ~allowed_operations:[] ~cluster_config:[] ~other_config:[] ;
+            ~allowed_operations:[] ~cluster_config:[] ~other_config:[]
+            ~is_quorate:false ~quorum:0L ~live_hosts:0L ;
           Db.Cluster_host.create ~__context ~ref:cluster_host_ref
             ~uuid:cluster_host_uuid ~cluster:cluster_ref ~host ~enabled:true
             ~pIF ~current_operations:[] ~allowed_operations:[] ~other_config:[]
-            ~joined:true ;
+            ~joined:true ~live:true ~last_update_live:API.Date.epoch ;
 
           let verify = Stunnel_client.get_verify_by_default () in
           Xapi_cluster_host.set_tls_config ~__context ~self:cluster_host_ref

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -194,6 +194,8 @@ let resync_host ~__context ~host =
             (* Note that join_internal and enable both use the clustering lock *)
             Client.Client.Cluster_host.enable ~rpc ~session_id ~self
           ) ;
+          (* create the watcher here so that the watcher exists after toolstack restart *)
+          create_cluster_watcher_on_master ~__context ~host ;
           Xapi_observer.initialise_observer ~__context
             Xapi_observer.Component.Xapi_clusterd ;
           let verify = Stunnel_client.get_verify_by_default () in
@@ -303,6 +305,7 @@ let enable ~__context ~self =
           "Cluster_host.enable: xapi-clusterd not running - attempting to start" ;
         Xapi_clustering.Daemon.enable ~__context
       ) ;
+      create_cluster_watcher_on_master ~__context ~host ;
       Xapi_observer.initialise_observer ~__context
         Xapi_observer.Component.Xapi_clusterd ;
       let verify = Stunnel_client.get_verify_by_default () in

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -63,7 +63,8 @@ let create_internal ~__context ~cluster ~host ~pIF : API.ref_Cluster_host =
       let uuid = Uuidx.(to_string (make ())) in
       Db.Cluster_host.create ~__context ~ref ~uuid ~cluster ~host ~pIF
         ~enabled:false ~current_operations:[] ~allowed_operations:[]
-        ~other_config:[] ~joined:false ;
+        ~other_config:[] ~joined:false ~live:false
+        ~last_update_live:API.Date.epoch ;
       ref
   )
 

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -401,3 +401,120 @@ let compute_corosync_max_host_failures ~__context =
     ((nhosts - disabled_hosts - 1) / 2) + disabled_hosts
   in
   corosync_ha_max_hosts
+
+let on_corosync_update ~__context ~cluster updates =
+  debug
+    "%s: Received %d updates from corosync_notifyd , run diagnostics to get \
+     new state"
+    __FUNCTION__ (List.length updates) ;
+  let m =
+    Cluster_client.LocalClient.diagnostics (rpc ~__context)
+      "update quorum api fields with diagnostics"
+  in
+  match Idl.IdM.run @@ Cluster_client.IDL.T.get m with
+  | Ok diag ->
+      Db.Cluster.set_is_quorate ~__context ~self:cluster ~value:diag.is_quorate ;
+      let all_cluster_hosts = Db.Cluster_host.get_all ~__context in
+      let ip_ch =
+        List.map
+          (fun ch ->
+            let pIF = Db.Cluster_host.get_PIF ~__context ~self:ch in
+            let (Cluster_interface.IPv4 ip) =
+              ip_of_pif (pIF, Db.PIF.get_record ~__context ~self:pIF)
+            in
+            (ip, ch)
+          )
+          all_cluster_hosts
+      in
+      let current_time = API.Date.now () in
+      ( match diag.quorum_members with
+      | None ->
+          List.iter
+            (fun self ->
+              Db.Cluster_host.set_live ~__context ~self ~value:false ;
+              Db.Cluster_host.set_last_update_live ~__context ~self
+                ~value:current_time
+            )
+            all_cluster_hosts
+      | Some nodel ->
+          let quorum_hosts =
+            List.filter_map
+              (fun {addr= IPv4 addr; _} ->
+                match List.assoc_opt addr ip_ch with
+                | None ->
+                    error
+                      "%s: cannot find cluster host with network address %s, \
+                       ignoring this host"
+                      __FUNCTION__ addr ;
+                    None
+                | Some ch ->
+                    Some ch
+              )
+              nodel
+          in
+          let missing_hosts =
+            List.filter
+              (fun h -> not (List.mem h quorum_hosts))
+              all_cluster_hosts
+          in
+          List.iter
+            (fun self ->
+              Db.Cluster_host.set_live ~__context ~self ~value:true ;
+              Db.Cluster_host.set_last_update_live ~__context ~self
+                ~value:current_time
+            )
+            quorum_hosts ;
+          List.iter
+            (fun self ->
+              Db.Cluster_host.set_live ~__context ~self ~value:false ;
+              Db.Cluster_host.set_last_update_live ~__context ~self
+                ~value:current_time
+            )
+            missing_hosts
+      ) ;
+      Db.Cluster.set_quorum ~__context ~self:cluster
+        ~value:(Int64.of_int diag.quorum) ;
+      Db.Cluster.set_live_hosts ~__context ~self:cluster
+        ~value:(Int64.of_int diag.total_votes)
+  | Error (InternalError message) | Error (Unix_error message) ->
+      warn "%s Cannot query diagnostics due to %s, not performing update"
+        __FUNCTION__ message
+  | exception exn ->
+      warn
+        "%s: Got exception %s while retrieving diagnostics info, not \
+         performing update"
+        __FUNCTION__ (Printexc.to_string exn)
+
+let create_cluster_watcher_on_master ~__context ~host =
+  if Helpers.is_pool_master ~__context ~host then (
+    let watch () =
+      while !Daemon.enabled do
+        let m =
+          Cluster_client.LocalClient.UPDATES.get (rpc ~__context)
+            "call cluster watcher" 3.
+        in
+        match Idl.IdM.run @@ Cluster_client.IDL.T.get m with
+        | Ok updates -> (
+          match find_cluster_host ~__context ~host with
+          | Some ch ->
+              let cluster = Db.Cluster_host.get_cluster ~__context ~self:ch in
+              on_corosync_update ~__context ~cluster updates
+          | None ->
+              ()
+        )
+        | Error (InternalError "UPDATES.Timeout") ->
+            (* UPDATES.get timed out, this is normal, now retry *)
+            ()
+        | Error (InternalError message) | Error (Unix_error message) ->
+            warn "%s: Cannot query cluster host updates with error %s"
+              __FUNCTION__ message
+        | exception exn ->
+            warn
+              "%s: Got exception %s while query cluster host updates, retrying"
+              __FUNCTION__ (Printexc.to_string exn) ;
+            Thread.delay 3.
+      done
+    in
+    debug "%s: create watcher for corosync-notifyd on master" __FUNCTION__ ;
+    ignore @@ Thread.create watch ()
+  )


### PR DESCRIPTION
Results look like this:
```bash
$ xe cluster-param-list uuid=690d6398-9f00-9ca9-497d-9ad5d700cdfd    
uuid ( RO)                         : 690d6398-9f00-9ca9-497d-9ad5d700cdfd
                cluster-hosts (SRO): 190aff88-c954-4286-ead7-7c81b3a00bd3; 81efff95-1baa-2801-3397-2b5a4b8c7ec4; 160139e0
-4dc2-be55-3cc8-02812536cd9a
                cluster-token ( RO): b03a7918-2ca7-4d9f-a1a1-5d5391eeaba1
                cluster-stack ( RO): corosync
                token-timeout ( RO): 20.000
    token-timeout-coefficient ( RO): 1.000
           allowed-operations (SRO): destroy; disable; enable; remove; add
           current-operations (SRO):
               pool-auto-join ( RO): true
               cluster-config (MRO):
                 other-config (MRW):
+                   is_quorate ( RO): true
+               quorum_members (SRO): 10.62.49.47; 10.62.49.39; 10.62.49.35
+                       quorum ( RO): 2
+                  total_votes ( RO): 3
```