### PR TITLE
github: restrict workflow permissions

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -1,5 +1,7 @@
 name: Build and test (1.249-lcm, scheduled)
 
+permissions: {}
+
 on:
   schedule:
     # run every Monday, this refreshes the cache
@@ -9,6 +11,8 @@ jobs:
   python-test:
     name: Python tests
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,7 @@
 name: Generate and upload docs
 
+permissions: {}
+
 on:
   push:
     branches: master
@@ -8,6 +10,8 @@ jobs:
   ocaml:
     name: Docs
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     env:
       XAPI_VERSION: "v0.0.0-${{ github.sha }}"
       STORAGE_DOCDIR: .gh-pages-xapi-storage

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,5 +1,7 @@
 name: Check format
 
+permissions: {}
+
 on:
   pull_request:
     branches:
@@ -12,6 +14,8 @@ jobs:
   ocaml-format:
     name: Ocaml files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -1,5 +1,7 @@
 name: Generate and Build SDKs
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -11,6 +13,9 @@ jobs:
   generate-sdk-sources:
     name: Generate SDK sources
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,7 +30,7 @@ jobs:
         run: opam exec -- make sdk
 
       # sdk-ci runs some Go unit tests.
-      # This setting ensures that SDK date time 
+      # This setting ensures that SDK date time
       # tests are run on a machine that
       # isn't using UTC
       - name: Set Timezone to Tokyo for datetime tests
@@ -77,6 +82,9 @@ jobs:
     name: Build C SDK
     runs-on: ubuntu-latest
     needs: generate-sdk-sources
+    permissions:
+      contents: read
+
     steps:
       - name: Install dependencies
         run: sudo apt-get install libxml2-dev
@@ -103,6 +111,9 @@ jobs:
     name: Build Java SDK
     runs-on: ubuntu-latest
     needs: generate-sdk-sources
+    permissions:
+      contents: read
+
     steps:
       - name: Install dependencies
         run: sudo apt-get install maven
@@ -120,9 +131,9 @@ jobs:
           distribution: 'temurin'
 
       # Java Tests are run at compile time.
-      # This setting ensures that SDK date time 
+      # This setting ensures that SDK date time
       # tests are run on a machine that
-      # isn't using UTC 
+      # isn't using UTC
       - name: Set Timezone to Tokyo for datetime tests
         run: |
           sudo timedatectl set-timezone Asia/Tokyo
@@ -144,6 +155,9 @@ jobs:
     name: Build C# SDK
     runs-on: windows-2022
     needs: generate-sdk-sources
+    permissions:
+      contents: read
+
     steps:
       - name: Strip 'v' prefix from xapi version
         shell: pwsh
@@ -158,7 +172,7 @@ jobs:
         # All tests builds and pipelines should
         # work on other timezones. This setting ensures that
         # SDK date time tests are run on a machine that
-        # isn't using UTC 
+        # isn't using UTC
       - name: Set Timezone to Tokyo for datetime tests
         shell: pwsh
         run: Set-TimeZone -Id "Tokyo Standard Time"
@@ -192,6 +206,9 @@ jobs:
     # PowerShell SDK for PowerShell 5.x needs to run on windows-2019 because
     # windows-2022 doesn't contain .NET Framework 4.x dev tools
     runs-on: windows-2019
+    permissions:
+      contents: read
+
     steps:
       - name: Strip 'v' prefix from xapi version
         shell: pwsh
@@ -265,6 +282,8 @@ jobs:
         dotnet: ["6", "8"]
     needs: build-csharp-sdk
     runs-on: windows-2022
+    permissions:
+      contents: read
 
     steps:
       - name: Strip 'v' prefix from xapi version

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,5 +1,7 @@
 name: Generate and upload Hugo docs
 
+permissions: {}
+
 on:
   push:
     branches: master
@@ -8,6 +10,9 @@ jobs:
   ocaml:
     name: Docs
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+
 
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Build and test
 
+permissions: {}
+
 on:
   # When only Hugo docs change, this workflow is not required:
   push:
@@ -20,6 +22,8 @@ jobs:
   ocaml-tests:
     name: Run OCaml tests
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     env:
       # Ensure you also update test-sdk-builds
       # when changing this value, to keep builds

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -1,5 +1,7 @@
 name: Build and test (other)
 
+permissions: {}
+
 on:
   # When only Hugo docs change, this workflow is not required:
   push:
@@ -20,6 +22,10 @@ jobs:
   python-test:
     name: Python tests
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write # allow commenting on the PR
+
     strategy:
       fail-fast: false
       matrix:
@@ -96,6 +102,8 @@ jobs:
   deprecation-test:
     name: Deprecation tests
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -110,6 +118,8 @@ jobs:
   test-sdk-builds:
     name: Test SDK builds
     uses: ./.github/workflows/generate-and-build-sdks.yml
+    permissions:
+      contents: read
     with:
       # Ensure you also update ocaml-tests
       # when changing this value, to keep builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Create release from tag
 
+permissions: {}
+
 on:
   push:
     tags:
@@ -9,6 +11,8 @@ jobs:
   build-python:
     name: Build and upload Python artifacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -36,10 +40,15 @@ jobs:
   build-sdks:
     name: Build and upload SDK artifacts
     uses: ./.github/workflows/generate-and-build-sdks.yml
+    permissions:
+      contents: read
     with:
       xapi_version: ${{ github.ref_name }}
 
   release:
+    permissions:
+      contents: write # allow creating a release
+
     name: "Create and package release"
     runs-on: ubuntu-latest
     needs: [build-python, build-sdks]
@@ -124,6 +133,7 @@ jobs:
     needs: release
     environment: pypi
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Retrieve python distribution artifacts

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,5 +1,7 @@
 name: ShellCheck
 
+permissions: {}
+
 on:
   pull_request:
   merge_group:
@@ -16,8 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      actions: read
+      contents: read
+      pull-requests: write # allow commenting on the PR
       security-events: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Removes all default permissions, and only adds needed permissions to the workflows that need it.

- read contents: allows reading the repository, most workflows need this
- write contents: allows to write to the repository. Needed to create releases
- write pull-requests: allows to manipulate pull requests. Unfortunately this is needed to comment on PRs
- read actions: allows reading the state of actions

Note that because all workflows remove all permissions at the top level the current default permissions don't take any effect.