### PR TITLE
Add option to disable fileserver in XAPI conf

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -824,68 +824,76 @@ let master_only_http_handlers =
   ]
 
 let common_http_handlers () =
-  [
-    ("get_services_xenops", Http_svr.FdIO Xapi_services.get_handler)
-  ; ("put_services_xenops", Http_svr.FdIO Xapi_services.put_handler)
-  ; ("post_services_xenops", Http_svr.FdIO Xapi_services.post_handler)
-  ; ("get_services_sm", Http_svr.FdIO Xapi_services.get_handler)
-  ; ("put_services_sm", Http_svr.FdIO Xapi_services.put_handler)
-  ; ("post_services_sm", Http_svr.FdIO Xapi_services.post_handler)
-  ; ("get_services", Http_svr.FdIO Xapi_services.get_handler)
-  ; ("post_services", Http_svr.FdIO Xapi_services.post_handler)
-  ; ("put_services", Http_svr.FdIO Xapi_services.put_handler)
-  ; ("put_import", Http_svr.FdIO Import.handler)
-  ; ("put_import_metadata", Http_svr.FdIO Import.metadata_handler)
-  ; ("put_import_raw_vdi", Http_svr.FdIO Import_raw_vdi.handler)
-  ; ("get_export", Http_svr.FdIO Export.handler)
-  ; ("get_export_metadata", Http_svr.FdIO Export.metadata_handler)
-  ; ("get_export_raw_vdi", Http_svr.FdIO Export_raw_vdi.handler)
-  ; ("connect_console", Http_svr.FdIO (Console.handler Console.real_proxy))
-  ; ("connect_console_ws", Http_svr.FdIO (Console.handler Console.ws_proxy))
-  ; ("get_root", Http_svr.BufIO (Fileserver.send_file "/" !Xapi_globs.web_dir))
-  ; ("post_cli", Http_svr.BufIO Xapi_cli.handler)
-  ; ("get_host_backup", Http_svr.FdIO Xapi_host_backup.host_backup_handler)
-  ; ("put_host_restore", Http_svr.FdIO Xapi_host_backup.host_restore_handler)
-  ; ( "get_host_logs_download"
-    , Http_svr.FdIO Xapi_logs_download.logs_download_handler
-    )
-  ; ( "put_pool_patch_upload"
-    , Http_svr.FdIO Xapi_pool_patch.pool_patch_upload_handler
-    )
-  ; ("get_vncsnapshot", Http_svr.FdIO Xapi_vncsnapshot.vncsnapshot_handler)
-  ; ( "get_pool_xml_db_sync"
-    , Http_svr.FdIO Pool_db_backup.pull_database_backup_handler
-    )
-  ; ( "put_pool_xml_db_sync"
-    , Http_svr.FdIO Pool_db_backup.push_database_restore_handler
-    )
-  ; ("get_config_sync", Http_svr.FdIO Config_file_sync.config_file_sync_handler)
-  ; ("get_system_status", Http_svr.FdIO System_status.handler)
-  ; (Constants.get_vm_rrd, Http_svr.FdIO Rrdd_proxy.get_vm_rrd_forwarder)
-  ; (Constants.get_host_rrd, Http_svr.FdIO Rrdd_proxy.get_host_rrd_forwarder)
-  ; (Constants.get_sr_rrd, Http_svr.FdIO Rrdd_proxy.get_sr_rrd_forwarder)
-  ; ( Constants.get_rrd_updates
-    , Http_svr.FdIO Rrdd_proxy.get_rrd_updates_forwarder
-    )
-  ; (Constants.put_rrd, Http_svr.FdIO Rrdd_proxy.put_rrd_forwarder)
-  ; ("get_blob", Http_svr.FdIO Xapi_blob.handler)
-  ; ("put_blob", Http_svr.FdIO Xapi_blob.handler)
-  ; ("put_messages", Http_svr.FdIO Xapi_message.handler)
-  ; ("connect_remotecmd", Http_svr.FdIO Xapi_remotecmd.handler)
-  ; ("get_wlb_report", Http_svr.BufIO Wlb_reports.report_handler)
-  ; ("get_wlb_diagnostics", Http_svr.BufIO Wlb_reports.diagnostics_handler)
-  ; ("get_audit_log", Http_svr.BufIO Audit_log.handler)
-  ; ("post_root", Http_svr.BufIO (Api_server.callback false))
-  ; ("post_json", Http_svr.BufIO (Api_server.callback true))
-  ; ("post_jsonrpc", Http_svr.BufIO Api_server.jsoncallback)
-  ; ("post_root_options", Http_svr.BufIO Api_server.options_callback)
-  ; ("post_json_options", Http_svr.BufIO Api_server.options_callback)
-  ; ("post_jsonrpc_options", Http_svr.BufIO Api_server.options_callback)
-  ; ( "get_pool_update_download"
-    , Http_svr.FdIO Xapi_pool_update.pool_update_download_handler
-    )
-  ; ("get_host_updates", Http_svr.FdIO Xapi_host.get_host_updates_handler)
-  ]
+  let handlers =
+    [
+      ("get_services_xenops", Http_svr.FdIO Xapi_services.get_handler)
+    ; ("put_services_xenops", Http_svr.FdIO Xapi_services.put_handler)
+    ; ("post_services_xenops", Http_svr.FdIO Xapi_services.post_handler)
+    ; ("get_services_sm", Http_svr.FdIO Xapi_services.get_handler)
+    ; ("put_services_sm", Http_svr.FdIO Xapi_services.put_handler)
+    ; ("post_services_sm", Http_svr.FdIO Xapi_services.post_handler)
+    ; ("get_services", Http_svr.FdIO Xapi_services.get_handler)
+    ; ("post_services", Http_svr.FdIO Xapi_services.post_handler)
+    ; ("put_services", Http_svr.FdIO Xapi_services.put_handler)
+    ; ("put_import", Http_svr.FdIO Import.handler)
+    ; ("put_import_metadata", Http_svr.FdIO Import.metadata_handler)
+    ; ("put_import_raw_vdi", Http_svr.FdIO Import_raw_vdi.handler)
+    ; ("get_export", Http_svr.FdIO Export.handler)
+    ; ("get_export_metadata", Http_svr.FdIO Export.metadata_handler)
+    ; ("get_export_raw_vdi", Http_svr.FdIO Export_raw_vdi.handler)
+    ; ("connect_console", Http_svr.FdIO (Console.handler Console.real_proxy))
+    ; ("connect_console_ws", Http_svr.FdIO (Console.handler Console.ws_proxy))
+    ; ("post_cli", Http_svr.BufIO Xapi_cli.handler)
+    ; ("get_host_backup", Http_svr.FdIO Xapi_host_backup.host_backup_handler)
+    ; ("put_host_restore", Http_svr.FdIO Xapi_host_backup.host_restore_handler)
+    ; ( "get_host_logs_download"
+      , Http_svr.FdIO Xapi_logs_download.logs_download_handler
+      )
+    ; ( "put_pool_patch_upload"
+      , Http_svr.FdIO Xapi_pool_patch.pool_patch_upload_handler
+      )
+    ; ("get_vncsnapshot", Http_svr.FdIO Xapi_vncsnapshot.vncsnapshot_handler)
+    ; ( "get_pool_xml_db_sync"
+      , Http_svr.FdIO Pool_db_backup.pull_database_backup_handler
+      )
+    ; ( "put_pool_xml_db_sync"
+      , Http_svr.FdIO Pool_db_backup.push_database_restore_handler
+      )
+    ; ( "get_config_sync"
+      , Http_svr.FdIO Config_file_sync.config_file_sync_handler
+      )
+    ; ("get_system_status", Http_svr.FdIO System_status.handler)
+    ; (Constants.get_vm_rrd, Http_svr.FdIO Rrdd_proxy.get_vm_rrd_forwarder)
+    ; (Constants.get_host_rrd, Http_svr.FdIO Rrdd_proxy.get_host_rrd_forwarder)
+    ; (Constants.get_sr_rrd, Http_svr.FdIO Rrdd_proxy.get_sr_rrd_forwarder)
+    ; ( Constants.get_rrd_updates
+      , Http_svr.FdIO Rrdd_proxy.get_rrd_updates_forwarder
+      )
+    ; (Constants.put_rrd, Http_svr.FdIO Rrdd_proxy.put_rrd_forwarder)
+    ; ("get_blob", Http_svr.FdIO Xapi_blob.handler)
+    ; ("put_blob", Http_svr.FdIO Xapi_blob.handler)
+    ; ("put_messages", Http_svr.FdIO Xapi_message.handler)
+    ; ("connect_remotecmd", Http_svr.FdIO Xapi_remotecmd.handler)
+    ; ("get_wlb_report", Http_svr.BufIO Wlb_reports.report_handler)
+    ; ("get_wlb_diagnostics", Http_svr.BufIO Wlb_reports.diagnostics_handler)
+    ; ("get_audit_log", Http_svr.BufIO Audit_log.handler)
+    ; ("post_root", Http_svr.BufIO (Api_server.callback false))
+    ; ("post_json", Http_svr.BufIO (Api_server.callback true))
+    ; ("post_jsonrpc", Http_svr.BufIO Api_server.jsoncallback)
+    ; ("post_root_options", Http_svr.BufIO Api_server.options_callback)
+    ; ("post_json_options", Http_svr.BufIO Api_server.options_callback)
+    ; ("post_jsonrpc_options", Http_svr.BufIO Api_server.options_callback)
+    ; ( "get_pool_update_download"
+      , Http_svr.FdIO Xapi_pool_update.pool_update_download_handler
+      )
+    ; ("get_host_updates", Http_svr.FdIO Xapi_host.get_host_updates_handler)
+    ]
+  in
+  if !Xapi_globs.disable_webserver then
+    handlers
+  else
+    ("get_root", Http_svr.BufIO (Fileserver.send_file "/" !Xapi_globs.web_dir))
+    :: handlers
 
 let listen_unix_socket sock_path =
   (* Always listen on the Unix domain socket first *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1025,6 +1025,8 @@ let python3_path = ref "/usr/bin/python3"
 let observer_experimental_components =
   ref (StringSet.singleton Constants.observer_component_smapi)
 
+let disable_webserver = ref false
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1543,6 +1545,11 @@ let other_options =
         |> String.concat ","
       )
     , "Comma-separated list of experimental observer components"
+    )
+  ; ( "disable-webserver"
+    , Arg.Set disable_webserver
+    , (fun () -> string_of_bool !disable_webserver)
+    , "Disable the host webserver"
     )
   ]
 


### PR DESCRIPTION
New XAPI conf option: `disable-webserver` (default: false) 
If true, all requests for the fileserver will get a 403 response.