### PR TITLE
CP-540722: Define the `MIRROR` interface to be implemented by Storage_smapi{v1,v3}_migrate.ml

### DIFF
--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -162,6 +162,10 @@ module DATA = struct
   module MIRROR = struct
     type context = unit
 
+    let send_start ctx ~dbg ~task_id ~dp ~sr ~vdi ~mirror_vm ~mirror_id
+        ~local_vdi ~copy_vm ~live_vm ~url ~remote_mirror ~dest_sr ~verify_dest =
+      u "DATA.MIRROR.send_start"
+
     let receive_start ctx ~dbg ~sr ~vdi_info ~id ~similar =
       u "DATA.MIRROR.receive_start"
 

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -162,15 +162,6 @@ module DATA = struct
   module MIRROR = struct
     type context = unit
 
-    (** [start task sr vdi url sr2] creates a VDI in remote [url]'s [sr2] and
-        writes data synchronously. It returns the id of the VDI.*)
-    let start ctx ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url ~dest =
-      u "DATA.MIRROR.start"
-
-    let stop ctx ~dbg ~id = u "DATA.MIRROR.stop"
-
-    let stat ctx ~dbg ~id = u "DATA.MIRROR.stat"
-
     let receive_start ctx ~dbg ~sr ~vdi_info ~id ~similar =
       u "DATA.MIRROR.receive_start"
 
@@ -182,8 +173,6 @@ module DATA = struct
     let receive_finalize2 ctx ~dbg ~id = u "DATA.MIRROR.receive_finalize2"
 
     let receive_cancel ctx ~dbg ~id = u "DATA.MIRROR.receive_cancel"
-
-    let list ctx ~dbg = u "DATA.MIRROR.list"
   end
 end
 

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -154,6 +154,11 @@ let get_by_name ctx ~dbg ~name = u "get_by_name"
 module DATA = struct
   let copy ctx ~dbg ~sr ~vdi ~vm ~url ~dest = u "DATA.copy"
 
+  let import_activate ctx ~dbg ~dp ~sr ~vdi ~vm =
+    u "DATA.MIRROR.import_activate"
+
+  let get_nbd_server ctx ~dbg ~dp ~sr ~vdi ~vm = u "DATA.MIRROR.get_nbd_server"
+
   module MIRROR = struct
     type context = unit
 
@@ -179,12 +184,6 @@ module DATA = struct
     let receive_cancel ctx ~dbg ~id = u "DATA.MIRROR.receive_cancel"
 
     let list ctx ~dbg = u "DATA.MIRROR.list"
-
-    let import_activate ctx ~dbg ~dp ~sr ~vdi ~vm =
-      u "DATA.MIRROR.import_activate"
-
-    let get_nbd_server ctx ~dbg ~dp ~sr ~vdi ~vm =
-      u "DATA.MIRROR.get_nbd_server"
   end
 end
 

--- a/ocaml/xapi-storage-cli/dune
+++ b/ocaml/xapi-storage-cli/dune
@@ -5,6 +5,7 @@
     xapi-idl
     xapi-idl.storage
     xapi-idl.storage.interface
+    xapi_internal
     re
     re.str
     rpclib.core

--- a/ocaml/xapi-storage-cli/main.ml
+++ b/ocaml/xapi-storage-cli/main.ml
@@ -149,7 +149,7 @@ let string_of_file filename =
 
 let mirror_list common_opts =
   wrap common_opts (fun () ->
-      let list = Client.DATA.MIRROR.list dbg in
+      let list = Storage_migrate.list ~dbg in
       List.iter
         (fun (id, status) -> Printf.printf "%s" (string_of_mirror id status))
         list
@@ -323,9 +323,9 @@ let mirror_start common_opts sr vdi dp url dest verify_dest =
       let url = get_opt url "Need a URL" in
       let dest = get_opt dest "Need a destination SR" in
       let task =
-        Client.DATA.MIRROR.start dbg sr vdi dp mirror_vm copy_vm url
-          (Storage_interface.Sr.of_string dest)
-          verify_dest
+        Storage_migrate.start ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url
+          ~dest:(Storage_interface.Sr.of_string dest)
+          ~verify_dest
       in
       Printf.printf "Task id: %s\n" task
     )
@@ -335,7 +335,7 @@ let mirror_stop common_opts id =
   wrap common_opts (fun () ->
       match id with
       | Some id ->
-          Client.DATA.MIRROR.stop dbg id
+          Storage_migrate.stop ~dbg ~id
       | None ->
           failwith "Need an ID"
   )

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1913,7 +1913,6 @@ let bind ~volume_script_dir =
   S.VDI.get_by_name (u "VDI.get_by_name") ;
   S.UPDATES.get (u "UPDATES.get") ;
   S.SR.update_snapshot_info_dest (u "SR.update_snapshot_info_dest") ;
-  S.DATA.MIRROR.list (u "DATA.MIRROR.list") ;
   S.TASK.stat (u "TASK.stat") ;
   S.DP.diagnostics (u "DP.diagnostics") ;
   S.TASK.destroy (u "TASK.destroy") ;
@@ -1932,12 +1931,9 @@ let bind ~volume_script_dir =
   S.VDI.attach (u "VDI.attach") ;
   S.VDI.attach2 (u "VDI.attach2") ;
   S.VDI.activate (u "VDI.activate") ;
-  S.DATA.MIRROR.stat (u "DATA.MIRROR.stat") ;
   S.VDI.get_url (u "VDI.get_url") ;
-  S.DATA.MIRROR.start (u "DATA.MIRROR.start") ;
   S.Policy.get_backend_vm (u "Policy.get_backend_vm") ;
   S.SR.update_snapshot_info_src (u "SR.update_snapshot_info_src") ;
-  S.DATA.MIRROR.stop (u "DATA.MIRROR.stop") ;
   Rpc_lwt.server S.implementation
 
 let process_smapiv2_requests server txt =

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1920,6 +1920,7 @@ let bind ~volume_script_dir =
   S.VDI.similar_content (u "VDI.similar_content") ;
   S.DATA.copy (u "DATA.copy") ;
   S.DP.stat_vdi (u "DP.stat_vdi") ;
+  S.DATA.MIRROR.send_start (u "DATA.MIRROR.send_start") ;
   S.DATA.MIRROR.receive_start (u "DATA.MIRROR.receive_start") ;
   S.DATA.MIRROR.receive_start2 (u "DATA.MIRROR.receive_start2") ;
   S.DATA.MIRROR.receive_finalize (u "DATA.MIRROR.receive_finalize") ;

--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -439,7 +439,7 @@ let update_task ~__context id =
 let update_mirror ~__context id =
   try
     let dbg = Context.string_of_task __context in
-    let m = Client.DATA.MIRROR.stat dbg id in
+    let m = Storage_migrate.stat ~dbg ~id in
     if m.Mirror.failed then
       debug "Mirror %s has failed" id ;
     let task = get_mirror_task id in

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -1013,7 +1013,7 @@ let nbd_handler req s ?(vm = "0") sr vdi dp =
   let vm = Vm.of_string vm in
   let path =
     Storage_utils.transform_storage_exn (fun () ->
-        Local.DATA.MIRROR.import_activate "nbd" dp sr vdi vm
+        Local.DATA.import_activate "nbd" dp sr vdi vm
     )
   in
   Http_svr.headers s (Http.http_200_ok () @ ["Transfer-encoding: nbd"]) ;
@@ -1043,7 +1043,7 @@ let nbd_proxy req s vm sr vdi dp =
   let vm = Vm.of_string vm in
   let path =
     Storage_utils.transform_storage_exn (fun () ->
-        Local.DATA.MIRROR.get_nbd_server "nbd" dp sr vdi vm
+        Local.DATA.get_nbd_server "nbd" dp sr vdi vm
     )
   in
   debug "%s got nbd server path %s" __FUNCTION__ path ;

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -426,10 +426,7 @@ module MigrateLocal = struct
             (* Destroy the snapshot, if it still exists *)
             let snap =
               List.find_opt
-                (fun x ->
-                  List.mem_assoc "base_mirror" x.sm_config
-                  && List.assoc "base_mirror" x.sm_config = id
-                )
+                (fun x -> List.assoc_opt "base_mirror" x.sm_config = Some id)
                 vdis
             in
             ( match snap with

--- a/ocaml/xapi/storage_migrate_helper.ml
+++ b/ocaml/xapi/storage_migrate_helper.ml
@@ -24,9 +24,9 @@ open Storage_interface
 open Xapi_stdext_pervasives.Pervasiveext
 open Xmlrpc_client
 
-module State = struct
-  let failwith_fmt fmt = Printf.ksprintf failwith fmt
+let failwith_fmt fmt = Printf.ksprintf failwith fmt
 
+module State = struct
   module Receive_state = struct
     type t = {
         sr: Sr.t

--- a/ocaml/xapi/storage_migrate_helper.mli
+++ b/ocaml/xapi/storage_migrate_helper.mli
@@ -14,6 +14,8 @@
 
 module SXM : Debug.DEBUG
 
+val failwith_fmt : ('a, unit, string, 'b) format4 -> 'a
+
 module State : sig
   module Receive_state : sig
     type t = {

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -760,6 +760,13 @@ module Mux = struct
     module MIRROR = struct
       type context = unit
 
+      let u x = raise Storage_interface.(Storage_error (Errors.Unimplemented x))
+
+      let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~mirror_vm:_
+          ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
+          ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
+        u "DATA.MIRROR.send_start" (* see storage_smapi{v1,v3}_migrate.ml *)
+
       let receive_start () ~dbg ~sr ~vdi_info ~id ~similar =
         with_dbg ~name:"DATA.MIRROR.receive_start" ~dbg @@ fun di ->
         info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s"

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -760,32 +760,6 @@ module Mux = struct
     module MIRROR = struct
       type context = unit
 
-      let start () ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url ~dest ~verify_dest
-          =
-        with_dbg ~name:"DATA.MIRROR.start" ~dbg @@ fun di ->
-        info
-          "%s dbg:%s sr: %s vdi: %s dp:%s mirror_vm: %s copy_vm: %s url: %s \
-           dest sr: %s verify_dest: %B"
-          __FUNCTION__ dbg (s_of_sr sr) (s_of_vdi vdi) dp (s_of_vm mirror_vm)
-          (s_of_vm copy_vm) url (s_of_sr dest) verify_dest ;
-        Storage_migrate.start ~dbg:di ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url
-          ~dest ~verify_dest
-
-      let stop () ~dbg ~id =
-        with_dbg ~name:"DATA.MIRROR.stop" ~dbg @@ fun di ->
-        info "%s dbg:%s mirror_id: %s" __FUNCTION__ dbg id ;
-        Storage_migrate.stop ~dbg:di.log ~id
-
-      let list () ~dbg =
-        with_dbg ~name:"DATA.MIRROR.list" ~dbg @@ fun di ->
-        info "%s dbg: %s" __FUNCTION__ dbg ;
-        Storage_migrate.list ~dbg:di.log
-
-      let stat () ~dbg ~id =
-        with_dbg ~name:"DATA.MIRROR.stat" ~dbg @@ fun di ->
-        info "%s dbg: %s mirror_id: %s" __FUNCTION__ di.log id ;
-        Storage_migrate.stat ~dbg:di.log ~id
-
       let receive_start () ~dbg ~sr ~vdi_info ~id ~similar =
         with_dbg ~name:"DATA.MIRROR.receive_start" ~dbg @@ fun di ->
         info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s"

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -739,6 +739,24 @@ module Mux = struct
     let copy () ~dbg =
       with_dbg ~name:"DATA.copy" ~dbg @@ fun dbg -> Storage_migrate.copy ~dbg
 
+    let import_activate () ~dbg ~dp ~sr ~vdi ~vm =
+      with_dbg ~name:"DATA.import_activate" ~dbg @@ fun di ->
+      info "%s dbg:%s dp:%s sr:%s vdi:%s vm:%s" __FUNCTION__ dbg dp (s_of_sr sr)
+        (s_of_vdi vdi) (s_of_vm vm) ;
+      let module C = StorageAPI (Idl.Exn.GenClient (struct
+        let rpc = of_sr sr
+      end)) in
+      C.DATA.import_activate (Debug_info.to_string di) dp sr vdi vm
+
+    let get_nbd_server () ~dbg ~dp ~sr ~vdi ~vm =
+      with_dbg ~name:"DATA.get_nbd_server" ~dbg @@ fun di ->
+      info "%s dbg:%s dp:%s sr:%s vdi:%s vm:%s" __FUNCTION__ dbg dp (s_of_sr sr)
+        (s_of_vdi vdi) (s_of_vm vm) ;
+      let module C = StorageAPI (Idl.Exn.GenClient (struct
+        let rpc = of_sr sr
+      end)) in
+      C.DATA.get_nbd_server (Debug_info.to_string di) dp sr vdi vm
+
     module MIRROR = struct
       type context = unit
 
@@ -803,24 +821,6 @@ module Mux = struct
         with_dbg ~name:"DATA.MIRROR.receive_cancel" ~dbg @@ fun di ->
         info "%s dbg: %s mirror_id: %s" __FUNCTION__ dbg id ;
         Storage_migrate.receive_cancel ~dbg:di.log ~id
-
-      let import_activate () ~dbg ~dp ~sr ~vdi ~vm =
-        with_dbg ~name:"DATA.MIRROR.import_activate" ~dbg @@ fun di ->
-        info "%s dbg:%s dp:%s sr:%s vdi:%s vm:%s" __FUNCTION__ dbg dp
-          (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) ;
-        let module C = StorageAPI (Idl.Exn.GenClient (struct
-          let rpc = of_sr sr
-        end)) in
-        C.DATA.MIRROR.import_activate (Debug_info.to_string di) dp sr vdi vm
-
-      let get_nbd_server () ~dbg ~dp ~sr ~vdi ~vm =
-        with_dbg ~name:"DATA.MIRROR.get_nbd_server" ~dbg @@ fun di ->
-        info "%s dbg:%s dp:%s sr:%s vdi:%s vm:%s" __FUNCTION__ dbg dp
-          (s_of_sr sr) (s_of_vdi vdi) (s_of_vm vm) ;
-        let module C = StorageAPI (Idl.Exn.GenClient (struct
-          let rpc = of_sr sr
-        end)) in
-        C.DATA.MIRROR.get_nbd_server (Debug_info.to_string di) dp sr vdi vm
     end
   end
 

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1219,16 +1219,6 @@ module SMAPIv1 : Server_impl = struct
     module MIRROR = struct
       type context = unit
 
-      let start _context ~dbg:_ ~sr:_ ~vdi:_ ~dp:_ ~mirror_vm:_ ~copy_vm:_
-          ~url:_ ~dest:_ ~verify_dest:_ =
-        assert false
-
-      let stop _context ~dbg:_ ~id:_ = assert false
-
-      let list _context ~dbg:_ = assert false
-
-      let stat _context ~dbg:_ ~id:_ = assert false
-
       let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
         assert false
 

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1219,6 +1219,11 @@ module SMAPIv1 : Server_impl = struct
     module MIRROR = struct
       type context = unit
 
+      let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~mirror_vm:_
+          ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
+          ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
+        assert false
+
       let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
         assert false
 

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1212,6 +1212,10 @@ module SMAPIv1 : Server_impl = struct
     let copy _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~url:_ ~dest:_ ~verify_dest:_ =
       assert false
 
+    let import_activate _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ ~vm:_ = assert false
+
+    let get_nbd_server _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ ~vm:_ = assert false
+
     module MIRROR = struct
       type context = unit
 
@@ -1237,11 +1241,6 @@ module SMAPIv1 : Server_impl = struct
       let receive_finalize2 _context ~dbg:_ ~id:_ = assert false
 
       let receive_cancel _context ~dbg:_ ~id:_ = assert false
-
-      let import_activate _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ ~vm:_ =
-        assert false
-
-      let get_nbd_server _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ ~vm:_ = assert false
     end
   end
 

--- a/ocaml/xapi/storage_smapiv1_migrate.ml
+++ b/ocaml/xapi/storage_smapiv1_migrate.ml
@@ -1,0 +1,177 @@
+(*
+ * Copyright (c) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = "storage_smapiv1_migrate" end)
+
+module Unixext = Xapi_stdext_unix.Unixext
+open Storage_interface
+open Storage_migrate_helper
+module State = Storage_migrate_helper.State
+module SXM = Storage_migrate_helper.SXM
+
+module type SMAPIv2_MIRROR = Storage_interface.MIRROR
+
+module MIRROR : SMAPIv2_MIRROR = struct
+  type context = unit
+
+  let u x = raise Storage_interface.(Storage_error (Errors.Unimplemented x))
+
+  let send_start _ctx = u __FUNCTION__
+
+  let receive_start_common ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+    let on_fail : (unit -> unit) list ref = ref [] in
+    let vdis = Local.SR.scan dbg sr in
+    (* We drop cbt_metadata VDIs that do not have any actual data *)
+    let vdis = List.filter (fun vdi -> vdi.ty <> "cbt_metadata") vdis in
+    let leaf_dp = Local.DP.create dbg Uuidx.(to_string (make ())) in
+    try
+      let vdi_info = {vdi_info with sm_config= [("base_mirror", id)]} in
+      let leaf = Local.VDI.create dbg sr vdi_info in
+      D.info "Created leaf VDI for mirror receive: %s" (string_of_vdi_info leaf) ;
+      on_fail := (fun () -> Local.VDI.destroy dbg sr leaf.vdi) :: !on_fail ;
+      (* dummy VDI is created so that the leaf VDI becomes a differencing disk,
+         useful for calling VDI.compose later on *)
+      let dummy = Local.VDI.snapshot dbg sr leaf in
+      on_fail := (fun () -> Local.VDI.destroy dbg sr dummy.vdi) :: !on_fail ;
+      D.debug "%s Created dummy snapshot for mirror receive: %s" __FUNCTION__
+        (string_of_vdi_info dummy) ;
+      let _ : backend = Local.VDI.attach3 dbg leaf_dp sr leaf.vdi vm true in
+      Local.VDI.activate3 dbg leaf_dp sr leaf.vdi vm ;
+      let nearest =
+        List.fold_left
+          (fun acc content_id ->
+            match acc with
+            | Some _ ->
+                acc
+            | None -> (
+              try
+                Some
+                  (List.find
+                     (fun vdi ->
+                       vdi.content_id = content_id
+                       && vdi.virtual_size <= vdi_info.virtual_size
+                     )
+                     vdis
+                  )
+              with Not_found -> None
+            )
+          )
+          None similar
+      in
+      D.debug "Nearest VDI: content_id=%s vdi=%s"
+        (Option.fold ~none:"None" ~some:(fun x -> x.content_id) nearest)
+        (Option.fold ~none:"None"
+           ~some:(fun x -> Storage_interface.Vdi.string_of x.vdi)
+           nearest
+        ) ;
+      let parent =
+        match nearest with
+        | Some vdi ->
+            D.debug "Cloning VDI" ;
+            let vdi = add_to_sm_config vdi "base_mirror" id in
+            let vdi_clone = Local.VDI.clone dbg sr vdi in
+            D.debug "Clone: %s" (Storage_interface.Vdi.string_of vdi_clone.vdi) ;
+            ( if vdi_clone.virtual_size <> vdi_info.virtual_size then
+                let new_size =
+                  Local.VDI.resize dbg sr vdi_clone.vdi vdi_info.virtual_size
+                in
+                D.debug "Resize local clone VDI to %Ld: result %Ld"
+                  vdi_info.virtual_size new_size
+            ) ;
+            vdi_clone
+        | None ->
+            D.debug "Creating a blank remote VDI" ;
+            Local.VDI.create dbg sr vdi_info
+      in
+      D.debug "Parent disk content_id=%s" parent.content_id ;
+      State.add id
+        State.(
+          Recv_op
+            Receive_state.
+              {
+                sr
+              ; dummy_vdi= dummy.vdi
+              ; leaf_vdi= leaf.vdi
+              ; leaf_dp
+              ; parent_vdi= parent.vdi
+              ; remote_vdi= vdi_info.vdi
+              ; mirror_vm= vm
+              }
+        ) ;
+      let nearest_content_id = Option.map (fun x -> x.content_id) nearest in
+      Mirror.Vhd_mirror
+        {
+          Mirror.mirror_vdi= leaf
+        ; mirror_datapath= leaf_dp
+        ; copy_diffs_from= nearest_content_id
+        ; copy_diffs_to= parent.vdi
+        ; dummy_vdi= dummy.vdi
+        }
+    with e ->
+      List.iter
+        (fun op ->
+          try op ()
+          with e ->
+            D.debug "Caught exception in on_fail: %s" (Printexc.to_string e)
+        )
+        !on_fail ;
+      raise e
+
+  let receive_start _ctx ~dbg ~sr ~vdi_info ~id ~similar =
+    receive_start_common ~dbg ~sr ~vdi_info ~id ~similar ~vm:(Vm.of_string "0")
+
+  let receive_start2 _ctx ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+    receive_start_common ~dbg ~sr ~vdi_info ~id ~similar ~vm
+
+  let receive_finalize _ctx ~dbg ~id =
+    let recv_state = State.find_active_receive_mirror id in
+    let open State.Receive_state in
+    Option.iter (fun r -> Local.DP.destroy dbg r.leaf_dp false) recv_state ;
+    State.remove_receive_mirror id
+
+  let receive_finalize2 _ctx ~dbg ~id =
+    let recv_state = State.find_active_receive_mirror id in
+    let open State.Receive_state in
+    Option.iter
+      (fun r ->
+        SXM.info
+          "%s Mirror done. Compose on the dest sr %s parent %s and leaf %s"
+          __FUNCTION__ (Sr.string_of r.sr)
+          (Vdi.string_of r.parent_vdi)
+          (Vdi.string_of r.leaf_vdi) ;
+        Local.DP.destroy2 dbg r.leaf_dp r.sr r.leaf_vdi r.mirror_vm false ;
+        Local.VDI.compose dbg r.sr r.parent_vdi r.leaf_vdi ;
+        (* On SMAPIv3, compose would have removed the now invalid dummy vdi, so
+           there is no need to destroy it anymore, while this is necessary on SMAPIv1 SRs. *)
+        D.log_and_ignore_exn (fun () -> Local.VDI.destroy dbg r.sr r.dummy_vdi) ;
+        Local.VDI.remove_from_sm_config dbg r.sr r.leaf_vdi "base_mirror"
+      )
+      recv_state ;
+    State.remove_receive_mirror id
+
+  let receive_cancel _ctx ~dbg ~id =
+    let receive_state = State.find_active_receive_mirror id in
+    let open State.Receive_state in
+    Option.iter
+      (fun r ->
+        D.log_and_ignore_exn (fun () -> Local.DP.destroy dbg r.leaf_dp false) ;
+        List.iter
+          (fun v ->
+            D.log_and_ignore_exn (fun () -> Local.VDI.destroy dbg r.sr v)
+          )
+          [r.dummy_vdi; r.leaf_vdi; r.parent_vdi]
+      )
+      receive_state ;
+    State.remove_receive_mirror id
+end

--- a/ocaml/xapi/storage_smapiv1_migrate.mli
+++ b/ocaml/xapi/storage_smapiv1_migrate.mli
@@ -1,0 +1,17 @@
+(*
+ * Copyright (c) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module type SMAPIv2_MIRROR = Storage_interface.MIRROR
+
+module MIRROR : SMAPIv2_MIRROR

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1186,6 +1186,14 @@ functor
       module MIRROR = struct
         type context = unit
 
+        let u x =
+          raise Storage_interface.(Storage_error (Errors.Unimplemented x))
+
+        let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~mirror_vm:_
+            ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
+            ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
+          u "DATA.MIRROR.send_start"
+
         let receive_start context ~dbg ~sr ~vdi_info ~id ~similar =
           info "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s similar:[%s]" dbg
             (s_of_sr sr) id

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1186,24 +1186,6 @@ functor
       module MIRROR = struct
         type context = unit
 
-        let start context ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm ~url ~dest =
-          info "DATA.MIRROR.start dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg
-            (s_of_sr sr) (s_of_vdi vdi) url (s_of_sr dest) ;
-          Impl.DATA.MIRROR.start context ~dbg ~sr ~vdi ~dp ~mirror_vm ~copy_vm
-            ~url ~dest
-
-        let stop context ~dbg ~id =
-          info "DATA.MIRROR.stop dbg:%s id:%s" dbg id ;
-          Impl.DATA.MIRROR.stop context ~dbg ~id
-
-        let list context ~dbg =
-          info "DATA.MIRROR.active dbg:%s" dbg ;
-          Impl.DATA.MIRROR.list context ~dbg
-
-        let stat context ~dbg ~id =
-          info "DATA.MIRROR.stat dbg:%s id:%s" dbg id ;
-          Impl.DATA.MIRROR.stat context ~dbg ~id
-
         let receive_start context ~dbg ~sr ~vdi_info ~id ~similar =
           info "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s similar:[%s]" dbg
             (s_of_sr sr) id

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -1,0 +1,39 @@
+(*
+ * Copyright (c) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = "storage_smapiv1_migrate" end)
+
+module Unixext = Xapi_stdext_unix.Unixext
+module State = Storage_migrate_helper.State
+module SXM = Storage_migrate_helper.SXM
+
+module type SMAPIv2_MIRROR = Storage_interface.MIRROR
+
+module MIRROR : SMAPIv2_MIRROR = struct
+  type context = unit
+
+  let u x = raise Storage_interface.(Storage_error (Errors.Unimplemented x))
+
+  let send_start _ctx = u __FUNCTION__
+
+  let receive_start _ctx = u __FUNCTION__
+
+  let receive_start2 _ctx = u __FUNCTION__
+
+  let receive_finalize _ctx = u __FUNCTION__
+
+  let receive_finalize2 _ctx = u __FUNCTION__
+
+  let receive_cancel _ctx = u __FUNCTION__
+end

--- a/ocaml/xapi/storage_smapiv3_migrate.mli
+++ b/ocaml/xapi/storage_smapiv3_migrate.mli
@@ -1,0 +1,17 @@
+(*
+ * Copyright (c) Cloud Software Group
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module type SMAPIv2_MIRROR = Storage_interface.MIRROR
+
+module MIRROR : SMAPIv2_MIRROR


### PR DESCRIPTION
This is a continuation of #6378: the refactoring effort of SXM code.

To be continued...