### PR TITLE
dune: declare stresstests dependencies

### DIFF
--- a/ocaml/libs/http-lib/dune
+++ b/ocaml/libs/http-lib/dune
@@ -60,7 +60,7 @@
   (modules http_test radix_tree_test)
   (libraries
     alcotest
-    
+
     fmt
     http_lib
   )
@@ -88,8 +88,9 @@
 
 (rule
   (alias stresstest)
+  (deps bufio_test.exe)
   ; use default random seed on stresstests
-  (action (run %{dep:bufio_test.exe} -v -bt))
+  (action (run %{deps} -v -bt))
 )
 
 (executable
@@ -97,7 +98,7 @@
   (name test_client)
   (modules test_client)
   (libraries
-    
+
     http_lib
     safe-resources
     stunnel
@@ -112,7 +113,7 @@
   (name test_server)
   (modules test_server)
   (libraries
-    
+
     http_lib
     httpsvr
     safe-resources

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
@@ -9,8 +9,9 @@
 
 (rule
   (alias stresstest)
+  (deps unixext_test.exe)
   ; use default random seed on stresstests
-  (action (run %{dep:unixext_test.exe} -v -bt))
+  (action (run %{deps} -v -bt))
 )
 
 (test


### PR DESCRIPTION
This should fix the nightly CIs: https://github.com/xapi-project/xen-api/actions/runs/10155212107/job/28081595232