### PR TITLE
Deterministic UUID for Backup VDIs

### DIFF
--- a/ocaml/libs/uuid/uuidx.ml
+++ b/ocaml/libs/uuid/uuidx.ml
@@ -83,3 +83,15 @@ let string_of_uuid = to_string
 let uuid_of_int_array = of_int_array
 
 let int_array_of_uuid = to_int_array
+
+module XenServer = struct
+  (** Derive a deterministic UUID from a string: the same
+      string maps to the same UUID. We are using our own namespace; the
+      namespace is not a secret *)
+
+  let xs = "e93e0639-2bdb-4a59-8b46-352b3f408c19"
+
+  let namespace = Uuidm.(of_string xs |> Option.get)
+
+  let hash str = Uuidm.v5 namespace str
+end

--- a/ocaml/libs/uuid/uuidx.mli
+++ b/ocaml/libs/uuid/uuidx.mli
@@ -81,3 +81,13 @@ val make_cookie : unit -> cookie
 val cookie_of_string : string -> cookie
 
 val string_of_cookie : cookie -> string
+
+module XenServer : sig
+  (** hash a string (deterministically) into a UUID. This uses
+      namespace UUID e93e0639-2bdb-4a59-8b46-352b3f408c19. *)
+
+  val namespace : 'a t (* UUID from above *)
+
+  (* UUID Version 5 derived from argument string and namespace UUID *)
+  val hash : string -> 'a t
+end

--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -152,7 +152,7 @@ let sr_update ~dbg dconf driver sr =
   let call = Sm_exec.make_call ~sr_ref:sr dconf "sr_update" [] in
   Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
 
-let vdi_create ~dbg dconf driver sr sm_config vdi_type size name_label
+let vdi_create ~dbg ?vdi_uuid dconf driver sr sm_config vdi_type size name_label
     name_description metadata_of_pool is_a_snapshot snapshot_time snapshot_of
     read_only =
   with_dbg ~dbg ~name:"vdi_create" @@ fun di ->
@@ -164,8 +164,8 @@ let vdi_create ~dbg dconf driver sr sm_config vdi_type size name_label
     ) ;
   srmaster_only dconf ;
   let call =
-    Sm_exec.make_call ~sr_ref:sr ~vdi_sm_config:sm_config ~vdi_type dconf
-      "vdi_create"
+    Sm_exec.make_call ?vdi_uuid ~sr_ref:sr ~vdi_sm_config:sm_config ~vdi_type
+      dconf "vdi_create"
       [
         sprintf "%Lu" size
       ; name_label

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -69,8 +69,8 @@ type call = {
 }
 
 let make_call ?driver_params ?sr_sm_config ?vdi_sm_config ?vdi_type
-    ?vdi_location ?new_uuid ?sr_ref ?vdi_ref (subtask_of, device_config) cmd
-    args =
+    ?vdi_location ?new_uuid ?sr_ref ?vdi_ref ?vdi_uuid
+    (subtask_of, device_config) cmd args =
   Server_helpers.exec_with_new_task "sm_exec" (fun __context ->
       (* Only allow a subset of calls if the SR has been introduced by a DR task. *)
       Option.iter
@@ -117,7 +117,11 @@ let make_call ?driver_params ?sr_sm_config ?vdi_sm_config ?vdi_type
           Option.map (fun self -> Db.VDI.get_location ~__context ~self) vdi_ref
       in
       let vdi_uuid =
-        Option.map (fun self -> Db.VDI.get_uuid ~__context ~self) vdi_ref
+        match vdi_uuid with
+        | None ->
+            Option.map (fun self -> Db.VDI.get_uuid ~__context ~self) vdi_ref
+        | uuid ->
+            uuid
       in
       let vdi_on_boot =
         Option.map

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -700,7 +700,7 @@ module SMAPIv1 : Server_impl = struct
             let sr = Db.SR.get_by_uuid ~__context ~uuid:(s_of_sr sr) in
             let value opt = Option.value ~default:"none" opt in
             let vi =
-              info "%s: CL vdi_info.uuid=%s" __FUNCTION__ (value vdi_info.uuid) ;
+              info "%s: vdi_info.uuid=%s" __FUNCTION__ (value vdi_info.uuid) ;
               Sm.call_sm_functions ~__context ~sR:sr (fun device_config _type ->
                   Sm.vdi_create ~dbg ?vdi_uuid:vdi_info.uuid device_config _type
                     sr vdi_info.sm_config vdi_info.ty vdi_info.virtual_size

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -698,12 +698,15 @@ module SMAPIv1 : Server_impl = struct
         Server_helpers.exec_with_new_task "VDI.create"
           ~subtask_of:(Ref.of_string dbg) (fun __context ->
             let sr = Db.SR.get_by_uuid ~__context ~uuid:(s_of_sr sr) in
+            let value opt = Option.value ~default:"none" opt in
             let vi =
+              info "%s: CL vdi_info.uuid=%s" __FUNCTION__ (value vdi_info.uuid) ;
               Sm.call_sm_functions ~__context ~sR:sr (fun device_config _type ->
-                  Sm.vdi_create ~dbg device_config _type sr vdi_info.sm_config
-                    vdi_info.ty vdi_info.virtual_size vdi_info.name_label
-                    vdi_info.name_description vdi_info.metadata_of_pool
-                    vdi_info.is_a_snapshot vdi_info.snapshot_time
+                  Sm.vdi_create ~dbg ?vdi_uuid:vdi_info.uuid device_config _type
+                    sr vdi_info.sm_config vdi_info.ty vdi_info.virtual_size
+                    vdi_info.name_label vdi_info.name_description
+                    vdi_info.metadata_of_pool vdi_info.is_a_snapshot
+                    vdi_info.snapshot_time
                     (s_of_vdi vdi_info.snapshot_of)
                     vdi_info.read_only
               )


### PR DESCRIPTION
I would like to use a deterministic UUID for Backup VDIs. This UUID is derived from the SR. This works with some manual testing but fails in some migration tests that don't even use these VDIs. I suspect this is related to code that I had to change in order to pass down the desired UUID to SM.

* I am using a special UUID when the VDI is "Pool Metadata Backup". This might not be the best way to recognize the special case.
* I had to add an optional `vdi_uuid` parameter in some calls and I suspect that is the source of the problem.

I would like to ask for a review.