### PR TITLE
CA-388180 Correcting Domain CPU Usage Values

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -240,7 +240,9 @@ let dss_vcpus xc doms =
         let dom_cpu_time =
           Int64.(to_float @@ logand dom.Xenctrl.cpu_time xen_flag_complement)
         in
-        let dom_cpu_time = dom_cpu_time /. 1.0e9 in
+        let dom_cpu_time =
+          dom_cpu_time /. (1.0e9 *. float_of_int dom.Xenctrl.nr_online_vcpus)
+        in
         try
           let ri = Xenctrl.domain_get_runstate_info xc domid in
           ( Rrd.VM uuid


### PR DESCRIPTION
According to [https://github.com/xen-project/xen/blob/9659b2a6d73b14620e187f9c626a09323853c459/xen/common/domctl.c#L84](url)
The `cpu_time` in `Xenctrl.domaininfo` represent the **sum** of the `cpu_time` for all the online vCPUs, but not an **average**, therefore, when obtaining the CPU usage for a domain, it is necessary to divide by the number of online CPUs.

test result:
`[root@xrtmia-10-03 home]# xe vm-data-source-query uuid=3541caa0-2ff3-4381-a19a-964d70fd3158 data-source=cpu_usage
0.503919`
`[root@xrtmia-10-03 home]# mpstat 1 1`
`Linux 4.19.0+1 (xrtmia-10-03)   01/25/2024      _x86_64_        (8 CPU)`
`09:04:04 AM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle`
`09:04:05 AM  all   51.38    0.00    0.00    0.00    0.00    0.00    0.12    0.00    0.00   48.50`
`Average:     all   51.38    0.00    0.00    0.00    0.00    0.00    0.12    0.00    0.00   48.50`