### PR TITLE
CP-49928/`static-vdis`: Fix pyright (3/3 of: prepare move to `python3/`)

### DIFF
--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -105,12 +105,12 @@ def list_vdis():
     return list(map(load, all))
 
 def fresh_name():
-    all = []
+    """Return a unique name for a new static VDI configuration directory"""
     try:
         all = os.listdir(main_dir)
         for i in range(0, len(all) + 1): # guarantees to find a unique number
             i = str(i)
-            if not(i in all):
+            if i not in all:
                 return i
     except:
         # Directory doesn't exist

--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -115,7 +115,7 @@ def fresh_name():
     except:
         # Directory doesn't exist
         os.mkdir(main_dir)
-        return "0"
+    return "0"  # Always return a string, fixes pyright error by not returning None
         
 
 def to_string_list(d):

--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -97,20 +97,20 @@ def sr_attach(ty, device_config):
     return call_volume_plugin(ty, "SR.attach", args)
 
 def list_vdis():
-    all = []
+    files = []
     try:
-        all = os.listdir(main_dir)
+        files = os.listdir(main_dir)
     except:
         pass
-    return list(map(load, all))
+    return list(map(load, files))
 
 def fresh_name():
     """Return a unique name for a new static VDI configuration directory"""
     try:
-        all = os.listdir(main_dir)
-        for i in range(0, len(all) + 1): # guarantees to find a unique number
+        files = os.listdir(main_dir)
+        for i in range(0, len(files) + 1):  # guarantees to find a unique number
             i = str(i)
-            if i not in all:
+            if i not in files:
                 return i
     except:
         # Directory doesn't exist

--- a/scripts/static-vdis
+++ b/scripts/static-vdis
@@ -100,7 +100,7 @@ def list_vdis():
     files = []
     try:
         files = os.listdir(main_dir)
-    except:
+    except OSError:  # All possible errors are subclasses of OSError
         pass
     return list(map(load, files))
 
@@ -112,7 +112,7 @@ def fresh_name():
             i = str(i)
             if i not in files:
                 return i
-    except:
+    except OSError:  # All possible errors are subclasses of OSError
         # Directory doesn't exist
         os.mkdir(main_dir)
     return "0"  # Always return a string, fixes pyright error by not returning None


### PR DESCRIPTION
`static-vdis`: Fix `pyright` and `pylint` warnings before moving `static-vdis` to `python3/`.

For information: @ashwin9390