### PR TITLE
CP-46179 backport for deterministic backup VDI

### DIFF
--- a/ocaml/xapi-aux/dune
+++ b/ocaml/xapi-aux/dune
@@ -2,6 +2,7 @@
  (name xapi_aux)
 
  (libraries
+   uuidm
    xapi-types
    stdext
  )

--- a/ocaml/xapi-aux/uuidx.ml
+++ b/ocaml/xapi-aux/uuidx.ml
@@ -1,0 +1,13 @@
+include Uuidm
+
+module Hash = struct
+  (** Derive a deterministic UUID from a string: the same
+      string maps to the same UUID. We are using our own namespace; the
+      namespace is not a secret *)
+
+  let namespace =
+    let ns = "e93e0639-2bdb-4a59-8b46-352b3f408c19" in
+    Uuidm.(of_string ns |> Option.get)
+
+  let string str = Uuidm.v5 namespace str
+end

--- a/ocaml/xapi-aux/uuidx.mli
+++ b/ocaml/xapi-aux/uuidx.mli
@@ -1,0 +1,11 @@
+type t
+
+val to_string : ?upper:bool -> t -> string
+
+module Hash : sig
+  (** hash a string (deterministically) into a UUID. This uses
+      namespace UUID e93e0639-2bdb-4a59-8b46-352b3f408c19. *)
+
+  (* UUID Version 5 derived from argument string and namespace UUID *)
+  val string : string -> t
+end

--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -134,7 +134,7 @@ let sr_update dconf driver sr =
   let call = Sm_exec.make_call ~sr_ref:sr dconf "sr_update" [] in
   Sm_exec.parse_unit (Sm_exec.exec_xmlrpc (driver_filename driver) call)
 
-let vdi_create dconf driver sr sm_config vdi_type size name_label
+let vdi_create ?vdi_uuid dconf driver sr sm_config vdi_type size name_label
     name_description metadata_of_pool is_a_snapshot snapshot_time snapshot_of
     read_only =
   debug "vdi_create" driver
@@ -144,8 +144,8 @@ let vdi_create dconf driver sr sm_config vdi_type size name_label
     ) ;
   srmaster_only dconf ;
   let call =
-    Sm_exec.make_call ~sr_ref:sr ~vdi_sm_config:sm_config ~vdi_type dconf
-      "vdi_create"
+    Sm_exec.make_call ?vdi_uuid ~sr_ref:sr ~vdi_sm_config:sm_config ~vdi_type
+      dconf "vdi_create"
       [
         sprintf "%Lu" size
       ; name_label

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -688,16 +688,31 @@ module SMAPIv1 = struct
       vdi_info_from_db ~__context (Db.VDI.get_by_uuid ~__context ~uuid)
 
     let create context ~dbg ~sr ~vdi_info =
+      let __FUNCTION__ = "Storage_access.create" in
       try
         Server_helpers.exec_with_new_task "VDI.create"
           ~subtask_of:(Ref.of_string dbg) (fun __context ->
-            let sr = Db.SR.get_by_uuid ~__context ~uuid:(s_of_sr sr) in
+            let sr_uuid = s_of_sr sr in
+            let sr = Db.SR.get_by_uuid ~__context ~uuid:sr_uuid in
             let vi =
+              (* we want to set vdi_uuid when creating a backup VDI with
+                 a specific UUID. SM picks up vdi_uuid instead of creating
+                 a new random UUID; Cf. Xapi_vdi.create *)
+              let vdi_uuid =
+                match vdi_info.uuid with
+                | Some uuid when uuid = Uuidx.(Hash.string sr_uuid |> to_string)
+                  ->
+                    info "%s: creating a backup VDI %s" __FUNCTION__ uuid ;
+                    vdi_info.uuid
+                | _ ->
+                    None
+              in
               Sm.call_sm_functions ~__context ~sR:sr (fun device_config _type ->
-                  Sm.vdi_create device_config _type sr vdi_info.sm_config
-                    vdi_info.ty vdi_info.virtual_size vdi_info.name_label
-                    vdi_info.name_description vdi_info.metadata_of_pool
-                    vdi_info.is_a_snapshot vdi_info.snapshot_time
+                  Sm.vdi_create ?vdi_uuid device_config _type sr
+                    vdi_info.sm_config vdi_info.ty vdi_info.virtual_size
+                    vdi_info.name_label vdi_info.name_description
+                    vdi_info.metadata_of_pool vdi_info.is_a_snapshot
+                    vdi_info.snapshot_time
                     (s_of_vdi vdi_info.snapshot_of)
                     vdi_info.read_only
               )

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -595,6 +595,7 @@ let update_vdi_db ~__context ~sr newvdi =
 
 let create ~__context ~name_label ~name_description ~sR ~virtual_size ~_type
     ~sharable ~read_only ~other_config ~xenstore_data ~sm_config ~tags =
+  let __FUNCTION__ = "Xapi_vdi.create" in
   if _type = `cbt_metadata then (
     error
       "VDI.create: creation of VDIs with type cbt_metadata is not allowed (at \
@@ -634,13 +635,27 @@ let create ~__context ~name_label ~name_description ~sR ~virtual_size ~_type
     | `cbt_metadata ->
         "cbt_metadata"
   in
+  (* special case: we want to use a specific UUID for Pool Meta Data
+     Backup *)
+  let uuid_ =
+    match (_type, name_label) with
+    | `user, "Pool Metadata Backup" ->
+        let sr = Db.SR.get_uuid ~__context ~self:sR in
+        let uuid = Uuidx.(Hash.string sr |> to_string) in
+        info "%s: using deterministic UUID for '%s' VDI: %s" __FUNCTION__
+          name_label uuid ;
+        Some uuid
+    | _ ->
+        None
+  in
   let open Storage_access in
   let task = Context.get_task_id __context in
   let open Storage_interface in
   let vdi_info =
     {
       Storage_interface.default_vdi_info with
-      name_label
+      uuid= uuid_
+    ; name_label
     ; name_description
     ; ty= vdi_type
     ; read_only

--- a/scripts/xe-backup-metadata
+++ b/scripts/xe-backup-metadata
@@ -48,6 +48,29 @@ function usage {
     exit 1
 }
 
+function uuid5 {
+  # could use a modern uuidgen but it's not on XS 8
+  # should work with Python 2 and 3
+  python -c "import uuid; print (uuid.uuid5(uuid.UUID('$1'), '$2'))"
+}
+
+function validate_vdi_uuid {
+  # we check that vdi has the expected UUID which depends on the UUID of
+  # the SR. This is a deterministic hash of the SR UUID and the
+  # namespace UUID $NS. This UUID must match what Xapi's Uuidx module is using.
+  local NS="e93e0639-2bdb-4a59-8b46-352b3f408c19"
+  local sr="$1"
+  local vdi="$2"
+  local uuid
+
+  uuid=$(uuid5 "$NS" "$sr")
+  if [ "$vdi" != "$uuid" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 function test_sr {
   sr_uuid_found=$(${XE} sr-list uuid="$1" --minimal)
   if [ "${sr_uuid_found}" != "$1" ]; then
@@ -93,7 +116,7 @@ if [  -z "${sr_uuid}" ]; then
 fi
 test_sr "${sr_uuid}"
 
-sr_name=$(${XE} sr-param-get uuid=${sr_uuid} param-name=name-label)
+sr_name=$(${XE} sr-param-get uuid="${sr_uuid}" param-name=name-label)
 # see if a backup VDI already exists on the selected SR
 vdi_uuid=$(${XE} vdi-list other-config:ctxs-pool-backup=true sr-uuid=${sr_uuid} params=uuid --minimal)
 
@@ -134,11 +157,24 @@ function cleanup {
    fi
 }
 
-echo Using SR: ${sr_name}
+# if we can't validate the UUID of the VDI, prompt the user
+if [ -n "${vdi_uuid}" ]; then
+    if ! validate_vdi_uuid "${sr_uuid}" "${vdi_uuid}"; then
+        echo "Backup VDI $vdi_uuid was most likley create by an earlier"
+        echo "version of this code. Make sure this is a VDI that you"
+        echo "created as we can't validate it without mounting it."
+        read -p "Continue? [Y/N]" -n 1 -r; echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then exit 1; fi
+    fi
+fi
+
+echo "Using SR: ${sr_name}"
 if [ -z "${vdi_uuid}" ]; then
   if [ "${create_vdi}" -gt 0 ]; then
     echo -n "Creating new backup VDI: "
-    vdi_uuid=$(${XE} vdi-create virtual-size=500MiB sr-uuid=${sr_uuid} type=user name-label="Pool Metadata Backup")
+    label="Pool Metadata Backup"
+    # the label must match what xapi_vdi.ml is using for backup VDIs
+    vdi_uuid=$(${XE} vdi-create virtual-size=500MiB sr-uuid="${sr_uuid}" type=user name-label="${label}")
     init_fs=1
     if [ $? -ne 0 ]; then
        echo failed
@@ -225,7 +261,7 @@ if [ ${leave_mounted} -eq 0 ]; then
   usage=`cd ${mnt} && df . | sed -n "2p" | awk '{ print $5 }' | tr -d '%'`
   echo "Checking backup VDI space usage: $usage%"
   if [ $usage -gt $usage_alert ] && [ ${force_backup} -eq 0 ]; then
-    echo "Running out of space, you can use "-d" option to attach VDI and free more space, exit now."
+    echo "Running out of space, you can use '-d' option to attach VDI and free more space, exit now."
     cleanup
     exit 1
   fi

--- a/scripts/xe-backup-metadata
+++ b/scripts/xe-backup-metadata
@@ -39,6 +39,7 @@ function usage {
     echo " -k: Number of older backups to preserve (default: ${history_kept})"
     echo " -n: Just try to find a backup VDI and stop the script after that"
     echo " -f  Force backup even when less than 10% free capacity is left on the backup VDI"
+    echo " -y: Assume non-interactive mode and yes to all questions"
     echo " -v: Verbose output"
     echo 
     echo
@@ -86,7 +87,8 @@ just_find_vdi=0
 fs_uninitialised=0
 usage_alert=90
 force_backup=0
-while getopts "hvink:u:dcf" opt ; do
+yes=0
+while getopts "yhvink:u:dcf" opt ; do
     case $opt in
     h) usage ;;
     c) create_vdi=1 ; fs_uninitialised=1 ;;
@@ -96,6 +98,7 @@ while getopts "hvink:u:dcf" opt ; do
     d) leave_mounted=1 ;;
     n) just_find_vdi=1 ;;
     v) debug="" ;;
+    y) yes=1 ;;
     f) force_backup=1 ;;
     *) echo "Invalid option"; usage ;;
     esac
@@ -159,7 +162,7 @@ function cleanup {
 
 # if we can't validate the UUID of the VDI, prompt the user
 if [ -n "${vdi_uuid}" ]; then
-    if ! validate_vdi_uuid "${sr_uuid}" "${vdi_uuid}"; then
+    if ! validate_vdi_uuid "${sr_uuid}" "${vdi_uuid}" && [ "$yes" -eq 0 ]; then
         echo "Backup VDI $vdi_uuid was most likley create by an earlier"
         echo "version of this code. Make sure this is a VDI that you"
         echo "created as we can't validate it without mounting it."

--- a/scripts/xe-backup-metadata
+++ b/scripts/xe-backup-metadata
@@ -74,7 +74,7 @@ function validate_vdi_uuid {
 function test_sr {
   sr_uuid_found=$(${XE} sr-list uuid="$1" --minimal)
   if [ "${sr_uuid_found}" != "$1" ]; then
-     echo Invalid SR UUID specified: $1
+     echo "Invalid SR UUID specified: $1"
      usage
   fi
 }
@@ -112,32 +112,32 @@ fi
 # determine if the SR UUID is vaid
 if [  -z "${sr_uuid}" ]; then
   # use the default-SR from the pool
-  sr_uuid=$(${XE} pool-param-get uuid=${pool_uuid} param-name=default-SR)
+  sr_uuid=$(${XE} pool-param-get uuid="${pool_uuid}" param-name=default-SR)
 fi
 test_sr "${sr_uuid}"
 
 sr_name=$(${XE} sr-param-get uuid="${sr_uuid}" param-name=name-label)
 # see if a backup VDI already exists on the selected SR
-vdi_uuid=$(${XE} vdi-list other-config:ctxs-pool-backup=true sr-uuid=${sr_uuid} params=uuid --minimal)
+vdi_uuid=$(${XE} vdi-list other-config:ctxs-pool-backup=true sr-uuid="${sr_uuid}" params=uuid --minimal)
 
 mnt=
 function cleanup {
    trap "" TERM INT
    cd /
    if [ ! -z "${mnt}" ]; then
-      umount ${mnt} >/dev/null 2>&1
-      rmdir ${mnt}
+      umount "${mnt}" >/dev/null 2>&1
+      rmdir "${mnt}"
    fi
 
    if [ ! -z "${vbd_uuid}" ]; then
       ${debug} echo -n "Unplugging VBD: "
-      ${XE} vbd-unplug uuid=${vbd_uuid} timeout=20
+      ${XE} vbd-unplug uuid="${vbd_uuid}" timeout=20
       # poll for the device to go away if we know its name
       if [ "${device}" != "" ]; then
           device_gone=0
           for ((i=0; i<10; i++)); do
               ${debug} echo -n "."
-              if [ ! -b ${device} ]; then
+              if [ ! -b "${device}" ]; then
                   ${debug} echo " done"
                   device_gone=1
                   break
@@ -146,14 +146,14 @@ function cleanup {
           done
           if [ ${device_gone} -eq 0 ]; then
               ${debug} echo " failed"
-              echo Please destroy VBD ${vbd_uuid} manually.
+              echo "Please destroy VBD ${vbd_uuid} manually."
           else
-              ${XE} vbd-destroy uuid=${vbd_uuid}
+              ${XE} vbd-destroy uuid="${vbd_uuid}"
           fi
       fi
    fi
    if [ ${fs_uninitialised} -eq 1 -a -n "${vdi_uuid}" ] ; then
-      ${XE} vdi-destroy uuid=${vdi_uuid}
+      ${XE} vdi-destroy uuid="${vdi_uuid}"
    fi
 }
 
@@ -184,8 +184,8 @@ if [ -z "${vdi_uuid}" ]; then
     echo "Backup VDI not found, aborting.  You can initialise one using the '-c' flag."
     exit 3
   fi
-  echo ${vdi_uuid}
-  ${XE} vdi-param-set uuid=${vdi_uuid} other-config:ctxs-pool-backup=true
+  echo "${vdi_uuid}"
+  ${XE} vdi-param-set uuid="${vdi_uuid}" other-config:ctxs-pool-backup=true
 else
   ${debug} echo "Using existing backup VDI: ${vdi_uuid}"
   fs_uninitialised=0
@@ -196,71 +196,71 @@ if [ ${just_find_vdi} -gt 0 ]; then
 fi
 
 ${debug} echo -n "Creating VBD: "
-vbd_uuid=$(${XE} vbd-create vm-uuid=${CONTROL_DOMAIN_UUID} vdi-uuid=${vdi_uuid} device=autodetect)
-${debug} echo ${vbd_uuid}
+vbd_uuid=$(${XE} vbd-create vm-uuid="${CONTROL_DOMAIN_UUID}" vdi-uuid="${vdi_uuid}" device=autodetect)
+${debug} echo "${vbd_uuid}"
 
 
 if [ $? -ne 0 -o -z "${vbd_uuid}" ]; then
-  echo error creating VBD
+  echo "error creating VBD"
   cleanup
   exit 1
 fi
 
 ${debug} echo -n "Plugging VBD: "
-${XE} vbd-plug uuid=${vbd_uuid}
-device=/dev/$(${XE} vbd-param-get uuid=${vbd_uuid} param-name=device)
+${XE} vbd-plug uuid="${vbd_uuid}"
+device=/dev/$(${XE} vbd-param-get uuid="${vbd_uuid}" param-name=device)
 
-if [ ! -b ${device} ]; then
-  ${debug} echo ${device}: not a block special
+if [ ! -b "${device}" ]; then
+  ${debug} echo "${device}: not a block special"
   cleanup
   exit 1
 fi
 
-${debug} echo ${device}
+${debug} echo "${device}"
 
-if [ $init_fs -eq 1 ]; then
+if [ "$init_fs" -eq 1 ]; then
   ${debug} echo -n "Creating filesystem: "
-  mkfs.ext3 -j -F ${device} > /dev/null 2>&1
+  mkfs.ext3 -j -F "${device}" > /dev/null 2>&1
   ${debug} echo "done"
   fs_uninitialised=0
 fi
 
 ${debug} echo -n "Mounting filesystem: "
-mnt=/var/run/pool-backup-${vdi_uuid}
-mkdir -p ${mnt}
+mnt="/var/run/pool-backup-${vdi_uuid}"
+mkdir -p "${mnt}"
 
-/sbin/fsck -a ${device} >/dev/null 2>&1
+/sbin/fsck -a "${device}" >/dev/null 2>&1
 if [ $? -ne 0 ]; then
   ${debug} fsck failed.  Please correct manually
   cleanup 
   exit 1
 fi
 
-mount ${device} ${mnt} > /dev/null 2>&1
+mount "${device}" "${mnt}" > /dev/null 2>&1
 if [ $? -ne 0 ]; then
   ${debug} echo failed
   cleanup
   exit 1
 fi
-${debug} echo ${mnt}
+${debug} echo "${mnt}"
 
 if [ ${leave_mounted} -eq 0 ]; then
-  lrconf=${mnt}/conf/${vdi_uuid}
-  if [ ! -f ${lrconf} ]; then
+  lrconf="${mnt}/conf/${vdi_uuid}"
+  if [ ! -f "${lrconf}" ]; then
      ${debug} echo -n "Initialising rotation: "
-     mkdir -p ${mnt}/conf/ 
-     echo "${mnt}/${pool_uuid}.db {" >> ${lrconf}
-     echo "    rotate ${history_kept}" >> ${lrconf}
-     echo "    missingok" >> ${lrconf}
-     echo "}" >> ${lrconf}
-     echo done
-     echo ${metadata_version} >> ${mnt}/.ctxs-metadata-backup
+     mkdir -p "${mnt}/conf/"
+     echo "${mnt}/${pool_uuid}.db {" >> "${lrconf}"
+     echo "    rotate ${history_kept}" >> "${lrconf}"
+     echo "    missingok" >> "${lrconf}"
+     echo "}" >> "${lrconf}"
+     echo "done"
+     echo "${metadata_version}" >> "${mnt}/.ctxs-metadata-backup"
   fi
 
   # check the usage of the backup VDI
-  usage=`cd ${mnt} && df . | sed -n "2p" | awk '{ print $5 }' | tr -d '%'`
+  usage=`cd "${mnt}" && df . | sed -n "2p" | awk '{ print $5 }' | tr -d '%'`
   echo "Checking backup VDI space usage: $usage%"
-  if [ $usage -gt $usage_alert ] && [ ${force_backup} -eq 0 ]; then
+  if [ "$usage" -gt "$usage_alert" ] && [ "${force_backup}" -eq 0 ]; then
     echo "Running out of space, you can use '-d' option to attach VDI and free more space, exit now."
     cleanup
     exit 1
@@ -268,38 +268,38 @@ if [ ${leave_mounted} -eq 0 ]; then
 
   # invoke logrotate to rotate over old pool db backups
   echo -n "Rotating old backups: "
-  logrotate -f ${lrconf}
-  num_found=$(find ${mnt} -name \*.db\.* | wc -l)
-  echo found ${num_found}
+  logrotate -f "${lrconf}"
+  num_found=$(find "${mnt}" -name '*.db.*' | wc -l)
+  echo "found ${num_found}"
   
   # perform the pool database dump
   echo -n "Backing up pool database: "
-  ${XE} pool-dump-database file-name=${mnt}/${pool_uuid}.db
+  ${XE} pool-dump-database file-name="${mnt}/${pool_uuid}.db"
   echo done
 
   # backup the VM metadata for each VM in the pool into a dated directory
   datetime=$(date +%F-%H-%M-%S)
-  metadir=${mnt}/metadata/${datetime}
-  mkdir -p ${metadir}
+  metadir="${mnt}/metadata/${datetime}"
+  mkdir -p "${metadir}"
   echo -n "Cleaning old VM metadata: "
   IFS=" "
-  todelete=$(cd ${mnt}/metadata && ls -1 |sort -n | head -n -${history_kept} | xargs echo)
+  todelete=$(cd "${mnt}/metadata" && ls -1 |sort -n | head -n -${history_kept} | xargs echo)
   for dir in ${todelete}; do
-    rm -rf ${mnt}/metadata/${dir}
+    rm -rf "${mnt}/metadata/${dir}"
   done
   echo done
   IFS=","
   echo -n "Backing up SR metadata: "
-  mkdir -p ${metadir}
-  "@LIBEXECDIR@/backup-sr-metadata.py" -f ${metadir}/SRMETA.xml
+  mkdir -p "${metadir}"
+  "@LIBEXECDIR@/backup-sr-metadata.py" -f "${metadir}/SRMETA.xml"
   echo "done"
 
   echo -n "Backing up VM metadata: "
   ${debug} echo ""
-  mkdir -p ${metadir}/all
+  mkdir -p "${metadir}/all"
   for vmuuid in $(${XE} vm-list params=uuid is-control-domain=false --minimal); do
     ${debug} echo -n .
-    ${XE} vm-export --metadata uuid=${vmuuid} filename=${metadir}/all/${vmuuid}.vmmeta >/dev/null 2>&1
+    ${XE} vm-export --metadata uuid="${vmuuid}" filename="${metadir}/all/${vmuuid}.vmmeta" >/dev/null 2>&1
   done
   echo "done"
   echo -n "Backing up Template metadata: "
@@ -307,13 +307,13 @@ if [ ${leave_mounted} -eq 0 ]; then
   template_uuids=$("@LIBEXECDIR@/print-custom-templates")
   if [ $? -eq 0 ]; then
       for tmpl_uuid in ${template_uuids}; do
-          ${XE} template-export --metadata template-uuid=${tmpl_uuid} filename=${metadir}/all/${tmpl_uuid}.vmmeta >/dev/null 2>&1
+          ${XE} template-export --metadata template-uuid="${tmpl_uuid}" filename="${metadir}/all/${tmpl_uuid}.vmmeta" >/dev/null 2>&1
       done
   fi
   echo "done"
-  "@LIBEXECDIR@/link-vms-by-sr.py" -d ${metadir}
+  "@LIBEXECDIR@/link-vms-by-sr.py" -d "${metadir}"
 else
-  cd ${mnt}
+  cd "${mnt}"
   env PS1="Mounted backup VDI on: ${mnt}\nPress ^D to exit shell and safely detach it.\n\n[\u@\h \W]\$ " bash
 fi
 

--- a/scripts/xe-restore-metadata
+++ b/scripts/xe-restore-metadata
@@ -60,6 +60,13 @@ function test_sr {
   fi
 }
 
+# name space to hash SRs for a deterministic VDI UUID
+NS="e93e0639-2bdb-4a59-8b46-352b3f408c19"
+function uuid5 {
+  # could use a modern uuidgen but it's not on XS 8
+  python -c "import uuid; print (uuid.uuid5(uuid.UUID('$1'), '$2'))"
+}
+
 dry_run=0
 sr_uuid=
 yes=0
@@ -108,9 +115,16 @@ test_sr "${sr_uuid}"
 
 sr_name=$(${XE} sr-param-get uuid=${sr_uuid} param-name=name-label)
 
+# probe first for a VDI with known UUID derived from the SR to avoid
+# scanning for a VDI
+backup_vdi=$(uuid5 "${NS}" "${sr_uuid}")
+if [ -z "${vdis}" ]; then
+  vdis=$(${XE} vdi-list uuid="${backup_vdi}" sr-uuid="${sr_uuid}" read-only=false --minimal)
+fi
+
 # get a list of all VDIs if an override has not been provided on the cmd line
 if [ -z "${vdis}" ]; then
-  vdis=$(${XE} vdi-list params=uuid sr-uuid=${sr_uuid} read-only=false --minimal)
+  vdis=$(${XE} vdi-list params=uuid sr-uuid="${sr_uuid}" read-only=false --minimal)
 fi
 
 mnt=
@@ -157,6 +171,14 @@ fi
 trap cleanup SIGINT ERR
 
 for vdi_uuid in ${vdis}; do
+   if [ "${vdi_uuid}" != "${backup_vdi}" ]; then
+      echo "Probing VDI ${vdi_uuid}."
+      echo "This VDI was created with a prior version of XenServer."
+      echo "Its validity can't be checked without mounting it first."
+      read -p "Continue? [Y/N]" -n 1 -r; echo
+      if [[ ! $REPLY =~ ^[Yy]$ ]]; then exit 1; fi
+   fi
+
    ${debug} echo -n "Creating VBD: " >&2
    vbd_uuid=$(${XE} vbd-create vm-uuid=${CONTROL_DOMAIN_UUID} vdi-uuid=${vdi_uuid} device=autodetect 2>/dev/null)
 
@@ -258,7 +280,7 @@ all)
     ;;
 esac
 
-if [ ! -d ${full_dir} ]; then
+if [ ! -d "${full_dir}" ]; then
     echo No VM metadata exports were found for the selected SR >&2
     cleanup
     exit 1
@@ -271,9 +293,9 @@ ${debug} echo "" >&2
 ${debug} echo Latest VM metadata found is: >&2
 ${debug} ls >&2
 
-if [ $yes -eq 0 ]; then
+if [ "$yes" -eq 0 ]; then
    echo "Do you wish to reimport all VM metadata?" 
-   echo "Please type in "yes" and <enter> to continue." 
+   echo "Please type in 'yes' and <enter> to continue."
    read response
    if [ "$response" != "yes" ]; then
      echo Aborting metadata restore.
@@ -302,8 +324,8 @@ else
 fi
 shopt -s nullglob
 for meta in *.vmmeta; do
-   echo xe vm-import filename=${meta} sr-uuid=${sr_uuid} --metadata --preserve${force_flag}${dry_run_flag}
-   "@BINDIR@/xe" vm-import filename="${full_dir}/${meta}" sr-uuid=${sr_uuid} --metadata --preserve${force_flag}${dry_run_flag}
+   echo xe vm-import filename="${meta}" sr-uuid="${sr_uuid}" --metadata --preserve"${force_flag}""${dry_run_flag}"
+   "@BINDIR@/bin/xe" vm-import filename="${full_dir}/${meta}" sr-uuid="${sr_uuid}" --preserve"${force_flag}""${dry_run_flag}"
    if [ $? -gt 0 ]; then
       error_count=$(( $error_count + 1 ))
    else
@@ -311,16 +333,16 @@ for meta in *.vmmeta; do
    fi
 done
 
-smmeta_file=${mnt}/metadata/${chosen_metadata_dir}/SRMETA.xml
+smmeta_file="${mnt}/metadata/${chosen_metadata_dir}/SRMETA.xml"
 if [ "$restore_mode" == "all" ]; then
    cmd="@LIBEXECDIR@/restore-sr-metadata.py -f ${smmeta_file}"
 else
    cmd="@LIBEXECDIR@/restore-sr-metadata.py -u ${sr_uuid} -f ${smmeta_file}"
 fi
 
-if [ -e ${smmeta_file} ]; then
-    if [ ${dry_run} -gt 0 ]; then
-        echo ${cmd}
+if [ -e "${smmeta_file}" ]; then
+    if [ "${dry_run}" -gt 0 ]; then
+        echo "${cmd}"
     else
         ${cmd}
     fi
@@ -328,4 +350,4 @@ fi
 
 echo "Restored ${good_count} VM(s), and ${error_count} error(s)"
 cleanup
-exit ${error_count}
+exit "${error_count}"

--- a/scripts/xe-restore-metadata
+++ b/scripts/xe-restore-metadata
@@ -55,7 +55,7 @@ function usage {
 function test_sr {
   sr_uuid_found=$(${XE} sr-list uuid="$1" --minimal)
   if [ "${sr_uuid_found}" != "$1" ]; then
-     echo Invalid SR UUID specified: $1
+     echo "Invalid SR UUID specified: $1"
      usage
   fi
 }
@@ -109,11 +109,11 @@ fi
 # determine if the SR UUID is vaid
 if [  -z "${sr_uuid}" ]; then
   # use the default-SR from the pool
-  sr_uuid=$(${XE} pool-param-get uuid=${pool_uuid} param-name=default-SR)
+  sr_uuid=$(${XE} pool-param-get uuid="${pool_uuid}" param-name=default-SR)
 fi
 test_sr "${sr_uuid}"
 
-sr_name=$(${XE} sr-param-get uuid=${sr_uuid} param-name=name-label)
+sr_name=$(${XE} sr-param-get uuid="${sr_uuid}" param-name=name-label)
 
 # probe first for a VDI with known UUID derived from the SR to avoid
 # scanning for a VDI
@@ -131,20 +131,20 @@ mnt=
 function cleanup {
    cd /
    if [ ! -z "${mnt}" ]; then
-      umount ${mnt} >/dev/null 2>&1
-      rmdir ${mnt}
+      umount "${mnt}" >/dev/null 2>&1
+      rmdir "${mnt}"
       mnt=""
    fi
 
    if [ ! -z "${vbd_uuid}" ]; then
       ${debug} echo -n "Unplugging VBD: " >&2
-      ${XE} vbd-unplug uuid=${vbd_uuid} timeout=20
+      ${XE} vbd-unplug uuid="${vbd_uuid}" timeout=20
       # poll for the device to go away if we know its name
       if [ "${device}" != "" ]; then
           device_gone=0
           for ((i=0; i<10; i++)); do
               ${debug} echo -n "." >&2
-              if [ ! -b ${device} ]; then
+              if [ ! -b "${device}" ]; then
                   ${debug} echo " done" >&2
                   device_gone=1
                   break
@@ -153,9 +153,9 @@ function cleanup {
           done
           if [ ${device_gone} -eq 0 ]; then
               ${debug} echo " failed" >&2
-              ${debug} echo Please destroy VBD ${vbd_uuid} manually. >&2
+              ${debug} echo "Please destroy VBD ${vbd_uuid} manually." >&2
           else
-              ${XE} vbd-destroy uuid=${vbd_uuid}
+              ${XE} vbd-destroy uuid="${vbd_uuid}"
               vbd_uuid=""
           fi
       fi
@@ -164,7 +164,7 @@ function cleanup {
 }
 
 if [ -z "${vdis}" ]; then
-   echo No VDIs found on SR. >&2
+   echo "No VDIs found on SR." >&2
    exit 0
 fi
 
@@ -173,45 +173,44 @@ trap cleanup SIGINT ERR
 for vdi_uuid in ${vdis}; do
    if [ "${vdi_uuid}" != "${backup_vdi}" ]; then
       echo "Probing VDI ${vdi_uuid}."
-      echo "This VDI was created with a prior version of XenServer."
+      echo "This VDI was created with a prior version of this code."
       echo "Its validity can't be checked without mounting it first."
       read -p "Continue? [Y/N]" -n 1 -r; echo
       if [[ ! $REPLY =~ ^[Yy]$ ]]; then exit 1; fi
    fi
 
    ${debug} echo -n "Creating VBD: " >&2
-   vbd_uuid=$(${XE} vbd-create vm-uuid=${CONTROL_DOMAIN_UUID} vdi-uuid=${vdi_uuid} device=autodetect 2>/dev/null)
+   vbd_uuid=$(${XE} vbd-create vm-uuid="${CONTROL_DOMAIN_UUID}" vdi-uuid="${vdi_uuid}" device=autodetect 2>/dev/null)
 
    if [ $? -ne 0 -o -z "${vbd_uuid}" ]; then
-      ${debug} echo error creating VBD for VDI ${vdi_uuid} >&2
+      ${debug} echo "error creating VBD for VDI ${vdi_uuid}" >&2
       cleanup
       continue
    fi
 
-   ${debug} echo ${vbd_uuid} >&2
+   ${debug} echo "${vbd_uuid}" >&2
 
    ${debug} echo -n "Plugging VBD: " >&2
-   ${XE} vbd-plug uuid=${vbd_uuid}
-   device=/dev/$(${XE} vbd-param-get uuid=${vbd_uuid} param-name=device)
+   ${XE} vbd-plug uuid="${vbd_uuid}"
+   device=/dev/$(${XE} vbd-param-get uuid="${vbd_uuid}" param-name=device)
 
-   if [ ! -b ${device} ]; then
-     ${debug} echo ${device}: not a block special >&2
+   if [ ! -b "${device}" ]; then
+     ${debug} echo "${device}: not a block special" >&2
      cleanup
      continue
    fi
 
-   ${debug} echo ${device} >&2
+   ${debug} echo "${device}" >&2
 
    ${debug} echo -n "Probing device: " >&2
    mnt=
    if [ "$(file_exists "${device}" "/.ctxs-metadata-backup")" = y ]; then
-     ${debug} echo found metadata backup >&2
-     ${debug} echo -n "Mounting filesystem: " >&2
-     mnt=/var/run/pool-backup-${vdi_uuid}
-     mkdir -p ${mnt}
+     ${debug} echo "found metadata backup" >&2
+     mnt="/var/run/pool-backup-${vdi_uuid}"
+     mkdir -p "${mnt}"
      /sbin/e2fsck -p -f "${device}" >/dev/null 2>&1
      if [ $? -ne 0 ]; then
-        echo File system integrity error.  Please correct manually. >&2
+        echo "File system integrity error.  Please correct manually." >&2
         cleanup
         continue
      fi
@@ -221,36 +220,36 @@ for vdi_uuid in ${vdis}; do
        cleanup
      else
        if [ -e "${mnt}/.ctxs-metadata-backup" ]; then
-          ${debug} echo Found backup metadata on VDI: ${vdi_uuid} >&2
-          xe vdi-param-set uuid=${vdi_uuid} other-config:ctxs-pool-backup=true
+          ${debug} echo "Found backup metadata on VDI: ${vdi_uuid}" >&2
+          xe vdi-param-set uuid="${vdi_uuid}" other-config:ctxs-pool-backup=true
           break
        fi
      fi
    else
-     ${debug} echo backup metadata not found >&2
+     ${debug} echo "backup metadata not found" >&2
    fi
    cleanup
 done
 
 if [ $just_probe -gt 0 ]; then
-   echo ${vdi_uuid}
+   echo "${vdi_uuid}"
    cleanup
    exit 0
 fi
 
-cd ${mnt}
+cd "${mnt}"
 ${debug} echo "" >&2
 
-if [ ! -d ${mnt}/metadata ]; then
-   echo Metadata backups not found. >&2
+if [ ! -d "${mnt}/metadata" ]; then
+   echo "Metadata backups not found." >&2
    cleanup
    exit 1
 fi
 
-cd ${mnt}/metadata
+cd "${mnt}/metadata"
 
-if [ $just_list_dates -gt 0 ]; then
-    ls -1r ${mnt}/metadata
+if [ "$just_list_dates" -gt 0 ]; then
+    ls -1r "${mnt}/metadata"
     cleanup
     exit 0
 fi
@@ -258,39 +257,39 @@ fi
 if [ -z "${chosen_date}" ]; then
     chosen_metadata_dir=$(ls | sort -n | tail -1)
     if [ -z "${chosen_metadata_dir}" ]; then
-       echo No VM metadata backups found in ${mnt}/metadata >&2
+       echo "No VM metadata backups found in ${mnt}/metadata" >&2
        cleanup
        exit 1
     fi
 else
-    if [ ! -d ${mnt}/metadata/${chosen_date} ]; then
-       echo Date directory "${chosen_date}" not found >&2
+    if [ ! -d "${mnt}/metadata/${chosen_date}" ]; then
+       echo "Date directory ${chosen_date} not found" >&2
        cleanup
        exit 1
     fi
-    chosen_metadata_dir=${chosen_date}
+    chosen_metadata_dir="${chosen_date}"
 fi
 
 case ${restore_mode} in
 sr)
-    full_dir=${mnt}/metadata/${chosen_metadata_dir}/by-sr/${sr_uuid}
+    full_dir="${mnt}/metadata/${chosen_metadata_dir}/by-sr/${sr_uuid}"
     ;;
 all)
-    full_dir=${mnt}/metadata/${chosen_metadata_dir}/all
+    full_dir="${mnt}/metadata/${chosen_metadata_dir}/all"
     ;;
 esac
 
 if [ ! -d "${full_dir}" ]; then
-    echo No VM metadata exports were found for the selected SR >&2
+    echo "No VM metadata exports were found for the selected SR" >&2
     cleanup
     exit 1
 fi
 
-${debug} echo Selected: ${full_dir}
+${debug} echo "Selected: ${full_dir}"
 
-cd ${full_dir}
+cd "${full_dir}"
 ${debug} echo "" >&2
-${debug} echo Latest VM metadata found is: >&2
+${debug} echo "Latest VM metadata found is": >&2
 ${debug} ls >&2
 
 if [ "$yes" -eq 0 ]; then
@@ -298,14 +297,14 @@ if [ "$yes" -eq 0 ]; then
    echo "Please type in 'yes' and <enter> to continue."
    read response
    if [ "$response" != "yes" ]; then
-     echo Aborting metadata restore.
+     echo "Aborting metadata restore."
      cleanup
      exit 1
    fi
 fi
 
 ${debug} echo "" >&2
-${debug} echo Restoring VM metadata: >&2
+${debug} echo "Restoring VM metadata:" >&2
 
 trap - ERR
 

--- a/scripts/xe-restore-metadata
+++ b/scripts/xe-restore-metadata
@@ -171,7 +171,7 @@ fi
 trap cleanup SIGINT ERR
 
 for vdi_uuid in ${vdis}; do
-   if [ "${vdi_uuid}" != "${backup_vdi}" ]; then
+   if [ "${vdi_uuid}" != "${backup_vdi}" ] && [ "$yes" -eq 0 ]; then
       echo "Probing VDI ${vdi_uuid}."
       echo "This VDI was created with a prior version of this code."
       echo "Its validity can't be checked without mounting it first."


### PR DESCRIPTION
We want to use a predictable VDI for metadata backup. This is the backport of that feature to Yangtze. 

* The existing shell scripts differ slightly between the branches and I've kept these changes.
* The UUIDX module does not exist in Yangtze; I created a minimal implementation for this backport to get UUIDv5.