### PR TITLE
Set `dependencyManagement` in Java SDK's `pom.xml`

### DIFF
--- a/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
+++ b/ocaml/sdk-gen/java/autogen/xen-api/pom.xml
@@ -51,6 +51,20 @@
         <revision>1.0.0-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.16.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>5.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This enables SDK consumers to see and resolve the full dependency list.

Spotted while updating Java SDK samples in [xenserver/xenserver-samples](github.com/xenserver/xenserver-samples)

With (ignore version number):
![image](https://github.com/xapi-project/xen-api/assets/32554698/2dbabeb3-2d1f-49c2-b37a-bab4479b5460)


Without (ignore version number):
![image](https://github.com/xapi-project/xen-api/assets/32554698/4e2f0801-c95a-4079-8672-dcbb6d434502)
