### PR TITLE
CP-308450 Improve bridge name converting and network name_label

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -35,8 +35,7 @@ let write_config () =
     try Network_config.write_config !config
     with Network_config.Write_error -> ()
 
-let get_index_from_ethx name =
-  try Scanf.sscanf name "eth%d%!" Option.some with _ -> None
+let get_index_from_ethx = Network_config.get_index_from_ethx
 
 let sort_based_on_ethx () =
   Sysfs.list ()

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -129,11 +129,11 @@ let call_script ?(log_output = Always) ?env ?stdin ?timeout script args =
       raise e
 
 (** Construct a descriptive network name (used as name_label) for a give network interface. *)
-let choose_network_name_for_pif device pos_opt =
-  let pos_str =
-    Option.fold ~none:"" ~some:(Printf.sprintf " (slot %d)") pos_opt
-  in
-  Printf.sprintf "Pool-wide network associated with %s%s" device pos_str
+let choose_network_name_for_pif device = function
+  | Some pos ->
+      Printf.sprintf "Pool-wide network %d" pos
+  | None ->
+      Printf.sprintf "Pool-wide network associated with %s" device
 
 (* !! FIXME - trap proper MISSINGREFERENCE exception when this has been defined *)
 (* !! FIXME(2) - this code could be shared with the CLI? *)

--- a/python3/bin/xe-reset-networking
+++ b/python3/bin/xe-reset-networking
@@ -72,8 +72,9 @@ def get_bridge_name(device, vlan):
     # NOTE: Only correct when interface-rename script exists
     if vlan != None:
         return 'xentemp'
-    if device[:3] == 'eth':
-        return 'xenbr' + device[3:]
+    m = re.match(r'^eth(\d+)$', device)
+    if m:
+        return 'xenbr' + m.group(1)
     return 'br' + device
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Unify the behaviour when converting interface name to bridge name. Get a stricter check for eth<N> with sscanf or re rather than start_with "eth".
2. Construct the default name_label for new created network only with position.