### PR TITLE
CA-378317 fix EBADF in waitpid_nohang

### DIFF
--- a/ocaml/forkexecd/lib/forkhelpers.mli
+++ b/ocaml/forkexecd/lib/forkhelpers.mli
@@ -111,8 +111,10 @@ val waitpid : pidty -> int * Unix.process_status
 (** [waitpid p] returns the (pid, Unix.process_status) *)
 
 val waitpid_nohang : pidty -> int * Unix.process_status
-(** [waitpid_nohang p] returns the (pid, Unix.process_status) if the process has already
-    	quit or (0, Unix.WEXITTED 0) if the process is still running. *)
+(** [waitpid_nohang p] returns the (pid, Unix.process_status) if the
+    process has already quit or (0, Unix.WEXITTED 0) if the process is
+    still running.  If the process is finished, the socket is closed
+    and not otherwise. *)
 
 val dontwaitpid : pidty -> unit
 (** [dontwaitpid p]: signals the caller's desire to never call waitpid. Note that the final


### PR DESCRIPTION
`waitpid_nohang` closes the socket by calling `waitpid` and then calls `clear_nonblock` on that socket, which fails.

`waitpid_nohang`'s policy around closing the socket is not obvious enough.  Make it more explicit by not calling waitpid but inlining this code and looking at the different cases. Also provide an option to never close the socket such that this resided with the caller - which is a cleaner protocol. The default behaviour is to still close the socket when the child process has terminated and not otherwise.

