### PR TITLE
c_stubs: use 'new' acquire and release runtime functions

### DIFF
--- a/ocaml/auth/xa_auth_stubs.c
+++ b/ocaml/auth/xa_auth_stubs.c
@@ -25,7 +25,7 @@
 #include <caml/custom.h>
 #include <caml/fail.h>
 #include <caml/callback.h>
-#include <caml/signals.h>
+#include <caml/threads.h>
 
 #include "xa_auth.h"
 
@@ -39,11 +39,11 @@ CAMLprim value stub_XA_mh_authorize(value username, value password){
     const char *error = NULL;
     int rc;
 
-    caml_enter_blocking_section();
+    caml_release_runtime_system();
     rc = XA_mh_authorize(c_username, c_password, &error);
     free(c_username);
     free(c_password);
-    caml_leave_blocking_section();
+    caml_acquire_runtime_system();
 
     if (rc != XA_SUCCESS)
         caml_failwith(error ? error : "Unknown error");
@@ -60,11 +60,11 @@ CAMLprim value stub_XA_mh_chpasswd(value username, value new_password){
     const char *error = NULL;
     int rc;
 
-    caml_enter_blocking_section();
+    caml_release_runtime_system();
     rc = XA_mh_chpasswd (c_username, c_new_password, &error);
     free(c_username);
     free(c_new_password);
-    caml_leave_blocking_section();
+    caml_acquire_runtime_system();
 
     if (rc != XA_SUCCESS)
         caml_failwith(error ? error : "Unknown error");
@@ -102,10 +102,10 @@ CAMLprim value stub_XA_crypt_r(value key, value setting) {
 
     struct crypt_data cd = {0};
 
-    caml_enter_blocking_section();
+    caml_release_runtime_system();
     const char* const hashed =
         crypt_r(String_val(key), String_val(setting), &cd);
-    caml_leave_blocking_section();
+    caml_acquire_runtime_system();
 
     if (!hashed || *hashed == '*')
       CAMLreturn(Val_none);

--- a/ocaml/libs/log/syslog_stubs.c
+++ b/ocaml/libs/log/syslog_stubs.c
@@ -18,7 +18,7 @@
 #include <caml/memory.h>
 #include <caml/alloc.h>
 #include <caml/custom.h>
-#include <caml/signals.h>
+#include <caml/threads.h>
 
 static int syslog_level_table[] = {
 	LOG_EMERG, LOG_ALERT, LOG_CRIT, LOG_ERR, LOG_WARNING,
@@ -57,10 +57,10 @@ value stub_syslog(value facility, value level, value msg)
 	int c_facility = syslog_facility_table[Int_val(facility)]
 	               | syslog_level_table[Int_val(level)];
 
-	caml_enter_blocking_section();
+	caml_release_runtime_system();
 	syslog(c_facility, "%s", c_msg);
 	free(c_msg);
-	caml_leave_blocking_section();
+	caml_acquire_runtime_system();
 
 	CAMLreturn(Val_unit);
 }

--- a/ocaml/libs/vhd/vhd_format_lwt/blkgetsize64_stubs.c
+++ b/ocaml/libs/vhd/vhd_format_lwt/blkgetsize64_stubs.c
@@ -25,7 +25,7 @@
 
 #include <caml/alloc.h>
 #include <caml/memory.h>
-#include <caml/signals.h>
+#include <caml/threads.h>
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
@@ -54,7 +54,7 @@ CAMLprim value stub_blkgetsize64(value filename){
   int rc = NOT_IMPLEMENTED;
   const char *filename_c = strdup(String_val(filename));
 
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
   fd = open(filename_c, O_RDONLY, 0);
   if (fd >= 0) {
 #if defined(BLKGETSIZE64)
@@ -71,7 +71,7 @@ CAMLprim value stub_blkgetsize64(value filename){
     close(fd);
   } else
     size_in_bytes = -1;
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
   free((void*)filename_c);
 
   if (fd == -1) uerror("open", filename);

--- a/ocaml/libs/vhd/vhd_format_lwt/lseek64_stubs.c
+++ b/ocaml/libs/vhd/vhd_format_lwt/lseek64_stubs.c
@@ -26,7 +26,7 @@
 
 #include <caml/alloc.h>
 #include <caml/memory.h>
-#include <caml/signals.h>
+#include <caml/threads.h>
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
@@ -43,7 +43,7 @@ CAMLprim value stub_lseek64_data(value fd, value ofs) {
   off_t c_ofs = Int64_val(ofs);
   off_t c_ret;
 
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
 #if defined(SEEK_DATA)
   c_ret = lseek(c_fd, c_ofs, SEEK_DATA);
   /* retry, if SEEK_DATA not supported on this file system */
@@ -53,7 +53,7 @@ CAMLprim value stub_lseek64_data(value fd, value ofs) {
   /* Set the file pointer to ofs; pretend there is data */
   c_ret = lseek(c_fd, c_ofs, SEEK_SET);
 #endif
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
   if (c_ret == -1) uerror("lseek", Nothing);
 
   result = caml_copy_int64(c_ret);
@@ -67,7 +67,7 @@ CAMLprim value stub_lseek64_hole(value fd, value ofs) {
   off_t c_ofs = Int64_val(ofs);
   off_t c_ret;
 
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
 #if defined(SEEK_HOLE)
   c_ret = lseek(c_fd, c_ofs, SEEK_HOLE);
   /* retry, if SEEK_HOLE not supported on this file system */
@@ -78,7 +78,7 @@ CAMLprim value stub_lseek64_hole(value fd, value ofs) {
      there is no hole */
   c_ret = lseek(c_fd, 0, SEEK_END);
 #endif
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
   if (c_ret == -1) uerror("lseek", Nothing);
   result = caml_copy_int64(c_ret);
   CAMLreturn(result);

--- a/ocaml/libs/vhd/vhd_format_lwt/odirect_stubs.c
+++ b/ocaml/libs/vhd/vhd_format_lwt/odirect_stubs.c
@@ -23,7 +23,7 @@
 
 #include <caml/alloc.h>
 #include <caml/memory.h>
-#include <caml/signals.h>
+#include <caml/threads.h>
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
@@ -36,7 +36,7 @@ CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
 
   const char *filename_c = strdup(String_val(filename));
 
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
   int flags = 0;
 #if defined(O_DIRECT)
   flags |= O_DIRECT;
@@ -47,7 +47,7 @@ CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
     flags |= O_RDONLY;
   }
   fd = open(filename_c, flags, Int_val(perm));
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
 
   free((void*)filename_c);
 

--- a/ocaml/vhd-tool/src/direct_copy_stubs.c
+++ b/ocaml/vhd-tool/src/direct_copy_stubs.c
@@ -28,7 +28,7 @@
 
 #include <caml/alloc.h>
 #include <caml/memory.h>
-#include <caml/signals.h>
+#include <caml/threads.h>
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
@@ -134,7 +134,7 @@ CAMLprim value stub_direct_copy(value handle, value len){
    * values may be accessed, until it is reacquired. Also this
    * means other OCaml threads may do things while this is going
    * on so the caller must be careful. */
-  caml_enter_blocking_section();
+  caml_release_runtime_system();
 
   rc = TRIED_AND_FAILED;
   bytes = 0;
@@ -195,7 +195,7 @@ CAMLprim value stub_direct_copy(value handle, value len){
   rc = OK;
 fail:
 
-  caml_leave_blocking_section();
+  caml_acquire_runtime_system();
   /* Now that the OCaml runtime lock is reacquired, it is safe to
    * raise OCaml exceptions */
 

--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -28,7 +28,7 @@
 #include <caml/alloc.h>
 #include <caml/custom.h>
 #include <caml/fail.h>
-#include <caml/signals.h>
+#include <caml/threads.h>
 #include <caml/callback.h>
 #include <caml/unixsupport.h>
 #include <caml/bigarray.h>
@@ -95,9 +95,9 @@ CAMLprim value stub_xenctrlext_interface_open(value unused)
 	CAMLlocal1(result);
 	xc_interface *xch;
 
-	caml_enter_blocking_section();
+	caml_release_runtime_system();
 	xch = xc_interface_open(NULL, NULL, 0);
-	caml_leave_blocking_section();
+	caml_acquire_runtime_system();
 
 	if ( !xch )
 		failwith_xc(xch);
@@ -226,9 +226,9 @@ CAMLprim value stub_xenctrlext_get_max_nr_cpus(value xch_val)
     xc_interface *xch = xch_of_val(xch_val);
 	int r;
 
-	caml_enter_blocking_section();
+	caml_release_runtime_system();
 	r = xc_physinfo(xch, &c_physinfo);
-	caml_leave_blocking_section();
+	caml_acquire_runtime_system();
 
 	if (r)
 		failwith_xc(xch);
@@ -256,9 +256,9 @@ CAMLprim value stub_xenctrlext_physdev_map_pirq(value xch_val,
     CAMLparam3(xch_val, domid, irq);
     xc_interface *xch = xch_of_val(xch_val);
     int pirq = Int_val(irq);
-    caml_enter_blocking_section();
+    caml_release_runtime_system();
     int retval = xc_physdev_map_pirq(xch, Int_val(domid), pirq, &pirq);
-    caml_leave_blocking_section();
+    caml_acquire_runtime_system();
     if (retval)
         failwith_xc(xch);
     CAMLreturn(Val_int(pirq));
@@ -269,9 +269,9 @@ CAMLprim value stub_xenctrlext_assign_device(value xch_val, value domid,
 {
     CAMLparam4(xch_val, domid, machine_sbdf, flag);
     xc_interface *xch = xch_of_val(xch_val);
-    caml_enter_blocking_section();
+    caml_release_runtime_system();
     int retval = xc_assign_device(xch, Int_val(domid), Int_val(machine_sbdf), Int_val(flag));
-    caml_leave_blocking_section();
+    caml_acquire_runtime_system();
     if (retval)
         failwith_xc(xch);
     CAMLreturn(Val_unit);
@@ -281,9 +281,9 @@ CAMLprim value stub_xenctrlext_deassign_device(value xch_val, value domid, value
 {
     CAMLparam3(xch_val, domid, machine_sbdf);
     xc_interface *xc = xch_of_val(xch_val);
-    caml_enter_blocking_section();
+    caml_release_runtime_system();
     int retval = xc_deassign_device(xc, Int_val(domid), Int_val(machine_sbdf));
-    caml_leave_blocking_section();
+    caml_acquire_runtime_system();
     if (retval)
         failwith_xc(xc);
     CAMLreturn(Val_unit);
@@ -299,9 +299,9 @@ CAMLprim value stub_xenctrlext_domain_soft_reset(value xch_val, value domid)
 {
     CAMLparam2(xch_val, domid);
     xc_interface *xc = xch_of_val(xch_val);
-    caml_enter_blocking_section();
+    caml_release_runtime_system();
     int retval = xc_domain_soft_reset(xc, Int_val(domid));
-    caml_leave_blocking_section();
+    caml_acquire_runtime_system();
     if (retval)
         failwith_xc(xc);
     CAMLreturn(Val_unit);
@@ -312,11 +312,11 @@ CAMLprim value stub_xenctrlext_domain_update_channels(value xch_val, value domid
 {
     CAMLparam4(xch_val, domid, store_port, console_port);
     xc_interface *xc = xch_of_val(xch_val);
-    caml_enter_blocking_section();
+    caml_release_runtime_system();
     int retval = xc_set_hvm_param(xc, Int_val(domid), HVM_PARAM_STORE_EVTCHN, Int_val(store_port));
     if (!retval)
         retval = xc_set_hvm_param(xc, Int_val(domid), HVM_PARAM_CONSOLE_EVTCHN, Int_val(console_port));
-    caml_leave_blocking_section();
+    caml_acquire_runtime_system();
     if (retval)
         failwith_xc(xc);
     CAMLreturn(Val_unit);


### PR DESCRIPTION
These functions have a more relevant name than the previous ones, especially with the advent of OCaml 5.0 the runtime lock becomes more important and programmers must be aware of it.

These functions were introduced in OCaml 3.12.