### PR TITLE
Use Cmdliner in gen_api_main.ml

### DIFF
--- a/ocaml/idl/datamodel_main.ml
+++ b/ocaml/idl/datamodel_main.ml
@@ -48,17 +48,15 @@ let _ =
   if num_modes_set > 1 then failwith "More than one mode on the commandline" ;
 
   let oss_filter api =
-    filter
-      (fun _ -> true)
-      (fun field -> List.mem "3.0.3" field.release.opensource)
-      (fun message -> List.mem "3.0.3" message.msg_release.opensource)
+    filter_by
+      ~field:(fun field -> List.mem "3.0.3" field.release.opensource)
+      ~message:(fun message -> List.mem "3.0.3" message.msg_release.opensource)
       api
   in
   let closed_filter api =
-    filter
-      (fun _ -> true)
-      (fun field -> List.mem "closed" field.release.internal)
-      (fun message -> List.mem "closed" message.msg_release.internal)
+    filter_by
+      ~field:(fun field -> List.mem "closed" field.release.internal)
+      ~message:(fun message -> List.mem "closed" message.msg_release.internal)
       api
   in
 
@@ -75,13 +73,12 @@ let _ =
   (* Add all implicit messages to the API directly *)
   let api = DU.add_implicit_messages ~document_order:!markdown_mode api in
   (* Only show those visible to the client *)
-  let api = filter (fun _ -> true) (Fun.const true) DU.on_client_side api in
+  let api = filter_by ~message:DU.on_client_side api in
   (* And only messages marked as not hidden from the docs, and non-internal fields *)
   let api =
-    filter
-      (fun _ -> true)
-      (fun f -> not f.internal_only)
-      (fun m -> not m.msg_hide_from_docs)
+    filter_by
+      ~field:(fun f -> not f.internal_only)
+      ~message:(fun m -> not m.msg_hide_from_docs)
       api
   in
 
@@ -94,10 +91,6 @@ let _ =
 
   if !dtd_mode then
     let api =
-      filter
-        (fun _ -> true)
-        (fun field -> field.qualifier <> DynamicRO)
-        (fun _ -> true)
-        api
+      filter_by ~field:(fun field -> field.qualifier <> DynamicRO) api
     in
     List.iter print_endline (Dtd_backend.of_objs api)

--- a/ocaml/idl/dm_api.ml
+++ b/ocaml/idl/dm_api.ml
@@ -156,6 +156,10 @@ let filter (obj : obj -> bool) (field : field -> bool)
   in
   rebuild system relations
 
+let filter_by ?(obj = fun _ -> true) ?(field = fun _ -> true)
+    ?(message = fun _ -> true) =
+  filter obj field message
+
 let map (obj : obj -> obj) (field : string -> field -> field)
     (message : message -> message) ((system, relations) : api) : api =
   let system =

--- a/ocaml/idl/dm_api.mli
+++ b/ocaml/idl/dm_api.mli
@@ -34,16 +34,14 @@ val get_obj_by_name : api -> objname:string -> obj
 val field_exists : api -> objname:string -> fieldname:string -> bool
 (** True if the named field exists *)
 
-val filter : (obj -> bool) -> (field -> bool) -> (message -> bool) -> api -> api
-(** Apply a predicate to every object, field and message, to generate a sub-API *)
-
 val filter_by :
      ?obj:(obj -> bool)
   -> ?field:(field -> bool)
   -> ?message:(message -> bool)
   -> api
   -> api
-(** Same as [filter] but with defaulted arguments that retain everything. *)
+(** Filter an API by filtering objects, fields, and messages. The
+    default predicates retain everything. *)
 
 val map :
      (obj -> obj)

--- a/ocaml/idl/dm_api.mli
+++ b/ocaml/idl/dm_api.mli
@@ -37,6 +37,14 @@ val field_exists : api -> objname:string -> fieldname:string -> bool
 val filter : (obj -> bool) -> (field -> bool) -> (message -> bool) -> api -> api
 (** Apply a predicate to every object, field and message, to generate a sub-API *)
 
+val filter_by :
+     ?obj:(obj -> bool)
+  -> ?field:(field -> bool)
+  -> ?message:(message -> bool)
+  -> api
+  -> api
+(** Same as [filter] but with defaulted arguments that retain everything. *)
+
 val map :
      (obj -> obj)
   -> (string -> field -> field)

--- a/ocaml/idl/json_backend/gen_json.ml
+++ b/ocaml/idl/json_backend/gen_json.ml
@@ -687,13 +687,12 @@ let () =
   (* Add all implicit messages *)
   let api = add_implicit_messages api in
   (* Only include messages that are visible to a XenAPI client *)
-  let api = filter (fun _ -> true) (fun _ -> true) on_client_side api in
+  let api = filter_by ~message:on_client_side api in
   (* And only messages marked as not hidden from the docs, and non-internal fields *)
   let api =
-    filter
-      (fun _ -> true)
-      (fun f -> not f.internal_only)
-      (fun m -> not m.msg_hide_from_docs)
+    filter_by
+      ~field:(fun f -> not f.internal_only)
+      ~message:(fun m -> not m.msg_hide_from_docs)
       api
   in
   let objs = objects_of_api api in

--- a/ocaml/idl/markdown_backend.ml
+++ b/ocaml/idl/markdown_backend.ml
@@ -528,10 +528,8 @@ let generate_errors () =
 let all api =
   (* Remove private messages that are only used internally (e.g. get_record_internal) *)
   let api =
-    Dm_api.filter
-      (fun _ -> true)
-      (fun _ -> true)
-      (fun msg ->
+    Dm_api.filter_by
+      ~message:(fun msg ->
         match msg.msg_tag with FromObject (Private _) -> false | _ -> true
       )
       api

--- a/ocaml/idl/ocaml_backend/dune
+++ b/ocaml/idl/ocaml_backend/dune
@@ -3,6 +3,7 @@
   (name gen_api_main)
   (libraries
     astring
+    cmdliner
     uuidm
     xapi-consts
     xapi-datamodel

--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -260,7 +260,7 @@ let gen_record_type ~with_module highapi tys =
   in
   aux [] tys
 
-let gen_client highapi =
+let gen_client _config highapi =
   List.iter (List.iter print)
     (between [""]
        [
@@ -352,7 +352,7 @@ let toposort_types highapi types =
   assert (List.sort compare result = List.sort compare types) ;
   result
 
-let gen_record_deserialization highapi =
+let gen_record_deserialization _config highapi =
   let gen_of_to_string types =
     let gen_string_and_all = function
       | DT.Set (DT.Enum (_, elist) as e) ->
@@ -384,7 +384,7 @@ let gen_record_deserialization highapi =
        ]
     )
 
-let gen_client_types highapi =
+let gen_client_types _config highapi =
   let all_types = all_types_of highapi in
   let all_types = add_set_enums all_types in
   List.iter (List.iter print)
@@ -440,7 +440,7 @@ let gen_client_types highapi =
        ]
     )
 
-let gen_server highapi =
+let gen_server _config highapi =
   List.iter (List.iter print)
     (between [""]
        [
@@ -449,7 +449,7 @@ let gen_server highapi =
        ]
     )
 
-let gen_custom_actions highapi =
+let gen_custom_actions _config highapi =
   List.iter (List.iter print)
     (between [""]
        [
@@ -464,7 +464,7 @@ let gen_custom_actions highapi =
 
 open Gen_db_actions
 
-let gen_db_actions highapi =
+let gen_db_actions _config highapi =
   let highapi_in_db =
     Dm_api.filter_by ~obj:(fun obj -> obj.DT.in_database) highapi
   in
@@ -491,4 +491,5 @@ let gen_db_actions highapi =
     @ []
     )
 
-let gen_rbac highapi = print (Gen_rbac.gen_permissions_of_static_roles highapi)
+let gen_rbac config highapi =
+  print (Gen_rbac.gen_permissions_of_static_roles config highapi)

--- a/ocaml/idl/ocaml_backend/gen_api.ml
+++ b/ocaml/idl/ocaml_backend/gen_api.ml
@@ -466,11 +466,7 @@ open Gen_db_actions
 
 let gen_db_actions highapi =
   let highapi_in_db =
-    Dm_api.filter
-      (fun obj -> obj.DT.in_database)
-      (fun _ -> true)
-      (fun _ -> true)
-      highapi
+    Dm_api.filter_by ~obj:(fun obj -> obj.DT.in_database) highapi
   in
   let all_types_in_db = all_types_of highapi_in_db in
   let only_records =

--- a/ocaml/idl/ocaml_backend/gen_api_main.ml
+++ b/ocaml/idl/ocaml_backend/gen_api_main.ml
@@ -48,18 +48,18 @@ let filter_api () =
   let api_used = Datamodel.all_api in
   (* Add all implicit messages to the API directly *)
   let api_used = Datamodel_utils.add_implicit_messages api_used in
-  let filterfn = Dm_api.filter (fun _ -> true) in
+  let filter_by = Dm_api.filter_by in
   match !filter with
   | None ->
       api_used
   | Some "opensource" ->
-      filterfn Field.opensource Message.opensource api_used
+      filter_by ~field:Field.opensource ~message:Message.opensource api_used
   | Some "closed" ->
-      filterfn Field.closed Message.closed api_used
+      filter_by ~field:Field.closed ~message:Message.closed api_used
   | Some "debug" ->
-      filterfn Field.debug Message.debug api_used
+      filter_by ~field:Field.debug ~message:Message.debug api_used
   | Some "nothing" ->
-      filterfn Field.nothing Message.nothing api_used
+      filter_by ~field:Field.nothing ~message:Message.nothing api_used
   | Some x ->
       Printf.eprintf "Unknown filter mode: %s\n" x ;
       api_used

--- a/ocaml/idl/ocaml_backend/gen_api_main.ml
+++ b/ocaml/idl/ocaml_backend/gen_api_main.ml
@@ -14,127 +14,130 @@
 (* Front end around the API code generator. Central place for filtering *)
 
 open Datamodel_types
+open Cmdliner
 
-let filter = ref None
-
-let filterinternal = ref false
+type filter = Nothing | OpenSource | Closed | Debug
 
 module Field = struct
-  let filter_internal x = if !filterinternal then not x.internal_only else true
-
-  let opensource x = List.mem "3.0.3" x.release.opensource && filter_internal x
-
-  let closed x = List.mem "closed" x.release.internal && filter_internal x
-
-  let debug x = List.mem "debug" x.release.internal && filter_internal x
-
-  let nothing x = filter_internal x
+  let filter_of filter filter_internal field =
+    let filter_internal =
+      if filter_internal then not field.internal_only else true
+    in
+    filter_internal
+    &&
+    match filter with
+    | OpenSource ->
+        List.mem "3.0.3" field.release.opensource
+    | Closed ->
+        List.mem "closed" field.release.internal
+    | Debug ->
+        List.mem "debug" field.release.internal
+    | Nothing ->
+        true
 end
 
 module Message = struct
-  let filter_internal x = if !filterinternal then not x.msg_db_only else true
-
-  let opensource x =
-    List.mem "3.0.3" x.msg_release.opensource && filter_internal x
-
-  let closed x = List.mem "closed" x.msg_release.internal && filter_internal x
-
-  let debug x = List.mem "debug" x.msg_release.internal && filter_internal x
-
-  let nothing x = filter_internal x
+  let filter_of filter filter_internal msg =
+    let filter_internal =
+      if filter_internal then
+        not msg.msg_db_only
+      else
+        true
+    in
+    filter_internal
+    &&
+    match filter with
+    | OpenSource ->
+        List.mem "3.0.3" msg.msg_release.opensource
+    | Closed ->
+        List.mem "closed" msg.msg_release.internal
+    | Debug ->
+        List.mem "debug" msg.msg_release.internal
+    | Nothing ->
+        true
 end
 
-let filter_api () =
-  let api_used = Datamodel.all_api in
-  (* Add all implicit messages to the API directly *)
-  let api_used = Datamodel_utils.add_implicit_messages api_used in
-  let filter_by = Dm_api.filter_by in
-  match !filter with
-  | None ->
-      api_used
-  | Some "opensource" ->
-      filter_by ~field:Field.opensource ~message:Message.opensource api_used
-  | Some "closed" ->
-      filter_by ~field:Field.closed ~message:Message.closed api_used
-  | Some "debug" ->
-      filter_by ~field:Field.debug ~message:Message.debug api_used
-  | Some "nothing" ->
-      filter_by ~field:Field.nothing ~message:Message.nothing api_used
-  | Some x ->
-      Printf.eprintf "Unknown filter mode: %s\n" x ;
-      api_used
+let filter_api filter filter_internal =
+  let api = Datamodel.all_api |> Datamodel_utils.add_implicit_messages in
+  let field = Field.filter_of filter filter_internal in
+  let message = Message.filter_of filter filter_internal in
+  Dm_api.filter_by ~field ~message api
 
-let set_gendebug () = Gen_server.enable_debugging := true
+let filter_internal_arg =
+  let doc = "Filter out internal messages and internal-only fields." in
+  Arg.(value & flag & info ["filter-internal"] ~doc ~docv:"FILTER_INTERNAL")
 
-let mode = ref None
+let gen_debug_arg =
+  let doc = "Intersperse debugging code amid output." in
+  Arg.(value & flag & info ["gen-debug"] ~doc ~docv:"GEN_DEBUG")
 
-let _ =
-  Arg.parse
+let filter_arg =
+  let options =
     [
-      ( "-mode"
-      , Arg.Symbol
-          ( [
-              "client"
-            ; "server"
-            ; "api"
-            ; "utils"
-            ; "db"
-            ; "actions"
-            ; "sql"
-            ; "rbac"
-            ; "test"
-            ]
-          , fun x -> mode := Some x
-          )
-      , "Choose which file to output"
-      )
-    ; ( "-filter"
-      , Arg.Symbol
-          ( ["opensource"; "closed"; "debug"; "nothing"]
-          , fun x -> filter := Some x
-          )
-      , "Apply a filter to the API"
-      )
-    ; ( "-filterinternal"
-      , Arg.Bool (fun x -> filterinternal := x)
-      , "Filter internal fields and messages"
-      )
-    ; ( "-gendebug"
-      , Arg.Unit (fun _ -> set_gendebug ())
-      , "Add debugging code to generated output"
-      )
-    ; ( "-output"
-      , Arg.String
-          (fun s ->
-            ( try Unix.mkdir (Filename.dirname s) 0o755
-              with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-            ) ;
-            Gen_api.oc := open_out s
-          )
-      , "Output to the specified file"
-      )
+      ("nothing", Nothing)
+    ; ("opensource", OpenSource)
+    ; ("closed", Closed)
+    ; ("debug", Debug)
     ]
-    (fun x -> Printf.eprintf "Ignoring argument: %s\n" x)
-    "Generate ocaml code from the datamodel. See -help" ;
-  let api = filter_api () in
-  match !mode with
-  | None ->
-      Printf.eprintf "Must select an output type with -mode\n"
-  | Some "client" ->
-      Gen_api.gen_client api
-  | Some "api" ->
-      Gen_api.gen_client_types api
-  | Some "utils" ->
-      Gen_api.gen_record_deserialization api
-  | Some "server" ->
-      Gen_api.gen_server api
-  | Some "db" ->
-      Gen_api.gen_db_actions api
-  | Some "actions" ->
-      Gen_api.gen_custom_actions api
-  | Some "rbac" ->
-      Gen_api.gen_rbac api
-  | Some "test" ->
-      Gen_test.gen_test api
-  | Some x ->
-      Printf.eprintf "Didn't recognise mode: %s\n" x
+  in
+  let doc =
+    let keys = List.map fst options |> String.concat ", " in
+    Printf.sprintf
+      "Specify how the datamodel API should be filtered prior to processing, \
+       one of: %s."
+      keys
+  in
+  let filter =
+    Arg.(opt (enum options) Nothing & info ["f"; "filter"] ~doc ~docv:"FILTER")
+  in
+  Arg.(value & filter)
+
+let gen_command_common ~name ~doc
+    ~(f : Gen_api_types.config -> Dm_api.api -> unit) =
+  let go filter filter_internal debug =
+    let api = filter_api filter filter_internal in
+    let config = Gen_api_types.{debug} in
+    f config api
+  in
+  let man = [] in
+  let info = Cmd.info name ~version:"0.1" ~doc ~man in
+  let term =
+    Term.(const go $ filter_arg $ filter_internal_arg $ gen_debug_arg)
+  in
+  Cmd.v info term
+
+module Commands = struct
+  open Gen_api
+
+  let server =
+    gen_command_common ~name:"server" ~doc:"generate server.ml" ~f:gen_server
+
+  let client =
+    gen_command_common ~name:"client" ~doc:"generate client.ml" ~f:gen_client
+
+  let api =
+    gen_command_common ~name:"api" ~doc:"generate api.ml" ~f:gen_client_types
+
+  let rbac =
+    gen_command_common ~name:"rbac" ~doc:"generate rbac_static.ml" ~f:gen_rbac
+
+  let db =
+    gen_command_common ~name:"db" ~doc:"generate db_actions.ml"
+      ~f:gen_db_actions
+
+  let utils =
+    gen_command_common ~name:"utils" ~doc:"generate generated_record_utils.ml"
+      ~f:gen_record_deserialization
+
+  let actions =
+    gen_command_common ~name:"actions" ~doc:"generate custom_actions.ml"
+      ~f:gen_custom_actions
+end
+
+let driver =
+  let group = Commands.[server; client; api; rbac; db; utils; actions] in
+  let exe = Filename.basename Sys.argv.(0) in
+  let info = Cmd.info exe ~version:"0.1" in
+  Cmd.group info group
+
+let () = exit (Cmd.eval driver)

--- a/ocaml/idl/ocaml_backend/gen_api_types.ml
+++ b/ocaml/idl/ocaml_backend/gen_api_types.ml
@@ -1,0 +1,15 @@
+(*
+ * Copyright (C) 2025 Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type config = {debug: bool}

--- a/ocaml/idl/ocaml_backend/gen_client.ml
+++ b/ocaml/idl/ocaml_backend/gen_client.ml
@@ -79,11 +79,12 @@ let objfilter msg api =
     (not msg_is_con_or_des) || obj_gen_con_and_des
 
 let client_api ~sync api =
-  let filter f = Dm_api.filter (fun _ -> true) (fun _ -> true) f in
   let api =
-    filter (fun msg -> DU.on_client_side msg && objfilter msg api) api
+    Dm_api.filter_by
+      ~message:(fun msg -> DU.on_client_side msg && objfilter msg api)
+      api
   in
-  if sync then api else filter has_async api
+  if sync then api else Dm_api.filter_by ~message:has_async api
 
 (* Client constructor takes all object fields which are StaticRO or RW *)
 let ctor_fields (obj : obj) =

--- a/ocaml/idl/ocaml_backend/gen_db_actions.ml
+++ b/ocaml/idl/ocaml_backend/gen_db_actions.ml
@@ -33,10 +33,7 @@ let _db_defaults = "DB_DEFAULTS"
 
 (** Filter out all the operations which don't make sense to the database *)
 let make_db_api =
-  Dm_api.filter
-    (fun _ -> true)
-    (fun _ -> true)
-    (fun {msg_tag= tag; _} ->
+  Dm_api.filter_by ~message:(fun {msg_tag= tag; _} ->
       match tag with
       | FromField (_, _) ->
           true
@@ -46,7 +43,7 @@ let make_db_api =
           false (* rely on the Private(GetDBAll) function for now *)
       | FromObject _ ->
           true
-    )
+  )
 
 (* Only these types are actually marshalled into the database: *)
 let type_marshalled_in_db = function
@@ -672,10 +669,9 @@ let db_action api : O.Module.t =
     which has no custom action. The signature will be smaller than the
     db_actions signature but the db_actions module will be compatible with it *)
 let make_db_defaults_api =
-  Dm_api.filter
-    (fun _ -> true)
-    (fun _ -> true)
-    (fun x -> not (Gen_empty_custom.operation_requires_side_effect x))
+  Dm_api.filter_by ~message:(fun msg ->
+      not (Gen_empty_custom.operation_requires_side_effect msg)
+  )
 
 let db_defaults api : O.Signature.t =
   (* Since we intend to defunctorise, don't bother filtering the signature *)

--- a/ocaml/idl/ocaml_backend/gen_empty_custom.ml
+++ b/ocaml/idl/ocaml_backend/gen_empty_custom.ml
@@ -79,10 +79,10 @@ let operation_requires_side_effect ({msg_tag= tag; _} as msg) =
       msg.DT.msg_has_effect && msg.DT.msg_forward_to = None
 
 let make_custom_api api =
-  Dm_api.filter
-    (fun _ -> true)
-    (fun _ -> true)
-    (fun msg -> operation_requires_side_effect msg && Client.objfilter msg api)
+  Dm_api.filter_by
+    ~message:(fun msg ->
+      operation_requires_side_effect msg && Client.objfilter msg api
+    )
     api
 
 let gen_debug_module name_override result_type_override body_override api :

--- a/ocaml/idl/ocaml_backend/gen_rbac.ml
+++ b/ocaml/idl/ocaml_backend/gen_rbac.ml
@@ -301,7 +301,7 @@ let apicalls obj =
   permissions_roles
 
 (* Returns a (static_role,permission list) list generated from datamodel.ml *)
-let gen_permissions_of_static_roles highapi =
+let gen_permissions_of_static_roles config highapi =
   let api = Client.client_api ~sync:true highapi in
   let all_objs = Dm_api.objects_of_api api in
   let rec get_roles_permissions_of_objs = function
@@ -338,7 +338,7 @@ let gen_permissions_of_static_roles highapi =
       (fun (r, _) -> r = internal_role_local_root)
       _permissions_roles
   in
-  if !Gen_server.enable_debugging then (* for rbac_static.csv *)
+  if config.Gen_api_types.debug then (* for rbac_static.csv *)
     writer_csv permissions_roles
   else (* for rbac_static.ml *)
     let _, roles_permissions =

--- a/ocaml/idl/ocaml_backend/gen_server.ml
+++ b/ocaml/idl/ocaml_backend/gen_server.ml
@@ -29,8 +29,6 @@ let _db_defaults = "Db_actions.DB_Action"
 
 let _concurrency = "Concurrency"
 
-let enable_debugging = ref false
-
 let is_session_arg arg =
   let binding = O.string_of_param arg in
   let converter = O.type_of_param arg in
@@ -44,10 +42,7 @@ let from_rpc ?(ignore = false) arg =
     binding converter binding
 
 let debug msg args =
-  if !enable_debugging then
-    "D.debug \"" ^ String.escaped msg ^ "\" " ^ String.concat " " args ^ ";"
-  else
-    ""
+  "D.debug \"" ^ String.escaped msg ^ "\" " ^ String.concat " " args ^ ";"
 
 let has_default_args args =
   let has_default arg = Option.is_some arg.DT.param_default in

--- a/ocaml/sdk-gen/c/gen_c_binding.ml
+++ b/ocaml/sdk-gen/c/gen_c_binding.ml
@@ -34,9 +34,11 @@ let api =
     && msg.msg_name <> "get"
     && msg.msg_name <> "get_data_sources"
   in
-  filter obj_filter field_filter message_filter
+  filter_by ~obj:obj_filter ~field:field_filter ~message:message_filter
     (Datamodel_utils.add_implicit_messages ~document_order:false
-       (filter obj_filter field_filter message_filter Datamodel.all_api)
+       (filter_by ~obj:obj_filter ~field:field_filter ~message:message_filter
+          Datamodel.all_api
+       )
     )
 
 let classes = objects_of_api api

--- a/ocaml/sdk-gen/common/CommonFunctions.ml
+++ b/ocaml/sdk-gen/common/CommonFunctions.ml
@@ -354,13 +354,12 @@ let objects =
   (* Add all implicit messages *)
   let api = add_implicit_messages api in
   (* Only include messages that are visible to a XenAPI client *)
-  let api = filter (fun _ -> true) (fun _ -> true) on_client_side api in
+  let api = filter_by ~message:on_client_side api in
   (* And only messages marked as not hidden from the docs, and non-internal fields *)
   let api =
-    filter
-      (fun _ -> true)
-      (fun f -> not f.internal_only)
-      (fun m -> not m.msg_hide_from_docs)
+    filter_by
+      ~field:(fun f -> not f.internal_only)
+      ~message:(fun m -> not m.msg_hide_from_docs)
       api
   in
   objects_of_api api

--- a/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
+++ b/ocaml/sdk-gen/csharp/gen_csharp_binding.ml
@@ -32,7 +32,6 @@ let templdir = "templates"
 let api =
   Datamodel_utils.named_self := true ;
 
-  let obj_filter _ = true in
   let field_filter field =
     (not field.internal_only) && List.mem "closed" field.release.internal
   in
@@ -41,10 +40,11 @@ let api =
     && (not msg.msg_hide_from_docs)
     && List.mem "closed" msg.msg_release.internal
   in
-  filter obj_filter field_filter message_filter
-    (Datamodel_utils.add_implicit_messages ~document_order:false
-       (filter obj_filter field_filter message_filter Datamodel.all_api)
-    )
+  let filter api = filter_by ~field:field_filter ~message:message_filter api in
+  Datamodel.all_api
+  |> filter
+  |> Datamodel_utils.add_implicit_messages ~document_order:false
+  |> filter
 
 let classes =
   List.filter

--- a/ocaml/sdk-gen/java/main.ml
+++ b/ocaml/sdk-gen/java/main.ml
@@ -16,7 +16,6 @@ module DU = Datamodel_utils
 let api =
   Datamodel_utils.named_self := true ;
 
-  let obj_filter _ = true in
   let field_filter field =
     (not field.internal_only) && List.mem "closed" field.release.internal
   in
@@ -25,10 +24,11 @@ let api =
     && (not msg.msg_hide_from_docs)
     && List.mem "closed" msg.msg_release.internal
   in
-  filter obj_filter field_filter message_filter
-    (Datamodel_utils.add_implicit_messages ~document_order:false
-       (filter obj_filter field_filter message_filter Datamodel.all_api)
-    )
+  let filter api = filter_by ~field:field_filter ~message:message_filter api in
+  Datamodel.all_api
+  |> filter
+  |> Datamodel_utils.add_implicit_messages ~document_order:false
+  |> filter
 
 (*Here we extract a list of objs (look in datamodel_types.ml for the structure definitions)*)
 let classes = objects_of_api api

--- a/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
+++ b/ocaml/sdk-gen/powershell/gen_powershell_binding.ml
@@ -25,7 +25,6 @@ type cmdlet = {filename: string; content: string}
 
 let api =
   Datamodel_utils.named_self := true ;
-  let obj_filter _ = true in
   let field_filter field =
     (not field.internal_only) && List.mem "closed" field.release.internal
   in
@@ -48,10 +47,11 @@ let api =
     && msg.msg_tag <> FromObject GetAllRecords
     && List.mem "closed" msg.msg_release.internal
   in
-  filter obj_filter field_filter message_filter
-    (Datamodel_utils.add_implicit_messages ~document_order:false
-       (filter obj_filter field_filter message_filter Datamodel.all_api)
-    )
+  let filter api = filter_by ~field:field_filter ~message:message_filter api in
+  Datamodel.all_api
+  |> filter
+  |> Datamodel_utils.add_implicit_messages ~document_order:false
+  |> filter
 
 let classes_with_records =
   Datamodel_utils.add_implicit_messages ~document_order:false Datamodel.all_api

--- a/ocaml/xapi-cli-server/dune
+++ b/ocaml/xapi-cli-server/dune
@@ -1,11 +1,11 @@
 (rule
-  (targets generated_record_utils.ml)
+  (target generated_record_utils.ml)
   (deps
-    ../idl/ocaml_backend/gen_api_main.exe
+    (:gen ../idl/ocaml_backend/gen_api_main.exe)
   )
   (action
-    (run %{deps} -filterinternal true -filter closed -mode utils -output
-      %{targets}))
+   (with-stdout-to %{target}
+    (run %{gen} utils --filter-internal --filter closed)))
 )
 
 (library

--- a/ocaml/xapi-client/dune
+++ b/ocaml/xapi-client/dune
@@ -1,11 +1,11 @@
 (rule
-  (targets client.ml)
+  (target client.ml)
   (deps
-    ../idl/ocaml_backend/gen_api_main.exe
+    (:gen ../idl/ocaml_backend/gen_api_main.exe)
   )
   (action
-    (run %{deps} -filterinternal true -filter closed -mode client -output
-      %{targets}))
+   (with-stdout-to %{target}
+    (run %{gen} client --filter-internal --filter closed)))
 )
 
 (library

--- a/ocaml/xapi-types/dune
+++ b/ocaml/xapi-types/dune
@@ -1,11 +1,11 @@
 (rule
-  (targets aPI.ml)
+  (target aPI.ml)
   (deps
-    ../idl/ocaml_backend/gen_api_main.exe
+    (:gen ../idl/ocaml_backend/gen_api_main.exe)
   )
   (action
-    (run %{deps} -filterinternal true -filter closed -mode api -output
-      %{targets}))
+   (with-stdout-to %{target}
+    (run %{gen} api --filter-internal --filter closed)))
 )
 
 (library

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -1,51 +1,51 @@
 (rule
-  (targets server.ml)
+  (target server.ml)
   (deps
-    ../idl/ocaml_backend/gen_api_main.exe
+    (:gen ../idl/ocaml_backend/gen_api_main.exe)
   )
   (action
-    (run %{deps} -filterinternal true -gendebug -filter closed -mode server
-      -output %{targets}))
+   (with-stdout-to %{target}
+    (run %{gen} server --gen-debug --filter-internal --filter closed)))
 )
 
 (rule
-  (targets db_actions.ml)
+  (target db_actions.ml)
   (deps
-    ../idl/ocaml_backend/gen_api_main.exe
+    (:gen ../idl/ocaml_backend/gen_api_main.exe)
   )
   (action
-    (run %{deps} -filterinternal false -filter nothing -mode db -output
-      %{targets}))
+   (with-stdout-to %{target}
+    (run %{gen} db --filter nothing)))
 )
 
 (rule
-  (targets custom_actions.ml)
+  (target custom_actions.ml)
   (deps
-    ../idl/ocaml_backend/gen_api_main.exe
+    (:gen ../idl/ocaml_backend/gen_api_main.exe)
   )
   (action
-    (run %{deps} -filterinternal true -filter closed -mode actions -output
-      %{targets}))
+   (with-stdout-to %{target}
+    (run %{gen} actions --filter-internal --filter closed)))
 )
 
 (rule
-  (targets rbac_static.ml)
+  (target rbac_static.ml)
   (deps
-    ../idl/ocaml_backend/gen_api_main.exe
+    (:gen ../idl/ocaml_backend/gen_api_main.exe)
   )
   (action
-    (run %{deps} -filterinternal true -filter closed -mode rbac -output
-      %{targets}))
+   (with-stdout-to %{target}
+    (run %{gen} rbac --filter-internal --filter closed)))
 )
 
 (rule
-  (targets rbac_static.csv)
+  (target rbac_static.csv)
   (deps
-    ../idl/ocaml_backend/gen_api_main.exe
+    (:gen ../idl/ocaml_backend/gen_api_main.exe)
   )
   (action
-    (run %{deps} -filterinternal true -gendebug -filter closed -mode rbac
-      -output %{targets}))
+   (with-stdout-to %{target}
+    (run %{gen} rbac --gen-debug --filter-internal --filter closed)))
 )
 
 (install

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -25,7 +25,7 @@ verify-cert () {
 }
 
 mli-files () {
-  N=496
+  N=497
   X="ocaml/tests"
   X+="|ocaml/quicktest"
   X+="|ocaml/message-switch/core_test"


### PR DESCRIPTION
- Drops usage of stdlib `Arg` module for argument parsing, replacing it with Cmdliner.
- Drops some globals pertaining to the filtering of APIs.
- Drops apparent condition in `Gen_server`: `server.ml` cannot be built without the debug flag being enabled, as the emitted OCaml code is ill formed.
- Drops ability to specify an output file; dune's `with-stdout-to` subsumes this behaviour, as does the piping functionality in every shell.

The idea is hopefully that it'll be more flexible to experiment and extend the `ocaml_backend/` targets.