### PR TITLE
CP-308485: Force xcp-networkd to use only OVS

### DIFF
--- a/ocaml/networkd/bin/network_server.ml
+++ b/ocaml/networkd/bin/network_server.ml
@@ -30,6 +30,8 @@ let write_lock = ref false
 
 let backend_kind = ref Openvswitch
 
+let support_linux_bridge = ref true
+
 let write_config () =
   if not !write_lock then
     try Network_config.write_config !config
@@ -803,8 +805,12 @@ module Bridge = struct
       match backend with
       | "openvswitch" | "vswitch" ->
           backend_kind := Openvswitch
-      | "bridge" ->
+      | "bridge" when !support_linux_bridge ->
           backend_kind := Bridge
+      | "bridge" when not !support_linux_bridge ->
+          (* XS 9 and later XS version does not support Linux bridge.*)
+          error "The network backend does not support Linux bridge anymore." ;
+          raise (Network_error Bridge_not_supported)
       | backend ->
           warn "Network backend unknown (%s). Falling back to Open vSwitch."
             backend ;

--- a/ocaml/networkd/bin/networkd.ml
+++ b/ocaml/networkd/bin/networkd.ml
@@ -146,6 +146,13 @@ let options =
       )
     , "JSON RPC write timeout value in ms"
     )
+  ; ( "support-linux-bridge"
+    , Arg.Bool (fun b -> Network_server.support_linux_bridge := b)
+    , (fun () -> string_of_bool !Network_server.support_linux_bridge)
+    , "Used to determine if the Linux bridge is supported. true if networkd \
+       selects the network backend (OVS or bridge) based on network-conf file \
+       content. false if networkd only supports OVS"
+    )
   ]
 
 let start server =

--- a/ocaml/xapi-idl/network/network_interface.ml
+++ b/ocaml/xapi-idl/network/network_interface.ml
@@ -268,6 +268,7 @@ type errors =
   | Interface_does_not_exist of string
       (** The named network interface does not exist *)
   | Bridge_does_not_exist of string  (** The named bridge does not exist *)
+  | Bridge_not_supported  (** The bridge is not supported *)
   | Internal_error of string
   | Unknown_error  (** The default variant for forward compatibility. *)
 [@@default Unknown_error] [@@deriving rpcty]

--- a/scripts/xcp-networkd.conf
+++ b/scripts/xcp-networkd.conf
@@ -1,7 +1,7 @@
 # Configuration file for xcp-networkd
 
 # Default paths to search for binaries
-# search-path=
+# search-path =
 
 # The location of the inventory file
 inventory = /etc/xensource-inventory
@@ -11,13 +11,18 @@ inventory = /etc/xensource-inventory
 # use-switch = false
 
 # The location of brctl tool
-# brctl=/usr/sbin/brctl
+# brctl = /usr/sbin/brctl
 
 # The location for network config file in host
-network-conf=/etc/xensource/network.conf
+network-conf = /etc/xensource/network.conf
 
 # The list of prefix interfaces that are not to be monitored
-# monitor-blacklist=dummy,xenbr,xapi,ovs-system,xenapi
+# monitor-blacklist = dummy,xenbr,xapi,ovs-system,xenapi
 
 # The version till enic driver workaround will be applied or set the version to an empty string for not applying the workaround.
 # enic-workaround-until-version = "2.3.0.30"
+
+# Used to determine if the Linux bridge is supported
+# true if networkd selects the network backend (OVS or bridge) based on network-conf file content
+# false if networkd always only supports OVS
+support-linux-bridge = true


### PR DESCRIPTION
Use `support-linux-bridge` to determine if Linux bridge is supported.

If `support-linux-bridge` is `true`: Linux bridge is supported. `networkd` selects the network backend (OVS or bridge) based on `/etc/xensource/network.conf`.

If `support-linux-bridge` is `false`: `networkd` always uses OVS, regardless of the value in `/etc/xensource/network.conf`.

Set `support-linux-bridge` to `false` in XS 9 as XS 9 does not support Linux bridge.