### PR TITLE
CP-308252 add VM.call_host_plugin

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -245,6 +245,8 @@ let prototyped_of_message = function
       Some "24.17.0"
   | "VM", "restart_device_models" ->
       Some "23.30.0"
+  | "VM", "call_host_plugin" ->
+      Some "25.21.0-next"
   | "VM", "set_groups" ->
       Some "24.19.1"
   | "pool", "set_console_idle_timeout" ->

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2098,6 +2098,19 @@ let call_plugin =
     ~result:(String, "Result from the plugin")
     ~allowed_roles:_R_VM_OP ()
 
+let call_host_plugin =
+  call ~name:"call_host_plugin"
+    ~doc:"Call an API plugin on the host where this vm resides" ~lifecycle:[]
+    ~params:
+      [
+        (Ref _vm, "vm", "The vm")
+      ; (String, "plugin", "The name of the plugin")
+      ; (String, "fn", "The name of the function within the plugin")
+      ; (Map (String, String), "args", "Arguments for the function")
+      ]
+    ~result:(String, "Result from the plugin")
+    ~allowed_roles:_R_VM_OP ()
+
 let set_has_vendor_device =
   call ~name:"set_has_vendor_device"
     ~lifecycle:
@@ -2545,6 +2558,7 @@ let t =
       ; set_groups
       ; query_services
       ; call_plugin
+      ; call_host_plugin
       ; set_has_vendor_device
       ; import
       ; set_actions_after_crash

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -1842,6 +1842,21 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "vm-call-host-plugin"
+    , {
+        reqd= ["vm-uuid"; "plugin"; "fn"]
+      ; optn= ["args:"]
+      ; help=
+          "Calls function fn within the plugin on the host where the VM is \
+           running with arguments (args:key=value). To pass a \"value\" string \
+           with special characters in it (e.g. new line), an alternative \
+           syntax args:key:file=local_file can be used in place, where the \
+           content of local_file will be retrieved and assigned to \"key\" as \
+           a whole."
+      ; implementation= With_fd Cli_operations.vm_call_host_plugin
+      ; flags= []
+      }
+    )
   ; ( "snapshot-export-to-template"
     , {
         reqd= ["filename"; "snapshot-uuid"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3516,6 +3516,18 @@ let vm_call_plugin fd printer rpc session_id params =
   let result = Client.VM.call_plugin ~rpc ~session_id ~vm ~plugin ~fn ~args in
   printer (Cli_printer.PList [result])
 
+let vm_call_host_plugin fd printer rpc session_id params =
+  let vm_uuid = List.assoc "vm-uuid" params in
+  let vm = Client.VM.get_by_uuid ~rpc ~session_id ~uuid:vm_uuid in
+  let plugin = List.assoc "plugin" params in
+  let fn = List.assoc "fn" params in
+  let args = read_map_params "args" params in
+  let args = List.map (args_file fd) args in
+  let result =
+    Client.VM.call_host_plugin ~rpc ~session_id ~vm ~plugin ~fn ~args
+  in
+  printer (Cli_printer.PList [result])
+
 let data_source_to_kvs ds =
   [
     ("name_label", ds.API.data_source_name_label)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2030,6 +2030,34 @@ functor
             forward_vm_op ~local_fn ~__context ~vm ~remote_fn
         )
 
+      let call_host_plugin ~__context ~vm ~plugin ~fn ~args =
+        info
+          "VM.call_host_plugin: VM = '%s'; plugin = '%s'; fn = '%s'; args = [ \
+           'hidden' ]"
+          (vm_uuid ~__context vm) plugin fn ;
+        let local_fn = Local.VM.call_host_plugin ~vm ~plugin ~fn ~args in
+        let remote_fn = Client.VM.call_host_plugin ~vm ~plugin ~fn ~args in
+        let power_state = Db.VM.get_power_state ~__context ~self:vm in
+        (* Insisting on running to make sure xenstore and domain exist
+           and the VM can react to xenstore events. Permitting Paused in
+           addition could be an option *)
+        if power_state <> `Running then
+          raise
+            Api_errors.(
+              Server_error
+                ( vm_bad_power_state
+                , [
+                    Ref.string_of vm
+                  ; Record_util.vm_power_state_to_string `Running
+                  ; Record_util.vm_power_state_to_string power_state
+                  ]
+                )
+            ) ;
+        with_vm_operation ~__context ~self:vm ~doc:"VM.call_host_plugin"
+          ~op:`call_plugin ~policy:Helpers.Policy.fail_immediately (fun () ->
+            forward_vm_op ~local_fn ~__context ~vm ~remote_fn
+        )
+
       let set_has_vendor_device ~__context ~self ~value =
         info "VM.set_has_vendor_device: VM = '%s' to %b"
           (vm_uuid ~__context self) value ;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1168,6 +1168,11 @@ let call_plugin ~__context ~vm ~plugin ~fn ~args =
          (Api_errors.xenapi_plugin_failure, ["failed to execute fn"; msg; msg])
       )
 
+let call_host_plugin ~__context ~vm ~plugin ~fn ~args =
+  (* vm is unused; was used to find the host *)
+  let _ = vm in
+  Xapi_plugins.call_plugin (Context.get_session_id __context) plugin fn args
+
 let send_sysrq ~__context ~vm:_ ~key:_ =
   raise (Api_errors.Server_error (Api_errors.not_implemented, ["send_sysrq"]))
 

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -399,6 +399,14 @@ val call_plugin :
   -> args:(string * string) list
   -> string
 
+val call_host_plugin :
+     __context:Context.t
+  -> vm:API.ref_VM
+  -> plugin:string
+  -> fn:string
+  -> args:(string * string) list
+  -> string
+
 val set_has_vendor_device :
   __context:Context.t -> self:API.ref_VM -> value:bool -> unit
 


### PR DESCRIPTION
This API call and corresponding XE implementation calls a host plugin on the host where a VM is running. It thus takes care of finding the right host, compared to Host.call_plugin where this would be left to the user.