### PR TITLE
CA-389319: Wait and retry for GET_UPDATES_IN_PROGRESS

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1913,11 +1913,6 @@ let _ =
     ~doc:"Failed to get available updates from a host." () ;
   error Api_errors.get_updates_failed []
     ~doc:"Failed to get available updates from the pool." () ;
-  error Api_errors.get_updates_in_progress []
-    ~doc:
-      "The operation could not be performed because getting updates is in \
-       progress."
-    () ;
   error Api_errors.apply_updates_in_progress []
     ~doc:
       "The operation could not be performed because applying updates is in \

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1261,8 +1261,6 @@ let invalid_repomd_xml = "INVALID_REPOMD_XML"
 
 let get_updates_failed = "GET_UPDATES_FAILED"
 
-let get_updates_in_progress = "GET_UPDATES_IN_PROGRESS"
-
 let apply_updates_in_progress = "APPLY_UPDATES_IN_PROGRESS"
 
 let apply_updates_failed = "APPLY_UPDATES_FAILED"

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -36,7 +36,6 @@ let blocking_ops =
   ; (`tls_verification_enable, Api_errors.tls_verification_enable_in_progress)
   ; (`configure_repositories, Api_errors.configure_repositories_in_progress)
   ; (`sync_updates, Api_errors.sync_updates_in_progress)
-  ; (`get_updates, Api_errors.get_updates_in_progress)
   ; (`apply_updates, Api_errors.apply_updates_in_progress)
   ]
 
@@ -52,6 +51,7 @@ let wait_ops =
   ; `exchange_ca_certificates_on_join
   ; `copy_primary_host_certs
   ; `eject
+  ; `get_updates
   ]
 
 let all_operations = blocking_ops |> List.map fst |> List.append wait_ops


### PR DESCRIPTION
The query on HTTP endpoint /updates will return the available updates in JSON format. Prior to the changes in this commit, if a query arrives when another query is being handled, a "GET_UPDATES_IN_PROGRESS" error will be returned immediately. This behaviour is not friendly to GUI client XenCenter.

In this commit, the behaviour is changed to wait and retry in handling the query in xapi since the "*_IN_PROGGRESS" error is a transient failure. Tolerating it in xapi (server) side avoids error handling in client side.