### PR TITLE
xe-cli completion bugfixes

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -143,9 +143,9 @@ _xe()
                 IFS=$'\n,'
                 # Here we actually WANT file name completion, so using compgen is OK.
                 local comp_files=$(compgen -f "$value")
-                COMPREPLY=( "$comp_files" )
                 __xe_debug "triggering filename completion for the value:"
                 __xe_debug $(__tab_delimited_newline_array "$comp_files")
+                set_completions "$comp_files" "$value"
                 return 0
                 ;;
 
@@ -156,7 +156,6 @@ _xe()
                 if [ "${OLDSTYLE_WORDS[1]}" == "pif-reconfigure-ip" ]; then
                     IFS=$'\n,'
                     suggested_modes="dhcp,static,none"
-                    COMPREPLY=( $(compgen -W "dhcp ,static ,none" -- "$value") )
                 elif [ "${COMP_WORDS[1]}" == "pif-reconfigure-ipv6" ]; then
                     IFS=$'\n,'
                     suggested_modes="dhcp,static,none,autoconf"

--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -675,7 +675,7 @@ description()
 
 __process_params()
 {
-    echo "$1" | cut -d: -f2- | egrep -v "^ $" | cut -c 2- | \
+    echo "$1" | cut -d: -f2- | grep -Ev "^ $" | cut -c 2- | \
     sed -e 's/,/=,/g' -e 's/$/=/g' -e 's/:=/:/g' -e 's/-=/-/g' -e 's/ //g'
 }
 


### PR DESCRIPTION
**xe-cli completion: Use grep -E instead of egrep**

Otherwise newer packages in XS9 issue
"egrep: warning: egrep is obsolescent; using grep -E"
warnings all over the place

---

**xe-cli completion: Hide COMPREPLY manipulation behind functions**

Though the majority of completions were already using set_completions and the
like to add completion suggestions, there were two leftovers still needlessly
changing COMPREPLY themselves. This caused bugs, as in the case of

`xe vm-import filename=<TAB>`

autocompleting all of the filenames into the prompt instead of presenting
the choice. Let only these functions operate on COMPREPLY directly.