### PR TITLE
Starts periodic schedule automatically

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/scheduler.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/scheduler.mli
@@ -24,5 +24,5 @@ val add_to_queue : string -> func_ty -> float -> (unit -> unit) -> unit
 val remove_from_queue : string -> unit
 (** Remove a scheduled item by name *)
 
-val loop : unit -> unit
-(** The scheduler's main loop, started by {!Xapi} on start-up. *)
+val loop_start : ((unit -> unit) -> unit) option -> unit
+(** Start the scheduler's main loop. *)

--- a/ocaml/tests/common/test_event_common.ml
+++ b/ocaml/tests/common/test_event_common.ml
@@ -11,7 +11,6 @@ let start_periodic_scheduler () =
   else (
     Scheduler.add_to_queue "dummy" (Scheduler.Periodic 60.0) 0.0 (fun () -> ()) ;
     Xapi_event.register_hooks () ;
-    ignore (Thread.create Scheduler.loop ()) ;
     ps_start := true
   ) ;
   Mutex.unlock scheduler_mutex


### PR DESCRIPTION
Remove dependency from Xapi.
The function "loop_start" allows to set a wrapper for the thread loop if needed.