### PR TITLE
py2->py3: hfx_filename

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -158,6 +158,31 @@ coverage:
         #
         threshold: 20%
 
+      python3:
+
+        #
+        # The python3 limit applies to:
+        # -----------------------------
+        #
+        # - python3/**
+        # - excluding: **/test_*.py
+        #
+        paths: ["python3/**", "!**/test_*.py"]
+
+        #
+        # For python3/** (excluding tests):
+        #
+        # For python3, coverage should not be reduced compared to its base:
+        #
+        target: auto
+
+        #
+        # Exception: the threshold value given is allowed
+        #
+        # Allows for not covering 20% if the changed lines of the PR:
+        #
+        threshold: 20%
+
       # Checks each Python version separately:
       python-3.11:
         flags: ["python3.11"]
@@ -175,17 +200,25 @@ coverage:
       # Python modules and scripts below scripts/ (excluding tests)
       #
       scripts:
+        paths: ["scripts/**", "!**/test_*.py"]
         target: 48%
         threshold: 2%
-        paths: ["scripts/**", "!**/test_*.py"]
 
       #
-      # Python modules and scripts below ocaml/
+      # Python modules and scripts below ocaml/ (excluding tests)
       #
       ocaml:
         paths: ["ocaml/**", "!**/test_*.py"]
         target: 51%
         threshold: 3%
+
+      #
+      # Python modules and scripts below python3/ (excluding tests)
+      #
+      python3:
+        paths: ["python3/**", "!**/test_*.py"]
+        target: 48%
+        threshold: 2%
 
       #
       # Test files
@@ -238,6 +271,10 @@ component_management:
         - "ocaml/xapi-storage/**"
         - "ocaml/xapi-storage-script/**"
         - "!**/test_*.py"
+
+    - component_id: python3
+      name: python3
+      paths: ["python3/**", "!**/test_*.py"]
 
     - component_id: test_cases
       name: test_cases

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,11 +56,24 @@ jobs:
       - name: Install common dependencies for Python ${{matrix.python-version}}
         run: pip install future mock pytest-coverage pytest-mock
 
-      - name: Run Pytest and get code coverage for Codecov
+      - name: Run Pytest for python 2 and get code coverage for Codecov
+        if: ${{ matrix.python-version == '2.7' }}
         run: >
           pytest
           --cov=scripts --cov=ocaml/xcp-rrdd
           scripts/ ocaml/xcp-rrdd -vv -rA
+          --junitxml=.git/pytest${{matrix.python-version}}.xml
+          --cov-report term-missing
+          --cov-report xml:.git/coverage${{matrix.python-version}}.xml
+        env:
+          PYTHONDEVMODE: yes
+
+      - name: Run Pytest for python 3 and get code coverage for Codecov
+        if: ${{ matrix.python-version != '2.7' }}
+        run: >
+          pytest
+          --cov=scripts --cov=ocaml/xcp-rrdd --cov=python3/
+          scripts/ ocaml/xcp-rrdd python3/ -vv -rA
           --junitxml=.git/pytest${{matrix.python-version}}.xml
           --cov-report term-missing
           --cov-report xml:.git/coverage${{matrix.python-version}}.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ discard_messages_matching = [
     "No Node.TEXT_NODE in module xml.dom.minidom, referenced from 'xml.dom.expatbuilder'"
 ]
 expected_to_fail = [
-    "scripts/hfx_filename",
     "scripts/perfmon",
     # Need 2to3 -w <file> and maybe a few other minor updates:
     "scripts/hatests",
@@ -96,7 +95,6 @@ expected_to_fail = [
 
 [tool.pytype]
 inputs = [
-    "scripts/hfx_filename",
     "scripts/perfmon",
     "scripts/static-vdis",
     "scripts/Makefile",
@@ -111,6 +109,10 @@ inputs = [
     "scripts/examples/python",
     "scripts/yum-plugins",
     "scripts/*.py",
+
+    # Python 3
+    "python3/bin/hfx_filename",
+    "python3/*.py",
 
     # To be added later,
     # when converted to Python3-compatible syntax:

--- a/python3/Makefile
+++ b/python3/Makefile
@@ -1,0 +1,7 @@
+include ../config.mk
+
+IPROG=install -m 755
+
+install:
+    mkdir -p $(DESTDIR)$(OPTDIR)/bin
+    $(IPROG) bin/hfx_filename $(DESTDIR)$(OPTDIR)/bin

--- a/python3/bin/hfx_filename
+++ b/python3/bin/hfx_filename
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015 Citrix, Inc.
 #
@@ -14,8 +14,8 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from __future__ import print_function
-import sys, os, socket, urllib2, urlparse, XenAPI, traceback, xmlrpclib
+
+import sys, socket, urllib.request, XenAPI
 
 db_url = "/remote_db_access"
 
@@ -28,18 +28,20 @@ def rpc(session_id, request):
         headers = [
           "POST %s?session_id=%s HTTP/1.0" % (db_url, session_id),
           "Connection:close",
-          "content-length:%d" % (len(request)),
+          "content-length:%d" % (len(request.encode('utf-8'))),
           ""
         ]
-        #print "Sending HTTP request:"
         for h in headers:
-          s.send("%s\r\n" % h)
-          #print "%s\r\n" % h,
-        s.send(request)
+          s.send((h + "\r\n").encode('utf-8'))
+        s.send(request.encode('utf-8'))
 
-        result = s.recv(1024)
-        #print "Received HTTP response:"
-        #print result
+        result = ""
+        while True:
+            chunk = s.recv(1024)
+            if not chunk:
+                break
+            result += chunk.decode('utf-8')
+
         if "200 OK" not in result:
           print("Expected an HTTP 200, got %s" % result, file=sys.stderr)
           return
@@ -55,13 +57,15 @@ def rpc(session_id, request):
         s.close()
 
 def parse_string(txt):
+    if not txt:
+        raise Exception("Unable to parse string response: None")
     prefix = "<value><array><data><value>success</value><value>"
     if not txt.startswith(prefix):
-        raise "Unable to parse string response"
+        raise Exception("Unable to parse string response: Wrong prefix")
     txt = txt[len(prefix):]
     suffix = "</value></data></array></value>"
     if not txt.endswith(suffix):
-        raise "Unable to parse string response"
+        raise Exception("Unable to parse string response: Wrong suffix")
     txt = txt[:len(txt)-len(suffix)]
     return txt
 
@@ -76,7 +80,6 @@ def read_field(session_id, table, fld, rf):
     return response
 
 if __name__ == "__main__":
-    import XenAPI
     xapi = XenAPI.xapi_local()
     xapi.xenapi.login_with_password('root', '')
     session_id = xapi._session

--- a/python3/unittest/import_file.py
+++ b/python3/unittest/import_file.py
@@ -1,0 +1,25 @@
+"""
+This file is used for importing a non-".py" file as a module in unit test.
+It never runs directly, so no shebang and no main()
+"""
+import sys
+import os
+from importlib import machinery, util
+
+def import_from_file(module_name, file_path):
+    """Import a file as a module"""
+    loader = machinery.SourceFileLoader(module_name, file_path)
+    spec = util.spec_from_loader(module_name, loader)
+    assert spec
+    assert spec.loader
+    module = util.module_from_spec(spec)
+    # Probably a good idea to add manually imported module stored in sys.modules
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+def get_module(module_name, file_path):
+    """get the module from a file"""
+    testdir = os.path.dirname(__file__)
+    print(testdir)
+    return import_from_file(module_name, testdir + file_path)

--- a/python3/unittest/test_hfx_filename.py
+++ b/python3/unittest/test_hfx_filename.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This module provides unittest for hfx_filename
+"""
+
+import sys
+import unittest
+from mock import MagicMock, patch, call
+from import_file import get_module
+
+# mock modules to avoid dependencies
+sys.modules["XenAPI"] = MagicMock()
+
+hfx_filename = get_module("hfx_filename", "/../bin/hfx_filename")
+
+
+@patch("socket.socket")
+class TestRpc(unittest.TestCase):
+    """
+    This class tests blow functions:
+    rpc()
+    db_get_uuid()
+    read_field()
+    """
+    def test_rpc(self, mock_socket):
+        """
+        Tests rpc
+        """
+        mock_connected_socket = MagicMock()
+        mock_socket.return_value = mock_connected_socket
+
+        recv_data = b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nHelloWorld"
+        # Set the return value for the first call to recv
+        mock_connected_socket.recv.side_effect = [recv_data, None]
+
+        session_id = 0
+        request = "socket request"
+        body = hfx_filename.rpc(session_id, request)
+
+        # Assert that the socket methods were called as expected
+        expected_data = [
+            b"POST /remote_db_access?session_id=0 HTTP/1.0\r\n",
+            b"Connection:close\r\n",
+            b"content-length:14\r\n",
+            b"\r\n",
+            b"socket request"
+        ]
+        mock_connected_socket.send.assert_has_calls([call(data) for data in expected_data])
+
+        expected_return = "HelloWorld"
+        self.assertEqual(expected_return, body)
+
+    def test_rpc_international_character(self, mock_socket):
+        """
+        Tests rpc using non-ascii characters
+        """
+        mock_connected_socket = MagicMock()
+        mock_socket.return_value = mock_connected_socket
+
+        recv_data = b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nHelloWorld"
+        # Set the return value for the first call to recv
+        mock_connected_socket.recv.side_effect = [recv_data, None]
+
+        session_id = 0
+        # Use international character"socket 请求" as request
+        request = "socket 请求"
+        body = hfx_filename.rpc(session_id, request)
+
+        # Assert that the socket methods were called as expected
+        expected_data = [
+            b"POST /remote_db_access?session_id=0 HTTP/1.0\r\n",
+            b"Connection:close\r\n",
+            b"content-length:13\r\n",
+            b"\r\n",
+            request.encode('utf-8')
+        ]
+        mock_connected_socket.send.assert_has_calls([call(data) for data in expected_data])
+
+        expected_return = "HelloWorld"
+        self.assertEqual(expected_return, body)
+
+    def test_db_get_uuid(self, mock_socket):
+        """
+        Tests db_get_uuid 
+        """
+        mock_connected_socket = MagicMock()
+        mock_socket.return_value = mock_connected_socket
+
+        header = "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n"
+        body = ("<value><array><data><value>success</value><value>HelloWorld"
+                "</value></data></array></value>")
+        recv_data = (header + body).encode('utf-8')
+        # Set the return value for the first call to recv
+        mock_connected_socket.recv.side_effect = [recv_data, None]
+
+        expected_response = "HelloWorld"
+        response = hfx_filename.db_get_by_uuid(0, "pool_patch", "22345")
+        self.assertEqual(expected_response, response)
+
+    def test_read_field(self, mock_socket):
+        """
+        Tests read_field 
+        """
+        mock_connected_socket = MagicMock()
+        mock_socket.return_value = mock_connected_socket
+
+        header = "HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n"
+        body = ("<value><array><data><value>success</value><value>file_name"
+                "</value></data></array></value>")
+        recv_data = (header + body).encode('utf-8')
+        # Set the return value for the first call to recv
+        mock_connected_socket.recv.side_effect = [recv_data, None]
+
+        expected_filename = "file_name"
+        filename = hfx_filename.read_field(0, "pool_patch", "filename", "rf")
+        self.assertEqual(expected_filename, filename)
+
+
+class TestParse(unittest.TestCase):
+    """
+    This class tests function parse_string()
+    """
+    def test_parse_string(self):
+        """
+        Tests parse_string
+        """
+        txt = ("<value><array><data><value>success</value><value>abcde"
+               "</value></data></array></value>")
+        expected_txt = "abcde"
+        return_txt = hfx_filename.parse_string(txt)
+        self.assertEqual(expected_txt, return_txt)

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -150,7 +150,6 @@ install:
 	$(IPROG) xe-syslog-reconfigure $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) xe-install-supplemental-pack $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) xe-enable-ipv6 $(DESTDIR)$(OPTDIR)/bin
-	$(IPROG) hfx_filename $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) pv2hvm $(DESTDIR)$(OPTDIR)/bin
 	mkdir -p $(DESTDIR)/etc/cron.daily
 	mkdir -p $(DESTDIR)/etc/cron.hourly


### PR DESCRIPTION
1. Create a new directory (python3/bin) for python3 scripts and move `hfx_filename` into it.
2. Migrate `hfx_filename` to python3.
3. Adjust CI check configurations to apply pytype check and unit test coverage to python3 scripts.
4. Added unit tests and covered all functions in hfx_filename.
5. Manually tested hfx_filename on XS8 to cover corner cases that not covered by unit tests:
- Use Flask to fake a HTTP server:
```
from flask import Flask, request

app = Flask(__name__)

@app.route('/remote_db_access', methods=['POST'])
def handle_request():
    # Extract session_id from query parameters
    session_id = request.args.get('session_id')

    # Extract data from the request XML
    data = "hotfix_filename"

    # Generate the response body with the desired format
    prefix = "<value><array><data><value>success</value><value>"
    suffix = "</value></data></array></value>"
    response_body = f"{prefix}{data}{suffix}"

    # Set the appropriate Content-Type header for XML response
    headers = {'Content-Type': 'application/xml'}

    return response_body, 200, headers

if __name__ == '__main__':
    app.run(host='127.0.0.1', port=8080)
```
- Scenario 1: Normal process
![image](https://github.com/xapi-project/xen-api/assets/131341002/779108a0-325c-4e89-a263-039c402124e4)
- Scenario 2: Response body in None
![image](https://github.com/xapi-project/xen-api/assets/131341002/d45dddaa-2ee9-4d38-85b6-321eac76dee4)
- Scenario 3: Response prefix is wrong
![image](https://github.com/xapi-project/xen-api/assets/131341002/a4f1600b-3a0d-4c62-9a5d-5262fabf0546)
- Scenario 4: Response suffix is wrong
![image](https://github.com/xapi-project/xen-api/assets/131341002/944d0ff0-0e3b-48c1-94b0-a9d8cf4e5860)

