### PR TITLE
CP-47043: Port usb_reset.py to python3. 

### DIFF
--- a/scripts/usb_reset.py
+++ b/scripts/usb_reset.py
@@ -236,14 +236,10 @@ def setup_cgroup(domid, pid):  # type:(str, str) -> None
         # Using the unbuffered Raw IO mode, we know the write was done
         # in exactly this way by the write function call itself, not later.
         #
-        # With such short writes, splitting the writes because of a
-        # too small buffer will not usually happen, but be paranoid
-        # and keep the same code for Python3 too. We've to use binary
-        # mode for Python3 for this as Python3 does now support unbuffered
-        # Raw I/O in Text mode (with implicit unicode str to byte encode()).
-        #
-        # In Python2 str is bytes anyway so in Python2 it was already binary.
-        # Using bytes for "wb" means also no change for use with Python3:
+        # With small writes like this , splitting them because of overflowing the
+        # buffer is not expected to happen. To stay safe and keep using unbuffered I/O
+        # We have to migrate to binary mode in python3,as python3 supports unbuffered 
+        # raw I/O in binary mode.
         #
         with open(cg_dir + "/tasks", "wb", 0) as tasks, \
                 open(cg_dir + "/devices.deny", "wb", 0) as deny, \

--- a/scripts/usb_reset.py
+++ b/scripts/usb_reset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) Citrix Systems Inc.
 #
@@ -122,7 +122,7 @@ def load_device_ids(device):
     ids_path = get_ids_path(device)
     try:
         with open(ids_path) as f:
-            uid, gid = map(int, f.readline().split())
+            uid, gid = list(map(int, f.readline().split()))
     except (IOError, ValueError) as e:
         log.error("Failed to load device ids: {}".format(str(e)))
 
@@ -212,17 +212,17 @@ def setup_cgroup(domid, pid):
 
     try:
         # unbuffered write to ensure each one is flushed immediately
-        with open(cg_dir + "/tasks", "w", 0) as tasks, \
-                open(cg_dir + "/devices.deny", "w", 0) as deny, \
-                open(cg_dir + "/devices.allow", "w", 0) as allow:
+        with open(cg_dir + "/tasks", "wb") as tasks, \
+                open(cg_dir + "/devices.deny", "wb") as deny, \
+                open(cg_dir + "/devices.allow", "wb") as allow:
 
             # deny all
-            deny.write("a")
+            deny.write(b"a")
 
             # grant rw access to /dev/null by default
-            allow.write(get_ctl("/dev/null", "rw"))
+            allow.write(get_ctl("/dev/null",b"rw"))
 
-            tasks.write(str(pid))
+            tasks.write(str(pid).encode())
 
     except (IOError, OSError, RuntimeError) as e:
         log.error("Failed to setup cgroup: {}".format(str(e)))

--- a/scripts/usb_reset.py
+++ b/scripts/usb_reset.py
@@ -157,7 +157,7 @@ def dev_path(device):
         exit(1)
 
 
-def get_ctl(path, mode):
+def get_ctl(path, mode):  # type:(str, str) -> str
     """get the string to control device access for cgroup
     :param path: the device file path
     :param mode: either "r" or "rw"
@@ -200,7 +200,23 @@ def deny_device(path, domid):
     _device_ctl(path, domid, False)
 
 
-def setup_cgroup(domid, pid):
+def setup_cgroup(domid, pid):  # type:(str, str) -> None
+    """
+    Associate the given process id (pid) with the given Linux kernel control group
+    and limit it's device access to only /dev/null.
+
+    :param domid (str): The control group ID string (passed on from the command line)
+    :param pid (str): The process ID string (passed on from the command line)
+
+    If the control group directory does not exist yet, the control group is created.
+
+    - The pid goes into the file "tasks" to associate the process with the cgroup.
+    - Deny device access by default by writing "a" to devices.deny.
+    - Grant read-write access to /dev/null, writing it's device IDs to devices.allow.
+
+    If any error occur during the setup process, the error is logged and
+    the program exits with a status code of 1.
+    """
     cg_dir = get_cg_dir(domid)
 
     try:
@@ -212,15 +228,34 @@ def setup_cgroup(domid, pid):
 
     try:
         # unbuffered write to ensure each one is flushed immediately
-        with open(cg_dir + "/tasks", "wb") as tasks, \
-                open(cg_dir + "/devices.deny", "wb") as deny, \
-                open(cg_dir + "/devices.allow", "wb") as allow:
+        # to the kernel's control group filesystem:
+        #
+        # The order of writes is likely not important, but the writes
+        # may have to be a single write() system call for the entire string.
+        #
+        # Using the unbuffered Raw IO mode, we know the write was done
+        # in exactly this way by the write function call itself, not later.
+        #
+        # With such short writes, splitting the writes because of a
+        # too small buffer will not usually happen, but be paranoid
+        # and keep the same code for Python3 too. We've to use binary
+        # mode for Python3 for this as Python3 does now support unbuffered
+        # Raw I/O in Text mode (with implicit unicode str to byte encode()).
+        #
+        # In Python2 str is bytes anyway so in Python2 it was already binary.
+        # Using bytes for "wb" means also no change for use with Python3:
+        #
+        with open(cg_dir + "/tasks", "wb", 0) as tasks, \
+                open(cg_dir + "/devices.deny", "wb", 0) as deny, \
+                open(cg_dir + "/devices.allow", "wb", 0) as allow:
 
             # deny all
             deny.write(b"a")
 
+            # To write bytes, we've to encode the strings to bytes below:
+
             # grant rw access to /dev/null by default
-            allow.write(get_ctl("/dev/null",b"rw"))
+            allow.write(get_ctl("/dev/null", "rw").encode())
 
             tasks.write(str(pid).encode())
 


### PR DESCRIPTION
PR#5350 contains the following changes:

- Shebang changed to python3,
- map() needs to be converted to list()
- Change `setup_cgroup()` to binary I/O:

Python3 does not support unbuffered Raw I/O in Text mode:

Fix "can't have unbuffered text I/O" by changing the code to use binary mode instead of text mode:
when executing `/opt/xensource/libexec/usb_reset.py attach 1-13.2 -d 16 -p 8470`. 
```py
Error code:
Traceback (most recent call last):
  File "/opt/xensource/libexec/usb_reset.py", line 343, in <module>
    attach(arg.device, arg.domid, arg.pid, arg.reset_only)
  File "/opt/xensource/libexec/usb_reset.py", line 285, in attach
    setup_cgroup(domid, pid)
  File "/opt/xensource/libexec/usb_reset.py", line 215, in setup_cgroup
    with open(cg_dir + "/tasks", "w", 0) as tasks, \
ValueError: can't have unbuffered text I/O  
```
Testing information:
Koji rpm package created with converted code: [taskID=567641], XenRT Job 3902923 completed succesfully

Signed-off-by: Ashwinh <ashwin.h@cloud.com>
Co-authored-by: Bernhard Kaindl <bernhard.kaindl@cloud.com> 

@psafont @Vincent-lau @lindig 