### PR TITLE
CA-387588: Avoid EADDRINUSE in test code due to TIME_WAIT

### DIFF
--- a/ocaml/xs-trace/test/test-xs-trace.sh
+++ b/ocaml/xs-trace/test/test-xs-trace.sh
@@ -9,6 +9,7 @@ MAX_WAIT=60
 
 PID=$!
 
+trap "kill $PID" SIGINT SIGTERM EXIT
 wait_counter=0
 while [ ! -f "test-server-ready" ] && [ $wait_counter -lt $MAX_WAIT ]; do
     sleep 3
@@ -25,4 +26,3 @@ rm test-http-server.out
 
 diff -B test-source.ndjson test-http-server.out || exit 1
 
-kill $PID

--- a/ocaml/xs-trace/test/test-xs-trace.sh
+++ b/ocaml/xs-trace/test/test-xs-trace.sh
@@ -12,8 +12,8 @@ PID=$!
 trap "kill $PID" SIGINT SIGTERM EXIT
 wait_counter=0
 while [ ! -f "test-server-ready" ] && [ $wait_counter -lt $MAX_WAIT ]; do
-    sleep 3
-    ((wait_counter+=3))
+    sleep 1
+    ((wait_counter+=1))
 done
 
 ../xs_trace.exe cp test-source.json http://$HOST:$PORT/api/v2/spans

--- a/ocaml/xs-trace/test/test_xs_trace.ml
+++ b/ocaml/xs-trace/test/test_xs_trace.ml
@@ -39,6 +39,7 @@ let _ =
         ()
   in
   let sock = Unix.socket Unix.PF_INET SOCK_STREAM 0 in
+  Unix.setsockopt sock Unix.SO_REUSEADDR true ;
   Unix.bind sock inet_addr ;
   Unix.listen sock 1 ;
   (*Create a file to indicate the server is ready and listening*)


### PR DESCRIPTION
Bypass TIME_WAIT on the test socket in test-xs-trace, otherwise running the test in a loop would sometimes fail.
(TIME_WAIT can take a minute or more to clear on its own, and there is no point in waiting for that in test code)