### PR TITLE
CA-412146 Filter out VF when scan

### DIFF
--- a/ocaml/networkd/lib/network_utils.ml
+++ b/ocaml/networkd/lib/network_utils.ml
@@ -181,17 +181,28 @@ module Sysfs = struct
       close_out outchan ;
       raise (Network_error (Write_error file))
 
-  let is_physical name =
+  exception Unable_to_read_driver_link
+
+  let is_vif name =
+    let devpath = getpath name "device" in
     try
-      let devpath = getpath name "device" in
       let driver_link = Unix.readlink (devpath ^ "/driver") in
       (* filter out symlinks under device/driver which look like
          /../../../devices/xen-backend/vif- *)
-      not
-        (List.mem "xen-backend"
-           (Astring.String.cuts ~empty:false ~sep:"/" driver_link)
-        )
+      List.mem "xen-backend"
+        (Astring.String.cuts ~empty:false ~sep:"/" driver_link)
+    with _ -> raise Unable_to_read_driver_link
+
+  let is_vf name =
+    let devpath = getpath name "device" in
+    try
+      ignore @@ Unix.readlink (devpath ^ "/physfn") ;
+      true
     with _ -> false
+
+  let is_physical name =
+    try not (is_vif name || is_vf name)
+    with Unable_to_read_driver_link -> false
 
   (* device types are defined in linux/if_arp.h *)
   let is_ether_device name =
@@ -1547,7 +1558,7 @@ module Ovs = struct
       let vif_arg =
         let existing_vifs =
           List.filter
-            (fun iface -> not (Sysfs.is_physical iface))
+            (fun iface -> try Sysfs.is_vif iface with _ -> false)
             (bridge_to_interfaces name)
         in
         let ifaces_with_type =


### PR DESCRIPTION
SR-IOV (Single Root I/O Virtualization) is a technology that allows a single physical PCI Express (PCIe) device, such as a network adapter, to be shared efficiently among multiple virtual machines (VMs) or containers. It achieves this by creating Virtual Functions (VFs) that act as lightweight PCIe functions, each assigned to a VM, while the Physical Function (PF) remains responsible for managing the device.

Add check in Sysfs.is_physical - check if there is "physfn" in the device dir to filter out VF, then XAPI will not create PIF object for VF during scan.