### PR TITLE
xenopsd: Allow to override the default NUMA placement

### DIFF
--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -59,6 +59,8 @@ let feature_flags_path = ref "/etc/xenserver/features.d"
 
 let pvinpvh_xen_cmdline = ref "pv-shim console=xen"
 
+let numa_placement_compat = ref true
+
 (* O(N^2) operations, until we get a xenstore cache, so use a small number here *)
 let vm_guest_agent_xenstore_quota = ref 128
 
@@ -240,11 +242,8 @@ let options =
     , "Command line for the inner-xen for PV-in-PVH guests"
     )
   ; ( "numa-placement"
-    , Arg.Bool (fun _ -> ())
-    , (fun () ->
-        string_of_bool
-          (!Xenops_server.default_numa_affinity_policy = Best_effort)
-      )
+    , Arg.Bool (fun x -> numa_placement_compat := x)
+    , (fun () -> string_of_bool !numa_placement_compat)
     , "NUMA-aware placement of VMs (deprecated, use XAPI setting)"
     )
   ; ( "pci-quarantine"

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -5259,6 +5259,8 @@ let init () =
         {Xs_protocol.ACL.owner= 0; other= Xs_protocol.ACL.READ; acl= []}
   ) ;
   Device.Backend.init () ;
+  Xenops_server.default_numa_affinity_policy :=
+    if !Xenopsd.numa_placement_compat then Best_effort else Any ;
   info "Default NUMA affinity policy is '%s'"
     Xenops_server.(string_of_numa_affinity_policy !default_numa_affinity_policy) ;
   Xenops_server.numa_placement := !Xenops_server.default_numa_affinity_policy ;


### PR DESCRIPTION
Use the numa-compat argument to be able to override the default numa placement using xenopsd.conf option.

This allows to change the default placement when building a package

This patch reverts some of the changes in e6f94be82198532d165018677a303a554c62c7ba