### PR TITLE
message-switch: Print more complete time info in diagnostics

### DIFF
--- a/ocaml/message-switch/cli/dune
+++ b/ocaml/message-switch/cli/dune
@@ -5,6 +5,7 @@
     cmdliner
     message-switch-core
     message-switch-unix
+    mtime
     rpclib.core
     rpclib.json
     threads.posix


### PR DESCRIPTION
Previously sub-second durations were printed as "ago", now they are pretty-printed using Mtime.Span's logic, for example "666ms ago".

If the point in time is unexpectedly in the future, print "0ns ago".

Durations lasting at least 1 seconds are printed as before.

These "ago" appear in the message_cli_diag.out from status reports, and are confusing to see, as they look like a bug. e.g.
```
- org.xen.xapi.xenops.classic
    2999282: request from: xapi:2778 sent ago
      - UPDATES.get
        - {"last_id":2612584,"debug_info":"org.xen.xapi.xenops.classic events D:
      - xapi:2778 is waiting for a response

```