### PR TITLE
xapi_guest_agent: Update xenstore keys for Windows PV drivers versions

### DIFF
--- a/ocaml/tests/test_guest_agent.ml
+++ b/ocaml/tests/test_guest_agent.ml
@@ -285,6 +285,7 @@ module Initial_guest_metrics = Generic.MakeStateless (struct
       Xapi_guest_agent.get_initial_guest_metrics (lookup tree) (list tree)
     in
     guest_metrics.Xapi_guest_agent.networks
+    @ guest_metrics.Xapi_guest_agent.pv_drivers_version
 
   let tests =
     `QuickAndAutoDocumented
@@ -464,6 +465,33 @@ module Initial_guest_metrics = Generic.MakeStateless (struct
           ; ("xenserver/attr/net-sriov-vf/0/ipv4/1", "192.168.0.1")
           ]
         , []
+        )
+      ; (* windows pv driver versions parsing *)
+        ( [
+            ("drivers/0", "XenServer XENBUS 9.1.9.105 ")
+          ; ("drivers/1", "XenServer XENVBD 9.1.8.79 ")
+          ; ("drivers/2", "XenServer XENVIF 9.1.12.101 ")
+          ; ("drivers/3", "XenServer XENIFACE 9.1.10.87 ")
+          ; ("drivers/4", "XenServer XENNET 9.1.7.65 ")
+          ]
+        , [
+            ("micro", "-1")
+          ; ("xennet", "XenServer 9.1.7.65 ")
+          ; ("xeniface", "XenServer 9.1.10.87 ")
+          ; ("xenvif", "XenServer 9.1.12.101 ")
+          ; ("xenvbd", "XenServer 9.1.8.79 ")
+          ; ("xenbus", "XenServer 9.1.9.105 ")
+          ]
+        )
+      ; ( [
+            ("drivers/0", "XenServer XENBUS 9.1.9.105 (DEBUG) (MOREDEBUG)")
+          ; ("drivers/2", "XCP_ng XENVIF 9.1.12.101 ")
+          ]
+        , [
+            ("micro", "-1")
+          ; ("xenvif", "XCP_ng 9.1.12.101 ")
+          ; ("xenbus", "XenServer 9.1.9.105 (DEBUG) (MOREDEBUG)")
+          ]
         )
       ]
 end)


### PR DESCRIPTION
Windows PV drivers do not store their version information into `drivers/{xeneventchn,xenvbd,xennet}` xenstore keys since 2015, see:

* PV drivers commit `784af16810d705ba2bc02bab6ac93b24119f886c (Publish distribution information to xenstore)` https://xenbits.xen.org/gitweb/?p=pvdrivers/win/xenbus.git;a=commit;h=784af16810d705ba2bc02bab6ac93b24119f886c

* Xen commit `71e64e163b2dae7d08f7d77ee942749663f484d5 (docs: Introduce xenstore paths for PV driver information)` https://xenbits.xen.org/gitweb/?p=xen.git;a=commit;h=71e64e163b2dae7d08f7d77ee942749663f484d5

Instead it is stored like this:
```
drivers/0 = "XenServer XENBUS 9.1.9.105 "
drivers/1 = "XenServer XENVBD 9.1.8.79 "
drivers/2 = "XenServer XENVIF 9.1.12.101 "
drivers/3 = "XenServer XENIFACE 9.1.10.87 "
drivers/4 = "XenServer XENNET 9.1.7.65 "
```

Modify `xapi_guest_agent` to list such entries under `drivers/` and present version information for each driver.