### PR TITLE
CA-401242: avoid long-running, idle connections on VDI.pool_migrate

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4181,6 +4181,13 @@ module SR = struct
           , "Exporting a bitmap that shows the changed blocks between two VDIs"
           )
         ; ("vdi_set_on_boot", "Setting the on_boot field of the VDI")
+        ; ("vdi_blocked", "Blocking other operations for a VDI")
+        ; ("vdi_copy", "Copying the VDI")
+        ; ("vdi_force_unlock", "Forcefully unlocking the VDI")
+        ; ("vdi_forget", "Forgetting about the VDI")
+        ; ("vdi_generate_config", "Generating the configuration of the VDI")
+        ; ("vdi_resize_online", "Resizing the VDI online")
+        ; ("vdi_update", "Refreshing the fields on the VDI")
         ; ("pbd_create", "Creating a PBD for this SR")
         ; ("pbd_destroy", "Destroying one of this SR's PBDs")
         ]

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 783
+let schema_minor_vsn = 784
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "8fcd8892ec0c7d130b0da44c5fd3990b"
+let last_known_schema_hash = "b427bac09aca4eabc9407738a9155326"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/record_util/old_record_util.ml
+++ b/ocaml/tests/record_util/old_record_util.ml
@@ -341,6 +341,21 @@ let sr_operation_to_string : API.storage_operations -> string = function
       "PBD.create"
   | `pbd_destroy ->
       "PBD.destroy"
+  (* The following ones were added after the file got introduced *)
+  | `vdi_blocked ->
+      "VDI.blocked"
+  | `vdi_copy ->
+      "VDI.copy"
+  | `vdi_force_unlock ->
+      "VDI.force_unlock"
+  | `vdi_forget ->
+      "VDI.forget"
+  | `vdi_generate_config ->
+      "VDI.generate_config"
+  | `vdi_resize_online ->
+      "VDI.resize_online"
+  | `vdi_update ->
+      "VDI.update"
 
 let vbd_operation_to_string = function
   | `attach ->

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -160,6 +160,20 @@ let sr_operation_to_string : API.storage_operations -> string = function
       "VDI.data_destroy"
   | `vdi_list_changed_blocks ->
       "VDI.list_changed_blocks"
+  | `vdi_blocked ->
+      "VDI.blocked"
+  | `vdi_copy ->
+      "VDI.copy"
+  | `vdi_force_unlock ->
+      "VDI.force_unlock"
+  | `vdi_forget ->
+      "VDI.forget"
+  | `vdi_generate_config ->
+      "VDI.generate_config"
+  | `vdi_resize_online ->
+      "VDI.resize_online"
+  | `vdi_update ->
+      "VDI.update"
   | `pbd_create ->
       "PBD.create"
   | `pbd_destroy ->

--- a/ocaml/xapi/xapi_vdi.ml
+++ b/ocaml/xapi/xapi_vdi.ml
@@ -22,49 +22,49 @@ open D
 (**************************************************************************************)
 (* current/allowed operations checking                                                *)
 
-let check_sm_feature_error (op : API.vdi_operations) sm_features sr =
-  let required_sm_feature =
-    Smint.(
-      match op with
-      | `forget | `copy | `force_unlock | `blocked ->
-          None
-      | `snapshot ->
-          Some Vdi_snapshot
-      | `destroy ->
-          Some Vdi_delete
-      | `resize ->
-          Some Vdi_resize
-      | `update ->
-          Some Vdi_update
-      | `resize_online ->
-          Some Vdi_resize_online
-      | `generate_config ->
-          Some Vdi_generate_config
-      | `clone ->
-          Some Vdi_clone
-      | `mirror ->
-          Some Vdi_mirror
-      | `enable_cbt | `disable_cbt | `data_destroy | `list_changed_blocks ->
-          Some Vdi_configure_cbt
-      | `set_on_boot ->
-          Some Vdi_reset_on_boot
-    )
-  in
-  match required_sm_feature with
-  | None ->
+let feature_of_op =
+  let open Smint in
+  function
+  | `forget | `copy | `force_unlock | `blocked ->
       None
+  | `snapshot ->
+      Some Vdi_snapshot
+  | `destroy ->
+      Some Vdi_delete
+  | `resize ->
+      Some Vdi_resize
+  | `update ->
+      Some Vdi_update
+  | `resize_online ->
+      Some Vdi_resize_online
+  | `generate_config ->
+      Some Vdi_generate_config
+  | `clone ->
+      Some Vdi_clone
+  | `mirror ->
+      Some Vdi_mirror
+  | `enable_cbt | `disable_cbt | `data_destroy | `list_changed_blocks ->
+      Some Vdi_configure_cbt
+  | `set_on_boot ->
+      Some Vdi_reset_on_boot
+
+let check_sm_feature_error (op : API.vdi_operations) sm_features sr =
+  match feature_of_op op with
+  | None ->
+      Ok ()
   | Some feature ->
       if Smint.(has_capability feature sm_features) then
-        None
+        Ok ()
       else
-        Some (Api_errors.sr_operation_not_supported, [Ref.string_of sr])
+        Error (Api_errors.sr_operation_not_supported, [Ref.string_of sr])
 
-(** Checks to see if an operation is valid in this state. Returns [Some exception]
-    if not and [None] if everything is ok. If the [vbd_records] parameter is
+(** Checks to see if an operation is valid in this state. Returns [Error exception]
+    if not and [Ok ()] if everything is ok. If the [vbd_records] parameter is
     specified, it should contain at least all the VBD records from the database
     that are linked to this VDI. *)
 let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
     ?vbd_records ha_enabled record _ref' op =
+  let ( let* ) = Result.bind in
   let _ref = Ref.string_of _ref' in
   let current_ops = record.Db_actions.vDI_current_operations in
   let reset_on_boot = record.Db_actions.vDI_on_boot = `reset in
@@ -83,14 +83,18 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
      	   5. HA prevents you from deleting statefiles or metadata volumes
      	   6. During rolling pool upgrade, only operations known by older releases are allowed
   *)
-  if
-    Helpers.rolling_upgrade_in_progress ~__context
-    && not (List.mem op Xapi_globs.rpu_allowed_vdi_operations)
-  then
-    Some (Api_errors.not_supported_during_upgrade, [])
-  else
-    (* Don't fail with other_operation_in_progress if VDI mirroring is in progress
-       	 * and destroy is called as part of VDI mirroring *)
+  let* () =
+    if
+      Helpers.rolling_upgrade_in_progress ~__context
+      && not (List.mem op Xapi_globs.rpu_allowed_vdi_operations)
+    then
+      Error (Api_errors.not_supported_during_upgrade, [])
+    else
+      Ok ()
+  in
+  let* () =
+    (* Don't fail with other_operation_in_progress if VDI mirroring is in
+       progress and destroy is called as part of VDI mirroring *)
     let is_vdi_mirroring_in_progress =
       List.exists (fun (_, op) -> op = `mirror) current_ops && op = `destroy
     in
@@ -98,373 +102,351 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
       List.exists (fun (_, op) -> op <> `copy) current_ops
       && not is_vdi_mirroring_in_progress
     then
-      Some (Api_errors.other_operation_in_progress, ["VDI"; _ref])
-    else (* check to see whether it's a local cd drive *)
-      let sr = record.Db_actions.vDI_SR in
-      let sr_type = Db.SR.get_type ~__context ~self:sr in
-      let is_tools_sr = Db.SR.get_is_tools_sr ~__context ~self:sr in
-      (* Check to see if any PBDs are attached *)
-      let open Xapi_database.Db_filter_types in
-      let pbds_attached =
-        match pbd_records with
-        | [] ->
-            Db.PBD.get_records_where ~__context
-              ~expr:
-                (And
-                   ( Eq (Field "SR", Literal (Ref.string_of sr))
-                   , Eq (Field "currently_attached", Literal "true")
-                   )
-                )
-        | _ ->
-            List.filter
-              (fun (_, pbd_record) ->
-                pbd_record.API.pBD_SR = sr
-                && pbd_record.API.pBD_currently_attached
-              )
-              pbd_records
-      in
-      if pbds_attached = [] && List.mem op [`resize] then
-        Some (Api_errors.sr_no_pbds, [Ref.string_of sr])
-      else
-        (* check to see whether VBDs exist which are using this VDI *)
-
-        (* Only a 'live' operation can be performed if there are active (even RO) devices *)
-        let my_active_vbd_records =
-          match vbd_records with
-          | None ->
-              List.map snd
-                (Db.VBD.get_internal_records_where ~__context
-                   ~expr:
-                     (And
-                        ( Eq (Field "VDI", Literal _ref)
-                        , Or
-                            ( Eq (Field "currently_attached", Literal "true")
-                            , Eq (Field "reserved", Literal "true")
-                            )
-                        )
-                     )
-                )
-          | Some records ->
-              List.map snd
-                (List.filter
-                   (fun (_, vbd_record) ->
-                     vbd_record.Db_actions.vBD_VDI = _ref'
-                     && (vbd_record.Db_actions.vBD_currently_attached
-                        || vbd_record.Db_actions.vBD_reserved
-                        )
-                   )
-                   records
-                )
-        in
-        let my_active_rw_vbd_records =
-          List.filter
-            (fun vbd -> vbd.Db_actions.vBD_mode = `RW)
-            my_active_vbd_records
-        in
-        (* VBD operations (plug/unplug) (which should be transient) cause us to serialise *)
-        let my_has_current_operation_vbd_records =
-          match vbd_records with
-          | None ->
-              List.map snd
-                (Db.VBD.get_internal_records_where ~__context
-                   ~expr:
-                     (And
-                        ( Eq (Field "VDI", Literal _ref)
-                        , Not (Eq (Field "current_operations", Literal "()"))
-                        )
-                     )
-                )
-          | Some records ->
-              List.map snd
-                (List.filter
-                   (fun (_, vbd_record) ->
-                     vbd_record.Db_actions.vBD_VDI = _ref'
-                     && vbd_record.Db_actions.vBD_current_operations <> []
-                   )
-                   records
-                )
-        in
-        (* If the VBD is currently_attached then some operations can still be performed ie:
-           			   VDI.clone (if the VM is suspended we have to have the 'allow_clone_suspended_vm'' flag)
-           			   VDI.snapshot; VDI.resize_online; 'blocked' (CP-831)
-           VDI.data_destroy: it is not allowed on VDIs linked to a VM, but the
-             implementation first waits for the VDI's VBDs to be unplugged and
-             destroyed, and the checks are performed there.
-        *)
-        let operation_can_be_performed_live =
-          match op with
-          | `snapshot
-          | `resize_online
-          | `blocked
-          | `clone
-          | `mirror
-          | `enable_cbt
-          | `disable_cbt
-          | `data_destroy ->
-              true
-          | _ ->
-              false
-        in
-        let operation_can_be_performed_with_ro_attach =
-          operation_can_be_performed_live
-          || match op with `copy -> true | _ -> false
-        in
-        (* NB RO vs RW sharing checks are done in xapi_vbd.ml *)
-        let blocked_by_attach =
-          let blocked_by_attach =
-            if operation_can_be_performed_live then
-              false
-            else if operation_can_be_performed_with_ro_attach then
-              my_active_rw_vbd_records <> []
-            else
-              my_active_vbd_records <> []
-          in
-          let allow_attached_vbds =
-            (* We use Valid_ref_list.list to ignore exceptions due to invalid references that
-               could propagate to the message forwarding layer, which calls this
-               function to check for errors - these exceptions would prevent the
-               actual XenAPI function from being run. Checks called from the
-               message forwarding layer should not fail with an exception. *)
-            let true_for_all_active_vbds f =
-              Valid_ref_list.for_all f my_active_vbd_records
-            in
-            match op with
-            | `list_changed_blocks ->
-                let vbd_connected_to_vm_snapshot vbd =
-                  let vm = vbd.Db_actions.vBD_VM in
-                  Db.is_valid_ref __context vm
-                  && Db.VM.get_is_a_snapshot ~__context ~self:vm
-                in
-                (* We allow list_changed_blocks on VDIs attached to snapshot VMs,
-                   because VM.checkpoint may set the currently_attached fields of the
-                   snapshot's VBDs to true, and this would block list_changed_blocks. *)
-                true_for_all_active_vbds vbd_connected_to_vm_snapshot
-            | _ ->
-                false
-          in
-          blocked_by_attach && not allow_attached_vbds
-        in
-        if blocked_by_attach then
-          Some
-            ( Api_errors.vdi_in_use
-            , [_ref; Record_util.vdi_operations_to_string op]
+      Error (Api_errors.other_operation_in_progress, ["VDI"; _ref])
+    else
+      Ok ()
+  in
+  (* check to see whether it's a local cd drive *)
+  let sr = record.Db_actions.vDI_SR in
+  let sr_type = Db.SR.get_type ~__context ~self:sr in
+  let is_tools_sr = Db.SR.get_is_tools_sr ~__context ~self:sr in
+  (* Check to see if any PBDs are attached *)
+  let open Xapi_database.Db_filter_types in
+  let pbds_attached =
+    match pbd_records with
+    | [] ->
+        Db.PBD.get_records_where ~__context
+          ~expr:
+            (And
+               ( Eq (Field "SR", Literal (Ref.string_of sr))
+               , Eq (Field "currently_attached", Literal "true")
+               )
             )
-        else if
-          (* data_destroy first waits for all the VBDs to disappear in its
-             implementation, so it is harmless to allow it when any of the VDI's
-             VBDs have operations in progress. This ensures that we avoid the retry
-             mechanism of message forwarding and only use the event loop. *)
-          my_has_current_operation_vbd_records <> [] && op <> `data_destroy
-        then
-          Some (Api_errors.other_operation_in_progress, ["VDI"; _ref])
-        else
-          let sm_features =
-            Xapi_sr_operations.features_of_sr_internal ~__context ~_type:sr_type
-          in
-          let sm_feature_error = check_sm_feature_error op sm_features sr in
-          if sm_feature_error <> None then
-            sm_feature_error
-          else
-            let allowed_for_cbt_metadata_vdi =
-              match op with
-              | `clone
-              | `copy
-              | `disable_cbt
-              | `enable_cbt
-              | `mirror
-              | `resize
-              | `resize_online
-              | `snapshot
-              | `set_on_boot ->
-                  false
-              | `blocked
-              | `data_destroy
-              | `destroy
-              | `list_changed_blocks
-              | `force_unlock
-              | `forget
-              | `generate_config
-              | `update ->
-                  true
-            in
-            if
-              (not allowed_for_cbt_metadata_vdi)
-              && record.Db_actions.vDI_type = `cbt_metadata
-            then
-              Some
-                ( Api_errors.vdi_incompatible_type
-                , [_ref; Record_util.vdi_type_to_string `cbt_metadata]
-                )
-            else
-              let allowed_when_cbt_enabled =
-                match op with
-                | `mirror | `set_on_boot ->
-                    false
-                | `blocked
-                | `clone
-                | `copy
-                | `data_destroy
-                | `destroy
-                | `disable_cbt
-                | `enable_cbt
-                | `list_changed_blocks
-                | `force_unlock
-                | `forget
-                | `generate_config
-                | `resize
-                | `resize_online
-                | `snapshot
-                | `update ->
-                    true
-              in
-              if
-                (not allowed_when_cbt_enabled)
-                && record.Db_actions.vDI_cbt_enabled
-              then
-                Some (Api_errors.vdi_cbt_enabled, [_ref])
-              else
-                let check_destroy () =
-                  if sr_type = "udev" then
-                    Some (Api_errors.vdi_is_a_physical_device, [_ref])
-                  else if is_tools_sr then
-                    Some
-                      (Api_errors.sr_operation_not_supported, [Ref.string_of sr])
-                  else if List.mem record.Db_actions.vDI_type [`rrd] then
-                    Some (Api_errors.vdi_has_rrds, [_ref])
-                  else if
-                    ha_enabled
-                    && List.mem record.Db_actions.vDI_type
-                         [`ha_statefile; `redo_log]
-                  then
-                    Some (Api_errors.ha_is_enabled, [])
-                  else if
-                    List.mem record.Db_actions.vDI_type
-                      [`ha_statefile; `metadata]
-                    && Xapi_pool_helpers.ha_enable_in_progress ~__context
-                  then
-                    Some (Api_errors.ha_enable_in_progress, [])
-                  else if
-                    List.mem record.Db_actions.vDI_type
-                      [`ha_statefile; `metadata]
-                    && Xapi_pool_helpers.ha_disable_in_progress ~__context
-                  then
-                    Some (Api_errors.ha_disable_in_progress, [])
-                  else
-                    None
-                in
-                match op with
-                | `forget ->
-                    if
-                      ha_enabled
-                      && List.mem record.Db_actions.vDI_type
-                           [`ha_statefile; `redo_log]
-                    then
-                      Some (Api_errors.ha_is_enabled, [])
-                    else if List.mem record.Db_actions.vDI_type [`rrd] then
-                      Some (Api_errors.vdi_has_rrds, [_ref])
-                    else
-                      None
-                | `destroy ->
-                    check_destroy ()
-                | `data_destroy ->
-                    if not record.Db_actions.vDI_is_a_snapshot then
-                      Some
-                        ( Api_errors.operation_not_allowed
-                        , ["VDI is not a snapshot: " ^ _ref]
-                        )
-                    else if not record.Db_actions.vDI_cbt_enabled then
-                      Some (Api_errors.vdi_no_cbt_metadata, [_ref])
-                    else
-                      check_destroy ()
-                | `resize ->
-                    if
-                      ha_enabled
-                      && List.mem record.Db_actions.vDI_type
-                           [`ha_statefile; `redo_log]
-                    then
-                      Some (Api_errors.ha_is_enabled, [])
-                    else
-                      None
-                | `resize_online ->
-                    if
-                      ha_enabled
-                      && List.mem record.Db_actions.vDI_type
-                           [`ha_statefile; `redo_log]
-                    then
-                      Some (Api_errors.ha_is_enabled, [])
-                    else
-                      None
-                | `snapshot when record.Db_actions.vDI_sharable ->
-                    Some (Api_errors.vdi_is_sharable, [_ref])
-                | (`snapshot | `copy) when reset_on_boot ->
-                    Some
-                      ( Api_errors.vdi_on_boot_mode_incompatible_with_operation
-                      , []
+    | _ ->
+        List.filter
+          (fun (_, pbd_record) ->
+            pbd_record.API.pBD_SR = sr && pbd_record.API.pBD_currently_attached
+          )
+          pbd_records
+  in
+  let* () =
+    if pbds_attached = [] && List.mem op [`resize] then
+      Error (Api_errors.sr_no_pbds, [Ref.string_of sr])
+    else
+      Ok ()
+  in
+
+  (* check to see whether VBDs exist which are using this VDI *)
+
+  (* Only a 'live' operation can be performed if there are active (even RO) devices *)
+  let my_active_vbd_records =
+    match vbd_records with
+    | None ->
+        List.map snd
+          (Db.VBD.get_internal_records_where ~__context
+             ~expr:
+               (And
+                  ( Eq (Field "VDI", Literal _ref)
+                  , Or
+                      ( Eq (Field "currently_attached", Literal "true")
+                      , Eq (Field "reserved", Literal "true")
                       )
-                | `snapshot ->
-                    if List.exists (fun (_, op) -> op = `copy) current_ops then
-                      Some
-                        ( Api_errors.operation_not_allowed
-                        , ["Snapshot operation not allowed during copy."]
-                        )
-                    else
-                      None
-                | `copy ->
-                    if
-                      List.mem record.Db_actions.vDI_type
-                        [`ha_statefile; `redo_log]
-                    then
-                      Some
-                        ( Api_errors.operation_not_allowed
-                        , [
-                            "VDI containing HA statefile or redo log cannot be \
-                             copied (check the VDI's allowed operations)."
-                          ]
-                        )
-                    else
-                      None
-                | `enable_cbt | `disable_cbt ->
-                    if record.Db_actions.vDI_is_a_snapshot then
-                      Some
-                        ( Api_errors.operation_not_allowed
-                        , ["VDI is a snapshot: " ^ _ref]
-                        )
-                    else if
-                      not (List.mem record.Db_actions.vDI_type [`user; `system])
-                    then
-                      Some
-                        ( Api_errors.vdi_incompatible_type
-                        , [
-                            _ref
-                          ; Record_util.vdi_type_to_string
-                              record.Db_actions.vDI_type
-                          ]
-                        )
-                    else if reset_on_boot then
-                      Some
-                        ( Api_errors.vdi_on_boot_mode_incompatible_with_operation
-                        , []
-                        )
-                    else
-                      None
-                | `mirror
-                | `clone
-                | `generate_config
-                | `force_unlock
-                | `set_on_boot
-                | `list_changed_blocks
-                | `blocked
-                | `update ->
-                    None
+                  )
+               )
+          )
+    | Some records ->
+        List.map snd
+          (List.filter
+             (fun (_, vbd_record) ->
+               vbd_record.Db_actions.vBD_VDI = _ref'
+               && (vbd_record.Db_actions.vBD_currently_attached
+                  || vbd_record.Db_actions.vBD_reserved
+                  )
+             )
+             records
+          )
+  in
+  let my_active_rw_vbd_records =
+    List.filter (fun vbd -> vbd.Db_actions.vBD_mode = `RW) my_active_vbd_records
+  in
+  (* VBD operations (plug/unplug) (which should be transient) cause us to serialise *)
+  let my_has_current_operation_vbd_records =
+    match vbd_records with
+    | None ->
+        List.map snd
+          (Db.VBD.get_internal_records_where ~__context
+             ~expr:
+               (And
+                  ( Eq (Field "VDI", Literal _ref)
+                  , Not (Eq (Field "current_operations", Literal "()"))
+                  )
+               )
+          )
+    | Some records ->
+        List.map snd
+          (List.filter
+             (fun (_, vbd_record) ->
+               vbd_record.Db_actions.vBD_VDI = _ref'
+               && vbd_record.Db_actions.vBD_current_operations <> []
+             )
+             records
+          )
+  in
+  (* If the VBD is currently_attached then some operations can still be
+     performed ie: VDI.clone (if the VM is suspended we have to have the
+      'allow_clone_suspended_vm' flag); VDI.snapshot; VDI.resize_online;
+      'blocked' (CP-831); VDI.data_destroy: it is not allowed on VDIs linked
+      to a VM, but the implementation first waits for the VDI's VBDs to be
+      unplugged and destroyed, and the checks are performed there.
+  *)
+  let operation_can_be_performed_live =
+    match op with
+    | `snapshot
+    | `resize_online
+    | `blocked
+    | `clone
+    | `mirror
+    | `enable_cbt
+    | `disable_cbt
+    | `data_destroy ->
+        true
+    | _ ->
+        false
+  in
+  let operation_can_be_performed_with_ro_attach =
+    operation_can_be_performed_live
+    || match op with `copy -> true | _ -> false
+  in
+  (* NB RO vs RW sharing checks are done in xapi_vbd.ml *)
+  let blocked_by_attach =
+    let blocked_by_attach =
+      if operation_can_be_performed_live then
+        false
+      else if operation_can_be_performed_with_ro_attach then
+        my_active_rw_vbd_records <> []
+      else
+        my_active_vbd_records <> []
+    in
+    let allow_attached_vbds =
+      (* We use Valid_ref_list.list to ignore exceptions due to invalid
+         references that could propagate to the message forwarding layer, which
+         calls this function to check for errors - these exceptions would
+         prevent the actual XenAPI function from being run. Checks called from
+         the message forwarding layer should not fail with an exception. *)
+      let true_for_all_active_vbds f =
+        Valid_ref_list.for_all f my_active_vbd_records
+      in
+      match op with
+      | `list_changed_blocks ->
+          let vbd_connected_to_vm_snapshot vbd =
+            let vm = vbd.Db_actions.vBD_VM in
+            Db.is_valid_ref __context vm
+            && Db.VM.get_is_a_snapshot ~__context ~self:vm
+          in
+          (* We allow list_changed_blocks on VDIs attached to snapshot VMs,
+             because VM.checkpoint may set the currently_attached fields of the
+             snapshot's VBDs to true, and this would block list_changed_blocks. *)
+          true_for_all_active_vbds vbd_connected_to_vm_snapshot
+      | _ ->
+          false
+    in
+    blocked_by_attach && not allow_attached_vbds
+  in
+  let* () =
+    if blocked_by_attach then
+      Error
+        (Api_errors.vdi_in_use, [_ref; Record_util.vdi_operations_to_string op])
+    else if
+      (* data_destroy first waits for all the VBDs to disappear in its
+         implementation, so it is harmless to allow it when any of the VDI's
+         VBDs have operations in progress. This ensures that we avoid the retry
+         mechanism of message forwarding and only use the event loop. *)
+      my_has_current_operation_vbd_records <> [] && op <> `data_destroy
+    then
+      Error (Api_errors.other_operation_in_progress, ["VDI"; _ref])
+    else
+      Ok ()
+  in
+  let sm_features =
+    Xapi_sr_operations.features_of_sr_internal ~__context ~_type:sr_type
+  in
+  let* () = check_sm_feature_error op sm_features sr in
+  let allowed_for_cbt_metadata_vdi =
+    match op with
+    | `clone
+    | `copy
+    | `disable_cbt
+    | `enable_cbt
+    | `mirror
+    | `resize
+    | `resize_online
+    | `snapshot
+    | `set_on_boot ->
+        false
+    | `blocked
+    | `data_destroy
+    | `destroy
+    | `list_changed_blocks
+    | `force_unlock
+    | `forget
+    | `generate_config
+    | `update ->
+        true
+  in
+  let* () =
+    if
+      (not allowed_for_cbt_metadata_vdi)
+      && record.Db_actions.vDI_type = `cbt_metadata
+    then
+      Error
+        ( Api_errors.vdi_incompatible_type
+        , [_ref; Record_util.vdi_type_to_string `cbt_metadata]
+        )
+    else
+      Ok ()
+  in
+  let allowed_when_cbt_enabled =
+    match op with
+    | `mirror | `set_on_boot ->
+        false
+    | `blocked
+    | `clone
+    | `copy
+    | `data_destroy
+    | `destroy
+    | `disable_cbt
+    | `enable_cbt
+    | `list_changed_blocks
+    | `force_unlock
+    | `forget
+    | `generate_config
+    | `resize
+    | `resize_online
+    | `snapshot
+    | `update ->
+        true
+  in
+  let* () =
+    if (not allowed_when_cbt_enabled) && record.Db_actions.vDI_cbt_enabled then
+      Error (Api_errors.vdi_cbt_enabled, [_ref])
+    else
+      Ok ()
+  in
+  let check_destroy () =
+    if sr_type = "udev" then
+      Error (Api_errors.vdi_is_a_physical_device, [_ref])
+    else if is_tools_sr then
+      Error (Api_errors.sr_operation_not_supported, [Ref.string_of sr])
+    else if List.mem record.Db_actions.vDI_type [`rrd] then
+      Error (Api_errors.vdi_has_rrds, [_ref])
+    else if
+      ha_enabled
+      && List.mem record.Db_actions.vDI_type [`ha_statefile; `redo_log]
+    then
+      Error (Api_errors.ha_is_enabled, [])
+    else if
+      List.mem record.Db_actions.vDI_type [`ha_statefile; `metadata]
+      && Xapi_pool_helpers.ha_enable_in_progress ~__context
+    then
+      Error (Api_errors.ha_enable_in_progress, [])
+    else if
+      List.mem record.Db_actions.vDI_type [`ha_statefile; `metadata]
+      && Xapi_pool_helpers.ha_disable_in_progress ~__context
+    then
+      Error (Api_errors.ha_disable_in_progress, [])
+    else
+      Ok ()
+  in
+  match op with
+  | `forget ->
+      if
+        ha_enabled
+        && List.mem record.Db_actions.vDI_type [`ha_statefile; `redo_log]
+      then
+        Error (Api_errors.ha_is_enabled, [])
+      else if List.mem record.Db_actions.vDI_type [`rrd] then
+        Error (Api_errors.vdi_has_rrds, [_ref])
+      else
+        Ok ()
+  | `destroy ->
+      check_destroy ()
+  | `data_destroy ->
+      if not record.Db_actions.vDI_is_a_snapshot then
+        Error
+          (Api_errors.operation_not_allowed, ["VDI is not a snapshot: " ^ _ref])
+      else if not record.Db_actions.vDI_cbt_enabled then
+        Error (Api_errors.vdi_no_cbt_metadata, [_ref])
+      else
+        check_destroy ()
+  | `resize ->
+      if
+        ha_enabled
+        && List.mem record.Db_actions.vDI_type [`ha_statefile; `redo_log]
+      then
+        Error (Api_errors.ha_is_enabled, [])
+      else
+        Ok ()
+  | `resize_online ->
+      if
+        ha_enabled
+        && List.mem record.Db_actions.vDI_type [`ha_statefile; `redo_log]
+      then
+        Error (Api_errors.ha_is_enabled, [])
+      else
+        Ok ()
+  | `snapshot when record.Db_actions.vDI_sharable ->
+      Error (Api_errors.vdi_is_sharable, [_ref])
+  | (`snapshot | `copy) when reset_on_boot ->
+      Error (Api_errors.vdi_on_boot_mode_incompatible_with_operation, [])
+  | `snapshot ->
+      if List.exists (fun (_, op) -> op = `copy) current_ops then
+        Error
+          ( Api_errors.operation_not_allowed
+          , ["Snapshot operation not allowed during copy."]
+          )
+      else
+        Ok ()
+  | `copy ->
+      if List.mem record.Db_actions.vDI_type [`ha_statefile; `redo_log] then
+        Error
+          ( Api_errors.operation_not_allowed
+          , [
+              "VDI containing HA statefile or redo log cannot be copied (check \
+               the VDI's allowed operations)."
+            ]
+          )
+      else
+        Ok ()
+  | `enable_cbt | `disable_cbt ->
+      if record.Db_actions.vDI_is_a_snapshot then
+        Error (Api_errors.operation_not_allowed, ["VDI is a snapshot: " ^ _ref])
+      else if not (List.mem record.Db_actions.vDI_type [`user; `system]) then
+        Error
+          ( Api_errors.vdi_incompatible_type
+          , [_ref; Record_util.vdi_type_to_string record.Db_actions.vDI_type]
+          )
+      else if reset_on_boot then
+        Error (Api_errors.vdi_on_boot_mode_incompatible_with_operation, [])
+      else
+        Ok ()
+  | `mirror
+  | `clone
+  | `generate_config
+  | `force_unlock
+  | `set_on_boot
+  | `list_changed_blocks
+  | `blocked
+  | `update ->
+      Ok ()
 
 let assert_operation_valid ~__context ~self ~(op : API.vdi_operations) =
   let pool = Helpers.get_pool ~__context in
   let ha_enabled = Db.Pool.get_ha_enabled ~__context ~self:pool in
   let all = Db.VDI.get_record_internal ~__context ~self in
   match check_operation_error ~__context ha_enabled all self op with
-  | None ->
+  | Ok () ->
       ()
-  | Some (a, b) ->
+  | Error (a, b) ->
       raise (Api_errors.Server_error (a, b))
 
 let update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records
@@ -501,7 +483,7 @@ let update_allowed_operations_internal ~__context ~self ~sr_records ~pbd_records
         check_operation_error ~__context ~sr_records ~pbd_records ?vbd_records
           ha_enabled all self x
       with
-      | None ->
+      | Ok () ->
           [x]
       | _ ->
           []

--- a/ocaml/xapi/xapi_vdi.mli
+++ b/ocaml/xapi/xapi_vdi.mli
@@ -28,7 +28,7 @@ val check_operation_error :
   -> Db_actions.vDI_t
   -> API.ref_VDI
   -> API.vdi_operations
-  -> (string * string list) option
+  -> (unit, string * string list) Result.t
 (** Checks to see if an operation is valid in this state. Returns Some exception
     if not and None if everything is ok. *)
 


### PR DESCRIPTION
When a VDI.pool_migrate starts at a pool member, a connection between the
coordinator and that host remains open for the duration of the migration. This
connection is completely idle. If it's open for 12 hours, stunnel closes the
connection due to inactivity, which cancels the migration.

To avoid this use an internal API that uses short-running connection whenever
possible to avoid interrupting the migration.

Also change nested if-else flow in vdi handling to use Result with let binds, and add missing CDI operations to storage operations.

I've manually verified the fix by changing the stunnel timeout in the coordinator of a pool to 5 seconds and migrating a vdi used by a VM in another host:
```
# xe vdi-pool-migrate uuid=fdb8783f-8cdb-44d3-9327-992f047e6262 sr-uuid=c879ffc9-bb14-fec5-3d95-8959db9337eb
270c3dc8-27bc-4ef2-982a-a6142f0ffce1
```

And after reverting the patch:
```
# xe vdi-pool-migrate uuid=270c3dc8-27bc-4ef2-982a-a6142f0ffce1 sr-uuid=aade9dc6-ff31-3204-4187-37f82ad06c77
Cannot forward messages because the server cannot be contacted. The server may be switched off or there may be network connectivity problems.
host: 0a3a45a0-8754-4570-bfde-6ef6843ccda1 (xs2)
```

The changes are best reviewed one by one, and while ignoring whitespace, if using github.