### PR TITLE
CP-54034: Expose `expected_votes` in Cluster object

### DIFF
--- a/ocaml/idl/datamodel_cluster.ml
+++ b/ocaml/idl/datamodel_cluster.ml
@@ -219,6 +219,9 @@ let t =
        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "live_hosts"
            ~default_value:(Some (VInt 0L))
            "Current number of live hosts, according to the cluster stack"
+       ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int "expected_hosts"
+           ~default_value:(Some (VInt 0L))
+           "Total number of hosts expected by the cluster stack"
        ]
       @ allowed_and_current_operations cluster_operation
       @ [

--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 788
+let schema_minor_vsn = 789
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -77,6 +77,8 @@ let prototyped_of_field = function
       Some "24.3.0"
   | "Cluster_host", "live" ->
       Some "24.3.0"
+  | "Cluster", "expected_hosts" ->
+      Some "25.16.0-next"
   | "Cluster", "live_hosts" ->
       Some "24.3.0"
   | "Cluster", "quorum" ->

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "0cf3458af211661024fca9c1d0ab34ab"
+let last_known_schema_hash = "2f80cd8fbfd0eedab4dfe345565bcb64"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -626,12 +626,13 @@ let make_cluster_and_cluster_host ~__context ?(ref = Ref.make ())
     ?(token_timeout = Constants.default_token_timeout_s)
     ?(token_timeout_coefficient = Constants.default_token_timeout_coefficient_s)
     ?(cluster_config = []) ?(other_config = []) ?(host = Ref.null)
-    ?(is_quorate = false) ?(quorum = 0L) ?(live_hosts = 0L) () =
+    ?(is_quorate = false) ?(quorum = 0L) ?(live_hosts = 0L)
+    ?(expected_hosts = 0L) () =
   Db.Cluster.create ~__context ~ref ~uuid ~cluster_token ~pending_forget:[]
     ~cluster_stack ~cluster_stack_version ~allowed_operations
     ~current_operations ~pool_auto_join ~token_timeout
     ~token_timeout_coefficient ~cluster_config ~other_config ~is_quorate ~quorum
-    ~live_hosts ;
+    ~live_hosts ~expected_hosts ;
   let cluster_host_ref =
     make_cluster_host ~__context ~cluster:ref ~host ~pIF ()
   in

--- a/ocaml/tests/test_cluster.ml
+++ b/ocaml/tests/test_cluster.ml
@@ -69,6 +69,7 @@ let test_clusterd_rpc ~__context call =
         ; num_times_booted= 1
         ; is_quorate= true
         ; total_votes= 1
+        ; expected_votes= 1
         ; quorum= 1
         ; quorum_members= Some [me]
         ; is_running= true

--- a/ocaml/tests/test_cluster_host.ml
+++ b/ocaml/tests/test_cluster_host.ml
@@ -24,7 +24,7 @@ let create_cluster ~__context pool_auto_join =
     ~token_timeout_coefficient:Constants.default_token_timeout_coefficient_s
     ~allowed_operations:[] ~current_operations:[] ~pool_auto_join
     ~cluster_config:[] ~other_config:[] ~pending_forget:[] ~is_quorate:false
-    ~quorum:0L ~live_hosts:0L ;
+    ~quorum:0L ~live_hosts:0L ~expected_hosts:0L ;
   cluster_ref
 
 let check_cluster_option =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -5132,6 +5132,9 @@ let cluster_record rpc session_id cluster =
       ; make_field ~name:"live-hosts"
           ~get:(fun () -> Int64.to_string (x ()).API.cluster_live_hosts)
           ()
+      ; make_field ~name:"expected-hosts"
+          ~get:(fun () -> Int64.to_string (x ()).API.cluster_expected_hosts)
+          ()
       ]
   }
 

--- a/ocaml/xapi-idl/cluster/cluster_interface.ml
+++ b/ocaml/xapi-idl/cluster/cluster_interface.ml
@@ -159,6 +159,9 @@ type optional_path = string option [@@deriving rpcty]
 type quorum_info = {
     is_quorate: bool
   ; total_votes: int
+        (* number of nodes that the cluster stack thinks are currently in the cluster *)
+  ; expected_votes: int
+        (* number of nodes that the cluster stack is expecting to be in the cluster *)
   ; quorum: int  (** number of nodes required to form a quorum *)
   ; quorum_members: all_members option
 }
@@ -179,6 +182,7 @@ type diagnostics = {
   ; is_quorate: bool
   ; is_running: bool
   ; total_votes: int
+  ; expected_votes: int
   ; quorum: int
   ; quorum_members: all_members option
   ; startup_finished: bool

--- a/ocaml/xapi/xapi_cluster.ml
+++ b/ocaml/xapi/xapi_cluster.ml
@@ -96,7 +96,7 @@ let create ~__context ~pIF ~cluster_stack ~pool_auto_join ~token_timeout
             ~pending_forget:[] ~pool_auto_join ~token_timeout
             ~token_timeout_coefficient ~current_operations:[]
             ~allowed_operations:[] ~cluster_config:[] ~other_config:[]
-            ~is_quorate:false ~quorum:0L ~live_hosts:0L ;
+            ~is_quorate:false ~quorum:0L ~live_hosts:0L ~expected_hosts:0L ;
           Db.Cluster_host.create ~__context ~ref:cluster_host_ref
             ~uuid:cluster_host_uuid ~cluster:cluster_ref ~host ~enabled:true
             ~pIF ~current_operations:[] ~allowed_operations:[] ~other_config:[]

--- a/ocaml/xapi/xapi_clustering.ml
+++ b/ocaml/xapi/xapi_clustering.ml
@@ -516,6 +516,8 @@ module Watcher = struct
         Db.Cluster.set_quorum ~__context ~self:cluster
           ~value:(Int64.of_int diag.quorum) ;
         Db.Cluster.set_live_hosts ~__context ~self:cluster
+          ~value:(Int64.of_int diag.total_votes) ;
+        Db.Cluster.set_expected_hosts ~__context ~self:cluster
           ~value:(Int64.of_int diag.total_votes)
     | Error (InternalError message) | Error (Unix_error message) ->
         warn "%s Cannot query diagnostics due to %s, not performing update"


### PR DESCRIPTION
The `expected_votes` field in corosync represents the number of hosts that is expected by the cluster stack. In the context of corosync, this is the same as the number of hosts as in the corosync.conf file*. This is a useful field to expose to the user so that they can see how many nodes actually are expected.

We also have `Cluster_host` object, which represents xapi's view of what nodes should be in the cluster, but that might not be identical to corosync's view, especially when a host is disabled, but is still left in the list of Cluster_host objects.

Although one could argue that we could infer this `expected_votes` field from the number of enabled Cluster_hosts, it might still be useful to get this information directly from corosync.

*: there are ways in corosync to make one host cast multiple votes, but that feature is not used.