### PR TITLE
XSI-1969 XSI-1973 use https for localhost migration

### DIFF
--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -395,7 +395,7 @@ let pool_migrate ~__context ~vm ~host ~options =
   let compress = use_compression ~__context options localhost host in
   debug "%s using stream compression=%b" __FUNCTION__ compress ;
   let http =
-    if !Xapi_globs.migration_https_only && host <> localhost then
+    if !Xapi_globs.migration_https_only then
       "https"
     else
       "http"


### PR DESCRIPTION
We observe an instability of localhost migration with NVidia SRIOV GPUs since we starting to fall back to http (rather than https) for localhost migration. Outside of development, localhost migration is used during device model restart.

Use HTTPS for localhost migration. This seems to improve stability (but is not the root cause).