### PR TITLE
CA-394343: After clock jump the xapi assumed the host is HOST_OFFLINE

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -707,7 +707,7 @@ let snapshot_with_quiesce_timeout = ref 600.
 let host_heartbeat_interval = ref 30.
 
 (* If we haven't heard a heartbeat from a host for this interval then the host is assumed dead *)
-let host_assumed_dead_interval = ref 600.0
+let host_assumed_dead_interval = ref Mtime.Span.(10 * min)
 
 (* If a session has a last_active older than this we delete it *)
 let inactive_session_timeout = ref 86400. (* 24 hrs in seconds *)
@@ -1070,7 +1070,9 @@ let xapi_globs_spec =
   ; ("wait_memory_target_timeout", Float wait_memory_target_timeout)
   ; ("snapshot_with_quiesce_timeout", Float snapshot_with_quiesce_timeout)
   ; ("host_heartbeat_interval", Float host_heartbeat_interval)
-  ; ("host_assumed_dead_interval", Float host_assumed_dead_interval)
+  ; ( "host_assumed_dead_interval"
+    , LongDurationFromSeconds host_assumed_dead_interval
+    )
   ; ("fuse_time", Float Constants.fuse_time)
   ; ("db_restore_fuse_time", Float Constants.db_restore_fuse_time)
   ; ("inactive_session_timeout", Float inactive_session_timeout)

--- a/ocaml/xapi/xapi_ha.ml
+++ b/ocaml/xapi/xapi_ha.ml
@@ -837,7 +837,7 @@ module Monitor = struct
                   (ExnHelper.string_of_exn e) ;
                 Thread.delay !Xapi_globs.ha_monitor_interval
             done ;
-            debug "Re-enabling old Host_metrics.live heartbeat" ;
+            debug "Re-enabling host heartbeat" ;
             with_lock Db_gc.use_host_heartbeat_for_liveness_m (fun () ->
                 Db_gc.use_host_heartbeat_for_liveness := true
             ) ;


### PR DESCRIPTION
Prior to this commit, the xapi on the coordinator host records the 'Unix.gettimeofday' as the timestamps of the heartbeat with other pool supporter hosts. When the system clock is updated with a huge jump forward, the timestamps would be far back into the past. This would cause the xapi assumes that the hosts are offline as long time no heartbeats.

In this commit, the timestamps are changed to get from a monotonic clock. In this way, the system clock changes will not impact the heartbeats' timestamps any more.

Additionally, Host_metrics.last_updated is only set when the object is created. It's useless in check_host_liveness at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xen-api/5700)
<!-- Reviewable:end -->
