### PR TITLE
docs/xenopsd: List the child pages using the children shortcode

### DIFF
--- a/doc/content/xenopsd/design/_index.md
+++ b/doc/content/xenopsd/design/_index.md
@@ -1,3 +1,6 @@
 +++
 title = "Design"
 +++
+
+Design documents for `xenopsd`:
+{{% children %}}

--- a/doc/content/xenopsd/walkthroughs/_index.md
+++ b/doc/content/xenopsd/walkthroughs/_index.md
@@ -6,8 +6,10 @@ linkTitle = "Walk-throughs"
 Let's trace through interesting operations to see how the whole system
 works.
 
-- [Starting a VM](VM.start.md)
-- [Migrating a VM](VM.migrate.md)
+{{% children %}}
+
+Inspiration for other walk-throughs:
+
 - Shutting down a VM and waiting for it to happen
 - A VM wants to reboot itself
 - A disk is hotplugged


### PR DESCRIPTION
The docs commonly use the children shortcode to list child pages,
we may use it for the xenopsd walk-throughs and designs as well.