### PR TITLE
CP-47033: Make message switch concurrent processing optional

### DIFF
--- a/ocaml/message-switch/async/protocol_async.ml
+++ b/ocaml/message-switch/async/protocol_async.ml
@@ -30,6 +30,9 @@ module M = struct
 
     let iter f t = Deferred.List.iter t ~f
 
+    let iter_dontwait f t =
+      Deferred.don't_wait_for @@ Deferred.List.iter ~how:`Parallel t ~f
+
     let any = Deferred.any
 
     let is_determined = Deferred.is_determined

--- a/ocaml/message-switch/core/dune
+++ b/ocaml/message-switch/core/dune
@@ -9,6 +9,7 @@
     sexplib
     sexplib0
     uri
+    xapi-log
   )
   (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )

--- a/ocaml/message-switch/core/s.ml
+++ b/ocaml/message-switch/core/s.ml
@@ -91,6 +91,14 @@ module type SERVER = sig
   (** Connect to [switch] and start processing messages on [queue] via function
       [process] *)
 
+  val listen_p :
+       process:(string -> string io)
+    -> switch:string
+    -> queue:string
+    -> unit
+    -> t result io
+  (** same as above, but processes requests concurrently *)
+
   val shutdown : t:t -> unit -> unit io
   (** [shutdown t] shutdown a server *)
 end

--- a/ocaml/message-switch/core/s.ml
+++ b/ocaml/message-switch/core/s.ml
@@ -29,6 +29,8 @@ module type BACKEND = sig
 
     val iter : ('a -> unit t) -> 'a list -> unit t
 
+    val iter_dontwait : ('a -> unit t) -> 'a list -> unit
+
     val any : 'a t list -> 'a t
 
     val is_determined : 'a t -> bool

--- a/ocaml/message-switch/core_test/basic-rpc-test.sh
+++ b/ocaml/message-switch/core_test/basic-rpc-test.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 set -e
 
-SPATH=${TMPDIR:-/tmp}/sock
-SWITCHPATH=${TMPDIR:-/tmp}/switch
+SPATH=${TMPDIR:-/tmp}/sock_s
+SWITCHPATH=${TMPDIR:-/tmp}/switch_s
 
 
 rm -rf ${SWITCHPATH} && mkdir -p ${SWITCHPATH}
+
+echo Test message switch serial processing
 
 echo Checking the switch can start late
 ./server_unix_main.exe -path $SPATH &

--- a/ocaml/message-switch/core_test/concur-rpc-test.sh
+++ b/ocaml/message-switch/core_test/concur-rpc-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+SPATH="${TMPDIR:-/tmp}/sock_p-$$"
+SWITCHPATH="${TMPDIR:-/tmp}/switch_p-$$"
+
+trap "cleanup" TERM INT
+
+function cleanup {
+  rm -rf "${SWITCHPATH}"
+}
+
+rm -rf "${SWITCHPATH}" && mkdir -p "${SWITCHPATH}"
+
+echo Test message switch concurrent processing
+
+echo Checking the switch can start late
+test -x ./server_unix_main.exe || exit 1
+./server_unix_main.exe -path "$SPATH" &
+sleep 1
+test -x ../switch/switch_main.exe && test -x ./client_unix_main.exe || exit 1
+../switch/switch_main.exe --path "$SPATH" --statedir "${SWITCHPATH}" &
+./client_unix_main.exe -path "$SPATH" -secs 5
+sleep 2
+
+echo Performance test of Lwt to Lwt
+test -x lwt/server_main.exe && test -x lwt/client_main.exe || exit 1
+lwt/server_main.exe -path "$SPATH" -concurrent &
+lwt/client_main.exe -path "$SPATH" -secs 5
+sleep 2
+
+echo Performance test of Async to Lwt
+test -x lwt/server_main.exe && test -x async/client_async_main.exe || exit 1
+lwt/server_main.exe -path "$SPATH" -concurrent &
+async/client_async_main.exe -path "$SPATH" -secs 5
+sleep 2
+
+echo Performance test of Async to Async
+test -x async/server_async_main.exe && test -x async/client_async_main.exe || exit 1
+async/server_async_main.exe -path "$SPATH" -concurrent &
+async/client_async_main.exe -path "$SPATH" -secs 5
+sleep 2
+
+../cli/main.exe shutdown --path "$SPATH"
+sleep 2

--- a/ocaml/message-switch/core_test/dune
+++ b/ocaml/message-switch/core_test/dune
@@ -27,3 +27,20 @@
   (package message-switch)
 )
 
+(rule
+  (alias runtest)
+  (deps
+    client_unix_main.exe
+    server_unix_main.exe
+    async/client_async_main.exe
+    async/server_async_main.exe
+    lwt/client_main.exe
+    lwt/server_main.exe
+    lwt/link_test_main.exe
+    ../switch/switch_main.exe
+    ../cli/main.exe
+  )
+  (action (run ./concur-rpc-test.sh))
+  (package message-switch)
+)
+

--- a/ocaml/message-switch/lwt/protocol_lwt.ml
+++ b/ocaml/message-switch/lwt/protocol_lwt.ml
@@ -27,6 +27,8 @@ module M = struct
 
     let iter = Lwt_list.iter_s
 
+    let iter_dontwait f lst = Lwt.async (fun () -> Lwt_list.iter_p f lst)
+
     let any = Lwt.choose
 
     let is_determined t = Lwt.state t <> Lwt.Sleep

--- a/ocaml/message-switch/switch/switch_main.ml
+++ b/ocaml/message-switch/switch/switch_main.ml
@@ -75,6 +75,13 @@ module Lwt_result = struct
   let ( >>= ) m f = m >>= fun x -> f (Stdlib.Result.get_ok x)
 end
 
+let exn_hook e =
+  let bt = Printexc.get_raw_backtrace () in
+  error "Caught exception in Lwt.async: %s" (Printexc.to_string e) ;
+  error "backtrace: %s" (Printexc.raw_backtrace_to_string bt)
+
+let () = Lwt.async_exception_hook := exn_hook
+
 let make_server config trace_config =
   let open Config in
   info "Started server on %s" config.path ;

--- a/ocaml/message-switch/unix/protocol_unix.ml
+++ b/ocaml/message-switch/unix/protocol_unix.ml
@@ -546,5 +546,7 @@ module Server = struct
     let (_ : Thread.t) = thread_forever (loop connections) None in
     Ok ()
 
+  let listen_p = listen
+
   let shutdown ~t:_ () = failwith "Shutdown is unimplemented"
 end


### PR DESCRIPTION
Reattempt of the revert #5388 of the original PR #5309, but be more conservative

make the previous concurrent processing of message switch optional. User has to use the `listen_p` method in order to use this feature. Didn't try to factor out the common code as the locking seems to be quite convoluted into the code itself, not easy to do. In the long run, we would want to remove the serial processing anyway.

Tested this on the vdi revert tests. The test seems to be happy now (after kicking off 30 of them), all I did in terms of the change was to add the `protect_connect` which disconnects the channel and returns an error. 
But still be a bit more conservative and not turning it on by default.