### PR TITLE
CP-46631: Add debug logs for most frequent spans.

### DIFF
--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -1,18 +1,17 @@
 (library
-  (name tracing)
-  (public_name xapi-tracing)
-  (libraries
-    cohttp
-    cohttp-posix
-    ptime
-    ptime.clock.os
-    rpclib.core
-    rpclib.json
-    xapi-log
-    xapi-open-uri
-    xapi-stdext-threads
-    xapi-stdext-unix
-    zstd
-  )
-  (preprocess (pps ppx_deriving_rpc))
-)
+ (name tracing)
+ (public_name xapi-tracing)
+ (libraries
+  cohttp
+  cohttp-posix
+  ptime
+  ptime.clock.os
+  rpclib.core
+  rpclib.json
+  xapi-log
+  xapi-open-uri
+  xapi-stdext-threads
+  xapi-stdext-unix
+  zstd)
+ (preprocess
+  (pps ppx_deriving_rpc ppx_deriving_yojson)))

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -11,6 +11,7 @@
   xapi-log
   xapi-open-uri
   xapi-stdext-threads
+  xapi-stdext-std
   xapi-stdext-unix
   zstd)
  (preprocess

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -352,75 +352,87 @@ module Spans = struct
 
   let finished_span_hashtbl_is_empty () = Hashtbl.length finished_spans = 0
 
-  let remove_from_spans span =
+  let remove_from_spans ?(with_lock = true) span =
     let key = span.Span.context.trace_id in
-    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
-        match Hashtbl.find_opt spans key with
-        | None ->
-            debug "%s span does not exist or already finished" __FUNCTION__ ;
-            None
-        | Some span_list ->
-            ( match
-                List.filter
-                  (fun x ->
-                    if x.Span.context <> span.context then
-                      true
-                    else
-                      let _ = SpanFrequencies.decr_frequency_tbl ~span:x in
-                      false
-                  )
-                  span_list
-              with
-            | [] ->
-                Hashtbl.remove spans key
-            | filtered_list ->
-                Hashtbl.replace spans key filtered_list
-            ) ;
-            Some span
-    )
+    let remove () =
+      match Hashtbl.find_opt spans key with
+      | None ->
+          debug "%s span does not exist or already finished" __FUNCTION__ ;
+          None
+      | Some span_list ->
+          ( match
+              List.filter
+                (fun x ->
+                  if x.Span.context <> span.context then
+                    true
+                  else
+                    let _ = SpanFrequencies.decr_frequency_tbl ~span:x in
+                    false
+                )
+                span_list
+            with
+          | [] ->
+              Hashtbl.remove spans key
+          | filtered_list ->
+              Hashtbl.replace spans key filtered_list
+          ) ;
+          Some span
+    in
+    if with_lock then
+      Xapi_stdext_threads.Threadext.Mutex.execute lock remove
+    else
+      remove ()
 
-  let add_to_finished span =
+  type tbls = ActiveTbl | FinishedTbl
+
+  let add_to_tbl_helper ?(trace_bucket = []) ~span ~key ~tbl ~tbl_type
+      do_on_full =
+    let full () =
+      match trace_bucket with
+      | [] ->
+          Hashtbl.length tbl >= !max_traces
+      | _ ->
+          List.length trace_bucket >= !max_spans
+    in
+
+    if not (full ()) then
+      match tbl_type with
+      | ActiveTbl ->
+          SpanFrequencies.incr_frequency_tbl ~span ;
+          Hashtbl.replace tbl key (span :: trace_bucket)
+      | FinishedTbl ->
+          Hashtbl.replace tbl key (span :: trace_bucket)
+    else
+      do_on_full ()
+
+  let add_to_finished ?(with_lock = true) span =
     let key = span.Span.context.trace_id in
-    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
-        match Hashtbl.find_opt finished_spans key with
-        | None ->
-            if Hashtbl.length finished_spans < !max_traces then
-              Hashtbl.add finished_spans key [span]
-            else
-              debug "%s exceeded max traces when adding to finished span table"
-                __FUNCTION__
-        | Some span_list ->
-            if List.length span_list < !max_spans then
-              Hashtbl.replace finished_spans key (span :: span_list)
-            else
-              debug "%s exceeded max traces when adding to finished span table"
-                __FUNCTION__
-    )
+    let add () =
+      add_to_tbl_helper
+        ?trace_bucket:(Hashtbl.find_opt finished_spans key)
+        ~span ~key ~tbl:finished_spans ~tbl_type:FinishedTbl
+      @@ fun () ->
+      debug "%s exceeded max traces when adding to finished span table"
+        __FUNCTION__
+    in
+    if with_lock then
+      Xapi_stdext_threads.Threadext.Mutex.execute lock add
+    else
+      add ()
 
-  let mark_finished span = Option.iter add_to_finished (remove_from_spans span)
+  let mark_finished ?(with_lock = true) span =
+    Option.iter (add_to_finished ~with_lock) (remove_from_spans ~with_lock span)
 
   let add_to_spans ~(span : Span.t) =
     let key = span.context.trace_id in
     Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
-        match Hashtbl.find_opt spans key with
-        | None ->
-            if Hashtbl.length spans < !max_traces then (
-              SpanFrequencies.incr_frequency_tbl ~span ;
-              Hashtbl.add spans key [span]
-            ) else (
-              debug "%s exceeded max traces when adding to span table"
-                __FUNCTION__ ;
-              ignore (SpanFrequencies.debug_most_frequent ())
-            )
-        | Some span_list ->
-            if List.length span_list < !max_spans then (
-              SpanFrequencies.incr_frequency_tbl ~span ;
-              Hashtbl.replace spans key (span :: span_list)
-            ) else (
-              debug "%s exceeded max traces when adding to span table"
-                __FUNCTION__ ;
-              ignore (SpanFrequencies.debug_most_frequent ())
-            )
+        add_to_tbl_helper
+          ?trace_bucket:(Hashtbl.find_opt spans key)
+          ~span ~key ~tbl:spans ~tbl_type:ActiveTbl
+        @@ fun () ->
+        debug "%s exceeded max traces when adding to finished span table"
+          __FUNCTION__ ;
+        ignore (SpanFrequencies.debug_most_frequent ())
     )
 
   let span_is_finished x =
@@ -443,7 +455,7 @@ module Spans = struct
         copy
     )
 
-  let dump () = Hashtbl.(copy spans, Hashtbl.copy finished_spans)
+  let dump () = Hashtbl.(copy spans, copy finished_spans)
 
   module GC = struct
     let lock = Mutex.create ()

--- a/xapi-tracing.opam
+++ b/xapi-tracing.opam
@@ -14,6 +14,7 @@ depends: [
   "cohttp-posix"
   "dune"
   "cohttp"
+  "ppx_deriving_yojson"
   "rpclib"
   "xapi-log"
   "xapi-open-uri"


### PR DESCRIPTION
Adds debug logs of the most frequent 10 spans when the spans table is full.
If the span table is full, when adding starting a new span, forcefully finish the oldest half of the most frequent spans before adding a new one.

In case the spans table is getting full, we want to know the most frequent spans. This will help us to better understand why they are not finishing in time.

As a consequence of having a shared lock between `spans` and `finished_spans`, the previous `mark_as_finished` couldn't be called when forcibly closing the spans. My workaround was to add some optional parameters `with_lock` that would allow some of the functions to be called without locks. As it is only a workaround, I have a subsequent PR, https://github.com/xapi-project/xen-api/pull/5467, that tries to create a better abstraction for the span tables. 