### PR TITLE
xapi: Cleanup unused functions

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -606,14 +606,6 @@ let call_emergency_mode_functions hostname f =
     (fun () -> f rpc session_id)
     (fun () -> Client.Client.Session.local_logout ~rpc ~session_id)
 
-let progress ~__context t =
-  for i = 0 to int_of_float (t *. 100.) do
-    let v = float_of_int i /. 100. /. t in
-    TaskHelper.set_progress ~__context v ;
-    Thread.delay 1.
-  done ;
-  TaskHelper.set_progress ~__context 1.
-
 let is_domain_zero_with_record ~__context vm_ref vm_rec =
   let host_ref = vm_rec.API.vM_resident_on in
   vm_rec.API.vM_is_control_domain

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -89,9 +89,6 @@ let retrieve_wlb_recommendations ~__context ~vm =
 
 let assert_agile ~__context ~self = Agility.vm_assert_agile ~__context ~self
 
-(* helpers *)
-let immediate_complete ~__context = Helpers.progress ~__context (0.0 -. 1.0)
-
 (* API *)
 let set_actions_after_crash ~__context ~self ~value =
   set_actions_after_crash ~__context ~self ~value

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -32,8 +32,6 @@ val retrieve_wlb_recommendations :
 
 val assert_agile : __context:Context.t -> self:[`VM] Ref.t -> unit
 
-val immediate_complete : __context:Context.t -> unit
-
 val set_actions_after_crash :
      __context:Context.t
   -> self:[`VM] Ref.t


### PR DESCRIPTION
`Helpers.progress`' only user was `Xapi_vm.immediate_complete`, which wasn't used anywhere. Remove both. No functional changes.