### PR TITLE
fix(CI): feature/py3 has been merged, refer to master now

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
         name: check that the Python3 test suite in passes
         entry: env PYTHONDEVMODE=yes sh -c 'coverage run && coverage xml &&
             coverage html && coverage report &&
-            diff-cover --ignore-whitespace --compare-branch=origin/feature/py3
+            diff-cover --ignore-whitespace --compare-branch=origin/master
             --show-uncovered --html-report .git/coverage-diff.html
             --fail-under 50 .git/coverage3.11.xml'
         require_serial: true
@@ -111,7 +111,7 @@ repos:
         stages: [push]
         name: check that changes to python3 tree pass pylint
         entry: diff-quality --violations=pylint
-            --ignore-whitespace --compare-branch=origin/feature/py3
+            --ignore-whitespace --compare-branch=origin/master
         pass_filenames: false
         language: python
         types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,7 @@ xfail_strict = true  # is used to fail tests that are marked as xfail but pass(f
 
 
 [tool.pytype_reporter]
-default_branch = "feature/py3"
+default_branch = "master"
 discard_messages_matching = [
     "Couldn't import pyi for 'xml.dom.minidom'",
     "No attribute '.*' on RRDContentHandler",


### PR DESCRIPTION
This causes problems with forks that don't have feature/py3. Although would it then compare with the fork's master branch which would still be out-of-date?