### PR TITLE
Make: install library clock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ install: build doc sdk doc-json
 		message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt \
 		message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-storage-cli \
 		xapi-nbd varstored-guard xapi-log xapi-open-uri xapi-tracing xapi-tracing-export xapi-expiry-alerts cohttp-posix \
-		xapi-rrd xapi-inventory \
+		xapi-rrd xapi-inventory clock \
 		xapi-stdext-date xapi-stdext-encodings xapi-stdext-pervasives xapi-stdext-std xapi-stdext-threads xapi-stdext-unix xapi-stdext-zerocheck
 # docs
 	mkdir -p $(DESTDIR)$(DOCDIR)
@@ -280,7 +280,7 @@ uninstall:
 		message-switch message-switch-async message-switch-cli message-switch-core message-switch-lwt \
 		message-switch-unix xapi-idl forkexec xapi-forkexecd xapi-storage xapi-storage-script xapi-log \
 		xapi-open-uri xapi-tracing xapi-tracing-export xapi-expiry-alerts cohttp-posix \
-		xapi-rrd xapi-inventory \
+		xapi-rrd xapi-inventory clock \
 		xapi-stdext-date xapi-stdext-encodings xapi-stdext-pervasives xapi-stdext-std xapi-stdext-threads xapi-stdext-unix xapi-stdext-zerocheck
 
 compile_flags.txt: Makefile


### PR DESCRIPTION
This is needed in order to expose the package to other rpms