### PR TITLE
Remove xapi-clusterd.service from toolstack.target

### DIFF
--- a/scripts/toolstack.target
+++ b/scripts/toolstack.target
@@ -20,7 +20,6 @@ Wants=xcp-networkd.service
 Wants=xenopsd-xc.service
 Wants=squeezed.service
 Wants=xapi-storage-script.service
-Wants=xapi-clusterd.service
 Wants=varstored-guard.service
 
 [Install]


### PR DESCRIPTION
xapi-clusterd should not be (re)started if it is not enabled, when, e.g. we do not have a cluster running.