### PR TITLE
Fix building of all opam packages for xs-opam's CI

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -264,6 +264,7 @@
     re
     result
     rpclib
+    rrdd-plugin
     rresult
     sexplib
     sexplib0
@@ -315,6 +316,7 @@
     ; 'xapi-tools' will have version ~dev, not 'master' like all the others
     ; because it is not in xs-opam yet
     rrd-transport
+    rrdd-plugin
     xapi-tracing-export
     xen-api-client
     (alcotest :with-test)
@@ -721,10 +723,11 @@ This package provides an Lwt compatible interface to the library.")
     base-threads
     base-unix
     (alcotest :with-test)
+    (clock (= :version))
     (fmt :with-test)
-    (odoc :with-doc)
+    mtime
+    (xapi-log (= :version))
     (xapi-stdext-pervasives (= :version))
-    (mtime :with-test)
     (xapi-stdext-unix (= :version))
   )
 )

--- a/ocaml/forkexecd/dune
+++ b/ocaml/forkexecd/dune
@@ -3,7 +3,6 @@
 (rule
   (deps (source_tree helper))
   (targets vfork_helper)
-  (package forkexec)
   (action
     (no-infer
       (progn

--- a/xapi-debug.opam
+++ b/xapi-debug.opam
@@ -42,6 +42,7 @@ depends: [
   "re"
   "result"
   "rpclib"
+  "rrdd-plugin"
   "rresult"
   "sexplib"
   "sexplib0"

--- a/xapi-stdext-threads.opam
+++ b/xapi-stdext-threads.opam
@@ -11,11 +11,13 @@ depends: [
   "base-threads"
   "base-unix"
   "alcotest" {with-test}
+  "clock" {= version}
   "fmt" {with-test}
-  "odoc" {with-doc}
+  "mtime"
+  "xapi-log" {= version}
   "xapi-stdext-pervasives" {= version}
-  "mtime" {with-test}
   "xapi-stdext-unix" {= version}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/xapi-tools.opam
+++ b/xapi-tools.opam
@@ -28,6 +28,7 @@ depends: [
   "xmlm"
   "yojson"
   "rrd-transport"
+  "rrdd-plugin"
   "xapi-tracing-export"
   "xen-api-client"
   "alcotest" {with-test}


### PR DESCRIPTION
- forkexecd: do not tie vfork_helper to the forkexec package
- opam: add missing dependencies to packages