### PR TITLE
CA-390277: Reduce record usage on CLI cross-pool migrations 

### DIFF
--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -586,6 +586,7 @@ and obj_op =
   | GetByLabel
   | GetRecord
   | GetAll
+  | GetAllWhere
   | GetAllRecordsWhere
   | GetAllRecords
   | Private of private_op

--- a/ocaml/idl/datamodel_types.mli
+++ b/ocaml/idl/datamodel_types.mli
@@ -210,6 +210,7 @@ and obj_op =
   | GetByLabel
   | GetRecord
   | GetAll
+  | GetAllWhere
   | GetAllRecordsWhere
   | GetAllRecords
   | Private of private_op

--- a/ocaml/idl/datamodel_utils.ml
+++ b/ocaml/idl/datamodel_utils.ml
@@ -683,6 +683,36 @@ let messages_of_obj (x : obj) document_order : message list =
     }
   in
 
+  let get_all_where =
+    {
+      get_all_public with
+      msg_name= "get_all_where"
+    ; msg_tag= FromObject GetAllWhere
+    ; msg_params=
+        [
+          {
+            param_type= String
+          ; param_name= "expr"
+          ; param_doc= "expression matching records"
+          ; param_release= x.obj_release
+          ; param_default= None
+          }
+        ]
+    ; msg_result= Some (Set (Ref x.name), "references to all matching objects")
+    ; msg_release=
+        {
+          opensource= []
+        ; internal=
+            x.obj_release.internal
+            (* This should be the release of getallwhere, or the class'
+                introduction, whichever is last. *)
+        ; internal_deprecated_since= None
+        }
+    ; msg_allowed_roles= x.obj_implicit_msg_allowed_roles
+    ; msg_hide_from_docs= true
+    }
+  in
+
   (* And the 'get_all_records_where' semi-public function *)
   let get_all_records_where =
     {
@@ -738,7 +768,7 @@ let messages_of_obj (x : obj) document_order : message list =
   in
   let get_all_public =
     if List.mem x.name expose_get_all_messages_for then
-      [get_all_public; get_all_records_where; get_all_records]
+      [get_all_public; get_all_where; get_all_records_where; get_all_records]
     else
       []
   in

--- a/ocaml/idl/ocaml_backend/gen_db_actions.ml
+++ b/ocaml/idl/ocaml_backend/gen_db_actions.ml
@@ -536,6 +536,12 @@ let db_action api : O.Module.t =
               "let expr' = Xapi_database.Db_filter.expr_of_string expr in"
             ; "get_records_where ~" ^ Gen_common.context ^ " ~expr:expr'"
             ]
+      | FromObject GetAllWhere ->
+          String.concat "\n"
+            [
+              "let expr' = Xapi_database.Db_filter.expr_of_string expr in"
+            ; "get_refs_where ~" ^ Gen_common.context ^ " ~expr:expr'"
+            ]
       | _ ->
           assert false
     in

--- a/ocaml/idl/ocaml_backend/gen_empty_custom.ml
+++ b/ocaml/idl/ocaml_backend/gen_empty_custom.ml
@@ -69,6 +69,7 @@ let operation_requires_side_effect ({msg_tag= tag; _} as msg) =
       | GetByUuid
       | GetByLabel
       | GetAll
+      | GetAllWhere
       | GetAllRecordsWhere
       | GetAllRecords ) ->
       false

--- a/ocaml/idl/ocaml_backend/gen_empty_custom.ml
+++ b/ocaml/idl/ocaml_backend/gen_empty_custom.ml
@@ -62,6 +62,8 @@ let operation_requires_side_effect ({msg_tag= tag; _} as msg) =
   match tag with
   | FromField (Setter, fld) ->
       fld.DT.field_has_effect
+  | FromField ((Getter | Add | Remove), _) ->
+      false
   | FromObject
       ( GetRecord
       | GetByUuid
@@ -70,12 +72,10 @@ let operation_requires_side_effect ({msg_tag= tag; _} as msg) =
       | GetAllRecordsWhere
       | GetAllRecords ) ->
       false
-  | FromObject _ ->
+  | FromObject (Make | Delete | Private _) ->
       true
   | Custom ->
       msg.DT.msg_has_effect && msg.DT.msg_forward_to = None
-  | _ ->
-      false
 
 let make_custom_api api =
   Dm_api.filter

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,7 +3,7 @@
 set -e
 
 list-hd () {
-  N=306
+  N=304
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD List.hd usages"


### PR DESCRIPTION
Using records in cross-pool migration code is dangerous, as the code interacts with potentially newer hosts. This means that fields in the record might be different from what's expected. In particular, adding an enum field can break the deserialization, and removing a field as well.

Instead, introduce and use a new call `get_all_where`: this calls allows the host to return a filtered list of object references.
 
With these changes, only SR records are used. This is done to minimize the number of calls done.