### PR TITLE
CP-52334 MVD - add -d option to mock driver-tool

### DIFF
--- a/ocaml/xapi/xapi_host_driver_tool.ml
+++ b/ocaml/xapi/xapi_host_driver_tool.ml
@@ -243,6 +243,15 @@ module Mock = struct
 set -o errexit
 set -o pipefail
 
+function deselect {
+  cat <<EOF
+{
+  "driver": "$1",
+  "exit": 0
+}
+EOF
+}
+
 function selection {
   cat <<EOF
 {
@@ -252,6 +261,7 @@ function selection {
 }
 EOF
 }
+
 
 function list() {
   cat <<EOF
@@ -606,9 +616,10 @@ l_flag=false
 s_flag=false
 n_value=""
 v_value=""
+d_value=""
 
 # Use getopt to parse command-line options
-while getopts "lsn:v:" opt; do
+while getopts "lsn:v:d:" opt; do
   case "$opt" in
     l)
       l_flag=true
@@ -621,6 +632,9 @@ while getopts "lsn:v:" opt; do
       ;;
     v)
       v_value="$OPTARG"
+      ;;
+    d)
+      d_value="$OPTARG"
       ;;
     \?)  # Invalid option
       echo "Invalid option: -$OPTARG" >&2  #>&2 redirects error message to stderr
@@ -654,6 +668,11 @@ if $s_flag; then
   fi
 
   selection "$n_value" "$v_value"
+  exit 0
+fi
+
+if [ -n "$d_value" ]; then
+  deselect "$d_value"
   exit 0
 fi
 |}


### PR DESCRIPTION
The API supports a driver deselect call for which Xapi  calls the underlying driver-tool. The mock driver is missing the corresponding -d option, which this patch adds. This fixes an internal error that Xapi raises otherwise.

An alternative would be to ignore the error from the driver-tool.