### PR TITLE
CA-405971: avoid calling DB functions when in emergency mode

### DIFF
--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -152,7 +152,14 @@ let do_dispatch ?session_id ?forward_op ?self:_ supports_async called_fn_name
                 Tgroup.Group.Identity.make ?user_agent:http_req.user_agent
                   subject
               )
-              session_id
+              ( if !Xapi_globs.slave_emergency_mode then
+                  (* in emergency mode we cannot reach the coordinator,
+                     and we must not attempt to make Db calls
+                  *)
+                  None
+                else
+                  session_id
+              )
           with _ -> None
         in
         Tgroup.of_creator (Tgroup.Group.Creator.make ?identity ())

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -141,19 +141,22 @@ let do_dispatch ?session_id ?forward_op ?self:_ supports_async called_fn_name
       Context.of_http_req ?session_id ~internal_async_subtask ~generate_task_for
         ~supports_async ~label ~http_req ~fd ()
     in
-    let identity =
-      try
-        Option.map
-          (fun session_id ->
-            let subject =
-              Db.Session.get_auth_user_sid ~__context ~self:session_id
-            in
-            Tgroup.Group.Identity.make ?user_agent:http_req.user_agent subject
-          )
-          session_id
-      with _ -> None
-    in
-    Tgroup.of_creator (Tgroup.Group.Creator.make ?identity ()) ;
+    ( if !Xapi_globs.tgroups_enabled then
+        let identity =
+          try
+            Option.map
+              (fun session_id ->
+                let subject =
+                  Db.Session.get_auth_user_sid ~__context ~self:session_id
+                in
+                Tgroup.Group.Identity.make ?user_agent:http_req.user_agent
+                  subject
+              )
+              session_id
+          with _ -> None
+        in
+        Tgroup.of_creator (Tgroup.Group.Creator.make ?identity ())
+    ) ;
     let sync () =
       let need_complete = not (Context.forwarded_task __context) in
       exec_with_context ~__context ~need_complete ~called_async


### PR DESCRIPTION
This breaks emergency mode commands.