### PR TITLE
CP-308455 VM.sysprep wait for shutdown

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2376,6 +2376,7 @@ let sysprep =
       [
         (Ref _vm, "self", "The VM")
       ; (String, "unattend", "XML content passed to sysprep")
+      ; (Float, "timeout", "timeout in seconds")
       ]
     ~doc:"Pass unattend.xml to Windows sysprep" ~allowed_roles:_R_VM_ADMIN ()
 

--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2376,9 +2376,12 @@ let sysprep =
       [
         (Ref _vm, "self", "The VM")
       ; (String, "unattend", "XML content passed to sysprep")
-      ; (Float, "timeout", "timeout in seconds")
+      ; (Float, "timeout", "timeout in seconds for expected reboot")
       ]
-    ~doc:"Pass unattend.xml to Windows sysprep" ~allowed_roles:_R_VM_ADMIN ()
+    ~doc:
+      "Pass unattend.xml to Windows sysprep and wait for the VM to shut down \
+       as part of a reboot."
+    ~allowed_roles:_R_VM_ADMIN ()
 
 let vm_uefi_mode =
   Enum

--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -2767,7 +2767,7 @@ let rec cmdtable_data : (string * cmd_spec) list =
   ; ( "vm-sysprep"
     , {
         reqd= ["filename"]
-      ; optn= []
+      ; optn= ["timeout"]
       ; help= "Pass and execute sysprep configuration file"
       ; implementation= With_fd Cli_operations.vm_sysprep
       ; flags= [Vm_selectors]

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3593,7 +3593,7 @@ let vm_sysprep fd printer rpc session_id params =
   let timeout =
     match List.assoc "timeout" params |> float_of_string with
     | exception _ ->
-        0.0
+        3.0 *. 60.0 (* default in the CLI, no default in the API *)
     | s when s < 0.0 ->
         0.0
     | s ->

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3590,6 +3590,15 @@ let vm_data_source_forget printer rpc session_id params =
 
 let vm_sysprep fd printer rpc session_id params =
   let filename = List.assoc "filename" params in
+  let timeout =
+    match List.assoc "timeout" params |> float_of_string with
+    | exception _ ->
+        0.0
+    | s when s < 0.0 ->
+        0.0
+    | s ->
+        s
+  in
   let unattend =
     match get_client_file fd filename with
     | Some xml ->
@@ -3602,8 +3611,9 @@ let vm_sysprep fd printer rpc session_id params =
     (do_vm_op printer rpc session_id
        (fun vm ->
          Client.VM.sysprep ~rpc ~session_id ~self:(vm.getref ()) ~unattend
+           ~timeout
        )
-       params ["filename"]
+       params ["filename"; "timeout"]
     )
 
 (* APIs to collect SR level RRDs *)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3116,10 +3116,10 @@ functor
         Local.VM.remove_from_blocked_operations ~__context ~self ~key ;
         Xapi_vm_lifecycle.update_allowed_operations ~__context ~self
 
-      let sysprep ~__context ~self ~unattend =
+      let sysprep ~__context ~self ~unattend ~timeout =
         info "VM.sysprep: self = '%s'" (vm_uuid ~__context self) ;
-        let local_fn = Local.VM.sysprep ~self ~unattend in
-        let remote_fn = Client.VM.sysprep ~self ~unattend in
+        let local_fn = Local.VM.sysprep ~self ~unattend ~timeout in
+        let remote_fn = Client.VM.sysprep ~self ~unattend ~timeout in
         let policy = Helpers.Policy.fail_immediately in
         with_vm_operation ~__context ~self ~doc:"VM.sysprep" ~op:`sysprep
           ~policy (fun () ->

--- a/ocaml/xapi/vm_sysprep.mli
+++ b/ocaml/xapi/vm_sysprep.mli
@@ -27,7 +27,12 @@ exception Sysprep of error
 val on_startup : __context:Context.t -> unit
 (** clean up on toolstart start up *)
 
-val sysprep : __context:Context.t -> vm:API.ref_VM -> unattend:string -> unit
+val sysprep :
+     __context:Context.t
+  -> vm:API.ref_VM
+  -> unattend:string
+  -> timeout:float
+  -> unit
 (** Execute sysprep on [vm] using script [unattend]. This requires
     driver support from the VM and is checked. [unattend:string] must
     not exceed 32kb. Raised [Failure] that must be handled, *)

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1702,9 +1702,9 @@ let get_secureboot_readiness ~__context ~self =
       )
     )
 
-let sysprep ~__context ~self ~unattend =
+let sysprep ~__context ~self ~unattend ~timeout =
   let uuid = Db.VM.get_uuid ~__context ~self in
-  debug "%s %S" __FUNCTION__ uuid ;
+  debug "%s %S (timeout %f)" __FUNCTION__ uuid timeout ;
   match Vm_sysprep.sysprep ~__context ~vm:self ~unattend with
   | () ->
       debug "%s %S success" __FUNCTION__ uuid ;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1705,7 +1705,12 @@ let get_secureboot_readiness ~__context ~self =
 let sysprep ~__context ~self ~unattend ~timeout =
   let uuid = Db.VM.get_uuid ~__context ~self in
   debug "%s %S (timeout %f)" __FUNCTION__ uuid timeout ;
-  match Vm_sysprep.sysprep ~__context ~vm:self ~unattend with
+  if timeout < 0.0 then
+    raise
+      Api_errors.(
+        Server_error (invalid_value, ["timeout"; string_of_float timeout])
+      ) ;
+  match Vm_sysprep.sysprep ~__context ~vm:self ~unattend ~timeout with
   | () ->
       debug "%s %S success" __FUNCTION__ uuid ;
       ()

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -451,4 +451,9 @@ val add_to_blocked_operations :
 val remove_from_blocked_operations :
   __context:Context.t -> self:API.ref_VM -> key:API.vm_operations -> unit
 
-val sysprep : __context:Context.t -> self:API.ref_VM -> unattend:string -> unit
+val sysprep :
+     __context:Context.t
+  -> self:API.ref_VM
+  -> unattend:string
+  -> timeout:float
+  -> unit


### PR DESCRIPTION

Change in semantics: the API call now waits for the VM to shut down (by observing the xenstore tree being removed). This is guarded by a user-provided timeout.