### PR TITLE
unixext: timed_read raises a Timeout exception on timeout

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
@@ -670,7 +670,10 @@ let time_limited_single_read filedesc length ~max_wait =
     ->
       0
   in
-  Bytes.sub_string buf 0 bytes
+  if bytes < length then
+    raise Timeout
+  else
+    Bytes.sub_string buf 0 bytes
 
 (** see [select(2)] "Correspondence between select() and poll() notifications".
     Note that HUP and ERR are ignored in events and returned only in revents.

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -157,6 +157,11 @@ val time_limited_read : Unix.file_descr -> int -> float -> string
 
 val time_limited_single_read :
   Unix.file_descr -> int -> max_wait:float -> string
+(** [time_limited_single_read fd length max_wait] Reads [length] bytes from
+    the file descriptor [fd] in a single read, allowing up to [time_span] of
+    time to pass. Raises [Timeout] exception when less than [amount] bytes have
+    been read after [time_span] of time has passed. It may raise exceptions
+    that come from {{Unix.read}} *)
 
 val select :
      Unix.file_descr list
@@ -262,7 +267,7 @@ val test_open : int -> unit
   to [Xapi_stdext_unix.Unixext.select] that use file descriptors, because such calls will then immediately fail.
 
   This assumes that [ulimit -n] has been suitably increased in the test environment.
-  
+
   Can only be called once in a program, and will raise an exception otherwise.
 
   The file descriptors will stay open until the program exits.


### PR DESCRIPTION
Users expected Timeout to be raised whenever the amount of bytes read was less than the amount of bytes requested. Do so, and document the behaviour of the function.

Drafting as this needs a build to be tested