### PR TITLE
doc, comment: Fix spelling of ommitted (incorrect) to omitted

### DIFF
--- a/doc/content/xen-api/wire-protocol.md
+++ b/doc/content/xen-api/wire-protocol.md
@@ -277,11 +277,11 @@ contains the members `jsonrpc`, `method`, `params`, and `id`.
 
 -  `params`: A JSON `array` of values, which represents the parameters of the
   function to be invoked. Although the JSON-RPC v2.0 specification allows this
-  member to be ommitted, in practice all API calls accept at least one parameter.
+  member to be omitted, in practice all API calls accept at least one parameter.
 
 -  `id`: A JSON `string` or `integer` representing the call id. Note that,
   diverging from the JSON-RPC v2.0 specification it cannot be null. Neither can
-  it be ommitted because the API does not accept _notification_ requests
+  it be omitted because the API does not accept _notification_ requests
   (requests without responses).
 
 For example, the body of a JSON-RPC v2.0 request to retrieve the VMs resident on
@@ -619,7 +619,7 @@ connection, this can be done as follows:
 
 Acquire a session reference by logging in with a username and password; the
 session reference is returned under the key `Value` in the resulting dictionary
-(error-handling ommitted for brevity):
+(error-handling omitted for brevity):
 
 ```python
 >>> session = xen.session.login_with_password("user", "passwd",

--- a/ocaml/vhd-tool/src/tar.md
+++ b/ocaml/vhd-tool/src/tar.md
@@ -19,9 +19,9 @@ The first and last blocks must be present. Readers expect the block size to be e
 ## Omitting empty blocks
 
 If it is known that a block is entirely empty (i.e. full of zeroes) then it may
-be ommitted from the stream *provided it is neither the first nor the last block*.
+be omitted from the stream *provided it is neither the first nor the last block*.
 The ommission is signaled by incrementing the counter value by 1 for every
-ommitted block.
+omitted block.
 
 Example sequence 1:
 
@@ -34,7 +34,7 @@ Example sequence 1:
 00000002.checksum
 ```
 
-no blocks have been ommitted, since the counter value increases by 1 each block.
+no blocks have been omitted, since the counter value increases by 1 each block.
 
 Example sequence 2:
 
@@ -45,7 +45,7 @@ Example sequence 2:
 00000002.checksum
 ```
 
-one block has been ommitted, since the counter value increased by 2.
+one block has been omitted, since the counter value increased by 2.
 
 ## Inserting dummy blocks
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -694,7 +694,7 @@ let destroy ~__context ~self =
 
 (* Note: we don't need to call lock_vm around clone or copy. The lock_vm just takes the local
    lock on a specific pool host and is used to manage contention between API threads and the
-   event monitoring thread on live VMs. Since clone does not deal with live VMs we ommit lock_vm. *)
+   event monitoring thread on live VMs. Since clone does not deal with live VMs we omit lock_vm. *)
 
 let clone ~__context ~vm ~new_name =
   TaskHelper.set_cancellable ~__context ;


### PR DESCRIPTION
doc, comment: Fix all spellings of omitted(from omit) from incorrect: "ommitted"
- Even if it may sound like "mm", English dictionaries and spelling sites say "omitted".