### PR TITLE
CA-413424: Enhance xe help output

### DIFF
--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -67,13 +67,22 @@ exception Usage
 
 let usage () =
   error
-    "Usage: %s <cmd> [-s server] [-p port] ([-u username] [-pw password] or \
-     [-pwf <password file>]) [--traceparent traceparent] <other arguments>\n"
+    "Usage:\n\
+    \  %s <command>\n\
+    \    [ -s <server> ]            XenServer host \n\
+    \    [ -p <port> ]              XenServer port number \n\
+    \    [ -u <username> -pw <password> | -pwf <password file> ] \n\
+    \                               User authentication (password or file) \n\
+    \    [ --nossl ]                Disable SSL/TLS \n\
+    \    [ --debug ]                Enable debug output \n\
+    \    [ --debug-on-fail ]        Enable debug output only on failure \n\
+    \    [ --traceparent <value> ]  Distributed tracing context \n\
+    \    [ <other arguments> ... ]  Command-specific options \n"
     Sys.argv.(0) ;
   error
     "\n\
      A full list of commands can be obtained by running \n\
-     \t%s help -s <server> -p <port>\n"
+    \  %s help -s <server> -p <port>\n"
     Sys.argv.(0)
 
 let is_localhost ip = ip = "127.0.0.1"


### PR DESCRIPTION
The previous `xe` help is as below:
```
Usage: xe <cmd> [-s server] [-p port] ([-u username] [-pw password] or [-pwf <password file>]) [--traceparent traceparent] <other arguments>

A full list of commands can be obtained by running
	xe help -s <server> -p <port>
```

The previous `xe` help output lacked debug-related options and did not provide detailed parameter description.
The new `xe` help output is as follows:
```
Usage:
  xe <command>
    [ -s <server> ]            XenServer host
    [ -p <port> ]              XenServer port number
    [ -u <username> -pw <password> | -pwf <password file> ]
                               User authentication (password or file)
    [ --nossl ]                Disable SSL/TLS
    [ --debug ]                Enable debug output
    [ --debug-on-fail ]        Enable debug output only on failure
    [ --traceparent <value> ]  Distributed tracing context
    [ <other arguments> ... ]  Command-specific options

A full list of commands can be obtained by running
  xe help -s <server> -p <port>
```