### PR TITLE
CA-407328: Change vm parameter names of SXM calls

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -805,13 +805,17 @@ let get_vdi_mirror __context vm vdi do_mirror =
   in
   let hash x =
     let s = Digest.string x |> Digest.to_hex in
-    String.sub s 0 5
+    String.sub s 0 3
   in
   let copy_vm =
-    Ref.string_of vm |> hash |> ( ^ ) "COPY" |> Storage_interface.Vm.of_string
+    (Ref.string_of vm |> hash) ^ (Ref.string_of vdi |> hash)
+    |> ( ^ ) "CP"
+    |> Storage_interface.Vm.of_string
   in
   let mirror_vm =
-    Ref.string_of vm |> hash |> ( ^ ) "MIR" |> Storage_interface.Vm.of_string
+    (Ref.string_of vm |> hash) ^ (Ref.string_of vdi |> hash)
+    |> ( ^ ) "MIR"
+    |> Storage_interface.Vm.of_string
   in
   {
     vdi


### PR DESCRIPTION
The vm parameter passed to SMAPIv2 calls is needed for the storage backend to know which domain slice it should operate on. For SXM, since there is no specific VM, we use the convention "MIR<vm-prefix>", where the <vm-prefix> is the first five characters of the hash of the vm uuid. This is not sufficient for VMs with multiple VDIs attached to it as they would result in the same vm parameter.

So use a new convention "MIR<vm-prefix><vdi-prefix>" so we distinguish VDIs during migration. These vm parameters cannot be too long though as otherwise the storage backend will not accept them.