### PR TITLE
Improve spelling and fix typos in comments of Python scripts

### DIFF
--- a/python3/bin/perfmon
+++ b/python3/bin/perfmon
@@ -27,7 +27,7 @@
 # based on the "start" CGI param.  It will return the highest level of granularity
 # available for the period requested.
 #
-# The "cf" CGI param specfies the row.  (All rows are returned if it's missing.)
+# The "cf" CGI param specifies the row. If it is not set, all rows are returned.
 
 # pylint: disable=too-many-lines, missing-class-docstring
 # pytype: disable=attribute-error

--- a/python3/libexec/nbd_client_manager.py
+++ b/python3/libexec/nbd_client_manager.py
@@ -96,7 +96,7 @@ def _call(cmd_args, error=True):
 
     if error and proc.returncode != 0:
         LOGGER.error(
-            "%s exitted with code %d: %s", " ".join(cmd_args), proc.returncode, stderr
+            "%s exited with code %d: %s", " ".join(cmd_args), proc.returncode, stderr
         )
 
         raise subprocess.CalledProcessError(

--- a/python3/packages/observer.py
+++ b/python3/packages/observer.py
@@ -33,13 +33,13 @@ from datetime import datetime, timezone
 from logging.handlers import SysLogHandler
 from typing import List, Sequence
 
-# The opentelemetry library may generate exceptions we aren't expecting, this code
+# The OpenTelemetry library may generate exceptions we aren't expecting: This code
 # must not fail or it will cause the pass-through script to fail when at worst
 # this script should be a noop. As such, we sometimes need to catch broad exceptions:
 # pylint: disable=broad-exception-caught, too-many-locals, too-many-statements
 # wrapt.decorator adds the extra parameters so we shouldn't provide them:
 # pylint: disable=no-value-for-parameter
-# We only want to import opentelemetry libraries if instrumentation is enabled
+# We only want to import OpenTelemetry libraries when instrumentation is enabled
 # pylint: disable=import-outside-toplevel
 
 DEBUG_ENABLED = os.getenv("XAPI_TEST")
@@ -103,7 +103,7 @@ def _init_tracing(configs: List[str], config_dir: str):
 
     If configs is empty, return the noop span and patch_module functions.
     If configs are passed:
-    - Import the opentelemetry packages
+    - Import the OpenTelemetry packages
     - Read the configuration file
     - Create a tracer
     - Trace the script
@@ -372,7 +372,7 @@ try:
     # are not overridden and will be the defined no-op functions.
     span, patch_module = _init_tracing(observer_configs, observer_config_dir)
 
-    # If tracing is now operational, explicity set "OTEL_SDK_DISABLED" to "false".
+    # If tracing is now operational, explicitly set "OTEL_SDK_DISABLED" to "false".
     # In our case, different from the standard, we want the tracing disabled by
     # default, so if the env variable is not set the noop implementation is used.
     os.environ["OTEL_SDK_DISABLED"] = "false"

--- a/python3/perfmon/perfmon
+++ b/python3/perfmon/perfmon
@@ -6,7 +6,7 @@ import os
 import socket
 import XenAPIPlugin
 
-# TODO: put this info plus all the supported cmds in a shared file
+# TODO: Document this information and all supported commands
 cmdsockname = "\0perfmon"  # an af_unix socket name (the "\0" stops socket.bind() creating a fs node)
 cmdmaxlen = 256
 

--- a/scripts/examples/python/XenAPIPlugin.py
+++ b/scripts/examples/python/XenAPIPlugin.py
@@ -16,7 +16,7 @@ else:
     import xmlrpc.client as xmlrpclib
 
 class Failure(Exception):
-    """Provide compatibilty with plugins written against XenServer 5.5 API"""
+    """Provide compatibility with plugins written against the XenServer 5.5 API"""
 
     def __init__(self, code, params):
         Exception.__init__(self)

--- a/scripts/plugins/extauth-hook-AD.py
+++ b/scripts/plugins/extauth-hook-AD.py
@@ -277,7 +277,7 @@ class UsersList(DynamicPam):
             logger.debug("Permit user %s, Current sid is %s",
                          formatted_name, sid)
             self._lines.append(formatted_name)
-            # If ssh key is permittd in authorized_keys,
+            # If the ssh key is permitted in the authorized_keys file,
             # The original name is compared, add UPN and original name
             if self._backend == ADBackend.BD_PBIS and name != formatted_name:
                 self._lines.append(name)
@@ -311,7 +311,7 @@ class GroupsList(DynamicPam):
 
 class KeyValueConfig(ADConfig):
     """
-     Only support configure files with key value in each line, seperated by sep
+     Only support configure files with key value in each line, separated by sep
      Otherwise, it will be just copied and un-configurable
      If multiple lines with the same key exists, only the first line will be configured
     """
@@ -475,7 +475,7 @@ def after_extauth_enable(session, args):
 
 
 def after_xapi_initialize(session, args):
-    """Callback afer xapi initialize"""
+    """Callback after xapi initialization"""
     return refresh_all_configurations(session, args, "after_xapi_initialize")
 
 
@@ -485,7 +485,7 @@ def after_subject_add(session, args):
 
 
 def after_subject_remove(session, args):
-    """Callbackk after remove subject"""
+    """Callback after remove subject"""
     return refresh_dynamic_pam(session, args, "after_subject_remove")
 
 


### PR DESCRIPTION
Improve spelling and fix typos in comments of Python scripts
(found using the [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) plugin)
