### PR TITLE
CP-53478: Implement SSH-related APIs for Dom0 SSH control

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -2040,6 +2040,9 @@ let _ =
   error Api_errors.disable_ssh_partially_failed ["hosts"]
     ~doc:"Some of hosts failed to disable SSH access." () ;
 
+  error Api_errors.set_console_timeout_partially_failed ["hosts"]
+    ~doc:"Some hosts failed to set console timeout." () ;
+
   error Api_errors.host_driver_no_hardware ["driver variant"]
     ~doc:"No hardware present for this host driver variant" () ;
 

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -2040,6 +2040,9 @@ let _ =
   error Api_errors.disable_ssh_partially_failed ["hosts"]
     ~doc:"Some of hosts failed to disable SSH access." () ;
 
+  error Api_errors.set_ssh_timeout_partially_failed ["hosts"]
+    ~doc:"Some hosts failed to set SSH timeout." () ;
+
   error Api_errors.set_console_timeout_partially_failed ["hosts"]
     ~doc:"Some hosts failed to set console timeout." () ;
 

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1420,6 +1420,9 @@ let enable_ssh_partially_failed = add_error "ENABLE_SSH_PARTIALLY_FAILED"
 
 let disable_ssh_partially_failed = add_error "DISABLE_SSH_PARTIALLY_FAILED"
 
+let set_console_timeout_partially_failed =
+  add_error "SET_CONSOLE_TIMEOUT_PARTIALLY_FAILED"
+
 let host_driver_no_hardware = add_error "HOST_DRIVER_NO_HARDWARE"
 
 let tls_verification_not_enabled_in_pool =

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1420,6 +1420,9 @@ let enable_ssh_partially_failed = add_error "ENABLE_SSH_PARTIALLY_FAILED"
 
 let disable_ssh_partially_failed = add_error "DISABLE_SSH_PARTIALLY_FAILED"
 
+let set_ssh_timeout_partially_failed =
+  add_error "SET_SSH_TIMEOUT_PARTIALLY_FAILED"
+
 let set_console_timeout_partially_failed =
   add_error "SET_CONSOLE_TIMEOUT_PARTIALLY_FAILED"
 

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1289,6 +1289,10 @@ let reboot_required_hfxs = ref "/run/reboot-required.hfxs"
 
 let console_timeout_profile_path = ref "/etc/profile.d/console_timeout.sh"
 
+let job_for_disable_ssh = ref "Disable SSH"
+
+let ssh_service = ref "sshd"
+
 (* Fingerprint of default patch key *)
 let citrix_patch_key =
   "NERDNTUzMDMwRUMwNDFFNDI4N0M4OEVCRUFEMzlGOTJEOEE5REUyNg=="

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1287,6 +1287,8 @@ let gpumon_stop_timeout = ref 10.0
 
 let reboot_required_hfxs = ref "/run/reboot-required.hfxs"
 
+let console_timeout_profile_path = ref "/etc/profile.d/console_timeout.sh"
+
 (* Fingerprint of default patch key *)
 let citrix_patch_key =
   "NERDNTUzMDMwRUMwNDFFNDI4N0M4OEVCRUFEMzlGOTJEOEE5REUyNg=="

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -4004,6 +4004,13 @@ module Ssh = struct
     operate ~__context ~action:Client.Host.disable_ssh
       ~error:Api_errors.disable_ssh_partially_failed
 
+  let set_enabled_timeout ~__context ~self:_ ~value =
+    operate ~__context
+      ~action:(fun ~rpc ~session_id ~self ->
+        Client.Host.set_ssh_enabled_timeout ~rpc ~session_id ~self ~value
+      )
+      ~error:Api_errors.set_ssh_timeout_partially_failed
+
   let set_console_timeout ~__context ~self:_ ~value =
     operate ~__context
       ~action:(fun ~rpc ~session_id ~self ->
@@ -4016,6 +4023,6 @@ let enable_ssh = Ssh.enable
 
 let disable_ssh = Ssh.disable
 
-let set_ssh_enabled_timeout ~__context ~self:_ ~value:_ = ()
+let set_ssh_enabled_timeout = Ssh.set_enabled_timeout
 
 let set_console_idle_timeout = Ssh.set_console_timeout

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -4003,6 +4003,13 @@ module Ssh = struct
   let disable ~__context ~self:_ =
     operate ~__context ~action:Client.Host.disable_ssh
       ~error:Api_errors.disable_ssh_partially_failed
+
+  let set_console_timeout ~__context ~self:_ ~value =
+    operate ~__context
+      ~action:(fun ~rpc ~session_id ~self ->
+        Client.Host.set_console_idle_timeout ~rpc ~session_id ~self ~value
+      )
+      ~error:Api_errors.set_console_timeout_partially_failed
 end
 
 let enable_ssh = Ssh.enable
@@ -4011,4 +4018,4 @@ let disable_ssh = Ssh.disable
 
 let set_ssh_enabled_timeout ~__context ~self:_ ~value:_ = ()
 
-let set_console_idle_timeout ~__context ~self:_ ~value:_ = ()
+let set_console_idle_timeout = Ssh.set_console_timeout


### PR DESCRIPTION
Implemented XAPI APIs:
  - `set_ssh_enabled_timeout`
  - `set_console_idle_timeout`

These APIs allow XAPI to configure timeouts for the SSH service and idle console sessions from both host and pool level.

Updated `records.ml` to support `host-param-set/get/list` and `pool-param-set/get/list` for SSH-related fields.