### PR TITLE
CP-50914 and CP-50717: Multi-version Drivers: Toolstack Implementation and extend bugtool data collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ install: build doc sdk doc-json
 	cp -f _build/install/default/bin/xapi $(DESTDIR)$(OPTDIR)/bin/xapi
 	scripts/install.sh 755 ocaml/quicktest/quicktest $(DESTDIR)$(OPTDIR)/debug
 	cp -f _build/install/default/bin/quicktestbin $(DESTDIR)$(OPTDIR)/debug/quicktestbin
+	cp -f _build/install/default/bin/mvd_cli $(DESTDIR)$(OPTDIR)/debug/mvd_cli
 	scripts/install.sh 644 _build/install/default/share/xapi/rbac_static.csv $(DESTDIR)$(OPTDIR)/debug
 # ocaml/xsh
 	cp -f _build/install/default/bin/xsh $(DESTDIR)$(OPTDIR)/bin/xsh

--- a/add-new-versions.sh
+++ b/add-new-versions.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir /lib/modules/4.19.0+1/xenserver/bnx2fc/5.4.3
+touch /lib/modules/4.19.0+1/xenserver/bnx2fc/5.4.3/bnx2fc.ko
+rm -rf /lib/modules/4.19.0+1/xenserver/bnx2fc/2.12.20-dell
+rm -rf /lib/modules/4.19.0+1/xenserver/dell_laptop
+

--- a/doc/content/toolstack/features/MVD/index.md
+++ b/doc/content/toolstack/features/MVD/index.md
@@ -1,0 +1,292 @@
++++
+title = "Multi-version drivers"
++++
+
+Linux loads device drivers on boot and every device driver exists in one
+version. XAPI extends this scheme such that device drivers may
+exist in multiple version plus a mechanism to select the version being
+loaded on boot. Such a driver is called a multi-version driver and we
+expect only a small subset of drivers, built and distributed by
+XenServer, to have this property. The following covers the background,
+API, and CLI for multi-version drivers in XAPI.
+
+## Device Drivers in Linux and XAPI
+
+Drivers that are not compiled into the kernel are loaded dynamically
+from the file system. They are loaded from the hierarchy
+
+* `/lib/modules/<kernel-version>/`
+
+and we are particularly interested in the hierarchy
+
+* `/lib/modules/<kernel-version>/updates/`
+
+where vendor-supplied ("driver disk") drivers are located and where we
+want to support multiple versions. A driver has typically file extension
+`.ko` (kernel object).
+
+A presence in the file system does not mean that a driver is loaded as
+this happens only on demand. The actually loaded drivers
+(or modules, in Linux parlance) can be observed from
+
+* `/proc/modules`
+
+```
+netlink_diag 16384 0 - Live 0x0000000000000000
+udp_diag 16384 0 - Live 0x0000000000000000
+tcp_diag 16384 0 - Live 0x0000000000000000
+```
+
+which includes dependencies between modules (the `-` means no dependencies).
+
+## Driver Properties
+
+* A driver name is unique and a driver can be loaded only once. The fact
+  that kernel object files are located in a file system hierarchy means
+  that a driver may exist multiple times and in different version in the
+  file system. From the kernel's perspective a driver has a unique name
+  and is loaded at most once. We thus can talk about a driver using its
+  name and acknowledge it may exist in different versions in the file
+  system.
+
+* A driver that is loaded by the kernel we call *active*.
+
+* A driver file (`name.ko`) that is in a hierarchy searched by the
+  kernel is called *selected*. If the kernel needs the driver of that
+  name, it would load this object file.
+
+For a driver (`name.ko`) selection and activation are independent
+properties:
+
+* *inactive*, *deselected*: not loaded now and won't be loaded on next
+  boot.
+* *active*, *deselected*: currently loaded but won't be loaded on next
+  boot.
+* *inactive*, *selected*: not loaded now but will be loaded on demand.
+* *active*, *selected*: currently loaded and will be loaded on demand
+  after a reboot.
+
+For a driver to be selected it needs to be in the hierarchy searched by
+the kernel. By removing a driver from the hierarchy it can be
+de-selected. This is possible even for drivers that are already loaded.
+Hence, activation and selection are independent.
+
+## Multi-Version Drivers
+
+To support multi-version drivers, XAPI introduces a new
+hierarchy in Dom0:
+
+* `/lib/modules/<kernel-version>/updates/` is searched by the kernel for
+  drivers.
+* The hierarchy is expected to contain symbolic links to the file
+  actually containing the driver:
+  `/lib/modules/<kernel-version>/xenserver/<driver>/<version>/<name>.ko`
+
+The `xenserver` hierarchy provides drivers in several versions. To
+select a particular version, we expect a symbolic link from
+`updates/<name>.ko` to `<driver>/<version>/<name>.ko`. At the next boot,
+the kernel will search the `updates/` entries and load the linked
+driver, which will become active.
+
+Example filesystem hierarchy:
+```
+/lib/
+└── modules
+    └── 4.19.0+1 ->
+        ├── updates
+        │   ├── aacraid.ko
+        │   ├── bnx2fc.ko -> ../xenserver/bnx2fc/2.12.13/bnx2fc.ko
+        │   ├── bnx2i.ko
+        │   ├── cxgb4i.ko
+        │   ├── cxgb4.ko
+        │   ├── dell_laptop.ko -> ../xenserver/dell_laptop/1.2.3/dell_laptop.ko
+        │   ├── e1000e.ko
+        │   ├── i40e.ko
+        │   ├── ice.ko -> ../xenserver/intel-ice/1.11.17.1/ice.ko
+        │   ├── igb.ko
+        │   ├── smartpqi.ko
+        │   └── tcm_qla2xxx.ko
+        └── xenserver
+            ├── bnx2fc
+            │   ├── 2.12.13
+            │   │   └── bnx2fc.ko
+            │   └── 2.12.20-dell
+            │       └── bnx2fc.ko
+            ├── dell_laptop
+            │   └── 1.2.3
+            │       └── dell_laptop.ko
+            └── intel-ice
+                ├── 1.11.17.1
+                │   └── ice.ko
+                └── 1.6.4
+                    └── ice.ko
+
+```
+
+Selection of a driver is synonymous with creating a symbolic link to the
+desired version.
+
+## Versions
+
+The version of a driver is encoded in the path to its object file but
+not in the name itself: for `xenserver/intel-ice/1.11.17.1/ice.ko` the
+driver name is `ice` and only its location hints at the version.
+
+The kernel does not reveal the location from where it loaded an active
+driver. Hence the name is not sufficient to observe the currently active
+version. For this, we use [ELF notes].
+
+The driver file (`name.ko`) is in ELF linker format and may contain
+custom [ELF notes]. These are binary annotations that can be compiled
+into the file. The kernel reveals these details for loaded drivers
+(i.e., modules) in:
+
+* `/sys/module/<name>/notes/`
+
+The directory contains files like
+
+* `/sys/module/xfs/notes/.note.gnu.build-id`
+
+with a specific name (`.note.xenserver`) for our purpose. Such a file contains
+in binary encoding a sequence of records, each containing:
+
+* A null-terminated name (string)
+* A type (integer)
+* A desc (see below)
+
+The format of the description is vendor specific and is used for
+a null-terminated string holding the version. The name is fixed to
+"XenServer". The exact format is described in [ELF notes].
+
+A note with the name "XenServer" and a particular type then has the version
+as a null-terminated string the `desc` field. Additional "XenServer" notes
+of a different type may be present.
+
+[ELF notes]: https://www.netbsd.org/docs/kernel/elf-notes.html
+
+## API
+
+XAPI has capabilities to inspect and select multi-version drivers.
+
+The API uses the terminology introduced above:
+
+* A driver is specific to a host
+* A driver has a unique name; however, for API purposes a driver is
+  identified by a UUID (on the CLI) and reference (programmatically).
+* A driver has multiple versions; a version that defines a total order.
+  See below for a discussion.
+* A driver is active if it is currently used by the kernel (loaded)
+* A driver is selected if it will be considered by the kernel (on next
+  boot or when loading on demand).
+* Only one version can be active, and only one version can be selected
+  but these can be the same or different versions.
+
+An example interaction with the API through xe:
+
+```
+# xe hostdriver-select uuid=3b3db5f6-3a6d-e668-9fd4-c2a21998dc08 version=3
+
+# xe hostdriver-list uuid=3b3db5f6-3a6d-e668-9fd4-c2a21998dc08
+uuid ( RO)                : 3b3db5f6-3a6d-e668-9fd4-c2a21998dc08
+                name ( RO): crct10dif_pclmul
+           host-uuid ( RO): e51d9f8c-e3d4-42ff-ad9c-c5a66078a096
+            versions ( RO): 1; 2; 3
+      active-version ( RO): 2
+    selected-version ( RO): 3
+    requires-reboot  ( RO): true
+```
+
+## Class Host_driver
+
+Class `Host_driver` represents an instance of a multi-version driver on a host.
+
+### Fields
+
+All fields are read-only and can't be set directly.
+
+* `host`: reference to the host where the driver is installed.
+* `name`: string; name of the driver without ".ko" extension.
+* `versions`: string set; set of versions available on the host. These are
+  arbitrary strings. This set should have no duplicates.
+* `selected_version`: string, possibly empty. Version that is selected,
+  i.e. the version of the driver that will be considered by the kernel
+  when loading the driver the next time. This string may be empty when
+  no version is selected (which is unusual, though).
+* `active_version`: string, possibly empty. Version that is currently
+  loaded by the kernel.
+
+CLI uses `hostdriver` and a dash instead of an underscore. The
+CLI also offers convenience fields. Specifically, whenever selected and
+active version are not the same, a reboot is required to activate the
+selected driver/version combination. This is synthesized into a
+`reboot_required` field.
+
+(We are not using `host-driver` to avoid the impression that this is
+ part of a host object.)
+
+### Methods
+
+* All method invocations require `Pool_Operator` rights. "The Pool
+  Operator role manages host- and pool-wide resources, including setting
+  up storage, creating resource pools and managing patches, high
+  availability (HA) and workload balancing (WLB)"
+
+* `select (self, version)`; select `version` of driver `self`. Selecting
+  the version (a string) of an existing driver.
+
+* `deselect(self)`: this driver can't be loaded next time the kernel is
+  looking for a driver. This is a potentially dangerous operation, so it's
+  protected in the CLI with a `--force` flag.
+
+* `rescan (host)`: scan the host and update its driver information.
+  Method on `Host`. Called on toolstack restart.
+
+Selecting a version on a host means creating a symbolic link \(aka
+symlink\) from `updates/name.ko` to `xenserver/version/name.ko`. Given
+that the name of a driver is unique, this means replacing any existing
+symlink with the new one.
+
+Any changes to selections need to be followed with:
+
+```
+# To regenerate dependencies
+depmod -ae -F /boot/System.map-$(uname -r) $(uname -r)
+# To generate initrd
+dracut -f /boot/initrd-$(uname -r).img $(uname -r)
+# If some required drivers weren't loaded on boot, they can be loaded at runtime
+udevadm trigger --attr-nomatch=driver
+```
+
+Deselecting a driver would mean removing the symlink `updates/name.ko`.
+Again, the command sequence above (without `udevadm`, since it won't unload
+an already loaded driver) needs to be executed.
+
+### Database
+
+Each `Host_driver` object is represented in the database and data is
+persisted over reboots. This means this data will be part of data
+collected in a `xen-bugtool` invocation.
+
+### Scan and Rescan
+
+On xapi start-up, xapi updates the `Host_driver` objects belonging to the
+host to reflect the actual situation. We do not delete all objects and
+re-create them because this would invalidate any reference an API client
+would hold. Hence, the implementation uses set arithmetic over driver names
+to find:
+
+  1. Drivers removed from the host. These are removed from Xapi.
+
+  2. Drivers added to the host and not yet present in Xapi. These are
+     added, including their selecting and active version -- see below.
+
+  3. Updating the driver information in xapi: new versions, changes in active
+     selected versions are located and the fields are updated accordingly.
+
+### Version Order
+
+Total order over versions is not yet specified completely. We should break the
+version string into segments separated by punctuation characters, and compare
+these segments individually.
+
+TODO: weighting

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -7876,6 +7876,7 @@ let all_system =
   ; Datamodel_repository.t
   ; Datamodel_observer.t
   ; Datamodel_vm_group.t
+  ; Datamodel_host_driver.t
   ]
 
 (* If the relation is one-to-many, the "many" nodes (one edge each) must come before the "one" node (many edges) *)
@@ -8112,6 +8113,7 @@ let expose_get_all_messages_for =
   ; _repository
   ; _vtpm
   ; _observer
+  ; _host_driver
   ]
 
 let no_task_id_for = [_task; (* _alert; *) _event]

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -311,6 +311,8 @@ let _repository = "Repository"
 
 let _observer = "Observer"
 
+let _host_driver = "Host_driver"
+
 let update_guidances =
   Enum
     ( "update_guidances"

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1766,6 +1766,13 @@ let apply_updates =
     ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)
     ()
 
+let rescan_drivers =
+  call ~name:"rescan_drivers" ~in_oss_since:None ~lifecycle:[]
+    ~doc:"Scan the host and update its driver information."
+    ~params:[(Ref _host, "host", "The host to be rescanned")]
+    ~result:(Map (String, Set String), "Updates to the drivers' versions")
+    ~allowed_roles:_R_POOL_ADMIN ()
+
 let copy_primary_host_certs =
   call ~name:"copy_primary_host_certs" ~in_oss_since:None
     ~in_product_since:"1.307.0"
@@ -1968,6 +1975,7 @@ let t =
       ; emergency_reenable_tls_verification
       ; cert_distrib_atom
       ; apply_updates
+      ; rescan_drivers
       ; copy_primary_host_certs
       ; set_https_only
       ; apply_recommended_guidances

--- a/ocaml/idl/datamodel_host_driver.ml
+++ b/ocaml/idl/datamodel_host_driver.ml
@@ -1,0 +1,67 @@
+(*
+   Copyright (c) Cloud Software Group, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+open Datamodel_types
+open Datamodel_common
+open Datamodel_roles
+
+(** A Host_driver instance represents a driver on a host that is
+    installed in multiple versions. At most one version is active; a
+    different version can be selected to become active after reboot. If
+    no version is active, selecting a version makes it the active
+    version immediately. *)
+
+let select =
+  call ~name:"select" ~in_oss_since:None ~lifecycle:[]
+    ~doc:
+      "Select a version of the driver to become active after reboot or \
+       immediately if currently no version is active"
+    ~params:
+      [
+        (Ref _host_driver, "self", "Driver to become active (after reboot).")
+      ; (String, "version", "Driver version to become active (after reboot).")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let deselect =
+  call ~name:"deselect" ~in_oss_since:None ~lifecycle:[]
+    ~doc:
+      "Deselect the currently active version of this driver after reboot. No \
+       action will be taken if no version is currently active."
+    ~params:
+      [(Ref _host_driver, "self", "Driver to become inactive (after reboot).")]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let t =
+  create_obj ~in_db:true ~in_oss_since:None ~persist:PersistEverything
+    ~lifecycle:[] ~name:_host_driver ~gen_constructor_destructor:false
+    ~descr:"A multi-version driver on a host" ~gen_events:true ~doccomments:[]
+    ~messages_default_allowed_roles:_R_POOL_ADMIN
+    ~contents:
+      [
+        uid _host_driver
+      ; field ~lifecycle:[] ~qualifier:StaticRO ~ty:(Ref _host) "host"
+          "Host where this driver is installed" ~default_value:(Some (VRef ""))
+      ; field ~lifecycle:[] ~qualifier:DynamicRO ~ty:String "name"
+          "Name identifying the driver uniquely"
+      ; field ~lifecycle:[] ~qualifier:DynamicRO ~ty:(Set String) "versions"
+          "Versions available of this driver available for selection"
+      ; field ~lifecycle:[] ~qualifier:DynamicRO ~ty:String "active_version"
+          "Currently active version of this driver, if any. An empty string \
+           means none is active."
+      ; field ~lifecycle:[] ~qualifier:DynamicRO ~ty:String "selected_version"
+          "Version (if any) selected to become active after reboot. An empty \
+           string means none is selected."
+      ]
+    ~messages:[select; deselect] ()

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -1,4 +1,6 @@
 let prototyped_of_class = function
+  | "Host_driver" ->
+      Some "24.26.0-next"
   | "VM_group" ->
       Some "24.19.1"
   | "Observer" ->
@@ -9,6 +11,16 @@ let prototyped_of_class = function
       None
 
 let prototyped_of_field = function
+  | "Host_driver", "selected_version" ->
+      Some "24.28.0-next"
+  | "Host_driver", "active_version" ->
+      Some "24.28.0-next"
+  | "Host_driver", "versions" ->
+      Some "24.28.0-next"
+  | "Host_driver", "name" ->
+      Some "24.28.0-next"
+  | "Host_driver", "host" ->
+      Some "24.28.0-next"
   | "VM_group", "VMs" ->
       Some "24.19.1"
   | "VM_group", "placement" ->
@@ -109,6 +121,10 @@ let prototyped_of_field = function
       None
 
 let prototyped_of_message = function
+  | "Host_driver", "deselect" ->
+      Some "24.26.0-next"
+  | "Host_driver", "select" ->
+      Some "24.26.0-next"
   | "Observer", "set_components" ->
       Some "23.14.0"
   | "Observer", "set_endpoints" ->

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -1,6 +1,6 @@
 let prototyped_of_class = function
   | "Host_driver" ->
-      Some "24.26.0-next"
+      Some "24.28.0-next"
   | "VM_group" ->
       Some "24.19.1"
   | "Observer" ->
@@ -80,7 +80,7 @@ let prototyped_of_field = function
   | "host", "last_software_update" ->
       Some "22.20.0"
   | "VM_guest_metrics", "netbios_name" ->
-      Some "24.27.0-next"
+      Some "24.28.0"
   | "VM", "groups" ->
       Some "24.19.1"
   | "VM", "pending_guidances_full" ->
@@ -122,9 +122,9 @@ let prototyped_of_field = function
 
 let prototyped_of_message = function
   | "Host_driver", "deselect" ->
-      Some "24.26.0-next"
+      Some "24.28.0-next"
   | "Host_driver", "select" ->
-      Some "24.26.0-next"
+      Some "24.28.0-next"
   | "Observer", "set_components" ->
       Some "23.14.0"
   | "Observer", "set_endpoints" ->
@@ -167,6 +167,8 @@ let prototyped_of_message = function
       Some "23.18.0"
   | "host", "set_https_only" ->
       Some "22.27.0"
+  | "host", "rescan_drivers" ->
+      Some "24.28.0-next"
   | "host", "set_numa_affinity_policy" ->
       Some "24.0.0"
   | "VM", "get_secureboot_readiness" ->

--- a/ocaml/idl/dune
+++ b/ocaml/idl/dune
@@ -6,7 +6,8 @@
     datamodel_pool datamodel_cluster datamodel_cluster_host dm_api escaping
     datamodel_values datamodel_schema datamodel_certificate
     datamodel_diagnostics datamodel_repository datamodel_lifecycle
-    datamodel_vtpm datamodel_observer datamodel_vm_group api_version)
+    datamodel_vtpm datamodel_observer datamodel_vm_group api_version
+    datamodel_host_driver)
   (libraries
     rpclib.core
     sexplib0
@@ -63,7 +64,7 @@
   (public_name gen_lifecycle)
   (package xapi-datamodel)
   (modules gen_lifecycle)
-  (libraries    
+  (libraries
     xapi-datamodel
     xapi-consts.xapi_version
   )

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "428caff23cdb969c59a9960beefd7bb6"
+let last_known_schema_hash = "7d004ad296287c819ae63890cc025f7f"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -7,7 +7,7 @@
       test_cluster_host test_cluster test_pusb test_network_sriov
       test_client test_valid_ref_list suite_alcotest_server
       test_vm_placement test_vm_helpers test_repository test_repository_helpers
-      test_ref test_xapi_helpers test_vm_group
+      test_ref test_xapi_helpers test_vm_group test_host_driver_helpers
       test_livepatch test_rpm test_updateinfo test_storage_smapiv1_wrapper test_storage_quicktest test_observer
       test_pool_periodic_update_sync test_pkg_mgr test_tar_ext test_pool_repository))
   (libraries
@@ -82,14 +82,14 @@
   (names test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt test_bounded_psq test_auth_cache
     test_clustering test_pusb test_daemon_manager test_repository test_repository_helpers
     test_livepatch test_rpm test_updateinfo test_pool_periodic_update_sync test_pkg_mgr
-    test_xapi_helpers test_tar_ext test_pool_repository)
+    test_xapi_helpers test_tar_ext test_pool_repository test_host_driver_helpers)
   (package xapi)
   (modes exe)
   (modules test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt test_bounded_psq test_auth_cache
     test_event test_clustering test_cluster_host test_cluster test_pusb
     test_daemon_manager test_repository test_repository_helpers test_livepatch test_rpm
     test_updateinfo test_pool_periodic_update_sync test_pkg_mgr
-    test_xapi_helpers test_tar_ext test_pool_repository)
+    test_xapi_helpers test_tar_ext test_pool_repository test_host_driver_helpers)
   (libraries
     alcotest
     bos
@@ -167,6 +167,27 @@
     (:x ../xapi/xapi_main.exe)
   )
   (action (run ./check-no-xenctrl %{x}))
+)
+
+(rule
+  (alias runtest)
+  (package xapi)
+  (targets
+    .note.XenServer
+    .note.Linux
+    .note.gnu.build-id
+    .note.XenServerTwo
+  )
+  (deps
+    (:asm
+     test_data/xenserver.s
+     test_data/xenserver_two_notes.s
+     test_data/linux.s
+     test_data/buildid.s
+    )
+    (:script test_data/gen_notes.sh)
+  )
+  (action (bash "%{script} %{asm}"))
 )
 
 (env (_ (env-vars (XAPI_TEST 1))))

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -15,7 +15,7 @@
     angstrom
     astring
     cstruct
-    
+
     fmt
     http_lib
     httpsvr
@@ -32,25 +32,26 @@
     threads.posix
     uuid
     xapi-backtrace
-    xapi_cli_server
     xapi-consts
-    xapi_database
     xapi-datamodel
     xapi-idl
     xapi-idl.storage.interface
     xapi-idl.xen.interface
     xapi-idl.xen.interface.types
-    xapi_internal
     xapi-log
     xapi-stdext-date
+    xapi-stdext-pervasives
     xapi-stdext-std
     xapi-stdext-threads
     xapi-stdext-unix
     xapi-test-utils
     xapi-tracing
     xapi-types
-    xapi-stdext-pervasives
     xapi-xenopsd
+    xapi_cli_server
+    xapi_database
+    xapi_host_driver_helpers
+    xapi_internal
     xml-light2
   )
   (deps
@@ -104,21 +105,22 @@
     threads.posix
     uuid
     xapi-client
-    xapi_cli_server
     xapi-consts
-    xapi_database
     xapi-idl
     xapi-idl.cluster
     xapi-idl.storage
     xapi-idl.storage.interface
     xapi-idl.xen
-    xapi_internal
-    xapi-test-utils
-    xapi-tracing
-    xapi-types
     xapi-stdext-date
     xapi-stdext-threads
     xapi-stdext-unix
+    xapi-test-utils
+    xapi-tracing
+    xapi-types
+    xapi_cli_server
+    xapi_database
+    xapi_host_driver_helpers
+    xapi_internal
     xml-light2
     yojson
   )

--- a/ocaml/tests/test_data/buildid.s
+++ b/ocaml/tests/test_data/buildid.s
@@ -1,0 +1,9 @@
+.section ".note.gnu.build-id", "a"
+    .p2align 2
+    .long 1f - 0f           # name size (not including padding)
+    .long 3f - 2f           # desc size (not including padding)
+    .long 0x1               # type
+0:  .asciz "gnu.build-id"   # name
+1:  .p2align 2
+2:  .long 0x000000          # desc
+3:  .p2align 2

--- a/ocaml/tests/test_data/gen_notes.sh
+++ b/ocaml/tests/test_data/gen_notes.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright (c) Cloud Software Group, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; version 2.1 only. with the special
+# exception on linking described in file LICENSE.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+elf_file=test_data/xenserver_elf_file
+as "$@" -o $elf_file
+
+sections=$(readelf -n $elf_file | grep -Po "(?<=Displaying notes found in: ).*")
+for dep in $sections; do
+        objcopy "$elf_file" "$dep" --only-section="$dep" -O binary
+done
+

--- a/ocaml/tests/test_data/linux.s
+++ b/ocaml/tests/test_data/linux.s
@@ -1,0 +1,9 @@
+.section ".note.Linux", "a"
+    .p2align 2
+    .long 1f - 0f           # name size (not including padding)
+    .long 3f - 2f           # desc size (not including padding)
+    .long 0x257             # type
+0:  .asciz "Linux"	    # name
+1:  .p2align 2
+2:  .asciz "4.19.0+1"       # desc
+3:  .p2align 2

--- a/ocaml/tests/test_data/xenserver.s
+++ b/ocaml/tests/test_data/xenserver.s
@@ -1,0 +1,9 @@
+.section ".note.XenServer", "a"
+    .p2align 2
+    .long 1f - 0f           # name size (not including padding)
+    .long 3f - 2f           # desc size (not including padding)
+    .long 0x1               # type
+0:  .asciz "XenServer"	    # name
+1:  .p2align 2
+2:  .asciz "v2.1.3+0.1fix"  # desc
+3:  .p2align 2

--- a/ocaml/tests/test_data/xenserver_two_notes.s
+++ b/ocaml/tests/test_data/xenserver_two_notes.s
@@ -1,0 +1,20 @@
+.section ".note.XenServerTwo", "a"
+    .p2align 2
+    .long 1f - 0f           # name size (not including padding)
+    .long 3f - 2f           # desc size (not including padding)
+    .long 0x2               # type
+0:  .asciz "XenServer"	    # name
+1:  .p2align 2
+2:  .asciz "Built on December 25th"  # desc
+3:  .p2align 2
+
+.section ".note.XenServerTwo", "a"
+    .p2align 2
+    .long 1f - 0f           # name size (not including padding)
+    .long 3f - 2f           # desc size (not including padding)
+    .long 0x1               # type
+0:  .asciz "XenServer"	    # name
+1:  .p2align 2
+2:  .asciz "2.0.0-rc.2"  # desc
+3:  .p2align 2
+

--- a/ocaml/tests/test_host_driver_helpers.ml
+++ b/ocaml/tests/test_host_driver_helpers.ml
@@ -1,0 +1,89 @@
+(*
+   Copyright (c) Cloud Software Group, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+open Xapi_host_driver_helpers
+
+let note =
+  Alcotest.testable
+    (Fmt.of_to_string (fun n ->
+         Printf.sprintf "{typ=%d; name=%s; desc=%s}" (Int32.to_int n.typ) n.name
+           n.desc
+     )
+    )
+    ( = )
+
+let versions =
+  [
+    (".note.XenServer", Some "v2.1.3+0.1fix")
+  ; (".note.XenServerTwo", Some "2.0.0-rc.2")
+  ; (".note.Linux", None)
+  ; (".note.gnu.build-id", None)
+  ]
+
+let get_version_test =
+  List.map
+    (fun (filename, expected) ->
+      let test_version () =
+        let parsed_ver = Result.to_option (get_version filename) in
+        Printf.printf "%s\n" filename ;
+        Alcotest.(check (option string))
+          "ELF notes should be parsed properly" expected parsed_ver
+      in
+      ( Printf.sprintf {|Validation of ELF note parsing: "%s"|} filename
+      , `Quick
+      , test_version
+      )
+    )
+    versions
+
+let notes =
+  [
+    (".note.XenServer", [{typ= 1l; name= "XenServer"; desc= "v2.1.3+0.1fix"}])
+  ; ( ".note.XenServerTwo"
+    , [
+        {typ= 2l; name= "XenServer"; desc= "Built on December 25th"}
+      ; {typ= 1l; name= "XenServer"; desc= "2.0.0-rc.2"}
+      ]
+    )
+  ; (".note.Linux", [{typ= 599l; name= "Linux"; desc= "4.19.0+1"}])
+  ; ( ".note.gnu.build-id"
+    , [{typ= 1l; name= "gnu.build-id"; desc= "\x00\x00\x00"}]
+    )
+  ]
+
+let note_parsing_test =
+  List.map
+    (fun (filename, expected) ->
+      let test_note () =
+        let parsed =
+          match get_notes filename with Ok res -> res | Error e -> failwith e
+        in
+        Printf.printf "%s\n" filename ;
+        Alcotest.(check (list note))
+          "ELF notes should be parsed properly" expected parsed
+      in
+      ( Printf.sprintf {|Validation of ELF note parsing: "%s"|} filename
+      , `Quick
+      , test_note
+      )
+    )
+    notes
+
+let () =
+  Suite_init.harness_init () ;
+  Alcotest.run "Test Host Driver Helpers suite"
+    [
+      ("Test_host_driver_helpers.get_note", note_parsing_test)
+    ; ("Test_host_driver_helpers.get_version", get_version_test)
+    ]

--- a/ocaml/util/dune
+++ b/ocaml/util/dune
@@ -17,3 +17,21 @@
   (wrapped false)
 )
 
+(executable
+  (modes exe)
+  (name mvd_cli)
+  (public_name mvd_cli)
+  (package xapi)
+  (modules mvd_cli)
+  (libraries
+    xapi_host_driver_helpers
+    cmdliner
+  )
+)
+
+(library
+  (name xapi_host_driver_helpers)
+  (modules xapi_host_driver_helpers)
+  (libraries yojson angstrom)
+  (wrapped false)
+)

--- a/ocaml/util/mvd_cli.ml
+++ b/ocaml/util/mvd_cli.ml
@@ -1,0 +1,49 @@
+module C = Cmdliner
+
+let ( // ) = Filename.concat
+
+let man =
+  [
+    `P "$(mname) is a helper util for multi-version XenServer drivers"
+  ; `P "Use `$(mname) $(i,COMMAND) --help' for help on a single command."
+  ; `S C.Manpage.s_bugs
+  ; `P "Check bug reports at https://github.com/xapi-project/xen-api"
+  ]
+
+let directory =
+  C.Arg.(
+    value
+    & pos 0 dir "/"
+    & info [] ~docv:"DIRECTORY"
+        ~doc:"Directory for XenServer multi-driver hierarchy"
+  )
+
+let list =
+  let doc = "list multi-version drivers ELF notes" in
+  let man =
+    [
+      `S C.Manpage.s_description
+    ; `P "List multi-version drivers' ELF\nnotes in JSON format"
+    ; `Blocks man
+    ]
+  in
+  let cmd directory =
+    Sys.readdir directory
+    |> Array.iter (fun driver_name ->
+           Xapi_host_driver_helpers.dump_notes ("/sys/module" // driver_name)
+       ) ;
+    `Ok ()
+  in
+  let info = C.Cmd.info "list" ~doc ~man in
+  C.(Cmd.v info Term.(ret (const cmd $ directory)))
+
+let cmds = [list]
+
+let main_cmd =
+  let help = `Help (`Pager, None) in
+  let doc = "Multi-version driver utils" in
+  let info = C.Cmd.info "mvd_utils" ~doc ~man in
+  let default = C.Term.(ret @@ const help) in
+  C.Cmd.group info ~default cmds
+
+let _ = C.Cmd.eval main_cmd |> exit

--- a/ocaml/util/xapi_host_driver_helpers.ml
+++ b/ocaml/util/xapi_host_driver_helpers.ml
@@ -1,0 +1,137 @@
+(*
+   Copyright (c) Cloud Software Group, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+module J = Yojson
+open Angstrom
+
+let defer finally = Fun.protect ~finally
+
+let int n = Int32.to_int n
+
+let ( // ) = Filename.concat
+
+(** Read a (small) file into a string *)
+let read path =
+  let ic = open_in path in
+  defer (fun () -> close_in ic) @@ fun () ->
+  let size = in_channel_length ic in
+  really_input_string ic size
+
+type note = {typ: int32; name: string; desc: string}
+
+module JSON = struct
+  let note l =
+    let l =
+      List.map
+        (fun d ->
+          `Assoc
+            [
+              ("type", `Int (int d.typ))
+            ; ("name", `String d.name)
+            ; ("desc", `String d.desc)
+            ]
+        )
+        l
+    in
+    `List l
+
+  let emit json = J.pretty_to_channel stdout json
+end
+
+(** return the smallest k >= n such that k is divisible by 4 *)
+let align4 n =
+  let ( & ) = Int.logand in
+  n + (-n & 3)
+
+(** advance the cursor to position n *)
+let advance_to n =
+  let* pos = pos in
+  advance (max 0 (n - pos))
+
+(** align the cursor to a multiple of 4 *)
+let align =
+  let* pos = pos in
+  advance_to (align4 pos)
+
+(** parse an ELF note entry; it assumes that name and desc are null
+    terminated strings. This should be always true for name but desc
+    depends on the entry. We don't capture the terminating zero for
+    strings. *)
+let note =
+  let* name_length = LE.any_int32 in
+  let* desc_length = LE.any_int32 in
+  let* typ = LE.any_int32 in
+  let* name = take (int name_length - 1) in
+  (* skip over terminating null and re-align cursor *)
+  let* _ = char '\000' in
+  let* () = align in
+  let* desc = take (int desc_length - 1) in
+  (* skip over terminating null and re-align cursor *)
+  let* _ = char '\000' in
+  let* () = align in
+  return {typ; name; desc}
+
+(** parser for a sequence of note entries *)
+let notes = many note
+
+(** parse a sequence of note entries from a string *)
+let parse str =
+  let consume = Consume.Prefix in
+  parse_string ~consume notes str
+
+let get_version path =
+  let version =
+    read path
+    |> parse
+    |> Result.map
+       @@ List.filter_map (fun note ->
+              match (note.typ, note.name) with
+              | 1l, "XenServer" ->
+                  Some note.desc
+              | _ ->
+                  None
+          )
+  in
+  match version with
+  | Ok (v :: _) ->
+      Ok v
+  | _ ->
+      Error
+        (Format.sprintf
+           "Failed to parse %s, didn't find a XenServer driver version notes \
+            section"
+           path
+        )
+
+let get_notes path =
+  let version = read path |> parse in
+  match version with
+  | Ok (_ :: _) as v ->
+      v
+  | _ ->
+      Error
+        (Format.sprintf "Failed to parse %s, didn't find a notes section" path)
+
+let dump_notes prefix =
+  let notes_dir = prefix // "notes" in
+  try
+    let lst =
+      Sys.readdir notes_dir
+      |> Array.to_list
+      |> List.map (fun n -> read (notes_dir // n))
+      |> List.filter_map (fun note_str -> Result.to_option (parse note_str))
+      |> List.map (fun note -> (prefix, JSON.note note))
+    in
+    JSON.emit (`Assoc lst)
+  with _ -> ()

--- a/ocaml/util/xapi_host_driver_helpers.mli
+++ b/ocaml/util/xapi_host_driver_helpers.mli
@@ -1,0 +1,28 @@
+(*
+   Copyright (c) Cloud Software Group, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+type note = {typ: int32; name: string; desc: string}
+
+(* Parse an ELF notes section, returning the specially-encoded driver version.
+
+   The kernel does not reveal the location from where it loaded an active
+   driver. Hence the name is not sufficient to observe the currently active
+   version. For this, XS uses ELF notes, with the kernel presenting a particular
+   note section in `/sys/module/<name>/notes/.note.XenServer` *)
+val get_version : string -> (string, string) result
+
+val get_notes : string -> (note list, string) result
+
+(* Dumps JSON-formatted parsed ELF notes of a driver *)
+val dump_notes : string -> unit

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3702,6 +3702,32 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "hostdriver-select"
+    , {
+        reqd= ["uuid"; "version"]
+      ; optn= []
+      ; help=
+          "Select a version of the specified driver. If no versions of the \
+           driver are loaded, this version will become active. If some other \
+           version is already active, a reboot will be required to activate \
+           the new version."
+      ; implementation= No_fd Cli_operations.Host_driver.select
+      ; flags= []
+      }
+    )
+  ; ( "hostdriver-deselect"
+    , {
+        reqd= ["uuid"]
+      ; optn= ["force"]
+      ; help=
+          "Deselect the currently active version of the specified driver after \
+           reboot. No action will be taken if no version is currently active. \
+           Potentially dangerous operation, needs the '--force' flag \
+           specified."
+      ; implementation= No_fd Cli_operations.Host_driver.deselect
+      ; flags= []
+      }
+    )
   ; ( "vtpm-create"
     , {
         reqd= ["vm-uuid"]

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1045,6 +1045,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= [Host_selectors]
       }
     )
+  ; ( "host-rescan-drivers"
+    , {
+        reqd= []
+      ; optn= []
+      ; help= "Scan the host and update its driver information."
+      ; implementation= No_fd Cli_operations.host_rescan_drivers
+      ; flags= [Host_selectors]
+      }
+    )
   ; ( "host-emergency-clear-mandatory-guidance"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1322,6 +1322,18 @@ let gen_cmds rpc session_id =
           ]
           rpc session_id
       )
+    ; Client.Host_driver.(
+        mk get_all_records_where get_by_uuid host_driver_record "hostdriver" []
+          [
+            "uuid"
+          ; "name"
+          ; "versions"
+          ; "active-version"
+          ; "selected-version"
+          ; "requires-reboot"
+          ]
+          rpc session_id
+      )
     ; Client.VTPM.(
         mk get_all_records_where get_by_uuid vtpm_record "vtpm" []
           ["uuid"; "vm-uuid"; "profile"]
@@ -7965,6 +7977,25 @@ module Repository = struct
     let gpgkey_path = List.assoc "gpgkey-path" params in
     Client.Repository.set_gpgkey_path ~rpc ~session_id ~self:ref
       ~value:gpgkey_path
+end
+
+module Host_driver = struct
+  let select _ rpc session_id params =
+    let driver_uuid = List.assoc "uuid" params in
+    let driver_version = List.assoc "version" params in
+    let driver =
+      Client.Host_driver.get_by_uuid ~rpc ~session_id ~uuid:driver_uuid
+    in
+    Client.Host_driver.select ~rpc ~session_id ~self:driver
+      ~version:driver_version
+
+  let deselect _ rpc session_id params =
+    fail_without_force params ;
+    let driver_uuid = List.assoc "uuid" params in
+    let driver =
+      Client.Host_driver.get_by_uuid ~rpc ~session_id ~uuid:driver_uuid
+    in
+    Client.Host_driver.deselect ~rpc ~session_id ~self:driver
 end
 
 module VTPM = struct

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7754,6 +7754,25 @@ let host_apply_updates _printer rpc session_id params =
        params ["hash"]
     )
 
+let host_rescan_drivers printer rpc session_id params =
+  ignore
+    (do_host_op rpc session_id ~multiple:false
+       (fun _ host ->
+         let host_t = host.record () in
+         let host = host.getref () in
+         let result =
+           ("host-uuid", host_t.host_uuid)
+           :: (Client.Host.rescan_drivers ~rpc ~session_id ~host
+              |> List.map (fun (rescan_result, drivers) ->
+                     (rescan_result, String.concat "; " drivers)
+                 )
+              )
+         in
+         printer (Cli_printer.PMsg (Cli_printer.multi_line_record result))
+       )
+       params []
+    )
+
 module SDN_controller = struct
   let introduce printer rpc session_id params =
     let port =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5263,6 +5263,55 @@ let repository_record rpc session_id repository =
       ]
   }
 
+let host_driver_record rpc session_id host_driver =
+  let _ref = ref host_driver in
+  let empty =
+    ToGet (fun () -> Client.Host_driver.get_record ~rpc ~session_id ~self:!_ref)
+  in
+  let record = ref empty in
+  let x () = lzy_get record in
+  {
+    setref=
+      (fun r ->
+        _ref := r ;
+        record := empty
+      )
+  ; setrefrec=
+      (fun (a, b) ->
+        _ref := a ;
+        record := Got b
+      )
+  ; record= x
+  ; getref= (fun () -> !_ref)
+  ; fields=
+      [
+        make_field ~name:"uuid" ~get:(fun () -> (x ()).API.host_driver_uuid) ()
+      ; make_field ~name:"name" ~get:(fun () -> (x ()).API.host_driver_name) ()
+      ; make_field ~name:"host-uuid"
+          ~get:(fun () ->
+            try get_uuid_from_ref (x ()).API.host_driver_host with _ -> nid
+          )
+          ()
+      ; make_field ~name:"versions"
+          ~get:(fun () -> concat_with_semi (x ()).API.host_driver_versions)
+          ()
+      ; make_field ~name:"active-version"
+          ~get:(fun () -> (x ()).API.host_driver_active_version)
+          ()
+      ; make_field ~name:"selected-version"
+          ~get:(fun () -> (x ()).API.host_driver_selected_version)
+          ()
+      ; make_field ~name:"requires-reboot"
+          ~get:(fun () ->
+            let active_version = (x ()).API.host_driver_active_version in
+            let selected_version = (x ()).API.host_driver_selected_version in
+            string_of_bool
+              (active_version <> "" && active_version <> selected_version)
+          )
+          ()
+      ]
+  }
+
 let vtpm_record rpc session_id vtpm =
   let _ref = ref vtpm in
   let empty_record =

--- a/ocaml/xapi/api_server_common.ml
+++ b/ocaml/xapi/api_server_common.ml
@@ -130,6 +130,7 @@ module Actions = struct
   module Diagnostics = Xapi_diagnostics
   module Repository = Repository
   module Observer = Xapi_observer
+  module Host_driver = Xapi_host_driver
 end
 
 (** Use the server functor to make an XML-RPC dispatcher. *)

--- a/ocaml/xapi/db_gc_util.ml
+++ b/ocaml/xapi/db_gc_util.ml
@@ -71,6 +71,16 @@ let gc_VDIs ~__context =
     )
     (Db.VDI.get_all ~__context)
 
+let gc_Host_drivers ~__context =
+  let all_host_drivers = Db.Host_driver.get_all ~__context in
+  List.iter
+    (fun self ->
+      if not (valid_ref __context (Db.Host_driver.get_host ~__context ~self))
+      then
+        Db.Host_driver.destroy ~__context ~self
+    )
+    all_host_drivers
+
 let gc_PIFs ~__context =
   gc_connector ~__context Db.PIF.get_all Db.PIF.get_record
     (fun x -> valid_ref __context x.pIF_host)
@@ -637,4 +647,5 @@ let gc_subtask_list =
     (* CA-29253: wake up all blocked clients *)
     ("Heartbeat", Xapi_event.heartbeat)
   ; ("Updates requiring reboot", gc_updates_requiring_reboot)
+  ; ("Host drivers", gc_Host_drivers)
   ]

--- a/ocaml/xapi/db_gc_util.ml
+++ b/ocaml/xapi/db_gc_util.ml
@@ -591,17 +591,6 @@ let gc_PVS_cache_storage ~__context =
     (fun x -> valid_ref __context x.pVS_cache_storage_host)
     Db.PVS_cache_storage.destroy
 
-(*
-let timeout_alerts ~__context =
-  let all_alerts = Db.Alert.get_all ~__context in
-  let now = Unix.gettimeofday() in
-  List.iter (fun alert ->
-    let alert_time = Date.to_float (Db.Alert.get_timestamp ~__context ~self:alert) in
-    if now -. alert_time > Xapi_globs.alert_timeout then
-      Db.Alert.destroy ~__context ~self:alert
-  ) all_alerts
-*)
-
 let gc_updates_requiring_reboot ~__context =
   List.iter
     (fun host ->
@@ -642,10 +631,8 @@ let gc_subtask_list =
   ; ("PVS servers", gc_PVS_servers)
   ; ("PVS cache storage", gc_PVS_cache_storage)
   ; ("Certificates", gc_certificates)
-  ; ("VTPMs", gc_vtpms)
-  ; (* timeout_alerts; *)
-    (* CA-29253: wake up all blocked clients *)
-    ("Heartbeat", Xapi_event.heartbeat)
+  ; ("VTPMs", gc_vtpms) (* CA-29253: wake up all blocked clients *)
+  ; ("Heartbeat", Xapi_event.heartbeat)
   ; ("Updates requiring reboot", gc_updates_requiring_reboot)
   ; ("Host drivers", gc_Host_drivers)
   ]

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -348,6 +348,10 @@ let update_env __context sync_keys =
           ~value:current_bios_strings
       )
   ) ;
+  switched_sync Xapi_globs.sync_host_driver (fun () ->
+      debug "%s" __FUNCTION__ ;
+      ignore (Xapi_host.rescan_drivers ~__context ~host:localhost)
+  ) ;
 
   (* CA-35549: In a pool rolling upgrade, the master will detect the end of upgrade when the software versions
      	 of all the hosts are the same. It will then assume that (for example) per-host patch records have

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -205,6 +205,7 @@
     xxhash
     yojson
     zstd
+    xapi_host_driver_helpers
   )
   (preprocess (per_module
    ((pps ppx_sexp_conv) Cert_distrib)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -4106,6 +4106,14 @@ functor
         info "Host.apply_updates: host = '%s'; hash = '%s'" uuid hash ;
         Local.Host.apply_updates ~__context ~self ~hash
 
+      let rescan_drivers ~__context ~host =
+        let uuid = host_uuid ~__context host in
+        info "Host.rescan_drivers: host = '%s'" uuid ;
+        let local_fn = Local.Host.rescan_drivers ~host in
+        do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
+            Client.Host.rescan_drivers ~rpc ~session_id ~host
+        )
+
       let set_https_only ~__context ~self ~value =
         let uuid = host_uuid ~__context self in
         info "Host.set_https_only: self = %s ; value = %b" uuid value ;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6554,6 +6554,26 @@ functor
 
     module Certificate = struct end
 
+    module Host_driver = struct
+      (** select needs to be executed on the host of the driver *)
+      let select ~__context ~self ~version =
+        info "%s" __FUNCTION__ ;
+        let host = Db.Host_driver.get_host ~__context ~self in
+        let local_fn = Local.Host_driver.select ~self ~version in
+        do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
+            Client.Host_driver.select ~rpc ~session_id ~self ~version
+        )
+
+      (** deselect needs to be executed on the host of the driver *)
+      let deselect ~__context ~self =
+        info "%s" __FUNCTION__ ;
+        let host = Db.Host_driver.get_host ~__context ~self in
+        let local_fn = Local.Host_driver.deselect ~self in
+        do_op_on ~__context ~local_fn ~host (fun session_id rpc ->
+            Client.Host_driver.deselect ~rpc ~session_id ~self
+        )
+    end
+
     module Repository = struct
       let introduce ~__context ~name_label ~name_description ~binary_url
           ~source_url ~update ~gpgkey_path =

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -370,6 +370,8 @@ let sync_pci_devices = "sync_pci_devices"
 
 let sync_gpus = "sync_gpus"
 
+let sync_host_driver = "sync_host_driver"
+
 (* Allow dbsync actions to be disabled via the redo log, since the database
    isn't of much use if xapi won't start. *)
 let disable_dbsync_for = ref []

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -927,6 +927,12 @@ let xen_livepatch_cmd = ref "/usr/sbin/xen-livepatch"
 
 let xl_cmd = ref "/usr/sbin/xl"
 
+let depmod = ref "/usr/sbin/depmod"
+
+let dracut = ref "/usr/sbin/dracut"
+
+let udevadm = ref "/usr/sbin/udevadm"
+
 let yum_repos_config_dir = ref "/etc/yum.repos.d"
 
 let remote_repository_prefix = ref "remote"
@@ -1743,6 +1749,9 @@ module Resources = struct
     ; ("modifyrepo-cmd", modifyrepo_cmd, "Path to modifyrepo command")
     ; ("rpm-cmd", rpm_cmd, "Path to rpm command")
     ; ("c_rehash", c_rehash, "Path to Regenerate CA store")
+    ; ("depmod", depmod, "Path to depmod command")
+    ; ("dracut", dracut, "Path to dracut command")
+    ; ("udevadm", udevadm, "Path to udevadm command")
     ]
 
   let nonessential_executables =

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -3027,6 +3027,8 @@ let apply_updates ~__context ~self ~hash =
   Db.Host.set_last_update_hash ~__context ~self ~value:hash ;
   warnings
 
+let rescan_drivers = Xapi_host_driver.discover
+
 let cc_prep () =
   let cc = "CC_PREPARATIONS" in
   Xapi_inventory.lookup ~default:"false" cc |> String.lowercase_ascii

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -553,6 +553,9 @@ val get_host_updates_handler : Http.Request.t -> Unix.file_descr -> 'a -> unit
 val apply_updates :
   __context:Context.t -> self:API.ref_host -> hash:string -> string list list
 
+val rescan_drivers :
+  __context:Context.t -> host:API.ref_host -> (string * string list) list
+
 val copy_primary_host_certs : __context:Context.t -> host:API.ref_host -> unit
 
 val set_https_only :

--- a/ocaml/xapi/xapi_host_driver.ml
+++ b/ocaml/xapi/xapi_host_driver.ml
@@ -269,12 +269,13 @@ let discover ~__context ~host =
       filesystem_drivers
   with
   | Sys_error e ->
-      internal_error "Failed to parse drivers on host %s: %s"
-        (Ref.string_of host) e
+      D.debug "Failed to parse drivers on host %s: %s" (Ref.string_of host) e ;
+      []
   | e ->
-      internal_error "Failed to parse drivers on host %s: %s - %s"
-        (Ref.string_of host) (Printexc.to_string e)
-        (Printexc.get_backtrace ())
+      D.debug "Failed to parse drivers on host %s: %s - %s" (Ref.string_of host)
+        (Printexc.to_string e)
+        (Printexc.get_backtrace ()) ;
+      []
 
 (* Runs on the necessary host *)
 let select ~__context ~self ~version =

--- a/ocaml/xapi/xapi_host_driver.ml
+++ b/ocaml/xapi/xapi_host_driver.ml
@@ -1,0 +1,173 @@
+(*
+   Copyright (c) Cloud Software Group, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = __MODULE__ end)
+
+open D
+module Unixext = Xapi_stdext_unix.Unixext
+
+let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+
+let selection_mutex = Mutex.create ()
+
+let ( // ) = Filename.concat
+
+let invalid_value field value =
+  raise Api_errors.(Server_error (invalid_value, [field; value]))
+
+let internal_error fmt =
+  Printf.ksprintf
+    (fun msg ->
+      error "%s" msg ;
+      raise Api_errors.(Server_error (internal_error, [msg]))
+    )
+    fmt
+
+let create ~__context ~host ~name ~versions ~active_version ~selected_version =
+  info "%s: %s" __FUNCTION__ name ;
+  let ref = Ref.make () in
+  let uuid = Uuidx.to_string (Uuidx.make ()) in
+  Db.Host_driver.create ~__context ~ref ~uuid ~host ~name ~versions
+    ~active_version ~selected_version
+
+let destroy ~__context ~self =
+  D.debug "Destroying driver %s" (Ref.string_of self) ;
+  Db.Host_driver.destroy ~__context ~self
+
+(*
+* `/lib/modules/<kernel-version>/updates/` is searched by the kernel for
+  drivers - this is `selected_dir`.
+* The hierarchy is expected to contain symbolic links to the file
+  actually containing the driver in
+  `/lib/modules/<kernel-version>/xenserver/<driver>/<version>/<name>.ko` -
+  the base directory here is `all_versions_dir`. *)
+type driver_paths = {selected_dir: string; all_versions_dir: string}
+
+let get_drivers_base_path ~__context ~host =
+  let linux_version =
+    List.assoc "linux" (Db.Host.get_software_version ~__context ~self:host)
+  in
+  let base_dir = "/lib/modules" // linux_version in
+  {
+    selected_dir= base_dir // "updates"
+  ; all_versions_dir= base_dir // "xenserver"
+  }
+
+(* To prevent potential conflicts in generating dependencies and initrd, allow
+   only one reload_driver_selection to run per host *)
+let reload_driver_selection ~__context ~host ~select =
+  with_lock selection_mutex (fun () ->
+      let linux_version =
+        List.assoc "linux" (Db.Host.get_software_version ~__context ~self:host)
+      in
+      try
+        let _, _ =
+          Forkhelpers.execute_command_get_output !Xapi_globs.depmod
+            [
+              "-ae"
+            ; "-F"
+            ; Format.sprintf "/boot/System.map-%s" linux_version
+            ; linux_version
+            ]
+        in
+        let _, _ =
+          Forkhelpers.execute_command_get_output !Xapi_globs.dracut
+            [
+              "-f"
+            ; Format.sprintf "/boot/initrd-%s.img" linux_version
+            ; linux_version
+            ]
+        in
+        (* udev event only needs to be triggered and waited for on selection, since
+           it can't unload a driver *)
+        if select then
+          let _, _ =
+            Forkhelpers.execute_command_get_output !Xapi_globs.udevadm
+              ["trigger"; "--attr-nomatch=driver"]
+          in
+          let _, _ =
+            Forkhelpers.execute_command_get_output !Xapi_globs.udevadm
+              ["settle"; "-t"; "30"]
+          in
+          ()
+      with Forkhelpers.Spawn_internal_error (err, _, _) ->
+        internal_error "Failed to reload driver selection (%s): %s" __FUNCTION__
+          err
+  )
+
+let update_drivers_db ~__context ~host ~driver_paths db_drivers
+    filesystem_drivers =
+  failwith "TODO"
+
+(* Runs on the necessary host *)
+let select ~__context ~self ~version =
+  let versions = Db.Host_driver.get_versions ~__context ~self in
+  match List.find_opt (String.equal version) versions with
+  | Some _ -> (
+      let host = Helpers.get_localhost ~__context in
+      let db_driver = Db.Host_driver.get_record ~__context ~self in
+      let driver_paths = get_drivers_base_path ~__context ~host in
+      let srcfile =
+        driver_paths.all_versions_dir
+        // db_driver.host_driver_name
+        // version
+        // (db_driver.host_driver_name ^ ".ko")
+      in
+      let destfile =
+        driver_paths.selected_dir // (db_driver.host_driver_name ^ ".ko")
+      in
+      try
+        if Sys.file_exists destfile then
+          Sys.remove destfile ;
+        Unix.symlink srcfile destfile ;
+        reload_driver_selection ~__context ~host ~select:true ;
+
+        (* Update the state of this driver to verify if it has been activated
+         *)
+        let db_drivers = [(self, db_driver)] in
+        let filesystem_drivers = Array.of_list [db_driver.host_driver_name] in
+        let _ =
+          update_drivers_db ~__context ~host ~driver_paths db_drivers
+            filesystem_drivers
+        in
+        ()
+      with e ->
+        internal_error "Couldn't select the version %s of driver %s: %s - %s"
+          version
+          (Db.Host_driver.get_uuid ~__context ~self)
+          (Printexc.to_string e)
+          (Printexc.get_backtrace ())
+    )
+  | None ->
+      invalid_value "version" version
+
+(* Runs on the necessary host *)
+let deselect ~__context ~self =
+  let host = Helpers.get_localhost ~__context in
+  let driver_name = Db.Host_driver.get_name ~__context ~self in
+  let driver_paths = get_drivers_base_path ~__context ~host in
+
+  let driverfile = driver_paths.selected_dir // (driver_name ^ ".ko") in
+  try
+    if Sys.file_exists driverfile then
+      Sys.remove driverfile ;
+    reload_driver_selection ~__context ~host ~select:false ;
+
+    Db.Host_driver.set_active_version ~__context ~self ~value:"" ;
+    Db.Host_driver.set_selected_version ~__context ~self ~value:""
+  with Sys_error e ->
+    internal_error "Couldn't deselect the driver %s: %s - %s"
+      (Db.Host_driver.get_uuid ~__context ~self)
+      e
+      (Printexc.get_backtrace ())

--- a/ocaml/xapi/xapi_host_driver.mli
+++ b/ocaml/xapi/xapi_host_driver.mli
@@ -9,6 +9,9 @@ val create :
 
 val destroy : __context:Context.t -> self:[`Host_driver] Ref.t -> unit
 
+val discover :
+  __context:Context.t -> host:[`host] Ref.t -> (string * string list) list
+
 val select :
   __context:Context.t -> self:[`Host_driver] Ref.t -> version:string -> unit
 

--- a/ocaml/xapi/xapi_host_driver.mli
+++ b/ocaml/xapi/xapi_host_driver.mli
@@ -1,0 +1,15 @@
+val create :
+     __context:Context.t
+  -> host:[`host] Ref.t
+  -> name:string
+  -> versions:string list
+  -> active_version:string
+  -> selected_version:string
+  -> unit
+
+val destroy : __context:Context.t -> self:[`Host_driver] Ref.t -> unit
+
+val select :
+  __context:Context.t -> self:[`Host_driver] Ref.t -> version:string -> unit
+
+val deselect : __context:Context.t -> self:[`Host_driver] Ref.t -> unit

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -493,6 +493,17 @@ _xe()
                 return 0
                 ;;
 
+            version) # for hostdriver-select
+                if [[ "$COMP_CWORD" == "3" ]]; then
+                    __xe_debug "triggering autocompletion for hostdriver's version"
+                    IFS=$'\n,'
+                    local cmd="$xe hostdriver-list ${OLDSTYLE_WORDS[2]} --minimal params=versions 2>/dev/null"
+                    __xe_debug "full list cmd is '$cmd'"
+                    local vals=$(eval "$cmd")
+                    set_completions "${vals//; /,}" "$value"
+                fi
+                ;;
+
             data-source) # for host-data-source-*
                 __xe_debug "param is 'data-source', list command is 'host-data-source-list'"
                 IFS=$','

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=510
+  N=511
   # do not count ml files from the tests in ocaml/{tests/perftest/quicktest}
   MLIS=$(git ls-files -- '**/*.mli' | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest|ocaml/message-switch/core_test" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)
   MLS=$(git  ls-files -- '**/*.ml'  | grep -vE "ocaml/tests|ocaml/perftest|ocaml/quicktest|ocaml/message-switch/core_test" | xargs -I {} sh -c "echo {} | cut -f 1 -d '.'" \;)

--- a/scripts/bugtool-plugin/xapi/stuff.xml
+++ b/scripts/bugtool-plugin/xapi/stuff.xml
@@ -14,4 +14,7 @@
 <command label="xapi_pool_cert">cat @ETCXENDIR@/xapi-pool-tls.pem | @BINDIR@/openssl x509 -text</command>
 <command label="save_rrd">rrd-cli save_rrds</command>
 <command label="task_list">@OPTDIR@/bin/xe task-list params=all</command>
+<command label="selected_drivers">ls -lR /lib/modules/$(uname -r)/updates</command>
+<command label="all_version_drivers">ls -lR /lib/modules/$(uname -r)/xenserver</command>
+<command label="driver_notes">@OPTDIR@/debug/mvd_cli list /lib/modules/$(uname -r)/xenserver</command>
 </collect>

--- a/setup-script.sh
+++ b/setup-script.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+mkdir /lib/modules/4.19.0+1/xenserver/bnx2fc/2.12.13 -p
+touch /lib/modules/4.19.0+1/xenserver/bnx2fc/2.12.13/bnx2fc.ko
+mkdir /lib/modules/4.19.0+1/xenserver/bnx2fc/2.12.20-dell
+touch /lib/modules/4.19.0+1/xenserver/bnx2fc/2.12.20-dell/bnx2fc.ko
+mkdir /lib/modules/4.19.0+1/xenserver/dell_laptop/1.2.3 -p
+touch /lib/modules/4.19.0+1/xenserver/dell_laptop/1.2.3/dell_laptop.ko
+mkdir /lib/modules/4.19.0+1/xenserver/intel-ice/1.11.17.1 -p
+touch /lib/modules/4.19.0+1/xenserver/intel-ice/1.11.17.1/intel-ice.ko
+mkdir /lib/modules/4.19.0+1/xenserver/intel-ice/1.6.4
+touch /lib/modules/4.19.0+1/xenserver/intel-ice/1.6.4/intel-ice.ko


### PR DESCRIPTION
Implements the feature outlined in the toolstack design document.

* New class `Host_driver`, with `select` and `deselect` methods
* New `Host` method `rescan-drivers`

Contains temporary workarounds intended to be removed when the foundations work is done.