### PR TITLE
CA-399187: Allow gencert to be called without groupid

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -68,7 +68,7 @@ let prototyped_of_field = function
   | "host", "last_software_update" ->
       Some "22.20.0"
   | "VM_guest_metrics", "netbios_name" ->
-      Some "24.27.0-next"
+      Some "24.28.0"
   | "VM", "groups" ->
       Some "24.19.1"
   | "VM", "pending_guidances_full" ->


### PR DESCRIPTION
Last year, an argument to determine the group id of the certificates created
was added. This broke test clients, and there's no need no make it compulsory
since there's a default value: -1.

Modify the binary so it can accept only 3 arguments like before, and change the
help output to mention the group id.

This makes quite a few internal certificate tests to pass compare the previous suite run 204647 to the new 204840