### PR TITLE
IH-689: Autogenerate record_util.ml (where it's reasonable)

### DIFF
--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -354,6 +354,38 @@ let toposort_types highapi types =
   assert (List.sort compare result = List.sort compare types) ;
   result
 
+let gen_record_deserialization highapi =
+  let gen_of_to_string types =
+    let gen_string_and_all = function
+      | DT.Set (DT.Enum (_, elist) as e) ->
+          let nlist = List.map fst elist in
+          [
+            (Printf.sprintf "let %s_of_string str = %s")
+              (OU.alias_of_ty e)
+              (OU.ocaml_of_string_of_enum nlist)
+          ; (Printf.sprintf "let %s_to_string = %s")
+              (OU.alias_of_ty e)
+              (OU.ocaml_to_string_of_enum nlist)
+          ]
+      | _ ->
+          []
+    in
+    List.concat_map gen_string_and_all types
+  in
+  let all_types = all_types_of highapi in
+  let all_types = add_set_enums all_types in
+  List.iter (List.iter print)
+    (between [""]
+       [
+         [
+           "exception Record_failure of string"
+         ; "let record_failure fmt ="
+         ; "Printf.ksprintf (fun msg -> raise (Record_failure msg)) fmt"
+         ]
+       ; gen_of_to_string all_types
+       ]
+    )
+
 let gen_client_types highapi =
   let all_types = all_types_of highapi in
   let all_types = add_set_enums all_types in

--- a/ocaml/idl/ocaml_backend/gen_api_main.ml
+++ b/ocaml/idl/ocaml_backend/gen_api_main.ml
@@ -73,7 +73,17 @@ let _ =
     [
       ( "-mode"
       , Arg.Symbol
-          ( ["client"; "server"; "api"; "db"; "actions"; "sql"; "rbac"; "test"]
+          ( [
+              "client"
+            ; "server"
+            ; "api"
+            ; "utils"
+            ; "db"
+            ; "actions"
+            ; "sql"
+            ; "rbac"
+            ; "test"
+            ]
           , fun x -> mode := Some x
           )
       , "Choose which file to output"
@@ -114,6 +124,8 @@ let _ =
       Gen_api.gen_client api
   | Some "api" ->
       Gen_api.gen_client_types api
+  | Some "utils" ->
+      Gen_api.gen_record_deserialization api
   | Some "server" ->
       Gen_api.gen_server api
   | Some "db" ->

--- a/ocaml/idl/ocaml_backend/ocaml_utils.ml
+++ b/ocaml/idl/ocaml_backend/ocaml_utils.ml
@@ -101,6 +101,19 @@ let ocaml_to_string_of_enum list =
   let single name = Printf.sprintf {|%s -> "%s"|} (constructor_of name) name in
   Printf.sprintf "function %s" (ocaml_map_enum_ " | " single list)
 
+(** Create the body of an of_string function for an enum *)
+let ocaml_of_string_of_enum list =
+  let single name =
+    Printf.sprintf {|"%s" -> %s|}
+      (String.lowercase_ascii name)
+      (constructor_of name)
+  in
+  let quoted name = Printf.sprintf {|'%s'|} name in
+  Printf.sprintf
+    {|match String.lowercase_ascii str with %s | s -> record_failure "Expected one of %s, got %%s" s|}
+    (ocaml_map_enum_ " | " single list)
+    (ocaml_map_enum_ ", " quoted list)
+
 (** Convert an IDL type into a string containing OCaml code representing the
     type. *)
 let rec ocaml_of_ty = function

--- a/ocaml/tests/record_util/old_enum_all.ml
+++ b/ocaml/tests/record_util/old_enum_all.ml
@@ -1,3 +1,7 @@
+let all_placement_policy = [`anti_affinity; `normal]
+
+let all_origin = [`remote; `bundle]
+
 let all_certificate_type = [`ca; `host; `host_internal]
 
 let all_cluster_host_operation = [`enable; `disable; `destroy]
@@ -22,7 +26,7 @@ let all_vgpu_type_implementation =
 
 let all_allocation_algorithm = [`breadth_first; `depth_first]
 
-let all_pgpu_dom0_access =
+let all_pci_dom0_access =
   [`enabled; `disable_on_reboot; `disabled; `enable_on_reboot]
 
 let all_sriov_configuration_mode = [`sysfs; `modprobe; `manual; `unknown]
@@ -135,15 +139,18 @@ let all_host_numa_affinity_policy = [`any; `best_effort; `default_policy]
 
 let all_host_sched_gran = [`core; `cpu; `socket]
 
-let all_latest_synced_updates_applied_state = [`yes; `no; `unknown]
-
 let all_update_guidances =
   [
     `reboot_host
   ; `reboot_host_on_livepatch_failure
+  ; `reboot_host_on_kernel_livepatch_failure
+  ; `reboot_host_on_xen_livepatch_failure
   ; `restart_toolstack
   ; `restart_device_model
+  ; `restart_vm
   ]
+
+let all_latest_synced_updates_applied_state = [`yes; `no; `unknown]
 
 let all_host_display =
   [`enabled; `disable_on_reboot; `disabled; `enable_on_reboot]
@@ -159,6 +166,7 @@ let all_host_allowed_operations =
   ; `vm_resume
   ; `vm_migrate
   ; `apply_updates
+  ; `enable
   ]
 
 let all_vm_appliance_operation =
@@ -179,6 +187,8 @@ let all_vmpp_backup_type = [`snapshot; `checkpoint]
 let all_tristate_type = [`yes; `no; `unspecified]
 
 let all_domain_type = [`hvm; `pv; `pv_in_pvh; `pvh; `unspecified]
+
+let all_vm_uefi_mode = [`setup; `user]
 
 let all_on_crash_behaviour =
   [
@@ -267,6 +277,7 @@ let all_pool_allowed_operations =
   ; `designate_new_master
   ; `configure_repositories
   ; `sync_updates
+  ; `sync_bundle
   ; `get_updates
   ; `apply_updates
   ; `tls_verification_enable
@@ -274,6 +285,7 @@ let all_pool_allowed_operations =
   ; `exchange_certificates_on_join
   ; `exchange_ca_certificates_on_join
   ; `copy_primary_host_certs
+  ; `eject
   ]
 
 let all_task_status_type =
@@ -283,9 +295,22 @@ let all_task_allowed_operations = [`cancel; `destroy]
 
 let all_hello_return = [`ok; `unknown_host; `cannot_talk_back]
 
+let all_pool_guest_secureboot_readiness = [`ready; `ready_no_dbx; `not_ready]
+
 let all_livepatch_status =
   [`ok_livepatch_complete; `ok_livepatch_incomplete; `ok]
 
-let all_sr_health = [`healthy; `recovering]
+let all_vm_secureboot_readiness =
+  [
+    `not_supported
+  ; `disabled
+  ; `first_boot
+  ; `ready
+  ; `ready_no_dbx
+  ; `setup_mode
+  ; `certs_incomplete
+  ]
+
+let all_sr_health = [`healthy; `recovering; `unreachable; `unavailable]
 
 let all_event_operation = [`add; `del; `_mod]

--- a/ocaml/tests/record_util/old_record_util.ml
+++ b/ocaml/tests/record_util/old_record_util.ml
@@ -72,7 +72,7 @@ let string_to_class str =
   | "Certificate" ->
       `Certificate
   | _ ->
-      failwith "Bad type"
+      record_failure "Bad type"
 
 let power_state_to_string state =
   match state with

--- a/ocaml/tests/record_util/old_record_util.ml
+++ b/ocaml/tests/record_util/old_record_util.ml
@@ -15,6 +15,9 @@
 
 exception Record_failure of string
 
+let record_failure fmt =
+  Printf.ksprintf (fun msg -> raise (Record_failure msg)) fmt
+
 let to_str = function Rpc.String x -> x | _ -> failwith "Invalid"
 
 let certificate_type_to_string = function
@@ -151,6 +154,38 @@ let string_to_vm_operation x =
   else
     List.assoc x table
 
+let vm_uefi_mode_of_string = function
+  | "setup" ->
+      `setup
+  | "user" ->
+      `user
+  | s ->
+      record_failure "Expected 'user','setup', got %s" s
+
+let vm_secureboot_readiness_to_string = function
+  | `not_supported ->
+      "not_supported"
+  | `disabled ->
+      "disabled"
+  | `first_boot ->
+      "first_boot"
+  | `ready ->
+      "ready"
+  | `ready_no_dbx ->
+      "ready_no_dbx"
+  | `setup_mode ->
+      "setup_mode"
+  | `certs_incomplete ->
+      "certs_incomplete"
+
+let pool_guest_secureboot_readiness_to_string = function
+  | `ready ->
+      "ready"
+  | `ready_no_dbx ->
+      "ready_no_dbx"
+  | `not_ready ->
+      "not_ready"
+
 let pool_operation_to_string = function
   | `ha_enable ->
       "ha_enable"
@@ -166,6 +201,8 @@ let pool_operation_to_string = function
       "configure_repositories"
   | `sync_updates ->
       "sync_updates"
+  | `sync_bundle ->
+      "sync_bundle"
   | `get_updates ->
       "get_updates"
   | `apply_updates ->
@@ -178,6 +215,8 @@ let pool_operation_to_string = function
       "exchange_ca_certificates_on_join"
   | `copy_primary_host_certs ->
       "copy_primary_host_certs"
+  | `eject ->
+      "eject"
 
 let host_operation_to_string = function
   | `provision ->
@@ -198,16 +237,24 @@ let host_operation_to_string = function
       "VM.migrate"
   | `apply_updates ->
       "apply_updates"
+  | `enable ->
+      "enable"
 
 let update_guidance_to_string = function
   | `reboot_host ->
       "reboot_host"
   | `reboot_host_on_livepatch_failure ->
       "reboot_host_on_livepatch_failure"
+  | `reboot_host_on_kernel_livepatch_failure ->
+      "reboot_host_on_kernel_livepatch_failure"
+  | `reboot_host_on_xen_livepatch_failure ->
+      "reboot_host_on_xen_livepatch_failure"
   | `restart_toolstack ->
       "restart_toolstack"
   | `restart_device_model ->
       "restart_device_model"
+  | `restart_vm ->
+      "restart_vm"
 
 let latest_synced_updates_applied_state_to_string = function
   | `yes ->
@@ -343,12 +390,8 @@ let string_to_vif_locking_mode = function
   | "disabled" ->
       `disabled
   | s ->
-      raise
-        (Record_failure
-           ("Expected 'network_default', 'locked', 'unlocked', 'disabled', got "
-           ^ s
-           )
-        )
+      record_failure
+        "Expected 'network_default', 'locked', 'unlocked', 'disabled', got %s" s
 
 let vmss_type_to_string = function
   | `snapshot ->
@@ -366,12 +409,8 @@ let string_to_vmss_type = function
   | "snapshot_with_quiesce" ->
       `snapshot_with_quiesce
   | s ->
-      raise
-        (Record_failure
-           ("Expected 'snapshot', 'checkpoint', 'snapshot_with_quiesce', got "
-           ^ s
-           )
-        )
+      record_failure
+        "Expected 'snapshot', 'checkpoint', 'snapshot_with_quiesce', got %s" s
 
 let vmss_frequency_to_string = function
   | `hourly ->
@@ -389,7 +428,7 @@ let string_to_vmss_frequency = function
   | "weekly" ->
       `weekly
   | s ->
-      raise (Record_failure ("Expected 'hourly', 'daily', 'weekly', got " ^ s))
+      record_failure "Expected 'hourly', 'daily', 'weekly', got %s" s
 
 let network_default_locking_mode_to_string = function
   | `unlocked ->
@@ -403,7 +442,7 @@ let string_to_network_default_locking_mode = function
   | "disabled" ->
       `disabled
   | s ->
-      raise (Record_failure ("Expected 'unlocked' or 'disabled', got " ^ s))
+      record_failure "Expected 'unlocked' or 'disabled', got %s" s
 
 let network_purpose_to_string : API.network_purpose -> string = function
   | `nbd ->
@@ -417,7 +456,7 @@ let string_to_network_purpose : string -> API.network_purpose = function
   | "insecure_nbd" ->
       `insecure_nbd
   | s ->
-      raise (Record_failure ("Expected a network purpose string; got " ^ s))
+      record_failure "Expected a network purpose string; got %s" s
 
 let vm_appliance_operation_to_string = function
   | `start ->
@@ -605,7 +644,7 @@ let string_to_on_normal_exit s =
   | "restart" ->
       `restart
   | _ ->
-      raise (Record_failure ("Expected 'destroy' or 'restart', got " ^ s))
+      record_failure "Expected 'destroy' or 'restart', got %s" s
 
 let on_crash_behaviour_to_string x =
   match x with
@@ -637,14 +676,11 @@ let string_to_on_crash_behaviour s =
   | "rename_restart" ->
       `rename_restart
   | _ ->
-      raise
-        (Record_failure
-           ("Expected 'destroy', 'coredump_and_destroy',"
-           ^ "'restart', 'coredump_and_restart', 'preserve' or \
-              'rename_restart', got "
-           ^ s
-           )
-        )
+      record_failure
+        "Expected 'destroy', 'coredump_and_destroy', \
+         'restart','coredump_and_restart', 'preserve' or 'rename_restart', got \
+         %s"
+        s
 
 let on_softreboot_behaviour_to_string x =
   match x with
@@ -668,14 +704,11 @@ let string_to_on_softreboot_behaviour s =
   | "soft_reboot" ->
       `soft_reboot
   | _ ->
-      raise
-        (Record_failure
-           ("Expected 'destroy', 'coredump_and_destroy',"
-           ^ "'restart', 'coredump_and_restart', 'preserve', 'soft_reboot' or \
-              'rename_restart', got "
-           ^ s
-           )
-        )
+      record_failure
+        "Expected 'destroy', 'coredump_and_destroy', 'restart', \
+         'coredump_and_restart', 'preserve', 'soft_reboot' or \
+         'rename_restart', got %s"
+        s
 
 let host_display_to_string h =
   match h with
@@ -697,7 +730,7 @@ let host_sched_gran_of_string s =
   | "socket" ->
       `socket
   | _ ->
-      raise (Record_failure ("Expected 'core','cpu', 'socket', got " ^ s))
+      record_failure "Expected 'core','cpu', 'socket', got %s" s
 
 let host_sched_gran_to_string = function
   | `core ->
@@ -724,10 +757,8 @@ let host_numa_affinity_policy_of_string a =
   | "default_policy" ->
       `default_policy
   | s ->
-      raise
-        (Record_failure
-           ("Expected 'any', 'best_effort' or 'default_policy', got " ^ s)
-        )
+      record_failure "Expected 'any', 'best_effort' or 'default_policy', got %s"
+        s
 
 let pci_dom0_access_to_string x = host_display_to_string x
 
@@ -738,7 +769,7 @@ let string_to_vdi_onboot s =
   | "reset" ->
       `reset
   | _ ->
-      raise (Record_failure ("Expected 'persist' or 'reset', got " ^ s))
+      record_failure "Expected 'persist' or 'reset', got %s" s
 
 let string_to_vbd_mode s =
   match String.lowercase_ascii s with
@@ -747,7 +778,7 @@ let string_to_vbd_mode s =
   | "rw" ->
       `RW
   | _ ->
-      raise (Record_failure ("Expected 'RO' or 'RW', got " ^ s))
+      record_failure "Expected 'RO' or 'RW', got %s" s
 
 let vbd_mode_to_string = function `RO -> "ro" | `RW -> "rw"
 
@@ -760,7 +791,7 @@ let string_to_vbd_type s =
   | "floppy" ->
       `Floppy
   | _ ->
-      raise (Record_failure ("Expected 'CD' or 'Disk', got " ^ s))
+      record_failure "Expected 'CD' or 'Disk', got %s" s
 
 let power_to_string h =
   match h with
@@ -819,7 +850,7 @@ let ip_configuration_mode_of_string m =
   | "static" ->
       `Static
   | s ->
-      raise (Record_failure ("Expected 'dhcp','none' or 'static', got " ^ s))
+      record_failure "Expected 'dhcp','none' or 'static', got %s" s
 
 let vif_ipv4_configuration_mode_to_string = function
   | `None ->
@@ -834,7 +865,7 @@ let vif_ipv4_configuration_mode_of_string m =
   | "static" ->
       `Static
   | s ->
-      raise (Record_failure ("Expected 'none' or 'static', got " ^ s))
+      record_failure "Expected 'none' or 'static', got %s" s
 
 let ipv6_configuration_mode_to_string = function
   | `None ->
@@ -857,10 +888,7 @@ let ipv6_configuration_mode_of_string m =
   | "autoconf" ->
       `Autoconf
   | s ->
-      raise
-        (Record_failure
-           ("Expected 'dhcp','none' 'autoconf' or 'static', got " ^ s)
-        )
+      record_failure "Expected 'dhcp','none' 'autoconf' or 'static', got %s" s
 
 let vif_ipv6_configuration_mode_to_string = function
   | `None ->
@@ -875,7 +903,7 @@ let vif_ipv6_configuration_mode_of_string m =
   | "static" ->
       `Static
   | s ->
-      raise (Record_failure ("Expected 'none' or 'static', got " ^ s))
+      record_failure "Expected 'none' or 'static', got %s" s
 
 let primary_address_type_to_string = function
   | `IPv4 ->
@@ -890,7 +918,7 @@ let primary_address_type_of_string m =
   | "ipv6" ->
       `IPv6
   | s ->
-      raise (Record_failure ("Expected 'ipv4' or 'ipv6', got " ^ s))
+      record_failure "Expected 'ipv4' or 'ipv6', got %s" s
 
 let bond_mode_to_string = function
   | `balanceslb ->
@@ -909,7 +937,7 @@ let bond_mode_of_string m =
   | "lacp" ->
       `lacp
   | s ->
-      raise (Record_failure ("Invalid bond mode. Got " ^ s))
+      record_failure "Invalid bond mode. Got %s" s
 
 let allocation_algorithm_to_string = function
   | `depth_first ->
@@ -924,7 +952,7 @@ let allocation_algorithm_of_string a =
   | "breadth-first" ->
       `breadth_first
   | s ->
-      raise (Record_failure ("Invalid allocation algorithm. Got " ^ s))
+      record_failure "Invalid allocation algorithm. Got %s" s
 
 let pvs_proxy_status_to_string = function
   | `stopped ->
@@ -945,12 +973,13 @@ let cluster_host_operation_to_string op =
 
 let bool_of_string s =
   match String.lowercase_ascii s with
-  | "true" | "yes" ->
+  | "true" | "t" | "yes" | "y" | "1" ->
       true
-  | "false" | "no" ->
+  | "false" | "f" | "no" | "n" | "0" ->
       false
   | _ ->
-      raise (Record_failure ("Expected 'true','yes','false','no', got " ^ s))
+      record_failure
+        "Expected 'true','t','yes','y','1','false','f','no','n','0' got %s" s
 
 let sdn_protocol_of_string s =
   match String.lowercase_ascii s with
@@ -959,7 +988,7 @@ let sdn_protocol_of_string s =
   | "pssl" ->
       `pssl
   | _ ->
-      raise (Record_failure ("Expected 'ssl','pssl', got " ^ s))
+      record_failure "Expected 'ssl','pssl', got %s" s
 
 let sdn_protocol_to_string = function `ssl -> "ssl" | `pssl -> "pssl"
 
@@ -970,7 +999,7 @@ let tunnel_protocol_of_string s =
   | "vxlan" ->
       `vxlan
   | _ ->
-      raise (Record_failure ("Expected 'gre','vxlan', got " ^ s))
+      record_failure "Expected 'gre','vxlan', got %s" s
 
 let tunnel_protocol_to_string = function `gre -> "gre" | `vxlan -> "vxlan"
 
@@ -999,14 +1028,6 @@ let network_sriov_configuration_mode_to_string = function
       "manual"
   | `unknown ->
       "unknown"
-
-(* string_to_string_map_to_string *)
-let s2sm_to_string sep x =
-  String.concat sep (List.map (fun (a, b) -> a ^ ": " ^ b) x)
-
-(* string to blob ref map to string *)
-let s2brm_to_string get_uuid_from_ref sep x =
-  String.concat sep (List.map (fun (n, r) -> n ^ ": " ^ get_uuid_from_ref r) x)
 
 let on_boot_to_string onboot =
   match onboot with `reset -> "reset" | `persist -> "persist"
@@ -1043,119 +1064,42 @@ let domain_type_of_string x =
   | "pvh" ->
       `pvh
   | s ->
-      raise (Record_failure ("Invalid domain type. Got " ^ s))
+      record_failure "Invalid domain type. Got %s" s
 
 let vtpm_operation_to_string (op : API.vtpm_operations) =
   match op with `destroy -> "destroy"
 
+(** parse [0-9]*(b|bytes|kib|mib|gib|tib)* to bytes *)
+let bytes_of_string str =
+  let ( ** ) a b = Int64.mul a b in
+  let invalid msg = raise (Invalid_argument msg) in
+  try
+    Scanf.sscanf str "%Ld %s" @@ fun size suffix ->
+    match String.lowercase_ascii suffix with
+    | _ when size < 0L ->
+        invalid str
+    | "bytes" | "b" | "" ->
+        size
+    | "kib" | "kb" | "k" ->
+        size ** 1024L
+    | "mib" | "mb" | "m" ->
+        size ** 1024L ** 1024L
+    | "gib" | "gb" | "g" ->
+        size ** 1024L ** 1024L ** 1024L
+    | "tib" | "tb" | "t" ->
+        size ** 1024L ** 1024L ** 1024L ** 1024L
+    | _ ->
+        invalid suffix
+  with _ -> invalid str
+
 (** Parse a string which might have a units suffix on the end *)
 let bytes_of_string field x =
-  let ( ** ) a b = Int64.mul a b in
-  let max_size_TiB =
-    Int64.div Int64.max_int (1024L ** 1024L ** 1024L ** 1024L)
-  in
-  (* detect big number that cannot be represented by Int64. *)
-  let int64_of_string s =
-    try Int64.of_string s
-    with _ ->
-      if s = "" then
-        raise
-          (Record_failure
-             (Printf.sprintf
-                "Failed to parse field '%s': expecting an integer (possibly \
-                 with suffix)"
-                field
-             )
-          ) ;
-      let alldigit = ref true and i = ref (String.length s - 1) in
-      while !alldigit && !i > 0 do
-        alldigit := Astring.Char.Ascii.is_digit s.[!i] ;
-        decr i
-      done ;
-      if !alldigit then
-        raise
-          (Record_failure
-             (Printf.sprintf
-                "Failed to parse field '%s': number too big (maximum = %Ld TiB)"
-                field max_size_TiB
-             )
-          )
-      else
-        raise
-          (Record_failure
-             (Printf.sprintf
-                "Failed to parse field '%s': expecting an integer (possibly \
-                 with suffix)"
-                field
-             )
-          )
-  in
-  match
-    Astring.(
-      String.fields ~empty:false ~is_sep:(fun c ->
-          Char.Ascii.(is_white c || is_digit c)
-      )
-    )
-      x
-  with
-  | [] ->
-      (* no suffix on the end *)
-      int64_of_string x
-  | [suffix] ->
-      let number =
-        match
-          Astring.(
-            String.fields ~empty:false ~is_sep:(Fun.negate Char.Ascii.is_digit)
-          )
-            x
-        with
-        | [number] ->
-            int64_of_string number
-        | _ ->
-            raise
-              (Record_failure
-                 (Printf.sprintf
-                    "Failed to parse field '%s': expecting an integer \
-                     (possibly with suffix)"
-                    field
-                 )
-              )
-      in
-      let multiplier =
-        match suffix with
-        | "bytes" ->
-            1L
-        | "KiB" ->
-            1024L
-        | "MiB" ->
-            1024L ** 1024L
-        | "GiB" ->
-            1024L ** 1024L ** 1024L
-        | "TiB" ->
-            1024L ** 1024L ** 1024L ** 1024L
-        | x ->
-            raise
-              (Record_failure
-                 (Printf.sprintf
-                    "Failed to parse field '%s': Unknown suffix: '%s' (try \
-                     KiB, MiB, GiB or TiB)"
-                    field x
-                 )
-              )
-      in
-      (* FIXME: detect overflow *)
-      number ** multiplier
-  | _ ->
-      raise
-        (Record_failure
-           (Printf.sprintf
-              "Failed to parse field '%s': expecting an integer (possibly with \
-               suffix)"
-              field
-           )
-        )
-
-(* Vincent's random mac utils *)
+  try bytes_of_string x
+  with Invalid_argument _ ->
+    record_failure
+      "Failed to parse field '%s': expecting an integer (possibly with suffix \
+       KiB, MiB, GiB, TiB), got '%s'"
+      field x
 
 let mac_from_int_array macs =
   (* make sure bit 1 (local) is set and bit 0 (unicast) is clear *)
@@ -1179,4 +1123,21 @@ let update_sync_frequency_of_string s =
   | "weekly" ->
       `weekly
   | _ ->
-      raise (Record_failure ("Expected 'daily', 'weekly', got " ^ s))
+      record_failure "Expected 'daily', 'weekly', got %s" s
+
+let vm_placement_policy_to_string = function
+  | `normal ->
+      "normal"
+  | `anti_affinity ->
+      "anti-affinity"
+
+let vm_placement_policy_of_string a =
+  match String.lowercase_ascii a with
+  | "normal" ->
+      `normal
+  | "anti-affinity" ->
+      `anti_affinity
+  | s ->
+      record_failure "Invalid VM placement policy, got %s" s
+
+let repo_origin_to_string = function `remote -> "remote" | `bundle -> "bundle"

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -112,7 +112,10 @@ let tests =
   [
     mk __LINE__ None all_certificate_type
       (O.certificate_type_to_string, N.certificate_type_to_string)
-  ; mk __LINE__ None all_cls (O.class_to_string, N.class_to_string)
+  ; mk __LINE__
+      (Some (O.string_to_class, N.cls_of_string))
+      all_cls
+      (O.class_to_string, N.cls_to_string)
   ; mk __LINE__ None all_vm_power_state
       (O.power_state_to_string, N.vm_power_state_to_string)
   ; mk __LINE__ None all_vm_power_state

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -122,6 +122,10 @@ let tests =
       (O.power_to_string, N.vm_power_state_to_lowercase_string)
   ; mk __LINE__ None all_vm_operations
       (O.vm_operation_to_string, N.vm_operation_to_string)
+  ; mk __LINE__
+      (Some (O.vm_uefi_mode_of_string, N.vm_uefi_mode_of_string))
+      all_vm_uefi_mode
+      (N.vm_uefi_mode_to_string, N.vm_uefi_mode_to_string)
   ; mk __LINE__ None all_vm_secureboot_readiness
       (O.vm_secureboot_readiness_to_string, N.vm_secureboot_readiness_to_string)
   ; mk __LINE__ None all_pool_guest_secureboot_readiness

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -136,7 +136,7 @@ let tests =
       , N.latest_synced_updates_applied_state_to_string
       )
   ; mk __LINE__ None all_vdi_operations
-      (O.vdi_operation_to_string, N.vdi_operation_to_string)
+      (O.vdi_operation_to_string, N.vdi_operations_to_string)
   ; mk __LINE__ None all_storage_operations
       (O.sr_operation_to_string, N.sr_operation_to_string)
   ; mk __LINE__ None all_vbd_operations

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -158,11 +158,19 @@ let tests =
       (Some (O.string_to_vmss_frequency, N.vmss_frequency_of_string))
       all_vmss_frequency
       (O.vmss_frequency_to_string, N.vmss_frequency_to_string)
-  ; mk __LINE__ None all_network_default_locking_mode
+  ; mk __LINE__
+      (Some
+         ( O.string_to_network_default_locking_mode
+         , N.network_default_locking_mode_of_string
+         )
+      )
+      all_network_default_locking_mode
       ( O.network_default_locking_mode_to_string
       , N.network_default_locking_mode_to_string
       )
-  ; mk __LINE__ None all_network_purpose
+  ; mk __LINE__
+      (Some (O.string_to_network_purpose, N.network_purpose_of_string))
+      all_network_purpose
       (O.network_purpose_to_string, N.network_purpose_to_string)
   ; mk __LINE__ None all_vm_appliance_operation
       (O.vm_appliance_operation_to_string, N.vm_appliance_operation_to_string)

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -130,7 +130,7 @@ let tests =
   ; mk __LINE__ None all_host_allowed_operations
       (O.host_operation_to_string, N.host_operation_to_string)
   ; mk __LINE__ None all_update_guidances
-      (O.update_guidance_to_string, N.update_guidance_to_string)
+      (O.update_guidance_to_string, N.update_guidances_to_string)
   ; mk __LINE__ None all_latest_synced_updates_applied_state
       ( O.latest_synced_updates_applied_state_to_string
       , N.latest_synced_updates_applied_state_to_string

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -256,7 +256,7 @@ let tests =
   ; mk __LINE__ None all_pif_igmp_status
       (O.pif_igmp_status_to_string, N.pif_igmp_status_to_string)
   ; mk __LINE__ None all_vusb_operations
-      (O.vusb_operation_to_string, N.vusb_operation_to_string)
+      (O.vusb_operation_to_string, N.vusb_operations_to_string)
   ; mk __LINE__ None all_sriov_configuration_mode
       ( O.network_sriov_configuration_mode_to_string
       , N.network_sriov_configuration_mode_to_string

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -280,8 +280,7 @@ let tests =
       (Some (O.vm_placement_policy_of_string, N.vm_placement_policy_of_string))
       all_placement_policy
       (O.vm_placement_policy_to_string, N.vm_placement_policy_to_string)
-  ; mk __LINE__ None all_origin
-      (O.repo_origin_to_string, N.repo_origin_to_string)
+  ; mk __LINE__ None all_origin (O.repo_origin_to_string, N.origin_to_string)
   ]
   |> List.concat
 

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -246,9 +246,9 @@ let tests =
   ; mk __LINE__ None all_cluster_host_operation
       (O.cluster_host_operation_to_string, N.cluster_host_operation_to_string)
   ; mk __LINE__
-      (Some (O.sdn_protocol_of_string, N.sdn_protocol_of_string))
+      (Some (O.sdn_protocol_of_string, N.sdn_controller_protocol_of_string))
       all_sdn_controller_protocol
-      (O.sdn_protocol_to_string, N.sdn_protocol_to_string)
+      (O.sdn_protocol_to_string, N.sdn_controller_protocol_to_string)
   ; mk __LINE__
       (Some (O.tunnel_protocol_of_string, N.tunnel_protocol_of_string))
       all_tunnel_protocol

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -259,7 +259,7 @@ let tests =
       (O.vusb_operation_to_string, N.vusb_operations_to_string)
   ; mk __LINE__ None all_sriov_configuration_mode
       ( O.network_sriov_configuration_mode_to_string
-      , N.network_sriov_configuration_mode_to_string
+      , N.sriov_configuration_mode_to_string
       )
   ; mk __LINE__ None all_on_boot (O.on_boot_to_string, N.on_boot_to_string)
   ; mk __LINE__ None all_tristate_type

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -148,8 +148,13 @@ let tests =
       (O.vif_operation_to_string, N.vif_operations_to_string)
   ; mk __LINE__ None all_vif_locking_mode
       (O.vif_locking_mode_to_string, N.vif_locking_mode_to_string)
-  ; mk __LINE__ None all_vmss_type (O.vmss_type_to_string, N.vmss_type_to_string)
-  ; mk __LINE__ None all_vmss_frequency
+  ; mk __LINE__
+      (Some (O.string_to_vmss_type, N.vmss_type_of_string))
+      all_vmss_type
+      (O.vmss_type_to_string, N.vmss_type_to_string)
+  ; mk __LINE__
+      (Some (O.string_to_vmss_frequency, N.vmss_frequency_of_string))
+      all_vmss_frequency
       (O.vmss_frequency_to_string, N.vmss_frequency_to_string)
   ; mk __LINE__ None all_network_default_locking_mode
       ( O.network_default_locking_mode_to_string

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -184,12 +184,22 @@ let tests =
   ; mk __LINE__ None all_task_allowed_operations
       (O.task_allowed_operations_to_string, N.task_allowed_operations_to_string)
     (*; mk __LINE__ None all_alert_level (O.alert_level_to_string, N.alert_level_to_string)*)
-  ; mk __LINE__ None all_on_normal_exit
+  ; mk __LINE__
+      (Some (O.string_to_on_normal_exit, N.on_normal_exit_of_string))
+      all_on_normal_exit
       (O.on_normal_exit_to_string, N.on_normal_exit_to_string)
-  ; mk __LINE__ None all_on_crash_behaviour
+  ; mk __LINE__
+      (Some (O.string_to_on_crash_behaviour, N.on_crash_behaviour_of_string))
+      all_on_crash_behaviour
       (O.on_crash_behaviour_to_string, N.on_crash_behaviour_to_string)
-  ; mk __LINE__ None all_on_softreboot_behavior
-      (O.on_softreboot_behaviour_to_string, N.on_softreboot_behaviour_to_string)
+  ; mk __LINE__
+      (Some
+         ( O.string_to_on_softreboot_behaviour
+         , N.on_softreboot_behavior_of_string
+         )
+      )
+      all_on_softreboot_behavior
+      (N.on_softreboot_behaviour_to_string, N.on_softreboot_behaviour_to_string)
   ; mk __LINE__ None all_host_display
       (O.host_display_to_string, N.host_display_to_string)
   ; mk __LINE__
@@ -286,7 +296,10 @@ let tests =
       ( O.network_sriov_configuration_mode_to_string
       , N.sriov_configuration_mode_to_string
       )
-  ; mk __LINE__ None all_on_boot (O.on_boot_to_string, N.on_boot_to_string)
+  ; mk __LINE__
+      (Some (O.string_to_vdi_onboot, N.on_boot_of_string))
+      all_on_boot
+      (O.on_boot_to_string, N.on_boot_to_string)
   ; mk __LINE__ None all_tristate_type
       (O.tristate_to_string, N.tristate_to_string)
   ; mk __LINE__

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -269,7 +269,7 @@ let tests =
       all_domain_type
       (O.domain_type_to_string, N.domain_type_to_string)
   ; mk __LINE__ None all_vtpm_operations
-      (O.vtpm_operation_to_string, N.vtpm_operation_to_string)
+      (O.vtpm_operation_to_string, N.vtpm_operations_to_string)
   ; mk __LINE__
       (Some
          (O.update_sync_frequency_of_string, N.update_sync_frequency_of_string)

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -142,7 +142,7 @@ let tests =
   ; mk __LINE__ None all_vbd_operations
       (O.vbd_operation_to_string, N.vbd_operations_to_string)
   ; mk __LINE__ None all_vif_operations
-      (O.vif_operation_to_string, N.vif_operation_to_string)
+      (O.vif_operation_to_string, N.vif_operations_to_string)
   ; mk __LINE__ None all_vif_locking_mode
       (O.vif_locking_mode_to_string, N.vif_locking_mode_to_string)
   ; mk __LINE__ None all_vmss_type (O.vmss_type_to_string, N.vmss_type_to_string)

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -94,6 +94,12 @@ let tests =
       (O.power_state_to_string, N.power_state_to_string)
   ; mk __LINE__ None all_vm_operations
       (O.vm_operation_to_string, N.vm_operation_to_string)
+  ; mk __LINE__ None all_vm_secureboot_readiness
+      (O.vm_secureboot_readiness_to_string, N.vm_secureboot_readiness_to_string)
+  ; mk __LINE__ None all_pool_guest_secureboot_readiness
+      ( O.pool_guest_secureboot_readiness_to_string
+      , N.pool_guest_secureboot_readiness_to_string
+      )
   ; mk __LINE__ None all_pool_allowed_operations
       (O.pool_operation_to_string, N.pool_operation_to_string)
   ; mk __LINE__ None all_host_allowed_operations
@@ -157,7 +163,7 @@ let tests =
       ( O.host_numa_affinity_policy_to_string
       , N.host_numa_affinity_policy_to_string
       )
-  ; mk __LINE__ None all_pgpu_dom0_access
+  ; mk __LINE__ None all_pci_dom0_access
       (O.pci_dom0_access_to_string, N.pci_dom0_access_to_string)
   ; mk __LINE__ None all_vbd_mode (O.vbd_mode_to_string, N.vbd_mode_to_string)
     (*; mk __LINE__ None all_power (O.power_to_string, N.power_to_string)*)
@@ -245,6 +251,12 @@ let tests =
       )
       all_update_sync_frequency
       (O.update_sync_frequency_to_string, N.update_sync_frequency_to_string)
+  ; mk __LINE__
+      (Some (O.vm_placement_policy_of_string, N.vm_placement_policy_of_string))
+      all_placement_policy
+      (O.vm_placement_policy_to_string, N.vm_placement_policy_to_string)
+  ; mk __LINE__ None all_origin
+      (O.repo_origin_to_string, N.repo_origin_to_string)
   ]
   |> List.concat
 

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -114,7 +114,9 @@ let tests =
       (O.certificate_type_to_string, N.certificate_type_to_string)
   ; mk __LINE__ None all_cls (O.class_to_string, N.class_to_string)
   ; mk __LINE__ None all_vm_power_state
-      (O.power_state_to_string, N.power_state_to_string)
+      (O.power_state_to_string, N.vm_power_state_to_string)
+  ; mk __LINE__ None all_vm_power_state
+      (O.power_to_string, N.vm_power_state_to_lowercase_string)
   ; mk __LINE__ None all_vm_operations
       (O.vm_operation_to_string, N.vm_operation_to_string)
   ; mk __LINE__ None all_vm_secureboot_readiness

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -146,7 +146,9 @@ let tests =
       (O.vbd_operation_to_string, N.vbd_operations_to_string)
   ; mk __LINE__ None all_vif_operations
       (O.vif_operation_to_string, N.vif_operations_to_string)
-  ; mk __LINE__ None all_vif_locking_mode
+  ; mk __LINE__
+      (Some (O.string_to_vif_locking_mode, N.vif_locking_mode_of_string))
+      all_vif_locking_mode
       (O.vif_locking_mode_to_string, N.vif_locking_mode_to_string)
   ; mk __LINE__
       (Some (O.string_to_vmss_type, N.vmss_type_of_string))

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -190,7 +190,14 @@ let tests =
       )
   ; mk __LINE__ None all_pci_dom0_access
       (O.pci_dom0_access_to_string, N.pci_dom0_access_to_string)
-  ; mk __LINE__ None all_vbd_mode (O.vbd_mode_to_string, N.vbd_mode_to_string)
+  ; mk __LINE__
+      (Some (O.string_to_vbd_mode, N.vbd_mode_of_string))
+      all_vbd_mode
+      (O.vbd_mode_to_string, N.vbd_mode_to_string)
+  ; mk __LINE__
+      (Some (O.string_to_vbd_type, N.vbd_type_of_string))
+      all_vbd_type
+      (N.vbd_type_to_string, N.vbd_type_to_string)
     (*; mk __LINE__ None all_power (O.power_to_string, N.power_to_string)*)
   ; mk __LINE__ None all_vdi_type (O.vdi_type_to_string, N.vdi_type_to_string)
   ; mk __LINE__

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -140,7 +140,7 @@ let tests =
   ; mk __LINE__ None all_storage_operations
       (O.sr_operation_to_string, N.sr_operation_to_string)
   ; mk __LINE__ None all_vbd_operations
-      (O.vbd_operation_to_string, N.vbd_operation_to_string)
+      (O.vbd_operation_to_string, N.vbd_operations_to_string)
   ; mk __LINE__ None all_vif_operations
       (O.vif_operation_to_string, N.vif_operation_to_string)
   ; mk __LINE__ None all_vif_locking_mode

--- a/ocaml/tests/record_util/test_record_util.ml
+++ b/ocaml/tests/record_util/test_record_util.ml
@@ -126,7 +126,7 @@ let tests =
       , N.pool_guest_secureboot_readiness_to_string
       )
   ; mk __LINE__ None all_pool_allowed_operations
-      (O.pool_operation_to_string, N.pool_operation_to_string)
+      (O.pool_operation_to_string, N.pool_allowed_operations_to_string)
   ; mk __LINE__ None all_host_allowed_operations
       (O.host_operation_to_string, N.host_operation_to_string)
   ; mk __LINE__ None all_update_guidances

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7753,7 +7753,8 @@ module SDN_controller = struct
     in
     let protocol =
       if List.mem_assoc "protocol" params then
-        Record_util.sdn_protocol_of_string (List.assoc "protocol" params)
+        Record_util.sdn_controller_protocol_of_string
+          (List.assoc "protocol" params)
       else
         `ssl
     in

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7370,8 +7370,8 @@ let vmss_create printer rpc session_id params =
           failwith ("No default value for parameter " ^ param_name)
   in
   let name_label = List.assoc "name-label" params in
-  let ty = Record_util.string_to_vmss_type (get "type") in
-  let frequency = Record_util.string_to_vmss_frequency (get "frequency") in
+  let ty = Record_util.vmss_type_of_string (get "type") in
+  let frequency = Record_util.vmss_frequency_of_string (get "frequency") in
   let schedule = read_map_params "schedule" params in
   (* optional parameters with default values *)
   let name_description = get "name-description" ~default:"" in

--- a/ocaml/xapi-cli-server/dune
+++ b/ocaml/xapi-cli-server/dune
@@ -1,3 +1,13 @@
+(rule
+  (targets generated_record_utils.ml)
+  (deps
+    ../idl/ocaml_backend/gen_api_main.exe
+  )
+  (action
+    (run %{deps} -filterinternal true -filter closed -mode utils -output
+      %{targets}))
+)
+
 (library
   (name xapi_cli_server)
   (modes best)

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -947,14 +947,6 @@ let pif_igmp_status_to_string = function
   | `unknown ->
       "unknown"
 
-let vusb_operation_to_string = function
-  | `attach ->
-      "attach"
-  | `plug ->
-      "plug"
-  | `unplug ->
-      "unplug"
-
 let network_sriov_configuration_mode_to_string = function
   | `sysfs ->
       "sysfs"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -981,5 +981,3 @@ let vm_placement_policy_of_string a =
       `anti_affinity
   | s ->
       record_failure "Invalid VM placement policy, got %s" s
-
-let repo_origin_to_string = function `remote -> "remote" | `bundle -> "bundle"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -101,14 +101,6 @@ let string_to_vm_operation x =
   else
     List.assoc x table
 
-let vm_uefi_mode_of_string = function
-  | "setup" ->
-      `setup
-  | "user" ->
-      `user
-  | s ->
-      record_failure "Expected 'user','setup', got %s" s
-
 let vm_secureboot_readiness_to_string = function
   | `not_supported ->
       "not_supported"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -251,16 +251,6 @@ let sr_operation_to_string : API.storage_operations -> string = function
   | `pbd_destroy ->
       "PBD.destroy"
 
-let vif_operation_to_string = function
-  | `attach ->
-      "attach"
-  | `plug ->
-      "plug"
-  | `unplug ->
-      "unplug"
-  | `unplug_force ->
-      "unplug_force"
-
 let vif_locking_mode_to_string = function
   | `network_default ->
       "network_default"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -179,38 +179,6 @@ let pool_guest_secureboot_readiness_to_string = function
   | `not_ready ->
       "not_ready"
 
-let pool_operation_to_string = function
-  | `ha_enable ->
-      "ha_enable"
-  | `ha_disable ->
-      "ha_disable"
-  | `cluster_create ->
-      "cluster_create"
-  | `designate_new_master ->
-      "designate_new_master"
-  | `tls_verification_enable ->
-      "tls_verification_enable"
-  | `configure_repositories ->
-      "configure_repositories"
-  | `sync_updates ->
-      "sync_updates"
-  | `sync_bundle ->
-      "sync_bundle"
-  | `get_updates ->
-      "get_updates"
-  | `apply_updates ->
-      "apply_updates"
-  | `cert_refresh ->
-      "cert_refresh"
-  | `exchange_certificates_on_join ->
-      "exchange_certificates_on_join"
-  | `exchange_ca_certificates_on_join ->
-      "exchange_ca_certificates_on_join"
-  | `copy_primary_host_certs ->
-      "copy_primary_host_certs"
-  | `eject ->
-      "eject"
-
 let host_operation_to_string = function
   | `provision ->
       "provision"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -36,52 +36,6 @@ let certificate_type_to_string = function
   | `ca ->
       "ca"
 
-let class_to_string cls =
-  match cls with
-  | `VM ->
-      "VM"
-  | `Host ->
-      "Host"
-  | `SR ->
-      "SR"
-  | `Pool ->
-      "Pool"
-  | `VMPP ->
-      "VMPP"
-  | `VMSS ->
-      "VMSS"
-  | `PVS_proxy ->
-      "PVS_proxy"
-  | `VDI ->
-      "VDI"
-  | `Certificate ->
-      "Certificate"
-  | _ ->
-      "unknown"
-
-let string_to_class str =
-  match str with
-  | "VM" ->
-      `VM
-  | "Host" ->
-      `Host
-  | "SR" ->
-      `SR
-  | "Pool" ->
-      `Pool
-  | "VMPP" ->
-      `VMPP
-  | "VMSS" ->
-      `VMSS
-  | "PVS_proxy" ->
-      `PVS_proxy
-  | "VDI" ->
-      `VDI
-  | "Certificate" ->
-      `Certificate
-  | _ ->
-      failwith "Bad type"
-
 let vm_operation_table =
   [
     (`assert_operation_valid, "assertoperationvalid")

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -257,42 +257,6 @@ let latest_synced_updates_applied_state_to_string = function
   | `unknown ->
       "unknown"
 
-let vdi_operation_to_string : API.vdi_operations -> string = function
-  | `clone ->
-      "clone"
-  | `copy ->
-      "copy"
-  | `resize ->
-      "resize"
-  | `resize_online ->
-      "resize_online"
-  | `destroy ->
-      "destroy"
-  | `force_unlock ->
-      "force_unlock"
-  | `snapshot ->
-      "snapshot"
-  | `mirror ->
-      "mirror"
-  | `forget ->
-      "forget"
-  | `update ->
-      "update"
-  | `generate_config ->
-      "generate_config"
-  | `enable_cbt ->
-      "enable_cbt"
-  | `disable_cbt ->
-      "disable_cbt"
-  | `data_destroy ->
-      "data_destroy"
-  | `list_changed_blocks ->
-      "list_changed_blocks"
-  | `set_on_boot ->
-      "set_on_boot"
-  | `blocked ->
-      "blocked"
-
 let sr_operation_to_string : API.storage_operations -> string = function
   | `scan ->
       "scan"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -28,14 +28,6 @@ include Generated_record_utils
 
 let to_str = function Rpc.String x -> x | _ -> failwith "Invalid"
 
-let certificate_type_to_string = function
-  | `host ->
-      "host"
-  | `host_internal ->
-      "host_internal"
-  | `ca ->
-      "ca"
-
 let vm_operation_table =
   [
     (`assert_operation_valid, "assertoperationvalid")
@@ -101,30 +93,6 @@ let string_to_vm_operation x =
   else
     List.assoc x table
 
-let vm_secureboot_readiness_to_string = function
-  | `not_supported ->
-      "not_supported"
-  | `disabled ->
-      "disabled"
-  | `first_boot ->
-      "first_boot"
-  | `ready ->
-      "ready"
-  | `ready_no_dbx ->
-      "ready_no_dbx"
-  | `setup_mode ->
-      "setup_mode"
-  | `certs_incomplete ->
-      "certs_incomplete"
-
-let pool_guest_secureboot_readiness_to_string = function
-  | `ready ->
-      "ready"
-  | `ready_no_dbx ->
-      "ready_no_dbx"
-  | `not_ready ->
-      "not_ready"
-
 let host_operation_to_string = function
   | `provision ->
       "provision"
@@ -146,14 +114,6 @@ let host_operation_to_string = function
       "apply_updates"
   | `enable ->
       "enable"
-
-let latest_synced_updates_applied_state_to_string = function
-  | `yes ->
-      "yes"
-  | `no ->
-      "no"
-  | `unknown ->
-      "unknown"
 
 let sr_operation_to_string : API.storage_operations -> string = function
   | `scan ->
@@ -196,16 +156,6 @@ let sr_operation_to_string : API.storage_operations -> string = function
       "PBD.create"
   | `pbd_destroy ->
       "PBD.destroy"
-
-let vm_appliance_operation_to_string = function
-  | `start ->
-      "start"
-  | `clean_shutdown ->
-      "clean_shutdown"
-  | `hard_shutdown ->
-      "hard_shutdown"
-  | `shutdown ->
-      "shutdown"
 
 let cpu_feature_to_string f =
   match f with
@@ -338,19 +288,6 @@ let cpu_feature_to_string f =
   | `VMX ->
       "VMX"
 
-let task_status_type_to_string s =
-  match s with
-  | `pending ->
-      "pending"
-  | `success ->
-      "success"
-  | `failure ->
-      "failure"
-  | `cancelling ->
-      "cancelling"
-  | `cancelled ->
-      "cancelled"
-
 let protocol_to_string = function
   | `vt100 ->
       "VT100"
@@ -358,14 +295,6 @@ let protocol_to_string = function
       "RFB"
   | `rdp ->
       "RDP"
-
-let telemetry_frequency_to_string = function
-  | `daily ->
-      "daily"
-  | `weekly ->
-      "weekly"
-  | `monthly ->
-      "monthly"
 
 let task_allowed_operations_to_string s =
   match s with `cancel -> "Cancel" | `destroy -> "Destroy"
@@ -404,56 +333,6 @@ let on_softreboot_behaviour_to_string x =
       "Preserve"
   | `soft_reboot ->
       "Soft reboot"
-
-let host_display_to_string h =
-  match h with
-  | `enabled ->
-      "enabled"
-  | `enable_on_reboot ->
-      "enable_on_reboot"
-  | `disabled ->
-      "disabled"
-  | `disable_on_reboot ->
-      "disable_on_reboot"
-
-let host_sched_gran_of_string s =
-  match String.lowercase_ascii s with
-  | "core" ->
-      `core
-  | "cpu" ->
-      `cpu
-  | "socket" ->
-      `socket
-  | _ ->
-      record_failure "Expected 'core','cpu', 'socket', got %s" s
-
-let host_sched_gran_to_string = function
-  | `core ->
-      "core"
-  | `cpu ->
-      "cpu"
-  | `socket ->
-      "socket"
-
-let host_numa_affinity_policy_to_string = function
-  | `any ->
-      "any"
-  | `best_effort ->
-      "best_effort"
-  | `default_policy ->
-      "default_policy"
-
-let host_numa_affinity_policy_of_string a =
-  match String.lowercase_ascii a with
-  | "any" ->
-      `any
-  | "best_effort" ->
-      `best_effort
-  | "default_policy" ->
-      `default_policy
-  | s ->
-      record_failure "Expected 'any', 'best_effort' or 'default_policy', got %s"
-        s
 
 let pci_dom0_access_to_string x = host_display_to_string x
 
@@ -498,93 +377,6 @@ let vdi_type_to_string t =
       "PVS cache"
   | `cbt_metadata ->
       "CBT metadata"
-
-let ip_configuration_mode_to_string = function
-  | `None ->
-      "None"
-  | `DHCP ->
-      "DHCP"
-  | `Static ->
-      "Static"
-
-let ip_configuration_mode_of_string m =
-  match String.lowercase_ascii m with
-  | "dhcp" ->
-      `DHCP
-  | "none" ->
-      `None
-  | "static" ->
-      `Static
-  | s ->
-      record_failure "Expected 'dhcp','none' or 'static', got %s" s
-
-let vif_ipv4_configuration_mode_to_string = function
-  | `None ->
-      "None"
-  | `Static ->
-      "Static"
-
-let vif_ipv4_configuration_mode_of_string m =
-  match String.lowercase_ascii m with
-  | "none" ->
-      `None
-  | "static" ->
-      `Static
-  | s ->
-      record_failure "Expected 'none' or 'static', got %s" s
-
-let ipv6_configuration_mode_to_string = function
-  | `None ->
-      "None"
-  | `DHCP ->
-      "DHCP"
-  | `Static ->
-      "Static"
-  | `Autoconf ->
-      "Autoconf"
-
-let ipv6_configuration_mode_of_string m =
-  match String.lowercase_ascii m with
-  | "dhcp" ->
-      `DHCP
-  | "none" ->
-      `None
-  | "static" ->
-      `Static
-  | "autoconf" ->
-      `Autoconf
-  | s ->
-      record_failure "Expected 'dhcp','none' 'autoconf' or 'static', got %s" s
-
-let vif_ipv6_configuration_mode_to_string = function
-  | `None ->
-      "None"
-  | `Static ->
-      "Static"
-
-let vif_ipv6_configuration_mode_of_string m =
-  match String.lowercase_ascii m with
-  | "none" ->
-      `None
-  | "static" ->
-      `Static
-  | s ->
-      record_failure "Expected 'none' or 'static', got %s" s
-
-let primary_address_type_to_string = function
-  | `IPv4 ->
-      "IPv4"
-  | `IPv6 ->
-      "IPv6"
-
-let primary_address_type_of_string m =
-  match String.lowercase_ascii m with
-  | "ipv4" ->
-      `IPv4
-  | "ipv6" ->
-      `IPv6
-  | s ->
-      record_failure "Expected 'ipv4' or 'ipv6', got %s" s
 
 let bond_mode_to_string = function
   | `balanceslb ->
@@ -646,25 +438,6 @@ let bool_of_string s =
   | _ ->
       record_failure
         "Expected 'true','t','yes','y','1','false','f','no','n','0' got %s" s
-
-let tunnel_protocol_of_string s =
-  match String.lowercase_ascii s with
-  | "gre" ->
-      `gre
-  | "vxlan" ->
-      `vxlan
-  | _ ->
-      record_failure "Expected 'gre','vxlan', got %s" s
-
-let tunnel_protocol_to_string = function `gre -> "gre" | `vxlan -> "vxlan"
-
-let pif_igmp_status_to_string = function
-  | `enabled ->
-      "enabled"
-  | `disabled ->
-      "disabled"
-  | `unknown ->
-      "unknown"
 
 let tristate_to_string tristate =
   match tristate with
@@ -740,21 +513,6 @@ let mac_from_int_array macs =
 
 (* generate a random mac that is locally administered *)
 let random_mac_local () = mac_from_int_array (Array.make 6 (Random.int 0x100))
-
-let update_sync_frequency_to_string = function
-  | `daily ->
-      "daily"
-  | `weekly ->
-      "weekly"
-
-let update_sync_frequency_of_string s =
-  match String.lowercase_ascii s with
-  | "daily" ->
-      `daily
-  | "weekly" ->
-      `weekly
-  | _ ->
-      record_failure "Expected 'daily', 'weekly', got %s" s
 
 let vm_placement_policy_to_string = function
   | `normal ->

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -897,16 +897,6 @@ let pif_igmp_status_to_string = function
   | `unknown ->
       "unknown"
 
-let network_sriov_configuration_mode_to_string = function
-  | `sysfs ->
-      "sysfs"
-  | `modprobe ->
-      "modprobe"
-  | `manual ->
-      "manual"
-  | `unknown ->
-      "unknown"
-
 let on_boot_to_string onboot =
   match onboot with `reset -> "reset" | `persist -> "persist"
 

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -201,22 +201,6 @@ let host_operation_to_string = function
   | `enable ->
       "enable"
 
-let update_guidance_to_string = function
-  | `reboot_host ->
-      "reboot_host"
-  | `reboot_host_on_livepatch_failure ->
-      "reboot_host_on_livepatch_failure"
-  | `reboot_host_on_kernel_livepatch_failure ->
-      "reboot_host_on_kernel_livepatch_failure"
-  | `reboot_host_on_xen_livepatch_failure ->
-      "reboot_host_on_xen_livepatch_failure"
-  | `restart_toolstack ->
-      "restart_toolstack"
-  | `restart_device_model ->
-      "restart_device_model"
-  | `restart_vm ->
-      "restart_vm"
-
 let latest_synced_updates_applied_state_to_string = function
   | `yes ->
       "yes"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -205,34 +205,6 @@ let sr_operation_to_string : API.storage_operations -> string = function
   | `pbd_destroy ->
       "PBD.destroy"
 
-let network_default_locking_mode_to_string = function
-  | `unlocked ->
-      "unlocked"
-  | `disabled ->
-      "disabled"
-
-let string_to_network_default_locking_mode = function
-  | "unlocked" ->
-      `unlocked
-  | "disabled" ->
-      `disabled
-  | s ->
-      record_failure "Expected 'unlocked' or 'disabled', got %s" s
-
-let network_purpose_to_string : API.network_purpose -> string = function
-  | `nbd ->
-      "nbd"
-  | `insecure_nbd ->
-      "insecure_nbd"
-
-let string_to_network_purpose : string -> API.network_purpose = function
-  | "nbd" ->
-      `nbd
-  | "insecure_nbd" ->
-      `insecure_nbd
-  | s ->
-      record_failure "Expected a network purpose string; got %s" s
-
 let vm_appliance_operation_to_string = function
   | `start ->
       "start"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -12,11 +12,19 @@
  * GNU Lesser General Public License for more details.
  *)
 (* conversion utils *)
+(* NOTE: Unless conversion requires some custom logic, no new functions should
+   be added here. Automatically-generated functions with consistent behaviour
+   and naming are generated from the datamodel and included here.
+   If the custom logic is required, these functions should be shadowed and
+   justified here.
+   See:
+    _build/default/ocaml/xapi-cli-server/generated_record_utils.ml
+   for the generated code. And:
+    ~/xen-api/ocaml/idl/ocaml_backend/gen_api.ml
+   for the code generating it.
+*)
 
-exception Record_failure of string
-
-let record_failure fmt =
-  Printf.ksprintf (fun msg -> raise (Record_failure msg)) fmt
+include Generated_record_utils
 
 let to_str = function Rpc.String x -> x | _ -> failwith "Invalid"
 

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -299,24 +299,6 @@ let sr_operation_to_string : API.storage_operations -> string = function
   | `pbd_destroy ->
       "PBD.destroy"
 
-let vbd_operation_to_string = function
-  | `attach ->
-      "attach"
-  | `eject ->
-      "eject"
-  | `insert ->
-      "insert"
-  | `plug ->
-      "plug"
-  | `unplug ->
-      "unplug"
-  | `unplug_force ->
-      "unplug_force"
-  | `pause ->
-      "pause"
-  | `unpause ->
-      "unpause"
-
 let vif_operation_to_string = function
   | `attach ->
       "attach"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -908,9 +908,6 @@ let domain_type_of_string x =
   | s ->
       record_failure "Invalid domain type. Got %s" s
 
-let vtpm_operation_to_string (op : API.vtpm_operations) =
-  match op with `destroy -> "destroy"
-
 (** parse [0-9]*(b|bytes|kib|mib|gib|tib)* to bytes *)
 let bytes_of_string str =
   let ( ** ) a b = Int64.mul a b in

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -652,27 +652,8 @@ let string_to_vdi_onboot s =
   | _ ->
       record_failure "Expected 'persist' or 'reset', got %s" s
 
-let string_to_vbd_mode s =
-  match String.lowercase_ascii s with
-  | "ro" ->
-      `RO
-  | "rw" ->
-      `RW
-  | _ ->
-      record_failure "Expected 'RO' or 'RW', got %s" s
-
+(* Intentional shadowing - inconsistent capitalization *)
 let vbd_mode_to_string = function `RO -> "ro" | `RW -> "rw"
-
-let string_to_vbd_type s =
-  match String.lowercase_ascii s with
-  | "cd" ->
-      `CD
-  | "disk" ->
-      `Disk
-  | "floppy" ->
-      `Floppy
-  | _ ->
-      record_failure "Expected 'CD' or 'Disk', got %s" s
 
 (* Some usage sites rely on the output of the
    conversion function to be lowercase*)

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -77,12 +77,17 @@ let vm_operation_table =
   ; (`create_vtpm, "create_vtpm")
   ]
 
+(* Intentional shadowing - data_souces_op, assertoperationinvalid,
+   changing_vcpus, changing_memory_limits, query_services, create_template
+   are inconsistent *)
 let vm_operation_to_string x =
   if not (List.mem_assoc x vm_operation_table) then
     "(unknown operation)"
   else
     List.assoc x vm_operation_table
 
+(* Intentional shadowing -
+   In addition to the above, also inconsistent exceptions *)
 let string_to_vm_operation x =
   let table = List.map (fun (a, b) -> (b, a)) vm_operation_table in
   if not (List.mem_assoc x table) then
@@ -93,6 +98,8 @@ let string_to_vm_operation x =
   else
     List.assoc x table
 
+(* Intentional shadowing - inconsistent behaviour:
+   vm_start, vm_resume, vm_migrate *)
 let host_operation_to_string = function
   | `provision ->
       "provision"
@@ -115,6 +122,7 @@ let host_operation_to_string = function
   | `enable ->
       "enable"
 
+(* Intentional shadowing - inconsistent behaviour around _/. *)
 let sr_operation_to_string : API.storage_operations -> string = function
   | `scan ->
       "scan"
@@ -157,6 +165,7 @@ let sr_operation_to_string : API.storage_operations -> string = function
   | `pbd_destroy ->
       "PBD.destroy"
 
+(* Is not defined in the datamodel - only defined here *)
 let cpu_feature_to_string f =
   match f with
   | `FPU ->
@@ -288,6 +297,7 @@ let cpu_feature_to_string f =
   | `VMX ->
       "VMX"
 
+(* Intentional shadowing - inconsistent capitalization *)
 let protocol_to_string = function
   | `vt100 ->
       "VT100"
@@ -296,9 +306,11 @@ let protocol_to_string = function
   | `rdp ->
       "RDP"
 
+(* Intentional shadowing - inconsistent capitalization *)
 let task_allowed_operations_to_string s =
   match s with `cancel -> "Cancel" | `destroy -> "Destroy"
 
+(* Is not defined in the datamodel - only defined here *)
 let alert_level_to_string s =
   match s with `Info -> "info" | `Warn -> "warning" | `Error -> "error"
 
@@ -353,6 +365,7 @@ let vbd_mode_to_string = function `RO -> "ro" | `RW -> "rw"
 let vm_power_state_to_lowercase_string h =
   vm_power_state_to_string h |> String.uncapitalize_ascii
 
+(* Intentional shadowing - inconsistent capitalization *)
 let vdi_type_to_string t =
   match t with
   | `system ->
@@ -378,6 +391,7 @@ let vdi_type_to_string t =
   | `cbt_metadata ->
       "CBT metadata"
 
+(* Intentional shadowing - inconsistent underscore/dash *)
 let bond_mode_to_string = function
   | `balanceslb ->
       "balance-slb"
@@ -386,6 +400,7 @@ let bond_mode_to_string = function
   | `lacp ->
       "lacp"
 
+(* Intentional shadowing - inconsistent underscore/dash, custom case *)
 let bond_mode_of_string m =
   match String.lowercase_ascii m with
   | "balance-slb" | "" ->
@@ -397,12 +412,14 @@ let bond_mode_of_string m =
   | s ->
       record_failure "Invalid bond mode. Got %s" s
 
+(* Intentional shadowing - inconsistent underscore/dash *)
 let allocation_algorithm_to_string = function
   | `depth_first ->
       "depth-first"
   | `breadth_first ->
       "breadth-first"
 
+(* Intentional shadowing - inconsistent underscore/dash *)
 let allocation_algorithm_of_string a =
   match String.lowercase_ascii a with
   | "depth-first" ->
@@ -412,6 +429,7 @@ let allocation_algorithm_of_string a =
   | s ->
       record_failure "Invalid allocation algorithm. Got %s" s
 
+(* Intentional shadowing - inconsistent underscore/dash *)
 let pvs_proxy_status_to_string = function
   | `stopped ->
       "stopped"
@@ -439,6 +457,7 @@ let bool_of_string s =
       record_failure
         "Expected 'true','t','yes','y','1','false','f','no','n','0' got %s" s
 
+(* Intentional shadowing - inconsistent naming *)
 let tristate_to_string tristate =
   match tristate with
   | `yes ->
@@ -448,6 +467,7 @@ let tristate_to_string tristate =
   | `unspecified ->
       "unspecified"
 
+(* Intentional shadowing - inconsistent underscore/dash *)
 let domain_type_to_string = function
   | `hvm ->
       "hvm"
@@ -460,6 +480,7 @@ let domain_type_to_string = function
   | `unspecified ->
       "unspecified"
 
+(* Intentional shadowing - inconsistent underscore/dash *)
 let domain_type_of_string x =
   match String.lowercase_ascii x with
   | "hvm" ->
@@ -514,12 +535,14 @@ let mac_from_int_array macs =
 (* generate a random mac that is locally administered *)
 let random_mac_local () = mac_from_int_array (Array.make 6 (Random.int 0x100))
 
+(* Intentional shadowing - inconsistent underscore/dash *)
 let vm_placement_policy_to_string = function
   | `normal ->
       "normal"
   | `anti_affinity ->
       "anti-affinity"
 
+(* Intentional shadowing - inconsistent underscore/dash *)
 let vm_placement_policy_of_string a =
   match String.lowercase_ascii a with
   | "normal" ->

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -381,18 +381,11 @@ let task_allowed_operations_to_string s =
 let alert_level_to_string s =
   match s with `Info -> "info" | `Warn -> "warning" | `Error -> "error"
 
+(* Intentional shadowing - inconsistent capitalization *)
 let on_normal_exit_to_string x =
   match x with `destroy -> "Destroy" | `restart -> "Restart"
 
-let string_to_on_normal_exit s =
-  match String.lowercase_ascii s with
-  | "destroy" ->
-      `destroy
-  | "restart" ->
-      `restart
-  | _ ->
-      record_failure "Expected 'destroy' or 'restart', got %s" s
-
+(* Intentional shadowing - inconsistent capitalization *)
 let on_crash_behaviour_to_string x =
   match x with
   | `destroy ->
@@ -408,27 +401,7 @@ let on_crash_behaviour_to_string x =
   | `rename_restart ->
       "Rename restart"
 
-let string_to_on_crash_behaviour s =
-  match String.lowercase_ascii s with
-  | "destroy" ->
-      `destroy
-  | "coredump_and_destroy" ->
-      `coredump_and_destroy
-  | "restart" ->
-      `restart
-  | "coredump_and_restart" ->
-      `coredump_and_restart
-  | "preserve" ->
-      `preserve
-  | "rename_restart" ->
-      `rename_restart
-  | _ ->
-      record_failure
-        "Expected 'destroy', 'coredump_and_destroy', \
-         'restart','coredump_and_restart', 'preserve' or 'rename_restart', got \
-         %s"
-        s
-
+(* Intentional shadowing - inconsistent capitalization *)
 let on_softreboot_behaviour_to_string x =
   match x with
   | `destroy ->
@@ -439,23 +412,6 @@ let on_softreboot_behaviour_to_string x =
       "Preserve"
   | `soft_reboot ->
       "Soft reboot"
-
-let string_to_on_softreboot_behaviour s =
-  match String.lowercase_ascii s with
-  | "destroy" ->
-      `destroy
-  | "restart" ->
-      `restart
-  | "preserve" ->
-      `preserve
-  | "soft_reboot" ->
-      `soft_reboot
-  | _ ->
-      record_failure
-        "Expected 'destroy', 'coredump_and_destroy', 'restart', \
-         'coredump_and_restart', 'preserve', 'soft_reboot' or \
-         'rename_restart', got %s"
-        s
 
 let host_display_to_string h =
   match h with
@@ -717,9 +673,6 @@ let pif_igmp_status_to_string = function
       "disabled"
   | `unknown ->
       "unknown"
-
-let on_boot_to_string onboot =
-  match onboot with `reset -> "reset" | `persist -> "persist"
 
 let tristate_to_string tristate =
   match tristate with

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -205,29 +205,6 @@ let sr_operation_to_string : API.storage_operations -> string = function
   | `pbd_destroy ->
       "PBD.destroy"
 
-let vif_locking_mode_to_string = function
-  | `network_default ->
-      "network_default"
-  | `locked ->
-      "locked"
-  | `unlocked ->
-      "unlocked"
-  | `disabled ->
-      "disabled"
-
-let string_to_vif_locking_mode = function
-  | "network_default" ->
-      `network_default
-  | "locked" ->
-      `locked
-  | "unlocked" ->
-      `unlocked
-  | "disabled" ->
-      `disabled
-  | s ->
-      record_failure
-        "Expected 'network_default', 'locked', 'unlocked', 'disabled', got %s" s
-
 let network_default_locking_mode_to_string = function
   | `unlocked ->
       "unlocked"

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -82,21 +82,6 @@ let string_to_class str =
   | _ ->
       failwith "Bad type"
 
-let power_state_to_string state =
-  match state with
-  | `Halted ->
-      "Halted"
-  | `Paused ->
-      "Paused"
-  | `Running ->
-      "Running"
-  | `Suspended ->
-      "Suspended"
-  | `ShuttingDown ->
-      "Shutting down"
-  | `Migrating ->
-      "Migrating"
-
 let vm_operation_table =
   [
     (`assert_operation_valid, "assertoperationvalid")
@@ -801,20 +786,10 @@ let string_to_vbd_type s =
   | _ ->
       record_failure "Expected 'CD' or 'Disk', got %s" s
 
-let power_to_string h =
-  match h with
-  | `Halted ->
-      "halted"
-  | `Paused ->
-      "paused"
-  | `Running ->
-      "running"
-  | `Suspended ->
-      "suspended"
-  | `ShuttingDown ->
-      "shutting down"
-  | `Migrating ->
-      "migrating"
+(* Some usage sites rely on the output of the
+   conversion function to be lowercase*)
+let vm_power_state_to_lowercase_string h =
+  vm_power_state_to_string h |> String.uncapitalize_ascii
 
 let vdi_type_to_string t =
   match t with

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -928,17 +928,6 @@ let bool_of_string s =
       record_failure
         "Expected 'true','t','yes','y','1','false','f','no','n','0' got %s" s
 
-let sdn_protocol_of_string s =
-  match String.lowercase_ascii s with
-  | "ssl" ->
-      `ssl
-  | "pssl" ->
-      `pssl
-  | _ ->
-      record_failure "Expected 'ssl','pssl', got %s" s
-
-let sdn_protocol_to_string = function `ssl -> "ssl" | `pssl -> "pssl"
-
 let tunnel_protocol_of_string s =
   match String.lowercase_ascii s with
   | "gre" ->

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -228,43 +228,6 @@ let string_to_vif_locking_mode = function
       record_failure
         "Expected 'network_default', 'locked', 'unlocked', 'disabled', got %s" s
 
-let vmss_type_to_string = function
-  | `snapshot ->
-      "snapshot"
-  | `checkpoint ->
-      "checkpoint"
-  | `snapshot_with_quiesce ->
-      "snapshot_with_quiesce"
-
-let string_to_vmss_type = function
-  | "snapshot" ->
-      `snapshot
-  | "checkpoint" ->
-      `checkpoint
-  | "snapshot_with_quiesce" ->
-      `snapshot_with_quiesce
-  | s ->
-      record_failure
-        "Expected 'snapshot', 'checkpoint', 'snapshot_with_quiesce', got %s" s
-
-let vmss_frequency_to_string = function
-  | `hourly ->
-      "hourly"
-  | `daily ->
-      "daily"
-  | `weekly ->
-      "weekly"
-
-let string_to_vmss_frequency = function
-  | "hourly" ->
-      `hourly
-  | "daily" ->
-      `daily
-  | "weekly" ->
-      `weekly
-  | s ->
-      record_failure "Expected 'hourly', 'daily', 'weekly', got %s" s
-
 let network_default_locking_mode_to_string = function
   | `unlocked ->
       "unlocked"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1070,7 +1070,7 @@ let net_record rpc session_id net =
           ~set:(fun value ->
             Client.Network.set_default_locking_mode ~rpc ~session_id
               ~network:net
-              ~value:(Record_util.string_to_network_default_locking_mode value)
+              ~value:(Record_util.network_default_locking_mode_of_string value)
           )
           ()
       ; make_field ~name:"purpose"
@@ -1084,11 +1084,11 @@ let net_record rpc session_id net =
           )
           ~add_to_set:(fun s ->
             Client.Network.add_purpose ~rpc ~session_id ~self:net
-              ~value:(Record_util.string_to_network_purpose s)
+              ~value:(Record_util.network_purpose_of_string s)
           )
           ~remove_from_set:(fun s ->
             Client.Network.remove_purpose ~rpc ~session_id ~self:net
-              ~value:(Record_util.string_to_network_purpose s)
+              ~value:(Record_util.network_purpose_of_string s)
           )
           ()
       ]

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -920,7 +920,7 @@ let vif_record rpc session_id vif =
           )
           ~set:(fun value ->
             Client.VIF.set_locking_mode ~rpc ~session_id ~self:vif
-              ~value:(Record_util.string_to_vif_locking_mode value)
+              ~value:(Record_util.vif_locking_mode_of_string value)
           )
           ()
       ; make_field ~name:"ipv4-allowed"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1860,7 +1860,10 @@ let vm_record rpc session_id vm =
           ~get:(fun () -> string_of_bool (x ()).API.vM_is_control_domain)
           ()
       ; make_field ~name:"power-state"
-          ~get:(fun () -> Record_util.power_to_string (x ()).API.vM_power_state)
+          ~get:(fun () ->
+            Record_util.vm_power_state_to_lowercase_string
+              (x ()).API.vM_power_state
+          )
           ()
       ; make_field ~name:"memory-actual"
           ~get:(fun () ->

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -816,23 +816,23 @@ let vif_record rpc session_id vif =
           ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () ->
-            map_and_concat Record_util.vif_operation_to_string
+            map_and_concat Record_util.vif_operations_to_string
               (x ()).API.vIF_allowed_operations
           )
           ~get_set:(fun () ->
-            List.map Record_util.vif_operation_to_string
+            List.map Record_util.vif_operations_to_string
               (x ()).API.vIF_allowed_operations
           )
           ()
       ; make_field ~name:"current-operations"
           ~get:(fun () ->
             map_and_concat
-              (fun (_, b) -> Record_util.vif_operation_to_string b)
+              (fun (_, b) -> Record_util.vif_operations_to_string b)
               (x ()).API.vIF_current_operations
           )
           ~get_set:(fun () ->
             List.map
-              (fun (_, b) -> Record_util.vif_operation_to_string b)
+              (fun (_, b) -> Record_util.vif_operations_to_string b)
               (x ()).API.vIF_current_operations
           )
           ()

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -4935,23 +4935,23 @@ let vusb_record rpc session_id vusb =
           ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () ->
-            map_and_concat Record_util.vusb_operation_to_string
+            map_and_concat Record_util.vusb_operations_to_string
               (x ()).API.vUSB_allowed_operations
           )
           ~get_set:(fun () ->
-            List.map Record_util.vusb_operation_to_string
+            List.map Record_util.vusb_operations_to_string
               (x ()).API.vUSB_allowed_operations
           )
           ()
       ; make_field ~name:"current-operations"
           ~get:(fun () ->
             map_and_concat
-              (fun (_, b) -> Record_util.vusb_operation_to_string b)
+              (fun (_, b) -> Record_util.vusb_operations_to_string b)
               (x ()).API.vUSB_current_operations
           )
           ~get_set:(fun () ->
             List.map
-              (fun (_, b) -> Record_util.vusb_operation_to_string b)
+              (fun (_, b) -> Record_util.vusb_operations_to_string b)
               (x ()).API.vUSB_current_operations
           )
           ()

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3446,23 +3446,23 @@ let vbd_record rpc session_id vbd =
           ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () ->
-            map_and_concat Record_util.vbd_operation_to_string
+            map_and_concat Record_util.vbd_operations_to_string
               (x ()).API.vBD_allowed_operations
           )
           ~get_set:(fun () ->
-            List.map Record_util.vbd_operation_to_string
+            List.map Record_util.vbd_operations_to_string
               (x ()).API.vBD_allowed_operations
           )
           ()
       ; make_field ~name:"current-operations"
           ~get:(fun () ->
             map_and_concat
-              (fun (_, b) -> Record_util.vbd_operation_to_string b)
+              (fun (_, b) -> Record_util.vbd_operations_to_string b)
               (x ()).API.vBD_current_operations
           )
           ~get_set:(fun () ->
             List.map
-              (fun (_, b) -> Record_util.vbd_operation_to_string b)
+              (fun (_, b) -> Record_util.vbd_operations_to_string b)
               (x ()).API.vBD_current_operations
           )
           ()

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -370,7 +370,7 @@ let message_record rpc session_id message =
           ~get:(fun () -> Int64.to_string (x ()).API.message_priority)
           ()
       ; make_field ~name:"class"
-          ~get:(fun () -> Record_util.class_to_string (x ()).API.message_cls)
+          ~get:(fun () -> Record_util.cls_to_string (x ()).API.message_cls)
           ()
       ; make_field ~name:"obj-uuid"
           ~get:(fun () -> (x ()).API.message_obj_uuid)

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1962,7 +1962,7 @@ let vm_record rpc session_id vm =
           )
           ~set:(fun x ->
             Client.VM.set_actions_after_shutdown ~rpc ~session_id ~self:vm
-              ~value:(Record_util.string_to_on_normal_exit x)
+              ~value:(Record_util.on_normal_exit_of_string x)
           )
           ()
       ; make_field ~name:"actions-after-softreboot"
@@ -1972,7 +1972,7 @@ let vm_record rpc session_id vm =
           )
           ~set:(fun x ->
             Client.VM.set_actions_after_softreboot ~rpc ~session_id ~self:vm
-              ~value:(Record_util.string_to_on_softreboot_behaviour x)
+              ~value:(Record_util.on_softreboot_behavior_of_string x)
           )
           ()
       ; make_field ~name:"actions-after-reboot"
@@ -1982,7 +1982,7 @@ let vm_record rpc session_id vm =
           )
           ~set:(fun x ->
             Client.VM.set_actions_after_reboot ~rpc ~session_id ~self:vm
-              ~value:(Record_util.string_to_on_normal_exit x)
+              ~value:(Record_util.on_normal_exit_of_string x)
           )
           ()
       ; make_field ~name:"actions-after-crash"
@@ -1992,7 +1992,7 @@ let vm_record rpc session_id vm =
           )
           ~set:(fun x ->
             Client.VM.set_actions_after_crash ~rpc ~session_id ~self:vm
-              ~value:(Record_util.string_to_on_crash_behaviour x)
+              ~value:(Record_util.on_crash_behaviour_of_string x)
           )
           ()
       ; make_field ~name:"console-uuids"
@@ -3359,7 +3359,7 @@ let vdi_record rpc session_id vdi =
           ~get:(fun () -> Record_util.on_boot_to_string (x ()).API.vDI_on_boot)
           ~set:(fun onboot ->
             Client.VDI.set_on_boot ~rpc ~session_id ~self:vdi
-              ~value:(Record_util.string_to_vdi_onboot onboot)
+              ~value:(Record_util.on_boot_of_string onboot)
           )
           ()
       ; make_field ~name:"allow-caching"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5295,11 +5295,11 @@ let vtpm_record rpc session_id vtpm =
           ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () ->
-            map_and_concat Record_util.vtpm_operation_to_string
+            map_and_concat Record_util.vtpm_operations_to_string
               (x ()).API.vTPM_allowed_operations
           )
           ~get_set:(fun () ->
-            List.map Record_util.vtpm_operation_to_string
+            List.map Record_util.vtpm_operations_to_string
               (x ()).API.vTPM_allowed_operations
           )
           ()

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5245,7 +5245,7 @@ let repository_record rpc session_id repository =
           ()
       ; make_field ~name:"origin"
           ~get:(fun () ->
-            Record_util.repo_origin_to_string (x ()).API.repository_origin
+            Record_util.origin_to_string (x ()).API.repository_origin
           )
           ()
       ]

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1518,7 +1518,7 @@ let vmss_record rpc session_id vmss =
           ~get:(fun () -> Record_util.vmss_type_to_string (x ()).API.vMSS_type)
           ~set:(fun x ->
             Client.VMSS.set_type ~rpc ~session_id ~self:vmss
-              ~value:(Record_util.string_to_vmss_type x)
+              ~value:(Record_util.vmss_type_of_string x)
           )
           ()
       ; make_field ~name:"retained-snapshots"
@@ -1536,7 +1536,7 @@ let vmss_record rpc session_id vmss =
           )
           ~set:(fun x ->
             Client.VMSS.set_frequency ~rpc ~session_id ~self:vmss
-              ~value:(Record_util.string_to_vmss_frequency x)
+              ~value:(Record_util.vmss_frequency_of_string x)
           )
           ()
       ; make_field ~name:"schedule"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3266,23 +3266,23 @@ let vdi_record rpc session_id vdi =
           ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () ->
-            map_and_concat Record_util.vdi_operation_to_string
+            map_and_concat Record_util.vdi_operations_to_string
               (x ()).API.vDI_allowed_operations
           )
           ~get_set:(fun () ->
-            List.map Record_util.vdi_operation_to_string
+            List.map Record_util.vdi_operations_to_string
               (x ()).API.vDI_allowed_operations
           )
           ()
       ; make_field ~name:"current-operations"
           ~get:(fun () ->
             map_and_concat
-              (fun (_, b) -> Record_util.vdi_operation_to_string b)
+              (fun (_, b) -> Record_util.vdi_operations_to_string b)
               (x ()).API.vDI_current_operations
           )
           ~get_set:(fun () ->
             List.map
-              (fun (_, b) -> Record_util.vdi_operation_to_string b)
+              (fun (_, b) -> Record_util.vdi_operations_to_string b)
               (x ()).API.vDI_current_operations
           )
           ()

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1189,23 +1189,23 @@ let pool_record rpc session_id pool =
           ()
       ; make_field ~name:"allowed-operations"
           ~get:(fun () ->
-            map_and_concat Record_util.pool_operation_to_string
+            map_and_concat Record_util.pool_allowed_operations_to_string
               (x ()).API.pool_allowed_operations
           )
           ~get_set:(fun () ->
-            List.map Record_util.pool_operation_to_string
+            List.map Record_util.pool_allowed_operations_to_string
               (x ()).API.pool_allowed_operations
           )
           ()
       ; make_field ~name:"current-operations"
           ~get:(fun () ->
             map_and_concat
-              (fun (_, b) -> Record_util.pool_operation_to_string b)
+              (fun (_, b) -> Record_util.pool_allowed_operations_to_string b)
               (x ()).API.pool_current_operations
           )
           ~get_set:(fun () ->
             List.map
-              (fun (_, b) -> Record_util.pool_operation_to_string b)
+              (fun (_, b) -> Record_util.pool_allowed_operations_to_string b)
               (x ()).API.pool_current_operations
           )
           ()

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -4730,7 +4730,7 @@ let sdn_controller_record rpc session_id sdn_controller =
           ()
       ; make_field ~name:"protocol"
           ~get:(fun () ->
-            Record_util.sdn_protocol_to_string
+            Record_util.sdn_controller_protocol_to_string
               (x ()).API.sDN_controller_protocol
           )
           ()

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -3489,7 +3489,7 @@ let vbd_record rpc session_id vbd =
           )
           ~set:(fun mode ->
             Client.VBD.set_mode ~rpc ~session_id ~self:vbd
-              ~value:(Record_util.string_to_vbd_mode mode)
+              ~value:(Record_util.vbd_mode_of_string mode)
           )
           ()
       ; make_field ~name:"type"
@@ -3504,7 +3504,7 @@ let vbd_record rpc session_id vbd =
           )
           ~set:(fun ty ->
             Client.VBD.set_type ~rpc ~session_id ~self:vbd
-              ~value:(Record_util.string_to_vbd_type ty)
+              ~value:(Record_util.vbd_type_of_string ty)
           )
           ()
       ; make_field ~name:"unpluggable"

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2547,7 +2547,7 @@ let vm_record rpc session_id vm =
           ()
       ; make_field ~name:"pending-guidances"
           ~get:(fun () ->
-            map_and_concat Record_util.update_guidance_to_string
+            map_and_concat Record_util.update_guidances_to_string
               (x ()).API.vM_pending_guidances
           )
           ()
@@ -2556,13 +2556,13 @@ let vm_record rpc session_id vm =
           ()
       ; make_field ~name:"pending-guidances-recommended"
           ~get:(fun () ->
-            map_and_concat Record_util.update_guidance_to_string
+            map_and_concat Record_util.update_guidances_to_string
               (x ()).API.vM_pending_guidances_recommended
           )
           ()
       ; make_field ~name:"pending-guidances-full"
           ~get:(fun () ->
-            map_and_concat Record_util.update_guidance_to_string
+            map_and_concat Record_util.update_guidances_to_string
               (x ()).API.vM_pending_guidances_full
           )
           ()
@@ -3181,7 +3181,7 @@ let host_record rpc session_id host =
           ()
       ; make_field ~name:"pending-guidances"
           ~get:(fun () ->
-            map_and_concat Record_util.update_guidance_to_string
+            map_and_concat Record_util.update_guidances_to_string
               (x ()).API.host_pending_guidances
           )
           ()
@@ -3201,13 +3201,13 @@ let host_record rpc session_id host =
           ()
       ; make_field ~name:"pending-guidances-recommended"
           ~get:(fun () ->
-            map_and_concat Record_util.update_guidance_to_string
+            map_and_concat Record_util.update_guidances_to_string
               (x ()).API.host_pending_guidances_recommended
           )
           ()
       ; make_field ~name:"pending-guidances-full"
           ~get:(fun () ->
-            map_and_concat Record_util.update_guidance_to_string
+            map_and_concat Record_util.update_guidances_to_string
               (x ()).API.host_pending_guidances_full
           )
           ()

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -468,8 +468,8 @@ module VM : HandlerTools = struct
                      ( Api_errors.vm_bad_power_state
                      , [
                          Ref.string_of vm
-                       ; Record_util.power_state_to_string `Halted
-                       ; Record_util.power_state_to_string power_state
+                       ; Record_util.vm_power_state_to_string `Halted
+                       ; Record_util.vm_power_state_to_string power_state
                        ]
                      )
                   )

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4364,7 +4364,7 @@ functor
 
       let unplug_common ~__context ~self ~force =
         let op = `unplug in
-        let name = "VIF." ^ Record_util.vif_operation_to_string op in
+        let name = "VIF." ^ Record_util.vif_operations_to_string op in
         info "%s: VIF = '%s'" name (vif_uuid ~__context self) ;
         let local_fn, remote_fn =
           if force then

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6200,7 +6200,7 @@ functor
     module SDN_controller = struct
       let introduce ~__context ~protocol ~address ~port =
         info "SDN_controller.introduce: protocol='%s', address='%s', port='%Ld'"
-          (Record_util.sdn_protocol_to_string protocol)
+          (Record_util.sdn_controller_protocol_to_string protocol)
           address port ;
         Local.SDN_controller.introduce ~__context ~protocol ~address ~port
 

--- a/ocaml/xapi/xapi_network_sriov_helpers.ml
+++ b/ocaml/xapi/xapi_network_sriov_helpers.ml
@@ -56,7 +56,7 @@ let sriov_bring_up ~__context ~self =
     in
     info "Enable network sriov on PIF %s successful, mode: %s need_reboot: %b"
       (Ref.string_of physical_pif)
-      (Record_util.network_sriov_configuration_mode_to_string mode)
+      (Record_util.sriov_configuration_mode_to_string mode)
       require_reboot ;
     Db.Network_sriov.set_configuration_mode ~__context ~self:sriov ~value:mode ;
     Db.Network_sriov.set_requires_reboot ~__context ~self:sriov

--- a/ocaml/xapi/xapi_pool_helpers.ml
+++ b/ocaml/xapi/xapi_pool_helpers.ml
@@ -138,7 +138,7 @@ let throw_error table op =
                Printf.sprintf
                  "xapi_pool_helpers.assert_operation_valid unknown operation: \
                   %s"
-                 (pool_operation_to_string op)
+                 (pool_allowed_operations_to_string op)
              ]
            )
         )
@@ -202,7 +202,7 @@ let assert_no_pool_ops ~__context =
       let err =
         ops
         |> List.map snd
-        |> List.map Record_util.pool_operation_to_string
+        |> List.map Record_util.pool_allowed_operations_to_string
         |> String.concat "; "
         |> Printf.sprintf "pool operations in progress: [ %s ]"
       in

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -310,10 +310,16 @@ let assert_not_suspended ~__context ~vm =
   if Db.VM.get_power_state ~__context ~self:vm = `Suspended then
     let expected =
       String.concat ", "
-        (List.map Record_util.power_to_string [`Halted; `Running])
+        (List.map Record_util.vm_power_state_to_lowercase_string
+           [`Halted; `Running]
+        )
     in
     let error_params =
-      [Ref.string_of vm; expected; Record_util.power_to_string `Suspended]
+      [
+        Ref.string_of vm
+      ; expected
+      ; Record_util.vm_power_state_to_lowercase_string `Suspended
+      ]
     in
     raise (Api_errors.Server_error (Api_errors.vm_bad_power_state, error_params))
 

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -235,7 +235,7 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
           snd (List.hd vdi_record.Db_actions.vDI_current_operations)
         in
         set_errors Api_errors.other_operation_in_progress
-          ["VDI"; Ref.string_of vdi; vdi_operation_to_string concurrent_op]
+          ["VDI"; Ref.string_of vdi; vdi_operations_to_string concurrent_op]
           [`attach; `plug; `insert]
     ) ;
     if

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -122,8 +122,8 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
       set_errors Api_errors.device_already_detached [_ref]
         [`unplug; `unplug_force]
   | _, _ ->
-      let actual = Record_util.power_to_string power_state in
-      let expected = Record_util.power_to_string `Running in
+      let actual = Record_util.vm_power_state_to_lowercase_string power_state in
+      let expected = Record_util.vm_power_state_to_lowercase_string `Running in
       (* If not Running, always block these operations: *)
       let bad_ops = [`plug; `unplug; `unplug_force] in
       (* However allow VBD pause and unpause if the VM is paused: *)
@@ -199,10 +199,16 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
   ( if record.Db_actions.vBD_type = `CD && power_state = `Suspended then
       let expected =
         String.concat ", "
-          (List.map Record_util.power_to_string [`Halted; `Running])
+          (List.map Record_util.vm_power_state_to_lowercase_string
+             [`Halted; `Running]
+          )
       in
       let error_params =
-        [Ref.string_of vm; expected; Record_util.power_to_string `Suspended]
+        [
+          Ref.string_of vm
+        ; expected
+        ; Record_util.vm_power_state_to_lowercase_string `Suspended
+        ]
       in
       set_errors Api_errors.vm_bad_power_state error_params [`insert; `eject]
     (* `attach required for resume *)

--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -76,7 +76,7 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
   ( if current_ops <> [] then
       let concurrent_op = List.hd current_ops in
       set_errors Api_errors.other_operation_in_progress
-        ["VBD"; _ref; vbd_operation_to_string concurrent_op]
+        ["VBD"; _ref; vbd_operations_to_string concurrent_op]
         (Listext.List.set_difference all_ops safe_to_parallelise)
   ) ;
   (* If not all operations are parallisable then preclude pause *)
@@ -88,7 +88,7 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
      parallelisable operations too *)
   if not all_are_parallelisable then
     set_errors Api_errors.other_operation_in_progress
-      ["VBD"; _ref; vbd_operation_to_string (List.hd current_ops)]
+      ["VBD"; _ref; vbd_operations_to_string (List.hd current_ops)]
       [`pause] ;
   (* If something other than `pause `unpause *and* `attach (for VM.reboot, see CA-24282) then disallow unpause *)
   if
@@ -96,7 +96,7 @@ let valid_operations ~expensive_sharing_checks ~__context record _ref' : table =
     <> []
   then
     set_errors Api_errors.other_operation_in_progress
-      ["VBD"; _ref; vbd_operation_to_string (List.hd current_ops)]
+      ["VBD"; _ref; vbd_operations_to_string (List.hd current_ops)]
       [`unpause] ;
   (* Drives marked as not unpluggable cannot be unplugged *)
   if not record.Db_actions.vBD_unpluggable then
@@ -313,7 +313,7 @@ let throw_error (table : table) op =
            , [
                Printf.sprintf
                  "xapi_vbd_helpers.assert_operation_valid unknown operation: %s"
-                 (vbd_operation_to_string op)
+                 (vbd_operations_to_string op)
              ]
            )
         )

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -247,7 +247,7 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
         if blocked_by_attach then
           Some
             ( Api_errors.vdi_in_use
-            , [_ref; Record_util.vdi_operation_to_string op]
+            , [_ref; Record_util.vdi_operations_to_string op]
             )
         else if
           (* data_destroy first waits for all the VBDs to disappear in its
@@ -961,7 +961,7 @@ let wait_for_vbds_to_be_unplugged_and_destroyed ~__context ~self ~timeout =
          ( Api_errors.vdi_in_use
          , [
              Ref.string_of self
-           ; Record_util.vdi_operation_to_string `data_destroy
+           ; Record_util.vdi_operations_to_string `data_destroy
            ]
          )
       )

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -85,8 +85,8 @@ let valid_operations ~__context record _ref' : table =
   | `Running, false ->
       set_errors Api_errors.device_already_detached [_ref] [`unplug]
   | _, _ ->
-      let actual = Record_util.power_to_string power_state in
-      let expected = Record_util.power_to_string `Running in
+      let actual = Record_util.vm_power_state_to_lowercase_string power_state in
+      let expected = Record_util.vm_power_state_to_lowercase_string `Running in
       set_errors Api_errors.vm_bad_power_state
         [Ref.string_of vm; expected; actual]
         [`plug; `unplug]

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -54,13 +54,13 @@ let valid_operations ~__context record _ref' : table =
     debug "No operations are valid because current-operations = [ %s ]"
       (String.concat "; "
          (List.map
-            (fun (task, op) -> task ^ " -> " ^ vif_operation_to_string op)
+            (fun (task, op) -> task ^ " -> " ^ vif_operations_to_string op)
             current_ops
          )
       ) ;
     let concurrent_op = snd (List.hd current_ops) in
     set_errors Api_errors.other_operation_in_progress
-      ["VIF"; _ref; vif_operation_to_string concurrent_op]
+      ["VIF"; _ref; vif_operations_to_string concurrent_op]
       all_ops
   ) ;
   (* No hotplug on dom0 *)
@@ -163,7 +163,7 @@ let throw_error (table : table) op =
            , [
                Printf.sprintf
                  "xapi_vif_helpers.assert_operation_valid unknown operation: %s"
-                 (vif_operation_to_string op)
+                 (vif_operations_to_string op)
              ]
            )
         )

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -411,8 +411,8 @@ let hard_reboot ~__context ~vm =
            ( Api_errors.vm_bad_power_state
            , [
                Ref.string_of vm
-             ; Record_util.power_to_string `Running
-             ; Record_util.power_to_string `Suspended
+             ; Record_util.vm_power_state_to_lowercase_string `Running
+             ; Record_util.vm_power_state_to_lowercase_string `Suspended
              ]
            )
         )
@@ -643,8 +643,8 @@ let create ~__context ~name_label ~name_description ~power_state ~user_version
           ( vm_bad_power_state
           , [
               Ref.string_of vm_ref
-            ; Record_util.power_to_string `Halted
-            ; Record_util.power_to_string power_state
+            ; Record_util.vm_power_state_to_lowercase_string `Halted
+            ; Record_util.vm_power_state_to_lowercase_string power_state
             ]
           )
       ) ;
@@ -1627,8 +1627,8 @@ let restart_device_models ~__context ~self =
           ( vm_bad_power_state
           , [
               Ref.string_of self
-            ; Record_util.power_state_to_string `Running
-            ; Record_util.power_state_to_string power_state
+            ; Record_util.vm_power_state_to_string `Running
+            ; Record_util.vm_power_state_to_string power_state
             ]
           )
       ) ;

--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -231,7 +231,9 @@ let quiesced = "quiesced"
 
 let snapshot_info ~power_state ~is_a_snapshot =
   let power_state_info =
-    [(power_state_at_snapshot, Record_util.power_state_to_string power_state)]
+    [
+      (power_state_at_snapshot, Record_util.vm_power_state_to_string power_state)
+    ]
   in
   if is_a_snapshot then
     (disk_snapshot_type, crash_consistent) :: power_state_info

--- a/ocaml/xapi/xapi_vm_clone.mli
+++ b/ocaml/xapi/xapi_vm_clone.mli
@@ -24,8 +24,7 @@ val disk_snapshot_type : string
 val quiesced : string
 
 val snapshot_info :
-     power_state:
-       [< `Halted | `Migrating | `Paused | `Running | `ShuttingDown | `Suspended]
+     power_state:[< `Halted | `Paused | `Running | `Suspended]
   -> is_a_snapshot:bool
   -> (string * string) list
 

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -262,9 +262,10 @@ let check_snapshot ~vmr:_ ~op ~ref_str =
 let report_power_state_error ~__context ~vmr ~power_state ~op ~ref_str =
   let expected = allowed_power_states ~__context ~vmr ~op in
   let expected =
-    String.concat ", " (List.map Record_util.power_to_string expected)
+    String.concat ", "
+      (List.map Record_util.vm_power_state_to_lowercase_string expected)
   in
-  let actual = Record_util.power_to_string power_state in
+  let actual = Record_util.vm_power_state_to_lowercase_string power_state in
   Some (Api_errors.vm_bad_power_state, [ref_str; expected; actual])
 
 let report_concurrent_operations_error ~current_ops ~ref_str =
@@ -972,8 +973,9 @@ let assert_initial_power_state_in ~__context ~self ~allowed =
          ( Api_errors.vm_bad_power_state
          , [
              Ref.string_of self
-           ; List.map Record_util.power_to_string allowed |> String.concat ";"
-           ; Record_util.power_to_string actual
+           ; List.map Record_util.vm_power_state_to_lowercase_string allowed
+             |> String.concat ";"
+           ; Record_util.vm_power_state_to_lowercase_string actual
            ]
          )
       )
@@ -992,8 +994,9 @@ let assert_final_power_state_in ~__context ~self ~allowed =
          , [
              "VM not in expected power state after completing operation"
            ; Ref.string_of self
-           ; List.map Record_util.power_to_string allowed |> String.concat ";"
-           ; Record_util.power_to_string actual
+           ; List.map Record_util.vm_power_state_to_lowercase_string allowed
+             |> String.concat ";"
+           ; Record_util.vm_power_state_to_lowercase_string actual
            ]
          )
       )

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1805,8 +1805,8 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
              ( Api_errors.vm_bad_power_state
              , [
                  Ref.string_of vm
-               ; Record_util.power_to_string `Halted
-               ; Record_util.power_to_string power_state
+               ; Record_util.vm_power_state_to_lowercase_string `Halted
+               ; Record_util.vm_power_state_to_lowercase_string power_state
                ]
              )
           ) ;

--- a/ocaml/xapi/xapi_vusb_helpers.ml
+++ b/ocaml/xapi/xapi_vusb_helpers.ml
@@ -69,8 +69,8 @@ let valid_operations ~__context record _ref' : table =
   | `Running, false ->
       set_errors Api_errors.device_already_detached [_ref] [`unplug]
   | _, _ ->
-      let actual = Record_util.power_to_string power_state in
-      let expected = Record_util.power_to_string `Running in
+      let actual = Record_util.vm_power_state_to_lowercase_string power_state in
+      let expected = Record_util.vm_power_state_to_lowercase_string `Running in
       set_errors Api_errors.vm_bad_power_state
         [Ref.string_of vm; expected; actual]
         [`plug; `unplug]

--- a/ocaml/xapi/xapi_vusb_helpers.ml
+++ b/ocaml/xapi/xapi_vusb_helpers.ml
@@ -52,13 +52,13 @@ let valid_operations ~__context record _ref' : table =
     debug "No operations are valid because current-operations = [ %s ]"
       (String.concat "; "
          (List.map
-            (fun (task, op) -> task ^ " -> " ^ vusb_operation_to_string op)
+            (fun (task, op) -> task ^ " -> " ^ vusb_operations_to_string op)
             current_ops
          )
       ) ;
     let concurrent_op = snd (List.hd current_ops) in
     set_errors Api_errors.other_operation_in_progress
-      ["VUSB"; _ref; vusb_operation_to_string concurrent_op]
+      ["VUSB"; _ref; vusb_operations_to_string concurrent_op]
       all_ops
   ) ;
   let vm = Db.VUSB.get_VM ~__context ~self:_ref' in
@@ -101,7 +101,7 @@ let throw_error (table : table) op =
                Printf.sprintf
                  "xapi_vusb_helpers.assert_operation_valid unknown operation: \
                   %s"
-                 (vusb_operation_to_string op)
+                 (vusb_operations_to_string op)
              ]
            )
         )

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -44,8 +44,8 @@ let check_power_state_is ~__context ~self ~expected =
     if actual <> expected then
       warn "Potential problem: VM %s in power state '%s' when expecting '%s'"
         (Db.VM.get_uuid ~__context ~self)
-        (Record_util.power_to_string actual)
-        (Record_util.power_to_string expected)
+        (Record_util.vm_power_state_to_lowercase_string actual)
+        (Record_util.vm_power_state_to_lowercase_string expected)
 
 let event_wait queue_name dbg ?from p =
   let finished = ref false in
@@ -2047,7 +2047,7 @@ let update_vm ~__context id =
                    changed." ;
                 should_update_allowed_operations := true ;
                 debug "xenopsd event: Updating VM %s power_state <- %s" id
-                  (Record_util.power_state_to_string power_state) ;
+                  (Record_util.vm_power_state_to_string power_state) ;
                 (* This will mark VBDs, VIFs as detached and clear resident_on
                    if the VM has permanently shutdown.  current-operations
                    should not be reset as there maybe a checkpoint is ongoing*)
@@ -3426,7 +3426,7 @@ let transform_xenops_exn ~__context ~vm queue_name f =
       | Bad_power_state (found, expected) ->
           let f x =
             xenapi_of_xenops_power_state (Some x)
-            |> Record_util.power_state_to_string
+            |> Record_util.vm_power_state_to_string
           in
           let found = f found and expected = f expected in
           reraise Api_errors.vm_bad_power_state


### PR DESCRIPTION
Best reviewed by commit - commit messages include the necessary context.

Changes can mostly be grouped into:
* Implementing autogeneration
* Removing manually-specified conversion functions that are identical to the automatically-generated ones
* Removing converters identical in function but not in form **(requires renaming usage sites)** - these are commit-per-function for ease of review, but can be squashed before merging
* Removing conversion functions that were not covered with tests **(requires also adding corresponding tests)** - these are commit-per-function
* Justifying the grim shadowing existence of the rest.

It might seem like a big patch, but most of it is removing and renaming things, with only a tiny bit of new code. Since Edwin's PR some time ago (#5349), we can now confirm the behaviour of the autogenerated code is the same as the old code, too!

It's better to autogenerate `record_util.ml` because we already have a lot of boilerplate that needs to be touched to add new things to the datamodel and CLI, this reduces the boring parts. In addition, the manual nature of this file caused duplicates (that existed since before git! And nobody noticed!), inconsistent behaviour (dots/dashes/underscores/case-sensitivity), odd cases (functions converting variants **not** in the datamodel), etc. The sooner we can get rid of the large part of this the better.