### PR TITLE
CA-392177: Keep current group after reverting from snapshot

### DIFF
--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -383,6 +383,7 @@ let do_not_copy =
     "snapshots"
   ; "tags"
   ; "affinity"
+  ; "groups"
   ; (* Current fields should remain to get destroyed during revert process *)
     "consoles"
   ; "VBDs"


### PR DESCRIPTION
When reverting to a snapshot, "groups" needs to be in `do_not_copy` to reserve the latest value of the VM.