### PR TITLE
CP-46377: Add env vars `TRACEPARENT` & `OBSERVER_CONFIG_DIR` to `exec_xmlrpc` calls

### DIFF
--- a/ocaml/forkexecd/lib/forkhelpers.ml
+++ b/ocaml/forkexecd/lib/forkhelpers.ml
@@ -23,6 +23,8 @@
 
 let default_path = ["/sbin"; "/usr/sbin"; "/bin"; "/usr/bin"]
 
+let default_path_env_pair = [|"PATH=" ^ String.concat ":" default_path|]
+
 (* /var/ may not be writable when testing, use XDG_RUNTIME_DIR instead in that
    case. Avoid changing the directory unless the code is being tested. *)
 let test_path =
@@ -182,13 +184,7 @@ let safe_close_and_exec ?env stdin stdout stderr
         List.fold_left maybe_add_id_to_fd_map dest_named_fds predefined_fds
       in
 
-      let env =
-        match env with
-        | Some e ->
-            e
-        | None ->
-            [|"PATH=" ^ String.concat ":" default_path|]
-      in
+      let env = match env with Some e -> e | None -> default_path_env_pair in
       let syslog_stdout =
         match syslog_stdout with
         | NoSyslogging ->

--- a/ocaml/forkexecd/lib/forkhelpers.mli
+++ b/ocaml/forkexecd/lib/forkhelpers.mli
@@ -41,6 +41,8 @@ type syslog_stdout_t =
 
 val default_path : string list
 
+val default_path_env_pair : string array
+
 val execute_command_get_output :
      ?env:string array
   -> ?syslog_stdout:syslog_stdout_t

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -152,6 +152,8 @@ module SpanContext = struct
         Some {trace_id; span_id}
     | _ ->
         None
+
+  let trace_id_of_span_context t = t.trace_id
 end
 
 module SpanLink = struct

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -46,6 +46,8 @@ module SpanContext : sig
   val to_traceparent : t -> string
 
   val of_traceparent : string -> t option
+
+  val trace_id_of_span_context : t -> string
 end
 
 module Span : sig

--- a/ocaml/xapi-aux/env_record.ml
+++ b/ocaml/xapi-aux/env_record.ml
@@ -26,3 +26,5 @@ let to_shell_string lst =
   lst
   |> List.map (fun (key, value) -> String.concat "=" [key; Filename.quote value])
   |> String.concat "\n"
+
+let to_string_array = Array.of_list

--- a/ocaml/xapi-aux/env_record.ml
+++ b/ocaml/xapi-aux/env_record.ml
@@ -1,0 +1,28 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type t = string
+
+let str txt = txt
+
+let option opt = Option.value ~default:"" opt
+
+let list element lst = List.map element lst |> String.concat ","
+
+let pair (key, value) = String.concat "=" [key; value]
+
+let to_shell_string lst =
+  lst
+  |> List.map (fun (key, value) -> String.concat "=" [key; Filename.quote value])
+  |> String.concat "\n"

--- a/ocaml/xapi-aux/env_record.mli
+++ b/ocaml/xapi-aux/env_record.mli
@@ -20,7 +20,7 @@
 (** A value of type [t] represents a value. 
   * It is constructed recursively from OCaml values using functions like [str], 
   * [option], or [list]. An environment value of type [t] can be observed using 
-  * [to_shell_string].
+  * [to_shell_string] or [to_string_array].
   *)
 type t
 
@@ -45,3 +45,7 @@ val to_shell_string : (string * t) list -> string
 (** [to_shell_string env_vars] is [env_vars] quoted as needed for use in a shell 
   * script.
   *)
+
+val to_string_array : t list -> string array
+(** Transforms a list of environment variables to a string array of environment 
+  * variables.*)

--- a/ocaml/xapi-aux/env_record.mli
+++ b/ocaml/xapi-aux/env_record.mli
@@ -1,0 +1,47 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** A Unix environment variable is a pair of a name and a value, both of which 
+  * are strings. This module helps to construct a complex environment value 
+  * that follows specific conventions.
+  *)
+
+(** A value of type [t] represents a value. 
+  * It is constructed recursively from OCaml values using functions like [str], 
+  * [option], or [list]. An environment value of type [t] can be observed using 
+  * [to_shell_string].
+  *)
+type t
+
+val str : string -> t
+(** Returns an environment variable value from a string.
+  *)
+
+val option : string option -> t
+(** Returns an environment variable value from a string option.
+  * If [None], returns an empty string value.
+  *)
+
+val list : ('a -> t) -> 'a list -> t
+(** [list element lst] is the list [lst] with elements converted by [element] 
+  * and separated by [,]. 
+  *)
+
+val pair : string * string -> t
+(** [pair (key, value)] is [key=value] pair. *)
+
+val to_shell_string : (string * t) list -> string
+(** [to_shell_string env_vars] is [env_vars] quoted as needed for use in a shell 
+  * script.
+  *)

--- a/ocaml/xapi-idl/lib/debuginfo.ml
+++ b/ocaml/xapi-idl/lib/debuginfo.ml
@@ -65,3 +65,11 @@ let with_dbg ?(with_thread = false) ~module_name ~name ~dbg f =
       Debug.with_thread_associated di.log f_with_trace ()
   | false ->
       f_with_trace ()
+
+let span_context_of_di di =
+  Option.map (fun span -> Tracing.Span.get_context span) di.tracing
+
+let traceparent_of_dbg dbg =
+  of_string dbg
+  |> span_context_of_di
+  |> Option.map Tracing.SpanContext.trace_id_of_span_context

--- a/ocaml/xapi-idl/lib/debuginfo.mli
+++ b/ocaml/xapi-idl/lib/debuginfo.mli
@@ -29,3 +29,5 @@ val with_dbg :
   -> dbg:string
   -> (t -> 'a)
   -> 'a
+
+val traceparent_of_dbg : string -> string option

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -333,6 +333,10 @@ let env_vars_of_observer dbg =
     let span_context_of_di (di : Debuginfo.t) =
       Option.map (fun span -> Tracing.Span.get_context span) di.tracing
     in
+    let dir_name =
+      Xapi_observer_components.dir_name_of_component
+        Xapi_observer_components.SMApi
+    in
     Debuginfo.of_string dbg
     |> span_context_of_di
     |> Option.map Tracing.SpanContext.trace_id_of_span_context
@@ -340,7 +344,7 @@ let env_vars_of_observer dbg =
            [|
               make_env "PATH" (String.concat ":" Forkhelpers.default_path)
             ; make_env "TRACEPARENT" v
-            ; make_env "OBSERVER_CONFIG_DIR" Xapi_globs.observer_config_dir
+            ; make_env "OBSERVER_CONFIG_DIR" dir_name
            |]
        )
   else

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -323,6 +323,10 @@ let with_session sr f =
       finally (fun () -> f session_id) (fun () -> destroy_session session_id)
   )
 
+let is_smapi_enabled () =
+  Xapi_observer_components.is_component_enabled
+    ~component:Xapi_observer_components.SMApi
+
 let exec_xmlrpc ~dbg ?context:_ ?(needs_session = true) (driver : string)
     (call : call) =
   with_dbg ~name:call.cmd ~dbg @@ fun di ->

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -197,7 +197,7 @@ let resync_host ~__context ~host =
           (* create the watcher here so that the watcher exists after toolstack restart *)
           create_cluster_watcher_on_master ~__context ~host ;
           Xapi_observer.initialise_observer ~__context
-            Xapi_observer.Component.Xapi_clusterd ;
+            Xapi_observer_components.Xapi_clusterd ;
           let verify = Stunnel_client.get_verify_by_default () in
           set_tls_config ~__context ~self ~verify
       )
@@ -307,7 +307,7 @@ let enable ~__context ~self =
       ) ;
       create_cluster_watcher_on_master ~__context ~host ;
       Xapi_observer.initialise_observer ~__context
-        Xapi_observer.Component.Xapi_clusterd ;
+        Xapi_observer_components.Xapi_clusterd ;
       let verify = Stunnel_client.get_verify_by_default () in
       set_tls_config ~__context ~self ~verify ;
       let init_config =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -938,7 +938,7 @@ let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
 
-let observer_config_dir = "/etc/xensource/observer/smapi/enabled"
+let observer_config_dir = "/etc/xensource/observer"
 
 let ignore_vtpm_unimplemented = ref false
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -938,6 +938,8 @@ let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
 
+let observer_config_dir = "/etc/xensource/observer/smapi/enabled"
+
 let ignore_vtpm_unimplemented = ref false
 
 let evacuation_batch_size = ref 10

--- a/ocaml/xapi/xapi_observer.mli
+++ b/ocaml/xapi/xapi_observer.mli
@@ -12,20 +12,13 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module Component : sig
-  type t = Xapi | Xenopsd | Xapi_clusterd | SMApi [@@deriving ord]
-
-  val to_string : t -> string
-
-  val of_string : string -> t
-end
-
 val observed_hosts_of :
   __context:Context.t -> API.ref_host list -> API.ref_host list
 
 val initialise : __context:Context.t -> unit
 
-val initialise_observer : __context:Context.t -> Component.t -> unit
+val initialise_observer :
+  __context:Context.t -> Xapi_observer_components.t -> unit
 
 val create :
      __context:Context.t

--- a/ocaml/xapi/xapi_observer_components.ml
+++ b/ocaml/xapi/xapi_observer_components.ml
@@ -76,3 +76,8 @@ let is_component_enabled ~component =
         with _ -> false
       )
   with _ -> false
+
+let ( // ) = Filename.concat
+
+let dir_name_of_component component =
+  Xapi_globs.observer_config_dir // to_string component // "enabled"

--- a/ocaml/xapi/xapi_observer_components.ml
+++ b/ocaml/xapi/xapi_observer_components.ml
@@ -1,0 +1,58 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type t = Xapi | Xenopsd | Xapi_clusterd | SMApi [@@deriving ord]
+
+exception Unsupported_Component of string
+
+let all = [Xapi; Xenopsd; Xapi_clusterd; SMApi]
+
+let to_string = function
+  | Xapi ->
+      "xapi"
+  | Xenopsd ->
+      "xenopsd"
+  | Xapi_clusterd ->
+      "xapi-clusterd"
+  | SMApi ->
+      "smapi"
+
+let of_string = function
+  | "xapi" ->
+      Xapi
+  | "xenopsd" ->
+      Xenopsd
+  | "xapi-clusterd" ->
+      Xapi_clusterd
+  | "smapi" ->
+      SMApi
+  | c ->
+      raise (Unsupported_Component c)
+
+(* We start up the observer for clusterd only if clusterd has been enabled
+   otherwise we initialise clusterd separately in cluster_host so that
+   there is no need to restart xapi in order for clusterd to be observed.
+   This does mean that observer will always be enabled for clusterd. *)
+let startup_components () =
+  List.filter
+    (function Xapi_clusterd -> !Xapi_clustering.Daemon.enabled | _ -> true)
+    all
+
+let assert_valid_components components =
+  try List.iter (fun c -> ignore @@ of_string c) components
+  with Unsupported_Component component ->
+    raise Api_errors.(Server_error (invalid_value, ["component"; component]))
+
+let observed_components_of components =
+  match components with [] -> startup_components () | components -> components

--- a/ocaml/xapi/xapi_observer_components.ml
+++ b/ocaml/xapi/xapi_observer_components.ml
@@ -77,7 +77,25 @@ let is_component_enabled ~component =
       )
   with _ -> false
 
+let is_smapi_enabled () = is_component_enabled ~component:SMApi
+
 let ( // ) = Filename.concat
 
 let dir_name_of_component component =
   Xapi_globs.observer_config_dir // to_string component // "enabled"
+
+let env_vars_of_component ~component ~traceparent =
+  let dir_name_value = Filename.quote (dir_name_of_component component) in
+  Array.concat
+    [
+      Forkhelpers.default_path_env_pair
+    ; Env_record.to_string_array
+        ([Env_record.pair ("OBSERVER_CONFIG_DIR", dir_name_value)]
+        @
+        match traceparent with
+        | None ->
+            []
+        | Some traceparent ->
+            [Env_record.pair ("TRACEPARENT", traceparent)]
+        )
+    ]

--- a/ocaml/xapi/xapi_observer_components.mli
+++ b/ocaml/xapi/xapi_observer_components.mli
@@ -53,7 +53,17 @@ val is_component_enabled : component:t -> bool
 (** Returns [true] if the given component is enabled, [false] otherwise.
   *)
 
+val is_smapi_enabled : unit -> bool
+(** Returns [true] if [SMApi] component is enabled, [false] otherwise.
+  *)
+
 val dir_name_of_component : t -> string
 (** Returns the directory path that python scripts check to see if a component 
   * is enabled.
+  *)
+
+val env_vars_of_component :
+  component:t -> traceparent:string option -> string array
+(** Returns an array of environment viariables used by python scripts to 
+  *  configure the python observers.  
   *)

--- a/ocaml/xapi/xapi_observer_components.mli
+++ b/ocaml/xapi/xapi_observer_components.mli
@@ -48,3 +48,7 @@ val observed_components_of : t list -> t list
 (** Transforms a list of components to a list of components that are expected 
   * to be observed. If the list is empty we expect all startup components.
   *)
+
+val is_component_enabled : component:t -> bool
+(** Returns [true] if the given component is enabled, [false] otherwise.
+  *)

--- a/ocaml/xapi/xapi_observer_components.mli
+++ b/ocaml/xapi/xapi_observer_components.mli
@@ -1,0 +1,50 @@
+(*
+ * Copyright (C) 2023 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** Xapi_observer_components module contains generic operations on components 
+  * instrumented with tracing. These operations act on components independently 
+  * of observers.
+  *)
+
+(** Type for components that are instrumented with tracing.
+  *)
+type t = Xapi | Xenopsd | Xapi_clusterd | SMApi [@@deriving ord]
+
+val all : t list
+(** List of all components available.
+  *)
+
+val to_string : t -> string
+(** Converts a component type to its string equivalent.
+  *)
+
+val of_string : string -> t
+(** Convert a string to a component.
+  * Raises Unsupported_Component if the component is not supported.
+  *)
+
+val startup_components : unit -> t list
+(** List of observed components on startup.
+  *)
+
+val assert_valid_components : string list -> unit
+(** Checks if a given list is made of only string equivalents of supported 
+  * components.
+  * Raises Server_error if at least one of the elements is invalid.
+  *)
+
+val observed_components_of : t list -> t list
+(** Transforms a list of components to a list of components that are expected 
+  * to be observed. If the list is empty we expect all startup components.
+  *)

--- a/ocaml/xapi/xapi_observer_components.mli
+++ b/ocaml/xapi/xapi_observer_components.mli
@@ -52,3 +52,8 @@ val observed_components_of : t list -> t list
 val is_component_enabled : component:t -> bool
 (** Returns [true] if the given component is enabled, [false] otherwise.
   *)
+
+val dir_name_of_component : t -> string
+(** Returns the directory path that python scripts check to see if a component 
+  * is enabled.
+  *)


### PR DESCRIPTION
Sets up the necessary environment variables, `TRACEPARENT` and `OBSERVER_CONFIG_DIR`  for  SMAPI `observer.py` configuration.