### PR TITLE
Random small corrections in the SDK and docs.

### DIFF
--- a/ocaml/doc/wire-protocol.md
+++ b/ocaml/doc/wire-protocol.md
@@ -371,9 +371,9 @@ should not assume that references generated during one session are valid for any
 future session. References do not allow objects to be compared for equality. Two
 references to the same object are not guaranteed to be textually identical.
 
-UUIDs are intended to be permanent names for objects. They are
+UUIDs are intended to be permanent identifiers for objects. They are
 guaranteed to be in the OSF DCE UUID presentation format (as output by `uuidgen`).
-Clients may store UUIDs on disk and use them to lookup objects in subsequent sessions
+Clients may store UUIDs on disk and use them to look up objects in subsequent sessions
 with the server. Clients may also test equality on objects by comparing UUID strings.
 
 The API provides mechanisms for translating between UUIDs and opaque references.

--- a/ocaml/idl/templates/toc.mustache
+++ b/ocaml/idl/templates/toc.mustache
@@ -8,7 +8,7 @@
     - title: Types
       url: @root@management-api/types.html
 {{#classes}}
-    - title: Class:{{{name}}}
+    - title: "Class: {{{name}}}"
       url: @root@management-api/class-{{{name_lower}}}.html
 {{/classes}}
     - title: Error Handling

--- a/ocaml/sdk-gen/c/templates/Makefile.mustache
+++ b/ocaml/sdk-gen/c/templates/Makefile.mustache
@@ -40,11 +40,9 @@ endif
 
 CFLAGS = -g -Iinclude \
          $(shell xml2-config --cflags) \
-         $(shell curl-config --cflags) \
          -W -Wall -Wmissing-prototypes -Werror -std=c99 $(POS_FLAG)
 
 LDFLAGS = -g $(shell xml2-config --libs) \
-             $(shell curl-config --libs) \
           -Wl,-rpath,$(shell pwd) $(CYGWIN_LIBXML)
 
 # -h for Solaris

--- a/ocaml/sdk-gen/csharp/FriendlyErrorNames.resx
+++ b/ocaml/sdk-gen/csharp/FriendlyErrorNames.resx
@@ -355,16 +355,6 @@
     <value>Your current role is not authorized to perform this action.
 Action: {0}</value>
   </data>
-  <data name="RBAC_PERMISSION_DENIED_FRIENDLY" xml:space="preserve">
-    <value>Your current role is not authorized to perform this action.
-Current Role: {0}
-Authorized Roles: {1}</value>
-  </data>
-  <data name="RBAC_PERMISSION_DENIED_FRIENDLY_CONNECTION" xml:space="preserve">
-    <value>Your current role is not authorized to perform this action on {2}.
-Current Role: {0}
-Authorized Roles: {1}</value>
-  </data>
   <data name="RESTORE_INCOMPATIBLE_VERSION" xml:space="preserve">
     <value>Cannot restore on this server because it was saved on an incompatible version</value>
   </data>

--- a/ocaml/sdk-gen/csharp/autogen/src/Failure.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Failure.cs
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) Cloud Software Group, Inc.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   1) Redistributions of source code must retain the above copyright
  *      notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   2) Redistributions in binary form must reproduce the above
  *      copyright notice, this list of conditions and the following
  *      disclaimer in the documentation and/or other materials
  *      provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -141,7 +141,6 @@ namespace XenAPI
 
             //call these before setting the shortError because they modify the errorText
             ParseSmapiV3Failures();
-            ParseCslgFailures();
 
             try
             {
@@ -178,57 +177,6 @@ namespace XenAPI
             catch
             {
                 //ignore
-            }
-        }
-
-        /// <summary>
-        /// The ErrorDescription[2] of Cslg failures contains embedded xml.
-        /// This method parses it and copies the user friendly part to errorText.
-        /// </summary>
-        private void ParseCslgFailures()
-        {
-            /* ErrorDescription[2] example:
-
-            <StorageLinkServiceError>
-                <Fault>Host ivory has not yet been added to the service. [err=Object was not found]</Fault>
-                <Detail>
-                    <errorCode>6</errorCode>
-                    <messageId></messageId>
-                    <defaultMessage>Host ivory has not yet been added to the service. [err=Object was not found]</defaultMessage>
-                    <severity>2</severity>
-                    <errorFunction>CXSSHostUtil::getHost</errorFunction>
-                    <errorLine>113</errorLine>
-                    <errorFile>.\\xss_util_host.cpp</errorFile>
-                </Detail>
-            </StorageLinkServiceError>
-            */
-
-            if (ErrorDescription.Count > 2 && ErrorDescription[2] != null && ErrorDescription[0] != null && ErrorDescription[0].StartsWith("SR_BACKEND_FAILURE"))
-            {
-                Match m = Regex.Match(ErrorDescription[2], @"<StorageLinkServiceError>.*</StorageLinkServiceError>", RegexOptions.Singleline);
-
-                if (m.Success)
-                {
-                    XmlDocument doc = new XmlDocument();
-
-                    try
-                    {
-                        doc.LoadXml(m.Value);
-                    }
-                    catch (XmlException)
-                    {
-                        return;
-                    }
-
-                    XmlNodeList nodes = doc.SelectNodes("/StorageLinkServiceError/Fault");
-
-                    if (nodes != null && nodes.Count > 0 && !string.IsNullOrEmpty(nodes[0].InnerText))
-                    {
-                        errorText = string.IsNullOrEmpty(errorText)
-                            ? nodes[0].InnerText
-                            : string.Format("{0} ({1})", errorText, nodes[0].InnerText);
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
- C SDK: curl flags are not needed since the SDK does not depend on curl.
- Removed entries that don't correspond to API messages. Removed obsolete parsing for CSLG failures.
- Minor doc corrections.