### PR TITLE
CP-307865 accept SHA512 for custom server certs

### DIFF
--- a/ocaml/gencert/lib.ml
+++ b/ocaml/gencert/lib.ml
@@ -93,9 +93,9 @@ let validate_pem_chain ~pem_leaf ~pem_chain now private_key =
     | _ ->
         Error (`Msg (server_certificate_key_mismatch, []))
   in
-  let ensure_sha256_signature_algorithm certificate =
+  let ensure_signature_algorithm certificate =
     match X509.Certificate.signature_algorithm certificate with
-    | Some (_, `SHA256) ->
+    | Some (_, (`SHA256 | `SHA512)) ->
         Ok certificate
     | _ ->
         Error (`Msg (server_certificate_signature_not_supported, []))
@@ -116,7 +116,7 @@ let validate_pem_chain ~pem_leaf ~pem_chain now private_key =
     ~error_not_yet:server_certificate_not_valid_yet
     ~error_expired:server_certificate_expired
   >>= ensure_keys_match private_key
-  >>= ensure_sha256_signature_algorithm
+  >>= ensure_signature_algorithm
   >>= fun cert ->
   match Option.map validate_chain pem_chain with
   | None ->

--- a/ocaml/gencert/test_lib.ml
+++ b/ocaml/gencert/test_lib.ml
@@ -50,6 +50,11 @@ let valid_leaf_certificates =
     , "2020-02-01T00:00:00Z"
     , `SHA256
     )
+  ; ( "Valid, SHA512, matches key"
+    , "pkey_rsa_2048"
+    , "2020-02-01T00:00:00Z"
+    , `SHA512
+    )
   ]
 
 (* ( description, leaf_private_key, expected_private_key, time_of_validation,
@@ -77,6 +82,14 @@ let invalid_leaf_certificates =
     , "pkey_rsa_4096"
     , "2020-02-01T00:00:00Z"
     , `SHA256
+    , server_certificate_key_mismatch
+    , []
+    )
+  ; ( "Valid, SHA512, keys do not match"
+    , "pkey_rsa_2048"
+    , "pkey_rsa_4096"
+    , "2020-02-01T00:00:00Z"
+    , `SHA512
     , server_certificate_key_mismatch
     , []
     )

--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1708,8 +1708,8 @@ let _ =
     ~doc:"The provided certificate has expired." () ;
   error Api_errors.server_certificate_signature_not_supported []
     ~doc:
-      "The provided certificate is not using the SHA256 (SHA2) signature \
-       algorithm."
+      "The provided certificate is not using one of the following SHA2 \
+       signature algorithms:  SHA256, SHA512."
     () ;
 
   error Api_errors.server_certificate_chain_invalid []


### PR DESCRIPTION
A user can install server certificates to secure the connection between xapi and their API clients. So far we demanded SHA256 certificates. Accept SHA512 in addition.

The patch renames the predicate to no longer imply that we only accept SHA256.

Tested this:

```
openssl req -x509 -sha512 -nodes -days 365 -newkey rsa:2048 -keyout mycert.key -out mycert.crt -subj "/CN=localhost"
xe host-server-certificate-install certificate=mycert.crt private-key=mycert.key
```
