### PR TITLE
rpm: remove `sexprpp` from public_name

### DIFF
--- a/ocaml/libs/sexpr/dune
+++ b/ocaml/libs/sexpr/dune
@@ -17,8 +17,6 @@
 (executable
   (modes exe)
   (name sexprpp)
-  (public_name sexprpp)
-  (package sexpr)
   (modules sexprpp)
   (libraries
     sexpr

--- a/ocaml/libs/sexpr/test/dune
+++ b/ocaml/libs/sexpr/test/dune
@@ -1,4 +1,5 @@
 (test
  (name test_sexpr)
+ (package sexpr)
  (modules test_sexpr)
  (libraries sexpr astring rresult qcheck-core alcotest threads))

--- a/sexpr.opam
+++ b/sexpr.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml"
   "dune"
   "astring"
+  "qcheck-core" {with-test}
   "xapi-stdext-threads"
 ]
 synopsis: "Library required by xapi"


### PR DESCRIPTION
Remove `package` and `public_name` stanzas for `sexprpp` executable.