### PR TITLE
CP-46946: Bumped API version to 2.21 for update guidance improvement

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -151,7 +151,7 @@ let tech_preview_releases =
  * but there are exceptions: please consult the XenCenter maintainers if in doubt. *)
 let api_version_major = 2L
 
-let api_version_minor = 20L
+let api_version_minor = 21L
 
 let api_version_string =
   Printf.sprintf "%Ld.%Ld" api_version_major api_version_minor


### PR DESCRIPTION
So that the existing XenCenter will refuse to connect to the new XAPI. This aims to force users to use the new XenCenter since the old XenCenter can't work with the new XAPI with update guidance improvement.