### PR TITLE
CP-53802: Restore SSH service to default state in pool eject

### DIFF
--- a/ocaml/idl/datamodel_host.ml
+++ b/ocaml/idl/datamodel_host.ml
@@ -1305,7 +1305,7 @@ let create_params =
     ; param_name= "ssh_enabled"
     ; param_doc= "True if SSH access is enabled for the host"
     ; param_release= numbered_release "25.14.0-next"
-    ; param_default= Some (VBool true)
+    ; param_default= Some (VBool Constants.default_ssh_enabled)
     }
   ; {
       param_type= Int
@@ -1315,7 +1315,7 @@ let create_params =
          disabled (0 means never), this setting will be applied every time the \
          SSH is enabled by XAPI"
     ; param_release= numbered_release "25.14.0-next"
-    ; param_default= Some (VInt 0L)
+    ; param_default= Some (VInt Constants.default_ssh_enabled_timeout)
     }
   ; {
       param_type= DateTime
@@ -1333,7 +1333,7 @@ let create_params =
         "The timeout in seconds after which idle console will be automatically \
          terminated (0 means never)"
     ; param_release= numbered_release "25.14.0-next"
-    ; param_default= Some (VInt 0L)
+    ; param_default= Some (VInt Constants.default_console_idle_timeout)
     }
   ]
 
@@ -2436,7 +2436,7 @@ let set_console_idle_timeout =
     ~params:
       [
         (Ref _host, "self", "The host")
-      ; (Int, "value", "The idle console timeout in seconds")
+      ; (Int, "value", "The console idle timeout in seconds")
       ]
     ~allowed_roles:_R_POOL_ADMIN ()
 
@@ -3039,10 +3039,11 @@ let t =
             "The SHA256 checksum of updateinfo of the most recently applied \
              update on the host"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Bool
-            ~default_value:(Some (VBool true)) "ssh_enabled"
-            "True if SSH access is enabled for the host"
+            ~default_value:(Some (VBool Constants.default_ssh_enabled))
+            "ssh_enabled" "True if SSH access is enabled for the host"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int
-            ~default_value:(Some (VInt 0L)) "ssh_enabled_timeout"
+            ~default_value:(Some (VInt Constants.default_ssh_enabled_timeout))
+            "ssh_enabled_timeout"
             "The timeout in seconds after which SSH access will be \
              automatically disabled (0 means never), this setting will be \
              applied every time the SSH is enabled by XAPI"
@@ -3051,7 +3052,8 @@ let t =
             "The time in UTC after which the SSH access will be automatically \
              disabled"
         ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int
-            ~default_value:(Some (VInt 0L)) "console_idle_timeout"
+            ~default_value:(Some (VInt Constants.default_console_idle_timeout))
+            "console_idle_timeout"
             "The timeout in seconds after which idle console will be \
              automatically terminated (0 means never)"
         ]

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -422,3 +422,9 @@ let observer_components_all =
 let tgroups_enabled = ref false
 
 let when_tgroups_enabled f = if !tgroups_enabled then f () else ()
+
+let default_ssh_enabled = true
+
+let default_ssh_enabled_timeout = 0L
+
+let default_console_idle_timeout = 0L

--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -59,8 +59,11 @@ let create_localhost ~__context info =
         ~external_auth_configuration:[] ~license_params:[] ~edition:""
         ~license_server:[("address", "localhost"); ("port", "27000")]
         ~local_cache_sr:Ref.null ~chipset_info:[] ~ssl_legacy:false
-        ~last_software_update:Date.epoch ~last_update_hash:"" ~ssh_enabled:true
-        ~ssh_enabled_timeout:0L ~ssh_expiry:Date.epoch ~console_idle_timeout:0L
+        ~last_software_update:Date.epoch ~last_update_hash:""
+        ~ssh_enabled:Constants.default_ssh_enabled
+        ~ssh_enabled_timeout:Constants.default_ssh_enabled_timeout
+        ~ssh_expiry:Date.epoch
+        ~console_idle_timeout:Constants.default_console_idle_timeout
     in
     ()
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2045,6 +2045,19 @@ let eject_self ~__context ~host =
           control_domains_to_destroy
       with _ -> ()
     ) ;
+    ( try
+        (* Restore console idle timeout *)
+        Xapi_host.set_console_idle_timeout ~__context ~self:host
+          ~value:0L ;
+        (* Restore SSH service to default state *)
+        Xapi_host.set_ssh_enabled_timeout ~__context ~self:host
+          ~value:0L ;
+        Xapi_host.enable_ssh ~__context ~self:host
+      with e ->
+        warn "Caught %s while restoring ssh service. Ignoring"
+          (Printexc.to_string e)
+    ) ;
+
     debug "Pool.eject: setting our role to be master" ;
     Xapi_pool_transition.set_role Pool_role.Master ;
     debug "Pool.eject: forgetting pool secret" ;

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2048,11 +2048,15 @@ let eject_self ~__context ~host =
     ( try
         (* Restore console idle timeout *)
         Xapi_host.set_console_idle_timeout ~__context ~self:host
-          ~value:0L ;
+          ~value:Constants.default_console_idle_timeout ;
         (* Restore SSH service to default state *)
         Xapi_host.set_ssh_enabled_timeout ~__context ~self:host
-          ~value:0L ;
-        Xapi_host.enable_ssh ~__context ~self:host
+          ~value:Constants.default_ssh_enabled_timeout ;
+        match Constants.default_ssh_enabled with
+        | true ->
+            Xapi_host.enable_ssh ~__context ~self:host
+        | false ->
+            Xapi_host.disable_ssh ~__context ~self:host
       with e ->
         warn "Caught %s while restoring ssh service. Ignoring"
           (Printexc.to_string e)


### PR DESCRIPTION
After being ejected from a pool, a new host obj will be created with default settings in DB.

This commit configures SSH service in the ejected host to default state during pool eject.