### PR TITLE
CA-396743: Don't allow NBD on boot from SAN devices, and fix Network.managed to reflect PIF.managed

### DIFF
--- a/ocaml/xapi/xapi_network.ml
+++ b/ocaml/xapi/xapi_network.ml
@@ -439,6 +439,7 @@ let assert_can_add_purpose ~__context ~network:_ ~current:_ newval =
       assert_no_net_has_bad_porpoise [`nbd]
 
 let add_purpose ~__context ~self ~value =
+  assert_network_is_managed ~__context ~self ;
   let current = Db.Network.get_purpose ~__context ~self in
   if not (List.mem value current) then (
     assert_can_add_purpose ~__context ~network:self ~current value ;

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -458,7 +458,7 @@ let db_forget ~__context ~self = Db.PIF.destroy ~__context ~self
 let introduce_internal ?network ?(physical = true) ~t:_ ~__context ~host ~mAC
     ~mTU ~device ~vLAN ~vLAN_master_of ?metrics ~managed
     ?(disallow_unplug = false) () =
-  let bridge = bridge_naming_convention device in
+  let bridge = if managed then bridge_naming_convention device else "" in
   (* If we are not told which network to use,
      	 * apply the default convention *)
   let net_ref =

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -347,7 +347,8 @@ let assert_fcoe_not_in_use ~__context ~self =
              ()
      )
 
-let find_or_create_network (bridge : string) (device : string) ~__context =
+let find_or_create_network (bridge : string) (device : string) ~managed
+    ~__context =
   let nets =
     Db.Network.get_refs_where ~__context
       ~expr:(Eq (Field "bridge", Literal bridge))
@@ -362,7 +363,7 @@ let find_or_create_network (bridge : string) (device : string) ~__context =
         Db.Network.create ~__context ~ref:net_ref ~uuid:net_uuid
           ~current_operations:[] ~allowed_operations:[]
           ~name_label:(Helpers.choose_network_name_for_pif device)
-          ~name_description:"" ~mTU:1500L ~purpose:[] ~bridge ~managed:true
+          ~name_description:"" ~mTU:1500L ~purpose:[] ~bridge ~managed
           ~other_config:[] ~blobs:[] ~tags:[] ~default_locking_mode:`unlocked
           ~assigned_ips:[]
       in
@@ -463,7 +464,7 @@ let introduce_internal ?network ?(physical = true) ~t:_ ~__context ~host ~mAC
   let net_ref =
     match network with
     | None ->
-        find_or_create_network bridge device ~__context
+        find_or_create_network bridge device ~managed ~__context
     | Some x ->
         x
   in

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -667,6 +667,8 @@ let scan ~__context ~host =
       ([], [])
     )
   in
+  debug "non-managed devices=%s" (String.concat "," non_managed_devices) ;
+  debug "disallow-unplug devices=%s" (String.concat "," disallow_unplug_devices) ;
   Xapi_stdext_threads.Threadext.Mutex.execute scan_m (fun () ->
       let t = make_tables ~__context ~host in
       let devices_not_yet_represented_by_pifs =
@@ -681,6 +683,8 @@ let scan ~__context ~host =
           let mTU = Int64.of_int (Net.Interface.get_mtu dbg device) in
           let managed = not (List.mem device non_managed_devices) in
           let disallow_unplug = List.mem device disallow_unplug_devices in
+          debug "About to introduce %s, managed=%b, disallow-unplug=%b" device
+            managed disallow_unplug ;
           let (_ : API.ref_PIF) =
             introduce_internal ~t ~__context ~host ~mAC ~mTU ~vLAN:(-1L)
               ~vLAN_master_of:Ref.null ~device ~managed ~disallow_unplug ()

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -175,12 +175,6 @@ val assert_usable_for_management :
   -> unit
 (** Ensure the PIF can be used for management. *)
 
-val find_or_create_network :
-  string -> string -> __context:Context.t -> [`network] Ref.t
-(** If a network for the given bridge already exists, then return a reference to this network,
- *  otherwise create a new network and return its reference.
-*)
-
 (** Convenient lookup tables for scanning etc *)
 type tables
 


### PR DESCRIPTION
This'll make it more obvious if test code attempts to do the wrong thing (such as setting `ibft0` with NBD purpose and expecting that to work).
It'll also make it easier for test code to filter out these networks, so it doesn't touch them.

Unfortunately we do need to create the Network object, because the PIF object references it, and I wouldn't want to make the reference null (it'll likely cause failures elsewhere in XAPI where it assumes that PIFs always have a network).
And we probably want to keep the PIF with managed=false for reporting purposes (the interface does have an IP address, which is useful to be able to see in the API).

Draft, needs some actual testing, I've only compile tested this so far.