### PR TITLE
ci: use the names of binaries, not libraries in stresstests

### DIFF
--- a/ocaml/libs/http-lib/dune
+++ b/ocaml/libs/http-lib/dune
@@ -97,7 +97,7 @@
 
 (rule
   (alias stresstest)
-  (deps bufio_test.exe)
+  (deps bufio_test_run.exe)
   ; use default random seed on stresstests
   (action (run %{deps} -v -bt))
 )

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
@@ -15,7 +15,7 @@
 
 (rule
   (alias stresstest)
-  (deps unixext_test.exe)
+  (deps unixext_test_run.exe)
   ; use default random seed on stresstests
   (action (run %{deps} -v -bt))
 )


### PR DESCRIPTION
These were changed recently and the stresstest rules need to match the new name.

I've tested this locally by running `dune build @stresstest`