### PR TITLE
CA-403851 disable API of ejected pool member

### DIFF
--- a/ocaml/xapi/xapi_fuse.ml
+++ b/ocaml/xapi/xapi_fuse.ml
@@ -86,6 +86,8 @@ let light_fuse_and_reboot_after_eject () =
   ignore
     (Thread.create
        (fun () ->
+         debug "%s: stop management server" __FUNCTION__ ;
+         Xapi_mgmt_iface.Server.stop () ;
          Thread.delay !Constants.fuse_time ;
          (* this activates firstboot script and reboots the host *)
          ignore

--- a/ocaml/xapi/xapi_mgmt_iface.ml
+++ b/ocaml/xapi/xapi_mgmt_iface.ml
@@ -36,6 +36,9 @@ module Server : sig
   val current_mode : unit -> listening_mode
 
   val is_ipv6_enabled : unit -> bool
+
+  val stop : unit -> unit
+  (** Stop server for external API calls *)
 end = struct
   (* Keep track of the management interface server thread.
      Stores a key into the table in Http_srv which identifies the server thread bound

--- a/ocaml/xapi/xapi_mgmt_iface.mli
+++ b/ocaml/xapi/xapi_mgmt_iface.mli
@@ -15,6 +15,11 @@
  *  @group Networking
 *)
 
+module Server : sig
+  val stop : unit -> unit
+  (** Stop server for external API calls *)
+end
+
 val himn_addr : unit -> string option
 (** Local IP address of the HIMN (if any) *)
 


### PR DESCRIPTION
When a pool member is ejected, for a (short) time it is still seen by XenCenter as a pool member because its role only changes after a reboot. To avoid it accepting API calls, disable the API server after the pool eject call has been processed. This happens in the call that initiates the reboot because the API call for the eject needs to finish first. We can't use a function there that requires the `__context` and thus use a lower-level primitive.

This might overall not be worth the effort to fix a mostly cosmetic problem, Passes the BST.