### PR TITLE
ci: remove warnings about outdated node versions (yangtze)

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -14,7 +14,7 @@ jobs:
         test: ["", "-3"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run python tests
         run: bash .github/python-nosetests${{ matrix.test }}.sh
@@ -22,12 +22,14 @@ jobs:
   ocaml-test:
     name: Ocaml tests
     runs-on: ubuntu-20.04
-    env:
-      package: "xapi-cli-protocol xapi-client xapi-consts xapi-database xapi-datamodel xapi-types xapi xe"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Free space
+        shell: bash
+        run: sudo rm -rf /usr/local/lib/android
 
       - name: Pull configuration from xs-opam
         run: |
@@ -35,39 +37,26 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
-
-      - name: Retrieve date for cache key (year-week)
-        id: cache-key
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%W")"
-        shell: bash
-
-      - name: Restore opam cache
-        id: opam-cache
-        uses: actions/cache@v2
-        with:
-          path: "~/.opam"
-          # invalidate cache every week, gets built using a scheduled job
-          key: ${{ steps.cache-key.outputs.date }}-1.249
+        uses: falti/dotenv-action@v1
 
       - name: Update Ubuntu repositories
+        shell: bash
         run: sudo apt-get update
 
       - name: Use ocaml
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
-          opam-repository: ${{ steps.dotenv.outputs.repository }}
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
+          dune-cache: true
 
       - name: Install dependencies
-        run: |
-          opam update
-          opam pin add . --no-action
-          opam depext -u ${{ env.package }}
-          opam upgrade
-          opam install ${{ env.package }} --deps-only --with-test -v
+        shell: bash
+        run: opam install . --deps-only --with-test -v
 
-      - name: Build
+      - name: Configure and build
+        shell: bash
         run: |
           opam exec -- ./configure
           opam exec -- make
@@ -80,4 +69,4 @@ jobs:
       - name: Avoid built packages to appear in the cache
         # only packages in this repository follow a branch, the rest point
         # to a tag
-        run: opam uninstall ${{ env.package }}
+        run: opam pin list --short | xargs opam unpin

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Pull configuration from xs-opam
         run: |
@@ -22,21 +22,23 @@ jobs:
 
       - name: Load environment file
         id: dotenv
-        uses: falti/dotenv-action@v0.2.7
+        uses: falti/dotenv-action@v1
 
       - name: Update Ubuntu repositories
         run: sudo apt-get update
 
       - name: Use ocaml
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
-          opam-repository: ${{ steps.dotenv.outputs.repository }}
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
+          dune-cache: true
+          opam-pin: false
+          opam-depext: false
 
       - name: Install ocamlformat
-        run: |
-          opam update
-          opam install ocamlformat
+        run: opam install ocamlformat
 
       - name: Check whether `make format` was run
         run: opam exec -- dune build @fmt


### PR DESCRIPTION
This needs updating the ocaml action, which might or might not need more disk space. I've added the disk-cleaning step just in case.

There's an equivalent PR for master branch, but it needs to change the scheduled run for yangtze, and it's easier to test it here/