### PR TITLE
CA-387201: Pool.last_sync_date not reset if the user changes update channel

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3352,11 +3352,14 @@ let set_repositories ~__context ~self ~value =
     (fun x ->
       if not (List.mem x existings) then (
         Db.Repository.set_hash ~__context ~self:x ~value:"" ;
-        Repository.reset_updates_in_cache ()
+        Repository.reset_updates_in_cache () ;
+        Db.Pool.set_last_update_sync ~__context ~self ~value:Date.epoch
       )
     )
     value ;
-  Db.Pool.set_repositories ~__context ~self ~value
+  Db.Pool.set_repositories ~__context ~self ~value ;
+  if Db.Pool.get_repositories ~__context ~self = [] then
+    Db.Pool.set_last_update_sync ~__context ~self ~value:Date.epoch
 
 let add_repository ~__context ~self ~value =
   Xapi_pool_helpers.with_pool_operation ~__context ~self
@@ -3366,7 +3369,8 @@ let add_repository ~__context ~self ~value =
   if not (List.mem value existings) then (
     Db.Pool.add_repositories ~__context ~self ~value ;
     Db.Repository.set_hash ~__context ~self:value ~value:"" ;
-    Repository.reset_updates_in_cache ()
+    Repository.reset_updates_in_cache () ;
+    Db.Pool.set_last_update_sync ~__context ~self ~value:Date.epoch
   )
 
 let remove_repository ~__context ~self ~value =
@@ -3381,7 +3385,9 @@ let remove_repository ~__context ~self ~value =
       )
     )
     (Db.Pool.get_repositories ~__context ~self) ;
-  Db.Pool.remove_repositories ~__context ~self ~value
+  Db.Pool.remove_repositories ~__context ~self ~value ;
+  if Db.Pool.get_repositories ~__context ~self = [] then
+    Db.Pool.set_last_update_sync ~__context ~self ~value:Date.epoch
 
 let sync_updates ~__context ~self ~force ~token ~token_id =
   Pool_features.assert_enabled ~__context ~f:Features.Updates ;


### PR DESCRIPTION
When a user adds more update repositories as enabled ones, the pool.last_update_sync will be invalid as at the moment not all the enabled repositories have been synced at the time which is recorded in pool.last_update_sync.

To avoid confusion, this commit resets the field to epoch so that the user can be notified to do a pool.sync_updates soon.

Disabling an update repository will not make the pool.last_update_sync be invalid unless no enabled repositories after the disabling.