### PR TITLE
CA-393866: Add support for Infinity in Java SDK parser

### DIFF
--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
@@ -30,6 +30,7 @@
 package com.xensource.xenapi;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -212,6 +213,7 @@ public class JsonRpcClient {
     private void initializeObjectMapperConfiguration() {
         var dateHandlerModule = new SimpleModule("DateHandler");
         dateHandlerModule.addDeserializer(Date.class, new CustomDateDeserializer());
+        this.objectMapper.enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature());
         this.objectMapper.registerModule(dateHandlerModule);
     }
 


### PR DESCRIPTION
Example usage where `Infinity` is reported, corresponding to `Double.POSITIVE_INFINITY` 👇 

![image](https://github.com/xapi-project/xen-api/assets/32554698/1fb0a576-a6fc-44a2-a189-c45955115d56)