### PR TITLE
[ci]: make concurrency group more unique

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   merge_group:
 
 concurrency: # On new push, cancel old workflows from the same PR, branch or tag:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{github.event_name}}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -9,7 +9,7 @@ on:
   merge_group:
 
 concurrency: # On new push, cancel old workflows from the same PR, branch or tag:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{github.event_name}}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -5,7 +5,7 @@ on:
   merge_group:
 
 concurrency:  # On new push, cancel old workflows from the same PR, branch or tag:
-  group: sc-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: sc-${{ github.workflow }}-${{github.event_name}}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
We notice that required CI checks cancel themselves even when attempting to merge a single PR at a time. That is probably because there are CI jobs run on both 'push' and 'merge_group'.

Try to make the concurrency group more unique by adding the github event name to the group key.