### PR TITLE
CP-28369: Remove `Unixext.daemonize`

### DIFF
--- a/ocaml/cdrommon/cdrommon.ml
+++ b/ocaml/cdrommon/cdrommon.ml
@@ -63,6 +63,5 @@ let () =
     Printf.eprintf "usage: %s <cdrompath>\n" Sys.argv.(0) ;
     exit 1
   ) ;
-  Xapi_stdext_unix.Unixext.daemonize () ;
   (* check every 2 seconds *)
   check 2 Sys.argv.(1)

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
@@ -94,27 +94,6 @@ let with_file file mode perms f =
     (fun () -> f fd)
     (fun () -> Unix.close fd)
 
-(* !! Must call this before spawning any threads !! *)
-
-(** daemonize a process *)
-let daemonize () =
-  match Unix.fork () with
-  | 0 -> (
-      if Unix.setsid () == -1 then
-        failwith "Unix.setsid failed" ;
-      match Unix.fork () with
-      | 0 ->
-          with_file "/dev/null" [Unix.O_WRONLY] 0 (fun nullfd ->
-              Unix.close Unix.stdin ;
-              Unix.dup2 nullfd Unix.stdout ;
-              Unix.dup2 nullfd Unix.stderr
-          )
-      | _ ->
-          exit 0
-    )
-  | _ ->
-      exit 0
-
 exception Break
 
 let lines_fold f start input =

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -30,8 +30,6 @@ val pidfile_write : string -> unit
 
 val pidfile_read : string -> int option
 
-val daemonize : unit -> unit
-
 val with_file :
      string
   -> Unix.open_flag list
@@ -262,7 +260,7 @@ val test_open : int -> unit
   to [Xapi_stdext_unix.Unixext.select] that use file descriptors, because such calls will then immediately fail.
 
   This assumes that [ulimit -n] has been suitably increased in the test environment.
-  
+
   Can only be called once in a program, and will raise an exception otherwise.
 
   The file descriptors will stay open until the program exits.

--- a/ocaml/networkd/bin/networkd.ml
+++ b/ocaml/networkd/bin/networkd.ml
@@ -224,15 +224,11 @@ let () =
       ~rpc_fn:(Idl.Exn.server Network_server.S.implementation)
       ()
   in
-  Xcp_service.maybe_daemonize
-    ~start_fn:(fun () ->
-      Debug.set_facility Syslog.Local5 ;
-      (* We should make the following configurable *)
-      Debug.disable "http" ;
-      handle_shutdown () ;
-      Debug.with_thread_associated "main" start server
-    )
-    () ;
+  Debug.set_facility Syslog.Local5 ;
+  (* We should make the following configurable *)
+  Debug.disable "http" ;
+  handle_shutdown () ;
+  Debug.with_thread_associated "main" start server ;
   let module Daemon = Xapi_stdext_unix.Unixext.Daemon in
   if Daemon.systemd_notify Daemon.State.Ready then
     ()

--- a/ocaml/squeezed/src/squeezed.ml
+++ b/ocaml/squeezed/src/squeezed.ml
@@ -110,9 +110,6 @@ let _ =
       ~rpc_fn:(Idl.Exn.server S.implementation)
       ()
   in
-  maybe_daemonize () ;
-  (* NB Initialise the xenstore connection after daemonising, otherwise we lose
-     our connection *)
   let _ = Thread.create Memory_server.record_boot_time_host_free_memory () in
   let rpc_server = Thread.create Xcp_service.serve_forever server in
   Memory_server.start_balance_thread balance_check_interval ;

--- a/ocaml/xapi-idl/lib/xcp_service.mli
+++ b/ocaml/xapi-idl/lib/xcp_service.mli
@@ -54,13 +54,7 @@ val make :
 
 val serve_forever : server -> unit
 
-val daemon : bool ref
-
 val loglevel : unit -> Syslog.level
-
-val daemonize : ?start_fn:(unit -> unit) -> unit -> unit
-
-val maybe_daemonize : ?start_fn:(unit -> unit) -> unit -> unit
 
 val cli :
      name:string

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -2043,11 +2043,6 @@ let _ =
   in
   configure2 ~name:"xapi-script-storage" ~version:Xapi_version.version
     ~doc:description ~resources ~options () ;
-  if !Xcp_service.daemon then (
-    Xcp_service.maybe_daemonize () ;
-    use_syslog := true ;
-    info "Daemonisation successful."
-  ) ;
   let run () =
     let ( let* ) = ( >>= ) in
     let* observer_enabled = observer_is_component_enabled () in

--- a/ocaml/xapi/xapi_main.ml
+++ b/ocaml/xapi/xapi_main.ml
@@ -22,8 +22,6 @@ let _ =
   Debug.set_facility Syslog.Local5 ;
   Sys.enable_runtime_warnings true ;
   init_args () ;
-  (* need to read args to find out whether to daemonize or not *)
-  Xcp_service.maybe_daemonize () ;
   (* Disable logging for the module requested in the config *)
   List.iter
     (fun m ->

--- a/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
+++ b/ocaml/xcp-rrdd/bin/rrdd/xcp_rrdd.ml
@@ -1098,7 +1098,6 @@ let _ =
   debug "Reading configuration file .." ;
   Xcp_service.configure2 ~name:Sys.argv.(0) ~version:Xapi_version.version ~doc
     ~options () ;
-  Xcp_service.maybe_daemonize () ;
   debug "Starting the HTTP server .." ;
   (* Eventually we should switch over to xcp_service to declare our services,
      but since it doesn't support HTTP GET and PUT we keep the old code for now.

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -461,7 +461,6 @@ let main backend =
   (* we need to catch this to make sure at_exit handlers are triggered. In
      particuar, triggers for the bisect_ppx coverage profiling *)
   let signal_handler n = debug "caught signal %d" n ; exit 0 in
-  Xcp_service.maybe_daemonize () ;
   Sys.set_signal Sys.sigpipe Sys.Signal_ignore ;
   Sys.set_signal Sys.sigterm (Sys.Signal_handle signal_handler) ;
   Xenops_utils.set_fs_backend

--- a/ocaml/xenopsd/xc/xenops_xc_main.ml
+++ b/ocaml/xenopsd/xc/xenops_xc_main.ml
@@ -37,13 +37,7 @@ let check_domain0_uuid () =
     ]
   in
   let open Ezxenstore_core.Xenstore in
-  with_xs (fun xs -> List.iter (fun (k, v) -> xs.Xs.write k v) kvs) ;
-  if !Xcp_service.daemon then
-    (* before daemonizing we need to forget the xenstore client because the
-       background thread will be gone after the fork().
-       Note that this leaks a thread.
-    *)
-    forget_client ()
+  with_xs (fun xs -> List.iter (fun (k, v) -> xs.Xs.write k v) kvs)
 
 let make_var_run_xen () =
   Xapi_stdext_unix.Unixext.mkdir_rec Device_common.var_run_xen_path 0o0755

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -40,7 +40,7 @@ mli-files () {
 }
 
 structural-equality () {
-  N=10
+  N=9
   EQ=$(git grep -r --count ' == ' -- '**/*.ml' ':!ocaml/sdk-gen/**/*.ml' | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$EQ" -eq "$N" ]; then
     echo "OK counted $EQ usages of ' == '"

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -40,7 +40,7 @@ mli-files () {
 }
 
 structural-equality () {
-  N=11
+  N=10
   EQ=$(git grep -r --count ' == ' -- '**/*.ml' ':!ocaml/sdk-gen/**/*.ml' | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$EQ" -eq "$N" ]; then
     echo "OK counted $EQ usages of ' == '"

--- a/scripts/cdrommon@.service
+++ b/scripts/cdrommon@.service
@@ -2,6 +2,4 @@
 Description=Monitor CDROM of %I
 
 [Service]
-Type=forking
-GuessMainPID=no
 ExecStart=/opt/xensource/libexec/cdrommon /dev/xapi/cd/%I


### PR DESCRIPTION
Last usage of `Unixext.daemonize` was in `cdrommon`, drop it and move the daemon to be fully handled by systemd (instead of `type=forking`).

`cdrommon` service is only started by storage scripts, and I'm not sure if it's tested at all, but these changes pass BST+BVT.