### PR TITLE
CA-384483: Can't export VDI to VHD file with base VDI

### DIFF
--- a/ocaml/xapi/vhd_tool_wrapper.ml
+++ b/ocaml/xapi/vhd_tool_wrapper.ml
@@ -170,9 +170,16 @@ let vhd_of_device path =
       | _, _, _ ->
           raise Not_found
     with
-    | Tapctl.Not_blktap ->
+    | Tapctl.Not_blktap -> (
         debug "Device %s is not controlled by blktap" path ;
-        None
+        (* Check if it is a VHD behind a NBD deivce *)
+        Stream_vdi.(get_nbd_device path |> image_behind_nbd_device) |> function
+        | Some ("vhd", vhd) ->
+            debug "%s is a VHD behind NBD device %s" vhd path ;
+            Some vhd
+        | _ ->
+            None
+      )
     | Tapctl.Not_a_device ->
         debug "%s is not a device" path ;
         None
@@ -186,15 +193,18 @@ let send progress_cb ?relative_to (protocol : string) (dest_format : string)
     (s : Unix.file_descr) (path : string) (size : Int64.t) (prefix : string) =
   let s' = Uuidx.(to_string (make ())) in
   let source_format, source =
-    match (Stream_vdi.get_nbd_device path, vhd_of_device path) with
-    | Some (nbd_server, exportname), _ ->
+    match (Stream_vdi.get_nbd_device path, vhd_of_device path, relative_to) with
+    | Some (nbd_server, exportname), _, None ->
         ( "nbdhybrid"
         , Printf.sprintf "%s:%s:%s:%Ld" path nbd_server exportname size
         )
-    | None, Some vhd ->
+    | Some _, Some vhd, Some _ | None, Some vhd, _ ->
         ("hybrid", path ^ ":" ^ vhd)
-    | None, None ->
+    | None, None, None ->
         ("raw", path)
+    | _, None, Some _ ->
+        let msg = "Cannot compute differences on non-VHD images" in
+        error "%s" msg ; failwith msg
   in
   let relative_to =
     match relative_to with


### PR DESCRIPTION
    With *hybrid source format in export, the following cases are supported:
    1. nbdhybrid: QCOW2 -> NBD device in dom0 -> exported file
    2. nbdhybrid: VHD -> NBD device in dom0 -> exported file
    3. hybrid: VHD -> blktap device in dom0 -> exported file

    The case 2 above can't support an optional parameter "base".
    This parameter holds the ID of another VHD VDI. When it is passed, the
    export will only write the differences between "source" and "base" to
    the destination file.

    As a short-term solution, in case 2 above, when the "base" is passed,
    the source format is changed to "hybrid" in this commit.
    This can work because:
    1. the comparsion on blocks required by "base" is supported by "hybrid";
    2. the raw data from NBD device and blktap (Frankentap) device are same;
    3. the sparseness information of the source required in case 2 can be
       get by either NBD interface (nbdhybrid) or VHD parsing (hybrid).

    Signed-off-by: Ming Lu <ming.lu@cloud.com>