### PR TITLE
CA-411122: do not call set-iscsi-initiator with an empty string for IQN

### DIFF
--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2790,6 +2790,7 @@ let set_uefi_certificates ~__context ~host:_ ~value:_ =
 let set_iscsi_iqn ~__context ~host ~value =
   if value = "" then
     raise Api_errors.(Server_error (invalid_value, ["value"; value])) ;
+  D.debug "%s: iqn=%S" __FUNCTION__ value ;
   (* Note, the following sequence is carefully written - see the
      other-config watcher thread in xapi_host_helpers.ml *)
   Db.Host.remove_from_other_config ~__context ~self:host ~key:"iscsi_iqn" ;


### PR DESCRIPTION
Back in 2018 a4a94b38c66203c9f02752f181d1c01f73bf52a1 rejected empty IQNs in set_iscsi_iqn API calls. However hosts are created with an empty IQN, and if this code runs too early then it will attempt to call `set-iscsi-initiator` with an empty string for the IQN:
```
/opt/xensource/libexec/set-iscsi-initiator  myhost
```

About a second later the script is called again with the correct value. This could potentially result in the iscsid service being restarted multiple times (and if a restart is still pending when restart is called a 2nd time I'm not sure it'll take effect, so we might be left with an empty initiator, I have also seen a GFS2 SR plug failure following this).

It is best to avoid setting empty initiators. The exception would be raised and ignore due to the log_and_ignore in the caller.

Also log wherever the IQN is set using %S, so that we notice if it ends up containing some extra whitespace characters.