### PR TITLE
CA-400199: open /dev/urandom on first use and use an input channel to reduce number of syscalls

### DIFF
--- a/ocaml/forkexecd/test/fe_test.ml
+++ b/ocaml/forkexecd/test/fe_test.ml
@@ -292,7 +292,7 @@ let slave = function
       (*
 		  Printf.fprintf stderr "%s %d\n" total_fds (List.length present - 1)
 		*)
-      if total_fds + 1 (* Uuid.dev_urandom *) <> List.length filtered then
+      if total_fds <> List.length filtered then
         fail "Expected %d fds; /proc/self/fd has %d: %s" total_fds
           (List.length filtered) ls
 

--- a/ocaml/libs/uuid/uuidx.mli
+++ b/ocaml/libs/uuid/uuidx.mli
@@ -194,8 +194,3 @@ module Hash : sig
   (* UUID Version 5 derived from argument string and namespace UUID *)
   val string : string -> [< not_secret] t
 end
-
-(**/**)
-
-(* just for feature flag, to be removed *)
-val make_default : (unit -> [< not_secret] t) ref

--- a/ocaml/tests/bench/bench_uuid.ml
+++ b/ocaml/tests/bench/bench_uuid.ml
@@ -1,7 +1,5 @@
 open Bechamel
 
-let () = Uuidx.make_default := Uuidx.make_uuid_fast
-
 let benchmarks =
   Test.make_grouped ~name:"uuidx creation"
     [

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1612,12 +1612,6 @@ let other_options =
     , (fun () -> string_of_bool !disable_webserver)
     , "Disable the host webserver"
     )
-  ; ( "use-prng-uuid-gen"
-      (* eventually this'll be the default, except for Sessions *)
-    , Arg.Unit (fun () -> Uuidx.make_default := Uuidx.make_uuid_fast)
-    , (fun () -> !Uuidx.make_default == Uuidx.make_uuid_fast |> string_of_bool)
-    , "Use PRNG based UUID generator instead of CSPRNG"
-    )
   ]
 
 (* The options can be set with the variable xapiflags in /etc/sysconfig/xapi.

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -40,7 +40,7 @@ mli-files () {
 }
 
 structural-equality () {
-  N=10
+  N=9
   EQ=$(git grep -r --count ' == ' -- '**/*.ml' ':!ocaml/sdk-gen/**/*.ml' | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$EQ" -eq "$N" ]; then
     echo "OK counted $EQ usages of ' == '"


### PR DESCRIPTION
This is an alternative to https://github.com/xapi-project/xen-api/pull/6077

2 recent optimizations have changed the Uuidx module to open
  /dev/urandom once on startup, instead of every time a value was
  requested.

However 'networkd_db' runs in the installer environment, inside a chroot where /dev/urandom is not available.

Open /dev/urandom on first use instead.

Simplify the code and use a single implementation for both fast and secure urandom generation:
* use a mutex to protect accesses to global urandom state
* use an input channel, rather than a Unix file descriptor, this allows us to read many bytes in one go, and then generate multiple random numbers without having to make syscalls that often

(syscalls are slow in this case because they require releasing the runtime mutex, which gives another thread the opportunity to run for 50ms).

Fixes: a0176da73 ("CP-49135: open /dev/urandom just once")
Fixes: a2d9fbe39 ("IH-577 Implement v7 UUID generation")
Fixes: 6635a00d6 ("CP-49136: Introduce PRNG for generating non-secret UUIDs")

This is slightly slower than before, but still fast enough:
```
│  uuidx creation/Uuidx.make            │             0.0004 mjw/run│            16.0001 mnw/run│            105.8801 ns/run│
│  uuidx creation/Uuidx.make_uuid_urnd  │             0.0004 mjw/run│            16.0001 mnw/run│            105.1474 ns/run│
```

Previously this used to take ~88ns, so in fact the difference is barely noticable.

Also remove the feature flag: the previous change was feature flagged too, but broke master anyway (I wouldn't have though anything *doesn't* have /dev/urandom available, and didn't feature flag that part, because in general it is not possible to feature flag startup code without races).

`networkd_db` now doesn't try to open this anymore:
```
strace -e openat -e open networkd_db
open("/etc/ld.so.cache", O_RDONLY|O_CLOEXEC) = 3
open("/lib64/libpthread.so.0", O_RDONLY|O_CLOEXEC) = 3
open("/lib64/librt.so.1", O_RDONLY|O_CLOEXEC) = 3
open("/lib64/libm.so.6", O_RDONLY|O_CLOEXEC) = 3
open("/lib64/libdl.so.2", O_RDONLY|O_CLOEXEC) = 3
open("/lib64/libc.so.6", O_RDONLY|O_CLOEXEC) = 3
open("/var/lib/xcp/networkd.db", O_RDONLY) = 3
+++ exited with 0 +++
```