### PR TITLE
CP-48221: Support new gpg for XS9 

### DIFF
--- a/ocaml/xapi/gpg.ml
+++ b/ocaml/xapi/gpg.ml
@@ -68,7 +68,14 @@ let common ty filename signature size f =
       fds_to_close := List.filter (fun x -> x <> fd) !fds_to_close
     )
   in
-  let gpg_pub_keyring = Filename.concat !Xapi_globs.gpg_homedir "pubring.gpg" in
+  let gpg_pub_keyring =
+    (* newer version of pgp use pubring.kbx as keyring database while older one use
+     * pubring.gpg. If pubring.kbx exists use it, otherwise, fallback to pubring.gpg *)
+    let kbx_path = Filename.concat !Xapi_globs.gpg_homedir "pubring.kbx" in
+    let gpg_path = Filename.concat !Xapi_globs.gpg_homedir "pubring.gpg" in
+    match Sys.file_exists kbx_path with true -> kbx_path | false -> gpg_path
+  in
+
   let gpg_args =
     match ty with
     | `signed_cleartext ->


### PR DESCRIPTION
The default gpg public keyring database updated
- pubring.kbx for new gpg on XS9
- pubring.gpg for old gpg on XS8 Detect whether pubring.kbx exists and fallback to old one for XS8