### PR TITLE
CP-47617:  Expose backwards compat info to update packaging tooling

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -57,6 +57,8 @@ let args =
   ; flag "yumplugindir" ~doc:"DIR YUM plugins" ~default:"/usr/lib/yum-plugins"
   ; flag "yumpluginconfdir" ~doc:"DIR YUM plugins conf dir"
       ~default:"/etc/yum/pluginconf.d"
+  ; flag "xapi_api_version_major" ~doc:"xapi api major version" ~default:"2"
+  ; flag "xapi_api_version_minor" ~doc:"xapi api minor version" ~default:"21"
   ]
   |> Arg.align
 
@@ -84,7 +86,7 @@ let () =
   in
   List.iter print_endline lines ;
   (* Expand @LIBEXEC@ in udev rules *)
-  match Hashtbl.find_opt config "XENOPSD_LIBEXECDIR" with
+  ( match Hashtbl.find_opt config "XENOPSD_LIBEXECDIR" with
   | Some xenopsd_libexecdir ->
       expand "@LIBEXEC@" xenopsd_libexecdir "ocaml/xenopsd/scripts/vif.in"
         "ocaml/xenopsd/scripts/vif" ;
@@ -93,3 +95,17 @@ let () =
         "ocaml/xenopsd/scripts/xen-backend.rules"
   | None ->
       failwith "xenopsd_libexecdir not set"
+  ) ;
+
+  match
+    ( Hashtbl.find_opt config "XAPI_API_VERSION_MAJOR"
+    , Hashtbl.find_opt config "XAPI_API_VERSION_MINOR"
+    )
+  with
+  | Some xapi_api_version_major, Some xapi_api_version_minor ->
+      expand "@APIVERMAJ@" xapi_api_version_major "ocaml/idl/api_version.ml.in"
+        "ocaml/idl/api_version.ml.in2" ;
+      expand "@APIVERMIN@" xapi_api_version_minor "ocaml/idl/api_version.ml.in2"
+        "ocaml/idl/api_version.ml"
+  | _, _ ->
+      failwith "xapi_api_version_major or xapi_api_version_minor not set"

--- a/ocaml/idl/api_version.ml
+++ b/ocaml/idl/api_version.ml
@@ -1,0 +1,22 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* This file is only needed for building xapi with local make, now the
+   api_version_major and api_version_minor are defined in xapi.spec and this
+   file will be regenerated from api_version.ml.in by configure.ml during koji
+   build. *)
+
+let api_version_major = 2L
+
+let api_version_minor = 21L

--- a/ocaml/idl/api_version.ml.in
+++ b/ocaml/idl/api_version.ml.in
@@ -1,0 +1,17 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+let api_version_major = @APIVERMAJ@L
+
+let api_version_minor = @APIVERMIN@L

--- a/ocaml/idl/api_version.mli
+++ b/ocaml/idl/api_version.mli
@@ -1,0 +1,17 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val api_version_major : int64
+
+val api_version_minor : int64

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -153,9 +153,9 @@ let tech_preview_releases =
 (* api version *)
 (* Normally xencenter_min_verstring and xencenter_max_verstring in the xapi_globs should be set to the same value,
  * but there are exceptions: please consult the XenCenter maintainers if in doubt. *)
-let api_version_major = 2L
+let api_version_major = Api_version.api_version_major
 
-let api_version_minor = 21L
+let api_version_minor = Api_version.api_version_minor
 
 let api_version_string =
   Printf.sprintf "%Ld.%Ld" api_version_major api_version_minor

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -6,7 +6,7 @@
     datamodel_pool datamodel_cluster datamodel_cluster_host dm_api escaping
     datamodel_values datamodel_schema datamodel_certificate
     datamodel_diagnostics datamodel_repository datamodel_lifecycle
-    datamodel_vtpm datamodel_observer datamodel_vm_group)
+    datamodel_vtpm datamodel_observer datamodel_vm_group api_version)
   (libraries
     ppx_sexp_conv.runtime-lib
     rpclib.core


### PR DESCRIPTION
The backwards compatibility info in xapi is the "api_version_major" and "api_version_minor". This info needs to be exposed to update packaging tooling so that it can add the backwards compatibility data into the update's metadata.

1. The defintions of api_version_major and api_version_minor are moved to xapi.spec, the file ocaml/idl/api_version.ml will be regenerated from api_version.ml.in with value of api_version_major and api_version_minor defined in xapi.spec by configure.ml during koji build.
2. Add ocaml/idl/api_version.ml only for buildng xapi with make.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xen-api/5852)
<!-- Reviewable:end -->
