### PR TITLE
Resurrect RRD scripts

### DIFF
--- a/python3/Makefile
+++ b/python3/Makefile
@@ -23,6 +23,7 @@ install:
 	$(IDATA) dnf_plugins/accesstoken.py $(DESTDIR)$(SITE3_DIR)/$(DNF_PLUGIN_DIR)/
 	$(IDATA) dnf_plugins/ptoken.py $(DESTDIR)$(SITE3_DIR)/$(DNF_PLUGIN_DIR)/
 
+	$(IPROG) libexec/metrics.py $(DESTDIR)$(OPTDIR)/debug
 	$(IPROG) libexec/host-display $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) libexec/link-vms-by-sr.py $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) libexec/usb_reset.py $(DESTDIR)$(LIBEXECDIR)

--- a/python3/Makefile
+++ b/python3/Makefile
@@ -24,6 +24,7 @@ install:
 	$(IDATA) dnf_plugins/ptoken.py $(DESTDIR)$(SITE3_DIR)/$(DNF_PLUGIN_DIR)/
 
 	$(IPROG) libexec/metrics.py $(DESTDIR)$(OPTDIR)/debug
+	$(IPROG) libexec/metricsgraph.py $(DESTDIR)$(OPTDIR)/debug
 	$(IPROG) libexec/host-display $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) libexec/link-vms-by-sr.py $(DESTDIR)$(LIBEXECDIR)
 	$(IPROG) libexec/usb_reset.py $(DESTDIR)$(LIBEXECDIR)

--- a/python3/libexec/metrics.py
+++ b/python3/libexec/metrics.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python3
+
+import atexit
+import contextlib
+from pprint import pprint, pformat
+
+import XenAPI
+
+
+# given a list of dictionaries, print selected keys in order from each one, nicely formatted with a title
+def dictionary_list_partial_print(title, dictionary_list, keys):
+    bar = "-" * len(title)
+    print(bar, "\n", title, "\n", bar)
+    print(
+        "\n--\n".join(
+            [
+                "\n".join(["%s  : %s" % (k, pformat(d[k])) for k in keys])
+                for d in dictionary_list
+            ]
+        )
+    )
+    print(bar)
+
+
+# x, 'VM', 'guest_metrics' -> guest_metrics_record of the VM x
+# catch the NULL if the record doesn't exist for some reason, and return the string 'NULL'
+def fetch_metrics_record(sx, object_reference, type_string, metrics_name):
+    record_reference = sx.__getattr__(type_string).__getattr__("get_" + metrics_name)(
+        object_reference
+    )
+    if record_reference == "OpaqueRef:NULL":
+        return "NULL"
+    else:
+        return sx.__getattr__(f"{type_string}_{metrics_name}").get_record(
+            record_reference
+        )
+
+
+def fetch_rrd_records(sx, object_reference, type_string, data_owner):
+    obj_class = sx.__getattr__(type_string)
+    owner_class = sx.__getattr__(data_owner)
+    belongs_to = obj_class.__getattr__(f"get_{data_owner}")(object_reference)
+    device_number = obj_class.__getattr__("get_device")(object_reference)
+    related_data_sources = [
+        x
+        for x in owner_class.get_data_sources(belongs_to)
+        if x["name_label"].startswith(f"{type_string.lower()}_{device_number}")
+    ]
+    related_data_sources = {x["name_label"]: x["value"] for x in related_data_sources}
+    return related_data_sources
+
+
+# the names of the vbds are a little more complicated, because there is the possiblility that a VBD connects
+# a VM to a CD drive, which may be empty, and thus not have a VDI to represent it.
+def get_vbd_name(sx, vbd):
+    if sx.VBD.get_type(vbd) == "CD" and sx.VBD.get_empty(vbd) == True:
+        device_name = "empty cd drive"
+    else:
+        device_name = sx.VDI.get_name_label(sx.VBD.get_VDI(vbd))
+    return f'VBD connecting "{sx.VM.get_name_label(sx.VBD.get_VM(vbd))}" to "{device_name}"'
+
+
+def main():
+    session = XenAPI.xapi_local()
+
+    def logout():
+        with contextlib.suppress(Exception):
+            session.xenapi.session.logout()
+
+    atexit.register(logout)
+
+    session.xenapi.login_with_password("", "", "1.0", "metrics-script")
+    sx = session.xenapi
+
+    # first, we'll find all the hosts, and get the information we care about from each
+    hosts = sx.host.get_all()
+    host_metrics = [
+        {
+            "name_label": sx.host.get_name_label(x),
+            "metrics": sx.host_metrics.get_record(sx.host.get_metrics(x)),
+            "host_cpus": [sx.host_cpu.get_record(x) for x in sx.host.get_host_CPUs(x)],
+        }
+        for x in hosts
+    ]
+
+    # and print out the interesting bits
+    dictionary_list_partial_print(
+        "Host Metrics", host_metrics, ["name_label", "metrics", "host_cpus"]
+    )
+
+    # find all the virtual machines which are resident on the hosts
+    resident_vms = set()
+    for host in hosts:
+        resident_vms.update(sx.host.get_resident_VMs(host))
+
+    # get and print their info
+    vm_metrics = [
+        {
+            "name_label": sx.VM.get_name_label(x),
+            "metrics": fetch_metrics_record(sx, x, "VM", "metrics"),
+            "guest_metrics": fetch_metrics_record(sx, x, "VM", "guest_metrics"),
+        }
+        for x in resident_vms
+    ]
+
+    dictionary_list_partial_print(
+        "Virtual Machine Metrics",
+        vm_metrics,
+        ["name_label", "metrics", "guest_metrics"],
+    )
+
+    # from the list of resident VMs we can find all the active VIFs and VBDs
+    # however these don't have useful names, so we have to make them up
+    active_vifs = [
+        vif for vif in sx.VIF.get_all() if sx.VIF.get_VM(vif) in resident_vms
+    ]
+
+    vif_metrics = [
+        {
+            "name_label": f'VIF connecting "{sx.network.get_name_label(sx.VIF.get_network(x))}" '
+            f'to "{sx.VM.get_name_label(sx.VIF.get_VM(x))}"',
+            "metrics": fetch_rrd_records(sx, x, "VIF", "VM"),
+        }
+        for x in active_vifs
+    ]
+
+    dictionary_list_partial_print("VIF metrics", vif_metrics, ["name_label", "metrics"])
+
+    active_vbds = [
+        vbd for vbd in sx.VBD.get_all() if sx.VBD.get_VM(vbd) in resident_vms
+    ]
+
+    vbd_metrics = [
+        {
+            "name_label": get_vbd_name(sx, x),
+            "metrics": fetch_rrd_records(sx, x, "VBD", "VM"),
+        }
+        for x in active_vbds
+    ]
+
+    dictionary_list_partial_print("VBD Metrics", vbd_metrics, ["name_label", "metrics"])
+
+    # from the VIFs we can find the active networks, which don't actually have any metrics
+    active_networks = set()
+    for vif in active_vifs:
+        active_networks.add(sx.VIF.get_network(vif))
+
+    network_metrics = [
+        {"name_label": sx.network.get_name_label(x)} for x in active_networks
+    ]
+    dictionary_list_partial_print("Network Metrics", network_metrics, ["name_label"])
+
+    # and from the active networks we can get all the relevant pifs
+    active_pifs = set()
+    for network in active_networks:
+        active_pifs.update(sx.network.get_PIFs(network))
+
+    pif_metrics = [
+        {
+            "name_label": f"{sx.PIF.get_device(x)} on "
+            f"{sx.host.get_name_label(sx.PIF.get_host(x))}",
+            "metrics": fetch_rrd_records(sx, x, "PIF", "host"),
+        }
+        for x in active_pifs
+    ]
+
+    dictionary_list_partial_print("PIF Metrics", pif_metrics, ["name_label", "metrics"])
+
+    # finish off by printing out a concise list of all the active objects
+    # awkward duplication instead of iterating over locals()[name] is so that
+    # pytype does not complain
+    print("Active Objects")
+    for name, lst in [
+        ("host_metrics", host_metrics),
+        ("vm_metrics", vm_metrics),
+        ("vif_metrics", vif_metrics),
+        ("vbd_metrics", vbd_metrics),
+        ("network_metrics", network_metrics),
+        ("pif_metrics", pif_metrics),
+    ]:
+        print(name, [(y["name_label"]) for y in lst])
+
+
+if __name__ == "__main__":
+    main()

--- a/python3/libexec/metricsgraph.py
+++ b/python3/libexec/metricsgraph.py
@@ -1,0 +1,207 @@
+#!/usr/bin/python3
+
+# program to run through all the interesting metrics (i.e. those that are related in some way to a resident VM)
+# and output a graph suitable for graphviz.
+# note that graphviz comments are /*C-style*/
+# the fundamental type here is a 'record dictionary', indexing object records by their opaque refs.
+
+import atexit
+import contextlib
+from pprint import pprint, pformat
+
+import XenAPI
+
+
+# given a set of object references of type 'type_string', return a
+# dictionary linking the references to the associated records
+def get_records(sx, object_set, type_string):
+    dic = {}
+    for x in object_set:
+        dic[x] = sx.__getattr__(type_string).get_record(x)
+    return dic
+
+
+# given a record dictionary, print out the 'name_labels' of each entry if it exists, and the reference otherwise
+def print_names(dictionary, title):
+    print("/*")
+    print(
+        title,
+        ":",
+        ", ".join([dictionary[x].get("name_label", x) for x in dictionary.keys()]),
+    )
+    print("*/")
+
+
+# for example, the record dictionary of VMs contains a key VIFs, which is a list of the associated VIFs
+# this function will take say, the dictionary of all the resident VMs, and return the set of all the VIFs
+# associated with them
+def set_from_key_in_dictionary_of_records(record_dict, key_name, key_is_list=True):
+    s = set()
+    for v in record_dict.values():
+        key = v[key_name]
+        if key_is_list:
+            s.update(key)
+        else:
+            s.add(key)
+    return s
+
+
+# and this composition function will, say, given the VM dictionary, and the key name VIFs, return the
+# dictionary of all associated VIFs
+def chase_key(sx, record_dictionary, type_name, key_name, key_is_list=True):
+    new_set = set_from_key_in_dictionary_of_records(
+        record_dictionary, key_name, key_is_list
+    )
+    return get_records(sx, new_set, type_name)
+
+
+# The metrics records hold a lot of data. The following functions take a reference/record pair of a particular type
+# get the associated metrics, and return a few interesting quantities we want to see on the graphs
+def host_data(sx, ref, record):
+    data = {}
+    data["name"] = record["name_label"]
+    metrics = sx.host_metrics.get_record(sx.host.get_metrics(ref))
+    cpu_utilisations = [
+        sx.host_cpu.get_utilisation(x) for x in sx.host.get_host_CPUs(ref)
+    ]
+    data["label"] = {}
+    data["label"]["cpus"] = " ".join(["%.2f" % x for x in cpu_utilisations])
+    data["label"]["memory"] = "%.2f" % (
+        float(metrics["memory_free"]) / float(metrics["memory_total"])
+    )
+    return data
+
+
+def vm_data(sx, ref, record):
+    data = {}
+    data["name"] = record["name_label"]
+    metrics = sx.VM_metrics.get_record(sx.VM.get_metrics(ref))
+    data["label"] = {}
+    data["label"]["cpus"] = " ".join(
+        ["%.2f" % x for x in metrics["VCPUs_utilisation"].values()]
+    )
+    data["label"]["memory"] = "%sM" % (
+        float(metrics["memory_actual"]) / float(1024 * 1024)
+    )
+    return data
+
+
+# vifs vbds and pifs all work the same way, but we need a type variable for the xapi bindings dispatcher
+def io_data(sx, ref, record, type_name, data_owner, suffixes):
+    data = {}
+    data["name"] = type_name.lower()
+    obj_class = sx.__getattr__(type_name)
+    owner_class = sx.__getattr__(data_owner)
+    belongs_to = obj_class.__getattr__(f"get_{data_owner}")(ref)
+    device_number = obj_class.__getattr__("get_device")(ref)
+    metric_name = f"{type_name.lower()}_{device_number}"
+    metrics = [
+        x
+        for x in owner_class.get_data_sources(belongs_to)
+        if x["name_label"].startswith(metric_name)
+    ]
+    metrics = {x["name_label"]: x["value"] for x in metrics}
+
+    data["label"] = {}
+    data["label"]["read"] = "%.2fk" % (metrics[f"{metric_name}_{suffixes[0]}"])
+    data["label"]["write"] = "%.2fk" % (metrics[f"{metric_name}_{suffixes[1]}"])
+    return data
+
+
+# these functions use the object lists constructed and metric analysis functions defined above
+# to print out the node and edge definitions required by graphviz
+def print_nodes(record_dictionary):
+    for x in record_dictionary.keys():
+        print('"%s" [label="%s"];' % (x, record_dictionary[x].get("name_label", "?")))
+
+
+# calls the metric analysis functions to output nodes labelled with their metrics as well as their names
+def print_metric_nodes(sx, dic, metricfn):
+    for ref, record in dic.items():
+        d = metricfn(sx, ref, record)
+        label = (
+            d["name"]
+            + "\\n"
+            + "\\n".join(["%s=%s" % (k, v) for k, v in d["label"].items()])
+        )
+        print('"%s" [label="%s"];' % (ref, label))
+
+
+# prints out the connecting edges, in similar manner to the key-chasing above when we first got the objects
+def print_edges(record_dictionary, key, key_is_list=True):
+    for k, v in record_dictionary.items():
+        if key_is_list:
+            for x in v[key]:
+                print('"%s" -> "%s";' % (k, x))
+        else:
+            print('"%s" -> "%s";' % (k, v[key]))
+
+
+def main():
+    session = XenAPI.xapi_local()
+
+    def logout():
+        with contextlib.suppress(Exception):
+            session.xenapi.session.logout()
+
+    atexit.register(logout)
+
+    session.xenapi.login_with_password("", "", "1.0", "newmetricsgraph-script")
+    sx = session.xenapi
+
+    # find all the hosts
+    host_dic = get_records(sx, set(sx.host.get_all()), "host")
+
+    # chase the chain of types through hosts->VMs->VIFs->networks->PIFs and hosts->VMs->VBDs
+    resident_vms_dic = chase_key(sx, host_dic, "VM", "resident_VMs")
+    active_vifs_dic = chase_key(sx, resident_vms_dic, "VIF", "VIFs")
+    active_vbds_dic = chase_key(sx, resident_vms_dic, "VBD", "VBDs")
+    active_networks_dic = chase_key(sx, active_vifs_dic, "network", "network", False)
+    active_pifs_dic = chase_key(sx, active_networks_dic, "PIF", "PIFs")
+
+    # print out the objects we found as a graphviz comment
+    print_names(host_dic, "hosts")
+    print_names(resident_vms_dic, "resident VMs")
+    print_names(active_vifs_dic, "active VIFs")
+    print_names(active_vbds_dic, "active VBDs")
+    print_names(active_networks_dic, "active networks")
+    print_names(active_pifs_dic, "active PIFs")
+
+    # We've now got all the objects we need, so we now need to get their metrics data and output it as a graphviz file
+
+    print('digraph active_objects {')
+    print('node [shape="rect"];')
+
+    print_metric_nodes(sx, host_dic, host_data)
+    print_metric_nodes(sx, resident_vms_dic, vm_data)
+    print_metric_nodes(
+        sx,
+        active_vifs_dic,
+        lambda sx, ref, record: io_data(sx, ref, record, "VIF", "VM", ["rx", "tx"]),
+    )
+    print_metric_nodes(
+        sx,
+        active_vbds_dic,
+        lambda sx, ref, record: io_data(
+            sx, ref, record, "VBD", "VM", ["read", "write"]
+        ),
+    )
+    print_metric_nodes(
+        sx,
+        active_pifs_dic,
+        lambda sx, ref, record: io_data(sx, ref, record, "PIF", "host", ["rx", "tx"]),
+    )
+
+    print_nodes(active_networks_dic)
+
+    print_edges(host_dic, "resident_VMs")
+    print_edges(resident_vms_dic, "VIFs")
+    print_edges(resident_vms_dic, "VBDs")
+    print_edges(active_vifs_dic, "network", False)
+    print_edges(active_networks_dic, "PIFs")
+
+    print("}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python3/stubs/XenAPI.pyi
+++ b/python3/stubs/XenAPI.pyi
@@ -51,8 +51,14 @@ class _Dispatcher:
     PBD: Incomplete
     pool: Incomplete
     host: Incomplete
+    host_metrics: Incomplete
+    host_cpu: Incomplete
     pool_update: Incomplete
     VM: Incomplete
+    VIF: Incomplete
+    PIF: Incomplete
+    VBD: Incomplete
+    network: Incomplete
 
 
 class Session(xmlrpclib.ServerProxy):


### PR DESCRIPTION
Resurrects two previously deleted scripts: `metrics.py` and `metricsgraph.py`.

The first one dumps a human-readable list of all host, VM, VIF, PIF, VBD-related metrics for quick troubleshooting.

`metricsgraph.py` creates a textual representation of the graph below, representing relationships between and basic characteristics/metrics of objects:

![image](https://github.com/user-attachments/assets/abbccb5d-c7b8-4ca2-a9f7-2303eaf980e4)

These are both installed alongside other Python libexec tools. I haven't altered what the scripts do themselves beyond bringing Python and API usage up to date, if anyone feels like these tools could be changed in some way to better serve their purpose (quick diagnostics for support/potentially part of the bugtool), please let me know.
