### PR TITLE
CA-410965: Modify default ref of console

### DIFF
--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -307,7 +307,7 @@ and create_domain_zero_console_record_with_protocol ~__context ~domain_zero_ref
   let location =
     Uri.(
       make ~scheme:"https" ~host:address ~path:Constants.console_uri
-        ~query:[("ref", [Ref.string_of domain_zero_ref])]
+        ~query:[("ref", [Ref.string_of console_ref])]
         ()
       |> to_string
     )


### PR DESCRIPTION
The `ref` parameter within the `location` attribute of the console can refer to either the VM's ref or the console's own ref. Currently, the console's location uses the VM's ref by default.

This causes an issue: when executing xe console, the requested location contains the VM's ref. If the ref points to the VM, xapi will attempt to use the RFB console (which is graphical) by default, rather than the VT100 console (which is text-based). As a result, the xs console command fails to open the console and hangs.

**Solution:**
Update the default ref in the console's `location` to the console's own ref. With this change, whether accessing the RFB or the VT100 console, the ref in the `location` will always point to the respective console itself.