### PR TITLE
CA-403767: verifyPeer can't use root CA for appliance cert check

### DIFF
--- a/ocaml/libs/stunnel/stunnel.ml
+++ b/ocaml/libs/stunnel/stunnel.ml
@@ -218,29 +218,29 @@ let config_file ?(accept = None) config host port =
          | None ->
              []
          | Some {sni; verify; cert_bundle_path} ->
-             [
-               ""
-             ; "# use SNI to request a specific cert. CAfile contains"
-             ; "# public certs of all hosts in the pool and must contain"
-             ; "# the cert of the server we connect to"
-             ; (match sni with None -> "" | Some s -> sprintf "sni = %s" s)
-             ; ( match verify with
+             List.rev_append
+               ( match verify with
                | VerifyPeer ->
-                   ""
+                   ["verifyPeer=yes"]
                | CheckHost ->
-                   sprintf "checkHost=%s" host
+                   [sprintf "checkHost=%s" host; "verifyChain=yes"]
                )
-             ; "verifyPeer=yes"
-             ; sprintf "CAfile=%s" cert_bundle_path
-             ; ( match Sys.readdir crl_path with
-               | [||] ->
-                   ""
-               | _ ->
-                   sprintf "CRLpath=%s" crl_path
-               | exception _ ->
-                   ""
-               )
-             ]
+               [
+                 ""
+               ; "# use SNI to request a specific cert. CAfile contains"
+               ; "# public certs of all hosts in the pool and must contain"
+               ; "# the cert of the server we connect to"
+               ; (match sni with None -> "" | Some s -> sprintf "sni = %s" s)
+               ; sprintf "CAfile=%s" cert_bundle_path
+               ; ( match Sys.readdir crl_path with
+                 | [||] ->
+                     ""
+                 | _ ->
+                     sprintf "CRLpath=%s" crl_path
+                 | exception _ ->
+                     ""
+                 )
+               ]
          )
        ; [""]
        ]


### PR DESCRIPTION
It is expected to use root CA certficate to verify an appliance's server
certificate for a xapi outgoing TLS connection.

Prior to this change, the related stunnel configurations are:
"verifyPeer=yes", and "checkHost=<hostname>".

The 'verifyPeer' option of stunnel doesn't treat the CA bundle as root
CA certificates. The 'checkHost' option of stunnel only checks the
host name against the one in server certificate. In other words, the
issue is that the root CA based checking doesn't work for appliance.

This change adds 'verifyChain' for the appliance to ensure the outgoing
TLS connection from xapi will verify the appliance's server certificates
by real root CA certificate.