### PR TITLE
Non-CDN updates bug fix

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1927,6 +1927,8 @@ let _ =
     () ;
   error Api_errors.reposync_failed []
     ~doc:"Syncing with remote YUM repository failed." () ;
+  error Api_errors.bundle_sync_failed []
+    ~doc:"Syncing with bundle repository failed." () ;
   error Api_errors.invalid_repomd_xml [] ~doc:"The repomd.xml is invalid." () ;
   error Api_errors.invalid_updateinfo_xml []
     ~doc:"The updateinfo.xml is invalid." () ;

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1338,6 +1338,8 @@ let sync_bundle_in_progress = add_error "SYNC_BUNDLE_IN_PROGRESS"
 
 let reposync_failed = add_error "REPOSYNC_FAILED"
 
+let bundle_sync_failed = add_error "BUNDLE_SYNC_FAILED"
+
 let createrepo_failed = add_error "CREATEREPO_FAILED"
 
 let invalid_updateinfo_xml = add_error "INVALID_UPDATEINFO_XML"

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -957,8 +957,8 @@ let ignore_vtpm_unimplemented = ref false
 
 let evacuation_batch_size = ref 10
 
-(* Max size limit of bundle file: 500 MB*)
-let bundle_max_size_limit = ref (Int64.of_int (500 * 1024 * 1024))
+(* Max size limit of bundle file: 1 GB*)
+let bundle_max_size_limit = ref (Int64.of_int (1024 * 1024 * 1024))
 
 type xapi_globs_spec =
   | Float of float ref

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3800,9 +3800,12 @@ let put_bundle_handler (req : Request.t) s _ =
                 TaskHelper.set_progress ~__context 0.8 ;
                 finally
                   (fun () ->
-                    sync_repos ~__context ~self:pool ~repos:[repo] ~force:true
-                      ~token:"" ~token_id:""
-                    |> ignore
+                    try
+                      sync_repos ~__context ~self:pool ~repos:[repo] ~force:true
+                        ~token:"" ~token_id:""
+                      |> ignore
+                    with _ ->
+                      raise Api_errors.(Server_error (bundle_sync_failed, []))
                   )
                   (fun () -> Unixext.rm_rec !Xapi_globs.bundle_repository_dir)
             | Error e ->


### PR DESCRIPTION
Fix some non-CDN bugs/comments:
1. Change the max total bundle files size limit to 1G.
2. Change HTTP error code for the following error to 400:
   bundle_repo_not_enabled.
   no_repository_enabled.
   multiple_update_repositories_enabled.
3. Add a new API error for bundle syncing failure "Syncing with bundle repository failed."

