### PR TITLE
Revert "XSI-1706/CP-51295: limit open TCP con's to 250 and increase socket backlog"

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -398,7 +398,7 @@ let pbis_db_path = "/var/lib/pbis/db/registry.db"
 let on_system_boot = ref false
 
 (* Default backlog supplied to Unix.listen *)
-let listen_backlog = 768
+let listen_backlog = 128
 
 (* Xapi script hooks root *)
 let xapi_hooks_root = ref "/etc/xapi.d"
@@ -892,9 +892,9 @@ let header_total_timeout_tcp = ref 60.
 let max_header_length_tcp = ref 1024
 (* Maximum accepted size of HTTP headers in bytes (on TCP only) *)
 
-let conn_limit_tcp = ref 250
+let conn_limit_tcp = ref 800
 
-let conn_limit_unix = ref 250
+let conn_limit_unix = ref 1024
 
 let xapi_globs_spec =
   [


### PR DESCRIPTION
…
This reverts commit af7b9c441158e6f4d5cbaf8da5e1879f0cbe51fd.

We found that the lower limits are too low for large pools and reverting this. We understand that this risks running out of file descriptors, which was the motivation to lower the limits and to introduce rate limits. The problem does not exist in XS8 and we hope to manage this problem until the end of support of this release.