### PR TITLE
CP-49148: More clean python2 code

### DIFF
--- a/ocaml/message-switch/core_test/interop-test.sh
+++ b/ocaml/message-switch/core_test/interop-test.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -ex
-
-LINKPATH="${TMPDIR:-/tmp}/link_test"
-
-rm -rf ${LINKPATH} && mkdir -p ${LINKPATH}
-
-lwt/link_test_main.exe
-PYTHONPATH=core python message_switch_test.py

--- a/scripts/generate-iscsi-iqn
+++ b/scripts/generate-iscsi-iqn
@@ -36,7 +36,7 @@ geniqn() {
         domain=${defaultdomain}
     fi
 
-    revdomain=$(python -c "${REVERSE_PY}" $domain)
+    revdomain=$(python3 -c "${REVERSE_PY}" $domain)
 
     uuid=$(uuidgen | cut -d- -f1)
     date=$(date +"%Y-%m")

--- a/scripts/xe-backup-metadata
+++ b/scripts/xe-backup-metadata
@@ -51,7 +51,7 @@ function usage {
 function uuid5 {
   # could use a modern uuidgen but it's not on XS 8
   # should work with Python 2 and 3
-  python -c "import uuid; print (uuid.uuid5(uuid.UUID('$1'), '$2'))"
+  python3 -c "import uuid; print (uuid.uuid5(uuid.UUID('$1'), '$2'))"
 }
 
 function test_sr {

--- a/scripts/xe-restore-metadata
+++ b/scripts/xe-restore-metadata
@@ -65,7 +65,7 @@ function test_sr {
 NS="e93e0639-2bdb-4a59-8b46-352b3f408c19"
 function uuid5 {
   # could use a modern uuidgen but it's not on XS 8
-  python -c "import uuid; print (uuid.uuid5(uuid.UUID('$1'), '$2'))"
+  python3 -c "import uuid; print (uuid.uuid5(uuid.UUID('$1'), '$2'))"
 }
 
 dry_run=0


### PR DESCRIPTION
- Update following embeded shellbang to python3
  * generate-iscsi-iqn 
  * xe-backup-metadata
  * xe-restore-metadata
- Remove interop-test.sh as not used