### PR TITLE
CI: When only Hugo docs change, other workflows do not need to run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,15 @@
 name: Build and test
 
 on:
+  # When only Hugo docs change, this workflow is not required:
   push:
+    paths-ignore:
+      - 'doc/**'
+      - '.github/workflows/hugo.yml'
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '.github/workflows/hugo.yml'
   schedule:
     # run daily, this refreshes the cache
     - cron: "13 2 * * *"

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -1,8 +1,15 @@
 name: Build and test (other)
 
 on:
+  # When only Hugo docs change, this workflow is not required:
   push:
+    paths-ignore:
+      - 'doc/**'
+      - '.github/workflows/hugo.yml'
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '.github/workflows/hugo.yml'
   schedule:
     # run daily, this refreshes the cache
     - cron: "13 2 * * *"

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -2,6 +2,10 @@ name: ShellCheck
 
 on:
   pull_request:
+    # When only Hugo docs change, this workflow is not required:
+    paths-ignore:
+      - 'doc/**'
+      - '.github/workflows/hugo.yml'
   merge_group:
 
 concurrency:  # On new push, cancel old workflows from the same PR, branch or tag:


### PR DESCRIPTION
Optional improvement for fast CI completion when only Hugo docs change on push/PRs:

When only Hugo docs change on push and PRs, other workflows can be skipped using
`paths-ignore:` for `docs/**` and `.github/workflows/hugo.yml` to not trigger other
workflows if only these paths change when pushing to a branch / work on a PR.

This is completely optional, but would be nice to have when only working on Hugo docs.
It does not change scheduled CI runs. It changes only on-demand push/PR workflow runs.