### PR TITLE
Revert "update mail-alarm and usb_scan to python3"

### DIFF
--- a/scripts/mail-alarm
+++ b/scripts/mail-alarm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # mail-alarm: uses ssmtp to send a mail message, to pool:other_config:mail-destination
 #
@@ -11,18 +11,18 @@
 # the only thing that needs be set is pool:other-config:ssmtp-mailhub
 
 from __future__ import print_function
-
-import json
-import os
-import re
+import XenAPI
 import sys
-import syslog
+import os
 import tempfile
 import traceback
-from socket import getfqdn
+import syslog
+import json
+import re
 from xml.dom import minidom
-
-import XenAPI
+from xml.sax.saxutils import unescape
+from xml.parsers.expat import ExpatError
+from socket import getfqdn
 from xcp import branding
 
 # Go read man ssmtp.conf

--- a/scripts/usb_scan.py
+++ b/scripts/usb_scan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (C) Citrix Systems Inc.
 #
@@ -21,16 +21,15 @@
 # 2. check if device can be passed through based on policy file
 # 3. return the device info to XAPI in json format
 
-
+from __future__ import print_function
 import abc
 import argparse
 import json
+import xcp.logger as log
 import logging
+import pyudev
 import re
 import sys
-
-import pyudev
-import xcp.logger as log
 
 
 def log_list(l):


### PR DESCRIPTION
This reverts commit 3259196db57c7e2c301519236b0723dfa095554d.

We've seen in the testsuite likely caused by this change:
```
Unexpected exception in message hook /opt/xensource/libexec/mail-alarm: INTERNAL_ERROR: [ Subprocess exited with unexpected code 1; stdout = [  ]; stderr = [ Traceback (most recent call last):\x0A\x0A  File "/opt/xensource/libexec/mail-alarm", line 1055, in <module>\x0A    rc = main()\x0A\x0A  File "/opt/xensource/libexec/mail-alarm", line 1027, in main\x0A    os.write(fd, config)\x0A\x0ATypeError: a bytes-like object is required, not 'str'\x0A\x0A ] ]
```