### PR TITLE
CA-400559: API Error too_many_groups is not in go SDK

### DIFF
--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1394,4 +1394,4 @@ let telemetry_next_collection_too_late =
 (* FIPS/CC_PREPARATIONS *)
 let illegal_in_fips_mode = add_error "ILLEGAL_IN_FIPS_MODE"
 
-let too_many_groups = "TOO_MANY_GROUPS"
+let too_many_groups = add_error "TOO_MANY_GROUPS"


### PR DESCRIPTION
Reason:
API errors in go sdk are generated from Api_errors.errors. Error is filled in Api_errors.errors when defined using add_error function. Error too_many_groups is not defined using add_error function.
Fix:
Define too_many_groups using add_error function.