### PR TITLE
CA-400924 - networkd: Add bonds to `devs` in network_monitor_thread

### DIFF
--- a/ocaml/networkd/bin/network_monitor_thread.ml
+++ b/ocaml/networkd/bin/network_monitor_thread.ml
@@ -225,7 +225,8 @@ let rec monitor dbg () =
       let bonds : (string * string list) list =
         Network_server.Bridge.get_all_bonds dbg from_cache
       in
-      let devs = get_link_stats () |> get_stats bonds in
+      let add_bonds bonds devs = List.map fst bonds @ devs in
+      let devs = get_link_stats () |> add_bonds bonds |> get_stats bonds in
       ( if List.length bonds <> Hashtbl.length bonds_status then
           let dead_bonds =
             Hashtbl.fold


### PR DESCRIPTION
Without it, stats for bond's interfaces are not identified correctly.

Fixes: bd4dda5c294aa51045bf3caccc48bb0870a7d428 (IH-715 - rrdp-netdev: Remove double (de)serialization)