### PR TITLE
CA-399396: Adjust the jemalloc parameters for memory performance

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -305,7 +305,7 @@ def main(argv):
        qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.2"
     else:
        qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.2:" + qemu_env["LD_PRELOAD"]
-    qemu_env["MALLOC_CONF"] = "narenas:1,tcache:false"
+    qemu_env["MALLOC_CONF"] = "background_thread:true,dirty_decay_ms:100,narenas:1,tcache:false"
 
     sys.stdout.flush()
     sys.stderr.flush()

--- a/scripts/xapi-nbd.service
+++ b/scripts/xapi-nbd.service
@@ -5,7 +5,7 @@ Wants=xapi.service message-switch.service syslog.target
 
 [Service]
 Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
-Environment="MALLOC_CONF=narenas:1,tcache:false"
+Environment="MALLOC_CONF=background_thread:true,dirty_decay_ms:100,narenas:1,tcache:false"
 Environment=OCAMLRUNPARAM=b
 # The --certfile option must match the server-cert-path in xapi.conf
 # and the PathExists in xapi-nbd.path: any change must be made in all three files.

--- a/scripts/xcp-networkd.service
+++ b/scripts/xcp-networkd.service
@@ -7,7 +7,7 @@ Wants=forkexecd.service message-switch.service syslog.target
 [Service]
 Type=notify
 Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
-Environment="MALLOC_CONF=narenas:1,tcache:false"
+Environment="MALLOC_CONF=background_thread:true,dirty_decay_ms:100,narenas:1,tcache:false"
 Environment=OCAMLRUNPARAM=b
 EnvironmentFile=-/etc/sysconfig/xcp-networkd
 ExecStart=/usr/sbin/xcp-networkd $XCP_NETWORKD_OPTIONS

--- a/scripts/xcp-rrdd.service
+++ b/scripts/xcp-rrdd.service
@@ -6,7 +6,7 @@ Wants=forkexecd.service xenstored.service message-switch.service syslog.target
 [Service]
 Type=notify
 Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
-Environment="MALLOC_CONF=narenas:1,tcache:false"
+Environment="MALLOC_CONF=background_thread:true,dirty_decay_ms:100,narenas:1,tcache:false"
 Environment=OCAMLRUNPARAM=b
 EnvironmentFile=-/etc/sysconfig/xcp-rrdd
 ExecStart=/usr/sbin/xcp-rrdd $XCP_RRDD_OPTIONS


### PR DESCRIPTION
The new version (5.3.0) jemalloc caused a significant increase of memory usage compared to the version 3.6.0.
Adjust the parameters to fix the memory usage issue.

The modification has two parts, the other PR is in the spec repo.

- dom0mem test:
-- xenopsd-xc
![image](https://github.com/user-attachments/assets/853212ce-de13-49ed-9890-97887c9836c1)
-- qemu
![image](https://github.com/user-attachments/assets/aa28b3d4-7948-472f-bcf1-62c866768299)
-- xapi (the config is not changed for xapi service)
![image](https://github.com/user-attachments/assets/02e924a6-22f4-48f4-a821-601cf205ffc7)


