### PR TITLE
CP-50181: Percent decode all Uri paths before using them

### DIFF
--- a/ocaml/libs/http-lib/http.ml
+++ b/ocaml/libs/http-lib/http.ml
@@ -916,7 +916,7 @@ module Url = struct
       in
       let data =
         {
-          uri= (match Uri.path uri with "" -> "/" | path -> path)
+          uri= (match Uri.path_unencoded uri with "" -> "/" | path -> path)
         ; query_params= Uri.query uri |> List.map query
         }
       in
@@ -929,7 +929,7 @@ module Url = struct
       | Some "https" ->
           (scheme ~ssl:true, data)
       | Some "file" ->
-          let scheme = File {path= Uri.path uri} in
+          let scheme = File {path= Uri.path_unencoded uri} in
           (scheme, {data with uri= "/"})
       | _ ->
           failwith "unsupported URI scheme"

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -377,7 +377,7 @@ let request_of_bio_exn ~proxy_seen ~read_timeout ~total_timeout ~max_length bio
                  (* Request-Line   = Method SP Request-URI SP HTTP-Version CRLF *)
                  let uri_t = Uri.of_string uri in
                  if uri_t = Uri.empty then raise Http_parse_failure ;
-                 let uri = Uri.path uri_t |> Uri.pct_decode in
+                 let uri = Uri.path_unencoded uri_t in
                  let query = Uri.query uri_t |> kvlist_flatten in
                  let m = Http.method_t_of_string meth in
                  let version =

--- a/ocaml/libs/open-uri/open_uri.ml
+++ b/ocaml/libs/open-uri/open_uri.ml
@@ -74,7 +74,7 @@ let with_open_uri ?verify_cert uri f =
             )
     )
   | Some "file" ->
-      let filename = Uri.path_and_query uri in
+      let filename = Uri.path_and_query uri |> Uri.pct_decode in
       let sockaddr = Unix.ADDR_UNIX filename in
       let s = Unix.socket Unix.PF_UNIX Unix.SOCK_STREAM 0 in
       finally

--- a/ocaml/message-switch/switch/switch_main.ml
+++ b/ocaml/message-switch/switch/switch_main.ml
@@ -222,7 +222,7 @@ let make_server config trace_config =
     let open Message_switch_core.Protocol in
     Cohttp_lwt.Body.to_string body >>= fun body ->
     let uri = Cohttp.Request.uri req in
-    let path = Uri.path uri in
+    let path = Uri.path_unencoded uri in
     match In.of_request body (Cohttp.Request.meth req) path with
     | None ->
         error "<- [unparsable request; path = %s; body = %s]" path

--- a/ocaml/nbd/src/main.ml
+++ b/ocaml/nbd/src/main.ml
@@ -59,7 +59,7 @@ let handle_connection fd tls_role =
     >>= fun session_id -> f uri rpc session_id
   in
   let serve t uri rpc session_id =
-    let path = Uri.path uri in
+    let path = Uri.path_unencoded uri in
     (* note preceeding / *)
     let vdi_uuid =
       if path <> "" then String.sub path 1 (String.length path - 1) else path

--- a/ocaml/vhd-tool/src/impl.ml
+++ b/ocaml/vhd-tool/src/impl.ml
@@ -787,9 +787,9 @@ let endpoint_of_string = function
           if he = [] then raise Not_found ;
           return (Sockaddr (List.hd he).Unix.ai_addr)
       | Some "unix", _ ->
-          return (Sockaddr (Lwt_unix.ADDR_UNIX (Uri.path uri')))
+          return (Sockaddr (Lwt_unix.ADDR_UNIX (Uri.path_unencoded uri')))
       | Some "file", _ ->
-          return (File (Uri.path uri'))
+          return (File (Uri.path_unencoded uri'))
       | Some "http", _ ->
           return (Http uri')
       | Some "https", _ ->

--- a/ocaml/xapi-idl/lib/xcp_service.ml
+++ b/ocaml/xapi-idl/lib/xcp_service.ml
@@ -501,8 +501,8 @@ let http_handler call_of_string string_of_response process s =
   | `Invalid x ->
       debug "Failed to read HTTP request. Got: '%s'" x
   | `Ok req -> (
-    match (Cohttp.Request.meth req, Uri.path (Cohttp.Request.uri req)) with
-    | `POST, _ -> (
+    match Cohttp.Request.meth req with
+    | `POST -> (
         let headers = Cohttp.Request.headers req in
         match Cohttp.Header.get headers "content-length" with
         | None ->
@@ -535,7 +535,7 @@ let http_handler call_of_string string_of_response process s =
               (fun t -> Response.write_body t response_txt)
               response oc
       )
-    | _, _ ->
+    | _ ->
         let content_length = 0 in
         let headers =
           Cohttp.Header.of_list

--- a/ocaml/xapi-storage-script/examples/volume/org.xen.xcp.storage.plainlvm/common.ml
+++ b/ocaml/xapi-storage-script/examples/volume/org.xen.xcp.storage.plainlvm/common.ml
@@ -333,7 +333,7 @@ let vg_of_uri uri =
   let uri' = Uri.of_string uri in
   match Uri.scheme uri' with
   | Some "vg" ->
-      let vg = Uri.path uri' in
+      let vg = Uri.path_unencoded uri' in
       if vg <> "" && vg.[0] = '/' then
         String.sub vg 1 (String.length vg - 1)
       else

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -977,7 +977,7 @@ let bind ~volume_script_dir =
             let uri = Uri.of_string datasource in
             match Uri.scheme uri with
             | Some "xeno+shm" -> (
-                let uid = Uri.path uri in
+                let uid = Uri.path_unencoded uri in
                 let uid =
                   if String.length uid > 1 then
                     String.sub uid ~pos:1 ~len:(String.length uid - 1)
@@ -1024,7 +1024,7 @@ let bind ~volume_script_dir =
                 let uri = Uri.of_string datasource in
                 match Uri.scheme uri with
                 | Some "xeno+shm" -> (
-                    let uid = Uri.path uri in
+                    let uid = Uri.path_unencoded uri in
                     let uid =
                       if String.length uid > 1 then
                         String.sub uid ~pos:1 ~len:(String.length uid - 1)

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -135,7 +135,7 @@ let parse_url url =
     let ( let* ) = Option.bind in
     let* scheme = Uri.scheme uri in
     let* host = Uri.host uri in
-    let path = Uri.path_and_query uri in
+    let path = Uri.path_and_query uri |> Uri.pct_decode in
     Some (scheme, host, path)
   in
   match parse (Uri.of_string url) with

--- a/ocaml/xen-api-client/lwt/xen_api_lwt_unix.ml
+++ b/ocaml/xen-api-client/lwt/xen_api_lwt_unix.ml
@@ -66,7 +66,7 @@ module Lwt_unix_IO = struct
   let open_connection uri =
     ( match Uri.scheme uri with
     | Some "file" ->
-        return (Unix.PF_UNIX, Unix.ADDR_UNIX (Uri.path uri), false)
+        return (Unix.PF_UNIX, Unix.ADDR_UNIX (Uri.path_unencoded uri), false)
     | Some "http+unix" ->
         return (Unix.PF_UNIX, Unix.ADDR_UNIX (Uri.host_with_default uri), false)
     | Some "http" | Some "https" ->

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -2629,7 +2629,7 @@ and perform_exn ?subtask ?result (op : operation) (t : Xenops_task.task_handle)
       let make_url snippet id_str =
         Uri.make ?scheme:(Uri.scheme url) ?host:(Uri.host url)
           ?port:(Uri.port url)
-          ~path:(Uri.path url ^ snippet ^ id_str)
+          ~path:(Uri.path_unencoded url ^ snippet ^ id_str)
           ~query:(Uri.query url) ()
       in
       (* CA-78365: set the memory dynamic range to a single value to stop
@@ -3630,7 +3630,7 @@ module VM = struct
         debug "traceparent: %s" (Option.value ~default:"(none)" traceparent) ;
         let id, final_id =
           (* The URI is /service/xenops/memory/id *)
-          let bits = Astring.String.cuts ~sep:"/" (Uri.path uri) in
+          let bits = Astring.String.cuts ~sep:"/" (Uri.path_unencoded uri) in
           let id = bits |> List.rev |> List.hd in
           let final_id =
             match List.assoc_opt "final_id" cookies with
@@ -3673,7 +3673,7 @@ module VM = struct
       (fun () ->
         let vgpu_id =
           (* The URI is /service/xenops/migrate-vgpu/id *)
-          let path = Uri.path uri in
+          let path = Uri.path_unencoded uri in
           let bits = Astring.String.cut ~sep:"/" ~rev:true path in
           let vgpu_id_str =
             match bits with
@@ -3736,7 +3736,7 @@ module VM = struct
     let dbg = List.assoc "dbg" cookies in
     Debug.with_thread_associated dbg
       (fun () ->
-        let vm = basename (Uri.path uri) in
+        let vm = basename (Uri.path_unencoded uri) in
         match context.transferred_fd with
         | Some fd ->
             debug "VM.receive_mem: passed fd %d" (Obj.magic fd) ;


### PR DESCRIPTION
`Uri.path` returns percent-encoded output, therefore it can't be expected to behave correctly in cases where it's used to map to Unix files. Our PR upstream introduced `Uri.path_unencoded` function, use that instead.

There is one usage of  `Uri.path` left:
```ocaml
$ rg --pcre2 'Uri.path(?!_unencoded)' --no-heading -g 'ocaml/**/*.ml'
ocaml/xe-cli/newcli.ml:138:    let path = Uri.path_and_query uri |> Uri.pct_decode in
ocaml/vhd-tool/cli/sparse_dd.ml:403:          ?port:(Uri.port uri) ~path:(Uri.path uri) ~query:(Uri.query uri)
ocaml/libs/open-uri/open_uri.ml:77:      let filename = Uri.path_and_query uri |> Uri.pct_decode in
```

But this is not dangeous as it's used as an argument for Uri.make, which is fine without `pct_decode`:

```ocaml
utop # Uri.make ~path:("/get<>`&") ();;
- : Uri.t = /get%3C%3E%60&
utop # Uri.make ~path:("/get%3C%3E%60&") ();;
- : Uri.t = /get%3C%3E%60&
```

I'm not sure it's worth adding a quality gate to future-proof this.

===

https://github.com/xapi-project/xs-opam/pull/693 is required to build and merge this, therefore currently opening as a draft - but it's ready for review.