### PR TITLE
Low risk Unix.select changes

### DIFF
--- a/ocaml/libs/stunnel/stunnel.ml
+++ b/ocaml/libs/stunnel/stunnel.ml
@@ -391,7 +391,7 @@ let rec retry f = function
     try f ()
     with Stunnel_initialisation_failed ->
       (* Leave a few seconds between each attempt *)
-      ignore (Unix.select [] [] [] 3.) ;
+      Thread.delay 3. ;
       retry f (n - 1)
   )
 

--- a/ocaml/squeezed/src/squeeze_xen.ml
+++ b/ocaml/squeezed/src/squeeze_xen.ml
@@ -581,7 +581,7 @@ let make_host ~verbose ~xc =
       1024L
     <> 0L
   do
-    ignore (Unix.select [] [] [] 0.25)
+    Thread.delay 0.25
   done ;
 
   (* Some VMs are considered by us (but not by xen) to have an
@@ -857,7 +857,7 @@ let io ~xc ~verbose =
       (fun domid kib ->
         execute_action ~xc {Squeeze.action_domid= domid; new_target_kib= kib}
       )
-  ; wait= (fun delay -> ignore (Unix.select [] [] [] delay))
+  ; wait= (fun delay -> Thread.delay delay)
   ; execute_action= (fun action -> execute_action ~xc action)
   ; target_host_free_mem_kib
   ; free_memory_tolerance_kib

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -463,14 +463,6 @@ let main_loop ifd ofd permitted_filenames =
   marshal_protocol ofd ;
   let exit_code = ref None in
   while !exit_code = None do
-    (* Wait for input asynchronously so that we can check the status
-       of Stunnel every now and then, for better debug/dignosis.
-    *)
-    while
-      match Unix.select [ifd] [] [] 5.0 with _ :: _, _, _ -> false | _ -> true
-    do
-      ()
-    done ;
     let cmd = try unmarshal ifd with e -> handle_unmarshal_failure e ifd in
     debug "Read: %s\n%!" (string_of_message cmd) ;
     flush stderr ;

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -633,7 +633,7 @@ let main_loop ifd ofd permitted_filenames =
           with
           | Unix.Unix_error (_, _, _)
             when !delay <= long_connection_retry_timeout ->
-              ignore (Unix.select [] [] [] !delay) ;
+              Unix.sleepf !delay ;
               delay := !delay *. 2. ;
               keep_connection ()
           | e ->

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -1047,7 +1047,7 @@ let raw_console_proxy sockaddr =
         (fun () -> Unix.close s)
     with
     | Unix.Unix_error (_, _, _) when !delay <= long_connection_retry_timeout ->
-        ignore (Unix.select [] [] [] !delay) ;
+        Unix.sleepf !delay ;
         delay := !delay *. 2. ;
         keep_connection ()
     | e ->

--- a/ocaml/xenopsd/xc/memory_breakdown.ml
+++ b/ocaml/xenopsd/xc/memory_breakdown.ml
@@ -246,7 +246,7 @@ let print_memory_field_values xc xs =
   flush stdout
 
 (** Sleeps for the given time period in seconds. *)
-let sleep time_period_seconds = ignore (Unix.select [] [] [] time_period_seconds)
+let sleep time_period_seconds = Unix.sleepf time_period_seconds
 
 (** Prints a header line of memory field names, and then periodically prints a
     line of memory field values. *)

--- a/ocaml/xenopsd/xc/memory_summary.ml
+++ b/ocaml/xenopsd/xc/memory_summary.ml
@@ -36,7 +36,7 @@ let _ =
   let finished = ref false in
   while not !finished do
     finished := !delay < 0. ;
-    if !delay > 0. then ignore (Unix.select [] [] [] !delay) ;
+    if !delay > 0. then Unix.sleepf !delay ;
     flush stdout ;
     let physinfo = Xenctrl.physinfo xc in
     let one_page = 4096L in


### PR DESCRIPTION
These do not convert to epoll, but instead:
* converts selects with a delay to Thread.delay / Unix.sleepf (depending on whether the module links `threads.posix` already or not)
* deletes one completely unnecessary select

There are a few more commits like this (e.g. replace one `proxy` function with another, or replace one `Delay` module with another, but I'd rather do more testing on those, even if they are seemingly low risk / correct).

For now `feature/perf` has already accumulated quite a few changes, that we should probably test + merge before putting more `epoll` content in (and then when we add epoll those same tests should still pass). 

Draft PR, waiting on a BVT just in case.