### PR TITLE
CP-308927 Add nr_nodes in host.cpu_info to expose numa nodes count

### DIFF
--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -43,6 +43,7 @@ let default_cpu_info =
     ("cpu_count", "0")
   ; ("socket_count", "0")
   ; ("threads_per_core", "0")
+  ; ("nr_nodes", "0")
   ; ("vendor", "Abacus")
   ; ("speed", "")
   ; ("modelname", "")
@@ -79,6 +80,7 @@ let make_localhost ~__context ?(features = Features.all_features) () =
             cpu_count= 1
           ; socket_count= 1
           ; threads_per_core= 1
+          ; nr_nodes= 1
           ; vendor= ""
           ; speed= ""
           ; modelname= ""

--- a/ocaml/xapi-idl/xen/xenops_interface.ml
+++ b/ocaml/xapi-idl/xen/xenops_interface.ml
@@ -453,6 +453,7 @@ module Host = struct
       cpu_count: int
     ; socket_count: int
     ; threads_per_core: int
+    ; nr_nodes: int
     ; vendor: string
     ; speed: string
     ; modelname: string

--- a/ocaml/xapi/cpuid_helpers.ml
+++ b/ocaml/xapi/cpuid_helpers.ml
@@ -42,6 +42,8 @@ let socket_count = Map_check.(field "socket_count" int)
 
 let threads_per_core = Map_check.(field "threads_per_core" int)
 
+let nr_nodes = Map_check.(field "nr_nodes" int)
+
 let vendor = Map_check.(field "vendor" string)
 
 let get_flags_for_vm ~__context domain_type cpu_info =

--- a/ocaml/xapi/cpuid_helpers.mli
+++ b/ocaml/xapi/cpuid_helpers.mli
@@ -31,6 +31,8 @@ val socket_count : int Map_check.field
 
 val threads_per_core : int Map_check.field
 
+val nr_nodes : int Map_check.field
+
 val features : [`vm] Xenops_interface.CPU_policy.t Map_check.field
 
 val features_pv : [`host] Xenops_interface.CPU_policy.t Map_check.field

--- a/ocaml/xapi/create_misc.ml
+++ b/ocaml/xapi/create_misc.ml
@@ -572,6 +572,7 @@ let create_host_cpu ~__context host_info =
           ("cpu_count", string_of_int cpu_info.cpu_count)
         ; ("socket_count", string_of_int cpu_info.socket_count)
         ; ("threads_per_core", string_of_int cpu_info.threads_per_core)
+        ; ("nr_nodes", string_of_int cpu_info.nr_nodes)
         ; ("vendor", cpu_info.vendor)
         ; ("speed", cpu_info.speed)
         ; ("modelname", cpu_info.modelname)
@@ -597,11 +598,12 @@ let create_host_cpu ~__context host_info =
       let old_cpu_info = Db.Host.get_cpu_info ~__context ~self:host in
       debug
         "create_host_cpuinfo: setting host cpuinfo: socket_count=%d, \
-         cpu_count=%d, threads_per_core=%d, features_hvm=%s, features_pv=%s, \
-         features_hvm_host=%s, features_pv_host=%s"
+         cpu_count=%d, threads_per_core=%d, nr_nodes=%d, features_hvm=%s, \
+         features_pv=%s, features_hvm_host=%s, features_pv_host=%s"
         (Map_check.getf socket_count cpu)
         (Map_check.getf cpu_count cpu)
         (Map_check.getf threads_per_core cpu)
+        (Map_check.getf nr_nodes cpu)
         (Map_check.getf features_hvm cpu |> CPU_policy.to_string)
         (Map_check.getf features_pv cpu |> CPU_policy.to_string)
         (Map_check.getf features_hvm_host cpu |> CPU_policy.to_string)

--- a/ocaml/xenopsd/lib/xenops_server_skeleton.ml
+++ b/ocaml/xenopsd/lib/xenops_server_skeleton.ml
@@ -27,6 +27,7 @@ module HOST = struct
           Host.cpu_count= 0
         ; socket_count= 0
         ; threads_per_core= 0
+        ; nr_nodes= 0
         ; vendor= "unknown"
         ; speed= ""
         ; modelname= ""

--- a/ocaml/xenopsd/xc/xenctrlext.ml
+++ b/ocaml/xenopsd/xc/xenctrlext.ml
@@ -131,3 +131,7 @@ let domain_claim_pages handle domid ?(numa_node = NumaNode.none) nr_pages =
   if numa_node <> NumaNode.none then
     raise Not_available ;
   stub_domain_claim_pages handle domid numa_node nr_pages
+
+let get_nr_nodes handle =
+  let info = numainfo handle in
+  Array.length info.memory

--- a/ocaml/xenopsd/xc/xenctrlext.mli
+++ b/ocaml/xenopsd/xc/xenctrlext.mli
@@ -108,3 +108,6 @@ val domain_claim_pages : handle -> domid -> ?numa_node:NumaNode.t -> int -> unit
 (** Raises {Unix_error} if there's not enough memory to claim in the system.
     Raises {Not_available} if a single numa node is requested and xen does not
     provide page claiming for single numa nodes. *)
+
+val get_nr_nodes : handle -> int
+(** Returns the count of NUMA nodes available in the system. *)

--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
+++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
@@ -989,6 +989,7 @@ module HOST = struct
           p.nr_cpus / (p.threads_per_core * p.cores_per_socket)
         in
         let threads_per_core = p.threads_per_core in
+        let nr_nodes = Xenctrlext.(get_handle () |> get_nr_nodes) in
         let features = get_cpu_featureset xc Featureset_host in
         (* this is Default policy in Xen's terminology, used on boot for new VMs *)
         let features_pv_host = get_cpu_featureset xc Featureset_pv in
@@ -1017,6 +1018,7 @@ module HOST = struct
               Host.cpu_count
             ; socket_count
             ; threads_per_core
+            ; nr_nodes
             ; vendor
             ; speed
             ; modelname


### PR DESCRIPTION
`host.cpu_info` is a map that contains details about the physical CPUs on this host. This PR adds a key of nr_nodes in the field to expose numa nodes count.
Use `Xenctrlext.numainfo` to get the array size of numainfo.memory, see https://github.com/xapi-project/xen-api/blob/v25.26.0/ocaml/xenopsd/c_stubs/xenctrlext_stubs.c#L395