### PR TITLE
message_forwarding: Change call_slave_... functions to reduce repetition

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -914,6 +914,7 @@ let is_slave ~__context ~host:_ = not (Pool_role.is_master ())
 let ask_host_if_it_is_a_slave ~__context ~host =
   let ask_and_warn_when_slow ~__context =
     let local_fn = is_slave ~host in
+    let remote_fn = Client.Client.Pool.is_slave ~host in
     let timeout = 10. in
     let task_name = Context.get_task_id __context |> Ref.string_of in
     let ip, uuid =
@@ -935,9 +936,7 @@ let ask_host_if_it_is_a_slave ~__context ~host =
       (log_host_slow_to_respond timeout) ;
     let res =
       Message_forwarding.do_op_on_localsession_nolivecheck ~local_fn ~__context
-        ~host (fun session_id rpc ->
-          Client.Client.Pool.is_slave ~rpc ~session_id ~host
-      )
+        ~host ~remote_fn
     in
     Xapi_stdext_threads_scheduler.Scheduler.remove_from_queue task_name ;
     res


### PR DESCRIPTION
These functions were calling remote functions with rpc and session_id as unnamed parameters. Because the remote functions always gave these two parameters named, it required closures throughout the file to fix this inconsistency.

This creates a lot of unnecessary code. Change the situation by making call_slave_... functions to call the functions using named parameters, and group the local and remote functions whenever a chain to_call_slave_... is initiated so it's easy to verify that the calls are correct.

Most of the callers use the same name for both local and remote functions, but there are some interesting cases that can be easily seen now: pool_eject always uses the same remote function for 3 different types of members in the pool, previously 3 different closures were created and the code had to be careful with names to not confuse the ejected host from the ejectors.

When starting a vm, the local function is start_on, while the remote function is start, the formers needs an additional host parameter, when compared to the latter.

A lot of functions in message_forwarding look very regular, this may lead to a chance to further reduce glue code, or even generate the code?