### PR TITLE
CP-308800: Dynamic control of firewalld service - part 2

### DIFF
--- a/ocaml/xapi/dbsync_slave.ml
+++ b/ocaml/xapi/dbsync_slave.ml
@@ -139,8 +139,19 @@ let refresh_localhost_info ~__context info =
         : Firewall.FIREWALL
       )
   in
-  let enabled = F.is_firewall_service_enabled ~service:Firewall.Http in
-  Db.Host.set_https_only ~__context ~self:host ~value:(not enabled)
+  let status =
+    match Db.Host.get_https_only ~__context ~self:host with
+    | true ->
+        Firewall.Disabled
+    | false ->
+        Firewall.Enabled
+  in
+  let module Fw =
+    ( val Firewall.firewall_provider !Xapi_globs.firewall_backend
+        : Firewall.FIREWALL
+      )
+  in
+  Fw.update_firewall_status ~service:Firewall.Http ~status
 (*************** update database tools ******************)
 
 (** Record host memory properties in database *)

--- a/ocaml/xapi/firewall.ml
+++ b/ocaml/xapi/firewall.ml
@@ -22,30 +22,72 @@ type status = Enabled | Disabled
 
 type protocol = TCP | UDP
 
-type service_info = {name: string; port: int; protocol: protocol}
+(* 1. For firewalld, xapi is always responsible for dynamically controlling
+      firewalld services.
+   2. For legacy iptables compatibility:
+      - Certain iptables ports (such as 4789 for VXLAN) are managed dynamically.
+      - Other ports (such as 22 for SSH) do not require dynamic control, as they
+        are already enabled when the host boots up.
+      - The `dynamic_control_iptables_port` parameter is used to decide if the
+        ports should be controlled dynamically when iptables is selected.
+*)
+type service_info = {
+    name: string
+  ; port: int
+  ; protocol: protocol
+  ; dynamic_control_iptables_port: bool
+}
 
 let status_to_string = function Enabled -> "enabled" | Disabled -> "disabled"
 
-let protocol_to_string = function TCP -> "TCP" | UDP -> "UDP"
+let protocol_to_string = function TCP -> "tcp" | UDP -> "udp"
 
 let service_type_to_service_info = function
   | Dlm ->
-      {name= "dlm"; port= !Xapi_globs.xapi_clusterd_port; protocol= TCP}
+      {
+        name= "dlm"
+      ; port= !Xapi_globs.xapi_clusterd_port
+      ; protocol= TCP
+      ; dynamic_control_iptables_port= true
+      }
   | Nbd ->
-      {name= "nbd"; port= 10809; protocol= TCP}
+      {
+        name= "nbd"
+      ; port= 10809
+      ; protocol= TCP
+      ; dynamic_control_iptables_port= true
+      }
   | Ssh ->
-      {name= "ssh"; port= 22; protocol= TCP}
+      {
+        name= "ssh"
+      ; port= 22
+      ; protocol= TCP
+      ; dynamic_control_iptables_port= false
+      }
   | Vxlan ->
-      {name= "vxlan"; port= 4789; protocol= UDP}
+      {
+        name= "vxlan"
+      ; port= 4789
+      ; protocol= UDP
+      ; dynamic_control_iptables_port= true
+      }
   | Http ->
-      {name= "xapi-insecure"; port= Constants.http_port; protocol= TCP}
+      {
+        name= "xapi-insecure"
+      ; port= Constants.http_port
+      ; protocol= TCP
+      ; dynamic_control_iptables_port= true
+      }
   | Xenha ->
-      {name= "xenha"; port= Xapi_globs.xha_udp_port; protocol= UDP}
+      {
+        name= "xenha"
+      ; port= Xapi_globs.xha_udp_port
+      ; protocol= UDP
+      ; dynamic_control_iptables_port= false
+      }
 
 module type FIREWALL = sig
   val update_firewall_status : service:service_type -> status:status -> unit
-
-  val is_firewall_service_enabled : service:service_type -> bool
 end
 
 module Firewalld : FIREWALL = struct
@@ -71,74 +113,30 @@ module Firewalld : FIREWALL = struct
         Helpers.internal_error "Failed to update firewall service (%s)"
           service_info.name
     )
-
-  let is_firewall_service_enabled ~service =
-    let service_info = service_type_to_service_info service in
-    try
-      let output =
-        Helpers.call_script !Xapi_globs.firewall_cmd
-          ["--query-service"; service_info.name]
-        |> String.trim
-        |> String.lowercase_ascii
-      in
-      debug "%s: Check firewall service (%s) return: %s" __FUNCTION__
-        service_info.name output ;
-      let status = Scanf.sscanf output "%s" Fun.id in
-      match status with "yes" -> true | _ -> false
-    with e ->
-      error "%s: Failed to check firewall service (%s) with error: %s"
-        __FUNCTION__ service_info.name (Printexc.to_string e) ;
-      Helpers.internal_error "Failed to check firewall service (%s)"
-        service_info.name
 end
 
 module Iptables : FIREWALL = struct
   let update_firewall_status ~service ~status =
     let op = match status with Enabled -> "open" | Disabled -> "close" in
     let service_info = service_type_to_service_info service in
-    try
-      Helpers.call_script
-        !Xapi_globs.firewall_port_config_script
-        [
-          op
-        ; string_of_int service_info.port
-        ; protocol_to_string service_info.protocol
-        ]
-      |> ignore
-    with e ->
-      error "%s: Failed to update firewall service (%s) to (%s) with error: %s"
-        __FUNCTION__ service_info.name (status_to_string status)
-        (Printexc.to_string e) ;
-      Helpers.internal_error "Failed to update firewall service (%s)"
-        service_info.name
-
-  let is_firewall_service_enabled ~service =
-    let service_info = service_type_to_service_info service in
-    try
-      let output =
+    if service_info.dynamic_control_iptables_port then (
+      try
         Helpers.call_script
           !Xapi_globs.firewall_port_config_script
           [
-            "check"
+            op
           ; string_of_int service_info.port
           ; protocol_to_string service_info.protocol
           ]
-      in
-      debug "%s: Check firewall service (%s) return: %s" __FUNCTION__
-        service_info.name output ;
-      let enabled =
-        (* The firewall-port script returns true if port 80 is blocked and false
-           if it is not. *)
-        Scanf.sscanf output "Port %d open: %B" (fun _ is_blocked ->
-            not is_blocked
-        )
-      in
-      enabled
-    with e ->
-      error "%s: Failed to check firewall service (%s) with error: %s"
-        __FUNCTION__ service_info.name (Printexc.to_string e) ;
-      Helpers.internal_error "Failed to check firewall service (%s)"
-        service_info.name
+        |> ignore
+      with e ->
+        error
+          "%s: Failed to update firewall service (%s) to (%s) with error: %s"
+          __FUNCTION__ service_info.name (status_to_string status)
+          (Printexc.to_string e) ;
+        Helpers.internal_error "Failed to update firewall service (%s)"
+          service_info.name
+    )
 end
 
 let firewall_provider (backend : Xapi_globs.firewall_backend_type) :

--- a/ocaml/xapi/firewall.mli
+++ b/ocaml/xapi/firewall.mli
@@ -18,8 +18,6 @@ type status = Enabled | Disabled
 
 module type FIREWALL = sig
   val update_firewall_status : service:service_type -> status:status -> unit
-
-  val is_firewall_service_enabled : service:service_type -> bool
 end
 
 module Firewalld : FIREWALL

--- a/ocaml/xapi/nm.ml
+++ b/ocaml/xapi/nm.ml
@@ -785,10 +785,13 @@ let bring_pif_up ~__context ?(management_interface = false) (pif : API.ref_PIF)
               | `vxlan ->
                   debug
                     "Opening VxLAN UDP port for tunnel with protocol 'vxlan'" ;
-                  ignore
-                  @@ Helpers.call_script
-                       !Xapi_globs.firewall_port_config_script
-                       ["open"; "4789"; "udp"]
+                  let module Fw =
+                    ( val Firewall.firewall_provider !Xapi_globs.firewall_backend
+                        : Firewall.FIREWALL
+                      )
+                  in
+                  Fw.update_firewall_status ~service:Firewall.Vxlan
+                    ~status:Firewall.Enabled
               | `gre ->
                   ()
             )
@@ -846,10 +849,13 @@ let bring_pif_down ~__context ?(force = false) (pif : API.ref_PIF) =
                 in
                 if no_more_vxlan then (
                   debug "Last VxLAN tunnel was closed, closing VxLAN UDP port" ;
-                  ignore
-                  @@ Helpers.call_script
-                       !Xapi_globs.firewall_port_config_script
-                       ["close"; "4789"; "udp"]
+                  let module Fw =
+                    ( val Firewall.firewall_provider !Xapi_globs.firewall_backend
+                        : Firewall.FIREWALL
+                      )
+                  in
+                  Fw.update_firewall_status ~service:Firewall.Vxlan
+                    ~status:Firewall.Disabled
                 )
             | `gre ->
                 ()

--- a/ocaml/xapi/xapi_periodic_scheduler_init.ml
+++ b/ocaml/xapi/xapi_periodic_scheduler_init.ml
@@ -96,6 +96,13 @@ let register ~__context =
          exceeds the timeout duration. In this scenario, we need to enable SSH auto
          mode to ensure the SSH service remains continuously available. *)
       else if Fe_systemctl.is_active ~service:!Xapi_globs.ssh_service then (
+        let module Fw =
+          ( val Firewall.firewall_provider !Xapi_globs.firewall_backend
+              : Firewall.FIREWALL
+            )
+        in
+        Fw.update_firewall_status ~service:Firewall.Ssh
+          ~status:Firewall.Disabled ;
         Xapi_host.disable_ssh ~__context ~self ;
         Xapi_host.set_ssh_auto_mode ~__context ~self ~value:true
       )


### PR DESCRIPTION
Dynamic control other firewalld services, including:

- VxLan
- Xha
- Cluster
- SSH

Besides, adding the following compatibility for iptables and firewalld:
1. For legacy iptables, some ports need dynamic control but some don't. So add a flag to decide if the port needs dynamic control.
2. Revert https_only update logic.