### PR TITLE
CP-49934-Remove python2.7 test coverage.

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -55,6 +55,7 @@ jobs:
           --cov-report xml:.git/coverage${{matrix.python-version}}.xml
 
       - name: Upload Python ${{matrix.python-version}} coverage report to Codecov
+        if: ${{ matrix.python-version != '2.7' }}
         uses: codecov/codecov-action@v3
         with:
           directory: .git


### PR DESCRIPTION
Main task : CP-49100- Move all scripts from scripts folder to python3 folder and modify Makefile to include these changes.

Subtask: CP-49934 -Remove python2.7 test upload coverage as we don't require this anymore for python3 code.

 Signed-off-by: Ashwinh <ashwin.h@cloud.com>

@psafont @liulinC @stephenchengCloud 