### PR TITLE
Adapt code to new mirage-crypto (CP-308222) 

### DIFF
--- a/ocaml/gencert/dune
+++ b/ocaml/gencert/dune
@@ -6,7 +6,7 @@
   (libraries
     angstrom
     astring
-    cstruct
+    digestif
     forkexec
     mirage-crypto
     mirage-crypto-pk
@@ -52,7 +52,7 @@
   (modules test_lib test_pem)
   (libraries
     alcotest
-    cstruct
+    digestif
     fmt
     gencertlib
     mirage-crypto

--- a/ocaml/gencert/selfcert.ml
+++ b/ocaml/gencert/selfcert.ml
@@ -43,7 +43,7 @@ let valid_from' date =
 
 (* Needed to initialize the rng to create random serial codes when signing
    certificates *)
-let () = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
+let () = Mirage_crypto_rng_unix.use_default ()
 
 (** [write_cert] writes a PKCS12 file to [path]. The typical file
  extension would be ".pem". It attempts to do that atomically by
@@ -117,7 +117,6 @@ let generate_pub_priv_key length =
   in
   let* privkey =
     rsa_string
-    |> Cstruct.of_string
     |> X509.Private_key.decode_pem
     |> R.reword_error (fun _ -> R.msg "decoding private key failed")
   in
@@ -132,9 +131,7 @@ let selfsign' issuer extensions key_length expiration =
   let* cert = sign expiration privkey pubkey issuer req extensions in
   let key_pem = X509.Private_key.encode_pem privkey in
   let cert_pem = X509.Certificate.encode_pem cert in
-  let pkcs12 =
-    String.concat "\n\n" [Cstruct.to_string key_pem; Cstruct.to_string cert_pem]
-  in
+  let pkcs12 = String.concat "\n\n" [key_pem; cert_pem] in
   Ok (cert, pkcs12)
 
 let selfsign issuer extensions key_length expiration certfile cert_gid =

--- a/ocaml/gencert/selfcert.mli
+++ b/ocaml/gencert/selfcert.mli
@@ -23,7 +23,7 @@ val write_certs : string -> int -> string -> (unit, [> Rresult.R.msg]) result
 val host :
      name:string
   -> dns_names:string list
-  -> ips:Cstruct.t list
+  -> ips:string list
   -> ?valid_from:Ptime.t (* default: now *)
   -> valid_for_days:int
   -> string

--- a/ocaml/gencert/test_lib.ml
+++ b/ocaml/gencert/test_lib.ml
@@ -8,7 +8,7 @@ open Rresult.R.Infix
 let ( let* ) = Rresult.R.bind
 
 (* Initialize RNG for testing certificates *)
-let () = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
+let () = Mirage_crypto_rng_unix.use_default ()
 
 let time_of_rfc3339 date =
   match Ptime.of_rfc3339 date with
@@ -204,7 +204,7 @@ let test_invalid_cert pem_leaf time pkey error reason =
         "Error must match" (error, reason) msg
 
 let load_pkcs8 name =
-  X509.Private_key.decode_pem (Cstruct.of_string (load_test_data name))
+  X509.Private_key.decode_pem (load_test_data name)
   |> Rresult.R.reword_error (fun (`Msg msg) ->
          `Msg
            (Printf.sprintf "Could not load private key with name '%s': %s" name
@@ -222,7 +222,6 @@ let sign_leaf_cert host_name digest pkey_leaf =
   load_pkcs8 "pkey_rsa_4096" >>= fun pkey_sign ->
   sign_cert host_name ~pkey_sign digest pkey_leaf
   >>| X509.Certificate.encode_pem
-  >>| Cstruct.to_string
 
 let valid_leaf_cert_tests =
   List.map
@@ -300,8 +299,7 @@ let valid_chain_cert_tests =
         (pkey_root, Ok []) key_chain
     in
     sign_leaf_cert host_name `SHA256 pkey_leaf >>= fun pem_leaf ->
-    chain >>| X509.Certificate.encode_pem_multiple >>| Cstruct.to_string
-    >>| fun pem_chain ->
+    chain >>| X509.Certificate.encode_pem_multiple >>| fun pem_chain ->
     test_valid_cert_chain ~pem_leaf ~pem_chain time pkey_leaf
   in
   [("Validation of a supported certificate chain", `Quick, test_cert)]

--- a/ocaml/tests/dune
+++ b/ocaml/tests/dune
@@ -15,7 +15,7 @@
     angstrom
     astring
     cstruct
-
+    digestif
     fmt
     http_lib
     httpsvr

--- a/ocaml/tests/test_certificates.ml
+++ b/ocaml/tests/test_certificates.ml
@@ -13,7 +13,7 @@ let pp_hash_test =
     (fun (hashable, expected) ->
       let test_hash () =
         let digest =
-          Cstruct.of_string hashable |> Mirage_crypto.Hash.digest `SHA256
+          Digestif.SHA256.(digest_string hashable |> to_raw_string)
         in
         Alcotest.(check string)
           "fingerprints must match" expected

--- a/ocaml/xapi-aux/networking_info.ml
+++ b/ocaml/xapi-aux/networking_info.ml
@@ -55,11 +55,13 @@ let dns_names () =
      )
   |> Astring.String.uniquify
 
-let ipaddr_to_cstruct = function
+let ipaddr_to_octets = function
   | Ipaddr.V4 addr ->
-      Cstruct.of_string (Ipaddr.V4.to_octets addr)
+      Ipaddr.V4.to_octets addr
   | Ipaddr.V6 addr ->
-      Cstruct.of_string (Ipaddr.V6.to_octets addr)
+      Ipaddr.V6.to_octets addr
+
+let ipaddr_to_cstruct c = ipaddr_to_octets c |> Cstruct.of_string
 
 let get_management_ip_addrs ~dbg =
   let iface = Inventory.lookup Inventory._management_interface in
@@ -113,7 +115,7 @@ let get_host_certificate_subjects ~dbg =
     | Ok (preferred, others) ->
         let ips = List.(rev_append (rev preferred) others) in
         Option.fold ~none:(Error IP_missing)
-          ~some:(fun ip -> Ok (List.map ipaddr_to_cstruct ips, ip))
+          ~some:(fun ip -> Ok (List.map ipaddr_to_octets ips, ip))
           (List.nth_opt ips 0)
   in
   let dns_names = dns_names () in

--- a/ocaml/xapi-aux/networking_info.ml
+++ b/ocaml/xapi-aux/networking_info.ml
@@ -61,8 +61,6 @@ let ipaddr_to_octets = function
   | Ipaddr.V6 addr ->
       Ipaddr.V6.to_octets addr
 
-let ipaddr_to_cstruct c = ipaddr_to_octets c |> Cstruct.of_string
-
 let get_management_ip_addrs ~dbg =
   let iface = Inventory.lookup Inventory._management_interface in
   try
@@ -101,8 +99,7 @@ let get_management_ip_addrs ~dbg =
 let get_management_ip_addr ~dbg =
   match get_management_ip_addrs ~dbg with
   | Ok (preferred, _) ->
-      List.nth_opt preferred 0
-      |> Option.map (fun addr -> (Ipaddr.to_string addr, ipaddr_to_cstruct addr))
+      List.nth_opt preferred 0 |> Option.map Ipaddr.to_string
   | Error _ ->
       None
 

--- a/ocaml/xapi-aux/networking_info.mli
+++ b/ocaml/xapi-aux/networking_info.mli
@@ -31,6 +31,6 @@ val get_management_ip_addr : dbg:string -> (string * Cstruct.t) option
 
 val get_host_certificate_subjects :
      dbg:string
-  -> (string * string list * Cstruct.t list, management_ip_error) Result.t
+  -> (string * string list * string list, management_ip_error) Result.t
 (** [get_host_certificate_subjects ~dbg] returns the main, dns names and ip
     addresses that identify the host in secure connections. *)

--- a/ocaml/xapi-aux/networking_info.mli
+++ b/ocaml/xapi-aux/networking_info.mli
@@ -24,10 +24,9 @@ val management_ip_error_to_string : management_ip_error -> string
 (** [management_ip_error err] returns a string representation of [err], useful
     only for logging. *)
 
-val get_management_ip_addr : dbg:string -> (string * Cstruct.t) option
+val get_management_ip_addr : dbg:string -> string option
 (** [get_management_ip_addr ~dbg] returns the preferred IP of the management
-    network, or None. The address is returned in two formats: a human-readable
-    string and its bytes representation. *)
+    network, or None. The address is returned in a human-readable string *)
 
 val get_host_certificate_subjects :
      dbg:string

--- a/ocaml/xapi/cert_refresh.ml
+++ b/ocaml/xapi/cert_refresh.ml
@@ -79,7 +79,7 @@ let host ~__context ~type' =
         Server_error
           (cannot_contact_host, [Ref.string_of (HostSet.choose unreachable)])
       ) ;
-  let content = X509.Certificate.encode_pem cert |> Cstruct.to_string in
+  let content = X509.Certificate.encode_pem cert in
   (* distribute public part of new cert in pool *)
   Cert_distrib.distribute_new_host_cert ~__context ~host ~content ;
   (* replace certs in file system on host *)

--- a/ocaml/xapi/certificates.ml
+++ b/ocaml/xapi/certificates.ml
@@ -32,7 +32,7 @@ open D
 type t_trusted = CA_Certificate | CRL
 
 let pem_of_string x =
-  match Cstruct.of_string x |> X509.Certificate.decode_pem with
+  match X509.Certificate.decode_pem x with
   | Error _ ->
       D.error "pem_of_string: failed to parse certificate string" ;
       raise
@@ -75,7 +75,7 @@ let to_string = function CA_Certificate -> "CA certificate" | CRL -> "CRL"
     adding a colon between every octet, in uppercase.
  *)
 let pp_hash hash =
-  let hex = Hex.(show @@ of_cstruct hash) in
+  let hex = Hex.(show @@ of_string hash) in
   let length = (3 * String.length hex / 2) - 1 in
   let value_of i =
     match (i + 1) mod 3 with
@@ -441,9 +441,7 @@ let get_internal_server_certificate () =
 open Rresult
 
 let hostnames_of_pem_cert pem =
-  Cstruct.of_string pem
-  |> X509.Certificate.decode_pem
-  >>| X509.Certificate.hostnames
+  X509.Certificate.decode_pem pem >>| X509.Certificate.hostnames
 
 let install_server_certificate ~pem_chain ~pem_leaf ~pkcs8_private_key ~path =
   let installation =

--- a/ocaml/xapi/certificates.mli
+++ b/ocaml/xapi/certificates.mli
@@ -18,10 +18,9 @@ type t_trusted = CA_Certificate | CRL
 
 val pem_of_string : string -> X509.Certificate.t
 
-val pp_hash : Cstruct.t -> string
+val pp_hash : string -> string
 
-val pp_fingerprint :
-  hash_type:Mirage_crypto.Hash.hash -> X509.Certificate.t -> string
+val pp_fingerprint : hash_type:Digestif.hash' -> X509.Certificate.t -> string
 
 val validate_name : t_trusted -> string -> unit
 

--- a/ocaml/xapi/certificates_sync.ml
+++ b/ocaml/xapi/certificates_sync.ml
@@ -57,10 +57,8 @@ let get_server_cert path =
   | Error msg ->
       Error (`Msg (msg, []))
   | Ok cert ->
-      let host_pem = cert.GP.host_cert in
       let* host_cert =
-        Cstruct.of_string host_pem
-        |> X509.Certificate.decode_pem
+        X509.Certificate.decode_pem cert.GP.host_cert
         |> R.reword_error (fun (`Msg msg) ->
                D.info {|Failed to decode certificate because "%s"|} msg ;
                `Msg (server_certificate_invalid, [])

--- a/ocaml/xapi/dune
+++ b/ocaml/xapi/dune
@@ -138,6 +138,7 @@
   clock
   cohttp
   cohttp_posix
+  digestif
   domain-name
   ezxenstore.core
   fmt

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -157,7 +157,7 @@ let get_management_iface_is_connected ~__context =
 
 let get_management_ip_addr ~__context =
   let dbg = Context.string_of_task __context in
-  Option.map fst (Networking_info.get_management_ip_addr ~dbg)
+  Networking_info.get_management_ip_addr ~dbg
 
 let get_localhost_uuid () =
   Xapi_inventory.lookup Xapi_inventory._installation_uuid

--- a/ocaml/xapi/xapi_db_upgrade.ml
+++ b/ocaml/xapi/xapi_db_upgrade.ml
@@ -930,7 +930,6 @@ let upgrade_ca_fingerprints =
               try
                 let* certificate =
                   Xapi_stdext_unix.Unixext.string_of_file filename
-                  |> Cstruct.of_string
                   |> X509.Certificate.decode_pem
                 in
                 let sha1 =

--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -801,12 +801,12 @@ module Caching = struct
        and type password = string
        and type session = external_auth_result
 
-  let () = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
+  let () = Mirage_crypto_rng_unix.use_default ()
 
   let create_salt () =
     (* Creates a Cstruct of length 8. *)
     let data = Mirage_crypto_rng.generate 8 in
-    let bytes = Cstruct.to_bytes data in
+    let bytes = Bytes.of_string data in
     (* Encode the salt as a hex string. Each byte becomes 2
        hexadecimal digits, so the length is 16 (the maximum for
        crypt_r). *)


### PR DESCRIPTION
Unfortunately mirage-crypto has accumulated breaking changes:
- Cstructs have been replaced with strings
- The digestif library has replaced ad-hoc hash implementation

A deprecation has happened as well:
- RNG initialization has changed

Because there are breaking changes, xs-opam changes need to be introduced at the same time: https://github.com/xapi-project/xs-opam/pull/731

Only xapi is affected by the breaking builds, so no other toolstack repositories have incoming PRs.
I've tested builds with  Smoke and validation tests: SR 218740


This means that the merge will be done as such:
- Both PRs are approved
- First I will merge xs-opam will be emrged (with failing CI)
- Then this PR will be merged with the merge train that runs tests before actually merging.
- CI is rerun manually on xs-opam to make it green again

After merging both xenserver's CI should create a successful build with both PR included