### PR TITLE
CA-388437: fix bond status reporting

### DIFF
--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -1278,25 +1278,29 @@ module Ovs = struct
 
     let get_bond_link_status name =
       try
+        (* Note: bond links are called "members" by the OVS. In old OVS
+           versions, the term "slaves" was used, which is also used by the
+           Linux kernel and in xapi. The terms bond link/slave/member are
+           used interchangably. *)
         let raw = appctl ~log:false ["bond/show"; name] in
         let lines = Astring.String.cuts ~empty:false ~sep:"\n" raw in
         List.fold_left
-          (fun (slaves, active_slave) line ->
-            let slaves =
+          (fun (members, active_member) line ->
+            let members =
               try
-                Scanf.sscanf line "slave %s@: %s" (fun slave state ->
-                    (slave, state = "enabled") :: slaves
+                Scanf.sscanf line "member %s@: %s" (fun member state ->
+                    (member, state = "enabled") :: members
                 )
-              with _ -> slaves
+              with _ -> members
             in
-            let active_slave =
+            let active_member =
               try
-                Scanf.sscanf line "active slave %s@(%s@)" (fun _ slave ->
-                    Some slave
+                Scanf.sscanf line "active member %s@(%s@)" (fun _ member ->
+                    Some member
                 )
-              with _ -> active_slave
+              with _ -> active_member
             in
-            (slaves, active_slave)
+            (members, active_member)
           )
           ([], None) lines
       with _ -> ([], None)


### PR DESCRIPTION
The OVS command to query the state of a bond now uses the term "member" rather than "slave" for bond links. Adapt the code in networkd to expect this.