### PR TITLE
Python SDK: Move "Packaging" section out of the public docs

### DIFF
--- a/scripts/examples/python/PACKAGING.md
+++ b/scripts/examples/python/PACKAGING.md
@@ -1,0 +1,8 @@
+Packaging
+=========
+
+`setup.py` is generated using an ocaml binary that fetches the api version string from xapi. An opam switch with the [xs-opam](https://github.com/xapi-project/xs-opam) repository is needed in order to build the binary.
+
+To build the package `setuptools>=38.6.0` and `wheel` need to be installed in the system or in the active python virtualenv.
+
+To build, use the command `make`.

--- a/scripts/examples/python/README.md
+++ b/scripts/examples/python/README.md
@@ -8,12 +8,3 @@ Examples
 --------
 
 The [examples](https://github.com/xapi-project/xen-api/tree/master/scripts/examples/python) will not work unless they have been placed in the same directory as `XenAPI.py` or `XenAPI` package from PyPI has been installed (`pip install XenAPI`)
-
-Packaging
-=========
-
-`setup.py` is generated using an ocaml binary that fetches the api version string from xapi. An opam switch with the [xs-opam](https://github.com/xapi-project/xs-opam) repository is needed in order to build the binary.
-
-To build the package `setuptools>=38.6.0` and `wheel` need to be installed in the system or in the active python virtualenv.
-
-To build, use the command `make`.


### PR DESCRIPTION
This has ended up in our public PyPI package description: https://pypi.org/project/XenAPI/

However it is irrelevant to a user of the package on PyPI, because they'd already get the "built" version, that has the version number inside, so they don't need OCaml or 'make' to use it.