### PR TITLE
CP-51429 Avoid redundant processing when full metadata already exists during sync_updates

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -25,6 +25,8 @@ module Pkgs = (val Pkg_mgr.get_pkg_mgr)
 
 let capacity_in_parallel = 16
 
+let ( // ) = Filename.concat
+
 (* The cache below is protected by pool's current_operations locking mechanism *)
 let updates_in_cache : (API.ref_host, Yojson.Basic.t) Hashtbl.t =
   Hashtbl.create 64
@@ -201,7 +203,15 @@ let sync ~__context ~self ~token ~token_id =
          * I.E. proxy username/password and temporary token file path.
          *)
         write_initial_yum_config ()
-      )
+      ) ;
+    (* The custom yum-utils will fully download repository metadata.*)
+    let repodata_dir =
+      !Xapi_globs.local_pool_repo_dir
+      // repo_name
+      // "repodata"
+      // "repomd.xml.asc"
+    in
+    Sys.file_exists repodata_dir
   with e ->
     error "Failed to sync with remote YUM repository: %s"
       (ExnHelper.string_of_exn e) ;

--- a/ocaml/xapi/repository.mli
+++ b/ocaml/xapi/repository.mli
@@ -40,7 +40,7 @@ val sync :
   -> self:[`Repository] API.Ref.t
   -> token:string
   -> token_id:string
-  -> unit
+  -> bool
 
 val create_pool_repository :
   __context:Context.t -> self:[`Repository] API.Ref.t -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3534,10 +3534,10 @@ let sync_repos ~__context ~self ~repos ~force ~token ~token_id =
   repos
   |> List.iter (fun repo ->
          if force then cleanup_pool_repo ~__context ~self:repo ;
-         sync ~__context ~self:repo ~token ~token_id ;
-         (* Dnf sync all the metadata including updateinfo,
+         let complete = sync ~__context ~self:repo ~token ~token_id in
+         (* Dnf and custom yum-utils sync all the metadata including updateinfo,
           * Thus no need to re-create pool repository *)
-         if Pkgs.manager = Yum then
+         if Pkgs.manager = Yum && complete = false then
            create_pool_repository ~__context ~self:repo
      ) ;
   let checksum = set_available_updates ~__context in


### PR DESCRIPTION
The new version of yum-utils introduced to xenserver enhances the --download-metadata functionality to align with **dnf reposync** (refer to: https://dnf-plugins-core.readthedocs.io/en/latest/reposync.html) by fully downloading repository metadata. 
Consequently, _create_pool_repository_ is no longer required. 
The PR introduces a check to verify whether the **repodata** already exists before proceeding to create repository metadata.