### PR TITLE
Adapt network interfaces sorting

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -111,7 +111,9 @@ let on_timer () = write_config ()
 
 let clear_state () =
   write_lock := true ;
-  config := Network_config.empty_config
+  (* Do not clear interface_order, it is only maintained by networkd *)
+  config :=
+    {Network_config.empty_config with interface_order= !config.interface_order}
 
 let sync_state () =
   write_lock := false ;

--- a/ocaml/networkd/bin/networkd.ml
+++ b/ocaml/networkd/bin/networkd.ml
@@ -183,6 +183,7 @@ let bind () =
   S.set_gateway_interface set_gateway_interface ;
   S.set_dns_interface set_dns_interface ;
   S.Interface.get_all Interface.get_all ;
+  S.Interface.get_interface_positions Interface.get_interface_positions ;
   S.Interface.exists Interface.exists ;
   S.Interface.get_mac Interface.get_mac ;
   S.Interface.get_pci_bus_path Interface.get_pci_bus_path ;

--- a/ocaml/networkd/lib/network_config.ml
+++ b/ocaml/networkd/lib/network_config.ml
@@ -22,17 +22,35 @@ exception Read_error
 
 exception Write_error
 
-let empty_config = default_config
+(* If the interface-rename script dir exists, the devices are already renamed
+   to eth<N>, the <N> indicates device order *)
+let device_already_renamed =
+  let dir = "/etc/sysconfig/network-scripts/interface-rename-data" in
+  Sys.file_exists dir && Sys.is_directory dir
+
+(* If devices have already been renamed, then interface_order is None,
+   since the order is now reflected in their names. *)
+let initial_interface_order = if device_already_renamed then None else Some []
+
+let empty_config =
+  {default_config with interface_order= initial_interface_order}
 
 let config_file_path = "/var/lib/xcp/networkd.db"
 
 let temp_vlan = "xentemp"
 
-let bridge_naming_convention (device : string) =
-  if Astring.String.is_prefix ~affix:"eth" device then
+let bridge_name_of_device (device : string) =
+  if String.starts_with ~prefix:"eth" device then
     "xenbr" ^ String.sub device 3 (String.length device - 3)
   else
     "br" ^ device
+
+let bridge_naming_convention (device : string) pos_opt =
+  match pos_opt with
+  | Some index ->
+      "xenbr" ^ string_of_int index
+  | None ->
+      bridge_name_of_device device
 
 let get_list_from ~sep ~key args =
   List.assoc_opt key args
@@ -79,7 +97,11 @@ let parse_dns_config args =
   let domains = get_list_from ~sep:" " ~key:"DOMAIN" args in
   (nameservers, domains)
 
-let read_management_conf () =
+let write_manage_iface_to_inventory bridge_name =
+  info "Writing management interface to inventory: %s" bridge_name ;
+  Inventory.update Inventory._management_interface bridge_name
+
+let read_management_conf interface_order =
   try
     let management_conf =
       Xapi_stdext_unix.Unixext.string_of_file
@@ -114,7 +136,12 @@ let read_management_conf () =
       | _, hd :: _ ->
           hd
     in
-    Inventory.reread_inventory () ;
+    let pos_opt =
+      Option.bind interface_order @@ fun order ->
+      List.find_map
+        (fun x -> if x.name = device then Some x.position else None)
+        order
+    in
     let bridge_name =
       let inventory_bridge =
         try Some (Inventory.lookup Inventory._management_interface)
@@ -124,7 +151,7 @@ let read_management_conf () =
       | Some "" | None ->
           let bridge =
             if vlan = None then
-              bridge_naming_convention device
+              bridge_naming_convention device pos_opt
             else
               (* At this point, we don't know what the VLAN bridge name will be,
                * so use a temporary name. Xapi will replace the bridge once the name
@@ -132,6 +159,8 @@ let read_management_conf () =
               temp_vlan
           in
           debug "No management bridge in inventory file... using %s" bridge ;
+          if not device_already_renamed then
+            write_manage_iface_to_inventory bridge ;
           bridge
       | Some bridge ->
           debug "Management bridge in inventory file: %s" bridge ;
@@ -176,7 +205,7 @@ let read_management_conf () =
           , [(bridge_name, primary_bridge_conf)]
           )
       | Some vlan ->
-          let parent = bridge_naming_convention device in
+          let parent = bridge_naming_convention device pos_opt in
           let secondary_bridge_conf =
             {
               default_bridge with
@@ -203,7 +232,7 @@ let read_management_conf () =
     ; bridge_config
     ; gateway_interface= Some bridge_name
     ; dns_interface= Some bridge_name
-    ; interface_order= None
+    ; interface_order
     }
   with e ->
     error "Error while trying to read firstboot data: %s\n%s"

--- a/ocaml/networkd/lib/network_device_order.ml
+++ b/ocaml/networkd/lib/network_device_order.ml
@@ -36,6 +36,22 @@ type error =
   | Duplicate_position
   | Invalid_biosdevname_key_value of (string * string)
 
+let string_of_error = function
+  | Pci_addr_parse_error s ->
+      Printf.sprintf "Invalid PCI address: %s" s
+  | Mac_addr_parse_error s ->
+      Printf.sprintf "Invalid MAC address: %s" s
+  | Rule_parse_error s ->
+      Printf.sprintf "Invalid rule: %s" s
+  | Missing_biosdevname_key k ->
+      Printf.sprintf "Missing key in biosdevname output: %s" k
+  | Duplicate_mac_address ->
+      "Duplicate MAC address"
+  | Duplicate_position ->
+      "Duplicate position"
+  | Invalid_biosdevname_key_value (k, v) ->
+      Printf.sprintf "Invalid key-value pair in biosdevname output: %s=%s" k v
+
 module Pciaddr = struct
   type t = Xcp_pci.address
 

--- a/ocaml/networkd/lib/network_device_order.mli
+++ b/ocaml/networkd/lib/network_device_order.mli
@@ -24,6 +24,9 @@ type error =
   | Duplicate_position
   | Invalid_biosdevname_key_value of (string * string)
 
+val string_of_error : error -> string
+(** [string_of_error e] returns a string representation of the error [e]. *)
+
 (** PCI address in format SBDF: domain:bus:device:function *)
 module Pciaddr : sig
   (** Type of the PCI address *)

--- a/ocaml/xapi-idl/network/network_interface.ml
+++ b/ocaml/xapi-idl/network/network_interface.ml
@@ -420,6 +420,18 @@ module Interface_API (R : RPC) = struct
         ["Get list of all interface names"]
         (debug_info_p @-> unit_p @-> returning iface_list_p err)
 
+    let get_interface_positions =
+      let module T = struct
+        type _iface_position_list_t = (iface * int) list [@@deriving rpcty]
+      end in
+      let iface_position_list_p =
+        Param.mk ~description:["interface postion list"]
+          T._iface_position_list_t
+      in
+      declare "Interface.get_interface_positions"
+        ["Get list of interface names and their positions"]
+        (debug_info_p @-> unit_p @-> returning iface_position_list_p err)
+
     let exists =
       let result = Param.mk ~description:["existence"] Types.bool in
       declare "Interface.exists"

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -129,8 +129,11 @@ let call_script ?(log_output = Always) ?env ?stdin ?timeout script args =
       raise e
 
 (** Construct a descriptive network name (used as name_label) for a give network interface. *)
-let choose_network_name_for_pif device =
-  Printf.sprintf "Pool-wide network associated with %s" device
+let choose_network_name_for_pif device pos_opt =
+  let pos_str =
+    Option.fold ~none:"" ~some:(Printf.sprintf " (slot %d)") pos_opt
+  in
+  Printf.sprintf "Pool-wide network associated with %s%s" device pos_str
 
 (* !! FIXME - trap proper MISSINGREFERENCE exception when this has been defined *)
 (* !! FIXME(2) - this code could be shared with the CLI? *)

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -370,9 +370,14 @@ let make_tables ~__context ~host =
   let dbg = Context.string_of_task __context in
   let device_to_position_table = Net.Interface.get_interface_positions dbg () in
   let device_to_mac_table =
-    List.map
-      (fun (name, _) -> (name, Net.Interface.get_mac dbg name))
-      device_to_position_table
+    List.filter_map
+      (fun name ->
+        if Net.Interface.is_physical dbg name then
+          Some (name, Net.Interface.get_mac dbg name)
+        else
+          None
+      )
+      (Net.Interface.get_all dbg ())
   in
   (* Get all PIFs on this host *)
   let pif_to_device_table =

--- a/ocaml/xapi/xapi_pif.mli
+++ b/ocaml/xapi/xapi_pif.mli
@@ -160,9 +160,10 @@ val plug : __context:Context.t -> self:[`PIF] Ref.t -> unit
 
 (** {2 Miscellaneous Helper Functions} *)
 
-val bridge_naming_convention : string -> string
-(** Constructs a bridge name from a device (network interface) name by replacing
- *  [eth] by [xenbr], or prepending [br] if the device name does not start with [eth].
+val bridge_naming_convention : string -> int option -> string
+(** Constructs a bridge name from a [device] (network interface) name and an optional
+    position [pos_opt]. If [pos_opt] is Some [pos], the bridge name will be
+    "xenbr" ^ [pos], else "br" ^ [device].
 *)
 
 val read_bridges_from_inventory : unit -> string list


### PR DESCRIPTION
This PR is the adaption of #6381 in networkd and xapi.
XS8: Keep the legacy behaviour, use host-installer, sort-script to sort and rename the network interfaces to `ethx`.
XS9: Use `Network_device_order.sort` to sort the interfaces, store the result in networkd `config.interface_order`.
Compatibility is offered by check the sort-script `interface-rename-data` dir.
Add new interface [Interface.get_interface_positions](https://github.com/xapi-project/xen-api/commit/a5e2cee10f1c51e9ad68147db67a3747e186c0b9) to pass interfaces and positions from networkd to xapi.