### PR TITLE
CA-390988: Prevent varstored-guard from shutting down while domains run

### DIFF
--- a/scripts/varstored-guard.service
+++ b/scripts/varstored-guard.service
@@ -2,7 +2,7 @@
 Description=Varstored XAPI socket deprivileging daemon
 Documentation=man:varstored-guard(1)
 After=message-switch.service syslog.target
-Before=xenopsd.service
+Before=xapi-domains.service xenopsd.service
 Wants=message-switch.service syslog.target
 
 [Service]


### PR DESCRIPTION
Domains using TPMs need to have SWTPM always available. Encode this information in the service file so the services are shut down at the correct time while powering off the hosts.

Some Xenserver internal tests were consistently failing without this change, I've verified this fixes it.

Prodding @rosslagerwall, he was interested in the fix