### PR TITLE
CA-393417: Drop device controller of cgroup v1 and fix USB passthrough for XS9

### DIFF
--- a/python3/libexec/usb_reset.py
+++ b/python3/libexec/usb_reset.py
@@ -15,36 +15,30 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 # attach
-# ./usb_reset.py attach device -d dom-id -p pid [-r]
+# ./usb_reset.py attach device -d dom-id [-r]
 # ./usb_reset.py attach 2-2 -d 12 -p 4130
 # ./usb_reset.py attach 2-2 -d 12 -p 4130 -r
 # 1. reset device
-# if without -r, do step 2~4
+# if without -r, do step 2~3
 # 2. if it's the first USB device to pass-through
-#      a) bind mount /dev /sys in chroot directory (/var/xen/qemu/root-<domid>)
-#      b) create new cgroup devices:/qemu-<domid>,
-#      c) blacklist all and add default device whitelist,
-#      d) join current qemu process to this cgroup
-# 3. save device uid/gid to /var/run/nonpersistent/usb/<device>
-# 4. set device file uid/gid to (qemu_base + dom-id)
-# 5. add current device to whitelist
+#      a) bind mount /sys in chroot directory (/var/xen/qemu/root-<domid>)
+#      b) clone (create the device with same major/minor number and mode) in chroot directory with same path
+# 3. set device file uid/gid to (qemu_base + dom-id)
 #
 # detach
 # ./usb_reset.py detach device -d dom-id
 # ./usb_reset.py detach 2-2 -d 12
-# 1. restore device file uid/gid from /var/run/nonpersistent/usb/<device>
-# 2. remove current device from whitelist
+# 1. Remove the cloned device file in chroot directory
 #
 # cleanup
 # ./usb_reset.py cleanup -d dom-id
 # ./usb_reset.py cleanup -d 12
-# 1.remove the cgroup if one has been created.
-# 2.umount /dev, /sys from chroot directory if they are mounted.
+# 1.umount /sys from chroot directory if they are mounted.
+# 2.remove /dev/bus directory in chroot directory if it exists
 
 import argparse
 import ctypes
 import ctypes.util
-import errno
 import fcntl
 import grp
 import xcp.logger as log  # pytype: disable=import-error
@@ -52,7 +46,7 @@ import logging
 import os
 import pwd
 import re
-from stat import S_ISCHR, S_ISBLK
+import shutil
 
 
 def parse_arg():
@@ -64,8 +58,6 @@ def parse_arg():
     attach.add_argument("device", help="the target usb device")
     attach.add_argument("-d", dest="domid", type=int, required=True,
                         help="specify the domid of the VM")
-    attach.add_argument("-p", dest="pid", type=int, required=True,
-                        help="the process id of QEMU")
     attach.add_argument("-r", dest="reset_only", action="store_true",
                         help="reset device only, for privileged mode")
 
@@ -83,56 +75,6 @@ def parse_arg():
 
 def get_root_dir(domid):
     return "/var/xen/qemu/root-{}".format(domid)
-
-
-def get_cg_dir(domid):
-    return "/sys/fs/cgroup/devices/qemu-{}".format(domid)
-
-
-def get_ids_path(device):
-    usb_dir = "/var/run/nonpersistent/usb"
-    try:
-        os.makedirs(usb_dir)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
-
-    return os.path.join(usb_dir, device)
-
-
-def save_device_ids(device):
-    path = dev_path(device)
-
-    try:
-        stat = os.stat(path)
-        ids_info = "{} {}".format(stat.st_uid, stat.st_gid)
-    except OSError as e:
-        log.error("Failed to stat {}: {}".format(path, str(e)))
-        exit(1)
-
-    try:
-        with open(get_ids_path(device), "w") as f:
-            f.write(ids_info)
-    except IOError as e:
-        log.error("Failed to save device ids {}: {}".format(path, str(e)))
-        exit(1)
-
-
-def load_device_ids(device):
-    ids_path = get_ids_path(device)
-    try:
-        with open(ids_path) as f:
-            uid, gid = list(map(int, f.readline().split()))
-    except (IOError, ValueError) as e:
-        log.error("Failed to load device ids: {}".format(str(e)))
-
-    try:
-        os.remove(ids_path)
-    except OSError as e:
-        # ignore and continue
-        log.warning("Failed to remove device ids: {}".format(str(e)))
-
-    return uid, gid  # pyright: ignore[reportPossiblyUnboundVariable] # pragma: no cover
 
 
 # throw IOError, ValueError
@@ -157,109 +99,6 @@ def dev_path(device):
         exit(1)
 
 
-def get_ctl(path, mode):  # type:(str, str) -> str
-    """get the string to control device access for cgroup
-    :param path: the device file path
-    :param mode: either "r" or "rw"
-    :return: the string to control device access
-    """
-    try:
-        st = os.stat(path)
-    except OSError as e:
-        log.error("Failed to get stat of {}: {}".format(path, str(e)))
-        raise
-
-    t = ""
-    if S_ISBLK(st.st_mode):
-        t = "b"
-    elif S_ISCHR(st.st_mode):
-        t = "c"
-    if t and mode in ("r", "rw"):
-        return "{} {}:{} {}".format(t, os.major(st.st_rdev), os.minor(
-            st.st_rdev), mode)
-    raise RuntimeError("Failed to get control string of {}".format(path))
-
-
-def _device_ctl(path, domid, allow):
-    cg_dir = get_cg_dir(domid)
-    file_name = "/devices.allow" if allow else "/devices.deny"
-    try:
-        with open(cg_dir + file_name, "w") as f:
-            f.write(get_ctl(path, "rw"))
-    except (IOError, OSError, RuntimeError) as e:
-        log.error("Failed to {} {}: {}".format(
-            "allow" if allow else "deny", path, str(e)))
-        exit(1)
-
-
-def allow_device(path, domid):
-    _device_ctl(path, domid, True)
-
-
-def deny_device(path, domid):
-    _device_ctl(path, domid, False)
-
-
-def setup_cgroup(domid, pid):  # type:(str, str) -> None
-    """
-    Associate the given process id (pid) with the given Linux kernel control group
-    and limit it's device access to only /dev/null.
-
-    :param domid (str): The control group ID string (passed on from the command line)
-    :param pid (str): The process ID string (passed on from the command line)
-
-    If the control group directory does not exist yet, the control group is created.
-
-    - The pid goes into the file "tasks" to associate the process with the cgroup.
-    - Deny device access by default by writing "a" to devices.deny.
-    - Grant read-write access to /dev/null, writing it's device IDs to devices.allow.
-
-    If any error occur during the setup process, the error is logged and
-    the program exits with a status code of 1.
-    """
-    cg_dir = get_cg_dir(domid)
-
-    try:
-        os.mkdir(cg_dir, 0o755)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            log.error("Failed to create cgroup: {}".format(cg_dir))
-            exit(1)
-
-    try:
-        # unbuffered write to ensure each one is flushed immediately
-        # to the kernel's control group filesystem:
-        #
-        # The order of writes is likely not important, but the writes
-        # may have to be a single write() system call for the entire string.
-        #
-        # Using the unbuffered Raw IO mode, we know the write was done
-        # in exactly this way by the write function call itself, not later.
-        #
-        # With small writes like this , splitting them because of overflowing the
-        # buffer is not expected to happen. To stay safe and keep using unbuffered I/O
-        # We have to migrate to binary mode in python3,as python3 supports unbuffered 
-        # raw I/O in binary mode.
-        #
-        with open(cg_dir + "/tasks", "wb", 0) as tasks, \
-                open(cg_dir + "/devices.deny", "wb", 0) as deny, \
-                open(cg_dir + "/devices.allow", "wb", 0) as allow:
-
-            # deny all
-            deny.write(b"a")
-
-            # To write bytes, we've to encode the strings to bytes below:
-
-            # grant rw access to /dev/null by default
-            allow.write(get_ctl("/dev/null", "rw").encode())
-
-            tasks.write(str(pid).encode())
-
-    except (IOError, OSError, RuntimeError) as e:
-        log.error("Failed to setup cgroup: {}".format(str(e)))
-        exit(1)
-
-
 def mount(source, target, fs, flags=0):
     if ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True
                    ).mount(source.encode(), target.encode(), fs.encode(), flags, None) < 0:
@@ -277,7 +116,43 @@ def umount(target):
                   format(target, os.strerror(ctypes.get_errno())))
 
 
-def attach(device, domid, pid, reset_only):
+def clone_device(path, root_dir, domid):
+    """
+    Clone the device file into the chroot directory.
+
+    :param path: The source device file under system /dev to clone.
+    :param root_dir: The root directory of the chroot environment.
+    :param domid: The domain ID of the VM, used to set the device file's uid/gid.
+    """
+    target_path = os.path.join(root_dir, path.lstrip(os.path.sep))
+    if os.path.exists(target_path):
+        log.info("Device file {} already exists in chroot".format(target_path))
+        return
+
+    os.makedirs(os.path.dirname(target_path), exist_ok=True, mode=0o755)
+
+    try:
+        st = os.stat(path)
+    except OSError as e:
+        log.error("Failed to get stat of {}: {}".format(path, str(e)))
+        exit(1)
+
+    mode = st.st_mode
+    major = os.major(st.st_rdev)
+    minor = os.minor(st.st_rdev)
+    clone_device_id = os.makedev(major, minor)
+    os.mknod(target_path, mode, clone_device_id)
+
+    # set device file uid/gid
+    try:
+        os.chown(target_path, pwd.getpwnam("qemu_base").pw_uid + domid,
+                 grp.getgrnam("qemu_base").gr_gid + domid)
+    except OSError as e:
+        log.error("Failed to chown device file {}: {}".format(path, str(e)))
+        exit(1)
+
+
+def attach(device, domid, reset_only):
     path = dev_path(device)
 
     # reset device
@@ -293,27 +168,13 @@ def attach(device, domid, pid, reset_only):
     if reset_only:
         return
 
-    save_device_ids(device)
-
-    # set device file uid/gid
-    try:
-        os.chown(path, pwd.getpwnam("qemu_base").pw_uid + domid,
-                 grp.getgrnam("qemu_base").gr_gid + domid)
-    except OSError as e:
-        log.error("Failed to chown device file {}: {}".format(path, str(e)))
-        exit(1)
-
     root_dir = get_root_dir(domid)
     dev_dir = root_dir + "/dev"
     if not os.path.isdir(root_dir) or not os.path.isdir(dev_dir):
         log.error("Error: The chroot or dev directory doesn't exist")
         exit(1)
 
-    if not os.path.isdir(dev_dir + "/bus"):
-        # first USB device to pass-through
-        MS_BIND = 4096  # mount flags, from fs.h
-        mount("/dev", dev_dir, "", MS_BIND)
-        setup_cgroup(domid, pid)
+    clone_device(path, root_dir, domid)
 
     sys_dir = root_dir + "/sys"
     # sys_dir could already be mounted because of PCI pass-through
@@ -326,41 +187,23 @@ def attach(device, domid, pid, reset_only):
     if not os.path.isdir(sys_dir + "/devices"):
         mount("/sys", sys_dir, "sysfs")
 
-    # add device to cgroup allow list
-    allow_device(path, domid)
-
 
 def detach(device, domid):
     path = dev_path(device)
-    uid, gid = load_device_ids(device)
-
-    # restore uid, gid of the device file.
-    try:
-        os.chown(path, uid, gid)
-    except OSError as e:
-        log.error("Failed to chown device file {}: {}".format(path, str(e)))
-        exit(1)
-
-    # remove device from cgroup allow list
-    deny_device(path, domid)
+    root_dir = get_root_dir(domid)
+    target_path = os.path.join(root_dir, path.lstrip(os.path.sep))
+    os.remove(target_path)
 
 
 def cleanup(domid):
-    # remove the cgroup if one has been created.
-    if os.path.isdir(get_cg_dir(domid)):
-        try:
-            os.rmdir(get_cg_dir(domid))
-        except OSError as e:
-            # log and continue
-            log.error("Failed to remove cgroup qemu-{}: {}"
-                      .format(domid, str(e)))
-
     # umount /dev, /sys from chroot directory if they are mounted.
     root_dir = get_root_dir(domid)
     dev_dir = root_dir + "/dev"
     sys_dir = root_dir + "/sys"
-    if os.path.isdir(dev_dir + "/bus"):
-        umount(dev_dir)
+    bus_dir = dev_dir + "/bus"
+    if os.path.isdir(bus_dir):
+        log.info("Removing bus directory: {} for cleanup".format(bus_dir))
+        shutil.rmtree(bus_dir)
     if os.path.isdir(sys_dir + "/devices"):
         umount(sys_dir)
 
@@ -371,7 +214,7 @@ if __name__ == "__main__":
     arg = parse_arg()
 
     if "attach" == arg.command:
-        attach(arg.device, arg.domid, arg.pid, arg.reset_only)
+        attach(arg.device, arg.domid, arg.reset_only)
     elif "detach" == arg.command:
         detach(arg.device, arg.domid)
     elif "cleanup" == arg.command:

--- a/python3/tests/import_helper.py
+++ b/python3/tests/import_helper.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from types import ModuleType
 
 from typing import Generator
-from mock import Mock
+from unittest.mock import MagicMock
 
 
 @contextmanager
@@ -28,7 +28,7 @@ def mocked_modules(*module_names: str) -> Generator[None, None, None]:
     ```
     """
     for module_name in module_names:
-        sys.modules[module_name] = Mock()
+        sys.modules[module_name] = MagicMock()
     yield
     for module_name in module_names:
         sys.modules.pop(module_name)

--- a/python3/tests/test_usb_reset.py
+++ b/python3/tests/test_usb_reset.py
@@ -1,0 +1,109 @@
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+import sys
+
+# some mocked arguemtn is not used in the tests, but as side-effects
+# disabled pylint warning for unused arguments
+# pylint: disable=unused-argument
+
+from python3.tests.import_helper import import_file_as_module
+# mock modules to avoid dependencies
+sys.modules["xcp"] = MagicMock()
+sys.modules["xcp.logger"] = MagicMock()
+usb_reset = import_file_as_module("python3/libexec/usb_reset.py")
+
+
+class TestUsbReset(unittest.TestCase):
+    @mock.patch("usb_reset.open", new_callable=mock.mock_open, read_data="5\n")
+    def test_read_int(self, mock_open):
+        self.assertEqual(usb_reset.read_int("/fake/path"), 5)
+        mock_open.assert_called_with("/fake/path")
+
+    @mock.patch("usb_reset.read_int", side_effect=[1, 2])
+    @mock.patch("usb_reset.log")
+    def test_dev_path_valid(self, mock_log, mock_read_int):
+        device = "1-2.3"
+        path = usb_reset.dev_path(device)
+        self.assertEqual(path, "/dev/bus/usb/001/002")
+        mock_log.error.assert_not_called()
+
+    @mock.patch("usb_reset.log")
+    def test_dev_path_invalid(self, mock_log):
+        with self.assertRaises(SystemExit):
+            usb_reset.dev_path("invalid-device")
+        mock_log.error.assert_called()
+
+    @mock.patch("usb_reset.ctypes.CDLL")
+    @mock.patch("usb_reset.ctypes.util.find_library", return_value="libc.so.6")
+    @mock.patch("usb_reset.log")
+    def test_mount_success(self, mock_log, mock_find_lib, mock_cdll):
+        mock_cdll.return_value.mount.return_value = 0
+        usb_reset.mount("src", "tgt", "fs")
+        mock_cdll.return_value.mount.assert_called()
+
+    @mock.patch("usb_reset.ctypes.CDLL")
+    @mock.patch("usb_reset.ctypes.util.find_library", return_value="libc.so.6")
+    @mock.patch("usb_reset.log")
+    def test_mount_fail(self, mock_log, mock_find_lib, mock_cdll):
+        mock_cdll.return_value.mount.return_value = -1
+        with self.assertRaises(SystemExit):
+            usb_reset.mount("src", "tgt", "fs")
+        mock_log.error.assert_called()
+
+    @mock.patch("usb_reset.ctypes.CDLL")
+    @mock.patch("usb_reset.ctypes.util.find_library", return_value="libc.so.6")
+    @mock.patch("usb_reset.log")
+    def test_umount(self, mock_log, mock_find_lib, mock_cdll):
+        mock_cdll.return_value.umount.return_value = -1
+        usb_reset.umount("tgt")
+        mock_log.error.assert_called()
+
+    @mock.patch("usb_reset.os")
+    @mock.patch("usb_reset.pwd.getpwnam")
+    @mock.patch("usb_reset.grp.getgrnam")
+    @mock.patch("usb_reset.log")
+    def test_clone_device(self, mock_log, mock_grp, mock_pwd, mock_os):
+        mock_os.path.exists.return_value = False
+        mock_os.path.sep = "/"
+        mock_os.stat.return_value.st_mode = 0o600
+        mock_os.stat.return_value.st_rdev = 0
+        mock_os.major.return_value = 1
+        mock_os.minor.return_value = 2
+        mock_os.makedev.return_value = 1234
+        mock_pwd.return_value.pw_uid = 1000
+        mock_grp.return_value.gr_gid = 1000
+        usb_reset.clone_device("/dev/bus/usb/001/002", "/root", 1)
+        mock_os.mknod.assert_called()
+        mock_os.chown.assert_called()
+
+    @mock.patch("usb_reset.dev_path", return_value="/dev/bus/usb/001/002")
+    @mock.patch("usb_reset.open", new_callable=mock.mock_open)
+    @mock.patch("usb_reset.fcntl.ioctl")
+    @mock.patch("usb_reset.log")
+    def test_attach_reset_only(self, mock_log, mock_ioctl, mock_open, mock_dev_path):
+        usb_reset.attach("1-2", 1, 123, True)
+        mock_open.assert_called()
+        mock_ioctl.assert_called()
+
+    @mock.patch("usb_reset.dev_path", return_value="/dev/bus/usb/001/002")
+    @mock.patch("usb_reset.os.remove")
+    @mock.patch("usb_reset.get_root_dir", return_value="/root")
+    def test_detach(self, mock_get_root_dir, mock_remove, mock_dev_path):
+        usb_reset.detach("1-2", 1)
+        mock_remove.assert_called()
+
+    @mock.patch("usb_reset.shutil.rmtree")
+    @mock.patch("usb_reset.os.path.isdir", return_value=True)
+    @mock.patch("usb_reset.os.path.exists", return_value=True)
+    @mock.patch("usb_reset.os.path.ismount", return_value=True)
+    @mock.patch("usb_reset.umount")
+    @mock.patch("usb_reset.log")
+    #pylint: disable=too-many-positional-arguments
+    def test_cleanup(self, mock_log, mock_umount, mock_ismount,
+                     mock_exists, mock_isdir, mock_rmtree):
+        usb_reset.cleanup(1)
+        mock_rmtree.assert_called()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python3/tests/test_usb_scan.py
+++ b/python3/tests/test_usb_scan.py
@@ -9,14 +9,14 @@ import tempfile
 import unittest
 from collections.abc import Mapping
 from typing import cast
+from unittest.mock import MagicMock
 
-import mock
 
 from python3.tests.import_helper import import_file_as_module
 # mock modules to avoid dependencies
-sys.modules["xcp"] = mock.Mock()
-sys.modules["xcp.logger"] = mock.Mock()
-sys.modules["pyudev"] = mock.Mock()
+sys.modules["xcp"] = MagicMock()
+sys.modules["xcp.logger"] = MagicMock()
+sys.modules["pyudev"] = MagicMock()
 usb_scan = import_file_as_module("python3/libexec/usb_scan.py")
 
 
@@ -90,7 +90,7 @@ def mock_setup(mod, devices, interfaces, path):
     mod.log.error = verify_log
     mod.log.debug = verify_log
     mod.Policy._PATH = path
-    mod.pyudev.Context = mock.Mock(
+    mod.pyudev.Context = MagicMock(
             return_value=MocContext(devices, interfaces))
 
 


### PR DESCRIPTION
The approach work for both XS8 and XS9

- 4357061 for xs9
- 4357062 for xs8


```
Date:   Fri Jul 4 15:40:00 2025 +0800

    CA-393417: Bind mount /proc/<pid> into chroot
    
    From strace/gdb, XS9 qemu requires /proc/self/fd/<fd> to work well
    This is due to systemd/libudev update.
    
    Just bind mount /proc/self/ to the chroot to permit qemu access
    
    ```
    1047 openat(AT_FDCWD, "/proc/self/fd/46", O_RDONLY|O_NOCTTY|O_CLOEXEC|O_PATH) = -1 ENOENT (No such file or directory)
    1048 openat(AT_FDCWD, "/proc/", O_RDONLY|O_NOCTTY|O_CLOEXEC|O_PATH) = -1 ENOENT (No such file or directory)
    
        ../sysdeps/unix/sysv/linux/fstatfs64.c:30
        out>, dir_fd=<optimized out>) at ../src/basic/stat-util.c:566
        magic_value=1650812274) at ../src/basic/stat-util.c:369
        fd=<optimized out>) at ../src/basic/stat-util.h:66
        verify=<optimized out>) at
    ../src/libsystemd/sd-device/sd-device.c:221
        (ret=0x7ffc67ebba20, syspath=0x7ffc67ebb950
    "/sys/bus/usb/devices/usb1", strict=true)
        at ../src/libsystemd/sd-device/sd-device.c:271
        (syspath=0x7ffc67ebb950 "/sys/bus/usb/devices/usb1",
    ret=0x7ffc67ebba20)
        at ../src/libsystemd/sd-device/sd-device.c:280
    ```
    
    Signed-off-by: Lin Liu <Lin.Liu01@cloud.com>

commit fc5f98b80badd2c9bb952b9a6ee7d7367bcb4f70
Author: Lin Liu <Lin.Liu01@cloud.com>
Date:   Tue Jul 1 15:56:18 2025 +0800

    CA-393417: Drop device controller of cgroup v1
    
    For deprivileged qemu, following ops are performed
    - bind mount /dev/ to qemu chroot, so qemu can access it
    - cgroup controller deny all devices, except the target usb device
    
    However, new XS updated to cgroup v2 and the devices controller
    available anymore.
    
    Instead of bind mount all /dev folder, only the permitted usb
    devices are created into the chroot. Thus, the cgroup controller
    is no longer necessary.
    
    Besides, there are following updates accordingly
    - qemu pid is no longer necessary as command line args, as cgroup
    is dropped.
    - save and restore system /etc/ devices file ownership is no longer
    necessary. New file is cloned into chroot instead of bind mount system
    device file, so only need to set ownership of chroot file directly
    ```