### PR TITLE
CA-387698: datamodel: eliminate next_release

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2211,7 +2211,7 @@ module Tunnel = struct
             param_type= tunnel_protocol
           ; param_name= "protocol"
           ; param_doc= "Protocol used for the tunnel (GRE or VxLAN)"
-          ; param_release= next_release
+          ; param_release= numbered_release "1.250.0"
           ; param_default= Some (VEnum "gre")
           }
         ]

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 773
+let schema_minor_vsn = 774
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -349,9 +349,19 @@ let get_product_releases in_product_since =
   in
   go_through_release_order release_order
 
-let next_release =
+let numbered_release version =
+  let ok fmt =
+    try Scanf.sscanf version fmt true
+    with Stdlib.Scanf.Scan_failure _ -> false
+  in
+  if not (ok "%_d.%_d.%_d%!" || ok "%_d.%_d.%_d-next%!") then
+    failwith
+      (Printf.sprintf
+         "Invalid numbered release: %s. Use the format x.y.z or x.y.z-next."
+         version
+      ) ;
   {
-    internal= get_product_releases rel_next
+    internal= get_product_releases version
   ; opensource= get_oss_releases None
   ; internal_deprecated_since= None
   }

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -372,7 +372,7 @@ let evacuate =
           param_type= Ref _network
         ; param_name= "network"
         ; param_doc= "Optional preferred network for migration"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.297.0"
         ; param_default= Some (VRef null_ref)
         }
       ; {
@@ -381,7 +381,7 @@ let evacuate =
         ; param_doc=
             "The maximum number of VMs to be migrated per batch 0 will use the \
              value `evacuation-batch-size` defined in xapi.conf"
-        ; param_release= next_release
+        ; param_release= numbered_release "23.27.0"
         ; param_default= Some (VInt 0L)
         }
       ]

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -40,7 +40,7 @@ let prototyped_of_field = function
   | "VTPM", "persistence_backend" ->
       Some "22.26.0"
   | "host", "numa_affinity_policy" ->
-      Some "24.2.1"
+      Some "24.0.0"
   | "host", "latest_synced_updates_applied" ->
       Some "23.18.0"
   | "host", "recommended_guidances" ->
@@ -76,7 +76,7 @@ let prototyped_of_field = function
   | "pool", "migration_compression" ->
       Some "22.33.0"
   | "pool", "custom_uefi_certificates" ->
-      Some "24.2.1"
+      Some "24.0.0"
   | _ ->
       None
 
@@ -114,7 +114,7 @@ let prototyped_of_message = function
   | "host", "set_https_only" ->
       Some "22.27.0"
   | "host", "set_numa_affinity_policy" ->
-      Some "24.2.1"
+      Some "24.0.0"
   | "VM", "restart_device_models" ->
       Some "23.30.0"
   | "pool", "set_ext_auth_max_threads" ->
@@ -132,6 +132,6 @@ let prototyped_of_message = function
   | "pool", "set_https_only" ->
       Some "22.27.0"
   | "pool", "set_custom_uefi_certificates" ->
-      Some "24.2.1"
+      Some "24.0.0"
   | _ ->
       None

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -907,7 +907,7 @@ let sync_updates =
           param_type= Ref _pool
         ; param_name= "self"
         ; param_doc= "The pool"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.329.0"
         ; param_default= None
         }
       ; {
@@ -915,21 +915,21 @@ let sync_updates =
         ; param_name= "force"
         ; param_doc=
             "If true local mirroring repo will be removed before syncing"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.329.0"
         ; param_default= None
         }
       ; {
           param_type= String
         ; param_name= "token"
         ; param_doc= "The token for repository client authentication"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.329.0"
         ; param_default= Some (VString "")
         }
       ; {
           param_type= String
         ; param_name= "token_id"
         ; param_doc= "The ID of the token"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.329.0"
         ; param_default= Some (VString "")
         }
       ]
@@ -1030,7 +1030,7 @@ let set_uefi_certificates =
     ~lifecycle:
       [
         (Published, "22.16.0", "")
-      ; (Deprecated, "23.32.0", "use set_custom_uefi_certificates instead")
+      ; (Deprecated, "24.0.0", "use set_custom_uefi_certificates instead")
       ]
     ~doc:
       "Set the UEFI certificates for a pool and all its hosts. Deprecated: use \
@@ -1441,7 +1441,7 @@ let t =
             ~lifecycle:
               [
                 (Published, "21.3.0", "")
-              ; (Changed, rel_next, "Changed internal_only to false")
+              ; (Changed, "23.9.0", "Changed internal_only to false")
               ]
             ~ty:(Ref _secret) ~default_value:(Some (VRef null_ref))
             "repository_proxy_password"

--- a/ocaml/idl/datamodel_repository.ml
+++ b/ocaml/idl/datamodel_repository.ml
@@ -28,28 +28,28 @@ let introduce =
           param_type= String
         ; param_name= "name_label"
         ; param_doc= "The name of the repository"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.301.0"
         ; param_default= None
         }
       ; {
           param_type= String
         ; param_name= "name_description"
         ; param_doc= "The description of the repository"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.301.0"
         ; param_default= None
         }
       ; {
           param_type= String
         ; param_name= "binary_url"
         ; param_doc= "Base URL of binary packages in this repository"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.301.0"
         ; param_default= None
         }
       ; {
           param_type= String
         ; param_name= "source_url"
         ; param_doc= "Base URL of source packages in this repository"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.301.0"
         ; param_default= None
         }
       ; {
@@ -58,14 +58,14 @@ let introduce =
         ; param_doc=
             "True if the repository is an update repository. This means that \
              updateinfo.xml will be parsed"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.301.0"
         ; param_default= None
         }
       ; {
           param_type= String
         ; param_name= "gpgkey_path"
         ; param_doc= "The GPG public key file name"
-        ; param_release= next_release
+        ; param_release= numbered_release "1.301.0"
         ; param_default= Some (VString "")
         }
       ]

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -97,8 +97,6 @@ let rel_stockholm = "stockholm"
 
 let rel_stockholm_psr = "stockholm_psr"
 
-let rel_next = "next"
-
 type api_release = {
     code_name: string option
   ; version_major: int
@@ -335,13 +333,6 @@ let release_order_full =
     ; version_minor= 15
     ; branding= "Citrix Hypervisor 8.2 Hotfix 2"
     ; release_date= Some "November 2020"
-    }
-  ; {
-      code_name= Some rel_next
-    ; version_major= 2
-    ; version_minor= 20
-    ; branding= "Unreleased"
-    ; release_date= Some "" (* unknown date *)
     }
   ]
 (* When you add a new release, use the version number of the latest release, "Unreleased"

--- a/ocaml/idl/datamodel_types.mli
+++ b/ocaml/idl/datamodel_types.mli
@@ -68,8 +68,6 @@ val rel_stockholm : string
 
 val rel_stockholm_psr : string
 
-val rel_next : string
-
 type api_release = {
     code_name: string option
   ; version_major: int

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -371,7 +371,7 @@ let snapshot =
           param_type= Set (Ref _vdi)
         ; param_name= "ignore_vdis"
         ; param_doc= "A list of VDIs to ignore for the snapshot"
-        ; param_release= next_release
+        ; param_release= numbered_release "21.4.0"
         ; param_default= Some (VSet [])
         }
       ]

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "a3ddab734ad88468120269cf3d0e3bd9"
+let last_known_schema_hash = "2923e663753266bbdcb313ed47bad726"
 
 let current_schema_hash : string =
   let open Datamodel_types in


### PR DESCRIPTION
Replace all occurances of `next_release` and `rel_next` with appropriate version numbers.