### PR TITLE
CP-308857: Update xapi to align with xen patch

### DIFF
--- a/ocaml/xcp-rrdd/bin/rrdp-cpu/rrdp_cpu.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-cpu/rrdp_cpu.ml
@@ -20,7 +20,7 @@ module Process = Rrdd_plugin.Process (struct let name = "xcp-rrdd-cpu" end)
 
 let xen_flag_complement = Int64.(shift_left 1L 63 |> lognot)
 
-(* This function is used for getting vcpu stats of the VMs present on this host. *)
+(* This function is used for getting vCPU stats of the VMs present on this host. *)
 let dss_vcpus xc doms =
   List.fold_left
     (fun dss (dom, uuid, domid) ->
@@ -49,7 +49,7 @@ let dss_vcpus xc doms =
           in
           cpus (i + 1) (cputime_rrd :: dss)
       in
-      (* Runstate info is per-domain rather than per-vcpu *)
+      (* Runstate info is per-domain rather than per-vCPU *)
       let dss =
         let dom_cpu_time =
           Int64.(to_float @@ logand dom.Xenctrl.cpu_time xen_flag_complement)
@@ -62,14 +62,14 @@ let dss_vcpus xc doms =
           ( Rrd.VM uuid
           , Ds.ds_make ~name:"runstate_fullrun" ~units:"(fraction)"
               ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time0 /. 1.0e9))
-              ~description:"Fraction of time that all VCPUs are running"
+              ~description:"Fraction of time that all vCPUs are running"
               ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
           )
           :: ( Rrd.VM uuid
              , Ds.ds_make ~name:"runstate_full_contention" ~units:"(fraction)"
                  ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time1 /. 1.0e9))
                  ~description:
-                   "Fraction of time that all VCPUs are runnable (i.e., \
+                   "Fraction of time that all vCPUs are runnable (i.e., \
                     waiting for CPU)"
                  ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
              )
@@ -78,7 +78,7 @@ let dss_vcpus xc doms =
                  ~units:"(fraction)"
                  ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time2 /. 1.0e9))
                  ~description:
-                   "Fraction of time that some VCPUs are running and some are \
+                   "Fraction of time that some vCPUs are running and some are \
                     runnable"
                  ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
              )
@@ -86,14 +86,14 @@ let dss_vcpus xc doms =
              , Ds.ds_make ~name:"runstate_blocked" ~units:"(fraction)"
                  ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time3 /. 1.0e9))
                  ~description:
-                   "Fraction of time that all VCPUs are blocked or offline"
+                   "Fraction of time that all vCPUs are blocked or offline"
                  ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
              )
           :: ( Rrd.VM uuid
              , Ds.ds_make ~name:"runstate_partial_run" ~units:"(fraction)"
                  ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time4 /. 1.0e9))
                  ~description:
-                   "Fraction of time that some VCPUs are running, and some are \
+                   "Fraction of time that some vCPUs are running and some are \
                     blocked"
                  ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
              )
@@ -102,7 +102,7 @@ let dss_vcpus xc doms =
                  ~units:"(fraction)"
                  ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time5 /. 1.0e9))
                  ~description:
-                   "Fraction of time that some VCPUs are runnable and some are \
+                   "Fraction of time that some vCPUs are runnable and some are \
                     blocked"
                  ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
              )

--- a/ocaml/xcp-rrdd/bin/rrdp-cpu/rrdp_cpu.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-cpu/rrdp_cpu.ml
@@ -57,6 +57,7 @@ let dss_vcpus xc doms =
         let dom_cpu_time =
           dom_cpu_time /. (1.0e9 *. float_of_int dom.Xenctrl.nr_online_vcpus)
         in
+        let ( ++ ) = Int64.add in
         try
           let ri = Xenctrl.domain_get_runstate_info xc domid in
           ( Rrd.VM uuid
@@ -104,6 +105,23 @@ let dss_vcpus xc doms =
                  ~description:
                    "Fraction of time that some vCPUs are runnable and some are \
                     blocked"
+                 ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
+             )
+          :: ( Rrd.VM uuid
+             , Ds.ds_make ~name:"runnable_any" ~units:"(fraction)"
+                 ~value:
+                   (Rrd.VT_Float
+                      (Int64.to_float
+                         (ri.Xenctrl.time1
+                         ++ ri.Xenctrl.time2
+                         ++ ri.Xenctrl.time5
+                         )
+                      /. 1.0e9
+                      )
+                   )
+                 ~description:
+                   "Fraction of time that at least one vCPU is runnable in the \
+                    domain"
                  ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
              )
           :: ( Rrd.VM uuid

--- a/ocaml/xcp-rrdd/bin/rrdp-cpu/rrdp_cpu.ml
+++ b/ocaml/xcp-rrdd/bin/rrdp-cpu/rrdp_cpu.ml
@@ -59,9 +59,9 @@ let dss_vcpus xc doms =
         in
         let ( ++ ) = Int64.add in
         try
-          let ri = Xenctrl.domain_get_runstate_info xc domid in
+          let ri = Xenctrl.Runstateinfo.V2.domain_get xc domid in
           let runnable_vcpus_ds =
-            match ri.Xenctrl.runnable with
+            match ri.Xenctrl.Runstateinfo.V2.runnable with
             | 0L ->
                 []
             | _ ->
@@ -70,7 +70,9 @@ let dss_vcpus xc doms =
                   , Ds.ds_make ~name:"runnable_vcpus" ~units:"(fraction)"
                       ~value:
                         (Rrd.VT_Float
-                           (Int64.to_float ri.Xenctrl.runnable /. 1.0e9)
+                           (Int64.to_float ri.Xenctrl.Runstateinfo.V2.runnable
+                           /. 1.0e9
+                           )
                         )
                       ~description:
                         "Fraction of time that vCPUs of the domain are runnable"
@@ -80,13 +82,19 @@ let dss_vcpus xc doms =
           in
           ( Rrd.VM uuid
           , Ds.ds_make ~name:"runstate_fullrun" ~units:"(fraction)"
-              ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time0 /. 1.0e9))
+              ~value:
+                (Rrd.VT_Float
+                   (Int64.to_float ri.Xenctrl.Runstateinfo.V2.time0 /. 1.0e9)
+                )
               ~description:"Fraction of time that all vCPUs are running"
               ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
           )
           :: ( Rrd.VM uuid
              , Ds.ds_make ~name:"runstate_full_contention" ~units:"(fraction)"
-                 ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time1 /. 1.0e9))
+                 ~value:
+                   (Rrd.VT_Float
+                      (Int64.to_float ri.Xenctrl.Runstateinfo.V2.time1 /. 1.0e9)
+                   )
                  ~description:
                    "Fraction of time that all vCPUs are runnable (i.e., \
                     waiting for CPU)"
@@ -95,7 +103,10 @@ let dss_vcpus xc doms =
           :: ( Rrd.VM uuid
              , Ds.ds_make ~name:"runstate_concurrency_hazard"
                  ~units:"(fraction)"
-                 ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time2 /. 1.0e9))
+                 ~value:
+                   (Rrd.VT_Float
+                      (Int64.to_float ri.Xenctrl.Runstateinfo.V2.time2 /. 1.0e9)
+                   )
                  ~description:
                    "Fraction of time that some vCPUs are running and some are \
                     runnable"
@@ -103,14 +114,20 @@ let dss_vcpus xc doms =
              )
           :: ( Rrd.VM uuid
              , Ds.ds_make ~name:"runstate_blocked" ~units:"(fraction)"
-                 ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time3 /. 1.0e9))
+                 ~value:
+                   (Rrd.VT_Float
+                      (Int64.to_float ri.Xenctrl.Runstateinfo.V2.time3 /. 1.0e9)
+                   )
                  ~description:
                    "Fraction of time that all vCPUs are blocked or offline"
                  ~ty:Rrd.Derive ~default:false ~min:0.0 ~max:1.0 ()
              )
           :: ( Rrd.VM uuid
              , Ds.ds_make ~name:"runstate_partial_run" ~units:"(fraction)"
-                 ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time4 /. 1.0e9))
+                 ~value:
+                   (Rrd.VT_Float
+                      (Int64.to_float ri.Xenctrl.Runstateinfo.V2.time4 /. 1.0e9)
+                   )
                  ~description:
                    "Fraction of time that some vCPUs are running and some are \
                     blocked"
@@ -119,7 +136,10 @@ let dss_vcpus xc doms =
           :: ( Rrd.VM uuid
              , Ds.ds_make ~name:"runstate_partial_contention"
                  ~units:"(fraction)"
-                 ~value:(Rrd.VT_Float (Int64.to_float ri.Xenctrl.time5 /. 1.0e9))
+                 ~value:
+                   (Rrd.VT_Float
+                      (Int64.to_float ri.Xenctrl.Runstateinfo.V2.time5 /. 1.0e9)
+                   )
                  ~description:
                    "Fraction of time that some vCPUs are runnable and some are \
                     blocked"
@@ -130,9 +150,9 @@ let dss_vcpus xc doms =
                  ~value:
                    (Rrd.VT_Float
                       (Int64.to_float
-                         (ri.Xenctrl.time1
-                         ++ ri.Xenctrl.time2
-                         ++ ri.Xenctrl.time5
+                         (ri.Xenctrl.Runstateinfo.V2.time1
+                         ++ ri.Xenctrl.Runstateinfo.V2.time2
+                         ++ ri.Xenctrl.Runstateinfo.V2.time5
                          )
                       /. 1.0e9
                       )


### PR DESCRIPTION
Xenctrl.Runstateinfo.V2.domain_get is added in xen patch for querying runnable time of vCPUs of a domain.