### PR TITLE
scripts/generate-iscsi-iqn: Fix inline Python to work with Py3

### DIFF
--- a/scripts/generate-iscsi-iqn
+++ b/scripts/generate-iscsi-iqn
@@ -21,7 +21,8 @@ def f(x):
   tmp = x.rstrip().split(".")
   tmp.reverse()
   return ".".join(tmp)
-if __name__ == "__main__": print f(sys.argv[1])
+
+if __name__ == "__main__": print(f(sys.argv[1]))
 '
 
 geniqn() {


### PR DESCRIPTION
Hi @psafont and @ashwin9390,

By visual inspection of the shell script 
https://github.com/xenserver-next/xen-api/blob/feature/py3/scripts/generate-iscsi-iqn
(that runs an inline python script), I saw a remaining `print` statement, that needs to be a function:

BTW: The inline Python script is used to reverse a domain name for the shell script:
```py
arg: www.name.com
ret: com.name.www 
```
PS: I guess that's something special for `iSCSI` (not related: DNS has the same of reverse DNS).

PPS: That could likely be done in the shell itself, but since that's in a large loop (I guess) it shouldn't be a performance issue to call PYthon for reversing the domain name.

The change is:
```py
- if __name__ == "__main__": print f(sys.argv[1])
+ if __name__ == "__main__": print(f(sys.argv[1]))
```
I tested the resulting shell script to successfully reverse the domain name with Python3 too.

Link to the commit: [scripts/generate-iscsi-iqn: Fix inline Python to work in Py3](https://github.com/xapi-project/xen-api/commit/91b646d0afb7936057dc09009bb8b9f39f9bdcf0)