### PR TITLE
CP-54217: Add a new xe command to limit the vnc console access

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -2068,6 +2068,9 @@ let _ =
        enable it in XC or run xe pool-enable-tls-verification instead."
     () ;
 
+  error Api_errors.limit_console_access_failed []
+    ~doc:"Failed to limit console access." () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -1606,6 +1606,23 @@ let set_console_idle_timeout =
       ]
     ~allowed_roles:_R_POOL_ADMIN ()
 
+let limit_console_access =
+  call ~name:"limit_console_access"
+    ~doc:
+      "Limit the number of concurrent console sessions per VM on all hosts in \
+       the pool."
+    ~lifecycle:[]
+    ~params:
+      [
+        (Ref _pool, "self", "The pool")
+      ; ( Int
+        , "value"
+        , "The maximum number of concurrent console sessions per VM on all \
+           hosts in the pool. A value of 0 means no limit."
+        )
+      ]
+    ~allowed_roles:_R_POOL_ADMIN ()
+
 (** A pool class *)
 let t =
   create_obj ~in_db:true
@@ -1704,6 +1721,7 @@ let t =
       ; disable_ssh
       ; set_ssh_enabled_timeout
       ; set_console_idle_timeout
+      ; limit_console_access
       ]
     ~contents:
       ([
@@ -2234,6 +2252,10 @@ let t =
             "Indicates whether an HA-protected VM that is shut down from \
              inside (not through the API) should be automatically rebooted \
              when HA is enabled"
+        ; field ~qualifier:DynamicRO ~lifecycle:[] ~ty:Int
+            ~default_value:(Some (VInt 0L)) "console_access_limit"
+            "The number of concurrent console sessions per VM on all hosts in \
+             the pool (0 means no limit)"
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "4cd835e2557dd7b5cbda6c681730c447"
+let last_known_schema_hash = "27d8d31cb4a593800bfea9c43749cad7"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -326,7 +326,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~ext_auth_cache_enabled:false ~ext_auth_cache_size:50L
     ~ext_auth_cache_expiry:300L ~update_sync_frequency ~update_sync_day
     ~update_sync_enabled ~recommendations ~license_server
-    ~ha_reboot_vm_on_internal_shutdown ;
+    ~ha_reboot_vm_on_internal_shutdown ~console_access_limit:0L ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -3156,6 +3156,18 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pool-limit-console-access"
+    , {
+        reqd= ["limit"]
+      ; optn= []
+      ; help=
+          "Limit the number of concurrent console sessions per VM on all hosts \
+           in the pool. limit=0 means no limit and limit >= 1 will be taken as \
+           limit=1"
+      ; implementation= No_fd Cli_operations.pool_limit_console_access
+      ; flags= []
+      }
+    )
   ; ( "host-ha-xapi-healthcheck"
     , {
         reqd= []

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -6837,6 +6837,12 @@ let pool_disable_ssh _printer rpc session_id params =
   let pool = get_pool_with_default rpc session_id params "uuid" in
   Client.Pool.disable_ssh ~rpc ~session_id ~self:pool
 
+let pool_limit_console_access _printer rpc session_id params =
+  let limit = List.assoc "limit" params in
+  let value = try Int64.of_string limit with _ -> 0L in
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  Client.Pool.limit_console_access ~rpc ~session_id ~self:pool ~value
+
 let host_restore fd _printer rpc session_id params =
   let filename = List.assoc "file-name" params in
   let op _ host =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1584,6 +1584,9 @@ let pool_record rpc session_id pool =
               ~value:(safe_i64_of_string "console-idle-timeout" value)
           )
           ()
+      ; make_field ~name:"console-access-limit"
+          ~get:(fun () -> Int64.to_string (x ()).API.pool_console_access_limit)
+          ()
       ]
   }
 

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1434,6 +1434,8 @@ let set_ssh_timeout_partially_failed =
 let set_console_timeout_partially_failed =
   add_error "SET_CONSOLE_TIMEOUT_PARTIALLY_FAILED"
 
+let limit_console_access_failed = add_error "LIMIT_CONSOLE_ACCESS_FAILED"
+
 let host_driver_no_hardware = add_error "HOST_DRIVER_NO_HARDWARE"
 
 let tls_verification_not_enabled_in_pool =

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -55,6 +55,7 @@ let create_pool_record ~__context =
       ~ext_auth_max_threads:1L ~ext_auth_cache_enabled:false
       ~ext_auth_cache_size:50L ~ext_auth_cache_expiry:300L ~recommendations:[]
       ~license_server:[] ~ha_reboot_vm_on_internal_shutdown:true
+      ~console_access_limit:0L
 
 let set_master_ip ~__context =
   let ip =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1197,6 +1197,10 @@ functor
           (pool_uuid ~__context self)
           value ;
         Local.Pool.set_console_idle_timeout ~__context ~self ~value
+
+      let limit_console_access ~__context ~self =
+        info "%s: pool = '%s'" __FUNCTION__ (pool_uuid ~__context self) ;
+        Local.Pool.limit_console_access ~__context ~self
     end
 
     module VM = struct

--- a/ocaml/xapi/xapi_pool.mli
+++ b/ocaml/xapi/xapi_pool.mli
@@ -443,3 +443,6 @@ val set_ssh_enabled_timeout :
 
 val set_console_idle_timeout :
   __context:Context.t -> self:API.ref_pool -> value:int64 -> unit
+
+val limit_console_access :
+  __context:Context.t -> self:API.ref_pool -> value:int64 -> unit


### PR DESCRIPTION
Some users want to limit VNC console access to one session per VM, to
prevent other users from taking over an active session.
This commit introduces a new `xe` command to set the limit at the pool
level. The logic for enforcing the concurrent VNC console access limit
will be implemented in subsequent commits.

Tested:
```
[root@eu1-dt021 bin]# xe pool-param-list uuid=a0ba22eb-1f91-895e-2dc9-923b81e72098 | grep limit
                 console-access-limit ( RO): 0
[root@eu1-dt021 bin]#
[root@eu1-dt021 bin]# xe pool-limit-console-access limit=5
[root@eu1-dt021 bin]# xe pool-param-list uuid=a0ba22eb-1f91-895e-2dc9-923b81e72098 | grep limit
                 console-access-limit ( RO): 1
[root@eu1-dt021 bin]# xe pool-limit-console-access limit=-5
The value given is invalid
field: console_access_limit
value: -5
[root@eu1-dt021 bin]# xe pool-param-list uuid=a0ba22eb-1f91-895e-2dc9-923b81e72098 | grep limit
                 console-access-limit ( RO): 1
```
