### PR TITLE
Access pvsproxy via a socket in /run

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -1474,7 +1474,7 @@ end
 module PVS_proxy = struct
   open S.PVS_proxy
 
-  let path = ref "/opt/citrix/pvsproxy/socket/pvsproxy"
+  let path = ref "/run/pvsproxy"
 
   let do_call call =
     try Jsonrpc_client.with_rpc ~path:!path ~call ()


### PR DESCRIPTION
The pvsproxy socket is available in both /opt/ and /run. Since /run is a more sensible location for a socket, use that one to allow the other to be removed in the future.