### PR TITLE
CP-47660 define anti-affinity feature

### DIFF
--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -64,6 +64,7 @@ type feature =
   | Updates
   | Internal_repo_access
   | VTPM
+  | VM_anti_affinity
 [@@deriving rpc]
 
 type orientation = Positive | Negative
@@ -132,6 +133,9 @@ let keys_of_features =
     , ("restrict_internal_repo_access", Negative, "Internal_repo_access")
     )
   ; (VTPM, ("restrict_vtpm", Negative, "VTPM"))
+  ; ( VM_anti_affinity
+    , ("restrict_vm_anti_affinity", Negative, "VM_anti_affinity")
+    )
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi-types/features.mli
+++ b/ocaml/xapi-types/features.mli
@@ -72,6 +72,7 @@ type feature =
   | Internal_repo_access
       (** Enable restriction on repository access to pool members only *)
   | VTPM  (** Support VTPM device required by Win11 guests *)
+  | VM_anti_affinity  (** Enable use of VM anti-affinity placement *)
 
 val feature_of_rpc : Rpc.t -> feature
 (** Convert RPC into {!feature}s *)


### PR DESCRIPTION
Added the definition of VM anti-affinity feature, the anti-affinity feature ensures that specified virtual machines are not co-located on the same physical host within a virtualized environment, enhancing fault tolerance and availability.