### PR TITLE
CP-49078: Preprocess fields into a Hashtbl within get_record

### DIFF
--- a/ocaml/database/db_cache_types.ml
+++ b/ocaml/database/db_cache_types.ml
@@ -158,6 +158,7 @@ module Row = struct
     with Not_found -> raise (DBCache_NotFound ("missing field", key, ""))
 
   let add_defaults g (schema : Schema.Table.t) t =
+    let schema = Schema.Table.t'_of_t schema in
     List.fold_left
       (fun t c ->
         if not (mem c.Schema.Column.name t) then

--- a/ocaml/database/test_schemas.ml
+++ b/ocaml/database/test_schemas.ml
@@ -99,22 +99,35 @@ let schema =
     ; issetref= false
     }
   in
-  let vm_table =
-    {
-      Schema.Table.name= "VM"
-    ; columns=
-        [_ref; uuid; name_label; vbds; pp; name_description; tags; other_config]
-    ; persistent= true
-    }
+  let vm_table : Schema.Table.t =
+    Schema.Table.t_of_t'
+      {
+        Schema.Table.name= "VM"
+      ; columns=
+          [
+            _ref
+          ; uuid
+          ; name_label
+          ; vbds
+          ; pp
+          ; name_description
+          ; tags
+          ; other_config
+          ]
+      ; persistent= true
+      }
   in
   let vbd_table =
-    {
-      Schema.Table.name= "VBD"
-    ; columns= [_ref; uuid; vm; type']
-    ; persistent= true
-    }
+    Schema.Table.t_of_t'
+      {
+        Schema.Table.name= "VBD"
+      ; columns= [_ref; uuid; vm; type']
+      ; persistent= true
+      }
   in
-  let database = {Schema.Database.tables= [vm_table; vbd_table]} in
+  let database =
+    Schema.Database.t_of_t' {Schema.Database.tables= [vm_table; vbd_table]}
+  in
   let one_to_many =
     Schema.ForeignMap.add "VBD" [("VM", "VM", "VBDs")] Schema.ForeignMap.empty
   in
@@ -140,12 +153,16 @@ let many_to_many =
   in
   let foo_column = {bar_column with Schema.Column.name= "foos"} in
   let foo_table =
-    {Schema.Table.name= "foo"; columns= [bar_column]; persistent= true}
+    Schema.Table.t_of_t'
+      {Schema.Table.name= "foo"; columns= [bar_column]; persistent= true}
   in
   let bar_table =
-    {Schema.Table.name= "bar"; columns= [foo_column]; persistent= true}
+    Schema.Table.t_of_t'
+      {Schema.Table.name= "bar"; columns= [foo_column]; persistent= true}
   in
-  let database = {Schema.Database.tables= [foo_table; bar_table]} in
+  let database =
+    Schema.Database.t_of_t' {Schema.Database.tables= [foo_table; bar_table]}
+  in
   let many_to_many =
     Schema.ForeignMap.add "foo"
       [("bars", "bar", "foos")]

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -52,7 +52,7 @@ let prototyped_of_field = function
   | "VTPM", "persistence_backend" ->
       Some "22.26.0"
   | "SM", "host_pending_features" ->
-      Some "24.36.0-next"
+      Some "24.37.0"
   | "host", "last_update_hash" ->
       Some "24.10.0"
   | "host", "pending_guidances_full" ->

--- a/ocaml/idl/datamodel_schema.ml
+++ b/ocaml/idl/datamodel_schema.ml
@@ -85,14 +85,16 @@ let of_datamodel () =
   in
 
   let table obj =
-    {
-      Table.name= Escaping.escape_obj obj.Datamodel_types.name
-    ; columns=
-        _ref
-        :: List.map (column obj) (flatten_fields obj.Datamodel_types.contents [])
-    ; persistent=
-        obj.Datamodel_types.persist = Datamodel_types.PersistEverything
-    }
+    Table.t_of_t'
+      {
+        Table.name= Escaping.escape_obj obj.Datamodel_types.name
+      ; columns=
+          _ref
+          :: List.map (column obj)
+               (flatten_fields obj.Datamodel_types.contents [])
+      ; persistent=
+          obj.Datamodel_types.persist = Datamodel_types.PersistEverything
+      }
   in
   let is_one_to_many x =
     match Datamodel_utils.Relations.classify Datamodel.all_api x with
@@ -119,7 +121,8 @@ let of_datamodel () =
   in
 
   let database api =
-    {Database.tables= List.map table (Dm_api.objects_of_api api)}
+    let tables = List.map table (Dm_api.objects_of_api api) in
+    Database.of_tables tables
   in
   {
     major_vsn= Datamodel_common.schema_major_vsn


### PR DESCRIPTION
Flame graphs indicate that, under load created by parallel "xe vm-list" commands, the DB action get_record is hit often. This function constructs an API-level record by marshalling an association list that maps field names to unmarshalled string values. To do this, it serially queries all the field names using `List.assoc`. This has rather large cost in doing lexicographical string comparisons (`caml_compare` on string keys).

To avoid this, regardless of record size, we preprocess the association lists `__regular_fields` and `__set_refs` into a (string, string) Hashtbl.t and query that to construct each record field.

---

This benefit of this change is most notable for large records (such as `VM` and `pool`). The cost of the previously generated code, which does a bunch of serial `List.assoc` calls, incurs the quadratic cost of list traversal (compounded by the costly lexicographical comparison of strings during the search).

To produce measurements, I sampled xapi under a load of 500 consecutive `xe vm-list` invocations (using the same sampling rate with `perf`) on a host with a single VM.

Without the change, the `get_record` done internally by `xe vm-list` makes up for ~33.59% of the samples (33.59% = 1,592,782,255 samples). With the change, `get_record` accounts for ~7.56 of the samples (of which there are substantially fewer collected: 7.56% = 264,948,239). So the number of samples for `get_record` has dropped from 1,592,782,255 to 264,948,239 (assuming `perf`'s sampling is reliable).

You can see the visual difference in the flame graphs:

Before:
![{B1FEFF3A-AD91-478B-A828-89DCD19C2BEA}](https://github.com/user-attachments/assets/b7a4d504-3894-4f34-8dbe-b63de0e1d88c)

After:
![{CB28FFEC-944D-4F26-918A-FFB57E4875A3}](https://github.com/user-attachments/assets/fa517307-deb6-4a49-9a18-8217deb38734)


Of course, this is benefit as measured in aggregate (`perf` sampling), so quite a fast and loose comparison. In practice, the `xe vm-list` stress test goes from 7.4s to 6.2s (as `get_record` makes up only a small part of the work done for a single `xe vm-list`). 