### PR TITLE
Specify OCaml version for ocamlformat's output

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -7,3 +7,4 @@ break-separators=before
 break-infix=fit-or-vertical
 break-infix-before-func=false
 sequence-blank-line=preserve-one
+ocaml-version=4.14


### PR DESCRIPTION
OCamlformat will correctly format new features only when it's aware the OCaml version it's outputting provides them. This allows to improve formatting for let-punning, punned labelled arguments, and more:
https://github.com/ocaml-ppx/ocamlformat/blob/main/CHANGES.md#added-8