### PR TITLE
CP-54138: Sync SSH status during XAPI startup

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -380,5 +380,10 @@ let update_env __context sync_keys =
       Create_misc.create_chipset_info ~__context info
   ) ;
   switched_sync Xapi_globs.sync_gpus (fun () -> Xapi_pgpu.update_gpus ~__context) ;
+  switched_sync Xapi_globs.sync_ssh_status (fun () ->
+      let ssh_service = !Xapi_globs.ssh_service in
+      let status = Fe_systemctl.is_active ~service:ssh_service in
+      Db.Host.set_ssh_enabled ~__context ~self:localhost ~value:status
+  ) ;
 
   remove_pending_guidances ~__context

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -368,6 +368,8 @@ let sync_bios_strings = "sync_bios_strings"
 
 let sync_chipset_info = "sync_chipset_info"
 
+let sync_ssh_status = "sync_ssh_status"
+
 let sync_pci_devices = "sync_pci_devices"
 
 let sync_gpus = "sync_gpus"

--- a/ocaml/xapi/xapi_host.mli
+++ b/ocaml/xapi/xapi_host.mli
@@ -577,3 +577,6 @@ val set_ssh_enabled_timeout :
 
 val set_console_idle_timeout :
   __context:Context.t -> self:API.ref_host -> value:int64 -> unit
+
+val schedule_disable_ssh_job :
+  __context:Context.t -> self:API.ref_host -> timeout:int64 -> unit


### PR DESCRIPTION
 - Ensure `host.ssh_enabled ` reflects the actual SSH service state on startup, in case it was manually changed by the user.

 - Reschedule the "disable SSH" job if:
   - `host.ssh_enabled_timeout` is set to a positive value, and
   - `host.ssh_expiry` is in the future.