### PR TITLE
CA-408492: Add back receive_start2 for backwards compat

### DIFF
--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -1124,6 +1124,24 @@ module StorageAPI (R : RPC) = struct
           @-> returning result err
           )
 
+      (** Called on the receiving end 
+        @deprecated This function is deprecated, and is only here to keep backward 
+        compatibility with old xapis that call Remote.DATA.MIRROR.receive_start2 during SXM. 
+        Use the receive_start3 function instead. 
+      *)
+      let receive_start2 =
+        let similar_p = Param.mk ~name:"similar" Mirror.similars in
+        let result = Param.mk ~name:"result" Mirror.mirror_receive_result in
+        declare "DATA.MIRROR.receive_start2" []
+          (dbg_p
+          @-> sr_p
+          @-> VDI.vdi_info_p
+          @-> id_p
+          @-> similar_p
+          @-> vm_p
+          @-> returning result err
+          )
+
       (** Called on the receiving end to prepare for receipt of the storage. This
       function should be used in conjunction with [receive_finalize2]*)
       let receive_start3 =
@@ -1272,6 +1290,16 @@ module type MIRROR = sig
     -> vdi_info:vdi_info
     -> id:Mirror.id
     -> similar:Mirror.similars
+    -> Mirror.mirror_receive_result
+
+  val receive_start2 :
+       context
+    -> dbg:debug_info
+    -> sr:sr
+    -> vdi_info:vdi_info
+    -> id:Mirror.id
+    -> similar:Mirror.similars
+    -> vm:vm
     -> Mirror.mirror_receive_result
 
   val receive_start3 :
@@ -1771,6 +1799,9 @@ module Server (Impl : Server_impl) () = struct
     ) ;
     S.DATA.MIRROR.receive_start (fun dbg sr vdi_info id similar ->
         Impl.DATA.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id ~similar
+    ) ;
+    S.DATA.MIRROR.receive_start2 (fun dbg sr vdi_info id similar vm ->
+        Impl.DATA.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~id ~similar ~vm
     ) ;
     S.DATA.MIRROR.receive_start3
       (fun dbg sr vdi_info mirror_id similar vm url verify_dest ->

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -1110,7 +1110,7 @@ module StorageAPI (R : RPC) = struct
       (** Called on the receiving end 
         @deprecated This function is deprecated, and is only here to keep backward 
         compatibility with old xapis that call Remote.DATA.MIRROR.receive_start during SXM. 
-        Use the receive_start2 function instead. 
+        Use the receive_start3 function instead. 
       *)
       let receive_start =
         let similar_p = Param.mk ~name:"similar" Mirror.similars in
@@ -1126,10 +1126,10 @@ module StorageAPI (R : RPC) = struct
 
       (** Called on the receiving end to prepare for receipt of the storage. This
       function should be used in conjunction with [receive_finalize2]*)
-      let receive_start2 =
+      let receive_start3 =
         let similar_p = Param.mk ~name:"similar" Mirror.similars in
         let result = Param.mk ~name:"result" Mirror.mirror_receive_result in
-        declare "DATA.MIRROR.receive_start2" []
+        declare "DATA.MIRROR.receive_start3" []
           (dbg_p
           @-> sr_p
           @-> VDI.vdi_info_p
@@ -1153,7 +1153,7 @@ module StorageAPI (R : RPC) = struct
       (** [receive_finalize2 dbg id] will stop the mirroring process and compose 
       the snapshot VDI with the mirror VDI. It also cleans up the storage resources 
       used by mirroring. It is called after the the source VM is paused. This fucntion
-      should be used in conjunction with [receive_start2] *)
+      should be used in conjunction with [receive_start3] *)
       let receive_finalize2 =
         declare "DATA.MIRROR.receive_finalize2" []
           (dbg_p
@@ -1175,7 +1175,7 @@ module StorageAPI (R : RPC) = struct
           (dbg_p @-> id_p @-> returning unit_p err)
 
       (** [receive_cancel2 dbg mirror_id url verify_dest] cleans up the side effects
-      done by [receive_start2] on the destination host when the migration fails. *)
+      done by [receive_start3] on the destination host when the migration fails. *)
       let receive_cancel2 =
         declare "DATA.MIRROR.receive_cancel2" []
           (dbg_p @-> id_p @-> url_p @-> verify_dest_p @-> returning unit_p err)
@@ -1274,7 +1274,7 @@ module type MIRROR = sig
     -> similar:Mirror.similars
     -> Mirror.mirror_receive_result
 
-  val receive_start2 :
+  val receive_start3 :
        context
     -> dbg:debug_info
     -> sr:sr
@@ -1772,9 +1772,9 @@ module Server (Impl : Server_impl) () = struct
     S.DATA.MIRROR.receive_start (fun dbg sr vdi_info id similar ->
         Impl.DATA.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id ~similar
     ) ;
-    S.DATA.MIRROR.receive_start2
+    S.DATA.MIRROR.receive_start3
       (fun dbg sr vdi_info mirror_id similar vm url verify_dest ->
-        Impl.DATA.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~mirror_id
+        Impl.DATA.MIRROR.receive_start3 () ~dbg ~sr ~vdi_info ~mirror_id
           ~similar ~vm ~url ~verify_dest
     ) ;
     S.DATA.MIRROR.receive_cancel (fun dbg id ->

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -169,9 +169,9 @@ module DATA = struct
     let receive_start ctx ~dbg ~sr ~vdi_info ~id ~similar =
       u "DATA.MIRROR.receive_start"
 
-    let receive_start2 ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar ~vm ~url
+    let receive_start3 ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar ~vm ~url
         ~verify_dest =
-      u "DATA.MIRROR.receive_start2"
+      u "DATA.MIRROR.receive_start3"
 
     let receive_finalize ctx ~dbg ~id = u "DATA.MIRROR.receive_finalize"
 

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -169,6 +169,9 @@ module DATA = struct
     let receive_start ctx ~dbg ~sr ~vdi_info ~id ~similar =
       u "DATA.MIRROR.receive_start"
 
+    let receive_start2 ctx ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+      u "DATA.MIRROR.receive_start2"
+
     let receive_start3 ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar ~vm ~url
         ~verify_dest =
       u "DATA.MIRROR.receive_start3"

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1922,6 +1922,7 @@ let bind ~volume_script_dir =
   S.DP.stat_vdi (u "DP.stat_vdi") ;
   S.DATA.MIRROR.send_start (u "DATA.MIRROR.send_start") ;
   S.DATA.MIRROR.receive_start (u "DATA.MIRROR.receive_start") ;
+  S.DATA.MIRROR.receive_start2 (u "DATA.MIRROR.receive_start2") ;
   S.DATA.MIRROR.receive_start3 (u "DATA.MIRROR.receive_start3") ;
   S.DATA.MIRROR.receive_finalize (u "DATA.MIRROR.receive_finalize") ;
   S.DATA.MIRROR.receive_finalize2 (u "DATA.MIRROR.receive_finalize2") ;

--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1922,7 +1922,7 @@ let bind ~volume_script_dir =
   S.DP.stat_vdi (u "DP.stat_vdi") ;
   S.DATA.MIRROR.send_start (u "DATA.MIRROR.send_start") ;
   S.DATA.MIRROR.receive_start (u "DATA.MIRROR.receive_start") ;
-  S.DATA.MIRROR.receive_start2 (u "DATA.MIRROR.receive_start2") ;
+  S.DATA.MIRROR.receive_start3 (u "DATA.MIRROR.receive_start3") ;
   S.DATA.MIRROR.receive_finalize (u "DATA.MIRROR.receive_finalize") ;
   S.DATA.MIRROR.receive_finalize2 (u "DATA.MIRROR.receive_finalize2") ;
   S.DATA.MIRROR.receive_cancel (u "DATA.MIRROR.receive_cancel") ;

--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -131,7 +131,7 @@ module MigrateLocal = struct
     try
       let (module Migrate_Backend) = choose_backend dbg sr in
       let similars = similar_vdis ~dbg ~sr ~vdi in
-      Migrate_Backend.receive_start2 () ~dbg ~sr:dest ~vdi_info:local_vdi
+      Migrate_Backend.receive_start3 () ~dbg ~sr:dest ~vdi_info:local_vdi
         ~mirror_id ~similar:similars ~vm:mirror_vm ~url ~verify_dest
     with e ->
       error "%s Caught error %s while preparing for SXM" __FUNCTION__

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -837,6 +837,20 @@ module Mux = struct
         Storage_smapiv1_migrate.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id
           ~similar
 
+      let receive_start2 () ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+        with_dbg ~name:"DATA.MIRROR.receive_start2" ~dbg @@ fun _di ->
+        info "%s dbg: %s sr: %s vdi_info: %s mirror_id: %s similar: %s vm: %s"
+          __FUNCTION__ dbg (s_of_sr sr)
+          (string_of_vdi_info vdi_info)
+          id
+          (String.concat ";" similar)
+          (s_of_vm vm) ;
+        info "%s dbg:%s" __FUNCTION__ dbg ;
+        (* This goes straight to storage_smapiv1_migrate for backwards compatability
+           reasons, new code should not call receive_start any more *)
+        Storage_smapiv1_migrate.MIRROR.receive_start2 () ~dbg ~sr ~vdi_info ~id
+          ~similar ~vm
+
       (** see storage_smapiv{1,3}_migrate.receive_start3 *)
       let receive_start3 () ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_ ~similar:_
           ~vm:_ =

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -837,8 +837,8 @@ module Mux = struct
         Storage_smapiv1_migrate.MIRROR.receive_start () ~dbg ~sr ~vdi_info ~id
           ~similar
 
-      (** see storage_smapiv{1,3}_migrate.receive_start2 *)
-      let receive_start2 () ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_ ~similar:_
+      (** see storage_smapiv{1,3}_migrate.receive_start3 *)
+      let receive_start3 () ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_ ~similar:_
           ~vm:_ =
         u __FUNCTION__
 

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1143,6 +1143,10 @@ module SMAPIv1 : Server_impl = struct
       let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
         assert false
 
+      let receive_start2 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_
+          ~vm:_ =
+        assert false
+
       let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
           ~similar:_ ~vm:_ ~url:_ ~verify_dest:_ =
         assert false

--- a/ocaml/xapi/storage_smapiv1.ml
+++ b/ocaml/xapi/storage_smapiv1.ml
@@ -1143,7 +1143,7 @@ module SMAPIv1 : Server_impl = struct
       let receive_start _context ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
         assert false
 
-      let receive_start2 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
+      let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
           ~similar:_ ~vm:_ ~url:_ ~verify_dest:_ =
         assert false
 

--- a/ocaml/xapi/storage_smapiv1_migrate.ml
+++ b/ocaml/xapi/storage_smapiv1_migrate.ml
@@ -680,7 +680,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
       (* The state tracking here does not need to be changed, however, it will be
          stored in memory on different hosts. If receive_start is called, by an older
          host, this State.add is run on the destination host. On the other hand, if
-         receive_start2 is called, this will be stored in memory on the source host.
+         receive_start3 is called, this will be stored in memory on the source host.
          receive_finalize2 and receive_cancel2 handles this similarly. *)
       State.add id
         State.(
@@ -724,7 +724,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
     receive_start_common ~dbg ~sr ~vdi_info ~id ~similar ~vm:(Vm.of_string "0")
       (module Local)
 
-  let receive_start2 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar ~vm ~url
+  let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar ~vm ~url
       ~verify_dest =
     D.debug "%s dbg: %s sr: %s vdi: %s id: %s vm: %s url: %s verify_dest: %B"
       __FUNCTION__ dbg (s_of_sr sr)

--- a/ocaml/xapi/storage_smapiv1_migrate.ml
+++ b/ocaml/xapi/storage_smapiv1_migrate.ml
@@ -724,6 +724,12 @@ module MIRROR : SMAPIv2_MIRROR = struct
     receive_start_common ~dbg ~sr ~vdi_info ~id ~similar ~vm:(Vm.of_string "0")
       (module Local)
 
+  let receive_start2 _ctx ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+    D.debug "%s dbg: %s sr: %s vdi: %s id: %s" __FUNCTION__ dbg (s_of_sr sr)
+      (string_of_vdi_info vdi_info)
+      id ;
+    receive_start_common ~dbg ~sr ~vdi_info ~id ~similar ~vm (module Local)
+
   let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar ~vm ~url
       ~verify_dest =
     D.debug "%s dbg: %s sr: %s vdi: %s id: %s vm: %s url: %s verify_dest: %B"

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1200,7 +1200,7 @@ functor
             (String.concat "," similar) ;
           Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id ~similar
 
-        let receive_start2 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
+        let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
             ~similar:_ ~vm:_ =
           u __FUNCTION__
 

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1200,8 +1200,18 @@ functor
             (String.concat "," similar) ;
           Impl.DATA.MIRROR.receive_start context ~dbg ~sr ~vdi_info ~id ~similar
 
+        let receive_start2 context ~dbg ~sr ~vdi_info ~id ~similar ~vm =
+          info
+            "DATA.MIRROR.receive_start2 dbg:%s sr:%s id:%s similar:[%s] vm:%s"
+            dbg (s_of_sr sr) id
+            (String.concat "," similar)
+            (s_of_vm vm) ;
+          Impl.DATA.MIRROR.receive_start2 context ~dbg ~sr ~vdi_info ~id
+            ~similar ~vm
+
         let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
             ~similar:_ ~vm:_ =
+          (* See Storage_smapiv1_migrate.receive_start3 *)
           u __FUNCTION__
 
         let receive_finalize context ~dbg ~id =

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -29,6 +29,8 @@ module MIRROR : SMAPIv2_MIRROR = struct
 
   let receive_start _ctx = u __FUNCTION__
 
+  let receive_start2 _ctx = u __FUNCTION__
+
   let receive_start3 _ctx = u __FUNCTION__
 
   let receive_finalize _ctx = u __FUNCTION__

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -29,7 +29,7 @@ module MIRROR : SMAPIv2_MIRROR = struct
 
   let receive_start _ctx = u __FUNCTION__
 
-  let receive_start2 _ctx = u __FUNCTION__
+  let receive_start3 _ctx = u __FUNCTION__
 
   let receive_finalize _ctx = u __FUNCTION__
 


### PR DESCRIPTION
This otherwise breaks migration from xapi-25.3.0 -- xapi-25.17.0 to newer versions of xapi (25.18.0)