### PR TITLE
CP-51690: fix timeouts shorter than 10s in the periodic scheduler

### DIFF
--- a/ocaml/xapi/xapi_periodic_scheduler.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler.ml
@@ -80,7 +80,7 @@ let loop () =
     while true do
       let empty = with_lock lock (fun () -> Ipq.is_empty queue) in
       if empty then
-        Thread.delay 10.0
+        wait_next 10.0
       (* Doesn't happen often - the queue isn't usually empty *)
       else
         let next = with_lock lock (fun () -> Ipq.maximum queue) in


### PR DESCRIPTION
When XAPI's queue is empty the periodic scheduler would sleep for 10s, during which time newly added jobs would get ignored.

This is mostly noticeable during unit tests, but we cannot rely on the queue not being empty in production either.
It is better to wake up the scheduler on the soonest of these 2 events:
* after 10s
* when a new task gets added to the queue