### PR TITLE
CA-393421: Special VMs cannot be added to VM groups

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1521,6 +1521,7 @@ let set_groups =
         (Ref _vm, "self", "The VM")
       ; (Set (Ref _vm_group), "value", "The VM groups to set")
       ]
+    ~errs:[Api_errors.operation_not_allowed]
     ~allowed_roles:_R_VM_ADMIN ()
 
 let call_plugin =

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1443,6 +1443,20 @@ let set_appliance ~__context ~self ~value =
 
 let set_groups ~__context ~self ~value =
   Pool_features.assert_enabled ~__context ~f:Features.VM_group ;
+  if
+    Db.VM.get_is_control_domain ~__context ~self
+    || Db.VM.get_is_a_template ~__context ~self
+    || Db.VM.get_is_a_snapshot ~__context ~self
+  then
+    raise
+      (Api_errors.Server_error
+         ( Api_errors.operation_not_allowed
+         , [
+             "Control domains, templates, and snapshots cannot be added to VM \
+              groups."
+           ]
+         )
+      ) ;
   if List.length value > 1 then
     raise Api_errors.(Server_error (Api_errors.too_many_groups, [])) ;
   Db.VM.set_groups ~__context ~self ~value


### PR DESCRIPTION
Control domains, templates, and snapshots cannot be added to VM groups.