### PR TITLE
CP-52807: No more cluster stack alert

### DIFF
--- a/ocaml/xapi-consts/api_messages.ml
+++ b/ocaml/xapi-consts/api_messages.ml
@@ -311,8 +311,6 @@ let cluster_host_leaving = addMessage "CLUSTER_HOST_LEAVING" 3L
 
 let cluster_host_joining = addMessage "CLUSTER_HOST_JOINING" 4L
 
-let cluster_stack_out_of_date = addMessage "CLUSTER_STACK_OUT_OF_DATE" 3L
-
 (* Certificate expiration messages *)
 let host_server_certificate_expiring = "HOST_SERVER_CERTIFICATE_EXPIRING"
 

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -562,8 +562,6 @@ module Watcher = struct
 
   let finish_watch = Atomic.make false
 
-  let cluster_stack_watcher : bool Atomic.t = Atomic.make false
-
   (* This function exists to store the fact that the watcher should be destroyed,
      to avoid the race that the cluster is destroyed, while the watcher is
      still waiting/stabilising.
@@ -632,41 +630,6 @@ module Watcher = struct
           ()
     done
 
-  let watch_cluster_stack_version ~__context ~host =
-    match find_cluster_host ~__context ~host with
-    | Some ch ->
-        let cluster_ref = Db.Cluster_host.get_cluster ~__context ~self:ch in
-        let cluster_rec = Db.Cluster.get_record ~__context ~self:cluster_ref in
-        if
-          Cluster_stack.of_version
-            ( cluster_rec.API.cluster_cluster_stack
-            , cluster_rec.API.cluster_cluster_stack_version
-            )
-          = Cluster_stack.Corosync2
-        then (
-          debug "%s: Detected Corosync 2 running as cluster stack" __FUNCTION__ ;
-          let body =
-            "The current cluster stack version of Corosync 2 is out of date, \
-             consider updating to Corosync 3"
-          in
-          let name, priority = Api_messages.cluster_stack_out_of_date in
-          let host_uuid = Db.Host.get_uuid ~__context ~self:host in
-
-          Helpers.call_api_functions ~__context (fun rpc session_id ->
-              let _ : [> `message] Ref.t =
-                Client.Client.Message.create ~rpc ~session_id ~name ~priority
-                  ~cls:`Host ~obj_uuid:host_uuid ~body
-              in
-              ()
-          )
-        ) else
-          debug
-            "%s: Detected Corosync 3 as cluster stack, not generating a \
-             warning messsage"
-            __FUNCTION__
-    | None ->
-        debug "%s: No cluster host, no need to watch" __FUNCTION__
-
   (** [create_as_necessary] will create cluster watchers on the coordinator if they are not
       already created. 
       There is no need to destroy them: once the clustering daemon is disabled, 
@@ -674,7 +637,7 @@ module Watcher = struct
   let create_as_necessary ~__context ~host =
     let is_master = Helpers.is_pool_master ~__context ~host in
     let daemon_enabled = Daemon.is_enabled () in
-    if is_master && daemon_enabled then (
+    if is_master && daemon_enabled then
       if Atomic.compare_and_set cluster_change_watcher false true then (
         debug "%s: create watcher for corosync-notifyd on coordinator"
           __FUNCTION__ ;
@@ -687,24 +650,8 @@ module Watcher = struct
         (* someone else must have gone into the if branch above and created the thread
            before us, leave it to them *)
         debug "%s: not create watcher for corosync-notifyd as it already exists"
-          __FUNCTION__ ;
-
-      if Xapi_cluster_helpers.corosync3_enabled ~__context then
-        if Atomic.compare_and_set cluster_stack_watcher false true then (
-          debug
-            "%s: create cluster stack watcher for out-of-date cluster stack \
-             (corosync2)"
-            __FUNCTION__ ;
-          let _ : Thread.t =
-            Thread.create
-              (fun () -> watch_cluster_stack_version ~__context ~host)
-              ()
-          in
-          ()
-        ) else
-          debug "%s: not create watcher for cluster stack as it already exists"
-            __FUNCTION__
-    ) else
+          __FUNCTION__
+    else
       debug
         "%s not create watcher because we are %b master and clustering is \
          enabled %b "


### PR DESCRIPTION
Previously a `CLUSTER_STACK_OUT_OF_DATE` is rasied when the user is running corosync 2 as the cluster stack, while corosync3  is available on the system. This is to nag people to upgrade their cluster stack to corosync 3, on XS 9.

As per the new design, we are no longer telling user that their cluster stack version is out of date, since the corosync upgrade will be part of the compulsory actions enforced by XC upgrade wizard and the host installer.