### PR TITLE
CP-44477 Add Typescript bindings for XenAPI

### DIFF
--- a/scripts/examples/typescript/.gitignore
+++ b/scripts/examples/typescript/.gitignore
@@ -1,0 +1,4 @@
+**/.env
+**/node_modules
+package-lock.json
+dist/

--- a/scripts/examples/typescript/Makefile
+++ b/scripts/examples/typescript/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build clean
+
+build:
+	sed -i '/version/s/1.0.0/'"$(XAPI_VERSION)"'/' package.json
+	npm install
+	npm run build
+
+publish:
+	npm publish
+
+clean:
+	rm -rf dist/ node-modules/ package-local.json

--- a/scripts/examples/typescript/README.md
+++ b/scripts/examples/typescript/README.md
@@ -1,0 +1,41 @@
+# A Typescript bindings for XenAPI
+A Typescript bindings for XenAPI, which is inspired by [Python XenAPI](https://xapi-project.github.io/xen-api/usage.html).
+
+## Usage
+Install lib from npm repository
+```
+$ npm install xen-api-ts
+```
+
+The usage of Typescript XenAPI is almost identical to the Python XenAPI, except it's asynchronous and requires async/await.
+```
+import { xapi_client } from "xen-api-ts";
+
+async function main() {
+  const session = xapi_client(process.env.HOST_URL);
+  try {
+    await session.login_with_password(process.env.USERNAME, process.env.PASSWORD);
+    const hosts = await session.xenapi.host.get_all();
+    console.log(hosts); // Do something with the retrieved hosts
+  } finally {
+    await session.xenapi.session.logout();
+  }
+}
+
+main();
+```
+
+For more example usage, please find in tests folder.
+```
+$ git clone git@github.com:acefei/xen-api-ts.git
+$ npm install
+$ echo "HOST_URL=xxx" >> .env
+$ echo "USERNAME=xxx" >> .env
+$ echo "PASSWORD=xxx" >> .env
+$ npm test tests/getXapiVersion.ts
+```
+
+And please find the all of Classes and its Fields in [XenAPI Reference](https://xapi-project.github.io/xen-api)
+
+## License
+This repository is licensed under the MIT License.

--- a/scripts/examples/typescript/package.json
+++ b/scripts/examples/typescript/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "xen-api-ts",
+  "version": "1.0.0",
+  "description": "A typescript library for Xen API",
+  "main": "dist/XenAPI.js",
+  "types": "dist/XenAPI.d.ts",
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "test": "node -r ts-node/register -r dotenv/config ",
+    "build": "tsc"
+  },
+  "keywords": [
+    "xenserve",
+    "xen-api",
+    "typescript"
+  ],
+  "author": "Su Fei <fei.su@cloud.com>",
+  "license": "GPLv2",
+  "devDependencies": {
+    "@types/node": "^20.8.9",
+    "axios": "^1.6.0",
+    "dotenv": "^16.3.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "json-rpc-2.0": "^1.6.0"
+  }
+}

--- a/scripts/examples/typescript/src/XenAPI.ts
+++ b/scripts/examples/typescript/src/XenAPI.ts
@@ -1,0 +1,52 @@
+import { JSONRPCClient } from "json-rpc-2.0";
+
+class XapiSession {
+    private client: JSONRPCClient;
+    private session_id: string | undefined;
+
+    constructor(hostUrl: string | undefined) {
+        this.client = new JSONRPCClient(async (request) => {
+            const response = await fetch(`${hostUrl}/jsonrpc`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify(request),
+            });
+            if (response.status === 200) {
+                const json = await response.json();
+                return this.client.receive(json);
+            } else if (request.id !== undefined) {
+                return Promise.reject(new Error(response.statusText));
+            }
+        });
+    }
+
+    async login(method: string, args: any[] = []) {
+        this.session_id = await this.client.request(`session.${method}`, [...args])
+        return this.session_id
+    }
+
+    async xapi_request(method: string, args: any[] = []) {
+        return await this.client.request(`${method}`, [this.session_id, ...args])
+    }
+}
+
+function xapi_proxy(obj: XapiSession, path: any[] = []): any {
+    return new Proxy(() => {}, {
+        get (target, property) {
+            return xapi_proxy(obj, path.concat(property))
+        },
+        apply (target, self, args) {
+            if (path.length > 0){
+                if(path[path.length-1].startsWith("login")) {
+                    return obj.login(path[path.length-1], args)
+                } else if (path[0].toLowerCase() == 'xenapi') {
+                    return obj.xapi_request(path.slice(1).join('.'), args)
+                }
+            }
+        }
+    })
+}
+
+export function xapi_client(url: string|undefined) {
+    return xapi_proxy(new XapiSession(url))
+}

--- a/scripts/examples/typescript/tests/fetchUpdates.ts
+++ b/scripts/examples/typescript/tests/fetchUpdates.ts
@@ -1,0 +1,107 @@
+import { xapi_client } from "../src/XenAPI"
+import axios from 'axios'
+
+async function get_pool_ref(session: any) {
+    const pool = await session.xenapi.pool.get_all()
+    return pool[0]
+}
+
+async function set_pool_repos(session: any, pool_ref:string, repo_refs: string[]) {
+    return await session.xenapi.pool.set_repositories(pool_ref, repo_refs)
+}
+
+async function create_repos(session: any) {
+    // Ref http://xapi-project.github.io/xen-api/classes/repository.html
+	const repositories: { [key: string]: any } = {
+		base: {
+			name_label: 'base',
+			name_description: 'base rpm repo',
+			binary_url: 'https://repo.ops.xenserver.com/xs8/base',
+			source_url: 'https://repo-src.ops.xenserver.com/xs8/base',
+			// base repo is not an update repo
+			update: false,
+		},
+		normal: {
+			name_label: 'normal',
+			name_description: 'normal rpm repo',
+			binary_url: 'https://repo.ops.xenserver.com/xs8/normal',
+			source_url: 'https://repo-src.ops.xenserver.com/xs8/normal',
+			update: true,
+		},
+	}
+
+    const res = Object.keys(repositories).sort().map(async repoKey => {
+        const repo = repositories[repoKey]
+        const { name_label, name_description, binary_url, source_url, update  } = repo
+        return await session.xenapi.Repository.introduce(name_label, name_description, binary_url, source_url, update)
+    })
+
+    const resPromises = await Promise.all(res)
+    return resPromises
+}
+
+async function get_repos(session: any) {
+    return await session.xenapi.Repository.get_all()
+}
+
+async function remove_repos(session: any) {
+    const repo_refs = await get_repos(session)
+    const res = repo_refs.map(async (ref:string)=> {
+        return await session.xenapi.Repository.forget(ref)
+    })
+    await Promise.all(res)
+}
+
+async function sync_updates(session: any, pool_ref:string) {
+    return await session.xenapi.pool.sync_updates(pool_ref, false, '', '')
+}
+
+async function list_updates(session: any, session_id:string) {
+    try {
+        const response = await axios.get(`${process.env.HOST_URL}/updates`, {
+            params: { 
+                session_id: session_id
+            },
+            httpsAgent: {
+                rejectUnauthorized: false
+            }
+        })
+        console.log('Response Data:', response.data)
+        return response.data
+    } catch (error) {
+        console.error('Error:', error)
+    }
+}
+
+async function main() {
+    console.log(`Login ${process.env.HOST_URL} with ${process.env.USERNAME}`)
+    const session = xapi_client(process.env.HOST_URL)
+    const sid = await session.login_with_password(process.env.USERNAME, process.env.PASSWORD)
+    console.log(`Login successfully with ${sid}`)
+
+    const pool_ref = await get_pool_ref(session)
+    let repo_refs = await get_repos(session)
+    if (!repo_refs.length) {
+        console.log('\nCreate new rpm repos')
+        repo_refs = await create_repos(session)
+    }
+
+    console.log('\nSet enabled set of repositories',repo_refs) 
+    await set_pool_repos(session, pool_ref, repo_refs)
+
+    console.log('\nSync updates')
+    await sync_updates(session, pool_ref)
+
+    console.log('\nList updates')
+    const updates = await list_updates(session, sid)
+    console.log(updates)
+
+    console.log('\nClean old rpm repos')
+    await set_pool_repos(session, pool_ref, [])
+    await remove_repos(session)
+
+    await session.xenapi.session.logout()
+    console.log(`\nSession Logout.`)
+}
+
+main()

--- a/scripts/examples/typescript/tests/getXapiVersion.ts
+++ b/scripts/examples/typescript/tests/getXapiVersion.ts
@@ -1,0 +1,28 @@
+import { xapi_client } from "../src/XenAPI"
+
+// Ref https://xapi-project.github.io/xen-api/
+async function get_api_version(session: any) {
+    const pool = await session.xenapi.pool.get_all()
+    const host = await session.xenapi.pool.get_master(pool[0])
+    const major = await session.xenapi.host.get_API_version_major(host)
+    const minor = await session.xenapi.host.get_API_version_minor(host)
+    return `${major}.${minor}`
+}
+
+async function main() {
+    console.log(`Login ${process.env.HOST_URL} with ${process.env.USERNAME}`)
+    const session = xapi_client(process.env.HOST_URL)
+    const sid = await session.login_with_password(process.env.USERNAME, process.env.PASSWORD)
+    console.log(`Login successfully with ${sid}`)
+
+    const ver = await get_api_version(session)
+    console.log(`\nCurrent XAPI Version: ${ver}`)
+
+    const hosts = await session.xenapi.host.get_all()
+    console.log(`\nGet Host list:\n${hosts.join("\n")}`)
+
+    await session.xenapi.session.logout()
+    console.log(`\nSession Logout.`)
+}
+
+main()

--- a/scripts/examples/typescript/tsconfig.json
+++ b/scripts/examples/typescript/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  /* select which files the compiler processes. */
+  "include": [
+      "src/**/*"
+  ],
+  "exclude": [
+      "node_modules"
+  ]
+}


### PR DESCRIPTION
In this PR, I implemented the Typescript bindings for XenAPI whose usage is almost identical to the [Python XenAPI](https://xapi-project.github.io/xen-api/usage.html), except it's asynchronous and requires async/await.

This PR is opened for following the action in https://issues.citrite.net/browse/CP-45039

CC @Zhengchai @qinzhang22