### PR TITLE
CA-413713: Change bash-completion shortcut

### DIFF
--- a/ocaml/xe-cli/bash-completion
+++ b/ocaml/xe-cli/bash-completion
@@ -909,4 +909,4 @@ __autocomplete_reqd_params_names()
     return 0
 }
 
-bind -x '"\C-rq":"__autocomplete_reqd_params_names"'
+bind -x '"\eq":"__autocomplete_reqd_params_names"'


### PR DESCRIPTION
The shortcut to show required parameters is Ctrl-rq but this conflicts with the default readline shortcut for reverse-search-history. Usually, it finds the first match but subsequent presses of Ctrl-r do not find any further matches.

Fix this by switching to Meta-q (aka Alt-q or Esc-q) which is unused.