### PR TITLE
CP-50270: Set the correct parent in `make_connection`

### DIFF
--- a/scripts/examples/python/XenAPI/XenAPI.py
+++ b/scripts/examples/python/XenAPI/XenAPI.py
@@ -123,12 +123,13 @@ class UDSTransport(xmlrpclib.Transport):
             for k, v in headers.items():
                 self.add_extra_header(k, v)
     def make_connection(self, host):
+        self.with_tracecontext()
+
         # compatibility with parent xmlrpclib.Transport HTTP/1.1 support
         if self._connection and host == self._connection[0]:
             return self._connection[1]
 
         self._connection = host, UDSHTTPConnection(host)
-        self.with_tracecontext()
         return self._connection[1]
 
 def notimplemented(name, *args, **kwargs):


### PR DESCRIPTION
Updates the correct parent span when we retrieve a cached connection.

Preveusly, we would call the instrumentation only when we make the connection for the first time. This resulted in seeing the same parent span for all subsequent calls of `make_connection`. Calling the instrumentation first ensures the correct parent is sent over the headers for all code branches.