### PR TITLE
CP-49903: mv echo plugin from `scripts/examples/python/echo.py` to `python3/plugins`

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -28,6 +28,7 @@ install:
 	$(IPROG) bin/xe-scsi-dev-map $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) plugins/disk-space $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/install-supp-pack $(DESTDIR)$(PLUGINDIR)
+	$(IPROG) plugins/echo.py $(DESTDIR)$(PLUGINDIR)/echo
 
 # poweron
 	$(IPROG) poweron/wlan.py $(DESTDIR)$(PLUGINDIR)/wlan.py

--- a/python3/plugins/echo.py
+++ b/python3/plugins/echo.py
@@ -5,8 +5,8 @@ import time
 
 import XenAPIPlugin
 
-
-def main(session, args):
+#First argument passed in session which is not used ,using _ to ignore
+def main(_, args):
     if "sleep" in args:
         secs = int(args["sleep"])
         time.sleep(secs)

--- a/python3/plugins/echo.py
+++ b/python3/plugins/echo.py
@@ -5,7 +5,7 @@ import time
 
 import XenAPIPlugin
 
-#First argument passed in session which is not used ,using _ to ignore
+# The 1st argument is the session. This plugin does not use it, hence use _:
 def main(_, args):
     if "sleep" in args:
         secs = int(args["sleep"])

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -161,7 +161,6 @@ endif
 	sed -i 's/#!\/usr\/bin\/python/#!\/usr\/bin\/python3/' $(DESTDIR)$(SITE3_DIR)/XenAPIPlugin.py
 	$(IDATA) examples/python/XenAPI/XenAPI.py $(DESTDIR)$(SITE3_DIR)/
 	$(IDATA) examples/python/inventory.py $(DESTDIR)$(SITE3_DIR)/
-	$(IPROG) examples/python/echo.py $(DESTDIR)$(PLUGINDIR)/echo
 	$(IPROG) examples/python/shell.py $(DESTDIR)$(LIBEXECDIR)/shell.py
 # YUM plugins
 	$(IPROG) yum-plugins/accesstoken.py $(DESTDIR)$(YUMPLUGINDIR)


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task CP-49903: 
- Moved echo.py from scripts/examples/python to python3/plugins directory
- Fixed unused-argument issue

Signed-off-by: Ashwinh <ashwin.h@cloud.com>
