### PR TITLE
CP-50135: Bump datamodel_lifecycle for anti-affinity

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -1,4 +1,6 @@
 let prototyped_of_class = function
+  | "VM_group" ->
+      Some "24.18.0-next"
   | "Observer" ->
       Some "23.14.0"
   | "VTPM" ->
@@ -7,6 +9,10 @@ let prototyped_of_class = function
       None
 
 let prototyped_of_field = function
+  | "VM_group", "VMs" ->
+      Some "24.18.0-next"
+  | "VM_group", "placement" ->
+      Some "24.18.0-next"
   | "Observer", "enabled" ->
       Some "23.14.0"
   | "Observer", "components" ->
@@ -55,6 +61,8 @@ let prototyped_of_field = function
       Some "22.27.0"
   | "host", "last_software_update" ->
       Some "22.20.0"
+  | "VM", "groups" ->
+      Some "24.18.0-next"
   | "VM", "pending_guidances_full" ->
       Some "24.10.0"
   | "VM", "pending_guidances_recommended" ->
@@ -63,6 +71,8 @@ let prototyped_of_field = function
       Some "23.18.0"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
+  | "pool", "recommendations" ->
+      Some "24.18.0-next"
   | "pool", "update_sync_enabled" ->
       Some "23.18.0"
   | "pool", "update_sync_day" ->
@@ -139,6 +149,8 @@ let prototyped_of_message = function
       Some "24.17.0"
   | "VM", "restart_device_models" ->
       Some "23.30.0"
+  | "VM", "set_groups" ->
+      Some "24.18.0-next"
   | "pool", "get_guest_secureboot_readiness" ->
       Some "24.17.0"
   | "pool", "set_ext_auth_max_threads" ->


### PR DESCRIPTION
datamodel_lifecycle.ml needs to be bumped to 24.18.0-next for anti-affinity change.