### PR TITLE
Miscellaneous IPv6 fixes and cleanup

### DIFF
--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -760,9 +760,9 @@ let check_network_reset () =
     ) ;
     (* Remove trigger file *)
     Unix.unlink Xapi_globs.network_reset_trigger
-  with _ -> ()
-
-(* TODO: catch specific exception for missing fields in reset_file and inform user *)
+  with e ->
+    D.error "%s: exception: %s (%s)" __FUNCTION__ (Printexc.to_string e)
+      (Printexc.get_backtrace ())
 
 (** Make sure our license is set correctly *)
 let handle_licensing () =

--- a/python3/bin/xe-reset-networking
+++ b/python3/bin/xe-reset-networking
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         f = open(pool_conf, 'r')
         try:
             l = f.readline()
-            ls = l.split(':')
+            ls = l.split(':', maxsplit=1)
             if ls[0].strip() == 'master':
                 master = True
                 address = 'localhost'


### PR DESCRIPTION
With this PR, `xapi` and `xcp-networkd` now properly handle emergency network resets on an IPv6-only host (when it's an individual host as well as when it's in a pool as a supporter and as a coordinator)

Tested manually, see also the required `xsconsole` PR: https://github.com/xapi-project/xsconsole/pull/55.