### PR TITLE
CP-54441 Adapt interface ordering in xe-reset-networking

### DIFF
--- a/python3/bin/xe-reset-networking
+++ b/python3/bin/xe-reset-networking
@@ -24,7 +24,8 @@ pool_conf = '@ETCXENDIR@/pool.conf'
 inventory_file = '@INVENTORY@'
 management_conf = '/etc/firstboot.d/data/management.conf'
 network_reset = '/var/tmp/network-reset'
-
+RENAME_SCRIPT = '/etc/sysconfig/network-scripts/interface-rename.py'
+rename_script_exists = os.path.exists(RENAME_SCRIPT)
 
 @contextmanager
 def fsync_write(filename):
@@ -65,6 +66,15 @@ def valid_vlan(vlan):
     if int(vlan)<0 or int(vlan)>4094:
         return False
     return True
+
+def get_bridge_name(device, vlan):
+    # Construct bridge name for management interface based on convention
+    # NOTE: Only correct when interface-rename script exists
+    if vlan != None:
+        return 'xentemp'
+    if device[:3] == 'eth':
+        return 'xenbr' + device[3:]
+    return 'br' + device
 
 if __name__ == "__main__":
     parser = OptionParser()
@@ -208,12 +218,6 @@ Type 'no' to cancel.
         with fsync_write(pool_conf) as f:
             f.write('slave:' + address)
 
-    # Construct bridge name for management interface based on convention
-    if device[:3] == 'eth':
-        bridge = 'xenbr' + device[3:]
-    else:
-        bridge = 'br' + device
-
     # Ensure xapi is not running
     print("Stopping xapi...")
     os.system('service xapi stop >/dev/null 2>/dev/null')
@@ -229,10 +233,10 @@ Type 'no' to cancel.
     # Update interfaces in inventory file
     print('Updating inventory file...')
     inventory = read_inventory()
-    if vlan != None:
-        inventory['MANAGEMENT_INTERFACE'] = 'xentemp'
-    else:
-        inventory['MANAGEMENT_INTERFACE'] = bridge
+    # If rename script does not exist, needn't to set MANAGEMENT_INTERFACE in inventory file
+    # Networkd will handle it while replacing the rename script to sort interfaces
+    bridge = '' if not rename_script_exists else get_bridge_name(device, vlan)
+    inventory['MANAGEMENT_INTERFACE'] = bridge
     inventory['CURRENT_INTERFACES'] = ''
     write_inventory(inventory)
 
@@ -280,11 +284,11 @@ Type 'no' to cancel.
                 f.write('GATEWAY_V6=' + options.gateway_v6 + '\n')
         if is_static and options.dns != '':
             f.write('DNS=' + options.dns + '\n')
-
-    # Reset the domain 0 network interface naming configuration
-    # back to a fresh-install state for the currently-installed
-    # hardware.
-    os.system("/etc/sysconfig/network-scripts/interface-rename.py --reset-to-install")
+    if rename_script_exists:
+        # Reset the domain 0 network interface naming configuration
+        # back to a fresh-install state for the currently-installed
+        # hardware.
+        os.system(f"{RENAME_SCRIPT} --reset-to-install")
 
     # Reboot
     os.system("mount -o remount,rw / && reboot -f")

--- a/python3/bin/xe-reset-networking
+++ b/python3/bin/xe-reset-networking
@@ -220,7 +220,7 @@ Type 'no' to cancel.
 
     # Ensure xapi is not running
     print("Stopping xapi...")
-    os.system('service xapi stop >/dev/null 2>/dev/null')
+    os.system('systemctl stop xapi >/dev/null 2>/dev/null')
 
     # Reconfigure new management interface
     print("Reconfiguring " + device + "...")


### PR DESCRIPTION
If interface-rename script doesn't exist, networkd will
- handle the interfaces sorting
- write inventory when first boot

So, when interface-rename doesn't exist, xe-reset-networking should:
- NOT call interface-rename script
- Delete MANAGEMENT_INTERFACE value in inventory.

BTW, the current bridge name conversion method rely on hardcode 'eth' which is correct only when interface-rename script exists.