### PR TITLE
xenopsd: Don't balloon down memory on same-host migration

### DIFF
--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -718,6 +718,11 @@ module XenopsAPI (R : RPC) = struct
           ~description:["when true, verify remote server certificate"]
           Types.bool
       in
+      let localhost_migration =
+        Param.mk ~name:"localhost_migration"
+          ~description:["when true, localhost migration is being performed"]
+          Types.bool
+      in
       declare "VM.migrate" []
         (debug_info_p
         @-> vm_id_p
@@ -727,6 +732,7 @@ module XenopsAPI (R : RPC) = struct
         @-> xenops_url
         @-> compress
         @-> verify_dest
+        @-> localhost_migration
         @-> returning task_id_p err
         )
 

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -244,7 +244,7 @@ let assert_licensed_storage_motion ~__context =
 
 let rec migrate_with_retries ~__context ~queue_name ~max ~try_no ~dbg:_ ~vm_uuid
     ~xenops_vdi_map ~xenops_vif_map ~xenops_vgpu_map ~xenops_url ~compress
-    ~verify_cert =
+    ~verify_cert ~localhost_migration =
   let open Xapi_xenops_queue in
   let module Client = (val make_client queue_name : XENOPS) in
   let dbg = Context.string_of_task_and_tracing __context in
@@ -254,7 +254,7 @@ let rec migrate_with_retries ~__context ~queue_name ~max ~try_no ~dbg:_ ~vm_uuid
     progress := "Client.VM.migrate" ;
     let t1 =
       Client.VM.migrate dbg vm_uuid xenops_vdi_map xenops_vif_map
-        xenops_vgpu_map xenops_url compress verify_dest
+        xenops_vgpu_map xenops_url compress verify_dest localhost_migration
     in
     progress := "sync_with_task" ;
     ignore (Xapi_xenops.sync_with_task __context queue_name t1)
@@ -281,7 +281,7 @@ let rec migrate_with_retries ~__context ~queue_name ~max ~try_no ~dbg:_ ~vm_uuid
           (Printexc.to_string e) !progress try_no max ;
         migrate_with_retries ~__context ~queue_name ~max ~try_no:(try_no + 1)
           ~dbg ~vm_uuid ~xenops_vdi_map ~xenops_vif_map ~xenops_vgpu_map
-          ~xenops_url ~compress ~verify_cert
+          ~xenops_url ~compress ~verify_cert ~localhost_migration
     (* Something else went wrong *)
     | e ->
         debug
@@ -374,7 +374,8 @@ let pool_migrate ~__context ~vm ~host ~options =
   Pool_features.assert_enabled ~__context ~f:Features.Xen_motion ;
   let dbg = Context.string_of_task __context in
   let localhost = Helpers.get_localhost ~__context in
-  if host = localhost then
+  let localhost_migration = host = localhost in
+  if localhost_migration then
     info "This is a localhost migration" ;
   let open Xapi_xenops_queue in
   let queue_name = queue_of_vm ~__context ~self:vm in
@@ -431,7 +432,7 @@ let pool_migrate ~__context ~vm ~host ~options =
                 let verify_cert = Stunnel_client.pool () in
                 migrate_with_retry ~__context ~queue_name ~dbg ~vm_uuid
                   ~xenops_vdi_map:[] ~xenops_vif_map:[] ~xenops_vgpu_map
-                  ~xenops_url ~compress ~verify_cert ;
+                  ~xenops_url ~compress ~verify_cert ~localhost_migration ;
                 (* Delete all record of this VM locally (including caches) *)
                 Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid
             )
@@ -1586,7 +1587,8 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
               let dbg = Context.string_of_task __context in
               migrate_with_retry ~__context ~queue_name ~dbg ~vm_uuid
                 ~xenops_vdi_map ~xenops_vif_map ~xenops_vgpu_map
-                ~xenops_url:remote.xenops_url ~compress ~verify_cert ;
+                ~xenops_url:remote.xenops_url ~compress ~verify_cert
+                ~localhost_migration:is_same_host ;
               Xapi_xenops.Xenopsd_metadata.delete ~__context vm_uuid
           )
         with


### PR DESCRIPTION
When the VM (and its memory) isn't actually going to be moved anywhere (like in VDI migration to another SR), there's no point in ballooning down, it's actually likely to make VDI migration take longer if swap is engaged.