### PR TITLE
Revert VM migration shutdown order change + change post_detach to post_deactivate

### DIFF
--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -1320,7 +1320,7 @@ let pre_deactivate_hook ~dbg:_ ~dp:_ ~sr ~vdi =
              s.failed <- true
      )
 
-let post_detach_hook ~sr ~vdi ~dp:_ =
+let post_deactivate_hook ~sr ~vdi ~dp:_ =
   let open State.Send_state in
   let id = State.mirror_id_of (sr, vdi) in
   State.find_active_local_mirror id

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -422,10 +422,10 @@ functor
               | Vdi_automaton.Deactivate ->
                   Storage_migrate.pre_deactivate_hook ~dbg ~dp ~sr ~vdi ;
                   Impl.VDI.deactivate context ~dbg ~dp ~sr ~vdi ~vm ;
+                  Storage_migrate.post_deactivate_hook ~sr ~vdi ~dp ;
                   vdi_t
               | Vdi_automaton.Detach ->
                   Impl.VDI.detach context ~dbg ~dp ~sr ~vdi ~vm ;
-                  Storage_migrate.post_detach_hook ~sr ~vdi ~dp ;
                   vdi_t
             in
             Sr.add_or_replace vdi new_vdi_t sr_t ;


### PR DESCRIPTION
There are two parts to this PR:

1. Reverts the VM migration ordering change, which was previously thought to be necessary as I did not see `VM_save` would actually deactivate the source VM datapath. Thanks @edwintorok for pointing that out.
2. Change `post_detach_hook` to `post_deactivate_hook`, as this should have been called as soon as the datapath is deactivated, at which point all r/w using that datapath will be stopped.

More details in the commit message.