### PR TITLE
quicktest: associate unit-test with xapi package

### DIFF
--- a/ocaml/quicktest/dune
+++ b/ocaml/quicktest/dune
@@ -40,5 +40,6 @@
 
 (rule
  (alias runtest)
+ (package xapi)
  (action (run ./quicktest.exe -skip-xapi -- list))
 )


### PR DESCRIPTION
Otherwise dune will try to run it when testing all the packags, but the quicktest binary won't be available