### PR TITLE
CA-397599 XSI-1704 

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -1628,6 +1628,43 @@ let operations =
         ]
     )
 
+let set_blocked_operations =
+  call ~name:"set_blocked_operations"
+    ~in_product_since:rel_orlando (* but updated 2024 *)
+    ~doc:
+      "Update list of operations which have been explicitly blocked and an \
+       error code"
+    ~params:
+      [
+        (Ref _vm, "self", "The VM")
+      ; (Map (operations, String), "value", "Blocked operations")
+      ]
+    ~allowed_roles:_R_VM_ADMIN ()
+
+let add_to_blocked_operations =
+  call ~name:"add_to_blocked_operations"
+    ~in_product_since:rel_orlando (* but updated 2024 *)
+    ~doc:
+      "Update list of operations which have been explicitly blocked and an \
+       error code"
+    ~params:
+      [
+        (Ref _vm, "self", "The VM")
+      ; (operations, "key", "Blocked operation")
+      ; (String, "value", "Error code")
+      ]
+    ~allowed_roles:_R_VM_ADMIN ()
+
+let remove_from_blocked_operations =
+  call ~name:"remove_from_blocked_operations"
+    ~in_product_since:rel_orlando (* but updated 2024 *)
+    ~doc:
+      "Update list of operations which have been explicitly blocked and an \
+       error code"
+    ~params:
+      [(Ref _vm, "self", "The VM"); (operations, "key", "Blocked operation")]
+    ~allowed_roles:_R_VM_ADMIN ()
+
 let assert_operation_valid =
   call ~in_oss_since:None ~in_product_since:rel_rio
     ~name:"assert_operation_valid"
@@ -1909,6 +1946,9 @@ let t =
       ; restart_device_models
       ; set_uefi_mode
       ; get_secureboot_readiness
+      ; set_blocked_operations
+      ; add_to_blocked_operations
+      ; remove_from_blocked_operations
       ]
     ~contents:
       ([uid _vm]
@@ -2086,7 +2126,7 @@ let t =
             ~default_value:(Some (VSet [])) ~ty:(Set String) "tags"
             "user-specified tags for categorization purposes"
         ; field ~in_product_since:rel_orlando ~default_value:(Some (VMap []))
-            ~qualifier:RW
+            ~qualifier:StaticRO
             ~ty:(Map (operations, String))
             "blocked_operations"
             "List of operations which have been explicitly blocked and an \

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "428caff23cdb969c59a9960beefd7bb6"
+let last_known_schema_hash = "60590fa3fa2f8af66d9bf3c50b7bacc2"
 
 let current_schema_hash : string =
   let open Datamodel_types in
@@ -19,11 +19,10 @@ let () =
   if last_known_schema_hash <> current_schema_hash then (
     Printf.eprintf
       {|
-
 New schema hash ('%s') doesn't match the last known one. Please bump the
-datamodel schema versions if necessary, and update 'last_known_schema_hash'.
-
+datamodel schema versions if necessary, and update 'last_known_schema_hash'
+in file %s.
 |}
-      current_schema_hash ;
+      current_schema_hash __FILE__ ;
     exit 1
   )

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3097,6 +3097,23 @@ functor
       let get_secureboot_readiness ~__context ~self =
         info "VM.get_secureboot_readiness: self = '%s'" (vm_uuid ~__context self) ;
         Local.VM.get_secureboot_readiness ~__context ~self
+
+      let set_blocked_operations ~__context ~self ~value =
+        info "VM.set_blocked_operations: self = '%s'" (vm_uuid ~__context self) ;
+        Local.VM.set_blocked_operations ~__context ~self ~value ;
+        Xapi_vm_lifecycle.update_allowed_operations ~__context ~self
+
+      let add_to_blocked_operations ~__context ~self ~key ~value =
+        info "VM.add_to_blocked_operations: self = '%s'"
+          (vm_uuid ~__context self) ;
+        Local.VM.add_to_blocked_operations ~__context ~self ~key ~value ;
+        Xapi_vm_lifecycle.update_allowed_operations ~__context ~self
+
+      let remove_from_blocked_operations ~__context ~self ~key =
+        info "VM.remove_from_blocked_operations: self = '%s'"
+          (vm_uuid ~__context self) ;
+        Local.VM.remove_from_blocked_operations ~__context ~self ~key ;
+        Xapi_vm_lifecycle.update_allowed_operations ~__context ~self
     end
 
     module VM_metrics = struct end

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1601,6 +1601,18 @@ let set_domain_type ~__context ~self ~value =
   Db.VM.set_HVM_boot_policy ~__context ~self
     ~value:(derive_hvm_boot_policy ~domain_type:value)
 
+let set_blocked_operations ~__context ~self ~value =
+  debug "%s" __FUNCTION__ ;
+  Db.VM.set_blocked_operations ~__context ~self ~value
+
+let add_to_blocked_operations ~__context ~self ~key ~value =
+  debug "%s" __FUNCTION__ ;
+  Db.VM.add_to_blocked_operations ~__context ~self ~key ~value
+
+let remove_from_blocked_operations ~__context ~self ~key =
+  debug "%s" __FUNCTION__ ;
+  Db.VM.remove_from_blocked_operations ~__context ~self ~key
+
 let set_HVM_boot_policy ~__context ~self ~value =
   Db.VM.set_domain_type ~__context ~self
     ~value:(derive_domain_type ~hVM_boot_policy:value) ;

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -428,3 +428,19 @@ val set_uefi_mode :
 
 val get_secureboot_readiness :
   __context:Context.t -> self:API.ref_VM -> API.vm_secureboot_readiness
+
+val set_blocked_operations :
+     __context:Context.t
+  -> self:API.ref_VM
+  -> value:(API.vm_operations * string) list
+  -> unit
+
+val add_to_blocked_operations :
+     __context:Context.t
+  -> self:API.ref_VM
+  -> key:API.vm_operations
+  -> value:string
+  -> unit
+
+val remove_from_blocked_operations :
+  __context:Context.t -> self:API.ref_VM -> key:API.vm_operations -> unit


### PR DESCRIPTION
```
    CA-397599 XSI-1704 implement setter for blocked ops manually
    
    Currently the setter for field VM.blocked_operations is auto generated.
    Implement this explicitly such that we can update allowed operations
    which currently is not happening. Allowed operations are used by
    XenCenter to disable operations; this has led to operations becoming
    unavailable because allowed operations where not aligned with blocked
    operations when blocked operations were updated.
```