### PR TITLE
Refactor cluster_health flag checking

### DIFF
--- a/ocaml/xapi/xapi_cluster_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_helpers.ml
@@ -103,3 +103,8 @@ let with_cluster_operation ~__context ~(self : [`Cluster] API.Ref.t) ~doc ~op
           (Datamodel_common._cluster, Ref.string_of self)
       with _ -> ()
   )
+
+let cluster_health_enabled ~__context =
+  let pool = Helpers.get_pool ~__context in
+  let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
+  List.assoc_opt "restrict_cluster_health" restrictions = Some "false"

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -515,12 +515,7 @@ let create_cluster_watcher_on_master ~__context ~host =
             Thread.delay 3.
       done
     in
-    let feature_enabled =
-      let pool = Helpers.get_pool ~__context in
-      let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
-      List.assoc_opt "restrict_cluster_health" restrictions = Some "false"
-    in
-    if feature_enabled then (
+    if Xapi_cluster_helpers.cluster_health_enabled ~__context then (
       debug "%s: create watcher for corosync-notifyd on master" __FUNCTION__ ;
       ignore @@ Thread.create watch ()
     ) else


### PR DESCRIPTION
This makes it more convenient to feature flag any future cluster_health features (A number of them on the way, such as sending alerts).