### PR TITLE
xapi_stdext_unix/test: Fix intermittent systemd cram test failure

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.t
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.t
@@ -10,8 +10,8 @@
   $ ./test_systemd.exe --server &
   @systemd.socket
   READY=1
-  $ sleep 1
   $ ./test_systemd.exe --notify
+  $ wait
 
 == Use socket files
   $ export TMPDIR=${TMPDIR:-/tmp}
@@ -22,6 +22,7 @@
   $ sleep 1
   $ test -S "$NOTIFY_SOCKET"
   $ ./test_systemd.exe --notify
+  $ wait
 
 == Currently not run tests because of insufficient permissions
 ==  in cram to be manipulating this file


### PR DESCRIPTION
Instead of sleeping and hoping for the best, wait for the background job to finish.