### PR TITLE
CA-387560 add support for more systemd execution types

### DIFF
--- a/ocaml/forkexecd/lib/fe_systemctl.ml
+++ b/ocaml/forkexecd/lib/fe_systemctl.ml
@@ -28,7 +28,7 @@ let action ~service action =
 
 (** Systemd execution type *)
 module Type = struct
-  type t = Simple | OneShot | Forking
+  type t = Simple | OneShot | Forking | Notify | Idle
 
   let to_string = function
     | Simple ->
@@ -37,6 +37,10 @@ module Type = struct
         "oneshot"
     | Forking ->
         "forking"
+    | Notify ->
+        "notify"
+    | Idle ->
+        "idle"
 end
 
 let default_env = ["PATH=" ^ String.concat ":" Forkhelpers.default_path]

--- a/ocaml/forkexecd/lib/fe_systemctl.ml
+++ b/ocaml/forkexecd/lib/fe_systemctl.ml
@@ -26,12 +26,25 @@ let action ~service action =
   in
   ()
 
+(** Systemd execution type *)
+module Type = struct
+  type t = Simple | OneShot | Forking
+
+  let to_string = function
+    | Simple ->
+        "simple"
+    | OneShot ->
+        "oneshot"
+    | Forking ->
+        "forking"
+end
+
 let default_env = ["PATH=" ^ String.concat ":" Forkhelpers.default_path]
 
 let run_path = "/run/systemd/system/"
 
 let start_transient ?(env = Array.of_list default_env) ?(properties = [])
-    ~service cmd args =
+    ~exec_ty ~service cmd args =
   let syslog_key = service in
   let service = syslog_key ^ ".service" in
   let destination = Filename.concat run_path service in
@@ -47,7 +60,7 @@ let start_transient ?(env = Array.of_list default_env) ?(properties = [])
        ; ("StandardError", "inherit")
        ; ("StartLimitInterval", "0") (* no rate-limit, for bootstorms *)
        ; ("ExecStart", String.concat " " (cmd :: List.map Filename.quote args))
-       ; ("Type", "simple")
+       ; ("Type", Type.to_string exec_ty)
          (* our systemd is too old, and doesn't support 'exec' *)
        ; ("Restart", "no")
          (* can't restart the device-model, it would've lost all state already *)
@@ -118,11 +131,12 @@ let is_active ~service =
 let exists ~service =
   Sys.file_exists (Filename.concat run_path (service ^ ".service"))
 
-let start_transient ?env ?properties ~service cmd args =
+let start_transient ?env ?properties ?(exec_ty = Type.Simple) ~service cmd args
+    =
   if exists ~service then
     (* this can only happen if there is a bug in the caller *)
     invalid_arg (Printf.sprintf "Tried to start %s twice" service) ;
-  try start_transient ?env ?properties ~service cmd args
+  try start_transient ?env ?properties ~exec_ty ~service cmd args
   with e ->
     Backtrace.is_important e ;
     (* If start failed we do not know what state the service is in:

--- a/ocaml/forkexecd/lib/fe_systemctl.mli
+++ b/ocaml/forkexecd/lib/fe_systemctl.mli
@@ -18,21 +18,29 @@ type status = {
   ; active_state: string
 }
 
+module Type : sig
+  type t = Simple | OneShot | Forking
+
+  val to_string : t -> string
+end
+
 val start_transient :
      ?env:string array
   -> ?properties:(string * string) list
+  -> ?exec_ty:Type.t
   -> service:string
   -> string
   -> string list
   -> unit
-(** [start_transient ?env ?properties ~service cmd args] generates and starts a transient systemd
- * [service] that will execute [cmd args].
- * stdout/stderr from the service is redirected to syslog with [service] as syslog key.
- * Additional [properties] can be specified that are written into the systemd unit file's [Service]
- * section.
- * By default the service is not auto-restarted when it fails, and there is a 10s timeout between
- * SIGTERM and SIGKILL on stop.
- * On failure it raises [Spawn_internal_error(stderr, stdout, Unix.process_status)] *)
+(** [start_transient ?env ?properties ~service cmd args] generates and
+    starts a transient systemd [service] that will execute [cmd args].
+    stdout/stderr from the service is redirected to syslog with
+    [service] as syslog key.  Additional [properties] can be specified
+    that are written into the systemd unit file's [Service] section.  By
+    default the service is not auto-restarted when it fails, and there
+    is a 10s timeout between SIGTERM and SIGKILL on stop.  On failure it
+    raises [Spawn_internal_error(stderr, stdout, Unix.process_status)]
+    *)
 
 val is_active : service:string -> bool
 (** [is_active ~service] checks whether the [service] is still running *)

--- a/ocaml/forkexecd/lib/fe_systemctl.mli
+++ b/ocaml/forkexecd/lib/fe_systemctl.mli
@@ -19,7 +19,7 @@ type status = {
 }
 
 module Type : sig
-  type t = Simple | OneShot | Forking
+  type t = Simple | OneShot | Forking | Notify | Idle
 
   val to_string : t -> string
 end


### PR DESCRIPTION
We use systemd to start transient services. So far, we use the Simple type but would like to add oneshot and potentially more.