### PR TITLE
opam: declare missing dependencies

### DIFF
--- a/clock.opam
+++ b/clock.opam
@@ -13,6 +13,7 @@ depends: [
   "astring"
   "mtime"
   "ptime"
+  "xapi-log" {= version}
   "qcheck-core" {with-test}
   "qcheck-alcotest" {with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@
     astring
     mtime
     ptime
+    (xapi-log (= :version))
     (qcheck-core :with-test)
     (qcheck-alcotest :with-test)
   )


### PR DESCRIPTION
clock now uses xapi-log, so it needs to have the dependency declared in opam