### PR TITLE
CP-49446: Update SR health to include new constructors

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2791,6 +2791,8 @@ module Sr_stat = struct
       , [
           ("healthy", "Storage is fully available")
         ; ("recovering", "Storage is busy recovering, e.g. rebuilding mirrors.")
+        ; ("unreachable", "Storage is unreachable")
+        ; ("unavailable", "Storage is unavailable")
         ]
       )
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -2798,7 +2798,14 @@ module Sr_stat = struct
 
   let t =
     let lifecycle =
-      [(Prototyped, rel_kolkata, ""); (Published, rel_lima, "")]
+      [
+        (Prototyped, rel_kolkata, "")
+      ; (Published, rel_lima, "")
+      ; ( Extended
+        , "24.16.0"
+        , "Enum extended with 'unreachable' and 'unavailable' values"
+        )
+      ]
     in
     create_obj ~in_db:false ~persist:PersistNothing
       ~gen_constructor_destructor:false ~lifecycle ~in_oss_since:None

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 777
+let schema_minor_vsn = 778
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 776
+let schema_minor_vsn = 777
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "2b8b5b107eb465e97d35a68274ac18ef"
+let last_known_schema_hash = "9cdffb92b17ec72818be9fb32a5f87b8"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "9cdffb92b17ec72818be9fb32a5f87b8"
+let last_known_schema_hash = "b24c445c4f9c3e7f63caf45705865fc8"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -2565,11 +2565,11 @@ let sr_probe_ext printer rpc session_id params =
       | `healthy ->
           "healthy"
       | `recovering ->
-         "recovering"
+          "recovering"
       | `unreachable ->
-         "unreachable"
+          "unreachable"
       | `unavailable ->
-         "unavailable"
+          "unavailable"
     in
     (match x.API.sr_stat_uuid with Some uuid -> [("uuid", uuid)] | None -> [])
     @ [

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -2565,7 +2565,11 @@ let sr_probe_ext printer rpc session_id params =
       | `healthy ->
           "healthy"
       | `recovering ->
-          "recovering"
+         "recovering"
+      | `unreachable ->
+         "unreachable"
+      | `unavailable ->
+         "unavailable"
     in
     (match x.API.sr_stat_uuid with Some uuid -> [("uuid", uuid)] | None -> [])
     @ [

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -232,7 +232,12 @@ let default_vdi_info =
   | Error (`Msg m) ->
       failwith (Printf.sprintf "Error creating default_vdi_info: %s" m)
 
-type sr_health = Healthy | Recovering [@@deriving rpcty]
+type sr_health =
+  | Healthy
+  | Recovering
+  | Unreachable
+  | Unavailable
+[@@deriving rpcty]
 
 type sr_info = {
     sr_uuid: string option

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -232,11 +232,7 @@ let default_vdi_info =
   | Error (`Msg m) ->
       failwith (Printf.sprintf "Error creating default_vdi_info: %s" m)
 
-type sr_health =
-  | Healthy
-  | Recovering
-  | Unreachable
-  | Unavailable
+type sr_health = Healthy | Recovering | Unreachable | Unavailable
 [@@deriving rpcty]
 
 type sr_info = {

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -299,7 +299,11 @@ let probe =
 let probe_ext =
   let to_xenapi_sr_health =
     let open Storage_interface in
-    function Healthy -> `healthy | Recovering -> `recovering
+    function
+    | Healthy -> `healthy
+    | Recovering -> `recovering
+    | Unreachable -> `unreachable
+    | Unavailable -> `unavailable
   in
   let to_xenapi_sr_stat
       Storage_interface.

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -300,10 +300,14 @@ let probe_ext =
   let to_xenapi_sr_health =
     let open Storage_interface in
     function
-    | Healthy -> `healthy
-    | Recovering -> `recovering
-    | Unreachable -> `unreachable
-    | Unavailable -> `unavailable
+    | Healthy ->
+        `healthy
+    | Recovering ->
+        `recovering
+    | Unreachable ->
+        `unreachable
+    | Unavailable ->
+        `unavailable
   in
   let to_xenapi_sr_stat
       Storage_interface.


### PR DESCRIPTION
Currently, the storage layer tracks two extra SR health statuses that XAPI is unaware of. These are "unreachable" and "unavailable". At present, the storage side simply maps these to "recovering" when sending information to the toolstack. This change will allow XAPI to track more accurate SR health statuses.

See this excerpt from `xapi-storage-plugins` (`util.py`) which maps these new constructors to the extant "recovering" enum.
```py
def sr_status_to_xapi(sr_status):
    """
    Convert the SR statuses we know internally into a String which XAPI understands.
    This small layer of indirection allows us to experiment with more states than XAPI
    knows of internally, until such time as XAPI is ready to learn of them.
    """
    if sr_status == SR_STATUS_OK:
        return "Healthy"
    if sr_status == SR_STATUS_RECOVERING:
        return "Recovering"
    if sr_status == SR_STATUS_UNREACHABLE:
        # XAPI does not yet understand "Unreachable"
        return "Recovering"
    if sr_status == SR_STATUS_UNAVAILABLE:
        # XAPI does not yet understand "Unavailable"
        return "Recovering"
```