### PR TITLE
IH-747 - Reduce pollution in migration logs

### DIFF
--- a/ocaml/database/db_cache_impl.ml
+++ b/ocaml/database/db_cache_impl.ml
@@ -240,6 +240,21 @@ let db_get_by_uuid t tbl uuid_val =
   | _ ->
       raise (Too_many_values (tbl, "", uuid_val))
 
+let db_get_by_uuid_opt t tbl uuid_val =
+  match
+    read_field_where t
+      {
+        table= tbl
+      ; return= Db_names.ref
+      ; where_field= Db_names.uuid
+      ; where_value= uuid_val
+      }
+  with
+  | [r] ->
+      Some r
+  | _ ->
+      None
+
 (** Return reference fields from tbl that matches specified name_label field *)
 let db_get_by_name_label t tbl label =
   read_field_where t

--- a/ocaml/database/db_interface.ml
+++ b/ocaml/database/db_interface.ml
@@ -56,6 +56,11 @@ module type DB_ACCESS = sig
   (** [db_get_by_uuid tbl uuid] returns the single object reference
       		associated with [uuid] *)
 
+  val db_get_by_uuid_opt : Db_ref.t -> string -> string -> string option
+  (** [db_get_by_uuid_opt tbl uuid] returns [Some obj] with the single object
+          reference associated with [uuid] if one exists and [None] otherwise,
+          instead of raising an exception like [get_by_uuid] *)
+
   val db_get_by_name_label : Db_ref.t -> string -> string -> string list
   (** [db_get_by_name_label tbl label] returns the list of object references
       		associated with [label] *)

--- a/ocaml/database/db_rpc_client_v1.ml
+++ b/ocaml/database/db_rpc_client_v1.ml
@@ -88,6 +88,10 @@ functor
       do_remote_call marshall_db_get_by_uuid_args
         unmarshall_db_get_by_uuid_response "db_get_by_uuid" (t, u)
 
+    let db_get_by_uuid_opt _ t u =
+      do_remote_call marshall_db_get_by_uuid_args
+        unmarshall_db_get_by_uuid_opt_response "db_get_by_uuid_opt" (t, u)
+
     let db_get_by_name_label _ t l =
       do_remote_call marshall_db_get_by_name_label_args
         unmarshall_db_get_by_name_label_response "db_get_by_name_label" (t, l)

--- a/ocaml/database/db_rpc_client_v2.ml
+++ b/ocaml/database/db_rpc_client_v2.ml
@@ -77,6 +77,13 @@ functor
       | _ ->
           raise Remote_db_server_returned_bad_message
 
+    let db_get_by_uuid_opt _ t u =
+      match process (Request.Db_get_by_uuid (t, u)) with
+      | Response.Db_get_by_uuid_opt y ->
+          y
+      | _ ->
+          raise Remote_db_server_returned_bad_message
+
     let db_get_by_name_label _ t l =
       match process (Request.Db_get_by_name_label (t, l)) with
       | Response.Db_get_by_name_label y ->

--- a/ocaml/database/db_rpc_common_v1.ml
+++ b/ocaml/database/db_rpc_common_v1.ml
@@ -194,6 +194,8 @@ let marshall_db_get_by_uuid_response s = XMLRPC.To.string s
 
 let unmarshall_db_get_by_uuid_response xml = XMLRPC.From.string xml
 
+let unmarshall_db_get_by_uuid_opt_response xml = unmarshall_stringopt xml
+
 (* db_get_by_name_label *)
 let marshall_db_get_by_name_label_args (s1, s2) = marshall_2strings (s1, s2)
 

--- a/ocaml/database/db_rpc_common_v2.ml
+++ b/ocaml/database/db_rpc_common_v2.ml
@@ -59,6 +59,7 @@ module Response = struct
     | Find_refs_with_filter of string list
     | Read_field_where of string list
     | Db_get_by_uuid of string
+    | Db_get_by_uuid_opt of string option
     | Db_get_by_name_label of string list
     | Create_row of unit
     | Delete_row of unit

--- a/ocaml/idl/ocaml_backend/gen_db_actions.ml
+++ b/ocaml/idl/ocaml_backend/gen_db_actions.ml
@@ -93,6 +93,9 @@ let dm_to_string tys : O.Module.t =
           "fun x -> x |> SecretString.rpc_of_t |> Rpc.string_of_rpc"
       | DT.Record _ ->
           failwith "record types never stored in the database"
+      | DT.Option (DT.Ref _ as ty) ->
+          String.concat ""
+            ["fun s -> set "; OU.alias_of_ty ty; "(Option.to_list s)"]
       | DT.Option _ ->
           failwith "option types never stored in the database"
     in
@@ -148,6 +151,13 @@ let string_to_dm tys : O.Module.t =
           "SecretString.of_string"
       | DT.Record _ ->
           failwith "record types never stored in the database"
+      | DT.Option (DT.Ref _ as ty) ->
+          String.concat ""
+            [
+              "fun s -> match set "
+            ; OU.alias_of_ty ty
+            ; " s with [] -> None | x::_ -> Some x"
+            ]
       | DT.Option _ ->
           failwith "option types never stored in the database"
     in
@@ -515,7 +525,32 @@ let db_action api : O.Module.t =
                 (Escaping.escape_obj obj.DT.name)
                 (OU.escape name)
             in
-            _string_to_dm ^ "." ^ OU.alias_of_ty result_ty ^ " (" ^ query ^ ")"
+            let func =
+              _string_to_dm
+              ^ "."
+              ^ OU.alias_of_ty result_ty
+              ^ " ("
+              ^ query
+              ^ ")"
+            in
+            let query_opt =
+              Printf.sprintf "DB.db_get_by_uuid_opt __t \"%s\" %s"
+                (Escaping.escape_obj obj.DT.name)
+                (OU.escape name)
+            in
+            String.concat "\n\t\t"
+              ([func]
+              @ [
+                  String.concat "\n\t\t  "
+                    (["and get_by_uuid_opt ~__context ~uuid ="]
+                    @ open_db_module
+                    @ [
+                        Printf.sprintf "Option.map %s.%s (%s)" _string_to_dm
+                          (OU.alias_of_ty result_ty) query_opt
+                      ]
+                    )
+                ]
+              )
         | _ ->
             failwith
               "GetByUuid call should have only one parameter and a result!"


### PR DESCRIPTION
Best reviewed by commit - the first one does not depend on database changes, only the last one does.

In short, simplifies and clarifies migration logs from this:
```
[error|1141 |VM metadata import |import]
Found no VDI with location = dedeeb44-62b3-460e-b55c-6de45ba10cc0:
treating as fatal and abandoning import

[debug|1141 |VM metadata import |import]
Ignoring missing disk Ref:4 -
this will be mirrored during a real live migration.
```
to this:
```
[ warn|VM metadata import |import]
Ignoring missing disk Ref:16 -
this will be mirrored during a real live migration.
(Suppressed error: 'Found no VDI with location = c208b47c-cf87-495f-bd3c-a4bc8167ef83')
```

And from this:
```
[error|backtrace] SR.get_by_uuid D:8651cc0c9fb6 failed with exception Db_exn.Read_missing_uuid("SR", "", "a94bf103-0169-6d70-8874-334261f5098e")
[error|backtrace] Raised Db_exn.Read_missing_uuid("SR", "", "a94bf103-0169-6d70-8874-334261f5098e")
[error|backtrace] 1/9 xapi Raised at file ocaml/database/db_cache_impl.ml, line 237
[error|backtrace] 2/9 xapi Called from file ocaml/xapi/db_actions.ml, line 13309
[error|backtrace] 3/9 xapi Called from file ocaml/xapi/rbac.ml, line 188
[error|backtrace] 4/9 xapi Called from file ocaml/xapi/rbac.ml, line 197
[error|backtrace] 5/9 xapi Called from file ocaml/xapi/server_helpers.ml, line 74
[error|backtrace] 6/9 xapi Called from file ocaml/xapi/server_helpers.ml, line 96
[error|backtrace] 7/9 xapi Called from file ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
[error|backtrace] 8/9 xapi Called from file ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml, line 39
[error|backtrace] 9/9 xapi Called from file ocaml/libs/log/debug.ml, line 250
[ warn|import] Failed to find SR with UUID: a94bf103-0169-6d70-8874-334261f5098e content-type: user - will still try to find individual VDIs
[....]
[debug|import] Importing 1 VM_guest_metrics(s)
[debug|import] Importing 1 VM_metrics(s)
[debug|import] Importing 1 VM(s)
[debug|import] Importing 1 network(s)
[debug|import] Importing 0 GPU_group(s)
[debug|import] Importing 1 VBD(s)
[error|backtrace] VBD.get_by_uuid D:3a12311e8be4 failed with exception Db_exn.Read_missing_uuid("VBD", "", "026d61e9-ed8a-fc72-7fd3-77422585baff")
[error|backtrace] Raised Db_exn.Read_missing_uuid("VBD", "", "026d61e9-ed8a-fc72-7fd3-77422585baff")
[error|backtrace] 1/9 xapi Raised at file ocaml/database/db_cache_impl.ml, line 237
[error|backtrace] 2/9 xapi Called from file ocaml/xapi/db_actions.ml, line 14485
[error|backtrace] 3/9 xapi Called from file ocaml/xapi/rbac.ml, line 188
[error|backtrace] 4/9 xapi Called from file ocaml/xapi/rbac.ml, line 197
[error|backtrace] 5/9 xapi Called from file ocaml/xapi/server_helpers.ml, line 74
[error|backtrace] 6/9 xapi Called from file ocaml/xapi/server_helpers.ml, line 96
[error|backtrace] 7/9 xapi Called from file ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
[error|backtrace] 8/9 xapi Called from file ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml, line 39
[error|backtrace] 9/9 xapi Called from file ocaml/libs/log/debug.ml, line 250
[debug|import] Importing 1 VIF(s)
[error|backtrace] VIF.get_by_uuid D:2bc78449e0bc failed with exception Db_exn.Read_missing_uuid("VIF", "", "7d14aee4-47a4-e271-4f64-fe9f9ef6d50b")
[error|backtrace] Raised Db_exn.Read_missing_uuid("VIF", "", "7d14aee4-47a4-e271-4f64-fe9f9ef6d50b")
[error|backtrace] 1/9 xapi Raised at file ocaml/database/db_cache_impl.ml, line 237
[error|backtrace] 2/9 xapi Called from file ocaml/xapi/db_actions.ml, line 10813
[error|backtrace] 3/9 xapi Called from file ocaml/xapi/rbac.ml, line 188
[error|backtrace] 4/9 xapi Called from file ocaml/xapi/rbac.ml, line 197
[error|backtrace] 5/9 xapi Called from file ocaml/xapi/server_helpers.ml, line 74
[error|backtrace] 6/9 xapi Called from file ocaml/xapi/server_helpers.ml, line 96
[error|backtrace] 7/9 xapi Called from file ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml, line 24
[error|backtrace] 8/9 xapi Called from file ocaml/libs/xapi-stdext/lib/xapi-stdext-pervasives/pervasiveext.ml, line 39
[error|backtrace] 9/9 xapi Called from file ocaml/libs/log/debug.ml, line 250
```

to this:
```
[debug|import] Importing 1 host(s)
[debug|import] Importing 2 SR(s)
[ warn|import] Failed to find SR with UUID: 8568e308-c61c-3b10-3953-45606cfecede content-type:  - will still try to find individual VDIs
[ warn|import] Failed to find SR with UUID: 40e9e252-46ac-ed3d-7a4c-6db175212195 content-type: user - will still try to find individual VDIs
[...]
[debug|import] Importing 2 VM_guest_metrics(s)
[debug|import] Importing 2 VM(s)
[debug|import] Importing 1 network(s)
[debug|import] Importing 1 GPU_group(s)
[debug|import] Importing 4 VBD(s)
[ info|import] Did not find an already existing VBD with the same uuid=569d0e60-6a89-d1fa-2ed6-38b8eebe9065, try to create a new one
[ info|import] Did not find an already existing VBD with the same uuid=533306da-cff1-7ada-71f7-2c4de8a0065b, try to create a new one
[ info|import] Did not find an already existing VBD with the same uuid=f9dec620-0180-f67f-6711-7f9e5222a682, try to create a new one
[ info|import] Did not find an already existing VBD with the same uuid=05e55076-b559-9b49-c247-e7850984ddae, try to create a new one
[debug|import] Importing 2 VIF(s)
[ info|import] Did not find an already existing VIF with the same uuid=a5a731d5-622c-5ca5-5b2a-a0053a11ef07, try to create a new one
[ info|import] Did not find an already existing VIF with the same uuid=1738bf20-8d16-0d69-48cd-8f3d9e7ea791, try to create a new one
```
