### PR TITLE
CA-404693 prohibit selecting driver variant if h/w not present

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -2010,6 +2010,9 @@ let _ =
 
   error Api_errors.too_many_groups [] ~doc:"VM can only belong to one group." () ;
 
+  error Api_errors.host_driver_no_hardware ["driver variant"]
+    ~doc:"No hardware present for this host driver variant" () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1403,3 +1403,5 @@ let telemetry_next_collection_too_late =
 let illegal_in_fips_mode = add_error "ILLEGAL_IN_FIPS_MODE"
 
 let too_many_groups = add_error "TOO_MANY_GROUPS"
+
+let host_driver_no_hardware = add_error "HOST_DRIVER_NO_HARDWARE"


### PR DESCRIPTION
Introduce a new error and raise it if a host driver variant is selected for hardware that is not present.