### PR TITLE
CP-51391: Implement handling for /repository/enabled

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -10971,6 +10971,15 @@ let http_actions =
   ; ( "get_repository"
     , (Get, Constants.get_repository_uri, false, [], _R_LOCAL_ROOT_ONLY, [])
     )
+  ; ( "get_enabled_repository"
+    , ( Get
+      , Constants.get_enabled_repository_uri
+      , false
+      , []
+      , _R_POOL_OP ++ _R_CLIENT_CERT
+      , []
+      )
+    )
   ; ( "get_host_updates"
     , ( Get
       , Constants.get_host_updates_uri
@@ -11014,7 +11023,6 @@ let public_http_actions_with_no_rbac_check =
   ; "post_jsonrpc"
   ; "post_jsonrpc_options"
   ; "get_pool_update_download"
-  ; "get_repository"
   ]
 
 (* permissions not associated with any object message or field *)

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -514,48 +514,25 @@ let get_host_updates_in_json ~__context ~installed =
 
 let get_repository_handler (req : Http.Request.t) s _ =
   let open Http in
-  let open Xapi_stdext_std.Xstringext in
-  debug "Repository.get_repository_handler URL %s" req.Request.uri ;
+  debug "%s URL: %s" __FUNCTION__ req.Request.uri ;
   req.Request.close <- true ;
-  if Fileserver.access_forbidden req s then
-    Http_svr.response_forbidden ~req s
-  else
-    let can_be_authorized =
-      try
-        Xapi_http.with_context "get_repository_handler" req s (fun _ -> ()) ;
-        true
-      with _ -> false
-    in
-    let internal_repo_access_only =
-      let __context =
-        Context.make ~origin:(Http (req, s)) "get_repository_handler"
+  Fileserver.send_file Constants.get_repository_uri
+    !Xapi_globs.local_pool_repo_dir
+    req s ()
+
+let get_enabled_repository_handler (req : Http.Request.t) s _ =
+  let open Http in
+  debug "%s URL: %s" __FUNCTION__ req.Request.uri ;
+  req.Request.close <- true ;
+  Xapi_http.with_context __FUNCTION__ req s (fun __context ->
+      let enabled_repo = get_single_enabled_update_repository ~__context in
+      let repo_name =
+        get_remote_repository_name ~__context ~self:enabled_repo
       in
-      Pool_features.is_enabled ~__context Features.Internal_repo_access
-    in
-    match (can_be_authorized, internal_repo_access_only) with
-    | false, true ->
-        error
-          "Invalid secret for authorization when Internal_repo_access is \
-           enabled" ;
-        Http_svr.response_forbidden ~req s
-    | _ -> (
-      try
-        let len = String.length Constants.get_repository_uri in
-        match String.sub_to_end req.Request.uri len with
-        | uri_path ->
-            let root = !Xapi_globs.local_pool_repo_dir in
-            Fileserver.response_file s (Helpers.resolve_uri_path ~root ~uri_path)
-        | exception e ->
-            let msg =
-              Printf.sprintf "Failed to get path from uri': %s"
-                (ExnHelper.string_of_exn e)
-            in
-            raise Api_errors.(Server_error (internal_error, [msg]))
-      with e ->
-        error "Failed to serve for request on uri %s: %s" req.Request.uri
-          (ExnHelper.string_of_exn e) ;
-        Http_svr.response_forbidden ~req s
-    )
+      Fileserver.send_file Constants.get_enabled_repository_uri
+        (Filename.concat !Xapi_globs.local_pool_repo_dir repo_name)
+        req s ()
+  )
 
 let consolidate_updates_of_hosts ~repository_name ~updates_info ~hosts =
   Hashtbl.fold

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -55,6 +55,9 @@ val create_pool_repository :
 
 val get_repository_handler : Http.Request.t -> Unix.file_descr -> 'a -> unit
 
+val get_enabled_repository_handler :
+  Http.Request.t -> Unix.file_descr -> 'a -> unit
+
 val get_host_updates_in_json :
   __context:Context.t -> installed:bool -> Yojson.Basic.t
 

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -789,6 +789,7 @@ let master_only_http_handlers =
     ("post_remote_db_access", remote_database_access_handler)
   ; ("post_remote_db_access_v2", remote_database_access_handler_v2)
   ; ("get_repository", Repository.get_repository_handler)
+  ; ("get_enabled_repository", Repository.get_enabled_repository_handler)
   ; ("get_updates", Xapi_pool.get_updates_handler)
   ]
 


### PR DESCRIPTION
Adding process logic for `/repository/enabled`. If there is `/enabled` after `/repository` in URI, then to find the current enabled repository. Otherwise, keep the existing process logic.