### PR TITLE
CP-49212: Update datamodel for non-CDN update 

### DIFF
--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "7885f7b085e4a5e32977a4b222030412"
+let last_known_schema_hash = "2a6baa01032827a321845b264c6aaae4"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/test_repository.ml
+++ b/ocaml/tests/test_repository.ml
@@ -14,7 +14,7 @@
 
 module T = Test_common
 
-let test_introduce_duplicate_name () =
+let test_introduce_duplicate_repo_name () =
   let __context = T.make_test_database () in
   let name_label = "name" in
   let name_description = "description" in
@@ -28,12 +28,19 @@ let test_introduce_duplicate_name () =
     Repository.introduce ~__context ~name_label ~name_description ~binary_url
       ~source_url ~update:true ~gpgkey_path
   in
-  Alcotest.check_raises "test_introduce_duplicate_name"
+  Alcotest.check_raises "test_introduce_duplicate_repo_name_1"
     Api_errors.(Server_error (repository_already_exists, [Ref.string_of ref]))
     (fun () ->
       Repository.introduce ~__context ~name_label
         ~name_description:name_description_1 ~binary_url:binary_url_1
         ~source_url:source_url_1 ~update:true ~gpgkey_path
+      |> ignore
+    ) ;
+  Alcotest.check_raises "test_introduce_duplicate_repo_name_2"
+    Api_errors.(Server_error (repository_already_exists, [Ref.string_of ref]))
+    (fun () ->
+      Repository.introduce_bundle ~__context ~name_label
+        ~name_description:name_description_1
       |> ignore
     )
 
@@ -51,7 +58,7 @@ let test_introduce_duplicate_binary_url () =
     Repository.introduce ~__context ~name_label ~name_description ~binary_url
       ~source_url ~update:true ~gpgkey_path
   in
-  Alcotest.check_raises "test_introduce_duplicate_name"
+  Alcotest.check_raises "test_introduce_duplicate_binary_url"
     Api_errors.(Server_error (repository_already_exists, [Ref.string_of ref]))
     (fun () ->
       Repository.introduce ~__context ~binary_url ~name_label:name_label_1
@@ -83,9 +90,30 @@ let test_introduce_invalid_gpgkey_path () =
       |> ignore
     )
 
+let test_introduce_duplicate_bundle_repo () =
+  let __context = T.make_test_database () in
+  let name_label = "name" in
+  let name_label_1 = "name1" in
+  let name_description = "description" in
+  let name_description_1 = "description1" in
+  let ref =
+    Repository.introduce_bundle ~__context ~name_label ~name_description
+  in
+
+  Alcotest.check_raises "test_introduce_duplicate_bundle_repo"
+    Api_errors.(Server_error (repository_already_exists, [Ref.string_of ref]))
+    (fun () ->
+      Repository.introduce_bundle ~__context ~name_label:name_label_1
+        ~name_description:name_description_1
+      |> ignore
+    )
+
 let test =
   [
-    ("test_introduce_duplicate_name", `Quick, test_introduce_duplicate_name)
+    ( "test_introduce_duplicate_repo_name"
+    , `Quick
+    , test_introduce_duplicate_repo_name
+    )
   ; ( "test_introduce_duplicate_binary_url"
     , `Quick
     , test_introduce_duplicate_binary_url
@@ -93,6 +121,10 @@ let test =
   ; ( "test_introduce_invalid_gpgkey_path"
     , `Quick
     , test_introduce_invalid_gpgkey_path
+    )
+  ; ( "test_introduce_duplicate_bundle_repo"
+    , `Quick
+    , test_introduce_duplicate_bundle_repo
     )
   ]
 

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3659,8 +3659,17 @@ let rec cmdtable_data : (string * cmd_spec) list =
     , {
         reqd= ["name-label"; "binary-url"; "source-url"; "update"]
       ; optn= ["name-description"; "gpgkey-path"]
-      ; help= "Add the configuration for a new repository."
+      ; help= "Add the configuration for a new remote repository."
       ; implementation= No_fd Cli_operations.Repository.introduce
+      ; flags= []
+      }
+    )
+  ; ( "repository-introduce-bundle"
+    , {
+        reqd= ["name-label"]
+      ; optn= ["name-description"]
+      ; help= "Add the configuration for a new bundle repository."
+      ; implementation= No_fd Cli_operations.Repository.introduce_bundle
       ; flags= []
       }
     )

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1318,6 +1318,7 @@ let gen_cmds rpc session_id =
           ; "hash"
           ; "up-to-date"
           ; "gpgkey-path"
+          ; "origin"
           ]
           rpc session_id
       )
@@ -7934,9 +7935,7 @@ end
 module Repository = struct
   let introduce printer rpc session_id params =
     let name_label = List.assoc "name-label" params in
-    let name_description =
-      try List.assoc "name-description" params with Not_found -> ""
-    in
+    let name_description = get_param params "name-description" ~default:"" in
     let binary_url = List.assoc "binary-url" params in
     let source_url = List.assoc "source-url" params in
     let update = get_bool_param params "update" in
@@ -7944,6 +7943,16 @@ module Repository = struct
     let ref =
       Client.Repository.introduce ~rpc ~session_id ~name_label ~name_description
         ~binary_url ~source_url ~update ~gpgkey_path
+    in
+    let uuid = Client.Repository.get_uuid ~rpc ~session_id ~self:ref in
+    printer (Cli_printer.PList [uuid])
+
+  let introduce_bundle printer rpc session_id params =
+    let name_label = List.assoc "name-label" params in
+    let name_description = get_param params "name-description" ~default:"" in
+    let ref =
+      Client.Repository.introduce_bundle ~rpc ~session_id ~name_label
+        ~name_description
     in
     let uuid = Client.Repository.get_uuid ~rpc ~session_id ~self:ref in
     printer (Cli_printer.PList [uuid])

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -1145,3 +1145,5 @@ let vm_placement_policy_of_string a =
       `anti_affinity
   | s ->
       record_failure "Invalid VM placement policy, got %s" s
+
+let repo_origin_to_string = function `remote -> "remote" | `bundle -> "bundle"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5370,6 +5370,11 @@ let repository_record rpc session_id repository =
               ~value:x
           )
           ()
+      ; make_field ~name:"origin"
+          ~get:(fun () ->
+            Record_util.repo_origin_to_string (x ()).API.repository_origin
+          )
+          ()
       ]
   }
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6560,6 +6560,12 @@ functor
         Local.Repository.introduce ~__context ~name_label ~name_description
           ~binary_url ~source_url ~update ~gpgkey_path
 
+      let introduce_bundle ~__context ~name_label ~name_description =
+        info "Repository.introduce_bundle: name = '%s'; name_description = '%s'"
+          name_label name_description ;
+        Local.Repository.introduce_bundle ~__context ~name_label
+          ~name_description
+
       let forget ~__context ~self =
         info "Repository.forget: self = '%s'" (repository_uuid ~__context self) ;
         Local.Repository.forget ~__context ~self

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -44,7 +44,22 @@ let introduce ~__context ~name_label ~name_description ~binary_url ~source_url
              )
      ) ;
   create_repository_record ~__context ~name_label ~name_description ~binary_url
-    ~source_url ~update ~gpgkey_path
+    ~source_url ~update ~gpgkey_path ~origin:`remote
+
+let introduce_bundle ~__context ~name_label ~name_description =
+  Db.Repository.get_all ~__context
+  |> List.iter (fun ref ->
+         if
+           name_label = Db.Repository.get_name_label ~__context ~self:ref
+           || Db.Repository.get_origin ~__context ~self:ref = `bundle
+         then
+           raise
+             Api_errors.(
+               Server_error (repository_already_exists, [Ref.string_of ref])
+             )
+     ) ;
+  create_repository_record ~__context ~name_label ~name_description
+    ~binary_url:"" ~source_url:"" ~update:true ~gpgkey_path:"" ~origin:`bundle
 
 let forget ~__context ~self =
   let pool = Helpers.get_pool ~__context in
@@ -112,8 +127,18 @@ let sync ~__context ~self ~token ~token_id =
   try
     let repo_name = get_remote_repository_name ~__context ~self in
     remove_repo_conf_file repo_name ;
-    let binary_url = Db.Repository.get_binary_url ~__context ~self in
-    let source_url = Db.Repository.get_source_url ~__context ~self in
+    let binary_url, source_url =
+      match Db.Repository.get_origin ~__context ~self with
+      | `remote ->
+          ( Db.Repository.get_binary_url ~__context ~self
+          , Some (Db.Repository.get_source_url ~__context ~self)
+          )
+      | `bundle ->
+          let uri =
+            Uri.make ~scheme:"file" ~path:!Xapi_globs.bundle_repository_dir ()
+          in
+          (Uri.to_string uri, None)
+    in
     let gpgkey_path =
       match Db.Repository.get_gpgkey_path ~__context ~self with
       | "" ->
@@ -122,8 +147,8 @@ let sync ~__context ~self ~token ~token_id =
           s
     in
     let write_initial_yum_config () =
-      write_yum_config ~source_url:(Some source_url) ~binary_url
-        ~repo_gpgcheck:true ~gpgkey_path ~repo_name
+      write_yum_config ~source_url ~binary_url ~repo_gpgcheck:true ~gpgkey_path
+        ~repo_name
     in
     write_initial_yum_config () ;
     clean_yum_cache repo_name ;

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -22,6 +22,12 @@ val introduce :
   -> gpgkey_path:string
   -> [`Repository] API.Ref.t
 
+val introduce_bundle :
+     __context:Context.t
+  -> name_label:string
+  -> name_description:string
+  -> [`Repository] API.Ref.t
+
 val forget : __context:Context.t -> self:[`Repository] API.Ref.t -> unit
 
 val cleanup_all_pool_repositories : unit -> unit

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -134,11 +134,12 @@ module GuidanceSet = struct
 end
 
 let create_repository_record ~__context ~name_label ~name_description
-    ~binary_url ~source_url ~update ~gpgkey_path =
+    ~binary_url ~source_url ~update ~gpgkey_path ~origin =
   let ref = Ref.make () in
   let uuid = Uuidx.(to_string (make ())) in
   Db.Repository.create ~__context ~ref ~uuid ~name_label ~name_description
-    ~binary_url ~source_url ~update ~hash:"" ~up_to_date:false ~gpgkey_path ;
+    ~binary_url ~source_url ~update ~hash:"" ~up_to_date:false ~gpgkey_path
+    ~origin ;
   ref
 
 module DomainNameIncludeIP = struct
@@ -377,9 +378,14 @@ let get_repository_name ~__context ~self =
   Db.Repository.get_uuid ~__context ~self
 
 let get_remote_repository_name ~__context ~self =
-  !Xapi_globs.remote_repository_prefix
-  ^ "-"
-  ^ get_repository_name ~__context ~self
+  let prefix =
+    match Db.Repository.get_origin ~__context ~self with
+    | `remote ->
+        !Xapi_globs.remote_repository_prefix
+    | `bundle ->
+        !Xapi_globs.bundle_repository_prefix
+  in
+  prefix ^ "-" ^ get_repository_name ~__context ~self
 
 let get_local_repository_name ~__context ~self =
   !Xapi_globs.local_repository_prefix

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -925,6 +925,8 @@ let yum_repos_config_dir = ref "/etc/yum.repos.d"
 
 let remote_repository_prefix = ref "remote"
 
+let bundle_repository_prefix = ref "bundle"
+
 let local_repository_prefix = ref "local"
 
 let yum_config_manager_cmd = ref "/usr/bin/yum-config-manager"
@@ -944,6 +946,8 @@ let rpm_gpgkey_dir = ref "/etc/pki/rpm-gpg"
 let repository_gpgkey_name = ref ""
 
 let repository_gpgcheck = ref true
+
+let bundle_repository_dir = ref "/var/xapi/bundle-repo"
 
 let observer_config_dir = "/etc/xensource/observer"
 


### PR DESCRIPTION
Add a field "origin" in "repository" to indicate the origin of the repository.
It's an enum type with 2 values: "remote" and "bundle".
