### PR TITLE
storage-api: Add initial pytest test case for datapath.Datapath_server_dispatcher()

### DIFF
--- a/ocaml/xapi-storage/python/xapi/storage/api/test_datapath.py
+++ b/ocaml/xapi-storage/python/xapi/storage/api/test_datapath.py
@@ -1,0 +1,108 @@
+from .datapath import datapath_server_test
+
+
+def internal_error(error):
+    """Return a dictionary with an internal error"""
+    return {"ErrorDescription": ["Internal_error", error], "Status": "Failure"}
+
+
+def assert_error(testee, caplog, method_args, method, error):
+    """Assert that the result of the testee matches the expected error result"""
+    args = method_args.copy()
+    if method != "open":  # the persistent arg is only checked for the open method
+        args["persistent"] = None  # pass it, but with a wrong type(not used/checked)
+    assert testee._dispatch(f"Datapath.{method}", [args]) == internal_error(error)
+    assert caplog.messages[0] == "caught " + error
+    caplog.clear()
+
+
+def assert_type_checks(testee, methods, template_args, bad_args, caplog):
+    """Assert that the result of the testee matches the expected result"""
+    for arg in bad_args:
+        # Sigh, if Python would be strongly typed, we wouldn't need this:
+        # Assert the type checks of the arguments
+        expected = "bool" if arg == "persistent" else "string"
+        other_type = False if expected == "string" else "str"
+        for actual in [None, [], (), {"dict": "val"}, 1, 1.0, str, caplog, other_type]:
+            bad_args = template_args.copy()
+            bad_args[arg] = actual
+            error_msg = f"TypeError expected={expected} actual={repr(actual)}"
+            for method in methods:
+                assert_error(testee, caplog, bad_args, method, error_msg)
+
+        # Remove the argument and assert the missing argument checks
+        bad_args.pop(arg)
+        error_msg = f"UnmarshalException thing=argument missing ty={arg} desc="
+        for method in methods:
+            assert_error(testee, caplog, bad_args, method, error_msg)
+
+
+def test_dispatcher(caplog, capsys):
+    """
+    Test the dispatcher of the Xapi storage API datapath interface
+
+    The dispatcher is a class that routes the calls to the corresponding methods
+    of a given Datapath implementation class.
+    """
+
+    # Setup
+
+    # The testee passes them to the Datapath_test class and its attach method
+    # is expected to return the values which we use to test the dispatcher:
+    args = {"dbg": "", "uri": "uri", "domain": "uuid", "persistent": True}
+
+    # Call
+
+    # datapath_server_test() returns an instance of the dispatcher class that
+    # routes the calls to the corresponding methods of the Datapath_test class:
+    testee = datapath_server_test()
+
+    # Test the argument checks of the dispatcher to identify missing arguments:
+
+    # Assert type checks on the dbg and uri arguments
+    missing = ["dbg", "uri"]
+    methods = ["attach", "activate", "deactivate", "detach", "open", "close"]
+    assert_type_checks(testee, methods, args, missing, caplog)
+
+    # Assert type checks on the missing domain argument
+    missing = ["domain"]
+    methods = ["attach", "activate", "deactivate", "detach"]
+    assert_type_checks(testee, methods, args, missing, caplog)
+
+    # Assert type checks on the persistent flag for the open method
+    missing = ["persistent"]
+    methods = ["open"]
+    assert_type_checks(testee, methods, args, missing, caplog)
+
+    # BUG: Datapath_test.attach() currently returns an mismatching dictionary:
+    # The dispatcher expects a dict with a "domain_uuid" key, but the implementation
+    # Datapath_test.attach() returns a dict with a "backend" key instead.
+    # Changing the implementation of Datapath_test.attach() will fix this issue.
+
+    # This WOULD be an example expected result, BUT the implementation of
+    # Datapath_test.attach() returns an invalid dictionary to the dispatcher:
+    assert testee._dispatch("Datapath.attach", [args]) != {
+        "Status": "Success",
+        "Value": {"domain_uuid": "uuid", "implementation": ("uri", "dbg")},
+    }
+
+    # BUG: This is the internal error that Datapath_test.attach() currently triggers:
+    assert testee._dispatch("Datapath.attach", [args]) == {
+        "ErrorDescription": ["Internal_error", "'domain_uuid'"],
+        "Status": "Failure",
+    }
+    assert caplog.messages[0] == "caught 'domain_uuid'"
+    caplog.clear()
+
+    # The other methods work as expected. Setup, Call, Assert:
+    success = {"Status": "Success", "Value": {}}
+    assert testee._dispatch("Datapath.open", [args]) == success
+    assert testee._dispatch("Datapath.activate", [args]) == success
+    assert testee._dispatch("Datapath.deactivate", [args]) == success
+    assert testee._dispatch("Datapath.detach", [args]) == success
+    assert testee._dispatch("Datapath.close", [args]) == success
+
+    # Assert that no errors were logged and no output was printed:
+    assert caplog.messages == []  # No messages were logged
+    assert capsys.readouterr().out == ""  # No output was printed
+    assert capsys.readouterr().err == ""  # No errors were printed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,7 @@ addopts = "-v -ra"
 # xfail_strict:     require to remove pytext.xfail marker when test is fixed
 # required_plugins: require that these plugins are installed before testing
 # -----------------------------------------------------------------------------
-testpaths = ["python3", "scripts", "ocaml/xcp-rrdd"]
+testpaths = ["python3", "ocaml/xcp-rrdd", "ocaml/xapi-storage"]
 required_plugins = ["pytest-cov", "pytest-mock"]
 log_cli_level = "INFO"
 log_cli = true


### PR DESCRIPTION
I've found some duplicated code in https://github.com/xenserver-next/xen-api/blob/feature/py3/ocaml/xapi-storage/python/xapi/storage/api/datapath.py that I'd like to deduplicate, but to ensure that no errors are made, I found that we can use a `pytest` test that can cover the most of the code in it.

By adding this test case, Local and GitHub CI will check and ensure that no lines that aren't covered are changed:

This PR only adds an initial `pytest` test case for `xapi.storage.api.datapath.Datapath_server_dispatcher()`.

While adding this test, I found an issues stub function used for testing that I'd then fix in the next PR (or a 2nd commit in this PR)