### PR TITLE
fixup! CP-50259 simplify parsing size with kib, mib, etc suffix

### DIFF
--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -1080,7 +1080,7 @@ let bytes_of_string str =
   let ( ** ) a b = Int64.mul a b in
   let invalid msg = raise (Invalid_argument msg) in
   try
-    Scanf.sscanf str "%Ld%s" @@ fun size suffix ->
+    Scanf.sscanf str "%Ld %s" @@ fun size suffix ->
     match String.lowercase_ascii suffix with
     | _ when size < 0L ->
         invalid str


### PR DESCRIPTION
To keep compatibility with the existing behavior, allow "1kib" and as well as "1 kib", that is, a space before the unit. This space is optional and it could be more than one.
