### PR TITLE
Improve `other_operation_in_progress` error users, fix handling of its delays

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -538,7 +538,8 @@ let _ =
     ~doc:"You attempted an operation on a VM which is not suspendable." () ;
   error Api_errors.vm_is_template ["vm"]
     ~doc:"The operation attempted is not valid for a template VM" () ;
-  error Api_errors.other_operation_in_progress ["class"; "object"]
+  error Api_errors.other_operation_in_progress
+    ["class"; "object"; "operation_type"; "operation_ref"]
     ~doc:"Another operation involving the object is currently in progress" () ;
   error Api_errors.vbd_not_removable_media ["vbd"]
     ~doc:"Media could not be ejected because it is not removable" () ;

--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -1685,7 +1685,7 @@ module Repeat_with_uniform_backoff : POLICY = struct
     debug "Waiting for up to %f seconds before retrying..." this_timeout ;
     let start = Unix.gettimeofday () in
     ( match e with
-    | Api_errors.Server_error (code, [cls; objref])
+    | Api_errors.Server_error (code, cls :: objref :: _)
       when code = Api_errors.other_operation_in_progress ->
         Early_wakeup.wait (cls, objref) this_timeout
     | _ ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -5720,14 +5720,21 @@ functor
             if Helpers.i_am_srmaster ~__context ~sr then
               List.iter
                 (fun vdi ->
-                  if Db.VDI.get_current_operations ~__context ~self:vdi <> []
-                  then
-                    raise
-                      (Api_errors.Server_error
-                         ( Api_errors.other_operation_in_progress
-                         , [Datamodel_common._vdi; Ref.string_of vdi]
-                         )
-                      )
+                  match Db.VDI.get_current_operations ~__context ~self:vdi with
+                  | (op_ref, op_type) :: _ ->
+                      raise
+                        (Api_errors.Server_error
+                           ( Api_errors.other_operation_in_progress
+                           , [
+                               Datamodel_common._vdi
+                             ; Ref.string_of vdi
+                             ; API.vdi_operations_to_string op_type
+                             ; op_ref
+                             ]
+                           )
+                        )
+                  | [] ->
+                      ()
                 )
                 (Db.SR.get_VDIs ~__context ~self:sr) ;
             SR.mark_sr ~__context ~sr ~doc ~op

--- a/ocaml/xapi/xapi_cluster_helpers.ml
+++ b/ocaml/xapi/xapi_cluster_helpers.ml
@@ -24,19 +24,23 @@ let is_allowed_concurrently ~op:_ ~current_ops:_ =
   false
 
 let report_concurrent_operations_error ~current_ops ~ref_str =
-  let current_ops_str =
+  let current_ops_ref_str, current_ops_str =
     let op_to_str = Record_util.cluster_operation_to_string in
+    let ( >> ) f g x = g (f x) in
     match current_ops with
     | [] ->
         failwith "No concurrent operation to report"
-    | [(_, cop)] ->
-        op_to_str cop
+    | [(op_ref, cop)] ->
+        (op_ref, op_to_str cop)
     | l ->
-        "{" ^ String.concat "," (List.map op_to_str (List.map snd l)) ^ "}"
+        ( Printf.sprintf "{%s}" (String.concat "," (List.map fst l))
+        , Printf.sprintf "{%s}"
+            (String.concat "," (List.map (snd >> op_to_str) l))
+        )
   in
   Some
     ( Api_errors.other_operation_in_progress
-    , ["Cluster." ^ current_ops_str; ref_str]
+    , ["Cluster"; ref_str; current_ops_str; current_ops_ref_str]
     )
 
 (** Take an internal Cluster record and a proposed operation. Return None iff the operation

--- a/ocaml/xapi/xapi_pif.ml
+++ b/ocaml/xapi/xapi_pif.ml
@@ -926,17 +926,25 @@ let assert_cluster_host_operation_not_in_progress ~__context =
   match Db.Cluster.get_all ~__context with
   | [] ->
       ()
-  | cluster :: _ ->
-      let ops =
-        Db.Cluster.get_current_operations ~__context ~self:cluster
-        |> List.map snd
-      in
-      if List.mem `enable ops || List.mem `add ops then
-        raise
-          Api_errors.(
-            Server_error
-              (other_operation_in_progress, ["Cluster"; Ref.string_of cluster])
-          )
+  | cluster :: _ -> (
+      let ops = Db.Cluster.get_current_operations ~__context ~self:cluster in
+      match List.find_opt (fun (_, op) -> op = `enable || op = `add) ops with
+      | Some (op_ref, op_type) ->
+          raise
+            Api_errors.(
+              Server_error
+                ( other_operation_in_progress
+                , [
+                    "Cluster"
+                  ; Ref.string_of cluster
+                  ; API.cluster_operation_to_string op_type
+                  ; op_ref
+                  ]
+                )
+            )
+      | None ->
+          ()
+    )
 
 (* Block allowing unplug if
    - a cluster host is enabled on this PIF

--- a/quality-gate.sh
+++ b/quality-gate.sh
@@ -3,7 +3,7 @@
 set -e
 
 list-hd () {
-  N=279
+  N=274
   LIST_HD=$(git grep -r --count 'List.hd' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc)
   if [ "$LIST_HD" -eq "$N" ]; then
     echo "OK counted $LIST_HD List.hd usages"


### PR DESCRIPTION
`other_operation_in_progress` is reported inconsistently, with some users only specifying `[class; class_ref]`, and others also `op_type`. Make it consistent, changing all users to report `[class; class_ref; op_type; op_ref]`. This makes it much easier to navigate the logs, since the operation blocking progress is clearly referenced. 

Compare before, where it's unclear which operation is precluding progress:
```
Caught exception while marking SR for VDI.clone in message forwarder:
OTHER_OPERATION_IN_PROGRESS:
[ SR; OpaqueRef:d019f26a-b2e8-529b-bb66-fd4f008d4f82; VDI.clone ]
```

And after, with the ID of the operation present:
```
Caught exception while marking SR for VDI.clone in message forwarder:
OTHER_OPERATION_IN_PROGRESS:
[ SR; OpaqueRef:b0f54a40-485f-f48f-fdc7-6db28a64d3fd;
  scan; OpaqueRef:832fb22d-2ce5-0d26-8a00-a4165e78b34d ]
```

In addition, fix incorrect operation reporting, so that when progress is blocked only when particular types of operations are present in `current_operations`, these specific operations are reported, and not just any current operation.

Also fix handling of `other_operation_in_progress` delays - some of the users would miss the `match` arm and use the non-interruptible `Thread.sleep`  instead of the interruptible `Delay.sleep` that provides a mechanism for the blocking task to wake us up on its way out.