### PR TITLE
CP-307958: small DB improvements and benchmarks

### DIFF
--- a/ocaml/database/db_backend.ml
+++ b/ocaml/database/db_backend.ml
@@ -21,11 +21,11 @@ let db_FLUSH_TIMER = 2.0
 
 (* --------------------- Util functions on db datastructures *)
 
-let master_database = ref (Db_cache_types.Database.make Schema.empty)
+let master_database = Atomic.make (Db_cache_types.Database.make Schema.empty)
 
-let __test_set_master_database db = master_database := db
+let __test_set_master_database db = Atomic.set master_database db
 
-let make () = Db_ref.in_memory (ref master_database)
+let make () = Db_ref.in_memory master_database
 
 (* !!! Right now this is called at cache population time. It would probably be preferable to call it on flush time instead, so we
    don't waste writes storing non-persistent field values on disk.. At the moment there's not much to worry about, since there are

--- a/ocaml/database/db_connections.ml
+++ b/ocaml/database/db_connections.ml
@@ -62,22 +62,12 @@ let preferred_write_db () = List.hd (Db_conn_store.read_db_connections ())
 let exit_on_next_flush = ref false
 
 (* db flushing thread refcount: the last thread out of the door does the exit(0) when flush_on_exit is true *)
-let with_lock = Xapi_stdext_threads.Threadext.Mutex.execute
+let db_flush_thread_refcount = Atomic.make 0
 
-let db_flush_thread_refcount_m = Mutex.create ()
-
-let db_flush_thread_refcount = ref 0
-
-let inc_db_flush_thread_refcount () =
-  with_lock db_flush_thread_refcount_m (fun () ->
-      db_flush_thread_refcount := !db_flush_thread_refcount + 1
-  )
+let inc_db_flush_thread_refcount () = Atomic.incr db_flush_thread_refcount
 
 let dec_and_read_db_flush_thread_refcount () =
-  with_lock db_flush_thread_refcount_m (fun () ->
-      db_flush_thread_refcount := !db_flush_thread_refcount - 1 ;
-      !db_flush_thread_refcount
-  )
+  Atomic.fetch_and_add db_flush_thread_refcount (-1)
 
 let pre_exit_hook () =
   (* We're about to exit. Close the active redo logs. *)

--- a/ocaml/database/db_ref.ml
+++ b/ocaml/database/db_ref.ml
@@ -12,15 +12,15 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type t = In_memory of Db_cache_types.Database.t ref ref | Remote
+type t = In_memory of Db_cache_types.Database.t Atomic.t | Remote
 
 exception Database_not_in_memory
 
-let in_memory (rf : Db_cache_types.Database.t ref ref) = In_memory rf
+let in_memory (rf : Db_cache_types.Database.t Atomic.t) = In_memory rf
 
 let get_database = function
   | In_memory x ->
-      !(!x)
+      Atomic.get x
   | Remote ->
       raise Database_not_in_memory
 
@@ -28,6 +28,6 @@ let update_database t f =
   match t with
   | In_memory x ->
       let d : Db_cache_types.Database.t = f (get_database t) in
-      !x := d
+      Atomic.set x d
   | Remote ->
       raise Database_not_in_memory

--- a/ocaml/database/db_ref.mli
+++ b/ocaml/database/db_ref.mli
@@ -12,11 +12,11 @@
  * GNU Lesser General Public License for more details.
  *)
 
-type t = In_memory of Db_cache_types.Database.t ref ref | Remote
+type t = In_memory of Db_cache_types.Database.t Atomic.t | Remote
 
 exception Database_not_in_memory
 
-val in_memory : Db_cache_types.Database.t ref ref -> t
+val in_memory : Db_cache_types.Database.t Atomic.t -> t
 
 val get_database : t -> Db_cache_types.Database.t
 

--- a/ocaml/tests/bench/bench_pool_field.ml
+++ b/ocaml/tests/bench/bench_pool_field.ml
@@ -82,6 +82,19 @@ let noop () = Sys.opaque_identity ()
 
 let db_lock_uncontended () : unit = Xapi_database.Db_lock.with_lock noop
 
+let event =
+  let open Event_types in
+  {
+    id= "id"
+  ; ts= "1000"
+  ; ty= "test"
+  ; op= `add
+  ; reference= "test"
+  ; snapshot= Some (Rpc.Dict [])
+  }
+
+let test_rpc_of_event () = Event_types.rpc_of_event event
+
 let benchmarks =
   [
     Test.make ~name:"local_session_hook" (Staged.stage local_session_hook)
@@ -95,6 +108,7 @@ let benchmarks =
   ; Test.make ~name:"Mutex+incr" (Staged.stage inc_with_mutex)
   ; Test.make ~name:"Db_lock.with_lock uncontended"
       (Staged.stage db_lock_uncontended)
+  ; Test.make ~name:"rpc_of_event" (Staged.stage test_rpc_of_event)
   ]
 
 let () = Bechamel_simple_cli.cli benchmarks

--- a/ocaml/tests/bench/bench_pool_field.ml
+++ b/ocaml/tests/bench/bench_pool_field.ml
@@ -17,7 +17,8 @@ open Bechamel
 let () =
   Suite_init.harness_init () ;
   Printexc.record_backtrace true ;
-  Debug.set_level Syslog.Emerg
+  Debug.set_level Syslog.Emerg ;
+  Xapi_event.register_hooks ()
 
 let date = "20250102T03:04:05Z"
 
@@ -36,11 +37,21 @@ let json_str =
 
 let __context = Test_common.make_test_database ()
 
+let host = Test_common.make_host ~__context ()
+
+let pool = Test_common.make_pool ~__context ~master:host ()
+
 let () =
-  let host = Test_common.make_host ~__context () in
-  let pool = Test_common.make_pool ~__context ~master:host () in
   Db.Pool.set_license_server ~__context ~self:pool
-    ~value:[("jsontest", json_str)]
+    ~value:[("jsontest", json_str)] ;
+  let open Xapi_database in
+  Db_ref.update_database
+    (Context.database_of __context)
+    (Db_cache_types.Database.register_callback "redo_log"
+       Redo_log.database_callback
+    )
+
+let vm = Test_common.make_vm ~__context ~name_label:"test" ()
 
 let get_all () : API.pool_t list =
   Db.Pool.get_all_records ~__context |> List.map snd
@@ -95,6 +106,20 @@ let event =
 
 let test_rpc_of_event () = Event_types.rpc_of_event event
 
+let counter = Atomic.make 0
+
+let test_set_vm_nvram () : unit =
+  let c = Atomic.fetch_and_add counter 1 mod 0x7F in
+  (* use different value each iteration, otherwise it becomes a noop *)
+  Db.VM.set_NVRAM ~__context ~self:vm
+    ~value:[("test", String.make 32768 (Char.chr @@ c))]
+
+let test_db_pool_write () =
+  let c = Atomic.fetch_and_add counter 1 mod 0x7F in
+  Db.Pool.set_tags ~__context ~self:pool ~value:[String.make 16 (Char.chr @@ c)]
+
+let test_db_pool_read () = Db.Pool.get_tags ~__context ~self:pool
+
 let benchmarks =
   [
     Test.make ~name:"local_session_hook" (Staged.stage local_session_hook)
@@ -109,6 +134,9 @@ let benchmarks =
   ; Test.make ~name:"Db_lock.with_lock uncontended"
       (Staged.stage db_lock_uncontended)
   ; Test.make ~name:"rpc_of_event" (Staged.stage test_rpc_of_event)
+  ; Test.make ~name:"Db.Pool.set_tags" (Staged.stage test_db_pool_write)
+  ; Test.make ~name:"Db.Pool.get_tags" (Staged.stage test_db_pool_read)
+  ; Test.make ~name:"Db.VM.set_NVRAM" (Staged.stage test_set_vm_nvram)
   ]
 
 let () = Bechamel_simple_cli.cli benchmarks

--- a/ocaml/tests/bench/dune
+++ b/ocaml/tests/bench/dune
@@ -27,4 +27,5 @@
   log
   xapi_database
   xapi_datamodel
-  xapi_internal))
+  xapi_internal
+  xapi-stdext-threads))

--- a/ocaml/xapi-types/event_types.ml
+++ b/ocaml/xapi-types/event_types.ml
@@ -20,36 +20,14 @@ let rpc_of_op = API.rpc_of_event_operation
 let op_of_rpc = API.event_operation_of_rpc
 
 type event = {
-    id: string
-  ; ts: string
-  ; ty: string
-  ; op: op
-  ; reference: string
-  ; snapshot: Rpc.t option
+    id: string [@key "id"]
+  ; ts: string [@key "timestamp"]
+  ; ty: string [@key "class"]
+  ; op: op [@key "operation"]
+  ; reference: string [@key "ref"]
+  ; snapshot: Rpc.t option [@key "snapshot"]
 }
 [@@deriving rpc]
-
-let ev_struct_remap =
-  [
-    ("id", "id")
-  ; ("ts", "timestamp")
-  ; ("ty", "class")
-  ; ("op", "operation")
-  ; ("reference", "ref")
-  ; ("snapshot", "snapshot")
-  ]
-
-let remap map str =
-  match str with
-  | Rpc.Dict d ->
-      Rpc.Dict (List.map (fun (k, v) -> (List.assoc k map, v)) d)
-  | _ ->
-      str
-
-let rpc_of_event ev = remap ev_struct_remap (rpc_of_event ev)
-
-let event_of_rpc rpc =
-  event_of_rpc (remap (List.map (fun (k, v) -> (v, k)) ev_struct_remap) rpc)
 
 type events = event list [@@deriving rpc]
 

--- a/ocaml/xapi/pool_db_backup.ml
+++ b/ocaml/xapi/pool_db_backup.ml
@@ -192,7 +192,7 @@ let restore_from_xml __context dry_run (xml_filename : string) =
       (Db_xml.From.file (Datamodel_schema.of_datamodel ()) xml_filename)
   in
   version_check db ;
-  let db_ref = Db_ref.in_memory (ref (ref db)) in
+  let db_ref = Db_ref.in_memory (Atomic.make db) in
   let new_context = Context.make ~database:db_ref "restore_db" in
   prepare_database_for_restore ~old_context:__context ~new_context ;
   (* write manifest and unmarshalled db directly to db_temporary_restore_path, so its ready for us on restart *)

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -1569,5 +1569,5 @@ let create_from_db_file ~__context ~filename =
     Xapi_database.Db_xml.From.file (Datamodel_schema.of_datamodel ()) filename
     |> Xapi_database.Db_upgrade.generic_database_upgrade
   in
-  let db_ref = Some (Xapi_database.Db_ref.in_memory (ref (ref db))) in
+  let db_ref = Some (Xapi_database.Db_ref.in_memory (Atomic.make db)) in
   create_readonly_session ~__context ~uname:"db-from-file" ~db_ref

--- a/ocaml/xapi/xapi_vdi_helpers.ml
+++ b/ocaml/xapi/xapi_vdi_helpers.ml
@@ -184,7 +184,7 @@ let database_ref_of_vdi ~__context ~vdi =
     debug "Enabling redo_log with device reason [%s]" device ;
     Redo_log.enable_block_existing log device ;
     let db = Database.make (Datamodel_schema.of_datamodel ()) in
-    let db_ref = Xapi_database.Db_ref.in_memory (ref (ref db)) in
+    let db_ref = Xapi_database.Db_ref.in_memory (Atomic.make db) in
     Redo_log_usage.read_from_redo_log log Xapi_globs.foreign_metadata_db db_ref ;
     Redo_log.delete log ;
     (* Upgrade database to the local schema. *)


### PR DESCRIPTION
We were converting events to RPC.t twice: first using the internal OCaml names, and then mapping them back to some "wire" names. This can be done a lot more simply by generating the wire names in the first place (the ppx support overriding the wire name of fields).

  `ministat` confirms an improvement on `rpc_of_event`:
```
      N           Min           Max        Median           Avg        Stddev
x  922     440.79126     46094.975     467.83727     563.79259     1676.0843
+ 1131     51.346821     33407.866     58.715393     115.98006     1105.4178
  Difference at 95.0% confidence
            -447.813 +/- 120.966
             -79.4286% +/- 13.1488%
           (Student's t, pooled s = 1390.95)
```

Atomic is also faster than an integer wrapped with a mutex:
```
Mutex+incr (ns):
 { monotonic-clock per run = 32.272091 (confidence: 32.365531 to 32.170138);
 r² = Some 0.999441 }
Atomic.incr (ns):
 { monotonic-clock per run = 2.938678 (confidence: 2.944486 to 2.933688);
   r² = Some 0.999857 }
```

I've added some new new benchmarks for event field conversion, atomic vs mutex and DB field writes.