### PR TITLE
XSI-1773 improve logging if service file unexpectedly exists

### DIFF
--- a/ocaml/forkexecd/lib/dune
+++ b/ocaml/forkexecd/lib/dune
@@ -13,6 +13,7 @@
    xapi-log
    xapi-stdext-pervasives
    xapi-stdext-unix
+   xapi-stdext-date
    xapi-tracing
  )
  (preprocess (per_module ((pps ppx_deriving_rpc) Fe))))


### PR DESCRIPTION
We have seen failures where a service file unexpectedly exists. It could have been left behind but a failed stop but we don't have evidence for that. To help with this, provide more details of the file found.