### PR TITLE
CP-50633 Auto configure certification for WLB

### DIFF
--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -146,6 +146,7 @@
     sexplib0
     sexpr
     sha
+    ssl
     stunnel
     tapctl
     tar


### PR DESCRIPTION
Currently, customers must manually import WLB certificates to establish secure communication between WLB and XenServer. This manual process is both time-consuming and prone to errors, potentially compromising the security and reliability of the system.

This PR automates the process of fetching and installing WLB certificates during an SSL/TLS connection. we eliminate the need for manual intervention, streamlining the setup process and reducing the risk of configuration errors.

Security Assurance:
1. The server address and port are explicitly defined by the user within XenCenter, ensuring that the certificate is fetched and installed for the correct target as verified by the user.
2. The WLB uses a self-signed certificate, which cannot be validated by an external root certificate authority. I believe for a root/self-signed, secure is ensured by TOFU (trust-on-first-use)
3. A basic validation step is performed during the installation to verify the integrity of the certificate. an outside third-party CA-cert will not be installed.

