### PR TITLE
CP-46122: Support PAX/POSIX tar on import

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -2018,6 +2018,56 @@ let assert_filename_is hdr =
     raise (IFailure (Unexpected_file (expected, actual)))
   )
 
+(* We want to read tar headers from a file descriptor (possibly a socket/pipe),
+   and retry with decompression if that fails.
+   To be able to do that we store the first block that we read, and try to parse it with Tar first,
+   and if that fails try zstd/gzip.
+
+   We need a Tar HeaderReader that reads either from a buffer, and then continues reading from an FD
+*)
+module BufferOrFile = struct
+  type in_channel = {
+      mutable buffer: Cstruct.t option
+    ; fd: Unix.file_descr
+    ; retry_with_compression: bool ref
+  }
+
+  type 'a t = 'a
+
+  let make retry_with_compression buffer fd =
+    {buffer= Some buffer; retry_with_compression; fd}
+
+  let really_read t dest =
+    match t.buffer with
+    | Some first ->
+        t.buffer <- None ;
+        assert (Cstruct.length dest = Cstruct.length first) ;
+        Cstruct.blit first 0 dest 0 (Cstruct.length first)
+    | None ->
+        (* if we've successfully parsed the first block as a tar header, then don't retry:
+           we are going to read more from the file anyway.
+        *)
+        t.retry_with_compression := false ;
+        Tar_unix.really_read t.fd dest
+
+  let skip t n =
+    assert (Option.is_none t.buffer) ;
+    (* while reading headers we only skip small distances *)
+    let buf = Cstruct.create n in
+    (* can't seek, because the FD might be a socket/pipe *)
+    Tar_unix.really_read t.fd buf
+end
+
+module Direct = struct
+  type 'a t = 'a
+
+  let ( >>= ) x f = f x
+
+  let return x = x
+end
+
+module TarHeaderReader = Tar.HeaderReader (Direct) (BufferOrFile)
+
 (** Takes an fd and a function, tries first to read the first tar block
     and checks for the existence of 'ova.xml'. If that fails then pipe
     the lot through an appropriate decompressor and try again *)
@@ -2028,7 +2078,10 @@ let with_open_archive fd ?length f =
   try
     Tar_unix.really_read fd buffer ;
     (* we assume the first block is not all zeroes *)
-    let hdr = Option.get (Tar.Header.unmarshal buffer) in
+    let hdr =
+      TarHeaderReader.read (BufferOrFile.make retry_with_compression buffer fd)
+      |> Result.get_ok
+    in
     assert_filename_is hdr ;
     (* successfully opened uncompressed stream *)
     retry_with_compression := false ;


### PR DESCRIPTION
POSIX/PAX headers in TAR may be larger than 1 TAR block (otherwise we see the Pax global headers as a "file" in backwards compatible mode).

Calling Tar_unix.get_next_header would already read the appropriate amount from a FD to find the first true file header.
However an imported file can be either compressed or not, and we need to retry with decompression if parsing as a Tar failed. But we might be importing from a socket or pipe, so we cannot just seek back to the beginning, and we cannot use Tar_unix.get_next_header either because we don't have access to its internal buffer.

Implement a custom Tar header reader using the functor, that first feeds the block that we already read to the reader, and then the file itself directly (at which point we turn off the retry because we no longer buffer all that we read).