### PR TITLE
CP-47935: Make `import_file.py` as a separate module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
         run: pip install future mock pytest-coverage pytest-mock
 
       - name: Run Pytest and get code coverage for Codecov
+        if: ${{ matrix.python-version != '2.7' }}
         run: >
           pytest
           --cov=scripts --cov=ocaml/xcp-rrdd
@@ -66,17 +67,6 @@ jobs:
           --cov-report xml:.git/coverage${{matrix.python-version}}.xml
         env:
           PYTHONDEVMODE: yes
-
-      - name: Upload Python ${{matrix.python-version}} coverage report to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          directory: .git
-          files: coverage${{matrix.python-version}}.xml
-          env_vars: OS,PYTHON
-          fail_ci_if_error: false
-          flags: python${{matrix.python-version}}
-          name: coverage${{matrix.python-version}}
-          verbose: true
 
       - uses: dciborow/action-pylint@0.1.0
         if: ${{ matrix.python-version != '2.7' }}

--- a/scripts/import_file.py
+++ b/scripts/import_file.py
@@ -1,0 +1,28 @@
+"""
+This file is used for importing a non-".py" file as a module in unit test.
+It never runs directly, so no shebang and no main()
+"""
+import sys
+import os
+if sys.version_info.major > 2:
+    from importlib import machinery, util
+
+def import_from_file(module_name, file_path):
+    """Import a file as a module"""
+    # Only for python3, but CI has python2 pytest check, so add this line
+    if sys.version_info.major == 2:
+        return None
+    loader = machinery.SourceFileLoader(module_name, file_path)
+    spec = util.spec_from_loader(module_name, loader)
+    assert spec
+    assert spec.loader
+    module = util.module_from_spec(spec)
+    # Probably a good idea to add manually imported module stored in sys.modules
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+def get_module(module_name, file_path):
+    """get the module from a file"""
+    testdir = os.path.dirname(__file__)
+    return import_from_file(module_name, testdir + file_path)

--- a/scripts/import_file.py
+++ b/scripts/import_file.py
@@ -4,14 +4,10 @@ It never runs directly, so no shebang and no main()
 """
 import sys
 import os
-if sys.version_info.major > 2:
-    from importlib import machinery, util
+from importlib import machinery, util
 
 def import_from_file(module_name, file_path):
     """Import a file as a module"""
-    # Only for python3, but CI has python2 pytest check, so add this line
-    if sys.version_info.major == 2:
-        return None
     loader = machinery.SourceFileLoader(module_name, file_path)
     spec = util.spec_from_loader(module_name, loader)
     assert spec

--- a/scripts/test_static_vdis.py
+++ b/scripts/test_static_vdis.py
@@ -1,56 +1,37 @@
 #!/usr/bin/env python3
-#
-# unittest for static-vdis
+
+"""
+This module provides unit test for static-vdis.
+"""
 
 import unittest
-from mock import MagicMock
 import sys
-import os
-import subprocess
 import tempfile
+from mock import MagicMock
+from import_file import get_module
 
 # mock modules to avoid dependencies
 sys.modules["XenAPI"] = MagicMock()
 sys.modules["inventory"] = MagicMock()
 
-def import_from_file(module_name, file_path):
-    """Import a file as a module"""
-    if sys.version_info.major == 2:
-        return None
-    else:
-        from importlib import machinery, util
-        loader = machinery.SourceFileLoader(module_name, file_path)
-        spec = util.spec_from_loader(module_name, loader)
-        assert spec
-        assert spec.loader
-        module = util.module_from_spec(spec)
-        # Probably a good idea to add manually imported module stored in sys.modules
-        sys.modules[module_name] = module
-        spec.loader.exec_module(module)
-        return module
+static_vdis = get_module("static_vdis", "/static-vdis")
 
-def get_module():
-    """Import the static-vdis script as a module for executing unit tests on functions"""
-    testdir = os.path.dirname(__file__)
-    return import_from_file("static_vdis", testdir + "/static-vdis")
-
-static_vdis = get_module()
-
-@unittest.skipIf(sys.version_info < (3, 0), reason="requires python3")     
+@unittest.skipIf(sys.version_info < (3, 0), reason="requires python3")
 class TestReadWriteFile(unittest.TestCase):
+    """Test function read_whole_file and write_whole_file"""
     def test_write_and_read_whole_file(self):
         """Test read_whole_file and write_whole_file"""
-        test_file = tempfile.NamedTemporaryFile(delete=True)
-        filename = str(test_file.name)
-        content = r"""def read_whole_file(filename):
+        with tempfile.NamedTemporaryFile(delete=True) as test_file:
+            filename = str(test_file.name)
+            # Construct a multi-line text containing indentation and spaces.
+            content = r"""def read_whole_file(filename):
     with open(filename, 'r', encoding='utf-8') as f:
         return ''.join(f.readlines()).strip()
         
 def write_whole_file(filename, contents):
     with open(filename, "w", encoding='utf-8') as f:
         f.write(contents)"""
-        static_vdis.write_whole_file(filename, content)
-        expected_content = static_vdis.read_whole_file(filename)
-        self.assertEqual(expected_content, content)
-        
-        
+
+            static_vdis.write_whole_file(filename, content)
+            expected_content = static_vdis.read_whole_file(filename)
+            self.assertEqual(expected_content, content)


### PR DESCRIPTION
- Make `import_file.py` as a separate module for reusing it.
- Fix pylint and pytype issues
- Remove CI check for python unit test coverage which was added recently while still running the unit tests, per the agreement with the toolstack team last time on " it is understood that it is not possible to have full comprehensive Unit Test coverage"