### PR TITLE
Raise VIF limit from 7 to 16 by calculating `max_grant_frames` on domain creation

### DIFF
--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -1304,9 +1304,9 @@ let allowed_VBD_devices_HVM_floppy =
     (fun x -> Device_number.(make Floppy ~disk:x ~partition:0))
     (inclusive_range 0 1)
 
-let allowed_VIF_devices_HVM = vif_inclusive_range 0 6
+let allowed_VIF_devices_HVM = vif_inclusive_range 0 15
 
-let allowed_VIF_devices_PV = vif_inclusive_range 0 6
+let allowed_VIF_devices_PV = vif_inclusive_range 0 15
 
 (** [possible_VBD_devices_of_string s] returns a list of Device_number.t which
     	represent possible interpretations of [s]. *)

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -848,10 +848,11 @@ module Queues = struct
 
   let get tag qs =
     with_lock qs.m (fun () ->
-        if StringMap.mem tag qs.qs then
-          StringMap.find tag qs.qs
-        else
-          Queue.create ()
+        match StringMap.find_opt tag qs.qs with
+        | Some x ->
+            x
+        | None ->
+            Queue.create ()
     )
 
   let tags qs =
@@ -862,10 +863,11 @@ module Queues = struct
   let push_with_coalesce should_keep tag item qs =
     with_lock qs.m (fun () ->
         let q =
-          if StringMap.mem tag qs.qs then
-            StringMap.find tag qs.qs
-          else
-            Queue.create ()
+          match StringMap.find_opt tag qs.qs with
+          | Some x ->
+              x
+          | None ->
+              Queue.create ()
         in
         push_with_coalesce should_keep item q ;
         qs.qs <- StringMap.add tag q qs.qs ;

--- a/ocaml/xenopsd/lib/xenops_server.ml
+++ b/ocaml/xenopsd/lib/xenops_server.ml
@@ -2297,11 +2297,18 @@ let rec perform_atomic ~progress_callback ?result (op : atomic)
       debug "VM.destroy %s" id ;
       B.VM.destroy t (VM_DB.read_exn id)
   | VM_create (id, memory_upper_bound, final_id, no_sharept) ->
-      debug "VM.create %s memory_upper_bound = %s" id
+      let num_of_vbds = List.length (VBD_DB.vbds id) in
+      let num_of_vifs = List.length (VIF_DB.vifs id) in
+      debug
+        "VM.create %s memory_upper_bound = %s, num_of_vbds = %d, num_of_vifs = \
+         %d"
+        id
         (Option.value ~default:"None"
            (Option.map Int64.to_string memory_upper_bound)
-        ) ;
+        )
+        num_of_vbds num_of_vifs ;
       B.VM.create t memory_upper_bound (VM_DB.read_exn id) final_id no_sharept
+        num_of_vbds num_of_vifs
   | VM_build (id, force) ->
       debug "VM.build %s" id ;
       let vbds : Vbd.t list = VBD_DB.vbds id |> vbd_plug_order in

--- a/ocaml/xenopsd/lib/xenops_server_plugin.ml
+++ b/ocaml/xenopsd/lib/xenops_server_plugin.ml
@@ -84,6 +84,8 @@ module type S = sig
       -> Vm.t
       -> Vm.id option
       -> bool (* no_sharept*)
+      -> int (* num_of_vbds *)
+      -> int (* num_of_vifs *)
       -> unit
 
     val build :

--- a/ocaml/xenopsd/lib/xenops_server_simulator.ml
+++ b/ocaml/xenopsd/lib/xenops_server_simulator.ml
@@ -547,7 +547,8 @@ module VM = struct
 
   let remove _vm = ()
 
-  let create _ memory_limit vm _ _ = with_lock m (create_nolock memory_limit vm)
+  let create _ memory_limit vm _ _ _ _ =
+    with_lock m (create_nolock memory_limit vm)
 
   let destroy _ vm = with_lock m (destroy_nolock vm)
 

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -390,7 +390,13 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept =
     ; max_maptrack_frames=
         ( try
             int_of_string (List.assoc "max_maptrack_frames" vm_info.platformdata)
-          with _ -> 1024
+          with _ ->
+            0
+            (* This should be >0 only for driver domains (Dom0 startup is not
+               handled by the toolstack), which currently do not exist.
+               To support these in the future, xenopsd would need to check what
+               type of domain is being started.
+            *)
         )
     ; max_grant_version=
         (if List.mem CAP_Gnttab_v2 host_info.capabilities then 2 else 1)

--- a/ocaml/xenopsd/xc/domain.ml
+++ b/ocaml/xenopsd/xc/domain.ml
@@ -395,8 +395,10 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept
                32 requests * 11 grant refs contained in each * 8 bytes ) /
                4096 bytes size of frame = 0.6875, rounded up *)
             let frames_number =
-              (max_per_vif * (num_of_vifs + 1))
-              + (reasonable_per_vbd * (num_of_vbds + 1))
+              max 64
+                ((max_per_vif * (num_of_vifs + 1))
+                + (reasonable_per_vbd * (num_of_vbds + 1))
+                )
             in
             debug "estimated max_grant_frames = %d" frames_number ;
             frames_number

--- a/ocaml/xenopsd/xc/domain.mli
+++ b/ocaml/xenopsd/xc/domain.mli
@@ -149,6 +149,8 @@ val make :
   -> [`VM] Uuidx.t
   -> string option
   -> bool (* no_sharept *)
+  -> int (* num_of_vbds *)
+  -> int (* num_of_vifs *)
   -> domid
 (** Create a fresh (empty) domain with a specific UUID, returning the domain ID *)
 

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -1389,7 +1389,8 @@ module VM = struct
         in
         (device_id, revision)
 
-  let create_exn task memory_upper_bound vm final_id no_sharept =
+  let create_exn task memory_upper_bound vm final_id no_sharept num_of_vbds
+      num_of_vifs =
     let k = vm.Vm.id in
     with_xc_and_xs (fun xc xs ->
         (* Ensure the DB contains something for this VM - this is to avoid a
@@ -1518,7 +1519,8 @@ module VM = struct
                   let create_info = generate_create_info ~xs vm persistent in
                   let domid =
                     Domain.make ~xc ~xs create_info vm.vcpu_max domain_config
-                      (uuid_of_vm vm) final_id no_sharept
+                      (uuid_of_vm vm) final_id no_sharept num_of_vbds
+                      num_of_vifs
                   in
                   Mem.transfer_reservation_to_domain dbg domid reservation_id ;
                   let initial_target =


### PR DESCRIPTION
xenopsd currently hardcodes 64 as the value for `max_grant_frames` for all domains. This limits how many grants a domain can allocate, thus limiting the number of VIFs and VBDs a domain can have. `max_grant_frames` can be changed for individual VMs through specifying a particular value in `platform`, but it's much better to be able to estimate how many grant frames a VM would need based on the number of VBDs and VIFs.

Implement this and add some notes on the difficulties and imprecisions of such an estimation.

This allows raising the number of supported VIFs from the current limit of 7 - we've picked 16 as a sweet spot, though this could be discussed further. (note that it's the `allowed_vifs` limit that's changed, VIFs can be created in arbitrary numbers on the CLI and by clients not honouring the `allowed_vifs` advice).

Given the current behaviour of the XenServer/XCP-ng system (hypervisor+drivers), where more VIFs allow for higher overall networking throughput, this is highly beneficial - in testing overall throughput with 16 VIFs was 18-27% higher than with 8 VIFs (tested with multiple iperf3 instances running on all interfaces simultaneously). The following table shows the performance per-VIF and per-VM on a host with 16 pcpus with 8 vCPUs for domU and dom0 each:

![image](https://github.com/user-attachments/assets/f61488bf-90f0-4cbd-8896-176e053f708f)

Moreover, some users coming from VMWare are used to networking setups with dozens of VIFs, and this is a step towards allowing that without encountering any other bottlenecks in the system.

Most of this work (except the last commit) was tested very thoroughly at XenServer, since it was initially intended to raise the supported limit of VBDs (it passed Ring3 BST+BVT multiple times, and ran through the config limits test several times). Raising the number of supported VBDs has other issues so was abandoned, but this PR solves all the issues for VIFs.
The new limit was tested with XCP-ng, with a new test being added to our CI (https://github.com/xcp-ng/xcp-ng-tests/pull/338), which will verify the ability to hit the new limit and perform well at it.