### PR TITLE
CP-49921: Moved print-custom-templates from scripts to python3/libexec directory

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -20,7 +20,8 @@ install:
 	$(IPROG) libexec/usb_scan.py $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) libexec/nbd_client_manager.py $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) libexec/probe-device-for-file $(DESTDIR)$(LIBEXECDIR)
-	
+	$(IPROG) libexec/print-custom-templates $(DESTDIR)$(LIBEXECDIR)
+
 	$(IPROG) bin/hfx_filename $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/perfmon $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/xe-scsi-dev-map $(DESTDIR)$(OPTDIR)/bin

--- a/python3/libexec/print-custom-templates
+++ b/python3/libexec/print-custom-templates
@@ -20,8 +20,8 @@ def main(argv):
         atexit.register(logout, session)
 
         templates = session.xenapi.VM.get_all_records_where('field "is_a_template" = "true" and field "is_a_snapshot" = "false"' )
-    except:
-        print("Error retrieving template list", file=sys.stderr)
+    except Exception as e:
+        print(type(e).__name__, "retrieving template list:", e, file=sys.stderr)
         sys.exit(1)
 
     output=[]

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -113,7 +113,6 @@ install:
 	$(IPROG) host-display $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) xe-backup-metadata $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) xe-restore-metadata $(DESTDIR)$(OPTDIR)/bin
-	$(IPROG) print-custom-templates $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) backup-sr-metadata.py $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) restore-sr-metadata.py $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) backup-metadata-cron $(DESTDIR)$(LIBEXECDIR)


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task CP-49921:

- Moved print-custom-templates from scripts to python3/libexec directory
- Modified python3/Makefile to include these changes.
-  fixed bare-except error

Signed-off-by: Ashwinh <ashwin.h@cloud.com>