### PR TITLE
xapi-tracing: bind its test to the package

### DIFF
--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -28,4 +28,5 @@
 (test
  (name test_tracing)
  (modules test_tracing)
+ (package xapi-tracing)
  (libraries tracing alcotest uuid))

--- a/xapi-tracing.opam
+++ b/xapi-tracing.opam
@@ -14,6 +14,7 @@ depends: [
   "dune"
   "re"
   "uri"
+  "uuid" {with-test}
   "xapi-log"
   "xapi-stdext-threads"
 ]

--- a/xapi-tracing.opam.template
+++ b/xapi-tracing.opam.template
@@ -12,6 +12,7 @@ depends: [
   "dune"
   "re"
   "uri"
+  "uuid" {with-test}
   "xapi-log"
   "xapi-stdext-threads"
 ]


### PR DESCRIPTION
These are needed to fix the opam world