### PR TITLE
CP-53161: `Baggage` threaded through `smapi` and back into `xapi`

### DIFF
--- a/ocaml/libs/tracing/dune
+++ b/ocaml/libs/tracing/dune
@@ -1,7 +1,7 @@
 (library
  (name tracing)
  (modules tracing)
- (libraries re uri yojson xapi-log xapi-stdext-threads threads.posix)
+ (libraries astring re uri yojson xapi-log xapi-stdext-threads threads.posix)
  (preprocess
   (pps ppx_deriving_yojson))
  (public_name xapi-tracing))
@@ -33,7 +33,7 @@
 (library
  (name tracing_propagator)
  (modules propagator)
- (libraries astring http-lib tracing))
+ (libraries http-lib tracing))
 
 (test
  (name test_tracing)

--- a/ocaml/libs/tracing/tracing.mli
+++ b/ocaml/libs/tracing/tracing.mli
@@ -95,6 +95,10 @@ module TraceContext : sig
 
   val baggage_of : t -> baggage option
 
+  val parse : string -> baggage
+
+  val encode_baggage : t -> string option
+
   val to_json_string : t -> string
 
   val of_json_string : string -> (t, string) result

--- a/python3/examples/XenAPI/XenAPI.py
+++ b/python3/examples/XenAPI/XenAPI.py
@@ -124,6 +124,10 @@ class UDSTransport(xmlrpclib.Transport):
             if traceparent:
                 self.add_extra_header("traceparent", traceparent)
 
+        baggage = os.getenv("BAGGAGE", None)
+        if baggage:
+            self.add_extra_header("baggage", baggage)
+
     def with_originator(self):
         originator_k = "ORIGINATOR"
         originator_v = os.getenv(originator_k, None)

--- a/python3/examples/XenAPI/XenAPI.py
+++ b/python3/examples/XenAPI/XenAPI.py
@@ -118,6 +118,11 @@ class UDSTransport(xmlrpclib.Transport):
 
             for k, v in headers.items():
                 self.add_extra_header(k, v)
+        else:
+            headers ={}
+            traceparent = os.getenv("TRACEPARENT", None)
+            if traceparent:
+                self.add_extra_header("traceparent", traceparent)
 
     def with_originator(self):
         originator_k = "ORIGINATOR"

--- a/python3/packages/observer.py
+++ b/python3/packages/observer.py
@@ -210,6 +210,13 @@ def _init_tracing(configs: List[str], config_dir: str):
             if "=" in item
         )
 
+        baggage = os.getenv("BAGGAGE")
+        if baggage:
+            update = dict(
+                item.split("=", 1) for item in baggage.split(";") if "=" in item
+            )
+            otel_resource_attrs.update(update)
+
         service_name = config.get(
             "otel_service_name", otel_resource_attrs.get("service.name", "unknown")
         )


### PR DESCRIPTION
It continues the path of threading the `trace_context` across different components. Specifically, from `xapi` to `smapi` and back to `xapi`. 

Additional improvement: the tracecontext is passed even when `smapi` component is experimental and it does not create spans. Therefore, it is not creating orphaned spans from http requests made to xapi.

BVT+BST: 213297