### PR TITLE
CA-413424: Enhance xe help output

### DIFF
--- a/ocaml/xapi-cli-server/cli_frontend.ml
+++ b/ocaml/xapi-cli-server/cli_frontend.ml
@@ -4047,6 +4047,26 @@ let rio_help printer minimal cmd =
     let cmds =
       List.sort (fun (name1, _) (name2, _) -> compare name1 name2) cmds
     in
+    let help =
+      Printf.sprintf
+        {|Usage: 
+  %s <command>
+    [ -s <server> ]            XenServer host
+    [ -p <port> ]              XenServer port number
+    [ -u <username> -pw <password> | -pwf <password file> ]
+                               User authentication (password or file)
+    [ --nossl ]                Disable SSL/TLS
+    [ --debug ]                Enable debug output
+    [ --debug-on-fail ]        Enable debug output only on failure
+    [ --traceparent <value> ]  Distributed tracing context
+    [ <other arguments> ... ]  Command-specific options
+
+To get help on a specific command: 
+  %s help <command>
+
+|}
+        cmd.argv0 cmd.argv0
+    in
     if List.mem_assoc "all" cmd.params && List.assoc "all" cmd.params = "true"
     then
       let cmds = List.map fst cmds in
@@ -4056,20 +4076,9 @@ let rio_help printer minimal cmd =
       let vm_cmds, other =
         List.partition (fun n -> Astring.String.is_prefix ~affix:"vm-" n) other
       in
-      let h =
-        "Usage: "
-        ^ cmd.argv0
-        ^ " <command> [-s server] [-pw passwd] [-p port] [-u user] [-pwf \
-           password-file]\n"
-      in
-      let h = h ^ "  [command specific arguments]\n\n" in
-      let h =
-        h
-        ^ "To get help on a specific command: "
-        ^ cmd.argv0
-        ^ " help <command>\n\n"
-      in
-      let h = h ^ "Full command list\n-----------------" in
+      let h = help ^ {|Full command list
+-----------------
+|} in
       if minimal then
         printer (Cli_printer.PList cmds)
       else (
@@ -4086,25 +4095,16 @@ let rio_help printer minimal cmd =
       in
       let cmds = List.map fst cmds in
       let h =
-        "Usage: "
-        ^ cmd.argv0
-        ^ " <command> [-s server] [-pw passwd] [-p port] [-u user] [-pwf \
-           password-file]\n"
+        help
+        ^ Printf.sprintf
+            {|To get a full listing of commands:
+  %s help --all
+
+Common command list
+-------------------
+|}
+            cmd.argv0
       in
-      let h = h ^ "  [command specific arguments]\n\n" in
-      let h =
-        h
-        ^ "To get help on a specific command: "
-        ^ cmd.argv0
-        ^ " help <command>\n"
-      in
-      let h =
-        h
-        ^ "To get a full listing of commands: "
-        ^ cmd.argv0
-        ^ " help --all\n\n"
-      in
-      let h = h ^ "Common command list\n-------------------" in
       if minimal then
         printer (Cli_printer.PList cmds)
       else (

--- a/ocaml/xe-cli/newcli.ml
+++ b/ocaml/xe-cli/newcli.ml
@@ -66,24 +66,26 @@ let debug fmt =
 exception Usage
 
 let usage () =
-  error
-    "Usage:\n\
-    \  %s <command>\n\
-    \    [ -s <server> ]            XenServer host \n\
-    \    [ -p <port> ]              XenServer port number \n\
-    \    [ -u <username> -pw <password> | -pwf <password file> ] \n\
-    \                               User authentication (password or file) \n\
-    \    [ --nossl ]                Disable SSL/TLS \n\
-    \    [ --debug ]                Enable debug output \n\
-    \    [ --debug-on-fail ]        Enable debug output only on failure \n\
-    \    [ --traceparent <value> ]  Distributed tracing context \n\
-    \    [ <other arguments> ... ]  Command-specific options \n"
-    Sys.argv.(0) ;
-  error
-    "\n\
-     A full list of commands can be obtained by running \n\
-    \  %s help -s <server> -p <port>\n"
-    Sys.argv.(0)
+  let help =
+    Printf.sprintf
+      {|Usage: 
+  %s <command>
+    [ -s <server> ]            XenServer host
+    [ -p <port> ]              XenServer port number
+    [ -u <username> -pw <password> | -pwf <password file> ]
+                               User authentication (password or file)
+    [ --nossl ]                Disable SSL/TLS
+    [ --debug ]                Enable debug output
+    [ --debug-on-fail ]        Enable debug output only on failure
+    [ --traceparent <value> ]  Distributed tracing context
+    [ <other arguments> ... ]  Command-specific options
+
+A full list of commands can be obtained by running
+  %s help -s <server> -p <port>
+|}
+      Sys.argv.(0) Sys.argv.(0)
+  in
+  error "%s" help
 
 let is_localhost ip = ip = "127.0.0.1"
 


### PR DESCRIPTION
The previous `xe` help is as below:
```
Usage: xe <cmd> [-s server] [-p port] ([-u username] [-pw password] or [-pwf <password file>]) [--traceparent traceparent] <other arguments>

A full list of commands can be obtained by running
	xe help -s <server> -p <port>
```

The previous `xe` help output lacked debug-related options and did not provide detailed parameter description.
The new `xe` help output is as follows:
```
Usage:
  xe <command>
    [ -s <server> ]            XenServer host
    [ -p <port> ]              XenServer port number
    [ -u <username> -pw <password> | -pwf <password file> ]
                               User authentication (password or file)
    [ --nossl ]                Disable SSL/TLS
    [ --debug ]                Enable debug output
    [ --debug-on-fail ]        Enable debug output only on failure
    [ --traceparent <value> ]  Distributed tracing context
    [ <other arguments> ... ]  Command-specific options

A full list of commands can be obtained by running
  xe help -s <server> -p <port>
```