### PR TITLE
CP-54275: Add a blocklist mechanism to avoid incorrect/old repo config.

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -1921,6 +1921,11 @@ let _ =
     () ;
   error Api_errors.invalid_base_url ["url"]
     ~doc:"The base url in the repository is invalid." () ;
+  error Api_errors.blocked_repo_url ["url"]
+    ~doc:
+      "Cannot create the repository as the url is blocked, please check your \
+       settings."
+    () ;
   error Api_errors.invalid_gpgkey_path ["gpgkey_path"]
     ~doc:"The GPG public key file name in the repository is invalid." () ;
   error Api_errors.repository_already_exists ["ref"]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1323,6 +1323,8 @@ let configure_repositories_in_progress =
 
 let invalid_base_url = add_error "INVALID_BASE_URL"
 
+let blocked_repo_url = add_error "BLOCKED_REPO_URL"
+
 let invalid_gpgkey_path = add_error "INVALID_GPGKEY_PATH"
 
 let repository_already_exists = add_error "REPOSITORY_ALREADY_EXISTS"

--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -33,6 +33,8 @@ let updates_in_cache : (API.ref_host, Yojson.Basic.t) Hashtbl.t =
 
 let introduce ~__context ~name_label ~name_description ~binary_url ~source_url
     ~update ~gpgkey_path =
+  assert_url_is_not_blocked ~url:binary_url ;
+  assert_url_is_not_blocked ~url:source_url ;
   assert_url_is_valid ~url:binary_url ;
   assert_url_is_valid ~url:source_url ;
   assert_gpgkey_path_is_valid gpgkey_path ;

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -932,6 +932,13 @@ let gen_pool_secret_script = ref "/usr/bin/pool_secret_wrapper"
 
 let repository_domain_name_allowlist = ref []
 
+(*
+    This blocklist aims to prevent the creation of any repository whose URL matches an entry in the blocklist.
+    Additionally, if an existing repository contains a URL that matches an entry in the blocklist,
+    it should be removed automatically after xapi is restarted.
+*)
+let repository_url_blocklist = ref []
+
 let yum_cmd = ref "/usr/bin/yum"
 
 let dnf_cmd = ref "/usr/bin/dnf"
@@ -1599,6 +1606,11 @@ let other_options =
       (fun s -> s)
       (fun s -> s)
       repository_domain_name_allowlist
+  ; gen_list_option "repository-url-blocklist"
+      "space-separated list of blocked URL patterns in base URL in repository."
+      (fun s -> s)
+      (fun s -> s)
+      repository_url_blocklist
   ; ( "repository-gpgcheck"
     , Arg.Set repository_gpgcheck
     , (fun () -> string_of_bool !repository_gpgcheck)


### PR DESCRIPTION
This change introduces a new `repository_domain_name_blocklist` that lists repo URL patterns to be blocked.
On XAPI startup, any exsiting pool repository whose URLs matches an entry in this blocklist will be automatically removed. This ensures that, for example, when upgrading from XS8 to XS9, any XS8 repos are purged.

Additionally, repository creating now check the same blocklist and rejects any attempt to add a blocked repo.

- On startup: read blocklist, delete matching blocked repos
- On repository creation: validate against blocklist and abort if matched

Tests:
- Create repo with the blocklist configured
![image](https://github.com/user-attachments/assets/8c77b76e-27ef-4184-b5aa-c68b6ee7b9c4)
- Create repo without the blocklist configured
![image](https://github.com/user-attachments/assets/89cebfb8-431d-4690-a667-9ecad6730ba8)
- With the blocklist, restart xapi and the repo was removed
`[root@eu1-dt013 yum.repos.d]# xe repository-list`

