### PR TITLE
Optimize Pool_role fastpath

### DIFF
--- a/ocaml/tests/bench/bench_cached_reads.ml
+++ b/ocaml/tests/bench/bench_cached_reads.ml
@@ -1,0 +1,16 @@
+open Bechamel
+
+let run () =
+  let _ : bool = Sys.opaque_identity (Pool_role.is_master ()) in
+  ()
+
+let mutex_workload =
+  Bechamel_simple_cli.thread_workload ~before:ignore ~after:ignore ~run
+
+let free_threads (stop, t) = Atomic.set stop true ; Array.iter Thread.join t
+
+let benchmarks =
+  Test.make_grouped ~name:"Cached reads"
+    [Test.make ~name:"Pool_role.is_master" (Staged.stage Pool_role.is_master)]
+
+let () = Bechamel_simple_cli.cli ~workloads:[mutex_workload] benchmarks

--- a/ocaml/tests/bench/bench_cached_reads.ml
+++ b/ocaml/tests/bench/bench_cached_reads.ml
@@ -7,8 +7,6 @@ let run () =
 let mutex_workload =
   Bechamel_simple_cli.thread_workload ~before:ignore ~after:ignore ~run
 
-let free_threads (stop, t) = Atomic.set stop true ; Array.iter Thread.join t
-
 let benchmarks =
   Test.make_grouped ~name:"Cached reads"
     [Test.make ~name:"Pool_role.is_master" (Staged.stage Pool_role.is_master)]

--- a/ocaml/tests/bench/dune
+++ b/ocaml/tests/bench/dune
@@ -1,4 +1,4 @@
 (executables
-	(names bench_tracing bench_uuid bench_throttle2)
+	(names bench_tracing bench_uuid bench_throttle2 bench_cached_reads)
 	(libraries tracing bechamel bechamel-notty notty.unix tracing_export threads.posix fmt notty uuid xapi_aux tests_common log xapi_internal)
 )


### PR DESCRIPTION
Before (measuring both unloaded, and loaded situation where other threads are accessing the mutex):
```
Running benchmarks (no workloads)
╭────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  Cached reads/Pool_role.is_master  │             0.0000 mjw/run│             4.0000 mnw/run│             23.6039 ns/run│
╰────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯

Cached reads/Pool_role.is_master (ns):
 { monotonic-clock per run = 23.603889 (confidence: 23.644693 to 23.568067);
   r² = Some 0.999899 }

Running benchmarks (workloads)
╭────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  Cached reads/Pool_role.is_master  │             0.0000 mjw/run│             7.4201 mnw/run│             76.4067 ns/run│
╰────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯

Cached reads/Pool_role.is_master (ns):
 { monotonic-clock per run = 76.406674 (confidence: 86.718075 to 66.336404);
   r² = Some 0.608131 }
```

After:
```


Running benchmarks (no workloads)
╭────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  Cached reads/Pool_role.is_master  │             0.0000 mjw/run│             0.0000 mnw/run│              3.1256 ns/run│
╰────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯

Cached reads/Pool_role.is_master (ns):
 { monotonic-clock per run = 3.125616 (confidence: 3.131412 to 3.120373);
   r² = Some 0.999885 }

Running benchmarks (workloads)
╭────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  Cached reads/Pool_role.is_master  │             0.0000 mjw/run│             0.0000 mnw/run│              6.2872 ns/run│
╰────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯

Cached reads/Pool_role.is_master (ns):
 { monotonic-clock per run = 6.287197 (confidence: 6.737363 to 5.830140);
   r² = Some 0.706843 }
```