### PR TITLE
Update qcheck-alcotest dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -331,6 +331,7 @@
     ppx_sexp_conv
     ppx_deriving
     psq
+    qcheck-alcotest
     rpclib
     (rrdd-plugin (= :version))
     rresult

--- a/ocaml/libs/clock/dune
+++ b/ocaml/libs/clock/dune
@@ -13,14 +13,12 @@
 
 (library
   (name test_timer)
-  (package clock)
   (modules test_timer)
   (libraries
     alcotest
     clock
     fmt
     mtime.clock.os
-    qcheck-alcotest
     qcheck-core
   )
 )

--- a/xapi.opam
+++ b/xapi.opam
@@ -37,6 +37,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_deriving"
   "psq"
+  "qcheck-alcotest"
   "rpclib"
   "rrdd-plugin" {= version}
   "rresult"


### PR DESCRIPTION
test_timer shouldn't be part of the clock package: it is only needed for testing.
test_timer doesn't need to depend on qcheck-alcotest: only _run needs to.

XAPI needs to depend on qcheck-alcotest, because quicktest uses it too now.