### PR TITLE
CA-401324: Update pvsproxy socket location

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -1474,10 +1474,21 @@ end
 module PVS_proxy = struct
   open S.PVS_proxy
 
-  let path = ref "/run/pvsproxy"
+  let path = ref ""
+
+  let depriv_path = "/run/pvsproxy-state/socket"
+
+  let legacy_path = "/opt/citrix/pvsproxy/socket/pvsproxy"
+
+  let default_path () =
+    if Sys.file_exists depriv_path then
+      depriv_path
+    else
+      legacy_path
 
   let do_call call =
-    try Jsonrpc_client.with_rpc ~path:!path ~call ()
+    let p = match !path with "" -> default_path () | path -> path in
+    try Jsonrpc_client.with_rpc ~path:p ~call ()
     with e ->
       error "Error when calling PVS proxy: %s" (Printexc.to_string e) ;
       raise (Network_error PVS_proxy_connection_error)


### PR DESCRIPTION
A previous commit changed the socket location to /run/pvsproxy but this is problematic because the pvsproxy daemon runs as a deprivileged user and cannot create the socket.

Instead, update the path to a location that the daemon has permission to create. Add a fallback to the original path to cope with older pvsproxy daemons. This fallback can be removed in the future.