### PR TITLE
CA-401023: Remove smapi observer config if smapi is set as experimental

### DIFF
--- a/ocaml/xapi/xapi_observer.ml
+++ b/ocaml/xapi/xapi_observer.ml
@@ -571,6 +571,14 @@ let initialise ~__context =
          |> observed_components_of
          |> List.iter (initialise_observer_component ~__context)
      ) ;
+  (* If SMApi is now experimental, manually remove the config as there is no observer to do it *)
+  if
+    Xapi_globs.(
+      StringSet.mem (to_string SMApi) !observer_experimental_components
+    )
+  then
+    Xapi_stdext_unix.Unixext.rm_rec (dir_name_of_component SMApi) ;
+
   Tracing_export.set_service_name "xapi"
 
 let set_hosts ~__context ~self ~value =


### PR DESCRIPTION
If smapi observer was previously enabled and then added to observer_experimental_components, when the toolstack is restarted the smapi observer will no longer exist. The observer will therefore not be "destroyed" by normal means so we must remove the config manually.

This is important for xapi-storage-script as it cannot read the DB and so relies on this config file to know whether to trace SMAPIv3 or not.