### PR TITLE
CA-405404: Fix path to dracut

### DIFF
--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -63,7 +63,7 @@ let bonding_dir = "/proc/net/bonding/"
 
 let uname = ref "/usr/bin/uname"
 
-let dracut = ref "/sbin/dracut"
+let dracut = ref "/usr/bin/dracut"
 
 let modinfo = ref "/sbin/modinfo"
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -935,7 +935,7 @@ let depmod = ref "/usr/sbin/depmod"
 
 let driver_tool = ref "/opt/xensource/debug/drivertool.sh"
 
-let dracut = ref "/usr/sbin/dracut"
+let dracut = ref "/usr/bin/dracut"
 
 let udevadm = ref "/usr/sbin/udevadm"
 


### PR DESCRIPTION
On all platforms tested the canonical location for dracut is `/usr/bin/dracut`. Older platforms symlink to it from `/usr/sbin/dracut`, whilst newer ones do not, thus on these platforms xapi is unable to find dracut and fails to start.

Adjust the path to the canonical location to ensure it operates correctly on all platforms.

Also adjust a reference in network_utils.ml (whilst newer platforms also seem to have the symlink from `/sbin/dracut`, it would seem to make sense to point to the canonical location regardless).