### PR TITLE
CA-388107: Make sure VM is running when starting restart_device_models

### DIFF
--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1613,6 +1613,19 @@ let set_NVRAM_EFI_variables ~__context ~self ~value =
   )
 
 let restart_device_models ~__context ~self =
+  let power_state = Db.VM.get_power_state ~__context ~self in
+  if power_state <> `Running then
+    raise
+      Api_errors.(
+        Server_error
+          ( vm_bad_power_state
+          , [
+              Ref.string_of self
+            ; Record_util.power_state_to_string `Running
+            ; Record_util.power_state_to_string power_state
+            ]
+          )
+      ) ;
   let host = Db.VM.get_resident_on ~__context ~self in
   (* As it is implemented as a localhost migration, just reuse message
    * forwarding of "pool_migrate" to handle "allowed operation" and "message


### PR DESCRIPTION
Now vm.restart_device_models is implemented using a local vm.pool_migrate. For vm.pool_migrate, a destination host is expected, while for vm.restart_device_models, no destination host is needed.

With a missing destination host(NULL), when a VM is paused or halted, vm.pool_migrate will raise Api_errors.vm_bad_power_state, while not for a suspended VM.

As this is not an issue of vm.pool_migrate, check VM power state before calling vm.pool_migrate in vm.restart_device_models.