### PR TITLE
redo_log: report redo log as broken if we cannot find the block device

### DIFF
--- a/ocaml/database/redo_log.ml
+++ b/ocaml/database/redo_log.ml
@@ -642,7 +642,8 @@ let startup log =
           ) ;
           match !(log.device) with
           | None ->
-              D.info "Could not find block device"
+              D.info "Could not find block device" ;
+              broken log
           | Some device ->
               D.info "Using block device at %s" device ;
               (* Check that the block device exists *)


### PR DESCRIPTION
XAPI was just retrying endlessly in a loop saying "Could not find block device", but didn't raise any alerts that XenRT could detect.

Report the redo log broken the first time we fail due to the lack of a bloc k device (which would indicate something going wrong in SM).