### PR TITLE
Revert "CP-49953: Remove parse_uri, switch to using Uri module instead'"

### DIFF
--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -119,6 +119,10 @@ module Request : sig
   val get_version : t -> string
   (** [get_version t] returns the HTTP protocol version *)
 
+  val of_request_line : string -> t
+  (** [of_request_line l] parses [l] of the form "METHOD HTTP/VERSION" and
+      		returns the corresponding [t] *)
+
   val to_string : t -> string
   (** [to_string t] returns a short string summarising [t] *)
 
@@ -171,6 +175,8 @@ module Response : sig
 end
 
 val authorization_of_string : string -> authorization
+
+val parse_uri : string -> string * (string * string) list
 
 val http_403_forbidden : ?version:string -> unit -> string list
 


### PR DESCRIPTION
Reverts xapi-project/xen-api#5726, which has been found to fail quicktest.