### PR TITLE
IH-583: Fix failing builds by attaching package to the cram test

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
@@ -4,4 +4,5 @@
  (libraries xapi-stdext-unix))
 
 (cram
+ (package xapi-stdext-unix)
  (deps test_systemd.exe))


### PR DESCRIPTION
xs-opam tests detected this failure: https://github.com/xapi-project/xs-opam/actions/runs/9645899485/job/26601099423