### PR TITLE
Move the `update_snapshot_info_dest` to storage mux

### DIFF
--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -278,7 +278,7 @@ module MigrateLocal = struct
 
     let (module Remote) = get_remote_backend url verify_dest in
     (* Find the local VDI *)
-    let local_vdi = find_local_vdi ~dbg ~sr ~vdi in
+    let local_vdi, _ = find_vdi ~dbg ~sr ~vdi (module Local) in
     let mirror_id = State.mirror_id_of (sr, local_vdi.vdi) in
     debug "%s: Adding to active local mirrors before sending: id=%s"
       __FUNCTION__ mirror_id ;

--- a/ocaml/xapi/storage_migrate_helper.ml
+++ b/ocaml/xapi/storage_migrate_helper.ml
@@ -346,14 +346,13 @@ let get_remote_backend url verify_dest =
   end)) in
   (module Remote : SMAPIv2)
 
-let find_local_vdi ~dbg ~sr ~vdi =
-  (* Find the local VDI *)
-  let vdis, _ = Local.SR.scan2 dbg sr in
+let find_vdi ~dbg ~sr ~vdi (module SMAPIv2 : SMAPIv2) =
+  let vdis, _ = SMAPIv2.SR.scan2 dbg sr in
   match List.find_opt (fun x -> x.vdi = vdi) vdis with
   | None ->
-      failwith "Local VDI not found"
+      failwith_fmt "VDI %s not found" (Storage_interface.Vdi.string_of vdi)
   | Some v ->
-      v
+      (v, vdis)
 
 (** [similar_vdis dbg sr vdi] returns a list of content_ids of vdis
   which are similar to the input [vdi] in [sr] *)

--- a/ocaml/xapi/storage_migrate_helper.mli
+++ b/ocaml/xapi/storage_migrate_helper.mli
@@ -261,6 +261,7 @@ module Local : SMAPIv2
 
 val get_remote_backend : string -> bool -> (module SMAPIv2)
 
-val find_local_vdi : dbg:string -> sr:sr -> vdi:vdi -> vdi_info
+val find_vdi :
+  dbg:string -> sr:sr -> vdi:vdi -> (module SMAPIv2) -> vdi_info * vdi_info list
 
 val similar_vdis : dbg:string -> sr:sr -> vdi:vdi -> uuid list

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -19,6 +19,7 @@ module D = Debug.Make (struct let name = "mux" end)
 open D
 open Storage_interface
 open Storage_mux_reg
+open Storage_utils
 
 let s_of_sr = Storage_interface.Sr.string_of
 
@@ -329,28 +330,6 @@ module Mux = struct
         ) ;
       Storage_migrate.update_snapshot_info_src ~dbg:(Debug_info.to_string di)
         ~sr ~vdi ~url ~dest ~dest_vdi ~snapshot_pairs
-
-    exception No_VDI
-
-    (* Find a VDI given a storage-layer SR and VDI *)
-    let find_vdi ~__context sr vdi =
-      let sr = s_of_sr sr in
-      let vdi = s_of_vdi vdi in
-      let open Xapi_database.Db_filter_types in
-      let sr = Db.SR.get_by_uuid ~__context ~uuid:sr in
-      match
-        Db.VDI.get_records_where ~__context
-          ~expr:
-            (And
-               ( Eq (Field "location", Literal vdi)
-               , Eq (Field "SR", Literal (Ref.string_of sr))
-               )
-            )
-      with
-      | x :: _ ->
-          x
-      | _ ->
-          raise No_VDI
 
     let set_is_a_snapshot _context ~dbg ~sr ~vdi ~is_a_snapshot =
       Server_helpers.exec_with_new_task "VDI.set_is_a_snapshot"

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -372,7 +372,7 @@ module Mux = struct
         ) ;
       Server_helpers.exec_with_new_task "SR.update_snapshot_info_dest"
         ~subtask_of:(Ref.of_string dbg) (fun __context ->
-          let local_vdis = scan () ~dbg ~sr in
+          let local_vdis, _ = scan2 () ~dbg ~sr in
           let find_sm_vdi ~vdi ~vdi_info_list =
             try List.find (fun x -> x.vdi = vdi) vdi_info_list
             with Not_found ->

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -18,8 +18,7 @@ open D
 module Date = Clock.Date
 module XenAPI = Client.Client
 open Storage_interface
-
-exception No_VDI
+open Storage_utils
 
 let s_of_vdi = Vdi.string_of
 
@@ -29,26 +28,6 @@ let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
 
 let with_dbg ~name ~dbg f =
   Debug_info.with_dbg ~module_name:"SMAPIv1" ~name ~dbg f
-
-(* Find a VDI given a storage-layer SR and VDI *)
-let find_vdi ~__context sr vdi =
-  let sr = s_of_sr sr in
-  let vdi = s_of_vdi vdi in
-  let open Xapi_database.Db_filter_types in
-  let sr = Db.SR.get_by_uuid ~__context ~uuid:sr in
-  match
-    Db.VDI.get_records_where ~__context
-      ~expr:
-        (And
-           ( Eq (Field "location", Literal vdi)
-           , Eq (Field "SR", Literal (Ref.string_of sr))
-           )
-        )
-  with
-  | x :: _ ->
-      x
-  | _ ->
-      raise No_VDI
 
 (* Find a VDI reference given a name *)
 let find_content ~__context ?sr name =

--- a/ocaml/xapi/storage_smapiv1.mli
+++ b/ocaml/xapi/storage_smapiv1.mli
@@ -20,7 +20,4 @@ val vdi_read_write : (Sr.t * Vdi.t, bool) Hashtbl.t
 
 val vdi_info_of_vdi_rec : Context.t -> API.vDI_t -> Storage_interface.vdi_info
 
-val find_vdi : __context:Context.t -> Sr.t -> Vdi.t -> [`VDI] Ref.t * API.vDI_t
-(** Find a VDI given a storage-layer SR and VDI *)
-
 module SMAPIv1 : Server_impl

--- a/ocaml/xapi/storage_utils.mli
+++ b/ocaml/xapi/storage_utils.mli
@@ -64,3 +64,12 @@ val rpc :
 
 val transform_storage_exn : (unit -> 'a) -> 'a
 (** [transform_storage_exn f] runs [f], rethrowing any storage error as a nice XenAPI error *)
+
+exception No_VDI
+
+val find_vdi :
+     __context:Context.t
+  -> Storage_interface.sr
+  -> Storage_interface.vdi
+  -> [`VDI] Ref.t * API.vDI_t
+(** Find a VDI given a storage-layer SR and VDI *)

--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -196,7 +196,7 @@ let put_handler (req : Http.Request.t) s _ =
           http_proxy_to_plugin req s name
       | [""; services; "SM"; "data"; sr; vdi] when services = _services ->
           let vdi, _ =
-            Storage_smapiv1.find_vdi ~__context
+            Storage_utils.find_vdi ~__context
               (Storage_interface.Sr.of_string sr)
               (Storage_interface.Vdi.of_string vdi)
           in


### PR DESCRIPTION
Move the update_snapshot_info_dest to storage mux as this function just does db operations.

Also rescan the SR after updaing the content_id during SXM, so that the latest content_id can be reflected in the returned vdi_info, which gets used later on in `update_snapshot_info`