### PR TITLE
CP-49634: Add alerting for Corosync upgrade

### DIFF
--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -311,6 +311,8 @@ let cluster_host_leaving = addMessage "CLUSTER_HOST_LEAVING" 3L
 
 let cluster_host_joining = addMessage "CLUSTER_HOST_JOINING" 4L
 
+let cluster_stack_out_of_date = addMessage "CLUSTER_STACK_OUT_OF_DATE" 3L
+
 (* Certificate expiration messages *)
 let host_server_certificate_expiring = "HOST_SERVER_CERTIFICATE_EXPIRING"
 


### PR DESCRIPTION
Xapi will send alert when the user is running on a Corosync 2 cluster and prompting them to upgrade. This should only happen on XS 9 and is behind the corosync3 feature flag.

XenCenter can take advantage of this alert message, but should have its own warning message to tell the user why/how to perform the upgrade.
