### PR TITLE
CA-404660: Refine repository enabling error message

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1933,10 +1933,10 @@ let _ =
       "The currently enabled repositories do not support periodic automatic \
        updates."
     () ;
-  error Api_errors.repo_should_be_single_one_enabled ["repo_types"]
+  error Api_errors.repo_should_be_single_one_enabled []
     ~doc:
       "If the bundle repository or remote_pool repository is enabled, it \
-       should be the only one enabled repository of the pool."
+       should be the only enabled repository of the pool."
     () ;
   error Api_errors.update_syncing_remote_pool_coordinator_connection_failed []
     ~doc:

--- a/ocaml/tests/test_pool_repository.ml
+++ b/ocaml/tests/test_pool_repository.ml
@@ -41,34 +41,19 @@ let test_set_repositories () =
       Xapi_pool.set_repositories ~__context ~self ~value:[ref_bundle] ;
       Xapi_pool.set_repositories ~__context ~self ~value:[ref_remote_pool] ;
       Alcotest.check_raises "test_set_repositories_1"
-        Api_errors.(
-          Server_error
-            ( repo_should_be_single_one_enabled
-            , [Record_util.origin_to_string `bundle]
-            )
-        )
+        Api_errors.(Server_error (repo_should_be_single_one_enabled, []))
         (fun () ->
           Xapi_pool.set_repositories ~__context ~self
             ~value:[ref_remote; ref_bundle]
         ) ;
       Alcotest.check_raises "test_set_repositories_2"
-        Api_errors.(
-          Server_error
-            ( repo_should_be_single_one_enabled
-            , [`bundle; `remote_pool] |> List.map Record_util.origin_to_string
-            )
-        )
+        Api_errors.(Server_error (repo_should_be_single_one_enabled, []))
         (fun () ->
           Xapi_pool.set_repositories ~__context ~self
             ~value:[ref_remote_pool; ref_bundle]
         ) ;
       Alcotest.check_raises "test_set_repositories_3"
-        Api_errors.(
-          Server_error
-            ( repo_should_be_single_one_enabled
-            , [Record_util.origin_to_string `remote_pool]
-            )
-        )
+        Api_errors.(Server_error (repo_should_be_single_one_enabled, []))
         (fun () ->
           Xapi_pool.set_repositories ~__context ~self
             ~value:[ref_remote; ref_remote_pool]
@@ -78,45 +63,25 @@ let test_set_repositories () =
 let test_add_repository () =
   on_repositories (fun __context self ref_remote ref_bundle ref_remote_pool ->
       Alcotest.check_raises "test_add_repository_1"
-        Api_errors.(
-          Server_error
-            ( repo_should_be_single_one_enabled
-            , [Record_util.origin_to_string `bundle]
-            )
-        )
+        Api_errors.(Server_error (repo_should_be_single_one_enabled, []))
         (fun () ->
           Xapi_pool.set_repositories ~__context ~self ~value:[ref_remote] ;
           Xapi_pool.add_repository ~__context ~self ~value:ref_bundle
         ) ;
       Alcotest.check_raises "test_add_repository_2"
-        Api_errors.(
-          Server_error
-            ( repo_should_be_single_one_enabled
-            , [Record_util.origin_to_string `remote_pool]
-            )
-        )
+        Api_errors.(Server_error (repo_should_be_single_one_enabled, []))
         (fun () ->
           Xapi_pool.set_repositories ~__context ~self ~value:[ref_remote] ;
           Xapi_pool.add_repository ~__context ~self ~value:ref_remote_pool
         ) ;
       Alcotest.check_raises "test_add_repository_3"
-        Api_errors.(
-          Server_error
-            ( repo_should_be_single_one_enabled
-            , [`remote_pool; `bundle] |> List.map Record_util.origin_to_string
-            )
-        )
+        Api_errors.(Server_error (repo_should_be_single_one_enabled, []))
         (fun () ->
           Xapi_pool.set_repositories ~__context ~self ~value:[ref_remote_pool] ;
           Xapi_pool.add_repository ~__context ~self ~value:ref_bundle
         ) ;
       Alcotest.check_raises "test_add_repository_4"
-        Api_errors.(
-          Server_error
-            ( repo_should_be_single_one_enabled
-            , [`bundle; `remote_pool] |> List.map Record_util.origin_to_string
-            )
-        )
+        Api_errors.(Server_error (repo_should_be_single_one_enabled, []))
         (fun () ->
           Xapi_pool.set_repositories ~__context ~self ~value:[ref_bundle] ;
           Xapi_pool.add_repository ~__context ~self ~value:ref_remote_pool

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3466,13 +3466,7 @@ let assert_single_repo_can_be_enabled ~__context ~repos =
   in
   match (repos, origins) with
   | _ :: _ :: _, _ :: _ ->
-      raise
-        Api_errors.(
-          Server_error
-            ( repo_should_be_single_one_enabled
-            , origins |> List.map Record_util.origin_to_string
-            )
-        )
+      raise Api_errors.(Server_error (repo_should_be_single_one_enabled, []))
   | _, _ ->
       ()
 


### PR DESCRIPTION
When enabling pool's repositories, if enabling bundle repo and remoe_pool
repositories at the same time, it returns error message:
`If the bundle repository or remote_pool repository is enabled, it should be
the only one enabled repository of the pool.
repo_types: bundle`
The `repo_types` is confusing and tedious as only these 2 types of repository
can meet this error. So remove the parameter `repo_types`.
