### PR TITLE
XenAPIPlugin.py: Remove  the superflous catch & raise of SystemExit

### DIFF
--- a/scripts/examples/python/XenAPIPlugin.py
+++ b/scripts/examples/python/XenAPIPlugin.py
@@ -44,9 +44,6 @@ def dispatch(fn_table):
         try:
             result = fn_table[methodname](x, args)
             print(success_message(result))
-        except SystemExit:
-            # SystemExit should not be caught, as it is handled elsewhere in the plugin system.
-            raise
         except Failure as e:
             print(failure_message(e.params))
         except Exception as e:


### PR DESCRIPTION
When reviewing XAPIPlugin.py for warning fixes,

Bernhard found a superfluous `catch` and `raise` in `XenAPIPlugin.py`'s `dispatch()` function
that we can clean up:

Commmit message:

> `SystemExit` does not need to be caught and raised in this `try`:
> Both other exceptions are subclasses of Exception, so they don't catch `SystemExit(BaseException)`:
>
> By design, SystemExit is a subclass of BaseException and because we are not catching BaseException and also not use a bare `except:` here, we can cleanup catching and re-raising `SystemExit()` here.
> Reference: https://docs.python.org/3/library/exceptions.html#SystemExit

Author / Signed-off-by: Bernhard Kaindl <bernhard.kaindl@cloud.com>

Committed by: Signed-off-by: Ashwinh <ashwin.h@cloud.com>