### PR TITLE
fix(WLS): disable non-root unit test

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/test/test_operations.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-fdcaps/test/test_operations.ml
@@ -197,9 +197,6 @@ let test_block () =
     in
     if Unix.geteuid () = 0 then
       run ()
-    else
-      Alcotest.check_raises "non-root fails to create blockdevice"
-        (Failure "with_temp_blk") run
   in
   test_fd with_make
     [("read", read_fd); ("write", write_fd); ("lseek", test_lseek)]


### PR DESCRIPTION
This fails when running kojienv from WSL2, but works when running kojienv from an actual Linux. In a WSL2 kojienv /dev/loop0 is world writable (even though the user is not root), whereas in a real kojienv /dev/loop0 is not world writable.

This test was here just to test my assumptions that indeed non-root cannot create block devices, assumptions which are not true in WSL2, so remove this test.

In Dom0 we run as root always, so this has no effect on the product.