### PR TITLE
CP-47754: Do not report errors attempting to read PCI vendor:product

### DIFF
--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -225,15 +225,15 @@ module Sysfs = struct
 
   let get_pci_ids name =
     let read_id_from path =
-      try
-        let l = read_one_line path in
-        (* trim 0x *)
-        String.sub l 2 (String.length l - 2)
-      with _ -> ""
+      let l = path |> Unixext.string_of_file |> String.trim in
+      (* trim 0x *)
+      String.sub l 2 (String.length l - 2)
     in
-    ( read_id_from (getpath name "device/vendor")
-    , read_id_from (getpath name "device/device")
-    )
+    try
+      ( read_id_from (getpath name "device/vendor")
+      , read_id_from (getpath name "device/device")
+      )
+    with _ -> ("", "")
 
   (** Returns the name of the driver for network device [dev] *)
   let get_driver_name dev =


### PR DESCRIPTION
Different network card (like virtual ones or USB ones) do not have a vendor:product causing networkd daemon to report a lot of errors like

    Error in read one line of file: /sys/class/net/eth0/device/device, exception Unix.Unix_error(Unix.ENOENT, "open", "/sys/class/net/eth0/device/device")
    Raised by primitive operation at Xapi_stdext_unix__Unixext.with_file in file "lib/xapi-stdext-unix/unixext.ml", line 68, characters 11-40
    Called from Xapi_stdext_unix__Unixext.buffer_of_file in file "lib/xapi-stdext-unix/unixext.ml" (inlined), line 155, characters 31-83
    Called from Xapi_stdext_unix__Unixext.string_of_file in file "lib/xapi-stdext-unix/unixext.ml", line 157, characters 47-73
    Called from Network_utils.Sysfs.read_one_line in file "ocaml/networkd/lib/network_utils.ml", line 156, characters 6-33

Do not report these missing file as errors.