### PR TITLE
tracing: observe modes and other tracing improvements.

### DIFF
--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -24,3 +24,8 @@
   zstd)
  (preprocess
   (pps ppx_deriving_rpc)))
+
+(test
+ (name test_tracing)
+ (modules test_tracing)
+ (libraries tracing alcotest uuid))

--- a/ocaml/libs/tracing/test_tracing.ml
+++ b/ocaml/libs/tracing/test_tracing.ml
@@ -45,7 +45,7 @@ let http_endpoint = "http://example.com:9411/api/v2/spans"
 let with_observe_mode_check flag f = f () ; assert_observe_mode flag
 
 let get_provider name_label =
-  Tracing.get_tracer_providers ()
+  Tracing.TracerProvider.get_tracer_providers ()
   |> List.filter (fun provider ->
          String.equal
            (Tracing.TracerProvider.get_name_label provider)
@@ -54,11 +54,14 @@ let get_provider name_label =
   |> List.hd
 
 let create_with (enabled, attributes, endpoints, name_label, uuid) =
-  let () = Tracing.create ~enabled ~attributes ~endpoints ~name_label ~uuid in
+  let () =
+    Tracing.TracerProvider.create ~enabled ~attributes ~endpoints ~name_label
+      ~uuid
+  in
   get_provider name_label
 
 let test_destroy_all_providers uuids =
-  let () = List.iter (fun uuid -> Tracing.destroy ~uuid) uuids in
+  let () = List.iter (fun uuid -> Tracing.TracerProvider.destroy ~uuid) uuids in
   assert_observe_mode false
 
 let test_create_and_destroy () =
@@ -139,7 +142,7 @@ let test_create_and_destroy () =
 
 let test_set_tracer_provider () =
   let test_set_with provider (enabled, attributes, endpoints, uuid) =
-    Tracing.set ~enabled ~attributes ~endpoints ~uuid () ;
+    Tracing.TracerProvider.set ~enabled ~attributes ~endpoints ~uuid () ;
     let updated_provider =
       provider |> Tracing.TracerProvider.get_name_label |> get_provider
     in

--- a/ocaml/libs/tracing/test_tracing.ml
+++ b/ocaml/libs/tracing/test_tracing.ml
@@ -1,0 +1,206 @@
+module D = Debug.Make (struct let name = "test_tracing" end)
+
+let attr_to_string (key, value) = Printf.sprintf "%s:%s" key value
+
+let attr_compare attr1 attr2 =
+  String.compare (attr_to_string attr1) (attr_to_string attr2)
+
+let attr_testable =
+  let pp = Fmt.of_to_string attr_to_string in
+
+  Alcotest.testable pp (fun (k1, v1) (k2, v2) -> k1 = k2 && v1 = v2)
+
+let assert_provider_enabled provider flag =
+  Alcotest.(check bool)
+    "Check state of trace provider" flag
+    (Tracing.TracerProvider.get_enabled provider)
+
+let assert_provider_attrs provider attributes =
+  Alcotest.(check (slist attr_testable attr_compare))
+    "Check attributes of trace provider" attributes
+    (Tracing.TracerProvider.get_attributes provider)
+
+let assert_provider_name_label provider label =
+  Alcotest.(check string)
+    "Check label of trace provider" label
+    (Tracing.TracerProvider.get_name_label provider)
+
+let assert_provider_endpoints provider endpoints =
+  Alcotest.(check (list string))
+    "Check endpoints of trace provider" endpoints
+    (provider
+    |> Tracing.TracerProvider.get_endpoints
+    |> List.map Tracing.endpoint_to_string
+    )
+
+let assert_observe_mode flag =
+  Alcotest.(check bool)
+    "Check observe mode of library" flag (Tracing.get_observe ())
+
+let uuid1, uuid2, uuid3 =
+  Uuidx.(to_string (make ()), to_string (make ()), to_string (make ()))
+
+let http_endpoint = "http://example.com:9411/api/v2/spans"
+
+let with_observe_mode_check flag f = f () ; assert_observe_mode flag
+
+let get_provider name_label =
+  Tracing.get_tracer_providers ()
+  |> List.filter (fun provider ->
+         String.equal
+           (Tracing.TracerProvider.get_name_label provider)
+           name_label
+     )
+  |> List.hd
+
+let create_with (enabled, attributes, endpoints, name_label, uuid) =
+  let () = Tracing.create ~enabled ~attributes ~endpoints ~name_label ~uuid in
+  get_provider name_label
+
+let test_destroy_all_providers uuids =
+  let () = List.iter (fun uuid -> Tracing.destroy ~uuid) uuids in
+  assert_observe_mode false
+
+let test_create_and_destroy () =
+  let test_create_with (enabled, attributes, endpoints, name_label, uuid) =
+    let provider =
+      create_with (enabled, attributes, endpoints, name_label, uuid)
+    in
+    assert_provider_enabled provider enabled ;
+    assert_provider_attrs provider attributes ;
+    assert_provider_endpoints provider endpoints ;
+    assert_provider_name_label provider name_label
+  in
+
+  let uuids = [uuid1; uuid2; uuid3] in
+
+  let provider_confs_enable_observe =
+    [
+      ( true
+      , [("enabled", "true")]
+      , [Tracing.bugtool_name]
+      , "dummy_test_provider_1"
+      , uuid1
+      )
+    ; ( false
+      , []
+      , [Tracing.bugtool_name; http_endpoint]
+      , "dummy_test_provider_2"
+      , uuid2
+      )
+    ; ( false
+      , [("enabled", "false"); ("is_test", "true")]
+      , [http_endpoint]
+      , "dummy_test_provider_3"
+      , uuid3
+      )
+    ]
+  in
+  let provider_confs_disable_observe =
+    [
+      ( false
+      , [("enabled", "false")]
+      , [Tracing.bugtool_name]
+      , "dummy_test_provider_1"
+      , uuid1
+      )
+    ; ( false
+      , []
+      , [Tracing.bugtool_name; http_endpoint]
+      , "dummy_test_provider_2"
+      , uuid2
+      )
+    ; ( false
+      , [("enabled", "false"); ("is_test", "true")]
+      , [http_endpoint]
+      , "dummy_test_provider_3"
+      , uuid3
+      )
+    ]
+  in
+
+  (* We start with no tracer providers, therefore, we expect the observe mode to
+     be disbled. *)
+  assert_observe_mode false ;
+
+  let test_provider_conf conf expected_mode_state =
+    with_observe_mode_check expected_mode_state (fun () ->
+        List.iter test_create_with conf
+    ) ;
+    test_destroy_all_providers uuids ;
+    with_observe_mode_check expected_mode_state (fun () ->
+        List.iter test_create_with (List.rev conf)
+    ) ;
+    test_destroy_all_providers uuids
+  in
+
+  test_provider_conf provider_confs_enable_observe true ;
+  test_provider_conf provider_confs_disable_observe false
+
+let test_set_tracer_provider () =
+  let test_set_with provider (enabled, attributes, endpoints, uuid) =
+    Tracing.set ~enabled ~attributes ~endpoints ~uuid () ;
+    let updated_provider =
+      provider |> Tracing.TracerProvider.get_name_label |> get_provider
+    in
+    assert_provider_enabled updated_provider enabled ;
+    assert_provider_attrs updated_provider attributes ;
+    assert_provider_endpoints updated_provider endpoints
+  in
+
+  let provider1 =
+    create_with
+      (false, [], [Tracing.bugtool_name], "dummy_test_provider_1", uuid1)
+  in
+
+  let provider2 =
+    create_with
+      (false, [], [Tracing.bugtool_name], "dummy_test_provider_2", uuid2)
+  in
+
+  let new_provider1_confs =
+    ( ( true
+      , [("test_set", "true")]
+      , [Tracing.bugtool_name; http_endpoint]
+      , uuid1
+      )
+    , (false, [], [Tracing.bugtool_name; http_endpoint], uuid1)
+    )
+  in
+
+  let new_provider2_confs =
+    ( ( true
+      , [("test_set", "true"); ("dummy_key", "dummy_value")]
+      , [Tracing.bugtool_name; http_endpoint]
+      , uuid2
+      )
+    , (false, [], [Tracing.bugtool_name; http_endpoint], uuid2)
+    )
+  in
+
+  assert_observe_mode false ;
+
+  with_observe_mode_check true (fun () ->
+      test_set_with provider1 (fst new_provider1_confs)
+  ) ;
+
+  with_observe_mode_check true (fun () ->
+      test_set_with provider2 (fst new_provider2_confs)
+  ) ;
+  with_observe_mode_check true (fun () ->
+      test_set_with provider1 (snd new_provider1_confs)
+  ) ;
+
+  with_observe_mode_check false (fun () ->
+      test_set_with provider2 (snd new_provider2_confs)
+  ) ;
+
+  test_destroy_all_providers [uuid1; uuid2]
+
+let test =
+  [
+    ("Create and destroy tracer providers", `Quick, test_create_and_destroy)
+  ; ("Set tracer provider", `Quick, test_set_tracer_provider)
+  ]
+
+let () = Alcotest.run "Tracing library" [("trace providers", test)]

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -477,6 +477,82 @@ module TracerProvider = struct
   let get_endpoints t = t.endpoints
 
   let get_enabled t = t.enabled
+
+  let lock = Mutex.create ()
+
+  let tracer_providers = Hashtbl.create 100
+
+  let create ~enabled ~attributes ~endpoints ~name_label ~uuid =
+    let provider : t =
+      let endpoints = List.map endpoint_of_string endpoints in
+      let attributes = Attributes.of_list attributes in
+      {name_label; attributes; endpoints; enabled}
+    in
+    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+        ( match Hashtbl.find_opt tracer_providers uuid with
+        | None ->
+            Hashtbl.add tracer_providers uuid provider
+        | Some _ ->
+            (* CP-45469: It is ok not to have an exception here since it is unlikely that the
+               user has caused the issue, so no need to propagate back. It is also
+               handy to not change the control flow since calls like cluster_pool_resync
+               might not be aware that a TracerProvider has already been created.*)
+            error "Tracing : TracerProvider %s already exists" name_label
+        ) ;
+        if enabled then set_observe true
+    )
+
+  let get_tracer_providers_unlocked () =
+    Hashtbl.fold (fun _ provider acc -> provider :: acc) tracer_providers []
+
+  let get_tracer_providers () =
+    Xapi_stdext_threads.Threadext.Mutex.execute lock
+      get_tracer_providers_unlocked
+
+  let set ?enabled ?attributes ?endpoints ~uuid () =
+    let update_provider (provider : t) enabled attributes endpoints =
+      let enabled = Option.value ~default:provider.enabled enabled in
+      let attributes : string Attributes.t =
+        Option.fold ~none:provider.attributes ~some:Attributes.of_list
+          attributes
+      in
+      let endpoints =
+        Option.fold ~none:provider.endpoints
+          ~some:(List.map endpoint_of_string)
+          endpoints
+      in
+      {provider with enabled; attributes; endpoints}
+    in
+
+    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+        let provider =
+          match Hashtbl.find_opt tracer_providers uuid with
+          | Some (provider : t) ->
+              update_provider provider enabled attributes endpoints
+          | None ->
+              failwith
+                (Printf.sprintf "The TracerProvider : %s does not exist" uuid)
+        in
+        Hashtbl.replace tracer_providers uuid provider ;
+        if
+          List.for_all
+            (fun provider -> not provider.enabled)
+            (get_tracer_providers_unlocked ())
+        then (
+          set_observe false ;
+          Xapi_stdext_threads.Threadext.Mutex.execute Spans.lock (fun () ->
+              Hashtbl.clear Spans.spans ;
+              Hashtbl.clear Spans.finished_spans
+          )
+        ) else
+          set_observe true
+    )
+
+  let destroy ~uuid =
+    Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
+        let _ = Hashtbl.remove tracer_providers uuid in
+        if Hashtbl.length tracer_providers = 0 then set_observe false else ()
+    )
 end
 
 module Tracer = struct
@@ -494,6 +570,19 @@ module Tracer = struct
       }
     in
     {name= ""; provider}
+
+  let get_tracer ~name =
+    let providers =
+      Xapi_stdext_threads.Threadext.Mutex.execute TracerProvider.lock
+        TracerProvider.get_tracer_providers_unlocked
+    in
+
+    match List.find_opt TracerProvider.get_enabled providers with
+    | Some provider ->
+        create ~name ~provider
+    | None ->
+        warn "No provider found for tracing %s" name ;
+        no_op
 
   let span_of_span_context context name : Span.t =
     {
@@ -642,7 +731,7 @@ let enable_span_garbage_collector ?(timeout = 86400.) () =
 
 let with_tracing ?(attributes = []) ?(parent = None) ~name f =
   if Atomic.get observe then (
-    let tracer = get_tracer ~name in
+    let tracer = Tracer.get_tracer ~name in
     match Tracer.start ~tracer ~attributes ~name ~parent () with
     | Ok span -> (
       try

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -174,7 +174,7 @@ val with_tracing :
   -> (Span.t option -> 'a)
   -> 'a
 
-val set_observe : bool -> unit
+val get_observe : unit -> bool
 
 val validate_attribute : string * string -> bool
 

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -110,6 +110,8 @@ end
 module Tracer : sig
   type t
 
+  val get_tracer : name:string -> t
+
   val span_of_span_context : SpanContext.t -> string -> Span.t
 
   val start :
@@ -131,39 +133,60 @@ module Tracer : sig
   val finished_span_hashtbl_is_empty : unit -> bool
 end
 
+(** [TracerProvider] module provides ways to intereact with the tracer providers. 
+    *)
 module TracerProvider : sig
+  (** Type that represents a tracer provider.*)
   type t
 
+  val create :
+       enabled:bool
+    -> attributes:(string * string) list
+    -> endpoints:string list
+    -> name_label:string
+    -> uuid:string
+    -> unit
+  (** [create ~enabled ~attributes ~endpoints ~name_label ~uuid] initializes a 
+      tracer provider based on the following parameters: [enabled], [attributes],
+      [endpoints], [name_label], and [uuid]. *)
+
+  val set :
+       ?enabled:bool
+    -> ?attributes:(string * string) list
+    -> ?endpoints:string list
+    -> uuid:string
+    -> unit
+    -> unit
+  (** [set ?enabled ?attributes ?endpoints ~uuid ()] updates the tracer provider
+      identified by the given [uuid] with the new configuration paremeters: 
+      [enabled], [attributes], and [endpoints]. 
+        
+      If any of the configuration parameters are
+      missing, the old ones are kept.
+        
+      Raises [Failure] if there are no tracer provider with the given [uuid].
+      *)
+
+  val destroy : uuid:string -> unit
+  (** [destroy ~uuid] destroys the tracer provider with the given [uuid]. 
+      If there are no tracer provider with the given [uuid], it does nothing.
+      *)
+
+  val get_tracer_providers : unit -> t list
+  (** [get_tracer_providers] returns a list of all existing tracer providers. *)
+
   val get_name_label : t -> string
+  (** [get_name_label provider] returns the name label of the [provider]. *)
 
   val get_attributes : t -> (string * string) list
+  (** [get_attributes provider] returns the list of attributes of the [provider]. *)
 
   val get_endpoints : t -> endpoint list
+  (** [get_endpoints provider] returns list of endpoints of the [provider]. *)
 
   val get_enabled : t -> bool
+  (** [get_name_label provider] returns whether or not the [provider] is enabled. *)
 end
-
-val set :
-     ?enabled:bool
-  -> ?attributes:(string * string) list
-  -> ?endpoints:string list
-  -> uuid:string
-  -> unit
-  -> unit
-
-val create :
-     enabled:bool
-  -> attributes:(string * string) list
-  -> endpoints:string list
-  -> name_label:string
-  -> uuid:string
-  -> unit
-
-val destroy : uuid:string -> unit
-
-val get_tracer_providers : unit -> TracerProvider.t list
-
-val get_tracer : name:string -> Tracer.t
 
 val enable_span_garbage_collector : ?timeout:float -> unit -> unit
 

--- a/ocaml/libs/tracing/tracing_export.ml
+++ b/ocaml/libs/tracing/tracing_export.ml
@@ -280,7 +280,7 @@ module Destination = struct
     let@ parent =
       with_tracing ~parent:None ~attributes ~name:"Tracing.flush_spans"
     in
-    get_tracer_providers ()
+    TracerProvider.get_tracer_providers ()
     |> List.filter TracerProvider.get_enabled
     |> List.concat_map TracerProvider.get_endpoints
     |> List.iter (export_to_endpoint parent span_list)

--- a/ocaml/tests/test_observer.ml
+++ b/ocaml/tests/test_observer.ml
@@ -62,13 +62,13 @@ end
 
 module TracerProvider = struct
   let assert_num_observers ~__context x =
-    let providers = get_tracer_providers () in
+    let providers = TracerProvider.get_tracer_providers () in
     Alcotest.(check int)
       (Printf.sprintf "%d provider(s) exists in lib " x)
       x (List.length providers)
 
   let find_provider_exn ~name =
-    let providers = get_tracer_providers () in
+    let providers = TracerProvider.get_tracer_providers () in
     match
       List.find_opt (fun x -> TracerProvider.get_name_label x = name) providers
     with
@@ -135,12 +135,12 @@ let test_create ~__context ?(name_label = "test-observer") ?(enabled = false) ()
   self
 
 let start_test_span () =
-  let tracer = get_tracer ~name:"test-observer" in
+  let tracer = Tracer.get_tracer ~name:"test-observer" in
   let span = Tracer.start ~tracer ~name:"test_task" ~parent:None () in
   span
 
 let start_test_trace () =
-  let tracer = get_tracer ~name:"test-observer" in
+  let tracer = Tracer.get_tracer ~name:"test-observer" in
   let root =
     Tracer.start ~tracer ~name:"test_task" ~parent:None ()
     |> Result.value ~default:None

--- a/ocaml/xapi/xapi_observer.ml
+++ b/ocaml/xapi/xapi_observer.ml
@@ -62,23 +62,24 @@ end
 module Observer : ObserverInterface = struct
   let create ~__context ~uuid ~name_label ~attributes ~endpoints ~enabled =
     debug "Observer.create %s" uuid ;
-    Tracing.create ~uuid ~name_label ~attributes ~endpoints ~enabled
+    Tracing.TracerProvider.create ~uuid ~name_label ~attributes ~endpoints
+      ~enabled
 
   let destroy ~__context ~uuid =
     debug "Observer.destroy %s" uuid ;
-    Tracing.destroy ~uuid
+    Tracing.TracerProvider.destroy ~uuid
 
   let set_enabled ~__context ~uuid ~enabled =
     debug "Observer.set_enabled %s" uuid ;
-    Tracing.set ~uuid ~enabled ()
+    Tracing.TracerProvider.set ~uuid ~enabled ()
 
   let set_attributes ~__context ~uuid ~attributes =
     debug "Observer.set_attributes %s" uuid ;
-    Tracing.set ~uuid ~attributes ()
+    Tracing.TracerProvider.set ~uuid ~attributes ()
 
   let set_endpoints ~__context ~uuid ~endpoints =
     debug "Observer.set_endpoints %s" uuid ;
-    Tracing.set ~uuid ~endpoints ()
+    Tracing.TracerProvider.set ~uuid ~endpoints ()
 
   let init ~__context =
     debug "Observer.init" ;

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -1822,7 +1822,7 @@ let rec atomics_of_operation = function
 let with_tracing ~name ~task f =
   let open Tracing in
   let parent = Xenops_task.tracing task in
-  let tracer = get_tracer ~name in
+  let tracer = Tracer.get_tracer ~name in
   match Tracer.start ~tracer ~name ~parent () with
   | Ok span -> (
       Xenops_task.set_tracing task span ;
@@ -4021,30 +4021,33 @@ module Observer = struct
     debug "Observer.create : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
       (fun () ->
-        Tracing.create ~uuid ~name_label ~attributes ~endpoints ~enabled
+        Tracing.TracerProvider.create ~uuid ~name_label ~attributes ~endpoints
+          ~enabled
       )
       ()
 
   let destroy _ dbg uuid =
     debug "Observer.destroy : dbg=%s" dbg ;
-    Debug.with_thread_associated dbg (fun () -> Tracing.destroy ~uuid) ()
+    Debug.with_thread_associated dbg
+      (fun () -> Tracing.TracerProvider.destroy ~uuid)
+      ()
 
   let set_enabled _ dbg uuid enabled =
     debug "Observer.set_enabled : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
-      (fun () -> Tracing.set ~uuid ~enabled ())
+      (fun () -> Tracing.TracerProvider.set ~uuid ~enabled ())
       ()
 
   let set_attributes _ dbg uuid attributes =
     debug "Observer.set_attributes : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
-      (fun () -> Tracing.set ~uuid ~attributes ())
+      (fun () -> Tracing.TracerProvider.set ~uuid ~attributes ())
       ()
 
   let set_endpoints _ dbg uuid endpoints =
     debug "Observer.set_endpoint : dbg=%s" dbg ;
     Debug.with_thread_associated dbg
-      (fun () -> Tracing.set ~uuid ~endpoints ())
+      (fun () -> Tracing.TracerProvider.set ~uuid ~endpoints ())
       ()
 
   let init _ dbg =


### PR DESCRIPTION
As a follow-up to commenting out the warning when no tracer providers were enabled here https://github.com/xapi-project/xen-api/pull/5583. This is meant to solve the issue of spamming the logs by properly setting the `observe` mode inside the library. 

This is based on top of https://github.com/xapi-project/xen-api/pull/5601 that addresses missing lock in the library.

Some other improvements:
- removes some code duplication;
- adds unit tests for the library;
- moves functions under a more appropriate module level;
- adds documentation on `TracerProvider` module.