### PR TITLE
xapi-rrd: attach tests to package

### DIFF
--- a/ocaml/libs/xapi-rrd/lib_test/dune
+++ b/ocaml/libs/xapi-rrd/lib_test/dune
@@ -1,5 +1,6 @@
 (test
   (name unit_tests)
+  (package xapi-rrd)
   (modules unit_tests)
   (deps (source_tree test_data))
   (libraries
@@ -13,6 +14,7 @@
 
 (test
   (name crowbar_tests)
+  (package xapi-rrd)
   (modules crowbar_tests)
   (libraries
     bigarray


### PR DESCRIPTION
Otherwise dune runs them for all packages in the repository, failing if they don't depend on the xapi-rrd library. This happens when opam builds the packages individually, like in https://github.com/xapi-project/xs-opam/actions/runs/7735950831/job/21092466205