### PR TITLE
CA-389345: fix incorrect data type in python3

### DIFF
--- a/ocaml/xenopsd/scripts/igmp_query_injector.py
+++ b/ocaml/xenopsd/scripts/igmp_query_injector.py
@@ -53,7 +53,8 @@ class IGMPQueryInjector(object):
         ether_part = Ether(src='00:00:00:00:00:00', dst=dst_mac)
         ip_part = IP(ttl=1, src='0.0.0.0', dst='224.0.0.1')
         igmp_part = IGMP(type=0x11)
-        igmp_part.mrcode = (self.max_resp_time / 100) & 0xff
+        # Should use integer division // in python 3
+        igmp_part.mrcode = (self.max_resp_time // 100) & 0xff
         igmp_part.igmpize()
         # Make this IGMP query packet as an unicast packet
         ether_part.dst = dst_mac


### PR DESCRIPTION
  even if turning igmp snooping on in ovs bridge, if there is no
  external querier multicast traffic, ovs igmp snooping will not
  work, so we need to inject igmp traffic