### PR TITLE
CA-414418: Sessions do not got destroyed after domain  user been removed and performance improvement

### DIFF
--- a/ocaml/xapi/xapi_session.ml
+++ b/ocaml/xapi/xapi_session.ml
@@ -472,15 +472,7 @@ let revalidate_external_session ~__context ~session =
 
           (* CP-827: if the user was suspended (disabled,expired,locked-out), then we must destroy the session *)
           let suspended, _ =
-            is_subject_suspended ~__context ~cache:true authenticated_user_sid
-          in
-          let suspended =
-            if suspended then
-              is_subject_suspended ~__context ~cache:false
-                authenticated_user_sid
-              |> fst
-            else
-              suspended
+            is_subject_suspended ~__context ~cache:false authenticated_user_sid
           in
           if suspended then (
             debug


### PR DESCRIPTION
```
commit 92377bfe2fffd762ab922a015a93afa314ae000f (HEAD -> private/linl/CA-414418, origin/private/linl/CA-414418)
Author: Lin Liu <Lin.Liu01@cloud.com>
Date:   Thu Jul 31 07:25:30 2025 +0000

    CA-414418: Perf: save user validate result and apply to sessions
    
    For all sessions created by external/AD users, session revalidate
    will check whether the users are still acitve, and kick off the
    session accordingly.
    
    However, xapi check the user for every session. The problem here
    is lots of session are created by only a few users. (for the case
    of CVAD and ControlUP). This would cause lot of duplicated check
    for the same user again and again, which is slow and waste lots
    of resources.
    
    To fix the issue, [(user_sid, check_result)] is defined for every
    round of check. The check result is saved so later check for the
    session with same user can just be applied.
    
    Signed-off-by: Lin Liu <Lin.Liu01@cloud.com>

commit b0e2b5bfd2791dfa38ee9e4c9cd9480f7a01016e
Author: Lin Liu <Lin.Liu01@cloud.com>
Date:   Thu Jul 31 06:17:32 2025 +0000

    CA-414418: Detection of AD account removal does not cause logout
    
    For performance, during revalidate existing sessions, xapi query
    subject details from xapi db first, if the subject is suspend,
    then goes to AD, to make sure unblocked user can login.
    
    There is a backend thread to update xapi db subject information
    from AD. However, it can not handle the case that the subject
    is removed. (and should not remove the subject for user until
    user remove it explictly). Thus, the subject information is not
    updated and keep alive.
    
    In this case, subject revalidate always got session not suspend
    from xapi db.
    
    The issue is fixed by query subject information from AD direclty,
    and session revalidate thread handle the removed subject properly
    to kick off the sessions
    
    For performance, there is a follow up commit to resovle that
    
    Signed-off-by: Lin Liu <Lin.Liu01@cloud.com>
    ```