### PR TITLE
CA-413254: Types `String` and `SecretString` were generating duplicates of method serializeString in convert.go.

### DIFF
--- a/.github/workflows/generate-and-build-sdks.yml
+++ b/.github/workflows/generate-and-build-sdks.yml
@@ -29,17 +29,6 @@ jobs:
         shell: bash
         run: opam exec -- make sdk
 
-      # sdk-ci runs some Go unit tests.
-      # This setting ensures that SDK date time
-      # tests are run on a machine that
-      # isn't using UTC
-      - name: Set Timezone to Tokyo for datetime tests
-        run: |
-          sudo timedatectl set-timezone Asia/Tokyo
-
-      - name: Run CI for SDKs
-        uses: ./.github/workflows/sdk-ci
-
       - name: Store C SDK source
         uses: actions/upload-artifact@v4
         with:
@@ -60,7 +49,13 @@ jobs:
           name: SDK_Source_PowerShell
           path: _build/install/default/share/powershell/*
 
-      - name: Store Go SDK Artifacts
+      - name: Store Java SDK source
+        uses: actions/upload-artifact@v4
+        with:
+          name: SDK_Source_Java
+          path: _build/install/default/share/java/*
+
+      - name: Store Go SDK source
         uses: actions/upload-artifact@v4
         with:
           name: SDK_Artifacts_Go
@@ -69,11 +64,16 @@ jobs:
             !_build/install/default/share/go/dune
             !_build/install/default/share/go/**/*_test.go
 
-      - name: Store Java SDK source
-        uses: actions/upload-artifact@v4
-        with:
-          name: SDK_Source_Java
-          path: _build/install/default/share/java/*
+      # sdk-ci runs some Go unit tests.
+      # This setting ensures that SDK date time
+      # tests are run on a machine that
+      # isn't using UTC
+      - name: Set Timezone to Tokyo for datetime tests
+        run: |
+          sudo timedatectl set-timezone Asia/Tokyo
+
+      - name: Run CI for SDKs
+        uses: ./.github/workflows/sdk-ci
 
       - name: Trim dune cache
         run: opam exec -- dune cache trim --size=2GiB

--- a/ocaml/sdk-gen/go/gen_go_binding.ml
+++ b/ocaml/sdk-gen/go/gen_go_binding.ml
@@ -105,6 +105,7 @@ let render_converts destdir =
            let json : Mustache.Json.t = of_json params in
            render_template template json ()
        )
+    |> List.sort_uniq compare
     |> String.concat ""
   in
   let rendered =


### PR DESCRIPTION
Now `VM.sysprep`'s XML content can be declared as `SecretString` again.