### PR TITLE
New base for a new Python3 branch: Simplify python3 tests and coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,9 +12,9 @@ codecov:
   #
   # Show the Codecov status without waiting for other status to pass:
   #
-  require_ci_to_pass: no
+  require_ci_to_pass: false
   notify:
-    wait_for_ci: no
+    wait_for_ci: false
 
 github_checks:
   #
@@ -174,7 +174,7 @@ coverage:
         #
         # For python3, coverage should not be reduced compared to its base:
         #
-        target: auto
+        target: 60%
 
         #
         # Exception: the threshold value given is allowed
@@ -186,8 +186,9 @@ coverage:
       # Checks each Python version separately:
       python-3.11:
         flags: ["python3.11"]
-      python-2.7:
-        flags: ["python2.7"]
+      # Not checked as py2-to-py3 migrated files are moved to the python3 directory:
+      # python-2.7:
+      #   flags: ["python2.7"]
 
     #
     # Project limits
@@ -195,14 +196,6 @@ coverage:
     # These checks are relative to all code, not the changes (not the diff of the PR)
     #
     project:
-
-      #
-      # Python modules and scripts below scripts/ (excluding tests)
-      #
-      scripts:
-        paths: ["scripts/**", "!**/test_*.py"]
-        target: 48%
-        threshold: 2%
 
       #
       # Python modules and scripts below ocaml/ (excluding tests)
@@ -226,7 +219,7 @@ coverage:
       tests:
         # Ensure that all tests are executed (tests themselves must be 100% covered)
         target: 98%
-        paths: ["**/test_*.py"]
+        paths: ["**/test_*.py", "**/it_*.py", ]
 
 
 #
@@ -244,7 +237,7 @@ component_management:
         # `auto` will use the coverage from the base commit (pull request base
         # or parent commit) coverage to compare against.
         target: auto
-        threshold: 2%
+        threshold: 20%
 
       - type: patch
         target: auto
@@ -252,30 +245,18 @@ component_management:
 
   individual_components:
 
-    - component_id: scripts  # this is an identifier that should not be changed
-      name: scripts  # this is a display name, and can be changed freely
-      # The list of paths that should be in- and excluded in this component:
-      paths: ["scripts/**", "!scripts/examples/**", "!**/test_*.py"]
-
-    - component_id: scripts/examples
-      name: scripts/examples
-      paths: ["scripts/examples/**", "!scripts/**/test_*.py"]
-
     - component_id: ocaml
       name: ocaml
       paths: ["ocaml/**", "!**/test_*.py"]
 
-    - component_id: ocaml/xapi-storage
-      name: ocaml/xapi-storage
-      paths:
-        - "ocaml/xapi-storage/**"
-        - "ocaml/xapi-storage-script/**"
-        - "!**/test_*.py"
+    # Not covered by the current tests:
+    #- component_id: ocaml/xapi-storage
+    #  name: ocaml/xapi-storage
+    #  paths:
+    #    - "ocaml/xapi-storage/**"
+    #    - "ocaml/xapi-storage-script/**"
+    #    - "!**/test_*.py"
 
     - component_id: python3
       name: python3
       paths: ["python3/**", "!**/test_*.py"]
-
-    - component_id: test_cases
-      name: test_cases
-      paths: ["**/test_*.py"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,46 +37,32 @@ jobs:
       - run: echo "::add-matcher::.github/workflows/python-warning-matcher.json"
         name: "Setup GitHub for reporting Python warnings as annotations in pull request code review"
 
+      - uses: jordemort/action-pyright@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+
       - uses: pre-commit/action@v3.0.0
-        name: Run pre-commit checks (no spaces at end of lines, etc)
+        name: Run pre-commit hooks with darker, pytest, pylint, and pytype
         if: ${{ matrix.python-version != '2.7' }}
         with:
-          extra_args: --all-files --verbose --hook-stage commit
+          extra_args: --all-files --verbose --hook-stage push
         env:
+          PR_NUMBER: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTYPE_REPORTER_DEBUG: True
           SKIP: no-commit-to-branch
-
-      - name: Install dependencies only needed for python 2
-        if: ${{ matrix.python-version == '2.7' }}
-        run: pip install enum
-
-      - name: Install dependencies only needed for python 3
-        if: ${{ matrix.python-version != '2.7' }}
-        run: pip install pandas pytype toml wrapt
-
-      - name: Install common dependencies for Python ${{matrix.python-version}}
-        run: pip install future mock pytest-coverage pytest-mock
 
       - name: Run Pytest for python 2 and get code coverage for Codecov
         if: ${{ matrix.python-version == '2.7' }}
         run: >
+          pip install enum future mock pytest-coverage pytest-mock &&
           pytest
           --cov=scripts --cov=ocaml/xcp-rrdd
           scripts/ ocaml/xcp-rrdd -vv -rA
           --junitxml=.git/pytest${{matrix.python-version}}.xml
           --cov-report term-missing
-          --cov-report xml:.git/coverage${{matrix.python-version}}.xml
-        env:
-          PYTHONDEVMODE: yes
-
-      - name: Run Pytest for python 3 and get code coverage for Codecov
-        if: ${{ matrix.python-version != '2.7' }}
-        run: >
-          pytest
-          --cov=scripts --cov=ocaml/xcp-rrdd --cov=python3/
-          scripts/ ocaml/xcp-rrdd python3/ -vv -rA
-          --junitxml=.git/pytest${{matrix.python-version}}.xml
-          --cov-report term-missing
-          --cov-report xml:.git/coverage${{matrix.python-version}}.xml
+          --cov-report xml:.git/coverage.xml
         env:
           PYTHONDEVMODE: yes
 
@@ -84,39 +70,21 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: .git
-          files: coverage${{matrix.python-version}}.xml
+          files: coverage.xml
           env_vars: OS,PYTHON
           fail_ci_if_error: false
           flags: python${{matrix.python-version}}
           name: coverage${{matrix.python-version}}
           verbose: true
 
-      - uses: dciborow/action-pylint@0.1.0
+      - uses: dciborow/action-pylint@0.1.1
         if: ${{ matrix.python-version != '2.7' }}
         with:
           reporter: github-pr-review
+          pylint_args: --disable=import-error
           level: warning
           # To be customized to cover remaining Python scripts:
           glob_pattern: "**/*.py"
-
-      - name: Run pytype checks
-        if: ${{ matrix.python-version != '2.7' }}
-        run: ./pytype_reporter.py
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PYTYPE_REPORTER_DEBUG: True
-
-      # Try to add pytype_report.py's summary file as a comment to the PR:
-      # Documentation: https://github.com/marketplace/actions/add-pr-comment
-      - name: Add the pytype summary as a comment to the PR (if permitted)
-        uses: mshick/add-pr-comment@v2
-        # Depends on pytype checks, which are not run for python 2.7:
-        if: ${{ matrix.python-version != '2.7' }}
-        # Fails for user workflows without permissions(fork-based pull requests):
-        continue-on-error: true
-        with:
-          message-path: .git/pytype-summary.md # Add the content of it as comment
 
   ocaml-tests:
     name: Run OCaml tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,25 @@
 #
-# Configuration of pre-commit, a Python framework for git hooks.
-# pre-commit is run for each git push by GitHub CI. It can run
-# locally as well for early feedback and automatic formatting
-# like trailing whitespace removal (to be configured later):
+# This is the configuration file of the pre-commit framework for this repository:
+# https://pypi.org/project/pre-commit / https://pre-commit.com
 #
-## For only installing the package itself, run:
-# pip3 install pre-commit
+# It is a Python framework for managing and multi-language pre-commit hooks.
+# pre-commit runs in the GitHub Workflow of this project, and
+# it can be run locally as well for early feedback and e.g. formatting checks.
 #
-## For activating it as a pre-commit and pre-push hook (recommended):
-# pre-commit install --hook-type pre-push --hook-type pre-commit
+# For only installing the package itself, run:
+# $ pip3 install pre-commit
 #
-## For manually executing the pre-push hook:
-# pre-commit run -av --hook-stage pre-push
+# On the initial run, pre-commit downloads its checkers, subsequent runs are fast:
+#
+# $ pre-commit run    # automatically checks which checks are needed.
+# $ pre-commit run -a # runs all fixes and checks, even when not needed#
+#
+# When this works, you can enable it as the pre-commit hook for this git clone:
+# $ pre-commit install
+# $ pre-commit install --hook-type pre-push
+#
+# You can skip checks if you commit very often you don't want them to run, e.g:
+# export SKIP=pytest;git commit -m "quick save" (or for --amend)
 #
 default_stages: [commit, push]
 repos:
@@ -29,18 +37,99 @@ repos:
     -   id: check-executables-have-shebangs
         exclude: ocaml
 
-# Recommendation for a minimal git pre-push hook:
-# While using pre-commit yields great results, it
-# is "not fast". Therefore only run it pre-push,
-# (but always in GitHub CI of course):
 #
-# Calls ./pytype_reporter.py in a dedicated venv:
-# pre-commit run -av --hook-stage push
+# Improve Python formatting incrementally:
+# https://dev.to/akaihola/improving-python-code-incrementally-3f7a
+#
+# darker checks if staged python changes are formatted according using
+# the PEP8-aligned black formatter. It also checks if the imports are sorted.
+#
+# It is a good idea to run this before committing, and it is also run in the
+# GitHub Workflow.
+#
+# Note: darker only checks the changes in files ending in .py!
+# Python scripts that don't end in .py should be renamed to have the .py extension
+# when moving them to python3/bin.
+# (remove the .py extension in the Makefile when installing the file)
+#
+-   repo: https://github.com/akaihola/darker
+    rev: 1.7.3
+    hooks:
+    -   id: darker
+        files: python3/
+        name: check changes in Python3 tree using darker and isort
+        args: [--diff, --skip-string-normalization, --isort, -tpy36]
+        additional_dependencies: [isort]
+
+#
+# Run pytest and diff-cover to check that the new /python3 test suite in passes.
+# This hook uses a local venv containing the required dependencies. When adding
+# new dependencies, they should be added to the additional_dependencies below.
+#
+-   repo: local
+    hooks:
+    -   id: pytest
+        files: python3/
+        name: check that the Python3 test suite in passes
+        entry: env PYTHONDEVMODE=yes sh -c 'python3 -m pytest -vv &&
+            diff-cover --ignore-whitespace --compare-branch=origin/master
+            --show-uncovered --html-report .git/coverage-diff.html
+            --fail-under 50 .git/coverage.xml'
+        require_serial: true
+        pass_filenames: false
+        language: python
+        types: [python]
+        additional_dependencies:
+        - coverage
+        - diff-cover
+        - future
+        - opentelemetry-api
+        - opentelemetry-exporter-zipkin-json
+        - opentelemetry-sdk
+        - pytest-coverage
+        - pytest-mock
+        - mock
+        - wrapt
+        - XenAPI
+
+
+-   repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.352
+    hooks:
+    -   id: pyright
+        name: check that python3 tree passes pyright/VSCode check
+        files: python3/
+        additional_dependencies:
+        - opentelemetry-api
+        - opentelemetry-exporter-zipkin-json
+        - opentelemetry-sdk
+        - pytest
+        - mock
+
+
+# Check that pylint passes for the changes in new /python3 code.
+-   repo: local
+    hooks:
+    -   id: pylint
+        files: python3/
+        stages: [push]
+        name: check that changes to python3 tree pass pylint
+        entry: diff-quality --violations=pylint
+            --ignore-whitespace --compare-branch=origin/master
+        pass_filenames: false
+        language: python
+        types: [python]
+        additional_dependencies: [diff-cover, pylint, pytest]
+
+
+# pre-push hook (it only runs if you install pre-commit as a pre-push hook):
 -   repo: local
     hooks:
     -   id: pytype
-        name: pytype
-        entry: python3 pytype_reporter.py
+        # It can be manually tested using: `pre-commit run -av --hook-stage push`
+        name: '[push, may be slow] run pytype_reporter.py for errors in python3/'
+        files: python3/
+        entry: ./pytype_reporter.py
         pass_filenames: false
         types: [python]
         stages: [push]
@@ -53,4 +142,11 @@ repos:
         # developers have such version installed, it can be configured here:
         # language_version: python3.11
         require_serial: true
-        additional_dependencies: [pandas, pytype]
+        additional_dependencies:
+        - future
+        - opentelemetry-api
+        - opentelemetry-exporter-zipkin-json
+        - opentelemetry-sdk
+        - pandas
+        - pytest
+        - pytype

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,65 +149,15 @@ discard_messages_matching = [
     "No attribute 'group' on None",
     "No Node.TEXT_NODE in module xml.dom.minidom, referenced from 'xml.dom.expatbuilder'"
 ]
-expected_to_fail = [
-    "scripts/hfx_filename",
-    "scripts/perfmon",
-    # Need 2to3 -w <file> and maybe a few other minor updates:
-    "scripts/hatests",
-    "scripts/backup-sr-metadata.py",
-    "scripts/restore-sr-metadata.py",
-    "scripts/nbd_client_manager.py",
-    # No attribute 'popen2' on module 'os' [module-attr] and a couple more:
-    "scripts/mail-alarm",
-    # SSLSocket.send() only accepts bytes, not unicode string as argument:
-    "scripts/examples/python/exportimport.py",
-    # Other fixes needed:
-    "scripts/examples/python/mini-xenrt.py",
-    "scripts/examples/python/XenAPI/XenAPI.py",
-    "scripts/examples/python/monitor-unwanted-domains.py",
-    "scripts/examples/python/shell.py",
-    "scripts/examples/smapiv2.py",
-    "scripts/static-vdis",
-    # add_interface: unsupported operand type(s) for +: str and UsbInterface
-    "scripts/usb_scan.py",
-    # TestUsbScan.assertIn() is called with wrong arguments(code not iterable)
-    "scripts/test_usb_scan.py",
-    "scripts/plugins/extauth-hook-AD.py",
-]
+expected_to_fail = []
 
 
 [tool.pytype]
 inputs = [
-    "scripts/hfx_filename",
-    "scripts/perfmon",
-    "scripts/static-vdis",
-    "scripts/Makefile",
-    "scripts/generate-iscsi-iqn",
-    "scripts/hatests",
-    "scripts/host-display",
-    "scripts/mail-alarm",
-    "scripts/print-custom-templates",
-    "scripts/probe-device-for-file",
-    "scripts/xe-reset-networking",
-    "scripts/xe-scsi-dev-map",
-    "scripts/examples/python",
-    "scripts/yum-plugins",
-    "scripts/*.py",
-    "python3/packages/*.py",
-
-    # To be added later,
-    # when converted to Python3-compatible syntax:
-    # "ocaml/message-switch/python",
-    # "ocaml/idl/ocaml_backend/python",
-    # "ocaml/xapi-storage/python",
+    "python3/",
+    "ocaml/xcp-rrdd",
 ]
 disable = [
-    "import-error",  # xenfsimage, xcp.bootloader. xcp.cmd
-    "ignored-abstractmethod",
-    "ignored-metaclass",
-    # https://github.com/google/pytype/issues/1130,
-    # https://github.com/google/pytype/issues/1485:
-    "pyi-error",
 ]
 platform = "linux"
-pythonpath = "scripts/examples/python:.:scripts:scripts/plugins:scripts/examples"
+pythonpath = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # https://packaging.python.org/en/latest/specifications/pyproject-toml/
 [project]
 name = "xen-api"
-requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+requires-python = ">=3.6.*"
 license = {file = "LICENSE"}
 keywords = ["xen-project", "Xen", "hypervisor", "libraries"]
 maintainers = [
@@ -29,7 +29,7 @@ line-length = 88
 
 [tool.isort]
 line_length = 88
-py_version = 27
+py_version = 36
 profile = "black"
 combine_as_imports = true
 ensure_newline_before_comments = false
@@ -59,6 +59,86 @@ disallow_any_explicit = false
 disallow_any_generics = true
 disallow_any_unimported = true
 disallow_subclassing_any = true
+
+
+# https://microsoft.github.io/pyright/#/configuration?id=main-configuration-options
+[tool.pyright]
+
+# Specifies the paths of directories or files that should be included in the
+# analysis. If no paths are specified, all files in the workspace are included:
+include = ["python3", "ocaml/xcp-rrdd"]
+
+# Conditionalize the stube files for type definitions based on the platform:
+pythonPlatform = "Linux"
+
+# typeCheckingMode: "off", "basic", "standard" or "strict"
+typeCheckingMode = "standard"
+
+# Specifies the version of Python that will be used to execute the source code.
+# Venerate errors if the source code makes use of language features that are
+# not supported in that version. It will also tailor its use of type stub files,
+# which conditionalizes type definitions based on the version. If no version is
+# specified, pyright will use the version of the current python interpreter,
+# if one is present:
+pythonVersion = "3.6"
+
+# Paths of directories or files that should use "strict" analysis if they are
+# included. This is the same as manually adding a "# pyright: strict" comment.
+# In strict mode, most type-checking rules are enabled, and the type-checker
+# will be more aggressive in inferring types. If no paths are specified, strict
+# mode is not enabled:
+strict = ["python3/tests/observer"]
+
+#
+# Paths to exclude from analysis. If a file is excluded, it will not be
+# analyzed.
+#
+# FIXME: Some of these may have type errors, so they should be inspected and fixed:
+#
+exclude = [
+    "ocaml/xcp-rrdd/scripts/rrdd/rrdd.py",
+    "ocaml/xcp-rrdd/scripts/rrdd/rrdd-example.py",
+    "python3/packages/observer.py",
+]
+
+[tool.pytest.ini_options]
+# The following options are passed to pytest:
+# -v is used to increase verbosity
+# -rA is used to show extra test summary info for all tests
+# --cov=python3 is used to measure coverage of the python3 directory
+# --cov-fail-under=60 is the minimum coverage required for the tests to pass
+# --cov-context=test is used to distinguish between test and non-test code
+# --cov-report=term-missing is used to show missing lines in the coverage report
+# --cov-report=html:.git/coverage is used to generate an HTML coverage report
+# --cov-report=xml:.git/coverage.xml is used to generate an XML coverage report
+# --junitxml=.git/pytest.xml is used to generate a JUnit XML report
+addopts = """
+-v -rA --cov=python3 --cov=scripts --cov-context=test --cov-fail-under=50
+--cov-report=term-missing
+--cov-report=html:.git/coverage
+--cov-report=xml:.git/coverage.xml
+--junitxml=.git/pytest.xml
+"""
+#
+# The following options are used to configure pytest:
+# log_cli = true is used to show log messages on the console
+# log_cli_level = "INFO" is used to set the log level to INFO
+# python_files = ["test_*.py"] is used to match test files
+# python_functions = ["test_", "it_", "when_"] is used to match test functions
+# pythonpath = "python3 python3/stubs" is used to add the python3 directory and
+# the stubs directory to the PYTHONPATH
+# testpaths = ["python3", "ocaml/xcp-rrdd"] sets test paths where tests are looked for
+# xfail_strict = true is used to fail tests marked as xfail if they pass(used for TDD)
+# required_plugins = ["pytest-cov", "pytest-mock"] makes sure that these are installed
+#
+log_cli = true
+log_cli_level = "INFO"
+python_files = ["test_*.py", "it_*.py"]
+python_functions = ["test_", "it_", "when_"]
+pythonpath = "python3 python3/stubs"
+required_plugins = ["pytest-cov", "pytest-mock"]
+testpaths = ["python3", "scripts", "ocaml/xcp-rrdd"]
+xfail_strict = true
 
 
 [tool.pytype_reporter]

--- a/pytype_reporter.py
+++ b/pytype_reporter.py
@@ -599,13 +599,15 @@ def main():
     config_file = "pyproject.toml"
     config = load_config(config_file, basename(__file__))
     config.setdefault("expected_to_fail", [])
-    debug("Expected to fail: %s", ", ".join(config["expected_to_fail"]))
+    changed_but_in_expected_to_fail = []
+    if config["expected_to_fail"]:
+        debug("Expected to fail: %s", ", ".join(config["expected_to_fail"]))
 
-    changed_but_in_expected_to_fail = git_diff(
-        "--name-only",
-        find_branch_point(config),
-        *config["expected_to_fail"],
-    ).splitlines()
+        changed_but_in_expected_to_fail = git_diff(
+            "--name-only",
+            find_branch_point(config),
+            *config["expected_to_fail"],
+        ).splitlines()
 
     if check_only_reverts_from_branch_point(config, changed_but_in_expected_to_fail):
         return run_pytype_and_generate_summary(config)


### PR DESCRIPTION
This pull request is a new base for a new Python3 branch:

1. Hopefully, no more fails of Covecov, because test coverage can now be checked locally, during development, before even pushing or opening an PR

2. Remove pytest and pytype for Python3 from `.github/workflows/main.yml`:
   - pytest and all other check for Python3 can be fully executed locally, in the Python environment created by pre-commit. This has a number of benefits:
     - No setup issues: Simply run `pip install pre-commit` and `pre-commit run pytest -av` then runs the exact same test that is run in CI, in the same environment on each host, each time. There is no manual setup involved.
     - If local checks (a single pre-commit command) pass, then GitHub CI will pass too, and the same test run will work for everyone.

3. Also add darker (black, but only for changes, not the complete file) for a consistent format of the migrated files
   - But no mass-formatting of the whole source file!!!
     - Helps to reduce churn when reviewing the changes and during PR review!

4. Because files will be moved Python3 will be moved to `python3/**`, the python3 checks are all moved to only check the `python3/**`:
   - Dramatically reduces the huge amount of noise that the pytype_reporter generates to `0`.
   - pytype_reporter completes now really fast compared to the current state!
   - GitHub CI for Python3 finishes a lot quicker now!

5. Clean up effect:
   - No more `pyproject.toml` `[tool.pytype_reporter]` `expected_to_fail`
     - Gone at once! No more conflicts from changing the list of expected_to_fail!
     - This is easy as all files in `python3/**` pass all checks, not list handling!
     - Those checks which are failing but are fine (not a problem) can of course like before disabled using comments, like now!

There is only one thing to remember:
- Simply run `pip install pre-commit` to install pre-commit and
- Run `pre-commit run pytest -av` to run quick tests (pytest, etc)
- Run `pre-commit run pytest -av --hook-stage push` to run all tests (pylint, pytype)
  - When this latter test passes, the GitHub CI workflow (that runs the same command) will also pass!
     
I think this removes a lot of churn from making Python3 work for a file
- by giving the developer direct control of the unit/integration test environment.
- More tests to have more examples to use for tests will be added in due course to python3/tests. GitHub Copilot is often very good at writing tests, and if existing test files are open in the IDE, it should be able to use these for context and model new test code after the existing tests.

It includes the following commits:

- pyproject.toml: Configure pytest and versions for testing
- GitHub CI: pytest and pytype are in pre-commit now: cleanup main.yml
- .pre-commit-config.yaml: Add darker, pylint and pytest hooks for python3/
- pytype_reporter: cleanup config to test files migrated to python3