### PR TITLE
`xapi_vm_lifecycle`: Disallow suspend when `cant_suspend_reason` is present

### DIFF
--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -201,7 +201,8 @@ let check_op_for_feature ~__context ~vmr:_ ~vmmr ~vmgmr ~power_state ~op ~ref
     | `changing_VCPUs_live when lack_feature "feature-vcpu-hotplug" ->
         some_err Api_errors.vm_lacks_feature
     | (`suspend | `checkpoint | `pool_migrate | `migrate_send)
-      when strict && lack_feature "feature-suspend" ->
+      when has_feature ~vmgmr ~feature:"data-cant-suspend-reason"
+           || (strict && lack_feature "feature-suspend") ->
         some_err Api_errors.vm_lacks_feature
     | _ ->
         None


### PR DESCRIPTION
When `data/cant_suspend_reason` is present in xenstore (renamed `data-cant-suspend-reason` in "other" guest metrics), it excludes operations involving suspend from the `allowed_operations` list, but still allows actually suspending (`strict=true` during `allowed_ops` checks but false otherwise). Suspending in such a situation would always result in a crash.

So disallow suspending altogether when `cant_suspend_reason` is present. This entry is appropriately cleaned up when the faulty device is unplugged, so there shouldn't be a situation where it would prevent a legitimate suspend from occurring.