### PR TITLE
fix(ci): remove 1024 fd limit for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ TEST_TIMEOUT=600
 TEST_TIMEOUT2=1200
 test:
 	ulimit -S -t $(TEST_TIMEOUT); \
-	 ulimit -n 1024; \
 	 (sleep $(TEST_TIMEOUT) && ps -ewwlyF --forest)& \
 	 PSTREE_SLEEP_PID=$$!; \
 	 trap "kill $${PSTREE_SLEEP_PID}" SIGINT SIGTERM EXIT; \


### PR DESCRIPTION
Setting this is useful for speeding up tests (by default my container has 1048576 as ulimit which makes the tests very slow), but there is something non-deterministic in the environment GitHub Actions run in:
* the tests pass on a PR, but fail when run as a scheduled CI job on master

We probably don't estimate correctly how many file descriptors the parent process uses in the test (GH actions seem to use more than locally).

Until we fully understand this revert the 'ulimit -n' part of this change.

Fixes: 954f3d337 ("build: set a timeout for the tests")