### PR TITLE
quicktest: disable open 1024 fds on startup for now

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
@@ -286,4 +286,5 @@ let tests =
 let () =
   (* avoid SIGPIPE *)
   let (_ : Sys.signal_behavior) = Sys.signal Sys.sigpipe Sys.Signal_ignore in
-  Xapi_stdext_unix.Unixext.test_open 1024
+  (* TODO: reenable once the epoll branch is merged Xapi_stdext_unix.Unixext.test_open 1024 *)
+  ()


### PR DESCRIPTION
We've enabled running the unixext tests in quicktest. They open 1024 file descriptors on startup to check for the absence of select. And although that works for unixext (it is select-free), it doesn't yet work for the rest of quicktests on master (the required changes to make it work are on the epoll branch).

Temporarily disable this test and add a note to reenable it on the epoll branch.

Fixes: efcb7af9d9d2 ("CP-50448: run the QuickCheck tests in QuickTest")