### PR TITLE
CA-412313: don't lose distributed tracing spans when XAPI is shut down

### DIFF
--- a/ocaml/libs/tracing/tracing_export.mli
+++ b/ocaml/libs/tracing/tracing_export.mli
@@ -85,9 +85,9 @@ module Destination : sig
   end
 end
 
-val flush_and_exit : unit -> unit
-(** [flush_and_exit ()] sends a signal to flush the finish spans and terminate
-    the exporter thread.
+val flush_and_exit : max_wait:float -> unit -> unit
+(** [flush_and_exit ~max_wait ()] sends a signal to flush the finish spans and terminate
+    the exporter thread. It waits at most [max_wait] seconds.
   *)
 
 val main : unit -> Thread.t

--- a/ocaml/tests/bench/bench_tracing.ml
+++ b/ocaml/tests/bench/bench_tracing.ml
@@ -25,7 +25,7 @@ let export_thread =
   (* need to ensure this isn't running outside the benchmarked section,
      or bechamel might fail with 'Failed to stabilize GC'
   *)
-  let after _ = Tracing_export.flush_and_exit () in
+  let after _ = Tracing_export.flush_and_exit ~max_wait:0. () in
   Bechamel_simple_cli.thread_workload ~before:Tracing_export.main ~after
     ~run:ignore
 
@@ -52,7 +52,7 @@ let allocate () =
 
 let free t =
   Tracing.TracerProvider.destroy ~uuid ;
-  Tracing_export.flush_and_exit () ;
+  Tracing_export.flush_and_exit ~max_wait:0. () ;
   Thread.join t
 
 let test_tracing_on ?(overflow = false) ~name f =

--- a/ocaml/xapi/xapi_fuse.ml
+++ b/ocaml/xapi/xapi_fuse.ml
@@ -53,6 +53,8 @@ let light_fuse_and_run ?(fuse_length = !Constants.fuse_time) () =
   let new_fuse_length = max 5. (fuse_length -. delay_so_far) in
   debug "light_fuse_and_run: current RRDs have been saved" ;
   ignore
+    (Thread.create Tracing_export.(flush_and_exit ~max_wait:new_fuse_length) ()) ;
+  ignore
     (Thread.create
        (fun () ->
          let open Xapi_database in

--- a/ocaml/xs-trace/dune
+++ b/ocaml/xs-trace/dune
@@ -1,23 +1,18 @@
 (executable
-  (modes exe)
-  (name xs_trace)
-  (public_name xs-trace)
-  (package xapi-tools)
-  (libraries
-    uri
-    tracing
-    cmdliner
-    tracing_export
-    xapi-stdext-unix
-    zstd
-  )
-)
+ (modes exe)
+ (name xs_trace)
+ (public_name xs-trace)
+ (package xapi-tools)
+ (libraries uri tracing cmdliner tracing_export yojson xapi-stdext-unix zstd))
 
 (rule
-  (targets xs-trace.1)
-  (deps (:exe xs_trace.exe))
-  (action (with-stdout-to %{targets} (run %{exe} --help=groff)))
-)
+ (targets xs-trace.1)
+ (deps
+  (:exe xs_trace.exe))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{exe} --help=groff))))
 
 ; not expected by the specfile
 ;(install


### PR DESCRIPTION
Soon after Host.evacuate XAPI could be restarted (e.g. on coordinator promotion).
But we only export traces every 30s, so we lose the spans from the last 30s, including the toplevel Host.evacuate span (which although long running is only emitted on completion).

After this change I'm now able to see Host.evacuate and all the migrate calls in the exported distributed trace.