### PR TITLE
CP-53658: Claim memory on a single NUMA node

### DIFF
--- a/ocaml/xapi-client/event_helper.ml
+++ b/ocaml/xapi-client/event_helper.ml
@@ -43,96 +43,132 @@ type event_record =
   | VMPP of [`VMPP] Ref.t * API.vMPP_t option
   | VMSS of [`VMSS] Ref.t * API.vMSS_t option
 
-let maybe f x = match x with Some x -> Some (f x) | None -> None
-
 let record_of_event ev =
   let rpc = ev.Event_types.snapshot in
   match ev.Event_types.ty with
   | "session" ->
       Session
         ( Ref.of_secret_string ev.Event_types.reference
-        , maybe API.session_t_of_rpc rpc
+        , Option.map API.session_t_of_rpc rpc
         )
   | "task" ->
-      Task (Ref.of_string ev.Event_types.reference, maybe API.task_t_of_rpc rpc)
+      Task
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.task_t_of_rpc rpc
+        )
   | "event" ->
       Event
-        (Ref.of_string ev.Event_types.reference, maybe API.event_t_of_rpc rpc)
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.event_t_of_rpc rpc
+        )
   | "vm" ->
-      VM (Ref.of_string ev.Event_types.reference, maybe API.vM_t_of_rpc rpc)
+      VM (Ref.of_string ev.Event_types.reference, Option.map API.vM_t_of_rpc rpc)
   | "vm_metrics" ->
       VM_metrics
         ( Ref.of_string ev.Event_types.reference
-        , maybe API.vM_metrics_t_of_rpc rpc
+        , Option.map API.vM_metrics_t_of_rpc rpc
         )
   | "vm_guest_metrics" ->
       VM_guest_metrics
         ( Ref.of_string ev.Event_types.reference
-        , maybe API.vM_guest_metrics_t_of_rpc rpc
+        , Option.map API.vM_guest_metrics_t_of_rpc rpc
         )
   | "host" ->
-      Host (Ref.of_string ev.Event_types.reference, maybe API.host_t_of_rpc rpc)
+      Host
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.host_t_of_rpc rpc
+        )
   | "host_metrics" ->
       Host_metrics
         ( Ref.of_string ev.Event_types.reference
-        , maybe API.host_metrics_t_of_rpc rpc
+        , Option.map API.host_metrics_t_of_rpc rpc
         )
   | "host_cpu" ->
       Host_cpu
-        (Ref.of_string ev.Event_types.reference, maybe API.host_cpu_t_of_rpc rpc)
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.host_cpu_t_of_rpc rpc
+        )
   | "network" ->
       Network
-        (Ref.of_string ev.Event_types.reference, maybe API.network_t_of_rpc rpc)
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.network_t_of_rpc rpc
+        )
   | "vif" ->
-      VIF (Ref.of_string ev.Event_types.reference, maybe API.vIF_t_of_rpc rpc)
+      VIF
+        (Ref.of_string ev.Event_types.reference, Option.map API.vIF_t_of_rpc rpc)
   | "vif_metrics" ->
       VIF_metrics
         ( Ref.of_string ev.Event_types.reference
-        , maybe API.vIF_metrics_t_of_rpc rpc
+        , Option.map API.vIF_metrics_t_of_rpc rpc
         )
   | "pif" ->
-      PIF (Ref.of_string ev.Event_types.reference, maybe API.pIF_t_of_rpc rpc)
+      PIF
+        (Ref.of_string ev.Event_types.reference, Option.map API.pIF_t_of_rpc rpc)
   | "pif_metrics" ->
       PIF_metrics
         ( Ref.of_string ev.Event_types.reference
-        , maybe API.pIF_metrics_t_of_rpc rpc
+        , Option.map API.pIF_metrics_t_of_rpc rpc
         )
   | "sr" ->
-      SR (Ref.of_string ev.Event_types.reference, maybe API.sR_t_of_rpc rpc)
+      SR (Ref.of_string ev.Event_types.reference, Option.map API.sR_t_of_rpc rpc)
   | "vdi" ->
-      VDI (Ref.of_string ev.Event_types.reference, maybe API.vDI_t_of_rpc rpc)
+      VDI
+        (Ref.of_string ev.Event_types.reference, Option.map API.vDI_t_of_rpc rpc)
   | "vbd" ->
-      VBD (Ref.of_string ev.Event_types.reference, maybe API.vBD_t_of_rpc rpc)
+      VBD
+        (Ref.of_string ev.Event_types.reference, Option.map API.vBD_t_of_rpc rpc)
   | "vbd_metrics" ->
       VBD_metrics
         ( Ref.of_string ev.Event_types.reference
-        , maybe API.vBD_metrics_t_of_rpc rpc
+        , Option.map API.vBD_metrics_t_of_rpc rpc
         )
   | "pbd" ->
-      PBD (Ref.of_string ev.Event_types.reference, maybe API.pBD_t_of_rpc rpc)
+      PBD
+        (Ref.of_string ev.Event_types.reference, Option.map API.pBD_t_of_rpc rpc)
   | "crashdump" ->
       Crashdump
         ( Ref.of_string ev.Event_types.reference
-        , maybe API.crashdump_t_of_rpc rpc
+        , Option.map API.crashdump_t_of_rpc rpc
         )
   | "vtpm" ->
-      VTPM (Ref.of_string ev.Event_types.reference, maybe API.vTPM_t_of_rpc rpc)
+      VTPM
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.vTPM_t_of_rpc rpc
+        )
   | "console" ->
       Console
-        (Ref.of_string ev.Event_types.reference, maybe API.console_t_of_rpc rpc)
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.console_t_of_rpc rpc
+        )
   | "user" ->
-      User (Ref.of_string ev.Event_types.reference, maybe API.user_t_of_rpc rpc)
+      User
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.user_t_of_rpc rpc
+        )
   | "pool" ->
-      Pool (Ref.of_string ev.Event_types.reference, maybe API.pool_t_of_rpc rpc)
+      Pool
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.pool_t_of_rpc rpc
+        )
   | "message" ->
       Message
-        (Ref.of_string ev.Event_types.reference, maybe API.message_t_of_rpc rpc)
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.message_t_of_rpc rpc
+        )
   | "secret" ->
       Secret
-        (Ref.of_string ev.Event_types.reference, maybe API.secret_t_of_rpc rpc)
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.secret_t_of_rpc rpc
+        )
   | "vmpp" ->
-      VMPP (Ref.of_string ev.Event_types.reference, maybe API.vMPP_t_of_rpc rpc)
+      VMPP
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.vMPP_t_of_rpc rpc
+        )
   | "vmss" ->
-      VMSS (Ref.of_string ev.Event_types.reference, maybe API.vMSS_t_of_rpc rpc)
+      VMSS
+        ( Ref.of_string ev.Event_types.reference
+        , Option.map API.vMSS_t_of_rpc rpc
+        )
   | _ ->
       failwith "unknown event type"

--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -678,11 +678,11 @@ CAMLprim value stub_xenctrlext_domain_claim_pages(value xch_val, value domid_val
         int retval, the_errno;
         xc_interface* xch = xch_of_val(xch_val);
         uint32_t domid = Int_val(domid_val);
-        unsigned int numa_node = Int_val(numa_node_val);
+        // unsigned int numa_node = Int_val(numa_node_val);
         unsigned long nr_pages = Long_val(nr_pages_val);
 
         caml_release_runtime_system();
-        retval = xc_domain_claim_pages(xch, domid, numa_node, nr_pages);
+        retval = xc_domain_claim_pages(xch, domid, /*numa_node,*/ nr_pages);
         the_errno = errno;
         caml_acquire_runtime_system();
 

--- a/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
+++ b/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c
@@ -672,16 +672,17 @@ CAMLprim value stub_xenforeignmemory_unmap(value fmem, value mapping)
 }
 
 CAMLprim value stub_xenctrlext_domain_claim_pages(value xch_val, value domid_val,
-        value nr_pages_val)
+        value numa_node_val, value nr_pages_val)
 {
-        CAMLparam3(xch_val, domid_val, nr_pages_val);
+        CAMLparam4(xch_val, domid_val, numa_node_val, nr_pages_val);
         int retval, the_errno;
         xc_interface* xch = xch_of_val(xch_val);
         uint32_t domid = Int_val(domid_val);
+        unsigned int numa_node = Int_val(numa_node_val);
         unsigned long nr_pages = Long_val(nr_pages_val);
 
         caml_release_runtime_system();
-        retval = xc_domain_claim_pages(xch, domid, nr_pages);
+        retval = xc_domain_claim_pages(xch, domid, numa_node, nr_pages);
         the_errno = errno;
         caml_acquire_runtime_system();
 

--- a/ocaml/xenopsd/lib/softaffinity.mli
+++ b/ocaml/xenopsd/lib/softaffinity.mli
@@ -14,7 +14,11 @@
 
 open Topology
 
-val plan : NUMA.t -> NUMAResource.t array -> vm:NUMARequest.t -> CPUSet.t option
+val plan :
+     NUMA.t
+  -> NUMAResource.t array
+  -> vm:NUMARequest.t
+  -> (Topology.CPUSet.t * Topology.NUMA.node list) option
 (** [plan host nodes ~vm] returns the CPU soft affinity recommended for [vm],
     Such that the memory latency between the NUMA nodes of the vCPUs is small,
     and usage of NUMA nodes is balanced.

--- a/ocaml/xenopsd/lib/topology.ml
+++ b/ocaml/xenopsd/lib/topology.ml
@@ -298,7 +298,7 @@ module NUMA = struct
       None
     else (
       List.iter (fun (Node n) -> t.node_usage.(n) <- t.node_usage.(n) + 1) nodes ;
-      Some result
+      Some (result, nodes)
     )
 
   let pp_dump_node = Fmt.(using (fun (Node x) -> x) int)

--- a/ocaml/xenopsd/lib/topology.mli
+++ b/ocaml/xenopsd/lib/topology.mli
@@ -150,7 +150,10 @@ module NUMA : sig
       NUMA nodes > 16 it limits the length of the sequence to [n+65520], to
       avoid exponential blowup. *)
 
-  val choose : t -> (node list * NUMAResource.t) Seq.t -> NUMAResource.t option
+  val choose :
+       t
+    -> (node list * NUMAResource.t) Seq.t
+    -> (NUMAResource.t * node list) option
   (** [choose t resources] will choose one NUMA node deterministically, trying
       to keep the overall NUMA node usage balanced *)
 

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -204,8 +204,6 @@ let assert_file_is_readable filename =
     error "Cannot read file %s" filename ;
     raise (Could_not_read_file filename)
 
-let maybe f = function None -> () | Some x -> f x
-
 (* Recursively iterate over a directory and all its children, calling fn for
    each *)
 let rec xenstore_iter t fn path =
@@ -931,7 +929,7 @@ let build_pre ~xc ~xs ~vcpus ~memory ~has_hard_affinity domid =
       error "VM = %s; domid = %d; %s" (Uuidx.to_string uuid) domid err_msg ;
       raise (Domain_build_pre_failed err_msg)
   in
-  maybe
+  Option.iter
     (fun mode ->
       log_reraise (Printf.sprintf "domain_set_timer_mode %d" mode) (fun () ->
           let xcext = Xenctrlext.get_handle () in
@@ -1163,7 +1161,7 @@ let build (task : Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid
           Memory.Linux.full_config static_max_mib video_mib target_mib vcpus
             shadow_multiplier
         in
-        maybe assert_file_is_readable pvinfo.ramdisk ;
+        Option.iter assert_file_is_readable pvinfo.ramdisk ;
         let store_port, console_port =
           build_pre ~xc ~xs ~memory ~vcpus ~has_hard_affinity domid
         in

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -919,7 +919,7 @@ let build_pre ~xc ~xs ~vcpus ~memory ~has_hard_affinity domid =
   let timer_mode = int_platform_flag "timer_mode" in
   let log_reraise call_str f =
     debug "VM = %s; domid = %d; %s" (Uuidx.to_string uuid) domid call_str ;
-    try ignore (f ())
+    try f ()
     with e ->
       let bt = Printexc.get_backtrace () in
       debug "Backtrace: %s" bt ;

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -880,7 +880,7 @@ let numa_placement domid ~vcpus ~memory =
             Array.map2 NUMAResource.min_memory (Array.of_list nodes) a
       in
       numa_resources := Some nodea ;
-      let memory_plan =
+      let _ =
         match Softaffinity.plan ~vm host nodea with
         | None ->
             D.debug "NUMA-aware placement failed for domid %d" domid ;
@@ -892,29 +892,10 @@ let numa_placement domid ~vcpus ~memory =
             done ;
             mem_plan
       in
-      (* Xen only allows a single node when using memory claims, or none at all. *)
-      let* numa_node, node =
-        match memory_plan with
-        | [Node node] ->
-            Some (Xenctrlext.NumaNode.from node, node)
-        | [] | _ :: _ :: _ ->
-            D.debug
-              "%s: domain %d can't fit a single NUMA node, falling back to \
-               default behaviour"
-              __FUNCTION__ domid ;
-            None
-      in
-      let nr_pages = Int64.div memory 4096L |> Int64.to_int in
-      try
-        Xenctrlext.domain_claim_pages xcext domid ~numa_node nr_pages ;
-        Some (node, memory)
-      with Xenctrlext.Unix_error (errno, _) ->
-        D.info
-          "%s: unable to claim enough memory, domain %d won't be hosted in a \
-           single NUMA node. (error %s)"
-          __FUNCTION__ domid
-          Unix.(error_message errno) ;
-        None
+      (* Neither xenguest nor emu-manager allow allocating pages to a single
+         NUMA node, don't return any NUMA in any case. Claiming the memory
+         would be done here, but it conflicts with DMC. *)
+      None
   )
 
 let build_pre ~xc ~xs ~vcpus ~memory ~has_hard_affinity domid =

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -860,42 +860,62 @@ let numa_init () =
 let numa_placement domid ~vcpus ~memory =
   let open Xenctrlext in
   let open Topology in
-  let hint =
-    with_lock numa_mutex (fun () ->
-        let ( let* ) = Option.bind in
-        let xcext = get_handle () in
-        let* host = Lazy.force numa_hierarchy in
-        let numa_meminfo = (numainfo xcext).memory |> Array.to_list in
-        let nodes =
-          ListLabels.map2
-            (NUMA.nodes host |> List.of_seq)
-            numa_meminfo
-            ~f:(fun node m -> NUMA.resource host node ~memory:m.memfree)
-        in
-        let vm = NUMARequest.make ~memory ~vcpus in
-        let nodea =
-          match !numa_resources with
-          | None ->
-              Array.of_list nodes
-          | Some a ->
-              Array.map2 NUMAResource.min_memory (Array.of_list nodes) a
-        in
-        numa_resources := Some nodea ;
-        Softaffinity.plan ~vm host nodea
-    )
-  in
-  let xcext = get_handle () in
-  ( match hint with
-  | None ->
-      D.debug "NUMA-aware placement failed for domid %d" domid
-  | Some soft_affinity ->
-      let cpua = CPUSet.to_mask soft_affinity in
-      for i = 0 to vcpus - 1 do
-        Xenctrlext.vcpu_setaffinity_soft xcext domid i cpua
-      done
-  ) ;
-  let nr_pages = Int64.div memory 4096L |> Int64.to_int in
-  Xenctrlext.domain_claim_pages xcext domid nr_pages
+  with_lock numa_mutex (fun () ->
+      let ( let* ) = Option.bind in
+      let xcext = get_handle () in
+      let* host = Lazy.force numa_hierarchy in
+      let numa_meminfo = (numainfo xcext).memory |> Array.to_list in
+      let nodes =
+        ListLabels.map2
+          (NUMA.nodes host |> List.of_seq)
+          numa_meminfo
+          ~f:(fun node m -> NUMA.resource host node ~memory:m.memfree)
+      in
+      let vm = NUMARequest.make ~memory ~vcpus in
+      let nodea =
+        match !numa_resources with
+        | None ->
+            Array.of_list nodes
+        | Some a ->
+            Array.map2 NUMAResource.min_memory (Array.of_list nodes) a
+      in
+      numa_resources := Some nodea ;
+      let memory_plan =
+        match Softaffinity.plan ~vm host nodea with
+        | None ->
+            D.debug "NUMA-aware placement failed for domid %d" domid ;
+            []
+        | Some (cpu_affinity, mem_plan) ->
+            let cpus = CPUSet.to_mask cpu_affinity in
+            for i = 0 to vcpus - 1 do
+              Xenctrlext.vcpu_setaffinity_soft xcext domid i cpus
+            done ;
+            mem_plan
+      in
+      (* Xen only allows a single node when using memory claims, or none at all. *)
+      let* numa_node, node =
+        match memory_plan with
+        | [Node node] ->
+            Some (Xenctrlext.NumaNode.from node, node)
+        | [] | _ :: _ :: _ ->
+            D.debug
+              "%s: domain %d can't fit a single NUMA node, falling back to \
+               default behaviour"
+              __FUNCTION__ domid ;
+            None
+      in
+      let nr_pages = Int64.div memory 4096L |> Int64.to_int in
+      try
+        Xenctrlext.domain_claim_pages xcext domid ~numa_node nr_pages ;
+        Some (node, memory)
+      with Xenctrlext.Unix_error (errno, _) ->
+        D.info
+          "%s: unable to claim enough memory, domain %d won't be hosted in a \
+           single NUMA node. (error %s)"
+          __FUNCTION__ domid
+          Unix.(error_message errno) ;
+        None
+  )
 
 let build_pre ~xc ~xs ~vcpus ~memory ~has_hard_affinity domid =
   let open Memory in
@@ -949,42 +969,54 @@ let build_pre ~xc ~xs ~vcpus ~memory ~has_hard_affinity domid =
   log_reraise (Printf.sprintf "shadow_allocation_set %d MiB" shadow_mib)
     (fun () -> Xenctrl.shadow_allocation_set xc domid shadow_mib
   ) ;
-  let () =
+  let node_placement =
     match !Xenops_server.numa_placement with
     | Any ->
-        ()
+        None
     | Best_effort ->
         log_reraise (Printf.sprintf "NUMA placement") (fun () ->
-            if has_hard_affinity then
-              D.debug "VM has hard affinity set, skipping NUMA optimization"
-            else
+            if has_hard_affinity then (
+              D.debug "VM has hard affinity set, skipping NUMA optimization" ;
+              None
+            ) else
               numa_placement domid ~vcpus
                 ~memory:(Int64.mul memory.xen_max_mib 1048576L)
+              |> Option.map fst
         )
   in
-  create_channels ~xc uuid domid
+  let store_chan, console_chan = create_channels ~xc uuid domid in
+  (store_chan, console_chan, node_placement)
+
+let args_numa_placements numa_placement =
+  Option.fold ~none:[]
+    ~some:(fun node -> ["-mem_pnode"; Printf.sprintf "%d" node])
+    numa_placement
 
 let xenguest_args_base ~domid ~store_port ~store_domid ~console_port
-    ~console_domid ~memory =
+    ~console_domid ~memory ~numa_placement =
   [
-    "-domid"
-  ; string_of_int domid
-  ; "-store_port"
-  ; string_of_int store_port
-  ; "-store_domid"
-  ; string_of_int store_domid
-  ; "-console_port"
-  ; string_of_int console_port
-  ; "-console_domid"
-  ; string_of_int console_domid
-  ; "-mem_max_mib"
-  ; Int64.to_string memory.Memory.build_max_mib
-  ; "-mem_start_mib"
-  ; Int64.to_string memory.Memory.build_start_mib
+    [
+      "-domid"
+    ; string_of_int domid
+    ; "-store_port"
+    ; string_of_int store_port
+    ; "-store_domid"
+    ; string_of_int store_domid
+    ; "-console_port"
+    ; string_of_int console_port
+    ; "-console_domid"
+    ; string_of_int console_domid
+    ; "-mem_max_mib"
+    ; Int64.to_string memory.Memory.build_max_mib
+    ; "-mem_start_mib"
+    ; Int64.to_string memory.Memory.build_start_mib
+    ]
+  ; args_numa_placements numa_placement
   ]
+  |> List.concat
 
 let xenguest_args_hvm ~domid ~store_port ~store_domid ~console_port
-    ~console_domid ~memory ~kernel ~vgpus =
+    ~console_domid ~memory ~kernel ~vgpus ~numa_placement =
   ["-mode"; "hvm_build"; "-image"; kernel]
   @ (vgpus |> function
      | Xenops_interface.Vgpu.{implementation= Nvidia _; _} :: _ ->
@@ -993,10 +1025,10 @@ let xenguest_args_hvm ~domid ~store_port ~store_domid ~console_port
          []
     )
   @ xenguest_args_base ~domid ~store_port ~store_domid ~console_port
-      ~console_domid ~memory
+      ~console_domid ~memory ~numa_placement
 
 let xenguest_args_pv ~domid ~store_port ~store_domid ~console_port
-    ~console_domid ~memory ~kernel ~cmdline ~ramdisk =
+    ~console_domid ~memory ~kernel ~cmdline ~ramdisk ~numa_placement =
   [
     "-mode"
   ; "linux_build"
@@ -1012,10 +1044,10 @@ let xenguest_args_pv ~domid ~store_port ~store_domid ~console_port
   ; "0"
   ]
   @ xenguest_args_base ~domid ~store_port ~store_domid ~console_port
-      ~console_domid ~memory
+      ~console_domid ~memory ~numa_placement
 
 let xenguest_args_pvh ~domid ~store_port ~store_domid ~console_port
-    ~console_domid ~memory ~kernel ~cmdline ~modules =
+    ~console_domid ~memory ~kernel ~cmdline ~modules ~numa_placement =
   let module_args =
     List.concat_map
       (fun (m, c) ->
@@ -1037,7 +1069,7 @@ let xenguest_args_pvh ~domid ~store_port ~store_domid ~console_port
   ]
   @ module_args
   @ xenguest_args_base ~domid ~store_port ~store_domid ~console_port
-      ~console_domid ~memory
+      ~console_domid ~memory ~numa_placement
 
 let xenguest task xenguest_path domid uuid args =
   let line =
@@ -1134,13 +1166,13 @@ let build (task : Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid
             shadow_multiplier
         in
         maybe_ca_140252_workaround ~xc ~vcpus domid ;
-        let store_port, console_port =
+        let store_port, console_port, numa_placement =
           build_pre ~xc ~xs ~memory ~vcpus ~has_hard_affinity domid
         in
         let store_mfn, console_mfn =
           let args =
             xenguest_args_hvm ~domid ~store_port ~store_domid ~console_port
-              ~console_domid ~memory ~kernel ~vgpus
+              ~console_domid ~memory ~kernel ~vgpus ~numa_placement
             @ force_arg
             @ extras
           in
@@ -1162,14 +1194,14 @@ let build (task : Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid
             shadow_multiplier
         in
         Option.iter assert_file_is_readable pvinfo.ramdisk ;
-        let store_port, console_port =
+        let store_port, console_port, numa_placement =
           build_pre ~xc ~xs ~memory ~vcpus ~has_hard_affinity domid
         in
         let store_mfn, console_mfn =
           let args =
             xenguest_args_pv ~domid ~store_port ~store_domid ~console_port
               ~console_domid ~memory ~kernel ~cmdline:pvinfo.cmdline
-              ~ramdisk:pvinfo.ramdisk
+              ~ramdisk:pvinfo.ramdisk ~numa_placement
             @ force_arg
             @ extras
           in
@@ -1185,13 +1217,13 @@ let build (task : Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid
             shadow_multiplier
         in
         maybe_ca_140252_workaround ~xc ~vcpus domid ;
-        let store_port, console_port =
+        let store_port, console_port, numa_placement =
           build_pre ~xc ~xs ~memory ~vcpus ~has_hard_affinity domid
         in
         let store_mfn, console_mfn =
           let args =
             xenguest_args_pvh ~domid ~store_port ~store_domid ~console_port
-              ~console_domid ~memory ~kernel ~cmdline ~modules
+              ~console_domid ~memory ~kernel ~cmdline ~modules ~numa_placement
             @ force_arg
             @ extras
           in
@@ -1221,8 +1253,8 @@ let dm_flags =
       []
 
 let with_emu_manager_restore (task : Xenops_task.task_handle) ~domain_type
-    ~(dm : Device.Profile.t) ~store_port ~console_port ~extras manager_path
-    domid _uuid main_fd vgpu_fd f =
+    ~(dm : Device.Profile.t) ~store_port ~console_port ~extras ~numa_placements
+    manager_path domid _uuid main_fd vgpu_fd f =
   let mode =
     match domain_type with `hvm | `pvh -> "hvm_restore" | `pv -> "restore"
   in
@@ -1240,20 +1272,24 @@ let with_emu_manager_restore (task : Xenops_task.task_handle) ~domain_type
   let fds = [(fd_uuid, main_fd)] @ vgpu_args in
   let args =
     [
-      "-mode"
-    ; mode
-    ; "-domid"
-    ; string_of_int domid
-    ; "-fd"
-    ; fd_uuid
-    ; "-store_port"
-    ; string_of_int store_port
-    ; "-console_port"
-    ; string_of_int console_port
+      [
+        "-mode"
+      ; mode
+      ; "-domid"
+      ; string_of_int domid
+      ; "-fd"
+      ; fd_uuid
+      ; "-store_port"
+      ; string_of_int store_port
+      ; "-console_port"
+      ; string_of_int console_port
+      ]
+    ; args_numa_placements numa_placements
+    ; dm_flags dm
+    ; extras
+    ; vgpu_cmdline
     ]
-    @ dm_flags dm
-    @ extras
-    @ vgpu_cmdline
+    |> List.concat
   in
   Emu_manager.with_connection task manager_path args fds f
 
@@ -1307,7 +1343,7 @@ let consume_qemu_record fd limit domid uuid =
 let restore_common (task : Xenops_task.task_handle) ~xc ~xs
     ~(dm : Device.Profile.t) ~domain_type ~store_port ~store_domid:_
     ~console_port ~console_domid:_ ~no_incr_generationid:_ ~vcpus:_ ~extras
-    ~vtpm manager_path domid main_fd vgpu_fd =
+    ~vtpm ~numa_placements manager_path domid main_fd vgpu_fd =
   let module DD = Debug.Make (struct let name = "mig64" end) in
   let open DD in
   let uuid = get_uuid ~xc domid in
@@ -1320,8 +1356,8 @@ let restore_common (task : Xenops_task.task_handle) ~xc ~xs
         match
           with_conversion_script task "Emu_manager" hvm main_fd (fun pipe_r ->
               with_emu_manager_restore task ~domain_type ~dm ~store_port
-                ~console_port ~extras manager_path domid uuid pipe_r vgpu_fd
-                (fun cnx -> restore_libxc_record cnx domid uuid
+                ~console_port ~extras ~numa_placements manager_path domid uuid
+                pipe_r vgpu_fd (fun cnx -> restore_libxc_record cnx domid uuid
               )
           )
         with
@@ -1360,7 +1396,8 @@ let restore_common (task : Xenops_task.task_handle) ~xc ~xs
             [main_fd]
       in
       with_emu_manager_restore task ~domain_type ~dm ~store_port ~console_port
-        ~extras manager_path domid uuid main_fd vgpu_fd (fun cnx ->
+        ~extras ~numa_placements manager_path domid uuid main_fd vgpu_fd
+        (fun cnx ->
           (* Maintain a list of results returned by emu-manager that are
              expected by the reader threads. Contains the emu for which a result
              is wanted plus an event channel for waking up the reader once the
@@ -1614,14 +1651,14 @@ let restore (task : Xenops_task.task_handle) ~xc ~xs ~dm ~store_domid
         maybe_ca_140252_workaround ~xc ~vcpus domid ;
         (memory, vm_stuff, `pvh)
   in
-  let store_port, console_port =
+  let store_port, console_port, numa_placements =
     build_pre ~xc ~xs ~memory ~vcpus ~has_hard_affinity:info.has_hard_affinity
       domid
   in
   let store_mfn, console_mfn =
     restore_common task ~xc ~xs ~dm ~domain_type ~store_port ~store_domid
       ~console_port ~console_domid ~no_incr_generationid ~vcpus ~extras ~vtpm
-      manager_path domid fd vgpu_fd
+      ~numa_placements manager_path domid fd vgpu_fd
   in
   let local_stuff = console_keys console_port console_mfn in
   (* And finish domain's building *)

--- a/ocaml/xenopsd/xc/dune
+++ b/ocaml/xenopsd/xc/dune
@@ -2,6 +2,7 @@
  (name xenopsd_xc)
  (modes best)
  (modules :standard \
+          numa
           xenops_xc_main
           memory_breakdown
           memory_summary
@@ -68,13 +69,18 @@
  )
  (wrapped false)
 )
+
+(executable
+ (name numa)
+ (modules numa)
+ (libraries fmt logs logs.fmt mtime mtime.clock threads.posix xenctrl xenopsd_xc)
+)
+
 (executable
  (name xenops_xc_main)
  (modes exe)
  (modules xenops_xc_main)
-
  (libraries
-  
   ezxenstore.core
   uuid
   xapi-idl
@@ -95,7 +101,7 @@
  (libraries
   astring
   cmdliner
-  
+
   ezxenstore.core
   uuid
   xapi-idl.memory
@@ -112,13 +118,13 @@
  (section sbin)
  (package xapi-tools)
 )
- 
+
 (executable
  (name memory_summary)
  (modes exe)
  (modules memory_summary)
  (libraries
-  
+
   clock
   xapi-stdext-unix
   xapi_xenopsd
@@ -143,7 +149,7 @@
  (modules cancel_utils_test)
  (libraries
   cmdliner
-  
+
   ezxenstore.core
   threads.posix
   xapi-idl.xen.interface

--- a/ocaml/xenopsd/xc/numa.ml
+++ b/ocaml/xenopsd/xc/numa.ml
@@ -1,0 +1,176 @@
+(* Copyright (C) 2025 Cloud Software Group
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation; version 2.1 only. with the special
+   exception on linking described in file LICENSE.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+*)
+
+(* Monitoring loop that keeps track of per-numa-node memory changes, and prints
+   the change. Useful to see whether memory scrubbing is seen as used or free
+   memory by userspace *)
+open! Xenctrlext
+
+let ( let@ ) f x = f x
+
+let stamp_tag : Mtime.span Logs.Tag.def =
+  Logs.Tag.def "stamp" ~doc:"Relative monotonic time stamp" Mtime.Span.pp
+
+let stamp c = Logs.Tag.(empty |> add stamp_tag (Mtime_clock.count c))
+
+let xc = get_handle ()
+
+let binary_prefixes = [""; "Ki"; "Mi"; "Gi"; "Ti"; "Pi"]
+
+let human_readable_bytes quantity =
+  let unit = "Bs" in
+  let print prefix q = Printf.sprintf "%Ld %s%s" q prefix unit in
+  let rec loop acc q = function
+    | [] ->
+        acc
+    | pre :: prefs ->
+        let quotient = Int64.div q 1024L in
+        let modulus = Int64.rem q 1024L in
+        let acc =
+          if Int64.equal modulus 0L then acc else print pre modulus :: acc
+        in
+        loop acc quotient prefs
+  in
+  if quantity = 0L then
+    print "" 0L
+  else
+    loop [] quantity binary_prefixes |> String.concat ", "
+
+let get_memory () =
+  let {memory; _} = numainfo xc in
+  memory
+
+let print_mem c mem =
+  for i = 0 to Array.length mem - 1 do
+    let {memfree; memsize} = mem.(i) in
+    let memfree = human_readable_bytes memfree in
+    let memsize = human_readable_bytes memsize in
+    Logs.app (fun m ->
+        m "\t%d: %s free out of %s" i memfree memsize ~tags:(stamp c)
+    )
+  done
+
+let print_diff_mem before after =
+  if before > after then
+    Printf.sprintf "%s 🢆 " (Int64.sub before after |> human_readable_bytes)
+  else
+    Printf.sprintf "%s 🢅 " (Int64.sub after before |> human_readable_bytes)
+
+let diff c old cur =
+  let changed_yet = ref false in
+  for i = 0 to Int.min (Array.length old) (Array.length cur) - 1 do
+    let {memfree= a_free; _}, {memfree= b_free; _} = (old.(i), cur.(i)) in
+    if a_free <> b_free then (
+      if not !changed_yet then
+        changed_yet := true ;
+      let free = human_readable_bytes b_free in
+      let updown = print_diff_mem a_free b_free in
+      Logs.app (fun m ->
+          m "\t%d: %s free (%s)" i free updown ~tags:(stamp (c ()))
+      )
+    )
+  done ;
+  !changed_yet
+
+let reporter ppf =
+  let report _src level ~over k msgf =
+    let k _ = over () ; k () in
+    let with_stamp h tags k ppf fmt =
+      let stamp =
+        match tags with
+        | None ->
+            None
+        | Some tags ->
+            Logs.Tag.find stamp_tag tags
+      in
+      let span_pp s =
+        match s with
+        | None ->
+            "0ns"
+        | Some s ->
+            Fmt.to_to_string Mtime.Span.pp s
+      in
+      Format.kfprintf k ppf
+        ("%a[%s] @[" ^^ fmt ^^ "@]@.")
+        Logs.pp_header (level, h) (span_pp stamp)
+    in
+    msgf @@ fun ?header ?tags fmt -> with_stamp header tags k ppf fmt
+  in
+  {Logs.report}
+
+let memory_changes () =
+  let max_time = Mtime.Span.(7 * s) in
+
+  let memory = get_memory () in
+  let c = Mtime_clock.counter () in
+  print_mem c memory ;
+  let rec loop since_started since_changed previous =
+    let current = get_memory () in
+
+    let since_started = ref since_started in
+    let timer () =
+      let last_changed = Mtime_clock.count since_changed in
+      if Mtime.Span.is_longer last_changed ~than:max_time then
+        since_started := Mtime_clock.counter () ;
+      !since_started
+    in
+
+    let changed = diff timer previous current in
+
+    let since_changed =
+      if changed then
+        Mtime_clock.counter ()
+      else
+        !since_started
+    in
+    Unix.sleepf 0.01 ;
+    loop !since_started since_changed current
+  in
+  loop c c memory
+
+module DomainSet = Set.Make (Int)
+
+let get_domains xc =
+  Xenctrl.domain_getinfolist xc 0
+  |> List.to_seq
+  |> Seq.map (function Xenctrl.{domid; _} -> domid)
+  |> DomainSet.of_seq
+
+let diff_domains c previous current =
+  let added = DomainSet.diff current previous in
+  let removed = DomainSet.diff previous current in
+  DomainSet.iter
+    (fun id -> Logs.app (fun m -> m "domain %d added" id ~tags:(stamp c)))
+    added ;
+  DomainSet.iter
+    (fun id -> Logs.app (fun m -> m "domain %d removed" id ~tags:(stamp c)))
+    removed
+
+let domain_changes xc =
+  let domains = get_domains xc in
+  let c = Mtime_clock.counter () in
+  let rec loop previous =
+    let current = get_domains xc in
+    diff_domains c previous current ;
+    Unix.sleepf 0.01 ;
+    loop current
+  in
+  loop domains
+
+let () =
+  Logs.set_reporter (reporter Format.std_formatter) ;
+  Logs.set_level (Some Logs.Info) ;
+
+  ignore (Thread.create memory_changes () : Thread.t) ;
+  let@ xc = Xenctrl.with_intf in
+  domain_changes xc

--- a/ocaml/xenopsd/xc/xenctrlext.ml
+++ b/ocaml/xenopsd/xc/xenctrlext.ml
@@ -109,5 +109,18 @@ external combine_cpu_policies : int64 array -> int64 array -> int64 array
 external policy_is_compatible : int64 array -> int64 array -> string option
   = "stub_xenctrlext_featuresets_are_compatible"
 
-external domain_claim_pages : handle -> domid -> int -> unit
+external stub_domain_claim_pages : handle -> domid -> int -> int -> unit
   = "stub_xenctrlext_domain_claim_pages"
+
+module NumaNode = struct
+  type t = int
+
+  (** Defined as XC_NUMA_NO_NODE in xen.git/tools/include/xenguest.h, it's an
+      unsigned int (~0U) *)
+  let none = 0xFFFFFFFF
+
+  let from = Fun.id
+end
+
+let domain_claim_pages handle domid ?(numa_node = NumaNode.none) nr_pages =
+  stub_domain_claim_pages handle domid numa_node nr_pages

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -100,3 +100,4 @@ module NumaNode : sig
 end
 
 val domain_claim_pages : handle -> domid -> ?numa_node:NumaNode.t -> int -> unit
+(** Raises {Unix_error} if there's not enough memory to claim in the system *)

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -91,5 +91,12 @@ external combine_cpu_policies : int64 array -> int64 array -> int64 array
 external policy_is_compatible : int64 array -> int64 array -> string option
   = "stub_xenctrlext_featuresets_are_compatible"
 
-external domain_claim_pages : handle -> domid -> int -> unit
-  = "stub_xenctrlext_domain_claim_pages"
+module NumaNode : sig
+  type t
+
+  val none : t
+
+  val from : int -> t
+end
+
+val domain_claim_pages : handle -> domid -> ?numa_node:NumaNode.t -> int -> unit


### PR DESCRIPTION
This PR allows xenopsd to launch domains that are using memory allocated in a single NUMA node in a reliable way. (when restarting a VM in a host with most of the memory in use)

Since this is only supported by Xen with this patchqueue: https://lists.xen.org/archives/html/xen-devel/2025-03/msg01127.html, and it needs support from xenguest and emu-manager, there are two commits that revert the changes to just claim memory pages without a NUMA memory node. These are easily revertable by patches to enable this functionality in cutting edge builds.

Revertable patches:
-  xenctrl: Don't use numa_node in domain_claim_pages calls
- xenopsd/xc: Do not try to allocate pages to a particular NUMA node 