### PR TITLE
CP-46939: Add config option observer_endpoint_http_enabled

### DIFF
--- a/ocaml/tests/test_observer.ml
+++ b/ocaml/tests/test_observer.ml
@@ -210,6 +210,7 @@ let test_components ~__context ~self =
     )
 
 let test_endpoints ~__context ~self =
+  Xapi_globs.observer_endpoint_http_enabled := true ;
   let valid_endpoints = ["bugtool"; "http://example.com:9411/api/v2/spans"] in
   List.iter
     (fun valid_endpoint ->

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1011,6 +1011,10 @@ let cert_thumbprint_header_value = ref "sha-256:master"
 let cert_thumbprint_header_response =
   ref "x-xenapi-response-host-certificate-thumbprint"
 
+let observer_endpoint_http_enabled = ref false
+
+let observer_endpoint_https_enabled = ref false
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1496,6 +1500,16 @@ let other_options =
     , Arg.Set compress_tracing_files
     , (fun () -> string_of_bool !compress_tracing_files)
     , "Enable compression of the tracing log files"
+    )
+  ; ( "observer-endpoint-http-enabled"
+    , Arg.Set observer_endpoint_http_enabled
+    , (fun () -> string_of_bool !observer_endpoint_http_enabled)
+    , "Enable http endpoints to be used by observers"
+    )
+  ; ( "observer-endpoint-https-enabled"
+    , Arg.Set observer_endpoint_https_enabled
+    , (fun () -> string_of_bool !observer_endpoint_https_enabled)
+    , "Enable https endpoints to be used by observers"
     )
   ]
 


### PR DESCRIPTION
This option defaults to false as it is unsafe for customers to use http endpoints. This can be enabled for dev testing and XenRT.