### PR TITLE
Some ideas for updating CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,86 +37,44 @@ jobs:
       - run: echo "::add-matcher::.github/workflows/python-warning-matcher.json"
         name: "Setup GitHub for reporting Python warnings as annotations in pull request code review"
 
+      - name: Install dependencies for the static analysis
+        if: ${{ matrix.python-version != '2.7' }}
+        run: >
+          pip install opentelemetry-api opentelemetry-exporter-zipkin-json
+          opentelemetry-sdk pytest types-mock mock wrapt pandas
+
       - uses: pre-commit/action@v3.0.0
-        name: Run pre-commit checks (no spaces at end of lines, etc)
+        name: Run pre-commit hooks with pylint and pytest
         if: ${{ matrix.python-version != '2.7' }}
         with:
-          extra_args: --all-files --verbose --hook-stage commit
-        env:
-          SKIP: no-commit-to-branch
-
-      - name: Install dependencies only needed for python 2
-        if: ${{ matrix.python-version == '2.7' }}
-        run: pip install enum
-
-      - name: Install dependencies only needed for python 3
-        if: ${{ matrix.python-version != '2.7' }}
-        run: pip install pandas pytype toml wrapt
-
-      - name: Install common dependencies for Python ${{matrix.python-version}}
-        run: pip install future mock pytest-coverage pytest-mock
+          # The --hook-stage manual only runs the stages that add the manual keyword in
+          # .pre-commit-config.yaml. Currently that's simple white space checks and pytest:
+          extra_args: --all-files --verbose --hook-stage manual
 
       - name: Run Pytest for python 2 and get code coverage for Codecov
         if: ${{ matrix.python-version == '2.7' }}
         run: >
-          pytest
+          pip install enum future mock pytest-coverage pytest-mock &&
+          pytest --cov-fail-under=10
           --cov=scripts --cov=ocaml/xcp-rrdd
-          scripts/ ocaml/xcp-rrdd -vv -rA
-          --junitxml=.git/pytest${{matrix.python-version}}.xml
-          --cov-report term-missing
-          --cov-report xml:.git/coverage${{matrix.python-version}}.xml
-        env:
-          PYTHONDEVMODE: yes
-
-      - name: Run Pytest for python 3 and get code coverage for Codecov
-        if: ${{ matrix.python-version != '2.7' }}
-        run: >
-          pytest
-          --cov=scripts --cov=ocaml/xcp-rrdd --cov=python3/
-          scripts/ ocaml/xcp-rrdd python3/ -vv -rA
-          --junitxml=.git/pytest${{matrix.python-version}}.xml
-          --cov-report term-missing
-          --cov-report xml:.git/coverage${{matrix.python-version}}.xml
+          scripts/ ocaml/xcp-rrdd -vv -ra
+          --cov-report xml:.git/coverage.xml
         env:
           PYTHONDEVMODE: yes
 
       - name: Upload Python ${{matrix.python-version}} coverage report to Codecov
         uses: codecov/codecov-action@v3
+        # Upload the .git/coverage.xml file created by --cov-report xml:.git/coverage.xml
+        # created by pytest --cov-report xml:.git/coverage.xml above and the pytest config
+        # in xen-api.git/pyproject.toml and .pre-commit-config.yaml in the pre-commit hook.
         with:
           directory: .git
-          files: coverage${{matrix.python-version}}.xml
+          files: coverage.xml
           env_vars: OS,PYTHON
           fail_ci_if_error: false
           flags: python${{matrix.python-version}}
           name: coverage${{matrix.python-version}}
           verbose: true
-
-      - uses: dciborow/action-pylint@0.1.0
-        if: ${{ matrix.python-version != '2.7' }}
-        with:
-          reporter: github-pr-review
-          level: warning
-          # To be customized to cover remaining Python scripts:
-          glob_pattern: "**/*.py"
-
-      - name: Run pytype checks
-        if: ${{ matrix.python-version != '2.7' }}
-        run: ./pytype_reporter.py
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PYTYPE_REPORTER_DEBUG: True
-
-      # Try to add pytype_report.py's summary file as a comment to the PR:
-      # Documentation: https://github.com/marketplace/actions/add-pr-comment
-      - name: Add the pytype summary as a comment to the PR (if permitted)
-        uses: mshick/add-pr-comment@v2
-        # Depends on pytype checks, which are not run for python 2.7:
-        if: ${{ matrix.python-version != '2.7' }}
-        # Fails for user workflows without permissions(fork-based pull requests):
-        continue-on-error: true
-        with:
-          message-path: .git/pytype-summary.md # Add the content of it as comment
 
   ocaml-tests:
     name: Run OCaml tests

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -16,7 +16,7 @@ jobs:
 
     permissions:
       security-events: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,28 @@
 #
-# Configuration of pre-commit, a Python framework for git hooks.
-# pre-commit is run for each git push by GitHub CI. It can run
-# locally as well for early feedback and automatic formatting
-# like trailing whitespace removal (to be configured later):
+# This is the configuration file of the pre-commit framework for this repository:
+# https://pypi.org/project/pre-commit / https://pre-commit.com
 #
-## For only installing the package itself, run:
-# pip3 install pre-commit
+# It is a Python framework for managing and multi-language pre-commit hooks.
+# pre-commit runs in the GitHub Workflow of this project, and
+# it can be run locally as well for early feedback and e.g. formatting checks.
 #
-## For activating it as a pre-commit and pre-push hook (recommended):
-# pre-commit install --hook-type pre-push --hook-type pre-commit
+# For only installing the package itself, run:
+# $ pip3 install pre-commit
 #
-## For manually executing the pre-push hook:
-# pre-commit run -av --hook-stage pre-push
+# On the initial run, pre-commit downloads its checkers, subsequent runs are fast:
 #
-default_stages: [commit, push]
+# $ pre-commit run    # automatically checks which checks are needed.
+# $ pre-commit run -a # runs all fixes and checks, even when not needed#
+#
+# When this works, you can enable it as the pre-commit hook for this git clone:
+# $ pre-commit install
+# $ pre-commit install --hook-type pre-push
+#
+# You can skip checks if you commit very often you don't want them to run, e.g:
+# export SKIP=pytest;git commit -m "quick save" (or for --amend)
+#
+# Hooks that do do not specify the `stages:` field, get these default stages assigned:
+default_stages: [commit, push, manual]
 repos:
 # Recommendation for a minimal git pre-commit hook:
 # https://github.com/pre-commit/pre-commit-hooks/blob/main/README.md:
@@ -29,28 +38,109 @@ repos:
     -   id: check-executables-have-shebangs
         exclude: ocaml
 
-# Recommendation for a minimal git pre-push hook:
-# While using pre-commit yields great results, it
-# is "not fast". Therefore only run it pre-push,
-# (but always in GitHub CI of course):
 #
-# Calls ./pytype_reporter.py in a dedicated venv:
-# pre-commit run -av --hook-stage push
+# Run pytest and diff-cover to check that the new /python3 test suite passes.
+# This hook uses a local venv containing the required dependencies. When adding
+# new dependencies, they should be added to the additional_dependencies below.
+#
+-   repo: local
+    hooks:
+    -   id: pytest
+        files: python3/
+        name: check that the Python3 test suite in passes
+        entry: env PYTHONDEVMODE=yes sh -c 'pytest --cov
+            --cov-report=term-missing --cov-report=xml --cov-report=html &&
+            diff-cover --ignore-whitespace --compare-branch=origin/master
+            --show-uncovered --html-report .git/coverage-diff.html
+            --fail-under 60 .git/coverage.xml'
+        require_serial: true  # Only one at a time, don't parallelize.
+        pass_filenames: false
+        language: python
+        types: [python]
+        additional_dependencies:
+        - coverage
+        - diff-cover
+        - future
+        - opentelemetry-api
+        - opentelemetry-exporter-zipkin-json
+        - opentelemetry-sdk
+        - pytest-coverage
+        - pytest-mock
+        - mock
+        - wrapt
+
+
+    -   id: mypy-reviewdog
+        name: run mypy with reviewdog to check for type errors
+        additional_dependencies:
+        - mypy
+        - opentelemetry-api
+        - opentelemetry-exporter-zipkin-json
+        - opentelemetry-sdk
+        - pytest
+        - types-mock
+        - wrapt
+        language: python
+        files: python3/
+        entry: sh -c 'python3/tests/reviewdog.sh mypy || echo mypy diff review failed!'
+        verbose: true
+        require_serial: true  # Only one at a time, don't parallelize.
+
+
+-   repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.353
+    hooks:
+    -   id: pyright
+        name: check that python3 tree passes pyright/VSCode check
+        files: python3/
+        additional_dependencies:
+        - opentelemetry-api
+        - opentelemetry-exporter-zipkin-json
+        - opentelemetry-sdk
+        - pytest
+        - mock
+
+
+# Check that pylint passes for the changes in new /python3 code.
+-   repo: local
+    hooks:
+    -   id: pylint
+        files: python3/
+        name: check that changes to python3 tree pass pylint
+        entry: env PYTHONPATH=scripts/examples/python
+            diff-quality --violations=pylint
+            --ignore-whitespace --compare-branch=origin/master
+        pass_filenames: false
+        types: [python]
+        language: python
+        additional_dependencies: [diff-cover, pylint, pytest]
+
+
+# pre-push hook (it only runs if you install pre-commit as a pre-push hook):
 -   repo: local
     hooks:
     -   id: pytype
-        name: pytype
-        entry: python3 pytype_reporter.py
-        pass_filenames: false
+        # It can be manually tested using: `pre-commit run -av --hook-stage push`
+        name: pytype with reviewdog filter for local and GitHub PR review
+        files: python3/
+        entry: python3/tests/reviewdog.sh pytype
+        stages: [push,manual]
+        pass_filenames: true
         types: [python]
-        stages: [push]
         verbose: true
         # This hook runs locally only when Python files change:
         language: python
+        require_serial: true  # Only one at a time, don't parallelize.
         # Pytype supports running on Python 3.8 to Python3.11 currently:
         # https://google.github.io/pytype/support.html
         # If a dev's default python3 interpreter is outside that range, but
         # developers have such version installed, it can be configured here:
         # language_version: python3.11
-        require_serial: true
-        additional_dependencies: [pandas, pytype]
+        additional_dependencies:
+        - future
+        - opentelemetry-api
+        - opentelemetry-exporter-zipkin-json
+        - opentelemetry-sdk
+        - pandas
+        - pytest
+        - pytype

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,65 +232,16 @@ discard_messages_matching = [
     "No attribute 'group' on None",
     "No Node.TEXT_NODE in module xml.dom.minidom, referenced from 'xml.dom.expatbuilder'"
 ]
-expected_to_fail = [
-    "scripts/hfx_filename",
-    "scripts/perfmon",
-    # Need 2to3 -w <file> and maybe a few other minor updates:
-    "scripts/hatests",
-    "scripts/backup-sr-metadata.py",
-    "scripts/restore-sr-metadata.py",
-    "scripts/nbd_client_manager.py",
-    # No attribute 'popen2' on module 'os' [module-attr] and a couple more:
-    "scripts/mail-alarm",
-    # SSLSocket.send() only accepts bytes, not unicode string as argument:
-    "scripts/examples/python/exportimport.py",
-    # Other fixes needed:
-    "scripts/examples/python/mini-xenrt.py",
-    "scripts/examples/python/XenAPI/XenAPI.py",
-    "scripts/examples/python/monitor-unwanted-domains.py",
-    "scripts/examples/python/shell.py",
-    "scripts/examples/smapiv2.py",
-    "scripts/static-vdis",
-    # add_interface: unsupported operand type(s) for +: str and UsbInterface
-    "scripts/usb_scan.py",
-    # TestUsbScan.assertIn() is called with wrong arguments(code not iterable)
-    "scripts/test_usb_scan.py",
-    "scripts/plugins/extauth-hook-AD.py",
-]
+expected_to_fail = []
 
 
 [tool.pytype]
 inputs = [
-    "scripts/hfx_filename",
-    "scripts/perfmon",
-    "scripts/static-vdis",
-    "scripts/Makefile",
-    "scripts/generate-iscsi-iqn",
-    "scripts/hatests",
-    "scripts/host-display",
-    "scripts/mail-alarm",
-    "scripts/print-custom-templates",
-    "scripts/probe-device-for-file",
-    "scripts/xe-reset-networking",
-    "scripts/xe-scsi-dev-map",
-    "scripts/examples/python",
-    "scripts/yum-plugins",
-    "scripts/*.py",
-    "python3/packages/*.py",
-
-    # To be added later,
-    # when converted to Python3-compatible syntax:
-    # "ocaml/message-switch/python",
-    # "ocaml/idl/ocaml_backend/python",
-    # "ocaml/xapi-storage/python",
+    "python3/",
+    "ocaml/xcp-rrdd",
 ]
 disable = [
-    "import-error",  # xenfsimage, xcp.bootloader. xcp.cmd
-    "ignored-abstractmethod",
-    "ignored-metaclass",
-    # https://github.com/google/pytype/issues/1130,
-    # https://github.com/google/pytype/issues/1485:
-    "pyi-error",
 ]
 platform = "linux"
-pythonpath = "scripts/examples/python:.:scripts:scripts/plugins:scripts/examples"
+# Allow pytype to find the XenAPI module, the rrdd module and python3 modules:
+pythonpath = "python3:scripts/examples/python:ocaml/xcp-rrdd/scripts/rrdd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # https://packaging.python.org/en/latest/specifications/pyproject-toml/
 [project]
 name = "xen-api"
-requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+requires-python = ">=3.6.*"
 license = {file = "LICENSE"}
 keywords = ["xen-project", "Xen", "hypervisor", "libraries"]
 maintainers = [
@@ -27,13 +27,73 @@ repository = "https://github.com/xapi-project/xen-api"
 [tool.black]
 line-length = 88
 
+
+# -----------------------------------------------------------------------------
+# Coverage.py - https://coverage.readthedocs.io/en/coverage-5.5/config.html
+# -----------------------------------------------------------------------------
+
+[tool.coverage.report]
+# Here, developers can configure which lines do not need to be covered by tests:
+exclude_lines = [
+    "pragma: no cover",  # standard pragma for not covering a line or block
+    "if TYPE_CHECKING:", # imports for type checking only
+    "pass",
+    # Other specific lines that do not need to be covered, comment in which file:
+]
+# Here, developers can configure the minimum coverage required for the checks to pass:
+fail_under = 60
+# precision digits to use when reporting coverage (sub-percent-digits are not reported):
+precision = 0
+# skip_covered: Skip reporting files with 100% coverage:
+skip_covered = true
+
+
+[tool.coverage.run]
+# Default command line for "coverage run": Run pytest in non-verbose mode
+command_line = "-m pytest -p no:logging -p no:warnings"
+# Default data file for "coverage run": Store coverage data in .git/.coverage
+data_file = ".git/.coverage"
+# Default context for "coverage run": Use the name of the test function
+dynamic_context = "test_function"
+# Default omit patterns for "coverage run": Omit test files and test directories
+omit = [
+    "python3/bin/__init__.py",
+    "python3/packages/__init__.py",
+    # omit tests anything in a test directory (focus on the code)
+    "python3/tests",
+    "scripts/test_*.py",
+    # omit anything in a .local directory anywhere
+    "*/.local/*",
+    # omit everything in /usr
+    "/usr/*",
+]
+relative_files = true
+
+
+# Default output when writing "coveragle xml" data. This needs to match what
+# diff-cover and coverage upload to Codecov expect
+[tool.coverage.xml]
+output = ".git/coverage.xml"
+
+
+# Default output directory for writing "coverage html" data.
+# Create it outside the source tree to avoid cluttering the source tree
+[tool.coverage.html]
+directory = ".git/coverage_html"
+show_contexts = true
+
+
 [tool.isort]
 line_length = 88
-py_version = 27
+py_version = 36
 profile = "black"
 combine_as_imports = true
 ensure_newline_before_comments = false
 
+
+# -----------------------------------------------------------------------------
+# Mypy static analysis - https://mypy.readthedocs.io/en/stable/config_file.html
+# -----------------------------------------------------------------------------
 
 [tool.mypy]
 # Note mypy has no config setting for PYTHONPATH, so you need to call it with:
@@ -59,6 +119,109 @@ disallow_any_explicit = false
 disallow_any_generics = true
 disallow_any_unimported = true
 disallow_subclassing_any = true
+disable_error_code = ["import-untyped"]  # XenAPI is not typed yet
+
+
+[[tool.mypy.overrides]]
+module = ["packages.observer"]
+disable_error_code = [
+    "arg-type",  # mypy does not know that the Context class is actually a dict
+    "override",  # Typing problem in the used library
+    "misc",
+    "no-any-unimported",
+]
+
+
+# -----------------------------------------------------------------------------
+# Pylint - https://pylint.pycqa.org/en/latest/technical_reference/features.html
+# -----------------------------------------------------------------------------
+
+[tool.pylint.design]
+max-branches = 43                  # perfmon has 43 branches in a function
+
+
+[tool.pylint.messages_control]
+# These are safe to disable, fixing them is best done during a later code cleanup phases
+disable = [
+    "broad-exception-caught",
+    "no-else-break",
+    "no-else-return",
+    "consider-using-f-string",     # f-strings is the big new feature of Python 3.6,
+    "consider-using-with",         # but like with, best done during code cleanup phase
+    "duplicate-code",              # likewise. This is a code cleanup task
+    "import-error",                # pylint does not do inter-procedural analysis
+    "invalid-name",                # doesn't conform to snake_case naming style
+    "missing-function-docstring",  # Likewise, best done in the code documentation phase
+    "missing-module-docstring",    # Likewise, best done in the code documentation phase
+    "no-else-break",               # else clause following a break statement
+    "protected-access",            # Best done during the code cleanup phase
+    "super-with-arguments",        # Consider using Python 3 style super(no args) calls
+    "unnecessary-pass",            # Cosmetic, best done during the code cleanup phase
+    "useless-object-inheritance",  # Useless object inheritance from object, likewise
+]
+
+
+# -----------------------------------------------------------------------------
+# Pyright is the static analysis behind the VSCode Python extension / Pylance
+# https://microsoft.github.io/pyright/#/configuration?id=main-configuration-options
+# -----------------------------------------------------------------------------
+
+[tool.pyright]
+# Specifies the paths of directories or files that should be included in the
+# analysis. If no paths are specified, all files in the workspace are included:
+include = ["python3", "ocaml/xcp-rrdd"]
+
+# Conditionalize the stube files for type definitions based on the platform:
+pythonPlatform = "Linux"
+
+# typeCheckingMode: "off", "basic", "standard" or "strict"
+typeCheckingMode = "standard"
+
+# Specifies the version of Python that will be used to execute the source code.
+# Generate errors if the source code makes use of language features that are
+# not supported in that version. It will also tailor its use of type stub files,
+# which conditionalizes type definitions based on the version. If no version is
+# specified, pyright will use the version of the current python interpreter,
+# if one is present:
+pythonVersion = "3.6"
+
+# Paths of directories or files that should use "strict" analysis if they are
+# included. This is the same as manually adding a "# pyright: strict" comment.
+# In strict mode, most type-checking rules are enabled, and the type-checker
+# will be more aggressive in inferring types. If no paths are specified, strict
+# mode is not enabled:
+strict = ["python3/tests/observer"]
+
+#
+# Paths to exclude from analysis. If a file is excluded, it will not be
+# analyzed.
+#
+# FIXME: Some of these may have type errors, so they should be inspected and fixed:
+#
+exclude = [
+    "ocaml/xcp-rrdd/scripts/rrdd/rrdd.py",
+    "ocaml/xcp-rrdd/scripts/rrdd/rrdd-example.py",
+    "python3/packages/observer.py",
+    "python3/tests/pytype_reporter.py",
+]
+
+
+# -----------------------------------------------------------------------------
+# Pytest is the test framework, for discovering and running tests, fixtures etc
+# https://pytest.readthedocs.io/en/latest/customize.html
+# -----------------------------------------------------------------------------
+
+
+[tool.pytest.ini_options]
+addopts = "-ra" # Show the output of all tests, including those that passed
+log_cli = true  # Capture log messages and show them in the output as well
+log_cli_level = "INFO"
+python_files = ["test_*.py", "it_*.py"]
+python_functions = ["test_", "it_", "when_"]
+pythonpath = "scripts/examples/python"  # Allows to import the XenAPI module
+required_plugins = ["pytest-mock"]
+testpaths = ["python3", "scripts", "ocaml/xcp-rrdd"]
+xfail_strict = true  # is used to fail tests that are marked as xfail but pass(for TDD)
 
 
 [tool.pytype_reporter]

--- a/python3/tests/reviewdog.sh
+++ b/python3/tests/reviewdog.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# -------------------------------------------------------------------------------------
+# Script to run mypy with reporting thru reviewdog, called from .pre-commit-config.yaml
+# -------------------------------------------------------------------------------------
+# Variables:
+# REVIEWDOG_REPORTER can be set to github-pr-check or github-pr-review for GitHub CI
+# GITHUB_BASE_REF is the base branch for the pull request, defaults to origin/master
+# GITHUB_REF is the current branch, defaults to HEAD, for diffing against the base branch
+# https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+# -------------------------------------------------------------------------------------
+# Usage:
+# source reviewdog.sh  # Run a sample command to test reviewdog_mypy and reviewdog_pytype
+# ./reviewdog.sh mypy   # Run mypy with reviewdog <changed_files>
+# ./reviewdog.sh pytype # Run pytype with reviewdog <changed_files>
+# -------------------------------------------------------------------------------------
+# Example to test GitHub CI with reviewdog in a pull request (PR) check or review:
+# REVIEWDOG_REPORTER=github-pr-check ./reviewdog.sh mypy <changed_files>
+# REVIEWDOG_REPORTER=github-pr-review ./reviewdog.sh pytype <changed_files>
+# -------------------------------------------------------------------------------------
+# To run this script in GitHub CI, add the following to your .github/workflows/*.yml file:
+# jobs:
+#   reviewdog-mypy:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions/setup-python@v4
+#       - run: reviewdog.sh mypy <changed_files>
+# -------------------------------------------------------------------------------------
+
+github_debug() {
+    if [ -n "$GITHUB_JOB" ]; then
+        echo "::debug::$*"
+    fi
+}
+
+git_diff_cmd() {  # Run git diff with the right range
+    GIT_DIFF_RANGE="${GITHUB_BASE_REF:-origin/master}..${GITHUB_REF:-HEAD}"
+    git diff --ignore-space-change "$GIT_DIFF_RANGE" >.git/diff
+    EXIT_CODE=$?
+    # cat .git/diff  # Uncomment to debug the diff
+    return $EXIT_CODE
+}
+
+check_diff() {
+    git_diff_cmd
+    if [ $EXIT_CODE -ge 128 ]; then
+        rm .git/index
+        git reset
+        git_diff_cmd
+    fi
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "Error: git diff failed with exit code $EXIT_CODE"
+        exit $EXIT_CODE
+    fi
+}
+
+install_reviewdog() {  # Install reviewdog
+    if ! type -p reviewdog >/dev/null; then
+        echo "Reviewdog is not installed, trying to install it to $PWD/.git"
+        curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh |
+            sh -s -- -b "$PWD/.git"
+    fi
+}
+
+reviewdog_mypy() {  # Run mypy with reviewdog
+    install_reviewdog
+    mypy_version=$(mypy --version) || pip install mypy
+    check_diff
+    github_debug "$mypy_version"
+    mypy "$@" |
+        reviewdog -name=mypy -reporter="${REVIEWDOG_REPORTER:-local}" \
+            -efm "%E%f:%l: %t%*[^:]: %m" \
+            -efm "%E%f: %t%*[^:]: %m" \
+            -efm "%C%m" \
+            -diff="cat .git/diff" -filter-mode file -level=warning -fail-on-error
+}
+
+reviewdog_pytype() {  # Run pytype with reviewdog
+    install_reviewdog
+    pytype_version=$(pytype --version) || pip install pytype
+    check_diff
+    github_debug "$pytype_version"
+    # shellcheck disable=SC2068
+    pytype $@ |
+        reviewdog -name=pytype -reporter="${REVIEWDOG_REPORTER:-local}" \
+            -efm "%EFile %f, line %l, in %m" \
+            -efm "%C%m" \
+            -diff="cat .git/diff" -filter-mode nofilter -level=warning -fail-on-error
+    # Kept until the reviewdog github-pr-check reporter has successfully
+    # reported the pytype errors in the GitHub CI pull request code review:
+    # shellcheck disable=SC2068
+    python3/tests/pytype_reporter.py $@ || exit $?
+}
+
+PATH="$PWD/.git:$PATH"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    command="$1"
+    shift  # pre-commit may pass the changed files to check
+    if [ -n "$GITHUB_JOB" ]; then  # Running in GitHub CI, enable the GitHub reporter
+        export REVIEWDOG_REPORTER=github-pr-check
+    fi
+    python_scripts="$([ $# == 0 ] || file "$@" | grep "Python script" | cut -d: -f1)"
+    if [ "$command" == "mypy" ]; then
+        reviewdog_mypy   "$python_scripts" || exit $?
+    elif [ "$command" == "pytype" ]; then
+        reviewdog_pytype "$python_scripts" || exit $?
+    fi
+else
+    # When the script is sourced, run a sample command to test reviewdog_mypy:
+    REVIEWDOG_BASE_REF=57508663329e838f51167faf0a3a05f8eac352b8...5e6c780d \
+        reviewdog_mypy   scripts/examples/python/XenAPI || echo Exit code: $?
+    REVIEWDOG_BASE_REF=57508663329e838f51167faf0a3a05f8eac352b8...5e6c780d \
+        reviewdog_pytype scripts/examples/python/XenAPI || echo Exit code: $?
+fi

--- a/python3/tests/reviewdog.sh
+++ b/python3/tests/reviewdog.sh
@@ -34,7 +34,7 @@ github_debug() {
 }
 
 git_diff_cmd() {  # Run git diff with the right range
-    GIT_DIFF_RANGE="${GITHUB_BASE_REF:-origin/master}..${GITHUB_REF:-HEAD}"
+    GIT_DIFF_RANGE="${GITHUB_BASE_REF:-origin/master}..HEAD"
     git diff --ignore-space-change "$GIT_DIFF_RANGE" >.git/diff
     EXIT_CODE=$?
     # cat .git/diff  # Uncomment to debug the diff

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -196,4 +196,3 @@ endif
 	$(IDATA) mail-languages/ja-JP.json $(DESTDIR)/etc/xapi.d/mail-languages
 # uefi
 	mkdir -p $(DESTDIR)/etc/xapi.d/efi-clone
-


### PR DESCRIPTION
A new base for a new Python3 branch:

1. This aims to make CI less strict. It removes the checks for the annotations (40 currently) in the scripts tree:
   - `expected_to_fail` is obsoleted by the new python3 tree and the feature branch.
      - no more removing files from `expected_to_fail` (empty now).
   - Instead, Reviewdog can create review comments/annotations in the code review if there is something to review.
   - The annotations are a friendly way, much better than warnings than failing CI.

2. All checks can now be run locally before pushing
   - This helps to fix any issues without needing to pushing ad PR it GitHub, this includes:
     - Tests and code coverage
     - pytype
     - pylint
     - mypy
   
Implementation:
1. Add the implementation of running pytest and checking coverage from GitHub and CodeCov to the exisiting configuration and already used configuration of the pre-commit tool.
   - Updated the

2. The specific calls to pytest and pytype are no longer implemented in `.github/workflows/main.yml`, but called from it.
   - The specific Python environment with the needed dependencies is created by pre-commit and can be fully tested locally before pushing:
      Simply run `pip install pre-commit` and `pre-commit run pytest -av` then runs the exact same test that is run in CI, in the same environment on each host, each time.

3. Because of the migration from `scripts/*`, only `python3/**` needs to be checked:
   - This dramatically reduces the huge amount of noise that the pytype_reporter generates to `0`.
   - pytype_reporter completes now really fast compared to the current state, and when the Reviewdog PR review is proven to work, it can be fully removed/obsoleted!
   - A lot of settings and code can be removed:
     - `expected_to_fail` of `[tool.pytype_reporter]` in `pyproject.toml`, is empty, can be removed!
     - No conflicts from changing the list of expected_to_fail!

4. To avoid conflicts from installing the moved files from python3/Makefile, it uses wildcard rules, so it only needs occasional fixed but not be updated in each PR for each file (which would not work if well many PRs are opened in parallel, as the PRs would conflict on adding installing the moved files in `python3/Makefile`)

5. Finally, add darker (black, but only for changes, not the complete file) for a consistent format of the migrated files, without the need to mass-format of the whole source file. Mass-formatting should preferably be done after the Py3-migration is fully reviewed, and merged (reformatting using the safe default mode of black is safe in production)
   - Only formatting the changes helps reduce churn when reviewing the changes and during PR review.

There are only one or two (items) to remember or to :
1. Simply run `pip install pre-commit` to install pre-commit and
  - Run `pre-commit run pytest -av` to run quick tests (pytest, etc)
  - Run `pre-commit run pytest -av --hook-stage push` to run all (slower) tests (pylint, pytype)

2. For easier maintenance of the feature branch, switch to a branch that can be rebased onto new updates of the master branch when needed instead of merging with it.
   - Rebasing the feature branch on top of the latest instead of merging the master branch into the feature branch enables us to keep the Python3 commits together on top of the master commits, so they are easier to find and makes it easier to keep track of them.