### PR TITLE
Hugo docs: Add dark mode support, theme variant selector and print

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.119.0'
+          hugo-version: '0.127.0'
 
       - name: Build
         run: |

--- a/doc/hugo.toml
+++ b/doc/hugo.toml
@@ -9,10 +9,32 @@ assetsDir = "assets"
 [[module.imports]]
     path = 'github.com/McShelby/hugo-theme-relearn'
 
+# The latest upstream version of hugo-theme-relearn needs hugo 0.121.0:
+# https://mcshelby.github.io/hugo-theme-relearn/basics/requirements/index.html
+[module.hugoVersion]
+    min = "0.121.0"
+
 [outputs]
-home = [ "HTML", "RSS", "SEARCH"]
+# Home and section pages should also have a print icon for the print view:
+home = [ "HTML", "RSS", "SEARCH", "PRINT"]
+section = [ "HTML", "RSS", "PRINT"]
 
 [params]
-themeVariant = "red"
+# Enable the theme variant selector, default to auto:
+themeVariant = [
+    "auto",
+    "zen-light",
+    "zen-dark",
+    "red",
+    "blue",
+    "green",
+    "learn",
+    "neon",
+    "relearn-light",
+    "relearn-bright",
+    "relearn-dark"
+]
+# auto switches between "red" and "zen-dark" depending on the browser/OS dark mode:
+themeVariantAuto = ["red", "zen-dark"]
 alwaysopen = false
 collapsibleMenu = true


### PR DESCRIPTION
Remark:
Same #5702 (closed), but for master (because it had nothing to do with py3 and had an unrelated CI failure)

Thanks everyone for all the reviews and tips for #5698!

In https://github.com/xapi-project/xen-api/pull/5698#issuecomment-2175713287 there was some doubt (or maybe just misunderstanding) on the second commit of #5698 for publishing a preview of the docs on the clone repo's GitHub pages (will only be published if the GitHub pages are configured to be published from GitHub actions, not from the `gh-pages` branch).

In any case, the two commits of #5698 are no dependent on each other, so this submits only the first commits of it for review.
- https://github.com/xapi-project/xen-api/pull/5698#issuecomment-2175397658 and 
- https://github.com/xapi-project/xen-api/pull/5698#issuecomment-2175424146
are two review comments with hints on the issues that exist in the print view and the dark mode at some places.

Thanks for the hints on fixing or working around these issues!

I cannot incorporate them in this PR at the moment because I'll be on PTO until Monday.

But if you merge (or otherwise approve - does not have to be now - the) enabling the selection of the theme variants (independent on if you include the auto switch to dark mode by default using the "auto" variant), we can make the fixes for those locations over time.

You can also close this PR if you like to have either the dark mode or print view issues fixed before enabling the automatic dark mode, all of that is fine of course.

I only opened these PRs because I saw the possibility to make these features of the theme available.

I'll (tentatively) close #5698 and to focus on this PR for now.