### PR TITLE
Xapi thread classification - part 2

### DIFF
--- a/ocaml/libs/tgroup/dune
+++ b/ocaml/libs/tgroup/dune
@@ -1,4 +1,11 @@
 (library
  (name tgroup)
+ (modules tgroup)
  (public_name tgroup)
  (libraries xapi-log xapi-stdext-unix xapi-stdext-std))
+
+(test
+ (name test_tgroup)
+ (modules test_tgroup)
+ (package tgroup)
+ (libraries tgroup alcotest xapi-log))

--- a/ocaml/libs/tgroup/dune
+++ b/ocaml/libs/tgroup/dune
@@ -1,4 +1,4 @@
 (library
  (name tgroup)
  (public_name tgroup)
- (libraries xapi-log xapi-stdext-unix))
+ (libraries xapi-log xapi-stdext-unix xapi-stdext-std))

--- a/ocaml/libs/tgroup/test_tgroup.ml
+++ b/ocaml/libs/tgroup/test_tgroup.ml
@@ -1,0 +1,83 @@
+module D = Debug.Make (struct let name = __MODULE__ end)
+
+let test_identity () =
+  let specs =
+    [
+      ((Some "XenCenter2024", "u1000"), "u1000/XenCenter2024")
+    ; ((None, "u1001"), "u1001")
+    ; ((None, "Special!@#"), "Special")
+    ; ((Some "With-Hyphen", "123"), "123/WithHyphen")
+    ; ((Some "", ""), "root")
+    ; ((Some " Xen Center 2024 ", ", u 1000 "), "u1000/XenCenter2024")
+    ; ((Some "Xen Center ,/@.~# 2024", "root"), "root/XenCenter2024")
+    ; ((Some "XenCenter 2024.3.18", ""), "root/XenCenter2024318")
+    ; ((Some "", "S-R-X-Y1-Y2-Yn-1-Yn"), "SRXY1Y2Yn1Yn")
+    ; ( (Some "XenCenter2024", "S-R-X-Y1-Y2-Yn-1-Yn")
+      , "SRXY1Y2Yn1Yn/XenCenter2024"
+      )
+    ]
+  in
+
+  let test_make ((user_agent, subject_sid), expected_identity) =
+    let actual_identity =
+      Tgroup.Group.Identity.(make ?user_agent subject_sid |> to_string)
+    in
+    Alcotest.(check string)
+      "Check expected identity" expected_identity actual_identity
+  in
+  List.iter test_make specs
+
+let test_of_creator () =
+  let dummy_identity =
+    Tgroup.Group.Identity.make ~user_agent:"XenCenter2024" "root"
+  in
+  let specs =
+    [
+      ((None, None, None, None), "external/unauthenticated")
+    ; ((Some true, None, None, None), "external/intrapool")
+    ; ( ( Some true
+        , Some Tgroup.Group.Endpoint.External
+        , Some dummy_identity
+        , Some "sm"
+        )
+      , "external/intrapool"
+      )
+    ; ( ( Some true
+        , Some Tgroup.Group.Endpoint.Internal
+        , Some dummy_identity
+        , Some "sm"
+        )
+      , "external/intrapool"
+      )
+    ; ( ( None
+        , Some Tgroup.Group.Endpoint.Internal
+        , Some dummy_identity
+        , Some "cli"
+        )
+      , "internal/cli"
+      )
+    ; ( (None, None, Some dummy_identity, Some "sm")
+      , "external/authenticated/root/XenCenter2024"
+      )
+    ]
+  in
+  let test_make ((intrapool, endpoint, identity, originator), expected_group) =
+    let originator = Option.map Tgroup.Group.Originator.of_string originator in
+    let actual_group =
+      Tgroup.Group.(
+        Creator.make ?intrapool ?endpoint ?identity ?originator ()
+        |> of_creator
+        |> to_string
+      )
+    in
+    Alcotest.(check string) "Check expected group" expected_group actual_group
+  in
+  List.iter test_make specs
+
+let tests =
+  [
+    ("identity make", `Quick, test_identity)
+  ; ("group of creator", `Quick, test_of_creator)
+  ]
+
+let () = Alcotest.run "Tgroup library" [("Thread classification", tests)]

--- a/ocaml/libs/tgroup/tgroup.mli
+++ b/ocaml/libs/tgroup/tgroup.mli
@@ -16,21 +16,38 @@
     threads.*)
 module Group : sig
   (** Abstract type that represents a group of execution threads in xapi. Each
-  group corresponds to a Creator, and has a designated level of priority.*)
+      group corresponds to a Creator, and has a designated level of priority.*)
   type t
+
+  (** Data structures that represents the identity  *)
+  module Identity : sig
+    type t
+
+    val root_identity : t
+
+    val make : ?user_agent:string -> string -> t
+
+    val to_string : t -> string
+  end
 
   (** Generic representation of different xapi threads originators. *)
   module Originator : sig
     (** Type that represents different originators of xapi threads. *)
-    type t = Internal_Host_SM | EXTERNAL
+    type t = Internal_SM | Internal_CLI | External
 
     val of_string : string -> t
     (** [of_string s] creates an originator from a string [s].
-    
-    e.g create an originator based on a http header. *)
+        
+        e.g create an originator based on a http header. *)
 
     val to_string : t -> string
     (** [to_string o] converts an originator [o] to its string representation.*)
+  end
+
+  (** Generic representation of different xapi threads origin endpoints. *)
+  module Endpoint : sig
+    (** Type that represents different origin endpoints of xapi threads. *)
+    type t = Internal | External
   end
 
   (** Generic representation of different xapi threads creators. *)
@@ -38,7 +55,13 @@ module Group : sig
     (** Abstract type that represents different creators of xapi threads.*)
     type t
 
-    val make : ?user:string -> ?endpoint:string -> Originator.t -> t
+    val make :
+         ?intrapool:bool
+      -> ?endpoint:Endpoint.t
+      -> ?identity:Identity.t
+      -> ?originator:Originator.t
+      -> unit
+      -> t
     (** [make o] creates a creator type based on a given originator [o].*)
 
     val to_string : t -> string
@@ -50,29 +73,35 @@ module Group : sig
 
   val of_creator : Creator.t -> t
   (** [of_creator c] returns the corresponding group based on the creator [c].*)
+
+  val to_string : t -> string
+  (** [to_string g] returns the string representation of the group [g].*)
 end
 
 (** [Cgroup] module encapsulates different function for managing the cgroups
-corresponding with [Groups].*)
+    corresponding with [Groups].*)
 module Cgroup : sig
   (** Represents one of the children of the cgroup directory.*)
   type t = string
 
   val dir_of : Group.t -> t option
   (** [dir_of group] returns the full path of the cgroup directory corresponding
-      to the group [group] as [Some dir].
-      
-      Returns [None] if [init dir] has not been called. *)
+          to the group [group] as [Some dir].
+          
+          Returns [None] if [init dir] has not been called. *)
 
   val init : string -> unit
   (** [init dir] initializes the hierachy of cgroups associated to all [Group.t]
-      types under the directory [dir].*)
+          types under the directory [dir].*)
 
   val set_cgroup : Group.Creator.t -> unit
   (** [set_cgroup c] sets the current xapi thread in a cgroup based on the
-      creator [c].*)
+          creator [c].*)
 end
 
+val of_creator : Group.Creator.t -> unit
+(** [of_creator g] classifies the current thread based based on the creator [c].*)
+
 val of_req_originator : string option -> unit
-(** [of_req_originator o] same as [of_originator] but it classifies based on the
-http request header.*)
+(** [of_req_originator o] same as [of_creator] but it classifies based on the
+    http request header.*)

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -78,6 +78,7 @@
     sexplib0
     sexplib
     sexpr
+    tgroup
     forkexec
     xapi-idl
     xapi_aux

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -133,6 +133,19 @@ let do_dispatch ?session_id ?forward_op ?self:_ supports_async called_fn_name
       Context.of_http_req ?session_id ~internal_async_subtask ~generate_task_for
         ~supports_async ~label ~http_req ~fd ()
     in
+    let identity =
+      try
+        Option.map
+          (fun session_id ->
+            let subject =
+              Db.Session.get_auth_user_sid ~__context ~self:session_id
+            in
+            Tgroup.Group.Identity.make ?user_agent:http_req.user_agent subject
+          )
+          session_id
+      with _ -> None
+    in
+    Tgroup.of_creator (Tgroup.Group.Creator.make ?identity ()) ;
     let sync () =
       let need_complete = not (Context.forwarded_task __context) in
       exec_with_context ~__context ~need_complete ~called_async

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -686,6 +686,7 @@ let consider_touching_session rpc session_id =
 (* Make sure the pool secret matches *)
 let slave_login_common ~__context ~host_str ~psecret =
   Context.with_tracing ~__context __FUNCTION__ @@ fun __context ->
+  Tgroup.of_creator (Tgroup.Group.Creator.make ~intrapool:true ()) ;
   if not (Helpers.PoolSecret.is_authorized psecret) then (
     let msg = "Pool credentials invalid" in
     debug "Failed to authenticate slave %s: %s" host_str msg ;
@@ -881,6 +882,8 @@ let login_with_password ~__context ~uname ~pwd ~version:_ ~originator =
   | Some `root ->
       (* in this case, the context origin of this login request is a unix socket bound locally to a filename *)
       (* we trust requests from local unix filename sockets, so no need to authenticate them before login *)
+      Tgroup.of_creator
+        Tgroup.Group.(Creator.make ~identity:Identity.root_identity ()) ;
       login_no_password_common ~__context ~uname:(Some uname) ~originator
         ~host:(Helpers.get_localhost ~__context)
         ~pool:false ~is_local_superuser:true ~subject:Ref.null ~auth_user_sid:""
@@ -929,6 +932,8 @@ let login_with_password ~__context ~uname ~pwd ~version:_ ~originator =
           do_local_auth uname pwd ;
           debug "Success: local auth, user %s from %s" uname
             (Context.get_origin __context) ;
+          Tgroup.of_creator
+            Tgroup.Group.(Creator.make ~identity:Identity.root_identity ()) ;
           login_no_password_common ~__context ~uname:(Some uname) ~originator
             ~host:(Helpers.get_localhost ~__context)
             ~pool:false ~is_local_superuser:true ~subject:Ref.null
@@ -1224,6 +1229,10 @@ let login_with_password ~__context ~uname ~pwd ~version:_ ~originator =
                 Caching.memoize ~__context uname pwd
                   ~slow_path:query_external_auth
               in
+              Tgroup.of_creator
+                Tgroup.Group.(
+                  Creator.make ~identity:(Identity.make subject_identifier) ()
+                ) ;
               login_no_password_common ~__context ~uname:(Some uname)
                 ~originator
                 ~host:(Helpers.get_localhost ~__context)

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -816,6 +816,7 @@ let main () =
         in
         let args = String.concat "\n" args in
         Printf.fprintf oc "User-agent: xe-cli/Unix/%d.%d\r\n" major minor ;
+        Printf.fprintf oc "originator: cli\r\n" ;
         Option.iter (Printf.fprintf oc "traceparent: %s\r\n") traceparent ;
         Printf.fprintf oc "content-length: %d\r\n\r\n" (String.length args) ;
         Printf.fprintf oc "%s" args ;


### PR DESCRIPTION
Adds more granurality in the xapi thread classification. Now, an
individual thread can be mapped to the following:

- {xapi_cgroup}/internal/SM;
- {xapi_cgroup}/internal/cli;
- {xapi_cgroup}/external/intrapool;
- {xapi_cgroup}/external/unauthenticated;
- {xapi_cgroup}/external/authenticated/{identity};

where {identity} is a {auth_user_sid}/{user_agent}.
Both {auth_user_sid} and {user_agent} strings are sanitized when
making the identity through `Identity.make`, by allowing only
alphanumeric characters and a maximum length of 16 characters each.

This should allow for proper thread classification in xapi. 

Note: Threads calling back into xapi from xenopsd are yet to be classified.

e.g. Cgroup hierarchy based on the new classification 
![image](https://github.com/user-attachments/assets/29774a5c-0581-405f-965c-4c7c823c6492)

BVT: 208947 & BST: 208972