### PR TITLE
Simplify some parts of message-switch/unix

### DIFF
--- a/ocaml/message-switch/unix/dune
+++ b/ocaml/message-switch/unix/dune
@@ -14,6 +14,5 @@
     xapi-stdext-threads
     xapi-stdext-unix
   )
-  (preprocess (per_module ((pps ppx_deriving_rpc) Protocol_unix_scheduler)))
 )
 

--- a/ocaml/message-switch/unix/protocol_unix.ml
+++ b/ocaml/message-switch/unix/protocol_unix.ml
@@ -65,7 +65,7 @@ module Clock : sig
 
   val cancel : t -> unit
 end = struct
-  type t = Protocol_unix_scheduler.t
+  type t = int64 * int
 
   let started = ref false
 
@@ -78,7 +78,7 @@ end = struct
           started := true
         )
     ) ;
-    Protocol_unix_scheduler.(one_shot (Delta timeout) "rpc" f)
+    Protocol_unix_scheduler.run_after ~seconds:timeout f
 
   let cancel = Protocol_unix_scheduler.cancel
 end

--- a/ocaml/message-switch/unix/protocol_unix_scheduler.mli
+++ b/ocaml/message-switch/unix/protocol_unix_scheduler.mli
@@ -1,0 +1,5 @@
+val run_after : seconds:int -> (unit -> unit) -> int64 * int
+
+val cancel : int64 * int -> unit
+
+val start : unit -> unit

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=497
+  N=496
   X="ocaml/tests"
   X+="|ocaml/quicktest"
   X+="|ocaml/message-switch/core_test"


### PR DESCRIPTION
There was duplicated and unused code, as well as unnecessarily-nested modules.