### PR TITLE
CP-50934: fix qemu cgroups to be compatible with cgroupv2

### DIFF
--- a/ocaml/xenopsd/scripts/qemu-wrapper
+++ b/ocaml/xenopsd/scripts/qemu-wrapper
@@ -95,13 +95,18 @@ def prepare_exec():
         # Move to nominated cgroup slice
         print("Moving to cgroup slice '%s'" % cgroup_slice)
         try:
-            # Note the default slice uses /sys/fs/cgroup/cpu/tasks but
-            # other.slice uses /sys/fs/cgroup/cpu/other.slice/tasks.
-            g = open("/sys/fs/cgroup/cpu/%s/tasks" % cgroup_slice, 'w')
+            try:
+                # cgroup-v1 path:
+                # Note the default slice uses /sys/fs/cgroup/cpu/cgroup.procs but
+                # other.slice uses /sys/fs/cgroup/cpu/other.slice/cgroup.procs.
+                g = open("/sys/fs/cgroup/cpu/%s/cgroup.procs" % cgroup_slice, 'w')
+            except FileNotFoundError:
+                # cgroup-v2 path:
+                g = open("/sys/fs/cgroup/%s/cgroup.procs" % cgroup_slice, 'w')
             g.write(str(os.getpid()))
             g.close()
         except IOError as e:
-            print("Warning: writing pid to '%s' tasks file: %s" \
+            print("Warning: writing pid to '%s' cgroup.procs file: %s" \
                 % (cgroup_slice, e))
 
     core_dump_limit = enable_core_dumps()


### PR DESCRIPTION
cgroup-v2 doesn't have a 'tasks' file anymore (which refers to threads, not processes). Use cgroup.procs instead which exists on both cgroupv1 and cgroupv2, and would be actually the correct one to use, because we want to move the entire process (even if it has, or will have multiple threads).


Tested on cgroup-v1 (XS8): 
```
systemd-cgls /sys/fs/cgroup/cpu/vm.slice|grep qemu-dm
└─2421656 qemu-dm-22 -machine pc-i440fx-2.10,accel=xen,max-ram-below-4g=40265...
```

And on cgroup-v2 (XS9):
```
systemd-cgls /sys/fs/cgroup/vm.slice|grep qemu-dm
└─777450 qemu-dm-511 -machine pc-i440fx-2.10,accel=xen,max-ram-below-4g=4026531…
```

Previously in cgroup-v2 qemu has ended up underneath forkexecd, which is part of control.slice, reducing the amount of CPU available to oxenstored and XAPI, leading to timeouts on busy machines.