### PR TITLE
Go SDK: Misc fixes for on-going component tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,7 +69,6 @@ linters:
     - testpackage # makes you use a separate _test package
     - decorder # checks declaration order and count of types, constants, variables and functions
     - thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    - tagliatelle # checks the struct tags
     - godox # detects FIXME, TODO and other comment keywords
     - gci # controls golang package import order and makes it always deterministic
     - tagalign # checks that struct tags are well aligned
@@ -78,6 +77,7 @@ linters:
 
 
     ## disabled
+    #- tagliatelle # checks the struct tags
     #- goconst # finds repeated strings that could be replaced by a constant
     #- gochecknoglobals # checks that no global variables exist
     #- gocyclo # computes and checks the cyclomatic complexity of functions

--- a/ocaml/sdk-gen/go/autogen/src/jsonrpc_client.go
+++ b/ocaml/sdk-gen/go/autogen/src/jsonrpc_client.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -66,9 +67,12 @@ func (client *rpcClient) newRequest(ctx context.Context, req interface{}) (*http
 
 func convertUnhandledJSONData(jsonBytes []byte) []byte {
 	jsonString := string(jsonBytes)
-	jsonString = strings.ReplaceAll(jsonString, ":Infinity", ":\"+Inf\"")
-	jsonString = strings.ReplaceAll(jsonString, ":-Infinity", ":\"-Inf\"")
-	jsonString = strings.ReplaceAll(jsonString, ":NaN", ":\"NaN\"")
+	re := regexp.MustCompile(`:[ ]*-Infinity`)
+	jsonString = re.ReplaceAllString(jsonString, `:"-Inf"`)
+	re = regexp.MustCompile(`:[ +]*Infinity`)
+	jsonString = re.ReplaceAllString(jsonString, `:"+Inf"`)
+	re = regexp.MustCompile(`:[ ]*NaN`)
+	jsonString = re.ReplaceAllString(jsonString, `:"NaN"`)
 
 	return []byte(jsonString)
 }

--- a/ocaml/sdk-gen/go/gen_go_helper.ml
+++ b/ocaml/sdk-gen/go/gen_go_helper.ml
@@ -180,6 +180,7 @@ module Json = struct
     `O
       [
         ("name", `String (concat_and_convert field))
+      ; ("json_name", `String (String.concat "_" field.full_name))
       ; ("description", `String (String.trim field.field_description))
       ; ("type", `String ty)
       ]
@@ -217,6 +218,7 @@ module Json = struct
         `O
           [
             ("name", `String "Snapshot")
+          ; ("json_name", `String "snapshot")
           ; ( "description"
             , `String
                 "The record of the database object that was added, changed or \

--- a/ocaml/sdk-gen/go/templates/ConvertTime.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertTime.mustache
@@ -26,7 +26,7 @@ func deserialize{{func_name_suffix}}(context string, input interface{}) (value {
 		return
 	}
 	unixTimestamp, err := strconv.ParseInt(strconv.Itoa(int(floatValue)), 10, 64)
-	value = time.Unix(unixTimestamp, 0)
+	value = time.Unix(unixTimestamp, 0).UTC()
 
 	return
 }

--- a/ocaml/sdk-gen/go/templates/Record.mustache
+++ b/ocaml/sdk-gen/go/templates/Record.mustache
@@ -1,7 +1,7 @@
 type {{name}}Record struct {
 {{#fields}}
 	//{{#description}} {{.}}{{/description}}
-	{{name}} {{type}}
+	{{name}} {{type}} `json:"{{json_name}},omitempty"`
 {{/fields}}
 }
 
@@ -11,9 +11,9 @@ type {{name}}Ref string
 type RecordInterface interface{}
 
 type EventBatch struct {
-	Token          string
-	ValidRefCounts map[string]int
-	Events         []EventRecord
+	Token          string         `json:"token,omitempty"`
+	ValidRefCounts map[string]int `json:"validRefCounts,omitempty"`
+	Events         []EventRecord  `json:"events,omitempty"`
 }
 
 {{/event}}

--- a/ocaml/sdk-gen/go/test_data/record.go
+++ b/ocaml/sdk-gen/go/test_data/record.go
@@ -1,8 +1,8 @@
 type SessionRecord struct {
 	// Unique identifier/object reference
-	UUID string
+	UUID string `json:"uuid,omitempty"`
 	// Currently connected host
-	ThisHost HostRef
+	ThisHost HostRef `json:"thishost,omitempty"`
 }
 
 type SessionRef string

--- a/ocaml/sdk-gen/go/test_data/time_convert.go
+++ b/ocaml/sdk-gen/go/test_data/time_convert.go
@@ -23,7 +23,7 @@ func deserializeTime(context string, input interface{}) (value time.Time, err er
 		return
 	}
 	unixTimestamp, err := strconv.ParseInt(strconv.Itoa(int(floatValue)), 10, 64)
-	value = time.Unix(unixTimestamp, 0)
+	value = time.Unix(unixTimestamp, 0).UTC()
 
 	return
 }

--- a/ocaml/sdk-gen/go/test_gen_go.ml
+++ b/ocaml/sdk-gen/go/test_gen_go.ml
@@ -58,12 +58,15 @@ let schema_check keys checker members =
   compare_keys keys keys' && List.for_all checker members
 
 let verify_field_member = function
-  | "name", `String _ | "description", `String _ | "type", `String _ ->
+  | "name", `String _
+  | "description", `String _
+  | "type", `String _
+  | "json_name", `String _ ->
       true
   | _ ->
       false
 
-let field_keys = ["name"; "description"; "type"]
+let field_keys = ["name"; "description"; "type"; "json_name"]
 
 let verify_field = function
   | `O members ->
@@ -558,12 +561,14 @@ let record : Mustache.Json.t =
             `O
               [
                 ("name", `String "UUID")
+              ; ("json_name", `String "uuid")
               ; ("description", `String "Unique identifier/object reference")
               ; ("type", `String "string")
               ]
           ; `O
               [
                 ("name", `String "ThisHost")
+              ; ("json_name", `String "thishost")
               ; ("description", `String "Currently connected host")
               ; ("type", `String "HostRef")
               ]


### PR DESCRIPTION
CP-49707: Go SDK: Add JSON tag for structs

This aims to allow a Go SDK client to unmarshal JSON to Go structs with
the function in Go json pacakge instead of using Go SDK.

The unmarshalling in Go SDK contains two steps: JSON -> map -> struct.
This is because some special cases need to be handled explicitly.
But for sake of safety, this unmarshalling is not exposed to clients.

CP-49349: Go SDK: Append UTC timezone to unix timestamp

The date time in Go requires a date time with timezone info. But XAPI
may return a UNIX timestamp to clients.

This commit blindly adds a UTC timezone for UNIX timestamps returned
from XAPI server.

CP-49349: Go SDK: Allow spaces in special value of float type

Some special values of float standing in JSON are handled specifically.
This commit allows the special values contain spaces.