### PR TITLE
CP-45569: Add API Host.emergency_clear_mandatory_guidance

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7966,6 +7966,7 @@ let emergency_calls =
   ; (Datamodel_host.t, Datamodel_host.emergency_reset_server_certificate)
   ; (Datamodel_host.t, Datamodel_host.emergency_disable_tls_verification)
   ; (Datamodel_host.t, Datamodel_host.emergency_reenable_tls_verification)
+  ; (Datamodel_host.t, Datamodel_host.emergency_clear_mandatory_guidance)
   ]
 
 (** Whitelist of calls that will not get forwarded from the slave to master via the unix domain socket *)

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1779,6 +1779,12 @@ let apply_recommended_guidances =
       ]
     ~allowed_roles:_R_POOL_OP ()
 
+let emergency_clear_mandatory_guidance =
+  call ~flags:[`Session] ~name:"emergency_clear_mandatory_guidance"
+    ~lifecycle:[] ~in_oss_since:None ~params:[]
+    ~doc:"Clear the pending mandatory guidance on this host"
+    ~allowed_roles:_R_LOCAL_ROOT_ONLY ()
+
 let latest_synced_updates_applied_state =
   Enum
     ( "latest_synced_updates_applied_state"
@@ -1932,6 +1938,7 @@ let t =
       ; copy_primary_host_certs
       ; set_https_only
       ; apply_recommended_guidances
+      ; emergency_clear_mandatory_guidance
       ]
     ~contents:
       ([

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1036,6 +1036,17 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Host_selectors]
       }
     )
+  ; ( "host-emergency-clear-mandatory-guidance"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Clear the pending mandatory guidance on this host"
+      ; implementation=
+          No_fd_local_session
+            Cli_operations.host_emergency_clear_mandatory_guidance
+      ; flags= [Neverforward]
+      }
+    )
   ; ( "patch-upload"
     , {
         reqd= ["file-name"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7110,6 +7110,9 @@ let host_reset_server_certificate _printer rpc session_id params =
        params []
     )
 
+let host_emergency_clear_mandatory_guidance _printer rpc session_id _params =
+  Client.Host.emergency_clear_mandatory_guidance ~rpc ~session_id
+
 let host_management_reconfigure _printer rpc session_id params =
   let pif =
     Client.PIF.get_by_uuid ~rpc ~session_id ~uuid:(List.assoc "pif-uuid" params)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4031,6 +4031,10 @@ functor
         do_op_on ~local_fn ~__context ~host:self (fun session_id rpc ->
             Client.Host.set_https_only ~rpc ~session_id ~self ~value
         )
+
+      let emergency_clear_mandatory_guidance ~__context =
+        info "Host.emergency_clear_mandatory_guidance" ;
+        Local.Host.emergency_clear_mandatory_guidance ~__context
     end
 
     module Host_crashdump = struct

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -3048,3 +3048,14 @@ let set_https_only ~__context ~self ~value =
   | true ->
       (* it is illegal changing the firewall/https config in CC/FIPS mode *)
       raise (Api_errors.Server_error (Api_errors.illegal_in_fips_mode, []))
+
+let emergency_clear_mandatory_guidance ~__context =
+  debug "Host.emergency_clear_mandatory_guidance" ;
+  let self = Helpers.get_localhost ~__context in
+  Db.Host.get_pending_guidances ~__context ~self
+  |> List.iter (fun g ->
+         let open Updateinfo.Guidance in
+         let s = g |> of_pending_guidance |> to_string in
+         info "%s: %s is cleared" __FUNCTION__ s
+     ) ;
+  Db.Host.set_pending_guidances ~__context ~self ~value:[]

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -551,3 +551,5 @@ val copy_primary_host_certs : __context:Context.t -> host:API.ref_host -> unit
 
 val set_https_only :
   __context:Context.t -> self:API.ref_host -> value:bool -> unit
+
+val emergency_clear_mandatory_guidance : __context:Context.t -> unit


### PR DESCRIPTION
The non-empty host pending mandatory guidance will result in the host blocked from being enabled or updated. This commit introduces a new API to clear the pending mandatory guidance in emergency cases. Otherwise, the host might be stuck in such a situation.