### PR TITLE
CA-407322 - libs/rrd: Keep lastupdate XML field as int, XenCenter relies on it

### DIFF
--- a/ocaml/libs/xapi-rrd/lib/rrd.ml
+++ b/ocaml/libs/xapi-rrd/lib/rrd.ml
@@ -999,7 +999,14 @@ let xml_to_output internal rrd output =
     (fun output ->
       tag "version" (data "0003") output ;
       tag "step" (data (Int64.to_string rrd.timestep)) output ;
-      tag "lastupdate" (data (Utils.f_to_s rrd.last_updated)) output ;
+      (* XenCenter and other legacy users expect this to be an integer
+         representing the number of seconds, so keep it an integer to avoid
+         breaking them. Some other libraries (e.g. the Python rrd parser,
+         the C rrd parser, xenrt) will expect a float and can easily convert
+         an int to it. *)
+      tag "lastupdate"
+        (data (Printf.sprintf "%Ld" (Int64.of_float rrd.last_updated)))
+        output ;
       do_dss rrd.rrd_dss output ;
       do_rras rrd.rrd_rras output
     )


### PR DESCRIPTION
Instead of waiting for a complicated fix on XC side, switch back to outputting integers when dumping XMLs.

Implementations that already switched to float should be good, since converting int to float is fine, but not the other way around.

XML is an outdated format, JSON should be preferrably used, and it will keep using floats with larger precision.

Fixes: a897b53 ("CA-391651: Use per-datasource last_updated timestamp during updating and archiving")