### PR TITLE
rrd2csv: Accept a trailing comma in metrics names

### DIFF
--- a/ocaml/rrd2csv/src/rrd2csv.ml
+++ b/ocaml/rrd2csv/src/rrd2csv.ml
@@ -149,27 +149,33 @@ module Ds_selector = struct
 
   let of_string str =
     let open Rrd in
-    let splitted = Xstringext.String.split ':' str in
+    let splitted = Xstringext.String.split ',' str in
     match splitted with
-    | [cf; owner; uuid; metric] ->
-        {
-          cf= (try Some (cf_type_of_string cf) with _ -> None)
-        ; owner=
-            ( match owner with
-            | "vm" ->
-                Some (VM uuid)
-            | "sr" ->
-                Some (SR uuid)
-            | "host" ->
-                Some Host
-            | _ ->
-                None
-            )
-        ; uuid
-        ; metric
-        }
-    | [metric] ->
-        {empty with metric}
+    | without_trailing_comma :: _ -> (
+        let splitted = Xstringext.String.split ':' without_trailing_comma in
+        match splitted with
+        | [cf; owner; uuid; metric] ->
+            {
+              cf= (try Some (cf_type_of_string cf) with _ -> None)
+            ; owner=
+                ( match owner with
+                | "vm" ->
+                    Some (VM uuid)
+                | "sr" ->
+                    Some (SR uuid)
+                | "host" ->
+                    Some Host
+                | _ ->
+                    None
+                )
+            ; uuid
+            ; metric
+            }
+        | [metric] ->
+            {empty with metric}
+        | _ ->
+            failwith "ds_selector_of_string"
+      )
     | _ ->
         failwith "ds_selector_of_string"
 


### PR DESCRIPTION
rrd2csv itself prints out a list of comma-separated metrics names, but could't accept this list as command line arguments:

```
$ rrd2csv
.....memory_total_kib, memory_free_kib, ....

$ rrd2csv memory_total_kib, memory_free_kib
WARNING: Requested metric AVERAGE:host:05e817e2-3a65-484d-b0da-a7163f9ffc12:memory_total_kib,
is disabled or non-existant
timestamp, AVERAGE:host:05e817e2-3a65-484d-b0da-a7163f9ffc12:memory_free_kib
2025-01-07T14:06:45Z, 30042000
```

Now this works just fine:
```
$ rrd2csv memory_total_kib, memory_free_kib
timestamp, AVERAGE:host:92bc3b1e-e0a3-49ba-8994-fc305ff882b7:memory_total_kib, AVERAGE:host:92bc3b1e-e0a3-49ba-8994-fc305ff882b7:memory_free_kib
2025-01-07T15:04:50Z, 33350000, 30023000
```