### PR TITLE
Change Ocaml version in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ To build xen-api from source, we recommend using [opam](https://opam.ocaml.org/d
     - Run that line, e.g.:
 
         ```bash
-        export OCAML_VERSION_FULL="4.14.1"
+        export OCAML_VERSION_FULL="4.14.2"
         ```
 
 4) Setup opam with your environment (i.e. switch).


### PR DESCRIPTION
Change Ocaml version of the example in readme to `4.14.2` as the same as the version in `xs-opam-ci.env`.