### PR TITLE
CA-394851: Update allowed operations on the cloned VBD

### DIFF
--- a/ocaml/xapi/xapi_vbd_helpers.ml
+++ b/ocaml/xapi/xapi_vbd_helpers.ml
@@ -443,4 +443,5 @@ let copy ~__context ?vdi ~vm vbd =
     ~qos_algorithm_type:all.API.vBD_qos_algorithm_type
     ~qos_algorithm_params:all.API.vBD_qos_algorithm_params
     ~qos_supported_algorithms:[] ~runtime_properties:[] ~metrics ;
+  update_allowed_operations ~__context ~self:new_vbd ;
   new_vbd


### PR DESCRIPTION
Default empty `allowed_operations` on a cloned VBD means that XenCenter does not display the DVD option in the console tab for VMs cloned from templates, for example.

Follow the practice in `xapi_vbd`, and `update_allowed_operations` immediately after `Db.VBD.create`.

---

I've tested this fix and XC displays the ISO selection on the cloned VM now, and allowed operations on the cloned VBDs are correct as well.