### PR TITLE
CP-49368 introduces a flag to  xenstore before suspend Linux guest

### DIFF
--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -1824,6 +1824,8 @@ let suspend (task : Xenops_task.task_handle) ~xc ~xs ~domain_type ~is_uefi ~dm
   let open Suspend_image in
   let open Suspend_image.M in
   (* Suspend image signature *)
+  let dom_path = xs.Xs.getdomainpath domid in
+  xs.Xs.write (Filename.concat dom_path "/control/suspend_initiate") "1" ;
   debug "Writing save signature: %s" save_signature ;
   Io.write main_fd save_signature ;
   (* CA-248130: originally, [xs_subtree] contained [xenstore_read_dir t


### PR DESCRIPTION
Systems under heavy disk I/O load may encounter suspend failures due to the inadequacy of the default process freeze timeout settings. This PR proposes a solution, introduces a flag `/control/suspend_initiate` for guest agent to dynamic adjustment of freeze timeouts or configurations before suspending, enhancing the robustness of the suspend process and potentially reducing migration failures.