### PR TITLE
opam: add hex to xapi dependencies

### DIFF
--- a/xapi.opam
+++ b/xapi.opam
@@ -24,6 +24,7 @@ depends: [
   "domain-name"
   "ezxenstore"
   "fmt" {with-test}
+  "hex"
   "http-lib" {with-test} # the public library is only used for testing
   "ipaddr"
   "mirage-crypto" {with-test}

--- a/xapi.opam.template
+++ b/xapi.opam.template
@@ -22,6 +22,7 @@ depends: [
   "domain-name"
   "ezxenstore"
   "fmt" {with-test}
+  "hex"
   "http-lib" {with-test} # the public library is only used for testing
   "ipaddr"
   "mirage-crypto" {with-test}


### PR DESCRIPTION
The latest xs-opam update seems to have removed the dependency since it's no longer an indirect one, adding it as a direct one should fix the build issues