### PR TITLE
VM shutdowns: do not block the calls to the domains prematurely

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2054,7 +2054,7 @@ functor
         info "VM.clean_shutdown: VM = '%s'" (vm_uuid ~__context vm) ;
         let local_fn = Local.VM.clean_shutdown ~vm in
         with_vm_operation ~__context ~self:vm ~doc:"VM.clean_shutdown"
-          ~op:`clean_shutdown (fun () ->
+          ~op:`clean_shutdown ~strict:false (fun () ->
             forward_vm_op ~local_fn ~__context ~vm (fun session_id rpc ->
                 Client.VM.clean_shutdown ~rpc ~session_id ~vm
             )
@@ -2073,7 +2073,7 @@ functor
         info "VM.shutdown: VM = '%s'" (vm_uuid ~__context vm) ;
         let local_fn = Local.VM.shutdown ~vm in
         with_vm_operation ~__context ~self:vm ~doc:"VM.shutdown" ~op:`shutdown
-          (fun () ->
+          ~strict:false (fun () ->
             if Db.VM.get_power_state ~__context ~self:vm = `Suspended then (
               debug
                 "VM '%s' is suspended. Shutdown will just delete suspend VDI"


### PR DESCRIPTION
I'm opening the PR to comment on this behaviour, since this should make possible to shutdown FreeBSD kernels.


The crux of the matter is that Just because a domain is not advertising it can shutdown cooperatively doesn't mean it can't at all. Doing it in any case would make it work with FreeBSD kernels, but I don't know whether this can break some expectations in xencenter about other guests.