### PR TITLE
CA-404062: Wrongly restart xapi when receiving HTTP errors

### DIFF
--- a/ocaml/database/master_connection.ml
+++ b/ocaml/database/master_connection.ml
@@ -229,17 +229,17 @@ let do_db_xml_rpc_persistent_with_reopen ~host ~path (req : string) :
     if !connection_timeout < 0. then (
       if not !surpress_no_timeout_logs then (
         debug
-          "Connection to master died. I will continue to retry \
-           indefinitely (supressing future logging of this message)." ;
+          "Connection to master died. I will continue to retry indefinitely \
+           (supressing future logging of this message)." ;
         error
-          "Connection to master died. I will continue to retry \
-           indefinitely (supressing future logging of this message)."
+          "Connection to master died. I will continue to retry indefinitely \
+           (supressing future logging of this message)."
       ) ;
       surpress_no_timeout_logs := true
     ) else
       debug
-        "Connection to master died: time taken so far in this call '%f'; \
-         will %s"
+        "Connection to master died: time taken so far in this call '%f'; will \
+         %s"
         time_sofar
         ( if !connection_timeout < 0. then
             "never timeout"
@@ -248,8 +248,7 @@ let do_db_xml_rpc_persistent_with_reopen ~host ~path (req : string) :
         ) ;
     if time_sofar > !connection_timeout && !connection_timeout >= 0. then
       if !restart_on_connection_timeout then (
-        debug
-          "Exceeded timeout for retrying master connection: restarting xapi" ;
+        debug "Exceeded timeout for retrying master connection: restarting xapi" ;
         !Db_globs.restart_fn ()
       ) else (
         debug
@@ -310,12 +309,12 @@ let do_db_xml_rpc_persistent_with_reopen ~host ~path (req : string) :
         debug "Re-raising exception to caller." ;
         raise Http_svr.Client_requested_size_over_limit
     | Http_client.Http_error (http_code, err_msg) ->
-        error "Received HTTP error %s (%s) from the coordinator." http_code err_msg ;
+        error "Received HTTP error %s (%s) from the coordinator." http_code
+          err_msg ;
         reconnect ()
-    | e -> (
+    | e ->
         error "Caught %s" (Printexc.to_string e) ;
         reconnect ()
-      )
   done ;
   !result
 


### PR DESCRIPTION
(This is a back porting from a [PR](https://github.com/xapi-project/xen-api/pull/6201) against master branch)

The xapi on a supporter host would restart when it received HTTP error
from the xapi on the coordinator host.

This breaks the pool.designate_new_master use case for a big pool, e.g.
64-host pool. In this case, some supporters may restart unexpectedly
within the phase of committing new coordinator due to the logic above.

Additionally, the purpose of this logic, explained by the error message,
is not correct also. Not all HTTP errors are caused by "our master
address is wrong".

On the other hand, if a use case requires to restart the xapi, a more
explicit logic should ensure that, instead of leveraging an implicit
HTTP error code. Furhtermore, if a supporter indeed is connecting to a
wrong coordinator, this should be a bug and can be recovered manually.

Based on above arguments, the restarting xapi after receiving HTTP error
is removed. This follows the TODO concluded in CA-36936 as well.