### PR TITLE
Enable to (un)hide a PCI device through the API

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -6519,12 +6519,39 @@ end
 (** PCI devices *)
 
 module PCI = struct
+  let disable_dom0_access =
+    call ~name:"disable_dom0_access" ~lifecycle:[]
+      ~doc:
+        "Hide a PCI device from the dom0 kernel. (Takes affect after next \
+         boot.)"
+      ~params:[(Ref _pci, "self", "The PCI to hide")]
+      ~allowed_roles:_R_POOL_OP ()
+
+  let enable_dom0_access =
+    call ~name:"enable_dom0_access" ~lifecycle:[]
+      ~doc:
+        "Unhide a PCI device from the dom0 kernel. (Takes affect after next \
+         boot.)"
+      ~params:[(Ref _pci, "self", "The PCI to unhide")]
+      ~allowed_roles:_R_POOL_OP ()
+
+  let is_dom0_access_enabled =
+    call ~name:"is_dom0_access_enabled" ~lifecycle:[]
+      ~doc:
+        "Returns whether the PCI device is accessible from the dom0 kernel on \
+         boot."
+      ~params:[(Ref _pci, "self", "The PCI")]
+      ~result:(Bool, "Whether the PCI is accessible from the dom0 kernel")
+      ~allowed_roles:_R_POOL_OP ()
+
   let t =
     create_obj ~name:_pci ~descr:"A PCI device" ~doccomments:[]
       ~gen_constructor_destructor:false ~gen_events:true ~in_db:true
       ~lifecycle:[(Published, rel_boston, "")]
-      ~messages:[] ~messages_default_allowed_roles:_R_POOL_OP
-      ~persist:PersistEverything ~in_oss_since:None ~db_logging:Log_destroy
+      ~messages:
+        [disable_dom0_access; enable_dom0_access; is_dom0_access_enabled]
+      ~messages_default_allowed_roles:_R_POOL_OP ~persist:PersistEverything
+      ~in_oss_since:None ~db_logging:Log_destroy
       ~contents:
         [
           uid _pci ~lifecycle:[(Published, rel_boston, "")]

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3680,6 +3680,35 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pci-enable-dom0-access"
+    , {
+        reqd= ["uuid"]
+      ; optn= []
+      ; help= "Enable PCI access to dom0."
+      ; implementation= No_fd Cli_operations.pci_enable_dom0_access
+      ; flags= []
+      }
+    )
+  ; ( "pci-disable-dom0-access"
+    , {
+        reqd= ["uuid"]
+      ; optn= []
+      ; help= "Disable PCI access to dom0."
+      ; implementation= No_fd Cli_operations.pci_disable_dom0_access
+      ; flags= []
+      }
+    )
+  ; ( "pci-is-dom0-access-enabled"
+    , {
+        reqd= ["uuid"]
+      ; optn= []
+      ; help=
+          "Returns whether the PCI device is accessible from the dom0 kernel \
+           on boot."
+      ; implementation= No_fd Cli_operations.is_dom0_access_enabled
+      ; flags= []
+      }
+    )
   ]
 
 let cmdtable : (string, cmd_spec) Hashtbl.t = Hashtbl.create 50

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1329,6 +1329,11 @@ let gen_cmds rpc session_id =
           ]
           rpc session_id
       )
+    ; Client.PCI.(
+        mk get_all_records_where get_by_uuid pci_record "pci" []
+          ["uuid"; "vendor-name"; "device-name"; "pci-id"]
+          rpc session_id
+      )
     ]
 
 let message_create (_ : printer) rpc session_id params =
@@ -7471,6 +7476,26 @@ let lvhd_enable_thin_provisioning _printer rpc session_id params =
        )
        params
        ["sr-uuid"; "initial-allocation"; "allocation-quantum"]
+    )
+
+let pci_enable_dom0_access _printer rpc session_id params =
+  let uuid = List.assoc "uuid" params in
+  let ref = Client.PCI.get_by_uuid ~rpc ~session_id ~uuid in
+  Client.PCI.enable_dom0_access ~rpc ~session_id ~self:ref
+
+let pci_disable_dom0_access _printer rpc session_id params =
+  let uuid = List.assoc "uuid" params in
+  let ref = Client.PCI.get_by_uuid ~rpc ~session_id ~uuid in
+  Client.PCI.disable_dom0_access ~rpc ~session_id ~self:ref
+
+let is_dom0_access_enabled printer rpc session_id params =
+  let uuid = List.assoc "uuid" params in
+  let ref = Client.PCI.get_by_uuid ~rpc ~session_id ~uuid in
+  printer
+    (Cli_printer.PMsg
+       (Bool.to_string
+          (Client.PCI.is_dom0_access_enabled ~rpc ~session_id ~self:ref)
+       )
     )
 
 module PVS_site = struct

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -5867,7 +5867,31 @@ functor
 
     module Secret = Local.Secret
 
-    module PCI = struct end
+    module PCI = struct
+      let disable_dom0_access ~__context ~self =
+        info "PCI.disable_dom0_access: pci = '%s'" (pci_uuid ~__context self) ;
+        let host = Db.PCI.get_host ~__context ~self in
+        let local_fn = Local.PCI.disable_dom0_access ~self in
+        do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
+            Client.PCI.disable_dom0_access ~rpc ~session_id ~self
+        )
+
+      let enable_dom0_access ~__context ~self =
+        info "PCI.enable_dom0_access: pci = '%s'" (pci_uuid ~__context self) ;
+        let host = Db.PCI.get_host ~__context ~self in
+        let local_fn = Local.PCI.enable_dom0_access ~self in
+        do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
+            Client.PCI.enable_dom0_access ~rpc ~session_id ~self
+        )
+
+      let is_dom0_access_enabled ~__context ~self =
+        info "PCI.is_dom0_access_enabled: pci = '%s'" (pci_uuid ~__context self) ;
+        let host = Db.PCI.get_host ~__context ~self in
+        let local_fn = Local.PCI.is_dom0_access_enabled ~self in
+        do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
+            Client.PCI.is_dom0_access_enabled ~rpc ~session_id ~self
+        )
+    end
 
     module VTPM = struct
       let create ~__context ~vM ~is_unique =

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -319,3 +319,10 @@ let get_system_display_device () =
       )
       None items
   with _ -> None
+
+let disable_dom0_access ~__context ~self = Pciops.hide_pci ~__context self
+
+let enable_dom0_access ~__context ~self = Pciops.unhide_pci ~__context self
+
+let is_dom0_access_enabled ~__context ~self =
+  not (Pciops.is_pci_hidden ~__context self)

--- a/ocaml/xapi/xapi_pci.ml
+++ b/ocaml/xapi/xapi_pci.ml
@@ -320,38 +320,13 @@ let get_system_display_device () =
       None items
   with _ -> None
 
-let update_dom0_access ~__context ~self ~action =
-  let expr = Printf.sprintf "field \"PCI\"=\"%s\"" (Ref.string_of self) in
-  let pgpus = Db.PGPU.get_all_records_where ~__context ~expr in
-  List.iter (
-    fun (pgpu_ref, _) -> (
-      let db_current = Db.PGPU.get_dom0_access ~__context ~self in
-      let db_new =
-        match (db_current, action) with
-        | `enabled, `enable | `disable_on_reboot, `enable ->
-            `enabled
-        | `disabled, `enable | `enable_on_reboot, `enable ->
-            `enable_on_reboot
-        | `enabled, `disable | `disable_on_reboot, `disable ->
-            `disable_on_reboot
-        | `disabled, `disable | `enable_on_reboot, `disable ->
-            `disabled
-      in
-      Db.PGPU.set_dom0_access ~__context ~self:pgpu_ref ~value:db_new
-    )
-  ) pgpus ;
-  ( match action with
-  | `enable ->
-      Pciops.unhide_pci ~__context self
-  | `disable ->
-      Pciops.hide_pci ~__context self
-  )
-
 let disable_dom0_access ~__context ~self =
-  update_dom0_access ~__context ~self ~action:`disable
+  ignore
+  @@ Xapi_pci_helpers.update_dom0_access ~__context ~pci:self ~action:`disable
 
 let enable_dom0_access ~__context ~self =
-  update_dom0_access ~__context ~self ~action:`enable
+  ignore
+  @@ Xapi_pci_helpers.update_dom0_access ~__context ~pci:self ~action:`enable
 
 let is_dom0_access_enabled ~__context ~self =
   not (Pciops.is_pci_hidden ~__context self)

--- a/ocaml/xapi/xapi_pci.mli
+++ b/ocaml/xapi/xapi_pci.mli
@@ -51,3 +51,12 @@ val disable_system_display_device : unit -> unit
 
 val dequarantine : __context:Context.t -> Xenops_interface.Pci.address -> unit
 (** dequarantine a PCI device. This is idempotent. *)
+
+val disable_dom0_access : __context:Context.t -> self:API.ref_PCI -> unit
+(** Hide a PCI device from the dom0 kernel. (Takes affect after next boot.) *)
+
+val enable_dom0_access : __context:Context.t -> self:API.ref_PCI -> unit
+(** Unhide a PCI device from the dom0 kernel. (Takes affect after next boot.) *)
+
+val is_dom0_access_enabled : __context:Context.t -> self:API.ref_PCI -> bool
+(** Check whether a PCI device will be hidden from the dom0 kernel on boot. *)

--- a/ocaml/xapi/xapi_pci_helpers.ml
+++ b/ocaml/xapi/xapi_pci_helpers.ml
@@ -185,7 +185,7 @@ let update_dom0_access ~__context ~pci ~action =
           `disabled
       )
   in
-  let expr = Printf.sprintf "field \"PCI\"=\"%s\"" (Ref.string_of pci) in
+  let expr = Printf.sprintf {|field "PCI"="%s"|} (Ref.string_of pci) in
   let pgpus = Db.PGPU.get_all_records_where ~__context ~expr in
   List.iter
     (fun (pgpu_ref, _) ->

--- a/ocaml/xapi/xapi_pgpu.ml
+++ b/ocaml/xapi/xapi_pgpu.ml
@@ -357,27 +357,8 @@ let assert_can_run_VGPU ~__context ~self ~vgpu =
     ~vgpu_type
 
 let update_dom0_access ~__context ~self ~action =
-  let db_current = Db.PGPU.get_dom0_access ~__context ~self in
-  let db_new =
-    match (db_current, action) with
-    | `enabled, `enable | `disable_on_reboot, `enable ->
-        `enabled
-    | `disabled, `enable | `enable_on_reboot, `enable ->
-        `enable_on_reboot
-    | `enabled, `disable | `disable_on_reboot, `disable ->
-        `disable_on_reboot
-    | `disabled, `disable | `enable_on_reboot, `disable ->
-        `disabled
-  in
   let pci = Db.PGPU.get_PCI ~__context ~self in
-  ( match db_new with
-  | `enabled | `enable_on_reboot ->
-      Pciops.unhide_pci ~__context pci
-  | `disabled | `disable_on_reboot ->
-      Pciops.hide_pci ~__context pci
-  ) ;
-  Db.PGPU.set_dom0_access ~__context ~self ~value:db_new ;
-  db_new
+  Xapi_pci_helpers.update_dom0_access ~__context ~pci ~action
 
 let enable_dom0_access ~__context ~self =
   update_dom0_access ~__context ~self ~action:`enable


### PR DESCRIPTION
New API:
- `PCI.disable_dom0_access`: hide a PCI device from the dom0 kernel
- `PCI.enable_dom0_access`: unhide a PCI device from the dom0 kernel
- `PCI.is_dom0_access_enabled`: return whether a PCI device is hidden

This is already possible for PGPUs with the `{enable/disable}_dom0_access` calls this extends it to all PCI devices.