### PR TITLE
CP-51692: use Event.from instead of Event.next

### DIFF
--- a/ocaml/tests/bench/bench_throttle2.ml
+++ b/ocaml/tests/bench/bench_throttle2.ml
@@ -1,0 +1,86 @@
+open Bechamel
+
+let () =
+  Suite_init.harness_init () ;
+  Debug.set_level Syslog.Warning
+
+let __context, _ = Test_event_common.event_setup_common ()
+
+let allocate_tasks n =
+  ( __context
+  , Array.init n @@ fun i ->
+    let label = Printf.sprintf "task %d" i in
+    Xapi_task.create ~__context ~label ~description:"test task"
+  )
+
+let free_tasks (__context, tasks) =
+  let () =
+    tasks |> Array.iter @@ fun self -> Xapi_task.destroy ~__context ~self
+  in
+  ()
+
+let set_pending tasks =
+  tasks
+  |> Array.iter @@ fun self ->
+     Xapi_task.set_status ~__context ~self ~value:`pending
+
+let run_tasks _n (__context, tasks) =
+  set_pending tasks ;
+  let () =
+    tasks
+    |> Array.iter @@ fun self ->
+       Xapi_task.set_status ~__context ~self ~value:`success
+  in
+  tasks |> Array.iter @@ fun t -> Helpers.Task.wait_for ~__context ~tasks:[t]
+
+let run_tasks' _n (__context, tasks) =
+  set_pending tasks ;
+  let () =
+    tasks
+    |> Array.iter @@ fun self ->
+       Xapi_task.set_status ~__context ~self ~value:`success
+  in
+  Helpers.Task.wait_for ~__context ~tasks:(Array.to_list tasks)
+
+module D = Debug.Make (struct let name = __MODULE__ end)
+
+let run_tasks'' n (__context, tasks) =
+  set_pending tasks ;
+  let finished = Atomic.make 0 in
+  let (t : Thread.t) =
+    Thread.create
+      (fun () ->
+        for _ = 1 to 10 do
+          Thread.yield ()
+        done ;
+        tasks
+        |> Array.iter @@ fun self ->
+           Xapi_task.set_status ~__context ~self ~value:`success ;
+           Atomic.incr finished
+      )
+      ()
+  in
+  Helpers.Task.wait_for ~__context ~tasks:(Array.to_list tasks) ;
+  let f = Atomic.get finished in
+  assert (f = n || f = n - 1) ;
+  Thread.join t
+
+let benchmarks =
+  Test.make_grouped ~name:"Task latency"
+    [
+      Test.make_indexed_with_resource ~name:"task complete+wait latency"
+        ~args:[1; 10; 100] Test.multiple ~allocate:allocate_tasks
+        ~free:free_tasks (fun n -> Staged.stage (run_tasks n)
+      )
+    ; Test.make_indexed_with_resource ~name:"task complete+wait all latency"
+        ~args:[1; 10; 100] Test.multiple ~allocate:allocate_tasks
+        ~free:free_tasks (fun n -> Staged.stage (run_tasks' n)
+      )
+    ; Test.make_indexed_with_resource
+        ~name:"task complete+wait all latency (thread)" ~args:[1; 10; 100]
+        Test.multiple ~allocate:allocate_tasks ~free:free_tasks (fun n ->
+          Staged.stage (run_tasks'' n)
+      )
+    ]
+
+let () = Bechamel_simple_cli.cli benchmarks

--- a/ocaml/tests/bench/dune
+++ b/ocaml/tests/bench/dune
@@ -1,4 +1,4 @@
 (executables
-	(names bench_tracing bench_uuid)
-	(libraries tracing bechamel bechamel-notty notty.unix tracing_export threads.posix fmt notty uuid)
+	(names bench_tracing bench_uuid bench_throttle2)
+	(libraries tracing bechamel bechamel-notty notty.unix tracing_export threads.posix fmt notty uuid xapi_aux tests_common log xapi_internal)
 )

--- a/ocaml/xapi-cli-server/cli_util.ml
+++ b/ocaml/xapi-cli-server/cli_util.ml
@@ -42,21 +42,41 @@ exception Cli_failure of string
 
 (** call [callback task_record] on every update to the task, until it completes or fails *)
 let track callback rpc (session_id : API.ref_session) task =
-  let classes = ["task"] in
+  let use_event_next = !Constants.use_event_next in
+  let classes =
+    if use_event_next then
+      ["task"]
+    else
+      [Printf.sprintf "task/%s" (Ref.string_of task)]
+  in
   finally
     (fun () ->
       let finished = ref false in
       while not !finished do
-        Client.Event.register ~rpc ~session_id ~classes ;
+        if use_event_next then
+          Client.Event.register ~rpc ~session_id ~classes ;
         try
           (* Need to check once after registering to avoid a race *)
           finished :=
             Client.Task.get_status ~rpc ~session_id ~self:task <> `pending ;
+          let token = ref "" in
           while not !finished do
             let events =
-              Event_types.events_of_rpc (Client.Event.next ~rpc ~session_id)
+              if use_event_next then
+                let events =
+                  Event_types.events_of_rpc (Client.Event.next ~rpc ~session_id)
+                in
+                List.map Event_helper.record_of_event events
+              else
+                let event_from =
+                  Event_types.event_from_of_rpc
+                    (Client.Event.from ~rpc ~session_id ~classes ~token:!token
+                       ~timeout:30.
+                    )
+                in
+                token := event_from.token ;
+                List.map Event_helper.record_of_event event_from.events
             in
-            let events = List.map Event_helper.record_of_event events in
             List.iter
               (function
                 | Event_helper.Task (t, Some t_rec) when t = task ->

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -275,6 +275,9 @@ let owner_key = "owner"
 
 (* set in VBD other-config to indicate that clients can delete the attached VDI on VM uninstall if they want.. *)
 
+(* xapi-cli-server doesn't link xapi-globs *)
+let use_event_next = ref true
+
 (* the time taken to wait before restarting in a different mode for pool eject/join operations *)
 let fuse_time = ref 10.
 

--- a/ocaml/xapi/taskHelper.mli
+++ b/ocaml/xapi/taskHelper.mli
@@ -36,6 +36,9 @@ val set_result : __context:Context.t -> Rpc.t option -> unit
 
 val status_is_completed : [> `cancelled | `failure | `success] -> bool
 
+val status_to_string :
+  [< `pending | `success | `failure | `cancelling | `cancelled] -> string
+
 val complete : __context:Context.t -> Rpc.t option -> unit
 
 val set_cancellable : __context:Context.t -> unit

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1395,6 +1395,11 @@ let other_options =
     , (fun () -> string_of_bool !Db_globs.idempotent_map)
     , "True if the add_to_<map> API calls should be idempotent"
     )
+  ; ( "use-event-next"
+    , Arg.Set Constants.use_event_next
+    , (fun () -> string_of_bool !Constants.use_event_next)
+    , "Use deprecated Event.next instead of Event.from"
+    )
   ; ( "nvidia_multi_vgpu_enabled_driver_versions"
     , Arg.String
         (fun x ->


### PR DESCRIPTION
Event.next can lose events, and we try to encourage our API users to always use Event.from instead.

My understanding (which could be wrong) is that Event.from will give you the events since a given point in time (token), whereas Event.next only gives you even from when you called the API (missing events between API calls).

This PR introduces a feature flag that we can use to switch the interal users of Event.next to Event.from.
Doing so I've discovered a bug in ocaml-rpc, where `int32_of_rpc` doesn't accept Int32 as input, just Int.
There is a workaround here for now, but I intend to fix this upstream instead, hence the draft PR.