### PR TITLE
CP-50100: `backup-sr-metadata,restore-sr-metadata`: `2to3`, fix `pytype`, `pyright`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,6 @@ discard_messages_matching = [
 ]
 expected_to_fail = [
     # Need 2to3 -w <file> and maybe a few other minor updates:
-    "scripts/backup-sr-metadata.py",
     "scripts/restore-sr-metadata.py",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,8 +260,6 @@ discard_messages_matching = [
     "No Node.TEXT_NODE in module xml.dom.minidom, referenced from 'xml.dom.expatbuilder'"
 ]
 expected_to_fail = [
-    # Need 2to3 -w <file> and maybe a few other minor updates:
-    "scripts/restore-sr-metadata.py",
 ]
 
 # -----------------------------------------------------------------------------

--- a/python3/stubs/XenAPI.pyi
+++ b/python3/stubs/XenAPI.pyi
@@ -42,9 +42,12 @@ class _Dispatcher:
         """Authenticate the session with the XenAPI server."""
     def logout(self) -> None:
         """End the session with the XenAPI server."""
+
+    # Dynamic attributes that type checkers like pytype and pyright cannot check:
     session: Incomplete
     secret: Incomplete
     SR: Incomplete
+    VDI: Incomplete
     PBD: Incomplete
     pool: Incomplete
     VM: Incomplete

--- a/scripts/backup-sr-metadata.py
+++ b/scripts/backup-sr-metadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Back up the SR metadata and VDI list into an XML file
 # (c) Anil Madhavapeddy, Citrix Systems Inc, 2008
 
@@ -7,7 +7,7 @@ import XenAPI
 import sys
 import getopt
 import codecs
-from xml.dom.minidom import Document
+from xml.dom.minidom import Document  # pytype: disable=pyi-error
 
 def logout():
     try:
@@ -17,11 +17,11 @@ def logout():
 atexit.register(logout)
 
 def usage():
-    print >> sys.stderr, "%s [-f <output file>]" % sys.argv[0]
+    print("%s [-f <output file>]" % sys.argv[0], file=sys.stderr)
     sys.exit(1)
 
 def set_if_exists(xml, record, key):
-    if record.has_key(key):
+    if key in record:
         xml.setAttribute(key, record[key])
     else:
         xml.setAttribute(key, "")
@@ -32,8 +32,8 @@ def main(argv):
 
     try:
         opts, args = getopt.getopt(argv, "hf:", [])
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
 
     outfile = None
@@ -60,18 +60,18 @@ def main(argv):
         set_if_exists(srxml, srrec, 'uuid')
         set_if_exists(srxml, srrec, 'name_label')
         set_if_exists(srxml, srrec, 'name_description')
- 
+
         for vdiref in srrec['VDIs']:
-            try: 
+            try:
                 vdirec = session.xenapi.VDI.get_record(vdiref)
                 vdixml = doc.createElement("vdi")
                 set_if_exists(vdixml, vdirec, 'uuid')
                 set_if_exists(vdixml, vdirec, 'name_label')
                 set_if_exists(vdixml, vdirec, 'name_description')
                 srxml.appendChild(vdixml)
-            except:
-                print >> sys.stderr, "Failed to get VDI record for: %s" % vdiref
- 
+            except Exception:
+                print("Failed to get VDI record for: %s" % vdiref, file=sys.stderr)
+
         metaxml.appendChild(srxml)
 
     doc.writexml(f, encoding="utf-8")

--- a/scripts/backup-sr-metadata.py
+++ b/scripts/backup-sr-metadata.py
@@ -3,52 +3,56 @@
 # (c) Anil Madhavapeddy, Citrix Systems Inc, 2008
 
 import atexit
-import XenAPI
-import sys
-import getopt
 import codecs
+import contextlib
+import getopt
+import sys
 from xml.dom.minidom import Document  # pytype: disable=pyi-error
 
-def logout():
-    try:
-        session.xenapi.session.logout()
-    except:
-        pass
-atexit.register(logout)
+import XenAPI
+
 
 def usage():
     print("%s [-f <output file>]" % sys.argv[0], file=sys.stderr)
-    sys.exit(1)
+
 
 def set_if_exists(xml, record, key):
     if key in record:
         xml.setAttribute(key, record[key])
     else:
         xml.setAttribute(key, "")
-   
+
 def main(argv):
     session = XenAPI.xapi_local()
+
+    def logout():
+        with contextlib.suppress(Exception):
+            session.xenapi.session.logout()
+
+    atexit.register(logout)
+
     session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-backup-sr-metadata")
 
     try:
-        opts, args = getopt.getopt(argv, "hf:", [])
+        opts, _ = getopt.getopt(argv, "hf:", [])
     except getopt.GetoptError as err:
-        print(str(err))
+        print(err)
         usage()
+        sys.exit(1)
 
     outfile = None
     for o,a in opts:
         if o == "-f":
             outfile = a
 
-    if outfile == None:
+    if outfile is None:
         usage()
+        sys.exit(1)
 
     f = codecs.open(outfile, 'w', encoding="utf-8")
 
     srs = session.xenapi.SR.get_all_records()
-    vdis = session.xenapi.SR.get_all_records()
- 
+
     doc = Document()
 
     metaxml = doc.createElement("meta")
@@ -80,5 +84,3 @@ def main(argv):
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-
-

--- a/scripts/restore-sr-metadata.py
+++ b/scripts/restore-sr-metadata.py
@@ -4,19 +4,19 @@
 
 import atexit
 import contextlib
-import XenAPI
-import os, sys, time
 import getopt
+import io
+import sys
 from xml.dom.minidom import parse  # pytype: disable=pyi-error
-import codecs
 
-sys.stdout = codecs.getwriter("utf-8")(sys.stdout)
-sys.stderr = codecs.getwriter("utf-8")(sys.stderr)
+import XenAPI
+
+sys.stdout = io.open(sys.stdout.fileno(), "w", encoding="utf-8")
+sys.stderr = io.open(sys.stderr.fileno(), "w", encoding="utf-8")
 
 
 def usage():
     print("%s -f <input file> -u <sr uuid>" % sys.argv[0], file=sys.stderr)
-    sys.exit(1)
 
 def main(argv):
     session = XenAPI.xapi_local()
@@ -34,6 +34,7 @@ def main(argv):
     except getopt.GetoptError as err:
         print(str(err))
         usage()
+        sys.exit(1)
 
     infile = None
     sruuid = None
@@ -45,6 +46,7 @@ def main(argv):
 
     if infile == None:
         usage()
+        sys.exit(1)
 
     try:
         doc = parse(infile)
@@ -93,10 +95,12 @@ def main(argv):
                     session.xenapi.VDI.set_name_description(vdiref, vdi_descr)
                     print("  Description: %s" % vdi_descr)
                 except:
-                    print("Error setting VDI data for: %s (%s)" % (vdi_uuid, name_label), file=sys.stderr)
+                    print(
+                        "Error setting VDI data for: %s (%s)" % (vdi_uuid, name_label),
+                        file=sys.stderr,
+                    )
                     continue
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-
-

--- a/scripts/restore-sr-metadata.py
+++ b/scripts/restore-sr-metadata.py
@@ -3,34 +3,36 @@
 # (c) Anil Madhavapeddy, Citrix Systems Inc, 2008
 
 import atexit
+import contextlib
 import XenAPI
 import os, sys, time
 import getopt
-from xml.dom.minidom import parse
+from xml.dom.minidom import parse  # pytype: disable=pyi-error
 import codecs
 
 sys.stdout = codecs.getwriter("utf-8")(sys.stdout)
 sys.stderr = codecs.getwriter("utf-8")(sys.stderr)
 
-def logout():
-    try:
-        session.xenapi.session.logout()
-    except:
-        pass
-atexit.register(logout)
 
 def usage():
-    print >> sys.stderr, "%s -f <input file> -u <sr uuid>" % sys.argv[0]
+    print("%s -f <input file> -u <sr uuid>" % sys.argv[0], file=sys.stderr)
     sys.exit(1)
 
 def main(argv):
     session = XenAPI.xapi_local()
+
+    def logout():
+        with contextlib.suppress(Exception):
+            session.xenapi.session.logout()
+
+    atexit.register(logout)
+
     session.xenapi.login_with_password("", "", "1.0", "xen-api-scripts-restore-sr-metadata")
 
     try:
         opts, args = getopt.getopt(argv, "hf:u:", [])
-    except getopt.GetoptError, err:
-        print str(err)
+    except getopt.GetoptError as err:
+        print(str(err))
         usage()
 
     infile = None
@@ -47,11 +49,11 @@ def main(argv):
     try:
         doc = parse(infile)
     except:
-        print >> sys.stderr, "Error parsing %s" % infile
+        print("Error parsing %s" % infile, file=sys.stderr)
         sys.exit(1)
 
     if doc.documentElement.tagName != "meta":
-        print >> sys.stderr, "Unexpected root element while parsing %s" % infile
+        print("Unexpected root element while parsing %s" % infile, file=sys.stderr)
         sys.exit(1)
     
     for srxml in doc.documentElement.childNodes:
@@ -60,19 +62,19 @@ def main(argv):
             name_label = srxml.getAttribute("name_label")
             name_descr = srxml.getAttribute("name_description")
         except:
-            print >> sys.stderr, "Error parsing SR tag"
+            print("Error parsing SR tag", file=sys.stderr)
             continue
         # only set attributes on the selected SR passed in on cmd line
         if sruuid is None or sruuid == "all" or sruuid == uuid:
             try:
                 srref = session.xenapi.SR.get_by_uuid(uuid)
-                print "Setting SR (%s):" % uuid
+                print("Setting SR (%s):" % uuid)
                 session.xenapi.SR.set_name_label(srref, name_label)
-                print "  Name: %s " % name_label
+                print("  Name: %s " % name_label)
                 session.xenapi.SR.set_name_description(srref, name_descr)
-                print "  Description: %s" % name_descr
+                print("  Description: %s" % name_descr)
             except:
-                print >> sys.stderr, "Error setting SR data for: %s (%s)" % (uuid, name_label)
+                print("Error setting SR data for: %s (%s)" % (uuid, name_label), file=sys.stderr)
                 sys.exit(1)
             # go through all the SR VDIs and set the name_label and description
             for vdixml in srxml.childNodes:
@@ -81,17 +83,17 @@ def main(argv):
                     vdi_label = vdixml.getAttribute("name_label")
                     vdi_descr = vdixml.getAttribute("name_description")
                 except: 
-                    print >> sys.stderr, "Error parsing VDI tag"
+                    print("Error parsing VDI tag", file=sys.stderr)
                     continue
                 try:
                     vdiref = session.xenapi.VDI.get_by_uuid(vdi_uuid)
-                    print "Setting VDI (%s):" % vdi_uuid
+                    print("Setting VDI (%s):" % vdi_uuid)
                     session.xenapi.VDI.set_name_label(vdiref, vdi_label)
-                    print "  Name: %s" % vdi_label
+                    print("  Name: %s" % vdi_label)
                     session.xenapi.VDI.set_name_description(vdiref, vdi_descr)
-                    print "  Description: %s" % vdi_descr
+                    print("  Description: %s" % vdi_descr)
                 except:
-                    print >> sys.stderr, "Error setting VDI data for: %s (%s)" % (vdi_uuid, name_label)
+                    print("Error setting VDI data for: %s (%s)" % (vdi_uuid, name_label), file=sys.stderr)
                     continue
 
 if __name__ == "__main__":


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task  CP-50100:

 2to3 and warning fixes to prepare its to move to python3 dirrectory:

Commit 1:
- apply 2to3 -w and update shebang

Commit 2:

- pyright:

  - Add VDI to the XenAPI typing stub as we don't do type checking of VDI attributes yet.
  - move `sys.exit()` from inside `usage()` to after to make pyright aware of the `exit`.
- apply isort to sort the imports
- update the logout() handler to:
  - use `contextlib.suppress()`
  - move it into main() to fix the undeclared session warning.
- remove the unused variable `vdis`: `vdis = session.xenapi.SR.get_all_records()`
- remove trailing whitespace

Author : Signed-off-by: Bernhard Kaindl <bernhard.kaindl@cloud.com>

Committed by: Signed-off-by: Ashwinh <ashwin.h@cloud.com>