### PR TITLE
Hugo docs: Enable dark mode support and PR review of Hugo doc updates on GH Pages of clone repos

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -2,12 +2,19 @@ name: Generate and upload Hugo docs
 
 on:
   push:
-    branches: master
+
+# Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages for doc reviews
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  ocaml:
+  hugo:
     name: Docs
     runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
       - name: Checkout code
@@ -18,13 +25,19 @@ jobs:
         with:
           hugo-version: '0.127.0'
 
-      - name: Build
+      - name: Build with defaults from doc/hugo.yml for the xapi-project/xen-api master
+        if: |
+          github.repository == 'xapi-project/xen-api' &&
+          github.ref == 'refs/heads/master'
         run: |
           cd doc
           hugo --minify
 
-      - name: Deploy
+      - name: Deploy xapi-project/xen-api master to https://xapi-project.github.io/new-docs
         uses: peaceiris/actions-gh-pages@v4
+        if: |
+          github.repository == 'xapi-project/xen-api' &&
+          github.ref == 'refs/heads/master'
         with:
           deploy_key: ${{ secrets.ACTIONS_DOCS_DEPLOY_KEY }}
           publish_dir: ./doc/public
@@ -35,3 +48,29 @@ jobs:
           destination_dir: new-docs # temporary staging branch
           allow_empty_commit: false
           enable_jekyll: true # do not create .nojekyll file
+
+      - name: Build to deploy to a clone's GitHub Pages for documentation update reviews
+        if: github.repository != 'xapi-project/xen-api'
+        env:
+          # Override the Hugo baseUrl in doc/hugo.toml with the repo name for doc reviews:
+          HUGO_BASEURL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
+        run: cd doc;hugo --minify
+
+      - name: Upload Hugo static site as an artifact for documentation update reviews
+        if: github.repository != 'xapi-project/xen-api'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./doc/public
+
+  # When pushed to other repositories, deploy to the repository's GitHub Pages
+  deploy:
+    needs: hugo
+    if: github.repository != 'xapi-project/xen-api'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy uploaded artifact to GitHub Pages for documentation update reviews
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.119.0'
+          hugo-version: '0.127.0'
 
       - name: Build
         run: |

--- a/doc/hugo.toml
+++ b/doc/hugo.toml
@@ -9,10 +9,32 @@ assetsDir = "assets"
 [[module.imports]]
     path = 'github.com/McShelby/hugo-theme-relearn'
 
+# The latest upstream version of hugo-theme-relearn needs hugo 0.121.0:
+# https://mcshelby.github.io/hugo-theme-relearn/basics/requirements/index.html
+[module.hugoVersion]
+    min = "0.121.0"
+
 [outputs]
-home = [ "HTML", "RSS", "SEARCH"]
+# Home and section pages should also have a print icon for the print view:
+home = [ "HTML", "RSS", "SEARCH", "PRINT"]
+section = [ "HTML", "RSS", "PRINT"]
 
 [params]
-themeVariant = "red"
+# Enable the theme variant selector, default to auto:
+themeVariant = [
+    "auto",
+    "zen-light",
+    "zen-dark",
+    "red",
+    "blue",
+    "green",
+    "learn",
+    "neon",
+    "relearn-light",
+    "relearn-bright",
+    "relearn-dark"
+]
+# auto switches between "red" and "zen-dark" depending on the browser/OS dark mode:
+themeVariantAuto = ["red", "zen-dark"]
 alwaysopen = false
 collapsibleMenu = true


### PR DESCRIPTION
Hello @robhoes,

this PR submits two commits to the Hugo documentation site for review:

Commit 1:
- [Hugo docs: Enable dark mode support and choosing the theme variant](https://github.com/xapi-project/xen-api/commit/97653bb8c1571bb3002ab79a58cd11e0f9079c31)
  - You can test it on this site for review: https://xenserver-next.github.io/xen-api/

  Not needed for it but recommended, I think:
  - As https://mcshelby.github.io/hugo-theme-relearn/basics/requirements/index.html says that the latest version of https://mcshelby.github.io/hugo-theme-relearn/ needs Hugo 0.121.0, I suggest defining it as the minimum Hugo version in `hugo.toml`.
  - I also updated the version used for deployment to GitHub pages to the current version of Hugo (0.127.0)
  - Enabled the print icon for printing the site, see below.

Commit 2:
- [Hugo docs: Support reviews of Hugo updates by publishing to a clone's gh-pages](https://github.com/xapi-project/xen-api/commit/7260518af2da4cfb125bc608362b9ceff0390c1f)
  - This commit publishes the Hugo doc site for review to https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/, which is https://xenserver-next.github.io/xen-api/ for this PR.
  - This upload is only enabled for other site besides https://github.com/xapi-project/xen-api
    - The deployment to https://xapi-project.github.io/new-docs/ should not be influenced by this PR.

You can review the combined result of this PR at: https://xenserver-next.github.io/xen-api/

This is how it looks in e.g. https://github.com/xenserver-next/xen-api/actions/runs/9551625367:
![image](https://github.com/xapi-project/xen-api/assets/43588962/954c1f11-6681-434d-bbe5-f2f63f369518)

With this, if the web browser or the OS specifies dark mode, the theme honors it.
In this configuration, it switches to the `zen-dark` variant of the theme by default, unless you switch to a fixed theme variant using the theme selector at the bottom of the left sidebar:

Except for a few minor dark mode theming issues from some graphics, the dark mode looks perfectly fine:
![image](https://github.com/xapi-project/xen-api/assets/43588962/82bc77d4-807a-472b-a633-713ffcae752e)

If dark mode is not selected by the OS or the browser, the auto theme switch continues to use the red theme variant, so no change in this case, except that you can now select a different theme variant if you want.

And I enabled the `print` support in Hugo for the home page and the section pages, so you can print the entire documentation site, which the case of the home page print, prints all pages, in which case, you get a printout of 273 pages PDF in A4. :)