### PR TITLE
CA-406770: Improve error message

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -143,24 +143,15 @@ let do_op_on_common ~local_fn ~__context ~host ~remote_fn f =
       let task_opt = set_forwarding_on_task ~__context ~host in
       f __context host task_opt remote_fn
   with
-  | Xmlrpc_client.Connection_reset | Http_client.Http_request_rejected _ ->
-      warn
-        "Caught Connection_reset when contacting host %s; converting into \
-         CANNOT_CONTACT_HOST"
-        (Ref.string_of host) ;
-      raise
-        (Api_errors.Server_error
-           (Api_errors.cannot_contact_host, [Ref.string_of host])
-        )
-  | Xmlrpc_client.Stunnel_connection_failed ->
-      warn
-        "Caught Stunnel_connection_failed while contacting host %s; converting \
-         into CANNOT_CONTACT_HOST"
-        (Ref.string_of host) ;
-      raise
-        (Api_errors.Server_error
-           (Api_errors.cannot_contact_host, [Ref.string_of host])
-        )
+  | ( Xmlrpc_client.Connection_reset
+    | Http_client.Http_request_rejected _
+    | Xmlrpc_client.Stunnel_connection_failed ) as e
+  ->
+    error
+      "%s: Caught %s when contacting host %s; converting into \
+       CANNOT_CONTACT_HOST"
+      __FUNCTION__ (Printexc.to_string e) (Ref.string_of host) ;
+    raise Api_errors.(Server_error (cannot_contact_host, [Ref.string_of host]))
 
 (* regular forwarding fn, with session and live-check. Used by most calls, will
    use the connection cache. *)


### PR DESCRIPTION
1. WLB request will raise `wlb_authentication_failed` when catching `Http_client.Http_error`. But actually only error code 401 and 403 should raise this type exception. For other error code, raise `wlb_connection_reset`. Also print the detail error code and message.
2. `message_forwarding` raises same error for `Http_request_rejected` and `Connection_reset` so we don't know which exception actually be raised. Print detailed logs for these 2 exceptions.