### PR TITLE
ci: reduce noise generated for PRs

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -25,14 +25,16 @@ jobs:
   ocaml-test:
     name: Ocaml tests
     runs-on: ubuntu-20.04
-    env:
-      package: "xapi-cli-protocol xapi-client xapi-consts xapi-database xapi-datamodel xapi-types xapi xe"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: '1.249-lcm'
+
+      - name: Free space
+        shell: bash
+        run: sudo rm -rf /usr/local/lib/android
 
       - name: Pull configuration from xs-opam
         run: |
@@ -42,37 +44,24 @@ jobs:
         id: dotenv
         uses: falti/dotenv-action@v1
 
-      - name: Retrieve date for cache key (year-week)
-        id: cache-key
-        run: echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Restore opam cache
-        id: opam-cache
-        uses: actions/cache@v4
-        with:
-          path: "~/.opam"
-          # invalidate cache every week, gets built using a scheduled job
-          key: ${{ steps.cache-key.outputs.date }}-1.249
-
       - name: Update Ubuntu repositories
+        shell: bash
         run: sudo apt-get update
 
       - name: Use ocaml
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
-          opam-repository: ${{ steps.dotenv.outputs.repository }}
+          ocaml-compiler: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repositories: |
+            xs-opam: ${{ steps.dotenv.outputs.repository }}
+          dune-cache: true
 
       - name: Install dependencies
-        run: |
-          opam update
-          opam pin add . --no-action
-          opam depext -u ${{ env.package }}
-          opam upgrade
-          opam install ${{ env.package }} --deps-only --with-test -v
+        shell: bash
+        run: opam install . --deps-only --with-test -v
 
-      - name: Build
+      - name: Configure and build
+        shell: bash
         run: |
           opam exec -- ./configure
           opam exec -- make
@@ -85,4 +74,4 @@ jobs:
       - name: Avoid built packages to appear in the cache
         # only packages in this repository follow a branch, the rest point
         # to a tag
-        run: opam uninstall ${{ env.package }}
+        run: opam pin list --short | xargs opam unpin

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
           opam exec -- dune exec ocaml/xapi-storage/generator/src/main.exe -- gen_markdown --path=$STORAGE_DOCDIR
 
       - name: Deploy xapi-storage docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.ACTIONS_STORAGE_DEPLOY_KEY }}
           publish_dir: ${{ env.STORAGE_DOCDIR }}

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.119.0'
 
@@ -24,7 +24,7 @@ jobs:
           hugo --minify
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.ACTIONS_DOCS_DEPLOY_KEY }}
           publish_dir: ./doc/public

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
           level: warning
           # To be customized to cover remaining Python scripts:
           glob_pattern: "**/*.py"
+        continue-on-error: true
 
       - name: Run pytype checks
         if: ${{ matrix.python-version != '2.7' }}
@@ -106,6 +107,13 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTYPE_REPORTER_DEBUG: True
+
+      - name: pyflakes
+        uses: reviewdog/action-pyflakes@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+        continue-on-error: true
+
 
   ocaml-tests:
     name: Run OCaml tests
@@ -161,13 +169,6 @@ jobs:
 
       - name: quality-gate
         run: make quality-gate
-
-      - name: pyflakes
-        uses: reviewdog/action-pyflakes@master
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-          level: error
 
   test-sdk-builds:
     name: Test SDK builds

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - run: echo "::add-matcher::.github/workflows/python-warning-matcher.json"
         name: "Setup GitHub for reporting Python warnings as annotations in pull request code review"
 
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
         name: Run pre-commit checks (no spaces at end of lines, etc)
         if: ${{ matrix.python-version != '2.7' }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,17 +107,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTYPE_REPORTER_DEBUG: True
 
-      # Try to add pytype_report.py's summary file as a comment to the PR:
-      # Documentation: https://github.com/marketplace/actions/add-pr-comment
-      - name: Add the pytype summary as a comment to the PR (if permitted)
-        uses: mshick/add-pr-comment@v2
-        # Depends on pytype checks, which are not run for python 2.7:
-        if: ${{ matrix.python-version != '2.7' }}
-        # Fails for user workflows without permissions(fork-based pull requests):
-        continue-on-error: true
-        with:
-          message-path: .git/pytype-summary.md # Add the content of it as comment
-
   ocaml-tests:
     name: Run OCaml tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install dependencies only needed for python 3
         if: ${{ matrix.python-version != '2.7' }}
-        run: pip install pandas pytype toml wrapt
+        run: pip install opentelemetry-api opentelemetry-exporter-zipkin-json opentelemetry-sdk pandas pytype toml wrapt
 
       - name: Install common dependencies for Python ${{matrix.python-version}}
         run: pip install future mock pytest-coverage pytest-mock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,65 +236,16 @@ discard_messages_matching = [
     "No attribute 'group' on None",
     "No Node.TEXT_NODE in module xml.dom.minidom, referenced from 'xml.dom.expatbuilder'"
 ]
-expected_to_fail = [
-    "scripts/hfx_filename",
-    "scripts/perfmon",
-    # Need 2to3 -w <file> and maybe a few other minor updates:
-    "scripts/hatests",
-    "scripts/backup-sr-metadata.py",
-    "scripts/restore-sr-metadata.py",
-    "scripts/nbd_client_manager.py",
-    # No attribute 'popen2' on module 'os' [module-attr] and a couple more:
-    "scripts/mail-alarm",
-    # SSLSocket.send() only accepts bytes, not unicode string as argument:
-    "scripts/examples/python/exportimport.py",
-    # Other fixes needed:
-    "scripts/examples/python/mini-xenrt.py",
-    "scripts/examples/python/XenAPI/XenAPI.py",
-    "scripts/examples/python/monitor-unwanted-domains.py",
-    "scripts/examples/python/shell.py",
-    "scripts/examples/smapiv2.py",
-    "scripts/static-vdis",
-    # add_interface: unsupported operand type(s) for +: str and UsbInterface
-    "scripts/usb_scan.py",
-    # TestUsbScan.assertIn() is called with wrong arguments(code not iterable)
-    "scripts/test_usb_scan.py",
-    "scripts/plugins/extauth-hook-AD.py",
-]
+expected_to_fail = []
 
 
 [tool.pytype]
 inputs = [
-    "scripts/hfx_filename",
-    "scripts/perfmon",
-    "scripts/static-vdis",
-    "scripts/Makefile",
-    "scripts/generate-iscsi-iqn",
-    "scripts/hatests",
-    "scripts/host-display",
-    "scripts/mail-alarm",
-    "scripts/print-custom-templates",
-    "scripts/probe-device-for-file",
-    "scripts/xe-reset-networking",
-    "scripts/xe-scsi-dev-map",
-    "scripts/examples/python",
-    "scripts/yum-plugins",
-    "scripts/*.py",
-    "python3/packages/*.py",
-
-    # To be added later,
-    # when converted to Python3-compatible syntax:
-    # "ocaml/message-switch/python",
-    # "ocaml/idl/ocaml_backend/python",
-    # "ocaml/xapi-storage/python",
+    "python3/",
+    "ocaml/xcp-rrdd",
 ]
 disable = [
-    "import-error",  # xenfsimage, xcp.bootloader. xcp.cmd
-    "ignored-abstractmethod",
-    "ignored-metaclass",
-    # https://github.com/google/pytype/issues/1130,
-    # https://github.com/google/pytype/issues/1485:
-    "pyi-error",
 ]
 platform = "linux"
-pythonpath = "scripts/examples/python:.:scripts:scripts/plugins:scripts/examples"
+# Allow pytype to find the XenAPI module, the rrdd module and python3 modules:
+pythonpath = "python3:scripts/examples/python:ocaml/xcp-rrdd/scripts/rrdd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # https://packaging.python.org/en/latest/specifications/pyproject-toml/
 [project]
 name = "xen-api"
-requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+requires-python = ">=3.6.*"
 license = {file = "LICENSE"}
 keywords = ["xen-project", "Xen", "hypervisor", "libraries"]
 maintainers = [
@@ -27,13 +27,71 @@ repository = "https://github.com/xapi-project/xen-api"
 [tool.black]
 line-length = 88
 
+
+# -----------------------------------------------------------------------------
+# Coverage.py - https://coverage.readthedocs.io/en/coverage-5.5/config.html
+# -----------------------------------------------------------------------------
+
+[tool.coverage.report]
+# Here, developers can configure which lines do not need to be covered by tests:
+exclude_lines = [
+    "pragma: no cover",  # standard pragma for not covering a line or block
+    "if TYPE_CHECKING:", # imports for type checking only
+    "pass",
+    # Other specific lines that do not need to be covered, comment in which file:
+]
+# precision digits to use when reporting coverage (sub-percent-digits are not reported):
+precision = 0
+# skip_covered: Skip reporting files with 100% coverage:
+skip_covered = true
+
+
+[tool.coverage.run]
+# Default command line for "coverage run": Run pytest in non-verbose mode
+command_line = "-m pytest -p no:logging -p no:warnings"
+# Default data file for "coverage run": Store coverage data in .git/.coverage
+data_file = ".git/.coverage"
+# Default context for "coverage run": Use the name of the test function
+dynamic_context = "test_function"
+# Default omit patterns for "coverage run": Omit test files and test directories
+omit = [
+    "python3/bin/__init__.py",
+    "python3/packages/__init__.py",
+    # omit tests anything in a test directory (focus on the code)
+    "python3/tests",
+    "scripts/test_*.py",
+    # omit anything in a .local directory anywhere
+    "*/.local/*",
+    # omit everything in /usr
+    "/usr/*",
+]
+relative_files = true
+
+
+# Default output when writing "coveragle xml" data. This needs to match what
+# diff-cover and coverage upload to Codecov expect
+[tool.coverage.xml]
+output = ".git/coverage.xml"
+
+
+# Default output directory for writing "coverage html" data.
+# Create it outside the source tree to avoid cluttering the source tree
+[tool.coverage.html]
+directory = ".git/coverage_html"
+show_contexts = true
+
+
 [tool.isort]
 line_length = 88
-py_version = 27
+py_version = 36
 profile = "black"
 combine_as_imports = true
 ensure_newline_before_comments = false
 
+
+# -----------------------------------------------------------------------------
+# Mypy static analysis - https://mypy.readthedocs.io/en/stable/config_file.html
+# -----------------------------------------------------------------------------
 
 [tool.mypy]
 # Note mypy has no config setting for PYTHONPATH, so you need to call it with:
@@ -59,6 +117,115 @@ disallow_any_explicit = false
 disallow_any_generics = true
 disallow_any_unimported = true
 disallow_subclassing_any = true
+disable_error_code = ["import-untyped"]  # XenAPI is not typed yet
+
+
+[[tool.mypy.overrides]]
+module = ["packages.observer"]
+disable_error_code = [
+    "arg-type",  # mypy does not know that the Context class is actually a dict
+    "override",  # Typing problem in the used library
+    "misc",
+    "no-any-unimported",
+]
+
+
+# -----------------------------------------------------------------------------
+# Pylint - https://pylint.pycqa.org/en/latest/technical_reference/features.html
+# -----------------------------------------------------------------------------
+
+[tool.pylint.design]
+max-branches = 43                  # perfmon has 43 branches in a function
+
+
+[tool.pylint.messages_control]
+# These are safe to disable, fixing them is best done during a later code cleanup phases
+disable = [
+    "broad-exception-caught",
+    "no-else-break",
+    "no-else-return",
+    "consider-using-f-string",     # f-strings is the big new feature of Python 3.6,
+    "consider-using-with",         # but like with, best done during code cleanup phase
+    "duplicate-code",              # likewise. This is a code cleanup task
+    "import-error",                # pylint does not do inter-procedural analysis
+    "invalid-name",                # doesn't conform to snake_case naming style
+    "missing-function-docstring",  # Best done in the code documentation phase
+    "missing-module-docstring",    # Likewise, best done in the code documentation phase
+    "missing-class-docstring",     # Likewise, best done in the code documentation phase
+    "no-member",                   # Existing code breaches this, not part of porting
+    "no-else-break",               # else clause following a break statement
+    "protected-access",            # Best done during the code cleanup phase
+    "super-with-arguments",        # Consider using Python 3 style super(no args) calls
+    "too-many-branches",           # Existing code breaches this, not part of porting
+    "too-many-arguments",          # Likewise, not part of porting
+    "too-many-locals",             # Likewise, not part of porting
+    "too-many-statements",         # Likewise, not part of porting
+    "unnecessary-pass",            # Cosmetic, best done during the code cleanup phase
+    "useless-object-inheritance",  # Useless object inheritance from object, likewise
+]
+
+
+# -----------------------------------------------------------------------------
+# Pyright is the static analysis behind the VSCode Python extension / Pylance
+# https://microsoft.github.io/pyright/#/configuration?id=main-configuration-options
+# -----------------------------------------------------------------------------
+
+[tool.pyright]
+# Specifies the paths of directories or files that should be included in the
+# analysis. If no paths are specified, all files in the workspace are included:
+include = ["python3", "ocaml/xcp-rrdd"]
+
+# Conditionalize the stube files for type definitions based on the platform:
+pythonPlatform = "Linux"
+
+# typeCheckingMode: "off", "basic", "standard" or "strict"
+typeCheckingMode = "standard"
+
+# Specifies the version of Python that will be used to execute the source code.
+# Generate errors if the source code makes use of language features that are
+# not supported in that version. It will also tailor its use of type stub files,
+# which conditionalizes type definitions based on the version. If no version is
+# specified, pyright will use the version of the current python interpreter,
+# if one is present:
+pythonVersion = "3.6"
+
+# Paths of directories or files that should use "strict" analysis if they are
+# included. This is the same as manually adding a "# pyright: strict" comment.
+# In strict mode, most type-checking rules are enabled, and the type-checker
+# will be more aggressive in inferring types. If no paths are specified, strict
+# mode is not enabled:
+strict = ["python3/tests/test_observer.py"]
+
+#
+# Paths to exclude from analysis. If a file is excluded, it will not be
+# analyzed.
+#
+# FIXME: Some of these may have type errors, so they should be inspected and fixed:
+#
+exclude = [
+    "ocaml/xcp-rrdd/scripts/rrdd/rrdd.py",
+    "ocaml/xcp-rrdd/scripts/rrdd/rrdd-example.py",
+    "python3/packages/observer.py",
+    "python3/tests/pytype_reporter.py",
+]
+
+
+# -----------------------------------------------------------------------------
+# Pytest is the test framework, for discovering and running tests, fixtures etc
+# https://pytest.readthedocs.io/en/latest/customize.html
+# -----------------------------------------------------------------------------
+
+
+[tool.pytest.ini_options]
+addopts = "-ra" # Show the output of all tests, including those that passed
+log_cli = true  # Capture log messages and show them in the output as well
+log_cli_level = "INFO"
+python_files = ["test_*.py", "it_*.py"]
+python_functions = ["test_", "it_", "when_"]
+pythonpath = "scripts/examples/python"  # Allows to import the XenAPI module
+required_plugins = ["pytest-mock"]
+testpaths = ["python3", "scripts", "ocaml/xcp-rrdd"]
+xfail_strict = true  # is used to fail tests that are marked as xfail but pass(for TDD)
 
 
 [tool.pytype_reporter]

--- a/python3/packages/observer.py
+++ b/python3/packages/observer.py
@@ -401,18 +401,25 @@ def main():
             return 0
         except FileNotFoundError as e:
             print(
-                f"{__file__}: {' '.join(sys.argv)}\n{e.filename}: No such file",
+                f"{__file__} {' '.join(sys.argv)}:\nScript not found: {e.filename}",
                 file=sys.stderr,
             )
             return 2
-        except Exception:
-            print(
-                f"{__file__}: {' '.join(sys.argv)}\n{traceback.format_exc()}",
-                file=sys.stderr)
+        except Exception as e:
+            print(f"{__file__} {' '.join(sys.argv)}:", file=sys.stderr)  # the command
+            print("Exception in the traced script:", file=sys.stderr)
+            print(e, file=sys.stderr)  # Print the exception message
+            print(traceback.format_exc(), file=sys.stderr)  # Print the traceback
             return 139  # This is what the default SIGSEGV handler on Linux returns
 
     return run(argv0)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Only use sys.exit(ret) raising SystemExit() if the return code is not 0
+    # to allow test_observer_as_script() to get the globals of observer.py:
+
+    exit_code = main()  # pylint: disable=invalid-name
+    logging.shutdown()  # Reduces the unclosed socket warnings by PYTHONDEVMODE=yes
+    if exit_code:
+        sys.exit(exit_code)

--- a/python3/tests/test_observer.py
+++ b/python3/tests/test_observer.py
@@ -12,17 +12,6 @@ with patch("os.listdir") as mock_listdir:
     mock_listdir.return_value = []
     from packages import observer
 
-# mock modules to avoid dependencies
-sys.modules["opentelemetry"] = MagicMock()
-sys.modules["opentelemetry.sdk.resources"] = MagicMock()
-sys.modules["opentelemetry.sdk.trace"] = MagicMock()
-sys.modules["opentelemetry.sdk.trace.export"] = MagicMock()
-sys.modules["opentelemetry.exporter.zipkin.json"] = MagicMock()
-sys.modules["opentelemetry.baggage.propagation"] = MagicMock()
-sys.modules["opentelemetry.trace.propagation.tracecontext"] = MagicMock()
-sys.modules["opentelemetry.context"] = MagicMock()
-sys.modules["opentelemetry.trace"] = MagicMock()
-
 TEST_CONFIG = """
     XS_EXPORTER_BUGTOOL_ENDPOINT='/var/log/dt/test'
     OTEL_SERVICE_NAME='test-observer'
@@ -31,10 +20,43 @@ TEST_CONFIG = """
 TEST_OBSERVER_CONF = "test-observer.conf"
 OBSERVER_OPEN = "packages.observer.open"
 
+#
+# These are the modules that are mocked to avoid dependencies.
+# Note: wrapt is not mocked: It is used to wrap the traced script.
+# These modules are not imported at the top of observer.py, but are
+# imported inside the observer._init_tracing(). This is why they are mocked
+# in the test class before calling observer._init_tracing() and then deleted
+# in the tearDown of the test class to avoid affecting other tests.
+#
+MOCKED_MODULES = [
+    "opentelemetry",
+    "opentelemetry.sdk.resources",
+    "opentelemetry.sdk.trace",
+    "opentelemetry.sdk.trace.export",
+    "opentelemetry.exporter.zipkin.json",
+    "opentelemetry.baggage.propagation",
+    "opentelemetry.trace.propagation.tracecontext",
+    "opentelemetry.context",
+    "opentelemetry.trace",
+]
+
 
 # pylint: disable=missing-function-docstring,protected-access
 class TestObserver(unittest.TestCase):
     """Test python3/packages/observer.py"""
+
+    def setUp(self) -> None:
+        # As setup for this class, mock modules to avoid dependencies
+        for mock in MOCKED_MODULES:
+            sys.modules[mock] = MagicMock()
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        # On teardown, delete mocks so they do not affect other tests
+        # Otherwise, the mocks will be used in other tests and cause errors
+        for mock in MOCKED_MODULES:
+            del sys.modules[mock]
+        return super().tearDown()
 
     def simple_method(self):
         """A simple helper method for tests to wrap using observer.span"""

--- a/pytype_reporter.py
+++ b/pytype_reporter.py
@@ -601,11 +601,13 @@ def main():
     config.setdefault("expected_to_fail", [])
     debug("Expected to fail: %s", ", ".join(config["expected_to_fail"]))
 
-    changed_but_in_expected_to_fail = git_diff(
-        "--name-only",
-        find_branch_point(config),
-        *config["expected_to_fail"],
-    ).splitlines()
+    changed_but_in_expected_to_fail = []
+    if config["expected_to_fail"] != []:
+        changed_but_in_expected_to_fail = git_diff(
+            "--name-only",
+            find_branch_point(config),
+            *config["expected_to_fail"],
+        ).splitlines()
 
     if check_only_reverts_from_branch_point(config, changed_but_in_expected_to_fail):
         return run_pytype_and_generate_summary(config)


### PR DESCRIPTION
Current CI setup generates a lot of messages for master branch which are not relevant: deprecation warnings regarding node, annotations produced for python2 code which is yet to be cleaned up, and comments with sometimes thousands of lines long after the PRs are merged.

This PR tries to remove all of them. This needs reviewing by the team doing the python3 porting to confirm this won't harm their efforts. I've adapted Bernhard's PR #5504 to include the current ignored issues to reduce friction, but it might need another pass. @liulinC @stephenchengCloud 

The changes in the LCM CI follow the ones in #5574


TODO:
- [x] Check why the Python coverage gates fail