### PR TITLE
CI: Fall back to codecov@v3 when @v4 has no token, add coveralls

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -80,8 +80,16 @@ jobs:
         env:
           PYTHONDEVMODE: yes
 
-      - name: Upload Python ${{matrix.python-version}} coverage report to Codecov
+      - name: Upload Python ${{matrix.python-version}} coverage report to Codecov using v4
         uses: codecov/codecov-action@v4
+        id: codecov4
+        # v4 fixes coverage upload failures by not using tokenless uploads.
+        # It needs secrets.CODECOV_TOKEN(from master/repo or org) to be set up.
+        # With CODECOV_TOKEN, the coverage upload is not victim to GitHub's API
+        # rate limiting and it works for PRs, pushes, forks and builds on master.
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: env.CODECOV_TOKEN
         with:
           directory: .git
           fail_ci_if_error: false
@@ -89,8 +97,49 @@ jobs:
           files: coverage${{matrix.python-version}}.xml
           flags: python${{matrix.python-version}}
           name: coverage${{matrix.python-version}}
+
+      - name: Upload Python ${{matrix.python-version}} coverage report to Codecov using OpenID Connect
+        uses: codecov/codecov-action@v4
+        id: codecov_openid
+        # If the user has OpenID Connect, use it. Does not work on branches(e.g. on master after merges)
+        continue-on-error: true  # When OpenID Connect (OIDC) is not available(non-PRs), fall back to v3
+        if: steps.codecov4.outcome != 'success'
+        with:
+          directory: .git
+          env_vars: OS,PYTHON
+          files: coverage${{matrix.python-version}}.xml
+          flags: python${{matrix.python-version}}
+          name: coverage${{matrix.python-version}}
           use_oidc: true
+
+      - name: Upload Python ${{matrix.python-version}} coverage report to Codecov using v3
+        uses: codecov/codecov-action@v3
+        id: codecov3
+        # When v4 was not possible, we have no other option but to fall back to v3.
+        # The drawback of v3 is that it is victim to GitHub's API rate limiting, which
+        # can cause the coverage upload to fail. Only the owner of the repo (or the org)
+        # can fix this situation by adding the CODECOV_TOKEN secret to the repo (or org).
+        # This requires manual action and trust in the Codecov service to not impersonate
+        # the owner of the repo (or the org) beyond API access for coverage uploads:
+        # https://docs.codecov.com/docs/adding-the-codecov-token
+        if: steps.codecov4.outcome != 'success' && steps.codecov_openid.outcome != 'success'
+        with:
+          directory: .git
+          fail_ci_if_error: false
+          env_vars: OS,PYTHON
+          files: coverage${{matrix.python-version}}.xml
+          flags: python${{matrix.python-version}}
+          name: coverage${{matrix.python-version}}
           verbose: true
+
+      - name: Upload coverage report to Coveralls (alternative to Codecov - was used earlier)
+        uses: coverallsapp/github-action@v2
+        if: ${{ matrix.python-version != '2.7' }}
+        continue-on-error: true
+        with:
+          format: cobertura
+          files: .git/coverage${{matrix.python-version}}.xml
+          flag-name: python${{matrix.python-version}}
 
       - uses: dciborow/action-pylint@0.1.0
         if: ${{ matrix.python-version != '2.7' }}


### PR DESCRIPTION
The merge of #5734 on master (merge commit on master: https://github.com/xapi-project/xen-api/commit/5bd9b86b30c9c02d3b702b45194fd5943e8ca10a) uses OpenID Connect (OIDC) to have a token-based coverage upload to Codecov.

But because OpenID Connect is only available for builds from users that use OIDC:
- The build of the merged commit on master (https://github.com/xapi-project/xen-api/commit/5bd9b86b30c9c02d3b702b45194fd5943e8ca10a) failed to upload because it has no context of the user pushing the merged PR: OIDC is not available during that build and the upload fails:
  > Run codecov/codecov-action@v4
  > evenName: push
  > Error: Codecov: Failed to get OIDC token with url: https://codecov.io./ Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable

Docs on the Codecov action and using OIDC: https://github.com/marketplace/actions/codecov#using-oidc

The most reliable way to upload to codecov.io is codecov@v4 with the CODECOV_TOKEN secret.
- It needs secrets.CODECOV_TOKEN, generated in codecov.io by the repo or organisation owner.
  These are the possible ways to set it up:
  - Only for one repo / for each repo individually:
    - Generated by the owner xen-api repo owner (@robhoes) and added as repo secret to xen-api, or
  - For all repos in the organisation:
    - Generated by the org owner of xapi-project and added as organisation secret to the xapi-project  organisation.
  - Precondition: The respective owner needs to have confidence (trust) that Codecov will not hurt the project.
    - When generating the token, github will show a very scary message saying that Codecov can impersonate the user who generates the secret token (using the given account permission).
    - The secret token is guarded by GitHub action of course.
    - As long as the repo or organiation owner use a secure environment to copy and paste the generated CODECOV_TOKEN from codecov into the repo or respective organisation secret on GitHub.
      - this is of course key: It must not be stored by any other means besides as repo/organisation secret for the GitHub action workflows.
      - The other trusted party is codecov.io, which must be trusted to not abuse the trust.

Without that hurdle jumped, we only have the option of fallbacks:
- Fall back to OIDC when the OIDC is available from the user
  - It will be used automatically on PR workflows, but not always on push workflows.
- If that fails too, we can only fall back to v3, with the known unreliable uploads due to GitHub's API rate-limiting.
  - This fallback is the last resort for the coverage uploads on branches/pushes OIDC is not accessible.
- Upload to coveralls.io, which was already used by the xen-api repository in the past.
  - Can always be used, no issue there,
  - Does not need a login to view coverage.
  - Very easy to administer, no complicated setup like for codecov.io.
    - The repo is already at https://coveralls.io/github/xapi-project/xen-api
    - Already works, this PR is uploaded at: https://coveralls.io/jobs/145432327

This PR implements all these fallbacks. These are useful for the xapi-project/xen-api and for working on and with forks.

If xapi-project/xen-api adopts the setup of the CODECOV_TOKEN, also forks of it would use it.
GitHub is trusted to protect the tokens like it it is trusted with all other GitHub action secrets.