### PR TITLE
CP-53708: Expose the existing PCI vendor/device IDs

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -9243,21 +9243,18 @@ module PCI = struct
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_boston, "")]
             "class_id" "PCI class ID" ~default_value:(Some (VString ""))
-            ~internal_only:true
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_boston, "")]
             "class_name" "PCI class name" ~default_value:(Some (VString ""))
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_boston, "")]
             "vendor_id" "Vendor ID" ~default_value:(Some (VString ""))
-            ~internal_only:true
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_boston, "")]
             "vendor_name" "Vendor name" ~default_value:(Some (VString ""))
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_boston, "")]
             "device_id" "Device ID" ~default_value:(Some (VString ""))
-            ~internal_only:true
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_boston, "")]
             "device_name" "Device name" ~default_value:(Some (VString ""))
@@ -9301,7 +9298,7 @@ module PCI = struct
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_clearwater_whetstone, "")]
             "subsystem_vendor_id" "Subsystem vendor ID"
-            ~default_value:(Some (VString "")) ~internal_only:true
+            ~default_value:(Some (VString ""))
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_clearwater_whetstone, "")]
             "subsystem_vendor_name" "Subsystem vendor name"
@@ -9309,7 +9306,7 @@ module PCI = struct
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_clearwater_whetstone, "")]
             "subsystem_device_id" "Subsystem device ID"
-            ~default_value:(Some (VString "")) ~internal_only:true
+            ~default_value:(Some (VString ""))
         ; field ~qualifier:StaticRO ~ty:String
             ~lifecycle:[(Published, rel_clearwater_whetstone, "")]
             "subsystem_device_name" "Subsystem device name"

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "e6b99e0d07ccf68df8f45c851e5d8dbf"
+let last_known_schema_hash = "ad67a64cd47cdea32085518c1fb38d27"
 
 let current_schema_hash : string =
   let open Datamodel_types in


### PR DESCRIPTION
To facilitate the telemetry purpose, change "*_id" fields in PCI objects from internal_only:true to internal_only:false in xapi.
class_id
vendor_id
device_id
subsystem_vendor_id
subsystem_device_id