### PR TITLE
fix(CI) Coveralls is down for maintenance: do not fail the CI if coveralls is down

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -56,6 +56,7 @@ jobs:
           files: .git/coverage${{matrix.python-version}}.xml
           flag-name: python${{matrix.python-version}}
           parallel: true
+          fail-on-error: false
 
       - uses: dciborow/action-pylint@0.1.0
         with:


### PR DESCRIPTION
Follow the official recommendation from Coveralls:

> While our API is in maintenance mode, new coverage report uploads (POSTs to /api/v1/jobs) will fail with a 405 or other 4xx error.
> To keep this from breaking your CI builds and holding up your PRs, allow coveralls steps to "fail on error."
> If you are using one of our Official Integrations, add: 
> - `fail-on-error: false` if using Coveralls GitHub Action