### PR TITLE
Move common retry_econnrefused function to xcp_client

### DIFF
--- a/ocaml/xapi-idl/rrd/rrd_client.ml
+++ b/ocaml/xapi-idl/rrd/rrd_client.ml
@@ -13,26 +13,12 @@
  *)
 
 open Rrd_interface
-open Xcp_client
 
-let rec retry_econnrefused f =
-  try f () with
-  | Unix.Unix_error (Unix.ECONNREFUSED, "connect", _) ->
-      (* debug "Caught ECONNREFUSED; retrying in 5s"; *)
-      Thread.delay 5. ; retry_econnrefused f
-  | e ->
-      (* error "Caught %s: does the rrd service need restarting?"
-         (Printexc.to_string e); *)
-      raise e
-
+(* TODO: use_switch=false as the message switch doesn't handle raw HTTP very well *)
 let rpc call =
-  retry_econnrefused (fun () ->
-      (* TODO: the message switch doesn't handle raw HTTP very well *)
-      if (* !use_switch *) false then
-        json_switch_rpc !queue_name call
-      else
-        xml_http_rpc ~srcstr:(get_user_agent ()) ~dststr:"rrd" Rrd_interface.uri
-          call
+  Xcp_client.(
+    retry_and_switch_rpc call ~use_switch:false ~queue_name:!queue_name
+      ~dststr:"rrd" ~uri
   )
 
 module Client = RPC_API (Idl.Exn.GenClient (struct let rpc = rpc end))


### PR DESCRIPTION
As per the commit message for fbda87d (12 years ago): "[ECONNREFUSED retry logic] probably should be pushed into the generic XCP function, since the same behaviour will probably be expected for other interfaces." and David was right!

Moving the functionality to Xcp_client.ml itself so that it isn't duplicated across 3 different clients.