### PR TITLE
CA-392836,CA-392847: Lost the power state on suspended VM import

### DIFF
--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -629,8 +629,6 @@ module VM : HandlerTools = struct
               ~domain_type:vm_record.API.vM_domain_type
               ~is_a_template:vm_record.API.vM_is_a_template
               vm_record.API.vM_platform
-        ; API.vM_suspend_VDI= Ref.null
-        ; API.vM_power_state= `Halted
         }
       in
       let vm =
@@ -642,7 +640,11 @@ module VM : HandlerTools = struct
               Db.VM.set_uuid ~__context ~self:vm ~value:value.API.vM_uuid ;
             vm
           )
-          vm_record
+          {
+            vm_record with
+            API.vM_suspend_VDI= Ref.null
+          ; API.vM_power_state= `Halted
+          }
       in
       state.cleanup <-
         (fun __context rpc session_id ->


### PR DESCRIPTION
The VM power state should be preserved on a suspended VM import.

In commit ebb58a8, the power state and suspend VDI in `vm_record` were
reset on importing a suspended VM. This meant to facilitate the
following `Client.VM.create_from_record`. But this gets the restore of
power state and suspend VDI broken as it requires the data in
`vm_record`.

This commit preserves the data in `vm_record` and reset it just before
it being passed to `Client.VM.create_from_record`.