### PR TITLE
CP-308863: Count vGPU migrations

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2501,6 +2501,8 @@ functor
             let snapshot = Db.VM.get_record ~__context ~self:vm in
             reserve_memory_for_vm ~__context ~vm ~host ~snapshot
               ~host_op:`vm_migrate (fun () ->
+                if Db.VM.get_VGPUs ~__context ~self:vm <> [] then
+                  Xapi_stats.incr_pool_vgpu_migration_count () ;
                 forward_vm_op ~local_fn ~__context ~vm ~remote_fn
             )
         ) ;
@@ -2622,6 +2624,8 @@ functor
                   assert_can_migrate ~__context ~vm ~dest ~live ~vdi_map
                     ~vif_map ~vgpu_map ~options
               ) ;
+              if vgpu_map <> [] then
+                Xapi_stats.incr_pool_vgpu_migration_count () ;
               forward_migrate_send ()
           )
         in

--- a/ocaml/xapi/xapi_stats.mli
+++ b/ocaml/xapi/xapi_stats.mli
@@ -18,3 +18,6 @@ val start : unit -> unit
 
 val stop : unit -> unit
 (** Stop the stats reporting thread. *)
+
+val incr_pool_vgpu_migration_count : unit -> unit
+(** Increments the pool_vgpu_migration_count by 1 . *)


### PR DESCRIPTION
This metric represents the rate of VM migrations with vGPUs per second.
The total count can be calculated as AVERAGE * seconds. For example,
for one-day data granularity, the total count for one day is
AVERAGE * 86400, in which 86400 is the seconds of one day.