### PR TITLE
Fix `xenopsd` `common.py`'s  `VIF.get_ethtool()` passing two args to `list().append()`

### DIFF
--- a/ocaml/xenopsd/scripts/common.py
+++ b/ocaml/xenopsd/scripts/common.py
@@ -159,10 +159,10 @@ class VIF:
         for (k, v) in self.json["other_config"]:
             if k.startswith("ethtool-"):
                 k = k[len("ethtool-"):]
-                if v == "true" or v == "on":
-                    results.append(k, True)
-                elif v == "false" or v == "off":
-                    results.append(k, False)
+                if v in ("true", "on"):
+                    results.append((k, True))
+                elif v in ("false", "off"):
+                    results.append((k, False))
                 else:
                     send_to_syslog("VIF %s/%d: ignoring ethtool argument %s=%s (use true/false)" % (self.vm_uuid, self.devid, k, v))
         return results

--- a/ocaml/xenopsd/scripts/common.py
+++ b/ocaml/xenopsd/scripts/common.py
@@ -192,28 +192,33 @@ class VIF:
             results["xs-network-uuid"] = self.json["extra_private_keys"]["network-uuid"]
         results["attached-mac"] = self.get_mac()
         return results
+
     def get_locking_mode(self):
-        def get_words(value, separator):
-            if string.strip(value) == "":
-                return []
-            else:
-               return string.split(value, separator)
+        """
+        Get the locking mode configuration for the VIF.
+
+        :returns dict: A dictionary containing the locking mode configuration with keys:
+        - mac: The MAC address
+        - locking_mode: The locking mode
+        - ipv4_allowed: List of IPv4 addresses allowed
+        - ipv6_allowed: List of IPv6 addresses allowed
+        """
         results = {
             "mac": self.get_mac(),
             "locking_mode": "",
             "ipv4_allowed": [],
-            "ipv6_allowed": []
+            "ipv6_allowed": [],
         }
         if "locking_mode" in self.json:
-            if type(self.json["locking_mode"]) is list:
-                # Must be type=locked here
+            if isinstance(self.json["locking_mode"], list):
+                # Must be type=locked and have keys for allowed ipv4 and ipv6 addresses
                 results["locking_mode"] = self.json["locking_mode"][0].lower()
-                locked_params=self.json["locking_mode"][1]
+                locked_params = self.json["locking_mode"][1]
                 results["ipv4_allowed"] = locked_params["ipv4"]
                 results["ipv6_allowed"] = locked_params["ipv6"]
             else:
                 results["locking_mode"] = self.json["locking_mode"].lower()
-        send_to_syslog("Got locking config: %s" % (repr(results)))
+        send_to_syslog("Got locking config: " + repr(results))
         return results
 
 class Interface:

--- a/ocaml/xenopsd/scripts/test_common_class_vif.py
+++ b/ocaml/xenopsd/scripts/test_common_class_vif.py
@@ -109,14 +109,10 @@ def test_get_ethtool(input_params, expected_results):
 
     # Act: Get the locking mode configuration for the input params from the VIF object:
     with patch("common.send_to_syslog") as send_to_syslog:
-        if expected_results:
-            with pytest.raises(TypeError) as ex:
-                MockVIF(input_params).get_ethtool()
-            # Assert the expected error message, will be fixed in the next commit:
-            assert "list.append() takes exactly one argument (2 given)" == str(ex.value)
-        else:
-            MockVIF(input_params).get_ethtool()
+        test_result = MockVIF(input_params).get_ethtool()
 
+    # Assert the expected output and the expected call to send_to_syslog():
+    assert test_result == expected_results
     if not expected_results:
         send_to_syslog.assert_called_once_with(
             "VIF vm_uuid/1: ignoring ethtool argument rx=Wrong (use true/false)"

--- a/ocaml/xenopsd/scripts/test_common_class_vif.py
+++ b/ocaml/xenopsd/scripts/test_common_class_vif.py
@@ -76,3 +76,48 @@ def test_get_locking_mode(input_params, expected_output):
     send_to_syslog.assert_called_once_with(
         "Got locking config: " + repr(expected_output)
     )
+
+
+@pytest.mark.parametrize(
+    "input_params, expected_results",
+    [
+        pytest.param(
+            {"other_config": [("ethtool-speed", "true"), ("ethtool-duplex", "false")]},
+            [("speed", True), ("duplex", False)],
+        ),
+        pytest.param(
+            {"other_config": [("ethtool-rx", "off"), ("ethtool-tso", "on")]},
+            [("rx", False), ("tso", True)],
+        ),
+        pytest.param(
+            {"other_config": [("ethtool-rx", "Wrong")]},
+            [],
+        ),
+    ],
+)
+def test_get_ethtool(input_params, expected_results):
+    """Test VIF.get_ethtool() using the VIF class test parameters defined above."""
+
+    # Arrange
+    class MockVIF(common.VIF):
+        """Mock class to simulate a VIF object containing the get_ethtool method"""
+
+        def __init__(self, json_data):  # pylint: disable=super-init-not-called
+            self.json = json_data
+            self.vm_uuid = "vm_uuid"
+            self.devid = 1
+
+    # Act: Get the locking mode configuration for the input params from the VIF object:
+    with patch("common.send_to_syslog") as send_to_syslog:
+        if expected_results:
+            with pytest.raises(TypeError) as ex:
+                MockVIF(input_params).get_ethtool()
+            # Assert the expected error message, will be fixed in the next commit:
+            assert "list.append() takes exactly one argument (2 given)" == str(ex.value)
+        else:
+            MockVIF(input_params).get_ethtool()
+
+    if not expected_results:
+        send_to_syslog.assert_called_once_with(
+            "VIF vm_uuid/1: ignoring ethtool argument rx=Wrong (use true/false)"
+        )

--- a/ocaml/xenopsd/scripts/test_common_class_vif.py
+++ b/ocaml/xenopsd/scripts/test_common_class_vif.py
@@ -1,0 +1,78 @@
+"""Test ocaml/xenopsd/scripts/common.VIF.get_locking_mode()"""
+
+from unittest.mock import patch  # to check the arguments passed to send_to_syslog()
+
+import pytest  # for pytest.parametrize to run the same test with different parameters
+
+import common  # Tested module
+
+
+# Mock class to simulate the object containing the get_locking_mode method
+class VifMockSubclass(common.VIF):
+    """Mock class to simulate a VIF object containing the get_locking_mode method"""
+
+    def __init__(self, json):  # pylint: disable=super-init-not-called
+        """Do not call the parent constructor, it would open a file"""
+        self.json = json
+
+    def get_mac(self):
+        return "00:11:22:33:44:55"  # Expected MAC address
+
+
+@pytest.mark.parametrize(
+    # Call the test case 3 times with two args:
+    # inp: input for VIF.get_locking_mode()
+    # expected_output: expected output of the get_locking_mode method
+    # Asserted with:
+    # assert expected_output == get_locking_mode(input)
+    "input_params, expected_output",
+    [
+        # Happy path tests
+        (
+            # locked
+            {  # input
+                "locking_mode": [
+                    "locked",
+                    {"ipv4": ["1.1.1.1"], "ipv6": ["fe80::1"]},
+                ]
+            },  # expected output
+            {
+                "mac": "00:11:22:33:44:55",
+                "locking_mode": "locked",
+                "ipv4_allowed": ["1.1.1.1"],
+                "ipv6_allowed": ["fe80::1"],
+            },
+        ),
+        (
+            # unlocked
+            {"locking_mode": "unlocked"},
+            {
+                "mac": "00:11:22:33:44:55",
+                "locking_mode": "unlocked",
+                "ipv4_allowed": [],
+                "ipv6_allowed": [],
+            },
+        ),
+        (
+            {},  # no locking_mode
+            {
+                "mac": "00:11:22:33:44:55",
+                "locking_mode": "",
+                "ipv4_allowed": [],
+                "ipv6_allowed": [],
+            },
+        ),
+    ],
+)
+def test_get_locking_mode(input_params, expected_output):
+    """Test VIF.get_locking_mode() using the VIF class test parameters defined above."""
+
+    # Act: Get the locking mode configuration for the input params from the VIF object:
+    with patch("common.send_to_syslog") as send_to_syslog:
+        test_result = VifMockSubclass(input_params).get_locking_mode()
+
+    # Assert the expected output and the expected call to send_to_syslog():
+    assert test_result == expected_output
+    send_to_syslog.assert_called_once_with(
+        "Got locking config: " + repr(expected_output)
+    )


### PR DESCRIPTION
Follow-up of #5921 that includes #5921 (please merge first) as it depends on it:
- Two commits are from #5921 and two commits (on `get_ethtool()`) are for this PR.

For @stephenchengCloud:
FYI: @ashwin9390

In https://github.com/xapi-project/xen-api/pull/5896#pullrequestreview-2223415175, changes were requested:

Before merging `feature/py3` into `master`, certain warnings in files that weren't checked so far should be fixed.

This PR fixes two of the mentioned `pytype` warnings:
```py
pytype ocaml/xenopsd/scripts/common.py
File "ocaml/xenopsd/scripts/common.py", line 163, in get_ethtool: Function list.append expects 2 arg(s), got 3 [wrong-arg-count]
         Expected: (self, object)
  Actually passed: (self, object, _)
File "ocaml/xenopsd/scripts/common.py", line 165, in get_ethtool: Function list.append expects 2 arg(s), got 3 [wrong-arg-count]
         Expected: (self, object)
  Actually passed: (self, object, _)
```
These are from these lines:
```py
                if v == "true" or v == "on":
                    results.append(k, True)
                elif v == "false" or v == "off":
                    results.append(k, False)
```
These `ethtool settings` are documented in the document [Develop for XenServer](https://docs.xenserver.com/en-us/xenserver/developer/develop-for-xenserver.pdf) starting at page 75.

As can be seen on the [blame view](https://github.com/xapi-project/xenopsd/blame/master/scripts/common.py#L162), these two arguments have been there for 12 years. Maybe they worked in Python versions before Python2.7, but they did not even work in Python2.7.

Reaching such `append(a, b)` would raise a `TypeError` with any Interpreter that I can find:
```py               
python2 -c '[].append(1, True)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: append() takes exactly one argument (2 given)
```

This PR adds a test to cover the method containing them and then fixes the bug.

The only call site of `VIF().get_ethtool()` is at https://github.com/xapi-project/xen-api/blob/feature/py3/ocaml/xenopsd/scripts/common.py#L229.

It expects that `get_ethtool()` returns a list of key/value sets like so: [(k, True), (k, False)], so pass (and return) `k, bool` as a `set`: `.append((k, bool))`.