### PR TITLE
Add file-upload support to xe host-call-plugin

### DIFF
--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -958,8 +958,9 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; optn= ["args:"]
       ; help=
           "Calls the function within the plugin on the given host with \
-           optional arguments."
-      ; implementation= No_fd Cli_operations.host_call_plugin
+           optional arguments. The syntax args:key:file=/path/file.ext passes \
+           the content of /path/file.ext under key to the plugin."
+      ; implementation= With_fd Cli_operations.host_call_plugin
       ; flags= []
       }
     )


### PR DESCRIPTION
To pass file content to a plugin, vm-call-plugin supports passing the content of a client-side file as a parameter. This is missing for host-call-plugin - this patch adds it. Otherwise it is difficult to pass anything beyond a short string to a plugin.