### PR TITLE
Remove tracing dependency from http-lib and add baggage

### DIFF
--- a/ocaml/libs/http-lib/dune
+++ b/ocaml/libs/http-lib/dune
@@ -30,7 +30,6 @@
     xapi-stdext-threads
     xapi-stdext-unix
     xml-light2
-    tracing
   )
 )
 
@@ -46,6 +45,7 @@
     polly
     threads.posix
     tracing
+    tracing_propagator
     uri
     xapi-log
     xapi-stdext-pervasives

--- a/ocaml/libs/http-lib/http.ml
+++ b/ocaml/libs/http-lib/http.ml
@@ -674,35 +674,6 @@ module Request = struct
     let headers, body = to_headers_and_body x in
     let frame_header = if x.frame then make_frame_header headers else "" in
     frame_header ^ headers ^ body
-
-  (* let traceparent_of req = *)
-  (*   let open Tracing in *)
-  (*   let ( let* ) = Option.bind in *)
-  (*   let* traceparent = req.traceparent in *)
-  (*   let* span_context = SpanContext.of_traceparent traceparent in *)
-  (*   let span = Tracer.span_of_span_context span_context req.uri in *)
-  (*   Some span *)
-
-  (* let with_tracing ?attributes ~name req f = *)
-  (*   let open Tracing in *)
-  (*   let parent = traceparent_of req in *)
-  (*   with_child_trace ?attributes parent ~name (fun (span : Span.t option) -> *)
-  (*       match span with *)
-  (*       | Some span -> *)
-  (*           let traceparent = *)
-  (*             Some (span |> Span.get_context |> SpanContext.to_traceparent) *)
-  (*           in *)
-  (*           let req = {req with traceparent} in *)
-  (*           f req *)
-  (*       | None -> *)
-  (*           f req *)
-  (*   ) *)
-
-  let traceparent_of _ = None
-
-  let with_tracing ?attributes ~name =
-    ignore (attributes, name) ;
-    Fun.flip ( @@ )
 end
 
 module Response = struct

--- a/ocaml/libs/http-lib/http.ml
+++ b/ocaml/libs/http-lib/http.ml
@@ -132,8 +132,6 @@ module Hdr = struct
 
   let location = "location"
 
-  let traceparent = "traceparent"
-
   let hsts = "strict-transport-security"
 end
 
@@ -522,7 +520,6 @@ module Request = struct
     ; mutable close: bool
     ; additional_headers: (string * string) list
     ; body: string option
-    ; traceparent: string option
   }
   [@@deriving rpc]
 
@@ -546,12 +543,11 @@ module Request = struct
     ; close= true
     ; additional_headers= []
     ; body= None
-    ; traceparent= None
     }
 
   let make ?(frame = false) ?(version = "1.1") ?(keep_alive = true) ?accept
       ?cookie ?length ?auth ?subtask_of ?body ?(headers = []) ?content_type
-      ?host ?(query = []) ?traceparent ~user_agent meth path =
+      ?host ?(query = []) ~user_agent meth path =
     {
       empty with
       version
@@ -570,7 +566,6 @@ module Request = struct
     ; body
     ; accept
     ; query
-    ; traceparent
     }
 
   let get_version x = x.version
@@ -582,8 +577,7 @@ module Request = struct
     Printf.sprintf
       "{ frame = %b; method = %s; uri = %s; query = [ %s ]; content_length = [ \
        %s ]; transfer encoding = %s; version = %s; cookie = [ %s ]; task = %s; \
-       subtask_of = %s; content-type = %s; host = %s; user_agent = %s; \
-       traceparent = %s }"
+       subtask_of = %s; content-type = %s; host = %s; user_agent = %s; }"
       x.frame (string_of_method_t x.m) x.uri (kvpairs x.query)
       (Option.fold ~none:"" ~some:Int64.to_string x.content_length)
       (Option.value ~default:"" x.transfer_encoding)
@@ -593,7 +587,6 @@ module Request = struct
       (Option.value ~default:"" x.content_type)
       (Option.value ~default:"" x.host)
       (Option.value ~default:"" x.user_agent)
-      (Option.value ~default:"" x.traceparent)
 
   let to_header_list x =
     let kvpairs x =
@@ -643,11 +636,6 @@ module Request = struct
         ~some:(fun x -> [Hdr.user_agent ^ ": " ^ x])
         x.user_agent
     in
-    let traceparent =
-      Option.fold ~none:[]
-        ~some:(fun x -> [Hdr.traceparent ^ ": " ^ x])
-        x.traceparent
-    in
     let close =
       [(Hdr.connection ^ ": " ^ if x.close then "close" else "keep-alive")]
     in
@@ -665,7 +653,6 @@ module Request = struct
     @ content_type
     @ host
     @ user_agent
-    @ traceparent
     @ close
     @ List.map (fun (k, v) -> k ^ ": " ^ v) x.additional_headers
 
@@ -688,28 +675,34 @@ module Request = struct
     let frame_header = if x.frame then make_frame_header headers else "" in
     frame_header ^ headers ^ body
 
-  let traceparent_of req =
-    let open Tracing in
-    let ( let* ) = Option.bind in
-    let* traceparent = req.traceparent in
-    let* span_context = SpanContext.of_traceparent traceparent in
-    let span = Tracer.span_of_span_context span_context req.uri in
-    Some span
+  (* let traceparent_of req = *)
+  (*   let open Tracing in *)
+  (*   let ( let* ) = Option.bind in *)
+  (*   let* traceparent = req.traceparent in *)
+  (*   let* span_context = SpanContext.of_traceparent traceparent in *)
+  (*   let span = Tracer.span_of_span_context span_context req.uri in *)
+  (*   Some span *)
 
-  let with_tracing ?attributes ~name req f =
-    let open Tracing in
-    let parent = traceparent_of req in
-    with_child_trace ?attributes parent ~name (fun (span : Span.t option) ->
-        match span with
-        | Some span ->
-            let traceparent =
-              Some (span |> Span.get_context |> SpanContext.to_traceparent)
-            in
-            let req = {req with traceparent} in
-            f req
-        | None ->
-            f req
-    )
+  (* let with_tracing ?attributes ~name req f = *)
+  (*   let open Tracing in *)
+  (*   let parent = traceparent_of req in *)
+  (*   with_child_trace ?attributes parent ~name (fun (span : Span.t option) -> *)
+  (*       match span with *)
+  (*       | Some span -> *)
+  (*           let traceparent = *)
+  (*             Some (span |> Span.get_context |> SpanContext.to_traceparent) *)
+  (*           in *)
+  (*           let req = {req with traceparent} in *)
+  (*           f req *)
+  (*       | None -> *)
+  (*           f req *)
+  (*   ) *)
+
+  let traceparent_of _ = None
+
+  let with_tracing ?attributes ~name =
+    ignore (attributes, name) ;
+    Fun.flip ( @@ )
 end
 
 module Response = struct

--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -126,11 +126,6 @@ module Request : sig
 
   val to_wire_string : t -> string
   (** [to_wire_string t] returns a string which could be sent to a server *)
-
-  val traceparent_of : t -> Tracing.Span.t option
-
-  val with_tracing :
-    ?attributes:(string * string) list -> name:string -> t -> (t -> 'a) -> 'a
 end
 
 (** Parsed form of the HTTP response *)

--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -86,7 +86,6 @@ module Request : sig
     ; mutable close: bool
     ; additional_headers: (string * string) list
     ; body: string option
-    ; traceparent: string option
   }
 
   val rpc_of_t : t -> Rpc.t
@@ -109,7 +108,6 @@ module Request : sig
     -> ?content_type:string
     -> ?host:string
     -> ?query:(string * string) list
-    -> ?traceparent:string
     -> user_agent:string
     -> method_t
     -> string
@@ -228,8 +226,6 @@ module Hdr : sig
   val accept : string
 
   val location : string
-
-  val traceparent : string
 
   val hsts : string
   (** Header used for HTTP Strict Transport Security *)

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -409,8 +409,6 @@ let read_request_exn ~proxy_seen ~read_timeout ~total_timeout ~max_length fd =
                        {req with host= Some v}
                    | k when k = Http.Hdr.user_agent ->
                        {req with user_agent= Some v}
-                   | k when k = Http.Hdr.traceparent ->
-                       {req with traceparent= Some v}
                    | k when k = Http.Hdr.connection && lowercase v = "close" ->
                        {req with close= true}
                    | k

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -101,7 +101,7 @@ let response_of_request req hdrs =
 
 module Helper = struct
   include Tracing.Propagator.Make (struct
-    include Propagator.Http
+    include Tracing_propagator.Propagator.Http
 
     let name_span req = req.Http.Request.uri
   end)

--- a/ocaml/libs/http-lib/xmlrpc_client.ml
+++ b/ocaml/libs/http-lib/xmlrpc_client.ml
@@ -50,15 +50,16 @@ let connect ?session_id ?task_id ?subtask_of path =
 
 let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth
     ?subtask_of ?query ?body ?(tracing = None) path =
-  let traceparent =
-    let open Tracing in
-    Option.map
-      (fun span -> Span.get_context span |> SpanContext.to_traceparent)
-      tracing
-  in
+  (* let traceparent = *)
+  (*   let open Tracing in *)
+  (*   Option.map *)
+  (*     (fun span -> Span.get_context span |> SpanContext.to_traceparent) *)
+  (*     tracing *)
+  (* in *)
+  ignore tracing ;
   let headers = Option.map (fun x -> [(Http.Hdr.task_id, x)]) task_id in
   Http.Request.make ~user_agent ?frame ?version ?keep_alive ?cookie ?headers
-    ?length ?auth ?subtask_of ?query ?body ?traceparent Http.Post path
+    ?length ?auth ?subtask_of ?query ?body Http.Post path
 
 (** Thrown when ECONNRESET is caught which suggests the remote crashed or restarted *)
 exception Connection_reset

--- a/ocaml/libs/http-lib/xmlrpc_client.ml
+++ b/ocaml/libs/http-lib/xmlrpc_client.ml
@@ -49,14 +49,7 @@ let connect ?session_id ?task_id ?subtask_of path =
     ?subtask_of Http.Connect path
 
 let xmlrpc ?frame ?version ?keep_alive ?task_id ?cookie ?length ?auth
-    ?subtask_of ?query ?body ?(tracing = None) path =
-  (* let traceparent = *)
-  (*   let open Tracing in *)
-  (*   Option.map *)
-  (*     (fun span -> Span.get_context span |> SpanContext.to_traceparent) *)
-  (*     tracing *)
-  (* in *)
-  ignore tracing ;
+    ?subtask_of ?query ?body path =
   let headers = Option.map (fun x -> [(Http.Hdr.task_id, x)]) task_id in
   Http.Request.make ~user_agent ?frame ?version ?keep_alive ?cookie ?headers
     ?length ?auth ?subtask_of ?query ?body Http.Post path

--- a/ocaml/libs/http-lib/xmlrpc_client.mli
+++ b/ocaml/libs/http-lib/xmlrpc_client.mli
@@ -72,7 +72,6 @@ val xmlrpc :
   -> ?subtask_of:string
   -> ?query:(string * string) list
   -> ?body:string
-  -> ?tracing:Tracing.Span.t option
   -> string
   -> Http.Request.t
 (** Returns an HTTP.Request.t representing an XMLRPC request *)

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -28,6 +28,11 @@
  (preprocess
   (pps ppx_deriving_rpc)))
 
+(library
+ (name tracing_propagator)
+ (modules propagator)
+ (libraries astring http-lib tracing))
+
 (test
  (name test_tracing)
  (modules test_tracing)

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -31,7 +31,6 @@
 (library
  (name tracing_propagator)
  (modules propagator)
- (wrapped false)
  (libraries astring http-lib tracing))
 
 (test

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -31,6 +31,7 @@
 (library
  (name tracing_propagator)
  (modules propagator)
+ (wrapped false)
  (libraries astring http-lib tracing))
 
 (test

--- a/ocaml/libs/tracing/propagator.ml
+++ b/ocaml/libs/tracing/propagator.ml
@@ -1,0 +1,108 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module type S = sig
+  type carrier
+
+  val inject_into : Tracing.TraceContext.t -> carrier -> carrier
+
+  val extract_from : carrier -> Tracing.TraceContext.t
+end
+
+let ( let* ) = Option.bind
+
+let ( >> ) f g x = g (f x)
+
+let maybe f = function Some _ as o -> f o | _ -> Fun.id
+
+let[@tail_mod_cons] rec filter_append p xs ys =
+  match xs with
+  | [] ->
+      ys
+  | x :: xs when p x ->
+      x :: filter_append p xs ys
+  | _ :: xs ->
+      filter_append p xs ys
+
+module Http = struct
+  type carrier = Http.Request.t
+
+  open struct
+    let hdr_traceparent = "traceparent"
+
+    let hdr_baggage = "baggage"
+  end
+
+  let alloc_assoc k kvs =
+    List.filter_map
+      (fun (key, value) -> if key = k then Some value else None)
+      kvs
+    |> function
+    | [] ->
+        None
+    | xs ->
+        Some xs
+
+  let parse =
+    let open Astring.String in
+    let trim_pair (key, value) = (trim key, trim value) in
+    cuts ~sep:";"
+    >> List.map (cut ~sep:"=" >> Option.map trim_pair)
+    >> List.filter_map Fun.id
+
+  let inject_into ctx req =
+    let open Tracing in
+    let traceparent = (hdr_traceparent, TraceContext.traceparent_of ctx) in
+    let baggage =
+      let encoded =
+        let encode =
+          List.map (fun (k, v) -> Printf.sprintf "%s=%s" k v)
+          >> String.concat ";"
+        in
+        TraceContext.baggage_of ctx |> Option.map encode
+      in
+      (hdr_baggage, encoded)
+    in
+    let entries = [traceparent; baggage] in
+    let filter_entries entries =
+      let tbl = Hashtbl.create 47 in
+      let record (k, v) =
+        match v with
+        | Some v ->
+            Hashtbl.replace tbl k () ;
+            Some (k, v)
+        | _ ->
+            None
+      in
+      let entries = List.filter_map record entries in
+      (entries, fst >> Hashtbl.mem tbl)
+    in
+    let entries, to_replace = filter_entries entries in
+    let headers = req.Http.Request.additional_headers in
+    let additional_headers =
+      filter_append (Fun.negate to_replace) headers entries
+    in
+    {req with additional_headers}
+
+  let extract_from req =
+    let open Tracing in
+    let headers = req.Http.Request.additional_headers in
+    let traceparent = List.assoc_opt hdr_traceparent headers in
+    let baggage =
+      let* all = alloc_assoc hdr_baggage headers in
+      Some (List.concat_map parse all)
+    in
+    let open TraceContext in
+    empty |> maybe with_traceparent traceparent |> maybe with_baggage baggage
+end

--- a/ocaml/libs/tracing/propagator.ml
+++ b/ocaml/libs/tracing/propagator.ml
@@ -54,12 +54,13 @@ module Http = struct
     | xs ->
         Some xs
 
-  let parse =
+  let parse input =
     let open Astring.String in
     let trim_pair (key, value) = (trim key, trim value) in
-    cuts ~sep:";"
-    >> List.map (cut ~sep:"=" >> Option.map trim_pair)
-    >> List.filter_map Fun.id
+    input
+    |> cuts ~sep:";"
+    |> List.map (cut ~sep:"=" >> Option.map trim_pair)
+    |> List.filter_map Fun.id
 
   let inject_into ctx req =
     let open Tracing in

--- a/ocaml/libs/tracing/propagator.mli
+++ b/ocaml/libs/tracing/propagator.mli
@@ -1,0 +1,23 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module type S = sig
+  type carrier
+
+  val inject_into : Tracing.TraceContext.t -> carrier -> carrier
+
+  val extract_from : carrier -> Tracing.TraceContext.t
+end
+
+module Http : S with type carrier = Http.Request.t

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -95,7 +95,7 @@ let validate_attribute (key, value) =
   && W3CBaggage.Key.is_valid_key key
 
 module SpanKind = struct
-  type t = Server | Consumer | Client | Producer | Internal [@@deriving rpcty]
+  type t = Server | Consumer | Client | Producer | Internal
 
   let to_string = function
     | Server ->
@@ -127,7 +127,7 @@ let endpoint_to_string = function
 let ok_none = Ok None
 
 module Status = struct
-  type status_code = Unset | Ok | Error [@@deriving rpcty]
+  type status_code = Unset | Ok | Error
 
   type t = {status_code: status_code; _description: string option}
 end
@@ -229,9 +229,14 @@ module TraceContext = struct
 end
 
 module SpanContext = struct
-  type t = {trace_id: Trace_id.t; span_id: Span_id.t} [@@deriving rpcty]
+  type t = {
+      trace_id: Trace_id.t
+    ; span_id: Span_id.t
+    ; trace_context: TraceContext.t
+  }
 
-  let context trace_id span_id = {trace_id; span_id}
+  let context trace_id span_id =
+    {trace_id; span_id; trace_context= TraceContext.empty}
 
   let to_traceparent t =
     let tid = Trace_id.to_string t.trace_id in
@@ -246,6 +251,7 @@ module SpanContext = struct
           {
             trace_id= Trace_id.of_string trace_id
           ; span_id= Span_id.of_string span_id
+          ; trace_context= TraceContext.empty
           }
     | _ ->
         None
@@ -253,6 +259,15 @@ module SpanContext = struct
   let trace_id_of_span_context t = t.trace_id
 
   let span_id_of_span_context t = t.span_id
+
+  let context_of_span_context t = t.trace_context
+
+  let with_trace_context trace_context t = {t with trace_context}
+
+  let of_trace_context trace_context =
+    let traceparent = TraceContext.traceparent_of trace_context in
+    let span_context = Option.(join (map of_traceparent traceparent)) in
+    Option.map (with_trace_context trace_context) span_context
 end
 
 module SpanLink = struct
@@ -282,16 +297,25 @@ module Span = struct
 
   let get_context t = t.context
 
-  let start ?(attributes = Attributes.empty) ~name ~parent ~span_kind () =
-    let trace_id =
+  let start ?(attributes = Attributes.empty)
+      ?(trace_context : TraceContext.t option) ~name ~parent ~span_kind () =
+    let trace_id, extra_context =
       match parent with
       | None ->
-          Trace_id.make ()
+          (Trace_id.make (), TraceContext.empty)
       | Some span_parent ->
-          span_parent.context.trace_id
+          (span_parent.context.trace_id, span_parent.context.trace_context)
     in
     let span_id = Span_id.make () in
-    let context : SpanContext.t = {trace_id; span_id} in
+    let context : SpanContext.t =
+      {trace_id; span_id; trace_context= extra_context}
+    in
+    let context =
+      (* If trace_context is provided to the call, override any inherited trace context. *)
+      Option.fold ~none:context
+        ~some:(Fun.flip SpanContext.with_trace_context context)
+        trace_context
+    in
     (* Using gettimeofday over Mtime as it is better for sharing timestamps between the systems *)
     let begin_time = Unix.gettimeofday () in
     let end_time = None in
@@ -669,15 +693,18 @@ module Tracer = struct
     ; attributes= Attributes.empty
     }
 
-  let start ~tracer:t ?(attributes = []) ?(span_kind = SpanKind.Internal) ~name
-      ~parent () : (Span.t option, exn) result =
+  let start ~tracer:t ?(attributes = []) ?trace_context
+      ?(span_kind = SpanKind.Internal) ~name ~parent () :
+      (Span.t option, exn) result =
     let open TracerProvider in
     (* Do not start span if the TracerProvider is disabled*)
     if not t.enabled then
       ok_none
     else
       let attributes = Attributes.merge_into t.attributes attributes in
-      let span = Span.start ~attributes ~name ~parent ~span_kind () in
+      let span =
+        Span.start ~attributes ?trace_context ~name ~parent ~span_kind ()
+      in
       Spans.add_to_spans ~span ; Ok (Some span)
 
   let update_span_with_parent span (parent : Span.t option) =
@@ -691,9 +718,11 @@ module Tracer = struct
           |> Option.map (fun existing_span ->
                  let old_context = Span.get_context existing_span in
                  let new_context : SpanContext.t =
+                   let trace_context = span.Span.context.trace_context in
                    SpanContext.context
                      (SpanContext.trace_id_of_span_context parent.context)
                      old_context.span_id
+                   |> SpanContext.with_trace_context trace_context
                  in
                  let updated_span = {existing_span with parent= Some parent} in
                  let updated_span = {updated_span with context= new_context} in
@@ -730,10 +759,10 @@ end
 let enable_span_garbage_collector ?(timeout = 86400.) () =
   Spans.GC.initialise_thread ~timeout
 
-let with_tracing ?(attributes = []) ?(parent = None) ~name f =
+let with_tracing ?(attributes = []) ?(parent = None) ?trace_context ~name f =
   let tracer = Tracer.get_tracer ~name in
   if tracer.enabled then (
-    match Tracer.start ~tracer ~attributes ~name ~parent () with
+    match Tracer.start ~tracer ?trace_context ~attributes ~name ~parent () with
     | Ok span -> (
       try
         let result = f span in
@@ -751,12 +780,12 @@ let with_tracing ?(attributes = []) ?(parent = None) ~name f =
   ) else
     f None
 
-let with_child_trace ?attributes parent ~name f =
+let with_child_trace ?attributes ?trace_context parent ~name f =
   match parent with
   | None ->
       f None
   | Some _ as parent ->
-      with_tracing ?attributes ~parent ~name f
+      with_tracing ?attributes ?trace_context ~parent ~name f
 
 module EnvHelpers = struct
   let traceparent_key = "TRACEPARENT"
@@ -824,6 +853,9 @@ module Propagator = struct
       let trace_context = P.extract_from carrier in
       let* parent = TraceContext.traceparent_of trace_context in
       let* span_context = SpanContext.of_traceparent parent in
+      let span_context =
+        SpanContext.with_trace_context trace_context span_context
+      in
       let name = P.name_span carrier in
       Some (Tracer.span_of_span_context span_context name)
 
@@ -845,6 +877,7 @@ module Propagator = struct
         | _ ->
             f carrier
       in
-      with_child_trace ?attributes parent ~name continue_with_child
+      with_child_trace ?attributes ~trace_context parent ~name
+        continue_with_child
   end
 end

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -297,3 +297,33 @@ module EnvHelpers : sig
       If [span] is [None], it returns an empty list.
       *)
 end
+
+(** [Propagator] is a utility module for creating trace propagators over arbitrary carriers. *)
+module Propagator : sig
+  module type S = sig
+    type carrier
+
+    val traceparent_of : carrier -> Span.t option
+    (** [traceparent_of carrier] creates a span whose context is that encoded within the [carrier] input.
+        If there is no traceparent encoded within the carrier, the function returns [None]. *)
+
+    val with_tracing :
+         ?attributes:(string * string) list
+      -> name:string
+      -> carrier
+      -> (carrier -> 'a)
+      -> 'a
+  end
+
+  module type PropS = sig
+    type carrier
+
+    val inject_into : TraceContext.t -> carrier -> carrier
+
+    val extract_from : carrier -> TraceContext.t
+
+    val name_span : carrier -> string
+  end
+
+  module Make : functor (P : PropS) -> S with type carrier = P.carrier
+end

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -103,9 +103,13 @@ module SpanContext : sig
 
   val of_traceparent : string -> t option
 
+  val of_trace_context : TraceContext.t -> t option
+
   val trace_id_of_span_context : t -> Trace_id.t
 
   val span_id_of_span_context : t -> Span_id.t
+
+  val context_of_span_context : t -> TraceContext.t
 end
 
 module Span : sig
@@ -164,6 +168,7 @@ module Tracer : sig
   val start :
        tracer:t
     -> ?attributes:(string * string) list
+    -> ?trace_context:TraceContext.t
     -> ?span_kind:SpanKind.t
     -> name:string
     -> parent:Span.t option
@@ -250,12 +255,14 @@ val enable_span_garbage_collector : ?timeout:float -> unit -> unit
 val with_tracing :
      ?attributes:(string * string) list
   -> ?parent:Span.t option
+  -> ?trace_context:TraceContext.t
   -> name:string
   -> (Span.t option -> 'a)
   -> 'a
 
 val with_child_trace :
      ?attributes:(string * string) list
+  -> ?trace_context:TraceContext.t
   -> Span.t option
   -> name:string
   -> (Span.t option -> 'a)

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -78,6 +78,24 @@ module Trace_id : sig
   val to_string : t -> string
 end
 
+module TraceContext : sig
+  type t
+
+  val empty : t
+
+  type traceparent = string
+
+  type baggage = (string * string) list
+
+  val with_traceparent : traceparent option -> t -> t
+
+  val with_baggage : baggage option -> t -> t
+
+  val traceparent_of : t -> traceparent option
+
+  val baggage_of : t -> baggage option
+end
+
 module SpanContext : sig
   type t
 

--- a/ocaml/xapi-cli-server/dune
+++ b/ocaml/xapi-cli-server/dune
@@ -42,6 +42,7 @@
     xapi-stdext-threads
     xapi-stdext-unix
     xapi-tracing
+    tracing_propagator
     xmlm
     xml-light2
   )

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -132,11 +132,17 @@ module TraceHelper = struct
     let open Tracing in
     let span_context = Option.map Span.get_context span in
     let traceparent = Option.map SpanContext.to_traceparent span_context in
-    let trace_context = TraceContext.(with_traceparent traceparent empty) in
+    let trace_context =
+      Option.map SpanContext.context_of_span_context span_context
+    in
+    let trace_context =
+      Option.value ~default:TraceContext.empty trace_context
+      |> TraceContext.with_traceparent traceparent
+    in
     Tracing_propagator.Propagator.Http.inject_into trace_context
 end
 
-let do_rpcs _req s username password minimal cmd session args tracing =
+let do_rpcs req s username password minimal cmd session args =
   let cmdname = get_cmdname cmd in
   let cspec =
     try Hashtbl.find cmdtable cmdname
@@ -151,8 +157,21 @@ let do_rpcs _req s username password minimal cmd session args tracing =
   let _ = check_required_keys cmd cspec.reqd in
   try
     let generic_rpc = get_rpc () in
+    let trace_context = Tracing_propagator.Propagator.Http.extract_from req in
+    let parent =
+      (* This is a "faux" span in the sense that it's not exported by the program. It exists
+         so that the derived child span can refer to its span-id as its parent during exportation
+         (along with inheriting the trace-id). *)
+      let open Tracing in
+      let ( let* ) = Option.bind in
+      let* traceparent = TraceContext.traceparent_of trace_context in
+      let* span_context = SpanContext.of_traceparent traceparent in
+      let span = Tracer.span_of_span_context span_context (get_cmdname cmd) in
+      Some span
+    in
     (* NB the request we've received is for the /cli. We need an XMLRPC request for the API *)
-    Tracing.with_tracing ~parent:tracing ~name:("xe " ^ cmdname) @@ fun span ->
+    Tracing.with_tracing ~trace_context ~parent ~name:("xe " ^ cmdname)
+    @@ fun span ->
     let req = Xmlrpc_client.xmlrpc ~version:"1.1" "/" in
     let req = TraceHelper.inject_span_into_req span req in
     let rpc = generic_rpc req s in
@@ -204,15 +223,6 @@ let uninteresting_cmd_postfixes = ["help"; "-get"; "-list"]
 
 let exec_command req cmd s session args =
   let params = get_params cmd in
-  let tracing =
-    let ( let* ) = Option.bind in
-    let open Tracing in
-    let context = Tracing_propagator.Propagator.Http.extract_from req in
-    let* traceparent = TraceContext.traceparent_of context in
-    let* span_context = SpanContext.of_traceparent traceparent in
-    let span = Tracer.span_of_span_context span_context (get_cmdname cmd) in
-    Some span
-  in
   let minimal =
     List.assoc_opt "minimal" params
     |> Option.fold ~none:false ~some:bool_of_string
@@ -271,7 +281,7 @@ let exec_command req cmd s session args =
             params
          )
       ) ;
-    do_rpcs req s u p minimal cmd session args tracing
+    do_rpcs req s u p minimal cmd session args
 
 let get_line str i =
   try

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -190,12 +190,13 @@ let uninteresting_cmd_postfixes = ["help"; "-get"; "-list"]
 let exec_command req cmd s session args =
   let params = get_params cmd in
   let tracing =
-    Option.bind
-      Http.Request.(req.traceparent)
-      Tracing.SpanContext.of_traceparent
-    |> Option.map (fun span_context ->
-           Tracing.Tracer.span_of_span_context span_context (get_cmdname cmd)
-       )
+    (* Option.bind *)
+    (*   Http.Request.(req.traceparent) *)
+    (*   Tracing.SpanContext.of_traceparent *)
+    (* |> Option.map (fun span_context -> *)
+    (*        Tracing.Tracer.span_of_span_context span_context (get_cmdname cmd) *)
+    (*    ) *)
+    None
   in
   let minimal =
     if List.mem_assoc "minimal" params then

--- a/ocaml/xapi-cli-server/xapi_cli.ml
+++ b/ocaml/xapi-cli-server/xapi_cli.ml
@@ -123,17 +123,17 @@ let with_session ~local rpc u p session f =
 
 module TraceHelper = struct
   include Tracing.Propagator.Make (struct
-    include Propagator.Http
+    include Tracing_propagator.Propagator.Http
 
     let name_span req = req.Http.Request.uri
   end)
 
   let inject_span_into_req (span : Tracing.Span.t option) =
-    let module T = Tracing in
-    let span_context = Option.map T.Span.get_context span in
-    let traceparent = Option.map T.SpanContext.to_traceparent span_context in
-    let trace_context = T.TraceContext.(with_traceparent traceparent empty) in
-    Propagator.Http.inject_into trace_context
+    let open Tracing in
+    let span_context = Option.map Span.get_context span in
+    let traceparent = Option.map SpanContext.to_traceparent span_context in
+    let trace_context = TraceContext.(with_traceparent traceparent empty) in
+    Tracing_propagator.Propagator.Http.inject_into trace_context
 end
 
 let do_rpcs _req s username password minimal cmd session args tracing =
@@ -206,8 +206,8 @@ let exec_command req cmd s session args =
   let params = get_params cmd in
   let tracing =
     let ( let* ) = Option.bind in
-    let context = Propagator.Http.extract_from req in
     let open Tracing in
+    let context = Tracing_propagator.Propagator.Http.extract_from req in
     let* traceparent = TraceContext.traceparent_of context in
     let* span_context = SpanContext.of_traceparent traceparent in
     let span = Tracer.span_of_span_context span_context (get_cmdname cmd) in

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -5,7 +5,7 @@ let ( let@ ) f x = f x
 
 module Helper = struct
   include Tracing.Propagator.Make (struct
-    include Propagator.Http
+    include Tracing_propagator.Propagator.Http
 
     let name_span req = req.Http.Request.uri
   end)

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -218,11 +218,11 @@ let span_kind_of_parent parent =
   Option.fold ~none:SpanKind.Internal ~some:(fun _ -> SpanKind.Server) parent
 
 let parent_of_origin (origin : origin) span_name =
-  let open Tracing in
   let ( let* ) = Option.bind in
   match origin with
   | Http (req, _) ->
       let context = Propagator.Http.extract_from req in
+      let open Tracing in
       let* traceparent = TraceContext.traceparent_of context in
       let* span_context = SpanContext.of_traceparent traceparent in
       let span = Tracer.span_of_span_context span_context span_name in

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -221,7 +221,7 @@ let parent_of_origin (origin : origin) span_name =
   let ( let* ) = Option.bind in
   match origin with
   | Http (req, _) ->
-      let context = Propagator.Http.extract_from req in
+      let context = Tracing_propagator.Propagator.Http.extract_from req in
       let open Tracing in
       let* traceparent = TraceContext.traceparent_of context in
       let* span_context = SpanContext.of_traceparent traceparent in

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -223,8 +223,7 @@ let parent_of_origin (origin : origin) span_name =
   | Http (req, _) ->
       let context = Tracing_propagator.Propagator.Http.extract_from req in
       let open Tracing in
-      let* traceparent = TraceContext.traceparent_of context in
-      let* span_context = SpanContext.of_traceparent traceparent in
+      let* span_context = SpanContext.of_trace_context context in
       let span = Tracer.span_of_span_context span_context span_name in
       Some span
   | _ ->

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -221,8 +221,8 @@ let parent_of_origin (origin : origin) span_name =
   let open Tracing in
   let ( let* ) = Option.bind in
   match origin with
-  | Http (req, _) ->
-      let* traceparent = req.Http.Request.traceparent in
+  | Http (_req, _) ->
+      let* traceparent = (* req.Http.Request.traceparent *) None in
       let* span_context = SpanContext.of_traceparent traceparent in
       let span = Tracer.span_of_span_context span_context span_name in
       Some span

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -221,8 +221,9 @@ let parent_of_origin (origin : origin) span_name =
   let open Tracing in
   let ( let* ) = Option.bind in
   match origin with
-  | Http (_req, _) ->
-      let* traceparent = (* req.Http.Request.traceparent *) None in
+  | Http (req, _) ->
+      let context = Propagator.Http.extract_from req in
+      let* traceparent = TraceContext.traceparent_of context in
       let* span_context = SpanContext.of_traceparent traceparent in
       let span = Tracer.span_of_span_context span_context span_name in
       Some span

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -68,6 +68,7 @@
     xapi_database
     mtime
     tracing
+    tracing_propagator
     uuid
     rpclib.core
     threads.posix

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -154,6 +154,7 @@
     tar-unix
     threads.posix
     tracing
+    tracing_propagator
     unixpwd
     uri
     uuid
@@ -240,6 +241,7 @@
     stunnel
     threads.posix
     tracing
+    tracing_propagator
     xapi-backtrace
     xapi-client
     xapi-consts

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -389,11 +389,11 @@ let update_pif_addresses ~__context =
 
 module TraceHelper = struct
   let inject_span_into_req (span : Tracing.Span.t option) =
-    let module T = Tracing in
-    let span_context = Option.map T.Span.get_context span in
-    let traceparent = Option.map T.SpanContext.to_traceparent span_context in
-    let trace_context = T.TraceContext.(with_traceparent traceparent empty) in
-    Propagator.Http.inject_into trace_context
+    let open Tracing in
+    let span_context = Option.map Span.get_context span in
+    let traceparent = Option.map SpanContext.to_traceparent span_context in
+    let trace_context = TraceContext.(with_traceparent traceparent empty) in
+    Tracing_propagator.Propagator.Http.inject_into trace_context
 end
 
 (* Note that both this and `make_timeboxed_rpc` are almost always

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -392,7 +392,13 @@ module TraceHelper = struct
     let open Tracing in
     let span_context = Option.map Span.get_context span in
     let traceparent = Option.map SpanContext.to_traceparent span_context in
-    let trace_context = TraceContext.(with_traceparent traceparent empty) in
+    let trace_context =
+      Option.map SpanContext.context_of_span_context span_context
+    in
+    let trace_context =
+      Option.value ~default:TraceContext.empty trace_context
+      |> TraceContext.with_traceparent traceparent
+    in
     Tracing_propagator.Propagator.Http.inject_into trace_context
 end
 

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -387,6 +387,15 @@ let update_pif_addresses ~__context =
   Option.iter (fun (pif, bridge) -> set_DNS ~__context ~pif ~bridge) dns_if ;
   List.iter (fun self -> update_pif_address ~__context ~self) pifs
 
+module TraceHelper = struct
+  let inject_span_into_req (span : Tracing.Span.t option) =
+    let module T = Tracing in
+    let span_context = Option.map T.Span.get_context span in
+    let traceparent = Option.map T.SpanContext.to_traceparent span_context in
+    let trace_context = T.TraceContext.(with_traceparent traceparent empty) in
+    Propagator.Http.inject_into trace_context
+end
+
 (* Note that both this and `make_timeboxed_rpc` are almost always
  * partially applied, returning a function of type 'Rpc.request -> Rpc.response'.
  * The body is therefore not evaluated until the RPC call is actually being
@@ -395,7 +404,8 @@ let make_rpc ~__context rpc : Rpc.response =
   let subtask_of = Ref.string_of (Context.get_task_id __context) in
   let open Xmlrpc_client in
   let tracing = Context.set_client_span __context in
-  let http = xmlrpc ~subtask_of ~version:"1.1" "/" ~tracing in
+  let http = xmlrpc ~subtask_of ~version:"1.1" "/" in
+  let http = TraceHelper.inject_span_into_req tracing http in
   let transport =
     if Pool_role.is_master () then
       Unix Xapi_globs.unix_domain_socket
@@ -418,7 +428,8 @@ let make_timeboxed_rpc ~__context timeout rpc : Rpc.response =
        * the task has acquired we make a new one specifically for the stunnel pid *)
       let open Xmlrpc_client in
       let tracing = Context.set_client_span __context in
-      let http = xmlrpc ~subtask_of ~version:"1.1" ~tracing "/" in
+      let http = xmlrpc ~subtask_of ~version:"1.1" "/" in
+      let http = TraceHelper.inject_span_into_req tracing http in
       let task_id = Context.get_task_id __context in
       let cancel () =
         let resources =
@@ -486,7 +497,8 @@ let make_remote_rpc ?(verify_cert = Stunnel_client.pool ()) ~__context
     SSL (SSL.make ~verify_cert (), remote_address, !Constants.https_port)
   in
   let tracing = Context.tracing_of __context in
-  let http = xmlrpc ~version:"1.0" ~tracing "/" in
+  let http = xmlrpc ~version:"1.0" "/" in
+  let http = TraceHelper.inject_span_into_req tracing http in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_xapi" ~transport ~http xml
 
 (* Helper type for an object which may or may not be in the local database. *)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -60,9 +60,8 @@ let remote_rpc_no_retry _context hostname (task_opt : API.ref_task option) xml =
   in
   let tracing = Context.set_client_span _context in
   let http =
-    xmlrpc
-      ?task_id:(Option.map Ref.string_of task_opt)
-      ~version:"1.0" ~tracing "/"
+    xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.0" "/"
+    |> Helpers.TraceHelper.inject_span_into_req tracing
   in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
@@ -80,9 +79,8 @@ let remote_rpc_retry _context hostname (task_opt : API.ref_task option) xml =
   in
   let tracing = Context.set_client_span _context in
   let http =
-    xmlrpc
-      ?task_id:(Option.map Ref.string_of task_opt)
-      ~version:"1.1" ~tracing "/"
+    xmlrpc ?task_id:(Option.map Ref.string_of task_opt) ~version:"1.1" "/"
+    |> Helpers.TraceHelper.inject_span_into_req tracing
   in
   XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -121,7 +121,7 @@ let dispatch_exn_wrapper f =
 
 module Helper = struct
   include Tracing.Propagator.Make (struct
-    include Propagator.Http
+    include Tracing_propagator.Propagator.Http
 
     let name_span req = req.Http.Request.uri
   end)

--- a/ocaml/xapi/system_domains.ml
+++ b/ocaml/xapi/system_domains.ml
@@ -181,7 +181,8 @@ let pingable ip () =
 let queryable ~__context transport () =
   let open Xmlrpc_client in
   let tracing = Context.set_client_span __context in
-  let http = xmlrpc ~version:"1.0" ~tracing "/" in
+  let http = xmlrpc ~version:"1.0" "/" in
+  let http = Helpers.TraceHelper.inject_span_into_req tracing http in
   let rpc =
     XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"remote_smapiv2" ~transport ~http
   in

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3406,7 +3406,8 @@ let perform ~local_fn ~__context ~host op =
     let verify_cert = Some Stunnel.pool (* verify! *) in
     let task_id = Option.map Ref.string_of task_opt in
     let tracing = Context.set_client_span __context in
-    let http = xmlrpc ?task_id ~version:"1.0" ~tracing "/" in
+    let http = xmlrpc ?task_id ~version:"1.0" "/" in
+    let http = Helpers.TraceHelper.inject_span_into_req tracing http in
     let port = !Constants.https_port in
     let transport = SSL (SSL.make ~verify_cert ?task_id (), hostname, port) in
     XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -817,6 +817,9 @@ let main () =
         let args = String.concat "\n" args in
         Printf.fprintf oc "User-agent: xe-cli/Unix/%d.%d\r\n" major minor ;
         Option.iter (Printf.fprintf oc "traceparent: %s\r\n") traceparent ;
+        Option.iter
+          (Printf.fprintf oc "baggage: %s\r\n")
+          (Sys.getenv_opt "BAGGAGE") ;
         Printf.fprintf oc "content-length: %d\r\n\r\n" (String.length args) ;
         Printf.fprintf oc "%s" args ;
         flush_all () ;


### PR DESCRIPTION
Removes dependency on `tracing` from `http-lib` and add baggage.

---

The introduction of it as a dependency was to support this style of code:

```ocaml
let@ req = Http.Request.with_tracing ~name req in
```

However, HTTP headers are just a carrier in the context of tracing. The library ought to be as inert as possible; providing enough to endow requests with tracing information, but not calling into the tracing library to export child spans (as is done above).

To this end, the notion of a [propagator](https://opentelemetry.io/docs/specs/otel/context/api-propagators/) is introduced that provides an interface for doing the above, but generalised to arbitrary carriers. If you can describe how to inject/extract a "trace context" into/from a carrier, you can conceivably propagate tracing across it.

---

In future, the idea will be to:
- This trace context can be inherited by spans, so it can reach the exporter. We can probably use the `SpanContext.t` record to do this. If this information can reach the exporter, we can choose to decorate spans with tags derived from the trace context (such as baggage) during exportation.
- At incoming service boundaries, instead of pushing down a `Span.t option` derived from an encoded `traceparent` in the carrier, we will push down `TraceContext` (which is more general than the encoded `SpanContext` carried by the optional `Span.t` that's currently pushed down). This is so we can more easily handle the case where baggage is provided but a traceparent isn't: in which case, a span is still created if tracing is enabled, but with no parent to inherit contextual metadata from (a previous - abandoned - PR introduced baggage in a way that only worked when a traceparent was provided).

---

Opening this as a draft for now. Would appreciate any commentary. There appears to be duplication of `Helper` but this is largely because XAPI's `dune` defines separate libraries which have slightly different dependencies.

This has been manually tested with Jaeger, but more thorough testing should probably be done (comparing deeper span forests before and after these changes).