### PR TITLE
xe autocompletion: Fix prefix escaping bug

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -768,10 +768,10 @@ __add_completion()
 
 __preprocess_suggestions()
 {
-    echo "$1" | \
-    sed -re 's/(^|[^\])((\\\\)*),,*/\1\2\n/g' -e 's/\\,/,/g' -e 's/\\\\/\\/g' | \
-    sed -e 's/ *$//' | \
-    grep "^${prefix}.*"
+    wordlist=$( echo "$1" | \
+                sed -re 's/(^|[^\])((\\\\)*),,*/\1\2\n/g' -e 's/\\,/,/g' -e 's/\\\\/\\/g' | \
+                sed -e 's/ *$//')
+    compgen -W "$wordlist" "$prefix"
 }
 
 # set_completions suggestions current_prefix description_cmd


### PR DESCRIPTION
Before, having an escape sequence as part of the parameter would break grep:
```
$ xe vdi-list name-label=CentOS\ 7\ \(1grep: Unmatched ( or \(
```

Move back to pure bash processing for the prefix, since it's the weirdness of variable escaping leaving the bash context causing this.

