### PR TITLE
CA-400860: make CPU and netdev RRDD plugins pick up changes in domains

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdp-cpu/rrdp_cpu.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-cpu/rrdp_cpu.ml
@@ -226,7 +226,8 @@ let dss_hostload xc domains =
     )
   ]
 
-let generate_cpu_ds_list xc domains () =
+let generate_cpu_ds_list xc () =
+  let _, domains, _ = Xenctrl_lib.domain_snapshot xc in
   dss_pcpus xc @ dss_vcpus xc domains @ dss_loadavg () @ dss_hostload xc domains
 
 let _ =
@@ -236,8 +237,8 @@ let _ =
       (* Share one page per PCPU and dom each *)
       let physinfo = Xenctrl.physinfo xc in
       let shared_page_count = physinfo.Xenctrl.nr_cpus + List.length domains in
-
+      (* TODO: Can run out of pages if a lot of domains are added at runtime *)
       Process.main_loop ~neg_shift:0.5
         ~target:(Reporter.Local shared_page_count) ~protocol:Rrd_interface.V2
-        ~dss_f:(generate_cpu_ds_list xc domains)
+        ~dss_f:(generate_cpu_ds_list xc)
   )


### PR DESCRIPTION
When these metrics were collected internally, Xenctrl was queried every 5 seconds. After being split into plugins, they started querying domains (and other information) only on startup, so couldn't pick up new VMs and report their metrics without restarting.