### PR TITLE
[ASAP] CA-394921: Ignore unknown properties during Java SDK deserialisation

### DIFF
--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
@@ -32,6 +32,7 @@ package com.xensource.xenapi;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -214,6 +215,7 @@ public class JsonRpcClient {
         var dateHandlerModule = new SimpleModule("DateHandler");
         dateHandlerModule.addDeserializer(Date.class, new CustomDateDeserializer());
         this.objectMapper.enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature());
+        this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         this.objectMapper.registerModule(dateHandlerModule);
     }
 


### PR DESCRIPTION
Tested with custom xapi build.


```java
public class Main {
    public static void main(String[] args) throws IOException {
        var c = new Connection(new URL("https://<url>"));

        try{
            Session.loginWithPassword(c, "<USERNAME>", "<PASSWORD>");
            System.out.println(VM.getAll(c).toArray().length);
        }finally {
            Session.logout(c);
        }
    }
}
````

Error before:
```log
Exception in thread "main" com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "recommendations" (class com.xensource.xenapi.Pool$Record), not marked as ignorable (57 known properties: "telemetry_uuid", "redo_log_enabled", "metadata_VDIs", "local_auth_max_threads", "ha_statefiles", "is_psr_pending", "ext_auth_max_threads", "wlb_verify_cert", "tags", "policy_no_vendor_device", "default_SR", "client_certificate_auth_name", "restrictions", "wlb_username", "igmp_snooping_enabled", "update_sync_day", "wlb_enabled", "ha_configuration", "ha_host_failures_to_tolerate", "uuid", "ha_cluster_stack", "redo_log_vdi", "name_label", "guest_agent_config", "gui_config", "ha_allow_overcommit", "name_description", "other_config", "update_sync_enabled", "telemetry_frequency", "custom_uefi_certificates", "health_check_config", "wlb_url", "tls_verification_enabled", "master", "allowed_operations", "telemetry_next_collection", "cpu_info", "suspend_image_SR", "repositories", "repository_proxy_url", "live_patching_disabled", "crash_dump_SR", "migration_compression", "ha_plan_exists_for", "ha_enabled", "repository_proxy_username", "uefi_certificates", "client_certificate_auth_enabled" [truncated]])
```
With change:

```log
26

Process finished with exit code 0
```