### PR TITLE
CA-388564: move qemu-dm to vm.slice

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -47,7 +47,7 @@ xenstore = xs.xs()
 #  - 'system.slice' means move it into the system slice, etc.
 # If the nominated slice does not already exist, the process will be
 # left in its parent's slice.
-cgroup_slice = ''
+cgroup_slice = 'vm.slice'
 
 CLONE_NEWNS = 0x00020000 # mount namespace
 CLONE_NEWNET = 0x40000000 # network namespace


### PR DESCRIPTION
This is a single line change to move qemu to the proper cgroup.

Qemu moves itself to the root cgroup, which makes it a sibling of control.slice. All toolstack processes are in control.slice, and even though control.slice gets 10x share of CPU, if we have 1000 qemu processes there is still a big imbalance (toolstack gets 10/1010 share of the CPU)

Qemu-wrapper already has the ability to move the process to another cgroup, so use it. tapdisk and qemu-datapath are already in vm.slice, so move qemu-dm there too.

Checked that qemu ends up in the correct slice:
```
cat /proc/$(pgrep qemu-dm\*|head -n1)/cgroup
8:memory:/vm.slice
7:blkio:/vm.slice
6:net_cls,net_prio:/
5:freezer:/
4:cpu,cpuacct:/vm.slice
3:cpuset:/
2:devices:/
1:name=systemd:/vm.slice/qemu-datapath@199.service
```

Tested with a script that control.slice and vm.slice are indeed properly limiting CPU usage, and control.slice gets the expected share of CPU even when vm.slice has a lot more processes:
```
#!/bin/bash
set -eu

# $$ is the pid of the main shell
# Need to use $BASHPID to get pid of subshell

for SLICE in system.slice control.slice vm.slice; do
	for i in $(seq 1 16); do
		(echo $BASHPID >/sys/fs/cgroup/cpu,cpuacct/${SLICE}/tasks; while true; do echo -n; done)&
	done
done

for i in $(seq 17 1000); do
	(echo $BASHPID >/sys/fs/cgroup/cpu,cpuacct/vm.slice/tasks; while true; do echo -n; done)&
done
```

```
329178 root      20   0  113216    216     16 R  92.4  0.0   0:07.50 bash
 329171 root      20   0  113216    216     16 R  84.4  0.0   0:07.05 bash
 329177 root      20   0  113216    216     16 R  84.4  0.0   0:06.97 bash
 329170 root      20   0  113216    216     16 R  84.1  0.0   0:06.65 bash
 329180 root      20   0  113216    216     16 R  84.1  0.0   0:06.94 bash
 329183 root      20   0  113216    220     16 R  81.8  0.0   0:06.93 bash
 329174 root      20   0  113216    216     16 R  80.6  0.0   0:06.90 bash
 329181 root      20   0  113216    216     16 R  79.9  0.0   0:07.13 bash
 329179 root      20   0  113216    216     16 R  79.3  0.0   0:06.78 bash
 329184 root      20   0  113216    220     16 R  79.3  0.0   0:06.55 bash
 329175 root      20   0  113216    216     16 R  79.0  0.0   0:06.87 bash
 329172 root      20   0  113216    216     16 R  78.7  0.0   0:07.29 bash
 329173 root      20   0  113216    216     16 R  78.7  0.0   0:06.86 bash
 329169 root      20   0  113216    216     16 R  77.4  0.0   0:07.04 bash
 329182 root      20   0  113216    220     16 R  76.4  0.0   0:06.75 bash
 329176 root      20   0  113216    216     16 R  76.1  0.0   0:06.76 bash
 329152 root      20   0  113216    212     16 R  11.1  0.0   0:00.83 bash
 329155 root      20   0  113216    212     16 R   9.9  0.0   0:00.87 bash
 329160 root      20   0  113216    212     16 R   8.6  0.0   0:00.70 bash
 329161 root      20   0  113216    212     16 R   8.3  0.0   0:00.71 bash
 329156 root      20   0  113216    212     16 R   8.0  0.0   0:00.66 bash
 329158 root      20   0  113216    212     16 R   8.0  0.0   0:00.66 bash
 329163 root      20   0  113216    212     16 R   8.0  0.0   0:00.88 bash
 329154 root      20   0  113216    212     16 R   7.6  0.0   0:00.66 bash
 329159 root      20   0  113216    212     16 R   7.6  0.0   0:00.67 bash
 329164 root      20   0  113216    212     16 R   7.6  0.0   0:00.68 bash
 329165 root      20   0  113216    212     16 R   7.6  0.0   0:00.79 bash
 329166 root      20   0  113216    216     16 R   7.6  0.0   0:00.65 bash
 329153 root      20   0  113216    212     16 R   7.3  0.0   0:00.67 bash
 329157 root      20   0  113216    212     16 R   7.3  0.0   0:00.73 bash
 329162 root      20   0  113216    212     16 R   7.3  0.0   0:00.64 bash
 329167 root      20   0  113216    216     16 R   7.3  0.0   0:00.64 bash
```

And verifying some of the high CPU usage `bash` processes vs some of the low ones: the high ones are in `control.slice`, the low ones are in other slices.
