### PR TITLE
Support pool.sync_updates from remote_pool repo

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1926,6 +1926,16 @@ let _ =
       "If the bundle repository or remote_pool repository is enabled, it \
        should be the only one enabled repository of the pool."
     () ;
+  error Api_errors.update_syncing_remote_pool_coordinator_connection_failed []
+    ~doc:
+      "There was an error connecting to the remote pool coordinator while \
+       syncing updates from it."
+    () ;
+  error Api_errors.update_syncing_remote_pool_coordinator_service_failed []
+    ~doc:
+      "There was an error connecting to the server while syncing updates from \
+       it. The service contacted didn't reply properly."
+    () ;
   error Api_errors.repository_is_in_use [] ~doc:"The repository is in use." () ;
   error Api_errors.repository_cleanup_failed []
     ~doc:"Failed to clean up local repository on coordinator." () ;

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1282,6 +1282,20 @@ let sync_updates =
         ; param_release= numbered_release "1.329.0"
         ; param_default= Some (VString "")
         }
+      ; {
+          param_type= String
+        ; param_name= "username"
+        ; param_doc= "The username of the remote pool"
+        ; param_release= numbered_release "24.39.0-next"
+        ; param_default= Some (VString "")
+        }
+      ; {
+          param_type= String
+        ; param_name= "password"
+        ; param_doc= "The password of the remote pool"
+        ; param_release= numbered_release "24.39.0-next"
+        ; param_default= Some (VString "")
+        }
       ]
     ~result:(String, "The SHA256 hash of updateinfo.xml.gz")
     ~allowed_roles:(_R_POOL_OP ++ _R_CLIENT_CERT)

--- a/ocaml/idl/datamodel_repository.ml
+++ b/ocaml/idl/datamodel_repository.ml
@@ -105,7 +105,9 @@ let introduce_remote_pool =
       ; ( String
         , "binary_url"
         , "Base URL of binary packages in the local repository of this remote \
-           pool in https://<coordinator-ip>/repository format"
+           pool in https://<coordinator-ip>"
+          ^ Constants.get_enabled_repository_uri
+          ^ " format"
         )
       ; ( String
         , "certificate"

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -511,7 +511,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "pool-sync-updates"
     , {
         reqd= []
-      ; optn= ["force"; "token"; "token-id"]
+      ; optn= ["force"; "token"; "token-id"; "username"; "password"]
       ; help= "Sync updates from remote YUM repository, pool-wide."
       ; implementation= No_fd Cli_operations.pool_sync_updates
       ; flags= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -1833,8 +1833,11 @@ let pool_sync_updates printer rpc session_id params =
   let force = get_bool_param params "force" in
   let token = get_param params "token" ~default:"" in
   let token_id = get_param params "token-id" ~default:"" in
+  let username = get_param params "username" ~default:"" in
+  let password = get_param params "password" ~default:"" in
   let hash =
     Client.Pool.sync_updates ~rpc ~session_id ~self:pool ~force ~token ~token_id
+      ~username ~password
   in
   printer (Cli_printer.PList [hash])
 

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1330,6 +1330,12 @@ let can_not_periodic_sync_updates = add_error "CAN_NOT_PERIODIC_SYNC_UPDATES"
 let repo_should_be_single_one_enabled =
   add_error "REPO_SHOULD_BE_SINGLE_ONE_ENABLED"
 
+let update_syncing_remote_pool_coordinator_connection_failed =
+  add_error "UPDATE_SYNCING_REMOTE_POOL_COORDINATOR_CONNECTION_FAILED"
+
+let update_syncing_remote_pool_coordinator_service_failed =
+  add_error "UPDATE_SYNCING_REMOTE_POOL_COORDINATOR_SERVICE_FAILED"
+
 let repository_is_in_use = add_error "REPOSITORY_IS_IN_USE"
 
 let repository_cleanup_failed = add_error "REPOSITORY_CLEANUP_FAILED"

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -2030,19 +2030,24 @@ let with_temp_file ?mode prefix suffix f =
   let path, channel = Filename.open_temp_file ?mode prefix suffix in
   finally (fun () -> f (path, channel)) (fun () -> Unix.unlink path)
 
+let with_temp_file_of_content ?mode prefix suffix content f =
+  let@ temp_file, temp_out_ch = with_temp_file ?mode prefix suffix in
+  Xapi_stdext_pervasives.Pervasiveext.finally
+    (fun () -> output_string temp_out_ch content)
+    (fun () -> close_out temp_out_ch) ;
+  f temp_file
+
 let with_temp_out_ch_of_temp_file ?mode prefix suffix f =
   let@ path, channel = with_temp_file ?mode prefix suffix in
   f (path, channel |> with_temp_out_ch)
 
-let make_external_host_verified_rpc ~__context ext_host_address ext_host_cert
-    xml =
-  let@ temp_file, temp_out_ch = with_temp_file "external-host-cert" ".pem" in
-  Xapi_stdext_pervasives.Pervasiveext.finally
-    (fun () -> output_string temp_out_ch ext_host_cert)
-    (fun () -> close_out temp_out_ch) ;
+let make_external_host_verified_rpc ~__context host_address host_cert xml =
+  let@ cert_file =
+    with_temp_file_of_content "external-host-cert-" ".pem" host_cert
+  in
   make_remote_rpc ~__context
-    ~verify_cert:(Stunnel_client.external_host temp_file)
-    ext_host_address xml
+    ~verify_cert:(Stunnel_client.external_host cert_file)
+    host_address xml
 
 module FileSys : sig
   (* bash-like interface for manipulating files *)

--- a/ocaml/xapi/pool_periodic_update_sync.ml
+++ b/ocaml/xapi/pool_periodic_update_sync.ml
@@ -140,7 +140,8 @@ let rec update_sync () =
                 ignore
                   (Client.Pool.sync_updates ~rpc ~session_id
                      ~self:(Helpers.get_pool ~__context)
-                     ~force:false ~token:"" ~token_id:""
+                     ~force:false ~token:"" ~token_id:"" ~username:""
+                     ~password:""
                   )
               with e ->
                 let exc = Printexc.to_string e in

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -223,19 +223,22 @@ let sync ~__context ~self ~token ~token_id =
         ignore (Helpers.call_script cmd params)
       )
       (fun () ->
-        (* Rewrite repo conf file as initial content to remove credential related info,
-         * I.E. proxy username/password and temporary token file path.
+        (* Rewrite repo conf file as initial content to remove credential
+         * related info, I.E. proxy username/password and temporary token file
+         * path.
          *)
         write_initial_yum_config ()
       ) ;
-    (* The custom yum-utils will fully download repository metadata.*)
-    let repodata_dir =
+    (* The custom yum-utils will fully download repository metadata including
+     * the repo gpg signature.
+     *)
+    let repo_gpg_signature =
       !Xapi_globs.local_pool_repo_dir
       // repo_name
       // "repodata"
       // "repomd.xml.asc"
     in
-    Sys.file_exists repodata_dir
+    Sys.file_exists repo_gpg_signature
   with e ->
     error "Failed to sync with remote YUM repository: %s"
       (ExnHelper.string_of_exn e) ;

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -48,6 +48,8 @@ val sync :
   -> self:[`Repository] API.Ref.t
   -> token:string
   -> token_id:string
+  -> username:string
+  -> password:string
   -> bool
 
 val create_pool_repository :

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -231,17 +231,21 @@ let assert_gpgkey_path_is_valid path =
     raise Api_errors.(Server_error (invalid_gpgkey_path, [path]))
   )
 
-let assert_remote_pool_url_is_valid ~url =
+let get_remote_pool_coordinator_ip url =
   let uri = Uri.of_string url in
   match (Uri.scheme uri, Uri.host uri, Uri.path uri) with
   | Some "https", Some host, path
     when path = Constants.get_enabled_repository_uri
          && Helpers.is_valid_ip `ipv4or6 host ->
-      ()
+      host
   | _ ->
       error "Invalid url: %s, expected url format: %s" url
         ("https://<coordinator-ip>" ^ Constants.get_enabled_repository_uri) ;
       raise Api_errors.(Server_error (invalid_base_url, [url]))
+
+let assert_remote_pool_url_is_valid ~url =
+  get_remote_pool_coordinator_ip url
+  |> Xapi_stdext_pervasives.Pervasiveext.ignore_string
 
 let with_pool_repositories f =
   Xapi_stdext_pervasives.Pervasiveext.finally
@@ -1284,26 +1288,69 @@ let get_single_enabled_update_repository ~__context =
   in
   get_singleton enabled_update_repositories
 
-let with_access_token ~token ~token_id f =
-  match (token, token_id) with
-  | t, tid when t <> "" && tid <> "" ->
-      info "sync updates with token_id: %s" tid ;
-      let json = `Assoc [("token", `String t); ("token_id", `String tid)] in
-      let tmpfile, tmpch =
-        Filename.open_temp_file ~mode:[Open_text] "accesstoken" ".json"
-      in
-      Xapi_stdext_pervasives.Pervasiveext.finally
-        (fun () ->
-          output_string tmpch (Yojson.Basic.to_string json) ;
-          close_out tmpch ;
-          f (Some tmpfile)
-        )
-        (fun () -> Unixext.unlink_safe tmpfile)
-  | t, tid when t = "" && tid = "" ->
+type client_auth =
+  | CdnTokenAuth (* remote *) of {
+        token_id: string
+      ; token: string
+      ; plugin: string
+    }
+  | NoAuth (* bundle *)
+  | PoolExtHostAuth (* remote_pool *) of {xapi_token: string; plugin: string}
+
+let with_sync_client_auth auth f =
+  let go_with_client_plugin cred plugin =
+    let ( let@ ) g x = g x in
+    let@ temp_file =
+      Helpers.with_temp_file_of_content ~mode:[Open_text] "token-" ".json" cred
+    in
+    f (Some (temp_file, plugin))
+  in
+  match auth with
+  | CdnTokenAuth {token_id; token; _} when token_id = "" && token = "" ->
       f None
-  | _ ->
-      let msg = Printf.sprintf "%s: The token or token_id is empty" __LOC__ in
-      raise Api_errors.(Server_error (internal_error, [msg]))
+  | CdnTokenAuth {token_id; token; plugin} ->
+      let cred =
+        `Assoc [("token", `String token); ("token_id", `String token_id)]
+        |> Yojson.Basic.to_string
+      in
+      go_with_client_plugin cred plugin
+  | PoolExtHostAuth {xapi_token; plugin} ->
+      let cred =
+        `Assoc [("xapitoken", `String xapi_token)] |> Yojson.Basic.to_string
+      in
+      go_with_client_plugin cred plugin
+  | NoAuth ->
+      f None
+
+type server_auth =
+  | DefaultAuth (* remote *)
+  | NoAuth (* bundle *)
+  | StunnelClientProxyAuth (* remote_pool *) of {
+        cert: string
+      ; remote_addr: string
+      ; remote_port: int
+    }
+
+let with_sync_server_auth auth f =
+  match auth with
+  | DefaultAuth | NoAuth ->
+      f None
+  | StunnelClientProxyAuth {cert; remote_addr; remote_port} ->
+      let local_host = "127.0.0.1" in
+      let local_port = !Xapi_globs.local_yum_repo_port in
+      let ( let@ ) f x = f x in
+      let@ temp_file =
+        Helpers.with_temp_file_of_content "external-host-cert-" ".pem" cert
+      in
+      let binary_url =
+        Uri.make ~scheme:"http" ~host:local_host ~port:local_port
+          ~path:Constants.get_enabled_repository_uri ()
+        |> Uri.to_string
+      in
+      Stunnel.with_client_proxy
+        ~verify_cert:(Stunnel_client.external_host temp_file)
+        ~remote_host:remote_addr ~remote_port ~local_host ~local_port
+      @@ fun () -> f (Some binary_url)
 
 let prune_updateinfo_for_livepatches latest_lps updateinfo =
   let livepatches =

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -360,6 +360,8 @@ val sync_updates :
   -> force:bool
   -> token:string
   -> token_id:string
+  -> username:string
+  -> password:string
   -> string
 
 val check_update_readiness :

--- a/python3/dnf_plugins/ptoken.py
+++ b/python3/dnf_plugins/ptoken.py
@@ -24,6 +24,8 @@ class Ptoken(dnf.Plugin):
         for repo_name in self.base.repos:
             repo = self.base.repos[repo_name]
 
+            # Only include the ptoken for repos with a localhost URL, for added safety.
+            # These will be proxied to the coordinator through stunnel, set up by xapi.
             if len(repo.baseurl) > 0 and repo.baseurl[0].startswith("http://127.0.0.1") \
                 and repo.ptoken:
                 secret = "pool_secret=" + ptoken

--- a/python3/tests/test_dnf_plugins.py
+++ b/python3/tests/test_dnf_plugins.py
@@ -1,4 +1,4 @@
-"""Test module for dnf accesstoken"""
+"""Test module for dnf accesstoken, ptoken and xapitoken"""
 import unittest
 import sys
 import json
@@ -17,14 +17,16 @@ sys.modules["urlgrabber"] = MagicMock()
 
 accesstoken = import_file_as_module("python3/dnf_plugins/accesstoken.py")
 ptoken = import_file_as_module("python3/dnf_plugins/ptoken.py")
+xapitoken = import_file_as_module("python3/dnf_plugins/xapitoken.py")
 
 REPO_NAME = "testrepo"
 
 
-def _mock_repo(a_token=None, p_token=None, baseurl=None):
+def _mock_repo(a_token=None, p_token=None, xapi_token=None, baseurl=None):
     mock_repo = MagicMock()
     mock_repo.accesstoken = a_token
     mock_repo.ptoken = p_token
+    mock_repo.xapitoken = xapi_token
     mock_repo.baseurl = baseurl
     mock_base = MagicMock()
     mock_base.repos = {REPO_NAME: mock_repo}
@@ -103,3 +105,60 @@ class TestPtoken(unittest.TestCase):
         mock_repo = _mock_repo(p_token=False, baseurl=["http://127.0.0.1/some_local_path"])
         ptoken.Ptoken(mock_repo.base, MagicMock()).config()
         assert not  mock_repo.set_http_headers.called
+
+@patch("xapitoken.urlgrabber")
+class TestXapitoken(unittest.TestCase):
+    """Test class for xapitoken dnf plugin"""
+
+    def test_set_http_header_with_xapi_token(self, mock_grabber):
+        """test config succeed with xapitokan"""
+        mock_repo = _mock_repo(xapi_token="file:///mock_xapitoken_url",
+                               baseurl=["http://127.0.0.1/some_local_path"])
+        mock_grabber.urlopen.return_value.read.return_value = json.dumps({
+            "xapitoken": "valid_token",
+        })
+        xapitoken.XapiToken(mock_repo.base, MagicMock()).config()
+        mock_repo.set_http_headers.assert_called_with(
+            ['cookie:session_id=valid_token']
+        )
+
+    def test_repo_without_xapi_token(self, mock_grabber):
+        """If repo has not xapitoken, it should not be blocked"""
+        mock_repo = _mock_repo()
+        xapitoken.XapiToken(mock_repo.base, MagicMock()).config()
+        assert not mock_repo.set_http_headers.called
+
+    def test_ignore_invalid_token_url(self, mock_grabber):
+        """If repo provided an invalid token url, it should be ignored"""
+        mock_repo = _mock_repo(xapi_token="Not_existed")
+        xapitoken.XapiToken(mock_repo.base, MagicMock()).config()
+        assert not mock_repo.set_http_headers.called
+
+    def test_invalid_token_raise_exception(self, mock_grabber):
+        """Token with right json format, bad content should raise"""
+        mock_repo = _mock_repo(xapi_token="file:///file_contain_invalid_token",
+                               baseurl=["http://127.0.0.1/some_local_path"])
+        mock_grabber.urlopen.return_value.read.return_value = json.dumps({
+            "bad_token": "I am bad guy"
+        })
+        with self.assertRaises(xapitoken.InvalidToken):
+            xapitoken.XapiToken(mock_repo.base, MagicMock()).config()
+
+    def test_remote_repo_ignore_xapitoken(self, mock_grabber):
+        """non-local repo should just ignore the xapitoken"""
+        mock_repo = _mock_repo(xapi_token=True,
+                               baseurl=["http://some_remote_token/some_local_path"])
+        mock_grabber.urlopen.return_value.read.return_value = json.dumps({
+            "xapitoken": "valid_token",
+        })
+        xapitoken.XapiToken(mock_repo.base, MagicMock()).config()
+        assert not mock_repo.set_http_headers.called
+
+    def test_local_repo_does_not_enable_xapitoken_should_ignore_xapitoken(self, mock_grabber):
+        """local repo which has not enabled xapitoken should just ignore the xapitoken"""
+        mock_repo = _mock_repo(xapi_token=False, baseurl=["http://127.0.0.1/some_local_path"])
+        mock_grabber.urlopen.return_value.read.return_value = json.dumps({
+            "xapitoken": "valid_token",
+        })
+        xapitoken.XapiToken(mock_repo.base, MagicMock()).config()
+        assert not mock_repo.set_http_headers.called

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -143,6 +143,8 @@ install:
 # YUM plugins
 	$(IPROG) yum-plugins/accesstoken.py $(DESTDIR)$(YUMPLUGINDIR)
 	$(IDATA) yum-plugins/accesstoken.conf $(DESTDIR)$(YUMPLUGINCONFDIR)
+	$(IPROG) yum-plugins/xapitoken.py $(DESTDIR)$(YUMPLUGINDIR)
+	$(IDATA) yum-plugins/xapitoken.conf $(DESTDIR)$(YUMPLUGINCONFDIR)
 	$(IPROG) yum-plugins/ptoken.py $(DESTDIR)$(YUMPLUGINDIR)
 	$(IDATA) yum-plugins/ptoken.conf $(DESTDIR)$(YUMPLUGINCONFDIR)
 # maillanguages

--- a/scripts/yum-plugins/accesstoken.py
+++ b/scripts/yum-plugins/accesstoken.py
@@ -11,16 +11,16 @@
 # The content of the file referred by the <token-file-path> looks like:
 # { 'token': '...', 'token_id': '...' }
 
+import json
 from yum import config
 from yum.plugins import TYPE_CORE
-import json
 import urlgrabber
 
 
 requires_api_version = '2.5'
 plugin_type = (TYPE_CORE,)
 
-def config_hook(conduit):
+def config_hook(conduit):  # pylint: disable=unused-argument
     config.RepoConf.accesstoken = config.UrlOption()
 
 def init_hook(conduit):
@@ -35,11 +35,11 @@ def init_hook(conduit):
         try:
             token_str = urlgrabber.urlopen(token_url).read().strip()
             token = json.loads(token_str)
-        except:
+        except Exception:  #pylint: disable=broad-except
             continue
 
         if not (token['token'] and token['token_id']):
-            raise Exception("Invalid token or token_id")
+            raise Exception("Invalid token or token_id")  #pylint: disable=broad-exception-raised
 
         repo.http_headers['X-Access-Token'] = str(token['token'])
         repo.http_headers['Referer'] = str(token['token_id'])

--- a/scripts/yum-plugins/ptoken.py
+++ b/scripts/yum-plugins/ptoken.py
@@ -25,7 +25,7 @@ def init_hook(conduit):
     for name in repos.repos:
         repo = repos.repos[name]
         # Only include the ptoken for repos with a localhost URL, for added safety.
-        # These may be proxied to the coordinator through stunnel, set up by xapi.
+        # These will be proxied to the coordinator through stunnel, set up by xapi.
         if len(repo.baseurl) > 0 and repo.baseurl[0].startswith("http://127.0.0.1") \
             and repo.getConfigOption('ptoken'):
             repo.http_headers['cookie'] = "pool_secret=" + ptoken

--- a/scripts/yum-plugins/xapitoken.conf
+++ b/scripts/yum-plugins/xapitoken.conf
@@ -1,0 +1,2 @@
+[main]
+enabled=1

--- a/scripts/yum-plugins/xapitoken.py
+++ b/scripts/yum-plugins/xapitoken.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+# Drop this file into /usr/lib/yum-plugins/
+# Enable it by creating conf file /etc/yum/pluginconf.d/xapitoken.conf:
+#   [main]
+#   enabled=1
+#
+# Configure it by:
+# yum-config-manager --setopt=<repo-name>.xapitoken=file://<token-file-path> --save
+
+# The content of the file referred by the <token-file-path> looks like:
+# { 'xapitoken': '...' }
+
+import json
+from yum import config
+from yum.plugins import TYPE_CORE
+import urlgrabber
+
+
+requires_api_version = '2.5'
+plugin_type = (TYPE_CORE,)
+
+def config_hook(conduit):  # pylint: disable=unused-argument
+    config.RepoConf.xapitoken = config.UrlOption()
+
+def init_hook(conduit):
+    repos = conduit.getRepos()
+    for name in repos.repos:
+        repo = repos.repos[name]
+        token_url = repo.getConfigOption('xapitoken')
+        if not token_url or token_url == '':
+            continue
+
+        token = {}
+        try:
+            token_str = urlgrabber.urlopen(token_url).read().strip()
+            token = json.loads(token_str)
+        except Exception:  #pylint: disable=broad-except
+            continue
+
+        if not token['xapitoken']:
+            raise Exception("Invalid xapitoken")  #pylint: disable=broad-exception-raised
+
+        # Only include the xapitoken for repos with a localhost URL, for added safety.
+        # These will be proxied to the remote pool coordinator through stunnel, set up by xapi.
+        if len(repo.baseurl) > 0 and repo.baseurl[0].startswith("http://127.0.0.1") \
+            and repo.getConfigOption('xapitoken'):
+            repo.http_headers['cookie'] = "session_id=" + str(token['xapitoken'])


### PR DESCRIPTION
CP-50787 CP-51347: Support pool.sync_updates from remote_pool repo

When a remote_pool type repository, which points to the enabled
repository in the remote pool coordinator, is set as the enabled
repository of the pool, updates can be synced from it with API
pool.sync_updates.

The username password of the remote pool coordinator is required as
parameters for pool.sync_updates to login the remote pool.

And the remote pool coordinator's host server certificate needs to be
configured in the remote_pool repository, it will be used to verify the
remote end when sending out username passwords.

A new yum/dnf plugin "xapitoken" is introduced to set xapi token as HTTP
cookie: "session_id" for each HTTP request which downloads files from the
remote_pool repository.


CP-52245: Temp disable repo_gpgcheck when syncing from remote_pool repo

Will re-enable repo_gpgcheck after CP-51429 is done by reverting this
commit.

