### PR TITLE
CA-381119: use JsonRPC V2 for error replies

### DIFF
--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -346,7 +346,7 @@ let jsoncallback req bio _ =
     Http_svr.response_str req
       ~hdrs:[(Http.Hdr.content_type, "application/json")]
       fd
-      (Jsonrpc.string_of_response
+      (Jsonrpc.string_of_response ~version:Jsonrpc.V2
          (Rpc.failure
             (Rpc.Enum (List.map (fun s -> Rpc.String s) (err :: params)))
          )


### PR DESCRIPTION
For regular replies we look at the request and reply with a matching version. However when we fail to parse the JsonRPC request itself then we don't know what version to use.

XenCenter uses JsonRPC v2 by default, and JsonRPC v2 has been supported in XAPI for a long time.