### PR TITLE
CP-49902: Moved DRAC.py from scripts/poweron to python3/poweron

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -24,3 +24,4 @@ install:
 	$(IPROG) plugins/disk-space $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wlan.py
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wake-on-lan
+	$(IPROG) poweron/DRAC.py $(DESTDIR)$(PLUGINDIR)/DRAC.py

--- a/python3/poweron/DRAC.py
+++ b/python3/poweron/DRAC.py
@@ -49,7 +49,7 @@ def DRAC(power_on_ip, user, password):
 
 def main():
     if len(sys.argv) < 3:
-        exit(0)
+        sys.exit(0)
     ip = sys.argv[1]
     user = sys.argv[2]
     password = sys.argv[3]

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -169,7 +169,6 @@ endif
 	$(IPROG) examples/python/echo.py $(DESTDIR)$(PLUGINDIR)/echo
 	$(IPROG) examples/python/shell.py $(DESTDIR)$(LIBEXECDIR)/shell.py
 # poweron
-	$(IPROG) poweron/DRAC.py $(DESTDIR)$(PLUGINDIR)/DRAC.py
 	$(IPROG) poweron/power-on.py $(DESTDIR)$(PLUGINDIR)/power-on-host
 # YUM plugins
 	$(IPROG) yum-plugins/accesstoken.py $(DESTDIR)$(YUMPLUGINDIR)


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task CP-49902:

- Modified Makefile in python3 directory to include DRAC.py
- Removed DRAC.PY from scripts/poweron
- Removed DRAC.py from scripts/Makefile
- Fixed pytlint issue by using sys.exit()

Signed-off-by: Ashwinh <ashwin.h@cloud.com>