### PR TITLE
xenopsd/xc: upstream more NUMA changes

### DIFF
--- a/ocaml/xenopsd/xc/xenctrlext.ml
+++ b/ocaml/xenopsd/xc/xenctrlext.ml
@@ -128,4 +128,6 @@ end
 exception Not_available
 
 let domain_claim_pages handle domid ?(numa_node = NumaNode.none) nr_pages =
+  if numa_node <> NumaNode.none then
+    raise Not_available ;
   stub_domain_claim_pages handle domid numa_node nr_pages

--- a/ocaml/xenopsd/xc/xenctrlext.ml
+++ b/ocaml/xenopsd/xc/xenctrlext.ml
@@ -125,5 +125,7 @@ module NumaNode = struct
   let from = Fun.id
 end
 
+exception Not_available
+
 let domain_claim_pages handle domid ?(numa_node = NumaNode.none) nr_pages =
   stub_domain_claim_pages handle domid numa_node nr_pages

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -102,5 +102,9 @@ module NumaNode : sig
   val from : int -> t
 end
 
+exception Not_available
+
 val domain_claim_pages : handle -> domid -> ?numa_node:NumaNode.t -> int -> unit
-(** Raises {Unix_error} if there's not enough memory to claim in the system *)
+(** Raises {Unix_error} if there's not enough memory to claim in the system.
+    Raises {Not_available} if a single numa node is requested and xen does not
+    provide page claiming for single numa nodes. *)


### PR DESCRIPTION
These commits allow to minimize the differences between the versions that use a xen with the NUMA-enabled claim_pages, and the ones that are not.

Now it's a single patch with 4 lines of code:
- 2 lines to change the C binding for domain_claim_pages (ocaml/xenopsd/c_stubs/xenctrlext_stubs.c)
- 2 lines to remove the raising of exception to try to use the C binding with a single NUMA node (ocaml/xenopsd/xc/xenctrlext.ml)