### PR TITLE
Make clear which drivers list we are getting

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -103,7 +103,7 @@ let set_dns_interface _dbg name =
  * constitutes adding a VLAN0 Linux device to strip those headers again.
  *)
 let need_enic_workaround () =
-  !backend_kind = Bridge && List.mem "enic" (Sysfs.list_drivers ())
+  !backend_kind = Bridge && List.mem "enic" (Sysfs.list_pci_drivers ())
 
 module Sriov = struct
   open S.Sriov

--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -143,10 +143,10 @@ let fork_script ?on_error ?log script args =
   check_n_run ?on_error ?log fork_script_internal script args
 
 module Sysfs = struct
-  let list_drivers () =
+  let list_pci_drivers () =
     try Array.to_list (Sys.readdir "/sys/bus/pci/drivers")
     with _ ->
-      warn "Failed to obtain list of drivers from sysfs" ;
+      warn "Failed to obtain list of PCI drivers from sysfs" ;
       []
 
   let getpath dev attr = Printf.sprintf "/sys/class/net/%s/%s" dev attr


### PR DESCRIPTION
Sysfs.list_drivers is returning the list of only PCI driver, so make it clear.
We want to support also USB cards so this change could avoid confusions in the future.