### PR TITLE
Add temporary exception for deprecation of `xmlStringDecodeEntities`

### DIFF
--- a/ocaml/sdk-gen/c/autogen/src/xen_common.c
+++ b/ocaml/sdk-gen/c/autogen/src/xen_common.c
@@ -1706,7 +1706,10 @@ get_val_as_string(const struct abstract_type *type, void *value)
         {
             xmlChar *encoded_value = *(xmlChar **)value;
             xmlParserCtxtPtr ctxt = xmlCreateDocParserCtxt(encoded_value);
+            #pragma GCC diagnostic push
+            #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             char *res = (char*)xmlStringDecodeEntities(ctxt, encoded_value, 1, 0, 0, 0);
+            #pragma GCC diagnostic pop
             xmlFreeParserCtxt(ctxt);
             return res;
         }


### PR DESCRIPTION
We already have an internal ticket to address this but builds will start to fail once `ubuntu-latest` points to packages already in `24.10` or above.

The deprecation for `libxml2` was added in `2.11.0` (see [here on GitLab](https://gitlab.gnome.org/GNOME/libxml2/-/commit/b47ebf047e959f43ae34582101a37b26764b9be3))

Fedora 40 already switched to 2.11.0+, and Ubuntu 24.10 did, too. Ubuntu 22.04 and 24.04 haven't, hence why builds aren't failing just yet.

Tested locally on Fedora 40 with `libxml2-2.12.8-1.fc40.x86_64`