### PR TITLE
maintenance: restore dune utop

### DIFF
--- a/ocaml/sdk-gen/go/dune
+++ b/ocaml/sdk-gen/go/dune
@@ -14,6 +14,7 @@
 (library
   (name gen_go_helper)
   (modules gen_go_helper)
+  (modes best)
   (libraries
     CommonFunctions
     astring

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -57,6 +57,7 @@
 (library
   (name xapi_internal_minimal)
   (modules context custom_actions xapi_globs server_helpers session_check rbac rbac_audit db_actions taskHelper eventgen locking_helpers exnHelper rbac_static xapi_role xapi_extensions db)
+  (modes best)
   (wrapped false)
   (libraries
     http_lib
@@ -65,7 +66,7 @@
     xapi-types
     xapi_database
     mtime
-    tracing 
+    tracing
     uuid
     rpclib.core
     threads.posix


### PR DESCRIPTION
Without specifying the mode for these libraries, utop fails to find their dependencies