### PR TITLE
CP-49073: Add multihoming support for cluster

### DIFF
--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -80,6 +80,15 @@ let create =
          }
        ]
       @ timeout_params
+      @ [
+          {
+            param_type= Map (Int, Ref _pif)
+          ; param_name= "extra_PIFs"
+          ; param_doc= ""
+          ; param_release= numbered_release "24.18.0-next"
+          ; param_default= Some (VMap [])
+          }
+        ]
       )
     ~lifecycle ~allowed_roles:_R_POOL_OP
     ~errs:
@@ -136,6 +145,19 @@ let pool_create =
          }
        ]
       @ timeout_params
+      @ [
+          {
+            param_type= Map (Int, Ref _network)
+          ; param_name= "extra_networks"
+          ; param_doc=
+              "Additional networks, used for multi-homing. Input as a map, \
+               with the key representing the priority of the network, and \
+               value the uuid of the network. Key should range from 1-7, and \
+               keys outside of 1-7 will be ignored."
+          ; param_release= numbered_release "24.18.0-next"
+          ; param_default= Some (VMap [])
+          }
+        ]
       )
     ~lifecycle ~allowed_roles:_R_POOL_OP ()
 

--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -85,7 +85,8 @@ let create =
             param_type= Map (Int, Ref _pif)
           ; param_name= "extra_PIFs"
           ; param_doc= ""
-          ; param_release= numbered_release "24.18.0-next"
+          ; param_release=
+              numbered_release "24.19.2-next" (* TODO update this *)
           ; param_default= Some (VMap [])
           }
         ]
@@ -118,6 +119,33 @@ let get_network =
     ~result:(Ref _network, "network of cluster")
     ~params:[(Ref _cluster, "self", "the Cluster with the network")]
     ~lifecycle ~allowed_roles:_R_READ_ONLY ()
+
+let add_extra_network =
+  call ~name:"add_extra_network"
+    ~doc:
+      "Add network for cluster. This allows the underlying cluster stack to \
+       utilise multihoming."
+    ~params:
+      [
+        (Ref _cluster, "self", "the Cluster to which network is added")
+      ; (Int, "index", "the index of the network, representing its priority")
+      ; (Ref _network, "network", "the network to be added")
+      ]
+    ~lifecycle:[] ~allowed_roles:_R_POOL_OP
+    ~errs:Api_errors.[pif_index_exists_on_cluster_host]
+    ()
+
+let remove_extra_network =
+  call ~name:"remove_extra_network"
+    ~doc:
+      "Remove network from cluster. Counterpart of add_extra_network. If an \
+       index is not present in the current cluster, this call has no effect."
+    ~params:
+      [
+        (Ref _cluster, "self", "the Cluster from which network is removed")
+      ; (Int, "index", "the network index to be removed")
+      ]
+    ~lifecycle:[] ~allowed_roles:_R_POOL_OP ()
 
 let pool_create =
   call ~name:"pool_create"
@@ -273,6 +301,8 @@ let t =
         create
       ; destroy
       ; get_network
+      ; add_extra_network
+      ; remove_extra_network
       ; pool_create
       ; pool_force_destroy
       ; pool_destroy

--- a/ocaml/idl/datamodel_cluster_host.ml
+++ b/ocaml/idl/datamodel_cluster_host.ml
@@ -148,6 +148,9 @@ let t =
            "last_update_live" ~default_value:(Some (VDateTime Date.epoch))
            "Time when the live field was last updated based on information \
             from the cluster stack"
+       ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:Int "nodeid"
+           ~default_value:(Some (VInt 0L))
+           "Unique node id used by the cluster stack"
        ]
       @ allowed_and_current_operations cluster_host_operation
       @ [

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 780
+let schema_minor_vsn = 781
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1865,6 +1865,14 @@ let _ =
       "Cluster_host creation failed as the PIF provided is not attached to the \
        host."
     () ;
+  error Api_errors.pif_not_in_cluster_network ["pif"; "host"; "index"]
+    ~doc:
+      "PIF(s) on the cluster host is not in the same network as other PIFs \
+       with the same index on other cluster hosts"
+    () ;
+  error Api_errors.pif_index_exists_on_cluster_host ["index"; "cluster_host"]
+    ~doc:"Adding a new network to a cluster failed as the index already exists"
+    () ;
   error Api_errors.cluster_host_not_joined ["cluster_host"]
     ~doc:
       "Cluster_host operation failed as the cluster_host has not joined the \

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -35,6 +35,8 @@ let prototyped_of_field = function
       Some "24.3.0"
   | "Cluster_host", "live" ->
       Some "24.3.0"
+  | "Cluster_host", "other_PIFs" ->
+      Some "24.18.0-next"
   | "Cluster", "live_hosts" ->
       Some "24.3.0"
   | "Cluster", "quorum" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "7885f7b085e4a5e32977a4b222030412"
+let last_known_schema_hash = "4d5eaec09428599c84ebe1f01438fd79"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/sdk-gen/csharp/autogen/src/Converters.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Converters.cs
@@ -144,6 +144,36 @@ namespace XenAPI
     }
 
 
+    internal class LongXenRefMapConverter<T> : CustomJsonConverter<long, LongXenRefMapConverter Dictionary<XenRef<T>> where T : XenObject<T>
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JToken jToken = JToken.Load(reader);
+            var dict = new Dictionary<long, XenRef<T>>();
+
+            foreach (JProperty property in jToken)
+                dict.Add(property.Name.ToObject<long>(), new XenRef<T>(property.Value.ToString()));
+
+            return dict;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var dict = value as Dictionary<long, XenRef<T>>;
+            writer.WriteStartObject();
+            if (dict != null)
+            {
+                foreach (var kvp in dict)
+                {
+                    writer.WritePropertyName(kvp.Key)
+                    writer.WriteValue(kvp.Value.opaque_ref);
+                }
+            }
+            writer.WriteEndObject();
+        }
+    }
+
+
     internal class XenRefStringMapConverter<T> : CustomJsonConverter<Dictionary<XenRef<T>, string>> where T : XenObject<T>
     {
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -1137,6 +1137,8 @@ and json_converter typ =
         (exposed_class_name u)
   | Map (String, Ref v) ->
       sprintf "new StringXenRefMapConverter<%s>()" (exposed_class_name v)
+  | Map (Int, Ref v) ->
+      sprintf "new LongXenRefMapConverter<%s>()" (exposed_class_name v)
   | Map (String, String) ->
       sprintf "new StringStringMapConverter()"
   | Map (Ref _, _) | Map (_, Ref _) ->
@@ -1178,6 +1180,9 @@ and json_serialization_attr fr =
   | Map (Ref u, Int) ->
       sprintf "\n        [JsonConverter(typeof(XenRefLongMapConverter<%s>))]"
         (exposed_class_name u)
+  | Map (Int, Ref v) ->
+      sprintf "\n        [JsonConverter(typeof(LongXenrefMapConverter<%s>))]"
+        (exposed_class_name v)
   | Map (Ref u, String) ->
       sprintf "\n        [JsonConverter(typeof(XenRefStringMapConverter<%s>))]"
         (exposed_class_name u)

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -624,12 +624,12 @@ let make_vfs_on_pf ~__context ~pf ~num =
   make_vf num
 
 let make_cluster_host ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
-    ?(cluster = Ref.null) ?(host = Ref.null) ?(pIF = Ref.null) ?(enabled = true)
-    ?(joined = true) ?(live = true) ?(last_update_live = Date.epoch)
-    ?(allowed_operations = []) ?(current_operations = []) ?(other_config = [])
-    () =
-  Db.Cluster_host.create ~__context ~ref ~uuid ~cluster ~host ~pIF ~enabled
-    ~allowed_operations ~current_operations ~other_config ~joined ~live
+    ?(cluster = Ref.null) ?(host = Ref.null) ?(pIF = Ref.null)
+    ?(extra_PIFs = []) ?(enabled = true) ?(joined = true) ?(live = true)
+    ?(last_update_live = Date.epoch) ?(allowed_operations = [])
+    ?(current_operations = []) ?(other_config = []) () =
+  Db.Cluster_host.create ~__context ~ref ~uuid ~cluster ~host ~pIF ~extra_PIFs
+    ~enabled ~allowed_operations ~current_operations ~other_config ~joined ~live
     ~last_update_live ;
   ref
 

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -626,11 +626,11 @@ let make_vfs_on_pf ~__context ~pf ~num =
 let make_cluster_host ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ?(cluster = Ref.null) ?(host = Ref.null) ?(pIF = Ref.null)
     ?(extra_PIFs = []) ?(enabled = true) ?(joined = true) ?(live = true)
-    ?(last_update_live = Date.epoch) ?(allowed_operations = [])
+    ?(last_update_live = Date.epoch) ?(nodeid = 0L) ?(allowed_operations = [])
     ?(current_operations = []) ?(other_config = []) () =
   Db.Cluster_host.create ~__context ~ref ~uuid ~cluster ~host ~pIF ~extra_PIFs
     ~enabled ~allowed_operations ~current_operations ~other_config ~joined ~live
-    ~last_update_live ;
+    ~last_update_live ~nodeid ;
   ref
 
 let make_cluster_and_cluster_host ~__context ?(ref = Ref.make ())

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -115,8 +115,8 @@ let create_cluster ~__context
   Db.PIF.set_IP ~__context ~self:pIF ~value:"192.0.2.1" ;
   Db.PIF.set_currently_attached ~__context ~self:pIF ~value:true ;
   Db.PIF.set_disallow_unplug ~__context ~self:pIF ~value:true ;
-  Xapi_cluster.create ~__context ~pIF ~cluster_stack ~pool_auto_join:true
-    ~token_timeout ~token_timeout_coefficient
+  Xapi_cluster.create ~__context ~pIF ~extra_PIFs:[] ~cluster_stack
+    ~pool_auto_join:true ~token_timeout ~token_timeout_coefficient
 
 let test_create_destroy_status () =
   let __context = Test_common.make_test_database () in

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3615,6 +3615,26 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "cluster-add-extra-network"
+    , {
+        reqd= ["cluster-uuid"; "network-index"; "network-uuid"]
+      ; optn= []
+      ; help=
+          "Add extra network to the cluster, to be used by the cluster stack \
+           for multi-homing. Index represents the priority of this network."
+      ; implementation= No_fd Cli_operations.Cluster.add_extra_network
+      ; flags= []
+      }
+    )
+  ; ( "cluster-remove-extra-network"
+    , {
+        reqd= ["cluster-uuid"; "network-index"]
+      ; optn= []
+      ; help= "Remove extra network to the cluster, based on its index"
+      ; implementation= No_fd Cli_operations.Cluster.remove_extra_network
+      ; flags= []
+      }
+    )
   ; ( "cluster-host-create"
     , {
         reqd= ["cluster-uuid"; "host-uuid"; "pif-uuid"]

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3551,7 +3551,13 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "cluster-pool-create"
     , {
         reqd= ["network-uuid"]
-      ; optn= ["cluster-stack"; "token-timeout"; "token-timeout-coefficient"]
+      ; optn=
+          [
+            "cluster-stack"
+          ; "token-timeout"
+          ; "token-timeout-coefficient"
+          ; "extra-network-uuids"
+          ]
       ; help= "Create pool-wide cluster"
       ; implementation= No_fd Cli_operations.Cluster.pool_create
       ; flags= []
@@ -3593,6 +3599,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
           ; "pool-auto-join"
           ; "token-timeout"
           ; "token-timeout-coefficient"
+          ; "extra-pif-uuids"
           ]
       ; help= "Create new cluster with master as first member"
       ; implementation= No_fd Cli_operations.Cluster.create
@@ -3611,7 +3618,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "cluster-host-create"
     , {
         reqd= ["cluster-uuid"; "host-uuid"; "pif-uuid"]
-      ; optn= []
+      ; optn= ["other-pif-uuids"]
       ; help= "Add a host to an existing cluster"
       ; implementation= No_fd Cli_operations.Cluster_host.create
       ; flags= [Hidden]

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -1027,6 +1027,18 @@ let network_sriov_configuration_mode_to_string = function
   | `unknown ->
       "unknown"
 
+let i2brm_to_string get_uuid_from_ref sep x =
+  String.concat sep
+    (List.map (fun (a, b) -> Int64.to_string a ^ ": " ^ get_uuid_from_ref b) x)
+
+(* string_to_string_map_to_string *)
+let s2sm_to_string sep x =
+  String.concat sep (List.map (fun (a, b) -> a ^ ": " ^ b) x)
+
+(* string to blob ref map to string *)
+let s2brm_to_string get_uuid_from_ref sep x =
+  String.concat sep (List.map (fun (n, r) -> n ^ ": " ^ get_uuid_from_ref r) x)
+
 let on_boot_to_string onboot =
   match onboot with `reset -> "reset" | `persist -> "persist"
 

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5089,6 +5089,17 @@ let cluster_host_record rpc session_id cluster_host =
       ; make_field ~name:"PIF"
           ~get:(fun () -> (x ()).API.cluster_host_PIF |> get_uuid_from_ref)
           ()
+      ; make_field ~name:"extra_PIFs"
+          ~get:(fun () ->
+            Record_util.i2brm_to_string get_uuid_from_ref "; "
+              (x ()).API.cluster_host_extra_PIFs
+          )
+          ~get_map:(fun () ->
+            List.map
+              (fun (a, b) -> (Int64.to_string a, get_uuid_from_ref b))
+              (x ()).API.cluster_host_extra_PIFs
+          )
+          ()
       ; make_field ~name:"host"
           ~get:(fun () -> (x ()).API.cluster_host_host |> get_uuid_from_ref)
           ()

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1285,6 +1285,9 @@ let pif_not_attached_to_host = add_error "PIF_NOT_ATTACHED_TO_HOST"
 
 let pif_not_in_cluster_network = add_error "PIF_NOT_IN_CLUSTER_NETWORK"
 
+let pif_index_exists_on_cluster_host =
+  add_error "PIF_INDEX_EXISTS_ON_CLUSTER_HOST"
+
 let cluster_host_not_joined = add_error "CLUSTER_HOST_NOT_JOINED"
 
 let no_cluster_hosts_reachable = add_error "NO_CLUSTER_HOSTS_REACHABLE"

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1283,6 +1283,8 @@ let invalid_cluster_stack = add_error "INVALID_CLUSTER_STACK"
 
 let pif_not_attached_to_host = add_error "PIF_NOT_ATTACHED_TO_HOST"
 
+let pif_not_in_cluster_network = add_error "PIF_NOT_IN_CLUSTER_NETWORK"
+
 let cluster_host_not_joined = add_error "CLUSTER_HOST_NOT_JOINED"
 
 let no_cluster_hosts_reachable = add_error "NO_CLUSTER_HOSTS_REACHABLE"

--- a/ocaml/xapi/xapi_cluster.mli
+++ b/ocaml/xapi/xapi_cluster.mli
@@ -25,6 +25,7 @@ val create :
   -> pool_auto_join:bool
   -> token_timeout:float
   -> token_timeout_coefficient:float
+  -> extra_PIFs:(int64 * API.ref_PIF) list
   -> API.ref_Cluster
 (** [create ~__context ~cluster_stack ~pool_auto_join ~token_timeout
  *   ~token_timeout_coefficient] is the implementation of the XenAPI method
@@ -39,12 +40,23 @@ val get_network : __context:Context.t -> self:API.ref_Cluster -> API.ref_network
     as well as logging whether all the cluster hosts in the pool have
     PIFs on the same network *)
 
+val add_extra_network :
+     __context:Context.t
+  -> self:API.ref_Cluster
+  -> index:int64
+  -> network:API.ref_network
+  -> unit
+
+val remove_extra_network :
+  __context:Context.t -> self:API.ref_Cluster -> index:int64 -> unit
+
 val pool_create :
      __context:Context.t
   -> network:API.ref_network
   -> cluster_stack:string
   -> token_timeout:float
   -> token_timeout_coefficient:float
+  -> extra_networks:(int64 * API.ref_network) list
   -> API.ref_Cluster
 (** [pool_create ~__context ~network ~cluster_stack ~token_timeout
     ~token_timeout_coefficient] is the implementation of the XenAPI

--- a/ocaml/xapi/xapi_cluster_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_helpers.ml
@@ -114,6 +114,11 @@ let corosync3_enabled ~__context =
   let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
   List.assoc_opt "restrict_corosync3" restrictions = Some "false"
 
+let multihoming_enabled ~__context =
+  let pool = Helpers.get_pool ~__context in
+  let restrictions = Db.Pool.get_restrictions ~__context ~self:pool in
+  List.assoc_opt "restrict_multihoming" restrictions = Some "false"
+
 let maybe_generate_alert ~__context ~num_hosts ~hosts_left ~hosts_joined ~quorum
     =
   let generate_alert join cluster_host =

--- a/ocaml/xapi/xapi_cluster_host.ml
+++ b/ocaml/xapi/xapi_cluster_host.ml
@@ -83,7 +83,7 @@ let create_internal ~__context ~cluster ~host ~pIF ~extra_PIFs :
       Db.Cluster_host.create ~__context ~ref ~uuid ~cluster ~host ~pIF
         ~extra_PIFs ~enabled:false ~current_operations:[] ~allowed_operations:[]
         ~other_config:[] ~joined:false ~live:false
-        ~last_update_live:API.Date.epoch ;
+        ~last_update_live:API.Date.epoch ~nodeid:0L ;
       ref
   )
 

--- a/ocaml/xapi/xapi_cluster_host.mli
+++ b/ocaml/xapi/xapi_cluster_host.mli
@@ -45,6 +45,7 @@ val create :
   -> cluster:API.ref_Cluster
   -> host:API.ref_host
   -> pif:API.ref_PIF
+  -> extra_PIFs:(int64 * API.ref_PIF) list
   -> API.ref_Cluster_host
 (** [create ~__context ~cluster ~host] is implementation of the XenAPI call
     'Cluster_host.create'. It is the Cluster_host object constructor, and creates


### PR DESCRIPTION

Corosync 3 introduces multihoming support, where a node can be assigned multiple IP addresses, even with different IP stacks such as IPv4 and IPv6. Expose this feature in the xapi datamodel by introducing `other_networks` and `other_pifs`.

The previous `network` and `pif` field remains in place and the extra IPs will only be used as a fail-over: when corosync fails to communicate through the main pif, these secondary pifs will be used. In the future we could add more configs to allow other behaviours of the redundant pifs.

