### PR TITLE
Fix newly introduced python warnings in XenAPI.py

### DIFF
--- a/scripts/examples/python/XenAPI/XenAPI.py
+++ b/scripts/examples/python/XenAPI/XenAPI.py
@@ -222,7 +222,9 @@ class Session(xmlrpclib.ServerProxy):
         try:
             if self.last_login_method.startswith("slave_local"):
                 # Proxied function, pytype can't see it
-                return _parse_result(self.session.local_logout(self._session)) # pytype: disable=attribute-error
+                # pytype: disable=attribute-error
+                return _parse_result(self.session.local_logout(self._session))
+                # pytype: enable=attribute-error
             else:
                 return _parse_result(self.session.logout(self._session))
         finally:

--- a/scripts/examples/python/XenAPI/XenAPI.py
+++ b/scripts/examples/python/XenAPI/XenAPI.py
@@ -216,8 +216,7 @@ class Session(xmlrpclib.ServerProxy):
             # pytype false positive: there is a socket.errno in both py2 and py3
             if e.errno == socket.errno.ETIMEDOUT: # pytype: disable=module-attr
                 raise xmlrpclib.Fault(504, 'The connection timed out')
-            else:
-                raise e
+            raise e
 
     def _logout(self):
         try:


### PR DESCRIPTION
Apparently some more checks got enabled on master for python that fail on the changes done to XenAPI.py on the feature branch (but these tests didn't fail at the time the changes were made, they probably weren't active yet).