### PR TITLE
CP-49918: Moved pool_update.apply from scripts/extensions to python3/extensions directory

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -13,7 +13,6 @@ install:
 	$(IPROG) -d $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) -d $(DESTDIR)/etc/sysconfig
 	$(IPROG) -d $(DESTDIR)/usr/lib/systemd/system
-
 	$(IPROG) -d $(DESTDIR)$(EXTENSIONDIR)
 
 	
@@ -33,6 +32,7 @@ install:
 	$(IPROG) bin/hfx_filename $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/perfmon $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/xe-scsi-dev-map $(DESTDIR)$(OPTDIR)/bin
+	$(IPROG) extensions/pool_update.apply $(DESTDIR)$(EXTENSIONDIR)
 
 	$(IPROG) extensions/Test.test $(DESTDIR)$(EXTENSIONDIR)
 	$(IPROG) plugins/disk-space $(DESTDIR)$(PLUGINDIR)

--- a/python3/extensions/pool_update.apply
+++ b/python3/extensions/pool_update.apply
@@ -1,83 +1,103 @@
 #!/usr/bin/env python3
 
 
-import xmlrpc.client
-import sys
-import XenAPI
+import errno
 import json
-import traceback
-import subprocess
+import logging
 import os
 import re
-import fasteners
-import errno
 import shutil
-import logging
-import xcp.logger
+import subprocess
+import sys
+import traceback
+import xmlrpc.client
 
-TMP_DIR = '/tmp/'
-UPDATE_ALREADY_APPLIED = 'UPDATE_ALREADY_APPLIED'
-UPDATE_APPLY_FAILED = 'UPDATE_APPLY_FAILED'
-OTHER_OPERATION_IN_PROGRESS = 'OTHER_OPERATION_IN_PROGRESS'
-UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR = 'UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR'
-CANNOT_FIND_UPDATE = 'CANNOT_FIND_UPDATE'
-INVALID_UPDATE = 'INVALID_UPDATE'
-ERROR_MESSAGE_DOWNLOAD_PACKAGE = 'Error downloading packages:\n'
-ERROR_MESSAGE_START = 'Error: '
-ERROR_MESSAGE_END = 'You could try '
+import fasteners
+import xcp.logger
+import XenAPI
+
+TMP_DIR = "/tmp/"
+UPDATE_ALREADY_APPLIED = "UPDATE_ALREADY_APPLIED"
+UPDATE_APPLY_FAILED = "UPDATE_APPLY_FAILED"
+OTHER_OPERATION_IN_PROGRESS = "OTHER_OPERATION_IN_PROGRESS"
+UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR = "UPDATE_PRECHECK_FAILED_UNKNOWN_ERROR"
+CANNOT_FIND_UPDATE = "CANNOT_FIND_UPDATE"
+INVALID_UPDATE = "INVALID_UPDATE"
+ERROR_MESSAGE_DOWNLOAD_PACKAGE = "Error downloading packages:\n"
+ERROR_MESSAGE_START = "Error: "
+ERROR_MESSAGE_END = "You could try "
+
 
 class EnvironmentFailure(Exception):
     pass
 
+
 class ApplyFailure(Exception):
     pass
+
 
 class InvalidUpdate(Exception):
     pass
 
+
 def success_message():
-    rpcparams = {'Status': 'Success', 'Value': ''}
-    return xmlrpc.client.dumps((rpcparams, ), '', True)
+    rpcparams = {"Status": "Success", "Value": ""}
+    return xmlrpc.client.dumps((rpcparams,), "", True)
 
 
 def failure_message(code, params):
-    rpcparams = {
-        'Status': 'Failure', 'ErrorDescription': [code] + params}
-    return xmlrpc.client.dumps((rpcparams, ), '', True)
+    rpcparams = {"Status": "Failure", "ErrorDescription": [code] + params}
+    return xmlrpc.client.dumps((rpcparams,), "", True)
 
 
 def execute_apply(session, update_package, yum_conf_file):
     yum_env = os.environ.copy()
-    yum_env['LANG'] = 'C'
+    yum_env["LANG"] = "C"
 
-    cmd = ['yum', 'clean', 'all', '--noplugins', '-c', yum_conf_file]
-    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env, universal_newlines=True)
+    cmd = ["yum", "clean", "all", "--noplugins", "-c", yum_conf_file]
+    p = subprocess.Popen(
+        cmd,
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        close_fds=True,
+        env=yum_env,
+        universal_newlines=True,
+    )
     output, _ = p.communicate()
-    for line in output.split('\n'):
+    for line in output.split("\n"):
         xcp.logger.info(line)
     if p.returncode != 0:
         raise EnvironmentFailure("Error cleaning yum cache")
 
-    cmd = ['yum', 'upgrade', '-y', '--noplugins', '-c', yum_conf_file, update_package]
-    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, env=yum_env, universal_newlines=True)
+    cmd = ["yum", "upgrade", "-y", "--noplugins", "-c", yum_conf_file, update_package]
+    p = subprocess.Popen(
+        cmd,
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        close_fds=True,
+        env=yum_env,
+        universal_newlines=True,
+    )
     output, _ = p.communicate()
-    xcp.logger.info('pool_update.apply %r returncode=%r output:', cmd, p.returncode)
-    for line in output.split('\n'):
+    xcp.logger.info("pool_update.apply %r returncode=%r output:", cmd, p.returncode)
+    for line in output.split("\n"):
         xcp.logger.info(line)
     if p.returncode != 0:
         if ERROR_MESSAGE_DOWNLOAD_PACKAGE in output:
-            raise InvalidUpdate('Missing package(s) in the update.')
+            raise InvalidUpdate("Missing package(s) in the update.")
 
-        m = re.search('(?<=' + ERROR_MESSAGE_START + ').+$', output, flags=re.DOTALL)
+        m = re.search("(?<=" + ERROR_MESSAGE_START + ").+$", output, flags=re.DOTALL)
         if m:
             errmsg = m.group()
-            errmsg = re.sub(ERROR_MESSAGE_END + '.+', '', errmsg, flags=re.DOTALL)
+            errmsg = re.sub(ERROR_MESSAGE_END + ".+", "", errmsg, flags=re.DOTALL)
             raise ApplyFailure(errmsg)
         else:
             raise ApplyFailure(output)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     xcp.logger.logToSyslog(level=logging.INFO)
     txt = sys.stdin.read()
     params, method = xmlrpc.client.loads(txt)
@@ -86,27 +106,29 @@ if __name__ == '__main__':
     lock_acquired = False
     try:
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '', '', 'Pool_update')
+        session.xenapi.login_with_password("root", "", "", "Pool_update")
 
         update = params[1]
         host = params[2]
         # Check if the update has been applied.
         if update in session.xenapi.host.get_updates(host):
-            print(failure_message(
-                UPDATE_ALREADY_APPLIED, [update]))
+            print(failure_message(UPDATE_ALREADY_APPLIED, [update]))
             sys.exit(0)
 
         update_uuid = session.xenapi.pool_update.get_uuid(update)
-        yum_conf_file = os.path.join(TMP_DIR, update_uuid, 'yum.conf')
+        yum_conf_file = os.path.join(TMP_DIR, update_uuid, "yum.conf")
 
         # To prevent the race condition of invoking apply, set a lock.
-        lock_file = os.path.join(TMP_DIR, update_uuid + '.lck')
+        lock_file = os.path.join(TMP_DIR, update_uuid + ".lck")
         lock = fasteners.InterProcessLock(lock_file)
         lock_acquired = lock.acquire(blocking=False)
 
         if not lock_acquired:
-            print(failure_message(
-                OTHER_OPERATION_IN_PROGRESS, ['Applying the update', update]))
+            print(
+                failure_message(
+                    OTHER_OPERATION_IN_PROGRESS, ["Applying the update", update]
+                )
+            )
             sys.exit(0)
 
         # Run precheck
@@ -136,10 +158,10 @@ if __name__ == '__main__':
                     pass
                 else:
                     raise
-            with open (yum_conf_file, "w+") as file:
+            with open(yum_conf_file, "w+") as file:
                 file.write("{0}".format(yum_conf))
 
-            execute_apply(session, '@update', yum_conf_file)
+            execute_apply(session, "@update", yum_conf_file)
 
             session.xenapi.pool_update.resync_host(host)
             print(success_message())

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -116,7 +116,6 @@ install:
 	$(IPROG) pbis-force-domain-leave $(DESTDIR)$(LIBEXECDIR)
 	mkdir -p $(DESTDIR)$(EXTENSIONDIR)
 	$(IPROG) extensions/pool_update.precheck $(DESTDIR)$(EXTENSIONDIR)
-	$(IPROG) extensions/pool_update.apply $(DESTDIR)$(EXTENSIONDIR)
 	mkdir -p $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/extauth-hook $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/extauth-hook-AD.py $(DESTDIR)$(PLUGINDIR)


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task CP-49918:

- Modified python3/Makefile to include  pool_update.apply
- Removed pool_update.apply from scripts/Makefile
- Fixed import order

Signed-off-by: Ashwinh <ashwin.h@cloud.com>