### PR TITLE
IH-666: Report guest AD domain name and host name in the API

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5175,6 +5175,10 @@ module VM_guest_metrics = struct
             "os_version" "version of the OS"
         ; field ~qualifier:DynamicRO
             ~ty:(Map (String, String))
+            ~lifecycle:[] "netbios_name" "The NETBIOS name of the machine"
+            ~default_value:(Some (VMap []))
+        ; field ~qualifier:DynamicRO
+            ~ty:(Map (String, String))
             "PV_drivers_version" "version of the PV drivers"
         ; field ~qualifier:DynamicRO ~ty:Bool ~in_oss_since:None
             ~lifecycle:

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -67,6 +67,8 @@ let prototyped_of_field = function
       Some "22.27.0"
   | "host", "last_software_update" ->
       Some "22.20.0"
+  | "VM_guest_metrics", "netbios_name" ->
+      Some "24.27.0-next"
   | "VM", "groups" ->
       Some "24.19.1"
   | "VM", "pending_guidances_full" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "4417b0087b481c3038e73f170b7d4d01"
+let last_known_schema_hash = "ce370e3b85178acfbcfce4963c4f8534"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -2301,6 +2301,18 @@ let vm_record rpc session_id vm =
               (xgm ())
           )
           ()
+      ; make_field ~name:"netbios-name"
+          ~get:(fun () ->
+            Option.fold ~none:nid
+              ~some:(fun m -> get_from_map m.API.vM_guest_metrics_netbios_name)
+              (xgm ())
+          )
+          ~get_map:(fun () ->
+            Option.fold ~none:[]
+              ~some:(fun m -> m.API.vM_guest_metrics_netbios_name)
+              (xgm ())
+          )
+          ()
       ; make_field ~name:"PV-drivers-version"
           ~get:(fun () ->
             Option.fold ~none:nid

--- a/ocaml/xapi/import.ml
+++ b/ocaml/xapi/import.ml
@@ -788,6 +788,7 @@ module GuestMetrics : HandlerTools = struct
     Db.VM_guest_metrics.create ~__context ~ref:gm
       ~uuid:(Uuidx.to_string (Uuidx.make ()))
       ~os_version:gm_record.API.vM_guest_metrics_os_version
+      ~netbios_name:gm_record.API.vM_guest_metrics_netbios_name
       ~pV_drivers_version:gm_record.API.vM_guest_metrics_PV_drivers_version
       ~pV_drivers_up_to_date:
         gm_record.API.vM_guest_metrics_PV_drivers_up_to_date

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -68,6 +68,10 @@ let os_version =
     ("attr/os/spminor", "spminor") (* windows *)
   ]
 
+let netbios_name = [("data/host_name_dns", "host_name")]
+
+let dns_domain = [("data/domain", "dns_domain")]
+
 let memory = [("data/meminfo_free", "free"); ("data/meminfo_total", "total")]
 
 let device_id = [("data/device_id", "device_id")]
@@ -215,6 +219,7 @@ type m = (string * string) list
 type guest_metrics_t = {
     pv_drivers_version: m
   ; os_version: m
+  ; netbios_name: m
   ; networks: m
   ; other: m
   ; memory: m
@@ -269,6 +274,14 @@ let get_initial_guest_metrics (lookup : string -> string option)
   in
   let pv_drivers_version = to_map pv_drivers_version
   and os_version = to_map os_version
+  and netbios_name =
+    match to_map dns_domain with
+    | [] ->
+        to_map netbios_name
+    | (_, dns_domain) :: _ ->
+        List.map
+          (fun (k, v) -> (k, Printf.sprintf "%s.%s" v dns_domain))
+          (to_map netbios_name)
   and device_id = to_map device_id
   and networks =
     to_map
@@ -294,6 +307,7 @@ let get_initial_guest_metrics (lookup : string -> string option)
   {
     pv_drivers_version
   ; os_version
+  ; netbios_name
   ; networks
   ; other
   ; memory
@@ -311,7 +325,7 @@ let create_and_set_guest_metrics (lookup : string -> string option)
   let new_gm_uuid = Uuidx.to_string (Uuidx.make ())
   and new_gm_ref = Ref.make () in
   Db.VM_guest_metrics.create ~__context ~ref:new_gm_ref ~uuid:new_gm_uuid
-    ~os_version:initial_gm.os_version
+    ~os_version:initial_gm.os_version ~netbios_name:initial_gm.netbios_name
     ~pV_drivers_version:initial_gm.pv_drivers_version
     ~pV_drivers_up_to_date:pV_drivers_detected ~memory:[] ~disks:[]
     ~networks:initial_gm.networks ~pV_drivers_detected ~other:initial_gm.other
@@ -339,6 +353,7 @@ let all (lookup : string -> string option) (list : string -> string list)
   let {
     pv_drivers_version
   ; os_version
+  ; netbios_name
   ; networks
   ; other
   ; memory
@@ -372,6 +387,7 @@ let all (lookup : string -> string option) (list : string -> string list)
             {
               pv_drivers_version= []
             ; os_version= []
+            ; netbios_name= []
             ; networks= []
             ; other= []
             ; memory= []
@@ -388,6 +404,7 @@ let all (lookup : string -> string option) (list : string -> string list)
         {
           pv_drivers_version
         ; os_version
+        ; netbios_name
         ; networks
         ; other
         ; memory
@@ -401,6 +418,7 @@ let all (lookup : string -> string option) (list : string -> string list)
   if
     (guest_metrics_cached.pv_drivers_version <> pv_drivers_version
     || guest_metrics_cached.os_version <> os_version
+    || guest_metrics_cached.netbios_name <> netbios_name
     || guest_metrics_cached.networks <> networks
     || guest_metrics_cached.other <> other
     || guest_metrics_cached.device_id <> device_id
@@ -431,6 +449,9 @@ let all (lookup : string -> string option) (list : string -> string list)
         ~value:pv_drivers_version ;
     if guest_metrics_cached.os_version <> os_version then
       Db.VM_guest_metrics.set_os_version ~__context ~self:gm ~value:os_version ;
+    if guest_metrics_cached.netbios_name <> netbios_name then
+      Db.VM_guest_metrics.set_netbios_name ~__context ~self:gm
+        ~value:netbios_name ;
     if guest_metrics_cached.networks <> networks then
       Db.VM_guest_metrics.set_networks ~__context ~self:gm ~value:networks ;
     if guest_metrics_cached.other <> other then (

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -1461,6 +1461,7 @@ let copy_guest_metrics ~__context ~vm =
     Db.VM_guest_metrics.create ~__context ~ref
       ~uuid:(Uuidx.to_string (Uuidx.make ()))
       ~os_version:all.API.vM_guest_metrics_os_version
+      ~netbios_name:all.API.vM_guest_metrics_netbios_name
       ~pV_drivers_version:all.API.vM_guest_metrics_PV_drivers_version
       ~pV_drivers_up_to_date:all.API.vM_guest_metrics_PV_drivers_up_to_date
       ~memory:all.API.vM_guest_metrics_memory


### PR DESCRIPTION
Exposes one of the keys reported by the Windows Guest Agent through VM_guest_metrics. This is designed to make it easier for admins to match up the AD hostname to a VM object - and CVAD uses the FQDN (host name + domain) in their UI, so this is what's exposed.

```
$ xenstore-read /local/domain/10/data/domain
eng.citrite.net
$ xenstore-read /local/domain/10/data/host_name_dns
WINDOWS-3LIPCLJ
$ xe vm-param-get uuid=WIN_UUID param-name=host-name
host_name: WINDOWS-3LIPCLJ.eng.citrite.net
```