### PR TITLE
CP-49647 use URI to build URIs

### DIFF
--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -264,9 +264,6 @@ module Url : sig
 
   val of_string : string -> t
 
-  val maybe_wrap_IPv6_literal : string -> string
-  (** Wrap a literal IPv6 address in square brackets; otherwise pass through *)
-
   val to_string : t -> string
 
   val get_uri : t -> string

--- a/ocaml/xapi-cli-server/cli_util.ml
+++ b/ocaml/xapi-cli-server/cli_util.ml
@@ -324,7 +324,7 @@ let rec uri_of_someone rpc session_id = function
         uri_of_someone rpc session_id Master
       else
         let address = Client.Host.get_address ~rpc ~session_id ~self:h in
-        "https://" ^ address
+        Uri.(make ~scheme:"https" ~host:address () |> to_string)
 
 let error_of_exn e =
   match e with

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -302,12 +302,15 @@ and create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref
     ~dom0_console_protocol =
   let console_ref = Ref.make () in
   let address =
-    Http.Url.maybe_wrap_IPv6_literal
-      (Db.Host.get_address ~__context ~self:(Helpers.get_localhost ~__context))
+    Db.Host.get_address ~__context ~self:(Helpers.get_localhost ~__context)
   in
   let location =
-    Printf.sprintf "https://%s%s?ref=%s" address Constants.console_uri
-      (Ref.string_of domain_zero_ref)
+    Uri.(
+      make ~scheme:"https" ~host:address ~path:Constants.console_uri
+        ~query:[("ref", [Ref.string_of domain_zero_ref])]
+        ()
+      |> to_string
+    )
   in
   let port =
     match dom0_console_protocol with

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -95,9 +95,12 @@ let refresh_console_urls ~__context =
             | "" ->
                 ""
             | address ->
-                let address = Http.Url.maybe_wrap_IPv6_literal address in
-                Printf.sprintf "https://%s%s?ref=%s" address
-                  Constants.console_uri (Ref.string_of console)
+                Uri.(
+                  make ~scheme:"https" ~host:address ~path:Constants.console_uri
+                    ~query:[("ref", [Ref.string_of console])]
+                    ()
+                  |> to_string
+                )
           in
           Db.Console.set_location ~__context ~self:console ~value:url_should_be
         )

--- a/ocaml/xapi/export.ml
+++ b/ocaml/xapi/export.ml
@@ -883,15 +883,14 @@ let handler (req : Request.t) s _ =
         (* task when it exits, and we don't want to do that *)
         try
           let host = find_host_for_VM ~__context vm_ref in
-          let address =
-            Http.Url.maybe_wrap_IPv6_literal
-              (Db.Host.get_address ~__context ~self:host)
-          in
+          let address = Db.Host.get_address ~__context ~self:host in
           let url =
-            Printf.sprintf "https://%s%s?%s" address req.Request.uri
-              (String.concat "&"
-                 (List.map (fun (a, b) -> a ^ "=" ^ b) req.Request.query)
-              )
+            Uri.(
+              make ~scheme:"https" ~host:address ~path:req.Request.uri
+                ~query:(List.map (fun (a, b) -> (a, [b])) req.Request.query)
+                ()
+              |> to_string
+            )
           in
           info "export VM = %s redirecting to: %s" (Ref.string_of vm_ref) url ;
           let headers = Http.http_302_redirect url in

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -2472,15 +2472,14 @@ let handler (req : Request.t) s _ =
           if not (check_sr_availability ~__context sr) then (
             debug "sr not available - redirecting" ;
             let host = find_host_for_sr ~__context sr in
-            let address =
-              Http.Url.maybe_wrap_IPv6_literal
-                (Db.Host.get_address ~__context ~self:host)
-            in
+            let address = Db.Host.get_address ~__context ~self:host in
             let url =
-              Printf.sprintf "https://%s%s?%s" address req.Request.uri
-                (String.concat "&"
-                   (List.map (fun (a, b) -> a ^ "=" ^ b) req.Request.query)
-                )
+              Uri.(
+                make ~scheme:"https" ~host:address ~path:req.Request.uri
+                  ~query:(List.map (fun (a, b) -> (a, [b])) req.Request.query)
+                  ()
+                |> to_string
+              )
             in
             let headers = Http.http_302_redirect url in
             debug "new location: %s" url ;

--- a/ocaml/xapi/importexport.ml
+++ b/ocaml/xapi/importexport.ml
@@ -501,12 +501,13 @@ module Devicetype = struct
 end
 
 let return_302_redirect (req : Http.Request.t) s address =
-  let address = Http.Url.maybe_wrap_IPv6_literal address in
   let url =
-    Printf.sprintf "https://%s%s?%s" address req.Http.Request.uri
-      (String.concat "&"
-         (List.map (fun (a, b) -> a ^ "=" ^ b) req.Http.Request.query)
-      )
+    Uri.(
+      make ~scheme:"https" ~host:address ~path:req.Http.Request.uri
+        ~query:(List.map (fun (a, b) -> (a, [b])) req.Http.Request.query)
+        ()
+      |> to_string
+    )
   in
   let headers = Http.http_302_redirect url in
   debug "HTTP 302 redirect to: %s" url ;

--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -25,15 +25,12 @@ module D = Debug.Make (struct let name = "rrdd_proxy" end)
 open D
 module Rrdd = Rrd_client.Client
 
-(* Helper methods. Should probably be moved to the Http.Request module. *)
-let get_query_string_from_query ~(query : (string * string) list) : string =
-  String.concat "&" (List.map (fun (k, v) -> k ^ "=" ^ v) query)
-
 let make_url_from_query ~(address : string) ~(uri : string)
     ~(query : (string * string) list) : string =
-  let query_string = get_query_string_from_query ~query in
-  let address = Http.Url.maybe_wrap_IPv6_literal address in
-  Printf.sprintf "https://%s%s?%s" address uri query_string
+  Uri.make ~scheme:"https" ~host:address ~path:uri
+    ~query:(List.map (fun (k, v) -> (k, [v])) query)
+    ()
+  |> Uri.to_string
 
 let make_url ~(address : string) ~(req : Http.Request.t) : string =
   let open Http.Request in

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2574,24 +2574,23 @@ let migrate_receive ~__context ~host ~network ~options:_ =
      able to do HTTPS migrations yet. *)
   let scheme = "http" in
   let sm_url =
-    Printf.sprintf "%s://%s/services/SM?session_id=%s" scheme
-      (Http.Url.maybe_wrap_IPv6_literal ip)
-      new_session_id
+    Uri.make ~scheme ~host:ip ~path:"services/SM"
+      ~query:[("session_id", [new_session_id])]
+      ()
+    |> Uri.to_string
   in
   let xenops_url =
-    Printf.sprintf "%s://%s/services/xenops?session_id=%s" scheme
-      (Http.Url.maybe_wrap_IPv6_literal ip)
-      new_session_id
+    Uri.make ~scheme ~host:ip ~path:"services/xenops"
+      ~query:[("session_id", [new_session_id])]
+      ()
+    |> Uri.to_string
   in
   let master_address =
     try Pool_role.get_master_address ()
     with Pool_role.This_host_is_a_master ->
       Option.get (Helpers.get_management_ip_addr ~__context)
   in
-  let master_url =
-    Printf.sprintf "%s://%s/" scheme
-      (Http.Url.maybe_wrap_IPv6_literal master_address)
-  in
+  let master_url = Uri.make ~scheme ~host:master_address () |> Uri.to_string in
   [
     (Xapi_vm_migrate._sm, sm_url)
   ; (Xapi_vm_migrate._host, Ref.string_of host)

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -787,12 +787,14 @@ let handler (req : Http.Request.t) fd _ =
         (* Redirect if we're not master *)
         if not (Pool_role.is_master ()) then
           let url =
-            Printf.sprintf "https://%s%s?%s"
-              (Http.Url.maybe_wrap_IPv6_literal
-                 (Pool_role.get_master_address ())
-              )
-              req.Http.Request.uri
-              (String.concat "&" (List.map (fun (a, b) -> a ^ "=" ^ b) query))
+            Uri.(
+              make ~scheme:"https"
+                ~host:(Pool_role.get_master_address ())
+                ~path:req.Http.Request.uri
+                ~query:(List.map (fun (k, v) -> (k, [v])) req.Http.Request.query)
+                ()
+              |> to_string
+            )
           in
           Http_svr.headers fd (Http.http_302_redirect url)
         else (* Get and check query parameters *)

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -399,10 +399,14 @@ let pool_migrate ~__context ~vm ~host ~options =
     use_compression ~__context options (Helpers.get_localhost ~__context) host
   in
   debug "%s using stream compression=%b" __FUNCTION__ compress ;
-  let ip = Http.Url.maybe_wrap_IPv6_literal address in
-  let scheme = if !Xapi_globs.migration_https_only then "https" else "http" in
+  let http = if !Xapi_globs.migration_https_only then "https" else "http" in
   let xenops_url =
-    Printf.sprintf "%s://%s/services/xenops?session_id=%s" scheme ip session_id
+    Uri.(
+      make ~scheme:http ~host:address ~path:"/services/xenops"
+        ~query:[("session_id", [session_id])]
+        ()
+      |> to_string
+    )
   in
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
   let xenops_vgpu_map = infer_vgpu_map ~__context vm in

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2118,12 +2118,14 @@ let update_vm ~__context id =
                   (fun (_, state) ->
                     let localhost = Helpers.get_localhost ~__context in
                     let address =
-                      Http.Url.maybe_wrap_IPv6_literal
-                        (Db.Host.get_address ~__context ~self:localhost)
+                      Db.Host.get_address ~__context ~self:localhost
                     in
                     let uri =
-                      Printf.sprintf "https://%s%s" address
-                        Constants.console_uri
+                      Uri.(
+                        make ~scheme:"https" ~host:address
+                          ~path:Constants.console_uri ()
+                        |> to_string
+                      )
                     in
                     let get_uri_from_location loc =
                       try


### PR DESCRIPTION
For improved IPv6 compatibility, use URI to build URIs. In particular, this will take care of bracketing IPv6 addresses in URIs.