### PR TITLE
Post-Python3-fixup for xcp-rrdd/scripts/rrdd.py:  Fix crash on `socket.error` on connect() to xcp-rrdd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,16 +54,18 @@ jobs:
         run: pip install pandas pytype toml
 
       - name: Install common dependencies for Python ${{matrix.python-version}}
-        run: pip install mock pytest-coverage pytest-mock
 
-      - name: Run Pytest tests for Python ${{matrix.python-version}}
-        run: >
-          pytest --cov scripts scripts/ -vv -rA
-          --junitxml=.git/pytest${{matrix.python-version}}.xml
-          --cov-report term-missing
-          --cov-report xml:.git/coverage${{matrix.python-version}}.xml
+        # pytest>=7 changed the pytest.ini settings in an incompatible way,
+        # skip it to have a uniform pytest config with Python 2.7:
+
+        run: pip install mock 'pytest<7' pytest-coverage pytest-mock
+
+      - name: Run Pytest tests with coverage for Python ${{matrix.python-version}}
+        # testpaths are set in pytest.ini(common config with pytest-4 of Python 2.7)
+        run: make diff-cover
         env:
           PYTHONDEVMODE: yes
+          PYTHONVERSION: ${{matrix.python-version}}
 
       - name: Upload Python ${{matrix.python-version}} coverage report to Codecov
         uses: codecov/codecov-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
-#
-# Configuration of pre-commit, a Python framework for git hooks.
+# -------------------------------------------------------------------------
+# `pre-commit` is a framework for managing and maintaining multi-language
+# pre-commit hooks. The hooks are run on every commit, and can be run
+# manually with `pre-commit run`. See: https://pre-commit.com/
+# -------------------------------------------------------------------------
 # pre-commit is run for each git push by GitHub CI. It can run
 # locally as well for early feedback and automatic formatting
 # like trailing whitespace removal (to be configured later):
@@ -28,6 +31,28 @@ repos:
     -   id: check-yaml
     -   id: check-executables-have-shebangs
         exclude: ocaml
+
+
+-   repo: local
+    hooks:
+    -   id: pytest
+        name: check Python unit tests pass and diff-cover misses no lines
+        entry: make diff-cover
+        require_serial: true
+        pass_filenames: false
+        language: python
+        types: [python]
+        additional_dependencies:
+        - coverage
+        - diff-cover
+        - future
+        - mock
+        - pytest<7
+        - pytest-coverage
+        - pytest-mock
+        - pytest-pythonpath
+        - pytest-timeout
+
 
 # Recommendation for a minimal git pre-push hook:
 # While using pre-commit yields great results, it

--- a/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
@@ -100,7 +100,7 @@ class Proxy(xmlrpc.client.ServerProxy):
     def __init__(self, uri, transport=None, encoding=None, verbose=0,
                  allow_none=1):
         xmlrpc.client.ServerProxy.__init__(self, uri, transport, encoding,
-                                       verbose, allow_none)
+                                           bool(verbose), bool(allow_none))
         self.transport = transport
 
     def request(self, methodname, params):
@@ -246,11 +246,11 @@ class API(object):
 
     def get_header(self):
         """Get the 'static' first line of the expected output format."""
-        return self.header
+        return self.header  # pytype: disable=attribute-error
 
     def get_path(self):
         """Get the path of the file in which to write the results to."""
-        return self.path
+        return self.path  # pytype: disable=attribute-error
 
     def register(self):
         """Register plugin if not already registered, and return next_reading."""

--- a/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/rrdd.py
@@ -286,7 +286,7 @@ class API(object):
                 return
             except socket.error:
                 msg = "Failed to contact xcp-rrdd. Sleeping for 5 seconds .."
-                print >> sys.stderr, msg
+                print(msg, file=sys.stderr)
                 time.sleep(5)
 
     def update(self):

--- a/ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py
@@ -1,0 +1,79 @@
+# Test: pytest -v -s ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py
+"""Parametrized test exercising all conditions in rrdd.API.wait_until_next_reading()"""
+import socket
+from warnings import catch_warnings as import_without_warnings, simplefilter
+
+# Dependencies:
+# pip install pytest-mock
+import pytest
+
+# Handle DeprecationWarning from importing imp (it was removed with Python 3.12)
+with import_without_warnings():
+    simplefilter(action="ignore", category=DeprecationWarning)
+    import rrdd
+
+
+# pylint:disable=no-member,redefined-outer-name  # pytest fixture, see below
+
+
+@pytest.fixture
+def api(mocker):
+    """Pytest fixture for creating a rrdd.API() instance"""
+    instance = rrdd.API("plugin_id")
+    instance.deregister = mocker.Mock()
+    return instance
+
+
+# pylint:disable=too-many-arguments  # pytest parametrized test, see below
+@pytest.mark.parametrize(
+    "neg_shift, interval, reading, sleep",
+    [
+        # Happy path tests with various realistic test values
+        (None, 5, (6,), 5),  # Test the default value of neg_shift
+        (1, 5, (6,), 5),  # to call in the same sleep as neg_shift=1
+        (2.25, 5, (6,), 3.75),  # Test neg_shift as float to get sleep as float
+        (0.5, 30, (30.5,), 30),  # Also as a fraction of a second
+        (2, 120, (122,), 120),  # Test large interval and reading
+        # Edge cases
+        (11, 5, (1,), 0),  # large neg_shift results in no sleep
+        (1, 10, (1,), 0),  # neg_shift equals reading from xcp-rrdd
+        (1, 9, (10,), 9),  # wait_time is exactly one cycle
+        (1, 10, (9,), 8),  # wait_time is negative, should wrap around
+        # Error case
+        (1, 7, (socket.error, 6), 5),  # first register raises socket.error
+    ],
+)
+def test_params(api, mocker, neg_shift, interval, reading, sleep, capsys):
+    """Test that wait_until_reading_from_xcp_rrd() works with various test values"""
+    # Arrange
+    api.frequency_in_seconds = interval
+    api.lazy_complete_init = mocker.Mock()
+    api.register = mocker.Mock(side_effect=reading)
+    api.deregister = mocker.Mock()
+
+    # Act
+    mock_sleep = mocker.patch("time.sleep")
+    if neg_shift is None:
+        rrdd.API.wait_until_next_reading(api)
+    else:
+        rrdd.API.wait_until_next_reading(api, neg_shift)
+
+    # Assert
+    mock_sleep.assert_called_with(sleep)
+
+    with capsys.disabled():
+        stderr = capsys.readouterr().err
+        stdout = capsys.readouterr().out
+        if reading[0] is socket.error:
+            assert stderr == "Failed to contact xcp-rrdd. Sleeping for 5 seconds ..\n"
+        else:
+            assert stderr == ""
+        assert stdout == ""
+
+
+def test_api_getter_functions(api):
+    """Test that the API getter functions work (and cover the code)"""
+    api.header = "header"
+    api.path = "path"
+    assert api.get_header() == "header"
+    assert api.get_path() == "path"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,59 @@
+#------------------------------------------------------------------------------
+# pytest.ini for pytest<=6 for uniform config with pytest-4 for Python 2.7
+# pyproject.toml is not supported by pytest-4, so this file is used instead.
+#------------------------------------------------------------------------------
+# Also, pyproject.toml is already full with many settings, so this file is
+# used to keep the pytest settings separate.
+#------------------------------------------------------------------------------
+# Install command: pip install pytest<7
+#------------------------------------------------------------------------------
+# For pytest>=7, you'd have to remove python_paths and replace testpaths below
+# which would mean that you cannot test with pytest-4 for Python2.7 anymore.
+#------------------------------------------------------------------------------
+
+[pytest]
+
+# pytest plugins required for testing:
+#
+required_plugins =
+    pytest-mock
+    pytest-pythonpath
+    pytest-timeout
+
+# Show reports for failed tests by default:
+#
+addopts=-rF
+
+#
+# Unless test targets are given on the command line,
+# run the tests found in these directories.
+# Also used in the GitHub CI workflow and for pre-commit hooks:
+#
+testpaths=scripts ocaml/xcp-rrdd
+
+#
+# All tests have to complete within a second, sleepy tests are not tolerated.
+# This is a hard limit, not a soft one, so it will kill slow tests.
+# This is a good thing, because it prevents the CI from hanging.
+# It also prevents the pre-commit hook from hanging or being slow.
+#
+# Timeout handling is provided by pytest-timeout, kills tests after 1 second:
+#
+timeout=1
+
+# Enabled live logging of the python log output, starting with logger level INFO by default:
+#
+log_cli=True
+log_cli_level=INFO
+
+#
+# Only effective for pytest<7: Don't warn about new configs for pytest>7:
+# In means pytest-7 has shut the door for all uniform compatibility configs:
+#
+filterwarnings=ignore:Unknown config option
+
+#
+# Provided by pytest-pythonpath for Python >=2.7
+# See https://pypi.org/project/pytest-pythonpath:
+#
+python_paths=scripts/examples/python scripts/plugins scripts/examples scripts .


### PR DESCRIPTION
`2to3` failed to convert `xcp-rrdd/scripts/rrdd.py` properly (it chokes and just quits), so here is the manual Post-Python3-fixup for it:
```js
             except socket.error:
                 msg = "Failed to contact xcp-rrdd. Sleeping for 5 seconds .."
-                print >> sys.stderr, msg
+                print(msg, file=sys.stderr)
```
This means, instead of sleeping and retrying in 5 seconds, the `xcp-rrdd/scripts/rrdd.py` would crash.

- Found by opening the file in VS Code and scrolling over the file, observing an orange squiggly line below this old print statement.

PS: In a follow-up PR, I'll also broaden the scan of the new Python CI Workflow using [xen-api/pytype_reporter.py](https://github.com/xapi-project/xen-api/blob/master/pytype_reporter.py) to cover all Python modules, not just those below [xen-api/scripts](https://github.com/xapi-project/xen-api/tree/master/scripts).

PPS: The results of these scans are in a Markdown table below the GitHub action summary. When you follow the link to the workflow run on GitHub from the PR and also just pushed commits. Improvements over that to come, hopefully.

An early preview of what would be possible is here: https://github.com/xenserver-next/xen-api/pull/11

This PR consists of:
1. The fix commit,
2. A unit test covering the function with the change, and ensuring the `print()` now really works!
3. A minimal plaster tapering over the other findings of the `pytype` static analysis checker that is now needed to pass CI with changed Python files.
   - xmlrpc.client.ServerProxy.__init__() receives the flags `verbose` and `allow_none` as `bool`, so static analysis does not like it when you pass integers to it. They can just be converted to `bool()`. The script does not actually pass these keyword arguments, but the subclass of it sets default values for them, that are currently given as `int` values.
   - static analysis tools in general like to see class attributes declared and initialised in the constructor of the class. When a class is written in a way to create class attributes dynamically, these  warnings ring. At a minimum, we now need to silence the warning for CI to pass.