### PR TITLE
CP-51393: Datamodel: update Repository for syncing from a remote pool

### DIFF
--- a/ocaml/idl/datamodel_repository.ml
+++ b/ocaml/idl/datamodel_repository.ml
@@ -24,6 +24,7 @@ let origin =
     , [
         ("remote", "The origin of the repository is a remote one")
       ; ("bundle", "The origin of the repository is a local bundle file")
+      ; ("remote_pool", "The origin of the repository is a remote pool")
       ]
     )
 
@@ -89,6 +90,27 @@ let introduce_bundle =
       [
         (String, "name_label", "The name of the repository")
       ; (String, "name_description", "The description of the repository")
+      ]
+    ~result:(Ref _repository, "The ref of the created repository record.")
+    ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)
+    ()
+
+let introduce_remote_pool =
+  call ~name:"introduce_remote_pool" ~in_oss_since:None ~lifecycle:[]
+    ~doc:"Add the configuration for a new remote pool repository"
+    ~params:
+      [
+        (String, "name_label", "The name of the repository")
+      ; (String, "name_description", "The description of the repository")
+      ; ( String
+        , "binary_url"
+        , "Base URL of binary packages in the local repository of this remote \
+           pool in https://<coordinator-ip>/repository format"
+        )
+      ; ( String
+        , "certificate"
+        , "The host certificate of the coordinator of the remote pool"
+        )
       ]
     ~result:(Ref _repository, "The ref of the created repository record.")
     ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)
@@ -173,6 +195,7 @@ let t =
       [
         introduce
       ; introduce_bundle
+      ; introduce_remote_pool
       ; forget
       ; apply
       ; set_gpgkey_path
@@ -223,8 +246,12 @@ let t =
           "The file name of the GPG public key of this repository"
       ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:origin "origin"
           ~default_value:(Some (VEnum "remote"))
-          "The origin of the repository. 'remote' if the origin of the \
+          "The origin of this repository. 'remote' if the origin of the \
            repository is a remote one, 'bundle' if the origin of the \
-           repository is a local bundle file."
+           repository is a local bundle file, 'remote_pool' if the origin of \
+           the repository is a remote pool"
+      ; field ~qualifier:StaticRO ~lifecycle:[] ~ty:String
+          ~default_value:(Some (VString "")) "certificate"
+          "The certificate of the host which hosts this repository"
       ]
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "8fcd8892ec0c7d130b0da44c5fd3990b"
+let last_known_schema_hash = "aba698bd66b04e0145f07130e6db9cad"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3684,6 +3684,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "repository-introduce-remote-pool"
+    , {
+        reqd= ["name-label"; "binary-url"; "certificate-file"]
+      ; optn= ["name-description"]
+      ; help= "Add the configuration for a new remote pool repository."
+      ; implementation= With_fd Cli_operations.Repository.introduce_remote_pool
+      ; flags= []
+      }
+    )
   ; ( "repository-forget"
     , {
         reqd= ["uuid"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -7936,6 +7936,21 @@ module Repository = struct
     let uuid = Client.Repository.get_uuid ~rpc ~session_id ~self:ref in
     printer (Cli_printer.PList [uuid])
 
+  let introduce_remote_pool fd printer rpc session_id params =
+    let name_label = List.assoc "name-label" params in
+    let name_description = get_param params "name-description" ~default:"" in
+    let binary_url = List.assoc "binary-url" params in
+    let certificate =
+      List.assoc "certificate-file" params
+      |> get_file_or_fail fd "certificate file"
+    in
+    let ref =
+      Client.Repository.introduce_remote_pool ~rpc ~session_id ~name_label
+        ~name_description ~binary_url ~certificate
+    in
+    let uuid = Client.Repository.get_uuid ~rpc ~session_id ~self:ref in
+    printer (Cli_printer.PList [uuid])
+
   let forget _printer rpc session_id params =
     let ref =
       Client.Repository.get_by_uuid ~rpc ~session_id

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5287,6 +5287,9 @@ let repository_record rpc session_id repository =
             Record_util.origin_to_string (x ()).API.repository_origin
           )
           ()
+      ; make_field ~name:"certificate" ~hidden:true
+          ~get:(fun () -> (x ()).API.repository_certificate)
+          ()
       ]
   }
 

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -6608,6 +6608,15 @@ functor
         Local.Repository.introduce_bundle ~__context ~name_label
           ~name_description
 
+      let introduce_remote_pool ~__context ~name_label ~name_description
+          ~binary_url ~certificate =
+        info
+          "Repository.introduce_remote_pool: name = '%s'; name_description = \
+           '%s'; binary_url = '%s'; certificate = '%s'"
+          name_label name_description binary_url certificate ;
+        Local.Repository.introduce_remote_pool ~__context ~name_label
+          ~name_description ~binary_url ~certificate
+
       let forget ~__context ~self =
         info "Repository.forget: self = '%s'" (repository_uuid ~__context self) ;
         Local.Repository.forget ~__context ~self

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -28,6 +28,14 @@ val introduce_bundle :
   -> name_description:string
   -> [`Repository] API.Ref.t
 
+val introduce_remote_pool :
+     __context:Context.t
+  -> name_label:string
+  -> name_description:string
+  -> binary_url:string
+  -> certificate:string
+  -> [`Repository] API.Ref.t
+
 val forget : __context:Context.t -> self:[`Repository] API.Ref.t -> unit
 
 val cleanup_all_pool_repositories : unit -> unit

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -136,12 +136,12 @@ module GuidanceSet = struct
 end
 
 let create_repository_record ~__context ~name_label ~name_description
-    ~binary_url ~source_url ~update ~gpgkey_path ~origin =
+    ~binary_url ~source_url ~update ~gpgkey_path ~origin ~certificate =
   let ref = Ref.make () in
   let uuid = Uuidx.(to_string (make ())) in
   Db.Repository.create ~__context ~ref ~uuid ~name_label ~name_description
     ~binary_url ~source_url ~update ~hash:"" ~up_to_date:false ~gpgkey_path
-    ~origin ;
+    ~origin ~certificate ;
   ref
 
 module DomainNameIncludeIP = struct
@@ -384,6 +384,8 @@ let get_remote_repository_name ~__context ~self =
         !Xapi_globs.remote_repository_prefix
     | `bundle ->
         !Xapi_globs.bundle_repository_prefix
+    | `remote_pool ->
+        !Xapi_globs.remote_pool_repository_prefix
   in
   prefix ^ "-" ^ get_repository_name ~__context ~self
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -933,6 +933,8 @@ let remote_repository_prefix = ref "remote"
 
 let bundle_repository_prefix = ref "bundle"
 
+let remote_pool_repository_prefix = ref "remote-pool"
+
 let local_repository_prefix = ref "local"
 
 let yum_config_manager_cmd = ref "/usr/bin/yum-config-manager"

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3898,7 +3898,7 @@ let put_bundle_handler (req : Request.t) s _ =
                   ) ;
                 Http_svr.headers s (Http.http_400_badrequest ())
           )
-        | `remote ->
+        | `remote | `remote_pool ->
             error "%s: Bundle repo is not enabled" __FUNCTION__ ;
             TaskHelper.failed ~__context
               Api_errors.(Server_error (bundle_repo_not_enabled, [])) ;


### PR DESCRIPTION
- add a new type of origin: "remote_pool"
- add a new API: "introduce_remote_pool" to init a remote_pool repository
- add a new field: "certificate" for a remote_pool repository
- for a remote_pool repository, binary_url will be reused to hold the
  base URL of binary packages of applied updates in the remote pool:
  https://<coordinator-ip>/applied_updates