### PR TITLE
Link just qcheck-core, not qcheck

### DIFF
--- a/ocaml/libs/sexpr/test/dune
+++ b/ocaml/libs/sexpr/test/dune
@@ -1,4 +1,4 @@
 (test
  (name test_sexpr)
  (modules test_sexpr)
- (libraries sexpr astring rresult qcheck alcotest threads))
+ (libraries sexpr astring rresult qcheck-core alcotest threads))

--- a/sexpr.opam.template
+++ b/sexpr.opam.template
@@ -11,6 +11,7 @@ depends: [
   "ocaml"
   "dune"
   "astring"
+  "qcheck-core" {with-test}
   "xapi-stdext-threads"
 ]
 synopsis: "Library required by xapi"

--- a/wsproxy.opam
+++ b/wsproxy.opam
@@ -22,7 +22,7 @@ depends: [
   "re"
   "uuid"
   "ounit2" {with-test}
-  "qcheck" {with-test}
+  "qcheck-core" {with-test}
 ]
 tags: [ "org:xapi-project" ]
 synopsis: "Websockets proxy for VNC traffic"

--- a/wsproxy.opam.template
+++ b/wsproxy.opam.template
@@ -20,7 +20,7 @@ depends: [
   "re"
   "uuid"
   "ounit2" {with-test}
-  "qcheck" {with-test}
+  "qcheck-core" {with-test}
 ]
 tags: [ "org:xapi-project" ]
 synopsis: "Websockets proxy for VNC traffic"


### PR DESCRIPTION
qcheck is in the wrong part of xs-opam currently, and although we're moving it this test really only needs qcheck-core, so link only that to fix an internal CI failure.