### PR TITLE
CA-399963: Block VM.start_on is feature flag is disabled

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1923,6 +1923,7 @@ functor
       let start_on ~__context ~vm ~host ~start_paused ~force =
         if Helpers.rolling_upgrade_in_progress ~__context then
           Helpers.assert_host_has_highest_version_in_pool ~__context ~host ;
+        Pool_features.assert_enabled ~__context ~f:Features.VM_start ;
         Xapi_vm_helpers.assert_matches_control_domain_affinity ~__context
           ~self:vm ~host ;
         (* Prevent VM start on a host that is evacuating *)


### PR DESCRIPTION
This was missed in cf8ba8b1f05c3490953f824c678528fba9a76bd2.