### PR TITLE
Remove possible file descriptor leak if safe_close_and_exec fails

### DIFF
--- a/ocaml/forkexecd/lib/forkhelpers.ml
+++ b/ocaml/forkexecd/lib/forkhelpers.ml
@@ -195,8 +195,12 @@ let safe_close_and_exec ?env stdin stdout stderr
   let fds_to_close = ref [] in
 
   let add_fd_to_close_list fd = fds_to_close := fd :: !fds_to_close in
-  (* let remove_fd_from_close_list fd = fds_to_close := List.filter (fun fd' -> fd' <> fd) !fds_to_close in *)
+  let remove_fd_from_close_list fd =
+    fds_to_close := List.filter (fun fd' -> fd' <> fd) !fds_to_close
+  in
   let close_fds () = List.iter (fun fd -> Unix.close fd) !fds_to_close in
+
+  add_fd_to_close_list sock ;
 
   finally
     (fun () ->
@@ -285,6 +289,7 @@ let safe_close_and_exec ?env stdin stdout stderr
       Fecomms.write_raw_rpc sock Fe.Exec ;
       match Fecomms.read_raw_rpc sock with
       | Ok (Fe.Execed pid) ->
+          remove_fd_from_close_list sock ;
           (sock, pid)
       | Ok status ->
           let msg =

--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -77,6 +77,8 @@ let shuffle x =
 
 let irrelevant_strings = ["irrelevant"; "not"; "important"]
 
+let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid ())
+
 let one fds x =
   (*Printf.fprintf stderr "named_fds = %d\n" x.named_fds;
     Printf.fprintf stderr "extra = %d\n" x.extra;*)
@@ -89,7 +91,6 @@ let one fds x =
   let number_of_extra = x.extra in
   let other_names = make_names number_of_extra in
 
-  let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid ()) in
   let table =
     (fun x -> List.combine x (List.map (fun _ -> fd) x)) (names @ other_names)
   in
@@ -114,7 +115,6 @@ let one fds x =
 
 let test_delay () =
   let start = Unix.gettimeofday () in
-  let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid ()) in
   let args = ["sleep"] in
   (* Need to have fractional part because some internal usage split integer
      and fractional and do computation.
@@ -137,7 +137,6 @@ let test_delay () =
       fail "Failed with unexpected exception: %s" (Printexc.to_string e)
 
 let test_notimeout () =
-  let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid ()) in
   let args = ["sleep"] in
   try
     Forkhelpers.execute_command_get_output exe args |> ignore ;
@@ -162,7 +161,6 @@ let test_exitcode () =
   Printf.printf "\nCompleted exitcode tests\n"
 
 let test_output () =
-  let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid ()) in
   let expected_out = "output string" in
   let expected_err = "error string" in
   let args = ["echo"; expected_out; expected_err] in
@@ -172,7 +170,6 @@ let test_output () =
   print_endline "Completed output tests"
 
 let test_input () =
-  let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid ()) in
   let input = "input string" in
   let args = ["replay"] in
   let out, _ =

--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -76,8 +76,7 @@ let shuffle x =
   Array.to_list arr
 
 let fd_list () =
-  let pid = Unix.getpid () in
-  let path = Printf.sprintf "/proc/%d/fd" pid in
+  let path = "/proc/self/fd" in
   List.filter (* get rid of the fd used to read the directory *)
     (fun x ->
       try
@@ -261,8 +260,7 @@ let slave = function
         List.filter (fun x -> not (List.mem x irrelevant_strings)) rest
       in
       (* Check that these fds are present *)
-      let pid = Unix.getpid () in
-      let path = Printf.sprintf "/proc/%d/fd" pid in
+      let path = "/proc/self/fd" in
       let raw = fd_list () in
       let pairs =
         List.map (fun x -> (x, Unix.readlink (Filename.concat path x))) raw
@@ -287,7 +285,7 @@ let slave = function
       List.iter
         (fun fd ->
           if not (List.mem fd (List.map fst filtered)) then
-            fail "fd %s not in /proc/%d/fd [ %s ]" fd pid ls
+            fail "fd %s not in /proc/self/fd [ %s ]" fd ls
         )
         fds ;
       (* Check that we have the expected number *)
@@ -295,7 +293,7 @@ let slave = function
 		  Printf.fprintf stderr "%s %d\n" total_fds (List.length present - 1)
 		*)
       if total_fds <> List.length filtered then
-        fail "Expected %d fds; /proc/%d/fd has %d: %s" total_fds pid
+        fail "Expected %d fds; /proc/self/fd has %d: %s" total_fds
           (List.length filtered) ls
 
 let sleep () = Unix.sleep 3 ; Printf.printf "Ok\n"

--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -149,17 +149,18 @@ let fail x =
   Printf.fprintf stderr "%s\n" x ;
   assert false
 
+let fail fmt = Format.ksprintf fail fmt
+
 let expect expected s =
   if s <> expected ^ "\n" then
-    fail (Printf.sprintf "output %s expected %s" s expected)
+    fail "output %s expected %s" s expected
 
 let test_exitcode () =
   let run_expect cmd expected =
     try Forkhelpers.execute_command_get_output cmd [] |> ignore
     with Forkhelpers.Spawn_internal_error (_, _, Unix.WEXITED n) ->
       if n <> expected then
-        fail
-          (Printf.sprintf "%s exited with code %d, expected %d" cmd n expected)
+        fail "%s exited with code %d, expected %d" cmd n expected
   in
   run_expect "/bin/false" 1 ;
   run_expect "/bin/xe-fe-test-no-command" 127 ;
@@ -257,7 +258,7 @@ let slave = function
       List.iter
         (fun fd ->
           if not (List.mem fd (List.map fst filtered)) then
-            fail (Printf.sprintf "fd %s not in /proc/%d/fd [ %s ]" fd pid ls)
+            fail "fd %s not in /proc/%d/fd [ %s ]" fd pid ls
         )
         fds ;
       (* Check that we have the expected number *)
@@ -265,10 +266,8 @@ let slave = function
 		  Printf.fprintf stderr "%s %d\n" total_fds (List.length present - 1)
 		*)
       if total_fds <> List.length filtered then
-        fail
-          (Printf.sprintf "Expected %d fds; /proc/%d/fd has %d: %s" total_fds
-             pid (List.length filtered) ls
-          )
+        fail "Expected %d fds; /proc/%d/fd has %d: %s" total_fds pid
+          (List.length filtered) ls
 
 let sleep () = Unix.sleep 3 ; Printf.printf "Ok\n"
 


### PR DESCRIPTION
Make sure we release the `sock` file descriptors in all cases.
Add test trying to reproduce the issue passing an invalid file descriptor; not a perfect reproduction but failure in this function can happen for instance if daemon is restarted.