### PR TITLE
`xenopsd`: Fix `pytype` warning on `get_words`: Name `string` is not defined

### DIFF
--- a/ocaml/xenopsd/scripts/common.py
+++ b/ocaml/xenopsd/scripts/common.py
@@ -192,28 +192,33 @@ class VIF:
             results["xs-network-uuid"] = self.json["extra_private_keys"]["network-uuid"]
         results["attached-mac"] = self.get_mac()
         return results
+
     def get_locking_mode(self):
-        def get_words(value, separator):
-            if string.strip(value) == "":
-                return []
-            else:
-               return string.split(value, separator)
+        """
+        Get the locking mode configuration for the VIF.
+
+        :returns dict: A dictionary containing the locking mode configuration with keys:
+        - mac: The MAC address
+        - locking_mode: The locking mode
+        - ipv4_allowed: List of IPv4 addresses allowed
+        - ipv6_allowed: List of IPv6 addresses allowed
+        """
         results = {
             "mac": self.get_mac(),
             "locking_mode": "",
             "ipv4_allowed": [],
-            "ipv6_allowed": []
+            "ipv6_allowed": [],
         }
         if "locking_mode" in self.json:
-            if type(self.json["locking_mode"]) is list:
-                # Must be type=locked here
+            if isinstance(self.json["locking_mode"], list):
+                # Must be type=locked and have keys for allowed ipv4 and ipv6 addresses
                 results["locking_mode"] = self.json["locking_mode"][0].lower()
-                locked_params=self.json["locking_mode"][1]
+                locked_params = self.json["locking_mode"][1]
                 results["ipv4_allowed"] = locked_params["ipv4"]
                 results["ipv6_allowed"] = locked_params["ipv6"]
             else:
                 results["locking_mode"] = self.json["locking_mode"].lower()
-        send_to_syslog("Got locking config: %s" % (repr(results)))
+        send_to_syslog("Got locking config: " + repr(results))
         return results
 
 class Interface:

--- a/ocaml/xenopsd/scripts/test_common_class_vif.py
+++ b/ocaml/xenopsd/scripts/test_common_class_vif.py
@@ -1,0 +1,78 @@
+"""Test ocaml/xenopsd/scripts/common.VIF.get_locking_mode()"""
+
+from unittest.mock import patch  # to check the arguments passed to send_to_syslog()
+
+import pytest  # for pytest.parametrize to run the same test with different parameters
+
+import common  # Tested module
+
+
+# Mock class to simulate the object containing the get_locking_mode method
+class VifMockSubclass(common.VIF):
+    """Mock class to simulate a VIF object containing the get_locking_mode method"""
+
+    def __init__(self, json):  # pylint: disable=super-init-not-called
+        """Do not call the parent constructor, it would open a file"""
+        self.json = json
+
+    def get_mac(self):
+        return "00:11:22:33:44:55"  # Expected MAC address
+
+
+@pytest.mark.parametrize(
+    # Call the test case 3 times with two args:
+    # inp: input for VIF.get_locking_mode()
+    # expected_output: expected output of the get_locking_mode method
+    # Asserted with:
+    # assert expected_output == get_locking_mode(input)
+    "input_params, expected_output",
+    [
+        # Happy path tests
+        (
+            # locked
+            {  # input
+                "locking_mode": [
+                    "locked",
+                    {"ipv4": ["1.1.1.1"], "ipv6": ["fe80::1"]},
+                ]
+            },  # expected output
+            {
+                "mac": "00:11:22:33:44:55",
+                "locking_mode": "locked",
+                "ipv4_allowed": ["1.1.1.1"],
+                "ipv6_allowed": ["fe80::1"],
+            },
+        ),
+        (
+            # unlocked
+            {"locking_mode": "unlocked"},
+            {
+                "mac": "00:11:22:33:44:55",
+                "locking_mode": "unlocked",
+                "ipv4_allowed": [],
+                "ipv6_allowed": [],
+            },
+        ),
+        (
+            {},  # no locking_mode
+            {
+                "mac": "00:11:22:33:44:55",
+                "locking_mode": "",
+                "ipv4_allowed": [],
+                "ipv6_allowed": [],
+            },
+        ),
+    ],
+)
+def test_get_locking_mode(input_params, expected_output):
+    """Test VIF.get_locking_mode() using the VIF class test parameters defined above."""
+
+    # Act: Get the locking mode configuration for the input params from the VIF object:
+    with patch("common.send_to_syslog") as send_to_syslog:
+        test_result = VifMockSubclass(input_params).get_locking_mode()
+
+    # Assert the expected output and the expected call to send_to_syslog():
+    assert test_result == expected_output
+    send_to_syslog.assert_called_once_with(
+        "Got locking config: " + repr(expected_output)
+    )


### PR DESCRIPTION
For @stephenchengCloud:
FYI: @ashwin9390

In https://github.com/xapi-project/xen-api/pull/5896#pullrequestreview-2223415175, changes were requested:

Before merging `feature/py3` into `master`, certain warnings in files that weren't checked so far should be fixed.

This PR fixes two of the mentioned `pytype` warnings:
```py
File "xen-api/ocaml/xenopsd/scripts/common.py", line 198, in get_words: Name 'string' is not defined [name-error]
File "xen-api/ocaml/xenopsd/scripts/common.py", line 201, in get_words: Name 'string' is not defined [name-error]
```
These uses of the not defined variable `string` are in an inner function of `VIF.get_locking_mode()`.
This inner function (`get_words`) isn't used by the method, see:
https://github.com/xapi-project/xen-api/blob/master/ocaml/xenopsd/scripts/common.py#L196

The inner function was never used, it is completely bogus.

Because inner functions cannot be called from outside the containing method, it is 100% safe to remove it:

- Remove the unused inner function `common.VIF.get_locking_mode().get_words()` to fix `pytype` warnings and apply minor clean-ups after adding a test that covers all branches in the method, ensuring that the changes do not change functionality.
- Apply cosmetic formatting fixes to show the whole function in the review so it can be checked.

Two commits are to be added to this PR:`
- [`xenopsd`: Add pytest file for `common.VIF.get_locking_mode()`](https://github.com/xapi-project/xen-api/commit/02a7154a67aa6feeeefce551007428fa0f32493b)
  - Passed before pushing the 2nd commit (see the blue checkmark for the commit)
- [`ocaml/xenopsd/scripts/common.py`: Fix warnings: remove inner function, use `isinstance`](https://github.com/xapi-project/xen-api/pull/5921/commits/e7c9da840a6800a646c0414fa07dcaa455602a70)
  - Test still passes: This ensures that there is no functional change to the changed method


