### PR TITLE
Do not include xapi-clusterd.service in toolstack.target

### DIFF
--- a/scripts/toolstack.target
+++ b/scripts/toolstack.target
@@ -20,7 +20,6 @@ Wants=xcp-networkd.service
 Wants=xenopsd-xc.service
 Wants=squeezed.service
 Wants=xapi-storage-script.service
-Wants=xapi-clusterd.service
 Wants=varstored-guard.service
 
 [Install]


### PR DESCRIPTION
This service is not enabled and started by default, but used on-demand whenever it is needed for clustering. The current Wants= option in the toolstack.target is causing xapi-clusterd.service to be started by xe-toolstack-restart even if it is not enabled.

The fix is to replace Wants= in toolstack.target with WantedBy= in xapi-clusterd.service, as the latter only installs the dependency when enabling the service.