### PR TITLE
Makefile: install tgroup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ DUNE_IU_PACKAGES1+=gzip http-lib pciutil sexpr stunnel uuid xml-light2 zstd xapi
 DUNE_IU_PACKAGES1+=message-switch message-switch-cli message-switch-core message-switch-lwt
 DUNE_IU_PACKAGES1+=message-switch-unix xapi-idl xapi-forkexecd xapi-storage xapi-storage-script xapi-storage-cli
 DUNE_IU_PACKAGES1+=xapi-nbd varstored-guard xapi-log xapi-open-uri xapi-tracing xapi-tracing-export xapi-expiry-alerts cohttp-posix
-DUNE_IU_PACKAGES1+=xapi-rrd xapi-inventory clock xapi-sdk
+DUNE_IU_PACKAGES1+=xapi-rrd xapi-inventory clock xapi-sdk tgroup
 DUNE_IU_PACKAGES1+=xapi-stdext-encodings xapi-stdext-pervasives xapi-stdext-std xapi-stdext-threads xapi-stdext-unix xapi-stdext-zerocheck xapi-tools
 
 


### PR DESCRIPTION
It is now a dependency of Threadext, which causes linking to fail if this isn't installed.
Only a problem when RPM is used, not when OPAM is used.