### PR TITLE
CA-399629: make daily-license-check aware of never

### DIFF
--- a/ocaml/license/daily_license_check.ml
+++ b/ocaml/license/daily_license_check.ml
@@ -12,8 +12,8 @@ let days_to_expiry now expiry =
 let get_expiry_date license =
   List.assoc_opt "expiry" license
   |> Fun.flip Option.bind (fun e -> if e = "never" then None else Some e)
-  |> Option.map Xapi_stdext_date.Date.of_iso8601
-  |> Option.map Xapi_stdext_date.Date.to_unix_time
+  |> Option.map Xapi_stdext_date.Date.of_string
+  |> Option.map Xapi_stdext_date.Date.to_float
 
 let get_hosts all_license_params threshold =
   List.fold_left

--- a/ocaml/tests/alerts/test_daily_license_check.ml
+++ b/ocaml/tests/alerts/test_daily_license_check.ml
@@ -47,6 +47,7 @@ let expiry_samples =
   [
     (([("expiry", "20170101T00:00:00Z")], []), Good)
   ; (([("expiry", "20160701T04:01:00Z")], []), Good)
+  ; (([("expiry", "never")], []), Good)
   ; (([("expiry", "20160701T04:00:00Z")], []), Expiring [])
   ; (([("expiry", "20160616T00:00:00Z")], []), Expiring [])
   ; (([("expiry", "20160601T04:00:01Z")], []), Expiring [])


### PR DESCRIPTION
The license field is not always a valid date, sometimes it contains a special
value to signify there's no expiry date.

(cherry picked from commit 6a66682)