### PR TITLE
IH-583: Ensure OCaml binaries don't link against libsystemd

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -517,6 +517,7 @@ This package provides an Lwt compatible interface to the library.")
     (fd-send-recv (>= 2.0.0))
     (odoc :with-doc)
     xapi-backtrace
+    unix-errno
     (xapi-stdext-pervasives (= :version))
   )
 )

--- a/dune-project
+++ b/dune-project
@@ -181,7 +181,6 @@
    mtime
    ppx_deriving_rpc
    rpclib
-   systemd
    (ezxenstore (= :version))
    (uuid (= :version))
    xapi-backtrace

--- a/ocaml/forkexecd/src/dune
+++ b/ocaml/forkexecd/src/dune
@@ -5,7 +5,6 @@
    astring
    fd-send-recv
    forkexec
-   systemd
    uuid
    xapi-log
    xapi-stdext-unix

--- a/ocaml/forkexecd/src/fe_main.ml
+++ b/ocaml/forkexecd/src/fe_main.ml
@@ -46,8 +46,6 @@ let setup sock cmdargs id_to_fd_map syslog_stdout redirect_stderr_to_stdout env
     Some {Fe.fd_sock_path}
   )
 
-let systemd_managed () = try Daemon.booted () with Unix.Unix_error _ -> false
-
 let _ =
   Sys.set_signal Sys.sigpipe Sys.Signal_ignore ;
 
@@ -63,8 +61,10 @@ let _ =
   in
   Xapi_stdext_unix.Unixext.mkdir_rec Forkhelpers.temp_dir_server 0o755 ;
 
-  if systemd_managed () then
-    Daemon.notify Daemon.State.Ready |> ignore ;
+  let module Daemon = Xapi_stdext_unix.Unixext.Daemon in
+  if Daemon.systemd_booted () && not (Daemon.systemd_notify Daemon.State.Ready)
+  then
+    warn "Sending systemd notification failed at %s" __LOC__ ;
 
   (* At this point the init.d script should return and we are listening on our socket. *)
   while true do

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/dune
@@ -5,6 +5,9 @@
     fd-send-recv
     unix
     xapi-backtrace
+    unix-errno
+    unix-errno.unix
+    astring
     xapi-stdext-pervasives)
   (foreign_stubs
     (language c)

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
@@ -1,0 +1,7 @@
+(executable
+ (modes exe)
+ (name test_systemd)
+ (libraries xapi-stdext-unix))
+
+(cram
+ (deps test_systemd.exe))

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.ml
@@ -1,0 +1,50 @@
+let _ =
+  let module Daemon = Xapi_stdext_unix.Unixext.Daemon in
+  let notify_test () =
+    if Daemon.systemd_notify Daemon.State.Ready then
+      exit 0
+    else
+      match Sys.getenv_opt "NOTIFY_SOCKET" with
+      | Some _ ->
+          exit 4
+      | None ->
+          print_endline "NOTIFY_SOCKET not set, notification couldn't be sent" ;
+          exit 1
+  in
+  let server () =
+    let temp_path =
+      match Sys.getenv_opt "NOTIFY_SOCKET" with Some a -> a | None -> exit 4
+    in
+    let socket_path =
+      if String.starts_with ~prefix:"@" temp_path then (
+        print_endline temp_path ;
+        "\x00" ^ String.sub temp_path 1 (String.length temp_path - 1)
+      ) else
+        temp_path
+    in
+    Unix.(
+      let sock = socket PF_UNIX SOCK_DGRAM 0 ~cloexec:true in
+      bind sock (ADDR_UNIX socket_path) ;
+      let b = Bytes.create 1024 in
+      let i, _ = recvfrom sock b 0 1024 [] in
+      print_endline (Bytes.sub_string b 0 i) ;
+      close sock
+    )
+  in
+  let booted_test () =
+    if Daemon.systemd_booted () then (
+      print_endline "Booted with systemd" ;
+      exit 0
+    ) else (
+      print_endline "Booted without systemd" ;
+      exit 2
+    )
+  in
+  Arg.parse
+    [
+      ("--notify", Arg.Unit notify_test, "Test systemd_notify function")
+    ; ("--server", Arg.Unit server, "Listen for the notifications")
+    ; ("--booted", Arg.Unit booted_test, "Test systemd_booted function")
+    ]
+    (fun _ -> raise (Arg.Bad "Specify a valid option"))
+    "Unit test for the Daemon module in Xapi_stdext_unix\nUsage:\n"

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.t
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.t
@@ -1,0 +1,34 @@
+== Testing no-ops
+  $ unset NOTIFY_SOCKET
+  $ ./test_systemd.exe --notify
+  NOTIFY_SOCKET not set, notification couldn't be sent
+  [1]
+
+== Use abstract sockets
+  $ export NOTIFY_SOCKET="@systemd.socket"; echo "$NOTIFY_SOCKET"
+  @systemd.socket
+  $ ./test_systemd.exe --server &
+  @systemd.socket
+  READY=1
+  $ sleep 1
+  $ ./test_systemd.exe --notify
+
+== Use socket files
+  $ export TMPDIR=${TMPDIR:-/tmp}
+  $ export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-$TMPDIR}
+  $ export NOTIFY_SOCKET="${XDG_RUNTIME_DIR}/systemd.socket"
+  $ rm -f "$NOTIFY_SOCKET"
+  $ ./test_systemd.exe --server &
+  READY=1
+  $ sleep 1
+  $ test -S "$NOTIFY_SOCKET"
+  $ ./test_systemd.exe --notify
+
+== Currently not run tests because of insufficient permissions
+==  in cram to be manipulating this file
+$ mv /run/systemd/system /run/systemd/system.old
+$ ./test_systemd.exe booted
+Booted without systemd
+$ mv /run/systemd/system.old /run/systemd/system
+$ ./test_systemd.exe booted
+Booted with systemd

--- a/ocaml/networkd/bin/dune
+++ b/ocaml/networkd/bin/dune
@@ -26,7 +26,6 @@
   rpclib.json
   result
   rresult
-  systemd
   threads.posix
   xapi-client
   xapi-consts

--- a/ocaml/networkd/bin/networkd.ml
+++ b/ocaml/networkd/bin/networkd.ml
@@ -233,7 +233,11 @@ let () =
       Debug.with_thread_associated "main" start server
     )
     () ;
-  ignore (Daemon.notify Daemon.State.Ready) ;
+  let module Daemon = Xapi_stdext_unix.Unixext.Daemon in
+  if Daemon.systemd_notify Daemon.State.Ready then
+    ()
+  else
+    D.warn "Sending systemd notification failed at %s" __LOC__ ;
   while true do
     Thread.delay 300. ; Network_server.on_timer ()
   done

--- a/ocaml/networkd/lib/dune
+++ b/ocaml/networkd/lib/dune
@@ -11,7 +11,6 @@
   rpclib.core
   rpclib.json
   rresult
-  systemd
   threads.posix
   uri
   xapi-stdext-pervasives

--- a/ocaml/xcp-rrdd/bin/rrdd/dune
+++ b/ocaml/xcp-rrdd/bin/rrdd/dune
@@ -17,7 +17,6 @@
     rrd-transport
     rrd-transport.lib
     stunnel
-    systemd
     threads.posix
     uuid
     xapi-backtrace
@@ -55,7 +54,6 @@
     rpclib.xml
     rrdd_libs_internal
     rrd-transport
-    systemd
     threads.posix
     uuid
     xapi-backtrace

--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -1133,7 +1133,12 @@ let _ =
     try Watcher.create_watcher_thread ()
     with _ -> error "xenstore-watching thread has failed"
   in
-  ignore (Daemon.notify Daemon.State.Ready) ;
+  let module Daemon = Xapi_stdext_unix.Unixext.Daemon in
+  if Daemon.systemd_booted () then
+    if Daemon.systemd_notify Daemon.State.Ready then
+      ()
+    else
+      warn "Sending systemd notification failed at %s" __LOC__ ;
   debug "Creating monitoring loop thread .." ;
   let () =
     try Debug.with_thread_associated "main" monitor_write_loop writers

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -21,7 +21,6 @@ depends: [
   "mtime"
   "ppx_deriving_rpc"
   "rpclib"
-  "systemd"
   "ezxenstore" {= version}
   "uuid" {= version}
   "xapi-backtrace"

--- a/xapi-stdext-unix.opam
+++ b/xapi-stdext-unix.opam
@@ -13,6 +13,7 @@ depends: [
   "fd-send-recv" {>= "2.0.0"}
   "odoc" {with-doc}
   "xapi-backtrace"
+  "unix-errno"
   "xapi-stdext-pervasives" {= version}
 ]
 build: [


### PR DESCRIPTION
Replaced usages of `ocaml-systemd` (that acts as thin glue on top of `libsystemd`) with standalone implementations of `sd_notify` and `sd_booted` functions in a new module in `stdext-unix`. These are identical to their `libsystemd` implementations short for differences in system calls unavailable in OCaml's stdlib that were deemed unimportant, and the interface was narrowed down to what we already use it for.

The implementation, unlike `ocaml-systemd` one, does not raise exceptions. Unit tests currently do not cover the entirety of the implementation but could be extended if deemed necessary. These changes passed BST/BVT test suites.

Compared to master:
```bash
(master) $  ldd _build/install/default/bin/* | grep systemd -B 2
_build/install/default/bin/xapi-networkd:
        linux-vdso.so.1 (0x00007ffe47353000)
        libsystemd.so.0 => /lib/x86_64-linux-gnu/libsystemd.so.0 (0x00007f9e0442c000)
--
_build/install/default/bin/xcp-rrdd:
        linux-vdso.so.1 (0x00007ffea955c000)
        libsystemd.so.0 => /lib/x86_64-linux-gnu/libsystemd.so.0 (0x00007f1fa8797000)

(private/asultanov/standalone-systemd) $ ldd _build/install/default/bin/* | grep systemd
[1]
```


This follows similar changes in the hypervisor: [1](https://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=78510f3a1522f2856330ffa429e0e35f8aab4277) and [2](https://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=caf864482689a5dd6a945759b6372bb260d49665).