### PR TITLE
CP-48855: fix go lint var-name warnings

### DIFF
--- a/ocaml/sdk-gen/go/gen_go_binding.ml
+++ b/ocaml/sdk-gen/go/gen_go_binding.ml
@@ -54,8 +54,9 @@ let main destdir =
       let header_rendered =
         render_template "FileHeader.mustache" obj ~newline:true ()
       in
+      let options_rendered = render_template "Option.mustache" obj () in
       let record_rendered = render_template "Record.mustache" obj () in
-      let rendered = header_rendered ^ record_rendered in
+      let rendered = header_rendered ^ options_rendered ^ record_rendered in
       let output_file = name ^ ".go" in
       generate_file ~rendered ~destdir ~output_file
     )

--- a/ocaml/sdk-gen/go/gen_go_binding.ml
+++ b/ocaml/sdk-gen/go/gen_go_binding.ml
@@ -24,6 +24,30 @@ let render_enums enums destdir =
   let rendered = header ^ enums ^ "\n" in
   generate_file ~rendered ~destdir ~output_file:"enums.go"
 
+let render_api_versions destdir =
+  let header_json =
+    let name s = `O [("name", `String s); ("sname", `Null)] in
+    `O
+      [
+        ( "modules"
+        , `O
+            [
+              ("import", `Bool true)
+            ; ("items", `A (List.map name ["errors"; "fmt"]))
+            ]
+        )
+      ]
+  in
+  let rendered =
+    let header =
+      render_template "FileHeader.mustache" header_json ~newline:true ()
+    in
+    header
+    ^ render_template "APIVersions.mustache" CommonFunctions.json_releases
+        ~newline:true ()
+  in
+  generate_file ~rendered ~destdir ~output_file:"api_versions.go"
+
 let render_api_messages_and_errors destdir =
   let obj =
     `O
@@ -45,6 +69,7 @@ let render_api_messages_and_errors destdir =
     ~output_file:"api_messages.go"
 
 let main destdir =
+  render_api_versions destdir ;
   render_api_messages_and_errors destdir ;
   let enums = Json.all_enums objects in
   render_enums enums destdir ;

--- a/ocaml/sdk-gen/go/gen_go_helper.ml
+++ b/ocaml/sdk-gen/go/gen_go_helper.ml
@@ -42,6 +42,8 @@ let generate_file ~rendered ~destdir ~output_file =
     ~finally:(fun () -> close_out out_chan)
 
 module Json = struct
+  open Xapi_stdext_std
+
   type enum = (string * string) list
 
   module StringMap = Map.Make (String)
@@ -52,6 +54,32 @@ module Json = struct
 
   let merge_maps m maps =
     List.fold_left (fun acc map -> StringMap.union choose_enum acc map) m maps
+
+  let rec func_name_suffix = function
+    | SecretString | String ->
+        "String"
+    | Int ->
+        "Int"
+    | Float ->
+        "Float"
+    | Bool ->
+        "Bool"
+    | DateTime ->
+        "Time"
+    | Enum (name, _) ->
+        "Enum" ^ snake_to_camel name
+    | Set ty ->
+        func_name_suffix ty ^ "Set"
+    | Map (ty1, ty2) ->
+        let k_suffix = func_name_suffix ty1 in
+        let v_suffix = func_name_suffix ty2 in
+        k_suffix ^ "To" ^ v_suffix ^ "Map"
+    | Ref r ->
+        snake_to_camel r ^ "Ref"
+    | Record r ->
+        snake_to_camel r ^ "Record"
+    | Option ty ->
+        func_name_suffix ty
 
   let rec string_of_ty_with_enums ty : string * enums =
     match ty with
@@ -81,7 +109,9 @@ module Json = struct
     | Record r ->
         (snake_to_camel r ^ "Record", StringMap.empty)
     | Option ty ->
-        string_of_ty_with_enums ty
+        let _, e = string_of_ty_with_enums ty in
+        let name = func_name_suffix ty in
+        ("Option" ^ name, e)
 
   let of_enum name vs =
     let name = snake_to_camel name in
@@ -123,9 +153,7 @@ module Json = struct
 
   let modules_of_types types =
     let common = [`O [("name", `String "fmt"); ("sname", `Null)]] in
-    let items =
-      List.map modules_of_type types |> List.concat |> List.append common
-    in
+    let items = List.concat_map modules_of_type types |> List.append common in
     `O [("import", `Bool true); ("items", `A items)]
 
   let all_enums objs =
@@ -169,13 +197,28 @@ module Json = struct
     | _ ->
         [("event", `Null); ("session", `Null)]
 
+  let of_option ty =
+    let name, _ = string_of_ty_with_enums ty in
+    `O
+      [
+        ("type", `String name)
+      ; ("type_name_suffix", `String (func_name_suffix ty))
+      ]
+
+  let of_options types =
+    types
+    |> List.filter_map (function Option ty -> Some ty | _ -> None)
+    |> List.map of_option
+
   let xenapi objs =
     List.map
       (fun obj ->
         let obj_name = snake_to_camel obj.name in
         let name_internal = String.uncapitalize_ascii obj_name in
         let fields = Datamodel_utils.fields_of_obj obj in
-        let types = List.map (fun field -> field.ty) fields in
+        let types =
+          List.map (fun field -> field.ty) fields |> Listext.List.setify
+        in
         let modules =
           match obj.messages with [] -> `Null | _ -> modules_of_types types
         in
@@ -188,6 +231,7 @@ module Json = struct
             , `A (get_event_snapshot obj.name @ List.map of_field fields)
             )
           ; ("modules", modules)
+          ; ("option", `A (of_options types))
           ]
         in
         let assoc_list = base_assoc_list @ get_event_session_value obj.name in

--- a/ocaml/sdk-gen/go/gen_go_helper.ml
+++ b/ocaml/sdk-gen/go/gen_go_helper.ml
@@ -16,16 +16,40 @@
 open Datamodel_types
 open CommonFunctions
 module Types = Datamodel_utils.Types
+module StringSet = Set.Make (String)
 
 let templates_dir = "templates"
 
 let ( // ) = Filename.concat
 
+let acronyms =
+  [
+    "id"
+  ; "ip"
+  ; "vm"
+  ; "api"
+  ; "uuid"
+  ; "cpu"
+  ; "tls"
+  ; "https"
+  ; "url"
+  ; "db"
+  ; "xml"
+  ; "eof"
+  ]
+  |> StringSet.of_list
+
+let is_acronym word = StringSet.mem word acronyms
+
 let snake_to_camel (s : string) : string =
   Astring.String.cuts ~sep:"_" s
-  |> List.map (fun s -> Astring.String.cuts ~sep:"-" s)
-  |> List.concat
-  |> List.map String.capitalize_ascii
+  |> List.concat_map (fun s -> Astring.String.cuts ~sep:"-" s)
+  |> List.map (function
+       | s when is_acronym s ->
+           String.uppercase_ascii s
+       | s ->
+           String.capitalize_ascii s
+       )
   |> String.concat ""
 
 let render_template template_file json ?(newline = false) () =
@@ -240,28 +264,22 @@ module Json = struct
       objs
 
   let of_api_message_or_error info =
-    let snake_to_camel (s : string) : string =
+    let xapi_constants_renaming (s : string) : string =
       String.split_on_char '_' s
       |> List.map (fun seg ->
              let lower = String.lowercase_ascii seg in
              match lower with
-             | "vm"
-             | "cpu"
-             | "tls"
-             | "xml"
-             | "url"
-             | "id"
-             | "uuid"
-             | "ip"
-             | "api"
-             | "eof" ->
+             | s when is_acronym s ->
                  String.uppercase_ascii lower
              | _ ->
                  String.capitalize_ascii lower
          )
       |> String.concat ""
     in
-    `O [("name", `String (snake_to_camel info)); ("value", `String info)]
+    `O
+      [
+        ("name", `String (xapi_constants_renaming info)); ("value", `String info)
+      ]
 
   let api_messages =
     List.map (fun (msg, _) -> of_api_message_or_error msg) !Api_messages.msgList

--- a/ocaml/sdk-gen/go/templates/APIErrors.mustache
+++ b/ocaml/sdk-gen/go/templates/APIErrors.mustache
@@ -1,6 +1,7 @@
+//nolint:gosec
 const (
 {{#api_errors}}
 	//
-	ERR_{{name}} = "{{name}}"
+	Error{{name}} = "{{value}}"
 {{/api_errors}}
 )

--- a/ocaml/sdk-gen/go/templates/APIMessages.mustache
+++ b/ocaml/sdk-gen/go/templates/APIMessages.mustache
@@ -1,6 +1,6 @@
 const (
 {{#api_messages}}
 	//
-	MSG_{{name}} = "{{name}}"
+	Message{{name}} = "{{value}}"
 {{/api_messages}}
 )

--- a/ocaml/sdk-gen/go/templates/APIVersions.mustache
+++ b/ocaml/sdk-gen/go/templates/APIVersions.mustache
@@ -1,0 +1,103 @@
+type APIVersion int
+
+const (
+{{#releases}}
+	// {{branding}} ({{code_name}})
+	APIVersion{{version_major}}_{{version_minor}}{{#first}} APIVersion = iota + 1{{/first}}
+{{/releases}}  
+	APIVersionLatest  APIVersion = {{latest_version_index}}
+	APIVersionUnknown APIVersion = 99
+)
+
+func (v APIVersion) String() string {
+	switch v {
+{{#releases}}
+	case APIVersion{{version_major}}_{{version_minor}}:
+		return "{{version_major}}.{{version_minor}}"
+{{/releases}}
+	case APIVersionUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
+var APIVersionMap = map[string]APIVersion{
+{{#releases}}
+	//
+	"APIVersion{{version_major}}_{{version_minor}}": APIVersion{{version_major}}_{{version_minor}},
+{{/releases}}
+	//
+	"APIVersionLatest": APIVersionLatest,
+	//
+	"APIVersionUnknown": APIVersionUnknown,
+}
+
+func GetAPIVersion(major int, minor int) APIVersion {
+	versionName := fmt.Sprintf("APIVersion%d_%d", major, minor)
+	apiVersion, ok := APIVersionMap[versionName]
+	if !ok {
+		apiVersion = APIVersionUnknown
+	}
+
+	return apiVersion
+}
+
+func getPoolMaster(session *Session) (HostRef, error) {
+	var master HostRef
+	poolRefs, err := Pool.GetAll(session)
+	if err != nil {
+		return master, err
+	}
+	if len(poolRefs) > 0 {
+		poolRecord, err := Pool.GetRecord(session, poolRefs[0])
+		if err != nil {
+			return master, err
+		}
+		return poolRecord.Master, nil
+	}
+	return master, errors.New("pool master not found")
+}
+
+func setSessionDetails(session *Session) error {
+	err := setAPIVersion(session)
+	if err != nil {
+		return err
+	}
+	err = setXAPIVersion(session)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setAPIVersion(session *Session) error {
+	session.APIVersion = APIVersionUnknown
+	masterRef, err := getPoolMaster(session)
+	if err != nil {
+		return err
+	}
+	hostRecord, err := Host.GetRecord(session, masterRef)
+	if err != nil {
+		return err
+	}
+	session.APIVersion = GetAPIVersion(hostRecord.APIVersionMajor, hostRecord.APIVersionMinor)
+	return nil
+}
+
+func setXAPIVersion(session *Session) error {
+	masterRef, err := getPoolMaster(session)
+	if err != nil {
+		return err
+	}
+	hostRecord, err := Host.GetRecord(session, masterRef)
+	if err != nil {
+		return err
+	}
+	version, ok := hostRecord.SoftwareVersion["xapi"]
+	if !ok {
+		return errors.New("xapi version not found")
+	}
+	session.XAPIVersion = version
+	return nil
+}

--- a/ocaml/sdk-gen/go/templates/Option.mustache
+++ b/ocaml/sdk-gen/go/templates/Option.mustache
@@ -1,0 +1,4 @@
+{{#option}}
+type Option{{type_name_suffix}} *{{type}}
+
+{{/option}}

--- a/ocaml/sdk-gen/go/templates/Record.mustache
+++ b/ocaml/sdk-gen/go/templates/Record.mustache
@@ -21,21 +21,23 @@ type EventBatch struct {
 // {{.}}
 {{/description}}
 {{#session}}
-type {{name}}Class struct {
-	client *rpcClient
-	ref    SessionRef
+type {{name}} struct {
+	APIVersion  APIVersion
+	client      *rpcClient
+	ref         SessionRef
+	XAPIVersion string
 }
 
-func NewSession(opts *ClientOpts) *SessionClass {
-	client := NewJsonRPCClient(opts)
-	var session SessionClass
+func NewSession(opts *ClientOpts) *Session {
+	client := newJSONRPCClient(opts)
+	var session Session
 	session.client = client
 
 	return &session
 }
 {{/session}}
 {{^session}}
-type {{name}}Class struct{}
+type {{name_internal}} struct{}
 
-var {{name}} *{{name}}Class
+var {{name}} {{name_internal}}
 {{/session}}

--- a/ocaml/sdk-gen/go/test_data/api_errors.go
+++ b/ocaml/sdk-gen/go/test_data/api_errors.go
@@ -1,6 +1,7 @@
+//nolint:gosec
 const (
 	//
-	ERR_MESSAGE_DEPRECATED = "MESSAGE_DEPRECATED"
+	ErrorMessageDeprecated = "MESSAGE_DEPRECATED"
 	//
-	ERR_MESSAGE_REMOVED = "MESSAGE_REMOVED"
+	ErrorMessageRemoved = "MESSAGE_REMOVED"
 )

--- a/ocaml/sdk-gen/go/test_data/api_messages.go
+++ b/ocaml/sdk-gen/go/test_data/api_messages.go
@@ -1,6 +1,6 @@
 const (
 	//
-	MSG_HA_STATEFILE_LOST = "HA_STATEFILE_LOST"
+	MessageHaStatefileLost = "HA_STATEFILE_LOST"
 	//
-	MSG_METADATA_LUN_HEALTHY = "METADATA_LUN_HEALTHY"
+	MessageMetadataLunHealthy = "METADATA_LUN_HEALTHY"
 )

--- a/ocaml/sdk-gen/go/test_data/api_versions.go
+++ b/ocaml/sdk-gen/go/test_data/api_versions.go
@@ -1,0 +1,103 @@
+type APIVersion int
+
+const (
+	// XenServer 4.0 (rio)
+	APIVersion1_1 APIVersion = iota + 1
+	// XenServer 4.1 (miami)
+	APIVersion1_2
+	APIVersionLatest  APIVersion = 2
+	APIVersionUnknown APIVersion = 99
+)
+
+func (v APIVersion) String() string {
+	switch v {
+	case APIVersion1_1:
+		return "1.1"
+	case APIVersion1_2:
+		return "1.2"
+	case APIVersionUnknown:
+		return "Unknown"
+	default:
+		return "Unknown"
+	}
+}
+
+var APIVersionMap = map[string]APIVersion{
+	//
+	"APIVersion1_1": APIVersion1_1,
+	//
+	"APIVersion1_2": APIVersion1_2,
+	//
+	"APIVersionLatest": APIVersionLatest,
+	//
+	"APIVersionUnknown": APIVersionUnknown,
+}
+
+func GetAPIVersion(major int, minor int) APIVersion {
+	versionName := fmt.Sprintf("APIVersion%d_%d", major, minor)
+	apiVersion, ok := APIVersionMap[versionName]
+	if !ok {
+		apiVersion = APIVersionUnknown
+	}
+
+	return apiVersion
+}
+
+func getPoolMaster(session *Session) (HostRef, error) {
+	var master HostRef
+	poolRefs, err := Pool.GetAll(session)
+	if err != nil {
+		return master, err
+	}
+	if len(poolRefs) > 0 {
+		poolRecord, err := Pool.GetRecord(session, poolRefs[0])
+		if err != nil {
+			return master, err
+		}
+		return poolRecord.Master, nil
+	}
+	return master, errors.New("pool master not found")
+}
+
+func setSessionDetails(session *Session) error {
+	err := setAPIVersion(session)
+	if err != nil {
+		return err
+	}
+	err = setXAPIVersion(session)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setAPIVersion(session *Session) error {
+	session.APIVersion = APIVersionUnknown
+	masterRef, err := getPoolMaster(session)
+	if err != nil {
+		return err
+	}
+	hostRecord, err := Host.GetRecord(session, masterRef)
+	if err != nil {
+		return err
+	}
+	session.APIVersion = GetAPIVersion(hostRecord.APIVersionMajor, hostRecord.APIVersionMinor)
+	return nil
+}
+
+func setXAPIVersion(session *Session) error {
+	masterRef, err := getPoolMaster(session)
+	if err != nil {
+		return err
+	}
+	hostRecord, err := Host.GetRecord(session, masterRef)
+	if err != nil {
+		return err
+	}
+	version, ok := hostRecord.SoftwareVersion["xapi"]
+	if !ok {
+		return errors.New("xapi version not found")
+	}
+	session.XAPIVersion = version
+	return nil
+}

--- a/ocaml/sdk-gen/go/test_data/record.go
+++ b/ocaml/sdk-gen/go/test_data/record.go
@@ -8,14 +8,16 @@ type SessionRecord struct {
 type SessionRef string
 
 // A session
-type SessionClass struct {
-	client *rpcClient
-	ref    SessionRef
+type Session struct {
+	APIVersion  APIVersion
+	client      *rpcClient
+	ref         SessionRef
+	XAPIVersion string
 }
 
-func NewSession(opts *ClientOpts) *SessionClass {
-	client := NewJsonRPCClient(opts)
-	var session SessionClass
+func NewSession(opts *ClientOpts) *Session {
+	client := newJSONRPCClient(opts)
+	var session Session
 	session.client = client
 
 	return &session

--- a/ocaml/sdk-gen/go/test_gen_go.ml
+++ b/ocaml/sdk-gen/go/test_gen_go.ml
@@ -136,7 +136,7 @@ let verify_enums : Mustache.Json.t -> bool = function
 
 (* obj *)
 let verify_obj_member = function
-  | "name", `String _ | "description", `String _ ->
+  | "name", `String _ | "description", `String _ | "name_internal", `String _ ->
       true
   | "event", `Bool _ | "event", `Null ->
       true
@@ -151,7 +151,16 @@ let verify_obj_member = function
   | _ ->
       false
 
-let obj_keys = ["name"; "description"; "fields"; "modules"; "event"; "session"]
+let obj_keys =
+  [
+    "name"
+  ; "name_internal"
+  ; "description"
+  ; "fields"
+  ; "modules"
+  ; "event"
+  ; "session"
+  ]
 
 let verify_obj = function
   | `O members ->
@@ -159,10 +168,18 @@ let verify_obj = function
   | _ ->
       false
 
+let verify_msg_or_error_member = function
+  | "name", `String _ | "value", `String _ ->
+      true
+  | _ ->
+      false
+
+let keys_in_error_or_msg = ["name"; "value"]
+
 let verify_msgs_or_errors lst =
   let verify_msg_or_error = function
-    | `O [("name", `String _)] ->
-        true
+    | `O members ->
+        schema_check keys_in_error_or_msg verify_msg_or_error_member members
     | _ ->
         false
   in
@@ -285,8 +302,16 @@ let api_errors : Mustache.Json.t =
       ( "api_errors"
       , `A
           [
-            `O [("name", `String "MESSAGE_DEPRECATED")]
-          ; `O [("name", `String "MESSAGE_REMOVED")]
+            `O
+              [
+                ("name", `String "MessageDeprecated")
+              ; ("value", `String "MESSAGE_DEPRECATED")
+              ]
+          ; `O
+              [
+                ("name", `String "MessageRemoved")
+              ; ("value", `String "MESSAGE_REMOVED")
+              ]
           ]
       )
     ]
@@ -297,8 +322,16 @@ let api_messages : Mustache.Json.t =
       ( "api_messages"
       , `A
           [
-            `O [("name", `String "HA_STATEFILE_LOST")]
-          ; `O [("name", `String "METADATA_LUN_HEALTHY")]
+            `O
+              [
+                ("name", `String "HaStatefileLost")
+              ; ("value", `String "HA_STATEFILE_LOST")
+              ]
+          ; `O
+              [
+                ("name", `String "MetadataLunHealthy")
+              ; ("value", `String "METADATA_LUN_HEALTHY")
+              ]
           ]
       )
     ]

--- a/ocaml/sdk-gen/go/test_gen_go.ml
+++ b/ocaml/sdk-gen/go/test_gen_go.ml
@@ -134,6 +134,20 @@ let verify_enums : Mustache.Json.t -> bool = function
   | _ ->
       false
 
+let option_keys = ["type"; "type_name_suffix"]
+
+let verify_option_member = function
+  | "type", `String _ | "type_name_suffix", `String _ ->
+      true
+  | _ ->
+      false
+
+let verify_option = function
+  | `O members ->
+      schema_check option_keys verify_option_member members
+  | _ ->
+      false
+
 (* obj *)
 let verify_obj_member = function
   | "name", `String _ | "description", `String _ | "name_internal", `String _ ->
@@ -144,6 +158,8 @@ let verify_obj_member = function
       true
   | "fields", `A fields ->
       List.for_all verify_field fields
+  | "option", `A options ->
+      List.for_all verify_option options
   | "modules", `Null ->
       true
   | "modules", `O members ->
@@ -160,6 +176,7 @@ let obj_keys =
   ; "modules"
   ; "event"
   ; "session"
+  ; "option"
   ]
 
 let verify_obj = function
@@ -336,6 +353,21 @@ let api_messages : Mustache.Json.t =
       )
     ]
 
+let option =
+  `O
+    [
+      ( "option"
+      , `A
+          [
+            `O
+              [
+                ("type", `String "string")
+              ; ("type_name_suffix", `String "String")
+              ]
+          ]
+      )
+    ]
+
 module TemplatesTest = Generic.MakeStateless (struct
   module Io = struct
     type input_t = string * Mustache.Json.t
@@ -361,6 +393,8 @@ module TemplatesTest = Generic.MakeStateless (struct
 
   let api_messages_rendered = string_of_file "api_messages.go"
 
+  let option_rendered = "type OptionString *string"
+
   let tests =
     `QuickAndAutoDocumented
       [
@@ -369,6 +403,7 @@ module TemplatesTest = Generic.MakeStateless (struct
       ; (("Enum.mustache", enums), enums_rendered)
       ; (("APIErrors.mustache", api_errors), api_errors_rendered)
       ; (("APIMessages.mustache", api_messages), api_messages_rendered)
+      ; (("Option.mustache", option), option_rendered)
       ]
 end)
 


### PR DESCRIPTION
## Fix go lint var-name warnings
1. update templates (APIErrors, APIMessages, Record)
2. use right reserved words

## Others
1. add templates for options and APIVersion
2. render options and APIVersion
