### PR TITLE
CA-403620: Drop the usage of fuser in stunnel client proxy

### DIFF
--- a/ocaml/libs/stunnel/stunnel.mli
+++ b/ocaml/libs/stunnel/stunnel.mli
@@ -88,11 +88,12 @@ val with_moved_exn : t -> (t -> 'd) -> 'd
 
 val safe_release : t -> unit
 
-val with_client_proxy :
+val with_client_proxy_systemd_service :
      verify_cert:verification_config option
   -> remote_host:string
   -> remote_port:int
   -> local_host:string
   -> local_port:int
+  -> service:string
   -> (unit -> 'a)
   -> 'a

--- a/ocaml/xapi/repository_helpers.ml
+++ b/ocaml/xapi/repository_helpers.ml
@@ -398,10 +398,11 @@ let with_local_repositories ~__context f =
     with Pool_role.This_host_is_a_master ->
       Option.get (Helpers.get_management_ip_addr ~__context)
   in
-  Stunnel.with_client_proxy ~verify_cert:(Stunnel_client.pool ())
-    ~remote_host:master_addr ~remote_port:Constants.default_ssl_port
-    ~local_host:"127.0.0.1"
+  Stunnel.with_client_proxy_systemd_service
+    ~verify_cert:(Stunnel_client.pool ()) ~remote_host:master_addr
+    ~remote_port:Constants.default_ssl_port ~local_host:"127.0.0.1"
     ~local_port:!Xapi_globs.local_yum_repo_port
+    ~service:"stunnel_proxy_for_update_client"
   @@ fun () ->
   let enabled = get_enabled_repositories ~__context in
   Xapi_stdext_pervasives.Pervasiveext.finally

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1143,6 +1143,7 @@ let xapi_globs_spec =
   ; ("max_traces", Int max_traces)
   ; ("max_observer_file_size", Int max_observer_file_size)
   ; ("test-open", Int test_open) (* for consistency with xenopsd *)
+  ; ("local_yum_repo_port", Int local_yum_repo_port)
   ]
 
 let xapi_globs_spec_with_descriptions = []


### PR DESCRIPTION
Two changes in the PR:
**Drop the usage of fuser in stunnel client proxy**
The drawback of fuser is that it gets too many things involved. E.g. it
is observed that it got stuck on cifs kernel module.

This change uses a cleaner way to remember the stunnel client proxy.
Even when the xapi restarted unexpectedly, it can stop the remnant
stunnel proxy and start a new one.

**Make the stunnel proxy local port configurable**
Making it configurable can avoid the situation when the port conflicts
with others, e.g. an external program from users.