### PR TITLE
CP-52365 adjust interface to dmv-utils

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -933,7 +933,7 @@ let xl_cmd = ref "/usr/sbin/xl"
 
 let depmod = ref "/usr/sbin/depmod"
 
-let driver_tool = ref "/opt/xensource/debug/drivertool.sh"
+let driver_tool = ref "/usr/sbin/driver-tool"
 
 let dracut = ref "/usr/bin/dracut"
 

--- a/ocaml/xapi/xapi_host_driver_tool.ml
+++ b/ocaml/xapi/xapi_host_driver_tool.ml
@@ -242,26 +242,6 @@ module Mock = struct
 
 set -o errexit
 set -o pipefail
-if [[ -n "$TRACE" ]]; then set -o xtrace; fi
-set -o nounset
-
-if [[ "${1-}" =~ ^-*h(elp)?$ ]]; then
-    cat <<EOF 
-Usage: $0 arg-one arg-two
-
-This is an awesome bash script to make your life better.
-EOF
-fi
-
-function deselect {
-  cat <<EOF
-{
-  "driver": "$1",
-  "exit": 0
-}
-EOF
-}
-
 
 function selection {
   cat <<EOF
@@ -621,22 +601,61 @@ function list() {
 EOF
 }
 
+# Initialize variables with default values
+l_flag=false
+s_flag=false
+n_value=""
+v_value=""
 
-case "$1" in
-  list)
-    list
-    ;;
-  select)
-    selection "$2" "$3"
-    ;;
-  deselect)
-    deselect "$2"
-    ;;
-   *)
-    echo "unknown command $1" 2>&1
+# Use getopt to parse command-line options
+while getopts "lsn:v:" opt; do
+  case "$opt" in
+    l)
+      l_flag=true
+      ;;
+    s)
+      s_flag=true
+      ;;
+    n)
+      n_value="$OPTARG"
+      ;;
+    v)
+      v_value="$OPTARG"
+      ;;
+    \?)  # Invalid option
+      echo "Invalid option: -$OPTARG" >&2  #>&2 redirects error message to stderr
+      exit 1
+      ;;
+    :)   # Missing argument for option
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Shift the remaining positional parameters (if any)
+shift $((OPTIND - 1))
+
+# We don't properly prevent illegal combinations because this is just a
+# mock. So we recognise -l first.
+if $l_flag; then
+  list
+  exit 0
+fi
+
+if $s_flag; then
+  if [ -z "$n_value" ]; then
+    echo "missing -n" >&2
     exit 1
-    ;;
-esac
+  fi
+  if [ -z "$v_value" ]; then
+    echo "missing -v" >&2
+    exit 1
+  fi
+
+  selection "$n_value" "$v_value"
+  exit 0
+fi
 |}
 
   let install () =
@@ -645,6 +664,6 @@ esac
       Xapi_stdext_unix.Unixext.write_string_to_file path drivertool_sh ;
       Unix.chmod path 0o755
     with e ->
-      Helpers.internal_error ~log_err:true "%s: can't install %s: %s"
-        __FUNCTION__ path (Printexc.to_string e)
+      Helpers.internal_error "%s: can't install %s: %s" __FUNCTION__ path
+        (Printexc.to_string e)
 end


### PR DESCRIPTION
* We currently have a mock implementation for driver-tool from the dmv-utils package. Adjust the command line argument structure to the real implementation to make the switch over easy.

* Install the mock implementation if the real implementation is not in place. We might want to remove this later. Currently xapi.spec does not list the dependency.