### PR TITLE
CP-48011: XAPI Support anti-affinity feature check

### DIFF
--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -64,7 +64,7 @@ type feature =
   | Updates
   | Internal_repo_access
   | VTPM
-  | VM_anti_affinity
+  | VM_group
 [@@deriving rpc]
 
 type orientation = Positive | Negative
@@ -133,9 +133,7 @@ let keys_of_features =
     , ("restrict_internal_repo_access", Negative, "Internal_repo_access")
     )
   ; (VTPM, ("restrict_vtpm", Negative, "VTPM"))
-  ; ( VM_anti_affinity
-    , ("restrict_vm_anti_affinity", Negative, "VM_anti_affinity")
-    )
+  ; (VM_group, ("restrict_vm_group", Negative, "VM_group"))
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi-types/features.mli
+++ b/ocaml/xapi-types/features.mli
@@ -72,7 +72,7 @@ type feature =
   | Internal_repo_access
       (** Enable restriction on repository access to pool members only *)
   | VTPM  (** Support VTPM device required by Win11 guests *)
-  | VM_anti_affinity  (** Enable use of VM anti-affinity placement *)
+  | VM_group  (** Enable use of VM group *)
 
 val feature_of_rpc : Rpc.t -> feature
 (** Convert RPC into {!feature}s *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1442,6 +1442,7 @@ let set_appliance ~__context ~self ~value =
   update_allowed_operations ~__context ~self
 
 let set_groups ~__context ~self ~value =
+  Pool_features.assert_enabled ~__context ~f:Features.VM_group ;
   if List.length value > 1 then
     raise Api_errors.(Server_error (Api_errors.too_many_groups, [])) ;
   Db.VM.set_groups ~__context ~self ~value

--- a/ocaml/xapi/xapi_vm_group.ml
+++ b/ocaml/xapi/xapi_vm_group.ml
@@ -15,6 +15,7 @@
 module D = Debug.Make (struct let name = "xapi_vm_group" end)
 
 let create ~__context ~name_label ~name_description ~placement =
+  Pool_features.assert_enabled ~__context ~f:Features.VM_group ;
   let uuid = Uuidx.make () in
   let ref = Ref.make () in
   Db.VM_group.create ~__context ~ref ~uuid:(Uuidx.to_string uuid) ~name_label

--- a/ocaml/xapi/xapi_vm_group_helpers.mli
+++ b/ocaml/xapi/xapi_vm_group_helpers.mli
@@ -29,7 +29,7 @@ val maybe_update_alerts_on_feature_change :
   -> old_restrictions:(string * string) list
   -> new_restrictions:(string * string) list
   -> unit
-(** Updates the VM anti-affinity alert only when Features.VM_anti_affinity changes.
+(** Updates the VM anti-affinity alert only when Features.VM_group changes.
 
     @param __context The context information.
     @param old_restrictions The old feature restrictions represented as an association list.
@@ -39,6 +39,6 @@ val maybe_update_alerts_on_feature_change :
     Example:
       [
         ("restrict_vlan", "true");
-        ("restrict_vm_anti_affinity", "false")
+        ("restrict_vm_group", "false")
       ]
 *)


### PR DESCRIPTION
Check feature flag in these places:
1. VM start.
2. Host evacuation. When this PR is raised, the host evacuation PR is
   still in review. So this PR doesn't include the checking for host
   evacuation. **It will be included in another new PR.**
3. Create VM group.
4. VM.set_groups. Adding VMs to a group and removing VMs from a group
   are all forbidden. If customers need to remove VMs from a group,
   just destroy the group.
5. Send VM anti-affinity alerts.
Also, based on our discussion, the name of feature is changed from
`VM_anti_affinity` to `VM_group`.
