### PR TITLE
xapi_xenops: Avoid a race during suspend

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -2049,18 +2049,10 @@ let update_vm ~__context id =
                 ) ;
                 debug "xenopsd event: Updating VM %s power_state <- %s" id
                   (Record_util.vm_power_state_to_string power_state) ;
-                (* This will mark VBDs, VIFs as detached and clear resident_on
-                   if the VM has permanently shutdown.  current-operations
-                   should not be reset as there maybe a checkpoint is ongoing*)
-                Xapi_vm_lifecycle.force_state_reset_keep_current_operations
-                  ~__context ~self ~value:power_state ;
-                if power_state = `Running then create_guest_metrics_if_needed () ;
-                if power_state = `Suspended || power_state = `Halted then (
-                  Xapi_network.detach_for_vm ~__context ~host:localhost ~vm:self ;
-                  Storage_access.reset ~__context ~vm:self
-                ) ;
-                if power_state = `Halted then
-                  Xenopsd_metadata.delete ~__context id ;
+
+                (* NOTE: Pull xenopsd metadata as soon as possible so that
+                   nothing comes inbetween the power state change and the
+                   Xenopsd_metadata.pull and overwrites it. *)
                 ( if power_state = `Suspended then
                     let md = Xenopsd_metadata.pull ~__context id in
                     match md.Metadata.domains with
@@ -2071,8 +2063,22 @@ let update_vm ~__context id =
                         debug "VM %s last_booted_record set to %s"
                           (Ref.string_of self) x
                 ) ;
-                if power_state = `Halted then
+
+                (* This will mark VBDs, VIFs as detached and clear resident_on
+                   if the VM has permanently shutdown.  current-operations
+                   should not be reset as there maybe a checkpoint is ongoing*)
+                Xapi_vm_lifecycle.force_state_reset_keep_current_operations
+                  ~__context ~self ~value:power_state ;
+                if power_state = `Running then
+                  create_guest_metrics_if_needed () ;
+                if power_state = `Suspended || power_state = `Halted then (
+                  Xapi_network.detach_for_vm ~__context ~host:localhost ~vm:self ;
+                  Storage_access.reset ~__context ~vm:self
+                ) ;
+                if power_state = `Halted then (
+                  Xenopsd_metadata.delete ~__context id ;
                   !trigger_xenapi_reregister ()
+                )
               with e ->
                 error "Caught %s: while updating VM %s power_state"
                   (Printexc.to_string e) id


### PR DESCRIPTION
As described in [#6451](https://github.com/xapi-project/xen-api/issues/6451), a xapi event could prevent update_vm from pulling the latest Xenopsd metadata, overwriting it with stale information. In case of suspend, this would make the snapshot unresumable, raising an assert in xenopsd due to incongruities in memory values.

Instead pull the xenopsd metadata right before updating DB.power_state in`Xapi_vm_lifecycle.force_state_reset_keep_current_operations`, eliminating the window for the race.


Closes #6451 