### PR TITLE
opam: update vhd packages' opam metadata

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -464,16 +464,16 @@ This package provides an Lwt compatible interface to the library.")
   (homepage "https://github.com/mirage/ocaml-vhd")
   (source (github mirage/ocaml-vhd))
   (depends
-    (ocaml (and (>= "4.02.3") (< "5.0.0")))
+    (ocaml (>= "4.10.0"))
     (alcotest :with-test)
-    (alcotest-lwt :with-test)
-    bigarray-compat
-    (cstruct (< "6.1.0"))
+    (alcotest-lwt (and :with-test (>= "1.0.0")))
+    (bigarray-compat (>= "1.1.0"))
+    (cstruct (>= "6.0.0"))
     cstruct-lwt
     (fmt :with-test)
     (lwt (>= "3.2.0"))
-    (mirage-block (>= "2.0.1"))
-    rresult
+    (mirage-block (>= "3.0.0"))
+    (rresult (>= "0.7.0"))
     (vhd-format (= :version))
     (io-page (and :with-test (>= "2.4.0")))
   )

--- a/ocaml/xcp-rrdd/lib/transport/base/rrd_protocol_v1.ml
+++ b/ocaml/xcp-rrdd/lib/transport/base/rrd_protocol_v1.ml
@@ -106,15 +106,19 @@ let parse_payload ~(json : string) : payload =
 let make_payload_reader () =
   let last_checksum = ref "" in
   fun cs ->
-    let header = Cstruct.copy cs 0 header_bytes in
+    let header = Cstruct.to_string cs ~off:0 ~len:header_bytes in
     if header <> default_header then
       raise Invalid_header_string ;
-    let length =
-      let length_str = "0x" ^ Cstruct.copy cs length_start length_bytes in
+    let len =
+      let length_str =
+        "0x" ^ Cstruct.to_string cs ~off:length_start ~len:length_bytes
+      in
       try int_of_string length_str with _ -> raise Invalid_length
     in
-    let checksum = Cstruct.copy cs checksum_start checksum_bytes in
-    let payload_string = Cstruct.copy cs payload_start length in
+    let checksum =
+      Cstruct.to_string cs ~off:checksum_start ~len:checksum_bytes
+    in
+    let payload_string = Cstruct.to_string cs ~off:payload_start ~len in
     if payload_string |> Digest.string |> Digest.to_hex <> checksum then
       raise Invalid_checksum ;
     if checksum = !last_checksum then

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -17,16 +17,16 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "dune" {>= "3.15"}
-  "ocaml" {>= "4.02.3" & < "5.0.0"}
+  "ocaml" {>= "4.10.0"}
   "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
-  "bigarray-compat"
-  "cstruct" {< "6.1.0"}
+  "alcotest-lwt" {with-test & >= "1.0.0"}
+  "bigarray-compat" {>= "1.1.0"}
+  "cstruct" {>= "6.0.0"}
   "cstruct-lwt"
   "fmt" {with-test}
   "lwt" {>= "3.2.0"}
-  "mirage-block" {>= "2.0.1"}
-  "rresult"
+  "mirage-block" {>= "3.0.0"}
+  "rresult" {>= "0.7.0"}
   "vhd-format" {= version}
   "io-page" {with-test & >= "2.4.0"}
   "odoc" {with-doc}

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -3,12 +3,13 @@
 opam-version: "2.0"
 name: "vhd-format"
 synopsis: "Pure OCaml library to read/write VHD format data"
-description: """\
+description: """
 A pure OCaml library to read and write
 [vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
 simple command-line tool which allows vhd files to be interrogated,
 manipulated, format-converted and streamed to and from files and remote
-servers."""
+servers.
+"""
 maintainer: "dave@recoil.org"
 authors: ["Dave Scott" "Jon Ludlam"]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
@@ -17,15 +18,14 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
-  "bigarray-compat"
-  "cstruct" {>= "1.9" & < "6.1.0"}
-  "dune" {>= "3.15"}
+  "ocaml" {>= "4.10.0"}
+  "bigarray-compat" {>= "1.1.0"}
+  "cstruct" {>= "6.0.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
-  "uuidm" {>= "0.9.6"}
+  "uuidm" {>= "0.9.9"}
   "stdlib-shims"
-  "dune" {>= "1.0"}
+  "dune" {>= "2.8"}
   "ppx_cstruct" {build & >= "3.0.0"}
 ]
 available: os = "linux" | os = "macos"

--- a/vhd-format.opam.template
+++ b/vhd-format.opam.template
@@ -1,12 +1,13 @@
 opam-version: "2.0"
 name: "vhd-format"
 synopsis: "Pure OCaml library to read/write VHD format data"
-description: """\
+description: """
 A pure OCaml library to read and write
 [vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
 simple command-line tool which allows vhd files to be interrogated,
 manipulated, format-converted and streamed to and from files and remote
-servers."""
+servers.
+"""
 maintainer: "dave@recoil.org"
 authors: ["Dave Scott" "Jon Ludlam"]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
@@ -15,15 +16,14 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
-  "bigarray-compat"
-  "cstruct" {>= "1.9" & < "6.1.0"}
-  "dune" {>= "3.15"}
+  "ocaml" {>= "4.10.0"}
+  "bigarray-compat" {>= "1.1.0"}
+  "cstruct" {>= "6.0.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
-  "uuidm" {>= "0.9.6"}
+  "uuidm" {>= "0.9.9"}
   "stdlib-shims"
-  "dune" {>= "1.0"}
+  "dune" {>= "2.8"}
   "ppx_cstruct" {build & >= "3.0.0"}
 ]
 available: os = "linux" | os = "macos"


### PR DESCRIPTION
Sync the metadata with upstream, which is not updated

This fixes the CI issue due to cstruct version in xs-opam being incompatible with the one requested by the opam metadata in this repository