### PR TITLE
XSI-1706/CP-51295: limit open TCP connections to 250 and increase soc…

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -398,7 +398,7 @@ let pbis_db_path = "/var/lib/pbis/db/registry.db"
 let on_system_boot = ref false
 
 (* Default backlog supplied to Unix.listen *)
-let listen_backlog = 128
+let listen_backlog = 768
 
 (* Xapi script hooks root *)
 let xapi_hooks_root = ref "/etc/xapi.d"
@@ -892,9 +892,9 @@ let header_total_timeout_tcp = ref 60.
 let max_header_length_tcp = ref 1024
 (* Maximum accepted size of HTTP headers in bytes (on TCP only) *)
 
-let conn_limit_tcp = ref 800
+let conn_limit_tcp = ref 250
 
-let conn_limit_unix = ref 1024
+let conn_limit_unix = ref 250
 
 let xapi_globs_spec =
   [


### PR DESCRIPTION
…ket backlog

The default limit of 800 external TCP connections still leads to EMFILE for authenticated users.

Due to the use of Unix.select/Thread.wait_timed_read we cannot increase the file descriptor limit beyond 1024 currently.

We can assume that each API call needs at least 4 file descriptors:
  * 1 for the TCP connection that received the API call
  * another for system calls, or talking to member hosts
  * SMAPIv1 will also require at least one connection back to XAPI, which will needs its own thread, and at least 1 file descriptor to perform certain operations

An API call could of course need more file descriptors than these, the real solution is to move to poll(2)/epoll(2) which doesn't have the 1024 limit that select(2) does.

However meanwhile this prevents problems that users have reported.

The downside is that users may now get client-side TCP errors if they open too many connections, but that is better than causing errors on unrelated API calls. To compensate increase the socket backlog from the default 128.

Due to the old kernel that Dom0 runs this will also require changing 'somaxconn' in /etc/sysctl.d/90-dom0.conf, but this is not controlled by XAPI.