### PR TITLE
Fix @stresstest failure

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.ml
@@ -62,8 +62,12 @@ let delay_of_size total_delay size =
   let open Gen in
   let* every_bytes = if size = 0 then return 1 else 1 -- size in
   let chunks = max 1 (size / every_bytes) in
-  let duration = total_delay /. float_of_int chunks |> span_of_s in
-  return @@ Some (Delay.v ~every_bytes ~duration)
+  let duration = total_delay /. float_of_int chunks in
+  if duration < 1e-6 then
+    return None
+  else
+    let duration = duration |> span_of_s in
+    return @@ Some (Delay.v ~every_bytes ~duration)
 
 let t =
   let open Gen in

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.ml
@@ -158,7 +158,9 @@ module CancellableSleep = struct
       ; buf= Bytes.make 1 ' '
       }
 
-  let set_rcvtimeo sock timeo = setsockopt_float sock Unix.SO_RCVTIMEO timeo
+  let set_rcvtimeo sock timeo =
+    if timeo < 1e-6 then Fmt.invalid_arg "timeout too short: %g" timeo ;
+    setsockopt_float sock Unix.SO_RCVTIMEO timeo
 
   let sleep t dt =
     set_rcvtimeo t.wait (Mtime.Span.to_float_ns dt *. 1e-9) ;

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.ml
@@ -175,6 +175,8 @@ end
 module Delay = struct
   type t = {duration: Mtime.span; every_bytes: int}
 
+  let every_bytes t = t.every_bytes
+
   let pp =
     Fmt.(
       record ~sep:(any ";")

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.mli
@@ -109,6 +109,9 @@ module Delay : sig
     Note that the time taken to send or receive [after_bytes] is not taken into account to guarantee the insertion of the delay.
   *)
 
+  val every_bytes : t -> int
+  (** [every_bytes t] is how often delays are inserted *)
+
   val apply_read :
        CancellableSleep.t
     -> t


### PR DESCRIPTION
Noticed by @psafont in https://github.com/xapi-project/xen-api/actions/runs/9901545401/job/27354091939#step:7:149.

The bug is in the test code, I misinterpreted what the meaning of the timeout parameter in `Buf_io.really_input` means, it is not the overall timeout, but the timeout for each individual read call.
So if the other end decides to send 1 byte at a time, then the overall timeout will be number of bytes * timeout.

This may be an unintentional bug in `really_input`, however it is unknown whether any callers rely on the current semantics or not, so fix the test instead to check for the actual behaviour of `really_input`.

There is also a bug in the use of `setsockopt`. It gets converted to a `struct timeval`, and the microseconds value truncated.
So if we end up asking for a too small timeout (which as a result of the above change we might!) then that would get truncated to 0 and instead we'd hang indefinetely, because 0 means "no timeout".