### PR TITLE
CA-408843: XSI-1852: Set encryption type of machine account

### DIFF
--- a/ocaml/xapi-aux/kerberos_encryption_types.ml
+++ b/ocaml/xapi-aux/kerberos_encryption_types.ml
@@ -20,6 +20,24 @@
 module Winbind = struct
   type t = Strong | Legacy | All
 
+  (*
+     * [X] 0x00000001 DES-CBC-CRC
+     * [X] 0x00000002 DES-CBC-MD5
+     * [X] 0x00000004 RC4-HMAC
+     * [X] 0x00000008 AES128-CTS-HMAC-SHA1-96
+     * [X] 0x00000010 AES256-CTS-HMAC-SHA1-96
+     * *)
+
+  let des_cbc_crc = 0x1
+
+  let des_cbc_md5 = 0x2
+
+  let rc4_hmac = 0x4
+
+  let aes128_cts_hmac_sha1_96 = 0x8
+
+  let aes256_cts_hmac_sha1_96 = 0x10
+
   let to_string = function
     | Strong ->
         "strong"
@@ -27,6 +45,20 @@ module Winbind = struct
         "legacy"
     | All ->
         "all"
+
+  let ( +++ ) x y = x lor y
+
+  let to_encoding = function
+    | Strong ->
+        aes128_cts_hmac_sha1_96 +++ aes256_cts_hmac_sha1_96
+    | Legacy ->
+        rc4_hmac
+    | All ->
+        des_cbc_crc
+        +++ des_cbc_md5
+        +++ rc4_hmac
+        +++ aes128_cts_hmac_sha1_96
+        +++ aes256_cts_hmac_sha1_96
 
   let of_string = function
     | "all" ->

--- a/ocaml/xapi-aux/kerberos_encryption_types.mli
+++ b/ocaml/xapi-aux/kerberos_encryption_types.mli
@@ -17,5 +17,7 @@ module Winbind : sig
 
   val to_string : t -> string
 
+  val to_encoding : t -> int
+
   val of_string : string -> t option
 end

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1004,6 +1004,8 @@ let winbind_update_closest_kdc_interval = ref (3600. *. 22.)
 
 let winbind_kerberos_encryption_type = ref Kerberos_encryption_types.Winbind.All
 
+let winbind_set_machine_account_kerberos_encryption_type = ref false
+
 let winbind_allow_kerberos_auth_fallback = ref false
 
 let winbind_keep_configuration = ref false
@@ -1545,6 +1547,14 @@ let other_options =
       )
     , "Encryption types to use when operating as Kerberos client \
        [strong|legacy|all]"
+    )
+  ; ( "winbind_set_machine_account_kerberos_encryption_type"
+    , Arg.Set winbind_set_machine_account_kerberos_encryption_type
+    , (fun () ->
+        string_of_bool !winbind_set_machine_account_kerberos_encryption_type
+      )
+    , "Whether set machine account encryption type \
+       (msDS-SupportedEncryptionTypes) on domain controller"
     )
   ; ( "winbind_allow_kerberos_auth_fallback"
     , Arg.Set winbind_allow_kerberos_auth_fallback


### PR DESCRIPTION
According to https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/decrypting-the-selection-of-supported-kerberos-encryption-types/1628797 msDS-SupportedEncryptionTypes of machine account help to decide Service Ticket encryption type

Some customer IT teams have strict encryption types limitation in their domains

This commit add winbind_set_machine_account_kerberos_encryption_type and default to false. When enabled, xapi set the machine account encryption types consistent with the samba client