### PR TITLE
Xen-API Java SDK: fix the build (reintroduce 2.20 API version definition)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ sdksanity: sdk
 	sed -i 's/FriendlyErrorNames.ResourceManager/null/g' ./_build/install/default/xapi/sdk/csharp/src/Failure.cs
 	cd _build/install/default/xapi/sdk/csharp/src && dotnet add package Newtonsoft.Json && dotnet build -f netstandard2.0
 
+.PHONY: sdk-build-java
+
+sdk-build-java: sdk
+	cd _build/install/default/xapi/sdk/java && mvn -f xen-api/pom.xml -B clean package install -Drevision=0.0
 
 python:
 	$(MAKE) -C scripts/examples/python build

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -334,6 +334,13 @@ let release_order_full =
     ; branding= "Citrix Hypervisor 8.2 Hotfix 2"
     ; release_date= Some "November 2020"
     }
+  ; {
+      code_name= Some "nile-preview"
+    ; version_major= 2
+    ; version_minor= 20
+    ; branding= "XenServer 8 Preview"
+    ; release_date= Some "August 2023"
+    }
   ]
 (* When you add a new release, use the version number of the latest release, "Unreleased"
    for the branding, and Some "" for the release date, until the actual values are finalised. *)

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "2de13a69470d10b12910322f8a6bce85"
+let last_known_schema_hash = "a99342e7a24557948df221c8da46ae71"
 
 let current_schema_hash : string =
   let open Datamodel_types in


### PR DESCRIPTION
The Java SDK was failing to build due to 29f844cc6:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project xen-api: Compilation failure
[ERROR] /home/edvint/koji/toolstack-dev2/xapi.spec/scm/_build/install/default/xapi/sdk/java/xen-api/src/main/java/com/xensource/xenapi/APIVersion.java:[63,16] cannot find symbol
[ERROR]   symbol:   variable API_2_20
[ERROR]   location: class com.xensource.xenapi.APIVersion
[ERROR] -> [Help 1]
```

Draft PR, because I've only compile tested it, haven't tried whether the SDK actually works once built.