### PR TITLE
Downgrade unknown SM.feature errors to warnings

### DIFF
--- a/ocaml/xapi/smint.ml
+++ b/ocaml/xapi/smint.ml
@@ -132,7 +132,7 @@ module Feature = struct
         Some (feature, 1L)
     )
     | feature :: _ ->
-        error "SM.feature: unknown feature %s" feature ;
+        warn "SM.feature: unknown feature %s" feature ;
         None
 
   (** [compat_features features1 features2] finds the compatible features in the input


### PR DESCRIPTION
Previously, encountering unknown features such as ATOMIC_PAUSE or SR_CACHING in SM.feature would trigger an error in xapi. However, these features can be used internally by SM and are not necessarily indicative of a misconfiguration.

This change downgrades such cases from error to warning to still notify the user that an unrecognized feature is present but can be expected. It fixes #5353. 