### PR TITLE
CP-49148: Convert rrdd-example.py to python3

### DIFF
--- a/ocaml/xcp-rrdd/scripts/rrdd/rrdd-example.py
+++ b/ocaml/xcp-rrdd/scripts/rrdd/rrdd-example.py
@@ -1,18 +1,19 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-import rrdd, os
+import os
+import rrdd
 
 if __name__ == "__main__":
-  # Create a proxy for communicating with xcp-rrdd.
-  api = rrdd.API(plugin_id="host_mem")
-  while True:
-    # Wait until 0.5 seconds before xcp-rrdd is going to read the output file.
-    api.wait_until_next_reading(neg_shift=.5)
-    # Collect measurements.
-    cmd = "free -k | grep Mem | awk '{print $2, $3, $4}'"
-    vs = os.popen(cmd).read().strip().split()
-    # Tell the proxy which datasources should be exposed in this iteration.
-    api.set_datasource("used_mem", vs[1], min_val=0, max_val=vs[0], units="KB")
-    api.set_datasource("free_mem", vs[2], min_val=0, max_val=vs[0], units="KB")
-    # Write all required information into a file about to be read by xcp-rrdd.
-    api.update()
+    # Create a proxy for communicating with xcp-rrdd.
+    api = rrdd.API(plugin_id="host_mem")
+    while True:
+        # Wait until 0.5 seconds before xcp-rrdd is going to read the output file.
+        api.wait_until_next_reading(neg_shift=.5)
+        # Collect measurements.
+        cmd = "free -k | grep Mem | awk '{print $2, $3, $4}'"
+        vs = os.popen(cmd).read().strip().split()
+        # Tell the proxy which datasources should be exposed in this iteration.
+        api.set_datasource("used_mem", vs[1], min_val=0, max_val=vs[0], units="KB")
+        api.set_datasource("free_mem", vs[2], min_val=0, max_val=vs[0], units="KB")
+        # Write all required information into a file about to be read by xcp-rrdd.
+        api.update()


### PR DESCRIPTION
Since this is only an example file, no xenrt test.
This file is not installed on dom0, should do no harm.
- pylint and pytype check passed
- Manually tested the main logic works in python3:
```
Python 3.11.0 (main, Jun 21 2024, 03:47:37) [GCC 13.3.1 20240522 (Red Hat 13.3.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> cmd = "free -k | grep Mem | awk '{print $2, $3, $4}'"
>>> import os
>>> vs = os.popen(cmd).read().strip().split()
>>> vs
['16336416', '4351784', '1958616']
```