### PR TITLE
CP-49931 - Convert tabs to spaces and fix whitespace for scripts/xe-reset-networking:

### DIFF
--- a/scripts/xe-reset-networking
+++ b/scripts/xe-reset-networking
@@ -27,147 +27,147 @@ management_conf = '/etc/firstboot.d/data/management.conf'
 network_reset = '/tmp/network-reset'
 
 def read_dict_file(fname):
-	f = open(fname, 'r')
-	d = {}
-	for l in f.readlines():
-		kv = l.split('=')
-		d[kv[0].strip()] = kv[1].strip().strip("'")
-	return d
+    f = open(fname, 'r')
+    d = {}
+    for l in f.readlines():
+        kv = l.split('=')
+        d[kv[0].strip()] = kv[1].strip().strip("'")
+    return d
 
 def read_inventory():
-	return read_dict_file(inventory_file)
+    return read_dict_file(inventory_file)
 
 def read_management_conf():
-	return read_dict_file(management_conf)
+    return read_dict_file(management_conf)
 
 def write_inventory(inventory):
-	f = open(inventory_file, 'w')
-	for k in inventory:
-		f.write(k + "='" + inventory[k] + "'\n")
-	f.flush()
-	os.fsync(f.fileno())
-	f.close()
+    f = open(inventory_file, 'w')
+    for k in inventory:
+        f.write(k + "='" + inventory[k] + "'\n")
+    f.flush()
+    os.fsync(f.fileno())
+    f.close()
 
 def valid_vlan(vlan):
-	if not re.match('^\d+$', vlan):
-		return False
-	if int(vlan)<0 or int(vlan)>4094:
-		return False
-	return True
+    if not re.match('^\d+$', vlan):
+        return False
+    if int(vlan)<0 or int(vlan)>4094:
+        return False
+    return True
 
 if __name__ == "__main__":
-	parser = OptionParser()
-	parser.add_option("-m", "--master", help="Master's address", dest="address", default=None)
-	parser.add_option("--device", help="Device name of new management interface", dest="device", default=None)
-	parser.add_option("--mode", help='IP configuration mode for new management interface: "none", "dhcp" or "static" (default is dhcp)', dest="mode", default="dhcp")
-	parser.add_option("--mode-v6", help='IPv6 configuration mode for new management interface: "none", "dhcp", "autoconf" or "static" (default is none)', dest="mode_v6", default="none")
-	parser.add_option("--novlan", help="no vlan is used for new management interface", dest="novlan", action="store_const", const=True, default=False)
-	parser.add_option("--vlan", help="vlanID for new management interface to be on vlan network", dest="vlan", default=None)
-	parser.add_option("--ip", help="IP address for new management interface", dest="ip", default='')
-	parser.add_option("--ipv6", help="IPv6 address (CIDR format) for new management interface", dest="ipv6", default='')
-	parser.add_option("--netmask", help="Netmask for new management interface", dest="netmask", default='')
-	parser.add_option("--gateway", help="Gateway for new management interface", dest="gateway", default='')
-	parser.add_option("--gateway-v6", help="IPv6 Gateway for new management interface", dest="gateway_v6", default='')
-	parser.add_option("--dns", help="DNS server for new management interface", dest="dns", default='')
-	(options, args) = parser.parse_args()
-	
-	# Determine pool role
-	try:
-		f = open(pool_conf, 'r')
-		try:
-			l = f.readline()
-			ls = l.split(':')
-			if ls[0].strip() == 'master':
-				master = True
-				address = 'localhost'
-			else:
-				master = False
-				if options.address == None:
-					address = ls[1].strip()
-				else:
-					address = options.address
-		finally:
-			f.close()
-	except:
-		pass
-	
-	# Get the management device from the firstboot data if not specified by the user
-	if options.device == None:
-		try:
-			conf = read_management_conf()
-			device = conf['LABEL']
-		except:
-			print("Could not figure out which interface should become the management interface. \
-				Please specify one using the --device option.")
-			sys.exit(1)
-	else:
-		device = options.device
+    parser = OptionParser()
+    parser.add_option("-m", "--master", help="Master's address", dest="address", default=None)
+    parser.add_option("--device", help="Device name of new management interface", dest="device", default=None)
+    parser.add_option("--mode", help='IP configuration mode for new management interface: "none", "dhcp" or "static" (default is dhcp)', dest="mode", default="dhcp")
+    parser.add_option("--mode-v6", help='IPv6 configuration mode for new management interface: "none", "dhcp", "autoconf" or "static" (default is none)', dest="mode_v6", default="none")
+    parser.add_option("--novlan", help="no vlan is used for new management interface", dest="novlan", action="store_const", const=True, default=False)
+    parser.add_option("--vlan", help="vlanID for new management interface to be on vlan network", dest="vlan", default=None)
+    parser.add_option("--ip", help="IP address for new management interface", dest="ip", default='')
+    parser.add_option("--ipv6", help="IPv6 address (CIDR format) for new management interface", dest="ipv6", default='')
+    parser.add_option("--netmask", help="Netmask for new management interface", dest="netmask", default='')
+    parser.add_option("--gateway", help="Gateway for new management interface", dest="gateway", default='')
+    parser.add_option("--gateway-v6", help="IPv6 Gateway for new management interface", dest="gateway_v6", default='')
+    parser.add_option("--dns", help="DNS server for new management interface", dest="dns", default='')
+    (options, args) = parser.parse_args()
 
-	# Get the VLAN if provided in the firstboot data and not specified by the user
-	vlan = None
-	if options.vlan:
-		if options.novlan:
-			parser.error('"--vlan <vlanId>" and "--novlan" should not be used together')
-			sys.exit(1)
-		if not valid_vlan(options.vlan):
-			print("VLAN tag you gave was invalid, It must be between 0 and 4094")
-			sys.exit(1)
-		vlan = options.vlan
-	elif not options.novlan:
-		try:
-			conf = read_management_conf()
-			vlan = conf['VLAN']
-		except KeyError:
-			pass
+    # Determine pool role
+    try:
+        f = open(pool_conf, 'r')
+        try:
+            l = f.readline()
+            ls = l.split(':')
+            if ls[0].strip() == 'master':
+                master = True
+                address = 'localhost'
+            else:
+                master = False
+                if options.address == None:
+                    address = ls[1].strip()
+                else:
+                    address = options.address
+        finally:
+            f.close()
+    except:
+        pass
 
-	# Determine IP configuration for management interface
-	options.mode = options.mode.lower()
-	if options.mode not in ["none", "dhcp", "static"]:
-		parser.error('mode should be either "none", "dhcp" or "static"')
-		sys.exit(1)
+    # Get the management device from the firstboot data if not specified by the user
+    if options.device == None:
+        try:
+            conf = read_management_conf()
+            device = conf['LABEL']
+        except:
+            print("Could not figure out which interface should become the management interface. \
+                Please specify one using the --device option.")
+            sys.exit(1)
+    else:
+        device = options.device
 
-	options.mode_v6 = options.mode_v6.lower()
-	if options.mode not in ["none", "autoconf", "dhcp", "static"]:
-		parser.error('mode-v6 should be either "none", "autoconf", "dhcp" or "static"')
-		sys.exit(1)
+    # Get the VLAN if provided in the firstboot data and not specified by the user
+    vlan = None
+    if options.vlan:
+        if options.novlan:
+            parser.error('"--vlan <vlanId>" and "--novlan" should not be used together')
+            sys.exit(1)
+        if not valid_vlan(options.vlan):
+            print("VLAN tag you gave was invalid, It must be between 0 and 4094")
+            sys.exit(1)
+        vlan = options.vlan
+    elif not options.novlan:
+        try:
+            conf = read_management_conf()
+            vlan = conf['VLAN']
+        except KeyError:
+            pass
 
-	if options.mode == "none" and options.mode_v6 == "none":
-		parser.error("Either mode or mode-v6 must be not 'none'")
-		sys.exit(1)
-		
-	if options.mode == 'static' and (options.ip == '' or options.netmask == ''):
-		parser.error("if static IP mode is selected, an IP address and netmask need to be specified")
-		sys.exit(1)
-  
-	if options.mode_v6 == 'static':
-		if options.ipv6 == '':
-	 		parser.error("if static IPv6 mode is selected, an IPv6 address needs to be specified")
-		elif options.ipv6.find('/') == -1:
-			parser.error("Invalid format: IPv6 must be specified with CIDR format: <IPv6>/<prefix>")
-		sys.exit(1)
-  
-	# Warn user
-	if not os.access('/tmp/fist_network_reset_no_warning', os.F_OK):
-		configuration = []
-		configuration.append("Management interface:   " + device)
-		configuration.append("IP configuration mode:  " + options.mode)
-		configuration.append("IPv6 configuration mode:" + options.mode_v6)
-		if vlan != None:
-			configuration.append("Vlan:                   " + vlan)
-		if options.mode == "static":
-			configuration.append("IP address:             " + options.ip)
-			configuration.append("Netmask:                " + options.netmask)
-		if options.mode_v6 == "static":
-			configuration.append("IPv6/CIDR:              " + options.ipv6)
-		if options.gateway != '':
-			configuration.append("Gateway:                " + options.gateway)
-		if options.gateway_v6 != '':
-			configuration.append("IPv6 gateway:           " + options.gateway_v6)
-		if options.dns != '':
-			configuration.append("DNS server(s):          " + options.dns)
-		if master == False:
-			configuration.append("Pool master's address:  " + address)
-		warning = """----------------------------------------------------------------------
+    # Determine IP configuration for management interface
+    options.mode = options.mode.lower()
+    if options.mode not in ["none", "dhcp", "static"]:
+        parser.error('mode should be either "none", "dhcp" or "static"')
+        sys.exit(1)
+
+    options.mode_v6 = options.mode_v6.lower()
+    if options.mode not in ["none", "autoconf", "dhcp", "static"]:
+        parser.error('mode-v6 should be either "none", "autoconf", "dhcp" or "static"')
+        sys.exit(1)
+
+    if options.mode == "none" and options.mode_v6 == "none":
+        parser.error("Either mode or mode-v6 must be not 'none'")
+        sys.exit(1)
+
+    if options.mode == 'static' and (options.ip == '' or options.netmask == ''):
+        parser.error("if static IP mode is selected, an IP address and netmask need to be specified")
+        sys.exit(1)
+
+    if options.mode_v6 == 'static':
+        if options.ipv6 == '':
+            parser.error("if static IPv6 mode is selected, an IPv6 address needs to be specified")
+        elif options.ipv6.find('/') == -1:
+            parser.error("Invalid format: IPv6 must be specified with CIDR format: <IPv6>/<prefix>")
+        sys.exit(1)
+
+    # Warn user
+    if not os.access('/tmp/fist_network_reset_no_warning', os.F_OK):
+        configuration = []
+        configuration.append("Management interface:   " + device)
+        configuration.append("IP configuration mode:  " + options.mode)
+        configuration.append("IPv6 configuration mode:" + options.mode_v6)
+        if vlan != None:
+            configuration.append("Vlan:                   " + vlan)
+        if options.mode == "static":
+            configuration.append("IP address:             " + options.ip)
+            configuration.append("Netmask:                " + options.netmask)
+        if options.mode_v6 == "static":
+            configuration.append("IPv6/CIDR:              " + options.ipv6)
+        if options.gateway != '':
+            configuration.append("Gateway:                " + options.gateway)
+        if options.gateway_v6 != '':
+            configuration.append("IPv6 gateway:           " + options.gateway_v6)
+        if options.dns != '':
+            configuration.append("DNS server(s):          " + options.dns)
+        if master == False:
+            configuration.append("Pool master's address:  " + address)
+        warning = """----------------------------------------------------------------------
 !! WARNING !!
 
 This command will reboot the host and reset its network configuration.
@@ -179,115 +179,114 @@ Before completing this command:
 ----------------------------------------------------------------------
 
 Your network will be re-configured as follows:\n\n"""
-		confirmation = """\n\nIf you want to change any of the above settings, type 'no' and re-run
+        confirmation = """\n\nIf you want to change any of the above settings, type 'no' and re-run
 the command with appropriate arguments (use --help for a list of options).
 
 Type 'yes' to continue.
 Type 'no' to cancel.
 """
-		res = input(warning + '\n'.join(configuration) + confirmation)
-		if res != 'yes':
-			sys.exit(1)
-	
-	# Update master's IP, if needed and given
-	if master == False and options.address != None:
-		print("Setting master's ip (" + address + ")...")
-		try:
-			f = open(pool_conf, 'w')
-			f.write('slave:' + address)
-		finally:
-			f.flush()
-			os.fsync(f.fileno())
-			f.close()
+        res = input(warning + '\n'.join(configuration) + confirmation)
+        if res != 'yes':
+            sys.exit(1)
 
-	# Construct bridge name for management interface based on convention
-	if device[:3] == 'eth':
-		bridge = 'xenbr' + device[3:]
-	else:
-		bridge = 'br' + device
-	
-	# Ensure xapi is not running
-	print("Stopping xapi...")
-	os.system('service xapi stop >/dev/null 2>/dev/null')
-	
-	# Reconfigure new management interface
-	print("Reconfiguring " + device + "...")
-	os.system('systemctl stop xcp-networkd >/dev/null 2>/dev/null')
-	try:
-		os.remove('/var/lib/xcp/networkd.db')
-	except Exception as e:
-		print('Warning: Failed to delete networkd.db.\n%s' % e)
+    # Update master's IP, if needed and given
+    if master == False and options.address != None:
+        print("Setting master's ip (" + address + ")...")
+        try:
+            f = open(pool_conf, 'w')
+            f.write('slave:' + address)
+        finally:
+            f.flush()
+            os.fsync(f.fileno())
+            f.close()
 
-	# Update interfaces in inventory file
-	print('Updating inventory file...')
-	inventory = read_inventory()
-	if vlan != None:
-		inventory['MANAGEMENT_INTERFACE'] = 'xentemp'
-	else:
-		inventory['MANAGEMENT_INTERFACE'] = bridge
-	inventory['CURRENT_INTERFACES'] = ''
-	write_inventory(inventory)
+    # Construct bridge name for management interface based on convention
+    if device[:3] == 'eth':
+        bridge = 'xenbr' + device[3:]
+    else:
+        bridge = 'br' + device
 
-	# Rewrite firstboot management.conf file, which will be picked it by xcp-networkd on restart (if used)
-	is_static = False
-	try:
-		f = open(management_conf, 'w')
-		f.write("LABEL='" + device + "'\n")
-		if options.mode != "none":
-			f.write("MODE='" + options.mode + "'\n")
-		if options.mode_v6 != "none":
-			f.write("MODEV6='" + options.mode_v6 + "'\n")
-		if vlan != None:
-			f.write("VLAN='" + vlan + "'\n")
-		if options.mode == 'static':
-			is_static = True
-			f.write("IP='" + options.ip + "'\n")
-			f.write("NETMASK='" + options.netmask + "'\n")
-			if options.gateway != '':
-				f.write("GATEWAY='" + options.gateway + "'\n")
-		if options.mode_v6 == "static":
-			is_static = True
-			f.write("IPv6='" + options.ipv6 + "'\n")
-			if options.gateway_v6 != '':
-				f.write("IPv6_GATEWAY='" + options.gateway_v6 + "'\n")
-		if is_static and options.dns != '':
-			f.write("DNS='" + options.dns + "'\n")
-	finally:
-		f.flush()
-		os.fsync(f.fileno())
-		f.close()
+    # Ensure xapi is not running
+    print("Stopping xapi...")
+    os.system('service xapi stop >/dev/null 2>/dev/null')
 
-	# Write trigger file for XAPI to continue the network reset on startup
-	try:
-		f = open(network_reset, 'w')
-		f.write('DEVICE=' + device + '\n')
-		if options.mode != "none":
-			f.write('MODE=' + options.mode + '\n')
-		if options.mode_v6 != "none":
-			f.write('MODE_V6=' + options.mode_v6 + '\n')
-		if vlan != None:
-			f.write('VLAN=' + vlan + '\n')
-		if options.mode == 'static':
-			f.write('IP=' + options.ip + '\n')
-			f.write('NETMASK=' + options.netmask + '\n')
-			if options.gateway != '':
-				f.write('GATEWAY=' + options.gateway + '\n')
-		if options.mode_v6 == "static":
-			f.write('IPV6=' + options.ipv6 + '\n')
-			if options.gateway_v6 != '':
-				f.write('GATEWAY_V6=' + options.gateway_v6 + '\n')
-		if is_static and options.dns != '':
-			f.write('DNS=' + options.dns + '\n')
-	finally:
-		f.flush()
-		os.fsync(f.fileno())
-		f.close()
+    # Reconfigure new management interface
+    print("Reconfiguring " + device + "...")
+    os.system('systemctl stop xcp-networkd >/dev/null 2>/dev/null')
+    try:
+        os.remove('/var/lib/xcp/networkd.db')
+    except Exception as e:
+        print('Warning: Failed to delete networkd.db.\n%s' % e)
 
-	# Reset the domain 0 network interface naming configuration
-	# back to a fresh-install state for the currently-installed
-	# hardware.
-	os.system("/etc/sysconfig/network-scripts/interface-rename.py --reset-to-install")
+    # Update interfaces in inventory file
+    print('Updating inventory file...')
+    inventory = read_inventory()
+    if vlan != None:
+        inventory['MANAGEMENT_INTERFACE'] = 'xentemp'
+    else:
+        inventory['MANAGEMENT_INTERFACE'] = bridge
+    inventory['CURRENT_INTERFACES'] = ''
+    write_inventory(inventory)
 
-	# Reboot
-	os.system("mount -o remount,rw / && reboot -f")
+    # Rewrite firstboot management.conf file, which will be picked it by xcp-networkd on restart (if used)
+    is_static = False
+    try:
+        f = open(management_conf, 'w')
+        f.write("LABEL='" + device + "'\n")
+        if options.mode != "none":
+            f.write("MODE='" + options.mode + "'\n")
+        if options.mode_v6 != "none":
+            f.write("MODEV6='" + options.mode_v6 + "'\n")
+        if vlan != None:
+            f.write("VLAN='" + vlan + "'\n")
+        if options.mode == 'static':
+            is_static = True
+            f.write("IP='" + options.ip + "'\n")
+            f.write("NETMASK='" + options.netmask + "'\n")
+            if options.gateway != '':
+                f.write("GATEWAY='" + options.gateway + "'\n")
+        if options.mode_v6 == "static":
+            is_static = True
+            f.write("IPv6='" + options.ipv6 + "'\n")
+            if options.gateway_v6 != '':
+                f.write("IPv6_GATEWAY='" + options.gateway_v6 + "'\n")
+        if is_static and options.dns != '':
+            f.write("DNS='" + options.dns + "'\n")
+    finally:
+        f.flush()
+        os.fsync(f.fileno())
+        f.close()
 
+    # Write trigger file for XAPI to continue the network reset on startup
+    try:
+        f = open(network_reset, 'w')
+        f.write('DEVICE=' + device + '\n')
+        if options.mode != "none":
+            f.write('MODE=' + options.mode + '\n')
+        if options.mode_v6 != "none":
+            f.write('MODE_V6=' + options.mode_v6 + '\n')
+        if vlan != None:
+            f.write('VLAN=' + vlan + '\n')
+        if options.mode == 'static':
+            f.write('IP=' + options.ip + '\n')
+            f.write('NETMASK=' + options.netmask + '\n')
+            if options.gateway != '':
+                f.write('GATEWAY=' + options.gateway + '\n')
+        if options.mode_v6 == "static":
+            f.write('IPV6=' + options.ipv6 + '\n')
+            if options.gateway_v6 != '':
+                f.write('GATEWAY_V6=' + options.gateway_v6 + '\n')
+        if is_static and options.dns != '':
+            f.write('DNS=' + options.dns + '\n')
+    finally:
+        f.flush()
+        os.fsync(f.fileno())
+        f.close()
+
+    # Reset the domain 0 network interface naming configuration
+    # back to a fresh-install state for the currently-installed
+    # hardware.
+    os.system("/etc/sysconfig/network-scripts/interface-rename.py --reset-to-install")
+
+    # Reboot
+    os.system("mount -o remount,rw / && reboot -f")


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task CP-49931:

-Fix tab and space indentation issues in  xe-reset-networking scripts


Author : Signed-off-by: Bernhard Kaindl <bernhard.kaindl@cloud.com>

Committed by: Signed-off-by: Ashwinh <ashwin.h@cloud.com>