### PR TITLE
CP-48969: Reduce amount of logspam created by iostat

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -110,11 +110,11 @@ let prototyped_of_message = function
   | "Repository", "set_gpgkey_path" ->
       Some "22.12.0"
   | "PCI", "get_dom0_access_status" ->
-      Some "24.13.0-next"
+      Some "24.14.0"
   | "PCI", "enable_dom0_access" ->
-      Some "24.13.0-next"
+      Some "24.14.0"
   | "PCI", "disable_dom0_access" ->
-      Some "24.13.0-next"
+      Some "24.14.0"
   | "message", "destroy_many" ->
       Some "22.19.0"
   | "VTPM", "set_contents" ->

--- a/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-iostat/rrdp_iostat.ml
@@ -124,7 +124,7 @@ let update_vdi_to_vm_map () =
                       xs.Xs.read (Printf.sprintf "%s/sm-data/vdi-uuid" vbd)
                     in
                     let device = xs.Xs.read (Printf.sprintf "%s/dev" vbd) in
-                    D.info "Found VDI %s at device %s in VM %s, device id %d"
+                    D.debug "Found VDI %s at device %s in VM %s, device id %d"
                       vdi device vm devid ;
                     Some (vdi, (vm, device, devid))
                   with Xs_protocol.Enoent _ ->
@@ -456,7 +456,7 @@ let exec_tap_ctl_list () : ((string * string) * int) list =
    | None ->
        ()
    | Some reason ->
-       D.info "Updating VDI-to-VM map because %s" reason ;
+       D.debug "Updating VDI-to-VM map because %s" reason ;
        update_vdi_to_vm_map ()
   ) ;
   previous_map := pid_and_minor_to_sr_and_vdi ;

--- a/xapi-idl.opam
+++ b/xapi-idl.opam
@@ -17,7 +17,9 @@ depends: [
   "astring"
   "cmdliner"
   "cohttp"
+  "cohttp-posix"
   "fd-send-recv"
+  "ipaddr"
   "logs"
   "lwt" {>= "5.0.0"}
   "message-switch-async" {with-test}

--- a/xapi-idl.opam.template
+++ b/xapi-idl.opam.template
@@ -15,7 +15,9 @@ depends: [
   "astring"
   "cmdliner"
   "cohttp"
+  "cohttp-posix"
   "fd-send-recv"
+  "ipaddr"
   "logs"
   "lwt" {>= "5.0.0"}
   "message-switch-async" {with-test}

--- a/xapi-xenopsd.opam
+++ b/xapi-xenopsd.opam
@@ -40,6 +40,7 @@ depends: [
   "xapi-stdext-threads"
   "xapi-stdext-unix"
   "xapi-tracing"
+  "xapi-tracing-export"
   "xenstore_transport" {with-test}
   "xmlm"
   "zstd"

--- a/xapi-xenopsd.opam.template
+++ b/xapi-xenopsd.opam.template
@@ -38,6 +38,7 @@ depends: [
   "xapi-stdext-threads"
   "xapi-stdext-unix"
   "xapi-tracing"
+  "xapi-tracing-export"
   "xenstore_transport" {with-test}
   "xmlm"
   "zstd"


### PR DESCRIPTION
Do not output loglines that are part of the normal operation. Use debug for them, they are not usually logged, but can be enabled if need be by changing the loglevel