### PR TITLE
[epoll]: alternative approach: write a drop-in replacement first

### DIFF
--- a/ocaml/database/block_device_io.ml
+++ b/ocaml/database/block_device_io.ml
@@ -328,7 +328,7 @@ let accept_conn s latest_response_time =
   let now = Unix.gettimeofday () in
   let timeout = latest_response_time -. now in
   (* Await an incoming connection... *)
-  let ready_to_read, _, _ = Unix.select [s] [] [] timeout in
+  let ready_to_read, _, _ = Xapi_stdext_unix.Unixext.select [s] [] [] timeout in
   R.info "Finished selecting" ;
   if List.mem s ready_to_read then
     (* We've received a connection. Accept it and return the socket. *)

--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -171,7 +171,11 @@ let open_secure_connection () =
     ~write_to_log:(fun x -> debug "stunnel: %s\n" x)
     ~verify_cert host port
   @@ fun st_proc ->
-  let fd_closed = Thread.wait_timed_read Unixfd.(!(st_proc.Stunnel.fd)) 5. in
+  let fd_closed =
+    Xapi_stdext_threads.Threadext.wait_timed_read
+      Unixfd.(!(st_proc.Stunnel.fd))
+      5.
+  in
   let proc_quit =
     try
       Unix.kill (Stunnel.getpid st_proc.Stunnel.pid) 0 ;

--- a/ocaml/forkexecd/src/child.ml
+++ b/ocaml/forkexecd/src/child.ml
@@ -61,7 +61,9 @@ let handle_comms_sock comms_sock state =
 
 let handle_comms_no_fd_sock2 comms_sock fd_sock state =
   debug "Selecting in handle_comms_no_fd_sock2" ;
-  let ready, _, _ = Unix.select [comms_sock; fd_sock] [] [] (-1.0) in
+  let ready, _, _ =
+    Xapi_stdext_unix.Unixext.select [comms_sock; fd_sock] [] [] (-1.0)
+  in
   debug "Done" ;
   if List.mem fd_sock ready then (
     debug "fd sock" ;
@@ -74,7 +76,9 @@ let handle_comms_no_fd_sock2 comms_sock fd_sock state =
 
 let handle_comms_with_fd_sock2 comms_sock _fd_sock fd_sock2 state =
   debug "Selecting in handle_comms_with_fd_sock2" ;
-  let ready, _, _ = Unix.select [comms_sock; fd_sock2] [] [] (-1.0) in
+  let ready, _, _ =
+    Xapi_stdext_unix.Unixext.select [comms_sock; fd_sock2] [] [] (-1.0)
+  in
   debug "Done" ;
   if List.mem fd_sock2 ready then (
     debug "fd sock2" ;

--- a/ocaml/libs/ezxenstore/core/dune
+++ b/ocaml/libs/ezxenstore/core/dune
@@ -9,5 +9,6 @@
     (re_export xenstore)
     (re_export xenstore_transport)
     threads.posix
+    xapi-stdext-unix
     (re_export xenstore.unix))
 )

--- a/ocaml/libs/ezxenstore/core/watch.ml
+++ b/ocaml/libs/ezxenstore/core/watch.ml
@@ -50,7 +50,7 @@ let wait_for ~xs ?(timeout = 300.) (x : 'a t) =
       let thread =
         Thread.create
           (fun () ->
-            let r, _, _ = Unix.select [p1] [] [] timeout in
+            let r, _, _ = Xapi_stdext_unix.Unixext.select [p1] [] [] timeout in
             if r <> [] then
               ()
             else

--- a/ocaml/libs/http-lib/buf_io.ml
+++ b/ocaml/libs/http-lib/buf_io.ml
@@ -79,7 +79,7 @@ let is_full ic = ic.cur = 0 && ic.max = Bytes.length ic.buf
 let fill_buf ~buffered ic timeout =
   let buf_size = Bytes.length ic.buf in
   let fill_no_exc timeout len =
-    let l, _, _ = Unix.select [ic.fd] [] [] timeout in
+    let l, _, _ = Xapi_stdext_unix.Unixext.select [ic.fd] [] [] timeout in
     if l <> [] then (
       let n = Unix.read ic.fd ic.buf ic.max len in
       ic.max <- n + ic.max ;

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
@@ -115,3 +115,23 @@ module Delay = struct
         (* If the wait hasn't happened yet then store up the signal *)
     )
 end
+
+let wait_timed_read fd timeout =
+  match Xapi_stdext_unix.Unixext.select [fd] [] [] timeout with
+  | [], _, _ ->
+      false
+  | [fd'], _, _ ->
+      assert (fd' = fd) ;
+      true
+  | _ ->
+      assert false
+
+let wait_timed_write fd timeout =
+  match Xapi_stdext_unix.Unixext.select [] [fd] [] timeout with
+  | _, [], _ ->
+      false
+  | _, [fd'], _ ->
+      assert (fd' = fd) ;
+      true
+  | _ ->
+      assert false

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
@@ -33,3 +33,7 @@ module Delay : sig
   val signal : t -> unit
   (** Sends a signal to a waiting thread. See 'wait' *)
 end
+
+val wait_timed_read : Unix.file_descr -> float -> bool
+
+val wait_timed_write : Unix.file_descr -> float -> bool

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -156,6 +156,13 @@ val time_limited_read : Unix.file_descr -> int -> float -> string
 val time_limited_single_read :
   Unix.file_descr -> int -> max_wait:float -> string
 
+val select :
+     Unix.file_descr list
+  -> Unix.file_descr list
+  -> Unix.file_descr list
+  -> float
+  -> Unix.file_descr list * Unix.file_descr list * Unix.file_descr list
+
 val read_data_in_string_chunks :
      (string -> int -> unit)
   -> ?block_size:int

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -257,7 +257,7 @@ val domain_of_addr : string -> Unix.socket_domain option
 
 val test_open : int -> unit
 (** [test_open n] opens n file descriptors. This is useful for testing that the application makes no calls
-  to [Unix.select] that use file descriptors, because such calls will then immediately fail.
+  to [Xapi_stdext_unix.Unixext.select] that use file descriptors, because such calls will then immediately fail.
 
   This assumes that [ulimit -n] has been suitably increased in the test environment.
   

--- a/ocaml/message-switch/unix/dune
+++ b/ocaml/message-switch/unix/dune
@@ -11,6 +11,7 @@
     rpclib.core
     rpclib.json
     threads.posix
+    xapi-stdext-unix
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/message-switch/unix/protocol_unix_scheduler.ml
+++ b/ocaml/message-switch/unix/protocol_unix_scheduler.ml
@@ -74,7 +74,9 @@ module Delay = struct
                 pipe_out
             )
           in
-          let r, _, _ = Unix.select [pipe_out] [] [] seconds in
+          let r, _, _ =
+            Xapi_stdext_unix.Unixext.select [pipe_out] [] [] seconds
+          in
           (* flush the single byte from the pipe *)
           if r <> [] then ignore (Unix.read pipe_out (Bytes.create 1) 0 1) ;
           (* return true if we waited the full length of time, false if we were woken *)

--- a/ocaml/networkd/lib/jsonrpc_client.ml
+++ b/ocaml/networkd/lib/jsonrpc_client.ml
@@ -43,7 +43,7 @@ let timeout_read fd timeout =
   in
   let rec inner max_time max_bytes =
     let ready_to_read, _, _ =
-      try Unix.select [fd] [] [] (to_s max_time)
+      try Xapi_stdext_unix.Unixext.select [fd] [] [] (to_s max_time)
       with
       (* in case the unix.select call fails in situation like interrupt *)
       | Unix.Unix_error (Unix.EINTR, _, _) ->
@@ -96,7 +96,7 @@ let timeout_write filedesc total_length data response_time =
   in
   let rec inner_write offset max_time =
     let _, ready_to_write, _ =
-      try Unix.select [] [filedesc] [] (to_s max_time)
+      try Xapi_stdext_unix.Unixext.select [] [filedesc] [] (to_s max_time)
       with
       (* in case the unix.select call fails in situation like interrupt *)
       | Unix.Unix_error (Unix.EINTR, _, _) ->

--- a/ocaml/xapi-idl/lib/dune
+++ b/ocaml/xapi-idl/lib/dune
@@ -34,6 +34,7 @@
    xapi-open-uri
    xapi-stdext-pervasives
    xapi-stdext-threads
+   xapi-stdext-unix
    xapi-inventory
    xmlm
  )

--- a/ocaml/xapi-idl/lib/posix_channel.ml
+++ b/ocaml/xapi-idl/lib/posix_channel.ml
@@ -80,7 +80,7 @@ let proxy (a : Unix.file_descr) (b : Unix.file_descr) =
       in
       (* If we can't make any progress (because fds have been closed), then stop *)
       if r = [] && w = [] then raise End_of_file ;
-      let r, w, _ = Unix.select r w [] (-1.0) in
+      let r, w, _ = Xapi_stdext_unix.Unixext.select r w [] (-1.0) in
       (* Do the writing before the reading *)
       List.iter
         (fun fd -> if a = fd then CBuf.write b' a else CBuf.write a' b)
@@ -153,7 +153,9 @@ let send proxy_socket =
             in
             finally
               (fun () ->
-                let readable, _, _ = Unix.select [s_ip; s_unix] [] [] (-1.0) in
+                let readable, _, _ =
+                  Xapi_stdext_unix.Unixext.select [s_ip; s_unix] [] [] (-1.0)
+                in
                 if List.mem s_unix readable then (
                   let fd, _peer = Unix.accept s_unix in
                   to_close := fd :: !to_close ;

--- a/ocaml/xapi-idl/lib/scheduler.ml
+++ b/ocaml/xapi-idl/lib/scheduler.ml
@@ -32,7 +32,7 @@ module PipeDelay = struct
 
   let wait (x : t) (seconds : float) =
     let timeout = if seconds < 0.0 then 0.0 else seconds in
-    if Thread.wait_timed_read x.pipe_out timeout then
+    if Xapi_stdext_threads.Threadext.wait_timed_read x.pipe_out timeout then
       (* flush the single byte from the pipe *)
       let (_ : int) = Unix.read x.pipe_out (Bytes.create 1) 0 1 in
       (* return false if we were woken *)

--- a/ocaml/xapi-idl/lib_test/dune
+++ b/ocaml/xapi-idl/lib_test/dune
@@ -49,5 +49,7 @@
    xapi-idl.xen.interface
    xapi-idl.xen.interface.types
    xapi-log
+   xapi-stdext-unix
+   xapi-stdext-threads
  )
  (preprocess (pps ppx_deriving_rpc)))

--- a/ocaml/xapi-idl/lib_test/scheduler_test.ml
+++ b/ocaml/xapi-idl/lib_test/scheduler_test.ml
@@ -37,7 +37,7 @@ let timed_wait_callback ~msg ?(time_min = 0.) ?(eps = 0.1) ?(time_max = 60.) f =
         ()
       in
       f callback ;
-      let ready = Thread.wait_timed_read rd time_max in
+      let ready = Xapi_stdext_threads.Threadext.wait_timed_read rd time_max in
       match (ready, !after) with
       | true, None ->
           Alcotest.fail "pipe ready to read, but after is not set"

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -594,7 +594,8 @@ let main_loop ifd ofd permitted_filenames =
                   finished := true
                 else
                   let r, _, _ =
-                    Unix.select [Unix.stdin; fd] [] [] heartbeat_interval
+                    Xapi_stdext_unix.Unixext.select [Unix.stdin; fd] [] []
+                      heartbeat_interval
                   in
                   let now = Unix.time () in
                   if now -. !last_heartbeat >= heartbeat_interval then (

--- a/ocaml/xenopsd/cli/dune
+++ b/ocaml/xenopsd/cli/dune
@@ -22,6 +22,7 @@
       xapi-idl.xen.interface
       xapi-idl.xen.interface.types
       xapi-stdext-pervasives
+      xapi-stdext-unix
   )
   (preprocess (pps ppx_deriving_rpc))
 )

--- a/ocaml/xenopsd/cli/xn.ml
+++ b/ocaml/xenopsd/cli/xn.ml
@@ -1009,7 +1009,9 @@ let raw_console_proxy sockaddr =
       ) else if !final then
         finished := true
       else
-        let r, _, _ = Unix.select [Unix.stdin; fd] [] [] (-1.) in
+        let r, _, _ =
+          Xapi_stdext_unix.Unixext.select [Unix.stdin; fd] [] [] (-1.)
+        in
         if List.mem Unix.stdin r then (
           let b =
             Unix.read Unix.stdin buf_remote !buf_remote_end

--- a/ocaml/xsh/dune
+++ b/ocaml/xsh/dune
@@ -9,6 +9,7 @@
     safe-resources
     xapi-consts
     xapi-log
+    xapi-stdext-unix
   )
 )
 

--- a/ocaml/xsh/xsh.ml
+++ b/ocaml/xsh/xsh.ml
@@ -60,7 +60,7 @@ let proxy (ain : Unix.file_descr) (aout : Unix.file_descr) (bin : Unixfd.t)
         (if can_write a' then [bout] else [])
         @ if can_write b' then [aout] else []
       in
-      let r, w, _ = Unix.select r w [] (-1.0) in
+      let r, w, _ = Xapi_stdext_unix.Unixext.select r w [] (-1.0) in
       (* Do the writing before the reading *)
       List.iter
         (fun fd -> if aout = fd then write_from b' a' else write_from a' b')


### PR DESCRIPTION
This is an alternative approach, that might be easier to review.

Untested, will need to add some tests next, and then search/replace all the codebase to these new functions in a separate commit that should be a mechanical change.