### PR TITLE
CP-51680: C bindings for `pthread_setname_np` and `pthread_getname_np`

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/dune
@@ -2,6 +2,10 @@
   (public_name xapi-stdext-threads)
   (name  xapi_stdext_threads)
   (modules :standard \ threadext_test)
+  (foreign_stubs
+  (language c)
+  (names pthread_helpers pthread_stubs))
+    (c_library_flags -lpthread)
   (libraries
     threads.posix
     unix

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/pthread_helpers.c
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/pthread_helpers.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+#define _GNU_SOURCE
+
+#include <pthread.h>
+
+int set_name(const char *name){
+    pthread_t thread;
+
+    thread = pthread_self();
+
+    return pthread_setname_np(thread, name);
+  }
+
+int get_name(char* thread_name, size_t len){
+  pthread_t thread;
+
+  thread = pthread_self();
+
+  return pthread_getname_np(thread, thread_name, len);
+}

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/pthread_helpers.h
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/pthread_helpers.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+int set_name(const char *name);
+
+int get_name(char * name, size_t len);

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/pthread_stubs.c
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/pthread_stubs.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ */
+
+#define _GNU_SOURCE
+
+#include <pthread.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
+#include <caml/signals.h>
+
+#include "pthread_helpers.h"
+
+#define NAMELEN 16
+
+CAMLprim value stub_set_name(value name){
+  CAMLparam1(name);
+  int rc;
+
+  caml_enter_blocking_section();
+  rc = set_name(String_val(name));
+  caml_leave_blocking_section();
+
+  CAMLreturn(Val_int(rc));
+}
+
+CAMLprim value stub_get_name(value unit){
+  CAMLparam1(unit);
+  CAMLlocal1(result);
+  char thread_name[NAMELEN];
+
+  caml_enter_blocking_section();
+  int rc = get_name(thread_name, NAMELEN);
+  caml_leave_blocking_section();
+
+  if (rc != 0)
+    CAMLreturn(Val_none);
+
+  result = caml_copy_string(thread_name);
+  CAMLreturn(caml_alloc_some(result));
+}

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
@@ -131,3 +131,14 @@ let wait_timed_write fd timeout =
       true
   | _ ->
       assert false
+
+module Pthread = struct
+  external c_set_name : string -> int = "stub_set_name"
+
+  let set_name s =
+    let len = Int.min (String.length s) 15 in
+    let tname = String.sub s 0 len in
+    match c_set_name tname with 0 -> Some tname | _ -> None
+
+  external get_name : unit -> string option = "stub_get_name"
+end

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
@@ -133,12 +133,15 @@ let wait_timed_write fd timeout =
       assert false
 
 module Pthread = struct
-  external c_set_name : string -> int = "stub_set_name"
+  external c_set_name : string -> unit = "stub_set_name"
 
   let set_name s =
     let len = Int.min (String.length s) 15 in
     let tname = String.sub s 0 len in
-    match c_set_name tname with 0 -> Some tname | _ -> None
+    try
+      let () = c_set_name tname in
+      Some tname
+    with _ -> None
 
-  external get_name : unit -> string option = "stub_get_name"
+  external get_name : unit -> string = "stub_get_name"
 end

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
@@ -46,7 +46,7 @@ module Pthread : sig
     Returns [Some n] where [n] is the new pthread name or [None] if the operation failed.
   *)
 
-  val get_name : unit -> string option
+  val get_name : unit -> string
   (** [get_name] returns [Some name] where [name] is the pthread name of the caller's pthread. 
   Returns [None] if the operation failed.*)
 end

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
@@ -37,3 +37,16 @@ end
 val wait_timed_read : Unix.file_descr -> float -> bool
 
 val wait_timed_write : Unix.file_descr -> float -> bool
+
+(** [Pthread] module contains a few helper functions that interact with pthreads.*)
+module Pthread : sig
+  val set_name : string -> string option
+  (** [set_name name] sets the name of the caller's pthread to the first 15 characters of [name].
+  
+    Returns [Some n] where [n] is the new pthread name or [None] if the operation failed.
+  *)
+
+  val get_name : unit -> string option
+  (** [get_name] returns [Some name] where [name] is the pthread name of the caller's pthread. 
+  Returns [None] if the operation failed.*)
+end


### PR DESCRIPTION
This creates 2 C bindings inside `Threadext` module for:
- pthread_setname_np;
- pthread_getname_np;

This allows for better debuggability of Ocaml threads.