### PR TITLE
CA-391485: Avoid InterpolationSyntaxError by turning off interpolation

### DIFF
--- a/python3/packages/observer.py
+++ b/python3/packages/observer.py
@@ -71,7 +71,7 @@ def _get_configs_list(config_dir):
 def read_config(config_path, header):
     """Read a config file and return a dictionary of key-value pairs."""
 
-    parser = configparser.ConfigParser()
+    parser = configparser.ConfigParser(interpolation=None)
     with open(config_path, encoding="utf-8") as config_file:
         try:
             parser.read_string(f"[{header}]\n{config_file.read()}")


### PR DESCRIPTION
OTEL_RESOURCE_ATTRIBUTES is in W3CBaggageFormat and thus uses %. ConfigParser attempts to interpolate these % signs but we want them to be left alone, so set interpolation=None