### PR TITLE
Xapi service depends on systemd-tmpfiles-setup

### DIFF
--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=XenAPI server (XAPI)
 
+Requires=systemd-tmpfiles-setup.service
+After=systemd-tmpfiles-setup.service
 After=attach-static-vdis.service
 After=forkexecd.service
 After=message-switch.service


### PR DESCRIPTION
:wave:
To give a little bit of context, I had a strange issue after building new RPMs (it was a new version of ZFS) and installing it. It appeared that `systemd` reported XAPI has failed. I looked more closely and the reason is because `/var/lock/subsys` directory is not present anymore (and the `touch /var/lock/subsys/xapi` command failed).  I didn't know exactly why this directory is not there but after discussing with several people it appears that it should be created by `systemd-tmpfiles-setup.service`. And in my case this service didn't start. To fix the issue one suggestion was to add `systemd-tmpfiles-setup.service` to be `Requires`+`After` in `xapi.service`. I think it makes sense and that is is the right way for fixing the issue but I was surprised that it wasn't already the case, so maybe there is another way to fix this? 
Regards,