### PR TITLE
ci: Avoid breaking through the opam sandbox in tests

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.t
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.t
@@ -15,8 +15,7 @@
 
 == Use socket files
   $ export TMPDIR=${TMPDIR:-/tmp}
-  $ export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-$TMPDIR}
-  $ export NOTIFY_SOCKET="${XDG_RUNTIME_DIR}/systemd.socket"
+  $ export NOTIFY_SOCKET="${TMPDIR}/systemd.socket"
   $ rm -f "$NOTIFY_SOCKET"
   $ ./test_systemd.exe --server &
   READY=1


### PR DESCRIPTION
Use tmpdir whenever possible.

This fixes testing under opam for xs-opam's CI, which is not done currently for the package