### PR TITLE
CA-399956 - xe autocompletion: Fix autocompletion for words with given prefix

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -771,7 +771,12 @@ __preprocess_suggestions()
     wordlist=$( echo "$1" | \
                 sed -re 's/(^|[^\])((\\\\)*),,*/\1\2\n/g' -e 's/\\,/,/g' -e 's/\\\\/\\/g' | \
                 sed -e 's/ *$//')
-    compgen -W "$wordlist" "$prefix"
+    local IFS=$'\n'
+    for word in $wordlist; do
+        if [[ "$word" =~ ^$prefix.* ]]; then
+            echo "$word"
+        fi
+    done
 }
 
 # set_completions suggestions current_prefix description_cmd


### PR DESCRIPTION
For unresolved reasons, `compgen -W` would not work as intended occasionally:

`xe host-param-get uuid=xxx param-na<TAB>`

would complete to:

`xe host-param-get uuid=xxx param-name=`

but typing:

`xe host-param-get uuid=xxx param-name=so<TAB>`

would not complete it to:

`xe host-param-get uuid=xxx param-name=software-version`

It's unlikely to be a bug in Bash since I couldn't find anything in the
changelog and upgrading the package did not fix it; nor could I reproduce it in
a different program with the same inputs - it is likely that something in the
environment breaks compgen. Switch to pure Bash string processing instead.