### PR TITLE
CA-409710: Modify the default backup parameters

### DIFF
--- a/scripts/xe-backup-metadata
+++ b/scripts/xe-backup-metadata
@@ -24,7 +24,7 @@ if [ "${master_uuid}" != "${INSTALLATION_UUID}" ]; then
    exit 1
 fi
 
-history_kept=25
+history_kept=12
 metadata_version=1
 debug=/bin/true
 
@@ -129,7 +129,7 @@ if [ -z "${vdi_uuid}" ]; then
     echo -n "Creating new backup VDI: "
     label="Pool Metadata Backup"
     # the label must match what xapi_vdi.ml is using for backup VDIs
-    vdi_uuid=$(${XE} vdi-create virtual-size=500MiB sr-uuid="${sr_uuid}" type=user name-label="${label}")
+    vdi_uuid=$(${XE} vdi-create virtual-size=1GiB sr-uuid="${sr_uuid}" type=user name-label="${label}")
     init_fs=1
     if [ $? -ne 0 ]; then
        echo failed


### PR DESCRIPTION
The current default count of metadata backup files is 25. This number is too
many. For the customer in XSI-1873, the backup disk is 500 MB, and each backup
file is about 35 MB. So it can't keep 25 backup files.

A quick solution is to modify the backup parameters, including:
1. Reduce the default count of metadata backup files to 12.
2. Increase the backup VDI size to 1 GiB so it can keep more backup files.
