### PR TITLE
CP-49141: mark the DB lock as high priority

### DIFF
--- a/ocaml/database/db_lock.ml
+++ b/ocaml/database/db_lock.ml
@@ -79,9 +79,11 @@ module ReentrantLock : REENTRANT_LOCK = struct
 
   let current_tid () = Thread.(self () |> id)
 
-  let[@inline never] [@specialize never] lock_acquired () = ()
+  let[@inline never] [@specialize never] lock_acquired () =
+    Xapi_timeslice.Timeslice.lock_acquired ()
 
-  let[@inline never] [@specialize never] lock_released () = ()
+  let[@inline never] [@specialize never] lock_released () =
+    Xapi_timeslice.Timeslice.lock_released ()
 
   let lock l =
     let me = current_tid () in

--- a/ocaml/database/dune
+++ b/ocaml/database/dune
@@ -48,6 +48,7 @@
     xapi-stdext-std
     xapi-stdext-threads
     xapi-stdext-unix
+    xapi_timeslice
     xml-light2
     xmlm
   )


### PR DESCRIPTION
Builds on top of https://github.com/xapi-project/xen-api/pull/6177 and https://github.com/xapi-project/xen-api/pull/6179, the commit new in this PR is CP-49141.