### PR TITLE
CA-397268: vbd.create failed: The device name is invalid

### DIFF
--- a/ocaml/tests/test_xapi_vbd_helpers.ml
+++ b/ocaml/tests/test_xapi_vbd_helpers.ml
@@ -85,6 +85,34 @@ let test_ca253933_valid_operations () =
   in
   List.iter operation_is_valid valid_operations
 
+let test_valid_device () =
+  let valid_devices =
+    [
+      ("autodetect", `Floppy)
+    ; ("sda", `Disk)
+    ; ("sda0", `Disk)
+    ; ("sdp", `Disk)
+    ; ("sdp99", `Disk)
+    ; ("xvda", `Disk)
+    ; ("xvda0", `Disk)
+    ; ("xvdp", `Disk)
+    ; ("xvdp99", `Disk)
+    ; ("hda", `Disk)
+    ; ("hda0", `Disk)
+    ; ("hdp", `Disk)
+    ; ("hdp99", `Disk)
+    ; ("fda", `Disk)
+    ; ("fdb", `Disk)
+    ; ("0", `CD)
+    ; ("1", `CD)
+    ]
+  in
+  let check (dev, _type) =
+    let f = Xapi_vbd_helpers.valid_device in
+    Alcotest.(check bool) "must be equal" true (f dev ~_type)
+  in
+  List.iter check valid_devices
+
 let test =
   [
     ( "test_ca253933_invalid_operations"
@@ -92,4 +120,5 @@ let test =
     , test_ca253933_invalid_operations
     )
   ; ("test_ca253933_valid_operations", `Quick, test_ca253933_valid_operations)
+  ; ("test_valid_device", `Quick, test_valid_device)
   ]

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -377,7 +377,7 @@ let clear_current_operations ~__context ~self =
 (** Check if the device string has the right form *)
 let valid_device dev ~_type =
   dev = "autodetect"
-  || Option.is_none (Device_number.of_string dev ~hvm:false)
+  || Option.is_some (Device_number.of_string dev ~hvm:false)
   ||
   match _type with
   | `Floppy ->


### PR DESCRIPTION
In the commit 62db5cb, the device name validation was consolidated with
the function which converts name to device number. Particularly, the
function "Device_number.of_string" is used for both the validation and
the conversion.

But one issue was introduced in the validation is that the "None" value
returned from "Device_number.of_string" is considered as valid. This
causes the error "the device name is invalid".

This PR just fixes this issue. And meanwhile, a unit test is also added.