### PR TITLE
CP:46157: Add `observer_experimental_components` flag

### DIFF
--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -398,3 +398,19 @@ let good_ciphersuites =
     ["ECDHE-RSA-AES256-GCM-SHA384"; "ECDHE-RSA-AES128-GCM-SHA256"]
 
 let verify_certificates_path = "/var/xapi/verify-certificates"
+
+let observer_component_xapi = "xapi"
+
+let observer_component_xenopsd = "xenopsd"
+
+let observer_component_xapi_clusterd = "xapi-clusterd"
+
+let observer_component_smapi = "smapi"
+
+let observer_components_all =
+  [
+    observer_component_xapi
+  ; observer_component_xenopsd
+  ; observer_component_xapi_clusterd
+  ; observer_component_smapi
+  ]

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -16,6 +16,7 @@
 
 module String_plain = String (* For when we don't want the Xstringext version *)
 open Xapi_stdext_std.Xstringext
+module StringSet = Set.Make (String)
 
 module D = Debug.Make (struct let name = "xapi_globs" end)
 
@@ -1019,6 +1020,9 @@ let observer_endpoint_https_enabled = ref false
 
 let python3_path = ref "/usr/bin/python3"
 
+let observer_experimental_components =
+  ref (StringSet.singleton Constants.observer_component_smapi)
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1514,6 +1518,29 @@ let other_options =
     , Arg.Set observer_endpoint_https_enabled
     , (fun () -> string_of_bool !observer_endpoint_https_enabled)
     , "Enable https endpoints to be used by observers"
+    )
+  ; ( "observer-experimental-components"
+    , Arg.String
+        (fun s ->
+          observer_experimental_components :=
+            match s with
+            | "" ->
+                StringSet.empty
+            | s ->
+                let input_set =
+                  s |> String.split_on_char ',' |> StringSet.of_list
+                in
+                let valid_set =
+                  Constants.observer_components_all |> StringSet.of_list
+                in
+                StringSet.inter input_set valid_set
+        )
+    , (fun () ->
+        !observer_experimental_components
+        |> StringSet.elements
+        |> String.concat ","
+      )
+    , "Comma-separated list of experimental observer components"
     )
   ]
 


### PR DESCRIPTION
Adds a new variable in `Xapi_globs` that is a comma-separeted string of components. Components in this list will be considered experimental and therefore disabled by default. They can be enabled by adding an entry in `xapi.conf` without their name.

For instance, adding the line:

observer-experimental-components = ""

will enable all experimental copmponents.