### PR TITLE
CA-394444: `hard_shutdown` stuck behind a `pending` `shutdown`

### DIFF
--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -118,6 +118,7 @@ let vm_operation_table =
   ; (`changing_NVRAM, "changing_NVRAM")
   ; (`start, "start")
   ; (`start_on, "start_on")
+  ; (`shutdown, "shutdown")
   ; (`suspend, "suspend")
   ; (`unpause, "unpause")
   ; (`update_allowed_operations, "update_allowed_operations")

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2126,6 +2126,7 @@ functor
                 ; `hard_reboot
                 ; `pool_migrate
                 ; `call_plugin
+                ; `shutdown
                 ; `suspend
                 ] ;
             (* If VM is actually suspended and we ask to hard_shutdown, we need to


### PR DESCRIPTION
`VM.hard_shutdown` does not cancel `VM.shutdown` operations. 

In the case of losing the session during a failed `VM.shutdown`, we cannot recover with `VM.hard_shutdown` as it is not in the list of operations that are to be cancelled.
These results in VM hanging until the requests time out.

Moreover, `VM.shutdowm` is missing from the `vm_operation_table` resulting in it being incorrectly displayed as `(unknown operation)`.