### PR TITLE
Remove _t suffix for syslog_stdout_t type

### DIFF
--- a/ocaml/forkexecd/lib/fe.ml
+++ b/ocaml/forkexecd/lib/fe.ml
@@ -1,13 +1,13 @@
 (* Disable "Warning 39: unused rec flag." caused by rpc *)
 [@@@warning "-39"]
 
-type syslog_stdout_t = {enabled: bool; key: string option} [@@deriving rpc]
+type syslog_stdout = {enabled: bool; key: string option} [@@deriving rpc]
 
 type setup_cmd = {
     cmdargs: string list
   ; env: string list
   ; id_to_fd_map: (string * int option) list
-  ; syslog_stdout: syslog_stdout_t
+  ; syslog_stdout: syslog_stdout
   ; redirect_stderr_to_stdout: bool
 }
 [@@deriving rpc]

--- a/ocaml/forkexecd/lib/forkhelpers.ml
+++ b/ocaml/forkexecd/lib/forkhelpers.ml
@@ -171,7 +171,7 @@ let with_logfile_fd ?(delete = true) prefix f =
 
 exception Spawn_internal_error of string * string * Unix.process_status
 
-type syslog_stdout_t =
+type syslog_stdout =
   | NoSyslogging
   | Syslog_DefaultKey
   | Syslog_WithKey of string

--- a/ocaml/forkexecd/lib/forkhelpers.mli
+++ b/ocaml/forkexecd/lib/forkhelpers.mli
@@ -34,7 +34,7 @@
 
 (** {2 High-level interface } *)
 
-type syslog_stdout_t =
+type syslog_stdout =
   | NoSyslogging
   | Syslog_DefaultKey
   | Syslog_WithKey of string
@@ -45,7 +45,7 @@ val default_path_env_pair : string array
 
 val execute_command_get_output :
      ?env:string array
-  -> ?syslog_stdout:syslog_stdout_t
+  -> ?syslog_stdout:syslog_stdout
   -> ?redirect_stderr_to_stdout:bool
   -> ?timeout:float
   -> string
@@ -57,7 +57,7 @@ val execute_command_get_output :
 
 val execute_command_get_output_send_stdin :
      ?env:string array
-  -> ?syslog_stdout:syslog_stdout_t
+  -> ?syslog_stdout:syslog_stdout
   -> ?redirect_stderr_to_stdout:bool
   -> ?timeout:float
   -> string
@@ -97,7 +97,7 @@ val safe_close_and_exec :
   -> Unix.file_descr option
   -> Unix.file_descr option
   -> (string * Unix.file_descr) list
-  -> ?syslog_stdout:syslog_stdout_t
+  -> ?syslog_stdout:syslog_stdout
   -> ?redirect_stderr_to_stdout:bool
   -> string
   -> string list

--- a/ocaml/forkexecd/src/child.ml
+++ b/ocaml/forkexecd/src/child.ml
@@ -3,13 +3,13 @@ let debug (fmt : ('a, unit, string, unit) format4) =
 
 exception Cancelled
 
-type syslog_stdout_t = {enabled: bool; key: string option}
+type syslog_stdout = {enabled: bool; key: string option}
 
 type state_t = {
     cmdargs: string list
   ; env: string list
   ; id_to_fd_map: (string * int option) list
-  ; syslog_stdout: syslog_stdout_t
+  ; syslog_stdout: syslog_stdout
   ; redirect_stderr_to_stdout: bool
   ; ids_received: (string * Unix.file_descr) list
   ; fd_sock2: Unix.file_descr option


### PR DESCRIPTION
There's no need for suffix, Ocaml has different namespace for types. This was suggested as part of a code review.