### PR TITLE
tests for Unix.select and introduce select-as-epoll

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/dune
@@ -1,7 +1,7 @@
 ; This will be used to test stdext itself, so do not depend on stdext here
 (library
 	(name xapi_fd_test)
-	(libraries (re_export xapi-stdext-unix.fdcaps) unix qcheck-core logs fmt (re_export mtime) mtime.clock.os rresult threads.posix)
+	(libraries clock (re_export xapi-stdext-unix.fdcaps) unix qcheck-core logs fmt (re_export mtime) mtime.clock.os rresult threads.posix)
 
 	; off by default, enable with --instrument-with bisect_ppx
 	(instrumentation (backend bisect_ppx))

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.ml
@@ -52,6 +52,28 @@ let testable_file_kind =
   , snd file_kind
   )
 
+let testable_file_kinds =
+  let f, _ = testable_file_kind in
+  let open Gen in
+  (* make sure we generate the empty list with ~50% probability,
+     and that we generate smaller lists more frequently
+  *)
+  let* size_bound = frequencya [|(4, 0); (4, 2); (2, 10); (1, 510)|] in
+  let size_gen = int_bound size_bound in
+  let repeated_list =
+    let* size = size_gen in
+    list_repeat size f
+  in
+  (* generates 2 kinds of lists:
+     - lists that contain only a single file kind
+     - lists that contain multiple file kinds
+
+     This is important for testing [select], because a single
+       [Unix.S_REG] would cause it to return immediately,
+       making it unlikely that we're actually testing the behaviour for other file descriptors.
+  *)
+  oneof [repeated_list; list_size size_gen f]
+
 (* also coincidentally the pipe buffer size on Linux *)
 let ocaml_unix_buffer_size = 65536
 

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.mli
@@ -85,3 +85,16 @@ val run_rw :
 
  @returns observations about [f]'s actions the file descriptor
 *)
+
+val file_kind : Unix.file_kind QCheck2.Gen.t * Unix.file_kind QCheck2.Print.t
+(** [file_kind] is a {!type:Unix.file_kind} generator and pretty printer.
+  It generates all file kinds, even ones that normally cannot be opened in OCaml,
+  like {!val:Unix.S_DIR}, or that require special privileges, like {!val:Unix.S_BLK}
+
+  See also {!val:testable_file_kind}.
+ *)
+
+val testable_file_kind :
+  Unix.file_kind QCheck2.Gen.t * Unix.file_kind QCheck2.Print.t
+(** [testable_file_kind] is like {!val:file_kind}, but only generates file kinds
+  that the current program can create. *)

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.mli
@@ -99,5 +99,9 @@ val testable_file_kind :
 (** [testable_file_kind] is like {!val:file_kind}, but only generates file kinds
   that the current program can create. *)
 
-val testable_file_kinds : Unix.file_kind list QCheck2.Gen.t
-(** [testable_file_kinds] generates multiple file kinds, suitable for [select/poll/epoll]. *)
+val select_input :
+  Observations.select_input QCheck2.Gen.t
+  * Observations.select_input QCheck2.Print.t
+(** [select_input] generates input for [select/(e)poll].
+  See {!val:Observations.with_select_input} on how to use it to get actual file descriptors.
+ *)

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/generate.mli
@@ -98,3 +98,6 @@ val testable_file_kind :
   Unix.file_kind QCheck2.Gen.t * Unix.file_kind QCheck2.Print.t
 (** [testable_file_kind] is like {!val:file_kind}, but only generates file kinds
   that the current program can create. *)
+
+val testable_file_kinds : Unix.file_kind list QCheck2.Gen.t
+(** [testable_file_kinds] generates multiple file kinds, suitable for [select/poll/epoll]. *)

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.ml
@@ -307,3 +307,18 @@ let observe_rw read write ~f ~size kind expected =
     |> Option.map @@ fun write -> {write with data= Buffer.contents written}
   in
   ({read; write; elapsed}, res)
+
+let rec with_kind_list create aux f = function
+  | [] ->
+      f (List.rev aux)
+  | kind :: tl ->
+      create kind @@ fun fd1 fd2 ->
+      with_kind_list create ((fd1, fd2) :: aux) f tl
+
+let with_kind_list g lst f = with_kind_list g [] f lst
+
+let with_kinds_ro lst = with_kind_list with_kind_ro lst
+
+let with_kinds_wo lst = with_kind_list with_kind_wo lst
+
+let with_kinds_rw lst = with_kind_list with_kind_rw lst

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.ml
@@ -58,9 +58,7 @@ let with_kind_wo kind f =
   | Unix.S_LNK ->
       invalid_arg "S_LNK" (* O_NOFOLLOW not bound in OCaml *)
   | Unix.S_BLK ->
-      let@ name, out = with_tempfile () in
-      (* block device must have an initial size *)
-      ftruncate out 512L ;
+      let@ name, _out = with_tempfile ~size:512L () in
       let@ blkname, _ = with_temp_blk name in
       let@ fd_ro = with_fd @@ open_ro blkname in
       let@ fd = with_fd @@ open_wo blkname in

--- a/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fd-test/observations.mli
@@ -28,6 +28,12 @@ val with_kind_ro :
   For character devices it receives a {!val:null} device.
 *)
 
+val with_kinds_ro :
+     Unix.file_kind list
+  -> ((([> rdonly], kind) make * ([> writable], kind) make option) list -> 'a)
+  -> 'a
+(** [with_kinds_ro kinds f] is like {!val:with_kind_ro} but for a list of file kinds. *)
+
 val with_kind_wo :
      Unix.file_kind
   -> (([> wronly], kind) make -> ([> readable], kind) make option -> 'a)
@@ -35,9 +41,22 @@ val with_kind_wo :
 (** [with_kind_wo kind f] is like {!val:with_kind_ro} but creates a write only file.
 *)
 
+val with_kinds_wo :
+     Unix.file_kind list
+  -> ((([> wronly], kind) make * ([> readable], kind) make option) list -> 'a)
+  -> 'a
+(** [with_kinds_wo kind f] is like {!val:with_kind_wo} but for a list of file kinds. *)
+
 val with_kind_rw :
   Unix.file_kind -> (([> rdwr], kind) make -> ([> rdwr], kind) make -> 'a) -> 'a
 (** [with_kind_rw kind f] is like {!val:with_kind_ro} but creates a read-write file.
+*)
+
+val with_kinds_rw :
+     Unix.file_kind list
+  -> ((([> rdwr], kind) make * ([> rdwr], kind) make) list -> 'a)
+  -> 'a
+(** [with_kinds_rw kind f] is like {!val:with_kind_rw} but for a list of file kinds.
 *)
 
 (** {1 Observe operations} *)

--- a/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.ml
@@ -58,6 +58,10 @@ let close t = Safefd.idempotent_close_exn t.fd
 
 let fsync t = Unix.fsync (Safefd.unsafe_to_file_descr_exn t.fd)
 
+let as_readable t = {t with props= as_readable t.props}
+
+let as_writable t = {t with props= as_writable t.props}
+
 let as_readable_opt t =
   match as_readable_opt t.props with
   | None ->

--- a/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.ml
@@ -229,18 +229,8 @@ let check_output cmd args =
   | _ ->
       failwith (Printf.sprintf "%s exited nonzero" cmd)
 
-let with_temp_blk ?(sector_size = 512) name f =
-  let blkdev =
-    check_output "losetup"
-      [
-        "--show"
-      ; "--sector-size"
-      ; string_of_int sector_size
-      ; "--direct-io=on"
-      ; "--find"
-      ; name
-      ]
-  in
+let with_temp_blk name f =
+  let blkdev = check_output "losetup" ["--show"; "--find"; name] in
   let custom_ftruncate size =
     Unix.LargeFile.truncate name size ;
     let (_ : string) = check_output "losetup" ["--set-capacity"; name] in

--- a/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.ml
@@ -207,7 +207,7 @@ let with_tempfile ?size () f =
     try Unix.unlink name with Unix.Unix_error (_, _, _) -> ()
   in
   let@ () = Fun.protect ~finally in
-  let t = ch |> Unix.descr_of_out_channel |> make_wo_exn `reg in
+  let t = ch |> Unix.descr_of_out_channel |> Unix.dup |> make_wo_exn `reg in
   let@ t = with_fd t in
   size |> Option.iter (fun size -> ftruncate t size) ;
   f (name, t)

--- a/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.mli
@@ -246,8 +246,7 @@ val with_tempfile :
 (** [with_tempfile () f] calls [f (name, outfd)] with the name of a temporary file and a file descriptor opened for writing.
   Deletes the temporary file when [f] finishes. *)
 
-val with_temp_blk :
-  ?sector_size:int -> string -> (string * ([> rdwr], [> blk]) make -> 'a) -> 'a
+val with_temp_blk : string -> (string * ([> rdwr], [> blk]) make -> 'a) -> 'a
 (** [with_temp_blk ?sector_size path f] calls [f (name, fd)] with a name and file descriptor pointing to a block device.
   The block device is temporarily created on top of [path].
 

--- a/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/operations.mli
@@ -45,6 +45,14 @@ val setup : unit -> unit
   By default a SIGPIPE would kill the program, this makes it return [EPIPE] instead.
  *)
 
+(** {1 Static property tests} *)
+
+val as_readable : (([< readable] as 'a), 'b) make -> ([> readable], 'b) make
+(** [as_readable_opt t] returns [Some t] when [t] is readable, and [None] otherwise. *)
+
+val as_writable : ([< writable], 'b) make -> ([> writable], 'b) make
+(** [as_writable_opt t] returns [Some t] when [t] is readable, and [None] otherwise. *)
+
 (** {1 Runtime property tests}  *)
 
 val as_readable_opt :

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
@@ -111,3 +111,23 @@ module Delay = struct
         (* If the wait hasn't happened yet then store up the signal *)
     )
 end
+
+let wait_timed_read fd timeout =
+  match Xapi_stdext_unix.Unixext.select [fd] [] [] timeout with
+  | [], _, _ ->
+      false
+  | [fd'], _, _ ->
+      assert (fd' = fd) ;
+      true
+  | _ ->
+      assert false
+
+let wait_timed_write fd timeout =
+  match Xapi_stdext_unix.Unixext.select [] [fd] [] timeout with
+  | _, [], _ ->
+      false
+  | _, [fd'], _ ->
+      assert (fd' = fd) ;
+      true
+  | _ ->
+      assert false

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
@@ -33,3 +33,7 @@ module Delay : sig
   val signal : t -> unit
   (** Sends a signal to a waiting thread. See 'wait' *)
 end
+
+val wait_timed_read : Unix.file_descr -> float -> bool
+
+val wait_timed_write : Unix.file_descr -> float -> bool

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/dune
@@ -1,7 +1,7 @@
 (library
   (name unixext_test)
   (modules unixext_test)
-  (libraries xapi_stdext_unix qcheck-core mtime.clock.os fmt xapi_fd_test mtime threads.posix rresult)
+  (libraries clock xapi_stdext_unix qcheck-core mtime.clock.os fmt xapi_fd_test mtime threads.posix rresult)
 )
 
 (test

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
@@ -72,7 +72,6 @@ let test_time_limited_write =
       ) ;
       buf
     in
-    (*Printf.eprintf "testing write: %s\n%!" (print (behaviour, timeout)) ;*)
     let observations, result = Generate.run_wo behaviour ~f:test in
     let () =
       let open Observations in
@@ -117,7 +116,6 @@ let test_time_limited_read =
   let gen = Gen.tup2 Generate.t Generate.timeouts
   and print = Print.tup2 Generate.print Print.float in
   Test.make ~name:__FUNCTION__ ~print gen @@ fun (behaviour, timeout) ->
-  (* Format.eprintf "Testing %s@." (print (behaviour, timeout)); *)
   skip_blk behaviour.kind ;
   skip_dirlnk behaviour.kind ;
   skip_blk_timed behaviour ;
@@ -132,7 +130,6 @@ let test_time_limited_read =
         Unixext.time_limited_read fd behaviour.size deadline
     )
   in
-  (*Printf.eprintf "testing: %s\n%!" (print (behaviour, timeout)) ;*)
   let observations, result =
     let buf = String.init behaviour.size (fun i -> Char.chr (i mod 255)) in
     Generate.run_ro behaviour buf ~f:test
@@ -145,7 +142,6 @@ let test_time_limited_read =
         "Function duration significantly exceeds timeout: %f > %f; %s" elapsed_s
         timeout
         (Fmt.to_to_string Fmt.(option pp) observations.Observations.write) ;
-    (* Format.eprintf "Result: %a@." (Fmt.option Observations.pp) observations.write;*)
     match (observations, result) with
     | {write= Some write; _}, Ok actual ->
         expect_amount ~expected:(String.length actual) write ;
@@ -200,9 +196,95 @@ let test_proxy =
       expect_string ~expected:write.data ~actual:read.data ;
       true
 
-let tests = [test_proxy; test_time_limited_write; test_time_limited_read]
+let run_select ro wo errs timeout =
+  let dt = Mtime_clock.counter () in
+  let r = Unix.select ro wo errs timeout in
+  (Mtime_clock.count dt, timeout, r)
+
+(* delays as long as 28.4ms were observed with epoll
+   (on an otherwise idle system with a single thread, and no Xen domains)
+   Be very conservative here and allow for a large difference
+*)
+let extra_timeout = Mtime.Span.(250 * ms)
+
+let check_timeout elapsed timeout =
+  let timeout_span = Clock.Timer.s_to_span timeout |> Option.get in
+  if
+    Clock.Timer.span_is_longer elapsed
+      ~than:(Mtime.Span.add Mtime.Span.(2 * timeout_span) extra_timeout)
+  then
+    Test.fail_reportf "Timed out too late: %a > %f" Mtime.Span.pp elapsed
+      timeout ;
+  timeout_span
+
+module FDSet = Set.Make (struct
+  type t = Unix.file_descr
+
+  let compare = Stdlib.compare
+end)
+
+let check_set lst =
+  let set = FDSet.of_list lst in
+  let n = List.length lst and n' = FDSet.cardinal set in
+  if n <> n' then
+    Test.fail_reportf
+      "File descriptor set contains duplicate elements: %d <> %d" n n' ;
+  set
+
+let check_sets (s1, s2, s3) = (check_set s1, check_set s2, check_set s3)
+
+let pp_fd = Fmt.using Unixext.int_of_file_descr Fmt.int
+
+let pp_fdset = Fmt.(using FDSet.to_seq @@ Dump.seq pp_fd)
+
+let check_subset msg msg' s1 s1' (r, w, e) (r', w', e') =
+  if not (FDSet.subset s1 s1') then
+    Test.fail_reportf
+      "%s %s: (%d and %d elements): %a and %a. output: %a,%a,%a; available: \
+       %a,%a,%a"
+      msg msg' (FDSet.cardinal s1) (FDSet.cardinal s1') pp_fdset s1 pp_fdset s1'
+      pp_fdset r pp_fdset w pp_fdset e pp_fdset r' pp_fdset w' pp_fdset e'
+
+let check_subsets msg ((s1, s2, s3) as all) ((s1', s2', s3') as all') =
+  check_subset msg "read" s1 s1' all all' ;
+  check_subset msg "write" s2 s2' all all' ;
+  check_subset msg "error" s3 s3' all all'
+
+let test_select =
+  let gen, print = Generate.select_input in
+  Test.make ~long_factor:10 ~name:__FUNCTION__ ~print gen @@ fun t ->
+  (* epoll raised EEXIST, but none of the actual callers in XAPI need this,
+     so skip
+  *)
+  QCheck2.assume (t.rw = [] && t.re = [] && t.we = []) ;
+  let ((elapsed, timeout, ready), (elapsed', timeout', ready')), available =
+    Observations.with_select_input t run_select
+  in
+  let timeout_span = check_timeout elapsed timeout in
+  let (_ : Mtime.Span.t) = check_timeout elapsed' timeout' in
+  let () =
+    match ready with
+    | [], [], [] ->
+        if Clock.Timer.span_is_shorter elapsed ~than:timeout_span then
+          Test.fail_reportf "Timed out too early: %a < %f" Mtime.Span.pp elapsed
+            timeout
+    | _ ->
+        let ready = check_sets ready in
+        let ready' = check_sets ready' in
+        let available = check_set available in
+        let available = (available, available, available) in
+        check_subsets "1st call subset of 2nd" ready ready' ;
+        check_subsets "ready subset of available" ready available ;
+        check_subsets "ready' subset of available" ready' available ;
+        ()
+  in
+  true
+
+let tests =
+  [test_select; test_proxy; test_time_limited_write; test_time_limited_read]
 
 let () =
   (* avoid SIGPIPE *)
   let (_ : Sys.signal_behavior) = Sys.signal Sys.sigpipe Sys.Signal_ignore in
-  Xapi_stdext_unix.Unixext.test_open 1024
+  (* Reenable this on the epoll branch: Xapi_stdext_unix.Unixext.test_open 1024 *)
+  ()

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
@@ -198,7 +198,7 @@ let test_proxy =
 
 let run_select ro wo errs timeout =
   let dt = Mtime_clock.counter () in
-  let r = Unix.select ro wo errs timeout in
+  let r = Unixext.select ro wo errs timeout in
   (Mtime_clock.count dt, timeout, r)
 
 (* delays as long as 28.4ms were observed with epoll
@@ -286,5 +286,4 @@ let tests =
 let () =
   (* avoid SIGPIPE *)
   let (_ : Sys.signal_behavior) = Sys.signal Sys.sigpipe Sys.Signal_ignore in
-  (* Reenable this on the epoll branch: Xapi_stdext_unix.Unixext.test_open 1024 *)
-  ()
+  Xapi_stdext_unix.Unixext.test_open 1024

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
@@ -672,6 +672,77 @@ let time_limited_single_read filedesc length ~max_wait =
   in
   Bytes.sub_string buf 0 bytes
 
+(** see [select(2)] "Correspondence between select() and poll() notifications".
+    Note that HUP and ERR are ignored in events and returned only in revents.
+    For simplicity we use the same event mask from the manual in both cases
+ *)
+let pollin_set = Polly.Events.(rdnorm lor rdband lor inp lor hup lor err)
+
+let pollout_set = Polly.Events.(wrband lor wrnorm lor out lor err)
+
+let pollerr_set = Polly.Events.pri
+
+let to_milliseconds ms = ms *. 1e3 |> ceil |> int_of_float
+
+(* we could change lists to proper Sets once the Unix.select to Unixext.select conversion is done *)
+
+let readable fd (rd, wr, ex) = (fd :: rd, wr, ex)
+
+let writable fd (rd, wr, ex) = (rd, fd :: wr, ex)
+
+let error fd (rd, wr, ex) = (rd, wr, fd :: ex)
+
+let check_events fd mask event action state =
+  if Polly.Events.test mask event then
+    action fd state
+  else
+    state
+
+let no_events = ([], [], [])
+
+let fold_events _ fd event state =
+  state
+  |> check_events fd pollin_set event readable
+  |> check_events fd pollout_set event writable
+  |> check_events fd pollerr_set event error
+
+let polly_fold_add polly events action immediate fd =
+  try Polly.add polly fd events ; immediate
+  with Unix.Unix_error (Unix.EPERM, _, _) ->
+    (* matches the behaviour of select: file descriptors that cannot be watched
+       are returned as ready immediately *)
+    action fd immediate
+
+let polly_fold polly events fds action immediate =
+  List.fold_left (polly_fold_add polly events action) immediate fds
+
+let select ins outs errs timeout =
+  (* -1.0 is a special value used in forkexecd *)
+  if timeout < 0. && timeout <> -1.0 then
+    invalid_arg (Printf.sprintf "negative timeout would hang: %g" timeout) ;
+  match (ins, outs, errs) with
+  | [], [], [] ->
+      Unix.sleepf timeout ; no_events
+  | _ -> (
+      with_polly @@ fun polly ->
+      (* file descriptors that cannot be watched by epoll *)
+      let immediate =
+        no_events
+        |> polly_fold polly pollin_set ins readable
+        |> polly_fold polly pollout_set outs writable
+        |> polly_fold polly pollerr_set errs error
+      in
+      match immediate with
+      | [], [], [] ->
+          Polly.wait_fold polly 1024 (to_milliseconds timeout) no_events
+            fold_events
+      | _ ->
+          (* we have some fds that are immediately available, but still poll the others
+             for any events that are available immediately
+          *)
+          Polly.wait_fold polly 1024 0 immediate fold_events
+    )
+
 (* --------------------------------------------------------------------------------------- *)
 
 (* Read a given number of bytes of data from the fd, or stop at EOF, whichever comes first. *)

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -156,6 +156,13 @@ val time_limited_read : Unix.file_descr -> int -> float -> string
 val time_limited_single_read :
   Unix.file_descr -> int -> max_wait:float -> string
 
+val select :
+     Unix.file_descr list
+  -> Unix.file_descr list
+  -> Unix.file_descr list
+  -> float
+  -> Unix.file_descr list * Unix.file_descr list * Unix.file_descr list
+
 val read_data_in_string_chunks :
      (string -> int -> unit)
   -> ?block_size:int

--- a/ocaml/quicktest/dune
+++ b/ocaml/quicktest/dune
@@ -20,6 +20,7 @@
     rpclib.core
     rrdd_libs
     stunnel
+    unixext_test
     bufio_test
     test_timer
     threads.posix

--- a/ocaml/quicktest/quicktest
+++ b/ocaml/quicktest/quicktest
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+ulimit -n 2048
 # Run quicktest with support for exception backtraces.
 OCAMLRUNPARAM=b "@OPTDIR@/debug/quicktestbin" "$@"

--- a/ocaml/quicktest/quicktest.ml
+++ b/ocaml/quicktest/quicktest.ml
@@ -15,7 +15,11 @@
 (** The main entry point of the quicktest executable *)
 
 let qchecks =
-  [("bufio", Bufio_test.tests); ("Timer", Test_timer.tests)]
+  [
+    ("unixext", Unixext_test.tests)
+  ; ("bufio", Bufio_test.tests)
+  ; ("Timer", Test_timer.tests)
+  ]
   |> List.map @@ fun (name, test) ->
      (name, List.map QCheck_alcotest.(to_alcotest ~long:true) test)
 

--- a/ocaml/quicktest/quicktest.ml
+++ b/ocaml/quicktest/quicktest.ml
@@ -44,16 +44,16 @@ let () =
         ; ("Quicktest_date", Quicktest_date.tests ())
         ; ("Quicktest_crypt_r", Quicktest_crypt_r.tests ())
         ]
+        @ ( if not !Quicktest_args.using_unix_domain_socket then
+              [("http", Quicktest_http.tests)]
+            else
+              []
+          )
         @
-        if not !Quicktest_args.using_unix_domain_socket then
-          [("http", Quicktest_http.tests)]
+        if not !Quicktest_args.skip_stress then
+          qchecks
         else
           []
-          @
-          if not !Quicktest_args.skip_stress then
-            qchecks
-          else
-            []
       in
       (* Only list tests if asked, without running them *)
       if !Quicktest_args.list_tests then


### PR DESCRIPTION
First write tests for the semantics of Unix.select.
Then introduce a Unixext.select implemented using epoll, and switch the tests to test this function: now we know that Unixext.select semantics matches Unix.select.
(we don't test error semantics, because XAPI only calls Unix.select with an empty list as the error list).

This doesn't yet switch the code to use Unixext.select, that will be done on feature/perf as it needs more testing.

Draft, needs testing in koji and some ticket numbers.
Also I don't know why the BLK tests haven't failed before on master, maybe they are not being run correctly, they were supposed to run as part of the Quicktests...