### PR TITLE
CP-308455 VM.sysprep if CD insert fails, remove ISO

### DIFF
--- a/ocaml/xapi/vm_sysprep.mli
+++ b/ocaml/xapi/vm_sysprep.mli
@@ -18,6 +18,7 @@ type error =
   | Other of string
   | VM_CDR_not_found
   | VM_CDR_eject
+  | VM_CDR_insert
   | VM_misses_feature
   | VM_not_running
   | VM_sysprep_timeout

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -1727,10 +1727,13 @@ let sysprep ~__context ~self ~unattend ~timeout =
       raise Api_errors.(Server_error (sysprep, [uuid; "VM is not running"]))
   | exception Vm_sysprep.Sysprep VM_CDR_eject ->
       raise Api_errors.(Server_error (sysprep, [uuid; "VM failed to eject CD"]))
+  | exception Vm_sysprep.Sysprep VM_CDR_insert ->
+      raise Api_errors.(Server_error (sysprep, [uuid; "VM failed to insert CD"]))
   | exception Vm_sysprep.Sysprep VM_sysprep_timeout ->
       raise
         Api_errors.(
-          Server_error (sysprep, [uuid; "sysprep not found running - timeout"])
+          Server_error
+            (sysprep, [uuid; "No response from sysprep within allocated time"])
         )
   | exception Vm_sysprep.Sysprep XML_too_large ->
       raise


### PR DESCRIPTION
If inserting the CD fails, remove the ISO to protect its contents. Likewise, remove it when eject fails.