### PR TITLE
Increase wait-init-complete timeout

### DIFF
--- a/scripts/xapi-wait-init-complete.service
+++ b/scripts/xapi-wait-init-complete.service
@@ -6,7 +6,7 @@ Before=xapi-init-complete.target
 
 [Service]
 Type=oneshot
-ExecStart=@OPTDIR@/bin/xapi-wait-init-complete 240
+ExecStart=@OPTDIR@/bin/xapi-wait-init-complete 300
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
When a host starts, the systemd service xapi-wait-init-complete waiting on the creation of the xapi init cookie file may fail on timeout for a matter of seconds. This patch adds 1 minute (300 seconds total) to the timeout passed to the script xapi-wait-init-complete.