### PR TITLE
CP-49446: expose SR health values to Python

### DIFF
--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1046,6 +1046,10 @@ let bind ~volume_script_dir =
                            Healthy
                        | Xapi_storage.Control.Recovering _ ->
                            Recovering
+                       | Xapi_storage.Control.Unreachable _ ->
+                           Unreachable
+                       | Xapi_storage.Control.Unavailable _ ->
+                           Unavailable
                        )
                    }
                  in
@@ -1405,6 +1409,10 @@ let bind ~volume_script_dir =
                      Healthy
                  | Xapi_storage.Control.Recovering _ ->
                      Recovering
+                 | Xapi_storage.Control.Unreachable _ ->
+                     Unreachable
+                 | Xapi_storage.Control.Unavailable _ ->
+                     Unavailable
                  )
              }
          )

--- a/ocaml/xapi-storage/generator/lib/control.ml
+++ b/ocaml/xapi-storage/generator/lib/control.ml
@@ -28,6 +28,10 @@ type health =
   | Healthy of string  (** Storage is fully available *)
   | Recovering of string
       (** Storage is busy recovering, e.g. rebuilding mirrors *)
+  | Unreachable of string
+      (** Storage is unreachable but may be recoverable with admin intervention *)
+  | Unavailable of string
+      (** Storage is unavailable, a host reboot will be required *)
 [@@deriving rpcty]
 
 type volume_type =


### PR DESCRIPTION
The previous change under this ticket (5ec4c2615c7a487f224bbcba90ea9c717ae594bf) was incomplete and did not propagate the changes to the Python binding as used by the implementation of the Storage API provider.