### PR TITLE
CP-53827, xenopsd: claim pages for domain on pre_build phase

### DIFF
--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -671,6 +671,27 @@ CAMLprim value stub_xenforeignmemory_unmap(value fmem, value mapping)
         CAMLreturn(Val_unit);
 }
 
+CAMLprim value stub_xenctrlext_domain_claim_pages(value xch_val, value domid_val,
+        value nr_pages_val)
+{
+        CAMLparam3(xch_val, domid_val, nr_pages_val);
+        int retval, the_errno;
+        xc_interface* xch = xch_of_val(xch_val);
+        uint32_t domid = Int_val(domid_val);
+        unsigned long nr_pages = Int_val(nr_pages_val);
+
+        caml_release_runtime_system();
+        retval = xc_domain_claim_pages(xch, domid, nr_pages);
+        the_errno = errno;
+        caml_acquire_runtime_system();
+
+        if(retval < 0) {
+                raise_unix_errno_msg(the_errno,
+                        "Error when trying to claim memory pages");
+        }
+        CAMLreturn(Val_unit);
+}
+
 /*
 * Local variables:
 * indent-tabs-mode: t

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -886,15 +886,18 @@ let numa_placement domid ~vcpus ~memory =
         Softaffinity.plan ~vm host nodea
     )
   in
-  match hint with
+  let xcext = get_handle () in
+  ( match hint with
   | None ->
       D.debug "NUMA-aware placement failed for domid %d" domid
   | Some soft_affinity ->
       let cpua = CPUSet.to_mask soft_affinity in
-      let xcext = get_handle () in
       for i = 0 to vcpus - 1 do
         Xenctrlext.vcpu_setaffinity_soft xcext domid i cpua
       done
+  ) ;
+  let nr_pages = Int64.div memory 4096L |> Int64.to_int in
+  Xenctrlext.domain_claim_pages xcext domid nr_pages
 
 let build_pre ~xc ~xs ~vcpus ~memory ~has_hard_affinity domid =
   let open Memory in

--- a/ocaml/xenopsd/xc/xenctrlext.ml
+++ b/ocaml/xenopsd/xc/xenctrlext.ml
@@ -108,3 +108,6 @@ external combine_cpu_policies : int64 array -> int64 array -> int64 array
 
 external policy_is_compatible : int64 array -> int64 array -> string option
   = "stub_xenctrlext_featuresets_are_compatible"
+
+external domain_claim_pages : handle -> domid -> int -> unit
+  = "stub_xenctrlext_domain_claim_pages"

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -90,3 +90,6 @@ external combine_cpu_policies : int64 array -> int64 array -> int64 array
 
 external policy_is_compatible : int64 array -> int64 array -> string option
   = "stub_xenctrlext_featuresets_are_compatible"
+
+external domain_claim_pages : handle -> domid -> int -> unit
+  = "stub_xenctrlext_domain_claim_pages"


### PR DESCRIPTION
This way xen can track the memory intended to be used for each domain and fail
early, if necessary.

This is done on numa_placement because the code is intended to change and do
per-numa-node memory claims in the near future.

Testing is in progress