### PR TITLE
CP-53335, topology: do not raise exception when loading invalid distance matrices (NUMA)

### DIFF
--- a/ocaml/xenopsd/lib/topology.ml
+++ b/ocaml/xenopsd/lib/topology.ml
@@ -14,8 +14,6 @@
 
 module D = Debug.Make (struct let name = "topology" end)
 
-open D
-
 module CPUSet = struct
   include Set.Make (struct
     type t = int
@@ -205,12 +203,8 @@ module NUMA = struct
     |> seq_sort ~cmp:dist_cmp
     |> Seq.map (fun ((_, avg), nodes) -> (avg, Seq.map (fun n -> Node n) nodes))
 
-  let pp_dump_distances = Fmt.(int |> Dump.array |> Dump.array)
-
   let make ~distances ~cpu_to_node =
     let ( let* ) = Option.bind in
-    debug "Distances: %s" (Fmt.to_to_string pp_dump_distances distances) ;
-    debug "CPU2Node: %s" (Fmt.to_to_string Fmt.(Dump.array int) cpu_to_node) ;
     let node_cpus = Array.map (fun _ -> CPUSet.empty) distances in
 
     (* nothing can be scheduled on unreachable nodes, remove them from the
@@ -222,9 +216,6 @@ module NUMA = struct
           node_cpus.(node) <- CPUSet.add i node_cpus.(node)
       )
       cpu_to_node ;
-
-    debug "Cpus in node: %s"
-      Fmt.(to_to_string (Dump.array CPUSet.pp_dump) node_cpus) ;
 
     let* () =
       if Array.for_all (fun cpus -> CPUSet.is_empty cpus) node_cpus then (

--- a/ocaml/xenopsd/lib/topology.ml
+++ b/ocaml/xenopsd/lib/topology.ml
@@ -181,18 +181,22 @@ module NUMA = struct
                None
          )
     in
-    let numa_nodes = Array.length d in
+    let numa_nodes = Seq.length valid_nodes in
     let nodes =
-      if numa_nodes > 16 then
+      if numa_nodes > 16 then (
         (* Avoid generating too many candidates because of the exponential
            running time. We could do better here, e.g. by
            reducing the matrix *)
+        D.info
+          "%s: More than 16 valid NUMA nodes detected, considering only \
+           individual nodes."
+          __FUNCTION__ ;
         valid_nodes
         |> Seq.map (fun i ->
                let self = d.(i).(i) in
                (distance_to_candidate self, Seq.return i)
            )
-      else
+      ) else
         valid_nodes |> seq_all_subsets |> Seq.filter_map (node_distances d)
     in
     nodes

--- a/ocaml/xenopsd/lib/topology.ml
+++ b/ocaml/xenopsd/lib/topology.ml
@@ -15,11 +15,7 @@
 module D = Debug.Make (struct let name = "topology" end)
 
 module CPUSet = struct
-  include Set.Make (struct
-    type t = int
-
-    let compare (x : int) (y : int) = compare x y
-  end)
+  include Set.Make (Int)
 
   let pp_dump = Fmt.using to_seq Fmt.(Dump.seq int)
 

--- a/ocaml/xenopsd/lib/topology.mli
+++ b/ocaml/xenopsd/lib/topology.mli
@@ -78,7 +78,7 @@ module NUMA : sig
   (** A NUMA node index. Distinct from an int to avoid mixing with CPU numbers *)
   type node = private Node of int
 
-  val make : distances:int array array -> cpu_to_node:int array -> t
+  val make : distances:int array array -> cpu_to_node:int array -> t option
   (** [make distances cpu_to_node] stores the topology. [distances] is a square
       matrix [d] where [d.(i).(j)] is an approximation to how much slower it is
       to access memory from node [j] when running on node [i]. Distances are
@@ -96,8 +96,6 @@ module NUMA : sig
       [cpu_to_nodes.(i)] = NUMA node of CPU [i]
 
       NUMA nodes without any CPUs are accepted (to handle hard affinities).
-
-      Raises [invalid_arg] if above constraints are not met
 
       A typical matrix might look like this:
 

--- a/ocaml/xenopsd/test/dune
+++ b/ocaml/xenopsd/test/dune
@@ -1,11 +1,9 @@
 (test
  (name test)
- (modes exe)
+ (modules :standard \ test_cpuid test_topology)
  (package xapi-tools)
  (libraries
   alcotest
-  cpuid
-  
   fmt
   result
   rpclib.core
@@ -15,13 +13,25 @@
   xapi-idl.xen.interface.types
   xapi-log
   xapi-stdext-pervasives
-  xapi-test-utils
   xapi_xenopsd
-  xenstore_transport.unix
  )
  (preprocess
   (per_module ((pps ppx_deriving_rpc) Test))
  )
+)
+
+(test
+  (name test_cpuid)
+  (modules test_cpuid)
+  (package xapi-tools)
+  (libraries alcotest cpuid xapi-test-utils xapi_xenopsd)
+)
+
+(test
+  (name test_topology)
+  (modules test_topology)
+  (package xapi-tools)
+  (libraries alcotest fmt xapi-log xapi_xenopsd)
 )
 
 (rule

--- a/ocaml/xenopsd/test/test.ml
+++ b/ocaml/xenopsd/test/test.ml
@@ -1032,4 +1032,4 @@ let _ =
     )
   in
   Debug.log_to_stdout () ;
-  Alcotest.run "xenops test" ([suite; Test_topology.suite] @ Test_cpuid.tests)
+  Alcotest.run "xenops test" [suite]

--- a/ocaml/xenopsd/test/test_cpuid.ml
+++ b/ocaml/xenopsd/test/test_cpuid.ml
@@ -327,3 +327,5 @@ let tests =
     ; ("equality", Equality.tests)
     ; ("comparisons", Comparisons.tests)
     ]
+
+let () = Alcotest.run "CPUID" tests

--- a/ocaml/xenopsd/test/test_topology.ml
+++ b/ocaml/xenopsd/test/test_topology.ml
@@ -186,51 +186,55 @@ let test_allocate ?(mem = default_mem) (expected_cores, h) ~vms () =
 let () = Printexc.record_backtrace true
 
 let suite =
-  ( "topology test"
-  , [
-      ( "Allocation of 1 VM on 1 node"
-      , `Quick
-      , test_allocate ~vms:1 @@ make_numa ~numa:1 ~cores:2
-      )
-    ; ( "Allocation of 10 VMs on 1 node"
-      , `Quick
-      , test_allocate ~vms:10 @@ make_numa ~numa:1 ~cores:8
-      )
-    ; ( "Allocation of 1 VM on 2 nodes"
-      , `Quick
-      , test_allocate ~vms:1 @@ make_numa ~numa:2 ~cores:4
-      )
-    ; ( "Allocation of 10 VM on 2 nodes"
-      , `Quick
-      , test_allocate ~vms:10 @@ make_numa ~numa:2 ~cores:4
-      )
-    ; ( "Allocation of 1 VM on 4 nodes"
-      , `Quick
-      , test_allocate ~vms:1 @@ make_numa ~numa:4 ~cores:16
-      )
-    ; ( "Allocation of 10 VM on 4 nodes"
-      , `Quick
-      , test_allocate ~vms:10 @@ make_numa ~numa:4 ~cores:16
-      )
-    ; ( "Allocation of 40 VM on 16 nodes"
-      , `Quick
-      , test_allocate ~vms:40 @@ make_numa ~numa:16 ~cores:256
-      )
-    ; ( "Allocation of 40 VM on 32 nodes"
-      , `Quick
-      , test_allocate ~vms:40 @@ make_numa ~numa:32 ~cores:256
-      )
-    ; ( "Allocation of 40 VM on 64 nodes"
-      , `Quick
-      , test_allocate ~vms:80 @@ make_numa ~numa:64 ~cores:256
-      )
-    ; ( "Allocation of 10 VM on assymetric nodes"
-      , `Quick
-      , test_allocate ~vms:10 (make_numa_amd ~cores_per_numa:4)
-      )
-    ; ( "Allocation of 10 VM on assymetric nodes"
-      , `Quick
-      , test_allocate ~vms:6 ~mem:mem3 (make_numa_amd ~cores_per_numa:4)
-      )
-    ]
-  )
+  [
+    ( "Allocation tests"
+    , [
+        ( "Allocation of 1 VM on 1 node"
+        , `Quick
+        , test_allocate ~vms:1 @@ make_numa ~numa:1 ~cores:2
+        )
+      ; ( "Allocation of 10 VMs on 1 node"
+        , `Quick
+        , test_allocate ~vms:10 @@ make_numa ~numa:1 ~cores:8
+        )
+      ; ( "Allocation of 1 VM on 2 nodes"
+        , `Quick
+        , test_allocate ~vms:1 @@ make_numa ~numa:2 ~cores:4
+        )
+      ; ( "Allocation of 10 VM on 2 nodes"
+        , `Quick
+        , test_allocate ~vms:10 @@ make_numa ~numa:2 ~cores:4
+        )
+      ; ( "Allocation of 1 VM on 4 nodes"
+        , `Quick
+        , test_allocate ~vms:1 @@ make_numa ~numa:4 ~cores:16
+        )
+      ; ( "Allocation of 10 VM on 4 nodes"
+        , `Quick
+        , test_allocate ~vms:10 @@ make_numa ~numa:4 ~cores:16
+        )
+      ; ( "Allocation of 40 VM on 16 nodes"
+        , `Quick
+        , test_allocate ~vms:40 @@ make_numa ~numa:16 ~cores:256
+        )
+      ; ( "Allocation of 40 VM on 32 nodes"
+        , `Quick
+        , test_allocate ~vms:40 @@ make_numa ~numa:32 ~cores:256
+        )
+      ; ( "Allocation of 40 VM on 64 nodes"
+        , `Quick
+        , test_allocate ~vms:80 @@ make_numa ~numa:64 ~cores:256
+        )
+      ; ( "Allocation of 10 VM on assymetric nodes"
+        , `Quick
+        , test_allocate ~vms:10 (make_numa_amd ~cores_per_numa:4)
+        )
+      ; ( "Allocation of 10 VM on assymetric nodes"
+        , `Quick
+        , test_allocate ~vms:6 ~mem:mem3 (make_numa_amd ~cores_per_numa:4)
+        )
+      ]
+    )
+  ]
+
+let () = Alcotest.run "Topology tests" suite

--- a/ocaml/xenopsd/test/test_topology.ml
+++ b/ocaml/xenopsd/test/test_topology.ml
@@ -281,17 +281,14 @@ let allocate_tests =
 let distances_tests =
   let specs =
     [
-      ( "Last node is unreachable"
-      , Distances.unreachable_last
-      , Some [(10., [0]); (10., [0])]
-      )
+      ("Last node is unreachable", Distances.unreachable_last, Some [(10., [0])])
     ; ( "Node in the middle is unreachable"
       , Distances.unreachable_middle
-      , Some [(10., [0]); (10., [2]); (10., [0]); (10., [2]); (15., [0; 2])]
+      , Some [(10., [0]); (10., [2]); (15., [0; 2])]
       )
     ; ( "The first two nodes are unreachable"
       , Distances.unreachable_two
-      , Some [(10., [2]); (10., [2])]
+      , Some [(10., [2])]
       )
     ; ("All nodes are unreachable", Distances.none_reachable, None)
     ]

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -851,7 +851,7 @@ let numa_init () =
   let host = Lazy.force numa_hierarchy in
   let mem = (Xenctrlext.numainfo xcext).memory in
   D.debug "Host NUMA information: %s"
-    (Fmt.to_to_string Topology.NUMA.pp_dump host) ;
+    (Fmt.to_to_string (Fmt.Dump.option Topology.NUMA.pp_dump) host) ;
   Array.iteri
     (fun i m ->
       let open Xenctrlext in
@@ -864,8 +864,9 @@ let numa_placement domid ~vcpus ~memory =
   let open Topology in
   let hint =
     with_lock numa_mutex (fun () ->
+        let ( let* ) = Option.bind in
         let xcext = get_handle () in
-        let host = Lazy.force numa_hierarchy in
+        let* host = Lazy.force numa_hierarchy in
         let numa_meminfo = (numainfo xcext).memory |> Array.to_list in
         let nodes =
           ListLabels.map2


### PR DESCRIPTION
Unreachable nodes do not contain any CPUs, and therefore VCPUs cannot be
scheduled on them. They marked with a value of (2ˆ32) - 1. Instead of failing
to produce a NUMA object that allows for scheduling, create an object that
contains only schedulable NUMA nodes. This means changing how the
datastructures node_cpus and candidates are created to ignore the unreachable
ones.

Fixes two minor potential issues (distances being NaN, and adding duplicates to candidates, which adds to running time); and separates the xenopsd unit tests into 3 binaries for ease of testing.

Fixes https://github.com/xapi-project/xen-api/issues/6240