### PR TITLE
CP-53314: Read and watch <domain>/data/service in xenstore to DB

### DIFF
--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -236,6 +236,31 @@ let dead_domains : IntSet.t ref = ref IntSet.empty
 
 let mutex = Mutex.create ()
 
+(* Parse data/service which has the following structure:
+   data/service/<service_name>/<key> = <value>
+   data/service/<service_name>/<key> = <value>
+   ...
+   data/service/<service_name>/<key> = <value>
+   Read and convert to [(<service_name>/<key>, <value>)] pair list.
+   The list is intended to store in VM_guest_metrics.services at last *)
+let get_guest_services (lookup : string -> string option)
+    (list : string -> string list) =
+  let base_path = "data/service" in
+  let services = list base_path in
+  List.fold_left
+    (fun acc service ->
+      let sub_path = base_path // service in
+      List.fold_left
+        (fun acc key ->
+          let full_path_key = sub_path // key in
+          let db_key = service // key in
+          let value = lookup full_path_key in
+          (db_key, Option.value ~default:"" value) :: acc
+        )
+        acc (list sub_path)
+    )
+    [] services
+
 (* In the following functions, 'lookup' reads a key from xenstore and 'list' reads
    a directory from xenstore. Both are relative to the guest's domainpath. *)
 let get_initial_guest_metrics (lookup : string -> string option)
@@ -290,7 +315,7 @@ let get_initial_guest_metrics (lookup : string -> string option)
          ; networks "xenserver/attr" "net-sriov-vf" list
          ]
       )
-  and services = []
+  and services = get_guest_services lookup list
   and other = List.append (to_map (other all_control)) ts
   and memory = to_map memory
   and last_updated = Unix.gettimeofday () in

--- a/ocaml/xapi/xapi_guest_agent.ml
+++ b/ocaml/xapi/xapi_guest_agent.ml
@@ -247,19 +247,17 @@ let get_guest_services (lookup : string -> string option)
     (list : string -> string list) =
   let base_path = "data/service" in
   let services = list base_path in
-  List.fold_left
-    (fun acc service ->
-      let sub_path = base_path // service in
-      List.fold_left
-        (fun acc key ->
-          let full_path_key = sub_path // key in
-          let db_key = service // key in
-          let value = lookup full_path_key in
-          (db_key, Option.value ~default:"" value) :: acc
-        )
-        acc (list sub_path)
-    )
-    [] services
+  services
+  |> List.concat_map (fun service ->
+         let sub_path = base_path // service in
+         list sub_path
+         |> List.map (fun key ->
+                let full_path_key = sub_path // key in
+                let db_key = service // key in
+                let value = lookup full_path_key in
+                (db_key, Option.value ~default:"" value)
+            )
+     )
 
 (* In the following functions, 'lookup' reads a key from xenstore and 'list' reads
    a directory from xenstore. Both are relative to the guest's domainpath. *)

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2744,9 +2744,10 @@ module VM = struct
                 (fun port -> {Vm.protocol= Vm.Vt100; port; path= ""})
                 (Device.get_tc_port ~xs di.Xenctrl.domid)
             in
-            let local x =
-              Printf.sprintf "/local/domain/%d/%s" di.Xenctrl.domid x
+            let root_path =
+              Printf.sprintf "/local/domain/%d" di.Xenctrl.domid
             in
+            let local x = Printf.sprintf "%s/%s" root_path x in
             let uncooperative =
               try
                 ignore_string (xs.Xs.read (local "memory/uncooperative")) ;
@@ -2853,9 +2854,7 @@ module VM = struct
               ]
               |> List.fold_left
                    (fun acc (dir, excludes, depth) ->
-                     ls_lR ?excludes ~depth
-                       (Printf.sprintf "/local/domain/%d" di.Xenctrl.domid)
-                       acc dir
+                     ls_lR ?excludes ~depth root_path acc dir
                    )
                    (quota, [])
               |> fun (quota, acc) ->
@@ -2863,9 +2862,7 @@ module VM = struct
             in
             let quota, xsdata_state =
               Domain.allowed_xsdata_prefixes
-              |> List.fold_left
-                   (ls_lR (Printf.sprintf "/local/domain/%d" di.Xenctrl.domid))
-                   (quota, [])
+              |> List.fold_left (ls_lR root_path) (quota, [])
             in
             let path =
               Device_common.xenops_path_of_domain di.Xenctrl.domid

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2849,6 +2849,7 @@ module VM = struct
               ; ("drivers", None, 0)
               ; ("data", None, 0)
                 (* in particular avoid data/volumes which contains many entries for each disk *)
+              ; ("data/service", None, 1) (* data/service/<service-name>/<key>*)
               ]
               |> List.fold_left
                    (fun acc (dir, excludes, depth) ->
@@ -4825,6 +4826,7 @@ module Actions = struct
       sprintf "/local/domain/%d/attr" domid
     ; sprintf "/local/domain/%d/data/updated" domid
     ; sprintf "/local/domain/%d/data/ts" domid
+    ; sprintf "/local/domain/%d/data/service" domid
     ; sprintf "/local/domain/%d/memory/target" domid
     ; sprintf "/local/domain/%d/memory/uncooperative" domid
     ; sprintf "/local/domain/%d/console/vnc-port" domid


### PR DESCRIPTION
The field `VM_guest_metrics.services` added previously (#6309) is used to store VM service information reported by guest tools.
Xapi does not use this data but just holds it for outside consumers.
This PR reads the xenstore path `data/service` and converts to `[("service_name/key", "value")]` pair list and then store to VM_guest_metrics.services.
The path to read is like:
`/local/domain/<id>/data/service/<service_name>/<key> = <value>`

