### PR TITLE
CP-51835: Keep the HTTP /repository handler enabled

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -488,10 +488,6 @@ let get_host_updates_in_json ~__context ~installed =
         (ExnHelper.string_of_exn e) ;
       raise Api_errors.(Server_error (get_host_updates_failed, [ref]))
 
-(* This handler hosts HTTP endpoint '/repository' which will be available iif
- * 'is_local_pool_repo_enabled' returns true with 'with_pool_repositories' being called by
- * others.
- *)
 let get_repository_handler (req : Http.Request.t) s _ =
   let open Http in
   let open Xapi_stdext_std.Xstringext in
@@ -499,7 +495,7 @@ let get_repository_handler (req : Http.Request.t) s _ =
   req.Request.close <- true ;
   if Fileserver.access_forbidden req s then
     Http_svr.response_forbidden ~req s
-  else if is_local_pool_repo_enabled () then
+  else
     let can_be_authorized =
       try
         Xapi_http.with_context "get_repository_handler" req s (fun _ -> ()) ;
@@ -536,10 +532,6 @@ let get_repository_handler (req : Http.Request.t) s _ =
           (ExnHelper.string_of_exn e) ;
         Http_svr.response_forbidden ~req s
     )
-  else (
-    error "Rejecting request: local pool repository is not enabled" ;
-    Http_svr.response_forbidden ~req s
-  )
 
 let consolidate_updates_of_hosts ~repository_name ~updates_info ~hosts =
   Hashtbl.fold

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -22,7 +22,7 @@ open Updateinfo
 module LivePatchSet = Set.Make (LivePatch)
 module RpmFullNameSet = Set.Make (String)
 
-let exposing_pool_repo_mutex = Mutex.create ()
+let pool_update_ops_mutex = Mutex.create ()
 
 module Pkgs = (val Pkg_mgr.get_pkg_mgr)
 
@@ -234,17 +234,10 @@ let assert_gpgkey_path_is_valid path =
 let with_pool_repositories f =
   Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () ->
-      Mutex.lock exposing_pool_repo_mutex ;
+      Mutex.lock pool_update_ops_mutex ;
       f ()
     )
-    (fun () -> Mutex.unlock exposing_pool_repo_mutex)
-
-let is_local_pool_repo_enabled () =
-  if Mutex.try_lock exposing_pool_repo_mutex then (
-    Mutex.unlock exposing_pool_repo_mutex ;
-    false
-  ) else
-    true
+    (fun () -> Mutex.unlock pool_update_ops_mutex)
 
 let with_updateinfo_xml gz_path f =
   let tmpfile, tmpch =


### PR DESCRIPTION
The HTTP /repository handler is guarded by a mutex `exposing_pool_repo_mutex` currently. Since now HTTP /repository is protected by `session_id` cookie, we can remove the mutex and keep the handler enabled all the time. Also, rename the mutex `exposing_pool_repo_mutex` to `pool_update_ops_mutex`.