### PR TITLE
CA-405593: Do not write extraneous data into the host certificate file

### DIFF
--- a/ocaml/gencert/lib.mli
+++ b/ocaml/gencert/lib.mli
@@ -43,8 +43,6 @@ val validate_not_expired :
 (** The following functions are exposed exclusively for unit-testing, please
     do not use them directly, they are not stable *)
 
-type t_certificate = Leaf | Chain
-
 val validate_private_key :
      string
   -> ( [> `RSA of Mirage_crypto_pk.Rsa.priv]
@@ -52,9 +50,12 @@ val validate_private_key :
      )
      Result.result
 
-val validate_certificate :
-     t_certificate
-  -> string
+val validate_pem_chain :
+     pem_leaf:string
+  -> pem_chain:string option
   -> Ptime.t
   -> [> `RSA of Mirage_crypto_pk.Rsa.priv]
-  -> (X509.Certificate.t, [> `Msg of string * string list]) Rresult.result
+  -> ( X509.Certificate.t * X509.Certificate.t list option
+     , [> `Msg of string * string list]
+     )
+     Result.t


### PR DESCRIPTION
When installing host certificates, the parser used accepts string with random characters surrounding the PEM-encoded data. The ad-hoc parser used to read the host certificate file was unable to parse them.

Because the PEM-encoded objects are copied as-is after validating them, the ad-hoc parser fails to read the file correctly when xapi restarts.

This change fixes the issue by making sure that the written file's data has been sanitized, by using parsed datastructures instead of user-provided data.

    Parse, don't validate

I've manually tested the fix on a host, before and after to validate that indeed now all the characters in between the PEM-encoded objects are stripped