### PR TITLE
epoll: introduce test-open and improve logging on failure in xapi startup and database. code

### DIFF
--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -271,7 +271,7 @@ let do_db_xml_rpc_persistent_with_reopen ~host:_ ~path (req : string) :
           !Db_globs.permanent_master_failure_retry_interval ;
         Thread.delay !Db_globs.permanent_master_failure_retry_interval ;
         !Db_globs.restart_fn ()
-    | e -> (
+    | e ->
         error "Caught %s" (Printexc.to_string e) ;
         (* RPC failed - there's no way we can recover from this so try reopening connection every 2s + backoff delay *)
         ( match !my_connection with
@@ -322,9 +322,7 @@ let do_db_xml_rpc_persistent_with_reopen ~host:_ ~path (req : string) :
           debug "%s: Sleep interrupted, retrying master connection now"
             __FUNCTION__ ;
         update_backoff_delay () ;
-        try open_secure_connection () with _ -> ()
-        (* oh well, maybe nextime... *)
-      )
+        D.log_and_ignore_exn open_secure_connection
   done ;
   !result
 

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
@@ -192,4 +192,5 @@ let tests = [test_proxy; test_time_limited_write; test_time_limited_read]
 let () =
   (* avoid SIGPIPE *)
   let (_ : Sys.signal_behavior) = Sys.signal Sys.sigpipe Sys.Signal_ignore in
+  Xapi_stdext_unix.Unixext.test_open 1024 ;
   QCheck_base_runner.run_tests_main tests

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -248,6 +248,17 @@ val statvfs : string -> statvfs_t
 val domain_of_addr : string -> Unix.socket_domain option
 (** Returns Some Unix.PF_INET or Some Unix.PF_INET6 if passed a valid IP address, otherwise returns None. *)
 
+val test_open : int -> unit
+(** [test_open n] opens n file descriptors. This is useful for testing that the application makes no calls
+  to [Unix.select] that use file descriptors, because such calls will then immediately fail.
+
+  This assumes that [ulimit -n] has been suitably increased in the test environment.
+  
+  Can only be called once in a program, and will raise an exception otherwise.
+
+  The file descriptors will stay open until the program exits.
+ *)
+
 module Direct : sig
   (** Perform I/O in O_DIRECT mode using 4KiB page-aligned buffers *)
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -930,12 +930,20 @@ let report_tls_verification ~__context =
   let value = Stunnel_client.get_verify_by_default () in
   Db.Host.set_tls_verification_enabled ~__context ~self ~value
 
+let test_open count =
+  if count > 0 then (
+    debug "%s: opening %d file descriptors" __FUNCTION__ count ;
+    Xapi_stdext_unix.Unixext.test_open count ;
+    debug "%s: opened %d files" __FUNCTION__ count
+  )
+
 let server_init () =
   let print_server_starting_message () =
     debug "(Re)starting xapi, pid: %d" (Unix.getpid ()) ;
     debug "on_system_boot=%b pool_role=%s" !Xapi_globs.on_system_boot
       (Pool_role.string_of (Pool_role.get_role ()))
   in
+  test_open !Xapi_globs.test_open ;
   Unixext.unlink_safe "/etc/xensource/boot_time_info_updated" ;
   (* Record the initial value of Master_connection.connection_timeout and set it to 'never'. When we are a slave who
      has just started up we want to wait forever for the master to appear. (See CA-25481) *)

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1031,6 +1031,8 @@ let observer_experimental_components =
 
 let disable_webserver = ref false
 
+let test_open = ref 0
+
 let xapi_globs_spec =
   [
     ( "master_connection_reset_timeout"
@@ -1114,6 +1116,7 @@ let xapi_globs_spec =
   ; ("max_spans", Int max_spans)
   ; ("max_traces", Int max_traces)
   ; ("max_observer_file_size", Int max_observer_file_size)
+  ; ("test-open", Int test_open) (* for consistency with xenopsd *)
   ]
 
 let options_of_xapi_globs_spec =


### PR DESCRIPTION
I think these are the only changes I have before we'd attempt a merge of feature/perf (with more epoll related content that I'll move to feature/epoll instead).