### PR TITLE
xapi-storage-script: attach tests to the package

### DIFF
--- a/ocaml/xapi-storage-script/dune
+++ b/ocaml/xapi-storage-script/dune
@@ -15,6 +15,7 @@
 (test
   (name test_lib)
   (modules test_lib)
+  (package xapi-storage-script)
   (libraries alcotest alcotest-lwt lwt fmt private)
   )
 


### PR DESCRIPTION
Otherwise opam + dune will try to run them as part of all the packages in the repository.