### PR TITLE
Plugin `openvswitch-config-update`: fix python2ism in python3 migration

### DIFF
--- a/scripts/plugins/openvswitch-config-update
+++ b/scripts/plugins/openvswitch-config-update
@@ -104,7 +104,7 @@ def update(session, args):
     if new_controller:
         query = 'field "management"="true"'
         recs = session.xenapi.PIF.get_all_records_where(query)
-        for rec in recs.itervalues():
+        for rec in recs.values():
             pool_mgmt_macs[rec.get("MAC")] = rec.get("device")
 
     dib_changed = False


### PR DESCRIPTION
PR #5261 made the switch to python3 but missed a dict.itervalues() call, which causes a failure with python3.

Should also be backported for XS8.
