### PR TITLE
Restored type SecretString for sysprep's parameter unattend

### DIFF
--- a/ocaml/idl/datamodel_vm.ml
+++ b/ocaml/idl/datamodel_vm.ml
@@ -2375,7 +2375,7 @@ let sysprep =
     ~params:
       [
         (Ref _vm, "self", "The VM")
-      ; (String, "unattend", "XML content passed to sysprep")
+      ; (SecretString, "unattend", "XML content passed to sysprep")
       ; (Float, "timeout", "timeout in seconds for expected reboot")
       ]
     ~doc:

--- a/ocaml/xapi-cli-server/cli_operations.ml
+++ b/ocaml/xapi-cli-server/cli_operations.ml
@@ -3602,7 +3602,7 @@ let vm_sysprep fd printer rpc session_id params =
   let unattend =
     match get_client_file fd filename with
     | Some xml ->
-        xml
+        xml |> SecretString.of_string
     | None ->
         marshal fd (Command (PrintStderr "Failed to read file.\n")) ;
         raise (ExitWithError 1)

--- a/ocaml/xapi-types/secretString.ml
+++ b/ocaml/xapi-types/secretString.ml
@@ -24,6 +24,8 @@ let write_to_channel c s = output_string c s
 
 let equal = String.equal
 
+let length = String.length
+
 let pool_secret = "pool_secret"
 
 let with_cookie t cookies = (pool_secret, t) :: cookies

--- a/ocaml/xapi-types/secretString.mli
+++ b/ocaml/xapi-types/secretString.mli
@@ -25,6 +25,8 @@ val of_string : string -> t
 
 val equal : t -> t -> bool
 
+val length : t -> int
+
 val json_rpc_of_t : t -> Rpc.t
 
 val t_of_rpc : Rpc.t -> t

--- a/ocaml/xapi/vm_sysprep.ml
+++ b/ocaml/xapi/vm_sysprep.ml
@@ -140,7 +140,7 @@ let make_iso ~vm_uuid ~unattend =
     Xapi_stdext_unix.Unixext.mkdir_rec SR.dir 0o755 ;
     with_temp_dir ~dir:"/var/tmp/xapi" "sysprep-" "-iso" (fun temp_dir ->
         let path = temp_dir // "unattend.xml" in
-        Unixext.write_string_to_file path unattend ;
+        SecretString.write_to_file path unattend ;
         debug "%s: written to %s" __FUNCTION__ path ;
         let args = ["-r"; "-J"; "-o"; iso; temp_dir] in
         Forkhelpers.execute_command_get_output genisoimage args |> ignore ;
@@ -262,7 +262,7 @@ let sysprep ~__context ~vm ~unattend ~timeout =
   let control = Printf.sprintf "/local/domain/%Ld/control" domid in
   if domid <= 0L then
     fail VM_not_running ;
-  if String.length unattend > 32 * 1024 then
+  if SecretString.length unattend > 32 * 1024 then
     fail XML_too_large ;
   Ezxenstore_core.Xenstore.with_xs (fun xs ->
       let open Ezxenstore_core.Xenstore in

--- a/ocaml/xapi/vm_sysprep.mli
+++ b/ocaml/xapi/vm_sysprep.mli
@@ -32,9 +32,9 @@ val on_startup : __context:Context.t -> unit
 val sysprep :
      __context:Context.t
   -> vm:API.ref_VM
-  -> unattend:string
+  -> unattend:SecretString.t
   -> timeout:float
   -> unit
 (** Execute sysprep on [vm] using script [unattend]. This requires
-    driver support from the VM and is checked. [unattend:string] must
+    driver support from the VM and is checked. [unattend] must
     not exceed 32kb. Raised [Failure] that must be handled, *)

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -454,6 +454,6 @@ val remove_from_blocked_operations :
 val sysprep :
      __context:Context.t
   -> self:API.ref_VM
-  -> unattend:string
+  -> unattend:SecretString.t
   -> timeout:float
   -> unit


### PR DESCRIPTION
This is simply a cherry pick of @lindig 's commit from https://github.com/xapi-project/xen-api/pull/6547 now that we have fixed https://github.com/xapi-project/xen-api/pull/6622. Let me know if anything more is needed.

> CP-308455 VM.sysprep declare XML content as SecretString
> Desclare the string parameter holding unattend.xml as secret to avoid logging it.
> 
> Signed-off-by: Christian Lindig <christian.lindig@cloud.com>

Conflicts:
- ocaml/idl/datamodel_vm.ml
- ocaml/xapi/vm_sysprep.mli
- ocaml/xapi/xapi_vm.mli