### PR TITLE
CP-52911: Negative scheduler for xapi threads.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -350,6 +350,7 @@
     astring
     base-threads
     base64
+    bechamel
     (bos :with-test)
     cdrom
     (clock (= :version))

--- a/ocaml/libs/http-lib/dune
+++ b/ocaml/libs/http-lib/dune
@@ -59,6 +59,7 @@
   tracing_propagator
   uri
   xapi-backtrace
+  xapi-consts
   xapi-log
   xapi-stdext-pervasives
   xapi-stdext-threads

--- a/ocaml/libs/http-lib/http.ml
+++ b/ocaml/libs/http-lib/http.ml
@@ -676,14 +676,6 @@ module Request = struct
     let headers, body = to_headers_and_body x in
     let frame_header = if x.frame then make_frame_header headers else "" in
     frame_header ^ headers ^ body
-
-  let with_originator_of req f =
-    Option.iter
-      (fun req ->
-        let originator = List.assoc_opt Hdr.originator req.additional_headers in
-        f originator
-      )
-      req
 end
 
 module Response = struct

--- a/ocaml/libs/http-lib/http.mli
+++ b/ocaml/libs/http-lib/http.mli
@@ -129,8 +129,6 @@ module Request : sig
 
   val to_wire_string : t -> string
   (** [to_wire_string t] returns a string which could be sent to a server *)
-
-  val with_originator_of : t option -> (string option -> unit) -> unit
 end
 
 (** Parsed form of the HTTP response *)
@@ -229,6 +227,8 @@ module Hdr : sig
 
   val hsts : string
   (** Header used for HTTP Strict Transport Security *)
+
+  val originator : string
 end
 
 val output_http : Unix.file_descr -> string list -> unit

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -577,10 +577,15 @@ let handle_connection ~header_read_timeout ~header_total_timeout
 
     Constants.when_tgroups_enabled (fun () ->
         Http.Request.with_originator_of req (fun originator ->
-            let _ : Tgroup.Group.t option =
-              originator |> Tgroup.of_req_originator
-            in
-            ()
+            let open Xapi_stdext_threads.Threadext in
+            originator
+            |> Tgroup.of_req_originator
+            |> Option.iter (fun tgroup ->
+                   ThreadRuntimeContext.get ()
+                   |> ThreadRuntimeContext.update (fun thread_ctx ->
+                          {thread_ctx with tgroup}
+                      )
+               )
         )
     ) ;
 

--- a/ocaml/libs/http-lib/http_svr.ml
+++ b/ocaml/libs/http-lib/http_svr.ml
@@ -575,7 +575,14 @@ let handle_connection ~header_read_timeout ~header_total_timeout
         ~max_length:max_header_length ss
     in
 
-    Http.Request.with_originator_of req Tgroup.of_req_originator ;
+    Constants.when_tgroups_enabled (fun () ->
+        Http.Request.with_originator_of req (fun originator ->
+            let _ : Tgroup.Group.t option =
+              originator |> Tgroup.of_req_originator
+            in
+            ()
+        )
+    ) ;
 
     (* 2. now we attempt to process the request *)
     let finished =

--- a/ocaml/libs/tgroup/dune
+++ b/ocaml/libs/tgroup/dune
@@ -2,7 +2,12 @@
  (name tgroup)
  (modules tgroup)
  (public_name tgroup)
- (libraries xapi-log xapi-stdext-unix xapi-stdext-std))
+ (libraries
+   xapi-log
+   xapi-stdext-pervasives
+   xapi-stdext-unix
+   xapi-stdext-std)
+)
 
 (test
  (name test_tgroup)

--- a/ocaml/libs/tgroup/test_tgroup.ml
+++ b/ocaml/libs/tgroup/test_tgroup.ml
@@ -20,7 +20,7 @@ let test_identity () =
 
   let test_make ((user_agent, subject_sid), expected_identity) =
     let actual_identity =
-      Tgroup.Group.Identity.(make ?user_agent subject_sid |> to_string)
+      Tgroup.Description.Identity.(make ?user_agent subject_sid |> to_string)
     in
     Alcotest.(check string)
       "Check expected identity" expected_identity actual_identity
@@ -29,28 +29,28 @@ let test_identity () =
 
 let test_of_creator () =
   let dummy_identity =
-    Tgroup.Group.Identity.make ~user_agent:"XenCenter2024" "root"
+    Tgroup.Description.Identity.make ~user_agent:"XenCenter2024" "root"
   in
   let specs =
     [
       ((None, None, None, None), "external/unauthenticated")
     ; ((Some true, None, None, None), "external/intrapool")
     ; ( ( Some true
-        , Some Tgroup.Group.Endpoint.External
+        , Some Tgroup.Description.Endpoint.External
         , Some dummy_identity
         , Some "sm"
         )
       , "external/intrapool"
       )
     ; ( ( Some true
-        , Some Tgroup.Group.Endpoint.Internal
+        , Some Tgroup.Description.Endpoint.Internal
         , Some dummy_identity
         , Some "sm"
         )
       , "external/intrapool"
       )
     ; ( ( None
-        , Some Tgroup.Group.Endpoint.Internal
+        , Some Tgroup.Description.Endpoint.Internal
         , Some dummy_identity
         , Some "cli"
         )
@@ -62,9 +62,11 @@ let test_of_creator () =
     ]
   in
   let test_make ((intrapool, endpoint, identity, originator), expected_group) =
-    let originator = Option.map Tgroup.Group.Originator.of_string originator in
+    let originator =
+      Option.map Tgroup.Description.Originator.of_string originator
+    in
     let actual_group =
-      Tgroup.Group.(
+      Tgroup.Description.(
         Creator.make ?intrapool ?endpoint ?identity ?originator ()
         |> of_creator
         |> to_string

--- a/ocaml/libs/tgroup/tgroup.mli
+++ b/ocaml/libs/tgroup/tgroup.mli
@@ -94,22 +94,22 @@ module Cgroup : sig
 
   val dir_of : Group.t -> t option
   (** [dir_of group] returns the full path of the cgroup directory corresponding
-          to the group [group] as [Some dir].
+      to the group [group] as [Some dir].
 
-          Returns [None] if [init dir] has not been called. *)
-
-  val init : string -> unit
-  (** [init dir] initializes the hierachy of cgroups associated to all [Group.t]
-          types under the directory [dir].*)
+      Returns [None] if [init dir] has not been called. *)
 
   val set_cgroup : Group.Creator.t -> unit
   (** [set_cgroup c] sets the current xapi thread in a cgroup based on the
-          creator [c].*)
+      creator [c].*)
 end
 
-val of_creator : Group.Creator.t -> unit
+val init : string -> unit
+(** [init dir] initializes the hierachy of cgroups and tgroups associated to
+    all [Group.t] types under the directory [dir].*)
+
+val of_creator : Group.Creator.t -> Group.t
 (** [of_creator g] classifies the current thread based based on the creator [c].*)
 
-val of_req_originator : string option -> unit
+val of_req_originator : string option -> Group.t option
 (** [of_req_originator o] same as [of_creator] but it classifies based on the
     http request header.*)

--- a/ocaml/libs/timeslice/dune
+++ b/ocaml/libs/timeslice/dune
@@ -1,5 +1,14 @@
 (library
-	(name xapi_timeslice)
-	(package xapi-idl)
- 	(libraries threads.posix mtime mtime.clock.os xapi-log)
+  (name xapi_timeslice)
+  (package xapi-idl)
+  (libraries
+    bechamel.monotonic_clock
+    threads.posix
+    tgroup
+    mtime
+    mtime.clock.os
+    xapi-consts
+    xapi-log
+    xapi-stdext-unix
+    xapi-stdext-threads)
 )

--- a/ocaml/libs/timeslice/timeslice.ml
+++ b/ocaml/libs/timeslice/timeslice.ml
@@ -31,24 +31,165 @@ let[@inline always] am_i_holding_locks () =
   let last = Atomic.get last_lock_holder in
   last <> invalid_holder && last = me ()
 
-let yield_interval = Atomic.make Mtime.Span.zero
+let yield_interval = Atomic.make 0
 
 (* TODO: use bechamel.monotonic-clock instead, which has lower overhead,
    but not in the right place in xs-opam yet
 *)
-let last_yield = Atomic.make (Mtime_clock.counter ())
+let last_yield = Atomic.make 0
+
+let thread_last_yield = Atomic.make 0
 
 let failures = Atomic.make 0
+
+let[@inline always] with_time_counter_now time_counter f args =
+  let now = Monotonic_clock.now () |> Int64.to_int in
+  Atomic.set time_counter now ;
+  f args
+
+module Runtime = struct
+  let epoch_count = Atomic.make 0
+
+  let maybe_thread_yield ~global_slice_period =
+    let open Xapi_stdext_threads.Threadext in
+    let thread_ctx = ThreadRuntimeContext.get () in
+    let tgroup = thread_ctx.tgroup |> Tgroup.group_of_description in
+    match tgroup with
+    | None ->
+        ()
+    | Some tgroup ->
+        let current_epoch = Atomic.get epoch_count in
+        ( if current_epoch <> thread_ctx.tepoch then
+            (* thread remembers that it is about to run in a new epoch *)
+            let () = thread_ctx.time_running <- 0 in
+            thread_ctx.tepoch <- current_epoch
+          else
+            (* thread remembers how long it is  running  in the current epoch *)
+            let time_running_since_last_yield =
+              (Monotonic_clock.now () |> Int64.to_int)
+              - Atomic.get thread_last_yield
+            in
+            let time_running =
+              thread_ctx.time_running + time_running_since_last_yield
+            in
+            thread_ctx.time_running <- time_running
+        ) ;
+
+        let sleep_or_yield sleep_time (tgroup : Tgroup.t) =
+          (*todo: do not sleep if this is the last thread in the tgroup(s) *)
+          if tgroup.group_descr = Tgroup.Description.authenticated_root then
+            with_time_counter_now thread_last_yield Thread.yield ()
+          else
+            with_time_counter_now thread_last_yield Unix.sleepf sleep_time
+        in
+        let is_to_sleep_or_yield delay_s =
+          if delay_s > 0. then
+            Tgroup.with_one_fewer_thread_in_tgroup tgroup
+              (sleep_or_yield delay_s)
+        in
+
+        (* fair scheduling decision to check if thread time_running has exceeded
+           tgroup-mandated ideal time per thread *)
+        if thread_ctx.time_running > tgroup.time_ideal then
+          let since_last_global_slice =
+            (Monotonic_clock.now () |> Int64.to_int) - Atomic.get last_yield
+          in
+          let until_next_global_slice =
+            if since_last_global_slice < global_slice_period then
+              global_slice_period - since_last_global_slice
+            else
+              0
+          in
+          let thread_delay_s =
+            (until_next_global_slice |> float_of_int) *. 1e-9
+          in
+          is_to_sleep_or_yield thread_delay_s
+
+  let incr_epoch ~frequency =
+    let epoch = epoch_count |> Atomic.get in
+    if epoch mod frequency = 0 then
+      Atomic.set epoch_count 1
+    else
+      Atomic.incr epoch_count
+
+  let sched_global_slice ~global_slice_period =
+    (*refresh the eopch counter roughly every 10s for timeslices of 10ms*)
+    incr_epoch ~frequency:1024 ;
+
+    (* goal is to recalculate thread.time_ideal for each thread: *)
+    (* 1) fairness: each thread group get the same amount of time inside the slice  *)
+    (* 2) control : each thread group time is then weighted by its tgroup_share     *)
+    (* 3) delegate: later, asynchronously, each thread decides to maybe yield based
+       on its thread group idea of ideal time per thread *)
+    (* delegation via tgroups minimizes the number of synchronous global writes
+       here from O(threads) to O(groups) *)
+    let time_ideal_of_tgroups groups =
+      Tgroup.(
+        let group_share_total =
+          groups |> List.fold_left (fun xs x -> x.tgroup_share + xs) 0
+        in
+        groups
+        |> List.iter (fun g ->
+               let group_share_ratio =
+                 match group_share_total with
+                 | 0 ->
+                     0.
+                 | gst ->
+                     (g.tgroup_share |> float_of_int) /. (gst |> float_of_int)
+               in
+               let group_time_ns =
+                 group_share_ratio *. (global_slice_period |> float_of_int)
+               in
+               let thread_time_ideal =
+                 match g.thread_count |> Atomic.get with
+                 | 0 ->
+                     0.
+                 | gnt ->
+                     group_time_ns /. (gnt |> float_of_int)
+               in
+               g.time_ideal <- thread_time_ideal |> int_of_float
+           )
+      )
+    in
+    let tgroups_with_threads =
+      List.fold_left
+        (fun xs x ->
+          if x.Tgroup.thread_count |> Atomic.get > 0 then
+            x :: xs
+          else
+            xs
+        )
+        [] (Tgroup.tgroups ())
+    in
+    (* reserve cpu time only to tgroups that have threads to run at the moment *)
+    tgroups_with_threads |> time_ideal_of_tgroups
+end
 
 let periodic_hook (_ : Gc.Memprof.allocation) =
   let () =
     try
-      if not (am_i_holding_locks ()) then
-        let elapsed = Mtime_clock.count (Atomic.get last_yield) in
-        if Mtime.Span.compare elapsed (Atomic.get yield_interval) > 0 then (
-          let now = Mtime_clock.counter () in
-          Atomic.set last_yield now ; Thread.yield ()
-        )
+      let yield_interval = Atomic.get yield_interval in
+      if !Constants.tgroups_enabled && !Constants.runtime_sched then
+        if not (am_i_holding_locks ()) then
+          let elapsed =
+            (Monotonic_clock.now () |> Int64.to_int) - Atomic.get last_yield
+          in
+          if elapsed > yield_interval then (
+            let now = Monotonic_clock.now () |> Int64.to_int in
+            Atomic.set last_yield now ;
+            Atomic.set thread_last_yield now ;
+            Runtime.sched_global_slice ~global_slice_period:yield_interval ;
+            Thread.yield ()
+          ) else
+            Runtime.maybe_thread_yield ~global_slice_period:yield_interval
+        else
+          ()
+      else if not (am_i_holding_locks ()) then
+        let elapsed =
+          (Monotonic_clock.now () |> Int64.to_int) - Atomic.get last_yield
+        in
+        if elapsed > yield_interval then
+          with_time_counter_now last_yield Thread.yield ()
     with _ ->
       (* It is not safe to raise exceptions here, it'd require changing all code to be safe to asynchronous interrupts/exceptions,
          see https://guillaume.munch.name/software/ocaml/memprof-limits/index.html#isolation
@@ -63,10 +204,9 @@ let periodic =
     {null_tracker with alloc_minor= periodic_hook; alloc_major= periodic_hook}
 
 let set ?(sampling_rate = 1e-4) interval =
-  Atomic.set yield_interval
-    (Mtime.Span.of_float_ns @@ (interval *. 1e9) |> Option.get) ;
+  Atomic.set yield_interval (interval *. 1e9 |> int_of_float) ;
   Gc.Memprof.start ~sampling_rate ~callstack_size:0 periodic
 
 let clear () =
   Gc.Memprof.stop () ;
-  Atomic.set yield_interval Mtime.Span.zero
+  Atomic.set yield_interval 0

--- a/ocaml/libs/timeslice/timeslice.mli
+++ b/ocaml/libs/timeslice/timeslice.mli
@@ -42,3 +42,9 @@ val lock_acquired : unit -> unit
 
 val lock_released : unit -> unit
 (** [lock_acquired ()] notifies about lock release. *)
+
+module Runtime : sig
+  val maybe_thread_yield : global_slice_period:int -> unit
+
+  val sched_global_slice : global_slice_period:int -> unit
+end

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.ml
@@ -104,7 +104,7 @@ module ThreadRuntimeContext = struct
     ; thread_name: string
     ; mutable time_running: int
     ; mutable tepoch: int
-    ; tgroup: Tgroup.Group.t
+    ; tgroup: Tgroup.Description.t
   }
 
   (*The documentation for Ambient_context_thread_local isn't really clear is
@@ -117,7 +117,7 @@ module ThreadRuntimeContext = struct
     let ocaml_tid = Thread.self () |> Thread.id in
     let time_running = 0 in
     let tepoch = 0 in
-    let tgroup = Tgroup.Group.authenticated_root in
+    let tgroup = Tgroup.Description.authenticated_root in
     let tls = {thread_name; tgroup; ocaml_tid; time_running; tepoch} in
     let () =
       Ambient_context_thread_local.Thread_local.set thread_local_storage tls

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-threads/threadext.mli
@@ -50,7 +50,7 @@ module ThreadRuntimeContext : sig
     ; thread_name: string
     ; mutable time_running: int
     ; mutable tepoch: int
-    ; tgroup: Tgroup.Group.t
+    ; tgroup: Tgroup.Description.t
   }
 
   val create : ?thread_name:string -> unit -> t

--- a/ocaml/tests/bench/bench_timeslice.ml
+++ b/ocaml/tests/bench/bench_timeslice.ml
@@ -1,0 +1,70 @@
+open Bechamel
+
+let test_maybe_thread_yield () =
+  Sys.opaque_identity
+    (Xapi_timeslice.Timeslice.Runtime.maybe_thread_yield
+       ~global_slice_period:10_000_000
+    )
+
+let test_sched_global_slice () =
+  Sys.opaque_identity
+    (Xapi_timeslice.Timeslice.Runtime.sched_global_slice
+       ~global_slice_period:10_000_000
+    )
+
+let test_tgroups_on ~name f =
+  let allocate () =
+    let () = Atomic.set Tgroup.Cgroup.cgroup_dir (Some "") in
+    let g_cli = Some "cli" |> Tgroup.of_req_originator |> Option.get in
+    let () = Tgroup.add g_cli in
+    let tg_cli = Tgroup.group_of_description g_cli |> Option.get in
+    let _ = Atomic.fetch_and_add tg_cli.thread_count 10 in
+    let () = Tgroup.add Tgroup.Description.authenticated_root in
+    let tg_authenticated_root =
+      Tgroup.group_of_description Tgroup.Description.authenticated_root
+      |> Option.get
+    in
+    let _ = Atomic.fetch_and_add tg_authenticated_root.thread_count 5 in
+    ()
+  in
+  let free = Tgroup.destroy in
+  Test.make_with_resource ~name ~allocate ~free Test.uniq f
+
+let test_with_thread_classified ~name f =
+  let allocate () =
+    let () = Atomic.set Tgroup.Cgroup.cgroup_dir (Some "") in
+    let g_cli = Some "cli" |> Tgroup.of_req_originator |> Option.get in
+    let () = Tgroup.add g_cli in
+    let tg_cli = Tgroup.group_of_description g_cli |> Option.get in
+    let _ = Atomic.fetch_and_add tg_cli.thread_count 10 in
+    let () = Tgroup.add Tgroup.Description.authenticated_root in
+    let tg_authenticated_root =
+      Tgroup.group_of_description Tgroup.Description.authenticated_root
+      |> Option.get
+    in
+    let () = Atomic.incr tg_authenticated_root.thread_count in
+    Xapi_stdext_threads.Threadext.ThreadRuntimeContext.(
+      let thread_ctx = get () in
+      update
+        (fun thread_ctx ->
+          {thread_ctx with tgroup= Tgroup.Description.authenticated_root}
+        )
+        thread_ctx
+    )
+  in
+  let free () =
+    Tgroup.destroy () ;
+    Xapi_stdext_threads.Threadext.ThreadRuntimeContext.remove ()
+  in
+  Test.make_with_resource ~name ~allocate ~free Test.uniq f
+
+let benchmarks =
+  Test.make_grouped ~name:"timeslice"
+    [
+      test_with_thread_classified ~name:"maybe_thread_yield"
+        (Staged.stage test_maybe_thread_yield)
+    ; test_tgroups_on ~name:"sched_global_slice"
+        (Staged.stage test_sched_global_slice)
+    ]
+
+let () = Bechamel_simple_cli.cli benchmarks

--- a/ocaml/tests/bench/dune
+++ b/ocaml/tests/bench/dune
@@ -1,5 +1,6 @@
 (executables
  (names
+  bench_timeslice
   bench_tracing
   bench_uuid
   bench_throttle2
@@ -10,6 +11,7 @@
   bechamel
   bechamel-notty
   notty.unix
+  tgroup
   tracing_export
   threads.posix
   fmt
@@ -18,4 +20,6 @@
   xapi_aux
   tests_common
   log
-  xapi_internal))
+  xapi_internal
+  xapi_timeslice
+  xapi-stdext-threads))

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -422,3 +422,5 @@ let observer_components_all =
 let tgroups_enabled = ref false
 
 let when_tgroups_enabled f = if !tgroups_enabled then f () else ()
+
+let runtime_sched = ref false

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -434,8 +434,8 @@ let make_rpc ~__context rpc : Rpc.response =
       in
       let originator =
         thread_ctx.tgroup
-        |> Tgroup.Group.get_originator
-        |> Tgroup.Group.Originator.to_string
+        |> Tgroup.Description.get_originator
+        |> Tgroup.Description.Originator.to_string
       in
       let additional_headers =
         ("originator", originator) :: http.additional_headers

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -163,7 +163,8 @@ let do_dispatch ?session_id ?forward_op ?self:_ supports_async called_fn_name
               )
           with _ -> None
         in
-        Tgroup.of_creator (Tgroup.Group.Creator.make ?identity ())
+        let _ = Tgroup.of_creator (Tgroup.Group.Creator.make ?identity ()) in
+        ()
     ) ;
 
     let sync () =

--- a/ocaml/xapi/server_helpers.ml
+++ b/ocaml/xapi/server_helpers.ml
@@ -163,8 +163,20 @@ let do_dispatch ?session_id ?forward_op ?self:_ supports_async called_fn_name
               )
           with _ -> None
         in
-        let _ = Tgroup.of_creator (Tgroup.Group.Creator.make ?identity ()) in
-        ()
+        let tgroup =
+          Tgroup.of_creator (Tgroup.Group.Creator.make ?identity ())
+        in
+        let open Xapi_stdext_threads.Threadext in
+        let thread_ctx = ThreadRuntimeContext.get () in
+        (* authenticated_root here should mean a group has not been set yet and
+           we should set one. otherwise go with what has already been set.*)
+        if
+          thread_ctx.tgroup = Tgroup.Group.authenticated_root
+          || thread_ctx.tgroup = Tgroup.Group.unauthenticated
+        then
+          ThreadRuntimeContext.update
+            (fun thread_ctx -> {thread_ctx with tgroup})
+            thread_ctx
     ) ;
 
     let sync () =

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1063,7 +1063,7 @@ let server_init () =
             , []
             , fun () ->
                 Constants.when_tgroups_enabled @@ fun () ->
-                Tgroup.Cgroup.init Xapi_globs.xapi_requests_cgroup
+                Tgroup.init Xapi_globs.xapi_requests_cgroup
             )
           ; ( "Registering SMAPIv1 plugins"
             , [Startup.OnlyMaster]

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1726,6 +1726,11 @@ let other_options =
     , (fun () -> string_of_bool !Constants.tgroups_enabled)
     , "Turn on tgroups classification"
     )
+  ; ( "runtime-sched"
+    , Arg.Set Constants.runtime_sched
+    , (fun () -> string_of_bool !Constants.tgroups_enabled)
+    , "Turn on tgroups classification"
+    )
   ; event_from_entry
   ; event_from_task_entry
   ; event_next_entry

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -745,7 +745,10 @@ let consider_touching_session rpc session_id =
 let slave_login_common ~__context ~host_str ~psecret =
   Context.with_tracing ~__context __FUNCTION__ @@ fun __context ->
   Constants.when_tgroups_enabled (fun () ->
-      Tgroup.of_creator (Tgroup.Group.Creator.make ~intrapool:true ())
+      let _ =
+        Tgroup.of_creator (Tgroup.Group.Creator.make ~intrapool:true ())
+      in
+      ()
   ) ;
 
   if not (Helpers.PoolSecret.is_authorized psecret) then (
@@ -944,8 +947,11 @@ let login_with_password ~__context ~uname ~pwd ~version:_ ~originator =
       (* in this case, the context origin of this login request is a unix socket bound locally to a filename *)
       (* we trust requests from local unix filename sockets, so no need to authenticate them before login *)
       Constants.when_tgroups_enabled (fun () ->
-          Tgroup.of_creator
-            Tgroup.Group.(Creator.make ~identity:Identity.root_identity ())
+          let _ =
+            Tgroup.of_creator
+              Tgroup.Group.(Creator.make ~identity:Identity.root_identity ())
+          in
+          ()
       ) ;
 
       login_no_password_common ~__context ~uname:(Some uname) ~originator
@@ -994,8 +1000,11 @@ let login_with_password ~__context ~uname ~pwd ~version:_ ~originator =
             (Context.get_origin __context) ;
 
           Constants.when_tgroups_enabled (fun () ->
-              Tgroup.of_creator
-                Tgroup.Group.(Creator.make ~identity:Identity.root_identity ())
+              let _ =
+                Tgroup.of_creator
+                  Tgroup.Group.(Creator.make ~identity:Identity.root_identity ())
+              in
+              ()
           ) ;
 
           login_no_password_common ~__context ~uname:(Some uname) ~originator
@@ -1295,12 +1304,15 @@ let login_with_password ~__context ~uname ~pwd ~version:_ ~originator =
               in
 
               Constants.when_tgroups_enabled (fun () ->
-                  Tgroup.of_creator
-                    Tgroup.Group.(
-                      Creator.make
-                        ~identity:(Identity.make subject_identifier)
-                        ()
-                    )
+                  let _ =
+                    Tgroup.of_creator
+                      Tgroup.Group.(
+                        Creator.make
+                          ~identity:(Identity.make subject_identifier)
+                          ()
+                      )
+                  in
+                  ()
               ) ;
 
               login_no_password_common ~__context ~uname:(Some uname)

--- a/opam/xapi.opam
+++ b/opam/xapi.opam
@@ -16,6 +16,7 @@ depends: [
   "astring"
   "base-threads"
   "base64"
+  "bechamel"
   "bos" {with-test}
   "cdrom"
   "clock" {= version}


### PR DESCRIPTION
This is a bit complex and it makes use of a few recently added changes:
- Thread Classification using `ocaml\libs\tgroups`;
- Thread Local Storage from `xapi-stdext-threads\threadsext`;
- ocaml's global timeslice configuration `ocaml\libs\timeslice`.

Summary:

We want a fair scheduling of different xapi threads, corresponding to the share allocated for each thread class inside `tgroup.ml`, but we cannot give more time to threads before the kernel decides to schedule a different one. Instead, we take away time from threads that have been running for longer than their defined share. This is achieved by a combination of yielding and sleeping depending on the thread class. `Unix.sleelpf` is used to throttle the requests from `xe` while critical working threads are just yielding more often. 

1. Every global timeslice we want to yield and start calculating the ideal times for the next epoch. The resulting values are stored in `Tgroup.ThreadGroups`. At this step we also reset the time counters. We also increment the epoch counter.
2. Every time we hit the periodic hook, we update the time running for the current thread inside the epoch. If the time running has exceeded the expected ideal time, we decide if we want to yield or sleep for the remain time in the current timeslice epoch.
If the time is exceeded, we also reset the counter for the thread_last_yield. This would give a good approximation for how long the next thread has been running.

The ideal time is calculated pretty straight forward: we look at ThreadGroups with more than 1 thread running. We add up the shares, updating the new total share, we normalize each share and we used the results as weights to get the ideal time for this ThreadGroup. The ideal time for the individual thread is the time for the ThreadGroup divided by the number of threads tunning inside the respective class.
  
This behaviour is behind 2 flags and both need to be enabled for this to take place. `tgroups-enabled` and `runtime-sched`.

Results:
While timing `vm starts` under different loads of `xe vm-list`, I managed to get the following results for different timeslices:

![image](https://github.com/user-attachments/assets/f07f0704-afe2-4e30-b5dc-c4a87c162998)

In the above, negative percentage are the improvement in time compared with the version without negative scheduling but under the same load and using the same timeslice values.

and these are the absolute vm start times in seconds under loads (with this configuration):
![image](https://github.com/user-attachments/assets/d829e49b-dc7d-4778-b0a6-c90f87536f77)

For this, results, I used slightly more skewed shares to illustrate that under load the amount of time to start a VM is can be close to that of starting a VM without a load. And the results are best visible when the load and test and clearly separable in terms of threads classification.   

This is on top of `ThreadLocalStorage` PR, https://github.com/xapi-project/xen-api/pull/6354.

Note: this will probably need changes to `xs-opam` (bechamel.monotonic_clock).