### PR TITLE
CA-392685:/tmp is mounted with type tmpfs which cause the files to be cleaned after host reboot in XS rawhide.

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -639,7 +639,7 @@ let metrics_prefix_mem_vms = "xcp-rrdd-mem_vms"
 let metrics_prefix_pvs_proxy = "pvsproxy-"
 
 (** Path to trigger file for Network Reset. *)
-let network_reset_trigger = "/tmp/network-reset"
+let network_reset_trigger = "/var/tmp/network-reset"
 
 let first_boot_dir = "/etc/firstboot.d/"
 

--- a/scripts/xe-reset-networking
+++ b/scripts/xe-reset-networking
@@ -24,7 +24,7 @@ from optparse import OptionParser
 pool_conf = '@ETCXENDIR@/pool.conf'
 inventory_file = '@INVENTORY@'
 management_conf = '/etc/firstboot.d/data/management.conf'
-network_reset = '/tmp/network-reset'
+network_reset = '/var/tmp/network-reset'
 
 def read_dict_file(fname):
 	f = open(fname, 'r')


### PR DESCRIPTION
CA-392685 :/tmp is mounted with type tmpfs which cause the files to be cleaned after host reboot in XS rawhide 

Fix contains:
- Replace /tmp/network-reset  with /var/tmp/network-reset to persist tmp file after reboot
- Modified xapi_globs.ml to include this change.

XenRT test -Completed 

Test Results:

Test id :4073591(XS9)-Pass
Test id :4068756(XS8)-Pass 

Signed-off-by: Ashwinh <ashwin.h@cloud.com>

@liulinC @psafont @rosslagerwall @bernhardkaindl 