### PR TITLE
CP-51714: Remove noisy xenopsd debug logs

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1864,20 +1864,14 @@ let update_vm ~__context id =
     else
       let self = Db.VM.get_by_uuid ~__context ~uuid:id in
       let localhost = Helpers.get_localhost ~__context in
-      if Db.VM.get_resident_on ~__context ~self <> localhost then
-        debug "xenopsd event: ignoring event for VM (VM %s not resident)" id
-      else
+      if Db.VM.get_resident_on ~__context ~self = localhost then
         let previous = Xenops_cache.find_vm id in
         let dbg = Context.string_of_task_and_tracing __context in
         let module Client =
           (val make_client (queue_of_vm ~__context ~self) : XENOPS)
         in
         let info = try Some (Client.VM.stat dbg id) with _ -> None in
-        if Option.map snd info = previous then
-          debug
-            "xenopsd event: ignoring event for VM %s: metadata has not changed"
-            id
-        else (
+        if Option.map snd info <> previous then (
           debug "xenopsd event: processing event for VM %s" id ;
           if info = None then
             debug "xenopsd event: VM state missing: assuming VM has shut down" ;
@@ -2438,27 +2432,19 @@ let update_vm ~__context id =
 let update_vbd ~__context (id : string * string) =
   try
     if Events_from_xenopsd.are_suppressed (fst id) then
-      debug "xenopsd event: ignoring event for VM (VM %s migrating away)"
+      debug "xenopsd event: ignoring event for VBD (VM %s migrating away)"
         (fst id)
     else
       let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
       let localhost = Helpers.get_localhost ~__context in
-      if Db.VM.get_resident_on ~__context ~self:vm <> localhost then
-        debug "xenopsd event: ignoring event for VBD (VM %s not resident)"
-          (fst id)
-      else
+      if Db.VM.get_resident_on ~__context ~self:vm = localhost then
         let previous = Xenops_cache.find_vbd id in
         let dbg = Context.string_of_task_and_tracing __context in
         let module Client =
           (val make_client (queue_of_vm ~__context ~self:vm) : XENOPS)
         in
         let info = try Some (Client.VBD.stat dbg id) with _ -> None in
-        if Option.map snd info = previous then
-          debug
-            "xenopsd event: ignoring event for VBD %s.%s: metadata has not \
-             changed"
-            (fst id) (snd id)
-        else
+        if Option.map snd info <> previous then (
           let vbds = Db.VM.get_VBDs ~__context ~self:vm in
           let vbdrs =
             List.map
@@ -2541,6 +2527,7 @@ let update_vbd ~__context (id : string * string) =
           if not (Db.VBD.get_empty ~__context ~self:vbd) then
             let vdi = Db.VBD.get_VDI ~__context ~self:vbd in
             Xapi_vdi.update_allowed_operations ~__context ~self:vdi
+        )
   with e ->
     error "xenopsd event: Caught %s while updating VBD" (string_of_exn e)
 
@@ -2552,22 +2539,14 @@ let update_vif ~__context id =
     else
       let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
       let localhost = Helpers.get_localhost ~__context in
-      if Db.VM.get_resident_on ~__context ~self:vm <> localhost then
-        debug "xenopsd event: ignoring event for VIF (VM %s not resident)"
-          (fst id)
-      else
+      if Db.VM.get_resident_on ~__context ~self:vm = localhost then
         let previous = Xenops_cache.find_vif id in
         let dbg = Context.string_of_task_and_tracing __context in
         let module Client =
           (val make_client (queue_of_vm ~__context ~self:vm) : XENOPS)
         in
         let info = try Some (Client.VIF.stat dbg id) with _ -> None in
-        if Option.map snd info = previous then
-          debug
-            "xenopsd event: ignoring event for VIF %s.%s: metadata has not \
-             changed"
-            (fst id) (snd id)
-        else
+        if Option.map snd info <> previous then (
           let vifs = Db.VM.get_VIFs ~__context ~self:vm in
           let vifrs =
             List.map
@@ -2656,6 +2635,7 @@ let update_vif ~__context id =
             info ;
           Xenops_cache.update_vif id (Option.map snd info) ;
           Xapi_vif_helpers.update_allowed_operations ~__context ~self:vif
+        )
   with e ->
     error "xenopsd event: Caught %s while updating VIF" (string_of_exn e)
 
@@ -2667,22 +2647,14 @@ let update_pci ~__context id =
     else
       let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
       let localhost = Helpers.get_localhost ~__context in
-      if Db.VM.get_resident_on ~__context ~self:vm <> localhost then
-        debug "xenopsd event: ignoring event for PCI (VM %s not resident)"
-          (fst id)
-      else
+      if Db.VM.get_resident_on ~__context ~self:vm = localhost then
         let previous = Xenops_cache.find_pci id in
         let dbg = Context.string_of_task_and_tracing __context in
         let module Client =
           (val make_client (queue_of_vm ~__context ~self:vm) : XENOPS)
         in
         let info = try Some (Client.PCI.stat dbg id) with _ -> None in
-        if Option.map snd info = previous then
-          debug
-            "xenopsd event: ignoring event for PCI %s.%s: metadata has not \
-             changed"
-            (fst id) (snd id)
-        else
+        if Option.map snd info <> previous then (
           let pcis = Db.Host.get_PCIs ~__context ~self:localhost in
           let pcirs =
             List.map
@@ -2731,6 +2703,7 @@ let update_pci ~__context id =
             )
             info ;
           Xenops_cache.update_pci id (Option.map snd info)
+        )
   with e ->
     error "xenopsd event: Caught %s while updating PCI" (string_of_exn e)
 
@@ -2742,22 +2715,14 @@ let update_vgpu ~__context id =
     else
       let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
       let localhost = Helpers.get_localhost ~__context in
-      if Db.VM.get_resident_on ~__context ~self:vm <> localhost then
-        debug "xenopsd event: ignoring event for VGPU (VM %s not resident)"
-          (fst id)
-      else
+      if Db.VM.get_resident_on ~__context ~self:vm = localhost then
         let previous = Xenops_cache.find_vgpu id in
         let dbg = Context.string_of_task_and_tracing __context in
         let module Client =
           (val make_client (queue_of_vm ~__context ~self:vm) : XENOPS)
         in
         let info = try Some (Client.VGPU.stat dbg id) with _ -> None in
-        if Option.map snd info = previous then
-          debug
-            "xenopsd event: ignoring event for VGPU %s.%s: metadata has not \
-             changed"
-            (fst id) (snd id)
-        else
+        if Option.map snd info <> previous then (
           let vgpus = Db.VM.get_VGPUs ~__context ~self:vm in
           let vgpu_records =
             List.map
@@ -2802,33 +2767,26 @@ let update_vgpu ~__context id =
               )
               info ;
           Xenops_cache.update_vgpu id (Option.map snd info)
+        )
   with e ->
     error "xenopsd event: Caught %s while updating VGPU" (string_of_exn e)
 
 let update_vusb ~__context (id : string * string) =
   try
     if Events_from_xenopsd.are_suppressed (fst id) then
-      debug "xenopsd event: ignoring event for VM (VM %s migrating away)"
+      debug "xenopsd event: ignoring event for VUSB (VM %s migrating away)"
         (fst id)
     else
       let vm = Db.VM.get_by_uuid ~__context ~uuid:(fst id) in
       let localhost = Helpers.get_localhost ~__context in
-      if Db.VM.get_resident_on ~__context ~self:vm <> localhost then
-        debug "xenopsd event: ignoring event for VUSB (VM %s not resident)"
-          (fst id)
-      else
+      if Db.VM.get_resident_on ~__context ~self:vm = localhost then
         let previous = Xenops_cache.find_vusb id in
         let dbg = Context.string_of_task_and_tracing __context in
         let module Client =
           (val make_client (queue_of_vm ~__context ~self:vm) : XENOPS)
         in
         let info = try Some (Client.VUSB.stat dbg id) with _ -> None in
-        if Option.map snd info = previous then
-          debug
-            "xenopsd event: ignoring event for VUSB %s.%s: metadata has not \
-             changed"
-            (fst id) (snd id)
-        else
+        if Option.map snd info <> previous then (
           let pusb, _ =
             Db.VM.get_VUSBs ~__context ~self:vm
             |> List.map (fun self -> Db.VUSB.get_USB_group ~__context ~self)
@@ -2853,6 +2811,7 @@ let update_vusb ~__context (id : string * string) =
             info ;
           Xenops_cache.update_vusb id (Option.map snd info) ;
           Xapi_vusb_helpers.update_allowed_operations ~__context ~self:vusb
+        )
   with e ->
     error "xenopsd event: Caught %s while updating VUSB" (string_of_exn e)
 

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2376,11 +2376,8 @@ module VM = struct
       | Dynamic.Vm id when id = vm.Vm.id ->
           debug "EVENT on our VM: %s" id ;
           Some ()
-      | Dynamic.Vm id ->
-          debug "EVENT on other VM: %s" id ;
-          None
       | _ ->
-          debug "OTHER EVENT" ; None
+          None
     in
     let vm_has_shutdown () =
       on_domain task vm (fun _ _ _ _ di -> di.Xenctrl.shutdown)


### PR DESCRIPTION
This is probably overzealous, so please let me know if some of these logs are still helpful. I have kept the "migrating away" logs as Christian said these are rare.