### PR TITLE
CP-46631: Better abstraction for span tables.

### DIFF
--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -1,18 +1,17 @@
 (library
-  (name tracing)
-  (public_name xapi-tracing)
-  (libraries
-    cohttp
-    cohttp-posix
-    ptime
-    ptime.clock.os
-    rpclib.core
-    rpclib.json
-    xapi-log
-    xapi-open-uri
-    xapi-stdext-threads
-    xapi-stdext-unix
-    zstd
-  )
-  (preprocess (pps ppx_deriving_rpc))
-)
+ (name tracing)
+ (public_name xapi-tracing)
+ (libraries
+  cohttp
+  cohttp-posix
+  ptime
+  ptime.clock.os
+  rpclib.core
+  rpclib.json
+  xapi-log
+  xapi-open-uri
+  xapi-stdext-threads
+  xapi-stdext-unix
+  zstd)
+ (preprocess
+  (pps ppx_deriving_rpc ppx_deriving_yojson)))

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -11,6 +11,7 @@
   xapi-log
   xapi-open-uri
   xapi-stdext-threads
+  xapi-stdext-std
   xapi-stdext-unix
   zstd)
  (preprocess

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -324,7 +324,7 @@ module Spans = struct
           else if v <= snd last_min then
             acc
           else
-            SpanMap.remove (fst last_min) acc |> SpanMap.add k v
+            acc |> SpanMap.remove (fst last_min) |> SpanMap.add k v
 
     let most_frequent () =
       Hashtbl.fold (take_most depth) frequency_tbl SpanMap.empty
@@ -337,6 +337,35 @@ module Spans = struct
         (most_frequent_list |> frequencies_to_yojson |> Yojson.Safe.to_string) ;
       most_frequent_list |> List.map fst
   end
+
+  let spans_with_names span_names =
+    let spans_copy = Hashtbl.copy spans in
+
+    Hashtbl.filter_map_inplace
+      (fun _ v ->
+        Some
+          (List.filter
+             (fun (span : Span.t) ->
+               List.exists (String.equal span.name) span_names
+             )
+             v
+          )
+      )
+      spans_copy ;
+    spans_copy
+    |> Hashtbl.to_seq_values
+    |> Seq.map List.to_seq
+    |> Seq.concat
+    |> List.of_seq
+
+  let get_oldest_half (spans : Span.t list) =
+    let sorted_spans =
+      List.sort
+        (fun (s1 : Span.t) (s2 : Span.t) -> compare s1.begin_time s2.begin_time)
+        spans
+    in
+    let length = List.length sorted_spans in
+    Xapi_stdext_std.Listext.List.take ((length + 1) / 2) sorted_spans
 
   let max_spans = ref 1000
 
@@ -427,16 +456,30 @@ module Spans = struct
   let mark_finished ?(with_lock = true) span =
     Option.iter (add_to_finished ~with_lock) (remove_from_spans ~with_lock span)
 
+  let finish_oldest_half (spans : Span.t list) =
+    let attributes =
+      Attributes.of_list [("xs.tracing.finished.reason", "gc.full")]
+    in
+    spans
+    |> get_oldest_half
+    |> List.iter (fun span ->
+           let span = Span.finish ~attributes ~span () in
+           debug "Mark span: %s as finished" span.name ;
+           mark_finished ~with_lock:false span
+       )
+
+  let clean_oldest () =
+    debug "%s exceeded max traces when adding to span table" __FUNCTION__ ;
+    SpanFrequencies.debug_most_frequent ()
+    |> spans_with_names
+    |> finish_oldest_half
+
   let add_to_spans ~(span : Span.t) =
     let key = span.context.trace_id in
     Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
         add_to_tbl_helper
           ?trace_bucket:(Hashtbl.find_opt spans key)
-          ~span ~key ~tbl:spans ~tbl_type:ActiveTbl
-        @@ fun () ->
-        debug "%s exceeded max traces when adding to finished span table"
-          __FUNCTION__ ;
-        ignore (SpanFrequencies.debug_most_frequent ())
+          ~span ~key ~tbl:spans ~tbl_type:ActiveTbl clean_oldest
     )
 
   let span_is_finished x =

--- a/ocaml/xapi/xapi_observer.ml
+++ b/ocaml/xapi/xapi_observer.ml
@@ -94,11 +94,11 @@ module Observer : ObserverInterface = struct
 
   let set_max_spans ~__context ~spans =
     debug "Observer.set_max_spans" ;
-    Tracing.Spans.set_max_spans spans
+    Tracing.Spans.SpanTbl.set_max_spans spans
 
   let set_max_traces ~__context ~traces =
     debug "Observer.set_max_traces" ;
-    Tracing.Spans.set_max_traces traces
+    Tracing.Spans.SpanTbl.set_max_traces traces
 
   let set_max_file_size ~__context ~file_size =
     debug "Observer.set_max_file_size" ;

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -4066,13 +4066,13 @@ module Observer = struct
   let set_max_spans _ dbg spans =
     debug "Observer.set_max_spans : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
-      (fun () -> Tracing.Spans.set_max_spans spans)
+      (fun () -> Tracing.Spans.SpanTbl.set_max_spans spans)
       ()
 
   let set_max_traces _ dbg traces =
     debug "Observer.set_max_traces : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
-      (fun () -> Tracing.Spans.set_max_traces traces)
+      (fun () -> Tracing.Spans.SpanTbl.set_max_traces traces)
       ()
 
   let set_max_file_size _ dbg file_size =

--- a/xapi-tracing.opam
+++ b/xapi-tracing.opam
@@ -14,6 +14,7 @@ depends: [
   "cohttp-posix"
   "dune"
   "cohttp"
+  "ppx_deriving_yojson"
   "rpclib"
   "xapi-log"
   "xapi-open-uri"


### PR DESCRIPTION
Hides the implementation of span tables behind a `SpanTbl` data structure that is meant to share common functionality between the `ongoing_spans` table and `finished_spans` table.

This is meant as a follow up to a previous PR, https://github.com/xapi-project/xen-api/pull/5380, to prevent issues with double locking when transitioning spans from `ongoing_spans` to `finished_spans`.

The first 3 commits of this PR are shared with https://github.com/xapi-project/xen-api/pull/5380.

