### PR TITLE
fe_test: fix compatibility with fd-send-recv 2.0.2

### DIFF
--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -221,9 +221,10 @@ let test_internal_failure_error () =
     Forkhelpers.safe_close_and_exec None (Some fd) None [] exe args |> ignore ;
     fail "Expected an exception"
   with
-  | Fd_send_recv.Unix_error _ ->
+  | Fd_send_recv.Unix_error _ | Unix.Unix_error (Unix.EBADF, _, _) ->
       leak_fd_detect ()
   | e ->
+      Printexc.print_backtrace stderr;
       fail "Failed with unexpected exception: %s" (Printexc.to_string e)
 
 let master fds =

--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -224,7 +224,7 @@ let test_internal_failure_error () =
   | Fd_send_recv.Unix_error _ | Unix.Unix_error (Unix.EBADF, _, _) ->
       leak_fd_detect ()
   | e ->
-      Printexc.print_backtrace stderr;
+      Printexc.print_backtrace stderr ;
       fail "Failed with unexpected exception: %s" (Printexc.to_string e)
 
 let master fds =


### PR DESCRIPTION
2.0.2 introduced a breaking change (maybe it should've been 3.0): it no longer raises Fd_send_recv.Unix_error, but Unix.Unix_error.
The test code here was specifically catching just Fd_send_recv.Unix_error. Make it catch both.