### PR TITLE
CP-44105: Adjust Net.reset_state for pool.eject_self

### DIFF
--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -116,7 +116,7 @@ let refresh_internal ~__context ~interface_tables ~self =
           info "PIF: device name changed from %s to %s" original_name name ;
         name
     | None -> (
-        (* This clause should be unlike to happen, if enter this, check the if
+        (* This clause should be unlikely to happen, if enter this, check the if
            we can get mac from networkd. If yes there may be a bug *)
         warn "PIF %s: no device found for position %d" original_name position ;
         try

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -2088,7 +2088,6 @@ let eject_self ~__context ~host =
         configuration_file
     in
     write_first_boot_management_interface_configuration_file () ;
-    Net.reset_state () ;
     Xapi_inventory.update Xapi_inventory._current_interfaces "" ;
     (* Destroy my control domains, since you can't do this from the API [operation not allowed] *)
     ( try
@@ -2148,15 +2147,10 @@ let eject_self ~__context ~host =
               (!Xapi_globs.remote_db_conf_fragment_path ^ ".bak")
           )
           () ;
-        (* Reset the domain 0 network interface naming configuration
-           			 * back to a fresh-install state for the currently-installed
-           			 * hardware.
-        *)
-        ignore
-          (Forkhelpers.execute_command_get_output
-             "/etc/sysconfig/network-scripts/interface-rename.py"
-             ["--reset-to-install"]
-          )
+        (* Reset the domain 0 network interface order back to a fresh-install
+         * state for the currently-installed hardware and reset networkd config.
+         *)
+        Net.reset_state ()
       )
       (fun () -> Xapi_fuse.light_fuse_and_reboot_after_eject ()) ;
     Xapi_hooks.pool_eject_hook ~__context


### PR DESCRIPTION
As pool.eject_self calls interface-rename script to rename the network interfaces, this behaviour should be done compatibly.
So, move the interface-rename to networkd with compatibility check.
When reset networkd state
legacy: use interface-rename script to sort and rename
new: use networkd network_device_order with initial empty order to sort