### PR TITLE
CA-388210: SMAPIv3 concurrency: turn on concurrent operations by default

### DIFF
--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1793,7 +1793,7 @@ let rec diff a b =
 
 (* default false due to bugs in SMAPIv3 plugins,
    once they are fixed this should be set to true *)
-let concurrent = ref false
+let concurrent = ref true
 
 type reload = All | Files of string list | Nothing
 

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1791,8 +1791,6 @@ let rec diff a b =
   | a :: aa ->
       if List.mem a b then diff aa b else a :: diff aa b
 
-(* default false due to bugs in SMAPIv3 plugins,
-   once they are fixed this should be set to true *)
 let concurrent = ref true
 
 type reload = All | Files of string list | Nothing


### PR DESCRIPTION
It is believed that the deadlocks in SMAPIv3 were caused by VDI.copy operations that attach the same disk RO multiple times in Dom0.
With the previous commits we now use a unique identifier and spawn a separate qemu-dp process in the SMAPIv3 plugins, which should prevent the deadlocks and IO errors due to lack of refcounting.

We have also identified the source of deadlocks in xapi-storage-plugins, as a missing _qmp_disconnect, so it should now be safe to enable this by default.