### PR TITLE
Makefile: fix compatibility with the dash shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test:
 	ulimit -S -t $(TEST_TIMEOUT); \
 	 (sleep $(TEST_TIMEOUT) && ps -ewwlyF --forest)& \
 	 PSTREE_SLEEP_PID=$$!; \
-	 trap "kill $${PSTREE_SLEEP_PID}" SIGINT SIGTERM EXIT; \
+	 trap "kill $${PSTREE_SLEEP_PID}" INT TERM EXIT; \
 	 timeout --foreground $(TEST_TIMEOUT2) \
 		 dune runtest --profile=$(PROFILE) --error-reporting=twice -j $(JOBS)
 ifneq ($(PY_TEST), NO)


### PR DESCRIPTION
Github CI runs the makefile using SHELL=/bin/dash, which doesn't support SIG* names for traps.
Drop the SIG prefix, which works with both `dash` and `bash`.

Avoid a `trap: SIGINT: bad trap` message in the CI. AFAICT it doesn't have other harmful effects, but lets avoid it.