### PR TITLE
Infrastructure: Add configuration to setup testing of Python code (pytest.ini + pyproject.toml only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,68 @@ profile = "black"
 combine_as_imports = true
 ensure_newline_before_comments = false
 
+# -----------------------------------------------------------------------------
+#                            COVERAGE CONFIGURATION
+#    https://coverage.readthedocs.io/en/latest/config.html#run-command-line
+# -----------------------------------------------------------------------------
+#          Section configuring the collection of the coverage data:
+# -----------------------------------------------------------------------------
+[tool.coverage.run]
+# -----------------------------------------------------------------------------
+# The default is to run the test suite with the command "coverage run -m pytest"
+#
+command_line = "-m pytest"
+
+# -----------------------------------------------------------------------------
+# The source option specifies the directories to be measured:
+#
+source = ["scripts", "ocaml"]
+
+# -----------------------------------------------------------------------------
+# The omit option specifies files or directories to be omitted from the report:
+#
+omit = [  # These need some simple syntax update to be parseable:
+    "scripts/backup-sr-metadata.py",
+    "scripts/restore-sr-metadata.py",
+    "scripts/nbd_client_manager.py",
+]
+
+# -----------------------------------------------------------------------------
+# If PYTHON_VERSION is set, use it as the context for the coverage data data.
+#
+context = "${PYTHON_VERSION}"
+
+# -----------------------------------------------------------------------------
+# If PYTHON_VERSION is set, append it to the name of the .coverage sqlite db:
+#
+data_file = ".git/.coverage${PYTHON_VERSION}"
+
+# -----------------------------------------------------------------------------
+# Record the path names of files when collecting coverage data relative only:
+# The absoluthe paths are not needed and this helps some tools:
+#
+relative_files = true
+
+# -----------------------------------------------------------------------------
+# Section to configure the reporting of the coverage data:
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    # Such may be used for @abstractmethod or @suffixed_method, no coverage:
+    "\\<pass\\>",
+    "def __repr__",
+    "raise NotImplementedError",
+    "raise TypeError",
+    "raise UnmarshalException",
+    "\\<raise\\>",  # At a few places, we raise an bare exception to catch it
+    "\\<except\\>",  # usinge a broad except clause to catch all exceptions.
+    # "assert" may be added pacify mypy and other type checkers and they show
+    # in the review of the code that the value could be None at this point:
+    "\\<assert\\>",
+]
+# -----------------------------------------------------------------------------
+
 
 [tool.mypy]
 # Note mypy has no config setting for PYTHONPATH, so you need to call it with:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,61 @@
+#------------------------------------------------------------------------------
+#                         PYTEST CONFIGURATION FILE
+#------------------------------------------------------------------------------
+#                FOR SEAMLESS TESTING WITH PYTHON 2.7 AND 3.x
+#------------------------------------------------------------------------------
+#      PURPOSE: SPECIFY DEFAULT OPTIONS FOR PYTEST, INCLUDING TEST PATHS
+#------------------------------------------------------------------------------
+#       BENEFIT: DEVELOPERS CAN RUN TESTS WITH A SINGLE COMMAND, E.G.:
+#
+#                                $ pytest
+#
+#         OR, IF YOU HAVE PYTEST FOR PYTHON 2.7 INSTALLED as pytest2:
+#
+#                           $ pytest && pytest2
+#
+#  ----------------->    LIKEWISE, TO COLLECT COVERAGE:    <-------------------
+#
+#                              $ coverage run
+#
+# -> OR, IF YOU HAVE PYTEST and COVERAGE.PY FOR PYTHON 2.7 INSTALLED AS WELL <-
+#
+#                  $ coverage3 run && coverage-2.7 run
+#
+#           ALL OF THIS DEPENDS ON THIS FILE TO SET THE DEFAULT PATHS
+#
+#     We will want to add other test paths (as more tests are ported) later,
+#           and apparently, this is the only place (besides tox.ini)
+#                to have a single location to set the paths
+#                     which allows you to just run:
+#
+#                         coverage run / pytest
+#
+#
+#          SEE ALSO: https://docs.pytest.org/en/latest/customize.html
+#
+#------------------------------------------------------------------------------
+#  Bear with me a little: pyproject.toml is not used by pytest for Python 2.7
+#------------------------------------------------------------------------------
+# Installation:
+# pip install pytest<7 pytest-mock pytest-pythonpath
+#------------------------------------------------------------------------------
+
+[pytest]
+
+# testpaths: Directories to search for tests when no test targets are given.
+# scripts: Search ./scripts for tests, ocaml/xcp-rrdd: Search ./ocaml/xcp-rrdd
+testpaths =
+    scripts
+    ocaml/xcp-rrdd
+
+# norecursedirs: Directories to ignore when searching for tests, e.g. build
+# build: Ignore ./build when searching for tests:
+norecursedirs = build
+
+# addopts: Additional command line options for pytest, see pytest --help:
+# -rF: Show extra test summary info for failed tests:
+addopts = -rF
+
+# pytest-mock:       Used by tests in ocaml/xcp-rrdd/scripts/rrdd/
+required_plugins =
+    pytest-mock


### PR DESCRIPTION
Only 2 config files are changed: This should be very easy to review.

@edwintorok @lindig 

Documentation is added at the configuration settings, so it should be very easy to use and maintain.

Interestingly, while this only adds useful configuration, it also helps coverage to gather the coverage of the new test actually calling the constructor of `class rrdd.Displatcher()` and its `__getattr__()` method to read an attribute, which the test indeed does:

https://app.codecov.io/gh/xapi-project/xen-api/commit/e3d21c2c225adafda56e33329be9e3b548984fb6/indirect-changes?flags%5B0%5D=python3.11

This means, without even intended for it, this already helps the test coverage results as an indirect change that you can examine at the Codecov.io link above.