### PR TITLE
IH-507: xapi_xenops: raise an error when the kernel isn't allowed

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -337,10 +337,7 @@ let rtc_timeoffset_of_vm ~__context (vm, vm_t) vbds =
            )
         )
 
-(* /boot/ contains potentially sensitive files like xen-initrd, only allow
-   directly booting guests from the subfolder /boot/guest/ *)
-let allowed_dom0_directories_for_boot_files =
-  ["/boot/guest/"; "/var/lib/xcp/guest/"]
+let allowed_dom0_directories_for_boot_files = ["/var/lib/xcp/guest/"]
 
 let kernel_path filename =
   let ( let* ) = Result.bind in


### PR DESCRIPTION
Previously the path was replaced by an empty string, when trying to start he vm. The only feedback was on the logs as a debug message, but not all users that start VMs have access to the logs.