### PR TITLE
Allow remediation commits for DCO

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+allowRemediationCommits:
+  individual: true
+  thirdParty: true


### PR DESCRIPTION
This change would allow commits to retroactively sign off ("remediate") commits that are already in `master`, without rewriting history. Ideally, no commit would get into `master` without being signed off. However, we have found that it is possible for the DCO bot to confuse the author's chosen sign-off name + email combination with the name + email combination that GitHub creates on the author's behalf when producing a merge commit. Since the DCO bot doesn't only compare by email, it believes there is a discrepancy and sets the DCO to fail.