### PR TITLE
Added preprocessor directive so that the assembly internals are visib…

### DIFF
--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -168,6 +168,7 @@ jobs:
         run: |
           dotnet test source/XenServerTest `
           --disable-build-servers `
+          -p:DefineConstants=BUILD_FOR_TEST `
           --verbosity=normal
 
       - name: Build C# SDK

--- a/ocaml/sdk-gen/csharp/autogen/src/Converters.cs
+++ b/ocaml/sdk-gen/csharp/autogen/src/Converters.cs
@@ -36,7 +36,9 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
+#if BUILD_FOR_TEST
 [assembly: InternalsVisibleTo("XenServerTest")]
+#endif
 
 namespace XenAPI
 {


### PR DESCRIPTION
…le to XenServerTest only when specified.

Making the internals visible to a friend assembly works only if both assemblies are signed with a strong name or both unsigned. The code won't compile in scenarios where only the source code needs to be built and signed with a .snk key, therefore I'm suggesting using a preprocessor directive that can be switched on and off by the build caller (the other option is to put both source and test projects in a solution and build and sign both at all times, but at the moment I think we can go with the easy option).