### PR TITLE
CP-54384 Update Auto-Mode Configuration for Pool Operations and Default Values

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1299,6 +1299,8 @@ let ssh_service = ref "sshd"
 
 let ssh_monitor_service = ref "xapi-ssh-monitor"
 
+let ssh_auto_mode_default = ref true
+
 (* Fingerprint of default patch key *)
 let citrix_patch_key =
   "NERDNTUzMDMwRUMwNDFFNDI4N0M4OEVCRUFEMzlGOTJEOEE5REUyNg=="
@@ -1742,6 +1744,12 @@ let other_options =
     , Arg.Set validate_reusable_pool_session
     , (fun () -> string_of_bool !validate_reusable_pool_session)
     , "Enable validation of reusable pool sessions before use"
+    )
+  ; ( "ssh-auto-mode"
+    , Arg.Bool (fun b -> ssh_auto_mode_default := b)
+    , (fun () -> string_of_bool !ssh_auto_mode_default)
+    , "Defaults to true; overridden to false via \
+       /etc/xapi.conf.d/ssh-auto-mode.conf(e.g., in XenServer 8)"
     )
   ]
 

--- a/ocaml/xapi/xapi_pool.ml
+++ b/ocaml/xapi/xapi_pool.ml
@@ -1670,10 +1670,15 @@ let join_common ~__context ~master_address ~master_username ~master_password
             Client.Host.get_console_idle_timeout ~rpc ~session_id
               ~self:remote_coordinator
           in
+          let ssh_auto_mode =
+            Client.Host.get_ssh_auto_mode ~rpc ~session_id
+              ~self:remote_coordinator
+          in
           Xapi_host.set_console_idle_timeout ~__context ~self:me
             ~value:console_idle_timeout ;
           Xapi_host.set_ssh_enabled_timeout ~__context ~self:me
             ~value:ssh_enabled_timeout ;
+          Xapi_host.set_ssh_auto_mode ~__context ~self:me ~value:ssh_auto_mode ;
           let ssh_enabled =
             Client.Host.get_ssh_enabled ~rpc ~session_id
               ~self:remote_coordinator
@@ -2056,6 +2061,8 @@ let eject_self ~__context ~host =
         (* Restore SSH service to default state *)
         Xapi_host.set_ssh_enabled_timeout ~__context ~self:host
           ~value:Constants.default_ssh_enabled_timeout ;
+        Xapi_host.set_ssh_auto_mode ~__context ~self:host
+          ~value:!Xapi_globs.ssh_auto_mode_default ;
         match Constants.default_ssh_enabled with
         | true ->
             Xapi_host.enable_ssh ~__context ~self:host


### PR DESCRIPTION
This PR aim to add following change for auto-mode:
Copy the auto-mode setting from the pool coordinator during a pool join. and restore the auto-mode setting to default value when a pool eject occurs.

- In XS8, the auto-mode is set to false by loading the config file `/etc/xapi.conf.d/ssh-auto-mode.conf`.
- In XS9, default value is set to true.