### PR TITLE
cleaning: removes redundant api call to `Pool.get_all`

### DIFF
--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -655,10 +655,6 @@ let login_no_password_common ~__context ~uname ~originator ~host ~pool
       )
   in
   Rbac_audit.session_create ~__context ~session_id ~uname ;
-  (* At this point, the session is created, but with an incorrect time *)
-  (* Force the time to be updated by calling an API function with this session *)
-  let rpc = Helpers.make_rpc ~__context in
-  ignore (Client.Pool.get_all ~rpc ~session_id) ;
   session_id
 
 (* XXX: only used internally by the code which grants the guest access to the API.


### PR DESCRIPTION
With the changes made here, 3ba6e6df2b321c0ff8323155532c84f325340208, calling `Pool.get_all` no longer updates the `last_active` field unless 10 minutes have elapsed since session creation. Therefore, this call should be redundant now. 

Passes BVT + BST: 208579 (Dev Run) (except one sequence that hasn't been scheduled)