### PR TITLE
Remove notion of weird string from sexpr library

### DIFF
--- a/ocaml/libs/sexpr/sExpr.ml
+++ b/ocaml/libs/sexpr/sExpr.ml
@@ -11,11 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-type t =
-  | Node of t list
-  | Symbol of string
-  | String of string
-  | WeirdString of string * string
+type t = Node of t list | Symbol of string | String of string
 
 let unescape_buf buf s =
   let aux esc = function
@@ -84,30 +80,12 @@ let string_of sexpr =
             List.iter (fun i -> Buffer.add_char buf ' ' ; __string_of_rec i) l
         ) ;
         Buffer.add_char buf ')'
-    | Symbol s | String s | WeirdString (_, s) ->
+    | Symbol s | String s ->
         Buffer.add_string buf "\'" ;
         Buffer.add_string buf (escape s) ;
         Buffer.add_string buf "\'"
   in
   __string_of_rec sexpr ; Buffer.contents buf
-
-let weird_of_string x =
-  let random_chars = "abcdefghijklmnopqrstuvwxyz" in
-  let randchar () =
-    String.sub random_chars (Random.int (String.length random_chars)) 1
-  in
-  (* true if the parent string contains child as a substring, starting the
-     search forward from offset *)
-  let rec has_substring parent offset child =
-    String.length parent - offset >= String.length child
-    && (String.sub parent offset (String.length child) = child
-       || has_substring parent (offset + 1) child
-       )
-  in
-  let rec find delim =
-    if has_substring x 0 delim then find (delim ^ randchar ()) else delim
-  in
-  WeirdString (find "xxx", x)
 
 let rec output_fmt ff = function
   | Node list ->
@@ -121,12 +99,5 @@ let rec output_fmt ff = function
             aux ~first t
       in
       Format.fprintf ff "@[(" ; aux list ; Format.fprintf ff ")@]"
-  | Symbol s | String s | WeirdString (_, s) ->
+  | Symbol s | String s ->
       Format.fprintf ff "\"%s\"" (escape s)
-
-(*
-  | Symbol s ->
-      Format.fprintf ff "%s" s
-  | WeirdString(tag, s) ->
-      Format.fprintf ff "<<%s<%s<%s<" tag s tag
-*)

--- a/ocaml/libs/sexpr/sExpr.mli
+++ b/ocaml/libs/sexpr/sExpr.mli
@@ -11,16 +11,10 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-type t =
-  | Node of t list
-  | Symbol of string
-  | String of string
-  | WeirdString of string * string
+type t = Node of t list | Symbol of string | String of string
 
 val mkstring : string -> t
 
 val string_of : t -> string
-
-val weird_of_string : string -> t
 
 val output_fmt : Format.formatter -> t -> unit

--- a/ocaml/libs/sexpr/sExprLexer.mli
+++ b/ocaml/libs/sexpr/sExprLexer.mli
@@ -1,7 +1,0 @@
-val line : int ref
-
-val __ocaml_lex_tables : Lexing.lex_tables
-
-val token : Lexing.lexbuf -> SExprParser.token
-
-val __ocaml_lex_token_rec : Lexing.lexbuf -> int -> SExprParser.token

--- a/ocaml/libs/sexpr/sExprLexer.mll
+++ b/ocaml/libs/sexpr/sExprLexer.mll
@@ -1,14 +1,9 @@
 {
   open SExprParser
-  let line = ref 1
 }
 
 rule token = parse
-  | [' ' '\t' '\r']                     { token lexbuf }
-  | ';' [^ '\n']* '\n'                  { incr line; token lexbuf }
-  | '\n'                                { incr line; token lexbuf }
-  | "<<" ([^ '<']+ as tag1) '<' ([^ '<']* as s) '<' ([^ '<']+ as tag2) '<'
-      { if tag1=tag2 then WEIRD(tag1, s) else invalid_arg "Weird tag" }
+  | [' ' '\t' '\r' '\n']+ | ';' [^ '\n']* '\n'     { token lexbuf }
   | '"'  (([^ '"' '\\']  | ('\\' _))* as s) '"'    { STRING s }
   | '\'' (([^ '\'' '\\'] | ('\\' _))* as s) '\''   { STRING s }
   | [^ '"' ' ' '\t' '\n' '(' ')']+ as s { SYMBOL s }

--- a/ocaml/libs/sexpr/sExprParser.mly
+++ b/ocaml/libs/sexpr/sExprParser.mly
@@ -1,17 +1,11 @@
 %token <string> SYMBOL STRING
-%token <string * string> WEIRD
 %token OPEN CLOSE
 
-%start expr
-%type <SExpr.t> expr
+%start<SExpr.t> expr
 
 %%
 
-expr_list: { [] }
-| expr expr_list { $1 :: $2 };
-
 expr:
-| OPEN expr_list CLOSE { SExpr.Node $2 }
-| SYMBOL               { SExpr.Symbol $1 }
-| STRING               { SExpr.mkstring $1 }
-| WEIRD                { (fun (tag, s) -> SExpr.WeirdString(tag, s)) $1 };
+| OPEN es = list(expr) CLOSE { SExpr.Node es }
+| s = SYMBOL { SExpr.Symbol s }
+| s = STRING { SExpr.mkstring s }


### PR DESCRIPTION
Removes the remnants of an escaping mechanism once used in xapi.

It appears that the format `<<xxx<value<xxx<` (where `xxx` acted as delimiting tags) was an early escaping format. The construction of these weird strings appears to have been dropped a long time ago (2006).