### PR TITLE
CP-49975: Replaced mkdir -p with \\\$(IPROG)  -d for directory creation in install target.

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -6,9 +6,10 @@ IDATA=install -m 644
 SITE3_DIR=$(shell python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 install:
-	mkdir -p $(DESTDIR)$(OPTDIR)/bin
-	mkdir -p $(DESTDIR)$(SITE3_DIR)
-	mkdir -p $(DESTDIR)$(LIBEXECDIR)
+	$(IPROG) -d $(DESTDIR)$(OPTDIR)/bin
+	$(IPROG) -d $(DESTDIR)$(SITE3_DIR)
+	$(IPROG) -d $(DESTDIR)$(LIBEXECDIR)
+	$(IPROG) -d $(DESTDIR)$(PLUGINDIR)
 
 	
 	$(IDATA) packages/observer.py $(DESTDIR)$(SITE3_DIR)/
@@ -20,7 +21,6 @@ install:
 	$(IPROG) bin/hfx_filename $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/perfmon $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/xe-scsi-dev-map $(DESTDIR)$(OPTDIR)/bin
-	install -d -m  755  $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/disk-space $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wlan.py
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wake-on-lan


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task 49975:

-Based on feedback provided in  https://github.com/xapi-project/xen-api/pull/5695 ,modified Makefile to use install -d -m instead of mkdir -p.

Signed-off-by: Ashwinh <ashwin.h@cloud.com>

@liulinC 
