### PR TITLE
CP-48011: Xapi Support anti-affinity feature flag

### DIFF
--- a/ocaml/xapi-types/features.ml
+++ b/ocaml/xapi-types/features.ml
@@ -64,7 +64,7 @@ type feature =
   | Updates
   | Internal_repo_access
   | VTPM
-  | VM_group
+  | VM_groups
 [@@deriving rpc]
 
 type orientation = Positive | Negative
@@ -133,7 +133,7 @@ let keys_of_features =
     , ("restrict_internal_repo_access", Negative, "Internal_repo_access")
     )
   ; (VTPM, ("restrict_vtpm", Negative, "VTPM"))
-  ; (VM_group, ("restrict_vm_group", Negative, "VM_group"))
+  ; (VM_groups, ("restrict_vm_groups", Negative, "VM_groups"))
   ]
 
 (* A list of features that must be considered "enabled" by `of_assoc_list`

--- a/ocaml/xapi-types/features.mli
+++ b/ocaml/xapi-types/features.mli
@@ -72,7 +72,7 @@ type feature =
   | Internal_repo_access
       (** Enable restriction on repository access to pool members only *)
   | VTPM  (** Support VTPM device required by Win11 guests *)
-  | VM_group  (** Enable use of VM group *)
+  | VM_groups  (** Enable use of VM groups *)
 
 val feature_of_rpc : Rpc.t -> feature
 (** Convert RPC into {!feature}s *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1442,7 +1442,7 @@ let set_appliance ~__context ~self ~value =
   update_allowed_operations ~__context ~self
 
 let set_groups ~__context ~self ~value =
-  Pool_features.assert_enabled ~__context ~f:Features.VM_group ;
+  Pool_features.assert_enabled ~__context ~f:Features.VM_groups ;
   if
     Db.VM.get_is_control_domain ~__context ~self
     || Db.VM.get_is_a_template ~__context ~self

--- a/ocaml/xapi/xapi_vm_group.ml
+++ b/ocaml/xapi/xapi_vm_group.ml
@@ -15,7 +15,7 @@
 module D = Debug.Make (struct let name = "xapi_vm_group" end)
 
 let create ~__context ~name_label ~name_description ~placement =
-  Pool_features.assert_enabled ~__context ~f:Features.VM_group ;
+  Pool_features.assert_enabled ~__context ~f:Features.VM_groups ;
   let uuid = Uuidx.make () in
   let ref = Ref.make () in
   Db.VM_group.create ~__context ~ref ~uuid:(Uuidx.to_string uuid) ~name_label

--- a/ocaml/xapi/xapi_vm_group_helpers.ml
+++ b/ocaml/xapi/xapi_vm_group_helpers.ml
@@ -139,7 +139,7 @@ let update_vm_anti_affinity_alert_for_group ~__context ~group ~alerts =
       ()
 
 let maybe_update_vm_anti_affinity_alert_for_vm ~__context ~vm =
-  if Pool_features.is_enabled ~__context Features.VM_group then
+  if Pool_features.is_enabled ~__context Features.VM_groups then
     try
       Db.VM.get_groups ~__context ~self:vm
       |> List.filter (fun g ->
@@ -186,7 +186,7 @@ let update_alert ~__context ~groups ~action =
   with e -> error "%s" (Printexc.to_string e)
 
 let update_vm_anti_affinity_alert ~__context ~groups =
-  if Pool_features.is_enabled ~__context Features.VM_group then
+  if Pool_features.is_enabled ~__context Features.VM_groups then
     update_alert ~__context ~groups
       ~action:update_vm_anti_affinity_alert_for_group
   else
@@ -200,7 +200,7 @@ let maybe_update_alerts_on_feature_change ~__context ~old_restrictions
     ~new_restrictions =
   try
     let is_enabled restrictions =
-      List.mem Features.VM_group (Features.of_assoc_list restrictions)
+      List.mem Features.VM_groups (Features.of_assoc_list restrictions)
     in
     let groups = Db.VM_group.get_all ~__context in
     match (is_enabled old_restrictions, is_enabled new_restrictions) with

--- a/ocaml/xapi/xapi_vm_group_helpers.mli
+++ b/ocaml/xapi/xapi_vm_group_helpers.mli
@@ -29,7 +29,7 @@ val maybe_update_alerts_on_feature_change :
   -> old_restrictions:(string * string) list
   -> new_restrictions:(string * string) list
   -> unit
-(** Updates the VM anti-affinity alert only when Features.VM_group changes.
+(** Updates the VM anti-affinity alert only when Features.VM_groups changes.
 
     @param __context The context information.
     @param old_restrictions The old feature restrictions represented as an association list.

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -913,7 +913,7 @@ let vm_can_run_on_host ~__context ~vm ~snapshot ~do_memory_check host =
   with _ -> false
 
 let vm_has_anti_affinity ~__context ~vm =
-  if Pool_features.is_enabled ~__context Features.VM_group then
+  if Pool_features.is_enabled ~__context Features.VM_groups then
     List.find_opt
       (fun g -> Db.VM_group.get_placement ~__context ~self:g = `anti_affinity)
       (Db.VM.get_groups ~__context ~self:vm)


### PR DESCRIPTION
1. Rename feature flag VM_group to VM_groups.
2. Add feature check in host evacuation