### PR TITLE
CP-49147: Reduce size of the pool record (uefi_certificates)

### DIFF
--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -2020,6 +2020,11 @@ let t =
                 , "22.16.0"
                 , "Became StaticRO to be editable through new method"
                 )
+              ; ( Changed
+                , "25.12.0"
+                , "Field replaced with a digest. You can still get the actual \
+                   value by calling Host.get_uefi_certificates"
+                )
               ]
             ~default_value:(Some (VString "")) "uefi_certificates"
             "The UEFI certificates allowing Secure Boot"

--- a/ocaml/idl/json_backend/gen_json.ml
+++ b/ocaml/idl/json_backend/gen_json.ml
@@ -613,8 +613,8 @@ module Version = struct
     try Scanf.sscanf name "%d.%d.%d%s" of_chunks
     with _ ->
       failwith
-        (Printf.sprintf "Version schema changed, please change this code %s"
-           __LOC__
+        (Printf.sprintf "Version schema changed, please change this code %s: %s"
+           name __LOC__
         )
 
   let to_name_date (lst, str) =

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "ad67a64cd47cdea32085518c1fb38d27"
+let last_known_schema_hash = "55f3fcbdb67344ba627fc1dec38fe232"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -2127,7 +2127,8 @@ let get_active_uefi_certificates ~__context ~self =
   in
   match (!Xapi_globs.allow_custom_uefi_certs, custom_uefi_certs) with
   | false, _ | true, "" ->
-      Db.Pool.get_uefi_certificates ~__context ~self
+      let master = Db.Pool.get_master ~__context ~self in
+      Db.Host.get_uefi_certificates ~__context ~self:master
   | true, _ ->
       custom_uefi_certs
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2757,7 +2757,12 @@ let write_uefi_certificates_to_disk ~__context ~host =
   if Pool_role.is_master () then
     Db.Pool.set_uefi_certificates ~__context
       ~self:(Helpers.get_pool ~__context)
-      ~value:disk_uefi_certs_tar ;
+      ~value:
+        ( if disk_uefi_certs_tar = "" then
+            ""
+          else
+            Digest.string disk_uefi_certs_tar |> Digest.to_hex
+        ) ;
   let pool_uefi_certs =
     Db.Pool.get_custom_uefi_certificates ~__context
       ~self:(Helpers.get_pool ~__context)


### PR DESCRIPTION
This field is very big and part of every pool.get_all_records() call (done by SM), which is currently >64KiB in size.

TODO: the Changed field needs to match the (future!) tag that this will receive. Hence draft.