### PR TITLE
Rename SMApi component to SM to better reflect what it is observing

### DIFF
--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -405,12 +405,12 @@ let observer_component_xenopsd = "xenopsd"
 
 let observer_component_xapi_clusterd = "xapi-clusterd"
 
-let observer_component_smapi = "smapi"
+let observer_component_sm = "sm"
 
 let observer_components_all =
   [
     observer_component_xapi
   ; observer_component_xenopsd
   ; observer_component_xapi_clusterd
-  ; observer_component_smapi
+  ; observer_component_sm
   ]

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -339,13 +339,13 @@ let exec_xmlrpc ~dbg ?context:_ ?(needs_session = true) (driver : string)
             let args = [Xml.to_string xml] in
             let output, stderr =
               let env, exe, args =
-                match Xapi_observer_components.is_smapi_enabled () with
+                match Xapi_observer_components.is_sm_enabled () with
                 | false ->
                     (None, exe, args)
                 | true ->
                     let traceparent = Debuginfo.traceparent_of_dbg dbg in
                     Xapi_observer_components.env_exe_args_of
-                      ~component:Xapi_observer_components.SMApi ~traceparent
+                      ~component:Xapi_observer_components.SM ~traceparent
                       ~exe ~args
               in
               Forkhelpers.execute_command_get_output ?env exe args

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1021,7 +1021,7 @@ let observer_endpoint_https_enabled = ref false
 let python3_path = ref "/usr/bin/python3"
 
 let observer_experimental_components =
-  ref (StringSet.singleton Constants.observer_component_smapi)
+  ref (StringSet.singleton Constants.observer_component_sm)
 
 let xapi_globs_spec =
   [

--- a/ocaml/xapi/xapi_observer.ml
+++ b/ocaml/xapi/xapi_observer.ml
@@ -350,7 +350,7 @@ module Dom0ObserverConfig (ObserverComponent : OBSERVER_COMPONENT) :
   let set_compress_tracing_files ~__context:_ ~enabled:_ = ()
 end
 
-module SMObserverConfig = Dom0ObserverConfig (struct let component = SMApi end)
+module SMObserverConfig = Dom0ObserverConfig (struct let component = SM end)
 
 let get_forwarder c =
   let module Forwarder =
@@ -361,7 +361,7 @@ let get_forwarder c =
               (module Xapi_xenops.Observer)
           | Xapi_clusterd ->
               (module Xapi_cluster.Observer)
-          | SMApi ->
+          | SM ->
               (module SMObserverConfig)
         : ObserverInterface
       )

--- a/ocaml/xapi/xapi_observer_components.ml
+++ b/ocaml/xapi/xapi_observer_components.ml
@@ -14,7 +14,7 @@
 
 module D = Debug.Make (struct let name = "xapi_observer_components" end)
 
-type t = Xapi | Xenopsd | Xapi_clusterd | SMApi [@@deriving ord]
+type t = Xapi | Xenopsd | Xapi_clusterd | SM [@@deriving ord]
 
 exception Unsupported_Component of string
 
@@ -25,8 +25,8 @@ let to_string = function
       Constants.observer_component_xenopsd
   | Xapi_clusterd ->
       Constants.observer_component_xapi_clusterd
-  | SMApi ->
-      Constants.observer_component_smapi
+  | SM ->
+      Constants.observer_component_sm
 
 let of_string = function
   | str when String.equal str Constants.observer_component_xapi ->
@@ -35,8 +35,8 @@ let of_string = function
       Xenopsd
   | str when String.equal str Constants.observer_component_xapi_clusterd ->
       Xapi_clusterd
-  | str when String.equal str Constants.observer_component_smapi ->
-      SMApi
+  | str when String.equal str Constants.observer_component_sm ->
+      SM
   | c ->
       raise (Unsupported_Component c)
 
@@ -92,7 +92,7 @@ let is_component_enabled ~component =
       )
   with _ -> false
 
-let is_smapi_enabled () = is_component_enabled ~component:SMApi
+let is_sm_enabled () = is_component_enabled ~component:SM
 
 let ( // ) = Filename.concat
 

--- a/ocaml/xapi/xapi_observer_components.mli
+++ b/ocaml/xapi/xapi_observer_components.mli
@@ -19,7 +19,7 @@
 
 (** Type for components that are instrumented with tracing.
   *)
-type t = Xapi | Xenopsd | Xapi_clusterd | SMApi [@@deriving ord]
+type t = Xapi | Xenopsd | Xapi_clusterd | SM [@@deriving ord]
 
 val all : t list
 (** List of all components available.
@@ -53,8 +53,8 @@ val is_component_enabled : component:t -> bool
 (** Returns [true] if the given component is enabled, [false] otherwise.
   *)
 
-val is_smapi_enabled : unit -> bool
-(** Returns [true] if [SMApi] component is enabled, [false] otherwise.
+val is_sm_enabled : unit -> bool
+(** Returns [true] if [SM] component is enabled, [false] otherwise.
   *)
 
 val dir_name_of_component : t -> string


### PR DESCRIPTION
Creating this as a draft Pull Request as it currently has a major issue. If a host already has an existing Observer and upgrades to this patch, it will be unable to remove the smapi component (which is a default component) as the check when running "unregister_component" will fail with Unsupport_component("smapi").
I'm not sure how best to fix this in a backwards compatible manner, although I have been thinking it would be good to make the default components explicit in the DB, rather than coming from observed_components_of and startup_components (https://github.com/xapi-project/xen-api/blob/master/ocaml/xapi/xapi_observer_components.ml#L69) which might possibly help to solve this issue.