### PR TITLE
xapi_message: Implement proper expression handling in get_all_records_where

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8976,7 +8976,7 @@ module Message = struct
   let get_all_records_where =
     call ~name:"get_all_records_where"
       ~lifecycle:[(Published, rel_orlando, "")]
-      ~params:[(String, "expr", "The expression to match (not currently used)")]
+      ~params:[(String, "expr", "The expression to match")]
       ~flags:[`Session]
       ~result:(Map (Ref _message, Record _message), "The messages")
       ~allowed_roles:_R_READ_ONLY ()
@@ -10543,12 +10543,12 @@ let all_system =
 (**
    These are the pairs of (object, field) which are bound together in
    the database schema.
-   
+
    It is assumed that, for any entry (p, p'), neither p nor p'
    appears in any other entry. It may be the case that p = p', which
    is the only instance where some object-field pair may appear more
    than once.
-   
+
    This is implicitly assumed by other code which treats this list -
    and its symmetric closure - as an association list
    without duplicate keys. *)


### PR DESCRIPTION
Messages are not stored in the database, so their handling is done through Custom_actions. The custom implementation of get_all_records_where, in particular, used to ignore the query expression altogether (as if expr = true).

Expand the existing handler to evaluate the query and match against the messages retrieved and parsed from disk.

An alternative approach would have instead special cased filtering code in the database itself, but in my attempts this was awkward and duplicated quite a lot of code.

With this it is possible to filter messages properly now:
```
>>> session.xenapi.message.get_all_records_where('field "name" = "VM_STARTED"')
<list of messages with name = VM_STARTED>
>>> session.xenapi.message.get_all_records_where('field "name" = "VM_STARTED" and field "obj_uuid" = "3c61111f-1d67-7db4-95a5-f0287aff57bf"')
<list of messages with name = VM_STARTED and obj_uuid with such value>
```

Also update the documentation to match new behaviour.

Closes #6340