### PR TITLE
Output if parameter is required in JSON backend

### DIFF
--- a/ocaml/idl/json_backend/gen_json.ml
+++ b/ocaml/idl/json_backend/gen_json.ml
@@ -197,6 +197,7 @@ end = struct
                 ("type", `String t)
               ; ("name", `String p.param_name)
               ; ("doc", `String p.param_doc)
+              ; ("required", `Bool (Option.is_none p.param_default))
               ]
             :: params
           , enums @ e


### PR DESCRIPTION
This small change augments all parameter structures emitted by the JSON backend to include a "required" member that specifies whether the parameter is optional or not. Parameters are considered optional in the IDL if a default value is provided for them.

The simplest example is `session.login_with_password`. This message permits two extra parameters, `version` and `originator` - but these are not required to successfully invoke the function.

---

I imagine two potential usages of this:
- The XenAPI class reference docs ought to distinguish between required and optional arguments. This change is relatively simple and can come later.
- The emitted `xenapi.json` actually provides just enough information to produce useful, light, typed, bindings. However, the presence of optional parameters should be indicated to simplify matters. See example below.

![image](https://github.com/user-attachments/assets/6e6351e4-4e74-41f8-b146-2dbdd819cf7f)

Before I port the above to OCaml and move it in-tree, I'd like to continue my prototype and be able to indicate that `version` and `originator` are optional parameters. Once it's moved to OCaml, the full datamodel API would be available and I'd stop processing the output of `make doc-json`.
