### PR TITLE
idl: Remove unused `vm_lacks_feature_*` errors

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -532,26 +532,6 @@ let _ =
       "You attempted an operation on a VM which requires a more recent version \
        of the PV drivers. Please upgrade your PV drivers."
     () ;
-  error Api_errors.vm_lacks_feature_shutdown ["vm"]
-    ~doc:
-      "You attempted an operation which needs the cooperative shutdown feature \
-       on a VM which lacks it."
-    () ;
-  error Api_errors.vm_lacks_feature_vcpu_hotplug ["vm"]
-    ~doc:
-      "You attempted an operation which needs the VM hotplug-vcpu feature on a \
-       VM which lacks it."
-    () ;
-  error Api_errors.vm_lacks_feature_suspend ["vm"]
-    ~doc:
-      "You attempted an operation which needs the VM cooperative suspend \
-       feature on a VM which lacks it."
-    () ;
-  error Api_errors.vm_lacks_feature_static_ip_setting ["vm"]
-    ~doc:
-      "You attempted an operation which needs the VM static-ip-setting feature \
-       on a VM which lacks it."
-    () ;
   error Api_errors.vm_lacks_feature ["vm"]
     ~doc:"You attempted an operation on a VM which lacks the feature." () ;
   error Api_errors.vm_is_template ["vm"]

--- a/ocaml/xapi-consts/api_errors.ml
+++ b/ocaml/xapi-consts/api_errors.ml
@@ -440,15 +440,6 @@ let vm_old_pv_drivers = add_error "VM_OLD_PV_DRIVERS"
 
 let vm_lacks_feature = add_error "VM_LACKS_FEATURE"
 
-let vm_lacks_feature_shutdown = add_error "VM_LACKS_FEATURE_SHUTDOWN"
-
-let vm_lacks_feature_suspend = add_error "VM_LACKS_FEATURE_SUSPEND"
-
-let vm_lacks_feature_vcpu_hotplug = add_error "VM_LACKS_FEATURE_VCPU_HOTPLUG"
-
-let vm_lacks_feature_static_ip_setting =
-  add_error "VM_LACKS_FEATURE_STATIC_IP_SETTING"
-
 let vm_cannot_delete_default_template =
   add_error "VM_CANNOT_DELETE_DEFAULT_TEMPLATE"
 


### PR DESCRIPTION
Most of these have been unused for almost 10 years since c4ccc564e ("CA-217842: Replace instances of vm_lacks_feature_x with vm_lacks_feature")

Drop them.