### PR TITLE
CA-405820 guard /etc/init.d/functions in xe-toolstack-restart

### DIFF
--- a/scripts/xe-toolstack-restart
+++ b/scripts/xe-toolstack-restart
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
 #
-. /etc/init.d/functions
+test -f /etc/init.d/functions && source /etc/init.d/functions
 
 FILENAME=`basename $0`
 LOCKFILE='/dev/shm/xe_toolstack_restart.lock'


### PR DESCRIPTION
The sourced file does not exist in XS9. I believe we are not using any of the functionality provided but to be safe, keep it in XS8 for now.