### PR TITLE
CA-398138: Handle enum value unknown error for Go SDK

### DIFF
--- a/ocaml/sdk-gen/go/templates/ConvertEnum.mustache
+++ b/ocaml/sdk-gen/go/templates/ConvertEnum.mustache
@@ -17,7 +17,7 @@ func deserialize{{func_name_suffix}}(context string, input interface{}) (value {
 		value = {{name}}
 {{/items}}
 	default:
-		err = fmt.Errorf("unable to parse XenAPI response: got value %q for enum %s at %s, but this is not any of the known values", strValue, "{{type}}", context)
+		value = {{type}}Unrecognized
 	}
 	return
 }

--- a/ocaml/sdk-gen/go/templates/Enum.mustache
+++ b/ocaml/sdk-gen/go/templates/Enum.mustache
@@ -6,6 +6,8 @@ const (
 	//{{#doc}} {{.}}{{/doc}}
 	{{name}} {{type}} = "{{value}}"
 {{/values}}
+	// The value does not belong to this enumeration
+	{{name}}Unrecognized {{name}} = "unrecognized"
 )
 
 {{/enums}}

--- a/ocaml/sdk-gen/go/test_data/enum.go
+++ b/ocaml/sdk-gen/go/test_data/enum.go
@@ -5,4 +5,6 @@ const (
 	VMTelemetryFrequencyDaily VMTelemetryFrequency = "daily"
 	// Run telemetry task weekly
 	VMTelemetryFrequencyWeekly VMTelemetryFrequency = "weekly"
+	// The value does not belong to this enumeration
+	VMTelemetryFrequencyUnrecognized VMTelemetryFrequency = "unrecognized"
 )

--- a/ocaml/sdk-gen/go/test_data/enum_convert.go
+++ b/ocaml/sdk-gen/go/test_data/enum_convert.go
@@ -14,7 +14,7 @@ func deserializeEnumTaskStatusType(context string, input interface{}) (value Tas
 	case "success":
 		value = TaskStatusTypeSuccess
 	default:
-		err = fmt.Errorf("unable to parse XenAPI response: got value %q for enum %s at %s, but this is not any of the known values", strValue, "TaskStatusType", context)
+		value = TaskStatusTypeUnrecognized
 	}
 	return
 }


### PR DESCRIPTION
Bug fix for Go SDK, add an default Enum value to replace raising error for unknown Enum value.

Build new SDK and samples,  test pass XenRT job: 4100718.