### PR TITLE
CA-399631: Increase the max size of xcp-rrdd-plugins for bug-tool

### DIFF
--- a/ocaml/xcp-rrdd/bugtool-plugin/rrdd-plugins.xml
+++ b/ocaml/xcp-rrdd/bugtool-plugin/rrdd-plugins.xml
@@ -1,1 +1,1 @@
-<capability pii="maybe" max_size="1638400" max_time="60" mime="text/plain" checked="true"/>
+<capability pii="maybe" max_size="13107200" max_time="60" mime="text/plain" checked="true"/>


### PR DESCRIPTION
The size is not enough in xs9, xen-bugtool.log:

> Omitting /dev/shm/metrics/xcp-rrdd-squeezed, size constraint of xcp-rrdd-plugins exceeded 
Omitting /dev/shm/metrics/xcp-rrdd-iostat, size constraint of xcp-rrdd-plugins exceeded 
Omitting /dev/shm/metrics/mem-stats, size constraint of xcp-rrdd-plugins exceeded
...

- Tested: 4243304 NRPE
Modifying the max_size to 13107200 (1638400 * 8) solved this issue.
1638400 * 2 and 1638400 * 4 are not enough.