### PR TITLE
CP-52524: Generate an alert when various host kernel taints are set

### DIFF
--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -360,6 +360,12 @@ let host_internal_certificate_expiring_07 =
 
 let failed_login_attempts = addMessage "FAILED_LOGIN_ATTEMPTS" 3L
 
+let kernel_is_broken which =
+  addMessage ("HOST_KERNEL_ENCOUNTERED_ERROR_" ^ which) 2L
+
+let kernel_is_broken_warning which =
+  addMessage ("HOST_KERNEL_ENCOUNTERED_WARNING_" ^ which) 3L
+
 let tls_verification_emergency_disabled =
   addMessage "TLS_VERIFICATION_EMERGENCY_DISABLED" 3L
 

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -539,6 +539,8 @@ val set_numa_affinity_policy :
 
 val emergency_disable_tls_verification : __context:Context.t -> unit
 
+val alert_if_kernel_broken : __context:Context.t -> unit
+
 val alert_if_tls_verification_was_emergency_disabled :
   __context:Context.t -> unit
 

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -106,6 +106,13 @@ let register ~__context =
         (Xapi_periodic_scheduler.Periodic freq) freq
         Xapi_pool.alert_failed_login_attempts
   ) ;
+  Xapi_periodic_scheduler.add_to_queue "broken_kernel"
+    (Xapi_periodic_scheduler.Periodic 600.) 600. (fun () ->
+      Server_helpers.exec_with_new_task
+        "Periodic alert if the running kernel is broken in some serious way."
+        (fun __context -> Xapi_host.alert_if_kernel_broken ~__context
+      )
+  ) ;
   Xapi_periodic_scheduler.add_to_queue
     "Period alert if TLS verification emergency disabled"
     (Xapi_periodic_scheduler.Periodic 600.) 600. (fun () ->

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -835,12 +835,12 @@ let create_channels ~xc uuid domid =
 let numa_hierarchy =
   let open Xenctrlext in
   let open Topology in
-  Lazy.from_fun (fun () ->
-      let xcext = get_handle () in
-      let distances = (numainfo xcext).distances in
-      let cpu_to_node = cputopoinfo xcext |> Array.map (fun t -> t.node) in
-      NUMA.make ~distances ~cpu_to_node
-  )
+  lazy
+    (let xcext = get_handle () in
+     let distances = (numainfo xcext).distances in
+     let cpu_to_node = cputopoinfo xcext |> Array.map (fun t -> t.node) in
+     NUMA.make ~distances ~cpu_to_node
+    )
 
 let numa_mutex = Mutex.create ()
 

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,7 +3,7 @@
 set -e
 
 list-hd () {
-  N=294
+  N=293
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD List.hd usages"


### PR DESCRIPTION
Issue an alert about a broken host kernel if bits 4, 5, 7, 9, or 14 are set in
`/proc/sys/kernel/tainted`, indicating some kind of error was encountered and the
future behaviour of the kernel might not be predictable or safe anymore (though
it generally should reasonably recover).

Only one alert per tainted bit per boot should be issued.

Distinguish between Major (4,5,7 - these are all things that might cause a
host crash, but are unlikely to corrupt whatever data has been written out) and
Warning (9, 14 - might be a concern and could be raised to Support but usually
are not severe enough to crash the host) levels of errors as
suggested by the Foundations team.

This should serve as an indicator during issue investigation to look for the
cause of the taint.