### PR TITLE
CP-308075 document changing paths for SM plugins in XS9

### DIFF
--- a/scripts/xapi.conf
+++ b/scripts/xapi.conf
@@ -159,7 +159,8 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
 # Directory containing supplemental pack data
 # packs-dir = @ETCXENDIR@/installed-repos
 
-# Directory containing SM plugins
+# Directory containing SM plugins. This path changes in XenServer 9 with a
+# configuration coming from /etc/xapi.conf.d/, which takes precedence
 # sm-dir =  @OPTDIR@/sm
 
 # Whitelist of SM plugins


### PR DESCRIPTION
The paths to SM plugins in XS9 is about to change. This will be implemented with a conf file in /etc/xapi.conf.d/ and will be easy to overlook when just looking at xapi.conf. Update the comment there.