### PR TITLE
CP-50546: Remove initscripts family

### DIFF
--- a/scripts/plugins/firewall-port
+++ b/scripts/plugins/firewall-port
@@ -37,14 +37,14 @@ case "${OP}" in
                 iptables -I INPUT -j "${CHAIN}"
             fi # asuume chain is used if it exists
         iptables -I "${CHAIN}" $RULE
-        service iptables save
+	/usr/libexec/iptables/iptables.init save
         fi
         ;;
     close)
         if iptables -C $CHAIN $RULE 2>/dev/null
         then # close port  if it was opened 
             iptables -D $CHAIN $RULE
-            service iptables save
+	    /usr/libexec/iptables/iptables.init save
         fi
         ;;
     check) 

--- a/scripts/xe-syslog-reconfigure
+++ b/scripts/xe-syslog-reconfigure
@@ -42,4 +42,4 @@ else
 fi
 
 [ -s /etc/syslog.$$ ] && mv -f /etc/syslog.$$ $conf_file
-service $service restart
+systemctl restart $service


### PR DESCRIPTION
initscripts family are legacy and want to be removed

`service iptables save` call
/usr/libexec/initscripts/legacy-actions/iptables/save, which call `exec /usr/libexec/iptables/iptables.init save`, to save iptables rules and remove initscripts, we call following directly `/usr/libexec/iptables/iptables.init save`

`service` command are also updated to `systemctl`