### PR TITLE
CP-48995: Instrument `XenAPI.py` to submit a `traceparent`

### DIFF
--- a/python3/packages/observer.py
+++ b/python3/packages/observer.py
@@ -371,6 +371,11 @@ try:
     # If there are no configs, or an exception is raised, span and patch_module
     # are not overridden and will be the defined no-op functions.
     span, patch_module = _init_tracing(observer_configs, observer_config_dir)
+
+    # If tracing is now operational, explicity set "OTEL_SDK_DISABLED" to "false".
+    # In our case, different from the standard, we want the tracing disabled by
+    # default, so if the env variable is not set the noop implementation is used.
+    os.environ["OTEL_SDK_DISABLED"] = "false"
 except Exception as exc:
     syslog.error("Exception while setting up tracing, running script untraced: %s", exc)
     span, patch_module = _span_noop, _patch_module_noop

--- a/scripts/examples/python/XenAPI/XenAPI.py
+++ b/scripts/examples/python/XenAPI/XenAPI.py
@@ -55,6 +55,7 @@
 # --------------------------------------------------------------------
 
 import gettext
+import os
 import socket
 import sys
 
@@ -65,6 +66,15 @@ else:
     import http.client as httplib
     import xmlrpc.client as xmlrpclib
 
+otel = False
+try:
+    if os.environ["OTEL_SDK_DISABLED"] == "false":
+        from opentelemetry import propagate
+        from opentelemetry.trace.propagation import set_span_in_context, get_current_span
+        otel = True
+
+except Exception:
+    pass
 
 translation = gettext.translation('xen-xm', fallback = True)
 
@@ -101,7 +111,19 @@ class UDSHTTPConnection(httplib.HTTPConnection):
 class UDSTransport(xmlrpclib.Transport):
     def add_extra_header(self, key, value):
         self._extra_headers += [ (key,value) ]
+    def with_tracecontext(self):
+        if otel:
+            headers = {}
+            # pylint: disable=possibly-used-before-assignment
+            ctx = set_span_in_context(get_current_span())
+            # pylint: disable=possibly-used-before-assignment
+            propagators = propagate.get_global_textmap()
+            propagators.inject(headers, ctx)
+            self._extra_headers = []
+            for k, v in headers.items():
+                self.add_extra_header(k, v)
     def make_connection(self, host):
+        self.with_tracecontext()
         return UDSHTTPConnection(host)
 
 def notimplemented(name, *args, **kwargs):


### PR DESCRIPTION
Instrument `XenAPI.py` to submit the current traceparent back into xapi if it can import `opentelemetry`.

Currently, we don't see the traces of `sm` calling back to `xapi` using `XenAPI.py`. This will instrument `XenAPI.py` to pass a traceparent into `xapi` when opentelemetry is available.