### PR TITLE
ocaml: fix packages for quicktest and xs-trace tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -304,6 +304,7 @@
     ; 'xapi-tools' will have version ~dev, not 'master' like all the others
     ; because it is not in xs-opam yet
     rrd-transport
+    xapi-tracing-export
     (alcotest :with-test)
     (ppx_deriving_rpc :with-test)
     (qcheck-core :with-test)
@@ -391,6 +392,7 @@
     (xapi-stdext-zerocheck (= :version))
     (xapi-test-utils :with-test)
     (xapi-tracing (= :version))
+    (xapi-tracing-export (= :version))
     (xapi-types (= :version))
     xenctrl ; for quicktest
     xenstore_transport

--- a/ocaml/quicktest/dune
+++ b/ocaml/quicktest/dune
@@ -45,6 +45,6 @@
 
 (rule
  (alias runtest)
- (package xapi)
+ (package xapi-debug)
  (action (run ./quicktest.exe -skip-xapi -- list))
 )

--- a/ocaml/xs-trace/test/dune
+++ b/ocaml/xs-trace/test/dune
@@ -5,6 +5,6 @@
 
 (rule
   (alias runtest)
-  (package xapi)
+  (package xapi-tools)
   (deps test-xs-trace.sh ../xs_trace.exe test-source.json test-source.ndjson test_xs_trace.exe)
   (action (run bash test-xs-trace.sh)))

--- a/xapi-tools.opam
+++ b/xapi-tools.opam
@@ -28,6 +28,7 @@ depends: [
   "xmlm"
   "yojson"
   "rrd-transport"
+  "xapi-tracing-export"
   "alcotest" {with-test}
   "ppx_deriving_rpc" {with-test}
   "qcheck-core" {with-test}

--- a/xapi.opam
+++ b/xapi.opam
@@ -84,6 +84,7 @@ depends: [
   "xapi-stdext-zerocheck" {= version}
   "xapi-test-utils" {with-test}
   "xapi-tracing" {= version}
+  "xapi-tracing-export" {= version}
   "xapi-types" {= version}
   "xenctrl"
   "xenstore_transport"


### PR DESCRIPTION
They were misatributed to xapi, when the binaries are built for other packages