### PR TITLE
CP-50422: Destroy authentication cache in disable_external_auth

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1928,6 +1928,11 @@ let disable_external_auth_common ?(during_pool_eject = false) ~__context ~host
 
         (* succeeds because there's no need to initialize anymore *)
 
+        (* If any cache is present, clear it in order to ensure cached
+           logins don't persist after disabling external
+           authentication. *)
+        Xapi_session.clear_external_auth_cache () ;
+
         (* 3. CP-703: we always revalidate all sessions after the external authentication has been disabled *)
         (* so that all sessions that were externally authenticated will be destroyed *)
         debug

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -838,7 +838,13 @@ module Caching = struct
         | Some prev_result ->
             prev_result
       )
+
+  let clear_cache () =
+    let@ () = with_lock lock in
+    cache := None
 end
+
+let clear_external_auth_cache = Caching.clear_cache
 
 (* CP-714: Modify session.login_with_password to first try local super-user
    login; and then call into external auth plugin if this is enabled

--- a/ocaml/xapi/xapi_session.mli
+++ b/ocaml/xapi/xapi_session.mli
@@ -110,3 +110,5 @@ val get_total_sessions : unit -> Int64.t
 val set_local_auth_max_threads : int64 -> unit
 
 val set_ext_auth_max_threads : int64 -> unit
+
+val clear_external_auth_cache : unit -> unit


### PR DESCRIPTION
Upon successfully disabling external authentication (e.g. winbind), any extant external authentication cache is cleared (as to not undermine disabling of the external authentication route).

We consider invalidating the cache as sufficient for our needs because external authentication would need to succeed for the cache to become populated again (even if it is recreated due to being enabled as a feature generally).