### PR TITLE
CA-406403: Do not return HTTP 500 when Accept header can't be parsed

### DIFF
--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -55,6 +55,9 @@ module Accept : sig
   val equal : t -> t -> bool
 
   val of_string : string -> t list
+  (** [of_string accept_hdr] Returns a list of weighted media types represented
+      by [accept_hdr]. If [accept_hdr] can't be parsed, raises [Parse_failure].
+      *)
 
   val to_string : t -> string
 

--- a/ocaml/libs/http-lib/http_test.ml
+++ b/ocaml/libs/http-lib/http_test.ml
@@ -24,6 +24,15 @@ module Accept = struct
     let actual = Accept.of_string data in
     Alcotest.(check @@ list accept) data expected actual
 
+  let test_invalid () =
+    let data = "text/html, image/gif, image/jpeg, ; q=.2, */; q=.2" in
+    let expected = Accept.Parse_failure " " in
+    let actual () =
+      let _ = Accept.of_string data in
+      ()
+    in
+    Alcotest.check_raises "Raises Parse failure" expected actual
+
   let test_accept_complex () =
     let data =
       "application/xml;q=0.9,text/html,application/xhtml+xml,*/*;q=0.8"
@@ -81,6 +90,7 @@ module Accept = struct
         [
           ("Simple", `Quick, test_accept_simple)
         ; ("Complex", `Quick, test_accept_complex)
+        ; ("Invalid", `Quick, test_invalid)
         ]
       ; preferred_tests
       ]


### PR DESCRIPTION
/update_rrds returned a 500 HTTP code in some cases where the accept header was
invalid. Now these cases are treated in the same way as a lack of Accept
header.