### PR TITLE
CA-403851 stop management server in Pool.eject ()

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2074,6 +2074,8 @@ let eject_self ~__context ~host =
           )
       )
       (fun () -> Xapi_fuse.light_fuse_and_reboot_after_eject ()) ;
+    debug "%s: stop management server" __FUNCTION__ ;
+    Xapi_mgmt_iface.run ~__context ~mgmt_enabled:false () ;
     Xapi_hooks.pool_eject_hook ~__context
 
 (** eject [host] from the pool. This code is run on all hosts in the


### PR DESCRIPTION
We are stopping the management server at the end of the API call. This avoids clients connecting to this host before it has rebooted and become a pool master.

Tested manually; running a BST now.
