### PR TITLE
Several fixes for XenServer SDK for Go

### DIFF
--- a/ocaml/sdk-gen/go/README.md
+++ b/ocaml/sdk-gen/go/README.md
@@ -48,12 +48,12 @@ Extract the contents of this archive.
 
 A. Navigate to the extracted `XenServer-SDK\XenServerGo\src` directory and copy the whole folder `src` into your Go project directory.
 
-B. To use XenServer Go SDK as a local Go module, update one line into the `go.mod` file under your Go project:
+B. To use the XenServer SDK for Go as a local Go module, include the following line into the `go.mod` file under your Go project:
 
 ```
 replace xenapi => ./src
 ```
-You can then import this XenServer SDK Go module with the following command:
+You can then import the XenServer SDK for Go with the following command:
 
 ```
 import "xenapi"

--- a/ocaml/sdk-gen/go/autogen/src/jsonrpc_client.go
+++ b/ocaml/sdk-gen/go/autogen/src/jsonrpc_client.go
@@ -1,3 +1,32 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package xenapi
 
 import (

--- a/ocaml/sdk-gen/go/gen_go_binding.ml
+++ b/ocaml/sdk-gen/go/gen_go_binding.ml
@@ -17,7 +17,7 @@ open Gen_go_helper
 let render_enums enums destdir =
   let header =
     render_template "FileHeader.mustache"
-      (`O [("modules", `Null)])
+      (`O [("modules", `Null); licence])
       ~newline:true ()
   in
   let enums = render_template "Enum.mustache" enums () |> String.trim in
@@ -36,6 +36,7 @@ let render_api_versions destdir =
             ; ("items", `A (List.map name ["errors"; "fmt"]))
             ]
         )
+      ; licence
       ]
   in
   let rendered =
@@ -55,6 +56,7 @@ let render_api_messages_and_errors destdir =
         ("api_errors", `A Json.api_errors)
       ; ("api_messages", `A Json.api_messages)
       ; ("modules", `Null)
+      ; licence
       ]
   in
   let header = render_template "FileHeader.mustache" obj ~newline:true () in
@@ -83,6 +85,7 @@ let render_convert_header () =
               )
             ]
         )
+      ; licence
       ]
   in
   render_template "FileHeader.mustache" obj ~newline:true ()

--- a/ocaml/sdk-gen/go/gen_go_helper.ml
+++ b/ocaml/sdk-gen/go/gen_go_helper.ml
@@ -22,6 +22,8 @@ let templates_dir = "templates"
 
 let ( // ) = Filename.concat
 
+let licence = ("licence", `String Licence.bsd_two_clause)
+
 let acronyms =
   [
     "id"
@@ -479,6 +481,7 @@ module Json = struct
           ; ("modules", modules)
           ; ("messages", `A (messages_of_obj obj))
           ; ("option", `A (of_options types))
+          ; licence
           ]
         in
         let assoc_list = base_assoc_list @ get_event_session_value obj.name in

--- a/ocaml/sdk-gen/go/gen_go_helper.mli
+++ b/ocaml/sdk-gen/go/gen_go_helper.mli
@@ -13,6 +13,8 @@
 
 val ( // ) : string -> string -> string
 
+val licence : string * Mustache.Json.value
+
 val snake_to_camel : ?internal:bool -> string -> string
 
 val render_template :

--- a/ocaml/sdk-gen/go/templates/FileHeader.mustache
+++ b/ocaml/sdk-gen/go/templates/FileHeader.mustache
@@ -1,3 +1,5 @@
+{{{licence}}}
+
 package xenapi
 {{#modules}}
 {{#import}}

--- a/ocaml/sdk-gen/go/templates/FileHeader.mustache
+++ b/ocaml/sdk-gen/go/templates/FileHeader.mustache
@@ -1,5 +1,4 @@
 {{{licence}}}
-
 package xenapi
 {{#modules}}
 {{#import}}

--- a/ocaml/sdk-gen/go/templates/Methods.mustache
+++ b/ocaml/sdk-gen/go/templates/Methods.mustache
@@ -8,10 +8,10 @@
 {{#errors}}
 // {{name}} - {{doc}}
 {{/errors}}
-func ({{name_internal}}) {{method_name_exported}}({{#params}}{{#first}}session *Session{{/first}}{{^first}}, {{name_internal}} {{type}}{{/first}}{{/params}}) ({{#result}}retval {{type}}, {{/result}}err error) {
+func ({{name_internal}}) {{method_name_exported}}({{func_params}}) ({{#result}}retval {{type}}, {{/result}}err error) {
 	method := "{{class_name}}.{{method_name}}"
 {{#params}}
-	{{name_internal}}Arg, err := serialize{{func_name_suffix}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{#first}}session.ref{{/first}}{{^first}}{{name_internal}}{{/first}})
+	{{name_internal}}Arg, err := serialize{{func_name_suffix}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{name_in_serialize_call}})
 	if err != nil {
 		return
 	}
@@ -36,10 +36,10 @@ func ({{name_internal}}) {{method_name_exported}}({{#params}}{{#first}}session *
 {{#errors}}
 // {{name}} - {{doc}}
 {{/errors}}
-func ({{name_internal}}) Async{{method_name_exported}}({{#params}}{{#first}}session *Session{{/first}}{{^first}}, {{name_internal}} {{type}}{{/first}}{{/params}}) (retval TaskRef, err error) {
+func ({{name_internal}}) Async{{method_name_exported}}({{func_params}}) (retval TaskRef, err error) {
 	method := "Async.{{class_name}}.{{method_name}}"
 {{#params}}
-	{{name_internal}}Arg, err := serialize{{func_name_suffix}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{#first}}session.ref{{/first}}{{^first}}{{name_internal}}{{/first}})
+	{{name_internal}}Arg, err := serialize{{func_name_suffix}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{name_in_serialize_call}})
 	if err != nil {
 		return
 	}

--- a/ocaml/sdk-gen/go/templates/SessionMethod.mustache
+++ b/ocaml/sdk-gen/go/templates/SessionMethod.mustache
@@ -8,10 +8,10 @@
 {{#errors}}
 // {{name}} - {{doc}}
 {{/errors}}
-func (class *Session) {{method_name_exported}}({{#func_params}}{{^first}}, {{/first}}{{name_internal}} {{type}}{{/func_params}}) ({{#result}}retval {{type}}, {{/result}}err error) {
+func (class *Session) {{method_name_exported}}({{func_params}}) ({{#result}}retval {{type}}, {{/result}}err error) {
 	method := "{{class_name}}.{{method_name}}"
 {{#params}}
-	{{name_internal}}Arg, err := serialize{{func_name_suffix}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{#is_session_id}}class.ref{{/is_session_id}}{{^is_session_id}}{{name_internal}}{{/is_session_id}})
+	{{name_internal}}Arg, err := serialize{{func_name_suffix}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{name_in_serialize_call}})
 	if err != nil {
 		return
 	}
@@ -46,10 +46,10 @@ func (class *Session) {{method_name_exported}}({{#func_params}}{{^first}}, {{/fi
 {{#errors}}
 // {{name}} - {{doc}}
 {{/errors}}
-func (class *Session) Async{{method_name_exported}}({{#func_params}}{{^first}}, {{/first}}{{name_internal}} {{type}}{{/func_params}}) (retval TaskRef, err error) {
+func (class *Session) Async{{method_name_exported}}({{func_params}}) (retval TaskRef, err error) {
 	method := "Async.{{class_name}}.{{method_name}}"
 {{#params}}
-	{{name_internal}}Arg, err := serialize{{func_name_suffix}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{#is_session_id}}class.ref{{/is_session_id}}{{^is_session_id}}{{name_internal}}{{/is_session_id}})
+	{{name_internal}}Arg, err := serialize{{func_name_suffix}}(fmt.Sprintf("%s(%s)", method, "{{name}}"), {{name_in_serialize_call}})
 	if err != nil {
 		return
 	}

--- a/ocaml/sdk-gen/go/test_data/file_header.go
+++ b/ocaml/sdk-gen/go/test_data/file_header.go
@@ -1,3 +1,32 @@
+/*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1) Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2) Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials
+ *      provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package xenapi
 
 import (

--- a/ocaml/sdk-gen/go/test_gen_go.ml
+++ b/ocaml/sdk-gen/go/test_gen_go.ml
@@ -592,6 +592,7 @@ let header : Mustache.Json.t =
             )
           ]
       )
+    ; ("licence", `String Licence.bsd_two_clause)
     ]
 
 let enums : Mustache.Json.t =


### PR DESCRIPTION
Based on the comments in https://github.com/xapi-project/xen-api/pull/5679, following changes are in this series:
1. Fix phrasing in readme
2. Add licence text on top of Go source files
3. Remove template variables 'first' and 'is_session_id'