### PR TITLE
CA-402263, xapi_sr_operatrions: don't include all API storage operations in all_ops

### DIFF
--- a/ocaml/xapi/xapi_sr_operations.ml
+++ b/ocaml/xapi/xapi_sr_operations.ml
@@ -26,7 +26,32 @@ open Client
 
 open Record_util
 
-let all_ops = API.storage_operations__all
+(* This is a subset of the API enumeration. Not all values can be included
+   because older versions which don't have them are unable to migrate VMs to the
+   the versions that have new fields in allowed operations *)
+let all_ops : API.storage_operations_set =
+  [
+    `scan
+  ; `destroy
+  ; `forget
+  ; `plug
+  ; `unplug
+  ; `vdi_create
+  ; `vdi_destroy
+  ; `vdi_resize
+  ; `vdi_clone
+  ; `vdi_snapshot
+  ; `vdi_mirror
+  ; `vdi_enable_cbt
+  ; `vdi_disable_cbt
+  ; `vdi_data_destroy
+  ; `vdi_list_changed_blocks
+  ; `vdi_set_on_boot
+  ; `vdi_introduce
+  ; `update
+  ; `pbd_create
+  ; `pbd_destroy
+  ]
 
 (* This list comes from https://github.com/xenserver/xen-api/blob/tampa-bugfix/ocaml/xapi/xapi_sr_operations.ml#L36-L38 *)
 let all_rpu_ops : API.storage_operations_set =


### PR DESCRIPTION
Otherwise the allowed_operations field in SRs can contain newly added operations, which can break cross-pool migrations when using `xe`. This regression was introduced by e40b3fc95601abd99d16e2c405c1878467f446f7

Partially reverts 723a4983ab1555b24222b417350cddebbf6dc1f5

I've manually tested the migration from a host with xapi 24.36.0 to a host with xapi 24.37.0.23.g2e1274d56 ([this patch](https://github.com/xapi-project/xen-api/commit/2e1274d567b38a4adbc0edae85bb6be2bf0d046d) on top of master)
```
# xe vm-migrate uuid=7ab2ad94-7d09-1fd5-b49a-19880a0908fc remote-master=10.73.82.91 remote-username=root remote-password=(...) host=xseu-41-03 vif:c07b60e0-1019-99d0-5680-03bdfcc33db5=1aa3b953-21a8-79fd-35b6-337d556336cb
Performing a storage live migration. Your VM's VDIs will be migrated with the VM.
Will migrate to remote host: xseu-41-03, using remote network: Pool-wide network associated with eth0. Here is the VDI mapping:
VDI 9bffe7a3-410e-4e65-82f1-1db6794c18c2 -> SR 17df852a-9463-a591-6196-5f4af08bc888
```