### PR TITLE
xenopsd: avoid log message about vmdesc

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -154,6 +154,7 @@ def main(argv):
 
     qemu_args.extend(['-machine',
                       '%s,accel=xen,max-ram-below-4g=%lu,'
+                      'suppress-vmdesc=on,'
                       'allow-unassigned=true,trad_compat=%s%s'
                       % (machine, mmio_start, trad_compat, igdpt)])
 


### PR DESCRIPTION
QEMU complains during a migration:
```
qemu-dm-120: Expected vmdescription section, but got 0
```

This has been fixed upstream in 2020, but only for libxl: https://patchew.org/Xen/20201029190332.31161-1-jandryuk@gmail.com/

(And QEMU 5.2+ would do it automatically for machine=xenfv but we're still using machine=pc, and an older QEMU.)

Implement the equivalent fix for xenopsd: we use qemu 4.x, and this CLI flag first appeared in 2.3, so should be fine.

I did a quick test on my XenServer box and a localhost migrate has succeeded and didn't log this message anymore.