### PR TITLE
CA-404013: replace Thread.delay with Delay module

### DIFF
--- a/ocaml/xcp-rrdd/lib/plugin/reporter_local.ml
+++ b/ocaml/xcp-rrdd/lib/plugin/reporter_local.ml
@@ -28,7 +28,7 @@ let start_local (module D : Debug.DEBUG) ~reporter ~uid ~neg_shift ~page_count
       overdue_count :=
         wait_until_next_reading
           (module D)
-          ~neg_shift ~uid ~protocol ~overdue_count:!overdue_count ;
+          ~neg_shift ~uid ~protocol ~overdue_count:!overdue_count ~reporter ;
       if page_count > 0 then
         let payload =
           Rrd_protocol.{timestamp= Utils.now (); datasources= dss_f ()}


### PR DESCRIPTION
Reporter.cancel would be blocked for a long time by backoff delay when another thread is waiting for next reading, replace Thread.delay with Delay module so that Reporter.cancel will not be blocked.