### PR TITLE
Backports for UPD-1009 / CP-50580

### DIFF
--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -108,6 +108,7 @@ let vm_operation_table =
   ; (`changing_NVRAM, "changing_NVRAM")
   ; (`start, "start")
   ; (`start_on, "start_on")
+  ; (`shutdown, "shutdown")
   ; (`suspend, "suspend")
   ; (`unpause, "unpause")
   ; (`update_allowed_operations, "update_allowed_operations")

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1858,6 +1858,7 @@ functor
                 ; `hard_reboot
                 ; `pool_migrate
                 ; `call_plugin
+                ; `shutdown
                 ; `suspend
                 ] ;
             (* If VM is actually suspended and we ask to hard_shutdown, we need to

--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -70,8 +70,7 @@ let get_vm_rrd_forwarder (req : Http.Request.t) (s : Unix.file_descr) _ =
           let url = make_url ~address ~req in
           Http_svr.headers s (Http.http_302_redirect url)
         in
-        let unarchive_at_master () =
-          let address = Pool_role.get_master_address () in
+        let unarchive_at address =
           let query = (Constants.rrd_unarchive, "") :: query in
           let url = make_url_from_query ~address ~uri:req.uri ~query in
           Http_svr.headers s (Http.http_302_redirect url)
@@ -113,9 +112,9 @@ let get_vm_rrd_forwarder (req : Http.Request.t) (s : Unix.file_descr) _ =
           | Master, true, _ | Master, false, false ->
               (* VM running on node, or not running at all. *)
               unarchive ()
-          | Slave _, true, _ | Slave _, _, false ->
+          | Slave coordinator, true, _ | Slave coordinator, _, false ->
               (* Coordinator knows best *)
-              unarchive_at_master ()
+              unarchive_at coordinator
           | Broken, _, _ ->
               info "%s: host is broken, VM's metrics are not available"
                 "get_vm_rrd_forwarder" ;

--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -77,17 +77,19 @@ let get_vm_rrd_forwarder (req : Http.Request.t) (s : Unix.file_descr) _ =
           Http_svr.headers s (Http.http_302_redirect url)
         in
         let unarchive () =
-          let req = {req with uri= Constants.rrd_unarchive_uri} in
+          let req = {req with m= Post; uri= Constants.rrd_unarchive_uri} in
           ignore
             (Xapi_services.hand_over_connection req s
                !Rrd_interface.forwarded_path
             )
         in
+        let unavailable () =
+          Http_svr.headers s (Http.http_503_service_unavailable ())
+        in
         (* List of conditions involved. *)
         let is_unarchive_request =
           List.mem_assoc Constants.rrd_unarchive query
         in
-        let is_master = Pool_role.is_master () in
         let is_owner_online owner = Db.is_valid_ref __context owner in
         let is_xapi_initialising = List.mem_assoc "dbsync" query in
         (* The logic. *)
@@ -99,15 +101,25 @@ let get_vm_rrd_forwarder (req : Http.Request.t) (s : Unix.file_descr) _ =
           let owner = Db.VM.get_resident_on ~__context ~self:vm_ref in
           let owner_uuid = Ref.string_of owner in
           let is_owner_localhost = owner_uuid = localhost_uuid in
-          if is_owner_localhost then
-            if is_master then
+          let owner_is_available =
+            is_owner_online owner && not is_xapi_initialising
+          in
+          match
+            (Pool_role.get_role (), is_owner_localhost, owner_is_available)
+          with
+          | (Master | Slave _), false, true ->
+              (* VM is running elsewhere *)
+              read_at_owner owner
+          | Master, true, _ | Master, false, false ->
+              (* VM running on node, or not running at all. *)
               unarchive ()
-            else
+          | Slave _, true, _ | Slave _, _, false ->
+              (* Coordinator knows best *)
               unarchive_at_master ()
-          else if is_owner_online owner && not is_xapi_initialising then
-            read_at_owner owner
-          else
-            unarchive_at_master ()
+          | Broken, _, _ ->
+              info "%s: host is broken, VM's metrics are not available"
+                __FUNCTION__ ;
+              unavailable ()
     )
 
 (* Forward the request for host RRD data to the RRDD HTTP handler. If the host

--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -118,7 +118,7 @@ let get_vm_rrd_forwarder (req : Http.Request.t) (s : Unix.file_descr) _ =
               unarchive_at_master ()
           | Broken, _, _ ->
               info "%s: host is broken, VM's metrics are not available"
-                __FUNCTION__ ;
+                "get_vm_rrd_forwarder" ;
               unavailable ()
     )
 

--- a/ocaml/xapi/taskHelper.ml
+++ b/ocaml/xapi/taskHelper.ml
@@ -56,6 +56,16 @@ let rbac_assert_permission_fn = ref None
 
 (* required to break dep-cycle with rbac.ml *)
 
+let are_auth_user_ids_of_sessions_equal ~__context s1 s2 =
+  Context.with_tracing ~__context __FUNCTION__ @@ fun __context ->
+  let s1_auth_user_sid =
+    Db_actions.DB_Action.Session.get_auth_user_sid ~__context ~self:s1
+  in
+  let s2_auth_user_sid =
+    Db_actions.DB_Action.Session.get_auth_user_sid ~__context ~self:s2
+  in
+  s1_auth_user_sid = s2_auth_user_sid
+
 let assert_op_valid ?(ok_if_no_session_in_context = false) ~__context task_id =
   let assert_permission_task_op_any () =
     match !rbac_assert_permission_fn with
@@ -80,19 +90,14 @@ let assert_op_valid ?(ok_if_no_session_in_context = false) ~__context task_id =
   | Some context_session ->
       let is_own_task =
         try
-          let task_session =
-            Db_actions.DB_Action.Task.get_session ~__context ~self:task_id
-          in
-          let task_auth_user_sid =
-            Db_actions.DB_Action.Session.get_auth_user_sid ~__context
-              ~self:task_session
-          in
-          let context_auth_user_sid =
-            Db_actions.DB_Action.Session.get_auth_user_sid ~__context
-              ~self:context_session
-          in
-          (*debug "task_auth_user_sid=%s,context_auth_user_sid=%s" task_auth_user_sid context_auth_user_sid;*)
-          task_auth_user_sid = context_auth_user_sid
+          (* If the task id is the same as the context's task id, we don't need
+             to go theough their respective sessions.*)
+          match Context.get_task_id __context = task_id with
+          | true ->
+              true
+          | false ->
+              are_auth_user_ids_of_sessions_equal ~__context context_session
+                (Db_actions.DB_Action.Task.get_session ~__context ~self:task_id)
         with e ->
           debug "assert_op_valid: %s" (ExnHelper.string_of_exn e) ;
           false

--- a/ocaml/xapi/taskHelper.ml
+++ b/ocaml/xapi/taskHelper.ml
@@ -57,7 +57,6 @@ let rbac_assert_permission_fn = ref None
 (* required to break dep-cycle with rbac.ml *)
 
 let are_auth_user_ids_of_sessions_equal ~__context s1 s2 =
-  Context.with_tracing ~__context __FUNCTION__ @@ fun __context ->
   let s1_auth_user_sid =
     Db_actions.DB_Action.Session.get_auth_user_sid ~__context ~self:s1
   in


### PR DESCRIPTION
* CA-395174: Try to unarchive VM's metrics when they aren..
* CA-395174: Try to unarchive VM's metrics when they aren..
* CA-394444: Update `vm_operation_table`                   
* CA-394444: Update task cancellation in `message_forward..
* CA-394169: Allow task to have permissions on itself - b..
* CA-394169: Allow task to have permissions on itself      
