### PR TITLE
Fix `xe host-get-cpu-features` command, add `pool-get-cpu-features`

### DIFF
--- a/ocaml/tests/test_xapi_xenops.ml
+++ b/ocaml/tests/test_xapi_xenops.ml
@@ -62,8 +62,8 @@ let test_xapi_restart_inner () =
   in
   let flags =
     [
-      (Xapi_globs.cpu_info_vendor_key, "AuthenticAMD")
-    ; (Xapi_globs.cpu_info_features_key, "deadbeef-deadbeef")
+      (Constants.cpu_info_vendor_key, "AuthenticAMD")
+    ; (Constants.cpu_info_features_key, "deadbeef-deadbeef")
     ]
   in
   let add_flags vm =

--- a/ocaml/tests/test_xenopsd_metadata.ml
+++ b/ocaml/tests/test_xenopsd_metadata.ml
@@ -38,8 +38,8 @@ let load_vm_config __context conf =
   in
   let flags =
     [
-      (Xapi_globs.cpu_info_vendor_key, "AuthenticAMD")
-    ; (Xapi_globs.cpu_info_features_key, "deadbeef-deadbeef")
+      (Constants.cpu_info_vendor_key, "AuthenticAMD")
+    ; (Constants.cpu_info_features_key, "deadbeef-deadbeef")
     ]
   in
   Db.VM.set_last_boot_CPU_flags ~__context ~self ~value:flags ;

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -535,6 +535,18 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "pool-get-cpu-features"
+    , {
+        reqd= []
+      ; optn= []
+      ; help=
+          {|Prints a hexadecimal representation of the pool's physical-CPU
+           features for PV and HVM VMs. These are combinations of all the
+           hosts' policies and are used when starting new VMs in a pool.|}
+      ; implementation= No_fd Cli_operations.pool_get_cpu_features
+      ; flags= []
+      }
+    )
   ; ( "host-is-in-emergency-mode"
     , {
         reqd= []
@@ -1018,8 +1030,10 @@ let rec cmdtable_data : (string * cmd_spec) list =
         reqd= []
       ; optn= ["uuid"]
       ; help=
-          "Prints a hexadecimal representation of the host's physical-CPU \
-           features."
+          {|Prints a hexadecimal representation of the host's physical-CPU
+           features for PV and HVM VMs. features_{hvm,pv} are "maximum"
+           featuresets the host will accept during migrations, and
+           features_{hvm,pv}_host will be used to start new VMs.|}
       ; implementation= No_fd Cli_operations.host_get_cpu_features
       ; flags= []
       }

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -6799,6 +6799,28 @@ let pool_get_guest_secureboot_readiness printer rpc session_id params =
        (Record_util.pool_guest_secureboot_readiness_to_string result)
     )
 
+let cpu_info_features_of feature_keys cpu_info =
+  let ( let* ) = Option.bind in
+  List.filter_map
+    (fun key ->
+      let* features = List.assoc_opt key cpu_info in
+      Some (key, features)
+    )
+    feature_keys
+
+let pool_get_cpu_features printer rpc session_id params =
+  let pool = get_pool_with_default rpc session_id params "uuid" in
+  let cpu_info = Client.Pool.get_cpu_info ~rpc ~session_id ~self:pool in
+
+  let feature_keys =
+    [
+      Constants.cpu_info_features_pv_host_key
+    ; Constants.cpu_info_features_hvm_host_key
+    ]
+  in
+  let features = cpu_info_features_of feature_keys cpu_info in
+  printer (Cli_printer.PTable [features])
+
 let pool_sync_bundle fd _printer rpc session_id params =
   let filename_opt = List.assoc_opt "filename" params in
   match filename_opt with
@@ -6968,8 +6990,17 @@ let host_get_cpu_features printer rpc session_id params =
       get_host_from_session rpc session_id
   in
   let cpu_info = Client.Host.get_cpu_info ~rpc ~session_id ~self:host in
-  let features = List.assoc "features" cpu_info in
-  printer (Cli_printer.PMsg features)
+
+  let feature_keys =
+    [
+      Constants.cpu_info_features_pv_key
+    ; Constants.cpu_info_features_hvm_key
+    ; Constants.cpu_info_features_pv_host_key
+    ; Constants.cpu_info_features_hvm_host_key
+    ]
+  in
+  let features = cpu_info_features_of feature_keys cpu_info in
+  printer (Cli_printer.PTable [features])
 
 let host_enable_display printer rpc session_id params =
   let host =

--- a/ocaml/xapi-consts/constants.ml
+++ b/ocaml/xapi-consts/constants.ml
@@ -177,6 +177,20 @@ let hvm_boot_params_order = "order"
 
 let hvm_default_boot_order = "cd"
 
+(** Keys for different CPUID policies in {Host,Pool}.cpu_info *)
+
+let cpu_info_vendor_key = "vendor"
+
+let cpu_info_features_key = "features"
+
+let cpu_info_features_pv_key = "features_pv"
+
+let cpu_info_features_hvm_key = "features_hvm"
+
+let cpu_info_features_pv_host_key = "features_pv_host"
+
+let cpu_info_features_hvm_host_key = "features_hvm_host"
+
 (* Key we put in VM.other_config when we upgrade a VM from Zurich/Geneva to Rio *)
 let vm_upgrade_time = "upgraded at"
 

--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -12,8 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-open Xapi_globs
-
 module D = Debug.Make (struct let name = "cpuid_helpers" end)
 
 open D
@@ -24,20 +22,19 @@ let features_t t =
     (Xenops_interface.CPU_policy.of_string t)
     Xenops_interface.CPU_policy.to_string
 
-let features =
-  Map_check.(field Xapi_globs.cpu_info_features_key (features_t `vm))
+let features = Map_check.(field Constants.cpu_info_features_key (features_t `vm))
 
 let features_pv =
-  Map_check.(field Xapi_globs.cpu_info_features_pv_key (features_t `host))
+  Map_check.(field Constants.cpu_info_features_pv_key (features_t `host))
 
 let features_hvm =
-  Map_check.(field Xapi_globs.cpu_info_features_hvm_key (features_t `host))
+  Map_check.(field Constants.cpu_info_features_hvm_key (features_t `host))
 
 let features_pv_host =
-  Map_check.(field Xapi_globs.cpu_info_features_pv_host_key (features_t `host))
+  Map_check.(field Constants.cpu_info_features_pv_host_key (features_t `host))
 
 let features_hvm_host =
-  Map_check.(field Xapi_globs.cpu_info_features_hvm_host_key (features_t `host))
+  Map_check.(field Constants.cpu_info_features_hvm_host_key (features_t `host))
 
 let cpu_count = Map_check.(field "cpu_count" int)
 
@@ -55,7 +52,7 @@ let get_flags_for_vm ~__context domain_type cpu_info =
     | `pv ->
         features_pv
   in
-  let vendor = List.assoc cpu_info_vendor_key cpu_info in
+  let vendor = List.assoc Constants.cpu_info_vendor_key cpu_info in
   let migration = Map_check.getf features_field cpu_info in
   (vendor, migration)
 
@@ -124,16 +121,18 @@ let assert_vm_is_compatible ~__context ~vm ~host =
         get_host_compatibility_info ~__context ~domain_type ~host ()
       in
       let vm_cpu_info = vm_rec.API.vM_last_boot_CPU_flags in
-      if List.mem_assoc cpu_info_vendor_key vm_cpu_info then (
+      if List.mem_assoc Constants.cpu_info_vendor_key vm_cpu_info then (
         (* Check the VM was last booted on a CPU with the same vendor as this host's CPU. *)
-        let vm_cpu_vendor = List.assoc cpu_info_vendor_key vm_cpu_info in
+        let vm_cpu_vendor =
+          List.assoc Constants.cpu_info_vendor_key vm_cpu_info
+        in
         debug "VM last booted on CPU of vendor %s; host CPUs are of vendor %s"
           vm_cpu_vendor host_cpu_vendor ;
         if vm_cpu_vendor <> host_cpu_vendor then
           fail
             "VM last booted on a host which had a CPU from a different vendor."
       ) ;
-      if List.mem_assoc cpu_info_features_key vm_cpu_info then (
+      if List.mem_assoc Constants.cpu_info_features_key vm_cpu_info then (
         (* Check the VM was last booted on a CPU whose features are a subset of the features of this host's CPU. *)
         let vm_cpu_features = Map_check.getf features vm_cpu_info in
         debug

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -579,16 +579,16 @@ let create_host_cpu ~__context host_info =
         ; ("model", cpu_info.model)
         ; ("stepping", cpu_info.stepping)
         ; ("flags", cpu_info.flags)
-        ; ( Xapi_globs.cpu_info_features_pv_key
+        ; ( Constants.cpu_info_features_pv_key
           , CPU_policy.to_string cpu_info.features_pv
           )
-        ; ( Xapi_globs.cpu_info_features_hvm_key
+        ; ( Constants.cpu_info_features_hvm_key
           , CPU_policy.to_string cpu_info.features_hvm
           )
-        ; ( Xapi_globs.cpu_info_features_hvm_host_key
+        ; ( Constants.cpu_info_features_hvm_host_key
           , CPU_policy.to_string cpu_info.features_hvm_host
           )
-        ; ( Xapi_globs.cpu_info_features_pv_host_key
+        ; ( Constants.cpu_info_features_pv_host_key
           , CPU_policy.to_string cpu_info.features_pv_host
           )
         ]
@@ -698,8 +698,8 @@ let create_pool_cpuinfo ~__context =
       ("vendor", "")
     ; ("socket_count", "0")
     ; ("cpu_count", "0")
-    ; (Xapi_globs.cpu_info_features_pv_host_key, "")
-    ; (Xapi_globs.cpu_info_features_hvm_host_key, "")
+    ; (Constants.cpu_info_features_pv_host_key, "")
+    ; (Constants.cpu_info_features_hvm_host_key, "")
     ]
   in
   let pool_cpuinfo = List.fold_left merge zero all_host_cpus in

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -631,20 +631,6 @@ let auth_type_PAM = "PAM"
 
 let event_hook_auth_on_xapi_initialize_succeeded = ref false
 
-(** {2 CPUID feature masking} *)
-
-let cpu_info_vendor_key = "vendor"
-
-let cpu_info_features_key = "features"
-
-let cpu_info_features_pv_key = "features_pv"
-
-let cpu_info_features_hvm_key = "features_hvm"
-
-let cpu_info_features_pv_host_key = "features_pv_host"
-
-let cpu_info_features_hvm_host_key = "features_hvm_host"
-
 (** Metrics *)
 
 let metrics_root = "/dev/shm/metrics"

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1213,7 +1213,7 @@ module MD = struct
       if not (List.mem_assoc Vm_platform.featureset platformdata) then
         let featureset =
           match
-            List.assoc_opt Xapi_globs.cpu_info_features_key
+            List.assoc_opt Constants.cpu_info_features_key
               vm.API.vM_last_boot_CPU_flags
           with
           | _ when vm.API.vM_power_state <> `Suspended ->
@@ -2418,12 +2418,12 @@ let update_vm ~__context id =
                     state.Vm.featureset ;
                   let vendor =
                     Db.Host.get_cpu_info ~__context ~self:localhost
-                    |> List.assoc Xapi_globs.cpu_info_vendor_key
+                    |> List.assoc Constants.cpu_info_vendor_key
                   in
                   let value =
                     [
-                      (Xapi_globs.cpu_info_vendor_key, vendor)
-                    ; (Xapi_globs.cpu_info_features_key, state.Vm.featureset)
+                      (Constants.cpu_info_vendor_key, vendor)
+                    ; (Constants.cpu_info_features_key, state.Vm.featureset)
                     ]
                   in
                   Db.VM.set_last_boot_CPU_flags ~__context ~self ~value


### PR DESCRIPTION
`Host.cpu_info` list no longer contains a value associated with
a "features" key, but the CLI implementation was hardcoded to expect it.

As a result, it would show an unhelpful error like:

```
The server failed to handle your request, due to an internal error.
The given message may give details useful for debugging the problem.
message: INTERNAL_ERROR: [ Not_found ]
```

Instead use the `cpu_info_features` keys from xapi-consts (after moving these keys from xapi-globs first).

Add the pool version of the command.

Additionally document their output format:

```
# xe help host-get-cpu-features
command name            : host-get-cpu-features
        reqd params     :
        optional params : uuid
        description     : Prints a hexadecimal representation of the host's physical-CPU
           features for PV and HVM VMs. features_{hvm,pv} are "maximum"
           featuresets the host will accept during migrations, and
           features_{hvm,pv}_host will be used to start new VMs.


# xe help pool-get-cpu-features
command name            : pool-get-cpu-features
        reqd params     :
        optional params :
        description     : Prints a hexadecimal representation of the pool's physical-CPU
           features for PV and HVM VMs. These are combinations of all the
           hosts' policies and are used when starting new VMs in a pool.

# xe host-get-cpu-features uuid=7f566729-0ee7-47c4-853d-2c5f3a195ad4
features_pv          : 1fc9cbf5-f6f83203-2991cbf5-00000123-00000001-000c0b39-00000000-00000100-00001000-ac000c00-00000000-00000000-00000000-00000000-00000000-00000000-1c020004-00000000-00000000-00000000-00000000-00000000
         features_hvm: 1fcbfbff-f7fa3223-2d93fbff-00000523-00000001-001c0fbb-00000000-00000100-00101000-bc000c00-00000000-00000000-00000000-00000000-00000000-00000000-1c020004-00000000-00000000-00000000-00000000-00000000
     features_pv_host: 1fc9cbf5-f6d83203-28100800-00000121-00000001-000c0b29-00000000-00000000-00001000-ac000400-00000000-00000000-00000000-00000000-00000000-00000000-0c000000-00000000-00000000-00000000-00000000-00000000
    features_hvm_host: 1fcbfbff-f7fa3203-2c100800-00000121-00000001-001c0fab-00000000-00000000-00101000-bc000400-00000000-00000000-00000000-00000000-00000000-00000000-0c000000-00000000-00000000-00000000-00000000-00000000


# xe pool-get-cpu-features
features_pv_host     : 1fc9cbf5-f6d83203-28100800-00000121-00000001-000c0b29-00000000-00000000-00001000-ac000400-00000000-00000000-00000000-00000000-00000000-00000000-0c000000-00000000-00000000-00000000-00000000-00000000
    features_hvm_host: 1fcbfbff-f7fa3203-2c100800-00000121-00000001-001c0fab-00000000-00000000-00101000-bc000400-00000000-00000000-00000000-00000000-00000000-00000000-0c000000-00000000-00000000-00000000-00000000-00000000
```

====

Tested manually