### PR TITLE
CP-47656 VM anti-affinity generate breach alert

### DIFF
--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -365,3 +365,6 @@ let periodic_update_sync_failed = addMessage "PERIODIC_UPDATE_SYNC_FAILED" 3L
 
 let xapi_startup_blocked_as_version_higher_than_coordinator =
   addMessage "XAPI_STARTUP_BLOCKED_AS_VERSION_HIGHER_THAN_COORDINATOR" 2L
+
+let all_running_vms_in_anti_affinity_grp_on_single_host =
+  addMessage "ALL_RUNNING_VMS_IN_ANTI_AFFINITY_GRP_ON_SINGLE_HOST" 3L

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3011,7 +3011,10 @@ functor
         info "VM.set_groups : self = '%s'; value = [ %s ]"
           (vm_uuid ~__context self)
           (String.concat "; " (List.map (vm_group_uuid ~__context) value)) ;
-        Local.VM.set_groups ~__context ~self ~value
+        let original_groups = Db.VM.get_groups ~__context ~self in
+        Local.VM.set_groups ~__context ~self ~value ;
+        Xapi_vm_group_helpers.update_vm_anti_affinity_alert ~__context
+          ~groups:(original_groups @ value)
 
       let import_convert ~__context ~_type ~username ~password ~sr
           ~remote_config =
@@ -6564,6 +6567,8 @@ functor
 
       let destroy ~__context ~self =
         info "VM_group.destroy: self = '%s'" (vm_group_uuid ~__context self) ;
+        Xapi_vm_group_helpers.remove_vm_anti_affinity_alert ~__context
+          ~groups:[self] ;
         Local.VM_group.destroy ~__context ~self
     end
 

--- a/ocaml/xapi/pool_features.ml
+++ b/ocaml/xapi/pool_features.ml
@@ -15,19 +15,13 @@ open Features
 
 module D = Debug.Make (struct let name = "pool_features" end)
 
-open D
-
 (*
 	Terminology:
 	- (Feature) flags: The keys in pool.restriction and host.license_params. Strings like "restrict_dmc".
 	- Params: An instance of host.license_params.
 	- Restrictions: A (string * string) list of feature flag to a Boolean string value ("true" or "false").
 	- Features: Values of type Features.feature.
-	- Core: Relating to features known by xapi, as define in features.ml.
-	- Additional: Relating to features provided by v6d beyond the core ones.
 *)
-
-let all_flags = List.map (fun (k, _) -> k) (to_assoc_list all_features)
 
 let get_pool_features ~__context =
   let pool = Helpers.get_pool ~__context in
@@ -43,78 +37,3 @@ let assert_enabled ~__context ~f =
       (Api_errors.Server_error
          (Api_errors.license_restriction, [name_of_feature f])
       )
-
-(* The set of core restrictions of a pool is the intersection of the sets of features
-   of the individual hosts. *)
-let compute_core_features all_host_params =
-  List.map of_assoc_list all_host_params
-  |> List.fold_left Xapi_stdext_std.Listext.List.intersect all_features
-
-(* Find the feature flags in the given license params that are not represented
-   in the feature type. These are additional flags given to us by v6d.
-   Assume that their names always start with "restrict_". *)
-let find_additional_flags params =
-  let kvs =
-    List.filter
-      (fun (k, _) ->
-        try String.sub k 0 9 = "restrict_" && not (List.mem k all_flags)
-        with Invalid_argument _ -> false
-      )
-      params
-  in
-  List.map fst kvs
-
-(* Determine the set of additional features. For each restrict_ flag,
-   looks for matching flags on all hosts; if one of them is restricted ("true")
-   or absent, then the feature on the pool level is marked as restricted. *)
-let rec compute_additional_restrictions all_host_params = function
-  | [] ->
-      []
-  | flag :: rest ->
-      let switches =
-        List.map
-          (function
-            | params ->
-                if List.mem_assoc flag params then
-                  bool_of_string (List.assoc flag params)
-                else
-                  true
-            )
-          all_host_params
-      in
-      (flag, string_of_bool (List.fold_left ( || ) false switches))
-      :: compute_additional_restrictions all_host_params rest
-
-(* Combine the host-level feature restrictions into pool-level ones, and write
-   the result to the database. *)
-let update_pool_features ~__context =
-  (* Get information from the database *)
-  let pool = Helpers.get_pool ~__context in
-  let old_restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
-  let all_host_params =
-    List.map
-      (fun (_, host_r) -> host_r.API.host_license_params)
-      (Db.Host.get_all_records ~__context)
-  in
-  let master_params =
-    let master_ref = Db.Pool.get_master ~__context ~self:pool in
-    Db.Host.get_license_params ~__context ~self:master_ref
-  in
-  (* Determine the set of core restrictions *)
-  let new_core_features = compute_core_features all_host_params in
-  let new_core_restrictions = to_assoc_list new_core_features in
-  (* Determine the set of additional restrictions *)
-  let additional_flags = find_additional_flags master_params in
-  let new_additional_restrictions =
-    compute_additional_restrictions all_host_params additional_flags
-  in
-  (* The complete set of restrictions is formed by the core feature plus the additional features *)
-  let new_restrictions = new_additional_restrictions @ new_core_restrictions in
-  (* Update the DB if the restrictions have changed *)
-  if new_restrictions <> old_restrictions then (
-    let old_core_features = of_assoc_list old_restrictions in
-    info "Old pool features enabled: %s" (to_compact_string old_core_features) ;
-    info "New pool features enabled: %s" (to_compact_string new_core_features) ;
-    Db.Pool.set_restrictions ~__context ~self:pool ~value:new_restrictions ;
-    Xapi_pool_helpers.apply_guest_agent_config ~__context
-  )

--- a/ocaml/xapi/pool_features.ml
+++ b/ocaml/xapi/pool_features.ml
@@ -13,8 +13,6 @@
 
 open Features
 
-module D = Debug.Make (struct let name = "pool_features" end)
-
 (*
 	Terminology:
 	- (Feature) flags: The keys in pool.restriction and host.license_params. Strings like "restrict_dmc".

--- a/ocaml/xapi/pool_features_helpers.ml
+++ b/ocaml/xapi/pool_features_helpers.ml
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2024 Cloud Software Group
+ * Copyright (c) 2024 Cloud Software Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -102,7 +102,7 @@ let update_pool_features ~__context =
     info "Old pool features enabled: %s" (to_compact_string old_core_features) ;
     info "New pool features enabled: %s" (to_compact_string new_core_features) ;
     Db.Pool.set_restrictions ~__context ~self:pool ~value:new_restrictions ;
-    Xapi_vm_group_helpers.update_vm_placement_alert_when_restriction_change
-      ~__context ~old_restrictions ~new_restrictions ;
+    Xapi_vm_group_helpers.maybe_update_alerts_on_feature_change ~__context
+      ~old_restrictions ~new_restrictions ;
     Xapi_pool_helpers.apply_guest_agent_config ~__context
   )

--- a/ocaml/xapi/pool_features_helpers.ml
+++ b/ocaml/xapi/pool_features_helpers.ml
@@ -1,0 +1,108 @@
+(*
+ * Copyright (C) 2024 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Features
+
+module D = Debug.Make (struct let name = "pool_features_helpers" end)
+
+open D
+
+(*
+	Terminology:
+	- (Feature) flags: The keys in pool.restriction and host.license_params. Strings like "restrict_dmc".
+	- Params: An instance of host.license_params.
+	- Restrictions: A (string * string) list of feature flag to a Boolean string value ("true" or "false").
+	- Features: Values of type Features.feature.
+	- Core: Relating to features known by xapi, as define in features.ml.
+	- Additional: Relating to features provided by v6d beyond the core ones.
+*)
+
+let all_flags = List.map (fun (k, _) -> k) (to_assoc_list all_features)
+
+(* The set of core restrictions of a pool is the intersection of the sets of features
+    of the individual hosts. *)
+let compute_core_features all_host_params =
+  List.map of_assoc_list all_host_params
+  |> List.fold_left Xapi_stdext_std.Listext.List.intersect all_features
+
+(* Find the feature flags in the given license params that are not represented
+    in the feature type. These are additional flags given to us by v6d.
+    Assume that their names always start with "restrict_". *)
+let find_additional_flags params =
+  let kvs =
+    List.filter
+      (fun (k, _) ->
+        try String.sub k 0 9 = "restrict_" && not (List.mem k all_flags)
+        with Invalid_argument _ -> false
+      )
+      params
+  in
+  List.map fst kvs
+
+(* Determine the set of additional features. For each restrict_ flag,
+    looks for matching flags on all hosts; if one of them is restricted ("true")
+    or absent, then the feature on the pool level is marked as restricted. *)
+let rec compute_additional_restrictions all_host_params = function
+  | [] ->
+      []
+  | flag :: rest ->
+      let switches =
+        List.map
+          (function
+            | params ->
+                if List.mem_assoc flag params then
+                  bool_of_string (List.assoc flag params)
+                else
+                  true
+            )
+          all_host_params
+      in
+      (flag, string_of_bool (List.fold_left ( || ) false switches))
+      :: compute_additional_restrictions all_host_params rest
+
+(* Combine the host-level feature restrictions into pool-level ones, and write
+    the result to the database. *)
+let update_pool_features ~__context =
+  (* Get information from the database *)
+  let pool = Helpers.get_pool ~__context in
+  let old_restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
+  let all_host_params =
+    List.map
+      (fun (_, host_r) -> host_r.API.host_license_params)
+      (Db.Host.get_all_records ~__context)
+  in
+  let master_params =
+    let master_ref = Db.Pool.get_master ~__context ~self:pool in
+    Db.Host.get_license_params ~__context ~self:master_ref
+  in
+  (* Determine the set of core restrictions *)
+  let new_core_features = compute_core_features all_host_params in
+  let new_core_restrictions = to_assoc_list new_core_features in
+  (* Determine the set of additional restrictions *)
+  let additional_flags = find_additional_flags master_params in
+  let new_additional_restrictions =
+    compute_additional_restrictions all_host_params additional_flags
+  in
+  (* The complete set of restrictions is formed by the core feature plus the additional features *)
+  let new_restrictions = new_additional_restrictions @ new_core_restrictions in
+  (* Update the DB if the restrictions have changed *)
+  if new_restrictions <> old_restrictions then (
+    let old_core_features = of_assoc_list old_restrictions in
+    info "Old pool features enabled: %s" (to_compact_string old_core_features) ;
+    info "New pool features enabled: %s" (to_compact_string new_core_features) ;
+    Db.Pool.set_restrictions ~__context ~self:pool ~value:new_restrictions ;
+    Xapi_vm_group_helpers.update_vm_placement_alert_when_restriction_change
+      ~__context ~old_restrictions ~new_restrictions ;
+    Xapi_pool_helpers.apply_guest_agent_config ~__context
+  )

--- a/ocaml/xapi/pool_features_helpers.mli
+++ b/ocaml/xapi/pool_features_helpers.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2024 Cloud Software Group
+ * Copyright (c) 2024 Cloud Software Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/ocaml/xapi/pool_features_helpers.mli
+++ b/ocaml/xapi/pool_features_helpers.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2006-2009 Citrix Systems Inc.
+ * Copyright (C) 2024 Cloud Software Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -11,12 +11,5 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-(** Module that controls feature restriction.
- * @group Licensing
-*)
 
-val is_enabled : __context:Context.t -> Features.feature -> bool
-(** Check whether a given feature is currently enabled on the pool. *)
-
-val assert_enabled : __context:Context.t -> f:Features.feature -> unit
-(** Raise appropriate exception if feature is not enabled. *)
+val update_pool_features : __context:Context.t -> unit

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1120,7 +1120,7 @@ let destroy ~__context ~self =
   Db.Host.destroy ~__context ~self ;
   Create_misc.create_pool_cpuinfo ~__context ;
   List.iter (fun vm -> Db.VM.destroy ~__context ~self:vm) my_control_domains ;
-  Pool_features.update_pool_features ~__context
+  Pool_features_helpers.update_pool_features ~__context
 
 let declare_dead ~__context ~host =
   precheck_destroy_declare_dead ~__context ~self:host "declare_dead" ;
@@ -2032,7 +2032,7 @@ let copy_license_to_db ~__context ~host:_ ~features ~additional =
 
 let set_license_params ~__context ~self ~value =
   Db.Host.set_license_params ~__context ~self ~value ;
-  Pool_features.update_pool_features ~__context
+  Pool_features_helpers.update_pool_features ~__context
 
 let apply_edition_internal ~__context ~host ~edition ~additional =
   (* Get localhost's current license state. *)

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1991,7 +1991,7 @@ let eject ~__context ~host =
       Create_misc.create_pool_cpuinfo ~__context ;
       (* Update pool features, in case this host had a different license to the
        * rest of the pool. *)
-      Pool_features.update_pool_features ~__context
+      Pool_features_helpers.update_pool_features ~__context
   | true, true ->
       raise Cannot_eject_master
 

--- a/ocaml/xapi/xapi_vm_group_helpers.ml
+++ b/ocaml/xapi/xapi_vm_group_helpers.ml
@@ -1,0 +1,205 @@
+(*
+ * Copyright (c) 2024 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = "xapi_vm_group_helpers" end)
+
+open D
+
+(** Check the breach state of a group.
+ When there are no VMs or only one VM in the group, it is not considered a breach.
+ when there are two or more VMs and all of them are on the same host, it is considered a breach, and the specific host is returned.
+*)
+let check_breach_on_vm_anti_affinity_rules ~__context ~group =
+  Db.VM_group.get_VMs ~__context ~self:group
+  |> List.filter_map (fun vm ->
+         let vm_rec = Db.VM.get_record ~__context ~self:vm in
+         match (vm_rec.API.vM_power_state, vm_rec.API.vM_resident_on) with
+         | `Running, h when h <> Ref.null ->
+             Some h
+         | _ ->
+             None
+     )
+  |> function
+  | [] | [_] ->
+      None
+  | h :: remaining ->
+      if List.exists (fun h' -> h' <> h) remaining then
+        None
+      else
+        Some h
+
+let report_anti_affinity_alert ~__context ~group ~host =
+  let group_uuid = Db.VM_group.get_uuid ~__context ~self:group in
+  let host_uuid = Db.Host.get_uuid ~__context ~self:host in
+  let body =
+    String.concat ""
+      [
+        "<body><message>Breach on VM anti-affinity rules</message><VM_group>"
+      ; group_uuid
+      ; "</VM_group><host>"
+      ; host_uuid
+      ; "</host></body>"
+      ]
+  in
+  let obj_uuid =
+    Db.Pool.get_uuid ~__context ~self:(Helpers.get_pool ~__context)
+  in
+  Xapi_alert.add
+    ~msg:Api_messages.all_running_vms_in_anti_affinity_grp_on_single_host
+    ~cls:`Pool ~obj_uuid ~body
+
+let get_anti_affinity_alerts ~__context =
+  Helpers.call_api_functions ~__context (fun rpc session_id ->
+      Client.Client.Message.get_all_records ~rpc ~session_id
+  )
+  |> List.filter (fun (_, record) ->
+         record.API.message_name
+         = fst Api_messages.all_running_vms_in_anti_affinity_grp_on_single_host
+     )
+
+let alert_matched ~__context ~label_name ~id alert =
+  let alert_rec = snd alert in
+  match Xml.parse_string alert_rec.API.message_body with
+  | Xml.Element ("body", _, children) -> (
+      let filtered =
+        List.filter_map
+          (function
+            | Xml.Element (name, _, [Xml.PCData v]) when name = label_name ->
+                Some v
+            | _ ->
+                None
+            )
+          children
+      in
+      match filtered with [uuid] when uuid = id -> true | _ -> false
+    )
+  | _ ->
+      let msg = "Invalid message body of VM group alert" in
+      error "%s" msg ;
+      raise Api_errors.(Server_error (internal_error, [msg]))
+  | exception e ->
+      let msg = Printf.sprintf "%s" (ExnHelper.string_of_exn e) in
+      error "%s" msg ;
+      raise Api_errors.(Server_error (internal_error, [msg]))
+
+let filter_alerts_with_group ~__context ~group ~alerts =
+  let group_uuid = Db.VM_group.get_uuid ~__context ~self:group in
+  List.filter
+    (alert_matched ~__context ~label_name:"VM_group" ~id:group_uuid)
+    alerts
+
+let filter_alerts_with_host ~__context ~host ~alerts =
+  let host_uuid = Db.Host.get_uuid ~__context ~self:host in
+  List.filter (alert_matched ~__context ~label_name:"host" ~id:host_uuid) alerts
+
+(** If it is a breach and no alerts exist, generate one,
+    If it is not a breach and alerts exist, dismiss the existing alert *)
+let update_vm_anti_affinity_alert_for_group ~__context ~group ~alerts =
+  let breach_on_host =
+    check_breach_on_vm_anti_affinity_rules ~__context ~group
+  in
+  debug "[Anti-affinity] existing alerts of group (UUID: %s) is: %d"
+    (Db.VM_group.get_uuid ~__context ~self:group)
+    (List.length alerts) ;
+  match (alerts, breach_on_host) with
+  | [], Some host ->
+      report_anti_affinity_alert ~__context ~group ~host
+  | alerts, None ->
+      List.iter
+        (fun (ref, _) ->
+          Helpers.call_api_functions ~__context (fun rpc session_id ->
+              Client.Client.Message.destroy ~rpc ~session_id ~self:ref
+          )
+        )
+        alerts
+  | alerts, Some host when filter_alerts_with_host ~__context ~host ~alerts = []
+    ->
+      List.iter
+        (fun (ref, _) ->
+          Helpers.call_api_functions ~__context (fun rpc session_id ->
+              Client.Client.Message.destroy ~rpc ~session_id ~self:ref
+          )
+        )
+        alerts ;
+      report_anti_affinity_alert ~__context ~group ~host
+  | _, _ ->
+      ()
+
+let maybe_update_vm_anti_affinity_alert_for_vm ~__context ~vm =
+  try
+    Db.VM.get_groups ~__context ~self:vm
+    |> List.filter (fun g ->
+           Db.VM_group.get_placement ~__context ~self:g = `anti_affinity
+       )
+    |> function
+    | [] ->
+        ()
+    | group :: _ ->
+        let alerts = get_anti_affinity_alerts ~__context in
+        let alerts_of_group =
+          filter_alerts_with_group ~__context ~group ~alerts
+        in
+        update_vm_anti_affinity_alert_for_group ~__context ~group
+          ~alerts:alerts_of_group
+  with e -> error "%s" (Printexc.to_string e)
+
+let remove_vm_anti_affinity_alert_for_group ~__context ~group ~alerts =
+  debug "[Anti-affinity] remove alert for group:%s"
+    (Db.VM_group.get_uuid ~__context ~self:group) ;
+  List.iter
+    (fun (ref, _) ->
+      Helpers.call_api_functions ~__context (fun rpc session_id ->
+          Client.Client.Message.destroy ~rpc ~session_id ~self:ref
+      )
+    )
+    alerts
+
+let update_alert ~__context ~groups ~action =
+  try
+    let alerts = get_anti_affinity_alerts ~__context in
+    groups
+    |> List.filter (fun g ->
+           Db.VM_group.get_placement ~__context ~self:g = `anti_affinity
+       )
+    |> List.iter (fun group ->
+           let alerts_of_group =
+             filter_alerts_with_group ~__context ~group ~alerts
+           in
+           action ~__context ~group ~alerts:alerts_of_group
+       )
+  with e -> error "%s" (Printexc.to_string e)
+
+let update_vm_anti_affinity_alert ~__context ~groups =
+  update_alert ~__context ~groups
+    ~action:update_vm_anti_affinity_alert_for_group
+
+let remove_vm_anti_affinity_alert ~__context ~groups =
+  update_alert ~__context ~groups
+    ~action:remove_vm_anti_affinity_alert_for_group
+
+let maybe_update_alerts_on_feature_change ~__context ~old_restrictions
+    ~new_restrictions =
+  try
+    let is_enabled restrictions =
+      List.mem Features.VM_anti_affinity (Features.of_assoc_list restrictions)
+    in
+    let groups = Db.VM_group.get_all ~__context in
+    match (is_enabled old_restrictions, is_enabled new_restrictions) with
+    | false, true ->
+        update_vm_anti_affinity_alert ~__context ~groups
+    | true, false ->
+        remove_vm_anti_affinity_alert ~__context ~groups
+    | _, _ ->
+        ()
+  with e -> error "%s" (Printexc.to_string e)

--- a/ocaml/xapi/xapi_vm_group_helpers.mli
+++ b/ocaml/xapi/xapi_vm_group_helpers.mli
@@ -1,0 +1,44 @@
+(*
+ * Copyright (c) 2024 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val maybe_update_vm_anti_affinity_alert_for_vm :
+  __context:Context.t -> vm:[`VM] API.Ref.t -> unit
+(** updates VM anti-affinity alert with a given VM.*)
+
+val remove_vm_anti_affinity_alert :
+  __context:Context.t -> groups:[`VM_group] API.Ref.t list -> unit
+(** removes VM anti-affinity alert with given groups.*)
+
+val update_vm_anti_affinity_alert :
+  __context:Context.t -> groups:[`VM_group] API.Ref.t list -> unit
+(** updates VM anti-affinity alert with given groups.*)
+
+val maybe_update_alerts_on_feature_change :
+     __context:Context.t
+  -> old_restrictions:(string * string) list
+  -> new_restrictions:(string * string) list
+  -> unit
+(** Updates the VM anti-affinity alert only when Features.VM_anti_affinity changes.
+
+    @param __context The context information.
+    @param old_restrictions The old feature restrictions represented as an association list.
+           Each entry in the list contains a feature identifier and its corresponding restriction status.
+    @param new_restrictions The new feature restrictions represented as an association list.
+           Each entry in the list contains a feature identifier and its corresponding restriction status.
+    Example:
+      [
+        ("restrict_vlan", "true");
+        ("restrict_vm_anti_affinity", "false")
+      ]
+*)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -490,7 +490,9 @@ let pool_migrate_complete ~__context ~vm ~host:_ =
     Xapi_xenops.add_caches id ;
     Xapi_xenops.refresh_vm ~__context ~self:vm ;
     Monitor_dbcalls_cache.clear_cache_for_vm ~vm_uuid:id
-  )
+  ) ;
+  Xapi_vm_group_helpers.maybe_update_vm_anti_affinity_alert_for_vm ~__context
+    ~vm
 
 type mirror_record = {
     mr_mirrored: bool


### PR DESCRIPTION
This PR introduces the generation of breach alerts during operations on VMs or groups, triggered when all VMs within a group are breached (i.e., placed on the same host).

Test scenarios covered in this PR include:

- Starting and resuming a VM triggers a breach alert if it is breached.
- Stopping and suspending a VM dismisses the breach alert if it is no longer breached.
- Migrating a VM, whether causing or resolving a breach, generates or dismisses the alert respectively.
- Moving a VM from one group to another triggers a breach alert if either group is breached.
- Destroying a VM group dismisses all related breach alerts.
- Changing the license from Premium to Standard dismisses all breach alerts, while changing from Standard to Premium generates them.

Additionally, the `pool_feature` has been split into two parts, `pool_feature` and `pool_feature_helpers`, to address dependency cycles.
`Error: dependency cycle between modules in _build/default/ocaml/xapi:
   Xha_statefile
-> Sm
-> Sm_exec
-> Xapi_session
-> Pool_features
-> Xapi_vm_group_helpers
-> Xapi_alert
-> Xapi_http
-> Xapi_session`