### PR TITLE
CP-51483: epoll tests: support QCHECK_LONG_FACTOR

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/unixext_test.ml
@@ -253,7 +253,7 @@ let check_subsets msg ((s1, s2, s3) as all) ((s1', s2', s3') as all') =
 
 let test_select =
   let gen, print = Generate.select_input in
-  Test.make ~long_factor:10 ~name:__FUNCTION__ ~print gen @@ fun t ->
+  Test.make ~name:__FUNCTION__ ~print gen @@ fun t ->
   (* epoll raised EEXIST, but none of the actual callers in XAPI need this,
      so skip
   *)

--- a/ocaml/quicktest/quicktest
+++ b/ocaml/quicktest/quicktest
@@ -1,5 +1,13 @@
 #!/bin/bash
 
 ulimit -n 2048
+
+# By default make the tests run 10x as many iterations as the default they
+# would've run in the CI
+# XenRT can further override this env var if desired
+# For this to have an effect tests must NOT specify a long_factor of their own.
+QCHECK_LONG_FACTOR=${QCHECK_LONG_FACTOR:=10}
+export QCHECK_LONG_FACTOR
+echo "QCHECK_LONG_FACTOR: ${QCHECK_LONG_FACTOR}"
 # Run quicktest with support for exception backtraces.
 OCAMLRUNPARAM=b "@OPTDIR@/debug/quicktestbin" "$@"


### PR DESCRIPTION
The following environment variables can now be used by tests:
* QCHECK_LONG_FACTOR (default 10): multiplies the default iteration count of 100
* QCHECK_SEED: an integer seed (the tests print their current seed on startup otherwise, can be used to reproduce a failure)

These environment variables are already supported by the QCheck framework, we just need to use them.