### PR TITLE
GitHub Actions: Node 16 warning fixes: update setup-dotnet to v4

### DIFF
--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -95,7 +95,7 @@ jobs:
       # Following needed for restoring packages
       # when calling dotnet add package
       - name: Set up dotnet CLI (.NET 6.0 and 8.0)
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             6
@@ -167,7 +167,7 @@ jobs:
           path: csharp/
 
       - name: Set up dotnet CLI (.NET ${{ matrix.dotnet }})
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet }}
 


### PR DESCRIPTION
This pull request updates the setup-dotnet actoin dependency from v3 (Node 16) to version v4 (Node 20) to fix Node 16 warnings.

----
All GitHub actions using Node 16 now issue a warning that they are deprecated. GitHub says:
> Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024.

Obviously, it will take much longer than "Spring 2024", but we can fix the warnings by updating.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 