### PR TITLE
CP-49811: Remove redundant method object from span name

### DIFF
--- a/python3/packages/observer.py
+++ b/python3/packages/observer.py
@@ -314,7 +314,7 @@ def _init_tracing(configs: List[str], config_dir: str):
                         continue
 
                     with t.start_as_current_span(
-                        f"class.instrument:{module_name}.{method_name}={method}"
+                        f"class.instrument:{module_name}.{method_name}"
                     ):
                         # Avoid RecursionError:
                         # 'maximum recursion depth exceeded in comparison'


### PR DESCRIPTION
We already have method_name so printing the method itself doesn't add anything. It also makes searching in Jaeger more difficult as the method includes its id.

You can see this in action here: http://rage.uk.xensource.com:16686/trace/46e188b3e42c0b2cec83af26e1d60bd8 (note the "class.instrument" spans)