### PR TITLE
CP-53477 Update host/pool datamodel to support Dom0 SSH Control

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 786
+let schema_minor_vsn = 787
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -2043,6 +2043,9 @@ let _ =
   error Api_errors.host_driver_no_hardware ["driver variant"]
     ~doc:"No hardware present for this host driver variant" () ;
 
+  error Api_errors.set_console_timeout_failed ["timeout"]
+    ~doc:"Failed to set SSH&VNC idle session timeout." () ;
+
   error Api_errors.tls_verification_not_enabled_in_pool []
     ~doc:
       "TLS verification has not been enabled in the pool successfully, please \

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2368,6 +2368,29 @@ let disable_ssh =
     ~params:[(Ref _host, "self", "The host")]
     ~allowed_roles:_R_POOL_ADMIN ()
 
+let set_ssh_enable_timeout =
+  call ~name:"set_ssh_enable_timeout " ~lifecycle:[]
+    ~doc:"Set the SSH service enabled timeout for the host"
+    ~params:
+      [
+        (Ref _host, "self", "The host")
+      ; ( Int
+        , "timeout"
+        , "The SSH enabled timeout in minutes (0 means no timeout, max 2880)"
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_console_timeout =
+  call ~name:"set_console_timeout" ~lifecycle:[]
+    ~doc:"Set the idle SSH/VNC session timeout for the host"
+    ~params:
+      [
+        (Ref _host, "self", "The host")
+      ; (Int, "console_timeout", "The idle console timeout in seconds")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
 let latest_synced_updates_applied_state =
   Enum
     ( "latest_synced_updates_applied_state"
@@ -2527,6 +2550,8 @@ let t =
       ; emergency_clear_mandatory_guidance
       ; enable_ssh
       ; disable_ssh
+      ; set_ssh_enable_timeout
+      ; set_console_timeout
       ]
     ~contents:
       ([
@@ -2964,6 +2989,20 @@ let t =
             ~default_value:(Some (VString "")) "last_update_hash"
             "The SHA256 checksum of updateinfo of the most recently applied \
              update on the host"
+        ; field ~qualifier:RW ~lifecycle:[] ~ty:Bool
+            ~default_value:(Some (VBool true)) "ssh_enabled"
+            "True if SSH access is enabled for the host"
+        ; field ~qualifier:RW ~lifecycle:[] ~ty:Int
+            ~default_value:(Some (VInt 0L)) "ssh_enabled_timeout"
+            "The timeout in minutes after which SSH access will be \
+             automatically disabled (0 means never)"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
+            ~default_value:(Some (VDateTime Date.epoch)) "ssh_expiry"
+            "The time when SSH access will expire"
+        ; field ~qualifier:RW ~lifecycle:[] ~ty:Int
+            ~default_value:(Some (VInt 0L)) "console_idle_timeout"
+            "The timeout in seconds after which idle console will be \
+             automatically terminated (0 means never)"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1571,6 +1571,33 @@ let disable_ssh =
     ~params:[(Ref _pool, "self", "The pool")]
     ~allowed_roles:_R_POOL_ADMIN ()
 
+let set_ssh_enable_timeout =
+  call ~name:"set_ssh_enable_timeout " ~lifecycle:[]
+    ~doc:"Set the SSH enabled timeout for the hosts in the pool"
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( Int
+        , "timeout"
+        , "The SSH enabled timeout in minutes. (0 means no timeout, max 2880)"
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_console_timeout =
+  call ~name:"set_console_timeout" ~lifecycle:[]
+    ~doc:"Set the idle SSH/VNC session timeout for the pool"
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( Int
+        , "console_timeout"
+        , "The idle SSH/VNC session timeout in seconds. A value of 0 means no \
+           timeout."
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
 (** A pool class *)
 let t =
   create_obj ~in_db:true
@@ -1667,6 +1694,8 @@ let t =
       ; get_guest_secureboot_readiness
       ; enable_ssh
       ; disable_ssh
+      ; set_ssh_enable_timeout
+      ; set_console_timeout
       ]
     ~contents:
       ([

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "ad67a64cd47cdea32085518c1fb38d27"
+let last_known_schema_hash = "42fd0bbdc613092390c32e04e35a24d2"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -215,7 +215,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
     ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
     ~pending_guidances_recommended:[] ~pending_guidances_full:[]
-    ~last_update_hash:"" ;
+    ~last_update_hash:"" ~ssh_enabled:true ~ssh_enabled_timeout:0L
+    ~ssh_expiry:Date.epoch ~console_idle_timeout:0L ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1424,3 +1424,5 @@ let host_driver_no_hardware = add_error "HOST_DRIVER_NO_HARDWARE"
 
 let tls_verification_not_enabled_in_pool =
   add_error "TLS_VERIFICATION_NOT_ENABLED_IN_POOL"
+
+let set_console_timeout_failed = add_error "SET_CONSOLE_TIMEOUT_FAILED"

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1185,6 +1185,14 @@ functor
       let disable_ssh ~__context ~self =
         info "%s: pool = '%s'" __FUNCTION__ (pool_uuid ~__context self) ;
         Local.Pool.disable_ssh ~__context ~self
+
+      let set_ssh_enable_timeout ~__context ~self ~timeout =
+        info "%s: pool = '%s'" __FUNCTION__ (pool_uuid ~__context self) ;
+        Local.Pool.set_ssh_enable_timeout ~__context ~self ~timeout
+
+      let set_console_timeout ~__context ~self ~console_timeout =
+        info "%s: pool = '%s'" __FUNCTION__ (pool_uuid ~__context self) ;
+        Local.Pool.set_console_timeout ~__context ~self ~console_timeout
     end
 
     module VM = struct
@@ -4034,6 +4042,22 @@ functor
         info "%s: host = '%s'" __FUNCTION__ (host_uuid ~__context self) ;
         let local_fn = Local.Host.disable_ssh ~self in
         let remote_fn = Client.Host.disable_ssh ~self in
+        do_op_on ~local_fn ~__context ~host:self ~remote_fn
+
+      let set_ssh_enable_timeout ~__context ~self ~timeout =
+        let uuid = host_uuid ~__context self in
+        info "Host.set_ssh_enable_timeout : host = '%s'" uuid ;
+        let local_fn = Local.Host.set_ssh_enable_timeout ~self ~timeout in
+        let remote_fn = Client.Host.set_ssh_enable_timeout ~self ~timeout in
+        do_op_on ~local_fn ~__context ~host:self ~remote_fn
+
+      let set_console_timeout ~__context ~self ~console_timeout =
+        let uuid = host_uuid ~__context self in
+        info "Host.set_console_timeout: host = '%s'" uuid ;
+        let local_fn = Local.Host.set_console_timeout ~self ~console_timeout in
+        let remote_fn =
+          Client.Host.set_console_timeout ~self ~console_timeout
+        in
         do_op_on ~local_fn ~__context ~host:self ~remote_fn
     end
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1042,7 +1042,9 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled ~last_software_update ~last_update_hash
     ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
-    ~pending_guidances_recommended:[] ~pending_guidances_full:[] ;
+    ~pending_guidances_recommended:[] ~pending_guidances_full:[]
+    ~ssh_enabled:true ~ssh_enabled_timeout:0L ~ssh_expiry:Date.epoch
+    ~console_idle_timeout:0L ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.now ()) ;
   Db.Host_metrics.set_live ~__context ~self:metrics ~value:host_is_us ;
@@ -3112,22 +3114,171 @@ let emergency_clear_mandatory_guidance ~__context =
      ) ;
   Db.Host.set_pending_guidances ~__context ~self ~value:[]
 
-let enable_ssh ~__context ~self =
-  try
-    Xapi_systemctl.enable ~wait_until_success:false "sshd" ;
-    Xapi_systemctl.start ~wait_until_success:false "sshd"
-  with _ ->
+let validate_timeout timeout =
+  if timeout < -1L || timeout > 2880L then
     raise
       (Api_errors.Server_error
-         (Api_errors.enable_ssh_failed, [Ref.string_of self])
+         ( Api_errors.invalid_value
+         , ["timeout"; Int64.to_string timeout; "must be between -1 and 2880"]
+         )
+      )
+  else
+    timeout
+
+let remove_disable_job ~__context ~self =
+  let host_uuid = Db.Host.get_uuid ~__context ~self in
+  let task_name = Printf.sprintf "disable_ssh_for_host_%s" host_uuid in
+  Xapi_stdext_threads_scheduler.Scheduler.remove_from_queue task_name
+
+let schedule_disable_job ~__context ~self ~timeout =
+  let host_uuid = Db.Host.get_uuid ~__context ~self in
+  let task_name = Printf.sprintf "disable_ssh_for_host_%s" host_uuid in
+  let current_time = Date.now () in
+
+  let expiry_time =
+    let current_secs = Date.to_unix_time current_time in
+    let timeout_secs = Int64.to_float timeout in
+    Date.of_unix_time (current_secs +. timeout_secs)
+  in
+
+  debug "Scheduling SSH disable job for host %s with timeout %Ld seconds"
+    host_uuid timeout ;
+
+  (* Remove any existing job first *)
+  remove_disable_job ~__context ~self ;
+
+  let _ =
+    Xapi_stdext_threads_scheduler.Scheduler.add_to_queue task_name
+      Xapi_stdext_threads_scheduler.Scheduler.OneShot (Int64.to_float timeout)
+      (fun () ->
+        try
+          Xapi_systemctl.disable ~wait_until_success:false "sshd" ;
+          Xapi_systemctl.stop ~wait_until_success:false "sshd" ;
+          Db.Host.set_ssh_enabled ~__context ~self ~value:false ;
+          debug "Successfully disabled SSH for host %s" host_uuid
+        with e ->
+          error "Failed to disable SSH for host %s: %s" host_uuid
+            (Printexc.to_string e)
+    )
+  in
+
+  Db.Host.set_ssh_expiry ~__context ~self ~value:expiry_time
+
+let enable_ssh ~__context ~self =
+  try
+    debug "Enabling SSH for host %s" (Db.Host.get_uuid ~__context ~self) ;
+
+    Xapi_systemctl.enable ~wait_until_success:false "sshd" ;
+    Xapi_systemctl.start ~wait_until_success:false "sshd" ;
+
+    let timeout = Db.Host.get_ssh_enabled_timeout ~__context ~self in
+    ( match timeout with
+    | 0L ->
+        remove_disable_job ~__context ~self
+    | t when t > 0L ->
+        schedule_disable_job ~__context ~self ~timeout:(Int64.mul t 60L)
+    | _ ->
+        ()
+    ) ;
+
+    Db.Host.set_ssh_enabled ~__context ~self ~value:true
+  with e ->
+    error "Failed to enable SSH on host %s: %s" (Ref.string_of self)
+      (Printexc.to_string e) ;
+    raise
+      (Api_errors.Server_error
+         ( Api_errors.enable_ssh_failed
+         , [Ref.string_of self; Printexc.to_string e]
+         )
       )
 
 let disable_ssh ~__context ~self =
   try
+    debug "Disabling SSH for host %s" (Db.Host.get_uuid ~__context ~self) ;
+
+    remove_disable_job ~__context ~self ;
+
     Xapi_systemctl.disable ~wait_until_success:false "sshd" ;
-    Xapi_systemctl.stop ~wait_until_success:false "sshd"
-  with _ ->
+    Xapi_systemctl.stop ~wait_until_success:false "sshd" ;
+    Db.Host.set_ssh_enabled ~__context ~self ~value:false ;
+
+    let expiry_time = Date.now () |> Date.to_unix_time |> Date.of_unix_time in
+    Db.Host.set_ssh_expiry ~__context ~self ~value:expiry_time
+  with e ->
+    error "Failed to disable SSH on host %s: %s" (Ref.string_of self)
+      (Printexc.to_string e) ;
     raise
       (Api_errors.Server_error
          (Api_errors.disable_ssh_failed, [Ref.string_of self])
       )
+
+let set_ssh_enable_timeout ~__context ~self ~timeout =
+  let timeout = validate_timeout timeout in
+  debug "Setting SSH timeout for host %s to %Ld minutes"
+    (Db.Host.get_uuid ~__context ~self)
+    timeout ;
+  Db.Host.set_ssh_enabled_timeout ~__context ~self ~value:timeout ;
+  match Db.Host.get_ssh_enabled ~__context ~self with
+  | false ->
+      ()
+  | true -> (
+    match timeout with
+    | 0L ->
+        remove_disable_job ~__context ~self ;
+        Db.Host.set_ssh_expiry ~__context ~self ~value:Date.epoch
+    | t ->
+        schedule_disable_job ~__context ~self ~timeout:(Int64.mul t 60L) ;
+        Db.Host.set_ssh_enabled_timeout ~__context ~self ~value:timeout
+  )
+
+let set_console_timeout ~__context ~self ~console_timeout =
+  let validate_timeout = function
+    | timeout when timeout >= 0L ->
+        timeout
+    | timeout ->
+        raise
+          (Api_errors.Server_error
+             ( Api_errors.invalid_value
+             , [
+                 "console_timeout"
+               ; Int64.to_string timeout
+               ; "must be a positive integer"
+               ]
+             )
+          )
+  in
+
+  let console_timeout = validate_timeout console_timeout in
+
+  let configure_timeout = function
+    | 0L ->
+        let script =
+          "sed -i '/^export TMOUT=/d' /root/.bashrc && source /root/.bashrc"
+        in
+        Helpers.call_script "/bin/bash" ["-c"; script] |> Result.ok
+    | timeout ->
+        let script =
+          Printf.sprintf
+            "sed -i '/^export TMOUT=/d' /root/.bashrc && echo 'export \
+             TMOUT=%Ld' >> /root/.bashrc && source /root/.bashrc"
+            timeout
+        in
+        Helpers.call_script "/bin/bash" ["-c"; script] |> Result.ok
+  in
+
+  configure_timeout console_timeout
+  |> Result.map (fun _ ->
+         Db.Host.set_console_idle_timeout ~__context ~self
+           ~value:console_timeout
+     )
+  |> function
+  | Ok () ->
+      ()
+  | Error e ->
+      error "Failed to configure console timeout: %s" (Printexc.to_string e) ;
+      raise
+        (Api_errors.Server_error
+           ( Api_errors.set_console_timeout_failed
+           , ["Failed to configure console timeout"; Printexc.to_string e]
+           )
+        )

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -567,3 +567,12 @@ val emergency_clear_mandatory_guidance : __context:Context.t -> unit
 val enable_ssh : __context:Context.t -> self:API.ref_host -> unit
 
 val disable_ssh : __context:Context.t -> self:API.ref_host -> unit
+
+val set_ssh_enable_timeout :
+  __context:Context.t -> self:API.ref_host -> timeout:int64 -> unit
+
+val set_console_timeout :
+  __context:Context.t -> self:API.ref_host -> console_timeout:int64 -> unit
+
+val schedule_disable_job :
+  __context:Context.t -> self:API.ref_host -> timeout:int64 -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -4008,3 +4008,25 @@ end
 let enable_ssh = Ssh.enable
 
 let disable_ssh = Ssh.disable
+
+let set_ssh_enable_timeout ~__context ~self:_ ~timeout =
+  let hosts = Db.Host.get_all ~__context in
+  List.iter
+    (fun host ->
+      Helpers.call_api_functions ~__context (fun rpc session_id ->
+          Client.Host.set_ssh_enable_timeout ~rpc ~session_id ~self:host
+            ~timeout
+      )
+    )
+    hosts
+
+let set_console_timeout ~__context ~self:_ ~console_timeout =
+  let hosts = Db.Host.get_all ~__context in
+  List.iter
+    (fun host ->
+      Helpers.call_api_functions ~__context (fun rpc session_id ->
+          Client.Host.set_console_timeout ~rpc ~session_id ~self:host
+            ~console_timeout
+      )
+    )
+    hosts

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -437,3 +437,9 @@ val put_bundle_handler : Http.Request.t -> Unix.file_descr -> 'a -> unit
 val enable_ssh : __context:Context.t -> self:API.ref_pool -> unit
 
 val disable_ssh : __context:Context.t -> self:API.ref_pool -> unit
+
+val set_ssh_enable_timeout :
+  __context:Context.t -> self:API.ref_pool -> timeout:int64 -> unit
+
+val set_console_timeout :
+  __context:Context.t -> self:API.ref_pool -> console_timeout:int64 -> unit


### PR DESCRIPTION
This PR introduces support for Dom0 SSH control, providing the following capabilities:

Query the SSH status.
Configure a temporary SSH enable timeout.
Configure the console idle timeout for a specific host or all hosts in the pool.
Changes
New Host Object Fields:

- `ssh_enabled`: Indicates whether SSH is enabled.
- `ssh_enabled_timeout`: Specifies the timeout for temporary SSH enablement.
- `ssh_expiry`: Tracks the expiration time for temporary SSH enablement.

console_idle_timeout: Configures the idle timeout for the console.
New Host/Pool APIs:

- `set_ssh_enable_timeout`: Allows setting a temporary timeout for enabling the SSH service.
- `set_console_timeout`: Allows configuring the console idle timeout.
