### PR TITLE
Remove python2 related CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Make install smoketest
         run: |
           opam exec -- make install DESTDIR=$(mktemp -d)
-          opam exec -- make install DESTDIR=$(mktemp -d) BUILD_PY2=NO
+          opam exec -- make install DESTDIR=$(mktemp -d)
 
       - name: Check disk space
         run: df -h || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Make install smoketest
         run: |
           opam exec -- make install DESTDIR=$(mktemp -d)
-          opam exec -- make install DESTDIR=$(mktemp -d)
 
       - name: Check disk space
         run: df -h || true

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.11"]
+        python-version: ["3.11"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,23 +39,10 @@ jobs:
 
       - uses: pre-commit/action@v3.0.1
         name: Run pre-commit checks (no spaces at end of lines, etc)
-        if: ${{ matrix.python-version != '2.7' }}
         with:
           extra_args: --all-files --verbose --hook-stage commit
         env:
           SKIP: no-commit-to-branch
-
-      - name: Run Pytest for python 2 and get code coverage
-        if: ${{ matrix.python-version == '2.7' }}
-        run: >
-          pip install enum future mock pytest-coverage pytest-mock &&
-          pytest -vv -rA --cov=ocaml ocaml
-          --cov-report term-missing
-          --cov-report xml:.git/coverage${{matrix.python-version}}.xml
-          --cov-fail-under 50
-        env:
-          PYTHONDEVMODE: yes
-          PYTHONPATH: "python3:python3/stubs"
 
       - name: Upload coverage report to Coveralls
         uses: coverallsapp/github-action@v2
@@ -66,7 +53,6 @@ jobs:
           parallel: true
 
       - uses: dciborow/action-pylint@0.1.0
-        if: ${{ matrix.python-version != '2.7' }}
         with:
           reporter: github-pr-review
           level: warning
@@ -75,7 +61,6 @@ jobs:
         continue-on-error: true
 
       - name: Run pytype checks
-        if: ${{ matrix.python-version != '2.7' }}
         run: pip install pandas pytype toml && ./pytype_reporter.py
         env:
           PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
The code has already been tested by python3.
Remove python2 test from the CI actions.

```
============================= test session starts ==============================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0 -- /home/runner/.cache/pre-commit/repom96bpdxe/py_env-**python3.11/bin/python**
cachedir: .pytest_cache
rootdir: /home/runner/work/xen-api/xen-api
configfile: pyproject.toml
testpaths: python3, **ocaml/xcp-rrdd, ocaml/xenopsd**

.....

ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[None-5-reading0-5] PASSED [ 87%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[1-5-reading1-5] PASSED [ 88%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[2.25-5-reading2-3.75] PASSED [ 89%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[0.5-30-reading3-30] PASSED [ 90%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[2-120-reading4-120] PASSED [ 91%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[11-5-reading5-0] PASSED [ 91%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[1-10-reading6-0] PASSED [ 92%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[1-9-reading7-9] PASSED [ 93%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[1-10-reading8-8] PASSED [ 94%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_params[1-7-reading9-5] PASSED [ 95%]
ocaml/xcp-rrdd/scripts/rrdd/test_api_wait_until_next_reading.py::test_api_getter_functions PASSED [ 95%]
ocaml/xenopsd/scripts/test_igmp_query_injector.py::TestXSWatcher::test_unwatch PASSED [ 96%]
ocaml/xenopsd/scripts/test_igmp_query_injector.py::TestXSWatcher::test_watch PASSED [ 97%]
ocaml/xenopsd/scripts/test_igmp_query_injector.py::TestIGMPQueryInjector::test_inject_with_connection_state_check_succ PASSED [ 98%]
ocaml/xenopsd/scripts/test_igmp_query_injector.py::TestIGMPQueryInjector::test_inject_with_connection_state_check_timeout PASSED [ 99%]
ocaml/xenopsd/scripts/test_igmp_query_injector.py::TestIGMPQueryInjector::test_inject_without_connection_state_check PASSED [100%]
...
Name                                                Stmts   Miss  Cover
-----------------------------------------------------------------------
ocaml/xcp-rrdd/scripts/rrdd/rrdd.py                   171     83    51%
ocaml/xenopsd/scripts/igmp_query_injector.py          144     51    65%
ocaml/xenopsd/scripts/test_igmp_query_injector.py      73      1    99%
```