### PR TITLE
CP-47302: VM start with anti-affinity

### DIFF
--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -35,6 +35,12 @@ module SRSet = Set.Make (struct
   let compare = Stdlib.compare
 end)
 
+module RefMap = Map.Make (struct
+  type t = [`host] Ref.t
+
+  let compare = Ref.compare
+end)
+
 let compute_memory_overhead ~__context ~vm =
   let vm_record = Db.VM.get_record ~__context ~self:vm in
   Memory_check.vm_compute_memory_overhead ~vm_record
@@ -931,6 +937,20 @@ let vm_can_run_on_host ~__context ~vm ~snapshot ~do_memory_check host =
     && host_evacuate_in_progress
   with _ -> false
 
+let vm_has_anti_affinity ~__context ~vm =
+  List.find_opt
+    (fun g -> Db.VM_group.get_placement ~__context ~self:g = `anti_affinity)
+    (Db.VM.get_groups ~__context ~self:vm)
+  |> Option.map (fun group ->
+         debug
+           "The VM (uuid %s) is associated with an anti-affinity group (uuid: \
+            %s, name: %s)"
+           (Db.VM.get_uuid ~__context ~self:vm)
+           (Db.VM_group.get_uuid ~__context ~self:group)
+           (Db.VM_group.get_name_label ~__context ~self:group) ;
+         `AntiAffinity group
+     )
+
 let vm_has_vgpu ~__context ~vm =
   match Db.VM.get_VGPUs ~__context ~self:vm with
   | [] ->
@@ -950,7 +970,11 @@ let vm_has_sriov ~__context ~vm =
 let ( >>= ) opt f = match opt with Some _ as v -> v | None -> f
 
 let get_group_key ~__context ~vm =
-  match None >>= vm_has_vgpu ~__context ~vm >>= vm_has_sriov ~__context ~vm with
+  match
+    vm_has_anti_affinity ~__context ~vm
+    >>= vm_has_vgpu ~__context ~vm
+    >>= vm_has_sriov ~__context ~vm
+  with
   | Some x ->
       x
   | None ->
@@ -996,12 +1020,81 @@ let rank_hosts_by_best_vgpu ~__context vgpu visible_hosts =
                0L
         )
         hosts
-      |> List.map (fun g -> List.map (fun (h, _) -> h) g)
+      |> List.map (fun g -> List.map fst g)
+
+(* Group all hosts to 2 parts:
+   1. A list of affinity host (only one host).
+   2. A list of lists, each list contains hosts with the same number of
+      running VM in that anti-affinity group.
+      These lists are sorted by VM's count.
+   Combine these lists into one list. The list is like below:
+   [ [host1] (affinity host)
+   , [host2, host3] (no VM running)
+   , [host4, host5] (one VM running)
+   , [host6, host7] (more VMs running)
+   , ...
+   ]
+*)
+let rank_hosts_by_placement ~__context ~vm ~group =
+  let affinity_host =
+    match Db.VM.get_affinity ~__context ~self:vm with
+    | ref when Db.is_valid_ref __context ref ->
+        [ref]
+    | _ ->
+        []
+  in
+  let sorted_hosts =
+    let host_without_affinity_host =
+      Db.Host.get_all ~__context
+      |> List.filter (fun host -> not (List.mem host affinity_host))
+    in
+    let host_of_vm vm =
+      let vm_rec = Db.VM.get_record ~__context ~self:vm in
+      (* 1. When a VM starts migrating, it's 'scheduled_to_be_resident_on' will be set,
+            while its 'resident_on' is not cleared. In this case,
+            'scheduled_to_be_resident_on' should be treated as its running host.
+         2. For paused VM, its 'resident_on' has value, but it will not be considered
+            while computing the amount of VMs. *)
+      match
+        ( vm_rec.API.vM_scheduled_to_be_resident_on
+        , vm_rec.API.vM_resident_on
+        , vm_rec.API.vM_power_state
+        )
+      with
+      | sh, _, _ when sh <> Ref.null ->
+          Some sh
+      | _, h, `Running when h <> Ref.null ->
+          Some h
+      | _ ->
+          None
+    in
+    let host_map =
+      Db.VM_group.get_VMs ~__context ~self:group
+      |> List.fold_left
+           (fun m vm ->
+             match host_of_vm vm with
+             | Some h ->
+                 RefMap.update h
+                   (fun c -> Option.(value ~default:0 c |> succ |> some))
+                   m
+             | None ->
+                 m
+           )
+           RefMap.empty
+    in
+    host_without_affinity_host
+    |> Helpers.group_by ~ordering:`ascending (fun h ->
+           RefMap.find_opt h host_map |> Option.value ~default:0
+       )
+    |> List.map (fun g -> List.map fst g)
+  in
+  affinity_host :: sorted_hosts |> List.filter (( <> ) [])
 
 (* Selects a single host from the set of all hosts on which the given [vm] can boot.
    Raises [Api_errors.no_hosts_available] if no such host exists.
-   1.Take Vgpu or Network SR-IOV as a group_key for group all hosts into host list list
-   2.helper function's order determine the priority of resources,now vgpu has higher priority than Network SR-IOV
+   1.Take anti-affinity, or VGPU, or Network SR-IOV as a group_key for group all hosts into host list list
+   2.helper function's order determine the priority of resources,now anti-affinity has the highest priority,
+     VGPU is the second, Network SR-IOV is the lowest
    3.If no key found in VM,then host_lists will be [all_hosts] *)
 let choose_host_for_vm_no_wlb ~__context ~vm ~snapshot =
   let validate_host =
@@ -1013,6 +1106,8 @@ let choose_host_for_vm_no_wlb ~__context ~vm ~snapshot =
     match group_key with
     | `Other ->
         [all_hosts]
+    | `AntiAffinity group ->
+        rank_hosts_by_placement ~__context ~vm ~group
     | `VGPU vgpu ->
         let can_host_vm ~__context host vm =
           try
@@ -1027,7 +1122,7 @@ let choose_host_for_vm_no_wlb ~__context ~vm ~snapshot =
         let host_group =
           Xapi_network_sriov_helpers.group_hosts_by_best_sriov ~__context
             ~network
-          |> List.map (fun g -> List.map (fun (h, _) -> h) g)
+          |> List.map (fun g -> List.map fst g)
         in
         if host_group <> [] then
           host_group


### PR DESCRIPTION
VM in an anti-affinity group will choose a host based on the following steps:
1. If the VM is associated with an anti-affinity group, compute the amount
   of VMs associated with this anti-affinity group for each host.
2. Group these hosts based on the VM's amount. The hosts with the same VM
   amount are in the same group. Sort all the host groups ascending based on
   the VM's amount.
3. If a host is an affinity host for this VM, it will be treated as a single
   host group and be put on the head of the group list.
4. Choose a host which the VM can run on it from each group.