### PR TITLE
CA-389506: fix platform:nested_virt typo

### DIFF
--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -351,7 +351,7 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept =
   if iommu then
     assert_capability CAP_DirectIO ~on_error:(fun () -> "IOMMU unavailable") ;
   let nested_virt =
-    get_platform_key ~key:"nested_virt" ~default:false require_hvm
+    get_platform_key ~key:"nested-virt" ~default:false require_hvm
   in
   let vpmu = get_platform_key ~key:"vpmu" ~default:false (fun _ -> Ok ()) in
 


### PR DESCRIPTION
Nested virt is not a supported feature yet, but when moving the setting from Xen to toolstack as part of the Xen-4.17 update I typoed the name of the setting.

It was platform/nested-virt in xenguest.patch before

Fixes: 664de7608d ("Xen-4.15+: CDF_NESTED_VIRT")

I'll also need to find another test to use that checks whether the feature works, the previous test that I used tested the feature by booting a guest, and checking that it has booted, without checking whether nested virt actually worked inside.