### PR TITLE
CP-49148: fix pylint warning

### DIFF
--- a/scripts/examples/python/XenAPI/XenAPI.py
+++ b/scripts/examples/python/XenAPI/XenAPI.py
@@ -54,7 +54,6 @@
 # OF THIS SOFTWARE.
 # --------------------------------------------------------------------
 
-import errno
 import gettext
 import os
 import socket


### PR DESCRIPTION
This `import errno` was added by feature/py3 branch to fix pytype issues. But in the master branch, there was also a change to fix pytype issues. Use master code and remove the import.