### PR TITLE
xe autocompletion: Exclude previously entered parameters before deciding whether to show optionality of the parameters

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -814,14 +814,13 @@ set_completions()
     if [[ $REQD_OPTIONAL_PARAMS == 1 ]]; then
         local reqd_params=$( __preprocess_suggestions "$REQD_PARAMS" )
         local opt_params=$( __preprocess_suggestions "$OPT_PARAMS" )
+        if [[ "$excludes" ]]; then
+            reqd_params=$(echo "$reqd_params" | eval "grep -v $excludes")
+            opt_params=$(echo "$opt_params" | eval "grep -v $excludes")
+        fi
         if [[ "$reqd_params" && "$opt_params" ]]; then
             __xe_debug "showing optional/required parameters"
             SHOW_DESCRIPTION=1
-
-            if [[ "$excludes" ]]; then
-                reqd_params=$(echo "$reqd_params" | eval "grep -v $excludes")
-                opt_params=$(echo "$opt_params" | eval "grep -v $excludes")
-            fi
 
             for word in $reqd_params; do
                 __add_completion "$word" "REQUIRED" "$max_cmd_length"


### PR DESCRIPTION

Fixes the bug when optionality of parameters would be shown when all the remaining parameters were of the same category, autocompleting the noise:
```
$ xe vm-param-get <TAB>
OPTIONAL: database:    REQUIRED: param-name=
OPTIONAL: param-key=   REQUIRED: uuid=

$ xe vm-param-get param-name=SMTH uuid=SMTH <TAB> <- automatically completes to
$ xe vm-param-get param-name=SMTH uuid=SMTH OPTIONAL:
```

Now works as intended:
```
$ xe vm-param-get param-name=SMTH uuid=SMTH <TAB>
database:   param-key=
```

=====

Cmdliner might be getting some support for generating generic autocompletion scripts (https://github.com/dbuenzli/cmdliner/pull/187), and dune has been exploring this as well (https://github.com/ocaml/dune/pull/6377). Go and Python CLI tooling has had this for a long time (https://github.com/spf13/cobra/blob/main/site/content/completions/_index.md, https://click.palletsprojects.com/en/8.1.x/shell-completion/).

The amount of tiny regressions that slipped through (and more that I haven't noticed) have convinced me that we should move this logic from BASH into xe's frontend, provide tests for it, and generate tiny scripts for bash, zsh, PowerShell calling out to `xe` instead of maintaining this monstrosity (it's relatively easy to debug it now with the facilities I've added, but still impossible to guarantee something hasn't slipped through).