### PR TITLE
doc: xapi storage layer doc update

### DIFF
--- a/doc/content/xapi/storage/_index.md
+++ b/doc/content/xapi/storage/_index.md
@@ -20,14 +20,14 @@ Xapi directly communicates only with the SMAPIv2 layer. There are no
 plugins directly implementing the SMAPIv2 interface, but the plugins in
 other layers are accessed through it:
 
-{{<mermaid>}}
+```mermaid
 graph TD
 A[xapi] --> B[SMAPIv2 interface]
 B --> C[SMAPIv2 <-> SMAPIv1 translation: storage_access.ml]
 B --> D[SMAPIv2 <-> SMAPIv3 translation: xapi-storage-script]
 C --> E[SMAPIv1 plugins]
 D --> F[SMAPIv3 plugins]
-{{< /mermaid >}}
+```
 
 ## SMAPIv1
 
@@ -118,7 +118,7 @@ translation.
 
 #### Registration of the various storage servers
 
-{{<mermaid>}}
+```mermaid
 sequenceDiagram
 participant q as message-switch
 participant v1 as Storage_access.SMAPIv1
@@ -134,11 +134,11 @@ q ->> svr:org.xen.xapi.storage
 
 Note over q, svr: SR.create, PBD.plug
 svr ->> q:org.xapi.storage.sr_type_2
-{{< /mermaid >}}
+```
 
 #### What happens when a SMAPIv2 "function" is called
 
-{{<mermaid>}}
+```mermaid
 graph TD
 
 call[SMAPIv2 call] --VDI.attach2--> org.xen.xapi.storage
@@ -164,8 +164,8 @@ subgraph SMAPIv1
 driver_x[SMAPIv1 driver for SR_type_x]
 end
 
-Storage_access.SMAPIv1 --vdi_attach--> driver_x
-{{< /mermaid >}}
+Storage_smapiv1.SMAPIv1 --vdi_attach--> driver_x
+```
 
 ### Interface Changes, Backward Compatibility, & SXM
 
@@ -282,7 +282,7 @@ expected.` `
 
 #### Registration of the various SMAPIv3 plugins
 
-{{<mermaid>}}
+```mermaid
 sequenceDiagram
 participant q as message-switch
 participant v1 as (Storage_access.SMAPIv1)
@@ -306,11 +306,11 @@ q ->> svr:org.xen.xapi.storage
 
 Note over q, svr: SR.create, PBD.plug
 svr ->> q:org.xapi.storage.sr_type_4
-{{< /mermaid >}}
+```
 
 #### What happens when a SMAPIv3 "function" is called
 
-{{<mermaid>}}
+```mermaid
 graph TD
 
 call[SMAPIv2 call] --VDI.attach2--> org.xen.xapi.storage
@@ -348,7 +348,7 @@ end
 end
 
 org.xen.xapi.storage.SR_type_x --VDI.attach2-->xapi-storage-script
-{{< /mermaid >}}
+```
 
 ## Error reporting
 

--- a/doc/content/xapi/storage/_index.md
+++ b/doc/content/xapi/storage/_index.md
@@ -3,18 +3,12 @@ title = "XAPI's Storage Layers"
 linkTitle = "Storage"
 +++
 
+
 {{% notice info %}}
 The links in this page point to the source files of xapi
-[v1.127.0](https://github.com/xapi-project/xen-api/tree/v1.127.0), and xcp-idl
-[v1.62.0](https://github.com/xapi-project/xcp-idl/tree/v1.62.0), not to the
-latest source code.
-
-In the beginning of 2023, significant changes have been made in the layering.
-In particular, the wrapper code from `storage_impl.ml` has been pushed down the
-stack, below the mux, such that it only covers the SMAPIv1 backend and not
-SMAPIv3. Also, all of the code (from xcp-idl etc) is now present in this repo
-(xen-api).
+[v25.11.0](https://github.com/xapi-project/xen-api/tree/v25.11.0).
 {{% /notice %}}
+
 
 Xapi directly communicates only with the SMAPIv2 layer. There are no
 plugins directly implementing the SMAPIv2 interface, but the plugins in


### PR DESCRIPTION
The storage layer code in xapi has undergone some changes: storage_impl.ml is no longer in the repo and is replaced by `storage_smapiv1_wrapper.ml` and `storage_smapiv1.ml`. Update the relevant docs to reflect this change.
