### PR TITLE
CP-51692: Do not enable Event.next ratelimiting if Event.next is still used internally

### DIFF
--- a/ocaml/xapi/xapi_event.ml
+++ b/ocaml/xapi/xapi_event.ml
@@ -476,7 +476,13 @@ let unregister ~__context ~classes =
 
 (** Blocking call which returns the next set of events relevant to this session. *)
 let rec next ~__context =
-  let batching = !Xapi_globs.event_next_delay in
+  let batching =
+    if !Constants.use_event_next then
+      Throttle.Batching.make ~delay_before:Mtime.Span.zero
+        ~delay_between:Mtime.Span.zero
+    else
+      !Xapi_globs.event_next_delay
+  in
   let session = Context.get_session_id __context in
   let open Next in
   assert_subscribed session ;


### PR DESCRIPTION
This fixes a performance regression on `feature/perf` with all feature flags disabled.

By default Event.next is still used internally, so although this API is deprecated do not yet enable the throttling by default. Fixes: 3e1d8a27a7 ("CP-51692: Event.next: use same batching as Event.from") 
Fixes: 2b4e0db649 ("CP-49158: [prep] Event.{from,next}: make delays configurable and prepare for task specific delays")

It slows down all synchronous API calls that create tasks, like VM.start.

Only enable the throttling when Event.next is not used internally (`use-event-next = false` in xapi.conf), which will eventually become the default.

The code prior to the above changes used 0 delay between checking for events, so do the same here (although this lead to a lot of inefficient wakeups of all active tasks in XAPI, whenever anything changes, it matches previous behaviour)

(the code for Event.from used a 50ms delay, which matches the default for that setting already)