### PR TITLE
CP-308690: Avoid unnecessary condition evaluations

### DIFF
--- a/ocaml/networkd/lib/network_device_order.ml
+++ b/ocaml/networkd/lib/network_device_order.ml
@@ -65,11 +65,12 @@ module Pciaddr = struct
 
   let compare t1 t2 =
     let open Xcp_pci in
-    let ( <?> ) a b = if a = 0 then b else a in
-    compare t1.domain t2.domain
-    <?> compare t1.bus t2.bus
-    <?> compare t1.dev t2.dev
-    <?> compare t1.fn t2.fn
+    let ( <?> ) a b = match a () with 0 -> b | x -> Fun.const x in
+    let cmp1 () = compare t1.domain t2.domain in
+    let cmp2 () = compare t1.bus t2.bus in
+    let cmp3 () = compare t1.dev t2.dev in
+    let cmp4 () = compare t1.fn t2.fn in
+    (cmp1 <?> cmp2 <?> cmp3 <?> cmp4) ()
 end
 
 module Macaddr = struct

--- a/ocaml/networkd/lib/network_device_order.ml
+++ b/ocaml/networkd/lib/network_device_order.ml
@@ -65,12 +65,11 @@ module Pciaddr = struct
 
   let compare t1 t2 =
     let open Xcp_pci in
-    let ( <?> ) a b = match a () with 0 -> b | x -> Fun.const x in
-    let cmp1 () = compare t1.domain t2.domain in
-    let cmp2 () = compare t1.bus t2.bus in
-    let cmp3 () = compare t1.dev t2.dev in
-    let cmp4 () = compare t1.fn t2.fn in
-    (cmp1 <?> cmp2 <?> cmp3 <?> cmp4) ()
+    let ( <?> ) a b = if a = 0 then Lazy.force b else a in
+    compare t1.domain t2.domain
+    <?> lazy (compare t1.bus t2.bus)
+    <?> lazy (compare t1.dev t2.dev)
+    <?> lazy (compare t1.fn t2.fn)
 end
 
 module Macaddr = struct


### PR DESCRIPTION
The "<?>" operator was introduced to simplify deeply nested conditionals. However, it also led to unintended side effects: all condition expressions are evaluated eagerly, even when some may not be needed.

This happens because OCaml uses call-by-value semantics, meaning function arguments are evaluated before the function is applied.

The change makes the evaluations lazily to avoid unnecessary condition evaluations.