### PR TITLE
xapi_vif: Guarantee the device parameter is an unsigned decimal integer

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3866,7 +3866,9 @@ module VIF = struct
                   , "order in which VIF backends are created by xapi"
                   )
                 ]
-              "device" "order in which VIF backends are created by xapi"
+              "device"
+              "order in which VIF backends are created by xapi. Guaranteed to \
+               be an unsigned decimal integer."
           ; field ~qualifier:StaticRO ~ty:(Ref _network)
               ~lifecycle:
                 [

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "dc1ccf295f957509f7eac4a005d17965"
+let last_known_schema_hash = "4cd835e2557dd7b5cbda6c681730c447"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi/xapi_vif_helpers.ml
+++ b/ocaml/xapi/xapi_vif_helpers.ml
@@ -192,10 +192,11 @@ let clear_current_operations ~__context ~self =
 
 (**************************************************************************************)
 
-(** Check if the device string has the right form *)
+(** Check if the device string has the right form - it should only be an
+    unsigned decimal integer *)
 let valid_device dev =
   try
-    ignore (int_of_string dev) ;
+    Scanf.sscanf dev "%u%!" ignore ;
     true
   with _ -> false
 


### PR DESCRIPTION
This has been always true as xapi will call valid_device on VIF creation to
    make sure device is an integer, but the datamodel type of 'device' is string,
    without any such guarantees.

Specify the guarantee in the documentation and make the check stricter
    (int_of_string will accept "0x9fe" as an integer, for example), making sure
    that the device is specifically a decimal unsigned integer. allowed_VIF_devices
    has already enforced the unsigned decimal integer limitation on compliant clients.

This could be helpful in ensuring that the clients will always be right in
    sorting devices as numbers, not as strings (so that "2" follows "1" instead of
    the string order of "1"->"10"->"11", etc.).