### PR TITLE
fix(test): avoid running XAPI hooks in unit tests

### DIFF
--- a/ocaml/tests/common/suite_init.ml
+++ b/ocaml/tests/common/suite_init.ml
@@ -1,5 +1,6 @@
 let harness_init () =
   (* before any calls to XAPI code, to catch early uses of Unix.select *)
+  Atomic.set Xapi_hooks.in_test true ;
   Xapi_stdext_unix.Unixext.test_open 1024 ;
   Xapi_stdext_unix.Unixext.mkdir_safe Test_common.working_area 0o755 ;
   (* Alcotest hides the standard output of successful tests,


### PR DESCRIPTION
If you install the XAPI RPMs in your koji build environment (e.g. to build a package that depends on XAPI) then you couldn't build XAPI again anymore because its unit tests were failing. They were failing because they found some xapi hooks installed by the previous version of XAPI, whereas normally there'd be none when the unit tests are running.

Disable running XAPI hooks during unit test, even if present we are not expected to run them.

```
[exception] Unix.Unix_error(Unix.ENOENT, "connect", "")
            Raised at Forkhelpers.execute_command_get_output_inner.(fun) in file "ocaml/forkexecd/lib/forkhelpers.ml", line 376, characters 10-19
            Called from Xapi_stdext_pervasives__Pervasiveext.finally in file "ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml", line 24, characters 8-14
            Re-raised at Xapi_stdext_pervasives__Pervasiveext.finally in file "ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml", line 39, characters 6-15
            Called from Xapi_hooks.execute_hook.(fun) in file "ocaml/xapi/xapi_hooks.ml", line 77, characters 10-113
            Called from Stdlib__Array.iter in file "array.ml", line 95, characters 31-48
            Called from Xapi_host.destroy in file "ocaml/xapi/xapi_host.ml", line 1108, characters 2-98
            Called from Dune__exe__Test_cluster_host.test_forget in file "ocaml/tests/test_cluster_host.ml", line 192, characters 2-42
            Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 181, characters 17-23
            Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
```