### PR TITLE
CA-391880: Update related field 'groups' of VM when destroying VM group.

### DIFF
--- a/ocaml/xapi/xapi_vm_group.ml
+++ b/ocaml/xapi/xapi_vm_group.ml
@@ -21,4 +21,8 @@ let create ~__context ~name_label ~name_description ~placement =
     ~name_description ~placement ;
   ref
 
-let destroy ~__context ~self = Db.VM_group.destroy ~__context ~self
+let destroy ~__context ~self =
+  List.iter
+    (fun vm -> Db.VM.remove_groups ~__context ~self:vm ~value:self)
+    (Db.VM_group.get_VMs ~__context ~self) ;
+  Db.VM_group.destroy ~__context ~self


### PR DESCRIPTION
In VM anti-affinity [datamodel PR](https://github.com/xapi-project/xen-api/pull/5546), there is many-many relation between VMs and VM groups. When changing the VM.groups manually, the VM_group.VMs will be updated automatically. But when removing a VM group, the VM.groups will not be updated automatically. This commit aims to update VM.groups for all VMs in a VM group when it is being removed.