### PR TITLE
CP-49909: Moved install-sup-pack from scripts/plugins to python3/plugins directory 

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -27,6 +27,8 @@ install:
 	$(IPROG) bin/perfmon $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/xe-scsi-dev-map $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) plugins/disk-space $(DESTDIR)$(PLUGINDIR)
+	$(IPROG) plugins/install-supp-pack $(DESTDIR)$(PLUGINDIR)
+
 # poweron
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wlan.py
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wake-on-lan

--- a/python3/plugins/install-supp-pack
+++ b/python3/plugins/install-supp-pack
@@ -36,8 +36,8 @@ def install(session, args):
     vdi_ref = None
     try:
         vdi_ref = session.xenapi.VDI.get_by_uuid(vdi)
-    except:
-        raise ArgumentError("VDI parameter invalid")
+    except Exception as exc:
+        raise ArgumentError("VDI parameter invalid") from exc
 
     inventory = xcp.environ.readInventory()
     this_host_uuid = inventory["INSTALLATION_UUID"]
@@ -46,8 +46,8 @@ def install(session, args):
     update_ref = None
     try:
         update_ref = session.xenapi.pool_update.introduce(vdi_ref)
-    except:
-        raise ArgumentError("VDI contains invalid update package")
+    except Exception as exc:
+        raise ArgumentError("VDI contains invalid update package") from exc
 
     try:
         session.xenapi.pool_update.apply(update_ref, this_host_ref)
@@ -57,9 +57,9 @@ def install(session, args):
             # "['ERRORCODE', 'error_message']"
             # fetch the error_message and display it.
             error = json.loads(str(e))[1].encode("utf8")
-        except:
+        except Exception:
             error = str(e)
-        raise InstallFailure("Failed to install the supplemental pack", error)
+        raise InstallFailure("Failed to install the supplemental pack", error) from e
 
     return "OK"
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -126,7 +126,6 @@ install:
 	$(IPROG) plugins/perfmon $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/extauth-hook $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/extauth-hook-AD.py $(DESTDIR)$(PLUGINDIR)
-	$(IPROG) plugins/install-supp-pack $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/firewall-port $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/openvswitch-config-update $(DESTDIR)$(PLUGINDIR)
 	mkdir -p $(DESTDIR)$(HOOKSDIR)/host-post-declare-dead


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task CP-49909:
-Move  install-sup-pack from scripts/plugins to python3/plugins directory 
-Fix static code checker issue with respect to bare-except and raise-missing-from exception

Signed-off-by: Ashwinh <ashwin.h@cloud.com>