### PR TITLE
CP-51870: Refresh toolstack services

### DIFF
--- a/python3/perfmon/perfmon.service
+++ b/python3/perfmon/perfmon.service
@@ -2,6 +2,7 @@
 Description=Performance monitoring/alarm generation daemon
 After=xapi.service
 Wants=xapi.service
+PartOf=toolstack.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/perfmon

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -152,3 +152,6 @@ install:
 	$(IDATA) mail-languages/ja-JP.json $(DESTDIR)/etc/xapi.d/mail-languages
 # uefi
 	mkdir -p $(DESTDIR)/etc/xapi.d/efi-clone
+
+# toolstack.target to manage toolstack services as a group
+	$(IDATA) toolstack.target  $(DESTDIR)/usr/lib/systemd/system/toolstack.target

--- a/scripts/toolstack.target
+++ b/scripts/toolstack.target
@@ -1,0 +1,27 @@
+[Unit]
+Description=toolstack Target to manage toolstack service restart
+# wants to start following services when run `systemctl start toolstack.target`
+# Note: `Wants` is used here instead of `Requires`, `Requires` will stop/restart
+# whole toolstack.target on any service stop/restart
+Wants=xapi.service
+Wants=message-switch.service
+Wants=forkexecd.service
+Wants=perfmon.service
+Wants=v6d.service
+Wants=xcp-rrdd-iostat.service
+Wants=xcp-rrdd-squeezed.service
+Wants=xcp-rrdd-netdev.service
+Wants=xcp-rrdd-dcmi.service
+Wants=xcp-rrdd-cpu.service
+Wants=xcp-rrdd-xenpm.service
+Wants=xcp-rrdd-gpumon.service
+Wants=xcp-rrdd.service
+Wants=xcp-networkd.service
+Wants=xenopsd-xc.service
+Wants=squeezed.service
+Wants=xapi-storage-script.service
+Wants=xapi-clusterd.service
+Wants=varstored-guard.service
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/varstored-guard.service
+++ b/scripts/varstored-guard.service
@@ -2,8 +2,9 @@
 Description=Varstored XAPI socket deprivileging daemon
 Documentation=man:varstored-guard(1)
 After=message-switch.service syslog.target
-Before=xapi-domains.service xenopsd.service
+Before=xapi-domains.service xenopsd-xc.service
 Wants=message-switch.service syslog.target
+PartOf=toolstack.target
 
 [Service]
 Type=simple

--- a/scripts/xapi.service
+++ b/scripts/xapi.service
@@ -16,6 +16,7 @@ After=xcp-rrdd.service
 After=xenopsd-xc.service
 After=xenstored.service
 After=stunnel@xapi.service
+PartOf=toolstack.target
 
 Conflicts=shutdown.target
 

--- a/scripts/xcp-networkd.service
+++ b/scripts/xcp-networkd.service
@@ -3,6 +3,7 @@ Description=XCP networking daemon
 Documentation=man:xcp-networkd(1)
 After=forkexecd.service message-switch.service syslog.target
 Wants=forkexecd.service message-switch.service syslog.target
+PartOf=toolstack.target
 
 [Service]
 Type=notify

--- a/scripts/xcp-rrdd-cpu.service
+++ b/scripts/xcp-rrdd-cpu.service
@@ -2,6 +2,7 @@
 Description=XCP RRD daemon CPU plugin
 After=xcp-rrdd.service
 Requires=xcp-rrdd.service
+PartOf=toolstack.target
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-cpu

--- a/scripts/xcp-rrdd-dcmi.service
+++ b/scripts/xcp-rrdd-dcmi.service
@@ -2,6 +2,7 @@
 Description=XCP RRD daemon IPMI DCMI power plugin
 After=xcp-rrdd.service
 Requires=xcp-rrdd.service
+PartOf=toolstack.target
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-dcmi

--- a/scripts/xcp-rrdd-iostat.service
+++ b/scripts/xcp-rrdd-iostat.service
@@ -2,6 +2,7 @@
 Description=XCP RRD daemon iostat plugin
 After=xcp-rrdd.service
 Requires=xcp-rrdd.service
+PartOf=toolstack.target
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-iostat

--- a/scripts/xcp-rrdd-netdev.service
+++ b/scripts/xcp-rrdd-netdev.service
@@ -2,6 +2,7 @@
 Description=XCP RRD daemon network plugin
 After=xcp-rrdd.service
 Requires=xcp-rrdd.service
+PartOf=toolstack.target
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-netdev

--- a/scripts/xcp-rrdd-squeezed.service
+++ b/scripts/xcp-rrdd-squeezed.service
@@ -2,6 +2,7 @@
 Description=XCP RRD daemon squeezed plugin
 After=xcp-rrdd.service
 Requires=xcp-rrdd.service
+PartOf=toolstack.target
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-squeezed

--- a/scripts/xcp-rrdd-xenpm.service
+++ b/scripts/xcp-rrdd-xenpm.service
@@ -2,6 +2,7 @@
 Description=XCP RRD daemon xenpm plugin
 After=xcp-rrdd.service
 Requires=xcp-rrdd.service
+PartOf=toolstack.target
 
 [Service]
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-xenpm

--- a/scripts/xcp-rrdd.service
+++ b/scripts/xcp-rrdd.service
@@ -2,6 +2,7 @@
 Description=XCP RRD daemon
 After=forkexecd.service xenstored.service message-switch.service syslog.target
 Wants=forkexecd.service xenstored.service message-switch.service syslog.target
+PartOf=toolstack.target
 
 [Service]
 Type=notify

--- a/scripts/xe-toolstack-restart
+++ b/scripts/xe-toolstack-restart
@@ -27,11 +27,6 @@ echo "Executing $FILENAME"
 
 POOLCONF=`cat @ETCXENDIR@/pool.conf`
 if [ $POOLCONF == "master" ]; then MPATHALERT="mpathalert"; else MPATHALERT=""; fi
-SERVICES="message-switch perfmon v6d xenopsd xenopsd-xc xenopsd-xenlight
-  xenopsd-simulator xenopsd-libvirt xcp-rrdd-iostat xcp-rrdd-squeezed
-  xcp-rrdd-netdev xcp-rrdd-cpu
-  xcp-rrdd-xenpm xcp-rrdd-gpumon xcp-rrdd xcp-networkd squeezed forkexecd
-  $MPATHALERT xapi-storage-script xapi-clusterd varstored-guard"
 
 tmp_file=$(mktemp --suffix="xe-toolstack-restart")
 systemctl stop stunnel@xapi > $tmp_file 2>&1
@@ -43,22 +38,23 @@ if [[ $kill_stunnel_exit_code != 0 ]]; then
 fi
 rm -f $tmp_file
 
-TO_RESTART=""
-for svc in $SERVICES ; do
-	# restart services only if systemd said they were enabled
-	systemctl is-enabled $svc >/dev/null 2>&1
-
-	if [ $? -eq 0 ] ; then
-		TO_RESTART="$svc $TO_RESTART"
-	fi
-done
-systemctl stop xapi
-systemctl stop ${TO_RESTART}
-
 set -e
 
-systemctl start ${TO_RESTART}
-systemctl start xapi
+systemctl restart $MPATHALERT toolstack.target
+
+# Check the status of toolstack services
+for service in $(systemctl list-dependencies --plain --no-pager toolstack.target); do
+  # During system bootup, xcp-rrdd-dcmi.service often fail as
+  # `ipmitool dcmi discover` discover nothing, just ignore it for now
+  if [ "$service" == "xcp-rrdd-dcmi.service" ]; then
+     continue
+  fi
+
+  if ! systemctl is-active --quiet "$service"; then
+     echo "$service failed to restart, $(systemctl status $service)"
+     exit 1
+  fi
+done
 
 rm -f $LOCKFILE
 echo "done."


### PR DESCRIPTION
- varstored-guard Before: xenopsd.servcie->xenopsd-xc.service
- Remove unnecessary xenopsd services
  * xenopsd
  * xenopsd-xenlight
  * xenopsd-simulator
  * xenopsd-libvirt
- Reorder services to stop/start
  * forkexecd: does not depends on others, move to last
  * xenopsd-xc After xcp-rrdd. so it needs after xcp-rrdd-*

Note: the for loop reverse the TO_RESTART order