### PR TITLE
CA-401498: Fix test_systemd occasional timeout

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.t
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/test/test_systemd.t
@@ -10,6 +10,7 @@
   $ ./test_systemd.exe --server &
   @systemd.socket
   READY=1
+  $ sleep 1
   $ ./test_systemd.exe --notify
   $ wait
 


### PR DESCRIPTION
CI check "Run OCaml tests" on github failed occasionally. The cause is test_systemd timeout. Add sleep 1 between server start and client to fix it.