### PR TITLE
CA-415952: HA can not be enabled

### DIFF
--- a/ocaml/xapi/xha_interface.ml
+++ b/ocaml/xapi/xha_interface.ml
@@ -493,7 +493,7 @@ module LiveSetInformation = struct
         ( match first_xml_element_with_name elements "localhost" with
         | Some
             (Xml.Element
-              (_, _, [Xml.Element ("HostID", _, [Xml.PCData local_host_id])])
+              (_, _, Xml.Element ("HostID", _, [Xml.PCData local_host_id]) :: _)
               ) -> (
           match Uuidx.of_string local_host_id with
           | None ->


### PR DESCRIPTION
https://github.com/xenserver/xha/commit/7ed46d6a871422837aae6a8d62eead0fa362585e
 Add a new field *HostIndex* into the ha_query_liveset result, Xapi needs to update accordingly to parse the result, Otherwise, xapi can not parse the result and understand the liveset thus cause pool-ha-enable always failed

This commit fix the issue and intend to be compatible with old/new xha, to update smoothly