### PR TITLE
CA-412420: Set vdi-type When Create snapshot on SMAPIv3 SR

### DIFF
--- a/ocaml/xapi-storage-script/main.ml
+++ b/ocaml/xapi-storage-script/main.ml
@@ -1447,6 +1447,9 @@ module VDIImpl (M : META) = struct
            set ~dbg ~sr ~vdi:response.Xapi_storage.Control.key
              ~key:_vdi_content_id_key ~value:vdi_info.content_id
            >>>= fun () ->
+           set ~dbg ~sr ~vdi:response.Xapi_storage.Control.key
+             ~key:_vdi_type_key ~value:vdi_info.ty
+           >>>= fun () ->
            let response =
              {
                (vdi_of_volume response) with


### PR DESCRIPTION
During the SMAPIv3 migration prepare step, it will create the VDI on the destination based on the source. The source retrieves vdi_info via `copy_into_sr` → `find_vdi` → `SR.scan2` → `sr_scan2_impl` → `COWVolume.ls`, and `sr_ls` extracts all vdi_info from the database.

However, when creating a snapshot with `COWVolume.snapshot` on V3, the vdi-type is not stored in the database, which causes getting an empty vdi-type and the migration prepare step to fail and result the folllowing error:

`\'INTERNAL_ERROR\', \'Failure("Unknown tag/contents")\']]);S()]]]))]))]))])`

This change adds a step to set vdi-type from the original VDI to the snapshot VDI to prevent this issue.