### PR TITLE
CI/coverage: Fix addopts, migrate away from pytest-cov

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,8 @@ repos:
     -   id: pytest
         files: python3/
         name: check that the Python3 test suite in passes
-        entry: env PYTHONDEVMODE=yes sh -c 'python3 -m pytest -vv &&
+        entry: env PYTHONDEVMODE=yes sh -c 'coverage run && coverage xml &&
+            coverage html && coverage report &&
             diff-cover --ignore-whitespace --compare-branch=origin/feature/py3
             --show-uncovered --html-report .git/coverage-diff.html
             --fail-under 50 .git/coverage3.11.xml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ skip_covered = true
 
 [tool.coverage.run]
 # Default command line for "coverage run": Run pytest in non-verbose mode
-command_line = "-m pytest -p no:logging -p no:warnings"
+command_line = "-m pytest -v -ra"
+
 # Default data file for "coverage run": Store coverage data in .git/.coverage
 data_file = ".git/.coverage"
 # Default context for "coverage run": Use the name of the test function
@@ -75,7 +76,7 @@ relative_files = true
 # Default output when writing "coveragle xml" data. This needs to match what
 # diff-cover and coverage upload to Codecov expect
 [tool.coverage.xml]
-output = ".git/coverage.xml"
+output = ".git/coverage3.11.xml"
 
 
 # Default output directory for writing "coverage html" data.
@@ -199,18 +200,22 @@ exclude              = [
 # -----------------------------------------------------------------------------
 # Options to enable for pytest by default:
 # -v                           show what happens
-# -rA                          show summary after running tests
-# --cov=python3                measure coverage of the python3 directory
-# --cov-fail-under             minimum coverage percentage
-# --cov-report=term-missing    show missing lines in the coverage report
-# --cov-report=html:<filename> generate an HTML coverage report(for viewing)
-# --cov-report=xml:<filename>  generate an XML coverage report(for upload)
+# -ra                          show short summary after running tests
+# Other options should not be passed using addopts, as addopts forces those
+# options to be used every time pytest is run, which is very restrictive.
+# Instead, use `coverage run` to configure coverage options, and support
+# running specific tests by passing them as arguments to pytest:
+# For example:
+# coverage run -m pytest python3/tests/test_xenapi.py
+# Adding specific --cov options using addopts is not recommended as it would
+# require to use the pytest-cov plugin, which would conflict with the use of
+# `coverage run`. Instead, use `coverage` to configure coverage options.
+# Specifying directories to test is better done using the testpaths option,
+# as testpaths sets the default directories to search for tests, but does not
+# force them to be run, so you can still run specific tests files by just
+# passing them as arguments to pytest: pytest python3/tests/test_xenapi.py
 # -----------------------------------------------------------------------------
-addopts = """
--v -rA --cov=python3 --cov=scripts --cov-fail-under=50
---cov-report=html:.git/coverage --cov-report=term-missing
---cov-report=xml:.git/coverage3.11.xml
-"""
+addopts = "-v -ra"
 
 # -----------------------------------------------------------------------------
 # Other pytest config options:


### PR DESCRIPTION
To: @stephenchengCloud and @liulinC: for you to review.
Cc: @ashwin9390 pre-review results with Ashwin:
- Ashwin suggested an improvement to make the pytest report less verbose using `-ra` (applied!)

The motivation and purpose for this PR is to allow running `pytest` for a given file. Example:
```py
pytest python3/tests/test_hfx_filename.py
=================================== test session starts ===================================
platform linux -- Python 3.11.9, pytest-8.2.1, pluggy-1.5.0 -- /usr/bin/python3.11
[...]
python3/tests/test_hfx_filename.py::TestRpc::test_db_get_uuid PASSED                [ 20%]
[...]
python3/tests/test_hfx_filename.py::TestParse::test_parse_string PASSED             [100%]

========================================= PASSES ==========================================
================================= short test summary info =================================
PASSED python3/tests/test_hfx_filename.py::TestRpc::test_db_get_uuid
[...]
PASSED python3/tests/test_hfx_filename.py::TestParse::test_parse_string
==================================== 5 passed in 0.04s ====================================
```
The expected result is to run only the tests in the given test case file (as shown above).
The unexpected (current) behaviour is that all tests are run.

Fix this issue by not forcing to run all tests using `addopts`:

pyproject.toml:
- Don't use `[tool.pytest.ini_options].addopts` to pass test paths: `addopts` forces those options to be used every time pytest is run, which is very restrictive. Instead, use `coverage run` to configure coverage options, and support running specific tests by passing them as arguments to pytest: `coverage run -m pytest python3/tests/test_xenapi.py`

.pre-commit-config.yaml:
- No longer rely on `[tool.pytest.ini_options].addopts` to use `pytest-cov`. Instead, use `coverage run` to run pytest with coverage, and then `coverage xml` to get an XML coverage dump of the coverage, as well as `coverage html` to generate html for viewing coverage locally, and `coverage report` to generate a brief textual report of the coverage.

  This improves the configuration to show the coverage report after the test results (and not in the middle of them).