### PR TITLE
CA-401242: avoid long-running, idle connections on VDI.pool_migrate, backport

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -5060,17 +5060,23 @@ functor
                 in
                 (snapshot, host)
             in
+            let op session_id rpc =
+              let sync_op () =
+                Client.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr ~options
+              in
+              let async_op () =
+                Client.InternalAsync.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr
+                  ~options
+              in
+              Helpers.try_internal_async ~__context API.ref_VDI_of_rpc async_op
+                sync_op
+            in
             VM.reserve_memory_for_vm ~__context ~vm ~host ~snapshot
               ~host_op:`vm_migrate (fun () ->
                 with_sr_andor_vdi ~__context
                   ~vdi:(vdi, `mirror)
                   ~doc:"VDI.mirror"
-                  (fun () ->
-                    do_op_on ~local_fn ~__context ~host (fun session_id rpc ->
-                        Client.VDI.pool_migrate ~rpc ~session_id ~vdi ~sr
-                          ~options
-                    )
-                  )
+                  (fun () -> do_op_on ~local_fn ~__context ~host op)
             )
         )
 


### PR DESCRIPTION
When a VDI.pool_migrate starts at a pool member, a connection between the coordinator and that host remains open for the duration of the migration. This connection is completely idle. If the migration lasts for more than 12 hours, stunnel closes the connection due to inactivity, which cancels the migration.

To avoid this use an internal API that uses short-running connection whenever possible to avoid interrupting the migration.

merged cherry-pick of 0149ee5c2433b8995d8b75f28c2037c9da4cba80