### PR TITLE
CA-400272: pool.set_igmp_snooping_enabled: ignore non-managed PIFs

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -3309,6 +3309,7 @@ let set_igmp_snooping_enabled ~__context ~self ~value =
                       if
                         pif_record.API.pIF_VLAN = -1L
                         && pif_record.API.pIF_bond_slave_of = Ref.null
+                        && pif_record.API.pIF_managed
                       then
                         Client.Network.attach ~rpc ~session_id ~network ~host ;
                       fail'


### PR DESCRIPTION
The call currently calls `network.attach` on all networks, but this fails for PIFs that are not managed by xapi. Simply skip those.