### PR TITLE
CP-48667:  Generate Go SDK part2

### DIFF
--- a/ocaml/sdk-gen/go/README.md
+++ b/ocaml/sdk-gen/go/README.md
@@ -34,7 +34,7 @@ To network with other developers using XenServer visit
 
 ## Prerequisites
 
-This library requires Go 1.22 or greater.
+This library requires Go 1.22.2 or greater.
 
 ## Folder Structure
 

--- a/ocaml/sdk-gen/go/autogen/src/go.mod
+++ b/ocaml/sdk-gen/go/autogen/src/go.mod
@@ -1,3 +1,3 @@
 module go/xenapi
 
-go 1.22.0
+go 1.22.2

--- a/ocaml/sdk-gen/go/autogen/src/jsonrpc_client.go
+++ b/ocaml/sdk-gen/go/autogen/src/jsonrpc_client.go
@@ -1,0 +1,225 @@
+package xenapi
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+)
+
+type Request struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+	ID      int         `json:"id"`
+}
+
+type ResponseError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+type Response struct {
+	JSONRPC string         `json:"jsonrpc"`
+	Result  interface{}    `json:"result,omitempty"`
+	Error   *ResponseError `json:"error,omitempty"`
+	ID      int            `json:"id"`
+}
+
+func paramsParse(params ...interface{}) interface{} {
+	var finalParams interface{}
+	finalParams = params
+	if len(params) == 1 {
+		if params[0] != nil {
+			var typeOf reflect.Type
+			typeOf = reflect.TypeOf(params[0])
+			for typeOf != nil && typeOf.Kind() == reflect.Ptr {
+				typeOf = typeOf.Elem()
+			}
+			typeArr := []reflect.Kind{reflect.Struct, reflect.Array, reflect.Slice, reflect.Interface, reflect.Map}
+			if typeOf != nil {
+				for _, value := range typeArr {
+					if value == typeOf.Kind() {
+						finalParams = params[0]
+						break
+					}
+				}
+			}
+		}
+	}
+	return finalParams
+}
+
+type rpcClient struct {
+	endpoint   string
+	httpClient *http.Client
+	headers    map[string]string
+}
+
+func (client *rpcClient) newRequest(ctx context.Context, req interface{}) (*http.Request, error) {
+	dataByte, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, client.endpoint, bytes.NewReader(dataByte))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	request.Header.Set("Content-Type", "application/json; charset=utf-8")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "XenAPI/" + APIVersionLatest.String())
+	for k, v := range client.headers {
+		request.Header.Set(k, v)
+	}
+
+	return request, nil
+}
+
+func convertUnhandledJSONData(jsonBytes []byte) []byte {
+	jsonString := string(jsonBytes)
+	jsonString = strings.ReplaceAll(jsonString, ":Infinity", ":\"+Inf\"")
+	jsonString = strings.ReplaceAll(jsonString, ":-Infinity", ":\"-Inf\"")
+	jsonString = strings.ReplaceAll(jsonString, ":NaN", ":\"NaN\"")
+
+	return []byte(jsonString)
+}
+
+func (client *rpcClient) call(ctx context.Context, methodName string, params ...interface{}) (*Response, error) {
+	request := &Request{
+		ID:      0,
+		Method:  methodName,
+		Params:  paramsParse(params...),
+		JSONRPC: "2.0",
+	}
+
+	httpRequest, err := client.newRequest(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("could not create request for %v() : %w", request.Method, err)
+	}
+
+	httpResponse, err := client.httpClient.Do(httpRequest)
+	if err != nil {
+		return nil, fmt.Errorf("call %v() on %v. Error making http request: %w", request.Method, httpRequest.URL.Redacted(), err)
+	}
+	defer httpResponse.Body.Close()
+
+	var rpcResponse *Response
+	body, err := io.ReadAll(httpResponse.Body)
+	if err != nil {
+		return nil, fmt.Errorf("call %v() on %v status code: %v. Could not read response body: %w", request.Method, httpRequest.URL.Redacted(), httpResponse.StatusCode, err)
+	}
+	body = convertUnhandledJSONData(body)
+	err = json.Unmarshal(body, &rpcResponse)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("call %v() on %v status code: %v. Could not decode response body: %w", request.Method, httpRequest.URL.Redacted(), httpResponse.StatusCode, err)
+	}
+
+	if rpcResponse == nil {
+		return nil, fmt.Errorf("call %v() on %v status code: %v. Response missing", request.Method, httpRequest.URL.Redacted(), httpResponse.StatusCode)
+	}
+
+	return rpcResponse, nil
+}
+
+func (client *rpcClient) sentCall(methodName string, params ...interface{}) (result interface{}, err error) {
+	response, err := client.call(context.Background(), methodName, params...)
+	if err != nil {
+		return
+	}
+
+	if response.Error != nil {
+		errString := fmt.Sprintf("API error: code %d, message %s", response.Error.Code, response.Error.Message)
+		if response.Error.Data != nil {
+			errString += fmt.Sprintf(", data %v", response.Error.Data)
+		}
+		err = errors.New(errString)
+		return
+	}
+
+	result = response.Result
+	return
+}
+
+type SecureOpts struct {
+	ServerCert string
+	ClientCert string
+	ClientKey  string
+}
+
+type ClientOpts struct {
+	URL        string
+	SecureOpts *SecureOpts
+	Timeout    int
+	Headers    map[string]string
+}
+
+func newJSONRPCClient(opts *ClientOpts) *rpcClient {
+	client := &rpcClient{
+		endpoint:   fmt.Sprintf("%s%s", opts.URL, "/jsonrpc"),
+		httpClient: &http.Client{},
+		headers:    make(map[string]string),
+	}
+
+	if strings.HasPrefix(opts.URL, "https://") {
+		skipVerify := true
+		caCertPool := x509.NewCertPool()
+		certs := []tls.Certificate{}
+		if opts.SecureOpts != nil {
+			skipVerify = false
+			if opts.SecureOpts.ServerCert != "" {
+				caCert, err := os.ReadFile(opts.SecureOpts.ServerCert)
+				if err != nil {
+					log.Fatal(err)
+				}
+				caCertPool.AppendCertsFromPEM(caCert)
+			}
+			if opts.SecureOpts.ClientCert != "" || opts.SecureOpts.ClientKey != "" {
+				if opts.SecureOpts.ClientCert == "" {
+					log.Fatal(errors.New("missing client certificate"))
+				}
+				if opts.SecureOpts.ClientKey == "" {
+					log.Fatal(errors.New("missing client private key"))
+				}
+				cert, err := tls.LoadX509KeyPair(opts.SecureOpts.ClientCert, opts.SecureOpts.ClientKey)
+				if err != nil {
+					log.Fatal(err)
+				}
+				certs = []tls.Certificate{cert}
+			}
+		}
+		tlsConfig := &tls.Config{
+			RootCAs:            caCertPool,
+			Certificates:       certs,
+			InsecureSkipVerify: skipVerify, // #nosec
+		}
+		transport := &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
+		client.httpClient.Transport = transport
+	}
+
+	if opts.Timeout != 0 {
+		client.httpClient.Timeout = time.Duration(opts.Timeout) * time.Second
+	}
+
+	if opts.Headers != nil {
+		for k, v := range opts.Headers {
+			client.headers[k] = v
+		}
+	}
+
+	return client
+}

--- a/ocaml/sdk-gen/go/gen_go_binding.ml
+++ b/ocaml/sdk-gen/go/gen_go_binding.ml
@@ -55,7 +55,15 @@ let main destdir =
         render_template "FileHeader.mustache" obj ~newline:true ()
       in
       let record_rendered = render_template "Record.mustache" obj () in
-      let rendered = header_rendered ^ record_rendered in
+      let methods_rendered = render_template "Methods.mustache" obj () in
+      let rendered =
+        let first_half = header_rendered ^ record_rendered in
+        match methods_rendered with
+        | "" ->
+            first_half
+        | _ ->
+            first_half ^ "\n" ^ methods_rendered
+      in
       let output_file = name ^ ".go" in
       generate_file ~rendered ~destdir ~output_file
     )

--- a/ocaml/sdk-gen/go/gen_go_helper.ml
+++ b/ocaml/sdk-gen/go/gen_go_helper.ml
@@ -23,11 +23,33 @@ let templates_dir = "templates"
 
 let ( // ) = Filename.concat
 
+let special_words =
+  [
+    "id"
+  ; "ip"
+  ; "vm"
+  ; "api"
+  ; "uuid"
+  ; "cpu"
+  ; "tls"
+  ; "https"
+  ; "url"
+  ; "db"
+  ; "xml"
+  ; "eof"
+  ]
+
 let snake_to_camel (s : string) : string =
-  Astring.String.cuts ~sep:"_" s
-  |> List.map (fun s -> Astring.String.cuts ~sep:"-" s)
+  String.split_on_char '_' s
+  |> List.map (fun s -> String.split_on_char '-' s)
   |> List.concat
-  |> List.map String.capitalize_ascii
+  |> List.map (fun s ->
+         match s with
+         | s when List.mem s special_words ->
+             String.uppercase_ascii s
+         | _ ->
+             String.capitalize_ascii s
+     )
   |> String.concat ""
 
 let render_template template_file json ?(newline = false) () =
@@ -544,16 +566,7 @@ module Json = struct
       |> List.map (fun seg ->
              let lower = String.lowercase_ascii seg in
              match lower with
-             | "vm"
-             | "cpu"
-             | "tls"
-             | "xml"
-             | "url"
-             | "id"
-             | "uuid"
-             | "ip"
-             | "api"
-             | "eof" ->
+             | s when List.mem s special_words ->
                  String.uppercase_ascii lower
              | _ ->
                  String.capitalize_ascii lower

--- a/ocaml/sdk-gen/go/gen_go_helper.mli
+++ b/ocaml/sdk-gen/go/gen_go_helper.mli
@@ -15,14 +15,20 @@ val ( // ) : string -> string -> string
 
 val snake_to_camel : string -> string
 
+type fields = string * Datamodel_types.field list
+
 val render_template :
   string -> Mustache.Json.t -> ?newline:bool -> unit -> string
 
 val generate_file :
   rendered:string -> destdir:string -> output_file:string -> unit
 
+val objs_and_convert_functions :
+  Datamodel_types.obj list -> (string * Mustache.Json.t) list * Mustache.Json.t
+
 module Json : sig
-  val xenapi : Datamodel_types.obj list -> (string * Mustache.Json.t) list
+  val xenapi :
+    Datamodel_types.obj list -> (string * Mustache.Json.t) list * fields list
 
   val all_enums : Datamodel_types.obj list -> Mustache.Json.t
 

--- a/ocaml/sdk-gen/go/templates/APIErrors.mustache
+++ b/ocaml/sdk-gen/go/templates/APIErrors.mustache
@@ -1,6 +1,7 @@
+//nolint:gosec
 const (
 {{#api_errors}}
 	//
-	ERR_{{name}} = "{{name}}"
+	Error{{name}} = "{{value}}"
 {{/api_errors}}
 )

--- a/ocaml/sdk-gen/go/templates/APIMessages.mustache
+++ b/ocaml/sdk-gen/go/templates/APIMessages.mustache
@@ -1,6 +1,6 @@
 const (
 {{#api_messages}}
 	//
-	MSG_{{name}} = "{{name}}"
+	Message{{name}} = "{{value}}"
 {{/api_messages}}
 )

--- a/ocaml/sdk-gen/go/templates/APIVersions.mustache
+++ b/ocaml/sdk-gen/go/templates/APIVersions.mustache
@@ -1,0 +1,103 @@
+type APIVersion int
+
+const (
+{{#releases}}
+	// {{branding}} ({{code_name}})
+	APIVersion{{version_major}}_{{version_minor}}{{#first}} APIVersion = iota + 1{{/first}}
+{{/releases}}  
+	APIVersionLatest  APIVersion = {{latest_version_index}}
+	APIVersionUnknown APIVersion = 99
+)
+
+func (v APIVersion) String() string {
+	switch v {
+{{#releases}}
+	case APIVersion{{version_major}}_{{version_minor}}:
+		return "{{version_major}}.{{version_minor}}"
+{{/releases}}
+	case APIVersionUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
+var APIVersionMap = map[string]APIVersion{
+{{#releases}}
+	//
+	"APIVersion{{version_major}}_{{version_minor}}": APIVersion{{version_major}}_{{version_minor}},
+{{/releases}}
+	//
+	"APIVersionLatest": APIVersionLatest,
+	//
+	"APIVersionUnknown": APIVersionUnknown,
+}
+
+func GetAPIVersion(major int, minor int) APIVersion {
+	versionName := fmt.Sprintf("APIVersion%d_%d", major, minor)
+	apiVersion, ok := APIVersionMap[versionName]
+	if !ok {
+		apiVersion = APIVersionUnknown
+	}
+
+	return apiVersion
+}
+
+func getPoolMaster(session *Session) (HostRef, error) {
+	var master HostRef
+	poolRefs, err := Pool.GetAll(session)
+	if err != nil {
+		return master, err
+	}
+	if len(poolRefs) > 0 {
+		poolRecord, err := Pool.GetRecord(session, poolRefs[0])
+		if err != nil {
+			return master, err
+		}
+		return poolRecord.Master, nil
+	}
+	return master, errors.New("pool master not found")
+}
+
+func setSessionDetails(session *Session) error {
+	err := setAPIVersion(session)
+	if err != nil {
+		return err
+	}
+	err = setXAPIVersion(session)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setAPIVersion(session *Session) error {
+	session.APIVersion = APIVersionUnknown
+	masterRef, err := getPoolMaster(session)
+	if err != nil {
+		return err
+	}
+	hostRecord, err := Host.GetRecord(session, masterRef)
+	if err != nil {
+		return err
+	}
+	session.APIVersion = GetAPIVersion(hostRecord.APIVersionMajor, hostRecord.APIVersionMinor)
+	return nil
+}
+
+func setXAPIVersion(session *Session) error {
+	masterRef, err := getPoolMaster(session)
+	if err != nil {
+		return err
+	}
+	hostRecord, err := Host.GetRecord(session, masterRef)
+	if err != nil {
+		return err
+	}
+	version, ok := hostRecord.SoftwareVersion["xapi"]
+	if !ok {
+		return errors.New("xapi version not found")
+	}
+	session.XAPIVersion = version
+	return nil
+}

--- a/ocaml/sdk-gen/go/templates/ConvertBatch.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertBatch.mustache
@@ -1,0 +1,22 @@
+{{#batch}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (batch {{type}}, err error) {
+	rpcStruct, ok := input.(map[string]interface{})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "map[string]interface{}", context, reflect.TypeOf(input), input)
+		return
+	}
+{{#elements}}
+	{{name_internal}}Value, ok := rpcStruct["{{name}}"]
+	if ok && {{name_internal}}Value != nil {
+		batch.{{name_exported}}, err = deserialize{{func_partial_type}}(fmt.Sprintf("%s.%s", context, "{{name}}"), {{name_internal}}Value)
+		if err != nil {
+			return
+		}
+	}
+{{/elements}}
+	return
+}
+
+{{/deserialize}}
+{{/batch}}

--- a/ocaml/sdk-gen/go/templates/ConvertEnum.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertEnum.mustache
@@ -1,0 +1,27 @@
+{{#enum}}
+{{#serialize}}
+func serialize{{func_partial_type}}(context string, value {{type}}) (string, error) {
+	_ = context
+	return string(value), nil
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (value {{type}}, err error) {
+	strValue, err := deserializeString(context, input)
+	if err != nil {
+		return
+	}
+	switch strValue {
+{{#items}}
+	case "{{value}}":
+		value = {{name}}
+{{/items}}
+	default:
+		err = fmt.Errorf("unable to parse XenAPI response: got value %q for enum %s at %s, but this is not any of the known values", strValue, "{{type}}", context)
+	}
+	return
+}
+
+{{/deserialize}}
+{{/enum}}

--- a/ocaml/sdk-gen/go/templates/ConvertFloat.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertFloat.mustache
@@ -1,0 +1,40 @@
+{{#float}}
+{{#serialize}}
+//nolint:unparam
+func serialize{{func_partial_type}}(context string, value {{type}}) (interface{}, error) {
+	_ = context
+	if math.IsInf(value, 0) {
+		if math.IsInf(value, 1) {
+			return "+Inf", nil
+		}
+		return "-Inf", nil
+	} else if math.IsNaN(value) {
+		return "NaN", nil
+	}
+	return value, nil
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (value {{type}}, err error) {
+	_ = context
+	if input == nil {
+		return
+	}
+	strValue := fmt.Sprintf("%v", input)
+	value, err = strconv.ParseFloat(strValue, 64)
+	if err != nil {
+		switch strValue {
+		case "+Inf":
+			return math.Inf(1), nil
+		case "-Inf":
+			return math.Inf(-1), nil
+		case "NaN":
+			return math.NaN(), nil
+		}
+	}
+	return
+}
+
+{{/deserialize}}
+{{/float}}

--- a/ocaml/sdk-gen/go/templates/ConvertInt.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertInt.mustache
@@ -1,0 +1,27 @@
+{{#int}}
+{{#serialize}}
+func serialize{{func_partial_type}}(context string, value {{type}}) ({{type}}, error) {
+	_ = context
+	return value, nil
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (value {{type}}, err error) {
+	_ = context
+	if input == nil {
+		return
+	}
+	strValue := fmt.Sprintf("%v", input)
+	value, err = strconv.Atoi(strValue)
+	if err != nil {
+		floatValue, err1 := strconv.ParseFloat(strValue, 64)
+		if err1 == nil {
+			return int(floatValue), nil
+		}
+	}
+	return
+}
+
+{{/deserialize}}
+{{/int}}

--- a/ocaml/sdk-gen/go/templates/ConvertInterface.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertInterface.mustache
@@ -1,0 +1,10 @@
+{{#interface}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (inter {{type}}, err error) {
+	_ = context
+	inter = input
+	return
+}
+
+{{/deserialize}}
+{{/interface}}

--- a/ocaml/sdk-gen/go/templates/ConvertMap.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertMap.mustache
@@ -1,0 +1,45 @@
+{{#map}}
+{{#serialize}}
+func serialize{{func_partial_type}}(context string, goMap {{type}}) (xenMap map[string]interface{}, err error) {
+	xenMap = make(map[string]interface{})
+	for goKey, goValue := range goMap {
+		keyContext := fmt.Sprintf("%s[%s]", context, goKey)
+		xenKey, err := serialize{{key_type}}(keyContext, goKey)
+		if err != nil {
+			return xenMap, err
+		}
+		xenValue, err := serialize{{value_type}}(keyContext, goValue)
+		if err != nil {
+			return xenMap, err
+		}
+		xenMap[xenKey] = xenValue
+	}
+	return
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (goMap {{type}}, err error) {
+	xenMap, ok := input.(map[string]interface{})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "map[string]interface{}", context, reflect.TypeOf(input), input)
+		return
+	}
+	goMap = make({{type}}, len(xenMap))
+	for xenKey, xenValue := range xenMap {
+		keyContext := fmt.Sprintf("%s[%s]", context, xenKey)
+		goKey, err := deserialize{{key_type}}(keyContext, xenKey)
+		if err != nil {
+			return goMap, err
+		}
+		goValue, err := deserialize{{value_type}}(keyContext, xenValue)
+		if err != nil {
+			return goMap, err
+		}
+		goMap[goKey] = goValue
+	}
+	return
+}
+
+{{/deserialize}}
+{{/map}}

--- a/ocaml/sdk-gen/go/templates/ConvertOption.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertOption.mustache
@@ -1,0 +1,29 @@
+{{#option}}
+{{#serialize}}
+func serializeOption{{func_partial_type}}(context string, input Option{{func_partial_type}}) (option interface{}, err error) {
+	if input == nil {
+		return
+	}
+	option, err = serialize{{func_partial_type}}(context, *input)
+	if err != nil {
+		return
+	}
+	return
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserializeOption{{func_partial_type}}(context string, input interface{}) (option Option{{func_partial_type}}, err error) {
+	if input == nil {
+		return
+	}
+	value, err := deserialize{{func_partial_type}}(context, input)
+	if err != nil {
+		return
+	}
+	option = &value
+	return
+}
+
+{{/deserialize}}
+{{/option}}

--- a/ocaml/sdk-gen/go/templates/ConvertRecord.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertRecord.mustache
@@ -1,0 +1,54 @@
+{{#record}}
+{{#serialize}}
+func serialize{{func_partial_type}}(context string, record {{type}}) (rpcStruct map[string]interface{}, err error) {
+	rpcStruct = map[string]interface{}{}
+{{#fields}}
+{{#type_option}}
+	{{name_internal}}, err := serializeOption{{func_partial_type}}(fmt.Sprintf("%s.%s", context, "{{name}}"), record.{{name_exported}})
+	if err != nil {
+		return
+	}
+	if {{name_internal}} != nil {
+		rpcStruct["{{name}}"] = {{name_internal}}
+	}
+{{/type_option}}
+{{^type_option}}
+	rpcStruct["{{name}}"], err = serialize{{func_partial_type}}(fmt.Sprintf("%s.%s", context, "{{name}}"), record.{{name_exported}})
+	if err != nil {
+		return
+	}
+{{/type_option}}
+{{/fields}}
+	return
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (record {{type}}, err error) {
+	rpcStruct, ok := input.(map[string]interface{})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "map[string]interface{}", context, reflect.TypeOf(input), input)
+		return
+	}
+{{#fields}}
+{{#type_option}}
+	record.{{name_exported}}, err = deserializeOption{{func_partial_type}}(fmt.Sprintf("%s.%s", context, "{{name}}"), rpcStruct["{{name}}"])
+	if err != nil {
+		return
+	}
+{{/type_option}}
+{{^type_option}}
+	{{name_internal}}Value, ok := rpcStruct["{{name}}"]
+	if ok && {{name_internal}}Value != nil {
+		record.{{name_exported}}, err = deserialize{{func_partial_type}}(fmt.Sprintf("%s.%s", context, "{{name}}"), {{name_internal}}Value)
+		if err != nil {
+			return
+		}
+	}
+{{/type_option}}
+{{/fields}}
+	return
+}
+
+{{/deserialize}}
+{{/record}}

--- a/ocaml/sdk-gen/go/templates/ConvertRef.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertRef.mustache
@@ -1,0 +1,20 @@
+{{#ref}}
+{{#serialize}}
+func serialize{{func_partial_type}}(context string, ref {{type}}) (string, error) {
+	_ = context
+	return string(ref), nil
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) ({{type}}, error) {
+	var ref {{type}}
+	value, ok := input.(string)
+	if !ok {
+		return ref, fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "string", context, reflect.TypeOf(input), input)
+	}
+	return {{type}}(value), nil
+}
+
+{{/deserialize}}
+{{/ref}}

--- a/ocaml/sdk-gen/go/templates/ConvertSet.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertSet.mustache
@@ -1,0 +1,37 @@
+{{#set}}
+{{#serialize}}
+func serialize{{func_partial_type}}(context string, slice []{{type}}) (set []interface{}, err error) {
+	set = make([]interface{}, len(slice))
+	for index, item := range slice {
+		itemContext := fmt.Sprintf("%s[%d]", context, index)
+		itemValue, err := serialize{{item_func_partial_type}}(itemContext, item)
+		if err != nil {
+			return set, err
+		}
+		set[index] = itemValue
+	}
+	return
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (slice []{{type}}, err error) {
+	set, ok := input.([]interface{})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "[]interface{}", context, reflect.TypeOf(input), input)
+		return
+	}
+	slice = make([]{{type}}, len(set))
+	for index, item := range set {
+		itemContext := fmt.Sprintf("%s[%d]", context, index)
+		itemValue, err := deserialize{{item_func_partial_type}}(itemContext, item)
+		if err != nil {
+			return slice, err
+		}
+		slice[index] = itemValue
+	}
+	return
+}
+
+{{/deserialize}}
+{{/set}}

--- a/ocaml/sdk-gen/go/templates/ConvertSimpleType.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertSimpleType.mustache
@@ -1,0 +1,22 @@
+{{#simple_type}}
+{{#serialize}}
+func serialize{{func_partial_type}}(context string, value {{type}}) ({{type}}, error) {
+	_ = context
+	return value, nil
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (value {{type}}, err error) {
+	if input == nil {
+		return
+	}
+	value, ok := input.({{type}})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "{{type}}", context, reflect.TypeOf(input), input)
+	}
+	return
+}
+
+{{/deserialize}}
+{{/simple_type}}

--- a/ocaml/sdk-gen/go/templates/ConvertTime.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertTime.mustache
@@ -1,0 +1,36 @@
+{{#time}}
+var timeFormats = []string{time.RFC3339, "20060102T15:04:05Z", "20060102T15:04:05"}
+
+{{#serialize}}
+//nolint:unparam
+func serialize{{func_partial_type}}(context string, value {{type}}) (string, error) {
+	_ = context
+	return value.Format(time.RFC3339), nil
+}
+
+{{/serialize}}
+{{#deserialize}}
+func deserialize{{func_partial_type}}(context string, input interface{}) (value {{type}}, err error) {
+	_ = context
+	if input == nil {
+		return
+	}
+	strValue := fmt.Sprintf("%v", input)
+	floatValue, err := strconv.ParseFloat(strValue, 64)
+	if err != nil {
+		for _, timeFormat := range timeFormats {
+			value, err = time.Parse(timeFormat, strValue)
+			if err == nil {
+				return value, nil
+			}
+		}
+		return
+	}
+	unixTimestamp, err := strconv.ParseInt(strconv.Itoa(int(floatValue)), 10, 64)
+	value = time.Unix(unixTimestamp, 0)
+
+	return
+}
+
+{{/deserialize}}
+{{/time}}

--- a/ocaml/sdk-gen/go/templates/Methods.mustache
+++ b/ocaml/sdk-gen/go/templates/Methods.mustache
@@ -1,0 +1,64 @@
+{{#messages}}
+// {{method_name_exported}}:{{#description}} {{.}}{{/description}}
+{{#has_error}}
+//
+// Errors:
+{{/has_error}}
+{{#errors}}
+// {{name}} - {{doc}}
+{{/errors}}
+func ({{#session_class}}class *Session{{/session_class}}{{^session_class}}{{name_internal}}{{/session_class}}) {{method_name_exported}}({{#params}}{{^param_ignore}}{{^first}}, {{/first}}{{#session}}session *Session{{/session}}{{^session}}{{name_internal}} {{type}}{{/session}}{{/param_ignore}}{{/params}}) ({{#result}}retval {{type}}, {{/result}}err error) {
+	method := "{{class_name}}.{{method_name}}"
+{{#params}}
+	{{name_internal}}Arg, err := serialize{{func_partial_type}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{#session}}{{#session_class}}class{{/session_class}}{{^session_class}}session{{/session_class}}.ref{{/session}}{{^session}}{{name_internal}}{{/session}})
+	if err != nil {
+		return
+	}
+{{/params}}
+	{{#result}}result, err := {{/result}}{{^result}}_, err = {{/result}}{{#session_class}}class{{/session_class}}{{^session_class}}session{{/session_class}}.client.sentCall(method{{#params}}, {{name_internal}}Arg{{/params}})
+{{#result}}
+	if err != nil {
+		return
+	}
+	retval, err = deserialize{{func_partial_type}}(method+" -> ", result)
+{{/result}}
+{{#session_login}}
+	if err != nil {
+		return
+	}
+	class.ref = retval
+	err = setSessionDetails(class)
+{{/session_login}}
+{{#session_logout}}
+	class.ref = ""
+{{/session_logout}}
+	return
+}
+
+{{#async}}
+// Async{{method_name_exported}}:{{#description}} {{.}}{{/description}}
+{{#has_error}}
+//
+// Errors:
+{{/has_error}}
+{{#errors}}
+// {{name}} - {{doc}}
+{{/errors}}
+func ({{#session_class}}class *Session{{/session_class}}{{^session_class}}{{name_internal}}{{/session_class}}) Async{{method_name_exported}}({{#params}}{{^param_ignore}}{{^first}}, {{/first}}{{#session}}session *Session{{/session}}{{^session}}{{name_internal}} {{type}}{{/session}}{{/param_ignore}}{{/params}}) (retval TaskRef, err error) {
+	method := "Async.{{class_name}}.{{method_name}}"
+{{#params}}
+	{{name_internal}}Arg, err := serialize{{func_partial_type}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{#session}}{{#session_class}}class{{/session_class}}{{^session_class}}session{{/session_class}}.ref{{/session}}{{^session}}{{name_internal}}{{/session}})
+	if err != nil {
+		return
+	}
+{{/params}}
+	result, err := {{#session_class}}class{{/session_class}}{{^session_class}}session{{/session_class}}.client.sentCall(method{{#params}}, {{name_internal}}Arg{{/params}})
+	if err != nil {
+		return
+	}
+	retval, err = deserializeTaskRef(method+" -> ", result)
+	return
+}
+
+{{/async}}
+{{/messages}}

--- a/ocaml/sdk-gen/go/templates/Option.mustache
+++ b/ocaml/sdk-gen/go/templates/Option.mustache
@@ -1,0 +1,4 @@
+{{#option}}
+type Option{{func_partial_type}} *{{type}}
+
+{{/option}}

--- a/ocaml/sdk-gen/go/templates/Record.mustache
+++ b/ocaml/sdk-gen/go/templates/Record.mustache
@@ -21,21 +21,23 @@ type EventBatch struct {
 // {{.}}
 {{/description}}
 {{#session}}
-type {{name}}Class struct {
-	client *rpcClient
-	ref    SessionRef
+type {{name}} struct {
+	APIVersion  APIVersion
+	client      *rpcClient
+	ref         SessionRef
+	XAPIVersion string
 }
 
-func NewSession(opts *ClientOpts) *SessionClass {
-	client := NewJsonRPCClient(opts)
-	var session SessionClass
+func NewSession(opts *ClientOpts) *Session {
+	client := newJSONRPCClient(opts)
+	var session Session
 	session.client = client
 
 	return &session
 }
 {{/session}}
 {{^session}}
-type {{name}}Class struct{}
+type {{name_internal}} struct{}
 
-var {{name}} *{{name}}Class
+var {{name}} {{name_internal}}
 {{/session}}

--- a/ocaml/sdk-gen/go/test_data/api_errors.go
+++ b/ocaml/sdk-gen/go/test_data/api_errors.go
@@ -1,6 +1,7 @@
+//nolint:gosec
 const (
 	//
-	ERR_MESSAGE_DEPRECATED = "MESSAGE_DEPRECATED"
+	ErrorMessageDeprecated = "MESSAGE_DEPRECATED"
 	//
-	ERR_MESSAGE_REMOVED = "MESSAGE_REMOVED"
+	ErrorMessageRemoved = "MESSAGE_REMOVED"
 )

--- a/ocaml/sdk-gen/go/test_data/api_messages.go
+++ b/ocaml/sdk-gen/go/test_data/api_messages.go
@@ -1,6 +1,6 @@
 const (
 	//
-	MSG_HA_STATEFILE_LOST = "HA_STATEFILE_LOST"
+	MessageHaStatefileLost = "HA_STATEFILE_LOST"
 	//
-	MSG_METADATA_LUN_HEALTHY = "METADATA_LUN_HEALTHY"
+	MessageMetadataLunHealthy = "METADATA_LUN_HEALTHY"
 )

--- a/ocaml/sdk-gen/go/test_data/batch.go
+++ b/ocaml/sdk-gen/go/test_data/batch.go
@@ -1,0 +1,22 @@
+func deserializeEventBatch(context string, input interface{}) (batch EventBatch, err error) {
+	rpcStruct, ok := input.(map[string]interface{})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "map[string]interface{}", context, reflect.TypeOf(input), input)
+		return
+	}
+	tokenValue, ok := rpcStruct["token"]
+	if ok && tokenValue != nil {
+		batch.Token, err = deserializeString(fmt.Sprintf("%s.%s", context, "token"), tokenValue)
+		if err != nil {
+			return
+		}
+	}
+	validRefCountsValue, ok := rpcStruct["valid_ref_counts"]
+	if ok && validRefCountsValue != nil {
+		batch.ValidRefCounts, err = deserializeStringToIntMap(fmt.Sprintf("%s.%s", context, "valid_ref_counts"), validRefCountsValue)
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/enum_convert.go
+++ b/ocaml/sdk-gen/go/test_data/enum_convert.go
@@ -1,0 +1,20 @@
+func serializeEnumTaskStatusType(context string, value TaskStatusType) (string, error) {
+	_ = context
+	return string(value), nil
+}
+
+func deserializeEnumTaskStatusType(context string, input interface{}) (value TaskStatusType, err error) {
+	strValue, err := deserializeString(context, input)
+	if err != nil {
+		return
+	}
+	switch strValue {
+	case "pending":
+		value = TaskStatusTypePending
+	case "success":
+		value = TaskStatusTypeSuccess
+	default:
+		err = fmt.Errorf("unable to parse XenAPI response: got value %q for enum %s at %s, but this is not any of the known values", strValue, "TaskStatusType", context)
+	}
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/float.go
+++ b/ocaml/sdk-gen/go/test_data/float.go
@@ -1,0 +1,33 @@
+//nolint:unparam
+func serializeFloat(context string, value float64) (interface{}, error) {
+	_ = context
+	if math.IsInf(value, 0) {
+		if math.IsInf(value, 1) {
+			return "+Inf", nil
+		}
+		return "-Inf", nil
+	} else if math.IsNaN(value) {
+		return "NaN", nil
+	}
+	return value, nil
+}
+
+func deserializeFloat(context string, input interface{}) (value float64, err error) {
+	_ = context
+	if input == nil {
+		return
+	}
+	strValue := fmt.Sprintf("%v", input)
+	value, err = strconv.ParseFloat(strValue, 64)
+	if err != nil {
+		switch strValue {
+		case "+Inf":
+			return math.Inf(1), nil
+		case "-Inf":
+			return math.Inf(-1), nil
+		case "NaN":
+			return math.NaN(), nil
+		}
+	}
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/int.go
+++ b/ocaml/sdk-gen/go/test_data/int.go
@@ -1,0 +1,20 @@
+func serializeInt(context string, value int) (int, error) {
+	_ = context
+	return value, nil
+}
+
+func deserializeInt(context string, input interface{}) (value int, err error) {
+	_ = context
+	if input == nil {
+		return
+	}
+	strValue := fmt.Sprintf("%v", input)
+	value, err = strconv.Atoi(strValue)
+	if err != nil {
+		floatValue, err1 := strconv.ParseFloat(strValue, 64)
+		if err1 == nil {
+			return int(floatValue), nil
+		}
+	}
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/interface.go
+++ b/ocaml/sdk-gen/go/test_data/interface.go
@@ -1,0 +1,5 @@
+func deserializeRecordInterface(context string, input interface{}) (inter RecordInterface, err error) {
+	_ = context
+	inter = input
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/map.go
+++ b/ocaml/sdk-gen/go/test_data/map.go
@@ -1,0 +1,38 @@
+func serializeVIFRefToStringMap(context string, goMap map[VIFRef]string) (xenMap map[string]interface{}, err error) {
+	xenMap = make(map[string]interface{})
+	for goKey, goValue := range goMap {
+		keyContext := fmt.Sprintf("%s[%s]", context, goKey)
+		xenKey, err := serializeVIFRef(keyContext, goKey)
+		if err != nil {
+			return xenMap, err
+		}
+		xenValue, err := serializeString(keyContext, goValue)
+		if err != nil {
+			return xenMap, err
+		}
+		xenMap[xenKey] = xenValue
+	}
+	return
+}
+
+func deserializePBDRefToPBDRecordMap(context string, input interface{}) (goMap map[PBDRef]PBDRecord, err error) {
+	xenMap, ok := input.(map[string]interface{})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "map[string]interface{}", context, reflect.TypeOf(input), input)
+		return
+	}
+	goMap = make(map[PBDRef]PBDRecord, len(xenMap))
+	for xenKey, xenValue := range xenMap {
+		keyContext := fmt.Sprintf("%s[%s]", context, xenKey)
+		goKey, err := deserializePBDRef(keyContext, xenKey)
+		if err != nil {
+			return goMap, err
+		}
+		goValue, err := deserializePBDRecord(keyContext, xenValue)
+		if err != nil {
+			return goMap, err
+		}
+		goMap[goKey] = goValue
+	}
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/methods.go
+++ b/ocaml/sdk-gen/go/test_data/methods.go
@@ -1,0 +1,80 @@
+// GetLog: GetLog Get the host log file
+func (host) GetLog(session *Session, host HostRef) (retval string, err error) {
+	method := "host.get_log"
+	sessionIDArg, err := serializeSessionRef(fmt.Sprintf("%s(%s)", method, "session_id"), session.ref)
+	if err != nil {
+		return
+	}
+	hostArg, err := serializeHostRef(fmt.Sprintf("%s(%s)", method, "host"), host)
+	if err != nil {
+		return
+	}
+	result, err := session.client.sentCall(method, sessionIDArg, hostArg)
+	if err != nil {
+		return
+	}
+	retval, err = deserializeString(method+" -> ", result)
+	return
+}
+
+// AsyncGetLog: GetLog Get the host log file
+func (host) AsyncGetLog(session *Session, host HostRef) (retval TaskRef, err error) {
+	method := "Async.host.get_log"
+	sessionIDArg, err := serializeSessionRef(fmt.Sprintf("%s(%s)", method, "session_id"), session.ref)
+	if err != nil {
+		return
+	}
+	hostArg, err := serializeHostRef(fmt.Sprintf("%s(%s)", method, "host"), host)
+	if err != nil {
+		return
+	}
+	result, err := session.client.sentCall(method, sessionIDArg, hostArg)
+	if err != nil {
+		return
+	}
+	retval, err = deserializeTaskRef(method+" -> ", result)
+	return
+}
+
+// LoginWithPassword: Attempt to authenticate the user); returning a session reference if successful
+//
+// Errors:
+// SESSION_AUTHENTICATION_FAILED - The credentials given by the user are incorrect
+func (class *Session) LoginWithPassword(session *Session, session *Session) (retval SessionRef, err error) {
+	method := "session.login_with_password"
+	unameArg, err := serializeString(fmt.Sprintf("%s(%s)", method, "uname"), class.ref)
+	if err != nil {
+		return
+	}
+	pwdArg, err := serializeString(fmt.Sprintf("%s(%s)", method, "pwd"), class.ref)
+	if err != nil {
+		return
+	}
+	result, err := class.client.sentCall(method, unameArg, pwdArg)
+	if err != nil {
+		return
+	}
+	retval, err = deserializeSessionRef(method+" -> ", result)
+	if err != nil {
+		return
+	}
+	class.ref = retval
+	err = setSessionDetails(class)
+	return
+}
+
+// Logout: Logout Log out of a session
+func (class *Session) Logout(session *Session) (err error) {
+	method := "session.logout"
+	sessionIDArg, err := serializeSessionRef(fmt.Sprintf("%s(%s)", method, "session_id"), class.ref)
+	if err != nil {
+		return
+	}
+	testParamArg, err := serializeString(fmt.Sprintf("%s(%s)", method, "test_param"), class.ref)
+	if err != nil {
+		return
+	}
+	_, err = class.client.sentCall(method, sessionIDArg, testParamArg)
+	class.ref = ""
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/option.go
+++ b/ocaml/sdk-gen/go/test_data/option.go
@@ -1,0 +1,22 @@
+func serializeOptionSrStatRecord(context string, input OptionSrStatRecord) (option interface{}, err error) {
+	if input == nil {
+		return
+	}
+	option, err = serializeSrStatRecord(context, *input)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func deserializeOptionSrStatRecord(context string, input interface{}) (option OptionSrStatRecord, err error) {
+	if input == nil {
+		return
+	}
+	value, err := deserializeSrStatRecord(context, input)
+	if err != nil {
+		return
+	}
+	option = &value
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/record.go
+++ b/ocaml/sdk-gen/go/test_data/record.go
@@ -8,14 +8,16 @@ type SessionRecord struct {
 type SessionRef string
 
 // A session
-type SessionClass struct {
-	client *rpcClient
-	ref    SessionRef
+type Session struct {
+	APIVersion  APIVersion
+	client      *rpcClient
+	ref         SessionRef
+	XAPIVersion string
 }
 
-func NewSession(opts *ClientOpts) *SessionClass {
-	client := NewJsonRPCClient(opts)
-	var session SessionClass
+func NewSession(opts *ClientOpts) *Session {
+	client := newJSONRPCClient(opts)
+	var session Session
 	session.client = client
 
 	return &session

--- a/ocaml/sdk-gen/go/test_data/record_convert.go
+++ b/ocaml/sdk-gen/go/test_data/record_convert.go
@@ -1,0 +1,35 @@
+func serializeVBDRecord(context string, record VBDRecord) (rpcStruct map[string]interface{}, err error) {
+	rpcStruct = map[string]interface{}{}
+	rpcStruct["uuid"], err = serializeString(fmt.Sprintf("%s.%s", context, "uuid"), record.UUID)
+	if err != nil {
+		return
+	}
+	rpcStruct["allowed_operations"], err = serializeEnumVbdOperationsSet(fmt.Sprintf("%s.%s", context, "allowed_operations"), record.AllowedOperations)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func deserializeVBDRecord(context string, input interface{}) (record VBDRecord, err error) {
+	rpcStruct, ok := input.(map[string]interface{})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "map[string]interface{}", context, reflect.TypeOf(input), input)
+		return
+	}
+	uuidValue, ok := rpcStruct["uuid"]
+	if ok && uuidValue != nil {
+		record.UUID, err = deserializeString(fmt.Sprintf("%s.%s", context, "uuid"), uuidValue)
+		if err != nil {
+			return
+		}
+	}
+	allowedOperationsValue, ok := rpcStruct["allowed_operations"]
+	if ok && allowedOperationsValue != nil {
+		record.AllowedOperations, err = deserializeEnumVbdOperationsSet(fmt.Sprintf("%s.%s", context, "allowed_operations"), allowedOperationsValue)
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/ref.go
+++ b/ocaml/sdk-gen/go/test_data/ref.go
@@ -1,0 +1,13 @@
+func serializeVMRef(context string, ref VMRef) (string, error) {
+	_ = context
+	return string(ref), nil
+}
+
+func deserializeVMRef(context string, input interface{}) (VMRef, error) {
+	var ref VMRef
+	value, ok := input.(string)
+	if !ok {
+		return ref, fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "string", context, reflect.TypeOf(input), input)
+	}
+	return VMRef(value), nil
+}

--- a/ocaml/sdk-gen/go/test_data/set.go
+++ b/ocaml/sdk-gen/go/test_data/set.go
@@ -1,0 +1,30 @@
+func serializeSRRefSet(context string, slice []SRRef) (set []interface{}, err error) {
+	set = make([]interface{}, len(slice))
+	for index, item := range slice {
+		itemContext := fmt.Sprintf("%s[%d]", context, index)
+		itemValue, err := serializeSRRef(itemContext, item)
+		if err != nil {
+			return set, err
+		}
+		set[index] = itemValue
+	}
+	return
+}
+
+func deserializeStringSet(context string, input interface{}) (slice []string, err error) {
+	set, ok := input.([]interface{})
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "[]interface{}", context, reflect.TypeOf(input), input)
+		return
+	}
+	slice = make([]string, len(set))
+	for index, item := range set {
+		itemContext := fmt.Sprintf("%s[%d]", context, index)
+		itemValue, err := deserializeString(itemContext, item)
+		if err != nil {
+			return slice, err
+		}
+		slice[index] = itemValue
+	}
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/simple_type.go
+++ b/ocaml/sdk-gen/go/test_data/simple_type.go
@@ -1,0 +1,31 @@
+func serializeString(context string, value string) (string, error) {
+	_ = context
+	return value, nil
+}
+
+func serializeBool(context string, value bool) (bool, error) {
+	_ = context
+	return value, nil
+}
+
+func deserializeString(context string, input interface{}) (value string, err error) {
+	if input == nil {
+		return
+	}
+	value, ok := input.(string)
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "string", context, reflect.TypeOf(input), input)
+	}
+	return
+}
+
+func deserializeBool(context string, input interface{}) (value bool, err error) {
+	if input == nil {
+		return
+	}
+	value, ok := input.(bool)
+	if !ok {
+		err = fmt.Errorf("failed to parse XenAPI response: expected Go type %s at %s but got Go type %s with value %v", "bool", context, reflect.TypeOf(input), input)
+	}
+	return
+}

--- a/ocaml/sdk-gen/go/test_data/time.go
+++ b/ocaml/sdk-gen/go/test_data/time.go
@@ -1,0 +1,29 @@
+var timeFormats = []string{time.RFC3339, "20060102T15:04:05Z", "20060102T15:04:05"}
+
+//nolint:unparam
+func serializeTime(context string, value time.Time) (string, error) {
+	_ = context
+	return value.Format(time.RFC3339), nil
+}
+
+func deserializeTime(context string, input interface{}) (value time.Time, err error) {
+	_ = context
+	if input == nil {
+		return
+	}
+	strValue := fmt.Sprintf("%v", input)
+	floatValue, err := strconv.ParseFloat(strValue, 64)
+	if err != nil {
+		for _, timeFormat := range timeFormats {
+			value, err = time.Parse(timeFormat, strValue)
+			if err == nil {
+				return value, nil
+			}
+		}
+		return
+	}
+	unixTimestamp, err := strconv.ParseInt(strconv.Itoa(int(floatValue)), 10, 64)
+	value = time.Unix(unixTimestamp, 0)
+
+	return
+}

--- a/ocaml/sdk-gen/go/test_gen_go.ml
+++ b/ocaml/sdk-gen/go/test_gen_go.ml
@@ -151,7 +151,16 @@ let verify_obj_member = function
   | _ ->
       false
 
-let obj_keys = ["name"; "description"; "fields"; "modules"; "event"; "session"]
+let obj_keys =
+  [
+    "name"
+  ; "name_internal"
+  ; "description"
+  ; "fields"
+  ; "modules"
+  ; "event"
+  ; "session"
+  ]
 
 let verify_obj = function
   | `O members ->
@@ -159,10 +168,18 @@ let verify_obj = function
   | _ ->
       false
 
+let verify_msg_or_error_member = function
+  | "name", `String _ | "value", `String _ ->
+      true
+  | _ ->
+      false
+
+let keys_in_error_or_msg = ["name"; "value"]
+
 let verify_msgs_or_errors lst =
   let verify_msg_or_error = function
-    | `O [("name", `String _)] ->
-        true
+    | `O members ->
+        schema_check keys_in_error_or_msg verify_msg_or_error_member members
     | _ ->
         false
   in
@@ -285,8 +302,16 @@ let api_errors : Mustache.Json.t =
       ( "api_errors"
       , `A
           [
-            `O [("name", `String "MESSAGE_DEPRECATED")]
-          ; `O [("name", `String "MESSAGE_REMOVED")]
+            `O
+              [
+                ("name", `String "MessageDeprecated")
+              ; ("value", `String "MESSAGE_DEPRECATED")
+              ]
+          ; `O
+              [
+                ("name", `String "MessageRemoved")
+              ; ("value", `String "MESSAGE_REMOVED")
+              ]
           ]
       )
     ]
@@ -297,8 +322,16 @@ let api_messages : Mustache.Json.t =
       ( "api_messages"
       , `A
           [
-            `O [("name", `String "HA_STATEFILE_LOST")]
-          ; `O [("name", `String "METADATA_LUN_HEALTHY")]
+            `O
+              [
+                ("name", `String "HaStatefileLost")
+              ; ("value", `String "HA_STATEFILE_LOST")
+              ]
+          ; `O
+              [
+                ("name", `String "MetadataLunHealthy")
+              ; ("value", `String "METADATA_LUN_HEALTHY")
+              ]
           ]
       )
     ]

--- a/ocaml/sdk-gen/go/test_gen_go.ml
+++ b/ocaml/sdk-gen/go/test_gen_go.ml
@@ -66,6 +66,113 @@ let verify_field = function
   | _ ->
       false
 
+let result_keys = ["type"; "func_partial_type"]
+
+let verify_result_member = function
+  | "type", `String _ | "func_partial_type", `String _ ->
+      true
+  | _ ->
+      false
+
+let error_keys = ["name"; "doc"]
+
+let verify_error_member = function
+  | "name", `String _ | "doc", `String _ ->
+      true
+  | _ ->
+      false
+
+let verify_error = function
+  | `O error ->
+      schema_check error_keys verify_error_member error
+  | _ ->
+      false
+
+let param_keys =
+  [
+    "session"
+  ; "type"
+  ; "name"
+  ; "name_internal"
+  ; "doc"
+  ; "func_partial_type"
+  ; "param_ignore"
+  ; "session_class"
+  ; "first"
+  ]
+
+let verify_param_member = function
+  | "session", `Bool _
+  | "first", `Bool _
+  | "type", `String _
+  | "name", `String _
+  | "name_internal", `String _
+  | "doc", `String _
+  | "func_partial_type", `String _ ->
+      true
+  | "param_ignore", `Bool _ | "param_ignore", `Null ->
+      true
+  | "session_class", `Bool _ | "session_class", `Null ->
+      true
+  | _ ->
+      false
+
+let verify_param = function
+  | `O param ->
+      schema_check param_keys verify_param_member param
+  | _ ->
+      false
+
+let verify_message_member = function
+  | "method_name", `String _
+  | "class_name", `String _
+  | "class_name_exported", `String _
+  | "method_name_exported", `String _ ->
+      true
+  | "description", `String _ | "description", `Null ->
+      true
+  | "result", `Null ->
+      true
+  | "result", `O result ->
+      schema_check result_keys verify_result_member result
+  | "params", `A params ->
+      List.for_all verify_param params
+  | "errors", `A errors ->
+      List.for_all verify_error errors
+  | "async", `Bool _
+  | "has_error", `Bool _
+  | "session_class", `Bool _
+  | "session_login", `Bool _
+  | "session_logout", `Bool _ ->
+      true
+  | "errors", `Null ->
+      true
+  | _ ->
+      false
+
+let message_keys =
+  [
+    "method_name"
+  ; "class_name"
+  ; "class_name_exported"
+  ; "method_name_exported"
+  ; "description"
+  ; "result"
+  ; "params"
+  ; "errors"
+  ; "session_class"
+  ; "session_login"
+  ; "session_logout"
+  ; "has_error"
+  ; "async"
+  ]
+
+let verify_message = function
+  | `O members ->
+      schema_check message_keys verify_message_member members
+  | _ ->
+      false
+
 (* module *)
 let verify_module_member = function
   | "name", `String _ ->
@@ -136,7 +243,7 @@ let verify_enums : Mustache.Json.t -> bool = function
 
 (* obj *)
 let verify_obj_member = function
-  | "name", `String _ | "description", `String _ ->
+  | "name", `String _ | "description", `String _ | "name_internal", `String _ ->
       true
   | "event", `Bool _ | "event", `Null ->
       true
@@ -144,6 +251,8 @@ let verify_obj_member = function
       true
   | "fields", `A fields ->
       List.for_all verify_field fields
+  | "messages", `A messages ->
+      List.for_all verify_message messages
   | "modules", `Null ->
       true
   | "modules", `O members ->
@@ -160,6 +269,7 @@ let obj_keys =
   ; "modules"
   ; "event"
   ; "session"
+  ; "messages"
   ]
 
 let verify_obj = function
@@ -336,6 +446,162 @@ let api_messages : Mustache.Json.t =
       )
     ]
 
+let messages : Mustache.Json.t =
+  `O
+    [
+      ( "messages"
+      , `A
+          [
+            `O
+              [
+                ("session_class", `Bool false)
+              ; ("session_login", `Bool false)
+              ; ("session_logout", `Bool false)
+              ; ("class_name", `String "host")
+              ; ("name_internal", `String "host")
+              ; ("method_name", `String "get_log")
+              ; ("method_name_exported", `String "GetLog")
+              ; ("description", `String "GetLog Get the host log file")
+              ; ("async", `Bool true)
+              ; ( "params"
+                , `A
+                    [
+                      `O
+                        [
+                          ("type", `String "SessionRef")
+                        ; ("name", `String "session_id")
+                        ; ("name_internal", `String "sessionID")
+                        ; ("func_partial_type", `String "SessionRef")
+                        ; ("session", `Bool true)
+                        ; ("session_class", `Bool false)
+                        ; ("first", `Bool true)
+                        ]
+                    ; `O
+                        [
+                          ("type", `String "HostRef")
+                        ; ("name", `String "host")
+                        ; ("name_internal", `String "host")
+                        ; ("func_partial_type", `String "HostRef")
+                        ; ("session_class", `Bool false)
+                        ; ("session", `Bool false)
+                        ]
+                    ]
+                )
+              ; ( "result"
+                , `O
+                    [
+                      ("type", `String "string")
+                    ; ("func_partial_type", `String "String")
+                    ]
+                )
+              ; ("has_error", `Bool false)
+              ; ("errors", `A [])
+              ]
+          ; `O
+              [
+                ("session_class", `Bool true)
+              ; ("session_login", `Bool true)
+              ; ("session_logout", `Bool false)
+              ; ("class_name", `String "session")
+              ; ("name_internal", `String "")
+              ; ("method_name", `String "login_with_password")
+              ; ("method_name_exported", `String "LoginWithPassword")
+              ; ( "description"
+                , `String
+                    "Attempt to authenticate the user); returning a session \
+                     reference if successful"
+                )
+              ; ("async", `Bool false)
+              ; ( "params"
+                , `A
+                    [
+                      `O
+                        [
+                          ("type", `String "string")
+                        ; ("name", `String "uname")
+                        ; ("name_internal", `String "uname")
+                        ; ("func_partial_type", `String "String")
+                        ; ("first", `Bool true)
+                        ; ("session_class", `Bool true)
+                        ; ("session", `Bool true)
+                        ]
+                    ; `O
+                        [
+                          ("type", `String "string")
+                        ; ("name", `String "pwd")
+                        ; ("name_internal", `String "pwd")
+                        ; ("func_partial_type", `String "String")
+                        ; ("session_class", `Bool true)
+                        ; ("session", `Bool true)
+                        ]
+                    ]
+                )
+              ; ( "result"
+                , `O
+                    [
+                      ("type", `String "SessionRef")
+                    ; ("func_partial_type", `String "SessionRef")
+                    ]
+                )
+              ; ("has_error", `Bool true)
+              ; ( "errors"
+                , `A
+                    [
+                      `O
+                        [
+                          ("name", `String "SESSION_AUTHENTICATION_FAILED")
+                        ; ( "doc"
+                          , `String
+                              "The credentials given by the user are incorrect"
+                          )
+                        ]
+                    ]
+                )
+              ]
+          ; `O
+              [
+                ("session_class", `Bool true)
+              ; ("session_logout", `Bool true)
+              ; ("session_login", `Bool false)
+              ; ("class_name", `String "session")
+              ; ("class_name_exported", `String "Session")
+              ; ("method_name", `String "logout")
+              ; ("method_name_exported", `String "Logout")
+              ; ("description", `String "Logout Log out of a session")
+              ; ("async", `Bool false)
+              ; ( "params"
+                , `A
+                    [
+                      `O
+                        [
+                          ("type", `String "SessionRef")
+                        ; ("name", `String "session_id")
+                        ; ("name_internal", `String "sessionID")
+                        ; ("func_partial_type", `String "SessionRef")
+                        ; ("param_ignore", `Bool true)
+                        ; ("session_class", `Bool true)
+                        ; ("session", `Bool true)
+                        ]
+                    ; `O
+                        [
+                          ("type", `String "string")
+                        ; ("name", `String "test_param")
+                        ; ("name_internal", `String "testParam")
+                        ; ("func_partial_type", `String "String")
+                        ; ("first", `Bool true)
+                        ; ("session_class", `Bool true)
+                        ; ("session", `Bool true)
+                        ]
+                    ]
+                )
+              ; ("result", `Null)
+              ; ("has_error", `Bool false)
+              ; ("errors", `A [])
+              ]
+          ]
+      )
+    ]
+
 module TemplatesTest = Generic.MakeStateless (struct
   module Io = struct
     type input_t = string * Mustache.Json.t
@@ -357,6 +623,8 @@ module TemplatesTest = Generic.MakeStateless (struct
 
   let enums_rendered = string_of_file "enum.go"
 
+  let methods_rendered = string_of_file "methods.go"
+
   let api_errors_rendered = string_of_file "api_errors.go"
 
   let api_messages_rendered = string_of_file "api_messages.go"
@@ -367,6 +635,7 @@ module TemplatesTest = Generic.MakeStateless (struct
         (("FileHeader.mustache", header), file_header_rendered)
       ; (("Record.mustache", record), record_rendered)
       ; (("Enum.mustache", enums), enums_rendered)
+      ; (("Methods.mustache", messages), methods_rendered)
       ; (("APIErrors.mustache", api_errors), api_errors_rendered)
       ; (("APIMessages.mustache", api_messages), api_messages_rendered)
       ]

--- a/ocaml/sdk-gen/go/test_gen_go.ml
+++ b/ocaml/sdk-gen/go/test_gen_go.ml
@@ -51,7 +51,6 @@ let schema_check keys checker members =
   let keys' = List.map (fun (k, _) -> k) members in
   compare_keys keys keys' && List.for_all checker members
 
-(* field *)
 let verify_field_member = function
   | "name", `String _ | "description", `String _ | "type", `String _ ->
       true
@@ -71,6 +70,12 @@ let result_keys = ["type"; "func_partial_type"]
 let verify_result_member = function
   | "type", `String _ | "func_partial_type", `String _ ->
       true
+  | _ ->
+      false
+
+let verify_option = function
+  | `O members ->
+      schema_check result_keys verify_result_member members
   | _ ->
       false
 
@@ -251,6 +256,8 @@ let verify_obj_member = function
       true
   | "fields", `A fields ->
       List.for_all verify_field fields
+  | "option", `A options ->
+      List.for_all verify_option options
   | "messages", `A messages ->
       List.for_all verify_message messages
   | "modules", `Null ->
@@ -270,6 +277,7 @@ let obj_keys =
   ; "event"
   ; "session"
   ; "messages"
+  ; "option"
   ]
 
 let verify_obj = function
@@ -294,6 +302,289 @@ let verify_msgs_or_errors lst =
         false
   in
   List.for_all verify_msg_or_error lst
+
+let verify_serialize_member = function
+  | "func_partial_type", `String _ | "type", `String _ ->
+      true
+  | _ ->
+      false
+
+let serialize_keys = ["func_partial_type"; "type"]
+
+let verify_serialize = function
+  | `O items ->
+      schema_check serialize_keys verify_serialize_member items
+  | _ ->
+      false
+
+let type_keys = ["serialize"; "deserialize"]
+
+let verify_simple_type_member = function
+  | "serialize", `A serializes ->
+      List.for_all verify_serialize serializes
+  | "deserialize", `A deserializes ->
+      List.for_all verify_serialize deserializes
+  | _ ->
+      false
+
+let verify_option_serialize_member = function
+  | "func_partial_type", `String _ ->
+      true
+  | _ ->
+      false
+
+let option_serialize_keys = ["func_partial_type"]
+
+let verify_option_serialize = function
+  | `O items ->
+      schema_check option_serialize_keys verify_option_serialize_member items
+  | _ ->
+      false
+
+let verify_option_member = function
+  | "serialize", `A serializes ->
+      List.for_all verify_option_serialize serializes
+  | "deserialize", `A deserializes ->
+      List.for_all verify_option_serialize deserializes
+  | _ ->
+      false
+
+let time_keys = ["serialize"; "deserialize"; "time_format"]
+
+let verify_time_member = function
+  | "serialize", `A serializes ->
+      List.for_all verify_serialize serializes
+  | "deserialize", `A deserializes ->
+      List.for_all verify_serialize deserializes
+  | "time_format", `String _ ->
+      true
+  | _ ->
+      false
+
+let verify_set_serialize_member = function
+  | "func_partial_type", `String _
+  | "type", `String _
+  | "item_func_partial_type", `String _ ->
+      true
+  | _ ->
+      false
+
+let serialize_set_keys = ["func_partial_type"; "type"; "item_func_partial_type"]
+
+let verify_set_serialize = function
+  | `O items ->
+      schema_check serialize_set_keys verify_set_serialize_member items
+  | _ ->
+      false
+
+let verify_set_member = function
+  | "serialize", `A serializes ->
+      List.for_all verify_set_serialize serializes
+  | "deserialize", `A deserializes ->
+      List.for_all verify_set_serialize deserializes
+  | _ ->
+      false
+
+let record_field_keys =
+  ["name"; "name_internal"; "name_exported"; "func_partial_type"; "type_option"]
+
+let verify_record_field_member = function
+  | "name", `String _
+  | "name_internal", `String _
+  | "func_partial_type", `String _
+  | "type_option", `Bool _
+  | "name_exported", `String _ ->
+      true
+  | _ ->
+      false
+
+let verify_record_field = function
+  | `O items ->
+      schema_check record_field_keys verify_record_field_member items
+  | _ ->
+      false
+
+let verify_record_serialize_member = function
+  | "func_partial_type", `String _ | "type", `String _ ->
+      true
+  | "fields", `A fields ->
+      List.for_all verify_record_field fields
+  | _ ->
+      false
+
+let serialize_record_keys = ["func_partial_type"; "type"; "fields"]
+
+let verify_record_serialize = function
+  | `O items ->
+      schema_check serialize_record_keys verify_record_serialize_member items
+  | _ ->
+      false
+
+let verify_record_member = function
+  | "serialize", `A serializes ->
+      List.for_all verify_record_serialize serializes
+  | "deserialize", `A deserializes ->
+      List.for_all verify_record_serialize deserializes
+  | _ ->
+      false
+
+let deserialize_keys = ["deserialize"]
+
+let verify_interface_member = function
+  | "deserialize", `A deserializes ->
+      List.for_all verify_serialize deserializes
+  | _ ->
+      false
+
+let batch_element_keys =
+  ["name"; "name_internal"; "name_exported"; "func_partial_type"]
+
+let verify_batch_element_member = function
+  | "func_partial_type", `String _
+  | "name", `String _
+  | "name_internal", `String _
+  | "name_exported", `String _ ->
+      true
+  | _ ->
+      false
+
+let verify_batch_element = function
+  | `O items ->
+      schema_check batch_element_keys verify_batch_element_member items
+  | _ ->
+      false
+
+let batch_deserialize_keys = ["func_partial_type"; "type"; "elements"]
+
+let verify_batch_deserialize_member = function
+  | "func_partial_type", `String _ | "type", `String _ ->
+      true
+  | "elements", `A elements ->
+      List.for_all verify_batch_element elements
+  | _ ->
+      false
+
+let verify_batch_deserialize = function
+  | `O items ->
+      schema_check batch_deserialize_keys verify_batch_deserialize_member items
+  | _ ->
+      false
+
+let verify_batch_member = function
+  | "deserialize", `A deserializes ->
+      List.for_all verify_batch_deserialize deserializes
+  | _ ->
+      false
+
+let map_serialize_keys = ["func_partial_type"; "type"; "key_type"; "value_type"]
+
+let verify_map_serialize_member = function
+  | "type", `String _
+  | "key_type", `String _
+  | "func_partial_type", `String _
+  | "value_type", `String _ ->
+      true
+  | _ ->
+      false
+
+let verify_map_serialize = function
+  | `O items ->
+      schema_check map_serialize_keys verify_map_serialize_member items
+  | _ ->
+      false
+
+let verify_map_member = function
+  | "serialize", `A serializes ->
+      List.for_all verify_map_serialize serializes
+  | "deserialize", `A deserializes ->
+      List.for_all verify_map_serialize deserializes
+  | _ ->
+      false
+
+let enum_item_keys = ["value"; "name"]
+
+let verify_enum_item_member = function
+  | "name", `String _ | "value", `String _ ->
+      true
+  | _ ->
+      false
+
+let verify_enum_item = function
+  | `O members ->
+      schema_check enum_item_keys verify_enum_item_member members
+  | _ ->
+      false
+
+let enum_serialize_keys = ["func_partial_type"; "type"; "items"]
+
+let verify_enum_serialize_member = function
+  | "func_partial_type", `String _ | "type", `String _ ->
+      true
+  | "items", `A items ->
+      List.for_all verify_enum_item items
+  | _ ->
+      false
+
+let verify_enum_serialize = function
+  | `O items ->
+      schema_check enum_serialize_keys verify_enum_serialize_member items
+  | _ ->
+      false
+
+let verify_enum_member = function
+  | "serialize", `A serializes ->
+      List.for_all verify_enum_serialize serializes
+  | "deserialize", `A deserializes ->
+      List.for_all verify_enum_serialize deserializes
+  | _ ->
+      false
+
+let verify_convert_member = function
+  | "simple_type", `O members
+  | "int", `O members
+  | "float", `O members
+  | "ref", `O members ->
+      schema_check type_keys verify_simple_type_member members
+  | "time", `O members ->
+      schema_check time_keys verify_time_member members
+  | "set", `O members ->
+      schema_check type_keys verify_set_member members
+  | "record", `O members ->
+      schema_check type_keys verify_record_member members
+  | "interface", `O members ->
+      schema_check deserialize_keys verify_interface_member members
+  | "map", `O members ->
+      schema_check type_keys verify_map_member members
+  | "enum", `O members ->
+      schema_check type_keys verify_enum_member members
+  | "batch", `O members ->
+      schema_check deserialize_keys verify_batch_member members
+  | "option", `O members ->
+      schema_check type_keys verify_option_member members
+  | _ ->
+      false
+
+let convert_keys =
+  [
+    "simple_type"
+  ; "int"
+  ; "float"
+  ; "time"
+  ; "ref"
+  ; "set"
+  ; "record"
+  ; "interface"
+  ; "map"
+  ; "enum"
+  ; "batch"
+  ; "option"
+  ]
+
+let verify_converts = function
+  | `O members ->
+      schema_check convert_keys verify_convert_member members
+  | _ ->
+      false
 
 let rec string_of_json_value (value : Mustache.Json.value) : string =
   match value with
@@ -602,6 +893,196 @@ let messages : Mustache.Json.t =
       )
     ]
 
+let simple_type_convert : Mustache.Json.t =
+  let array =
+    [
+      `O [("func_partial_type", `String "String"); ("type", `String "string")]
+    ; `O [("func_partial_type", `String "Bool"); ("type", `String "bool")]
+    ]
+  in
+  `O [("simple_type", `O [("serialize", `A array); ("deserialize", `A array)])]
+
+let int_convert : Mustache.Json.t =
+  let array =
+    [`O [("func_partial_type", `String "Int"); ("type", `String "int")]]
+  in
+  `O [("int", `O [("serialize", `A array); ("deserialize", `A array)])]
+
+let float_convert : Mustache.Json.t =
+  let array =
+    [`O [("func_partial_type", `String "Float"); ("type", `String "float64")]]
+  in
+  `O [("float", `O [("serialize", `A array); ("deserialize", `A array)])]
+
+let time_convert : Mustache.Json.t =
+  let array =
+    [`O [("func_partial_type", `String "Time"); ("type", `String "time.Time")]]
+  in
+  `O [("time", `O [("serialize", `A array); ("deserialize", `A array)])]
+
+let ref_string_convert : Mustache.Json.t =
+  let array =
+    [`O [("func_partial_type", `String "VMRef"); ("type", `String "VMRef")]]
+  in
+  `O [("ref", `O [("serialize", `A array); ("deserialize", `A array)])]
+
+let set_convert : Mustache.Json.t =
+  let serialize =
+    [
+      `O
+        [
+          ("func_partial_type", `String "SRRefSet")
+        ; ("type", `String "SRRef")
+        ; ("item_func_partial_type", `String "SRRef")
+        ]
+    ]
+  in
+  let deserialize =
+    [
+      `O
+        [
+          ("func_partial_type", `String "StringSet")
+        ; ("type", `String "string")
+        ; ("item_func_partial_type", `String "String")
+        ]
+    ]
+  in
+  `O
+    [("set", `O [("serialize", `A serialize); ("deserialize", `A deserialize)])]
+
+let record_convert : Mustache.Json.t =
+  let array =
+    [
+      `O
+        [
+          ("func_partial_type", `String "VBDRecord")
+        ; ("type", `String "VBDRecord")
+        ; ( "fields"
+          , `A
+              [
+                `O
+                  [
+                    ("name", `String "uuid")
+                  ; ("name_internal", `String "uuid")
+                  ; ("name_exported", `String "UUID")
+                  ; ("func_partial_type", `String "String")
+                  ; ("type_option", `Bool false)
+                  ]
+              ; `O
+                  [
+                    ("name", `String "allowed_operations")
+                  ; ("name_internal", `String "allowedOperations")
+                  ; ("name_exported", `String "AllowedOperations")
+                  ; ("func_partial_type", `String "EnumVbdOperationsSet")
+                  ; ("type_option", `Bool false)
+                  ]
+              ]
+          )
+        ]
+    ]
+  in
+  `O [("record", `O [("serialize", `A array); ("deserialize", `A array)])]
+
+let interface_convert : Mustache.Json.t =
+  let array =
+    [
+      `O
+        [
+          ("func_partial_type", `String "RecordInterface")
+        ; ("type", `String "RecordInterface")
+        ]
+    ]
+  in
+  `O [("interface", `O [("deserialize", `A array)])]
+
+let map_convert : Mustache.Json.t =
+  let deserialize =
+    [
+      `O
+        [
+          ("func_partial_type", `String "PBDRefToPBDRecordMap")
+        ; ("type", `String "map[PBDRef]PBDRecord")
+        ; ("key_type", `String "PBDRef")
+        ; ("value_type", `String "PBDRecord")
+        ]
+    ]
+  in
+  let serialize =
+    [
+      `O
+        [
+          ("func_partial_type", `String "VIFRefToStringMap")
+        ; ("type", `String "map[VIFRef]string")
+        ; ("key_type", `String "VIFRef")
+        ; ("value_type", `String "String")
+        ]
+    ]
+  in
+  `O
+    [("map", `O [("serialize", `A serialize); ("deserialize", `A deserialize)])]
+
+let enum_convert : Mustache.Json.t =
+  let array =
+    [
+      `O
+        [
+          ("func_partial_type", `String "EnumTaskStatusType")
+        ; ("type", `String "TaskStatusType")
+        ; ( "items"
+          , `A
+              [
+                `O
+                  [
+                    ("name", `String "TaskStatusTypePending")
+                  ; ("value", `String "pending")
+                  ]
+              ; `O
+                  [
+                    ("name", `String "TaskStatusTypeSuccess")
+                  ; ("value", `String "success")
+                  ]
+              ]
+          )
+        ]
+    ]
+  in
+  `O [("enum", `O [("serialize", `A array); ("deserialize", `A array)])]
+
+let batch_convert : Mustache.Json.t =
+  let array =
+    [
+      `O
+        [
+          ("func_partial_type", `String "EventBatch")
+        ; ("type", `String "EventBatch")
+        ; ( "elements"
+          , `A
+              [
+                `O
+                  [
+                    ("name", `String "token")
+                  ; ("name_internal", `String "token")
+                  ; ("name_exported", `String "Token")
+                  ; ("func_partial_type", `String "String")
+                  ]
+              ; `O
+                  [
+                    ("name", `String "valid_ref_counts")
+                  ; ("name_internal", `String "validRefCounts")
+                  ; ("name_exported", `String "ValidRefCounts")
+                  ; ("func_partial_type", `String "StringToIntMap")
+                  ]
+              ]
+          )
+        ]
+    ]
+  in
+  `O [("batch", `O [("deserialize", `A array)])]
+
+let option_convert : Mustache.Json.t =
+  let array = [`O [("func_partial_type", `String "SrStatRecord")]] in
+  `O [("option", `O [("serialize", `A array); ("deserialize", `A array)])]
+
 module TemplatesTest = Generic.MakeStateless (struct
   module Io = struct
     type input_t = string * Mustache.Json.t
@@ -629,6 +1110,30 @@ module TemplatesTest = Generic.MakeStateless (struct
 
   let api_messages_rendered = string_of_file "api_messages.go"
 
+  let simple_type_rendered = string_of_file "simple_type.go"
+
+  let int_rendered = string_of_file "int.go"
+
+  let float_rendered = string_of_file "float.go"
+
+  let time_rendered = string_of_file "time.go"
+
+  let string_ref_rendered = string_of_file "ref.go"
+
+  let set_rendered = string_of_file "set.go"
+
+  let record_convert_rendered = string_of_file "record_convert.go"
+
+  let interface_rendered = string_of_file "interface.go"
+
+  let map_rendered = string_of_file "map.go"
+
+  let enum_rendered = string_of_file "enum_convert.go"
+
+  let batch_rendered = string_of_file "batch.go"
+
+  let option_rendered = string_of_file "option.go"
+
   let tests =
     `QuickAndAutoDocumented
       [
@@ -638,6 +1143,20 @@ module TemplatesTest = Generic.MakeStateless (struct
       ; (("Methods.mustache", messages), methods_rendered)
       ; (("APIErrors.mustache", api_errors), api_errors_rendered)
       ; (("APIMessages.mustache", api_messages), api_messages_rendered)
+      ; ( ("ConvertSimpleType.mustache", simple_type_convert)
+        , simple_type_rendered
+        )
+      ; (("ConvertInt.mustache", int_convert), int_rendered)
+      ; (("ConvertFloat.mustache", float_convert), float_rendered)
+      ; (("ConvertTime.mustache", time_convert), time_rendered)
+      ; (("ConvertRef.mustache", ref_string_convert), string_ref_rendered)
+      ; (("ConvertSet.mustache", set_convert), set_rendered)
+      ; (("ConvertRecord.mustache", record_convert), record_convert_rendered)
+      ; (("ConvertInterface.mustache", interface_convert), interface_rendered)
+      ; (("ConvertMap.mustache", map_convert), map_rendered)
+      ; (("ConvertEnum.mustache", enum_convert), enum_rendered)
+      ; (("ConvertBatch.mustache", batch_convert), batch_rendered)
+      ; (("ConvertOption.mustache", option_convert), option_rendered)
       ]
 end)
 
@@ -649,9 +1168,12 @@ module TestGeneratedJson = struct
     let enums = Json.all_enums objects in
     verify "enums" verify_enums enums
 
+  let objs, converts = objs_and_convert_functions objects
+
   let test_obj () =
-    Json.xenapi objects
-    |> List.iter (fun (name, obj) -> verify name verify_obj obj)
+    List.iter (fun (name, obj) -> verify name verify_obj obj) objs
+
+  let test_converts () = verify "schema" verify_converts converts
 
   let test_errors_and_msgs () =
     verify "errors_and_msgs" verify_msgs_or_errors
@@ -661,6 +1183,7 @@ module TestGeneratedJson = struct
     [
       ("enums", `Quick, test_enums)
     ; ("objs", `Quick, test_obj)
+    ; ("converts", `Quick, test_converts)
     ; ("errors_and_msgs", `Quick, test_errors_and_msgs)
     ]
 end


### PR DESCRIPTION

## Add templates and  jsonrpc client, update some templates
1. templates update (APIErrors, APIMessages, Record)
2. add mustache template for deserialize and serialize functions
3. add mustache template for xapi data module class messages
4. add jsonrpc client

## Generate code
1. Generate messages functions Golang code for all classes
2. Support backwards capability for Go SDK
3. Generate Convert functions Go code
4. Fix go lint errors and warnings