### PR TITLE
CP-49930: Moved wlan.py from scripts/poweron to python3/poweron

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -22,3 +22,5 @@ install:
 	$(IPROG) bin/xe-scsi-dev-map $(DESTDIR)$(OPTDIR)/bin
 	install -d -m  755  $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/disk-space $(DESTDIR)$(PLUGINDIR)
+	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wlan.py
+	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wake-on-lan

--- a/python3/poweron/wlan.py
+++ b/python3/poweron/wlan.py
@@ -65,6 +65,10 @@ def get_physical_pif(session, pif_ref):
 
 
 def wake_on_lan(session, host, remote_host_uuid):
+    """
+     Attempt to wake up a machine by sending Wake-On-Lan packets encapsulated within UDP datagrams
+     sent to the broadcast_addr.
+     """
     # Find this Host's management interface:
     this_pif = find_host_mgmt_pif(session, inventory.get_localhost_uuid())
     # Find the name of the bridge to which it is connected:
@@ -79,9 +83,6 @@ def wake_on_lan(session, host, remote_host_uuid):
     remote_pif = get_physical_pif(session, mgmt_pif)
     # Find the MAC address of the management interface:
     mac = session.xenapi.PIF.get_MAC(remote_pif)
-
-    """Attempt to wake up a machine by sending Wake-On-Lan packets encapsulated within UDP datagrams
-    sent to the broadcast_addr."""
     # A Wake-On-LAN packet contains FF:FF:FF:FF:FF:FF followed by 16 repetitions of the target MAC address
     bin_payload = bytes.fromhex("F" * 12 + mac.replace(":", "") * 16)
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -169,8 +169,6 @@ endif
 	$(IPROG) examples/python/echo.py $(DESTDIR)$(PLUGINDIR)/echo
 	$(IPROG) examples/python/shell.py $(DESTDIR)$(LIBEXECDIR)/shell.py
 # poweron
-	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wlan.py
-	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wake-on-lan
 	$(IPROG) poweron/DRAC.py $(DESTDIR)$(PLUGINDIR)/DRAC.py
 	$(IPROG) poweron/power-on.py $(DESTDIR)$(PLUGINDIR)/power-on-host
 # YUM plugins


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Subtask CP-49930:

- Modified  Makefile in python3 directory  to include wlan.py
- Fixed pytest error
- Removed wlan.py from scripts/Makefile

 Signed-off-by: Ashwinh <ashwin.h@cloud.com>

@liulinC 