### PR TITLE
XSI-1821: Add pre-condition for host.emergency_reenable_tls_verification

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -2039,6 +2039,12 @@ let _ =
   error Api_errors.host_driver_no_hardware ["driver variant"]
     ~doc:"No hardware present for this host driver variant" () ;
 
+  error Api_errors.tls_verification_not_enabled_in_pool []
+    ~doc:
+      "TLS verification has not been enabled in the pool successfully, please \
+       enable it in XC or run xe pool-enable-tls-verification instead."
+    () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2263,7 +2263,9 @@ let emergency_reenable_tls_verification =
   call ~flags:[`Session] ~name:"emergency_reenable_tls_verification"
     ~lifecycle:[(Published, "1.298.0", "")]
     ~in_oss_since:None ~params:[]
-    ~doc:"Reenable TLS verification for this host only"
+    ~doc:
+      "Reenable TLS verification for this host only, and only after it was \
+       emergency disabled"
     ~allowed_roles:_R_LOCAL_ROOT_ONLY ()
 
 let apply_updates =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -842,7 +842,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
     , {
         reqd= []
       ; optn= []
-      ; help= "Disable TLS verification for this host only"
+      ; help= "Disable TLS verification for this host only."
       ; implementation=
           No_fd_local_session
             Cli_operations.host_emergency_disable_tls_verification
@@ -853,7 +853,9 @@ let rec cmdtable_data : (string * cmd_spec) list =
     , {
         reqd= []
       ; optn= []
-      ; help= "Reenable TLS verification for this host only"
+      ; help=
+          "Reenable TLS verification for this host only, and only after it was \
+           emergency disabled."
       ; implementation=
           No_fd_local_session
             Cli_operations.host_emergency_reenable_tls_verification

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1419,3 +1419,6 @@ let illegal_in_fips_mode = add_error "ILLEGAL_IN_FIPS_MODE"
 let too_many_groups = add_error "TOO_MANY_GROUPS"
 
 let host_driver_no_hardware = add_error "HOST_DRIVER_NO_HARDWARE"
+
+let tls_verification_not_enabled_in_pool =
+  add_error "TLS_VERIFICATION_NOT_ENABLED_IN_POOL"


### PR DESCRIPTION
host.emergency_reenable_tls_verification can only be used after TLS
verification is enabled in pool, raise an error if otherwise.