### PR TITLE
CP-52526: rate limit event updates

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -327,6 +327,7 @@
   (synopsis "The toolstack daemon which implements the XenAPI")
   (description "This daemon exposes the XenAPI and is used by clients such as 'xe' and 'XenCenter' to manage clusters of Xen-enabled hosts.")
   (depends
+    (ocaml (>= 4.09))
     (alcotest :with-test)
     angstrom
     astring

--- a/ocaml/xapi-aux/dune
+++ b/ocaml/xapi-aux/dune
@@ -3,6 +3,7 @@
   (modes best)
   (libraries
     astring
+    clock
     cstruct
     forkexec
     ipaddr

--- a/ocaml/xapi-aux/throttle.ml
+++ b/ocaml/xapi-aux/throttle.ml
@@ -56,25 +56,31 @@ module Batching = struct
     in
     {delay_initial; delay_before; delay_between}
 
+  let span_min a b = if Mtime.Span.is_shorter a ~than:b then a else b
+
   (** [perform_delay delay] calls {!val:Thread.delay} when [delay] is non-zero.
 
     Thread.delay 0 provides no fairness guarantees, the current thread may actually be the one that gets the global lock again.
     Instead {!val:Thread.yield} could be used, which does provide fairness guarantees, but it may also introduce large latencies
-    when there are lots of threads waiting for the OCaml runtime lock.
+    when there are lots of threads waiting for the OCaml runtime lock. Only invoke this once, in the [delay_before] section.
    *)
-  let perform_delay delay =
+  let perform_delay ~yield delay =
     if Mtime.Span.is_longer delay ~than:Mtime.Span.zero then
       Thread.delay (Clock.Timer.span_to_s delay)
-
-  let span_min a b = if Mtime.Span.is_shorter a ~than:b then a else b
+    else if yield then
+      (* this is a low-priority thread, if there are any other threads waiting, then run them now.
+         If there are no threads waiting then this a noop.
+         Requires OCaml >= 4.09 (older versions had fairness issues in Thread.yield)
+      *)
+      Thread.yield ()
 
   let with_recursive_loop config f =
     let rec self arg input =
       let arg = span_min config.delay_between Mtime.Span.(2 * arg) in
-      perform_delay arg ;
+      perform_delay ~yield:false arg ;
       (f [@tailcall]) (self arg) input
     in
-    let self0 arg input = (f [@tailcall]) (self arg) input in
-    perform_delay config.delay_before ;
-    f (self0 config.delay_initial)
+    let self0 input = (f [@tailcall]) (self config.delay_initial) input in
+    perform_delay ~yield:true config.delay_before ;
+    f self0
 end

--- a/ocaml/xapi-aux/throttle.ml
+++ b/ocaml/xapi-aux/throttle.ml
@@ -39,3 +39,27 @@ module Make (Size : SIZE) = struct
 
   let execute f = execute (get_semaphore ()) f
 end
+
+module Batching = struct
+  type t = {delay_before: Mtime.span; delay_between: Mtime.span}
+
+  let make ~delay_before ~delay_between = {delay_before; delay_between}
+
+  (** [perform_delay delay] calls {!val:Thread.delay} when [delay] is non-zero.
+
+    Thread.delay 0 provides no fairness guarantees, the current thread may actually be the one that gets the global lock again.
+    Instead {!val:Thread.yield} could be used, which does provide fairness guarantees, but it may also introduce large latencies
+    when there are lots of threads waiting for the OCaml runtime lock.
+   *)
+  let perform_delay delay =
+    if Mtime.Span.is_longer delay ~than:Mtime.Span.zero then
+      Thread.delay (Clock.Timer.span_to_s delay)
+
+  let with_recursive_loop config f arg =
+    let rec self arg =
+      perform_delay config.delay_between ;
+      (f [@tailcall]) self arg
+    in
+    perform_delay config.delay_before ;
+    f self arg
+end

--- a/ocaml/xapi-aux/throttle.mli
+++ b/ocaml/xapi-aux/throttle.mli
@@ -22,3 +22,33 @@ module Make (_ : SIZE) : sig
 
   val execute : (unit -> 'a) -> 'a
 end
+
+module Batching : sig
+  (** batching delay configuration *)
+  type t
+
+  val make : delay_before:Mtime.Span.t -> delay_between:Mtime.Span.t -> t
+  (** [make ~delay_before ~delay_between] creates a configuration,
+    where we delay the API call by [delay_before] once,
+    and then with [delay_between] between each recursive call.
+   *)
+
+  val with_recursive_loop : t -> (('a -> 'b) -> 'a -> 'b) -> 'a -> 'b
+  (** [with_recursive_loop config f arg] calls [f self arg], where [self] can be used
+    for recursive calls.
+
+    A [delay_before] amount of seconds is inserted once, and [delay_between] is inserted between recursive calls:
+    {v
+      delay_before
+      f ...
+        (self[@tailcall]) ...
+         delay_between
+         f ...
+          (self[@tailcall]) ...
+          delay_between
+          f ...
+     v}
+
+    The delays are determined by [config]
+   *)
+end

--- a/ocaml/xapi-aux/throttle.mli
+++ b/ocaml/xapi-aux/throttle.mli
@@ -37,18 +37,24 @@ module Batching : sig
   (** [with_recursive_loop config f arg] calls [f self arg], where [self] can be used
     for recursive calls.
 
-    A [delay_before] amount of seconds is inserted once, and [delay_between] is inserted between recursive calls:
+    [arg] is an argument that the implementation of [f] can change between recursive calls for its own purposes,
+    otherwise [()] can be used.
+
+    A [delay_before] amount of seconds is inserted once, and [delay_between/8] is inserted between recursive calls,
+    except the first one, and delays increase exponentially until [delay_between] is reached
     {v
       delay_before
       f ...
         (self[@tailcall]) ...
-         delay_between
          f ...
           (self[@tailcall]) ...
-          delay_between
+          delay_between/8
           f ...
+            (self[@tailcall]) ...
+            delay_between/4
+            f ...
      v}
 
-    The delays are determined by [config]
+    The delays are determined by [config], and [delay_between] uses an exponential backoff, up to [config.delay_between] delay.
    *)
 end

--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -497,11 +497,11 @@ let rec next ~__context =
   in
   (* Like grab_range () only guarantees to return a non-empty range by blocking if necessary *)
   let grab_nonempty_range =
-    Throttle.Batching.with_recursive_loop batching @@ fun self () ->
+    Throttle.Batching.with_recursive_loop batching @@ fun self arg ->
     let last_id, end_id = grab_range () in
     if last_id = end_id then
       let (_ : int64) = wait subscription end_id in
-      (self [@tailcall]) ()
+      (self [@tailcall]) arg
     else
       (last_id, end_id)
   in
@@ -608,7 +608,7 @@ let from_inner __context session subs from from_t timer batching =
   let msg_gen, messages, tableset, (creates, mods, deletes, last) =
     with_call session subs (fun sub ->
         let grab_nonempty_range =
-          Throttle.Batching.with_recursive_loop batching @@ fun self () ->
+          Throttle.Batching.with_recursive_loop batching @@ fun self arg ->
           let ( (msg_gen, messages, _tableset, (creates, mods, deletes, last))
                 as result
               ) =
@@ -627,7 +627,7 @@ let from_inner __context session subs from from_t timer batching =
             (* last id the client got is equivalent to the current one *)
             last_msg_gen := msg_gen ;
             wait2 sub last timer ;
-            (self [@tailcall]) ()
+            (self [@tailcall]) arg
           ) else
             result
         in

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1105,7 +1105,8 @@ let event_from_task_delay, event_from_task_entry =
     ~delay_between:Mtime.Span.(50 * ms)
 
 let event_next_delay, event_next_entry =
-  make_batching "event_next" ~delay_before:Mtime.Span.zero
+  make_batching "event_next"
+    ~delay_before:Mtime.Span.(200 * ms)
     ~delay_between:Mtime.Span.(50 * ms)
 
 let xapi_globs_spec =

--- a/xapi.opam
+++ b/xapi.opam
@@ -10,6 +10,7 @@ homepage: "https://xapi-project.github.io/"
 bug-reports: "https://github.com/xapi-project/xen-api/issues"
 depends: [
   "dune" {>= "3.15"}
+  "ocaml" {>= "4.09"}
   "alcotest" {with-test}
   "angstrom"
   "astring"


### PR DESCRIPTION
We generate O(N^2) events when we update O(N) fields: each field update generates an event including the entire object, even if later we are going to change other fields of the same object.

Instead of returning the individual field update events immediately (and generating a storm of events whenever an API client watcher for VM power events), we batch these event updates by introducing a minimum amount of time that successive Event.from need to have between them.
(The client is working as expected here: when it gets an event and processes it, it immediately calls Event.from to get more events)

Although this doesn't guarantee to eliminate the O(N^2) problem, in practice it reduces the overhead significantly.

There is one case where we do want almost immediately notification of updates: task completions (because then the client likely wants to send us more tasks).

This PR makes the already existing rate limiting in Xapi_event consistent and configurable, but doesn't yet introduce a batching delay for Event.from (it does for Event.next, which is deprecated). A separate PR (or config change) can then enable this for testing purposes, but also allows us to roll the change back by changing the tunable in the config file.

There is also a new microbenchmark introduced here, I'll need to update that with the latest results.