### PR TITLE
Try to avoid ENOSPC in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,16 @@ jobs:
       - name: Update Ubuntu repositories
         run: sudo apt-get update
 
+      - name: Use disk with more space for TMPDIR and XDG_CACHE_HOME
+        run: |
+          df -h || true
+          export TMPDIR="/mnt/build/tmp"
+          export XDG_CACHE_HOME="/mnt/build/cache"
+          sudo mkdir -p "${TMPDIR}" "${XDG_CACHE_HOME}"
+          sudo chown "$(id -u):$(id -g)" "${TMPDIR}" "${XDG_CACHE_HOME}"
+          echo "TMPDIR=${TMPDIR}" >>"$GITHUB_ENV"
+          echo "XDG_CACHE_HOME=${XDG_CACHE_HOME}" >>"$GITHUB_ENV"
+                        
       - name: Use ocaml
         uses: ocaml/setup-ocaml@v2
         with:
@@ -166,6 +176,9 @@ jobs:
       - name: Sanity test SDK
         run: |
           opam exec -- make sdksanity
+
+      - name: Check disk space
+        run: df -h || true
 
       - name: Uninstall unversioned packages and remove pins
         # This should purge them from the cache, unversioned package have

--- a/ocaml/libs/vhd/vhd_format_lwt_test/parse_test.ml
+++ b/ocaml/libs/vhd/vhd_format_lwt_test/parse_test.ml
@@ -29,7 +29,7 @@ let diff () =
   let _ = Diff_vhd.disk in
   ()
 
-let tmp_file_dir = "/tmp"
+let tmp_file_dir = Filename.get_temp_dir_name ()
 
 let disk_name_stem = tmp_file_dir ^ "/parse_test."
 

--- a/ocaml/libs/vhd/vhd_format_lwt_test/patterns_lwt.ml
+++ b/ocaml/libs/vhd/vhd_format_lwt_test/patterns_lwt.ml
@@ -29,7 +29,7 @@ module Memory = struct
       Cstruct.sub pages 0 bytes
 end
 
-let disk_name_stem = "/tmp/dynamic."
+let disk_name_stem = Filename.get_temp_dir_name () ^ "/dynamic."
 
 let disk_suffix = ".vhd"
 


### PR DESCRIPTION
The VHD unit tests create a lot of files in /tmp and don't always clean it up.
Move the files elsewhere, although we should really fix the test to clean up too.