### PR TITLE
ci: enable experimental ocaml workflow on aarch64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,17 @@ concurrency: # On new push, cancel old workflows from the same PR, branch or tag
 jobs:
   ocaml-tests:
     name: Run OCaml tests
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: ["ubuntu-22.04"]
+        experimental: [false]
+        include:
+        - runs-on: "ubuntu-22.04-arm"
+          experimental: true
+
+    continue-on-error: ${{ matrix.experimental }}
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
     env:
@@ -29,6 +39,7 @@ jobs:
       # when changing this value, to keep builds
       # consistent
       XAPI_VERSION: "v0.0.0"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This allows to see any regressions happening while not blocking any merges.

This is useful to have as a base to make xapi work on arm-based hosts, which is an objective for xcp-ng.

Depends on https://github.com/xapi-project/xs-opam/pull/737 being merged first, and needs to tweak the required workflows to add the runner and experimental mode. I'll do the latter before merging