### PR TITLE
Github Actions: Update up/download-artifact to v4 to fix Node 16 warnings

### DIFF
--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -25,13 +25,13 @@ jobs:
         run: opam exec -- make sdk
 
       - name: Store C# SDK source
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SDK_Source_CSharp
           path: _build/install/default/xapi/sdk/csharp/*
 
       - name: Store PowerShell SDK source
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SDK_Source_PowerShell
           path: _build/install/default/xapi/sdk/powershell/*
@@ -49,7 +49,7 @@ jobs:
         run: echo "XAPI_VERSION_NUMBER=$("${{ inputs.xapi_version }}".TrimStart('v'))" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Retrieve C# SDK source
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SDK_Source_CSharp
           path: source/
@@ -64,7 +64,7 @@ jobs:
           --verbosity=normal
 
       - name: Store C# SDK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SDK_Binaries_CSharp
           path: source/src/bin/Release/XenServer.NET.${{ env.XAPI_VERSION_NUMBER }}-prerelease-unsigned.nupkg
@@ -81,13 +81,13 @@ jobs:
         run: echo "XAPI_VERSION_NUMBER=$("${{ inputs.xapi_version }}".TrimStart('v'))" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Retrieve PowerShell SDK source
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SDK_Source_PowerShell
           path: source/
 
       - name: Retrieve C# SDK binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SDK_Binaries_CSharp
           path: csharp/
@@ -135,7 +135,7 @@ jobs:
           ForEach-Object -Process { Copy-Item -Verbose $_.FullName -Destination "output" }
 
       - name: Store PowerShell SDK (.NET Framework 4.5)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SDK_Binaries_XenServerPowerShell_NET45
           path: output/**/*
@@ -155,13 +155,13 @@ jobs:
         run: echo "XAPI_VERSION_NUMBER=$("${{ inputs.xapi_version }}".TrimStart('v'))" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Retrieve PowerShell SDK source
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SDK_Source_PowerShell
           path: source/
 
       - name: Retrieve C# SDK binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SDK_Binaries_CSharp
           path: csharp/
@@ -205,7 +205,7 @@ jobs:
           ForEach-Object -Process { Copy-Item -Verbose $_.FullName -Destination "output" }
 
       - name: Store PowerShell SDK (.NET ${{ matrix.dotnet }})
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SDK_Binaries_XenServerPowerShell_NET${{ matrix.dotnet }}
           path: output/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           make python
 
       - name: Store python distribution artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: XenAPI
           path: scripts/examples/python/dist/
@@ -47,25 +47,25 @@ jobs:
     needs: [build-python, build-sdks]
     steps:
       - name: Retrieve Python SDK distribution artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: XenAPI
           path: dist/
 
       - name: Retrieve C# SDK distribution artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SDK_Binaries_CSharp
           path: dist/
 
       - name: Retrieve PowerShell 5.x SDK distribution artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SDK_Binaries_XenServerPowerShell_NET45
           path: sdk_powershell_5x/
 
       - name: Retrieve PowerShell 7.x SDK distribution artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SDK_Binaries_XenServerPowerShell_NET6
           path: sdk_powershell_7x/
@@ -96,7 +96,7 @@ jobs:
       id-token: write
     steps:
       - name: Retrieve python distribution artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: XenAPI
           path: dist/


### PR DESCRIPTION
This pull request updates the upload- and download-artifact actions dependency to version 4 in order to fix Node 16 warnings.

----
All GitHub actions using Node 16 issue a warning that they are deprecated. GitHub says:
                                                                                                                                                                           > Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our
plan is to transition all actions to run on Node 20 by Spring 2024.
                                                                                                                                                                           Obviously, it will take much longer than the "Spring 2024", but we can fix the warnings by updating.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 