### PR TITLE
xapi-stdext-unix: catch exceptions in the test server

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.ml
@@ -1,4 +1,4 @@
-let _ =
+let () =
   let module Daemon = Xapi_stdext_unix.Unixext.Daemon in
   let notify_test () =
     if Daemon.systemd_notify Daemon.State.Ready then
@@ -22,15 +22,18 @@ let _ =
       ) else
         temp_path
     in
-    Unix.(
-      let sock = socket PF_UNIX SOCK_DGRAM 0 ~cloexec:true in
-      bind sock (ADDR_UNIX socket_path) ;
+    let sock = Unix.(socket PF_UNIX SOCK_DGRAM 0 ~cloexec:true) in
+    try
+      Unix.bind sock (Unix.ADDR_UNIX socket_path) ;
       let b = Bytes.create 1024 in
-      let i, _ = recvfrom sock b 0 1024 [] in
+      let i, _ = Unix.recvfrom sock b 0 1024 [] in
       print_endline (Bytes.sub_string b 0 i) ;
-      close sock
-    )
+      Unix.close sock
+    with e ->
+      print_endline (Printexc.to_string e) ;
+      exit 5
   in
+
   let booted_test () =
     if Daemon.systemd_booted () then (
       print_endline "Booted with systemd" ;


### PR DESCRIPTION
Setting up the server for the tests sometimes fails to write the new state to stdout. Catch an exceptions while binding the socket to print them and make the issue more visible.

Ironically, as soon as I started testing xs-opam with this patch, the issue magically disappeared, so I don't know what went wrong.