### PR TITLE
#PR2- CP-47869-Update XAPI code to python3.

### DIFF
--- a/.github/workflows/setup-xapi-environment/action.yml
+++ b/.github/workflows/setup-xapi-environment/action.yml
@@ -27,9 +27,9 @@ runs:
       shell: bash
       run: sudo apt-get update
 
-    - name: Install python2
+    - name: Install python3
       shell: bash
-      run: sudo apt-get install python2
+      run: sudo apt-get install python3
 
     - name: Use disk with more space for TMPDIR and XDG_CACHE_HOME
       shell: bash

--- a/doc/content/xapi/storage/_index.md
+++ b/doc/content/xapi/storage/_index.md
@@ -245,7 +245,7 @@ From this interface we generate
         and appear in the` _build/default/python/xapi/storage/api/v5`
         directory.
     -   On a XenServer host, they are stored in the
-        `/usr/lib/python2.7/site-packages/xapi/storage/api/v5/`
+        `/usr/lib/python3.6/site-packages/xapi/storage/api/v5/`
         directory
 
 ### SMAPIv3 Plugins

--- a/ocaml/doc/wire-protocol.md
+++ b/ocaml/doc/wire-protocol.md
@@ -463,7 +463,7 @@ XML-RPC and JSON-RPC client libraries.
 First, initialise python:
 
 ```bash
-$ python2.7
+$ python3
 >>>
 ```
 

--- a/ocaml/xapi-storage-script/examples/datapath/block/Datapath.activate
+++ b/ocaml/xapi-storage-script/examples/datapath/block/Datapath.activate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 sys.path.append("/home/vagrant/djs55/dbus-test/python")
@@ -17,10 +17,10 @@ if __name__ == "__main__":
     args = vars(parser.parse_args())
 
     if not(args['json']):
-        print "Not implemented"
+        print("Not implemented")
         sys.exit(1)
 
     dispatcher = d.Datapath_server_dispatcher(Implementation())
-    request = json.loads(sys.stdin.readline(),)
+    request = json.loads(sys.stdin.readline())
     results = dispatcher.activate(request)
-    print json.dumps(results)
+    print(json.dumps(results))

--- a/ocaml/xapi-storage-script/examples/datapath/block/Datapath.attach
+++ b/ocaml/xapi-storage-script/examples/datapath/block/Datapath.attach
@@ -1,15 +1,15 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 sys.path.append("/home/vagrant/djs55/dbus-test/python")
 
 import xapi, d
 
-import argparse, json, urlparse
+import argparse, json, urllib.parse
 
 class Implementation(d.Datapath_skeleton):
     def attach(self, dbg, uri, domain):
-        u = urlparse.urlparse(uri)
+        u = urllib.parse.urlparse(uri)
         return {
             'implementations': [ ['XenDisk', {"backend_type":"vbd", "extra":{}, "params":u.path}], ['BlockDevice', {"path":u.path}] ]
         }
@@ -20,10 +20,10 @@ if __name__ == "__main__":
     args = vars(parser.parse_args())
 
     if not(args['json']):
-        print "Not implemented"
+        print("Not implemented")
         sys.exit(1)
 
     dispatcher = d.Datapath_server_dispatcher(Implementation())
-    request = json.loads(sys.stdin.readline(),)
+    request = json.loads(sys.stdin.readline())
     results = dispatcher.attach(request)
-    print json.dumps(results)
+    print(json.dumps(results))

--- a/ocaml/xapi-storage-script/examples/datapath/block/Datapath.deactivate
+++ b/ocaml/xapi-storage-script/examples/datapath/block/Datapath.deactivate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 sys.path.append("/home/vagrant/djs55/dbus-test/python")
@@ -17,10 +17,10 @@ if __name__ == "__main__":
     args = vars(parser.parse_args())
 
     if not(args['json']):
-        print "Not implemented"
+        print("Not implemented")
         sys.exit(1)
 
     dispatcher = d.Datapath_server_dispatcher(Implementation())
-    request = json.loads(sys.stdin.readline(),)
+    request = json.loads(sys.stdin.readline())
     results = dispatcher.deactivate(request)
-    print json.dumps(results)
+    print(json.dumps(results))

--- a/ocaml/xapi-storage-script/examples/datapath/block/Datapath.detach
+++ b/ocaml/xapi-storage-script/examples/datapath/block/Datapath.detach
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 sys.path.append("/home/vagrant/djs55/dbus-test/python")
@@ -17,10 +17,10 @@ if __name__ == "__main__":
     args = vars(parser.parse_args())
 
     if not(args['json']):
-        print "Not implemented"
+        print("Not implemented")
         sys.exit(1)
 
     dispatcher = d.Datapath_server_dispatcher(Implementation())
-    request = json.loads(sys.stdin.readline(),)
+    request = json.loads(sys.stdin.readline())
     results = dispatcher.detach(request)
-    print json.dumps(results)
+    print(json.dumps(results))

--- a/ocaml/xapi-storage/python/Makefile
+++ b/ocaml/xapi-storage/python/Makefile
@@ -1,5 +1,5 @@
 PREFIX?=/usr
-PYTHON?=python2
+PYTHON?=python3
 
 .PHONY: build release clean install uninstall
 

--- a/ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py
+++ b/ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Copyright (C) Citrix Systems Inc.
+# Copyright (C) Cloud Software Group.
 #
 # This program is free software; you can redistribute it and/or modify 
 # it under the terms of the GNU Lesser General Public License as published 
@@ -15,10 +15,10 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-from __future__ import print_function
+
 import os
 import sys
-import urlparse
+import urllib.parse
 
 import xapi.storage.api.v5.datapath
 from xapi.storage.common import call
@@ -64,8 +64,8 @@ class Implementation(xapi.storage.api.v5.datapath.Datapath_skeleton):
         pass
 
     def attach(self, dbg, uri, domain):
-        parsed_url = urlparse.urlparse(uri)
-        query = urlparse.parse_qs(parsed_url.query)
+        parsed_url = urllib.parse.urlparse(uri)
+        query = urllib.parse.parse_qs(parsed_url.query)
 
         file_path = os.path.realpath(parsed_url.path)
 
@@ -97,7 +97,7 @@ class Implementation(xapi.storage.api.v5.datapath.Datapath_skeleton):
         pass
 
     def detach(self, dbg, uri, domain):
-        parsed_url = urlparse.urlparse(uri)
+        parsed_url = urllib.parse.urlparse(uri)
 
         file_path = os.path.realpath(parsed_url.path)
 

--- a/ocaml/xapi-storage/python/examples/datapath/loop+blkback/plugin.py
+++ b/ocaml/xapi-storage/python/examples/datapath/loop+blkback/plugin.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Copyright (C) Citrix Systems Inc.
+# Copyright (C) Cloud Software Group,Inc.
 #
 # This program is free software; you can redistribute it and/or modify 
 # it under the terms of the GNU Lesser General Public License as published 

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/plugin.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/plugin.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Copyright (C) Citrix Systems Inc.
+# Copyright (C) Cloud Software Group, Inc.
 #
 # This program is free software; you can redistribute it and/or modify 
 # it under the terms of the GNU Lesser General Public License as published 

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/sr.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/sr.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Copyright (C) Citrix Systems Inc.
+# Copyright (C) Cloud Software Group, Inc.
 #
 # This program is free software; you can redistribute it and/or modify 
 # it under the terms of the GNU Lesser General Public License as published 
@@ -18,8 +18,8 @@
 from __future__ import print_function
 import os
 import sys
-import urllib
-import urlparse
+import urllib.request, urllib.parse, urllib.error
+import urllib.parse
 
 import xapi.storage.api.v5.volume
 from xapi import InternalError
@@ -66,12 +66,12 @@ class Implementation(SR_skeleton):
         # As a simple "stateless" implementation, encode all the
         # configuration into the URI returned. This is passed back
         # into volume interface APIs and the stat and ls operations.
-        return urlparse.urlunparse((
+        return urllib.parse.urlunparse((
             'file',
             '',
             configuration['path'],
             '',
-            urllib.urlencode(configuration, True),
+            urllib.parse.urlencode(configuration, True),
             None))
 
     def detach(self, dbg, sr):
@@ -96,8 +96,8 @@ class Implementation(SR_skeleton):
         [stat sr] returns summary metadata associated with [sr]. Note this
         call does not return details of sub-volumes, see SR.ls.
         """
-        parsed_url = urlparse.urlparse(sr)
-        config = urlparse.parse_qs(parsed_url.query)
+        parsed_url = urllib.parse.urlparse(sr)
+        config = urllib.parse.parse_qs(parsed_url.query)
 
         description = (config['description'][0]
                        if 'description' in config

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/sr.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/sr.py
@@ -18,8 +18,9 @@
 from __future__ import print_function
 import os
 import sys
-import urllib.request, urllib.parse, urllib.error
+import urllib.request
 import urllib.parse
+import urllib.error
 
 import xapi.storage.api.v5.volume
 from xapi import InternalError

--- a/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/volume.py
+++ b/ocaml/xapi-storage/python/examples/volume/org.xen.xapi.storage.simple-file/volume.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Copyright (C) Citrix Systems Inc.
+# Copyright (C) Cloud Software Group, Inc.
 #
 # This program is free software; you can redistribute it and/or modify 
 # it under the terms of the GNU Lesser General Public License as published 
@@ -21,8 +21,9 @@ import json
 import os
 import sys
 import uuid
-import urllib
-import urlparse
+import urllib.request
+import urllib.parse
+import urllib.error
 
 import xapi.storage.api.v5.volume
 from xapi.storage import log
@@ -31,8 +32,8 @@ from xapi.storage import log
 class Implementation(xapi.storage.api.v5.volume.Volume_skeleton):
 
     def parse_sr(self, sr_uri):
-        parsed_url = urlparse.urlparse(sr_uri)
-        config = urlparse.parse_qs(parsed_url.query)
+        parsed_url = urllib.parse.urlparse(sr_uri)
+        config = urllib.parse.parse_qs(parsed_url.query)
         return parsed_url, config
 
     def create_volume_data(self, name, description, size, uris, uuid):
@@ -50,8 +51,8 @@ class Implementation(xapi.storage.api.v5.volume.Volume_skeleton):
         }
 
     def volume_uris(self, sr_path, name, size):
-        query = urllib.urlencode({'size': size}, True)
-        return [urlparse.urlunparse(
+        query = urllib.parse.urlencode({'size': size}, True)
+        return [urllib.parse.urlunparse(
             ('loop+blkback', None, os.path.join(sr_path, name),
              None, query, None))]
 
@@ -187,7 +188,7 @@ class Implementation(xapi.storage.api.v5.volume.Volume_skeleton):
         """
         [ls sr] lists the volumes from [sr]
         """
-        parsed_url = urlparse.urlparse(sr)
+        parsed_url = urllib.parse.urlparse(sr)
         sr_path = parsed_url.path
         files = glob.glob(os.path.join(sr_path, '*.inf'))
         log.debug('files to list {}'.format(files))

--- a/ocaml/xapi-storage/python/xapi/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/__init__.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
-Copyright (c) 2013-2018, Citrix Inc.
+Copyright (c) 2013-2024, Cloud Software Group,Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/ocaml/xapi-storage/python/xapi/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/__init__.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """
-Copyright (c) 2013-2018, Citrix Inc.
+Copyright (c) 2013-2024, Cloud Software Group,Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -72,7 +72,7 @@ class XenAPIException(Exception):
 
     def __init__(self, code, params):
         Exception.__init__(self)
-        if not isinstance(code, str) and not isinstance(code, unicode):
+        if not isinstance(code, str) and not isinstance(code, str):
             raise TypeError("string", repr(code))
         if not isinstance(params, list):
             raise TypeError("list", repr(params))
@@ -139,7 +139,7 @@ class UnknownMethod(InternalError):
 
 def is_long(x):
     try:
-        long(x)
+        int(x)
         return True
     except ValueError:
         return False

--- a/ocaml/xapi-storage/python/xapi/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/__init__.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 
 """
-Copyright (c) 2013-2024, Cloud Software Group,Inc.
+Copyright (c) 2013-2018, Citrix Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -72,7 +72,7 @@ class XenAPIException(Exception):
 
     def __init__(self, code, params):
         Exception.__init__(self)
-        if not isinstance(code, str) and not isinstance(code, str):
+        if not isinstance(code, str) and not isinstance(code, unicode):
             raise TypeError("string", repr(code))
         if not isinstance(params, list):
             raise TypeError("list", repr(params))
@@ -139,7 +139,7 @@ class UnknownMethod(InternalError):
 
 def is_long(x):
     try:
-        int(x)
+        long(x)
         return True
     except ValueError:
         return False

--- a/ocaml/xapi-storage/python/xapi/storage/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/storage/__init__.py
@@ -1,1 +1,1 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3

--- a/ocaml/xapi-storage/python/xapi/storage/api/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/__init__.py
@@ -1,1 +1,1 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3

--- a/ocaml/xapi-storage/python/xapi/storage/api/v5/__init__.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/v5/__init__.py
@@ -1,1 +1,1 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3

--- a/ocaml/xapi-storage/python/xapi/storage/common.py
+++ b/ocaml/xapi-storage/python/xapi/storage/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from xapi.storage import log
 import xapi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,11 +251,9 @@ expected_to_fail = [
     # SSLSocket.send() only accepts bytes, not unicode string as argument:
     "scripts/examples/python/exportimport.py",
     # Other fixes needed:
-    "scripts/examples/python/mini-xenrt.py",
     "scripts/examples/python/XenAPI/XenAPI.py",
     "scripts/examples/python/monitor-unwanted-domains.py",
     "scripts/examples/python/shell.py",
-    "scripts/examples/smapiv2.py",
     "scripts/static-vdis",
     "scripts/plugins/extauth-hook-AD.py",
 ]

--- a/scripts/examples/python/mini-xenrt.py
+++ b/scripts/examples/python/mini-xenrt.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         print("  -- performs parallel operations on VMs with the specified other-config key")
         sys.exit(1)
     
-    x = xmlrpc.client.server(sys.argv[1])
+    x = xmlrpc.client.ServerProxy(sys.argv[1])
     key = sys.argv[2]
     session = x.session.login_with_password("root", "xenroot", "1.0", "xen-api-scripts-minixenrt.py")["Value"]
     vms = x.VM.get_all_records(session)["Value"]

--- a/scripts/examples/python/provision.py
+++ b/scripts/examples/python/provision.py
@@ -107,5 +107,5 @@ if __name__ == "__main__":
     txt2 = printProvisionSpec(ps)
     print(txt2)
     if txt != txt2:
-        raise AssertionError("Sanity-check failed: print(parse(print(x))) <> print(x)")
+        raise AssertionError("Sanity-check failed: print(parse(print(x))) != print(x)")
     print("* OK: print(parse(print(x))) == print(x)")

--- a/scripts/examples/smapiv2.py
+++ b/scripts/examples/smapiv2.py
@@ -13,7 +13,7 @@ def reopenlog(log_file):
     if log_file:
         try:
             log_f = open(log_file, "a")
-        except FilenotFoundError:
+        except FileNotFoundError:
             log_f = open(log_file, "w")
     else:
         log_f = open(os.dup(sys.stdout.fileno()), "a")


### PR DESCRIPTION
Main ticket:CP-47869 -Clean up XAPI code  

Sub task :CP-49681
- Convert the existing code to python3 in XAPI

Split2 from https://github.com/xapi-project/xen-api/pull/5662

Test done in PR 5662 holds good.

Test result -198930 (Dev Run)
Ring0 BST - 8.4.0-206415 (pbb-ashwinh-xapiclean) (repo) run 30 May 2024
Tests Executed (excludes blocked): 47
Tests Failed: 1
Tests Errored: 0
Tests Blocked: 0
Tests Not Executed: 0
Test failed due to production issues: 0
Pass rate (excluding failures due to non product issues): 100.0%
Pass rate (of testcases XenRT was able to resource): 97.9%
Pass rate (of all test cases): 97.9%
Percentage of nightly complete: 100.0%
Tests excluded from numbers: 0


Signed-off-by: Ashwinh <ashwin.h@cloud.com>


@liulinC @stephenchengCloud @psafont 