### PR TITLE
CA-411766: Detach VBDs right after VM Halted

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -856,8 +856,6 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
   if state = `Suspended then
     remove_pending_guidance ~__context ~self ~value:`restart_device_model ;
   if state = `Halted then (
-    remove_pending_guidance ~__context ~self ~value:`restart_device_model ;
-    remove_pending_guidance ~__context ~self ~value:`restart_vm ;
     (* mark all devices as disconnected *)
     List.iter
       (fun vbd ->
@@ -899,7 +897,9 @@ let force_state_reset_keep_current_operations ~__context ~self ~value:state =
       )
       (Db.VM.get_VUSBs ~__context ~self) ;
     (* Blank the requires_reboot flag *)
-    Db.VM.set_requires_reboot ~__context ~self ~value:false
+    Db.VM.set_requires_reboot ~__context ~self ~value:false ;
+    remove_pending_guidance ~__context ~self ~value:`restart_device_model ;
+    remove_pending_guidance ~__context ~self ~value:`restart_vm
   ) ;
   (* Do not clear resident_on for VM and VGPU in a checkpoint operation *)
   if


### PR DESCRIPTION
In XSI-1915, MCS shutdowned a VM and tried to destroy VBD right after MCS received the event which came from power_state's change and failed. The failure reason is below:
1. The update for VM's power_state and the update for VBDs is not a transaction, so the client may receive the event from the update for power_state and operate VBDs before the update for VBDs.
2. The VM's running on supporter. The DB operation needs to send RPC to the coordinator. This needs time.
3. Between the update for VM's power_state and the update for VBD, xapi also updates the field pending_guildencs which needs at least 8 DB operation. This also delays the update for VBDs. 

It's not straightforward to add transactions for these DB operations. The workaround is to move the update for pending_guildencs to the end of the DB operation of VBDs, VIFs, GPUs, etc. So that VBD will be updated after the update for VM's power_state immediately.