### PR TITLE
xenopsd/scripts: Make pygrub wrapper use the libexec path

### DIFF
--- a/ocaml/xenopsd/scripts/pygrub-wrapper
+++ b/ocaml/xenopsd/scripts/pygrub-wrapper
@@ -15,7 +15,7 @@
 
 import pwd, subprocess, sys
 
-cmd = ["pygrub"]
+cmd = ["/usr/libexec/xen/bin/pygrub"]
 
 # Get the usage string. We can't use check_output() because the exit status isn't 0
 pygrub_usage = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()[1]


### PR DESCRIPTION
From Xen 4.19 onwards the legacy paths disappeared and the only valid path for pygrub is /usr/libexec/xen/bin/pygrub. This path has always been preferred, but now it's mandatory.