### PR TITLE
IH-642: Restructure xs-trace to use Cmdliner

### DIFF
--- a/ocaml/xs-trace/dune
+++ b/ocaml/xs-trace/dune
@@ -4,7 +4,20 @@
   (public_name xs-trace)
   (package xapi)
   (libraries
+    cmdliner
     tracing_export
     xapi-stdext-unix
   )
+)
+
+(rule
+  (targets xs-trace.1)
+  (deps (:exe xs_trace.exe))
+  (action (with-stdout-to %{targets} (run %{exe} --help=groff)))
+)
+
+(install
+  (section man)
+  (package xapi)
+  (files (xs-trace.1 as man1/xs-trace.1))
 )


### PR DESCRIPTION
The xs-trace utility is restructured to enhance its readability and, to aid with potential future extension, its CLI is reimplemented in terms of Cmdliner.

It is hoped that the current command modes are consistent with what was already expected by xs-trace, i.e. xs-trace (cp|mv) <src> <endpoint>

These changes should make it simpler to extend this utility with more functionality. For example, there is an idea to add some short conversion routines from Zipkinv2 to Google's Catapult trace format - so that single host triaging can bypass heavy distributed tracing services and use functionality built into Chrome (or the online Perfetto trace viewer).

![image](https://github.com/xapi-project/xen-api/assets/20199633/addfd008-b996-4ea2-b837-fa30f983bc73)
![image](https://github.com/xapi-project/xen-api/assets/20199633/fa77be77-d9f4-4029-ab19-1bab5f6f8ca7)