### PR TITLE
CA-401075: remove misleading logs from HTTP client

### DIFF
--- a/ocaml/libs/http-lib/http_client.ml
+++ b/ocaml/libs/http-lib/http_client.ml
@@ -119,6 +119,8 @@ let response_of_fd_exn_slow fd =
       ; additional_headers= !headers
       ; body= None
       }
+  | [] ->
+      raise End_of_file
   | _ ->
       error "Failed to parse HTTP response status line [%s]" line ;
       raise (Parse_error (Printf.sprintf "Expected initial header [%s]" line))
@@ -192,6 +194,9 @@ let response_of_fd ?(use_fastpath = false) fd =
   with
   | Unix.Unix_error (_, _, _) as e ->
       raise e
+  | End_of_file ->
+      info "No response: connection closed by server" ;
+      None
   | e ->
       Backtrace.is_important e ;
       let bt = Backtrace.get e in


### PR DESCRIPTION
Recent changes to Http_client were made to log errors and backtraces in case of unusual errors, in order to better diagnose problems. Unfortunately, this also led to benign exceptions being logged, which caused people to suspect problems where the exception was actually "expected". In particular the following error started appearing in the logs many times:

    Raised Http_client.Parse_error("Expected initial header []")

The case here is that the client has sent an HTTP request, but the server disconnects before sending a response.

It turns out that this happens commonly when an external connection is received by xapi and handed over to another process, such as xcp-rrdd. The connection's file descriptor is passed to the other process, and the original HTTP request is forwarded over a local socket. The other process continues to handle the request and sends responses to the forwarded socket, but never to the local socket, where xapi is waiting for the response.

This is a quick change that makes the caller of the receive function aware that no response was sent, without logging scary errors, to fix the immediate problem. In addition, we should enhance the handover process to actually send responses, although funcionally this is not an issue.