### PR TITLE
CP-49668: Revert definition of the old 'vm_anti_affinity' feature flag

### DIFF
--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -64,7 +64,6 @@ type feature =
   | Updates
   | Internal_repo_access
   | VTPM
-  | VM_anti_affinity
 [@@deriving rpc]
 
 type orientation = Positive | Negative
@@ -133,9 +132,6 @@ let keys_of_features =
     , ("restrict_internal_repo_access", Negative, "Internal_repo_access")
     )
   ; (VTPM, ("restrict_vtpm", Negative, "VTPM"))
-  ; ( VM_anti_affinity
-    , ("restrict_vm_anti_affinity", Negative, "VM_anti_affinity")
-    )
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi-types/features.mli
+++ b/ocaml/xapi-types/features.mli
@@ -72,7 +72,6 @@ type feature =
   | Internal_repo_access
       (** Enable restriction on repository access to pool members only *)
   | VTPM  (** Support VTPM device required by Win11 guests *)
-  | VM_anti_affinity  (** Enable use of VM anti-affinity placement *)
 
 val feature_of_rpc : Rpc.t -> feature
 (** Convert RPC into {!feature}s *)


### PR DESCRIPTION
Based on the discussion, the feature name has been changed from `vm_anti_affinity `to `vm_group`. Therefore, the feature definition about `vm_anti_affinity `should be removed.
The new feature flag and its control logic will be developed based on the new feature name.
