### PR TITLE
Don't pollute the logs with some errors

### DIFF
--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.ml
@@ -17,6 +17,11 @@ exception Unix_error of int
 
 let _exit = Unix._exit
 
+let raise_with_preserved_backtrace exn f =
+  let bt = Printexc.get_raw_backtrace () in
+  f () ;
+  Printexc.raise_with_backtrace exn bt
+
 (** remove a file, but doesn't raise an exception if the file is already removed *)
 let unlink_safe file =
   try Unix.unlink file with (* Unix.Unix_error (Unix.ENOENT, _ , _)*) _ -> ()

--- a/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
+++ b/ocaml/libs/xapi-stdext/lib/xapi-stdext-unix/unixext.mli
@@ -15,6 +15,10 @@
 
 val _exit : int -> unit
 
+val raise_with_preserved_backtrace : exn -> (unit -> unit) -> 'b
+(** A wrapper that preserves the backtrace (otherwise erased by calling
+    formatting functions, for example) *)
+
 val unlink_safe : string -> unit
 
 val mkdir_safe : string -> Unix.file_perm -> unit

--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -162,7 +162,8 @@ module Sysfs = struct
     with
     | End_of_file ->
         ""
-    | Unix.Unix_error (Unix.EINVAL, _, _) ->
+    | Unix.Unix_error (Unix.EINVAL, _, _) | Unix.Unix_error (Unix.ENOENT, _, _)
+      ->
         (* The device is not yet up *)
         raise (Network_error (Read_error file))
     | exn ->

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -1033,7 +1033,9 @@ module Nvidia_compat = struct
           read_configs ac tl
       )
     in
-    let conf_files = Array.to_list (Sys.readdir conf_dir) in
+    let conf_files =
+      try Array.to_list (Sys.readdir conf_dir) with Sys_error _ -> []
+    in
     debug "Reading NVIDIA vGPU config files %s/{%s}" conf_dir
       (String.concat ", " conf_files) ;
     read_configs []


### PR DESCRIPTION
It's an in-house joke that most of `xapi`'s errors are "expected" (either because they're handled by the caller after being logged or because they are frequent and benign) and knowing which ones are unusual and actually critical takes a lot of learning. Try to remove at least some of the most obvious ones from the toolstack startup/VM resume, either removing the logs completely or downgrading it to `debug` when appropriate.

Manually tested in the appropriate scenarios.