### PR TITLE
CA-404591 - rrd: Do not lose precision when converting floats to strings

### DIFF
--- a/ocaml/libs/xapi-rrd/lib/rrd_utils.ml
+++ b/ocaml/libs/xapi-rrd/lib/rrd_utils.ml
@@ -69,7 +69,7 @@ let array_remove n a =
 let f_to_s f =
   match classify_float f with
   | FP_normal | FP_subnormal ->
-      Printf.sprintf "%0.5g" f
+      Printf.sprintf "%0.15g" f
   | FP_nan ->
       "NaN"
   | FP_infinite ->


### PR DESCRIPTION
`lastupdate` field in the XML RRD blob file, in particular, was getting truncated floats representing the number of seconds, which loses A LOT of precision, meaning RRDs could not be checked to have been produced with the 5-second frequency.