### PR TITLE
Minor forkexecd test changes

### DIFF
--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -150,6 +150,7 @@ let test_exitcode () =
   in
   run_expect "/bin/false" 1 ;
   run_expect "/bin/xe-fe-test-no-command" 127 ;
+  run_expect "/bin/xe-fe-no-path/xe-fe-test-no-command" 127 ;
   run_expect "/etc/hosts" 126 ;
   Printf.printf "\nCompleted exitcode tests\n"
 

--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -140,6 +140,10 @@ let fail x =
   Printf.fprintf stderr "%s\n" x ;
   assert false
 
+let expect expected s =
+  if s <> expected ^ "\n" then
+    fail (Printf.sprintf "output %s expected %s" s expected)
+
 let test_exitcode () =
   let run_expect cmd expected =
     try Forkhelpers.execute_command_get_output cmd [] |> ignore
@@ -154,12 +158,24 @@ let test_exitcode () =
   run_expect "/etc/hosts" 126 ;
   Printf.printf "\nCompleted exitcode tests\n"
 
+let test_output () =
+  let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid ()) in
+  let expected_out = "output string" in
+  let expected_err = "error string" in
+  let args = ["echo"; expected_out; expected_err] in
+  let out, err = Forkhelpers.execute_command_get_output exe args in
+  expect expected_out out ;
+  expect expected_err err ;
+  print_endline "Completed output tests"
+
 let master fds =
   Printf.printf "\nPerforming timeout tests\n%!" ;
   test_delay () ;
   test_notimeout () ;
   Printf.printf "\nCompleted timeout test\n%!" ;
   test_exitcode () ;
+  Printf.printf "\nPerforming input/output tests\n%!" ;
+  test_output () ;
   let combinations = shuffle (all_combinations fds) in
   Printf.printf "Starting %d tests\n%!" (List.length combinations) ;
   let i = ref 0 in
@@ -236,6 +252,10 @@ let slave = function
 
 let sleep () = Unix.sleep 5 ; Printf.printf "Ok\n"
 
+let echo out err =
+  if out <> "" then print_endline out ;
+  if err <> "" then prerr_endline err
+
 let usage () =
   Printf.printf "Usage:\n" ;
   Printf.printf
@@ -254,6 +274,8 @@ let _ =
       sleep ()
   | _ :: "slave" :: rest ->
       slave rest
+  | _ :: "echo" :: out :: err :: _ ->
+      echo out err
   | [_] ->
       master max_fds
   | [_; fds] -> (

--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -168,6 +168,16 @@ let test_output () =
   expect expected_err err ;
   print_endline "Completed output tests"
 
+let test_input () =
+  let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid ()) in
+  let input = "input string" in
+  let args = ["replay"] in
+  let out, _ =
+    Forkhelpers.execute_command_get_output_send_stdin exe args input
+  in
+  expect input out ;
+  print_endline "Completed input tests"
+
 let master fds =
   Printf.printf "\nPerforming timeout tests\n%!" ;
   test_delay () ;
@@ -176,6 +186,7 @@ let master fds =
   test_exitcode () ;
   Printf.printf "\nPerforming input/output tests\n%!" ;
   test_output () ;
+  test_input () ;
   let combinations = shuffle (all_combinations fds) in
   Printf.printf "Starting %d tests\n%!" (List.length combinations) ;
   let i = ref 0 in
@@ -256,6 +267,10 @@ let echo out err =
   if out <> "" then print_endline out ;
   if err <> "" then prerr_endline err
 
+let replay () =
+  let line = read_line () in
+  print_endline line
+
 let usage () =
   Printf.printf "Usage:\n" ;
   Printf.printf
@@ -276,6 +291,8 @@ let _ =
       slave rest
   | _ :: "echo" :: out :: err :: _ ->
       echo out err
+  | _ :: "replay" :: _ ->
+      replay ()
   | [_] ->
       master max_fds
   | [_; fds] -> (

--- a/ocaml/forkexecd/test/fe_test.sh
+++ b/ocaml/forkexecd/test/fe_test.sh
@@ -6,13 +6,14 @@ export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-$TMPDIR}
 export FE_TEST=1
 
 SOCKET=${XDG_RUNTIME_DIR}/xapi/forker/main
+rm -f "$SOCKET"
 
 ../src/fe_main.exe &
 MAIN=$!
 cleanup () {
     kill $MAIN
 }
-trap cleanup EXIT
+trap cleanup EXIT INT
 for _ in $(seq 1 10); do
     test -S ${SOCKET} || sleep 1
 done


### PR DESCRIPTION
Add some minor tests for forkexecd
- invalid path;
- input/output.

Make manual usage easier.