### PR TITLE
CP-49920: Moved power-on.py from scripts/poweron to python3/poweron directory.

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -25,6 +25,8 @@ install:
 	$(IPROG) bin/perfmon $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/xe-scsi-dev-map $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) plugins/disk-space $(DESTDIR)$(PLUGINDIR)
+# poweron
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wlan.py
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wake-on-lan
 	$(IPROG) poweron/DRAC.py $(DESTDIR)$(PLUGINDIR)/DRAC.py
+	$(IPROG) poweron/power-on.py $(DESTDIR)$(PLUGINDIR)/power-on-host

--- a/python3/poweron/power-on.py
+++ b/python3/poweron/power-on.py
@@ -3,6 +3,7 @@
 # Example script which shows how to use the XenAPI to find a particular Host's management interface
 # and send it a wake-on-LAN packet.
 
+import sys
 import syslog
 import time
 
@@ -26,8 +27,8 @@ def waitForXapi(session, host):
         metrics = session.xenapi.host.get_metrics(host)
         try:
             finished = session.xenapi.host_metrics.get_live(metrics)
-        except:
-            pass
+        except Exception as e:
+            print(type(e).__name__, "occurred:", e, file=sys.stderr)
     return str(finished)
 
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -166,8 +166,6 @@ endif
 	$(IDATA) examples/python/inventory.py $(DESTDIR)$(SITE3_DIR)/
 	$(IPROG) examples/python/echo.py $(DESTDIR)$(PLUGINDIR)/echo
 	$(IPROG) examples/python/shell.py $(DESTDIR)$(LIBEXECDIR)/shell.py
-# poweron
-	$(IPROG) poweron/power-on.py $(DESTDIR)$(PLUGINDIR)/power-on-host
 # YUM plugins
 	$(IPROG) yum-plugins/accesstoken.py $(DESTDIR)$(YUMPLUGINDIR)
 	$(IDATA) yum-plugins/accesstoken.conf $(DESTDIR)$(YUMPLUGINCONFDIR)


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task CP-49920:

- Modified Makefile to include  power-on.py under python3 directory
- Removed  power-on.py from scripts/Makefile
- Fixed No exception type(s) specified (bare-except)


Signed-off-by: Ashwinh <ashwin.h@cloud.com>