### PR TITLE
XSI-1722 fix timer for host heartbeat

### DIFF
--- a/ocaml/xapi/db_gc.ml
+++ b/ocaml/xapi/db_gc.ml
@@ -91,8 +91,12 @@ let check_host_liveness ~__context =
               | Some x ->
                   x
               | None ->
-                  Clock.Timer.start
-                    ~duration:!Xapi_globs.host_assumed_dead_interval
+                  let t =
+                    Clock.Timer.start
+                      ~duration:!Xapi_globs.host_assumed_dead_interval
+                  in
+                  Hashtbl.replace host_heartbeat_table host t ;
+                  t
           )
         in
         if not (Clock.Timer.has_expired timer) then


### PR DESCRIPTION
In XSI-1722 we notive that xapi does not detect a host beeing offline based on the heartbeat. The reason is a bug: we miss to store a new timer in the corresponding hashtable.