### PR TITLE
CP-49148: Fix ambiguous python shebang for XS9

### DIFF
--- a/python3/libexec/restore-sr-metadata.py
+++ b/python3/libexec/restore-sr-metadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Restore SR metadata and VDI names from an XML file
 # (c) Anil Madhavapeddy, Citrix Systems Inc, 2008
 


### PR DESCRIPTION
When building xapi for XS9, ran into errors:

*** ERROR: ambiguous python shebang in /opt/xensource/libexec/restore-sr-metadata.py:
 #!/usr/bin/python. Change it to python3 (or python2) explicitly.

Explicitly use python3.

Test: 
202187 Ring3:BST+BVT (failed case is not related to this PR)

- [x] CI Ocaml test failed. Will sync with the master code and rebase.
