### PR TITLE
(CI) Use the default setup-python action again as Python 2.7 is obsoleted

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # To check which files changed: origin/master..HEAD
-      - uses: LizardByte/setup-python-action@master
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
 


### PR DESCRIPTION
`LizardByte/setup-python-action` was only needed for Python2.7, which is obsolete now