### PR TITLE
CP-309523: Make networkd_db utility return bridge MAC address

### DIFF
--- a/ocaml/networkd/bin_db/networkd_db.ml
+++ b/ocaml/networkd/bin_db/networkd_db.ml
@@ -38,6 +38,8 @@ let _ =
           List.concat_map (fun (_, port) -> port.interfaces) bridge_config.ports
         in
         Printf.printf "interfaces=%s\n" (String.concat "," ifaces) ;
+        Printf.printf "hwaddrs=%s\n"
+          (Option.value ~default:"" bridge_config.bridge_mac) ;
         match bridge_config.vlan with
         | None ->
             ()


### PR DESCRIPTION
This is a simplified version of commit 846ce82ba3. The feature introduced that commit is to remove the network device renaming functionality. When the feature is merged, there will be 3 states of releases:
1. without the feature.
2. with the feature but renaming is still working.
3. with the feature and renaming has been removed.

Originally, the upgrade path was intended to support transitions from state 2 to state 3 only. However, it has become necessary to also support upgrades directly from state 1 to state 3.

This commit is to enable the release in state 1 to upgrade to state 3. The change is kept extremely small so it can be merged independently without waiting for the full feature to be merged.

In details, during the upgrade, the host-installer can't know the management interface as the eth<N> will not present in the environment the host-installer running. So it needs the MAC address to find out the management interface for setting up network.