### PR TITLE
xapi-log/test: Package the cram test in xapi-log

### DIFF
--- a/ocaml/libs/log/test/dune
+++ b/ocaml/libs/log/test/dune
@@ -3,4 +3,5 @@
  (libraries log xapi-stdext-threads threads.posix xapi-backtrace))
 
 (cram
+ (package xapi-log)
  (deps log_test.exe))


### PR DESCRIPTION
This should fix the current xs-opam failure with xapi master, see for example the failure here: https://github.com/last-genius/xs-opam/tree/master

Fixes: bfea6f33240a ("CA-409628: Add backtrace logging test")