### PR TITLE
CP-45016 Implement inbound SXM for SMAPIv3 SRs

### DIFF
--- a/ocaml/tests/test_sm_features.ml
+++ b/ocaml/tests/test_sm_features.ml
@@ -20,7 +20,7 @@ type sm_data_sequence = {
     (* Text feature list we get back as part of sr_get_driver_info. *)
     raw: string list
   ; (* SMAPIv1 driver info. *)
-    smapiv1_features: Smint.feature list
+    smapiv1_features: Smint.Feature.t list
   ; (* SMAPIv2 driver info. *)
     smapiv2_features: string list
   ; (* SM object created in the database. *)
@@ -40,7 +40,6 @@ let string_of_sm_object sm =
     )
 
 let test_sequences =
-  let open Smint in
   [
     (* Test NFS driver features as of Clearwater. *)
     {
@@ -179,14 +178,14 @@ module ParseSMAPIv1Features = Generic.MakeStateless (struct
   module Io = struct
     type input_t = string list
 
-    type output_t = Smint.feature list
+    type output_t = Smint.Feature.t list
 
     let string_of_input_t = Test_printers.(list string)
 
-    let string_of_output_t = Test_printers.(list Smint.string_of_feature)
+    let string_of_output_t = Test_printers.(list Smint.Feature.to_string)
   end
 
-  let transform = Smint.parse_capability_int64_features
+  let transform = Smint.Feature.parse_capability_int64
 
   let tests =
     `QuickAndAutoDocumented
@@ -198,16 +197,16 @@ end)
 
 module CreateSMAPIv2Features = Generic.MakeStateless (struct
   module Io = struct
-    type input_t = Smint.feature list
+    type input_t = Smint.Feature.t list
 
     type output_t = string list
 
-    let string_of_input_t = Test_printers.(list Smint.string_of_feature)
+    let string_of_input_t = Test_printers.(list Smint.Feature.to_string)
 
     let string_of_output_t = Test_printers.(list string)
   end
 
-  let transform = List.map Smint.string_of_feature
+  let transform = List.map Smint.Feature.to_string
 
   let tests =
     `QuickAndAutoDocumented
@@ -276,9 +275,10 @@ module CompatSMFeatures = Generic.MakeStateless (struct
   end
 
   let transform l =
+    let open Smint.Feature in
     List.split l |> fun (x, y) ->
-    (Smint.parse_string_int64_features x, Smint.parse_string_int64_features y)
-    |> fun (x, y) -> Smint.compat_features x y |> List.map Smint.unparse_feature
+    (parse_string_int64 x, parse_string_int64 y) |> fun (x, y) ->
+    compat_features x y |> List.map unparse
 
   let tests =
     let r1, r2 = test_intersection_sequences in

--- a/ocaml/tests/test_storage_migrate_state.ml
+++ b/ocaml/tests/test_storage_migrate_state.ml
@@ -44,14 +44,15 @@ let sample_send_state =
     }
 
 let sample_receive_state =
+  let open Storage_interface in
   Storage_migrate.State.Receive_state.
     {
-      sr= Storage_interface.Sr.of_string "my_sr"
-    ; dummy_vdi= Storage_interface.Vdi.of_string "dummy_vdi"
-    ; leaf_vdi= Storage_interface.Vdi.of_string "leaf_vdi"
+      sr= Sr.of_string "my_sr"
+    ; dummy_vdi= Vdi.of_string "dummy_vdi"
+    ; leaf_vdi= Vdi.of_string "leaf_vdi"
     ; leaf_dp= "leaf_dp"
-    ; parent_vdi= Storage_interface.Vdi.of_string "parent_vdi"
-    ; remote_vdi= Storage_interface.Vdi.of_string "remote_vdi"
+    ; parent_vdi= Vdi.of_string "parent_vdi"
+    ; remote_vdi= Vdi.of_string "remote_vdi"
     }
 
 let sample_copy_state =

--- a/ocaml/tests/test_storage_migrate_state.ml
+++ b/ocaml/tests/test_storage_migrate_state.ml
@@ -53,6 +53,7 @@ let sample_receive_state =
     ; leaf_dp= "leaf_dp"
     ; parent_vdi= Vdi.of_string "parent_vdi"
     ; remote_vdi= Vdi.of_string "remote_vdi"
+    ; mirror_vm= Vm.of_string "mirror_vm"
     }
 
 let sample_copy_state =

--- a/ocaml/vhd-tool/cli/dune
+++ b/ocaml/vhd-tool/cli/dune
@@ -4,7 +4,7 @@
   (libraries
     astring
 
-    local_lib
+    vhd_lib
     cmdliner
     cstruct
     forkexec

--- a/ocaml/vhd-tool/src/dune
+++ b/ocaml/vhd-tool/src/dune
@@ -4,7 +4,7 @@
     (language c)
     (names direct_copy_stubs)
   )
-  (name local_lib)
+  (name vhd_lib)
   (wrapped false)
   (libraries
     astring

--- a/ocaml/vhd-tool/src/dune
+++ b/ocaml/vhd-tool/src/dune
@@ -32,6 +32,7 @@
     tapctl
     xapi-stdext-std
     xapi-stdext-unix
+    xapi-log
     xen-api-client-lwt
   )
   (preprocess

--- a/ocaml/vhd-tool/src/impl.ml
+++ b/ocaml/vhd-tool/src/impl.ml
@@ -220,7 +220,7 @@ let[@warning "-27"] stream_human _common _ s _ _ ?(progress = no_progress_bar)
   Printf.printf "# end of stream\n" ;
   return None
 
-let stream_nbd _common c s prezeroed _ ?(progress = no_progress_bar) () =
+let stream_nbd _common c s prezeroed ~export ?(progress = no_progress_bar) () =
   let open Nbd_unix in
   let c =
     {
@@ -231,7 +231,7 @@ let stream_nbd _common c s prezeroed _ ?(progress = no_progress_bar) () =
     }
   in
 
-  Client.negotiate c "" >>= fun (server, size, _flags) ->
+  Client.negotiate c export >>= fun (server, size, _flags) ->
   (* Work to do is: non-zero data to write + empty sectors if the
      target is not prezeroed *)
   D.debug "%s nbd negotiation done, size is %Ld" __FUNCTION__ size ;
@@ -988,7 +988,7 @@ let write_stream common s destination destination_protocol prezeroed progress
       return (c, [NoProtocol; Human; Tar])
   | File_descr fd ->
       Channels.of_raw_fd fd >>= fun c ->
-      return (c, [Nbd; NoProtocol; Chunked; Human; Tar])
+      return (c, [dummy_nbd; NoProtocol; Chunked; Human; Tar])
   | Sockaddr sockaddr ->
       let sock = socket sockaddr in
       Lwt.catch
@@ -996,7 +996,7 @@ let write_stream common s destination destination_protocol prezeroed progress
         (fun e -> Lwt_unix.close sock >>= fun () -> Lwt.fail e)
       >>= fun () ->
       Channels.of_raw_fd sock >>= fun c ->
-      return (c, [Nbd; NoProtocol; Chunked; Human; Tar])
+      return (c, [dummy_nbd; NoProtocol; Chunked; Human; Tar])
   | Https uri' | Http uri' -> (
       (* TODO: https is not currently implemented *)
       let port =
@@ -1016,7 +1016,6 @@ let write_stream common s destination destination_protocol prezeroed progress
       let host = Scanf.ksscanf host (fun _ _ -> host) "[%s@]" Fun.id in
       Lwt_unix.getaddrinfo host (string_of_int port) [] >>= fun he ->
       if he = [] then raise Not_found ;
-
       let sockaddr = (List.hd he).Unix.ai_addr in
       let sock = socket sockaddr in
       Lwt.catch
@@ -1077,7 +1076,7 @@ let write_stream common s destination destination_protocol prezeroed progress
               List.mem_assoc te headers && List.assoc te headers = "nbd"
             in
             if advertises_nbd then
-              return (c, [Nbd])
+              return (c, [dummy_nbd])
             else
               return (c, [Chunked; NoProtocol])
           else
@@ -1094,7 +1093,12 @@ let write_stream common s destination destination_protocol prezeroed progress
         D.info "Using protocol: %s\n%!" (string_of_protocol t) ;
         t
   in
-  if not (List.mem destination_protocol possible_protocols) then
+  (* when checking for the validity of the protocol, we only care about the protocol
+     itself and not the export name, if it was nbd. Convert all Nbd export to Nbd "" *)
+  let equal_to_dest_proto =
+    ( = ) (match destination_protocol with Nbd _ -> dummy_nbd | y -> y)
+  in
+  if not (List.exists equal_to_dest_proto possible_protocols) then
     fail
       (Failure
          (Printf.sprintf "this destination only supports protocols: [ %s ]"
@@ -1104,18 +1108,17 @@ let write_stream common s destination destination_protocol prezeroed progress
   else
     let start = Unix.gettimeofday () in
     ( match destination_protocol with
-    | Nbd ->
-        stream_nbd
+    | Nbd export ->
+        stream_nbd common c s prezeroed ~export ~progress ()
     | Human ->
-        stream_human
+        stream_human common c s prezeroed tar_filename_prefix ~progress ()
     | Chunked ->
-        stream_chunked
+        stream_chunked common c s prezeroed tar_filename_prefix ~progress ()
     | Tar ->
-        stream_tar
+        stream_tar common c s prezeroed tar_filename_prefix ~progress ()
     | NoProtocol ->
-        stream_raw
+        stream_raw common c s prezeroed tar_filename_prefix ~progress ()
     )
-      common c s prezeroed tar_filename_prefix ~progress ()
     >>= fun p ->
     c.Channels.close () >>= fun () ->
     match p with
@@ -1322,7 +1325,7 @@ let serve common_options source source_fd source_format source_protocol
     let supported_formats = ["raw"] in
     if not (List.mem destination_format supported_formats) then
       failwith (Printf.sprintf "%s is not a supported format" destination_format) ;
-    let supported_protocols = [NoProtocol; Chunked; Nbd; Tar] in
+    let supported_protocols = [NoProtocol; Chunked; dummy_nbd; Tar] in
     if not (List.mem source_protocol supported_protocols) then
       failwith
         (Printf.sprintf "%s is not a supported source protocol"
@@ -1412,7 +1415,7 @@ let serve common_options source source_fd source_format source_protocol
         match (source_format, source_protocol) with
         | "raw", NoProtocol ->
             serve_raw_to_raw common_options size
-        | "raw", Nbd ->
+        | "raw", Nbd _ ->
             serve_nbd_to_raw common_options size
         | "raw", Chunked ->
             serve_chunked_to_raw common_options

--- a/ocaml/vhd-tool/src/streamCommon.ml
+++ b/ocaml/vhd-tool/src/streamCommon.ml
@@ -12,11 +12,20 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type protocol = Nbd | Chunked | Human | Tar | NoProtocol
+type protocol =
+  | Nbd of string (* export name used by the nbd client during negotiation*)
+  | Chunked
+  | Human
+  | Tar
+  | NoProtocol
+
+(** This dummy nbd has no export name in it, it is introduced for backwards compatability 
+reasons. *)
+let dummy_nbd = Nbd ""
 
 let protocol_of_string = function
   | "nbd" ->
-      Nbd
+      dummy_nbd
   | "chunked" ->
       Chunked
   | "human" ->
@@ -29,8 +38,8 @@ let protocol_of_string = function
       failwith (Printf.sprintf "Unsupported protocol: %s" x)
 
 let string_of_protocol = function
-  | Nbd ->
-      "nbd"
+  | Nbd export ->
+      "nbd:" ^ export
   | Chunked ->
       "chunked"
   | Human ->

--- a/ocaml/vhd-tool/test/dune
+++ b/ocaml/vhd-tool/test/dune
@@ -4,7 +4,7 @@
     alcotest
     alcotest-lwt
     lwt
-    local_lib
+    vhd_lib
     vhd-format
     vhd-format-lwt
   )

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -512,6 +512,9 @@ module StorageAPI (R : RPC) = struct
         @-> returning unit_p err
         )
 
+    (** [attach_info context dbg sr vdi dp vm] returns the information as returned
+    by the [attach3 dbg dp sr vdi vm _] call. Callers of this function should ensure
+    that VDIs are already attached before calling this function. *)
     let attach_info =
       let backend_p = Param.mk ~name:"backend" backend in
       declare "DP.attach_info"
@@ -519,7 +522,7 @@ module StorageAPI (R : RPC) = struct
           "[DP.attach_info  sr vdi dp]: returns the params of the dp (the \
            return value of VDI.attach2)"
         ]
-        (dbg_p @-> sr_p @-> vdi_p @-> dp_p @-> returning backend_p err)
+        (dbg_p @-> sr_p @-> vdi_p @-> dp_p @-> vm_p @-> returning backend_p err)
 
     (**  *)
     let diagnostics =
@@ -824,7 +827,7 @@ module StorageAPI (R : RPC) = struct
         @-> returning backend_p err
         )
 
-    (** [attach3 task dp sr vdi read_write] returns the [params] for a given
+    (** [attach3 task dp sr vdi vm read_write] returns the [params] for a given
         [vdi] in [sr] which can be written to if (but not necessarily only if)
         [read_write] is true *)
     let attach3 =
@@ -1108,7 +1111,7 @@ module type Server_impl = sig
       -> unit
 
     val attach_info :
-      context -> dbg:debug_info -> sr:sr -> vdi:vdi -> dp:dp -> backend
+      context -> dbg:debug_info -> sr:sr -> vdi:vdi -> dp:dp -> vm:vm -> backend
 
     val diagnostics : context -> unit -> string
 
@@ -1409,8 +1412,8 @@ module Server (Impl : Server_impl) () = struct
     S.DP.destroy2 (fun dbg dp sr vdi vm allow_leak ->
         Impl.DP.destroy2 () ~dbg ~dp ~sr ~vdi ~vm ~allow_leak
     ) ;
-    S.DP.attach_info (fun dbg sr vdi dp ->
-        Impl.DP.attach_info () ~dbg ~sr ~vdi ~dp
+    S.DP.attach_info (fun dbg sr vdi dp vm ->
+        Impl.DP.attach_info () ~dbg ~sr ~vdi ~dp ~vm
     ) ;
     S.DP.diagnostics (fun () -> Impl.DP.diagnostics () ()) ;
     S.DP.stat_vdi (fun dbg sr vdi () -> Impl.DP.stat_vdi () ~dbg ~sr ~vdi ()) ;

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -1058,8 +1058,21 @@ module StorageAPI (R : RPC) = struct
           @-> returning result err
           )
 
+      (** Called on the receiving end 
+        @deprecated This function is deprecated, and is only here to keep backward 
+        compatibility with old xapis that call Remote.DATA.MIRROR.receive_finalize
+        during SXM.  Use the receive_finalize2 function instead. 
+      *)
       let receive_finalize =
         declare "DATA.MIRROR.receive_finalize" []
+          (dbg_p @-> id_p @-> returning unit_p err)
+
+      (** [receive_finalize2 dbg id] will stop the mirroring process and compose 
+      the snapshot VDI with the mirror VDI. It also cleans up the storage resources 
+      used by mirroring. It is called after the the source VM is paused. This fucntion
+      should be used in conjunction with [receive_start2] *)
+      let receive_finalize2 =
+        declare "DATA.MIRROR.receive_finalize2" []
           (dbg_p @-> id_p @-> returning unit_p err)
 
       let receive_cancel =
@@ -1424,6 +1437,8 @@ module type Server_impl = sig
 
       val receive_finalize : context -> dbg:debug_info -> id:Mirror.id -> unit
 
+      val receive_finalize2 : context -> dbg:debug_info -> id:Mirror.id -> unit
+
       val receive_cancel : context -> dbg:debug_info -> id:Mirror.id -> unit
 
       val list : context -> dbg:debug_info -> (Mirror.id * Mirror.t) list
@@ -1611,6 +1626,9 @@ module Server (Impl : Server_impl) () = struct
     ) ;
     S.DATA.MIRROR.receive_finalize (fun dbg id ->
         Impl.DATA.MIRROR.receive_finalize () ~dbg ~id
+    ) ;
+    S.DATA.MIRROR.receive_finalize2 (fun dbg id ->
+        Impl.DATA.MIRROR.receive_finalize2 () ~dbg ~id
     ) ;
     S.DATA.MIRROR.list (fun dbg -> Impl.DATA.MIRROR.list () ~dbg) ;
     S.DATA.MIRROR.import_activate (fun dbg dp sr vdi vm ->

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -913,8 +913,8 @@ module StorageAPI (R : RPC) = struct
       declare "VDI.set_content_id" []
         (dbg_p @-> sr_p @-> vdi_p @-> content_id_p @-> returning unit_p err)
 
-    (** [compose task sr vdi1 vdi2] layers the updates from [vdi2] onto [vdi1],
-        modifying [vdi2] *)
+    (** [compose task sr parent child] layers the updates from [child] onto [parent],
+        modifying [child] *)
     let compose =
       let vdi1_p = Param.mk ~name:"vdi1" Vdi.t in
       let vdi2_p = Param.mk ~name:"vdi2" Vdi.t in
@@ -1044,7 +1044,8 @@ module StorageAPI (R : RPC) = struct
           @-> returning result err
           )
 
-      (** Called on the receiving end to prepare for receipt of the storage.*)
+      (** Called on the receiving end to prepare for receipt of the storage. This
+      function should be used in conjunction with [receive_finalize2]*)
       let receive_start2 =
         let similar_p = Param.mk ~name:"similar" Mirror.similars in
         let result = Param.mk ~name:"result" Mirror.mirror_receive_result in
@@ -1075,6 +1076,8 @@ module StorageAPI (R : RPC) = struct
         declare "DATA.MIRROR.receive_finalize2" []
           (dbg_p @-> id_p @-> returning unit_p err)
 
+      (** [receive_cancel dbg id] is called in the case of migration failure to
+      do the clean up.*)
       let receive_cancel =
         declare "DATA.MIRROR.receive_cancel" []
           (dbg_p @-> id_p @-> returning unit_p err)

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -1097,7 +1097,19 @@ module StorageAPI (R : RPC) = struct
           @-> returning sock_path_p err
           )
 
-
+      (** [get_nbd_server dbg dp sr vdi vm] returns the address of a generic nbd
+      server that can be connected to. Depending on the backend, this will either
+      be a nbd server backed by tapdisk or qemu-dp. Note this is different 
+      from [import_activate] as the returned server does not accept fds. *)
+      let get_nbd_server =
+        declare "DATA.MIRROR.get_nbd_server" []
+          (dbg_p
+          @-> dp_p
+          @-> sr_p
+          @-> vdi_p
+          @-> vm_p
+          @-> returning sock_path_p err
+          )
     end
   end
 
@@ -1452,6 +1464,14 @@ module type Server_impl = sig
         -> vm:vm
         -> sock_path
 
+      val get_nbd_server :
+           context
+        -> dbg:debug_info
+        -> dp:dp
+        -> sr:sr
+        -> vdi:vdi
+        -> vm:vm
+        -> sock_path
     end
   end
 
@@ -1634,7 +1654,9 @@ module Server (Impl : Server_impl) () = struct
     S.DATA.MIRROR.import_activate (fun dbg dp sr vdi vm ->
         Impl.DATA.MIRROR.import_activate () ~dbg ~dp ~sr ~vdi ~vm
     ) ;
-
+    S.DATA.MIRROR.get_nbd_server (fun dbg dp sr vdi vm ->
+        Impl.DATA.MIRROR.get_nbd_server () ~dbg ~dp ~sr ~vdi ~vm
+    ) ;
     S.Policy.get_backend_vm (fun dbg vm sr vdi ->
         Impl.Policy.get_backend_vm () ~dbg ~vm ~sr ~vdi
     ) ;

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -989,6 +989,7 @@ module StorageAPI (R : RPC) = struct
         (dbg_p
         @-> sr_p
         @-> vdi_p
+        @-> vm_p
         @-> url_p
         @-> dest_p
         @-> verify_dest_p
@@ -996,6 +997,10 @@ module StorageAPI (R : RPC) = struct
         )
 
     module MIRROR = struct
+      let mirror_vm_p = Param.mk ~name:"mirror_vm" Vm.t
+
+      let copy_vm_p = Param.mk ~name:"copy_vm" Vm.t
+
       (** [start task sr vdi url sr2] creates a VDI in remote [url]'s [sr2] and
           writes data synchronously. It returns the id of the VDI.*)
       let start =
@@ -1004,6 +1009,8 @@ module StorageAPI (R : RPC) = struct
           @-> sr_p
           @-> vdi_p
           @-> dp_p
+          @-> mirror_vm_p
+          @-> copy_vm_p
           @-> url_p
           @-> dest_p
           @-> verify_dest_p
@@ -1020,7 +1027,11 @@ module StorageAPI (R : RPC) = struct
         let result_p = Param.mk ~name:"result" Mirror.t in
         declare "DATA.MIRROR.stat" [] (dbg_p @-> id_p @-> returning result_p err)
 
-      (** Called on the receiving end *)
+      (** Called on the receiving end 
+        @deprecated This function is deprecated, and is only here to keep backward 
+        compatibility with old xapis that call Remote.DATA.MIRROR.receive_start during SXM. 
+        Use the receive_start2 function instead. 
+      *)
       let receive_start =
         let similar_p = Param.mk ~name:"similar" Mirror.similars in
         let result = Param.mk ~name:"result" Mirror.mirror_receive_result in
@@ -1030,6 +1041,20 @@ module StorageAPI (R : RPC) = struct
           @-> VDI.vdi_info_p
           @-> id_p
           @-> similar_p
+          @-> returning result err
+          )
+
+      (** Called on the receiving end to prepare for receipt of the storage.*)
+      let receive_start2 =
+        let similar_p = Param.mk ~name:"similar" Mirror.similars in
+        let result = Param.mk ~name:"result" Mirror.mirror_receive_result in
+        declare "DATA.MIRROR.receive_start2" []
+          (dbg_p
+          @-> sr_p
+          @-> VDI.vdi_info_p
+          @-> id_p
+          @-> similar_p
+          @-> vm_p
           @-> returning result err
           )
 
@@ -1354,6 +1379,7 @@ module type Server_impl = sig
       -> dbg:debug_info
       -> sr:sr
       -> vdi:vdi
+      -> vm:vm
       -> url:string
       -> dest:sr
       -> verify_dest:bool
@@ -1366,6 +1392,8 @@ module type Server_impl = sig
         -> sr:sr
         -> vdi:vdi
         -> dp:dp
+        -> mirror_vm:vm
+        -> copy_vm:vm
         -> url:string
         -> dest:sr
         -> verify_dest:bool
@@ -1382,6 +1410,16 @@ module type Server_impl = sig
         -> vdi_info:vdi_info
         -> id:Mirror.id
         -> similar:Mirror.similars
+        -> Mirror.mirror_receive_result
+
+      val receive_start2 :
+           context
+        -> dbg:debug_info
+        -> sr:sr
+        -> vdi_info:vdi_info
+        -> id:Mirror.id
+        -> similar:Mirror.similars
+        -> vm:vm
         -> Mirror.mirror_receive_result
 
       val receive_finalize : context -> dbg:debug_info -> id:Mirror.id -> unit
@@ -1552,16 +1590,21 @@ module Server (Impl : Server_impl) () = struct
         Impl.VDI.list_changed_blocks () ~dbg ~sr ~vdi_from ~vdi_to
     ) ;
     S.get_by_name (fun dbg name -> Impl.get_by_name () ~dbg ~name) ;
-    S.DATA.copy (fun dbg sr vdi url dest verify_dest ->
-        Impl.DATA.copy () ~dbg ~sr ~vdi ~url ~dest ~verify_dest
+    S.DATA.copy (fun dbg sr vdi vm url dest verify_dest ->
+        Impl.DATA.copy () ~dbg ~sr ~vdi ~vm ~url ~dest ~verify_dest
     ) ;
-    S.DATA.MIRROR.start (fun dbg sr vdi dp url dest verify_dest ->
-        Impl.DATA.MIRROR.start () ~dbg ~sr ~vdi ~dp ~url ~dest ~verify_dest
+    S.DATA.MIRROR.start
+      (fun dbg sr vdi dp mirror_vm copy_vm url dest verify_dest ->
+        Impl.DATA.MIRROR.start () ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url
+          ~dest ~verify_dest
     ) ;
     S.DATA.MIRROR.stop (fun dbg id -> Impl.DATA.MIRROR.stop () ~dbg ~id) ;
     S.DATA.MIRROR.stat (fun dbg id -> Impl.DATA.MIRROR.stat () ~dbg ~id) ;
     S.DATA.MIRROR.receive_start (fun dbg sr vdi_info id similar ->
         Impl.DATA.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id ~similar
+    ) ;
+    S.DATA.MIRROR.receive_start2 (fun dbg sr vdi_info id similar vm ->
+        Impl.DATA.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~id ~similar ~vm
     ) ;
     S.DATA.MIRROR.receive_cancel (fun dbg id ->
         Impl.DATA.MIRROR.receive_cancel () ~dbg ~id

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -39,7 +39,7 @@ module DP = struct
 
   let destroy2 ctx ~dbg ~dp ~sr ~vdi ~vm ~allow_leak = u "DP.destroy2"
 
-  let attach_info ctx ~dbg ~sr ~vdi ~dp = u "DP.attach_info"
+  let attach_info ctx ~dbg ~sr ~vdi ~dp ~vm = u "DP.attach_info"
 
   let diagnostics ctx () = u "DP.diagnostics"
 

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -172,6 +172,8 @@ module DATA = struct
 
     let receive_finalize ctx ~dbg ~id = u "DATA.MIRROR.receive_finalize"
 
+    let receive_finalize2 ctx ~dbg ~id = u "DATA.MIRROR.receive_finalize2"
+
     let receive_cancel ctx ~dbg ~id = u "DATA.MIRROR.receive_cancel"
 
     let list ctx ~dbg = u "DATA.MIRROR.list"

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -180,6 +180,9 @@ module DATA = struct
 
     let import_activate ctx ~dbg ~dp ~sr ~vdi ~vm =
       u "DATA.MIRROR.import_activate"
+
+    let get_nbd_server ctx ~dbg ~dp ~sr ~vdi ~vm =
+      u "DATA.MIRROR.get_nbd_server"
   end
 end
 

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -152,12 +152,13 @@ end
 let get_by_name ctx ~dbg ~name = u "get_by_name"
 
 module DATA = struct
-  let copy ctx ~dbg ~sr ~vdi ~url ~dest = u "DATA.copy"
+  let copy ctx ~dbg ~sr ~vdi ~vm ~url ~dest = u "DATA.copy"
 
   module MIRROR = struct
     (** [start task sr vdi url sr2] creates a VDI in remote [url]'s [sr2] and
         writes data synchronously. It returns the id of the VDI.*)
-    let start ctx ~dbg ~sr ~vdi ~dp ~url ~dest = u "DATA.MIRROR.start"
+    let start ctx ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url ~dest =
+      u "DATA.MIRROR.start"
 
     let stop ctx ~dbg ~id = u "DATA.MIRROR.stop"
 
@@ -165,6 +166,9 @@ module DATA = struct
 
     let receive_start ctx ~dbg ~sr ~vdi_info ~id ~similar =
       u "DATA.MIRROR.receive_start"
+
+    let receive_start2 ctx ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+      u "DATA.MIRROR.receive_start2"
 
     let receive_finalize ctx ~dbg ~id = u "DATA.MIRROR.receive_finalize"
 

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -171,6 +171,9 @@ module DATA = struct
     let receive_cancel ctx ~dbg ~id = u "DATA.MIRROR.receive_cancel"
 
     let list ctx ~dbg = u "DATA.MIRROR.list"
+
+    let import_activate ctx ~dbg ~dp ~sr ~vdi ~vm =
+      u "DATA.MIRROR.import_activate"
   end
 end
 

--- a/ocaml/xapi-storage-cli/main.ml
+++ b/ocaml/xapi-storage-cli/main.ml
@@ -311,6 +311,10 @@ let on_vdi' f common_opts sr vdi =
     )
     common_opts sr vdi
 
+let mirror_vm = Vm.of_string "SXM_mirror"
+
+let copy_vm = Vm.of_string "SXM_copy"
+
 let mirror_start common_opts sr vdi dp url dest verify_dest =
   on_vdi'
     (fun sr vdi ->
@@ -319,7 +323,7 @@ let mirror_start common_opts sr vdi dp url dest verify_dest =
       let url = get_opt url "Need a URL" in
       let dest = get_opt dest "Need a destination SR" in
       let task =
-        Client.DATA.MIRROR.start dbg sr vdi dp url
+        Client.DATA.MIRROR.start dbg sr vdi dp mirror_vm copy_vm url
           (Storage_interface.Sr.of_string dest)
           verify_dest
       in

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1823,6 +1823,7 @@ let bind ~volume_script_dir =
   S.get_by_name (u "get_by_name") ;
   S.VDI.get_by_name (u "VDI.get_by_name") ;
   S.DATA.MIRROR.receive_start (u "DATA.MIRROR.receive_start") ;
+  S.DATA.MIRROR.receive_start2 (u "DATA.MIRROR.receive_start2") ;
   S.UPDATES.get (u "UPDATES.get") ;
   S.SR.update_snapshot_info_dest (u "SR.update_snapshot_info_dest") ;
   S.DATA.MIRROR.list (u "DATA.MIRROR.list") ;

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1840,6 +1840,7 @@ let bind ~volume_script_dir =
   S.DATA.copy (u "DATA.copy") ;
   S.DP.stat_vdi (u "DP.stat_vdi") ;
   S.DATA.MIRROR.receive_finalize (u "DATA.MIRROR.receive_finalize") ;
+  S.DATA.MIRROR.receive_finalize2 (u "DATA.MIRROR.receive_finalize2") ;
   S.DP.create (u "DP.create") ;
   S.TASK.cancel (u "TASK.cancel") ;
   S.VDI.attach (u "VDI.attach") ;

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -356,6 +356,10 @@ let _clone_on_boot_key = "clone-on-boot"
 
 let _vdi_type_key = "vdi-type"
 
+let _vdi_content_id_key = "content_id"
+
+let _sm_config_prefix_key = "_sm_config_"
+
 let _snapshot_time_key = "snapshot_time"
 
 let _is_a_snapshot_key = "is_a_snapshot"
@@ -749,7 +753,7 @@ let vdi_of_volume x =
   {
     vdi= Vdi.of_string x.Xapi_storage.Control.key
   ; uuid= x.Xapi_storage.Control.uuid
-  ; content_id= ""
+  ; content_id= find_string _vdi_content_id_key ~default:""
   ; name_label= x.Xapi_storage.Control.name
   ; name_description= x.Xapi_storage.Control.description
   ; ty= find_string _vdi_type_key ~default:""
@@ -762,7 +766,24 @@ let vdi_of_volume x =
   ; cbt_enabled= Option.value x.Xapi_storage.Control.cbt_enabled ~default:false
   ; virtual_size= x.Xapi_storage.Control.virtual_size
   ; physical_utilisation= x.Xapi_storage.Control.physical_utilisation
-  ; sm_config= []
+  ; (* All the sm_config stored is of the form (k, v) where k will be prefixed by
+       "_sm_config_". For example if the sm_config passed was ("base_mirror", 3),
+       then it will be stored as ()"_sm_config_base_mirror", mirror_id). The
+       code below removed this prefix and extracts the actual key. *)
+    sm_config=
+      List.filter_map
+        (fun (k, v) ->
+          if String.starts_with ~prefix:_sm_config_prefix_key k then
+            Some
+              ( String.sub k
+                  (String.length _sm_config_prefix_key)
+                  (String.length k - String.length _sm_config_prefix_key)
+              , v
+              )
+          else
+            None
+        )
+        x.Xapi_storage.Control.keys
   ; sharable= x.Xapi_storage.Control.sharable
   ; persistent= true
   }
@@ -1479,6 +1500,10 @@ let bind ~volume_script_dir =
     |> wrap
   in
   S.VDI.attach3 vdi_attach3_impl ;
+  let dp_attach_info_impl dbg sr vdi dp vm =
+    vdi_attach3_impl dbg dp sr vdi vm ()
+  in
+  S.DP.attach_info dp_attach_info_impl ;
   let vdi_activate_common dbg dp sr vdi' vm' readonly =
     (let vdi = Storage_interface.Vdi.string_of vdi' in
      let domain = domain_of ~dp ~vm' in
@@ -1732,27 +1757,60 @@ let bind ~volume_script_dir =
     set ~dbg ~sr ~vdi ~key:_vdi_type_key ~value:"cbt_metadata"
   in
   S.VDI.data_destroy vdi_data_destroy_impl ;
+  let vdi_compose_impl dbg sr parent child =
+    wrap
+    @@
+    let* sr = Attached_SRs.find sr in
+    let child = Storage_interface.Vdi.string_of child in
+    let parent = Storage_interface.Vdi.string_of parent in
+    return_volume_rpc (fun () ->
+        Volume_client.compose (volume_rpc ~dbg) dbg sr child parent
+    )
+  in
+  S.VDI.compose vdi_compose_impl ;
+  let vdi_set_content_id_impl dbg sr vdi content_id =
+    wrap
+    @@
+    let* sr = Attached_SRs.find sr in
+    let vdi = Storage_interface.Vdi.string_of vdi in
+    let* () = set ~dbg ~sr ~vdi ~key:_vdi_content_id_key ~value:content_id in
+    return ()
+  in
+  S.VDI.set_content_id vdi_set_content_id_impl ;
+  let vdi_add_to_sm_config_impl dbg sr vdi key value =
+    wrap
+    @@
+    let* sr = Attached_SRs.find sr in
+    let vdi = Storage_interface.Vdi.string_of vdi in
+    let* () = set ~dbg ~sr ~vdi ~key:(_sm_config_prefix_key ^ key) ~value in
+    return ()
+  in
+  S.VDI.add_to_sm_config vdi_add_to_sm_config_impl ;
+  let vdi_remove_from_sm_config_impl dbg sr vdi key =
+    wrap
+    @@
+    let* sr = Attached_SRs.find sr in
+    let vdi = Storage_interface.Vdi.string_of vdi in
+    let* () = unset ~dbg ~sr ~vdi ~key:(_sm_config_prefix_key ^ key) in
+    return ()
+  in
+  S.VDI.remove_from_sm_config vdi_remove_from_sm_config_impl ;
   let u name _ = failwith ("Unimplemented: " ^ name) in
   S.get_by_name (u "get_by_name") ;
-  S.VDI.compose (u "VDI.compose") ;
   S.VDI.get_by_name (u "VDI.get_by_name") ;
   S.DATA.MIRROR.receive_start (u "DATA.MIRROR.receive_start") ;
   S.UPDATES.get (u "UPDATES.get") ;
   S.SR.update_snapshot_info_dest (u "SR.update_snapshot_info_dest") ;
   S.DATA.MIRROR.list (u "DATA.MIRROR.list") ;
   S.TASK.stat (u "TASK.stat") ;
-  S.VDI.remove_from_sm_config (u "VDI.remove_from_sm_config") ;
   S.DP.diagnostics (u "DP.diagnostics") ;
   S.TASK.destroy (u "TASK.destroy") ;
   S.DP.destroy (u "DP.destroy") ;
-  S.VDI.add_to_sm_config (u "VDI.add_to_sm_config") ;
   S.VDI.similar_content (u "VDI.similar_content") ;
   S.DATA.copy (u "DATA.copy") ;
   S.DP.stat_vdi (u "DP.stat_vdi") ;
   S.DATA.MIRROR.receive_finalize (u "DATA.MIRROR.receive_finalize") ;
   S.DP.create (u "DP.create") ;
-  S.VDI.set_content_id (u "VDI.set_content_id") ;
-  S.DP.attach_info (u "DP.attach_info") ;
   S.TASK.cancel (u "TASK.cancel") ;
   S.VDI.attach (u "VDI.attach") ;
   S.VDI.attach2 (u "VDI.attach2") ;

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -159,6 +159,7 @@
     uri
     uuid
     uuidm
+    vhd_lib
     x509
     xapi_aux
     xapi-backtrace

--- a/ocaml/xapi/sm.ml
+++ b/ocaml/xapi/sm.ml
@@ -117,7 +117,7 @@ let sr_detach ~dbg dconf driver sr =
 let sr_probe ~dbg dconf driver sr_sm_config =
   with_dbg ~dbg ~name:"sr_probe" @@ fun di ->
   let dbg = Debug_info.to_string di in
-  if List.mem_assoc Sr_probe (features_of_driver driver) then
+  if Feature.(has_capability Sr_probe (features_of_driver driver)) then
     Locking_helpers.Named_mutex.execute serialize_attach_detach (fun () ->
         debug "sr_probe" driver
           (sprintf "sm_config=[%s]"

--- a/ocaml/xapi/sm_exec.ml
+++ b/ocaml/xapi/sm_exec.ml
@@ -551,8 +551,8 @@ let parse_sr_get_driver_info driver (xml : Xml.xml) =
   let strings =
     XMLRPC.From.array XMLRPC.From.string (safe_assoc "capabilities" info)
   in
-  let features = Smint.parse_capability_int64_features strings in
-  let text_features = List.map Smint.string_of_feature features in
+  let features = Smint.Feature.parse_capability_int64 strings in
+  let text_features = List.map Smint.Feature.to_string features in
   (* Parse the driver options *)
   let configuration =
     List.map

--- a/ocaml/xapi/smint.ml
+++ b/ocaml/xapi/smint.ml
@@ -54,6 +54,7 @@ module Feature = struct
     | Vdi_attach_offline
     | Vdi_reset_on_boot
     | Vdi_configure_cbt
+    | Vdi_compose
     | Large_vdi  (** Supports >2TB VDIs *)
     | Thin_provisioning
     | Vdi_read_caching
@@ -92,6 +93,7 @@ module Feature = struct
     ; ("VDI_ATTACH_OFFLINE", Vdi_attach_offline)
     ; ("VDI_RESET_ON_BOOT", Vdi_reset_on_boot)
     ; ("VDI_CONFIG_CBT", Vdi_configure_cbt)
+    ; ("VDI_COMPOSE", Vdi_compose)
     ; ("LARGE_VDI", Large_vdi)
     ; ("THIN_PROVISIONING", Thin_provisioning)
     ; ("VDI_READ_CACHING", Vdi_read_caching)

--- a/ocaml/xapi/smint.ml
+++ b/ocaml/xapi/smint.ml
@@ -21,99 +21,96 @@ open D
 
 type vdi_info = {vdi_info_uuid: string option; vdi_info_location: string}
 
-(** Very primitive first attempt at a set of backend features *)
-type capability =
-  | Sr_create
-  | Sr_delete
-  | Sr_attach
-  | Sr_detach
-  | Sr_scan
-  | Sr_probe
-  | Sr_update
-  | Sr_supports_local_caching
-  | Sr_stats
-  | Sr_metadata
-  | Sr_trim
-  | Sr_multipath
-  | Vdi_create
-  | Vdi_delete
-  | Vdi_attach
-  | Vdi_detach
-  | Vdi_mirror
-  | Vdi_clone
-  | Vdi_snapshot
-  | Vdi_resize
-  | Vdi_activate
-  | Vdi_activate_readonly
-  | Vdi_deactivate
-  | Vdi_update
-  | Vdi_introduce
-  | Vdi_resize_online
-  | Vdi_generate_config
-  | Vdi_attach_offline
-  | Vdi_reset_on_boot
-  | Vdi_configure_cbt
-  | Large_vdi  (** Supports >2TB VDIs *)
-  | Thin_provisioning
-  | Vdi_read_caching
+module Feature = struct
+  (** Very primitive first attempt at a set of backend features *)
+  type capability =
+    | Sr_create
+    | Sr_delete
+    | Sr_attach
+    | Sr_detach
+    | Sr_scan
+    | Sr_probe
+    | Sr_update
+    | Sr_supports_local_caching
+    | Sr_stats
+    | Sr_metadata
+    | Sr_trim
+    | Sr_multipath
+    | Vdi_create
+    | Vdi_delete
+    | Vdi_attach
+    | Vdi_detach
+    | Vdi_mirror
+    | Vdi_clone
+    | Vdi_snapshot
+    | Vdi_resize
+    | Vdi_activate
+    | Vdi_activate_readonly
+    | Vdi_deactivate
+    | Vdi_update
+    | Vdi_introduce
+    | Vdi_resize_online
+    | Vdi_generate_config
+    | Vdi_attach_offline
+    | Vdi_reset_on_boot
+    | Vdi_configure_cbt
+    | Large_vdi  (** Supports >2TB VDIs *)
+    | Thin_provisioning
+    | Vdi_read_caching
 
-type feature = capability * int64
+  type t = capability * int64
 
-let string_to_capability_table =
-  [
-    ("SR_CREATE", Sr_create)
-  ; ("SR_DELETE", Sr_delete)
-  ; ("SR_ATTACH", Sr_attach)
-  ; ("SR_DETACH", Sr_detach)
-  ; ("SR_SCAN", Sr_scan)
-  ; ("SR_PROBE", Sr_probe)
-  ; ("SR_UPDATE", Sr_update)
-  ; ("SR_SUPPORTS_LOCAL_CACHING", Sr_supports_local_caching)
-  ; ("SR_METADATA", Sr_metadata)
-  ; ("SR_TRIM", Sr_trim)
-  ; ("SR_MULTIPATH", Sr_multipath)
-  ; ("SR_STATS", Sr_stats)
-  ; ("VDI_CREATE", Vdi_create)
-  ; ("VDI_DELETE", Vdi_delete)
-  ; ("VDI_ATTACH", Vdi_attach)
-  ; ("VDI_DETACH", Vdi_detach)
-  ; ("VDI_MIRROR", Vdi_mirror)
-  ; ("VDI_RESIZE", Vdi_resize)
-  ; ("VDI_RESIZE_ONLINE", Vdi_resize_online)
-  ; ("VDI_CLONE", Vdi_clone)
-  ; ("VDI_SNAPSHOT", Vdi_snapshot)
-  ; ("VDI_ACTIVATE", Vdi_activate)
-  ; ("VDI_ACTIVATE_READONLY", Vdi_activate_readonly)
-  ; ("VDI_DEACTIVATE", Vdi_deactivate)
-  ; ("VDI_UPDATE", Vdi_update)
-  ; ("VDI_INTRODUCE", Vdi_introduce)
-  ; ("VDI_GENERATE_CONFIG", Vdi_generate_config)
-  ; ("VDI_ATTACH_OFFLINE", Vdi_attach_offline)
-  ; ("VDI_RESET_ON_BOOT", Vdi_reset_on_boot)
-  ; ("VDI_CONFIG_CBT", Vdi_configure_cbt)
-  ; ("LARGE_VDI", Large_vdi)
-  ; ("THIN_PROVISIONING", Thin_provisioning)
-  ; ("VDI_READ_CACHING", Vdi_read_caching)
-  ]
+  let string_to_capability_table =
+    [
+      ("SR_CREATE", Sr_create)
+    ; ("SR_DELETE", Sr_delete)
+    ; ("SR_ATTACH", Sr_attach)
+    ; ("SR_DETACH", Sr_detach)
+    ; ("SR_SCAN", Sr_scan)
+    ; ("SR_PROBE", Sr_probe)
+    ; ("SR_UPDATE", Sr_update)
+    ; ("SR_SUPPORTS_LOCAL_CACHING", Sr_supports_local_caching)
+    ; ("SR_METADATA", Sr_metadata)
+    ; ("SR_TRIM", Sr_trim)
+    ; ("SR_MULTIPATH", Sr_multipath)
+    ; ("SR_STATS", Sr_stats)
+    ; ("VDI_CREATE", Vdi_create)
+    ; ("VDI_DELETE", Vdi_delete)
+    ; ("VDI_ATTACH", Vdi_attach)
+    ; ("VDI_DETACH", Vdi_detach)
+    ; ("VDI_MIRROR", Vdi_mirror)
+    ; ("VDI_RESIZE", Vdi_resize)
+    ; ("VDI_RESIZE_ONLINE", Vdi_resize_online)
+    ; ("VDI_CLONE", Vdi_clone)
+    ; ("VDI_SNAPSHOT", Vdi_snapshot)
+    ; ("VDI_ACTIVATE", Vdi_activate)
+    ; ("VDI_ACTIVATE_READONLY", Vdi_activate_readonly)
+    ; ("VDI_DEACTIVATE", Vdi_deactivate)
+    ; ("VDI_UPDATE", Vdi_update)
+    ; ("VDI_INTRODUCE", Vdi_introduce)
+    ; ("VDI_GENERATE_CONFIG", Vdi_generate_config)
+    ; ("VDI_ATTACH_OFFLINE", Vdi_attach_offline)
+    ; ("VDI_RESET_ON_BOOT", Vdi_reset_on_boot)
+    ; ("VDI_CONFIG_CBT", Vdi_configure_cbt)
+    ; ("LARGE_VDI", Large_vdi)
+    ; ("THIN_PROVISIONING", Thin_provisioning)
+    ; ("VDI_READ_CACHING", Vdi_read_caching)
+    ]
 
-let capability_to_string_table =
-  List.map (fun (k, v) -> (v, k)) string_to_capability_table
+  let capability_to_string_table =
+    List.map (fun (k, v) -> (v, k)) string_to_capability_table
 
-let string_of_capability c = List.assoc c capability_to_string_table
+  let known_features = List.map fst string_to_capability_table
 
-let string_of_feature (c, v) =
-  Printf.sprintf "%s/%Ld" (string_of_capability c) v
+  let capability_to_string c = List.assoc c capability_to_string_table
 
-let has_capability (c : capability) fl = List.mem_assoc c fl
+  let to_string (c, v) = Printf.sprintf "%s/%Ld" (capability_to_string c) v
 
-let capability_of_feature : feature -> capability = fst
+  let capability_of : t -> capability = fst
 
-let known_features = List.map fst string_to_capability_table
+  let unparse (f, v) = f ^ "/" ^ Int64.to_string v
 
-let unparse_feature (f, v) = f ^ "/" ^ Int64.to_string v
-
-let parse_string_int64_features features =
-  let scan feature =
+  let string_int64_of_string_opt feature =
     match String.split_on_char '/' feature with
     | [] ->
         None
@@ -131,30 +128,46 @@ let parse_string_int64_features features =
     | feature :: _ ->
         error "SM.feature: unknown feature %s" feature ;
         None
-  in
-  features
-  |> List.filter_map scan
-  |> List.sort_uniq (fun (x, _) (y, _) -> compare x y)
 
-(** [compat_features features1 features2] finds the compatible features in the input
-features lists. We assume features backwards compatible, i.e. if there are FOO/1 and
+  (** [compat_features features1 features2] finds the compatible features in the input
+  features lists. We assume features backwards compatible, i.e. if there are FOO/1 and
   FOO/2 are present, then we assume they can both do FOO/1*)
-let compat_features features1 features2 =
-  let features2 = List.to_seq features2 |> Hashtbl.of_seq in
-  List.filter_map
-    (fun (f1, v1) ->
-      match Hashtbl.find_opt features2 f1 with
-      | Some v2 ->
-          Some (f1, Int64.min v1 v2)
-      | None ->
-          None
-    )
-    features1
+  let compat_features features1 features2 =
+    let features2 = List.to_seq features2 |> Hashtbl.of_seq in
+    List.filter_map
+      (fun (f1, v1) ->
+        match Hashtbl.find_opt features2 f1 with
+        | Some v2 ->
+            Some (f1, Int64.min v1 v2)
+        | None ->
+            None
+      )
+      features1
 
-let parse_capability_int64_features strings =
-  List.map
-    (function c, v -> (List.assoc c string_to_capability_table, v))
-    (parse_string_int64_features strings)
+  let of_string_int64_opt (c, v) =
+    List.assoc_opt c string_to_capability_table |> Option.map (fun c -> (c, v))
+
+  (** [has_capability c fl] will test weather the required capability [c] is present 
+  in the feature list [fl]. Callers should use this function to test if a feature
+    is available rather than directly using membership functions on a feature list
+    as this function might have special logic for some features. *)
+  let has_capability (c : capability) fl = List.mem_assoc c fl
+
+  (** [parse_string_int64 features] takes a [features] list in its plain string
+  forms such as "VDI_MIRROR/2" and parses them into the form of (VDI_MIRROR, 2).
+  If the number is malformated, default to (VDI_MIRROR, 1). It will also deduplicate
+  based on the capability ONLY, and randomly choose a verion, based on the order
+  it appears in the input list.
+  *)
+  let parse_string_int64 features =
+    List.filter_map string_int64_of_string_opt features
+    |> List.sort_uniq (fun (x, _) (y, _) -> compare x y)
+
+  (** [parse_capability_int64 features] is similar to [parse_string_int64_features features]
+  but parses the input list into a [t list] *)
+  let parse_capability_int64 features =
+    parse_string_int64 features |> List.filter_map of_string_int64_opt
+end
 
 type sr_driver_info = {
     sr_driver_filename: string
@@ -164,7 +177,7 @@ type sr_driver_info = {
   ; sr_driver_copyright: string
   ; sr_driver_version: string
   ; sr_driver_required_api_version: string
-  ; sr_driver_features: feature list
+  ; sr_driver_features: Feature.t list
   ; sr_driver_text_features: string list
   ; sr_driver_configuration: (string * string) list
   ; sr_driver_required_cluster_stack: string list

--- a/ocaml/xapi/smint.ml
+++ b/ocaml/xapi/smint.ml
@@ -41,6 +41,7 @@ module Feature = struct
     | Vdi_attach
     | Vdi_detach
     | Vdi_mirror
+    | Vdi_mirror_in
     | Vdi_clone
     | Vdi_snapshot
     | Vdi_resize
@@ -80,6 +81,7 @@ module Feature = struct
     ; ("VDI_ATTACH", Vdi_attach)
     ; ("VDI_DETACH", Vdi_detach)
     ; ("VDI_MIRROR", Vdi_mirror)
+    ; ("VDI_MIRROR_IN", Vdi_mirror_in)
     ; ("VDI_RESIZE", Vdi_resize)
     ; ("VDI_RESIZE_ONLINE", Vdi_resize_online)
     ; ("VDI_CLONE", Vdi_clone)
@@ -151,9 +153,14 @@ module Feature = struct
 
   (** [has_capability c fl] will test weather the required capability [c] is present 
   in the feature list [fl]. Callers should use this function to test if a feature
-    is available rather than directly using membership functions on a feature list
-    as this function might have special logic for some features. *)
-  let has_capability (c : capability) fl = List.mem_assoc c fl
+  is available rather than directly using membership functions on a feature list
+  as this function might have special logic for some features. *)
+  let has_capability (c : capability) (fl : t list) =
+    List.exists
+      (fun (c', _v) ->
+        match (c, c') with Vdi_mirror_in, Vdi_mirror -> true | c, c' -> c = c'
+      )
+      fl
 
   (** [parse_string_int64 features] takes a [features] list in its plain string
   forms such as "VDI_MIRROR/2" and parses them into the form of (VDI_MIRROR, 2).

--- a/ocaml/xapi/storage_access.mli
+++ b/ocaml/xapi/storage_access.mli
@@ -61,9 +61,6 @@ val reset : __context:Context.t -> vm:API.ref_VM -> unit
 (** [reset __context vm] declares that [vm] has reset and if it's a driver
     domain, we expect it to lose all state. *)
 
-val transform_storage_exn : (unit -> 'a) -> 'a
-(** [transform_storage_exn f] runs [f], rethrowing any storage error as a nice XenAPI error *)
-
 val attach_and_activate :
      __context:Context.t
   -> vbd:API.ref_VBD

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -790,7 +790,7 @@ module MigrateLocal = struct
       let verify_cert = if verify_dest then Stunnel_client.pool () else None in
       let transport = Xmlrpc_client.transport_of_url ~verify_cert dest_url in
       debug "Searching for data path: %s" dp ;
-      let attach_info = Local.DP.attach_info "nbd" sr vdi dp in
+      let attach_info = Local.DP.attach_info dbg sr vdi dp (Vm.of_string "0") in
       on_fail :=
         (fun () -> Remote.DATA.MIRROR.receive_cancel dbg mirror_id) :: !on_fail ;
       let tapdev =
@@ -1318,7 +1318,7 @@ let post_detach_hook ~sr ~vdi ~dp:_ =
 let nbd_handler req s sr vdi dp =
   debug "sr=%s vdi=%s dp=%s" sr vdi dp ;
   let sr, vdi = Storage_interface.(Sr.of_string sr, Vdi.of_string vdi) in
-  let attach_info = Local.DP.attach_info "nbd" sr vdi dp in
+  let attach_info = Local.DP.attach_info "nbd" sr vdi dp (Vm.of_string "0") in
   req.Http.Request.close <- true ;
   match tapdisk_of_attach_info attach_info with
   | Some tapdev ->

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -862,6 +862,17 @@ module Mux = struct
       let receive_cancel () ~dbg =
         with_dbg ~name:"DATA.MIRROR.receive_cancel" ~dbg @@ fun {log= dbg; _} ->
         Storage_migrate.receive_cancel ~dbg
+
+      let import_activate () ~dbg ~dp ~sr ~vdi ~vm =
+        with_dbg ~name:"DATA.MIRROR.import_activate" ~dbg @@ fun di ->
+        info "%s dbg:%s dp:%s sr:%s vdi:%s vm:%s" __FUNCTION__ dbg dp
+          (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) ;
+        let module C = StorageAPI (Idl.Exn.GenClient (struct
+          let rpc = of_sr sr
+        end)) in
+        C.DATA.MIRROR.import_activate (Debug_info.to_string di) dp sr vdi vm
+
+
     end
   end
 

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -253,7 +253,14 @@ module Mux = struct
 
     let diagnostics () = Storage_smapiv1_wrapper.Impl.DP.diagnostics ()
 
-    let attach_info () = Storage_smapiv1_wrapper.Impl.DP.attach_info ()
+    let attach_info _context ~dbg ~sr ~vdi ~dp ~vm =
+      with_dbg ~name:"DP.attach_info" ~dbg @@ fun di ->
+      info "%s dbg:%s sr:%s vdi:%s dp:%s vm:%s" __FUNCTION__ dbg (s_of_sr sr)
+        (s_of_vdi vdi) dp (s_of_vm vm) ;
+      let module C = StorageAPI (Idl.Exn.GenClient (struct
+        let rpc = of_sr sr
+      end)) in
+      C.DP.attach_info (Debug_info.to_string di) sr vdi dp vm
 
     let stat_vdi () = Storage_smapiv1_wrapper.Impl.DP.stat_vdi ()
   end

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -855,6 +855,10 @@ module Mux = struct
         with_dbg ~name:"DATA.MIRROR.receive_start" ~dbg @@ fun {log= dbg; _} ->
         Storage_migrate.receive_start ~dbg
 
+      let receive_start2 () ~dbg =
+        with_dbg ~name:"DATA.MIRROR.receive_start2" ~dbg @@ fun {log= dbg; _} ->
+        Storage_migrate.receive_start2 ~dbg
+
       let receive_finalize () ~dbg =
         with_dbg ~name:"DATA.MIRROR.receive_finalize" ~dbg
         @@ fun {log= dbg; _} -> Storage_migrate.receive_finalize ~dbg

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -880,7 +880,14 @@ module Mux = struct
         end)) in
         C.DATA.MIRROR.import_activate (Debug_info.to_string di) dp sr vdi vm
 
-
+      let get_nbd_server () ~dbg ~dp ~sr ~vdi ~vm =
+        with_dbg ~name:"DATA.MIRROR.get_nbd_server" ~dbg @@ fun di ->
+        info "%s dbg:%s dp:%s sr:%s vdi:%s vm:%s" __FUNCTION__ dbg dp
+          (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) ;
+        let module C = StorageAPI (Idl.Exn.GenClient (struct
+          let rpc = of_sr sr
+        end)) in
+        C.DATA.MIRROR.get_nbd_server (Debug_info.to_string di) dp sr vdi vm
     end
   end
 

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -863,6 +863,10 @@ module Mux = struct
         with_dbg ~name:"DATA.MIRROR.receive_finalize" ~dbg
         @@ fun {log= dbg; _} -> Storage_migrate.receive_finalize ~dbg
 
+      let receive_finalize2 () ~dbg =
+        with_dbg ~name:"DATA.MIRROR.receive_finalize2" ~dbg
+        @@ fun {log= dbg; _} -> Storage_migrate.receive_finalize2 ~dbg
+
       let receive_cancel () ~dbg =
         with_dbg ~name:"DATA.MIRROR.receive_cancel" ~dbg @@ fun {log= dbg; _} ->
         Storage_migrate.receive_cancel ~dbg

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -37,7 +37,7 @@ type plugin = {
     processor: processor
   ; backend_domain: string
   ; query_result: query_result
-  ; features: Smint.feature list
+  ; features: Smint.Feature.t list
 }
 
 let plugins : (sr, plugin) Hashtbl.t = Hashtbl.create 10
@@ -53,7 +53,7 @@ let debug_printer rpc call =
 let register sr rpc d info =
   with_lock m (fun () ->
       let features =
-        Smint.parse_capability_int64_features info.Storage_interface.features
+        Smint.Feature.parse_capability_int64 info.Storage_interface.features
       in
       Hashtbl.replace plugins sr
         {
@@ -88,7 +88,7 @@ let sr_has_capability sr capability =
   with_lock m (fun () ->
       match Hashtbl.find_opt plugins sr with
       | Some x ->
-          Smint.has_capability capability x.features
+          Smint.Feature.has_capability capability x.features
       | None ->
           false
   )
@@ -648,7 +648,9 @@ module Mux = struct
         | None ->
             failwith "DP not found"
       in
-      if (not read_write) && sr_has_capability sr Smint.Vdi_activate_readonly
+      if
+        (not read_write)
+        && sr_has_capability sr Smint.Feature.Vdi_activate_readonly
       then (
         info "The VDI was attached read-only: calling activate_readonly" ;
         C.VDI.activate_readonly (Debug_info.to_string di) dp sr vdi vm

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -835,41 +835,67 @@ module Mux = struct
       with_dbg ~name:"DATA.copy" ~dbg @@ fun dbg -> Storage_migrate.copy ~dbg
 
     module MIRROR = struct
-      let start () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.start" ~dbg @@ fun dbg ->
-        Storage_migrate.start ~dbg
+      let start () ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url ~dest ~verify_dest
+          =
+        with_dbg ~name:"DATA.MIRROR.start" ~dbg @@ fun di ->
+        info
+          "%s dbg:%s sr: %s vdi: %s dp:%s mirror_vm: %s copy_vm: %s url: %s \
+           dest sr: %s verify_dest: %B"
+          __FUNCTION__ dbg (s_of_sr sr) (s_of_vdi vdi) dp (s_of_vm mirror_vm)
+          (s_of_vm copy_vm) url (s_of_sr dest) verify_dest ;
+        Storage_migrate.start ~dbg:di ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url
+          ~dest ~verify_dest
 
-      let stop () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.stop" ~dbg @@ fun {log= dbg; _} ->
-        Storage_migrate.stop ~dbg
+      let stop () ~dbg ~id =
+        with_dbg ~name:"DATA.MIRROR.stop" ~dbg @@ fun di ->
+        info "%s dbg:%s mirror_id: %s" __FUNCTION__ dbg id ;
+        Storage_migrate.stop ~dbg:di.log ~id
 
       let list () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.list" ~dbg @@ fun {log= dbg; _} ->
-        Storage_migrate.list ~dbg
+        with_dbg ~name:"DATA.MIRROR.list" ~dbg @@ fun di ->
+        info "%s dbg: %s" __FUNCTION__ dbg ;
+        Storage_migrate.list ~dbg:di.log
 
-      let stat () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.stat" ~dbg @@ fun {log= dbg; _} ->
-        Storage_migrate.stat ~dbg
+      let stat () ~dbg ~id =
+        with_dbg ~name:"DATA.MIRROR.stat" ~dbg @@ fun di ->
+        info "%s dbg: %s mirror_id: %s" __FUNCTION__ di.log id ;
+        Storage_migrate.stat ~dbg:di.log ~id
 
-      let receive_start () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.receive_start" ~dbg @@ fun {log= dbg; _} ->
-        Storage_migrate.receive_start ~dbg
+      let receive_start () ~dbg ~sr ~vdi_info ~id ~similar =
+        with_dbg ~name:"DATA.MIRROR.receive_start" ~dbg @@ fun di ->
+        info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s"
+          __FUNCTION__ dbg (s_of_sr sr)
+          (string_of_vdi_info vdi_info)
+          id
+          (String.concat ";" similar) ;
+        Storage_migrate.receive_start ~dbg:di.log ~sr ~vdi_info ~id ~similar
 
-      let receive_start2 () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.receive_start2" ~dbg @@ fun {log= dbg; _} ->
-        Storage_migrate.receive_start2 ~dbg
+      let receive_start2 () ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+        with_dbg ~name:"DATA.MIRROR.receive_start2" ~dbg @@ fun di ->
+        info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s vm: %s"
+          __FUNCTION__ dbg (s_of_sr sr)
+          (string_of_vdi_info vdi_info)
+          id
+          (String.concat ";" similar)
+          (s_of_vm vm) ;
+        info "%s dbg:%s" __FUNCTION__ dbg ;
+        Storage_migrate.receive_start2 ~dbg:di.log ~sr ~vdi_info ~id ~similar
+          ~vm
 
-      let receive_finalize () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.receive_finalize" ~dbg
-        @@ fun {log= dbg; _} -> Storage_migrate.receive_finalize ~dbg
+      let receive_finalize () ~dbg ~id =
+        with_dbg ~name:"DATA.MIRROR.receive_finalize" ~dbg @@ fun di ->
+        info "%s dbg: %s mirror_id: %s" __FUNCTION__ dbg id ;
+        Storage_migrate.receive_finalize ~dbg:di.log ~id
 
-      let receive_finalize2 () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.receive_finalize2" ~dbg
-        @@ fun {log= dbg; _} -> Storage_migrate.receive_finalize2 ~dbg
+      let receive_finalize2 () ~dbg ~id =
+        with_dbg ~name:"DATA.MIRROR.receive_finalize2" ~dbg @@ fun di ->
+        info "%s dbg: %s mirror_id: %s" __FUNCTION__ dbg id ;
+        Storage_migrate.receive_finalize2 ~dbg:di.log ~id
 
-      let receive_cancel () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.receive_cancel" ~dbg @@ fun {log= dbg; _} ->
-        Storage_migrate.receive_cancel ~dbg
+      let receive_cancel () ~dbg ~id =
+        with_dbg ~name:"DATA.MIRROR.receive_cancel" ~dbg @@ fun di ->
+        info "%s dbg: %s mirror_id: %s" __FUNCTION__ dbg id ;
+        Storage_migrate.receive_cancel ~dbg:di.log ~id
 
       let import_activate () ~dbg ~dp ~sr ~vdi ~vm =
         with_dbg ~name:"DATA.MIRROR.import_activate" ~dbg @@ fun di ->

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1228,6 +1228,10 @@ module SMAPIv1 : Server_impl = struct
       let receive_finalize _context ~dbg:_ ~id:_ = assert false
 
       let receive_cancel _context ~dbg:_ ~id:_ = assert false
+
+      let import_activate _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ ~vm:_ =
+        assert false
+
     end
   end
 

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1231,6 +1231,8 @@ module SMAPIv1 : Server_impl = struct
 
       let receive_finalize _context ~dbg:_ ~id:_ = assert false
 
+      let receive_finalize2 _context ~dbg:_ ~id:_ = assert false
+
       let receive_cancel _context ~dbg:_ ~id:_ = assert false
 
       let import_activate _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ ~vm:_ =

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1208,12 +1208,12 @@ module SMAPIv1 : Server_impl = struct
   let get_by_name _context ~dbg:_ ~name:_ = assert false
 
   module DATA = struct
-    let copy _context ~dbg:_ ~sr:_ ~vdi:_ ~url:_ ~dest:_ ~verify_dest:_ =
+    let copy _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~url:_ ~dest:_ ~verify_dest:_ =
       assert false
 
     module MIRROR = struct
-      let start _context ~dbg:_ ~sr:_ ~vdi:_ ~dp:_ ~url:_ ~dest:_ ~verify_dest:_
-          =
+      let start _context ~dbg:_ ~sr:_ ~vdi:_ ~dp:_ ~mirror_vm:_ ~copy_vm:_
+          ~url:_ ~dest:_ ~verify_dest:_ =
         assert false
 
       let stop _context ~dbg:_ ~id:_ = assert false
@@ -1223,6 +1223,10 @@ module SMAPIv1 : Server_impl = struct
       let stat _context ~dbg:_ ~id:_ = assert false
 
       let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
+        assert false
+
+      let receive_start2 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_
+          ~vm:_ =
         assert false
 
       let receive_finalize _context ~dbg:_ ~id:_ = assert false

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -607,7 +607,10 @@ module SMAPIv1 : Server_impl = struct
                     ~key:"content_id"
             ) ;
             (* If the backend doesn't advertise the capability then do nothing *)
-            if List.mem_assoc Smint.Vdi_activate (Sm.features_of_driver _type)
+            if
+              Smint.Feature.(
+                has_capability Vdi_activate (Sm.features_of_driver _type)
+              )
             then
               Sm.vdi_activate ~dbg device_config _type sr self read_write
             else
@@ -638,7 +641,10 @@ module SMAPIv1 : Server_impl = struct
                     ~value:Uuidx.(to_string (make ()))
             ) ;
             (* If the backend doesn't advertise the capability then do nothing *)
-            if List.mem_assoc Smint.Vdi_deactivate (Sm.features_of_driver _type)
+            if
+              Smint.Feature.(
+                has_capability Vdi_deactivate (Sm.features_of_driver _type)
+              )
             then
               Sm.vdi_deactivate ~dbg device_config _type sr self
             else

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1238,6 +1238,7 @@ module SMAPIv1 : Server_impl = struct
       let import_activate _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ ~vm:_ =
         assert false
 
+      let get_nbd_server _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ ~vm:_ = assert false
     end
   end
 

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1229,6 +1229,9 @@ functor
 
         let import_activate context ~dbg ~dp ~sr ~vdi ~vm =
           get_nbd_server_common context ~dbg ~dp ~sr ~vdi ~vm ~style:`oldstyle
+
+        let get_nbd_server context ~dbg ~dp ~sr ~vdi ~vm =
+          get_nbd_server_common context ~dbg ~dp ~sr ~vdi ~vm ~style:`real
       end
     end
 

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1137,7 +1137,7 @@ functor
         in
         String.concat "" (List.map (fun x -> x ^ "\n") lines)
 
-      let attach_info _context ~dbg:_ ~sr ~vdi ~dp =
+      let attach_info _context ~dbg:_ ~sr ~vdi ~dp ~vm:_ =
         let srs = Host.list !Host.host in
         let sr_state = List.assoc sr srs in
         let vdi_state = Hashtbl.find sr_state.Sr.vdis vdi in

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1180,6 +1180,10 @@ functor
           info "DATA.MIRROR.receive_finalize dbg:%s id:%s" dbg id ;
           Impl.DATA.MIRROR.receive_finalize context ~dbg ~id
 
+        let receive_finalize2 context ~dbg ~id =
+          info "DATA.MIRROR.receive_finalize2 dbg:%s id:%s" dbg id ;
+          Impl.DATA.MIRROR.receive_finalize2 context ~dbg ~id
+
         let receive_cancel context ~dbg ~id =
           info "DATA.MIRROR.receive_cancel dbg:%s id:%s" dbg id ;
           Impl.DATA.MIRROR.receive_cancel context ~dbg ~id

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -932,46 +932,6 @@ functor
       let dbg = Debug_info.to_string di in
       Impl.get_by_name context ~dbg ~name
 
-    module DATA = struct
-      let copy context ~dbg ~sr ~vdi ~url ~dest =
-        info "DATA.copy dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg (s_of_sr sr)
-          (s_of_vdi vdi) url (s_of_sr dest) ;
-        Impl.DATA.copy context ~dbg ~sr ~vdi ~url ~dest
-
-      module MIRROR = struct
-        let start context ~dbg ~sr ~vdi ~dp ~url ~dest =
-          info "DATA.MIRROR.start dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg
-            (s_of_sr sr) (s_of_vdi vdi) url (s_of_sr dest) ;
-          Impl.DATA.MIRROR.start context ~dbg ~sr ~vdi ~dp ~url ~dest
-
-        let stop context ~dbg ~id =
-          info "DATA.MIRROR.stop dbg:%s id:%s" dbg id ;
-          Impl.DATA.MIRROR.stop context ~dbg ~id
-
-        let list context ~dbg =
-          info "DATA.MIRROR.active dbg:%s" dbg ;
-          Impl.DATA.MIRROR.list context ~dbg
-
-        let stat context ~dbg ~id =
-          info "DATA.MIRROR.stat dbg:%s id:%s" dbg id ;
-          Impl.DATA.MIRROR.stat context ~dbg ~id
-
-        let receive_start context ~dbg ~sr ~vdi_info ~id ~similar =
-          info "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s similar:[%s]" dbg
-            (s_of_sr sr) id
-            (String.concat "," similar) ;
-          Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id ~similar
-
-        let receive_finalize context ~dbg ~id =
-          info "DATA.MIRROR.receive_finalize dbg:%s id:%s" dbg id ;
-          Impl.DATA.MIRROR.receive_finalize context ~dbg ~id
-
-        let receive_cancel context ~dbg ~id =
-          info "DATA.MIRROR.receive_cancel dbg:%s id:%s" dbg id ;
-          Impl.DATA.MIRROR.receive_cancel context ~dbg ~id
-      end
-    end
-
     module DP = struct
       let create _context ~dbg:_ ~id = id
 
@@ -1174,6 +1134,88 @@ functor
                       (Vdi.dp vdi_t)
                 }
         )
+    end
+
+    module DATA = struct
+      let copy context ~dbg ~sr ~vdi ~url ~dest =
+        info "DATA.copy dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg (s_of_sr sr)
+          (s_of_vdi vdi) url (s_of_sr dest) ;
+        Impl.DATA.copy context ~dbg ~sr ~vdi ~url ~dest
+
+      module MIRROR = struct
+        let start context ~dbg ~sr ~vdi ~dp ~url ~dest =
+          info "DATA.MIRROR.start dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg
+            (s_of_sr sr) (s_of_vdi vdi) url (s_of_sr dest) ;
+          Impl.DATA.MIRROR.start context ~dbg ~sr ~vdi ~dp ~url ~dest
+
+        let stop context ~dbg ~id =
+          info "DATA.MIRROR.stop dbg:%s id:%s" dbg id ;
+          Impl.DATA.MIRROR.stop context ~dbg ~id
+
+        let list context ~dbg =
+          info "DATA.MIRROR.active dbg:%s" dbg ;
+          Impl.DATA.MIRROR.list context ~dbg
+
+        let stat context ~dbg ~id =
+          info "DATA.MIRROR.stat dbg:%s id:%s" dbg id ;
+          Impl.DATA.MIRROR.stat context ~dbg ~id
+
+        let receive_start context ~dbg ~sr ~vdi_info ~id ~similar =
+          info "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s similar:[%s]" dbg
+            (s_of_sr sr) id
+            (String.concat "," similar) ;
+          Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id ~similar
+
+        let receive_finalize context ~dbg ~id =
+          info "DATA.MIRROR.receive_finalize dbg:%s id:%s" dbg id ;
+          Impl.DATA.MIRROR.receive_finalize context ~dbg ~id
+
+        let receive_cancel context ~dbg ~id =
+          info "DATA.MIRROR.receive_cancel dbg:%s id:%s" dbg id ;
+          Impl.DATA.MIRROR.receive_cancel context ~dbg ~id
+
+        (* tapdisk supports three kind of nbd servers, the old style nbdserver,
+           the new style nbd server and a real nbd server. The old and new style nbd servers
+           are "special" nbd servers that accept fds passed via SCM_RIGHTS and handle
+           connection based on that fd. The real nbd server is a "normal" nbd server
+           that accepts nbd connections from nbd clients, and it does not support fd
+           passing. *)
+        let get_nbd_server_common context ~dbg ~dp ~sr ~vdi ~vm ~style =
+          info "%s DATA.MIRROR.get_nbd_server dbg:%s dp:%s sr:%s vdi:%s vm:%s"
+            __FUNCTION__ dbg dp (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) ;
+          let attach_info =
+            DP.attach_info context ~dbg:"nbd" ~sr ~vdi ~dp ~vm
+          in
+          match Storage_migrate.tapdisk_of_attach_info attach_info with
+          | Some tapdev ->
+              let minor = Tapctl.get_minor tapdev in
+              let pid = Tapctl.get_tapdisk_pid tapdev in
+              let path =
+                match style with
+                | `newstyle ->
+                    Printf.sprintf "/var/run/blktap-control/nbdserver-new%d.%d"
+                      pid minor
+                | `oldstyle ->
+                    Printf.sprintf "/var/run/blktap-control/nbdserver%d.%d" pid
+                      minor
+                | `real ->
+                    Printf.sprintf "/var/run/blktap-control/nbd%d.%d" pid minor
+              in
+              debug "%s nbd server path is %s" __FUNCTION__ path ;
+              path
+          | None ->
+              raise
+                (Storage_interface.Storage_error
+                   (Backend_error
+                      ( Api_errors.internal_error
+                      , ["No tapdisk attach info found"]
+                      )
+                   )
+                )
+
+        let import_activate context ~dbg ~dp ~sr ~vdi ~vm =
+          get_nbd_server_common context ~dbg ~dp ~sr ~vdi ~vm ~style:`oldstyle
+      end
     end
 
     module SR = struct

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1137,16 +1137,17 @@ functor
     end
 
     module DATA = struct
-      let copy context ~dbg ~sr ~vdi ~url ~dest =
+      let copy context ~dbg ~sr ~vdi ~vm ~url ~dest =
         info "DATA.copy dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg (s_of_sr sr)
           (s_of_vdi vdi) url (s_of_sr dest) ;
-        Impl.DATA.copy context ~dbg ~sr ~vdi ~url ~dest
+        Impl.DATA.copy context ~dbg ~sr ~vdi ~vm ~url ~dest
 
       module MIRROR = struct
-        let start context ~dbg ~sr ~vdi ~dp ~url ~dest =
+        let start context ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url ~dest =
           info "DATA.MIRROR.start dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg
             (s_of_sr sr) (s_of_vdi vdi) url (s_of_sr dest) ;
-          Impl.DATA.MIRROR.start context ~dbg ~sr ~vdi ~dp ~url ~dest
+          Impl.DATA.MIRROR.start context ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm
+            ~url ~dest
 
         let stop context ~dbg ~id =
           info "DATA.MIRROR.stop dbg:%s id:%s" dbg id ;
@@ -1165,6 +1166,15 @@ functor
             (s_of_sr sr) id
             (String.concat "," similar) ;
           Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id ~similar
+
+        let receive_start2 context ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+          info
+            "DATA.MIRROR.receive_start2 dbg:%s sr:%s id:%s similar:[%s] vm:%s"
+            dbg (s_of_sr sr) id
+            (String.concat "," similar)
+            (s_of_vm vm) ;
+          Impl.DATA.MIRROR.receive_start2 context ~dbg ~sr ~vdi_info ~id
+            ~similar ~vm
 
         let receive_finalize context ~dbg ~id =
           info "DATA.MIRROR.receive_finalize dbg:%s id:%s" dbg id ;

--- a/ocaml/xapi/storage_utils.mli
+++ b/ocaml/xapi/storage_utils.mli
@@ -1,0 +1,66 @@
+(* Copyright (C) Cloud Software Group Inc.
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+*)
+
+val string_of_vdi_type :
+     [< `cbt_metadata
+     | `crashdump
+     | `ephemeral
+     | `ha_statefile
+     | `metadata
+     | `pvs_cache
+     | `redo_log
+     | `rrd
+     | `suspend
+     | `system
+     | `user ]
+  -> string
+
+val vdi_type_of_string :
+     string
+  -> [> `cbt_metadata
+     | `crashdump
+     | `ephemeral
+     | `ha_statefile
+     | `metadata
+     | `pvs_cache
+     | `redo_log
+     | `rrd
+     | `suspend
+     | `system
+     | `user ]
+
+val redirectable_rpc :
+     redirect_to_ip:(ip:string -> Rpc.call -> Rpc.response)
+  -> original:(Rpc.call -> Rpc.response)
+  -> Rpc.call
+  -> Rpc.response
+
+type connection_args = {
+    url: Http.Url.t
+  ; pool_secret: SecretString.t option
+  ; verify_cert: Stunnel.verification_config option
+}
+
+val localhost_connection_args : unit -> connection_args
+
+val intra_pool_connection_args_of_ip : string -> connection_args
+
+val connection_args_of_uri : verify_dest:bool -> string -> connection_args
+
+val intra_pool_rpc_of_ip :
+  srcstr:string -> dststr:string -> ip:string -> Rpc.call -> Rpc.response
+
+val rpc :
+  srcstr:string -> dststr:string -> connection_args -> Rpc.call -> Rpc.response
+
+val transform_storage_exn : (unit -> 'a) -> 'a
+(** [transform_storage_exn f] runs [f], rethrowing any storage error as a nice XenAPI error *)

--- a/ocaml/xapi/xapi_dr_task.ml
+++ b/ocaml/xapi/xapi_dr_task.ml
@@ -101,7 +101,8 @@ let create ~__context ~_type ~device_config ~whitelist =
   (* Check if licence allows disaster recovery. *)
   Pool_features.assert_enabled ~__context ~f:Features.DR ;
   (* Check that the SR type supports metadata. *)
-  if not (List.mem_assoc Smint.Sr_metadata (Sm.features_of_driver _type)) then
+  if not Smint.Feature.(has_capability Sr_metadata (Sm.features_of_driver _type))
+  then
     raise
       (Api_errors.Server_error
          ( Api_errors.operation_not_allowed

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2232,7 +2232,7 @@ let enable_local_storage_caching ~__context ~host ~sr =
   let shared = Db.SR.get_shared ~__context ~self:sr in
   let has_required_capability =
     let caps = Sm.features_of_driver ty in
-    List.mem_assoc Smint.Sr_supports_local_caching caps
+    Smint.Feature.(has_capability Sr_supports_local_caching caps)
   in
   debug "shared: %b. List.length pbds: %d. has_required_capability: %b" shared
     (List.length pbds) has_required_capability ;

--- a/ocaml/xapi/xapi_pbd.ml
+++ b/ocaml/xapi/xapi_pbd.ml
@@ -188,7 +188,7 @@ let plug ~__context ~self =
         check_sharing_constraint ~__context ~sr ;
         let dbg = Ref.string_of (Context.get_task_id __context) in
         let device_config = Db.PBD.get_device_config ~__context ~self in
-        Storage_access.transform_storage_exn (fun () ->
+        Storage_utils.transform_storage_exn (fun () ->
             C.SR.attach dbg
               (Storage_interface.Sr.of_string
                  (Db.SR.get_uuid ~__context ~self:sr)
@@ -264,7 +264,7 @@ let unplug ~__context ~self =
         ) ;
         let dbg = Ref.string_of (Context.get_task_id __context) in
         let uuid = Db.SR.get_uuid ~__context ~self:sr in
-        Storage_access.transform_storage_exn (fun () ->
+        Storage_utils.transform_storage_exn (fun () ->
             C.SR.detach dbg (Storage_interface.Sr.of_string uuid)
         ) ;
         Storage_access.unbind ~__context ~pbd:self ;

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -849,7 +849,8 @@ let pre_join_checks ~__context ~rpc ~session_id ~force =
     let features_compatible coor_features candidate_features =
       (* The pool features must not be reduced or downgraded, although it is fine
          the other way around. *)
-      Smint.compat_features coor_features candidate_features = coor_features
+      Smint.Feature.compat_features coor_features candidate_features
+      = coor_features
     in
     let pool_sms = Client.SM.get_all_records ~rpc ~session_id in
     List.iter
@@ -3156,8 +3157,10 @@ let enable_local_storage_caching ~__context ~self:_ =
       (fun (_, _, srrec) ->
         (not srrec.API.sR_shared)
         && List.length srrec.API.sR_PBDs = 1
-        && List.mem_assoc Smint.Sr_supports_local_caching
-             (Sm.features_of_driver srrec.API.sR_type)
+        && Smint.Feature.(
+             has_capability Sr_supports_local_caching
+               (Sm.features_of_driver srrec.API.sR_type)
+           )
       )
       hosts_and_srs
   in

--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -203,6 +203,9 @@ let put_handler (req : Http.Request.t) s _ =
           ignore (Import_raw_vdi.import (Some vdi) req s ())
       | [""; services; "SM"; "nbd"; sr; vdi; dp] when services = _services ->
           Storage_migrate.nbd_handler req s sr vdi dp
+      | [""; services; "SM"; "nbd"; vm; sr; vdi; dp] when services = _services
+        ->
+          Storage_migrate.nbd_handler req s ~vm sr vdi dp
       | _ ->
           Http_svr.headers s (Http.http_404_missing ~version:"1.0" ()) ;
           req.Http.Request.close <- true

--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -206,6 +206,9 @@ let put_handler (req : Http.Request.t) s _ =
       | [""; services; "SM"; "nbd"; vm; sr; vdi; dp] when services = _services
         ->
           Storage_migrate.nbd_handler req s ~vm sr vdi dp
+      | [""; services; "SM"; "nbdproxy"; vm; sr; vdi; dp]
+        when services = _services ->
+          Storage_migrate.nbd_proxy req s vm sr vdi dp
       | _ ->
           Http_svr.headers s (Http.http_404_missing ~version:"1.0" ()) ;
           req.Http.Request.close <- true

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -482,7 +482,7 @@ let find_or_create_rrd_vdi ~__context ~sr =
 let should_manage_stats ~__context sr =
   let sr_record = Db.SR.get_record_internal ~__context ~self:sr in
   let sr_features = Xapi_sr_operations.features_of_sr ~__context sr_record in
-  Smint.(has_capability Sr_stats sr_features)
+  Smint.Feature.(has_capability Sr_stats sr_features)
   && Helpers.i_am_srmaster ~__context ~sr
 
 let maybe_push_sr_rrds ~__context ~sr =

--- a/ocaml/xapi/xapi_sr.ml
+++ b/ocaml/xapi/xapi_sr.ml
@@ -234,7 +234,7 @@ let call_probe ~__context ~host:_ ~device_config ~_type ~sm_config ~f =
     let rpc = rpc
   end)) in
   let dbg = Context.string_of_task __context in
-  Storage_access.transform_storage_exn (fun () ->
+  Storage_utils.transform_storage_exn (fun () ->
       Client.SR.probe dbg queue device_config sm_config |> f
   )
 
@@ -570,7 +570,7 @@ let update ~__context ~sr =
   let module C = Storage_interface.StorageAPI (Idl.Exn.GenClient (struct
     let rpc = rpc
   end)) in
-  transform_storage_exn (fun () ->
+  Storage_utils.transform_storage_exn (fun () ->
       let sr' =
         Db.SR.get_uuid ~__context ~self:sr |> Storage_interface.Sr.of_string
       in
@@ -764,7 +764,7 @@ let scan ~__context ~sr =
   end)) in
   let sr' = Ref.string_of sr in
   SRScanThrottle.execute (fun () ->
-      transform_storage_exn (fun () ->
+      Storage_utils.transform_storage_exn (fun () ->
           let sr_uuid = Db.SR.get_uuid ~__context ~self:sr in
           (* CA-399757: Do not update_vdis unless we are sure that the db was not
              changed during the scan. If it was, retry the scan operation. This
@@ -851,13 +851,12 @@ let set_shared ~__context ~sr ~value =
     Db.SR.set_shared ~__context ~self:sr ~value
 
 let set_name_label ~__context ~sr ~value =
-  let open Storage_access in
   let task = Context.get_task_id __context in
   let sr' = Db.SR.get_uuid ~__context ~self:sr in
   let module C = Storage_interface.StorageAPI (Idl.Exn.GenClient (struct
     let rpc = Storage_access.rpc
   end)) in
-  transform_storage_exn (fun () ->
+  Storage_utils.transform_storage_exn (fun () ->
       C.SR.set_name_label (Ref.string_of task)
         (Storage_interface.Sr.of_string sr')
         value
@@ -865,13 +864,12 @@ let set_name_label ~__context ~sr ~value =
   Db.SR.set_name_label ~__context ~self:sr ~value
 
 let set_name_description ~__context ~sr ~value =
-  let open Storage_access in
   let task = Context.get_task_id __context in
   let sr' = Db.SR.get_uuid ~__context ~self:sr in
   let module C = Storage_interface.StorageAPI (Idl.Exn.GenClient (struct
     let rpc = Storage_access.rpc
   end)) in
-  transform_storage_exn (fun () ->
+  Storage_utils.transform_storage_exn (fun () ->
       C.SR.set_name_description (Ref.string_of task)
         (Storage_interface.Sr.of_string sr')
         value

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -23,7 +23,7 @@ open D
 (* current/allowed operations checking                                                *)
 
 let feature_of_op =
-  let open Smint in
+  let open Smint.Feature in
   function
   | `forget | `copy | `force_unlock | `blocked ->
       None
@@ -53,7 +53,7 @@ let check_sm_feature_error (op : API.vdi_operations) sm_features sr =
   | None ->
       Ok ()
   | Some feature ->
-      if Smint.(has_capability feature sm_features) then
+      if Smint.Feature.(has_capability feature sm_features) then
         Ok ()
       else
         Error (Api_errors.sr_operation_not_supported, [Ref.string_of sr])

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -479,6 +479,7 @@ let remove_stale_pcis ~__context ~vm =
   in
   List.iter remove stale_pcis
 
+(** Called on the destination side *)
 let pool_migrate_complete ~__context ~vm ~host:_ =
   let id = Db.VM.get_uuid ~__context ~self:vm in
   debug "VM.pool_migrate_complete %s" id ;

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -162,36 +162,31 @@ open Storage_interface
 
 let assert_sr_support_operations ~__context ~vdi_map ~remote ~ops =
   let op_supported_on_source_sr vdi ops =
+    let open Smint.Feature in
     (* Check VDIs must not be present on SR which doesn't have required capability *)
     let source_sr = Db.VDI.get_SR ~__context ~self:vdi in
     let sr_record = Db.SR.get_record_internal ~__context ~self:source_sr in
     let sr_features = Xapi_sr_operations.features_of_sr ~__context sr_record in
-    if not (List.for_all (fun op -> Smint.(has_capability op sr_features)) ops)
-    then
+    if not (List.for_all (fun op -> has_capability op sr_features) ops) then
       raise
         (Api_errors.Server_error
            (Api_errors.sr_does_not_support_migration, [Ref.string_of source_sr])
         )
   in
   let op_supported_on_dest_sr sr ops sm_record remote =
+    let open Smint.Feature in
     (* Check VDIs must not be mirrored to SR which doesn't have required capability *)
     let sr_type =
       XenAPI.SR.get_type ~rpc:remote.rpc ~session_id:remote.session ~self:sr
     in
-    let sm_capabilities =
+    let sm_features =
       match List.filter (fun (_, r) -> r.API.sM_type = sr_type) sm_record with
       | [(_, plugin)] ->
-          plugin.API.sM_capabilities
+          plugin.API.sM_features |> List.filter_map of_string_int64_opt
       | _ ->
           []
     in
-    if
-      not
-        (List.for_all
-           (fun op -> List.mem Smint.(string_of_capability op) sm_capabilities)
-           ops
-        )
-    then
+    if not (List.for_all (fun op -> has_capability op sm_features) ops) then
       raise
         (Api_errors.Server_error
            (Api_errors.sr_does_not_support_migration, [Ref.string_of sr])
@@ -1755,7 +1750,9 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
     )
     vms_vdis ;
   (* operations required for migration *)
-  let required_sr_operations = [Smint.Vdi_mirror; Smint.Vdi_snapshot] in
+  let required_sr_operations =
+    [Smint.Feature.Vdi_mirror; Smint.Feature.Vdi_snapshot]
+  in
   let host_from = Helpers.LocalObject source_host_ref in
   ( match migration_type ~__context ~remote with
   | `intra_pool ->

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -732,6 +732,10 @@ type vdi_mirror = {
     snapshot_of: [`VDI] API.Ref.t
   ; (* API's snapshot_of reference *)
     do_mirror: bool (* Whether we should mirror or just copy the VDI *)
+  ; mirror_vm: Vm.t
+        (* The domain slice to which SMAPI calls should be made when mirroring this vdi *)
+  ; copy_vm: Vm.t
+        (* The domain slice to which SMAPI calls should be made when copying this vdi *)
 }
 
 (* For VMs (not snapshots) xenopsd does not allow remapping, so we
@@ -797,7 +801,28 @@ let get_vdi_mirror __context vm vdi do_mirror =
     Storage_interface.Sr.of_string
       (Db.SR.get_uuid ~__context ~self:(Db.VDI.get_SR ~__context ~self:vdi))
   in
-  {vdi; dp; location; sr; xenops_locator; size; snapshot_of; do_mirror}
+  let hash x =
+    let s = Digest.string x |> Digest.to_hex in
+    String.sub s 0 5
+  in
+  let copy_vm =
+    Ref.string_of vm |> hash |> ( ^ ) "COPY" |> Storage_interface.Vm.of_string
+  in
+  let mirror_vm =
+    Ref.string_of vm |> hash |> ( ^ ) "MIR" |> Storage_interface.Vm.of_string
+  in
+  {
+    vdi
+  ; dp
+  ; location
+  ; sr
+  ; xenops_locator
+  ; size
+  ; snapshot_of
+  ; do_mirror
+  ; copy_vm
+  ; mirror_vm
+  }
 
 (* We ignore empty or CD VBDs - nothing to do there. Possible redundancy here:
    I don't think any VBDs other than CD VBDs can be 'empty' *)
@@ -923,6 +948,8 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
   let with_remote_vdi remote_vdi cont =
     debug "Executing remote scan to ensure VDI is known to xapi" ;
     let remote_vdi_str = Storage_interface.Vdi.string_of remote_vdi in
+    debug "%s Executing remote scan to ensure VDI %s is known to xapi "
+      __FUNCTION__ remote_vdi_str ;
     XenAPI.SR.scan ~rpc:remote.rpc ~session_id:remote.session ~sr:dest_sr_ref ;
     let query =
       Printf.sprintf "(field \"location\"=\"%s\") and (field \"SR\"=\"%s\")"
@@ -980,8 +1007,8 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
   let mirror_to_remote new_dp =
     let task =
       if not vconf.do_mirror then
-        SMAPI.DATA.copy dbg vconf.sr vconf.location remote.sm_url dest_sr
-          is_intra_pool
+        SMAPI.DATA.copy dbg vconf.sr vconf.location vconf.copy_vm remote.sm_url
+          dest_sr is_intra_pool
       else
         (* Though we have no intention of "write", here we use the same mode as the
            associated VBD on a mirrored VDIs (i.e. always RW). This avoids problem
@@ -989,17 +1016,21 @@ let vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis so_far
         let read_write = true in
         (* DP set up is only essential for MIRROR.start/stop due to their open ended pattern.
            It's not necessary for copy which will take care of that itself. *)
-        let vm = Storage_interface.Vm.of_string "0" in
         ignore
-          (SMAPI.VDI.attach3 dbg new_dp vconf.sr vconf.location vm read_write) ;
-        SMAPI.VDI.activate dbg new_dp vconf.sr vconf.location ;
+          (SMAPI.VDI.attach3 dbg new_dp vconf.sr vconf.location vconf.mirror_vm
+             read_write
+          ) ;
+        SMAPI.VDI.activate3 dbg new_dp vconf.sr vconf.location vconf.mirror_vm ;
         let id =
           Storage_migrate.State.mirror_id_of (vconf.sr, vconf.location)
         in
+        debug "%s mirror_vm is %s copy_vm is %s" __FUNCTION__
+          (Vm.string_of vconf.mirror_vm)
+          (Vm.string_of vconf.copy_vm) ;
         (* Layering violation!! *)
         ignore (Storage_access.register_mirror __context id) ;
-        SMAPI.DATA.MIRROR.start dbg vconf.sr vconf.location new_dp remote.sm_url
-          dest_sr is_intra_pool
+        SMAPI.DATA.MIRROR.start dbg vconf.sr vconf.location new_dp
+          vconf.mirror_vm vconf.copy_vm remote.sm_url dest_sr is_intra_pool
     in
     let mapfn x =
       let total = Int64.to_float total_size in

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -1515,7 +1515,8 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
           )
           vifs
       in
-      (* Destroy the local datapaths - this allows the VDIs to properly detach, invoking the migrate_finalize calls *)
+      (* Destroy the local datapaths - this allows the VDIs to properly detach,
+         invoking the migrate_finalize calls *)
       List.iter
         (fun mirror_record ->
           if mirror_record.mr_mirrored then
@@ -1537,7 +1538,8 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
         TaskHelper.exn_if_cancelling ~__context ;
         TaskHelper.set_not_cancellable ~__context
       ) ;
-      (* It's acceptable for the VM not to exist at this point; shutdown commutes with storage migrate *)
+      (* It's acceptable for the VM not to exist at this point; shutdown commutes
+         with storage migrate *)
       ( try
           Xapi_xenops.Events_from_xenopsd.with_suppressed queue_name dbg vm_uuid
             (fun () ->

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -160,7 +160,8 @@ end))
 
 open Storage_interface
 
-let assert_sr_support_operations ~__context ~vdi_map ~remote ~ops =
+let assert_sr_support_operations ~__context ~vdi_map ~remote ~local_ops
+    ~remote_ops =
   let op_supported_on_source_sr vdi ops =
     let open Smint.Feature in
     (* Check VDIs must not be present on SR which doesn't have required capability *)
@@ -211,8 +212,8 @@ let assert_sr_support_operations ~__context ~vdi_map ~remote ~ops =
   in
   List.filter (fun (vdi, sr) -> not (is_sr_matching vdi sr)) vdi_map
   |> List.iter (fun (vdi, sr) ->
-         op_supported_on_source_sr vdi ops ;
-         op_supported_on_dest_sr sr ops sm_record remote
+         op_supported_on_source_sr vdi local_ops ;
+         op_supported_on_dest_sr sr remote_ops sm_record remote
      )
 
 (** Check that none of the VDIs that are mapped to a different SR have CBT
@@ -1781,8 +1782,9 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
     )
     vms_vdis ;
   (* operations required for migration *)
-  let required_sr_operations =
-    [Smint.Feature.Vdi_mirror; Smint.Feature.Vdi_snapshot]
+  let required_src_sr_operations = Smint.Feature.[Vdi_snapshot; Vdi_mirror] in
+  let required_dst_sr_operations =
+    Smint.Feature.[Vdi_snapshot; Vdi_mirror_in]
   in
   let host_from = Helpers.LocalObject source_host_ref in
   ( match migration_type ~__context ~remote with
@@ -1796,7 +1798,8 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
           (Api_errors.Server_error (Api_errors.not_supported_during_upgrade, [])) ;
       (* Check VDIs are not migrating to or from an SR which doesn't have required_sr_operations *)
       assert_sr_support_operations ~__context ~vdi_map ~remote
-        ~ops:required_sr_operations ;
+        ~local_ops:required_src_sr_operations
+        ~remote_ops:required_dst_sr_operations ;
       let snapshot = Db.VM.get_record ~__context ~self:vm in
       let do_cpuid_check = not force in
       Xapi_vm_helpers.assert_can_boot_here ~__context ~self:vm
@@ -1828,7 +1831,8 @@ let assert_can_migrate ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~options
       let power_state = Db.VM.get_power_state ~__context ~self:vm in
       (* Check VDIs are not migrating to or from an SR which doesn't have required_sr_operations *)
       assert_sr_support_operations ~__context ~vdi_map ~remote
-        ~ops:required_sr_operations ;
+        ~local_ops:required_src_sr_operations
+        ~remote_ops:required_dst_sr_operations ;
       (* The copy mode is only allow on stopped VM *)
       if (not force) && copy && power_state <> `Halted then
         raise

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -104,7 +104,7 @@ let checkpoint ~__context ~vm ~new_name =
         in
         (* Check if SR has snapshot feature *)
         let sr_has_snapshot_feature sr =
-          Smint.has_capability Vdi_snapshot
+          Smint.Feature.(has_capability Vdi_snapshot)
             (Xapi_sr_operations.features_of_sr ~__context sr)
         in
         List.iter

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=498
+  N=497
   X="ocaml/tests"
   X+="|ocaml/quicktest"
   X+="|ocaml/message-switch/core_test"


### PR DESCRIPTION
I am aware this is quite a large PR and there are a couple of things that could be done in different ways, so would probably benefit from opening it a bit earlier for discussion.

Currently this feature is controlled by the feature flag `sm3_import_mirror` on the storage side, which in turn controls the SM feature `VDI_MIRROR_IN`, which controls whether SXM can run or not. Current SXM of SMAPIv1 SRs are not affected, since `VDI_MIRROR` contains `VDI_MIRROR_IN`

Undraft this as the test went surprisingly well (all green).

Best reviewed by commits.

There is also a lightweight design doc on xs-documents if any one wants to read it.