### PR TITLE
CP-49919: mv scripts/extensions/pool_update.precheck to python3/extensions

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -32,7 +32,7 @@ install:
 	$(IPROG) bin/perfmon $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) bin/xe-scsi-dev-map $(DESTDIR)$(OPTDIR)/bin
 	$(IPROG) extensions/pool_update.apply $(DESTDIR)$(EXTENSIONDIR)
-
+	$(IPROG) extensions/pool_update.precheck $(DESTDIR)$(EXTENSIONDIR)
 	$(IPROG) extensions/Test.test $(DESTDIR)$(EXTENSIONDIR)
 	$(IPROG) plugins/disk-space $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/install-supp-pack $(DESTDIR)$(PLUGINDIR)

--- a/python3/extensions/pool_update.precheck
+++ b/python3/extensions/pool_update.precheck
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 
 
-import xmlrpc.client
-import sys
-import XenAPI
-import json
-import urllib.request, urllib.error, urllib.parse
-import xml.dom.minidom
-import traceback
-import subprocess
-import os
+import configparser
 import errno
+import io
+import logging
+import os
 import re
 import shutil
-import io
-import configparser
-import logging
-import xcp.logger
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.dom.minidom
+import xmlrpc.client
 
+import xcp.logger
+import XenAPI
 
 TMP_DIR = '/tmp/'
 UPDATE_DIR = '/var/update/'
@@ -234,6 +234,9 @@ if __name__ == '__main__':
 
     update_vdi_valid = False
     session = None
+    update_package = None
+    update = None
+    yum_conf_file = ""
     try:
         session = XenAPI.xapi_local()
         session.xenapi.login_with_password('root', '', '', 'Pool_update')

--- a/python3/stubs/XenAPI.pyi
+++ b/python3/stubs/XenAPI.pyi
@@ -50,6 +50,8 @@ class _Dispatcher:
     VDI: Incomplete
     PBD: Incomplete
     pool: Incomplete
+    host: Incomplete
+    pool_update: Incomplete
     VM: Incomplete
 
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -115,7 +115,6 @@ install:
 	$(IPROG) backup-metadata-cron $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) pbis-force-domain-leave $(DESTDIR)$(LIBEXECDIR)
 	mkdir -p $(DESTDIR)$(EXTENSIONDIR)
-	$(IPROG) extensions/pool_update.precheck $(DESTDIR)$(EXTENSIONDIR)
 	mkdir -p $(DESTDIR)$(PLUGINDIR)
 	$(IPROG) plugins/firewall-port $(DESTDIR)$(PLUGINDIR)
 	mkdir -p $(DESTDIR)$(HOOKSDIR)/host-post-declare-dead


### PR DESCRIPTION
Main ticket CP-49100 :Move python3 scripts from scripts directory to python3 directory.

Sub task CP-49919:
 
- Modified python3/Makefile to include  pool_update.precheck
- Removed pool_update.precheck from scripts/Makefile
- Added necessary methods in stubs/XenAPI.py to fix pyright issue
- Initialized variable to fix reportPossiblyUnboundVariable

Signed-off-by: Ashwinh <ashwin.h@cloud.com>