### PR TITLE
CP-308201: make unimplemented function more obvious

### DIFF
--- a/ocaml/xapi-idl/lib/observer_skeleton.ml
+++ b/ocaml/xapi-idl/lib/observer_skeleton.ml
@@ -13,36 +13,36 @@
  *)
 [@@@ocaml.warning "-27"]
 
-let u x = raise Observer_helpers.(Observer_error (Errors.Unimplemented x))
+let unimplemented x =
+  raise Observer_helpers.(Observer_error (Errors.Unimplemented x))
 
 module Observer = struct
   type context = unit
 
   let create ctx ~dbg ~uuid ~name_label ~attributes ~endpoints ~enabled =
-    u "Observer.create"
+    unimplemented __FUNCTION__
 
-  let destroy ctx ~dbg ~uuid = u "Observer.destroy"
+  let destroy ctx ~dbg ~uuid = unimplemented __FUNCTION__
 
-  let set_enabled ctx ~dbg ~uuid ~enabled = u "Observer.set_enabled"
+  let set_enabled ctx ~dbg ~uuid ~enabled = unimplemented __FUNCTION__
 
-  let set_attributes ctx ~dbg ~uuid ~attributes = u "Observer.set_attributes"
+  let set_attributes ctx ~dbg ~uuid ~attributes = unimplemented __FUNCTION__
 
-  let set_endpoints ctx ~dbg ~uuid ~endpoints = u "Observer.set_endpoints"
+  let set_endpoints ctx ~dbg ~uuid ~endpoints = unimplemented __FUNCTION__
 
-  let init ctx ~dbg = u "Observer.init"
+  let init ctx ~dbg = unimplemented __FUNCTION__
 
-  let set_trace_log_dir ctx ~dbg ~dir = u "Observer.set_trace_log_dir"
+  let set_trace_log_dir ctx ~dbg ~dir = unimplemented __FUNCTION__
 
-  let set_export_interval ctx ~dbg ~interval = u "Observer.set_export_interval"
+  let set_export_interval ctx ~dbg ~interval = unimplemented __FUNCTION__
 
-  let set_max_spans ctx ~dbg ~spans = u "Observer.set_max_spans"
+  let set_max_spans ctx ~dbg ~spans = unimplemented __FUNCTION__
 
-  let set_max_traces ctx ~dbg ~traces = u "Observer.set_max_traces"
+  let set_max_traces ctx ~dbg ~traces = unimplemented __FUNCTION__
 
-  let set_max_file_size ctx ~dbg ~file_size = u "Observer.set_max_file_size"
+  let set_max_file_size ctx ~dbg ~file_size = unimplemented __FUNCTION__
 
-  let set_host_id ctx ~dbg ~host_id = u "Observer.set_host_id"
+  let set_host_id ctx ~dbg ~host_id = unimplemented __FUNCTION__
 
-  let set_compress_tracing_files ctx ~dbg ~enabled =
-    u "Observer.set_compress_tracing_files"
+  let set_compress_tracing_files ctx ~dbg ~enabled = unimplemented __FUNCTION__
 end

--- a/ocaml/xapi-idl/storage/storage_interface.ml
+++ b/ocaml/xapi-idl/storage/storage_interface.ml
@@ -425,6 +425,8 @@ end
 
 exception Storage_error of Errors.error
 
+let unimplemented x = raise (Storage_error (Errors.Unimplemented x))
+
 let () =
   (* register printer *)
   let sprintf = Printf.sprintf in

--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
+++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
@@ -13,8 +13,6 @@
  *)
 [@@@ocaml.warning "-27"]
 
-let u x = raise Storage_interface.(Storage_error (Errors.Unimplemented x))
-
 type context = unit
 
 module UPDATES = struct
@@ -27,193 +25,231 @@ module UPDATES = struct
 end
 
 module Query = struct
-  let query ctx ~dbg = u "Query.query"
+  let query ctx ~dbg = Storage_interface.unimplemented __FUNCTION__
 
-  let diagnostics ctx ~dbg = u "Query.diagnostics"
+  let diagnostics ctx ~dbg = Storage_interface.unimplemented __FUNCTION__
 end
 
 module DP = struct
-  let create ctx ~dbg ~id = u "DP.create"
+  let create ctx ~dbg ~id = Storage_interface.unimplemented __FUNCTION__
 
-  let destroy ctx ~dbg ~dp ~allow_leak = u "DP.destroy"
+  let destroy ctx ~dbg ~dp ~allow_leak =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let destroy2 ctx ~dbg ~dp ~sr ~vdi ~vm ~allow_leak = u "DP.destroy2"
+  let destroy2 ctx ~dbg ~dp ~sr ~vdi ~vm ~allow_leak =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let attach_info ctx ~dbg ~sr ~vdi ~dp ~vm = u "DP.attach_info"
+  let attach_info ctx ~dbg ~sr ~vdi ~dp ~vm =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let diagnostics ctx () = u "DP.diagnostics"
+  let diagnostics ctx () = Storage_interface.unimplemented __FUNCTION__
 
-  let stat_vdi ctx ~dbg ~sr ~vdi () = u "DP.stat_vdi"
+  let stat_vdi ctx ~dbg ~sr ~vdi () =
+    Storage_interface.unimplemented __FUNCTION__
 end
 
 module SR = struct
   let create ctx ~dbg ~sr ~name_label ~name_description ~device_config
       ~physical_size =
-    u "SR.create"
+    Storage_interface.unimplemented __FUNCTION__
 
-  let attach ctx ~dbg ~sr ~device_config = u "SR.attach"
+  let attach ctx ~dbg ~sr ~device_config =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let set_name_label ctx ~dbg ~sr ~new_name_label = u "SR.set_name_label"
+  let set_name_label ctx ~dbg ~sr ~new_name_label =
+    Storage_interface.unimplemented __FUNCTION__
 
   let set_name_description ctx ~dbg ~sr ~new_name_description =
-    u "SR.set_name_description"
+    Storage_interface.unimplemented __FUNCTION__
 
-  let detach ctx ~dbg ~sr = u "SR.detach"
+  let detach ctx ~dbg ~sr = Storage_interface.unimplemented __FUNCTION__
 
-  let reset ctx ~dbg ~sr = u "SR.reset"
+  let reset ctx ~dbg ~sr = Storage_interface.unimplemented __FUNCTION__
 
-  let destroy ctx ~dbg ~sr = u "SR.destroy"
+  let destroy ctx ~dbg ~sr = Storage_interface.unimplemented __FUNCTION__
 
-  let probe ctx ~dbg ~queue ~device_config ~sm_config = u "SR.probe"
+  let probe ctx ~dbg ~queue ~device_config ~sm_config =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let scan ctx ~dbg ~sr = u "SR.scan"
+  let scan ctx ~dbg ~sr = Storage_interface.unimplemented __FUNCTION__
 
-  let scan2 ctx ~dbg ~sr = u "SR.scan2"
+  let scan2 ctx ~dbg ~sr = Storage_interface.unimplemented __FUNCTION__
 
   let update_snapshot_info_src ctx ~dbg ~sr ~vdi ~url ~dest ~dest_vdi
       ~snapshot_pairs =
-    u "SR.update_snapshot_info_src"
+    Storage_interface.unimplemented __FUNCTION__
 
   let update_snapshot_info_dest ctx ~dbg ~sr ~vdi ~src_vdi ~snapshot_pairs =
-    u "SR.update_snapshot_info_dest"
+    Storage_interface.unimplemented __FUNCTION__
 
-  let stat ctx ~dbg ~sr = u "SR.stat"
+  let stat ctx ~dbg ~sr = Storage_interface.unimplemented __FUNCTION__
 
-  let list ctx ~dbg = u "SR.list"
+  let list ctx ~dbg = Storage_interface.unimplemented __FUNCTION__
 end
 
 module VDI = struct
-  let create ctx ~dbg ~sr ~vdi_info = u "VDI.create"
+  let create ctx ~dbg ~sr ~vdi_info =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let set_name_label ctx ~dbg ~sr ~vdi ~new_name_label = u "VDI.set_name_label"
+  let set_name_label ctx ~dbg ~sr ~vdi ~new_name_label =
+    Storage_interface.unimplemented __FUNCTION__
 
   let set_name_description ctx ~dbg ~sr ~vdi ~new_name_description =
-    u "VDI.set_name_description"
+    Storage_interface.unimplemented __FUNCTION__
 
-  let snapshot ctx ~dbg ~sr ~vdi_info = u "VDI.snapshot"
+  let snapshot ctx ~dbg ~sr ~vdi_info =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let clone ctx ~dbg ~sr ~vdi_info = u "VDI.clone"
+  let clone ctx ~dbg ~sr ~vdi_info =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let resize ctx ~dbg ~sr ~vdi ~new_size = u "VDI.resize"
+  let resize ctx ~dbg ~sr ~vdi ~new_size =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let destroy ctx ~dbg ~sr ~vdi = u "VDI.destroy"
+  let destroy ctx ~dbg ~sr ~vdi = Storage_interface.unimplemented __FUNCTION__
 
-  let stat ctx ~dbg ~sr ~vdi = u "VDI.stat"
+  let stat ctx ~dbg ~sr ~vdi = Storage_interface.unimplemented __FUNCTION__
 
-  let introduce ctx ~dbg ~sr ~uuid ~sm_config ~location = u "VDI.introduce"
+  let introduce ctx ~dbg ~sr ~uuid ~sm_config ~location =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let set_persistent ctx ~dbg ~sr ~vdi ~persistent = u "VDI.set_persistent"
+  let set_persistent ctx ~dbg ~sr ~vdi ~persistent =
+    Storage_interface.unimplemented __FUNCTION__
 
   let epoch_begin ctx ~dbg ~sr ~vdi ~vm ~persistent = ()
 
-  let attach ctx ~dbg ~dp ~sr ~vdi ~read_write = u "VDI.attach"
+  let attach ctx ~dbg ~dp ~sr ~vdi ~read_write =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let attach2 ctx ~dbg ~dp ~sr ~vdi ~read_write = u "VDI.attach2"
+  let attach2 ctx ~dbg ~dp ~sr ~vdi ~read_write =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let attach3 ctx ~dbg ~dp ~sr ~vdi ~vm ~read_write = u "VDI.attach3"
+  let attach3 ctx ~dbg ~dp ~sr ~vdi ~vm ~read_write =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let activate ctx ~dbg ~dp ~sr ~vdi = u "VDI.activate"
+  let activate ctx ~dbg ~dp ~sr ~vdi =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let activate3 ctx ~dbg ~dp ~sr ~vdi ~vm = u "VDI.activate3"
+  let activate3 ctx ~dbg ~dp ~sr ~vdi ~vm =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let activate_readonly ctx ~dbg ~dp ~sr ~vdi ~vm = u "VDI.activate_readonly"
+  let activate_readonly ctx ~dbg ~dp ~sr ~vdi ~vm =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let deactivate ctx ~dbg ~dp ~sr ~vdi ~vm = u "VDI.deactivate"
+  let deactivate ctx ~dbg ~dp ~sr ~vdi ~vm =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let detach ctx ~dbg ~dp ~sr ~vdi ~vm = u "VDI.detach"
+  let detach ctx ~dbg ~dp ~sr ~vdi ~vm =
+    Storage_interface.unimplemented __FUNCTION__
 
   let epoch_end ctx ~dbg ~sr ~vdi ~vm = ()
 
-  let get_url ctx ~dbg ~sr ~vdi = u "VDI.get_url"
+  let get_url ctx ~dbg ~sr ~vdi = Storage_interface.unimplemented __FUNCTION__
 
-  let similar_content ctx ~dbg ~sr ~vdi = u "VDI.similar_content"
+  let similar_content ctx ~dbg ~sr ~vdi =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let get_by_name ctx ~dbg ~sr ~name = u "VDI.get_by_name"
+  let get_by_name ctx ~dbg ~sr ~name =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let set_content_id ctx ~dbg ~sr ~vdi ~content_id = u "VDI.set_content_id"
+  let set_content_id ctx ~dbg ~sr ~vdi ~content_id =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let compose ctx ~dbg ~sr ~vdi1 ~vdi2 = u "VDI.compose"
+  let compose ctx ~dbg ~sr ~vdi1 ~vdi2 =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let add_to_sm_config ctx ~dbg ~sr ~vdi ~key ~value = u "VDI.add_to_sm_config"
+  let add_to_sm_config ctx ~dbg ~sr ~vdi ~key ~value =
+    Storage_interface.unimplemented __FUNCTION__
 
   let remove_from_sm_config ctx ~dbg ~sr ~vdi ~key =
-    u "VDI.remove_from_sm_config"
+    Storage_interface.unimplemented __FUNCTION__
 
-  let enable_cbt ctx ~dbg ~sr ~vdi = u "VDI.enable_cbt"
+  let enable_cbt ctx ~dbg ~sr ~vdi =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let disable_cbt ctx ~dbg ~sr ~vdi = u "VDI.disable_cbt"
+  let disable_cbt ctx ~dbg ~sr ~vdi =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let data_destroy ctx ~dbg ~sr ~vdi = u "VDI.data_destroy"
+  let data_destroy ctx ~dbg ~sr ~vdi =
+    Storage_interface.unimplemented __FUNCTION__
 
   let list_changed_blocks ctx ~dbg ~sr ~vdi_from ~vdi_to =
-    u "VDI.list_changed_blocks"
+    Storage_interface.unimplemented __FUNCTION__
 end
 
-let get_by_name ctx ~dbg ~name = u "get_by_name"
+let get_by_name ctx ~dbg ~name = Storage_interface.unimplemented __FUNCTION__
 
 module DATA = struct
-  let copy ctx ~dbg ~sr ~vdi ~vm ~url ~dest = u "DATA.copy"
+  let copy ctx ~dbg ~sr ~vdi ~vm ~url ~dest =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let mirror ctx ~dbg ~sr ~vdi ~vm ~dest = u "DATA.mirror"
+  let mirror ctx ~dbg ~sr ~vdi ~vm ~dest =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let stat ctx ~dbg ~sr ~vdi ~vm ~key = u "DATA.stat"
+  let stat ctx ~dbg ~sr ~vdi ~vm ~key =
+    Storage_interface.unimplemented __FUNCTION__
 
   let import_activate ctx ~dbg ~dp ~sr ~vdi ~vm =
-    u "DATA.MIRROR.import_activate"
+    Storage_interface.unimplemented __FUNCTION__
 
-  let get_nbd_server ctx ~dbg ~dp ~sr ~vdi ~vm = u "DATA.MIRROR.get_nbd_server"
+  let get_nbd_server ctx ~dbg ~dp ~sr ~vdi ~vm =
+    Storage_interface.unimplemented __FUNCTION__
 
   module MIRROR = struct
     type context = unit
 
     let send_start ctx ~dbg ~task_id ~dp ~sr ~vdi ~mirror_vm ~mirror_id
         ~local_vdi ~copy_vm ~live_vm ~url ~remote_mirror ~dest_sr ~verify_dest =
-      u "DATA.MIRROR.send_start"
+      Storage_interface.unimplemented __FUNCTION__
 
     let receive_start ctx ~dbg ~sr ~vdi_info ~id ~similar =
-      u "DATA.MIRROR.receive_start"
+      Storage_interface.unimplemented __FUNCTION__
 
     let receive_start2 ctx ~dbg ~sr ~vdi_info ~id ~similar ~vm =
-      u "DATA.MIRROR.receive_start2"
+      Storage_interface.unimplemented __FUNCTION__
 
     let receive_start3 ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar ~vm ~url
         ~verify_dest =
-      u "DATA.MIRROR.receive_start3"
+      Storage_interface.unimplemented __FUNCTION__
 
-    let receive_finalize ctx ~dbg ~id = u "DATA.MIRROR.receive_finalize"
+    let receive_finalize ctx ~dbg ~id =
+      Storage_interface.unimplemented __FUNCTION__
 
-    let receive_finalize2 ctx ~dbg ~id = u "DATA.MIRROR.receive_finalize2"
+    let receive_finalize2 ctx ~dbg ~id =
+      Storage_interface.unimplemented __FUNCTION__
 
     let receive_finalize3 ctx ~dbg ~mirror_id ~sr ~url ~verify_dest =
-      u "DATA.MIRROR.receive_finalize3"
+      Storage_interface.unimplemented __FUNCTION__
 
-    let receive_cancel ctx ~dbg ~id = u "DATA.MIRROR.receive_cancel"
+    let receive_cancel ctx ~dbg ~id =
+      Storage_interface.unimplemented __FUNCTION__
 
     let receive_cancel2 ctx ~dbg ~mirror_id ~url ~verify_dest =
-      u "DATA.MIRROR.receive_cancel2"
+      Storage_interface.unimplemented __FUNCTION__
 
     let pre_deactivate_hook ctx ~dbg ~dp ~sr ~vdi =
-      u "DATA.MIRROR.pre_deactivate_hook"
+      Storage_interface.unimplemented __FUNCTION__
 
     let has_mirror_failed ctx ~dbg ~mirror_id ~sr =
-      u "DATA.MIRROR.has_mirror_failed"
+      Storage_interface.unimplemented __FUNCTION__
 
-    let list ctx ~dbg = u "DATA.MIRROR.list"
+    let list ctx ~dbg = Storage_interface.unimplemented __FUNCTION__
 
-    let stat ctx ~dbg ~id = u "DATA.MIRROR.stat"
+    let stat ctx ~dbg ~id = Storage_interface.unimplemented __FUNCTION__
   end
 end
 
 module Policy = struct
-  let get_backend_vm ctx ~dbg ~vm ~sr ~vdi = u "Policy.get_backend_vm"
+  let get_backend_vm ctx ~dbg ~vm ~sr ~vdi =
+    Storage_interface.unimplemented __FUNCTION__
 end
 
 module TASK = struct
-  let stat ctx ~dbg ~task = u "TASK.stat"
+  let stat ctx ~dbg ~task = Storage_interface.unimplemented __FUNCTION__
 
-  let cancel ctx ~dbg ~task = u "TASK.cancel"
+  let cancel ctx ~dbg ~task = Storage_interface.unimplemented __FUNCTION__
 
-  let destroy ctx ~dbg ~task = u "TASK.destroy"
+  let destroy ctx ~dbg ~task = Storage_interface.unimplemented __FUNCTION__
 
-  let list ctx ~dbg = u "TASK.list"
+  let list ctx ~dbg = Storage_interface.unimplemented __FUNCTION__
 end

--- a/ocaml/xapi/storage_mux.ml
+++ b/ocaml/xapi/storage_mux.ml
@@ -844,12 +844,11 @@ module Mux = struct
     module MIRROR = struct
       type context = unit
 
-      let u x = raise Storage_interface.(Storage_error (Errors.Unimplemented x))
-
       let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~mirror_vm:_
           ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
           ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
-        u "DATA.MIRROR.send_start" (* see storage_smapi{v1,v3}_migrate.ml *)
+        Storage_interface.unimplemented
+          __FUNCTION__ (* see storage_smapi{v1,v3}_migrate.ml *)
 
       let receive_start () ~dbg ~sr ~vdi_info ~id ~similar =
         with_dbg ~name:"DATA.MIRROR.receive_start" ~dbg @@ fun _di ->
@@ -880,7 +879,7 @@ module Mux = struct
       (** see storage_smapiv{1,3}_migrate.receive_start3 *)
       let receive_start3 () ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_ ~similar:_
           ~vm:_ =
-        u __FUNCTION__
+        Storage_interface.unimplemented __FUNCTION__
 
       let receive_finalize () ~dbg ~id =
         with_dbg ~name:"DATA.MIRROR.receive_finalize" ~dbg @@ fun di ->
@@ -893,7 +892,7 @@ module Mux = struct
         Storage_smapiv1_migrate.MIRROR.receive_finalize2 () ~dbg:di.log ~id
 
       let receive_finalize3 () ~dbg:_ ~mirror_id:_ ~sr:_ ~url:_ ~verify_dest:_ =
-        u __FUNCTION__
+        Storage_interface.unimplemented __FUNCTION__
 
       let receive_cancel () ~dbg ~id =
         with_dbg ~name:"DATA.MIRROR.receive_cancel" ~dbg @@ fun di ->
@@ -901,13 +900,13 @@ module Mux = struct
         Storage_smapiv1_migrate.MIRROR.receive_cancel () ~dbg:di.log ~id
 
       let receive_cancel2 () ~dbg:_ ~mirror_id:_ ~url:_ ~verify_dest:_ =
-        u __FUNCTION__
+        Storage_interface.unimplemented __FUNCTION__
 
       let pre_deactivate_hook _ctx ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ =
-        u "DATA.MIRROR.pre_deactivate_hook"
+        Storage_interface.unimplemented __FUNCTION__
 
       let has_mirror_failed _ctx ~dbg:_ ~mirror_id:_ ~sr:_ =
-        u "DATA.MIRROR.has_mirror_failed"
+        Storage_interface.unimplemented __FUNCTION__
 
       let list () ~dbg =
         with_dbg ~name:"DATA.MIRROR.list" ~dbg @@ fun di ->

--- a/ocaml/xapi/storage_smapiv1_migrate.ml
+++ b/ocaml/xapi/storage_smapiv1_migrate.ml
@@ -567,8 +567,6 @@ let mirror_cleanup ~dbg ~sr ~snapshot =
 module MIRROR : SMAPIv2_MIRROR = struct
   type context = unit
 
-  let u x = raise Storage_interface.(Storage_error (Errors.Unimplemented x))
-
   let send_start _ctx ~dbg ~task_id ~dp ~sr ~vdi ~mirror_vm ~mirror_id
       ~local_vdi ~copy_vm ~live_vm ~url ~remote_mirror ~dest_sr ~verify_dest =
     D.debug
@@ -878,9 +876,9 @@ module MIRROR : SMAPIv2_MIRROR = struct
     | _ ->
         false
 
-  let list _ctx = u __FUNCTION__
+  let list _ctx = Storage_interface.unimplemented __FUNCTION__
 
-  let stat _ctx = u __FUNCTION__
+  let stat _ctx = Storage_interface.unimplemented __FUNCTION__
 
   let receive_cancel2 _ctx ~dbg ~mirror_id ~url ~verify_dest =
     let (module Remote) =

--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
+++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
@@ -1137,16 +1137,16 @@ functor
     end
 
     module DATA = struct
-      let u x = raise Storage_interface.(Storage_error (Errors.Unimplemented x))
-
       let copy context ~dbg ~sr ~vdi ~vm ~url ~dest =
         info "DATA.copy dbg:%s sr:%s vdi:%s url:%s dest:%s" dbg (s_of_sr sr)
           (s_of_vdi vdi) url (s_of_sr dest) ;
         Impl.DATA.copy context ~dbg ~sr ~vdi ~vm ~url ~dest
 
-      let mirror _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~dest:_ = u "DATA.mirror"
+      let mirror _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~dest:_ =
+        Storage_interface.unimplemented __FUNCTION__
 
-      let stat _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~key:_ = u "DATA.stat"
+      let stat _context ~dbg:_ ~sr:_ ~vdi:_ ~vm:_ ~key:_ =
+        Storage_interface.unimplemented __FUNCTION__
 
       (* tapdisk supports three kind of nbd servers, the old style nbdserver,
          the new style nbd server and a real nbd server. The old and new style nbd servers
@@ -1195,7 +1195,7 @@ functor
         let send_start _ctx ~dbg:_ ~task_id:_ ~dp:_ ~sr:_ ~vdi:_ ~mirror_vm:_
             ~mirror_id:_ ~local_vdi:_ ~copy_vm:_ ~live_vm:_ ~url:_
             ~remote_mirror:_ ~dest_sr:_ ~verify_dest:_ =
-          u "DATA.MIRROR.send_start"
+          Storage_interface.unimplemented __FUNCTION__
 
         let receive_start context ~dbg ~sr ~vdi_info ~id ~similar =
           info "DATA.MIRROR.receive_start dbg:%s sr:%s id:%s similar:[%s]" dbg
@@ -1215,7 +1215,7 @@ functor
         let receive_start3 _context ~dbg:_ ~sr:_ ~vdi_info:_ ~mirror_id:_
             ~similar:_ ~vm:_ =
           (* See Storage_smapiv1_migrate.receive_start3 *)
-          u __FUNCTION__
+          Storage_interface.unimplemented __FUNCTION__
 
         let receive_finalize context ~dbg ~id =
           info "DATA.MIRROR.receive_finalize dbg:%s id:%s" dbg id ;
@@ -1228,24 +1228,25 @@ functor
         let receive_finalize3 _context ~dbg:_ ~mirror_id:_ ~sr:_ ~url:_
             ~verify_dest:_ =
           (* see storage_smapiv{1,3}_migrate *)
-          u __FUNCTION__
+          Storage_interface.unimplemented __FUNCTION__
 
         let receive_cancel context ~dbg ~id =
           info "DATA.MIRROR.receive_cancel dbg:%s id:%s" dbg id ;
           Impl.DATA.MIRROR.receive_cancel context ~dbg ~id
 
         let receive_cancel2 _context ~dbg:_ ~mirror_id:_ ~url:_ ~verify_dest:_ =
-          u __FUNCTION__
+          Storage_interface.unimplemented __FUNCTION__
 
         let pre_deactivate_hook _context ~dbg:_ ~dp:_ ~sr:_ ~vdi:_ =
-          u __FUNCTION__
+          Storage_interface.unimplemented __FUNCTION__
 
         let has_mirror_failed _context ~dbg:_ ~mirror_id:_ ~sr:_ =
-          u __FUNCTION__
+          Storage_interface.unimplemented __FUNCTION__
 
-        let list _context ~dbg:_ = u __FUNCTION__
+        let list _context ~dbg:_ = Storage_interface.unimplemented __FUNCTION__
 
-        let stat _context ~dbg:_ ~id:_ = u __FUNCTION__
+        let stat _context ~dbg:_ ~id:_ =
+          Storage_interface.unimplemented __FUNCTION__
       end
     end
 

--- a/ocaml/xapi/storage_smapiv3_migrate.ml
+++ b/ocaml/xapi/storage_smapiv3_migrate.ml
@@ -108,8 +108,6 @@ let mirror_wait ~dbg ~sr ~vdi ~vm ~mirror_id mirror_key =
 module MIRROR : SMAPIv2_MIRROR = struct
   type context = unit
 
-  let u x = raise Storage_interface.(Storage_error (Errors.Unimplemented x))
-
   let send_start _ctx ~dbg ~task_id:_ ~dp ~sr ~vdi ~mirror_vm ~mirror_id
       ~local_vdi:_ ~copy_vm:_ ~live_vm ~url ~remote_mirror ~dest_sr ~verify_dest
       =
@@ -187,10 +185,10 @@ module MIRROR : SMAPIv2_MIRROR = struct
     )
 
   let receive_start _ctx ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ =
-    u "DATA.MIRROR.receive_start"
+    Storage_interface.unimplemented __FUNCTION__
 
   let receive_start2 _ctx ~dbg:_ ~sr:_ ~vdi_info:_ ~id:_ ~similar:_ ~vm:_ =
-    u "DATA.MIRROR.receive_start2"
+    Storage_interface.unimplemented __FUNCTION__
 
   let receive_start3 _ctx ~dbg ~sr ~vdi_info ~mirror_id ~similar:_ ~vm ~url
       ~verify_dest =
@@ -269,9 +267,11 @@ module MIRROR : SMAPIv2_MIRROR = struct
         !on_fail ;
       raise e
 
-  let receive_finalize _ctx ~dbg:_ ~id:_ = u "DATA.MIRROR.receive_finalize"
+  let receive_finalize _ctx ~dbg:_ ~id:_ =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let receive_finalize2 _ctx ~dbg:_ ~id:_ = u "DATA.MIRROR.receive_finalize2"
+  let receive_finalize2 _ctx ~dbg:_ ~id:_ =
+    Storage_interface.unimplemented __FUNCTION__
 
   let receive_finalize3 _ctx ~dbg ~mirror_id ~sr ~url ~verify_dest =
     D.debug "%s dbg:%s id: %s sr: %s url: %s verify_dest: %B" __FUNCTION__ dbg
@@ -289,11 +289,12 @@ module MIRROR : SMAPIv2_MIRROR = struct
       recv_state ;
     State.remove_receive_mirror mirror_id
 
-  let receive_cancel _ctx ~dbg:_ ~id:_ = u __FUNCTION__
+  let receive_cancel _ctx ~dbg:_ ~id:_ =
+    Storage_interface.unimplemented __FUNCTION__
 
-  let list _ctx = u __FUNCTION__
+  let list _ctx = Storage_interface.unimplemented __FUNCTION__
 
-  let stat _ctx = u __FUNCTION__
+  let stat _ctx = Storage_interface.unimplemented __FUNCTION__
 
   let receive_cancel2 _ctx ~dbg ~mirror_id ~url ~verify_dest =
     D.debug "%s dbg:%s mirror_id:%s url:%s verify_dest:%B" __FUNCTION__ dbg

--- a/ocaml/xenopsd/lib/xenops_server_skeleton.ml
+++ b/ocaml/xenopsd/lib/xenops_server_skeleton.ml
@@ -64,50 +64,49 @@ module VM = struct
 
   let remove _ = ()
 
-  let create _ _ _ _ = unimplemented "VM.create"
+  let create _ _ _ _ = unimplemented __FUNCTION__
 
-  let build ?restore_fd:_ _ _ _ _ _ = unimplemented "VM.build"
+  let build ?restore_fd:_ _ _ _ _ _ = unimplemented __FUNCTION__
 
-  let create_device_model _ _ _ _ _ = unimplemented "VM.create_device_model"
+  let create_device_model _ _ _ _ _ = unimplemented __FUNCTION__
 
-  let destroy_device_model _ _ = unimplemented "VM.destroy_device_model"
+  let destroy_device_model _ _ = unimplemented __FUNCTION__
 
-  let destroy _ _ = unimplemented "VM.destroy"
+  let destroy _ _ = unimplemented __FUNCTION__
 
-  let pause _ _ = unimplemented "VM.pause"
+  let pause _ _ = unimplemented __FUNCTION__
 
-  let unpause _ _ = unimplemented "VM.unpause"
+  let unpause _ _ = unimplemented __FUNCTION__
 
-  let set_xsdata _ _ _ = unimplemented "VM.set_xsdata"
+  let set_xsdata _ _ _ = unimplemented __FUNCTION__
 
-  let set_vcpus _ _ _ = unimplemented "VM.set_vcpus"
+  let set_vcpus _ _ _ = unimplemented __FUNCTION__
 
-  let set_shadow_multiplier _ _ _ = unimplemented "VM.set_shadow_multipler"
+  let set_shadow_multiplier _ _ _ = unimplemented __FUNCTION__
 
-  let set_memory_dynamic_range _ _ _ _ =
-    unimplemented "VM.set_memory_dynamic_range"
+  let set_memory_dynamic_range _ _ _ _ = unimplemented __FUNCTION__
 
-  let request_shutdown _ _ _ _ = unimplemented "VM.request_shutdown"
+  let request_shutdown _ _ _ _ = unimplemented __FUNCTION__
 
-  let wait_shutdown _ _ _ _ = unimplemented "VM.wait_shutdown"
+  let wait_shutdown _ _ _ _ = unimplemented __FUNCTION__
 
-  let assert_can_save _ = unimplemented "VM.assert_can_save"
+  let assert_can_save _ = unimplemented __FUNCTION__
 
-  let save _ _ _ _ _ _ _ = unimplemented "VM.save"
+  let save _ _ _ _ _ _ _ = unimplemented __FUNCTION__
 
-  let restore _ _ _ _ _ _ _ = unimplemented "VM.restore"
+  let restore _ _ _ _ _ _ _ = unimplemented __FUNCTION__
 
-  let s3suspend _ _ = unimplemented "VM.s3suspend"
+  let s3suspend _ _ = unimplemented __FUNCTION__
 
-  let s3resume _ _ = unimplemented "VM.s3resume"
+  let s3resume _ _ = unimplemented __FUNCTION__
 
-  let soft_reset _ _ = unimplemented "VM.soft_reset"
+  let soft_reset _ _ = unimplemented __FUNCTION__
 
   let get_state _ = Xenops_utils.halted_vm
 
-  let request_rdp _ _ = unimplemented "VM.request_rdp"
+  let request_rdp _ _ = unimplemented __FUNCTION__
 
-  let run_script _ _ _ = unimplemented "VM.run_script"
+  let run_script _ _ _ = unimplemented __FUNCTION__
 
   let set_domain_action_request _ _ = ()
 
@@ -131,9 +130,9 @@ module PCI = struct
 
   let dequarantine _ = ()
 
-  let plug _ _ _ = unimplemented "PCI.plug"
+  let plug _ _ _ = unimplemented __FUNCTION__
 
-  let unplug _ _ _ = unimplemented "PCI.unplug"
+  let unplug _ _ _ = unimplemented __FUNCTION__
 
   let get_device_action_request _ _ = None
 end
@@ -145,17 +144,17 @@ module VBD = struct
 
   let epoch_end _ _ _ = ()
 
-  let attach _ _ _ = unimplemented "VBD.attach"
+  let attach _ _ _ = unimplemented __FUNCTION__
 
-  let activate _ _ _ = unimplemented "VBD.activate"
+  let activate _ _ _ = unimplemented __FUNCTION__
 
-  let deactivate _ _ _ _ = unimplemented "VBD.deactivate"
+  let deactivate _ _ _ _ = unimplemented __FUNCTION__
 
-  let detach _ _ _ = unimplemented "VBD.detach"
+  let detach _ _ _ = unimplemented __FUNCTION__
 
-  let insert _ _ _ _ = unimplemented "VBD.insert"
+  let insert _ _ _ _ = unimplemented __FUNCTION__
 
-  let eject _ _ _ = unimplemented "VBD.eject"
+  let eject _ _ _ = unimplemented __FUNCTION__
 
   let set_qos _ _ _ = ()
 
@@ -167,23 +166,21 @@ end
 module VIF = struct
   let set_active _ _ _ _ = ()
 
-  let plug _ _ _ = unimplemented "VIF.plug"
+  let plug _ _ _ = unimplemented __FUNCTION__
 
-  let unplug _ _ _ _ = unimplemented "VIF.unplug"
+  let unplug _ _ _ _ = unimplemented __FUNCTION__
 
-  let move _ _ _ _ = unimplemented "VIF.move"
+  let move _ _ _ _ = unimplemented __FUNCTION__
 
-  let set_carrier _ _ _ _ = unimplemented "VIF.set_carrier"
+  let set_carrier _ _ _ _ = unimplemented __FUNCTION__
 
-  let set_locking_mode _ _ _ _ = unimplemented "VIF.set_locking_mode"
+  let set_locking_mode _ _ _ _ = unimplemented __FUNCTION__
 
-  let set_ipv4_configuration _ _ _ _ =
-    unimplemented "VIF.set_ipv4_configuration"
+  let set_ipv4_configuration _ _ _ _ = unimplemented __FUNCTION__
 
-  let set_ipv6_configuration _ _ _ _ =
-    unimplemented "VIF.set_ipv6_configuration"
+  let set_ipv6_configuration _ _ _ _ = unimplemented __FUNCTION__
 
-  let set_pvs_proxy _ _ _ _ = unimplemented "VIF.set_pvs_proxy"
+  let set_pvs_proxy _ _ _ _ = unimplemented __FUNCTION__
 
   let get_state _ _ = unplugged_vif
 
@@ -191,7 +188,7 @@ module VIF = struct
 end
 
 module VGPU = struct
-  let start _ _ _ _ = unimplemented "VGPU.start"
+  let start _ _ _ _ = unimplemented __FUNCTION__
 
   let set_active _ _ _ _ = ()
 
@@ -199,9 +196,9 @@ module VGPU = struct
 end
 
 module VUSB = struct
-  let plug _ _ _ = unimplemented "VUSB.plug"
+  let plug _ _ _ = unimplemented __FUNCTION__
 
-  let unplug _ _ _ = unimplemented "VUSB.unplug"
+  let unplug _ _ _ = unimplemented __FUNCTION__
 
   let get_state _ _ = unplugged_vusb
 
@@ -216,4 +213,4 @@ module UPDATES = struct
     assert false
 end
 
-module DEBUG = struct let trigger _ _ = unimplemented "DEBUG.trigger" end
+module DEBUG = struct let trigger _ _ = unimplemented __FUNCTION__ end


### PR DESCRIPTION
Rename the "u" function used across storage and observer_helpers to make its meaning more obvious and use __FUNCTION__ instead of hardcoding the function name.