### PR TITLE
xe autocompletion: Only show required/optional prefixes when parameter name is empty

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -617,7 +617,9 @@ _xe()
         __xe_debug "triggering autocompletion for parameter names, param is '$param'"
 
         IFS=$'\n,'
-        REQD_OPTIONAL_PARAMS=1
+        if [ ! "$param" ]; then
+            REQD_OPTIONAL_PARAMS=1
+        fi
         get_params_for_command "${OLDSTYLE_WORDS[1]}"
 
         # Don't suggest already provided parameters


### PR DESCRIPTION
Otherwise, these prefixes break autocompletion of common prefixes, like in:
```
$ xe pool-param-get <TAB>
OPTIONAL: database:    REQUIRED: param-name=
OPTIONAL: param-key=   REQUIRED: uuid=

$ xe pool-param-get p<TAB> <- gets autocompleted before showing further suggestions
$ xe pool-param-get param-
param-key=   param-name=
```

Without this fix, instead worked like this:
```
$ xe pool-param-get <TAB>
OPTIONAL: database:    REQUIRED: param-name=
OPTIONAL: param-key=   REQUIRED: uuid=

$ xe pool-param-get p<TAB> <-- no prefix autocompletion
OPTIONAL: param-key=   REQUIRED: param-name=
```

This is a temporary workaround, since upgrading bash would allow us to show prefixes as section headers without polluting suggested words themselves.