### PR TITLE
CI: Update endcover step to v2 to fix CI

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -115,13 +115,15 @@ jobs:
   # To view the Coveralls results of the PR, click on the "Details" link to the right
   # of the Coveralls Logo in the Checks section of the PR.
   finish-parallel-coveralls-upload:
+    name: Finish coverage upload
     needs: python-test  # run after the python-test has completed uploading coverages
     runs-on: ubuntu-latest
     steps:
       - name: Finish the parallel coverage upload to Coveralls
-        uses: coverallsapp/github-action@v1
+        uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
+        continue-on-error: true  # Do not fail CI if this step fails
 
   deprecation-test:
     name: Deprecation tests


### PR DESCRIPTION
I believe that this update to `coverallsapp/github-action@v2` (the existing uses of `coverallsapp/github-action` also use `v2`) is expected to fix the CI failure @edwintorok saw in https://github.com/xapi-project/xen-api/pull/5761#issuecomment-2200502721.

Also added:
- Make the step use `continue-on-error: true` (already used in other steps before) to not fail 
CI.
- Added a `name:` to the new step to complete the coveralls upload so it shows in the GitHub workflow graph and on the "Checks:" with a proper name.

Checked: Fixed the builds to no longer be in status "pending completion" on https://coveralls.io/github/xapi-project/xen-api