### PR TITLE
CP-51693: introduce feature flag to use JSONRPC for internal pool communication

### DIFF
--- a/ocaml/tests/common/mock_rpc.ml
+++ b/ocaml/tests/common/mock_rpc.ml
@@ -25,7 +25,7 @@ let rpc __context call =
       Rpc.
         {
           success= true
-        ; contents= contents |> Xmlrpc.to_string |> Xmlrpc.of_string
+        ; contents= contents |> Jsonrpc.to_string |> Jsonrpc.of_string
         ; is_notification= false
         }
   | "VM.update_allowed_operations", [session_id_rpc; self_rpc] ->

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -395,7 +395,13 @@ let make_rpc ~__context rpc : Rpc.response =
   let subtask_of = Ref.string_of (Context.get_task_id __context) in
   let open Xmlrpc_client in
   let tracing = Context.set_client_span __context in
-  let http = xmlrpc ~subtask_of ~version:"1.1" "/" ~tracing in
+  let dorpc, path =
+    if !Xapi_globs.use_xmlrpc then
+      (XMLRPC_protocol.rpc, "/")
+    else
+      (JSONRPC_protocol.rpc, "/jsonrpc")
+  in
+  let http = xmlrpc ~subtask_of ~version:"1.1" path ~tracing in
   let transport =
     if Pool_role.is_master () then
       Unix Xapi_globs.unix_domain_socket
@@ -407,7 +413,7 @@ let make_rpc ~__context rpc : Rpc.response =
         , !Constants.https_port
         )
   in
-  XMLRPC_protocol.rpc ~srcstr:"xapi" ~dststr:"xapi" ~transport ~http rpc
+  dorpc ~srcstr:"xapi" ~dststr:"xapi" ~transport ~http rpc
 
 let make_timeboxed_rpc ~__context timeout rpc : Rpc.response =
   let subtask_of = Ref.string_of (Context.get_task_id __context) in

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1025,6 +1025,8 @@ let max_spans = ref 10000
 
 let max_traces = ref 10000
 
+let use_xmlrpc = ref true
+
 let compress_tracing_files = ref true
 
 let prefer_nbd_attach = ref false
@@ -1435,6 +1437,11 @@ let other_options =
     , Arg.Set allow_host_sched_gran_modification
     , (fun () -> string_of_bool !allow_host_sched_gran_modification)
     , "Allows to modify the host's scheduler granularity"
+    )
+  ; ( "use-xmlrpc"
+    , Arg.Set use_xmlrpc
+    , (fun () -> string_of_bool !use_xmlrpc)
+    , "Use XMLRPC (deprecated) for internal communication or JSONRPC"
     )
   ; ( "extauth_ad_backend"
     , Arg.Set_string extauth_ad_backend


### PR DESCRIPTION
XenCenter uses JSONRPC, and our SDK also prefers it.


Benchmarks have also shown that the OCaml implementation of xmlrpc is slower than jsonrpc.
In order of decreasing speed: CSexp > JsonRPC > Sexplib > XmlRPC

```
╭─────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                     │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├─────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  rpc/of_string/csexp    │          4190.9180 mjw/run│         10283.3264 mnw/run│          29749.2737 ns/run│
│  rpc/of_string/jsonrpc  │         16674.5459 mjw/run│          4635.7389 mnw/run│         170947.3848 ns/run│
│  rpc/of_string/sexplib  │         12146.0870 mjw/run│          9776.0204 mnw/run│         334001.4020 ns/run│
│  rpc/of_string/xmlrpc   │         13178.2650 mjw/run│        212605.8519 mnw/run│        1203750.1038 ns/run│
│  rpc/to_string/csexp    │          9367.3232 mjw/run│          4926.4732 mnw/run│          67864.9349 ns/run│
│  rpc/to_string/jsonrpc  │         20749.7349 mjw/run│          2884.7246 mnw/run│         170285.9229 ns/run│
│  rpc/to_string/sexplib  │         22109.0000 mjw/run│          4368.8197 mnw/run│         220765.0898 ns/run│
│  rpc/to_string/xmlrpc   │         15137.2038 mjw/run│           510.7853 mnw/run│         201271.8122 ns/run│
```

This PR just introduces a feature flag, but doesn't enable it yet (it can be enabled in xapi.conf, or by inheriting from this branch and flipping the boolean, which is what I've done to test it)