### PR TITLE
CA-409949 CA-408048 remove unavailable SM types at startup

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -111,13 +111,12 @@ exception Message_switch_failure
 let on_xapi_start ~__context =
   (* An SM is either implemented as a plugin - for which we check its
       presence, or via an API *)
-  let is_available (_rf, rc) =
+  let is_available rc =
     Sys.file_exists rc.API.sM_driver_filename
     || Version.String.ge rc.sM_required_api_version "5.0"
   in
   let existing =
     Db.SM.get_all_records ~__context
-    |> List.filter is_available
     |> List.map (fun (rf, rc) -> (rc.API.sM_type, (rf, rc)))
   in
   let explicitly_configured_drivers =
@@ -172,6 +171,9 @@ let on_xapi_start ~__context =
   in
   (* Add all the running SMAPIv2 drivers *)
   let to_keep = to_keep @ running_smapiv2_drivers in
+  let unavailable =
+    List.filter (fun (_, (_, rc)) -> not (is_available rc)) existing
+  in
   (* Delete all records which aren't configured or in-use *)
   List.iter
     (fun ty ->
@@ -181,7 +183,12 @@ let on_xapi_start ~__context =
       let self, _ = List.assoc ty existing in
       try Db.SM.destroy ~__context ~self with _ -> ()
     )
-    (Listext.List.set_difference (List.map fst existing) to_keep) ;
+    (List.concat
+       [
+         Listext.List.set_difference (List.map fst existing) to_keep
+       ; List.map fst unavailable
+       ]
+    ) ;
 
   (* Synchronize SMAPIv1 plugins *)
 


### PR DESCRIPTION
On XS9 a previiously available SM type might become unavailable. Make sure we remove it on upgrade. The previius fix in CA-408048 did not work.