### PR TITLE
CP-50836: Add VM_migrate_downtime and request_shutdown spans to help visualise potential optimisations

### DIFF
--- a/ocaml/libs/tracing/tracing.ml
+++ b/ocaml/libs/tracing/tracing.ml
@@ -437,10 +437,7 @@ module Span = struct
 
   let to_propagation_context span =
     let traceparent = span |> get_context |> SpanContext.to_traceparent in
-    span
-    |> get_context
-    |> SpanContext.context_of_span_context
-    |> TraceContext.with_traceparent (Some traceparent)
+    span |> get_trace_context |> TraceContext.with_traceparent (Some traceparent)
 
   let with_trace_context span trace_context =
     let span_context =

--- a/ocaml/libs/tracing/tracing_export.ml
+++ b/ocaml/libs/tracing/tracing_export.ml
@@ -83,10 +83,7 @@ module Content = struct
              )
         in
         let tags =
-          let span_context = Span.get_context s in
-          let trace_context =
-            SpanContext.context_of_span_context span_context
-          in
+          let trace_context = Span.get_trace_context s in
           let baggage =
             TraceContext.baggage_of trace_context |> Option.value ~default:[]
           in

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -2988,6 +2988,7 @@ and perform_exn ?result (op : operation) (t : Xenops_task.task_handle) : unit =
             ]
           )
           t ;
+        with_tracing ~task:t ~name:"VM_migrate_downtime_end" Fun.id ;
         Handshake.send s Handshake.Success ;
         debug "VM.receive_memory: Synchronisation point 4"
       with e ->

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -2515,6 +2515,7 @@ module VM = struct
                 @@ fun () -> pre_suspend_callback task
                 ) ;
 
+                with_tracing ~task ~name:"VM_save_request_shutdown" @@ fun () ->
                 if
                   not
                     ( with_tracing ~task
@@ -2523,6 +2524,13 @@ module VM = struct
                     )
                 then
                   raise (Xenopsd_error Failed_to_acknowledge_suspend_request) ;
+                (* If this is for a migration, record the begin time *)
+                ( match data with
+                | FD _ ->
+                    with_tracing ~task ~name:"VM_migrate_downtime_begin" Fun.id
+                | _ ->
+                    ()
+                ) ;
                 if
                   not
                     ( with_tracing ~task


### PR DESCRIPTION
Also simplify two tracing functions which could just use Span.get_trace_context directly