### PR TITLE
Add message argument to LICENSE_CHECKOUT_ERROR

### DIFF
--- a/ocaml/idl/datamodel_errors.ml
+++ b/ocaml/idl/datamodel_errors.ml
@@ -68,7 +68,7 @@ let _ =
       "The license-server connection details (address or port) were missing or \
        incomplete."
     () ;
-  error Api_errors.license_checkout_error ["reason"]
+  error Api_errors.license_checkout_error ["code"; "message"]
     ~doc:"The license for the edition you requested is not available." () ;
   error Api_errors.license_file_deprecated []
     ~doc:

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -5338,9 +5338,8 @@ let with_license_server_changes printer rpc session_id params hosts f =
           )
           hosts
   ) ;
-  let now = Unix.gettimeofday () in
   try f rpc session_id with
-  | Api_errors.Server_error (name, _) as e
+  | Api_errors.Server_error (name, [_; msg])
     when name = Api_errors.license_checkout_error ->
       (* Put back original license_server_details *)
       List.iter
@@ -5349,28 +5348,8 @@ let with_license_server_changes printer rpc session_id params hosts f =
             ~value:license_server
         )
         current_license_servers ;
-      let alerts =
-        Client.Message.get_since ~rpc ~session_id
-          ~since:(Date.of_unix_time (now -. 1.))
-      in
-      let print_if_checkout_error (ref, msg) =
-        if
-          false
-          || msg.API.message_name = fst Api_messages.v6_rejected
-          || msg.API.message_name = fst Api_messages.v6_comm_error
-          || msg.API.message_name
-             = fst Api_messages.v6_license_server_version_obsolete
-        then (
-          Client.Message.destroy ~rpc ~session_id ~self:ref ;
-          printer (Cli_printer.PStderr (msg.API.message_body ^ "\n"))
-        )
-      in
-      if alerts = [] then
-        raise e
-      else (
-        List.iter print_if_checkout_error alerts ;
-        raise (ExitWithError 1)
-      )
+      printer (Cli_printer.PStderr (msg ^ "\n")) ;
+      raise (ExitWithError 1)
   | Api_errors.Server_error (name, _) as e
     when name = Api_errors.invalid_edition ->
       let host = get_host_from_session rpc session_id in

--- a/ocaml/xapi-idl/v6/v6_interface.ml
+++ b/ocaml/xapi-idl/v6/v6_interface.ml
@@ -78,7 +78,8 @@ type errors =
       (** Thrown by license_check when expiry date matches or precedes current
           date *)
   | License_processing_error  (** License could not be processed *)
-  | License_checkout_error of string  (** License could not be checked out *)
+  | License_checkout_error of string * string
+      (** License could not be checked out *)
   | Missing_connection_details
       (** Thrown if connection port or address parameter not supplied to
           check_license *)

--- a/ocaml/xapi/xapi_host.ml
+++ b/ocaml/xapi/xapi_host.ml
@@ -2079,8 +2079,8 @@ let apply_edition_internal ~__context ~host ~edition ~additional =
         raise Api_errors.(Server_error (license_processing_error, []))
     | V6_interface.(V6_error Missing_connection_details) ->
         raise Api_errors.(Server_error (missing_connection_details, []))
-    | V6_interface.(V6_error (License_checkout_error s)) ->
-        raise Api_errors.(Server_error (license_checkout_error, [s]))
+    | V6_interface.(V6_error (License_checkout_error (code, msg))) ->
+        raise Api_errors.(Server_error (license_checkout_error, [code; msg]))
     | V6_interface.(V6_error (Internal_error e)) ->
         Helpers.internal_error "%s" e
   in


### PR DESCRIPTION
The first argument of this API error is used for error codes as defined by v6d. These product-specific error codes can be matched on by clients who know about them (e.g. XenCenter for XenServer).

The new, second argument allows v6d to return an error message in English that xe can print directly, while xe remains product agnostic and does not need to know v6d's error definitions. This replaces some awkward API-message handling code in cli_operations.