### PR TITLE
CA-382640: open SHM with os.open to allow for RW/Creat

### DIFF
--- a/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
@@ -223,7 +223,8 @@ class API(object):
         self.path = self.dispatcher.get_path({"uid": self.uid})
         base_path = os.path.dirname(self.path)
         if not os.path.exists(base_path): os.makedirs(base_path)
-        self.dest = open(self.path, "wb")
+        fd = os.open(self.path, os.O_RDWR|os.O_CREAT)
+        self.dest = os.fdopen(fd, mode='r+b')
 
     def __del__(self):
         self.deregister()

--- a/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
@@ -223,6 +223,7 @@ class API(object):
         self.path = self.dispatcher.get_path({"uid": self.uid})
         base_path = os.path.dirname(self.path)
         if not os.path.exists(base_path): os.makedirs(base_path)
+        # Open file at pos 0, creating but not truncating the file(not possible otherwise):
         fd = os.open(self.path, os.O_RDWR|os.O_CREAT)
         self.dest = os.fdopen(fd, mode='r+b')
 

--- a/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
@@ -225,7 +225,7 @@ class API(object):
         if not os.path.exists(base_path): os.makedirs(base_path)
         # Open file at pos 0, creating but not truncating the file(not possible otherwise):
         fd = os.open(self.path, os.O_RDWR|os.O_CREAT)
-        self.dest = os.fdopen(fd, mode='r+b')
+        self.dest = os.fdopen(fd, "r+b")
 
     def __del__(self):
         self.deregister()


### PR DESCRIPTION
This avoid the possibility of the `open` truncating an existing shared memory block, which `open(<path>, 'wb')` would do. Should have only happened on domain id wrap so is probably extremely rare/unlikely.