### PR TITLE
CA-390109: Use `$PROFILE` path to store and read known cert list 

### DIFF
--- a/ocaml/sdk-gen/powershell/autogen/Initialize-Environment.ps1
+++ b/ocaml/sdk-gen/powershell/autogen/Initialize-Environment.ps1
@@ -46,4 +46,6 @@ if (Test-Path $perUserXsProfile) {
 Remove-Item variable:systemWideXsProfile
 Remove-Item variable:perUserXsProfile
 
+$global:KnownServerCertificatesFilePath = Join-Path -Path (Split-Path $PROFILE) -ChildPath "XenServer_Known_Certificates.xml"
+
 $XenServer_Environment_Initialized = $true

--- a/ocaml/sdk-gen/powershell/autogen/src/Connect-XenServer.cs
+++ b/ocaml/sdk-gen/powershell/autogen/src/Connect-XenServer.cs
@@ -253,9 +253,9 @@ namespace Citrix.XenServer.Commands
 
         private void AddCertificate(string hostname, string fingerprint)
         {
-            var certificates = CommonCmdletFunctions.LoadCertificates();
+            var certificates = CommonCmdletFunctions.LoadCertificates(this);
             certificates[hostname] = fingerprint;
-            CommonCmdletFunctions.SaveCertificates(certificates);
+            CommonCmdletFunctions.SaveCertificates(this, certificates);
         }
 
         private bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
@@ -274,7 +274,7 @@ namespace Citrix.XenServer.Commands
 
                 bool trusted = VerifyInAllStores(new X509Certificate2(certificate));
 
-                var certificates = CommonCmdletFunctions.LoadCertificates();
+                var certificates = CommonCmdletFunctions.LoadCertificates(this);
 
                 if (certificates.ContainsKey(hostname))
                 {
@@ -292,7 +292,7 @@ namespace Citrix.XenServer.Commands
                 }
 
                 certificates[hostname] = fingerprint;
-                CommonCmdletFunctions.SaveCertificates(certificates);
+                CommonCmdletFunctions.SaveCertificates(this, certificates);
                 return true;
             }
         }

--- a/ocaml/sdk-gen/powershell/autogen/src/XenServerPowerShell.csproj
+++ b/ocaml/sdk-gen/powershell/autogen/src/XenServerPowerShell.csproj
@@ -6,7 +6,7 @@
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- This propety ensures all DLLs are placed oin `bin/` at compile time -->
+    <!-- This propety ensures all DLLs are placed in `bin/` at compile time -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)|$(OS)' == 'Debug|AnyCPU|Windows_NT' And '$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
Before these changes, the `SaveCertificates` method relied on machines having a `SpecialFolder.MyDocuments` folder. This is true in Windows and GUI versions of some Linux distros, but it's an assumption that caused the save method to fail if the folder didn't exist.

With this commit, we're storing and reading from the path where `$PROFILE` is stored, which is platform agnostic from the point of view of the SDK.
