### PR TITLE
CP-50603: Replace `c_rehash` with `openssl rehash` sub command

### DIFF
--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -51,7 +51,15 @@ let library_filename kind name = Filename.concat (library_path kind) name
 let mkdir_cert_path kind = Unixext.mkdir_rec (library_path kind) 0o700
 
 let rehash' path =
-  ignore (Forkhelpers.execute_command_get_output !Xapi_globs.c_rehash [path])
+  match Sys.file_exists !Xapi_globs.c_rehash with
+  | true ->
+      Forkhelpers.execute_command_get_output !Xapi_globs.c_rehash [path]
+      |> ignore
+  | false ->
+      (* c_rehash will be replaced with openssl sub-command in newer version *)
+      Forkhelpers.execute_command_get_output !Constants.openssl_path
+        ["rehash"; path]
+      |> ignore
 
 let rehash () =
   mkdir_cert_path CA_Certificate ;

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -768,7 +768,7 @@ let server_cert_group_id = ref (-1)
 let server_cert_internal_path =
   ref (Filename.concat "/etc/xensource" "xapi-pool-tls.pem")
 
-let c_rehash = ref "c_rehash"
+let c_rehash = ref "/usr/bin/c_rehash"
 
 let trusted_certs_dir = ref "/etc/stunnel/certs"
 
@@ -1714,7 +1714,6 @@ module Resources = struct
     ; ("createrepo-cmd", createrepo_cmd, "Path to createrepo command")
     ; ("modifyrepo-cmd", modifyrepo_cmd, "Path to modifyrepo command")
     ; ("rpm-cmd", rpm_cmd, "Path to rpm command")
-    ; ("c_rehash", c_rehash, "Path to Regenerate CA store")
     ]
 
   let nonessential_executables =
@@ -1795,6 +1794,7 @@ module Resources = struct
       , yum_config_manager_cmd
       , "Path to yum-config-manager command"
       )
+    ; ("c_rehash", c_rehash, "Path to regenerate CA store")
     ]
 
   let essential_files =


### PR DESCRIPTION
`openssl rehash` sub command provides the same functionality for `c_rehash`, but quicker
We replace `c_rehash` with `openssl rehash` in XS9, However, we will keep `c_rehash` compatbilility for XS8 stream