### PR TITLE
CA-393507: Default cluster_stack value

### DIFF
--- a/ocaml/xapi-idl/cluster/cluster_interface.ml
+++ b/ocaml/xapi-idl/cluster/cluster_interface.ml
@@ -132,7 +132,7 @@ type cluster_config = {
   ; config_version: int64
   ; cluster_token_timeout_ms: int64
   ; cluster_token_coefficient_ms: int64
-  ; cluster_stack: Cluster_stack.t
+  ; cluster_stack: Cluster_stack.t [@default Corosync2]
 }
 [@@deriving rpcty]
 


### PR DESCRIPTION
Add a `@default` attribute to the `cluster_stack` field in the cluster config. This field was introduced in #c1bd0e31a but causes RPU to fail since it is not optional, and while xapi-clusterd was unmarshalling an old db (which contains cluster config), it cannot find this field, and throws an exception.

Adding `@default` can make the rpc library to fill this field in when it is missing, solving the above problem.

Manul test looks ok, waiting for xrt tests.