### PR TITLE
CA-400860: rrdp-netdev - drop xenctrl, use xenstore to get UUIDs from domids instead

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdp-netdev/dune
+++ b/ocaml/xcp-rrdd/bin/rrdp-netdev/dune
@@ -3,6 +3,7 @@
   (name rrdp_netdev)
   (libraries
     astring
+    ezxenstore.core
     integers
     netlink
     rrdd-plugin
@@ -13,7 +14,6 @@
     xapi-log
     xapi-rrd
     xapi-stdext-std
-    xenctrl
   )
 )
 


### PR DESCRIPTION
Follow-up to the fix we had to rush, dropping xenctrl entirely.

Tested with a Windows VM, the domain creation is picked up and network metrics are present for it, with correct UUIDs determined.