### PR TITLE
Merge `master` into `feature/py3`: Fix races for CI

### DIFF
--- a/ocaml/xapi-idl/lib/task_server.ml
+++ b/ocaml/xapi-idl/lib/task_server.ml
@@ -112,10 +112,8 @@ functor
 
     (* [next_task_id ()] returns a fresh task id *)
     let next_task_id =
-      let counter = ref 0 in
-      fun () ->
-        let result = string_of_int !counter in
-        incr counter ; result
+      let counter = Atomic.make 0 in
+      fun () -> Atomic.fetch_and_add counter 1 |> string_of_int
 
     let set_cancel_trigger tasks dbg n =
       with_lock tasks.m (fun () -> tasks.test_cancel_trigger <- Some (dbg, n))

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -346,7 +346,7 @@ let jsoncallback req bio _ =
     Http_svr.response_str req
       ~hdrs:[(Http.Hdr.content_type, "application/json")]
       fd
-      (Jsonrpc.string_of_response
+      (Jsonrpc.string_of_response ~version:Jsonrpc.V2
          (Rpc.failure
             (Rpc.Enum (List.map (fun s -> Rpc.String s) (err :: params)))
          )


### PR DESCRIPTION
This PR merges the latest `xen-api/master` branch into `xen-api/feature/py3` to fix race conditions in CI.

Merging these latest commits from `master` into `feature/py3` was recommended by @psafont and @edwintorok in #5733.

FYI: @ashwin9390 and @stephenchengCloud 