### PR TITLE
CP-53362: Rename hcp_nss to nss_override_id

### DIFF
--- a/python3/plugins/extauth-hook-AD.py
+++ b/python3/plugins/extauth-hook-AD.py
@@ -332,7 +332,7 @@ class NssConfig(KeyValueConfig):
             "/etc/nsswitch.conf", session, args, ad_enabled)
         modules = "files sss"
         if ad_enabled:
-            modules = "files hcp winbind"
+            modules = "files override_id winbind"
         self._update_key_value("passwd", modules)
         self._update_key_value("group", modules)
         self._update_key_value("shadow", modules)

--- a/python3/tests/test_extauth_hook_AD.py
+++ b/python3/tests/test_extauth_hook_AD.py
@@ -201,7 +201,7 @@ class TestNssConfig(TestCase):
         self.assertTrue(line_exists_in_config(nss._lines, expected_config))
 
     def test_ad_enabled(self, mock_install):
-        expected_config = "passwd: files hcp winbind"
+        expected_config = "passwd: files override_id winbind"
         nss = NssConfig(mock_session, args_bd_winbind, True)
         nss.apply()
         self.assertTrue(line_exists_in_config(nss._lines, expected_config))


### PR DESCRIPTION
hcp_nss is a nss module to override the uid/gid of pooladmin when they ssh into dom0, as dom0 only support one single user

However, the name wants to be updated to nss_override_id to reflect its usage