### PR TITLE
CA-402921: Relax VIF constraint for PVS proxy

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1818,6 +1818,11 @@ let _ =
       "The address specified is already in use by an existing PVS_server object"
     () ;
 
+  error Api_errors.pvs_vif_must_be_first_device []
+    ~doc:
+      "The VIF used by PVS proxy must be the one with the lowest device number"
+    () ;
+
   error Api_errors.usb_group_contains_vusb ["vusbs"]
     ~doc:"The USB group contains active VUSBs and cannot be deleted." () ;
   error Api_errors.usb_group_contains_pusb ["pusbs"]

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1823,6 +1823,13 @@ let _ =
       "The VIF used by PVS proxy must be the one with the lowest device number"
     () ;
 
+  error Api_errors.pvs_proxy_present_on_higher_vif_device ["device"]
+    ~doc:
+      "The VM has a VIF, with a higher device number than the new VIF, that \
+       uses a PVS proxy. The VIF used by PVS proxy must be the one with the \
+       lowest device number."
+    () ;
+
   error Api_errors.usb_group_contains_vusb ["vusbs"]
     ~doc:"The USB group contains active VUSBs and cannot be deleted." () ;
   error Api_errors.usb_group_contains_pusb ["pusbs"]

--- a/ocaml/tests/suite_alcotest.ml
+++ b/ocaml/tests/suite_alcotest.ml
@@ -37,6 +37,7 @@ let () =
      ; ("Test_pvs_site", Test_pvs_site.test)
      ; ("Test_pvs_proxy", Test_pvs_proxy.test)
      ; ("Test_pvs_server", Test_pvs_server.test)
+     ; ("Test_vif_helpers", Test_vif_helpers.test)
      ; ("Test_vm_memory_constraints", Test_vm_memory_constraints.test)
      ; ("Test_xapi_xenops", Test_xapi_xenops.test)
      ; ("Test_network_event_loop", Test_network_event_loop.test)

--- a/ocaml/tests/test_vif_helpers.ml
+++ b/ocaml/tests/test_vif_helpers.ml
@@ -1,0 +1,90 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module T = Test_common
+
+(* Function under test *)
+let create ~__context ~device ~network ~vM ?(mAC = "00:00:00:00:00:00")
+    ?(mTU = 1500L) ?(qos_algorithm_type = "") ?(qos_algorithm_params = [])
+    ?(currently_attached = false) ?(other_config = [])
+    ?(locking_mode = `unlocked) ?(ipv4_allowed = []) ?(ipv6_allowed = [])
+    ?(ipv4_configuration_mode = `None) ?(ipv4_addresses = [])
+    ?(ipv4_gateway = "") ?(ipv6_configuration_mode = `None)
+    ?(ipv6_addresses = []) ?(ipv6_gateway = "") () =
+  Xapi_vif_helpers.create ~__context ~device ~network ~vM ~mAC ~mTU
+    ~other_config ~qos_algorithm_type ~qos_algorithm_params ~currently_attached
+    ~locking_mode ~ipv4_allowed ~ipv6_allowed ~ipv4_configuration_mode
+    ~ipv4_addresses ~ipv4_gateway ~ipv6_configuration_mode ~ipv6_addresses
+    ~ipv6_gateway
+
+let test_create_ok () =
+  let __context = T.make_test_database () in
+  let vM = T.make_vm ~__context () in
+  let network = T.make_network ~__context () in
+  let vif = create ~__context ~device:"0" ~network ~vM () in
+  Alcotest.(check (Alcotest_comparators.ref ()))
+    "test_create_ok testing get_VM" vM
+    (Db.VIF.get_VM ~__context ~self:vif)
+
+let test_create_duplicate_device () =
+  let __context = T.make_test_database () in
+  let vM = T.make_vm ~__context () in
+  let network = T.make_network ~__context () in
+  let _vif0 = T.make_vif ~__context ~device:"0" ~vM ~network () in
+  Alcotest.check_raises
+    "test_create_duplicate_device should raise device_already_exists"
+    Api_errors.(Server_error (device_already_exists, ["0"]))
+  @@ fun () ->
+  let _ = create ~__context ~device:"0" ~network ~vM () in
+  ()
+
+let test_create_with_pvs_proxy_ok () =
+  let __context = T.make_test_database () in
+  let vM = T.make_vm ~__context () in
+  let network = T.make_network ~__context () in
+  let vIF = T.make_vif ~__context ~device:"0" ~vM ~network () in
+  let _vIF2 = T.make_vif ~__context ~device:"2" ~vM ~network () in
+  let site = T.make_pvs_site ~__context () in
+  let _pvs_proxy = T.make_pvs_proxy ~__context ~site ~vIF () in
+  let vif1 = create ~__context ~device:"1" ~network ~vM () in
+  Alcotest.(check (Alcotest_comparators.ref ()))
+    "test_create_with_pvs_proxy_ok testing get_VM" vM
+    (Db.VIF.get_VM ~__context ~self:vif1)
+
+let test_create_with_pvs_proxy_not_ok () =
+  let __context = T.make_test_database () in
+  let vM = T.make_vm ~__context () in
+  let network = T.make_network ~__context () in
+  let vIF = T.make_vif ~__context ~device:"1" ~vM ~network () in
+  let _vIF2 = T.make_vif ~__context ~device:"2" ~vM ~network () in
+  let site = T.make_pvs_site ~__context () in
+  let _pvs_proxy = T.make_pvs_proxy ~__context ~site ~vIF () in
+  Alcotest.check_raises
+    "test_create_with_pvs_proxy_not_ok should raise \
+     pvs_proxy_present_on_higher_vif_device"
+    Api_errors.(Server_error (pvs_proxy_present_on_higher_vif_device, ["1"]))
+  @@ fun () ->
+  let _ = create ~__context ~device:"0" ~network ~vM () in
+  ()
+
+let test =
+  [
+    ("test_create_ok", `Quick, test_create_ok)
+  ; ("test_create_duplicate_device", `Quick, test_create_duplicate_device)
+  ; ("test_create_with_pvs_proxy_ok", `Quick, test_create_with_pvs_proxy_ok)
+  ; ( "test_create_with_pvs_proxy_not_ok"
+    , `Quick
+    , test_create_with_pvs_proxy_not_ok
+    )
+  ]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1246,6 +1246,8 @@ let pvs_proxy_already_present = add_error "PVS_PROXY_ALREADY_PRESENT"
 
 let pvs_server_address_in_use = add_error "PVS_SERVER_ADDRESS_IN_USE"
 
+let pvs_vif_must_be_first_device = add_error "PVS_VIF_MUST_BE_FIRST_DEVICE"
+
 let extension_protocol_failure = add_error "EXTENSION_PROTOCOL_FAILURE"
 
 let usb_group_contains_vusb = add_error "USB_GROUP_CONTAINS_VUSB"

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1248,6 +1248,9 @@ let pvs_server_address_in_use = add_error "PVS_SERVER_ADDRESS_IN_USE"
 
 let pvs_vif_must_be_first_device = add_error "PVS_VIF_MUST_BE_FIRST_DEVICE"
 
+let pvs_proxy_present_on_higher_vif_device =
+  add_error "PVS_PROXY_PRESENT_ON_HIGHER_VIF_DEVICE"
+
 let extension_protocol_failure = add_error "EXTENSION_PROTOCOL_FAILURE"
 
 let usb_group_contains_vusb = add_error "USB_GROUP_CONTAINS_VUSB"


### PR DESCRIPTION
The current constraint is that the VIF used for PVS proxy must have
device number 0. It turned out that this can be relaxed. It is
sufficient to enforce that the VIF is the one with the lowest device
number for the VM.