### PR TITLE
CP-53642: change default NUMA placement policy to best-effort

### DIFF
--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -3556,9 +3556,9 @@ module VIF = struct
       ()
 end
 
-let default_numa_affinity_policy = ref Xenops_interface.Host.Any
+let default_numa_affinity_policy = ref Xenops_interface.Host.Best_effort
 
-let numa_placement = ref Xenops_interface.Host.Any
+let numa_placement = ref !default_numa_affinity_policy
 
 let string_of_numa_affinity_policy =
   Xenops_interface.Host.(function Any -> "any" | Best_effort -> "best-effort")

--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -59,8 +59,6 @@ let feature_flags_path = ref "/etc/xenserver/features.d"
 
 let pvinpvh_xen_cmdline = ref "pv-shim console=xen"
 
-let numa_placement_compat = ref false
-
 (* O(N^2) operations, until we get a xenstore cache, so use a small number here *)
 let vm_guest_agent_xenstore_quota = ref 128
 
@@ -242,8 +240,11 @@ let options =
     , "Command line for the inner-xen for PV-in-PVH guests"
     )
   ; ( "numa-placement"
-    , Arg.Bool (fun x -> numa_placement_compat := x)
-    , (fun () -> string_of_bool !numa_placement_compat)
+    , Arg.Bool (fun _ -> ())
+    , (fun () ->
+        string_of_bool
+          (!Xenops_server.default_numa_affinity_policy = Best_effort)
+      )
     , "NUMA-aware placement of VMs (deprecated, use XAPI setting)"
     )
   ; ( "pci-quarantine"

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -5294,8 +5294,6 @@ let init () =
         {Xs_protocol.ACL.owner= 0; other= Xs_protocol.ACL.READ; acl= []}
   ) ;
   Device.Backend.init () ;
-  Xenops_server.default_numa_affinity_policy :=
-    if !Xenopsd.numa_placement_compat then Best_effort else Any ;
   info "Default NUMA affinity policy is '%s'"
     Xenops_server.(string_of_numa_affinity_policy !default_numa_affinity_policy) ;
   Xenops_server.numa_placement := !Xenops_server.default_numa_affinity_policy ;


### PR DESCRIPTION
We've seen that using the policy can be up to 10% faster than using any is some
workflows, while not observing workflows that were negatively affected. The
policy per VM can always be change if need be.

Note that currently sometime the best-effort falls back to the same behaviour,
especially when restarting on starting more than one VM at a time. This needs
xen patches to be fixed:
https://lore.kernel.org/xen-devel/20250314172502.53498-1-alejandro.vallejo@cloud.com/

Also fix the legacy numa-placement configuration option for xenopsd. It was
always deciding the setting, even when not used, not it only takes effect when
it's present, otherwise it leaves the default option untouched.