### PR TITLE
CP-49665: VM anti-affinity support for host evacuation - implemented with Psq

### DIFF
--- a/ocaml/tests/test_ha_vm_failover.ml
+++ b/ocaml/tests/test_ha_vm_failover.ml
@@ -27,6 +27,8 @@ type vbd = {agile: bool}
 
 type vif = {agile: bool}
 
+type group = {name_label: string; placement: string}
+
 type vm = {
     ha_always_run: bool
   ; ha_restart_priority: string
@@ -34,6 +36,8 @@ type vm = {
   ; name_label: string
   ; vbds: vbd list
   ; vifs: vif list
+  ; groups: group list
+  ; power_state: string
 }
 
 let basic_vm =
@@ -44,6 +48,8 @@ let basic_vm =
   ; name_label= "vm"
   ; vbds= [{agile= true}]
   ; vifs= [{agile= true}]
+  ; groups= []
+  ; power_state= "running"
   }
 
 type host = {memory_total: int64; name_label: string; vms: vm list}
@@ -55,8 +61,13 @@ type pool = {
   ; cluster: int
 }
 
-let string_of_vm {memory; name_label; _} =
-  Printf.sprintf "{memory = %Ld; name_label = %S}" memory name_label
+let string_of_group {name_label; placement} =
+  Printf.sprintf "{name_label = %S; placement = %S}" name_label placement
+
+let string_of_vm {memory; name_label; groups; _} =
+  Printf.sprintf "{memory = %Ld; name_label = %S; groups = [%s]}" memory
+    name_label
+    (Test_printers.list string_of_group groups)
 
 let string_of_host {memory_total; name_label; vms} =
   Printf.sprintf "{memory_total = %Ld; name_label = %S; vms = [%s]}"
@@ -70,6 +81,26 @@ let string_of_pool {master; slaves; ha_host_failures_to_tolerate; cluster} =
     (string_of_host master)
     (Test_printers.list string_of_host slaves)
     ha_host_failures_to_tolerate cluster
+
+let load_group ~__context ~group =
+  let placement =
+    match group.placement with
+    | "anti_affinity" ->
+        `anti_affinity
+    | _ ->
+        `normal
+  in
+  match
+    Db.VM_group.get_all ~__context
+    |> List.find_opt (fun g ->
+           Db.VM_group.get_name_label ~__context ~self:g = group.name_label
+           && Db.VM_group.get_placement ~__context ~self:g = placement
+       )
+  with
+  | None ->
+      make_vm_group ~__context ~name_label:group.name_label ~placement ()
+  | Some g ->
+      g
 
 let load_vm ~__context ~(vm : vm) ~local_sr ~shared_sr ~local_net ~shared_net =
   let vm_ref =
@@ -98,6 +129,14 @@ let load_vm ~__context ~(vm : vm) ~local_sr ~shared_sr ~local_net ~shared_net =
       )
       vm.vbds
   in
+  let groups =
+    List.fold_left
+      (fun acc group -> load_group ~__context ~group :: acc)
+      [] vm.groups
+  in
+  Db.VM.set_groups ~__context ~self:vm_ref ~value:groups ;
+  if "running" = vm.power_state then
+    Db.VM.set_power_state ~__context ~self:vm_ref ~value:`Running ;
   vm_ref
 
 let load_host ~__context ~host ~local_sr ~shared_sr ~local_net ~shared_net =
@@ -110,7 +149,11 @@ let load_host ~__context ~host ~local_sr ~shared_sr ~local_net ~shared_net =
   let (_ : API.ref_VM list) =
     List.map
       (fun vm ->
-        load_vm ~__context ~vm ~local_sr ~shared_sr ~local_net ~shared_net
+        let vm_ref =
+          load_vm ~__context ~vm ~local_sr ~shared_sr ~local_net ~shared_net
+        in
+        Db.VM.set_resident_on ~__context ~self:vm_ref ~value:host_ref ;
+        vm_ref
       )
       host.vms
   in

--- a/ocaml/tests/test_ha_vm_failover.ml
+++ b/ocaml/tests/test_ha_vm_failover.ml
@@ -27,7 +27,9 @@ type vbd = {agile: bool}
 
 type vif = {agile: bool}
 
-type group = {name_label: string; placement: string}
+type placement_policy = AntiAffinity | Normal
+
+type group = {name_label: string; placement: placement_policy}
 
 type vm = {
     ha_always_run: bool
@@ -61,8 +63,62 @@ type pool = {
   ; cluster: int
 }
 
+let master = "master"
+
+let slave = "slave"
+
+let slave1 = "slave1"
+
+let slave2 = "slave2"
+
+let slave3 = "slave3"
+
+let grp1 = "grp1"
+
+let grp2 = "grp2"
+
+(** vmX_grpY: in test case for anti_affinity, the VM is the Xth smallest of slave1's VMs of
+    the same placement type in terms of VM's memory size, and it belows to VM group: grpY. *)
+let vm1_grp1 = "vm1_grp1"
+
+let vm2_grp1 = "vm2_grp1"
+
+let vm3_grp1 = "vm3_grp1"
+
+let vm4_grp1 = "vm4_grp1"
+
+let vm5_grp1 = "vm5_grp1"
+
+let vm6_grp1 = "vm6_grp1"
+
+let vm8_grp1 = "vm8_grp1"
+
+let vm2_grp2 = "vm2_grp2"
+
+let vm3_grp2 = "vm3_grp2"
+
+let vm4_grp2 = "vm4_grp2"
+
+let vm5_grp2 = "vm5_grp2"
+
+let vm7_grp2 = "vm7_grp2"
+
+(** In test case for anti_affinity, it is a VM resident on host other than slave1 *)
+let vm_grp1 = "vm_grp1"
+
+(** vmX: in test case for anti_affinity, it is a VM not in any VM group, and it is the Xth
+    largest of slave1's VMs not in any VM group in terms of VM's memory size. *)
+let vm1 = "vm1"
+
+let vm2 = "vm2"
+
+let vm3 = "vm3"
+
+let vm4 = "vm4"
+
 let string_of_group {name_label; placement} =
-  Printf.sprintf "{name_label = %S; placement = %S}" name_label placement
+  Printf.sprintf "{name_label = %S; placement = %S}" name_label
+    (match placement with AntiAffinity -> "anti_affinity" | Normal -> "normal")
 
 let string_of_vm {memory; name_label; groups; _} =
   Printf.sprintf "{memory = %Ld; name_label = %S; groups = [%s]}" memory
@@ -85,9 +141,9 @@ let string_of_pool {master; slaves; ha_host_failures_to_tolerate; cluster} =
 let load_group ~__context ~group =
   let placement =
     match group.placement with
-    | "anti_affinity" ->
+    | AntiAffinity ->
         `anti_affinity
-    | _ ->
+    | Normal ->
         `normal
   in
   match
@@ -227,7 +283,7 @@ module AllProtectedVms = Generic.MakeStateful (struct
       [
         (* No VMs and a single host. *)
         ( {
-            master= {memory_total= gib 256L; name_label= "master"; vms= []}
+            master= {memory_total= gib 256L; name_label= master; vms= []}
           ; slaves= []
           ; ha_host_failures_to_tolerate= 0L
           ; cluster= 0
@@ -239,7 +295,7 @@ module AllProtectedVms = Generic.MakeStateful (struct
             master=
               {
                 memory_total= gib 256L
-              ; name_label= "master"
+              ; name_label= master
               ; vms=
                   [
                     {basic_vm with ha_always_run= false; ha_restart_priority= ""}
@@ -256,7 +312,7 @@ module AllProtectedVms = Generic.MakeStateful (struct
             master=
               {
                 memory_total= gib 256L
-              ; name_label= "master"
+              ; name_label= master
               ; vms= [{basic_vm with ha_always_run= false}]
               }
           ; slaves= []
@@ -267,8 +323,7 @@ module AllProtectedVms = Generic.MakeStateful (struct
         )
       ; (* One protected VM. *)
         ( {
-            master=
-              {memory_total= gib 256L; name_label= "master"; vms= [basic_vm]}
+            master= {memory_total= gib 256L; name_label= master; vms= [basic_vm]}
           ; slaves= []
           ; ha_host_failures_to_tolerate= 0L
           ; cluster= 0
@@ -280,15 +335,15 @@ module AllProtectedVms = Generic.MakeStateful (struct
             master=
               {
                 memory_total= gib 256L
-              ; name_label= "master"
+              ; name_label= master
               ; vms=
                   [
-                    {basic_vm with name_label= "vm1"}
+                    {basic_vm with name_label= vm1}
                   ; {
                       basic_vm with
                       ha_always_run= false
                     ; ha_restart_priority= ""
-                    ; name_label= "vm2"
+                    ; name_label= vm2
                     }
                   ]
               }
@@ -296,7 +351,7 @@ module AllProtectedVms = Generic.MakeStateful (struct
           ; ha_host_failures_to_tolerate= 0L
           ; cluster= 0
           }
-        , ["vm1"]
+        , [vm1]
         )
       ]
 end)
@@ -336,8 +391,8 @@ module PlanForNFailures = Generic.MakeStateful (struct
       [
         (* Two host pool with no VMs. *)
         ( {
-            master= {memory_total= gib 256L; name_label= "master"; vms= []}
-          ; slaves= [{memory_total= gib 256L; name_label= "slave"; vms= []}]
+            master= {memory_total= gib 256L; name_label= master; vms= []}
+          ; slaves= [{memory_total= gib 256L; name_label= slave; vms= []}]
           ; ha_host_failures_to_tolerate= 1L
           ; cluster= 0
           }
@@ -349,10 +404,10 @@ module PlanForNFailures = Generic.MakeStateful (struct
             master=
               {
                 memory_total= gib 256L
-              ; name_label= "master"
-              ; vms= [{basic_vm with memory= gib 120L; name_label= "vm1"}]
+              ; name_label= master
+              ; vms= [{basic_vm with memory= gib 120L; name_label= vm1}]
               }
-          ; slaves= [{memory_total= gib 256L; name_label= "slave"; vms= []}]
+          ; slaves= [{memory_total= gib 256L; name_label= slave; vms= []}]
           ; ha_host_failures_to_tolerate= 1L
           ; cluster= 0
           }
@@ -363,14 +418,14 @@ module PlanForNFailures = Generic.MakeStateful (struct
             master=
               {
                 memory_total= gib 256L
-              ; name_label= "master"
+              ; name_label= master
               ; vms=
                   [
-                    {basic_vm with memory= gib 120L; name_label= "vm1"}
-                  ; {basic_vm with memory= gib 120L; name_label= "vm2"}
+                    {basic_vm with memory= gib 120L; name_label= vm1}
+                  ; {basic_vm with memory= gib 120L; name_label= vm2}
                   ]
               }
-          ; slaves= [{memory_total= gib 256L; name_label= "slave"; vms= []}]
+          ; slaves= [{memory_total= gib 256L; name_label= slave; vms= []}]
           ; ha_host_failures_to_tolerate= 1L
           ; cluster= 0
           }
@@ -381,22 +436,22 @@ module PlanForNFailures = Generic.MakeStateful (struct
             master=
               {
                 memory_total= gib 256L
-              ; name_label= "master"
+              ; name_label= master
               ; vms=
                   [
-                    {basic_vm with memory= gib 120L; name_label= "vm1"}
-                  ; {basic_vm with memory= gib 120L; name_label= "vm2"}
+                    {basic_vm with memory= gib 120L; name_label= vm1}
+                  ; {basic_vm with memory= gib 120L; name_label= vm2}
                   ]
               }
           ; slaves=
               [
                 {
                   memory_total= gib 256L
-                ; name_label= "slave"
+                ; name_label= slave
                 ; vms=
                     [
-                      {basic_vm with memory= gib 120L; name_label= "vm3"}
-                    ; {basic_vm with memory= gib 120L; name_label= "vm4"}
+                      {basic_vm with memory= gib 120L; name_label= vm3}
+                    ; {basic_vm with memory= gib 120L; name_label= vm4}
                     ]
                 }
               ]
@@ -465,10 +520,10 @@ module AssertNewVMPreservesHAPlan = Generic.MakeStateful (struct
               master=
                 {
                   memory_total= gib 256L
-                ; name_label= "master"
-                ; vms= [{basic_vm with memory= gib 120L; name_label= "vm1"}]
+                ; name_label= master
+                ; vms= [{basic_vm with memory= gib 120L; name_label= vm1}]
                 }
-            ; slaves= [{memory_total= gib 256L; name_label= "slave"; vms= []}]
+            ; slaves= [{memory_total= gib 256L; name_label= slave; vms= []}]
             ; ha_host_failures_to_tolerate= 1L
             ; cluster= 0
             }
@@ -477,7 +532,7 @@ module AssertNewVMPreservesHAPlan = Generic.MakeStateful (struct
               ha_always_run= false
             ; ha_restart_priority= "restart"
             ; memory= gib 120L
-            ; name_label= "vm2"
+            ; name_label= vm2
             }
           )
         , Ok ()
@@ -488,14 +543,14 @@ module AssertNewVMPreservesHAPlan = Generic.MakeStateful (struct
               master=
                 {
                   memory_total= gib 256L
-                ; name_label= "master"
+                ; name_label= master
                 ; vms=
                     [
-                      {basic_vm with memory= gib 120L; name_label= "vm1"}
-                    ; {basic_vm with memory= gib 120L; name_label= "vm2"}
+                      {basic_vm with memory= gib 120L; name_label= vm1}
+                    ; {basic_vm with memory= gib 120L; name_label= vm2}
                     ]
                 }
-            ; slaves= [{memory_total= gib 256L; name_label= "slave"; vms= []}]
+            ; slaves= [{memory_total= gib 256L; name_label= slave; vms= []}]
             ; ha_host_failures_to_tolerate= 1L
             ; cluster= 0
             }
@@ -504,7 +559,7 @@ module AssertNewVMPreservesHAPlan = Generic.MakeStateful (struct
               ha_always_run= false
             ; ha_restart_priority= "restart"
             ; memory= gib 120L
-            ; name_label= "vm2"
+            ; name_label= vm2
             }
           )
         , Error
@@ -518,19 +573,19 @@ module AssertNewVMPreservesHAPlan = Generic.MakeStateful (struct
               master=
                 {
                   memory_total= gib 256L
-                ; name_label= "master"
+                ; name_label= master
                 ; vms=
                     [
-                      {basic_vm with memory= gib 120L; name_label= "vm1"}
-                    ; {basic_vm with memory= gib 120L; name_label= "vm2"}
+                      {basic_vm with memory= gib 120L; name_label= vm1}
+                    ; {basic_vm with memory= gib 120L; name_label= vm2}
                     ]
                 }
             ; slaves=
                 [
                   {
                     memory_total= gib 256L
-                  ; name_label= "slave"
-                  ; vms= [{basic_vm with memory= gib 120L; name_label= "vm1"}]
+                  ; name_label= slave
+                  ; vms= [{basic_vm with memory= gib 120L; name_label= vm1}]
                   }
                 ]
             ; ha_host_failures_to_tolerate= 1L
@@ -541,7 +596,7 @@ module AssertNewVMPreservesHAPlan = Generic.MakeStateful (struct
               ha_always_run= false
             ; ha_restart_priority= "restart"
             ; memory= gib 120L
-            ; name_label= "vm2"
+            ; name_label= vm2
             }
           )
         , Ok ()
@@ -576,11 +631,11 @@ module ComputeMaxFailures = Generic.MakeStateful (struct
       [
         (* Three host pool with no VMs. *)
         ( {
-            master= {memory_total= gib 256L; name_label= "master"; vms= []}
+            master= {memory_total= gib 256L; name_label= master; vms= []}
           ; slaves=
               [
-                {memory_total= gib 256L; name_label= "slave1"; vms= []}
-              ; {memory_total= gib 256L; name_label= "slave2"; vms= []}
+                {memory_total= gib 256L; name_label= slave1; vms= []}
+              ; {memory_total= gib 256L; name_label= slave2; vms= []}
               ]
           ; (* Placeholder value that is overridden when we call the compute function *)
             ha_host_failures_to_tolerate= 3L
@@ -591,8 +646,8 @@ module ComputeMaxFailures = Generic.MakeStateful (struct
         )
       ; (* Two hosts pool with no VMs  *)
         ( {
-            master= {memory_total= gib 256L; name_label= "master"; vms= []}
-          ; slaves= [{memory_total= gib 256L; name_label= "slave1"; vms= []}]
+            master= {memory_total= gib 256L; name_label= master; vms= []}
+          ; slaves= [{memory_total= gib 256L; name_label= slave1; vms= []}]
           ; ha_host_failures_to_tolerate= 2L
           ; cluster= 2
           }
@@ -601,8 +656,8 @@ module ComputeMaxFailures = Generic.MakeStateful (struct
         )
       ; (* Two host pool with one down  *)
         ( {
-            master= {memory_total= gib 256L; name_label= "master"; vms= []}
-          ; slaves= [{memory_total= gib 256L; name_label= "slave1"; vms= []}]
+            master= {memory_total= gib 256L; name_label= master; vms= []}
+          ; slaves= [{memory_total= gib 256L; name_label= slave1; vms= []}]
           ; ha_host_failures_to_tolerate= 2L
           ; cluster= 1
           }
@@ -612,4 +667,730 @@ module ComputeMaxFailures = Generic.MakeStateful (struct
       ]
 end)
 
-let tests = [("plan_for_n_failures", PlanForNFailures.tests)]
+let extract_output_for_anti_aff_plan ~__context plan =
+  plan
+  |> List.map (fun (vm, host) ->
+         ( Db.VM.get_name_label ~__context ~self:vm
+         , Db.Host.get_name_label ~__context ~self:host
+         )
+     )
+
+let anti_aff_grp1 = {name_label= grp1; placement= AntiAffinity}
+
+let anti_aff_plan_test_cases =
+  [
+    (* Test 0: No VMs in slave1 to be evacuated. *)
+    ( {
+        master= {memory_total= gib 256L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {memory_total= gib 256L; name_label= slave1; vms= []}
+          ; {memory_total= gib 256L; name_label= slave2; vms= []}
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      []
+    , (* Assert that no_breach_plan returns as expected *)
+      []
+    )
+  ; (* Test 1: No anti-affinity VMs in slave1 to be evacuated *)
+    ( {
+        master= {memory_total= gib 256L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {
+              memory_total= gib 256L
+            ; name_label= slave1
+            ; vms=
+                [
+                  {basic_vm with memory= gib 120L; name_label= vm1}
+                ; {basic_vm with memory= gib 120L; name_label= vm2}
+                ]
+            }
+          ; {memory_total= gib 256L; name_label= slave2; vms= []}
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      []
+    , (* Assert that no_breach_plan returns as expected *)
+      []
+    )
+  ; (* Test 2: One anti-affinity VM in slave1 to be evacuated *)
+    ( {
+        master= {memory_total= gib 512L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {
+              memory_total= gib 256L
+            ; name_label= slave1
+            ; vms=
+                [
+                  {
+                    basic_vm with
+                    memory= gib 120L
+                  ; name_label= vm1_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {basic_vm with memory= gib 120L; name_label= vm1}
+                ]
+            }
+          ; {memory_total= gib 256L; name_label= slave2; vms= []}
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      [(vm1_grp1, slave2)]
+    , (* Assert that no_breach_plan returns as expected *)
+      [(vm1_grp1, slave2)]
+    )
+  ; (* Test 3: One anti-affinity VM in slave1 to be evacuated, the smallest host already has anti-affinity VM in the same group *)
+    ( {
+        master= {memory_total= gib 512L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {
+              memory_total= gib 256L
+            ; name_label= slave1
+            ; vms=
+                [
+                  {
+                    basic_vm with
+                    memory= gib 120L
+                  ; name_label= vm1_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {basic_vm with memory= gib 120L; name_label= "vm2"}
+                ]
+            }
+          ; {
+              memory_total= gib 256L
+            ; name_label= slave2
+            ; vms=
+                [
+                  {
+                    basic_vm with
+                    memory= gib 120L
+                  ; name_label= vm_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ]
+            }
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      [(vm1_grp1, master)]
+    , (* Assert that no_breach_plan returns as expected *)
+      [(vm1_grp1, master)]
+    )
+  ; (* Test 4: Two anti-affinity VMs belong to one group in slave1 to be evacuated *)
+    ( {
+        master= {memory_total= gib 512L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {
+              memory_total= gib 256L
+            ; name_label= slave1
+            ; vms=
+                [
+                  {
+                    basic_vm with
+                    memory= gib 120L
+                  ; name_label= vm1_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 130L
+                  ; name_label= vm2_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ]
+            }
+          ; {memory_total= gib 256L; name_label= slave2; vms= []}
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      [(vm2_grp1, master); (vm1_grp1, slave2)]
+    , (* Assert that no_breach_plan returns as expected *)
+      [(vm2_grp1, master); (vm1_grp1, slave2)]
+    )
+  ; (* Test 5: Two anti-affinity VMs belong to one group in slave1 to be evacuated, only 1 can be planed *)
+    ( {
+        master= {memory_total= gib 512L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {
+              memory_total= gib 256L
+            ; name_label= slave1
+            ; vms=
+                [
+                  {
+                    basic_vm with
+                    memory= gib 120L
+                  ; name_label= vm1_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 513L
+                  ; name_label= vm2_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ]
+            }
+          ; {memory_total= gib 256L; name_label= slave2; vms= []}
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      []
+    , (* Assert that no_breach_plan returns as expected *)
+      [(vm1_grp1, slave2)]
+    )
+  ; (* Test 6: 6 anti-affinity VMs belong to one group in slave1 to be evacuated, only 5 can be planned *)
+    ( {
+        master= {memory_total= gib 640L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {
+              memory_total= gib 256L
+            ; name_label= slave1
+            ; vms=
+                [
+                  {
+                    basic_vm with
+                    memory= gib 120L
+                  ; name_label= vm2_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 60L
+                  ; name_label= vm1_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 400L
+                  ; name_label= vm6_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 250L
+                  ; name_label= vm4_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 260L
+                  ; name_label= vm5_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 130L
+                  ; name_label= vm3_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ]
+            }
+          ; {memory_total= gib 256L; name_label= slave2; vms= []}
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      []
+    , (* Assert that no_breach_plan returns as expected *)
+      [(vm2_grp1, master); (vm1_grp1, slave2)]
+    )
+  ; (* Test 7: Two groups anti-affinity VMs in slave1 to be evacuated *)
+    ( {
+        master= {memory_total= gib 512L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {
+              memory_total= gib 256L
+            ; name_label= slave1
+            ; vms=
+                [
+                  {
+                    basic_vm with
+                    memory= gib 120L
+                  ; name_label= vm6_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 60L
+                  ; name_label= vm5_grp2
+                  ; groups= [{name_label= grp2; placement= AntiAffinity}]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 130L
+                  ; name_label= vm7_grp2
+                  ; groups= [{name_label= grp2; placement= AntiAffinity}]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 1L
+                  ; name_label= vm1_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 2L
+                  ; name_label= vm2_grp2
+                  ; groups= [{name_label= grp2; placement= AntiAffinity}]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 3L
+                  ; name_label= vm3_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 4L
+                  ; name_label= vm4_grp2
+                  ; groups= [{name_label= grp2; placement= AntiAffinity}]
+                  }
+                ]
+            }
+          ; {memory_total= gib 256L; name_label= slave2; vms= []}
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      [
+        (vm7_grp2, master)
+      ; (vm6_grp1, slave2)
+      ; (vm5_grp2, slave2)
+      ; (vm4_grp2, master)
+      ; (vm3_grp1, master)
+      ; (vm2_grp2, slave2)
+      ; (vm1_grp1, slave2)
+      ]
+    , (* Assert that no_breach_plan returns as expected *)
+      [
+        (vm4_grp2, master)
+      ; (vm3_grp1, master)
+      ; (vm2_grp2, slave2)
+      ; (vm1_grp1, slave2)
+      ]
+    )
+  ; (* Test 8: Two groups anti-affinity VMs in slave1 to be evacuated, master is bigger than slave2 in size when started, but becomes smaller during planning *)
+    ( {
+        master= {memory_total= gib 512L; name_label= master; vms= []}
+      ; slaves=
+          [
+            {
+              memory_total= gib 256L
+            ; name_label= slave1
+            ; vms=
+                [
+                  {
+                    basic_vm with
+                    memory= gib 120L
+                  ; name_label= vm6_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 60L
+                  ; name_label= vm5_grp2
+                  ; groups= [{name_label= grp2; placement= AntiAffinity}]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 130L
+                  ; name_label= vm7_grp2
+                  ; groups= [{name_label= grp2; placement= AntiAffinity}]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 1L
+                  ; name_label= vm1_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 6L
+                  ; name_label= vm3_grp2
+                  ; groups= [{name_label= grp2; placement= AntiAffinity}]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 5L
+                  ; name_label= vm2_grp1
+                  ; groups= [anti_aff_grp1]
+                  }
+                ; {
+                    basic_vm with
+                    memory= gib 7L
+                  ; name_label= vm4_grp2
+                  ; groups= [{name_label= grp2; placement= AntiAffinity}]
+                  }
+                ]
+            }
+          ; {memory_total= gib 510L; name_label= slave2; vms= []}
+          ]
+      ; ha_host_failures_to_tolerate= 0L
+      ; cluster= 0
+      }
+    , (* Assert that spread_evenly_plan returns as expected *)
+      [
+        (vm7_grp2, slave2)
+      ; (vm6_grp1, master)
+      ; (vm5_grp2, master)
+      ; (vm4_grp2, slave2)
+      ; (vm3_grp2, master)
+      ; (vm2_grp1, master)
+      ; (vm1_grp1, slave2)
+      ]
+    , (* Assert that no_breach_plan returns as expected *)
+      [
+        (vm4_grp2, slave2)
+      ; (vm3_grp2, master)
+      ; (vm2_grp1, master)
+      ; (vm1_grp1, slave2)
+      ]
+    )
+  ]
+
+module Slave1EvacuationVMAntiAffinitySpreadEvenlyPlan =
+Generic.MakeStateful (struct
+  module Io = struct
+    type input_t = pool
+
+    type output_t = (string * string) list
+
+    let string_of_input_t = string_of_pool
+
+    let string_of_output_t = Test_printers.(list (pair string string))
+  end
+
+  module State = Test_state.XapiDb
+
+  let load_input __context = setup ~__context
+
+  let extract_output __context _ =
+    let slv1 =
+      Db.Host.get_all ~__context
+      |> List.find (fun self -> Db.Host.get_name_label ~__context ~self = slave1)
+    in
+    let slave1_anti_aff_vms =
+      Db.Host.get_resident_VMs ~__context ~self:slv1
+      |> List.map (fun self -> (self, Db.VM.get_record ~__context ~self))
+      |> List.filter (fun (_, record) -> not record.API.vM_is_control_domain)
+      |> List.map (fun (self, record) ->
+             (self, Xapi_ha_vm_failover.vm_memory ~__context record)
+         )
+      |> Xapi_ha_vm_failover.vms_partition ~__context
+      |> fst
+    in
+    let hosts =
+      Db.Host.get_all ~__context
+      |> List.filter (( <> ) slv1)
+      |> List.map (fun host ->
+             (host, Xapi_ha_vm_failover.host_free_memory ~__context ~host)
+         )
+    in
+    let pool_state =
+      Xapi_ha_vm_failover.init_spread_evenly_plan_pool_state ~__context
+        slave1_anti_aff_vms hosts
+    in
+    extract_output_for_anti_aff_plan ~__context
+      (Xapi_ha_vm_failover.compute_spread_evenly_plan ~__context pool_state
+         (slave1_anti_aff_vms
+         |> List.sort (fun (_, a, _) (_, b, _) -> compare a b)
+         )
+      )
+
+  let tests =
+    `QuickAndAutoDocumented
+      (anti_aff_plan_test_cases
+      |> List.map (fun (pool, spread_evenly_plan, _no_breach_plan) ->
+             (pool, spread_evenly_plan)
+         )
+      )
+end)
+
+module Slave1EvacuationVMAntiAffinityNoBreachPlan = Generic.MakeStateful (struct
+  module Io = struct
+    type input_t = pool
+
+    type output_t = (string * string) list
+
+    let string_of_input_t = string_of_pool
+
+    let string_of_output_t = Test_printers.(list (pair string string))
+  end
+
+  module State = Test_state.XapiDb
+
+  let load_input __context = setup ~__context
+
+  let extract_output __context _ =
+    let slv1 =
+      Db.Host.get_all ~__context
+      |> List.find (fun self -> Db.Host.get_name_label ~__context ~self = slave1)
+    in
+    let slave1_anti_aff_vms =
+      Db.Host.get_resident_VMs ~__context ~self:slv1
+      |> List.map (fun self -> (self, Db.VM.get_record ~__context ~self))
+      |> List.filter (fun (_, record) -> not record.API.vM_is_control_domain)
+      |> List.map (fun (self, record) ->
+             (self, Xapi_ha_vm_failover.vm_memory ~__context record)
+         )
+      |> Xapi_ha_vm_failover.vms_partition ~__context
+      |> fst
+    in
+    let hosts =
+      Db.Host.get_all ~__context
+      |> List.filter (( <> ) slv1)
+      |> List.map (fun host ->
+             (host, Xapi_ha_vm_failover.host_free_memory ~__context ~host)
+         )
+    in
+    let pool_state =
+      Xapi_ha_vm_failover.init_spread_evenly_plan_pool_state ~__context
+        slave1_anti_aff_vms hosts
+      |> Xapi_ha_vm_failover.init_no_breach_plan_pool_state
+    in
+    extract_output_for_anti_aff_plan ~__context
+      (Xapi_ha_vm_failover.compute_no_breach_plan ~__context pool_state
+         (slave1_anti_aff_vms
+         |> List.sort (fun (_, a, _) (_, b, _) -> compare a b)
+         )
+      |> fst
+      )
+
+  let tests =
+    `QuickAndAutoDocumented
+      (anti_aff_plan_test_cases
+      |> List.map (fun (pool, _spread_evenly_plan, no_breach_plan) ->
+             (pool, no_breach_plan)
+         )
+      )
+end)
+
+module Slave1EvacuationPlan = Generic.MakeStateful (struct
+  module Io = struct
+    type input_t = pool
+
+    type output_t = (string * string) list
+
+    let string_of_input_t = string_of_pool
+
+    let string_of_output_t = Test_printers.(list (pair string string))
+  end
+
+  module State = Test_state.XapiDb
+
+  let load_input __context = setup ~__context
+
+  let extract_output __context _ =
+    let all_hosts = Db.Host.get_all ~__context in
+    let slv1 =
+      Db.Host.get_all ~__context
+      |> List.find (fun self -> Db.Host.get_name_label ~__context ~self = slave1)
+    in
+    let slave1_vms =
+      Db.Host.get_resident_VMs ~__context ~self:slv1
+      |> List.map (fun self -> (self, Db.VM.get_record ~__context ~self))
+      |> List.filter (fun (_, record) -> not record.API.vM_is_control_domain)
+      |> List.map (fun (self, record) ->
+             (self, Xapi_ha_vm_failover.vm_memory ~__context record)
+         )
+    in
+    let hosts =
+      all_hosts
+      |> List.filter (( <> ) slv1)
+      |> List.map (fun host ->
+             (host, Xapi_ha_vm_failover.host_free_memory ~__context ~host)
+         )
+    in
+    Xapi_ha_vm_failover.compute_anti_aff_evac_plan ~__context
+      (List.length all_hosts) hosts slave1_vms
+    |> List.map (fun (vm, host) ->
+           ( Db.VM.get_name_label ~__context ~self:vm
+           , Db.Host.get_name_label ~__context ~self:host
+           )
+       )
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        (* Test 0: Spread evenly plan is taken. *)
+        ( {
+            master= {memory_total= gib 200L; name_label= master; vms= []}
+          ; slaves=
+              [
+                {
+                  memory_total= gib 256L
+                ; name_label= slave1
+                ; vms=
+                    [
+                      {
+                        basic_vm with
+                        memory= gib 24L
+                      ; name_label= vm4_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ; {
+                        basic_vm with
+                        memory= gib 23L
+                      ; name_label= vm3_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ; {
+                        basic_vm with
+                        memory= gib 22L
+                      ; name_label= vm2_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ; {
+                        basic_vm with
+                        memory= gib 21L
+                      ; name_label= vm1_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ]
+                }
+              ; {memory_total= gib 60L; name_label= slave2; vms= []}
+              ]
+          ; ha_host_failures_to_tolerate= 0L
+          ; cluster= 0
+          }
+        , (* Assert that spread_evenly_plan is taken. *)
+          [
+            (vm4_grp1, master)
+          ; (vm3_grp1, slave2)
+          ; (vm2_grp1, master)
+          ; (vm1_grp1, slave2)
+          ]
+        )
+        (* Test 1: No breach plan is taken. *)
+      ; ( {
+            master= {memory_total= gib 100L; name_label= master; vms= []}
+          ; slaves=
+              [
+                {
+                  memory_total= gib 256L
+                ; name_label= slave1
+                ; vms=
+                    [
+                      {basic_vm with memory= gib 85L; name_label= vm1}
+                    ; {basic_vm with memory= gib 65L; name_label= vm2}
+                    ; {
+                        basic_vm with
+                        memory= gib 30L
+                      ; name_label= vm3_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ; {
+                        basic_vm with
+                        memory= gib 20L
+                      ; name_label= vm2_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ; {
+                        basic_vm with
+                        memory= gib 10L
+                      ; name_label= vm1_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ]
+                }
+              ; {memory_total= gib 90L; name_label= slave2; vms= []}
+              ; {memory_total= gib 70L; name_label= slave3; vms= []}
+              ]
+          ; ha_host_failures_to_tolerate= 0L
+          ; cluster= 0
+          }
+        , (* Assert that no-breach-plan is taken *)
+          [
+            (vm2_grp1, slave2)
+          ; (vm1_grp1, slave3)
+          ; (vm3_grp1, slave3)
+          ; (vm2, slave2)
+          ; (vm1, master)
+          ]
+        )
+        (* Test 2: Fallback to binpack plan. *)
+      ; ( {
+            master= {memory_total= gib 100L; name_label= master; vms= []}
+          ; slaves=
+              [
+                {
+                  memory_total= gib 256L
+                ; name_label= slave1
+                ; vms=
+                    [
+                      {basic_vm with memory= gib 95L; name_label= vm1}
+                    ; {basic_vm with memory= gib 75L; name_label= vm2}
+                    ; {
+                        basic_vm with
+                        memory= gib 30L
+                      ; name_label= vm3_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ; {
+                        basic_vm with
+                        memory= gib 20L
+                      ; name_label= vm2_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ; {
+                        basic_vm with
+                        memory= gib 10L
+                      ; name_label= vm1_grp1
+                      ; groups= [anti_aff_grp1]
+                      }
+                    ]
+                }
+              ; {memory_total= gib 80L; name_label= slave2; vms= []}
+              ; {memory_total= gib 70L; name_label= slave3; vms= []}
+              ]
+          ; ha_host_failures_to_tolerate= 0L
+          ; cluster= 0
+          }
+        , (* Assert that binpack-plan is taken *)
+          [
+            (vm1_grp1, slave3)
+          ; (vm2_grp1, slave3)
+          ; (vm3_grp1, slave3)
+          ; (vm2, slave2)
+          ; (vm1, master)
+          ]
+        )
+      ]
+end)
+
+let tests =
+  [
+    ("plan_for_n_failures", PlanForNFailures.tests)
+  ; ( "anti-affinity spread evenly plan"
+    , Slave1EvacuationVMAntiAffinitySpreadEvenlyPlan.tests
+    )
+  ; ( "anti-affinity no breach plan"
+    , Slave1EvacuationVMAntiAffinityNoBreachPlan.tests
+    )
+  ; ( "3 phases planning: spread evenly plan, no breach plan, binpacking plan"
+    , Slave1EvacuationPlan.tests
+    )
+  ]

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -84,6 +84,7 @@
     pam
     pciutil
     pci
+    psq
     ptime
     rpclib.core
     rpclib.json

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -175,9 +175,6 @@ let order_f (_, vm_rec) =
 
 let ( $ ) x y = x y
 
-(*****************************************************************************************************)
-(* Planning code follows                                                                             *)
-
 (* Compute the total memory required of a VM (Running or not) *)
 let total_memory_of_vm ~__context policy snapshot =
   let main, shadow =
@@ -185,50 +182,411 @@ let total_memory_of_vm ~__context policy snapshot =
   in
   Int64.add main shadow
 
-(** Return a VM -> Host plan for the Host.evacuate code. We assume the VMs are all agile. The returned plan may
-    be incomplete if there was not enough memory. *)
-let compute_evacuation_plan ~__context total_hosts remaining_hosts
-    vms_and_snapshots =
-  let hosts =
-    List.map
-      (fun host ->
-        ( host
-        , Memory_check.host_compute_free_memory_with_maximum_compression
-            ~__context ~host None
-        )
-      )
-      remaining_hosts
+let host_free_memory ~__context ~host =
+  Memory_check.host_compute_free_memory_with_maximum_compression ~__context
+    ~host None
+
+let vm_memory ~__context snapshot =
+  let policy =
+    match Helpers.check_domain_type snapshot.API.vM_domain_type with
+    | `hvm | `pv ->
+        Memory_check.Dynamic_min
+    | `pv_in_pvh | `pvh ->
+        Memory_check.Static_max
   in
-  let vms =
-    List.map
-      (fun (vm, snapshot) ->
-        let policy =
-          match Helpers.check_domain_type snapshot.API.vM_domain_type with
-          | `hvm | `pv ->
-              Memory_check.Dynamic_min
-          | `pv_in_pvh | `pvh ->
-              Memory_check.Static_max
+  total_memory_of_vm ~__context policy snapshot
+
+module VMGrpRefOrd = struct
+  type t = [`VM_group] Ref.t
+
+  let compare = Ref.compare
+end
+
+module VMGrpMap = Map.Make (VMGrpRefOrd)
+
+module HostKey = struct
+  type t = [`host] Ref.t
+
+  let compare = Ref.compare
+end
+
+(* For a VM anti-affinity group, the state of a host which determines
+   evacuation planning for anti-affinity VMs in that group:
+   1. vm_cnt: the number of running VMs in that group resident on the host
+   2. h_size: the amount of free memory of the host *)
+module HostStatistics = struct
+  type t = {vm_cnt: int; h_size: int64}
+
+  (* During evacuation planning for anti-affinity VMs, "vm_cnt" is the first
+     factor considered, "h_size" is the second factor considered:
+     Let's say the next anti-affinity VM to be planned belongs to group A, the
+     host to be selected should be the one which has minimal "vm_cnt" of group
+     A, for hosts with the same "vm_cnt", pick the one with the minimal
+     "h_size" which can hold the VM(h_size >= vm_size). *)
+  let compare {vm_cnt= vm_cnt_0; h_size= h_size_0}
+      {vm_cnt= vm_cnt_1; h_size= h_size_1} =
+    match Int.compare vm_cnt_0 vm_cnt_1 with
+    | 0 ->
+        Int64.compare h_size_0 h_size_1
+    | c ->
+        c
+end
+
+(* A Psq of hosts for an anti-affinity group, which is used for evacuation
+   planning for anti-affinity VMs in that group: the minimal host in this Psq
+   is the first one to be considered to plan a VM from that group.
+   When several hosts share the minimal "HostStatistics",
+   the minimal host is the host with the smallest ref. *)
+module AntiAffEvacPlanHostPsq = Psq.Make (HostKey) (HostStatistics)
+
+(* The spread evenly plan pool state determines the spread evenly evacuation
+   planning for anti-affinity VMs.
+   It's a VMGrpMap which contains a Psq for each group, and each Psq contains
+   all the available hosts in the pool.
+   Let's say the anti-affinity VM to be planned belongs to anti-affinity group
+   A. To get a spread evenly evacuation plan, the most suitable host to plan
+   the VM would be the host which has the minimal number of running VMs from
+   group A resident on it, for the hosts with the same number of running VMs
+   from group A, the one with the minimal free memory will be checked first,
+   which is just the minimal host returned from "Psq.min" on the Psq of group
+   A. *)
+let init_spread_evenly_plan_pool_state ~__context anti_aff_vms hosts =
+  let module Q = AntiAffEvacPlanHostPsq in
+  let gen_psq grp =
+    let module H = Xapi_vm_helpers in
+    let host_vm_cnt = H.host_to_vm_count_map ~__context grp in
+    List.fold_left
+      (fun q (h, h_size) ->
+        let vm_cnt =
+          H.HostMap.find_opt h host_vm_cnt |> Option.value ~default:0
         in
-        (vm, total_memory_of_vm ~__context policy snapshot)
+        Q.add h {vm_cnt; h_size} q
       )
-      vms_and_snapshots
+      Q.empty hosts
   in
+  let module VMGrpSet = Set.Make (VMGrpRefOrd) in
+  anti_aff_vms |> List.map (fun (_, _, grp) -> grp) |> VMGrpSet.of_list
+  |> fun s ->
+  VMGrpSet.fold
+    (fun grp grp_psq -> VMGrpMap.add grp (gen_psq grp) grp_psq)
+    s VMGrpMap.empty
+
+(* Update "spread_evenly_plan_pool_state" after a VM from anti-affinity "group"
+   with memory size: "vm_size" is planned on the "host":
+   1. For the "group", increase "vm_cnt" of the "host" by 1.
+   2. For each group, updates the host's size by substracting "vm_size". *)
+let update_spread_evenly_plan_pool_state vm_size group host pool_state =
+  let module Q = AntiAffEvacPlanHostPsq in
+  VMGrpMap.mapi
+    (fun grp hosts_q ->
+      Q.adjust host
+        (fun {vm_cnt; h_size} ->
+          let h_size = Int64.sub h_size vm_size in
+          let vm_cnt = vm_cnt + if grp = group then 1 else 0 in
+          {vm_cnt; h_size}
+        )
+        hosts_q
+    )
+    pool_state
+
+(* The no breach plan pool state determines the no breach evacuation planning
+   for anti-affinity VMs.
+   It's a VMGrpMap which contains "no breach plan state" for each VM anti-
+   affinity group.
+   "no breach plan state" has 2 elements:
+   1. a Psq which contains "no_resident" hosts for that group. (A "no
+      resident" host for a group is a host which has no running VMs from that
+      group resident on it.)
+   2. an int which is the number of "resident" hosts for each group. (A
+      "resident" host for a group is a host which has at least one running VM
+      from that group resident on it.)
+   Let's say the anti-affinity VM to be planned belongs to anti-affinity group
+   A. If for group A, the number of "resident" hosts is already 2 or greater
+   than 2, then we don't need to plan the VM on any host, if not, we will need
+   to check the host with the minimal free memory from the "no resident" hosts
+   queue, which is just the minimal host returned from "Psq.min" on the "no
+   resident" hosts Psq of group A. *)
+let init_no_breach_plan_pool_state spread_evenly_plan_pool_state =
+  let module Q = AntiAffEvacPlanHostPsq in
+  spread_evenly_plan_pool_state
+  |> VMGrpMap.map (fun hs ->
+         let no_resident_hosts, resident_hosts =
+           Q.partition (fun _ {vm_cnt; _} -> vm_cnt = 0) hs
+         in
+         (no_resident_hosts, Q.size resident_hosts)
+     )
+
+(* Update "no_breach_plan_pool_state" after a VM from anti-affinity "group"
+   with memory size: "vm_size" is planned on the "host":
+   1. For the "group", the "host" is removed from its "no_resident" hosts
+      queue, and increase its "resident_hosts_cnt" by 1.
+   2. For other groups, updates the host's size by substracting "vm_size" if
+      the host is in that group's "no_resident" hosts queue. *)
+let update_no_breach_plan_pool_state vm_size group host pool_state =
+  let module Q = AntiAffEvacPlanHostPsq in
+  VMGrpMap.mapi
+    (fun grp (no_resident_hosts, resident_hosts_cnt) ->
+      match grp = group with
+      | true ->
+          (Q.remove host no_resident_hosts, succ resident_hosts_cnt)
+      | false ->
+          let open HostStatistics in
+          ( Q.update host
+              (Option.map (fun {vm_cnt; h_size} ->
+                   {vm_cnt; h_size= Int64.sub h_size vm_size}
+               )
+              )
+              no_resident_hosts
+          , resident_hosts_cnt
+          )
+    )
+    pool_state
+
+(* For an anti-affinity group, select host for a VM of memory size: vm_size
+   from hosts Psq: hosts_psq, returns the selected host for the VM and the
+   available hosts Psq for the remaining VMs to be planned in that anti-
+   affinity group. *)
+let rec select_host_for_anti_aff_evac_plan vm_size hosts_psq =
+  let module Q = AntiAffEvacPlanHostPsq in
+  match Q.pop hosts_psq with
+  | None ->
+      None
+  | Some ((host, {vm_cnt= _; h_size}), rest_hosts) -> (
+    match vm_size <= h_size with
+    | true ->
+        (* "host", the minimal one in "hosts_psq", might still be able to hold
+           the next VM: if its free memory, after the current VM is placed on
+           it, is still larger than the size of the next VM *)
+        Some (host, hosts_psq)
+    | false ->
+        (* "host" will not be available for the remaining VMs as the anti-
+           affinity VMs to be planned are sorted increasingly in terms of their
+           size, since the host can't hold current VM, it will not be able to
+           hold the next VM. *)
+        select_host_for_anti_aff_evac_plan vm_size rest_hosts
+  )
+
+let impossible_error_handler () =
+  let msg = "Data corrupted during host evacuation." in
+  error "%s" msg ;
+  raise (Api_errors.Server_error (Api_errors.internal_error, [msg]))
+
+(*****************************************************************************************************)
+(* Planning code follows                                                                             *)
+
+(* Try to get a spread evenly plan for anti-affinity VMs (for each anti-
+   affinity group, the number of running VMs from that group are spread evenly
+   in all the rest hosts in the pool):
+   1. For all the anti-affinity VMs which sorted in an increasing order in
+      terms of the VM's memory size, do host selection as below step 2.
+   2. For each anti-affinity VM, select a host which can run it, and which has
+      the minimal number of VMs in the same anti-affinity group running on it,
+      for the hosts with the same number of running VMs in that group, pick the
+      one with the minimal free memory. *)
+let compute_spread_evenly_plan ~__context pool_state anti_aff_vms =
+  info "compute_spread_evenly_plan" ;
+  List.fold_left
+    (fun (acc_mapping, acc_pool_state) (vm, vm_size, group) ->
+      debug "Spread evenly plan: try to plan for anti-affinity VM (%s %s %s)."
+        (Ref.string_of vm)
+        (Db.VM.get_name_label ~__context ~self:vm)
+        (Db.VM_group.get_name_label ~__context ~self:group) ;
+      match
+        VMGrpMap.find group acc_pool_state
+        |> select_host_for_anti_aff_evac_plan vm_size
+      with
+      | None ->
+          debug
+            "Spread evenly plan: no host can hold this anti-affinity VM. Stop \
+             the planning as there won't be a valid plan for this VM." ;
+          ([], VMGrpMap.empty)
+      | Some (h, avail_hosts_for_group) ->
+          debug
+            "Spread evenly plan: choose the host with the minimal free memory \
+             which can run the vm: (%s %s)."
+            (Ref.string_of h)
+            (Db.Host.get_name_label ~__context ~self:h) ;
+          ( (vm, h) :: acc_mapping
+          , acc_pool_state
+            |> VMGrpMap.update group (fun _ -> Some avail_hosts_for_group)
+            |> update_spread_evenly_plan_pool_state vm_size group h
+          )
+      | exception Not_found ->
+          impossible_error_handler ()
+    )
+    ([], pool_state) anti_aff_vms
+  |> fst
+
+(* Try to get a no breach plan for anti-affinity VMs (for each anti-affinity
+   group, there are at least 2 hosts having running VMs in the group):
+   1. For all the anti-affinity VMs which sorted in an increasing order in
+      terms of the VM's memory size, do host selection as below step 2.
+   2. For each anti-affinity VM, try to select a host for it so that there are
+      at least 2 hosts which has running VMs in the same anti-affinity group.
+      If there are already 2 hosts having running VMs in that group, skip
+      planning for the VM. *)
+let compute_no_breach_plan ~__context pool_state anti_aff_vms =
+  info "compute_no_breach_plan" ;
+  List.fold_left
+    (fun (acc_mapping, acc_not_planned_vms, acc_pool_state) (vm, vm_size, group) ->
+      debug "No breach plan: try to plan for anti-affinity VM (%s %s %s)."
+        (Ref.string_of vm)
+        (Db.VM.get_name_label ~__context ~self:vm)
+        (Db.VM_group.get_name_label ~__context ~self:group) ;
+
+      match VMGrpMap.find group acc_pool_state with
+      | no_resident_hosts, resident_hosts_cnt when resident_hosts_cnt < 2 -> (
+          debug
+            "No breach plan: there are less than 2 hosts has running VM in the \
+             same anti-affinity group, and there are still host(s) which has 0 \
+             running VMs, try to plan for it." ;
+          match
+            select_host_for_anti_aff_evac_plan vm_size no_resident_hosts
+          with
+          | None ->
+              debug
+                "No breach plan: failed to select host on any of the no \
+                 resident hosts, skip it, continue with the next VM." ;
+              (acc_mapping, (vm, vm_size) :: acc_not_planned_vms, acc_pool_state)
+          | Some (h, hosts) ->
+              debug
+                "No breach plan: choose the no resident host with the minimal \
+                 free memory which can run the vm: (%s)."
+                (Db.Host.get_name_label ~__context ~self:h) ;
+              ( (vm, h) :: acc_mapping
+              , acc_not_planned_vms
+              , acc_pool_state
+                |> VMGrpMap.update group (Option.map (fun (_, i) -> (hosts, i)))
+                |> update_no_breach_plan_pool_state vm_size group h
+              )
+        )
+      | exception Not_found ->
+          impossible_error_handler ()
+      | _ ->
+          debug
+            "No breach plan: no need to plan for the VM as the number of hosts \
+             which has running VMs from the same group is no less than 2, \
+             continue to plan for the next one." ;
+          (acc_mapping, (vm, vm_size) :: acc_not_planned_vms, acc_pool_state)
+    )
+    ([], [], pool_state) anti_aff_vms
+  |> fun (plan, not_planned_vms, _) -> (plan, not_planned_vms)
+
+let vms_partition ~__context vms =
+  vms
+  |> List.partition_map (fun (vm, vm_size) ->
+         match Xapi_vm_helpers.vm_has_anti_affinity ~__context ~vm with
+         | Some (`AntiAffinity group) ->
+             Either.Left (vm, vm_size, group)
+         | _ ->
+             Either.Right (vm, vm_size)
+     )
+
+(* Return an evacuation plan respecting VM anti-affinity rules: it is done in 3
+   phases:
+   1. Try to get a "spread evenly" plan for anti-affinity VMs, and then a
+      binpack plan for the rest of VMs. Done if every VM got planned, otherwise
+      continue.
+   2. Try to get a "no breach" plan for anti-affinity VMs, and then a binpack
+      plan for the rest of VMs. Done if every VM got planned, otherwise
+      continue.
+   3. Carry out a binpack plan ignoring VM anti-affinity. *)
+let compute_anti_aff_evac_plan ~__context total_hosts hosts vms =
   let config =
     {Binpack.hosts; vms; placement= []; total_hosts; num_failures= 1}
   in
   Binpack.check_configuration config ;
-  debug "Planning configuration for offline agile VMs = %s"
-    (Binpack.string_of_configuration
-       (fun x ->
-         Printf.sprintf "%s (%s)" (Ref.short_string_of x)
-           (Db.Host.get_hostname ~__context ~self:x)
-       )
-       (fun x ->
-         Printf.sprintf "%s (%s)" (Ref.short_string_of x)
-           (Db.VM.get_name_label ~__context ~self:x)
-       )
-       config
-    ) ;
+
+  let binpack_plan ~__context config vms =
+    debug "Binpack planning configuration = %s"
+      (Binpack.string_of_configuration
+         (fun x ->
+           Printf.sprintf "%s (%s)" (Ref.short_string_of x)
+             (Db.Host.get_name_label ~__context ~self:x)
+         )
+         (fun x ->
+           Printf.sprintf "%s (%s)" (Ref.short_string_of x)
+             (Db.VM.get_name_label ~__context ~self:x)
+         )
+         config
+      ) ;
+    debug "VMs to attempt to evacuate: [ %s ]"
+      (String.concat "; "
+         (vms
+         |> List.map (fun (self, _) ->
+                Printf.sprintf "%s (%s)" (Ref.short_string_of self)
+                  (Db.VM.get_name_label ~__context ~self)
+            )
+         )
+      ) ;
+    let h = Binpack.choose_heuristic config in
+    h.Binpack.get_specific_plan config (List.map fst vms)
+  in
+
+  let binpack_after_plan_applied plan not_planned_vms =
+    match plan with
+    | [] ->
+        None
+    | plan -> (
+        debug "Binpack for the rest VMs" ;
+        let config_after_plan_applied = Binpack.apply_plan config plan in
+        let config_after_plan_applied =
+          {config_after_plan_applied with vms= not_planned_vms}
+        in
+        let b_plan =
+          binpack_plan ~__context config_after_plan_applied not_planned_vms
+        in
+        match List.length b_plan = List.length not_planned_vms with
+        | true ->
+            debug "Got final plan." ;
+            Some (plan @ b_plan)
+        | false ->
+            debug
+              "Failed to get final plan as failed to binpack for all the rest \
+               VMs." ;
+            None
+      )
+  in
+
+  match total_hosts with
+  | h when h < 3 ->
+      debug
+        "There are less than 2 available hosts to migrate VMs to, \
+         anti-affinity evacuation plan is not needed." ;
+      binpack_plan ~__context config vms
+  | _ ->
+      let anti_aff_vms, non_anti_aff_vms = vms |> vms_partition ~__context in
+      let spread_evenly_plan_pool_state =
+        init_spread_evenly_plan_pool_state ~__context anti_aff_vms hosts
+      in
+      let anti_aff_vms_increasing =
+        anti_aff_vms |> List.sort (fun (_, a, _) (_, b, _) -> compare a b)
+      in
+
+      let ( let* ) o f = match o with None -> f None | p -> p in
+      (let* _no_plan =
+         let plan =
+           compute_spread_evenly_plan ~__context spread_evenly_plan_pool_state
+             anti_aff_vms_increasing
+         in
+         binpack_after_plan_applied plan non_anti_aff_vms
+       in
+       let* _no_plan =
+         let plan, not_planned_vms =
+           compute_no_breach_plan ~__context
+             (init_no_breach_plan_pool_state spread_evenly_plan_pool_state)
+             anti_aff_vms_increasing
+         in
+         binpack_after_plan_applied plan (non_anti_aff_vms @ not_planned_vms)
+       in
+       binpack_plan ~__context config vms |> Option.some
+      )
+      |> Option.value ~default:[]
+
+(** Return a VM -> Host plan for the Host.evacuate code. We assume the VMs are all agile. The returned plan may
+    be incomplete if there was not enough memory. *)
+let compute_evacuation_plan ~__context total_hosts remaining_hosts
+    vms_and_snapshots =
   debug "VMs to attempt to evacuate: [ %s ]"
     (String.concat "; "
        (List.map
@@ -239,8 +597,17 @@ let compute_evacuation_plan ~__context total_hosts remaining_hosts
           vms_and_snapshots
        )
     ) ;
-  let h = Binpack.choose_heuristic config in
-  h.Binpack.get_specific_plan config (List.map fst vms_and_snapshots)
+  let hosts =
+    List.map
+      (fun host -> (host, host_free_memory ~__context ~host))
+      remaining_hosts
+  in
+  let vms =
+    List.map
+      (fun (vm, snapshot) -> (vm, vm_memory ~__context snapshot))
+      vms_and_snapshots
+  in
+  compute_anti_aff_evac_plan ~__context total_hosts hosts vms
 
 (** Passed to the planner to reason about other possible configurations, used to block operations which would
     destroy the HA VM restart plan. *)

--- a/ocaml/xapi/xapi_ha_vm_failover.mli
+++ b/ocaml/xapi/xapi_ha_vm_failover.mli
@@ -86,3 +86,51 @@ val assert_nfailures_change_preserves_ha_plan :
   __context:Context.t -> int -> unit
 
 val assert_new_vm_preserves_ha_plan : __context:Context.t -> API.ref_VM -> unit
+
+(* Below exposed only for ease of testing *)
+
+module VMGrpMap : Map.S with type key = API.ref_VM_group
+
+module HostKey : sig
+  type t = API.ref_host
+end
+
+module AntiAffEvacPlanHostPsq : Psq.S with type k = HostKey.t
+
+val compute_spread_evenly_plan :
+     __context:Context.t
+  -> AntiAffEvacPlanHostPsq.t VMGrpMap.t
+  -> (API.ref_VM * int64 * API.ref_VM_group) list
+  -> (API.ref_VM * API.ref_host) list
+
+val compute_no_breach_plan :
+     __context:Context.t
+  -> (AntiAffEvacPlanHostPsq.t * int) VMGrpMap.t
+  -> (API.ref_VM * int64 * API.ref_VM_group) list
+  -> (API.ref_VM * API.ref_host) list * (API.ref_VM * int64) list
+
+val compute_anti_aff_evac_plan :
+     __context:Context.t
+  -> int
+  -> (API.ref_host * int64) list
+  -> (API.ref_VM * int64) list
+  -> (API.ref_VM * API.ref_host) list
+
+val host_free_memory : __context:Context.t -> host:API.ref_host -> int64
+
+val vm_memory : __context:Context.t -> API.vM_t -> int64
+
+val vms_partition :
+     __context:Context.t
+  -> (API.ref_VM * 'a) list
+  -> (API.ref_VM * 'a * API.ref_VM_group) list * (API.ref_VM * 'a) list
+
+val init_spread_evenly_plan_pool_state :
+     __context:Context.t
+  -> ('a * 'b * API.ref_VM_group) list
+  -> (API.ref_host * int64) list
+  -> AntiAffEvacPlanHostPsq.t VMGrpMap.t
+
+val init_no_breach_plan_pool_state :
+     AntiAffEvacPlanHostPsq.t VMGrpMap.t
+  -> (AntiAffEvacPlanHostPsq.t * int) VMGrpMap.t

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -35,7 +35,7 @@ module SRSet = Set.Make (struct
   let compare = Stdlib.compare
 end)
 
-module RefMap = Map.Make (struct
+module HostMap = Map.Make (struct
   type t = [`host] Ref.t
 
   let compare = Ref.compare
@@ -1003,6 +1003,46 @@ let rank_hosts_by_best_vgpu ~__context vgpu visible_hosts =
         hosts
       |> List.map (fun g -> List.map fst g)
 
+let host_to_vm_count_map ~__context group =
+  let host_of_vm vm =
+    let vm_rec = Db.VM.get_record ~__context ~self:vm in
+    (* 1. When a VM starts migrating, it's 'scheduled_to_be_resident_on' will be set,
+          while its 'resident_on' is not cleared. In this case,
+          'scheduled_to_be_resident_on' should be treated as its running host.
+       2. For paused VM, its 'resident_on' has value, but it will not be considered
+          while computing the amount of VMs. *)
+    match
+      ( vm_rec.API.vM_scheduled_to_be_resident_on
+      , vm_rec.API.vM_resident_on
+      , vm_rec.API.vM_power_state
+      )
+    with
+    | sh, _, _ when sh <> Ref.null ->
+        Some sh
+    | _, h, `Running when h <> Ref.null ->
+        Some h
+    | _ ->
+        None
+  in
+  Db.VM_group.get_VMs ~__context ~self:group
+  |> List.fold_left
+       (fun m vm ->
+         match host_of_vm vm with
+         | Some h ->
+             HostMap.update h
+               (fun c -> Option.(value ~default:0 c |> succ |> some))
+               m
+         | None ->
+             m
+       )
+       HostMap.empty
+
+let rank_hosts_by_vm_cnt_in_group ~__context group hosts =
+  let host_map = host_to_vm_count_map ~__context group in
+  Helpers.group_by ~ordering:`ascending
+    (fun h -> HostMap.find_opt h host_map |> Option.value ~default:0)
+    hosts
+
 (* Group all hosts to 2 parts:
    1. A list of affinity host (only one host).
    2. A list of lists, each list contains hosts with the same number of
@@ -1055,21 +1095,42 @@ let rank_hosts_by_placement ~__context ~vm ~group =
            (fun m vm ->
              match host_of_vm vm with
              | Some h ->
-                 RefMap.update h
+                 HostMap.update h
                    (fun c -> Option.(value ~default:0 c |> succ |> some))
                    m
              | None ->
                  m
            )
-           RefMap.empty
+           HostMap.empty
     in
     host_without_affinity_host
     |> Helpers.group_by ~ordering:`ascending (fun h ->
-           RefMap.find_opt h host_map |> Option.value ~default:0
+           HostMap.find_opt h host_map |> Option.value ~default:0
        )
     |> List.map (fun g -> List.map fst g)
   in
   affinity_host :: sorted_hosts |> List.filter (( <> ) [])
+
+let rec select_host_from_ranked_lists ~vm ~host_selector ~ranked_host_lists =
+  match ranked_host_lists with
+  | [] ->
+      raise (Api_errors.Server_error (Api_errors.no_hosts_available, []))
+  | hosts :: less_optimal_groups_of_hosts -> (
+      debug
+        "Attempting to select host for VM (%s) in a group of equally optimal \
+         hosts [ %s ]"
+        (Ref.string_of vm)
+        (String.concat ";" (List.map Ref.string_of hosts)) ;
+      try host_selector hosts
+      with _ ->
+        info
+          "Failed to select host for VM (%s) in any of [ %s ], continue to \
+           select from less optimal hosts"
+          (Ref.string_of vm)
+          (String.concat ";" (List.map Ref.string_of hosts)) ;
+        select_host_from_ranked_lists ~vm ~host_selector
+          ~ranked_host_lists:less_optimal_groups_of_hosts
+    )
 
 (* Selects a single host from the set of all hosts on which the given [vm] can boot.
    Raises [Api_errors.no_hosts_available] if no such host exists.
@@ -1115,22 +1176,12 @@ let choose_host_for_vm_no_wlb ~__context ~vm ~snapshot =
                )
             )
   in
-  let rec select_host_from = function
-    | [] ->
-        raise (Api_errors.Server_error (Api_errors.no_hosts_available, []))
-    | hosts :: less_optimal_groups_of_hosts -> (
-        debug
-          "Attempting to start VM (%s) on one of equally optimal hosts [ %s ]"
-          (Ref.string_of vm)
-          (String.concat ";" (List.map Ref.string_of hosts)) ;
-        try Xapi_vm_placement.select_host __context vm validate_host hosts
-        with _ ->
-          info "Failed to start VM (%s) on any of [ %s ]" (Ref.string_of vm)
-            (String.concat ";" (List.map Ref.string_of hosts)) ;
-          select_host_from less_optimal_groups_of_hosts
-      )
+  let host_selector =
+    Xapi_vm_placement.select_host __context vm validate_host
   in
-  try select_host_from host_lists
+  try
+    select_host_from_ranked_lists ~vm ~host_selector
+      ~ranked_host_lists:host_lists
   with
   | Api_errors.Server_error (x, []) when x = Api_errors.no_hosts_available ->
     debug

--- a/xapi.opam
+++ b/xapi.opam
@@ -38,6 +38,7 @@ depends: [
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "ppx_deriving"
+  "psq"
   "rpclib"
   "rrdd-plugin"
   "rresult"

--- a/xapi.opam.template
+++ b/xapi.opam.template
@@ -36,6 +36,7 @@ depends: [
   "ppx_deriving_rpc"
   "ppx_sexp_conv"
   "ppx_deriving"
+  "psq"
   "rpclib"
   "rrdd-plugin"
   "rresult"


### PR DESCRIPTION
Host evacuation plan with anti-affinity support will be carried out in 3 phases:

1. Try to get a "spread evenly" plan for anti-affinity VMs, done if
all the rest VMs got planned using binpack, otherwise continue.
2. Try to get a "no breach" plan for anti-affinity VMs, done if all the rest VMs
got planned using binpack, otherwise continue.
3. Carry out a binpack plan ignoring VM anti-affinity.