### PR TITLE
ci: remove action lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
           sudo chown "$(id -u):$(id -g)" "${TMPDIR}" "${XDG_CACHE_HOME}"
           echo "TMPDIR=${TMPDIR}" >>"$GITHUB_ENV"
           echo "XDG_CACHE_HOME=${XDG_CACHE_HOME}" >>"$GITHUB_ENV"
-                        
+
       - name: Use ocaml
         uses: ocaml/setup-ocaml@v2
         with:
@@ -200,9 +200,6 @@ jobs:
 
       - name: quality-gate
         run: make quality-gate
-
-      - uses: reviewdog/action-actionlint@v1
-        name: GitHub Action linter from https://github.com/reviewdog/action-actionlint
 
       - name: pyflakes
         uses: reviewdog/action-pyflakes@master


### PR DESCRIPTION
It does not support linting actions, which blocks reusing code in github actions.

On top of that it hasn't been updated in months. There's a PR to add actions to it since october.

Since this is blocking #5433, remove it