### PR TITLE
Backport CP-43755 - rate limits for PAM logins

### DIFF
--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -307,7 +307,6 @@ let release_lock (target : API.ref_VM) (token : token) =
   Thread_state.released (lock_of_vm target) ;
   debug "Released lock on VM %s with token %Ld" (Ref.string_of target) token
 
-
 module Semaphore = struct
   type t = {
       name: string
@@ -316,8 +315,13 @@ module Semaphore = struct
     ; mutable max: int
   }
 
-  let create ?(max=1) name =
-    {name; sem= Semaphore_vendored.Counting.make max; max_lock= Mutex.create (); max}
+  let create ?(max = 1) name =
+    {
+      name
+    ; sem= Semaphore_vendored.Counting.make max
+    ; max_lock= Mutex.create ()
+    ; max
+    }
 
   let execute (x : t) f =
     Semaphore_vendored.Counting.acquire x.sem ;

--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -316,8 +316,7 @@ module Semaphore = struct
     ; mutable max: int
   }
 
-  let create name =
-    let max = 1 in
+  let create ?(max=1) name =
     {name; sem= Semaphore_vendored.Counting.make max; max_lock= Mutex.create (); max}
 
   let execute (x : t) f =

--- a/ocaml/xapi/locking_helpers.ml
+++ b/ocaml/xapi/locking_helpers.ml
@@ -22,6 +22,8 @@ module D = Debug.Make (struct let name = "locking_helpers" end)
 
 open D
 
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
 type resource = Lock of string | Process of string * int
 
 let string_of_resource = function
@@ -304,3 +306,55 @@ let release_lock (target : API.ref_VM) (token : token) =
   ) ;
   Thread_state.released (lock_of_vm target) ;
   debug "Released lock on VM %s with token %Ld" (Ref.string_of target) token
+
+
+module Semaphore = struct
+  type t = {
+      name: string
+    ; sem: Semaphore_vendored.Counting.t
+    ; max_lock: Mutex.t
+    ; mutable max: int
+  }
+
+  let create name =
+    let max = 1 in
+    {name; sem= Semaphore_vendored.Counting.make max; max_lock= Mutex.create (); max}
+
+  let execute (x : t) f =
+    Semaphore_vendored.Counting.acquire x.sem ;
+    finally f (fun () -> Semaphore_vendored.Counting.release x.sem)
+
+  let set_max t n =
+    if n < 1 then
+      Fmt.invalid_arg
+        "The semaphore '%s' must have at least 1 resource available, \
+         requested: %d"
+        t.name n ;
+    (* ensure only 1 thread attempts to modify the maximum at a time, this is a slow path *)
+    with_lock t.max_lock @@ fun () ->
+    D.debug
+      "Setting semaphore '%s' to have at most %d resource (current max: %d)"
+      t.name n t.max ;
+
+    (* requested to decrease maximum, this might block *)
+    while t.max > n do
+      if not (Semaphore_vendored.Counting.try_acquire t.sem) then (
+        D.debug
+          "Semaphore '%s' has >%d resources in use, waiting until some of them \
+           are released"
+          t.name n ;
+        (* may block *)
+        Semaphore_vendored.Counting.acquire t.sem
+      ) ;
+      t.max <- t.max - 1
+    done ;
+
+    (* requested to increase maximum, this doesn't block *)
+    while t.max < n do
+      (* doesn't block, semaphores can also be acquired and released from any thread *)
+      Semaphore_vendored.Counting.release t.sem ;
+      t.max <- t.max + 1
+    done ;
+    D.debug "Semaphore '%s' updated to have %d resources (%d in use)" t.name n
+      (Semaphore_vendored.Counting.get_value t.sem)
+end

--- a/ocaml/xapi/locking_helpers.mli
+++ b/ocaml/xapi/locking_helpers.mli
@@ -54,7 +54,7 @@ module Semaphore : sig
   (** a semaphore that allows at most N operations to proceed at a time *)
   type t
 
-  val create : string -> t
+  val create : ?max:int -> string -> t
   (** [create name] creates a semaphore with an initial count of 1.
     @see {!set_max} *)
 

--- a/ocaml/xapi/locking_helpers.mli
+++ b/ocaml/xapi/locking_helpers.mli
@@ -49,7 +49,6 @@ module Named_mutex : sig
   val execute : t -> (unit -> 'a) -> 'a
 end
 
-
 module Semaphore : sig
   (** a semaphore that allows at most N operations to proceed at a time *)
   type t

--- a/ocaml/xapi/locking_helpers.mli
+++ b/ocaml/xapi/locking_helpers.mli
@@ -48,3 +48,28 @@ module Named_mutex : sig
 
   val execute : t -> (unit -> 'a) -> 'a
 end
+
+
+module Semaphore : sig
+  (** a semaphore that allows at most N operations to proceed at a time *)
+  type t
+
+  val create : string -> t
+  (** [create name] creates a semaphore with an initial count of 1.
+    @see {!set_max} *)
+
+  val execute : t -> (unit -> 'a) -> 'a
+  (** [execute sem f] executes [f] after acquiring the [sem]aphore.
+    Releases the semaphore on all codepaths. *)
+
+  val set_max : t -> int -> unit
+  (** [set_max sem n] sets the semaphore's maximum count to [n].
+    Once all threads that are inside {!execute} release the semaphore then the semaphore will accept
+    at most [n] {!execute} calls in parallel until it blocks.
+
+    Increasing a semaphore's count is done immediately,
+    whereas decreasing the count may block until sufficient number of threads release the semaphore.    
+
+    It is safe to call this function in parallel.
+  *)
+end

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -32,9 +32,11 @@ let local_superuser = "root"
 
 let xapi_internal_originator = "xapi"
 
-let throttle_auth_internal = Locking_helpers.Semaphore.create "Internal auth"
+let throttle_auth_internal =
+  Locking_helpers.Semaphore.create ~max:8 "Internal auth"
 
-let throttle_auth_external = Locking_helpers.Semaphore.create "External auth"
+let throttle_auth_external =
+  Locking_helpers.Semaphore.create ~max:8 "External auth"
 
 let with_throttle = Locking_helpers.Semaphore.execute
 

--- a/semaphore_vendored.ml
+++ b/semaphore_vendored.ml
@@ -1,0 +1,86 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Xavier Leroy, Collège de France and INRIA Paris               *)
+(*                                                                        *)
+(*   Copyright 2020 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Semaphores *)
+
+type sem = {
+  mut: Mutex.t;                         (* protects [v] *)
+  mutable v: int;                       (* the current value *)
+  nonzero: Condition.t                  (* signaled when [v > 0] *)
+}
+
+module Counting = struct
+
+type t = sem
+
+let make v =
+  if v < 0 then invalid_arg "Semaphore.Counting.init: wrong initial value";
+  { mut = Mutex.create(); v; nonzero = Condition.create() }
+
+let release s =
+  Mutex.lock s.mut;
+  if s.v < max_int then begin
+    s.v <- s.v + 1;
+    Condition.signal s.nonzero;
+    Mutex.unlock s.mut
+  end else begin
+    Mutex.unlock s.mut;
+    raise (Sys_error "Semaphore.Counting.release: overflow")
+  end
+
+let acquire s =
+  Mutex.lock s.mut;
+  while s.v = 0 do Condition.wait s.nonzero s.mut done;
+  s.v <- s.v - 1;
+  Mutex.unlock s.mut
+
+let try_acquire s =
+  Mutex.lock s.mut;
+  let ret = if s.v = 0 then false else (s.v <- s.v - 1; true) in
+  Mutex.unlock s.mut;
+  ret
+
+let get_value s = s.v
+
+end
+
+module Binary = struct
+
+type t = sem
+
+let make b =
+  { mut = Mutex.create();
+    v = if b then 1 else 0;
+    nonzero = Condition.create() }
+
+let release s =
+  Mutex.lock s.mut;
+  s.v <- 1;
+  Condition.signal s.nonzero;
+  Mutex.unlock s.mut
+
+let acquire s =
+  Mutex.lock s.mut;
+  while s.v = 0 do Condition.wait s.nonzero s.mut done;
+  s.v <- 0;
+  Mutex.unlock s.mut
+
+let try_acquire s =
+  Mutex.lock s.mut;
+  let ret = if s.v = 0 then false else (s.v <- 0; true) in
+  Mutex.unlock s.mut;
+  ret
+
+end

--- a/semaphore_vendored.ml
+++ b/semaphore_vendored.ml
@@ -16,71 +16,87 @@
 (** Semaphores *)
 
 type sem = {
-  mut: Mutex.t;                         (* protects [v] *)
-  mutable v: int;                       (* the current value *)
-  nonzero: Condition.t                  (* signaled when [v > 0] *)
+    mut: Mutex.t
+  ; (* protects [v] *)
+    mutable v: int
+  ; (* the current value *)
+    nonzero: Condition.t (* signaled when [v > 0] *)
 }
 
 module Counting = struct
+  type t = sem
 
-type t = sem
+  let make v =
+    if v < 0 then invalid_arg "Semaphore.Counting.init: wrong initial value" ;
+    {mut= Mutex.create (); v; nonzero= Condition.create ()}
 
-let make v =
-  if v < 0 then invalid_arg "Semaphore.Counting.init: wrong initial value";
-  { mut = Mutex.create(); v; nonzero = Condition.create() }
+  let release s =
+    Mutex.lock s.mut ;
+    if s.v < max_int then (
+      s.v <- s.v + 1 ;
+      Condition.signal s.nonzero ;
+      Mutex.unlock s.mut
+    ) else (
+      Mutex.unlock s.mut ;
+      raise (Sys_error "Semaphore.Counting.release: overflow")
+    )
 
-let release s =
-  Mutex.lock s.mut;
-  if s.v < max_int then begin
-    s.v <- s.v + 1;
-    Condition.signal s.nonzero;
+  let acquire s =
+    Mutex.lock s.mut ;
+    while s.v = 0 do
+      Condition.wait s.nonzero s.mut
+    done ;
+    s.v <- s.v - 1 ;
     Mutex.unlock s.mut
-  end else begin
-    Mutex.unlock s.mut;
-    raise (Sys_error "Semaphore.Counting.release: overflow")
-  end
 
-let acquire s =
-  Mutex.lock s.mut;
-  while s.v = 0 do Condition.wait s.nonzero s.mut done;
-  s.v <- s.v - 1;
-  Mutex.unlock s.mut
+  let try_acquire s =
+    Mutex.lock s.mut ;
+    let ret =
+      if s.v = 0 then
+        false
+      else (
+        s.v <- s.v - 1 ;
+        true
+      )
+    in
+    Mutex.unlock s.mut ; ret
 
-let try_acquire s =
-  Mutex.lock s.mut;
-  let ret = if s.v = 0 then false else (s.v <- s.v - 1; true) in
-  Mutex.unlock s.mut;
-  ret
-
-let get_value s = s.v
-
+  let get_value s = s.v
 end
 
 module Binary = struct
+  type t = sem
 
-type t = sem
+  let make b =
+    {
+      mut= Mutex.create ()
+    ; v= (if b then 1 else 0)
+    ; nonzero= Condition.create ()
+    }
 
-let make b =
-  { mut = Mutex.create();
-    v = if b then 1 else 0;
-    nonzero = Condition.create() }
+  let release s =
+    Mutex.lock s.mut ;
+    s.v <- 1 ;
+    Condition.signal s.nonzero ;
+    Mutex.unlock s.mut
 
-let release s =
-  Mutex.lock s.mut;
-  s.v <- 1;
-  Condition.signal s.nonzero;
-  Mutex.unlock s.mut
+  let acquire s =
+    Mutex.lock s.mut ;
+    while s.v = 0 do
+      Condition.wait s.nonzero s.mut
+    done ;
+    s.v <- 0 ;
+    Mutex.unlock s.mut
 
-let acquire s =
-  Mutex.lock s.mut;
-  while s.v = 0 do Condition.wait s.nonzero s.mut done;
-  s.v <- 0;
-  Mutex.unlock s.mut
-
-let try_acquire s =
-  Mutex.lock s.mut;
-  let ret = if s.v = 0 then false else (s.v <- 0; true) in
-  Mutex.unlock s.mut;
-  ret
-
+  let try_acquire s =
+    Mutex.lock s.mut ;
+    let ret =
+      if s.v = 0 then
+        false
+      else (
+        s.v <- 0 ;
+        true
+      )
+    in
+    Mutex.unlock s.mut ; ret
 end


### PR DESCRIPTION
We are backporting a list of commits from master but drop the changes to the datamodel and instead use a hard-coded value.