### PR TITLE
Hugo docs: Allow for quick doc updates using the edit button

### DIFF
--- a/doc/hugo.toml
+++ b/doc/hugo.toml
@@ -29,6 +29,7 @@ home = [ "HTML", "RSS",  "PRINT"]
 section = [ "HTML", "RSS", "PRINT"]
 
 [params]
+editURL = 'https://github.com/xapi-project/xen-api/edit/master/doc/content/${FilePath}'
 # Enable the theme variant selector, default to auto:
 themeVariant = [
     "auto",


### PR DESCRIPTION
Enable the edit button next to the prev/next buttons in the topbar:
`editURL` enables to editing (using your fork+new PR) on GitHub.com