### PR TITLE
CA-402654: Partially revert 3e2e970af

### DIFF
--- a/ocaml/xapi/rbac.ml
+++ b/ocaml/xapi/rbac.ml
@@ -243,6 +243,12 @@ let assert_permission_name ~__context ~permission =
 let assert_permission ~__context ~permission =
   assert_permission_name ~__context ~permission:permission.role_name_label
 
+(* Populates assert_permission_fn on behalf of TaskHelper to
+   avoid a dependency cycle. *)
+let () =
+  if !TaskHelper.rbac_assert_permission_fn = None then
+    TaskHelper.rbac_assert_permission_fn := Some assert_permission
+
 let has_permission_name ~__context ~permission =
   let session_id = get_session_of_context ~__context ~permission in
   is_access_allowed ~__context ~session_id ~permission


### PR DESCRIPTION
A module binding appeared to be unused but was being evaluated for its effect alone. We reintroduce it here and don't bind a name.