### PR TITLE
CA-408339: Respect xenopsd's NUMA-placement-policy default

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -206,9 +206,9 @@ let prototyped_of_message = function
   | "VTPM", "create" ->
       Some "22.26.0"
   | "host", "disable_ssh" ->
-      Some "25.12.0-next"
+      Some "25.13.0"
   | "host", "enable_ssh" ->
-      Some "25.12.0-next"
+      Some "25.13.0"
   | "host", "emergency_clear_mandatory_guidance" ->
       Some "24.10.0"
   | "host", "apply_recommended_guidances" ->
@@ -228,9 +228,9 @@ let prototyped_of_message = function
   | "VM", "set_groups" ->
       Some "24.19.1"
   | "pool", "disable_ssh" ->
-      Some "25.12.0-next"
+      Some "25.13.0"
   | "pool", "enable_ssh" ->
-      Some "25.12.0-next"
+      Some "25.13.0"
   | "pool", "get_guest_secureboot_readiness" ->
       Some "24.17.0"
   | "pool", "set_ext_auth_cache_expiry" ->

--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -501,6 +501,8 @@ module Host = struct
         (** best effort placement on the smallest number of NUMA nodes where possible *)
   [@@deriving rpcty]
 
+  type numa_affinity_policy_opt = numa_affinity_policy option [@@deriving rpcty]
+
   type guest_agent_feature_list = guest_agent_feature list [@@deriving rpcty]
 end
 
@@ -657,7 +659,7 @@ module XenopsAPI (R : RPC) = struct
       let numa_affinity_policy_p =
         Param.mk
           ~description:["Host NUMA affinity policy"]
-          ~name:"numa_affinity_policy" Host.numa_affinity_policy
+          ~name:"numa_affinity_policy" Host.numa_affinity_policy_opt
       in
       declare "HOST.set_numa_affinity_policy"
         ["Sets the host's NUMA aware VM scheduling policy"]

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -3098,11 +3098,11 @@ let set_numa_affinity_policy ~__context ~value =
     let open Xenops_interface.Host in
     match value with
     | `any ->
-        Any
+        Some Any
     | `best_effort ->
-        Best_effort
+        Some Best_effort
     | `default_policy ->
-        Any
+        None
   in
   Client.HOST.set_numa_affinity_policy dbg value
 

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -3398,7 +3398,12 @@ module VIF = struct
       ()
 end
 
+let default_numa_affinity_policy = ref Xenops_interface.Host.Any
+
 let numa_placement = ref Xenops_interface.Host.Any
+
+let string_of_numa_affinity_policy =
+  Xenops_interface.Host.(function Any -> "any" | Best_effort -> "best-effort")
 
 module HOST = struct
   let stat _ dbg =
@@ -3413,7 +3418,15 @@ module HOST = struct
   let set_numa_affinity_policy _ dbg =
     Debug.with_thread_associated dbg @@ fun policy ->
     debug "HOST.set_numa_affinity_policy" ;
-    numa_placement := policy
+    match policy with
+    | None ->
+        info "Enforcing default NUMA affinity policy (%s)"
+          (string_of_numa_affinity_policy !default_numa_affinity_policy) ;
+        numa_placement := !default_numa_affinity_policy
+    | Some p ->
+        info "Enforcing '%s' NUMA affinity policy"
+          (string_of_numa_affinity_policy p) ;
+        numa_placement := p
 
   let get_console_data _ dbg =
     Debug.with_thread_associated dbg

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -5148,8 +5148,11 @@ let init () =
         {Xs_protocol.ACL.owner= 0; other= Xs_protocol.ACL.READ; acl= []}
   ) ;
   Device.Backend.init () ;
-  Xenops_server.numa_placement :=
+  Xenops_server.default_numa_affinity_policy :=
     if !Xenopsd.numa_placement_compat then Best_effort else Any ;
+  info "Default NUMA affinity policy is '%s'"
+    Xenops_server.(string_of_numa_affinity_policy !default_numa_affinity_policy) ;
+  Xenops_server.numa_placement := !Xenops_server.default_numa_affinity_policy ;
   Domain.numa_init () ;
   debug "xenstore is responding to requests" ;
   let () = Watcher.create_watcher_thread () in


### PR DESCRIPTION
Xenopsd has an experimental feature that aims to optimise NUMA
placement. This used to be configured by adding `numa-placement=true` to
the file /etc/xenopsd.conf, which tells xenopsd to enable the feature.

Later, an actual API was added to configure this:
`host.set_numa_affinity_policy`. The expectation was that, while this
new API should be preferred, the old xenopsd.conf option would still
work for backwards compatibility reasons. This is particularly important
for hosts that are upgraded to the new version.

Unfortunately, while code exists in xenopsd to read and use the config
option when it starts up, when xapi starts up immediately after xenopsd,
it always overrides the NUMA config based its own DB field. The field
type actually has a "default" option, but this gets translated to "any"
(= no NUMA). By default, this means means that the experimental feature
is disabled, no matter what the config file says, and can only be
enabled through the API.

The fix is for xapi to not assign a default value itself, but let
xenopsd decide on the default policy. And xenopsd uses its config file
to do so, as before.