### PR TITLE
[OIL] Use mustache templates to build Java SDK + Add Java SDK build step to actions 

### DIFF
--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -55,6 +55,12 @@ jobs:
             _build/install/default/xapi/sdk/go/*
             !_build/install/default/xapi/sdk/go/dune
 
+      - name: Store Java SDK source
+        uses: actions/upload-artifact@v4
+        with:
+          name: SDK_Source_Java
+          path: _build/install/default/xapi/sdk/java/*
+
       - name: Trim dune cache
         run: opam exec -- dune cache trim --size=2GiB
 
@@ -83,6 +89,39 @@ jobs:
           path: |
             source/*
             !source/src/*.o
+
+  build-java-sdk:
+    name: Build Java SDK
+    runs-on: ubuntu-latest
+    needs: generate-sdk-sources
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get install maven
+
+      - name: Retrieve Java SDK source
+        uses: actions/download-artifact@v4
+        with:
+          name: SDK_Source_Java
+          path: source/
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build Java SDK
+        shell: bash
+        run: |
+          xapi_version="${{ inputs.xapi_version }}"
+          xapi_version="${xapi_version//v/}"
+          mkdir -p target && mvn -f source/xen-api/pom.xml -B -Drevision=$xapi_version-prerelease clean package && mv source/xen-api/target/*.jar target/
+
+      - name: Store Java SDK
+        uses: actions/upload-artifact@v4
+        with:
+          name: SDK_Artifacts_Java
+          path: target/*
 
   build-csharp-sdk:
     name: Build C# SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,12 @@ jobs:
           name: SDK_Artifacts_C
           path: libxenserver/usr/local/
 
+      - name: Retrieve Java SDK distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: SDK_Artifacts_Java
+          path: dist/
+
       - name: Retrieve C# SDK distribution artifacts
         uses: actions/download-artifact@v4
         with:

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -120,7 +120,9 @@ module TypeSet = Set.Make (Ty)
 
 let types = ref TypeSet.empty
 
-(* Helper functions for types *)
+(***************************************)
+(* Helpers for generating Types.java   *)
+(***************************************)
 let rec get_java_type ty =
   types := TypeSet.add ty !types ;
   match ty with
@@ -148,12 +150,9 @@ let rec get_java_type ty =
   | Option x ->
       get_java_type x
 
-(*We'd like the list of XenAPI objects to appear as an enumeration so we can*)
-(* switch on them, so add it using this mechanism*)
 let switch_enum =
   Enum ("XenAPIObjects", List.map (fun x -> (x.name, x.description)) classes)
 
-(*Helper function for get_marshall_function*)
 let rec get_marshall_function_rec = function
   | SecretString | String ->
       "String"
@@ -222,8 +221,6 @@ let field_default = function
       "null"
 
 let class_is_empty cls = cls.contents = []
-
-(*This generates the special case code for marshalling the snapshot field in an Event.Record*)
 
 let generate_snapshot_hack =
   {|
@@ -364,9 +361,9 @@ let populate_releases templdir class_dir =
     ("APIVersion.mustache", "APIVersion.java")
     json_releases templdir class_dir
 
-(*
-  Populate JSON object for the Types.java template     
-*)
+(****************************************************)
+(* Populate JSON object for the Types.java template *)
+(****************************************************)
 let get_types_errors_json =
   let list_errors =
     Hashtbl.fold (fun k v acc -> (k, v) :: acc) Datamodel.errors []
@@ -465,37 +462,38 @@ let populate_types types templdir class_dir =
   in
   render_file ("Types.mustache", "Types.java") json templdir class_dir
 
-let get_message_object cls message async_version params =
-  let is_method_async = async_version in
-  let return_type =
-    if is_method_async then
-      "Task"
-    else if
-      String.lowercase_ascii cls.name = "event"
-      && String.lowercase_ascii message.msg_name = "from"
-    then
-      "EventBatch"
-    else
+(***************************************)
+(* Helpers for generating class methods *)
+(***************************************)
+let get_message_return_type cls message is_method_async =
+  if is_method_async then
+    "Task"
+  else if
+    String.lowercase_ascii cls.name = "event"
+    && String.lowercase_ascii message.msg_name = "from"
+  then
+    "EventBatch"
+  else
+    get_java_type_or_void message.msg_result
+
+let get_message_return_description message =
+  match message.msg_result with
+  | None ->
       get_java_type_or_void message.msg_result
-  in
-  let return_description =
-    match message.msg_result with
-    | None ->
-        get_java_type_or_void message.msg_result
-    | Some (_, description) ->
-        description
-  in
-  let returns_void = message.msg_result = None && not async_version in
-  let record_parameters =
-    List.map
-      (fun parameter ->
-        `O [("name_camel", `String (camel_case parameter.param_name))]
-      )
-      (List.filter
-         (function {param_type= Record _; _} -> true | _ -> false)
-         message.msg_params
-      )
-  in
+  | Some (_, description) ->
+      description
+
+let get_message_return_parameters message =
+  List.map
+    (fun parameter ->
+      `O [("name_camel", `String (camel_case parameter.param_name))]
+    )
+    (List.filter
+       (function {param_type= Record _; _} -> true | _ -> false)
+       message.msg_params
+    )
+
+let get_message_deprecation_info message =
   let is_deprecated =
     match message.msg_release.internal_deprecated_since with
     | Some _ ->
@@ -510,34 +508,37 @@ let get_message_object cls message async_version params =
     | None ->
         ""
   in
-  let type_reference =
-    if is_method_async then
-      "Task"
-    else if message.msg_result != None then
-      return_type
-    else
-      ""
-  in
-  let parameters =
-    List.map
-      (fun parameter ->
-        let publish_info = get_published_info_param message parameter in
-        let name_camel = camel_case parameter.param_name in
-        let description = escape_xml parameter.param_doc in
-        `O
-          [
-            ("type", `String (get_java_type parameter.param_type))
-          ; ( "is_record"
-            , `Bool
-                (match parameter.param_type with Record _ -> true | _ -> false)
-            )
-          ; ("name_camel", `String name_camel)
-          ; ("description", `String description)
-          ; ("publish_info", `String publish_info)
-          ]
-      )
-      params
-  in
+  (is_deprecated, deprecated_release)
+
+let get_message_type_reference is_method_async message return_type =
+  if is_method_async then
+    "Task"
+  else if message.msg_result != None then
+    return_type
+  else
+    ""
+
+let get_message_formatted_parameters parameters message =
+  List.map
+    (fun parameter ->
+      let publish_info = get_published_info_param message parameter in
+      let name_camel = camel_case parameter.param_name in
+      let description = escape_xml parameter.param_doc in
+      `O
+        [
+          ("type", `String (get_java_type parameter.param_type))
+        ; ( "is_record"
+          , `Bool
+              (match parameter.param_type with Record _ -> true | _ -> false)
+          )
+        ; ("name_camel", `String name_camel)
+        ; ("description", `String description)
+        ; ("publish_info", `String publish_info)
+        ]
+    )
+    parameters
+
+let get_message_errors message =
   let error_definitions =
     List.map
       (fun error ->
@@ -546,14 +547,13 @@ let get_message_object cls message async_version params =
       )
       message.msg_errors
   in
-  let errors =
-    List.map
-      (fun (name, description) ->
-        `O [("name", `String name); ("description", `String description)]
-      )
-      error_definitions
-  in
-  let is_static = is_method_static message in
+  List.map
+    (fun (name, description) ->
+      `O [("name", `String name); ("description", `String description)]
+    )
+    error_definitions
+
+let get_message_method_parameters parameters is_static message =
   let session_parameter =
     `O
       [
@@ -594,8 +594,25 @@ let get_message_object cls message async_version params =
     | `O h :: tail ->
         `O (("is_last", `Bool false) :: h) :: set_is_last tail acc
   in
+  set_is_last (extra_method_parameters @ parameters) []
+
+let get_class_message_json cls message async_version params =
+  let is_method_async = async_version in
+  let return_type = get_message_return_type cls message is_method_async in
+  let return_description = get_message_return_description message in
+  let returns_void = message.msg_result = None && not async_version in
+  let record_parameters = get_message_return_parameters message in
+  let is_deprecated, deprecated_release =
+    get_message_deprecation_info message
+  in
+  let type_reference =
+    get_message_type_reference is_method_async message return_type
+  in
+  let parameters = get_message_formatted_parameters params message in
+  let errors = get_message_errors message in
+  let is_static = is_method_static message in
   let method_parameters =
-    set_is_last (extra_method_parameters @ parameters) []
+    get_message_method_parameters parameters is_static message
   in
   `O
     [
@@ -620,9 +637,8 @@ let get_message_object cls message async_version params =
     ; ("errors", `A errors)
     ]
 
-let populate_class cls templdir class_dir =
+let get_class_fields_json cls =
   Hashtbl.replace records cls.name cls.contents ;
-  let class_name = class_case cls.name in
   let rec content_fields content namespace_name =
     match content with
     | Field f ->
@@ -659,44 +675,65 @@ let populate_class cls templdir class_dir =
     | Namespace (name, contents) ->
         List.flatten (List.map (fun c -> content_fields c name) contents)
   in
-  let fields =
-    List.flatten (List.map (fun c -> content_fields c "") cls.contents)
-  in
-  let rec get_async_and_sync_methods methods acc =
-    match methods with
-    | [] ->
-        acc
-    | h :: tail ->
-        let get_variants messages =
-          (* we get the param groups outside of the mapping because we know it's always the same message *)
-          let params = gen_param_groups h h.msg_params in
-          match params with
-          | [] ->
-              List.map
-                (fun (message, is_async) -> (message, is_async, []))
-                messages
-          | _ ->
-              List.map
-                (fun (message, is_async) ->
-                  List.map (fun param -> (message, is_async, param)) params
-                )
-                messages
-              |> List.flatten
-        in
-        if h.msg_async then
-          get_variants [(h, true); (h, false)]
-          @ get_async_and_sync_methods tail acc
-        else
-          get_variants [(h, false)] @ get_async_and_sync_methods tail acc
-  in
-  let async_and_sync_methods = get_async_and_sync_methods cls.messages [] in
-  let methods =
-    List.map
-      (fun (message, async_version, params) ->
-        get_message_object cls message async_version params
-      )
-      async_and_sync_methods
-  in
+  List.flatten (List.map (fun c -> content_fields c "") cls.contents)
+
+(** [get_all_message_variants messages acc] takes a list of messages [messages] and an accumulator [acc],
+    and recursively constructs a list of tuples representing both asynchronous and synchronous variants of each message,
+    along with their associated parameters. If a message does not have an asynchronous version, this function simply returns
+    its synchronous version, with parameter information.
+
+    For each message, if it has parameter information, the function generates all possible combinations of parameters
+    and pairs them with the message, marking each combination as either asynchronous or synchronous. Then, it constructs
+    a list of tuples containing each combination along with its associated message and its asynchronous/synchronous flag.
+
+    @param messages a list of messages to process
+    @param acc an accumulator for collecting the constructed tuples
+    @return a list of tuples representing both asynchronous and synchronous variants of each message,
+    along with their associated parameters *)
+let rec get_all_message_variants messages acc =
+  match messages with
+  | [] ->
+      acc
+  | h :: tail ->
+      let get_variants messages =
+        (* we get the param groups outside of the mapping because we know it's always the same message *)
+        let params = gen_param_groups h h.msg_params in
+        match params with
+        | [] ->
+            List.map
+              (fun (message, is_async) -> (message, is_async, []))
+              messages
+        | _ ->
+            List.map
+              (fun (message, is_async) ->
+                List.map (fun param -> (message, is_async, param)) params
+              )
+              messages
+            |> List.flatten
+      in
+      if h.msg_async then
+        get_variants [(h, false); (h, true)] @ get_all_message_variants tail acc
+      else
+        get_variants [(h, false)] @ get_all_message_variants tail acc
+
+let get_class_methods_json cls =
+  let messages = get_all_message_variants cls.messages [] in
+  List.map
+    (fun (message, async_version, params) ->
+      get_class_message_json cls message async_version params
+    )
+    messages
+
+(***********************************************)
+(* Populate JSON object for the class template *)
+(***********************************************)
+let populate_class cls templdir class_dir =
+  (*todo: is this still neeeded?!*)
+  Hashtbl.replace records cls.name cls.contents ;
+
+  let class_name = class_case cls.name in
+  let fields = get_class_fields_json cls in
+  let methods = get_class_methods_json cls in
   let json =
     `O
       [

--- a/ocaml/sdk-gen/java/templates/Class.mustache
+++ b/ocaml/sdk-gen/java/templates/Class.mustache
@@ -56,28 +56,28 @@ public class {{class_name}} extends XenAPIObject {
     {{/is_empty_class}}
     {{^is_empty_class}}
     /**
-    * The XenAPI reference (OpaqueRef) to this object.
-    */
+     * The XenAPI reference (OpaqueRef) to this object.
+     */
     protected final String ref;
 
     /**
-    * For internal use only.
-    */
+     * For internal use only.
+     */
     {{{class_name}}}(String ref) {
         this.ref = ref;
     }
 
     /**
-    * @return The XenAPI reference (OpaqueRef) to this object.
-    */
+     * @return The XenAPI reference (OpaqueRef) to this object.
+     */
     @JsonValue
     public String toWireString() {
         return this.ref;
     }
 
     /**
-    * If obj is a {{{class_name}}}, compares XenAPI references for equality.
-    */
+     * If obj is a {{{class_name}}}, compares XenAPI references for equality.
+     */
     @Override
     public boolean equals(Object obj)
     {
@@ -105,25 +105,22 @@ public class {{class_name}} extends XenAPIObject {
             StringWriter writer = new StringWriter();
             PrintWriter print = new PrintWriter(writer);
             {{#fields}}
-                print.printf("%1$20s: %2$s\n", "{{{name_camel}}}", this.{{{name_camel}}});
+            print.printf("%1$20s: %2$s\n", "{{{name_camel}}}", this.{{{name_camel}}});
             {{/fields}}
             {{#is_event_class}}
-                print.printf("%1$20s: %2$s\n", "snapshot", this.snapshot);
+            print.printf("%1$20s: %2$s\n", "snapshot", this.snapshot);
             {{/is_event_class}}
             return writer.toString();
         }
 
         /**
-        * Convert a {{{class_name}}}.Record to a Map
-        */
+         * Convert a {{{class_name}}}.Record to a Map
+         */
         public Map<String,Object> toMap() {
             var map = new HashMap<String,Object>();
             {{#fields}}
             map.put("{{{name}}}", this.{{{name_camel}}} == null ? {{{default_value}}} : this.{{{name_camel}}});
             {{/fields}}
-            {{#is_event_class}}
-                print.printf("%1$20s: %2$s\n", "snapshot", this.snapshot);
-            {{/is_event_class}}
             return map;
         }
 
@@ -149,30 +146,30 @@ public class {{class_name}} extends XenAPIObject {
     {{/is_empty_class}}
     {{#methods}}
     /**
-    * {{{description}}}
-    * Minimum allowed role: {{{minimum_allowed_role}}}
-    * {{{publish_info}}}{{#is_deprecated}}
-    * @deprecated since {{{deprecated_release}}}{{/is_deprecated}}
-    *
-    * @param c The connection the call is made on{{#parameters}}
-    * @param {{{name_camel}}} {{^description}}No description{{/description}}{{#description}}{{{.}}}{{/description}} {{{publish_info}}}{{/parameters}}{{^returns_void}}
-    * @return {{#is_async}}Task{{/is_async}}{{^is_async}}{{{return_description}}}{{/is_async}}{{/returns_void}}
-    * @throws BadServerResponse Thrown if the response from the server contains an invalid status.
-    * @throws XenAPIException if the call failed.
-    * @throws IOException if an error occurs during a send or receive. This includes cases where a payload is invalid JSON.{{#errors}}
-    * @throws {{{name}}} {{{description}}}{{/errors}}
-    */{{#is_deprecated}}
+     * {{{description}}}
+     * Minimum allowed role: {{{minimum_allowed_role}}}
+     * {{{publish_info}}}{{#is_deprecated}}
+     * @deprecated since {{{deprecated_release}}}{{/is_deprecated}}
+     *
+     * @param c The connection the call is made on{{#parameters}}
+     * @param {{{name_camel}}} {{{description}}} {{{publish_info}}}{{/parameters}}{{^returns_void}}
+     * @return {{#is_async}}Task{{/is_async}}{{^is_async}}{{{return_description}}}{{/is_async}}{{/returns_void}}
+     * @throws BadServerResponse Thrown if the response from the server contains an invalid status.
+     * @throws XenAPIException if the call failed.
+     * @throws IOException if an error occurs during a send or receive. This includes cases where a payload is invalid JSON.{{#errors}}
+     * @throws {{{name}}} {{{description}}}{{/errors}}
+     */{{#is_deprecated}}
     @Deprecated(since = "{{{deprecated_release}}}"){{/is_deprecated}}
     public{{#is_static}} static{{/is_static}} {{#is_async}}Task{{/is_async}}{{^is_async}}{{{return_type}}}{{/is_async}} {{name_camel}}{{#is_async}}Async{{/is_async}}(Connection c{{#parameters}}, {{{type}}} {{{name_camel}}}{{/parameters}}) throws
-    BadServerResponse,
-    XenAPIException,
-    IOException{{#errors}},
+            BadServerResponse,
+            XenAPIException,
+            IOException{{#errors}},
     {{name}}{{/errors}} {
-        String methodCall = "{{#is_async}}Async.{{/is_async}}{{{object_name}}}.{{{name}}}";
-        {{#supports_session}}String sessionReference = c.getSessionReference();{{/supports_session}}{{#method_parameters}}{{#is_record}}
+        String methodCall = "{{#is_async}}Async.{{/is_async}}{{{object_name}}}.{{{name}}}";{{#supports_session}}
+        String sessionReference = c.getSessionReference();{{/supports_session}}{{#method_parameters}}{{#is_record}}
         var {{{name_camel}}}_map = {{{name_camel}}}.toMap();{{/is_record}}{{/method_parameters}}
         Object[] methodParameters = { {{#method_parameters}}{{{name_camel}}}{{#is_record}}_map{{/is_record}}{{^is_last}}, {{/is_last}}{{/method_parameters}} };{{#type_reference}}
-        var typeReference = new TypeReference<{{{type_reference}}}>(){};{{/type_reference}}
+        var typeReference = new TypeReference<{{{.}}}>(){};{{/type_reference}}
         {{^returns_void}}return {{/returns_void}}c.dispatch(methodCall, methodParameters{{#type_reference}}, typeReference{{/type_reference}});
     }
 

--- a/ocaml/sdk-gen/java/templates/Class.mustache
+++ b/ocaml/sdk-gen/java/templates/Class.mustache
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+package com.xensource.xenapi;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.xensource.xenapi.Types.BadServerResponse;
+import com.xensource.xenapi.Types.XenAPIException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.*;
+import java.io.IOException;
+
+/**
+ * {{description}}{{#publish_info}}
+ * {{{publish_info}}}{{/publish_info}}
+ *
+ * @author Cloud Software Group, Inc.
+ */
+public class {{class_name}} extends XenAPIObject {
+
+    {{#is_empty_class}}
+    @JsonValue
+    public String toWireString() {
+        return null;
+    }
+
+    {{/is_empty_class}}
+    {{^is_empty_class}}
+    /**
+    * The XenAPI reference (OpaqueRef) to this object.
+    */
+    protected final String ref;
+
+    /**
+    * For internal use only.
+    */
+    {{{class_name}}}(String ref) {
+        this.ref = ref;
+    }
+
+    /**
+    * @return The XenAPI reference (OpaqueRef) to this object.
+    */
+    @JsonValue
+    public String toWireString() {
+        return this.ref;
+    }
+
+    /**
+    * If obj is a {{{class_name}}}, compares XenAPI references for equality.
+    */
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj instanceof {{{class_name}}})
+        {
+            {{{class_name}}} other = ({{{class_name}}}) obj;
+            return other.ref.equals(this.ref);
+        } else
+        {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return ref.hashCode();
+    }
+
+    /**
+     * Represents all the fields in a {{{class_name}}}
+     */
+    public static class Record implements Types.Record {
+        public String toString() {
+            StringWriter writer = new StringWriter();
+            PrintWriter print = new PrintWriter(writer);
+            {{#fields}}
+                print.printf("%1$20s: %2$s\n", "{{{name_camel}}}", this.{{{name_camel}}});
+            {{/fields}}
+            {{#is_event_class}}
+                print.printf("%1$20s: %2$s\n", "snapshot", this.snapshot);
+            {{/is_event_class}}
+            return writer.toString();
+        }
+
+        /**
+        * Convert a {{{class_name}}}.Record to a Map
+        */
+        public Map<String,Object> toMap() {
+            var map = new HashMap<String,Object>();
+            {{#fields}}
+            map.put("{{{name}}}", this.{{{name_camel}}} == null ? {{{default_value}}} : this.{{{name_camel}}});
+            {{/fields}}
+            {{#is_event_class}}
+                print.printf("%1$20s: %2$s\n", "snapshot", this.snapshot);
+            {{/is_event_class}}
+            return map;
+        }
+
+        {{#fields}}
+        /**
+         * {{{description}}}{{#publish_info}}
+         * {{{publish_info}}}{{/publish_info}}
+         */
+        @JsonProperty("{{{name}}}"){{#is_deprecated}}
+        @Deprecated(since = "{{{deprecated_release}}}"){{/is_deprecated}}
+        public {{{type}}} {{{name_camel}}};
+
+        {{/fields}}
+        {{#is_event_class}}
+            /**
+            * The record of the database object that was added, changed or deleted.
+            * The actual type will be VM.Record, VBD.Record, or similar.
+            */
+            public Object snapshot;
+        {{/is_event_class}}
+    }
+
+    {{/is_empty_class}}
+    {{#methods}}
+    /**
+    * {{{description}}}
+    * Minimum allowed role: {{{minimum_allowed_role}}}
+    * {{{publish_info}}}{{#is_deprecated}}
+    * @deprecated since {{{deprecated_release}}}{{/is_deprecated}}
+    *
+    * @param c The connection the call is made on{{#parameters}}
+    * @param {{{name_camel}}} {{^description}}No description{{/description}}{{#description}}{{{.}}}{{/description}} {{{publish_info}}}{{/parameters}}{{^returns_void}}
+    * @return {{#is_async}}Task{{/is_async}}{{^is_async}}{{{return_description}}}{{/is_async}}{{/returns_void}}
+    * @throws BadServerResponse Thrown if the response from the server contains an invalid status.
+    * @throws XenAPIException if the call failed.
+    * @throws IOException if an error occurs during a send or receive. This includes cases where a payload is invalid JSON.{{#errors}}
+    * @throws {{{name}}} {{{description}}}{{/errors}}
+    */{{#is_deprecated}}
+    @Deprecated(since = "{{{deprecated_release}}}"){{/is_deprecated}}
+    public{{#is_static}} static{{/is_static}} {{#is_async}}Task{{/is_async}}{{^is_async}}{{{return_type}}}{{/is_async}} {{name_camel}}{{#is_async}}Async{{/is_async}}(Connection c{{#parameters}}, {{{type}}} {{{name_camel}}}{{/parameters}}) throws
+    BadServerResponse,
+    XenAPIException,
+    IOException{{#errors}},
+    {{name}}{{/errors}} {
+        String methodCall = "{{#is_async}}Async.{{/is_async}}{{{object_name}}}.{{{name}}}";
+        {{#supports_session}}String sessionReference = c.getSessionReference();{{/supports_session}}{{#method_parameters}}{{#is_record}}
+        var {{{name_camel}}}_map = {{{name_camel}}}.toMap();{{/is_record}}{{/method_parameters}}
+        Object[] methodParameters = { {{#method_parameters}}{{{name_camel}}}{{#is_record}}_map{{/is_record}}{{^is_last}}, {{/is_last}}{{/method_parameters}} };{{#type_reference}}
+        var typeReference = new TypeReference<{{{type_reference}}}>(){};{{/type_reference}}
+        {{^returns_void}}return {{/returns_void}}c.dispatch(methodCall, methodParameters{{#type_reference}}, typeReference{{/type_reference}});
+    }
+
+    {{/methods}}
+}

--- a/ocaml/sdk-gen/java/templates/Types.mustache
+++ b/ocaml/sdk-gen/java/templates/Types.mustache
@@ -174,6 +174,19 @@ public class Types
     }
     {{/errors}}
 
+    public static class BadAsyncResult extends XenAPIException {
+        public final String result;
+
+        /**
+         * Create a new BadAsyncResult
+         */
+        public BadAsyncResult(String result)
+        {
+            super(result);
+            this.result = result;
+        }
+    }
+
     {{#types}}
     /**
     * Converts an {@link Object} to a {@link {{{name}}}} object.
@@ -215,24 +228,12 @@ public class Types
 
     {{/generate_reference_task_result_func}}
     {{/types}}
-
-    public static class BadAsyncResult extends XenAPIException
-    {
-        public final String result;
-
-        public BadAsyncResult(String result)
-        {
-            super(result);
-            this.result = result;
-        }
-    }
-
     private static String parseResult(String result) throws BadAsyncResult
     {
         Pattern pattern = Pattern.compile("<value>(.*)</value>");
         Matcher matcher = pattern.matcher(result);
         if (!matcher.find() || matcher.groupCount() != 1) {
-            throw new Types.BadAsyncResult("Can't interpret: " + result);
+            throw new Types.BadAsyncResult("Can't parse: " + result);
         }
 
         return matcher.group(1);

--- a/ocaml/sdk-gen/java/templates/Types.mustache
+++ b/ocaml/sdk-gen/java/templates/Types.mustache
@@ -101,7 +101,6 @@ public class Types
            super(String.valueOf(responseError));
        }
    }
-
    /**
    * Checks the provided server response was successful. If the call
    * failed, throws a XenAPIException. If the server
@@ -117,13 +116,12 @@ public class Types
         var errorName = response.message;
 
         {{#errors}}
-        if (errorName.equals("{{class_name}}")){
+        if (errorName.equals("{{{name}}}")){
             {{#err_params}}
-            String p{{index}} = errorData.length > {{index}} ? errorData[{{index}}] : "";
+            String p{{{index}}} = errorData.length > {{{index}}} ? errorData[{{{index}}}] : "";
             {{/err_params}}
-            throw new Types.{{class_name}}({{#err_params}}p{{index}}{{^last}}, {{/last}}{{/err_params}});
+            throw new Types.{{{class_name}}}({{#err_params}}p{{{index}}}{{^last}}, {{/last}}{{/err_params}});
         }
-        
         {{/errors}}
 
         // An unknown error occurred
@@ -131,7 +129,7 @@ public class Types
     }
 
     {{#enums}}
-    public enum {{class_name}} {
+    public enum {{{class_name}}} {
         /**
          * The value does not belong to this enumeration
          */
@@ -139,62 +137,60 @@ public class Types
         UNRECOGNIZED,
         {{#values}}
         /**
-         * {{description}}
+         * {{{description}}}
          */
-        @JsonProperty("{{name}}")
-        {{name_uppercase}};
+        @JsonProperty("{{{name}}}")
+        {{{name_uppercase}}}{{^is_last}},{{/is_last}}{{#is_last}};{{/is_last}}
         {{/values}}
         
         public String toString() {
-            if (this == UNRECOGNIZED) return "UNRECOGNIZED";
-            {{#values}}
-            if (this == {{name_uppercase}}) return "{{name}}";
-            {{/values}}
-
+            if (this == UNRECOGNIZED) return "UNRECOGNIZED";{{#values}}
+            if (this == {{{name_uppercase}}}) return "{{{name}}}";{{/values}}
             /* This can never be reached */
             return "illegal enum";
         }
+
     }
 
     {{/enums}}
-
     {{#errors}}
     /**
-     * {{description}}
+     * {{{description}}}
      */
-    public static class {{class_name}} extends XenAPIException {
-        public final String proxies;
+    public static class {{{class_name}}} extends XenAPIException {
+        {{#err_params}}
+        public final String {{{name}}};
+        {{/err_params}}
 
         /**
-         * Create a new {{class_name}}
+         * Create a new {{{class_name}}}
          */
-        public {{class_name}}({{#err_params}}String {{name}}{{^last}}, {{/last}}{{/err_params}}) {
-            super("The PVS site contains running proxies.");#
+        public {{{class_name}}}({{#err_params}}String {{{name}}}{{^last}}, {{/last}}{{/err_params}}) {
+            super("{{{description}}}");
             {{#err_params}}
-            this.{{name}} = {{name}};
+            this.{{{name}}} = {{{name}}};
             {{/err_params}}
         }
     }
-
     {{/errors}}
 
     {{#types}}
     /**
     * Converts an {@link Object} to a {@link {{{name}}}} object.
     * <br />
-    * This method takes an {@link Object} as input and attempts to convert it into a {@link name} object.
-    * If the input object is null, the method returns null. Otherwise, it creates a new {@link name}
+    * This method takes an {@link Object} as input and attempts to convert it into a {@link {{{name}}}} object.
+    * If the input object is null, the method returns null. Otherwise, it creates a new {@link {{{name}}}}
     * object using the input object's {@link String} representation.
     * <br />
-    * @param object The {@link Object} to be converted to a {@link name} object.
-    * @return A {@link name} object created from the input {@link Object}'s {@link String} representation,
+    * @param object The {@link Object} to be converted to a {@link {{{name}}}} object.
+    * @return A {@link {{{name}}}} object created from the input {@link Object}'s {@link String} representation,
     *         or null if the input object is null.
     * @deprecated this method will not be publicly exposed in future releases of this package.
     */
     @Deprecated{{#suppress_unchecked_warning}}
     @SuppressWarnings("unchecked"){{/suppress_unchecked_warning}}
-    public static {{{name}}} {{method_name}}(Object object) {
-        if(object == null){
+    public static {{{name}}} {{{method_name}}}(Object object) {
+        if (object == null) {
             return null;
         }
         {{{method_body}}}

--- a/ocaml/sdk-gen/java/templates/Types.mustache
+++ b/ocaml/sdk-gen/java/templates/Types.mustache
@@ -147,7 +147,7 @@ public class Types
             if (this == UNRECOGNIZED) return "UNRECOGNIZED";{{#values}}
             if (this == {{{name_uppercase}}}) return "{{{name}}}";{{/values}}
             /* This can never be reached */
-            return "illegal enum";
+            return "UNRECOGNIZED";
         }
 
     }

--- a/ocaml/sdk-gen/java/templates/Types.mustache
+++ b/ocaml/sdk-gen/java/templates/Types.mustache
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.xensource.xenapi;
+import java.util.*;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class holds enum types and exceptions.
+ */
+public class Types
+{
+   /**
+    * Interface for all Record classes
+    */
+   public interface Record
+   {
+       /**
+        * Convert a Record to a Map
+        */
+       Map<String, Object> toMap();
+   }
+   /**
+    * Base class for all XenAPI Exceptions
+    */
+   public static class XenAPIException extends IOException {
+       public final String shortDescription;
+       public final String[] errorDescription;
+       XenAPIException(String shortDescription)
+       {
+           this.shortDescription = shortDescription;
+           this.errorDescription = null;
+       }
+       XenAPIException(String[] errorDescription)
+       {
+           this.errorDescription = errorDescription;
+           if (errorDescription.length > 0)
+           {
+               shortDescription = errorDescription[0];
+           } else
+           {
+               shortDescription = "";
+           }
+       }
+       public String toString()
+       {
+           if (errorDescription == null)
+           {
+               return shortDescription;
+           } else if (errorDescription.length == 0)
+           {
+               return "";
+           }
+           StringBuilder sb = new StringBuilder();
+           for (int i = 0; i < errorDescription.length - 1; i++)
+           {
+               sb.append(errorDescription[i]);
+           }
+           sb.append(errorDescription[errorDescription.length - 1]);
+           return sb.toString();
+       }
+   }
+
+   /**
+    * Thrown if the response from the server contains an invalid status.
+    */
+   public static class BadServerResponse extends XenAPIException
+   {
+       public BadServerResponse(JsonRpcResponseError responseError)
+       {
+           super(String.valueOf(responseError));
+       }
+   }
+
+   /**
+   * Checks the provided server response was successful. If the call
+   * failed, throws a XenAPIException. If the server
+   * returned an invalid response, throws a BadServerResponse.
+   * Otherwise, returns the server response as passed in.
+   */
+   public static void checkError(JsonRpcResponseError response) throws XenAPIException, BadServerResponse
+   {
+        var errorData = response.data;
+        if(errorData.length == 0){
+            throw new BadServerResponse(response);
+        }
+        var errorName = response.message;
+
+        {{#errors}}
+        if (errorName.equals("{{class_name}}")){
+            {{#err_params}}
+            String p{{index}} = errorData.length > {{index}} ? errorData[{{index}}] : "";
+            {{/err_params}}
+            throw new Types.{{class_name}}({{#err_params}}p{{index}}{{^last}}, {{/last}}{{/err_params}});
+        }
+        
+        {{/errors}}
+
+        // An unknown error occurred
+        throw new Types.XenAPIException(errorData);
+    }
+
+    {{#enums}}
+    public enum {{class_name}} {
+        /**
+         * The value does not belong to this enumeration
+         */
+        @JsonEnumDefaultValue
+        UNRECOGNIZED,
+        {{#values}}
+        /**
+         * {{description}}
+         */
+        @JsonProperty("{{name}}")
+        {{name_uppercase}};
+        {{/values}}
+        
+        public String toString() {
+            if (this == UNRECOGNIZED) return "UNRECOGNIZED";
+            {{#values}}
+            if (this == {{name_uppercase}}) return "{{name}}";
+            {{/values}}
+
+            /* This can never be reached */
+            return "illegal enum";
+        }
+    }
+
+    {{/enums}}
+
+    {{#errors}}
+    /**
+     * {{description}}
+     */
+    public static class {{class_name}} extends XenAPIException {
+        public final String proxies;
+
+        /**
+         * Create a new {{class_name}}
+         */
+        public {{class_name}}({{#err_params}}String {{name}}{{^last}}, {{/last}}{{/err_params}}) {
+            super("The PVS site contains running proxies.");#
+            {{#err_params}}
+            this.{{name}} = {{name}};
+            {{/err_params}}
+        }
+    }
+
+    {{/errors}}
+
+    {{#types}}
+    /**
+    * Converts an {@link Object} to a {@link {{{name}}}} object.
+    * <br />
+    * This method takes an {@link Object} as input and attempts to convert it into a {@link name} object.
+    * If the input object is null, the method returns null. Otherwise, it creates a new {@link name}
+    * object using the input object's {@link String} representation.
+    * <br />
+    * @param object The {@link Object} to be converted to a {@link name} object.
+    * @return A {@link name} object created from the input {@link Object}'s {@link String} representation,
+    *         or null if the input object is null.
+    * @deprecated this method will not be publicly exposed in future releases of this package.
+    */
+    @Deprecated{{#suppress_unchecked_warning}}
+    @SuppressWarnings("unchecked"){{/suppress_unchecked_warning}}
+    public static {{{name}}} {{method_name}}(Object object) {
+        if(object == null){
+            return null;
+        }
+        {{{method_body}}}
+    }
+
+    {{/types}}
+
+    {{#types}}{{#generate_reference_task_result_func}}
+    /**
+     * Attempt to convert the {@link Task}'s result to a {@link {{{name}}}} object.
+     * Will return null if the method cannot fetch a valid value from the {@link Task} object.
+     * @param task The task from which to fetch the result.
+     * @param connection The connection
+     * @return the instantiated object if a valid value was found, null otherwise.
+     * @throws BadServerResponse Thrown if the response from the server contains an invalid status.
+     * @throws XenAPIException if the call failed.
+     * @throws IOException if an error occurs during a send or receive. This includes cases where a payload is invalid JSON.
+     */
+    public static {{class_name}} to{{class_name}}(Task task, Connection connection) throws IOException {
+        return Types.to{{class_name}}(parseResult(task.getResult(connection)));
+    }
+
+    {{/generate_reference_task_result_func}}
+    {{/types}}
+
+    public static class BadAsyncResult extends XenAPIException
+    {
+        public final String result;
+
+        public BadAsyncResult(String result)
+        {
+            super(result);
+            this.result = result;
+        }
+    }
+
+    private static String parseResult(String result) throws BadAsyncResult
+    {
+        Pattern pattern = Pattern.compile("<value>(.*)</value>");
+        Matcher matcher = pattern.matcher(result);
+        if (!matcher.find() || matcher.groupCount() != 1) {
+            throw new Types.BadAsyncResult("Can't interpret: " + result);
+        }
+
+        return matcher.group(1);
+    }
+
+    public static EventBatch toEventBatch(Object object) {
+      if (object == null) {
+          return null;
+      }
+      Map map = (Map) object;
+      EventBatch batch = new EventBatch();
+      batch.token = toString(map.get("token"));
+      batch.validRefCounts = map.get("valid_ref_counts");
+      batch.events = toSetOfEventRecord(map.get("events"));
+      return batch;
+    }
+}

--- a/ocaml/sdk-gen/java/templates/Types.mustache
+++ b/ocaml/sdk-gen/java/templates/Types.mustache
@@ -101,6 +101,7 @@ public class Types
            super(String.valueOf(responseError));
        }
    }
+
    /**
    * Checks the provided server response was successful. If the call
    * failed, throws a XenAPIException. If the server
@@ -149,7 +150,6 @@ public class Types
             /* This can never be reached */
             return "UNRECOGNIZED";
         }
-
     }
 
     {{/enums}}
@@ -172,8 +172,8 @@ public class Types
             {{/err_params}}
         }
     }
-    {{/errors}}
 
+    {{/errors}}
     public static class BadAsyncResult extends XenAPIException {
         public final String result;
 


### PR DESCRIPTION
Unfortunately, I couldn't come up with an easy way to keep the same order of types in `Types.java`. The issue here is that they were added as they were found, so there was no specified order.

A good way to check would probably be to compare class structures instead. I'm happy to assist if possible.

The SDK sources are present in the PR's artifacts so you don't have to build them yourself.

This PR also adds the JAR to the release files.

Note that I did keep the existing side-effect operations of updating `enums`, `types`, etc.. I found that they weren't _that_ much of an hassle to keep but feel free to weigh in. 

For result of a release with the changes here see https://github.com/danilo-delbusso/xen-api/releases/tag/v60.1.3