### PR TITLE
fix(ci): Move differential shellcheck to its own workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,28 +12,6 @@ concurrency:  # On new push, cancel old workflows from the same PR, branch or ta
   cancel-in-progress: true
 
 jobs:
-  # https://www.shellcheck.net/wiki/GitHub-Actions
-  # https://github.com/redhat-plumbers-in-action/differential-shellcheck?tab=readme-ov-file#usage
-  shell-test:
-    name: Differential ShellCheck
-    runs-on: ubuntu-latest
-
-    permissions:
-      security-events: write
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-            fetch-depth: 0
-
-# If needed severity levels can be controlled here
-#            severity: warning
-      - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
-        with:
-            token: ${{ secrets.GITHUB_TOKEN }}
-    
   python-test:
     name: Python tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,32 @@
+name: ShellCheck
+
+on:
+  push:
+  pull_request:
+
+concurrency:  # On new push, cancel old workflows from the same PR, branch or tag:
+  group: sc-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # https://www.shellcheck.net/wiki/GitHub-Actions
+  # https://github.com/redhat-plumbers-in-action/differential-shellcheck?tab=readme-ov-file#usage
+  shell-test:
+    name: Differential ShellCheck
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+
+# If needed severity levels can be controlled here
+#            severity: warning
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,7 +1,6 @@
 name: ShellCheck
 
 on:
-  push:
   pull_request:
 
 concurrency:  # On new push, cancel old workflows from the same PR, branch or tag:


### PR DESCRIPTION
It is not supported in scheduled runs, and fails: https://github.com/xapi-project/xen-api/actions/runs/8090127285/job/22107122716

I'm not sure how to define `on` for a given job, so move it to a separate workflow file instead.