### PR TITLE
build: set a timeout for the tests and fix forkexecd unit test

### DIFF
--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -18,7 +18,7 @@ type config = {
 
 let min_fds = 7
 
-let max_fds = 1024 - 11 (* fe daemon has a bunch for its own use *)
+let max_fds = 1024 - 13 (* fe daemon has a bunch for its own use *)
 
 let all_combinations fds =
   let y =


### PR DESCRIPTION
We have some non-deterministic timeouts on github actions. Introduce some shorter timeouts that is under our control,
 and print more information about what is stuck.

GH actions take <2m to run the tests, so add 5m as a timeout for the children, and twice that for the parent.

This is like https://github.com/xapi-project/xen-api/pull/5355 but without the hacks to disable unreliable tests.

If the CI passes on this one then we should probably merge this to make diagnosing test failures in other PRs easier. I added the missing cleanup code so the ps output should only be printed if there is an actual timeout (if the tests fail or succeed sooner then the sleeping process is killed and ps tree is never dumped).