### PR TITLE
Minimize xenstore accesses during domid-to-uuid lookups

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdp-netdev/rrdp_netdev.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-netdev/rrdp_netdev.ml
@@ -138,9 +138,16 @@ let generate_netdev_dss () =
   let uuid_of_domid domid =
     try
       Xenstore.with_xs (fun xs ->
-          let vm = xs.Xenstore.Xs.getdomainpath domid ^ "/vm" in
-          let vm_dir = xs.Xenstore.Xs.read vm in
-          xs.Xenstore.Xs.read (vm_dir ^ "/uuid")
+          let vm_uuid_path =
+            Printf.sprintf "/local/domain/%d/vm" domid
+            |> xs.Xenstore.Xs.read
+            |> String.split_on_char '/'
+          in
+          match vm_uuid_path with
+          | [_; _; uuid] ->
+              uuid
+          | _ ->
+              raise (Invalid_argument "Incorrect xenstore node")
       )
     with e ->
       fail "Failed to find uuid corresponding to domid: %d (%s)" domid

--- a/ocaml/xenopsd/xc/xenops_helpers.ml
+++ b/ocaml/xenopsd/xc/xenops_helpers.ml
@@ -28,12 +28,20 @@ exception Domain_not_found
 
 let uuid_of_domid ~xs domid =
   try
-    let vm = xs.Xs.getdomainpath domid ^ "/vm" in
-    let vm_dir = xs.Xs.read vm in
-    match Uuidx.of_string (xs.Xs.read (vm_dir ^ "/uuid")) with
-    | Some uuid ->
-        uuid
-    | None ->
+    let vm_uuid_path =
+      Printf.sprintf "/local/domain/%d/vm" domid
+      |> xs.Xs.read
+      |> String.split_on_char '/'
+    in
+    match vm_uuid_path with
+    | [_; _; uuid] -> (
+      match Uuidx.of_string uuid with
+      | Some uuid ->
+          uuid
+      | None ->
+          raise Domain_not_found
+    )
+    | _ ->
         raise Domain_not_found
   with _ -> raise Domain_not_found
 


### PR DESCRIPTION
Bake in assumptions that have been constant ever since xenstore was created: getdomainpath always returns "/local/domain/domid", /local/domain/domid/vm returns "/vm/uuid", so there's no need to look up that path to get the uuid again

This reduces the number of xenstore accesses from 3 to 1 with no functional change.

As suggested in: https://github.com/xapi-project/xen-api/pull/6068#pullrequestreview-2446644349