### PR TITLE
GitHub Actions: Update actions/checkout to v4 to fix Node 16 warnings

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -15,7 +15,7 @@ jobs:
         test: ["", "-3"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: '1.249-lcm'
 
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: '1.249-lcm'
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Restore opam cache
         id: opam-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "~/.opam"
           # invalidate cache every week, gets built using a scheduled job

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull configuration from xs-opam
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull configuration from xs-opam
         run: |

--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup XenAPI environment
         uses: ./.github/workflows/setup-xapi-environment

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,14 +21,14 @@ jobs:
         python-version: ["2.7", "3.11"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # To check which files changed: origin/master..HEAD
       - uses: LizardByte/setup-python-action@master
         with:
           python-version: ${{matrix.python-version}}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup cache for running pre-commit fast
         with:
           path: ~/.cache/pre-commit
@@ -128,7 +128,7 @@ jobs:
       XAPI_VERSION: "v0.0.0"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup XenAPI environment
         uses: ./.github/workflows/setup-xapi-environment
@@ -165,7 +165,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate empty configuration for make to be happy
         run: touch config.mk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Update all `uses: actions/checkout@v3` to `@v4` (From Node 16 to Node 20)

All GitHub actions using Node 16 now issue a warning that they are deprecated. GitHub says:

> Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024.

Obviously, it will take much longer than the "Spring 2024", but we can fix the warnings by updating.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/