### PR TITLE
dune: fix tests to packages

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/test/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/test/dune
@@ -5,5 +5,6 @@
 )
 
 (cram
+	(package xapi-stdext-unix)
 	(deps (package xapi-stdext-unix))
 )

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/dune
@@ -10,6 +10,7 @@
 )
 (test
   (name threadext_test)
+  (package xapi-stdext-threads)
   (modules threadext_test)
   (libraries xapi_stdext_threads alcotest mtime.clock.os mtime fmt)
 )

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
@@ -1,5 +1,6 @@
 (test
   (name unixext_test)
+  (package xapi-stdext-unix)
   (modules unixext_test)
   (libraries xapi_stdext_unix qcheck-core mtime.clock.os qcheck-core.runner fmt xapi_fd_test mtime threads.posix rresult)
   ; use fixed seed to avoid causing random failures in CI and package builds
@@ -12,9 +13,10 @@
   (action (run %{dep:unixext_test.exe} -v -bt))
 )
 
-(executable
+(test
  (modes exe)
  (name test_systemd)
+ (package xapi-stdext-unix)
  (modules test_systemd)
  (libraries xapi-stdext-unix))
 

--- a/ocaml/tests/record_util/dune
+++ b/ocaml/tests/record_util/dune
@@ -1,5 +1,6 @@
 (test
 	(name test_record_util)
+	(package xapi)
 	(libraries alcotest xapi_cli_server rpclib.core xapi_consts xapi_types astring fmt)
 	(action (run %{test} --show-errors))
 )


### PR DESCRIPTION
Otherwise the tests are run as part of every package when installing them using opam, leading to failures in xs-opam's CI