### PR TITLE
CA-407687/XSI-1834: get_subject_information_from_identifier should

### DIFF
--- a/ocaml/xapi/xapi_auth.ml
+++ b/ocaml/xapi/xapi_auth.ml
@@ -18,22 +18,6 @@
 open Auth_signature
 open Extauth
 
-let call_with_exception_handler fn =
-  try fn () with
-  | Extauth.Extauth_is_disabled ->
-      raise (Api_errors.Server_error (Api_errors.auth_is_disabled, []))
-  | Extauth.Unknown_extauth_type msg ->
-      raise (Api_errors.Server_error (Api_errors.auth_unknown_type, [msg]))
-  | Not_found | Auth_signature.Subject_cannot_be_resolved ->
-      raise (Api_errors.Server_error (Api_errors.subject_cannot_be_resolved, []))
-  | Auth_signature.Auth_service_error (_, msg) ->
-      raise (Api_errors.Server_error (Api_errors.auth_service_error, [msg]))
-  | e ->
-      raise
-        (Api_errors.Server_error
-           (Api_errors.auth_service_error, [ExnHelper.string_of_exn e])
-        )
-
 (* PRECONDITION: All of these additional calls require a valid session to be presented.*)
 (* ==> the session validity is already checked in every server.ml call by using Session_check.check *)
 
@@ -49,5 +33,12 @@ let get_group_membership ~__context ~subject_identifier =
 
 let get_subject_information_from_identifier ~__context ~subject_identifier =
   call_with_exception_handler (fun () ->
-      (Ext_auth.d ()).query_subject_information ~__context subject_identifier
+      try
+        (* Query from xapi db first *)
+        Xapi_subject.query_subject_information_from_db ~__context
+          subject_identifier
+      with Auth_signature.Subject_cannot_be_resolved ->
+        (* Not found, fall back to query AD *)
+        Xapi_subject.query_subject_information_from_AD ~__context
+          subject_identifier
   )

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2661,9 +2661,8 @@ let revalidate_subjects ~__context =
     let subj_id = Db.Subject.get_subject_identifier ~__context ~self in
     debug "Revalidating subject %s" subj_id ;
     try
-      let open Auth_signature in
-      ignore
-        ((Extauth.Ext_auth.d ()).query_subject_information ~__context subj_id)
+      Xapi_subject.query_subject_information_from_AD ~__context subj_id
+      |> ignore
     with Not_found ->
       debug "Destroying subject %s" subj_id ;
       Xapi_subject.destroy ~__context ~self


### PR DESCRIPTION
query xapi db, then fallback to query domain DC

get_subject_information_from_identifier query subject details from subject id. It triggers some DNS query to do kerberos query, this causes the problem that authenticating to XAPI with an AD account causes large amounts of Kerberos / DNS traffic

The subject details are actually cached in xapi db and refreshed default in every 10 minutes. get_subject_information_from_identifier should query subject details from xapi DB and only fallback to DC when xapi DB does not have it.