### PR TITLE
Don't open /dev/urandom on startup

### DIFF
--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -292,7 +292,7 @@ let slave = function
       (*
 		  Printf.fprintf stderr "%s %d\n" total_fds (List.length present - 1)
 		*)
-      if total_fds + 1 (* Uuid.dev_urandom *) <> List.length filtered then
+      if total_fds <> List.length filtered then
         fail "Expected %d fds; /proc/self/fd has %d: %s" total_fds
           (List.length filtered) ls
 

--- a/ocaml/libs/uuid/dune
+++ b/ocaml/libs/uuid/dune
@@ -3,6 +3,9 @@
   (public_name uuid)
   (modules uuidx)
   (libraries
+    cstruct
+    mirage-crypto-rng
+    mirage-crypto-rng.unix
     mtime
     mtime.clock.os
     ptime

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1612,11 +1612,11 @@ let other_options =
     , (fun () -> string_of_bool !disable_webserver)
     , "Disable the host webserver"
     )
-  ; ( "use-prng-uuid-gen"
-      (* eventually this'll be the default, except for Sessions *)
+  ; ( "use-fortuna-uuid-gen"
+      (* eventually this'll be the default *)
     , Arg.Unit (fun () -> Uuidx.make_default := Uuidx.make_uuid_fast)
     , (fun () -> !Uuidx.make_default == Uuidx.make_uuid_fast |> string_of_bool)
-    , "Use PRNG based UUID generator instead of CSPRNG"
+    , "Use Fortuna based UUID generator instead of /dev/urandom"
     )
   ]
 


### PR DESCRIPTION
The host installer run `networkd_db` in a chroot without creating `/dev/urandom` there.
Removing the dependency on `uuid` (or on uuid generation) would be difficult, because it is closely tied to the `Ref` type which is used throughout xapi-types/xapi-idl/etc.

However we can use Mirage's crypto rng instead of opening /dev/urandom on startup, and this would use the `getrandom` syscall when available instead.

This works on Fedora 40, but I haven't tested yet whether it'd work in our much older CentOS 7 Dom0, hence opening as a draft.

Note that reverting the first commit is not enough, because there was also a followup commit that calls `Random.State.make_self_init` on startup, but that commit doesn't revert cleanly.