### PR TITLE
IH-553: Optimize Sexpr.{escape,unescape}

### DIFF
--- a/ocaml/libs/sexpr/sExpr.ml
+++ b/ocaml/libs/sexpr/sExpr.ml
@@ -27,6 +27,8 @@ let unescape_buf buf s =
   if Astring.String.fold_left aux false s then
     Buffer.add_char buf '\\'
 
+let is_escape_char = function '\\' | '"' | '\'' -> true | _ -> false
+
 (* XXX: This escapes "'c'" and "\'c\'" to "\\'c\\'".
  * They are both unescaped as "'c'". They have been ported
  * to make sure that this corner case is left unchanged.
@@ -36,21 +38,24 @@ let unescape_buf buf s =
  * that have guaranteed invariants and optimised performances *)
 let escape s =
   let open Astring in
-  let escaped = Buffer.create (String.length s + 10) in
-  String.iter
-    (fun c ->
-      match c with
-      | '\\' ->
-          Buffer.add_string escaped "\\\\"
-      | '"' ->
-          Buffer.add_string escaped "\\\""
-      | '\'' ->
-          Buffer.add_string escaped "\\\'"
-      | _ ->
-          Buffer.add_char escaped c
-    )
-    s ;
-  Buffer.contents escaped
+  if String.exists is_escape_char s then (
+    let escaped = Buffer.create (String.length s + 10) in
+    String.iter
+      (fun c ->
+        match c with
+        | '\\' ->
+            Buffer.add_string escaped "\\\\"
+        | '"' ->
+            Buffer.add_string escaped "\\\""
+        | '\'' ->
+            Buffer.add_string escaped "\\\'"
+        | _ ->
+            Buffer.add_char escaped c
+      )
+      s ;
+    Buffer.contents escaped
+  ) else
+    s
 
 let unescape s =
   let buf = Buffer.create (String.length s) in

--- a/ocaml/libs/sexpr/sExpr.ml
+++ b/ocaml/libs/sexpr/sExpr.ml
@@ -39,18 +39,15 @@ let escape s =
   let escaped = Buffer.create (String.length s + 10) in
   String.iter
     (fun c ->
-      let c' =
-        match c with
-        | '\\' ->
-            "\\\\"
-        | '"' ->
-            "\\\""
-        | '\'' ->
-            "\\\'"
-        | _ ->
-            Astring.String.of_char c
-      in
-      Buffer.add_string escaped c'
+      match c with
+      | '\\' ->
+          Buffer.add_string escaped "\\\\"
+      | '"' ->
+          Buffer.add_string escaped "\\\""
+      | '\'' ->
+          Buffer.add_string escaped "\\\'"
+      | _ ->
+          Buffer.add_char escaped c
     )
     s ;
   Buffer.contents escaped

--- a/ocaml/libs/sexpr/sExpr.ml
+++ b/ocaml/libs/sexpr/sExpr.ml
@@ -58,8 +58,11 @@ let escape s =
     s
 
 let unescape s =
-  let buf = Buffer.create (String.length s) in
-  unescape_buf buf s ; Buffer.contents buf
+  if String.contains s '\\' then (
+    let buf = Buffer.create (String.length s) in
+    unescape_buf buf s ; Buffer.contents buf
+  ) else
+    s
 
 let mkstring x = String (unescape x)
 


### PR DESCRIPTION
It was allocating a string for each character, only to then immediately add it to a buffer. Instead add the character to the buffer directly.

The temporary string was probably created to factor out 'Buffer.add', but I'd rather copy Buffer.add 4x times than have the perf hit.

Further optimizations might be possible here as the comments says, but this is a low-risk, obvious optimization.

Before (see how Buffer.add_string and caml_alloc_string take up quite a bit of time):
<img width="1229" alt="Screenshot 2024-04-19 at 17 20 17" src="https://github.com/xapi-project/xen-api/assets/721894/b0eca8f6-e155-4f5d-8009-61e771baab14">

After: (Buffer.add_string completely gone, no more alloc_string, and the Sexpr.escape is narrower)
<img width="1231" alt="Screenshot 2024-04-19 at 17 19 53" src="https://github.com/xapi-project/xen-api/assets/721894/b0c489e9-3570-4841-9740-b6e3c0814f40">

In fact we can take this a bit further and check for the presence of escapable characters when escaping and for the presence of the escape character when unescaping. Notice how Sexpr.escape is a lot narrower now, and Sexpr.unescape has disappeared from the flamegraph:
<img width="1215" alt="Screenshot 2024-04-19 at 17 41 17" src="https://github.com/xapi-project/xen-api/assets/721894/47f1604a-11ee-4e40-a904-f824bb6d169e">
