### PR TITLE
CA-404946: NBD: increase timeout to match iSCSI timeout and use persistent connections

### DIFF
--- a/python3/libexec/nbd_client_manager.py
+++ b/python3/libexec/nbd_client_manager.py
@@ -209,6 +209,7 @@ def connect_nbd(path, exportname):
                     nbd_device,
                     "-timeout",
                     "90",
+                    "-persist",
                     "-name",
                     exportname,
                 ]

--- a/python3/libexec/nbd_client_manager.py
+++ b/python3/libexec/nbd_client_manager.py
@@ -208,7 +208,7 @@ def connect_nbd(path, exportname):
                     path,
                     nbd_device,
                     "-timeout",
-                    "60",
+                    "90",
                     "-name",
                     exportname,
                 ]


### PR DESCRIPTION
This was found during a previous stress test.
Without a persistent connection the kernel might disconnect from the backing qemu/tapdisk in Dom0 when I/O takes too long, and that prevents all future I/O to that device from working, not just the one that had the speed hickup.
Since our NBD connection is local, mark it as persistent, so that it tries to reconnect on timeout.
