### PR TITLE
http-lib: log reason that causes lack of response

### DIFF
--- a/ocaml/libs/http-lib/http_client.ml
+++ b/ocaml/libs/http-lib/http_client.ml
@@ -187,7 +187,9 @@ let response_of_fd ?(use_fastpath = false) fd =
   with
   | Unix.Unix_error (_, _, _) as e ->
       raise e
-  | _ ->
+  | e ->
+      D.debug "%s: returning no response because of the exception: %s"
+        __FUNCTION__ (Printexc.to_string e) ;
       None
 
 (** See perftest/tests.ml *)


### PR DESCRIPTION
Otherwise users are nonthewiser when a long migration fails. With this change and a reproduction we can have the chance to understand the issue and maybe fix it.