### PR TITLE
xapi-stdext-threads: use mtime.clock.os

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/dune
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/dune
@@ -13,7 +13,7 @@
   (public_name xapi-stdext-threads.scheduler)
   (name xapi_stdext_threads_scheduler)
   (modules ipq scheduler)
-  (libraries mtime mtime.clock threads.posix unix xapi-log xapi-stdext-threads)
+  (libraries mtime mtime.clock.os threads.posix unix xapi-log xapi-stdext-threads)
 )
 
 (tests


### PR DESCRIPTION
mtime.clock is not yet available on the xs-opam available when building xenserver