### PR TITLE
CI: Introduce differential shellcheck

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,28 @@ concurrency:  # On new push, cancel old workflows from the same PR, branch or ta
   cancel-in-progress: true
 
 jobs:
+  # https://www.shellcheck.net/wiki/GitHub-Actions
+  # https://github.com/redhat-plumbers-in-action/differential-shellcheck?tab=readme-ov-file#usage
+  shell-test:
+    name: Differential ShellCheck
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+
+# If needed severity levels can be controlled here
+#            severity: warning
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+    
   python-test:
     name: Python tests
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This should report Shellcheck issues only on lines modified by a pull-request: https://github.com/redhat-plumbers-in-action/differential-shellcheck

We have a lot of scripts in XAPI, and if we'd require them to be fully shellcheck clean the tiniest change would need to do a lot of unrelated changes. This way we can gradually get to a shellcheck-clean state, by ensuring that newly added scripts and lines are clean.

The severity can be tweaked, for now lets see all warnings.