### PR TITLE
Add VM.sysprep API call

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -2068,6 +2068,9 @@ let _ =
        enable it in XC or run xe pool-enable-tls-verification instead."
     () ;
 
+  error Api_errors.sysprep ["vm"; "message"]
+    ~doc:"VM.sysprep error with details in the message" () ;
+
   message
     (fst Api_messages.ha_pool_overcommitted)
     ~doc:

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -239,6 +239,8 @@ let prototyped_of_message = function
       Some "25.2.0"
   | "host", "set_numa_affinity_policy" ->
       Some "24.0.0"
+  | "VM", "sysprep" ->
+      Some "25.21.0-next"
   | "VM", "get_secureboot_readiness" ->
       Some "24.17.0"
   | "VM", "set_uefi_mode" ->

--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -240,7 +240,7 @@ let prototyped_of_message = function
   | "host", "set_numa_affinity_policy" ->
       Some "24.0.0"
   | "VM", "sysprep" ->
-      Some "25.21.0-next"
+      Some "25.22.0"
   | "VM", "get_secureboot_readiness" ->
       Some "24.17.0"
   | "VM", "set_uefi_mode" ->

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2211,6 +2211,7 @@ let operations =
         ; ("reverting", "Reverting the VM to a previous snapshotted state")
         ; ("destroy", "refers to the act of uninstalling the VM")
         ; ("create_vtpm", "Creating and adding a VTPM to this VM")
+        ; ("sysprep", "Performing a Windows sysprep on this VM")
         ]
     )
 
@@ -2368,6 +2369,15 @@ let restart_device_models =
       ]
     ~allowed_roles:(_R_VM_POWER_ADMIN ++ _R_CLIENT_CERT)
     ()
+
+let sysprep =
+  call ~name:"sysprep" ~lifecycle:[]
+    ~params:
+      [
+        (Ref _vm, "self", "The VM")
+      ; (String, "unattend", "XML content passed to sysprep")
+      ]
+    ~doc:"Pass unattend.xml to Windows sysprep" ~allowed_roles:_R_VM_ADMIN ()
 
 let vm_uefi_mode =
   Enum
@@ -2571,6 +2581,7 @@ let t =
       ; set_blocked_operations
       ; add_to_blocked_operations
       ; remove_from_blocked_operations
+      ; sysprep
       ]
     ~contents:
       ([

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "4cd835e2557dd7b5cbda6c681730c447"
+let last_known_schema_hash = "9cd32d98d092440c36617546a3d995bd"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2764,6 +2764,15 @@ let rec cmdtable_data : (string * cmd_spec) list =
       ; flags= []
       }
     )
+  ; ( "vm-sysprep"
+    , {
+        reqd= ["filename"]
+      ; optn= []
+      ; help= "Pass and execure sysprep configuration file"
+      ; implementation= With_fd Cli_operations.vm_sysprep
+      ; flags= [Vm_selectors]
+      }
+    )
   ; ( "diagnostic-vm-status"
     , {
         reqd= ["uuid"]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3588,6 +3588,24 @@ let vm_data_source_forget printer rpc session_id params =
        params ["data-source"]
     )
 
+let vm_sysprep fd printer rpc session_id params =
+  let filename = List.assoc "filename" params in
+  let unattend =
+    match get_client_file fd filename with
+    | Some xml ->
+        xml
+    | None ->
+        marshal fd (Command (PrintStderr "Failed to read file.\n")) ;
+        raise (ExitWithError 1)
+  in
+  ignore
+    (do_vm_op printer rpc session_id
+       (fun vm ->
+         Client.VM.sysprep ~rpc ~session_id ~self:(vm.getref ()) ~unattend
+       )
+       params ["filename"]
+    )
+
 (* APIs to collect SR level RRDs *)
 let sr_data_source_list printer rpc session_id params =
   ignore

--- a/ocaml/xapi-cli-server/record_util.ml
+++ b/ocaml/xapi-cli-server/record_util.ml
@@ -75,6 +75,7 @@ let vm_operation_table =
   ; (`csvm, "csvm")
   ; (`call_plugin, "call_plugin")
   ; (`create_vtpm, "create_vtpm")
+  ; (`sysprep, "sysprep")
   ]
 
 (* Intentional shadowing - data_souces_op, assertoperationinvalid,

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -1438,3 +1438,9 @@ let host_driver_no_hardware = add_error "HOST_DRIVER_NO_HARDWARE"
 
 let tls_verification_not_enabled_in_pool =
   add_error "TLS_VERIFICATION_NOT_ENABLED_IN_POOL"
+
+(* VM.sysprep *)
+
+(* Using a single error during development, might want to expand this
+   later *)
+let sysprep = add_error "SYSPREP"

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3124,6 +3124,17 @@ functor
           (vm_uuid ~__context self) ;
         Local.VM.remove_from_blocked_operations ~__context ~self ~key ;
         Xapi_vm_lifecycle.update_allowed_operations ~__context ~self
+
+      let sysprep ~__context ~self ~unattend =
+        info "VM.sysprep: self = '%s'" (vm_uuid ~__context self) ;
+        let local_fn = Local.VM.sysprep ~self ~unattend in
+        let remote_fn = Client.VM.sysprep ~self ~unattend in
+        let policy = Helpers.Policy.fail_immediately in
+        with_vm_operation ~__context ~self ~doc:"VM.sysprep" ~op:`sysprep
+          ~policy (fun () ->
+            forward_vm_op ~local_fn ~__context ~vm:self ~remote_fn
+        ) ;
+        Xapi_vm_lifecycle.update_allowed_operations ~__context ~self
     end
 
     module VM_metrics = struct end

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -1,0 +1,61 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = __MODULE__ end)
+
+open D
+open Xapi_stdext_unix
+
+let ( // ) = Filename.concat
+
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
+
+let tmp_dir = Filename.get_temp_dir_name ()
+
+let sr_dir = "/opt/opt/iso"
+
+let genisoimage = "/usr/bin/genisoimage"
+
+(** name of the ISO we will use for a VMi; this is not a path *)
+let iso_name ~vm_uuid =
+  let now = Ptime_clock.now () |> Ptime.to_rfc3339 in
+  Printf.sprintf "config-%s-%s.iso" vm_uuid now
+
+(** taken from OCaml 5 stdlib *)
+let temp_dir ?(dir = tmp_dir) ?(perms = 0o700) prefix suffix =
+  let rec try_name counter =
+    let name = Filename.temp_file ~temp_dir:dir prefix suffix in
+    try Sys.mkdir name perms ; name
+    with Sys_error _ as e ->
+      if counter >= 20 then raise e else try_name (counter + 1)
+  in
+  try_name 0
+
+(** Crteate a temporary directory, and pass its path to [f]. Once [f]
+    returns the directory is removed again *)
+let with_temp_dir ?(dir = tmp_dir) ?(perms = 0o700) prefix suffix f =
+  let dir = temp_dir ~dir ~perms prefix suffix in
+  finally (fun () -> f dir) (fun () -> Unixext.rm_rec dir)
+
+let make_iso ~vm_uuid ~unattend =
+  try
+    let _iso = sr_dir // iso_name ~vm_uuid in
+    Xapi_stdext_unix.Unixext.mkdir_rec sr_dir 0o755
+    (* Unixext.write_string_to_file path unattend *)
+  with e ->
+    let msg = Printexc.to_string e in
+    Helpers.internal_error "%s failed: %s" __FUNCTION__ msg
+
+(* This function is executed on the host where [vm] is running *)
+let sysprep ~__context ~vm ~unattend = debug "%s" __FUNCTION__

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -86,8 +86,7 @@ let mkdtemp ?(dir = temp_dir) ?(perms = 0o700) prefix suffix =
         failwith_fmt "s: can't create directory in %s" __FUNCTION__ dir
     | n -> (
         let path = Filename.concat dir (temp_name prefix suffix) in
-        try Sys.mkdir path perms ; path
-        with Sys_error _ -> try_upto (n - 1)
+        try Sys.mkdir path perms ; path with Sys_error _ -> try_upto (n - 1)
       )
   in
   try_upto 20
@@ -205,6 +204,8 @@ let trigger ~domid =
 let sysprep ~__context ~vm ~unattend =
   let open Ezxenstore_core.Xenstore in
   debug "%s" __FUNCTION__ ;
+  if not !Xapi_globs.vm_sysprep_enabled then
+    failwith_fmt "Experimental VM.sysprep API call is not enabled" ;
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
   let domid = Db.VM.get_domid ~__context ~self:vm in
   let control = Printf.sprintf "/local/domain/%Ld/control" domid in

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -21,41 +21,68 @@ let ( // ) = Filename.concat
 
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
-let tmp_dir = Filename.get_temp_dir_name ()
+let temp_dir = Filename.get_temp_dir_name ()
 
 let sr_dir = "/opt/opt/iso"
 
 let genisoimage = "/usr/bin/genisoimage"
+
+let failwith_fmt fmt = Printf.ksprintf failwith fmt
+
+let prng = lazy (Random.State.make_self_init ())
+
+let temp_name prefix suffix =
+  let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
+  Printf.sprintf "%s%06x%s" prefix rnd suffix
+
+(** [mkdtmp] creates a directory in [dir] and returns its path. If [dir]
+    does not yet exist it is created. It is a an error if [dir] is not a
+    directory. *)
+let mkdtemp ?(dir = temp_dir) ?(perms = 0o700) prefix suffix =
+  ( match Sys.file_exists dir with
+  | true when not (Sys.is_directory dir) ->
+      failwith_fmt "s: %s is not a directory" __FUNCTION__ dir
+  | true ->
+      ()
+  | false ->
+      Unixext.mkdir_rec dir perms
+  ) ;
+  let rec loop = function
+    | n when n >= 20 ->
+        failwith_fmt "s: can't create directory in %s" __FUNCTION__ dir
+    | n -> (
+        let path = Filename.concat dir (temp_name prefix suffix) in
+        try Sys.mkdir path perms ; path with Sys_error _ -> loop (n + 1)
+      )
+  in
+  loop 0
+
+(** Crteate a temporary directory, and pass its path to [f]. Once [f]
+    returns the directory is removed again *)
+let with_temp_dir ?(dir = temp_dir) ?(perms = 0o700) prefix suffix f =
+  let dir = mkdtemp ~dir ~perms prefix suffix in
+  finally (fun () -> f dir) (fun () -> Unixext.rm_rec dir)
 
 (** name of the ISO we will use for a VMi; this is not a path *)
 let iso_name ~vm_uuid =
   let now = Ptime_clock.now () |> Ptime.to_rfc3339 in
   Printf.sprintf "config-%s-%s.iso" vm_uuid now
 
-(** taken from OCaml 5 stdlib *)
-let temp_dir ?(dir = tmp_dir) ?(perms = 0o700) prefix suffix =
-  let rec try_name counter =
-    let name = Filename.temp_file ~temp_dir:dir prefix suffix in
-    try Sys.mkdir name perms ; name
-    with Sys_error _ as e ->
-      if counter >= 20 then raise e else try_name (counter + 1)
-  in
-  try_name 0
-
-(** Crteate a temporary directory, and pass its path to [f]. Once [f]
-    returns the directory is removed again *)
-let with_temp_dir ?(dir = tmp_dir) ?(perms = 0o700) prefix suffix f =
-  let dir = temp_dir ~dir ~perms prefix suffix in
-  finally (fun () -> f dir) (fun () -> Unixext.rm_rec dir)
-
 let make_iso ~vm_uuid ~unattend =
   try
     let _iso = sr_dir // iso_name ~vm_uuid in
-    Xapi_stdext_unix.Unixext.mkdir_rec sr_dir 0o755
-    (* Unixext.write_string_to_file path unattend *)
+    Xapi_stdext_unix.Unixext.mkdir_rec sr_dir 0o755 ;
+    with_temp_dir ~dir:"/var/tmp/xapi" "sysprep-" "-iso" @@ fun temp_dir ->
+    debug "%s: %s = %b" __FUNCTION__ temp_dir (Sys.file_exists temp_dir) ;
+    let path = temp_dir // "unattend.xml" in
+    Unixext.write_string_to_file path unattend ;
+    debug "%s: written to %s" __FUNCTION__ path
   with e ->
     let msg = Printexc.to_string e in
     Helpers.internal_error "%s failed: %s" __FUNCTION__ msg
 
 (* This function is executed on the host where [vm] is running *)
-let sysprep ~__context ~vm ~unattend = debug "%s" __FUNCTION__
+let sysprep ~__context ~vm ~unattend =
+  debug "%s" __FUNCTION__ ;
+  let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
+  make_iso ~vm_uuid ~unattend

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -23,7 +23,12 @@ let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let genisoimage = "/usr/bin/genisoimage"
 
-let failwith_fmt fmt = Printf.ksprintf failwith fmt
+(** This will be shown to the user to explain a failure *)
+exception Failure of string
+
+let failwith_fmt fmt = Printf.ksprintf (fun msg -> raise (Failure msg)) fmt
+
+let internal_error = Helpers.internal_error
 
 let prng = lazy (Random.State.make_self_init ())
 
@@ -78,7 +83,7 @@ let temp_dir = Filename.get_temp_dir_name ()
 let mkdtemp ?(dir = temp_dir) ?(perms = 0o700) prefix suffix =
   ( match Sys.file_exists dir with
   | true when not (Sys.is_directory dir) ->
-      failwith_fmt "s: %s is not a directory" __FUNCTION__ dir
+      internal_error "s: %s is not a directory" __FUNCTION__ dir
   | true ->
       ()
   | false ->
@@ -86,7 +91,7 @@ let mkdtemp ?(dir = temp_dir) ?(perms = 0o700) prefix suffix =
   ) ;
   let rec try_upto = function
     | n when n < 0 ->
-        failwith_fmt "s: can't create directory in %s" __FUNCTION__ dir
+        internal_error "%s: can't create directory %S" __FUNCTION__ dir
     | n -> (
         let path = Filename.concat dir (temp_name prefix suffix) in
         try Sys.mkdir path perms ; path with Sys_error _ -> try_upto (n - 1)
@@ -157,7 +162,7 @@ let find_cdr_vbd ~__context ~vm =
   let uuid = Db.VM.get_uuid ~__context ~self:vm in
   match List.filter is_cd vbds' with
   | [] ->
-      failwith_fmt "%s: can't find CDR for VM %s" __FUNCTION__ uuid
+      failwith_fmt "can't find CDR for VM %s" uuid
   | [(rf, rc)] ->
       debug "%s: for VM %s using VBD %s" __FUNCTION__ uuid rc.API.vBD_uuid ;
       rf
@@ -171,7 +176,7 @@ let find_cdr_vbd ~__context ~vm =
 let find_vdi ~__context ~label =
   match Db.VDI.get_by_name_label ~__context ~label with
   | [] ->
-      failwith_fmt "%s: can't find VDI for %s" __FUNCTION__ label
+      internal_error "%s: can't find VDI for %s" __FUNCTION__ label
   | [vdi] ->
       vdi
   | vdi :: _ ->
@@ -213,7 +218,7 @@ let sysprep ~__context ~vm ~unattend =
   let domid = Db.VM.get_domid ~__context ~self:vm in
   let control = Printf.sprintf "/local/domain/%Ld/control" domid in
   if domid <= 0L then
-    failwith_fmt "%s: VM %s is not running" __FUNCTION__ vm_uuid ;
+    failwith_fmt " VM %s is not running" __FUNCTION__ vm_uuid ;
   if String.length unattend > 32 * 1024 then
     failwith_fmt "%s: provided file for %s larger than 32KiB" __FUNCTION__
       vm_uuid ;
@@ -236,10 +241,10 @@ let sysprep ~__context ~vm ~unattend =
   | "running" ->
       debug "%s: sysprep running, ejecting CD" __FUNCTION__ ;
       Xapi_vbd.eject ~__context ~vbd ;
-      Sys.remove iso ;
-      Result.ok ()
+      Sys.remove iso
   | status ->
       debug "%s: sysprep %S, ejecting CD" __FUNCTION__ status ;
       Xapi_vbd.eject ~__context ~vbd ;
       Sys.remove iso ;
-      Result.error status
+      failwith_fmt "VM %s sysprep not found running as expected: %S" vm_uuid
+        status

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -63,7 +63,6 @@ let on_startup ~__context =
       |> List.iter @@ fun self ->
          match Db.VDI.get_record ~__context ~self with
          | API.{vDI_VBDs= []; vDI_location= location; _} ->
-             Sys.remove (SR.dir // location) ;
              Xapi_vdi.destroy ~__context ~self
          | _ ->
              ()

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -21,8 +21,6 @@ let ( // ) = Filename.concat
 
 let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
-let temp_dir = Filename.get_temp_dir_name ()
-
 let genisoimage = "/usr/bin/genisoimage"
 
 let failwith_fmt fmt = Printf.ksprintf failwith fmt
@@ -35,9 +33,12 @@ module SR = struct
   let name hostname = Printf.sprintf "SYSPREP-%s" hostname
 end
 
+(** create a name with a random infix *)
 let temp_name prefix suffix =
   let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
   Printf.sprintf "%s%06x%s" prefix rnd suffix
+
+let temp_dir = Filename.get_temp_dir_name ()
 
 (** [mkdtmp] creates a directory in [dir] and returns its path. If [dir]
     does not yet exist it is created. It is a an error if [dir] exists
@@ -67,7 +68,7 @@ let with_temp_dir ?(dir = temp_dir) ?(perms = 0o700) prefix suffix f =
   let dir = mkdtemp ~dir ~perms prefix suffix in
   finally (fun () -> f dir) (fun () -> Unixext.rm_rec dir)
 
-(** name of the ISO we will use for a VMi; this is not a path *)
+(** name of the ISO we will use for a VM; this is not a path *)
 let iso_basename ~vm_uuid =
   let now = Ptime_clock.now () |> Ptime.to_rfc3339 in
   Printf.sprintf "sysprep-%s-%s.iso" vm_uuid now
@@ -76,7 +77,8 @@ let iso_basename ~vm_uuid =
     created if it not already exists. Returns the path of the ISO image *)
 let make_iso ~vm_uuid ~unattend =
   try
-    let iso = SR.dir // iso_basename ~vm_uuid in
+    let basename = iso_basename ~vm_uuid in
+    let iso = SR.dir // basename in
     Xapi_stdext_unix.Unixext.mkdir_rec SR.dir 0o755 ;
     with_temp_dir ~dir:"/var/tmp/xapi" "sysprep-" "-iso" (fun temp_dir ->
         let path = temp_dir // "unattend.xml" in
@@ -84,7 +86,7 @@ let make_iso ~vm_uuid ~unattend =
         debug "%s: written to %s" __FUNCTION__ path ;
         let args = ["-r"; "-J"; "-o"; iso; temp_dir] in
         Forkhelpers.execute_command_get_output genisoimage args |> ignore ;
-        iso
+        (iso, basename)
     )
   with e ->
     let msg = Printexc.to_string e in
@@ -105,17 +107,53 @@ let update_sr ~__context =
         warn "%s: more than one SR with label %s" __FUNCTION__ label ;
         sr
     | [] ->
-        let device_config = [("location", SR.dir); ("legcay_mode", "true")] in
+        let device_config = [("location", SR.dir); ("legacy_mode", "true")] in
         Xapi_sr.create ~__context ~host ~name_label:label ~device_config
           ~content_type:"iso" ~_type:"iso" ~name_description:"Sysprep ISOs"
           ~shared:false ~sm_config:[] ~physical_size:(mib 512)
   in
-  Xapi_sr.scan ~__context ~sr
+  Xapi_sr.scan ~__context ~sr ;
+  sr
+
+let find_cdr_vbd ~__context ~vm =
+  let vbds = Db.VM.get_VBDs ~__context ~self:vm in
+  let vbds' =
+    List.map (fun self -> (self, Db.VBD.get_record ~__context ~self)) vbds
+  in
+  let is_cd (rf, rc) =
+    let open API in
+    rc.vBD_type = `CD && rc.vBD_empty
+  in
+  let uuid = Db.VM.get_uuid ~__context ~self:vm in
+  match List.filter is_cd vbds' with
+  | [] ->
+      failwith_fmt "%s: can't find CDR for VM %s" __FUNCTION__ uuid
+  | [(rf, rc)] ->
+      debug "%s: for VM %s using VBD %s" __FUNCTION__ uuid rc.API.vBD_uuid ;
+      rf
+  | (rf, rc) :: _ ->
+      debug "%s: for VM %s using VBD %s" __FUNCTION__ uuid rc.API.vBD_uuid ;
+      warn "%s: for VM %s found additions VBDs" __FUNCTION__ uuid ;
+      rf
+
+let find_vdi ~__context ~label =
+  match Db.VDI.get_by_name_label ~__context ~label with
+  | [] ->
+      failwith_fmt "%s: can't find VDI for %s" __FUNCTION__ label
+  | [vdi] ->
+      vdi
+  | vdi :: _ ->
+      warn "%s: more than one VDI with label %s" __FUNCTION__ label ;
+      vdi
 
 (* This function is executed on the host where [vm] is running *)
 let sysprep ~__context ~vm ~unattend =
   debug "%s" __FUNCTION__ ;
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
-  let iso = make_iso ~vm_uuid ~unattend in
+  let iso, label = make_iso ~vm_uuid ~unattend in
   debug "%s: created ISO %s" __FUNCTION__ iso ;
-  update_sr ~__context
+  let _sr = update_sr ~__context in
+  let vbd = find_cdr_vbd ~__context ~vm in
+  let vdi = find_vdi ~__context ~label in
+  debug "%s: inserting Syspep VDI for VM %s" __FUNCTION__ vm_uuid ;
+  Xapi_vbd.insert ~__context ~vdi ~vbd

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -27,6 +27,8 @@ let failwith_fmt fmt = Printf.ksprintf failwith fmt
 
 let prng = lazy (Random.State.make_self_init ())
 
+(* A local ISO SR; we create an ISO that holds an unattend.xml file that
+   is than passed as CD to a VM *)
 module SR = struct
   let dir = "/var/opt/iso"
 
@@ -62,7 +64,8 @@ let on_startup ~__context =
              ()
     )
 
-(** create a name with a random infix *)
+(** create a name with a random infix. We need random names for
+    temporay directories to avoid collition *)
 let temp_name prefix suffix =
   let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
   Printf.sprintf "%s%06x%s" prefix rnd suffix

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -23,13 +23,17 @@ let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let temp_dir = Filename.get_temp_dir_name ()
 
-let sr_dir = "/var/opt/iso"
-
 let genisoimage = "/usr/bin/genisoimage"
 
 let failwith_fmt fmt = Printf.ksprintf failwith fmt
 
 let prng = lazy (Random.State.make_self_init ())
+
+module SR = struct
+  let dir = "/var/opt/iso"
+
+  let name hostname = Printf.sprintf "SYSPREP-%s" hostname
+end
 
 let temp_name prefix suffix =
   let rnd = Random.State.bits (Lazy.force prng) land 0xFFFFFF in
@@ -64,16 +68,16 @@ let with_temp_dir ?(dir = temp_dir) ?(perms = 0o700) prefix suffix f =
   finally (fun () -> f dir) (fun () -> Unixext.rm_rec dir)
 
 (** name of the ISO we will use for a VMi; this is not a path *)
-let iso_name ~vm_uuid =
+let iso_basename ~vm_uuid =
   let now = Ptime_clock.now () |> Ptime.to_rfc3339 in
-  Printf.sprintf "config-%s-%s.iso" vm_uuid now
+  Printf.sprintf "sysprep-%s-%s.iso" vm_uuid now
 
-(** Create an ISO in [sr_dir] with content [unattend]. [sr_dir] is
+(** Create an ISO in [SR.dir] with content [unattend]. [SR.dir] is
     created if it not already exists. Returns the path of the ISO image *)
 let make_iso ~vm_uuid ~unattend =
   try
-    let iso = sr_dir // iso_name ~vm_uuid in
-    Xapi_stdext_unix.Unixext.mkdir_rec sr_dir 0o755 ;
+    let iso = SR.dir // iso_basename ~vm_uuid in
+    Xapi_stdext_unix.Unixext.mkdir_rec SR.dir 0o755 ;
     with_temp_dir ~dir:"/var/tmp/xapi" "sysprep-" "-iso" (fun temp_dir ->
         let path = temp_dir // "unattend.xml" in
         Unixext.write_string_to_file path unattend ;
@@ -86,9 +90,32 @@ let make_iso ~vm_uuid ~unattend =
     let msg = Printexc.to_string e in
     Helpers.internal_error "%s failed: %s" __FUNCTION__ msg
 
+(** create a local ISO SR when necessary and update it such that it
+    recognises any ISO we added or removed *)
+let update_sr ~__context =
+  let host = Helpers.get_localhost ~__context in
+  let hostname = Db.Host.get_hostname ~__context ~self:host in
+  let label = SR.name hostname in
+  let mib n = Int64.(n * 1024 * 1024 |> of_int) in
+  let sr =
+    match Db.SR.get_by_name_label ~__context ~label with
+    | [sr] ->
+        sr
+    | sr :: _ ->
+        warn "%s: more than one SR with label %s" __FUNCTION__ label ;
+        sr
+    | [] ->
+        let device_config = [("location", SR.dir); ("legcay_mode", "true")] in
+        Xapi_sr.create ~__context ~host ~name_label:label ~device_config
+          ~content_type:"iso" ~_type:"iso" ~name_description:"Sysprep ISOs"
+          ~shared:false ~sm_config:[] ~physical_size:(mib 512)
+  in
+  Xapi_sr.scan ~__context ~sr
+
 (* This function is executed on the host where [vm] is running *)
 let sysprep ~__context ~vm ~unattend =
   debug "%s" __FUNCTION__ ;
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
   let iso = make_iso ~vm_uuid ~unattend in
-  debug "%s: created %s" __FUNCTION__ iso
+  debug "%s: created ISO %s" __FUNCTION__ iso ;
+  update_sr ~__context

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -31,7 +31,36 @@ module SR = struct
   let dir = "/var/opt/iso"
 
   let name hostname = Printf.sprintf "SYSPREP-%s" hostname
+
+  let find_opt ~__context ~label =
+    match Db.SR.get_by_name_label ~__context ~label with
+    | [sr] ->
+        Some sr
+    | sr :: _ ->
+        warn "%s: more than one SR with label %s" __FUNCTION__ label ;
+        Some sr
+    | [] ->
+        None
 end
+
+(** This is called on xapi startup. Opportunity to set up or clean up.
+    We destroy all VDIs that are unused. *)
+let on_startup ~__context =
+  let host = Helpers.get_localhost ~__context in
+  let hostname = Db.Host.get_hostname ~__context ~self:host in
+  match SR.find_opt ~__context ~label:(SR.name hostname) with
+  | None ->
+      ()
+  | Some sr -> (
+      Db.SR.get_VDIs ~__context ~self:sr
+      |> List.iter @@ fun self ->
+         match Db.VDI.get_record ~__context ~self with
+         | API.{vDI_VBDs= []; vDI_location= location; _} ->
+             Sys.remove (SR.dir // location) ;
+             Xapi_vdi.destroy ~__context ~self
+         | _ ->
+             ()
+    )
 
 (** create a name with a random infix *)
 let temp_name prefix suffix =
@@ -52,15 +81,16 @@ let mkdtemp ?(dir = temp_dir) ?(perms = 0o700) prefix suffix =
   | false ->
       Unixext.mkdir_rec dir perms
   ) ;
-  let rec loop = function
-    | n when n >= 20 ->
+  let rec try_upto = function
+    | n when n < 0 ->
         failwith_fmt "s: can't create directory in %s" __FUNCTION__ dir
     | n -> (
         let path = Filename.concat dir (temp_name prefix suffix) in
-        try Sys.mkdir path perms ; path with Sys_error _ -> loop (n + 1)
+        try Sys.mkdir path perms ; path
+        with Sys_error _ -> try_upto (n - 1)
       )
   in
-  loop 0
+  try_upto 20
 
 (** Crteate a temporary directory, and pass its path to [f]. Once [f]
     returns the directory is removed again *)
@@ -100,13 +130,10 @@ let update_sr ~__context =
   let label = SR.name hostname in
   let mib n = Int64.(n * 1024 * 1024 |> of_int) in
   let sr =
-    match Db.SR.get_by_name_label ~__context ~label with
-    | [sr] ->
+    match SR.find_opt ~__context ~label with
+    | Some sr ->
         sr
-    | sr :: _ ->
-        warn "%s: more than one SR with label %s" __FUNCTION__ label ;
-        sr
-    | [] ->
+    | None ->
         let device_config = [("location", SR.dir); ("legacy_mode", "true")] in
         Xapi_sr.create ~__context ~host ~name_label:label ~device_config
           ~content_type:"iso" ~_type:"iso" ~name_description:"Sysprep ISOs"
@@ -154,28 +181,61 @@ let find_vdi ~__context ~label =
 let trigger ~domid =
   let open Ezxenstore_core.Xenstore in
   let control = Printf.sprintf "/local/domain/%Ld/control/sysprep" domid in
-  with_xs @@ fun xs ->
-  xs.Xs.write (control // "filename") "D://unattend.xml" ;
-  Thread.delay 5.0 ;
-  xs.Xs.write (control // "action") "sysprep" ;
-  debug "%s: notified domain %Ld" __FUNCTION__ domid ;
-  Thread.delay 5.0 ;
-  let action = xs.Xs.read (control // "action") in
-  debug "%s: sysprep for domain %Ld reports %S" __FUNCTION__ domid action
+  with_xs (fun xs ->
+      xs.Xs.write (control // "filename") "D://unattend.xml" ;
+      Thread.delay 5.0 ;
+      xs.Xs.write (control // "action") "sysprep" ;
+      debug "%s: notified domain %Ld" __FUNCTION__ domid ;
+      let rec wait n =
+        match (n, xs.Xs.read (control // "action")) with
+        | _, "running" ->
+            "running"
+        | n, action when n < 0 ->
+            action
+        | _, _ ->
+            Thread.delay 1.0 ;
+            wait (n - 1)
+      in
+      (* wait up to 5 iterations for runnung to appear or report whatever
+         is the status at the end *)
+      wait 5
+  )
 
 (* This function is executed on the host where [vm] is running *)
 let sysprep ~__context ~vm ~unattend =
+  let open Ezxenstore_core.Xenstore in
   debug "%s" __FUNCTION__ ;
   let vm_uuid = Db.VM.get_uuid ~__context ~self:vm in
   let domid = Db.VM.get_domid ~__context ~self:vm in
+  let control = Printf.sprintf "/local/domain/%Ld/control" domid in
   if domid <= 0L then
-    failwith_fmt "%s: VM %s does not have a domain" __FUNCTION__ vm_uuid ;
+    failwith_fmt "%s: VM %s is not running" __FUNCTION__ vm_uuid ;
+  if String.length unattend > 32 * 1024 then
+    failwith_fmt "%s: provided file for %s larger than 32KiB" __FUNCTION__
+      vm_uuid ;
+  with_xs (fun xs ->
+      match xs.Xs.read (control // "feature-sysprep") with
+      | "1" ->
+          debug "%s: VM %s supports sysprep" __FUNCTION__ vm_uuid
+      | _ ->
+          failwith_fmt "VM %s does not support sysprep" vm_uuid
+  ) ;
   let iso, label = make_iso ~vm_uuid ~unattend in
   debug "%s: created ISO %s" __FUNCTION__ iso ;
   let _sr = update_sr ~__context in
   let vbd = find_cdr_vbd ~__context ~vm in
   let vdi = find_vdi ~__context ~label in
-  debug "%s: inserting Sysppep VDI for VM %s" __FUNCTION__ vm_uuid ;
+  debug "%s: inserting Sysprep VDI for VM %s" __FUNCTION__ vm_uuid ;
   Xapi_vbd.insert ~__context ~vdi ~vbd ;
   Thread.delay 5.0 ;
-  trigger ~domid
+  match trigger ~domid with
+  | "running" ->
+      debug "%s: sysprep running, ejecting CD" __FUNCTION__ ;
+      Xapi_vbd.eject ~__context ~vbd ;
+      Sys.remove iso ;
+      Result.ok ()
+  | status ->
+      debug "%s: sysprep %S, ejecting CD" __FUNCTION__ status ;
+      Xapi_vbd.eject ~__context ~vbd ;
+      Sys.remove iso ;
+      Result.error status

--- a/ocaml/xapi/vm_sysprep.mli
+++ b/ocaml/xapi/vm_sysprep.mli
@@ -1,0 +1,15 @@
+(*
+ * Copyright (c) Cloud Software Group, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val sysprep : __context:Context.t -> vm:API.ref_VM -> unattend:string -> unit

--- a/ocaml/xapi/vm_sysprep.mli
+++ b/ocaml/xapi/vm_sysprep.mli
@@ -12,14 +12,12 @@
  * GNU Lesser General Public License for more details.
  *)
 
+exception Failure of string
+
 val on_startup : __context:Context.t -> unit
 (** clean up on toolstart start up *)
 
-val sysprep :
-     __context:Context.t
-  -> vm:API.ref_VM
-  -> unattend:string
-  -> (unit, string) Result.t
+val sysprep : __context:Context.t -> vm:API.ref_VM -> unattend:string -> unit
 (** Execute sysprep on [vm] using script [unattend]. This requires
     driver support from the VM and is checked. [unattend:string] must
-    not exceed 32kb. *)
+    not exceed 32kb. Raised [Failure] that must be handled, *)

--- a/ocaml/xapi/vm_sysprep.mli
+++ b/ocaml/xapi/vm_sysprep.mli
@@ -12,4 +12,14 @@
  * GNU Lesser General Public License for more details.
  *)
 
-val sysprep : __context:Context.t -> vm:API.ref_VM -> unattend:string -> unit
+val on_startup : __context:Context.t -> unit
+(** clean up on toolstart start up *)
+
+val sysprep :
+     __context:Context.t
+  -> vm:API.ref_VM
+  -> unattend:string
+  -> (unit, string) Result.t
+(** Execute sysprep on [vm] using script [unattend]. This requires
+    driver support from the VM and is checked. [unattend:string] must
+    not exceed 32kb. *)

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -1170,6 +1170,10 @@ let server_init () =
             , [Startup.OnThread]
             , Remote_requests.handle_requests
             )
+          ; ( "Remove local ISO SR"
+            , [Startup.OnThread]
+            , fun () -> Vm_sysprep.on_startup ~__context
+            )
           ] ;
         ( match Pool_role.get_role () with
         | Pool_role.Master ->

--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -1091,6 +1091,9 @@ let reuse_pool_sessions = ref false
 let validate_reusable_pool_session = ref false
 (* Validate a reusable session before each use. This is slower and should not be required *)
 
+let vm_sysprep_enabled = ref false
+(* enable VM.sysprep API *)
+
 let test_open = ref 0
 
 let xapi_requests_cgroup =
@@ -1752,6 +1755,11 @@ let other_options =
     , Arg.Set validate_reusable_pool_session
     , (fun () -> string_of_bool !validate_reusable_pool_session)
     , "Enable validation of reusable pool sessions before use"
+    )
+  ; ( "vm-sysprep-enabled"
+    , Arg.Set vm_sysprep_enabled
+    , (fun () -> string_of_bool !vm_sysprep_enabled)
+    , "Enable VM.sysprep API"
     )
   ]
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1701,3 +1701,6 @@ let get_secureboot_readiness ~__context ~self =
           )
       )
     )
+
+let sysprep ~__context ~self ~unattend =
+  Vm_sysprep.sysprep ~__context ~vm:self ~unattend

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1703,4 +1703,15 @@ let get_secureboot_readiness ~__context ~self =
     )
 
 let sysprep ~__context ~self ~unattend =
-  Vm_sysprep.sysprep ~__context ~vm:self ~unattend
+  match Vm_sysprep.sysprep ~__context ~vm:self ~unattend with
+  | Ok _ ->
+      ()
+  | Error msg ->
+      let uuid = Db.VM.get_uuid ~__context ~self in
+      raise
+        Api_errors.(
+          Server_error (sysprep, [uuid; "Sysprep not found running: " ^ msg])
+        )
+  | exception Failure msg ->
+      let uuid = Db.VM.get_uuid ~__context ~self in
+      raise Api_errors.(Server_error (sysprep, [uuid; msg]))

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1703,15 +1703,16 @@ let get_secureboot_readiness ~__context ~self =
     )
 
 let sysprep ~__context ~self ~unattend =
+  let uuid = Db.VM.get_uuid ~__context ~self in
+  debug "%s %S (1/2)" __FUNCTION__ uuid ;
   match Vm_sysprep.sysprep ~__context ~vm:self ~unattend with
-  | Ok _ ->
+  | () ->
+      debug "%s %S (2/2)" __FUNCTION__ uuid ;
       ()
-  | Error msg ->
-      let uuid = Db.VM.get_uuid ~__context ~self in
-      raise
-        Api_errors.(
-          Server_error (sysprep, [uuid; "Sysprep not found running: " ^ msg])
-        )
-  | exception Failure msg ->
-      let uuid = Db.VM.get_uuid ~__context ~self in
+  | exception Vm_sysprep.Failure msg ->
+      debug "%s %S (2/2)" __FUNCTION__ uuid ;
+      raise Api_errors.(Server_error (sysprep, [uuid; msg]))
+  | exception e ->
+      debug "%s %S (2/2)" __FUNCTION__ uuid ;
+      let msg = Printexc.to_string e in
       raise Api_errors.(Server_error (sysprep, [uuid; msg]))

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -450,3 +450,5 @@ val add_to_blocked_operations :
 
 val remove_from_blocked_operations :
   __context:Context.t -> self:API.ref_VM -> key:API.vm_operations -> unit
+
+val sysprep : __context:Context.t -> self:API.ref_VM -> unattend:string -> unit

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -61,6 +61,7 @@ let allowed_power_states ~__context ~vmr ~(op : API.vm_operations) =
   | `send_sysrq
   | `send_trigger
   | `snapshot_with_quiesce
+  | `sysprep
   | `suspend ->
       [`Running]
   | `changing_dynamic_range ->


### PR DESCRIPTION
A new API call that works in collaboration with a guest agent on a Windows VM to pass a `unattend.xml` to Windows sysprep.

* Receives the XML content as a parameter. The XE interface supports defining this from a file but an API client has to pass the content as a parameter.
* The API call creates a local ISO SR; creates an ISO with `unattended.xml` and inserts the ISO into the VMs CD-ROM, then notifies the WM via xenstore.
* Outside of scaffolding for the API, everything in `vm_sysprep.ml`.
* Exceptions raised are handled in `Xapi_vm.sysprep()`