### PR TITLE
build: add a C# SDK sanity test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,10 @@ jobs:
           opam exec -- make install DESTDIR=$(mktemp -d)
           opam exec -- make install DESTDIR=$(mktemp -d) BUILD_PY2=NO
 
+      - name: Sanity test SDK
+        run: |
+          opam exec -- make sdksanity
+
       - name: Uninstall unversioned packages and remove pins
         # This should purge them from the cache, unversioned package have
         # 'master' as its version

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ sdk:
 		@ocaml/sdk-gen/csharp/generate \
 		@ocaml/sdk-gen/java/generate \
 		@ocaml/sdk-gen/powershell/generate
+	rm -rf $(XAPISDK)
 	mkdir -p $(XAPISDK)/c
 	mkdir -p $(XAPISDK)/csharp
 	mkdir -p $(XAPISDK)/java

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,12 @@ sdk:
 	sh ocaml/sdk-gen/windows-line-endings.sh $(XAPISDK)/csharp
 	sh ocaml/sdk-gen/windows-line-endings.sh $(XAPISDK)/powershell
 
+# workaround for no .resx generation, just for compilation testing
+sdksanity: sdk
+	sed -i 's/FriendlyErrorNames.ResourceManager/null/g' ./_build/install/default/xapi/sdk/csharp/src/Failure.cs
+	cd _build/install/default/xapi/sdk/csharp/src && dotnet add package Newtonsoft.Json && dotnet build -f netstandard2.0
+
+
 python:
 	$(MAKE) -C scripts/examples/python build
 


### PR DESCRIPTION
I've recently broken the C# SDK build by introducing an enum that happened to be a keyword.

Would be good to test all SDK languages in the CI, but lets start with just one: add a command to the makefile to build-test the SDK, and then run the command in the CI.

This also works on Linux using the 'dotnet' build tool (which IIRC should be preinstalled on github workers, but we'll find out).

A hack was needed to get this to compile: generating FriendlyNames.cs from FriendlyNames.resx is not yet supported on Linux (needs some changes to the C# project definition/code/build system), but we don't want to run the SDK here, just test that it builds, so setting to null achieves that.