### PR TITLE
Fix CI failures caused by setup-ocaml@v3

### DIFF
--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   generate-sdk-sources:
     name: Generate SDK sources
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/setup-xapi-environment/action.yml
+++ b/.github/workflows/setup-xapi-environment/action.yml
@@ -12,6 +12,7 @@ runs:
       shell: bash
       run: |
         curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+        cat /etc/os-release
 
     - name: Download XE_SR_ERRORCODES.xml
       shell: bash
@@ -42,6 +43,10 @@ runs:
         echo "TMPDIR=${TMPDIR}" >>"$GITHUB_ENV"
         echo "XDG_CACHE_HOME=${XDG_CACHE_HOME}" >>"$GITHUB_ENV"
 
+    - name: Get runner OS info
+      uses: kenchan0130/actions-system-info@master
+      id: system-info
+
     # We set DUNE_CACHE_STORAGE_MODE, it is required for dune cache to work inside opam for now,
     # otherwise it gets EXDEV and considers it a cache miss
     - name: Use ocaml
@@ -52,6 +57,7 @@ runs:
           xs-opam: ${{ steps.dotenv.outputs.repository }}
         dune-cache: true
         opam-pin: false
+        cache-prefix: v3-${{ steps.system-info.outputs.name }}-${{ steps.system-info.outputs.release }}
       env:
         DUNE_CACHE_STORAGE_MODE: copy
 


### PR DESCRIPTION
Workaround for https://github.com/ocaml/setup-ocaml/issues/839.

Draft PR to check that it all works and creates correct cache keys.