### PR TITLE
CP-46944: Update yum plugins to dnf plugins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,7 @@ jobs:
           --cov-report xml:.git/coverage${{matrix.python-version}}.xml
         env:
           PYTHONDEVMODE: yes
+          PYTHONPATH: "python3:python3/tests/stubs"
 
       - name: Upload Python ${{matrix.python-version}} coverage report to Codecov
         uses: codecov/codecov-action@v3

--- a/python3/Makefile
+++ b/python3/Makefile
@@ -3,7 +3,11 @@ include ../config.mk
 SITE3_DIR=$(shell python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 IDATA=install -m 644
+DNF_PLUGIN_DIR=dnf-plugins
 
 install:
 	mkdir -p $(DESTDIR)$(SITE3_DIR)
+	mkdir -p $(DESTDIR)$(SITE3_DIR)/$(DNF_PLUGIN_DIR)
 	$(IDATA) packages/observer.py $(DESTDIR)$(SITE3_DIR)/
+	$(IDATA) dnf_plugins/accesstoken.py $(DESTDIR)$(SITE3_DIR)/$(DNF_PLUGIN_DIR)/
+	$(IDATA) dnf_plugins/ptoken.py $(DESTDIR)$(SITE3_DIR)/$(DNF_PLUGIN_DIR)/

--- a/python3/README.md
+++ b/python3/README.md
@@ -10,3 +10,4 @@ run by xapi and other daemons.
 - packages: This contains files to be installed in python's site-packages and are meant
 to be modules and packages to be imported by other scripts or executed via python3 -m
 - plugins: This contains files that are meant to be xapi plugins
+- dnf-plugins: This contains dnf-plugins and are meant to be called automatically by dnf

--- a/python3/dnf_plugins/accesstoken.py
+++ b/python3/dnf_plugins/accesstoken.py
@@ -1,15 +1,29 @@
 """dnf plugin to set accesstoken http header for enabled repos"""
 import json
 import logging
+# Disable the error, it can be import in production env
+# and mocked out in unitttest
+#pylint: disable=import-error
 import dnf
 import urlgrabber
 
+
+class InvalidToken(Exception):
+    """Token is invlaid"""
+    def __init__(self, token):
+        super().__init__(f"Invalid token: {token}")
+
+
+#pylint: disable=too-few-public-methods
 class AccessToken(dnf.Plugin):
     """dnf accesstoken plugin class"""
 
     name = "accesstoken"
 
     def config(self):
+        """ DNF plugin config hook,
+        refer to https://dnf.readthedocs.io/en/latest/api_plugins.html"""
+
         for repo_name in self.base.repos:
             repo = self.base.repos[repo_name]
 
@@ -23,8 +37,8 @@ class AccessToken(dnf.Plugin):
                 logging.debug("Failed to load token from: %s", token_url)
                 continue
 
-            if not (token['token'] and token['token_id']):
-                raise Exception("Invalid token or token_id")
+            if not (token.get('token') and token.get('token_id')):
+                raise InvalidToken(token)
 
             access_token = f'X-Access-Token:{str(token["token"])}'
             referer = f'Referer:{str(token["token_id"])}'

--- a/python3/dnf_plugins/accesstoken.py
+++ b/python3/dnf_plugins/accesstoken.py
@@ -1,0 +1,31 @@
+"""dnf plugin to set accesstoken http header for enabled repos"""
+import json
+import logging
+import dnf
+import urlgrabber
+
+class AccessToken(dnf.Plugin):
+    """dnf accesstoken plugin class"""
+
+    name = "accesstoken"
+
+    def config(self):
+        for repo_name in self.base.repos:
+            repo = self.base.repos[repo_name]
+
+            token_url = repo.accesstoken
+            if not token_url or token_url == '':
+                continue
+            try:
+                token_str = urlgrabber.urlopen(token_url).read().strip()
+                token = json.loads(token_str)
+            except Exception:  #pylint: disable=broad-except
+                logging.debug("Failed to load token from: %s", token_url)
+                continue
+
+            if not (token['token'] and token['token_id']):
+                raise Exception("Invalid token or token_id")
+
+            access_token = f'X-Access-Token:{str(token["token"])}'
+            referer = f'Referer:{str(token["token_id"])}'
+            repo.set_http_headers([access_token, referer])

--- a/python3/dnf_plugins/ptoken.py
+++ b/python3/dnf_plugins/ptoken.py
@@ -1,0 +1,18 @@
+"""dnf plugin to add ptoken for repos"""
+import dnf
+
+class Ptoken(dnf.Plugin):
+    """ptoken plugin class"""
+    name = "ptoken"
+
+    def config(self):
+        with open('/etc/xensource/ptoken', encoding="utf-8") as file:
+            ptoken = file.read().strip()
+
+        for repo_name in self.base.repos:
+            repo = self.base.repos[repo_name]
+
+            if len(repo.baseurl) > 0 and repo.baseurl[0].startswith("http://127.0.0.1") \
+                and repo.ptoken:
+                secret = "pool_secret=" + ptoken
+                repo.set_http_headers([f'cookie:{secret}'])

--- a/python3/dnf_plugins/ptoken.py
+++ b/python3/dnf_plugins/ptoken.py
@@ -1,13 +1,24 @@
 """dnf plugin to add ptoken for repos"""
+import logging
 import dnf
 
+PTOKEN_PATH = "/etc/xensource/ptoken"
+
+#pylint: disable=too-few-public-methods
 class Ptoken(dnf.Plugin):
     """ptoken plugin class"""
+
     name = "ptoken"
 
     def config(self):
-        with open('/etc/xensource/ptoken', encoding="utf-8") as file:
-            ptoken = file.read().strip()
+        """ DNF plugin config hook,
+        refer to https://dnf.readthedocs.io/en/latest/api_plugins.html"""
+        try:
+            with open('/etc/xensource/ptoken', encoding="utf-8") as file:
+                ptoken = file.read().strip()
+        except Exception: #pylint: disable=broad-exception-caught
+            logging.error("Failed to open %s", PTOKEN_PATH)
+            raise
 
         for repo_name in self.base.repos:
             repo = self.base.repos[repo_name]

--- a/python3/tests/stubs/dnf.py
+++ b/python3/tests/stubs/dnf.py
@@ -1,0 +1,12 @@
+"""This is a stub module for dnf.base
+
+This module is introduced to decouple the dependencies from dnf
+modules during unittest, as the github CI ubuntu container has
+issues with the python-dnf and python3.11
+"""
+#pylint: disable=too-few-public-methods
+class Plugin:
+    """Dnf plugin interface"""
+    def __init__(self, base, cli):
+        self.base = base
+        self.cli = cli

--- a/python3/tests/test_dnf_plugins.py
+++ b/python3/tests/test_dnf_plugins.py
@@ -20,6 +20,7 @@ from dnf_plugins import ptoken
 
 REPO_NAME = "testrepo"
 
+
 def _mock_repo(a_token=None, p_token=None, baseurl=None):
     mock_repo = MagicMock()
     mock_repo.accesstoken = a_token

--- a/python3/tests/test_dnf_plugins.py
+++ b/python3/tests/test_dnf_plugins.py
@@ -1,0 +1,96 @@
+"""Test module for dnf accesstoken"""
+import unittest
+import sys
+import json
+from unittest.mock import MagicMock, patch
+
+sys.modules["urlgrabber"] = MagicMock()
+
+# Disable wrong import postition as need to mock some sys modules first
+#pylint: disable=wrong-import-position
+
+# Disable unused-argument as some mock obj is not used
+#pylint: disable=unused-argument
+
+# Some test case does not use self
+#pylint: disable=no-self-use
+
+from dnf_plugins import accesstoken
+from dnf_plugins import ptoken
+
+REPO_NAME = "testrepo"
+
+def _mock_repo(a_token=None, p_token=None, baseurl=None):
+    mock_repo = MagicMock()
+    mock_repo.accesstoken = a_token
+    mock_repo.ptoken = p_token
+    mock_repo.baseurl = baseurl
+    mock_base = MagicMock()
+    mock_base.repos = {REPO_NAME: mock_repo}
+    mock_repo.base = mock_base
+    return mock_repo
+
+
+@patch("dnf_plugins.accesstoken.urlgrabber")
+class TestAccesstoken(unittest.TestCase):
+    """Test class for dnf access plugin"""
+
+    def test_set_http_header_with_access_token(self, mock_grabber):
+        """test config succeed with accesstokan"""
+        mock_repo = _mock_repo(a_token="file:///mock_accesstoken_url")
+        mock_grabber.urlopen.return_value.read.return_value = json.dumps({
+            "token": "valid_token",
+            "token_id": "valid_token_id",
+        })
+        accesstoken.AccessToken(mock_repo.base, MagicMock()).config()
+        mock_repo.set_http_headers.assert_called_with(
+            ['X-Access-Token:valid_token','Referer:valid_token_id']
+        )
+
+    def test_repo_without_access_token(self, mock_grabber):
+        """If repo has not accestoken, it should not be blocked"""
+        mock_repo = _mock_repo()
+        accesstoken.AccessToken(mock_repo.base, MagicMock()).config()
+
+    def test_ignore_invalid_token_url(self, mock_grabber):
+        """If repo provided an invalid token url, it should be ignored"""
+        mock_repo = _mock_repo(a_token="Not_existed")
+        mock_grabber.urlopen.side_effect = FileNotFoundError('')
+        accesstoken.AccessToken(mock_repo.base, MagicMock()).config()
+        assert not mock_repo.set_http_headers.called
+
+    def test_invalid_token_raise_exception(self, mock_grabber):
+        """Token with right json format, bad content should raise"""
+        mock_repo = _mock_repo(a_token="file:///file_contain_invalid_token")
+        mock_grabber.urlopen.return_value.read.return_value = json.dumps({
+            "bad_token": "I am bad guy"
+        })
+        with self.assertRaises(Exception):
+            accesstoken.AccessToken(mock_repo.base, MagicMock()).config()
+
+
+class TestPtoken(unittest.TestCase):
+    """Test class for ptoken dnf plugin"""
+    @patch("builtins.open")
+    def test_set_ptoken_to_http_header(self, mock_open):
+        """Local repo with ptoken enabled should set the ptoken to its http header"""
+        mock_open.return_value.__enter__.return_value.read.return_value = "valid_ptoken"
+        mock_repo = _mock_repo(p_token=True, baseurl=["http://127.0.0.1/some_local_path"])
+        ptoken.Ptoken(mock_repo.base, MagicMock()).config()
+        mock_repo.set_http_headers.assert_called_with(["cookie:pool_secret=valid_ptoken"])
+
+    @patch("builtins.open")
+    def test_remote_repo_ignore_ptoken(self, mock_open):
+        """non-local repo should just ignore the ptoken"""
+        mock_open.return_value.__enter__.return_value.read.return_value = "valid_ptoken"
+        mock_repo = _mock_repo(p_token=True, baseurl=["http://some_remote_token/some_local_path"])
+        ptoken.Ptoken(mock_repo.base, MagicMock()).config()
+        assert not  mock_repo.set_http_headers.called
+
+    @patch("builtins.open")
+    def test_local_repo_does_not_enable_ptoken_should_ignore_ptoken(self, mock_open):
+        """local repo which has not enabled ptoken should just ignore the ptoken"""
+        mock_open.return_value.__enter__.return_value.read.return_value = "valid_ptoken"
+        mock_repo = _mock_repo(p_token=False, baseurl=["http://127.0.0.1/some_local_path"])
+        ptoken.Ptoken(mock_repo.base, MagicMock()).config()
+        assert not  mock_repo.set_http_headers.called


### PR DESCRIPTION
XS9 does not have yum command, and yum plugin is used to add HTTP headers automatically for yum commands when
- access pool master repo. (ptoken)
- access remote repo for CDN udpate (accesstoken)

This is updating the yum plugins to corresponding DNF plugins, and enable dnf with the same functionality.




Test done:
- XenRT test
  - XS9: 3961239.  (The suite cover sync updates from pool cordinator, thus covered the plugins)
  - XS8: 3961239 (XS8 is not related, just run for sure)

Manul test:
- Add *print* in the plugins to make sure it is called.  For example.
`print("set ptoken: ", f'cookie:{secret}')`
`print("set accesstoken: ", access_token, "tokenid: ", referer)`
 
``` 
dnf --disablerepo=* --enablerepo=local-6192a1a6-cda9-4ba1-e4a6-e36148fcb239,local-e6445302-c68d-8154-647c-785d93e59307 check-update
set ptoken:  cookie:pool_secret=70d0ef24-832b-adef-afec-f06011eed6d9/7993fa04-59e1-5ea3-016d-8908c63764cb/05feb002-bb82-8b7f-a025-db6805ea5525
set ptoken:  cookie:pool_secret=70d0ef24-832b-adef-afec-f06011eed6d9/7993fa04-59e1-5ea3-016d-8908c63764cb/05feb002-bb82-8b7f-a025-db6805ea5525
local-6192a1a6-cda9-4ba1-e4a6-e36148fcb239                                                                52 kB/s | 991  B     00:00    
local-e6445302-c68d-8154-647c-785d93e59307 ```


```

- run *xe pool-sync-updates token=this_is_token token-id=this_is_token_id*


```
/usr/bin/dnf --disablerepo=* --enablerepo=remote-6192a1a6-cda9-4ba1-e4a6-e36148fcb239 -y makecache succeeded [ output = 'set ptoken:  cookie:pool_secret=70d0ef24-832b-adef-afec-f06011eed6d9/7993fa04-59e1-5ea3-016d-8908c63764cb/05feb002-bb82-8b7f-a025-db6805ea5525\x0Aset ptoken:  cookie:pool_secret=70d0ef24-832b-adef-afec-f06011eed6d9/7993fa04-59e1-5ea3-016d-8908c63764cb/05feb002-bb82-8b7f-a025-db6805ea5525\x0Aset accesstoken:  X-Access-Token:this_is_token tokenid:  Referer:this_is_token_id\x0Aremote-6192a1a6-cda9-4ba1-e4a6-e36148fcb239     5.0 kB/s | 991  B     00:00    \x0AMetadata cache created.\x0A' ]
```

call path:    `sync_updates --> set_available_updates -> get_hosts_updates -> http_get_host_updates_in_json --> Xapi_http.http_request  Constants.get_host_updates_uri`