### PR TITLE
CP-51895: Drop FCoE support when fcoe_driver does not exists

### DIFF
--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -1067,12 +1067,17 @@ module Fcoe = struct
   let call ?log args = call_script ?log ~timeout:(Some 10.0) !fcoedriver args
 
   let get_capabilities name =
-    try
-      let output = call ~log:false ["--xapi"; name; "capable"] in
-      if Astring.String.is_infix ~affix:"True" output then ["fcoe"] else []
-    with _ ->
-      debug "Failed to get fcoe support status on device %s" name ;
-      []
+    match Sys.file_exists !fcoedriver with
+    | false ->
+        [] (* Does not support FCoE *)
+    | true -> (
+      try
+        let output = call ~log:false ["--xapi"; name; "capable"] in
+        if Astring.String.is_infix ~affix:"True" output then ["fcoe"] else []
+      with _ ->
+        debug "Failed to get fcoe support status on device %s" name ;
+        []
+    )
 end
 
 module Sysctl = struct

--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -1069,13 +1069,15 @@ module Fcoe = struct
   let get_capabilities name =
     match Sys.file_exists !fcoedriver with
     | false ->
+        info "%s: %s not found, does not support FCoE" __FUNCTION__ !fcoedriver ;
         [] (* Does not support FCoE *)
     | true -> (
       try
         let output = call ~log:false ["--xapi"; name; "capable"] in
         if Astring.String.is_infix ~affix:"True" output then ["fcoe"] else []
       with _ ->
-        debug "Failed to get fcoe support status on device %s" name ;
+        debug "%s: Failed to get fcoe support status on device %s" __FUNCTION__
+          name ;
         []
     )
 end

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1689,11 +1689,6 @@ module Resources = struct
     ; ("xsh", xsh, "Path to xsh binary")
     ; ("static-vdis", static_vdis, "Path to static-vdis script")
     ; ("xen-cmdline-script", xen_cmdline_script, "Path to xen-cmdline script")
-    ; ( "fcoe-driver"
-      , fcoe_driver
-      , "Execute during PIF unplug to get the lun devices related with the \
-         ether interface of the PIF"
-      )
     ; ("list_domains", list_domains, "Path to the list_domains command")
     ; ("systemctl", systemctl, "Control the systemd system and service manager")
     ; ( "alert-certificate-check"
@@ -1797,6 +1792,12 @@ module Resources = struct
       , "Path to yum-config-manager command"
       )
     ; ("c_rehash", c_rehash, "Path to regenerate CA store")
+      (* Dropped since XS9, list here as XS8 still requires it *)
+    ; ( "fcoe-driver"
+      , fcoe_driver
+      , "Execute during PIF unplug to get the lun devices related with the \
+         ether interface of the PIF"
+      )
     ]
 
   let essential_files =


### PR DESCRIPTION
FCoE support will be removed from XS9 and dom0 will no longer provide fcoe_driver. However, XS8 still actively support it.

Xapi checks the existence of fcoe_driver, and thinks all PIFs no longer support FCoE if fcoe_driver not found