### PR TITLE
Python3 fixes for storage api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,7 @@ test:
 	 trap "kill $${PSTREE_SLEEP_PID}" SIGINT SIGTERM EXIT; \
 	 timeout --foreground $(TEST_TIMEOUT2) \
 		 dune runtest --profile=$(PROFILE) --error-reporting=twice -j $(JOBS)
-ifneq ($(PY_TEST), NO)
 	dune build @runtest-python --profile=$(PROFILE)
-endif
 
 stresstest:
 	dune build @stresstest --profile=$(PROFILE) --no-buffer -j $(JOBS)

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/plugin.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/plugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
  Copyright (C) Citrix Systems, Inc.

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/sr.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/sr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
  Copyright (C) Citrix Systems, Inc.
@@ -6,7 +6,7 @@
 
 import os
 import sys
-import urlparse
+import urllib.parse
 import xapi.storage.api.volume
 
 import plugin
@@ -21,11 +21,11 @@ class Implementation(xapi.storage.api.volume.SR_skeleton):
         return
 
     def detach(self, dbg, sr):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         return
 
     def ls(self, dbg, sr):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         qr = plugin.Implementation().query(dbg)
         return [{
             "name": qr['name'],
@@ -40,7 +40,7 @@ class Implementation(xapi.storage.api.volume.SR_skeleton):
             }]
 
     def stat(self, dbg, sr):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         qr = plugin.Implementation().query(dbg)
         return {
             "sr": sr,

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/volume.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummy/volume.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
  Copyright (C) Citrix Systems, Inc.
 """
 
 import uuid
-import urlparse
+import urllib.parse
 import os
 import sys
 import xapi.storage.api.volume
@@ -17,7 +17,7 @@ import plugin
 class Implementation(xapi.storage.api.volume.Volume_skeleton):
 
     def create(self, dbg, sr, name, description, size):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         voluuid = str(uuid.uuid4())
         return {
             "name": name,
@@ -32,11 +32,11 @@ class Implementation(xapi.storage.api.volume.Volume_skeleton):
         }
 
     def destroy(self, dbg, sr, key):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         return
 
     def stat(self, dbg, sr, key):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         qr = plugin.Implementation().query(dbg)
         return {
                 "name": qr['name'],

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/plugin.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/plugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
  Copyright (C) Citrix Systems, Inc.

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/sr.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/sr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
  Copyright (C) Citrix Systems, Inc.
@@ -6,7 +6,7 @@
 
 import os
 import sys
-import urlparse
+import urllib.parse
 import xapi.storage.api.v5.volume
 
 import plugin
@@ -22,11 +22,11 @@ class Implementation(xapi.storage.api.v5.volume.SR_skeleton):
         return configuration
 
     def detach(self, dbg, sr):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         return
 
     def ls(self, dbg, sr):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         qr = plugin.Implementation().query(dbg)
         return [{
             "name": qr['name'],
@@ -42,7 +42,7 @@ class Implementation(xapi.storage.api.v5.volume.SR_skeleton):
             }]
 
     def stat(self, dbg, sr):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         qr = plugin.Implementation().query(dbg)
         return {
             "sr": sr,

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
  Copyright (C) Citrix Systems, Inc.
 """
 
 import uuid
-import urlparse
+import urllib.parse
 import os
 import sys
 import xapi.storage.api.v5.volume
@@ -17,7 +17,7 @@ import plugin
 class Implementation(xapi.storage.api.v5.volume.Volume_skeleton):
 
     def create(self, dbg, sr, name, description, size, sharable):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         voluuid = str(uuid.uuid4())
         return {
             "name": name,
@@ -33,11 +33,11 @@ class Implementation(xapi.storage.api.v5.volume.Volume_skeleton):
         }
 
     def destroy(self, dbg, sr, key):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         return
 
     def stat(self, dbg, sr, key):
-        urlparse.urlparse(sr)
+        urllib.parse.urlparse(sr)
         qr = plugin.Implementation().query(dbg)
         return {
                 "name": qr['name'],

--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
+++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
@@ -69,8 +69,8 @@ if __name__ == "__main__":
     elif base == "Volume.stat":
         cmd.stat()
     elif base == "Volume.set":
-	cmd.set()
+        cmd.set()
     elif base == "Volume.unset":
-	cmd.unset()
+        cmd.unset()
     else:
         raise xapi.storage.api.v5.volume.Unimplemented(base)

--- a/ocaml/xapi-storage/python/xapi/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/__init__.py
@@ -31,6 +31,13 @@ import traceback
 import json
 import argparse
 
+# pylint: disable=invalid-name,redefined-builtin,undefined-variable
+# pyright: reportUndefinedVariable=false
+if sys.version_info[0] > 2:
+    long = int
+    unicode = str
+    str = bytes
+
 
 def success(result):
     return {"Status": "Success", "Value": result}

--- a/ocaml/xapi-storage/python/xapi/storage/api/datapath.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/datapath.py
@@ -6,6 +6,14 @@ import json
 import argparse
 import traceback
 import logging
+
+# pylint: disable=invalid-name,redefined-builtin,undefined-variable
+# pyright: reportUndefinedVariable=false
+if sys.version_info[0] > 2:
+    long = int
+    unicode = str
+    str = bytes
+
 class Unimplemented(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])

--- a/ocaml/xapi-storage/python/xapi/storage/api/plugin.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/plugin.py
@@ -6,6 +6,14 @@ import json
 import argparse
 import traceback
 import logging
+
+# pylint: disable=invalid-name,redefined-builtin,undefined-variable
+# pyright: reportUndefinedVariable=false
+if sys.version_info[0] > 2:
+    long = int
+    unicode = str
+    str = bytes
+
 class Unimplemented(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])


### PR DESCRIPTION
Running "make test" on a Debian12 fails because of the lack of python2, and switching those tests to python3 revealed problems.

It may be worth to have give "make test" the ability to run under python2 too (in which case the `urlparse` replacement must be kept py2-compatible), to ensure xs/xcp-ng 8.x do not regress.  I'm not sure how best to do achieve that, with the python tests run through `dune`.  Maybe they should be added to the py2/py3 tests jobs in Gitlab Actions, too.