### PR TITLE
message-switch: remove dependency on async binaries

### DIFF
--- a/ocaml/message-switch/core_test/dune
+++ b/ocaml/message-switch/core_test/dune
@@ -5,7 +5,7 @@
     server_unix_main
     lock_test_lwt
   )
-  (modules 
+  (modules
     client_unix_main
     server_unix_main
     lock_test_lwt
@@ -48,8 +48,6 @@
   (deps
     client_unix_main.exe
     server_unix_main.exe
-    async/client_async_main.exe
-    async/server_async_main.exe
     lwt/client_main.exe
     lwt/server_main.exe
     lwt/link_test_main.exe


### PR DESCRIPTION
The stresstest rule still contained references to async binaries. I haven't seen any other reference to async in the dune files