### PR TITLE
Tracing: optimize and reduce overhead

### DIFF
--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -197,7 +197,12 @@ end = struct
 
   let make = Random.bits64
 
-  let of_string s = Scanf.sscanf s "%Lx" Fun.id
+  let of_string s =
+    try Scanf.sscanf s "%Lx" Fun.id
+    with e ->
+      D.debug "Failed to parse span id %s: %s" s (Printexc.to_string e) ;
+      (* don't cause XAPI to fail *)
+      0L
 
   let to_string = Printf.sprintf "%016Lx"
 

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -393,19 +393,6 @@ module Spans = struct
 
   let mark_finished span = Option.iter add_to_finished (remove_from_spans span)
 
-  let span_is_finished x =
-    match x with
-    | None ->
-        false
-    | Some (span : Span.t) ->
-        Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
-            match Hashtbl.find_opt finished_spans span.context.trace_id with
-            | None ->
-                false
-            | Some span_list ->
-                List.mem span span_list
-        )
-
   (** since copies the existing finished spans and then clears the existing spans as to only export them once  *)
   let since () =
     Xapi_stdext_threads.Threadext.Mutex.execute lock (fun () ->
@@ -659,8 +646,6 @@ module Tracer = struct
          )
          span
       )
-
-  let span_is_finished x = Spans.span_is_finished x
 
   let span_hashtbl_is_empty () = Spans.span_hashtbl_is_empty ()
 

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -135,6 +135,10 @@ end
 module Attributes = struct
   include Map.Make (String)
 
+  let merge_element map (key, value) = add key value map
+
+  let merge_into into list = List.fold_left merge_element into list
+
   let of_list list = List.to_seq list |> of_seq
 
   let to_assoc_list attr = to_seq attr |> List.of_seq
@@ -646,10 +650,7 @@ module Tracer = struct
     if not t.enabled then
       ok_none
     else
-      let attributes = Attributes.of_list attributes in
-      let attributes =
-        Attributes.union (fun _k a _b -> Some a) attributes t.attributes
-      in
+      let attributes = Attributes.merge_into t.attributes attributes in
       let span = Span.start ~attributes ~name ~parent ~span_kind () in
       Spans.add_to_spans ~span ; Ok (Some span)
 

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -54,18 +54,40 @@ module SpanEvent : sig
   type t = {name: string; time: float; attributes: string Attributes.t}
 end
 
-module SpanContext : sig
+module Span_id : sig
   type t
 
-  val context : string -> string -> t
+  val make : unit -> t
+
+  val compare : t -> t -> int
+
+  val of_string : string -> t
+
+  val to_string : t -> string
+end
+
+module Trace_id : sig
+  type t
+
+  val make : unit -> t
+
+  val compare : t -> t -> int
+
+  val of_string : string -> t
+
+  val to_string : t -> string
+end
+
+module SpanContext : sig
+  type t
 
   val to_traceparent : t -> string
 
   val of_traceparent : string -> t option
 
-  val trace_id_of_span_context : t -> string
+  val trace_id_of_span_context : t -> Trace_id.t
 
-  val span_id_of_span_context : t -> string
+  val span_id_of_span_context : t -> Span_id.t
 end
 
 module Span : sig
@@ -105,10 +127,9 @@ module Spans : sig
 
   val span_count : unit -> int
 
-  val since : unit -> (string, Span.t list) Hashtbl.t
+  val since : unit -> Span.t list * int
 
-  val dump :
-    unit -> (string, Span.t list) Hashtbl.t * (string, Span.t list) Hashtbl.t
+  val dump : unit -> (Trace_id.t, Span.t list) Hashtbl.t * (Span.t list * int)
 end
 
 module Tracer : sig

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -120,6 +120,8 @@ module Span : sig
   val get_attributes : t -> (string * string) list
 end
 
+module SpanMap : module type of Map.Make (Trace_id)
+
 module Spans : sig
   val set_max_spans : int -> unit
 
@@ -129,7 +131,7 @@ module Spans : sig
 
   val since : unit -> Span.t list * int
 
-  val dump : unit -> (Trace_id.t, Span.t list) Hashtbl.t * (Span.t list * int)
+  val dump : unit -> Span.t list SpanMap.t * (Span.t list * int)
 end
 
 module Tracer : sig

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -120,7 +120,9 @@ module Span : sig
   val get_attributes : t -> (string * string) list
 end
 
-module SpanMap : module type of Map.Make (Trace_id)
+module TraceMap : module type of Map.Make (Trace_id)
+
+module SpanMap : module type of Map.Make (Span_id)
 
 module Spans : sig
   val set_max_spans : int -> unit
@@ -131,7 +133,7 @@ module Spans : sig
 
   val since : unit -> Span.t list * int
 
-  val dump : unit -> Span.t list SpanMap.t * (Span.t list * int)
+  val dump : unit -> Span.t SpanMap.t TraceMap.t * (Span.t list * int)
 end
 
 module Tracer : sig

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -140,8 +140,6 @@ module Tracer : sig
   val finish :
     ?error:exn * string -> Span.t option -> (Span.t option, exn) result
 
-  val span_is_finished : Span.t option -> bool
-
   val span_hashtbl_is_empty : unit -> bool
 
   val finished_span_hashtbl_is_empty : unit -> bool

--- a/ocaml/libs/tracing/tracing_export.ml
+++ b/ocaml/libs/tracing/tracing_export.ml
@@ -83,13 +83,24 @@ module Content = struct
              )
         in
         {
-          id= s |> Span.get_context |> SpanContext.span_id_of_span_context
-        ; traceId= s |> Span.get_context |> SpanContext.trace_id_of_span_context
+          id=
+            s
+            |> Span.get_context
+            |> SpanContext.span_id_of_span_context
+            |> Span_id.to_string
+        ; traceId=
+            s
+            |> Span.get_context
+            |> SpanContext.trace_id_of_span_context
+            |> Trace_id.to_string
         ; parentId=
             s
             |> Span.get_parent
             |> Option.map (fun x ->
-                   x |> Span.get_context |> SpanContext.span_id_of_span_context
+                   x
+                   |> Span.get_context
+                   |> SpanContext.span_id_of_span_context
+                   |> Span_id.to_string
                )
         ; name= s |> Span.get_name
         ; timestamp= int_of_float (Span.get_begin_time s *. 1000000.)
@@ -248,9 +259,7 @@ module Destination = struct
             | Bugtool ->
                 (file_export, "Tracing.File.export")
           in
-          let all_spans =
-            Hashtbl.fold (fun _ spans acc -> spans @ acc) traces []
-          in
+          let all_spans, count = traces in
           let attributes =
             [
               ("export.span.count", all_spans |> List.length |> string_of_int)
@@ -258,9 +267,7 @@ module Destination = struct
             ; ( "xs.tracing.spans_table.count"
               , Spans.span_count () |> string_of_int
               )
-            ; ( "xs.tracing.finished_spans_table.count"
-              , traces |> Hashtbl.length |> string_of_int
-              )
+            ; ("xs.tracing.finished_spans_table.count", string_of_int count)
             ]
           in
           let@ _ = with_tracing ~parent ~attributes ~name in
@@ -273,17 +280,15 @@ module Destination = struct
       debug "Tracing: unable to export span : %s" (Printexc.to_string exn)
 
   let flush_spans () =
-    let span_list = Spans.since () in
-    let attributes =
-      [("export.traces.count", Hashtbl.length span_list |> string_of_int)]
-    in
+    let ((_span_list, span_count) as span_info) = Spans.since () in
+    let attributes = [("export.traces.count", string_of_int span_count)] in
     let@ parent =
       with_tracing ~parent:None ~attributes ~name:"Tracing.flush_spans"
     in
     TracerProvider.get_tracer_providers ()
     |> List.filter TracerProvider.get_enabled
     |> List.concat_map TracerProvider.get_endpoints
-    |> List.iter (export_to_endpoint parent span_list)
+    |> List.iter (export_to_endpoint parent span_info)
 
   let delay = Delay.make ()
 

--- a/ocaml/tests/bench/bechamel_simple_cli.ml
+++ b/ocaml/tests/bench/bechamel_simple_cli.ml
@@ -1,0 +1,153 @@
+open Bechamel
+open Toolkit
+
+(* Bechamel doesn't provide before/after hooks, just allocate/free, but those are done outside the place where
+   Bechamel checks for GC live words stabilization.
+*)
+let before_after ~before ~after ~get ~label ~unit =
+  let shared_state = Atomic.make None and called = Atomic.make 0 in
+  let module BeforeAfter = struct
+    type witness = int Atomic.t
+
+    let make () = Atomic.make 0
+
+    let load t = Atomic.set t 0
+
+    let unload _ = ()
+
+    let label _ = label
+
+    let unit _ = unit
+
+    let get _ =
+      (*
+        We get added to the instances both at the beginning and the end, so we get called 4 times:
+
+        get () - 0: None -> state := before ()
+        time ()
+        get () - 1
+        
+        benchmark_loop ()
+
+        get () - 2
+        time ()
+        get () - 3, after state, state := None
+
+        We want the time measurement to be as close to the benchmark loop as possible,
+        so we perform operations only on call 1 and 4
+      *)
+      let phase = Atomic.fetch_and_add called 1 mod 4 in
+      let old = Atomic.get shared_state in
+      match (old, phase) with
+      | None, 0 ->
+          before () |> Option.some |> Atomic.set shared_state ;
+          0.
+      | Some state, (1 | 2) ->
+          get state
+      | Some state, 3 ->
+          let r = get state in
+          Atomic.set shared_state None ;
+          after state ;
+          r
+      | None, _ ->
+          assert false
+      | Some _, _ ->
+          assert false
+  end in
+  let measure = Measure.register (module BeforeAfter) in
+  Measure.instance (module BeforeAfter) measure
+
+let skip_label = "workload"
+
+let thread_workload ~before ~run ~after =
+  let before () =
+    let state = before ()
+    and stop = Atomic.make false
+    and loops = Atomic.make 0 in
+    let thread_worker () =
+      while not (Atomic.get stop) do
+        Sys.opaque_identity (run state : unit) ;
+        Atomic.incr loops
+      done
+    in
+    let t = Thread.create thread_worker () in
+    (state, stop, loops, t)
+  and after (state, stop, _loops, worker) =
+    Atomic.set stop true ; Thread.join worker ; after state
+  and get (_, _, loops, _) = Atomic.fetch_and_add loops 1 |> float_of_int in
+  before_after ~before ~after ~get ~label:skip_label ~unit:"loops"
+
+(* based on bechamel example code *)
+
+(* For very short benchmarks ensure that they get to run long enough to switch threads
+   a few times.
+    Bechamel has both an iteration count and time limit, so this won't be a problem for slower benchmarks.
+*)
+let limit = 10_000_000
+
+let benchmark ~instances tests =
+  let cfg = Benchmark.cfg ~limit ~quota:(Time.second 10.0) () in
+  Benchmark.all cfg instances tests
+
+let analyze ~instances raw_results =
+  let ols ~bootstrap =
+    Analyze.ols ~bootstrap ~r_square:true ~predictors:[|Measure.run|]
+  in
+  let results =
+    List.map
+      (fun instance ->
+        let f bootstrap = Analyze.all (ols ~bootstrap) instance raw_results in
+        try f 3000 with _ -> f 0
+      )
+      instances
+  in
+  (Analyze.merge (ols ~bootstrap:3000) instances results, raw_results)
+
+open Notty_unix
+
+let img (window, results) =
+  Bechamel_notty.Multiple.image_of_ols_results ~rect:window
+    ~predictor:Measure.run results
+  |> eol
+
+let not_workload measure = not (Measure.label measure = skip_label)
+
+let run_and_print instances tests =
+  let results, _ =
+    tests
+    |> benchmark ~instances
+    |> analyze ~instances:(List.filter not_workload instances)
+  in
+  let window =
+    match winsize Unix.stdout with
+    | Some (w, h) ->
+        {Bechamel_notty.w; h}
+    | None ->
+        {Bechamel_notty.w= 80; h= 1}
+  in
+  img (window, results) |> eol |> output_image ;
+  results
+  |> Hashtbl.iter @@ fun label results ->
+     if label = Measure.label Instance.monotonic_clock then
+       let units = Bechamel_notty.Unit.unit_of_label label in
+       results
+       |> Hashtbl.iter @@ fun name ols ->
+          Format.printf "%s (%s):@, %a@." name units Analyze.OLS.pp ols
+
+let cli ?(always = []) ?(workloads = []) tests =
+  let instances =
+    always
+    @ Instance.[monotonic_clock; minor_allocated; major_allocated]
+    @ always
+  in
+  List.iter (fun i -> Bechamel_notty.Unit.add i (Measure.unit i)) instances ;
+  Format.printf "@,Running benchmarks (no workloads)@." ;
+  run_and_print instances tests ;
+
+  if workloads <> [] then (
+    Format.printf "@,Running benchmarks (workloads)@." ;
+    List.iter (fun i -> Bechamel_notty.Unit.add i (Measure.unit i)) workloads ;
+    (* workloads come first, so that we unpause them in time *)
+    let instances = workloads @ instances @ workloads in
+    run_and_print instances tests
+  )

--- a/ocaml/tests/bench/bench_tracing.ml
+++ b/ocaml/tests/bench/bench_tracing.ml
@@ -1,0 +1,87 @@
+open Bechamel
+
+let ( let@ ) f x = f x
+
+(* TODO: before *)
+
+let trace_test_inner span =
+  let@ span =
+    Tracing.with_child_trace
+      ~attributes:[("foo", "testing")]
+      span ~name:__FUNCTION__
+  in
+  let@ _ =
+    Tracing.with_child_trace ~attributes:[("bar", "val")] span ~name:"test"
+  in
+  Sys.opaque_identity ignore ()
+
+let trace_test_span _ = Tracing.with_tracing ~name:__FUNCTION__ trace_test_inner
+
+let trace_test_off _ = trace_test_inner None
+
+let uuid = "TEST"
+
+let export_thread =
+  (* need to ensure this isn't running outside the benchmarked section,
+     or bechamel might fail with 'Failed to stabilize GC'
+  *)
+  let after _ = Tracing_export.flush_and_exit () in
+  Bechamel_simple_cli.thread_workload ~before:Tracing_export.main ~after
+    ~run:ignore
+
+let workload1 =
+  Bechamel_simple_cli.thread_workload ~before:ignore ~after:ignore
+    ~run:trace_test_span
+
+let create_gc_work =
+  let a = Array.make 1_000 "" in
+  fun () ->
+    (* create work for the GC by continously creating a lot of short lived strings *)
+    Sys.opaque_identity (Array.iteri (fun i _ -> a.(i) <- String.make 2 'x') a)
+
+let workload2 =
+  Bechamel_simple_cli.thread_workload ~before:ignore ~after:ignore
+    ~run:create_gc_work
+
+let workloads = [workload1; workload2]
+
+let allocate () =
+  Tracing.TracerProvider.create ~enabled:true ~attributes:[] ~endpoints:[]
+    ~name_label:__MODULE__ ~uuid ;
+  Tracing_export.main ()
+
+let free t =
+  Tracing.TracerProvider.destroy ~uuid ;
+  Tracing_export.flush_and_exit () ;
+  Thread.join t
+
+let test_tracing_on ?(overflow = false) ~name f =
+  let allocate () =
+    if overflow then (
+      Tracing.Spans.set_max_spans 10 ;
+      Tracing.Spans.set_max_traces 10
+    ) ;
+    allocate ()
+  and free t =
+    if overflow then (
+      Tracing.Spans.set_max_spans Bechamel_simple_cli.limit ;
+      Tracing.Spans.set_max_traces Bechamel_simple_cli.limit
+    ) ;
+    free t
+  in
+  Test.make_with_resource ~name ~allocate ~free Test.uniq f
+
+let benchmarks =
+  Tracing.Spans.set_max_spans Bechamel_simple_cli.limit ;
+  Tracing.Spans.set_max_traces Bechamel_simple_cli.limit ;
+  Test.make_grouped ~name:"tracing"
+    [
+      Test.make ~name:"overhead(off)" (Staged.stage trace_test_off)
+    ; test_tracing_on ~name:"overhead(on, no span)" (Staged.stage trace_test_off)
+    ; test_tracing_on ~name:"overhead(on, create span)"
+        (Staged.stage trace_test_span)
+    ; test_tracing_on ~overflow:true ~name:"max span overflow"
+        (Staged.stage trace_test_span)
+    ]
+
+let () = Bechamel_simple_cli.cli ~always:[export_thread] ~workloads benchmarks

--- a/ocaml/tests/bench/dune
+++ b/ocaml/tests/bench/dune
@@ -1,0 +1,4 @@
+(executable
+	(name bench_tracing)
+	(libraries tracing bechamel bechamel-notty notty.unix tracing_export threads.posix fmt notty)
+)

--- a/ocaml/tests/test_observer.ml
+++ b/ocaml/tests/test_observer.ml
@@ -385,15 +385,15 @@ let test_all_spans_finish () =
   let _ = List.map (fun span -> Tracer.finish span) trace_spans in
   let remaining_spans, finished_spans = Spans.dump () in
   let result =
-    SpanMap.fold
-      (fun _k v acc -> snd finished_spans = List.length v && acc)
+    TraceMap.fold
+      (fun _k v acc -> snd finished_spans = SpanMap.cardinal v && acc)
       active_spans true
   in
   Alcotest.(check bool)
     "All spans that are finished are moved to finished_spans" true result ;
   Alcotest.(check int)
     "traces with no spans are removed from the hashtable" 0
-    (SpanMap.cardinal remaining_spans) ;
+    (TraceMap.cardinal remaining_spans) ;
   test_destroy ~__context ~self ()
 
 let test_hashtbl_leaks () =

--- a/ocaml/tests/test_observer.ml
+++ b/ocaml/tests/test_observer.ml
@@ -385,7 +385,7 @@ let test_all_spans_finish () =
   let _ = List.map (fun span -> Tracer.finish span) trace_spans in
   let remaining_spans, finished_spans = Spans.dump () in
   let result =
-    Hashtbl.fold
+    SpanMap.fold
       (fun _k v acc -> snd finished_spans = List.length v && acc)
       active_spans true
   in
@@ -393,7 +393,7 @@ let test_all_spans_finish () =
     "All spans that are finished are moved to finished_spans" true result ;
   Alcotest.(check int)
     "traces with no spans are removed from the hashtable" 0
-    (Hashtbl.length remaining_spans) ;
+    (SpanMap.cardinal remaining_spans) ;
   test_destroy ~__context ~self ()
 
 let test_hashtbl_leaks () =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1019,7 +1019,7 @@ let trace_log_dir = ref "/var/log/dt/zipkinv2/json"
 
 let export_interval = ref 30.
 
-let max_spans = ref 1000
+let max_spans = ref 10000
 
 let max_traces = ref 10000
 


### PR DESCRIPTION
We've noticed some delays when tracing is enabled, and suspected it is due to lock contention or GC activity created by the tracing module itself.

I've added some benchmarks to measure the overhead of tracing, and made some improvements (more improvements are possible).
The benchmarks test both a situation with no workload, and a situation with 2 other threads: one running the same workload as the function under test, and another that runs a very GC intensive workload.

Improved:
* when max spans limit is hit: don't spam syslog. Time goes down from  202 *milli*seconds to 14 *micro*seconds per span
* reduce lock contention: eliminate one global lock, replace with atomic ops
* reduce allocation

We are now at ~9µs/nested span on this particular machine, but further improvements are possible by delaying work to the exporter thread and finishing really quickly otherwise (e.g. upstream ocaml-trace claims ~60ns/span).

When tracing is disabled the overhead is very small, just like before (on the order of 20ns without a workload).

Before:
```
Running benchmarks (no workloads)
╭─────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                 │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├─────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  tracing/max span overflow          │             0.0000 mjw/run│          1187.0000 mnw/run│       96214066.4652 ns/run│
│  tracing/overhead(off)              │             0.0000 mjw/run│            14.0000 mnw/run│             19.0061 ns/run│
│  tracing/overhead(on, create span)  │             2.9250 mjw/run│           496.3888 mnw/run│          25431.5210 ns/run│
│  tracing/overhead(on, no span)      │             0.0000 mjw/run│            14.0000 mnw/run│             18.8063 ns/run│
╰─────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯

tracing/overhead(on, no span) (ns):
 { monotonic-clock per run = 18.806282 (confidence: 20.597860 to 16.986898);
   r² = Some 0.63699 }
tracing/max span overflow (ns):
 { monotonic-clock per run = 96214066.465201 (confidence: 125336685.666667 to 70136316.380165);
   r² = Some 0.518256 }
tracing/overhead(off) (ns):
 { monotonic-clock per run = 19.006133 (confidence: 20.619355 to 17.390492);
   r² = Some 0.667542 }
tracing/overhead(on, create span) (ns):
 { monotonic-clock per run = 25431.521030 (confidence: 37607.254799 to 15151.227932);
   r² = Some 0.0329005 }

Running benchmarks (workloads)
╭─────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                 │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├─────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  tracing/max span overflow          │         80934.7363 mjw/run│      10580588.4725 mnw/run│      202271848.5714 ns/run│
│  tracing/overhead(off)              │             0.0000 mjw/run│            16.5479 mnw/run│            212.0958 ns/run│
│  tracing/overhead(on, create span)  │             0.0000 mjw/run│           503.4400 mnw/run│          15633.2400 ns/run│
│  tracing/overhead(on, no span)      │             0.0000 mjw/run│            18.3256 mnw/run│            326.9568 ns/run│
╰─────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯

tracing/overhead(on, no span) (ns):
 { monotonic-clock per run = 326.956811; r² = Some -9.40099 }
tracing/max span overflow (ns):
 { monotonic-clock per run = 202271848.571429; r² = Some 0.065489 }
tracing/overhead(off) (ns):
 { monotonic-clock per run = 212.095829; r² = Some -4.46794 }
tracing/overhead(on, create span) (ns):
 { monotonic-clock per run = 15633.240000; r² = Some 0.805726 }
```

After:
```
Running benchmarks (no workloads)
╭─────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                 │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├─────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  tracing/max span overflow          │             0.0964 mjw/run│           379.0196 mnw/run│          14479.0371 ns/run│
│  tracing/overhead(off)              │             0.0000 mjw/run│            14.0000 mnw/run│             18.2174 ns/run│
│  tracing/overhead(on, create span)  │             0.0000 mjw/run│           397.3440 mnw/run│          14712.1307 ns/run│
│  tracing/overhead(on, no span)      │             0.0000 mjw/run│            14.0000 mnw/run│             18.1771 ns/run│
╰─────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯

tracing/overhead(on, no span) (ns):
 { monotonic-clock per run = 18.177093 (confidence: 19.990180 to 16.374104);
   r² = Some 0.600249 }
tracing/max span overflow (ns):
 { monotonic-clock per run = 14479.037101 (confidence: 15625.053708 to 13293.667720);
   r² = Some 0.635766 }
tracing/overhead(off) (ns):
 { monotonic-clock per run = 18.217390 (confidence: 19.845841 to 16.442527);
   r² = Some 0.642373 }
tracing/overhead(on, create span) (ns):
 { monotonic-clock per run = 14712.130670 (confidence: 23416.444172 to 7426.891454);
   r² = Some 0.0476263 }

Running benchmarks (workloads)
╭─────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                 │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├─────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  tracing/max span overflow          │             0.0000 mjw/run│           380.4429 mnw/run│           7658.2207 ns/run│
│  tracing/overhead(off)              │             0.0000 mjw/run│            15.3007 mnw/run│            102.2479 ns/run│
│  tracing/overhead(on, create span)  │             0.0000 mjw/run│           400.5094 mnw/run│           8657.5585 ns/run│
│  tracing/overhead(on, no span)      │             0.0000 mjw/run│            18.1333 mnw/run│            373.9794 ns/run│
╰─────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯

tracing/overhead(on, no span) (ns):
 { monotonic-clock per run = 373.979447 (confidence: 435.400802 to 336.056569);
   r² = Some -1.84338 }
tracing/max span overflow (ns):
 { monotonic-clock per run = 7658.220695 (confidence: 7952.878804 to 7396.117711);
   r² = Some 0.950954 }
tracing/overhead(off) (ns):
 { monotonic-clock per run = 102.247932 (confidence: 119.364768 to 89.830417);
   r² = Some -0.607146 }
tracing/overhead(on, create span) (ns):
 { monotonic-clock per run = 8657.558458 (confidence: 8904.596470 to 8435.216348);
   r² = Some 0.956299 }
```

Draft PR, this was only unit tested so far.