### PR TITLE
CP-308873 Update software_version to reflect the newly applied livepatch after apply_livepatch

### DIFF
--- a/ocaml/xapi/repository.ml
+++ b/ocaml/xapi/repository.ml
@@ -702,7 +702,8 @@ let apply_livepatch ~__context ~host:_ ~component ~base_build_id ~base_version
   with
   | Some livepatch_file ->
       Livepatch.apply ~component:component' ~livepatch_file ~base_build_id
-        ~base_version ~base_release ~to_version ~to_release
+        ~base_version ~base_release ~to_version ~to_release ;
+      Create_misc.create_software_version ~__context ()
   | None ->
       Helpers.internal_error ~log_err:true "No expected livepatch file for %s"
         component


### PR DESCRIPTION
The `kernel_livepatches` and `xen_livepatches` fields in `host.software_version` are not updated after `apply_livepatch` completes.

Add a software version refresh step after successful `apply_livepatch` to ensure `host.software_version` accurately reflects the current patch state.