### PR TITLE
CP-45970 remove qemu_trad_image.py

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -15,7 +15,6 @@
 import os
 import sys
 import socket
-import tempfile
 import errno
 import stat
 import pwd
@@ -28,7 +27,6 @@ from resource import getrlimit, RLIMIT_CORE, RLIMIT_FSIZE, setrlimit
 
 import xen.lowlevel.xs as xs
 
-import qemu_trad_image
 
 #
 # Constants from Xen's public/hvm/e820.h
@@ -248,20 +246,7 @@ def main(argv):
 
         if p == "-loadvm":
             loadvm_path = qemu_args[n+1]
-            if qemu_trad_image.is_trad_image(loadvm_path):
-                print("QEMU Traditional image detected. Upgrading...")
-
-                loadvm_file = open(loadvm_path, "rb")
-                incoming_file = tempfile.TemporaryFile()
-                upgraded_save_image = qemu_trad_image.convert_file(loadvm_file,
-                                                                   incoming_file,
-                                                                   qemu_args)
-                loadvm_file.close()
-
-                incoming_file.seek(0)
-                incoming_fd = os.dup(incoming_file.fileno())
-            else:
-                incoming_fd = os.open(loadvm_path, os.O_RDONLY)
+            incoming_fd = os.open(loadvm_path, os.O_RDONLY)
             qemu_args[n] = "-incoming"
             qemu_args[n+1] = "fd:%d" % incoming_fd
             open_fds.append(incoming_fd)


### PR DESCRIPTION
The script is only used at specific points:

- Migrating a VM from an XS7.1 host to XS8.
- Resuming a VM suspended on an XS 7.1 host on XS8.
- Reverting to a disk+memory snapshot created on XS 7.1 on an XS8 host.

All of these are unlikely scenarios since the only way to get to XS8 is by upgrading from CH 8.2 which means the customer would need to do a multi hop upgrade to hit the issue. We don't have XenRT tests for this. After discussing with Alex, we thought it would be better to remove this code and document this as a known limitation.

This modification involves changes in two aspects, xen-api and qemu.spec.

Test passed with 192904 (Ring3 BVT+BST combined) and 192757 (QA Karma test)