### PR TITLE
CP-48570: Load recommendations from config file when Xapi starts

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1490,6 +1490,11 @@ let t =
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
             ~default_value:(Some (VBool false)) "update_sync_enabled"
             "Whether periodic update synchronization is enabled or not"
+        ; field ~qualifier:DynamicRO ~lifecycle:[]
+            ~ty:(Map (String, String))
+            ~default_value:(Some (VMap [])) "recommendations"
+            "The recommended pool properties for clients to respect for \
+             optimal performance. e.g. max-vm-group=5"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "81ba6b9699b3f6c2969dd5510cbbe4aa"
+let last_known_schema_hash = "024b6ce32246d7549898310675631d51"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -298,7 +298,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(telemetry_uuid = Ref.null) ?(telemetry_frequency = `weekly)
     ?(telemetry_next_collection = API.Date.never)
     ?(last_update_sync = API.Date.epoch) ?(update_sync_frequency = `daily)
-    ?(update_sync_day = 0L) ?(update_sync_enabled = false) () =
+    ?(update_sync_day = 0L) ?(update_sync_enabled = false)
+    ?(recommendations = []) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -316,7 +317,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~migration_compression ~coordinator_bias ~telemetry_uuid
     ~telemetry_frequency ~telemetry_next_collection ~last_update_sync
     ~local_auth_max_threads:8L ~ext_auth_max_threads:8L ~update_sync_frequency
-    ~update_sync_day ~update_sync_enabled ;
+    ~update_sync_day ~update_sync_enabled ~recommendations ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1493,6 +1493,12 @@ let pool_record rpc session_id pool =
       ; make_field ~name:"update-sync-enabled"
           ~get:(fun () -> (x ()).API.pool_update_sync_enabled |> string_of_bool)
           ()
+      ; make_field ~name:"recommendations"
+          ~get:(fun () ->
+            Record_util.s2sm_to_string "; " (x ()).API.pool_recommendations
+          )
+          ~get_map:(fun () -> (x ()).API.pool_recommendations)
+          ()
       ]
   }
 

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -53,7 +53,7 @@ let create_pool_record ~__context =
       ~last_update_sync:Xapi_stdext_date.Date.epoch
       ~update_sync_frequency:`weekly ~update_sync_day:0L
       ~update_sync_enabled:false ~local_auth_max_threads:8L
-      ~ext_auth_max_threads:1L
+      ~ext_auth_max_threads:1L ~recommendations:[]
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/recommendations.ml
+++ b/ocaml/xapi/recommendations.ml
@@ -1,0 +1,50 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module Unixext = Xapi_stdext_unix.Unixext
+module Config_file = Xcp_service.Config_file
+
+module D = Debug.Make (struct let name = "recommendations" end)
+
+open D
+module StringMap = Map.Make (String)
+
+let process_line map data =
+  match Config_file.parse_line data with
+  | Some (k, v) ->
+      debug "Parsing data, key: %s, value: %s" k v ;
+      StringMap.add k v map
+  | None ->
+      map
+
+let parse map filename =
+  debug "Parsing recommendations file: %s" filename ;
+  Unixext.file_lines_fold process_line map filename
+
+let load ~path =
+  (try Sys.readdir path with _ -> [||])
+  |> Array.to_list
+  |> List.filter (fun f -> Filename.check_suffix f ".conf")
+  |> List.stable_sort compare
+  |> List.map (Filename.concat path)
+  |> List.filter (fun f ->
+         match Unix.((stat f).st_kind) with
+         | Unix.S_REG ->
+             true
+         | _ ->
+             false
+         | exception _ ->
+             false
+     )
+  |> List.fold_left parse StringMap.empty

--- a/ocaml/xapi/recommendations.mli
+++ b/ocaml/xapi/recommendations.mli
@@ -1,0 +1,17 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module StringMap : Map.S with type key = string
+
+val load : path:string -> string StringMap.t

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1023,6 +1023,8 @@ let python3_path = ref "/usr/bin/python3"
 let observer_experimental_components =
   ref (StringSet.singleton Constants.observer_component_smapi)
 
+let pool_recommendations_dir = ref "/etc/xapi.pool-recommendations.d"
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1802,6 +1804,10 @@ module Resources = struct
     ; ( "trace-log-dir"
       , trace_log_dir
       , "Directory for storing traces exported to logs"
+      )
+    ; ( "pool-recommendations-dir"
+      , pool_recommendations_dir
+      , "Directory containing files with recommendations in key=value format"
       )
     ]
 


### PR DESCRIPTION
1. Add a field 'recommendations' in pool.
2. The recommendations are read from files `/etc/xapi.pool-recommendations.d/*` and exposed to clients. They are read-only and only for clients, hence they don't impact the behavior of Xapi directly but only indirectly as they inform a client's behavior.
3. When Xapi starts, it will read each file and update the recommendations into the database. 
4. If we need to add recommendations to other type objects e.g. host, VM, etc in the future, just add a similar `xapi.*-recommendations.d` directory and define the path in xapi_globs.