### PR TITLE
Revert "CP-45572: Print update guidance in xe host-apply-updates"

### DIFF
--- a/ocaml/xapi-cli-protocol/cli_protocol.ml
+++ b/ocaml/xapi-cli-protocol/cli_protocol.ml
@@ -26,6 +26,13 @@ let minor = 2
     a totally different kind of server (eg a standard HTTP server) *)
 let prefix = "XenSource thin CLI protocol"
 
+(* Be careful to add/remove/modify the commands. The CLI interface is expected
+   to be extreme stable. Please keep following in mind when doing the changes:
+     1. backwards compatibility support. E.g. a very old CLI client may need to
+        be supported still,
+     2. a new command should be one for general purpose only rather than for a
+        specific usage. *)
+
 (** Command sent by the server to the client.
     If the command is "Save" then the server waits for "OK" from the client
     and then streams a list of data chunks to the client. *)

--- a/ocaml/xapi-cli-protocol/cli_protocol.ml
+++ b/ocaml/xapi-cli-protocol/cli_protocol.ml
@@ -35,7 +35,6 @@ type command =
   | Load of string (* filename *)
   | HttpGet of string * string (* filename * path *)
   | PrintHttpGetJson of string (* path *)
-  | PrintUpdateGuidance of string (* path *)
   | HttpPut of string * string (* filename * path *)
   | HttpConnect of string (* path *)
   | Prompt (* request the user enter some text *)
@@ -70,8 +69,6 @@ let string_of_command = function
       "HttpGet " ^ path ^ " -> " ^ filename
   | PrintHttpGetJson path ->
       "PrintHttpGetJson " ^ path ^ " -> stdout"
-  | PrintUpdateGuidance path ->
-      "PrintUpdateGuidance " ^ path ^ " -> stdout"
   | HttpPut (filename, path) ->
       "HttpPut " ^ path ^ " -> " ^ filename
   | HttpConnect path ->
@@ -161,7 +158,7 @@ let unmarshal_list pos f =
 (*****************************************************************************)
 (* Marshal/Unmarshal higher-level messages                                   *)
 
-(* Highest command id: 19 *)
+(* Highest command id: 18 *)
 
 let marshal_command = function
   | Print x ->
@@ -174,8 +171,6 @@ let marshal_command = function
       marshal_int 12 ^ marshal_string a ^ marshal_string b
   | PrintHttpGetJson a ->
       marshal_int 18 ^ marshal_string a
-  | PrintUpdateGuidance a ->
-      marshal_int 19 ^ marshal_string a
   | HttpPut (a, b) ->
       marshal_int 13 ^ marshal_string a ^ marshal_string b
   | HttpConnect a ->
@@ -229,9 +224,6 @@ let unmarshal_command pos =
   | 18 ->
       let a, pos = unmarshal_string pos in
       (PrintHttpGetJson a, pos)
-  | 19 ->
-      let a, pos = unmarshal_string pos in
-      (PrintUpdateGuidance a, pos)
   | n ->
       raise (Unknown_tag ("command", n))
 

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1032,7 +1032,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
         reqd= ["hash"]
       ; optn= []
       ; help= "Apply updates from enabled repository on specified host."
-      ; implementation= With_fd Cli_operations.host_apply_updates
+      ; implementation= No_fd Cli_operations.host_apply_updates
       ; flags= [Host_selectors]
       }
     )

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7641,32 +7641,19 @@ let print_avail_updates ~rpc ~session_id ~fd ~host =
       PrintHttpGetJson (get_avail_updates_uri ~session_id ~task ~host)
   )
 
-let print_update_guidance ~rpc ~session_id ~fd ~host =
-  command_in_task ~rpc ~session_id ~fd ~obj:host
-    ~label:"Print update guidance for host" ~quiet_on_success:true
-    (fun session_id task host ->
-      PrintUpdateGuidance (get_avail_updates_uri ~session_id ~task ~host)
-  )
-
-let host_apply_updates fd printer rpc session_id params =
+let host_apply_updates _printer rpc session_id params =
   let hash = List.assoc "hash" params in
-  do_host_op rpc session_id ~multiple:false
-    (fun _ host ->
-      let host = host.getref () in
-      printer (Cli_printer.PMsg "Guidance of updates:") ;
-      print_update_guidance ~rpc ~session_id ~fd ~host ;
-      printer (Cli_printer.PMsg "Applying updates ...") ;
-      match Client.Host.apply_updates ~rpc ~session_id ~self:host ~hash with
-      | [] ->
-          printer (Cli_printer.PMsg "Updated.")
-      | warnings ->
-          printer (Cli_printer.PMsg "Updated with warnings:") ;
-          List.iter
-            (fun l -> printer (Cli_printer.PMsg (String.concat "; " l)))
-            warnings
+  ignore
+    (do_host_op rpc session_id ~multiple:false
+       (fun _ host ->
+         let host = host.getref () in
+         Client.Host.apply_updates ~rpc ~session_id ~self:host ~hash
+         |> List.iter (fun l ->
+                _printer (Cli_printer.PMsg (String.concat "; " l))
+            )
+       )
+       params ["hash"]
     )
-    params ["hash"]
-  |> ignore
 
 let host_updates_show_available fd _printer rpc session_id params =
   do_host_op rpc session_id ~multiple:false

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -773,23 +773,6 @@ let main_loop ifd ofd permitted_filenames =
             |> print_endline ;
             flush stdout
         )
-    | Command (PrintUpdateGuidance url) ->
-        do_http_get ofd url exit_code (fun ic ->
-            while input_line ic <> "\r" do
-              ()
-            done ;
-            Yojson.Basic.from_channel ic |> Yojson.Basic.Util.member "hosts"
-            |> function
-            | `List [] ->
-                raise (ClientSideError "No host data returned")
-            | `List (host :: _) ->
-                Yojson.Basic.Util.member "guidance" host
-                |> Yojson.Basic.pretty_to_string
-                |> print_endline ;
-                flush stdout
-            | _ ->
-                raise (ClientSideError "Unknown data format")
-        )
     | Command Prompt ->
         let data = input_line stdin in
         marshal ofd (Blob (Chunk (Int32.of_int (String.length data)))) ;


### PR DESCRIPTION
The commit is being reverted because:
1. It introduces a new CLI command "PrintUpdateGuidance" in an existing CLI interface "host-apply-updates". This breaks the use cases in which the old CLI clients are used.
2. The new CLI command "PrintUpdateGuidance" is a specific one. The commands used in CLI interfaces should be only for general purpose usage.

A comment is added around the type definition of CLI command for this as well.