### PR TITLE
[maintenance]: add forkexecd C objects to .gitignore

### DIFF
--- a/ocaml/forkexecd/.gitignore
+++ b/ocaml/forkexecd/.gitignore
@@ -1,4 +1,7 @@
 _build/
+helper/*.o
+helper/*.o.d
+helper/vfork_helper
 .merlin
 *.install
 

--- a/ocaml/forkexecd/helper/Makefile
+++ b/ocaml/forkexecd/helper/Makefile
@@ -5,7 +5,7 @@ LDFLAGS ?=
 all:: vfork_helper
 
 clean::
-	rm -f vfork_helper *.o
+	rm -f vfork_helper *.o *.o.d
 
 %.o: %.c
 	$(CC) $(CFLAGS) -MMD -MP -MF $@.d -c -o $@ $<


### PR DESCRIPTION
Also fix the Makefile, so that 'make clean' also deletes the `.o.d` files.

This avoids accidentally adding these files to git (although normally dune would invoke make in _build,
 only if you manually invoke it would it create these extra files):
```
A ocaml/forkexecd/helper/close_from.o
A ocaml/forkexecd/helper/close_from.o.d
A ocaml/forkexecd/helper/syslog.o
A ocaml/forkexecd/helper/syslog.o.d
A ocaml/forkexecd/helper/vfork_helper
A ocaml/forkexecd/helper/vfork_helper.o
A ocaml/forkexecd/helper/vfork_helper.o.d
```