### PR TITLE
CA-393119: Don't use HTTPS for localhost migrations

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -380,6 +380,9 @@ let infer_vgpu_map ~__context ?remote vm =
 let pool_migrate ~__context ~vm ~host ~options =
   Pool_features.assert_enabled ~__context ~f:Features.Xen_motion ;
   let dbg = Context.string_of_task __context in
+  let localhost = Helpers.get_localhost ~__context in
+  if host = localhost then
+    info "This is a localhost migration" ;
   let open Xapi_xenops_queue in
   let queue_name = queue_of_vm ~__context ~self:vm in
   let module XenopsAPI = (val make_client queue_name : XENOPS) in
@@ -395,11 +398,14 @@ let pool_migrate ~__context ~vm ~host ~options =
         .assert_valid_ip_configuration_on_network_for_host ~__context
           ~self:network ~host
   in
-  let compress =
-    use_compression ~__context options (Helpers.get_localhost ~__context) host
-  in
+  let compress = use_compression ~__context options localhost host in
   debug "%s using stream compression=%b" __FUNCTION__ compress ;
-  let http = if !Xapi_globs.migration_https_only then "https" else "http" in
+  let http =
+    if !Xapi_globs.migration_https_only && host <> localhost then
+      "https"
+    else
+      "http"
+  in
   let xenops_url =
     Uri.(
       make ~scheme:http ~host:address ~path:"/services/xenops"


### PR DESCRIPTION
This is unnecessary overhead for traffic that does not actually hit the network.