### PR TITLE
CP-50050 track CBT status for SMAPIv3 SRs

### DIFF
--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -684,7 +684,7 @@ let vdi_of_volume x =
   ; snapshot_time= find_string _snapshot_time_key ~default:"19700101T00:00:00Z"
   ; snapshot_of= Vdi.of_string (find_string _snapshot_of_key ~default:"")
   ; read_only= not x.Xapi_storage.Control.read_write
-  ; cbt_enabled= false
+  ; cbt_enabled= Option.value x.Xapi_storage.Control.cbt_enabled ~default:false
   ; virtual_size= x.Xapi_storage.Control.virtual_size
   ; physical_utilisation= x.Xapi_storage.Control.physical_utilisation
   ; sm_config= []
@@ -1553,9 +1553,13 @@ let bind ~volume_script_dir =
     @@
     let* sr = Attached_SRs.find sr in
     let vdi = Storage_interface.Vdi.string_of vdi in
-    return_volume_rpc (fun () ->
-        Volume_client.data_destroy volume_rpc dbg sr vdi
-    )
+    let* response =
+      return_volume_rpc (fun () ->
+          Volume_client.data_destroy volume_rpc dbg sr vdi
+      )
+    in
+    let* () = set ~dbg ~sr ~vdi ~key:_vdi_type_key ~value:"cbt_metadata" in
+    Deferred.Result.return response
   in
   S.VDI.data_destroy vdi_data_destroy_impl ;
   let u name _ = failwith ("Unimplemented: " ^ name) in


### PR DESCRIPTION
- Use cbt_enabled flag from plugin responses, to allow that a snapshot of a CBT-enabled VDI will itself be CBT-enabled.
- As part of vdi-data-destroy, record the VDI type as a custom key, so that on a subsequent sr-scan it still shows up as a metadata-only snapshot.