### PR TITLE
CP-53477 Update Host/Pool Data model to Support Dom0 SSH Control

### DIFF
--- a/ocaml/idl/datamodel_common.ml
+++ b/ocaml/idl/datamodel_common.ml
@@ -10,7 +10,7 @@ open Datamodel_roles
               to leave a gap for potential hotfixes needing to increment the schema version.*)
 let schema_major_vsn = 5
 
-let schema_minor_vsn = 786
+let schema_minor_vsn = 787
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -2043,6 +2043,9 @@ let _ =
   error Api_errors.host_driver_no_hardware ["driver variant"]
     ~doc:"No hardware present for this host driver variant" () ;
 
+  error Api_errors.set_console_idle_timeout_failed ["timeout"]
+    ~doc:"Failed to set console idle timeout." () ;
+
   error Api_errors.tls_verification_not_enabled_in_pool []
     ~doc:
       "TLS verification has not been enabled in the pool successfully, please \

--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -2368,6 +2368,29 @@ let disable_ssh =
     ~params:[(Ref _host, "self", "The host")]
     ~allowed_roles:_R_POOL_ADMIN ()
 
+let set_ssh_enabled_timeout =
+  call ~name:"set_ssh_enabled_timeout" ~lifecycle:[]
+    ~doc:"Set the SSH service enabled timeout for the host"
+    ~params:
+      [
+        (Ref _host, "self", "The host")
+      ; ( Int
+        , "value"
+        , "The SSH enabled timeout in seconds (0 means no timeout, max 2 days)"
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_console_idle_timeout =
+  call ~name:"set_console_idle_timeout" ~lifecycle:[]
+    ~doc:"Set the console idle timeout for the host"
+    ~params:
+      [
+        (Ref _host, "self", "The host")
+      ; (Int, "value", "The idle console timeout in seconds")
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
 let latest_synced_updates_applied_state =
   Enum
     ( "latest_synced_updates_applied_state"
@@ -2527,6 +2550,8 @@ let t =
       ; emergency_clear_mandatory_guidance
       ; enable_ssh
       ; disable_ssh
+      ; set_ssh_enabled_timeout
+      ; set_console_idle_timeout
       ]
     ~contents:
       ([
@@ -2964,6 +2989,22 @@ let t =
             ~default_value:(Some (VString "")) "last_update_hash"
             "The SHA256 checksum of updateinfo of the most recently applied \
              update on the host"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
+            ~default_value:(Some (VBool true)) "ssh_enabled"
+            "True if SSH access is enabled for the host"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int
+            ~default_value:(Some (VInt 0L)) "ssh_enabled_timeout"
+            "The timeout in seconds after which SSH access will be \
+             automatically disabled (0 means never), this setting will be \
+             applied every time the SSH is enabled by XAPI"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:DateTime
+            ~default_value:(Some (VDateTime Date.epoch)) "ssh_expiry"
+            "The time in UTC after which the SSH access will be automatically \
+             disabled"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int
+            ~default_value:(Some (VInt 0L)) "console_idle_timeout"
+            "The timeout in seconds after which idle console will be \
+             automatically terminated (0 means never)"
         ]
       )
     ()

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1571,6 +1571,33 @@ let disable_ssh =
     ~params:[(Ref _pool, "self", "The pool")]
     ~allowed_roles:_R_POOL_ADMIN ()
 
+let set_ssh_enabled_timeout =
+  call ~name:"set_ssh_enabled_timeout" ~lifecycle:[]
+    ~doc:"Set the SSH enabled timeout for all hosts in the pool"
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( Int
+        , "value"
+        , "The SSH enabled timeout in seconds. (0 means no timeout, max 2 days)"
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
+let set_console_idle_timeout =
+  call ~name:"set_console_idle_timeout" ~lifecycle:[]
+    ~doc:"Set the console idle timeout for all hosts in the pool"
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( Int
+        , "value"
+        , "The idle SSH/VNC session timeout in seconds. A value of 0 means no \
+           timeout."
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
 (** A pool class *)
 let t =
   create_obj ~in_db:true
@@ -1667,6 +1694,8 @@ let t =
       ; get_guest_secureboot_readiness
       ; enable_ssh
       ; disable_ssh
+      ; set_ssh_enabled_timeout
+      ; set_console_idle_timeout
       ]
     ~contents:
       ([

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "ad67a64cd47cdea32085518c1fb38d27"
+let last_known_schema_hash = "0cc42d0325bd7ea01a5024d63b835bfb"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -215,7 +215,8 @@ let make_host2 ~__context ?(ref = Ref.make ()) ?(uuid = make_uuid ())
     ~last_software_update:(Xapi_host.get_servertime ~__context ~host:ref)
     ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
     ~pending_guidances_recommended:[] ~pending_guidances_full:[]
-    ~last_update_hash:"" ;
+    ~last_update_hash:"" ~ssh_enabled:true ~ssh_enabled_timeout:0L
+    ~ssh_expiry:Date.epoch ~console_idle_timeout:0L ;
   ref
 
 let make_pif ~__context ~network ~host ?(device = "eth0")

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1424,3 +1424,6 @@ let host_driver_no_hardware = add_error "HOST_DRIVER_NO_HARDWARE"
 
 let tls_verification_not_enabled_in_pool =
   add_error "TLS_VERIFICATION_NOT_ENABLED_IN_POOL"
+
+let set_console_idle_timeout_failed =
+  add_error "SET_CONSOLE_IDLE_TIMEOUT_FAILED"

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1185,6 +1185,18 @@ functor
       let disable_ssh ~__context ~self =
         info "%s: pool = '%s'" __FUNCTION__ (pool_uuid ~__context self) ;
         Local.Pool.disable_ssh ~__context ~self
+
+      let set_ssh_enabled_timeout ~__context ~self ~value =
+        info "Pool.set_ssh_enabled_timeout: pool='%s' value='%Ld'"
+          (pool_uuid ~__context self)
+          value ;
+        Local.Pool.set_ssh_enabled_timeout ~__context ~self ~value
+
+      let set_console_idle_timeout ~__context ~self ~value =
+        info "Pool.set_console_idle_timeout: pool='%s' value='%Ld'"
+          (pool_uuid ~__context self)
+          value ;
+        Local.Pool.set_console_idle_timeout ~__context ~self ~value
     end
 
     module VM = struct
@@ -4034,6 +4046,22 @@ functor
         info "%s: host = '%s'" __FUNCTION__ (host_uuid ~__context self) ;
         let local_fn = Local.Host.disable_ssh ~self in
         let remote_fn = Client.Host.disable_ssh ~self in
+        do_op_on ~local_fn ~__context ~host:self ~remote_fn
+
+      let set_ssh_enabled_timeout ~__context ~self ~value =
+        info "Host.set_ssh_enabled_timeout: host='%s' value='%Ld'"
+          (host_uuid ~__context self)
+          value ;
+        let local_fn = Local.Host.set_ssh_enabled_timeout ~self ~value in
+        let remote_fn = Client.Host.set_ssh_enabled_timeout ~self ~value in
+        do_op_on ~local_fn ~__context ~host:self ~remote_fn
+
+      let set_console_idle_timeout ~__context ~self ~value =
+        info "Host.set_console_idle_timeout: host='%s' value='%Ld'"
+          (host_uuid ~__context self)
+          value ;
+        let local_fn = Local.Host.set_console_idle_timeout ~self ~value in
+        let remote_fn = Client.Host.set_console_idle_timeout ~self ~value in
         do_op_on ~local_fn ~__context ~host:self ~remote_fn
     end
 

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -1042,7 +1042,9 @@ let create ~__context ~uuid ~name_label ~name_description:_ ~hostname ~address
     ~multipathing:false ~uefi_certificates:"" ~editions:[] ~pending_guidances:[]
     ~tls_verification_enabled ~last_software_update ~last_update_hash
     ~recommended_guidances:[] ~latest_synced_updates_applied:`unknown
-    ~pending_guidances_recommended:[] ~pending_guidances_full:[] ;
+    ~pending_guidances_recommended:[] ~pending_guidances_full:[]
+    ~ssh_enabled:true ~ssh_enabled_timeout:0L ~ssh_expiry:Date.epoch
+    ~console_idle_timeout:0L ;
   (* If the host we're creating is us, make sure its set to live *)
   Db.Host_metrics.set_last_updated ~__context ~self:metrics ~value:(Date.now ()) ;
   Db.Host_metrics.set_live ~__context ~self:metrics ~value:host_is_us ;
@@ -3131,3 +3133,7 @@ let disable_ssh ~__context ~self =
       (Api_errors.Server_error
          (Api_errors.disable_ssh_failed, [Ref.string_of self])
       )
+
+let set_ssh_enabled_timeout ~__context ~self:_ ~value:_ = ()
+
+let set_console_idle_timeout ~__context ~self:_ ~value:_ = ()

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -567,3 +567,9 @@ val emergency_clear_mandatory_guidance : __context:Context.t -> unit
 val enable_ssh : __context:Context.t -> self:API.ref_host -> unit
 
 val disable_ssh : __context:Context.t -> self:API.ref_host -> unit
+
+val set_ssh_enabled_timeout :
+  __context:Context.t -> self:API.ref_host -> value:int64 -> unit
+
+val set_console_idle_timeout :
+  __context:Context.t -> self:API.ref_host -> value:int64 -> unit

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -4008,3 +4008,7 @@ end
 let enable_ssh = Ssh.enable
 
 let disable_ssh = Ssh.disable
+
+let set_ssh_enabled_timeout ~__context ~self:_ ~value:_ = ()
+
+let set_console_idle_timeout ~__context ~self:_ ~value:_ = ()

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -437,3 +437,9 @@ val put_bundle_handler : Http.Request.t -> Unix.file_descr -> 'a -> unit
 val enable_ssh : __context:Context.t -> self:API.ref_pool -> unit
 
 val disable_ssh : __context:Context.t -> self:API.ref_pool -> unit
+
+val set_ssh_enabled_timeout :
+  __context:Context.t -> self:API.ref_pool -> value:int64 -> unit
+
+val set_console_idle_timeout :
+  __context:Context.t -> self:API.ref_pool -> value:int64 -> unit


### PR DESCRIPTION
This PR introduces support for Dom0 SSH control, providing the following capabilities:

Query the SSH status.
Configure a temporary SSH enable timeout  for a specific host or all hosts in the pool.
Configure the console idle timeout for a specific host or all hosts in the pool.

Changes
New Host Object Fields:

- `ssh_enabled`: Indicates whether SSH is enabled.
- `ssh_enabled_timeout`: Specifies the timeout for temporary SSH enablement.
- `ssh_expiry`: Tracks the expiration time for temporary SSH enablement.
- `console_idle_timeout`: Configures the idle timeout for the console.

New Host/Pool APIs (This PR only include the change of data model, the implementation of this API will be include in the next PR):

- `set_ssh_enabled_timeout`: Allows setting a temporary timeout for enabling the SSH service.
- `set_console_idle_timeout`: Allows configuring the console idle timeout.