### PR TITLE
Hugo docs: Fix {{site.baseurl}} links to use relative internal links instead

### DIFF
--- a/doc/content/design/integrated-gpu-passthrough/index.md
+++ b/doc/content/design/integrated-gpu-passthrough/index.md
@@ -11,7 +11,7 @@ Introduction
 ------------
 
 Passthrough of discrete GPUs has been
-[available since XenServer 6.0]({{site.baseurl}}/xapi/design/gpu-passthrough.html).
+[available since XenServer 6.0](../gpu-passthrough.md).
 With some extensions, we will also be able to support passthrough of integrated
 GPUs.
 

--- a/doc/content/toolstack/features/VGPU/index.md
+++ b/doc/content/toolstack/features/VGPU/index.md
@@ -89,7 +89,7 @@ hardware and config files present in dom0. They exist in the pool database, and
 a primary key is used to avoid duplication. In XenServer 6.x the tuple of
 `(vendor_name, model_name)` was used as the primary key, however this was not
 ideal as these values are subject to change. XenServer 7.0 switched to a
-[new primary key]({{site.baseurl}}/xapi/futures/vgpu-type-identifiers.html)
+[new primary key](../../../design/vgpu-type-identifiers)
 generated from static metadata, falling back to the old method for backwards
 compatibility.
 
@@ -109,12 +109,12 @@ on PGPUs.
 
 In XenServer 6.x, all VGPU config was added to the VM's `platform` field at
 startup, and this information was used by xenopsd to start the display emulator.
-See the relevant code [here][5].
+See the relevant code in [ocaml/xapi/vgpuops.ml][5].
 
 In XenServer 7.0, to facilitate support of VGPU on Intel hardware in parallel
 with the existing NVIDIA support, VGPUs were made first-class objects in the
-xapi-xenopsd interface. The interface is described
-[here]({{site.baseurl}}/features/futures/gpu-support-evolution.html).
+xapi-xenopsd interface. The interface is described in the design document on
+the [GPU support evolution](../../../design/gpu-support-evolution).
 
 ## VM startup
 


### PR DESCRIPTION
For links to internal pages, `{{site.baseurl}}` (without the leading `.`) does not
work in current Hugo, and it is better to replace it by using relative links:

`{{.Site.BaseURL}}` is replaced in the rendered output, but it doesn't work when
viewing and editing the files using Markdown editors and viewers like on GitHub/Lab
as well as IDEs with improved support for Markdown editing(in editor and preview).

As the relative links work in all cases like in the editors and previews,
fix those (currently broken) links to use the relative links instead.

While at those, also replace the link name "here" with a more specific link name.

PS: The only place were `{{.Site.BaseURL}}` or similar is needed is the link in
the `logo.html` template for `img="{{.Site.BaseURL}}/images/xapi-project.png"`