### PR TITLE
CA-397171: Replace libjemalloc.so.1 with libjemalloc.so.2

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -302,10 +302,10 @@ def main(argv):
     # set up library preload path for qemu such that it can use jemalloc
     qemu_env = os.environ
     if "LD_PRELOAD" not in qemu_env:
-       qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.1"
+       qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.2"
     else:
-       qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.1:" + qemu_env["LD_PRELOAD"]
-    qemu_env["MALLOC_CONF"] = "narenas:1,tcache:false,lg_dirty_mult:22"
+       qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.2:" + qemu_env["LD_PRELOAD"]
+    qemu_env["MALLOC_CONF"] = "narenas:1,tcache:false"
 
     sys.stdout.flush()
     sys.stderr.flush()

--- a/scripts/xapi-nbd.service
+++ b/scripts/xapi-nbd.service
@@ -4,8 +4,8 @@ After=xapi.service message-switch.service syslog.target
 Wants=xapi.service message-switch.service syslog.target
 
 [Service]
-Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
-Environment="MALLOC_CONF=narenas:1,tcache:false,lg_dirty_mult:22"
+Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
+Environment="MALLOC_CONF=narenas:1,tcache:false"
 Environment=OCAMLRUNPARAM=b
 # The --certfile option must match the server-cert-path in xapi.conf
 # and the PathExists in xapi-nbd.path: any change must be made in all three files.

--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -21,8 +21,8 @@ Conflicts=shutdown.target
 
 [Service]
 User=root
-Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
-Environment="MALLOC_CONF=narenas:1,tcache:true,lg_dirty_mult:22"
+Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
+Environment="MALLOC_CONF=narenas:1,tcache:true"
 Type=simple
 Restart=on-failure
 ExecStart=@LIBEXECDIR@/xapi-init start

--- a/scripts/xcp-networkd.service
+++ b/scripts/xcp-networkd.service
@@ -6,8 +6,8 @@ Wants=forkexecd.service message-switch.service syslog.target
 
 [Service]
 Type=notify
-Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.1"
-Environment="MALLOC_CONF=narenas:1,tcache:false,lg_dirty_mult:22"
+Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
+Environment="MALLOC_CONF=narenas:1,tcache:false"
 Environment=OCAMLRUNPARAM=b
 EnvironmentFile=-/etc/sysconfig/xcp-networkd
 ExecStart=/usr/sbin/xcp-networkd $XCP_NETWORKD_OPTIONS


### PR DESCRIPTION
jemalloc was updated to version 5.3.0:
- Provides libjemalloc.so.2 instead of libjemalloc.so.1
- No longer supported `lg_dirty_mult` option

Note that part of the change is in the .spec file.

Tested that all `.service` files have been replaced:
```
[root@xrtmia-11-09 ~]# find / -type f  -name "*.service" | xargs grep "libjemalloc.so.1"
find: ‘/proc/4079’: No such file or directory
[root@xrtmia-11-09 ~]# find / -type f  -name "*.service" | xargs grep "libjemalloc.so.2"
/usr/lib/systemd/system/xcp-rrdd.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
/usr/lib/systemd/system/xapi-nbd.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
/usr/lib/systemd/system/xenopsd-xc.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
/usr/lib/systemd/system/squeezed.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
/usr/lib/systemd/system/xcp-networkd.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
/usr/lib/systemd/system/xapi-storage-script.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
/usr/lib/systemd/system/message-switch.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
/usr/lib/systemd/system/xapi.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
/usr/lib/systemd/system/forkexecd.service:Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
```
No LD_PRELOAD errors in daemon.log:
`[root@xrtmia-11-09 log]# grep "libjemalloc" /var/log/daemon.log`

202861 Ring3: BVT passed