### PR TITLE
[ASAP] CA-396479: Use default value for unknown enums in Java

### DIFF
--- a/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
+++ b/ocaml/sdk-gen/java/autogen/xen-api/src/main/java/com/xensource/xenapi/JsonRpcClient.java
@@ -216,6 +216,7 @@ public class JsonRpcClient {
         dateHandlerModule.addDeserializer(Date.class, new CustomDateDeserializer());
         this.objectMapper.enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature());
         this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        this.objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
         this.objectMapper.registerModule(dateHandlerModule);
     }
 

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -882,7 +882,7 @@ let gen_enum file name ls =
     )
     ls ;
   fprintf file "        /* This can never be reached */\n" ;
-  fprintf file "        return \"illegal enum\";\n" ;
+  fprintf file "        return \"UNRECOGNIZED\";\n" ;
   fprintf file "        }\n" ;
   fprintf file "\n    }\n\n"
 


### PR DESCRIPTION
Default enum is `UNRECOGNIZED`