### PR TITLE
CP-52744: Thread `TraceContext` as JSON inside `debug_info`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -103,11 +103,13 @@
    dune
    (alcotest :with-test)
    (fmt :with-test)
+   ppx_deriving_yojson
    re
    uri
    (uuid :with-test)
    (xapi-log (= :version))
    (xapi-stdext-threads (= :version))
+   yojson
   )
   (synopsis "Allows to instrument code to generate tracing information")
   (description "This library provides modules to allow gathering runtime traces.")

--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -1,7 +1,9 @@
 (library
  (name tracing)
  (modules tracing)
- (libraries re uri xapi-log xapi-stdext-threads threads.posix)
+ (libraries re uri yojson xapi-log xapi-stdext-threads threads.posix)
+ (preprocess
+  (pps ppx_deriving_yojson))
  (public_name xapi-tracing))
 
 (library

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -425,6 +425,12 @@ module Span = struct
     |> get_context
     |> SpanContext.context_of_span_context
     |> TraceContext.with_traceparent (Some traceparent)
+
+  let with_trace_context span trace_context =
+    let span_context =
+      span |> get_context |> SpanContext.with_trace_context trace_context
+    in
+    {span with context= span_context}
 end
 
 module TraceMap = Map.Make (Trace_id)

--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -211,11 +211,12 @@ end
 
 (* The context of a trace that can be propagated across service boundaries. *)
 module TraceContext = struct
-  type traceparent = string
+  type traceparent = string [@@deriving yojson]
 
-  type baggage = (string * string) list
+  type baggage = (string * string) list [@@deriving yojson]
 
   type t = {traceparent: traceparent option; baggage: baggage option}
+  [@@deriving yojson]
 
   let empty = {traceparent= None; baggage= None}
 
@@ -226,6 +227,10 @@ module TraceContext = struct
   let traceparent_of ctx = ctx.traceparent
 
   let baggage_of ctx = ctx.baggage
+
+  let to_json_string t = Yojson.Safe.to_string (to_yojson t)
+
+  let of_json_string s = of_yojson (Yojson.Safe.from_string s)
 end
 
 module SpanContext = struct
@@ -297,6 +302,8 @@ module Span = struct
 
   let get_context t = t.context
 
+  let get_trace_context t = t.context |> SpanContext.context_of_span_context
+
   let start ?(attributes = Attributes.empty)
       ?(trace_context : TraceContext.t option) ~name ~parent ~span_kind () =
     let trace_id, extra_context =
@@ -312,9 +319,9 @@ module Span = struct
     in
     let context =
       (* If trace_context is provided to the call, override any inherited trace context. *)
-      Option.fold ~none:context
-        ~some:(Fun.flip SpanContext.with_trace_context context)
-        trace_context
+      trace_context
+      |> Option.fold ~none:context
+           ~some:(Fun.flip SpanContext.with_trace_context context)
     in
     (* Using gettimeofday over Mtime as it is better for sharing timestamps between the systems *)
     let begin_time = Unix.gettimeofday () in
@@ -411,6 +418,13 @@ module Span = struct
         {span with status= {status_code; _description}}
     | _ ->
         span
+
+  let to_propagation_context span =
+    let traceparent = span |> get_context |> SpanContext.to_traceparent in
+    span
+    |> get_context
+    |> SpanContext.context_of_span_context
+    |> TraceContext.with_traceparent (Some traceparent)
 end
 
 module TraceMap = Map.Make (Trace_id)

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -148,6 +148,8 @@ module Span : sig
   val get_attributes : t -> (string * string) list
 
   val to_propagation_context : t -> TraceContext.t
+
+  val with_trace_context : t -> TraceContext.t -> t
 end
 
 module TraceMap : module type of Map.Make (Trace_id)

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -94,6 +94,10 @@ module TraceContext : sig
   val traceparent_of : t -> traceparent option
 
   val baggage_of : t -> baggage option
+
+  val to_json_string : t -> string
+
+  val of_json_string : string -> (t, string) result
 end
 
 module SpanContext : sig
@@ -119,6 +123,8 @@ module Span : sig
 
   val get_context : t -> SpanContext.t
 
+  val get_trace_context : t -> TraceContext.t
+
   val add_link : t -> SpanContext.t -> (string * string) list -> t
 
   val add_event : t -> string -> (string * string) list -> t
@@ -140,6 +146,8 @@ module Span : sig
   val get_end_time : t -> float option
 
   val get_attributes : t -> (string * string) list
+
+  val to_propagation_context : t -> TraceContext.t
 end
 
 module TraceMap : module type of Map.Make (Trace_id)

--- a/ocaml/xapi/context.ml
+++ b/ocaml/xapi/context.ml
@@ -337,7 +337,11 @@ let start_tracing_helper ?(span_attributes = []) parent_fn task_name =
       ~parent ()
   with
   | Ok x ->
-      x
+      Option.map
+        (fun span ->
+          span |> Span.to_propagation_context |> Span.with_trace_context span
+        )
+        x
   | Error e ->
       R.warn "Failed to start tracing: %s" (Printexc.to_string e) ;
       None

--- a/xapi-tracing.opam
+++ b/xapi-tracing.opam
@@ -13,11 +13,13 @@ depends: [
   "dune" {>= "3.15"}
   "alcotest" {with-test}
   "fmt" {with-test}
+  "ppx_deriving_yojson"
   "re"
   "uri"
   "uuid" {with-test}
   "xapi-log" {= version}
   "xapi-stdext-threads" {= version}
+  "yojson"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Adds functionality to marshal and unmarshal `TraceContext` in the tracing library.
Instead of passing only the `traceparent` in `debug_info`, the entire `TraceContext` is now passed as JSON.

This change enables the transfer of baggage across xenopsd boundaries, improving tracing propagation and debugging capabilities. This should also enable later use of `baggage` as means of passing the thread classification between components.

Latest BVT+BST:211567