### PR TITLE
IH-533: Remove usage of forkexecd daemon to execute processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 	dune build @update-dm-lifecycle -j $(JOBS) --profile=$(PROFILE) --auto-promote || dune build @update-dm-lifecycle -j $(JOBS) --profile=$(PROFILE) --auto-promote
 	dune build @install -j $(JOBS) --profile=$(PROFILE)
 	dune build @python --profile=$(PROFILE)
+	$(MAKE) -C ocaml/forkexecd/helper
 
 # Quickly verify that the code compiles, without actually building it
 check:
@@ -246,6 +247,8 @@ install: build doc sdk doc-json
 	install -m 644 _build/default/ocaml/networkd/bin/xcp-networkd.1 $(DESTDIR)/usr/share/man/man1/xcp-networkd.1
 # wsproxy
 	install -m 755 _build/install/default/bin/wsproxy $(DESTDIR)$(LIBEXECDIR)/wsproxy
+# forkexecd
+	install -m 755 ocaml/forkexecd/helper/syslogger $(DESTDIR)/usr/libexec/xapi/syslogger
 # dune can install libraries and several other files into the right locations
 	dune install --destdir=$(DESTDIR) --prefix=$(PREFIX) --libdir=$(LIBDIR) --mandir=$(MANDIR) \
 		xapi-client xapi-schema xapi-consts xapi-cli-protocol xapi-datamodel xapi-types \

--- a/ocaml/forkexecd/helper/.gitignore
+++ b/ocaml/forkexecd/helper/.gitignore
@@ -1,0 +1,1 @@
+syslogger

--- a/ocaml/forkexecd/helper/Makefile
+++ b/ocaml/forkexecd/helper/Makefile
@@ -1,0 +1,6 @@
+## Set some macro but not override environment ones
+CFLAGS ?= -O2 -g
+LDFLAGS ?=
+
+syslogger: syslogger.c ../lib/close_from.c ../lib/close_from.h
+	gcc $(CFLAGS) $(LDFLAGS) -Wall -Werror -o $@ $< ../lib/close_from.c

--- a/ocaml/forkexecd/helper/syslogger.c
+++ b/ocaml/forkexecd/helper/syslogger.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <syslog.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+
+#include "../lib/close_from.h"
+
+static inline size_t quoted_length(const char c)
+{
+	return c == '\\' ? 2 :
+		(c >= ' ' && c < 0x7f) ? 1 :
+		4;
+}
+
+static const char hex[] = "0123456789ABCDEF";
+
+static inline void write_quoted(char *const p, const char c)
+{
+	if (c == '\\') {
+		p[0] = p[1] = c;
+	} else if (c >= ' ' && c < 0x7f) {
+		p[0] = c;
+	} else {
+		p[0] = '\\';
+		p[1] = 'x';
+		p[2] = hex[(c>>4)&0xf];
+		p[3] = hex[c&0xf];
+	}
+}
+
+static char quoted_buf[64000];
+static const char *key = NULL;
+static int child_pid;
+
+static void syslog_line(const char *line)
+{
+	syslog(LOG_DAEMON|LOG_INFO, "%s[%d]: %s", key, child_pid, line);
+}
+
+static bool forward_to_syslog(int fd)
+{
+	FILE *f = fdopen(fd, "r");
+	char *dest = quoted_buf;
+	char *const dest_end = quoted_buf + sizeof(quoted_buf) - sizeof(" ...") - 1;
+	bool overflowed = false;
+	while (true) {
+		int ch = getc_unlocked(f);
+
+		if (!overflowed && dest != quoted_buf && (ch == '\n' || ch == EOF)) {
+			*dest = 0;
+			syslog_line(quoted_buf);
+		}
+
+		if (ch == EOF)
+			return !!feof(f);
+
+		if (ch == '\n') {
+			overflowed = false;
+			dest = quoted_buf;
+			continue;
+		}
+
+		if (overflowed)
+			continue;
+
+		const size_t quoted_len = quoted_length(ch);
+		if (dest + quoted_len >= dest_end) {
+			strcpy(dest, " ...");
+			syslog_line(quoted_buf);
+			overflowed = true;
+			continue;
+		}
+		write_quoted(dest, ch);
+		dest += quoted_len;
+	}
+}
+
+// first argument file descriptor for read pipe
+// second option key
+// others just arguments
+int main(int argc, char **argv)
+{
+	int fds[2];
+	int version;
+	int status;
+	int redirect_stderr_to_stdout;
+	pid_t pid;
+
+	if (argc < 4)
+		return 125;
+
+	// first argument, <version>:<redirect>:<file descriptor>
+	if (sscanf(argv[1], "%d:%d:%d", &version, &redirect_stderr_to_stdout, &fds[0]) != 3)
+		return 125;
+	if (version != 1)
+		return 125;
+
+	// second argument, key
+	key = argv[2];
+
+	// others are the arguments
+	argv += 3;
+
+	fds[1] = -1;
+	if (fds[0] < 0) {
+		if (pipe(fds) < 0)
+			return 125;
+	}
+
+	child_pid = (int) getpid();
+
+	pid = fork();
+	if (pid < 0)
+		return 125;
+
+	if (pid == 0) {
+		// child
+		if (fds[1] >= 0)
+			close(fds[1]);
+
+		close(0);
+		close(1);
+		close(2);
+		open("/dev/null", O_RDONLY);
+		open("/dev/null", O_WRONLY);
+		open("/dev/null", O_WRONLY);
+		if (fds[0] != 3) {
+			dup2(fds[0], 3);
+			fds[0] = 3;
+		}
+		close_fds_from(4);
+
+		pid = fork();
+		if (pid < 0)
+			return 125;
+		if (pid > 0)
+			// parent
+			return 0;
+
+		openlog("forkexecd", 0, LOG_DAEMON);
+		forward_to_syslog(fds[0]);
+		return 0;
+	}
+
+	// parent
+	wait(&status);
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		return 125;
+
+	close(fds[0]);
+	if (fds[1] >= 0)
+		dup2(fds[1], 1);
+	if (fds[1] >= 0 && redirect_stderr_to_stdout)
+		dup2(fds[1], 2);
+	if (fds[1] >= 0)
+		close(fds[1]);
+	execv(argv[0], argv);
+
+	return errno == ENOENT ? 127 : 126;
+}

--- a/ocaml/forkexecd/helper/syslogger.c
+++ b/ocaml/forkexecd/helper/syslogger.c
@@ -61,6 +61,8 @@ static void syslog_line(const char *line)
 	syslog(LOG_DAEMON|LOG_INFO, "%s[%d]: %s", key, child_pid, line);
 }
 
+// Quote and forward every line from "fd" to the syslog.
+// "fd" will be closed.
 static bool forward_to_syslog(int fd)
 {
 	FILE *f = fdopen(fd, "r");
@@ -75,8 +77,11 @@ static bool forward_to_syslog(int fd)
 			syslog_line(quoted_buf);
 		}
 
-		if (ch == EOF)
-			return !!feof(f);
+		if (ch == EOF) {
+			bool res = !!feof(f);
+			fclose(f);
+			return res;
+		}
 
 		if (ch == '\n') {
 			overflowed = false;

--- a/ocaml/forkexecd/lib/.gitignore
+++ b/ocaml/forkexecd/lib/.gitignore
@@ -1,0 +1,1 @@
+fe_stubs_algo_fuzzer

--- a/ocaml/forkexecd/lib/Makefile
+++ b/ocaml/forkexecd/lib/Makefile
@@ -1,0 +1,18 @@
+## Makefile for fe_stubs algorithm fuzzer.
+## Fuzzer uses AFL (American Fuzzy Lop).
+##
+## Use "make" to build and launch the fuzzer
+##
+## Use "make show" to look at the first failures (if found).
+
+fuzz::
+	afl-gcc -O2 -Wall -Werror -g -o fe_stubs_algo_fuzzer fe_stubs_algo_fuzzer.c
+	rm -rf testcase_dir
+	mkdir testcase_dir
+	echo maomaoamaoaoao > testcase_dir/test1
+	rm -rf findings_dir/
+	afl-fuzz -i testcase_dir -o findings_dir -- ./fe_stubs_algo_fuzzer
+
+show::
+	cat "$$(ls -1 findings_dir/default/crashes/id* | head -1)" | ./fe_stubs_algo_fuzzer
+

--- a/ocaml/forkexecd/lib/close_from.c
+++ b/ocaml/forkexecd/lib/close_from.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#include "close_from.h"
+
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <sys/types.h>
+#include <sys/resource.h>
+
+#ifdef __linux__
+#include <sys/syscall.h>
+#endif
+
+// try to use close_range on Linux even if not defined by headers
+#if defined(__linux__) && !defined(SYS_close_range)
+#  if defined(__alpha__)
+#    define SYS_close_range 546
+#  elif defined(__amd64__) || defined(__x86_64__) || defined(__arm__) || \
+        defined(__aarch64__) || defined(__hppa__) || defined(__i386__) || \
+        defined(__ia64__) || defined(__m68k__) || defined(__mips__) || \
+        defined(__powerpc__) || defined(__powerpc64__) || defined(__sparc__) || \
+        defined(__s390x__)
+#    define SYS_close_range 436
+#  endif
+#endif
+
+bool
+close_fds_from(int fd_from)
+{
+    // first method, use close_range
+#if (defined(__linux__) && defined(SYS_close_range)) \
+    || (defined(__FreeBSD__) && defined(CLOSE_RANGE_CLOEXEC))
+    static bool close_range_supported = true;
+    if (close_range_supported) {
+#if defined(__linux__)
+        if (syscall(SYS_close_range, fd_from, ~0U, 0) == 0)
+#else
+        if (close_range(fd_from, ~0U, 0) == 0)
+#endif
+            return true;
+
+        if (errno == ENOSYS)
+            close_range_supported = false;
+    }
+#endif
+
+    // second method, read fds list from /proc
+    DIR *dir = opendir("/proc/self/fd");
+    if (dir) {
+        const int dir_fd = dirfd(dir);
+        struct dirent *ent;
+        while ((ent = readdir(dir)) != NULL) {
+            char *end = NULL;
+            unsigned long fd = strtoul(ent->d_name, &end, 10);
+            if (end == NULL || *end)
+                continue;
+            if (fd >= fd_from && fd != dir_fd)
+                close(fd);
+        }
+        closedir(dir);
+        return true;
+    }
+
+    // third method, use just a loop
+    struct rlimit limit;
+    if (getrlimit(RLIMIT_NOFILE, &limit) < 0)
+        return false;
+    for (int fd = fd_from; fd < limit.rlim_cur; ++ fd)
+        close(fd);
+
+    return true;
+}

--- a/ocaml/forkexecd/lib/close_from.h
+++ b/ocaml/forkexecd/lib/close_from.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#include <stdbool.h>
+
+bool close_fds_from(int fd);

--- a/ocaml/forkexecd/lib/dune
+++ b/ocaml/forkexecd/lib/dune
@@ -14,5 +14,10 @@
    xapi-stdext-unix
    xapi-tracing
  )
+ (foreign_stubs
+  (language c)
+  (names fe_stubs close_from logs)
+  (flags :standard -Wall -Werror)
+ )
  (preprocess
   (pps ppx_deriving_rpc)))

--- a/ocaml/forkexecd/lib/fe_stubs.c
+++ b/ocaml/forkexecd/lib/fe_stubs.c
@@ -1,0 +1,899 @@
+/*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdbool.h>
+#include <math.h>
+#include <pthread.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <sys/syscall.h>
+#include <sys/resource.h>
+
+#include <caml/alloc.h>
+#include <caml/mlvalues.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
+#include <caml/memory.h>
+#include <caml/custom.h>
+#include <caml/unixsupport.h>
+#include <caml/signals.h>
+
+#include "close_from.h"
+
+#define FOREACH_LIST(name, list) \
+    for(value name = (list); name != Val_emptylist; name = Field(name, 1))
+
+#include "logs.h"
+
+// Create thread reducing stack usage to a minimum to reduce memory usage.
+// Returns error number (like pthread_create).
+static int create_thread_minstack(pthread_t *th, void *(*proc)(void *), void *arg);
+
+static value alloc_process_status(int pid, int status);
+
+// Internal custom object.
+// This structure cannot be put into Ocaml custom data to avoid move it
+// as containing a mutex (which cannot be moved).
+typedef struct {
+    // pid of the process we wait, never changed
+    pid_t pid;
+
+    // protects the rest of this structure
+    pthread_mutex_t mtx;
+
+    // if pid was reaped, we need to reap only once
+    bool reaped;
+} pidwaiter;
+
+#define PIDWAITER(name, value) \
+    pidwaiter *const name = (*((pidwaiter**) Data_custom_val(value)))
+
+static void *
+thread_proc_reap(void *arg)
+{
+    pid_t pid = (pid_t) (intptr_t) arg;
+
+    int status;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+        continue;
+
+    return NULL;
+}
+
+static void
+pidwaiter_finalize(value v)
+{
+    PIDWAITER(waiter, v);
+
+    pid_t pid = waiter->pid;
+    bool reaped = waiter->reaped;
+    pthread_mutex_destroy(&waiter->mtx);
+    caml_stat_free(waiter);
+
+    // reap the pid to avoid zombies
+    if (!reaped) {
+        pthread_t th;
+        if (create_thread_minstack(&th, thread_proc_reap, (void *) (intptr_t) pid) == 0)
+            pthread_detach(th);
+    }
+}
+
+static struct custom_operations custom_ops = {
+    "com.xenserver.pidwaiter",
+    pidwaiter_finalize,
+    custom_compare_default,
+    custom_hash_default,
+    custom_serialize_default,
+    custom_deserialize_default,
+    custom_compare_ext_default,
+    custom_fixed_length_default
+};
+
+static value
+pidwaiter_alloc(pid_t pid)
+{
+    // Allocate static memory, we can't retain pointer to
+    // Ocaml dynamic memory when we release Ocaml engine.
+    pidwaiter *waiter = caml_stat_alloc(sizeof(pidwaiter));
+
+    waiter->pid = pid;
+    pthread_mutex_init(&waiter->mtx, NULL);
+    waiter->reaped = false;
+
+    value v = caml_alloc_custom(&custom_ops, sizeof(pidwaiter*), 0, 1);
+    *((pidwaiter**) Data_custom_val(v)) = waiter;
+    return v;
+}
+
+#define log(...) do {} while(0)
+#include "fe_stubs_redirect_algo.h"
+
+typedef struct {
+    char **args;
+    char **environment;
+    mapping *mappings;
+    fd_operation operations[MAX_OPERATIONS];
+    int err;
+    const char *err_func;
+} exec_info;
+
+// Appends a string to *p_dest buffer.
+// It updates *p_dest to point after copied string.
+// Returns copied string.
+static char *
+append_string(char **p_dest, const char *s)
+{
+    char *const dest = *p_dest;
+    size_t const size = strlen(s) + 1;
+    memcpy(dest, s, size);
+    *p_dest = dest + size;
+    return dest;
+}
+
+static void adjust_args(char **args, mapping *const mappings, unsigned num_mappings);
+static void reset_signal_handlers(void);
+static void clear_cgroup(void);
+static const char *get_syslog_key(value syslog_stdout, value args);
+
+CAMLprim value
+caml_safe_exec_nat(value environment,
+    value stdin_fd, value stdout_fd, value stderr_fd,
+    value id_mapping, value syslog_stdout, value redirect, value args)
+{
+    // We need to retain all paramters, they are either array,
+    // list or options.
+    value waiter = Val_unit;
+    CAMLparam5(environment, stdin_fd, stdout_fd, stderr_fd, waiter);
+    CAMLxparam4(id_mapping, syslog_stdout, redirect, args);
+
+    value res;
+    unsigned num_args = 0, num_mappings = 0;
+    const mlsize_t num_environment = caml_array_length(environment);
+    size_t strings_size = 0;
+    const bool redirect_stderr_to_stdout =
+        (syslog_stdout == Val_none || redirect == Val_none) ? false : Bool_val(Some_val(redirect));
+    const char *const key = get_syslog_key(syslog_stdout, args);
+    pid_t pid;
+    struct rlimit nofile_limit;
+
+    mapped_logs logs = mapped_logs_open();
+#undef log
+#define log(fmt, ...) mapped_logs_add(logs, fmt "\n", ## __VA_ARGS__)
+#define log_fail(fmt, ...) do {\
+    mapped_logs_failure(logs); \
+    mapped_logs_add(logs, fmt "\n", ## __VA_ARGS__); \
+} while(0)
+
+    log("starting");
+
+    // Scan all arguments, check them and collect some information.
+
+    // Standard file descriptors.
+    int standard_fds[3];
+    const value standard_fd_values[3] = { stdin_fd, stdout_fd, stderr_fd };
+    for (int i = 0; i < 3; ++i) {
+        int fd = -1;
+        if (standard_fd_values[i] != Val_none) {
+            fd = Int_val(Some_val(standard_fd_values[i]));
+            if (fd < 0) {
+                log_fail("invalid standard fd");
+                mapped_logs_close(logs);
+                unix_error(EINVAL, "safe_exec", Nothing);
+            }
+        }
+        standard_fds[i] = fd;
+    }
+
+    FOREACH_LIST(arg, args) {
+        strings_size += strlen(String_val(Field(arg, 0))) + 1;
+        ++num_args;
+    }
+    if (num_args < 1) {
+        log_fail("no args");
+        mapped_logs_close(logs);
+        unix_error(EINVAL, "safe_exec", Nothing);
+    }
+
+    for (mlsize_t n = 0; n < num_environment; ++n)
+        strings_size += strlen(String_val(Field(environment, n))) + 1;
+
+    FOREACH_LIST(map, id_mapping) {
+        ++num_mappings;
+        value item = Field(map, 0);
+        const char *const uuid = String_val(Field(item, 0));
+        const int current_fd = Int_val(Field(item, 1));
+        // Check values.
+        // The check for UUID length makes sure we'll have space to replace last part of
+        // the command line arguments with file descriptor.
+        if (strlen(uuid) != 36 || current_fd < 0) {
+            log_fail("invalid mapping");
+            mapped_logs_close(logs);
+            unix_error(EINVAL, "safe_exec", Nothing);
+        }
+        strings_size += 36 + 1;
+    }
+    // Limit number of mappings to some sensible value.
+    // Also to avoid overflows with redirect code.
+    if (num_mappings > MAX_TOTAL_MAPPINGS) {
+        log_fail("too many mappings");
+        mapped_logs_close(logs);
+        unix_error(EINVAL, "safe_exec", Nothing);
+    }
+
+    // Prefix arguments with our helper to support syslog redirection.
+    if (key) {
+        num_args += 3;
+        strings_size += 64;
+        strings_size += strlen(key) + 1;
+    }
+
+    if (getrlimit(RLIMIT_NOFILE, &nofile_limit) < 0) {
+        log_fail("getrlimit error");
+        mapped_logs_close(logs);
+        unix_error(errno, "safe_exec", Nothing);
+    }
+
+    // Allocate buffer to copy all data that we need.
+    num_mappings += 3;
+    size_t total_size =
+        sizeof(exec_info) +
+        sizeof(char*) * (num_args + 1 + num_environment + 1) +
+        sizeof(mapping) * num_mappings +
+        strings_size;
+    exec_info *info = (exec_info *) caml_stat_alloc(total_size);
+    memset(info, 0, total_size);
+
+    log("copying");
+
+    // Copy all needed information.
+    {
+        char **ptrs = (char**)(info + 1);
+        mapping *mappings = (mapping *) (ptrs + num_args + 1 + num_environment + 1);
+        char *strings = (char*) (mappings + num_mappings);
+#ifdef FORKEXECD_DEBUG_LOGS
+        mapping *const initial_mappings = mappings;
+        char *const initial_strings = strings;
+#endif
+
+        // Copy arguments into list.
+        info->args = ptrs;
+        if (key) {
+            *ptrs++ = "/usr/libexec/xapi/syslogger";
+            sprintf(strings, "1:%d:-1", !!redirect_stderr_to_stdout);
+            *ptrs++ = strings;
+            strings += 64;
+            *ptrs++ = append_string(&strings, key);
+        }
+        FOREACH_LIST(arg, args) {
+            const char *const s = String_val(Field(arg, 0));
+            *ptrs++ = append_string(&strings, s);
+        }
+        *ptrs++ = NULL;
+
+        // Copy environments into list.
+        // We need to copy also the content, Ocaml system could move it
+        // after calling caml_enter_blocking_section.
+        info->environment = ptrs;
+        for (mlsize_t n = 0; n < num_environment; ++n) {
+            const char *const s = String_val(Field(environment, n));
+            *ptrs++ = append_string(&strings, s);
+        }
+        *ptrs++ = NULL;
+
+        // Copy all mappings, we need to change them.
+        info->mappings = mappings;
+        for (int i = 0; i < 3; ++i) {
+            mapping *m = mappings++;
+            m->uuid = NULL;
+            m->current_fd = standard_fds[i];
+            m->wanted_fd = i;
+        }
+        FOREACH_LIST(map, id_mapping) {
+            mapping *m = mappings++;
+            value item = Field(map, 0);
+            m->uuid = append_string(&strings, String_val(Field(item, 0)));
+            m->current_fd = Int_val(Field(item, 1));
+            m->wanted_fd = -1;
+        }
+
+#ifdef FORKEXECD_DEBUG_LOGS
+        if (strings - (char*)info != total_size
+            || initial_mappings != (mapping*) ptrs
+            || initial_strings != (char*) mappings) {
+            log_fail("internal error copying");
+            caml_stat_free(info);
+            mapped_logs_close(logs);
+            unix_error(EACCES, "safe_exec", Nothing);
+        }
+#endif
+    }
+
+    // Release Ocaml engine, it could feel all operations are pretty quick
+    // so there's no need but potentially launching a process can take
+    // some time (like files on NFS), so better safe than sorry.
+    caml_enter_blocking_section();
+    {
+    // make sure we don't use Ocaml variables anymore in the section
+    enum {
+        environment, stdin_fd, stdout_fd, stderr_fd, waiter,
+        id_mapping, syslog_stdout, redirect, args,
+        key, strings_size, res
+    };
+
+    sigset_t sigset, old_sigset;
+    int cancellation_state;
+
+    // Compute the file operations we need to do for the file mappings,
+    // this is done before vfork() call to reduce operations done between
+    // vfork() and execve().
+    int num_operations =
+        redirect_mappings(info->mappings, num_mappings, info->operations);
+
+    if (FORKEXECD_DEBUG_LOGS) {
+        for (size_t n = 0; info->args[n]; ++n)
+            log("arg %zd %s", n, info->args[n]);
+    }
+
+    // Rename all command line.
+    adjust_args(info->args, info->mappings, num_mappings);
+
+    if (FORKEXECD_DEBUG_LOGS) {
+        for (size_t n = 0; info->args[n]; ++n)
+            log("arg %zd %s", n, info->args[n]);
+    }
+
+    // Disable cancellation to avoid some signals.
+    // Glibc use some signals to handle thread cancellation.
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cancellation_state);
+
+    // Block all possible signals to avoid receiving some in the child.
+    // Signal mask is inherited to new process/thread will start with
+    // all signals disabled and we can safely change them.
+    sigfillset(&sigset);
+    pthread_sigmask(SIG_BLOCK, &sigset, &old_sigset);
+
+    log("vfork");
+
+    // fork
+    pid = vfork();
+    if (pid < 0) {
+        int err = errno;
+        // error, notify with an exception
+        log_fail("vfork %d", err);
+        caml_stat_free(info);
+        mapped_logs_close(logs);
+        unix_error(err, "safe_exec", Nothing);
+    }
+
+    if (pid == 0) {
+        // child
+        log("child");
+
+        reset_signal_handlers();
+
+        if (chdir("/") < 0) {
+            info->err = errno;
+            info->err_func = "chdir";
+            log_fail("chdir %d", errno);
+            _exit(125);
+        }
+
+        // Clear cgroup otherwise systemd will shutdown processes if
+        // toolstack is restarted.
+        clear_cgroup();
+
+        if (setsid() < 0) {
+            info->err = errno;
+            info->err_func = "setsid";
+            log_fail("setsid %d", errno);
+            _exit(125);
+        }
+
+        // Redirect file descriptors.
+        int err = 0;
+        const char *err_func = NULL;
+        for (int i = 0; i < num_operations; ++i) {
+            const fd_operation* const op = &info->operations[i];
+            log("op %d %d %d", op->fd_from, op->fd_to, op->operation);
+            switch (op->operation) {
+            case FD_OP_DUP:
+                if (op->fd_from == op->fd_to) {
+                    err_func = "fcntl";
+                    int flags = fcntl(op->fd_from, F_GETFD);
+                    if (flags == -1) {
+                        err = errno;
+                    } else if ((flags & FD_CLOEXEC) != 0) {
+                        if (fcntl(op->fd_from, F_SETFD, flags & ~FD_CLOEXEC) == -1)
+                            err = errno;
+                    }
+                } else {
+                    err_func = "dup2";
+                    if (dup2(op->fd_from, op->fd_to) < 0)
+                        err = errno;
+                }
+                break;
+            case FD_OP_MOVE:
+                err_func = "dup2";
+                if (dup2(op->fd_from, op->fd_to) < 0)
+                    err = errno;
+                close(op->fd_from);
+                break;
+            case FD_OP_CLOSE:
+                close(op->fd_from);
+                break;
+            case FD_OP_DEVNULL:
+                // first close old, then create new one
+                close(op->fd_to);
+                // TODO ideally we want read only for input for Ocaml did the same...
+                err_func = "open";
+                if (open("/dev/null", O_WRONLY) != op->fd_to)
+                    err = errno ? errno : EBADF;
+                break;
+            case FD_OP_CLOSE_FROM:
+                close_fds_from(op->fd_from);
+                break;
+            default:
+                err_func = "safe_exec";
+                err = EINVAL;
+            }
+        }
+        if (err != 0) {
+            info->err = err;
+            info->err_func = err_func;
+            log_fail("redirect error %d in %s", err, err_func);
+            _exit(125);
+        }
+
+        // Limit number of files limits to standard limit to avoid
+        // creating bugs with old programs.
+        if (nofile_limit.rlim_cur > 1024) {
+            nofile_limit.rlim_cur = 1024;
+            setrlimit(RLIMIT_NOFILE, &nofile_limit);
+        }
+
+        // Reset signal mask, inherited by the process we are going to execute
+        sigemptyset(&sigset);
+        pthread_sigmask(SIG_SETMASK, &sigset, NULL);
+
+        log("execve...");
+        mapped_logs_success(logs);
+        execve(info->args[0], info->args, info->environment);
+        log_fail("execve failed %d", errno);
+        // Here we could set err and err_func but we kept compatibility
+        // with forkexecd daemon.
+        _exit(errno == ENOENT ? 127 : 126);
+    }
+
+    log("done");
+
+    // Restore thread state
+    pthread_sigmask(SIG_SETMASK, &old_sigset, NULL);
+    pthread_setcancelstate(cancellation_state, NULL);
+    mapped_logs_close(logs);
+
+    }
+    caml_leave_blocking_section();
+
+    // Handle errors from child.
+    int err = info->err;
+    const char *err_func = info->err_func;
+    caml_stat_free(info);
+    if (err != 0 && err_func != NULL) {
+        while (waitpid(pid, NULL, 0) < 0 && errno == EINTR)
+            continue;
+        unix_error(err, err_func, Nothing);
+    }
+
+    waiter = pidwaiter_alloc(pid);
+
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = waiter;
+    Field(res, 1) = Val_int(pid);
+
+    CAMLreturn(res);
+}
+
+CAMLprim value
+caml_safe_exec_byte(value *argv)
+{
+    return caml_safe_exec_nat(argv[0], argv[1], argv[2], argv[3], argv[4], argv[5], argv[6], argv[7]);
+}
+
+static const char *
+get_syslog_key(value syslog_stdout, value args)
+{
+    // no syslog parameter
+    if (syslog_stdout == Val_none)
+        return NULL;
+
+    // remove the optional
+    syslog_stdout = Some_val(syslog_stdout);
+
+    // no-constant, user passed the key
+    if (Is_block(syslog_stdout))
+        return String_val(Field(syslog_stdout,0));
+
+    // no syslog wanted
+    if (Int_val(syslog_stdout) == 0)
+        return NULL;
+
+    // wrong arguments, will be checked later on the code
+    if (args == Val_emptylist)
+        return NULL;
+
+    // get basename of first argument
+    const char *filename = String_val(Field(args, 0));
+    const char *sep = strrchr(filename, '/');
+    return sep ? sep + 1 : filename;
+}
+
+static void
+adjust_args(char **args, mapping *const mappings, unsigned num_mappings)
+{
+    for (; *args; ++args) {
+        char *arg = *args;
+        size_t len = strlen(arg);
+        if (len < 36)
+            continue;
+
+        // replace uuid with file descriptor
+        char *uuid = arg + len - 36;
+        for (unsigned i = 0; i < num_mappings; ++i) {
+            const mapping *m = &mappings[i];
+            if (m->uuid == NULL || strcmp(m->uuid, uuid) != 0)
+                continue;
+            sprintf(uuid, "%d", m->current_fd);
+        }
+    }
+}
+
+static void
+reset_signal_handlers(void)
+{
+    for (int sig = 1; sig < NSIG; ++sig) {
+        // these signals can't be overridden
+        if (sig == SIGKILL || sig == SIGSTOP)
+            continue;
+
+        // Set signal dispositions.
+        // This avoids inherit unwanted overrides.
+        // Also prevent handling unwanted signal handler, especially using vfork().
+        // Use ignore SIGPIPE for compatibility with forkexecd.
+        signal(sig, sig == SIGPIPE ? SIG_IGN : SIG_DFL);
+    }
+}
+
+static void
+clear_cgroup(void)
+{
+    int fd = open("/sys/fs/cgroup/systemd/cgroup.procs", O_WRONLY|O_CLOEXEC);
+    if (fd >= 0) {
+        char string_pid[32];
+        int ignored __attribute__((unused));
+        sprintf(string_pid, "%d\n", (int) getpid());
+        ignored = write(fd, string_pid, strlen(string_pid));
+        close(fd);
+    }
+}
+
+CAMLprim value
+caml_pidwaiter_dontwait(value waiter_val)
+{
+    CAMLparam1(waiter_val);
+    PIDWAITER(waiter, waiter_val);
+
+    pthread_mutex_lock(&waiter->mtx);
+    bool reaped = waiter->reaped;
+    waiter->reaped = true;
+    pthread_mutex_unlock(&waiter->mtx);
+
+    // reap the pid to avoid zombies
+    if (!reaped) {
+        pthread_t th;
+        if (create_thread_minstack(&th, thread_proc_reap, (void *) (intptr_t) waiter->pid) == 0)
+            pthread_detach(th);
+    }
+
+    CAMLreturn(Val_unit);
+}
+
+typedef struct {
+    pid_t pid;
+    bool timed_out;
+    bool stop;
+    struct timespec deadline;
+    pthread_mutex_t mtx;
+    pthread_cond_t cond;
+} timeout_kill;
+
+static void *
+thread_proc_timeout_kill(void *arg)
+{
+    timeout_kill *tm = (timeout_kill *) arg;
+
+    pthread_mutex_lock(&tm->mtx);
+    int res  = tm->stop ? 0:
+        pthread_cond_timedwait(&tm->cond, &tm->mtx, &tm->deadline);
+    pthread_mutex_unlock(&tm->mtx);
+
+    if (res == ETIMEDOUT) {
+        kill(tm->pid, SIGKILL);
+        tm->timed_out = true;
+    }
+    return NULL;
+}
+
+static int
+create_thread_minstack(pthread_t *th, void *(*proc)(void *), void *arg)
+{
+    int res;
+
+    // disable any possible signal handler so we can safely use a small stack
+    // for the thread
+    sigset_t sigset, old_sigset;
+    sigfillset(&sigset);
+    pthread_sigmask(SIG_BLOCK, &sigset, &old_sigset);
+
+    pthread_attr_t th_attr;
+    res = pthread_attr_init(&th_attr);
+    if (res)
+        return res;
+    pthread_attr_setstacksize(&th_attr, PTHREAD_STACK_MIN);
+
+    res = pthread_create(th, &th_attr, proc, arg);
+
+    pthread_attr_destroy(&th_attr);
+    pthread_sigmask(SIG_SETMASK, &old_sigset, NULL);
+
+    return res;
+}
+
+/*
+ * Wait a process with a given timeout.
+ * At the end of timeout (if trigger) kill the process.
+ * To avoid race we need to wait a specific process, but this is blocking
+ * and we use a timeout to implement the wait. Timer functions are per
+ * process, not per thread.
+ * Returns <0 if error, 0 if not timed out, >0 if timedout.
+ */
+static int
+wait_process_timeout(pid_t pid, double timeout)
+{
+    int err;
+
+    // compute deadline
+    timeout_kill tm = { pid, false, false };
+    if (clock_gettime(CLOCK_MONOTONIC, &tm.deadline) < 0)
+        return -errno;
+
+    double f = floor(timeout);
+    tm.deadline.tv_sec += f;
+    tm.deadline.tv_nsec += (timeout - f) * 1000000000.;
+    if (tm.deadline.tv_nsec >= 1000000000) {
+        tm.deadline.tv_nsec -= 1000000000;
+        tm.deadline.tv_sec += 1;
+    }
+
+    pthread_condattr_t attr;
+    err = pthread_condattr_init(&attr);
+    if (err)
+        return -err;
+    err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (!err)
+        err = pthread_cond_init(&tm.cond, &attr);
+    pthread_condattr_destroy(&attr);
+    if (err)
+        return -err;
+
+    err = pthread_mutex_init(&tm.mtx, NULL);
+    if (err) {
+        pthread_cond_destroy(&tm.cond);
+        return -err;
+    }
+
+    // Create timeout thread
+    pthread_t th;
+    err = create_thread_minstack(&th, thread_proc_timeout_kill, &tm);
+    if (err) {
+        pthread_cond_destroy(&tm.cond);
+        pthread_mutex_destroy(&tm.mtx);
+        return -err;
+    }
+
+    // Wait the process, we avoid to reap the other process to avoid
+    // race conditions. Consider:
+    // - process exit;
+    // - we reap the thread;
+    // - OS reuse the pid;
+    // - timeout thread terminate the pid, now reused.
+    // Avoiding reaping the process will create a zombie process so
+    // the KILL would be directed to that.
+    siginfo_t info;
+    waitid(P_PID, pid, &info, WEXITED|WNOWAIT);
+
+    // Close the timeout thread
+    pthread_mutex_lock(&tm.mtx);
+    // We use also a variable to avoid races like
+    // - we create the thread;
+    // - we start waiting the process which was already exited;
+    // - we came here trying to close the thread;
+    // - thread waits for signal.
+    tm.stop = true;
+    pthread_cond_broadcast(&tm.cond);
+    pthread_mutex_unlock(&tm.mtx);
+    pthread_join(th, NULL);
+
+    // Cleanup
+    pthread_cond_destroy(&tm.cond);
+    pthread_mutex_destroy(&tm.mtx);
+
+    return tm.timed_out ? 1 : 0;
+}
+
+// Similar to waitpid.
+// Returns 0 on process still running, pid > 0 process
+// exited, -1 error (on errno).
+static pid_t
+pidwaiter_wait(mapped_logs logs, pidwaiter *waiter, int *status, bool nohang)
+{
+    pid_t pid;
+
+    pthread_mutex_lock(&waiter->mtx);
+    if (waiter->reaped) {
+        // if already reaped do not attempt to reap again to avoid
+        // potentially reaping another child.
+        log_fail("reaped was true");
+        errno = ECHILD;
+        pid = -1;
+    } else if (nohang) {
+        log("before waitpid");
+        pid = waitpid(waiter->pid, status, WNOHANG);
+        waiter->reaped = (pid > 0);
+        if (pid == -1)
+            mapped_logs_failure(logs);
+        log("waitpid res %d reaped %d errno %d", (int) pid, waiter->reaped, errno);
+    } else {
+        log("before waitpid");
+
+        // We are going always to wait and reap, release
+        // mutex to avoid blocking other threads.
+        waiter->reaped = true;
+        pthread_mutex_unlock(&waiter->mtx);
+        do {
+            pid = waitpid(waiter->pid, status, 0);
+        } while (pid == -1 && errno == EINTR);
+        log("waitpid res %d errno %d", (int) pid, errno);
+        return pid;
+    }
+    pthread_mutex_unlock(&waiter->mtx);
+    return pid;
+}
+
+CAMLprim value
+caml_pidwaiter_waitpid(value timeout_value, value waiter_value)
+{
+    CAMLparam1(waiter_value);
+    double timeout = timeout_value == Val_none ? 0 : Double_val(Some_val(timeout_value));
+    PIDWAITER(waiter, waiter_value);
+    pid_t pid = waiter->pid;
+    int status = 0;
+
+    pthread_mutex_lock(&waiter->mtx);
+    bool reaped = waiter->reaped;
+    pthread_mutex_unlock(&waiter->mtx);
+
+    mapped_logs logs = mapped_logs_open();
+    log("waitpid pid %d reaped %d tid %d", (int) waiter->pid, reaped, (int) syscall(SYS_gettid));
+
+    // already reaped, we cannot wait more
+    if (reaped) {
+        mapped_logs_failure(logs);
+        mapped_logs_close(logs);
+        unix_error(EINVAL, "pidwaiter_waitpid", Nothing);
+    }
+
+    caml_enter_blocking_section();
+
+    bool timed_out = false;
+    int err = 0;
+    if (timeout > 0) {
+        int res = wait_process_timeout(pid, timeout);
+        log("after wait_process_timeout res %d", res);
+        if (res < 0)
+            err = -res;
+        else if (res != 0)
+            timed_out = true;
+    }
+
+    if (!err) {
+        pid = pidwaiter_wait(logs, waiter, &status, false);
+        if (pid == -1)
+            err = errno;
+    }
+
+    caml_leave_blocking_section();
+
+    if (timed_out)
+        err = ETIMEDOUT;
+
+    if (err) {
+        log_fail("final res %d", err);
+        mapped_logs_close(logs);
+        unix_error(err, "waitpid", Nothing);
+    }
+
+    mapped_logs_success(logs);
+    mapped_logs_close(logs);
+
+    CAMLreturn(alloc_process_status(pid, status));
+}
+
+CAMLprim value
+caml_pidwaiter_waitpid_nohang(value waiter_value)
+{
+    CAMLparam1(waiter_value);
+    PIDWAITER(waiter, waiter_value);
+
+    int status = 0;
+    pid_t pid = pidwaiter_wait(NULL_MAPPED_LOGS, waiter, &status, true);
+
+    if (pid == -1)
+        unix_error(errno, "waitpid", Nothing);
+
+    CAMLreturn(alloc_process_status(pid, status));
+}
+
+// function to build a "int * Unix.process_status", taken a bit
+// from Ocaml source, a bit from dune sources.
+static value
+alloc_process_status(int pid, int status)
+{
+    CAMLextern int caml_rev_convert_signal_number(int);
+
+    enum {
+        TAG_WEXITED,
+        TAG_WSIGNALED,
+        TAG_WSTOPPED
+    };
+
+    CAMLparam0();
+    CAMLlocal1(st);
+    value res;
+    int tag, val;
+
+    // status is undefined when pid is zero so we set a default value.
+    if (pid == 0) status = 0;
+
+    if (WIFEXITED(status)) {
+        tag = TAG_WEXITED;
+        val = WEXITSTATUS(status);
+    } else if (WIFSTOPPED(status)) {
+        tag = TAG_WSTOPPED;
+        val = caml_rev_convert_signal_number(WSTOPSIG(status));
+    } else {
+        tag = TAG_WSIGNALED;
+        val = caml_rev_convert_signal_number(WTERMSIG(status));
+    }
+    st = caml_alloc_small(1, tag);
+    Field(st, 0) = Val_int(val);
+    res = caml_alloc_small(2, 0);
+    Field(res, 0) = Val_int(pid);
+    Field(res, 1) = st;
+    CAMLreturn(res);
+}
+
+// vim: expandtab ts=4 sw=4 sts=4:

--- a/ocaml/forkexecd/lib/fe_stubs.c
+++ b/ocaml/forkexecd/lib/fe_stubs.c
@@ -410,7 +410,7 @@ caml_safe_exec_nat(value environment,
         // Redirect file descriptors.
         int err = 0;
         const char *err_func = NULL;
-        for (int i = 0; i < num_operations; ++i) {
+        for (int i = 0; i < num_operations && err == 0; ++i) {
             const fd_operation* const op = &info->operations[i];
             log("op %d %d %d", op->fd_from, op->fd_to, op->operation);
             switch (op->operation) {

--- a/ocaml/forkexecd/lib/fe_stubs_algo_fuzzer.c
+++ b/ocaml/forkexecd/lib/fe_stubs_algo_fuzzer.c
@@ -1,0 +1,263 @@
+
+/*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#undef NDEBUG
+#define DEBUG 1
+
+#if DEBUG
+#define log(fmt, ...) printf(fmt "\n", ##__VA_ARGS__)
+#else
+#define log(fmt, ...) do {} while(0)
+#endif
+
+// include as first file to make sure header is self container
+#include "fe_stubs_redirect_algo.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+
+static int fake_close(int fd);
+
+typedef struct {
+    bool open;
+    bool cloexec;
+    char *name;
+} fd;
+
+#define NUM_FDS 4096
+static fd fds[NUM_FDS];
+
+static bool
+fake_close_fds_from(int fd_from)
+{
+    for (int fd = fd_from; fd < NUM_FDS; ++fd)
+        fake_close(fd);
+
+    return true;
+}
+
+#define O_WRONLY 1
+static int
+fake_open(const char *fn, int dummy)
+{
+    for (int i = 0; i < NUM_FDS; ++i)
+        if (!fds[i].open) {
+            assert(fds[i].name == NULL);
+            fds[i].name = strdup(fn);
+            fds[i].open = true;
+            fds[i].cloexec = false;
+            return i;
+        }
+    assert(0);
+    return -1;
+}
+
+static int
+fake_close(int fd)
+{
+    assert(fd >= 0);
+    assert(fd < NUM_FDS);
+    if (!fds[fd].open) {
+        errno = EBADF;
+        return -1;
+    }
+    fds[fd].open = false;
+    free(fds[fd].name);
+    fds[fd].name = NULL;
+    return 0;
+}
+
+static int
+fake_dup2(int from, int to)
+{
+    assert(from >= 0 && from < NUM_FDS);
+    assert(to >= 0 && to < NUM_FDS);
+    assert(fds[from].open);
+    assert(from != to);
+    free(fds[to].name);
+    fds[to].open = true;
+    fds[to].name = strdup(fds[from].name);
+    fds[to].cloexec = false;
+    return 0;
+}
+
+static int
+fake_fcntl(int fd)
+{
+    assert(fd >= 0 && fd < NUM_FDS);
+    assert(fds[fd].open);
+    fds[fd].cloexec = false;
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    // Input where a given FD goes??
+    // No, not enough, can be duplicated.
+    // Numbers >4096 in 2 bytes not file descriptor,
+    // (-1 for standard, skip for normal).
+    // We should add some random fds.
+    enum { MAX_FILE_BUF = 2048 };
+    uint16_t file_buf[MAX_FILE_BUF];
+    size_t read = fread(file_buf, 2, MAX_FILE_BUF, stdin);
+    if (read < 3)
+        return 0;
+
+    static const char standard_names[][8] = {
+        "stdin", "stdout", "stderr"
+    };
+    int num_mappings = 0;
+    uint16_t *num = file_buf;
+    mapping mappings[MAX_FILE_BUF];
+    int i = 0;
+    for (i = 0; i < 3; ++i) {
+        mapping *m = &mappings[num_mappings++];
+        m->uuid = standard_names[i];
+        uint16_t n = *num++;
+        m->current_fd = n < NUM_FDS ? n : -1;
+        m->wanted_fd = i;
+    }
+    for (; i < read; ++i) {
+        uint16_t n = *num++;
+        if (n >= NUM_FDS)
+            continue;
+
+        mapping *m = &mappings[num_mappings++];
+        m->current_fd = n;
+        m->wanted_fd = -1;
+        char buf[64];
+        sprintf(buf, "file%d", i);
+        m->uuid = strdup(buf);
+    }
+    if (num_mappings > MAX_TOTAL_MAPPINGS)
+        return 0;
+
+    for (unsigned n = 0; n < num_mappings; ++n) {
+        mapping *m = &mappings[n];
+        int fd = m->current_fd;
+        if (fd < 0)
+            continue;
+        fake_close(fd);
+        fds[fd].open = true;
+        fds[fd].name = strdup(m->uuid);
+        fds[fd].cloexec = true;
+    }
+
+    // Check in the final file mapping all valid mappings
+    // has an open file descriptor.
+    // There should be no duplicate numbers in current_fd.
+    // current_fd must be in a range.
+    // Only if wanted_fd >= 0 current_fd can be -1.
+    // There should be a correspondance between input and output names.
+    // If current_fd was -1 it will still be -1.
+    // If wanted_fd >= 0 current_fd should be the same.
+#if 0
+    mapping mappings[] = {
+        { "stdin", -1, 0 },
+        { "stdout", -1, 1 },
+        { "stderr", -1, 2 },
+        { "file2", 3, -1 },
+    };
+    fds[3].open = true;
+    fds[3].name = strdup("file2");
+    fds[3].cloexec = true;
+    int num_mappings = 4;
+#endif
+
+    fd_operation operations[MAX_OPERATIONS];
+    int num_operations =
+        redirect_mappings(mappings, num_mappings, operations);
+    assert(num_operations > 0);
+    assert(num_operations <= MAX_OPERATIONS);
+
+    for (int i = 0; i < num_operations; ++i) {
+        const fd_operation* op = &operations[i];
+        log("op %d %d %d", op->fd_from, op->fd_to, op->operation);
+        switch (op->operation) {
+        case FD_OP_DUP:
+            if (op->fd_from == op->fd_to)
+                fake_fcntl(op->fd_from);
+            else
+                fake_dup2(op->fd_from, op->fd_to);
+            break;
+        case FD_OP_MOVE:
+            assert(op->fd_from != op->fd_to);
+            fake_dup2(op->fd_from, op->fd_to);
+            fake_close(op->fd_from);
+            break;
+        case FD_OP_CLOSE:
+            fake_close(op->fd_from);
+            break;
+        case FD_OP_DEVNULL:
+            // first close old, then create new one
+            fake_close(op->fd_to);
+            // TODO ideally we want read only for input for Ocaml did the same...
+            assert(fake_open("/dev/null", O_WRONLY) == op->fd_to);
+            break;
+        case FD_OP_CLOSE_FROM:
+            fake_close_fds_from(op->fd_from);
+            break;
+        default:
+            assert(0);
+        }
+    }
+
+    // check files opened
+    for (int fd = 0; fd < NUM_FDS; ++fd)
+        assert(fds[fd].open == (fd < num_mappings));
+
+    for (int fd = 0; fd < num_mappings; ++fd) {
+        assert(fds[fd].cloexec == false);
+        log("file %d %s", fd, fds[fd].name);
+    }
+
+    // Check in the final file mapping all valid mappings
+    // has an open file descriptor.
+    bool already_found[NUM_FDS] = { false, };
+    for (unsigned n = 0; n < num_mappings; ++n) {
+        const int fd = mappings[n].current_fd;
+        const int wanted = mappings[n].wanted_fd;
+        if (fd >= 0) {
+            assert(fd < NUM_FDS);
+            assert(fds[fd].open);
+
+            // There should be no duplicate numbers in current_fd.
+            assert(!already_found[fd]);
+            already_found[fd] = true;
+        } else {
+            // Only if wanted_fd >= 0 current_fd can be -1.
+            assert(mappings[n].wanted_fd >= 0);
+            assert(fd == -1);
+        }
+
+        // If wanted_fd >= 0 current_fd should be the same.
+        if (wanted >= 0)
+            assert(wanted == fd || fd == -1);
+
+        // current_fd must be in a range.
+        assert(fd >= -1);
+        assert(fd < num_mappings);
+    }
+
+    // There should be a correspondance between input and output names.
+    // If current_fd was -1 it will still be -1.
+}
+
+// vim: expandtab ts=4 sw=4 sts=4:

--- a/ocaml/forkexecd/lib/fe_stubs_redirect_algo.h
+++ b/ocaml/forkexecd/lib/fe_stubs_redirect_algo.h
@@ -1,0 +1,216 @@
+/* Algorithm used to remap file handles befeore executing a process.
+ * The algorithm is separated in a different file in order to reuse for
+ * fuzzing it.
+ */
+#ifndef GUARD_b3aaeqTwyeVtsAZIDwP2qf
+#define GUARD_b3aaeqTwyeVtsAZIDwP2qf
+
+#pragma once
+
+#if !defined(DEBUG)
+#define DEBUG 0
+#endif
+
+#if (DEBUG) != 0 && (DEBUG) != 1
+#error Expected DEBUG to be defined either 0 or 1
+#endif
+
+#ifndef log
+#error Expected log macro to be defined
+#endif
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef struct {
+    const char *uuid;
+    int current_fd;
+    int wanted_fd;
+} mapping;
+
+typedef struct {
+    // source file
+    int fd_from;
+    // destination file
+    short fd_to;
+    // see FD_OP_ constants
+    uint8_t operation;
+} fd_operation;
+
+typedef enum {
+    // Duplicate from fd_from to fd_to.
+    // If fd_from is the same as fd_to remove FD_CLOEXEC flag.
+    FD_OP_DUP,
+    // Duplicate from fd_from to fd_to and close fd_from.
+    FD_OP_MOVE,
+    // Close fd_from.
+    FD_OP_CLOSE,
+    // Open /dev/null on fd_to.
+    FD_OP_DEVNULL,
+    // Close from fd_from to the sky!
+    FD_OP_CLOSE_FROM,
+} FD_OP;
+
+#define MAX_OPERATIONS 1024
+#define MAX_TOTAL_MAPPINGS (MAX_OPERATIONS - 4)
+
+static uint16_t remap_fds(mapping *const mappings, unsigned num_mappings, int from, int to);
+
+// Given the passed mappings update them (current_fd) and returns the
+// requested operations to do the job.
+// First 3 mappings should refer to standard file descriptors (stdin,
+// stdout, stderr).
+// Returns the number of operations to perform or negative if error.
+static int
+redirect_mappings(mapping *const mappings, const unsigned num_mappings, fd_operation *operations)
+{
+    mapping *const end_mappins = mappings + num_mappings;
+    uint16_t used_fds[MAX_OPERATIONS] = {0,};
+    fd_operation *ops = operations;
+
+#define DUMP_MAPPINGS do { \
+    if (DEBUG) { \
+        for (unsigned i = 0; i < num_mappings; ++i) { \
+            const mapping *m __attribute__((unused)) = &mappings[i]; \
+            log("mapping %s %d %d", m->uuid, m->current_fd, m->wanted_fd); \
+        } \
+        char lbuf[MAX_OPERATIONS* 16]; \
+        lbuf[0] = 0; \
+        for (int i = 0; i < MAX_OPERATIONS; ++i) { \
+            if (used_fds[i]) \
+                sprintf(strchr(lbuf, 0), "%d=%d,", i, used_fds[i]); \
+        } \
+        log("used %s", lbuf); \
+    } \
+} while(0);
+
+    log("handle");
+
+    // parse all mappings + standard fds, mark ones using range 0-MAX_OPERATIONS
+    for (mapping *m = mappings; m < end_mappins; ++m) {
+        if (m->current_fd < 0 || m->current_fd >= MAX_OPERATIONS)
+            continue;
+        used_fds[m->current_fd]++;
+    }
+    DUMP_MAPPINGS;
+
+    // Move standard file descriptors out of the way.
+    // Maximum 3 operations.
+    log("move standard fds away");
+    for (mapping *m = mappings; m < end_mappins; ++m) {
+        const int current_fd = m->current_fd;
+        if (current_fd < 0 || current_fd > 2)
+            continue;
+        // find first available fd to use
+        int fd = 3;
+        while (used_fds[fd])
+            ++fd;
+        *ops++ = (fd_operation){ current_fd, fd, FD_OP_DUP };
+        uint16_t changed = remap_fds(mappings, num_mappings, current_fd, fd);
+        log("changed %d from %d to %d", changed, current_fd, fd);
+        used_fds[current_fd] = 0;
+        used_fds[fd] = changed;
+    }
+    DUMP_MAPPINGS;
+
+    // Move standard fds into proper positions
+    // Maximum 3 operations (standard fds to be moved).
+    log("move standard fds correctly");
+    for (mapping *m = mappings; m < end_mappins; ++m) {
+        const int current_fd = m->current_fd;
+        if (current_fd < 0 || m->wanted_fd < 0)
+            continue;
+        int fd = m->wanted_fd;
+        FD_OP op = FD_OP_DUP;
+        if (current_fd >= num_mappings) {
+            // move
+            op = FD_OP_MOVE;
+            uint16_t changed = remap_fds(mappings, num_mappings, current_fd, fd);
+            log("changed %d from %d to %d", changed, current_fd, fd);
+            used_fds[fd] = changed;
+        } else {
+            // duplicate
+            m->current_fd = fd;
+            if (--used_fds[current_fd] == 0)
+                op = FD_OP_MOVE;
+            used_fds[fd] = 1;
+        }
+        *ops++ = (fd_operation){ current_fd, fd, op };
+    }
+    DUMP_MAPPINGS;
+
+    // Remove cloexec on range [3, 3 + num mappings).
+    // Maximum no standard mappings operations.
+    log("remove cloexec flags");
+    for (int fd = 3; fd < num_mappings; ++fd) {
+        if (!used_fds[fd])
+            continue;
+        log("remove cloexec from %d", fd);
+        *ops++ = (fd_operation){ fd, fd, FD_OP_DUP };
+    }
+    DUMP_MAPPINGS;
+
+    // Move all fds left in range [3, 3 + num mappings).
+    // Maximum no standard mapping operations; then sum with
+    // the above is the no standard mapping operations.
+    log("move all fds left in range");
+    int last_free = 3;
+    for (mapping *m = mappings; m < end_mappins; ++m) {
+        const int current_fd = m->current_fd;
+        if (m->wanted_fd >= 0)
+            continue;
+        if (current_fd < num_mappings && used_fds[current_fd] == 1)
+            continue;
+        while (used_fds[last_free])
+            ++last_free;
+        int fd = last_free;
+        // TODO copied from above
+        FD_OP op = FD_OP_DUP;
+        if (current_fd >= num_mappings) {
+            // move
+            op = FD_OP_MOVE;
+            uint16_t changed = remap_fds(mappings, num_mappings, current_fd, fd);
+            log("changed %d from %d to %d", changed, current_fd, fd);
+            used_fds[fd] = changed;
+        } else {
+            // duplicate
+            m->current_fd = fd;
+            if (--used_fds[current_fd] == 0)
+                op = FD_OP_MOVE;
+            used_fds[fd] = 1;
+        }
+        *ops++ = (fd_operation){ current_fd, fd, op };
+    }
+    DUMP_MAPPINGS;
+
+    // Close extra fds.
+    *ops++ = (fd_operation){ num_mappings, 0, FD_OP_CLOSE_FROM };
+
+    // Create missing standard fds.
+    // Maximum standard mapping operations, but not the above,
+    // so the sum with move the standard is 3.
+    for (int fd = 0; fd < 3; ++fd) {
+        if (used_fds[fd])
+            continue;
+        *ops++ = (fd_operation){ fd, fd, FD_OP_DEVNULL };
+    }
+
+    return ops - operations;
+}
+
+static uint16_t
+remap_fds(mapping *const mappings, unsigned num_mappings, int from, int to)
+{
+    uint16_t res = 0;
+    for (unsigned i = 0; i < num_mappings; ++i) {
+        mapping *m = &mappings[i];
+        if (m->current_fd == from) {
+            m->current_fd = to;
+            res++;
+        }
+    }
+    return res;
+}
+
+#endif

--- a/ocaml/forkexecd/lib/logs.c
+++ b/ocaml/forkexecd/lib/logs.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#include "logs.h"
+
+#if FORKEXECD_DEBUG_LOGS
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+
+#include <caml/fail.h>
+
+#define FILE_SIZE (32 * 1024)
+
+struct priv_mapped_logs {
+    uint32_t size;
+
+    // Flags, we use characters instead of binary so
+    // easily see them easily with different tools.
+    char flags[4];
+    char filename[64];
+    pid_t pid;
+    int num;
+};
+
+// flags order
+enum { SUCCESS, FAILURE };
+
+mapped_logs mapped_logs_open(void)
+{
+    static int last_num = 0;
+
+    // create a mapped file with a given size, will write header as structure
+    // and update using memory
+    mkdir("/tmp/fe_repl", 0777);
+
+    char tmpl[] = "/tmp/fe_repl/logXXXXXX";
+    int fd = mkstemp(tmpl);
+    if (!fd)
+        caml_raise_out_of_memory();
+
+    if (ftruncate(fd, FILE_SIZE) < 0) {
+        close(fd);
+        caml_raise_out_of_memory();
+    }
+
+    priv_mapped_logs *l = mmap(NULL, FILE_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+    if (l == MAP_FAILED) {
+        close(fd);
+        caml_raise_out_of_memory();
+    }
+    close(fd);
+
+    l->size = sizeof(*l);
+    memcpy(l->flags, "____", 4);
+    strncpy(l->filename, tmpl, sizeof(l->filename));
+    l->pid = getpid();
+    l->num = ++last_num;
+
+    return (mapped_logs){l};
+}
+
+#define RANGE \
+    char *start = (char*) logs.priv + sizeof(priv_mapped_logs); \
+    char *const end = (char*) logs.priv + FILE_SIZE
+
+void mapped_logs_close(mapped_logs logs)
+{
+    if (!logs.priv)
+        return;
+    RANGE;
+    bool written = false;
+    bool success = logs.priv->flags[FAILURE] == '_' && logs.priv->flags[SUCCESS] != '_';
+    if (!success) {
+        FILE *f = fopen("/tmp/fe_repl/all_logs", "a");
+        if (f) {
+            end[-1] = 0;
+            size_t len = strlen(start);
+            written = (fwrite(start, 1, len, f) == len);
+            fclose(f);
+        }
+    }
+    if (written || success)
+        unlink(logs.priv->filename);
+    munmap(logs.priv, FILE_SIZE);
+}
+
+void mapped_logs_failure(mapped_logs logs)
+{
+    if (!logs.priv)
+        return;
+    logs.priv->flags[FAILURE] = 'F';
+}
+
+void mapped_logs_success(mapped_logs logs)
+{
+    if (!logs.priv)
+        return;
+    logs.priv->flags[SUCCESS] = 'S';
+}
+
+void mapped_logs_add(mapped_logs logs, const char *fmt, ...)
+{
+    if (!logs.priv)
+        return;
+    int save_errno = errno;
+    RANGE;
+    start += strlen(start);
+    if (start >= end -1) {
+        errno = save_errno;
+        return; // no more space
+    }
+    size_t len = end - start;
+    int l = snprintf(start, len, "%d:%d ", (int) logs.priv->pid, logs.priv->num);
+    if (l >= len) {
+        errno = save_errno;
+        return;
+    }
+    start += l;
+    len -= l;
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(start, len, fmt, ap);
+    va_end(ap);
+
+    errno = save_errno;
+}
+#endif
+
+// vim: expandtab ts=4 sw=4 sts=4:

--- a/ocaml/forkexecd/lib/logs.c
+++ b/ocaml/forkexecd/lib/logs.c
@@ -53,7 +53,7 @@ mapped_logs mapped_logs_open(void)
 
     // create a mapped file with a given size, will write header as structure
     // and update using memory
-    mkdir("/tmp/fe_repl", 0777);
+    mkdir("/tmp/fe_repl", 0755);
 
     char tmpl[] = "/tmp/fe_repl/logXXXXXX";
     int fd = mkstemp(tmpl);
@@ -81,7 +81,7 @@ mapped_logs mapped_logs_open(void)
     return (mapped_logs){l};
 }
 
-#define RANGE \
+#define DEFINE_RANGE(start, end) \
     char *start = (char*) logs.priv + sizeof(priv_mapped_logs); \
     char *const end = (char*) logs.priv + FILE_SIZE
 
@@ -89,7 +89,7 @@ void mapped_logs_close(mapped_logs logs)
 {
     if (!logs.priv)
         return;
-    RANGE;
+    DEFINE_RANGE(start, end);
     bool written = false;
     bool success = logs.priv->flags[FAILURE] == '_' && logs.priv->flags[SUCCESS] != '_';
     if (!success) {
@@ -125,7 +125,7 @@ void mapped_logs_add(mapped_logs logs, const char *fmt, ...)
     if (!logs.priv)
         return;
     int save_errno = errno;
-    RANGE;
+    DEFINE_RANGE(start, end);
     start += strlen(start);
     if (start >= end -1) {
         errno = save_errno;

--- a/ocaml/forkexecd/lib/logs.h
+++ b/ocaml/forkexecd/lib/logs.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+// Definitions to write logs into memory mapped objects.
+// We use a memory mapped object here because we close file descriptors
+// so writing to file using them would cause logs to be lost.
+
+#if !defined(FORKEXECD_DEBUG_LOGS)
+#define FORKEXECD_DEBUG_LOGS 0
+#endif
+
+#if (FORKEXECD_DEBUG_LOGS) != 0 && (FORKEXECD_DEBUG_LOGS) != 1
+#error Expected FORKEXECD_DEBUG_LOGS to be defined either 0 or 1
+#endif
+
+typedef struct priv_mapped_logs priv_mapped_logs;
+typedef struct mapped_logs mapped_logs;
+
+#if FORKEXECD_DEBUG_LOGS
+struct mapped_logs {
+    priv_mapped_logs *priv;
+};
+#define NULL_MAPPED_LOGS ((mapped_logs){0})
+mapped_logs mapped_logs_open(void);
+void mapped_logs_close(mapped_logs logs);
+
+// Add a log entry, similar to printf.
+void mapped_logs_add(mapped_logs logs, const char *fmt, ...);
+
+// Mark as failed, any failure will keep the log.
+void mapped_logs_failure(mapped_logs logs);
+
+// Mark as successful, if successful and no failure during
+// execution the log will be removed.
+void mapped_logs_success(mapped_logs logs);
+#else
+// Use an empty structure, compiler will strip it passing
+// it as a parameter without the needs to change the source
+// code.
+struct mapped_logs {};
+#define NULL_MAPPED_LOGS ((mapped_logs){})
+static inline mapped_logs mapped_logs_open(void) {
+    return (mapped_logs){};
+}
+
+static inline void mapped_logs_close(mapped_logs logs) {
+}
+
+static inline void mapped_logs_failure(mapped_logs logs) {
+}
+
+static inline void mapped_logs_success(mapped_logs logs) {
+}
+
+#define mapped_logs_add(...) \
+    do {} while(0)
+#endif

--- a/ocaml/libs/stunnel/stunnel.ml
+++ b/ocaml/libs/stunnel/stunnel.ml
@@ -99,11 +99,6 @@ type pid =
   | FEFork of Forkhelpers.pidty  (** the forkhelpers module did it for us. *)
   | Nopid
 
-(* let string_of_pid = function
-   | StdFork x -> Printf.sprintf "(StdFork %d)" x
-   | FEFork x -> Forkhelpers.string_of_pidty x
-   | Nopid -> "None" *)
-
 let getpid ty =
   match ty with
   | StdFork pid ->


### PR DESCRIPTION
Forkexecd was written to avoid some issues with Ocaml and multi-threading.
Instead use C code to launch processes and avoid these issues. Interface remains unchanged from Ocaml side but implemntation rely entirely on C code.
vfork() is used to avoid performance memory issue. Reap of the processes are done directly.
Using fork() in XenPV guests is extremely expensive, currently forkexecd is calling 2 fork()s for each process launched.
Code automatically reap child processes to avoid zombies. One small helper is used in case syslog redirection is used. This allows to restart the toolstack and keep launched programs running; note that even with forkexecd daemon one process was used for this purpose.
Code tries to keep compability with forkexecd, in particular:
- SIGPIPE disposition is set to ignore;
- /dev/null is open with O_WRONLY even for stdin;
- file descriptors are limited to 1024. We use close_range (if available) to reduce system calls to close file descriptors.
Cgroup is set to avoid systemd closing processes on toolstack restart. There's a fuzzer program to check file remapping algorithm; for this reason the algorithm is in a separate file.

To turn internal debug on you need to set FORKEXECD_DEBUG_LOGS C preprocessor macro to 1.