### PR TITLE
CP-49133: Use a worker pool for handling requests

### DIFF
--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -654,7 +654,7 @@ type socket = Unix.file_descr * string
 
 (* Start an HTTP server on a new socket *)
 let start ?header_read_timeout ?header_total_timeout ?max_header_length
-    ~conn_limit (x : 'a Server.t) (socket, name) =
+    ?worker_pool_size ~conn_limit (x : 'a Server.t) (socket, name) =
   let handler =
     {
       Server_io.name
@@ -664,7 +664,7 @@ let start ?header_read_timeout ?header_total_timeout ?max_header_length
     ; lock= Semaphore.Counting.make conn_limit
     }
   in
-  let server = Server_io.server handler socket in
+  let server = Server_io.server ?worker_pool_size handler socket in
   Hashtbl.add socket_table socket server
 
 exception Socket_not_found

--- a/ocaml/libs/http-lib/http_svr.mli
+++ b/ocaml/libs/http-lib/http_svr.mli
@@ -61,6 +61,7 @@ val start :
      ?header_read_timeout:float
   -> ?header_total_timeout:float
   -> ?max_header_length:int
+  -> ?worker_pool_size:int
   -> conn_limit:int
   -> 'a Server.t
   -> socket

--- a/ocaml/libs/http-lib/server_io.mli
+++ b/ocaml/libs/http-lib/server_io.mli
@@ -23,5 +23,5 @@ type server = {
     shutdown: unit -> unit  (** clean shutdown, blocks until thread has gone *)
 }
 
-val server : handler -> Unix.file_descr -> server
+val server : ?worker_pool_size:int -> handler -> Unix.file_descr -> server
 (** Creates a server given a bound socket and a handler *)

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -854,12 +854,10 @@ let listen_unix_socket sock_path =
   (* Always listen on the Unix domain socket first *)
   Unixext.mkdir_safe (Filename.dirname sock_path) 0o700 ;
   Unixext.unlink_safe sock_path ;
+  let conn_limit = !Xapi_globs.conn_limit_unix in
+  let worker_pool_size = !Xapi_globs.request_worker_pool_size in
   let domain_sock = Xapi_http.bind (Unix.ADDR_UNIX sock_path) in
-  ignore
-    (Http_svr.start
-       ~conn_limit:!Xapi_globs.conn_limit_unix
-       Xapi_http.server domain_sock
-    )
+  Http_svr.start ~conn_limit ~worker_pool_size Xapi_http.server domain_sock
 
 let set_stunnel_timeout () =
   try

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1011,6 +1011,8 @@ let header_total_timeout_tcp = ref 60.
 let max_header_length_tcp = ref 1024
 (* Maximum accepted size of HTTP headers in bytes (on TCP only) *)
 
+let request_worker_pool_size = ref 0
+
 let conn_limit_tcp = ref 800
 
 let conn_limit_unix = ref 1024
@@ -1613,6 +1615,11 @@ let other_options =
     , Arg.Set disable_webserver
     , (fun () -> string_of_bool !disable_webserver)
     , "Disable the host webserver"
+    )
+  ; ( "request-worker-pool-size"
+    , Arg.Set_int request_worker_pool_size
+    , (fun () -> string_of_int !request_worker_pool_size)
+    , "Specify size of worker pool servicing xapi requests, must be non-zero."
     )
   ]
 


### PR DESCRIPTION
Instead of creating a new thread for each request, enqueue tasks for a pool of dedicated worker threads to process. To avoid delaying (and deadlocking, in the case of a task that calls back into xapi), we fallback to spawning a new thread if the task queue cannot be accessed immediately. In practice, we found that under a reasonable load, every request was handled by the pool (of size 16).

You can specify an integer [0-16] for the worker pool size via the "request-worker-pool-size" option in xapi.conf.

---

## Measurements

Comparing `master` against `private/cbarr/worker-pool`, we measure the time taken by a combined `xe vm-start uuid=$VM && xe vm-shutdown --force uuid=$VM`. We test this for both a loaded and unloaded workload, where "loaded" is the usual 10 parallel `xe vm-list` stress test. 

| Case                    | Run 1  | Run 2  | Run 3  | Run 4  | Run 5  | Avg    |
|-------------------------|--------|--------|--------|--------|--------|--------|
| master (unloaded)       | 11.466 | 11.562 | 11.596 | 11.436 | 11.760 | 11.564 |
| master (loaded)         | 16.123 | 15.750 | 15.686 | 15.552 | 17.241 | 16.070 |
| worker-pools (unloaded) | 10.456 | 10.259 | 10.211 | 10.201 | 10.189 | 10.263 |
| worker-pools (loaded)   | 12.903 | 11.901 | 12.403 | 12.626 | 12.375 | 12.441 |

Using the worker pool benefits the unloaded case in a ~11.25% reduction in time taken for the VM start and shutdown sequence. In the loaded case, the worker pool improves the situation by ~22.58%.