### PR TITLE
CP-50789: Enable verified rpc to external host

### DIFF
--- a/ocaml/libs/stunnel/stunnel.ml
+++ b/ocaml/libs/stunnel/stunnel.ml
@@ -157,6 +157,9 @@ let pool =
   ; cert_bundle_path= "/etc/stunnel/xapi-pool-ca-bundle.pem"
   }
 
+let external_host ext_host_cert_file =
+  {sni= None; verify= VerifyPeer; cert_bundle_path= ext_host_cert_file}
+
 let debug_conf_of_bool verbose : string =
   if verbose then "debug=authpriv.7" else "debug=authpriv.5"
 

--- a/ocaml/libs/stunnel/stunnel.mli
+++ b/ocaml/libs/stunnel/stunnel.mli
@@ -59,6 +59,8 @@ val appliance : verification_config
 
 val pool : verification_config
 
+val external_host : string -> verification_config
+
 val with_connect :
      ?unique_id:int
   -> ?use_fork_exec_helper:bool

--- a/ocaml/libs/stunnel/stunnel_client.ml
+++ b/ocaml/libs/stunnel/stunnel_client.ml
@@ -26,7 +26,12 @@ let set_verify_by_default = function
       D.info "enabling default tls verification" ;
       verify := true
 
-let pool () = match !verify with true -> Some Stunnel.pool | false -> None
+let get_verification_config config =
+  match !verify with true -> Some config | false -> None
 
-let appliance () =
-  match !verify with true -> Some Stunnel.appliance | false -> None
+let pool () = get_verification_config Stunnel.pool
+
+let appliance () = get_verification_config Stunnel.appliance
+
+let external_host cert_file =
+  Stunnel.external_host cert_file |> get_verification_config

--- a/ocaml/libs/stunnel/stunnel_client.mli
+++ b/ocaml/libs/stunnel/stunnel_client.mli
@@ -19,3 +19,5 @@ val set_verify_by_default : bool -> unit
 val pool : unit -> Stunnel.verification_config option
 
 val appliance : unit -> Stunnel.verification_config option
+
+val external_host : string -> Stunnel.verification_config option

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -2015,6 +2015,16 @@ let with_temp_out_ch_of_temp_file ?mode prefix suffix f =
   let@ path, channel = with_temp_file ?mode prefix suffix in
   f (path, channel |> with_temp_out_ch)
 
+let make_external_host_verified_rpc ~__context ext_host_address ext_host_cert
+    xml =
+  let@ temp_file, temp_out_ch = with_temp_file "external-host-cert" ".pem" in
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () -> output_string temp_out_ch ext_host_cert)
+    (fun () -> close_out temp_out_ch) ;
+  make_remote_rpc ~__context
+    ~verify_cert:(Stunnel_client.external_host temp_file)
+    ext_host_address xml
+
 module FileSys : sig
   (* bash-like interface for manipulating files *)
   type path = string


### PR DESCRIPTION
Now xapi supports setting up rpc to hosts in the pool and appliances, while for syncing updates from remote_pool type repository, we need to set up rpc to remote coordinator with its certificate verfieid.

Add util Helpers.make_external_host_verified_rpc, which will set up a secure connection to the external host(host outside the pool) with its host certificate verified.