### PR TITLE
Py3: Update tests to use unittest.mock and mocked_modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,9 +81,7 @@ repos:
         - opentelemetry-api
         - opentelemetry-exporter-zipkin-json
         - opentelemetry-sdk
-        - pytest-coverage
         - pytest-mock
-        - mock
         - wrapt
         - XenAPI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ addopts = "-v -ra"
 # required_plugins: require that these plugins are installed before testing
 # -----------------------------------------------------------------------------
 testpaths = ["python3", "scripts", "ocaml/xcp-rrdd"]
-required_plugins = ["pytest-cov", "pytest-mock"]
+required_plugins = ["pytest-mock"]
 log_cli_level = "INFO"
 log_cli = true
 minversion = "7.0"

--- a/python3/tests/import_helper.py
+++ b/python3/tests/import_helper.py
@@ -3,9 +3,8 @@ import os
 import sys
 from contextlib import contextmanager
 from types import ModuleType
-
 from typing import Generator
-from mock import Mock
+from unittest.mock import Mock
 
 
 @contextmanager

--- a/python3/tests/test_hfx_filename.py
+++ b/python3/tests/test_hfx_filename.py
@@ -4,15 +4,13 @@
 This module provides unittest for hfx_filename
 """
 
-import sys
 import unittest
-from mock import MagicMock, patch, call
-from python3.tests.import_helper import import_file_as_module
+from unittest.mock import MagicMock, call, patch
 
-# mock modules to avoid dependencies
-sys.modules["XenAPI"] = MagicMock()
+from python3.tests.import_helper import import_file_as_module, mocked_modules
 
-hfx_filename = import_file_as_module("python3/bin/hfx_filename")
+with mocked_modules("XenAPI"):
+    hfx_filename = import_file_as_module("python3/bin/hfx_filename")
 
 
 @patch("socket.socket")

--- a/python3/tests/test_nbd_client_manager.py
+++ b/python3/tests/test_nbd_client_manager.py
@@ -3,9 +3,10 @@
 This module provides unittest for nbd_client_manager.py
 """
 
-import unittest
 import subprocess
-from mock import MagicMock, patch, mock_open, call
+import unittest
+from unittest.mock import MagicMock, call, mock_open, patch
+
 from python3.tests.import_helper import import_file_as_module
 
 nbd_client_manager = import_file_as_module("python3/libexec/nbd_client_manager.py")

--- a/python3/tests/test_perfmon.py
+++ b/python3/tests/test_perfmon.py
@@ -5,16 +5,14 @@ This module provides unittest for perfmon
 
 # pyright: reportAttributeAccessIssue=false
 
-import sys
 import math
 import unittest
-from mock import MagicMock, patch, mock_open
-from python3.tests.import_helper import import_file_as_module
+from unittest.mock import MagicMock, mock_open, patch
 
-# mock modules to avoid dependencies
-sys.modules["XenAPI"] = MagicMock()
+from python3.tests.import_helper import import_file_as_module, mocked_modules
 
-perfmon = import_file_as_module("python3/bin/perfmon")
+with mocked_modules("XenAPI"):
+    perfmon = import_file_as_module("python3/bin/perfmon")
 
 
 @patch("subprocess.getoutput")

--- a/python3/tests/test_usb_scan.py
+++ b/python3/tests/test_usb_scan.py
@@ -4,20 +4,16 @@
 
 import os
 import shutil
-import sys
 import tempfile
 import unittest
 from collections.abc import Mapping
 from typing import cast
+from unittest.mock import Mock
 
-import mock
+from python3.tests.import_helper import import_file_as_module, mocked_modules
 
-from python3.tests.import_helper import import_file_as_module
-# mock modules to avoid dependencies
-sys.modules["xcp"] = mock.Mock()
-sys.modules["xcp.logger"] = mock.Mock()
-sys.modules["pyudev"] = mock.Mock()
-usb_scan = import_file_as_module("python3/libexec/usb_scan.py")
+with mocked_modules("xcp", "xcp.logger", "pyudev"):
+    usb_scan = import_file_as_module("python3/libexec/usb_scan.py")
 
 
 class MocDeviceAttrs(Mapping):
@@ -87,15 +83,11 @@ class MocContext():
 
 
 def mock_setup(mod, devices, interfaces, path):
-    mod.log.error = verify_log
-    mod.log.debug = verify_log
+    mod.log.error = Mock()
+    mod.log.debug = Mock()
     mod.Policy._PATH = path
-    mod.pyudev.Context = mock.Mock(
+    mod.pyudev.Context = Mock(
             return_value=MocContext(devices, interfaces))
-
-
-def verify_log(_):
-    pass
 
 
 class TestUsbScan(unittest.TestCase):


### PR DESCRIPTION
Requires #5829 to remove the remaining dependency on the `mock` module.
Closing until #5829 is merged.

Updates on imports of the tests (actual test code is really changed):

- Update Python3 tests to use `unittest.mock` and `mocked_modules`:
  - We no longer need to install the `mock` package because Python3 has it in `unittest.mock`.
- `pytest-coverage` / `pytest-cov` has been replaced by `coverage`, remote the former as well.
- Use the context manager `with mocked_modules("module1", "module2, ...)` instead of global `Mock()`ing by patching `sys.module[]` permanently
  - Explanation: This triggers that `import sys` is now obsolete in some tests:
    - `sys.modules` is no longer permanently changed by the test:
      - this is now only done inside the context manager for importing the modules.
- As imports are updated, imports are sorted like `isort` does it.

Only tests are updated in the PR:
- No installed module, packages or script is touched in this PR.