### PR TITLE
CA-392163 clear scheduled assignments on startup

### DIFF
--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -156,12 +156,20 @@ let release_locks ~__context =
       Xapi_vm_lifecycle.force_state_reset ~__context ~self ~value:`Halted
     )
     vms ;
-  (* All VMs should have their scheduled_to_be_resident_on field cleared *)
-  List.iter
-    (fun self ->
-      Db.VM.set_scheduled_to_be_resident_on ~__context ~self ~value:Ref.null
-    )
-    (Db.VM.get_all ~__context)
+  (* Clear all assignments that are only scheduled *)
+  let value = Ref.null in
+  Db.VM.get_all ~__context
+  |> List.iter (fun self ->
+         Db.VM.set_scheduled_to_be_resident_on ~__context ~self ~value
+     ) ;
+  Db.PCI.get_all ~__context
+  |> List.iter (fun self ->
+         Db.PCI.set_scheduled_to_be_attached_to ~__context ~self ~value
+     ) ;
+  Db.VGPU.get_all ~__context
+  |> List.iter (fun self ->
+         Db.VGPU.set_scheduled_to_be_resident_on ~__context ~self ~value
+     )
 
 let create_tools_sr __context name_label name_description sr_introduce
     maybe_create_pbd =


### PR DESCRIPTION
Clear all (stale) scheduled assignments for: VM, PCI, VGPU objects on startup. We were missing the latter two.

