### PR TITLE
datamodel_lifecycle: update cluster forum introduction versions

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -22,15 +22,15 @@ let prototyped_of_field = function
   | "Repository", "gpgkey_path" ->
       Some "22.12.0"
   | "Cluster_host", "last_update_live" ->
-      Some "24.2.1-next"
+      Some "24.3.0"
   | "Cluster_host", "live" ->
-      Some "24.2.1-next"
+      Some "24.3.0"
   | "Cluster", "live_hosts" ->
-      Some "24.2.1-next"
+      Some "24.3.0"
   | "Cluster", "quorum" ->
-      Some "24.2.1-next"
+      Some "24.3.0"
   | "Cluster", "is_quorate" ->
-      Some "24.2.1-next"
+      Some "24.3.0"
   | "VTPM", "contents" ->
       Some "22.26.0"
   | "VTPM", "is_protected" ->


### PR DESCRIPTION
I manually set this, as these were missed when cutting 24.3.0: https://github.com/xapi-project/xen-api/releases/tag/v24.3.0