### PR TITLE
CP-47622: Add CLI interface 'xe host-updates-show-available'

### DIFF
--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1047,6 +1047,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Neverforward]
       }
     )
+  ; ( "host-updates-show-available"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Show the available updates for the host"
+      ; implementation= With_fd Cli_operations.host_updates_show_available
+      ; flags= [Host_selectors]
+      }
+    )
   ; ( "patch-upload"
     , {
         reqd= ["file-name"]


### PR DESCRIPTION
XAPI reports the available updates for a host through the HTTP endpoint
"/updates". This requires a HTTP client/lib in client side.

This commit adds a new xe CLI interface "xe host-updates-show-available"
to report the available updates for a host for convenience.