### PR TITLE
CA-412164: XSI-1901: uid-info does not support `:`

### DIFF
--- a/ocaml/tests/test_extauth_plugin_ADwinbind.ml
+++ b/ocaml/tests/test_extauth_plugin_ADwinbind.ml
@@ -219,6 +219,27 @@ let test_parse_wbinfo_uid_info =
           ; gecos= {|ladmin|}
           }
       )
+      (* XSI-1901: output of customer environment, has `:` in the gecos,
+         other fields does not likely contain it *)
+    ; ( {|HVS\udaadmin:*:3000000:3000000:ADMIN: Dalsem, Ulric:/home/HVS/udaadmin:/bin/bash|}
+      , Ok
+          {
+            user_name= {|HVS\udaadmin|}
+          ; uid= 3000000
+          ; gid= 3000000
+          ; gecos= {|ADMIN: Dalsem, Ulric|}
+          }
+      )
+      (* Multiple `:` in gecos *)
+    ; ( {|HVS\udaadmin:*:3000000:3000000:ADMIN: Dalsem, Ulric, POOL OP: udaadmin:/home/HVS/udaadmin:/bin/bash|}
+      , Ok
+          {
+            user_name= {|HVS\udaadmin|}
+          ; uid= 3000000
+          ; gid= 3000000
+          ; gecos= {|ADMIN: Dalsem, Ulric, POOL OP: udaadmin|}
+          }
+      )
     ; ( {|CONNAPP\locked:*:3000004:3000174::/home/CONNAPP/locked:/bin/bash|}
       , Ok
           {user_name= {|CONNAPP\locked|}; uid= 3000004; gid= 3000174; gecos= ""}

--- a/ocaml/xapi/extauth_plugin_ADwinbind.ml
+++ b/ocaml/xapi/extauth_plugin_ADwinbind.ml
@@ -686,11 +686,30 @@ module Wbinfo = struct
   let parse_uid_info stdout =
     (* looks like one line from /etc/passwd: https://en.wikipedia.org/wiki/Passwd#Password_file *)
     match String.split_on_char ':' stdout with
-    | [user_name; _passwd; uid; gid; gecos; _homedir; _shell] -> (
-      try Ok {user_name; uid= int_of_string uid; gid= int_of_string gid; gecos}
-      with _ -> Error ()
-    )
+    | user_name :: _passwd :: uid :: gid :: rest -> (
+        (* We expect at least homedir and shell at the end *)
+        let rest = List.rev rest in
+        match rest with
+        | _shell :: _homedir :: tail -> (
+            (* Rev it back to original order *)
+            let tail = List.rev tail in
+            let gecos = String.concat ":" tail in
+            try
+              Ok
+                {
+                  user_name
+                ; uid= int_of_string uid
+                ; gid= int_of_string gid
+                ; gecos
+                }
+            with _ -> Error ()
+          )
+        | _ ->
+            debug "uid_info format error: %s" stdout ;
+            Error ()
+      )
     | _ ->
+        debug "uid_info format error: %s" stdout ;
         Error ()
 
   let uid_info_of_uid (uid : int) =


### PR DESCRIPTION
from https://en.wikipedia.org/wiki/Passwd#Password_file uid_info as following format

username:password:uid:gid:gecos:homedir:shell

Regarding gecos, it is recommended as follows

Typically, this is a set of comma-separated values including the user's full name and contact details.

However, this information comes form AD and user may mis-configure it with `:`, which is used as seperator. In such case, the parse would failed.

Enhance the parse function to support `:` in gecos, other fields does not likely contain it.