### PR TITLE
Hoist value access outside section without lock

### DIFF
--- a/ocaml/auth/xa_auth_stubs.c
+++ b/ocaml/auth/xa_auth_stubs.c
@@ -96,15 +96,23 @@ void __attribute__((constructor)) stub_XA_workaround(void)
 }
 
 /* key:string -> setting:string -> string option */
-CAMLprim value stub_XA_crypt_r(value key, value setting) {
-    CAMLparam2(key, setting);
+CAMLprim value stub_XA_crypt_r(value key_val, value setting_val) {
+    CAMLparam2(key_val, setting_val);
     CAMLlocal1(result);
 
     struct crypt_data cd = {0};
 
+    char* const key =
+        caml_stat_strdup(String_val(key_val));
+    char* const setting =
+        caml_stat_strdup(String_val(setting_val));
+
     caml_release_runtime_system();
     const char* const hashed =
-        crypt_r(String_val(key), String_val(setting), &cd);
+        crypt_r(key, setting, &cd);
+
+    caml_stat_free(key);
+    caml_stat_free(setting);
     caml_acquire_runtime_system();
 
     if (!hashed || *hashed == '*')


### PR DESCRIPTION
The runtime lock is not being held when `String_val(...)` is used on OCaml values. Instead, we duplicate the strings whilst holding the lock, then use (and free) the values without the lock.

---

Thanks to @last-genius for spotting this. It's a bad pattern used in other places with less consequence (e.g. `Int_val` is unboxed and cannot be relocated), but they should all be changed - I just wanted to quickly address this in particular, since it's my mistake.