### PR TITLE
CA-403744: Implement other_config operations for task

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -551,6 +551,80 @@ module Task = struct
   let task_allowed_operations =
     Enum ("task_allowed_operations", List.map operation_enum [cancel; destroy])
 
+  module Special = struct
+    (* These keys are usually ascribed to the field directly but,
+       since we are providing custom implementations, we ascribe them
+       to the messages themselves.
+
+       Note that only the "add_to" and "remove_from" messages are
+       protected by these keys. This is because the current RBAC logic
+       is special cased to those messages. The "set_other_config"
+       message has a relaxed RBAC restriction by comparison, and its
+       checking logic is defined in terms of the permissions created
+       for the "add_to" and "remove_from" operations.
+
+       The difference is subtle: if a session attempts to perform
+       "add_to"/"remove_from" upon "other_config", those operations
+       are purely destructive and RBAC checking can be done by the
+       current logic in Rbac.check (which guards the action). However,
+       in the case of "set_other_config", we relax the restriction and
+       must do the RBAC checking ourselves. The relaxed restriction is
+       that the call may maintain entries that it cannot change
+       itself. This means a read-only user can technically supply a
+       map containing privileged entries, so long as those entries are
+       already present. This allows read-only users to update a subset
+       of the entries within "other_config".
+    *)
+    let protected_keys =
+      [
+        ("applies_to", _R_VM_OP)
+      ; ("XenCenterUUID", _R_VM_OP)
+      ; ("XenCenterMeddlingActionTitle", _R_VM_OP)
+      ]
+
+    let call = call ~lifecycle:[] ~errs:[] ~allowed_roles:_R_READ_ONLY
+
+    let add_to_other_config =
+      call ~name:"add_to_other_config"
+        ~doc:
+          "Add the given key-value pair to the other_config field of the given \
+           task."
+        ~params:
+          [
+            (Ref _task, "self", "Task object to modify")
+          ; (String, "key", "Key to add")
+          ; (String, "value", "Value to add")
+          ]
+        ~map_keys_roles:protected_keys ()
+
+    let remove_from_other_config =
+      call ~name:"remove_from_other_config"
+        ~doc:
+          "Remove the given key and its corresponding value from the \
+           other_config field of the given task. If the key is not in that \
+           Map, then do nothing."
+        ~params:
+          [
+            (Ref _task, "self", "Task object to modify")
+          ; (String, "key", "Key of entry to remove")
+          ]
+          (* Privileged key permissions are generated for each of these protected keys. *)
+        ~map_keys_roles:protected_keys ()
+
+    (* We cannot cite the protected keys here as the current RBAC
+       logic only works for "add_to" and "remove_from" and, even if it
+       did, it is too strict. *)
+    let set_other_config =
+      call ~name:"set_other_config"
+        ~doc:"Set the other_config field of the given task."
+        ~params:
+          [
+            (Ref _task, "self", "Task object to modify")
+          ; (Map (String, String), "value", "New value to set")
+          ]
+        ()
+  end
+
   let t =
     create_obj ~in_db:true
       ~lifecycle:[(Published, rel_rio, "A long-running asynchronous task")]
@@ -567,6 +641,9 @@ module Task = struct
         ; set_progress
         ; set_result
         ; set_error_info
+        ; Special.add_to_other_config
+        ; Special.remove_from_other_config
+        ; Special.set_other_config
         ]
       ~contents:
         ([
@@ -716,7 +793,7 @@ module Task = struct
               "error_info"
               "if the task has failed, this field contains the set of \
                associated error strings. Undefined otherwise."
-          ; field
+          ; field ~qualifier:DynamicRO
               ~lifecycle:[(Published, rel_miami, "additional configuration")]
               ~default_value:(Some (VMap []))
               ~ty:(Map (String, String))

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -247,5 +247,11 @@ let prototyped_of_message = function
       Some "22.27.0"
   | "pool", "set_custom_uefi_certificates" ->
       Some "24.0.0"
+  | "task", "set_other_config" ->
+      Some "25.2.0-next"
+  | "task", "remove_from_other_config" ->
+      Some "25.2.0-next"
+  | "task", "add_to_other_config" ->
+      Some "25.2.0-next"
   | _ ->
       None

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "05ac9223f9c17b07b12e328d5dc3db52"
+let last_known_schema_hash = "e6b99e0d07ccf68df8f45c851e5d8dbf"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi/rbac.mli
+++ b/ocaml/xapi/rbac.mli
@@ -22,6 +22,26 @@ val is_access_allowed :
     (on the coordinator only) to benefit successive queries for the
     same session. *)
 
+val find_first_disallowed_permission :
+     __context:Context.t
+  -> session_id:[`session] Ref.t
+  -> permissions:string list
+  -> string option
+(** Given a list of permissions, determine if the given session is
+    permitted to perform the related actions. If not, stop and return
+    the first disallowed permssion (without considering the remaining ones). *)
+
+val disallowed_permission_exn :
+     ?extra_dmsg:string
+  -> ?extra_msg:string
+  -> __context:Context.t
+  -> permission:string
+  -> action:string
+  -> exn
+(** Create an RBAC_PERMISSION_DENIED exception for the given
+    permission. Attempts to report the role(s) which do have the given
+    permission (if any). *)
+
 val check :
      ?extra_dmsg:string
   -> ?extra_msg:string

--- a/ocaml/xapi/xapi_task.ml
+++ b/ocaml/xapi/xapi_task.ml
@@ -88,3 +88,198 @@ let set_resident_on ~__context ~self ~value =
   Context.with_tracing ~__context __FUNCTION__ @@ fun __context ->
   TaskHelper.assert_op_valid ~__context self ;
   Db.Task.set_resident_on ~__context ~self ~value
+
+(* Simple trie data structure that performs a favoured lookup to
+   implement a simple form of wildcard key matching. The trie is not
+   pruned during (or after) construction. *)
+module MatchTrie = struct
+  type 'a node = {arrows: (string, 'a node) Hashtbl.t; mutable value: 'a option}
+
+  let create_node () =
+    let arrows = Hashtbl.create 16 in
+    let value = None in
+    {arrows; value}
+
+  let create = create_node
+
+  let insert root ~key ~value =
+    let parts = String.split_on_char '.' key in
+    let rec extend focused = function
+      | part :: parts ->
+          let next =
+            match Hashtbl.find_opt focused.arrows part with
+            | Some node ->
+                node
+            | _ ->
+                let next = create_node () in
+                Hashtbl.replace focused.arrows part next ;
+                next
+          in
+          extend next parts
+      | [] ->
+          focused
+    in
+    let final = extend root parts in
+    final.value <- Some value
+
+  let find root ~key =
+    let parts = String.split_on_char '.' key in
+    let rec find focused = function
+      | part :: parts -> (
+        (* Wildcard edges override other edges. *)
+        match Hashtbl.find_opt focused.arrows "*" with
+        | Some _ as sink ->
+            sink
+        | _ -> (
+          match Hashtbl.find_opt focused.arrows part with
+          | Some next ->
+              (find [@tailcall]) next parts
+          | _ ->
+              None
+        )
+      )
+      | _ ->
+          Some focused
+    in
+    match find root parts with Some node -> node.value | _ -> None
+end
+
+(* Given an input key, compare against the protected keys of the
+   task.other_config field. If a protected key matches, return it.
+
+   For example, if the datamodel specifies "foo.bar.*" as a protected
+   key, then: match_protected_key ~key:"foo.bar.baz" = Some "foo.bar.*".
+
+   It must return the protected key as that is what key-related RBAC
+   entries are defined in terms of.
+*)
+let match_protected_key =
+  (* Attain the listing of protected keys from the datamodel at module
+     initialisation. Usually, this list is passed to Rbac.check by
+     handlers inside the auto-generated server.ml file. *)
+  let protected_keys =
+    let api = Datamodel.all_api in
+    let field =
+      Dm_api.get_field_by_name api ~objname:"task" ~fieldname:"other_config"
+    in
+    List.map fst field.field_map_keys_roles
+  in
+  (* Define the lookup function in terms of a simple trie data
+     structure - which is flexible to account for overlapping paths and
+     presence of wildcards. *)
+  let trie =
+    let root = MatchTrie.create () in
+    let add key = MatchTrie.insert root ~key ~value:key in
+    List.iter add protected_keys ;
+    root
+  in
+  MatchTrie.find trie
+
+let assert_can_modify_other_config ~__context ~task =
+  TaskHelper.assert_op_valid ~__context task
+
+let add_to_other_config ~__context ~self ~key ~value =
+  assert_can_modify_other_config ~__context ~task:self ;
+  Db.Task.add_to_other_config ~__context ~self ~key ~value
+
+let remove_from_other_config ~__context ~self ~key =
+  assert_can_modify_other_config ~__context ~task:self ;
+  Db.Task.remove_from_other_config ~__context ~self ~key
+
+(* The behaviour of this function, with respect to RBAC checking, must
+   match serial "remove_from" and "add_to" operations (for only the keys
+   that are changing).
+
+   There is normally no key-related RBAC checking for
+   "set_other_config" because the required writer role for the entire
+   field is usually higher than the role(s) required for
+   individually-protected keys.
+
+   Task's "set_other_config" is a special case where read-only
+   sessions must be able to manipulate a subset of entries (those not
+   protected by a more privileged role), along with this capability
+   being restricted to only the task objects that they created.
+*)
+let set_other_config ~__context ~self ~value =
+  let module S = Set.Make (String) in
+  assert_can_modify_other_config ~__context ~task:self ;
+  let create_lookup kvs =
+    let table = List.to_seq kvs |> Hashtbl.of_seq in
+    Hashtbl.find_opt table
+  in
+  let old_value = Db.Task.get_other_config ~__context ~self in
+  let lookup_old, lookup_new = (create_lookup old_value, create_lookup value) in
+  let keys_before, keys_after =
+    let keys = List.map fst in
+    let before = keys old_value in
+    let after = keys value in
+    S.(of_list before, of_list after)
+  in
+  let keys_removed =
+    (* Keys no longer appearing in the map. The user must have the
+       "remove_from" role for each of the protected keys in the set. *)
+    S.diff keys_before keys_after
+  in
+  let keys_unchanged =
+    (* Keys that persist across the update. If any key in this set is
+       protected AND the value mapped to by the key would be changed by
+       the update, the session must have the "add_to" role. *)
+    let updated = S.inter keys_before keys_after in
+    let is_entry_unchanged key =
+      let is_same =
+        let ( let* ) = Option.bind in
+        let* old_value = lookup_old key in
+        let* new_value = lookup_new key in
+        Some (old_value = new_value)
+      in
+      Option.value ~default:false is_same
+    in
+    (* Filter out the unchanged entries, as you don't need any
+       extra privileges to maintain an entry that's already there. *)
+    S.filter is_entry_unchanged updated
+  in
+  let keys_added =
+    (* Treat all keys as new, unless they're referring to entries that
+       are unchanged across the update. *)
+    S.diff keys_after keys_unchanged
+  in
+  let permissions =
+    (* Map each of the added and removed keys to protected keys, if
+       such a key exists. *)
+    let filter keys =
+      S.filter_map (fun key -> match_protected_key ~key) keys |> S.elements
+    in
+    let added = filter keys_added in
+    let removed = filter keys_removed in
+    let format operation key =
+      (* All the permissions are stored in lowercase. *)
+      let key = String.lowercase_ascii key in
+      Printf.sprintf "task.%s_other_config/key:%s" operation key
+    in
+    (* The required permissions are defined in terms of those
+       generated for "add_to" and "remove_from" (both implemented
+       above). They can be defined as custom AND use RBAC checking within
+       server.ml because their operation is purely destructive, so it's
+       sufficient to guard the entire action with Rbac.check. *)
+    let added_perms = List.map (format "add_to") added in
+    let removed_perms = List.map (format "remove_from") removed in
+    added_perms @ removed_perms
+  in
+  (* Find the first disallowed permission, indicating that we cannot
+     perform the action. *)
+  let session_id = Context.get_session_id __context in
+  match
+    Rbac.find_first_disallowed_permission ~__context ~session_id ~permissions
+  with
+  | None ->
+      (* No disallowed permission, perform the update. *)
+      Db.Task.set_other_config ~__context ~self ~value
+  | Some disallowed ->
+      (* Report it as an RBAC error. *)
+      let action = "task.set_other_config" in
+      let extra_msg = "" in
+      let extra_dmsg = "" in
+      raise
+        (Rbac.disallowed_permission_exn ~extra_dmsg ~extra_msg ~__context
+           ~permission:disallowed ~action
+        )


### PR DESCRIPTION
Currently, users with read-only permissions can freely manipulate their own tasks (create, cancel, destroy, etc.). However, they cannot easily manipulate the `other_config` field. Some keys are specified in the datamodel as being writeable by subjects with the VM operator role.

However, RBAC checking for keys was only ever implemented for the individual "add" and "remove" operations, not the `set_other_config` operation. This makes sense because the typical scenario is that the required writer role for an "other_config" field is more privileged than each of the individually-specified key-specific roles.

In the case of tasks, the desired role for the `set_other_config` operation is the read-only role. However, we cannot simply demote the required "writer role" for the `other_config` field, because:

1) We must maintain key-based RBAC checks for the operation. For
   example, if a read-only user attempts to modify a task's `other_config`
   using `set_other_config`, the operation must fail if they've attempted
   to modify the value mapped to by some key that they are not
   privileged to use.

2) Key-based RBAC checking is special cased to `add_to` and
   `remove_from`. You can attempt to ascribe key-related role
   restrictions to arbitrary messages but these will all fail at
   runtime, when invoked - because `Rbac.check` is special cased to expect
   to be able to extract out the key name from a `key` argument it
   receives, which is emitted for `add_to` and `remove_from`.

3) There is an additional restriction that read-only users should not be
   able to modify arbitrary tasks, only their own.

Both of these points require a custom implementation. To this end, we mark `other_config` as read-only (DynamicRO) and implement custom handlers for the `add_to`, `remove_from`, and `set` operations. In doing so, we implement a subset of the RBAC protection logic for keys.

This custom implementation amounts to a relaxation of the usual RBAC rules: where `add_to` and `remove_from` (both purely destructive operations) cite a protected key (that they are not permitted to write), RBAC fails. In the custom implementation of `set_other_config`, an under-privileged session can cite any key so long as their change is not destructive (it must preserve what is already there).

---

The motivation for this change is in fusing serial `add_to_other_config` and `remove_from_other_config` operations into a single `set_other_config` call. I've included (possibly excessive) commentary within the code as the RBAC checking stuff is not touched a lot. This change may not be desirable overall, as it has low impact.