### PR TITLE
update-ca-bundle: really avoid failure on missing directory

### DIFF
--- a/scripts/update-ca-bundle.sh
+++ b/scripts/update-ca-bundle.sh
@@ -5,6 +5,6 @@
 
 set -e
 
-mkdir -p /etc/stunnel
+mkdir -p /etc/stunnel/certs
 find /etc/stunnel/certs -name '*.pem' | xargs cat > /etc/stunnel/xapi-stunnel-ca-bundle.pem.tmp
 mv /etc/stunnel/xapi-stunnel-ca-bundle.pem.tmp /etc/stunnel/xapi-stunnel-ca-bundle.pem


### PR DESCRIPTION
While no problem was observed while XAPI launches this script, and there is little reason to launch it while the certs dir does not exist (except maybe for testing purposes), there is existing logic to create /etc/stunnel, which when needed will still let `find` fail for lack of /etc/stunnel/certs.