### PR TITLE
CA-409949 CA-408048 XSI-1912 remove unavailable SM plugin by ref

### DIFF
--- a/ocaml/xapi/storage_access.ml
+++ b/ocaml/xapi/storage_access.ml
@@ -183,12 +183,14 @@ let on_xapi_start ~__context =
       let self, _ = List.assoc ty existing in
       try Db.SM.destroy ~__context ~self with _ -> ()
     )
-    (List.concat
-       [
-         Listext.List.set_difference (List.map fst existing) to_keep
-       ; List.map fst unavailable
-       ]
-    ) ;
+    (Listext.List.set_difference (List.map fst existing) to_keep) ;
+  List.iter
+    (fun (name, (self, rc)) ->
+      info "%s: unregistering SM plugin %s (%s) since it is unavailable"
+        __FUNCTION__ name rc.API.sM_uuid ;
+      try Db.SM.destroy ~__context ~self with _ -> ()
+    )
+    unavailable ;
 
   (* Synchronize SMAPIv1 plugins *)
 


### PR DESCRIPTION
When we have multiple SM plugins in XAPI for the same type (which happens only because of past problems) and want to remove the obsolete one, do this iby  reference. The code so far was assuming only one per type and looked up the reference by name which was not unique and hence could end up removing the wrong SM entry.