### PR TITLE
SXM: Keep previous http handler for back-compat

### DIFF
--- a/ocaml/xapi/xapi_services.ml
+++ b/ocaml/xapi/xapi_services.ml
@@ -206,6 +206,7 @@ let put_handler (req : Http.Request.t) s _ =
       | [""; services; "SM"; "nbd"; vm; sr; vdi; dp] when services = _services
         ->
           Storage_migrate.nbd_handler req s ~vm sr vdi dp
+      | [""; services; "SM"; "nbdproxy"; vm; sr; vdi; dp]
       | [""; services; "SM"; "nbdproxy"; "import"; vm; sr; vdi; dp]
         when services = _services ->
           Storage_migrate.import_nbd_proxy req s vm sr vdi dp


### PR DESCRIPTION
Sorry folks, looks like we need an epilogue of #6457 forget about this backwards compatability issue. Backwards compatability is hard...