### PR TITLE
[epoll]: improve debugging for timers and forkexecd

### DIFF
--- a/ocaml/forkexecd/src/child.ml
+++ b/ocaml/forkexecd/src/child.ml
@@ -94,14 +94,7 @@ let handle_comms comms_sock fd_sock state =
 let log_failure args child_pid reason =
   (* The commandline might be too long to clip it *)
   let cmdline = String.concat " " args in
-  let limit = 80 - 3 in
-  let cmdline' =
-    if String.length cmdline > limit then
-      String.sub cmdline 0 limit ^ "..."
-    else
-      cmdline
-  in
-  Fe_debug.error "%d (%s) %s" child_pid cmdline' reason
+  Fe_debug.error "%d (%s) %s" child_pid cmdline reason
 
 let report_child_exit comms_sock args child_pid status =
   let module Unixext = Xapi_stdext_unix.Unixext in

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1160,15 +1160,8 @@ let options_of_xapi_globs_spec =
               string_of_float !x
           | Int x ->
               string_of_int !x
-          | ShortDurationFromSeconds x ->
-              let literal =
-                Mtime.Span.to_uint64_ns !x |> fun ns ->
-                Int64.div ns 1_000_000_000L |> Int64.to_int |> string_of_int
-              in
-              Fmt.str "%s (%a)" literal Mtime.Span.pp !x
-          | LongDurationFromSeconds x ->
-              let literal = Clock.Timer.span_to_s !x |> string_of_float in
-              Fmt.str "%s (%a)" literal Mtime.Span.pp !x
+          | ShortDurationFromSeconds x | LongDurationFromSeconds x ->
+              Fmt.str "%Luns (%a)" (Mtime.Span.to_uint64_ns !x) Mtime.Span.pp !x
         )
       , Printf.sprintf "Set the value of '%s'" name
       )


### PR DESCRIPTION
Print timeout settings to full precision in logs instead of converting.
Avoid clipping command-line arguments in forkexecd logs, we need to see the full command-line for commands that fail.

This was split out of the epoll PR.