### PR TITLE
CP-308049: rrdview tool

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,771 +1,854 @@
 (lang dune 3.15)
 
-(formatting (enabled_for ocaml))
+(formatting
+ (enabled_for ocaml))
+
 (using menhir 2.0)
+
 (using directory-targets 0.1)
+
 (opam_file_location inside_opam_directory)
 
 (cram enable)
+
 (implicit_transitive_deps false)
+
 (generate_opam_files true)
 
 (name "xapi")
-(source (github xapi-project/xen-api))
+
+(source
+ (github xapi-project/xen-api))
+
 (license "LGPL-2.1-only WITH OCaml-LGPL-linking-exception")
+
 (authors "xen-api@lists.xen.org")
+
 (maintainers "Xapi project maintainers")
+
 (homepage "https://xapi-project.github.io/")
 
 (package
-  (name zstd)
-)
-
+ (name zstd))
 
 (package
-  (name clock)
-  (synopsis "Xapi's library for managing time")
-  (authors "Jonathan Ludlam" "Pau Ruiz Safont")
-  (depends
-    (ocaml (>= 4.12))
-    (alcotest :with-test)
-    astring
-    fmt
-    mtime
-    ptime
-    (xapi-log (= :version))
-    (qcheck-core :with-test)
-    (qcheck-alcotest :with-test)
-  )
-)
+ (name clock)
+ (synopsis "Xapi's library for managing time")
+ (authors "Jonathan Ludlam" "Pau Ruiz Safont")
+ (depends
+  (ocaml
+   (>= 4.12))
+  (alcotest :with-test)
+  astring
+  fmt
+  mtime
+  ptime
+  (xapi-log
+   (= :version))
+  (qcheck-core :with-test)
+  (qcheck-alcotest :with-test)))
 
 (package
-  (name tgroup)
-  (depends
-    xapi-log
-    xapi-stdext-unix)
-)
+ (name tgroup)
+ (depends xapi-log xapi-stdext-unix))
 
 (package
-  (name xml-light2)
-)
+ (name xml-light2))
 
 (package
-  (name xapi-sdk)
-  (license "BSD-2-Clause")
-  (synopsis "Xen API SDK generation code")
-  (depends
-   (alcotest :with-test)
-   astring
-   (fmt :with-test)
-   mustache
-   (xapi-datamodel (= :version))
-   (xapi-stdext-unix (and (= :version) :with-test))
-   (xapi-test-utils :with-test)
-  )
-  (allow_empty)
-)
-(package
-  (name xen-api-client-lwt)
-)
-
+ (name xapi-sdk)
+ (license "BSD-2-Clause")
+ (synopsis "Xen API SDK generation code")
+ (depends
+  (alcotest :with-test)
+  astring
+  (fmt :with-test)
+  mustache
+  (xapi-datamodel
+   (= :version))
+  (xapi-stdext-unix
+   (and
+    (= :version)
+    :with-test))
+  (xapi-test-utils :with-test))
+ (allow_empty))
 
 (package
-  (name xen-api-client)
-  (synopsis "Xen-API client library for remotely-controlling a xapi host")
-  (authors "David Scott" "Anil Madhavapeddy" "Jerome Maloberti" "John Else" "Jon Ludlam" "Thomas Sanders" "Mike McClurg")
-  (depends
-   (alcotest :with-test)
-   astring
-   (cohttp (>= "0.22.0"))
-   re
-   rpclib
-   uri
-   (uuid (= :version))
-   (xapi-client (= :version))
-   (xapi-idl (= :version))
-   (xapi-rrd (= :version))
-   (xapi-types (= :version))
-   xmlm
-  )
-)
+ (name xen-api-client-lwt))
 
 (package
-  (name xe)
-)
+ (name xen-api-client)
+ (synopsis "Xen-API client library for remotely-controlling a xapi host")
+ (authors
+  "David Scott"
+  "Anil Madhavapeddy"
+  "Jerome Maloberti"
+  "John Else"
+  "Jon Ludlam"
+  "Thomas Sanders"
+  "Mike McClurg")
+ (depends
+  (alcotest :with-test)
+  astring
+  (cohttp
+   (>= "0.22.0"))
+  re
+  rpclib
+  uri
+  (uuid
+   (= :version))
+  (xapi-client
+   (= :version))
+  (xapi-idl
+   (= :version))
+  (xapi-rrd
+   (= :version))
+  (xapi-types
+   (= :version))
+  xmlm))
 
 (package
-  (name xapi-types)
-)
+ (name xe))
 
 (package
-  (name xapi-tracing)
-  (depends
-   ocaml
-   dune
-   (alcotest :with-test)
-   (fmt :with-test)
-   ppx_deriving_yojson
-   re
-   uri
-   (uuid :with-test)
-   (xapi-log (= :version))
-   (xapi-stdext-threads (= :version))
-   yojson
-  )
-  (synopsis "Allows to instrument code to generate tracing information")
-  (description "This library provides modules to allow gathering runtime traces.")
-)
+ (name xapi-types))
 
 (package
-  (name xapi-tracing-export)
-  (depends
-   ocaml
-   cohttp-posix
-   dune
-   cohttp
-   ptime
-   result
-   rresult
-   rpclib
-   ppx_deriving_rpc
-   uri
-   (xapi-log (= :version))
-   (xapi-open-uri (= :version))
-   (xapi-stdext-threads (= :version))
-   (xapi-stdext-unix (= :version))
-   (xapi-tracing (= :version))
-   (zstd (= :version))
-  )
-  (synopsis "Export traces in multiple protocols and formats")
-  (description "This library export traces is able to push traces to http endpoints or generate compressed tarballs in the filesystem.")
-)
+ (name xapi-tracing)
+ (depends
+  ocaml
+  dune
+  (alcotest :with-test)
+  (fmt :with-test)
+  ppx_deriving_yojson
+  re
+  uri
+  (uuid :with-test)
+  (xapi-log
+   (= :version))
+  (xapi-stdext-threads
+   (= :version))
+  yojson)
+ (synopsis "Allows to instrument code to generate tracing information")
+ (description
+  "This library provides modules to allow gathering runtime traces."))
 
 (package
-  (name xapi-storage-script)
-)
+ (name xapi-tracing-export)
+ (depends
+  ocaml
+  cohttp-posix
+  dune
+  cohttp
+  ptime
+  result
+  rresult
+  rpclib
+  ppx_deriving_rpc
+  uri
+  (xapi-log
+   (= :version))
+  (xapi-open-uri
+   (= :version))
+  (xapi-stdext-threads
+   (= :version))
+  (xapi-stdext-unix
+   (= :version))
+  (xapi-tracing
+   (= :version))
+  (zstd
+   (= :version)))
+ (synopsis "Export traces in multiple protocols and formats")
+ (description
+  "This library export traces is able to push traces to http endpoints or generate compressed tarballs in the filesystem."))
 
 (package
-  (name xapi-storage-cli)
-  (depends
-   cmdliner
-   re
-   rpclib
-   ppx_deriving_rpc
-   (xapi-client (= :version))
-   (xapi-idl (= :version))
-   (xapi-types (= :version))
-  )
-  (synopsis "A CLI for xapi storage services")
-  (description "The CLI allows you to directly manipulate virtual disk images, without them being attached to VMs.")
-)
+ (name xapi-storage-script))
 
 (package
-  (name xapi-storage)
-)
+ (name xapi-storage-cli)
+ (depends
+  cmdliner
+  re
+  rpclib
+  ppx_deriving_rpc
+  (xapi-client
+   (= :version))
+  (xapi-idl
+   (= :version))
+  (xapi-types
+   (= :version)))
+ (synopsis "A CLI for xapi storage services")
+ (description
+  "The CLI allows you to directly manipulate virtual disk images, without them being attached to VMs."))
 
 (package
-  (name xapi-schema)
-)
+ (name xapi-storage))
 
 (package
-  (name rrdd-plugin)
-  (synopsis "A plugin library for the xapi performance monitoring daemon")
-  (description "This library allows one to expose a datasource which can then be sampled by the performance monitoring daemon.")
-  (depends
-   ocaml
-   astring
-   rpclib
-   (rrd-transport (= :version))
-   (xapi-forkexecd (= :version))
-   (xapi-stdext-pervasives (= :version))
-   (xapi-stdext-std (= :version))
-   (xapi-stdext-threads (= :version))
-   (xapi-stdext-unix (= :version))
-   (xapi-idl (= :version))
-   xenstore
-   xenstore_transport
-  )
-)
+ (name xapi-schema))
 
 (package
-  (name xapi-open-uri)
-)
+ (name rrdd-plugin)
+ (synopsis "A plugin library for the xapi performance monitoring daemon")
+ (description
+  "This library allows one to expose a datasource which can then be sampled by the performance monitoring daemon.")
+ (depends
+  ocaml
+  astring
+  rpclib
+  (rrd-transport
+   (= :version))
+  (xapi-forkexecd
+   (= :version))
+  (xapi-stdext-pervasives
+   (= :version))
+  (xapi-stdext-std
+   (= :version))
+  (xapi-stdext-threads
+   (= :version))
+  (xapi-stdext-unix
+   (= :version))
+  (xapi-idl
+   (= :version))
+  xenstore
+  xenstore_transport))
 
 (package
-  (name xapi-nbd)
-)
+ (name xapi-open-uri))
 
 (package
-  (name xapi-log)
-)
+ (name xapi-nbd))
 
 (package
-  (name xapi-idl)
-)
+ (name xapi-log))
 
 (package
-  (name xapi-forkexecd)
-  (synopsis "Sub-process control service for xapi")
-  (description "This daemon creates and manages sub-processes on behalf of xapi.")
-  (depends
-   astring
-   (forkexec (= :version))
-   (uuid (= :version))
-   (xapi-stdext-unix (= :version))
-  )
-)
+ (name xapi-idl))
 
 (package
-  (name xapi-expiry-alerts)
-)
+ (name xapi-forkexecd)
+ (synopsis "Sub-process control service for xapi")
+ (description
+  "This daemon creates and manages sub-processes on behalf of xapi.")
+ (depends
+  astring
+  (forkexec
+   (= :version))
+  (uuid
+   (= :version))
+  (xapi-stdext-unix
+   (= :version))))
 
 (package
-  (name xapi-datamodel)
-)
+ (name xapi-expiry-alerts))
 
 (package
-  (name xapi-consts)
-)
+ (name xapi-datamodel))
 
 (package
-  (name xapi-compression)
-)
+ (name xapi-consts))
 
 (package
-  (name xapi-client)
-)
+ (name xapi-compression))
 
 (package
-  (name xapi-cli-protocol)
-)
+ (name xapi-client))
 
 (package
-  (name xapi-debug)
-  (synopsis "Debugging tools for XAPI")
-  (description "Tools installed into the non-standard /opt/xensource/debug location")
-  (depends
-    alcotest
-    angstrom
-    astring
-    base64
-    cmdliner
-    cohttp
-    cstruct
-    ctypes
-    domain-name
-    fd-send-recv
-    fmt
-    hex
-    integers
-    ipaddr
-    logs
-    magic-mime
-    mirage-crypto
-    mirage-crypto-pk
-    mirage-crypto-rng
-    mtime
-    pci
-    polly
-    ppx_deriving
-    ppx_deriving_rpc
-    ppx_sexp_conv
-    psq
-    ptime
-    qcheck-alcotest
-    qcheck-core
-    re
-    result
-    rpclib
-    rrdd-plugin
-    rresult
-    sexplib
-    sexplib0
-    sha
-    tar
-    tar-unix
-    uri
-    uuidm
-    uutf
-    x509
-    xapi-backtrace
-    xapi-log
-    xapi-types
-    xapi-stdext-pervasives
-    xapi-stdext-unix
-    xen-api-client
-    xen-api-client-lwt
-    xenctrl
-    xenstore_transport
-    xmlm
-    yojson
-  )
-)
+ (name xapi-cli-protocol))
 
 (package
-  (name xapi-tools)
-  (synopsis "Various daemons and CLI applications required by XAPI")
-  (description "Includes message-switch, xenopsd, forkexecd, ...")
-  (depends
-    astring
-    base64
-    cmdliner
-    cstruct-unix
-    fmt
-    logs
-    lwt
-    mtime
-    netlink
-    qmp
-    re
-    result
-    rpclib
-    rresult
-    uri
-    xenctrl
-    xmlm
-    yojson
-    ; can't use '= version' here yet,
-    ; 'xapi-tools' will have version ~dev, not 'master' like all the others
-    ; because it is not in xs-opam yet
-    rrd-transport
-    rrdd-plugin
-    xapi-tracing-export
-    xen-api-client
-    (alcotest :with-test)
-    (ppx_deriving_rpc :with-test)
-    (qcheck-core :with-test)
-    (xapi-test-utils :with-test)
-    (xenstore_transport :with-test)
-  )
-)
+ (name xapi-debug)
+ (synopsis "Debugging tools for XAPI")
+ (description
+  "Tools installed into the non-standard /opt/xensource/debug location")
+ (depends
+  alcotest
+  angstrom
+  astring
+  base64
+  cmdliner
+  cohttp
+  cstruct
+  ctypes
+  domain-name
+  fd-send-recv
+  fmt
+  hex
+  integers
+  ipaddr
+  logs
+  magic-mime
+  mirage-crypto
+  mirage-crypto-pk
+  mirage-crypto-rng
+  mtime
+  pci
+  polly
+  ppx_deriving
+  ppx_deriving_rpc
+  ppx_sexp_conv
+  psq
+  ptime
+  qcheck-alcotest
+  qcheck-core
+  re
+  result
+  rpclib
+  rrdd-plugin
+  rresult
+  sexplib
+  sexplib0
+  sha
+  tar
+  tar-unix
+  uri
+  uuidm
+  uutf
+  x509
+  xapi-backtrace
+  xapi-log
+  xapi-types
+  xapi-stdext-pervasives
+  xapi-stdext-unix
+  xen-api-client
+  xen-api-client-lwt
+  xenctrl
+  xenstore_transport
+  xmlm
+  yojson))
 
 (package
-  (name xapi)
-  (synopsis "The toolstack daemon which implements the XenAPI")
-  (description "This daemon exposes the XenAPI and is used by clients such as 'xe' and 'XenCenter' to manage clusters of Xen-enabled hosts.")
-  (depends
-    (ocaml (>= 4.09))
-    (alcotest :with-test)
-    angstrom
-    astring
-    base-threads
-    base64
-    (bos :with-test)
-    cdrom
-    (clock (= :version))
-    cmdliner
-    cohttp
-    conf-pam
-    (crowbar :with-test)
-    cstruct
-    ctypes
-    ctypes-foreign
-    domain-name
-    (ezxenstore (= :version))
-    fmt
-    fd-send-recv
-    hex
-    (http-lib (and :with-test (= :version))) ; the public library is only used for testing
-    integers
-    ipaddr
-    logs
-    magic-mime
-    mirage-crypto
-    mirage-crypto-pk
-    (mirage-crypto-rng (>= "0.11.0"))
-    (message-switch-unix (= :version))
-    mtime
-    opentelemetry-client-ocurl
-    pci
-    (pciutil (= :version))
-    polly
-    ppx_deriving_rpc
-    ppx_sexp_conv
-    ppx_deriving
-    psq
-    ptime
-    qcheck-alcotest
-    qcheck-core
-    re
-    result
-    rpclib
-    (rrdd-plugin (= :version))
-    rresult
-    sexpr
-    sexplib
-    sexplib0
-    sha
-    (stunnel (= :version))
-    tar
-    tar-unix
-    uri
-    tgroup
-    (uuid (= :version))
-    uutf
-    uuidm
-    x509
-    xapi-backtrace
-    (xapi-client (= :version))
-    (xapi-cli-protocol (= :version))
-    (xapi-consts (= :version))
-    (xapi-datamodel (= :version))
-    (xapi-expiry-alerts (= :version))
-    (xapi-idl (= :version))
-    (xapi-inventory (= :version))
-    (xapi-log (= :version))
-    (xapi-stdext-pervasives (= :version))
-    (xapi-stdext-std (= :version))
-    (xapi-stdext-threads (= :version))
-    (xapi-stdext-unix (= :version))
-    (xapi-stdext-zerocheck (= :version))
-    (xapi-test-utils :with-test)
-    (xapi-tracing (= :version))
-    (xapi-tracing-export (= :version))
-    (xapi-types (= :version))
-    (xen-api-client-lwt (= :version))
-    xenctrl ; for quicktest
-    xenstore_transport
-    xmlm
-    (xml-light2 (= :version))
-    yojson
-    (zstd (= :version))
-  )
-)
+ (name xapi-tools)
+ (synopsis "Various daemons and CLI applications required by XAPI")
+ (description "Includes message-switch, xenopsd, forkexecd, ...")
+ (depends
+  astring
+  base64
+  cmdliner
+  cstruct-unix
+  fmt
+  logs
+  lwt
+  mtime
+  netlink
+  qmp
+  re
+  result
+  rpclib
+  rresult
+  uri
+  tyre
+  xenctrl
+  xmlm
+  yojson
+  ; can't use '= version' here yet,
+  ; 'xapi-tools' will have version ~dev, not 'master' like all the others
+  ; because it is not in xs-opam yet
+  rrd-transport
+  rrdd-plugin
+  xapi-tracing-export
+  xen-api-client
+  (alcotest :with-test)
+  (ppx_deriving_rpc :with-test)
+  (qcheck-core :with-test)
+  (xapi-test-utils :with-test)
+  (xenstore_transport :with-test)))
 
 (package
-  (name vhd-tool)
-  (synopsis "Manipulate .vhd files")
-  (tags ("org.mirage" "org:xapi-project"))
-  (depends
-    (alcotest-lwt :with-test)
-    astring
-    bigarray-compat
-    cmdliner
-    cohttp
-    cohttp-lwt
-    conf-libssl
-    (cstruct (>= "3.0.0"))
-    (ezxenstore (= :version))
-    (forkexec (= :version))
-    io-page
-    lwt
-    lwt_ssl
-    nbd
-    nbd-unix
-    ppx_cstruct
-    ppx_deriving_rpc
-    re
-    result
-    rpclib
-    ssl
-    sha
-    tar
-    uri
-    (vhd-format (= :version))
-    (vhd-format-lwt (= :version))
-    (xapi-idl (= :version))
-    (xapi-log (= :version))
-    (xen-api-client-lwt (= :version))
-    xenstore
-    xenstore_transport
-  )
-)
+ (name xapi)
+ (synopsis "The toolstack daemon which implements the XenAPI")
+ (description
+  "This daemon exposes the XenAPI and is used by clients such as 'xe' and 'XenCenter' to manage clusters of Xen-enabled hosts.")
+ (depends
+  (ocaml
+   (>= 4.09))
+  (alcotest :with-test)
+  angstrom
+  astring
+  base-threads
+  base64
+  (bos :with-test)
+  cdrom
+  (clock
+   (= :version))
+  cmdliner
+  cohttp
+  conf-pam
+  (crowbar :with-test)
+  cstruct
+  ctypes
+  ctypes-foreign
+  domain-name
+  (ezxenstore
+   (= :version))
+  fmt
+  fd-send-recv
+  hex
+  (http-lib
+   (and
+    :with-test
+    (= :version))) ; the public library is only used for testing
+  integers
+  ipaddr
+  logs
+  magic-mime
+  mirage-crypto
+  mirage-crypto-pk
+  (mirage-crypto-rng
+   (>= "0.11.0"))
+  (message-switch-unix
+   (= :version))
+  mtime
+  opentelemetry-client-ocurl
+  pci
+  (pciutil
+   (= :version))
+  polly
+  ppx_deriving_rpc
+  ppx_sexp_conv
+  ppx_deriving
+  psq
+  ptime
+  qcheck-alcotest
+  qcheck-core
+  re
+  result
+  rpclib
+  (rrdd-plugin
+   (= :version))
+  rresult
+  sexpr
+  sexplib
+  sexplib0
+  sha
+  (stunnel
+   (= :version))
+  tar
+  tar-unix
+  uri
+  tgroup
+  (uuid
+   (= :version))
+  uutf
+  uuidm
+  x509
+  xapi-backtrace
+  (xapi-client
+   (= :version))
+  (xapi-cli-protocol
+   (= :version))
+  (xapi-consts
+   (= :version))
+  (xapi-datamodel
+   (= :version))
+  (xapi-expiry-alerts
+   (= :version))
+  (xapi-idl
+   (= :version))
+  (xapi-inventory
+   (= :version))
+  (xapi-log
+   (= :version))
+  (xapi-stdext-pervasives
+   (= :version))
+  (xapi-stdext-std
+   (= :version))
+  (xapi-stdext-threads
+   (= :version))
+  (xapi-stdext-unix
+   (= :version))
+  (xapi-stdext-zerocheck
+   (= :version))
+  (xapi-test-utils :with-test)
+  (xapi-tracing
+   (= :version))
+  (xapi-tracing-export
+   (= :version))
+  (xapi-types
+   (= :version))
+  (xen-api-client-lwt
+   (= :version))
+  xenctrl ; for quicktest
+  xenstore_transport
+  xmlm
+  (xml-light2
+   (= :version))
+  yojson
+  (zstd
+   (= :version))))
 
 (package
-  (name vhd-format)
-)
+ (name vhd-tool)
+ (synopsis "Manipulate .vhd files")
+ (tags
+  ("org.mirage" "org:xapi-project"))
+ (depends
+  (alcotest-lwt :with-test)
+  astring
+  bigarray-compat
+  cmdliner
+  cohttp
+  cohttp-lwt
+  conf-libssl
+  (cstruct
+   (>= "3.0.0"))
+  (ezxenstore
+   (= :version))
+  (forkexec
+   (= :version))
+  io-page
+  lwt
+  lwt_ssl
+  nbd
+  nbd-unix
+  ppx_cstruct
+  ppx_deriving_rpc
+  re
+  result
+  rpclib
+  ssl
+  sha
+  tar
+  uri
+  (vhd-format
+   (= :version))
+  (vhd-format-lwt
+   (= :version))
+  (xapi-idl
+   (= :version))
+  (xapi-log
+   (= :version))
+  (xen-api-client-lwt
+   (= :version))
+  xenstore
+  xenstore_transport))
 
 (package
-  (name vhd-format-lwt)
-  (synopsis "Lwt interface to read/write VHD format data")
-  (description "A pure OCaml library to read and write
-[vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
-simple command-line tool which allows vhd files to be interrogated,
-manipulated, format-converted and streamed to and from files and remote
-servers.
-
-This package provides an Lwt compatible interface to the library.")
-  (authors "Jon Ludlam" "Dave Scott")
-  (maintainers "Dave Scott <dave@recoil.org>")
-  (tags ("org:mirage" "org:xapi-project"))
-  (homepage "https://github.com/mirage/ocaml-vhd")
-  (source (github mirage/ocaml-vhd))
-  (depends
-    (ocaml (>= "4.10.0"))
-    (alcotest :with-test)
-    (alcotest-lwt (and :with-test (>= "1.0.0")))
-    (bigarray-compat (>= "1.1.0"))
-    (cstruct (>= "6.0.0"))
-    cstruct-lwt
-    (fmt :with-test)
-    (lwt (>= "3.2.0"))
-    (mirage-block (>= "3.0.0"))
-    (rresult (>= "0.7.0"))
-    (vhd-format (= :version))
-    (io-page (and :with-test (>= "2.4.0")))
-  )
-)
+ (name vhd-format))
 
 (package
-  (name varstored-guard)
-)
+ (name vhd-format-lwt)
+ (synopsis "Lwt interface to read/write VHD format data")
+ (description
+  "A pure OCaml library to read and write\n[vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a\nsimple command-line tool which allows vhd files to be interrogated,\nmanipulated, format-converted and streamed to and from files and remote\nservers.\n\nThis package provides an Lwt compatible interface to the library.")
+ (authors "Jon Ludlam" "Dave Scott")
+ (maintainers "Dave Scott <dave@recoil.org>")
+ (tags
+  ("org:mirage" "org:xapi-project"))
+ (homepage "https://github.com/mirage/ocaml-vhd")
+ (source
+  (github mirage/ocaml-vhd))
+ (depends
+  (ocaml
+   (>= "4.10.0"))
+  (alcotest :with-test)
+  (alcotest-lwt
+   (and
+    :with-test
+    (>= "1.0.0")))
+  (bigarray-compat
+   (>= "1.1.0"))
+  (cstruct
+   (>= "6.0.0"))
+  cstruct-lwt
+  (fmt :with-test)
+  (lwt
+   (>= "3.2.0"))
+  (mirage-block
+   (>= "3.0.0"))
+  (rresult
+   (>= "0.7.0"))
+  (vhd-format
+   (= :version))
+  (io-page
+   (and
+    :with-test
+    (>= "2.4.0")))))
 
 (package
-  (name uuid)
-)
+ (name varstored-guard))
 
 (package
-  (name stunnel)
-  (synopsis "Library used by xapi to herd stunnel processes")
-  (description "This library allows xapi to configure, launch and terminate stunnel processes that act as clients and servers.")
-  (depends
-    astring
-    (forkexec (= :version))
-    (safe-resources (= :version))
-    (uuid (= :version))
-    (xapi-consts (= :version))
-    xapi-inventory
-    (xapi-log (= :version))
-    (xapi-stdext-pervasives (= :version))
-    (xapi-stdext-threads (= :version))
-    (xapi-stdext-unix (= :version))
-    (odoc :with-doc)
-  )
-)
+ (name uuid))
 
 (package
-  (name sexpr)
-)
+ (name stunnel)
+ (synopsis "Library used by xapi to herd stunnel processes")
+ (description
+  "This library allows xapi to configure, launch and terminate stunnel processes that act as clients and servers.")
+ (depends
+  astring
+  (forkexec
+   (= :version))
+  (safe-resources
+   (= :version))
+  (uuid
+   (= :version))
+  (xapi-consts
+   (= :version))
+  xapi-inventory
+  (xapi-log
+   (= :version))
+  (xapi-stdext-pervasives
+   (= :version))
+  (xapi-stdext-threads
+   (= :version))
+  (xapi-stdext-unix
+   (= :version))
+  (odoc :with-doc)))
 
 (package
-  (name safe-resources)
-)
+ (name sexpr))
 
 (package
-  (name rrd-transport)
-  (synopsis "Shared-memory protocols for exposing system metrics")
-  (description "VMs running on a Xen host can use this library to expose performance counters which can be sampled by xapi's metric daemon.")
-  (authors "John Else")
-  (depends
-    (alcotest :with-test)
-    astring
-    bigarray-compat
-    cstruct
-    crc
-    (fmt :with-test)
-    rpclib
-    yojson
-    (xapi-idl (= :version))
-    (xapi-rrd (= :version))
-    (odoc :with-doc)
-  )
-)
+ (name safe-resources))
 
 (package
-  (name pciutil)
-)
+ (name rrd-transport)
+ (synopsis "Shared-memory protocols for exposing system metrics")
+ (description
+  "VMs running on a Xen host can use this library to expose performance counters which can be sampled by xapi's metric daemon.")
+ (authors "John Else")
+ (depends
+  (alcotest :with-test)
+  astring
+  bigarray-compat
+  cstruct
+  crc
+  (fmt :with-test)
+  rpclib
+  yojson
+  (xapi-idl
+   (= :version))
+  (xapi-rrd
+   (= :version))
+  (odoc :with-doc)))
 
 (package
-  (name message-switch-lwt)
-)
+ (name pciutil))
 
 (package
-  (name message-switch-core)
-  (synopsis "A simple store-and-forward message switch")
-  (description "The switch stores messages in queues with well-known names. Clients use a simple HTTP protocol to enqueue and dequeue messages.")
-  (depends
-    astring
-    (cohttp (>= "0.21.1"))
-    ppx_deriving_rpc
-    ppx_sexp_conv
-    rpclib
-    sexplib
-    sexplib0
-    uri
-    (xapi-log (= :version))
-    (xapi-stdext-threads (= :version))
-    (odoc :with-doc)
-  )
-)
+ (name message-switch-lwt))
 
 (package
-  (name message-switch-cli)
-)
+ (name message-switch-core)
+ (synopsis "A simple store-and-forward message switch")
+ (description
+  "The switch stores messages in queues with well-known names. Clients use a simple HTTP protocol to enqueue and dequeue messages.")
+ (depends
+  astring
+  (cohttp
+   (>= "0.21.1"))
+  ppx_deriving_rpc
+  ppx_sexp_conv
+  rpclib
+  sexplib
+  sexplib0
+  uri
+  (xapi-log
+   (= :version))
+  (xapi-stdext-threads
+   (= :version))
+  (odoc :with-doc)))
 
 (package
-  (name message-switch-unix)
-  (synopsis "A simple store-and-forward message switch")
-  (description "The switch stores messages in queues with well-known names. Clients use a simple HTTP protocol to enqueue and dequeue messages.")
-  (depends
-    base-threads
-    cohttp
-    (message-switch-core (= :version))
-    ppx_deriving_rpc
-    rpclib
-    (xapi-stdext-threads (= :version))
-  )
-)
+ (name message-switch-cli))
 
 (package
-  (name message-switch)
-)
+ (name message-switch-unix)
+ (synopsis "A simple store-and-forward message switch")
+ (description
+  "The switch stores messages in queues with well-known names. Clients use a simple HTTP protocol to enqueue and dequeue messages.")
+ (depends
+  base-threads
+  cohttp
+  (message-switch-core
+   (= :version))
+  ppx_deriving_rpc
+  rpclib
+  (xapi-stdext-threads
+   (= :version))))
 
 (package
-  (name http-lib)
-  (synopsis "An HTTP required used by xapi")
-  (description "This library allows xapi to perform varios activities related to the HTTP protocol.")
-  (depends
-    (alcotest :with-test)
-    astring
-    (base64 (>= "3.1.0"))
-    (clock (= :version))
-    fmt
-    ipaddr
-    mtime
-    ppx_deriving_rpc
-    (qcheck-core :with-test)
-    rpclib
-    (safe-resources(= :version))
-    sha
-    (stunnel (= :version))
-    tgroup
-    uri
-    (uuid (= :version))
-    xapi-backtrace
-    (xapi-idl (= :version))
-    (xapi-log (= :version))
-    (xapi-stdext-pervasives (= :version))
-    (xapi-stdext-threads (= :version))
-    (xapi-tracing (= :version))
-    (xml-light2 (= :version))
-    (odoc :with-doc)
-  )
-)
+ (name message-switch))
 
 (package
-  (name gzip)
-)
+ (name http-lib)
+ (synopsis "An HTTP required used by xapi")
+ (description
+  "This library allows xapi to perform varios activities related to the HTTP protocol.")
+ (depends
+  (alcotest :with-test)
+  astring
+  (base64
+   (>= "3.1.0"))
+  (clock
+   (= :version))
+  fmt
+  ipaddr
+  mtime
+  ppx_deriving_rpc
+  (qcheck-core :with-test)
+  rpclib
+  (safe-resources
+   (= :version))
+  sha
+  (stunnel
+   (= :version))
+  tgroup
+  uri
+  (uuid
+   (= :version))
+  xapi-backtrace
+  (xapi-idl
+   (= :version))
+  (xapi-log
+   (= :version))
+  (xapi-stdext-pervasives
+   (= :version))
+  (xapi-stdext-threads
+   (= :version))
+  (xapi-tracing
+   (= :version))
+  (xml-light2
+   (= :version))
+  (odoc :with-doc)))
 
 (package
-  (name forkexec)
-  (synopsis "Process-spawning library")
-  (description "Client and server library to spawn processes.")
-  (depends
-    astring
-    base-threads
-    (fd-send-recv (>= "2.0.0"))
-    ppx_deriving_rpc
-    rpclib
-    (uuid (= :version))
-    xapi-backtrace
-    (xapi-log (= :version))
-    (xapi-stdext-pervasives (= :version))
-    (xapi-stdext-unix (= :version))
-    (xapi-tracing (= :version))
-  )
-)
+ (name gzip))
 
 (package
-  (name ezxenstore)
-)
+ (name forkexec)
+ (synopsis "Process-spawning library")
+ (description "Client and server library to spawn processes.")
+ (depends
+  astring
+  base-threads
+  (fd-send-recv
+   (>= "2.0.0"))
+  ppx_deriving_rpc
+  rpclib
+  (uuid
+   (= :version))
+  xapi-backtrace
+  (xapi-log
+   (= :version))
+  (xapi-stdext-pervasives
+   (= :version))
+  (xapi-stdext-unix
+   (= :version))
+  (xapi-tracing
+   (= :version))))
 
 (package
-  (name cohttp-posix)
-)
+ (name ezxenstore))
 
 (package
-  (name xapi-rrd)
-)
+ (name cohttp-posix))
 
 (package
-  (name xapi-inventory)
-)
+ (name xapi-rrd))
 
 (package
-  (name xapi-stdext-encodings)
-  (synopsis "Xapi's standard library extension, Encodings")
-  (authors "Jonathan Ludlam")
-  (depends
-    (ocaml (>= 4.13.0))
-    (alcotest (and (>= 0.6.0) :with-test))
-    (odoc :with-doc)
-    (bechamel :with-test)
-    (bechamel-notty :with-test)
-    (notty :with-test)
-  )
-)
+ (name xapi-inventory))
 
 (package
-  (name xapi-stdext-pervasives)
-  (synopsis "Xapi's standard library extension, Pervasives")
-  (authors "Jonathan Ludlam")
-  (depends
-    (ocaml (>= 4.08))
-    logs
-    (odoc :with-doc)
-    xapi-backtrace
-  )
-)
+ (name xapi-stdext-encodings)
+ (synopsis "Xapi's standard library extension, Encodings")
+ (authors "Jonathan Ludlam")
+ (depends
+  (ocaml
+   (>= 4.13.0))
+  (alcotest
+   (and
+    (>= 0.6.0)
+    :with-test))
+  (odoc :with-doc)
+  (bechamel :with-test)
+  (bechamel-notty :with-test)
+  (notty :with-test)))
 
 (package
-  (name xapi-stdext-std)
-  (synopsis "Xapi's standard library extension, Stdlib")
-  (depends
-    (ocaml (>= 4.08.0))
-    (alcotest :with-test)
-    (odoc :with-doc)
-  )
-)
+ (name xapi-stdext-pervasives)
+ (synopsis "Xapi's standard library extension, Pervasives")
+ (authors "Jonathan Ludlam")
+ (depends
+  (ocaml
+   (>= 4.08))
+  logs
+  (odoc :with-doc)
+  xapi-backtrace))
 
 (package
-  (name xapi-stdext-threads)
-  (synopsis "Xapi's standard library extension, Threads")
-  (authors "Jonathan Ludlam")
-  (depends
-    ambient-context
-    base-threads
-    base-unix
-    (alcotest :with-test)
-    (clock (= :version))
-    (fmt :with-test)
-    mtime
-    tgroup
-    (xapi-log (= :version))
-    (xapi-stdext-pervasives (= :version))
-    (xapi-stdext-unix (= :version))
-  )
-)
+ (name xapi-stdext-std)
+ (synopsis "Xapi's standard library extension, Stdlib")
+ (depends
+  (ocaml
+   (>= 4.08.0))
+  (alcotest :with-test)
+  (odoc :with-doc)))
 
 (package
-  (name xapi-stdext-unix)
-  (synopsis "Xapi's standard library extension, Unix")
-  (authors "Jonathan Ludlam")
-  (depends
-    (ocaml (>= 4.12.0))
-    (alcotest :with-test)
-    astring
-    base-unix
-    (bisect_ppx :with-test)
-    (clock (and (= :version) :with-test))
-    (fd-send-recv (>= 2.0.0))
-    fmt
-    integers
-    (mtime (and (>= 2.0.0) :with-test))
-    (logs :with-test)
-    (qcheck-core (and (>= 0.21.2) :with-test))
-    (odoc :with-doc)
-    xapi-backtrace
-    unix-errno
-    (xapi-stdext-pervasives (= :version))
-    polly
-  )
-)
+ (name xapi-stdext-threads)
+ (synopsis "Xapi's standard library extension, Threads")
+ (authors "Jonathan Ludlam")
+ (depends
+  ambient-context
+  base-threads
+  base-unix
+  (alcotest :with-test)
+  (clock
+   (= :version))
+  (fmt :with-test)
+  mtime
+  tgroup
+  (xapi-log
+   (= :version))
+  (xapi-stdext-pervasives
+   (= :version))
+  (xapi-stdext-unix
+   (= :version))))
 
 (package
-  (name xapi-stdext-zerocheck)
-  (synopsis "Xapi's standard library extension, Zerocheck")
-  (authors "Jonathan Ludlam")
-  (depends
-    (odoc :with-doc)
-  )
-)
+ (name xapi-stdext-unix)
+ (synopsis "Xapi's standard library extension, Unix")
+ (authors "Jonathan Ludlam")
+ (depends
+  (ocaml
+   (>= 4.12.0))
+  (alcotest :with-test)
+  astring
+  base-unix
+  (bisect_ppx :with-test)
+  (clock
+   (and
+    (= :version)
+    :with-test))
+  (fd-send-recv
+   (>= 2.0.0))
+  fmt
+  integers
+  (mtime
+   (and
+    (>= 2.0.0)
+    :with-test))
+  (logs :with-test)
+  (qcheck-core
+   (and
+    (>= 0.21.2)
+    :with-test))
+  (odoc :with-doc)
+  xapi-backtrace
+  unix-errno
+  (xapi-stdext-pervasives
+   (= :version))
+  polly))
+
+(package
+ (name xapi-stdext-zerocheck)
+ (synopsis "Xapi's standard library extension, Zerocheck")
+ (authors "Jonathan Ludlam")
+ (depends
+  (odoc :with-doc)))

--- a/ocaml/xcp-rrdd/bin/rrdview/dune
+++ b/ocaml/xcp-rrdd/bin/rrdview/dune
@@ -1,0 +1,17 @@
+(executable
+ (modes byte exe)
+ (name rrdview)
+ ;(public_name rrdview)
+ (libraries
+  threads
+  xapi-rrd.unix
+  bos.setup
+  astring
+  fpath
+  rresult
+  xmlm
+  tyre
+  xapi-rrd
+  result)
+ ;(package xapi-tools)
+ )

--- a/ocaml/xcp-rrdd/bin/rrdview/rrdgraph.ml
+++ b/ocaml/xcp-rrdd/bin/rrdview/rrdgraph.ml
@@ -1,0 +1,83 @@
+open Rrd
+
+type vname = VName of string
+
+module Rpn = struct
+  module VDef = struct
+    (* see rrdgraph_rpn(3) *)
+    type t = vname * string
+
+    type op = vname -> t
+
+    let op kind vname = (vname, kind)
+
+    let maximum = op "MAXIMUM"
+
+    let minimum = op "MINIMUM"
+
+    let average = op "AVERAGE"
+
+    let stdev = op "STDEV"
+
+    let last = op "LAST"
+
+    let first = op "FIRST"
+
+    let total = op "TOTAL"
+
+    let percent = op "PERCENT"
+
+    let percentnan = op "PERCENTNAN"
+
+    let lsl_slope = op "LSLSLOPE"
+
+    let lsl_intercept = op "LSLSLINT"
+
+    let lsl_correlation = op "LSLCORREL"
+  end
+
+  module CDef = struct
+    type t = string Seq.t (* stores a serialized RPN expression *)
+
+    let to_string r = r |> List.of_seq |> String.concat ","
+
+    let vname (VName vname) = Seq.return vname
+
+    let value f = Printf.sprintf "%g" f |> Seq.return
+
+    (* reverse polish notation: arguments first, operator last *)
+
+    let opn op args = Seq.append (List.to_seq args |> Seq.concat) (Seq.return op)
+
+    let op1 op arg = opn op [arg]
+
+    let op2 op arg1 arg2 = opn op [arg1; arg2]
+
+    let op3 op arg1 arg2 arg3 = opn op [arg1; arg2; arg3]
+  end
+end
+
+module Data = struct
+  type t = string
+
+  (* see rrdgraph_data (3) *)
+
+  let def vname rrdfile rrd rra ds =
+    let step = Int64.mul rrd.timestep @@ Int64.of_int rra.rra_pdp_cnt in
+    ( VName vname
+    , String.concat ":"
+        [
+          "DEF"
+        ; vname ^ "=" ^ Fpath.to_string rrdfile
+        ; ds.ds_name
+        ; Rrd.cf_type_to_string rra.rra_cf
+        ; Printf.sprintf "step=%Lu" step
+        ]
+    )
+
+  let vdef vname (VName var, rpnvdefop) =
+    (VName vname, Printf.sprintf "CDEF:%s=%s,%s" vname var rpnvdefop)
+
+  let cdef vname rpn =
+    (VName vname, Printf.sprintf "CDEF:%s=%s" vname (Rpn.CDef.to_string rpn))
+end

--- a/ocaml/xcp-rrdd/bin/rrdview/rrdgraph.mli
+++ b/ocaml/xcp-rrdd/bin/rrdview/rrdgraph.mli
@@ -1,0 +1,88 @@
+(** a variable name *)
+type vname
+
+module Rpn : sig
+  (** RPN expressions for VDEF statements, see [rrdgraph_rpn(3)] *)
+  module VDef : sig
+    (** an RPN expression for VDEF, see [rrdgraph_data(3)] *)
+    type t
+
+    (** a VDEF RPN expression, see [rrdgraph_rpn(3)] *)
+    type op = vname -> t
+
+    val maximum : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val minimum : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val average : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val stdev : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val last : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val first : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val total : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val percent : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val percentnan : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val lsl_slope : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val lsl_intercept : op
+    (** see [rrdgraph_rpn(3)] *)
+
+    val lsl_correlation : op
+    (** see [rrdgraph_rpn(3)] *)
+  end
+
+  module CDef : sig
+    (** an RPN expression for CDEF, see [rrdgraph_data(3)] *)
+    type t
+
+    val vname : vname -> t
+    (** [vname v] is [v] as an RPN expression *)
+
+    val value : float -> t
+    (** [value v] is [v] as an RPN expression *)
+
+    val op1 : string -> t -> t
+    (** [op1 op arg1] is [op arg1]. For valid operators see [rrdgraph_rpn(3)] *)
+
+    val op2 : string -> t -> t -> t
+    (** [op2 op arg1 arg2] is [op arg1 arg2]. For valid operators see [rrdgraph_rpn(3)] *)
+
+    val op3 : string -> t -> t -> t -> t
+    (** [op3 op arg1 arg2 arg3] is [op arg1 arg2 arg3]. For valid operators see [rrdgraph_rpn(3)] *)
+  end
+end
+
+module Data : sig
+  (** an rrd graph data definition, see [rrdgraph_data(3)] *)
+  type t
+
+  val def : string -> Fpath.t -> Rrd.rrd -> Rrd.rra -> Rrd.ds -> vname * t
+  (** [def vname rrdfile rrd rra datasource] is a [DEF] (see [rrdgraph_data(3)]) that loads
+      [datasource.ds_name] from the [rrdfile] and plots it according to the consolidation function in the
+      specified [rra] and timestep calculated based on [rrd]. This data can be refered to as [vname]
+      elsewhere. *)
+
+  val vdef : string -> Rpn.VDef.t -> vname * t
+  (** [vdef vname vdefrpn] defines [vname] through a [VDEF] (see [rrdgraph_data(3)]) using the
+  specified [vdefrpn] expression. Conversion to RPN form is handled internally. *)
+
+  val cdef : string -> Rpn.CDef.t -> vname * t
+  (** [cdef vname cdefrpn] defines [vname] through a [CDEF] (see [rrdgraph_data(3)]) using the
+  specified [cdefrpn] expression. Conversion to RPN form is handled internally. *)
+end

--- a/ocaml/xcp-rrdd/bin/rrdview/rrdview.ml
+++ b/ocaml/xcp-rrdd/bin/rrdview/rrdview.ml
@@ -1,0 +1,483 @@
+(*
+ * Copyright (C) 2006-2009 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Bos_setup
+
+type def = Def of string * Rrd.cf_type | Cdef of string
+
+let name ~ds_name ~cf_type =
+  cf_type
+  |> Rrd.cf_type_to_string
+  |> String.Ascii.lowercase
+  |> Printf.sprintf "%s_%s" ds_name
+
+type ds_def = {units: string option}
+
+let default_def = {units= None}
+
+let def ~data ~step ~ds_name ~cf_type =
+  let cfstr = Rrd.cf_type_to_string cf_type in
+  let namestr = name ~ds_name ~cf_type in
+  ( Def (ds_name, cf_type)
+  , Printf.sprintf "DEF:%s=%s:%s:%s:step=%Ld" namestr (Fpath.to_string data)
+      ds_name cfstr step
+  )
+
+type ds = Ds : string -> ds
+
+type cdef = Op of cdef * string * cdef | Var of def
+
+let rec string_of_cdef = function
+  | Op (lhs, op, rhs) ->
+      String.concat ~sep:"," [string_of_cdef lhs; string_of_cdef rhs; op]
+  | Var (Def (ds_name, cf_type)) ->
+      name ~ds_name ~cf_type
+  | Var (Cdef s) ->
+      s
+
+let cdef name ops =
+  (Cdef name, Printf.sprintf "CDEF:%s=%s" name @@ string_of_cdef ops)
+
+type rgb = {r: int; g: int; b: int; alpha: int option}
+
+type fill = RGB of rgb
+
+let shape ?(stack = false) kind ?label ~def fill =
+  let defstr =
+    match def with
+    | Def (ds_name, cf_type) ->
+        name ~ds_name ~cf_type
+    | Cdef str ->
+        str
+  in
+  let fillstr =
+    match fill with
+    | Some (RGB {r; g; b; alpha}) ->
+        Printf.sprintf "#%02x%02x%02x%s" r g b
+          (Option.fold ~none:"" ~some:(Printf.sprintf "%02u") alpha)
+    | None ->
+        ""
+  in
+  Printf.sprintf "%s:%s%s%s%s" kind defstr fillstr
+    (if stack then ":STACK" else "")
+    (match label with None -> "" | Some x -> ":" ^ x)
+
+let area = shape "AREA"
+
+let area_stack = shape ~stack:true "AREA"
+
+let line ?label = shape ?label "LINE"
+
+(* colors from rrdtool wiki OutlinedAreaGraph  *)
+let rgb ?alpha hex =
+  let r = (hex lsr 16) land 0xff
+  and g = (hex lsr 8) land 0xff
+  and b = hex land 0xff in
+  RGB {r; g; b; alpha}
+
+let rgb light dark = (rgb light, rgb dark)
+
+let colors =
+  [|
+     rgb 0x54EC48 0x24BC14
+   ; rgb 0x48C4EC 0x1598C3
+   ; rgb 0xDE48EC 0xB415C7
+   ; rgb 0x7648EC 0x4D18E4
+   ; rgb 0xEA644A 0xCC3118
+   ; rgb 0xEC9D48 0xCC7016
+   ; rgb 0xECD748 0xC9B215
+  |]
+
+let get_color ~dark i =
+  let RGB col_light, col_dark = colors.(i mod Array.length colors) in
+  Some (if dark then col_dark else RGB {col_light with alpha= Some 50})
+
+let rrdtool ~filename ~data title ~ds_names ~first ~last ~step ~width
+    ~has_min_max =
+  let graph =
+    List.of_seq
+      (ds_names
+      |> List.mapi (fun x s -> (s, x))
+      |> List.to_seq
+      |> Seq.flat_map @@ fun (ds_name, i) ->
+         Seq.append
+           ( if has_min_max then
+               let ds_min, def1 = def ~step ~data ~ds_name ~cf_type:Rrd.CF_Min
+               and ds_max, def2 =
+                 def ~step ~data ~ds_name ~cf_type:Rrd.CF_Max
+               in
+               let ds_range, cdef1 =
+                 cdef (ds_name ^ "range") (Op (Var ds_max, "-", Var ds_min))
+               in
+               List.to_seq
+                 [
+                   def1
+                 ; def2
+                 ; cdef1
+                 ; area ~def:ds_min None
+                 ; area_stack ~def:ds_range @@ get_color ~dark:false i
+                 ]
+             else
+               Seq.empty
+           )
+           (let ds_avg, def3 =
+              def ~step ~data ~ds_name ~cf_type:Rrd.CF_Average
+            in
+            List.to_seq
+              [def3; line ~label:ds_name ~def:ds_avg @@ get_color ~dark:true i]
+           )
+      )
+  in
+  Cmd.(
+    v "rrdtool"
+    % "graph"
+    % "--imgformat"
+    % "SVG"
+    % Fpath.to_string filename
+    % "--title"
+    % title
+    % "--width"
+    % string_of_int width
+    % "--height"
+    % "256" (* ~4 rows *)
+    % "--start"
+    % Int64.to_string first
+    % "--end"
+    % Int64.to_string last
+    %% of_list graph
+  )
+
+let prepare_plot_cmds ~filename ~data rrd =
+  let open Rrd in
+  let has cf rra = rra.rra_cf = cf in
+  let has_min =
+    Array.find_opt (has Rrd.CF_Min) rrd.rrd_rras |> Option.is_some
+  in
+  let has_max =
+    Array.find_opt (has Rrd.CF_Max) rrd.rrd_rras |> Option.is_some
+  in
+  rrd.rrd_rras
+  |> Array.to_seq
+  |> Seq.map @@ fun rra ->
+     let timespan =
+       Int64.mul (Int64.of_int (rra.rra_pdp_cnt * rra.rra_row_cnt)) rrd.timestep
+     in
+     let start = rrd.last_updated -. Int64.to_float timespan in
+     let filename =
+       Fpath.add_ext (Int64.to_string timespan) filename |> Fpath.add_ext "svg"
+     in
+     let title =
+       Fpath.rem_ext filename
+       |> Fpath.basename
+       |> String.cuts ~sep:"."
+       |> String.concat ~sep:"<br/>"
+     in
+     let step = Int64.(mul (of_int rra.rra_pdp_cnt) rrd.timestep) in
+     let width = 2 * rra.rra_row_cnt in
+     (* 1 point = 1 CDP from the RRA *)
+     (* TODO: could look up original names in original_ds *)
+     rrdtool ~step ~width ~data ~filename title ~ds_names:(ds_names rrd)
+       ~has_min_max:(has_min && has_max) ~first:(Int64.of_float start)
+       ~last:(Int64.of_float rrd.last_updated)
+
+let prepare_plots ?(exec = false) ~filename ~data rrd =
+  let output = Fpath.set_ext ".sh" filename in
+  let cmds = prepare_plot_cmds ~filename ~data rrd in
+  if exec then
+    cmds
+    |> Seq.iter @@ fun cmd ->
+       OS.Cmd.run cmd
+       |> Logs.on_error_msg ~use:(fun () -> failwith "failed to run rrdtool")
+  else
+    cmds
+    |> Seq.map Cmd.to_string
+    |> List.of_seq
+    |> OS.File.write_lines output
+    |> Logs.on_error_msg ~use:(fun _ -> exit 2)
+
+let finally f ~(always : unit -> unit) =
+  match f () with
+  | result ->
+      always () ; result
+  | exception e ->
+      always () ; raise e
+
+let with_input_file path f =
+  if Fpath.has_ext "gz" path then
+    let cmd = Cmd.(v "zcat" % p path) in
+    let ic = cmd |> Cmd.to_string |> Unix.open_process_in in
+    finally
+      (fun () -> f ic)
+      ~always:(fun () ->
+        let (_ : Unix.process_status) = Unix.close_process_in ic in
+        ()
+      )
+  else
+    let ic = open_in Fpath.(to_string path) in
+    finally (fun () -> f ic) ~always:(fun () -> close_in ic)
+
+let with_input_rrd f filename =
+  with_input_file filename @@ fun ic ->
+  Logs.info (fun m -> m "Parsing RRD %a" Fpath.pp filename) ;
+  let input = Xmlm.make_input (`Channel ic) in
+  let rrd = Rrd.from_xml input in
+  f ~filename rrd
+
+(* to avoid mixing data source and filenames we use a different type here *)
+
+let make_ds ?filename dsname =
+  let dsname =
+    if String.length dsname >= 20 then (
+      Logs.warn (fun m ->
+          m "RRD data source name exceeds 20 char limit: %s" dsname
+      ) ;
+      String.with_range dsname ~len:19
+    ) else
+      dsname
+  in
+  (Option.map Fpath.v filename, Ds dsname)
+
+let make_sr (dsname, uuid) = make_ds ~filename:("_sr_" ^ uuid) dsname
+
+let make_vbd (vbd, dsname) = make_ds ~filename:vbd dsname
+
+let make_runstate dsname = make_ds ~filename:"runstate" dsname
+
+(* top-level value to compile regexes only once *)
+let classify =
+  (* some RRD data source names are too long, max is 20 chars.
+     Splitting RRDs into different files allows to shorten the names,
+     e.g. remove the UUID from SR datasources.
+     Some names are still too long, but those can be shortened without losing information. *)
+  let open Tyre in
+  let uuid8 = pcre "[0-9a-f]{8}" in
+  let uuid_rest = pcre "(-[0-9a-f]{4}){3}-[0-9a-f]{12}" in
+  let dsname = pcre "[a-zA-Z_]+" in
+  let shorten from target = str from --> fun () -> make_ds target in
+  [
+    (dsname <&> char '_' *> uuid8) --> make_sr
+  ; (str "sr_" *> uuid8 <* uuid_rest <* char '_' <&> dsname) --> make_sr
+  ; shorten "Tapdisks_in_low_memory_mode" "Tapdisks_in_lowmem"
+  ; ( (opt dsname <* str "memory_" <&> dsname) --> fun (pre, post) ->
+      make_ds (Option.value ~default:"" pre ^ "mem_" ^ post)
+    )
+  ; (pcre "vbd_[^_]+" <* char '_' <&> dsname) --> make_vbd
+  ; (str "runstate_" *> dsname) --> make_runstate
+  ; ( (str "cpu" *> int <&> opt @@ (str "-C" *> int)) --> fun (cpuidx, cstate) ->
+      let filename =
+        match cstate with None -> "cpu" | Some n -> Printf.sprintf "cpu-C%d" n
+      in
+      make_ds ~filename ("cpu" ^ string_of_int cpuidx)
+    )
+  ; (str "cpu_avg" --> fun () -> make_ds ~filename:"cpu_avg" "cpu_avg")
+  ; (pcre "pif_" *> dsname) --> make_ds ~filename:"pif"
+    (* TODO: could provide info on polarity based on rx/tx and on kind, TICK for errors *)
+  ]
+  |> route
+
+let classify_dsname dsname =
+  let error _ = make_ds dsname in
+  dsname |> Tyre.exec classify |> Result.fold ~ok:Fun.id ~error
+
+let classify ~ds_def ~filename ds =
+  let open Rrd in
+  let override, dsname = classify_dsname ds.ds_name in
+  let pathname =
+    let name = Fpath.rem_ext filename in
+    match override with
+    | None ->
+        Fpath.(name + "_filtered")
+    | Some newname ->
+        Fpath.(name + to_string newname)
+  in
+  (* Logs.debug (fun m -> m "%s -> %a" ds.ds_name Fpath.pp pathname); *)
+  let def =
+    StringMap.find_opt ds.ds_name ds_def |> Option.value ~default:default_def
+  in
+  (* can only plot graphs with same units *)
+  let extra =
+    match def.units with
+    | None ->
+        (* use RRD type as approximation to "same unit", at least same kind of unit,
+           e.g. rate vs duration *)
+        Rrd.ds_type_to_string ds.ds_ty
+    | Some u ->
+        String.take ~sat:Char.Ascii.is_alphanum u
+  in
+  (Fpath.(pathname + extra |> add_ext "xml"), dsname)
+
+let rrdtool =
+  OS.Cmd.resolve (Cmd.v "rrdtool")
+  |> Logs.on_error_msg ~use:(fun () -> failwith "rrdtool is not installed")
+
+let rrd_restore filename rrd =
+  let filename = Fpath.set_ext "xml" filename in
+  Logs.debug (fun m -> m "Writing RRD xml to %a" Fpath.pp filename) ;
+  let () =
+    Out_channel.with_open_text (Fpath.to_string filename) @@ fun ch ->
+    Rrd_unix.to_fd rrd (Unix.descr_of_out_channel ch)
+  in
+  let dot_rrd = Fpath.set_ext "rrd" filename in
+  Logs.debug (fun m -> m "Restoring RRD to %a" Fpath.pp dot_rrd) ;
+  Cmd.(rrdtool % "restore" % "-f" % p filename % p dot_rrd)
+  |> OS.Cmd.run
+  |> Result.map (fun () -> dot_rrd)
+
+let split_rrd ~ds_def ~filename rrd =
+  let open Rrd in
+  let rrds = Hashtbl.create 3 in
+  let original_ds = Hashtbl.create 127 in
+
+  (* split the rrd into multiple rrds based on data source name *)
+  let () =
+    Logs.info (fun m -> m "classifying data sources") ;
+    rrd.rrd_dss
+    |> Array.iteri @@ fun i ds ->
+       let filename, Ds ds_name = classify ~ds_def ~filename ds in
+       let get_i rra = (rra.rra_data.(i), rra.rra_cdps.(i)) in
+       let previous =
+         Hashtbl.find_opt rrds filename |> Option.value ~default:[]
+       in
+       Hashtbl.replace original_ds ds_name ds ;
+       Hashtbl.replace rrds filename
+       @@ (({ds with ds_name}, Array.map get_i rrd.rrd_rras) :: previous)
+  in
+  Logs.info (fun m -> m "Building and restoring RRDs") ;
+  (* now build an RRD and restore it to binary .rrd form *)
+  rrds
+  |> Hashtbl.iter @@ fun filename lst ->
+     Logs.debug (fun m -> m "Building %a" Fpath.pp filename) ;
+     let rrd_dss, rrd_rras = List.split lst in
+     let rrd_rras =
+       rrd.rrd_rras
+       |> Array.mapi @@ fun i rra ->
+          let rra_seq = List.to_seq rrd_rras in
+          let geti a = a.(i) in
+          {
+            rra with
+            rra_data= rra_seq |> Seq.map geti |> Seq.map fst |> Array.of_seq
+          ; rra_cdps= rra_seq |> Seq.map geti |> Seq.map snd |> Array.of_seq
+          }
+     in
+     let rrd = {rrd with rrd_dss= Array.of_list rrd_dss; rrd_rras} in
+     let data =
+       rrd_restore filename rrd
+       |> Logs.on_error_msg ~use:(fun () -> failwith "Failed to restore RRD")
+     in
+     prepare_plots ~filename ~data rrd
+
+type mode = Split | Default | Plot
+
+let parse_ds_def def k v =
+  match k with "units" when v <> "unknown" -> {units= Some v} | _ -> def
+
+let parse_ds_defs path =
+  Logs.info (fun m -> m "Loading data source definitions from %a" Fpath.pp path) ;
+  let fields line =
+    line
+    |> String.cut ~sep:":"
+    |> Option.map @@ fun (k, v) -> (String.trim k, String.trim v)
+  in
+  let fold (map, key_opt) line =
+    match (fields line, key_opt) with
+    | Some ("name_label", ds_name), None ->
+        (map, Some ds_name) (* start parsing new item *)
+    | _, None ->
+        (map, None) (* ignore *)
+    | None, Some _ ->
+        (map, None)
+    | Some (k, v), Some ds_name ->
+        let map =
+          map
+          |> Rrd.StringMap.update ds_name @@ fun def ->
+             Some (parse_ds_def (Option.value ~default:default_def def) k v)
+        in
+        (map, Some ds_name)
+  in
+  OS.File.fold_lines fold (Rrd.StringMap.empty, None) path
+  |> Logs.on_error_msg ~use:(fun _ ->
+         failwith "Could not parse datasource definitions"
+     )
+  |> fst
+
+let plot_rrd ~filename rrd =
+  let data =
+    rrd_restore filename rrd
+    |> Logs.on_error_msg ~use:(fun () -> failwith "Failed to restore RRD")
+  in
+  prepare_plots ~exec:true ~filename ~data rrd
+
+let () =
+  let open OS.Arg in
+  let level =
+    let conv =
+      conv ~docv:"LEVEL" Logs.level_of_string Fmt.(option Logs.pp_level)
+    in
+    opt ~doc:"Set log level" ["log"] conv ~absent:(Some Logs.Debug)
+  in
+  let mode =
+    opt
+      ~doc:
+        "Used in self-invocation to split rrd into multiple rrds, or to plot \
+         an already split rrd"
+      ["mode"] ~absent:Default
+    @@ enum [("split", Split); ("plot", Plot); ("default", Default)]
+  in
+
+  let data_source_list =
+    opt ~doc:"Load data source definitions" ~docv:"PATH" ["def"] ~absent:None
+      (some path)
+  in
+  let paths =
+    OS.Arg.(
+      parse ~doc:"Split and plot xcp-rrdd XML rrd.gz with rrdtool" ~pos:path ()
+    )
+  in
+
+  Logs.set_level level ;
+  let ds_def =
+    Option.map parse_ds_defs data_source_list
+    |> Option.value ~default:Rrd.StringMap.empty
+  in
+  match mode with
+  | Default ->
+      let cmd =
+        Cmd.(
+          v "find" %% of_values p paths % "-name" % "*.gz" % "-print0"
+          |> OS.Cmd.run_out
+        )
+      in
+      (* TODO: forward level *)
+      let xargs =
+        Cmd.(
+          v "xargs"
+          % "-0"
+          % "-P0"
+          % "-n1"
+          % Sys.executable_name
+          %% of_values ~slip:"--def" p (Option.to_list data_source_list)
+          % "--mode=split"
+          |> OS.Cmd.run_in
+        )
+      in
+      let res =
+        OS.Cmd.out_run_in cmd
+        |> Logs.on_error_msg ~use:(fun _ -> exit 1)
+        |> xargs
+      in
+      Logs.on_error_msg ~use:(fun _ -> exit 1) res
+  | Split ->
+      paths |> List.iter @@ with_input_rrd (split_rrd ~ds_def)
+  | Plot ->
+      paths |> List.iter @@ with_input_rrd plot_rrd

--- a/opam/xapi-tools.opam
+++ b/opam/xapi-tools.opam
@@ -24,6 +24,7 @@ depends: [
   "rpclib"
   "rresult"
   "uri"
+  "tyre"
   "xenctrl"
   "xmlm"
   "yojson"


### PR DESCRIPTION
I wrote this in ~2022, so I don't fully remember how it all works, but I tried to document what I know in the commit message, in the CLI flag docs and here:
```
scp -r root@$YOURBOX:/var/lib/xcp/blobs/rrds /tmp/rrds
dune exec ./rrdview.exe -- /tmp/rrds
bash /tmp/rrds/16db833b-7cd6-4b69-9037-144076c71033.cpu_avg.DERIVE.sh
```
![rrd](https://github.com/user-attachments/assets/b3c98936-cc29-4871-b4ea-1511853d623e)



Viewing RRDs produced by xcp-rrdd is difficult, because the format is incompatible with rrdtool. rrdtool has a hardcoded limit of 20 char for RRD names for backward compat with its binary format.

Steps:
* given a directory of xml .gz files containing xcp-rrdd produced rrds
* invokes itself recursively with each file in turn using xargs -P (easy way to parallelize on OCaml 4)
* load all RRDs, and split them into separate files, allowing us to shorten many of their names without conflicts
* some names are still too long, there is a builtin translation table to shorten these
* once split an .rrd file is created using 'rrdtool restore'. This can further be queried/inspected/transformed by rrdtool as needed
* a .sh script is produced that can plot the RRD if desired.

There are many RRDs so plotting isn't done automatically yet.

RRDs contain min/avg/max usually, so this is drawn as a strong line at the average, and an area in a lighter color for min/max (especially useful for historic data that has been aggregated).

Caveats:
* we don't know the unit name, that is part of the XAPI metadata, but not the XML apparently?
* separate plots are generated for separate intervals, it'd be nice to join all these into the same graph
* the visualization type is not the best for all RRDs, some might benefit from a smoother line, etc.
* for now the tool is just built, but not installed (that'll require a .spec change too and can be done later)
* there is some code there to start parsing the data source definitions, eventually I wanted to plot the data using OCaml instead of rrdtool (e.g. generate Vega/Vega-lite graphs), but I can't find which branch I put *that* code on, what I have here is incomplete (or maybe I never wrote that part, just thought about it). We could trim the dead code from here if needed, but it might be useful if we continue improving the tool later, so for now I left the parsing in.

This is just a starting point to be able to visualize this data somehow, and we can improve the actual plotting later.