### PR TITLE
xapi.conf: fix setting name for custom UEFI certs

### DIFF
--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -81,9 +81,8 @@ igd-passthru-vendor-whitelist = 8086
 # Allowlist of domain name pattern in binary-url and source-url in repository
 # repository-domain-name-allowlist =
 
-# Override the default location of RPM-provided certificates in default_auth_dir (/usr/share/varstored)
-# to force use of customised UEFI certificates in varstore_dir (/var/lib/varstored)
-# override-uefi-certs = false
+# Allow the use of custom UEFI certificates
+# allow-custom-uefi-certs = false
 
 # Paths to utilities: ############################################
 


### PR DESCRIPTION
When the `override-uefi-certs` setting was renamed to `allow-custom-uefi-certs`, we forgot to update xapi.conf.