### PR TITLE
CA-400060: Sm feature intersection

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5001,10 +5001,20 @@ module SM = struct
                 , "capabilities of the SM plugin, with capability version \
                    numbers"
                 )
+              ; ( Changed
+                , "24.37.0"
+                , "features are now pool-wide, instead of what is available on \
+                   the coordinator sm"
+                )
               ]
             ~ty:(Map (String, Int))
             "features"
             "capabilities of the SM plugin, with capability version numbers"
+            ~default_value:(Some (VMap []))
+        ; field ~in_oss_since:None ~qualifier:DynamicRO ~lifecycle:[]
+            ~ty:(Map (Ref _host, Set String))
+            ~internal_only:true "host_pending_features"
+            "SM features that are waiting to be declared per host."
             ~default_value:(Some (VMap []))
         ; field
             ~lifecycle:[(Published, rel_miami, "additional configuration")]

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 784
+let schema_minor_vsn = 785
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -890,6 +890,13 @@ let _ =
       "The host joining the pool has different CA certificates from the pool \
        coordinator while using the same name, uninstall them and try again."
     () ;
+  error Api_errors.pool_joining_sm_features_incompatible
+    ["pool_sm_ref"; "candidate_sm_ref"]
+    ~doc:
+      "The host joining the pool has an incompatible set of sm features from \
+       the pool coordinator. Make sure the sm are of the same versions and try \
+       again."
+    () ;
 
   (* External directory service *)
   error Api_errors.subject_cannot_be_resolved []

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -51,6 +51,8 @@ let prototyped_of_field = function
       Some "22.26.0"
   | "VTPM", "persistence_backend" ->
       Some "22.26.0"
+  | "SM", "host_pending_features" ->
+      Some "24.36.0-next"
   | "host", "last_update_hash" ->
       Some "24.10.0"
   | "host", "pending_guidances_full" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "b427bac09aca4eabc9407738a9155326"
+let last_known_schema_hash = "18df8c33434e3df1982e11ec55d1f3f8"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -1184,6 +1184,10 @@ and json_serialization_attr fr =
         (exposed_class_name v)
   | Map (String, String) ->
       sprintf "\n        [JsonConverter(typeof(StringStringMapConverter))]"
+  | Map (Ref u, Set String) ->
+      sprintf
+        "\n        [JsonConverer(typeof(XenRefStringSetMapConverter<%s>))]"
+        (exposed_class_name u)
   | Map (Ref _, _) | Map (_, Ref _) ->
       failwith (sprintf "Need converter for %s" fr.field_name)
   | _ ->

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -342,12 +342,13 @@ let default_sm_features =
 let make_sm ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ?(_type = "sm") ?(name_label = "") ?(name_description = "") ?(vendor = "")
     ?(copyright = "") ?(version = "") ?(required_api_version = "")
-    ?(capabilities = []) ?(features = default_sm_features) ?(configuration = [])
-    ?(other_config = []) ?(driver_filename = "/dev/null")
-    ?(required_cluster_stack = []) () =
+    ?(capabilities = []) ?(features = default_sm_features)
+    ?(host_pending_features = []) ?(configuration = []) ?(other_config = [])
+    ?(driver_filename = "/dev/null") ?(required_cluster_stack = []) () =
   Db.SM.create ~__context ~ref ~uuid ~_type ~name_label ~name_description
     ~vendor ~copyright ~version ~required_api_version ~capabilities ~features
-    ~configuration ~other_config ~driver_filename ~required_cluster_stack ;
+    ~host_pending_features ~configuration ~other_config ~driver_filename
+    ~required_cluster_stack ;
   ref
 
 let make_sr ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -754,6 +754,9 @@ let pool_joining_host_tls_verification_mismatch =
 let pool_joining_host_ca_certificates_conflict =
   add_error "POOL_JOINING_HOST_CA_CERTIFICATES_CONFLICT"
 
+let pool_joining_sm_features_incompatible =
+  add_error "POOL_JOINING_SM_FEATURES_INCOMPATIBLE"
+
 (*workload balancing*)
 let wlb_not_initialized = add_error "WLB_NOT_INITIALIZED"
 

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -373,7 +373,6 @@ let update_env __context =
      in the db for cancelling *)
   Cancel_tasks.cancel_tasks_on_host ~__context ~host_opt:None ;
   (* Update the SM plugin table *)
-  Storage_access.on_xapi_start ~__context ;
   if !Xapi_globs.create_tools_sr then
     create_tools_sr_noexn __context ;
   ensure_vm_metrics_records_exist_noexn __context ;

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -362,6 +362,9 @@ let update_env __context sync_keys =
   switched_sync Xapi_globs.sync_refresh_localhost_info (fun () ->
       refresh_localhost_info ~__context info
   ) ;
+  switched_sync Xapi_globs.sync_sm_records (fun () ->
+      Storage_access.on_xapi_start ~__context
+  ) ;
   switched_sync Xapi_globs.sync_local_vdi_activations (fun () ->
       Storage_access.refresh_local_vdi_activations ~__context
   ) ;

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -340,6 +340,8 @@ let sync_switch_off = "nosync"
 (* dbsync_slave *)
 let sync_local_vdi_activations = "sync_local_vdi_activations"
 
+let sync_sm_records = "sync_sm_records"
+
 let sync_create_localhost = "sync_create_localhost"
 
 let sync_set_cache_sr = "sync_set_cache_sr"


### PR DESCRIPTION
There are two parts to this PR:
1. only declare a feature as a public sm feature when it is advertised by all SMs in the pool
2. reject a host from joining the pool if it does not have a compatible set of SM features with the current pool

Now I did not create a new class just for SM features as I feel having a decidated class for something that is supposed to be quite a temporary state (as this is only supposed to happen during an upgrade) is an overkill. But I am open to suggestions.