### PR TITLE
`xapi-storage/python/xapi/storage/common.py`: Fix call() for Python2+3

### DIFF
--- a/ocaml/xapi-storage/python/xapi/storage/common.py
+++ b/ocaml/xapi-storage/python/xapi/storage/common.py
@@ -11,11 +11,17 @@ import subprocess
 
 
 def call(dbg, cmd_args, error=True, simple=True, expRc=0):
+    """
+    Used by
+    xapi-storage/python/examples/datapath/loop+blkback/datapath.py to run losetup
+    """
+
     log.debug('{}: Running cmd {}'.format(dbg, cmd_args))
     proc = subprocess.Popen(
         cmd_args,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        universal_newlines=True,
         close_fds=True)
     stdout, stderr = proc.communicate()
     if error and proc.returncode != expRc:


### PR DESCRIPTION
Bugfix for py3, but likely not the cause of issues so far:

This was found by `mypy`: I confirmed it, it's not a false positive:

Currently, https://github.com/xenserver-next/xen-api/blob/feature/py3/ocaml/xapi-storage/python doesn't support Python3 (dues to some issue with the PR for it, it was reverted).

But, if [ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py](https://github.com/xenserver-next/xen-api/blob/feature/py3/ocaml/xapi-storage/python/examples/datapath/loop%2Bblkback/datapath.py) would be used, it would call the function `call()` to run `losetup`.

If it were converted to Python3, and mypy warnings would not be enabled, and the example above would use it to all `losetup -a`, checking the returned lines would fail because Python3 would get a bytestring, and not the expected unicode `str` as return value from `call`. This would be fixed using `universal_newlines=True` like many other callers in `xen-api` (checked: all users of `subprocess.*` that would need it, do it already or don't need it) already do.

PS: This function is only used by the example:
```py
grep -r '\<call\>.*(' ocaml/xapi-storage/python/
ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py:        call(dbg, ["losetup", "-d", self.loop])
ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py:        for line in call(dbg, ["losetup", "-a"]).split("\n"):
ocaml/xapi-storage/python/examples/datapath/loop+blkback/datapath.py:        call(dbg, cmd)
ocaml/xapi-storage/python/xapi/storage/common.py:def call(dbg, cmd_args, error=True, simple=True, expRc=0):
```