### PR TITLE
CP-49217: Update datamodel_lifecycle

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -25,6 +25,8 @@ let prototyped_of_field = function
       Some "23.14.0"
   | "Observer", "uuid" ->
       Some "23.14.0"
+  | "Repository", "origin" ->
+      Some "24.21.0-next"
   | "Repository", "gpgkey_path" ->
       Some "22.12.0"
   | "Certificate", "fingerprint_sha1" ->
@@ -123,6 +125,8 @@ let prototyped_of_message = function
       Some "22.20.0"
   | "Repository", "set_gpgkey_path" ->
       Some "22.12.0"
+  | "Repository", "introduce_bundle" ->
+      Some "24.21.0-next"
   | "PCI", "get_dom0_access_status" ->
       Some "24.14.0"
   | "PCI", "enable_dom0_access" ->

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -6773,7 +6773,7 @@ let pool_sync_bundle fd _printer rpc session_id params =
         in
         let uri =
           Uri.(
-            make ~scheme:"http" ~host:master_address
+            make ~scheme:"https" ~host:master_address
               ~path:Constants.put_bundle_uri
               ~query:
                 [


### PR DESCRIPTION
1. Update the auto-generated changes in `datamodel_lifecycle.ml` before the code is merged into master.
2. Update `scheme` to `https` in `Cli_operations.pool_sync_bundle` as `http` can't be used in newcli and will be executed on slave.