### PR TITLE
Refine the description and unit of 'running_vcpus' and 'running_domai…

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -398,14 +398,14 @@ let dss_hostload xc domains =
         ()
     )
   ; ( Rrd.Host
-    , Ds.ds_make ~name:"running_vcpus" ~units:"(vcpus)"
-        ~description:"The total number of running vCPU per host"
+    , Ds.ds_make ~name:"running_vcpus" ~units:"count"
+        ~description:"The total number of running vCPUs per host"
         ~value:(Rrd.VT_Int64 (Int64.of_int load))
         ~min:0.0 ~ty:Rrd.Gauge ~default:true ()
     )
   ; ( Rrd.Host
-    , Ds.ds_make ~name:"running_domains" ~units:"(domains)"
-        ~description:"The total number of running domain per host"
+    , Ds.ds_make ~name:"running_domains" ~units:"count"
+        ~description:"The total number of running domains per host"
         ~value:(Rrd.VT_Int64 (Int64.of_int running_domains))
         ~min:0.0 ~ty:Rrd.Gauge ~default:true ()
     )


### PR DESCRIPTION
Implementing a suggestion from XenCenter: converting specific units to common units for simplification in XenCenter implementation.

- `(vcpus) `-> `count`
- `(domains) `-> `count`
