### PR TITLE
xenopsd: fix Xen version comparison. 4.17 is > 4.2, not lower!

### DIFF
--- a/ocaml/xenopsd/lib/xenops_utils.ml
+++ b/ocaml/xenopsd/lib/xenops_utils.ml
@@ -584,7 +584,7 @@ let _sys_hypervisor_version_major = "/sys/hypervisor/version/major"
 let _sys_hypervisor_version_minor = "/sys/hypervisor/version/minor"
 
 type hypervisor =
-  | Xen of string * string
+  | Xen of int * int
   (* major, minor *)
   | Other of string
 
@@ -601,7 +601,7 @@ let detect_hypervisor () =
         let minor =
           String.trim (Unixext.string_of_file _sys_hypervisor_version_minor)
         in
-        Some (Xen (major, minor))
+        Some (Xen (int_of_string major, int_of_string minor))
     | x ->
         Some (Other x)
   else

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -5147,11 +5147,10 @@ let init () =
   look_for_forkexec () ;
   let major, minor = look_for_xen () in
   look_for_xenctrl () ;
-  if
-    major < "4" || ((major = "4" && minor < "2") && !Xenopsd.run_hotplug_scripts)
+  if major < 4 || ((major = 4 && minor < 2) && !Xenopsd.run_hotplug_scripts)
   then (
     error
-      "This is xen version %s.%s. On all versions < 4.1 we must use \
+      "This is xen version %d.%d. On all versions < 4.2 we must use \
        hotplug/udev scripts"
       major minor ;
     error


### PR DESCRIPTION
Don't use string comparisons for versions, "17" < "2", but 17 > 2!

This setting prevents using `run_hotplug_scripts=true` (the default is still `false`, which says can lead to device timeouts, and indeed it does, I can't boot a single VM on this particular host).
I don't quite understand why udev won't run the xenopsd block script, but the fallback of having xenopsd run them doesn't work either.

This would've already affected 4.13 too (but not any versions between 4.3 and 4.9).