### PR TITLE
Add opam local switch in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _coverage/
 *.install
 *.swp
 compile_flags.txt
+_opam
 
 # tests
 xapi-db.xml


### PR DESCRIPTION
When using an opam local switch, ignoring the _opam directory prevents git from searching within it, reducing noise in search results.