### PR TITLE
Add pool-level field to limit VNC console access to one session per VM/host

### DIFF
--- a/ocaml/idl/datamodel_lifecycle.ml
+++ b/ocaml/idl/datamodel_lifecycle.ml
@@ -137,6 +137,8 @@ let prototyped_of_field = function
       Some "23.18.0"
   | "VM", "actions__after_softreboot" ->
       Some "23.1.0"
+  | "pool", "limit_console_sessions" ->
+      Some "25.30.0-next"
   | "pool", "ha_reboot_vm_on_internal_shutdown" ->
       Some "25.16.0"
   | "pool", "license_server" ->

--- a/ocaml/idl/datamodel_pool.ml
+++ b/ocaml/idl/datamodel_pool.ml
@@ -2250,6 +2250,12 @@ let t =
             "Indicates whether an HA-protected VM that is shut down from \
              inside (not through the API) should be automatically rebooted \
              when HA is enabled"
+        ; field ~writer_roles:_R_POOL_OP ~qualifier:RW ~lifecycle:[] ~ty:Bool
+            ~default_value:(Some (VBool false)) "limit_console_sessions"
+            "When true, only one console connection per VM/host in the pool is \
+             accepted. Otherwise every connection for a VM/host's console is \
+             accepted. Note: when true, connection attempts via websocket will \
+             be rejected."
         ]
       )
     ()

--- a/ocaml/idl/schematest.ml
+++ b/ocaml/idl/schematest.ml
@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
 (* BEWARE: if this changes, check that schema has been bumped accordingly in
    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
 
-let last_known_schema_hash = "7586cb039918e573594fc358e90b0f04"
+let last_known_schema_hash = "cf1c1e26b4288dd53cf6da5a4d6ad13c"
 
 let current_schema_hash : string =
   let open Datamodel_types in

--- a/ocaml/tests/common/test_common.ml
+++ b/ocaml/tests/common/test_common.ml
@@ -305,7 +305,8 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ?(last_update_sync = API.Date.epoch) ?(update_sync_frequency = `daily)
     ?(update_sync_day = 0L) ?(update_sync_enabled = false)
     ?(recommendations = []) ?(license_server = [])
-    ?(ha_reboot_vm_on_internal_shutdown = true) () =
+    ?(ha_reboot_vm_on_internal_shutdown = true)
+    ?(limit_console_sessions = false) () =
   let pool_ref = Ref.make () in
   Db.Pool.create ~__context ~ref:pool_ref ~uuid:(make_uuid ()) ~name_label
     ~name_description ~master ~default_SR ~suspend_image_SR ~crash_dump_SR
@@ -326,7 +327,7 @@ let make_pool ~__context ~master ?(name_label = "") ?(name_description = "")
     ~ext_auth_cache_enabled:false ~ext_auth_cache_size:50L
     ~ext_auth_cache_expiry:300L ~update_sync_frequency ~update_sync_day
     ~update_sync_enabled ~recommendations ~license_server
-    ~ha_reboot_vm_on_internal_shutdown ;
+    ~ha_reboot_vm_on_internal_shutdown ~limit_console_sessions ;
   pool_ref
 
 let default_sm_features =

--- a/ocaml/xapi-cli-server/records.ml
+++ b/ocaml/xapi-cli-server/records.ml
@@ -1595,6 +1595,13 @@ let pool_record rpc session_id pool =
               ~value:(safe_bool_of_string "ssh-auto-mode" value)
           )
           ()
+      ; make_field ~name:"limit-console-sessions"
+          ~get:(fun () -> string_of_bool (x ()).API.pool_limit_console_sessions)
+          ~set:(fun x ->
+            Client.Pool.set_limit_console_sessions ~rpc ~session_id ~self:pool
+              ~value:(safe_bool_of_string "limit-console-sessions" x)
+          )
+          ()
       ]
   }
 

--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -55,6 +55,7 @@ let create_pool_record ~__context =
       ~ext_auth_max_threads:1L ~ext_auth_cache_enabled:false
       ~ext_auth_cache_size:50L ~ext_auth_cache_expiry:300L ~recommendations:[]
       ~license_server:[] ~ha_reboot_vm_on_internal_shutdown:true
+      ~limit_console_sessions:false
 
 let set_master_ip ~__context =
   let ip =


### PR DESCRIPTION
- First commit:
    Introduces a new pool-level parameter that restricts VNC console access
    to a single active session per VM/host.
    This prevents multiple users from simultaneously connecting to the same VM console,
    preventing one user 'watching' another user operating a session.

- Second commit:
When the `limit_console_sessions` is true.
    - Enforced a single active VNC console connection per VM/host
    - Disable connection to websocket

Tested:
- [root@eu1-dt094 bin]# xe pool-param-get  uuid=de76d8c9-2e1b-f868-39fe-5768bf8c3c0d param-name=limit-console-sessions
true
Only one console can be connected:
<img width="3370" height="1162" alt="image" src="https://github.com/user-attachments/assets/6c231cf5-51d1-4e91-b8dd-6249a74b925c" />

- [root@eu1-dt094 bin]# xe pool-param-get  uuid=de76d8c9-2e1b-f868-39fe-5768bf8c3c0d param-name=limit-console-sessions
false
Both consoles can be connected:
<img width="3420" height="1165" alt="image" src="https://github.com/user-attachments/assets/be7adbc1-82d4-4240-8d09-dde201597adc" />

