### PR TITLE
rrd_updates: output JSON in the same structure as XML

### DIFF
--- a/ocaml/libs/xapi-rrd/lib/rrd_updates.ml
+++ b/ocaml/libs/xapi-rrd/lib/rrd_updates.ml
@@ -194,9 +194,9 @@ let json_of_t t =
             ; ("rows", int (Array.length t.data))
             ; ("columns", int (Array.length t.legend))
             ; ("legend", array (map_to_list string t.legend))
-            ; ("data", array (map_to_list data_record t.data))
             ]
         )
+      ; ("data", array (map_to_list data_record t.data))
       ]
   in
   Yojson.to_string meta


### PR DESCRIPTION
the data field is not part of meta. see the XML generator at ocaml/libs/xapi-rrd/lib/rrd_updates.ml line 124

The issue was introduced when serialization was changed to use yojson: https://github.com/xapi-project/xcp-rrd/commit/048b0e33b992e45ba8a465b24bbbfe10aa5d65c2

This broke Xen orchestra's metrics