### PR TITLE
CA-395626: Fix (server status report generation report)

### DIFF
--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -359,11 +359,13 @@ let request_of_bio_exn ~proxy_seen ~read_timeout ~total_timeout ~max_length bio
     proxy |> Option.fold ~none:[] ~some:(fun p -> [("STUNNEL_PROXY", p)])
   in
   let open Http.Request in
-  (* Below transformation only keeps one value per key, whereas
-     a fully compliant implementation following Uri's interface
-     would operate on list of values for each key instead *)
   let kvlist_flatten ls =
-    List.map (function k, v :: _ -> (k, v) | k, [] -> (k, "")) ls
+    (* Uri.query splits the value string into several if they are separated
+       with commas. Like this: "?k=v1,v2,v3" -> [("k", ["v1";"v2";"v3"])]
+       This function concatenates these back. It will not concatenate values
+       entered for duplicate keys, as these will be separate tuples:
+       "?k=v1,v2,v3&k=v4" ->  [("k", ["v1"; "v2"; "v3"]); ("k", ["v4"])] *)
+    List.map (fun (k, vs) -> (k, Astring.String.concat ~sep:"," vs)) ls
   in
   let request =
     Astring.String.cuts ~sep:"\n" headers

--- a/ocaml/libs/http-lib/test_server.ml
+++ b/ocaml/libs/http-lib/test_server.ml
@@ -64,6 +64,22 @@ let _ =
          Unixext.really_write_string s r
        )
     ) ;
+  Server.add_handler server Http.Get "/query"
+    (FdIO
+       (fun request s _ ->
+         match request.Http.Request.query with
+         | (_, v) :: _ ->
+             Unixext.really_write_string s
+               (Http.Response.to_wire_string
+                  (Http.Response.make ~body:v "200" "OK")
+               )
+         | _ ->
+             Unixext.really_write_string s
+               (Http.Response.to_wire_string
+                  (Http.Response.make "404" "Query string missing")
+               )
+       )
+    ) ;
   let ip = "0.0.0.0" in
   let inet_addr = Unix.inet_addr_of_string ip in
   let addr = Unix.ADDR_INET (inet_addr, !port) in


### PR DESCRIPTION
Concatenates the query value back after Uri.query splits the string separated by commas.

`Uri.query` splits the value string into several if they are separated with commas. Like this: `"?k=v1,v2,v3" -> [("k", ["v1";"v2";"v3"])]` This function concatenates these back. (i.e. into `[("k", "v1,v2,v3")]`).

It will not concatenate values entered for duplicate keys, as these will be separate tuples: `"?k=v1,v2,v3&k=v4" ->  [("k", ["v1"; "v2"; "v3"]); ("k", ["v4"])]`

This was tested manually by issuing a host-get-system-status call:
```
$ xe host-get-system-status uuid=ed4342d9-eeaf-41a3-88d3-90c0d47c3f76   
output=tar filename=just.tar entries=xapi-debug,xen-info,xha-liveset,high-availability,cron,control-slice,firstboot,NVIDIA-logs,block-scheduler,xenserver-databases,multipath,disk-info,xenserver-logs,xenserver-install,process-list,xapi,host-crashdump-logs,xapi-subprocess,pam,observer,system-load,tapdisk-logs,kernel-info,xenserver-config,xenserver-domains,device-model,hardware-info,xenopsd,loopback-devices,system-services,system-logs,network-status,v6d,xspvscache,message-switch,VM-snapshot-schedule,xen-bugtool,xcp-rrdd-plugins,yum,fcoe,xapi-clusterd,vtpm,network-config,boot-loader,xenrt username=root password=(*)

==== Before:
/var/log/xensource.log:Jul 15 08:10:36 lcy2-dt29 xapi: [debug||122714 HTTP 127.0.0.1->
:::80|system-status download R:71d7056eb7d4|system_status] running /usr/sbin/xen-bugtool --entries=xapi-debug 
--silent --yestoall --output=tar --outfd=c0284748-dd7a-0200-6c1b-3a30ba3387c8

==== After:
/var/log/xensource.log:Jul 15 08:15:56 lcy2-dt29 xapi: [debug||190 HTTP 127.0.0.1->
:::80|system-status download R:4861c74180fc|system_status] running /usr/sbin/xen-bugtool
--entries=xapi-debug,xen-info,xha-liveset,high-availability,cron,control-slice,firstboot,NVIDIA-logs,block-scheduler,xenserver-databases,multipath,disk-info,xenserver-logs,xenserver-install,process-list,xapi,host-crashdump-logs,xapi-subprocess,pam,observer,system-load,tapdisk-logs,kernel-info,xenserver-config,xenserver-domains,device-model,hardware-info,xenopsd,loopback-devices,system-services,system-logs,network-status,v6d,xspvscache,message-switch,VM-snapshot-schedule,xen-bugtool,xcp-rrdd-plugins,yum,fcoe,xapi-clusterd,vtpm,network-config,boot-loader,xenrt --silent --yestoall --output=tar --outfd=fc3a22b6-ec90-59ec-7ae2-868d5c36c66e

```
