### PR TITLE
Fix C SDK build on Fedora39

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,11 @@ sdk:
 	sh ocaml/sdk-gen/windows-line-endings.sh $(XAPISDK)/csharp
 	sh ocaml/sdk-gen/windows-line-endings.sh $(XAPISDK)/powershell
 
+.PHONY: sdk-build-c sdk sdksanity
+
+sdk-build-c: sdk
+	cd _build/install/default/xapi/sdk/c && make -j $(JOBS)
+
 # workaround for no .resx generation, just for compilation testing
 sdksanity: sdk
 	sed -i 's/FriendlyErrorNames.ResourceManager/null/g' ./_build/install/default/xapi/sdk/csharp/src/Failure.cs

--- a/ocaml/sdk-gen/c/autogen/src/xen_common.c
+++ b/ocaml/sdk-gen/c/autogen/src/xen_common.c
@@ -292,10 +292,7 @@ set_api_version(xen_session *session)
 void
 xen_session_logout(xen_session *session)
 {
-    abstract_value params[] =
-        {
-        };
-    xen_call_(session, "session.logout", params, 0, NULL, NULL);
+    xen_call_(session, "session.logout", NULL, 0, NULL, NULL);
 
     if (session->error_description != NULL)
     {
@@ -314,10 +311,7 @@ xen_session_logout(xen_session *session)
 void
 xen_session_local_logout(xen_session *session)
 {
-    abstract_value params[] =
-        {
-        };
-    xen_call_(session, "session.local_logout", params, 0, NULL, NULL);
+    xen_call_(session, "session.local_logout", NULL, 0, NULL, NULL);
 
     if (session->error_description != NULL)
     {
@@ -336,14 +330,11 @@ xen_session_local_logout(xen_session *session)
 bool
  xen_session_get_all_subject_identifiers(xen_session *session, struct xen_string_set **result)
 {
-    abstract_value params[] =
-        {
-        };
 
     abstract_type result_type = abstract_type_string_set;
 
     *result = NULL;
-    xen_call_(session, "session.get_all_subject_identifiers", params, 0, &result_type, result);
+    xen_call_(session, "session.get_all_subject_identifiers", NULL, 0, &result_type, result);
     return session->ok;
 }
 
@@ -351,14 +342,10 @@ bool
 bool
 xen_session_get_all_subject_identifiers_async(xen_session *session, xen_task *result)
 {
-    abstract_value params[] =
-        {
-        };
-
     abstract_type result_type = abstract_type_string;
 
     *result = NULL;
-    xen_call_(session, "Async.session.get_all_subject_identifiers", params, 0, &result_type, result);
+    xen_call_(session, "Async.session.get_all_subject_identifiers", NULL, 0, &result_type, result);
     return session->ok;
 }
 

--- a/ocaml/sdk-gen/c/gen_c_binding.ml
+++ b/ocaml/sdk-gen/c/gen_c_binding.ml
@@ -387,7 +387,9 @@ and impl_message needed classname message =
         sprintf
           "    xen_call_(session, \"%s.%s\", %s, %d, NULL, NULL);\n\
           \    return session->ok;\n"
-          classname message.msg_name param_call param_count
+          classname message.msg_name
+          (if param_count = 0 then "NULL" else param_call)
+          param_count
   in
 
   let messageAsyncImpl = impl_message_async needed classname message in


### PR DESCRIPTION
I was trying to build the XenAPI C SDK on master and it was failing like this on Fedora39:
```
src/xen_common.c: In function ‘xen_session_logout’:
src/xen_common.c:298:5: error: ‘xen_call_’ accessing 16 bytes in a region of size 0 [-Werror=stringop-overflow=]
  298 |     xen_call_(session, "session.logout", params, 0, NULL, NULL);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Although `params[]` there is a 0 sized array, AFAICT the code doesn't actually try to read from it (and `clang` is fine with compiling it as is). Could be a bug in GCC, or some corner case of the language (is a 0 sized array valid?).

To avoid any ambiguity replace it with NULL, if anything tries to access it then it will crash instead, and GCC doesn't raise any errors anymore and successfully compiles the SDK now.

I've also added a makefile rule to be able to test building the C SDK locally, haven't added it to the github CI yet (it'll require install libxml2-dev/libxml2-devel as a pre-requisite).

Draft PR, because I've only compile-tested it, I haven't checked whether the SDK built this way actually works or not.