### PR TITLE
CA-399638: The livepatches are absent in the response of /updates

### DIFF
--- a/ocaml/tests/test_repository_helpers.ml
+++ b/ocaml/tests/test_repository_helpers.ml
@@ -3881,7 +3881,29 @@ module PruneUpdateInfoForLivepatches = Generic.MakeStateless (struct
       ; base_build_id= "2cc28689364587682593b6a72e2a586d29996bb9"
       ; base_version= "4.19.19"
       ; base_release= "8.0.20.xs8"
-      ; to_version= "4.13.4"
+      ; to_version= "4.19.19"
+      ; to_release= "8.0.21.xs8"
+      }
+
+  let lp2 =
+    LivePatch.
+      {
+        component= Livepatch.Kernel
+      ; base_build_id= "2cc28689364587682593b6a72e2a586d29996bb9"
+      ; base_version= "4.19.19"
+      ; base_release= "8.0.20.xs8"
+      ; to_version= "4.19.20"
+      ; to_release= "8.0.21.xs8"
+      }
+
+  let lp3 =
+    LivePatch.
+      {
+        component= Livepatch.Kernel
+      ; base_build_id= "4cc28689364587682593b6a72e2a586d29996bb9"
+      ; base_version= "4.19.20"
+      ; base_release= "7.0.20.xs8"
+      ; to_version= "4.13.5"
       ; to_release= "8.0.21.xs8"
       }
 
@@ -3914,6 +3936,12 @@ module PruneUpdateInfoForLivepatches = Generic.MakeStateless (struct
         )
       ; ( ([], {updateinfo with livepatches= [lp0; lp1]})
         , {updateinfo with livepatches= []}
+        )
+      ; ( ([lp0; lp2], {updateinfo with livepatches= [lp0; lp1; lp2; lp3]})
+        , {updateinfo with livepatches= [lp0; lp1; lp2]}
+        )
+      ; ( ([lp0], {updateinfo with livepatches= [lp0; lp1; lp2; lp3]})
+        , {updateinfo with livepatches= [lp0]}
         )
       ]
 end)


### PR DESCRIPTION
When applying livepatches, for one component, only the latest one will
be applied. This is because the latest livepatch will always roll up all
the previous ones if they are of the same component and base build ID.

The bug to be fixed in this commit is that the previous livepatches with
the same build ID are not returned in the response of the query on
the /updates HTTP endpoint.