### PR TITLE
maintenance: delete unused fields

### DIFF
--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -71,7 +71,7 @@ let force_connection_reset () =
        		   host and port are fixed values. *)
     let rec purge_stunnels verify_cert =
       match
-        Stunnel_cache.with_remove ~host ~port verify_cert @@ fun st ->
+        Stunnel_cache.with_remove ~host ~port @@ fun st ->
         try Stunnel.disconnect ~wait:false ~force:true st with _ -> ()
       with
       | None ->

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -28,9 +28,9 @@ let prototyped_of_field = function
   | "Repository", "gpgkey_path" ->
       Some "22.12.0"
   | "Certificate", "fingerprint_sha1" ->
-      Some "24.19.1-next"
+      Some "24.20.0"
   | "Certificate", "fingerprint_sha256" ->
-      Some "24.19.1-next"
+      Some "24.20.0"
   | "Cluster_host", "last_update_live" ->
       Some "24.3.0"
   | "Cluster_host", "live" ->

--- a/ocaml/idl/datamodel_values.ml
+++ b/ocaml/idl/datamodel_values.ml
@@ -80,7 +80,7 @@ let to_ocaml_string v =
   in
   aux (to_rpc v)
 
-let rec to_db v =
+let to_db v =
   let open Schema.Value in
   match v with
   | VString s ->

--- a/ocaml/libs/http-lib/buf_io.ml
+++ b/ocaml/libs/http-lib/buf_io.ml
@@ -13,12 +13,7 @@
  *)
 (* Buffered IO with timeouts *)
 
-type t = {
-    fd: Unix.file_descr
-  ; mutable buf: bytes
-  ; mutable cur: int
-  ; mutable max: int
-}
+type t = {fd: Unix.file_descr; buf: bytes; mutable cur: int; mutable max: int}
 
 type err =
   | (* Line input is > 1024 chars *)

--- a/ocaml/libs/http-lib/xmlrpc_client.ml
+++ b/ocaml/libs/http-lib/xmlrpc_client.ml
@@ -189,7 +189,7 @@ let with_reusable_stunnel ?use_fork_exec_helper ?write_to_log ?verify_cert host
   (* 1. First check if there is a suitable stunnel in the cache. *)
   let rec loop () =
     match
-      Stunnel_cache.with_remove ~host ~port verify_cert @@ fun x ->
+      Stunnel_cache.with_remove ~host ~port @@ fun x ->
       if check_reusable x.Stunnel.fd (Stunnel.getpid x.Stunnel.pid) then
         Ok (f x)
       else (

--- a/ocaml/libs/stunnel/stunnel_cache.mli
+++ b/ocaml/libs/stunnel/stunnel_cache.mli
@@ -28,7 +28,7 @@ val with_connect :
   -> (Stunnel.t -> 'b)
   -> 'b
 (** Connects via stunnel (optionally via an external 'fork/exec helper') to
-    a host and port. If there is a suitable stunnel in the cache then this 
+    a host and port. If there is a suitable stunnel in the cache then this
     will be used, otherwise we make a fresh one. *)
 
 val add : Stunnel.t -> unit
@@ -37,7 +37,6 @@ val add : Stunnel.t -> unit
 val with_remove :
      host:string (** host *)
   -> port:int (** port *)
-  -> Stunnel.verification_config option
   -> (Stunnel.t -> 'b)
   -> 'b option
 (** Given a host and port call a function with a cached stunnel, or return None. *)

--- a/ocaml/libs/vhd/vhd_format/f.ml
+++ b/ocaml/libs/vhd/vhd_format/f.ml
@@ -1607,8 +1607,6 @@ module Vhd = struct
   module Field = struct
     (** Dynamically-typed field-level access *)
 
-    type 'a f = {name: string; get: 'a t -> string}
-
     let _features = "features"
 
     let _data_offset = "data-offset"
@@ -1770,8 +1768,6 @@ module Vhd = struct
         opt (fun (t, _) -> Int32.to_string t.Batmap_header.checksum) t.batmap
       else
         None
-
-    type 'a t = 'a f
   end
 end
 

--- a/ocaml/libs/vhd/vhd_format_lwt/block.ml
+++ b/ocaml/libs/vhd/vhd_format_lwt/block.ml
@@ -25,7 +25,7 @@ let pp_write_error = Mirage_block.pp_write_error
 
 type info = Mirage_block.info
 
-type t = {mutable vhd: IO.fd Vhd_format.F.Vhd.t option; info: info; id: string}
+type t = {mutable vhd: IO.fd Vhd_format.F.Vhd.t option; info: info}
 
 let connect path =
   Lwt_unix.LargeFile.stat path >>= fun _ ->
@@ -38,8 +38,7 @@ let connect path =
   let sector_size = 512 in
   let size_sectors = Int64.div vhd.Vhd.footer.Footer.current_size 512L in
   let info = Mirage_block.{read_write; sector_size; size_sectors} in
-  let id = path in
-  return {vhd= Some vhd; info; id}
+  return {vhd= Some vhd; info}
 
 let disconnect t =
   match t.vhd with

--- a/ocaml/libs/vhd/vhd_format_lwt/iO.ml
+++ b/ocaml/libs/vhd/vhd_format_lwt/iO.ml
@@ -46,13 +46,13 @@ let complete name offset op fd buffer =
 module Fd = struct
   open Lwt
 
-  type fd = {fd: Lwt_unix.file_descr; filename: string; lock: Lwt_mutex.t}
+  type fd = {fd: Lwt_unix.file_descr; lock: Lwt_mutex.t}
 
   let openfile filename rw =
     let unix_fd = File.openfile filename rw 0o644 in
     let fd = Lwt_unix.of_unix_file_descr unix_fd in
     let lock = Lwt_mutex.create () in
-    return {fd; filename; lock}
+    return {fd; lock}
 
   let fsync {fd; _} =
     let fd' = Lwt_unix.unix_file_descr fd in

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
@@ -49,15 +49,13 @@ module Delay = struct
   (* Concrete type is the ends of a pipe *)
   type t = {
       (* A pipe is used to wake up a thread blocked in wait: *)
-      mutable pipe_out: Unix.file_descr option
-    ; mutable pipe_in: Unix.file_descr option
+      mutable pipe_in: Unix.file_descr option
     ; (* Indicates that a signal arrived before a wait: *)
       mutable signalled: bool
     ; m: M.t
   }
 
-  let make () =
-    {pipe_out= None; pipe_in= None; signalled= false; m= M.create ()}
+  let make () = {pipe_in= None; signalled= false; m= M.create ()}
 
   exception Pre_signalled
 
@@ -80,7 +78,6 @@ module Delay = struct
                 let pipe_out, pipe_in = Unix.pipe () in
                 (* these will be unconditionally closed on exit *)
                 to_close := [pipe_out; pipe_in] ;
-                x.pipe_out <- Some pipe_out ;
                 x.pipe_in <- Some pipe_in ;
                 x.signalled <- false ;
                 pipe_out
@@ -99,7 +96,6 @@ module Delay = struct
       )
       (fun () ->
         Mutex.execute x.m (fun () ->
-            x.pipe_out <- None ;
             x.pipe_in <- None ;
             List.iter close' !to_close
         )

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
@@ -303,7 +303,7 @@ let open_connection_unix_fd filename =
 module CBuf = struct
   (** A circular buffer constructed from a string *)
   type t = {
-      mutable buffer: bytes
+      buffer: bytes
     ; mutable len: int  (** bytes of valid data in [buffer] *)
     ; mutable start: int  (** index of first valid byte in [buffer] *)
     ; mutable r_closed: bool  (** true if no more data can be read due to EOF *)

--- a/ocaml/libs/xml-light2/xml.ml
+++ b/ocaml/libs/xml-light2/xml.ml
@@ -22,7 +22,7 @@ type xml =
   | Element of (string * (string * string) list * xml list)
   | PCData of string
 
-type error_pos = {eline: int; eline_start: int; emin: int; emax: int}
+type error_pos = {eline: int}
 
 type error = string * error_pos
 
@@ -69,8 +69,8 @@ let _parse i =
 
 let parse i =
   try _parse i
-  with Xmlm.Error ((line, col), msg) ->
-    let pos = {eline= line; eline_start= line; emin= col; emax= col} in
+  with Xmlm.Error ((line, _), msg) ->
+    let pos = {eline= line} in
     let err = Xmlm.error_message msg in
     raise (Error (err, pos))
 

--- a/ocaml/message-switch/switch/logging.ml
+++ b/ocaml/message-switch/switch/logging.ml
@@ -20,7 +20,6 @@ type logger = {
     stream: string Lwt_stream.t
   ; push: string -> unit
   ; elements: int ref
-  ; max_elements: int
   ; dropped_elements: int ref
 }
 
@@ -35,13 +34,7 @@ let create max_elements =
       stream_push (Some line) ; incr !elements
     )
   in
-  {
-    stream
-  ; push
-  ; elements= !elements
-  ; max_elements
-  ; dropped_elements= !dropped_elements
-  }
+  {stream; push; elements= !elements; dropped_elements= !dropped_elements}
 
 let get (logger : logger) =
   let return_lines all =

--- a/ocaml/rrd2csv/src/rrd2csv.ml
+++ b/ocaml/rrd2csv/src/rrd2csv.ml
@@ -143,10 +143,9 @@ module Ds_selector = struct
     ; owner: Rrd.ds_owner option
     ; uuid: string
     ; metric: string
-    ; enabled: bool
   }
 
-  let empty = {cf= None; owner= None; uuid= ""; metric= ""; enabled= true}
+  let empty = {cf= None; owner= None; uuid= ""; metric= ""}
 
   let of_string str =
     let open Rrd in
@@ -154,7 +153,6 @@ module Ds_selector = struct
     match splitted with
     | [cf; owner; uuid; metric] ->
         {
-          empty with
           cf= (try Some (cf_type_of_string cf) with _ -> None)
         ; owner=
             ( match owner with
@@ -351,9 +349,7 @@ module Xport = struct
   (* Xport.t structure *)
 
   type meta = {
-      time_start: int64
-    ; time_step: int64
-    ; time_end: int64
+      time_step: int64
     ; entries: Ds_selector.t list
           (* XXX: remove when merging *)
           (* entries: Ds_selector.t list; *)
@@ -411,9 +407,7 @@ module Xport = struct
     let process_meta (elts : xml_tree list) =
       let kvs = kvs elts in
       {
-        time_start= Int64.of_string (List.assoc "start" kvs)
-      ; time_step= Int64.of_string (List.assoc "step" kvs)
-      ; time_end= Int64.of_string (List.assoc "end" kvs)
+        time_step= Int64.of_string (List.assoc "step" kvs)
       ; entries= process_legend (find_elt "legend" elts)
       }
     in

--- a/ocaml/xapi-idl/lib/scheduler.ml
+++ b/ocaml/xapi-idl/lib/scheduler.ml
@@ -41,7 +41,7 @@ module HandleMap = Map.Make (struct
       c
 end)
 
-type item = {id: int; name: string; fn: unit -> unit}
+type item = {name: string; fn: unit -> unit}
 
 type t = {
     mutable schedule: item HandleMap.t
@@ -88,7 +88,7 @@ let one_shot_f s dt (name : string) f =
   with_lock s.m (fun () ->
       let id = s.next_id in
       s.next_id <- s.next_id + 1 ;
-      let item = {id; name; fn= f} in
+      let item = {name; fn= f} in
       let handle = (time, id) in
       s.schedule <- HandleMap.add handle item s.schedule ;
       PipeDelay.signal s.delay ;

--- a/ocaml/xapi-idl/lib/task_server.ml
+++ b/ocaml/xapi-idl/lib/task_server.ml
@@ -101,14 +101,12 @@ functor
         task_map: task_handle SMap.t ref
       ; mutable test_cancel_trigger: (string * int) option
       ; m: Mutex.t
-      ; c: Condition.t
     }
 
     let empty () =
       let task_map = ref SMap.empty in
       let m = Mutex.create () in
-      let c = Condition.create () in
-      {task_map; test_cancel_trigger= None; m; c}
+      {task_map; test_cancel_trigger= None; m}
 
     (* [next_task_id ()] returns a fresh task id *)
     let next_task_id =

--- a/ocaml/xapi/vgpuops.ml
+++ b/ocaml/xapi/vgpuops.ml
@@ -20,8 +20,6 @@ open Xapi_stdext_std.Xstringext
 type vgpu_t = {
     vgpu_ref: API.ref_VGPU
   ; gpu_group_ref: API.ref_GPU_group
-  ; devid: int
-  ; other_config: (string * string) list
   ; type_ref: API.ref_VGPU_type
   ; requires_passthrough: [`PF | `VF] option
 }
@@ -31,8 +29,6 @@ let vgpu_of_ref ~__context vgpu =
   {
     vgpu_ref= vgpu
   ; gpu_group_ref= vgpu_r.API.vGPU_GPU_group
-  ; devid= int_of_string vgpu_r.API.vGPU_device
-  ; other_config= vgpu_r.API.vGPU_other_config
   ; type_ref= vgpu_r.API.vGPU_type
   ; requires_passthrough= Xapi_vgpu.requires_passthrough ~__context ~self:vgpu
   }

--- a/ocaml/xapi/xapi_dr_task.ml
+++ b/ocaml/xapi/xapi_dr_task.ml
@@ -26,12 +26,7 @@ let make_task ~__context =
   ref
 
 (* A type to represent an SR record parsed from an sr_probe result. *)
-type sr_probe_sr = {
-    uuid: string
-  ; name_label: string
-  ; name_description: string
-  ; metadata_detected: bool
-}
+type sr_probe_sr = {uuid: string; name_label: string; name_description: string}
 
 (* Attempt to parse a key/value pair from XML. *)
 let parse_kv = function
@@ -53,8 +48,6 @@ let parse_sr_probe xml =
               uuid= List.assoc "UUID" all
             ; name_label= List.assoc "name_label" all
             ; name_description= List.assoc "name_description" all
-            ; metadata_detected=
-                List.assoc "pool_metadata_detected" all = "true"
             }
         | _ ->
             failwith "Malformed or missing <SR>"

--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -117,17 +117,12 @@ module Next = struct
   let highest_forgotten_id = ref (-1L)
 
   type subscription = {
-      mutable last_id: int64
-    ; (* last event ID to sent to this client *)
-      mutable subs: Subscription.t list
-    ; (* list of all the subscriptions *)
-      m: Mutex.t
-    ; (* protects access to the mutable fields in this record *)
-      session: API.ref_session
-    ; (* session which owns this subscription *)
-      mutable session_invalid: bool
-    ; (* set to true if the associated session has been deleted *)
-      mutable timeout: float (* Timeout *)
+      mutable last_id: int64  (** last event ID to sent to this client *)
+    ; mutable subs: Subscription.t list  (** all the subscriptions *)
+    ; m: Mutex.t  (** protects access to the mutable fields in this record *)
+    ; session: API.ref_session  (** session which owns this subscription *)
+    ; mutable session_invalid: bool
+          (** set to true if the associated session has been deleted *)
   }
 
   (* For Event.next, the single subscription associated with a session *)
@@ -235,7 +230,6 @@ module Next = struct
               ; m= Mutex.create ()
               ; session
               ; session_invalid= false
-              ; timeout= 0.0
               }
             in
             Hashtbl.replace subscriptions session subscription ;

--- a/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/rrdd_server.ml
@@ -457,8 +457,8 @@ let query_host_ds (ds_name : string) : float =
   )
 
 (** Dump all latest data of host dss to file in json format so that any client
-    can read even if it's non-privileged user, such as NRPE. 
-    Especially, nan, infinity and neg_infinity will be converted to strings 
+    can read even if it's non-privileged user, such as NRPE.
+    Especially, nan, infinity and neg_infinity will be converted to strings
     "NaN", "infinity" and "-infinity", the client needs to handle by itself.
     *)
 let convert_value x =
@@ -651,8 +651,7 @@ module Plugin = struct
          - Can the code for backwards compatibility be expunged? *)
 
       type plugin = {
-          info: P.info
-        ; reader: Rrd_reader.reader
+          reader: Rrd_reader.reader
         ; mutable skip_init: int  (** initial value for skip after read err *)
         ; mutable skip: int  (** number of cycles to skip b/f next read *)
       }
@@ -748,7 +747,7 @@ module Plugin = struct
               let reader =
                 P.make_reader ~uid ~info ~protocol:(choose_protocol protocol)
               in
-              Hashtbl.add registered uid {info; reader; skip_init= 1; skip= 0}
+              Hashtbl.add registered uid {reader; skip_init= 1; skip= 0}
         ) ;
         next_reading uid
 

--- a/ocaml/xen-api-client/lib_test/xen_api_test.ml
+++ b/ocaml/xen-api-client/lib_test/xen_api_test.ml
@@ -46,13 +46,13 @@ module Fake_IO = struct
 
   let flush _oc = return ()
 
-  type connection = {address: Uri.t; ic: ic; oc: ic}
+  type connection = {ic: ic; oc: ic}
 
   let connections = ref []
 
-  let open_connection address =
+  let open_connection _ =
     let ic = Queue.create () and oc = Queue.create () in
-    let c = {address; ic; oc} in
+    let c = {ic; oc} in
     connections := c :: !connections ;
     return (Ok (ic, oc))
 
@@ -111,7 +111,7 @@ let test_login_success () =
   let module Fake_IO = struct
     include Fake_IO
 
-    let open_connection address =
+    let open_connection _ =
       let ic = Queue.create () and oc = Queue.create () in
       Queue.push "HTTP/1.1 200 OK\r\n" ic ;
       Queue.push
@@ -119,7 +119,7 @@ let test_login_success () =
         ic ;
       Queue.push "\r\n" ic ;
       Queue.push result ic ;
-      let c = {address; ic; oc} in
+      let c = {ic; oc} in
       connections := c :: !connections ;
       return (Ok (ic, oc))
   end in

--- a/ocaml/xsh/xsh.ml
+++ b/ocaml/xsh/xsh.ml
@@ -19,7 +19,7 @@ open D
 type endpoint = {
     fdin: Unix.file_descr
   ; fdout: Unix.file_descr
-  ; mutable buffer: bytes
+  ; buffer: bytes
   ; mutable buffer_len: int
 }
 


### PR DESCRIPTION
These are errors in dune 3.15 and don't seem to be problematic

The warnings in tracing have been left in the code, but need to be dealt with 

They are span links and description for the status. Currently they are unused. @GabrielBuica is there any work in the pipeline planned for this? I'd like to readd the warning as an error