### PR TITLE
Replace fold with of_list in rbac

### DIFF
--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -69,10 +69,7 @@ let session_permissions_tbl = Hashtbl.create 256 (* initial 256 sessions *)
 
 module Permission_set = Set.Make (String)
 
-let permission_set permission_list =
-  List.fold_left
-    (fun set r -> Permission_set.add r set)
-    Permission_set.empty permission_list
+let permission_set = Permission_set.of_list
 
 let create_session_permissions_tbl ~session_id ~rbac_permissions =
   if


### PR DESCRIPTION
Folding over a list to add its elements to a set (which is initially empty) is operationally equivalent to calling of_list (of the set), but potentially less efficient.

The implementation of of_list only uses `add` for small lists, e.g. the cases for lists `[x_1; x_2; ...; x_N]` for all `N` in range `2 <= N <= 5` are matched literally and expanded to:
```
add x_N (... (add x_1 (singleton x_0)))
```
However, larger lists are first sorted and the underlying tree representing the set is constructed directly.

---

This is a stray change I cherry-picked from another branch.