### PR TITLE
[ASAP] CA-392453: Misc fixes to Java SDK

### DIFF
--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/Connection.java
@@ -259,10 +259,8 @@ public class Connection {
     public <T> T dispatch(String methodCall, Object[] methodParameters, TypeReference<T> responseTypeReference) throws XenAPIException, IOException {
         var result = client.sendRequest(methodCall, methodParameters, responseTypeReference);
         if (result.error != null) {
-            throw new XenAPIException(String.valueOf(result.error));
-        }
-
-        if (methodCall.equals("session.login_with_password")) {
+            Types.checkError(result.error);
+        } else if (methodCall.equals("session.login_with_password")) {
             var session = ((Session) result.result);
             sessionReference = session.ref;
             setAPIVersion();


### PR DESCRIPTION
After the latest changes of the SDK, some of the API isn't matching ⬇️ 

- Use `Types.checkError` instead of throwing a generic `XenAPIException`. This ensures the `Types.XYZ` family of exceptions is being used
- Use `@JsonValue` to ensure base class objects are deserialised as a simple opaque_ref string, as opposed to a mapping of each field. This ensures the API's behaviour is unchanged.
- Parse the results of `task.getResult` calls. The jsonrpc method returns value payloads of the form `"value" : "<value>OpaqueRef:XYZ</value>"` so we need to strip the surrounding XML