### PR TITLE
CA-387456 serialise Pool.eject

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 771
+let schema_minor_vsn = 772
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -44,6 +44,7 @@ let operations =
         , "Indicates the primary host is sending its certificates to another \
            host"
         )
+      ; ("eject", "Ejection of a host from the pool is under way")
       ]
     )
 

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "29a820cd4c81617f07b43c9b4f934317"
+let last_known_schema_hash = "ab570d662d657ee2055194110d536302"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -177,6 +177,8 @@ let pool_operation_to_string = function
       "exchange_ca_certificates_on_join"
   | `copy_primary_host_certs ->
       "copy_primary_host_certs"
+  | `eject ->
+      "eject"
 
 let host_operation_to_string = function
   | `provision ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -788,6 +788,10 @@ functor
         info "Pool.eject: pool = '%s'; host = '%s'"
           (current_pool_uuid ~__context)
           (host_uuid ~__context host) ;
+        let pool = Helpers.get_pool ~__context in
+        Xapi_pool_helpers.with_pool_operation ~__context ~doc:"Pool.eject"
+          ~self:pool ~op:`eject
+        @@ fun () ->
         let master = Helpers.get_master ~__context in
         let local_fn = Local.Pool.eject ~host in
         let other =

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -51,6 +51,7 @@ let wait_ops =
   ; `exchange_certificates_on_join
   ; `exchange_ca_certificates_on_join
   ; `copy_primary_host_certs
+  ; `eject
   ]
 
 let all_operations = blocking_ops |> List.map fst |> List.append wait_ops


### PR DESCRIPTION
When a host is ejected from a pool, its certificate for pool-internal communication is removed from all remaining hosts. This is unlikely to work when we have multiple eject operations overlapping. Hence, introduce an eject operation and make sure ejects are serialised.