### PR TITLE
fix: do not expose new sublibrary of rrdd-plugin that depends on ezxenstore

### DIFF
--- a/ocaml/xapi-idl/lib/xcp_service.ml
+++ b/ocaml/xapi-idl/lib/xcp_service.ml
@@ -464,7 +464,13 @@ let configure ?(argv = Sys.argv) ?(options = []) ?(resources = []) () =
           (fun _ -> failwith "Invalid argument")
           (Printf.sprintf "Usage: %s [-config filename]" Sys.argv.(0))
     )
-  with Failure msg -> prerr_endline msg ; flush stderr ; exit 1
+  with
+  | Failure msg ->
+      prerr_endline msg ; flush stderr ; exit 1
+  | Arg.Bad msg ->
+      Printf.eprintf "%s" msg ; exit 2
+  | Arg.Help msg ->
+      Printf.printf "%s" msg ; exit 0
 
 let configure2 ~name ~version ~doc ?(options = []) ?(resources = []) () =
   configure_common ~options ~resources @@ fun config_spec ->

--- a/ocaml/xcp-rrdd/bin/rrdp-cpu/dune
+++ b/ocaml/xcp-rrdd/bin/rrdp-cpu/dune
@@ -4,7 +4,7 @@
   (libraries
     astring
     rrdd-plugin
-    rrdd-plugin.xenctrl
+    rrdd_plugin_xenctrl
     rrdd_plugins_libs
     xapi-idl.rrd
     xapi-log

--- a/ocaml/xcp-rrdd/bin/rrdp-iostat/dune
+++ b/ocaml/xcp-rrdd/bin/rrdp-iostat/dune
@@ -10,7 +10,7 @@
     mtime
     mtime.clock.os
     rrdd-plugin
-    rrdd-plugin.xenctrl
+    rrdd_plugin_xenctrl
     rrdd_plugins_libs
     str
     stringext

--- a/ocaml/xcp-rrdd/bin/rrdp-netdev/dune
+++ b/ocaml/xcp-rrdd/bin/rrdp-netdev/dune
@@ -4,7 +4,7 @@
   (libraries
     astring
     rrdd-plugin
-    rrdd-plugin.xenctrl
+    rrdd_plugin_xenctrl
     rrdd_plugins_libs
     xapi-idl
     xapi-idl.network

--- a/ocaml/xcp-rrdd/lib/plugin/dune
+++ b/ocaml/xcp-rrdd/lib/plugin/dune
@@ -24,7 +24,6 @@
 
 (library
   (name rrdd_plugin_xenctrl)
-  (public_name rrdd-plugin.xenctrl)
   (flags (:standard -bin-annot))
   (wrapped false)
   (modules xenctrl_lib)


### PR DESCRIPTION
ezxenstore wasn't being installed by the specfile, but a new dependency was added between the RRDD plugins and Ezxenstore.

We don't want to introduce new publicly installed packages in the specfile, so move ezxenstore to an existing package: the RRDD plugin one.