### PR TITLE
opam: add missing dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -271,6 +271,7 @@
     xapi-stdext-pervasives
     xapi-stdext-unix
     xen-api-client
+    xen-api-client-lwt
     xenctrl
     xenstore_transport
     xmlm
@@ -396,6 +397,7 @@
     (xapi-tracing (= :version))
     (xapi-tracing-export (= :version))
     (xapi-types (= :version))
+    (xen-api-client-lwt (= :version))
     xenctrl ; for quicktest
     xenstore_transport
     xmlm

--- a/xapi-debug.opam
+++ b/xapi-debug.opam
@@ -58,6 +58,7 @@ depends: [
   "xapi-stdext-pervasives"
   "xapi-stdext-unix"
   "xen-api-client"
+  "xen-api-client-lwt"
   "xenctrl"
   "xenstore_transport"
   "xmlm"

--- a/xapi.opam
+++ b/xapi.opam
@@ -86,6 +86,7 @@ depends: [
   "xapi-tracing" {= version}
   "xapi-tracing-export" {= version}
   "xapi-types" {= version}
+  "xen-api-client-lwt" {= version}
   "xenctrl"
   "xenstore_transport"
   "xmlm"


### PR DESCRIPTION
These were added for the SMAPIv3-inbound VM migrations