### PR TITLE
xenopsd: set xen-platform-pci-bar-uc key in xenstore

### DIFF
--- a/ocaml/xenopsd/lib/xenopsd.ml
+++ b/ocaml/xenopsd/lib/xenopsd.ml
@@ -49,6 +49,8 @@ let default_vbd_backend_kind = ref "vbd"
 
 let ca_140252_workaround = ref false
 
+let xen_platform_pci_bar_uc = ref true
+
 let action_after_qemu_crash = ref None
 
 let additional_ballooning_timeout = ref 120.
@@ -206,6 +208,14 @@ let options =
     , Arg.Bool (fun x -> ca_140252_workaround := x)
     , (fun () -> string_of_bool !ca_140252_workaround)
     , "Workaround for evtchn misalignment for legacy PV tools"
+    )
+  ; ( "xen-platform-pci-bar-uc"
+    , Arg.Bool (fun x -> xen_platform_pci_bar_uc := x)
+    , (fun () -> string_of_bool !xen_platform_pci_bar_uc)
+    , "Controls whether, when the VM starts in HVM mode, the Xen PCI MMIO used \
+       by grant tables is mapped as Uncached (UC, the default) or WriteBack \
+       (WB, the workaround). WB mapping could improve performance of devices \
+       using grant tables. This is useful on AMD platform only."
     )
   ; ( "additional-ballooning-timeout"
     , Arg.Set_float additional_ballooning_timeout

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -501,6 +501,9 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept =
     xs.Xs.writev (dom_path ^ "/bios-strings") vm_info.bios_strings ;
     if vm_info.is_uefi then
       xs.Xs.write (dom_path ^ "/hvmloader/bios") "ovmf" ;
+    xs.Xs.write
+      (dom_path ^ "/hvmloader/pci/xen-platform-pci-bar-uc")
+      (if !Xenopsd.xen_platform_pci_bar_uc then "1" else "0") ;
     (* If a toolstack sees a domain which it should own in this state then the
        domain is not completely setup and should be shutdown. *)
     xs.Xs.write (dom_path ^ "/action-request") "poweroff" ;

--- a/ocaml/xenopsd/xenopsd.conf
+++ b/ocaml/xenopsd/xenopsd.conf
@@ -108,3 +108,9 @@ disable-logging-for=http tracing tracing_export
 # time to wait for in-guest PV drivers to acknowledge a shutdown request
 # before we conclude that the drivers have failed
 # domain_shutdown_ack_timeout = 60
+
+# Controls whether, when the VM starts in HVM mode, the Xen PCI MMIO used
+# by grant tables is mapped as Uncached (UC, the default) or WriteBack
+# (WB, the workaround). WB mapping could improve performance of devices
+# using grant tables. This is useful on AMD platform only.
+# xen-platform-pci-bar-uc=true


### PR DESCRIPTION
This patch add a new parameter named 'xen-platform-pci-bar-uc' in xenopsd config file who has a default value of 'true' to keep the default behavior of hvmloader.  Putting 'false' to this parameter will tell xenopsd to add a xenstore key of '0' in:
'/local/domain/<domid>/hvmloader/pci/xen-platform-pci-bar-uc'. Only this key set to 0 will change the behavior of hvmloader. Otherwise, xenstore is set with '1' by default.

This changeset is link to this xen commit:
https://xenbits.xen.org/gitweb/?p=xen.git;a=commit;h=22650d6054625be10172fe0c78b9cadd1a39bd63

This is a new and much more simpler version of: https://github.com/xapi-project/xen-api/pull/6555