### PR TITLE
Revert "CA-403851 stop management server in Pool.eject ()"

### DIFF
--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2074,8 +2074,6 @@ let eject_self ~__context ~host =
           )
       )
       (fun () -> Xapi_fuse.light_fuse_and_reboot_after_eject ()) ;
-    debug "%s: stop management server" __FUNCTION__ ;
-    Xapi_mgmt_iface.run ~__context ~mgmt_enabled:false () ;
     Xapi_hooks.pool_eject_hook ~__context
 
 (** eject [host] from the pool. This code is run on all hosts in the


### PR DESCRIPTION
This reverts commit 9b1b8d4dc9e27dc58ef6f21b3526b31dc1f6405f.