### PR TITLE
`python3/plugins/test_extauth_hook_AD.py`: Fix logging in `run_cmd()`

### DIFF
--- a/python3/plugins/extauth-hook-AD.py
+++ b/python3/plugins/extauth-hook-AD.py
@@ -61,17 +61,14 @@ setup_logger()
 logger = logging.getLogger(__name__)
 
 
-def run_cmd(cmd, log_cmd=True):
-    """Helper function to run command"""
+def run_cmd(command: "list[str]"):
+    """Helper function to run a command and log the output"""
     try:
-        result = subprocess.check_output(cmd)
-        if log_cmd:
-            msg = "{} -> {}".format(cmd, result)
-            logger.debug(msg)
-        return result.strip()
-    except Exception:  # pylint: disable=broad-except
-        logger.exception("Failed to run command %s", cmd)
-        return None
+        output = subprocess.check_output(command, universal_newlines=True)
+        logger.debug("%s -> %s", command, output.strip())
+
+    except OSError:
+        logger.exception("Failed to run command %s", command)
 
 
 class ADBackend(Enum):

--- a/python3/plugins/test_extauth_hook_AD.py
+++ b/python3/plugins/test_extauth_hook_AD.py
@@ -22,12 +22,11 @@ def test_run_cmd(caplog):
 
     # Call the function under test, check the return value and capture the log message
     with caplog.at_level(logging.DEBUG):
-        # Bug in the current code, the result is a byte string:
-        assert run_cmd(cmd) == cmd[1].strip().encode()
+        assert run_cmd(cmd) is None  # The return value is None (not used in the code)
 
-    # Bug in the current code after not fully tested py3 migration:
-    # The logged message contains a byte string that is not stripped:
-    assert caplog.records[0].message == "%s -> b' Hello World! \\n'" % (cmd)
+    # Assert the log message
+    assert caplog.records[0].message == "%s -> Hello World!" % (cmd)
+
     # Test the case where the command fails:
     assert run_cmd(["bad command"]) is None
     assert caplog.records[1].message == "Failed to run command ['bad command']"

--- a/python3/plugins/test_extauth_hook_AD.py
+++ b/python3/plugins/test_extauth_hook_AD.py
@@ -1,13 +1,12 @@
 """
 Test module for extauth_hook_ad
 """
-#pylint: disable=invalid-name
-import sys
-import os
-from unittest import TestCase
-from mock import MagicMock, patch
 
-import pytest
+import logging
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 # mock modules to avoid dependencies
 sys.modules["XenAPIPlugin"] = MagicMock()
@@ -15,11 +14,23 @@ sys.modules["XenAPI"] = MagicMock()
 # pylint: disable=wrong-import-position
 # Import must after mock modules
 from extauth_hook_ad import StaticSSHPam, NssConfig, SshdConfig, UsersList, GroupsList
+from extauth_hook_ad import run_cmd
 
+def test_run_cmd(caplog):
+    """Assert the current buggy behavior of the run_cmd function after py3 migration"""
+    cmd = ["echo", " Hello World! "]
 
-if sys.version_info < (3, ):  # pragma: no cover
-    pytest.skip(allow_module_level=True)
+    # Call the function under test, check the return value and capture the log message
+    with caplog.at_level(logging.DEBUG):
+        # Bug in the current code, the result is a byte string:
+        assert run_cmd(cmd) == cmd[1].strip().encode()
 
+    # Bug in the current code after not fully tested py3 migration:
+    # The logged message contains a byte string that is not stripped:
+    assert caplog.records[0].message == "%s -> b' Hello World! \\n'" % (cmd)
+    # Test the case where the command fails:
+    assert run_cmd(["bad command"]) is None
+    assert caplog.records[1].message == "Failed to run command ['bad command']"
 
 def line_exists_in_config(lines, line):
     """


### PR DESCRIPTION
Hi @psafont, 
For logging the output of `/usr/bin/systemctl reload-or-restart sshd` in `python3/plugins/extauth-hook-AD.py`, `mypy` found a minor regression:
- We should add `universal_newlines=True` there to fix the formatting of the logged output.

How this could be found:
- `mypy` is good at spotting changes in `str`/`bytes` from moving to Python3
- `mypy` wasn't fully usable yet, the config was not yet updated for `python3/*`.
  - But with the moving of files to `python3/*` having made good process, I fixed the config for it.


In Python3, `subprocess.check_output(command)` returns `bytes` by default (unless it is switched to text mode).

- The original Python2 code assumes it returns `str` by default.
  - This leads to slightly non-ideal logging in this case.
- Fix this by using `subprocess.check_output(command, universal_newlines=True)`

The `run_cmd` function in `python3/plugins/extauth-hook-AD.py` has only one call:
```py
       run_cmd(["/usr/bin/systemctl", "reload-or-restart", "sshd"])
```
Therefore, the unused default argument and returning the output can be removed (both are not used):

Commit 1:
- `python3/plugins/test_extauth_hook_AD.py`:
  - Assert the current bug and cover the to be fixed code.
  - No code change.

Commit 2:
- `python3/plugins/extauth-hook-AD.py`: Fix logging in `run_cmd()`
  - Fixes the bug and updates the test case
  - Simply the code and the test:
    - Remove the unused default argument `log_cmd=True` (cmd is always logged - only one call site)
    - Remove returning the command output (not used by the sole call site of this function)
