### PR TITLE
IPv6 IPs in host certificates

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -412,12 +412,23 @@ module Interface = struct
                 Ip.set_ipv6_link_local_addr name
               )
           | DHCP6 ->
+              let gateway =
+                Option.fold ~none:[]
+                  ~some:(fun n -> [`gateway n])
+                  !config.gateway_interface
+              in
+              let dns =
+                Option.fold ~none:[]
+                  ~some:(fun n -> [`dns n])
+                  !config.dns_interface
+              in
               if Dhclient.is_running ~ipv6:true name then
                 ignore (Dhclient.stop ~ipv6:true name) ;
               Sysctl.set_ipv6_autoconf name false ;
               Ip.flush_ip_addr ~ipv6:true name ;
               Ip.set_ipv6_link_local_addr name ;
-              ignore (Dhclient.ensure_running ~ipv6:true name [])
+              let options = gateway @ dns in
+              ignore (Dhclient.ensure_running ~ipv6:true name options)
           | Autoconf6 ->
               if Dhclient.is_running ~ipv6:true name then
                 ignore (Dhclient.stop ~ipv6:true name) ;

--- a/ocaml/xapi-aux/networking_info.mli
+++ b/ocaml/xapi-aux/networking_info.mli
@@ -14,15 +14,32 @@ val get_hostname : unit -> string
 (** [get_hostname ()] returns the hostname as returned by Unix.gethostname.
     If there is an error "" is returned. *)
 
-exception Unexpected_address_type of string
+type management_ip_error =
+  | Interface_missing
+  | Unexpected_address_type of string
+  | IP_missing
+  | Other of exn
+
+val management_ip_error_to_string : management_ip_error -> string
+(** [management_ip_error err] returns a string representation of [err], useful
+    only for logging. *)
 
 val dns_names : unit -> string list
 (** [dns_names ()] returns a list of the hostnames that the host may have.
     Ignores empty names as well as "localhost" *)
 
+val get_management_ip_addrs :
+  dbg:string -> (Ipaddr.t list * Ipaddr.t list, management_ip_error) Result.t
+(** [get_management_ip_addr ~dbg] returns IPs of the management network.
+    The addresses are returned in order of preference, the left-mostr ones are
+    preferred *)
+
 val get_management_ip_addr : dbg:string -> (string * Cstruct.t) option
-(** [get_management_ip_addr ~dbg] returns the IP of the management network.
-    If the system does not have management address None is return.
-    [Unexpected_address_type] is raised if there is an unexpected address is
-    stored. The address is return in two formats: human-readable string and
-    its bytes representation. *)
+(** [get_management_ip_addr ~dbg] returns the preferred IP of the management
+    network, or None. *)
+
+val get_host_certificate_subjects :
+     dbg:string
+  -> (string * string list * Cstruct.t list, management_ip_error) Result.t
+(** [get_host_certificate_subjects ~dbg] returns the main, dns names and ip
+    addresses that identify the host in secure connections. *)

--- a/ocaml/xapi-aux/networking_info.mli
+++ b/ocaml/xapi-aux/networking_info.mli
@@ -24,6 +24,9 @@ val management_ip_error_to_string : management_ip_error -> string
 (** [management_ip_error err] returns a string representation of [err], useful
     only for logging. *)
 
+val ipaddr_to_cstruct : Ipaddr.t -> Cstruct.t
+(** [ipaddr_to_cstruct ip] returns the binary representation of [ip] *)
+
 val dns_names : unit -> string list
 (** [dns_names ()] returns a list of the hostnames that the host may have.
     Ignores empty names as well as "localhost" *)


### PR DESCRIPTION
Adds IPv6 addresses to host certificates when their management interfaces are configured to use that.

I've tested manually on IPv4-only hosts, and the certificates are generated in the same way as before.
I've run the smoke and verification tests (Suite Run 215863), all of them passed

@last-genius you probably want to test these changes, run `openssl x509 -text -in /etc/xensource/xapi-ssl.pem` on a dual host, and see that it contains the IPv6 and IPv4 addresses.