### PR TITLE
github: keep scheduled yangtze's runs working

### DIFF
--- a/.github/workflows/1.249-lcm.yml
+++ b/.github/workflows/1.249-lcm.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-test:
     name: Python tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     strategy:
@@ -28,7 +28,7 @@ jobs:
 
   ocaml-test:
     name: Ocaml tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
at least for a while longer...

Mirrors the changes in the 1.249 LCM branch: #6473