### PR TITLE
CP-54468 Handle USB network devices in network devices sort

### DIFF
--- a/ocaml/networkd/lib/network_device_order.ml
+++ b/ocaml/networkd/lib/network_device_order.ml
@@ -243,7 +243,17 @@ module Dev = struct
       )
     ; ( "Bus Info"
       , fun r v ->
-          let* pci = Pciaddr.of_string v in
+          let pci_str =
+            match String.split_on_char '-' v with
+            | ["usb"; pci; _] ->
+                (* For USB device, the bus-info is like
+                   "usb-<PCI address of USB controller>-<USB port path>",
+                    use the PCI address of the USB controller *)
+                pci
+            | _ ->
+                v
+          in
+          let* pci = Pciaddr.of_string pci_str in
           Ok {r with pci}
       )
     ]


### PR DESCRIPTION
The bus-info of a USB-based network device follows the format `usb-<PCI address of USB controller>-<USB port path>`. To determine the device's order when sorting, use the PCI address of the USB controller.