### PR TITLE
CP-50193: Update new fingerprint fields on DB upgrade

### DIFF
--- a/ocaml/idl/datamodel_certificate.ml
+++ b/ocaml/idl/datamodel_certificate.ml
@@ -69,10 +69,10 @@ let t =
             [(Published, rel_stockholm, ""); (Deprecated, "24.19.0", "")]
           ~ty:String "fingerprint" ~default_value:(Some (VString ""))
           "Use fingerprint_sha256 instead"
-      ; field ~qualifier:StaticRO ~lifecycle ~ty:String "fingerprint_sha256"
+      ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:String "fingerprint_sha256"
           ~default_value:(Some (VString ""))
           "The certificate's SHA256 fingerprint / hash"
-      ; field ~qualifier:StaticRO ~lifecycle ~ty:String "fingerprint_sha1"
+      ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:String "fingerprint_sha1"
           ~default_value:(Some (VString ""))
           "The certificate's SHA1 fingerprint / hash"
       ]

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 779
+let schema_minor_vsn = 780
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -27,6 +27,10 @@ let prototyped_of_field = function
       Some "23.14.0"
   | "Repository", "gpgkey_path" ->
       Some "22.12.0"
+  | "Certificate", "fingerprint_sha1" ->
+      Some "24.19.1-next"
+  | "Certificate", "fingerprint_sha256" ->
+      Some "24.19.1-next"
   | "Cluster_host", "last_update_live" ->
       Some "24.3.0"
   | "Cluster_host", "live" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "efdb1c7e536362523741ccdb7f33f797"
+let last_known_schema_hash = "7885f7b085e4a5e32977a4b222030412"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -80,6 +80,9 @@ let pp_hash hash =
   in
   String.init length value_of
 
+let pp_fingerprint ~hash_type cert =
+  X509.Certificate.fingerprint hash_type cert |> pp_hash
+
 let safe_char c =
   match c with
   | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' ->
@@ -218,12 +221,8 @@ end = struct
     let not_before, not_after =
       dates_of_ptimes (X509.Certificate.validity certificate)
     in
-    let fingerprint_sha256 =
-      X509.Certificate.fingerprint `SHA256 certificate |> pp_hash
-    in
-    let fingerprint_sha1 =
-      X509.Certificate.fingerprint `SHA1 certificate |> pp_hash
-    in
+    let fingerprint_sha256 = pp_fingerprint ~hash_type:`SHA256 certificate in
+    let fingerprint_sha1 = pp_fingerprint ~hash_type:`SHA1 certificate in
     let uuid = Uuidx.(to_string (make ())) in
     let ref' = Ref.make () in
     Db.Certificate.create ~__context ~ref:ref' ~uuid ~host ~not_before

--- a/ocaml/xapi/certificates.mli
+++ b/ocaml/xapi/certificates.mli
@@ -20,6 +20,9 @@ val pem_of_string : string -> X509.Certificate.t
 
 val pp_hash : Cstruct.t -> string
 
+val pp_fingerprint :
+  hash_type:Mirage_crypto.Hash.hash -> X509.Certificate.t -> string
+
 val validate_name : t_trusted -> string -> unit
 
 val hostnames_of_pem_cert :


### PR DESCRIPTION
The new fingerprint_sha256 and fingerprint_sha1 fields will be empty when upgrading from a version without the fields. This commit checks for this and fills them in, stopping the certificate from being needlessly reinstalled.