### PR TITLE
py3: Config updates for removing and deprecating Python2 support

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -52,7 +52,7 @@ jobs:
           pytest -vv -rA --cov=ocaml ocaml
           --cov-report term-missing
           --cov-report xml:.git/coverage${{matrix.python-version}}.xml
-          --cov-fail-under 60
+          --cov-fail-under 50
         env:
           PYTHONDEVMODE: yes
           PYTHONPATH: "python3:python3/stubs"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,6 @@ repos:
         - opentelemetry-api
         - opentelemetry-exporter-zipkin-json
         - opentelemetry-sdk
-        - pytest-coverage
         - pytest-mock
         - mock
         - wrapt
@@ -89,7 +88,7 @@ repos:
 
 
 -   repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.361
+    rev: v1.1.372
     hooks:
     -   id: pyright
         name: check that python3 tree passes pyright/VSCode check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,8 +260,8 @@ addopts = "-v -ra"
 # xfail_strict:     require to remove pytext.xfail marker when test is fixed
 # required_plugins: require that these plugins are installed before testing
 # -----------------------------------------------------------------------------
-testpaths = ["python3", "ocaml/xcp-rrdd", "ocaml/xapi-storage"]
-required_plugins = ["pytest-cov", "pytest-mock"]
+testpaths = ["python3", "ocaml/xcp-rrdd", "ocaml/xenopsd"]
+required_plugins = ["pytest-mock"]
 log_cli_level = "INFO"
 log_cli = true
 minversion = "7.0"

--- a/scripts/examples/python/setup.cfg
+++ b/scripts/examples/python/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4
+python_requires = >=3.6.*, <4
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
Hi @stephenchengCloud,

 it turned out that the updates in this PR were not blocking for merging #5873.
 These changes are therefore just updates that are nice to have, do not change the code and can be merged later (independent of your regression testing).

This PR is now just a collection of minor updates that just happen to be in one PR to update python3 testing and to no longer announce support for Python 2.7 at https://pypi.org/project/XenAPI

Collected updates:
- pytest config update for Python3:
  - Run xenopsd tests
  - remove pytest-cov requirement (was obsoleted a while ago)
- Update the minimum supported Python version for XenAPI.py to 3.6 (for XS8)
  for https://pypi.org/project/XenAPI/ to `python_requires = >=3.6.*, <4`
- Remove ocaml/xapi-storage from the directories to test with Python3 in pyproject.toml
- Reduce pytest --cov-fail-under to 50% (50 is the default, should work with the removal)
- update pyright version